### PR TITLE
Change How We Count Overvotes in CDF CVRs

### DIFF
--- a/libs/backend/src/scan/cast_vote_records/build_cast_vote_record.test.ts
+++ b/libs/backend/src/scan/cast_vote_records/build_cast_vote_record.test.ts
@@ -316,7 +316,7 @@ describe('buildCVRContestsFromVotes', () => {
     expect(result).toHaveLength(1);
     const cvrContest = result[0];
     expect(cvrContest).toMatchObject({
-      Overvotes: 1,
+      Overvotes: 3,
       Undervotes: 0,
       Status: expect.arrayContaining([
         CVR.ContestStatus.Overvoted,

--- a/libs/backend/src/scan/cast_vote_records/build_cast_vote_record.ts
+++ b/libs/backend/src/scan/cast_vote_records/build_cast_vote_record.ts
@@ -56,7 +56,7 @@ function buildCVRBallotMeasureContest({
   return {
     '@type': 'CVR.CVRContest',
     ContestId: contest.id,
-    Overvotes: Math.max(vote.length - 1, 0),
+    Overvotes: vote.length > 1 ? 1 : 0,
     Undervotes: Math.max(1 - vote.length, 0),
     Status: overvoted
       ? [CVR.ContestStatus.Overvoted, CVR.ContestStatus.InvalidatedRules]
@@ -211,7 +211,7 @@ function buildCVRCandidateContest({
   return {
     '@type': 'CVR.CVRContest',
     ContestId: contest.id,
-    Overvotes: Math.max(vote.length - contest.seats, 0), // VVSG 2.0 1.1.5-E.2
+    Overvotes: vote.length > contest.seats ? contest.seats : 0, // VVSG 2.0 1.1.5-E.2
     Undervotes: Math.max(contest.seats - vote.length, 0), // VVSG 2.0 1.1.5-E.2
     WriteIns: numWriteIns, // VVSG 2.0 1.1.5-E.3
     Status: statuses.length > 0 ? statuses : undefined,

--- a/libs/fixtures/data/electionGridLayoutNewHampshireAmherst/cvr-files/standard/cast-vote-record-report.json
+++ b/libs/fixtures/data/electionGridLayoutNewHampshireAmherst/cvr-files/standard/cast-vote-record-report.json
@@ -3,7 +3,7 @@
   "Version": "1.0.0",
   "ReportType": ["originating-device-export", "other"],
   "OtherReportType": "test",
-  "GeneratedDate": "2023-05-03T19:26:52.584Z",
+  "GeneratedDate": "2023-05-10T19:36:40.507Z",
   "ReportGeneratingDeviceIds": ["VX-00-000"],
   "ReportingDevice": [
     {
@@ -607,7 +607,7 @@
       "@id": "9822c71014",
       "BatchLabel": "9822c71014",
       "SequenceId": 1,
-      "StartTime": "2023-05-03T19:26:52.584Z",
+      "StartTime": "2023-05-10T19:36:40.507Z",
       "NumberSheets": 184,
       "CreatingDeviceId": "VX-00-000"
     }
@@ -1334,7 +1334,7 @@
             {
               "@type": "CVR.CVRContest",
               "ContestId": "Governor-061a401b",
-              "Overvotes": 2,
+              "Overvotes": 1,
               "Undervotes": 0,
               "WriteIns": 0,
               "Status": ["overvoted", "invalidated-rules"],
@@ -1419,7 +1419,7 @@
             {
               "@type": "CVR.CVRContest",
               "ContestId": "Representative-in-Congress-24683b44",
-              "Overvotes": 2,
+              "Overvotes": 1,
               "Undervotes": 0,
               "WriteIns": 0,
               "Status": ["overvoted", "invalidated-rules"],
@@ -1570,7 +1570,7 @@
             {
               "@type": "CVR.CVRContest",
               "ContestId": "State-Representative-Hillsborough-District-37-f3bde894",
-              "Overvotes": 2,
+              "Overvotes": 1,
               "Undervotes": 0,
               "WriteIns": 0,
               "Status": ["overvoted", "invalidated-rules"],
@@ -1993,7 +1993,7 @@
             {
               "@type": "CVR.CVRContest",
               "ContestId": "State-Representatives-Hillsborough-District-34-b1012d38",
-              "Overvotes": 1,
+              "Overvotes": 3,
               "Undervotes": 0,
               "WriteIns": 0,
               "Status": ["overvoted", "invalidated-rules"],
@@ -2371,7 +2371,7 @@
             {
               "@type": "CVR.CVRContest",
               "ContestId": "State-Representatives-Hillsborough-District-34-b1012d38",
-              "Overvotes": 2,
+              "Overvotes": 3,
               "Undervotes": 0,
               "WriteIns": 0,
               "Status": ["overvoted", "invalidated-rules"],
@@ -3142,7 +3142,7 @@
             {
               "@type": "CVR.CVRContest",
               "ContestId": "State-Representatives-Hillsborough-District-34-b1012d38",
-              "Overvotes": 4,
+              "Overvotes": 3,
               "Undervotes": 0,
               "WriteIns": 0,
               "Status": ["overvoted", "invalidated-rules"],
@@ -3550,7 +3550,7 @@
             {
               "@type": "CVR.CVRContest",
               "ContestId": "State-Representatives-Hillsborough-District-34-b1012d38",
-              "Overvotes": 5,
+              "Overvotes": 3,
               "Undervotes": 0,
               "WriteIns": 0,
               "Status": ["overvoted", "invalidated-rules"],
@@ -4005,8 +4005,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -4361,8 +4361,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -4717,8 +4717,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -5073,8 +5073,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -5429,8 +5429,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -5785,8 +5785,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -6141,8 +6141,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -6497,8 +6497,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -6853,8 +6853,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -7209,8 +7209,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -7565,8 +7565,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -7921,8 +7921,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -8277,8 +8277,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -8633,8 +8633,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -8989,8 +8989,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -9345,8 +9345,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -9701,8 +9701,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -10057,8 +10057,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -10413,8 +10413,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -10769,8 +10769,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -11125,8 +11125,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -11481,8 +11481,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -11837,8 +11837,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -12193,8 +12193,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -12549,8 +12549,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -12905,8 +12905,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -13261,8 +13261,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -13617,8 +13617,8 @@
                 },
                 {
                   "@type": "CVR.CVRContestSelection",
-                  "ContestSelectionId": "write-in-2",
-                  "OptionPosition": 10,
+                  "ContestSelectionId": "write-in-0",
+                  "OptionPosition": 8,
                   "Status": ["needs-adjudication"],
                   "SelectionPosition": [
                     {
@@ -33628,7 +33628,7 @@
             {
               "@type": "CVR.CVRContest",
               "ContestId": "Governor-061a401b",
-              "Overvotes": 2,
+              "Overvotes": 1,
               "Undervotes": 0,
               "WriteIns": 0,
               "Status": ["overvoted", "invalidated-rules"],
@@ -33713,7 +33713,7 @@
             {
               "@type": "CVR.CVRContest",
               "ContestId": "Representative-in-Congress-24683b44",
-              "Overvotes": 2,
+              "Overvotes": 1,
               "Undervotes": 0,
               "WriteIns": 0,
               "Status": ["overvoted", "invalidated-rules"],
@@ -33864,7 +33864,7 @@
             {
               "@type": "CVR.CVRContest",
               "ContestId": "State-Representative-Hillsborough-District-37-f3bde894",
-              "Overvotes": 2,
+              "Overvotes": 1,
               "Undervotes": 0,
               "WriteIns": 0,
               "Status": ["overvoted", "invalidated-rules"],
@@ -34287,7 +34287,7 @@
             {
               "@type": "CVR.CVRContest",
               "ContestId": "State-Representatives-Hillsborough-District-34-b1012d38",
-              "Overvotes": 1,
+              "Overvotes": 3,
               "Undervotes": 0,
               "WriteIns": 0,
               "Status": ["overvoted", "invalidated-rules"],
@@ -34665,7 +34665,7 @@
             {
               "@type": "CVR.CVRContest",
               "ContestId": "State-Representatives-Hillsborough-District-34-b1012d38",
-              "Overvotes": 2,
+              "Overvotes": 3,
               "Undervotes": 0,
               "WriteIns": 0,
               "Status": ["overvoted", "invalidated-rules"],
@@ -35436,7 +35436,7 @@
             {
               "@type": "CVR.CVRContest",
               "ContestId": "State-Representatives-Hillsborough-District-34-b1012d38",
-              "Overvotes": 4,
+              "Overvotes": 3,
               "Undervotes": 0,
               "WriteIns": 0,
               "Status": ["overvoted", "invalidated-rules"],
@@ -35844,7 +35844,7 @@
             {
               "@type": "CVR.CVRContest",
               "ContestId": "State-Representatives-Hillsborough-District-34-b1012d38",
-              "Overvotes": 5,
+              "Overvotes": 3,
               "Undervotes": 0,
               "WriteIns": 0,
               "Status": ["overvoted", "invalidated-rules"],

--- a/libs/fixtures/data/electionMinimalExhaustiveSample/cvr-files/standard/cast-vote-record-report.json
+++ b/libs/fixtures/data/electionMinimalExhaustiveSample/cvr-files/standard/cast-vote-record-report.json
@@ -3,7 +3,7 @@
   "Version": "1.0.0",
   "ReportType": ["originating-device-export", "other"],
   "OtherReportType": "test",
-  "GeneratedDate": "2023-05-03T19:23:41.820Z",
+  "GeneratedDate": "2023-05-10T19:35:12.957Z",
   "ReportGeneratingDeviceIds": ["VX-00-000"],
   "ReportingDevice": [
     {
@@ -265,7 +265,7 @@
       "@id": "9822c71014",
       "BatchLabel": "9822c71014",
       "SequenceId": 1,
-      "StartTime": "2023-05-03T19:23:41.820Z",
+      "StartTime": "2023-05-10T19:35:12.957Z",
       "NumberSheets": 112,
       "CreatingDeviceId": "VX-00-000"
     }
@@ -540,7 +540,7 @@
             {
               "@type": "CVR.CVRContest",
               "ContestId": "best-animal-mammal",
-              "Overvotes": 2,
+              "Overvotes": 1,
               "Undervotes": 0,
               "WriteIns": 0,
               "Status": ["overvoted", "invalidated-rules"],
@@ -791,7 +791,7 @@
             {
               "@type": "CVR.CVRContest",
               "ContestId": "zoo-council-mammal",
-              "Overvotes": 1,
+              "Overvotes": 3,
               "Undervotes": 0,
               "WriteIns": 0,
               "Status": ["overvoted", "invalidated-rules"],
@@ -2335,7 +2335,7 @@
             {
               "@type": "CVR.CVRContest",
               "ContestId": "best-animal-mammal",
-              "Overvotes": 2,
+              "Overvotes": 1,
               "Undervotes": 0,
               "WriteIns": 0,
               "Status": ["overvoted", "invalidated-rules"],
@@ -2586,7 +2586,7 @@
             {
               "@type": "CVR.CVRContest",
               "ContestId": "zoo-council-mammal",
-              "Overvotes": 1,
+              "Overvotes": 3,
               "Undervotes": 0,
               "WriteIns": 0,
               "Status": ["overvoted", "invalidated-rules"],
@@ -4130,7 +4130,7 @@
             {
               "@type": "CVR.CVRContest",
               "ContestId": "best-animal-mammal",
-              "Overvotes": 2,
+              "Overvotes": 1,
               "Undervotes": 0,
               "WriteIns": 0,
               "Status": ["overvoted", "invalidated-rules"],
@@ -4381,7 +4381,7 @@
             {
               "@type": "CVR.CVRContest",
               "ContestId": "zoo-council-mammal",
-              "Overvotes": 1,
+              "Overvotes": 3,
               "Undervotes": 0,
               "WriteIns": 0,
               "Status": ["overvoted", "invalidated-rules"],
@@ -5925,7 +5925,7 @@
             {
               "@type": "CVR.CVRContest",
               "ContestId": "best-animal-mammal",
-              "Overvotes": 2,
+              "Overvotes": 1,
               "Undervotes": 0,
               "WriteIns": 0,
               "Status": ["overvoted", "invalidated-rules"],
@@ -6176,7 +6176,7 @@
             {
               "@type": "CVR.CVRContest",
               "ContestId": "zoo-council-mammal",
-              "Overvotes": 1,
+              "Overvotes": 3,
               "Undervotes": 0,
               "WriteIns": 0,
               "Status": ["overvoted", "invalidated-rules"],
@@ -7742,7 +7742,7 @@
             {
               "@type": "CVR.CVRContest",
               "ContestId": "aquarium-council-fish",
-              "Overvotes": 1,
+              "Overvotes": 2,
               "Undervotes": 0,
               "WriteIns": 0,
               "Status": ["overvoted", "invalidated-rules"],
@@ -9383,7 +9383,7 @@
             {
               "@type": "CVR.CVRContest",
               "ContestId": "aquarium-council-fish",
-              "Overvotes": 1,
+              "Overvotes": 2,
               "Undervotes": 0,
               "WriteIns": 0,
               "Status": ["overvoted", "invalidated-rules"],
@@ -11024,7 +11024,7 @@
             {
               "@type": "CVR.CVRContest",
               "ContestId": "aquarium-council-fish",
-              "Overvotes": 1,
+              "Overvotes": 2,
               "Undervotes": 0,
               "WriteIns": 0,
               "Status": ["overvoted", "invalidated-rules"],
@@ -12665,7 +12665,7 @@
             {
               "@type": "CVR.CVRContest",
               "ContestId": "aquarium-council-fish",
-              "Overvotes": 1,
+              "Overvotes": 2,
               "Undervotes": 0,
               "WriteIns": 0,
               "Status": ["overvoted", "invalidated-rules"],


### PR DESCRIPTION
Makes the `Overvotes` count in our CVRs consistent with a) our interpretation of the CDF spec and b) the way we count overvotes when tallying.

