### PR TITLE
change how we handle write-in candidates in manual tally entry

### DIFF
--- a/apps/admin/frontend/jest.config.js
+++ b/apps/admin/frontend/jest.config.js
@@ -27,7 +27,7 @@ module.exports = {
     global: {
       statements: 83,
       branches: 70,
-      functions: 79,
+      functions: 78,
       lines: 83,
     },
   },

--- a/apps/admin/frontend/src/app.test.tsx
+++ b/apps/admin/frontend/src/app.test.tsx
@@ -536,6 +536,7 @@ test('tabulating CVRs with manual data', async () => {
     { ...mockCastVoteRecordFileRecord, numCvrsImported: 100 },
   ]);
   apiMock.expectGetCastVoteRecordFileMode('test');
+  apiMock.expectGetWriteInCandidates([]);
   apiMock.expectGetWriteInSummaryAdjudicated([]);
 
   const { getByText, getByTestId, getAllByText } = renderApp();

--- a/apps/admin/frontend/src/screens/manual_data_import_precinct_screen.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_import_precinct_screen.tsx
@@ -37,6 +37,7 @@ import {
   getWriteInCandidates,
   addWriteInCandidate as addWriteInCandidateApi,
 } from '../api';
+import { normalizeWriteInName } from '../utils/write_ins';
 
 const TallyInput = styled(TextInput)`
   width: 4em;
@@ -85,10 +86,6 @@ function ContestDataRow({
       </TD>
     </tr>
   );
-}
-
-function normalizeWriteInName(name: string) {
-  return name.toLowerCase().trim();
 }
 
 function AddWriteInRow({

--- a/apps/admin/frontend/src/screens/manual_data_import_precinct_screen.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_import_precinct_screen.tsx
@@ -1,4 +1,4 @@
-import { assert, assertDefined } from '@votingworks/basics';
+import { Optional, assert, assertDefined, find } from '@votingworks/basics';
 import React, { useCallback, useContext, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import styled from 'styled-components';
@@ -33,7 +33,6 @@ import {
   getEmptyManualTalliesByPrecinct,
   getTotalNumberOfBallots,
 } from '../utils/manual_tallies';
-import { isManuallyAdjudicatedWriteInCandidate } from '../utils/write_ins';
 import {
   getWriteInCandidates,
   addWriteInCandidate as addWriteInCandidateApi,
@@ -88,6 +87,10 @@ function ContestDataRow({
   );
 }
 
+function normalizeWriteInName(name: string) {
+  return name.toLowerCase().trim();
+}
+
 function AddWriteInRow({
   addWriteInCandidate,
   contestId,
@@ -115,7 +118,9 @@ function AddWriteInRow({
             onPress={onAdd}
             disabled={
               writeInName.length === 0 ||
-              disallowedCandidateNames.includes(writeInName)
+              disallowedCandidateNames.includes(
+                normalizeWriteInName(writeInName)
+              )
             }
           >
             Add
@@ -173,6 +178,12 @@ interface TempContestTally {
 interface TempManualTally {
   readonly contestTallies: Dictionary<TempContestTally>;
   readonly numberOfBallotsCounted: number;
+}
+
+interface TempWriteInCandidate {
+  readonly id: string;
+  readonly name: string;
+  readonly contestId: string;
 }
 
 function getNumericalValueForTally(tally: number | EmptyValue): number {
@@ -262,26 +273,6 @@ export function getContestTallyWithUpdatedNumberOfBallots(
   };
 }
 
-export function getCandidatesFromContestTally(
-  contestTally: TempContestTally
-): Candidate[] {
-  if (contestTally.contest.type !== 'candidate') return [];
-  const contestOptions = Object.values(contestTally.tallies).map(
-    (optionTally) => {
-      assert(optionTally);
-      return optionTally.option;
-    }
-  );
-  return contestOptions as Candidate[];
-}
-
-export function getCandidateNamesFromContestTally(
-  contestTally: TempContestTally
-): string[] {
-  const candidates = getCandidatesFromContestTally(contestTally);
-  return candidates.map((candidate) => candidate.name);
-}
-
 export function ManualDataImportPrecinctScreen(): JSX.Element {
   const {
     electionDefinition,
@@ -299,6 +290,9 @@ export function ManualDataImportPrecinctScreen(): JSX.Element {
     useParams<ManualDataPrecinctScreenProps>();
   const history = useHistory();
 
+  const getWriteInCandidatesQuery = getWriteInCandidates.useQuery();
+  const addWriteInCandidateMutation = addWriteInCandidateApi.useMutation();
+
   const ballotType =
     existingManualData?.votingMethod ?? manualTallyVotingMethod;
   const initialTalliesByPrecinct: Dictionary<ManualTally> =
@@ -308,25 +302,81 @@ export function ManualDataImportPrecinctScreen(): JSX.Element {
   const currentPrecinct = election.precincts.find(
     (p) => p.id === currentPrecinctId
   );
-  const [currentPrecinctTally, setCurrentPrecinctTally] =
-    useState<TempManualTally>(
-      assertDefined(initialTalliesByPrecinct[currentPrecinctId])
-    );
+  const [currentPrecinctTally, setCurrentPrecinctTally] = useState<
+    Optional<TempManualTally>
+  >(initialTalliesByPrecinct[currentPrecinctId]);
+
+  const [tempWriteInCandidates, setTempWriteInCandidates] = useState<
+    TempWriteInCandidate[]
+  >([]);
 
   async function saveResults() {
-    // Convert the temporary data structure that allows empty strings or
-    // numbers for all tallies to fill in 0s for any empty strings.
-    const convertedCurrentPrecinctTally: ManualTally = {
+    assert(currentPrecinctTally);
+    // replace temporary tally values with the numeric values we'll save
+    const finalPrecinctTally: ManualTally = {
       ...currentPrecinctTally,
       contestTallies: convertContestTallies(
         currentPrecinctTally.contestTallies
       ),
     };
 
-    const manualTally = convertTalliesByPrecinctToFullManualTally(
+    // remove any temporary write-in candidates with 0 votes
+    const nonZeroTempWriteInCandidates: TempWriteInCandidate[] = [];
+    for (const writeInCandidate of tempWriteInCandidates) {
+      const numVotes =
+        finalPrecinctTally.contestTallies[writeInCandidate.contestId]?.tallies[
+          writeInCandidate.id
+        ]?.tally;
+
+      if (!numVotes) {
+        delete finalPrecinctTally.contestTallies[writeInCandidate.contestId]
+          ?.tallies[writeInCandidate.id];
+      } else {
+        nonZeroTempWriteInCandidates.push(writeInCandidate);
+      }
+    }
+    try {
+      // add temporary write-in candidates to backend, get ids
+      const writeInCandidateRecords = await Promise.all(
+        nonZeroTempWriteInCandidates.map((candidate) =>
+          addWriteInCandidateMutation.mutateAsync({
+            contestId: candidate.contestId,
+            name: candidate.name,
+          })
+        )
+      );
+
+      // edit the precinctTally to use the new ids
+      for (const tempWriteInCandidate of nonZeroTempWriteInCandidates) {
+        const oldId = tempWriteInCandidate.id;
+        const newId = find(
+          writeInCandidateRecords,
+          (writeInCandidateRecord) =>
+            writeInCandidateRecord.name === tempWriteInCandidate.name
+        ).id;
+
+        const contestTally =
+          finalPrecinctTally.contestTallies[tempWriteInCandidate.contestId];
+        assert(contestTally);
+        const optionTally = contestTally.tallies[oldId];
+        assert(optionTally);
+        contestTally.tallies[newId] = {
+          ...optionTally,
+          option: {
+            ...(optionTally.option as Candidate),
+            id: newId,
+          },
+        };
+        delete contestTally.tallies[oldId];
+      }
+    } catch {
+      // Handled by default query client error handling
+    }
+
+    const newFullManualTally = convertTalliesByPrecinctToFullManualTally(
       {
         ...initialTalliesByPrecinct,
-        [currentPrecinctId]: convertedCurrentPrecinctTally,
+        [currentPrecinctId]: finalPrecinctTally,
       },
       election,
       ballotType,
@@ -335,10 +385,10 @@ export function ManualDataImportPrecinctScreen(): JSX.Element {
     await logger.log(LogEventId.ManualTallyDataEdited, userRole, {
       disposition: 'success',
       message: `Manually entered tally data added or edited for precinct: ${currentPrecinctId}`,
-      numberOfBallotsInPrecinct: currentPrecinctTally.numberOfBallotsCounted,
+      numberOfBallotsInPrecinct: finalPrecinctTally.numberOfBallotsCounted,
       precinctId: currentPrecinctId,
     });
-    await updateManualTally(manualTally);
+    await updateManualTally(newFullManualTally);
     history.push(routerPaths.manualDataImport);
   }
 
@@ -361,24 +411,45 @@ export function ManualDataImportPrecinctScreen(): JSX.Element {
     }
   }
 
+  /**
+   * Takes a `contestTally` with update option tallies and recalculates the
+   * ballot count for that contest and the ballot count for the entire
+   * precinct tally.
+   */
+  function updateCurrentPrecinctTally(
+    contestId: ContestId,
+    contestTally: TempContestTally
+  ) {
+    assert(currentPrecinctTally);
+    setCurrentPrecinctTally(
+      // Create tally with updated total number of ballots for the entire tally
+      getManualTallyFromContestTallies(
+        {
+          ...currentPrecinctTally.contestTallies,
+          // Create contest tally with updated number of ballots for the contest
+          [contestId]: getContestTallyWithUpdatedNumberOfBallots(contestTally),
+        },
+        election
+      )
+    );
+  }
+
   function updateContestData(
     contestId: ContestId,
     dataKey: string,
-    event: React.FormEvent<HTMLInputElement>
+    event: React.FormEvent<HTMLInputElement>,
+    candidateName?: string
   ) {
     assert(currentPrecinctTally);
     const contestTally = currentPrecinctTally.contestTallies[contestId];
     assert(contestTally);
     const stringValue = event.currentTarget.value;
     // eslint-disable-next-line vx/gts-safe-number-parse
-    let numericalValue = parseInt(stringValue, 10);
-    if (stringValue === '') {
-      numericalValue = 0;
-    }
-    const valueToSave = stringValue === '' ? '' : numericalValue;
+    const numericalValue = Number(stringValue);
     if (Number.isNaN(numericalValue)) {
       return;
     }
+    const valueToSave = stringValue === '' ? '' : numericalValue;
     let newContestTally = contestTally;
     switch (dataKey) {
       case 'overvotes':
@@ -401,32 +472,49 @@ export function ManualDataImportPrecinctScreen(): JSX.Element {
         break;
       default: {
         const tally = contestTally.tallies[dataKey];
-        assert(tally);
+        const option = tally
+          ? tally.option
+          : {
+              id: dataKey,
+              isWriteIn: true,
+              name: assertDefined(candidateName),
+            };
         newContestTally = {
           ...contestTally,
           tallies: {
             ...contestTally.tallies,
             [dataKey]: {
-              option: tally.option,
+              option,
               tally: valueToSave,
             },
           },
         };
       }
     }
-    // Update the total number of ballots for this contest
-    newContestTally =
-      getContestTallyWithUpdatedNumberOfBallots(newContestTally);
-    setCurrentPrecinctTally(
-      // Create tally with updated total number of ballots for the entire tally
-      getManualTallyFromContestTallies(
-        {
-          ...currentPrecinctTally.contestTallies,
-          [contestId]: newContestTally,
-        },
-        election
-      )
-    );
+
+    updateCurrentPrecinctTally(contestId, newContestTally);
+  }
+
+  function addTempWriteInCandidate(name: string, contestId: string): void {
+    setTempWriteInCandidates([
+      ...tempWriteInCandidates,
+      {
+        id: `write-in-(${name})-temp`,
+        name,
+        contestId,
+      },
+    ]);
+  }
+
+  function removeTempWriteInCandidate(id: string, contestId: string): void {
+    setTempWriteInCandidates(tempWriteInCandidates.filter((c) => c.id !== id));
+
+    // remove temp candidate from contest and recompute the ballot counts
+    assert(currentPrecinctTally);
+    const contestTally = currentPrecinctTally.contestTallies[contestId];
+    assert(contestTally);
+    delete contestTally?.tallies[id];
+    updateCurrentPrecinctTally(contestId, contestTally);
   }
 
   const currentContests = getContestsForPrecinct(election, currentPrecinctId);
@@ -447,13 +535,15 @@ export function ManualDataImportPrecinctScreen(): JSX.Element {
     );
   }
 
-  if (!currentPrecinctTally) {
+  if (!currentPrecinctTally || !getWriteInCandidatesQuery.isSuccess) {
     return (
       <NavigationScreen>
         <br />
       </NavigationScreen>
     );
   }
+
+  const writeInCandidates = getWriteInCandidatesQuery.data;
 
   return (
     <NavigationScreen>
@@ -478,29 +568,51 @@ export function ManualDataImportPrecinctScreen(): JSX.Element {
           const contestTally = currentPrecinctTally.contestTallies[contest.id];
           assert(contestTally);
 
+          const contestWriteInCandidates = writeInCandidates.filter(
+            ({ contestId }) => contestId === contest.id
+          );
+          const contestTempWriteInCandidates = tempWriteInCandidates.filter(
+            ({ contestId }) => contestId === contest.id
+          );
+          const disallowedNewWriteInCandidateNames =
+            contest.type === 'candidate'
+              ? [
+                  ...contest.candidates,
+                  ...contestWriteInCandidates,
+                  ...contestTempWriteInCandidates,
+                ].map(({ name }) => normalizeWriteInName(name))
+              : [];
+
           return (
             <ContestData key={contest.id}>
               <Text small>{getContestDistrictName(election, contest)}</Text>
               <h3>{contestTitle}</h3>
               <Table borderTop condensed>
                 <tbody>
-                  {contest.type === 'candidate' &&
-                    getCandidatesFromContestTally(contestTally).map(
-                      (candidate) => (
+                  {contest.type === 'candidate' && (
+                    <React.Fragment>
+                      {contest.candidates
+                        .filter((c) => !c.isWriteIn)
+                        .map((candidate) => (
+                          <ContestDataRow
+                            key={candidate.id}
+                            label={candidate.name}
+                            testId={`${contest.id}-${candidate.id}`}
+                          >
+                            <TallyInput
+                              name={`${contest.id}-${candidate.id}`}
+                              data-testid={`${contest.id}-${candidate.id}-input`}
+                              value={getValueForInput(contest.id, candidate.id)}
+                              onChange={(e) =>
+                                updateContestData(contest.id, candidate.id, e)
+                              }
+                            />
+                          </ContestDataRow>
+                        ))}
+                      {contestWriteInCandidates.map((candidate) => (
                         <ContestDataRow
                           key={candidate.id}
-                          label={`${candidate.name}${
-                            candidate.isWriteIn ? ' (write-in)' : ''
-                          }`}
-                          onRemove={
-                            isManuallyAdjudicatedWriteInCandidate(candidate)
-                              ? () =>
-                                  setCandidateToRemove({
-                                    candidate,
-                                    contest,
-                                  })
-                              : undefined
-                          }
+                          label={`${candidate.name} (write-in)`}
                           testId={`${contest.id}-${candidate.id}`}
                         >
                           <TallyInput
@@ -508,21 +620,54 @@ export function ManualDataImportPrecinctScreen(): JSX.Element {
                             data-testid={`${contest.id}-${candidate.id}-input`}
                             value={getValueForInput(contest.id, candidate.id)}
                             onChange={(e) =>
-                              updateContestData(contest.id, candidate.id, e)
+                              updateContestData(
+                                contest.id,
+                                candidate.id,
+                                e,
+                                candidate.name
+                              )
                             }
                           />
                         </ContestDataRow>
-                      )
-                    )}
+                      ))}
+                      {contestTempWriteInCandidates.map((candidate) => (
+                        <ContestDataRow
+                          key={candidate.id}
+                          label={`${candidate.name} (write-in)`}
+                          testId={`${contest.id}-${candidate.id}`}
+                          onRemove={() => {
+                            removeTempWriteInCandidate(
+                              candidate.id,
+                              contest.id
+                            );
+                          }}
+                        >
+                          <TallyInput
+                            name={`${contest.id}-${candidate.id}`}
+                            data-testid={`${contest.id}-${candidate.id}-input`}
+                            value={getValueForInput(contest.id, candidate.id)}
+                            onChange={(e) =>
+                              updateContestData(
+                                contest.id,
+                                candidate.id,
+                                e,
+                                candidate.name
+                              )
+                            }
+                          />
+                        </ContestDataRow>
+                      ))}
+                    </React.Fragment>
+                  )}
                   {contest.type === 'candidate' && contest.allowWriteIns && (
                     <AddWriteInRow
                       addWriteInCandidate={(name) =>
-                        addWriteInCandidate(contest.id, name)
+                        addTempWriteInCandidate(name, contest.id)
                       }
                       contestId={contest.id}
-                      disallowedCandidateNames={getCandidateNamesFromContestTally(
-                        contestTally
-                      )}
+                      disallowedCandidateNames={
+                        disallowedNewWriteInCandidateNames
+                      }
                     />
                   )}
                   {contest.type === 'yesno' && (

--- a/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
@@ -37,6 +37,7 @@ import {
   useApiClient,
   addWriteInCandidate,
 } from '../api';
+import { normalizeWriteInName } from '../utils/write_ins';
 
 const BallotViews = styled.div`
   flex: 3;
