### PR TITLE
[VxAdmin] Use new theme-aware VoterContestSummary cards on ReviewPage

### DIFF
--- a/apps/mark/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
@@ -228,7 +228,7 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -274,7 +274,7 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -320,7 +320,7 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -366,7 +366,7 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -412,7 +412,7 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -458,7 +458,7 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -511,7 +511,7 @@ exports[`Single Seat Contest 1`] = `
         type="button"
       >
         <span
-          class="sc-ezbkgU gcJsOl"
+          class="sc-ezbkgU bmeHoE"
         >
           <span
             class="c9"
@@ -527,7 +527,7 @@ exports[`Single Seat Contest 1`] = `
         type="button"
       >
         <span
-          class="sc-ezbkgU gcJsOl"
+          class="sc-ezbkgU bmeHoE"
         >
           <span
             class="c10"
@@ -542,7 +542,7 @@ exports[`Single Seat Contest 1`] = `
         type="button"
       >
         <span
-          class="sc-ezbkgU gcJsOl"
+          class="sc-ezbkgU bmeHoE"
         >
           Settings
         </span>

--- a/apps/mark/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
@@ -235,7 +235,7 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -285,7 +285,7 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -335,7 +335,7 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -385,7 +385,7 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -435,7 +435,7 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -485,7 +485,7 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -535,7 +535,7 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -585,7 +585,7 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -635,7 +635,7 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -685,7 +685,7 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -735,7 +735,7 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -784,7 +784,7 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -853,7 +853,7 @@ exports[`Single Seat Contest 1`] = `
         type="button"
       >
         <span
-          class="sc-ezbkgU gcJsOl"
+          class="sc-ezbkgU bmeHoE"
         >
           <span
             class="c9"
@@ -869,7 +869,7 @@ exports[`Single Seat Contest 1`] = `
         type="button"
       >
         <span
-          class="sc-ezbkgU gcJsOl"
+          class="sc-ezbkgU bmeHoE"
         >
           <span
             class="c10"
@@ -884,7 +884,7 @@ exports[`Single Seat Contest 1`] = `
         type="button"
       >
         <span
-          class="sc-ezbkgU gcJsOl"
+          class="sc-ezbkgU bmeHoE"
         >
           Settings
         </span>

