### PR TITLE
use generator for CVRs retrieved from db

### DIFF
--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -15,7 +15,14 @@ import {
   SystemSettings,
   SystemSettingsSchema,
 } from '@votingworks/types';
-import { assert, assertDefined, err, ok, Optional } from '@votingworks/basics';
+import {
+  assert,
+  assertDefined,
+  err,
+  iter,
+  ok,
+  Optional,
+} from '@votingworks/basics';
 import express, { Application } from 'express';
 import {
   DippedSmartCardAuthApi,
@@ -285,8 +292,11 @@ function buildApi({
         return [];
       }
 
-      return store
-        .getCastVoteRecordEntries(currentElectionId)
+      const castVoteRecordEntryIter = iter(
+        store.getCastVoteRecordEntries(currentElectionId)
+      );
+
+      return castVoteRecordEntryIter
         .map(
           (entry) => safeParseJson(entry.data).unsafeUnwrap() as CastVoteRecord
         )
@@ -295,7 +305,8 @@ function buildApi({
           // Strip out ballot images to keep the response size low, since
           // they're not needed client-side.
           _ballotImages: undefined,
-        }));
+        }))
+        .toArray();
     },
 
     /**

--- a/apps/admin/backend/src/store.test.ts
+++ b/apps/admin/backend/src/store.test.ts
@@ -275,7 +275,9 @@ test('analyze a CVR file', async () => {
   });
 
   // analyzing does not add to the store
-  expect(store.getCastVoteRecordEntries(electionId)).toHaveLength(0);
+  expect(Array.from(store.getCastVoteRecordEntries(electionId))).toHaveLength(
+    0
+  );
 });
 
 test('adding a CVR file if adding an entry fails', async () => {
@@ -301,7 +303,9 @@ test('adding a CVR file if adding an entry fails', async () => {
     ).unsafeUnwrap()
   ).rejects.toThrowError('oops');
 
-  expect(store.getCastVoteRecordEntries(electionId)).toHaveLength(0);
+  expect(Array.from(store.getCastVoteRecordEntries(electionId))).toHaveLength(
+    0
+  );
 });
 
 test('add a CVR file entry without a ballot ID', async () => {
@@ -750,7 +754,9 @@ test('get write-in adjudication records', async () => {
     })
   ).unsafeUnwrap();
 
-  const castVoteRecordId = store.getCastVoteRecordEntries(electionId)[0]!.id;
+  const castVoteRecordId = Array.from(
+    store.getCastVoteRecordEntries(electionId)
+  )[0]!.id;
   const writeInAdjudicationRecords = store.getWriteInRecords({
     electionId,
   });
@@ -861,7 +867,9 @@ test('write-in adjudication lifecycle', async () => {
     })
   ).unsafeUnwrap();
 
-  const castVoteRecordId = store.getCastVoteRecordEntries(electionId)[0]!.id;
+  const castVoteRecordId = Array.from(
+    store.getCastVoteRecordEntries(electionId)
+  )[0]!.id;
   const writeInId = store.addWriteIn({
     castVoteRecordId,
     contestId: 'zoo-council-mammal',


### PR DESCRIPTION
## Overview

We appear to be crashing due to memory limitations when the number of CVRs gets around 3,000 when the CVRs have lots of write-ins. This seems to be due to when we are returning CVRs to the frontend and parsing them all. In this patch, I stream CVRs out of the store rather than returning them all at once, so the parsing is happening one at a time.