@@ -394,8 +395,8 @@ export function WriteInsAdjudicationScreen({
   const writeInCandidates = writeInCandidatesQuery.data;
   const disallowedWriteInCandidateNames = [
     '',
-    ...officialCandidates.map((c) => c.name.toLowerCase()),
-    ...writeInCandidates.map((c) => c.name.toLowerCase()),
+    ...officialCandidates.map((c) => normalizeWriteInName(c.name)),
+    ...writeInCandidates.map((c) => normalizeWriteInName(c.name)),
   ];
 
   function goPrevious() {
@@ -499,7 +500,9 @@ export function WriteInsAdjudicationScreen({
     const name = newWriteInCandidateInput.current?.value;
     assert(currentWriteIn);
     if (!name) return;
-    if (disallowedWriteInCandidateNames.includes(name.toLowerCase())) return;
+    if (disallowedWriteInCandidateNames.includes(normalizeWriteInName(name))) {
+      return;
+    }
 
     try {
       const writeInCandidate = await addWriteInCandidateMutation.mutateAsync({
@@ -669,7 +672,9 @@ export function WriteInsAdjudicationScreen({
                       disabled={
                         !!newWriteInCandidateInput.current &&
                         disallowedWriteInCandidateNames.includes(
-                          newWriteInCandidateInput.current.value.toLowerCase()
+                          normalizeWriteInName(
+                            newWriteInCandidateInput.current.value
+                          )
                         )
                       }
                     >

--- a/apps/admin/frontend/src/utils/manual_tallies.ts
+++ b/apps/admin/frontend/src/utils/manual_tallies.ts
@@ -301,13 +301,12 @@ export function getEmptyContestTallies(
 }
 
 export function getEmptyManualTalliesByPrecinct(
-  election: Election,
-  allAdjudicatedValues?: Map<ContestId, string[]>
+  election: Election
 ): Dictionary<ManualTally> {
   const tallies: Dictionary<ManualTally> = {};
   for (const precinct of election.precincts) {
     tallies[precinct.id] = {
-      contestTallies: getEmptyContestTallies(election, allAdjudicatedValues),
+      contestTallies: getEmptyContestTallies(election),
       numberOfBallotsCounted: 0,
     };
   }

--- a/apps/admin/frontend/src/utils/manual_tallies.ts
+++ b/apps/admin/frontend/src/utils/manual_tallies.ts
@@ -12,7 +12,6 @@ import {
   VotingMethod,
   PartyId,
   PrecinctId,
-  ContestId,
 } from '@votingworks/types';
 import { combineContestTallies } from '@votingworks/utils';
 import { assert, throwIllegalValue } from '@votingworks/basics';
@@ -21,7 +20,6 @@ import {
   getDistrictIdsForPartyId,
   getPartiesWithPrimaryElections,
 } from './election';
-import { getAdjudicatedWriteInCandidate } from './write_ins';
 
 export function convertManualTallyToStorageString(
   tally: FullElectionManualTally
@@ -246,8 +244,7 @@ export function convertTalliesByPrecinctToFullManualTally(
 }
 
 export function getEmptyContestTallies(
-  election: Election,
-  allAdjudicatedValues?: Map<ContestId, string[]>
+  election: Election
 ): Dictionary<ContestTally> {
   const contestTallies: Dictionary<ContestTally> = {};
   for (const contest of election.contests) {
@@ -259,21 +256,6 @@ export function getEmptyContestTallies(
             option: candidate,
             tally: 0,
           };
-        }
-        if (contest.allowWriteIns && allAdjudicatedValues) {
-          const adjudicatedValues = allAdjudicatedValues.get(contest.id);
-          if (adjudicatedValues) {
-            for (const adjudicatedValue of adjudicatedValues) {
-              const adjudicatedCandidate = getAdjudicatedWriteInCandidate(
-                adjudicatedValue,
-                false
-              );
-              optionTallies[adjudicatedCandidate.id] = {
-                option: adjudicatedCandidate,
-                tally: 0,
-              };
-            }
-          }
         }
         break;
       }

--- a/apps/admin/frontend/src/utils/write_ins.test.ts
+++ b/apps/admin/frontend/src/utils/write_ins.test.ts
@@ -1,5 +1,6 @@
 import { electionSample } from '@votingworks/fixtures';
 import {
+  Candidate,
   CandidateId,
   ContestId,
   Dictionary,
@@ -10,7 +11,6 @@ import { buildManualTally } from '../../test/helpers/build_manual_tally';
 import {
   combineWriteInCounts,
   CountsByContestAndCandidateName,
-  getAdjudicatedWriteInCandidate,
   getManualWriteInCounts,
   mergeWriteIns,
 } from './write_ins';
@@ -35,7 +35,11 @@ function addWriteInToManualTally(
   tally: number
 ): CandidateId {
   const contestTally = manualTally.contestTallies[contestId];
-  const candidate = getAdjudicatedWriteInCandidate(name, false);
+  const candidate: Candidate = {
+    name,
+    isWriteIn: true,
+    id: `write-in-(${name})-temp`,
+  };
   contestTally!.tallies[candidate.id] = {
     option: candidate,
     tally,

--- a/apps/admin/frontend/src/utils/write_ins.test.ts
+++ b/apps/admin/frontend/src/utils/write_ins.test.ts
@@ -13,6 +13,7 @@ import {
   CountsByContestAndCandidateName,
   getManualWriteInCounts,
   mergeWriteIns,
+  normalizeWriteInName,
 } from './write_ins';
 
 // Converts the nested maps of write-in counts to an object for easier assertions
@@ -155,4 +156,10 @@ test('mergeWriteIns', () => {
   for (const originalWriteInId of originalWriteInIds) {
     expect(countyCommissionerCandidateIds).not.toContain(originalWriteInId);
   }
+});
+
+test('normalizeWriteInName', () => {
+  expect(normalizeWriteInName('Name')).toEqual('name');
+  expect(normalizeWriteInName('  Name  ')).toEqual('name');
+  expect(normalizeWriteInName('  Na     me  ')).toEqual('na me');
 });

--- a/apps/admin/frontend/src/utils/write_ins.ts
+++ b/apps/admin/frontend/src/utils/write_ins.ts
@@ -115,33 +115,6 @@ export function filterWriteInCountsByParty(
   return filteredCounts;
 }
 
-// ManualTally write-in candidate id creation
-export function getAdjudicatedWriteInCandidateId(
-  name: string,
-  manual: boolean
-): string {
-  return `write-in-(${name})${manual ? '-manual' : ''}`;
-}
-
-export function getAdjudicatedWriteInCandidate(
-  name: string,
-  manual: boolean
-): Candidate {
-  return {
-    id: getAdjudicatedWriteInCandidateId(name, manual),
-    name,
-    isWriteIn: true,
-  };
-}
-
-export function isManuallyAdjudicatedWriteInCandidate(
-  candidate: Candidate
-): boolean {
-  return (
-    candidate.id.startsWith('write-in-(') && candidate.id.endsWith(')-manual')
-  );
-}
-
 // Extracts all write-in data from an ManualTally and formats it
 // as CountsByContestAndCandidateName for the write-in report
 export function getManualWriteInCounts(

--- a/apps/admin/frontend/src/utils/write_ins.ts
+++ b/apps/admin/frontend/src/utils/write_ins.ts
@@ -221,3 +221,7 @@ export function mergeWriteIns(manualTally: ManualTally): ManualTally {
     contestTallies: newContestTallies,
   };
 }
+
+export function normalizeWriteInName(name: string): string {
+  return name.toLowerCase().trim().replace(/\s+/, ' ');
+}

--- a/apps/admin/frontend/test/helpers/api_mock.ts
+++ b/apps/admin/frontend/test/helpers/api_mock.ts
@@ -230,6 +230,15 @@ export function createApiMock(
       }
     },
 
+    expectAddWriteInCandidate(
+      input: { contestId: string; name: string },
+      writeInCandidateRecord: WriteInCandidateRecord
+    ) {
+      apiClient.addWriteInCandidate
+        .expectCallWith(input)
+        .resolves(writeInCandidateRecord);
+    },
+
     expectGetWriteInDetailView(
       writeInId: string,
       detailView: Partial<WriteInDetailView> = {}


### PR DESCRIPTION
## Overview

In order to move manual tally data to the backend, I needed to make this transition PR changing how we treat write-in candidates in manual data.

I added the ability to add write-in candidates to manual tallies in #2649. I recommend watching the video in that PR description for context. The way I implemented it had two main problems:

1. Feature Limitation: Write-in candidates from on-screen adjudication would pre-populate in the manual tally entry screens, but write-in candidates from manual tally entry would not pre-populate in on-screen adjudication. We assumed that the flow would move in that direction, but we know we can't always guarantee it
2. Technical Issue: The way that manual data added write-in candidates were tracked was by having a key value pair in the manual tally. But, there is a manual tally for each precinct, so it required some overcomplicated logic to update _all_ precinct tallies when you save the current one. When moving to the backend, this makes it more complicated than just updating one precinct at a time.

Both of these issues can be addressed now that write-in candidates are normalized after #3417, which is the purpose of this PR. A good deal of the logic you see added here is very temporary and will be cleared in the next PR, which I'll call out in comments.

This is a refactor mostly but there were a couple product choices I made:
- Previously we allowed removing a manual data added write-in candidate. You would delete them from a precinct screen and they would be removed from all the tallies. Now that I understand more about manual tally data, I think this is an unsafe action. It allows you to possibly (probably) invalidate a bunch of other data that has been validated on entry. I removed the modal entirely
- I allow you to remove a newly added candidate (from the manual interface) if you haven't saved it yet, but if you have saved it, there's no way to delete them! Ever! (without clearing the election). In a subsequent PR moving manual tallies to the backend, I will implement logic to remove such candidates if they are no longer being referenced, similar to how candidates via on screen adjudication are removed automatically.

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
