### PR TITLE
[VxMark] VVSG Design Fit and Finish - Part 1

### DIFF
--- a/apps/mark/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.tsx
@@ -6,8 +6,6 @@ import {
   ChangePrecinctButton,
   CurrentDateAndTime,
   ElectionInfoBar,
-  H1,
-  H2,
   Main,
   Prose,
   Screen,
@@ -19,6 +17,8 @@ import {
   Caption,
   Font,
   Icons,
+  H4,
+  H1,
 } from '@votingworks/ui';
 import {
   ElectionDefinition,
@@ -73,22 +73,24 @@ export function AdminScreen({
       {election && !isLiveMode && <TestMode />}
       <Main padded>
         <Prose>
-          <H1>
+          <H1 as="h1">
             VxMark{' '}
             <Font weight="light" noWrap>
               Election Manager Actions
             </Font>
           </H1>
-          <P weight="bold">Remove card when finished.</P>
+          <P weight="bold">
+            <Icons.Info /> Remove card when finished.
+          </P>
           {election && (
             <React.Fragment>
-              <H2>Stats</H2>
+              <H4 as="h2">Stats</H4>
               <P>
                 Ballots Printed: <strong>{ballotsPrintedCount}</strong>
               </P>
-              <H2>
+              <H4 as="h2">
                 <label htmlFor="selectPrecinct">Precinct</label>
-              </H2>
+              </H4>
               <P>
                 <ChangePrecinctButton
                   appPrecinctSelection={appPrecinct}
@@ -116,7 +118,7 @@ export function AdminScreen({
                   </React.Fragment>
                 )}
               </P>
-              <H2>Test Ballot Mode</H2>
+              <H4 as="h2">Test Ballot Mode</H4>
               <P>
                 <SegmentedButton
                   label="Test Ballot Mode"
@@ -135,14 +137,16 @@ export function AdminScreen({
               </P>
             </React.Fragment>
           )}
-          <H2>Current Date and Time</H2>
+          <H4 as="h2">Current Date and Time</H4>
           <P>
-            <CurrentDateAndTime />
+            <Caption>
+              <CurrentDateAndTime />
+            </Caption>
           </P>
           <P>
             <SetClockButton>Update Date and Time</SetClockButton>
           </P>
-          <H2>Configuration</H2>
+          <H4 as="h2">Configuration</H4>
           <P>
             <Font color="success">
               <Icons.Checkbox />
@@ -152,7 +156,7 @@ export function AdminScreen({
               Unconfigure Machine
             </Button>
           </P>
-          <H2>USB</H2>
+          <H4 as="h2">USB</H4>
           <UsbControllerButton
             small={false}
             primary

--- a/apps/mark/frontend/src/pages/diagnostics_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/diagnostics_screen.test.tsx
@@ -55,17 +55,12 @@ describe('System Diagnostics screen: Computer section', () => {
 
     screen.getByRole('heading', { name: 'System Diagnostics' });
 
-    const computerSection = screen
-      .getByRole('heading', { name: 'Computer' })
-      .closest('section')!;
-    const batteryText = within(computerSection).getByText('Battery: 5%');
+    const batteryText = screen.getByText('Battery: 5%');
     // The battery level always has a success icon, even when it's low, since
     // it's only an actionable problem if the computer is not connected to
     // power, and that would trigger a full-screen alert
     expectToHaveSuccessIcon(batteryText);
-    const powerCordText = within(computerSection).getByText(
-      'Power cord connected.'
-    );
+    const powerCordText = screen.getByText('Power cord connected.');
     expectToHaveSuccessIcon(powerCordText);
 
     // Explicitly unmount before the printer status has resolved to verify that
@@ -79,12 +74,9 @@ describe('System Diagnostics screen: Computer section', () => {
     });
     const { unmount } = renderScreen({ devices });
 
-    const computerSection = screen
-      .getByRole('heading', { name: 'Computer' })
-      .closest('section')!;
-    const batteryText = within(computerSection).getByText('Battery: 80%');
+    const batteryText = screen.getByText('Battery: 80%');
     expectToHaveSuccessIcon(batteryText);
-    const powerCordText = within(computerSection).getByText(
+    const powerCordText = screen.getByText(
       'No power cord connected. Connect power cord.'
     );
     expectToHaveWarningIcon(powerCordText);
@@ -100,22 +92,17 @@ describe('System Diagnostics screen: Printer section', () => {
     const hardware = MemoryHardware.buildStandard();
     renderScreen({ hardware });
 
-    const printerSection = screen
-      .getByRole('heading', { name: 'Printer' })
-      .closest('section')!;
-    within(printerSection).getByText('Loading printer status…');
+    screen.getByText('Loading printer status…');
 
-    let printerStatusText = await within(printerSection).findByText(
-      'Printer status: Ready'
-    );
+    let printerStatusText = await screen.findByText('Printer status: Ready');
     expectToHaveSuccessIcon(printerStatusText);
-    let tonerLevelText = within(printerSection).getByText('Toner level: 92%');
+    let tonerLevelText = screen.getByText('Toner level: 92%');
     expectToHaveSuccessIcon(tonerLevelText);
 
-    const refreshButton = within(printerSection).getByRole('button', {
+    const refreshButton = screen.getByRole('button', {
       name: 'Refresh Printer Status',
     });
-    within(printerSection).getByText('Last updated at 11:23 AM');
+    screen.getByText('Last updated at 11:23 AM');
 
     hardware.setPrinterIppAttributes({
       state: 'stopped',
@@ -124,17 +111,15 @@ describe('System Diagnostics screen: Printer section', () => {
     });
     userEvent.click(refreshButton);
 
-    within(printerSection).getByText('Loading printer status…');
+    screen.getByText('Loading printer status…');
 
-    printerStatusText = await within(printerSection).findByText(
-      'Printer status: Stopped'
-    );
+    printerStatusText = await screen.findByText('Printer status: Stopped');
     expectToHaveWarningIcon(printerStatusText);
-    const warningText = within(printerSection).getByText(
+    const warningText = screen.getByText(
       'Warning: The printer is low on toner. Replace toner cartridge.'
     );
     expectToHaveWarningIcon(warningText);
-    tonerLevelText = within(printerSection).getByText('Toner level: 2%');
+    tonerLevelText = screen.getByText('Toner level: 2%');
     expectToHaveWarningIcon(tonerLevelText);
   });
 
@@ -145,18 +130,15 @@ describe('System Diagnostics screen: Printer section', () => {
     });
     renderScreen({ hardware });
 
-    const printerSection = screen
-      .getByRole('heading', { name: 'Printer' })
-      .closest('section')!;
-    const printerStatusText = await within(printerSection).findByText(
+    const printerStatusText = await screen.findByText(
       'Could not get printer status.'
     );
     expectToHaveWarningIcon(printerStatusText);
 
-    within(printerSection).getByRole('button', {
+    screen.getByRole('button', {
       name: 'Refresh Printer Status',
     });
-    within(printerSection).getByText('Last updated at 11:23 AM');
+    screen.getByText('Last updated at 11:23 AM');
   });
 
   it('shows only the highest priority printer state reason', async () => {
@@ -173,10 +155,7 @@ describe('System Diagnostics screen: Printer section', () => {
     });
     renderScreen({ hardware });
 
-    const printerSection = screen
-      .getByRole('heading', { name: 'Printer' })
-      .closest('section')!;
-    const warningText = await within(printerSection).findByText(
+    const warningText = await screen.findByText(
       'Warning: The printer is out of paper. Add paper to the printer.'
     );
     expectToHaveWarningIcon(warningText);
@@ -191,12 +170,7 @@ describe('System Diagnostics screen: Printer section', () => {
     });
     renderScreen({ hardware });
 
-    const printerSection = screen
-      .getByRole('heading', { name: 'Printer' })
-      .closest('section')!;
-    const warningText = await within(printerSection).findByText(
-      'Warning: some-other-reason'
-    );
+    const warningText = await screen.findByText('Warning: some-other-reason');
     expectToHaveWarningIcon(warningText);
   });
 
@@ -209,13 +183,8 @@ describe('System Diagnostics screen: Printer section', () => {
     });
     renderScreen({ hardware });
 
-    const printerSection = screen
-      .getByRole('heading', { name: 'Printer' })
-      .closest('section')!;
-    await within(printerSection).findByText('Printer status: Stopped');
-    expect(
-      within(printerSection).queryByText(/Warning/)
-    ).not.toBeInTheDocument();
+    await screen.findByText('Printer status: Stopped');
+    expect(screen.queryByText(/Warning/)).not.toBeInTheDocument();
   });
 
   it("handles negative toner level (which indicates that the toner level can't be read)", async () => {
@@ -227,12 +196,7 @@ describe('System Diagnostics screen: Printer section', () => {
     });
     renderScreen({ hardware });
 
-    const printerSection = screen
-      .getByRole('heading', { name: 'Printer' })
-      .closest('section')!;
-    const tonerLevelText = await within(printerSection).findByText(
-      'Toner level: Unknown'
-    );
+    const tonerLevelText = await screen.findByText('Toner level: Unknown');
     expectToHaveWarningIcon(tonerLevelText);
   });
 });
@@ -243,17 +207,10 @@ describe('System Diagnostics screen: Accessible Controller section', () => {
     const screenReader = new AriaScreenReader(mockTts);
     const { unmount } = renderScreen({ screenReader });
 
-    let controllerSection = screen
-      .getByRole('heading', { name: 'Accessible Controller' })
-      .closest('section')!;
-    const connectionText = within(controllerSection).getByText(
-      'Accessible controller connected.'
-    );
+    const connectionText = screen.getByText('Accessible controller connected.');
     expectToHaveSuccessIcon(connectionText);
 
-    userEvent.click(
-      within(controllerSection).getByText('Start Accessible Controller Test')
-    );
+    userEvent.click(screen.getByText('Start Accessible Controller Test'));
 
     // Execute happy path so we can get a test result
     // We have to wrap key presses in act to avoid a warning. This may be due
@@ -274,25 +231,17 @@ describe('System Diagnostics screen: Accessible Controller section', () => {
     await waitFor(() => expect(mockTts.speak).toHaveBeenCalled());
     act(() => void userEvent.keyboard('{Enter}'));
 
-    controllerSection = (
-      await screen.findByRole('heading', { name: 'Accessible Controller' })
-    ).closest('section')!;
-    const testResultText = within(controllerSection).getByText('Test passed.');
+    const testResultText = screen.getByText('Test passed.');
     expectToHaveSuccessIcon(testResultText);
-    within(controllerSection).getByText('Last tested at 11:23 AM');
+    screen.getByText('Last tested at 11:23 AM');
 
     // Bonus test - if we start a new test and cancel it, last results should still be shown
     MockDate.set(new Date());
-    userEvent.click(
-      within(controllerSection).getByText('Start Accessible Controller Test')
-    );
+    userEvent.click(screen.getButton('Start Accessible Controller Test'));
     userEvent.click(screen.getByRole('button', { name: 'Cancel Test' }));
 
-    controllerSection = (
-      await screen.findByRole('heading', { name: 'Accessible Controller' })
-    ).closest('section')!;
-    within(controllerSection).getByText('Test passed.');
-    within(controllerSection).getByText('Last tested at 11:23 AM');
+    screen.getByText('Test passed.');
+    screen.getByText('Last tested at 11:23 AM');
 
     unmount();
   });
@@ -302,15 +251,12 @@ describe('System Diagnostics screen: Accessible Controller section', () => {
     devices.accessibleController = undefined;
     const { unmount } = renderScreen({ devices });
 
-    const controllerSection = screen
-      .getByRole('heading', { name: 'Accessible Controller' })
-      .closest('section')!;
-    const connectionText = within(controllerSection).getByText(
+    const connectionText = screen.getByText(
       'No accessible controller connected.'
     );
     expectToHaveWarningIcon(connectionText);
     expect(
-      within(controllerSection).queryByText('Start Accessible Controller Test')
+      screen.queryByText('Start Accessible Controller Test')
     ).not.toBeInTheDocument();
 
     unmount();
@@ -326,10 +272,7 @@ describe('System Diagnostics screen: Accessible Controller section', () => {
       screen.getByRole('button', { name: 'Up Button is Not Working' })
     );
 
-    const controllerSection = (
-      await screen.findByRole('heading', { name: 'Accessible Controller' })
-    ).closest('section')!;
-    const testResultText = within(controllerSection).getByText(
+    const testResultText = screen.getByText(
       'Test failed: Up button is not working.'
     );
     expectToHaveWarningIcon(testResultText);

--- a/apps/mark/frontend/src/pages/diagnostics_screen.tsx
+++ b/apps/mark/frontend/src/pages/diagnostics_screen.tsx
@@ -299,30 +299,24 @@ export function DiagnosticsScreen({
         <Screen>
           <Main padded>
             <Prose compact maxWidth={false}>
+              <H1>System Diagnostics</H1>
               <P>
-                <Button variant="primary" onPress={onBackButtonPress}>
+                <Button variant="previousPrimary" onPress={onBackButtonPress}>
                   Back to Poll Worker Actions
                 </Button>
               </P>
-              <H1>System Diagnostics</H1>
               <span className="screen-reader-only">
                 To navigate through the available actions, use the down arrow.
               </span>
-              <section>
-                <H2>Computer</H2>
-                <ComputerStatus computer={devices.computer} />
-              </section>
-              <section>
-                <H2>Printer</H2>
-                <PrinterStatus hardware={hardware} />
-              </section>
-              <section>
-                <H2>Accessible Controller</H2>
-                <AccessibleControllerStatus
-                  accessibleController={devices.accessibleController}
-                  diagnosticResults={accessibleControllerDiagnosticResults}
-                />
-              </section>
+              <H2>Computer</H2>
+              <ComputerStatus computer={devices.computer} />
+              <H2>Printer</H2>
+              <PrinterStatus hardware={hardware} />
+              <H2>Accessible Controller</H2>
+              <AccessibleControllerStatus
+                accessibleController={devices.accessibleController}
+                diagnosticResults={accessibleControllerDiagnosticResults}
+              />
             </Prose>
           </Main>
         </Screen>

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -37,6 +37,9 @@ import {
   P,
   Caption,
   Font,
+  H3,
+  H4,
+  Icons,
 } from '@votingworks/ui';
 
 import {
@@ -636,7 +639,7 @@ export function PollWorkerScreen({
                 Poll Worker Actions
               </Font>
             </H1>
-            <H2>
+            <H3 as="h2">
               <NoWrap>
                 <Font weight="light">Ballots Printed:</Font>{' '}
                 {ballotsPrintedCount}
@@ -647,14 +650,14 @@ export function PollWorkerScreen({
                 <Font weight="light">Polls:</Font>{' '}
                 {getPollsStateName(pollsState)}
               </NoWrap>
-            </H2>
+            </H3>
             {canSelectBallotStyle && !isHidingSelectBallotStyle ? (
               <React.Fragment>
                 <VotingSession>
-                  <H1>Start a New Voting Session</H1>
+                  <H2>Start a New Voting Session</H2>
                   {appPrecinct.kind === 'AllPrecincts' && (
                     <React.Fragment>
-                      <H2>1. Select Voter’s Precinct</H2>
+                      <H4 as="h3">1. Select Voter’s Precinct</H4>
                       <ButtonList data-testid="precincts">
                         {election.precincts.map((precinct) => (
                           <Button
@@ -676,10 +679,10 @@ export function PollWorkerScreen({
                       </ButtonList>
                     </React.Fragment>
                   )}
-                  <H2>
+                  <H4 as="h3">
                     {appPrecinct.kind === 'AllPrecincts' ? '2. ' : ''}Select
                     Voter’s Ballot Style
-                  </H2>
+                  </H4>
                   {selectedCardlessVoterPrecinctId ? (
                     <ButtonList data-testid="ballot-styles">
                       {precinctBallotStyles.map((ballotStyle) => (
@@ -700,8 +703,8 @@ export function PollWorkerScreen({
                     </ButtonList>
                   ) : (
                     <P>
-                      Select the voter’s precinct above to view ballot styles
-                      for the precinct.
+                      <Icons.Info /> Select the voter’s precinct above to view
+                      ballot styles for the precinct.
                     </P>
                   )}
                 </VotingSession>

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -40,6 +40,7 @@ import {
   H3,
   H4,
   Icons,
+  FullScreenIconWrapper,
 } from '@votingworks/ui';
 
 import {
@@ -590,20 +591,29 @@ export function PollWorkerScreen({
       <Screen white>
         <Main centerChild>
           <Prose id="audiofocus">
-            <H1>
+            <FullScreenIconWrapper align="center" color="success">
+              <Icons.Done />
+            </FullScreenIconWrapper>
+            <H1 align="center">
               {`Voting Session Active: ${ballotStyleId} at ${precinct.name}`}
             </H1>
             <ol>
               <li>
-                Instruct the voter to press the{' '}
-                <Font weight="bold" noWrap>
-                  Start Voting
-                </Font>{' '}
-                button on the next screen.
+                <P>
+                  Instruct the voter to press the{' '}
+                  <Font weight="bold" noWrap>
+                    Start Voting
+                  </Font>{' '}
+                  button on the next screen.
+                </P>
               </li>
-              <li>Remove the poll worker card to continue.</li>
+              <li>
+                <P>Remove the poll worker card to continue.</P>
+              </li>
             </ol>
-            <HorizontalRule>or</HorizontalRule>
+            <P>
+              <HorizontalRule>or</HorizontalRule>
+            </P>
             <P align="center">Deactivate this voter session to start over.</P>
             <P align="center">
               <Button small onPress={resetCardlessVoterSession}>

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -417,10 +417,9 @@ function UpdatePollsDirectlyButton({
       <Button onPress={() => setIsConfirmationModalOpen(true)}>{action}</Button>
       {isConfirmationModalOpen && (
         <Modal
-          centerContent
+          title={`No ${reportTitle} on Card`}
           content={
-            <Prose textCenter id="modalaudiofocus">
-              <H1>No {reportTitle} on Card</H1>
+            <Prose id="modalaudiofocus">
               <P>{suggestVxScanText}</P>
             </Prose>
           }

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -719,7 +719,7 @@ export function PollWorkerScreen({
                   <React.Fragment>
                     <P>
                       <Button
-                        variant="primary"
+                        variant="previousPrimary"
                         onPress={() => setIsHidingSelectBallotStyle(false)}
                       >
                         Back to Ballot Style Selection

--- a/libs/ui/src/button_list.tsx
+++ b/libs/ui/src/button_list.tsx
@@ -10,6 +10,7 @@ export const ButtonList = styled.p`
   }
   & > button {
     margin-bottom: 0.5rem;
+    width: 100%;
     overflow: hidden;
   }
 `;


### PR DESCRIPTION
## Overview

Enabling the new themes locally and tweaking styling on each screen to fix anything that looks broken and make sure everything looks reasonable at the default text size on the ELO 15".

Starting with the official-facing screens in this PR - commits are organised according to screen/modal/screen variation.

## Demo Video or Screenshot
### Before/after screenshots with VVSG default color & size (commit order):
<img width="300" src="https://user-images.githubusercontent.com/264902/236013996-665ff35c-d4ac-42be-9616-f863d585fa37.png" /> <img width="300" src="https://user-images.githubusercontent.com/264902/236014029-e911c6ee-7454-4647-9d7c-21beec03fd09.png" />

<img width="300" src="https://user-images.githubusercontent.com/264902/236014214-130526af-56a1-4ffb-83a2-405633adeaf6.png" /> <img width="300" src="https://user-images.githubusercontent.com/264902/236014251-c180c5f9-f0c5-4b05-a7e6-34af8272e825.png" />

<img width="300" src="https://user-images.githubusercontent.com/264902/236014384-0a5de4fa-aede-4a82-bcc4-5d89a2079467.png "/> <img width="300" src="https://user-images.githubusercontent.com/264902/236014397-bdc97928-4694-4ae9-ab59-bafd0870dbd1.png" />

<img width="300" src="https://user-images.githubusercontent.com/264902/236014605-4ee5b26c-5ec7-4437-a41d-a3b4a370f61e.png" /> <img width="300" src="https://user-images.githubusercontent.com/264902/236014620-d5297b0c-e941-4106-89dd-e1793d1f7412.png" />

<img width="300" src="https://user-images.githubusercontent.com/264902/236014816-27c4f8aa-07f1-483d-a1ba-018b7bcd8bb4.png" /> <img width="300" src="https://user-images.githubusercontent.com/264902/236014822-dcc1bb20-cb95-4531-98dc-d929bb5701d8.png" />

<img width="300" src="https://user-images.githubusercontent.com/264902/236014923-200ccfb1-1cb7-4e8d-b584-a30e64f9e40e.png" /> <img width="300" src="https://user-images.githubusercontent.com/264902/236014937-07344f4c-20e8-4d56-930e-0dd8c53518bf.png" />

## Testing Plan
- Visual testing
- Updating any affected tests as I go

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
