### PR TITLE
Bump wait time to hopefully decrease flakiness

### DIFF
--- a/apps/scan/backend/test/helpers/shared_helpers.ts
+++ b/apps/scan/backend/test/helpers/shared_helpers.ts
@@ -51,7 +51,7 @@ export async function waitForStatus(
 ): Promise<void> {
   await waitForExpect(async () => {
     await expectStatus(apiClient, status);
-  }, 1_000);
+  }, 2_000);
 }
 
 const electionFamousNames2021WithoutTemplatesBallotPackageBuffer =


### PR DESCRIPTION
This PR bumps a wait time to hopefully decrease flakiness we've been seeing with VxScan backend tests. My rudimentary testing (i.e. retrying in CircleCI a few times) suggests that this will help!