### PR TITLE
Create libs/usb-drive, integrate into VxScan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -859,6 +859,28 @@ jobs:
       - store_test_results:
           path: libs/ui/reports/
 
+  test-libs-usb-drive:
+    executor: nodejs
+    resource_class: xlarge
+    steps:
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            pnpm --dir libs/usb-drive build
+      - run:
+          name: Lint
+          command: |
+            pnpm --dir libs/usb-drive lint
+      - run:
+          name: Test
+          command: |
+            pnpm --dir libs/usb-drive test
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./reports/
+      - store_test_results:
+          path: libs/usb-drive/reports/
+
   test-libs-utils:
     executor: nodejs-browsers
     resource_class: xlarge
@@ -951,6 +973,7 @@ workflows:
       - test-libs-test-utils
       - test-libs-types
       - test-libs-ui
+      - test-libs-usb-drive
       - test-libs-utils
       - test-services-converter-ms-sems
       - validate-monorepo

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,3 +25,4 @@ libs/logging/ @carolinemodic @votingworks/vxsuite-eng
 libs/auth/ @arsalansufi @votingworks/vxsuite-eng
 libs/dev-dock/ @jonahkagan @votingworks/vxsuite-eng
 libs/grout/ @jonahkagan @votingworks/vxsuite-eng
+libs/usb-drive/ @jonahkagan @votingworks/vxsuite-eng

--- a/apps/scan/backend/package.json
+++ b/apps/scan/backend/package.json
@@ -52,6 +52,7 @@
     "@votingworks/logging": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
     "@votingworks/types": "workspace:*",
+    "@votingworks/usb-drive": "workspace:*",
     "@votingworks/utils": "workspace:*",
     "better-sqlite3": "^7.5.0",
     "buffer": "^6.0.3",

