### PR TITLE
CVR Fixture Generation Tweaks

### DIFF
--- a/libs/cvr-fixture-generator/README.md
+++ b/libs/cvr-fixture-generator/README.md
@@ -23,6 +23,14 @@ Optional flags:
   required, the default number is determined as the number of possible variants
   of ballot style, precinct, ballot type (absentee or precinct), scanner, and
   vote variations.
+- `--ballotIdPrefix` - a prefix to prepend to every ballot id (or `UniqueId` in
+  the CDF). Since ballot ids are incrementing numbers starting from 1, they will
+  have id collisions in VxAdmin if they are not distinguished by a prefix.
+- `--bmdBallots` - use this flag to generate BMD ballots instead of HMPB
+  ballots. BMD ballots have no images, their write-ins include a `Text` field
+  instead of an image reference, and all the contests are in one CVR rather than
+  one CVR per sheet. Note that if you use this option, `--includeBallotImages`
+  will do nothing.
 
 ## Vote Variations
 

--- a/libs/cvr-fixture-generator/src/cli/generate/main.test.ts
+++ b/libs/cvr-fixture-generator/src/cli/generate/main.test.ts
@@ -8,6 +8,7 @@ import { dirSync } from 'tmp';
 import { CAST_VOTE_RECORD_REPORT_FILENAME } from '@votingworks/utils';
 import {
   getCastVoteRecordReportImport,
+  getWriteInsFromCastVoteRecord,
   isBmdWriteIn,
 } from '@votingworks/backend';
 import { assert } from '@votingworks/basics';
@@ -302,8 +303,14 @@ test('generating as BMD ballots', async () => {
 
   const report = reportFromFile(outputDirectory.name);
   assert(report.CVR);
-  for (const cvr of report.CVR) {
+  for (const [index, cvr] of report.CVR.entries()) {
     expect(cvr.BallotImage).toBeUndefined();
+    expect(cvr.UniqueId).toEqual(index.toString());
+    expect(
+      getWriteInsFromCastVoteRecord(cvr).every((castVoteRecordWriteIn) =>
+        Boolean(castVoteRecordWriteIn.text)
+      )
+    ).toEqual(true);
     const writeIns = cvr.CVRSnapshot[0]!.CVRContest.flatMap(
       (contest) => contest.CVRContestSelection
     )

--- a/libs/cvr-fixture-generator/src/cli/generate/main.test.ts
+++ b/libs/cvr-fixture-generator/src/cli/generate/main.test.ts
@@ -133,6 +133,8 @@ test('generate with custom number of records above the suggested number', async 
       outputDirectory.name,
       '--numBallots',
       '3000',
+      '--ballotIdPrefix',
+      'pre',
     ])
   ).toEqual({
     exitCode: 0,
@@ -149,7 +151,7 @@ test('generate with custom number of records above the suggested number', async 
   let cvrCount = 0;
   for await (const unparsedCastVoteRecord of castVoteRecordReportImport.CVR) {
     const castVoteRecord = unsafeParse(CVR.CVRSchema, unparsedCastVoteRecord);
-    expect(castVoteRecord.UniqueId).toEqual(`${cvrCount}`);
+    expect(castVoteRecord.UniqueId).toEqual(`pre-${cvrCount}`);
     cvrCount += 1;
   }
 

--- a/libs/cvr-fixture-generator/src/cli/generate/main.ts
+++ b/libs/cvr-fixture-generator/src/cli/generate/main.ts
@@ -40,6 +40,7 @@ interface GenerateCvrFileArguments {
   scannerNames?: Array<string | number>;
   officialBallots: boolean;
   includeBallotImages: boolean;
+  ballotIdPrefix?: string;
   help?: boolean;
   [x: string]: unknown;
 }
@@ -92,6 +93,11 @@ export async function main(
         description:
           'Whether to include ballot images with write-in ballots in the output.',
       },
+      ballotIdPrefix: {
+        type: 'string',
+        description:
+          'If included, applies a prefix to the ballot ids. E.g. "p-456" instead of "456"',
+      },
     })
     .alias('-h', '--help')
     .help(false)
@@ -131,6 +137,7 @@ export async function main(
     outputPath,
     includeBallotImages,
     ballotPackage: ballotPackagePath,
+    ballotIdPrefix,
   } = args;
   const scannerNames = (args.scannerNames ?? ['scanner']).map((s) => `${s}`);
   const testMode = !args.officialBallots;
@@ -146,6 +153,7 @@ export async function main(
       includeBallotImages,
       testMode,
       scannerNames,
+      ballotIdPrefix,
     })
   ).toArray();
 
@@ -171,7 +179,10 @@ export async function main(
     assert(castVoteRecord);
 
     // we need each cast vote record to have a unique id
-    const newCastVoteRecord = replaceUniqueId(castVoteRecord, `${ballotId}`);
+    const newCastVoteRecord = replaceUniqueId(
+      castVoteRecord,
+      ballotIdPrefix ? `${ballotIdPrefix}-${ballotId}` : ballotId.toString()
+    );
 
     // clone deep so jsonStream util will not detect circular references
     castVoteRecords.push(cloneDeep(newCastVoteRecord));

--- a/libs/cvr-fixture-generator/src/cli/generate/main.ts
+++ b/libs/cvr-fixture-generator/src/cli/generate/main.ts
@@ -41,6 +41,7 @@ interface GenerateCvrFileArguments {
   officialBallots: boolean;
   includeBallotImages: boolean;
   ballotIdPrefix?: string;
+  bmdBallots: boolean;
   help?: boolean;
   [x: string]: unknown;
 }
@@ -98,6 +99,11 @@ export async function main(
         description:
           'If included, applies a prefix to the ballot ids. E.g. "p-456" instead of "456"',
       },
+      bmdBallots: {
+        type: 'boolean',
+        description:
+          'Create BMD ballots when specified. By default HMPB ballots are created. Note that this will create ballots without images, regardless of the "includeBallotImages" argument',
+      },
     })
     .alias('-h', '--help')
     .help(false)
