### PR TITLE
feat(scan-nh): allow interpreting `ImageData`

### DIFF
--- a/libs/ballot-interpreter-nh-next/src/js/args.rs
+++ b/libs/ballot-interpreter-nh-next/src/js/args.rs
@@ -1,0 +1,80 @@
+use neon::types::JsObject;
+use neon::{prelude::*, result::Throw};
+use std::path::PathBuf;
+
+use crate::election::Election;
+
+use super::image_data::ImageData;
+
+/// Image arguments can be either a path or an `ImageData` object.
+#[derive(Debug)]
+pub enum ImageSource {
+    Path(PathBuf),
+    ImageData(ImageData),
+}
+
+impl ImageSource {
+    /// Gets a label for display purposes, either the image path or a default.
+    pub fn as_label_or<S: Into<String>>(&self, default: S) -> String {
+        match self {
+            Self::Path(path) => path.to_string_lossy().to_string(),
+            Self::ImageData(_) => default.into(),
+        }
+    }
+}
+
+/// Gets an `ImageSource` from the argument at the given index.
+pub fn get_image_data_or_path_from_arg(
+    cx: &mut FunctionContext,
+    argument: i32,
+) -> Result<ImageSource, Throw> {
+    let argument = cx.argument::<JsValue>(argument)?;
+    if argument.is_a::<JsString, _>(cx) {
+        let path = argument
+            .downcast::<JsString, _>(cx)
+            .unwrap()
+            .value(&mut *cx);
+        Ok(ImageSource::Path(PathBuf::from(path)))
+    } else if argument.is_a::<JsObject, _>(cx) {
+        let image_data = argument.downcast::<JsObject, _>(cx).unwrap();
+        ImageData::from_js_object(cx, image_data).map_or_else(
+            || cx.throw_type_error("unable to read argument as ImageData"),
+            |image| Ok(ImageSource::ImageData(image)),
+        )
+    } else {
+        cx.throw_type_error("expected image data or path")
+    }
+}
+
+/// Gets a `PathBuf` from the argument at the given index, if it exists.
+pub fn get_path_from_arg_opt(cx: &mut FunctionContext, argument: i32) -> Option<PathBuf> {
+    let argument = cx.argument_opt(argument)?;
+    let js_string = argument.downcast::<JsString, _>(cx).ok()?;
+    let string = js_string.value(cx);
+    Some(PathBuf::from(string))
+}
+
+/// Gets an `Election` from the argument at the given index.
+pub fn get_election_definition_from_arg(
+    cx: &mut FunctionContext,
+    argument: i32,
+) -> Result<Election, Throw> {
+    let Some(election_json) = cx.argument_opt(0) else {
+        return cx.throw_type_error(format!(
+            "election definition expected at argument {argument}"
+        ));
+    };
+
+    let Ok(election_json) = election_json
+        .downcast::<JsString, _>(cx) else {
+            return cx.throw_type_error(format!(
+                "election definition at argument {argument} must be a string"
+            ));
+        };
+
+    serde_json::from_str(election_json.value(cx).as_str()).or_else(|err| {
+        cx.throw_type_error(format!(
+            "failed to parse election definition at argument {argument}: {err}"
+        ))
+    })
+}

--- a/libs/ballot-interpreter-nh-next/src/js/image_data.rs
+++ b/libs/ballot-interpreter-nh-next/src/js/image_data.rs
@@ -1,0 +1,87 @@
+use std::borrow::{Borrow, BorrowMut};
+
+use image::{DynamicImage, GrayImage};
+use neon::prelude::*;
+use neon::types::{buffer::TypedArray, JsNumber, JsObject};
+
+/// Represents an image as stored in JavaScript. Used to convert between
+/// JavaScript and Rust. Expected to be RGBA8.
+#[derive(Debug)]
+pub struct ImageData {
+    width: u32,
+    height: u32,
+    data: Vec<u8>,
+}
+
+impl ImageData {
+    /// Creates a new `ImageData` object.
+    pub fn new(width: u32, height: u32, data: Vec<u8>) -> Self {
+        Self {
+            width,
+            height,
+            data,
+        }
+    }
+
+    /// Converts a JavaScript object compatible with the `ImageData` interface.
+    pub fn convert_gray_image_to_js_object<'a>(
+        cx: &mut FunctionContext<'a>,
+        image: GrayImage,
+    ) -> JsResult<'a, JsObject> {
+        let (width, height) = image.dimensions();
+        let data = DynamicImage::ImageLuma8(image).into_rgba8().into_raw();
+        let image_data = Self::new(width, height, data);
+        image_data.to_js_object(cx)
+    }
+
+    /// Converts a JavaScript `ImageData` object to a Rust `ImageData`.
+    pub fn from_js_object(cx: &mut FunctionContext, js_object: Handle<JsObject>) -> Option<Self> {
+        let width = js_object.get::<JsNumber, _, _>(cx, "width").ok()?.value(cx) as u32;
+        let height = js_object
+            .get::<JsNumber, _, _>(cx, "height")
+            .ok()?
+            .value(cx) as u32;
+        let data = js_object
+            .get::<JsBuffer, _, _>(cx, "data")
+            .ok()?
+            .borrow()
+            .as_slice(cx)
+            .to_vec();
+        Some(Self::new(width, height, data))
+    }
+
+    pub fn to_js_object<'a>(&self, cx: &mut FunctionContext<'a>) -> JsResult<'a, JsObject> {
+        let js_object = cx.empty_object();
+        let width = cx.number(self.width as f64);
+        let height = cx.number(self.height as f64);
+        js_object.set(cx, "width", width)?;
+        js_object.set(cx, "height", height)?;
+        let mut data = cx.buffer(self.data.len())?;
+        data.borrow_mut()
+            .as_mut_slice(cx)
+            .copy_from_slice(self.data.as_slice());
+        js_object.set(cx, "data", data)?;
+        Ok(js_object)
+    }
+}
+
+impl From<DynamicImage> for ImageData {
+    fn from(image: DynamicImage) -> Self {
+        let image = image.into_rgba8();
+        let (width, height) = image.dimensions();
+        let data = image.into_raw();
+        Self::new(width, height, data)
+    }
+}
+
+impl From<ImageData> for DynamicImage {
+    fn from(image_data: ImageData) -> Self {
+        let ImageData {
+            width,
+            height,
+            data,
+        } = image_data;
+        let image = image::ImageBuffer::from_raw(width, height, data).expect("Invalid image data");
+        Self::ImageRgba8(image)
+    }
+}

