### PR TITLE
[VxAdmin] Replace <p> elements with the theme-aware <P>

### DIFF
--- a/apps/mark/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
@@ -187,7 +187,9 @@ exports[`Single Seat Contest 1`] = `
             </div>
             President and Vice-President
           </h1>
-          <p>
+          <p
+            class="sc-dkPtyc XGKAk"
+          >
             <span
               class="sc-bqiQRQ bIFmdQ"
             >

--- a/apps/mark/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
@@ -187,7 +187,9 @@ exports[`Single Seat Contest 1`] = `
             </div>
             County Commissioners
           </h1>
-          <p>
+          <p
+            class="sc-dkPtyc XGKAk"
+          >
             <span
               class="sc-bqiQRQ bIFmdQ"
             >

--- a/apps/mark/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
@@ -187,7 +187,9 @@ exports[`Single Seat Contest 1`] = `
             </div>
             President and Vice-President
           </h1>
-          <p>
+          <p
+            class="sc-dkPtyc XGKAk"
+          >
             <span
               class="sc-bqiQRQ bIFmdQ"
             >

--- a/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
@@ -187,7 +187,9 @@ exports[`Single Seat Contest with Write In 1`] = `
             </div>
             Registrar of Wills
           </h1>
-          <p>
+          <p
+            class="sc-dkPtyc XGKAk"
+          >
             <span
               class="sc-bqiQRQ bIFmdQ"
             >

--- a/apps/mark/frontend/src/components/__snapshots__/election_info.test.tsx.snap
+++ b/apps/mark/frontend/src/components/__snapshots__/election_info.test.tsx.snap
@@ -702,6 +702,7 @@ exports[`renders vertical ElectionInfo with hash when specified 1`] = `
       </h1>
       <p
         aria-label="November 3, 2020. State of Hamilton, Franklin County. Center Springfield."
+        class="sc-dkPtyc XGKAk"
       >
         November 3, 2020
         <br />
@@ -921,6 +922,7 @@ exports[`renders vertical ElectionInfo without hash by default 1`] = `
       </h1>
       <p
         aria-label="November 3, 2020. State of Hamilton, Franklin County. Center Springfield."
+        class="sc-dkPtyc XGKAk"
       >
         November 3, 2020
         <br />

--- a/apps/mark/frontend/src/components/__snapshots__/settings_text_size.test.tsx.snap
+++ b/apps/mark/frontend/src/components/__snapshots__/settings_text_size.test.tsx.snap
@@ -56,7 +56,9 @@ exports[`renders SettingsTextSize 1`] = `
   margin-bottom: 0.4rem;
 }
 
-<p>
+<p
+  class="sc-dkPtyc XGKAk"
+>
   <label
     aria-hidden="true"
     class="c0"

--- a/apps/mark/frontend/src/components/__snapshots__/yes_no_contest.test.tsx.snap
+++ b/apps/mark/frontend/src/components/__snapshots__/yes_no_contest.test.tsx.snap
@@ -98,7 +98,9 @@ exports[`supports yes/no contest allows voting for both yes and no 1`] = `
           </div>
           Ballot Measure 3
         </h1>
-        <p>
+        <p
+          class="sc-dkPtyc XGKAk"
+        >
           Vote 
           <strong>
             Yes
