### PR TITLE
Update VxMark backend to pull election hash from backend store

### DIFF
--- a/apps/mark/backend/src/app.test.ts
+++ b/apps/mark/backend/src/app.test.ts
@@ -27,7 +27,7 @@ import {
 import { Server } from 'http';
 import * as grout from '@votingworks/grout';
 import { DEFAULT_SYSTEM_SETTINGS } from '@votingworks/types';
-import { createApp } from '../test/app_helpers';
+import { configureApp, createApp } from '../test/app_helpers';
 import { Api } from './app';
 
 let apiClient: grout.Client<Api>;
@@ -74,6 +74,7 @@ test('uses default machine config if not set', async () => {
 test('read scanner report data from card', async () => {
   const { electionDefinition } = electionFamousNames2021Fixtures;
   const { electionHash } = electionDefinition;
+  await configureApp(apiClient, mockAuth, mockUsb);
 
   const scannerReportData: ScannerReportData = {
     ballotCounts: {},
@@ -96,7 +97,7 @@ test('read scanner report data from card', async () => {
   mockOf(mockAuth.getAuthStatus).mockImplementation(() =>
     Promise.resolve({ status: 'logged_out', reason: 'no_card' })
   );
-  result = await apiClient.readScannerReportDataFromCard({ electionHash });
+  result = await apiClient.readScannerReportDataFromCard();
   expect(result).toEqual(err(new Error('User is not logged in')));
 
   mockOf(mockAuth.getAuthStatus).mockImplementation(() =>
@@ -106,7 +107,7 @@ test('read scanner report data from card', async () => {
       sessionExpiresAt: fakeSessionExpiresAt(),
     })
   );
-  result = await apiClient.readScannerReportDataFromCard({ electionHash });
+  result = await apiClient.readScannerReportDataFromCard();
   expect(result).toEqual(err(new Error('User is not a poll worker')));
 
   mockOf(mockAuth.getAuthStatus).mockImplementation(() =>
@@ -116,7 +117,7 @@ test('read scanner report data from card', async () => {
       sessionExpiresAt: fakeSessionExpiresAt(),
     })
   );
-  result = await apiClient.readScannerReportDataFromCard({ electionHash });
+  result = await apiClient.readScannerReportDataFromCard();
   expect(result).toEqual(ok(scannerReportData));
   expect(mockAuth.readCardData).toHaveBeenCalledTimes(1);
   expect(mockAuth.readCardData).toHaveBeenNthCalledWith(
@@ -129,6 +130,7 @@ test('read scanner report data from card', async () => {
 test('clear scanner report data from card', async () => {
   const { electionDefinition } = electionFamousNames2021Fixtures;
   const { electionHash } = electionDefinition;
+  await configureApp(apiClient, mockAuth, mockUsb);
 
   mockOf(mockAuth.clearCardData).mockImplementation(() =>
     Promise.resolve(ok())
@@ -139,7 +141,7 @@ test('clear scanner report data from card', async () => {
   mockOf(mockAuth.getAuthStatus).mockImplementation(() =>
     Promise.resolve({ status: 'logged_out', reason: 'no_card' })
   );
-  result = await apiClient.clearScannerReportDataFromCard({ electionHash });
+  result = await apiClient.clearScannerReportDataFromCard();
   expect(result).toEqual(err(new Error('User is not logged in')));
 
   mockOf(mockAuth.getAuthStatus).mockImplementation(() =>
@@ -149,7 +151,7 @@ test('clear scanner report data from card', async () => {
       sessionExpiresAt: fakeSessionExpiresAt(),
     })
   );
-  result = await apiClient.clearScannerReportDataFromCard({ electionHash });
+  result = await apiClient.clearScannerReportDataFromCard();
   expect(result).toEqual(err(new Error('User is not a poll worker')));
 
   mockOf(mockAuth.getAuthStatus).mockImplementation(() =>
@@ -159,7 +161,7 @@ test('clear scanner report data from card', async () => {
       sessionExpiresAt: fakeSessionExpiresAt(),
     })
   );
-  result = await apiClient.clearScannerReportDataFromCard({ electionHash });
+  result = await apiClient.clearScannerReportDataFromCard();
   expect(result).toEqual(ok());
   expect(mockAuth.clearCardData).toHaveBeenCalledTimes(1);
   expect(mockAuth.clearCardData).toHaveBeenNthCalledWith(1, {

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -43,8 +43,6 @@ function buildApi(
   return grout.createApi({
     getMachineConfig,
 
-    // TODO: Once election definition has been moved to the backend, no longer require the frontend
-    // to provide election hash to this and other methods that use the auth lib
     getAuthStatus() {
       return auth.getAuthStatus(constructAuthMachineState(workspace));
     },

--- a/apps/mark/frontend/src/api.ts
+++ b/apps/mark/frontend/src/api.ts
@@ -13,7 +13,6 @@ import {
   AUTH_STATUS_POLLING_INTERVAL_MS,
   QUERY_CLIENT_DEFAULT_OPTIONS,
 } from '@votingworks/ui';
-import { BallotStyleId, PrecinctId } from '@votingworks/types';
 
 export type ApiClient = grout.Client<Api>;
 
@@ -72,15 +71,11 @@ export const getAuthStatus = {
   queryKey(): QueryKey {
     return ['getAuthStatus'];
   },
-  // TODO: Once election definition has been moved to the backend, no longer require election hash
-  // to be provided here and in other auth/card queries/mutations
-  useQuery(electionHash?: string) {
+  useQuery() {
     const apiClient = useApiClient();
-    return useQuery(
-      this.queryKey(),
-      () => apiClient.getAuthStatus({ electionHash }),
-      { refetchInterval: AUTH_STATUS_POLLING_INTERVAL_MS }
-    );
+    return useQuery(this.queryKey(), () => apiClient.getAuthStatus(), {
+      refetchInterval: AUTH_STATUS_POLLING_INTERVAL_MS,
+    });
   },
 } as const;
 
@@ -88,11 +83,11 @@ export const getScannerReportDataFromCard = {
   queryKey(): QueryKey {
     return ['getScannerReportDataFromCard'];
   },
-  useQuery(electionHash?: string) {
+  useQuery() {
     const apiClient = useApiClient();
     return useQuery(
       this.queryKey(),
-      () => apiClient.readScannerReportDataFromCard({ electionHash }),
+      () => apiClient.readScannerReportDataFromCard(),
       // Don't cache this since caching would require invalidation in response to external
       // circumstances, like card removal
       { cacheTime: 0, staleTime: 0 }
@@ -101,29 +96,25 @@ export const getScannerReportDataFromCard = {
 } as const;
 
 export const checkPin = {
-  useMutation(electionHash?: string) {
+  useMutation() {
     const apiClient = useApiClient();
     const queryClient = useQueryClient();
-    return useMutation(
-      (input: { pin: string }) =>
-        apiClient.checkPin({ ...input, electionHash }),
-      {
-        async onSuccess() {
-          // Because we poll auth status with high frequency, this invalidation isn't strictly
-          // necessary
-          await queryClient.invalidateQueries(getAuthStatus.queryKey());
-        },
-      }
-    );
+    return useMutation(apiClient.checkPin, {
+      async onSuccess() {
+        // Because we poll auth status with high frequency, this invalidation isn't strictly
+        // necessary
+        await queryClient.invalidateQueries(getAuthStatus.queryKey());
+      },
+    });
   },
 } as const;
 
 /* istanbul ignore next */
 export const logOut = {
-  useMutation(electionHash?: string) {
+  useMutation() {
     const apiClient = useApiClient();
     const queryClient = useQueryClient();
-    return useMutation(() => apiClient.logOut({ electionHash }), {
+    return useMutation(apiClient.logOut, {
       async onSuccess() {
         // Because we poll auth status with high frequency, this invalidation isn't strictly
         // necessary
@@ -135,74 +126,60 @@ export const logOut = {
 
 /* istanbul ignore next */
 export const updateSessionExpiry = {
-  useMutation(electionHash?: string) {
+  useMutation() {
     const apiClient = useApiClient();
     const queryClient = useQueryClient();
-    return useMutation(
-      (input: { sessionExpiresAt: Date }) =>
-        apiClient.updateSessionExpiry({ ...input, electionHash }),
-      {
-        async onSuccess() {
-          // Because we poll auth status with high frequency, this invalidation isn't strictly
-          // necessary
-          await queryClient.invalidateQueries(getAuthStatus.queryKey());
-        },
-      }
-    );
+    return useMutation(apiClient.updateSessionExpiry, {
+      async onSuccess() {
+        // Because we poll auth status with high frequency, this invalidation isn't strictly
+        // necessary
+        await queryClient.invalidateQueries(getAuthStatus.queryKey());
+      },
+    });
   },
 } as const;
 
 export const startCardlessVoterSession = {
-  useMutation(electionHash?: string) {
+  useMutation() {
     const apiClient = useApiClient();
     const queryClient = useQueryClient();
-    return useMutation(
-      (input: { ballotStyleId: BallotStyleId; precinctId: PrecinctId }) =>
-        apiClient.startCardlessVoterSession({ ...input, electionHash }),
-      {
-        async onSuccess() {
-          // Because we poll auth status with high frequency, this invalidation isn't strictly
-          // necessary
-          await queryClient.invalidateQueries(getAuthStatus.queryKey());
-        },
-      }
-    );
+    return useMutation(apiClient.startCardlessVoterSession, {
+      async onSuccess() {
+        // Because we poll auth status with high frequency, this invalidation isn't strictly
+        // necessary
+        await queryClient.invalidateQueries(getAuthStatus.queryKey());
+      },
+    });
   },
 } as const;
 
 export const endCardlessVoterSession = {
-  useMutation(electionHash?: string) {
+  useMutation() {
     const apiClient = useApiClient();
     const queryClient = useQueryClient();
-    return useMutation(
-      () => apiClient.endCardlessVoterSession({ electionHash }),
-      {
-        async onSuccess() {
-          // Because we poll auth status with high frequency, this invalidation isn't strictly
-          // necessary
-          await queryClient.invalidateQueries(getAuthStatus.queryKey());
-        },
-      }
-    );
+    return useMutation(apiClient.endCardlessVoterSession, {
+      async onSuccess() {
+        // Because we poll auth status with high frequency, this invalidation isn't strictly
+        // necessary
+        await queryClient.invalidateQueries(getAuthStatus.queryKey());
+      },
+    });
   },
 } as const;
 
 export const clearScannerReportDataFromCard = {
-  useMutation(electionHash?: string) {
+  useMutation() {
     const apiClient = useApiClient();
     const queryClient = useQueryClient();
-    return useMutation(
-      () => apiClient.clearScannerReportDataFromCard({ electionHash }),
-      {
-        async onSuccess() {
-          // Because we don't cache scanner report data from cards, this invalidation isn't
-          // strictly necessary
-          await queryClient.invalidateQueries(
-            getScannerReportDataFromCard.queryKey()
-          );
-        },
-      }
-    );
+    return useMutation(apiClient.clearScannerReportDataFromCard, {
+      async onSuccess() {
+        // Because we don't cache scanner report data from cards, this invalidation isn't
+        // strictly necessary
+        await queryClient.invalidateQueries(
+          getScannerReportDataFromCard.queryKey()
+        );
+      },
+    });
   },
 } as const;
 

--- a/apps/mark/frontend/src/app.tsx
+++ b/apps/mark/frontend/src/app.tsx
@@ -28,6 +28,7 @@ import {
   createApiClient,
   createQueryClient,
 } from './api';
+import { SessionTimeLimitTracker } from './components/session_time_limit_tracker';
 
 window.oncontextmenu = (e: MouseEvent): void => {
   e.preventDefault();
@@ -156,6 +157,7 @@ export function App({
                   reload={reload}
                   logger={logger}
                 />
+                <SessionTimeLimitTracker />
               </AppBase>
             </QueryClientProvider>
           </ApiClientContext.Provider>

--- a/apps/mark/frontend/src/app_cardless_voting.test.tsx
+++ b/apps/mark/frontend/src/app_cardless_voting.test.tsx
@@ -121,7 +121,7 @@ test('Cardless Voting Flow', async () => {
   await advanceTimersAndPromises();
   await screen.findByText('Select Voter’s Ballot Style');
   apiMock.mockApiClient.startCardlessVoterSession
-    .expectCallWith({ electionHash, ballotStyleId: '12', precinctId: '23' })
+    .expectCallWith({ ballotStyleId: '12', precinctId: '23' })
     .resolves();
   fireEvent.click(within(screen.getByTestId('ballot-styles')).getByText('12'));
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
@@ -134,9 +134,7 @@ test('Cardless Voting Flow', async () => {
   screen.getByText(/(12)/);
 
   // Poll Worker deactivates ballot style
-  apiMock.mockApiClient.endCardlessVoterSession
-    .expectCallWith({ electionHash })
-    .resolves();
+  apiMock.mockApiClient.endCardlessVoterSession.expectCallWith().resolves();
   userEvent.click(await screen.findByText('Deactivate Voting Session'));
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
     isScannerReportDataReadExpected: false,
@@ -145,7 +143,7 @@ test('Cardless Voting Flow', async () => {
 
   // Poll Worker reactivates ballot style
   apiMock.mockApiClient.startCardlessVoterSession
-    .expectCallWith({ electionHash, ballotStyleId: '12', precinctId: '23' })
+    .expectCallWith({ ballotStyleId: '12', precinctId: '23' })
     .resolves();
   fireEvent.click(within(screen.getByTestId('ballot-styles')).getByText('12'));
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
@@ -183,9 +181,7 @@ test('Cardless Voting Flow', async () => {
   await screen.findByText('Ballot Contains Votes');
 
   // Poll Worker resets ballot to remove votes
-  apiMock.mockApiClient.endCardlessVoterSession
-    .expectCallWith({ electionHash })
-    .resolves();
+  apiMock.mockApiClient.endCardlessVoterSession.expectCallWith().resolves();
   fireEvent.click(screen.getByText('Reset Ballot'));
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
     isScannerReportDataReadExpected: false,
@@ -196,7 +192,7 @@ test('Cardless Voting Flow', async () => {
 
   // Activates Ballot Style again
   apiMock.mockApiClient.startCardlessVoterSession
-    .expectCallWith({ electionHash, ballotStyleId: '12', precinctId: '23' })
+    .expectCallWith({ ballotStyleId: '12', precinctId: '23' })
     .resolves();
   fireEvent.click(within(screen.getByTestId('ballot-styles')).getByText('12'));
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
@@ -253,9 +249,7 @@ test('Cardless Voting Flow', async () => {
   ).toBeFalsy();
 
   // Wait for timeout to return to Insert Card screen
-  apiMock.mockApiClient.endCardlessVoterSession
-    .expectCallWith({ electionHash })
-    .resolves();
+  apiMock.mockApiClient.endCardlessVoterSession.expectCallWith().resolves();
   await advanceTimersAndPromises(GLOBALS.BALLOT_INSTRUCTIONS_TIMEOUT_SECONDS);
   apiMock.setAuthStatusLoggedOut();
   await screen.findByText('Insert Card');
@@ -265,7 +259,6 @@ test('Another Voter submits blank ballot and clicks Done', async () => {
   // ====================== BEGIN CONTEST SETUP ====================== //
 
   const electionDefinition = electionSampleDefinition;
-  const { electionHash } = electionDefinition;
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
   apiMock.expectGetMachineConfig();
@@ -293,7 +286,7 @@ test('Another Voter submits blank ballot and clicks Done', async () => {
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
   await advanceTimersAndPromises();
   apiMock.mockApiClient.startCardlessVoterSession
-    .expectCallWith({ electionHash, ballotStyleId: '12', precinctId: '23' })
+    .expectCallWith({ ballotStyleId: '12', precinctId: '23' })
     .resolves();
   userEvent.click(
     within(await screen.findByTestId('ballot-styles')).getByText('12')
@@ -346,9 +339,7 @@ test('Another Voter submits blank ballot and clicks Done', async () => {
   expect(screen.queryByText('3. Return the card.')).toBeFalsy();
 
   // Click "Done" to get back to Insert Card screen
-  apiMock.mockApiClient.endCardlessVoterSession
-    .expectCallWith({ electionHash })
-    .resolves();
+  apiMock.mockApiClient.endCardlessVoterSession.expectCallWith().resolves();
   fireEvent.click(screen.getByText('Done'));
   apiMock.setAuthStatusLoggedOut();
   await screen.findByText('Insert Card');
@@ -436,7 +427,7 @@ test('poll worker must select a precinct first', async () => {
   );
   screen.getByText('2. Select Voter’s Ballot Style');
   apiMock.mockApiClient.startCardlessVoterSession
-    .expectCallWith({ electionHash, ballotStyleId: '12', precinctId: '23' })
+    .expectCallWith({ ballotStyleId: '12', precinctId: '23' })
     .resolves();
   fireEvent.click(within(screen.getByTestId('ballot-styles')).getByText('12'));
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
@@ -449,9 +440,7 @@ test('poll worker must select a precinct first', async () => {
   await screen.findByText('Voting Session Active: 12 at Center Springfield');
 
   // Poll Worker deactivates ballot style
-  apiMock.mockApiClient.endCardlessVoterSession
-    .expectCallWith({ electionHash })
-    .resolves();
+  apiMock.mockApiClient.endCardlessVoterSession.expectCallWith().resolves();
   fireEvent.click(screen.getByText('Deactivate Voting Session'));
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
     isScannerReportDataReadExpected: false,
@@ -463,7 +452,7 @@ test('poll worker must select a precinct first', async () => {
     within(screen.getByTestId('precincts')).getByText('Center Springfield')
   );
   apiMock.mockApiClient.startCardlessVoterSession
-    .expectCallWith({ electionHash, ballotStyleId: '12', precinctId: '23' })
+    .expectCallWith({ ballotStyleId: '12', precinctId: '23' })
     .resolves();
   fireEvent.click(within(screen.getByTestId('ballot-styles')).getByText('12'));
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
@@ -501,9 +490,7 @@ test('poll worker must select a precinct first', async () => {
   await screen.findByText('Ballot Contains Votes');
 
   // Poll Worker resets ballot to remove votes
-  apiMock.mockApiClient.endCardlessVoterSession
-    .expectCallWith({ electionHash })
-    .resolves();
+  apiMock.mockApiClient.endCardlessVoterSession.expectCallWith().resolves();
   fireEvent.click(screen.getByText('Reset Ballot'));
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
     isScannerReportDataReadExpected: false,
@@ -518,7 +505,7 @@ test('poll worker must select a precinct first', async () => {
   );
   screen.getByText('2. Select Voter’s Ballot Style');
   apiMock.mockApiClient.startCardlessVoterSession
-    .expectCallWith({ electionHash, ballotStyleId: '12', precinctId: '23' })
+    .expectCallWith({ ballotStyleId: '12', precinctId: '23' })
     .resolves();
   fireEvent.click(within(screen.getByTestId('ballot-styles')).getByText('12'));
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
@@ -576,9 +563,7 @@ test('poll worker must select a precinct first', async () => {
   ).toBeFalsy();
 
   // Wait for timeout to return to Insert Card screen
-  apiMock.mockApiClient.endCardlessVoterSession
-    .expectCallWith({ electionHash })
-    .resolves();
+  apiMock.mockApiClient.endCardlessVoterSession.expectCallWith().resolves();
   await advanceTimersAndPromises(GLOBALS.BALLOT_INSTRUCTIONS_TIMEOUT_SECONDS);
   apiMock.setAuthStatusLoggedOut();
   await screen.findByText('Insert Card');

--- a/apps/mark/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark/frontend/src/app_end_to_end.test.tsx
@@ -89,9 +89,7 @@ test('MarkAndPrint end-to-end flow', async () => {
     user: fakeElectionManagerUser(electionDefinition),
   });
   await screen.findByText('Enter the card PIN to unlock.');
-  apiMock.mockApiClient.checkPin
-    .expectCallWith({ electionHash: undefined, pin: '111111' })
-    .resolves();
+  apiMock.mockApiClient.checkPin.expectCallWith({ pin: '111111' }).resolves();
   userEvent.click(screen.getByText('1'));
   userEvent.click(screen.getByText('1'));
   userEvent.click(screen.getByText('1'));
@@ -106,9 +104,7 @@ test('MarkAndPrint end-to-end flow', async () => {
   await screen.findByText('Incorrect PIN. Please try again.');
 
   // Enter correct PIN
-  apiMock.mockApiClient.checkPin
-    .expectCallWith({ electionHash: undefined, pin: '123456' })
-    .resolves();
+  apiMock.mockApiClient.checkPin.expectCallWith({ pin: '123456' }).resolves();
   userEvent.click(screen.getByText('1'));
   userEvent.click(screen.getByText('2'));
   userEvent.click(screen.getByText('3'));
@@ -197,7 +193,7 @@ test('MarkAndPrint end-to-end flow', async () => {
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
   await advanceTimersAndPromises();
   apiMock.mockApiClient.startCardlessVoterSession
-    .expectCallWith({ electionHash, ballotStyleId: '12', precinctId: '23' })
+    .expectCallWith({ ballotStyleId: '12', precinctId: '23' })
     .resolves();
   userEvent.click(await screen.findByText('12'));
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
@@ -341,9 +337,7 @@ test('MarkAndPrint end-to-end flow', async () => {
   await advanceTimersAndPromises(GLOBALS.BALLOT_PRINTING_TIMEOUT_SECONDS);
 
   screen.getByText('You’re Almost Done');
-  apiMock.mockApiClient.endCardlessVoterSession
-    .expectCallWith({ electionHash })
-    .resolves();
+  apiMock.mockApiClient.endCardlessVoterSession.expectCallWith().resolves();
   userEvent.click(screen.getByText('Done'));
   apiMock.setAuthStatusLoggedOut();
 
@@ -388,10 +382,10 @@ test('MarkAndPrint end-to-end flow', async () => {
   await advanceTimersAndPromises();
   await screen.findByText('Polls Closed Report on Card');
   apiMock.mockApiClient.clearScannerReportDataFromCard
-    .expectCallWith({ electionHash })
+    .expectCallWith()
     .resolves(ok());
   apiMock.mockApiClient.readScannerReportDataFromCard
-    .expectCallWith({ electionHash })
+    .expectCallWith()
     .resolves(ok(undefined));
   userEvent.click(screen.getByText('Print Report'));
   await advanceTimersAndPromises();

--- a/apps/mark/frontend/src/app_polls_flows.test.tsx
+++ b/apps/mark/frontend/src/app_polls_flows.test.tsx
@@ -136,7 +136,6 @@ function checkPollsOpenedReport(printedElement: PrintRenderResult) {
 }
 
 test('full polls flow with tally reports - general, single precinct', async () => {
-  const { electionHash } = electionSampleDefinition;
   const { renderApp, storage, logger } = buildApp(apiMock);
   await setElectionInStorage(storage, electionSampleDefinition);
   await setStateInStorage(storage, { pollsState: 'polls_closed_initial' });
@@ -169,10 +168,10 @@ test('full polls flow with tally reports - general, single precinct', async () =
   screen.getByText(/contains a polls opened report/);
   screen.getByText(/the polls will be open on VxMark/);
   apiMock.mockApiClient.clearScannerReportDataFromCard
-    .expectCallWith({ electionHash })
+    .expectCallWith()
     .resolves(ok());
   apiMock.mockApiClient.readScannerReportDataFromCard
-    .expectCallWith({ electionHash })
+    .expectCallWith()
     .resolves(ok(undefined));
   userEvent.click(screen.getByText('Open Polls and Print Report'));
   await screen.findByText('Printing polls opened report');
@@ -238,10 +237,10 @@ test('full polls flow with tally reports - general, single precinct', async () =
   screen.getByText(/contains a voting paused report/);
   screen.getByText(/the polls will be paused on VxMark/);
   apiMock.mockApiClient.clearScannerReportDataFromCard
-    .expectCallWith({ electionHash })
+    .expectCallWith()
     .resolves(ok());
   apiMock.mockApiClient.readScannerReportDataFromCard
-    .expectCallWith({ electionHash })
+    .expectCallWith()
     .resolves(ok(undefined));
   userEvent.click(screen.getByText('Pause Voting and Print Report'));
   await screen.findByText('Printing voting paused report');
@@ -309,10 +308,10 @@ test('full polls flow with tally reports - general, single precinct', async () =
   screen.getByText(/contains a voting resumed report/);
   screen.getByText(/the polls will be open on VxMark/);
   apiMock.mockApiClient.clearScannerReportDataFromCard
-    .expectCallWith({ electionHash })
+    .expectCallWith()
     .resolves(ok());
   apiMock.mockApiClient.readScannerReportDataFromCard
-    .expectCallWith({ electionHash })
+    .expectCallWith()
     .resolves(ok(undefined));
   userEvent.click(screen.getByText('Resume Voting and Print Report'));
   await screen.findByText('Printing voting resumed report');
@@ -394,10 +393,10 @@ test('full polls flow with tally reports - general, single precinct', async () =
   screen.getByText(/contains a polls closed report/);
   screen.getByText(/the polls will be closed on VxMark/);
   apiMock.mockApiClient.clearScannerReportDataFromCard
-    .expectCallWith({ electionHash })
+    .expectCallWith()
     .resolves(ok());
   apiMock.mockApiClient.readScannerReportDataFromCard
-    .expectCallWith({ electionHash })
+    .expectCallWith()
     .resolves(ok(undefined));
   userEvent.click(screen.getByText('Close Polls and Print Report'));
   await screen.findByText('Printing polls closed report');
@@ -463,7 +462,6 @@ test('full polls flow with tally reports - general, single precinct', async () =
 });
 
 test('tally report: as expected with all precinct combined data for general election', async () => {
-  const { electionHash } = electionSampleDefinition;
   const existingTally = getZeroCompressedTally(electionSample);
   // add tallies to the president contest
   existingTally[0] = typedAs<CandidateContestWithoutWriteInsCompressedTally>([
@@ -494,10 +492,10 @@ test('tally report: as expected with all precinct combined data for general elec
   });
 
   apiMock.mockApiClient.clearScannerReportDataFromCard
-    .expectCallWith({ electionHash })
+    .expectCallWith()
     .resolves(ok());
   apiMock.mockApiClient.readScannerReportDataFromCard
-    .expectCallWith({ electionHash })
+    .expectCallWith()
     .resolves(ok(undefined));
   await printPollsClosedReport();
 
@@ -529,7 +527,6 @@ test('tally report: as expected with all precinct combined data for general elec
 });
 
 test('tally report: as expected with all precinct specific data for general election', async () => {
-  const { electionHash } = electionSampleDefinition;
   const centerSpringfield = getZeroCompressedTally(electionSample);
   const northSpringfield = getZeroCompressedTally(electionSample);
   const southSpringfield = getZeroCompressedTally(electionSample);
@@ -590,10 +587,10 @@ test('tally report: as expected with all precinct specific data for general elec
   });
 
   apiMock.mockApiClient.clearScannerReportDataFromCard
-    .expectCallWith({ electionHash })
+    .expectCallWith()
     .resolves(ok());
   apiMock.mockApiClient.readScannerReportDataFromCard
-    .expectCallWith({ electionHash })
+    .expectCallWith()
     .resolves(ok(undefined));
   await printPollsClosedReport();
 
@@ -811,7 +808,6 @@ function checkPrimaryElectionOverallTallyReports(
 
 test('tally report: as expected with a single precinct for primary election', async () => {
   const electionDefinition = electionMinimalExhaustiveSampleDefinition;
-  const { electionHash } = electionDefinition;
 
   const tallyOnCard: ScannerTallyReportData = {
     tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
@@ -844,10 +840,10 @@ test('tally report: as expected with a single precinct for primary election', as
   });
 
   apiMock.mockApiClient.clearScannerReportDataFromCard
-    .expectCallWith({ electionHash })
+    .expectCallWith()
     .resolves(ok());
   apiMock.mockApiClient.readScannerReportDataFromCard
-    .expectCallWith({ electionHash })
+    .expectCallWith()
     .resolves(ok(undefined));
   await printPollsClosedReport();
 
@@ -856,7 +852,6 @@ test('tally report: as expected with a single precinct for primary election', as
 
 test('tally report: as expected with all precinct combined data for primary election', async () => {
   const electionDefinition = electionMinimalExhaustiveSampleDefinition;
-  const { electionHash } = electionDefinition;
 
   const tallyOnCard: ScannerTallyReportData = {
     tallyMachineType: ReportSourceMachineType.PRECINCT_SCANNER,
@@ -891,10 +886,10 @@ test('tally report: as expected with all precinct combined data for primary elec
   });
 
   apiMock.mockApiClient.clearScannerReportDataFromCard
-    .expectCallWith({ electionHash })
+    .expectCallWith()
     .resolves(ok());
   apiMock.mockApiClient.readScannerReportDataFromCard
-    .expectCallWith({ electionHash })
+    .expectCallWith()
     .resolves(ok(undefined));
   await printPollsClosedReport();
 
@@ -904,7 +899,7 @@ test('tally report: as expected with all precinct combined data for primary elec
 test('tally report: as expected with all precinct specific data for primary election + VxQR', async () => {
   const electionDefinition =
     electionMinimalExhaustiveSampleWithReportingUrlDefinition;
-  const { electionHash, election } = electionDefinition;
+  const { election } = electionDefinition;
 
   const talliesByPrecinct: Dictionary<CompressedTally> = {
     'precinct-1': [
@@ -1022,10 +1017,10 @@ test('tally report: as expected with all precinct specific data for primary elec
   });
 
   apiMock.mockApiClient.clearScannerReportDataFromCard
-    .expectCallWith({ electionHash })
+    .expectCallWith()
     .resolves(ok());
   apiMock.mockApiClient.readScannerReportDataFromCard
-    .expectCallWith({ electionHash })
+    .expectCallWith()
     .resolves(ok(undefined));
   await printPollsClosedReport();
 
@@ -1287,7 +1282,6 @@ test('tally report: as expected with all precinct specific data for primary elec
 });
 
 test('tally report: will print but not update polls state appropriate', async () => {
-  const { electionHash } = electionSampleDefinition;
   const { renderApp, storage } = buildApp(apiMock);
   await setElectionInStorage(storage, electionSampleDefinition);
   // The polls have already been closed
@@ -1322,10 +1316,10 @@ test('tally report: will print but not update polls state appropriate', async ()
     'This poll worker card contains a polls opened report. After printing, the report will be cleared from the card.'
   );
   apiMock.mockApiClient.clearScannerReportDataFromCard
-    .expectCallWith({ electionHash })
+    .expectCallWith()
     .resolves(ok());
   apiMock.mockApiClient.readScannerReportDataFromCard
-    .expectCallWith({ electionHash })
+    .expectCallWith()
     .resolves(ok(undefined));
   userEvent.click(screen.getByText('Print Report'));
   await expectPrint(checkPollsOpenedReport);
@@ -1572,7 +1566,6 @@ test('cannot close polls from closed report on card if polls have not been opene
 });
 
 test('error clearing report from card does not affect printing and is logged', async () => {
-  const { electionHash } = electionSampleDefinition;
   const { logger, renderApp, storage } = buildApp(apiMock);
   await setElectionInStorage(storage, electionSampleDefinition);
   await setStateInStorage(storage, { pollsState: 'polls_closed_initial' });
@@ -1600,10 +1593,10 @@ test('error clearing report from card does not affect printing and is logged', a
   await screen.findByText('Polls Opened Report on Card');
 
   apiMock.mockApiClient.clearScannerReportDataFromCard
-    .expectCallWith({ electionHash })
+    .expectCallWith()
     .resolves(err(new Error('Error clearing report from card')));
   apiMock.mockApiClient.readScannerReportDataFromCard
-    .expectCallWith({ electionHash })
+    .expectCallWith()
     .resolves(ok(pollsOpenedReport));
   userEvent.click(screen.getByText('Open Polls and Print Report'));
   await screen.findByText('Printing polls opened report');

--- a/apps/mark/frontend/src/app_quit_on_idle.test.tsx
+++ b/apps/mark/frontend/src/app_quit_on_idle.test.tsx
@@ -74,7 +74,6 @@ test('Insert Card screen idle timeout to quit app', async () => {
 
 test('Voter idle timeout', async () => {
   const electionDefinition = electionSampleDefinition;
-  const { electionHash } = electionDefinition;
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
   apiMock.expectGetMachineConfig();
@@ -108,9 +107,7 @@ test('Voter idle timeout', async () => {
   // Let idle timeout kick in and don't acknowledge
   await advanceTimersAndPromises(IDLE_TIMEOUT_SECONDS);
   screen.getByText('Are you still voting?');
-  apiMock.mockApiClient.endCardlessVoterSession
-    .expectCallWith({ electionHash })
-    .resolves();
+  apiMock.mockApiClient.endCardlessVoterSession.expectCallWith().resolves();
   await advanceTimersAndPromises(IDLE_RESET_TIMEOUT_SECONDS);
   screen.getByText('Clearing ballot');
   apiMock.setAuthStatusLoggedOut();

--- a/apps/mark/frontend/src/app_voter_settings_landscape.test.tsx
+++ b/apps/mark/frontend/src/app_voter_settings_landscape.test.tsx
@@ -37,7 +37,6 @@ jest.setTimeout(15000);
 test('MarkAndPrint: voter settings in landscape orientation', async () => {
   const logger = fakeLogger();
   const electionDefinition = electionSampleDefinition;
-  const { electionHash } = electionDefinition;
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
   apiMock.expectGetMachineConfig({
@@ -95,7 +94,7 @@ test('MarkAndPrint: voter settings in landscape orientation', async () => {
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
   await advanceTimersAndPromises();
   apiMock.mockApiClient.startCardlessVoterSession
-    .expectCallWith({ electionHash, ballotStyleId: '12', precinctId: '23' })
+    .expectCallWith({ ballotStyleId: '12', precinctId: '23' })
     .resolves();
   userEvent.click(await screen.findByText('12'));
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {

--- a/apps/mark/frontend/src/components/session_time_limit_tracker.tsx
+++ b/apps/mark/frontend/src/components/session_time_limit_tracker.tsx
@@ -3,15 +3,10 @@ import { SessionTimeLimitTracker as SessionTimeLimitTrackerBase } from '@votingw
 
 import { getAuthStatus, logOut, updateSessionExpiry } from '../api';
 
-interface Props {
-  electionHash?: string;
-}
-
-export function SessionTimeLimitTracker({ electionHash }: Props): JSX.Element {
-  const authStatusQuery = getAuthStatus.useQuery(electionHash);
-  const logOutMutation = logOut.useMutation(electionHash);
-  const updateSessionExpiryMutation =
-    updateSessionExpiry.useMutation(electionHash);
+export function SessionTimeLimitTracker(): JSX.Element {
+  const authStatusQuery = getAuthStatus.useQuery();
+  const logOutMutation = logOut.useMutation();
+  const updateSessionExpiryMutation = updateSessionExpiry.useMutation();
 
   return (
     <SessionTimeLimitTrackerBase

--- a/apps/mark/frontend/src/pages/poll_worker_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.test.tsx
@@ -91,7 +91,7 @@ function renderScreen(
 
 test('renders PollWorkerScreen in MarkAndPrint app mode', () => {
   apiMock.mockApiClient.readScannerReportDataFromCard
-    .expectCallWith({ electionHash: electionSampleDefinition.electionHash })
+    .expectCallWith()
     .resolves(ok(undefined));
   renderScreen(undefined, undefined, undefined);
   screen.getByText('Poll Worker Actions');
@@ -102,7 +102,7 @@ test('renders PollWorkerScreen in MarkAndPrint app mode', () => {
 
 test('renders PollWorkerScreen', () => {
   apiMock.mockApiClient.readScannerReportDataFromCard
-    .expectCallWith({ electionHash: electionSampleDefinition.electionHash })
+    .expectCallWith()
     .resolves(ok(undefined));
   renderScreen();
   screen.getByText('Poll Worker Actions');
@@ -114,7 +114,7 @@ test('switching out of test mode on election day', () => {
     date: new Date().toISOString(),
   });
   apiMock.mockApiClient.readScannerReportDataFromCard
-    .expectCallWith({ electionHash: electionDefinition.electionHash })
+    .expectCallWith()
     .resolves(ok(undefined));
   const enableLiveMode = jest.fn();
   renderScreen({
@@ -136,7 +136,7 @@ test('keeping test mode on election day', () => {
     date: new Date().toISOString(),
   });
   apiMock.mockApiClient.readScannerReportDataFromCard
-    .expectCallWith({ electionHash: electionDefinition.electionHash })
+    .expectCallWith()
     .resolves(ok(undefined));
   const enableLiveMode = jest.fn();
   renderScreen({ electionDefinition, enableLiveMode });
@@ -150,7 +150,7 @@ test('keeping test mode on election day', () => {
 
 test('live mode on election day', () => {
   apiMock.mockApiClient.readScannerReportDataFromCard
-    .expectCallWith({ electionHash: electionSampleDefinition.electionHash })
+    .expectCallWith()
     .resolves(ok(undefined));
   renderScreen({ isLiveMode: true });
   expect(
@@ -162,7 +162,7 @@ test('live mode on election day', () => {
 
 test('navigates to System Diagnostics screen', () => {
   apiMock.mockApiClient.readScannerReportDataFromCard
-    .expectCallWith({ electionHash: electionSampleDefinition.electionHash })
+    .expectCallWith()
     .resolves(ok(undefined));
   const { unmount } = renderScreen();
 
@@ -182,7 +182,7 @@ test('navigates to System Diagnostics screen', () => {
 
 test('requires confirmation to open polls if no report on card', () => {
   apiMock.mockApiClient.readScannerReportDataFromCard
-    .expectCallWith({ electionHash: electionSampleDefinition.electionHash })
+    .expectCallWith()
     .resolves(ok(undefined));
   const updatePollsState = jest.fn();
   renderScreen({
@@ -208,7 +208,7 @@ test('requires confirmation to open polls if no report on card', () => {
 
 test('can toggle between vote activation and "other actions" during polls open', async () => {
   apiMock.mockApiClient.readScannerReportDataFromCard
-    .expectCallWith({ electionHash: electionSampleDefinition.electionHash })
+    .expectCallWith()
     .resolves(ok(undefined));
   renderScreen({
     pollsState: 'polls_open',

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -155,7 +155,7 @@ function ScannerReportModal({
   );
 
   const clearScannerReportDataFromCardMutation =
-    clearScannerReportDataFromCard.useMutation(electionDefinition.electionHash);
+    clearScannerReportDataFromCard.useMutation();
 
   async function printReport(copies: number) {
     const report = await (async () => {
@@ -478,12 +478,12 @@ export function PollWorkerScreen({
   reload,
   logger,
 }: PollworkerScreenProps): JSX.Element {
-  const { election, electionHash } = electionDefinition;
+  const { election } = electionDefinition;
   const electionDate = DateTime.fromISO(electionDefinition.election.date);
   const isElectionDay = electionDate.hasSame(DateTime.now(), 'day');
 
   const scannerReportDataFromCardQuery =
-    getScannerReportDataFromCard.useQuery(electionHash);
+    getScannerReportDataFromCard.useQuery();
   const [scannerReportDataToBePrinted, setScannerReportDataToBePrinted] =
     useState<ScannerReportData>();
 

--- a/apps/mark/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/mark/frontend/test/helpers/mock_api_client.tsx
@@ -104,7 +104,7 @@ export function createApiMock() {
 
       if (isScannerReportDataReadExpected) {
         mockApiClient.readScannerReportDataFromCard
-          .expectCallWith({ electionHash })
+          .expectCallWith()
           .resolves(scannerReportDataReadResult);
       }
 


### PR DESCRIPTION
_Easiest reviewed by commit_

## Overview

Now that VxMark persists the election definition on the backend (thanks Kevin!), we can pull election hash from the backend store for auth calls, instead of having the frontend provide it. This simplifies the code quite a bit and makes VxMark better match the other machines.

Tackling this as a precursor to VxMark jurisdiction state management.

## Testing

- [x] Updated automated tests
- [x] Tested manually

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A