### PR TITLE
[scan] consolidate normalized/original ballot images

### DIFF
--- a/apps/central-scan/backend/bin/extract-backup
+++ b/apps/central-scan/backend/bin/extract-backup
@@ -24,8 +24,8 @@ sqlite3 "${BACKUP_DIR}/ballots.db" "
     '# batch ' || batches.id || x'0a' ||
     -- get all pages from the batch in front/back order
     group_concat(
-      sheets.front_original_filename || x'0a' ||
-      sheets.back_original_filename,
+      sheets.front_normalized_filename || x'0a' ||
+      sheets.back_normalized_filename,
       x'0a'
     ) ||
     -- separate batches with an empty line

--- a/apps/central-scan/backend/bin/extract-backup
+++ b/apps/central-scan/backend/bin/extract-backup
@@ -24,8 +24,8 @@ sqlite3 "${BACKUP_DIR}/ballots.db" "
     '# batch ' || batches.id || x'0a' ||
     -- get all pages from the batch in front/back order
     group_concat(
-      sheets.front_normalized_filename || x'0a' ||
-      sheets.back_normalized_filename,
+      sheets.front_image_path || x'0a' ||
+      sheets.back_image_path,
       x'0a'
     ) ||
     -- separate batches with an empty line

--- a/apps/central-scan/backend/schema.sql
+++ b/apps/central-scan/backend/schema.sql
@@ -30,8 +30,6 @@ create table sheets (
   batch_id varchar(36),
 
   -- Filenames for where the sheet images are stored on disk.
-  front_original_filename text unique,
-  back_original_filename text unique,
   front_normalized_filename text unique,
   back_normalized_filename text unique,
 

--- a/apps/central-scan/backend/schema.sql
+++ b/apps/central-scan/backend/schema.sql
@@ -29,9 +29,9 @@ create table sheets (
   id varchar(36) primary key,
   batch_id varchar(36),
 
-  -- Filenames for where the sheet images are stored on disk.
-  front_normalized_filename text unique,
-  back_normalized_filename text unique,
+  -- Paths for the sheet images.
+  front_image_path text unique,
+  back_image_path text unique,
 
   -- Original interpretation of the sheet. These values should never be updated.
   -- @type {PageInterpretation}

--- a/apps/central-scan/backend/src/backup.test.ts
+++ b/apps/central-scan/backend/src/backup.test.ts
@@ -147,20 +147,20 @@ test('has all files referenced in the database', async () => {
   });
   const batchId = store.addBatch();
 
-  const frontNormalizedFile = fileSync();
-  await writeFile(frontNormalizedFile.fd, 'front normalized');
+  const frontImagePath = fileSync();
+  await writeFile(frontImagePath.fd, 'front image path');
 
-  const backNormalizedFile = fileSync();
-  await writeFile(backNormalizedFile.fd, 'back normalized');
+  const backImagePath = fileSync();
+  await writeFile(backImagePath.fd, 'back image path');
 
   store.addSheet('sheet-1', batchId, [
     {
       interpretation: { type: 'UnreadablePage' },
-      normalizedFilename: frontNormalizedFile.name,
+      imagePath: frontImagePath.name,
     },
     {
       interpretation: { type: 'UnreadablePage' },
-      normalizedFilename: backNormalizedFile.name,
+      imagePath: backImagePath.name,
     },
   ]);
 
@@ -185,18 +185,14 @@ test('has all files referenced in the database', async () => {
       )
       .sort()
   ).toEqual(
-    [
-      frontNormalizedFile.name,
-      frontNormalizedFile.name,
-      backNormalizedFile.name,
-    ]
+    [frontImagePath.name, backImagePath.name]
       .map((name) => basename(name))
       .sort()
   );
 
   for (const [{ name }, content] of [
-    [frontNormalizedFile, 'front normalized'],
-    [backNormalizedFile, 'back normalized'],
+    [frontImagePath, 'front image path'],
+    [backImagePath, 'back image path'],
   ] as const) {
     expect(
       new TextDecoder().decode(
@@ -210,11 +206,11 @@ test('has all files referenced in the database', async () => {
   await writeFile(dbFile.fd, await readEntry(dbEntry!));
   const db = new Database(dbFile.name);
   const stmt = db.prepare<[]>(
-    'select front_normalized_filename as filename from sheets'
+    'select front_image_path as filename from sheets'
   );
   const row: { filename: string } = stmt.get();
   expect(row).toEqual({
-    filename: basename(frontNormalizedFile.name),
+    filename: basename(frontImagePath.name),
   });
 });
 
@@ -228,7 +224,7 @@ test('has cast vote record report', async () => {
 
   const batchId = store.addBatch();
   const imageFile = fileSync();
-  await writeFile(imageFile.fd, 'front normalized');
+  await writeFile(imageFile.fd, 'front image path');
   store.addSheet('sheet-1', batchId, [
     {
       interpretation: {
@@ -246,11 +242,11 @@ test('has cast vote record report', async () => {
           'flag-question': ['yes'],
         },
       },
-      normalizedFilename: imageFile.name,
+      imagePath: imageFile.name,
     },
     {
       interpretation: { type: 'BlankPage' },
-      normalizedFilename: imageFile.name,
+      imagePath: imageFile.name,
     },
   ]);
 

--- a/apps/central-scan/backend/src/backup.test.ts
+++ b/apps/central-scan/backend/src/backup.test.ts
@@ -11,7 +11,6 @@ import {
   TEST_JURISDICTION,
   unsafeParse,
 } from '@votingworks/types';
-import { throwIllegalValue } from '@votingworks/basics';
 import Database from 'better-sqlite3';
 import { writeFileSync } from 'fs';
 import { writeFile, existsSync } from 'fs-extra';
@@ -148,26 +147,20 @@ test('has all files referenced in the database', async () => {
   });
   const batchId = store.addBatch();
 
-  const frontOriginalFile = fileSync();
-  await writeFile(frontOriginalFile.fd, 'front original');
-
   const frontNormalizedFile = fileSync();
   await writeFile(frontNormalizedFile.fd, 'front normalized');
 
-  const backOriginalFile = fileSync();
-  await writeFile(backOriginalFile.fd, 'back original');
+  const backNormalizedFile = fileSync();
+  await writeFile(backNormalizedFile.fd, 'back normalized');
 
   store.addSheet('sheet-1', batchId, [
     {
       interpretation: { type: 'UnreadablePage' },
-      originalFilename: frontOriginalFile.name,
       normalizedFilename: frontNormalizedFile.name,
     },
     {
       interpretation: { type: 'UnreadablePage' },
-      // intentionally the same, for cases where that's true
-      originalFilename: backOriginalFile.name,
-      normalizedFilename: backOriginalFile.name,
+      normalizedFilename: backNormalizedFile.name,
     },
   ]);
 
@@ -192,15 +185,18 @@ test('has all files referenced in the database', async () => {
       )
       .sort()
   ).toEqual(
-    [frontOriginalFile.name, frontNormalizedFile.name, backOriginalFile.name]
+    [
+      frontNormalizedFile.name,
+      frontNormalizedFile.name,
+      backNormalizedFile.name,
+    ]
       .map((name) => basename(name))
       .sort()
   );
 
   for (const [{ name }, content] of [
-    [frontOriginalFile, 'front original'],
     [frontNormalizedFile, 'front normalized'],
-    [backOriginalFile, 'back original'],
+    [backNormalizedFile, 'back normalized'],
   ] as const) {
     expect(
       new TextDecoder().decode(
@@ -214,11 +210,11 @@ test('has all files referenced in the database', async () => {
   await writeFile(dbFile.fd, await readEntry(dbEntry!));
   const db = new Database(dbFile.name);
   const stmt = db.prepare<[]>(
-    'select front_original_filename as filename from sheets'
+    'select front_normalized_filename as filename from sheets'
   );
   const row: { filename: string } = stmt.get();
   expect(row).toEqual({
-    filename: basename(frontOriginalFile.name),
+    filename: basename(frontNormalizedFile.name),
   });
 });
 
@@ -232,7 +228,7 @@ test('has cast vote record report', async () => {
 
   const batchId = store.addBatch();
   const imageFile = fileSync();
-  await writeFile(imageFile.fd, 'front original');
+  await writeFile(imageFile.fd, 'front normalized');
   store.addSheet('sheet-1', batchId, [
     {
       interpretation: {
@@ -250,12 +246,10 @@ test('has cast vote record report', async () => {
           'flag-question': ['yes'],
         },
       },
-      originalFilename: imageFile.name,
       normalizedFilename: imageFile.name,
     },
     {
       interpretation: { type: 'BlankPage' },
-      originalFilename: imageFile.name,
       normalizedFilename: imageFile.name,
     },
   ]);
@@ -322,111 +316,3 @@ test('has vx-logs.log if file exists', async () => {
   const logsEntry = entries.find(({ name }) => name === 'vx-logs.log')!;
   expect(await readTextEntry(logsEntry)).toEqual('mock logs');
 });
-
-const spaceOptimizedBackupTestCases: Array<{
-  saveOnlyOriginalImagesThenOnlyNormalizedImagesAfterNumSheets?: number;
-  numSheets: number;
-  expectedScanImagesInBackup: 'All' | 'OriginalOnly' | 'NormalizedOnly';
-}> = [
-  {
-    saveOnlyOriginalImagesThenOnlyNormalizedImagesAfterNumSheets: undefined,
-    numSheets: 1,
-    expectedScanImagesInBackup: 'All',
-  },
-  {
-    saveOnlyOriginalImagesThenOnlyNormalizedImagesAfterNumSheets: 1,
-    numSheets: 1,
-    expectedScanImagesInBackup: 'OriginalOnly',
-  },
-  {
-    saveOnlyOriginalImagesThenOnlyNormalizedImagesAfterNumSheets: 1,
-    numSheets: 2,
-    expectedScanImagesInBackup: 'NormalizedOnly',
-  },
-];
-
-test.each(spaceOptimizedBackupTestCases)(
-  'saveOnlyOriginalImagesThenOnlyNormalizedImagesAfterNumSheets affects what is backed up as expected (%s)',
-  async ({
-    saveOnlyOriginalImagesThenOnlyNormalizedImagesAfterNumSheets,
-    numSheets,
-    expectedScanImagesInBackup,
-  }) => {
-    const store = Store.memoryStore();
-    store.setElectionAndJurisdiction({
-      electionData: electionDefinition.electionData,
-      jurisdiction,
-    });
-    const batchId = store.addBatch();
-
-    const originalFileNames = [];
-    const normalizedFileNames = [];
-    for (let i = 0; i < numSheets; i += 1) {
-      const frontOriginalFile = fileSync();
-      await writeFile(frontOriginalFile.fd, 'front-original');
-      const frontNormalizedFile = fileSync();
-      await writeFile(frontNormalizedFile.fd, 'front-normalized');
-      const backOriginalFile = fileSync();
-      await writeFile(backOriginalFile.fd, 'back-original');
-      const backNormalizedFile = fileSync();
-      await writeFile(backNormalizedFile.fd, 'back-normalized');
-      originalFileNames.push(frontOriginalFile.name, backOriginalFile.name);
-      normalizedFileNames.push(
-        frontNormalizedFile.name,
-        backNormalizedFile.name
-      );
-      store.addSheet(`sheet-${i + 1}`, batchId, [
-        {
-          interpretation: { type: 'UnreadablePage' },
-          originalFilename: frontOriginalFile.name,
-          normalizedFilename: frontNormalizedFile.name,
-        },
-        {
-          interpretation: { type: 'UnreadablePage' },
-          originalFilename: backOriginalFile.name,
-          normalizedFilename: backNormalizedFile.name,
-        },
-      ]);
-    }
-
-    const output = new WritableStream();
-    await new Promise((resolve, reject) => {
-      backup(store, {
-        saveOnlyOriginalImagesThenOnlyNormalizedImagesAfterNumSheets,
-      })
-        .on('error', reject)
-        .pipe(output)
-        .on('finish', resolve);
-    });
-    const zipfile = await openZip(output.toBuffer());
-    const entries = getEntries(zipfile);
-
-    let expectedScanImageFileNamesInBackup: string[] = [];
-    if (expectedScanImagesInBackup === 'All') {
-      expectedScanImageFileNamesInBackup = [
-        ...originalFileNames,
-        ...normalizedFileNames,
-      ];
-    } else if (expectedScanImagesInBackup === 'NormalizedOnly') {
-      expectedScanImageFileNamesInBackup = normalizedFileNames;
-    } else if (expectedScanImagesInBackup === 'OriginalOnly') {
-      expectedScanImageFileNamesInBackup = originalFileNames;
-    } else {
-      throwIllegalValue(expectedScanImagesInBackup);
-    }
-    expect(
-      entries
-        .map((entry) => entry.name)
-        .filter(
-          (fileName) =>
-            fileName !== 'election.json' &&
-            fileName !== 'ballots.db' &&
-            fileName !== 'ballots.db.digest' &&
-            fileName !== CAST_VOTE_RECORD_REPORT_FILENAME
-        )
-        .sort()
-    ).toEqual(
-      expectedScanImageFileNamesInBackup.map((name) => basename(name)).sort()
-    );
-  }
-);

--- a/apps/central-scan/backend/src/backup.ts
+++ b/apps/central-scan/backend/src/backup.ts
@@ -112,8 +112,8 @@ export class Backup {
     }
     debug('adding ballot images to backup...');
     for (const sheet of sheets) {
-      await this.addFileEntry(sheet.front.normalized);
-      await this.addFileEntry(sheet.back.normalized);
+      await this.addFileEntry(sheet.frontImagePath);
+      await this.addFileEntry(sheet.backImagePath);
     }
     debug('added ballot images to backup');
 
@@ -136,15 +136,15 @@ export class Backup {
     const selectSheets = db.prepare<[]>(`
       select
         id,
-        front_normalized_filename,
-        back_normalized_filename
+        front_image_path,
+        back_image_path
       from sheets
       `);
     const updateSheet = db.prepare<[string, string, string]>(
       `
       update sheets
-      set front_normalized_filename = ?,
-          back_normalized_filename = ?
+      set front_image_path = ?,
+          back_image_path = ?
       where id = ?
       `
     );
@@ -152,8 +152,8 @@ export class Backup {
     const updates: Array<Promise<void>> = [];
     for (const row of selectSheets.all()) {
       updateSheet.run(
-        basename(row.front_normalized_filename),
-        basename(row.back_normalized_filename),
+        basename(row.front_image_path),
+        basename(row.back_image_path),
         row.id
       );
     }

--- a/apps/central-scan/backend/src/backup.ts
+++ b/apps/central-scan/backend/src/backup.ts
@@ -19,19 +19,6 @@ import { Store } from './store';
 const debug = makeDebug('scan:backup');
 
 /**
- * Specifies what to include in the backup
- *
- * @property saveOnlyOriginalImagesThenOnlyNormalizedImagesAfterNumSheets If the number of sheets
- * scanned by the machine is less than or equal to this, only original scan images will be included
- * in the backup, and if the number of sheets scanned by the machine is greater, only normalized
- * scan images will be included in the backup. If not specified, both original and normalized scan
- * images will be included.
- */
-export interface BackupOptions {
-  saveOnlyOriginalImagesThenOnlyNormalizedImagesAfterNumSheets?: number;
-}
-
-/**
  * Creates a backup of the database and all scanned files.
  */
 export class Backup {
@@ -81,9 +68,7 @@ export class Backup {
   /**
    * Runs the backup.
    */
-  async backup({
-    saveOnlyOriginalImagesThenOnlyNormalizedImagesAfterNumSheets,
-  }: BackupOptions = {}): Promise<void> {
+  async backup(): Promise<void> {
     debug('starting a backup');
 
     const electionDefinition = this.store.getElectionDefinition();
@@ -126,28 +111,9 @@ export class Backup {
       sheets.push(sheet);
     }
     debug('adding ballot images to backup...');
-    if (
-      saveOnlyOriginalImagesThenOnlyNormalizedImagesAfterNumSheets !== undefined
-    ) {
-      for (const sheet of sheets) {
-        if (
-          sheets.length <=
-          saveOnlyOriginalImagesThenOnlyNormalizedImagesAfterNumSheets
-        ) {
-          await this.addFileEntry(sheet.front.original);
-          await this.addFileEntry(sheet.back.original);
-        } else {
-          await this.addFileEntry(sheet.front.normalized);
-          await this.addFileEntry(sheet.back.normalized);
-        }
-      }
-    } else {
-      for (const sheet of sheets) {
-        await this.addFileEntry(sheet.front.original);
-        await this.addFileEntry(sheet.front.normalized);
-        await this.addFileEntry(sheet.back.original);
-        await this.addFileEntry(sheet.back.normalized);
-      }
+    for (const sheet of sheets) {
+      await this.addFileEntry(sheet.front.normalized);
+      await this.addFileEntry(sheet.back.normalized);
     }
     debug('added ballot images to backup');
 
@@ -170,18 +136,14 @@ export class Backup {
     const selectSheets = db.prepare<[]>(`
       select
         id,
-        front_original_filename,
         front_normalized_filename,
-        back_original_filename,
         back_normalized_filename
       from sheets
       `);
-    const updateSheet = db.prepare<[string, string, string, string, string]>(
+    const updateSheet = db.prepare<[string, string, string]>(
       `
       update sheets
-      set front_original_filename = ?,
-          front_normalized_filename = ?,
-          back_original_filename = ?,
+      set front_normalized_filename = ?,
           back_normalized_filename = ?
       where id = ?
       `
@@ -190,9 +152,7 @@ export class Backup {
     const updates: Array<Promise<void>> = [];
     for (const row of selectSheets.all()) {
       updateSheet.run(
-        basename(row.front_original_filename),
         basename(row.front_normalized_filename),
-        basename(row.back_original_filename),
         basename(row.back_normalized_filename),
         row.id
       );
@@ -205,15 +165,12 @@ export class Backup {
 /**
  * Backs up the store and all referenced files into a zip archive.
  */
-export function backup(
-  store: Store,
-  options: BackupOptions = {}
-): NodeJS.ReadableStream {
+export function backup(store: Store): NodeJS.ReadableStream {
   const zip = new ZipStream();
 
   process.nextTick(() => {
     new Backup(zip, store)
-      .backup(options)
+      .backup()
       .then(() => {
         store.setScannerBackedUp();
       })
@@ -231,8 +188,7 @@ export function backup(
  */
 export async function backupToUsbDrive(
   exporter: Exporter,
-  store: Store,
-  options: BackupOptions = {}
+  store: Store
 ): Promise<Scan.BackupResult> {
   const electionDefinition = store.getElectionDefinition();
 
@@ -249,6 +205,6 @@ export async function backupToUsbDrive(
       electionDefinition.election,
       electionDefinition.electionHash
     )}/${new Date().toISOString().replace(/[^-a-z0-9]+/gi, '-')}-backup.zip`,
-    backup(store, options)
+    backup(store)
   );
 }

--- a/apps/central-scan/backend/src/central_scanner_app.test.ts
+++ b/apps/central-scan/backend/src/central_scanner_app.test.ts
@@ -80,9 +80,9 @@ afterEach(async () => {
   server?.close();
 });
 
-const frontNormalized =
+const frontImagePath =
   electionGridLayoutNewHampshireAmherstFixtures.scanMarkedFront.asFilePath();
-const backNormalized =
+const backImagePath =
   electionGridLayoutNewHampshireAmherstFixtures.scanMarkedBack.asFilePath();
 const sheet: SheetOf<PageInterpretationWithFiles> = (() => {
   const metadata: BallotMetadata = {
@@ -97,7 +97,7 @@ const sheet: SheetOf<PageInterpretationWithFiles> = (() => {
   };
   return [
     {
-      normalizedFilename: frontNormalized,
+      imagePath: frontImagePath,
       interpretation: {
         type: 'InterpretedHmpbPage',
         metadata: {
@@ -126,7 +126,7 @@ const sheet: SheetOf<PageInterpretationWithFiles> = (() => {
       },
     },
     {
-      normalizedFilename: backNormalized,
+      imagePath: backImagePath,
       interpretation: {
         type: 'InterpretedHmpbPage',
         metadata: {
@@ -434,32 +434,16 @@ test('GET /scan/hmpb/ballot/:ballotId/:side/image', async () => {
 
   await request(app)
     .get(`/central-scanner/scan/hmpb/ballot/${sheetId}/front/image`)
-    .expect(301)
-    .expect(
-      'Location',
-      `/central-scanner/scan/hmpb/ballot/${sheetId}/front/image/normalized`
-    );
-
-  await request(app)
-    .get(`/central-scanner/scan/hmpb/ballot/${sheetId}/front/image/normalized`)
-    .expect(200, await fs.readFile(frontNormalized));
+    .expect(200, await fs.readFile(frontImagePath));
 
   await request(app)
     .get(`/central-scanner/scan/hmpb/ballot/${sheetId}/back/image`)
-    .expect(301)
-    .expect(
-      'Location',
-      `/central-scanner/scan/hmpb/ballot/${sheetId}/back/image/normalized`
-    );
-
-  await request(app)
-    .get(`/central-scanner/scan/hmpb/ballot/${sheetId}/back/image/normalized`)
-    .expect(200, await fs.readFile(backNormalized));
+    .expect(200, await fs.readFile(backImagePath));
 });
 
 test('GET /scan/hmpb/ballot/:sheetId/image 404', async () => {
   await request(app)
-    .get(`/central-scanner/scan/hmpb/ballot/111/front/image/normalized`)
+    .get(`/central-scanner/scan/hmpb/ballot/111/front/image`)
     .expect(404);
 });
 

--- a/apps/central-scan/backend/src/central_scanner_app.test.ts
+++ b/apps/central-scan/backend/src/central_scanner_app.test.ts
@@ -80,12 +80,10 @@ afterEach(async () => {
   server?.close();
 });
 
-const frontOriginal =
+const frontNormalized =
   electionGridLayoutNewHampshireAmherstFixtures.scanMarkedFront.asFilePath();
-const frontNormalized = frontOriginal;
-const backOriginal =
+const backNormalized =
   electionGridLayoutNewHampshireAmherstFixtures.scanMarkedBack.asFilePath();
-const backNormalized = backOriginal;
 const sheet: SheetOf<PageInterpretationWithFiles> = (() => {
   const metadata: BallotMetadata = {
     locales: { primary: 'en-US' },
@@ -99,7 +97,6 @@ const sheet: SheetOf<PageInterpretationWithFiles> = (() => {
   };
   return [
     {
-      originalFilename: frontOriginal,
       normalizedFilename: frontNormalized,
       interpretation: {
         type: 'InterpretedHmpbPage',
@@ -129,7 +126,6 @@ const sheet: SheetOf<PageInterpretationWithFiles> = (() => {
       },
     },
     {
-      originalFilename: backOriginal,
       normalizedFilename: backNormalized,
       interpretation: {
         type: 'InterpretedHmpbPage',
@@ -449,10 +445,6 @@ test('GET /scan/hmpb/ballot/:ballotId/:side/image', async () => {
     .expect(200, await fs.readFile(frontNormalized));
 
   await request(app)
-    .get(`/central-scanner/scan/hmpb/ballot/${sheetId}/front/image/original`)
-    .expect(200, await fs.readFile(frontOriginal));
-
-  await request(app)
     .get(`/central-scanner/scan/hmpb/ballot/${sheetId}/back/image`)
     .expect(301)
     .expect(
@@ -463,10 +455,6 @@ test('GET /scan/hmpb/ballot/:ballotId/:side/image', async () => {
   await request(app)
     .get(`/central-scanner/scan/hmpb/ballot/${sheetId}/back/image/normalized`)
     .expect(200, await fs.readFile(backNormalized));
-
-  await request(app)
-    .get(`/central-scanner/scan/hmpb/ballot/${sheetId}/back/image/original`)
-    .expect(200, await fs.readFile(backOriginal));
 });
 
 test('GET /scan/hmpb/ballot/:sheetId/image 404', async () => {

--- a/apps/central-scan/backend/src/central_scanner_app.ts
+++ b/apps/central-scan/backend/src/central_scanner_app.ts
@@ -453,22 +453,21 @@ export function buildCentralScannerApp({
   );
 
   deprecatedApiRouter.get(
-    '/central-scanner/scan/hmpb/ballot/:sheetId/:side/image/:version',
+    '/central-scanner/scan/hmpb/ballot/:sheetId/:side/image/normalized',
     (request, response) => {
-      const { sheetId, side, version } = request.params;
+      const { sheetId, side } = request.params;
 
       if (
         typeof sheetId !== 'string' ||
-        (side !== 'front' && side !== 'back') ||
-        (version !== 'original' && version !== 'normalized')
+        (side !== 'front' && side !== 'back')
       ) {
         response.status(404);
         return;
       }
       const filenames = store.getBallotFilenames(sheetId, side);
 
-      if (filenames && version in filenames) {
-        response.sendFile(filenames[version]);
+      if (filenames) {
+        response.sendFile(filenames.normalized);
       } else {
         response.status(404).end();
       }

--- a/apps/central-scan/backend/src/central_scanner_app.ts
+++ b/apps/central-scan/backend/src/central_scanner_app.ts
@@ -444,30 +444,10 @@ export function buildCentralScannerApp({
         response.status(404);
         return;
       }
+      const imagePath = store.getBallotImagePath(sheetId, side);
 
-      response.redirect(
-        301,
-        `/central-scanner/scan/hmpb/ballot/${sheetId}/${side}/image/normalized`
-      );
-    }
-  );
-
-  deprecatedApiRouter.get(
-    '/central-scanner/scan/hmpb/ballot/:sheetId/:side/image/normalized',
-    (request, response) => {
-      const { sheetId, side } = request.params;
-
-      if (
-        typeof sheetId !== 'string' ||
-        (side !== 'front' && side !== 'back')
-      ) {
-        response.status(404);
-        return;
-      }
-      const filenames = store.getBallotFilenames(sheetId, side);
-
-      if (filenames) {
-        response.sendFile(filenames.normalized);
+      if (imagePath) {
+        response.sendFile(imagePath);
       } else {
         response.status(404).end();
       }

--- a/apps/central-scan/backend/src/importer.ts
+++ b/apps/central-scan/backend/src/importer.ts
@@ -89,23 +89,21 @@ export class Importer {
 
   async importSheet(
     batchId: string,
-    frontImagePath: string,
-    backImagePath: string
+    frontInputImagePath: string,
+    backInputImagePath: string
   ): Promise<string> {
     let sheetId = uuid();
     const interpretResult = await this.interpretSheet(sheetId, [
-      frontImagePath,
-      backImagePath,
+      frontInputImagePath,
+      backInputImagePath,
     ]);
 
     if (interpretResult.isErr()) {
       throw interpretResult.err();
     }
 
-    const [
-      { normalizedFilename: frontNormalizedFilename },
-      { normalizedFilename: backNormalizedFilename },
-    ] = interpretResult.ok();
+    const [{ imagePath: frontImagePath }, { imagePath: backImagePath }] =
+      interpretResult.ok();
     let [
       { interpretation: frontInterpretation },
       { interpretation: backInterpretation },
@@ -149,9 +147,9 @@ export class Importer {
 
     sheetId = await this.addSheet(
       batchId,
-      frontNormalizedFilename,
+      frontImagePath,
       frontInterpretation,
-      backNormalizedFilename,
+      backImagePath,
       backInterpretation
     );
 
@@ -186,9 +184,9 @@ export class Importer {
    */
   private async addSheet(
     batchId: string,
-    frontNormalizedBallotImagePath: string,
+    frontImagePath: string,
     frontInterpretation: PageInterpretation,
-    backNormalizedBallotImagePath: string,
+    backImagePath: string,
     backInterpretation: PageInterpretation
   ): Promise<string> {
     if ('metadata' in frontInterpretation && 'metadata' in backInterpretation) {
@@ -202,9 +200,9 @@ export class Importer {
         ) {
           return this.addSheet(
             batchId,
-            backNormalizedBallotImagePath,
+            backImagePath,
             backInterpretation,
-            frontNormalizedBallotImagePath,
+            frontImagePath,
             frontInterpretation
           );
         }
@@ -213,11 +211,11 @@ export class Importer {
 
     const ballotId = this.workspace.store.addSheet(uuid(), batchId, [
       {
-        normalizedFilename: frontNormalizedBallotImagePath,
+        imagePath: frontImagePath,
         interpretation: frontInterpretation,
       },
       {
-        normalizedFilename: backNormalizedBallotImagePath,
+        imagePath: backImagePath,
         interpretation: backInterpretation,
       },
     ]);

--- a/apps/central-scan/backend/src/importer.ts
+++ b/apps/central-scan/backend/src/importer.ts
@@ -103,14 +103,8 @@ export class Importer {
     }
 
     const [
-      {
-        originalFilename: frontOriginalFilename,
-        normalizedFilename: frontNormalizedFilename,
-      },
-      {
-        originalFilename: backOriginalFilename,
-        normalizedFilename: backNormalizedFilename,
-      },
+      { normalizedFilename: frontNormalizedFilename },
+      { normalizedFilename: backNormalizedFilename },
     ] = interpretResult.ok();
     let [
       { interpretation: frontInterpretation },
@@ -155,10 +149,8 @@ export class Importer {
 
     sheetId = await this.addSheet(
       batchId,
-      frontOriginalFilename,
       frontNormalizedFilename,
       frontInterpretation,
-      backOriginalFilename,
       backNormalizedFilename,
       backInterpretation
     );
@@ -194,10 +186,8 @@ export class Importer {
    */
   private async addSheet(
     batchId: string,
-    frontOriginalBallotImagePath: string,
     frontNormalizedBallotImagePath: string,
     frontInterpretation: PageInterpretation,
-    backOriginalBallotImagePath: string,
     backNormalizedBallotImagePath: string,
     backInterpretation: PageInterpretation
   ): Promise<string> {
@@ -212,10 +202,8 @@ export class Importer {
         ) {
           return this.addSheet(
             batchId,
-            backOriginalBallotImagePath,
             backNormalizedBallotImagePath,
             backInterpretation,
-            frontOriginalBallotImagePath,
             frontNormalizedBallotImagePath,
             frontInterpretation
           );
@@ -225,12 +213,10 @@ export class Importer {
 
     const ballotId = this.workspace.store.addSheet(uuid(), batchId, [
       {
-        originalFilename: frontOriginalBallotImagePath,
         normalizedFilename: frontNormalizedBallotImagePath,
         interpretation: frontInterpretation,
       },
       {
-        originalFilename: backOriginalBallotImagePath,
         normalizedFilename: backNormalizedBallotImagePath,
         interpretation: backInterpretation,
       },

--- a/apps/central-scan/backend/src/store.test.ts
+++ b/apps/central-scan/backend/src/store.test.ts
@@ -241,14 +241,12 @@ test('batchStatus', () => {
   const batchId = store.addBatch();
   const sheetId = store.addSheet(uuid(), batchId, [
     {
-      originalFilename: '/tmp/front-page.png',
       normalizedFilename: '/tmp/front-normalized-page.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      originalFilename: '/tmp/back-page.png',
       normalizedFilename: '/tmp/back-normalized-page.png',
       interpretation: {
         type: 'UnreadablePage',
@@ -259,14 +257,12 @@ test('batchStatus', () => {
   // Add a second sheet
   const sheetId2 = store.addSheet(uuid(), batchId, [
     {
-      originalFilename: '/tmp/front-page2.png',
       normalizedFilename: '/tmp/front-normalized-page2.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      originalFilename: '/tmp/back-page2.png',
       normalizedFilename: '/tmp/back-normalized-page2.png',
       interpretation: {
         type: 'UnreadablePage',
@@ -322,14 +318,12 @@ test('canUnconfigure not in test mode', async () => {
   // Cannot unconfigure after new sheet added
   const sheetId = store.addSheet(uuid(), batchId, [
     {
-      originalFilename: '/tmp/front-page.png',
       normalizedFilename: '/tmp/front-normalized-page.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      originalFilename: '/tmp/back-page.png',
       normalizedFilename: '/tmp/back-normalized-page.png',
       interpretation: {
         type: 'UnreadablePage',
@@ -345,14 +339,12 @@ test('canUnconfigure not in test mode', async () => {
   const batchId2 = store.addBatch();
   store.addSheet(uuid(), batchId2, [
     {
-      originalFilename: '/tmp/front-page2.png',
       normalizedFilename: '/tmp/front-normalized-page2.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      originalFilename: '/tmp/back-page2.png',
       normalizedFilename: '/tmp/back-normalized-page2.png',
       interpretation: {
         type: 'UnreadablePage',
@@ -368,14 +360,12 @@ test('canUnconfigure not in test mode', async () => {
   const batchId3 = store.addBatch();
   const sheetId3 = store.addSheet(uuid(), batchId3, [
     {
-      originalFilename: '/tmp/front-page3.png',
       normalizedFilename: '/tmp/front-normalized-page3.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      originalFilename: '/tmp/back-page3.png',
       normalizedFilename: '/tmp/back-normalized-page3.png',
       interpretation: {
         type: 'UnreadablePage',
@@ -432,7 +422,6 @@ test('adjudication', () => {
       ballotType: BallotType.Standard,
     };
     return {
-      originalFilename: i === 0 ? '/front-original.png' : '/back-original.png',
       normalizedFilename:
         i === 0 ? '/front-normalized.png' : '/back-normalized.png',
       interpretation: {
@@ -529,7 +518,6 @@ const metadata: BallotMetadata = {
 };
 const sheetWithFiles: SheetOf<PageInterpretationWithFiles> = [
   {
-    originalFilename: '/original.png',
     normalizedFilename: '/normalized.png',
     interpretation: {
       type: 'InterpretedHmpbPage',
@@ -559,7 +547,6 @@ const sheetWithFiles: SheetOf<PageInterpretationWithFiles> = [
     },
   },
   {
-    originalFilename: '/original.png',
     normalizedFilename: '/normalized.png',
     interpretation: {
       type: 'InterpretedHmpbPage',
@@ -659,12 +646,10 @@ test('iterating over each result sheet includes correct batch sequence id', () =
     return [
       {
         ...sheetWithFiles[0],
-        originalFilename: uuid(),
         normalizedFilename: uuid(),
       },
       {
         ...sheetWithFiles[1],
-        originalFilename: uuid(),
         normalizedFilename: uuid(),
       },
     ];
@@ -759,14 +744,12 @@ test('getBallotsCounted', () => {
   const batchId = store.addBatch();
   store.addSheet(uuid(), batchId, [
     {
-      originalFilename: '/tmp/front-page.png',
       normalizedFilename: '/tmp/front-normalized-page.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      originalFilename: '/tmp/back-page.png',
       normalizedFilename: '/tmp/back-normalized-page.png',
       interpretation: {
         type: 'UnreadablePage',
@@ -782,14 +765,12 @@ test('getBallotsCounted', () => {
   const batch2Id = store.addBatch();
   store.addSheet(uuid(), batch2Id, [
     {
-      originalFilename: '/tmp/front-page2.png',
       normalizedFilename: '/tmp/front-normalized-page2.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      originalFilename: '/tmp/back-page2.png',
       normalizedFilename: '/tmp/back-normalized-page2.png',
       interpretation: {
         type: 'UnreadablePage',
@@ -801,14 +782,12 @@ test('getBallotsCounted', () => {
 
   const sheetId3 = store.addSheet(uuid(), batch2Id, [
     {
-      originalFilename: '/tmp/front-page3.png',
       normalizedFilename: '/tmp/front-normalized-page3.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      originalFilename: '/tmp/back-page3.png',
       normalizedFilename: '/tmp/back-normalized-page3.png',
       interpretation: {
         type: 'UnreadablePage',

--- a/apps/central-scan/backend/src/store.test.ts
+++ b/apps/central-scan/backend/src/store.test.ts
@@ -241,13 +241,13 @@ test('batchStatus', () => {
   const batchId = store.addBatch();
   const sheetId = store.addSheet(uuid(), batchId, [
     {
-      normalizedFilename: '/tmp/front-normalized-page.png',
+      imagePath: '/tmp/front-page.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      normalizedFilename: '/tmp/back-normalized-page.png',
+      imagePath: '/tmp/back-page.png',
       interpretation: {
         type: 'UnreadablePage',
       },
@@ -257,13 +257,13 @@ test('batchStatus', () => {
   // Add a second sheet
   const sheetId2 = store.addSheet(uuid(), batchId, [
     {
-      normalizedFilename: '/tmp/front-normalized-page2.png',
+      imagePath: '/tmp/front-page2.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      normalizedFilename: '/tmp/back-normalized-page2.png',
+      imagePath: '/tmp/back-page2.png',
       interpretation: {
         type: 'UnreadablePage',
       },
@@ -318,13 +318,13 @@ test('canUnconfigure not in test mode', async () => {
   // Cannot unconfigure after new sheet added
   const sheetId = store.addSheet(uuid(), batchId, [
     {
-      normalizedFilename: '/tmp/front-normalized-page.png',
+      imagePath: '/tmp/front-page.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      normalizedFilename: '/tmp/back-normalized-page.png',
+      imagePath: '/tmp/back-page.png',
       interpretation: {
         type: 'UnreadablePage',
       },
@@ -339,13 +339,13 @@ test('canUnconfigure not in test mode', async () => {
   const batchId2 = store.addBatch();
   store.addSheet(uuid(), batchId2, [
     {
-      normalizedFilename: '/tmp/front-normalized-page2.png',
+      imagePath: '/tmp/front-page2.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      normalizedFilename: '/tmp/back-normalized-page2.png',
+      imagePath: '/tmp/back-page2.png',
       interpretation: {
         type: 'UnreadablePage',
       },
@@ -360,13 +360,13 @@ test('canUnconfigure not in test mode', async () => {
   const batchId3 = store.addBatch();
   const sheetId3 = store.addSheet(uuid(), batchId3, [
     {
-      normalizedFilename: '/tmp/front-normalized-page3.png',
+      imagePath: '/tmp/front-page3.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      normalizedFilename: '/tmp/back-normalized-page3.png',
+      imagePath: '/tmp/back-page3.png',
       interpretation: {
         type: 'UnreadablePage',
       },
@@ -422,8 +422,7 @@ test('adjudication', () => {
       ballotType: BallotType.Standard,
     };
     return {
-      normalizedFilename:
-        i === 0 ? '/front-normalized.png' : '/back-normalized.png',
+      imagePath: i === 0 ? '/front.png' : '/back.png',
       interpretation: {
         type: 'InterpretedHmpbPage',
         votes: {},
@@ -518,7 +517,7 @@ const metadata: BallotMetadata = {
 };
 const sheetWithFiles: SheetOf<PageInterpretationWithFiles> = [
   {
-    normalizedFilename: '/normalized.png',
+    imagePath: '/front.png',
     interpretation: {
       type: 'InterpretedHmpbPage',
       votes: {},
@@ -547,7 +546,7 @@ const sheetWithFiles: SheetOf<PageInterpretationWithFiles> = [
     },
   },
   {
-    normalizedFilename: '/normalized.png',
+    imagePath: '/back.png',
     interpretation: {
       type: 'InterpretedHmpbPage',
       votes: {},
@@ -598,8 +597,8 @@ test('iterating over all result sheets', () => {
         indexInBatch: 1,
         batchLabel: 'Batch 1',
         interpretation: mapSheet(sheetWithFiles, (page) => page.interpretation),
-        frontNormalizedFilename: '/normalized.png',
-        backNormalizedFilename: '/normalized.png',
+        frontImagePath: '/front.png',
+        backImagePath: '/back.png',
       },
     ])
   );
@@ -646,11 +645,11 @@ test('iterating over each result sheet includes correct batch sequence id', () =
     return [
       {
         ...sheetWithFiles[0],
-        normalizedFilename: uuid(),
+        imagePath: uuid(),
       },
       {
         ...sheetWithFiles[1],
-        normalizedFilename: uuid(),
+        imagePath: uuid(),
       },
     ];
   }
@@ -744,13 +743,13 @@ test('getBallotsCounted', () => {
   const batchId = store.addBatch();
   store.addSheet(uuid(), batchId, [
     {
-      normalizedFilename: '/tmp/front-normalized-page.png',
+      imagePath: '/tmp/front-page.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      normalizedFilename: '/tmp/back-normalized-page.png',
+      imagePath: '/tmp/back-page.png',
       interpretation: {
         type: 'UnreadablePage',
       },
@@ -765,13 +764,13 @@ test('getBallotsCounted', () => {
   const batch2Id = store.addBatch();
   store.addSheet(uuid(), batch2Id, [
     {
-      normalizedFilename: '/tmp/front-normalized-page2.png',
+      imagePath: '/tmp/front-page2.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      normalizedFilename: '/tmp/back-normalized-page2.png',
+      imagePath: '/tmp/back-page2.png',
       interpretation: {
         type: 'UnreadablePage',
       },
@@ -782,13 +781,13 @@ test('getBallotsCounted', () => {
 
   const sheetId3 = store.addSheet(uuid(), batch2Id, [
     {
-      normalizedFilename: '/tmp/front-normalized-page3.png',
+      imagePath: '/tmp/front-page3.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      normalizedFilename: '/tmp/back-normalized-page3.png',
+      imagePath: '/tmp/back-page3.png',
       interpretation: {
         type: 'UnreadablePage',
       },

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -662,23 +662,19 @@ export class Store {
         `insert into sheets (
             id,
             batch_id,
-            front_original_filename,
             front_normalized_filename,
             front_interpretation_json,
-            back_original_filename,
             back_normalized_filename,
             back_interpretation_json,
             requires_adjudication,
             finished_adjudication_at
           ) values (
-            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            ?, ?, ?, ?, ?, ?, ?, ?
           )`,
         sheetId,
         batchId,
-        front.originalFilename,
         front.normalizedFilename,
         JSON.stringify(front.interpretation),
-        back.originalFilename,
         back.normalizedFilename,
         JSON.stringify(back.interpretation ?? {}),
         sheetRequiresAdjudication([front.interpretation, back.interpretation])
@@ -689,13 +685,13 @@ export class Store {
     } catch (error) {
       debug(
         'sheet insert failed; maybe a duplicate? filenames=[%s, %s]',
-        front.originalFilename,
-        back.originalFilename
+        front.normalizedFilename,
+        back.normalizedFilename
       );
 
       const row = this.client.one<[string]>(
-        'select id from sheets where front_original_filename = ?',
-        front.originalFilename
+        'select id from sheets where front_normalized_filename = ?',
+        front.normalizedFilename
       ) as { id: string } | undefined;
 
       if (row) {
@@ -736,11 +732,10 @@ export class Store {
   getBallotFilenames(
     sheetId: string,
     side: Side
-  ): { original: string; normalized: string } | undefined {
+  ): { normalized: string } | undefined {
     const row = this.client.one<[string]>(
       `
       select
-        ${side}_original_filename as original,
         ${side}_normalized_filename as normalized
       from
         sheets
@@ -748,14 +743,13 @@ export class Store {
         id = ?
     `,
       sheetId
-    ) as { original: string; normalized: string } | undefined;
+    ) as { normalized: string } | undefined;
 
     if (!row) {
       return;
     }
 
     return {
-      original: normalizeAndJoin(dirname(this.getDbPath()), row.original),
       normalized: normalizeAndJoin(dirname(this.getDbPath()), row.normalized),
     };
   }
@@ -812,42 +806,34 @@ export class Store {
 
   *getSheets(): Generator<{
     id: string;
-    front: { original: string; normalized: string };
-    back: { original: string; normalized: string };
+    front: { normalized: string };
+    back: { normalized: string };
     exportedAsCvrAt: Iso8601Timestamp;
   }> {
     for (const {
       id,
-      frontOriginalFilename,
       frontNormalizedFilename,
-      backOriginalFilename,
       backNormalizedFilename,
       exportedAsCvrAt,
     } of this.client.each(`
       select
         id,
-        front_original_filename as frontOriginalFilename,
         front_normalized_filename as frontNormalizedFilename,
-        back_original_filename as backOriginalFilename,
         back_normalized_filename as backNormalizedFilename
       from sheets
       order by created_at asc
     `) as Iterable<{
       id: string;
-      frontOriginalFilename: string;
       frontNormalizedFilename: string;
-      backOriginalFilename: string;
       backNormalizedFilename: string;
       exportedAsCvrAt: Iso8601Timestamp;
     }>) {
       yield {
         id,
         front: {
-          original: frontOriginalFilename,
           normalized: frontNormalizedFilename,
         },
         back: {
-          original: backOriginalFilename,
           normalized: backNormalizedFilename,
         },
         exportedAsCvrAt,

--- a/apps/scan/backend/bin/extract-backup
+++ b/apps/scan/backend/bin/extract-backup
@@ -24,8 +24,8 @@ sqlite3 "${BACKUP_DIR}/ballots.db" "
     '# batch ' || batches.id || x'0a' ||
     -- get all pages from the batch in front/back order
     group_concat(
-      sheets.front_original_filename || x'0a' ||
-      sheets.back_original_filename,
+      sheets.front_normalized_filename || x'0a' ||
+      sheets.back_normalized_filename,
       x'0a'
     ) ||
     -- separate batches with an empty line

--- a/apps/scan/backend/bin/extract-backup
+++ b/apps/scan/backend/bin/extract-backup
@@ -24,8 +24,8 @@ sqlite3 "${BACKUP_DIR}/ballots.db" "
     '# batch ' || batches.id || x'0a' ||
     -- get all pages from the batch in front/back order
     group_concat(
-      sheets.front_normalized_filename || x'0a' ||
-      sheets.back_normalized_filename,
+      sheets.front_image_path || x'0a' ||
+      sheets.back_image_path,
       x'0a'
     ) ||
     -- separate batches with an empty line

--- a/apps/scan/backend/schema.sql
+++ b/apps/scan/backend/schema.sql
@@ -31,8 +31,6 @@ create table sheets (
   batch_id varchar(36),
 
   -- Filenames for where the sheet images are stored on disk.
-  front_original_filename text unique,
-  back_original_filename text unique,
   front_normalized_filename text unique,
   back_normalized_filename text unique,
 

--- a/apps/scan/backend/schema.sql
+++ b/apps/scan/backend/schema.sql
@@ -30,9 +30,9 @@ create table sheets (
   id varchar(36) primary key,
   batch_id varchar(36),
 
-  -- Filenames for where the sheet images are stored on disk.
-  front_normalized_filename text unique,
-  back_normalized_filename text unique,
+  -- Paths for the sheet images.
+  front_image_path text unique,
+  back_image_path text unique,
 
   -- Original interpretation of the sheet. These values should never be updated.
   -- @type {PageInterpretation}

--- a/apps/scan/backend/src/backup.test.ts
+++ b/apps/scan/backend/src/backup.test.ts
@@ -147,20 +147,20 @@ test('has all files referenced in the database', async () => {
   });
   const batchId = store.addBatch();
 
-  const frontNormalizedFile = fileSync();
-  await writeFile(frontNormalizedFile.fd, 'front normalized');
+  const frontImagePath = fileSync();
+  await writeFile(frontImagePath.fd, 'front image path');
 
-  const backNormalizedFile = fileSync();
-  await writeFile(backNormalizedFile.fd, 'back normalized');
+  const backImagePath = fileSync();
+  await writeFile(backImagePath.fd, 'back image path');
 
   store.addSheet('sheet-1', batchId, [
     {
       interpretation: { type: 'UnreadablePage' },
-      normalizedFilename: frontNormalizedFile.name,
+      imagePath: frontImagePath.name,
     },
     {
       interpretation: { type: 'UnreadablePage' },
-      normalizedFilename: backNormalizedFile.name,
+      imagePath: backImagePath.name,
     },
   ]);
 
@@ -185,14 +185,14 @@ test('has all files referenced in the database', async () => {
       )
       .sort()
   ).toEqual(
-    [frontNormalizedFile.name, backNormalizedFile.name]
+    [frontImagePath.name, backImagePath.name]
       .map((name) => basename(name))
       .sort()
   );
 
   for (const [{ name }, content] of [
-    [frontNormalizedFile, 'front normalized'],
-    [backNormalizedFile, 'back normalized'],
+    [frontImagePath, 'front image path'],
+    [backImagePath, 'back image path'],
   ] as const) {
     expect(
       new TextDecoder().decode(
@@ -206,11 +206,11 @@ test('has all files referenced in the database', async () => {
   await writeFile(dbFile.fd, await readEntry(dbEntry!));
   const db = new Database(dbFile.name);
   const stmt = db.prepare<[]>(
-    'select front_normalized_filename as filename from sheets'
+    'select front_image_path as filename from sheets'
   );
   const row: { filename: string } = stmt.get();
   expect(row).toEqual({
-    filename: basename(frontNormalizedFile.name),
+    filename: basename(frontImagePath.name),
   });
 });
 
@@ -224,7 +224,7 @@ test('has cast vote record report', async () => {
 
   const batchId = store.addBatch();
   const imageFile = fileSync();
-  await writeFile(imageFile.fd, 'front normalized');
+  await writeFile(imageFile.fd, 'front image path');
   store.addSheet('sheet-1', batchId, [
     {
       interpretation: {
@@ -242,11 +242,11 @@ test('has cast vote record report', async () => {
           'flag-question': ['yes'],
         },
       },
-      normalizedFilename: imageFile.name,
+      imagePath: imageFile.name,
     },
     {
       interpretation: { type: 'BlankPage' },
-      normalizedFilename: imageFile.name,
+      imagePath: imageFile.name,
     },
   ]);
 

--- a/apps/scan/backend/src/backup.test.ts
+++ b/apps/scan/backend/src/backup.test.ts
@@ -11,7 +11,6 @@ import {
   TEST_JURISDICTION,
   unsafeParse,
 } from '@votingworks/types';
-import { throwIllegalValue } from '@votingworks/basics';
 import Database from 'better-sqlite3';
 import { writeFileSync } from 'fs';
 import { writeFile, existsSync } from 'fs-extra';
@@ -148,26 +147,20 @@ test('has all files referenced in the database', async () => {
   });
   const batchId = store.addBatch();
 
-  const frontOriginalFile = fileSync();
-  await writeFile(frontOriginalFile.fd, 'front original');
-
   const frontNormalizedFile = fileSync();
   await writeFile(frontNormalizedFile.fd, 'front normalized');
 
-  const backOriginalFile = fileSync();
-  await writeFile(backOriginalFile.fd, 'back original');
+  const backNormalizedFile = fileSync();
+  await writeFile(backNormalizedFile.fd, 'back normalized');
 
   store.addSheet('sheet-1', batchId, [
     {
       interpretation: { type: 'UnreadablePage' },
-      originalFilename: frontOriginalFile.name,
       normalizedFilename: frontNormalizedFile.name,
     },
     {
       interpretation: { type: 'UnreadablePage' },
-      // intentionally the same, for cases where that's true
-      originalFilename: backOriginalFile.name,
-      normalizedFilename: backOriginalFile.name,
+      normalizedFilename: backNormalizedFile.name,
     },
   ]);
 
@@ -192,15 +185,14 @@ test('has all files referenced in the database', async () => {
       )
       .sort()
   ).toEqual(
-    [frontOriginalFile.name, frontNormalizedFile.name, backOriginalFile.name]
+    [frontNormalizedFile.name, backNormalizedFile.name]
       .map((name) => basename(name))
       .sort()
   );
 
   for (const [{ name }, content] of [
-    [frontOriginalFile, 'front original'],
     [frontNormalizedFile, 'front normalized'],
-    [backOriginalFile, 'back original'],
+    [backNormalizedFile, 'back normalized'],
   ] as const) {
     expect(
       new TextDecoder().decode(
@@ -214,11 +206,11 @@ test('has all files referenced in the database', async () => {
   await writeFile(dbFile.fd, await readEntry(dbEntry!));
   const db = new Database(dbFile.name);
   const stmt = db.prepare<[]>(
-    'select front_original_filename as filename from sheets'
+    'select front_normalized_filename as filename from sheets'
   );
   const row: { filename: string } = stmt.get();
   expect(row).toEqual({
-    filename: basename(frontOriginalFile.name),
+    filename: basename(frontNormalizedFile.name),
   });
 });
 
@@ -232,7 +224,7 @@ test('has cast vote record report', async () => {
 
   const batchId = store.addBatch();
   const imageFile = fileSync();
-  await writeFile(imageFile.fd, 'front original');
+  await writeFile(imageFile.fd, 'front normalized');
   store.addSheet('sheet-1', batchId, [
     {
       interpretation: {
@@ -250,12 +242,10 @@ test('has cast vote record report', async () => {
           'flag-question': ['yes'],
         },
       },
-      originalFilename: imageFile.name,
       normalizedFilename: imageFile.name,
     },
     {
       interpretation: { type: 'BlankPage' },
-      originalFilename: imageFile.name,
       normalizedFilename: imageFile.name,
     },
   ]);
@@ -322,111 +312,3 @@ test('has vx-logs.log if file exists', async () => {
   const logsEntry = entries.find(({ name }) => name === 'vx-logs.log')!;
   expect(await readTextEntry(logsEntry)).toEqual('mock logs');
 });
-
-const spaceOptimizedBackupTestCases: Array<{
-  saveOnlyOriginalImagesThenOnlyNormalizedImagesAfterNumSheets?: number;
-  numSheets: number;
-  expectedScanImagesInBackup: 'All' | 'OriginalOnly' | 'NormalizedOnly';
-}> = [
-  {
-    saveOnlyOriginalImagesThenOnlyNormalizedImagesAfterNumSheets: undefined,
-    numSheets: 1,
-    expectedScanImagesInBackup: 'All',
-  },
-  {
-    saveOnlyOriginalImagesThenOnlyNormalizedImagesAfterNumSheets: 1,
-    numSheets: 1,
-    expectedScanImagesInBackup: 'OriginalOnly',
-  },
-  {
-    saveOnlyOriginalImagesThenOnlyNormalizedImagesAfterNumSheets: 1,
-    numSheets: 2,
-    expectedScanImagesInBackup: 'NormalizedOnly',
-  },
-];
-
-test.each(spaceOptimizedBackupTestCases)(
-  'saveOnlyOriginalImagesThenOnlyNormalizedImagesAfterNumSheets affects what is backed up as expected (%s)',
-  async ({
-    saveOnlyOriginalImagesThenOnlyNormalizedImagesAfterNumSheets,
-    numSheets,
-    expectedScanImagesInBackup,
-  }) => {
-    const store = Store.memoryStore();
-    store.setElectionAndJurisdiction({
-      electionData: electionDefinition.electionData,
-      jurisdiction,
-    });
-    const batchId = store.addBatch();
-
-    const originalFileNames = [];
-    const normalizedFileNames = [];
-    for (let i = 0; i < numSheets; i += 1) {
-      const frontOriginalFile = fileSync();
-      await writeFile(frontOriginalFile.fd, 'front-original');
-      const frontNormalizedFile = fileSync();
-      await writeFile(frontNormalizedFile.fd, 'front-normalized');
-      const backOriginalFile = fileSync();
-      await writeFile(backOriginalFile.fd, 'back-original');
-      const backNormalizedFile = fileSync();
-      await writeFile(backNormalizedFile.fd, 'back-normalized');
-      originalFileNames.push(frontOriginalFile.name, backOriginalFile.name);
-      normalizedFileNames.push(
-        frontNormalizedFile.name,
-        backNormalizedFile.name
-      );
-      store.addSheet(`sheet-${i + 1}`, batchId, [
-        {
-          interpretation: { type: 'UnreadablePage' },
-          originalFilename: frontOriginalFile.name,
-          normalizedFilename: frontNormalizedFile.name,
-        },
-        {
-          interpretation: { type: 'UnreadablePage' },
-          originalFilename: backOriginalFile.name,
-          normalizedFilename: backNormalizedFile.name,
-        },
-      ]);
-    }
-
-    const output = new WritableStream();
-    await new Promise((resolve, reject) => {
-      backup(store, {
-        saveOnlyOriginalImagesThenOnlyNormalizedImagesAfterNumSheets,
-      })
-        .on('error', reject)
-        .pipe(output)
-        .on('finish', resolve);
-    });
-    const zipfile = await openZip(output.toBuffer());
-    const entries = getEntries(zipfile);
-
-    let expectedScanImageFileNamesInBackup: string[] = [];
-    if (expectedScanImagesInBackup === 'All') {
-      expectedScanImageFileNamesInBackup = [
-        ...originalFileNames,
-        ...normalizedFileNames,
-      ];
-    } else if (expectedScanImagesInBackup === 'NormalizedOnly') {
-      expectedScanImageFileNamesInBackup = normalizedFileNames;
-    } else if (expectedScanImagesInBackup === 'OriginalOnly') {
-      expectedScanImageFileNamesInBackup = originalFileNames;
-    } else {
-      throwIllegalValue(expectedScanImagesInBackup);
-    }
-    expect(
-      entries
-        .map((entry) => entry.name)
-        .filter(
-          (fileName) =>
-            fileName !== 'election.json' &&
-            fileName !== 'ballots.db' &&
-            fileName !== 'ballots.db.digest' &&
-            fileName !== CAST_VOTE_RECORD_REPORT_FILENAME
-        )
-        .sort()
-    ).toEqual(
-      expectedScanImageFileNamesInBackup.map((name) => basename(name)).sort()
-    );
-  }
-);

--- a/apps/scan/backend/src/backup.ts
+++ b/apps/scan/backend/src/backup.ts
@@ -116,8 +116,8 @@ export class Backup {
     }
     debug('adding ballot images to backup...');
     for (const sheet of sheets) {
-      await this.addFileEntry(sheet.front.normalized);
-      await this.addFileEntry(sheet.back.normalized);
+      await this.addFileEntry(sheet.frontImagePath);
+      await this.addFileEntry(sheet.backImagePath);
     }
     debug('added ballot images to backup');
 
@@ -140,15 +140,16 @@ export class Backup {
     const selectSheets = db.prepare<[]>(`
       select
         id,
-        front_normalized_filename,
-        back_normalized_filename
+        front_image_path,
+        back_image_path
       from sheets
       `);
     const updateSheet = db.prepare<[string, string, string]>(
       `
       update sheets
-          front_normalized_filename = ?,
-          back_normalized_filename = ?
+      set
+        front_image_path = ?,
+        back_image_path = ?
       where id = ?
       `
     );
@@ -156,8 +157,8 @@ export class Backup {
     const updates: Array<Promise<void>> = [];
     for (const row of selectSheets.all()) {
       updateSheet.run(
-        basename(row.front_normalized_filename),
-        basename(row.back_normalized_filename),
+        basename(row.front_image_path),
+        basename(row.back_image_path),
         row.id
       );
     }

--- a/apps/scan/backend/src/backup.ts
+++ b/apps/scan/backend/src/backup.ts
@@ -23,19 +23,6 @@ import { buildExporter } from './util/exporter';
 const debug = rootDebug.extend('backup');
 
 /**
- * Specifies what to include in the backup
- *
- * @property saveOnlyOriginalImagesThenOnlyNormalizedImagesAfterNumSheets If the number of sheets
- * scanned by the machine is less than or equal to this, only original scan images will be included
- * in the backup, and if the number of sheets scanned by the machine is greater, only normalized
- * scan images will be included in the backup. If not specified, both original and normalized scan
- * images will be included.
- */
-export interface BackupOptions {
-  saveOnlyOriginalImagesThenOnlyNormalizedImagesAfterNumSheets?: number;
-}
-
-/**
  * Creates a backup of the database and all scanned files.
  */
 export class Backup {
@@ -85,9 +72,7 @@ export class Backup {
   /**
    * Runs the backup.
    */
-  async backup({
-    saveOnlyOriginalImagesThenOnlyNormalizedImagesAfterNumSheets,
-  }: BackupOptions = {}): Promise<void> {
+  async backup(): Promise<void> {
     debug('starting a backup');
 
     const electionDefinition = this.store.getElectionDefinition();
@@ -130,28 +115,9 @@ export class Backup {
       sheets.push(sheet);
     }
     debug('adding ballot images to backup...');
-    if (
-      saveOnlyOriginalImagesThenOnlyNormalizedImagesAfterNumSheets !== undefined
-    ) {
-      for (const sheet of sheets) {
-        if (
-          sheets.length <=
-          saveOnlyOriginalImagesThenOnlyNormalizedImagesAfterNumSheets
-        ) {
-          await this.addFileEntry(sheet.front.original);
-          await this.addFileEntry(sheet.back.original);
-        } else {
-          await this.addFileEntry(sheet.front.normalized);
-          await this.addFileEntry(sheet.back.normalized);
-        }
-      }
-    } else {
-      for (const sheet of sheets) {
-        await this.addFileEntry(sheet.front.original);
-        await this.addFileEntry(sheet.front.normalized);
-        await this.addFileEntry(sheet.back.original);
-        await this.addFileEntry(sheet.back.normalized);
-      }
+    for (const sheet of sheets) {
+      await this.addFileEntry(sheet.front.normalized);
+      await this.addFileEntry(sheet.back.normalized);
     }
     debug('added ballot images to backup');
 
@@ -174,18 +140,14 @@ export class Backup {
     const selectSheets = db.prepare<[]>(`
       select
         id,
-        front_original_filename,
         front_normalized_filename,
-        back_original_filename,
         back_normalized_filename
       from sheets
       `);
-    const updateSheet = db.prepare<[string, string, string, string, string]>(
+    const updateSheet = db.prepare<[string, string, string]>(
       `
       update sheets
-      set front_original_filename = ?,
           front_normalized_filename = ?,
-          back_original_filename = ?,
           back_normalized_filename = ?
       where id = ?
       `
@@ -194,9 +156,7 @@ export class Backup {
     const updates: Array<Promise<void>> = [];
     for (const row of selectSheets.all()) {
       updateSheet.run(
-        basename(row.front_original_filename),
         basename(row.front_normalized_filename),
-        basename(row.back_original_filename),
         basename(row.back_normalized_filename),
         row.id
       );
@@ -209,15 +169,12 @@ export class Backup {
 /**
  * Backs up the store and all referenced files into a zip archive.
  */
-export function backup(
-  store: Store,
-  options: BackupOptions = {}
-): NodeJS.ReadableStream {
+export function backup(store: Store): NodeJS.ReadableStream {
   const zip = new ZipStream();
 
   process.nextTick(() => {
     new Backup(zip, store)
-      .backup(options)
+      .backup()
       .then(() => {
         store.setScannerBackedUp();
       })
@@ -235,8 +192,7 @@ export function backup(
  */
 export async function backupToUsbDrive(
   store: Store,
-  usbDrive: UsbDrive,
-  options: BackupOptions = {}
+  usbDrive: UsbDrive
 ): Promise<Result<void, ExportDataError>> {
   const electionDefinition = store.getElectionDefinition();
   assert(electionDefinition, 'Cannot backup without election configuration');
@@ -248,7 +204,7 @@ export async function backupToUsbDrive(
       electionDefinition.election,
       electionDefinition.electionHash
     )}/${new Date().toISOString().replace(/[^-a-z0-9]+/gi, '-')}-backup.zip`,
-    backup(store, options)
+    backup(store)
   );
   return result.isErr() ? result : ok();
 }

--- a/apps/scan/backend/src/store.test.ts
+++ b/apps/scan/backend/src/store.test.ts
@@ -330,14 +330,12 @@ test('batchStatus', () => {
   const batchId = store.addBatch();
   const sheetId = store.addSheet(uuid(), batchId, [
     {
-      originalFilename: '/tmp/front-page.png',
       normalizedFilename: '/tmp/front-normalized-page.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      originalFilename: '/tmp/back-page.png',
       normalizedFilename: '/tmp/back-normalized-page.png',
       interpretation: {
         type: 'UnreadablePage',
@@ -348,14 +346,12 @@ test('batchStatus', () => {
   // Add a second sheet
   const sheetId2 = store.addSheet(uuid(), batchId, [
     {
-      originalFilename: '/tmp/front-page2.png',
       normalizedFilename: '/tmp/front-normalized-page2.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      originalFilename: '/tmp/back-page2.png',
       normalizedFilename: '/tmp/back-normalized-page2.png',
       interpretation: {
         type: 'UnreadablePage',
@@ -421,14 +417,12 @@ test('canUnconfigure not in test mode', async () => {
   // Cannot unconfigure after new sheet added
   const sheetId = store.addSheet(uuid(), batchId, [
     {
-      originalFilename: '/tmp/front-page.png',
       normalizedFilename: '/tmp/front-normalized-page.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      originalFilename: '/tmp/back-page.png',
       normalizedFilename: '/tmp/back-normalized-page.png',
       interpretation: {
         type: 'UnreadablePage',
@@ -444,14 +438,12 @@ test('canUnconfigure not in test mode', async () => {
   const batchId2 = store.addBatch();
   store.addSheet(uuid(), batchId2, [
     {
-      originalFilename: '/tmp/front-page2.png',
       normalizedFilename: '/tmp/front-normalized-page2.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      originalFilename: '/tmp/back-page2.png',
       normalizedFilename: '/tmp/back-normalized-page2.png',
       interpretation: {
         type: 'UnreadablePage',
@@ -467,14 +459,12 @@ test('canUnconfigure not in test mode', async () => {
   const batchId3 = store.addBatch();
   const sheetId3 = store.addSheet(uuid(), batchId3, [
     {
-      originalFilename: '/tmp/front-page3.png',
       normalizedFilename: '/tmp/front-normalized-page3.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      originalFilename: '/tmp/back-page3.png',
       normalizedFilename: '/tmp/back-normalized-page3.png',
       interpretation: {
         type: 'UnreadablePage',
@@ -540,7 +530,6 @@ test('adjudication', () => {
       ballotType: BallotType.Standard,
     };
     return {
-      originalFilename: i === 0 ? '/front-original.png' : '/back-original.png',
       normalizedFilename:
         i === 0 ? '/front-normalized.png' : '/back-normalized.png',
       interpretation: {
@@ -653,7 +642,6 @@ test('iterating over all result sheets', () => {
   };
   const sheetWithFiles: SheetOf<PageInterpretationWithFiles> = [
     {
-      originalFilename: '/original.png',
       normalizedFilename: '/normalized.png',
       interpretation: {
         type: 'InterpretedHmpbPage',
@@ -683,7 +671,6 @@ test('iterating over all result sheets', () => {
       },
     },
     {
-      originalFilename: '/original.png',
       normalizedFilename: '/normalized.png',
       interpretation: {
         type: 'InterpretedHmpbPage',
@@ -816,14 +803,12 @@ test('getBallotsCounted', () => {
   const batchId = store.addBatch();
   store.addSheet(uuid(), batchId, [
     {
-      originalFilename: '/tmp/front-page.png',
       normalizedFilename: '/tmp/front-normalized-page.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      originalFilename: '/tmp/back-page.png',
       normalizedFilename: '/tmp/back-normalized-page.png',
       interpretation: {
         type: 'UnreadablePage',
@@ -839,14 +824,12 @@ test('getBallotsCounted', () => {
   const batch2Id = store.addBatch();
   store.addSheet(uuid(), batch2Id, [
     {
-      originalFilename: '/tmp/front-page2.png',
       normalizedFilename: '/tmp/front-normalized-page2.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      originalFilename: '/tmp/back-page2.png',
       normalizedFilename: '/tmp/back-normalized-page2.png',
       interpretation: {
         type: 'UnreadablePage',
@@ -858,14 +841,12 @@ test('getBallotsCounted', () => {
 
   const sheetId3 = store.addSheet(uuid(), batch2Id, [
     {
-      originalFilename: '/tmp/front-page3.png',
       normalizedFilename: '/tmp/front-normalized-page3.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      originalFilename: '/tmp/back-page3.png',
       normalizedFilename: '/tmp/back-normalized-page3.png',
       interpretation: {
         type: 'UnreadablePage',

--- a/apps/scan/backend/src/store.test.ts
+++ b/apps/scan/backend/src/store.test.ts
@@ -330,13 +330,13 @@ test('batchStatus', () => {
   const batchId = store.addBatch();
   const sheetId = store.addSheet(uuid(), batchId, [
     {
-      normalizedFilename: '/tmp/front-normalized-page.png',
+      imagePath: '/tmp/front-page.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      normalizedFilename: '/tmp/back-normalized-page.png',
+      imagePath: '/tmp/back-page.png',
       interpretation: {
         type: 'UnreadablePage',
       },
@@ -346,13 +346,13 @@ test('batchStatus', () => {
   // Add a second sheet
   const sheetId2 = store.addSheet(uuid(), batchId, [
     {
-      normalizedFilename: '/tmp/front-normalized-page2.png',
+      imagePath: '/tmp/front-page2.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      normalizedFilename: '/tmp/back-normalized-page2.png',
+      imagePath: '/tmp/back-page2.png',
       interpretation: {
         type: 'UnreadablePage',
       },
@@ -417,13 +417,13 @@ test('canUnconfigure not in test mode', async () => {
   // Cannot unconfigure after new sheet added
   const sheetId = store.addSheet(uuid(), batchId, [
     {
-      normalizedFilename: '/tmp/front-normalized-page.png',
+      imagePath: '/tmp/front-page.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      normalizedFilename: '/tmp/back-normalized-page.png',
+      imagePath: '/tmp/back-page.png',
       interpretation: {
         type: 'UnreadablePage',
       },
@@ -438,13 +438,13 @@ test('canUnconfigure not in test mode', async () => {
   const batchId2 = store.addBatch();
   store.addSheet(uuid(), batchId2, [
     {
-      normalizedFilename: '/tmp/front-normalized-page2.png',
+      imagePath: '/tmp/front-page2.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      normalizedFilename: '/tmp/back-normalized-page2.png',
+      imagePath: '/tmp/back-page2.png',
       interpretation: {
         type: 'UnreadablePage',
       },
@@ -459,13 +459,13 @@ test('canUnconfigure not in test mode', async () => {
   const batchId3 = store.addBatch();
   const sheetId3 = store.addSheet(uuid(), batchId3, [
     {
-      normalizedFilename: '/tmp/front-normalized-page3.png',
+      imagePath: '/tmp/front-page3.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      normalizedFilename: '/tmp/back-normalized-page3.png',
+      imagePath: '/tmp/back-page3.png',
       interpretation: {
         type: 'UnreadablePage',
       },
@@ -530,8 +530,7 @@ test('adjudication', () => {
       ballotType: BallotType.Standard,
     };
     return {
-      normalizedFilename:
-        i === 0 ? '/front-normalized.png' : '/back-normalized.png',
+      imagePath: i === 0 ? '/front.png' : '/back.png',
       interpretation: {
         type: 'InterpretedHmpbPage',
         votes: {},
@@ -642,7 +641,7 @@ test('iterating over all result sheets', () => {
   };
   const sheetWithFiles: SheetOf<PageInterpretationWithFiles> = [
     {
-      normalizedFilename: '/normalized.png',
+      imagePath: '/front.png',
       interpretation: {
         type: 'InterpretedHmpbPage',
         votes: {},
@@ -671,7 +670,7 @@ test('iterating over all result sheets', () => {
       },
     },
     {
-      normalizedFilename: '/normalized.png',
+      imagePath: '/back.png',
       interpretation: {
         type: 'InterpretedHmpbPage',
         votes: {},
@@ -711,8 +710,8 @@ test('iterating over all result sheets', () => {
         batchId,
         batchLabel: 'Batch 1',
         interpretation: mapSheet(sheetWithFiles, (page) => page.interpretation),
-        frontNormalizedFilename: '/normalized.png',
-        backNormalizedFilename: '/normalized.png',
+        frontImagePath: '/front.png',
+        backImagePath: '/back.png',
       },
     ])
   );
@@ -803,13 +802,13 @@ test('getBallotsCounted', () => {
   const batchId = store.addBatch();
   store.addSheet(uuid(), batchId, [
     {
-      normalizedFilename: '/tmp/front-normalized-page.png',
+      imagePath: '/tmp/front-page.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      normalizedFilename: '/tmp/back-normalized-page.png',
+      imagePath: '/tmp/back-page.png',
       interpretation: {
         type: 'UnreadablePage',
       },
@@ -824,13 +823,13 @@ test('getBallotsCounted', () => {
   const batch2Id = store.addBatch();
   store.addSheet(uuid(), batch2Id, [
     {
-      normalizedFilename: '/tmp/front-normalized-page2.png',
+      imagePath: '/tmp/front-page2.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      normalizedFilename: '/tmp/back-normalized-page2.png',
+      imagePath: '/tmp/back-page2.png',
       interpretation: {
         type: 'UnreadablePage',
       },
@@ -841,13 +840,13 @@ test('getBallotsCounted', () => {
 
   const sheetId3 = store.addSheet(uuid(), batch2Id, [
     {
-      normalizedFilename: '/tmp/front-normalized-page3.png',
+      imagePath: '/tmp/front-page3.png',
       interpretation: {
         type: 'UnreadablePage',
       },
     },
     {
-      normalizedFilename: '/tmp/back-normalized-page3.png',
+      imagePath: '/tmp/back-page3.png',
       interpretation: {
         type: 'UnreadablePage',
       },

--- a/apps/scan/backend/src/tally-cvrs/export.test.ts
+++ b/apps/scan/backend/src/tally-cvrs/export.test.ts
@@ -78,7 +78,6 @@ test('exportCvrs', () => {
   const batchId = store.addBatch();
   store.addSheet(uuid(), batchId, [
     {
-      originalFilename: '/tmp/front-page.png',
       normalizedFilename: '/tmp/front-page-normalized.png',
       interpretation: {
         type: 'InterpretedHmpbPage',
@@ -108,7 +107,6 @@ test('exportCvrs', () => {
       },
     },
     {
-      originalFilename: '/tmp/back-page.png',
       normalizedFilename: '/tmp/back-page-normalized.png',
       interpretation: {
         type: 'InterpretedHmpbPage',
@@ -168,7 +166,6 @@ test('exportCvrs orders by sheet ID', async () => {
 
     store.addSheet(sheetId, batchId, [
       {
-        originalFilename: `/tmp/front-page-${sheetId}.png`,
         normalizedFilename: frontNormalizedFile.name,
         interpretation: {
           type: 'InterpretedHmpbPage',
@@ -198,7 +195,6 @@ test('exportCvrs orders by sheet ID', async () => {
         },
       },
       {
-        originalFilename: `/tmp/back-page-${sheetId}.png`,
         normalizedFilename: backNormalizedFile.name,
         interpretation: {
           type: 'InterpretedHmpbPage',

--- a/apps/scan/backend/src/tally-cvrs/export.test.ts
+++ b/apps/scan/backend/src/tally-cvrs/export.test.ts
@@ -78,7 +78,7 @@ test('exportCvrs', () => {
   const batchId = store.addBatch();
   store.addSheet(uuid(), batchId, [
     {
-      normalizedFilename: '/tmp/front-page-normalized.png',
+      imagePath: '/tmp/front-page.png',
       interpretation: {
         type: 'InterpretedHmpbPage',
         metadata: {
@@ -107,7 +107,7 @@ test('exportCvrs', () => {
       },
     },
     {
-      normalizedFilename: '/tmp/back-page-normalized.png',
+      imagePath: '/tmp/back-page.png',
       interpretation: {
         type: 'InterpretedHmpbPage',
         metadata: {
@@ -158,15 +158,15 @@ test('exportCvrs orders by sheet ID', async () => {
   const sheetIds = ['fake-uuid-zzz', 'fake-uuid-lll', 'fake-uuid-aaa'];
   const batchId = store.addBatch();
   for (const sheetId of sheetIds) {
-    const frontNormalizedFile = tmp.fileSync();
-    await writeFile(frontNormalizedFile.fd, 'front normalized');
+    const frontImagePath = tmp.fileSync();
+    await writeFile(frontImagePath.fd, 'front image path');
 
-    const backNormalizedFile = tmp.fileSync();
-    await writeFile(backNormalizedFile.fd, 'back normalized');
+    const backImagePath = tmp.fileSync();
+    await writeFile(backImagePath.fd, 'back image path');
 
     store.addSheet(sheetId, batchId, [
       {
-        normalizedFilename: frontNormalizedFile.name,
+        imagePath: frontImagePath.name,
         interpretation: {
           type: 'InterpretedHmpbPage',
           metadata: {
@@ -195,7 +195,7 @@ test('exportCvrs orders by sheet ID', async () => {
         },
       },
       {
-        normalizedFilename: backNormalizedFile.name,
+        imagePath: backImagePath.name,
         interpretation: {
           type: 'InterpretedHmpbPage',
           metadata: {

--- a/apps/scan/backend/test/helpers/shared_helpers.ts
+++ b/apps/scan/backend/test/helpers/shared_helpers.ts
@@ -129,12 +129,10 @@ export function mockInterpretation(
       pages: [
         {
           interpretation: { type: 'BlankPage' },
-          originalFilename: 'fake_original_filename',
           normalizedFilename: 'fake_normalized_filename',
         },
         {
           interpretation: { type: 'BlankPage' },
-          originalFilename: 'fake_original_filename',
           normalizedFilename: 'fake_normalized_filename',
         },
       ],

--- a/apps/scan/backend/test/helpers/shared_helpers.ts
+++ b/apps/scan/backend/test/helpers/shared_helpers.ts
@@ -129,11 +129,11 @@ export function mockInterpretation(
       pages: [
         {
           interpretation: { type: 'BlankPage' },
-          normalizedFilename: 'fake_normalized_filename',
+          imagePath: 'fake_filename',
         },
         {
           interpretation: { type: 'BlankPage' },
-          normalizedFilename: 'fake_normalized_filename',
+          imagePath: 'fake_filename',
         },
       ],
     })

--- a/libs/backend/src/scan/cast_vote_records/export.test.ts
+++ b/libs/backend/src/scan/cast_vote_records/export.test.ts
@@ -66,8 +66,8 @@ test('getCastVoteRecordReportStream', async () => {
       id: 'ballot-1',
       batchId: 'batch-1',
       indexInBatch: 1,
-      frontNormalizedFilename: 'front.jpg',
-      backNormalizedFilename: 'back.jpg',
+      frontImagePath: 'front.jpg',
+      backImagePath: 'back.jpg',
       interpretation: [interpretedHmpbPage1, interpretedHmpbPage2],
     };
 
@@ -75,8 +75,8 @@ test('getCastVoteRecordReportStream', async () => {
       id: 'ballot-2',
       batchId: 'batch-1',
       indexInBatch: 2,
-      frontNormalizedFilename: 'front.jpg',
-      backNormalizedFilename: 'back.jpg',
+      frontImagePath: 'front.jpg',
+      backImagePath: 'back.jpg',
       interpretation: [interpretedBmdPage, { type: 'BlankPage' }],
     };
   }
@@ -108,8 +108,8 @@ test('getCastVoteRecordReportStream results in error when validation fails', asy
     yield {
       id: 'ballot-1',
       batchId: 'batch-1',
-      frontNormalizedFilename: 'front.jpg',
-      backNormalizedFilename: 'back.jpg',
+      frontImagePath: 'front.jpg',
+      backImagePath: 'back.jpg',
       interpretation: [interpretedHmpbPage1, { type: 'BlankPage' }],
     };
   }
@@ -136,8 +136,8 @@ test('getCastVoteRecordReportStream can include file uris in backup format', asy
     yield {
       id: 'ballot-1',
       batchId: 'batch-1',
-      frontNormalizedFilename: 'front.jpg',
-      backNormalizedFilename: 'back.jpg',
+      frontImagePath: 'front.jpg',
+      backImagePath: 'back.jpg',
       interpretation: [
         {
           ...interpretedHmpbPage1,
@@ -231,16 +231,16 @@ test('exportCastVoteRecordReportToUsbDrive, with write-in image', async () => {
     yield {
       id: 'ballot-1',
       batchId: 'batch-1',
-      frontNormalizedFilename: 'front.jpg',
-      backNormalizedFilename: 'back.jpg',
+      frontImagePath: 'front.jpg',
+      backImagePath: 'back.jpg',
       interpretation: [interpretedHmpbPage1WithWriteIn, interpretedHmpbPage2],
     };
 
     yield {
       id: 'ballot-2',
       batchId: 'batch-1',
-      frontNormalizedFilename: 'front.jpg',
-      backNormalizedFilename: 'back.jpg',
+      frontImagePath: 'front.jpg',
+      backImagePath: 'back.jpg',
       interpretation: [interpretedBmdPage, { type: 'BlankPage' }],
     };
   }
@@ -322,8 +322,8 @@ test('exportCastVoteRecordReportToUsbDrive bubbles up export errors', async () =
     yield {
       id: 'ballot-1',
       batchId: 'batch-1',
-      frontNormalizedFilename: 'front.jpg',
-      backNormalizedFilename: 'back.jpg',
+      frontImagePath: 'front.jpg',
+      backImagePath: 'back.jpg',
       interpretation: [interpretedHmpbPage1WithWriteIn, interpretedHmpbPage2],
     };
   }

--- a/libs/backend/src/scan/cast_vote_records/export.ts
+++ b/libs/backend/src/scan/cast_vote_records/export.ts
@@ -49,8 +49,8 @@ export interface ResultSheet {
   // TODO: remove once the deprecated CVR export is no longer using batchLabel
   readonly batchLabel?: string;
   readonly interpretation: SheetOf<PageInterpretation>;
-  readonly frontNormalizedFilename: string;
-  readonly backNormalizedFilename: string;
+  readonly frontImagePath: string;
+  readonly backImagePath: string;
 }
 
 /**
@@ -124,8 +124,8 @@ function* getCastVoteRecordGenerator({
     batchId,
     indexInBatch,
     interpretation: [sideOne, sideTwo],
-    frontNormalizedFilename: sideOneFilename,
-    backNormalizedFilename: sideTwoFilename,
+    frontImagePath: sideOneFilename,
+    backImagePath: sideTwoFilename,
   } of resultSheetGenerator) {
     const canonicalizationResult = canonicalizeSheet(
       [sideOne, sideTwo],
@@ -364,8 +364,8 @@ export async function exportCastVoteRecordReportToUsbDrive(
   for (const {
     batchId,
     interpretation: [sideOne, sideTwo],
-    frontNormalizedFilename: sideOneFilename,
-    backNormalizedFilename: sideTwoFilename,
+    frontImagePath: sideOneFilename,
+    backImagePath: sideTwoFilename,
   } of getResultSheetGenerator()) {
     const canonicalizationResult = canonicalizeSheet(
       [sideOne, sideTwo],

--- a/libs/backend/src/scan/interpretation/interpret.ts
+++ b/libs/backend/src/scan/interpretation/interpret.ts
@@ -31,7 +31,7 @@ export type InterpretResult = Result<SheetOf<InterpretFileResult>, Error>;
  */
 export interface InterpretFileResult {
   interpretation: PageInterpretation;
-  normalizedImage?: ImageData;
+  normalizedImage: ImageData;
 }
 
 /**

--- a/libs/backend/src/scan/interpretation/interpret_and_save_files.test.ts
+++ b/libs/backend/src/scan/interpretation/interpret_and_save_files.test.ts
@@ -28,7 +28,7 @@ test('interprets ballot images and saves images for storage', async () => {
     'InterpretedBmdPage',
     'BlankPage',
   ]);
-  for (const imagePath of result.map((page) => page.imagePath)) {
+  for (const { imagePath } of result) {
     await expect(loadImageData(imagePath)).resolves.toBeDefined();
   }
 });

--- a/libs/backend/src/scan/interpretation/interpret_and_save_files.test.ts
+++ b/libs/backend/src/scan/interpretation/interpret_and_save_files.test.ts
@@ -28,9 +28,7 @@ test('interprets ballot images and saves images for storage', async () => {
     'InterpretedBmdPage',
     'BlankPage',
   ]);
-  for (const imagePath of result.flatMap(({ normalizedFilename }) => [
-    normalizedFilename,
-  ])) {
+  for (const imagePath of result.map((page) => page.imagePath)) {
     await expect(loadImageData(imagePath)).resolves.toBeDefined();
   }
 });

--- a/libs/backend/src/scan/interpretation/interpret_and_save_files.test.ts
+++ b/libs/backend/src/scan/interpretation/interpret_and_save_files.test.ts
@@ -28,12 +28,9 @@ test('interprets ballot images and saves images for storage', async () => {
     'InterpretedBmdPage',
     'BlankPage',
   ]);
-  for (const imagePath of result.flatMap(
-    ({ originalFilename, normalizedFilename }) => [
-      originalFilename,
-      normalizedFilename,
-    ]
-  )) {
+  for (const imagePath of result.flatMap(({ normalizedFilename }) => [
+    normalizedFilename,
+  ])) {
     await expect(loadImageData(imagePath)).resolves.toBeDefined();
   }
 });

--- a/libs/backend/src/scan/interpretation/interpret_and_save_files.ts
+++ b/libs/backend/src/scan/interpretation/interpret_and_save_files.ts
@@ -4,7 +4,7 @@ import {
   SheetOf,
   mapSheet,
 } from '@votingworks/types';
-import { saveSheetImages } from './save_images';
+import { saveSheetImage } from './save_images';
 import { InterpreterOptions, interpretSheet } from './interpret';
 
 /**
@@ -20,15 +20,16 @@ export async function interpretSheetAndSaveImages(
     await interpretSheet(interpreterOptions, sheet),
     async (result, side) => {
       const ballotImagePath = sheet[side === 'front' ? 0 : 1];
-      const images = await saveSheetImages(
+      const imagePath = await saveSheetImage({
         sheetId,
+        side,
         ballotImagesPath,
-        ballotImagePath,
-        result.normalizedImage
-      );
+        sourceImagePath: ballotImagePath,
+        normalizedImage: result.normalizedImage,
+      });
       return {
         interpretation: result.interpretation,
-        normalizedFilename: images.normalized,
+        imagePath,
       };
     }
   );

--- a/libs/backend/src/scan/interpretation/interpret_and_save_files.ts
+++ b/libs/backend/src/scan/interpretation/interpret_and_save_files.ts
@@ -28,7 +28,6 @@ export async function interpretSheetAndSaveImages(
       );
       return {
         interpretation: result.interpretation,
-        originalFilename: images.original,
         normalizedFilename: images.normalized,
       };
     }

--- a/libs/backend/src/scan/interpretation/save_images.test.ts
+++ b/libs/backend/src/scan/interpretation/save_images.test.ts
@@ -4,41 +4,9 @@ import {
   toGrayscale,
   writeImageData,
 } from '@votingworks/image-utils';
-import { readFileSync } from 'fs-extra';
 import { join } from 'path';
-import { tmpDir, tmpFileWithData } from '../../../test/helpers/tmp';
-import { saveImage, saveSheetImage } from './save_images';
-
-test('saveImages without normalized image', async () => {
-  const destinationImagePath = tmpFileWithData('image');
-  const sourceImagePath = tmpFileWithData('source image');
-
-  await saveImage({ sourceImagePath, destinationImagePath });
-
-  // has the new data
-  expect(readFileSync(destinationImagePath, 'utf8')).toEqual('source image');
-
-  // unchanged
-  expect(readFileSync(sourceImagePath, 'utf8')).toEqual('source image');
-});
-
-test('saveImages with normalized image', async () => {
-  const destinationImagePath = tmpFileWithData('image');
-  const sourceImagePath = tmpFileWithData('source image');
-
-  await saveImage({
-    sourceImagePath,
-    destinationImagePath,
-    normalizedImage: createImageData(1, 1),
-  });
-
-  expect(readFileSync(sourceImagePath, 'utf8')).toEqual('source image');
-
-  // has the image data
-  expect(toGrayscale(await loadImageData(destinationImagePath))).toEqual(
-    toGrayscale(createImageData(1, 1))
-  );
-});
+import { tmpDir } from '../../../test/helpers/tmp';
+import { saveSheetImage } from './save_images';
 
 test.each([
   ['.jpg', 'front'],

--- a/libs/backend/src/scan/interpretation/save_images.ts
+++ b/libs/backend/src/scan/interpretation/save_images.ts
@@ -1,44 +1,6 @@
 import { writeImageData } from '@votingworks/image-utils';
 import { Side } from '@votingworks/types';
-import makeDebug from 'debug';
-import * as fsExtra from 'fs-extra';
 import { join, parse } from 'path';
-
-const debug = makeDebug('backend:scan:save_images');
-
-/**
- * Links {@link src} to {@link dest} if both paths are on the same file system,
- * otherwise does a file copy.
- */
-async function linkOrCopy(src: string, dest: string): Promise<void> {
-  try {
-    await fsExtra.link(src, dest);
-  } catch {
-    await fsExtra.copy(src, dest);
-  }
-}
-
-/**
- * Saves the image for a ballot in the ballot images directory.
- */
-export async function saveImage({
-  sourceImagePath,
-  destinationImagePath,
-  normalizedImage,
-}: {
-  sourceImagePath: string;
-  destinationImagePath: string;
-  normalizedImage?: ImageData;
-}): Promise<void> {
-  if (normalizedImage) {
-    debug('about to write normalized ballot image to %s', destinationImagePath);
-    await writeImageData(destinationImagePath, normalizedImage);
-    debug('wrote normalized ballot image to %s', destinationImagePath);
-  } else {
-    debug('using the original ballot image at %s', sourceImagePath);
-    await linkOrCopy(sourceImagePath, destinationImagePath);
-  }
-}
 
 /**
  * Stores the image for a ballot in the ballot images directory.
@@ -54,7 +16,7 @@ export async function saveSheetImage({
   side: Side;
   ballotImagesPath: string;
   sourceImagePath: string;
-  normalizedImage?: ImageData;
+  normalizedImage: ImageData;
 }): Promise<string> {
   const parts = parse(sourceImagePath);
   const ext = parts.ext === '.png' ? '.png' : '.jpg';
@@ -62,10 +24,6 @@ export async function saveSheetImage({
     ballotImagesPath,
     `${sheetId}-${side}${ext}`
   );
-  await saveImage({
-    sourceImagePath,
-    destinationImagePath,
-    normalizedImage,
-  });
+  await writeImageData(destinationImagePath, normalizedImage);
   return destinationImagePath;
 }

--- a/libs/ballot-interpreter-nh/ts/src/cli.ts
+++ b/libs/ballot-interpreter-nh/ts/src/cli.ts
@@ -337,12 +337,12 @@ async function interpretWorkspace(
     sheetIdsArray.length
       ? db
           .prepare(
-            'SELECT id, front_original_filename as frontPath, back_original_filename as backPath FROM sheets WHERE id IN ?'
+            'SELECT id, front_normalized_filename as frontPath, back_normalized_filename as backPath FROM sheets WHERE id IN ?'
           )
           .all(sheetIdsArray)
       : db
           .prepare(
-            'SELECT id, front_original_filename as frontPath, back_original_filename as backPath FROM sheets'
+            'SELECT id, front_normalized_filename as frontPath, back_normalized_filename as backPath FROM sheets'
           )
           .all()
   ) as Array<{ id: string; frontPath: string; backPath: string }>;

--- a/libs/ballot-interpreter-nh/ts/src/cli.ts
+++ b/libs/ballot-interpreter-nh/ts/src/cli.ts
@@ -234,11 +234,24 @@ async function interpretFiles(
 
   if (json) {
     const normalizedImagePaths = await writeNormalizedImages(result.ok());
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const resultJson: any = result.ok();
-    resultJson.front.normalizedImage = normalizedImagePaths.front;
-    resultJson.back.normalizedImage = normalizedImagePaths.back;
-    await writeIterToStream(jsonStream(resultJson, { compact: false }), stdout);
+    const interpreted = result.ok();
+    await writeIterToStream(
+      jsonStream(
+        {
+          ...interpreted,
+          front: {
+            ...interpreted.front,
+            normalizedImage: normalizedImagePaths.front,
+          },
+          back: {
+            ...interpreted.back,
+            normalizedImage: normalizedImagePaths.back,
+          },
+        },
+        { compact: false }
+      ),
+      stdout
+    );
   } else {
     prettyPrintInterpretation({
       electionDefinition,
@@ -337,15 +350,16 @@ async function interpretWorkspace(
     sheetIdsArray.length
       ? db
           .prepare(
-            'SELECT id, front_normalized_filename as frontPath, back_normalized_filename as backPath FROM sheets WHERE id IN ?'
+            'SELECT id, front_image_path as frontPath, back_image_path as backPath FROM sheets WHERE id IN ?'
           )
           .all(sheetIdsArray)
       : db
           .prepare(
-            'SELECT id, front_normalized_filename as frontPath, back_normalized_filename as backPath FROM sheets'
+            'SELECT id, front_image_path as frontPath, back_image_path as backPath FROM sheets'
           )
           .all()
   ) as Array<{ id: string; frontPath: string; backPath: string }>;
+  console.log(sheets);
 
   /**
    * Look for the ballot images where the database says they are, and if not

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -979,15 +979,6 @@ export const BatchInfoSchema: z.ZodSchema<BatchInfo> = z.object({
   count: z.number().nonnegative(),
 });
 
-export interface InlineBallotImage {
-  normalized: string;
-}
-export const InlineBallotImageSchema: z.ZodSchema<InlineBallotImage> = z.object(
-  {
-    normalized: z.string(),
-  }
-);
-
 export interface CompletedBallot {
   readonly electionHash: string;
   readonly ballotStyleId: BallotStyleId;

--- a/libs/types/src/interpretation.ts
+++ b/libs/types/src/interpretation.ts
@@ -132,12 +132,12 @@ export const PageInterpretationSchema: z.ZodSchema<PageInterpretation> =
   ]);
 
 export interface PageInterpretationWithFiles {
-  normalizedFilename: string;
+  imagePath: string;
   interpretation: PageInterpretation;
 }
 export const PageInterpretationWithFilesSchema: z.ZodSchema<PageInterpretationWithFiles> =
   z.object({
-    normalizedFilename: z.string(),
+    imagePath: z.string(),
     interpretation: PageInterpretationSchema,
   });
 

--- a/libs/types/src/interpretation.ts
+++ b/libs/types/src/interpretation.ts
@@ -132,13 +132,11 @@ export const PageInterpretationSchema: z.ZodSchema<PageInterpretation> =
   ]);
 
 export interface PageInterpretationWithFiles {
-  originalFilename: string;
   normalizedFilename: string;
   interpretation: PageInterpretation;
 }
 export const PageInterpretationWithFilesSchema: z.ZodSchema<PageInterpretationWithFiles> =
   z.object({
-    originalFilename: z.string(),
     normalizedFilename: z.string(),
     interpretation: PageInterpretationSchema,
   });


### PR DESCRIPTION
## Overview
We previously stored both the "original" (image from the scanner) and "normalized" (scaled/deskewed/rotated/etc) versions of the scanned ballot images. However, we've decided we don't actually need the original image. This consolidates down to just using the normalized image and calling it `imagePath` (`front_image_path` and `back_image_path`) in the database.

## Demo Video or Screenshot
```
.
├── ballot-images
│   └── 8d2f7b03-09bf-4bad-be77-4c2ce1e57b15
│       └── 2f5b5e2b-8115-466a-976b-1adf777feb24-front.jpg
├── ballot-layouts
│   └── 8d2f7b03-09bf-4bad-be77-4c2ce1e57b15
│       └── 2f5b5e2b-8115-466a-976b-1adf777feb24-front.layout.json
└── cast-vote-record-report.json

4 directories, 3 files
```

## Testing Plan
Automated. Manually tested VxScan and VxCentralScan with a NH HMPB election.
