### PR TITLE
[libs/ui] Add DisplaySettings component

### DIFF
--- a/apps/mark/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
@@ -188,7 +188,7 @@ exports[`Single Seat Contest 1`] = `
   tabindex="-1"
 >
   <div
-    class="sc-jObXwK fVjSuM"
+    class="sc-clIAKW iOFdCU"
   >
     <div
       class="c1"
@@ -213,7 +213,7 @@ exports[`Single Seat Contest 1`] = `
       </div>
     </div>
     <main
-      class="sc-dPiKHq iTRmFc"
+      class="sc-faUofl iEqEvY"
     >
       <div
         class="c2"

--- a/apps/mark/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
@@ -236,7 +236,7 @@ exports[`Single Seat Contest 1`] = `
   tabindex="-1"
 >
   <div
-    class="sc-jObXwK fVjSuM"
+    class="sc-clIAKW iOFdCU"
   >
     <div
       class="c1"
@@ -261,7 +261,7 @@ exports[`Single Seat Contest 1`] = `
       </div>
     </div>
     <main
-      class="sc-dPiKHq iTRmFc"
+      class="sc-faUofl iEqEvY"
     >
       <div
         class="c2"

--- a/apps/mark/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
@@ -236,7 +236,7 @@ exports[`Single Seat Contest 1`] = `
   tabindex="-1"
 >
   <div
-    class="sc-jObXwK fVjSuM"
+    class="sc-clIAKW iOFdCU"
   >
     <div
       class="c1"
@@ -261,7 +261,7 @@ exports[`Single Seat Contest 1`] = `
       </div>
     </div>
     <main
-      class="sc-dPiKHq iTRmFc"
+      class="sc-faUofl iEqEvY"
     >
       <div
         class="c2"

--- a/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
@@ -188,7 +188,7 @@ exports[`Single Seat Contest with Write In 1`] = `
   tabindex="-1"
 >
   <div
-    class="sc-jObXwK fVjSuM"
+    class="sc-clIAKW iOFdCU"
   >
     <div
       class="c1"
@@ -213,7 +213,7 @@ exports[`Single Seat Contest with Write In 1`] = `
       </div>
     </div>
     <main
-      class="sc-dPiKHq iTRmFc"
+      class="sc-faUofl iEqEvY"
     >
       <div
         class="c2"

--- a/apps/mark/frontend/src/components/__snapshots__/yes_no_contest.test.tsx.snap
+++ b/apps/mark/frontend/src/components/__snapshots__/yes_no_contest.test.tsx.snap
@@ -124,7 +124,7 @@ exports[`supports yes/no contest allows voting for both yes and no 1`] = `
 
 <div>
   <main
-    class="sc-dPiKHq iTRmFc"
+    class="sc-faUofl iEqEvY"
   >
     <div
       class="c0"
@@ -423,7 +423,7 @@ exports[`supports yes/no contest displays warning when attempting to change vote
 
 <div>
   <main
-    class="sc-dPiKHq iTRmFc"
+    class="sc-faUofl iEqEvY"
   >
     <div
       class="c0"

--- a/apps/mark/frontend/src/pages/__snapshots__/cast_ballot_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/cast_ballot_page.test.tsx.snap
@@ -38,10 +38,10 @@ exports[`renders CastBallotPage 1`] = `
 }
 
 <div
-  class="sc-jObXwK fsbztL"
+  class="sc-clIAKW kmQKez"
 >
   <main
-    class="sc-dPiKHq iNXixc"
+    class="sc-faUofl dztJPY"
   >
     <div
       class="sc-fotPbf iNBQun"

--- a/apps/mark/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
@@ -177,7 +177,7 @@ exports[`Renders ContestPage 1`] = `
 
 <div>
   <div
-    class="sc-jObXwK fVjSuM"
+    class="sc-clIAKW iOFdCU"
   >
     <div
       class="c0"
@@ -202,7 +202,7 @@ exports[`Renders ContestPage 1`] = `
       </div>
     </div>
     <main
-      class="sc-dPiKHq iTRmFc"
+      class="sc-faUofl iEqEvY"
     >
       <div
         class="c1"
@@ -701,10 +701,10 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
 
 <div>
   <div
-    class="sc-jObXwK fzGfcs"
+    class="sc-clIAKW gtMbaI"
   >
     <main
-      class="sc-dPiKHq iTRmFc"
+      class="sc-faUofl iEqEvY"
     >
       <div
         class="c0"

--- a/apps/mark/frontend/src/pages/__snapshots__/not_found_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/not_found_page.test.tsx.snap
@@ -2,10 +2,10 @@
 
 exports[`renders NotFoundPage 1`] = `
 <div
