### PR TITLE
[libs/ui] Add a theme management API context to AppBase

### DIFF
--- a/apps/admin/frontend/src/app.tsx
+++ b/apps/admin/frontend/src/app.tsx
@@ -29,7 +29,7 @@ export function App({
   return (
     <BrowserRouter>
       <AppBase
-        colorMode={colorMode}
+        defaultColorMode={colorMode}
         legacyBaseFontSizePx={baseFontSizePx}
         legacyPrintFontSizePx={printFontSizePx}
       >

--- a/apps/central-scan/frontend/src/app.tsx
+++ b/apps/central-scan/frontend/src/app.tsx
@@ -46,7 +46,7 @@ export function App({
         <ApiClientContext.Provider value={apiClient}>
           <QueryClientProvider client={queryClient}>
             <AppBase
-              colorMode={colorMode}
+              defaultColorMode={colorMode}
               legacyBaseFontSizePx={baseFontSizePx}
             >
               <AppRoot hardware={hardware} logger={logger} />

--- a/apps/mark/frontend/src/app.tsx
+++ b/apps/mark/frontend/src/app.tsx
@@ -145,7 +145,7 @@ export function App({
           <ApiClientContext.Provider value={apiClient}>
             <QueryClientProvider client={queryClient}>
               <AppBase
-                colorMode={colorMode}
+                defaultColorMode={colorMode}
                 isTouchscreen
                 legacyBaseFontSizePx={baseFontSizePx}
               >

--- a/apps/scan/frontend/src/scan_app_base.tsx
+++ b/apps/scan/frontend/src/scan_app_base.tsx
@@ -18,10 +18,10 @@ const DEFAULT_SIZE_MODE: SizeMode = 'm';
 export function ScanAppBase({ children }: AppBaseProps): JSX.Element {
   return (
     <AppBase
-      colorMode={DEFAULT_COLOR_MODE}
+      defaultColorMode={DEFAULT_COLOR_MODE}
+      defaultSizeMode={DEFAULT_SIZE_MODE}
       isTouchscreen
       screenType={DEFAULT_SCREEN_TYPE}
-      sizeMode={DEFAULT_SIZE_MODE}
     >
       {children}
     </AppBase>

--- a/libs/ui/.storybook/preview.tsx
+++ b/libs/ui/.storybook/preview.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
-import { DecoratorFunction, GlobalTypes, InputType, Parameters } from '@storybook/types';
+import {
+  DecoratorFunction,
+  GlobalTypes,
+  Parameters,
+  StoryContext,
+} from '@storybook/types';
 
-import { AppBase } from '../src';
+import { AppBase, ThemeManagerContext } from '../src';
 import { ColorMode, SizeMode } from '@votingworks/types';
 
 // TODO: Find the storybook.js type declaration for this. Doesn't seem to be in
@@ -79,6 +84,31 @@ export const parameters: Parameters = {
   },
 };
 
+/**
+ * Pass-through wrapper for stories that updates the UI theme when the defaults
+ * are changed via the storybook toolbar.
+ */
+function StoryWrapper(props: {
+  children: React.ReactNode;
+  context: StoryContext;
+}): JSX.Element {
+  const { children, context } = props;
+
+  const { setColorMode, setSizeMode } = React.useContext(
+    ThemeManagerContext
+  );
+
+  React.useEffect(() => {
+    setColorMode(context.globals.colorMode);
+  }, [context.globals.colorMode]);
+
+  React.useEffect(() => {
+    setSizeMode(context.globals.sizeMode);
+  }, [context.globals.sizeMode]);
+
+  return <React.Fragment>{children}</React.Fragment>;
+}
+
 // Decorators allow us to wrap stories in custom components, provide context
 // data, or modify the existing story context, if needed, to enable proper
 // rendering, or to add any desired visual scaffolding.
@@ -89,13 +119,14 @@ export const decorators: DecoratorFunction[] = [
   ) => {
     return (
       <AppBase
-        colorMode={context.globals.colorMode}
+        defaultColorMode={context.globals.colorMode}
+        defaultSizeMode={context.globals.sizeMode}
         enableScroll
-        sizeMode={context.globals.sizeMode}
       >
-        <Story />
+        <StoryWrapper context={context}>
+          <Story />
+        </StoryWrapper>
       </AppBase>
     );
   },
 ];
-

--- a/libs/ui/src/app_base.tsx
+++ b/libs/ui/src/app_base.tsx
@@ -1,10 +1,11 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { ThemeProvider } from 'styled-components';
 
 import { ColorMode, ScreenType, SizeMode, UiTheme } from '@votingworks/types';
 
 import { GlobalStyles } from './global_styles';
 import { makeTheme } from './themes/make_theme';
+import { ThemeManagerContext } from './theme_manager_context';
 
 declare module 'styled-components' {
   /**
@@ -23,13 +24,13 @@ declare module 'styled-components' {
  */
 export interface AppBaseProps {
   children: React.ReactNode;
-  colorMode?: ColorMode;
+  defaultColorMode?: ColorMode;
+  defaultSizeMode?: SizeMode;
   enableScroll?: boolean;
   isTouchscreen?: boolean;
   legacyBaseFontSizePx?: number;
   legacyPrintFontSizePx?: number;
   screenType?: ScreenType;
-  sizeMode?: SizeMode;
 }
 
 /**
@@ -38,14 +39,22 @@ export interface AppBaseProps {
 export function AppBase(props: AppBaseProps): JSX.Element {
   const {
     children,
-    colorMode = 'legacy',
+    defaultColorMode = 'legacy',
+    defaultSizeMode = 'legacy',
     enableScroll = false,
     isTouchscreen = false,
     legacyBaseFontSizePx,
     legacyPrintFontSizePx,
     screenType = 'builtIn',
-    sizeMode = 'legacy',
   } = props;
+
+  const [colorMode, setColorMode] = React.useState<ColorMode>(defaultColorMode);
+  const [sizeMode, setSizeMode] = React.useState<SizeMode>(defaultSizeMode);
+
+  const resetThemes = useCallback(() => {
+    setColorMode(defaultColorMode);
+    setSizeMode(defaultSizeMode);
+  }, [defaultColorMode, defaultSizeMode]);
 
   const theme = useMemo(
     () => makeTheme({ colorMode, screenType, sizeMode }),
@@ -53,14 +62,22 @@ export function AppBase(props: AppBaseProps): JSX.Element {
   );
 
   return (
-    <ThemeProvider theme={theme}>
-      <GlobalStyles
-        enableScroll={enableScroll}
-        isTouchscreen={isTouchscreen}
-        legacyBaseFontSizePx={legacyBaseFontSizePx}
-        legacyPrintFontSizePx={legacyPrintFontSizePx}
-      />
-      {children}
-    </ThemeProvider>
+    <ThemeManagerContext.Provider
+      value={{
+        resetThemes,
+        setColorMode,
+        setSizeMode,
+      }}
+    >
+      <ThemeProvider theme={theme}>
+        <GlobalStyles
+          enableScroll={enableScroll}
+          isTouchscreen={isTouchscreen}
+          legacyBaseFontSizePx={legacyBaseFontSizePx}
+          legacyPrintFontSizePx={legacyPrintFontSizePx}
+        />
+        {children}
+      </ThemeProvider>
+    </ThemeManagerContext.Provider>
   );
 }

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -63,6 +63,7 @@ export * from './tally_report_metadata';
 export * from './tally_report_summary';
 export * from './test_mode';
 export * from './text';
+export * from './theme_manager_context';
 export * from './themes';
 export * from './timer';
 export * from './typography';

--- a/libs/ui/src/theme_manager_context.tsx
+++ b/libs/ui/src/theme_manager_context.tsx
@@ -1,0 +1,24 @@
+// istanbul ignore file: tested via AppBase
+import React from 'react';
+
+import { ColorMode, SizeMode } from '@votingworks/types';
+
+/** Provides an API for managing themes. */
+export interface ThemeManagerContextInterface {
+  /** Restores themes to their initial default state. */
+  resetThemes: () => void;
+
+  /** Switches over to the specified color theme. */
+  setColorMode: (mode: ColorMode) => void;
+
+  /** Switches over to the specified size theme. */
+  setSizeMode: (mode: SizeMode) => void;
+}
+
+/** Context instance for {@link ThemeManagerContextInterface}. */
+export const ThemeManagerContext =
+  React.createContext<ThemeManagerContextInterface>({
+    resetThemes: () => undefined,
+    setColorMode: () => undefined,
+    setSizeMode: () => undefined,
+  });

--- a/libs/ui/src/themes/render_with_themes.tsx
+++ b/libs/ui/src/themes/render_with_themes.tsx
@@ -50,8 +50,8 @@ export function renderWithThemes(
   function wrapper(props: { children: React.ReactNode }): JSX.Element {
     return (
       <AppBase
-        colorMode={vxTheme.colorMode}
-        sizeMode={vxTheme.sizeMode}
+        defaultColorMode={vxTheme.colorMode}
+        defaultSizeMode={vxTheme.sizeMode}
         {...props}
       />
     );

--- a/libs/ui/src/typography.test.tsx
+++ b/libs/ui/src/typography.test.tsx
@@ -12,7 +12,7 @@ for (const Component of [Caption, Font, P, Pre]) {
       sizeMode: 'm',
     });
     render(
-      <AppBase colorMode="contrastHighDark" sizeMode="m">
+      <AppBase defaultColorMode="contrastHighDark" defaultSizeMode="m">
         <Component>regular text</Component>
         <Component weight="bold">bold text</Component>
         <Component italic weight="light">
@@ -55,7 +55,7 @@ for (const Heading of [H1, H2, H3, H4, H5, H6]) {
       sizeMode: 'xl',
     });
     render(
-      <AppBase colorMode="contrastHighLight" sizeMode="xl">
+      <AppBase defaultColorMode="contrastHighLight" defaultSizeMode="xl">
         <Heading>regular heading</Heading>
         <Heading as="h1">heading with modified semantics</Heading>
         <Heading italic>italic heading</Heading>
@@ -114,7 +114,7 @@ for (const Component of [Caption, Font, P, Pre, H1, H2, H3, H4, H5, H6]) {
       sizeMode: 'l',
     });
     render(
-      <AppBase colorMode="contrastMedium" sizeMode="l">
+      <AppBase defaultColorMode="contrastMedium" defaultSizeMode="l">
         <Component color="danger">danger color text</Component>
         <Component color="default">default color text</Component>
         <Component color="success">success color text</Component>


### PR DESCRIPTION
## Overview

Adding a theme management API (`setColorMode`, `setSizeMode`, `resetThemes`) which will initially be used by the voter-facing display settings component.

- Updating  the `colorMode`, `sizeMode` props on `AppBase` to a more appropriately named `default*Mode` - these will now represent the initial/default state of the UI that we return to when `resetThemes` is used.
- Also updating the storybook bootstrap code to use the theme manager API when switching between modes.

## Testing Plan
- Added test case for the `AppBase` implementation of the `ThemeManagerContext`

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
