### PR TITLE
test(admin): quiet `app.test.ts` a bit

### DIFF
--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -5,6 +5,7 @@ import {
 } from '@votingworks/fixtures';
 import { LogEventId } from '@votingworks/logging';
 
+import { suppressingConsoleOutput } from '@votingworks/test-utils';
 import {
   buildTestEnvironment,
   configureMachine,
@@ -191,10 +192,12 @@ test('setSystemSettings throws error when store.saveSystemSettings fails', async
   });
 
   mockSystemAdministratorAuth(auth);
-  // https://jestjs.io/docs/expect#rejects
-  await expect(
-    apiClient.setSystemSettings({ systemSettings: systemSettings.asText() })
-  ).rejects.toThrow(errorString);
+
+  await suppressingConsoleOutput(async () => {
+    await expect(
+      apiClient.setSystemSettings({ systemSettings: systemSettings.asText() })
+    ).rejects.toThrow(errorString);
+  });
 
   // Logger call 1 is made by configureMachine when loading the election definition
   expect(logger.log).toHaveBeenNthCalledWith(


### PR DESCRIPTION

## Overview
It was loudly logging an error.

## Demo Video or Screenshot
<img width="567" alt="image" src="https://user-images.githubusercontent.com/1938/232917444-684aeff1-9f36-4fd5-8d40-041b8824d2b0.png">

## Testing Plan
Automated.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
