### PR TITLE
Turn off gts-no-import-export-type lint rule

### DIFF
--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { Api } from '@votingworks/admin-backend'; // eslint-disable-line vx/gts-no-import-export-type
+import type { Api } from '@votingworks/admin-backend';
 import {
   AUTH_STATUS_POLLING_INTERVAL_MS,
   QUERY_CLIENT_DEFAULT_OPTIONS,

--- a/apps/admin/frontend/src/components/import_cvrfiles_modal.test.tsx
+++ b/apps/admin/frontend/src/components/import_cvrfiles_modal.test.tsx
@@ -5,7 +5,6 @@ import { Admin } from '@votingworks/api';
 import { ElectronFile, UsbDriveStatus, mockUsbDrive } from '@votingworks/ui';
 import userEvent from '@testing-library/user-event';
 import { ok } from '@votingworks/basics';
-// eslint-disable-next-line vx/gts-no-import-export-type
 import type { CastVoteRecordFileMetadata } from '@votingworks/admin-backend';
 import {
   waitFor,

--- a/apps/admin/frontend/src/contexts/app_context.ts
+++ b/apps/admin/frontend/src/contexts/app_context.ts
@@ -11,7 +11,6 @@ import {
 import { NullPrinter, getEmptyFullElectionTally } from '@votingworks/utils';
 import { Logger, LogSource } from '@votingworks/logging';
 import { UsbDrive } from '@votingworks/ui';
-// eslint-disable-next-line vx/gts-no-import-export-type
 import type { MachineConfig } from '@votingworks/admin-backend';
 import {
   Iso8601Timestamp,

--- a/apps/admin/frontend/src/screens/unconfigured_screen.tsx
+++ b/apps/admin/frontend/src/screens/unconfigured_screen.tsx
@@ -12,7 +12,6 @@ import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 import { Button, Prose, useMountedState } from '@votingworks/ui';
 import { assert } from '@votingworks/basics';
 
-// eslint-disable-next-line vx/gts-no-import-export-type
 import type { ConfigureResult } from '@votingworks/admin-backend';
 import { readFileAsyncAsString } from '@votingworks/utils';
 import { DEFAULT_SYSTEM_SETTINGS } from '@votingworks/types';

--- a/apps/admin/frontend/test/render_in_app_context.tsx
+++ b/apps/admin/frontend/test/render_in_app_context.tsx
@@ -26,7 +26,6 @@ import {
   fakeSessionExpiresAt,
   fakeSystemAdministratorUser,
 } from '@votingworks/test-utils';
-// eslint-disable-next-line vx/gts-no-import-export-type
 import type { MachineConfig } from '@votingworks/admin-backend';
 import { UsbDrive, mockUsbDrive } from '@votingworks/ui';
 import { render as testRender, RenderResult } from './react_testing_library';

--- a/apps/central-scan/frontend/src/api.ts
+++ b/apps/central-scan/frontend/src/api.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { Api } from '@votingworks/central-scan-backend'; // eslint-disable-line vx/gts-no-import-export-type
+import type { Api } from '@votingworks/central-scan-backend';
 import {
   AUTH_STATUS_POLLING_INTERVAL_MS,
   QUERY_CLIENT_DEFAULT_OPTIONS,

--- a/apps/central-scan/frontend/test/api.tsx
+++ b/apps/central-scan/frontend/test/api.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { Api } from '@votingworks/central-scan-backend'; // eslint-disable-line vx/gts-no-import-export-type
+import type { Api } from '@votingworks/central-scan-backend';
 import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
 import { DippedSmartCardAuth } from '@votingworks/types';
 import { QueryClientProvider } from '@tanstack/react-query';

--- a/apps/mark/frontend/src/api.ts
+++ b/apps/mark/frontend/src/api.ts
@@ -1,4 +1,3 @@
-/* eslint-disable vx/gts-no-import-export-type */
 import type { Api } from '@votingworks/mark-backend';
 import React from 'react';
 import * as grout from '@votingworks/grout';

--- a/apps/mark/frontend/src/config/types.ts
+++ b/apps/mark/frontend/src/config/types.ts
@@ -10,7 +10,6 @@ import {
   PrecinctId,
   VotesDict,
 } from '@votingworks/types';
-// eslint-disable-next-line vx/gts-no-import-export-type
 import type { MachineConfig } from '@votingworks/mark-backend';
 import {
   ContestsWithMsEitherNeither,

--- a/apps/mark/frontend/src/lib/screen_orientation.test.tsx
+++ b/apps/mark/frontend/src/lib/screen_orientation.test.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line vx/gts-no-import-export-type
 import type { MachineConfig } from '@votingworks/mark-backend';
 import { screenOrientation } from './screen_orientation';
 

--- a/apps/mark/frontend/src/lib/screen_orientation.ts
+++ b/apps/mark/frontend/src/lib/screen_orientation.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line vx/gts-no-import-export-type
 import type { MachineConfig } from '@votingworks/mark-backend';
 
 interface ScreenOrientationReturnType {

--- a/apps/mark/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.tsx
@@ -25,7 +25,6 @@ import {
 } from '@votingworks/types';
 import { makeAsync } from '@votingworks/utils';
 import { Logger } from '@votingworks/logging';
-// eslint-disable-next-line vx/gts-no-import-export-type
 import type { MachineConfig } from '@votingworks/mark-backend';
 import { ScreenReader } from '../config/types';
 

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -57,7 +57,6 @@ import {
 } from '@votingworks/utils';
 
 import { LogEventId, Logger } from '@votingworks/logging';
-// eslint-disable-next-line vx/gts-no-import-export-type
 import type { MachineConfig } from '@votingworks/mark-backend';
 import styled from 'styled-components';
 import { assert, find, sleep, throwIllegalValue } from '@votingworks/basics';

--- a/apps/mark/frontend/src/pages/replace_election_screen.tsx
+++ b/apps/mark/frontend/src/pages/replace_election_screen.tsx
@@ -10,7 +10,6 @@ import {
   P,
 } from '@votingworks/ui';
 import { formatLongDate } from '@votingworks/utils';
-// eslint-disable-next-line vx/gts-no-import-export-type
 import type { MachineConfig } from '@votingworks/mark-backend';
 import { DateTime } from 'luxon';
 import pluralize from 'pluralize';

--- a/apps/mark/frontend/test/helpers/fake_machine_config.ts
+++ b/apps/mark/frontend/test/helpers/fake_machine_config.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line vx/gts-no-import-export-type
 import type { MachineConfig } from '@votingworks/mark-backend';
 
 export function fakeMachineConfig({

--- a/apps/mark/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/mark/frontend/test/helpers/mock_api_client.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
-// eslint-disable-next-line vx/gts-no-import-export-type
 import type { Api, MachineConfig } from '@votingworks/mark-backend';
 import { QueryClientProvider } from '@tanstack/react-query';
 import {

--- a/apps/scan/frontend/src/api.ts
+++ b/apps/scan/frontend/src/api.ts
@@ -1,4 +1,3 @@
-/* eslint-disable-next-line vx/gts-no-import-export-type */
 import type { Api, PrecinctScannerStatus } from '@votingworks/scan-backend';
 import React from 'react';
 import * as grout from '@votingworks/grout';

--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -22,7 +22,6 @@ import {
 import { AdjudicationReason, getDisplayElectionHash } from '@votingworks/types';
 import { err, ok } from '@votingworks/basics';
 
-// eslint-disable-next-line vx/gts-no-import-export-type
 import type {
   PrecinctScannerConfig,
   SheetInterpretation,

--- a/apps/scan/frontend/src/app_unhappy_paths.test.tsx
+++ b/apps/scan/frontend/src/app_unhappy_paths.test.tsx
@@ -14,7 +14,6 @@ import userEvent from '@testing-library/user-event';
 import { ServerError } from '@votingworks/grout';
 import { fakeLogger } from '@votingworks/logging';
 import { deferred } from '@votingworks/basics';
-// eslint-disable-next-line vx/gts-no-import-export-type
 import type { PrecinctScannerConfig } from '@votingworks/scan-backend';
 import { act, render, screen, waitFor } from '../test/react_testing_library';
 import { scannerStatus } from '../test/helpers/helpers';

--- a/apps/scan/frontend/src/components/calibrate_scanner_modal.test.tsx
+++ b/apps/scan/frontend/src/components/calibrate_scanner_modal.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { deferred } from '@votingworks/basics';
 import userEvent from '@testing-library/user-event';
-// eslint-disable-next-line vx/gts-no-import-export-type
 import type { PrecinctScannerStatus } from '@votingworks/scan-backend';
 import { render, screen, waitFor } from '../../test/react_testing_library';
 import {

--- a/apps/scan/frontend/src/components/calibrate_scanner_modal.tsx
+++ b/apps/scan/frontend/src/components/calibrate_scanner_modal.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { Button, Modal, P, Prose } from '@votingworks/ui';
 import { assert } from '@votingworks/basics';
-// eslint-disable-next-line vx/gts-no-import-export-type
 import type { PrecinctScannerStatus } from '@votingworks/scan-backend';
 import { calibrate, supportsCalibration } from '../api';
 

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -14,7 +14,6 @@ import {
   Caption,
 } from '@votingworks/ui';
 import React, { useState } from 'react';
-// eslint-disable-next-line vx/gts-no-import-export-type
 import type { PrecinctScannerStatus } from '@votingworks/scan-backend';
 import { Logger, LogSource } from '@votingworks/logging';
 import { CalibrateScannerModal } from '../components/calibrate_scanner_modal';

--- a/apps/scan/frontend/src/screens/scan_error_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_error_screen.tsx
@@ -8,7 +8,6 @@ import {
   P,
 } from '@votingworks/ui';
 import { throwIllegalValue } from '@votingworks/basics';
-// eslint-disable-next-line vx/gts-no-import-export-type
 import type {
   InvalidInterpretationReason,
   PrecinctScannerErrorType,

--- a/apps/scan/frontend/test/helpers/helpers.ts
+++ b/apps/scan/frontend/test/helpers/helpers.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line vx/gts-no-import-export-type
 import type { PrecinctScannerStatus } from '@votingworks/scan-backend';
 
 export function scannerStatus(

--- a/apps/scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/scan/frontend/test/helpers/mock_api_client.tsx
@@ -10,7 +10,6 @@ import {
   PrecinctSelection,
 } from '@votingworks/types';
 import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
-// eslint-disable-next-line vx/gts-no-import-export-type
 import type {
   Api,
   MachineConfig,

--- a/libs/basics/src/result.ts
+++ b/libs/basics/src/result.ts
@@ -218,7 +218,6 @@ type OkInterface<T> = Ok<T>;
 // eslint-disable-next-line vx/gts-jsdoc
 type ErrInterface<T> = Err<T>;
 // Allow `export type` here so we can use `isolatedModules`.
-// eslint-disable-next-line vx/gts-no-import-export-type
 export type { OkInterface as Ok, ErrInterface as Err };
 
 /**

--- a/libs/dev-dock/backend/src/dev_dock_api.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line vx/gts-no-import-export-type
 import type Express from 'express';
 import * as grout from '@votingworks/grout';
 import * as fs from 'fs';

--- a/libs/dev-dock/frontend/src/dev_dock.test.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.test.tsx
@@ -2,7 +2,6 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { Buffer } from 'buffer';
 import userEvent from '@testing-library/user-event';
 import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
-// eslint-disable-next-line vx/gts-no-import-export-type
 import type { Api } from '@votingworks/dev-dock-backend';
 import {
   BooleanEnvironmentVariableName,

--- a/libs/dev-dock/frontend/src/dev_dock.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.tsx
@@ -10,7 +10,6 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import styled from 'styled-components';
 import * as grout from '@votingworks/grout';
 import { assert, assertDefined, uniqueBy } from '@votingworks/basics';
-// eslint-disable-next-line vx/gts-no-import-export-type
 import type { Api, DevDockUserRole } from '@votingworks/dev-dock-backend';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {

--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -49,7 +49,10 @@ export = {
     'vx/gts-no-default-exports': 'error',
     'vx/gts-no-foreach': 'error',
     'vx/gts-no-for-in-loop': 'error',
-    'vx/gts-no-import-export-type': ['error', { allowReexport: true }],
+    // Importing types allows a package to list another package as a dev
+    // dependencies if only using the package's types. This makes it possible
+    // for browser-based packages to import types from Node-based packages.
+    'vx/gts-no-import-export-type': 'off',
     'vx/gts-no-private-fields': 'error',
     'vx/gts-no-public-class-fields': 'error',
     'vx/gts-no-public-modifier': 'error',
@@ -92,7 +95,7 @@ export = {
     // Disallows async functions with no await to prevent bugs and confusion
     '@typescript-eslint/require-await': 'error',
 
-    // Configure default rules as recommened by Google TypeScript Style Guide.
+    // Configure default rules as recommended by Google TypeScript Style Guide.
     'class-methods-use-this': 'off',
     'consistent-return': 'off',
     'dot-notation': 'off',

--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -50,8 +50,8 @@ export = {
     'vx/gts-no-foreach': 'error',
     'vx/gts-no-for-in-loop': 'error',
     // Importing types allows a package to list another package as a dev
-    // dependencies if only using the package's types. This makes it possible
-    // for browser-based packages to import types from Node-based packages.
+    // dependency if only using the package's types. This makes it possible for
+    // browser-based packages to import types from Node-based packages.
     'vx/gts-no-import-export-type': 'off',
     'vx/gts-no-private-fields': 'error',
     'vx/gts-no-public-class-fields': 'error',

--- a/libs/grout/src/server.ts
+++ b/libs/grout/src/server.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line vx/gts-no-import-export-type
 import type Express from 'express';
 import { rootDebug } from './debug';
 import { serialize, deserialize } from './serialization';

--- a/libs/ui/src/hooks/use_change_listener.ts
+++ b/libs/ui/src/hooks/use_change_listener.ts
@@ -1,6 +1,5 @@
 import { useEffect, useRef } from 'react';
 import deepEqual from 'deep-eql';
-// eslint-disable-next-line vx/gts-no-import-export-type
 import type { UseQueryResult } from '@tanstack/react-query';
 
 /**

--- a/libs/ui/src/radio_group/index.tsx
+++ b/libs/ui/src/radio_group/index.tsx
@@ -6,7 +6,6 @@ import { Caption } from '../typography';
 import { RadioButton } from './radio_button';
 import { RadioGroupOption, RadioGroupOptionId } from './types';
 
-// eslint-disable-next-line vx/gts-no-import-export-type
 export type { RadioGroupOption, RadioGroupOptionId };
 
 /** Props for {@link RadioGroup}. */

--- a/libs/ui/src/react_query.ts
+++ b/libs/ui/src/react_query.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line vx/gts-no-import-export-type
 import type { DefaultOptions } from '@tanstack/react-query';
 
 /**


### PR DESCRIPTION
## Overview

We often disable this rule to allow importing types from backend packages into frontend packages. Here, we change the recommended setting to disable this rule by default.

_Review by commits_

## Demo Video or Screenshot
N/A

## Testing Plan
CI should cover it

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
