### PR TITLE
[VxAdmin] Reduce unnecessary rapid re-renders of the full React tree

### DIFF
--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import React from 'react';
 import type { Api } from '@votingworks/admin-backend';
 import {
@@ -59,6 +60,15 @@ export const getAuthStatus = {
     const apiClient = useApiClient();
     return useQuery(this.queryKey(), () => apiClient.getAuthStatus(), {
       refetchInterval: AUTH_STATUS_POLLING_INTERVAL_MS,
+      structuralSharing(oldData, newData) {
+        if (!oldData) {
+          return newData;
+        }
+
+        // Prevent infinite re-renders of the app tree:
+        const isUnchanged = _.isEqual(oldData, newData);
+        return isUnchanged ? oldData : newData;
+      },
     });
   },
 } as const;


### PR DESCRIPTION
## Overview

Noticed VxAdmin was running slowly and stuttering sometimes, CSS transitions weren't working, and my computer generally seemed to be working a little harder than it should.

Dug a bit and realised our auth status polling is done at the root component level and triggers a re-render of everything (every 100ms - just short enough to kill my beautiful transitions).

Started off by using the `isDataEqual()` react-query param, but got console warnings about it being deprecated, so using the unfortunately named `structuralSharing()` param instead. This does mean we're doing an object compare every 100ms, but it's a negligible cost compared to recomputing the render tree. Open to change suggestions if there are better workarounds here.

@adghayes - not 100% sure, but this could be what was slowing your machine to crawl whenever you were presenting.

## Demo Video or Screenshot
### Before:
https://github.com/votingworks/vxsuite/assets/264902/5b059336-66ba-44d5-99fc-1fe1b7c36c3f

### After:
https://github.com/votingworks/vxsuite/assets/264902/54358dcb-673a-4b5a-af16-2a668844397d

## Testing Plan
- Listened to my computer fan 😜 

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
