### PR TITLE
[libs/ui] Add ThemeLabel subcomponent of the DisplaySettings screen

### DIFF
--- a/libs/ui/jest.config.js
+++ b/libs/ui/jest.config.js
@@ -11,6 +11,8 @@ module.exports = {
     '.*\\.stories\\.ts',
     '.*\\.stories\\.tsx',
     // Purely presentational components:
+    'src/display_settings/theme_label.tsx',
+    'src/display_settings/theme_preview.tsx',
     'src/insert_ballot_image.tsx',
     'src/insert_card_image.tsx',
     'src/loading_animation.tsx',

--- a/libs/ui/src/display_settings/theme_label.tsx
+++ b/libs/ui/src/display_settings/theme_label.tsx
@@ -1,0 +1,41 @@
+/* stylelint-disable order/properties-order */
+import React from 'react';
+import styled from 'styled-components';
+import { ColorMode, SizeMode } from '@votingworks/types';
+
+import { ThemePreview } from './theme_preview';
+import { Font } from '../typography';
+
+/** Props for {@link ThemeLabel}. */
+export interface ThemeLabelProps {
+  children: React.ReactNode;
+  colorMode?: ColorMode;
+  sizeMode?: SizeMode;
+}
+
+const Container = styled.span`
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+`;
+
+const LabelText = styled(Font)`
+  display: block;
+  flex-grow: 1;
+`;
+
+/**
+ * Renders the given label text alongside a small preview window for the given
+ * theme parameters, which default to the currently active theme parameters, if
+ * unspecified.
+ */
+export function ThemeLabel(props: ThemeLabelProps): JSX.Element {
+  const { children, colorMode, sizeMode } = props;
+
+  return (
+    <Container>
+      <ThemePreview colorMode={colorMode} sizeMode={sizeMode} />
+      <LabelText weight="semiBold">{children}</LabelText>
+    </Container>
+  );
+}

--- a/libs/ui/src/display_settings/theme_preview.tsx
+++ b/libs/ui/src/display_settings/theme_preview.tsx
@@ -1,0 +1,59 @@
+/* stylelint-disable order/properties-order */
+import React from 'react';
+import styled, { ThemeProvider } from 'styled-components';
+
+import { ColorMode, SizeMode } from '@votingworks/types';
+
+import { makeTheme } from '../themes/make_theme';
+
+/** Props for {@link ThemePreview}. */
+export interface ThemePreviewProps {
+  colorMode?: ColorMode;
+  sizeMode?: SizeMode;
+}
+
+const PREVIEW_CONTAINER_STATIC_SIZE_PX = 140;
+const PREVIEW_CONTAINER_STATIC_BORDER_RADIUS_PX = 10;
+const PREVIEW_CONTAINER_STATIC_BORDER_WIDTH_PX =
+  PREVIEW_CONTAINER_STATIC_BORDER_RADIUS_PX / 3;
+
+const Container = styled.span`
+  align-items: center;
+  background: ${(p) => p.theme.colors.background};
+  border-radius: ${PREVIEW_CONTAINER_STATIC_BORDER_RADIUS_PX}px;
+  border: ${PREVIEW_CONTAINER_STATIC_BORDER_WIDTH_PX}px solid
+    ${(p) => p.theme.colors.foreground};
+  color: ${(p) => p.theme.colors.foreground};
+  display: flex;
+  flex-shrink: 0;
+  font-size: ${(p) => p.theme.sizes.fontDefault}px;
+  font-weight: ${(p) => p.theme.sizes.fontWeight.bold};
+  height: ${PREVIEW_CONTAINER_STATIC_SIZE_PX}px;
+  justify-content: center;
+  line-height: ${(p) => p.theme.sizes.lineHeight};
+  width: ${PREVIEW_CONTAINER_STATIC_SIZE_PX}px;
+`;
+
+/**
+ * Renders a small preview window for the given theme parameters, which default
+ * to the currently active theme parameters, if unspecified.
+ */
+export function ThemePreview(props: ThemePreviewProps): JSX.Element {
+  const { colorMode, sizeMode } = props;
+
+  return (
+    <ThemeProvider
+      theme={(theme) =>
+        makeTheme({
+          colorMode: colorMode || theme.colorMode,
+          screenType: theme.screenType,
+          sizeMode: sizeMode || theme.sizeMode,
+        })
+      }
+    >
+      <Container aria-hidden role="img">
+        Aa
+      </Container>
+    </ThemeProvider>
+  );
+}


### PR DESCRIPTION
## Overview

Adding the `ThemeLabel` subcomponent for the upcoming display settings screen.

Renders a theme preview window along with a text label to give the user a sense of what that option looks like.

The preview window is set at a fixed pixel size to keep the color and size settings tabs similar and reduce UI jumpiness when switching between themes. 

## Demo Video or Screenshot
### ThemeLabel highlighted in context:
<img width="300" src="https://user-images.githubusercontent.com/264902/233483370-7d53e2b7-0559-43bf-9873-a59b09cd2b6b.png"> <img width="300" src="https://user-images.githubusercontent.com/264902/233483657-fe7e8635-aa63-403f-83d0-a0fb450445bd.png">

## Testing Plan
- Purely presentational - relying on visual testing for these pieces, but will be adding unit tests for the eventual DisplaySettings component

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
