### PR TITLE
Improve interpreter timing mark detection

### DIFF
--- a/libs/ballot-interpreter-nh/src/metadata.rs
+++ b/libs/ballot-interpreter-nh/src/metadata.rs
@@ -195,19 +195,22 @@ pub fn compute_bits_from_bottom_timing_marks(
 
     // The first and last timing marks must be present.
     match (bottom_timing_marks.first(), bottom_timing_marks.last()) {
-        (Some(Some(_)), Some(Some(_))) => {}
-        _ => {
+        (Some(Some(_)), Some(Some(_))) => {
+            // both timing marks are present
+        }
+        (Some(None), Some(None)) => {
             return Err(BallotPageMetadataError::InvalidTimingMarkCount {
                 expected: 2,
-                actual: vec![
-                    bottom_timing_marks.first().unwrap(),
-                    bottom_timing_marks.last().unwrap(),
-                ]
-                .iter()
-                .filter(|&mark| mark.is_some())
-                .count(),
+                actual: 0,
             });
         }
+        (Some(None), _) | (_, Some(None)) => {
+            return Err(BallotPageMetadataError::InvalidTimingMarkCount {
+                expected: 2,
+                actual: 1,
+            });
+        }
+        _ => unreachable!(),
     }
 
     let bits: Vec<bool> = bottom_timing_marks

--- a/libs/ballot-interpreter-nh/src/metadata.rs
+++ b/libs/ballot-interpreter-nh/src/metadata.rs
@@ -199,10 +199,13 @@ pub fn compute_bits_from_bottom_timing_marks(
         _ => {
             return Err(BallotPageMetadataError::InvalidTimingMarkCount {
                 expected: 2,
-                actual: bottom_timing_marks
-                    .iter()
-                    .filter(|&mark| mark.is_some())
-                    .count(),
+                actual: vec![
+                    bottom_timing_marks.first().unwrap(),
+                    bottom_timing_marks.last().unwrap(),
+                ]
+                .iter()
+                .filter(|&mark| mark.is_some())
+                .count(),
             });
         }
     }

--- a/libs/ballot-interpreter-nh/src/timing_marks.rs
+++ b/libs/ballot-interpreter-nh/src/timing_marks.rs
@@ -696,18 +696,21 @@ pub fn find_complete_timing_marks_from_partial_timing_marks(
     let left_line = &partial_timing_marks.left_rects;
     let right_line = &partial_timing_marks.right_rects;
 
-    let mut all_distances = vec![];
-    all_distances.append(&mut distances_between_rects(top_line));
-    all_distances.append(&mut distances_between_rects(bottom_line));
-    all_distances.append(&mut distances_between_rects(left_line));
-    all_distances.append(&mut distances_between_rects(right_line));
-    all_distances.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mut horizontal_distances = vec![];
+    horizontal_distances.append(&mut distances_between_rects(top_line));
+    horizontal_distances.append(&mut distances_between_rects(bottom_line));
+    horizontal_distances.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mut vertical_distances = vec![];
+    vertical_distances.append(&mut distances_between_rects(left_line));
+    vertical_distances.append(&mut distances_between_rects(right_line));
+    vertical_distances.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
-    if all_distances.is_empty() {
+    if horizontal_distances.is_empty() || vertical_distances.is_empty() {
         return None;
     }
 
-    let median_distance = all_distances[all_distances.len() / 2];
+    let median_horizontal_distance = horizontal_distances[horizontal_distances.len() / 2];
+    let median_vertical_distance = vertical_distances[vertical_distances.len() / 2];
 
     let top_line = infer_missing_timing_marks_on_segment(
         top_line,
@@ -715,7 +718,7 @@ pub fn find_complete_timing_marks_from_partial_timing_marks(
             partial_timing_marks.top_left_corner,
             partial_timing_marks.top_right_corner,
         ),
-        median_distance,
+        median_horizontal_distance,
         geometry.grid_size.width,
         geometry,
     );
@@ -726,7 +729,7 @@ pub fn find_complete_timing_marks_from_partial_timing_marks(
             partial_timing_marks.bottom_left_corner,
             partial_timing_marks.bottom_right_corner,
         ),
-        median_distance,
+        median_horizontal_distance,
         geometry.grid_size.width,
         geometry,
     );
@@ -737,7 +740,7 @@ pub fn find_complete_timing_marks_from_partial_timing_marks(
             partial_timing_marks.top_left_corner,
             partial_timing_marks.bottom_left_corner,
         ),
-        median_distance,
+        median_vertical_distance,
         geometry.grid_size.height,
         geometry,
     );
@@ -748,7 +751,7 @@ pub fn find_complete_timing_marks_from_partial_timing_marks(
             partial_timing_marks.top_right_corner,
             partial_timing_marks.bottom_right_corner,
         ),
-        median_distance,
+        median_vertical_distance,
         geometry.grid_size.height,
         geometry,
     );


### PR DESCRIPTION
## Overview

When exploring designing our own ballots from scratch, I ran into some small snags with the interpreter:
- A confusing error message when the corner timing marks couldn't be found
- An expectation that the horizontal spacing between timing marks is equivalent to the vertical spacing

I made attempts to fix both of these in a way that I think is a net improvement, but would like to hear if there's a good reason things were set up that way before.

## Demo Video or Screenshot
N/A

## Testing Plan
Manually tested on the ballots I've been designing, relying on existing tests to prevent regressions.

(Side note: now that we're investing in this interpreter, it might be good to think about beefing up the testing so that it's easy to add new tests or change tests for situations like this)

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
