### PR TITLE
Vxmark replace text components

### DIFF
--- a/apps/mark/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
@@ -149,8 +149,8 @@ exports[`Single Seat Contest 1`] = `
       <div
         class="sc-fotPbf iwtRsQ"
       >
-        <p
-          class="sc-bqiQRQ jKCqve"
+        <span
+          class="sc-gsDJrp cXSIgy"
         >
           This is the
            
@@ -162,7 +162,7 @@ exports[`Single Seat Contest 1`] = `
            
           20 contests
            on your ballot.
-        </p>
+        </span>
       </div>
     </div>
     <main
@@ -190,13 +190,9 @@ exports[`Single Seat Contest 1`] = `
           <p
             class="sc-dkPtyc XGKAk"
           >
-            <span
-              class="sc-bqiQRQ bIFmdQ"
-            >
-              Vote for 
-              1
-              .
-            </span>
+            Vote for 
+            1
+            .
              
             <span
               class="screen-reader-only"

--- a/apps/mark/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
@@ -149,8 +149,8 @@ exports[`Single Seat Contest 1`] = `
       <div
         class="sc-fotPbf iwtRsQ"
       >
-        <p
-          class="sc-bqiQRQ jKCqve"
+        <span
+          class="sc-gsDJrp cXSIgy"
         >
           This is the
            
@@ -162,7 +162,7 @@ exports[`Single Seat Contest 1`] = `
            
           20 contests
            on your ballot.
-        </p>
+        </span>
       </div>
     </div>
     <main
@@ -190,16 +190,12 @@ exports[`Single Seat Contest 1`] = `
           <p
             class="sc-dkPtyc XGKAk"
           >
-            <span
-              class="sc-bqiQRQ bIFmdQ"
-            >
-              Vote for 
-              4
-              .
-            </span>
+            Vote for 
+            4
+            .
              
             <span
-              class="sc-bqiQRQ gRKWVK"
+              class="sc-bdvvaa hCYwzI"
             >
               You have selected 
               4

--- a/apps/mark/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
@@ -149,8 +149,8 @@ exports[`Single Seat Contest 1`] = `
       <div
         class="sc-fotPbf iwtRsQ"
       >
-        <p
-          class="sc-bqiQRQ jKCqve"
+        <span
+          class="sc-gsDJrp cXSIgy"
         >
           This is the
            
@@ -162,7 +162,7 @@ exports[`Single Seat Contest 1`] = `
            
           20 contests
            on your ballot.
-        </p>
+        </span>
       </div>
     </div>
     <main
@@ -190,16 +190,12 @@ exports[`Single Seat Contest 1`] = `
           <p
             class="sc-dkPtyc XGKAk"
           >
-            <span
-              class="sc-bqiQRQ bIFmdQ"
-            >
-              Vote for 
-              1
-              .
-            </span>
+            Vote for 
+            1
+            .
              
             <span
-              class="sc-bqiQRQ gRKWVK"
+              class="sc-bdvvaa hCYwzI"
             >
               You have selected 
               1

--- a/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
@@ -149,8 +149,8 @@ exports[`Single Seat Contest with Write In 1`] = `
       <div
         class="sc-fotPbf iwtRsQ"
       >
-        <p
-          class="sc-bqiQRQ jKCqve"
+        <span
+          class="sc-gsDJrp cXSIgy"
         >
           This is the
            
@@ -162,7 +162,7 @@ exports[`Single Seat Contest with Write In 1`] = `
            
           20 contests
            on your ballot.
-        </p>
+        </span>
       </div>
     </div>
     <main
@@ -190,13 +190,9 @@ exports[`Single Seat Contest with Write In 1`] = `
           <p
             class="sc-dkPtyc XGKAk"
           >
-            <span
-              class="sc-bqiQRQ bIFmdQ"
-            >
-              Vote for 
-              1
-              .
-            </span>
+            Vote for 
+            1
+            .
              
             <span
               class="screen-reader-only"

--- a/apps/mark/frontend/src/components/__snapshots__/election_info.test.tsx.snap
+++ b/apps/mark/frontend/src/components/__snapshots__/election_info.test.tsx.snap
@@ -220,32 +220,36 @@ exports[`renders horizontal ElectionInfo with hash when specified 1`] = `
            General Election
         </h5>
         <p
-          class="sc-bqiQRQ jKCqve"
+          class="sc-dkPtyc XGKAk"
         >
-          November 3, 2020
-          <br />
           <span
-            class="sc-ksdxAp gMaEyZ"
+            class="sc-gsDJrp cXSIgy"
           >
-            Franklin County
-            ,
-          </span>
-           
-          <span
-            class="sc-ksdxAp gMaEyZ"
-          >
-            State of Hamilton
+            November 3, 2020
+            <br />
+            <span
+              class="sc-ksdxAp gMaEyZ"
+            >
+              Franklin County
+              ,
+            </span>
+             
+            <span
+              class="sc-ksdxAp gMaEyZ"
+            >
+              State of Hamilton
+            </span>
           </span>
         </p>
-        <p
-          class="sc-bqiQRQ lpjhJV"
+        <span
+          class="sc-gsDJrp cXSIgy"
         >
           <span
             class="sc-ksdxAp gMaEyZ"
           >
             Center Springfield
           </span>
-        </p>
+        </span>
       </div>
     </div>
   </div>
@@ -472,32 +476,36 @@ exports[`renders horizontal ElectionInfo without hash by default 1`] = `
            General Election
         </h5>
         <p
