### PR TITLE
[libs/ui] Add ColorSettings and SizeSettings components

### DIFF
--- a/libs/ui/src/display_settings/color_settings.test.tsx
+++ b/libs/ui/src/display_settings/color_settings.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { UiTheme } from '@votingworks/types';
+import { ThemeConsumer } from 'styled-components';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '../../test/react_testing_library';
+import { ColorSettings } from './color_settings';
+import { H1 } from '../typography';
+
+test('renders with default color options', () => {
+  render(<ColorSettings />, {
+    vxTheme: { colorMode: 'contrastLow', sizeMode: 'l' },
+  });
+
+  // contractHighDark:
+  screen.getByRole('radio', {
+    name: /white text on black background/i,
+    checked: false,
+  });
+
+  // contrastLow:
+  screen.getByRole('radio', {
+    name: /gray text on dark background/i,
+    checked: true,
+  });
+
+  // contrastMedium:
+  screen.getByRole('radio', {
+    name: /dark text on light background/i,
+    checked: false,
+  });
+
+  // contrastHighLight:
+  screen.getByRole('radio', {
+    name: /black text on white background/i,
+    checked: false,
+  });
+});
+
+test('renders with specified color options', () => {
+  render(<ColorSettings colorModes={['contrastLow', 'contrastMedium']} />, {
+    vxTheme: { colorMode: 'contrastLow', sizeMode: 'l' },
+  });
+
+  expect(screen.queryAllByRole('radio')).toHaveLength(2);
+
+  // contrastLow:
+  screen.getByRole('radio', {
+    name: /gray text on dark background/i,
+    checked: true,
+  });
+
+  // contrastMedium:
+  screen.getByRole('radio', {
+    name: /dark text on light background/i,
+    checked: false,
+  });
+});
+
+test('option selections trigger theme updates', () => {
+  let currentTheme: UiTheme | null = null;
+
+  function TestComponent(): JSX.Element {
+    return (
+      <ThemeConsumer>
+        {(theme) => {
+          currentTheme = theme;
+          return (
+            <div>
+              <H1>Foo</H1>
+              <ColorSettings />
+            </div>
+          );
+        }}
+      </ThemeConsumer>
+    );
+  }
+
+  render(<TestComponent />, {
+    vxTheme: { colorMode: 'contrastHighDark', sizeMode: 'l' },
+  });
+
+  expect(currentTheme).toEqual(
+    expect.objectContaining<Partial<UiTheme>>({
+      colorMode: 'contrastHighDark',
+      sizeMode: 'l',
+    })
+  );
+
+  userEvent.click(
+    screen.getByRole('radio', { name: /gray text on dark background/i })
+  );
+
+  expect(currentTheme).toEqual(
+    expect.objectContaining<Partial<UiTheme>>({
+      colorMode: 'contrastLow',
+      sizeMode: 'l',
+    })
+  );
+});

--- a/libs/ui/src/display_settings/color_settings.tsx
+++ b/libs/ui/src/display_settings/color_settings.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { ColorMode } from '@votingworks/types';
+import { ThemeConsumer } from 'styled-components';
+import { SettingsPane } from './settings_pane';
+import { RadioGroup } from '../radio_group';
+import { ThemeManagerContext } from '../theme_manager_context';
+import { ThemeLabel } from './theme_label';
+
+export interface ColorSettingsProps {
+  /** @default ['contrastLow', 'contrastMedium', 'contrastHighLight', 'contrastHighDark'] */
+  colorModes?: ColorMode[];
+}
+
+const DEFAULT_COLOR_MODES: ColorMode[] = [
+  'contrastHighDark',
+  'contrastLow',
+  'contrastMedium',
+  'contrastHighLight',
+];
+
+const ORDERED_COLOR_MODE_LABELS: Record<ColorMode, string> = {
+  contrastHighDark: 'White text on black background',
+  contrastHighLight: 'Black text on white background',
+  contrastLow: 'Gray text on dark background',
+  contrastMedium: 'Dark text on light background',
+  legacy: 'DEV ONLY: Pre-VVSG styling',
+};
+
+export function ColorSettings(props: ColorSettingsProps): JSX.Element {
+  const { colorModes = DEFAULT_COLOR_MODES } = props;
+  const enabledColorModes = new Set(colorModes);
+
+  const { setColorMode } = React.useContext(ThemeManagerContext);
+
+  const orderedColorModes = (
+    Object.keys(ORDERED_COLOR_MODE_LABELS) as ColorMode[]
+  ).filter((m) => enabledColorModes.has(m));
+
+  return (
+    <ThemeConsumer>
+      {(currentTheme) => (
+        <SettingsPane id="displaySettingsColor">
+          <RadioGroup
+            hideLabel
+            label="Color Contrast Settings"
+            onChange={setColorMode}
+            options={orderedColorModes.map((mode) => ({
+              id: mode,
+              label: (
+                <ThemeLabel colorMode={mode}>
+                  {ORDERED_COLOR_MODE_LABELS[mode]}
+                </ThemeLabel>
+              ),
+            }))}
+            selectedOptionId={currentTheme.colorMode}
+          />
+        </SettingsPane>
+      )}
+    </ThemeConsumer>
+  );
+}

--- a/libs/ui/src/display_settings/settings_pane.tsx
+++ b/libs/ui/src/display_settings/settings_pane.tsx
@@ -1,0 +1,21 @@
+/* stylelint-disable order/properties-order */
+import React from 'react';
+import styled from 'styled-components';
+import { SettingsPaneId } from './types';
+
+export interface SettingsPaneProps {
+  children: React.ReactNode;
+  id: SettingsPaneId;
+}
+
+const Container = styled.div.attrs({ role: 'tabpanel' })`
+  display: flex;
+  flex-direction: column;
+  padding: 0.75rem 0.5rem;
+`;
+
+export function SettingsPane(props: SettingsPaneProps): JSX.Element {
+  const { children, id } = props;
+
+  return <Container id={id}>{children}</Container>;
+}

