### PR TITLE
Minor API Cleanup

### DIFF
--- a/apps/admin/frontend/package.json
+++ b/apps/admin/frontend/package.json
@@ -70,7 +70,6 @@
     "@types/react-dom": "^17.0.0",
     "@types/react-router-dom": "^5.1.5",
     "@types/styled-components": "^5.1.7",
-    "@votingworks/api": "workspace:*",
     "@votingworks/ballot-encoder": "workspace:*",
     "@votingworks/basics": "workspace:*",
     "@votingworks/dev-dock-frontend": "workspace:*",

--- a/apps/central-scan/backend/src/central_scanner_app.test.ts
+++ b/apps/central-scan/backend/src/central_scanner_app.test.ts
@@ -208,22 +208,6 @@ test('GET /config/election (application/json)', async () => {
     .expect(200, 'null');
 });
 
-test('GET /config/testMode', async () => {
-  workspace.store.setElectionAndJurisdiction({
-    electionData: testElectionDefinition.electionData,
-    jurisdiction,
-  });
-  workspace.store.setTestMode(true);
-  workspace.store.setMarkThresholdOverrides(undefined);
-  const response = await request(app)
-    .get('/central-scanner/config/testMode')
-    .expect(200);
-  expect(response.body).toEqual({
-    status: 'ok',
-    testMode: true,
-  });
-});
-
 test('GET /config/markThresholdOverrides', async () => {
   workspace.store.setElectionAndJurisdiction({
     electionData: testElectionDefinition.electionData,
@@ -291,28 +275,6 @@ test('DELETE /config/election ignores lack of backup when ?ignoreBackupRequireme
     .set('Accept', 'application/json')
     .expect(200, { status: 'ok' });
   expect(importer.unconfigure).toBeCalled();
-});
-
-test('PATCH /config/testMode', async () => {
-  importer.setTestMode.mockReturnValue(undefined);
-
-  await request(app)
-    .patch('/central-scanner/config/testMode')
-    .send({ testMode: true })
-    .set('Content-Type', 'application/json')
-    .set('Accept', 'application/json')
-    .expect(200);
-
-  expect(importer.setTestMode).toHaveBeenNthCalledWith(1, true);
-
-  await request(app)
-    .patch('/central-scanner/config/testMode')
-    .set('Content-Type', 'application/json')
-    .set('Accept', 'application/json')
-    .send({ testMode: false })
-    .expect(200);
-
-  expect(importer.setTestMode).toHaveBeenNthCalledWith(2, false);
 });
 
 test('PATCH /config/markThresholdOverrides', async () => {

--- a/apps/central-scan/backend/src/central_scanner_app.ts
+++ b/apps/central-scan/backend/src/central_scanner_app.ts
@@ -84,6 +84,14 @@ function buildApi({
       return auth.logOut(constructAuthMachineState(workspace));
     },
 
+    getTestMode() {
+      return store.getTestMode();
+    },
+
+    setTestMode(input: { testMode: boolean }) {
+      return store.setTestMode(input.testMode);
+    },
+
     updateSessionExpiry(input: { sessionExpiresAt: Date }) {
       return auth.updateSessionExpiry(
         constructAuthMachineState(workspace),
@@ -245,37 +253,6 @@ export function buildCentralScannerApp({
       response.json({ status: 'ok' });
     }
   );
-
-  deprecatedApiRouter.get<NoParams, Scan.GetTestModeConfigResponse>(
-    '/central-scanner/config/testMode',
-    (_request, response) => {
-      const testMode = store.getTestMode();
-      response.json({ status: 'ok', testMode });
-    }
-  );
-
-  deprecatedApiRouter.patch<
-    NoParams,
-    Scan.PatchTestModeConfigResponse,
-    Scan.PatchTestModeConfigRequest
-  >('/central-scanner/config/testMode', (request, response) => {
-    const bodyParseResult = safeParse(
-      Scan.PatchTestModeConfigRequestSchema,
-      request.body
-    );
-
-    if (bodyParseResult.isErr()) {
-      const error = bodyParseResult.err();
-      response.status(400).json({
-        status: 'error',
-        errors: [{ type: error.name, message: error.message }],
-      });
-      return;
-    }
-
-    importer.setTestMode(bodyParseResult.ok().testMode);
-    response.json({ status: 'ok' });
-  });
 
   deprecatedApiRouter.get<
     NoParams,

--- a/apps/central-scan/backend/src/end_to_end_hmpb.test.ts
+++ b/apps/central-scan/backend/src/end_to_end_hmpb.test.ts
@@ -151,12 +151,7 @@ test('going through the whole process works', async () => {
   expect(configureResult.ok()).toEqual(electionDefinition);
 
   // need to turn off test mode after election is loaded
-  await request(app)
-    .patch('/central-scanner/config/testMode')
-    .send({ testMode: false })
-    .set('Content-Type', 'application/json')
-    .set('Accept', 'application/json')
-    .expect(200, { status: 'ok' });
+  await apiClient.setTestMode({ testMode: false });
 
   mockUsb.removeUsbDrive();
 

--- a/apps/central-scan/frontend/src/api.ts
+++ b/apps/central-scan/frontend/src/api.ts
@@ -47,6 +47,28 @@ export const getAuthStatus = {
   },
 } as const;
 
+export const getTestMode = {
+  queryKey(): QueryKey {
+    return ['getTestMode'];
+  },
+  useQuery() {
+    const apiClient = useApiClient();
+    return useQuery(this.queryKey(), () => apiClient.getTestMode());
+  },
+} as const;
+
+export const setTestMode = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.setTestMode, {
+      async onSuccess() {
+        await queryClient.invalidateQueries(getTestMode.queryKey());
+      },
+    });
+  },
+} as const;
+
 export const getSystemSettings = {
   queryKey(): QueryKey {
     return ['getSystemSettings'];

--- a/apps/central-scan/frontend/src/api/config.ts
+++ b/apps/central-scan/frontend/src/api/config.ts
@@ -77,26 +77,6 @@ export async function deleteElection({
   await del(deletionUrl);
 }
 
-export async function getTestMode(): Promise<boolean> {
-  return safeParseJson(
-    await (await fetch('/central-scanner/config/testMode')).text(),
-    Scan.GetTestModeConfigResponseSchema
-  ).unsafeUnwrap().testMode;
-}
-
-export async function setTestMode(testMode: boolean): Promise<void> {
-  await patch<Scan.PatchTestModeConfigRequest>(
-    '/central-scanner/config/testMode',
-    {
-      testMode,
-    }
-  );
-  const newTestMode = await getTestMode();
-  if (newTestMode !== testMode) {
-    throw new Error('Error setting test mode, please try again');
-  }
-}
-
 export async function getMarkThresholdOverrides(): Promise<
   MarkThresholds | undefined
 > {

--- a/apps/central-scan/frontend/src/app.test.tsx
+++ b/apps/central-scan/frontend/src/app.test.tsx
@@ -125,10 +125,7 @@ export async function authenticateAsElectionManager(
 test('renders without crashing', async () => {
   const getElectionResponseBody: Scan.GetElectionConfigResponse =
     electionSampleDefinition;
-  const getTestModeResponseBody: Scan.GetTestModeConfigResponse = {
-    status: 'ok',
-    testMode: true,
-  };
+  mockApiClient.getTestMode.expectCallWith().resolves(true);
   const getMarkThresholdOverridesResponseBody: Scan.GetMarkThresholdOverridesConfigResponse =
     {
       status: 'ok',
@@ -136,9 +133,6 @@ test('renders without crashing', async () => {
   fetchMock
     .getOnce('/central-scanner/config/election', {
       body: getElectionResponseBody,
-    })
-    .getOnce('/central-scanner/config/testMode', {
-      body: getTestModeResponseBody,
     })
     .getOnce('/central-scanner/config/markThresholdOverrides', {
       body: getMarkThresholdOverridesResponseBody,
@@ -152,17 +146,13 @@ test('renders without crashing', async () => {
 test('shows a "test ballot mode" button if the app is in Official Ballot Mode', async () => {
   const getElectionResponseBody: Scan.GetElectionConfigResponse =
     electionSampleDefinition;
-  const getTestModeResponseBody: Scan.GetTestModeConfigResponse = {
-    status: 'ok',
-    testMode: false,
-  };
+  mockApiClient.getTestMode.expectCallWith().resolves(false);
   const getMarkThresholdOverridesResponseBody: Scan.GetMarkThresholdOverridesConfigResponse =
     {
       status: 'ok',
     };
   fetchMock
     .get('/central-scanner/config/election', { body: getElectionResponseBody })
-    .get('/central-scanner/config/testMode', { body: getTestModeResponseBody })
     .get('/central-scanner/config/markThresholdOverrides', {
       body: getMarkThresholdOverridesResponseBody,
     });
@@ -179,17 +169,13 @@ test('shows a "test ballot mode" button if the app is in Official Ballot Mode', 
 test('shows an "official ballot mode" button if the app is in Test Mode', async () => {
   const getElectionResponseBody: Scan.GetElectionConfigResponse =
     electionSampleDefinition;
-  const getTestModeResponseBody: Scan.GetTestModeConfigResponse = {
-    status: 'ok',
-    testMode: true,
-  };
+  mockApiClient.getTestMode.expectCallWith().resolves(true);
   const getMarkThresholdOverridesResponseBody: Scan.GetMarkThresholdOverridesConfigResponse =
     {
       status: 'ok',
     };
   fetchMock
     .get('/central-scanner/config/election', { body: getElectionResponseBody })
-    .get('/central-scanner/config/testMode', { body: getTestModeResponseBody })
     .get('/central-scanner/config/markThresholdOverrides', {
       body: getMarkThresholdOverridesResponseBody,
     });
@@ -210,10 +196,7 @@ test('shows an "official ballot mode" button if the app is in Test Mode', async 
 test('clicking Scan Batch will scan a batch', async () => {
   const getElectionResponseBody: Scan.GetElectionConfigResponse =
     electionSampleDefinition;
-  const getTestModeResponseBody: Scan.GetTestModeConfigResponse = {
-    status: 'ok',
-    testMode: true,
-  };
+  mockApiClient.getTestMode.expectCallWith().resolves(true);
   const getMarkThresholdOverridesResponseBody: Scan.GetMarkThresholdOverridesConfigResponse =
     {
       status: 'ok',
@@ -224,7 +207,6 @@ test('clicking Scan Batch will scan a batch', async () => {
   };
   fetchMock
     .get('/central-scanner/config/election', { body: getElectionResponseBody })
-    .get('/central-scanner/config/testMode', { body: getTestModeResponseBody })
     .get('/central-scanner/config/markThresholdOverrides', {
       body: getMarkThresholdOverridesResponseBody,
     })
@@ -262,10 +244,7 @@ test('clicking "Save CVRs" shows modal and makes a request to export', async () 
 
   const getElectionResponseBody: Scan.GetElectionConfigResponse =
     electionSampleDefinition;
-  const getTestModeResponseBody: Scan.GetTestModeConfigResponse = {
-    status: 'ok',
-    testMode: true,
-  };
+  mockApiClient.getTestMode.expectCallWith().resolves(true);
   const getMarkThresholdOverridesResponseBody: Scan.GetMarkThresholdOverridesConfigResponse =
     {
       status: 'ok',
@@ -285,7 +264,6 @@ test('clicking "Save CVRs" shows modal and makes a request to export', async () 
   };
   fetchMock
     .get('/central-scanner/config/election', { body: getElectionResponseBody })
-    .get('/central-scanner/config/testMode', { body: getTestModeResponseBody })
     .get('/central-scanner/config/markThresholdOverrides', {
       body: getMarkThresholdOverridesResponseBody,
     })
@@ -320,25 +298,15 @@ test('clicking "Save CVRs" shows modal and makes a request to export', async () 
 
 // bad cleanup
 test('configuring election from usb ballot package works end to end', async () => {
-  const getTestModeConfigResponse: Scan.GetTestModeConfigResponse = {
-    status: 'ok',
-    testMode: true,
-  };
+  mockApiClient.getTestMode.expectCallWith().resolves(true);
   const getMarkThresholdOverridesResponse: Scan.GetMarkThresholdOverridesConfigResponse =
     {
       status: 'ok',
     };
   fetchMock
     .get('/central-scanner/config/election', { body: 'null' })
-    .get('/central-scanner/config/testMode', {
-      body: getTestModeConfigResponse,
-    })
     .get('/central-scanner/config/markThresholdOverrides', {
       body: getMarkThresholdOverridesResponse,
-    })
-    .patchOnce('/central-scanner/config/testMode', {
-      body: '{"status": "ok"}',
-      status: 200,
     })
     .patchOnce('/central-scanner/config/election', {
       body: '{"status": "ok"}',
@@ -362,15 +330,9 @@ test('configuring election from usb ballot package works end to end', async () =
   mockKiosk.getUsbDriveInfo.mockResolvedValue([fakeUsbDrive()]);
   expectConfigureFromBallotPackageOnUsbDrive();
 
-  fetchMock
-    .get('/central-scanner/config/election', electionSampleDefinition, {
-      overwriteRoutes: true,
-    })
-    .getOnce(
-      '/central-scanner/config/testMode',
-      { status: 'ok', testMode: true },
-      { overwriteRoutes: true }
-    );
+  fetchMock.get('/central-scanner/config/election', electionSampleDefinition, {
+    overwriteRoutes: true,
+  });
 
   await act(async () => {
     await sleep(500);
@@ -390,13 +352,6 @@ test('configuring election from usb ballot package works end to end', async () =
     .getOnce('/central-scanner/config/election', JSON.stringify(null), {
       overwriteRoutes: true,
     })
-    .getOnce(
-      '/central-scanner/config/testMode',
-      { body: getTestModeConfigResponse },
-      {
-        overwriteRoutes: true,
-      }
-    )
     .deleteOnce('/central-scanner/config/election', {
       body: '{"status": "ok"}',
       status: 200,
@@ -423,10 +378,7 @@ test('authentication works', async () => {
   hardware.setBatchScannerConnected(false);
   const getElectionResponseBody: Scan.GetElectionConfigResponse =
     electionSampleDefinition;
-  const getTestModeResponseBody: Scan.GetTestModeConfigResponse = {
-    status: 'ok',
-    testMode: true,
-  };
+  mockApiClient.getTestMode.expectCallWith().resolves(true);
   const getMarkThresholdOverridesResponseBody: Scan.GetMarkThresholdOverridesConfigResponse =
     {
       status: 'ok',
@@ -434,7 +386,6 @@ test('authentication works', async () => {
 
   fetchMock
     .get('/central-scanner/config/election', { body: getElectionResponseBody })
-    .get('/central-scanner/config/testMode', { body: getTestModeResponseBody })
     .get('/central-scanner/config/markThresholdOverrides', {
       body: getMarkThresholdOverridesResponseBody,
     });
@@ -533,10 +484,7 @@ test('authentication works', async () => {
 test('system administrator can log in and unconfigure machine', async () => {
   const getElectionResponseBody: Scan.GetElectionConfigResponse =
     electionSampleDefinition;
-  const getTestModeResponseBody: Scan.GetTestModeConfigResponse = {
-    status: 'ok',
-    testMode: true,
-  };
+  mockApiClient.getTestMode.expectCallWith().resolves(true);
   const getMarkThresholdOverridesResponseBody: Scan.GetMarkThresholdOverridesConfigResponse =
     {
       status: 'ok',
@@ -547,7 +495,6 @@ test('system administrator can log in and unconfigure machine', async () => {
 
   fetchMock
     .get('/central-scanner/config/election', { body: getElectionResponseBody })
-    .get('/central-scanner/config/testMode', { body: getTestModeResponseBody })
     .get('/central-scanner/config/markThresholdOverrides', {
       body: getMarkThresholdOverridesResponseBody,
     })
@@ -584,16 +531,12 @@ test('system administrator can log in and unconfigure machine', async () => {
 test('election manager cannot auth onto machine with different election hash', async () => {
   const getElectionResponseBody: Scan.GetElectionConfigResponse =
     electionSampleDefinition;
-  const getTestModeResponseBody: Scan.GetTestModeConfigResponse = {
-    status: 'ok',
-    testMode: true,
-  };
+  mockApiClient.getTestMode.expectCallWith().resolves(true);
   const getMarkThresholdOverridesResponseBody: Scan.GetMarkThresholdOverridesConfigResponse =
     { status: 'ok' };
 
   fetchMock
     .get('/central-scanner/config/election', { body: getElectionResponseBody })
-    .get('/central-scanner/config/testMode', { body: getTestModeResponseBody })
     .get('/central-scanner/config/markThresholdOverrides', {
       body: getMarkThresholdOverridesResponseBody,
     });
@@ -615,16 +558,12 @@ test('election manager cannot auth onto machine with different election hash', a
 test('error boundary', async () => {
   const getElectionResponseBody: Scan.GetElectionConfigResponse =
     electionSampleDefinition;
-  const getTestModeResponseBody: Scan.GetTestModeConfigResponse = {
-    status: 'ok',
-    testMode: true,
-  };
+  mockApiClient.getTestMode.expectCallWith().resolves(true);
   const getMarkThresholdOverridesResponseBody: Scan.GetMarkThresholdOverridesConfigResponse =
     { status: 'ok' };
 
   fetchMock
     .get('/central-scanner/config/election', { body: getElectionResponseBody })
-    .get('/central-scanner/config/testMode', { body: getTestModeResponseBody })
     .get('/central-scanner/config/markThresholdOverrides', {
       body: getMarkThresholdOverridesResponseBody,
     });

--- a/libs/api/src/services/scan/index.test.ts
+++ b/libs/api/src/services/scan/index.test.ts
@@ -1,9 +1,0 @@
-import { safeParse } from '@votingworks/types';
-import { GetPrecinctSelectionConfigResponseSchema } from '.';
-
-test('sanity check', () => {
-  safeParse(GetPrecinctSelectionConfigResponseSchema, {
-    status: 'ok',
-    precinctId: 'abc',
-  }).unsafeUnwrap();
-});

--- a/libs/api/src/services/scan/index.ts
+++ b/libs/api/src/services/scan/index.ts
@@ -1,4 +1,4 @@
-import { Optional, Result } from '@votingworks/basics';
+import { Result } from '@votingworks/basics';
 import {
   AdjudicationStatus,
   AdjudicationStatusSchema,
@@ -15,10 +15,6 @@ import {
   IdSchema,
   MarkThresholds,
   MarkThresholdsSchema,
-  PollsState,
-  PollsStateSchema,
-  PrecinctSelection,
-  PrecinctSelectionSchema,
 } from '@votingworks/types';
 import * as z from 'zod';
 import {
@@ -70,35 +66,6 @@ export const GetElectionConfigResponseSchema: z.ZodSchema<GetElectionConfigRespo
 
 /**
  * @url /config/election
- * @method PATCH
- */
-export type PatchElectionConfigResponse = OkResponse | ErrorsResponse;
-
-/**
- * @url /config/election
- * @method PATCH
- */
-export const PatchElectionConfigResponseSchema: z.ZodSchema<PatchElectionConfigResponse> =
-  z.union([OkResponseSchema, ErrorsResponseSchema]);
-
-/**
- * @url /config/election
- * @method PATCH
- */
-export type PatchElectionConfigRequest = Uint8Array; // should be Buffer, but this triggers type errors
-
-/**
- * @url /config/election
- * @method PATCH
- */
-export const PatchElectionConfigRequestSchema: z.ZodSchema<PatchElectionConfigRequest> =
-  z.instanceof(
-    // should be Buffer, but this triggers type errors
-    Uint8Array
-  );
-
-/**
- * @url /config/election
  * @method DELETE
  */
 export type DeleteElectionConfigResponse = OkResponse | ErrorsResponse;
@@ -109,32 +76,6 @@ export type DeleteElectionConfigResponse = OkResponse | ErrorsResponse;
  */
 export const DeleteElectionConfigResponseSchema: z.ZodSchema<DeleteElectionConfigResponse> =
   OkResponseSchema;
-
-/**
- * @url /config/package
- * @method PUT
- */
-export type PutConfigPackageRequest = never;
-
-/**
- * @url /config/package
- * @method PUT
- */
-export const PutConfigPackageRequestSchema: z.ZodSchema<PutConfigPackageRequest> =
-  z.never();
-
-/**
- * @url /config/package
- * @method PUT
- */
-export type PutConfigPackageResponse = OkResponse | ErrorsResponse;
-
-/**
- * @url /config/package
- * @method PUT
- */
-export const PutConfigPackageResponseSchema: z.ZodSchema<PutConfigPackageResponse> =
-  z.union([OkResponseSchema, ErrorsResponseSchema]);
 
 /**
  * @url /config/testMode
@@ -181,127 +122,6 @@ export type PatchTestModeConfigResponse = OkResponse | ErrorsResponse;
  */
 export const PatchTestModeConfigResponseSchema: z.ZodSchema<PatchTestModeConfigResponse> =
   z.union([OkResponseSchema, ErrorsResponseSchema]);
-
-/**
- * @url /config/precinct
- * @method GET
- */
-export type GetPrecinctSelectionConfigResponse = OkResponse<{
-  precinctSelection?: PrecinctSelection;
-}>;
-
-/**
- * @url /config/precinct
- * @method GET
- */
-export const GetPrecinctSelectionConfigResponseSchema: z.ZodSchema<GetPrecinctSelectionConfigResponse> =
-  z.object({
-    status: z.literal('ok'),
-    precinctSelection: z.optional(PrecinctSelectionSchema),
-  });
-
-/**
- * @url /config/precinct
- * @method PATCH
- */
-export interface PatchPrecinctSelectionConfigRequest {
-  precinctSelection: PrecinctSelection;
-}
-
-/**
- * @url /config/precinct
- * @method PATCH
- */
-export const PatchPrecinctSelectionConfigRequestSchema: z.ZodSchema<PatchPrecinctSelectionConfigRequest> =
-  z.object({
-    precinctSelection: PrecinctSelectionSchema,
-  });
-
-/**
- * @url /config/precinct
- * @method PATCH
- */
-export type PatchPrecinctSelectionConfigResponse = OkResponse | ErrorsResponse;
-
-/**
- * @url /config/precinct
- * @method PATCH
- */
-export const PatchPrecinctSelectionConfigResponseSchema: z.ZodSchema<PatchPrecinctSelectionConfigResponse> =
-  z.union([OkResponseSchema, ErrorsResponseSchema]);
-
-/**
- * @url /config/isSoundMuted
- * @method PATCH
- */
-export type PatchIsSoundMutedConfigResponse = OkResponse | ErrorsResponse;
-
-/**
- * @url /config/isSoundMuted
- * @method PATCH
- */
-export const PatchIsSoundMutedConfigResponseSchema: z.ZodSchema<PatchIsSoundMutedConfigResponse> =
-  z.union([OkResponseSchema, ErrorsResponseSchema]);
-
-/**
- * @url /config/isSoundMuted
- * @method PATCH
- */
-export interface PatchIsSoundMutedConfigRequest {
-  isSoundMuted: boolean;
-}
-
-/**
- * @url /config/isSoundMuted
- * @method PATCH
- */
-export const PatchIsSoundMutedConfigRequestSchema: z.ZodSchema<PatchIsSoundMutedConfigRequest> =
-  z.object({
-    isSoundMuted: z.boolean(),
-  });
-
-/**
- * @url /config/polls
- * @method PATCH
- */
-export interface PatchPollsStateRequest {
-  pollsState: PollsState;
-}
-
-/**
- * @url /config/polls
- * @method PATCH
- */
-export const PatchPollsStateRequestSchema: z.ZodSchema<PatchPollsStateRequest> =
-  z.object({
-    pollsState: PollsStateSchema,
-  });
-
-/**
- * @url /config/polls
- * @method PATCH
- */
-export type PatchPollsStateResponse = OkResponse | ErrorsResponse;
-
-/**
- * @url /config/polls
- * @method PATCH
- */
-export const PatchPollsStateResponseSchema: z.ZodSchema<PatchPollsStateResponse> =
-  z.union([OkResponseSchema, ErrorsResponseSchema]);
-
-/**
- * @url /config/ballotCountWhenBallotBagLastReplaced
- * @method PATCH
- */
-export type PatchBallotBagReplaced = OkResponse;
-
-/**
- * @url /config/ballotCountWhenBallotBagLastReplaced
- * @method PATCH
- */
-export const PatchBallotBagReplacedSchema: z.ZodSchema<PatchBallotBagReplaced> =
-  OkResponseSchema;
 
 /**
  * @url /config/markThresholdOverrides
@@ -453,56 +273,6 @@ export type ExportToUsbDriveResponse = OkResponse | ErrorsResponse;
  */
 export const ExportToUsbDriveResponseSchema: z.ZodSchema<ExportToUsbDriveResponse> =
   z.union([OkResponseSchema, ErrorsResponseSchema]);
-
-/**
- * @url /scan/export
- * @method POST
- */
-export type ExportRequest = Optional<{
-  skipImages: boolean;
-}>;
-
-/**
- * @url /scan/export
- * @method POST
- */
-export const ExportRequestSchema: z.ZodSchema<ExportRequest> = z
-  .object({
-    skipImages: z.boolean(),
-  })
-  .optional();
-
-/**
- * @url /scan/export
- * @method POST
- */
-export type ExportResponse = string | ErrorsResponse;
-
-/**
- * @url /scan/export
- * @method POST
- */
-export const ExportResponseSchema: z.ZodSchema<ExportResponse> = z.union([
-  z.string(),
-  ErrorsResponseSchema,
-]);
-
-/**
- * @url /scan/export
- * @method GET
- */
-export interface DownloadExportQueryParams {
-  filename?: string;
-}
-
-/**
- * @url /scan/export
- * @method GET
- */
-export const DownloadExportQueryParamsSchema: z.ZodSchema<DownloadExportQueryParams> =
-  z.object({
-    filename: z.string().optional(),
-  });
 
 /**
  * Possible errors when exporting a file.

--- a/libs/api/src/services/scan/index.ts
+++ b/libs/api/src/services/scan/index.ts
@@ -78,52 +78,6 @@ export const DeleteElectionConfigResponseSchema: z.ZodSchema<DeleteElectionConfi
   OkResponseSchema;
 
 /**
- * @url /config/testMode
- * @method GET
- */
-export type GetTestModeConfigResponse = OkResponse<{ testMode: boolean }>;
-
-/**
- * @url /config/testMode
- * @method GET
- */
-export const GetTestModeConfigResponseSchema: z.ZodSchema<GetTestModeConfigResponse> =
-  z.object({
-    status: z.literal('ok'),
-    testMode: z.boolean(),
-  });
-
-/**
- * @url /config/testMode
- * @method PATCH
- */
-export interface PatchTestModeConfigRequest {
-  testMode: boolean;
-}
-
-/**
- * @url /config/testMode
- * @method PATCH
- */
-export const PatchTestModeConfigRequestSchema: z.ZodSchema<PatchTestModeConfigRequest> =
-  z.object({
-    testMode: z.boolean(),
-  });
-
-/**
- * @url /config/testMode
- * @method PATCH
- */
-export type PatchTestModeConfigResponse = OkResponse | ErrorsResponse;
-
-/**
- * @url /config/testMode
- * @method PATCH
- */
-export const PatchTestModeConfigResponseSchema: z.ZodSchema<PatchTestModeConfigResponse> =
-  z.union([OkResponseSchema, ErrorsResponseSchema]);
-
-/**
  * @url /config/markThresholdOverrides
  * @method GET
  */

--- a/libs/backend/src/exporter.test.ts
+++ b/libs/backend/src/exporter.test.ts
@@ -5,7 +5,7 @@ import { readFile, symlink, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { Readable } from 'stream';
 import { DirResult, dirSync } from 'tmp';
-import { Exporter, ExportFileResult } from './exporter';
+import { Exporter, ExportDataResult } from './exporter';
 import { UsbDrive } from './get_usb_drives';
 import { execFile } from './utils/exec';
 
@@ -105,7 +105,7 @@ test('exportData with a symbolic link', async () => {
   await writeFile(existingPath, 'bar');
   await symlink(existingPath, linkPath);
   const result = await exporter.exportData(linkPath, 'bar');
-  expect(result).toEqual<ExportFileResult>(
+  expect(result).toEqual<ExportDataResult>(
     err({
       type: 'permission-denied',
       message: expect.stringContaining('Path must not contain symbolic links'),

--- a/libs/backend/src/exporter.ts
+++ b/libs/backend/src/exporter.ts
@@ -1,4 +1,3 @@
-import { z } from 'zod';
 import { err, ok, Result } from '@votingworks/basics';
 import { mkdir, writeFile } from 'fs/promises';
 import { any } from 'micromatch';
@@ -26,32 +25,9 @@ export type ExportDataError =
   | { type: 'missing-usb-drive'; message: string };
 
 /**
- * Schema for {@link ExportDataError}.
+ * Result of exporting data to the file system.
  */
-export const ExportFileErrorSchema: z.ZodSchema<ExportDataError> =
-  z.discriminatedUnion('type', [
-    z.object({
-      type: z.literal('relative-file-path'),
-      message: z.string(),
-    }),
-    z.object({
-      type: z.literal('permission-denied'),
-      message: z.string(),
-    }),
-    z.object({
-      type: z.literal('file-system-error'),
-      message: z.string(),
-    }),
-    z.object({
-      type: z.literal('missing-usb-drive'),
-      message: z.string(),
-    }),
-  ]);
-
-/**
- * Result of exporting a file to the file system.
- */
-export type ExportFileResult = Result<string[], ExportDataError>;
+export type ExportDataResult = Result<string[], ExportDataError>;
 
 /** Settings for the {@link Exporter}. */
 export interface ExporterSettings {
@@ -89,7 +65,7 @@ export class Exporter {
     }: {
       maximumFileSize?: number;
     } = {}
-  ): Promise<ExportFileResult> {
+  ): Promise<ExportDataResult> {
     const getSafePathResult = this.getSafePathForWriting(path);
 
     if (getSafePathResult.isErr()) {
@@ -139,7 +115,7 @@ export class Exporter {
     }: {
       maximumFileSize?: number;
     } = {}
-  ): Promise<ExportFileResult> {
+  ): Promise<ExportDataResult> {
     const [usbDrive] = await this.getUsbDrives();
 
     if (!usbDrive?.mountPoint) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,9 +350,6 @@ importers:
       '@types/styled-components':
         specifier: ^5.1.7
         version: 5.1.9
-      '@votingworks/api':
-        specifier: workspace:*
-        version: link:../../../libs/api
       '@votingworks/ballot-encoder':
         specifier: workspace:*
         version: link:../../../libs/ballot-encoder


### PR DESCRIPTION
## Overview
<!-- add a link to a GitHub Issue here -->
Chips away more at `@votingworks/api`, replacing it with Grout APIs.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated. Manually tested toggling test mode in VxCentralScan.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
