### PR TITLE
feat(basics): add early-return for `Result` functions

### DIFF
--- a/libs/basics/src/result.ts
+++ b/libs/basics/src/result.ts
@@ -50,11 +50,10 @@ class Ok<T> {
   }
 
   /**
-   * Returns the contained value. For use with `resultBlock` or
-   * `asyncResultBlock`.
+   * Returns the contained value.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  or<E>(ret: (error: E) => void): T {
+  okOrElse<E>(fn: (error: E) => void): T {
     return this.value;
   }
 
@@ -140,11 +139,12 @@ class Err<E> {
   }
 
   /**
-   * Calls `ret` with the contained error. For use with `resultBlock` or
-   * `asyncResultBlock`.
+   * Calls the given callback with the contained error.
    */
-  or(ret: (error: E) => never): never {
-    ret(this.error);
+  okOrElse(fn: (error: E) => never): never;
+  okOrElse<T>(fn: (error: E) => T): T;
+  okOrElse<T>(fn: (error: E) => T): T {
+    return fn(this.error);
   }
 
   /**

--- a/libs/basics/src/result.ts
+++ b/libs/basics/src/result.ts
@@ -50,6 +50,15 @@ class Ok<T> {
   }
 
   /**
+   * Returns the contained value. For use with `resultBlock` or
+   * `asyncResultBlock`.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  or<E>(ret: (error: E) => void): T {
+    return this.value;
+  }
+
+  /**
    * Returns the contained value.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -128,6 +137,14 @@ class Err<E> {
    */
   unsafeUnwrapErr(): E {
     return this.error;
+  }
+
+  /**
+   * Calls `ret` with the contained error. For use with `resultBlock` or
+   * `asyncResultBlock`.
+   */
+  or(ret: (error: E) => never): never {
+    ret(this.error);
   }
 
   /**
@@ -214,4 +231,88 @@ export type Result<T, E> = Ok<T> | Err<E>;
  */
 export function isResult(value: unknown): value is Result<unknown, unknown> {
   return value instanceof Ok || value instanceof Err;
+}
+
+class ResultBlockError<E> {
+  constructor(private readonly error: E) {}
+
+  err(): E {
+    return this.error;
+  }
+}
+
+/**
+ * Provides an early-return mechanism for functions that return `Result`s,
+ * similar to Rust's `?` operator. This is useful for avoiding `if` statements
+ * that check for errors and return early.
+ *
+ * Note that errors thrown are not caught by this function, so you should use
+ * standard try/catch blocks to catch thrown errors.
+ *
+ * @example
+ *
+ * ```ts
+ * function doSomething(): Result<string, Error> {
+ *   return resultBlock((ret) => {
+ *     const value = doSomethingThatMightFail().or(ret);
+ *     const value2 = doSomethingElseThatMightFail(value).or(ret);
+ *     return anotherThingThatMightFail(value2);
+ *   });
+ * }
+ * ```
+ */
+export function resultBlock<T, E>(
+  fn: (ret: (error: E) => never) => T | Result<T, E>
+): Result<T, E> {
+  function ret(error: E): never {
+    throw new ResultBlockError(error);
+  }
+
+  try {
+    const returnValue = fn(ret);
+    return isResult(returnValue) ? returnValue : ok(returnValue);
+  } catch (error) {
+    if (error instanceof ResultBlockError) {
+      return err(error.err());
+    }
+    throw error;
+  }
+}
+
+/**
+ * Provides an early-return mechanism for async functions that return `Result`s,
+ * similar to Rust's `?` operator. This is useful for avoiding `if` statements
+ * that check for errors and return early.
+ *
+ * Note that errors thrown are not caught by this function, so you should use
+ * standard try/catch blocks to catch thrown errors.
+ *
+ * @example
+ *
+ * ```ts
+ * function doSomething(): Promise<Result<string, Error>> {
+ *   return asyncResultBlock(async (ret) => {
+ *     const value = (await doSomethingThatMightFail()).or(ret);
+ *     const value2 = (await doSomethingElseThatMightFail(value)).or(ret);
+ *     return anotherThingThatMightFail(value2);
+ *   });
+ * }
+ * ```
+ */
+export async function asyncResultBlock<T, E>(
+  fn: (ret: (error: E) => never) => Promise<T | Result<T, E>>
+): Promise<Result<T, E>> {
+  function ret(error: E): never {
+    throw new ResultBlockError(error);
+  }
+
+  try {
+    const returnValue = await fn(ret);
+    return isResult(returnValue) ? returnValue : ok(returnValue);
+  } catch (error) {
+    if (error instanceof ResultBlockError) {
+      return err(error.err());
+    }
+    throw error;
+  }
 }

--- a/libs/message-coder/src/base_coder.ts
+++ b/libs/message-coder/src/base_coder.ts
@@ -1,4 +1,4 @@
-import { err, ok, Result } from '@votingworks/basics';
+import { err, ok, Result, resultBlock } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import { toByteLength } from './bits';
 import {
@@ -7,7 +7,6 @@ import {
   CoderError,
   DecodeResult,
   EncodeResult,
-  mapResult,
 } from './types';
 
 /**
@@ -30,12 +29,12 @@ export abstract class BaseCoder<T> implements Coder<T> {
   }
 
   decode(buffer: Buffer): Result<T, CoderError> {
-    return mapResult(this.decodeFrom(buffer, 0), ({ bitOffset, value }) => {
+    return resultBlock((ret) => {
+      const { bitOffset, value } = this.decodeFrom(buffer, 0).or(ret);
       if (toByteLength(bitOffset) !== buffer.byteLength) {
         return err('TrailingData');
       }
-
-      return ok(value);
+      return value;
     });
   }
 }

--- a/libs/message-coder/src/base_coder.ts
+++ b/libs/message-coder/src/base_coder.ts
@@ -29,8 +29,8 @@ export abstract class BaseCoder<T> implements Coder<T> {
   }
 
   decode(buffer: Buffer): Result<T, CoderError> {
-    return resultBlock((ret) => {
-      const { bitOffset, value } = this.decodeFrom(buffer, 0).or(ret);
+    return resultBlock((fail) => {
+      const { bitOffset, value } = this.decodeFrom(buffer, 0).okOrElse(fail);
       if (toByteLength(bitOffset) !== buffer.byteLength) {
         return err('TrailingData');
       }

--- a/libs/message-coder/src/fixed_string.ts
+++ b/libs/message-coder/src/fixed_string.ts
@@ -57,8 +57,8 @@ export class FixedStringCoder implements Coder<string> {
     // reverse because it's easier to allocate a buffer from a string using
     // `Buffer.byteLength` and `Buffer#write` in `encode` and to reuse that work
     // here.
-    return resultBlock((ret) => {
-      const bytes = this.encode(value).or(ret);
+    return resultBlock((fail) => {
+      const bytes = this.encode(value).okOrElse(fail);
       if (
         !bufferContainsBitOffset(
           buffer,
@@ -69,7 +69,7 @@ export class FixedStringCoder implements Coder<string> {
         return err('SmallBuffer');
       }
 
-      const byteOffset = toByteOffset(bitOffset).or(ret);
+      const byteOffset = toByteOffset(bitOffset).okOrElse(fail);
       return bitOffset + toBitOffset(bytes.copy(buffer, byteOffset));
     });
   }
@@ -88,12 +88,12 @@ export class FixedStringCoder implements Coder<string> {
   }
 
   decodeFrom(buffer: Buffer, bitOffset: BitOffset): DecodeResult<string> {
-    return resultBlock((ret) => {
+    return resultBlock((fail) => {
       if (!bufferContainsBitOffset(buffer, 0, toBitLength(this.byteLength))) {
         return err('SmallBuffer');
       }
 
-      const byteOffset = toByteOffset(bitOffset).or(ret);
+      const byteOffset = toByteOffset(bitOffset).okOrElse(fail);
       const string = buffer.toString(
         'utf8',
         byteOffset,

--- a/libs/message-coder/src/literal_coder.ts
+++ b/libs/message-coder/src/literal_coder.ts
@@ -32,18 +32,18 @@ export class LiteralCoder extends BaseCoder<void> {
   }
 
   encodeInto(_value: void, buffer: Buffer, bitOffset: BitOffset): EncodeResult {
-    return resultBlock((ret) => {
+    return resultBlock((fail) => {
       const { value } = this;
-      const byteOffset = toByteOffset(bitOffset).or(ret);
+      const byteOffset = toByteOffset(bitOffset).okOrElse(fail);
       buffer.set(value, byteOffset);
       return toBitLength(byteOffset + value.byteLength);
     });
   }
 
   decodeFrom(buffer: Buffer, bitOffset: BitOffset): DecodeResult<void> {
-    return resultBlock((ret) => {
+    return resultBlock((fail) => {
       const { value } = this;
-      const byteOffset = toByteOffset(bitOffset).or(ret);
+      const byteOffset = toByteOffset(bitOffset).okOrElse(fail);
       const data = buffer.slice(byteOffset, byteOffset + value.byteLength);
       if (!data.equals(value)) {
         return err('InvalidValue');

--- a/libs/message-coder/src/literal_coder.ts
+++ b/libs/message-coder/src/literal_coder.ts
@@ -1,8 +1,8 @@
-import { err, ok } from '@votingworks/basics';
+import { err, resultBlock } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import { BaseCoder } from './base_coder';
 import { toBitLength, toByteOffset } from './bits';
-import { BitOffset, DecodeResult, EncodeResult, mapResult } from './types';
+import { BitOffset, DecodeResult, EncodeResult } from './types';
 
 /**
  * A literal value in a message.
@@ -32,24 +32,26 @@ export class LiteralCoder extends BaseCoder<void> {
   }
 
   encodeInto(_value: void, buffer: Buffer, bitOffset: BitOffset): EncodeResult {
-    const { value } = this;
-    return mapResult(toByteOffset(bitOffset), (byteOffset) => {
+    return resultBlock((ret) => {
+      const { value } = this;
+      const byteOffset = toByteOffset(bitOffset).or(ret);
       buffer.set(value, byteOffset);
       return toBitLength(byteOffset + value.byteLength);
     });
   }
 
   decodeFrom(buffer: Buffer, bitOffset: BitOffset): DecodeResult<void> {
-    const { value } = this;
-    return mapResult(toByteOffset(bitOffset), (byteOffset) => {
+    return resultBlock((ret) => {
+      const { value } = this;
+      const byteOffset = toByteOffset(bitOffset).or(ret);
       const data = buffer.slice(byteOffset, byteOffset + value.byteLength);
       if (!data.equals(value)) {
         return err('InvalidValue');
       }
-      return ok({
+      return {
         value: undefined,
         bitOffset: toBitLength(byteOffset + value.byteLength),
-      });
+      };
     });
   }
 }

--- a/libs/message-coder/src/message_coder.ts
+++ b/libs/message-coder/src/message_coder.ts
@@ -101,7 +101,7 @@ class MessageCoder<P extends MessageCoderParts<object>>
     buffer: Buffer,
     initialBitOffset: BitOffset
   ): EncodeResult {
-    return resultBlock((ret) => {
+    return resultBlock((fail) => {
       let bitOffset = initialBitOffset;
 
       for (const [k, v] of Object.entries(this.parts)) {
@@ -110,7 +110,7 @@ class MessageCoder<P extends MessageCoderParts<object>>
           coder instanceof LiteralCoder || coder instanceof PaddingCoder
             ? coder.encodeInto(undefined, buffer, bitOffset)
             : coder.encodeInto(value[k], buffer, bitOffset)
-        ).or(ret);
+        ).okOrElse(fail);
       }
 
       return bitOffset;
@@ -121,14 +121,14 @@ class MessageCoder<P extends MessageCoderParts<object>>
     buffer: Buffer,
     initialBitOffset: BitOffset
   ): DecodeResult<ObjectFromParts<P>> {
-    return resultBlock((ret) => {
+    return resultBlock((fail) => {
       let bitOffset = initialBitOffset;
       const result: Record<string, unknown> = {};
       for (const [k, v] of Object.entries(this.parts)) {
         const coder = v as Coder<ObjectFromParts<P>[keyof ObjectFromParts<P>]>;
         const { value, bitOffset: nextOffset } = coder
           .decodeFrom(buffer, bitOffset)
-          .or(ret);
+          .okOrElse(fail);
 
         if (
           !(coder instanceof LiteralCoder) &&

--- a/libs/message-coder/src/message_coder.ts
+++ b/libs/message-coder/src/message_coder.ts
@@ -1,4 +1,4 @@
-import { ok } from '@votingworks/basics';
+import { resultBlock } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import { BaseCoder } from './base_coder';
 import { LiteralCoder } from './literal_coder';
@@ -101,49 +101,47 @@ class MessageCoder<P extends MessageCoderParts<object>>
     buffer: Buffer,
     initialBitOffset: BitOffset
   ): EncodeResult {
-    let bitOffset = initialBitOffset;
+    return resultBlock((ret) => {
+      let bitOffset = initialBitOffset;
 
-    for (const [k, v] of Object.entries(this.parts)) {
-      const coder = v as Coder<ObjectFromParts<P>[keyof ObjectFromParts<P>]>;
-      const encoded =
-        coder instanceof LiteralCoder || coder instanceof PaddingCoder
-          ? coder.encodeInto(undefined, buffer, bitOffset)
-          : coder.encodeInto(value[k], buffer, bitOffset);
-      if (encoded.isErr()) {
-        return encoded;
+      for (const [k, v] of Object.entries(this.parts)) {
+        const coder = v as Coder<ObjectFromParts<P>[keyof ObjectFromParts<P>]>;
+        bitOffset = (
+          coder instanceof LiteralCoder || coder instanceof PaddingCoder
+            ? coder.encodeInto(undefined, buffer, bitOffset)
+            : coder.encodeInto(value[k], buffer, bitOffset)
+        ).or(ret);
       }
-      bitOffset = encoded.ok();
-    }
 
-    return ok(bitOffset);
+      return bitOffset;
+    });
   }
 
   decodeFrom(
     buffer: Buffer,
     initialBitOffset: BitOffset
   ): DecodeResult<ObjectFromParts<P>> {
-    let bitOffset = initialBitOffset;
-    const result: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(this.parts)) {
-      const coder = v as Coder<ObjectFromParts<P>[keyof ObjectFromParts<P>]>;
-      const decodeResult = coder.decodeFrom(buffer, bitOffset);
-      if (decodeResult.isErr()) {
-        return decodeResult;
+    return resultBlock((ret) => {
+      let bitOffset = initialBitOffset;
+      const result: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(this.parts)) {
+        const coder = v as Coder<ObjectFromParts<P>[keyof ObjectFromParts<P>]>;
+        const { value, bitOffset: nextOffset } = coder
+          .decodeFrom(buffer, bitOffset)
+          .or(ret);
+
+        if (
+          !(coder instanceof LiteralCoder) &&
+          !(coder instanceof PaddingCoder)
+        ) {
+          result[k] = value;
+        }
+
+        bitOffset = nextOffset;
       }
 
-      const { value, bitOffset: nextOffset } = decodeResult.ok();
-
-      if (
-        !(coder instanceof LiteralCoder) &&
-        !(coder instanceof PaddingCoder)
-      ) {
-        result[k] = value;
-      }
-
-      bitOffset = nextOffset;
-    }
-
-    return ok({ value: result as ObjectFromParts<P>, bitOffset });
+      return { value: result as ObjectFromParts<P>, bitOffset };
+    });
   }
 }
 

--- a/libs/message-coder/src/types.ts
+++ b/libs/message-coder/src/types.ts
@@ -1,4 +1,4 @@
-import { isResult, ok, Result } from '@votingworks/basics';
+import { Result } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 
 /**
@@ -104,41 +104,6 @@ export interface Coder<T> {
    * @returns the decoded value and the bit offset after the decoded value
    */
   decodeFrom(buffer: Buffer, bitOffset: BitOffset): DecodeResult<T>;
-}
-
-/**
- * Maps a `Result` to a new `Result` by applying a function to a contained `Ok`
- * value, leaving an `Err` value untouched.
- */
-export function mapResult<T, U, E>(
-  result: Result<T, CoderError>,
-  fn: (value: T) => Result<U, E>
-): Result<U, CoderError | E>;
-
-/**
- * Maps a `Result` to a new `Result` by applying a function to a contained `Ok`
- * value and wrapping the result in an `Ok`, leaving an `Err` value untouched.
- */
-export function mapResult<T, U>(
-  result: Result<T, CoderError>,
-  fn: (value: T) => U
-): Result<U, CoderError>;
-
-/**
- * Maps a `Result` to a new `Result` by applying a function to a contained `Ok`
- * value and optionally wrapping the result in an `Ok`, leaving an `Err` value
- * untouched.
- */
-export function mapResult<T, U, E>(
-  result: Result<T, CoderError>,
-  fn: (value: T) => Result<U, E> | U
-): Result<U, CoderError | E> {
-  if (result.isErr()) {
-    return result;
-  }
-
-  const mapped = fn(result.ok());
-  return isResult(mapped) ? mapped : ok(mapped);
 }
 
 /**

--- a/libs/message-coder/src/uint16_coder.ts
+++ b/libs/message-coder/src/uint16_coder.ts
@@ -28,8 +28,8 @@ export class Uint16Coder extends UintCoder {
     buffer: Buffer,
     bitOffset: BitOffset
   ): EncodeResult {
-    return resultBlock((ret) => {
-      this.validateValue(value).or(ret);
+    return resultBlock((fail) => {
+      this.validateValue(value).okOrElse(fail);
 
       return this.encodeUsing(buffer, bitOffset, (byteOffset) =>
         buffer.writeUInt16LE(value, byteOffset)

--- a/libs/message-coder/src/uint16_coder.ts
+++ b/libs/message-coder/src/uint16_coder.ts
@@ -1,4 +1,5 @@
 import { Buffer } from 'buffer';
+import { resultBlock } from '@votingworks/basics';
 import { MAX_UINT16, MIN_UINT16 } from './constants';
 import {
   BitLength,
@@ -6,7 +7,6 @@ import {
   Coder,
   DecodeResult,
   EncodeResult,
-  mapResult,
   Uint16,
 } from './types';
 import { UintCoder } from './uint_coder';
@@ -28,11 +28,13 @@ export class Uint16Coder extends UintCoder {
     buffer: Buffer,
     bitOffset: BitOffset
   ): EncodeResult {
-    return mapResult(this.validateValue(value), () =>
-      this.encodeUsing(buffer, bitOffset, (byteOffset) =>
+    return resultBlock((ret) => {
+      this.validateValue(value).or(ret);
+
+      return this.encodeUsing(buffer, bitOffset, (byteOffset) =>
         buffer.writeUInt16LE(value, byteOffset)
-      )
-    );
+      );
+    });
   }
 
   decodeFrom(buffer: Buffer, bitOffset: BitOffset): DecodeResult<Uint16> {

--- a/libs/message-coder/src/uint24_coder.ts
+++ b/libs/message-coder/src/uint24_coder.ts
@@ -21,8 +21,8 @@ export class Uint24Coder extends UintCoder {
     buffer: Buffer,
     bitOffset: BitOffset
   ): EncodeResult {
-    return resultBlock((ret) => {
-      this.validateValue(value).or(ret);
+    return resultBlock((fail) => {
+      this.validateValue(value).okOrElse(fail);
 
       return this.encodeUsing(buffer, bitOffset, (byteOffset) => {
         const nextOffset = buffer.writeUInt16LE(value & 0xffff, byteOffset);

--- a/libs/message-coder/src/uint24_coder.ts
+++ b/libs/message-coder/src/uint24_coder.ts
@@ -1,13 +1,7 @@
+import { resultBlock } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import { MAX_UINT24, MIN_UINT24 } from './constants';
-import {
-  BitOffset,
-  Coder,
-  DecodeResult,
-  EncodeResult,
-  mapResult,
-  Uint24,
-} from './types';
+import { BitOffset, Coder, DecodeResult, EncodeResult, Uint24 } from './types';
 import { UintCoder } from './uint_coder';
 
 /**
@@ -27,12 +21,14 @@ export class Uint24Coder extends UintCoder {
     buffer: Buffer,
     bitOffset: BitOffset
   ): EncodeResult {
-    return mapResult(this.validateValue(value), () =>
-      this.encodeUsing(buffer, bitOffset, (byteOffset) => {
+    return resultBlock((ret) => {
+      this.validateValue(value).or(ret);
+
+      return this.encodeUsing(buffer, bitOffset, (byteOffset) => {
         const nextOffset = buffer.writeUInt16LE(value & 0xffff, byteOffset);
         return buffer.writeUInt8((value >> 16) & 0xff, nextOffset);
-      })
-    );
+      });
+    });
   }
 
   decodeFrom(buffer: Buffer, bitOffset: BitOffset): DecodeResult<Uint24> {

--- a/libs/message-coder/src/uint2_coder.ts
+++ b/libs/message-coder/src/uint2_coder.ts
@@ -32,8 +32,11 @@ class Uint2Coder extends BaseCoder<Uint2> {
   protected maxValue = 0b11;
 
   encodeInto(value: Uint2, buffer: Buffer, bitOffset: BitOffset): EncodeResult {
-    return resultBlock((ret) => {
-      const validatedValue = validateEnumValue(this.enumeration, value).or(ret);
+    return resultBlock((fail) => {
+      const validatedValue = validateEnumValue(
+        this.enumeration,
+        value
+      ).okOrElse(fail);
 
       if (validatedValue < this.minValue || validatedValue > this.maxValue) {
         return err('InvalidValue');
@@ -59,7 +62,7 @@ class Uint2Coder extends BaseCoder<Uint2> {
   }
 
   decodeFrom(buffer: Buffer, bitOffset: BitOffset): DecodeResult<Uint2> {
-    return resultBlock((ret) => {
+    return resultBlock((fail) => {
       const remainder = bitOffset % BITS_PER_BYTE;
 
       if (remainder + 1 >= BITS_PER_BYTE) {
@@ -76,7 +79,7 @@ class Uint2Coder extends BaseCoder<Uint2> {
       const value = validateEnumValue(
         this.enumeration,
         (byte & mask) >> shift
-      ).or(ret);
+      ).okOrElse(fail);
       return { value, bitOffset: bitOffset + this.bitLength() };
     });
   }

--- a/libs/message-coder/src/uint32_coder.ts
+++ b/libs/message-coder/src/uint32_coder.ts
@@ -1,3 +1,4 @@
+import { resultBlock } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import { MAX_UINT32, MIN_UINT32 } from './constants';
 import {
@@ -6,7 +7,6 @@ import {
   Coder,
   DecodeResult,
   EncodeResult,
-  mapResult,
   Uint32,
 } from './types';
 import { UintCoder } from './uint_coder';
@@ -28,11 +28,13 @@ export class Uint32Coder extends UintCoder {
     buffer: Buffer,
     bitOffset: BitOffset
   ): EncodeResult {
-    return mapResult(this.validateValue(value), () =>
-      this.encodeUsing(buffer, bitOffset, (byteOffset) =>
+    return resultBlock((ret) => {
+      this.validateValue(value).or(ret);
+
+      return this.encodeUsing(buffer, bitOffset, (byteOffset) =>
         buffer.writeUInt32LE(value, byteOffset)
-      )
-    );
+      );
+    });
   }
 
   decodeFrom(buffer: Buffer, bitOffset: BitOffset): DecodeResult<Uint32> {

--- a/libs/message-coder/src/uint32_coder.ts
+++ b/libs/message-coder/src/uint32_coder.ts
@@ -28,8 +28,8 @@ export class Uint32Coder extends UintCoder {
     buffer: Buffer,
     bitOffset: BitOffset
   ): EncodeResult {
-    return resultBlock((ret) => {
-      this.validateValue(value).or(ret);
+    return resultBlock((fail) => {
+      this.validateValue(value).okOrElse(fail);
 
       return this.encodeUsing(buffer, bitOffset, (byteOffset) =>
         buffer.writeUInt32LE(value, byteOffset)

--- a/libs/message-coder/src/uint4_coder.ts
+++ b/libs/message-coder/src/uint4_coder.ts
@@ -1,4 +1,4 @@
-import { err, ok } from '@votingworks/basics';
+import { err, resultBlock } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import { BaseCoder } from './base_coder';
 import { BITS_PER_BYTE, toByteOffset } from './bits';
@@ -8,7 +8,6 @@ import {
   Coder,
   DecodeResult,
   EncodeResult,
-  mapResult,
   Uint4,
 } from './types';
 import { defaultEnumValue, validateEnumValue } from './uint_coder';
@@ -33,55 +32,54 @@ export class Uint4Coder extends BaseCoder<Uint4> {
   protected maxValue = 0b1111;
 
   encodeInto(value: Uint4, buffer: Buffer, bitOffset: BitOffset): EncodeResult {
-    const validationResult = validateEnumValue(this.enumeration, value);
+    return resultBlock((ret) => {
+      const validatedValue = validateEnumValue(this.enumeration, value).or(ret);
 
-    if (validationResult.isErr()) {
-      return validationResult;
-    }
+      if (validatedValue < this.minValue || validatedValue > this.maxValue) {
+        return err('InvalidValue');
+      }
 
-    const validatedValue = validationResult.ok();
+      const remainder = bitOffset % BITS_PER_BYTE;
+      const isHigh = remainder === 0;
+      const isLow = remainder === 4;
 
-    if (validatedValue < this.minValue || validatedValue > this.maxValue) {
-      return err('InvalidValue');
-    }
+      if (!isHigh && !isLow) {
+        return err('UnsupportedOffset');
+      }
 
-    const remainder = bitOffset % BITS_PER_BYTE;
-    const isHigh = remainder === 0;
-    const isLow = remainder === 4;
-
-    if (!isHigh && !isLow) {
-      return err('UnsupportedOffset');
-    }
-
-    const byteOffset = toByteOffset(bitOffset - remainder).assertOk(
-      'subtracting remainder, which was checked above, should yield a valid byte offset'
-    );
-    const mask = isHigh ? 0x0f : 0xf0;
-    const shift = isHigh ? this.bitLength() : 0;
-    const byte = buffer.readUInt8(byteOffset);
-    const nextByte = (byte & mask) | ((validatedValue << shift) & ~mask);
-    buffer.writeUInt8(nextByte, byteOffset);
-    return ok(bitOffset + this.bitLength());
+      const byteOffset = toByteOffset(bitOffset - remainder).assertOk(
+        'subtracting remainder, which was checked above, should yield a valid byte offset'
+      );
+      const mask = isHigh ? 0x0f : 0xf0;
+      const shift = isHigh ? this.bitLength() : 0;
+      const byte = buffer.readUInt8(byteOffset);
+      const nextByte = (byte & mask) | ((validatedValue << shift) & ~mask);
+      buffer.writeUInt8(nextByte, byteOffset);
+      return bitOffset + this.bitLength();
+    });
   }
 
   decodeFrom(buffer: Buffer, bitOffset: BitOffset): DecodeResult<Uint4> {
-    const remainder = bitOffset % BITS_PER_BYTE;
-    const isHigh = remainder === 0;
-    const isLow = remainder === 4;
+    return resultBlock((ret) => {
+      const remainder = bitOffset % BITS_PER_BYTE;
+      const isHigh = remainder === 0;
+      const isLow = remainder === 4;
 
-    if (!isHigh && !isLow) {
-      return err('UnsupportedOffset');
-    }
+      if (!isHigh && !isLow) {
+        return err('UnsupportedOffset');
+      }
 
-    const byteOffset = toByteOffset(bitOffset - remainder).assertOk(
-      'subtracting remainder, which was checked above, should yield a valid byte offset'
-    );
-    const shift = isHigh ? this.bitLength() : 0;
-    const byte = buffer.readUInt8(byteOffset);
-    return mapResult(
-      validateEnumValue(this.enumeration, (byte >> shift) & 0xf),
-      (value) => ({ value, bitOffset: bitOffset + this.bitLength() })
-    );
+      const byteOffset = toByteOffset(bitOffset - remainder).assertOk(
+        'subtracting remainder, which was checked above, should yield a valid byte offset'
+      );
+      const shift = isHigh ? this.bitLength() : 0;
+      const byte = buffer.readUInt8(byteOffset);
+      const value = validateEnumValue(
+        this.enumeration,
+        (byte >> shift) & 0xf
+      ).or(ret);
+      return { value, bitOffset: bitOffset + this.bitLength() };
+    });
   }
 }
 

--- a/libs/message-coder/src/uint4_coder.ts
+++ b/libs/message-coder/src/uint4_coder.ts
@@ -32,8 +32,11 @@ export class Uint4Coder extends BaseCoder<Uint4> {
   protected maxValue = 0b1111;
 
   encodeInto(value: Uint4, buffer: Buffer, bitOffset: BitOffset): EncodeResult {
-    return resultBlock((ret) => {
-      const validatedValue = validateEnumValue(this.enumeration, value).or(ret);
+    return resultBlock((fail) => {
+      const validatedValue = validateEnumValue(
+        this.enumeration,
+        value
+      ).okOrElse(fail);
 
       if (validatedValue < this.minValue || validatedValue > this.maxValue) {
         return err('InvalidValue');
@@ -60,7 +63,7 @@ export class Uint4Coder extends BaseCoder<Uint4> {
   }
 
   decodeFrom(buffer: Buffer, bitOffset: BitOffset): DecodeResult<Uint4> {
-    return resultBlock((ret) => {
+    return resultBlock((fail) => {
       const remainder = bitOffset % BITS_PER_BYTE;
       const isHigh = remainder === 0;
       const isLow = remainder === 4;
@@ -77,7 +80,7 @@ export class Uint4Coder extends BaseCoder<Uint4> {
       const value = validateEnumValue(
         this.enumeration,
         (byte >> shift) & 0xf
-      ).or(ret);
+      ).okOrElse(fail);
       return { value, bitOffset: bitOffset + this.bitLength() };
     });
   }

--- a/libs/message-coder/src/uint8_coder.ts
+++ b/libs/message-coder/src/uint8_coder.ts
@@ -23,8 +23,8 @@ export class Uint8Coder extends UintCoder {
   protected maxValue = MAX_UINT8;
 
   encodeInto(value: Uint8, buffer: Buffer, bitOffset: BitOffset): EncodeResult {
-    return resultBlock((ret) => {
-      this.validateValue(value).or(ret);
+    return resultBlock((fail) => {
+      this.validateValue(value).okOrElse(fail);
 
       return this.encodeUsing(buffer, bitOffset, (byteOffset) =>
         buffer.writeUInt8(value, byteOffset)

--- a/libs/message-coder/src/uint8_coder.ts
+++ b/libs/message-coder/src/uint8_coder.ts
@@ -1,3 +1,4 @@
+import { resultBlock } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import { MAX_UINT8, MIN_UINT8 } from './constants';
 import {
@@ -6,7 +7,6 @@ import {
   Coder,
   DecodeResult,
   EncodeResult,
-  mapResult,
   Uint8,
 } from './types';
 import { UintCoder } from './uint_coder';
@@ -23,11 +23,13 @@ export class Uint8Coder extends UintCoder {
   protected maxValue = MAX_UINT8;
 
   encodeInto(value: Uint8, buffer: Buffer, bitOffset: BitOffset): EncodeResult {
-    return mapResult(this.validateValue(value), () =>
-      this.encodeUsing(buffer, bitOffset, (byteOffset) =>
+    return resultBlock((ret) => {
+      this.validateValue(value).or(ret);
+
+      return this.encodeUsing(buffer, bitOffset, (byteOffset) =>
         buffer.writeUInt8(value, byteOffset)
-      )
-    );
+      );
+    });
   }
 
   decodeFrom(buffer: Buffer, bitOffset: BitOffset): DecodeResult<Uint8> {

--- a/libs/message-coder/src/uint_coder.ts
+++ b/libs/message-coder/src/uint_coder.ts
@@ -1,5 +1,5 @@
+import { err, ok, Result, resultBlock } from '@votingworks/basics';
 import { Buffer } from 'buffer';
-import { err, ok, Result } from '@votingworks/basics';
 import { BaseCoder } from './base_coder';
 import { bufferContainsBitOffset, toByteOffset } from './bits';
 import {
@@ -9,7 +9,6 @@ import {
   CoderError,
   DecodeResult,
   EncodeResult,
-  mapResult,
 } from './types';
 
 /**
@@ -70,11 +69,12 @@ export abstract class UintCoder extends BaseCoder<number> {
     buffer: Buffer,
     bitOffset: BitOffset
   ): Result<number, CoderError> {
-    return mapResult(toByteOffset(bitOffset), (byteOffset) =>
-      bufferContainsBitOffset(buffer, bitOffset, this.bitLength())
+    return resultBlock((ret) => {
+      const byteOffset = toByteOffset(bitOffset).or(ret);
+      return bufferContainsBitOffset(buffer, bitOffset, this.bitLength())
         ? ok(byteOffset)
-        : err('SmallBuffer')
-    );
+        : err('SmallBuffer');
+    });
   }
 
   protected encodeUsing(
@@ -82,13 +82,11 @@ export abstract class UintCoder extends BaseCoder<number> {
     bitOffset: BitOffset,
     fn: (byteOffset: ByteOffset) => void
   ): EncodeResult {
-    return mapResult(
-      this.getByteOffset(buffer, bitOffset),
-      (byteOffset): Result<BitOffset, CoderError> => {
-        fn(byteOffset);
-        return ok(bitOffset + this.bitLength());
-      }
-    );
+    return resultBlock((ret) => {
+      const byteOffset = this.getByteOffset(buffer, bitOffset).or(ret);
+      fn(byteOffset);
+      return bitOffset + this.bitLength();
+    });
   }
 
   protected decodeUsing(
@@ -96,26 +94,23 @@ export abstract class UintCoder extends BaseCoder<number> {
     bitOffset: BitOffset,
     fn: (byteOffset: ByteOffset) => Result<number, CoderError>
   ): DecodeResult<number> {
-    return mapResult(
-      mapResult(this.getByteOffset(buffer, bitOffset), (byteOffset) =>
-        fn(byteOffset)
-      ),
-      (value) => ({ value, bitOffset: bitOffset + this.bitLength() })
-    );
+    return resultBlock((ret) => {
+      const byteOffset = this.getByteOffset(buffer, bitOffset).or(ret);
+      const value = fn(byteOffset).or(ret);
+      return { value, bitOffset: bitOffset + this.bitLength() };
+    });
   }
 
   protected validateValue(value: number): Result<number, CoderError> {
-    const enumValidationResult = validateEnumValue(this.enumeration, value);
+    return resultBlock((ret) => {
+      validateEnumValue(this.enumeration, value).or(ret);
 
-    if (enumValidationResult.isErr()) {
-      return enumValidationResult;
-    }
+      if (value < this.minValue || value > this.maxValue) {
+        return err('InvalidValue');
+      }
 
-    if (value < this.minValue || value > this.maxValue) {
-      return err('InvalidValue');
-    }
-
-    return ok(value);
+      return value;
+    });
   }
 
   abstract encodeInto(

--- a/libs/message-coder/src/uint_coder.ts
+++ b/libs/message-coder/src/uint_coder.ts
@@ -69,8 +69,8 @@ export abstract class UintCoder extends BaseCoder<number> {
     buffer: Buffer,
     bitOffset: BitOffset
   ): Result<number, CoderError> {
-    return resultBlock((ret) => {
-      const byteOffset = toByteOffset(bitOffset).or(ret);
+    return resultBlock((fail) => {
+      const byteOffset = toByteOffset(bitOffset).okOrElse(fail);
       return bufferContainsBitOffset(buffer, bitOffset, this.bitLength())
         ? ok(byteOffset)
         : err('SmallBuffer');
@@ -82,8 +82,8 @@ export abstract class UintCoder extends BaseCoder<number> {
     bitOffset: BitOffset,
     fn: (byteOffset: ByteOffset) => void
   ): EncodeResult {
-    return resultBlock((ret) => {
-      const byteOffset = this.getByteOffset(buffer, bitOffset).or(ret);
+    return resultBlock((fail) => {
+      const byteOffset = this.getByteOffset(buffer, bitOffset).okOrElse(fail);
       fn(byteOffset);
       return bitOffset + this.bitLength();
     });
@@ -94,16 +94,16 @@ export abstract class UintCoder extends BaseCoder<number> {
     bitOffset: BitOffset,
     fn: (byteOffset: ByteOffset) => Result<number, CoderError>
   ): DecodeResult<number> {
-    return resultBlock((ret) => {
-      const byteOffset = this.getByteOffset(buffer, bitOffset).or(ret);
-      const value = fn(byteOffset).or(ret);
+    return resultBlock((fail) => {
+      const byteOffset = this.getByteOffset(buffer, bitOffset).okOrElse(fail);
+      const value = fn(byteOffset).okOrElse(fail);
       return { value, bitOffset: bitOffset + this.bitLength() };
     });
   }
 
   protected validateValue(value: number): Result<number, CoderError> {
-    return resultBlock((ret) => {
-      validateEnumValue(this.enumeration, value).or(ret);
+    return resultBlock((fail) => {
+      validateEnumValue(this.enumeration, value).okOrElse(fail);
 
       if (value < this.minValue || value > this.maxValue) {
         return err('InvalidValue');

--- a/libs/message-coder/src/unbounded_string_coder.ts
+++ b/libs/message-coder/src/unbounded_string_coder.ts
@@ -1,4 +1,4 @@
-import { err, ok, Result } from '@votingworks/basics';
+import { err, ok, Result, resultBlock } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import {
   bufferContainsBitOffset,
@@ -13,7 +13,6 @@ import {
   CoderError,
   DecodeResult,
   EncodeResult,
-  mapResult,
 } from './types';
 
 /**
@@ -38,17 +37,21 @@ export class UnboundedStringCoder implements Coder<string> {
     buffer: Buffer,
     bitOffset: BitOffset
   ): EncodeResult {
-    const bytes = Buffer.from(value);
+    return resultBlock((ret) => {
+      const bytes = Buffer.from(value);
 
-    if (
-      !bufferContainsBitOffset(buffer, bitOffset, toBitLength(bytes.byteLength))
-    ) {
-      return err('SmallBuffer');
-    }
+      if (
+        !bufferContainsBitOffset(
+          buffer,
+          bitOffset,
+          toBitLength(bytes.byteLength)
+        )
+      ) {
+        return err('SmallBuffer');
+      }
 
-    return mapResult(toByteOffset(bitOffset), (byteOffset) =>
-      toBitOffset(bytes.copy(buffer, byteOffset))
-    );
+      return toBitOffset(bytes.copy(buffer, toByteOffset(bitOffset).or(ret)));
+    });
   }
 
   decode(buffer: Buffer): Result<string, CoderError> {
@@ -56,14 +59,16 @@ export class UnboundedStringCoder implements Coder<string> {
   }
 
   decodeFrom(buffer: Buffer, bitOffset: BitOffset): DecodeResult<string> {
-    if (!bufferContainsBitOffset(buffer, bitOffset)) {
-      return err('SmallBuffer');
-    }
+    return resultBlock((ret) => {
+      if (!bufferContainsBitOffset(buffer, bitOffset)) {
+        return err('SmallBuffer');
+      }
 
-    return mapResult(toByteOffset(bitOffset), (byteOffset) => ({
-      value: buffer.toString('utf8', byteOffset),
-      bitOffset: toBitLength(buffer.byteLength),
-    }));
+      return {
+        value: buffer.toString('utf8', toByteOffset(bitOffset).or(ret)),
+        bitOffset: toBitLength(buffer.byteLength),
+      };
+    });
   }
 }
 

--- a/libs/message-coder/src/unbounded_string_coder.ts
+++ b/libs/message-coder/src/unbounded_string_coder.ts
@@ -37,7 +37,7 @@ export class UnboundedStringCoder implements Coder<string> {
     buffer: Buffer,
     bitOffset: BitOffset
   ): EncodeResult {
-    return resultBlock((ret) => {
+    return resultBlock((fail) => {
       const bytes = Buffer.from(value);
 
       if (
@@ -50,7 +50,9 @@ export class UnboundedStringCoder implements Coder<string> {
         return err('SmallBuffer');
       }
 
-      return toBitOffset(bytes.copy(buffer, toByteOffset(bitOffset).or(ret)));
+      return toBitOffset(
+        bytes.copy(buffer, toByteOffset(bitOffset).okOrElse(fail))
+      );
     });
   }
 
@@ -59,13 +61,13 @@ export class UnboundedStringCoder implements Coder<string> {
   }
 
   decodeFrom(buffer: Buffer, bitOffset: BitOffset): DecodeResult<string> {
-    return resultBlock((ret) => {
+    return resultBlock((fail) => {
       if (!bufferContainsBitOffset(buffer, bitOffset)) {
         return err('SmallBuffer');
       }
 
       return {
-        value: buffer.toString('utf8', toByteOffset(bitOffset).or(ret)),
+        value: buffer.toString('utf8', toByteOffset(bitOffset).okOrElse(fail)),
         bitOffset: toBitLength(buffer.byteLength),
       };
     });


### PR DESCRIPTION
_(I recommend reviewing with ["Hide whitespace" enabled](https://github.com/votingworks/vxsuite/pull/3367/files?diff=split&w=1))_

## Overview
Rust has the [`?` operator](https://doc.rust-lang.org/reference/expressions/operator-expr.html#the-question-mark-operator) to return early from functions if the `Result` operand is `Err`. This is convenient, and the lack of it with our `Result` type means a lot of extra error checks with early returns. This is annoying boilerplate, but it also makes complete code coverage difficult to achieve since you need to write tests that cover what is essentially just propagating an error.

A note about the design of this API: it uses JavaScript exceptions. This is not ideal but is unavoidable since it's the only way to return early from a function without `return`. Additionally, you might ask why `resultBlock` has a function to be passed to `or` rather than simply having `or` (or some other `Result` method) throw the exception. The reason for that is to ensure the errors propagated have the right type. Otherwise a thrown `Err` might not be compatible with the type expected by the containing function.

## Demo Video or Screenshot
```ts
// before
function doSomething(): Result<string, Error> {
  const valueResult = doSomethingThatMightFail();
  if (valueResult.isErr()) {
    return valueResult;
  }
  const value = valueResult.ok();
  const value2Result = doSomethingElseThatMightFail(value);
  if (value2Result.isErr()) {
    return value2Result;
  }
  const value2 = value2Result.ok();
  return anotherThingThatMightFail(value2);
}

// after
function doSomething(): Result<string, Error> {
  return resultBlock((fail) => {
    const value = doSomethingThatMightFail().okOrElse(fail);
    const value2 = doSomethingElseThatMightFail(value).okOrElse(fail);
    return anotherThingThatMightFail(value2);
  });
}
```

## Testing Plan
Automated.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