-          class="sc-bqiQRQ jKCqve"
+          class="sc-dkPtyc XGKAk"
         >
-          November 3, 2020
-          <br />
           <span
-            class="sc-ksdxAp gMaEyZ"
+            class="sc-gsDJrp cXSIgy"
           >
-            Franklin County
-            ,
-          </span>
-           
-          <span
-            class="sc-ksdxAp gMaEyZ"
-          >
-            State of Hamilton
+            November 3, 2020
+            <br />
+            <span
+              class="sc-ksdxAp gMaEyZ"
+            >
+              Franklin County
+              ,
+            </span>
+             
+            <span
+              class="sc-ksdxAp gMaEyZ"
+            >
+              State of Hamilton
+            </span>
           </span>
         </p>
-        <p
-          class="sc-bqiQRQ lpjhJV"
+        <span
+          class="sc-gsDJrp cXSIgy"
         >
           <span
             class="sc-ksdxAp gMaEyZ"
           >
             Center Springfield
           </span>
-        </p>
+        </span>
       </div>
     </div>
   </div>

--- a/apps/mark/frontend/src/components/candidate_contest.tsx
+++ b/apps/mark/frontend/src/components/candidate_contest.tsx
@@ -24,8 +24,8 @@ import {
   Main,
   Modal,
   Prose,
-  Text,
   P,
+  Font,
 } from '@votingworks/ui';
 import { assert } from '@votingworks/basics';
 
