### PR TITLE
remove the shortcut open/close polls screens.

### DIFF
--- a/frontends/precinct-scanner/jest.config.js
+++ b/frontends/precinct-scanner/jest.config.js
@@ -13,9 +13,9 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      statements: 94.98,
+      statements: 94.96,
       branches: 87,
-      functions: 88.4,
+      functions: 88.34,
       lines: 95,
     },
   },

--- a/frontends/precinct-scanner/src/app.test.tsx
+++ b/frontends/precinct-scanner/src/app.test.tsx
@@ -181,7 +181,7 @@ test('initializes app with stored state', async () => {
   fetchMock.post('/precinct-scanner/export', {});
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
-  await screen.findByText('Do you want to close the polls?');
+  await screen.findByText('Poll Worker Actions');
 });
 
 test('app can load and configure from a usb stick', async () => {
@@ -339,7 +339,7 @@ test('election manager must set precinct', async () => {
   fetchMock.post('/precinct-scanner/export', {});
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
-  await screen.findByText('Do you want to open the polls?');
+  await screen.findByText('Poll Worker Actions');
 });
 
 test('election manager and poll worker configuration', async () => {
@@ -365,7 +365,7 @@ test('election manager and poll worker configuration', async () => {
   fetchMock.post('/precinct-scanner/export', {});
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
-  await screen.findByText('Do you want to open the polls?');
+  await screen.findByText('Poll Worker Actions');
 
   // Basic auth logging check
   expect(logger.log).toHaveBeenCalledWith(
@@ -375,7 +375,7 @@ test('election manager and poll worker configuration', async () => {
   );
 
   // Open Polls
-  fireEvent.click(await screen.findByText('Yes, Open the Polls'));
+  fireEvent.click(await screen.findByText('Open Polls for All Precincts'));
   await screen.findByText(
     'Insert poll worker card into VxMark to print the report.'
   );
@@ -422,7 +422,7 @@ test('election manager and poll worker configuration', async () => {
   // Open Polls again
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
-  fireEvent.click(await screen.findByText('Yes, Open the Polls'));
+  fireEvent.click(await screen.findByText('Open Polls for All Precincts'));
   await screen.findByText(
     'Insert poll worker card into VxMark to print the report.'
   );
@@ -571,10 +571,10 @@ test('voter can cast a ballot that scans successfully ', async () => {
   });
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
-  await screen.findByText('Do you want to close the polls?');
+  await screen.findByText('Poll Worker Actions');
 
   // Close Polls
-  fireEvent.click(await screen.findByText('Yes, Close the Polls'));
+  fireEvent.click(await screen.findByText('Close Polls for All Precincts'));
   await screen.findByText('Closing Polls…');
   await screen.findByText('Polls are closed.');
   expect(writeLongObjectMock).toHaveBeenCalledTimes(1);
@@ -826,7 +826,7 @@ test('scanning is not triggered when polls closed or cards present', async () =>
   fetchMock.post('/precinct-scanner/export', {});
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
-  await screen.findByText('Do you want to open the polls?');
+  await screen.findByText('Poll Worker Actions');
   // We should see 15 ballots were scanned
   fireEvent.click(screen.getAllByText('No')[0]);
   expect((await screen.findByTestId('ballot-count')).textContent).toBe('15');
@@ -861,8 +861,8 @@ test('no printer: poll worker can open and close polls without scanning any ball
   // Open Polls Flow
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
-  await screen.findByText('Do you want to open the polls?');
-  fireEvent.click(await screen.findByText('Yes, Open the Polls'));
+  await screen.findByText('Poll Worker Actions');
+  fireEvent.click(await screen.findByText('Open Polls for All Precincts'));
   await screen.findByText(
     'Insert poll worker card into VxMark to print the report.'
   );
@@ -872,8 +872,8 @@ test('no printer: poll worker can open and close polls without scanning any ball
   // Close Polls Flow
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
-  await screen.findByText('Do you want to close the polls?');
-  fireEvent.click(await screen.findByText('Yes, Close the Polls'));
+  await screen.findByText('Poll Worker Actions');
+  fireEvent.click(await screen.findByText('Close Polls for All Precincts'));
   await screen.findByText('Closing Polls…');
   await screen.findByText(
     'Insert poll worker card into VxMark to print the report.'
@@ -906,8 +906,10 @@ test('with printer: poll worker can open and close polls without scanning any ba
   // Open Polls Flow
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
-  await screen.findByText('Do you want to open the polls?');
-  userEvent.click(screen.getByRole('button', { name: 'Yes, Open the Polls' }));
+  await screen.findByText('Poll Worker Actions');
+  userEvent.click(
+    screen.getByRole('button', { name: 'Open Polls for All Precincts' })
+  );
   await screen.findByText('Polls are open.');
   expect(printFn).toHaveBeenCalledTimes(1);
   userEvent.click(
@@ -925,8 +927,10 @@ test('with printer: poll worker can open and close polls without scanning any ba
   // Close Polls Flow
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
-  await screen.findByText('Do you want to close the polls?');
-  userEvent.click(screen.getByRole('button', { name: 'Yes, Close the Polls' }));
+  await screen.findByText('Poll Worker Actions');
+  userEvent.click(
+    screen.getByRole('button', { name: 'Close Polls for All Precincts' })
+  );
   await screen.findByText('Polls are closed.');
   expect(printFn).toHaveBeenCalledTimes(3);
   userEvent.click(
@@ -958,8 +962,8 @@ test('no printer: open polls, scan ballot, close polls, save results', async () 
   // Open Polls Flow
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
-  await screen.findByText('Do you want to open the polls?');
-  fireEvent.click(await screen.findByText('Yes, Open the Polls'));
+  await screen.findByText('Poll Worker Actions');
+  fireEvent.click(await screen.findByText('Open Polls for All Precincts'));
   expect(writeLongObjectMock).toHaveBeenCalledTimes(1);
   await screen.findByText(
     'Insert poll worker card into VxMark to print the report.'
@@ -1017,9 +1021,9 @@ test('no printer: open polls, scan ballot, close polls, save results', async () 
   );
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
-  await screen.findByText('Do you want to close the polls?');
+  await screen.findByText('Poll Worker Actions');
 
-  fireEvent.click(await screen.findByText('Yes, Close the Polls'));
+  fireEvent.click(await screen.findByText('Close Polls for All Precincts'));
   await screen.findByText('Closing Polls…');
   await screen.findByText('Polls are closed.');
   await screen.findByText(
@@ -1269,7 +1273,7 @@ test('uses storage for frontend state', async () => {
   // Confirm polls status is saved to storage
   fetchMock.post('/precinct-scanner/export', {});
   card.insertCard(pollWorkerCard);
-  userEvent.click(await screen.findByText('Yes, Close the Polls'));
+  userEvent.click(await screen.findByText('Close Polls for All Precincts'));
   await screen.findByText('Polls are closed.');
   card.removeCard();
   await advanceTimersAndPromises(1);

--- a/frontends/precinct-scanner/src/app_tally_report_paths.test.tsx
+++ b/frontends/precinct-scanner/src/app_tally_report_paths.test.tsx
@@ -167,7 +167,7 @@ test('expected tally reports are printed for a primary election with all precinc
   );
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
-  await screen.findByText('Do you want to open the polls?');
+  await screen.findByText('Poll Worker Actions');
   expect(fetchMock.calls('/precinct-scanner/export')).toHaveLength(1);
 
   expect(
@@ -276,7 +276,7 @@ test('expected tally reports for a primary election with all precincts with CVRs
   );
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
-  await screen.findByText('Do you want to close the polls?');
+  await screen.findByText('Poll Worker Actions');
   expect(fetchMock.calls('/precinct-scanner/export')).toHaveLength(1);
 
   expect(
@@ -441,7 +441,7 @@ test('expected tally reports for a primary election with all precincts with CVRs
   act(() => {
     hardware.setPrinterConnected(false);
   });
-  fireEvent.click(await screen.findByText('Yes, Close the Polls'));
+  fireEvent.click(await screen.findByText('Close Polls for All Precincts'));
   await screen.findByText('Polls are closed.');
   card.removeCard();
   await advanceTimersAndPromises(1);
@@ -502,7 +502,7 @@ test('expected tally reports for a primary election with all precincts with CVRs
     .mockResolvedValue(err(new Error('bad read')));
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
-  fireEvent.click(await screen.findByText('Yes, Open the Polls'));
+  fireEvent.click(await screen.findByText('Open Polls for All Precincts'));
   await screen.findByText('Polls are open.');
   expect(writeLongObjectMock).toHaveBeenCalledTimes(3);
   expect(writeLongObjectMock).toHaveBeenNthCalledWith(
@@ -623,7 +623,7 @@ test('expected tally reports for a primary election with a single precincts with
   );
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
-  await screen.findByText('Do you want to close the polls?');
+  await screen.findByText('Poll Worker Actions');
   expect(fetchMock.calls('/precinct-scanner/export')).toHaveLength(1);
 
   expect(
@@ -866,7 +866,7 @@ test('expected tally reports for a general election with all precincts with CVRs
   );
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
-  await screen.findByText('Do you want to close the polls?');
+  await screen.findByText('Poll Worker Actions');
   expect(fetchMock.calls('/precinct-scanner/export')).toHaveLength(1);
 
   screen.getByText('TEST Polls Closed Report for Center Springfield');
@@ -936,7 +936,7 @@ test('expected tally reports for a general election with all precincts with CVRs
   act(() => {
     hardware.setPrinterConnected(false);
   });
-  fireEvent.click(await screen.findByText('Yes, Close the Polls'));
+  fireEvent.click(await screen.findByText('Close Polls for All Precincts'));
   await screen.findByText('Polls are closed.');
   card.removeCard();
   await advanceTimersAndPromises(1);
@@ -983,7 +983,7 @@ test('expected tally reports for a general election with all precincts with CVRs
     .mockResolvedValue(err(new Error('bad read')));
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
-  fireEvent.click(await screen.findByText('Yes, Open the Polls'));
+  fireEvent.click(await screen.findByText('Open Polls for All Precincts'));
   await screen.findByText('Polls are open.');
   expect(writeLongObjectMock).toHaveBeenCalledTimes(3);
   expect(writeLongObjectMock).toHaveBeenNthCalledWith(
@@ -1087,7 +1087,7 @@ test('expected tally reports for a general election with a single precincts with
   );
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
-  await screen.findByText('Do you want to close the polls?');
+  await screen.findByText('Poll Worker Actions');
   expect(fetchMock.calls('/precinct-scanner/export')).toHaveLength(1);
 
   screen.getByText('TEST Polls Closed Report for Center Springfield');
@@ -1125,7 +1125,9 @@ test('expected tally reports for a general election with a single precincts with
   act(() => {
     hardware.setPrinterConnected(false);
   });
-  fireEvent.click(await screen.findByText('Yes, Close the Polls'));
+  fireEvent.click(
+    await screen.findByText('Close Polls for Center Springfield')
+  );
   await screen.findByText('Polls are closed.');
 
   card.removeCard();
@@ -1163,7 +1165,7 @@ test('expected tally reports for a general election with a single precincts with
     .mockResolvedValue(err(new Error('bad read')));
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
-  fireEvent.click(await screen.findByText('Yes, Open the Polls'));
+  fireEvent.click(await screen.findByText('Open Polls for Center Springfield'));
   await screen.findByText('Polls are open.');
   expect(writeLongObjectMock).toHaveBeenCalledTimes(3);
   expect(writeLongObjectMock).toHaveBeenNthCalledWith(

--- a/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
+++ b/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
@@ -368,7 +368,7 @@ test('App shows warning message to connect to power when disconnected', async ()
   );
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
-  fireEvent.click(await screen.findByText('Yes, Open the Polls'));
+  fireEvent.click(await screen.findByText('Open Polls for All Precincts'));
   await screen.findByText('Polls are open.');
 
   // Remove pollworker card
@@ -420,7 +420,7 @@ test('removing card during calibration', async () => {
   card.insertCard(pollWorkerCard);
   await advanceTimersAndPromises(1);
   userEvent.click(
-    await screen.findByRole('button', { name: 'Yes, Open the Polls' })
+    await screen.findByRole('button', { name: 'Open Polls for All Precincts' })
   );
   await screen.findByText('Polls are open.');
   card.removeCard();

--- a/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/poll_worker_screen.tsx
@@ -293,14 +293,7 @@ export function PollWorkerScreen({
 
   const [pollWorkerFlowState, setPollWorkerFlowState] = useState<
     PollWorkerFlowState | undefined
-  >(
-    isPollsOpen
-      ? PollWorkerFlowState.CLOSE_POLLS_FLOW__CONFIRM
-      : PollWorkerFlowState.OPEN_POLLS_FLOW__CONFIRM
-  );
-  function showAllPollWorkerActions() {
-    return setPollWorkerFlowState(undefined);
-  }
+  >(undefined);
 
   async function openPolls() {
     setPollWorkerFlowState(PollWorkerFlowState.OPEN_POLLS_FLOW__PROCESSING);
@@ -398,25 +391,6 @@ export function PollWorkerScreen({
     </PrintableContainer>
   );
 
-  if (pollWorkerFlowState === PollWorkerFlowState.OPEN_POLLS_FLOW__CONFIRM) {
-    return (
-      <React.Fragment>
-        <ScreenMainCenterChild infoBarMode="pollworker">
-          <CenteredLargeProse>
-            <p>Do you want to open the polls?</p>
-            <p>
-              <Button primary onPress={openPolls}>
-                Yes, Open the Polls
-              </Button>{' '}
-              <Button onPress={showAllPollWorkerActions}>No</Button>
-            </p>
-          </CenteredLargeProse>
-        </ScreenMainCenterChild>
-        {printableReport}
-      </React.Fragment>
-    );
-  }
-
   if (pollWorkerFlowState === PollWorkerFlowState.OPEN_POLLS_FLOW__PROCESSING) {
     return (
       <React.Fragment>
@@ -452,25 +426,6 @@ export function PollWorkerScreen({
         </CenteredLargeProse>
         {printableReport}
       </ScreenMainCenterChild>
-    );
-  }
-
-  if (pollWorkerFlowState === PollWorkerFlowState.CLOSE_POLLS_FLOW__CONFIRM) {
-    return (
-      <React.Fragment>
-        <ScreenMainCenterChild infoBarMode="pollworker">
-          <CenteredLargeProse>
-            <p>Do you want to close the polls?</p>
-            <p>
-              <Button primary onPress={closePolls}>
-                Yes, Close the Polls
-              </Button>{' '}
-              <Button onPress={showAllPollWorkerActions}>No</Button>
-            </p>
-          </CenteredLargeProse>
-        </ScreenMainCenterChild>
-        {printableReport}
-      </React.Fragment>
     );
   }
 
@@ -547,15 +502,15 @@ export function PollWorkerScreen({
   return (
     <React.Fragment>
       <ScreenMainCenterChild infoBarMode="pollworker">
-        <Prose textCenter>
+        <CenteredLargeProse>
           <h1>Poll Worker Actions</h1>
           <p>
             {isPollsOpen ? (
-              <Button primary large onPress={closePolls}>
+              <Button primary onPress={closePolls}>
                 Close Polls for {precinctName}
               </Button>
             ) : (
-              <Button primary large onPress={openPolls}>
+              <Button primary onPress={openPolls}>
                 Open Polls for {precinctName}
               </Button>
             )}
@@ -581,7 +536,7 @@ export function PollWorkerScreen({
               </Button>
             </p>
           )}
-        </Prose>
+        </CenteredLargeProse>
         <ScannedBallotCount count={scannedBallotCount} />
         {isExportingResults && (
           <ExportResultsModal


### PR DESCRIPTION
## Overview

Removed the shortcut screens "do you want to open/close the polls?" because it became confusing to change the ballot bag before the hard limit is reached, you'd have insert poll worker card, tap "no" explicitly to move to the next screen, and that's just unintuitive.

## Testing Plan

Manually tested and updated automated tests.

## Checklist

~- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
~- [ ] I have added a screenshot and/or video to this PR to demo the change~
- [ X ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