--- a/apps/mark/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
@@ -235,7 +235,7 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -285,7 +285,7 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -335,7 +335,7 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -385,7 +385,7 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -435,7 +435,7 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -485,7 +485,7 @@ exports[`Single Seat Contest 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -542,7 +542,7 @@ exports[`Single Seat Contest 1`] = `
         type="button"
       >
         <span
-          class="sc-ezbkgU gcJsOl"
+          class="sc-ezbkgU bmeHoE"
         >
           <span
             class="c9"
@@ -558,7 +558,7 @@ exports[`Single Seat Contest 1`] = `
         type="button"
       >
         <span
-          class="sc-ezbkgU gcJsOl"
+          class="sc-ezbkgU bmeHoE"
         >
           <span
             class="c10"
@@ -573,7 +573,7 @@ exports[`Single Seat Contest 1`] = `
         type="button"
       >
         <span
-          class="sc-ezbkgU gcJsOl"
+          class="sc-ezbkgU bmeHoE"
         >
           Settings
         </span>

--- a/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
@@ -228,7 +228,7 @@ exports[`Single Seat Contest with Write In 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -277,7 +277,7 @@ exports[`Single Seat Contest with Write In 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -346,7 +346,7 @@ exports[`Single Seat Contest with Write In 1`] = `
         type="button"
       >
         <span
-          class="sc-ezbkgU gcJsOl"
+          class="sc-ezbkgU bmeHoE"
         >
           <span
             class="c9"
@@ -362,7 +362,7 @@ exports[`Single Seat Contest with Write In 1`] = `
         type="button"
       >
         <span
-          class="sc-ezbkgU gcJsOl"
+          class="sc-ezbkgU bmeHoE"
         >
           <span
             class="c10"
@@ -377,7 +377,7 @@ exports[`Single Seat Contest with Write In 1`] = `
         type="button"
       >
         <span
-          class="sc-ezbkgU gcJsOl"
+          class="sc-ezbkgU bmeHoE"
         >
           Settings
         </span>

--- a/apps/mark/frontend/src/app_contest_ms_either_neither.test.tsx
+++ b/apps/mark/frontend/src/app_contest_ms_either_neither.test.tsx
@@ -16,7 +16,12 @@ import { expectPrint, PrintRenderResult } from '@votingworks/test-utils';
 import { electionWithMsEitherNeitherDefinition } from '@votingworks/fixtures';
 import { assert, assertDefined, find } from '@votingworks/basics';
 import userEvent from '@testing-library/user-event';
-import { fireEvent, render, screen } from '../test/react_testing_library';
+import {
+  fireEvent,
+  render,
+  screen,
+  within,
+} from '../test/react_testing_library';
 import { App } from './app';
 import { PrintPage } from './pages/print_page';
 
@@ -312,13 +317,14 @@ test('Can vote on a Mississippi Either Neither Contest', async () => {
   contestReviewTitle = getByTextWithMarkup(
     `${districtName}${eitherNeitherContest.title}`
   );
-  const eitherAndFirst = getByTextWithMarkup(
-    `${districtName}${eitherNeitherContest.title}`
-  ).nextSibling;
-  expect(eitherAndFirst?.textContent?.trim()).toEqual(
+  assert(contestReviewTitle.parentElement);
+  const eitherAndFirstVotes = within(
+    contestReviewTitle.parentElement
+  ).getAllByRole('listitem');
+  expect(eitherAndFirstVotes[0]).toHaveTextContent(
     'FOR APPROVAL OF EITHER Initiative No. 65 OR Alternative Measure No. 65 A'
   );
-  expect(eitherAndFirst?.nextSibling?.textContent?.trim()).toEqual(
+  expect(eitherAndFirstVotes[1]).toHaveTextContent(
     'FOR Initiative Measure No. 65'
   );
 
@@ -340,13 +346,14 @@ test('Can vote on a Mississippi Either Neither Contest', async () => {
   contestReviewTitle = getByTextWithMarkup(
     `${districtName}${eitherNeitherContest.title}`
   );
-  const neitherAndSecond = getByTextWithMarkup(
-    `${districtName}${eitherNeitherContest.title}`
-  ).nextSibling;
-  expect(neitherAndSecond?.textContent?.trim()).toEqual(
+  assert(contestReviewTitle.parentElement);
+  const neitherAndSecondVotes = within(
+    contestReviewTitle.parentElement
+  ).getAllByRole('listitem');
+  expect(neitherAndSecondVotes[0]).toHaveTextContent(
     'AGAINST BOTH Initiative Measure No. 65 AND Alternative Measure No. 65 A'
   );
-  expect(neitherAndSecond?.nextSibling?.textContent?.trim()).toEqual(
+  expect(neitherAndSecondVotes[1]).toHaveTextContent(
     'FOR Alternative Measure 65 A'
   );
 
@@ -365,15 +372,14 @@ test('Can vote on a Mississippi Either Neither Contest', async () => {
   contestReviewTitle = getByTextWithMarkup(
     `${districtName}${eitherNeitherContest.title}`
   );
-  const noneAndSecond = getByTextWithMarkup(
-    `${districtName}${eitherNeitherContest.title}`
-  ).nextSibling;
-  expect(noneAndSecond?.textContent?.trim()).toEqual(
+  assert(contestReviewTitle.parentElement);
+  within(contestReviewTitle.parentElement).getByText(
     'You may still vote in this contest.'
   );
-  expect(noneAndSecond?.nextSibling?.textContent?.trim()).toEqual(
-    'FOR Alternative Measure 65 A'
+  const noneAndSecondVote = within(contestReviewTitle.parentElement).getByRole(
+    'listitem'
   );
+  expect(noneAndSecondVote).toHaveTextContent('FOR Alternative Measure 65 A');
 
   // Go to Contest Screen
   fireEvent.click(contestReviewTitle);
@@ -393,13 +399,14 @@ test('Can vote on a Mississippi Either Neither Contest', async () => {
   contestReviewTitle = getByTextWithMarkup(
     `${districtName}${eitherNeitherContest.title}`
   );
-  const eitherAndNone = getByTextWithMarkup(
-    `${districtName}${eitherNeitherContest.title}`
-  ).nextSibling;
-  expect(eitherAndNone?.textContent?.trim()).toEqual(
+  assert(contestReviewTitle.parentElement);
+  const eitherAndNoneVote = within(contestReviewTitle.parentElement).getByRole(
+    'listitem'
+  );
+  expect(eitherAndNoneVote).toHaveTextContent(
     'FOR APPROVAL OF EITHER Initiative No. 65 OR Alternative Measure No. 65 A'
   );
-  expect(eitherAndNone?.nextSibling?.textContent?.trim()).toEqual(
+  within(contestReviewTitle.parentElement).getByText(
     'You may still vote in this contest.'
   );
 });

--- a/apps/mark/frontend/src/app_contest_write_in.test.tsx
+++ b/apps/mark/frontend/src/app_contest_write_in.test.tsx
@@ -168,7 +168,7 @@ it('Single Seat Contest with Write In', async () => {
   // Review Screen
   await screen.findByText('Review Your Votes');
   expect(screen.getByText('SAL')).toBeTruthy();
-  expect(screen.getByText('(write-in)')).toBeTruthy();
+  expect(screen.getByText(/\(write-in\)/)).toBeTruthy();
 
   // Print Screen
   fireEvent.click(getByTextWithMarkup('I’m Ready to Print My Ballot'));

--- a/apps/mark/frontend/src/components/__snapshots__/settings_text_size.test.tsx.snap
+++ b/apps/mark/frontend/src/components/__snapshots__/settings_text_size.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`renders SettingsTextSize 1`] = `
       type="button"
     >
       <span
-        class="sc-ezbkgU gcJsOl"
+        class="sc-ezbkgU bmeHoE"
       >
         A
       </span>
@@ -86,7 +86,7 @@ exports[`renders SettingsTextSize 1`] = `
       type="button"
     >
       <span
-        class="sc-ezbkgU gcJsOl"
+        class="sc-ezbkgU bmeHoE"
       >
         A
       </span>
@@ -97,7 +97,7 @@ exports[`renders SettingsTextSize 1`] = `
       type="button"
     >
       <span
-        class="sc-ezbkgU gcJsOl"
+        class="sc-ezbkgU bmeHoE"
       >
         A
       </span>

--- a/apps/mark/frontend/src/components/__snapshots__/yes_no_contest.test.tsx.snap
+++ b/apps/mark/frontend/src/components/__snapshots__/yes_no_contest.test.tsx.snap
@@ -163,7 +163,7 @@ exports[`supports yes/no contest allows voting for both yes and no 1`] = `
           type="button"
         >
           <span
-            class="sc-ezbkgU gcJsOl"
+            class="sc-ezbkgU bmeHoE"
           >
             <span
               class="sc-caiKgP SOLan"
@@ -208,7 +208,7 @@ exports[`supports yes/no contest allows voting for both yes and no 1`] = `
           type="button"
         >
           <span
-            class="sc-ezbkgU gcJsOl"
+            class="sc-ezbkgU bmeHoE"
           >
             <span
               class="sc-caiKgP SOLan"
@@ -414,7 +414,7 @@ exports[`supports yes/no contest displays warning when attempting to change vote
           type="button"
         >
           <span
-            class="sc-ezbkgU gcJsOl"
+            class="sc-ezbkgU bmeHoE"
           >
             <span
               class="sc-caiKgP SOLan"
@@ -459,7 +459,7 @@ exports[`supports yes/no contest displays warning when attempting to change vote
           type="button"
         >
           <span
-            class="sc-ezbkgU gcJsOl"
+            class="sc-ezbkgU bmeHoE"
           >
             <span
               class="sc-caiKgP SOLan"

--- a/apps/mark/frontend/src/config/types.ts
+++ b/apps/mark/frontend/src/config/types.ts
@@ -9,6 +9,7 @@ import {
   OptionalYesNoVote,
   PrecinctId,
   VotesDict,
+  YesNoContest,
 } from '@votingworks/types';
 // eslint-disable-next-line vx/gts-no-import-export-type
 import type { MachineConfig } from '@votingworks/mark-backend';
@@ -49,10 +50,13 @@ export interface CandidateContestResultInterface {
   vote: CandidateVote;
 }
 export interface YesNoContestResultInterface {
+  contest: YesNoContest;
+  election: Election;
   vote: OptionalYesNoVote;
 }
 export interface MsEitherNeitherContestResultInterface {
   contest: MsEitherNeitherContest;
+  election: Election;
   eitherNeitherContestVote: OptionalYesNoVote;
   pickOneContestVote: OptionalYesNoVote;
 }

--- a/apps/mark/frontend/src/pages/__snapshots__/cast_ballot_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/cast_ballot_page.test.tsx.snap
@@ -106,7 +106,7 @@ exports[`renders CastBallotPage 1`] = `
         type="button"
       >
         <span
-          class="sc-ezbkgU gcJsOl"
+          class="sc-ezbkgU bmeHoE"
         >
           Done
         </span>

--- a/apps/mark/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
@@ -217,7 +217,7 @@ exports[`Renders ContestPage 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -267,7 +267,7 @@ exports[`Renders ContestPage 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -317,7 +317,7 @@ exports[`Renders ContestPage 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -367,7 +367,7 @@ exports[`Renders ContestPage 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -417,7 +417,7 @@ exports[`Renders ContestPage 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -467,7 +467,7 @@ exports[`Renders ContestPage 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -524,7 +524,7 @@ exports[`Renders ContestPage 1`] = `
         type="button"
       >
         <span
-          class="sc-ezbkgU gcJsOl"
+          class="sc-ezbkgU bmeHoE"
         >
           <span
             class="c8"
@@ -540,7 +540,7 @@ exports[`Renders ContestPage 1`] = `
         type="button"
       >
         <span
-          class="sc-ezbkgU gcJsOl"
+          class="sc-ezbkgU bmeHoE"
         >
           <span
             class="c9"
@@ -555,7 +555,7 @@ exports[`Renders ContestPage 1`] = `
         type="button"
       >
         <span
-          class="sc-ezbkgU gcJsOl"
+          class="sc-ezbkgU bmeHoE"
         >
           Settings
         </span>
@@ -813,7 +813,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -863,7 +863,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -913,7 +913,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -963,7 +963,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -1013,7 +1013,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -1063,7 +1063,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                 type="button"
               >
                 <span
-                  class="sc-ezbkgU gcJsOl"
+                  class="sc-ezbkgU bmeHoE"
                 >
                   <span
                     class="sc-caiKgP SOLan"
@@ -1141,7 +1141,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
               type="button"
             >
               <span
-                class="sc-ezbkgU gcJsOl"
+                class="sc-ezbkgU bmeHoE"
               >
                 <span
                   class="c8"
@@ -1161,7 +1161,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
               type="button"
             >
               <span
-                class="sc-ezbkgU gcJsOl"
+                class="sc-ezbkgU bmeHoE"
               >
                 <span
                   class="c9"
@@ -1185,7 +1185,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
             type="button"
           >
             <span
-              class="sc-ezbkgU gcJsOl"
+              class="sc-ezbkgU bmeHoE"
             >
               Settings
             </span>

--- a/apps/mark/frontend/src/pages/__snapshots__/not_found_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/not_found_page.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`renders NotFoundPage 1`] = `
           type="button"
         >
           <span
-            class="sc-ezbkgU gcJsOl"
+            class="sc-ezbkgU bmeHoE"
           >
             Start Over
           </span>

--- a/apps/mark/frontend/src/pages/__snapshots__/start_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/start_page.test.tsx.snap
@@ -192,7 +192,7 @@ exports[`renders StartPage 1`] = `
           type="button"
         >
           <span
-            class="sc-ezbkgU gcJsOl"
+            class="sc-ezbkgU bmeHoE"
           >
             Start Voting
           </span>
@@ -225,7 +225,7 @@ exports[`renders StartPage 1`] = `
               type="button"
             >
               <span
-                class="sc-ezbkgU gcJsOl"
+                class="sc-ezbkgU bmeHoE"
               >
                 A
               </span>
@@ -236,7 +236,7 @@ exports[`renders StartPage 1`] = `
               type="button"
             >
               <span
-                class="sc-ezbkgU gcJsOl"
+                class="sc-ezbkgU bmeHoE"
               >
                 A
               </span>
@@ -247,7 +247,7 @@ exports[`renders StartPage 1`] = `
               type="button"
             >
               <span
-                class="sc-ezbkgU gcJsOl"
+                class="sc-ezbkgU bmeHoE"
               >
                 A
               </span>
@@ -606,7 +606,7 @@ exports[`renders StartPage with inline SVG 1`] = `
           type="button"
         >
           <span
-            class="sc-ezbkgU gcJsOl"
+            class="sc-ezbkgU bmeHoE"
           >
             Start Voting
           </span>
@@ -639,7 +639,7 @@ exports[`renders StartPage with inline SVG 1`] = `
               type="button"
             >
               <span
-                class="sc-ezbkgU gcJsOl"
+                class="sc-ezbkgU bmeHoE"
               >
                 A
               </span>
@@ -650,7 +650,7 @@ exports[`renders StartPage with inline SVG 1`] = `
               type="button"
             >
               <span
-                class="sc-ezbkgU gcJsOl"
+                class="sc-ezbkgU bmeHoE"
               >
                 A
               </span>
@@ -661,7 +661,7 @@ exports[`renders StartPage with inline SVG 1`] = `
               type="button"
             >
               <span
-                class="sc-ezbkgU gcJsOl"
+                class="sc-ezbkgU bmeHoE"
               >
                 A
               </span>
@@ -856,7 +856,7 @@ exports[`renders StartPage with no seal 1`] = `
           type="button"
         >
           <span
-            class="sc-ezbkgU gcJsOl"
+            class="sc-ezbkgU bmeHoE"
           >
             Start Voting
           </span>
@@ -889,7 +889,7 @@ exports[`renders StartPage with no seal 1`] = `
               type="button"
             >
               <span
-                class="sc-ezbkgU gcJsOl"
+                class="sc-ezbkgU bmeHoE"
               >
                 A
               </span>
@@ -900,7 +900,7 @@ exports[`renders StartPage with no seal 1`] = `
               type="button"
             >
               <span
-                class="sc-ezbkgU gcJsOl"
+                class="sc-ezbkgU bmeHoE"
               >
                 A
               </span>
@@ -911,7 +911,7 @@ exports[`renders StartPage with no seal 1`] = `
               type="button"
             >
               <span
-                class="sc-ezbkgU gcJsOl"
+                class="sc-ezbkgU bmeHoE"
               >
                 A
               </span>

--- a/libs/ui/src/button.tsx
+++ b/libs/ui/src/button.tsx
@@ -262,6 +262,7 @@ const IconContainer = styled.span`
 
 const TextContainer = styled.span`
   display: inline-block;
+  flex-grow: 1;
   flex-shrink: 1;
 `;
 

--- a/libs/ui/src/card.tsx
+++ b/libs/ui/src/card.tsx
@@ -28,7 +28,7 @@ const StyledContent = styled.div`
   padding: 0.6rem;
 
   /* Shrink padding if there's a footer: */
-  &:last-child {
+  &:not(:last-child) {
     padding-bottom: 0.25rem;
   }
 `;


### PR DESCRIPTION
## Overview

Using the theme-aware `VoterContestSummary` component from libs/ui on the VxMark review page

- Needed to update the `Button` component to allow its content to grow to fit its container to make sure the summary cards are rendered to fill the available horizontal space.
- Also fixed a small bug in the `Card` components content padding.

## Demo Video or Screenshot
### Before/After (Legacy Theme):
<img width="300" src="https://user-images.githubusercontent.com/264902/235783185-849a6bcc-3d07-4467-84a0-768781bdcbb6.png" /> <img width="300" src="https://user-images.githubusercontent.com/264902/235783325-e7179976-a8a7-4e39-831b-075516feae2c.png" />

### With VVSG Themes:
<img width="300" src="https://user-images.githubusercontent.com/264902/235783528-c6b1fa0c-b1fc-44fe-9745-dd0750841bca.png" /> <img width="300" src="https://user-images.githubusercontent.com/264902/235783545-0db25e0f-8379-4010-89be-7175f8e4e253.png" />

## Testing Plan
- Mostly a refactor - updated some element queries in affected tests
- Visual verification

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
