### PR TITLE
support big-endian in uint16 and uint32 coders

### DIFF
--- a/libs/message-coder/src/uint16_coder.test.ts
+++ b/libs/message-coder/src/uint16_coder.test.ts
@@ -29,6 +29,29 @@ test('uint16', () => {
   );
 });
 
+test('uint16 with littleEndian=false', () => {
+  fc.assert(
+    fc.property(
+      fc.integer(0, 65535),
+      fc.integer({ min: 0, max: 100 }),
+      (value, byteOffset) => {
+        const bitOffset = byteOffset * 8;
+        const buffer = Buffer.alloc(2 + byteOffset);
+        const field = uint16(undefined, { littleEndian: false });
+        type field = CoderType<typeof field>;
+
+        expect(field.encodeInto(value, buffer, bitOffset)).toEqual(
+          ok(bitOffset + 16)
+        );
+        expect(buffer.readUInt16BE(byteOffset)).toEqual(value);
+        expect(field.decodeFrom(buffer, bitOffset)).toEqual(
+          typedAs<DecodeResult<field>>(ok({ value, bitOffset: bitOffset + 16 }))
+        );
+      }
+    )
+  );
+});
+
 test('uint16 with enumeration', () => {
   enum Enum {
     A = 1,

--- a/libs/message-coder/src/uint16_coder.ts
+++ b/libs/message-coder/src/uint16_coder.ts
@@ -11,11 +11,25 @@ import {
 } from './types';
 import { UintCoder } from './uint_coder';
 
+interface Uint16CoderOptions {
+  littleEndian: boolean;
+}
+
 /**
  * Coder for a uint16, aka a 16-bit unsigned integer. Uses little-endian byte
  * order.
  */
 export class Uint16Coder extends UintCoder {
+  private readonly littleEndian: boolean;
+
+  constructor(
+    enumeration?: unknown,
+    options: Uint16CoderOptions = { littleEndian: true }
+  ) {
+    super(enumeration);
+    this.littleEndian = options?.littleEndian;
+  }
+
   bitLength(): BitLength {
     return 16;
   }
@@ -32,14 +46,20 @@ export class Uint16Coder extends UintCoder {
       this.validateValue(value).okOrElse(fail);
 
       return this.encodeUsing(buffer, bitOffset, (byteOffset) =>
-        buffer.writeUInt16LE(value, byteOffset)
+        this.littleEndian
+          ? buffer.writeUInt16LE(value, byteOffset)
+          : buffer.writeUInt16BE(value, byteOffset)
       );
     });
   }
 
   decodeFrom(buffer: Buffer, bitOffset: BitOffset): DecodeResult<Uint16> {
     return this.decodeUsing(buffer, bitOffset, (byteOffset) =>
-      this.validateValue(buffer.readUInt16LE(byteOffset))
+      this.validateValue(
+        this.littleEndian
+          ? buffer.readUInt16LE(byteOffset)
+          : buffer.readUInt16BE(byteOffset)
+      )
     );
   }
 }
@@ -49,7 +69,8 @@ export class Uint16Coder extends UintCoder {
  */
 // eslint-disable-next-line vx/gts-no-return-type-only-generics -- TS does not have a way of saying "I want an enum of numbers"
 export function uint16<T extends number = Uint16>(
-  enumeration?: unknown
+  enumeration?: unknown,
+  options?: Uint16CoderOptions
 ): Coder<T> {
-  return new Uint16Coder(enumeration) as unknown as Coder<T>;
+  return new Uint16Coder(enumeration, options) as unknown as Coder<T>;
 }

--- a/libs/message-coder/src/uint16_coder.ts
+++ b/libs/message-coder/src/uint16_coder.ts
@@ -27,7 +27,7 @@ export class Uint16Coder extends UintCoder {
     { littleEndian = true }: Partial<Uint16CoderOptions> = {}
   ) {
     super(enumeration);
-    this.littleEndian = options.littleEndian;
+    this.littleEndian = littleEndian;
   }
 
   bitLength(): BitLength {

--- a/libs/message-coder/src/uint16_coder.ts
+++ b/libs/message-coder/src/uint16_coder.ts
@@ -27,7 +27,7 @@ export class Uint16Coder extends UintCoder {
     options: Uint16CoderOptions = { littleEndian: true }
   ) {
     super(enumeration);
-    this.littleEndian = options?.littleEndian;
+    this.littleEndian = options.littleEndian;
   }
 
   bitLength(): BitLength {

--- a/libs/message-coder/src/uint16_coder.ts
+++ b/libs/message-coder/src/uint16_coder.ts
@@ -24,7 +24,7 @@ export class Uint16Coder extends UintCoder {
 
   constructor(
     enumeration?: unknown,
-    options: Uint16CoderOptions = { littleEndian: true }
+    { littleEndian = true }: Partial<Uint16CoderOptions> = {}
   ) {
     super(enumeration);
     this.littleEndian = options.littleEndian;

--- a/libs/message-coder/src/uint32_coder.test.ts
+++ b/libs/message-coder/src/uint32_coder.test.ts
@@ -29,6 +29,29 @@ test('uint32', () => {
   );
 });
 
+test('uint32 with big-endian=true', () => {
+  fc.assert(
+    fc.property(
+      fc.integer(0, 0xffffffff),
+      fc.integer({ min: 0, max: 100 }),
+      (value, byteOffset) => {
+        const bitOffset = byteOffset * 8;
+        const buffer = Buffer.alloc(4 + byteOffset);
+        const field = uint32(undefined, { littleEndian: false });
+        type field = CoderType<typeof field>;
+
+        expect(field.encodeInto(value, buffer, bitOffset)).toEqual(
+          ok(bitOffset + 32)
+        );
+        expect(buffer.readUInt32BE(byteOffset)).toEqual(value);
+        expect(field.decodeFrom(buffer, bitOffset)).toEqual(
+          typedAs<DecodeResult<field>>(ok({ value, bitOffset: bitOffset + 32 }))
+        );
+      }
+    )
+  );
+});
+
 test('uint32 with enumeration', () => {
   enum Enum {
     A = 1,

--- a/libs/message-coder/src/uint32_coder.test.ts
+++ b/libs/message-coder/src/uint32_coder.test.ts
@@ -29,7 +29,7 @@ test('uint32', () => {
   );
 });
 
-test('uint32 with big-endian=true', () => {
+test('uint32 with little-endian=false', () => {
   fc.assert(
     fc.property(
       fc.integer(0, 0xffffffff),

--- a/libs/message-coder/src/uint32_coder.ts
+++ b/libs/message-coder/src/uint32_coder.ts
@@ -24,7 +24,7 @@ export class Uint32Coder extends UintCoder {
 
   constructor(
     enumeration?: unknown,
-    options: Uint32CoderOptions = { littleEndian: true }
+    { littleEndian = true }: Partial<Uint32CoderOptions> = {}
   ) {
     super(enumeration);
     this.littleEndian = options.littleEndian;

--- a/libs/message-coder/src/uint32_coder.ts
+++ b/libs/message-coder/src/uint32_coder.ts
@@ -27,7 +27,7 @@ export class Uint32Coder extends UintCoder {
     { littleEndian = true }: Partial<Uint32CoderOptions> = {}
   ) {
     super(enumeration);
-    this.littleEndian = options.littleEndian;
+    this.littleEndian = littleEndian;
   }
 
   bitLength(): BitLength {

--- a/libs/message-coder/src/uint32_coder.ts
+++ b/libs/message-coder/src/uint32_coder.ts
@@ -27,7 +27,7 @@ export class Uint32Coder extends UintCoder {
     options: Uint32CoderOptions = { littleEndian: true }
   ) {
     super(enumeration);
-    this.littleEndian = options?.littleEndian;
+    this.littleEndian = options.littleEndian;
   }
 
   bitLength(): BitLength {

--- a/libs/message-coder/src/uint32_coder.ts
+++ b/libs/message-coder/src/uint32_coder.ts
@@ -11,11 +11,25 @@ import {
 } from './types';
 import { UintCoder } from './uint_coder';
 
+interface Uint32CoderOptions {
+  littleEndian: boolean;
+}
+
 /**
  * Coder for a uint32, aka a 32-bit unsigned integer. Uses little-endian byte
  * order.
  */
 export class Uint32Coder extends UintCoder {
+  private readonly littleEndian: boolean;
+
+  constructor(
+    enumeration?: unknown,
+    options: Uint32CoderOptions = { littleEndian: true }
+  ) {
+    super(enumeration);
+    this.littleEndian = options?.littleEndian;
+  }
+
   bitLength(): BitLength {
     return 32;
   }
@@ -32,14 +46,20 @@ export class Uint32Coder extends UintCoder {
       this.validateValue(value).okOrElse(fail);
 
       return this.encodeUsing(buffer, bitOffset, (byteOffset) =>
-        buffer.writeUInt32LE(value, byteOffset)
+        this.littleEndian
+          ? buffer.writeUInt32LE(value, byteOffset)
+          : buffer.writeUInt32BE(value, byteOffset)
       );
     });
   }
 
   decodeFrom(buffer: Buffer, bitOffset: BitOffset): DecodeResult<Uint32> {
     return this.decodeUsing(buffer, bitOffset, (byteOffset) =>
-      this.validateValue(buffer.readUInt32LE(byteOffset))
+      this.validateValue(
+        this.littleEndian
+          ? buffer.readUInt32LE(byteOffset)
+          : buffer.readUInt32BE(byteOffset)
+      )
     );
   }
 }
@@ -49,7 +69,8 @@ export class Uint32Coder extends UintCoder {
  */
 // eslint-disable-next-line vx/gts-no-return-type-only-generics -- TS does not have a way of saying "I want an enum of numbers"
 export function uint32<T extends number = Uint32>(
-  enumeration?: unknown
+  enumeration?: unknown,
+  options?: Uint32CoderOptions
 ): Coder<T> {
-  return new Uint32Coder(enumeration) as unknown as Coder<T>;
+  return new Uint32Coder(enumeration, options) as unknown as Coder<T>;
 }


### PR DESCRIPTION
## Overview
Supports big-endian `Uint16` and `Uint32` in `message-coder`.

## Demo Video or Screenshot

## Testing Plan
* Updated automated tests for big endian case

## Checklist

- [ x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.