### PR TITLE
Consistently initialize file underlying MockFileCard

### DIFF
--- a/libs/auth/scripts/generate_dev_keys_and_certs.ts
+++ b/libs/auth/scripts/generate_dev_keys_and_certs.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import { Buffer } from 'buffer';
-import { promises as fs } from 'fs';
+import fs from 'fs/promises';
 import yargs from 'yargs/yargs';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 

--- a/libs/auth/src/card.ts
+++ b/libs/auth/src/card.ts
@@ -6,18 +6,18 @@ import {
 } from '@votingworks/types';
 
 interface SystemAdministratorCardDetails {
-  numIncorrectPinAttempts?: number;
   user: SystemAdministratorUser;
+  numIncorrectPinAttempts?: number;
 }
 
 interface ElectionManagerCardDetails {
-  numIncorrectPinAttempts?: number;
   user: ElectionManagerUser;
+  numIncorrectPinAttempts?: number;
 }
 
 interface PollWorkerCardDetails {
-  numIncorrectPinAttempts?: number;
   user: PollWorkerUser;
+  numIncorrectPinAttempts?: number;
 
   /**
    * Unlike system administrator and election manager cards, which always have PINs, poll worker
@@ -25,6 +25,14 @@ interface PollWorkerCardDetails {
    */
   hasPin: boolean;
 }