@@ -138,6 +144,7 @@ export async function main(
     includeBallotImages,
     ballotPackage: ballotPackagePath,
     ballotIdPrefix,
+    bmdBallots,
   } = args;
   const scannerNames = (args.scannerNames ?? ['scanner']).map((s) => `${s}`);
   const testMode = !args.officialBallots;
@@ -154,6 +161,7 @@ export async function main(
       testMode,
       scannerNames,
       ballotIdPrefix,
+      bmdBallots,
     })
   ).toArray();
 

--- a/libs/cvr-fixture-generator/src/generate_cvrs.ts
+++ b/libs/cvr-fixture-generator/src/generate_cvrs.ts
@@ -209,6 +209,8 @@ export function* generateCvrs({
                   },
                 ],
               };
+
+              castVoteRecordId += 1;
             } else {
               // Since this is HMPB, we generate a CVR for each sheet (not fully supported yet)
               const contestsBySheet = arrangeContestsBySheet(

--- a/libs/cvr-fixture-generator/src/generate_cvrs.ts
+++ b/libs/cvr-fixture-generator/src/generate_cvrs.ts
@@ -105,6 +105,7 @@ interface GenerateCvrsParams {
   scannerNames: readonly string[];
   ballotPackage: BallotPackage;
   includeBallotImages: boolean;
+  ballotIdPrefix?: string;
 }
 
 /**
@@ -119,6 +120,7 @@ export function* generateCvrs({
   scannerNames,
   ballotPackage,
   includeBallotImages,
+  ballotIdPrefix,
 }: GenerateCvrsParams): Iterable<CVR.CVR> {
   const { electionDefinition } = ballotPackage;
   const { election } = electionDefinition;
@@ -218,7 +220,9 @@ export function* generateCvrs({
                 vxBallotType: ballotType,
                 BallotSheetId: (sheetIndex + 1).toString(),
                 CurrentSnapshotId: `${castVoteRecordId}-modified`,
-                UniqueId: castVoteRecordId.toString(),
+                UniqueId: ballotIdPrefix
+                  ? `${ballotIdPrefix}-${castVoteRecordId.toString()}`
+                  : castVoteRecordId.toString(),
                 CVRSnapshot: [
                   {
                     '@type': 'CVR.CVRSnapshot',


### PR DESCRIPTION
A couple quick additions to CVR fixture generation to more easily make CVR fixtures for performance testing:
1. **Ballot Prefix ID** - useful when wanting to create multiple CVRs for the same election without ID collision
2. **BMD Ballots** - useful when wanting to test without images. We can generate CVRs without images by default, if we don't use the `--includeBallotImages` flag, but the CVRs still have write-ins so they fail VxAdmin validation. Rather than tweaking validation, I wanted to be able to produce BMD ballots. They aren't procedurally valid - they contain overvotes which are not possible on a BMD - but they are formally valid.
