### PR TITLE
[VxMark] Replace heading elements with theme-aware versions

### DIFF
--- a/apps/mark/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
@@ -178,6 +178,7 @@ exports[`Single Seat Contest 1`] = `
         >
           <h1
             aria-label="District 1 President and Vice-President."
+            class="sc-eCImvq cmseZU"
           >
             <div
               class="c3"

--- a/apps/mark/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
@@ -178,6 +178,7 @@ exports[`Single Seat Contest 1`] = `
         >
           <h1
             aria-label="District 2 County Commissioners."
+            class="sc-eCImvq cmseZU"
           >
             <div
               class="c3"

--- a/apps/mark/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
@@ -178,6 +178,7 @@ exports[`Single Seat Contest 1`] = `
         >
           <h1
             aria-label="District 1 President and Vice-President."
+            class="sc-eCImvq cmseZU"
           >
             <div
               class="c3"

--- a/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
@@ -178,6 +178,7 @@ exports[`Single Seat Contest with Write In 1`] = `
         >
           <h1
             aria-label="District 1 Registrar of Wills."
+            class="sc-eCImvq cmseZU"
           >
             <div
               class="c3"

--- a/apps/mark/frontend/src/app.tsx
+++ b/apps/mark/frontend/src/app.tsx
@@ -9,7 +9,7 @@ import {
 } from '@votingworks/utils';
 import { Logger, LogSource } from '@votingworks/logging';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { AppBase, ErrorBoundary, Prose, Text } from '@votingworks/ui';
