### PR TITLE
feat(admin): number the CVR files in the tally screen.

### DIFF
--- a/apps/admin/frontend/src/screens/tally_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally_screen.tsx
@@ -116,6 +116,9 @@ export function TallyScreen(): JSX.Element | null {
               {hasAnyFiles ? (
                 <React.Fragment>
                   <tr>
+                    <TD as="th" narrow nowrap textAlign="right">
+                      #
+                    </TD>
                     <TD as="th" narrow nowrap>
                       Created At
                     </TD>
@@ -130,14 +133,20 @@ export function TallyScreen(): JSX.Element | null {
                     </TD>
                   </tr>
                   {castVoteRecordFileList.map(
-                    ({
-                      filename,
-                      exportTimestamp,
-                      numCvrsImported,
-                      scannerIds,
-                      precinctIds,
-                    }) => (
+                    (
+                      {
+                        filename,
+                        exportTimestamp,
+                        numCvrsImported,
+                        scannerIds,
+                        precinctIds,
+                      },
+                      cvrFileIndex
+                    ) => (
                       <tr key={filename}>
+                        <TD narrow nowrap textAlign="right">
+                          {cvrFileIndex + 1}.
+                        </TD>
                         <TD narrow nowrap>
                           {moment(exportTimestamp).format(
                             'MM/DD/YYYY hh:mm:ss A'
@@ -153,6 +162,7 @@ export function TallyScreen(): JSX.Element | null {
                   )}
                   {fullElectionManualTally ? (
                     <tr key="manual-data">
+                      <TD />
                       <TD narrow nowrap>
                         {moment(
                           fullElectionManualTally.timestampCreated
@@ -175,6 +185,7 @@ export function TallyScreen(): JSX.Element | null {
                     </tr>
                   ) : null}
                   <tr>
+                    <TD />
                     <TD as="th" narrow nowrap>
                       Total CVRs Count
                     </TD>
@@ -194,7 +205,7 @@ export function TallyScreen(): JSX.Element | null {
                 </React.Fragment>
               ) : (
                 <tr>
-                  <TD colSpan={2}>
+                  <TD colSpan={3}>
                     <em>No CVR files loaded.</em>
                   </TD>
                 </tr>


### PR DESCRIPTION
## Overview

Apply the same patch as in #3426, this time to `main`. Same reasons.

## Demo Video or Screenshot

<img width="649" alt="Screenshot 2023-05-09 at 5 03 27 PM" src="https://github.com/votingworks/vxsuite/assets/18057/e8b43c74-9ba8-452d-9c2f-69c7db443128">

## Testing Plan

tested manually, looks good.

## Checklist

~- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ X ] I have added a screenshot and/or video to this PR to demo the change
- [ X ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