@@ -347,7 +349,9 @@ exports[`supports yes/no contest displays warning when attempting to change vote
           </div>
           Ballot Measure 3
         </h1>
-        <p>
+        <p
+          class="sc-dkPtyc XGKAk"
+        >
           Vote 
           <strong>
             Yes

--- a/apps/mark/frontend/src/components/candidate_contest.tsx
+++ b/apps/mark/frontend/src/components/candidate_contest.tsx
@@ -25,6 +25,7 @@ import {
   Modal,
   Prose,
   Text,
+  P,
 } from '@votingworks/ui';
 import { assert } from '@votingworks/basics';
 
@@ -304,7 +305,7 @@ export function CandidateContest({
               <DistrictName>{districtName}</DistrictName>
               {contest.title}
             </H1>
-            <p>
+            <P>
               <Text as="span">Vote for {contest.seats}.</Text>{' '}
               {vote.length === contest.seats && (
                 <Text as="span" bold>
@@ -320,7 +321,7 @@ export function CandidateContest({
                 To navigate through the contest choices, use the down button. To
                 move to the next contest, use the right button.
               </span>
-            </p>
+            </P>
           </Prose>
         </ContentHeader>
         <VariableContentContainer

--- a/apps/mark/frontend/src/components/election_info.tsx
+++ b/apps/mark/frontend/src/components/election_info.tsx
@@ -9,7 +9,7 @@ import {
 } from '@votingworks/types';
 import { getPrecinctSelectionName, format } from '@votingworks/utils';
 
-import { Prose, Text, NoWrap, H1, H5 } from '@votingworks/ui';
+import { Prose, Text, NoWrap, H1, H5, P } from '@votingworks/ui';
 import pluralize from 'pluralize';
 import { Seal } from './seal';
 
@@ -98,7 +98,7 @@ export function ElectionInfo({
       <Seal seal={seal} sealUrl={sealUrl} />
       <Prose textCenter>
         <H1 aria-label={`${title}.`}>{title}</H1>
-        <p
+        <P
           aria-label={`${electionDate}. ${state}, ${county.name}. ${precinctName}.`}
         >
           {electionDate}
@@ -113,14 +113,14 @@ export function ElectionInfo({
               {ballotStyleId && <NoWrap>({ballotStyleId})</NoWrap>}
             </strong>
           )}
-        </p>
+        </P>
         {contestCount && (
           <React.Fragment>
             <hr />
-            <p>
+            <P>
               Your ballot has{' '}
               <strong>{pluralize('contest', contestCount, true)}</strong>.
-            </p>
+            </P>
           </React.Fragment>
         )}
       </Prose>

--- a/apps/mark/frontend/src/components/ms_either_neither_contest.tsx
+++ b/apps/mark/frontend/src/components/ms_either_neither_contest.tsx
@@ -7,9 +7,8 @@ import React, {
   useState,
 } from 'react';
 import styled from 'styled-components';
-
-import { YesNoVote, OptionalYesNoVote } from '@votingworks/types';
 import {
+  P,
   Button,
   ContestChoiceButton,
   H1,
@@ -18,6 +17,8 @@ import {
   Text,
   TextWithLineBreaks,
 } from '@votingworks/ui';
+
+import { YesNoVote, OptionalYesNoVote } from '@votingworks/types';
 
 import { ScrollDirections, UpdateVoteFunction } from '../config/types';
 import {
@@ -207,7 +208,7 @@ export function MsEitherNeitherContest({
             <DistrictName>{districtName}</DistrictName>
             {contest.title}
           </H1>
-          <p>
+          <P>
             {eitherNeitherVote && pickOneVote ? (
               <span>
                 You have selected {eitherLabel} and your preferred measure.
@@ -240,7 +241,7 @@ export function MsEitherNeitherContest({
               To navigate through the contest choices, use the down button. To
               move to the next contest, use the right button.
             </span>
-          </p>
+          </P>
         </Prose>
       </ContentHeader>
       <VariableContentContainer

--- a/apps/mark/frontend/src/components/settings_text_size.tsx
+++ b/apps/mark/frontend/src/components/settings_text_size.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import {
   Button,
   SegmentedButtonDeprecated as SegmentedButton,
+  P,
 } from '@votingworks/ui';
 
 import {
@@ -50,7 +51,7 @@ export function SettingsTextSize({
     setUserSettings({ textSize });
   }
   return (
-    <p>
+    <P>
       <Label aria-hidden>Text Size</Label>
       <TextSizeSegmentedButton data-testid="change-text-size-buttons">
         {FONT_SIZES.slice(0, 3).map((v: number, i: number) => (
@@ -68,6 +69,6 @@ export function SettingsTextSize({
           </Button>
         ))}
       </TextSizeSegmentedButton>
-    </p>
+    </P>
   );
 }

--- a/apps/mark/frontend/src/components/yes_no_contest.tsx
+++ b/apps/mark/frontend/src/components/yes_no_contest.tsx
@@ -21,6 +21,7 @@ import {
   Modal,
   Prose,
   TextWithLineBreaks,
+  P,
 } from '@votingworks/ui';
 
 import { getSingleYesNoVote } from '@votingworks/utils';
@@ -155,14 +156,14 @@ export function YesNoContest({
               <DistrictName>{districtName}</DistrictName>
               {contest.title}
             </H1>
-            <p>
+            <P>
               Vote <strong>Yes</strong> or <strong>No</strong>.
               <span className="screen-reader-only">
                 {contest.description}
                 To navigate through the contest choices, use the down button. To
                 move to the next contest, use the right button.
               </span>
-            </p>
+            </P>
           </Prose>
         </ContentHeader>
         <VariableContentContainer
@@ -249,7 +250,7 @@ export function YesNoContest({
           content={
             <Prose>
               {overvoteSelection && (
-                <p id="modalaudiofocus">
+                <P id="modalaudiofocus">
                   Do you want to change your vote to{' '}
                   <strong>{DisplayTextForYesOrNo[overvoteSelection]}</strong>?
                   To change your vote, first unselect your vote for{' '}
@@ -262,7 +263,7 @@ export function YesNoContest({
                     }
                   </strong>
                   .
-                </p>
+                </P>
               )}
             </Prose>
           }

--- a/apps/mark/frontend/src/pages/__snapshots__/cast_ballot_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/cast_ballot_page.test.tsx.snap
@@ -53,7 +53,9 @@ exports[`renders CastBallotPage 1`] = `
       >
         You’re Almost Done
       </h1>
-      <p>
+      <p
+        class="sc-dkPtyc XGKAk"
+      >
         Your official ballot is printing. To finish voting you need to…
       </p>
       <ol

--- a/apps/mark/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
@@ -176,7 +176,9 @@ exports[`Renders ContestPage 1`] = `
             </div>
             President and Vice-President
           </h1>
-          <p>
+          <p
+            class="sc-dkPtyc XGKAk"
+          >
             <span
               class="sc-bqiQRQ bIFmdQ"
             >
@@ -770,7 +772,9 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
             </div>
             President and Vice-President
           </h1>
-          <p>
+          <p
+            class="sc-dkPtyc XGKAk"
+          >
             <span
               class="sc-bqiQRQ bIFmdQ"
             >
@@ -1127,7 +1131,9 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
             21 contests
             .
           </p>
-          <p>
+          <p
+            class="sc-dkPtyc XGKAk"
+          >
             <button
               aria-label="next contest"
               class="sc-iJKOzS gmzpar"
@@ -1145,7 +1151,9 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
               </span>
             </button>
           </p>
-          <p>
+          <p
+            class="sc-dkPtyc XGKAk"
+          >
             <button
               aria-label="previous contest"
               class="sc-iJKOzS fssKts"

--- a/apps/mark/frontend/src/pages/__snapshots__/not_found_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/not_found_page.test.tsx.snap
@@ -15,14 +15,18 @@ exports[`renders NotFoundPage 1`] = `
       >
         Page Not Found.
       </h1>
-      <p>
+      <p
+        class="sc-dkPtyc XGKAk"
+      >
         No page exists at 
         <code>
           /foobar-not-found-path
         </code>
         .
       </p>
-      <p>
+      <p
+        class="sc-dkPtyc XGKAk"
+      >
         <button
           class="sc-iJKOzS ebzhGa"
           type="button"

--- a/apps/mark/frontend/src/pages/__snapshots__/start_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/start_page.test.tsx.snap
@@ -133,6 +133,7 @@ exports[`renders StartPage 1`] = `
         </h1>
         <p
           aria-label="November 3, 2020. State of Hamilton, Franklin County. Center Springfield."
+          class="sc-dkPtyc XGKAk"
         >
           November 3, 2020
           <br />
@@ -157,7 +158,9 @@ exports[`renders StartPage 1`] = `
           </strong>
         </p>
         <hr />
-        <p>
+        <p
+          class="sc-dkPtyc XGKAk"
+        >
           Your ballot has
            
           <strong>
@@ -168,7 +171,7 @@ exports[`renders StartPage 1`] = `
       </div>
     </div>
     <p
-      class="screen-reader-only"
+      class="sc-dkPtyc XGKAk screen-reader-only"
     >
       When voting with the text-to-speech audio, use the accessible controller to navigate your ballot. To navigate through the contests, use the left and right buttons. To navigate through contest choices, use the up and down buttons. To select or unselect a contest choice as your vote, use the select button.
     </p>
@@ -203,7 +206,9 @@ exports[`renders StartPage 1`] = `
       <div
         class="c5"
       >
-        <p>
+        <p
+          class="sc-dkPtyc XGKAk"
+        >
           <label
             aria-hidden="true"
             class="c6"
@@ -542,6 +547,7 @@ exports[`renders StartPage with inline SVG 1`] = `
         </h1>
         <p
           aria-label="November 3, 2020. State of Hamilton, Franklin County. Center Springfield."
+          class="sc-dkPtyc XGKAk"
         >
           November 3, 2020
           <br />
@@ -566,7 +572,9 @@ exports[`renders StartPage with inline SVG 1`] = `
           </strong>
         </p>
         <hr />
-        <p>
+        <p
+          class="sc-dkPtyc XGKAk"
+        >
           Your ballot has
            
           <strong>
@@ -577,7 +585,7 @@ exports[`renders StartPage with inline SVG 1`] = `
       </div>
     </div>
     <p
-      class="screen-reader-only"
+      class="sc-dkPtyc XGKAk screen-reader-only"
     >
       When voting with the text-to-speech audio, use the accessible controller to navigate your ballot. To navigate through the contests, use the left and right buttons. To navigate through contest choices, use the up and down buttons. To select or unselect a contest choice as your vote, use the select button.
     </p>
@@ -612,7 +620,9 @@ exports[`renders StartPage with inline SVG 1`] = `
       <div
         class="c4"
       >
-        <p>
+        <p
+          class="sc-dkPtyc XGKAk"
+        >
           <label
             aria-hidden="true"
             class="c5"
@@ -787,6 +797,7 @@ exports[`renders StartPage with no seal 1`] = `
         </h1>
         <p
           aria-label="November 3, 2020. State of Hamilton, Franklin County. Center Springfield."
+          class="sc-dkPtyc XGKAk"
         >
           November 3, 2020
           <br />
@@ -811,7 +822,9 @@ exports[`renders StartPage with no seal 1`] = `
           </strong>
         </p>
         <hr />
-        <p>
+        <p
+          class="sc-dkPtyc XGKAk"
+        >
           Your ballot has
            
           <strong>
@@ -822,7 +835,7 @@ exports[`renders StartPage with no seal 1`] = `
       </div>
     </div>
     <p
-      class="screen-reader-only"
+      class="sc-dkPtyc XGKAk screen-reader-only"
     >
       When voting with the text-to-speech audio, use the accessible controller to navigate your ballot. To navigate through the contests, use the left and right buttons. To navigate through contest choices, use the up and down buttons. To select or unselect a contest choice as your vote, use the select button.
     </p>
@@ -857,7 +870,9 @@ exports[`renders StartPage with no seal 1`] = `
       <div
         class="c4"
       >
-        <p>
+        <p
+          class="sc-dkPtyc XGKAk"
+        >
           <label
             aria-hidden="true"
             class="c5"

--- a/apps/mark/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.tsx
@@ -1,12 +1,7 @@
 import React, { useEffect } from 'react';
 
 import {
-  ElectionDefinition,
-  PollsState,
-  PrecinctSelection,
-} from '@votingworks/types';
-import { makeAsync } from '@votingworks/utils';
-import {
+  P,
   Button,
   ChangePrecinctButton,
   CurrentDateAndTime,
@@ -23,6 +18,12 @@ import {
   UsbControllerButton,
   UsbDrive,
 } from '@votingworks/ui';
+import {
+  ElectionDefinition,
+  PollsState,
+  PrecinctSelection,
+} from '@votingworks/types';
+import { makeAsync } from '@votingworks/utils';
 import { Logger } from '@votingworks/logging';
 // eslint-disable-next-line vx/gts-no-import-export-type
 import type { MachineConfig } from '@votingworks/mark-backend';
@@ -81,13 +82,13 @@ export function AdminScreen({
           {election && (
             <React.Fragment>
               <H2>Stats</H2>
-              <p>
+              <P>
                 Ballots Printed: <strong>{ballotsPrintedCount}</strong>
-              </p>
+              </P>
               <H2>
                 <label htmlFor="selectPrecinct">Precinct</label>
               </H2>
-              <p>
+              <P>
                 <ChangePrecinctButton
                   appPrecinctSelection={appPrecinct}
                   updatePrecinctSelection={makeAsync(updateAppPrecinct)}
@@ -113,9 +114,9 @@ export function AdminScreen({
                     </Text>
                   </React.Fragment>
                 )}
-              </p>
+              </P>
               <H2>Test Ballot Mode</H2>
-              <p>
+              <P>
                 <SegmentedButton
                   label="Test Ballot Mode"
                   hideLabel
@@ -130,25 +131,25 @@ export function AdminScreen({
                 <Text small italic as="span">
                   Switching the mode will reset the Ballots Printed count.
                 </Text>
-              </p>
+              </P>
             </React.Fragment>
           )}
           <H2>Current Date and Time</H2>
-          <p>
+          <P>
             <CurrentDateAndTime />
-          </p>
-          <p>
+          </P>
+          <P>
             <SetClockButton>Update Date and Time</SetClockButton>
-          </p>
+          </P>
           <H2>Configuration</H2>
-          <p>
+          <P>
             <Text as="span" voteIcon>
               Election Definition is loaded.
             </Text>{' '}
             <Button variant="danger" small onPress={unconfigure}>
               Unconfigure Machine
             </Button>
-          </p>
+          </P>
           <H2>USB</H2>
           <UsbControllerButton
             small={false}

--- a/apps/mark/frontend/src/pages/card_error_screen.tsx
+++ b/apps/mark/frontend/src/pages/card_error_screen.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 
-import { Main, Screen, Prose, RotateCardImage, H1 } from '@votingworks/ui';
+import { Main, Screen, Prose, RotateCardImage, H1, P } from '@votingworks/ui';
 import { triggerAudioFocus } from '../utils/trigger_audio_focus';
 
 interface Props {
@@ -21,7 +21,7 @@ export function CardErrorScreen({
           <RotateCardImage />
           <Prose textCenter id="audiofocus">
             <H1>Card is Backwards</H1>
-            <p>Remove the card, turn it around, and insert it again.</p>
+            <P>Remove the card, turn it around, and insert it again.</P>
           </Prose>
         </div>
       </Main>

--- a/apps/mark/frontend/src/pages/cast_ballot_page.tsx
+++ b/apps/mark/frontend/src/pages/cast_ballot_page.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { Button, Main, Screen, Prose, Text, H1, H3 } from '@votingworks/ui';
+import { Button, Main, Screen, Prose, Text, H1, H3, P } from '@votingworks/ui';
 
 const SingleGraphic = styled.img`
   margin: 0 auto 1em;
@@ -43,7 +43,7 @@ export function CastBallotPage({
       <Main centerChild>
         <Prose textCenter maxWidth={false} id="audiofocus">
           <H1 aria-label="You’re almost done.">You’re Almost Done</H1>
-          <p>Your official ballot is printing. To finish voting you need to…</p>
+          <P>Your official ballot is printing. To finish voting you need to…</P>
           <Instructions>
             <li>
               <SingleGraphic

--- a/apps/mark/frontend/src/pages/contest_page.tsx
+++ b/apps/mark/frontend/src/pages/contest_page.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 import { CandidateVote, OptionalYesNoVote } from '@votingworks/types';
-import { LinkButton, Screen, Prose, Text } from '@votingworks/ui';
+import { LinkButton, Screen, Prose, Text, P } from '@votingworks/ui';
 import { singlePrecinctSelectionFor } from '@votingworks/utils';
 import pluralize from 'pluralize';
 import React, { useContext, useEffect, useState } from 'react';
@@ -215,11 +215,11 @@ export function ContestPage(): JSX.Element {
               {pluralize('contest', contests.length, true)}.
             </Text>
             {isReviewMode ? (
-              <p>{reviewScreenButton}</p>
+              <P>{reviewScreenButton}</P>
             ) : (
               <React.Fragment>
-                <p>{nextContestButton}</p>
-                <p>{previousContestButton}</p>
+                <P>{nextContestButton}</P>
+                <P>{previousContestButton}</P>
               </React.Fragment>
             )}
           </Prose>

--- a/apps/mark/frontend/src/pages/diagnostics_screen.tsx
+++ b/apps/mark/frontend/src/pages/diagnostics_screen.tsx
@@ -11,6 +11,7 @@ import {
   Screen,
   Text,
   useCancelablePromise,
+  P,
 } from '@votingworks/ui';
 import { formatTime, Hardware } from '@votingworks/utils';
 import { DateTime } from 'luxon';
@@ -281,11 +282,11 @@ export function DiagnosticsScreen({
         <Screen>
           <Main padded>
             <Prose compact maxWidth={false}>
-              <p>
+              <P>
                 <Button variant="primary" onPress={onBackButtonPress}>
                   Back to Poll Worker Actions
                 </Button>
-              </p>
+              </P>
               <H1>System Diagnostics</H1>
               <span className="screen-reader-only">
                 To navigate through the available actions, use the down arrow.

--- a/apps/mark/frontend/src/pages/idle_page.tsx
+++ b/apps/mark/frontend/src/pages/idle_page.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import pluralize from 'pluralize';
 import useInterval from 'use-interval';
 
-import { Button, H1, Loading, Main, Prose, Screen } from '@votingworks/ui';
+import { Button, H1, Loading, Main, Prose, Screen, P } from '@votingworks/ui';
 
 import {
   IDLE_RESET_TIMEOUT_SECONDS,
@@ -43,15 +43,15 @@ export function IdlePage(): JSX.Element {
         ) : (
           <Prose textCenter>
             <H1 aria-label="Are you still voting?">Are you still voting?</H1>
-            <p>
+            <P>
               This voting station has been inactive for more than{' '}
               {pluralize('minute', IDLE_TIMEOUT_SECONDS / 60, true)}.
-            </p>
+            </P>
             {countdown <= timeoutSeconds / 2 && (
-              <p>
+              <P>
                 To protect your privacy, this ballot will be cleared in{' '}
                 <strong>{pluralize('second', countdown, true)}</strong>.
-              </p>
+              </P>
             )}
             <Button variant="primary" onPress={onPress}>
               Yes, I’m still voting.

--- a/apps/mark/frontend/src/pages/insert_card_screen.tsx
+++ b/apps/mark/frontend/src/pages/insert_card_screen.tsx
@@ -13,6 +13,7 @@ import {
   ElectionInfoBar,
   InsertCardImage,
   H1,
+  P,
 } from '@votingworks/ui';
 
 import { throwIllegalValue } from '@votingworks/basics';
@@ -43,7 +44,7 @@ export function InsertCardScreen({
         return (
           <React.Fragment>
             <H1>Polls Closed</H1>
-            <p>Insert Poll Worker card to open.</p>
+            <P>Insert Poll Worker card to open.</P>
           </React.Fragment>
         );
       case 'polls_open':
@@ -52,14 +53,14 @@ export function InsertCardScreen({
         return (
           <React.Fragment>
             <H1>Voting Paused</H1>
-            <p>Insert Poll Worker card to resume voting.</p>
+            <P>Insert Poll Worker card to resume voting.</P>
           </React.Fragment>
         );
       case 'polls_closed_final':
         return (
           <React.Fragment>
             <H1>Polls Closed</H1>
-            <p>Voting is complete.</p>
+            <P>Voting is complete.</P>
           </React.Fragment>
         );
       /* istanbul ignore next - compile time check for completeness */
@@ -79,9 +80,9 @@ export function InsertCardScreen({
               plug in the power cord for this machine.
             </Text>
           )}
-          <p>
+          <P>
             <InsertCardImage />
-          </p>
+          </P>
           {mainText}
           {showNoAccessibleControllerWarning && (
             <Text muted small>

--- a/apps/mark/frontend/src/pages/not_found_page.tsx
+++ b/apps/mark/frontend/src/pages/not_found_page.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import { useLocation } from 'react-router-dom';
 
-import { Button, Main, Screen, Prose, H1 } from '@votingworks/ui';
+import { Button, Main, Screen, Prose, H1, P } from '@votingworks/ui';
 import { BallotContext } from '../contexts/ballot_context';
 
 export function NotFoundPage(): JSX.Element {
@@ -15,12 +15,12 @@ export function NotFoundPage(): JSX.Element {
       <Main centerChild>
         <Prose textCenter>
           <H1>Page Not Found.</H1>
-          <p>
+          <P>
             No page exists at <code>{pathname}</code>.
-          </p>
-          <p>
+          </P>
+          <P>
             <Button onPress={requestResetBallot}>Start Over</Button>
-          </p>
+          </P>
         </Prose>
       </Main>
     </Screen>

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -35,6 +35,7 @@ import {
   useQueryChangeListener,
   H1,
   H2,
+  P,
 } from '@votingworks/ui';
 
 import {
@@ -275,16 +276,16 @@ function ScannerReportModal({
         <Prose id="modalaudiofocus">
           <H1>{reportTitle} on Card</H1>
           {willUpdatePollsToMatchScanner ? (
-            <p>
+            <P>
               This poll worker card contains a {reportTitle.toLowerCase()}.
               After printing, the report will be cleared from the card and the
               polls will be {newPollsStateName.toLowerCase()} on VxMark.
-            </p>
+            </P>
           ) : (
-            <p>
+            <P>
               This poll worker card contains a {reportTitle.toLowerCase()}.
               After printing, the report will be cleared from the card.
-            </p>
+            </P>
           )}
         </Prose>
       );
@@ -311,15 +312,15 @@ function ScannerReportModal({
         <Prose id="modalaudiofocus">
           <H1>{reportTitle} Printed</H1>
           {willUpdatePollsToMatchScanner ? (
-            <p>
+            <P>
               The polls are now {newPollsStateName.toLowerCase()}. If needed,
               you may print additional copies of the polls opened report.
-            </p>
+            </P>
           ) : (
-            <p>
+            <P>
               If needed, you may print additional copies of the polls opened
               report.
-            </p>
+            </P>
           )}
         </Prose>
       );
@@ -420,7 +421,7 @@ function UpdatePollsDirectlyButton({
           content={
             <Prose textCenter id="modalaudiofocus">
               <H1>No {reportTitle} on Card</H1>
-              <p>{suggestVxScanText}</p>
+              <P>{suggestVxScanText}</P>
             </Prose>
           }
           actions={
@@ -565,14 +566,14 @@ export function PollWorkerScreen({
             >
               Ballot Contains Votes
             </H1>
-            <p>
+            <P>
               Remove card to allow voter to continue voting, or reset ballot.
-            </p>
-            <p>
+            </P>
+            <P>
               <Button variant="danger" onPress={resetCardlessVoterSession}>
                 Reset Ballot
               </Button>
-            </p>
+            </P>
           </Prose>
         </Main>
       </Screen>
@@ -718,18 +719,18 @@ export function PollWorkerScreen({
                 <div /> {/* Enforces css margin from the following P tag. */}
                 {canSelectBallotStyle && (
                   <React.Fragment>
-                    <p>
+                    <P>
                       <Button
                         variant="primary"
                         onPress={() => setIsHidingSelectBallotStyle(false)}
                       >
                         Back to Ballot Style Selection
                       </Button>
-                    </p>
+                    </P>
                     <H1>More Actions</H1>
                   </React.Fragment>
                 )}
-                <p>
+                <P>
                   {getPollTransitionsFromState(pollsState).map(
                     (pollsTransition, index) => {
                       return (
@@ -745,15 +746,15 @@ export function PollWorkerScreen({
                       );
                     }
                   )}
-                </p>
-                <p>
+                </P>
+                <P>
                   <Button onPress={() => setIsDiagnosticsScreenOpen(true)}>
                     System Diagnostics
                   </Button>
-                </p>
-                <p>
+                </P>
+                <P>
                   <Button onPress={reload}>Reset Accessible Controller</Button>
-                </p>
+                </P>
               </React.Fragment>
             )}
           </Prose>
@@ -767,12 +768,12 @@ export function PollWorkerScreen({
                   Switch to Official Ballot Mode and reset the Ballots Printed
                   count?
                 </H1>
-                <p>
+                <P>
                   Today is election day and this machine is in{' '}
                   <strong>
                     <NoWrap>Test Ballot Mode.</NoWrap>
                   </strong>
-                </p>
+                </P>
                 <Text small italic>
                   Note: Switching back to Test Ballot Mode requires an{' '}
                   <NoWrap>Election Manager Card.</NoWrap>

--- a/apps/mark/frontend/src/pages/print_page.tsx
+++ b/apps/mark/frontend/src/pages/print_page.tsx
@@ -11,6 +11,7 @@ import {
   Prose,
   Screen,
   useLock,
+  P,
 } from '@votingworks/ui';
 
 import { BALLOT_PRINTING_TIMEOUT_SECONDS } from '../config/globals';
@@ -94,13 +95,13 @@ export function PrintPage(): JSX.Element {
     <Screen white>
       <Main centerChild>
         <Prose textCenter id="audiofocus">
-          <p>
+          <P>
             <Graphic
               src="/images/printing-ballot.svg"
               alt="Printing Ballot"
               aria-hidden
             />
-          </p>
+          </P>
           <H1>
             <ProgressEllipsis aria-label="Printing your official ballot.">
               Printing Your Official Ballot

--- a/apps/mark/frontend/src/pages/replace_election_screen.tsx
+++ b/apps/mark/frontend/src/pages/replace_election_screen.tsx
@@ -7,6 +7,7 @@ import {
   Screen,
   Table,
   Text,
+  P,
 } from '@votingworks/ui';
 import { formatLongDate } from '@votingworks/utils';
 // eslint-disable-next-line vx/gts-no-import-export-type
@@ -50,7 +51,7 @@ export function ReplaceElectionScreen({
       <Screen>
         <Main padded centerChild>
           <Prose textCenter>
-            <p>Unconfiguring election on machine…</p>
+            <P>Unconfiguring election on machine…</P>
           </Prose>
         </Main>
       </Screen>
@@ -62,8 +63,8 @@ export function ReplaceElectionScreen({
       <Screen>
         <Main padded centerChild>
           <Prose textCenter>
-            <p>Error unconfiguring the machine.</p>
-            <p>Remove card to continue.</p>
+            <P>Error unconfiguring the machine.</P>
+            <P>Remove card to continue.</P>
           </Prose>
         </Main>
       </Screen>
@@ -111,18 +112,18 @@ export function ReplaceElectionScreen({
             </tbody>
           </Table>
           {ballotsPrintedCount === 0 ? (
-            <p>
+            <P>
               This machine has not printed any ballots for the current election.
-            </p>
+            </P>
           ) : (
-            <p>
+            <P>
               This machine has printed{' '}
               <strong>{pluralize('ballot', ballotsPrintedCount, true)}</strong>{' '}
               for the current election.
-            </p>
+            </P>
           )}
           <H2>Cancel and Go Back</H2>
-          <p>Remove the inserted card to cancel.</p>
+          <P>Remove the inserted card to cancel.</P>
         </Prose>
       </Main>
       {election && (

--- a/apps/mark/frontend/src/pages/review_page.tsx
+++ b/apps/mark/frontend/src/pages/review_page.tsx
@@ -25,6 +25,7 @@ import {
   Prose,
   Screen,
   Text,
+  P,
 } from '@votingworks/ui';
 
 import {
@@ -550,8 +551,8 @@ export function ReviewPage(): JSX.Element {
           <SidebarSpacer />
           <Prose>
             <H2 aria-hidden>Review Votes</H2>
-            <p>Confirm your votes are correct.</p>
-            <p>{printMyBallotButton}</p>
+            <P>Confirm your votes are correct.</P>
+            <P>{printMyBallotButton}</P>
           </Prose>
         </Sidebar>
       )}

--- a/apps/mark/frontend/src/pages/setup_power_page.tsx
+++ b/apps/mark/frontend/src/pages/setup_power_page.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 
-import { Main, NoWrap, Screen, Prose, H1 } from '@votingworks/ui';
+import { Main, NoWrap, Screen, Prose, H1, P } from '@votingworks/ui';
 
 interface Props {
   useEffectToggleLargeDisplay: () => void;
@@ -19,9 +19,9 @@ export function SetupPowerPage({
           <H1>
             No Power Detected <NoWrap>and Battery is Low</NoWrap>
           </H1>
-          <p>
+          <P>
             Please ask a poll worker to plug-in the power cord for this machine.
-          </p>
+          </P>
         </Prose>
       </Main>
     </Screen>

--- a/apps/mark/frontend/src/pages/setup_printer_page.tsx
+++ b/apps/mark/frontend/src/pages/setup_printer_page.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 
-import { Main, Screen, Prose, H1 } from '@votingworks/ui';
+import { Main, Screen, Prose, H1, P } from '@votingworks/ui';
 
 interface Props {
   useEffectToggleLargeDisplay: () => void;
@@ -17,7 +17,7 @@ export function SetupPrinterPage({
       <Main padded centerChild>
         <Prose textCenter>
           <H1>No Printer Detected</H1>
-          <p>Please ask a poll worker to connect printer.</p>
+          <P>Please ask a poll worker to connect printer.</P>
         </Prose>
       </Main>
     </Screen>

--- a/apps/mark/frontend/src/pages/start_page.tsx
+++ b/apps/mark/frontend/src/pages/start_page.tsx
@@ -3,7 +3,7 @@ import React, { useContext, useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import { useHistory } from 'react-router-dom';
 import { getPartyPrimaryAdjectiveFromBallotStyle } from '@votingworks/types';
-import { Main, Screen, Prose, Button, H1 } from '@votingworks/ui';
+import { Main, Screen, Prose, Button, H1, P } from '@votingworks/ui';
 
 import pluralize from 'pluralize';
 import { assert } from '@votingworks/basics';
@@ -122,22 +122,22 @@ export function StartPage(): JSX.Element {
               {partyPrimaryAdjective} {title}
             </H1>
             <hr />
-            <p>
+            <P>
               <span>
                 Your ballot has{' '}
                 <strong>{pluralize('contest', contests.length, true)}</strong>.
               </span>
-            </p>
+            </P>
             {settingsContainer}
           </Prose>
         )}
-        <p className="screen-reader-only">
+        <P className="screen-reader-only">
           When voting with the text-to-speech audio, use the accessible
           controller to navigate your ballot. To navigate through the contests,
           use the left and right buttons. To navigate through contest choices,
           use the up and down buttons. To select or unselect a contest choice as
           your vote, use the select button.
-        </p>
+        </P>
       </Main>
       {isPortrait ? (
         <Footer>

--- a/apps/mark/frontend/src/pages/unconfigured_screen.tsx
+++ b/apps/mark/frontend/src/pages/unconfigured_screen.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Main, Screen, CenteredLargeProse, H1 } from '@votingworks/ui';
+import { Main, Screen, CenteredLargeProse, H1, P } from '@votingworks/ui';
 
 interface Props {
   hasElectionDefinition: boolean;
@@ -15,9 +15,9 @@ export function UnconfiguredScreen({
         <CenteredLargeProse>
           <H1>VxMark is Not Configured</H1>
           {hasElectionDefinition ? (
-            <p>Insert Election Manager card to select a precinct.</p>
+            <P>Insert Election Manager card to select a precinct.</P>
           ) : (
-            <p>Insert Election Manager card to load an election definition.</p>
+            <P>Insert Election Manager card to load an election definition.</P>
           )}
         </CenteredLargeProse>
       </Main>

--- a/apps/mark/frontend/src/pages/wrong_election_screen.tsx
+++ b/apps/mark/frontend/src/pages/wrong_election_screen.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 
-import { Main, Screen, Prose, H1 } from '@votingworks/ui';
+import { Main, Screen, Prose, H1, P } from '@votingworks/ui';
 
 import { triggerAudioFocus } from '../utils/trigger_audio_focus';
 
@@ -20,8 +20,8 @@ export function WrongElectionScreen({
       <Main centerChild>
         <Prose textCenter id="audiofocus">
           <H1>Invalid Card Data</H1>
-          <p>Card is not configured for this election.</p>
-          <p>Please ask admin for assistance.</p>
+          <P>Card is not configured for this election.</P>
+          <P>Please ask admin for assistance.</P>
         </Prose>
       </Main>
     </Screen>

--- a/libs/ui/src/typography.tsx
+++ b/libs/ui/src/typography.tsx
@@ -13,7 +13,9 @@ type HeadingType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 export interface FontProps {
   align?: Align;
   children?: React.ReactNode;
+  className?: string;
   color?: AccentColor;
+  id?: string;
   italic?: boolean;
   noWrap?: boolean;
   weight?: keyof SizeTheme['fontWeight'];


### PR DESCRIPTION
## Overview

_Relevant changes in 1st commit, snapshot updates in 2nd_

Replacing typography elements in VxMark in chunks to make it easier to parse the changes.
This PR replaces native `<p>` elements with their `<P>` theme-aware equivalents from libs/ui.

Did a search-and-replace `<p>` -> `<P>` and used eslint autofix to add missing imports.

Also added support for the `id` and `className` props to components in `libs/ui/typography.tsx`, since they're used for to support some custom screenreader functionality in VxMark.

This is currently a no-op and will only affect the UI when we enable the new VVSG themes.

## Testing Plan
- Visual spot checks

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