-  class="sc-jObXwK fVjSuM"
+  class="sc-clIAKW iOFdCU"
 >
   <main
-    class="sc-dPiKHq iNXixc"
+    class="sc-faUofl dztJPY"
   >
     <div
       class="sc-fotPbf ljYHag"

--- a/apps/mark/frontend/src/pages/__snapshots__/start_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/start_page.test.tsx.snap
@@ -103,10 +103,10 @@ exports[`renders StartPage 1`] = `
 }
 
 <div
-  class="sc-jObXwK fVjSuM"
+  class="sc-clIAKW iOFdCU"
 >
   <main
-    class="sc-dPiKHq oFCMn"
+    class="sc-faUofl bPNoEL"
   >
     <div
       aria-hidden="false"
@@ -351,10 +351,10 @@ exports[`renders StartPage with inline SVG 1`] = `
 }
 
 <div
-  class="sc-jObXwK fVjSuM"
+  class="sc-clIAKW iOFdCU"
 >
   <main
-    class="sc-dPiKHq oFCMn"
+    class="sc-faUofl bPNoEL"
   >
     <div
       aria-hidden="false"
@@ -757,10 +757,10 @@ exports[`renders StartPage with no seal 1`] = `
 }
 
 <div
-  class="sc-jObXwK fVjSuM"
+  class="sc-clIAKW iOFdCU"
 >
   <main
-    class="sc-dPiKHq oFCMn"
+    class="sc-faUofl bPNoEL"
   >
     <div
       aria-hidden="false"

--- a/libs/ui/src/display_settings/color_settings.tsx
+++ b/libs/ui/src/display_settings/color_settings.tsx
@@ -20,9 +20,9 @@ const DEFAULT_COLOR_MODES: ColorMode[] = [
 
 const ORDERED_COLOR_MODE_LABELS: Record<ColorMode, string> = {
   contrastHighDark: 'White text on black background',
-  contrastHighLight: 'Black text on white background',
   contrastLow: 'Gray text on dark background',
   contrastMedium: 'Dark text on light background',
+  contrastHighLight: 'Black text on white background',
   legacy: 'DEV ONLY: Pre-VVSG styling',
 };
 

--- a/libs/ui/src/display_settings/display_settings.stories.tsx
+++ b/libs/ui/src/display_settings/display_settings.stories.tsx
@@ -1,0 +1,15 @@
+import { Meta } from '@storybook/react';
+
+import { DisplaySettings } from '.';
+
+const meta: Meta<typeof DisplaySettings> = {
+  title: 'libs-ui/DisplaySettings',
+  component: DisplaySettings,
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+
+export { DisplaySettings };

--- a/libs/ui/src/display_settings/display_settings.test.tsx
+++ b/libs/ui/src/display_settings/display_settings.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { ThemeConsumer } from 'styled-components';
+import { UiTheme } from '@votingworks/types';
+import { render, screen } from '../../test/react_testing_library';
+import { DisplaySettings } from '.';
+
+test('renders expected subcomponents', () => {
+  render(<DisplaySettings onClose={jest.fn()} />);
+
+  screen.getByRole('heading', { name: 'Display Settings' });
+  screen.getByRole('tablist', { name: 'Display settings' });
+  screen.getByRole('tabpanel');
+  screen.getByRole('radiogroup', { name: 'Color Contrast Settings' });
+});
+
+test('changes tab pane on tab bar events', () => {
+  render(<DisplaySettings onClose={jest.fn()} />);
+
+  screen.getByRole('radiogroup', { name: 'Color Contrast Settings' });
+
+  userEvent.click(screen.getByRole('tab', { name: /size/i }));
+
+  screen.getByRole('radiogroup', { name: 'Text Size Settings' });
+});
+
+test('resets button resets global theme', () => {
+  let currentTheme: UiTheme | null = null;
+
+  function TestComponent(): JSX.Element {
+    return (
+      <ThemeConsumer>
+        {(theme) => {
+          currentTheme = theme;
+          return <DisplaySettings onClose={jest.fn()} />;
+        }}
+      </ThemeConsumer>
+    );
+  }
+
+  render(<TestComponent />, {
+    vxTheme: { colorMode: 'contrastHighDark', sizeMode: 'l' },
+  });
+
+  expect(currentTheme).toEqual(
+    expect.objectContaining<Partial<UiTheme>>({
+      colorMode: 'contrastHighDark',
+      sizeMode: 'l',
+    })
+  );
+
+  userEvent.click(screen.getByRole('tab', { name: /color/i }));
+  userEvent.click(screen.getByRole('radio', { name: /gray text/i }));
+
+  userEvent.click(screen.getByRole('tab', { name: /size/i }));
+  userEvent.click(screen.getByRole('radio', { name: /small/i }));
+
+  expect(currentTheme).toEqual(
+    expect.objectContaining<Partial<UiTheme>>({
+      colorMode: 'contrastLow',
+      sizeMode: 's',
+    })
+  );
+
+  userEvent.click(screen.getButton('Reset'));
+
+  expect(currentTheme).toEqual(
+    expect.objectContaining<Partial<UiTheme>>({
+      colorMode: 'contrastHighDark',
+      sizeMode: 'l',
+    })
+  );
+});
+
+test('done button fires onClose event', () => {
+  const onClose = jest.fn();
+  render(<DisplaySettings onClose={onClose} />);
+
+  expect(onClose).not.toHaveBeenCalled();
+
+  userEvent.click(screen.getButton('Done'));
+
+  expect(onClose).toHaveBeenCalled();
+});

--- a/libs/ui/src/display_settings/index.tsx
+++ b/libs/ui/src/display_settings/index.tsx
@@ -1,0 +1,79 @@
+/* stylelint-disable order/properties-order */
+import React from 'react';
+import styled from 'styled-components';
+
+import { SettingsPaneId } from './types';
+import { TabBar } from './tab_bar';
+import { ColorSettings, ColorSettingsProps } from './color_settings';
+import { SizeSettings, SizeSettingsProps } from './size_settings';
+import { H1 } from '../typography';
+import { Button } from '../button';
+import { ThemeManagerContext } from '../theme_manager_context';
+
+export interface DisplaySettingsProps {
+  /** @default ['contrastLow', 'contrastMedium', 'contrastHighLight', 'contrastHighDark'] */
+  colorModes?: ColorSettingsProps['colorModes'];
+  onClose: () => void;
+  /** @default ['s', 'm', 'l', 'xl'] */
+  sizeModes?: SizeSettingsProps['sizeModes'];
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+`;
+
+const Header = styled.div`
+  padding: 0.5rem 0.5rem 0.125rem;
+`;
+
+const ActivePaneContainer = styled.div`
+  flex-grow: 1;
+`;
+
+const Footer = styled.div`
+  display: flex;
+  gap: 0.5rem;
+  justify-content: end;
+  padding: 0.25rem 0.5rem 0.5rem;
+`;
+
+/**
+ * Display setting controls for VxSuite apps.
+ *
+ * These settings modify the active UI theme used by components in libs/ui, as
+ * well as theme-dependent global styles.
+ */
+export function DisplaySettings(props: DisplaySettingsProps): JSX.Element {
+  const { colorModes, onClose, sizeModes } = props;
+
+  const [activePaneId, setActivePaneId] = React.useState<SettingsPaneId>(
+    'displaySettingsColor'
+  );
+
+  const { resetThemes } = React.useContext(ThemeManagerContext);
+
+  return (
+    <Container>
+      <Header>
+        <H1>Display Settings</H1>
+      </Header>
+      <TabBar activePaneId={activePaneId} onChange={setActivePaneId} />
+      <ActivePaneContainer>
+        {activePaneId === 'displaySettingsColor' && (
+          <ColorSettings colorModes={colorModes} />
+        )}
+        {activePaneId === 'displaySettingsSize' && (
+          <SizeSettings sizeModes={sizeModes} />
+        )}
+      </ActivePaneContainer>
+      <Footer>
+        <Button onPress={resetThemes}>Reset</Button>
+        <Button onPress={onClose} variant="done">
+          Done
+        </Button>
+      </Footer>
+    </Container>
+  );
+}

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -10,6 +10,7 @@ export * from './card';
 export * from './centered_large_prose';
 export * from './contest_tally';
 export * from './contest_writein_tally';
+export * from './display_settings';
 export * from './error_boundary';
 export * from './election_info_bar';
 export * from './global_styles';


### PR DESCRIPTION
## Overview

_1st commit has relevant changes - 2nd commit is just unrelated test snapshot updates_

Adding the `DisplaySettings` component for modifying the active UI theme. Intended to be rendered as a fullscreen component within VxSuite apps.

Ties together the previously added `ColorSettings` and `SizeSettings` subcomponents and includes a "Reset" button to return the UI to the default theme specified by the app in `AppBase`

Also sneaking in a quick fix to the color settings ordering (meant to go from darkest to lightest).

## Demo Video or Screenshot

https://user-images.githubusercontent.com/264902/234351430-657ce2ef-8fdb-488b-97b0-c86763d9f6d2.mov

## Testing Plan
- Unit tests for proper rendering and event handling
- Visual testing for ELO screen fit

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
