### PR TITLE
fix(scan): Prevent double sounds on accept

### DIFF
--- a/apps/scan/frontend/src/screens/voter_screen.tsx
+++ b/apps/scan/frontend/src/screens/voter_screen.tsx
@@ -50,30 +50,34 @@ export function VoterScreen({
   const playSuccess = useSound('success');
   const playWarning = useSound('warning');
   const playError = useSound('error');
-  useQueryChangeListener(scannerStatusQuery, (newScannerStatus) => {
-    if (isSoundMuted) return;
-    switch (newScannerStatus.state) {
-      case 'accepted': {
-        playSuccess();
-        break;
-      }
-      case 'needs_review':
-      case 'both_sides_have_paper': {
-        playWarning();
-        break;
-      }
-      case 'rejecting':
-      case 'jammed':
-      case 'double_sheet_jammed':
-      case 'unrecoverable_error': {
-        playError();
-        break;
-      }
-      default: {
-        // No sound
+  useQueryChangeListener(
+    scannerStatusQuery,
+    (newScannerStatus, previousScannerStatus) => {
+      if (isSoundMuted) return;
+      if (newScannerStatus.state === previousScannerStatus?.state) return;
+      switch (newScannerStatus.state) {
+        case 'accepted': {
+          playSuccess();
+          break;
+        }
+        case 'needs_review':
+        case 'both_sides_have_paper': {
+          playWarning();
+          break;
+        }
+        case 'rejecting':
+        case 'jammed':
+        case 'double_sheet_jammed':
+        case 'unrecoverable_error': {
+          playError();
+          break;
+        }
+        default: {
+          // No sound
+        }
       }
     }
-  });
+  );
 
   if (!scannerStatusQuery.isSuccess) {
     return null;


### PR DESCRIPTION


## Overview

It's possible for the scanner status from the state machine to change even when the state doesn't change - in this case, the `interpretation` field was being cleared before leaving the `accepted` state. This caused the success sound to play twice. To fix, we make sure we only play sounds when the actual state changes.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
