### PR TITLE
Add jurisdiction state management to VxScan

### DIFF
--- a/apps/admin/backend/src/app.auth.test.ts
+++ b/apps/admin/backend/src/app.auth.test.ts
@@ -1,12 +1,16 @@
 import { DateTime } from 'luxon';
-import { DEV_JURISDICTION } from '@votingworks/auth';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import { TEST_JURISDICTION } from '@votingworks/types';
 
 import { buildTestEnvironment, configureMachine } from '../test/app';
 
+beforeEach(() => {
+  process.env = { ...process.env, VX_MACHINE_JURISDICTION: TEST_JURISDICTION };
+});
+
+const jurisdiction = TEST_JURISDICTION;
 const { electionDefinition } = electionFamousNames2021Fixtures;
 const { electionData, electionHash } = electionDefinition;
-const jurisdiction = DEV_JURISDICTION;
 
 test('getAuthStatus', async () => {
   const { apiClient, auth } = buildTestEnvironment();

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -11,6 +11,7 @@ import {
   safeParseNumber,
   SystemSettings,
   SystemSettingsSchema,
+  TEST_JURISDICTION,
 } from '@votingworks/types';
 import {
   assert,
@@ -32,6 +33,7 @@ import { promises as fs, Stats } from 'fs';
 import { basename, dirname } from 'path';
 import {
   CAST_VOTE_RECORD_REPORT_FILENAME,
+  isIntegrationTest,
   parseCastVoteRecordReportDirectoryName,
 } from '@votingworks/utils';
 import { loadImageData, toDataUrl } from '@votingworks/image-utils';
@@ -65,7 +67,9 @@ function constructAuthMachineState(
   return {
     arePollWorkerCardPinsEnabled: systemSettings?.arePollWorkerCardPinsEnabled,
     electionHash: currentElectionDefinition?.electionHash,
-    jurisdiction: process.env.VX_MACHINE_JURISDICTION ?? DEV_JURISDICTION,
+    jurisdiction: isIntegrationTest()
+      ? TEST_JURISDICTION
+      : process.env.VX_MACHINE_JURISDICTION ?? DEV_JURISDICTION,
   };
 }
 

--- a/apps/admin/integration-testing/cypress/support/auth.ts
+++ b/apps/admin/integration-testing/cypress/support/auth.ts
@@ -1,13 +1,10 @@
 import { methodUrl } from '@votingworks/grout';
+import { TEST_JURISDICTION } from '@votingworks/types';
 
 // Importing all of @votingworks/auth causes Cypress tests to fail since @votingworks/auth contains
 // code that isn't browser-safe
 // eslint-disable-next-line vx/no-import-workspace-subfolders
-import {
-  DEV_JURISDICTION,
-  mockCard,
-  MockFileContents,
-} from '@votingworks/auth/src/cypress';
+import { mockCard, MockFileContents } from '@votingworks/auth/src/cypress';
 
 const PIN = '000000';
 
@@ -22,7 +19,7 @@ export function mockSystemAdministratorCardInsertion(): void {
       cardDetails: {
         user: {
           role: 'system_administrator',
-          jurisdiction: DEV_JURISDICTION,
+          jurisdiction: TEST_JURISDICTION,
         },
       },
     },
@@ -43,7 +40,7 @@ export function mockElectionManagerCardInsertion({
       cardDetails: {
         user: {
           role: 'election_manager',
-          jurisdiction: DEV_JURISDICTION,
+          jurisdiction: TEST_JURISDICTION,
           electionHash,
         },
       },

--- a/apps/central-scan/backend/src/auth.test.ts
+++ b/apps/central-scan/backend/src/auth.test.ts
@@ -4,12 +4,12 @@ import { DateTime } from 'luxon';
 import { dirSync } from 'tmp';
 import {
   buildMockDippedSmartCardAuth,
-  DEV_JURISDICTION,
   DippedSmartCardAuthApi,
 } from '@votingworks/auth';
 import { createMockUsb } from '@votingworks/backend';
 import * as grout from '@votingworks/grout';
 import { fakeLogger, Logger } from '@votingworks/logging';
+import { TEST_JURISDICTION } from '@votingworks/types';
 
 import * as stateOfHamilton from '../test/fixtures/state-of-hamilton';
 import { makeMockScanner } from '../test/util/mocks';
@@ -51,9 +51,9 @@ afterEach(() => {
   server.close();
 });
 
+const jurisdiction = TEST_JURISDICTION;
 const { electionDefinition } = stateOfHamilton;
 const { electionData, electionHash } = electionDefinition;
-const jurisdiction = DEV_JURISDICTION;
 
 function configureMachine(): void {
   workspace.store.setElectionAndJurisdiction({ electionData, jurisdiction });

--- a/apps/central-scan/backend/src/backup.test.ts
+++ b/apps/central-scan/backend/src/backup.test.ts
@@ -5,6 +5,7 @@ import {
   BallotType,
   CVR,
   safeParseJson,
+  TEST_JURISDICTION,
   unsafeParse,
 } from '@votingworks/types';
 import { throwIllegalValue } from '@votingworks/basics';
@@ -18,7 +19,6 @@ import { basename } from 'path';
 import { fileSync, tmpNameSync } from 'tmp';
 import ZipStream from 'zip-stream';
 import { CAST_VOTE_RECORD_REPORT_FILENAME } from '@votingworks/utils';
-import { DEV_JURISDICTION } from '@votingworks/auth';
 import { election, electionDefinition } from '../test/fixtures/2020-choctaw';
 import { backup, Backup } from './backup';
 import { Store } from './store';
@@ -40,9 +40,9 @@ jest.mock('fs-extra', (): typeof import('fs-extra') => {
   };
 });
 
-const jurisdiction = DEV_JURISDICTION;
-
 const existsSyncMock = mockOf(existsSync);
+
+const jurisdiction = TEST_JURISDICTION;
 
 function getEntries(zipfile: JsZip): JSZipObject[] {
   return Object.values(zipfile.files);

--- a/apps/central-scan/backend/src/central_scanner_app.test.ts
+++ b/apps/central-scan/backend/src/central_scanner_app.test.ts
@@ -12,6 +12,7 @@ import {
   InterpretedHmpbPage,
   PageInterpretationWithFiles,
   SheetOf,
+  TEST_JURISDICTION,
 } from '@votingworks/types';
 import { Scan } from '@votingworks/api';
 import { CAST_VOTE_RECORD_REPORT_FILENAME } from '@votingworks/utils';
@@ -25,7 +26,6 @@ import path from 'path';
 import { typedAs } from '@votingworks/basics';
 import {
   buildMockDippedSmartCardAuth,
-  DEV_JURISDICTION,
   DippedSmartCardAuthApi,
 } from '@votingworks/auth';
 import { Server } from 'http';
@@ -40,7 +40,7 @@ import { getCastVoteRecordReportPaths } from '../test/helpers/usb';
 
 jest.mock('./importer');
 
-const jurisdiction = DEV_JURISDICTION;
+const jurisdiction = TEST_JURISDICTION;
 
 let app: Application;
 let auth: DippedSmartCardAuthApi;

--- a/apps/central-scan/backend/src/central_scanner_app.ts
+++ b/apps/central-scan/backend/src/central_scanner_app.ts
@@ -1,6 +1,5 @@
 import { Scan } from '@votingworks/api';
 import {
-  DEV_JURISDICTION,
   DippedSmartCardAuthApi,
   DippedSmartCardAuthMachineState,
 } from '@votingworks/auth';
@@ -18,6 +17,7 @@ import {
   ElectionDefinition,
   SystemSettings,
   safeParse,
+  TEST_JURISDICTION,
 } from '@votingworks/types';
 import { isElectionManagerAuth } from '@votingworks/utils';
 import express, { Application } from 'express';
@@ -130,7 +130,7 @@ function buildApi({
       const { electionDefinition } = ballotPackage;
       const systemSettings = DEFAULT_SYSTEM_SETTINGS;
 
-      importer.configure(electionDefinition, DEV_JURISDICTION);
+      importer.configure(electionDefinition, TEST_JURISDICTION);
       store.setSystemSettings(systemSettings);
     },
 

--- a/apps/central-scan/backend/src/cli/render_pages.test.ts
+++ b/apps/central-scan/backend/src/cli/render_pages.test.ts
@@ -3,10 +3,13 @@ import { promises as fs } from 'fs';
 import { join } from 'path';
 import { pathExists } from 'fs-extra';
 import { tmpNameSync } from 'tmp';
-import { BallotMetadata, BallotType } from '@votingworks/types';
+import {
+  BallotMetadata,
+  BallotType,
+  TEST_JURISDICTION,
+} from '@votingworks/types';
 import { asElectionDefinition } from '@votingworks/fixtures';
 import { loadImageData } from '@votingworks/image-utils';
-import { DEV_JURISDICTION } from '@votingworks/auth';
 import { Store } from '../store';
 import {
   election,
@@ -15,7 +18,7 @@ import {
 import { main } from './render_pages';
 import { getMockBallotPageLayoutsWithImages } from '../../test/helpers/mock_layouts';
 
-const jurisdiction = DEV_JURISDICTION;
+const jurisdiction = TEST_JURISDICTION;
 
 function fakeOutput(): WritableStream & NodeJS.WriteStream {
   return new WritableStream() as WritableStream & NodeJS.WriteStream;

--- a/apps/central-scan/backend/src/end_to_end.test.ts
+++ b/apps/central-scan/backend/src/end_to_end.test.ts
@@ -1,7 +1,4 @@
-import {
-  DEV_JURISDICTION,
-  buildMockDippedSmartCardAuth,
-} from '@votingworks/auth';
+import { buildMockDippedSmartCardAuth } from '@votingworks/auth';
 import {
   convertCastVoteRecordVotesToLegacyVotes,
   createMockUsb,
@@ -15,7 +12,7 @@ import {
   electionSample as election,
   sampleBallotImages,
 } from '@votingworks/fixtures';
-import { CVR, unsafeParse } from '@votingworks/types';
+import { CVR, TEST_JURISDICTION, unsafeParse } from '@votingworks/types';
 import {
   BooleanEnvironmentVariableName,
   CAST_VOTE_RECORD_REPORT_FILENAME,
@@ -80,7 +77,7 @@ afterEach(async () => {
   featureFlagMock.resetFeatureFlags();
 });
 
-const jurisdiction = DEV_JURISDICTION;
+const jurisdiction = TEST_JURISDICTION;
 
 test('going through the whole process works', async () => {
   auth.getAuthStatus.mockResolvedValue({

--- a/apps/central-scan/backend/src/end_to_end_hmpb.test.ts
+++ b/apps/central-scan/backend/src/end_to_end_hmpb.test.ts
@@ -12,7 +12,7 @@ import {
   asElectionDefinition,
   electionGridLayoutNewHampshireAmherstFixtures,
 } from '@votingworks/fixtures';
-import { CVR, unsafeParse } from '@votingworks/types';
+import { CVR, TEST_JURISDICTION, unsafeParse } from '@votingworks/types';
 import * as grout from '@votingworks/grout';
 import {
   BooleanEnvironmentVariableName,
@@ -25,10 +25,7 @@ import * as fs from 'fs-extra';
 import { join } from 'path';
 import request from 'supertest';
 import { dirSync } from 'tmp';
-import {
-  buildMockDippedSmartCardAuth,
-  DEV_JURISDICTION,
-} from '@votingworks/auth';
+import { buildMockDippedSmartCardAuth } from '@votingworks/auth';
 import { fakeLogger, Logger } from '@votingworks/logging';
 import { Server } from 'http';
 import { fakeSessionExpiresAt } from '@votingworks/test-utils';
@@ -116,7 +113,7 @@ afterEach(async () => {
   server.close();
 });
 
-const jurisdiction = DEV_JURISDICTION;
+const jurisdiction = TEST_JURISDICTION;
 
 test('going through the whole process works', async () => {
   jest.setTimeout(25000);

--- a/apps/central-scan/backend/src/importer.test.ts
+++ b/apps/central-scan/backend/src/importer.test.ts
@@ -1,13 +1,12 @@
 import { dirSync } from 'tmp';
 import { typedAs } from '@votingworks/basics';
-import { MarkThresholds } from '@votingworks/types';
+import { MarkThresholds, TEST_JURISDICTION } from '@votingworks/types';
 import { electionGridLayoutNewHampshireAmherstFixtures } from '@votingworks/fixtures';
-import { DEV_JURISDICTION } from '@votingworks/auth';
 import { Importer } from './importer';
 import { createWorkspace } from './util/workspace';
 import { makeMockScanner } from '../test/util/mocks';
 
-const jurisdiction = DEV_JURISDICTION;
+const jurisdiction = TEST_JURISDICTION;
 
 test('no election is configured', async () => {
   const workspace = await createWorkspace(dirSync().name);

--- a/apps/central-scan/backend/src/interpreters/nh.test.ts
+++ b/apps/central-scan/backend/src/interpreters/nh.test.ts
@@ -1,12 +1,12 @@
 import { electionGridLayoutNewHampshireAmherstFixtures } from '@votingworks/fixtures';
+import { TEST_JURISDICTION } from '@votingworks/types';
 import { readdir } from 'fs/promises';
 import { join } from 'path';
 import { dirSync, fileSync } from 'tmp';
-import { DEV_JURISDICTION } from '@votingworks/auth';
 import { Store } from '../store';
 import * as interpretNh from './nh';
 
-const jurisdiction = DEV_JURISDICTION;
+const jurisdiction = TEST_JURISDICTION;
 
 test('interpret', async () => {
   const dbPath = fileSync().name;

--- a/apps/central-scan/backend/src/store.test.ts
+++ b/apps/central-scan/backend/src/store.test.ts
@@ -9,6 +9,7 @@ import {
   mapSheet,
   PageInterpretationWithFiles,
   SheetOf,
+  TEST_JURISDICTION,
   YesNoContest,
 } from '@votingworks/types';
 import {
@@ -21,7 +22,6 @@ import * as fs from 'fs/promises';
 import { v4 as uuid } from 'uuid';
 import { sleep, typedAs } from '@votingworks/basics';
 import { ResultSheet } from '@votingworks/backend';
-import { DEV_JURISDICTION } from '@votingworks/auth';
 import * as stateOfHamilton from '../test/fixtures/state-of-hamilton';
 import { zeroRect } from '../test/fixtures/zero_rect';
 import {
@@ -34,7 +34,7 @@ import { ballotPdf } from '../test/fixtures/2020-choctaw';
 // We pause in some of these tests so we need to increase the timeout
 jest.setTimeout(20000);
 
-const jurisdiction = DEV_JURISDICTION;
+const jurisdiction = TEST_JURISDICTION;
 const { electionDefinition } = stateOfHamilton;
 const { election, electionData, electionHash } = electionDefinition;
 

--- a/apps/central-scan/integration-testing/cypress/e2e/configuration.cy.ts
+++ b/apps/central-scan/integration-testing/cypress/e2e/configuration.cy.ts
@@ -1,15 +1,12 @@
 import { Buffer } from 'buffer';
-import { methodUrl } from '@votingworks/grout';
 import { sha256 } from 'js-sha256';
+import { methodUrl } from '@votingworks/grout';
+import { TEST_JURISDICTION } from '@votingworks/types';
 
 // Importing all of @votingworks/auth causes Cypress tests to fail since @votingworks/auth contains
 // code that isn't browser-safe
 // eslint-disable-next-line vx/no-import-workspace-subfolders
-import {
-  DEV_JURISDICTION,
-  mockCard,
-  MockFileContents,
-} from '@votingworks/auth/src/cypress';
+import { mockCard, MockFileContents } from '@votingworks/auth/src/cypress';
 
 const PIN = '000000';
 
@@ -28,7 +25,7 @@ function mockElectionManagerCard() {
           cardDetails: {
             user: {
               role: 'election_manager',
-              jurisdiction: DEV_JURISDICTION,
+              jurisdiction: TEST_JURISDICTION,
               electionHash,
             },
           },

--- a/apps/central-scan/integration-testing/package.json
+++ b/apps/central-scan/integration-testing/package.json
@@ -44,6 +44,7 @@
     "@votingworks/auth": "workspace:*",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/grout": "workspace:*",
+    "@votingworks/types": "workspace:*",
     "buffer": "^6.0.3",
     "cypress": "^10.3.1",
     "js-sha256": "^0.9.0",

--- a/apps/central-scan/integration-testing/tsconfig.json
+++ b/apps/central-scan/integration-testing/tsconfig.json
@@ -21,6 +21,7 @@
     { "path": "../../../libs/auth/tsconfig.build.json" },
     { "path": "../../../libs/eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../../../libs/fixtures/tsconfig.build.json" },
-    { "path": "../../../libs/grout/tsconfig.build.json" }
+    { "path": "../../../libs/grout/tsconfig.build.json" },
+    { "path": "../../../libs/types/tsconfig.build.json" }
   ]
 }

--- a/apps/mark/backend/src/app.auth.test.ts
+++ b/apps/mark/backend/src/app.auth.test.ts
@@ -1,12 +1,12 @@
 import { DateTime } from 'luxon';
-import { DEV_JURISDICTION } from '@votingworks/auth';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import { TEST_JURISDICTION } from '@votingworks/types';
 
 import { configureApp, createApp } from '../test/app_helpers';
 
+const jurisdiction = TEST_JURISDICTION;
 const { electionDefinition } = electionFamousNames2021Fixtures;
 const { electionHash } = electionDefinition;
-const jurisdiction = DEV_JURISDICTION;
 
 test('getAuthStatus', async () => {
   const { apiClient, mockAuth, mockUsb } = createApp();

--- a/apps/mark/backend/src/app.test.ts
+++ b/apps/mark/backend/src/app.test.ts
@@ -11,7 +11,7 @@ import {
   mockOf,
   suppressingConsoleOutput,
 } from '@votingworks/test-utils';
-import { DEV_JURISDICTION, InsertedSmartCardAuthApi } from '@votingworks/auth';
+import { InsertedSmartCardAuthApi } from '@votingworks/auth';
 import {
   ALL_PRECINCTS_SELECTION,
   ReportSourceMachineType,
@@ -28,6 +28,7 @@ import {
   DEFAULT_SYSTEM_SETTINGS,
   safeParseJson,
   SystemSettingsSchema,
+  TEST_JURISDICTION,
 } from '@votingworks/types';
 import { configureApp, createApp } from '../test/app_helpers';
 import { Api } from './app';
@@ -45,7 +46,7 @@ afterEach(() => {
   server?.close();
 });
 
-const jurisdiction = DEV_JURISDICTION;
+const jurisdiction = TEST_JURISDICTION;
 
 test('uses machine config from env', async () => {
   const originalEnv = process.env;

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -1,7 +1,6 @@
 import express, { Application } from 'express';
 import { z } from 'zod';
 import {
-  DEV_JURISDICTION,
   InsertedSmartCardAuthApi,
   InsertedSmartCardAuthMachineState,
 } from '@votingworks/auth';
@@ -14,6 +13,7 @@ import {
   PrecinctId,
   SystemSettings,
   DEFAULT_SYSTEM_SETTINGS,
+  TEST_JURISDICTION,
 } from '@votingworks/types';
 import {
   ScannerReportData,
@@ -106,7 +106,7 @@ function buildApi(
       const systemSettings = DEFAULT_SYSTEM_SETTINGS;
       workspace.store.setElectionAndJurisdiction({
         electionData: electionDefinition.electionData,
-        jurisdiction: DEV_JURISDICTION,
+        jurisdiction: TEST_JURISDICTION,
       });
       workspace.store.setSystemSettings(systemSettings);
       return ok(electionDefinition);

--- a/apps/mark/backend/src/store.test.ts
+++ b/apps/mark/backend/src/store.test.ts
@@ -1,13 +1,12 @@
 import { safeParseSystemSettings } from '@votingworks/utils';
 import { electionMinimalExhaustiveSampleFixtures } from '@votingworks/fixtures';
-import { SystemSettings } from '@votingworks/types';
-import { DEV_JURISDICTION } from '@votingworks/auth';
+import { SystemSettings, TEST_JURISDICTION } from '@votingworks/types';
 import { Store } from './store';
 
 // We pause in some of these tests so we need to increase the timeout
 jest.setTimeout(20000);
 
-const jurisdiction = DEV_JURISDICTION;
+const jurisdiction = TEST_JURISDICTION;
 
 test('getDbPath', () => {
   const store = Store.memoryStore();

--- a/apps/mark/backend/test/app_helpers.ts
+++ b/apps/mark/backend/test/app_helpers.ts
@@ -1,6 +1,5 @@
 import {
   buildMockInsertedSmartCardAuth,
-  DEV_JURISDICTION,
   InsertedSmartCardAuthApi,
 } from '@votingworks/auth';
 import * as grout from '@votingworks/grout';
@@ -20,6 +19,7 @@ import {
   fakeSessionExpiresAt,
   mockOf,
 } from '@votingworks/test-utils';
+import { TEST_JURISDICTION } from '@votingworks/types';
 import { Api, buildApp } from '../src/app';
 import { createWorkspace } from '../src/util/workspace';
 
@@ -59,7 +59,7 @@ export async function configureApp(
   mockAuth: InsertedSmartCardAuthApi,
   mockUsb: MockUsb
 ): Promise<void> {
-  const jurisdiction = DEV_JURISDICTION;
+  const jurisdiction = TEST_JURISDICTION;
   const { electionJson, electionDefinition } = electionFamousNames2021Fixtures;
   const { electionHash } = electionDefinition;
   mockOf(mockAuth.getAuthStatus).mockImplementation(() =>

--- a/apps/mark/integration-testing/cypress/support/e2e.js
+++ b/apps/mark/integration-testing/cypress/support/e2e.js
@@ -18,14 +18,12 @@ import './commands';
 
 import { electionSampleDefinition } from '@votingworks/fixtures';
 import { methodUrl } from '@votingworks/grout';
+import { TEST_JURISDICTION } from '@votingworks/types';
 
 // Importing all of @votingworks/auth causes Cypress tests to fail since @votingworks/auth contains
 // code that isn't browser-safe
 // eslint-disable-next-line vx/no-import-workspace-subfolders
-import {
-  DEV_JURISDICTION,
-  mockCard,
-} from '@votingworks/auth/src/cypress';
+import { mockCard } from '@votingworks/auth/src/cypress';
 
 const { electionData, electionHash } = electionSampleDefinition;
 const PIN = '000000';
@@ -41,7 +39,7 @@ function insertElectionManagerCard() {
       cardDetails: {
         user: {
           role: 'election_manager',
-          jurisdiction: DEV_JURISDICTION,
+          jurisdiction: TEST_JURISDICTION,
           electionHash,
         },
       },
@@ -58,7 +56,7 @@ function insertPollWorkerCard() {
       cardDetails: {
         user: {
           role: 'poll_worker',
-          jurisdiction: DEV_JURISDICTION,
+          jurisdiction: TEST_JURISDICTION,
           electionHash,
         },
         hasPin: false,

--- a/apps/scan/backend/schema.sql
+++ b/apps/scan/backend/schema.sql
@@ -2,6 +2,7 @@ create table election (
   -- enforce singleton table
   id integer primary key check (id = 1),
   election_data text not null,
+  jurisdiction text not null,
   precinct_selection text,
   is_test_mode boolean not null default true,
   polls_state text not null default "polls_closed_initial",

--- a/apps/scan/backend/src/app_auth.test.ts
+++ b/apps/scan/backend/src/app_auth.test.ts
@@ -1,12 +1,12 @@
 import { DateTime } from 'luxon';
-import { DEV_JURISDICTION } from '@votingworks/auth';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import { TEST_JURISDICTION } from '@votingworks/types';
 
 import { withApp } from '../test/helpers/custom_helpers';
 import { configureApp } from '../test/helpers/shared_helpers';
 
+const jurisdiction = TEST_JURISDICTION;
 const { electionHash } = electionFamousNames2021Fixtures.electionDefinition;
-const jurisdiction = DEV_JURISDICTION;
 
 test('getAuthStatus', async () => {
   await withApp({}, async ({ apiClient, mockAuth, mockUsb }) => {
@@ -71,7 +71,7 @@ test('getAuthStatus before election definition has been configured', async () =>
   await withApp({}, async ({ apiClient, mockAuth }) => {
     await apiClient.getAuthStatus();
     expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(1);
-    expect(mockAuth.getAuthStatus).toHaveBeenNthCalledWith(1, { jurisdiction });
+    expect(mockAuth.getAuthStatus).toHaveBeenNthCalledWith(1, {});
   });
 });
 
@@ -79,11 +79,7 @@ test('checkPin before election definition has been configured', async () => {
   await withApp({}, async ({ apiClient, mockAuth }) => {
     await apiClient.checkPin({ pin: '123456' });
     expect(mockAuth.checkPin).toHaveBeenCalledTimes(1);
-    expect(mockAuth.checkPin).toHaveBeenNthCalledWith(
-      1,
-      { jurisdiction },
-      { pin: '123456' }
-    );
+    expect(mockAuth.checkPin).toHaveBeenNthCalledWith(1, {}, { pin: '123456' });
   });
 });
 
@@ -91,7 +87,7 @@ test('logOut before election definition has been configured', async () => {
   await withApp({}, async ({ apiClient, mockAuth }) => {
     await apiClient.logOut();
     expect(mockAuth.logOut).toHaveBeenCalledTimes(1);
-    expect(mockAuth.logOut).toHaveBeenNthCalledWith(1, { jurisdiction });
+    expect(mockAuth.logOut).toHaveBeenNthCalledWith(1, {});
   });
 });
 
@@ -103,7 +99,7 @@ test('updateSessionExpiry before election definition has been configured', async
     expect(mockAuth.updateSessionExpiry).toHaveBeenCalledTimes(1);
     expect(mockAuth.updateSessionExpiry).toHaveBeenNthCalledWith(
       1,
-      { jurisdiction },
+      {},
       { sessionExpiresAt: expect.any(Date) }
     );
   });

--- a/apps/scan/backend/src/backup.test.ts
+++ b/apps/scan/backend/src/backup.test.ts
@@ -5,6 +5,7 @@ import {
   BallotType,
   CVR,
   safeParseJson,
+  TEST_JURISDICTION,
   unsafeParse,
 } from '@votingworks/types';
 import { throwIllegalValue } from '@votingworks/basics';
@@ -41,6 +42,8 @@ jest.mock('fs-extra', (): typeof import('fs-extra') => {
 
 const existsSyncMock = mockOf(existsSync);
 
+const jurisdiction = TEST_JURISDICTION;
+
 function getEntries(zipfile: JsZip): JSZipObject[] {
   return Object.values(zipfile.files);
 }
@@ -75,7 +78,10 @@ test('unconfigured', async () => {
 
 test('configured', async () => {
   const store = Store.memoryStore();
-  store.setElection(electionDefinition.electionData);
+  store.setElectionAndJurisdiction({
+    electionData: electionDefinition.electionData,
+    jurisdiction,
+  });
   const result = new WritableStream();
   const onError = jest.fn();
 
@@ -105,7 +111,10 @@ test('zip entry fails', async () => {
 
 test('has election.json', async () => {
   const store = Store.memoryStore();
-  store.setElection(asElectionDefinition(election).electionData);
+  store.setElectionAndJurisdiction({
+    electionData: asElectionDefinition(election).electionData,
+    jurisdiction,
+  });
   const result = new WritableStream();
 
   await new Promise((resolve, reject) => {
@@ -120,7 +129,10 @@ test('has election.json', async () => {
 
 test('has ballots.db', async () => {
   const store = Store.memoryStore();
-  store.setElection(electionDefinition.electionData);
+  store.setElectionAndJurisdiction({
+    electionData: electionDefinition.electionData,
+    jurisdiction,
+  });
   const output = new WritableStream();
 
   await new Promise((resolve, reject) => {
@@ -142,7 +154,10 @@ test('has ballots.db', async () => {
 
 test('has all files referenced in the database', async () => {
   const store = Store.memoryStore();
-  store.setElection(electionDefinition.electionData);
+  store.setElectionAndJurisdiction({
+    electionData: electionDefinition.electionData,
+    jurisdiction,
+  });
   const batchId = store.addBatch();
 
   const frontOriginalFile = fileSync();
@@ -221,7 +236,10 @@ test('has all files referenced in the database', async () => {
 
 test('has cast vote record report', async () => {
   const store = Store.memoryStore();
-  store.setElection(electionDefinition.electionData);
+  store.setElectionAndJurisdiction({
+    electionData: electionDefinition.electionData,
+    jurisdiction,
+  });
   const result = new WritableStream();
 
   const batchId = store.addBatch();
@@ -282,7 +300,10 @@ test('does not have vx-logs.log if file does not exist', async () => {
   existsSyncMock.mockReturnValueOnce(false);
 
   const store = Store.memoryStore();
-  store.setElection(asElectionDefinition(election).electionData);
+  store.setElectionAndJurisdiction({
+    electionData: asElectionDefinition(election).electionData,
+    jurisdiction,
+  });
   const result = new WritableStream();
 
   await new Promise((resolve, reject) => {
@@ -298,7 +319,10 @@ test('has vx-logs.log if file exists', async () => {
   existsSyncMock.mockReturnValueOnce(true);
 
   const store = Store.memoryStore();
-  store.setElection(asElectionDefinition(election).electionData);
+  store.setElectionAndJurisdiction({
+    electionData: asElectionDefinition(election).electionData,
+    jurisdiction,
+  });
   const result = new WritableStream();
 
   await new Promise((resolve, reject) => {
@@ -341,7 +365,10 @@ test.each(spaceOptimizedBackupTestCases)(
     expectedScanImagesInBackup,
   }) => {
     const store = Store.memoryStore();
-    store.setElection(electionDefinition.electionData);
+    store.setElectionAndJurisdiction({
+      electionData: electionDefinition.electionData,
+      jurisdiction,
+    });
     const batchId = store.addBatch();
 
     const originalFileNames = [];

--- a/apps/scan/backend/src/scanners/custom/app_scan.test.ts
+++ b/apps/scan/backend/src/scanners/custom/app_scan.test.ts
@@ -1,4 +1,8 @@
-import { AdjudicationReason, AdjudicationReasonInfo } from '@votingworks/types';
+import {
+  AdjudicationReason,
+  AdjudicationReasonInfo,
+  TEST_JURISDICTION,
+} from '@votingworks/types';
 import waitForExpect from 'wait-for-expect';
 import { err, ok, Result, sleep, typedAs } from '@votingworks/basics';
 import {
@@ -19,7 +23,6 @@ import {
 } from '@votingworks/utils';
 import { Logger } from '@votingworks/logging';
 import { ErrorCode, mocks } from '@votingworks/custom-scanner';
-import { DEV_JURISDICTION } from '@votingworks/auth';
 import { MAX_FAILED_SCAN_ATTEMPTS } from './state_machine';
 import {
   configureApp,
@@ -75,7 +78,7 @@ function checkLogs(logger: Logger): void {
   );
 }
 
-const jurisdiction = DEV_JURISDICTION;
+const jurisdiction = TEST_JURISDICTION;
 
 test('configure and scan hmpb', async () => {
   await withApp(

--- a/apps/scan/backend/src/store.test.ts
+++ b/apps/scan/backend/src/store.test.ts
@@ -12,6 +12,7 @@ import {
   mapSheet,
   PageInterpretationWithFiles,
   SheetOf,
+  TEST_JURISDICTION,
   YesNoContest,
 } from '@votingworks/types';
 import {
@@ -33,19 +34,24 @@ import { Store } from './store';
 // We pause in some of these tests so we need to increase the timeout
 jest.setTimeout(20000);
 
+const jurisdiction = TEST_JURISDICTION;
+
 test('get/set election', () => {
   const store = Store.memoryStore();
 
   expect(store.getElectionDefinition()).toBeUndefined();
   expect(store.hasElection()).toBeFalsy();
 
-  store.setElection(stateOfHamilton.electionDefinition.electionData);
+  store.setElectionAndJurisdiction({
+    electionData: stateOfHamilton.electionDefinition.electionData,
+    jurisdiction,
+  });
   expect(store.getElectionDefinition()?.election).toEqual(
     stateOfHamilton.election
   );
   expect(store.hasElection()).toBeTruthy();
 
-  store.setElection(undefined);
+  store.setElectionAndJurisdiction(undefined);
   expect(store.getElectionDefinition()).toBeUndefined();
 });
 
@@ -68,7 +74,10 @@ test('get/set test mode', () => {
   expect(store.getTestMode()).toEqual(true);
   expect(() => store.setTestMode(false)).toThrowError();
 
-  store.setElection(stateOfHamilton.electionDefinition.electionData);
+  store.setElectionAndJurisdiction({
+    electionData: stateOfHamilton.electionDefinition.electionData,
+    jurisdiction,
+  });
 
   // After setting an election
   expect(store.getTestMode()).toEqual(true);
@@ -87,7 +96,10 @@ test('get/set is sounds muted mode', () => {
   expect(store.getIsSoundMuted()).toEqual(false);
   expect(() => store.setIsSoundMuted(true)).toThrowError();
 
-  store.setElection(stateOfHamilton.electionDefinition.electionData);
+  store.setElectionAndJurisdiction({
+    electionData: stateOfHamilton.electionDefinition.electionData,
+    jurisdiction,
+  });
 
   // After setting an election
   expect(store.getIsSoundMuted()).toEqual(false);
@@ -106,7 +118,10 @@ test('get/set is ultrasonic disabled mode', () => {
   expect(store.getIsUltrasonicDisabled()).toEqual(false);
   expect(() => store.setIsUltrasonicDisabled(true)).toThrowError();
 
-  store.setElection(stateOfHamilton.electionDefinition.electionData);
+  store.setElectionAndJurisdiction({
+    electionData: stateOfHamilton.electionDefinition.electionData,
+    jurisdiction,
+  });
 
   // After setting an election
   expect(store.getIsUltrasonicDisabled()).toEqual(false);
@@ -127,7 +142,10 @@ test('get/set ballot count when ballot bag last replaced', () => {
     store.setBallotCountWhenBallotBagLastReplaced(1500)
   ).toThrowError();
 
-  store.setElection(stateOfHamilton.electionDefinition.electionData);
+  store.setElectionAndJurisdiction({
+    electionData: stateOfHamilton.electionDefinition.electionData,
+    jurisdiction,
+  });
 
   // After setting an election
   expect(store.getBallotCountWhenBallotBagLastReplaced()).toEqual(0);
@@ -145,7 +163,10 @@ test('get/set precinct selection', () => {
     store.setPrecinctSelection(ALL_PRECINCTS_SELECTION)
   ).toThrowError();
 
-  store.setElection(stateOfHamilton.electionDefinition.electionData);
+  store.setElectionAndJurisdiction({
+    electionData: stateOfHamilton.electionDefinition.electionData,
+    jurisdiction,
+  });
 
   // After setting an election
   expect(store.getPrecinctSelection()).toEqual(undefined);
@@ -165,7 +186,10 @@ test('get/set mark threshold overrides', () => {
   expect(store.getMarkThresholdOverrides()).toEqual(undefined);
   expect(() => store.setMarkThresholdOverrides()).toThrowError();
 
-  store.setElection(stateOfHamilton.electionDefinition.electionData);
+  store.setElectionAndJurisdiction({
+    electionData: stateOfHamilton.electionDefinition.electionData,
+    jurisdiction,
+  });
 
   store.setMarkThresholdOverrides({ definite: 0.6, marginal: 0.5 });
   expect(store.getMarkThresholdOverrides()).toStrictEqual({
@@ -179,7 +203,10 @@ test('get/set mark threshold overrides', () => {
 
 test('get current mark thresholds falls back to election definition defaults', () => {
   const store = Store.memoryStore();
-  store.setElection(stateOfHamilton.electionDefinition.electionData);
+  store.setElectionAndJurisdiction({
+    electionData: stateOfHamilton.electionDefinition.electionData,
+    jurisdiction,
+  });
   expect(store.getCurrentMarkThresholds()).toStrictEqual({
     definite: 0.17,
     marginal: 0.12,
@@ -205,7 +232,10 @@ test('get/set polls state', () => {
   expect(store.getPollsState()).toEqual('polls_closed_initial');
   expect(() => store.setPollsState('polls_open')).toThrowError();
 
-  store.setElection(stateOfHamilton.electionDefinition.electionData);
+  store.setElectionAndJurisdiction({
+    electionData: stateOfHamilton.electionDefinition.electionData,
+    jurisdiction,
+  });
 
   // After setting an election
   store.setPollsState('polls_open');
@@ -214,7 +244,10 @@ test('get/set polls state', () => {
 
 test('get/set scanner as backed up', () => {
   const store = Store.memoryStore();
-  store.setElection(stateOfHamilton.electionDefinition.electionData);
+  store.setElectionAndJurisdiction({
+    electionData: stateOfHamilton.electionDefinition.electionData,
+    jurisdiction,
+  });
   expect(store.getScannerBackupTimestamp()).toBeFalsy();
   store.setScannerBackedUp();
   expect(store.getScannerBackupTimestamp()).toBeTruthy();
@@ -224,7 +257,10 @@ test('get/set scanner as backed up', () => {
 
 test('get/set cvrs as backed up', () => {
   const store = Store.memoryStore();
-  store.setElection(stateOfHamilton.electionDefinition.electionData);
+  store.setElectionAndJurisdiction({
+    electionData: stateOfHamilton.electionDefinition.electionData,
+    jurisdiction,
+  });
   expect(store.getCvrsBackupTimestamp()).toBeFalsy();
   store.setCvrsBackedUp();
   expect(store.getCvrsBackupTimestamp()).toBeTruthy();
@@ -275,7 +311,10 @@ const ballotTemplates: BallotPackageEntry[] = [
 
 test('HMPB template handling', async () => {
   const store = Store.memoryStore();
-  store.setElection(stateOfHamilton.electionDefinition.electionData);
+  store.setElectionAndJurisdiction({
+    electionData: stateOfHamilton.electionDefinition.electionData,
+    jurisdiction,
+  });
 
   expect(store.getHmpbTemplates()).toEqual([]);
 
@@ -321,7 +360,10 @@ test('HMPB template handling', async () => {
 test('layout caching', async () => {
   const dbFile = tmp.fileSync();
   const initialStore = await Store.fileStore(dbFile.name);
-  initialStore.setElection(stateOfHamilton.electionDefinition.electionData);
+  initialStore.setElectionAndJurisdiction({
+    electionData: stateOfHamilton.electionDefinition.electionData,
+    jurisdiction,
+  });
 
   await initialStore.setHmpbTemplates(ballotTemplates);
 
@@ -361,7 +403,10 @@ test('layout caching', async () => {
 
   // if we reset and reload templates, the cache should be clear
   loadedStore.reset();
-  loadedStore.setElection(stateOfHamilton.electionDefinition.electionData);
+  loadedStore.setElectionAndJurisdiction({
+    electionData: stateOfHamilton.electionDefinition.electionData,
+    jurisdiction,
+  });
   expect(await loadedStore.loadLayouts()).toMatchObject([]);
 });
 
@@ -466,7 +511,10 @@ test('batchStatus', () => {
 
 test('canUnconfigure in test mode', () => {
   const store = Store.memoryStore();
-  store.setElection(stateOfHamilton.electionDefinition.electionData);
+  store.setElectionAndJurisdiction({
+    electionData: stateOfHamilton.electionDefinition.electionData,
+    jurisdiction,
+  });
   store.setTestMode(true);
 
   // With an unexported batch, we should be able to unconfigure the machine in test mode
@@ -476,7 +524,10 @@ test('canUnconfigure in test mode', () => {
 
 test('canUnconfigure not in test mode', async () => {
   const store = Store.memoryStore();
-  store.setElection(stateOfHamilton.electionDefinition.electionData);
+  store.setElectionAndJurisdiction({
+    electionData: stateOfHamilton.electionDefinition.electionData,
+    jurisdiction,
+  });
   store.setTestMode(false);
 
   // Can unconfigure if no batches added
@@ -598,7 +649,10 @@ test('adjudication', async () => {
     locales: { primary: 'en-US' },
     ballotType: BallotType.Standard,
   };
-  store.setElection(stateOfHamilton.electionDefinition.electionData);
+  store.setElectionAndJurisdiction({
+    electionData: stateOfHamilton.electionDefinition.electionData,
+    jurisdiction,
+  });
   await store.setHmpbTemplates([
     {
       pdf: await fs.readFile(ballotPdf),
@@ -736,7 +790,10 @@ test('adjudication', async () => {
 
 test('iterating over all result sheets', () => {
   const store = Store.memoryStore();
-  store.setElection(stateOfHamilton.electionDefinition.electionData);
+  store.setElectionAndJurisdiction({
+    electionData: stateOfHamilton.electionDefinition.electionData,
+    jurisdiction,
+  });
 
   // starts empty
   expect(Array.from(store.forEachResultSheet())).toEqual([]);
@@ -851,7 +908,10 @@ test('iterating over all result sheets', () => {
 test('resetElectionSession', async () => {
   const dbFile = tmp.fileSync();
   const store = await Store.fileStore(dbFile.name);
-  store.setElection(stateOfHamilton.electionDefinition.electionData);
+  store.setElectionAndJurisdiction({
+    electionData: stateOfHamilton.electionDefinition.electionData,
+    jurisdiction,
+  });
 
   store.setPollsState('polls_open');
   store.setBallotCountWhenBallotBagLastReplaced(1500);

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -174,14 +174,28 @@ export class Store {
   }
 
   /**
-   * Sets the current election definition.
+   * Gets the current jurisdiction.
    */
-  setElection(electionData?: string): void {
+  getJurisdiction(): string | undefined {
+    const electionRow = this.client.one('select jurisdiction from election') as
+      | { jurisdiction: string }
+      | undefined;
+    return electionRow?.jurisdiction;
+  }
+
+  /**
+   * Sets the current election definition and jurisdiction.
+   */
+  setElectionAndJurisdiction(input?: {
+    electionData: string;
+    jurisdiction: string;
+  }): void {
     this.client.run('delete from election');
-    if (electionData) {
+    if (input) {
       this.client.run(
-        'insert into election (election_data) values (?)',
-        electionData
+        'insert into election (election_data, jurisdiction) values (?, ?)',
+        input.electionData,
+        input.jurisdiction
       );
     }
   }

--- a/apps/scan/backend/src/tally-cvrs/export.test.ts
+++ b/apps/scan/backend/src/tally-cvrs/export.test.ts
@@ -5,6 +5,7 @@ import {
   BallotPageMetadata,
   BallotType,
   CastVoteRecord,
+  TEST_JURISDICTION,
 } from '@votingworks/types';
 import { isFeatureFlagEnabled } from '@votingworks/utils';
 import { writeFile } from 'fs-extra';
@@ -23,6 +24,8 @@ jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
     isFeatureFlagEnabled: jest.fn(),
   };
 });
+
+const jurisdiction = TEST_JURISDICTION;
 
 const ballotConfig: BallotConfig = {
   filename: 'test-filename',
@@ -83,7 +86,10 @@ test('exportCvrs', async () => {
   buildCastVoteRecordMock.mockReturnValue(cvr);
 
   const store = Store.memoryStore();
-  store.setElection(stateOfHamilton.electionDefinition.electionData);
+  store.setElectionAndJurisdiction({
+    electionData: stateOfHamilton.electionDefinition.electionData,
+    jurisdiction,
+  });
 
   // No CVRs, export should be empty
   expect(iter(exportCastVoteRecords({ store })).toArray()).toEqual([]);
@@ -149,7 +155,10 @@ test('exportCvrs', async () => {
 
 test('exportCvrs orders by sheet ID', async () => {
   const store = Store.memoryStore();
-  store.setElection(stateOfHamilton.electionDefinition.electionData);
+  store.setElectionAndJurisdiction({
+    electionData: stateOfHamilton.electionDefinition.electionData,
+    jurisdiction,
+  });
 
   await store.setHmpbTemplates(ballotTemplates);
 

--- a/libs/auth/src/cypress.ts
+++ b/libs/auth/src/cypress.ts
@@ -10,6 +10,5 @@
  * ```
  */
 
-export { DEV_JURISDICTION } from './jurisdictions';
 export { mockCard } from './mock_file_card';
 export type { MockFileContents } from './mock_file_card';

--- a/libs/test-utils/src/auth.ts
+++ b/libs/test-utils/src/auth.ts
@@ -5,6 +5,7 @@ import {
   ElectionManagerUser,
   PollWorkerUser,
   SystemAdministratorUser,
+  TEST_JURISDICTION,
 } from '@votingworks/types';
 
 export function fakeSystemAdministratorUser(
@@ -12,7 +13,7 @@ export function fakeSystemAdministratorUser(
 ): SystemAdministratorUser {
   return {
     role: 'system_administrator',
-    jurisdiction: 'jurisdiction',
+    jurisdiction: TEST_JURISDICTION,
     ...props,
   };
 }
@@ -22,7 +23,7 @@ export function fakeElectionManagerUser(
 ): ElectionManagerUser {
   return {
     role: 'election_manager',
-    jurisdiction: 'jurisdiction',
+    jurisdiction: TEST_JURISDICTION,
     electionHash: 'election-hash',
     ...props,
   };
@@ -33,7 +34,7 @@ export function fakePollWorkerUser(
 ): PollWorkerUser {
   return {
     role: 'poll_worker',
-    jurisdiction: 'jurisdiction',
+    jurisdiction: TEST_JURISDICTION,
     electionHash: 'election-hash',
     ...props,
   };

--- a/libs/types/src/auth/auth.ts
+++ b/libs/types/src/auth/auth.ts
@@ -66,3 +66,15 @@ export type OverallSessionTimeLimitHours =
   | 11
   | 12;
 export const DEFAULT_OVERALL_SESSION_TIME_LIMIT_HOURS: OverallSessionTimeLimitHours = 12;
+
+/**
+ * The jurisdiction used across tests.
+ *
+ * We define this here instead of in @votingworks/auth so that it can be imported by
+ * @votingworks/test-utils without creating a circular dependency.
+ *
+ * And we define it here instead of in @votingworks/test-utils so that it can be imported by app
+ * source code, e.g. for integration tests, without having to move @votingworks/test-utils from dev
+ * dependencies to non-dev dependencies.
+ */
+export const TEST_JURISDICTION = 'jurisdiction';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1455,6 +1455,9 @@ importers:
       '@votingworks/grout':
         specifier: workspace:*
         version: link:../../../libs/grout
+      '@votingworks/types':
+        specifier: workspace:*
+        version: link:../../../libs/types
       buffer:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
_Easiest reviewed by commit_

## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/2912

The VxScan equivalent of https://github.com/votingworks/vxsuite/pull/3348 for VxCentralScan and https://github.com/votingworks/vxsuite/pull/3360 for VxMark. Largely copying from those PRs' descriptions:

This PR replaces the hardcoded dev jurisdiction in VxScan with proper jurisdiction state management. When the machine is configured, the jurisdiction will be set to the jurisdiction on the election manager card used to auth onto the machine. And when the machine is unconfigured, the jurisdiction will be cleared.

When a jurisdiction is set, the machine will only accept cards from that jurisdiction. And when no jurisdiction is set, the machine will accept cards from all jurisdictions. This logic already exists and lives in the auth lib.

While I was at it, I also tweaked how we define jurisdiction in tests.

## Testing

- [x] Updated automated tests
- [x] Manually tested that jurisdiction is set on configure
- [x] Manually tested that jurisdiction is cleared on unconfigure

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A