### PR TITLE
feat(election-manager): number the CVR files.

### DIFF
--- a/frontends/election-manager/src/screens/tally_screen.tsx
+++ b/frontends/election-manager/src/screens/tally_screen.tsx
@@ -163,6 +163,9 @@ export function TallyScreen(): JSX.Element {
               {hasAnyFiles ? (
                 <React.Fragment>
                   <tr>
+                    <TD as="th" narrow nowrap textAlign="right">
+                      #
+                    </TD>
                     <TD as="th" narrow nowrap>
                       Created At
                     </TD>
@@ -177,14 +180,20 @@ export function TallyScreen(): JSX.Element {
                     </TD>
                   </tr>
                   {castVoteRecordFileList.map(
-                    ({
-                      name,
-                      exportTimestamp,
-                      importedCvrCount,
-                      scannerIds,
-                      precinctIds,
-                    }) => (
+                    (
+                      {
+                        name,
+                        exportTimestamp,
+                        importedCvrCount,
+                        scannerIds,
+                        precinctIds,
+                      },
+                      cvrFileIndex
+                    ) => (
                       <tr key={name}>
+                        <TD narrow nowrap textAlign="right">
+                          {cvrFileIndex + 1}.
+                        </TD>
                         <TD narrow nowrap>
                           {moment(exportTimestamp).format(
                             'MM/DD/YYYY hh:mm:ss A'
@@ -200,6 +209,7 @@ export function TallyScreen(): JSX.Element {
                   )}
                   {externalTallyRows}
                   <tr>
+                    <TD />
                     <TD as="th" narrow nowrap>
                       Total CVRs Count
                     </TD>


### PR DESCRIPTION
## Overview

When jurisdictions import CVRs from multiple precinct scanners, having a quick count of how many CVR files have been loaded makes it very easy to know how many you've got left to load. We've seen this in the field. This just adds numbering to the list of CVR files in election-manager.

I'll also PR this into `main` separately.

## Demo Video or Screenshot

Before:
<img width="618" alt="Screenshot 2023-05-09 at 12 08 12 PM" src="https://github.com/votingworks/vxsuite/assets/18057/e2cde310-6a85-4da2-8934-dd55953ee6cd">


After:
<img width="752" alt="Screenshot 2023-05-09 at 12 07 05 PM" src="https://github.com/votingworks/vxsuite/assets/18057/44848875-92cd-42f6-bd3d-156c0622151c">


## Testing Plan

Manually tested.

## Checklist

~- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ X ] I have added a screenshot and/or video to this PR to demo the change
- [ X ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
