### PR TITLE
fix(usb-mocking): fix `insert.sh` parsing of `lsblk` output

### DIFF
--- a/libs/usb-mocking/insert.sh
+++ b/libs/usb-mocking/insert.sh
@@ -24,7 +24,7 @@ echo "Virtual USB drive attached."
 DELAY=0.05
 DELAY_COUNTER=0
 DELAY_MAX_TIMES=10
-until [[ $( lsblk -fl | grep "${DEVICE_BASENAME}p1 vfat" ) ]]
+until [[ $( lsblk -fl | grep "${DEVICE_BASENAME}p1.*vfat" ) ]]
 do
     echo "Waiting for OS to detect filesystem on virtual USB drive partition..."
     sleep $DELAY


### PR DESCRIPTION
## Overview
We were `grep`ping for `${DEVICE_BASENAME}p1 vfat`, but because `lsblk` prints it as a table it might not be the case that there's a single space between the `p1` and `vfat`. This commit accounts for that.

Related [Slack thread](https://votingworks.slack.com/archives/CEL6D3GAD/p1683844280388539).

## Demo Video or Screenshot
```
debian--11--vg-root   ext4        1.0                  1ea4b907-0a2c-4f85-8f46-d932ec8f3fbd     33.1G    40% /
debian--11--vg-swap_1 swap        1                    db2ddb9e-d9b5-4b5e-8b7e-8142e0b19ddd                  [SWAP]
loop0p1               vfat        FAT32    VIRTUAL-USB A58C-44AE
```

## Testing Plan
Tested manually.
