### PR TITLE
Kevin/vxmark eject usb modal

### DIFF
--- a/apps/admin/frontend/src/components/export_ballot_pdfs_button.test.tsx
+++ b/apps/admin/frontend/src/components/export_ballot_pdfs_button.test.tsx
@@ -10,8 +10,8 @@ import { getDisplayElectionHash } from '@votingworks/types';
 import { UsbDriveStatus } from '@votingworks/ui';
 import { assert } from '@votingworks/basics';
 import React from 'react';
+import { mockUsbDrive } from '@votingworks/ui';
 import { screen, waitFor, within } from '../../test/react_testing_library';
-import { mockUsbDrive } from '../../test/helpers/mock_usb_drive';
 import { renderInAppContext } from '../../test/render_in_app_context';
 import { ExportBallotPdfsButton } from './export_ballot_pdfs_button';
 

--- a/apps/admin/frontend/src/components/export_election_ballot_package_modal_button.test.tsx
+++ b/apps/admin/frontend/src/components/export_election_ballot_package_modal_button.test.tsx
@@ -10,6 +10,7 @@ import { UsbDriveStatus } from '@votingworks/ui';
 import userEvent from '@testing-library/user-event';
 import { iter } from '@votingworks/basics';
 import { interpretMultiPagePdfTemplate } from '@votingworks/ballot-interpreter-vx';
