### PR TITLE
[VxMark] VVSG Design Updates for Write-In Modal

### DIFF
--- a/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
@@ -506,22 +506,6 @@ exports[`Single Seat Contest with Write In 1`] = `
 
 }
 
-@media (min-width:480px) {
-
-}
-
-@media (min-width:480px) {
-
-}
-
-@media (min-width:480px) {
-
-}
-
-@media (min-width:850px) {
-
-}
-
 @media print {
 
 }

--- a/apps/mark/frontend/src/app_contest_write_in.test.tsx
+++ b/apps/mark/frontend/src/app_contest_write_in.test.tsx
@@ -106,7 +106,7 @@ it('Single Seat Contest with Write In', async () => {
   fireEvent.click(
     screen.getByText('add write-in candidate').closest('button')!
   );
-  expect(screen.getByText('Write-In Candidate')).toBeTruthy();
+  screen.getByText(`Write-In: ${singleSeatContestWithWriteIn.title}`);
   // Capture styles of Single Candidate Contest
   expect(container.firstChild).toMatchSnapshot();
 
@@ -114,7 +114,7 @@ it('Single Seat Contest with Write In', async () => {
   fireEvent.click(getWithinKeyboard('B'));
   fireEvent.click(getWithinKeyboard('O'));
   fireEvent.click(getWithinKeyboard('V'));
-  fireEvent.click(getWithinKeyboard('⌫ delete'));
+  fireEvent.click(getWithinKeyboard('delete'));
   fireEvent.click(getWithinKeyboard('B'));
   fireEvent.click(screen.getByText('Accept'));
   advanceTimers();

--- a/apps/mark/frontend/src/components/candidate_contest.test.tsx
+++ b/apps/mark/frontend/src/components/candidate_contest.test.tsx
@@ -4,7 +4,7 @@ import { CandidateContest as CandidateContestInterface } from '@votingworks/type
 import { electionSampleDefinition } from '@votingworks/fixtures';
 
 import { act } from 'react-dom/test-utils';
-import { fireEvent, screen } from '../../test/react_testing_library';
+import { fireEvent, screen, within } from '../../test/react_testing_library';
 import { render as renderWithBallotContext } from '../../test/test_utils';
 import { CandidateContest } from './candidate_contest';
 
@@ -182,10 +182,18 @@ describe('supports write-in candidates', () => {
     fireEvent.click(
       screen.getByText('add write-in candidate').closest('button')!
     );
-    screen.getByText('Write-In Candidate');
+
+    const modal = within(screen.getByRole('alertdialog'));
+
+    modal.getByText(`Write-In: ${candidateContestWithWriteIns.title}`);
+    modal.getByText(/40 characters remaining/);
+
     typeKeysInVirtualKeyboard('LIZARD PEOPLE');
-    fireEvent.click(screen.getByText('Accept'));
-    expect(screen.queryByText('Write-In Candidate')).toBeFalsy();
+
+    modal.getByText(/27 characters remaining/);
+
+    fireEvent.click(modal.getByText('Accept'));
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
 
     expect(updateVote).toHaveBeenCalledWith(candidateContestWithWriteIns.id, [
       { id: 'write-in-lizardPeople', isWriteIn: true, name: 'LIZARD PEOPLE' },
@@ -212,11 +220,14 @@ describe('supports write-in candidates', () => {
     fireEvent.click(
       screen.getByText('add write-in candidate').closest('button')!
     );
-    screen.getByText('Write-In Candidate');
+
+    const modal = within(screen.getByRole('alertdialog'));
+
+    modal.getByText(`Write-In: ${candidateContestWithWriteIns.title}`);
     typeKeysInVirtualKeyboard('JACOB JOHANSON JINGLEHEIMMER SCHMIDTT');
-    screen.getByText('You have entered 37 of maximum 40 characters.');
-    fireEvent.click(screen.getByText('Cancel'));
-    expect(screen.queryByText('Write-In Candidate')).toBeFalsy();
+    modal.getByText(/3 characters remaining/);
+    fireEvent.click(modal.getByText('Cancel'));
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
 
     act(() => {
       jest.runOnlyPendingTimers();
@@ -239,17 +250,20 @@ describe('supports write-in candidates', () => {
     fireEvent.click(
       screen.getByText('add write-in candidate').closest('button')!
     );
-    screen.getByText('Write-In Candidate');
+
+    const modal = within(screen.getByRole('alertdialog'));
+
+    modal.getByText(`Write-In: ${candidateContestWithWriteIns.title}`);
     const writeInCandidate =
       "JACOB JOHANSON JINGLEHEIMMER SCHMIDTT, THAT'S MY NAME TOO";
     typeKeysInVirtualKeyboard(writeInCandidate);
-    screen.getByText('You have entered 40 of maximum 40 characters.');
+    modal.getByText(/0 characters remaining/);
 
     expect(
-      screen.getByText('space').closest('button')!.hasAttribute('disabled')
+      modal.getByText('space').closest('button')!.hasAttribute('disabled')
     ).toEqual(true);
-    fireEvent.click(screen.getByText('Accept'));
-    expect(screen.queryByText('Write-In Candidate')).toBeFalsy();
+    fireEvent.click(modal.getByText('Accept'));
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
 
     expect(updateVote).toHaveBeenCalledWith(candidateContestWithWriteIns.id, [
       {

--- a/apps/mark/frontend/src/components/candidate_contest.tsx
+++ b/apps/mark/frontend/src/components/candidate_contest.tsx
@@ -27,6 +27,7 @@ import {
   P,
   Font,
   Caption,
+  VirtualKeyboard,
 } from '@votingworks/ui';
 import { assert } from '@votingworks/basics';
 
@@ -38,7 +39,6 @@ import { BallotContext } from '../contexts/ballot_context';
 
 import { Blink } from './animations';
 import { WRITE_IN_CANDIDATE_MAX_LENGTH } from '../config/globals';
-import { VirtualKeyboard } from './virtual_keyboard';
 import {
   ContentHeader,
   VariableContentContainer,

--- a/apps/mark/frontend/src/components/candidate_contest.tsx
+++ b/apps/mark/frontend/src/components/candidate_contest.tsx
@@ -18,26 +18,25 @@ import {
 import {
   Button,
   ContestChoiceButton,
-  H1,
-  H3,
   Icons,
   Main,
   Modal,
   Prose,
   P,
   Font,
-  Caption,
   VirtualKeyboard,
+  Caption,
+  TouchTextInput,
 } from '@votingworks/ui';
 import { assert } from '@votingworks/basics';
 
+import pluralize from 'pluralize';
 import { stripQuotes } from '../utils/strip_quotes';
 
 import { ScrollDirections, UpdateVoteFunction } from '../config/types';
 
 import { BallotContext } from '../contexts/ballot_context';
 
-import { Blink } from './animations';
 import { WRITE_IN_CANDIDATE_MAX_LENGTH } from '../config/globals';
 import {
   ContentHeader,
@@ -50,39 +49,7 @@ import {
 import { useCurrentTextSizePx } from '../hooks/use_current_text_size';
 import { ContestTitle } from './contest_title';
 
-const WriteInModalContent = styled.div`
-  margin: -0.5rem;
-  max-width: 80vw;
-`;
-
-const WriteInCandidateForm = styled.div`
-  margin-top: 1rem;
-  border-radius: 0.25rem;
-  background-color: rgb(211, 211, 211);
-  padding: 0.25rem;
-`;
-
-const WriteInCandidateFieldSet = styled.div`
-  margin: 0 0.5rem 0.5rem;
-`;
-
-const WriteInCandidateName = styled.div`
-  border: 1px solid rgb(169, 169, 169);
-  box-shadow: 0 0 3px -1px rgba(0, 0, 0, 0.3);
-  background: #ffffff;
-  width: 100%;
-  padding: 1rem;
-  font-size: 1.5rem;
-`;
-
-const WriteInCandidateCursor = styled(Blink)`
-  display: inline-block;
-  position: relative;
-  top: 3px;
-  margin-left: 0.1rem;
-  border-left: 0.15rem solid #000000;
-  height: 1.3rem;
-`;
+const WriteInModalContent = styled.div``;
 
 interface Props {
   contest: CandidateContestInterface;
@@ -247,23 +214,24 @@ export function CandidateContest({
 
   function onKeyboardInput(key: string) {
     setWriteInCandidateName((prevName) => {
-      let newName = prevName;
-      if (key === 'space') {
-        newName += ' ';
-      } else if (key === '⌫ delete') {
-        newName = newName.slice(0, -1);
-      } else {
-        newName += key;
-      }
-      return newName.slice(0, WRITE_IN_CANDIDATE_MAX_LENGTH);
+      return (prevName + key)
+        .trimStart()
+        .replace(/\s+/g, ' ')
+        .slice(0, WRITE_IN_CANDIDATE_MAX_LENGTH);
     });
   }
 
-  function keyDisabled(key: string) {
-    return (
-      writeInCandidateName.length >= WRITE_IN_CANDIDATE_MAX_LENGTH &&
-      key !== '⌫ delete'
-    );
+  function onKeyboardBackspace() {
+    setWriteInCandidateName((prevName) => {
+      return prevName.slice(0, Math.max(0, prevName.length - 1));
+    });
+  }
+
+  const writeInCharsRemaining =
+    WRITE_IN_CANDIDATE_MAX_LENGTH - writeInCandidateName.length;
+
+  function keyDisabled() {
+    return writeInCharsRemaining === 0;
   }
 
   /* istanbul ignore next: Tested by Cypress */
@@ -481,47 +449,43 @@ export function CandidateContest({
           }
         />
       )}
+      {/* TODO: This should really be broken out into separate components. */}
       {writeInCandidateModalIsOpen && (
         <Modal
           ariaLabel=""
+          title={`Write-In: ${contest.title}`}
           content={
             <WriteInModalContent>
               <Prose id="modalaudiofocus" maxWidth={false}>
-                <H1 aria-label="Write-In Candidate.">Write-In Candidate</H1>
-                <P aria-label="Enter the name of a person who is not on the ballot. Use the up and down buttons to navigate between the letters of a standard keyboard. Use the select button to select the current letter.">
-                  Enter the name of a person who is{' '}
-                  <Font weight="bold">not</Font> on the ballot.
+                <P>
+                  <Caption aria-label="Enter the name of a person who is not on the ballot. Use the up and down buttons to navigate between the letters of a standard keyboard. Use the select button to select the current letter.">
+                    <Icons.Info /> Enter the name of a person who is{' '}
+                    <Font weight="bold">not</Font> on the ballot:
+                  </Caption>
                 </P>
-                {writeInCandidateName.length >
-                  WRITE_IN_CANDIDATE_MAX_LENGTH - 5 && (
-                  <P color="danger">
-                    <Icons.Danger /> <Font>Note:</Font> You have entered{' '}
-                    {writeInCandidateName.length} of maximum{' '}
-                    {WRITE_IN_CANDIDATE_MAX_LENGTH} characters.
-                  </P>
-                )}
               </Prose>
-              <WriteInCandidateForm>
-                <WriteInCandidateFieldSet>
-                  <Prose>
-                    <H3>{contest.title} (write-in)</H3>
-                  </Prose>
-                  <WriteInCandidateName>
-                    {writeInCandidateName}
-                    <WriteInCandidateCursor />
-                  </WriteInCandidateName>
-                </WriteInCandidateFieldSet>
-                <VirtualKeyboard
-                  onKeyPress={onKeyboardInput}
-                  keyDisabled={keyDisabled}
-                />
-              </WriteInCandidateForm>
+              <TouchTextInput value={writeInCandidateName} />
+              <P
+                align="right"
+                color={writeInCharsRemaining ? 'default' : 'warning'}
+              >
+                <Caption>
+                  {writeInCharsRemaining === 0 && <Icons.Warning />}{' '}
+                  {writeInCharsRemaining}{' '}
+                  {pluralize('character', writeInCharsRemaining)} remaining
+                </Caption>
+              </P>
+              <VirtualKeyboard
+                onBackspace={onKeyboardBackspace}
+                onKeyPress={onKeyboardInput}
+                keyDisabled={keyDisabled}
+              />
             </WriteInModalContent>
           }
           actions={
             <React.Fragment>
               <Button
-                variant="primary"
+                variant="done"
                 onPress={addWriteInCandidate}
                 disabled={
                   normalizeCandidateName(writeInCandidateName).length === 0

--- a/libs/ui/jest.config.js
+++ b/libs/ui/jest.config.js
@@ -19,6 +19,7 @@ module.exports = {
     'src/printing_ballot_image.tsx',
     'src/rotate_card_image.tsx',
     'src/svg.tsx',
+    'src/touch_text_input.tsx',
     'src/verify_ballot_image.tsx',
     'src/voter_contest_summary.tsx',
   ],

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -89,4 +89,5 @@ export * from './unconfigured_election_screen';
 export * from './usb_drive';
 export * from './power_down_button';
 export * from './verify_ballot_image';
+export * from './virtual_keyboard';
 export * from './voter_contest_summary';

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -71,6 +71,7 @@ export * from './text';
 export * from './theme_manager_context';
 export * from './themes';
 export * from './timer';
+export * from './touch_text_input';
 export * from './typography';
 export * from './usbcontroller_button';
 export * from './remove_card_screen';

--- a/libs/ui/src/touch_text_input.tsx
+++ b/libs/ui/src/touch_text_input.tsx
@@ -1,0 +1,46 @@
+/* stylelint-disable order/properties-order */
+import React from 'react';
+import styled, { keyframes } from 'styled-components';
+
+export interface TouchTextInputProps {
+  value: string;
+}
+
+const Container = styled.div`
+  border-radius: 0.25rem;
+  border: ${(p) => p.theme.sizes.bordersRem.medium}rem solid
+    ${(p) => p.theme.colors.foreground};
+  font-weight: ${(p) => p.theme.sizes.fontWeight.semiBold};
+  line-height: 0.8;
+  padding: 0.35rem 0.3rem;
+  width: 100%;
+  word-wrap: break-word;
+`;
+
+const Value = styled.span`
+  vertical-align: middle;
+`;
+
+const blinkKeyframes = keyframes`
+  to { visibility: hidden }
+`;
+
+const Cursor = styled.span`
+  animation: ${blinkKeyframes} 1s steps(2, start) infinite;
+  border-left: 0.15em solid currentColor;
+  display: inline-block;
+  height: 1em;
+  margin-left: 0.025em;
+  vertical-align: middle;
+`;
+
+export function TouchTextInput(props: TouchTextInputProps): JSX.Element {
+  const { value } = props;
+
+  return (
+    <Container>
+      <Value>{value}</Value>
+      <Cursor />
+    </Container>
+  );
+}

--- a/libs/ui/src/virtual_keyboard.stories.tsx
+++ b/libs/ui/src/virtual_keyboard.stories.tsx
@@ -1,0 +1,17 @@
+import { Meta } from '@storybook/react';
+
+import { VirtualKeyboard, VirtualKeyboardProps } from '.';
+
+const initialArgs: Partial<VirtualKeyboardProps> = {
+  keyDisabled: () => false,
+};
+
+const meta: Meta<typeof VirtualKeyboard> = {
+  title: 'libs-ui/VirtualKeyboard',
+  component: VirtualKeyboard,
+  args: initialArgs,
+};
+
+export default meta;
+
+export { VirtualKeyboard };

--- a/libs/ui/src/virtual_keyboard.test.tsx
+++ b/libs/ui/src/virtual_keyboard.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '../test/react_testing_library';
+import { VirtualKeyboard } from './virtual_keyboard';
+
+test('fires key events', () => {
+  const onKeyPress = jest.fn();
+  const onBackspace = jest.fn();
+
+  render(
+    <VirtualKeyboard
+      onBackspace={onBackspace}
+      onKeyPress={onKeyPress}
+      keyDisabled={() => false}
+    />
+  );
+
+  const text = 'THE QUICK, BROWN FOX JUMPED OVER THE LAZY DOG.';
+  const specialCharKeyNames: Record<string, string> = {
+    ' ': 'space',
+    ',': 'comma',
+    '.': 'period',
+  };
+
+  for (const letter of text) {
+    const keyName = specialCharKeyNames[letter] || letter;
+    userEvent.click(screen.getButton(keyName));
+    expect(onKeyPress).lastCalledWith(letter);
+  }
+
+  expect(onBackspace).not.toHaveBeenCalled();
+
+  userEvent.click(screen.getButton('delete'));
+  expect(onBackspace).toHaveBeenCalled();
+});
+
+test("doesn't fire key events for disabled keys", () => {
+  const onKeyPress = jest.fn();
+  const onBackspace = jest.fn();
+
+  render(
+    <VirtualKeyboard
+      onBackspace={onBackspace}
+      onKeyPress={onKeyPress}
+      keyDisabled={(k) => k === 'M'}
+    />
+  );
+
+  userEvent.click(screen.getButton('M'));
+  expect(onKeyPress).not.toHaveBeenCalled();
+});
+
+test('custom keymap', () => {
+  const onKeyPress = jest.fn();
+  const onBackspace = jest.fn();
+
+  render(
+    <VirtualKeyboard
+      onBackspace={onBackspace}
+      onKeyPress={onKeyPress}
+      keyDisabled={(k) => k === 'M'}
+      keyMap={{
+        rows: [
+          [
+            { label: '😅' },
+            { label: '😂' },
+            { label: '✨', ariaLabel: 'magic' },
+          ],
+        ],
+      }}
+    />
+  );
+
+  userEvent.click(screen.getButton('😅'));
+  expect(onKeyPress).lastCalledWith('😅');
+
+  userEvent.click(screen.getButton('😂'));
+  expect(onKeyPress).lastCalledWith('😂');
+
+  userEvent.click(screen.getButton('magic'));
+  expect(onKeyPress).lastCalledWith('✨');
+});

--- a/libs/ui/src/virtual_keyboard.tsx
+++ b/libs/ui/src/virtual_keyboard.tsx
@@ -1,51 +1,49 @@
+/* stylelint-disable order/properties-order */
 import React from 'react';
-import styled from 'styled-components';
-
+import styled, { DefaultTheme } from 'styled-components';
 import { Button } from './button';
+import { Icons } from './icons';
+
+/* istanbul ignore next */
+function getBorderWidthRem(p: { theme: DefaultTheme }): number {
+  switch (p.theme.sizeMode) {
+    case 'xl':
+      return p.theme.sizes.bordersRem.hairline;
+    default:
+      return p.theme.sizes.bordersRem.thin;
+  }
+}
 
 const Keyboard = styled.div`