--- a/libs/ui/src/display_settings/size_settings.test.tsx
+++ b/libs/ui/src/display_settings/size_settings.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { UiTheme } from '@votingworks/types';
+import { ThemeConsumer } from 'styled-components';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '../../test/react_testing_library';
+import { SizeSettings } from './size_settings';
+import { H1 } from '../typography';
+
+test('renders with default size options', () => {
+  render(<SizeSettings />, {
+    vxTheme: { colorMode: 'contrastLow', sizeMode: 'l' },
+  });
+
+  screen.getByRole('radio', {
+    name: /small/i,
+    checked: false,
+  });
+
+  screen.getByRole('radio', {
+    name: /medium/i,
+    checked: false,
+  });
+
+  screen.getByRole('radio', {
+    name: /large/i,
+    checked: true,
+  });
+
+  screen.getByRole('radio', {
+    name: /extra-large/i,
+    checked: false,
+  });
+});
+
+test('renders with specified size options', () => {
+  render(<SizeSettings sizeModes={['m', 'l']} />, {
+    vxTheme: { colorMode: 'contrastLow', sizeMode: 'l' },
+  });
+
+  expect(screen.queryAllByRole('radio')).toHaveLength(2);
+
+  screen.getByRole('radio', {
+    name: /medium/i,
+    checked: false,
+  });
+
+  screen.getByRole('radio', {
+    name: /large/i,
+    checked: true,
+  });
+});
+
+test('option selections trigger theme updates', () => {
+  let currentTheme: UiTheme | null = null;
+
+  function TestComponent(): JSX.Element {
+    return (
+      <ThemeConsumer>
+        {(theme) => {
+          currentTheme = theme;
+          return (
+            <div>
+              <H1>Foo</H1>
+              <SizeSettings />
+            </div>
+          );
+        }}
+      </ThemeConsumer>
+    );
+  }
+
+  render(<TestComponent />, {
+    vxTheme: { colorMode: 'contrastHighDark', sizeMode: 'l' },
+  });
+
+  expect(currentTheme).toEqual(
+    expect.objectContaining<Partial<UiTheme>>({
+      colorMode: 'contrastHighDark',
+      sizeMode: 'l',
+    })
+  );
+
+  userEvent.click(screen.getByRole('radio', { name: /small/i }));
+
+  expect(currentTheme).toEqual(
+    expect.objectContaining<Partial<UiTheme>>({
+      colorMode: 'contrastHighDark',
+      sizeMode: 's',
+    })
+  );
+});

--- a/libs/ui/src/display_settings/size_settings.tsx
+++ b/libs/ui/src/display_settings/size_settings.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { SizeMode } from '@votingworks/types';
+import { ThemeConsumer } from 'styled-components';
+import { SettingsPane } from './settings_pane';
+import { RadioGroup } from '../radio_group';
+import { ThemeManagerContext } from '../theme_manager_context';
+import { ThemeLabel } from './theme_label';
+
+export interface SizeSettingsProps {
+  /** @default ['s', 'm', 'l', 'xl'] */
+  sizeModes?: SizeMode[];
+}
+
+const DEFAULT_SIZE_MODES: SizeMode[] = ['s', 'm', 'l', 'xl'];
+
+const ORDERED_SIZE_MODE_LABELS: Record<SizeMode, string> = {
+  s: 'Small',
+  m: 'Medium',
+  l: 'Large',
+  xl: 'Extra-Large',
+  legacy: 'DEV ONLY: Pre-VVSG Styling',
+};
+
+export function SizeSettings(props: SizeSettingsProps): JSX.Element {
+  const { sizeModes = DEFAULT_SIZE_MODES } = props;
+  const enabledSizeModes = new Set(sizeModes);
+
+  const { setSizeMode } = React.useContext(ThemeManagerContext);
+
+  const orderedSizeModes = (
+    Object.keys(ORDERED_SIZE_MODE_LABELS) as SizeMode[]
+  ).filter((m) => enabledSizeModes.has(m));
+
+  return (
+    <ThemeConsumer>
+      {(currentTheme) => (
+        <SettingsPane id="displaySettingsSize">
+          <RadioGroup
+            hideLabel
+            label="Text Size Settings"
+            onChange={setSizeMode}
+            options={orderedSizeModes.map((m) => ({
+              id: m,
+              label: (
+                <ThemeLabel sizeMode={m}>
+                  {ORDERED_SIZE_MODE_LABELS[m]}
+                </ThemeLabel>
+              ),
+            }))}
+            selectedOptionId={currentTheme.sizeMode}
+          />
+        </SettingsPane>
+      )}
+    </ThemeConsumer>
+  );
+}

--- a/libs/ui/src/display_settings/types.ts
+++ b/libs/ui/src/display_settings/types.ts
@@ -1,0 +1,6 @@
+/* istanbul ignore next */
+export const PANE_IDS = [
+  'displaySettingsColor',
+  'displaySettingsSize',
+] as const;
+export type SettingsPaneId = typeof PANE_IDS[number];


### PR DESCRIPTION
## Overview

Adding components for the `ColorSettings` and `SizeSettings` panes within the upcoming display settings screen component.

Both render the display options as `RadioGroup` components and use the theme manager context API to modify the global theme.

## Demo Video or Screenshot

https://user-images.githubusercontent.com/264902/234090389-2f7ebfd7-2be3-4291-80f1-ae273746ccbc.mov

## Testing Plan
- Added unit tests to verify rendered options and theme-change functionality

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
