### PR TITLE
fix(scan): do not generate ballots for grid-based elections

### DIFF
--- a/apps/admin/frontend/src/components/export_election_ballot_package_modal_button.test.tsx
+++ b/apps/admin/frontend/src/components/export_election_ballot_package_modal_button.test.tsx
@@ -6,11 +6,10 @@ import {
   mockOf,
 } from '@votingworks/test-utils';
 import React from 'react';
-import { UsbDriveStatus } from '@votingworks/ui';
+import { UsbDriveStatus, mockUsbDrive } from '@votingworks/ui';
 import userEvent from '@testing-library/user-event';
 import { iter } from '@votingworks/basics';
 import { interpretMultiPagePdfTemplate } from '@votingworks/ballot-interpreter-vx';
-import { mockUsbDrive } from '@votingworks/ui';
 import {
   fireEvent,
   screen,

--- a/apps/admin/frontend/src/components/export_election_ballot_package_modal_button.tsx
+++ b/apps/admin/frontend/src/components/export_election_ballot_package_modal_button.tsx
@@ -65,7 +65,7 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
 
   const loaded = systemSettingsQuery.isSuccess;
 
-  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   /**
    * Execute side effects for the current state and, when ready, transition to

--- a/apps/admin/frontend/src/utils/get_all_ballot_configs.ts
+++ b/apps/admin/frontend/src/utils/get_all_ballot_configs.ts
@@ -9,6 +9,12 @@ export function getAllBallotConfigs(
   localeCodes: readonly string[]
 ): BallotConfig[] {
   const { election } = electionDefinition;
+
+  if (election.gridLayouts) {
+    // don't generate ballots for election with grid layouts
+    return [];
+  }
+
   const ballotStyles = getBallotStylesDataByStyle(election);
   const allLocaleConfigs = localeCodes.map<BallotLocale>((localeCode) => ({
     primary: DEFAULT_LOCALE,

--- a/apps/admin/frontend/src/workflows/export_election_ballot_package_workflow.test.ts
+++ b/apps/admin/frontend/src/workflows/export_election_ballot_package_workflow.test.ts
@@ -1,4 +1,7 @@
-import { electionSampleDefinition } from '@votingworks/fixtures';
+import {
+  electionGridLayoutNewHampshireAmherstFixtures,
+  electionSampleDefinition,
+} from '@votingworks/fixtures';
 import { fakeKiosk } from '@votingworks/test-utils';
 import * as workflow from './export_election_ballot_package_workflow';
 import { DownloadableArchive } from '../utils/downloadable_archive';
@@ -100,6 +103,23 @@ test('advances to the next ballot config if there is one', () => {
         locales: { primary: 'en-US' },
       },
       ballotConfigsCount: 2,
+    })
+  );
+});
+
+test('skips RenderBallot if there are no ballot configs', () => {
+  expect(
+    workflow.next({
+      type: 'ArchiveBegin',
+      electionDefinition:
+        electionGridLayoutNewHampshireAmherstFixtures.electionDefinition,
+      archive: new DownloadableArchive(),
+      ballotConfigs: [],
+    })
+  ).toEqual(
+    expect.objectContaining({
+      type: 'ArchiveEnd',
+      ballotConfigsCount: 0,
     })
   );
 });

--- a/apps/admin/frontend/src/workflows/export_election_ballot_package_workflow.ts
+++ b/apps/admin/frontend/src/workflows/export_election_ballot_package_workflow.ts
@@ -76,6 +76,14 @@ export function next(state: State): State {
       const [currentBallotConfig, ...remainingBallotConfigs] =
         state.ballotConfigs;
 
+      if (!currentBallotConfig) {
+        return {
+          type: 'ArchiveEnd',
+          archive: state.archive,
+          ballotConfigsCount: state.ballotConfigs.length,
+        };
+      }
+
       return {
         type: 'RenderBallot',
         electionDefinition: state.electionDefinition,


### PR DESCRIPTION
## Overview
Grid-based elections do not need or want VX-style ballots in their ballot package. This makes exporting and importing such ballot packages faster, and the packages themselves smaller.

## Demo Video or Screenshot
```
128K   ┌── no-ballots.zip                                                        
384K   ├── moultonborough_annual-town-election_1aebf55dda__2023-04-18_11-28-43.zip
```

[no-ballots.zip](https://github.com/votingworks/vxsuite/files/11266974/no-ballots.zip)

## Testing Plan
Manually generated a new ballot package (`no-ballots.zip` above), configured VxCentralScan with it, and scanned a ballot.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