+import { AppBase, ErrorBoundary, H1, Prose, Text } from '@votingworks/ui';
 import { ColorMode } from '@votingworks/types';
 import { memoize } from './utils/memoize';
 import {
@@ -132,7 +132,7 @@ export function App({
       <ErrorBoundary
         errorMessage={
           <Prose textCenter>
-            <h1>Something went wrong</h1>
+            <H1>Something went wrong</H1>
             <Text>Ask a poll worker to restart the ballot marking device.</Text>
           </Prose>
         }

--- a/apps/mark/frontend/src/components/__snapshots__/election_info.test.tsx.snap
+++ b/apps/mark/frontend/src/components/__snapshots__/election_info.test.tsx.snap
@@ -215,6 +215,7 @@ exports[`renders horizontal ElectionInfo with hash when specified 1`] = `
       >
         <h5
           aria-label=" General Election."
+          class="sc-furvIG fvCtYG"
         >
            General Election
         </h5>
@@ -466,6 +467,7 @@ exports[`renders horizontal ElectionInfo without hash by default 1`] = `
       >
         <h5
           aria-label=" General Election."
+          class="sc-furvIG fvCtYG"
         >
            General Election
         </h5>
@@ -694,6 +696,7 @@ exports[`renders vertical ElectionInfo with hash when specified 1`] = `
     >
       <h1
         aria-label=" General Election."
+        class="sc-eCImvq cmseZU"
       >
          General Election
       </h1>
@@ -912,6 +915,7 @@ exports[`renders vertical ElectionInfo without hash by default 1`] = `
     >
       <h1
         aria-label=" General Election."
+        class="sc-eCImvq cmseZU"
       >
          General Election
       </h1>

--- a/apps/mark/frontend/src/components/__snapshots__/yes_no_contest.test.tsx.snap
+++ b/apps/mark/frontend/src/components/__snapshots__/yes_no_contest.test.tsx.snap
@@ -89,6 +89,7 @@ exports[`supports yes/no contest allows voting for both yes and no 1`] = `
       >
         <h1
           aria-label="District 1 Ballot Measure 3."
+          class="sc-eCImvq cmseZU"
         >
           <div
             class="c1"
@@ -337,6 +338,7 @@ exports[`supports yes/no contest displays warning when attempting to change vote
       >
         <h1
           aria-label="District 1 Ballot Measure 3."
+          class="sc-eCImvq cmseZU"
         >
           <div
             class="c1"

--- a/apps/mark/frontend/src/components/candidate_contest.tsx
+++ b/apps/mark/frontend/src/components/candidate_contest.tsx
@@ -18,6 +18,8 @@ import {
 import {
   Button,
   ContestChoiceButton,
+  H1,
+  H3,
   Icons,
   Main,
   Modal,
@@ -298,10 +300,10 @@ export function CandidateContest({
       <Main flexColumn>
         <ContentHeader id="contest-header">
           <Prose id="audiofocus">
-            <h1 aria-label={`${districtName} ${contest.title}.`}>
+            <H1 aria-label={`${districtName} ${contest.title}.`}>
               <DistrictName>{districtName}</DistrictName>
               {contest.title}
-            </h1>
+            </H1>
             <p>
               <Text as="span">Vote for {contest.seats}.</Text>{' '}
               {vote.length === contest.seats && (
@@ -488,7 +490,7 @@ export function CandidateContest({
           content={
             <WriteInModalContent>
               <Prose id="modalaudiofocus" maxWidth={false}>
-                <h1 aria-label="Write-In Candidate.">Write-In Candidate</h1>
+                <H1 aria-label="Write-In Candidate.">Write-In Candidate</H1>
                 <Text aria-label="Enter the name of a person who is not on the ballot. Use the up and down buttons to navigate between the letters of a standard keyboard. Use the select button to select the current letter.">
                   Enter the name of a person who is <strong>not</strong> on the
                   ballot.
@@ -505,7 +507,7 @@ export function CandidateContest({
               <WriteInCandidateForm>
                 <WriteInCandidateFieldSet>
                   <Prose>
-                    <h3>{contest.title} (write-in)</h3>
+                    <H3>{contest.title} (write-in)</H3>
                   </Prose>
                   <WriteInCandidateName>
                     {writeInCandidateName}

--- a/apps/mark/frontend/src/components/election_info.tsx
+++ b/apps/mark/frontend/src/components/election_info.tsx
@@ -9,7 +9,7 @@ import {
 } from '@votingworks/types';
 import { getPrecinctSelectionName, format } from '@votingworks/utils';
 
-import { Prose, Text, NoWrap } from '@votingworks/ui';
+import { Prose, Text, NoWrap, H1, H5 } from '@votingworks/ui';
 import pluralize from 'pluralize';
 import { Seal } from './seal';
 
@@ -73,7 +73,7 @@ export function ElectionInfo({
         <HorizontalContainer>
           <Seal seal={seal} sealUrl={sealUrl} />
           <Prose compact>
-            <h5 aria-label={`${title}.`}>{title}</h5>
+            <H5 aria-label={`${title}.`}>{title}</H5>
             <Text small>
               {electionDate}
               <br />
@@ -97,7 +97,7 @@ export function ElectionInfo({
     <VerticalContainer aria-hidden={ariaHidden}>
       <Seal seal={seal} sealUrl={sealUrl} />
       <Prose textCenter>
-        <h1 aria-label={`${title}.`}>{title}</h1>
+        <H1 aria-label={`${title}.`}>{title}</H1>
         <p
           aria-label={`${electionDate}. ${state}, ${county.name}. ${precinctName}.`}
         >

--- a/apps/mark/frontend/src/components/ms_either_neither_contest.tsx
+++ b/apps/mark/frontend/src/components/ms_either_neither_contest.tsx
@@ -12,6 +12,7 @@ import { YesNoVote, OptionalYesNoVote } from '@votingworks/types';
 import {
   Button,
   ContestChoiceButton,
+  H1,
   Main,
   Prose,
   Text,
@@ -202,10 +203,10 @@ export function MsEitherNeitherContest({
     <Main flexColumn>
       <ContentHeader>
         <Prose>
-          <h1 aria-label={`${districtName} ${contest.title}.`}>
+          <H1 aria-label={`${districtName} ${contest.title}.`}>
             <DistrictName>{districtName}</DistrictName>
             {contest.title}
-          </h1>
+          </H1>
           <p>
             {eitherNeitherVote && pickOneVote ? (
               <span>

--- a/apps/mark/frontend/src/components/yes_no_contest.tsx
+++ b/apps/mark/frontend/src/components/yes_no_contest.tsx
@@ -16,6 +16,7 @@ import {
   Button,
   ContestChoiceButton,
   DisplayTextForYesOrNo,
+  H1,
   Main,
   Modal,
   Prose,
@@ -150,10 +151,10 @@ export function YesNoContest({
       <Main flexColumn>
         <ContentHeader id="contest-header">
           <Prose id="audiofocus">
-            <h1 aria-label={`${districtName} ${contest.title}.`}>
+            <H1 aria-label={`${districtName} ${contest.title}.`}>
               <DistrictName>{districtName}</DistrictName>
               {contest.title}
-            </h1>
+            </H1>
             <p>
               Vote <strong>Yes</strong> or <strong>No</strong>.
               <span className="screen-reader-only">

--- a/apps/mark/frontend/src/pages/__snapshots__/cast_ballot_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/cast_ballot_page.test.tsx.snap
@@ -49,6 +49,7 @@ exports[`renders CastBallotPage 1`] = `
     >
       <h1
         aria-label="You’re almost done."
+        class="sc-eCImvq cmseZU"
       >
         You’re Almost Done
       </h1>
@@ -86,7 +87,9 @@ exports[`renders CastBallotPage 1`] = `
           </p>
         </li>
       </ol>
-      <h3>
+      <h3
+        class="sc-gKckTs lQVQK"
+      >
         <strong>
           Need help?
         </strong>

--- a/apps/mark/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
@@ -167,6 +167,7 @@ exports[`Renders ContestPage 1`] = `
         >
           <h1
             aria-label="District 1 President and Vice-President."
+            class="sc-eCImvq cmseZU"
           >
             <div
               class="c2"
@@ -760,6 +761,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
         >
           <h1
             aria-label="District 1 President and Vice-President."
+            class="sc-eCImvq cmseZU"
           >
             <div
               class="c1"
@@ -1198,6 +1200,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
             >
               <h5
                 aria-label=" General Election."
+                class="sc-furvIG fvCtYG"
               >
                  General Election
               </h5>

--- a/apps/mark/frontend/src/pages/__snapshots__/not_found_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/not_found_page.test.tsx.snap
@@ -10,7 +10,9 @@ exports[`renders NotFoundPage 1`] = `
     <div
       class="sc-fotPbf ljYHag"
     >
-      <h1>
+      <h1
+        class="sc-eCImvq cmseZU"
+      >
         Page Not Found.
       </h1>
       <p>

--- a/apps/mark/frontend/src/pages/__snapshots__/start_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/start_page.test.tsx.snap
@@ -127,6 +127,7 @@ exports[`renders StartPage 1`] = `
       >
         <h1
           aria-label="Democratic Primary Election."
+          class="sc-eCImvq cmseZU"
         >
           Democratic Primary Election
         </h1>
@@ -194,7 +195,9 @@ exports[`renders StartPage 1`] = `
           </span>
         </button>
       </p>
-      <h1>
+      <h1
+        class="sc-eCImvq cmseZU"
+      >
         Voter Settings
       </h1>
       <div
@@ -533,6 +536,7 @@ exports[`renders StartPage with inline SVG 1`] = `
       >
         <h1
           aria-label=" General Election."
+          class="sc-eCImvq cmseZU"
         >
            General Election
         </h1>
@@ -600,7 +604,9 @@ exports[`renders StartPage with inline SVG 1`] = `
           </span>
         </button>
       </p>
-      <h1>
+      <h1
+        class="sc-eCImvq cmseZU"
+      >
         Voter Settings
       </h1>
       <div
@@ -775,6 +781,7 @@ exports[`renders StartPage with no seal 1`] = `
       >
         <h1
           aria-label=" General Election."
+          class="sc-eCImvq cmseZU"
         >
            General Election
         </h1>
@@ -842,7 +849,9 @@ exports[`renders StartPage with no seal 1`] = `
           </span>
         </button>
       </p>
-      <h1>
+      <h1
+        class="sc-eCImvq cmseZU"
+      >
         Voter Settings
       </h1>
       <div

--- a/apps/mark/frontend/src/pages/accessible_controller_diagnostic_screen.tsx
+++ b/apps/mark/frontend/src/pages/accessible_controller_diagnostic_screen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Button, Main, Prose, Screen, Text } from '@votingworks/ui';
+import { Button, H1, Main, Prose, Screen, Text } from '@votingworks/ui';
 import { DateTime } from 'luxon';
 import styled from 'styled-components';
 import { ScreenReader } from '../config/types';
@@ -154,7 +154,7 @@ function AccessibleControllerButtonDiagnostic({
   return (
     <StepInnerContainer>
       <div>
-        <h1>Press the {buttonName.toLowerCase()} button.</h1>
+        <H1>Press the {buttonName.toLowerCase()} button.</H1>
         <Button
           onPress={() => onFailure(`${buttonName} button is not working.`)}
         >
@@ -203,7 +203,7 @@ function AccessibleControllerSoundDiagnostic({
   return (
     <StepInnerContainer>
       <div>
-        <h1>Confirm sound is working.</h1>
+        <H1>Confirm sound is working.</H1>
         <ol>
           <li>Plug in headphones.</li>
           <li>Press the right button to play sound.</li>

--- a/apps/mark/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.tsx
@@ -11,6 +11,8 @@ import {
   ChangePrecinctButton,
   CurrentDateAndTime,
   ElectionInfoBar,
+  H1,
+  H2,
   Main,
   Prose,
   Screen,
@@ -69,22 +71,22 @@ export function AdminScreen({
       {election && !isLiveMode && <TestMode />}
       <Main padded>
         <Prose>
-          <h1>
+          <H1>
             VxMark{' '}
             <Text as="span" light noWrap>
               Election Manager Actions
             </Text>
-          </h1>
+          </H1>
           <Text italic>Remove card when finished.</Text>
           {election && (
             <React.Fragment>
-              <h2>Stats</h2>
+              <H2>Stats</H2>
               <p>
                 Ballots Printed: <strong>{ballotsPrintedCount}</strong>
               </p>
-              <h2>
+              <H2>
                 <label htmlFor="selectPrecinct">Precinct</label>
-              </h2>
+              </H2>
               <p>
                 <ChangePrecinctButton
                   appPrecinctSelection={appPrecinct}
@@ -112,7 +114,7 @@ export function AdminScreen({
                   </React.Fragment>
                 )}
               </p>
-              <h2>Test Ballot Mode</h2>
+              <H2>Test Ballot Mode</H2>
               <p>
                 <SegmentedButton
                   label="Test Ballot Mode"
@@ -131,14 +133,14 @@ export function AdminScreen({
               </p>
             </React.Fragment>
           )}
-          <h2>Current Date and Time</h2>
+          <H2>Current Date and Time</H2>
           <p>
             <CurrentDateAndTime />
           </p>
           <p>
             <SetClockButton>Update Date and Time</SetClockButton>
           </p>
-          <h2>Configuration</h2>
+          <H2>Configuration</H2>
           <p>
             <Text as="span" voteIcon>
               Election Definition is loaded.
@@ -147,7 +149,7 @@ export function AdminScreen({
               Unconfigure Machine
             </Button>
           </p>
-          <h2>USB</h2>
+          <H2>USB</H2>
           <UsbControllerButton
             small={false}
             primary

--- a/apps/mark/frontend/src/pages/card_error_screen.tsx
+++ b/apps/mark/frontend/src/pages/card_error_screen.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 
-import { Main, Screen, Prose, RotateCardImage } from '@votingworks/ui';
+import { Main, Screen, Prose, RotateCardImage, H1 } from '@votingworks/ui';
 import { triggerAudioFocus } from '../utils/trigger_audio_focus';
 
 interface Props {
@@ -20,7 +20,7 @@ export function CardErrorScreen({
         <div>
           <RotateCardImage />
           <Prose textCenter id="audiofocus">
-            <h1>Card is Backwards</h1>
+            <H1>Card is Backwards</H1>
             <p>Remove the card, turn it around, and insert it again.</p>
           </Prose>
         </div>

--- a/apps/mark/frontend/src/pages/cast_ballot_page.tsx
+++ b/apps/mark/frontend/src/pages/cast_ballot_page.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { Button, Main, Screen, Prose, Text } from '@votingworks/ui';
+import { Button, Main, Screen, Prose, Text, H1, H3 } from '@votingworks/ui';
 
 const SingleGraphic = styled.img`
   margin: 0 auto 1em;
@@ -42,7 +42,7 @@ export function CastBallotPage({
     <Screen white>
       <Main centerChild>
         <Prose textCenter maxWidth={false} id="audiofocus">
-          <h1 aria-label="You’re almost done.">You’re Almost Done</h1>
+          <H1 aria-label="You’re almost done.">You’re Almost Done</H1>
           <p>Your official ballot is printing. To finish voting you need to…</p>
           <Instructions>
             <li>
@@ -63,9 +63,9 @@ export function CastBallotPage({
               <Text>2. Scan your official ballot.</Text>
             </li>
           </Instructions>
-          <h3>
+          <H3>
             <strong>Need help?</strong> Ask a poll worker.
-          </h3>
+          </H3>
         </Prose>
         <Done>
           <Button onPress={hidePostVotingInstructions}>Done</Button>

--- a/apps/mark/frontend/src/pages/diagnostics_screen.tsx
+++ b/apps/mark/frontend/src/pages/diagnostics_screen.tsx
@@ -3,6 +3,8 @@ import {
   Button,
   ComputerStatus as ComputerStatusType,
   Devices,
+  H1,
+  H2,
   LinkButton,
   Main,
   Prose,
@@ -284,20 +286,20 @@ export function DiagnosticsScreen({
                   Back to Poll Worker Actions
                 </Button>
               </p>
-              <h1>System Diagnostics</h1>
+              <H1>System Diagnostics</H1>
               <span className="screen-reader-only">
                 To navigate through the available actions, use the down arrow.
               </span>
               <section>
-                <h2>Computer</h2>
+                <H2>Computer</H2>
                 <ComputerStatus computer={devices.computer} />
               </section>
               <section>
-                <h2>Printer</h2>
+                <H2>Printer</H2>
                 <PrinterStatus hardware={hardware} />
               </section>
               <section>
-                <h2>Accessible Controller</h2>
+                <H2>Accessible Controller</H2>
                 <AccessibleControllerStatus
                   accessibleController={devices.accessibleController}
                   diagnosticResults={accessibleControllerDiagnosticResults}

--- a/apps/mark/frontend/src/pages/idle_page.tsx
+++ b/apps/mark/frontend/src/pages/idle_page.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import pluralize from 'pluralize';
 import useInterval from 'use-interval';
 
-import { Button, Loading, Main, Prose, Screen } from '@votingworks/ui';
+import { Button, H1, Loading, Main, Prose, Screen } from '@votingworks/ui';
 
 import {
   IDLE_RESET_TIMEOUT_SECONDS,
@@ -42,7 +42,7 @@ export function IdlePage(): JSX.Element {
           <Loading>Clearing ballot</Loading>
         ) : (
           <Prose textCenter>
-            <h1 aria-label="Are you still voting?">Are you still voting?</h1>
+            <H1 aria-label="Are you still voting?">Are you still voting?</H1>
             <p>
               This voting station has been inactive for more than{' '}
               {pluralize('minute', IDLE_TIMEOUT_SECONDS / 60, true)}.

--- a/apps/mark/frontend/src/pages/insert_card_screen.tsx
+++ b/apps/mark/frontend/src/pages/insert_card_screen.tsx
@@ -12,6 +12,7 @@ import {
   Text,
   ElectionInfoBar,
   InsertCardImage,
+  H1,
 } from '@votingworks/ui';
 
 import { throwIllegalValue } from '@votingworks/basics';
@@ -41,23 +42,23 @@ export function InsertCardScreen({
       case 'polls_closed_initial':
         return (
           <React.Fragment>
-            <h1>Polls Closed</h1>
+            <H1>Polls Closed</H1>
             <p>Insert Poll Worker card to open.</p>
           </React.Fragment>
         );
       case 'polls_open':
-        return <h1>Insert Card</h1>;
+        return <H1>Insert Card</H1>;
       case 'polls_paused':
         return (
           <React.Fragment>
-            <h1>Voting Paused</h1>
+            <H1>Voting Paused</H1>
             <p>Insert Poll Worker card to resume voting.</p>
           </React.Fragment>
         );
       case 'polls_closed_final':
         return (
           <React.Fragment>
-            <h1>Polls Closed</h1>
+            <H1>Polls Closed</H1>
             <p>Voting is complete.</p>
           </React.Fragment>
         );

--- a/apps/mark/frontend/src/pages/not_found_page.tsx
+++ b/apps/mark/frontend/src/pages/not_found_page.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import { useLocation } from 'react-router-dom';
 
-import { Button, Main, Screen, Prose } from '@votingworks/ui';
+import { Button, Main, Screen, Prose, H1 } from '@votingworks/ui';
 import { BallotContext } from '../contexts/ballot_context';
 
 export function NotFoundPage(): JSX.Element {
@@ -14,7 +14,7 @@ export function NotFoundPage(): JSX.Element {
     <Screen>
       <Main centerChild>
         <Prose textCenter>
-          <h1>Page Not Found.</h1>
+          <H1>Page Not Found.</H1>
           <p>
             No page exists at <code>{pathname}</code>.
           </p>

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -33,6 +33,8 @@ import {
   TestMode,
   NoWrap,
   useQueryChangeListener,
+  H1,
+  H2,
 } from '@votingworks/ui';
 
 import {
@@ -271,7 +273,7 @@ function ScannerReportModal({
     case 'initial':
       modalContent = (
         <Prose id="modalaudiofocus">
-          <h1>{reportTitle} on Card</h1>
+          <H1>{reportTitle} on Card</H1>
           {willUpdatePollsToMatchScanner ? (
             <p>
               This poll worker card contains a {reportTitle.toLowerCase()}.
@@ -307,7 +309,7 @@ function ScannerReportModal({
     case 'reprint':
       modalContent = (
         <Prose id="modalaudiofocus">
-          <h1>{reportTitle} Printed</h1>
+          <H1>{reportTitle} Printed</H1>
           {willUpdatePollsToMatchScanner ? (
             <p>
               The polls are now {newPollsStateName.toLowerCase()}. If needed,
@@ -417,7 +419,7 @@ function UpdatePollsDirectlyButton({
           centerContent
           content={
             <Prose textCenter id="modalaudiofocus">
-              <h1>No {reportTitle} on Card</h1>
+              <H1>No {reportTitle} on Card</H1>
               <p>{suggestVxScanText}</p>
             </Prose>
           }
@@ -558,11 +560,11 @@ export function PollWorkerScreen({
       <Screen white>
         <Main centerChild>
           <Prose textCenter>
-            <h1
+            <H1
               aria-label={`Ballot style ${pollWorkerAuth.cardlessVoterUser.ballotStyleId} has been activated.`}
             >
               Ballot Contains Votes
-            </h1>
+            </H1>
             <p>
               Remove card to allow voter to continue voting, or reset ballot.
             </p>
@@ -585,9 +587,9 @@ export function PollWorkerScreen({
       <Screen white>
         <Main centerChild>
           <Prose id="audiofocus">
-            <h1>
+            <H1>
               {`Voting Session Active: ${ballotStyleId} at ${precinct.name}`}
-            </h1>
+            </H1>
             <ol>
               <li>
                 Instruct the voter to press the{' '}
@@ -628,13 +630,13 @@ export function PollWorkerScreen({
         {!isLiveMode && <TestMode />}
         <Main padded>
           <Prose maxWidth={false}>
-            <h1>
+            <H1>
               VxMark{' '}
               <Text as="span" light noWrap>
                 Poll Worker Actions
               </Text>
-            </h1>
-            <h2>
+            </H1>
+            <H2>
               <NoWrap>
                 <Text light as="span">
                   Ballots Printed:
@@ -649,14 +651,14 @@ export function PollWorkerScreen({
                 </Text>{' '}
                 <strong>{getPollsStateName(pollsState)}</strong>
               </NoWrap>
-            </h2>
+            </H2>
             {canSelectBallotStyle && !isHidingSelectBallotStyle ? (
               <React.Fragment>
                 <VotingSession>
-                  <h1>Start a New Voting Session</h1>
+                  <H1>Start a New Voting Session</H1>
                   {appPrecinct.kind === 'AllPrecincts' && (
                     <React.Fragment>
-                      <h2>1. Select Voter’s Precinct</h2>
+                      <H2>1. Select Voter’s Precinct</H2>
                       <ButtonList data-testid="precincts">
                         {election.precincts.map((precinct) => (
                           <Button
@@ -678,10 +680,10 @@ export function PollWorkerScreen({
                       </ButtonList>
                     </React.Fragment>
                   )}
-                  <h2>
+                  <H2>
                     {appPrecinct.kind === 'AllPrecincts' ? '2. ' : ''}Select
                     Voter’s Ballot Style
-                  </h2>
+                  </H2>
                   {selectedCardlessVoterPrecinctId ? (
                     <ButtonList data-testid="ballot-styles">
                       {precinctBallotStyles.map((ballotStyle) => (
@@ -724,7 +726,7 @@ export function PollWorkerScreen({
                         Back to Ballot Style Selection
                       </Button>
                     </p>
-                    <h1>More Actions</h1>
+                    <H1>More Actions</H1>
                   </React.Fragment>
                 )}
                 <p>
@@ -761,10 +763,10 @@ export function PollWorkerScreen({
             centerContent
             content={
               <Prose textCenter id="modalaudiofocus">
-                <h1>
+                <H1>
                   Switch to Official Ballot Mode and reset the Ballots Printed
                   count?
-                </h1>
+                </H1>
                 <p>
                   Today is election day and this machine is in{' '}
                   <strong>

--- a/apps/mark/frontend/src/pages/print_page.tsx
+++ b/apps/mark/frontend/src/pages/print_page.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import {
   BmdPaperBallot,
+  H1,
   Main,
   printElement,
   ProgressEllipsis,
@@ -100,11 +101,11 @@ export function PrintPage(): JSX.Element {
               aria-hidden
             />
           </p>
-          <h1>
+          <H1>
             <ProgressEllipsis aria-label="Printing your official ballot.">
               Printing Your Official Ballot
             </ProgressEllipsis>
-          </h1>
+          </H1>
         </Prose>
       </Main>
     </Screen>

--- a/apps/mark/frontend/src/pages/replace_election_screen.tsx
+++ b/apps/mark/frontend/src/pages/replace_election_screen.tsx
@@ -1,6 +1,7 @@
 import { ElectionDefinition, PrecinctSelection } from '@votingworks/types';
 import {
   ElectionInfoBar,
+  H2,
   Main,
   Prose,
   Screen,
@@ -120,7 +121,7 @@ export function ReplaceElectionScreen({
               for the current election.
             </p>
           )}
-          <h2>Cancel and Go Back</h2>
+          <H2>Cancel and Go Back</H2>
           <p>Remove the inserted card to cancel.</p>
         </Prose>
       </Main>

--- a/apps/mark/frontend/src/pages/review_page.tsx
+++ b/apps/mark/frontend/src/pages/review_page.tsx
@@ -17,6 +17,8 @@ import {
   Button,
   DecoyButton,
   DisplayTextForYesOrNo,
+  H1,
+  H2,
   LinkButton,
   Main,
   NoWrap,
@@ -421,7 +423,7 @@ export function ReviewPage(): JSX.Element {
       <Main flexColumn>
         <ContentHeader>
           <Prose id="audiofocus">
-            <h1>
+            <H1>
               <span aria-label="Review Your Votes.">Review Your Votes</span>
               <span className="screen-reader-only">
                 To review your votes, advance through the ballot contests using
@@ -430,7 +432,7 @@ export function ReviewPage(): JSX.Element {
                 finished making your ballot selections and ready to print your
                 ballot, use the right button to print your ballot.
               </span>
-            </h1>
+            </H1>
           </Prose>
         </ContentHeader>
         <VariableContentContainer
@@ -450,7 +452,7 @@ export function ReviewPage(): JSX.Element {
                   to={`/contests/${i}#review`}
                 >
                   <ContestProse compact>
-                    <h2
+                    <H2
                       aria-label={`${getContestDistrictName(
                         election,
                         contest
@@ -460,7 +462,7 @@ export function ReviewPage(): JSX.Element {
                         {getContestDistrictName(election, contest)}
                       </DistrictName>
                       {contest.title}
-                    </h2>
+                    </H2>
 
                     {contest.type === 'candidate' && (
                       <CandidateContestResult
@@ -547,7 +549,7 @@ export function ReviewPage(): JSX.Element {
         >
           <SidebarSpacer />
           <Prose>
-            <h2 aria-hidden>Review Votes</h2>
+            <H2 aria-hidden>Review Votes</H2>
             <p>Confirm your votes are correct.</p>
             <p>{printMyBallotButton}</p>
           </Prose>

--- a/apps/mark/frontend/src/pages/setup_power_page.tsx
+++ b/apps/mark/frontend/src/pages/setup_power_page.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 
-import { Main, NoWrap, Screen, Prose } from '@votingworks/ui';
+import { Main, NoWrap, Screen, Prose, H1 } from '@votingworks/ui';
 
 interface Props {
   useEffectToggleLargeDisplay: () => void;
@@ -16,9 +16,9 @@ export function SetupPowerPage({
     <Screen white>
       <Main padded centerChild>
         <Prose textCenter>
-          <h1>
+          <H1>
             No Power Detected <NoWrap>and Battery is Low</NoWrap>
-          </h1>
+          </H1>
           <p>
             Please ask a poll worker to plug-in the power cord for this machine.
           </p>

--- a/apps/mark/frontend/src/pages/setup_printer_page.tsx
+++ b/apps/mark/frontend/src/pages/setup_printer_page.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 
-import { Main, Screen, Prose } from '@votingworks/ui';
+import { Main, Screen, Prose, H1 } from '@votingworks/ui';
 
 interface Props {
   useEffectToggleLargeDisplay: () => void;
@@ -16,7 +16,7 @@ export function SetupPrinterPage({
     <Screen white>
       <Main padded centerChild>
         <Prose textCenter>
-          <h1>No Printer Detected</h1>
+          <H1>No Printer Detected</H1>
           <p>Please ask a poll worker to connect printer.</p>
         </Prose>
       </Main>

--- a/apps/mark/frontend/src/pages/start_page.tsx
+++ b/apps/mark/frontend/src/pages/start_page.tsx
@@ -3,7 +3,7 @@ import React, { useContext, useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import { useHistory } from 'react-router-dom';
 import { getPartyPrimaryAdjectiveFromBallotStyle } from '@votingworks/types';
-import { Main, Screen, Prose, Button } from '@votingworks/ui';
+import { Main, Screen, Prose, Button, H1 } from '@votingworks/ui';
 
 import pluralize from 'pluralize';
 import { assert } from '@votingworks/basics';
@@ -80,7 +80,7 @@ export function StartPage(): JSX.Element {
 
   const settingsContainer = (
     <React.Fragment>
-      <h1>Voter Settings</h1>
+      <H1>Voter Settings</H1>
       <SettingsContainer>
         <SettingsTextSize
           userSettings={userSettings}
@@ -118,9 +118,9 @@ export function StartPage(): JSX.Element {
           />
         ) : (
           <Prose textCenter>
-            <h1 aria-label={`${partyPrimaryAdjective} ${title}.`}>
+            <H1 aria-label={`${partyPrimaryAdjective} ${title}.`}>
               {partyPrimaryAdjective} {title}
-            </h1>
+            </H1>
             <hr />
             <p>
               <span>

--- a/apps/mark/frontend/src/pages/unconfigured_screen.tsx
+++ b/apps/mark/frontend/src/pages/unconfigured_screen.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Main, Screen, CenteredLargeProse } from '@votingworks/ui';
+import { Main, Screen, CenteredLargeProse, H1 } from '@votingworks/ui';
 
 interface Props {
   hasElectionDefinition: boolean;
@@ -13,7 +13,7 @@ export function UnconfiguredScreen({
     <Screen>
       <Main centerChild>
         <CenteredLargeProse>
-          <h1>VxMark is Not Configured</h1>
+          <H1>VxMark is Not Configured</H1>
           {hasElectionDefinition ? (
             <p>Insert Election Manager card to select a precinct.</p>
           ) : (

--- a/apps/mark/frontend/src/pages/user_settings_modal.tsx
+++ b/apps/mark/frontend/src/pages/user_settings_modal.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect } from 'react';
 
-import { Button, Prose, Modal } from '@votingworks/ui';
+import { Button, Prose, Modal, H1 } from '@votingworks/ui';
 import { BallotContext } from '../contexts/ballot_context';
 import { SettingsTextSize } from '../components/settings_text_size';
 import { handleGamepadKeyboardEvent } from '../lib/gamepad';
@@ -37,7 +37,7 @@ export function VoterSettingsModal(): JSX.Element {
     <Modal
       content={
         <Prose textCenter maxWidth={false} id="modalaudiofocus">
-          <h1>Voter Settings</h1>
+          <H1>Voter Settings</H1>
           <span aria-label="Navigate through the settings using the up and down buttons. Use the select button to select a setting. When you are done, use the right or left arrow to close settings." />
           <SettingsTextSize
             userSettings={userSettings}

--- a/apps/mark/frontend/src/pages/wrong_election_screen.tsx
+++ b/apps/mark/frontend/src/pages/wrong_election_screen.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 
-import { Main, Screen, Prose } from '@votingworks/ui';
+import { Main, Screen, Prose, H1 } from '@votingworks/ui';
 
 import { triggerAudioFocus } from '../utils/trigger_audio_focus';
 
@@ -19,7 +19,7 @@ export function WrongElectionScreen({
     <Screen white>
       <Main centerChild>
         <Prose textCenter id="audiofocus">
-          <h1>Invalid Card Data</h1>
+          <H1>Invalid Card Data</H1>
           <p>Card is not configured for this election.</p>
           <p>Please ask admin for assistance.</p>
         </Prose>


### PR DESCRIPTION
## Overview

_Relevant changes in 1st commit, snapshot updates in 2nd_

Replacing typography elements in VxMark in chunks to make it easier to parse the changes.
This PR replaces native `h[1-6]` elements with their `H[1-6]` theme-aware equivalents from libs/ui.

Mostly a no-op visually, except for minor margin size changes here and there - and this is a short-lived state anyway, since we're moving all of VxMark over to the new themes before next release.

## Demo Video or Screenshot
### Sample Before/After:
<img width="300" src="https://user-images.githubusercontent.com/264902/234714388-a596eb79-874a-4aa7-b46c-a7ef082876b0.png" /> <img width="300" src="https://user-images.githubusercontent.com/264902/234714533-8b032ea8-e343-4fd2-880d-b8039ae1147c.png" />

## Testing Plan
- Visual spot checks

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