--- a/libs/ballot-interpreter-nh-next/src/js/mod.rs
+++ b/libs/ballot-interpreter-nh-next/src/js/mod.rs
@@ -1,0 +1,125 @@
+use image::{DynamicImage, GrayImage};
+use neon::prelude::*;
+use neon::types::JsObject;
+
+use crate::ballot_card::load_oval_template;
+use crate::interpret::{interpret_ballot_card, Options, SIDE_A_LABEL, SIDE_B_LABEL};
+
+use self::args::{
+    get_election_definition_from_arg, get_image_data_or_path_from_arg, get_path_from_arg_opt,
+    ImageSource,
+};
+use self::image_data::ImageData;
+
+mod args;
+mod image_data;
+
+fn make_interpret_result<'a>(
+    cx: &mut FunctionContext<'a>,
+    result: Result<Handle<JsString>, Handle<JsString>>,
+) -> JsResult<'a, JsObject> {
+    let result_object = cx.empty_object();
+    let (success, value) = match result {
+        Ok(value) => (cx.boolean(true), value),
+        Err(error) => (cx.boolean(false), error),
+    };
+    result_object.set(cx, "success", success)?;
+    result_object.set(cx, "value", value)?;
+    Ok(result_object)
+}
+
+/// Interpret a ballot card.
+///
+/// From JavaScript, this function takes the following arguments:
+/// 1. The election definition as a JSON string.
+/// 2. An `ImageData` or path to load for side A of the ballot card.
+/// 3. An `ImageData` or path to load for side B of the ballot card.
+/// 4. An optional base path to save interpretation debug images for the side A.
+/// 5. An optional base path to save interpretation debug images for the side B.
+///
+/// Processing the arguments, including reading images from disk, will
+/// result in a `Throw` if any of the arguments are invalid. If the return
+/// value cannot be serialized to JSON, a `Throw` will result.
+///
+/// Once interpretation starts, errors are returned as structured data.
+pub fn interpret(mut cx: FunctionContext) -> JsResult<JsObject> {
+    let election = get_election_definition_from_arg(&mut cx, 0)?;
+    let side_a_image_or_path = get_image_data_or_path_from_arg(&mut cx, 1)?;
+    let side_b_image_or_path = get_image_data_or_path_from_arg(&mut cx, 2)?;
+    let debug_side_a_base = get_path_from_arg_opt(&mut cx, 3);
+    let debug_side_b_base = get_path_from_arg_opt(&mut cx, 4);
+
+    let side_a_label = side_a_image_or_path.as_label_or(SIDE_A_LABEL);
+    let side_b_label = side_b_image_or_path.as_label_or(SIDE_B_LABEL);
+    let (side_a_image, side_b_image) = rayon::join(
+        || load_ballot_image_from_image_or_path(side_a_image_or_path),
+        || load_ballot_image_from_image_or_path(side_b_image_or_path),
+    );
+
+    let (side_a_image, side_b_image) =
+        match ((side_a_image, side_a_label), (side_b_image, side_b_label)) {
+            ((Some(a), _), (Some(b), _)) => (a, b),
+            ((None, label), (Some(_), _)) | ((Some(_), _), (None, label)) => {
+                return cx.throw_error(format!("failed to load ballot card image: {label}"));
+            }
+            ((None, a), (None, b)) => {
+                return cx.throw_error(format!("failed to load ballot card images: {a}, {b}"));
+            }
+        };
+
+    let interpret_result = interpret_ballot_card(
+        side_a_image,
+        side_b_image,
+        &Options {
+            election,
+            oval_template: load_oval_template().expect("failed to load oval template"),
+            debug_side_a_base,
+            debug_side_b_base,
+        },
+    );
+
+    let card = match interpret_result {
+        Ok(interpreted) => interpreted,
+        Err(err) => {
+            if let Ok(error_json) = serde_json::to_string(&err) {
+                let error = Err(cx.string(error_json));
+                return make_interpret_result(&mut cx, error);
+            }
+
+            return cx.throw_error(format!(
+                "failed to interpret ballot card; further, the error could not be serialized: {:?}",
+                err
+            ));
+        }
+    };
+
+    let json = serde_json::to_string(&card).or_else(|err| {
+        cx.throw_error(format!(
+            "ballot card interpretation succeeded, but serialization as JSON failed: {err}"
+        ))
+    })?;
+
+    let value = Ok(cx.string(json));
+    let result_object = make_interpret_result(&mut cx, value)?;
+
+    let front_js_normalized_image_obj =
+        ImageData::convert_gray_image_to_js_object(&mut cx, card.front.normalized_image)?;
+    let back_js_normalized_image_obj =
+        ImageData::convert_gray_image_to_js_object(&mut cx, card.back.normalized_image)?;
+    result_object.set(
+        &mut cx,
+        "frontNormalizedImage",
+        front_js_normalized_image_obj,
+    )?;
+    result_object.set(&mut cx, "backNormalizedImage", back_js_normalized_image_obj)?;
+
+    Ok(result_object)
+}
+
+fn load_ballot_image_from_image_or_path(image_or_path: ImageSource) -> Option<GrayImage> {
+    let image: Option<DynamicImage> = match image_or_path {
+        ImageSource::ImageData(image) => Some(image.into()),
+        ImageSource::Path(path) => image::open(path).ok(),
+    };
+    image.map(DynamicImage::into_luma8)
+}

