### PR TITLE
feat(grout): add `Buffer` support

### DIFF
--- a/libs/grout/src/serialization.test.ts
+++ b/libs/grout/src/serialization.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { Buffer } from 'buffer';
 import { err, ok } from '@votingworks/basics';
 import { deserialize, serialize } from './serialization';
 
@@ -48,6 +49,10 @@ test('JSON serialization/deserialization', () => {
   expectToBePreservedExactly(new Date('2020-01-01T00:00:00.000Z'));
   expectToBePreservedExactly(new Date());
   expectToBePreservedExactly({ a: new Date() });
+  // Buffer
+  expectToBePreservedExactly(Buffer.from('some string'));
+  expectToBePreservedExactly({ a: Buffer.from('some string') });
+  expectToBePreservedExactly(Buffer.of(1, 2, 3));
   // Error
   expectToBePreservedExactly(new Error('some error'));
   // Result

--- a/libs/grout/src/serialization.ts
+++ b/libs/grout/src/serialization.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import { err, isResult, ok, Result } from '@votingworks/basics';
 import {
   isArray,
@@ -98,12 +99,20 @@ const resultTagger: Tagger<
   },
 };
 
+const bufferTagger: Tagger<Buffer, string> = {
+  tag: 'Buffer',
+  shouldTag: (value): value is Buffer => Buffer.isBuffer(value),
+  serialize: (value) => value.toString('base64'),
+  deserialize: (value) => Buffer.from(value, 'base64'),
+};
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const taggers: Array<Tagger<any, any>> = [
   undefinedTagger,
   dateTagger,
   errorTagger,
   resultTagger,
+  bufferTagger,
 ];
 
 function tagValueIfNeeded(value: unknown): TaggedValue | unknown {
@@ -131,6 +140,9 @@ function unserializableError(value: unknown) {
 }
 
 function throwIfUnserializable(value: unknown): void {
+  if (taggers.some((tagger) => tagger.shouldTag(value))) {
+    return;
+  }
   if (
     isObject(value) &&
     !(value instanceof Date) &&
@@ -142,9 +154,6 @@ function throwIfUnserializable(value: unknown): void {
     throw unserializableError(value);
   }
   if (isJsonBuiltInValueShallow(value)) {
-    return;
-  }
-  if (taggers.some((tagger) => tagger.shouldTag(value))) {
     return;
   }
   throw unserializableError(value);

--- a/libs/grout/src/serialization.ts
+++ b/libs/grout/src/serialization.ts
@@ -143,11 +143,7 @@ function throwIfUnserializable(value: unknown): void {
   if (taggers.some((tagger) => tagger.shouldTag(value))) {
     return;
   }
-  if (
-    isObject(value) &&
-    !(value instanceof Date) &&
-    isFunction(value['toJSON'])
-  ) {
+  if (isObject(value) && isFunction(value['toJSON'])) {
     throw unserializableError(value);
   }
   if (isNumber(value) && (isNaN(value) || !isFinite(value))) {


### PR DESCRIPTION

## Overview

In general we won't use this because we do most data processing on the backend. However, we still have some use cases for sending binary data back and forth. This makes doing so easier.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