--- a/apps/scan/backend/src/app_auth.test.ts
+++ b/apps/scan/backend/src/app_auth.test.ts
@@ -9,8 +9,8 @@ const jurisdiction = TEST_JURISDICTION;
 const { electionHash } = electionFamousNames2021Fixtures.electionDefinition;
 
 test('getAuthStatus', async () => {
-  await withApp({}, async ({ apiClient, mockAuth, mockUsb }) => {
-    await configureApp(apiClient, mockUsb, { mockAuth });
+  await withApp({}, async ({ apiClient, mockAuth, mockUsbDrive }) => {
+    await configureApp(apiClient, mockUsbDrive, { mockAuth });
 
     // Gets called once during configuration
     expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(1);
@@ -26,8 +26,8 @@ test('getAuthStatus', async () => {
 });
 
 test('checkPin', async () => {
-  await withApp({}, async ({ apiClient, mockAuth, mockUsb }) => {
-    await configureApp(apiClient, mockUsb, { mockAuth });
+  await withApp({}, async ({ apiClient, mockAuth, mockUsbDrive }) => {
+    await configureApp(apiClient, mockUsbDrive, { mockAuth });
 
     await apiClient.checkPin({ pin: '123456' });
     expect(mockAuth.checkPin).toHaveBeenCalledTimes(1);
@@ -40,8 +40,8 @@ test('checkPin', async () => {
 });
 
 test('logOut', async () => {
-  await withApp({}, async ({ apiClient, mockAuth, mockUsb }) => {
-    await configureApp(apiClient, mockUsb, { mockAuth });
+  await withApp({}, async ({ apiClient, mockAuth, mockUsbDrive }) => {
+    await configureApp(apiClient, mockUsbDrive, { mockAuth });
 
     await apiClient.logOut();
     expect(mockAuth.logOut).toHaveBeenCalledTimes(1);
@@ -54,8 +54,8 @@ test('logOut', async () => {
 });
 
 test('updateSessionExpiry', async () => {
-  await withApp({}, async ({ apiClient, mockAuth, mockUsb }) => {
-    await configureApp(apiClient, mockUsb, { mockAuth });
+  await withApp({}, async ({ apiClient, mockAuth, mockUsbDrive }) => {
+    await configureApp(apiClient, mockUsbDrive, { mockAuth });
 
     await apiClient.updateSessionExpiry({
       sessionExpiresAt: DateTime.now().plus({ seconds: 60 }).toJSDate(),

--- a/apps/scan/backend/src/app_usb_drive.test.ts
+++ b/apps/scan/backend/src/app_usb_drive.test.ts
@@ -1,0 +1,23 @@
+import { withApp } from '../test/helpers/custom_helpers';
+
+test('getUsbDriveStatus', async () => {
+  await withApp({}, async ({ apiClient, mockUsbDrive }) => {
+    mockUsbDrive.removeUsbDrive();
+    await expect(apiClient.getUsbDriveStatus()).resolves.toEqual({
+      status: 'no_drive',
+    });
+    mockUsbDrive.insertUsbDrive({});
+    await expect(apiClient.getUsbDriveStatus()).resolves.toEqual({
+      status: 'mounted',
+      mountPoint: expect.any(String),
+      deviceName: 'mock-usb-drive',
+    });
+  });
+});
+
+test('ejectUsbDrive', async () => {
+  await withApp({}, async ({ apiClient, mockUsbDrive }) => {
+    mockUsbDrive.usbDrive.eject.expectCallWith().resolves();
+    await expect(apiClient.ejectUsbDrive()).resolves.toBeUndefined();
+  });
+});

--- a/apps/scan/backend/src/backup.ts
+++ b/apps/scan/backend/src/backup.ts
@@ -15,10 +15,10 @@ import { createReadStream, existsSync } from 'fs-extra';
 import { basename } from 'path';
 import { fileSync } from 'tmp';
 import ZipStream from 'zip-stream';
+import { UsbDrive } from '@votingworks/usb-drive';
 import { Store } from './store';
 import { rootDebug } from './util/debug';
 import { buildExporter } from './util/exporter';
-import { Usb } from './util/usb';
 
 const debug = rootDebug.extend('backup');
 
@@ -235,13 +235,13 @@ export function backup(
  */
 export async function backupToUsbDrive(
   store: Store,
-  usb: Usb,
+  usbDrive: UsbDrive,
   options: BackupOptions = {}
 ): Promise<Result<void, ExportDataError>> {
   const electionDefinition = store.getElectionDefinition();
   assert(electionDefinition, 'Cannot backup without election configuration');
 
-  const exporter = buildExporter(usb);
+  const exporter = buildExporter(usbDrive);
   const result = await exporter.exportDataToUsbDrive(
     SCANNER_BACKUPS_FOLDER,
     `${generateElectionBasedSubfolderName(

--- a/apps/scan/backend/src/scanners/custom/app_scan_double_sheets.test.ts
+++ b/apps/scan/backend/src/scanners/custom/app_scan_double_sheets.test.ts
@@ -21,8 +21,8 @@ const needsReviewInterpretation: SheetInterpretation = {
 test('insert second ballot before first ballot accept', async () => {
   await withApp(
     { delays: {} },
-    async ({ apiClient, mockScanner, mockUsb, mockAuth }) => {
-      await configureApp(apiClient, mockUsb, { mockAuth, testMode: true });
+    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth }) => {
+      await configureApp(apiClient, mockUsbDrive, { mockAuth, testMode: true });
 
       mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
       await waitForStatus(apiClient, { state: 'ready_to_scan' });
@@ -66,8 +66,8 @@ test('insert second ballot while first ballot is accepting', async () => {
         DELAY_ACCEPTED_RESET_TO_NO_PAPER: 2000,
       },
     },
-    async ({ apiClient, mockScanner, interpreter, mockUsb, mockAuth }) => {
-      await configureApp(apiClient, mockUsb, { mockAuth });
+    async ({ apiClient, mockScanner, interpreter, mockUsbDrive, mockAuth }) => {
+      await configureApp(apiClient, mockUsbDrive, { mockAuth });
 
       mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
       await waitForStatus(apiClient, { state: 'ready_to_scan' });
@@ -106,8 +106,8 @@ test('insert second ballot while first ballot is accepting', async () => {
 test('insert second ballot while first ballot needs review', async () => {
   await withApp(
     {},
-    async ({ apiClient, mockScanner, interpreter, mockUsb, mockAuth }) => {
-      await configureApp(apiClient, mockUsb, { mockAuth });
+    async ({ apiClient, mockScanner, interpreter, mockUsbDrive, mockAuth }) => {
+      await configureApp(apiClient, mockUsbDrive, { mockAuth });
 
       mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
       await waitForStatus(apiClient, { state: 'ready_to_scan' });
@@ -157,8 +157,8 @@ test('double sheet on scan', async () => {
         DELAY_JAM_WHEN_SCANNING: 50,
       },
     },
-    async ({ apiClient, mockScanner, mockUsb, mockAuth }) => {
-      await configureApp(apiClient, mockUsb, { mockAuth });
+    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth }) => {
+      await configureApp(apiClient, mockUsbDrive, { mockAuth });
 
       mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
       await waitForStatus(apiClient, { state: 'ready_to_scan' });

--- a/apps/scan/backend/src/scanners/custom/app_scan_jam.test.ts
+++ b/apps/scan/backend/src/scanners/custom/app_scan_jam.test.ts
@@ -24,8 +24,8 @@ test('jam on scan', async () => {
         DELAY_RECONNECT_ON_UNEXPECTED_ERROR: 500,
       },
     },
-    async ({ apiClient, mockScanner, mockUsb, mockAuth }) => {
-      await configureApp(apiClient, mockUsb, { mockAuth });
+    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth }) => {
+      await configureApp(apiClient, mockUsbDrive, { mockAuth });
 
       mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
       await waitForStatus(apiClient, { state: 'ready_to_scan' });
@@ -50,8 +50,8 @@ test('jam on accept', async () => {
         DELAY_ACCEPTING_TIMEOUT: 500,
       },
     },
-    async ({ apiClient, mockScanner, interpreter, mockUsb, mockAuth }) => {
-      await configureApp(apiClient, mockUsb, { mockAuth, testMode: true });
+    async ({ apiClient, mockScanner, interpreter, mockUsbDrive, mockAuth }) => {
+      await configureApp(apiClient, mockUsbDrive, { mockAuth, testMode: true });
 
       mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
       await waitForStatus(apiClient, { state: 'ready_to_scan' });
@@ -95,8 +95,8 @@ test('jam on accept', async () => {
 test('jam on return', async () => {
   await withApp(
     {},
-    async ({ apiClient, mockScanner, interpreter, mockUsb, mockAuth }) => {
-      await configureApp(apiClient, mockUsb, { mockAuth });
+    async ({ apiClient, mockScanner, interpreter, mockUsbDrive, mockAuth }) => {
+      await configureApp(apiClient, mockUsbDrive, { mockAuth });
 
       mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
       await waitForStatus(apiClient, { state: 'ready_to_scan' });
@@ -126,8 +126,8 @@ test('jam on return', async () => {
 test('jam on reject', async () => {
   await withApp(
     {},
-    async ({ apiClient, mockScanner, interpreter, mockUsb, mockAuth }) => {
-      await configureApp(apiClient, mockUsb, { mockAuth });
+    async ({ apiClient, mockScanner, interpreter, mockUsbDrive, mockAuth }) => {
+      await configureApp(apiClient, mockUsbDrive, { mockAuth });
 
       mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
       await waitForStatus(apiClient, { state: 'ready_to_scan' });

--- a/apps/scan/backend/src/scanners/custom/app_scan_power_off.test.ts
+++ b/apps/scan/backend/src/scanners/custom/app_scan_power_off.test.ts
@@ -18,40 +18,46 @@ const needsReviewInterpretation: SheetInterpretation = {
 };
 
 test('scanner powered off while waiting for paper', async () => {
-  await withApp({}, async ({ apiClient, mockScanner, mockUsb, mockAuth }) => {
-    await configureApp(apiClient, mockUsb, { mockAuth });
+  await withApp(
+    {},
+    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth }) => {
+      await configureApp(apiClient, mockUsbDrive, { mockAuth });
 
-    mockScanner.getStatus.mockResolvedValue(err(ErrorCode.ScannerOffline));
-    await waitForStatus(apiClient, { state: 'disconnected' });
+      mockScanner.getStatus.mockResolvedValue(err(ErrorCode.ScannerOffline));
+      await waitForStatus(apiClient, { state: 'disconnected' });
 
-    mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_NO_PAPER));
-    await waitForStatus(apiClient, { state: 'no_paper' });
-  });
+      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_NO_PAPER));
+      await waitForStatus(apiClient, { state: 'no_paper' });
+    }
+  );
 });
 
 test('scanner powered off while scanning', async () => {
-  await withApp({}, async ({ apiClient, mockScanner, mockUsb, mockAuth }) => {
-    await configureApp(apiClient, mockUsb, { mockAuth });
+  await withApp(
+    {},
+    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth }) => {
+      await configureApp(apiClient, mockUsbDrive, { mockAuth });
 
-    mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
-    await waitForStatus(apiClient, { state: 'ready_to_scan' });
+      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
+      await waitForStatus(apiClient, { state: 'ready_to_scan' });
 
-    mockScanner.scan.mockResolvedValue(ok(await ballotImages.completeBmd()));
-    await apiClient.scanBallot();
-    await expectStatus(apiClient, { state: 'scanning' });
-    mockScanner.getStatus.mockResolvedValue(err(ErrorCode.ScannerOffline));
-    await waitForStatus(apiClient, { state: 'disconnected' });
+      mockScanner.scan.mockResolvedValue(ok(await ballotImages.completeBmd()));
+      await apiClient.scanBallot();
+      await expectStatus(apiClient, { state: 'scanning' });
+      mockScanner.getStatus.mockResolvedValue(err(ErrorCode.ScannerOffline));
+      await waitForStatus(apiClient, { state: 'disconnected' });
 
-    mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_INTERNAL_JAM));
-    await waitForStatus(apiClient, { state: 'jammed' });
-  });
+      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_INTERNAL_JAM));
+      await waitForStatus(apiClient, { state: 'jammed' });
+    }
+  );
 });
 
 test('scanner powered off while accepting', async () => {
   await withApp(
     {},
-    async ({ apiClient, mockScanner, interpreter, mockUsb, mockAuth }) => {
-      await configureApp(apiClient, mockUsb, { mockAuth });
+    async ({ apiClient, mockScanner, interpreter, mockUsbDrive, mockAuth }) => {
+      await configureApp(apiClient, mockUsbDrive, { mockAuth });
 
       mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
       await waitForStatus(apiClient, { state: 'ready_to_scan' });
@@ -90,8 +96,8 @@ test('scanner powered off while accepting', async () => {
 test('scanner powered off after accepting', async () => {
   await withApp(
     {},
-    async ({ apiClient, mockScanner, interpreter, mockUsb, mockAuth }) => {
-      await configureApp(apiClient, mockUsb, { mockAuth });
+    async ({ apiClient, mockScanner, interpreter, mockUsbDrive, mockAuth }) => {
+      await configureApp(apiClient, mockUsbDrive, { mockAuth });
 
       mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
       await waitForStatus(apiClient, { state: 'ready_to_scan' });
@@ -136,8 +142,8 @@ test('scanner powered off after accepting', async () => {
 test('scanner powered off while rejecting', async () => {
   await withApp(
     {},
-    async ({ apiClient, mockScanner, interpreter, mockUsb, mockAuth }) => {
-      await configureApp(apiClient, mockUsb, { mockAuth });
+    async ({ apiClient, mockScanner, interpreter, mockUsbDrive, mockAuth }) => {
+      await configureApp(apiClient, mockUsbDrive, { mockAuth });
 
       mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
       await waitForStatus(apiClient, { state: 'ready_to_scan' });
@@ -171,8 +177,8 @@ test('scanner powered off while rejecting', async () => {
 test('scanner powered off while returning', async () => {
   await withApp(
     {},
-    async ({ apiClient, mockScanner, interpreter, mockUsb, mockAuth }) => {
-      await configureApp(apiClient, mockUsb, { mockAuth });
+    async ({ apiClient, mockScanner, interpreter, mockUsbDrive, mockAuth }) => {
+      await configureApp(apiClient, mockUsbDrive, { mockAuth });
 
       mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
       await waitForStatus(apiClient, { state: 'ready_to_scan' });
@@ -204,8 +210,8 @@ test('scanner powered off while returning', async () => {
 test('scanner powered off after returning', async () => {
   await withApp(
     {},
-    async ({ apiClient, mockScanner, interpreter, mockUsb, mockAuth }) => {
-      await configureApp(apiClient, mockUsb, { mockAuth });
+    async ({ apiClient, mockScanner, interpreter, mockUsbDrive, mockAuth }) => {
+      await configureApp(apiClient, mockUsbDrive, { mockAuth });
 
       mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
       await waitForStatus(apiClient, { state: 'ready_to_scan' });

--- a/apps/scan/backend/src/scanners/custom/app_scan_precinct_config.test.ts
+++ b/apps/scan/backend/src/scanners/custom/app_scan_precinct_config.test.ts
@@ -12,129 +12,141 @@ import { SheetInterpretation } from '../../types';
 jest.setTimeout(20_000);
 
 test('bmd ballot is rejected when scanned for wrong precinct', async () => {
-  await withApp({}, async ({ apiClient, mockScanner, mockUsb, mockAuth }) => {
-    // Ballot should be rejected when configured for the wrong precinct
-    await configureApp(apiClient, mockUsb, {
-      precinctId: '22',
-      mockAuth,
-      testMode: true,
-    });
+  await withApp(
+    {},
+    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth }) => {
+      // Ballot should be rejected when configured for the wrong precinct
+      await configureApp(apiClient, mockUsbDrive, {
+        precinctId: '22',
+        mockAuth,
+        testMode: true,
+      });
 
-    mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
-    await waitForStatus(apiClient, { state: 'ready_to_scan' });
+      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
+      await waitForStatus(apiClient, { state: 'ready_to_scan' });
 
-    const interpretation: SheetInterpretation = {
-      type: 'InvalidSheet',
-      reason: 'invalid_precinct',
-    };
+      const interpretation: SheetInterpretation = {
+        type: 'InvalidSheet',
+        reason: 'invalid_precinct',
+      };
 
-    mockScanner.scan.mockResolvedValue(ok(await ballotImages.completeBmd()));
-    await apiClient.scanBallot();
-    await expectStatus(apiClient, { state: 'scanning' });
-    mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
-    await waitForStatus(apiClient, {
-      state: 'rejecting',
-      interpretation,
-    });
-    mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
-    await waitForStatus(apiClient, {
-      state: 'rejected',
-      interpretation,
-    });
+      mockScanner.scan.mockResolvedValue(ok(await ballotImages.completeBmd()));
+      await apiClient.scanBallot();
+      await expectStatus(apiClient, { state: 'scanning' });
+      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
+      await waitForStatus(apiClient, {
+        state: 'rejecting',
+        interpretation,
+      });
+      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
+      await waitForStatus(apiClient, {
+        state: 'rejected',
+        interpretation,
+      });
 
-    mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_NO_PAPER));
-    await waitForStatus(apiClient, { state: 'no_paper' });
-  });
+      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_NO_PAPER));
+      await waitForStatus(apiClient, { state: 'no_paper' });
+    }
+  );
 });
 
 test('bmd ballot is accepted if precinct is set for the right precinct', async () => {
-  await withApp({}, async ({ apiClient, mockScanner, mockUsb, mockAuth }) => {
-    // Configure for the proper precinct and verify the ballot scans
-    await configureApp(apiClient, mockUsb, {
-      precinctId: '23',
-      mockAuth,
-      testMode: true,
-    });
+  await withApp(
+    {},
+    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth }) => {
+      // Configure for the proper precinct and verify the ballot scans
+      await configureApp(apiClient, mockUsbDrive, {
+        precinctId: '23',
+        mockAuth,
+        testMode: true,
+      });
 
-    const validInterpretation: SheetInterpretation = {
-      type: 'ValidSheet',
-    };
+      const validInterpretation: SheetInterpretation = {
+        type: 'ValidSheet',
+      };
 
-    mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
-    await waitForStatus(apiClient, { state: 'ready_to_scan' });
+      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
+      await waitForStatus(apiClient, { state: 'ready_to_scan' });
 
-    mockScanner.scan.mockResolvedValue(ok(await ballotImages.completeBmd()));
-    await apiClient.scanBallot();
-    await expectStatus(apiClient, { state: 'scanning' });
-    mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
-    await waitForStatus(apiClient, {
-      state: 'ready_to_accept',
-      interpretation: validInterpretation,
-    });
-  });
+      mockScanner.scan.mockResolvedValue(ok(await ballotImages.completeBmd()));
+      await apiClient.scanBallot();
+      await expectStatus(apiClient, { state: 'scanning' });
+      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
+      await waitForStatus(apiClient, {
+        state: 'ready_to_accept',
+        interpretation: validInterpretation,
+      });
+    }
+  );
 });
 
 test('hmpb ballot is rejected when scanned for wrong precinct', async () => {
-  await withApp({}, async ({ apiClient, mockScanner, mockUsb, mockAuth }) => {
-    // Ballot should be rejected when configured for the wrong precinct
-    await configureApp(apiClient, mockUsb, {
-      ballotPackage:
-        electionGridLayoutNewHampshireAmherstFixtures.electionJson.toBallotPackage(),
-      precinctId: '22',
-      mockAuth,
-    });
+  await withApp(
+    {},
+    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth }) => {
+      // Ballot should be rejected when configured for the wrong precinct
+      await configureApp(apiClient, mockUsbDrive, {
+        ballotPackage:
+          electionGridLayoutNewHampshireAmherstFixtures.electionJson.toBallotPackage(),
+        precinctId: '22',
+        mockAuth,
+      });
 
-    mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
-    await waitForStatus(apiClient, { state: 'ready_to_scan' });
+      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
+      await waitForStatus(apiClient, { state: 'ready_to_scan' });
 
-    const interpretation: SheetInterpretation = {
-      type: 'InvalidSheet',
-      reason: 'invalid_precinct',
-    };
+      const interpretation: SheetInterpretation = {
+        type: 'InvalidSheet',
+        reason: 'invalid_precinct',
+      };
 
-    mockScanner.scan.mockResolvedValue(ok(await ballotImages.completeHmpb()));
-    await apiClient.scanBallot();
-    await expectStatus(apiClient, { state: 'scanning' });
-    mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
-    await waitForStatus(apiClient, {
-      state: 'rejecting',
-      interpretation,
-    });
-    mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
-    await waitForStatus(apiClient, {
-      state: 'rejected',
-      interpretation,
-    });
+      mockScanner.scan.mockResolvedValue(ok(await ballotImages.completeHmpb()));
+      await apiClient.scanBallot();
+      await expectStatus(apiClient, { state: 'scanning' });
+      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
+      await waitForStatus(apiClient, {
+        state: 'rejecting',
+        interpretation,
+      });
+      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
+      await waitForStatus(apiClient, {
+        state: 'rejected',
+        interpretation,
+      });
 
-    mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_NO_PAPER));
-    await waitForStatus(apiClient, { state: 'no_paper' });
-  });
+      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_NO_PAPER));
+      await waitForStatus(apiClient, { state: 'no_paper' });
+    }
+  );
 });
 
 test('hmpb ballot is accepted if precinct is set for the right precinct', async () => {
-  await withApp({}, async ({ apiClient, mockScanner, mockUsb, mockAuth }) => {
-    // Configure for the proper precinct and verify the ballot scans
-    await configureApp(apiClient, mockUsb, {
-      ballotPackage:
-        electionGridLayoutNewHampshireAmherstFixtures.electionJson.toBallotPackage(),
-      precinctId: 'town-id-00701-precinct-id-',
-      mockAuth,
-    });
+  await withApp(
+    {},
+    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth }) => {
+      // Configure for the proper precinct and verify the ballot scans
+      await configureApp(apiClient, mockUsbDrive, {
+        ballotPackage:
+          electionGridLayoutNewHampshireAmherstFixtures.electionJson.toBallotPackage(),
+        precinctId: 'town-id-00701-precinct-id-',
+        mockAuth,
+      });
 
-    const validInterpretation: SheetInterpretation = {
-      type: 'ValidSheet',
-    };
+      const validInterpretation: SheetInterpretation = {
+        type: 'ValidSheet',
+      };
 
-    mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
-    await waitForStatus(apiClient, { state: 'ready_to_scan' });
+      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
+      await waitForStatus(apiClient, { state: 'ready_to_scan' });
 
-    mockScanner.scan.mockResolvedValue(ok(await ballotImages.completeHmpb()));
-    await apiClient.scanBallot();
-    await expectStatus(apiClient, { state: 'scanning' });
-    mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
-    await waitForStatus(apiClient, {
-      state: 'ready_to_accept',
-      interpretation: validInterpretation,
-    });
-  });
+      mockScanner.scan.mockResolvedValue(ok(await ballotImages.completeHmpb()));
+      await apiClient.scanBallot();
+      await expectStatus(apiClient, { state: 'scanning' });
+      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
+      await waitForStatus(apiClient, {
+        state: 'ready_to_accept',
+        interpretation: validInterpretation,
+      });
+    }
+  );
 });

--- a/apps/scan/backend/src/server.ts
+++ b/apps/scan/backend/src/server.ts
@@ -5,8 +5,8 @@ import {
   JavaCard,
   MockFileCard,
 } from '@votingworks/auth';
-import { getUsbDrives } from '@votingworks/backend';
 import { LogEventId, Logger, LogSource } from '@votingworks/logging';
+import { detectUsbDrive } from '@votingworks/usb-drive';
 import {
   BooleanEnvironmentVariableName,
   isFeatureFlagEnabled,
@@ -16,7 +16,6 @@ import { buildApp } from './app';
 import { PORT } from './globals';
 import { PrecinctScannerInterpreter } from './interpret';
 import { PrecinctScannerStateMachine } from './types';
-import { Usb } from './util/usb';
 import { Workspace } from './util/workspace';
 
 export interface StartOptions {
@@ -51,7 +50,7 @@ export function start({
       logger,
     });
 
-  const usb: Usb = { getUsbDrives };
+  const usbDrive = detectUsbDrive();
 
   // Clear any cached data
   workspace.clearUploads();
@@ -61,7 +60,7 @@ export function start({
     precinctScannerStateMachine,
     precinctScannerInterpreter,
     workspace,
-    usb,
+    usbDrive,
     logger
   );
 

--- a/apps/scan/backend/src/util/exporter.ts
+++ b/apps/scan/backend/src/util/exporter.ts
@@ -1,14 +1,18 @@
 import { Exporter } from '@votingworks/backend';
-import { Usb } from './usb';
+import { UsbDrive } from '@votingworks/usb-drive';
 import { SCAN_ALLOWED_EXPORT_PATTERNS } from '../globals';
 
 /**
  * Builds an exporter suitable for saving data to a file or USB drive.
  */
-export function buildExporter(usb: Usb): Exporter {
+export function buildExporter(usbDrive: UsbDrive): Exporter {
   const exporter = new Exporter({
     allowedExportPatterns: SCAN_ALLOWED_EXPORT_PATTERNS,
-    getUsbDrives: usb.getUsbDrives,
+    // TODO Convert Exporter to use libs/usb-drive types
+    getUsbDrives: async () => {
+      const drive = await usbDrive.status();
+      return drive.status === 'mounted' ? [drive] : [];
+    },
   });
   return exporter;
 }

--- a/apps/scan/backend/src/util/usb.ts
+++ b/apps/scan/backend/src/util/usb.ts
@@ -1,9 +1,0 @@
-import { UsbDrive } from '@votingworks/backend';
-
-/**
- * An interface for interacting with USB drives. We inject this into the app so
- * that we can easily mock it in tests.
- */
-export interface Usb {
-  getUsbDrives: () => Promise<UsbDrive[]>;
-}

--- a/apps/scan/backend/test/helpers/custom_helpers.ts
+++ b/apps/scan/backend/test/helpers/custom_helpers.ts
@@ -26,7 +26,7 @@ import { Application } from 'express';
 import { Server } from 'http';
 import { AddressInfo } from 'net';
 import tmp from 'tmp';
-import { MockUsb, createMockUsb } from '@votingworks/backend';
+import { createMockUsbDrive, MockUsbDrive } from '@votingworks/usb-drive';
 import { Api, buildApp } from '../../src/app';
 import {
   PrecinctScannerInterpreter,
@@ -53,7 +53,7 @@ export async function withApp(
     mockAuth: InsertedSmartCardAuthApi;
     mockScanner: jest.Mocked<CustomScanner>;
     workspace: Workspace;
-    mockUsb: MockUsb;
+    mockUsbDrive: MockUsbDrive;
     logger: Logger;
     interpreter: PrecinctScannerInterpreter;
     server: Server;
@@ -89,13 +89,13 @@ export async function withApp(
       ...delays,
     },
   });
-  const mockUsb = createMockUsb();
+  const mockUsbDrive = createMockUsbDrive();
   const app = buildApp(
     mockAuth,
     precinctScannerMachine,
     interpreter,
     workspace,
-    mockUsb.mock,
+    mockUsbDrive.usbDrive,
     logger
   );
 
@@ -116,11 +116,12 @@ export async function withApp(
       mockAuth,
       mockScanner,
       workspace,
-      mockUsb,
+      mockUsbDrive,
       logger,
       interpreter,
       server,
     });
+    mockUsbDrive.assertComplete();
   } finally {
     const { promise, resolve, reject } = deferred<void>();
     server.close((error) => (error ? reject(error) : resolve()));

--- a/apps/scan/backend/test/helpers/shared_helpers.ts
+++ b/apps/scan/backend/test/helpers/shared_helpers.ts
@@ -1,6 +1,6 @@
 import { InsertedSmartCardAuthApi } from '@votingworks/auth';
 import { ok } from '@votingworks/basics';
-import { MockUsb, createBallotPackageZipArchive } from '@votingworks/backend';
+import { createBallotPackageZipArchive } from '@votingworks/backend';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 import * as grout from '@votingworks/grout';
 import {
@@ -14,6 +14,7 @@ import {
   singlePrecinctSelectionFor,
 } from '@votingworks/utils';
 import waitForExpect from 'wait-for-expect';
+import { MockUsbDrive } from '@votingworks/usb-drive';
 import { Api } from '../../src/app';
 import { PrecinctScannerInterpreter } from '../../src/interpret';
 import {
@@ -54,7 +55,7 @@ export async function waitForStatus(
 /**
  * configureApp is a testing convenience function that handles some common configuration of the VxScan app.
  * @param apiClient - a VxScan API client
- * @param mockUsb - a mock USB
+ * @param mockUsbDrive - a mock USB drive
  * @param options - an object containing optional arguments
  * @param options.mockAuth - a mock InsertedSmartCardAuthApi. Passing this will automatically
  *                           create a mock that auths the user as an election manager of the same
@@ -62,7 +63,7 @@ export async function waitForStatus(
  */
 export async function configureApp(
   apiClient: grout.Client<Api>,
-  mockUsb: MockUsb,
+  mockUsbDrive: MockUsbDrive,
   {
     ballotPackage = electionFamousNames2021Fixtures.electionJson.toBallotPackage(),
     precinctId,
@@ -85,7 +86,7 @@ export async function configureApp(
     );
   }
 
-  mockUsb.insertUsbDrive({
+  mockUsbDrive.insertUsbDrive({
     'ballot-packages': {
       'test-ballot-package.zip': await createBallotPackageZipArchive(
         ballotPackage

--- a/apps/scan/backend/tsconfig.build.json
+++ b/apps/scan/backend/tsconfig.build.json
@@ -27,6 +27,7 @@
     { "path": "../../../libs/logging/tsconfig.build.json" },
     { "path": "../../../libs/test-utils/tsconfig.build.json" },
     { "path": "../../../libs/types/tsconfig.build.json" },
+    { "path": "../../../libs/usb-drive/tsconfig.build.json" },
     { "path": "../../../libs/utils/tsconfig.build.json" }
   ]
 }

--- a/apps/scan/backend/tsconfig.json
+++ b/apps/scan/backend/tsconfig.json
@@ -34,6 +34,7 @@
     { "path": "../../../libs/logging/tsconfig.build.json" },
     { "path": "../../../libs/test-utils/tsconfig.build.json" },
     { "path": "../../../libs/types/tsconfig.build.json" },
+    { "path": "../../../libs/usb-drive/tsconfig.build.json" },
     { "path": "../../../libs/utils/tsconfig.build.json" }
   ]
 }

--- a/apps/scan/frontend/package.json
+++ b/apps/scan/frontend/package.json
@@ -104,6 +104,7 @@
     "@votingworks/grout-test-utils": "workspace:*",
     "@votingworks/scan-backend": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
+    "@votingworks/usb-drive": "workspace:*",
     "eslint": "8.23.1",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.5.0",

--- a/apps/scan/frontend/src/api.ts
+++ b/apps/scan/frontend/src/api.ts
@@ -12,11 +12,11 @@ import {
 import { CastVoteRecord } from '@votingworks/types';
 import {
   AUTH_STATUS_POLLING_INTERVAL_MS,
+  USB_DRIVE_STATUS_POLLING_INTERVAL_MS,
   QUERY_CLIENT_DEFAULT_OPTIONS,
   UsbDriveStatus as LegacyUsbDriveStatus,
 } from '@votingworks/ui';
 import { typedAs } from '@votingworks/basics';
-// eslint-disable-next-line vx/gts-no-import-export-type
 import type { UsbDriveStatus } from '@votingworks/usb-drive';
 
 export type ApiClient = grout.Client<Api>;
@@ -122,7 +122,7 @@ export const getUsbDriveStatus = {
   useQuery() {
     const apiClient = useApiClient();
     return useQuery(this.queryKey(), () => apiClient.getUsbDriveStatus(), {
-      refetchInterval: 500,
+      refetchInterval: USB_DRIVE_STATUS_POLLING_INTERVAL_MS,
     });
   },
 } as const;

--- a/apps/scan/frontend/src/app_tally_report_paths.test.tsx
+++ b/apps/scan/frontend/src/app_tally_report_paths.test.tsx
@@ -8,13 +8,12 @@ import {
   electionSample2Definition,
 } from '@votingworks/fixtures';
 import {
-  fakeKiosk,
   advanceTimersAndPromises,
   generateCvr,
   getZeroCompressedTally,
-  fakeUsbDrive,
   expectPrint,
   hasTextAcrossElements,
+  fakeKiosk,
 } from '@votingworks/test-utils';
 import {
   ALL_PRECINCTS_SELECTION,
@@ -38,7 +37,6 @@ import MockDate from 'mockdate';
 import { fakeLogger } from '@votingworks/logging';
 import { err } from '@votingworks/basics';
 import { render, screen, within } from '../test/react_testing_library';
-import { fakeFileWriter } from '../test/helpers/fake_file_writer';
 import { App } from './app';
 import {
   ApiMock,
@@ -104,13 +102,10 @@ beforeEach(() => {
   jest.useFakeTimers();
   apiMock = createApiMock();
   apiMock.expectGetMachineConfig();
+  apiMock.expectGetUsbDriveStatus('mounted');
   apiMock.removeCard(); // Set a default auth state of no card inserted.
 
   const kiosk = fakeKiosk();
-  kiosk.getUsbDriveInfo.mockResolvedValue([fakeUsbDrive()]);
-  kiosk.writeFile.mockResolvedValue(
-    fakeFileWriter() as unknown as ReturnType<KioskBrowser.Kiosk['writeFile']>
-  );
   window.kiosk = kiosk;
 });
 

--- a/apps/scan/frontend/src/app_unhappy_paths.test.tsx
+++ b/apps/scan/frontend/src/app_unhappy_paths.test.tsx
@@ -4,7 +4,6 @@ import { electionSampleDefinition } from '@votingworks/fixtures';
 import {
   advanceTimersAndPromises,
   fakeKiosk,
-  fakeUsbDrive,
   suppressingConsoleOutput,
 } from '@votingworks/test-utils';
 import { MemoryHardware } from '@votingworks/utils';
@@ -46,6 +45,7 @@ beforeEach(() => {
   jest.useFakeTimers();
   apiMock = createApiMock();
   apiMock.expectGetMachineConfig();
+  apiMock.expectGetUsbDriveStatus('mounted');
   apiMock.removeCard(); // Set a default auth state of no card inserted.
 });
 
@@ -70,6 +70,7 @@ test('backend fails to unconfigure', async () => {
   apiMock.expectCheckUltrasonicSupported(false);
   apiMock.expectGetConfig();
   apiMock.expectGetScannerStatus({ ...statusNoPaper, canUnconfigure: true });
+  apiMock.mockApiClient.ejectUsbDrive.expectCallWith().resolves();
   apiMock.mockApiClient.unconfigureElection
     .expectCallWith({})
     .throws(new ServerError('failed'));
@@ -209,7 +210,6 @@ test('App shows warning message to connect to power when disconnected', async ()
   hardware.setBatteryDischarging(true);
   hardware.setBatteryLevel(0.9);
   const kiosk = fakeKiosk();
-  kiosk.getUsbDriveInfo = jest.fn().mockResolvedValue([fakeUsbDrive()]);
   window.kiosk = kiosk;
   apiMock.expectGetScannerStatus(statusNoPaper);
   renderApp({ hardware });

--- a/apps/scan/frontend/src/components/export_backup_modal.test.tsx
+++ b/apps/scan/frontend/src/components/export_backup_modal.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils';
 import { err, ok } from '@votingworks/basics';
-import { UsbDriveStatus, mockUsbDrive } from '@votingworks/ui';
+// eslint-disable-next-line vx/gts-no-import-export-type
+import type { UsbDriveStatus } from '@votingworks/usb-drive';
 import { render, screen } from '../../test/react_testing_library';
 import {
   ApiMock,
@@ -13,6 +13,7 @@ import {
   ExportBackupModal,
   ExportBackupModalProps,
 } from './export_backup_modal';
+import { fakeUsbDriveStatus } from '../../test/helpers/fake_usb_drive';
 
 let apiMock: ApiMock;
 
@@ -30,33 +31,25 @@ function renderModal(props: Partial<ExportBackupModalProps> = {}) {
       apiMock,
       <ExportBackupModal
         onClose={jest.fn()}
-        usbDrive={mockUsbDrive('mounting')}
+        usbDrive={fakeUsbDriveStatus('mounted')}
         {...props}
       />
     )
   );
 }
 
-test('renders loading screen when USB drive is mounting or ejecting in export modal', () => {
-  const usbStatuses: UsbDriveStatus[] = ['mounting', 'ejecting'];
-
-  for (const status of usbStatuses) {
-    const { unmount } = renderModal({
-      usbDrive: mockUsbDrive(status),
-    });
-    screen.getByText('Loading');
-    unmount();
-  }
-});
-
 test('render no USB found screen when there is not a compatible mounted USB drive', () => {
-  const usbStatuses: UsbDriveStatus[] = ['absent', 'ejected', 'bad_format'];
+  const usbStatuses: Array<UsbDriveStatus['status']> = [
+    'no_drive',
+    'ejected',
+    'error',
+  ];
 
   for (const status of usbStatuses) {
     const onClose = jest.fn();
     const { unmount } = renderModal({
       onClose,
-      usbDrive: mockUsbDrive(status),
+      usbDrive: fakeUsbDriveStatus(status),
     });
     screen.getByText('No USB Drive Detected');
     screen.getByText('Please insert a USB drive to save the backup.');
@@ -70,15 +63,10 @@ test('render no USB found screen when there is not a compatible mounted USB driv
 });
 
 test('render export modal when a USB drive is mounted as expected and allows automatic export', async () => {
-  const mockKiosk = fakeKiosk();
-  window.kiosk = mockKiosk;
-  mockKiosk.getUsbDriveInfo.mockResolvedValue([fakeUsbDrive()]);
-
   const onClose = jest.fn();
-  const usbDrive = mockUsbDrive('mounted');
   renderModal({
     onClose,
-    usbDrive,
+    usbDrive: fakeUsbDriveStatus('mounted'),
   });
   screen.getByText('Save Backup');
 
@@ -86,44 +74,20 @@ test('render export modal when a USB drive is mounted as expected and allows aut
   userEvent.click(screen.getByText('Save'));
   await screen.findByText('Backup Saved');
 
+  apiMock.mockApiClient.ejectUsbDrive.expectCallWith().resolves();
   userEvent.click(screen.getByText('Eject USB'));
-  expect(usbDrive.eject).toHaveBeenCalled();
   userEvent.click(screen.getByText('Cancel'));
   expect(onClose).toHaveBeenCalled();
 });
 
-test('handles no USB drives', async () => {
-  const mockKiosk = fakeKiosk();
-  window.kiosk = mockKiosk;
-
-  const onClose = jest.fn();
-  renderModal({
-    onClose,
-    usbDrive: mockUsbDrive('mounted'),
-  });
-  screen.getByText('Save Backup');
-
-  mockKiosk.getUsbDriveInfo.mockResolvedValueOnce([]);
-  userEvent.click(screen.getByText('Save'));
-  await screen.findByText('Failed to Save Backup');
-  screen.getByText(/No USB drive found./);
-
-  userEvent.click(screen.getByText('Close'));
-  expect(onClose).toHaveBeenCalled();
-});
-
 test('shows errors from the backend', async () => {
-  const mockKiosk = fakeKiosk();
-  window.kiosk = mockKiosk;
-
   const onClose = jest.fn();
   renderModal({
     onClose,
-    usbDrive: mockUsbDrive('mounted'),
+    usbDrive: fakeUsbDriveStatus('mounted'),
   });
   screen.getByText('Save Backup');
 
-  mockKiosk.getUsbDriveInfo.mockResolvedValueOnce([fakeUsbDrive()]);
   apiMock.mockApiClient.backupToUsbDrive
     .expectCallWith()
     .resolves(err({ type: 'permission-denied', message: 'Permission denied' }));

--- a/apps/scan/frontend/test/helpers/fake_usb_drive.ts
+++ b/apps/scan/frontend/test/helpers/fake_usb_drive.ts
@@ -1,0 +1,26 @@
+import { throwIllegalValue } from '@votingworks/basics';
+// eslint-disable-next-line vx/gts-no-import-export-type
+import type { UsbDriveStatus } from '@votingworks/usb-drive';
+
+export function fakeUsbDriveStatus(
+  status: UsbDriveStatus['status']
+): UsbDriveStatus {
+  switch (status) {
+    case 'mounted':
+      return {
+        status,
+        mountPoint: 'test-mount-point',
+        deviceName: 'test-device-name',
+      };
+    case 'no_drive':
+    case 'ejected':
+      return { status };
+    case 'error':
+      return {
+        status,
+        reason: 'bad_format',
+      };
+    default:
+      throwIllegalValue(status);
+  }
+}

--- a/apps/scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/scan/frontend/test/helpers/mock_api_client.tsx
@@ -25,7 +25,9 @@ import {
   fakeSessionExpiresAt,
   fakeSystemAdministratorUser,
 } from '@votingworks/test-utils';
+import { UsbDriveStatus } from '@votingworks/usb-drive';
 import { ApiClientContext, createQueryClient } from '../../src/api';
+import { fakeUsbDriveStatus } from './fake_usb_drive';
 
 export const machineConfig: MachineConfig = {
   machineId: '0002',
@@ -116,6 +118,12 @@ export function createApiMock() {
         status: 'logged_out',
         reason: 'no_card',
       });
+    },
+
+    expectGetUsbDriveStatus(status: UsbDriveStatus['status']): void {
+      mockApiClient.getUsbDriveStatus
+        .expectRepeatedCallsWith()
+        .resolves(fakeUsbDriveStatus(status));
     },
 
     expectGetMachineConfig(): void {

--- a/apps/scan/frontend/tsconfig.json
+++ b/apps/scan/frontend/tsconfig.json
@@ -31,6 +31,7 @@
     { "path": "../../../libs/test-utils/tsconfig.build.json" },
     { "path": "../../../libs/types/tsconfig.build.json" },
     { "path": "../../../libs/ui/tsconfig.build.json" },
+    { "path": "../../../libs/usb-drive/tsconfig.build.json" },
     { "path": "../../../libs/utils/tsconfig.build.json" }
   ]
 }

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -84,5 +84,6 @@ export * from './export_logs_modal';
 export * from './graphics';
 export * from './types';
 export * from './unconfigured_election_screen';
+export * from './usb_drive';
 export * from './power_down_button';
 export * from './voter_contest_summary';

--- a/libs/ui/src/usb_drive.ts
+++ b/libs/ui/src/usb_drive.ts
@@ -1,0 +1,2 @@
+/* istanbul ignore next */
+export const USB_DRIVE_STATUS_POLLING_INTERVAL_MS = 100;

--- a/libs/ui/src/usbcontroller_button.tsx
+++ b/libs/ui/src/usbcontroller_button.tsx
@@ -21,6 +21,7 @@ interface Props {
   usbDriveEject: () => void;
   primary?: boolean;
   small?: boolean;
+  disabled?: boolean;
 }
 
 export function UsbControllerButton({
@@ -28,12 +29,18 @@ export function UsbControllerButton({
   usbDriveEject,
   primary = false,
   small = true,
+  disabled = false,
 }: Props): JSX.Element | null {
   const variant: ButtonVariant = primary ? 'primary' : 'regular';
 
   if (usbDriveStatus === 'mounted') {
     return (
-      <Button small={small} variant={variant} onPress={usbDriveEject}>
+      <Button
+        small={small}
+        variant={variant}
+        onPress={usbDriveEject}
+        disabled={disabled}
+      >
         Eject USB
       </Button>
     );

--- a/libs/usb-drive/.eslintignore
+++ b/libs/usb-drive/.eslintignore
@@ -1,0 +1,3 @@
+build
+coverage
+jest.config.js

--- a/libs/usb-drive/.eslintrc.json
+++ b/libs/usb-drive/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["plugin:vx/recommended"],
+  "rules": {
+    "vx/gts-jsdoc": "off"
+  }
+}

--- a/libs/usb-drive/README.md
+++ b/libs/usb-drive/README.md
@@ -13,3 +13,7 @@ A few things to note:
 
 You can use `./bin/usb-drive <command>` to play with the API. Run
 `./bin/usb-drive` to see the available commands.
+
+## Debugging
+
+Set `DEBUG=usb-drive` to see debug logs.

--- a/libs/usb-drive/README.md
+++ b/libs/usb-drive/README.md
@@ -1,0 +1,15 @@
+# usb-drive
+
+A library for interacting with a USB drive. Intended to be used by app backends.
+
+A few things to note:
+
+- The library only supports interacting with a single USB drive at a time (since
+  our machines should only ever have one USB drive plugged in at a time).
+- The library will automatically mount the USB drive if it is not already
+  mounted.
+
+## CLI
+
+You can use `./bin/usb-drive <command>` to play with the API. Run
+`./bin/usb-drive` to see the available commands.

--- a/libs/usb-drive/README.md
+++ b/libs/usb-drive/README.md
@@ -9,6 +9,16 @@ A few things to note:
 - The library will automatically mount the USB drive if it is not already
   mounted.
 
+## Setup
+
+In order for this library to work, it will need `sudo` access to two scripts:
+`src/mount.sh` and `src/unmount.sh`. You can set this up by adding the following
+to your `/etc/sudoers` file:
+
+```
+<username> ALL=(root:ALL) NOPASSWD: /path/to/vxsuite/libs/usb-drive/src/*.sh
+```
+
 ## CLI
 
 You can use `./bin/usb-drive <command>` to play with the API. Run

--- a/libs/usb-drive/bin/usb-drive
+++ b/libs/usb-drive/bin/usb-drive
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+// @ts-check
+
+require('esbuild-runner/register');
+
+require('../src/cli')
+  .main(process.argv)
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/libs/usb-drive/jest.config.js
+++ b/libs/usb-drive/jest.config.js
@@ -1,4 +1,4 @@
-const shared = require('../../../jest.config.shared');
+const shared = require('../../jest.config.shared');
 
 /**
  * @type {import('@jest/types').Config.InitialOptions}

--- a/libs/usb-drive/jest.config.js
+++ b/libs/usb-drive/jest.config.js
@@ -1,0 +1,8 @@
+const shared = require('../../../jest.config.shared');
+
+/**
+ * @type {import('@jest/types').Config.InitialOptions}
+ */
+module.exports = {
+  ...shared,
+};

--- a/libs/usb-drive/package.json
+++ b/libs/usb-drive/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@votingworks/usb-drive",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Library for interacting with a USB drive",
+  "license": "GPL-3.0",
+  "author": "VotingWorks Eng <eng@voting.works>",
+  "main": "build/index.js",
+  "types": "build/index.d.js",
+  "scripts": {
+    "build": "tsc --build tsconfig.build.json",
+    "clean": "rm -rf build *.tsbuildinfo",
+    "lint": "pnpm type-check && eslint .",
+    "lint:fix": "pnpm type-check && eslint . --fix",
+    "pre-commit": "lint-staged",
+    "test": "is-ci test:ci test:watch",
+    "test:ci": "TZ=UTC pnpm build && pnpm test:coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:coverage": "TZ=UTC jest --coverage",
+    "test:watch": "TZ=UTC jest --watch",
+    "type-check": "tsc --build"
+  },
+  "lint-staged": {
+    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
+      "prettier --write"
+    ],
+    "*.+(js|jsx|ts|tsx)": [
+      "eslint --quiet --fix"
+    ],
+    "package.json": [
+      "sort-package-json"
+    ]
+  },
+  "dependencies": {
+    "@votingworks/basics": "workspace:*",
+    "debug": "^4.3.2"
+  },
+  "devDependencies": {
+    "@types/debug": "^4.1.7",
+    "@types/jest": "^27.0.3",
+    "@types/node": "^18.11.18",
+    "@types/styled-components": "^5.1.9",
+    "@typescript-eslint/eslint-plugin": "^5.37.0",
+    "@typescript-eslint/parser": "^5.37.0",
+    "esbuild": "^0.17.11",
+    "esbuild-runner": "^2.2.2",
+    "eslint": "8.23.1",
+    "eslint-config-prettier": "^8.5.0",
+    "eslint-import-resolver-node": "^0.3.6",
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-jest": "^26.1.5",
+    "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-vx": "workspace:*",
+    "is-ci-cli": "^2.2.0",
+    "jest": "^27.3.1",
+    "jest-junit": "^14.0.1",
+    "jest-watch-typeahead": "^0.6.4",
+    "lint-staged": "^11.0.0",
+    "prettier": "^2.6.2",
+    "sort-package-json": "^1.50.0",
+    "ts-jest": "^27.0.7",
+    "typescript": "4.6.3"
+  },
+  "packageManager": "pnpm@7.24.3"
+}

--- a/libs/usb-drive/package.json
+++ b/libs/usb-drive/package.json
@@ -39,11 +39,11 @@
   "devDependencies": {
     "@types/debug": "^4.1.7",
     "@types/jest": "^27.0.3",
-    "@types/node": "^18.11.18",
+    "@types/node": "16.18.23",
     "@types/styled-components": "^5.1.9",
     "@types/tmp": "^0.2.3",
-    "@typescript-eslint/eslint-plugin": "^5.37.0",
-    "@typescript-eslint/parser": "^5.37.0",
+    "@typescript-eslint/eslint-plugin": "5.37.0",
+    "@typescript-eslint/parser": "5.37.0",
     "esbuild": "^0.17.11",
     "esbuild-runner": "^2.2.2",
     "eslint": "8.23.1",
@@ -58,10 +58,10 @@
     "jest-junit": "^14.0.1",
     "jest-watch-typeahead": "^0.6.4",
     "lint-staged": "^11.0.0",
-    "prettier": "^2.6.2",
+    "prettier": "2.6.2",
     "sort-package-json": "^1.50.0",
     "ts-jest": "^27.0.7",
     "typescript": "4.6.3"
   },
-  "packageManager": "pnpm@7.24.3"
+  "packageManager": "pnpm@8.1.0"
 }

--- a/libs/usb-drive/package.json
+++ b/libs/usb-drive/package.json
@@ -32,13 +32,16 @@
   },
   "dependencies": {
     "@votingworks/basics": "workspace:*",
-    "debug": "^4.3.2"
+    "@votingworks/test-utils": "workspace:*",
+    "debug": "^4.3.2",
+    "tmp": "^0.2.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",
     "@types/jest": "^27.0.3",
     "@types/node": "^18.11.18",
     "@types/styled-components": "^5.1.9",
+    "@types/tmp": "^0.2.3",
     "@typescript-eslint/eslint-plugin": "^5.37.0",
     "@typescript-eslint/parser": "^5.37.0",
     "esbuild": "^0.17.11",

--- a/libs/usb-drive/src/cli.ts
+++ b/libs/usb-drive/src/cli.ts
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 import { sleep } from '@votingworks/basics';
 import { detectUsbDrive, UsbDrive } from './usb_drive';
 

--- a/libs/usb-drive/src/cli.ts
+++ b/libs/usb-drive/src/cli.ts
@@ -1,0 +1,47 @@
+import { sleep } from '@votingworks/basics';
+import { detectUsbDrive, UsbDrive } from './usb_drive';
+
+async function printStatus(usbDrive: UsbDrive, stdout: NodeJS.WriteStream) {
+  const status = await usbDrive.status();
+  stdout.write(`${JSON.stringify(status)}\n`);
+}
+
+async function watchUsbDrive(usbDrive: UsbDrive): Promise<void> {
+  const { stdout } = process;
+  for (;;) {
+    await printStatus(usbDrive, stdout);
+    await sleep(1000);
+  }
+}
+
+export async function main(args: string[]): Promise<number> {
+  const { stdout, stderr } = process;
+  const command = args[2];
+  const usbDrive = detectUsbDrive();
+  switch (command) {
+    case 'status': {
+      await printStatus(usbDrive, stdout);
+      break;
+    }
+    case 'eject': {
+      await usbDrive.eject();
+      stdout.write('Ejected\n');
+      await printStatus(usbDrive, stdout);
+      break;
+    }
+    case 'watch': {
+      await watchUsbDrive(usbDrive);
+      break;
+    }
+    case undefined: {
+      stderr.write(`Usage: usb-drive status|eject|watch\n`);
+      break;
+    }
+    default: {
+      stderr.write(`Unknown command: ${command}\n`);
+      stderr.write(`Usage: usb-drive status|eject|watch\n`);
+      return 1;
+    }
+  }
+  return 0;
+}

--- a/libs/usb-drive/src/exec.ts
+++ b/libs/usb-drive/src/exec.ts
@@ -1,0 +1,9 @@
+/* istanbul ignore file */
+/**
+ * Small module to make it easier to mock execFile.
+ */
+
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+export const exec = promisify(execFile);

--- a/libs/usb-drive/src/index.ts
+++ b/libs/usb-drive/src/index.ts
@@ -1,0 +1,2 @@
+/* istanbul ignore file */
+export * from './usb_drive';

--- a/libs/usb-drive/src/index.ts
+++ b/libs/usb-drive/src/index.ts
@@ -1,2 +1,3 @@
 /* istanbul ignore file */
 export * from './usb_drive';
+export * from './mock_usb_drive';

--- a/libs/usb-drive/src/mock_usb_drive.ts
+++ b/libs/usb-drive/src/mock_usb_drive.ts
@@ -1,0 +1,88 @@
+import { MockFunction, mockFunction } from '@votingworks/test-utils';
+import { execSync } from 'child_process';
+import { join } from 'path';
+import { mkdirSync, writeFileSync } from 'fs';
+import tmp from 'tmp';
+import { Buffer } from 'buffer';
+import { UsbDrive } from './usb_drive';
+
+type MockFileTree = MockFile | MockDirectory;
+type MockFile = Buffer;
+interface MockDirectory {
+  [name: string]: MockFileTree;
+}
+
+function writeMockFileTree(destinationPath: string, tree: MockFileTree): void {
+  if (Buffer.isBuffer(tree)) {
+    writeFileSync(destinationPath, tree);
+  } else {
+    mkdirSync(destinationPath, { recursive: true });
+    for (const [name, child] of Object.entries(tree)) {
+      // Sleep 1ms to ensure that each file is created with a distinct timestamp
+      execSync('sleep 0.01');
+      writeMockFileTree(join(destinationPath, name), child);
+    }
+  }
+}
+
+type MockedUsbDrive = {
+  [Method in keyof UsbDrive]: MockFunction<UsbDrive[Method]>;
+};
+
+/**
+ * A mock of the UsbDrive interface. See createMockUsbDrive for details.
+ */
+export interface MockUsbDrive {
+  usbDrive: MockedUsbDrive;
+  assertComplete(): void;
+  insertUsbDrive(contents: MockFileTree): void;
+  removeUsbDrive(): void;
+}
+
+/**
+ * Creates a mock of the UsbDrive interface. Each method is mocked with a
+ * mockFunction (see @votingworks/test-utils).
+ *
+ * Also has a insert()/remove() interface to create a fake USB drive backed by a
+ * filesystem directory. If using this interface, the mock functions will
+ * automatically be updated to return the correct status.
+ *
+ * Warning: if you use both interfaces, they may get out of sync.
+ */
+export function createMockUsbDrive(): MockUsbDrive {
+  let mockUsbTmpDir: tmp.DirResult | undefined;
+
+  const usbDrive: MockedUsbDrive = {
+    status: mockFunction('status'),
+    eject: mockFunction('eject'),
+  };
+
+  return {
+    usbDrive,
+
+    assertComplete() {
+      for (const method of Object.values(usbDrive)) {
+        method.assertComplete();
+      }
+    },
+
+    insertUsbDrive(contents: MockFileTree) {
+      mockUsbTmpDir?.removeCallback();
+      mockUsbTmpDir = tmp.dirSync({ unsafeCleanup: true });
+      writeMockFileTree(mockUsbTmpDir.name, contents);
+      usbDrive.status.expectRepeatedCallsWith().resolves({
+        status: 'mounted',
+        mountPoint: mockUsbTmpDir.name,
+        deviceName: 'mock-usb-drive',
+      });
+    },
+
+    removeUsbDrive() {
+      mockUsbTmpDir?.removeCallback();
+      mockUsbTmpDir = undefined;
+      usbDrive.status
+        .expectRepeatedCallsWith()
+        .resolves({ status: 'no_drive' });
+    },
+  };
+}

--- a/libs/usb-drive/src/mock_usb_drive.ts
+++ b/libs/usb-drive/src/mock_usb_drive.ts
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 import { MockFunction, mockFunction } from '@votingworks/test-utils';
 import { execSync } from 'child_process';
 import { join } from 'path';

--- a/libs/usb-drive/src/mount.sh
+++ b/libs/usb-drive/src/mount.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -euo pipefail
+
+usage () {
+    echo 'Usage: mount.sh <device>'
+    exit 1
+}
+
+if ! [[ $# -eq 1 ]]; then
+    usage
+fi
+
+USB_DRIVE_DEVICE_REGEX=^/dev/sd[a-z][0-9]$
+LOOP_DEVICE_REGEX=^/dev/loop[0-9]p[0-9]$
+
+if ! [[ $1 =~ $USB_DRIVE_DEVICE_REGEX || $1 =~ $LOOP_DEVICE_REGEX ]]; then
+    echo "mount.sh: device \"${1}\" is not a USB drive"
+    exit 1
+fi
+
+DEVICE=$1
+MOUNTPOINT=/media/vx/usb-drive
+
+# The mount point will already exist in production but possibly not in development
+if ! [[ -e $MOUNTPOINT ]]; then
+    mkdir -p $MOUNTPOINT 
+fi
+mount -w -o umask=000,nosuid,nodev,noexec $DEVICE $MOUNTPOINT

--- a/libs/usb-drive/src/unmount.sh
+++ b/libs/usb-drive/src/unmount.sh
@@ -21,4 +21,9 @@ if ! [[ $MOUNTPOINT = $VX_MOUNTPOINT || $MOUNTPOINT =~ $DEV_MOUNTPOINT_REGEX ]];
     echo "unmount.sh: mount point \"${MOUNTPOINT}\" is not a valid mounted USB drive"
     exit 1
 fi
+
+# Run sync before unmounting to force any cached file data to be flushed to the
+# removable drive. Used to prevent incomplete file transfers.
+sync -f $MOUNTPOINT
+
 umount $MOUNTPOINT

--- a/libs/usb-drive/src/unmount.sh
+++ b/libs/usb-drive/src/unmount.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euo pipefail
+
+usage () {
+    echo 'Usage: unmount-usb.sh'
+    exit 1
+}
+
+if ! [[ $# -eq 1 ]]; then
+    usage
+fi
+
+MOUNTPOINT=$1
+
+USER=`logname`
+VX_MOUNTPOINT=/media/vx/usb-drive
+DEV_MOUNTPOINT_REGEX=^/media/$USER/[a-Z0-9-]+$
+
+if ! [[ $MOUNTPOINT = $VX_MOUNTPOINT || $MOUNTPOINT =~ $DEV_MOUNTPOINT_REGEX ]]; then
+    echo "unmount.sh: mount point \"${MOUNTPOINT}\" is not a valid mounted USB drive"
+    exit 1
+fi
+umount $MOUNTPOINT

--- a/libs/usb-drive/src/usb_drive.test.ts
+++ b/libs/usb-drive/src/usb_drive.test.ts
@@ -226,5 +226,23 @@ describe('eject', () => {
     execMock.mockResolvedValueOnce(lsblkOutput({ mountpoint: null }));
 
     await expect(usbDrive.status()).resolves.toEqual({ status: 'ejected' });
+
+    // Remove USB and reinsert, should be detected and mounted again
+    readdirMock.mockResolvedValueOnce([]);
+    await expect(usbDrive.status()).resolves.toEqual({ status: 'no_drive' });
+    readdirMock.mockResolvedValueOnce(['usb-foobar-part23']);
+    readlinkMock.mockResolvedValueOnce('../../sdb1');
+    execMock.mockResolvedValueOnce(lsblkOutput({ mountpoint: null }));
+    execMock.mockResolvedValueOnce({ stdout: '' });
+    readdirMock.mockResolvedValueOnce(['usb-foobar-part23']);
+    readlinkMock.mockResolvedValueOnce('../../sdb1');
+    execMock.mockResolvedValueOnce(
+      lsblkOutput({ mountpoint: '/media/vx/usb-drive' })
+    );
+    await expect(usbDrive.status()).resolves.toEqual({
+      status: 'mounted',
+      mountPoint: '/media/vx/usb-drive',
+      deviceName: 'sdb1',
+    });
   });
 });

--- a/libs/usb-drive/src/usb_drive.test.ts
+++ b/libs/usb-drive/src/usb_drive.test.ts
@@ -162,6 +162,34 @@ describe('status', () => {
       status: 'no_drive',
     });
   });
+
+  test('bad format', async () => {
+    const usbDrive = detectUsbDrive();
+
+    readdirMock.mockResolvedValue(['usb-foobar-part23']);
+    readlinkMock.mockResolvedValue('../../sdb1');
+    execMock.mockResolvedValueOnce(
+      lsblkOutput({
+        fstype: 'exfat',
+      })
+    );
+
+    await expect(usbDrive.status()).resolves.toEqual({
+      status: 'error',
+      reason: 'bad_format',
+    });
+
+    execMock.mockResolvedValueOnce(
+      lsblkOutput({
+        fsver: 'EXFAT',
+      })
+    );
+
+    await expect(usbDrive.status()).resolves.toEqual({
+      status: 'error',
+      reason: 'bad_format',
+    });
+  });
 });
 
 describe('eject', () => {

--- a/libs/usb-drive/src/usb_drive.test.ts
+++ b/libs/usb-drive/src/usb_drive.test.ts
@@ -1,0 +1,216 @@
+import { promises as fs } from 'fs';
+import { BlockDeviceInfo, detectUsbDrive } from './usb_drive';
+import { exec } from './exec';
+
+jest.mock('fs', () => ({
+  promises: {
+    mkdir: jest.fn().mockRejectedValue(new Error('Not mocked')),
+    readdir: jest.fn().mockRejectedValue(new Error('Not mocked')),
+    readlink: jest.fn().mockRejectedValue(new Error('Not mocked')),
+  },
+}));
+jest.mock('./exec', () => ({
+  exec: jest.fn().mockRejectedValue(new Error('Not mocked')),
+}));
+
+const mkdirMock = fs.mkdir as unknown as jest.Mock<Promise<void>>;
+const readdirMock = fs.readdir as unknown as jest.Mock<Promise<string[]>>;
+const readlinkMock = fs.readlink as unknown as jest.Mock<Promise<string>>;
+const execMock = exec as unknown as jest.Mock<Promise<{ stdout: string }>>;
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+function lsblkOutput(device: Partial<BlockDeviceInfo> = {}) {
+  return {
+    stdout: JSON.stringify({
+      blockdevices: [
+        {
+          name: 'sdb1',
+          mountpoint: '/media/usb-drive-sdb1',
+          fstype: 'vfat',
+          fsver: 'FAT32',
+          label: 'VxUSB-00000',
+          ...device,
+        },
+      ],
+    }),
+  };
+}
+
+describe('status', () => {
+  test('no drive', async () => {
+    const usbDrive = detectUsbDrive();
+
+    readdirMock.mockResolvedValueOnce([]);
+
+    await expect(usbDrive.status()).resolves.toEqual({
+      status: 'no_drive',
+    });
+
+    expect(readdirMock).toHaveBeenCalledWith('/dev/disk/by-id/');
+  });
+
+  test('one drive, mounted', async () => {
+    const usbDrive = detectUsbDrive();
+
+    readdirMock.mockResolvedValueOnce(['usb-foobar-part23']);
+    readlinkMock.mockResolvedValueOnce('../../sdb1');
+    execMock.mockResolvedValueOnce(
+      lsblkOutput({ mountpoint: '/media/usb-drive-sdb1' })
+    );
+
+    await expect(usbDrive.status()).resolves.toEqual({
+      status: 'mounted',
+      mountPoint: '/media/usb-drive-sdb1',
+      deviceName: 'sdb1',
+    });
+
+    expect(readdirMock).toHaveBeenCalledWith('/dev/disk/by-id/');
+    expect(readlinkMock).toHaveBeenCalledWith(
+      '/dev/disk/by-id/usb-foobar-part23'
+    );
+    expect(execMock).toHaveBeenCalledWith('lsblk', [
+      '-J',
+      '-n',
+      '-l',
+      '-o',
+      ['NAME', 'MOUNTPOINT', 'FSTYPE', 'FSVER', 'LABEL'].join(','),
+      '/dev/sdb1',
+    ]);
+  });
+
+  test('one drive, unmounted', async () => {
+    const usbDrive = detectUsbDrive();
+
+    readdirMock.mockResolvedValue(['usb-foobar-part23']);
+    readlinkMock.mockResolvedValue('../../sdb1');
+    // Initial status
+    execMock.mockResolvedValueOnce(lsblkOutput({ mountpoint: null }));
+    // Mount
+    mkdirMock.mockResolvedValueOnce();
+    execMock.mockResolvedValueOnce({ stdout: '' });
+    // Status after mount
+    execMock.mockResolvedValueOnce(
+      lsblkOutput({ mountpoint: '/media/vx/usb-drive' })
+    );
+
+    await expect(usbDrive.status()).resolves.toEqual({
+      status: 'mounted',
+      mountPoint: '/media/vx/usb-drive',
+      deviceName: 'sdb1',
+    });
+
+    expect(execMock).toHaveBeenNthCalledWith(1, 'lsblk', [
+      '-J',
+      '-n',
+      '-l',
+      '-o',
+      ['NAME', 'MOUNTPOINT', 'FSTYPE', 'FSVER', 'LABEL'].join(','),
+      '/dev/sdb1',
+    ]);
+    expect(execMock).toHaveBeenNthCalledWith(2, 'sudo', [
+      '-n',
+      'mount',
+      '-w',
+      '-o',
+      'umask=000,nosuid,nodev,noexec',
+      '/dev/sdb1',
+      '/media/vx/usb-drive',
+    ]);
+    expect(mkdirMock).toHaveBeenCalledWith('/media/vx/usb-drive', {
+      recursive: true,
+    });
+    expect(execMock).toHaveBeenNthCalledWith(3, 'lsblk', [
+      '-J',
+      '-n',
+      '-l',
+      '-o',
+      ['NAME', 'MOUNTPOINT', 'FSTYPE', 'FSVER', 'LABEL'].join(','),
+      '/dev/sdb1',
+    ]);
+  });
+
+  test('multiple usb devices', async () => {
+    const usbDrive = detectUsbDrive();
+
+    readdirMock.mockResolvedValue([
+      'notausb-bazbar-part21', // Should be ignored
+      'usb-foobar-part23', // Should take the first matching USB drive
+      'usb-babar-part3',
+    ]);
+    readlinkMock.mockResolvedValueOnce('../../sdb1');
+    execMock.mockResolvedValueOnce(
+      lsblkOutput({ mountpoint: '/media/usb-drive-sdb1' })
+    );
+    await expect(usbDrive.status()).resolves.toEqual({
+      status: 'mounted',
+      mountPoint: '/media/usb-drive-sdb1',
+      deviceName: 'sdb1',
+    });
+  });
+
+  test('error getting block device info', async () => {
+    const usbDrive = detectUsbDrive();
+
+    readdirMock.mockResolvedValueOnce(['usb-foobar-part23']);
+    readlinkMock.mockResolvedValueOnce('../../sdb1');
+    execMock.mockRejectedValue(new Error('Failed to get block device info'));
+
+    await expect(usbDrive.status()).resolves.toEqual({
+      status: 'no_drive',
+    });
+  });
+});
+
+describe('eject', () => {
+  test('no drive', async () => {
+    const usbDrive = detectUsbDrive();
+
+    readdirMock.mockResolvedValueOnce([]);
+
+    await expect(usbDrive.eject()).rejects.toThrowError(
+      'No USB drive detected'
+    );
+  });
+
+  test('not mounted', async () => {
+    const usbDrive = detectUsbDrive();
+
+    readdirMock.mockResolvedValueOnce(['usb-foobar-part23']);
+    readlinkMock.mockResolvedValueOnce('../../sdb1');
+    execMock.mockResolvedValueOnce(lsblkOutput({ mountpoint: null }));
+
+    await expect(usbDrive.eject()).rejects.toThrowError(
+      'USB drive is not mounted'
+    );
+  });
+
+  test('mounted', async () => {
+    const usbDrive = detectUsbDrive();
+
+    readdirMock.mockResolvedValueOnce(['usb-foobar-part23']);
+    readlinkMock.mockResolvedValueOnce('../../sdb1');
+    // Initial status
+    execMock.mockResolvedValueOnce(
+      lsblkOutput({ mountpoint: '/media/usb-drive-sdb1' })
+    );
+    // Unmount
+    execMock.mockResolvedValueOnce({ stdout: '' });
+
+    await expect(usbDrive.eject()).resolves.toBeUndefined();
+
+    expect(execMock).toHaveBeenNthCalledWith(2, 'sudo', [
+      '-n',
+      'umount',
+      '/media/usb-drive-sdb1',
+    ]);
+
+    readdirMock.mockResolvedValueOnce(['usb-foobar-part23']);
+    readlinkMock.mockResolvedValueOnce('../../sdb1');
+    execMock.mockResolvedValueOnce(lsblkOutput({ mountpoint: null }));
+
+    await expect(usbDrive.status()).resolves.toEqual({ status: 'ejected' });
+  });
+});

--- a/libs/usb-drive/src/usb_drive.test.ts
+++ b/libs/usb-drive/src/usb_drive.test.ts
@@ -193,26 +193,22 @@ describe('status', () => {
 });
 
 describe('eject', () => {
-  test('no drive', async () => {
+  test('no drive - no op', async () => {
     const usbDrive = detectUsbDrive();
 
     readdirMock.mockResolvedValueOnce([]);
 
-    await expect(usbDrive.eject()).rejects.toThrowError(
-      'No USB drive detected'
-    );
+    await expect(usbDrive.eject()).resolves.toBeUndefined();
   });
 
-  test('not mounted', async () => {
+  test('not mounted - no op', async () => {
     const usbDrive = detectUsbDrive();
 
     readdirMock.mockResolvedValueOnce(['usb-foobar-part23']);
     readlinkMock.mockResolvedValueOnce('../../sdb1');
     execMock.mockResolvedValueOnce(lsblkOutput({ mountpoint: null }));
 
-    await expect(usbDrive.eject()).rejects.toThrowError(
-      'USB drive is not mounted'
-    );
+    await expect(usbDrive.eject()).resolves.toBeUndefined();
   });
 
   test('mounted', async () => {

--- a/libs/usb-drive/src/usb_drive.test.ts
+++ b/libs/usb-drive/src/usb_drive.test.ts
@@ -88,11 +88,14 @@ describe('status', () => {
     execMock.mockResolvedValueOnce(lsblkOutput({ mountpoint: null }));
     // Mount
     execMock.mockResolvedValueOnce({ stdout: '' });
+
+    // While mounting, status is 'no_drive'
+    await expect(usbDrive.status()).resolves.toEqual({ status: 'no_drive' });
+
     // Status after mount
     execMock.mockResolvedValueOnce(
       lsblkOutput({ mountpoint: '/media/vx/usb-drive' })
     );
-
     await expect(usbDrive.status()).resolves.toEqual({
       status: 'mounted',
       mountPoint: '/media/vx/usb-drive',
@@ -234,6 +237,7 @@ describe('eject', () => {
     readlinkMock.mockResolvedValueOnce('../../sdb1');
     execMock.mockResolvedValueOnce(lsblkOutput({ mountpoint: null }));
     execMock.mockResolvedValueOnce({ stdout: '' });
+    await expect(usbDrive.status()).resolves.toEqual({ status: 'no_drive' });
     readdirMock.mockResolvedValueOnce(['usb-foobar-part23']);
     readlinkMock.mockResolvedValueOnce('../../sdb1');
     execMock.mockResolvedValueOnce(

--- a/libs/usb-drive/src/usb_drive.test.ts
+++ b/libs/usb-drive/src/usb_drive.test.ts
@@ -4,7 +4,6 @@ import { exec } from './exec';
 
 jest.mock('fs', () => ({
   promises: {
-    mkdir: jest.fn().mockRejectedValue(new Error('Not mocked')),
     readdir: jest.fn().mockRejectedValue(new Error('Not mocked')),
     readlink: jest.fn().mockRejectedValue(new Error('Not mocked')),
   },
@@ -13,7 +12,6 @@ jest.mock('./exec', () => ({
   exec: jest.fn().mockRejectedValue(new Error('Not mocked')),
 }));
 
-const mkdirMock = fs.mkdir as unknown as jest.Mock<Promise<void>>;
 const readdirMock = fs.readdir as unknown as jest.Mock<Promise<string[]>>;
 const readlinkMock = fs.readlink as unknown as jest.Mock<Promise<string>>;
 const execMock = exec as unknown as jest.Mock<Promise<{ stdout: string }>>;
@@ -89,7 +87,6 @@ describe('status', () => {
     // Initial status
     execMock.mockResolvedValueOnce(lsblkOutput({ mountpoint: null }));
     // Mount
-    mkdirMock.mockResolvedValueOnce();
     execMock.mockResolvedValueOnce({ stdout: '' });
     // Status after mount
     execMock.mockResolvedValueOnce(
@@ -112,16 +109,9 @@ describe('status', () => {
     ]);
     expect(execMock).toHaveBeenNthCalledWith(2, 'sudo', [
       '-n',
-      'mount',
-      '-w',
-      '-o',
-      'umask=000,nosuid,nodev,noexec',
+      `${__dirname}/mount.sh`,
       '/dev/sdb1',
-      '/media/vx/usb-drive',
     ]);
-    expect(mkdirMock).toHaveBeenCalledWith('/media/vx/usb-drive', {
-      recursive: true,
-    });
     expect(execMock).toHaveBeenNthCalledWith(3, 'lsblk', [
       '-J',
       '-n',
@@ -227,7 +217,7 @@ describe('eject', () => {
 
     expect(execMock).toHaveBeenNthCalledWith(2, 'sudo', [
       '-n',
-      'umount',
+      `${__dirname}/unmount.sh`,
       '/media/usb-drive-sdb1',
     ]);
 

--- a/libs/usb-drive/src/usb_drive.ts
+++ b/libs/usb-drive/src/usb_drive.ts
@@ -109,6 +109,8 @@ export function detectUsbDrive(): UsbDrive {
     async status(): Promise<UsbDriveStatus> {
       let deviceInfo = await getUsbDriveStatus();
       if (!deviceInfo) {
+        // Reset eject state in case the drive was removed
+        didEject = false;
         return { status: 'no_drive' };
       }
       if (!isFat32(deviceInfo)) {

--- a/libs/usb-drive/src/usb_drive.ts
+++ b/libs/usb-drive/src/usb_drive.ts
@@ -133,7 +133,6 @@ export function detectUsbDrive(): UsbDrive {
       return { status: 'ejected' };
     },
 
-    // TODO do we need to run a `sync` command before unmounting?
     async eject(): Promise<void> {
       const deviceInfo = await getUsbDriveDeviceInfo();
       if (!deviceInfo?.mountpoint) {

--- a/libs/usb-drive/src/usb_drive.ts
+++ b/libs/usb-drive/src/usb_drive.ts
@@ -1,11 +1,8 @@
 import { promises as fs } from 'fs';
 import { join } from 'path';
-import { execFile } from 'child_process';
-import { promisify } from 'util';
 import { assertDefined } from '@votingworks/basics';
 import makeDebug from 'debug';
-
-const exec = promisify(execFile);
+import { exec } from './exec';
 
 const debug = makeDebug('usb-drive');
 
@@ -25,7 +22,7 @@ export interface UsbDrive {
   eject(): Promise<void>;
 }
 
-interface BlockDeviceInfo {
+export interface BlockDeviceInfo {
   name: string;
   path: string;
   mountpoint: string | null;

--- a/libs/usb-drive/src/usb_drive.ts
+++ b/libs/usb-drive/src/usb_drive.ts
@@ -90,7 +90,9 @@ const VX_MOUNT_POINT = '/media/vx/usb-drive';
 async function mountUsbDrive(devicePath: string): Promise<void> {
   debug(`Mounting USB drive ${devicePath} at ${VX_MOUNT_POINT}`);
   await fs.mkdir(VX_MOUNT_POINT, { recursive: true });
-  await exec('mount', [
+  await exec('sudo', [
+    '-n',
+    'mount',
     '-w',
     '-o',
     'umask=000,nosuid,nodev,noexec',
@@ -101,7 +103,7 @@ async function mountUsbDrive(devicePath: string): Promise<void> {
 
 async function unmountUsbDrive(mountPoint: string): Promise<void> {
   debug(`Unmounting USB drive at ${mountPoint}`);
-  await exec('umount', [mountPoint]);
+  await exec('sudo', ['-n', 'umount', mountPoint]);
 }
 
 // TODO check format?

--- a/libs/usb-drive/src/usb_drive.ts
+++ b/libs/usb-drive/src/usb_drive.ts
@@ -85,25 +85,14 @@ async function getUsbDriveStatus(): Promise<BlockDeviceInfo | undefined> {
   return await getBlockDeviceInfo(devicePath);
 }
 
-const VX_MOUNT_POINT = '/media/vx/usb-drive';
-
 async function mountUsbDrive(devicePath: string): Promise<void> {
-  debug(`Mounting USB drive ${devicePath} at ${VX_MOUNT_POINT}`);
-  await fs.mkdir(VX_MOUNT_POINT, { recursive: true });
-  await exec('sudo', [
-    '-n',
-    'mount',
-    '-w',
-    '-o',
-    'umask=000,nosuid,nodev,noexec',
-    devicePath,
-    VX_MOUNT_POINT,
-  ]);
+  debug(`Mounting USB drive ${devicePath}`);
+  await exec('sudo', ['-n', `${__dirname}/mount.sh`, devicePath]);
 }
 
 async function unmountUsbDrive(mountPoint: string): Promise<void> {
   debug(`Unmounting USB drive at ${mountPoint}`);
-  await exec('sudo', ['-n', 'umount', mountPoint]);
+  await exec('sudo', ['-n', `${__dirname}/unmount.sh`, mountPoint]);
 }
 
 function isFat32(deviceInfo: BlockDeviceInfo): boolean {
@@ -127,8 +116,6 @@ export function detectUsbDrive(): UsbDrive {
       }
 
       // Automatically mount the drive if it's not already mounted
-      // TODO if the drive is mounted at a different mount point than our
-      // default VX mount point, do we want to unmount and remount it?
       if (!deviceInfo.mountpoint && !didEject) {
         await mountUsbDrive(deviceInfo.path);
         deviceInfo = assertDefined(await getUsbDriveStatus());

--- a/libs/usb-drive/src/usb_drive.ts
+++ b/libs/usb-drive/src/usb_drive.ts
@@ -147,11 +147,9 @@ export function detectUsbDrive(): UsbDrive {
     // TODO do we need to run a `sync` command before unmounting?
     async eject(): Promise<void> {
       const deviceInfo = await getUsbDriveStatus();
-      if (!deviceInfo) {
-        throw new Error('No USB drive detected');
-      }
-      if (!deviceInfo.mountpoint) {
-        throw new Error('USB drive is not mounted');
+      if (!deviceInfo?.mountpoint) {
+        debug('No USB drive mounted, skipping eject');
+        return;
       }
       await unmountUsbDrive(deviceInfo.mountpoint);
       didEject = true;

--- a/libs/usb-drive/src/usb_drive.ts
+++ b/libs/usb-drive/src/usb_drive.ts
@@ -1,0 +1,143 @@
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { assertDefined } from '@votingworks/basics';
+import makeDebug from 'debug';
+
+const exec = promisify(execFile);
+
+const debug = makeDebug('usb-drive');
+
+export type UsbDriveStatus =
+  | { status: 'no_drive' }
+  | { status: 'mounted'; mountPoint: string }
+  | { status: 'ejected' }
+  | { status: 'error'; reason: 'bad_format' };
+
+export interface UsbDrive {
+  status(): Promise<UsbDriveStatus>;
+  eject(): Promise<void>;
+  format(): Promise<void>;
+}
+
+interface BlockDeviceInfo {
+  name: string;
+  path: string;
+  mountpoint: string | null;
+  fstype: string | null;
+  fsver: string | null;
+  label: string | null;
+}
+
+async function getBlockDeviceInfo(
+  devicePath: string
+): Promise<BlockDeviceInfo | undefined> {
+  try {
+    const { stdout } = await exec('lsblk', [
+      '-J',
+      '-n',
+      '-l',
+      '-o',
+      ['NAME', 'MOUNTPOINT', 'FSTYPE', 'FSVER', 'LABEL'].join(','),
+      devicePath,
+    ]);
+    const rawData = JSON.parse(stdout) as {
+      blockdevices: BlockDeviceInfo[];
+    };
+    debug(`Got block device info for ${devicePath}: ${stdout}`);
+    return { ...assertDefined(rawData.blockdevices[0]), path: devicePath };
+  } catch (error) {
+    debug(`Error getting block device info for ${devicePath}: ${error}`);
+    return undefined;
+  }
+}
+
+async function findUsbDriveDevice(): Promise<string | undefined> {
+  const DEVICE_PATH_PREFIX = '/dev/disk/by-id/';
+  const USB_REGEXP = /^usb(.+)part(.*)$/;
+
+  // List devices, filtering to only the USB partitions
+  const devicesById = (await fs.readdir(DEVICE_PATH_PREFIX)).filter((name) =>
+    USB_REGEXP.test(name)
+  );
+
+  // We only support one USB drive at a time
+  const [deviceId] = devicesById;
+  if (!deviceId) {
+    return undefined;
+  }
+
+  // Follow the symlink
+  const devicePath = join(
+    DEVICE_PATH_PREFIX,
+    await fs.readlink(join(DEVICE_PATH_PREFIX, deviceId))
+  );
+
+  return devicePath;
+}
+
+async function getUsbDriveStatus(): Promise<BlockDeviceInfo | undefined> {
+  const devicePath = await findUsbDriveDevice();
+  if (!devicePath) return undefined;
+  debug(`Found USB drive at ${devicePath}`);
+  return await getBlockDeviceInfo(devicePath);
+}
+
+const VX_MOUNT_POINT = '/media/vx/usb-drive';
+
+async function mountUsbDrive(devicePath: string): Promise<void> {
+  debug(`Mounting USB drive ${devicePath} at ${VX_MOUNT_POINT}`);
+  await fs.mkdir(VX_MOUNT_POINT, { recursive: true });
+  await exec('mount', [
+    '-w',
+    '-o',
+    'umask=000,nosuid,nodev,noexec',
+    devicePath,
+    VX_MOUNT_POINT,
+  ]);
+}
+
+async function unmountUsbDrive(mountPoint: string): Promise<void> {
+  debug(`Unmounting USB drive at ${mountPoint}`);
+  await exec('umount', [mountPoint]);
+}
+
+export function detectUsbDrive(): UsbDrive {
+  let didEject = false;
+
+  return {
+    async status(): Promise<UsbDriveStatus> {
+      let deviceInfo = await getUsbDriveStatus();
+      if (!deviceInfo) return { status: 'no_drive' };
+      // Automatically mount the drive if it's not already mounted
+      // TODO if the drive is mounted at a different mount point than our
+      // default VX mount point, do we want to unmount and remount it?
+      if (!deviceInfo.mountpoint && !didEject) {
+        await mountUsbDrive(deviceInfo.path);
+        deviceInfo = assertDefined(await getUsbDriveStatus());
+      }
+      if (deviceInfo.mountpoint) {
+        return { status: 'mounted', mountPoint: deviceInfo.mountpoint };
+      }
+      return { status: 'ejected' };
+    },
+
+    async eject(): Promise<void> {
+      const deviceInfo = await getUsbDriveStatus();
+      if (!deviceInfo) {
+        throw new Error('No USB drive detected');
+      }
+      if (!deviceInfo.mountpoint) {
+        throw new Error('USB drive is not mounted');
+      }
+      await unmountUsbDrive(deviceInfo.mountpoint);
+      didEject = true;
+    },
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async format(): Promise<void> {
+      throw new Error('Not implemented');
+    },
+  };
+}

--- a/libs/usb-drive/src/usb_drive.ts
+++ b/libs/usb-drive/src/usb_drive.ts
@@ -80,19 +80,22 @@ async function findUsbDriveDevice(): Promise<string | undefined> {
 
 async function getUsbDriveDeviceInfo(): Promise<BlockDeviceInfo | undefined> {
   const devicePath = await findUsbDriveDevice();
-  if (!devicePath) return undefined;
-  debug(`Found USB drive at ${devicePath}`);
+  if (!devicePath) {
+    debug(`No USB drive detected`);
+    return undefined;
+  }
+  debug(`Detected USB drive at ${devicePath}`);
   return await getBlockDeviceInfo(devicePath);
 }
 
 async function mountUsbDrive(devicePath: string): Promise<void> {
   debug(`Mounting USB drive ${devicePath}`);
-  await exec('sudo', ['-n', `${__dirname}/mount.sh`, devicePath]);
+  await exec('sudo', ['-n', `${__dirname}/../src/mount.sh`, devicePath]);
 }
 
 async function unmountUsbDrive(mountPoint: string): Promise<void> {
   debug(`Unmounting USB drive at ${mountPoint}`);
-  await exec('sudo', ['-n', `${__dirname}/unmount.sh`, mountPoint]);
+  await exec('sudo', ['-n', `${__dirname}/../src/unmount.sh`, mountPoint]);
 }
 
 function isFat32(deviceInfo: BlockDeviceInfo): boolean {

--- a/libs/usb-drive/src/usb_drive.ts
+++ b/libs/usb-drive/src/usb_drive.ts
@@ -78,7 +78,7 @@ async function findUsbDriveDevice(): Promise<string | undefined> {
   return devicePath;
 }
 
-async function getUsbDriveStatus(): Promise<BlockDeviceInfo | undefined> {
+async function getUsbDriveDeviceInfo(): Promise<BlockDeviceInfo | undefined> {
   const devicePath = await findUsbDriveDevice();
   if (!devicePath) return undefined;
   debug(`Found USB drive at ${devicePath}`);
@@ -107,7 +107,7 @@ export function detectUsbDrive(): UsbDrive {
 
   return {
     async status(): Promise<UsbDriveStatus> {
-      let deviceInfo = await getUsbDriveStatus();
+      let deviceInfo = await getUsbDriveDeviceInfo();
       if (!deviceInfo) {
         // Reset eject state in case the drive was removed
         didEject = false;
@@ -120,7 +120,7 @@ export function detectUsbDrive(): UsbDrive {
       // Automatically mount the drive if it's not already mounted
       if (!deviceInfo.mountpoint && !didEject) {
         await mountUsbDrive(deviceInfo.path);
-        deviceInfo = assertDefined(await getUsbDriveStatus());
+        deviceInfo = assertDefined(await getUsbDriveDeviceInfo());
       }
 
       if (deviceInfo.mountpoint) {
@@ -135,7 +135,7 @@ export function detectUsbDrive(): UsbDrive {
 
     // TODO do we need to run a `sync` command before unmounting?
     async eject(): Promise<void> {
-      const deviceInfo = await getUsbDriveStatus();
+      const deviceInfo = await getUsbDriveDeviceInfo();
       if (!deviceInfo?.mountpoint) {
         debug('No USB drive mounted, skipping eject');
         return;

--- a/libs/usb-drive/tsconfig.build.json
+++ b/libs/usb-drive/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "exclude": ["**/*.test.ts"],
+  "compilerOptions": {
+    "noEmit": false,
+    "rootDir": "src",
+    "outDir": "build",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "references": [{ "path": "../basics/tsconfig.build.json" }]
+}

--- a/libs/usb-drive/tsconfig.build.json
+++ b/libs/usb-drive/tsconfig.build.json
@@ -9,5 +9,8 @@
     "declaration": true,
     "declarationMap": true
   },
-  "references": [{ "path": "../basics/tsconfig.build.json" }]
+  "references": [
+    { "path": "../basics/tsconfig.build.json" },
+    { "path": "../test-utils/tsconfig.build.json" }
+  ]
 }

--- a/libs/usb-drive/tsconfig.json
+++ b/libs/usb-drive/tsconfig.json
@@ -10,5 +10,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true
   },
-  "references": [{ "path": "../basics/tsconfig.build.json" }]
+  "references": [
+    { "path": "../basics/tsconfig.build.json" },
+    { "path": "../test-utils/tsconfig.build.json" }
+  ]
 }

--- a/libs/usb-drive/tsconfig.json
+++ b/libs/usb-drive/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.shared.json",
+  "include": ["src", "test"],
+  "exclude": [],
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": ["esnext"],
+    "composite": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "references": [{ "path": "../basics/tsconfig.build.json" }]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2173,6 +2173,9 @@ importers:
       '@votingworks/types':
         specifier: workspace:*
         version: link:../../../libs/types
+      '@votingworks/usb-drive':
+        specifier: workspace:*
+        version: link:../../../libs/usb-drive
       '@votingworks/utils':
         specifier: workspace:*
         version: link:../../../libs/utils
@@ -2499,6 +2502,9 @@ importers:
       '@votingworks/test-utils':
         specifier: workspace:*
         version: link:../../../libs/test-utils
+      '@votingworks/usb-drive':
+        specifier: workspace:*
+        version: link:../../../libs/usb-drive
       eslint:
         specifier: 8.23.1
         version: 8.23.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5468,9 +5468,15 @@ importers:
       '@votingworks/basics':
         specifier: workspace:*
         version: link:../basics
+      '@votingworks/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
       debug:
         specifier: ^4.3.2
         version: 4.3.4(supports-color@8.1.1)
+      tmp:
+        specifier: ^0.2.1
+        version: 0.2.1
     devDependencies:
       '@types/debug':
         specifier: ^4.1.7
@@ -5479,16 +5485,19 @@ importers:
         specifier: ^27.0.3
         version: 27.4.1
       '@types/node':
-        specifier: ^18.11.18
-        version: 18.11.18
+        specifier: 16.18.23
+        version: 16.18.23
       '@types/styled-components':
         specifier: ^5.1.9
         version: 5.1.9
+      '@types/tmp':
+        specifier: ^0.2.3
+        version: 0.2.3
       '@typescript-eslint/eslint-plugin':
-        specifier: ^5.37.0
+        specifier: 5.37.0
         version: 5.37.0(@typescript-eslint/parser@5.37.0)(eslint@8.23.1)(typescript@4.6.3)
       '@typescript-eslint/parser':
-        specifier: ^5.37.0
+        specifier: 5.37.0
         version: 5.37.0(eslint@8.23.1)(typescript@4.6.3)
       esbuild:
         specifier: ^0.17.11
@@ -5513,7 +5522,7 @@ importers:
         version: 26.6.0(@typescript-eslint/eslint-plugin@5.37.0)(eslint@8.23.1)(jest@27.5.1)(typescript@4.6.3)
       eslint-plugin-prettier:
         specifier: ^4.2.1
-        version: 4.2.1(eslint-config-prettier@8.6.0)(eslint@8.23.1)(prettier@2.8.3)
+        version: 4.2.1(eslint-config-prettier@8.6.0)(eslint@8.23.1)(prettier@2.6.2)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
@@ -5533,8 +5542,8 @@ importers:
         specifier: ^11.0.0
         version: 11.0.0
       prettier:
-        specifier: ^2.6.2
-        version: 2.8.3
+        specifier: 2.6.2
+        version: 2.6.2
       sort-package-json:
         specifier: ^1.50.0
         version: 1.50.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5457,6 +5457,88 @@ importers:
         specifier: ^4.0.4
         version: 4.0.4(@types/node@16.18.23)
 
+  libs/usb-drive:
+    dependencies:
+      '@votingworks/basics':
+        specifier: workspace:*
+        version: link:../basics
+      debug:
+        specifier: ^4.3.2
+        version: 4.3.4(supports-color@8.1.1)
+    devDependencies:
+      '@types/debug':
+        specifier: ^4.1.7
+        version: 4.1.7
+      '@types/jest':
+        specifier: ^27.0.3
+        version: 27.4.1
+      '@types/node':
+        specifier: ^18.11.18
+        version: 18.11.18
+      '@types/styled-components':
+        specifier: ^5.1.9
+        version: 5.1.9
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^5.37.0
+        version: 5.37.0(@typescript-eslint/parser@5.37.0)(eslint@8.23.1)(typescript@4.6.3)
+      '@typescript-eslint/parser':
+        specifier: ^5.37.0
+        version: 5.37.0(eslint@8.23.1)(typescript@4.6.3)
+      esbuild:
+        specifier: ^0.17.11
+        version: 0.17.11
+      esbuild-runner:
+        specifier: ^2.2.2
+        version: 2.2.2(esbuild@0.17.11)
+      eslint:
+        specifier: 8.23.1
+        version: 8.23.1
+      eslint-config-prettier:
+        specifier: ^8.5.0
+        version: 8.6.0(eslint@8.23.1)
+      eslint-import-resolver-node:
+        specifier: ^0.3.6
+        version: 0.3.7
+      eslint-plugin-import:
+        specifier: ^2.26.0
+        version: 2.27.5(@typescript-eslint/parser@5.37.0)(eslint@8.23.1)
+      eslint-plugin-jest:
+        specifier: ^26.1.5
+        version: 26.6.0(@typescript-eslint/eslint-plugin@5.37.0)(eslint@8.23.1)(jest@27.5.1)(typescript@4.6.3)
+      eslint-plugin-prettier:
+        specifier: ^4.2.1
+        version: 4.2.1(eslint-config-prettier@8.6.0)(eslint@8.23.1)(prettier@2.8.3)
+      eslint-plugin-vx:
+        specifier: workspace:*
+        version: link:../eslint-plugin-vx
+      is-ci-cli:
+        specifier: ^2.2.0
+        version: 2.2.0
+      jest:
+        specifier: ^27.3.1
+        version: 27.5.1
+      jest-junit:
+        specifier: ^14.0.1
+        version: 14.0.1
+      jest-watch-typeahead:
+        specifier: ^0.6.4
+        version: 0.6.4(jest@27.5.1)
+      lint-staged:
+        specifier: ^11.0.0
+        version: 11.0.0
+      prettier:
+        specifier: ^2.6.2
+        version: 2.8.3
+      sort-package-json:
+        specifier: ^1.50.0
+        version: 1.50.0
+      ts-jest:
+        specifier: ^27.0.7
+        version: 27.1.3(@babel/core@7.12.3)(@types/jest@27.4.1)(esbuild@0.17.11)(jest@27.5.1)(typescript@4.6.3)
+      typescript:
+        specifier: 4.6.3
+        version: 4.6.3
+
   libs/utils:
     dependencies:
       '@types/node':
@@ -14326,18 +14408,18 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /babel-jest@27.5.1(@babel/core@7.20.12):
+  /babel-jest@27.5.1(@babel/core@7.12.3):
     resolution: {integrity: sha512-cdQ5dXjGRd0IBRATiQ4mZGlGlRE8kJpjPOixdNRdT+m3UcNqmYWN6rK6nvtXYfY3D76cb8s/O1Ss8ea24PIwcg==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     peerDependencies:
       '@babel/core': ^7.8.0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.12.3
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
       '@types/babel__core': 7.20.0
       babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 27.5.1(@babel/core@7.20.12)
+      babel-preset-jest: 27.5.1(@babel/core@7.12.3)
       chalk: 4.1.2
       graceful-fs: 4.2.10
       slash: 3.0.0
@@ -14682,15 +14764,15 @@ packages:
       babel-plugin-jest-hoist: 26.6.2
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.20.12)
 
-  /babel-preset-jest@27.5.1(@babel/core@7.20.12):
+  /babel-preset-jest@27.5.1(@babel/core@7.12.3):
     resolution: {integrity: sha512-Nptf2FzlPCWYuJg41HBqXVT8ym6bXOevuCTbhxlUpjwtysGaIWFvDEjp4y+G7fl13FgOdjs7P/DmErqH7da0Ag==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.12.3
       babel-plugin-jest-hoist: 27.5.1
-      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.20.12)
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.12.3)
     dev: true
 
   /babel-preset-jest@28.1.3(@babel/core@7.20.12):
@@ -22673,10 +22755,10 @@ packages:
       ts-node:
         optional: true
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.12.3
       '@jest/test-sequencer': 27.5.1
       '@jest/types': 27.5.1
-      babel-jest: 27.5.1(@babel/core@7.20.12)
+      babel-jest: 27.5.1(@babel/core@7.12.3)
       chalk: 4.1.2
       ci-info: 3.3.2
       deepmerge: 4.2.2
@@ -30892,6 +30974,42 @@ packages:
       '@types/jest': 27.4.1
       bs-logger: 0.2.6
       esbuild: 0.16.17
+      fast-json-stable-stringify: 2.1.0
+      jest: 27.5.1
+      jest-util: 27.5.1
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.3.2
+      typescript: 4.6.3
+      yargs-parser: 20.2.9
+    dev: true
+
+  /ts-jest@27.1.3(@babel/core@7.12.3)(@types/jest@27.4.1)(esbuild@0.17.11)(jest@27.5.1)(typescript@4.6.3):
+    resolution: {integrity: sha512-6Nlura7s6uM9BVUAoqLH7JHyMXjz8gluryjpPXxr3IxZdAXnU6FhjvVLHFtfd1vsE1p8zD1OJfskkc0jhTSnkA==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@types/jest': ^27.0.0
+      babel-jest: '>=27.0.0 <28'
+      esbuild: ~0.14.0
+      jest: ^27.0.0
+      typescript: '>=3.8 <5.0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@types/jest':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    dependencies:
+      '@babel/core': 7.12.3
+      '@types/jest': 27.4.1
+      bs-logger: 0.2.6
+      esbuild: 0.17.11
       fast-json-stable-stringify: 2.1.0
       jest: 27.5.1
       jest-util: 27.5.1

--- a/vxsuite.code-workspace
+++ b/vxsuite.code-workspace
@@ -145,6 +145,10 @@
       "path": "libs/ui"
     },
     {
+      "name": "libs/usb-drive",
+      "path": "libs/usb-drive"
+    },
+    {
       "name": "libs/usb-mocking",
       "path": "libs/usb-mocking"
     },


### PR DESCRIPTION
## Overview

_Review by commit_

First step towards https://github.com/votingworks/vxsuite/issues/3296

Creates a new library libs/usb-drive that interfaces with a single USB drive (following the logic from kiosk-browser). Then uses that library to replace existing USB code in apps/scan. Also adds a mock for use in backend tests.

## Demo Video or Screenshot

N/A

## Testing Plan
- Updated existing tests
- New tests for library
- Some basic manual testing

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