--- a/libs/ballot-interpreter-nh-next/src/layout.rs
+++ b/libs/ballot-interpreter-nh-next/src/layout.rs
@@ -96,7 +96,7 @@ pub fn build_interpreted_page_layout(
         .grid_positions
         .iter()
         .filter(|grid_position| grid_position.location().side == side)
-        .map(|grid_position| grid_position.contest_id())
+        .map(GridPosition::contest_id)
         .unique()
         .collect::<Vec<_>>();
 

--- a/libs/ballot-interpreter-nh-next/src/lib.rs
+++ b/libs/ballot-interpreter-nh-next/src/lib.rs
@@ -1,9 +1,4 @@
-use ballot_card::load_oval_template;
-use image::{DynamicImage, GrayImage};
-use interpret::load_ballot_card_images;
-use neon::{prelude::*, types::buffer::TypedArray};
-use serde::Serialize;
-use std::{borrow::BorrowMut, path::Path};
+use neon::prelude::*;
 
 mod ballot_card;
 mod debug;
@@ -11,177 +6,16 @@ mod election;
 mod geometry;
 mod image_utils;
 mod interpret;
+mod js;
 mod layout;
 mod metadata;
 mod scoring;
 mod timing_marks;
 mod types;
 
-use crate::interpret::{interpret_ballot_card, Options};
-
-fn make_interpret_result<'a>(
-    cx: &mut FunctionContext<'a>,
-    result: Result<Handle<JsString>, Handle<JsString>>,
-) -> JsResult<'a, JsObject> {
-    let result_object = cx.empty_object();
-    let (success, value) = match result {
-        Ok(value) => (cx.boolean(true), value),
-        Err(error) => (cx.boolean(false), error),
-    };
-    result_object.set(cx, "success", success)?;
-    result_object.set(cx, "value", value)?;
-    Ok(result_object)
-}
-
-#[derive(Debug, Serialize)]
-struct InterpretError {
-    #[serde(rename = "type")]
-    error_type: &'static str,
-    message: String,
-}
-
-/// "unknown" error type for errors that are not specific to the interpretation process.
-impl InterpretError {
-    const fn new(message: String) -> Self {
-        Self {
-            error_type: "unknown",
-            message,
-        }
-    }
-
-    fn to_json(&self) -> String {
-        serde_json::to_string(self).unwrap_or_else(|_| {
-            r#"{"type": "unknown", "message": "Failed to serialize error"}"#.to_string()
-        })
-    }
-
-    fn json(message: String) -> String {
-        Self::new(message).to_json()
-    }
-}
-
-/// Interpret a ballot card.
-///
-/// From JavaScript, this function takes three arguments:
-/// 1. The election definition as a JSON string.
-/// 2. The path to the image of one side of the ballot card.
-/// 3. The path to the image of the other side of the ballot card.
-/// 4. A boolean indicating whether to output debug images.
-///
-/// The return value is an object with the following properties:
-/// 1. `success`: a boolean indicating whether the interpretation succeeded.
-/// 3. `value`: the JSON-encoded result of the interpretation.
-fn interpret(mut cx: FunctionContext) -> JsResult<JsObject> {
-    let election_json = cx.argument::<JsString>(0)?.value(&mut cx);
-    let side_a_path = cx.argument::<JsString>(1)?.value(&mut cx);
-    let side_b_path = cx.argument::<JsString>(2)?.value(&mut cx);
-    let debug = cx.argument::<JsBoolean>(3)?.value(&mut cx);
-
-    let election = match serde_json::from_str(election_json.as_str()) {
-        Ok(election) => election,
-        Err(err) => {
-            let error = Err(cx.string(InterpretError::json(format!(
-                "Failed to parse election JSON: {err}"
-            ))));
-            return make_interpret_result(&mut cx, error);
-        }
-    };
-
-    let (side_a_image, side_b_image) = match load_ballot_card_images(
-        Path::new(side_a_path.as_str()),
-        Path::new(side_b_path.as_str()),
-    ) {
-        Ok(images) => images,
-        Err(err) => {
-            let error = Err(cx.string(InterpretError::json(format!(
-                "Failed to load ballot card images: {err}"
-            ))));
-            return make_interpret_result(&mut cx, error);
-        }
-    };
-    let interpret_result = interpret_ballot_card(
-        side_a_image,
-        side_b_image,
-        &Options {
-            election,
-            oval_template: load_oval_template().expect("Failed to load oval template"),
-            debug_side_a_base: if debug {
-                Some(Path::new(side_a_path.as_str()).to_path_buf())
-            } else {
-                None
-            },
-            debug_side_b_base: if debug {
-                Some(Path::new(side_b_path.as_str()).to_path_buf())
-            } else {
-                None
-            },
-        },
-    );
-
-    let card = match interpret_result {
-        Ok(interpreted) => interpreted,
-        Err(err) => {
-            if let Ok(error_json) = serde_json::to_string(&err) {
-                let error = Err(cx.string(error_json));
-                return make_interpret_result(&mut cx, error);
-            }
-
-            let error = Err(cx.string(InterpretError::json(format!(
-                "Failed to interpret ballot card; further, the error could not be serialized: {:?}",
-                err
-            ))));
-            return make_interpret_result(&mut cx, error);
-        }
-    };
-
-    let json = match serde_json::to_string(&card) {
-        Ok(json) => json,
-        Err(err) => {
-            let error = Err(cx.string(InterpretError::json(format!(
-                "Ballot card interpretation succeeded, but serialization as JSON failed: {err}"
-            ))));
-            return make_interpret_result(&mut cx, error);
-        }
-    };
-
-    let value = Ok(cx.string(json));
-    let result_object = make_interpret_result(&mut cx, value)?;
-
-    let front_js_normalized_image_obj =
-        make_js_image_data_object(&mut cx, card.front.normalized_image)?;
-    let back_js_normalized_image_obj =
-        make_js_image_data_object(&mut cx, card.back.normalized_image)?;
-    result_object.set(
-        &mut cx,
-        "frontNormalizedImage",
-        front_js_normalized_image_obj,
-    )?;
-    result_object.set(&mut cx, "backNormalizedImage", back_js_normalized_image_obj)?;
-
-    Ok(result_object)
-}
-
-/// Creates a JavaScript object compatible with the `ImageData` interface.
-fn make_js_image_data_object<'a>(
-    cx: &mut FunctionContext<'a>,
-    image: GrayImage,
-) -> JsResult<'a, JsObject> {
-    let js_object = cx.empty_object();
-    let rgba_image = DynamicImage::ImageLuma8(image).into_rgba8();
-    let mut data = cx.buffer(rgba_image.len())?;
-    data.borrow_mut()
-        .as_mut_slice(cx)
-        .copy_from_slice(rgba_image.as_ref());
-    let (width, height) = rgba_image.dimensions();
-    let (width, height) = (cx.number(f64::from(width)), cx.number(f64::from(height)));
-    js_object.set(cx, "data", data)?;
-    js_object.set(cx, "width", width)?;
-    js_object.set(cx, "height", height)?;
-    Ok(js_object)
-}
-
+/// Entry point for the Neon module. Exports values to JavaScript.
 #[neon::main]
 fn main(mut cx: ModuleContext) -> NeonResult<()> {
-    cx.export_function("interpret", interpret)?;
+    cx.export_function("interpret", js::interpret)?;
     Ok(())
 }

