### PR TITLE
m16: HMPB density tweaks

### DIFF
--- a/frontends/election-manager/src/components/bubble_mark.tsx
+++ b/frontends/election-manager/src/components/bubble_mark.tsx
@@ -9,6 +9,7 @@ interface StyledProps {
 interface Props extends StyledProps {
   children?: React.ReactNode;
   position?: BallotTargetMarkPosition;
+  density?: number;
 }
 
 export const Bubble = styled.span<StyledProps>`
@@ -29,7 +30,7 @@ const Container = styled.span<Props>`
   text-align: ${({ position }) =>
     position === BallotTargetMarkPosition.Right ? 'right' : 'left'};
   & > span:first-child {
-    margin-top: 0.15em;
+    margin-top: ${({ density }) => (density === 2 ? '0' : '0.15em')};
     margin-right: ${({ position }) =>
       position === BallotTargetMarkPosition.Right ? 'auto' : '0.3em'};
     margin-left: ${({ position }) =>
@@ -46,10 +47,11 @@ const Content = styled.span`
 export function BubbleMark({
   checked = false,
   position = BallotTargetMarkPosition.Left,
+  density = 0,
   children,
 }: Props): JSX.Element {
   return (
-    <Container position={position}>
+    <Container position={position} density={density}>
       <Bubble checked={checked} data-mark />
       <Content>{children}</Content>
     </Container>

--- a/frontends/election-manager/src/components/hand_marked_paper_ballot.tsx
+++ b/frontends/election-manager/src/components/hand_marked_paper_ballot.tsx
@@ -954,7 +954,7 @@ export function HandMarkedPaperBallot({
                     { lng: locales.primary }
                   )}
                 </Text>
-                <h4>{t('To correct a mistake', { lng: locales.primary })}</h4>
+                <h4>{t('To Correct a Mistake', { lng: locales.primary })}</h4>
                 <Text small>
                   {t(
                     'To make a correction, please ask for a replacement ballot. Any marks other than filled ovals may cause your ballot not to be counted.',

--- a/frontends/election-manager/src/components/hand_marked_paper_ballot.tsx
+++ b/frontends/election-manager/src/components/hand_marked_paper_ballot.tsx
@@ -522,6 +522,7 @@ export function CandidateContestChoices({
           <BubbleMark
             position={targetMarkPosition}
             checked={hasVote(vote, candidate.id)}
+            density={density}
           >
             <CandidateDescription isSmall>
               <strong data-candidate-name={candidate.name}>
@@ -1113,6 +1114,7 @@ export function HandMarkedPaperBallot({
                       <BubbleMark
                         position={election.ballotLayout?.targetMarkPosition}
                         checked={hasVote(votes?.[contest.id], 'yes')}
+                        density={layoutDensity}
                       >
                         <span>
                           {dualLanguageWithSlash(
@@ -1125,6 +1127,7 @@ export function HandMarkedPaperBallot({
                       <BubbleMark
                         position={election.ballotLayout?.targetMarkPosition}
                         checked={hasVote(votes?.[contest.id], 'no')}
+                        density={layoutDensity}
                       >
                         <span>
                           {dualLanguageWithSlash(
@@ -1164,6 +1167,7 @@ export function HandMarkedPaperBallot({
                           votes?.[contest.eitherNeitherContestId],
                           'yes'
                         )}
+                        density={layoutDensity}
                       >
                         <span>
                           {dualLanguageWithSlash(contest.eitherOption.label)}
@@ -1177,6 +1181,7 @@ export function HandMarkedPaperBallot({
                           votes?.[contest.eitherNeitherContestId],
                           'no'
                         )}
+                        density={layoutDensity}
                       >
                         <span>
                           {dualLanguageWithSlash(contest.neitherOption.label)}
@@ -1191,6 +1196,7 @@ export function HandMarkedPaperBallot({
                           votes?.[contest.pickOneContestId],
                           'yes'
                         )}
+                        density={layoutDensity}
                       >
                         <span>
                           {dualLanguageWithSlash(contest.firstOption.label)}
@@ -1204,6 +1210,7 @@ export function HandMarkedPaperBallot({
                           votes?.[contest.pickOneContestId],
                           'no'
                         )}
+                        density={layoutDensity}
                       >
                         <span>
                           {dualLanguageWithSlash(contest.secondOption.label)}


### PR DESCRIPTION
## Overview

_Review by commits_

- Small bubble alignment fix
- Fix capitalization in instructions

## Demo Video or Screenshot

Before (density 2)
![density-2-ballot-1](https://user-images.githubusercontent.com/530106/234722902-0bab8fde-4532-4919-916b-ddf23685344e.jpg)


After (density 2)
![fixed-density-2-1](https://user-images.githubusercontent.com/530106/234723016-fc75fbe1-001b-40de-9096-637fdd9272a9.jpg)


## Testing Plan
Visual inspection of density 0, density 1, and density 2 ballots

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
