### PR TITLE
[libs/ui] Add RadioGroup component

### DIFF
--- a/libs/ui/.storybook/main.ts
+++ b/libs/ui/.storybook/main.ts
@@ -5,7 +5,7 @@ import { StorybookConfig } from '@storybook/react-vite';
 import { getWorkspacePackageInfo } from '../../../script/src/validate-monorepo/pnpm';
 
 const config: StorybookConfig = {
-  stories: ['../src/*.stories.@(ts|tsx)'],
+  stories: ['../src/**/*.stories.@(ts|tsx)'],
   addons: [
     '@storybook/addon-links',
     '@storybook/addon-essentials',

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -18,6 +18,7 @@ import {
   faXmark,
   faMagnifyingGlassPlus,
   faMagnifyingGlassMinus,
+  faBan,
 } from '@fortawesome/free-solid-svg-icons';
 import {
   faXmarkCircle,
@@ -81,6 +82,10 @@ export const Icons = {
 
   Delete(): JSX.Element {
     return <FaIcon type={faTrashCan} />;
+  },
+
+  Disabled(): JSX.Element {
+    return <FaIcon type={faBan} />;
   },
 
   Done(): JSX.Element {

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -45,6 +45,7 @@ export * from './progress_bar';
 export * from './progress_ellipsis';
 export * from './prose';
 export * from './qrcode';
+export * from './radio_group';
 export * from './react_query';
 export * from './reboot_from_usb_button';
 export * from './reboot_to_bios_button';

--- a/libs/ui/src/radio_group/index.tsx
+++ b/libs/ui/src/radio_group/index.tsx
@@ -1,0 +1,71 @@
+/* stylelint-disable order/properties-order */
+import React from 'react';
+import styled from 'styled-components';
+
+import { Caption } from '../typography';
+import { RadioButton } from './radio_button';
+import { RadioGroupOption, RadioGroupOptionId } from './types';
+
+// eslint-disable-next-line vx/gts-no-import-export-type
+export type { RadioGroupOption, RadioGroupOptionId };
+
+/** Props for {@link RadioGroup}. */
+export interface RadioGroupProps<T extends RadioGroupOptionId> {
+  hideLabel?: boolean;
+  /**
+   * Required for a11y - use {@link hideLabel} to visually hide the label, while
+   * still allowing it to be assigned to the control for screen readers.
+   */
+  label: string;
+  onChange: (newId: T) => void;
+  options: ReadonlyArray<RadioGroupOption<T>>;
+  selectedOptionId?: T;
+}
+
+const OuterContainer = styled.fieldset.attrs({ role: 'radiogroup' })`
+  display: inline-block;
+`;
+
+const LabelContainer = styled.legend`
+  display: block;
+  margin-bottom: 0.5rem;
+`;
+
+const OptionsContainer = styled.span`
+  border-radius: 0.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 0.35rem;
+`;
+
+/**
+ * Renders a theme-compatible and touch-friendly radio button input group with
+ * browser-native semantic elements.
+ */
+export function RadioGroup<T extends RadioGroupOptionId>(
+  props: RadioGroupProps<T>
+): JSX.Element {
+  const { hideLabel, label, onChange, options, selectedOptionId } = props;
+
+  return (
+    <OuterContainer aria-label={label}>
+      {!hideLabel && (
+        <LabelContainer aria-hidden>
+          <Caption weight="semiBold">{label}</Caption>
+        </LabelContainer>
+      )}
+      <OptionsContainer>
+        {options.map((o) => (
+          <RadioButton
+            {...o}
+            groupLabel={label}
+            key={o.id}
+            onSelect={onChange}
+            selected={o.id === selectedOptionId}
+          />
+        ))}
+      </OptionsContainer>
+    </OuterContainer>
+  );
+}

--- a/libs/ui/src/radio_group/radio.tsx
+++ b/libs/ui/src/radio_group/radio.tsx
@@ -1,0 +1,85 @@
+/* stylelint-disable order/properties-order, value-keyword-case */
+import React, { useCallback } from 'react';
+import styled, { css } from 'styled-components';
+
+import { OptionProps, RadioGroupOptionId } from './types';
+import { Icons } from '../icons';
+
+const RADIO_SIZE_REM = 0.9;
+
+interface ContainerProps {
+  disabled: boolean;
+  selected: boolean;
+}
+
+const disabledContainerStyles = css`
+  border: none; /* We replace the radio with a not-allowed icon when disabled. */
+`;
+
+const Container = styled.span<ContainerProps>`
+  align-items: center;
+  border-radius: 50%;
+  border: ${(p) => p.theme.sizes.bordersRem.medium}rem solid currentColor;
+  display: flex;
+  flex-shrink: 0;
+  font-size: ${RADIO_SIZE_REM}rem;
+  height: ${RADIO_SIZE_REM}rem;
+  justify-content: center;
+  position: relative;
+  transition: border 100ms ease-in;
+  width: ${RADIO_SIZE_REM}rem;
+
+  ${(p) => p.disabled && disabledContainerStyles}
+`;
+
+interface MarkProps {
+  selected: boolean;
+}
+
+const SelectedRadioMark = styled.span<MarkProps>`
+  background: currentColor;
+  border-radius: 50%;
+  display: block;
+  flex-shrink: 0;
+  height: 60%;
+  opacity: ${(p) => (p.selected ? 1 : 0)};
+  transition: opacity 100ms ease-in;
+  width: 60%;
+`;
+
+// Rendered as a transparent overlay above the custom radio to retain browser
+// native radio button interaction.
+const RadioInput = styled.input.attrs({ type: 'radio' })`
+  cursor: ${(p) => (p.disabled ? 'not-allowed' : 'pointer')};
+  height: 100%;
+  left: 0;
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+`;
+
+/** Custom-styled radio input, used in the RadioGroup component. */
+export function Radio<T extends RadioGroupOptionId>(
+  props: OptionProps<T>
+): JSX.Element {
+  const { disabled, groupLabel, id, onSelect, selected } = props;
+
+  const boundOnSelect = useCallback(() => onSelect(id), [id, onSelect]);
+
+  return (
+    <Container disabled={!!disabled} selected={selected}>
+      {disabled ? (
+        <Icons.Disabled />
+      ) : (
+        <SelectedRadioMark selected={selected} />
+      )}
+      <RadioInput
+        checked={selected}
+        disabled={disabled}
+        name={groupLabel}
+        onChange={boundOnSelect}
+      />
+    </Container>
+  );
+}

--- a/libs/ui/src/radio_group/radio_button.tsx
+++ b/libs/ui/src/radio_group/radio_button.tsx
@@ -1,0 +1,48 @@
+/* stylelint-disable order/properties-order, value-keyword-case */
+import React from 'react';
+import styled from 'styled-components';
+
+import { ButtonProps, buttonStyles } from '../button';
+import { Radio } from './radio';
+import { OptionProps, RadioGroupOptionId } from './types';
+
+type OptionContainerProps = Pick<ButtonProps, 'disabled' | 'variant'>;
+
+const Container = styled.label<OptionContainerProps>`
+  ${buttonStyles}
+
+  align-items: center;
+  border-radius: 0.125rem;
+  border-width: ${(p) => p.theme.sizes.bordersRem.hairline}rem;
+  display: flex;
+  justify-content: start;
+  min-height: 2.5rem;
+  text-align: left;
+
+  &[disabled] {
+    border-width: ${(p) => p.theme.sizes.bordersRem.hairline}rem;
+  }
+`;
+
+const Label = styled.span`
+  display: block;
+  flex-grow: 1;
+  font-weight: ${(p) => p.theme.sizes.fontWeight.regular};
+`;
+
+export function RadioButton<T extends RadioGroupOptionId>(
+  props: OptionProps<T>
+): JSX.Element {
+  const { ariaLabel, disabled, label, selected } = props;
+
+  return (
+    <Container
+      aria-label={ariaLabel}
+      disabled={disabled}
+      variant={selected ? 'primary' : 'regular'}
+    >
+      <Radio {...props} />
+      <Label>{label}</Label>
+    </Container>
+  );
+}

--- a/libs/ui/src/radio_group/radio_button.tsx
+++ b/libs/ui/src/radio_group/radio_button.tsx
@@ -15,6 +15,7 @@ const Container = styled.label<OptionContainerProps>`
   border-radius: 0.125rem;
   border-width: ${(p) => p.theme.sizes.bordersRem.hairline}rem;
   display: flex;
+  flex-wrap: nowrap;
   justify-content: start;
   min-height: 2.5rem;
   text-align: left;

--- a/libs/ui/src/radio_group/radio_group.stories.tsx
+++ b/libs/ui/src/radio_group/radio_group.stories.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import { RadioGroup as Component, RadioGroupProps } from '.';
+
+const initialArgs: Partial<RadioGroupProps<string>> = {
+  label: 'Favourite Thing:',
+  options: [
+    { id: 'raindrops', label: 'Raindrops on roses' },
+    { id: 'whiskers', label: 'Whiskers on kittens' },
+    { id: 'kettles', label: 'Bright copper kettles' },
+    { id: 'mittens', label: 'Warm woolen mittens', disabled: true },
+    { id: 'packages', label: 'Brown paper packages tied up with strings' },
+  ],
+};
+
+const meta: Meta<typeof Component> = {
+  title: 'libs-ui/RadioGroup',
+  component: Component,
+  args: initialArgs,
+};
+
+export default meta;
+
+export function RadioGroup(props: RadioGroupProps<string>): JSX.Element {
+  const { onChange } = props;
+  const [selectedOptionId, setSelectedOptionId] = React.useState<string>('');
+
+  function handleChange(id: string) {
+    setSelectedOptionId(id);
+    onChange(id);
+  }
+
+  return (
+    <Component
+      {...props}
+      onChange={handleChange}
+      selectedOptionId={selectedOptionId}
+    />
+  );
+}

--- a/libs/ui/src/radio_group/radio_group.test.tsx
+++ b/libs/ui/src/radio_group/radio_group.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+
+import userEvent from '@testing-library/user-event';
+import { render, screen, within } from '../../test/react_testing_library';
+import { RadioGroup } from '.';
+
+test('renders all provided options', () => {
+  const onChange = jest.fn();
+
+  render(
+    <RadioGroup
+      label="Pick a card:"
+      onChange={onChange}
+      options={[
+        { id: 'hearts-4', label: 'Four of Hearts' },
+        { id: 'clubs-6', label: 'Six of Clubs' },
+        { id: 'diamonds-jack', label: 'Jack of Diamonds' },
+        { id: 'spades-2', label: 'Two of Spades' },
+      ]}
+      selectedOptionId="diamonds-jack"
+    />
+  );
+
+  screen.getByText('Pick a card:');
+
+  const groupElement = screen.getByRole('radiogroup', { name: 'Pick a card:' });
+
+  const withinGroup = within(groupElement);
+  withinGroup.getByRole('radio', { name: 'Four of Hearts', checked: false });
+  withinGroup.getByRole('radio', { name: 'Six of Clubs', checked: false });
+  withinGroup.getByRole('radio', { name: 'Jack of Diamonds', checked: true });
+  withinGroup.getByRole('radio', { name: 'Two of Spades', checked: false });
+
+  userEvent.click(withinGroup.getByRole('radio', { name: 'Four of Hearts' }));
+  expect(onChange).toBeCalledWith('hearts-4');
+});
+
+test('a11y for disabled options', () => {
+  const onChange = jest.fn();
+
+  render(
+    <RadioGroup
+      label="Pick a card:"
+      onChange={onChange}
+      options={[
+        { id: 'hearts-4', label: 'Four of Hearts' },
+        { id: 'clubs-6', label: 'Six of Clubs', disabled: true },
+      ]}
+      selectedOptionId="hearts-4"
+    />
+  );
+
+  const disabledOption = screen.getByRole('radio', { name: 'Six of Clubs' });
+  userEvent.click(disabledOption);
+
+  expect(onChange).not.toHaveBeenCalled();
+});
+
+test('label is not visible if `hideLabel == true`', () => {
+  const onChange = jest.fn();
+
+  render(
+    <RadioGroup
+      hideLabel
+      label="Pick a card:"
+      onChange={onChange}
+      options={[
+        { id: 'hearts-4', label: 'Four of Hearts' },
+        { id: 'clubs-6', label: 'Six of Clubs' },
+      ]}
+      selectedOptionId="hearts-4"
+    />
+  );
+
+  expect(screen.queryByText('Pick a card:')).not.toBeInTheDocument();
+
+  // Verify the radiogroup role is still labelled appropriately.
+  screen.getByRole('radiogroup', { name: 'Pick a card:' });
+});

--- a/libs/ui/src/radio_group/types.ts
+++ b/libs/ui/src/radio_group/types.ts
@@ -1,0 +1,17 @@
+/** Option ID type for the RadioGroup component. */
+export type RadioGroupOptionId = string | number;
+
+/** Data schema for a single option in the RadioGroup component. */
+export interface RadioGroupOption<T extends RadioGroupOptionId> {
+  ariaLabel?: string;
+  disabled?: boolean;
+  id: T;
+  label: React.ReactNode;
+}
+
+/** Common props for subcomponents of a single RadioGroup option. */
+export type OptionProps<T extends RadioGroupOptionId> = RadioGroupOption<T> & {
+  groupLabel: string;
+  onSelect: (id: T) => void;
+  selected: boolean;
+};


### PR DESCRIPTION
## Overview

Adding a `RadioGroup` component that uses native `<fieldset>` and `<input type="radio">` semantic elements, styled with our VVSG themes.

Initial usage will be in the voter-facing display settings screen in upcoming PRs.

- Broken out into subcomponent files within the `src/radio_group` folder:
  - `index.tsx`: Glue component and outer container styling
  - `radio_button.tsx`: Single radio option component with state-specific styling for option container and label
  - `radio.tsx`: Wrapper around browser-native radio input with event handling and VxSuite-specific styling.

## Demo Video or Screenshot

https://user-images.githubusercontent.com/264902/233213540-7f8d68cc-205b-4304-ae75-97d476a87083.mov

## Testing Plan
- New unit tests for RadioGroup - functionality and a11y
- Visual testing via storybook

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