-  & div {
-    display: flex;
-    &:nth-child(2) {
-      margin-right: 0;
-      margin-left: 0.25rem;
-      @media (min-width: 480px) {
-        margin-right: 0;
-        margin-left: 0.5rem;
-      }
-    }
-    &:nth-child(3) {
-      margin-right: 0.25rem;
-      margin-left: 0.5rem;
-      @media (min-width: 480px) {
-        margin-right: 0.5rem;
-        margin-left: 1rem;
-      }
-    }
-  }
   & button {
-    flex: 1;
-    margin: 4px;
-    box-sizing: content-box;
-    background: #ffffff;
-    padding: 2vw 0;
-    white-space: nowrap;
-    color: #000000;
-    @media (min-width: 480px) {
-      min-width: 1rem;
-    }
-    @media (min-width: 850px) {
-      padding: 0.75rem 0;
-    }
+    border-width: ${getBorderWidthRem}rem;
+    font-weight: ${(p) => p.theme.sizes.fontWeight.semiBold};
+    min-height: ${(p) => p.theme.sizes.minTouchAreaSizePx}px;
+    min-width: ${(p) => p.theme.sizes.minTouchAreaSizePx}px;
 
     &:disabled {
-      color: #999999;
+      border-width: ${getBorderWidthRem}rem;
     }
   }
 `;
 
-interface Props {
+const KeyRow = styled.div`
+  display: flex;
+  gap: ${(p) => p.theme.sizes.minTouchAreaSeparationPx}px;
+  justify-content: center;
+  margin-bottom: ${(p) => p.theme.sizes.minTouchAreaSeparationPx}px;
+`;
+
+const SpaceBar = styled.span`
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  flex-grow: 1;
+`;
+
+export interface VirtualKeyboardProps {
   onKeyPress: (key: string) => void;
+  onBackspace: () => void;
   keyDisabled(key: string): boolean;
   keyMap?: KeyMap;
 }
@@ -98,34 +96,44 @@ const US_ENGLISH_KEYMAP: KeyMap = {
       { label: '.', ariaLabel: 'period' },
       { label: '-', ariaLabel: 'dash' },
     ],
-    [{ label: 'space' }, { label: '⌫ delete', ariaLabel: 'delete' }],
   ],
 };
 
 export function VirtualKeyboard({
+  onBackspace,
   onKeyPress,
   keyDisabled,
   keyMap = US_ENGLISH_KEYMAP,
-}: Props): JSX.Element {
+}: VirtualKeyboardProps): JSX.Element {
   return (
     <Keyboard data-testid="virtual-keyboard">
       {keyMap.rows.map((row) => {
         return (
-          <div key={`row-${row.map((key) => key.label).join()}`}>
+          <KeyRow key={`row-${row.map((key) => key.label).join()}`}>
             {row.map(({ label, ariaLabel }) => (
               <Button
                 key={label}
                 value={label}
-                aria-label={ariaLabel ?? label.toLowerCase()}
+                aria-label={ariaLabel}
                 onPress={onKeyPress}
                 disabled={keyDisabled(label)}
               >
                 {label}
               </Button>
             ))}
-          </div>
+          </KeyRow>
         );
       })}
+      <KeyRow>
+        <SpaceBar>
+          <Button disabled={keyDisabled(' ')} onPress={onKeyPress} value=" ">
+            space
+          </Button>
+        </SpaceBar>
+        <Button onPress={onBackspace}>
+          <Icons.Backspace /> delete
+        </Button>
+      </KeyRow>
     </Keyboard>
   );
 }

--- a/libs/ui/src/virtual_keyboard.tsx
+++ b/libs/ui/src/virtual_keyboard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { Button } from '@votingworks/ui';
+import { Button } from './button';
 
 const Keyboard = styled.div`
   & div {


### PR DESCRIPTION
## Overview

Final piece (I think) of VVSG design updates for VxMark - re-styling the write-in candidate modal:
- Moved `VirtualKeyboard` to libs/ui for easier design iteration
  - Meant to move out the rest of the write-in form as well, but didn't fit in the time box - punting for later.
  - Did break out the fake input box to `libs/ui/TouchTextInput` - not the best of names, so open to suggestions if you feel inspired.
- Moved contest title to the modal title to de-clutter the UI
- Changed character limit warning to a "characters remaining" countdown to minimise the UI flicker when it used to pop in and out of existence.
- Removed the key row staggering that we had in place before to mimic a real keyboard - causing issues at larger sizes and doesn't feel like we've taken a usability hit without it.
- Some misc bug fixes around text wrapping and backspace handling on empty inputs.

## Demo Video or Screenshot
<img width="300" src="https://github.com/votingworks/vxsuite/assets/264902/ebf71e63-b1c5-4504-a34c-4216f25e28f0" /> <img width="300" src="https://github.com/votingworks/vxsuite/assets/264902/75f3cfb7-e5f9-4dc9-aaf6-fdd3b4a3b375" />

<img width="300" src="https://github.com/votingworks/vxsuite/assets/264902/ae7a126a-3995-40ac-8f02-6495227b0b89" /> <img width="300" src="https://github.com/votingworks/vxsuite/assets/264902/0d2f074f-a391-4705-b8c5-5de9152b1fc1" />

### Interaction/Theme Variations:
https://github.com/votingworks/vxsuite/assets/264902/b776b4bc-3ac4-4903-841b-786e8c4dd56e

## Testing Plan
- Added unit tests for `VirtualKeyboard` - some of the larger functional tests also test it, so we can eventually prune those, but considering that out of scope here.
- Updated element queries and test snapshots

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
