### PR TITLE
[libs/ui] Add TabBar component for the display settings screen

### DIFF
--- a/libs/ui/src/display_settings/tab_bar.test.tsx
+++ b/libs/ui/src/display_settings/tab_bar.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { render, screen, within } from '../../test/react_testing_library';
+import { TabBar } from './tab_bar';
+import { SettingsPaneId } from './types';
+
+test('renders all available display settings tabs', () => {
+  render(<TabBar activePaneId="displaySettingsSize" onChange={jest.fn()} />);
+
+  const tabList = screen.getByRole('tablist', { name: 'Display settings' });
+  within(tabList).getByRole('tab', { name: 'Color', selected: false });
+  within(tabList).getByRole('tab', { name: 'Text Size', selected: true });
+});
+
+test('fires change event with settings pane id', () => {
+  const onChange = jest.fn();
+  render(<TabBar activePaneId="displaySettingsSize" onChange={onChange} />);
+
+  expect(onChange).not.toHaveBeenCalled();
+
+  userEvent.click(screen.getByRole('tab', { name: 'Color', selected: false }));
+
+  expect(onChange).toHaveBeenCalledWith<[SettingsPaneId]>(
+    'displaySettingsColor'
+  );
+});

--- a/libs/ui/src/display_settings/tab_bar.tsx
+++ b/libs/ui/src/display_settings/tab_bar.tsx
@@ -1,0 +1,72 @@
+/* stylelint-disable order/properties-order */
+import React from 'react';
+import styled from 'styled-components';
+
+import { PANE_IDS, SettingsPaneId } from './types';
+import { Icons } from '../icons';
+import { Button } from '../button';
+
+export interface TabBarProps {
+  activePaneId: SettingsPaneId;
+  onChange: (selectedPaneId: SettingsPaneId) => void;
+}
+
+const Container = styled.div`
+  border-bottom: ${(p) => p.theme.sizes.bordersRem.hairline}rem dotted
+    ${(p) => p.theme.colors.foreground};
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.25rem 0.5rem 0.75rem;
+
+  & > * {
+    max-width: ${100 / PANE_IDS.length}%;
+    min-width: min-content;
+  }
+`;
+
+const TabLabel = styled.span`
+  align-items: center;
+  display: flex;
+  gap: 0.4rem;
+  text-align: left;
+`;
+
+const TAB_LABELS: Record<SettingsPaneId, JSX.Element> = {
+  displaySettingsColor: (
+    <React.Fragment>
+      <Icons.Contrast /> <span>Color</span>
+    </React.Fragment>
+  ),
+  displaySettingsSize: (
+    <React.Fragment>
+      <Icons.TextSize /> <span>Text Size</span>
+    </React.Fragment>
+  ),
+};
+
+/**
+ * TODO: Not fully accessible yet - need to set tabIndex to -1 for all
+ * unselected tabs and manually handle arrow keys cycling through the tabs.
+ */
+export function TabBar(props: TabBarProps): JSX.Element {
+  const { activePaneId, onChange } = props;
+
+  return (
+    <Container aria-label="Display settings" role="tablist">
+      {[...PANE_IDS].map((paneId) => (
+        <Button
+          aria-controls={paneId}
+          aria-selected={activePaneId === paneId}
+          key={paneId}
+          onPress={onChange}
+          role="tab"
+          value={paneId}
+          variant={activePaneId === paneId ? 'primary' : 'regular'}
+        >
+          <TabLabel>{TAB_LABELS[paneId]}</TabLabel>
+        </Button>
+      ))}
+    </Container>
+  );
+}

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -5,6 +5,7 @@ import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faCheckCircle,
+  faCircleHalfStroke,
   faCircleLeft,
   faCircleRight,
   faDeleteLeft,
@@ -18,6 +19,7 @@ import {
   faXmark,
   faMagnifyingGlassPlus,
   faMagnifyingGlassMinus,
+  faTextHeight,
   faBan,
 } from '@fortawesome/free-solid-svg-icons';
 import {
@@ -72,6 +74,10 @@ export const Icons = {
     return <FaIcon type={faMinusCircle} />;
   },
 
+  Contrast(): JSX.Element {
+    return <FaIcon type={faCircleHalfStroke} />;
+  },
+
   Danger(): JSX.Element {
     return <FaIcon type={faExclamationCircle} />;
   },
@@ -114,6 +120,10 @@ export const Icons = {
 
   Settings(): JSX.Element {
     return <FaIcon type={faGear} />;
+  },
+
+  TextSize(): JSX.Element {
+    return <FaIcon type={faTextHeight} />;
   },
 
   Warning(): JSX.Element {


### PR DESCRIPTION
## Overview

Adding the `TabBar` subcomponent for the upcoming display settings screen.

Renders tabs as detached `Button`s, since VVSG 2.0 requires a minimum amount of separation between touch targets.

## Demo Video or Screenshot
### In Context:
https://user-images.githubusercontent.com/264902/234335868-6ce7667d-b3ee-45fb-8c5b-54f311188b33.mov

## Testing Plan
- Unit tests to verify a11y and event handling
- Visual testing in context

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
