### PR TITLE
refactor(auth): use `tmp` directly

### DIFF
--- a/apps/admin/integration-testing/cypress/support/auth.ts
+++ b/apps/admin/integration-testing/cypress/support/auth.ts
@@ -3,7 +3,7 @@ import { methodUrl } from '@votingworks/grout';
 // Importing all of @votingworks/auth causes Cypress tests to fail since Cypress doesn't seem to
 // interact well with PCSC Lite card reader code
 // eslint-disable-next-line vx/no-import-workspace-subfolders
-import { DEV_JURISDICTION } from '@votingworks/auth/src/certs';
+import { DEV_JURISDICTION } from '@votingworks/auth/src/constants';
 // eslint-disable-next-line vx/no-import-workspace-subfolders
 import {
   mockCard,

--- a/apps/central-scan/integration-testing/cypress/e2e/configuration.cy.ts
+++ b/apps/central-scan/integration-testing/cypress/e2e/configuration.cy.ts
@@ -5,7 +5,7 @@ import { sha256 } from 'js-sha256';
 // Importing all of @votingworks/auth causes Cypress tests to fail since Cypress doesn't seem to
 // interact well with PCSC Lite card reader code
 // eslint-disable-next-line vx/no-import-workspace-subfolders
-import { DEV_JURISDICTION } from '@votingworks/auth/src/certs';
+import { DEV_JURISDICTION } from '@votingworks/auth/src/constants';
 // eslint-disable-next-line vx/no-import-workspace-subfolders
 import {
   mockCard,

--- a/apps/mark/integration-testing/cypress/support/e2e.js
+++ b/apps/mark/integration-testing/cypress/support/e2e.js
@@ -22,7 +22,7 @@ import { methodUrl } from '@votingworks/grout';
 // Importing all of @votingworks/auth causes Cypress tests to fail since Cypress doesn't seem to
 // interact well with PCSC Lite card reader code
 // eslint-disable-next-line vx/no-import-workspace-subfolders
-import { DEV_JURISDICTION } from '@votingworks/auth/src/certs';
+import { DEV_JURISDICTION } from '@votingworks/auth/src/constants';
 // eslint-disable-next-line vx/no-import-workspace-subfolders
 import { mockCard } from '@votingworks/auth/src/mock_file_card';
 
@@ -75,11 +75,19 @@ function removeCard() {
 }
 
 function endCardlessVoterSession() {
-  cy.request('POST', methodUrl('endCardlessVoterSession', 'http://localhost:3000/api'), {});
+  cy.request(
+    'POST',
+    methodUrl('endCardlessVoterSession', 'http://localhost:3000/api'),
+    {}
+  );
 }
 
 function configureWithSampleDefinitionAndSystemSettings() {
-  cy.request('POST', methodUrl('configureSampleBallotPackage', 'http://localhost:3000/api'), {});
+  cy.request(
+    'POST',
+    methodUrl('configureSampleBallotPackage', 'http://localhost:3000/api'),
+    {}
+  );
 }
 
 beforeEach(() => {

--- a/libs/auth/package.json
+++ b/libs/auth/package.json
@@ -41,6 +41,7 @@
     "luxon": "^3.0.0",
     "node-fetch": "^2.6.0",
     "pcsclite": "^1.0.1",
+    "tmp": "^0.2.1",
     "uuid": "^9.0.0",
     "yargs": "^17.7.1",
     "zod": "3.14.4"
@@ -49,6 +50,7 @@
     "@types/jest": "^27.0.3",
     "@types/luxon": "^3.0.0",
     "@types/node-fetch": "^2.6.0",
+    "@types/tmp": "^0.2.3",
     "@types/uuid": "^9.0.1",
     "@types/yargs": "^17.0.22",
     "@typescript-eslint/eslint-plugin": "5.37.0",

--- a/libs/auth/scripts/generate_dev_keys_and_certs.ts
+++ b/libs/auth/scripts/generate_dev_keys_and_certs.ts
@@ -6,13 +6,9 @@ import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 
 import { CardDetails } from '../src/card';
 import {
-  CardType,
-  CERT_EXPIRY_IN_DAYS,
   constructCardCertSubject,
   constructCardCertSubjectWithoutJurisdictionAndCardType,
   constructMachineCertSubject,
-  DEV_JURISDICTION,
-  STANDARD_CERT_FIELDS,
 } from '../src/certs';
 import { DEV_PRIVATE_KEY_PASSWORD } from '../src/java_card_config';
 import {
@@ -23,6 +19,12 @@ import {
   publicKeyPemToDer,
 } from '../src/openssl';
 import { runCommand } from './utils';
+import {
+  CERT_EXPIRY_IN_DAYS,
+  DEV_JURISDICTION,
+  STANDARD_CERT_FIELDS,
+} from '../src/constants';
+import { CardType } from '../src/types';
 
 async function generateDevPrivateKey(): Promise<Buffer> {
   const privateKey = await openssl([

--- a/libs/auth/scripts/mock_card.ts
+++ b/libs/auth/scripts/mock_card.ts
@@ -6,7 +6,7 @@ import yargs from 'yargs/yargs';
 import { assert, Optional, throwIllegalValue } from '@votingworks/basics';
 import { safeParseElection } from '@votingworks/types';
 
-import { DEV_JURISDICTION } from '../src/certs';
+import { DEV_JURISDICTION } from '../src/constants';
 import { mockCard } from '../src/mock_file_card';
 
 const CARD_TYPES = [

--- a/libs/auth/scripts/program_system_administrator_java_card.ts
+++ b/libs/auth/scripts/program_system_administrator_java_card.ts
@@ -3,7 +3,7 @@ import { assert } from '@votingworks/basics';
 import { generatePin, hyphenatePin } from '@votingworks/utils';
 
 import { ResponseApduError } from '../src/apdu';
-import { DEV_JURISDICTION } from '../src/certs';
+import { DEV_JURISDICTION } from '../src/constants';
 import { getRequiredEnvVar } from '../src/env_vars';
 import { JavaCard } from '../src/java_card';
 import { constructJavaCardConfig } from '../src/java_card_config';

--- a/libs/auth/src/certs.test.ts
+++ b/libs/auth/src/certs.test.ts
@@ -6,11 +6,11 @@ import {
   constructCardCertSubject,
   constructCardCertSubjectWithoutJurisdictionAndCardType,
   constructMachineCertSubject,
-  CustomCertFields,
   parseCardDetailsFromCert,
   parseCert,
 } from './certs';
 import { openssl } from './openssl';
+import { CustomCertFields } from './types';
 
 jest.mock('./openssl');
 

--- a/libs/auth/src/certs.ts
+++ b/libs/auth/src/certs.ts
@@ -1,90 +1,14 @@
 import { Buffer } from 'buffer';
-import { z } from 'zod';
 import { assert, throwIllegalValue } from '@votingworks/basics';
 
 import { arePollWorkerCardDetails, CardDetails } from './card';
 import { openssl } from './openssl';
-
-/**
- * VotingWorks's IANA-assigned enterprise OID
- */
-const VX_IANA_ENTERPRISE_OID = '1.3.6.1.4.1.59817';
-
-/**
- * Instead of overloading existing X.509 cert fields, we're using our own custom cert fields.
- */
-const VX_CUSTOM_CERT_FIELD = {
-  /** One of: card, admin, central-scan, mark, scan (the latter four referring to machines) */
-  COMPONENT: `${VX_IANA_ENTERPRISE_OID}.1`,
-  /** Format: {state-2-letter-abbreviation}.{county-or-town} (e.g. ms.warren or ca.los-angeles) */
-  JURISDICTION: `${VX_IANA_ENTERPRISE_OID}.2`,
-  /** One of: system-administrator, election-manager, poll-worker, poll-worker-with-pin */
-  CARD_TYPE: `${VX_IANA_ENTERPRISE_OID}.3`,
-  /** The SHA-256 hash of the election definition  */
-  ELECTION_HASH: `${VX_IANA_ENTERPRISE_OID}.4`,
-} as const;
-
-/**
- * Standard X.509 cert fields, common across all VotingWorks certs
- */
-export const STANDARD_CERT_FIELDS = [
-  'C=US', // Country
-  'ST=CA', // State
-  'O=VotingWorks', // Organization
-] as const;
-
-/**
- * Valid values for cert card type field
- */
-export type CardType =
-  | 'system-administrator'
-  | 'election-manager'
-  | 'poll-worker'
-  | 'poll-worker-with-pin';
-
-/**
- * Parsed custom cert fields
- */
-export interface CustomCertFields {
-  component: 'card' | 'admin' | 'central-scan' | 'mark' | 'scan';
-  jurisdiction: string;
-  cardType?: CardType;
-  electionHash?: string;
-}
-
-/**
- * A schema to facilitate parsing custom cert fields
- */
-const CustomCertFieldsSchema: z.ZodSchema<CustomCertFields> = z.object({
-  component: z.enum(['card', 'admin', 'central-scan', 'mark', 'scan']),
-  jurisdiction: z.string(),
-  cardType: z.optional(
-    z.enum([
-      'system-administrator',
-      'election-manager',
-      'poll-worker',
-      'poll-worker-with-pin',
-    ])
-  ),
-  electionHash: z.optional(z.string()),
-});
-
-/**
- * Cert expiries in days. Must be integers.
- */
-export const CERT_EXPIRY_IN_DAYS = {
-  CARD_VX_CERT: 365 * 100, // 100 years
-  SYSTEM_ADMINISTRATOR_CARD_VX_ADMIN_CERT: 365 * 5, // 5 years
-  ELECTION_CARD_VX_ADMIN_CERT: Math.round(365 * 0.5), // 6 months
-
-  /** Used by dev/test cert-generation scripts */
-  DEV: 365 * 100, // 100 years
-} as const;
-
-/**
- * The jurisdiction in all dev certs
- */
-export const DEV_JURISDICTION = 'st.dev-jurisdiction';
+import {
+  CustomCertFieldsSchema,
+  STANDARD_CERT_FIELDS,
+  VX_CUSTOM_CERT_FIELD,
+} from './constants';
+import { CustomCertFields } from './types';
 
 /**
  * Parses the provided cert and returns the custom cert fields. Throws an error if the cert doesn't

--- a/libs/auth/src/constants.ts
+++ b/libs/auth/src/constants.ts
@@ -1,0 +1,69 @@
+/**
+ * These are here mainly so `configuration.cy.ts` can import them in a browser
+ * environment by importing this file directly. That way we don't have to
+ * import packages that don't work in the browser.
+ */
+import { z } from 'zod';
+import { CustomCertFields } from './types';
+
+/**
+ * VotingWorks's IANA-assigned enterprise OID
+ */
+const VX_IANA_ENTERPRISE_OID = '1.3.6.1.4.1.59817';
+
+/**
+ * Instead of overloading existing X.509 cert fields, we're using our own custom cert fields.
+ */
+export const VX_CUSTOM_CERT_FIELD = {
+  /** One of: card, admin, central-scan, mark, scan (the latter four referring to machines) */
+  COMPONENT: `${VX_IANA_ENTERPRISE_OID}.1`,
+  /** Format: {state-2-letter-abbreviation}.{county-or-town} (e.g. ms.warren or ca.los-angeles) */
+  JURISDICTION: `${VX_IANA_ENTERPRISE_OID}.2`,
+  /** One of: system-administrator, election-manager, poll-worker, poll-worker-with-pin */
+  CARD_TYPE: `${VX_IANA_ENTERPRISE_OID}.3`,
+  /** The SHA-256 hash of the election definition  */
+  ELECTION_HASH: `${VX_IANA_ENTERPRISE_OID}.4`,
+} as const;
+
+/**
+ * Standard X.509 cert fields, common across all VotingWorks certs
+ */
+export const STANDARD_CERT_FIELDS = [
+  'C=US', // Country
+  'ST=CA', // State
+  'O=VotingWorks', // Organization
+] as const;
+
+/**
+ * A schema to facilitate parsing custom cert fields
+ */
+export const CustomCertFieldsSchema: z.ZodSchema<CustomCertFields> = z.object({
+  component: z.enum(['card', 'admin', 'central-scan', 'mark', 'scan']),
+  jurisdiction: z.string(),
+  cardType: z.optional(
+    z.enum([
+      'system-administrator',
+      'election-manager',
+      'poll-worker',
+      'poll-worker-with-pin',
+    ])
+  ),
+  electionHash: z.optional(z.string()),
+});
+
+/**
+ * Cert expiries in days. Must be integers.
+ */
+export const CERT_EXPIRY_IN_DAYS = {
+  CARD_VX_CERT: 365 * 100, // 100 years
+  SYSTEM_ADMINISTRATOR_CARD_VX_ADMIN_CERT: 365 * 5, // 5 years
+  ELECTION_CARD_VX_ADMIN_CERT: Math.round(365 * 0.5), // 6 months
+
+  /** Used by dev/test cert-generation scripts */
+  DEV: 365 * 100, // 100 years
+} as const;
+
+/**
+ * The jurisdiction in all dev certs
+ */
+export const DEV_JURISDICTION = 'st.dev-jurisdiction';

--- a/libs/auth/src/index.ts
+++ b/libs/auth/src/index.ts
@@ -1,4 +1,4 @@
-export { DEV_JURISDICTION } from './certs';
+export { DEV_JURISDICTION } from './constants';
 export * from './dipped_smart_card_auth_api';
 export * from './dipped_smart_card_auth';
 export * from './inserted_smart_card_auth_api';

--- a/libs/auth/src/java_card.test.ts
+++ b/libs/auth/src/java_card.test.ts
@@ -28,7 +28,8 @@ import {
 } from './apdu';
 import { Card, CardDetails, CheckPinResponse } from './card';
 import { CardReader } from './card_reader';
-import { CardType, DEV_JURISDICTION } from './certs';
+import { DEV_JURISDICTION } from './constants';
+import { CardType } from './types';
 import {
   CARD_VX_ADMIN_CERT,
   CARD_VX_CERT,

--- a/libs/auth/src/java_card.ts
+++ b/libs/auth/src/java_card.ts
@@ -27,7 +27,6 @@ import {
 } from './card';
 import { CardReader } from './card_reader';
 import {
-  CERT_EXPIRY_IN_DAYS,
   constructCardCertSubject,
   constructCardCertSubjectWithoutJurisdictionAndCardType,
   parseCardDetailsFromCert,
@@ -57,6 +56,7 @@ import {
   RESET_RETRY_COUNTER,
   VERIFY,
 } from './piv';
+import { CERT_EXPIRY_IN_DAYS } from './constants';
 
 /**
  * The OpenFIPS201 applet ID

--- a/libs/auth/src/memory_card.ts
+++ b/libs/auth/src/memory_card.ts
@@ -13,7 +13,7 @@ import {
 } from '@votingworks/types';
 
 import { Card, CardDetails, CardStatus, CheckPinResponse } from './card';
-import { DEV_JURISDICTION } from './certs';
+import { DEV_JURISDICTION } from './constants';
 import * as Legacy from './legacy';
 
 interface CardData {

--- a/libs/auth/src/mock_file_card.test.ts
+++ b/libs/auth/src/mock_file_card.test.ts
@@ -6,7 +6,7 @@ import {
   SystemAdministratorUser,
 } from '@votingworks/types';
 
-import { DEV_JURISDICTION } from './certs';
+import { DEV_JURISDICTION } from './constants';
 import {
   deserializeMockFileContents,
   mockCard,

--- a/libs/auth/src/types.ts
+++ b/libs/auth/src/types.ts
@@ -1,0 +1,18 @@
+/**
+ * Valid values for cert card type field
+ */
+export type CardType =
+  | 'system-administrator'
+  | 'election-manager'
+  | 'poll-worker'
+  | 'poll-worker-with-pin';
+
+/**
+ * Parsed custom cert fields
+ */
+export interface CustomCertFields {
+  component: 'card' | 'admin' | 'central-scan' | 'mark' | 'scan';
+  jurisdiction: string;
+  cardType?: CardType;
+  electionHash?: string;
+}

--- a/libs/auth/test/utils.ts
+++ b/libs/auth/test/utils.ts
@@ -7,7 +7,7 @@ import {
   OnReaderStatusChange,
   ReaderStatus,
 } from '../src/card_reader';
-import { CardType } from '../src/certs';
+import { CardType } from '../src/types';
 import { JavaCard } from '../src/java_card';
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2810,6 +2810,9 @@ importers:
       pcsclite:
         specifier: ^1.0.1
         version: 1.0.1
+      tmp:
+        specifier: ^0.2.1
+        version: 0.2.1
       uuid:
         specifier: ^9.0.0
         version: 9.0.0
@@ -2829,6 +2832,9 @@ importers:
       '@types/node-fetch':
         specifier: ^2.6.0
         version: 2.6.2
+      '@types/tmp':
+        specifier: ^0.2.3
+        version: 0.2.3
       '@types/uuid':
         specifier: ^9.0.1
         version: 9.0.1


### PR DESCRIPTION


## Overview
Rather than implementing our own `tmp`-like functionality, let's just use the `tmp` package. Advantages:
- we don't have to hardcode a particular place to put files
- we don't have to implement logic to avoid writing to an existing file
- we can use the existing `tmp` cleanup facility

All of the above simplifies the tests somewhat as well.
<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot
n/a

## Testing Plan
Automated.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