+import { mockUsbDrive } from '@votingworks/ui';
 import {
   fireEvent,
   screen,
@@ -21,7 +22,6 @@ import {
   renderInAppContext,
 } from '../../test/render_in_app_context';
 import { ExportElectionBallotPackageModalButton } from './export_election_ballot_package_modal_button';
-import { mockUsbDrive } from '../../test/helpers/mock_usb_drive';
 import { ApiMock, createApiMock } from '../../test/helpers/api_mock';
 
 jest.mock('@votingworks/ballot-interpreter-vx', () => ({

--- a/apps/admin/frontend/src/components/full_test_deck_tally_report_button.test.tsx
+++ b/apps/admin/frontend/src/components/full_test_deck_tally_report_button.test.tsx
@@ -10,10 +10,10 @@ import {
   fakeUsbDrive,
 } from '@votingworks/test-utils';
 import React from 'react';
+import { mockUsbDrive } from '@votingworks/ui';
 import { screen, within } from '../../test/react_testing_library';
 import { renderInAppContext } from '../../test/render_in_app_context';
 import { FullTestDeckTallyReportButton } from './full_test_deck_tally_report_button';
-import { mockUsbDrive } from '../../test/helpers/mock_usb_drive';
 
 beforeEach(() => {
   const mockKiosk = fakeKiosk();

--- a/apps/admin/frontend/src/components/import_cvrfiles_modal.test.tsx
+++ b/apps/admin/frontend/src/components/import_cvrfiles_modal.test.tsx
@@ -7,6 +7,7 @@ import userEvent from '@testing-library/user-event';
 import { ok } from '@votingworks/basics';
 // eslint-disable-next-line vx/gts-no-import-export-type
 import type { CastVoteRecordFileMetadata } from '@votingworks/admin-backend';
+import { mockUsbDrive } from '@votingworks/ui';
 import {
   waitFor,
   fireEvent,
@@ -16,7 +17,6 @@ import {
 } from '../../test/react_testing_library';
 import { ImportCvrFilesModal } from './import_cvrfiles_modal';
 import { renderInAppContext } from '../../test/render_in_app_context';
-import { mockUsbDrive } from '../../test/helpers/mock_usb_drive';
 import { ApiMock, createApiMock } from '../../test/helpers/api_mock';
 import { mockCastVoteRecordFileRecord } from '../../test/api_mock_data';
 

--- a/apps/admin/frontend/src/components/save_file_to_usb.test.tsx
+++ b/apps/admin/frontend/src/components/save_file_to_usb.test.tsx
@@ -5,10 +5,10 @@ import { fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils';
 import { fakeLogger, LogEventId } from '@votingworks/logging';
 import userEvent from '@testing-library/user-event';
 import { UsbDriveStatus } from '@votingworks/ui';
+import { mockUsbDrive } from '@votingworks/ui';
 import { fireEvent, waitFor } from '../../test/react_testing_library';
 import { SaveFileToUsb, FileType } from './save_file_to_usb';
 import { renderInAppContext } from '../../test/render_in_app_context';
-import { mockUsbDrive } from '../../test/helpers/mock_usb_drive';
 
 test('renders loading screen when usb drive is mounting or ejecting in export modal', () => {
   const usbStatuses: UsbDriveStatus[] = ['mounting', 'ejecting'];

--- a/apps/admin/frontend/src/screens/print_test_deck_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/print_test_deck_screen.test.tsx
@@ -16,8 +16,8 @@ import {
   fakeUsbDrive,
 } from '@votingworks/test-utils';
 import { LogEventId, Logger, LogSource } from '@votingworks/logging';
+import { mockUsbDrive } from '@votingworks/ui';
 import { screen, waitFor } from '../../test/react_testing_library';
-import { mockUsbDrive } from '../../test/helpers/mock_usb_drive';
 
 import {
   LAST_PRINT_JOB_SLEEP_MS,

--- a/apps/admin/frontend/src/screens/printed_ballots_report_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/printed_ballots_report_screen.test.tsx
@@ -12,11 +12,11 @@ import { fakeLogger, LogEventId, Logger } from '@votingworks/logging';
 import { screen, waitFor, within } from '@testing-library/react';
 
 import { Admin } from '@votingworks/api';
+import { mockUsbDrive } from '@votingworks/ui';
 import { renderInAppContext } from '../../test/render_in_app_context';
 import { ApiMock, createApiMock } from '../../test/helpers/api_mock';
 import { PrintedBallotsReportScreen } from './printed_ballots_report_screen';
 import { mockPrintedBallotRecord } from '../../test/api_mock_data';
-import { mockUsbDrive } from '../../test/helpers/mock_usb_drive';
 
 jest.mock('../components/hand_marked_paper_ballot');
 

--- a/apps/admin/frontend/test/render_in_app_context.tsx
+++ b/apps/admin/frontend/test/render_in_app_context.tsx
@@ -30,6 +30,7 @@ import {
 } from '@votingworks/test-utils';
 // eslint-disable-next-line vx/gts-no-import-export-type
 import type { MachineConfig } from '@votingworks/admin-backend';
+import { mockUsbDrive } from '@votingworks/ui';
 import { render as testRender, RenderResult } from './react_testing_library';
 import { AppContext } from '../src/contexts/app_context';
 import { Iso8601Timestamp, ExportableTallies } from '../src/config/types';
@@ -38,7 +39,6 @@ import {
   ElectionManagerStoreBackend,
   ElectionManagerStoreMemoryBackend,
 } from '../src/lib/backends';
-import { mockUsbDrive } from './helpers/mock_usb_drive';
 import { ApiClient, ApiClientContext, createQueryClient } from '../src/api';
 import { ApiMock } from './helpers/api_mock';
 

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -672,6 +672,7 @@ export function AppRoot({
       />
     );
   }
+
   if (isSystemAdministratorAuth(authStatus)) {
     return (
       <React.Fragment>
@@ -744,6 +745,7 @@ export function AppRoot({
           screenReader={screenReader}
           pollsState={pollsState}
           logger={logger}
+          usbDrive={usbDrive}
         />
         <SessionTimeLimitTracker electionHash={electionHash} />
       </React.Fragment>

--- a/apps/mark/frontend/src/pages/admin_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.test.tsx
@@ -13,6 +13,7 @@ import {
 import { fakeLogger } from '@votingworks/logging';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { mockUsbDrive } from '@votingworks/ui';
+import userEvent from '@testing-library/user-event';
 import {
   act,
   fireEvent,
@@ -149,4 +150,13 @@ test('renders a USB controller button', async () => {
 
   renderScreen({ usbDrive: mockUsbDrive('mounted') });
   await screen.findByText('Eject USB');
+});
+
+test('USB button calls eject', async () => {
+  const usbDrive = mockUsbDrive('mounted');
+
+  renderScreen({ usbDrive });
+  const ejectButton = await screen.findByText('Eject USB');
+  userEvent.click(ejectButton);
+  expect(usbDrive.eject).toHaveBeenCalledTimes(1);
 });

--- a/apps/mark/frontend/src/pages/admin_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.test.tsx
@@ -12,6 +12,7 @@ import {
 } from '@votingworks/utils';
 import { fakeLogger } from '@votingworks/logging';
 import { QueryClientProvider } from '@tanstack/react-query';
+import { mockUsbDrive } from '@votingworks/ui';
 import {
   act,
   fireEvent,
@@ -66,6 +67,7 @@ function renderScreen(props: Partial<AdminScreenProps> = {}) {
           screenReader={new AriaScreenReader(new SpeechSynthesisTextToSpeech())}
           pollsState="polls_open"
           logger={fakeLogger()}
+          usbDrive={mockUsbDrive('mounted')}
           {...props}
         />
       </QueryClientProvider>
@@ -139,4 +141,12 @@ test('precinct selection disabled if single precinct election', async () => {
   screen.getByText(
     'Precinct cannot be changed because there is only one precinct configured for this election.'
   );
+});
+
+test('renders a USB controller button', async () => {
+  renderScreen({ usbDrive: mockUsbDrive('absent') });
+  await screen.findByText('No USB');
+
+  renderScreen({ usbDrive: mockUsbDrive('mounted') });
+  await screen.findByText('Eject USB');
 });

--- a/apps/mark/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.tsx
@@ -18,6 +18,8 @@ import {
   SetClockButton,
   TestMode,
   Text,
+  UsbControllerButton,
+  UsbDrive,
 } from '@votingworks/ui';
 import { Logger } from '@votingworks/logging';
 // eslint-disable-next-line vx/gts-no-import-export-type
@@ -36,6 +38,7 @@ export interface AdminScreenProps {
   screenReader: ScreenReader;
   pollsState: PollsState;
   logger: Logger;
+  usbDrive: UsbDrive;
 }
 
 export function AdminScreen({
@@ -50,6 +53,7 @@ export function AdminScreen({
   screenReader,
   pollsState,
   logger,
+  usbDrive,
 }: AdminScreenProps): JSX.Element {
   const { election } = electionDefinition;
 
@@ -143,6 +147,13 @@ export function AdminScreen({
               Unconfigure Machine
             </Button>
           </p>
+          <h2>USB</h2>
+          <UsbControllerButton
+            small={false}
+            primary
+            usbDriveStatus={usbDrive.status}
+            usbDriveEject={() => usbDrive.eject('election_manager')}
+          />
         </Prose>
       </Main>
       {election && (

--- a/apps/scan/frontend/src/components/export_backup_modal.test.tsx
+++ b/apps/scan/frontend/src/components/export_backup_modal.test.tsx
@@ -3,13 +3,13 @@ import userEvent from '@testing-library/user-event';
 import { fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils';
 import { err, ok } from '@votingworks/basics';
 import { UsbDriveStatus } from '@votingworks/ui';
+import { mockUsbDrive } from '@votingworks/ui';
 import { render, screen } from '../../test/react_testing_library';
 import {
   ApiMock,
   createApiMock,
   provideApi,
 } from '../../test/helpers/mock_api_client';
-import { mockUsbDrive } from '../../test/helpers/mock_usb_drive';
 import {
   ExportBackupModal,
   ExportBackupModalProps,

--- a/apps/scan/frontend/src/components/export_results_modal.test.tsx
+++ b/apps/scan/frontend/src/components/export_results_modal.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils';
 import { UsbDriveStatus } from '@votingworks/ui';
 import { err } from '@votingworks/basics';
+import { mockUsbDrive } from '@votingworks/ui';
 import { fireEvent, render, waitFor } from '../../test/react_testing_library';
 import {
   ExportResultsModal,
@@ -14,7 +15,6 @@ import {
   createApiMock,
   provideApi,
 } from '../../test/helpers/mock_api_client';
-import { mockUsbDrive } from '../../test/helpers/mock_usb_drive';
 
 let apiMock: ApiMock;
 

--- a/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
@@ -8,6 +8,7 @@ import { fakeKiosk } from '@votingworks/test-utils';
 import { singlePrecinctSelectionFor } from '@votingworks/utils';
 import MockDate from 'mockdate';
 import React from 'react';
+import { mockUsbDrive } from '@votingworks/ui';
 import {
   act,
   render,
@@ -22,7 +23,6 @@ import {
   provideApi,
   statusNoPaper,
 } from '../../test/helpers/mock_api_client';
-import { mockUsbDrive } from '../../test/helpers/mock_usb_drive';
 import {
   ElectionManagerScreen,
   ElectionManagerScreenProps,

--- a/apps/scan/frontend/test/helpers/mock_usb_drive.ts
+++ b/apps/scan/frontend/test/helpers/mock_usb_drive.ts
@@ -1,9 +1,0 @@
-import { UsbDrive, UsbDriveStatus } from '@votingworks/ui';
-
-export function mockUsbDrive(status: UsbDriveStatus = 'absent'): UsbDrive {
-  return {
-    status,
-    eject: jest.fn(),
-    format: jest.fn(),
-  };
-}

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -36,6 +36,7 @@ export * from './loading';
 export * from './loading_animation';
 export * from './logo_mark';
 export * from './main';
+export * from './mock_usb_drive';
 export * from './modal';
 export * from './number_pad';
 export * from './precinct_scanner_tally_report';

--- a/libs/ui/src/mock_usb_drive.test.ts
+++ b/libs/ui/src/mock_usb_drive.test.ts
@@ -1,0 +1,13 @@
+import { mockUsbDrive } from './mock_usb_drive';
+
+test('creates a UsbDrive', () => {
+  const mock = mockUsbDrive('mounted');
+  expect(mock.status).toEqual('mounted');
+  expect(typeof mock.eject).toEqual('function');
+  expect(typeof mock.format).toEqual('function');
+});
+
+test('uses default drive status of absent', () => {
+  const mock = mockUsbDrive();
+  expect(mock.status).toEqual('absent');
+});

--- a/libs/ui/src/mock_usb_drive.ts
+++ b/libs/ui/src/mock_usb_drive.ts
@@ -1,4 +1,4 @@
-import { UsbDrive, UsbDriveStatus } from '@votingworks/ui';
+import { UsbDrive, UsbDriveStatus } from './hooks/use_usb_drive';
 
 export function mockUsbDrive(status: UsbDriveStatus = 'absent'): UsbDrive {
   return {


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/3290

Adds an "Eject" button to VxMark's admin page




## Demo Video or Screenshot
![Screenshot 2023-04-14 at 2 03 49 PM](https://user-images.githubusercontent.com/1060688/232161833-cc74e2da-76fd-4636-b946-84a27694cba9.png)
![Screenshot 2023-04-14 at 2 03 39 PM](https://user-images.githubusercontent.com/1060688/232161836-79805d94-b11a-4be8-a412-f43cab29dc2c.png)

## Testing Plan
* added tests for rendering + interaction with USB controller button

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