+
+/**
+ * Details about a programmed card
+ */
+export type CardDetails =
+  | SystemAdministratorCardDetails
+  | ElectionManagerCardDetails
+  | PollWorkerCardDetails;
 
 /**
  * A CardDetails type guard
@@ -52,14 +60,6 @@ export function arePollWorkerCardDetails(
 ): cardDetails is PollWorkerCardDetails {
   return cardDetails.user.role === 'poll_worker';
 }
-
-/**
- * Details about a programmed card
- */
-export type CardDetails =
-  | SystemAdministratorCardDetails
-  | ElectionManagerCardDetails
-  | PollWorkerCardDetails;
 
 interface CardStatusReady {
   status: 'ready';

--- a/libs/auth/src/cypress.ts
+++ b/libs/auth/src/cypress.ts
@@ -1,7 +1,7 @@
 /**
  * This file exists so that Cypress tests can import what they need without having to import all of
- * the auth lib. This ensures that we don't import packages that don't work in the browser. All of
- * this file's dependencies should accordingly contain only browser-safe code.
+ * the auth lib. This ensures that we only import packages that work in the browser. All of this
+ * file's dependencies should accordingly contain only browser-safe code.
  *
  * Cypress tests should import from this file as follows:
  * ```

--- a/libs/auth/src/dipped_smart_card_auth.test.ts
+++ b/libs/auth/src/dipped_smart_card_auth.test.ts
@@ -370,8 +370,8 @@ test('Card lockout', async () => {
   mockCardStatus({
     status: 'ready',
     cardDetails: {
-      numIncorrectPinAttempts: 2,
       user: electionManagerUser,
+      numIncorrectPinAttempts: 2,
     },
   });
   expect(await auth.getAuthStatus(machineState)).toEqual({
@@ -403,8 +403,8 @@ test('Card lockout', async () => {
   mockCardStatus({
     status: 'ready',
     cardDetails: {
-      numIncorrectPinAttempts: 3,
       user: electionManagerUser,
+      numIncorrectPinAttempts: 3,
     },
   });
   expect(await auth.getAuthStatus(machineState)).toEqual({

--- a/libs/auth/src/dipped_smart_card_auth.ts
+++ b/libs/auth/src/dipped_smart_card_auth.ts
@@ -464,17 +464,20 @@ export class DippedSmartCardAuth implements DippedSmartCardAuthApi {
                   const skipPinEntry = isFeatureFlagEnabled(
                     BooleanEnvironmentVariableName.SKIP_PIN_ENTRY
                   );
-                  const lockedOutUntil = computeCardLockoutEndTime(
-                    machineState,
-                    cardDetails.numIncorrectPinAttempts
-                  );
                   return skipPinEntry
                     ? {
                         status: 'remove_card',
                         user,
                         sessionExpiresAt: computeSessionEndTime(machineState),
                       }
-                    : { status: 'checking_pin', user, lockedOutUntil };
+                    : {
+                        status: 'checking_pin',
+                        user,
+                        lockedOutUntil: computeCardLockoutEndTime(
+                          machineState,
+                          cardDetails.numIncorrectPinAttempts
+                        ),
+                      };
                 }
                 return {
                   status: 'logged_out',

--- a/libs/auth/src/inserted_smart_card_auth.test.ts
+++ b/libs/auth/src/inserted_smart_card_auth.test.ts
@@ -403,8 +403,8 @@ test('Card lockout', async () => {
   mockCardStatus({
     status: 'ready',
     cardDetails: {
-      numIncorrectPinAttempts: 2,
       user: electionManagerUser,
+      numIncorrectPinAttempts: 2,
     },
   });
   expect(await auth.getAuthStatus(machineState)).toEqual({
@@ -436,8 +436,8 @@ test('Card lockout', async () => {
   mockCardStatus({
     status: 'ready',
     cardDetails: {
-      numIncorrectPinAttempts: 3,
       user: electionManagerUser,
+      numIncorrectPinAttempts: 3,
     },
   });
   expect(await auth.getAuthStatus(machineState)).toEqual({

--- a/libs/auth/src/java_card.ts
+++ b/libs/auth/src/java_card.ts
@@ -1,5 +1,5 @@
 import { Buffer } from 'buffer';
-import { promises as fs } from 'fs';
+import fs from 'fs/promises';
 import { sha256 } from 'js-sha256';
 import { v4 as uuid } from 'uuid';
 import { assert, Optional, throwIllegalValue } from '@votingworks/basics';

--- a/libs/auth/src/java_card.ts
+++ b/libs/auth/src/java_card.ts
@@ -386,7 +386,7 @@ export class JavaCard implements Card {
   }
 
   /**
-   * We wrap this.readCardDetails to create this.safeReadCardDetails because this.readCardDetails:
+   * We wrap readCardDetails to create safeReadCardDetails because readCardDetails:
    * 1. Intentionally throws errors if any verification fails
    * 2. Can throw errors due to external actions like preemptively removing the card from the card
    *    reader

--- a/libs/auth/src/mock_file_card.test.ts
+++ b/libs/auth/src/mock_file_card.test.ts
@@ -288,3 +288,11 @@ test('MockFileCard resiliency to deletion of underlying file', async () => {
     status: 'no_card',
   });
 });
+
+test('MockFileCard resiliency to underlying file that cannot be parsed', async () => {
+  const card = new MockFileCard();
+  fs.writeFileSync(MOCK_FILE_PATH, 'Not valid JSON');
+  expect(await card.getCardStatus()).toEqual({
+    status: 'no_card',
+  });
+});

--- a/libs/auth/src/mock_file_card.test.ts
+++ b/libs/auth/src/mock_file_card.test.ts
@@ -1,4 +1,5 @@
 import { Buffer } from 'buffer';
+import fs from 'fs';
 import { electionSampleDefinition } from '@votingworks/fixtures';
 import {
   ElectionManagerUser,
@@ -9,6 +10,7 @@ import {
 import { DEV_JURISDICTION } from './jurisdictions';
 import {
   deserializeMockFileContents,
+  MOCK_FILE_PATH,
   mockCard,
   MockFileCard,
   MockFileContents,
@@ -277,4 +279,12 @@ test('MockFileCard data reading and writing', async () => {
   );
   await card.clearData();
   expect(await card.readData()).toEqual(Buffer.from([]));
+});
+
+test('MockFileCard resiliency to deletion of underlying file', async () => {
+  const card = new MockFileCard();
+  fs.rmSync(MOCK_FILE_PATH);
+  expect(await card.getCardStatus()).toEqual({
+    status: 'no_card',
+  });
 });

--- a/libs/auth/src/mock_file_card.ts
+++ b/libs/auth/src/mock_file_card.ts
@@ -1,5 +1,5 @@
 import { Buffer } from 'buffer';
-import * as fs from 'fs';
+import fs from 'fs';
 import { assert, throwIllegalValue } from '@votingworks/basics';
 import {
   ElectionManagerUser,
@@ -11,7 +11,10 @@ import { Card, CardStatus, CheckPinResponse } from './card';
 
 type WriteFileFn = (filePath: string, fileContents: Buffer) => void;
 
-const MOCK_FILE_PATH = '/tmp/mock-file-card.json';
+/**
+ * The path of the file underlying a MockFileCard
+ */
+export const MOCK_FILE_PATH = '/tmp/mock-file-card.json';
 
 /**
  * The contents of the file underlying a MockFileCard

--- a/libs/auth/src/mock_file_card.ts
+++ b/libs/auth/src/mock_file_card.ts
@@ -24,7 +24,7 @@ export interface MockFileContents {
 }
 
 /**
- * Convert a MockFileContents object into a Buffer
+ * Converts a MockFileContents object into a Buffer
  */
 export function serializeMockFileContents(
   mockFileContents: MockFileContents
@@ -42,7 +42,7 @@ export function serializeMockFileContents(
 }
 
 /**
- * Convert a Buffer created by serializeMockFileContents back into a MockFileContents object
+ * Converts a Buffer created by serializeMockFileContents back into a MockFileContents object
  */
 export function deserializeMockFileContents(file: Buffer): MockFileContents {
   const { cardStatus, data, numIncorrectPinAttempts, pin } = JSON.parse(
@@ -54,14 +54,6 @@ export function deserializeMockFileContents(file: Buffer): MockFileContents {
     numIncorrectPinAttempts,
     pin,
   };
-}
-
-/**
- * Read and parse the contents of the mock file for the current MockFileCard
- */
-export function readFromMockFile(): MockFileContents {
-  const file = fs.readFileSync(MOCK_FILE_PATH);
-  return deserializeMockFileContents(file);
 }
 
 function writeToMockFile(
@@ -77,10 +69,27 @@ function writeToMockFile(
 export const mockCard = writeToMockFile;
 
 /**
+ * Reads and parses the contents of the file underlying a MockFileCard
+ */
+export function readFromMockFile(): MockFileContents {
+  // Initialize the mock file if it doesn't already exist
+  if (!fs.existsSync(MOCK_FILE_PATH)) {
+    writeToMockFile({
+      cardStatus: {
+        status: 'no_card',
+      },
+    });
+  }
+
+  const file = fs.readFileSync(MOCK_FILE_PATH);
+  return deserializeMockFileContents(file);
+}
+
+/**
  * A mock implementation of the card API that reads from and writes to a file under the hood. Meant
  * for local development and integration tests.
  *
- * Use the mock-card script in libs/auth/scripts/ to mock cards during local development.
+ * Use ./scripts/mock-card in libs/auth/ to mock cards during local development.
  */
 export class MockFileCard implements Card {
   constructor() {

--- a/libs/auth/src/openssl.test.ts
+++ b/libs/auth/src/openssl.test.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'buffer';
 import { spawn } from 'child_process';
-import { promises as fs } from 'fs';
+import fs from 'fs/promises';
 import { fileSync } from 'tmp';
 import {
   fakeChildProcess as newMockChildProcess,

--- a/libs/auth/src/openssl.ts
+++ b/libs/auth/src/openssl.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'buffer';
 import { spawn } from 'child_process';
-import { promises as fs } from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 import { FileResult, fileSync } from 'tmp';
 


### PR DESCRIPTION
_Easiest reviewed by commit_

## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/3346

@eventualbuddha recently noticed that card mocking can get thrown off if the `/tmp` directory is cleaned up ([comment](https://github.com/votingworks/vxsuite/pull/3331#discussion_r1173170682)). With the addition of the dev dock, I've now actually seen us hit errors due to the file underlying card mocking not existing:

<img width="1310" alt="errors" src="https://user-images.githubusercontent.com/12616928/236011038-b08ae4c6-17f7-4b47-b455-99757b407d60.png">

This PR makes sure that the relevant file always exists.

The PR also makes an unrelated tweak to the MockFileCard's data schema, using an existing field for the number of incorrect PIN attempts instead of creating a new one.

## Testing

- [x] Existing automated tests
- [x] A new automated test
- [x] Manual testing

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A