@@ -306,16 +306,14 @@ export function CandidateContest({
               {contest.title}
             </H1>
             <P>
-              <Text as="span">Vote for {contest.seats}.</Text>{' '}
+              Vote for {contest.seats}.{' '}
               {vote.length === contest.seats && (
-                <Text as="span" bold>
-                  You have selected {contest.seats}.
-                </Text>
+                <Font weight="bold">You have selected {contest.seats}.</Font>
               )}
               {vote.length < contest.seats && vote.length !== 0 && (
-                <Text as="span" bold>
+                <Font weight="bold">
                   You may select {contest.seats - vote.length} more.
-                </Text>
+                </Font>
               )}
               <span className="screen-reader-only">
                 To navigate through the contest choices, use the down button. To
@@ -439,14 +437,14 @@ export function CandidateContest({
           centerContent
           content={
             <Prose>
-              <Text id="modalaudiofocus">
+              <P id="modalaudiofocus">
                 You may only select {contest.seats}{' '}
                 {contest.seats === 1 ? 'candidate' : 'candidates'} in this
                 contest. To vote for {attemptedOvervoteCandidate.name}, you must
                 first unselect the selected{' '}
                 {contest.seats === 1 ? 'candidate' : 'candidates'}.
                 <span aria-label="Use the select button to continue." />
-              </Text>
+              </P>
             </Prose>
           }
           actions={
@@ -466,10 +464,10 @@ export function CandidateContest({
           centerContent
           content={
             <Prose>
-              <Text id="modalaudiofocus">
+              <P id="modalaudiofocus">
                 Do you want to unselect and remove{' '}
                 {candidatePendingRemoval.name}?
-              </Text>
+              </P>
             </Prose>
           }
           actions={
@@ -492,17 +490,17 @@ export function CandidateContest({
             <WriteInModalContent>
               <Prose id="modalaudiofocus" maxWidth={false}>
                 <H1 aria-label="Write-In Candidate.">Write-In Candidate</H1>
-                <Text aria-label="Enter the name of a person who is not on the ballot. Use the up and down buttons to navigate between the letters of a standard keyboard. Use the select button to select the current letter.">
-                  Enter the name of a person who is <strong>not</strong> on the
-                  ballot.
-                </Text>
+                <P aria-label="Enter the name of a person who is not on the ballot. Use the up and down buttons to navigate between the letters of a standard keyboard. Use the select button to select the current letter.">
+                  Enter the name of a person who is{' '}
+                  <Font weight="bold">not</Font> on the ballot.
+                </P>
                 {writeInCandidateName.length >
                   WRITE_IN_CANDIDATE_MAX_LENGTH - 5 && (
-                  <Text error>
-                    <strong>Note:</strong> You have entered{' '}
+                  <P color="danger">
+                    <Icons.Danger /> <Font>Note:</Font> You have entered{' '}
                     {writeInCandidateName.length} of maximum{' '}
                     {WRITE_IN_CANDIDATE_MAX_LENGTH} characters.
-                  </Text>
+                  </P>
                 )}
               </Prose>
               <WriteInCandidateForm>

--- a/apps/mark/frontend/src/components/election_info.tsx
+++ b/apps/mark/frontend/src/components/election_info.tsx
@@ -9,7 +9,7 @@ import {
 } from '@votingworks/types';
 import { getPrecinctSelectionName, format } from '@votingworks/utils';
 
-import { Prose, Text, NoWrap, H1, H5, P } from '@votingworks/ui';
+import { Prose, NoWrap, H1, H5, P, Caption } from '@votingworks/ui';
 import pluralize from 'pluralize';
 import { Seal } from './seal';
 
@@ -74,19 +74,21 @@ export function ElectionInfo({
           <Seal seal={seal} sealUrl={sealUrl} />
           <Prose compact>
             <H5 aria-label={`${title}.`}>{title}</H5>
-            <Text small>
-              {electionDate}
-              <br />
-              <NoWrap>{county.name},</NoWrap> <NoWrap>{state}</NoWrap>
-            </Text>
+            <P>
+              <Caption>
+                {electionDate}
+                <br />
+                <NoWrap>{county.name},</NoWrap> <NoWrap>{state}</NoWrap>
+              </Caption>
+            </P>
             {precinctName && (
-              <Text small light>
+              <Caption>
                 <NoWrap>
                   {precinctName}
                   {ballotStyleId && ', '}
                 </NoWrap>
                 {ballotStyleId && <NoWrap>ballot style {ballotStyleId}</NoWrap>}
-              </Text>
+              </Caption>
             )}
           </Prose>
         </HorizontalContainer>

--- a/apps/mark/frontend/src/components/ms_either_neither_contest.tsx
+++ b/apps/mark/frontend/src/components/ms_either_neither_contest.tsx
@@ -14,8 +14,8 @@ import {
   H1,
   Main,
   Prose,
-  Text,
   TextWithLineBreaks,
+  Caption,
 } from '@votingworks/ui';
 
 import { YesNoVote, OptionalYesNoVote } from '@votingworks/types';
@@ -297,15 +297,9 @@ export function MsEitherNeitherContest({
           }}
         >
           <Prose>
-            <Text
-              small
-              bold
-              style={{
-                fontSize: '0.7rem',
-              }}
-            >
-              {contest.eitherNeitherLabel}
-            </Text>
+            <P weight="bold">
+              <Caption>{contest.eitherNeitherLabel}</Caption>
+            </P>
           </Prose>
         </GridLabel>
         <ContestChoiceButton
@@ -342,15 +336,9 @@ export function MsEitherNeitherContest({
           }}
         >
           <Prose>
-            <Text
-              small
-              bold
-              style={{
-                fontSize: '0.7rem',
-              }}
-            >
-              {contest.pickOneLabel}
-            </Text>
+            <P weight="bold">
+              <Caption>{contest.pickOneLabel}</Caption>
+            </P>
           </Prose>
         </GridLabel>
         <ContestChoiceButton

--- a/apps/mark/frontend/src/pages/__snapshots__/cast_ballot_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/cast_ballot_page.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`renders CastBallotPage 1`] = `
             style="left: -0.75em;"
           />
           <p
-            class="sc-bqiQRQ bIFmdQ"
+            class="sc-dkPtyc XGKAk"
           >
             1. Verify your official ballot.
           </p>
@@ -83,7 +83,7 @@ exports[`renders CastBallotPage 1`] = `
             src="/images/instructions-2-scan.svg"
           />
           <p
-            class="sc-bqiQRQ bIFmdQ"
+            class="sc-dkPtyc XGKAk"
           >
             2. Scan your official ballot.
           </p>
@@ -92,9 +92,11 @@ exports[`renders CastBallotPage 1`] = `
       <h3
         class="sc-gKckTs lQVQK"
       >
-        <strong>
+        <span
+          class="sc-bdvvaa hCYwzI"
+        >
           Need help?
-        </strong>
+        </span>
          Ask a poll worker.
       </h3>
     </div>

--- a/apps/mark/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
@@ -138,8 +138,8 @@ exports[`Renders ContestPage 1`] = `
       <div
         class="sc-fotPbf iwtRsQ"
       >
-        <p
-          class="sc-bqiQRQ jKCqve"
+        <span
+          class="sc-gsDJrp cXSIgy"
         >
           This is the
            
@@ -151,7 +151,7 @@ exports[`Renders ContestPage 1`] = `
            
           21 contests
            on your ballot.
-        </p>
+        </span>
       </div>
     </div>
     <main
@@ -179,13 +179,9 @@ exports[`Renders ContestPage 1`] = `
           <p
             class="sc-dkPtyc XGKAk"
           >
-            <span
-              class="sc-bqiQRQ bIFmdQ"
-            >
-              Vote for 
-              1
-              .
-            </span>
+            Vote for 
+            1
+            .
              
             <span
               class="screen-reader-only"
@@ -775,13 +771,9 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
           <p
             class="sc-dkPtyc XGKAk"
           >
-            <span
-              class="sc-bqiQRQ bIFmdQ"
-            >
-              Vote for 
-              1
-              .
-            </span>
+            Vote for 
+            1
+            .
              
             <span
               class="screen-reader-only"
@@ -1120,7 +1112,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
           class="sc-fotPbf iwtRsQ"
         >
           <p
-            class="sc-bqiQRQ boCaWT"
+            class="sc-dkPtyc ckrwKj"
           >
             This is the 
             <strong>
@@ -1213,25 +1205,29 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                  General Election
               </h5>
               <p
-                class="sc-bqiQRQ jKCqve"
+                class="sc-dkPtyc XGKAk"
               >
-                November 3, 2020
-                <br />
                 <span
-                  class="sc-ksdxAp gMaEyZ"
+                  class="sc-gsDJrp cXSIgy"
                 >
-                  Franklin County
-                  ,
-                </span>
-                 
-                <span
-                  class="sc-ksdxAp gMaEyZ"
-                >
-                  State of Hamilton
+                  November 3, 2020
+                  <br />
+                  <span
+                    class="sc-ksdxAp gMaEyZ"
+                  >
+                    Franklin County
+                    ,
+                  </span>
+                   
+                  <span
+                    class="sc-ksdxAp gMaEyZ"
+                  >
+                    State of Hamilton
+                  </span>
                 </span>
               </p>
-              <p
-                class="sc-bqiQRQ lpjhJV"
+              <span
+                class="sc-gsDJrp cXSIgy"
               >
                 <span
                   class="sc-ksdxAp gMaEyZ"
@@ -1245,7 +1241,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                   ballot style 
                   12
                 </span>
-              </p>
+              </span>
             </div>
           </div>
         </div>

--- a/apps/mark/frontend/src/pages/accessible_controller_diagnostic_screen.tsx
+++ b/apps/mark/frontend/src/pages/accessible_controller_diagnostic_screen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Button, H1, Main, Prose, Screen, Text } from '@votingworks/ui';
+import { Button, Font, H1, Main, P, Prose, Screen } from '@votingworks/ui';
 import { DateTime } from 'luxon';
 import styled from 'styled-components';
 import { ScreenReader } from '../config/types';
@@ -282,10 +282,10 @@ export function AccessibleControllerDiagnosticScreen({
     <Screen>
       <Main centerChild>
         <Header>
-          <Text>
-            <strong>Accessible Controller Test</strong> &mdash; Step {step + 1}{' '}
-            of {steps.length}
-          </Text>
+          <P>
+            <Font weight="bold">Accessible Controller Test</Font> &mdash; Step{' '}
+            {step + 1} of {steps.length}
+          </P>
           <Button onPress={onCancel}>Cancel Test</Button>
         </Header>
         <StepContainer>{steps[step]}</StepContainer>

--- a/apps/mark/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.tsx
@@ -14,9 +14,11 @@ import {
   SegmentedButton,
   SetClockButton,
   TestMode,
-  Text,
   UsbControllerButton,
   UsbDrive,
+  Caption,
+  Font,
+  Icons,
 } from '@votingworks/ui';
 import {
   ElectionDefinition,
@@ -73,11 +75,11 @@ export function AdminScreen({
         <Prose>
           <H1>
             VxMark{' '}
-            <Text as="span" light noWrap>
+            <Font weight="light" noWrap>
               Election Manager Actions
-            </Text>
+            </Font>
           </H1>
-          <Text italic>Remove card when finished.</Text>
+          <P weight="bold">Remove card when finished.</P>
           {election && (
             <React.Fragment>
               <H2>Stats</H2>
@@ -101,16 +103,16 @@ export function AdminScreen({
                   logger={logger}
                 />
                 <br />
-                <Text small italic as="span">
+                <Caption>
                   Changing the precinct will reset the Ballots Printed count.
-                </Text>
+                </Caption>
                 {election.precincts.length === 1 && (
                   <React.Fragment>
                     <br />
-                    <Text small italic as="span">
+                    <Caption>
                       Precinct cannot be changed because there is only one
                       precinct configured for this election.
-                    </Text>
+                    </Caption>
                   </React.Fragment>
                 )}
               </P>
@@ -127,9 +129,9 @@ export function AdminScreen({
                   selectedOptionId={isLiveMode ? 'official' : 'test'}
                 />
                 <br />
-                <Text small italic as="span">
+                <Caption>
                   Switching the mode will reset the Ballots Printed count.
-                </Text>
+                </Caption>
               </P>
             </React.Fragment>
           )}
@@ -142,9 +144,10 @@ export function AdminScreen({
           </P>
           <H2>Configuration</H2>
           <P>
-            <Text as="span" voteIcon>
-              Election Definition is loaded.
-            </Text>{' '}
+            <Font color="success">
+              <Icons.Checkbox />
+            </Font>{' '}
+            Election Definition is loaded.{' '}
             <Button variant="danger" small onPress={unconfigure}>
               Unconfigure Machine
             </Button>

--- a/apps/mark/frontend/src/pages/cast_ballot_page.tsx
+++ b/apps/mark/frontend/src/pages/cast_ballot_page.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { Button, Main, Screen, Prose, Text, H1, H3, P } from '@votingworks/ui';
+import { Button, Main, Screen, Prose, H1, H3, P, Font } from '@votingworks/ui';
 
 const SingleGraphic = styled.img`
   margin: 0 auto 1em;
@@ -52,7 +52,7 @@ export function CastBallotPage({
                 src="/images/instructions-1-verify.svg"
                 style={{ left: '-0.75em' }}
               />
-              <Text>1. Verify your official ballot.</Text>
+              <P>1. Verify your official ballot.</P>
             </li>
             <li>
               <SingleGraphic
@@ -60,11 +60,11 @@ export function CastBallotPage({
                 alt="Scan Your Ballot"
                 src="/images/instructions-2-scan.svg"
               />
-              <Text>2. Scan your official ballot.</Text>
+              <P>2. Scan your official ballot.</P>
             </li>
           </Instructions>
           <H3>
-            <strong>Need help?</strong> Ask a poll worker.
+            <Font weight="bold">Need help?</Font> Ask a poll worker.
           </H3>
         </Prose>
         <Done>

--- a/apps/mark/frontend/src/pages/contest_page.tsx
+++ b/apps/mark/frontend/src/pages/contest_page.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 import { CandidateVote, OptionalYesNoVote } from '@votingworks/types';
-import { LinkButton, Screen, Prose, Text, P } from '@votingworks/ui';
+import { LinkButton, Screen, Prose, P, Caption } from '@votingworks/ui';
 import { singlePrecinctSelectionFor } from '@votingworks/utils';
 import pluralize from 'pluralize';
 import React, { useContext, useEffect, useState } from 'react';
@@ -145,11 +145,11 @@ export function ContestPage(): JSX.Element {
       {isPortrait && (
         <Breadcrumbs>
           <Prose>
-            <Text small>
+            <Caption>
               This is the{' '}
               <strong>{ordinal(ballotContestNumber)} contest</strong> of{' '}
               {pluralize('contest', ballotContestsLength, true)} on your ballot.
-            </Text>
+            </Caption>
           </Prose>
         </Breadcrumbs>
       )}
@@ -210,10 +210,10 @@ export function ContestPage(): JSX.Element {
           }
         >
           <Prose>
-            <Text center>
+            <P align="center">
               This is the <strong>{ordinal(currentContestIndex + 1)}</strong> of{' '}
               {pluralize('contest', contests.length, true)}.
-            </Text>
+            </P>
             {isReviewMode ? (
               <P>{reviewScreenButton}</P>
             ) : (

--- a/apps/mark/frontend/src/pages/diagnostics_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/diagnostics_screen.test.tsx
@@ -12,24 +12,20 @@ import {
   within,
 } from '../../test/react_testing_library';
 import {
+  CHECKBOX_ICON_TEST_ID,
   DiagnosticsScreen,
   DiagnosticsScreenProps,
+  WARNING_ICON_TEST_ID,
 } from './diagnostics_screen';
 import { fakeDevices } from '../../test/helpers/fake_devices';
 import { AriaScreenReader } from '../utils/ScreenReader';
 import { fakeTts } from '../../test/helpers/fake_tts';
 
-// Unfortunately, since the icons are rendered in CSS ::before pseudo-elements,
-// we can't check for them in the rendered HTML output. The
-// jest-styled-components library does enable us to check for this, but we would
-// need to upgrade jest first (https://github.com/votingworks/vxsuite/issues/1622).
-// For now, we just hardcode the styled-components generated class names of the
-// Text components with the various icons.
 function expectToHaveSuccessIcon(element: HTMLElement) {
-  expect(element).toHaveClass('sc-bqiQRQ cheCgH');
+  within(element).getByTestId(CHECKBOX_ICON_TEST_ID);
 }
 function expectToHaveWarningIcon(element: HTMLElement) {
-  expect(element).toHaveClass('sc-bqiQRQ eMTyqo');
+  within(element).getByTestId(WARNING_ICON_TEST_ID);
 }
 
 function renderScreen(props: Partial<DiagnosticsScreenProps> = {}) {

--- a/apps/mark/frontend/src/pages/diagnostics_screen.tsx
+++ b/apps/mark/frontend/src/pages/diagnostics_screen.tsx
@@ -35,14 +35,16 @@ const ButtonAndTimestamp = styled.div`
   }
 `;
 
+export const CHECKBOX_ICON_TEST_ID = 'checkboxIcon';
 const CHECKBOX_ICON = (
-  <Font color="success">
+  <Font color="success" data-testid={CHECKBOX_ICON_TEST_ID}>
     <Icons.Checkbox />
   </Font>
 );
 
+export const WARNING_ICON_TEST_ID = 'warningIcon';
 const WARNING_ICON = (
-  <Font color="warning">
+  <Font color="warning" data-testid={WARNING_ICON_TEST_ID}>
     <Icons.Warning />
   </Font>
 );

--- a/apps/mark/frontend/src/pages/diagnostics_screen.tsx
+++ b/apps/mark/frontend/src/pages/diagnostics_screen.tsx
@@ -9,9 +9,11 @@ import {
   Main,
   Prose,
   Screen,
-  Text,
   useCancelablePromise,
   P,
+  Caption,
+  Font,
+  Icons,
 } from '@votingworks/ui';
 import { formatTime, Hardware } from '@votingworks/utils';
 import { DateTime } from 'luxon';
@@ -33,6 +35,18 @@ const ButtonAndTimestamp = styled.div`
   }
 `;
 
+const CHECKBOX_ICON = (
+  <Font color="success">
+    <Icons.Checkbox />
+  </Font>
+);
+
+const WARNING_ICON = (
+  <Font color="warning">
+    <Icons.Warning />
+  </Font>
+);
+
 interface ComputerStatusProps {
   computer: ComputerStatusType;
 }
@@ -40,14 +54,14 @@ interface ComputerStatusProps {
 function ComputerStatus({ computer }: ComputerStatusProps) {
   return (
     <React.Fragment>
-      <Text voteIcon>
-        Battery:{' '}
+      <P>
+        {CHECKBOX_ICON} Battery:{' '}
         {computer.batteryLevel && `${Math.round(computer.batteryLevel * 100)}%`}
-      </Text>
+      </P>
       {computer.batteryIsCharging ? (
-        <Text voteIcon>Power cord connected.</Text>
+        <P>{CHECKBOX_ICON} Power cord connected.</P>
       ) : (
-        <Text warningIcon>No power cord connected. Connect power cord.</Text>
+        <P>{WARNING_ICON} No power cord connected. Connect power cord.</P>
       )}
     </React.Fragment>
   );
@@ -161,21 +175,21 @@ function PrinterStatus({ hardware }: PrinterStatusProps) {
   }, [loadPrinterStatus]);
 
   if (printerStatus.isLoading) {
-    return <Text>Loading printer status…</Text>;
+    return <P>Loading printer status…</P>;
   }
   const { printer, loadedAt } = printerStatus;
 
   const refreshButton = (
     <ButtonAndTimestamp>
       <Button onPress={loadPrinterStatus}>Refresh Printer Status</Button>
-      {loadedAt && <Text small>Last updated at {formatTime(loadedAt)}</Text>}
+      {loadedAt && <Caption>Last updated at {formatTime(loadedAt)}</Caption>}
     </ButtonAndTimestamp>
   );
 
   if (!printer || printer.state === 'unknown') {
     return (
       <React.Fragment>
-        <Text warningIcon>Could not get printer status.</Text>
+        <P>{WARNING_ICON} Could not get printer status.</P>
         {refreshButton}
       </React.Fragment>
     );
@@ -187,11 +201,9 @@ function PrinterStatus({ hardware }: PrinterStatusProps) {
 
   return (
     <React.Fragment>
-      <Text
-        voteIcon={printer.state !== 'stopped'}
-        warningIcon={printer.state === 'stopped'}
-      >
-        Printer status:{' '}
+      <P>
+        {printer.state === 'stopped' ? WARNING_ICON : CHECKBOX_ICON} Printer
+        status:{' '}
         {
           {
             idle: 'Ready',
@@ -199,16 +211,17 @@ function PrinterStatus({ hardware }: PrinterStatusProps) {
             stopped: 'Stopped',
           }[printer.state]
         }
-      </Text>
+      </P>
       {bestReason && bestReason !== 'none' && (
-        <Text warningIcon>
-          Warning: {IppPrinterStateReasonMessage[bestReason] ?? bestReason}
-        </Text>
+        <P>
+          {WARNING_ICON} Warning:{' '}
+          {IppPrinterStateReasonMessage[bestReason] ?? bestReason}
+        </P>
       )}
-      <Text voteIcon={!markerLow} warningIcon={markerLow}>
-        Toner level:{' '}
+      <P>
+        {markerLow ? WARNING_ICON : CHECKBOX_ICON} Toner level:{' '}
         {marker && marker.level >= 0 ? `${marker.level}%` : 'Unknown'}
-      </Text>
+      </P>
       {refreshButton}
     </React.Fragment>
   );
@@ -224,26 +237,28 @@ function AccessibleControllerStatus({
   diagnosticResults,
 }: AccessibleControllerStatusProps) {
   if (!accessibleController) {
-    return <Text warningIcon>No accessible controller connected.</Text>;
+    return <P>{WARNING_ICON} No accessible controller connected.</P>;
   }
 
   return (
     <React.Fragment>
-      <Text voteIcon>Accessible controller connected.</Text>
+      <P>{CHECKBOX_ICON} Accessible controller connected.</P>
       {diagnosticResults &&
         (diagnosticResults.passed ? (
-          <Text voteIcon>Test passed.</Text>
+          <P>{CHECKBOX_ICON} Test passed.</P>
         ) : (
-          <Text warningIcon>Test failed: {diagnosticResults.message}</Text>
+          <P>
+            {WARNING_ICON} Test failed: {diagnosticResults.message}
+          </P>
         ))}
       <ButtonAndTimestamp>
         <LinkButton to="/accessible-controller">
           Start Accessible Controller Test
         </LinkButton>
         {diagnosticResults && (
-          <Text small>
+          <Caption>
             Last tested at {formatTime(diagnosticResults.completedAt)}
-          </Text>
+          </Caption>
         )}
       </ButtonAndTimestamp>
     </React.Fragment>

--- a/apps/mark/frontend/src/pages/insert_card_screen.tsx
+++ b/apps/mark/frontend/src/pages/insert_card_screen.tsx
@@ -9,11 +9,13 @@ import {
   Screen,
   Prose,
   TestMode,
-  Text,
   ElectionInfoBar,
   InsertCardImage,
   H1,
   P,
+  Caption,
+  Icons,
+  Font,
 } from '@votingworks/ui';
 
 import { throwIllegalValue } from '@votingworks/basics';
@@ -75,19 +77,20 @@ export function InsertCardScreen({
       <Main centerChild>
         <Prose textCenter id="audiofocus">
           {showNoChargerAttachedWarning && (
-            <Text warning small>
-              <strong>No Power Detected.</strong> Please ask a poll worker to
-              plug in the power cord for this machine.
-            </Text>
+            <Caption color="warning">
+              <Icons.Warning /> <Font weight="bold">No Power Detected.</Font>{' '}
+              Please ask a poll worker to plug in the power cord for this
+              machine.
+            </Caption>
           )}
           <P>
             <InsertCardImage />
           </P>
           {mainText}
           {showNoAccessibleControllerWarning && (
-            <Text muted small>
+            <Caption>
               Voting with an accessible controller is not currently available.
-            </Text>
+            </Caption>
           )}
         </Prose>
       </Main>

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -27,7 +27,6 @@ import {
   printElement,
   Prose,
   Screen,
-  Text,
   PrecinctScannerBallotCountReport,
   ElectionInfoBar,
   TestMode,
@@ -36,6 +35,8 @@ import {
   H1,
   H2,
   P,
+  Caption,
+  Font,
 } from '@votingworks/ui';
 
 import {
@@ -593,20 +594,20 @@ export function PollWorkerScreen({
             <ol>
               <li>
                 Instruct the voter to press the{' '}
-                <Text as="span" bold noWrap>
+                <Font weight="bold" noWrap>
                   Start Voting
-                </Text>{' '}
+                </Font>{' '}
                 button on the next screen.
               </li>
               <li>Remove the poll worker card to continue.</li>
             </ol>
             <HorizontalRule>or</HorizontalRule>
-            <Text center>Deactivate this voter session to start over.</Text>
-            <Text center>
+            <P align="center">Deactivate this voter session to start over.</P>
+            <P align="center">
               <Button small onPress={resetCardlessVoterSession}>
                 Deactivate Voting Session
               </Button>
-            </Text>
+            </P>
           </Prose>
         </Main>
       </Screen>
@@ -632,24 +633,20 @@ export function PollWorkerScreen({
           <Prose maxWidth={false}>
             <H1>
               VxMark{' '}
-              <Text as="span" light noWrap>
+              <Font weight="light" noWrap>
                 Poll Worker Actions
-              </Text>
+              </Font>
             </H1>
             <H2>
               <NoWrap>
-                <Text light as="span">
-                  Ballots Printed:
-                </Text>{' '}
-                <strong>{ballotsPrintedCount}</strong>
+                <Font weight="light">Ballots Printed:</Font>{' '}
+                {ballotsPrintedCount}
               </NoWrap>
               <br />
 
               <NoWrap>
-                <Text light as="span">
-                  Polls:
-                </Text>{' '}
-                <strong>{getPollsStateName(pollsState)}</strong>
+                <Font weight="light">Polls:</Font>{' '}
+                {getPollsStateName(pollsState)}
               </NoWrap>
             </H2>
             {canSelectBallotStyle && !isHidingSelectBallotStyle ? (
@@ -703,10 +700,10 @@ export function PollWorkerScreen({
                       ))}
                     </ButtonList>
                   ) : (
-                    <Text italic>
+                    <P>
                       Select the voter’s precinct above to view ballot styles
                       for the precinct.
-                    </Text>
+                    </P>
                   )}
                 </VotingSession>
                 <Button onPress={() => setIsHidingSelectBallotStyle(true)}>
@@ -769,14 +766,14 @@ export function PollWorkerScreen({
                 </H1>
                 <P>
                   Today is election day and this machine is in{' '}
-                  <strong>
-                    <NoWrap>Test Ballot Mode.</NoWrap>
-                  </strong>
+                  <Font noWrap weight="bold">
+                    Test Ballot Mode.
+                  </Font>
                 </P>
-                <Text small italic>
+                <Caption>
                   Note: Switching back to Test Ballot Mode requires an{' '}
                   <NoWrap>Election Manager Card.</NoWrap>
-                </Text>
+                </Caption>
               </Prose>
             }
             actions={

--- a/apps/mark/frontend/src/pages/replace_election_screen.tsx
+++ b/apps/mark/frontend/src/pages/replace_election_screen.tsx
@@ -6,8 +6,9 @@ import {
   Prose,
   Screen,
   Table,
-  Text,
   P,
+  H1,
+  Icons,
 } from '@votingworks/ui';
 import { formatLongDate } from '@votingworks/utils';
 import type { MachineConfig } from '@votingworks/mark-backend';
@@ -74,9 +75,9 @@ export function ReplaceElectionScreen({
     <Screen>
       <Main padded centerChild>
         <Prose id="audiofocus">
-          <Text as="h1" error>
-            This card is configured for a different election.
-          </Text>
+          <H1 color="danger">
+            <Icons.Danger /> This card is configured for a different election.
+          </H1>
           <Table>
             <thead>
               <tr>

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -22,6 +22,7 @@ import {
   faMagnifyingGlassMinus,
   faTextHeight,
   faBan,
+  faCheckSquare,
 } from '@fortawesome/free-solid-svg-icons';
 import {
   faXmarkCircle,
@@ -55,6 +56,10 @@ function FaIcon(props: InnerProps): JSX.Element {
 export const Icons = {
   Backspace(): JSX.Element {
     return <FaIcon type={faDeleteLeft} />;
+  },
+
+  Checkbox(): JSX.Element {
+    return <FaIcon type={faCheckSquare} />;
   },
 
   Checkmark(): JSX.Element {

--- a/libs/ui/src/typography.tsx
+++ b/libs/ui/src/typography.tsx
@@ -11,6 +11,7 @@ type HeadingType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
 /** Props for {@link Font}, {@link P}, and {@link Caption}. */
 export interface FontProps {
+  'aria-label'?: string;
   align?: Align;
   children?: React.ReactNode;
   className?: string;


### PR DESCRIPTION
## Overview

Replacing last remaining bits of typography in VxAdmin with the newer theme-aware components from `libs/ui`:
- `<Text>` -> `<P>`
- `<Text small>` -> `<Caption>` (wrapped in a `<P>` when intended as a standalone paragraph).
- `<Text as="span">` -> `<Font>` (or removed entirely in a couple cases, where it's unnecessary).
- `<Text warning|error|etc>` -> `<P color="...">` or `<Font color="...">` if rendered as span within surrounding text.
  - Additionally, adding appropriate icons whenever we use color, as recommended by VVSG (since not all contrast modes support colors).
- `<Text bold|light>` -> `<P weight="...">` or `<Font weight="...">`
- `<Text italic>` -> `<P>` or `<P weight="bold">` in rare cases where we actually need the text emphasized - italic text can be tough to parse for some people.

Mostly a no-op, but there are bound to be a few short-lived spacing and size(for captions) changes here and there - will be adjusting screen by screen once new themes are enabled.

## Demo Video or Screenshot
### Sample Before/Ater:
_(Ignore the old warning icon in the "after" screenshot - fixed that in the code, but my env is hosed at the moment, so I couldn't get an updated screenshot)_
<img width="300" src="https://user-images.githubusercontent.com/264902/235803536-ca7c909a-7a61-45b0-a6be-f616d036c139.png" /> <img width="300" src="https://user-images.githubusercontent.com/264902/235803570-be1cf1d5-a9b7-45c7-8f89-652228176970.png" />

## Testing Plan
- Visual spot checks
- Updated affected test expectations and snapshots

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
