### PR TITLE
feat(message-coder): add `oneOf` coder

### DIFF
--- a/libs/custom-scanner/src/mocks/coder.ts
+++ b/libs/custom-scanner/src/mocks/coder.ts
@@ -14,7 +14,10 @@ function notImplemented() {
  */
 // eslint-disable-next-line vx/gts-no-return-type-only-generics
 export function mockCoder<T>(): jest.Mocked<Coder<T>> {
-  return {
+  // due to overloads, we can't just use jest.Mocked<Coder<T>>
+  // but we can at least ensure we use the right keys
+  const coder: jest.Mocked<{ [K in keyof Coder<T>]: unknown }> = {
+    canEncode: jest.fn().mockImplementation(notImplemented),
     default: jest.fn().mockImplementation(notImplemented),
     bitLength: jest.fn().mockImplementation(notImplemented),
     encode: jest.fn().mockImplementation(notImplemented),
@@ -22,4 +25,5 @@ export function mockCoder<T>(): jest.Mocked<Coder<T>> {
     decode: jest.fn().mockImplementation(notImplemented),
     decodeFrom: jest.fn().mockImplementation(notImplemented),
   };
+  return coder as jest.Mocked<Coder<T>>;
 }

--- a/libs/custom-scanner/src/protocol.test.ts
+++ b/libs/custom-scanner/src/protocol.test.ts
@@ -108,6 +108,7 @@ test('get image data request', () => {
   );
 
   expect(GetImageDataRequest.default()).toEqual({
+    header: ['IMG', 0x00],
     length: 0,
     scanSide: ScanSide.A,
   });
@@ -789,6 +790,7 @@ test('getImageData', async () => {
 
         onRead.mockResolvedValueOnce(ok(res));
 
+        expect(GetImageDataRequest.canEncode(req)).toEqual(true);
         expect(await getImageData(channel, req.length, req.scanSide)).toEqual(
           ok(res)
         );

--- a/libs/custom-scanner/src/protocol.ts
+++ b/libs/custom-scanner/src/protocol.ts
@@ -628,12 +628,16 @@ class GetImageDataRequestScanSideCoder extends BaseCoder<ScanSide> {
   private static readonly SideA = 0x0;
   private static readonly SideB = 0x1;
 
+  canEncode(value: unknown): value is ScanSide {
+    return value === ScanSide.A || value === ScanSide.B;
+  }
+
   default(): ScanSide {
     return ScanSide.A;
   }
 
-  bitLength(): BitLength {
-    return 8;
+  bitLength(): Result<BitLength, CoderError> {
+    return ok(8);
   }
 
   encodeInto(value: ScanSide, buffer: Buffer, bitOffset: number): EncodeResult {

--- a/libs/message-coder/src/base_coder.test.ts
+++ b/libs/message-coder/src/base_coder.test.ts
@@ -1,17 +1,27 @@
-import { err, ok } from '@votingworks/basics';
+import { Result, err, ok } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import * as fc from 'fast-check';
 import { BaseCoder } from './base_coder';
 import { bufferContainsBitOffset, toByteOffset } from './bits';
-import { DecodeResult, EncodeResult, Uint8 } from './types';
+import {
+  BitLength,
+  CoderError,
+  DecodeResult,
+  EncodeResult,
+  Uint8,
+} from './types';
 
 class TestCoder extends BaseCoder<number> {
+  canEncode(value: unknown): value is number {
+    return typeof value === 'number';
+  }
+
   default(): number {
     return 0;
   }
 
-  bitLength(): number {
-    return 8;
+  bitLength(): Result<BitLength, CoderError> {
+    return ok(8);
   }
 
   encodeInto(value: number, buffer: Buffer, bitOffset: number): EncodeResult {

--- a/libs/message-coder/src/fixed_string.test.ts
+++ b/libs/message-coder/src/fixed_string.test.ts
@@ -10,8 +10,10 @@ test('fixed string', () => {
   const coder = fixedString(5);
   type coder = CoderType<typeof coder>;
 
+  expect(coder.canEncode('hello')).toEqual(true);
+  expect(coder.canEncode(1)).toEqual(false);
   expect(coder.default()).toEqual('');
-  expect(coder.bitLength('hello')).toEqual(40);
+  expect(coder.bitLength('hello')).toEqual(ok(40));
   expect(coder.encode('hello')).toEqual(ok(Buffer.from('hello')));
   expect(coder.decode(Buffer.from('hello'))).toEqual(ok('hello'));
 
@@ -69,7 +71,7 @@ test('fixed string random', () => {
         // encodeInto/decodeFrom
         const buffer = Buffer.alloc(byteLength + byteOffset);
         expect(coder.encodeInto(s, buffer, toBitOffset(byteOffset))).toEqual(
-          ok(bitOffset + coder.bitLength(s))
+          ok(bitOffset + coder.bitLength(s).unsafeUnwrap())
         );
         expect(buffer.slice(byteOffset).toString('utf8')).toEqual(s);
         expect(coder.decodeFrom(buffer, toBitOffset(byteOffset))).toEqual(

--- a/libs/message-coder/src/fixed_string.ts
+++ b/libs/message-coder/src/fixed_string.ts
@@ -25,6 +25,10 @@ export class FixedStringCoder implements Coder<string> {
     private readonly includeTrailingNulls = false
   ) {}
 
+  canEncode(value: unknown): value is string {
+    return typeof value === 'string';
+  }
+
   default(): string {
     if (!this.includeTrailingNulls) {
       return '';
@@ -33,8 +37,8 @@ export class FixedStringCoder implements Coder<string> {
     return Buffer.alloc(this.byteLength).toString('utf8');
   }
 
-  bitLength(): BitLength {
-    return toBitLength(this.byteLength);
+  bitLength(): Result<BitLength, CoderError> {
+    return ok(toBitLength(this.byteLength));
   }
 
   encode(value: string): Result<Buffer, CoderError> {

--- a/libs/message-coder/src/index.ts
+++ b/libs/message-coder/src/index.ts
@@ -6,6 +6,7 @@ export * from './equality';
 export * from './fixed_string';
 export * from './literal_coder';
 export * from './message_coder';
+export * from './one_of_coder';
 export * from './padding_coder';
 export * from './types';
 export * from './uint16_coder';

--- a/libs/message-coder/src/one_of_coder.test.ts
+++ b/libs/message-coder/src/one_of_coder.test.ts
@@ -1,0 +1,127 @@
+import { err, ok } from '@votingworks/basics';
+import { Buffer } from 'buffer';
+import fc from 'fast-check';
+import { literal } from './literal_coder';
+import { message } from './message_coder';
+import { oneOf } from './one_of_coder';
+import { uint16 } from './uint16_coder';
+import { uint8 } from './uint8_coder';
+
+test('oneOf one message', () => {
+  const a = oneOf(
+    message({
+      type: literal('A'),
+      aValue: uint16(),
+    })
+  );
+
+  expect(a.canEncode({ aValue: 1 })).toEqual(true);
+  expect(a.canEncode({ bValue: 1 })).toEqual(false);
+
+  expect(a.bitLength({ aValue: 1 })).toEqual(ok(8 + 16));
+  // @ts-expect-error - intentionally incompatible to test an error case
+  expect(a.bitLength({ bValue: 1 })).toEqual(err('InvalidValue'));
+
+  // uses the default of the first coder
+  expect(a.default()).toEqual({ type: ['A'], aValue: 0 });
+
+  expect(a.encode({ aValue: 1 })).toEqual(
+    ok(Buffer.of('A'.charCodeAt(0), 0x01, 0x00))
+  );
+  expect(a.decode(Buffer.from(['A'.charCodeAt(0), 0x01, 0x00]))).toEqual(
+    ok({ aValue: 1 })
+  );
+});
+
+test('oneOf two messages', () => {
+  const aOrB = oneOf(
+    message({
+      type: literal('A'),
+      aValue: uint16(),
+    }),
+    message({
+      type: literal('B'),
+      bValue: uint8(),
+    })
+  );
+
+  expect(aOrB.canEncode({ aValue: 1 })).toEqual(true);
+  expect(aOrB.canEncode({ bValue: 1 })).toEqual(true);
+  expect(aOrB.canEncode({ cValue: 1 })).toEqual(false);
+
+  expect(aOrB.bitLength({ aValue: 1 })).toEqual(ok(8 + 16));
+  expect(aOrB.bitLength({ bValue: 1 })).toEqual(ok(8 + 8));
+  // @ts-expect-error - intentionally incompatible to test an error case
+  expect(aOrB.bitLength({ cValue: 1 })).toEqual(err('InvalidValue'));
+
+  // uses the default of the first coder
+  expect(aOrB.default()).toEqual({ type: ['A'], aValue: 0 });
+
+  expect(aOrB.encode({ aValue: 1 })).toEqual(
+    ok(Buffer.of('A'.charCodeAt(0), 0b00000001, 0b00000000))
+  );
+  expect(aOrB.encode({ bValue: 1 })).toEqual(
+    ok(Buffer.of('B'.charCodeAt(0), 0b00000001))
+  );
+  // @ts-expect-error - intentionally incompatible to test an error case
+  expect(aOrB.encode({ cValue: 1 })).toEqual(err('InvalidValue'));
+
+  // @ts-expect-error - intentionally incompatible to test an error case
+  expect(aOrB.encodeInto({ cValue: 1 }, Buffer.alloc(3), 0)).toEqual(
+    err('InvalidValue')
+  );
+
+  expect(aOrB.decode(Buffer.from([]))).toEqual(err('InvalidValue'));
+
+  fc.assert(
+    fc.property(fc.integer({ min: 0, max: 0xffff }), (aValue) => {
+      const encoded = aOrB.encode({ aValue }).unsafeUnwrap();
+      expect(encoded).toEqual(
+        Buffer.of('A'.charCodeAt(0), aValue & 0xff, aValue >> 8)
+      );
+      const decoded = aOrB.decode(encoded).unsafeUnwrap();
+      expect(decoded).toEqual({ aValue });
+    })
+  );
+
+  fc.assert(
+    fc.property(fc.integer({ min: 0, max: 0xff }), (bValue) => {
+      const encoded = aOrB.encode({ bValue }).unsafeUnwrap();
+      expect(encoded).toEqual(Buffer.of('B'.charCodeAt(0), bValue));
+      const decoded = aOrB.decode(encoded).unsafeUnwrap();
+      expect(decoded).toEqual({ bValue });
+    })
+  );
+});
+
+test('oneOf by discriminator', () => {
+  const HorizontalSettings = message({
+    type: literal('horizontal'),
+    resolution: uint16(),
+  });
+  const VerticalSettings = message({
+    type: literal('vertical'),
+    resolution: uint16(),
+  });
+
+  const Settings = oneOf(HorizontalSettings, VerticalSettings);
+
+  // implicitly uses `HorizontalSettings` since it's first and both match
+  expect(Settings.encode({ resolution: 1024 }).unsafeUnwrap()).toEqual(
+    Buffer.concat([Buffer.from('horizontal'), Buffer.from([0x00, 0x04])])
+  );
+
+  // explicitly uses `VerticalSettings` because `type` is provided
+  expect(
+    Settings.encode({ type: 'vertical', resolution: 768 }).unsafeUnwrap()
+  ).toEqual(
+    Buffer.concat([Buffer.from('vertical'), Buffer.from([0x00, 0x03])])
+  );
+
+  // explicitly uses `HorizontalSettings` because `type` is provided
+  expect(
+    Settings.encode({ type: 'horizontal', resolution: 1024 }).unsafeUnwrap()
+  ).toEqual(
+    Buffer.concat([Buffer.from('horizontal'), Buffer.from([0x00, 0x04])])
+  );
+});

--- a/libs/message-coder/src/one_of_coder.ts
+++ b/libs/message-coder/src/one_of_coder.ts
@@ -1,0 +1,120 @@
+import { Buffer } from 'buffer';
+import { Result, assert, err } from '@votingworks/basics';
+import { BaseCoder } from './base_coder';
+import {
+  BitLength,
+  Coder,
+  CoderError,
+  DecodeResult,
+  EncodeResult,
+} from './types';
+import { CoderType } from './message_coder';
+
+/**
+ * A coder that encodes/decodes one of a set of coders.
+ */
+export class OneOfCoder<T> extends BaseCoder<T> {
+  constructor(private readonly coders: ReadonlyArray<Coder<T>>) {
+    super();
+  }
+
+  /**
+   * Determines whether a value can be encoded by trying each coder in turn.
+   */
+  canEncode(value: unknown): value is T {
+    return this.coders.some((coder) => coder.canEncode(value));
+  }
+
+  /**
+   * Returns the default value of the first coder.
+   */
+  default(): T {
+    const [coder] = this.coders;
+    assert(coder !== undefined);
+    return coder.default();
+  }
+
+  /**
+   * Returns the bit length of a value by trying each coder in turn.
+   */
+  bitLength(value: T): Result<BitLength, CoderError> {
+    for (const coder of this.coders) {
+      if (!coder.canEncode(value)) {
+        continue;
+      }
+
+      return coder.bitLength(value);
+    }
+
+    return err('InvalidValue');
+  }
+
+  /**
+   * Encodes a value into a buffer by trying each coder in turn.
+   */
+  encodeInto(value: T, buffer: Buffer, bitOffset: number): EncodeResult {
+    for (const coder of this.coders) {
+      if (!coder.canEncode(value)) {
+        continue;
+      }
+
+      return coder.encodeInto(value, buffer, bitOffset);
+    }
+
+    return err('InvalidValue');
+  }
+
+  /**
+   * Decodes a value from a buffer by trying each coder in turn.
+   */
+  decodeFrom(buffer: Buffer, bitOffset: number): DecodeResult<T> {
+    for (const coder of this.coders) {
+      const result = coder.decodeFrom(buffer, bitOffset);
+      if (result.isOk()) {
+        return result;
+      }
+    }
+
+    return err('InvalidValue');
+  }
+}
+
+/**
+ * Builds a coder that encodes/decodes one of a set of coders. Each coder is
+ * tried in turn until one succeeds. It's simplest to provide coders whose types
+ * are incompatible with each other so that only one can succeed. If multiple
+ * coders can encode a value, the first one is used. This may not be the one you
+ * expect, but if the coder types are discriminated based on a `literal` then
+ * you can provide the literal value to ensure the correct coder is used.
+ *
+ * @example
+ *
+ * ```ts
+ * const HorizontalSettings = message({
+ *   type: literal('horizontal'),
+ *   resolution: uint16(),
+ * });
+ * const VerticalSettings = message({
+ *  type: literal('vertical'),
+ *  resolution: uint16(),
+ * });
+ *
+ * const Settings = oneOf(HorizontalSettings, VerticalSettings);
+ *
+ * // implicitly uses `HorizontalSettings` since it's first and both match
+ * const encoded1 = Settings.encode({ resolution: 1024 });
+ *
+ * // explicitly uses `VerticalSettings` because `type` is provided
+ * const encoded2 = Settings.encode({ type: 'vertical', resolution: 768 });
+ *
+ * // explicitly uses `HorizontalSettings` because `type` is provided
+ * const encoded3 = Settings.encode({ type: 'horizontal', resolution: 1024 });
+ * ```
+ */
+export function oneOf<T extends Array<Coder<unknown>>>(
+  ...coders: T
+): Coder<CoderType<T>> {
+  return new OneOfCoder<CoderType<T>>(
+    coders as ReadonlyArray<Coder<CoderType<T>>>
+  );
+}

--- a/libs/message-coder/src/padding_coder.test.ts
+++ b/libs/message-coder/src/padding_coder.test.ts
@@ -12,8 +12,11 @@ test('padding', () => {
     b: uint8(),
   });
 
+  expect(padding(1).canEncode(undefined)).toEqual(true);
+  expect(padding(1).canEncode('a value')).toEqual(false);
+
   expect(m.default()).toEqual({ a: 0, b: 0 });
-  expect(m.bitLength({ a: 1, b: 2 })).toEqual(16);
+  expect(m.bitLength({ a: 1, b: 2 })).toEqual(ok(16));
   expect(m.encode({ a: 1, b: 2 })).toEqual(ok(Buffer.from([0b00010000, 0x02])));
   expect(m.decode(Buffer.from([0b00010000, 0x02]))).toEqual(ok({ a: 1, b: 2 }));
 

--- a/libs/message-coder/src/padding_coder.ts
+++ b/libs/message-coder/src/padding_coder.ts
@@ -1,8 +1,14 @@
-import { err, ok } from '@votingworks/basics';
+import { Result, err, ok } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import { BaseCoder } from './base_coder';
 import { bufferContainsBitOffset } from './bits';
-import { BitOffset, DecodeResult, EncodeResult } from './types';
+import {
+  BitLength,
+  BitOffset,
+  CoderError,
+  DecodeResult,
+  EncodeResult,
+} from './types';
 
 /**
  * Occupies bits in the buffer without encoding or decoding any data.
@@ -12,12 +18,16 @@ export class PaddingCoder extends BaseCoder<void> {
     super();
   }
 
+  canEncode(value: unknown): value is void {
+    return value === undefined;
+  }
+
   default(): void {
     return undefined;
   }
 
-  bitLength(): number {
-    return this.paddingBitsLength;
+  bitLength(): Result<BitLength, CoderError> {
+    return ok(this.paddingBitsLength);
   }
 
   encodeInto(_value: void, buffer: Buffer, bitOffset: BitOffset): EncodeResult {
@@ -33,7 +43,7 @@ export class PaddingCoder extends BaseCoder<void> {
   decodeFrom(buffer: Buffer, bitOffset: BitOffset): DecodeResult<void> {
     const nextOffset = bitOffset + this.paddingBitsLength;
 
-    if (!bufferContainsBitOffset(buffer, nextOffset, this.paddingBitsLength)) {
+    if (!bufferContainsBitOffset(buffer, nextOffset)) {
       return err('SmallBuffer');
     }
 

--- a/libs/message-coder/src/types.ts
+++ b/libs/message-coder/src/types.ts
@@ -72,6 +72,11 @@ export interface Coder<T> {
   default(): T;
 
   /**
+   * Determine whether a value can be encoded by this coder.
+   */
+  canEncode(value: unknown): value is T;
+
+  /**
    * Encode a value as a buffer.
    */
   encode(value: T): Result<Buffer, CoderError>;
@@ -84,7 +89,7 @@ export interface Coder<T> {
   /**
    * Calculate how many bits are needed to encode a value.
    */
-  bitLength(value: T): BitLength;
+  bitLength(value: T): Result<BitLength, CoderError>;
 
   /**
    * Encode a value into a buffer at a given bit offset.

--- a/libs/message-coder/src/uint16_coder.test.ts
+++ b/libs/message-coder/src/uint16_coder.test.ts
@@ -60,7 +60,9 @@ test('uint16 with enumeration', () => {
   }
 
   const field = uint16<Enum>(Enum);
-  expect(field.bitLength(Enum.A)).toEqual(16);
+  expect(field.canEncode(Enum.A)).toEqual(true);
+  expect(field.canEncode(99)).toEqual(false);
+  expect(field.bitLength(Enum.A)).toEqual(ok(16));
   expect(field.encode(Enum.A)).toEqual(ok(Buffer.from([1, 0])));
   expect(field.decode(Buffer.from([1, 0]))).toEqual(ok(Enum.A));
   expect(field.encode(99)).toEqual(err('InvalidValue'));

--- a/libs/message-coder/src/uint16_coder.ts
+++ b/libs/message-coder/src/uint16_coder.ts
@@ -1,10 +1,11 @@
 import { Buffer } from 'buffer';
-import { resultBlock } from '@votingworks/basics';
+import { Result, ok, resultBlock } from '@votingworks/basics';
 import { MAX_UINT16, MIN_UINT16 } from './constants';
 import {
   BitLength,
   BitOffset,
   Coder,
+  CoderError,
   DecodeResult,
   EncodeResult,
   Uint16,
@@ -30,8 +31,8 @@ export class Uint16Coder extends UintCoder {
     this.littleEndian = littleEndian;
   }
 
-  bitLength(): BitLength {
-    return 16;
+  bitLength(): Result<BitLength, CoderError> {
+    return ok(16);
   }
 
   protected minValue = MIN_UINT16;

--- a/libs/message-coder/src/uint1_coder.test.ts
+++ b/libs/message-coder/src/uint1_coder.test.ts
@@ -10,6 +10,9 @@ test('uint1 offset=0', () => {
   type coder = CoderType<typeof coder>;
   const buffer = Buffer.alloc(1);
   const bitOffset = 0;
+  expect(coder.canEncode(true)).toEqual(true);
+  expect(coder.canEncode(false)).toEqual(true);
+  expect(coder.canEncode(0)).toEqual(false);
   expect(coder.default()).toEqual(false);
   expect(coder.encodeInto(true, buffer, bitOffset)).toEqual(ok(bitOffset + 1));
   expect(buffer.readUInt8(0)).toEqual(0b10000000);

--- a/libs/message-coder/src/uint24_coder.test.ts
+++ b/libs/message-coder/src/uint24_coder.test.ts
@@ -37,7 +37,9 @@ test('uint24 with enumeration', () => {
   }
 
   const field = uint24<Enum>(Enum);
-  expect(field.bitLength(Enum.A)).toEqual(24);
+  expect(field.canEncode(Enum.A)).toEqual(true);
+  expect(field.canEncode(99)).toEqual(false);
+  expect(field.bitLength(Enum.A)).toEqual(ok(24));
   expect(field.encode(Enum.A)).toEqual(ok(Buffer.from([1, 0, 0])));
   expect(field.decode(Buffer.from([1, 0, 0]))).toEqual(ok(Enum.A));
   expect(field.encode(99)).toEqual(err('InvalidValue'));

--- a/libs/message-coder/src/uint24_coder.ts
+++ b/libs/message-coder/src/uint24_coder.ts
@@ -1,7 +1,14 @@
-import { resultBlock } from '@votingworks/basics';
+import { Result, ok, resultBlock } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import { MAX_UINT24, MIN_UINT24 } from './constants';
-import { BitOffset, Coder, DecodeResult, EncodeResult, Uint24 } from './types';
+import {
+  BitOffset,
+  Coder,
+  CoderError,
+  DecodeResult,
+  EncodeResult,
+  Uint24,
+} from './types';
 import { UintCoder } from './uint_coder';
 
 /**
@@ -9,8 +16,8 @@ import { UintCoder } from './uint_coder';
  * order.
  */
 export class Uint24Coder extends UintCoder {
-  bitLength(): Uint24 {
-    return 24;
+  bitLength(): Result<Uint24, CoderError> {
+    return ok(24);
   }
 
   protected minValue = MIN_UINT24;

--- a/libs/message-coder/src/uint2_coder.test.ts
+++ b/libs/message-coder/src/uint2_coder.test.ts
@@ -8,6 +8,11 @@ import { uint2 } from './uint2_coder';
 test('uint2 simple', () => {
   const coder = uint2();
 
+  expect(coder.canEncode(0)).toEqual(true);
+  expect(coder.canEncode(1)).toEqual(true);
+  expect(coder.canEncode(2)).toEqual(true);
+  expect(coder.canEncode(3)).toEqual(true);
+  expect(coder.canEncode(4)).toEqual(false);
   expect(coder.default()).toEqual(0);
 
   // encode/decode

--- a/libs/message-coder/src/uint32_coder.test.ts
+++ b/libs/message-coder/src/uint32_coder.test.ts
@@ -60,7 +60,9 @@ test('uint32 with enumeration', () => {
   }
 
   const field = uint32<Enum>(Enum);
-  expect(field.bitLength(Enum.A)).toEqual(32);
+  expect(field.canEncode(Enum.A)).toEqual(true);
+  expect(field.canEncode(99)).toEqual(false);
+  expect(field.bitLength(Enum.A)).toEqual(ok(32));
   expect(field.encode(Enum.A)).toEqual(ok(Buffer.from([1, 0, 0, 0])));
   expect(field.decode(Buffer.from([1, 0, 0, 0]))).toEqual(ok(Enum.A));
   expect(field.encode(99)).toEqual(err('InvalidValue'));

--- a/libs/message-coder/src/uint32_coder.ts
+++ b/libs/message-coder/src/uint32_coder.ts
@@ -1,10 +1,11 @@
-import { resultBlock } from '@votingworks/basics';
+import { Result, ok, resultBlock } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import { MAX_UINT32, MIN_UINT32 } from './constants';
 import {
   BitLength,
   BitOffset,
   Coder,
+  CoderError,
   DecodeResult,
   EncodeResult,
   Uint32,
@@ -30,8 +31,8 @@ export class Uint32Coder extends UintCoder {
     this.littleEndian = littleEndian;
   }
 
-  bitLength(): BitLength {
-    return 32;
+  bitLength(): Result<BitLength, CoderError> {
+    return ok(32);
   }
 
   protected minValue = MIN_UINT32;

--- a/libs/message-coder/src/uint4_coder.test.ts
+++ b/libs/message-coder/src/uint4_coder.test.ts
@@ -9,7 +9,7 @@ import { uint4 } from './uint4_coder';
 test('uint4', () => {
   fc.assert(
     fc.property(
-      fc.integer(0, 15),
+      fc.integer({ min: 0, max: 15 }),
       fc.integer({ min: 0, max: 100 }),
       (value, byteOffset) => {
         const bitOffset = byteOffset * 8;
@@ -17,6 +17,7 @@ test('uint4', () => {
         const field = uint4();
         type field = CoderType<typeof field>;
 
+        expect(field.canEncode(value)).toEqual(true);
         expect(field.encodeInto(value, buffer, bitOffset)).toEqual(
           ok(bitOffset + 4)
         );
@@ -52,6 +53,8 @@ test('uint4 with enumeration', () => {
   const coder = uint4<Speed>(Speed);
 
   // encode/decode
+  expect(coder.canEncode(Speed.Fast)).toEqual(true);
+  expect(coder.canEncode(3)).toEqual(false);
   expect(coder.encode(Speed.Fast)).toEqual(ok(Buffer.from([0b00100000])));
   expect(coder.decode(Buffer.from([0b00100000]))).toEqual(ok(Speed.Fast));
 

--- a/libs/message-coder/src/uint8_coder.test.ts
+++ b/libs/message-coder/src/uint8_coder.test.ts
@@ -63,7 +63,9 @@ test('uint8 with enumeration', () => {
   }
 
   const field = uint8<Enum>(Enum);
-  expect(field.bitLength(Enum.A)).toEqual(8);
+  expect(field.canEncode(Enum.A)).toEqual(true);
+  expect(field.canEncode(99)).toEqual(false);
+  expect(field.bitLength(Enum.A)).toEqual(ok(8));
   expect(field.encode(Enum.A)).toEqual(ok(Buffer.from([1])));
   expect(field.decode(Buffer.from([1]))).toEqual(ok(Enum.A));
   expect(field.encode(99)).toEqual(err('InvalidValue'));

--- a/libs/message-coder/src/uint8_coder.ts
+++ b/libs/message-coder/src/uint8_coder.ts
@@ -1,10 +1,11 @@
-import { resultBlock } from '@votingworks/basics';
+import { Result, ok, resultBlock } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import { MAX_UINT8, MIN_UINT8 } from './constants';
 import {
   BitLength,
   BitOffset,
   Coder,
+  CoderError,
   DecodeResult,
   EncodeResult,
   Uint8,
@@ -15,8 +16,8 @@ import { UintCoder } from './uint_coder';
  * Coder for a uint8, aka an 8-bit unsigned integer.
  */
 export class Uint8Coder extends UintCoder {
-  bitLength(): BitLength {
-    return 8;
+  bitLength(): Result<BitLength, CoderError> {
+    return ok(8);
   }
 
   protected minValue = MIN_UINT8;

--- a/libs/message-coder/src/unbounded_string_coder.test.ts
+++ b/libs/message-coder/src/unbounded_string_coder.test.ts
@@ -6,16 +6,19 @@ import { unboundedString } from './unbounded_string_coder';
 
 test('unbounded string', () => {
   const coder = unboundedString();
+  expect(coder.canEncode('')).toEqual(true);
+  expect(coder.canEncode('hello')).toEqual(true);
+  expect(coder.canEncode(undefined)).toEqual(false);
   expect(coder.default()).toEqual('');
-  expect(coder.bitLength('hello')).toEqual(5 * 8);
+  expect(coder.bitLength('hello')).toEqual(ok(5 * 8));
   expect(coder.encode('hello')).toEqual(ok(Buffer.from('hello')));
   expect(coder.decode(Buffer.from('hello'))).toEqual(ok('hello'));
 });
 
 test('unbounded string inside a message', () => {
   const m = message({ header: literal('CDAT'), data: unboundedString() });
-  expect(m.default()).toEqual({ data: '' });
-  expect(m.bitLength({ data: 'hello' })).toEqual(32 + 5 * 8);
+  expect(m.default()).toEqual({ header: ['CDAT'], data: '' });
+  expect(m.bitLength({ data: 'hello' })).toEqual(ok(32 + 5 * 8));
   expect(m.encode({ data: 'hello' })).toEqual(ok(Buffer.from('CDAThello')));
   expect(m.decode(Buffer.from('CDAThello'))).toEqual(ok({ data: 'hello' }));
 });

--- a/libs/message-coder/src/unbounded_string_coder.ts
+++ b/libs/message-coder/src/unbounded_string_coder.ts
@@ -20,12 +20,16 @@ import {
  * required to be the last field in a message.
  */
 export class UnboundedStringCoder implements Coder<string> {
+  canEncode(value: unknown): value is string {
+    return typeof value === 'string';
+  }
+
   default(): string {
     return '';
   }
 
-  bitLength(string: string): BitLength {
-    return toBitLength(Buffer.from(string).byteLength);
+  bitLength(string: string): Result<BitLength, CoderError> {
+    return ok(toBitLength(Buffer.from(string).byteLength));
   }
 
   encode(value: string): Result<Buffer, CoderError> {


### PR DESCRIPTION
## Overview
This coder allows trying a list of coders until one succeeds. This required making some changes to the way the library works:
- rather than simply trying to encode, `Coder` now has a `canEncode` method; this prevents partial updates to a `Buffer` while encoding
- `literal` is now allowed to contribute a property to the decoded representation; this is to allow it to act as a discriminator for `oneOf` in case the only difference in types for the coders contained in a `oneOf` is some literal value
- `Coder::bitLength` now returns a `Result` since it may be called on a value that the coder does not support

I believe we're going to need this to support e.g. the "Get scanner capability" command response for `print-scan`:
> The capability data are structured in a stream of data composed by a byte that identify the capability,
followed by a byte of dimension, and by the option identifier, and optionally by the value.

We'll probably also need a `repeated` coder, but that should be pretty straightforward to build.

## Demo Video or Screenshot
```ts
// a simple example
const aOrB = oneOf(
  message({
    type: literal('A'),
    aValue: uint16(),
  }),
  message({
    type: literal('B'),
    bValue: uint8(),
  })
);

const encodedA = aOrB.encode({ aValue: 1 });
const encodedB = aOrB.encode({ bValue: 1 });
const decodedA = aOrB.decode(Buffer.concat([Buffer.from('A'), Buffer.of(0x00, 0x01)]));
const decodedB = aOrB.decode(Buffer.concat([Buffer.from('B'), Buffer.of(0x00, 0x01)]));

// a discriminator example
const HorizontalSettings = message({
  type: literal('horizontal'),
  resolution: uint16(),
});
const VerticalSettings = message({
 type: literal('vertical'),
 resolution: uint16(),
});

const Settings = oneOf(HorizontalSettings, VerticalSettings);

// implicitly uses `HorizontalSettings` since it's first and both match
const encoded1 = Settings.encode({ resolution: 1024 });

// explicitly uses `VerticalSettings` because `type` is provided
const encoded2 = Settings.encode({ type: 'vertical', resolution: 768 });

// explicitly uses `HorizontalSettings` because `type` is provided
const encoded3 = Settings.encode({ type: 'horizontal', resolution: 1024 });
```

## Testing Plan
- [x] Automated
- [x] Manual testing of VxScan with `custom-scanner`

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
