### PR TITLE
[libs/ui] Add a VoterContestSummary component for VxMark

### DIFF
--- a/libs/ui/jest.config.js
+++ b/libs/ui/jest.config.js
@@ -17,7 +17,8 @@ module.exports = {
     'src/insert_card_image.tsx',
     'src/loading_animation.tsx',
     'src/rotate_card_image.tsx',
-    'src/svg.tsx'
+    'src/svg.tsx',
+    'src/voter_contest_summary.tsx',
   ],
   transform: {
     '^.+\\.css$': '<rootDir>/config/jest/cssTransform.js',

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -85,3 +85,4 @@ export * from './graphics';
 export * from './types';
 export * from './unconfigured_election_screen';
 export * from './power_down_button';
+export * from './voter_contest_summary';

--- a/libs/ui/src/voter_contest_summary.stories.tsx
+++ b/libs/ui/src/voter_contest_summary.stories.tsx
@@ -1,0 +1,28 @@
+import { Meta } from '@storybook/react';
+
+import {
+  VoterContestSummary,
+  VoterContestSummaryProps,
+} from './voter_contest_summary';
+
+const initialProps: VoterContestSummaryProps = {
+  districtName: 'East Fullerton',
+  title: 'City Council',
+  titleType: 'h3',
+  votes: [
+    { label: 'Martin Scorsese', caption: 'American' },
+    { label: 'Jean-Luc Godard', caption: 'French' },
+    { label: 'Akira Kurosawa', caption: 'Japanese' },
+    { label: 'Barney', caption: '(write-in)' },
+  ],
+};
+
+const meta: Meta<typeof VoterContestSummary> = {
+  title: 'libs-ui/VoterContestSummary',
+  component: VoterContestSummary,
+  args: initialProps,
+};
+
+export default meta;
+
+export { VoterContestSummary };

--- a/libs/ui/src/voter_contest_summary.tsx
+++ b/libs/ui/src/voter_contest_summary.tsx
@@ -1,0 +1,84 @@
+/* stylelint-disable order/properties-order */
+import React from 'react';
+import styled from 'styled-components';
+
+import { Checkbox } from './checkbox';
+import { Icons } from './icons';
+import { Caption, Font, H5, HeadingProps, P } from './typography';
+
+export interface VoterContestSummaryProps {
+  districtName: string;
+  title: string;
+  titleType: HeadingProps['as'];
+  undervoteWarning?: string;
+  votes: ContestVote[];
+}
+
+export interface ContestVote {
+  caption?: string;
+  label: string;
+}
+
+const ListContainer = styled.ul`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+`;
+
+const DistrictName = styled(Caption)`
+  display: block;
+  margin-bottom: 0;
+`;
+
+const VoteInfo = styled.li`
+  align-items: start;
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 0.25rem;
+  margin-bottom: 0.25rem;
+`;
+
+const CheckboxContainer = styled(Font)`
+  font-size: 0.65rem;
+`;
+
+/** Vote summary list for a single contest, for a single voter session. */
+export function VoterContestSummary(
+  props: VoterContestSummaryProps
+): JSX.Element {
+  const { districtName, title, titleType, undervoteWarning, votes } = props;
+
+  return (
+    <div>
+      <H5 as={titleType}>
+        <DistrictName weight="regular">{districtName}</DistrictName>
+        {title}
+      </H5>
+      {undervoteWarning && (
+        <P color="warning">
+          <Caption>
+            <Icons.Warning /> {undervoteWarning}
+          </Caption>
+        </P>
+      )}
+      <ListContainer>
+        {votes.map((v) => (
+          <VoteInfo key={v.label}>
+            <CheckboxContainer color="success">
+              <Checkbox checked />
+            </CheckboxContainer>
+            <span>
+              <Font>{v.label}</Font>
+              {v.caption && (
+                <Caption noWrap weight="light">
+                  {' '}
+                  | {v.caption}
+                </Caption>
+              )}
+            </span>
+          </VoteInfo>
+        ))}
+      </ListContainer>
+    </div>
+  );
+}


### PR DESCRIPTION
## Overview
Adding a theme-aware replacement for the contest summary info shown in VxMark, using `<ul>|<li>` semantics.

## Demo Video or Screenshot
https://user-images.githubusercontent.com/264902/234705972-fa687643-d39d-45ed-95d2-3cbb130276a5.mov

### Current styling, for reference:
![Screenshot 2023-04-26 at 16 16 47](https://user-images.githubusercontent.com/264902/234706072-dfd9ab7c-5915-4deb-80a7-defe424ef705.png)

## Testing Plan
- Excluded from coverage as purely presentational

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
