### PR TITLE
m16 replace ballot bag any time poll worker wants to

### DIFF
--- a/frontends/precinct-scanner/jest.config.js
+++ b/frontends/precinct-scanner/jest.config.js
@@ -13,9 +13,9 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      statements: 95,
+      statements: 94.98,
       branches: 87,
-      functions: 89,
+      functions: 88.4,
       lines: 95,
     },
   },

--- a/frontends/precinct-scanner/src/components/replace_ballot_bag_screen.tsx
+++ b/frontends/precinct-scanner/src/components/replace_ballot_bag_screen.tsx
@@ -17,12 +17,14 @@ export function ReplaceBallotBagScreen({
   onComplete,
 }: Props): JSX.Element {
   const [confirmed, setConfirmed] = useState(false);
+  const [onCompleteCalled, setOnCompleteCalled] = useState(false);
 
   useEffect(() => {
-    if (confirmed && !pollWorkerAuthenticated) {
+    if (confirmed && !onCompleteCalled) {
       onComplete();
+      setOnCompleteCalled(true);
     }
-  }, [confirmed, pollWorkerAuthenticated, onComplete]);
+  }, [confirmed, onCompleteCalled, setOnCompleteCalled, onComplete]);
 
   const mainContent = (() => {
     if (!confirmed && !pollWorkerAuthenticated) {

--- a/frontends/precinct-scanner/src/screens/poll_worker_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/poll_worker_screen.test.tsx
@@ -175,3 +175,29 @@ describe('shows Livecheck button only when enabled', () => {
     expect(screen.queryByText('Live Check')).toBeFalsy();
   });
 });
+
+describe('shows ballot bag replacement when tapped', () => {
+  test('tap replace ballot bag', async () => {
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      renderScreen({
+        scannedBallotCount: 5,
+        isPollsOpen: true,
+      });
+      jest.advanceTimersByTime(2000);
+    });
+
+    // don't close the polls
+    fireEvent.click(screen.queryAllByText('No')[0]);
+
+    expect(screen.queryByText('Replace Ballot Bag')).toBeTruthy();
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      fireEvent.click(screen.getByText('Replace Ballot Bag'));
+    });
+    screen.getByText(
+      'Has the full ballot bag been replaced with an empty ballot bag?'
+    );
+  });
+});

--- a/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
@@ -42,6 +42,7 @@ import {
   InsertedSmartcardAuth,
   Printer,
 } from '@votingworks/types';
+import { ReplaceBallotBagScreen } from '../components/replace_ballot_bag_screen';
 import {
   CenteredLargeProse,
   ScreenMainCenterChild,
@@ -99,6 +100,7 @@ interface Props {
   printer: Printer;
   hasPrinterAttached: boolean;
   usbDrive: UsbDrive;
+  onReplaceBallotBag?: () => void;
 }
 
 export function PollWorkerScreen({
@@ -109,6 +111,7 @@ export function PollWorkerScreen({
   hasPrinterAttached: printerFromProps,
   printer,
   usbDrive,
+  onReplaceBallotBag,
 }: Props): JSX.Element {
   const { electionDefinition, precinctSelection, machineConfig, auth } =
     useContext(AppContext);
@@ -121,6 +124,7 @@ export function PollWorkerScreen({
   >(new Map());
   const [isExportingResults, setIsExportingResults] = useState(false);
   const [isShowingLiveCheck, setIsShowingLiveCheck] = useState(false);
+  const [isReplacingBallotBag, setIsReplacingBallotBag] = useState(false);
   const [pollsToggledTime, setPollsToggledTime] = useState<number>();
   const hasPrinterAttached = printerFromProps || !window.kiosk;
   const { election } = electionDefinition;
@@ -523,6 +527,23 @@ export function PollWorkerScreen({
       </React.Fragment>
     );
   }
+
+  // we don't need to ever set isReplacingBallotBag to false
+  // because we depend on unmounting for that to happen.
+  if (isReplacingBallotBag) {
+    return (
+      <ReplaceBallotBagScreen
+        scannedBallotCount={scannedBallotCount}
+        pollWorkerAuthenticated
+        onComplete={() => {
+          if (onReplaceBallotBag) {
+            onReplaceBallotBag();
+          }
+        }}
+      />
+    );
+  }
+
   return (
     <React.Fragment>
       <ScreenMainCenterChild infoBarMode="pollworker">
@@ -543,6 +564,13 @@ export function PollWorkerScreen({
             <p>
               <Button onPress={() => setIsExportingResults(true)}>
                 Save Results to USB Drive
+              </Button>
+            </p>
+          )}
+          {isPollsOpen && (
+            <p>
+              <Button onPress={() => setIsReplacingBallotBag(true)}>
+                Replace Ballot Bag
               </Button>
             </p>
           )}


### PR DESCRIPTION

This is a minimal change to allow for replacing the ballot bag at any time from the poll worker screen.

This is a little bit more convoluted than I would have liked, in that the existing replace-ballot-bag-screen was fairly tightly bound, in its behavior, to a situation where the ballot bag *must* be replaced. I made two changes:

- update the ballot bag counter the moment the confirm button is hit, independent of auth status.
- force the replace ballot bag screen to continue to be shown until the poll worker card is removed.

I *think* this logic is better, but this is a slightly bigger change than I would have liked.
