### PR TITLE
fix(scan): use correct layout for grid-based elections

### DIFF
--- a/libs/backend/jest.config.js
+++ b/libs/backend/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       statements: 93,
-      branches: 83,
+      branches: 82,
       functions: 95,
       lines: 94,
     },

--- a/libs/backend/src/scan/cast_vote_records/page_layouts.test.ts
+++ b/libs/backend/src/scan/cast_vote_records/page_layouts.test.ts
@@ -56,11 +56,19 @@ describe('getBallotPageLayout', () => {
     ).toThrow();
   });
 
-  test('generates layout if layout not found and is gridLayouts election', () => {
+  test('ignores ballot page layouts if using a gridLayouts election', () => {
     expect(
       getBallotPageLayout({
         ballotPageMetadata,
-        ballotPageLayoutsLookup: [],
+        ballotPageLayoutsLookup: [
+          {
+            ballotMetadata: ballotPageMetadata,
+            ballotPageLayouts: mockBallotPageLayouts.map((layout) => ({
+              ...layout,
+              name: 'ignore me',
+            })),
+          },
+        ],
         election: {
           ...election,
           gridLayouts: [],

--- a/libs/backend/src/scan/cast_vote_records/page_layouts.ts
+++ b/libs/backend/src/scan/cast_vote_records/page_layouts.ts
@@ -39,7 +39,11 @@ function getBallotPageLayouts({
   ballotPageLayoutsLookup: BallotPageLayoutsLookup;
   election: Election;
 }): BallotPageLayout[] {
-  let ballotPageLayouts = ballotPageLayoutsLookup.find(
+  if (election.gridLayouts) {
+    return generateBallotPageLayouts(election, ballotMetadata).unsafeUnwrap();
+  }
+
+  const ballotPageLayouts = ballotPageLayoutsLookup.find(
     ({ ballotMetadata: lookupMetadata }) =>
       lookupMetadata.locales.primary === ballotMetadata.locales.primary &&
       lookupMetadata.locales.secondary === ballotMetadata.locales.secondary &&
@@ -49,14 +53,7 @@ function getBallotPageLayouts({
   )?.ballotPageLayouts;
 
   if (!ballotPageLayouts) {
-    if (election.gridLayouts) {
-      ballotPageLayouts = generateBallotPageLayouts(
-        election,
-        ballotMetadata
-      ).unsafeUnwrap();
-    } else {
-      throw new Error('unable to find template layout for the current ballot');
-    }
+    throw new Error('unable to find template layout for the current ballot');
   }
 
   return ballotPageLayouts;


### PR DESCRIPTION
## Overview

For some reason we still generate VX-style ballots when building ballot packages for grid-based elections, which means that a layout is generated too. That layout is unlikely to put contests on the same pages as the real layout, which can result in contests appearing on the wrong pages. This affects write-in adjudication because a write-in may be ignored if the two layouts disagree about which page it is on. This commit fixes the issue by always using the generated layouts for grid-based elections, ignoring the vestigial VX-style ballots generated for such elections.

[Slack context](https://votingworks.slack.com/archives/C04U11L9SCR/p1681843934357579)

## Demo Video or Screenshot
In the table below, the write-in votes for the "Planning Board Members" contest are ignored because they are mistakenly thought to be on the second page.
| Before (dashboard) | Before (transcription) | After |
|-|-|-|
|![image](https://user-images.githubusercontent.com/1938/232915774-4b5d8fdf-f67e-4ca4-881e-3a88172e809a.png)|![image](https://user-images.githubusercontent.com/1938/232915882-0b8c32b0-5446-4c7d-88f6-fe96ff54ab2c.png)|![image](https://user-images.githubusercontent.com/1938/232915915-23d7cb7c-3688-4ef9-a588-24d8a43b0e43.png)|

## Testing Plan
Tested manually with a grid-based election.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