--- a/libs/ballot-interpreter-nh-next/src/timing_marks.rs
+++ b/libs/ballot-interpreter-nh-next/src/timing_marks.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use image::{imageops::rotate180, GenericImageView, GrayImage};
 use imageproc::{
     contours::{find_contours_with_threshold, BorderType, Contour},
@@ -193,7 +191,7 @@ impl TimingMarkGrid {
 /// marks, i.e. the locations of all the possible ovals.
 #[time]
 pub fn find_timing_mark_grid(
-    image_path: &Path,
+    label: &str,
     geometry: &Geometry,
     img: &GrayImage,
     border_inset: Inset,
@@ -270,7 +268,7 @@ pub fn find_timing_mark_grid(
         Ok(metadata) => metadata,
         Err(error) => {
             return Err(Error::InvalidMetadata {
-                path: image_path.to_str().unwrap_or_default().to_string(),
+                label: label.to_string(),
                 error,
             })
         }

--- a/libs/ballot-interpreter-nh-next/ts/src/__snapshots__/interpret.test.ts.snap
+++ b/libs/ballot-interpreter-nh-next/ts/src/__snapshots__/interpret.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`interpret with valid data 1`] = `
+exports[`interpret \`ImageData\` objects 1`] = `
 [
   {
     "bounds": {
@@ -370,7 +370,639 @@ exports[`interpret with valid data 1`] = `
 ]
 `;
 
-exports[`interpret with valid data 2`] = `
+exports[`interpret \`ImageData\` objects 2`] = `
+[
+  {
+    "bounds": {
+      "height": 153,
+      "left": 382,
+      "top": 253,
+      "width": 1301,
+    },
+    "contestId": "Sheriff-4243fe0b",
+    "options": [
+      {
+        "bounds": {
+          "height": 153,
+          "left": 382,
+          "top": 253,
+          "width": 351,
+        },
+        "optionId": "Edward-Randolph-bf4c848a",
+      },
+      {
+        "bounds": {
+          "height": 153,
+          "left": 732,
+          "top": 253,
+          "width": 351,
+        },
+        "optionId": "Edward-Randolph-bf4c848a",
+      },
+      {
+        "bounds": {
+          "height": 153,
+          "left": 1382,
+          "top": 253,
+          "width": 301,
+        },
+        "optionId": "write-in-0",
+      },
+    ],
+  },
+  {
+    "bounds": {
+      "height": 152,
+      "left": 382,
+      "top": 405,
+      "width": 1301,
+    },
+    "contestId": "County-Attorney-133f910f",
+    "options": [
+      {
+        "bounds": {
+          "height": 151,
+          "left": 382,
+          "top": 405,
+          "width": 351,
+        },
+        "optionId": "Ezra-Bartlett-8f95223c",
+      },
+      {
+        "bounds": {
+          "height": 152,
+          "left": 732,
+          "top": 405,
+          "width": 351,
+        },
+        "optionId": "Mary-Woolson-dc0b854a",
+      },
+      {
+        "bounds": {
+          "height": 152,
+          "left": 1382,
+          "top": 405,
+          "width": 301,
+        },
+        "optionId": "write-in-0",
+      },
+    ],
+  },
+  {
+    "bounds": {
+      "height": 153,
+      "left": 382,
+      "top": 555,
+      "width": 1301,
+    },
+    "contestId": "County-Treasurer-87d25a31",
+    "options": [
+      {
+        "bounds": {
+          "height": 153,
+          "left": 382,
+          "top": 555,
+          "width": 351,
+        },
+        "optionId": "John-Smith-ef61a579",
+      },
+      {
+        "bounds": {
+          "height": 153,
+          "left": 732,
+          "top": 555,
+          "width": 351,
+        },
+        "optionId": "Jane-Jones-9caa141f",
+      },
+      {
+        "bounds": {
+          "height": 152,
+          "left": 1382,
+          "top": 556,
+          "width": 301,
+        },
+        "optionId": "write-in-0",
+      },
+    ],
+  },
+  {
+    "bounds": {
+      "height": 152,
+      "left": 382,
+      "top": 707,
+      "width": 1301,
+    },
+    "contestId": "Register-of-Deeds-a1278df2",
+    "options": [
+      {
+        "bounds": {
+          "height": 151,
+          "left": 382,
+          "top": 707,
+          "width": 351,
+        },
+        "optionId": "John-Mann-b56bbdd3",
+      },
+      {
+        "bounds": {
+          "height": 152,
+          "left": 732,
+          "top": 707,
+          "width": 351,
+        },
+        "optionId": "Ellen-A-Stileman-14408737",
+      },
+      {
+        "bounds": {
+          "height": 152,
+          "left": 1382,
+          "top": 707,
+          "width": 301,
+        },
+        "optionId": "write-in-0",
+      },
+    ],
+  },
+  {
+    "bounds": {
+      "height": 153,
+      "left": 382,
+      "top": 857,
+      "width": 1301,
+    },
+    "contestId": "Register-of-Probate-a4117da8",
+    "options": [
+      {
+        "bounds": {
+          "height": 152,
+          "left": 382,
+          "top": 857,
+          "width": 351,
+        },
+        "optionId": "Nathaniel-Parker-56a06c29",
+      },
+      {
+        "bounds": {
+          "height": 153,
+          "left": 732,
+          "top": 857,
+          "width": 351,
+        },
+        "optionId": "Claire-Cutts-07a436e7",
+      },
+      {
+        "bounds": {
+          "height": 152,
+          "left": 1381,
+          "top": 858,
+          "width": 302,
+        },
+        "optionId": "write-in-0",
+      },
+    ],
+  },
+  {
+    "bounds": {
+      "height": 154,
+      "left": 381,
+      "top": 1008,
+      "width": 1301,
+    },
+    "contestId": "County-Commissioner-d6feed25",
+    "options": [
+      {
+        "bounds": {
+          "height": 153,
+          "left": 381,
+          "top": 1008,
+          "width": 352,
+        },
+        "optionId": "Ichabod-Goodwin-55e8de1f",
+      },
+      {
+        "bounds": {
+          "height": 153,
+          "left": 731,
+          "top": 1008,
+          "width": 351,
+        },
+        "optionId": "Valbe-Cady-ba3af3af",
+      },
+      {
+        "bounds": {
+          "height": 153,
+          "left": 1381,
+          "top": 1009,
+          "width": 301,
+        },
+        "optionId": "write-in-0",
+      },
+    ],
+  },
+  {
+    "bounds": {
+      "height": 154,
+      "left": 1081,
+      "top": 1260,
+      "width": 601,
+    },
+    "contestId": "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc",
+    "options": [
+      {
+        "bounds": {
+          "height": 154,
+          "left": 1081,
+          "top": 1260,
+          "width": 351,
+        },
+        "optionId": "yes",
+      },
+      {
+        "bounds": {
+          "height": 153,
+          "left": 1381,
+          "top": 1261,
+          "width": 301,
+        },
+        "optionId": "no",
+      },
+    ],
+  },
+]
+`;
+
+exports[`interpret images from paths 1`] = `
+[
+  {
+    "bounds": {
+      "height": 152,
+      "left": 372,
+      "top": 455,
+      "width": 1301,
+    },
+    "contestId": "Governor-061a401b",
+    "options": [
+      {
+        "bounds": {
+          "height": 152,
+          "left": 372,
+          "top": 455,
+          "width": 352,
+        },
+        "optionId": "Josiah-Bartlett-1bb99985",
+      },
+      {
+        "bounds": {
+          "height": 152,
+          "left": 722,
+          "top": 455,
+          "width": 351,
+        },
+        "optionId": "Hannah-Dustin-ab4ef7c8",
+      },
+      {
+        "bounds": {
+          "height": 152,
+          "left": 1072,
+          "top": 455,
+          "width": 351,
+        },
+        "optionId": "John-Spencer-9ffb5970",
+      },
+      {
+        "bounds": {
+          "height": 152,
+          "left": 1372,
+          "top": 455,
+          "width": 301,
+        },
+        "optionId": "write-in-0",
+      },
+    ],
+  },
+  {
+    "bounds": {
+      "height": 152,
+      "left": 373,
+      "top": 606,
+      "width": 1300,
+    },
+    "contestId": "United-States-Senator-d3f1c75b",
+    "options": [
+      {
+        "bounds": {
+          "height": 152,
+          "left": 373,
+          "top": 606,
+          "width": 351,
+        },
+        "optionId": "John-Langdon-5951c8e1",
+      },
+      {
+        "bounds": {
+          "height": 152,
+          "left": 723,
+          "top": 606,
+          "width": 350,
+        },
+        "optionId": "William-Preston-3778fcd5",
+      },
+      {
+        "bounds": {
+          "height": 152,
+          "left": 1372,
+          "top": 606,
+          "width": 301,
+        },
+        "optionId": "write-in-0",
+      },
+    ],
+  },
+  {
+    "bounds": {
+      "height": 153,
+      "left": 373,
+      "top": 757,
+      "width": 1301,
+    },
+    "contestId": "Representative-in-Congress-24683b44",
+    "options": [
+      {
+        "bounds": {
+          "height": 153,
+          "left": 373,
+          "top": 757,
+          "width": 351,
+        },
+        "optionId": "Jeremiah-Smith-469560c9",
+      },
+      {
+        "bounds": {
+          "height": 153,
+          "left": 723,
+          "top": 757,
+          "width": 351,
+        },
+        "optionId": "Nicholas-Gilman-1791aed7",
+      },
+      {
+        "bounds": {
+          "height": 152,
+          "left": 1072,
+          "top": 757,
+          "width": 352,
+        },
+        "optionId": "Richard-Coote-b9095636",
+      },
+      {
+        "bounds": {
+          "height": 152,
+          "left": 1372,
+          "top": 757,
+          "width": 302,
+        },
+        "optionId": "write-in-0",
+      },
+    ],
+  },
+  {
+    "bounds": {
+      "height": 153,
+      "left": 373,
+      "top": 908,
+      "width": 1301,
+    },
+    "contestId": "Executive-Councilor-bb22557f",
+    "options": [
+      {
+        "bounds": {
+          "height": 152,
+          "left": 373,
+          "top": 909,
+          "width": 351,
+        },
+        "optionId": "Anne-Waldron-ee0cbc85",
+      },
+      {
+        "bounds": {
+          "height": 152,
+          "left": 723,
+          "top": 908,
+          "width": 351,
+        },
+        "optionId": "Daniel-Webster-13f77b2d",
+      },
+      {
+        "bounds": {
+          "height": 151,
+          "left": 1373,
+          "top": 908,
+          "width": 301,
+        },
+        "optionId": "write-in-0",
+      },
+    ],
+  },
+  {
+    "bounds": {
+      "height": 154,
+      "left": 373,
+      "top": 1058,
+      "width": 1301,
+    },
+    "contestId": "State-Senator-391381f8",
+    "options": [
+      {
+        "bounds": {
+          "height": 153,
+          "left": 373,
+          "top": 1059,
+          "width": 352,
+        },
+        "optionId": "James-Poole-db5ef4bd",
+      },
+      {
+        "bounds": {
+          "height": 152,
+          "left": 723,
+          "top": 1059,
+          "width": 351,
+        },
+        "optionId": "Matthew-Thornton-f66fec5e",
+      },
+      {
+        "bounds": {
+          "height": 152,
+          "left": 1373,
+          "top": 1058,
+          "width": 301,
+        },
+        "optionId": "write-in-0",
+      },
+    ],
+  },
+  {
+    "bounds": {
+      "height": 406,
+      "left": 374,
+      "top": 1209,
+      "width": 1301,
+    },
+    "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+    "options": [
+      {
+        "bounds": {
+          "height": 152,
+          "left": 374,
+          "top": 1261,
+          "width": 351,
+        },
+        "optionId": "Obadiah-Carrigan-5c95145a",
+      },
+      {
+        "bounds": {
+          "height": 153,
+          "left": 374,
+          "top": 1361,
+          "width": 351,
+        },
+        "optionId": "Mary-Baker-Eddy-350785d5",
+      },
+      {
+        "bounds": {
+          "height": 153,
+          "left": 374,
+          "top": 1462,
+          "width": 352,
+        },
+        "optionId": "Samuel-Bell-17973275",
+      },
+      {
+        "bounds": {
+          "height": 152,
+          "left": 724,
+          "top": 1210,
+          "width": 351,
+        },
+        "optionId": "Samuel-Livermore-f927fef1",
+      },
+      {
+        "bounds": {
+          "height": 153,
+          "left": 724,
+          "top": 1310,
+          "width": 351,
+        },
+        "optionId": "Elijah-Miller-a52e6988",
+      },
+      {
+        "bounds": {
+          "height": 153,
+          "left": 724,
+          "top": 1411,
+          "width": 351,
+        },
+        "optionId": "Isaac-Hill-d6c9deeb",
+      },
+      {
+        "bounds": {
+          "height": 152,
+          "left": 1073,
+          "top": 1260,
+          "width": 352,
+        },
+        "optionId": "Abigail-Bartlett-4e46c9d4",
+      },
+      {
+        "bounds": {
+          "height": 153,
+          "left": 1074,
+          "top": 1360,
+          "width": 351,
+        },
+        "optionId": "Jacob-Freese-b5146505",
+      },
+      {
+        "bounds": {
+          "height": 152,
+          "left": 1373,
+          "top": 1209,
+          "width": 302,
+        },
+        "optionId": "write-in-0",
+      },
+      {
+        "bounds": {
+          "height": 152,
+          "left": 1374,
+          "top": 1310,
+          "width": 301,
+        },
+        "optionId": "write-in-1",
+      },
+      {
+        "bounds": {
+          "height": 153,
+          "left": 1374,
+          "top": 1410,
+          "width": 301,
+        },
+        "optionId": "write-in-2",
+      },
+    ],
+  },
+  {
+    "bounds": {
+      "height": 153,
+      "left": 375,
+      "top": 1661,
+      "width": 1301,
+    },
+    "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
+    "options": [
+      {
+        "bounds": {
+          "height": 151,
+          "left": 375,
+          "top": 1663,
+          "width": 351,
+        },
+        "optionId": "Abeil-Foster-ded38e36",
+      },
+      {
+        "bounds": {
+          "height": 151,
+          "left": 725,
+          "top": 1662,
+          "width": 351,
+        },
+        "optionId": "Charles-H-Hersey-096286a4",
+      },
+      {
+        "bounds": {
+          "height": 151,
+          "left": 1074,
+          "top": 1661,
+          "width": 352,
+        },
+        "optionId": "William-Lovejoy-fde3c2df",
+      },
+      {
+        "bounds": {
+          "height": 151,
+          "left": 1374,
+          "top": 1661,
+          "width": 302,
+        },
+        "optionId": "write-in-0",
+      },
+    ],
+  },
+]
+`;
+
+exports[`interpret images from paths 2`] = `
 [
   {
     "bounds": {

--- a/libs/ballot-interpreter-nh-next/ts/src/debug.test.ts
+++ b/libs/ballot-interpreter-nh-next/ts/src/debug.test.ts
@@ -1,0 +1,131 @@
+import { electionGridLayoutNewHampshireAmherstFixtures } from '@votingworks/fixtures';
+// eslint-disable-next-line import/no-unresolved -- `./rust-addon` is a native module
+import { interpret as interpretImpl } from './rust-addon';
+import { interpret } from './interpret';
+
+jest.mock('./rust-addon');
+
+const interpretImplMock = interpretImpl as jest.MockedFunction<
+  typeof interpretImpl
+>;
+
+let frontImageData!: ImageData;
+let backImageData!: ImageData;
+
+beforeAll(async () => {
+  frontImageData =
+    await electionGridLayoutNewHampshireAmherstFixtures.scanMarkedFront.asImageData();
+  backImageData =
+    await electionGridLayoutNewHampshireAmherstFixtures.scanMarkedBack.asImageData();
+});
+
+test('no debug', () => {
+  interpretImplMock.mockReturnValue({
+    success: false,
+    value: '{}',
+  });
+
+  void interpret(
+    electionGridLayoutNewHampshireAmherstFixtures.electionDefinition,
+    ['a.jpeg', 'b.jpeg'],
+    { debug: false }
+  );
+
+  expect(interpretImplMock).toHaveBeenCalledWith(
+    electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+      .electionData,
+    'a.jpeg',
+    'b.jpeg',
+    undefined,
+    undefined
+  );
+});
+
+test('empty debug paths', () => {
+  interpretImplMock.mockReturnValue({
+    success: false,
+    value: '{}',
+  });
+
+  void interpret(
+    electionGridLayoutNewHampshireAmherstFixtures.electionDefinition,
+    [frontImageData, backImageData],
+    // @ts-expect-error -- intentionally passing invalid data
+    { debugBasePaths: [] }
+  );
+
+  expect(interpretImplMock).toHaveBeenCalledWith(
+    electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+      .electionData,
+    frontImageData,
+    backImageData,
+    undefined,
+    undefined
+  );
+});
+
+test('undefined debug paths', () => {
+  interpretImplMock.mockReturnValue({
+    success: false,
+    value: '{}',
+  });
+
+  void interpret(
+    electionGridLayoutNewHampshireAmherstFixtures.electionDefinition,
+    [frontImageData, backImageData],
+    { debugBasePaths: undefined }
+  );
+
+  expect(interpretImplMock).toHaveBeenCalledWith(
+    electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+      .electionData,
+    frontImageData,
+    backImageData,
+    undefined,
+    undefined
+  );
+});
+
+test('debug with image paths', () => {
+  interpretImplMock.mockReturnValue({
+    success: false,
+    value: '{}',
+  });
+
+  void interpret(
+    electionGridLayoutNewHampshireAmherstFixtures.electionDefinition,
+    ['a.jpeg', 'b.jpeg'],
+    { debug: true }
+  );
+
+  expect(interpretImplMock).toHaveBeenCalledWith(
+    electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+      .electionData,
+    'a.jpeg',
+    'b.jpeg',
+    'a.jpeg',
+    'b.jpeg'
+  );
+});
+
+test('debug with image data', () => {
+  interpretImplMock.mockReturnValue({
+    success: false,
+    value: '{}',
+  });
+
+  void interpret(
+    electionGridLayoutNewHampshireAmherstFixtures.electionDefinition,
+    [frontImageData, backImageData],
+    { debugBasePaths: ['a.jpeg', 'b.jpeg'] }
+  );
+
+  expect(interpretImplMock).toHaveBeenCalledWith(
+    electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+      .electionData,
+    frontImageData,
+    backImageData,
+    'a.jpeg',
+    'b.jpeg'
+  );
+});

--- a/libs/ballot-interpreter-nh-next/ts/src/interpret.test.ts
+++ b/libs/ballot-interpreter-nh-next/ts/src/interpret.test.ts
@@ -1,8 +1,7 @@
-import { assertDefined, err, ok, typedAs, unique } from '@votingworks/basics';
+import { assertDefined, ok, unique } from '@votingworks/basics';
 import { electionGridLayoutNewHampshireAmherstFixtures } from '@votingworks/fixtures';
 import { ElectionDefinition, SheetOf } from '@votingworks/types';
 import { interpret } from './interpret';
-import { InterpretError } from './types';
 
 test('interpret exists', () => {
   expect(interpret).toBeDefined();
@@ -14,28 +13,353 @@ test('interpret with bad election data', () => {
     electionData: 'not json',
   };
 
-  expect(interpret(electionDefinition, ['a', 'b'])).toEqual(
-    err({
-      type: 'unknown',
-      message: expect.stringContaining('Failed to parse election JSON'),
-    })
+  expect(() => interpret(electionDefinition, ['a', 'b'])).toThrowError(
+    'failed to parse election definition'
   );
 });
 
 test('interpret with bad ballot image paths', () => {
   const { electionDefinition } = electionGridLayoutNewHampshireAmherstFixtures;
 
-  expect(interpret(electionDefinition, ['a', 'b'])).toEqual(
-    err(
-      typedAs<InterpretError>({
-        type: 'imageOpenFailure',
-        path: expect.stringMatching(/a|b/),
-      })
-    )
+  expect(() => interpret(electionDefinition, ['a', 'b'])).toThrowError(
+    'failed to load ballot card images: a, b'
   );
 });
 
-test('interpret with valid data', async () => {
+test('interpret `ImageData` objects', async () => {
+  const { electionDefinition } = electionGridLayoutNewHampshireAmherstFixtures;
+  const ballotImages: SheetOf<ImageData> = [
+    await electionGridLayoutNewHampshireAmherstFixtures.scanMarkedFront.asImageData(),
+    await electionGridLayoutNewHampshireAmherstFixtures.scanMarkedBack.asImageData(),
+  ];
+
+  const result = interpret(electionDefinition, ballotImages);
+  expect(result).toEqual(ok(expect.anything()));
+
+  const { front, back } = result.unsafeUnwrap();
+
+  expect(front.normalizedImage).toBeDefined();
+  expect(back.normalizedImage).toBeDefined();
+  const frontImageData =
+    await electionGridLayoutNewHampshireAmherstFixtures.scanMarkedFront.asImageData();
+  const backImageData =
+    await electionGridLayoutNewHampshireAmherstFixtures.scanMarkedBack.asImageData();
+  // While we would usually expect a normalized image to differ from the
+  // original more significantly, in this case their dimensions are basically
+  // identical due to minimal cropping and no scaling, which makes for a basic test.
+  expect(front.normalizedImage.width).toEqual(frontImageData.width - 1);
+  expect(front.normalizedImage.height).toEqual(frontImageData.height);
+  expect(back.normalizedImage.width).toEqual(backImageData.width);
+  expect(back.normalizedImage.height).toEqual(backImageData.height);
+  expect(front.normalizedImage.data.length).toBeGreaterThan(0);
+  expect(back.normalizedImage.data.length).toBeGreaterThan(0);
+
+  const gridPositions = assertDefined(
+    electionDefinition.election.gridLayouts?.[0]?.gridPositions
+  );
+
+  // Layout should contain all the contests in order
+  expect(
+    [...front.contestLayouts, ...back.contestLayouts].map(
+      (layout) => layout.contestId
+    )
+  ).toEqual(unique(gridPositions.map((position) => position.contestId)));
+
+  // Each contest should contain all the options in order
+  for (const contestLayout of [
+    ...front.contestLayouts,
+    ...back.contestLayouts,
+  ]) {
+    expect(contestLayout.options.map((option) => option.optionId)).toEqual(
+      gridPositions
+        .filter((position) => position.contestId === contestLayout.contestId)
+        .map((position) =>
+          position.type === 'option'
+            ? position.optionId
+            : `write-in-${position.writeInIndex}`
+        )
+    );
+  }
+
+  expect(front.contestLayouts).toMatchSnapshot();
+  expect(back.contestLayouts).toMatchSnapshot();
+
+  expect(
+    [...front.marks, ...back.marks].map(([position, mark]) => ({
+      contestId: position.contestId,
+      optionId:
+        position.type === 'option'
+          ? position.optionId
+          : `write-in-${position.writeInIndex}`,
+      score: mark?.fillScore,
+    }))
+  ).toMatchInlineSnapshot(`
+    [
+      {
+        "contestId": "Governor-061a401b",
+        "optionId": "Josiah-Bartlett-1bb99985",
+        "score": 0.38557693,
+      },
+      {
+        "contestId": "United-States-Senator-d3f1c75b",
+        "optionId": "John-Langdon-5951c8e1",
+        "score": 0,
+      },
+      {
+        "contestId": "Representative-in-Congress-24683b44",
+        "optionId": "Jeremiah-Smith-469560c9",
+        "score": 0,
+      },
+      {
+        "contestId": "Executive-Councilor-bb22557f",
+        "optionId": "Anne-Waldron-ee0cbc85",
+        "score": 0,
+      },
+      {
+        "contestId": "State-Senator-391381f8",
+        "optionId": "James-Poole-db5ef4bd",
+        "score": 0.2875,
+      },
+      {
+        "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+        "optionId": "Obadiah-Carrigan-5c95145a",
+        "score": 0,
+      },
+      {
+        "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+        "optionId": "Mary-Baker-Eddy-350785d5",
+        "score": 0,
+      },
+      {
+        "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+        "optionId": "Samuel-Bell-17973275",
+        "score": 0.3201923,
+      },
+      {
+        "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
+        "optionId": "Abeil-Foster-ded38e36",
+        "score": 0,
+      },
+      {
+        "contestId": "Governor-061a401b",
+        "optionId": "Hannah-Dustin-ab4ef7c8",
+        "score": 0,
+      },
+      {
+        "contestId": "United-States-Senator-d3f1c75b",
+        "optionId": "William-Preston-3778fcd5",
+        "score": 0.37980768,
+      },
+      {
+        "contestId": "Representative-in-Congress-24683b44",
+        "optionId": "Nicholas-Gilman-1791aed7",
+        "score": 0,
+      },
+      {
+        "contestId": "Executive-Councilor-bb22557f",
+        "optionId": "Daniel-Webster-13f77b2d",
+        "score": 0,
+      },
+      {
+        "contestId": "State-Senator-391381f8",
+        "optionId": "Matthew-Thornton-f66fec5e",
+        "score": 0,
+      },
+      {
+        "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+        "optionId": "Samuel-Livermore-f927fef1",
+        "score": 0.3221154,
+      },
+      {
+        "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+        "optionId": "Elijah-Miller-a52e6988",
+        "score": 0,
+      },
+      {
+        "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+        "optionId": "Isaac-Hill-d6c9deeb",
+        "score": 0,
+      },
+      {
+        "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
+        "optionId": "Charles-H-Hersey-096286a4",
+        "score": 0.2778846,
+      },
+      {
+        "contestId": "Governor-061a401b",
+        "optionId": "John-Spencer-9ffb5970",
+        "score": 0,
+      },
+      {
+        "contestId": "Representative-in-Congress-24683b44",
+        "optionId": "Richard-Coote-b9095636",
+        "score": 0.32307693,
+      },
+      {
+        "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+        "optionId": "Abigail-Bartlett-4e46c9d4",
+        "score": 0,
+      },
+      {
+        "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+        "optionId": "Jacob-Freese-b5146505",
+        "score": 0.3326923,
+      },
+      {
+        "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
+        "optionId": "William-Lovejoy-fde3c2df",
+        "score": 0,
+      },
+      {
+        "contestId": "Governor-061a401b",
+        "optionId": "write-in-0",
+        "score": 0,
+      },
+      {
+        "contestId": "United-States-Senator-d3f1c75b",
+        "optionId": "write-in-0",
+        "score": 0,
+      },
+      {
+        "contestId": "Representative-in-Congress-24683b44",
+        "optionId": "write-in-0",
+        "score": 0,
+      },
+      {
+        "contestId": "Executive-Councilor-bb22557f",
+        "optionId": "write-in-0",
+        "score": 0.24903846,
+      },
+      {
+        "contestId": "State-Senator-391381f8",
+        "optionId": "write-in-0",
+        "score": 0,
+      },
+      {
+        "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+        "optionId": "write-in-0",
+        "score": 0,
+      },
+      {
+        "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+        "optionId": "write-in-1",
+        "score": 0,
+      },
+      {
+        "contestId": "State-Representatives-Hillsborough-District-34-b1012d38",
+        "optionId": "write-in-2",
+        "score": 0,
+      },
+      {
+        "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
+        "optionId": "write-in-0",
+        "score": 0,
+      },
+      {
+        "contestId": "Sheriff-4243fe0b",
+        "optionId": "Edward-Randolph-bf4c848a",
+        "score": 0.30192307,
+      },
+      {
+        "contestId": "County-Attorney-133f910f",
+        "optionId": "Ezra-Bartlett-8f95223c",
+        "score": 0,
+      },
+      {
+        "contestId": "County-Treasurer-87d25a31",
+        "optionId": "John-Smith-ef61a579",
+        "score": 0,
+      },
+      {
+        "contestId": "Register-of-Deeds-a1278df2",
+        "optionId": "John-Mann-b56bbdd3",
+        "score": 0.35192308,
+      },
+      {
+        "contestId": "Register-of-Probate-a4117da8",
+        "optionId": "Nathaniel-Parker-56a06c29",
+        "score": 0,
+      },
+      {
+        "contestId": "County-Commissioner-d6feed25",
+        "optionId": "Ichabod-Goodwin-55e8de1f",
+        "score": 0,
+      },
+      {
+        "contestId": "Sheriff-4243fe0b",
+        "optionId": "Edward-Randolph-bf4c848a",
+        "score": 0,
+      },
+      {
+        "contestId": "County-Attorney-133f910f",
+        "optionId": "Mary-Woolson-dc0b854a",
+        "score": 0.31923077,
+      },
+      {
+        "contestId": "County-Treasurer-87d25a31",
+        "optionId": "Jane-Jones-9caa141f",
+        "score": 0,
+      },
+      {
+        "contestId": "Register-of-Deeds-a1278df2",
+        "optionId": "Ellen-A-Stileman-14408737",
+        "score": 0,
+      },
+      {
+        "contestId": "Register-of-Probate-a4117da8",
+        "optionId": "Claire-Cutts-07a436e7",
+        "score": 0.2971154,
+      },
+      {
+        "contestId": "County-Commissioner-d6feed25",
+        "optionId": "Valbe-Cady-ba3af3af",
+        "score": 0,
+      },
+      {
+        "contestId": "Sheriff-4243fe0b",
+        "optionId": "write-in-0",
+        "score": 0,
+      },
+      {
+        "contestId": "County-Attorney-133f910f",
+        "optionId": "write-in-0",
+        "score": 0,
+      },
+      {
+        "contestId": "County-Treasurer-87d25a31",
+        "optionId": "write-in-0",
+        "score": 0.37115383,
+      },
+      {
+        "contestId": "Register-of-Deeds-a1278df2",
+        "optionId": "write-in-0",
+        "score": 0,
+      },
+      {
+        "contestId": "Register-of-Probate-a4117da8",
+        "optionId": "write-in-0",
+        "score": 0,
+      },
+      {
+        "contestId": "County-Commissioner-d6feed25",
+        "optionId": "write-in-0",
+        "score": 0.30865383,
+      },
+      {
+        "contestId": "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc",
+        "optionId": "yes",
+        "score": 0.32596153,
+      },
+      {
+        "contestId": "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc",
+        "optionId": "no",
+        "score": 0,
+      },
+    ]
+  `);
+});
+
+test('interpret images from paths', async () => {
   const { electionDefinition } = electionGridLayoutNewHampshireAmherstFixtures;
   const ballotImagePaths: SheetOf<string> = [
     electionGridLayoutNewHampshireAmherstFixtures.scanMarkedFront.asFilePath(),

--- a/libs/ballot-interpreter-nh-next/ts/src/rust-addon.d.ts
+++ b/libs/ballot-interpreter-nh-next/ts/src/rust-addon.d.ts
@@ -20,7 +20,8 @@ export type BridgeInterpretResult =
  */
 export function interpret(
   electionJson: string,
-  ballotImagePath1: string,
-  ballotImagePath2: string,
-  debug: boolean
+  ballotImageSourceSideA: string | ImageData,
+  ballotImageSourceSideB: string | ImageData,
+  debugBasePathSideA?: string,
+  debugBasePathSideB?: string
 ): BridgeInterpretResult;


### PR DESCRIPTION
## Overview

Previously we required passing paths to image files to load. Now we can pass `ImageData` objects directly. This has the potential to be faster, though in my basic testing it was only faster some of the time. I'm hoping that eliminating the encode+write of the images does make a difference, though.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
