### PR TITLE
Add jurisdiction state management to VxMark

### DIFF
--- a/apps/mark/backend/schema.sql
+++ b/apps/mark/backend/schema.sql
@@ -2,6 +2,7 @@ create table election (
   -- enforce singleton table
   id integer primary key check (id = 1),
   election_data text not null,
+  jurisdiction text not null,
   created_at timestamp not null default current_timestamp
 );
 

--- a/apps/mark/backend/src/app.auth.test.ts
+++ b/apps/mark/backend/src/app.auth.test.ts
@@ -96,9 +96,7 @@ test('getAuthStatus before election definition has been configured', async () =>
 
   await apiClient.getAuthStatus();
   expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(1);
-  expect(mockAuth.getAuthStatus).toHaveBeenNthCalledWith(1, {
-    jurisdiction,
-  });
+  expect(mockAuth.getAuthStatus).toHaveBeenNthCalledWith(1, {});
 });
 
 test('checkPin before election definition has been configured', async () => {
@@ -106,11 +104,7 @@ test('checkPin before election definition has been configured', async () => {
 
   await apiClient.checkPin({ pin: '123456' });
   expect(mockAuth.checkPin).toHaveBeenCalledTimes(1);
-  expect(mockAuth.checkPin).toHaveBeenNthCalledWith(
-    1,
-    { jurisdiction },
-    { pin: '123456' }
-  );
+  expect(mockAuth.checkPin).toHaveBeenNthCalledWith(1, {}, { pin: '123456' });
 });
 
 test('logOut before election definition has been configured', async () => {
@@ -118,9 +112,7 @@ test('logOut before election definition has been configured', async () => {
 
   await apiClient.logOut();
   expect(mockAuth.logOut).toHaveBeenCalledTimes(1);
-  expect(mockAuth.logOut).toHaveBeenNthCalledWith(1, {
-    jurisdiction,
-  });
+  expect(mockAuth.logOut).toHaveBeenNthCalledWith(1, {});
 });
 
 test('updateSessionExpiry before election definition has been configured', async () => {
@@ -132,7 +124,7 @@ test('updateSessionExpiry before election definition has been configured', async
   expect(mockAuth.updateSessionExpiry).toHaveBeenCalledTimes(1);
   expect(mockAuth.updateSessionExpiry).toHaveBeenNthCalledWith(
     1,
-    { jurisdiction },
+    {},
     { sessionExpiresAt: expect.any(Date) }
   );
 });
@@ -147,7 +139,7 @@ test('startCardlessVoterSession before election definition has been configured',
   expect(mockAuth.startCardlessVoterSession).toHaveBeenCalledTimes(1);
   expect(mockAuth.startCardlessVoterSession).toHaveBeenNthCalledWith(
     1,
-    { jurisdiction },
+    {},
     { ballotStyleId: 'b1', precinctId: 'p1' }
   );
 });
@@ -157,7 +149,5 @@ test('endCardlessVoterSession before election definition has been configured', a
 
   await apiClient.endCardlessVoterSession();
   expect(mockAuth.endCardlessVoterSession).toHaveBeenCalledTimes(1);
-  expect(mockAuth.endCardlessVoterSession).toHaveBeenNthCalledWith(1, {
-    jurisdiction,
-  });
+  expect(mockAuth.endCardlessVoterSession).toHaveBeenNthCalledWith(1, {});
 });

--- a/apps/mark/backend/src/app.test.ts
+++ b/apps/mark/backend/src/app.test.ts
@@ -259,8 +259,9 @@ test('configureBallotPackageFromUsb returns an error if ballot package parsing f
   expect(result.err()).toEqual('auth_required_before_ballot_package_load');
 });
 
-test('configureSampleBallotPackage configures electionSampleDefinition and DEFAULT_SYSTEM_SETTINGS', async () => {
-  const writeResult = await apiClient.configureSampleBallotPackage();
+test('configureWithSampleBallotPackageForIntegrationTest configures electionSampleDefinition and DEFAULT_SYSTEM_SETTINGS', async () => {
+  const writeResult =
+    await apiClient.configureWithSampleBallotPackageForIntegrationTest();
   assert(writeResult.isOk());
 
   const readResult = await apiClient.getSystemSettings();

--- a/apps/mark/backend/src/store.test.ts
+++ b/apps/mark/backend/src/store.test.ts
@@ -1,10 +1,13 @@
 import { safeParseSystemSettings } from '@votingworks/utils';
 import { electionMinimalExhaustiveSampleFixtures } from '@votingworks/fixtures';
 import { SystemSettings } from '@votingworks/types';
+import { DEV_JURISDICTION } from '@votingworks/auth';
 import { Store } from './store';
 
 // We pause in some of these tests so we need to increase the timeout
 jest.setTimeout(20000);
+
+const jurisdiction = DEV_JURISDICTION;
 
 test('getDbPath', () => {
   const store = Store.memoryStore();
@@ -19,11 +22,14 @@ test('get/set/has election', () => {
   expect(store.getElectionDefinition()).toBeUndefined();
   expect(store.hasElection()).toBeFalsy();
 
-  store.setElection(electionDefinition.electionData);
+  store.setElectionAndJurisdiction({
+    electionData: electionDefinition.electionData,
+    jurisdiction,
+  });
   expect(store.getElectionDefinition()?.election).toEqual(election);
   expect(store.hasElection()).toBeTruthy();
 
-  store.setElection(undefined);
+  store.setElectionAndJurisdiction(undefined);
   expect(store.getElectionDefinition()).toBeUndefined();
 });
 
@@ -64,7 +70,10 @@ test('setSystemSettings can handle boolean values in input', () => {
 
 test('errors when election definition cannot be parsed', () => {
   const store = Store.memoryStore();
-  store.setElection('{malformed json');
+  store.setElectionAndJurisdiction({
+    electionData: '{malformed json',
+    jurisdiction,
+  });
   expect(() => store.getElectionDefinition()).toThrow(
     'Unable to parse stored election data.'
   );
@@ -74,7 +83,10 @@ test('reset clears the database', () => {
   const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
   const store = Store.memoryStore();
 
-  store.setElection(electionDefinition.electionData);
+  store.setElectionAndJurisdiction({
+    electionData: electionDefinition.electionData,
+    jurisdiction,
+  });
   expect(store.hasElection()).toBeTruthy();
   store.reset();
   expect(store.hasElection()).toBeFalsy();

--- a/apps/mark/backend/src/store.ts
+++ b/apps/mark/backend/src/store.ts
@@ -82,14 +82,28 @@ export class Store {
   }
 
   /**
-   * Sets the current election definition.
+   * Gets the current jurisdiction.
    */
-  setElection(electionData?: string): void {
+  getJurisdiction(): string | undefined {
+    const electionRow = this.client.one('select jurisdiction from election') as
+      | { jurisdiction: string }
+      | undefined;
+    return electionRow?.jurisdiction;
+  }
+
+  /**
+   * Sets the current election definition and jurisdiction.
+   */
+  setElectionAndJurisdiction(input?: {
+    electionData: string;
+    jurisdiction: string;
+  }): void {
     this.client.run('delete from election');
-    if (electionData) {
+    if (input) {
       this.client.run(
-        'insert into election (election_data) values (?)',
-        electionData
+        'insert into election (election_data, jurisdiction) values (?, ?)',
+        input.electionData,
+        input.jurisdiction
       );
     }
   }

--- a/apps/mark/backend/test/app_helpers.ts
+++ b/apps/mark/backend/test/app_helpers.ts
@@ -1,5 +1,6 @@
 import {
   buildMockInsertedSmartCardAuth,
+  DEV_JURISDICTION,
   InsertedSmartCardAuthApi,
 } from '@votingworks/auth';
 import * as grout from '@votingworks/grout';
@@ -54,11 +55,13 @@ export async function configureApp(
   mockAuth: InsertedSmartCardAuthApi,
   mockUsb: MockUsb
 ): Promise<void> {
+  const jurisdiction = DEV_JURISDICTION;
   const { ballotPackage, electionDefinition } = electionFamousNames2021Fixtures;
+  const { electionHash } = electionDefinition;
   mockOf(mockAuth.getAuthStatus).mockImplementation(() =>
     Promise.resolve({
       status: 'logged_in',
-      user: fakeElectionManagerUser(electionDefinition),
+      user: fakeElectionManagerUser({ electionHash, jurisdiction }),
       sessionExpiresAt: fakeSessionExpiresAt(),
     })
   );

--- a/apps/mark/integration-testing/cypress/support/e2e.js
+++ b/apps/mark/integration-testing/cypress/support/e2e.js
@@ -86,7 +86,7 @@ function endCardlessVoterSession() {
 function configureWithSampleDefinitionAndSystemSettings() {
   cy.request(
     'POST',
-    methodUrl('configureSampleBallotPackage', 'http://localhost:3000/api'),
+    methodUrl('configureWithSampleBallotPackageForIntegrationTest', 'http://localhost:3000/api'),
     {}
   );
 }


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/2912

The VxMark equivalent of https://github.com/votingworks/vxsuite/pull/3348 for VxCentralScan. Largely copying from that PR's description:

This PR replaces the hardcoded dev jurisdiction in VxMark with proper jurisdiction state management. When the machine is configured, the jurisdiction will be set to the jurisdiction on the election manager card used to auth onto the machine. And when the machine is unconfigured, the jurisdiction will be cleared.

When a jurisdiction is set, the machine will only accept cards from that jurisdiction. And when no jurisdiction is set, the machine will accept cards from all jurisdictions. This logic already exists and lives in the auth lib.

## Testing

- [x] Updated automated tests
- [x] Manually tested that jurisdiction is set on configure
- [x] Manually tested that jurisdiction is cleared on unconfigure

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A