### PR TITLE
feat(monorepo-utils): add some features for RAVE

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,6 @@
+# THIS FILE IS GENERATED. DO NOT EDIT IT DIRECTLY.
+# Run `pnpm -w generate-circleci-config` to regenerate it.
+
 version: 2.1
 
 orbs:
@@ -18,172 +21,7 @@ executors:
           password: $VX_DOCKER_PASSWORD
 
 jobs:
-  test-codemods:
-    executor: nodejs-browsers
-    resource_class: xlarge
-    steps:
-      - checkout-and-install
-      - run:
-          name: Build
-          command: |
-            pnpm --dir codemods build
-      - run:
-          name: Lint
-          command: |
-            pnpm --dir codemods lint
-      - run:
-          name: Test
-          command: |
-            pnpm --dir codemods test
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: ./reports/
-      - store_test_results:
-          path: codemods/reports/
-
-  test-apps-design-frontend:
-    executor: nodejs-browsers
-    resource_class: xlarge
-    steps:
-      - checkout-and-install
-      - run:
-          name: Build
-          command: |
-            pnpm --dir apps/design/frontend build
-      - run:
-          name: Lint
-          command: |
-            pnpm --dir apps/design/frontend lint
-      - run:
-          name: Test
-          command: |
-            pnpm --dir apps/design/frontend test
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: ./reports/
-      - store_test_results:
-          path: apps/design/frontend/reports/
-
-  test-apps-mark-backend:
-    executor: nodejs
-    resource_class: xlarge
-    steps:
-      - checkout-and-install
-      - run:
-          name: Build
-          command: |
-            pnpm --dir apps/mark/backend build
-      - run:
-          name: Lint
-          command: |
-            pnpm --dir apps/mark/backend lint
-      - run:
-          name: Test
-          command: |
-            pnpm --dir apps/mark/backend test
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: ./reports/
-      - store_test_results:
-          path: apps/mark/backend/reports/
-
-  test-apps-mark-frontend:
-    executor: nodejs-browsers
-    resource_class: xlarge
-    steps:
-      - checkout-and-install
-      - run:
-          name: Build
-          command: |
-            pnpm --dir apps/mark/frontend build
-      - run:
-          name: Lint
-          command: |
-            pnpm --dir apps/mark/frontend lint
-      - run:
-          name: Test
-          command: |
-            pnpm --dir apps/mark/frontend test
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: ./reports/
-      - store_test_results:
-          path: apps/mark/frontend/reports/
-      - store_artifacts:
-          path: apps/mark/frontend/cypress/screenshots
-      - store_artifacts:
-          path: apps/mark/frontend/cypress/videos
-
-  test-apps-central-scan-frontend:
-    executor: nodejs-browsers
-    resource_class: xlarge
-    steps:
-      - checkout-and-install
-      - run:
-          name: Build
-          command: |
-            pnpm --dir apps/central-scan/frontend build
-      - run:
-          name: Lint
-          command: |
-            pnpm --dir apps/central-scan/frontend lint
-      - run:
-          name: Test
-          command: |
-            pnpm --dir apps/central-scan/frontend test
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: ./reports/
-      - store_test_results:
-          path: apps/central-scan/frontend/reports/
-      - store_artifacts:
-          path: apps/central-scan/frontend/cypress/screenshots
-      - store_artifacts:
-          path: apps/central-scan/frontend/cypress/videos
-
-  test-apps-central-scan-backend:
-    executor: nodejs
-    resource_class: xlarge
-    steps:
-      - checkout-and-install
-      - run:
-          name: Build
-          command: |
-            pnpm --dir apps/central-scan/backend build
-      - run:
-          name: Lint
-          command: |
-            pnpm --dir apps/central-scan/backend lint
-      - run:
-          name: Test
-          command: |
-            pnpm --dir apps/central-scan/backend test
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: ./reports/
-      - store_test_results:
-          path: apps/central-scan/backend/reports/
-
-  test-apps-admin-frontend:
-    executor: nodejs-browsers
-    resource_class: xlarge
-    steps:
-      - checkout-and-install
-      - run:
-          name: Build
-          command: |
-            pnpm --dir apps/admin/frontend build
-      - run:
-          name: Lint
-          command: |
-            pnpm --dir apps/admin/frontend lint
-      - run:
-          name: Test
-          command: |
-            pnpm --dir apps/admin/frontend test
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: ./reports/
-      - store_test_results:
-          path: apps/admin/frontend/reports/
-      - store_artifacts:
-          path: apps/admin/frontend/cypress/screenshots
-      - store_artifacts:
-          path: apps/admin/frontend/cypress/videos
-
+  # @votingworks/admin-backend
   test-apps-admin-backend:
     executor: nodejs
     resource_class: xlarge
@@ -206,6 +44,229 @@ jobs:
       - store_test_results:
           path: apps/admin/backend/reports/
 
+  # @votingworks/admin-frontend
+  test-apps-admin-frontend:
+    executor: nodejs
+    resource_class: xlarge
+    steps:
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            pnpm --dir apps/admin/frontend build
+      - run:
+          name: Lint
+          command: |
+            pnpm --dir apps/admin/frontend lint
+      - run:
+          name: Test
+          command: |
+            pnpm --dir apps/admin/frontend test
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./reports/
+      - store_test_results:
+          path: apps/admin/frontend/reports/
+
+  # @votingworks/integration-testing-election-manager
+  test-apps-admin-integration-testing:
+    executor: nodejs-browsers
+    resource_class: xlarge
+    steps:
+      - install-cypress-browser
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            pnpm --dir apps/admin/integration-testing build
+      - run:
+          name: Lint
+          command: |
+            pnpm --dir apps/admin/integration-testing lint
+      - run:
+          name: Test
+          command: |
+            pnpm --dir apps/admin/integration-testing test
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./reports/
+      - store_test_results:
+          path: apps/admin/integration-testing/reports/
+      - store_artifacts:
+          path: apps/admin/integration-testing/cypress/screenshots/
+      - store_artifacts:
+          path: apps/admin/integration-testing/cypress/videos/
+
+  # @votingworks/central-scan-backend
+  test-apps-central-scan-backend:
+    executor: nodejs
+    resource_class: xlarge
+    steps:
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            pnpm --dir apps/central-scan/backend build
+      - run:
+          name: Lint
+          command: |
+            pnpm --dir apps/central-scan/backend lint
+      - run:
+          name: Test
+          command: |
+            pnpm --dir apps/central-scan/backend test
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./reports/
+      - store_test_results:
+          path: apps/central-scan/backend/reports/
+
+  # @votingworks/central-scan-frontend
+  test-apps-central-scan-frontend:
+    executor: nodejs
+    resource_class: xlarge
+    steps:
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            pnpm --dir apps/central-scan/frontend build
+      - run:
+          name: Lint
+          command: |
+            pnpm --dir apps/central-scan/frontend lint
+      - run:
+          name: Test
+          command: |
+            pnpm --dir apps/central-scan/frontend test
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./reports/
+      - store_test_results:
+          path: apps/central-scan/frontend/reports/
+
+  # @votingworks/central-scan-integration-testing
+  test-apps-central-scan-integration-testing:
+    executor: nodejs-browsers
+    resource_class: xlarge
+    steps:
+      - install-cypress-browser
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            pnpm --dir apps/central-scan/integration-testing build
+      - run:
+          name: Lint
+          command: |
+            pnpm --dir apps/central-scan/integration-testing lint
+      - run:
+          name: Test
+          command: |
+            pnpm --dir apps/central-scan/integration-testing test
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./reports/
+      - store_test_results:
+          path: apps/central-scan/integration-testing/reports/
+      - store_artifacts:
+          path: apps/central-scan/integration-testing/cypress/screenshots/
+      - store_artifacts:
+          path: apps/central-scan/integration-testing/cypress/videos/
+
+  # @votingworks/design-frontend
+  test-apps-design-frontend:
+    executor: nodejs
+    resource_class: xlarge
+    steps:
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            pnpm --dir apps/design/frontend build
+      - run:
+          name: Lint
+          command: |
+            pnpm --dir apps/design/frontend lint
+      - run:
+          name: Test
+          command: |
+            pnpm --dir apps/design/frontend test
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./reports/
+      - store_test_results:
+          path: apps/design/frontend/reports/
+
+  # @votingworks/mark-backend
+  test-apps-mark-backend:
+    executor: nodejs
+    resource_class: xlarge
+    steps:
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            pnpm --dir apps/mark/backend build
+      - run:
+          name: Lint
+          command: |
+            pnpm --dir apps/mark/backend lint
+      - run:
+          name: Test
+          command: |
+            pnpm --dir apps/mark/backend test
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./reports/
+      - store_test_results:
+          path: apps/mark/backend/reports/
+
+  # @votingworks/mark-frontend
+  test-apps-mark-frontend:
+    executor: nodejs
+    resource_class: xlarge
+    steps:
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            pnpm --dir apps/mark/frontend build
+      - run:
+          name: Lint
+          command: |
+            pnpm --dir apps/mark/frontend lint
+      - run:
+          name: Test
+          command: |
+            pnpm --dir apps/mark/frontend test
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./reports/
+      - store_test_results:
+          path: apps/mark/frontend/reports/
+
+  # @votingworks/mark-integration-testing
+  test-apps-mark-integration-testing:
+    executor: nodejs-browsers
+    resource_class: xlarge
+    steps:
+      - install-cypress-browser
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            pnpm --dir apps/mark/integration-testing build
+      - run:
+          name: Lint
+          command: |
+            pnpm --dir apps/mark/integration-testing lint
+      - run:
+          name: Test
+          command: |
+            pnpm --dir apps/mark/integration-testing test
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./reports/
+      - store_test_results:
+          path: apps/mark/integration-testing/reports/
+      - store_artifacts:
+          path: apps/mark/integration-testing/cypress/screenshots/
+      - store_artifacts:
+          path: apps/mark/integration-testing/cypress/videos/
+
+  # @votingworks/scan-backend
   test-apps-scan-backend:
     executor: nodejs
     resource_class: xlarge
@@ -228,8 +289,9 @@ jobs:
       - store_test_results:
           path: apps/scan/backend/reports/
 
+  # @votingworks/scan-frontend
   test-apps-scan-frontend:
-    executor: nodejs-browsers
+    executor: nodejs
     resource_class: xlarge
     steps:
       - checkout-and-install
@@ -250,87 +312,30 @@ jobs:
       - store_test_results:
           path: apps/scan/frontend/reports/
 
-  test-apps-mark-integration-testing:
-    executor: nodejs-browsers
+  # @votingworks/codemods
+  test-codemods:
+    executor: nodejs
     resource_class: xlarge
     steps:
-      - install-cypress-browser
       - checkout-and-install
       - run:
           name: Build
           command: |
-            pnpm --dir apps/mark/integration-testing build
+            pnpm --dir codemods build
       - run:
           name: Lint
           command: |
-            pnpm --dir apps/mark/integration-testing lint
+            pnpm --dir codemods lint
       - run:
           name: Test
           command: |
-            pnpm --dir apps/mark/integration-testing test
+            pnpm --dir codemods test
           environment:
-            MOCHA_FILE: ./reports/junit.xml
+            JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
-          path: apps/mark/integration-testing/reports/
-      - store_artifacts:
-          path: apps/mark/integration-testing/cypress/screenshots
-      - store_artifacts:
-          path: apps/mark/integration-testing/cypress/videos
+          path: codemods/reports/
 
-  test-apps-central-scan-integration-testing:
-    executor: nodejs-browsers
-    resource_class: xlarge
-    steps:
-      - install-cypress-browser
-      - checkout-and-install
-      - run:
-          name: Build
-          command: |
-            pnpm --dir apps/central-scan/integration-testing build
-      - run:
-          name: Lint
-          command: |
-            pnpm --dir apps/central-scan/integration-testing lint
-      - run:
-          name: Test
-          command: |
-            pnpm --dir apps/central-scan/integration-testing test
-          environment:
-            MOCHA_FILE: ./reports/junit.xml
-      - store_test_results:
-          path: apps/central-scan/integration-testing/reports/
-      - store_artifacts:
-          path: apps/central-scan/integration-testing/cypress/screenshots
-      - store_artifacts:
-          path: apps/central-scan/integration-testing/cypress/videos
-
-  test-apps-admin-integration-testing:
-    executor: nodejs-browsers
-    resource_class: xlarge
-    steps:
-      - install-cypress-browser
-      - checkout-and-install
-      - run:
-          name: Build
-          command: |
-            pnpm --dir apps/admin/integration-testing build
-      - run:
-          name: Lint
-          command: |
-            pnpm --dir apps/admin/integration-testing lint
-      - run:
-          name: Test
-          command: |
-            pnpm --dir apps/admin/integration-testing test
-          environment:
-            MOCHA_FILE: ./reports/junit.xml
-      - store_test_results:
-          path: apps/admin/integration-testing/reports/
-      - store_artifacts:
-          path: apps/admin/integration-testing/cypress/screenshots
-      - store_artifacts:
-          path: apps/admin/integration-testing/cypress/videos
-
+  # @votingworks/api
   test-libs-api:
     executor: nodejs
     resource_class: xlarge
@@ -353,6 +358,7 @@ jobs:
       - store_test_results:
           path: libs/api/reports/
 
+  # @votingworks/auth
   test-libs-auth:
     executor: nodejs
     resource_class: xlarge
@@ -375,204 +381,7 @@ jobs:
       - store_test_results:
           path: libs/auth/reports/
 
-  test-libs-ballot-encoder:
-    executor: nodejs
-    resource_class: xlarge
-    steps:
-      - checkout-and-install
-      - run:
-          name: Build
-          command: |
-            pnpm --dir libs/ballot-encoder build
-      - run:
-          name: Lint
-          command: |
-            pnpm --dir libs/ballot-encoder lint
-      - run:
-          name: Test
-          command: |
-            pnpm --dir libs/ballot-encoder test
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: ./reports/
-      - store_test_results:
-          path: libs/ballot-encoder/reports/
-
-  test-libs-ballot-interpreter-nh:
-    executor: nodejs
-    resource_class: xlarge
-    steps:
-      - checkout-and-install
-      - run:
-          name: Build
-          command: |
-            pnpm --dir libs/ballot-interpreter-nh build
-      - run:
-          name: Lint
-          command: |
-            pnpm --dir libs/ballot-interpreter-nh lint
-      - run:
-          name: Test
-          command: |
-            pnpm --dir libs/ballot-interpreter-nh test
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: ./reports/
-      - store_test_results:
-          path: libs/ballot-interpreter-nh/reports/
-
-  test-libs-ballot-interpreter-vx:
-    executor: nodejs
-    resource_class: xlarge
-    steps:
-      - checkout-and-install
-      - run:
-          name: Build
-          command: |
-            pnpm --dir libs/ballot-interpreter-vx build
-      - run:
-          name: Lint
-          command: |
-            pnpm --dir libs/ballot-interpreter-vx lint
-      - run:
-          name: Test
-          command: |
-            pnpm --dir libs/ballot-interpreter-vx test
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: ./reports/
-      - store_test_results:
-          path: libs/ballot-interpreter-vx/reports/
-
-  test-libs-basics:
-    executor: nodejs-browsers
-    resource_class: xlarge
-    steps:
-      - checkout-and-install
-      - run:
-          name: Build
-          command: |
-            pnpm --dir libs/basics build
-      - run:
-          name: Lint
-          command: |
-            pnpm --dir libs/basics lint
-      - run:
-          name: Test
-          command: |
-            pnpm --dir libs/basics test
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: ./reports/
-      - store_test_results:
-          path: libs/basics/reports/
-
-  test-libs-cdf-schema-builder:
-    executor: nodejs
-    resource_class: xlarge
-    steps:
-      - checkout-and-install
-      - run:
-          name: Build
-          command: |
-            pnpm --dir libs/cdf-schema-builder build
-      - run:
-          name: Lint
-          command: |
-            pnpm --dir libs/cdf-schema-builder lint
-      - run:
-          name: Test
-          command: |
-            pnpm --dir libs/cdf-schema-builder test
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: ./reports/
-      - store_test_results:
-          path: libs/cdf-schema-builder/reports/
-
-  test-libs-converter-nh-accuvote:
-    executor: nodejs
-    resource_class: xlarge
-    steps:
-      - checkout-and-install
-      - run:
-          name: Build
-          command: |
-            pnpm --dir libs/converter-nh-accuvote build
-      - run:
-          name: Lint
-          command: |
-            pnpm --dir libs/converter-nh-accuvote lint
-      - run:
-          name: Test
-          command: |
-            pnpm --dir libs/converter-nh-accuvote test
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: ./reports/
-      - store_test_results:
-          path: libs/converter-nh-accuvote/reports/
-
-  test-libs-custom-scanner:
-    executor: nodejs
-    resource_class: xlarge
-    steps:
-      - checkout-and-install
-      - run:
-          name: Build
-          command: |
-            pnpm --dir libs/custom-scanner build
-      - run:
-          name: Lint
-          command: |
-            pnpm --dir libs/custom-scanner lint
-      - run:
-          name: Test
-          command: |
-            pnpm --dir libs/custom-scanner test
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: ./reports/
-      - store_test_results:
-          path: libs/custom-scanner/reports/
-
-  test-libs-custom-paper-handler:
-    executor: nodejs
-    resource_class: xlarge
-    steps:
-      - checkout-and-install
-      - run:
-          name: Build
-          command: |
-            pnpm --dir libs/custom-paper-handler build
-      - run:
-          name: Lint
-          command: |
-            pnpm --dir libs/custom-paper-handler lint
-      - run:
-          name: Test
-          command: |
-            pnpm --dir libs/custom-paper-handler test
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: ./reports/
-      - store_test_results:
-          path: libs/custom-paper-handler/reports/
-
-  test-libs-cvr-fixture-generator:
-    executor: nodejs
-    resource_class: xlarge
-    steps:
-      - checkout-and-install
-      - run:
-          name: Build
-          command: |
-            pnpm --dir libs/cvr-fixture-generator build
-      - run:
-          name: Lint
-          command: |
-            pnpm --dir libs/cvr-fixture-generator lint
-      - run:
-          name: Test
-          command: |
-            pnpm --dir libs/cvr-fixture-generator test
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: ./reports/
-      - store_test_results:
-          path: libs/cvr-fixture-generator/reports/
-
+  # @votingworks/backend
   test-libs-backend:
     executor: nodejs
     resource_class: xlarge
@@ -595,6 +404,214 @@ jobs:
       - store_test_results:
           path: libs/backend/reports/
 
+  # @votingworks/ballot-encoder
+  test-libs-ballot-encoder:
+    executor: nodejs
+    resource_class: xlarge
+    steps:
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            pnpm --dir libs/ballot-encoder build
+      - run:
+          name: Lint
+          command: |
+            pnpm --dir libs/ballot-encoder lint
+      - run:
+          name: Test
+          command: |
+            pnpm --dir libs/ballot-encoder test
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./reports/
+      - store_test_results:
+          path: libs/ballot-encoder/reports/
+
+  # @votingworks/ballot-interpreter-nh
+  test-libs-ballot-interpreter-nh:
+    executor: nodejs
+    resource_class: xlarge
+    steps:
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            pnpm --dir libs/ballot-interpreter-nh build
+      - run:
+          name: Lint
+          command: |
+            pnpm --dir libs/ballot-interpreter-nh lint
+      - run:
+          name: Test
+          command: |
+            pnpm --dir libs/ballot-interpreter-nh test
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./reports/
+      - store_test_results:
+          path: libs/ballot-interpreter-nh/reports/
+
+  # @votingworks/ballot-interpreter-vx
+  test-libs-ballot-interpreter-vx:
+    executor: nodejs
+    resource_class: xlarge
+    steps:
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            pnpm --dir libs/ballot-interpreter-vx build
+      - run:
+          name: Lint
+          command: |
+            pnpm --dir libs/ballot-interpreter-vx lint
+      - run:
+          name: Test
+          command: |
+            pnpm --dir libs/ballot-interpreter-vx test
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./reports/
+      - store_test_results:
+          path: libs/ballot-interpreter-vx/reports/
+
+  # @votingworks/basics
+  test-libs-basics:
+    executor: nodejs
+    resource_class: xlarge
+    steps:
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            pnpm --dir libs/basics build
+      - run:
+          name: Lint
+          command: |
+            pnpm --dir libs/basics lint
+      - run:
+          name: Test
+          command: |
+            pnpm --dir libs/basics test
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./reports/
+      - store_test_results:
+          path: libs/basics/reports/
+
+  # @votingworks/cdf-schema-builder
+  test-libs-cdf-schema-builder:
+    executor: nodejs
+    resource_class: xlarge
+    steps:
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            pnpm --dir libs/cdf-schema-builder build
+      - run:
+          name: Lint
+          command: |
+            pnpm --dir libs/cdf-schema-builder lint
+      - run:
+          name: Test
+          command: |
+            pnpm --dir libs/cdf-schema-builder test
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./reports/
+      - store_test_results:
+          path: libs/cdf-schema-builder/reports/
+
+  # @votingworks/converter-nh-accuvote
+  test-libs-converter-nh-accuvote:
+    executor: nodejs
+    resource_class: xlarge
+    steps:
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            pnpm --dir libs/converter-nh-accuvote build
+      - run:
+          name: Lint
+          command: |
+            pnpm --dir libs/converter-nh-accuvote lint
+      - run:
+          name: Test
+          command: |
+            pnpm --dir libs/converter-nh-accuvote test
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./reports/
+      - store_test_results:
+          path: libs/converter-nh-accuvote/reports/
+
+  # @votingworks/custom-paper-handler
+  test-libs-custom-paper-handler:
+    executor: nodejs
+    resource_class: xlarge
+    steps:
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            pnpm --dir libs/custom-paper-handler build
+      - run:
+          name: Lint
+          command: |
+            pnpm --dir libs/custom-paper-handler lint
+      - run:
+          name: Test
+          command: |
+            pnpm --dir libs/custom-paper-handler test
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./reports/
+      - store_test_results:
+          path: libs/custom-paper-handler/reports/
+
+  # @votingworks/custom-scanner
+  test-libs-custom-scanner:
+    executor: nodejs
+    resource_class: xlarge
+    steps:
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            pnpm --dir libs/custom-scanner build
+      - run:
+          name: Lint
+          command: |
+            pnpm --dir libs/custom-scanner lint
+      - run:
+          name: Test
+          command: |
+            pnpm --dir libs/custom-scanner test
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./reports/
+      - store_test_results:
+          path: libs/custom-scanner/reports/
+
+  # @votingworks/cvr-fixture-generator
+  test-libs-cvr-fixture-generator:
+    executor: nodejs
+    resource_class: xlarge
+    steps:
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            pnpm --dir libs/cvr-fixture-generator build
+      - run:
+          name: Lint
+          command: |
+            pnpm --dir libs/cvr-fixture-generator lint
+      - run:
+          name: Test
+          command: |
+            pnpm --dir libs/cvr-fixture-generator test
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./reports/
+      - store_test_results:
+          path: libs/cvr-fixture-generator/reports/
+
+  # @votingworks/db
   test-libs-db:
     executor: nodejs
     resource_class: xlarge
@@ -617,6 +634,7 @@ jobs:
       - store_test_results:
           path: libs/db/reports/
 
+  # @votingworks/dev-dock-backend
   test-libs-dev-dock-backend:
     executor: nodejs
     resource_class: xlarge
@@ -639,6 +657,7 @@ jobs:
       - store_test_results:
           path: libs/dev-dock/backend/reports/
 
+  # @votingworks/dev-dock-frontend
   test-libs-dev-dock-frontend:
     executor: nodejs
     resource_class: xlarge
@@ -661,8 +680,9 @@ jobs:
       - store_test_results:
           path: libs/dev-dock/frontend/reports/
 
+  # eslint-plugin-vx
   test-libs-eslint-plugin-vx:
-    executor: nodejs-browsers
+    executor: nodejs
     resource_class: xlarge
     steps:
       - checkout-and-install
@@ -683,6 +703,7 @@ jobs:
       - store_test_results:
           path: libs/eslint-plugin-vx/reports/
 
+  # @votingworks/fixtures
   test-libs-fixtures:
     executor: nodejs
     resource_class: xlarge
@@ -705,6 +726,7 @@ jobs:
       - store_test_results:
           path: libs/fixtures/reports/
 
+  # @votingworks/grout
   test-libs-grout:
     executor: nodejs
     resource_class: xlarge
@@ -727,6 +749,7 @@ jobs:
       - store_test_results:
           path: libs/grout/reports/
 
+  # @votingworks/grout-test-utils
   test-libs-grout-test-utils:
     executor: nodejs
     resource_class: xlarge
@@ -749,6 +772,7 @@ jobs:
       - store_test_results:
           path: libs/grout/test-utils/reports/
 
+  # @votingworks/image-utils
   test-libs-image-utils:
     executor: nodejs
     resource_class: xlarge
@@ -771,6 +795,7 @@ jobs:
       - store_test_results:
           path: libs/image-utils/reports/
 
+  # @votingworks/logging
   test-libs-logging:
     executor: nodejs
     resource_class: xlarge
@@ -793,6 +818,7 @@ jobs:
       - store_test_results:
           path: libs/logging/reports/
 
+  # @votingworks/message-coder
   test-libs-message-coder:
     executor: nodejs
     resource_class: xlarge
@@ -815,6 +841,7 @@ jobs:
       - store_test_results:
           path: libs/message-coder/reports/
 
+  # @votingworks/monorepo-utils
   test-libs-monorepo-utils:
     executor: nodejs
     resource_class: xlarge
@@ -837,15 +864,16 @@ jobs:
       - store_test_results:
           path: libs/monorepo-utils/reports/
 
+  # @votingworks/res-to-ts
   test-libs-res-to-ts:
     executor: nodejs
     resource_class: xlarge
     steps:
       - checkout-and-install
       - run:
-          name: Type Check
+          name: Build
           command: |
-            pnpm --dir libs/res-to-ts type-check
+            pnpm --dir libs/res-to-ts build
       - run:
           name: Lint
           command: |
@@ -853,14 +881,15 @@ jobs:
       - run:
           name: Test
           command: |
-            pnpm --dir libs/res-to-ts test:ci
+            pnpm --dir libs/res-to-ts test
           environment:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/res-to-ts/reports/
 
+  # @votingworks/test-utils
   test-libs-test-utils:
-    executor: nodejs-browsers
+    executor: nodejs
     resource_class: xlarge
     steps:
       - checkout-and-install
@@ -881,6 +910,7 @@ jobs:
       - store_test_results:
           path: libs/test-utils/reports/
 
+  # @votingworks/types
   test-libs-types:
     executor: nodejs
     resource_class: xlarge
@@ -903,8 +933,9 @@ jobs:
       - store_test_results:
           path: libs/types/reports/
 
+  # @votingworks/ui
   test-libs-ui:
-    executor: nodejs-browsers
+    executor: nodejs
     resource_class: xlarge
     steps:
       - checkout-and-install
@@ -925,6 +956,7 @@ jobs:
       - store_test_results:
           path: libs/ui/reports/
 
+  # @votingworks/usb-drive
   test-libs-usb-drive:
     executor: nodejs
     resource_class: xlarge
@@ -947,8 +979,9 @@ jobs:
       - store_test_results:
           path: libs/usb-drive/reports/
 
+  # @votingworks/utils
   test-libs-utils:
-    executor: nodejs-browsers
+    executor: nodejs
     resource_class: xlarge
     steps:
       - checkout-and-install
@@ -969,6 +1002,7 @@ jobs:
       - store_test_results:
           path: libs/utils/reports/
 
+  # TODO: remove this once we replace the Python code
   test-services-converter-ms-sems:
     executor: nodejs
     resource_class: medium
@@ -984,10 +1018,6 @@ jobs:
           name: Test
           command: |
             make -C services/converter-ms-sems coverage
-      # - run:
-      #     name: Typecheck
-      #     command: |
-      #       make -C services/converter-ms-sems typecheck
 
   validate-monorepo:
     executor: nodejs
@@ -1006,34 +1036,34 @@ jobs:
 workflows:
   test:
     jobs:
-      - test-codemods
+      - test-apps-admin-backend
+      - test-apps-admin-frontend
+      - test-apps-admin-integration-testing
+      - test-apps-central-scan-backend
+      - test-apps-central-scan-frontend
+      - test-apps-central-scan-integration-testing
       - test-apps-design-frontend
       - test-apps-mark-backend
       - test-apps-mark-frontend
       - test-apps-mark-integration-testing
       - test-apps-scan-backend
       - test-apps-scan-frontend
-      - test-apps-admin-frontend
-      - test-apps-admin-backend
-      - test-apps-admin-integration-testing
-      - test-apps-central-scan-frontend
-      - test-apps-central-scan-backend
-      - test-apps-central-scan-integration-testing
+      - test-codemods
       - test-libs-api
       - test-libs-auth
+      - test-libs-backend
       - test-libs-ballot-encoder
       - test-libs-ballot-interpreter-nh
       - test-libs-ballot-interpreter-vx
       - test-libs-basics
       - test-libs-cdf-schema-builder
       - test-libs-converter-nh-accuvote
-      - test-libs-custom-scanner
       - test-libs-custom-paper-handler
+      - test-libs-custom-scanner
       - test-libs-cvr-fixture-generator
-      - test-libs-backend
+      - test-libs-db
       - test-libs-dev-dock-backend
       - test-libs-dev-dock-frontend
-      - test-libs-db
       - test-libs-eslint-plugin-vx
       - test-libs-fixtures
       - test-libs-grout

--- a/libs/cvr-fixture-generator/package.json
+++ b/libs/cvr-fixture-generator/package.json
@@ -6,6 +6,9 @@
   "license": "GPL-3.0",
   "author": "VotingWorks Eng <eng@voting.works>",
   "main": "build/index.js",
+  "bin": {
+    "cvr-fixture-generator": "bin/generate"
+  },
   "scripts": {
     "type-check": "tsc --build",
     "build": "tsc --build tsconfig.build.json",

--- a/libs/monorepo-utils/bin/generate-circleci-config
+++ b/libs/monorepo-utils/bin/generate-circleci-config
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+// @ts-check
+
+require('esbuild-runner/register');
+
+const { join } = require('path');
+const { generateConfig } = require('../src/circleci');
+const { getWorkspacePackageInfo } = require('../src/pnpm');
+const { writeFileSync } = require('fs');
+
+const workspaceRoot = join(__dirname, '..', '..', '..');
+
+writeFileSync(
+  join(workspaceRoot, '.circleci', 'config.yml'),
+  generateConfig(getWorkspacePackageInfo(workspaceRoot))
+);

--- a/libs/monorepo-utils/bin/prune-unused
+++ b/libs/monorepo-utils/bin/prune-unused
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+// @ts-check
+
+require('esbuild-runner/register');
+
+const { rmSync } = require('fs');
+const { join } = require('path');
+const { findUnusedPackages } = require('../src/unused');
+const { getWorkspacePackageInfo } = require('../src/pnpm');
+
+const MONOREPO_ROOT = join(__dirname, '..', '..', '..');
+
+/**
+ * Removes a package from the monorepo.
+ */
+function pruneUnusedPackages({ dryRun = false } = {}) {
+  let count = 0;
+
+  function doPrunePass() {
+    const initialCount = count;
+    const pkgs = getWorkspacePackageInfo(MONOREPO_ROOT);
+
+    for (const pkg of findUnusedPackages(pkgs)) {
+      console.log(`${dryRun ? '[skip] ' : ''}Removing ${pkg.name}…`);
+      if (!dryRun) {
+      rmSync(pkg.path, { recursive: true });
+      }
+      count++;
+    }
+
+    if (count > initialCount) {
+      doPrunePass();
+    }
+  }
+
+  doPrunePass();
+
+  if (dryRun) {
+    console.log(`Would remove ${count} packages.`)
+  } else {
+    console.log(`Removed ${count} packages.`)
+  }
+}
+
+pruneUnusedPackages({ dryRun: process.argv.includes('--dry-run') });

--- a/libs/monorepo-utils/bin/remove-package
+++ b/libs/monorepo-utils/bin/remove-package
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+// @ts-check
+
+require('esbuild-runner/register');
+
+const { join } = require('path');
+const { getWorkspacePackageInfo } = require('../src/pnpm');
+const { findAllMonorepoDependencies } = require('../src/dependencies');
+const { rmSync } = require('fs');
+
+/**
+ * @param {readonly string[]} names
+ */
+function removePackages(names) {
+  for (const name of names) {
+    const pkgs = getWorkspacePackageInfo(join(__dirname, '..', '..', '..'));
+    const pkgToRemove = pkgs.get(name);
+
+    if (!pkgToRemove) {
+      console.error(`Package ${name} not found!`);
+      process.exit(1);
+    }
+
+    for (const pkg of pkgs.values()) {
+      if (pkg !== pkgToRemove) {
+        for (const dep of findAllMonorepoDependencies(pkgs, pkg)) {
+          if (dep === pkgToRemove) {
+            console.error(`Package ${pkgToRemove.name} is depended on by ${pkg.name}!`);
+            process.exit(1);
+          }
+        }
+      }
+    }
+
+    console.log(`Removing ${pkgToRemove.name}…`)
+    rmSync(pkgToRemove.path, { recursive: true, force: true });
+  }
+}
+
+removePackages(process.argv.slice(2));

--- a/libs/monorepo-utils/package.json
+++ b/libs/monorepo-utils/package.json
@@ -39,6 +39,7 @@
     "@types/node": "16.18.23",
     "@typescript-eslint/eslint-plugin": "5.37.0",
     "@typescript-eslint/parser": "5.37.0",
+    "esbuild-runner": "^2.2.2",
     "eslint": "8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.6",

--- a/libs/monorepo-utils/src/circleci.test.ts
+++ b/libs/monorepo-utils/src/circleci.test.ts
@@ -1,0 +1,9 @@
+import { join } from 'path';
+import { generateConfig } from './circleci';
+import { getWorkspacePackageInfo } from './pnpm';
+
+test('generateConfig', () => {
+  expect(
+    generateConfig(getWorkspacePackageInfo(join(__dirname, '../../..')))
+  ).toContain('test-libs-basics');
+});

--- a/libs/monorepo-utils/src/circleci.ts
+++ b/libs/monorepo-utils/src/circleci.ts
@@ -1,0 +1,190 @@
+import { join } from 'path';
+import { existsSync } from 'fs';
+import { Optional } from '@votingworks/basics';
+import { PackageInfo } from './pnpm';
+
+function jobIdForPackage(pkg: PackageInfo): string {
+  return `test-${pkg.relativePath.replace(/\//g, '-')}`;
+}
+
+function generateTestJobForNodeJsPackage(pkg: PackageInfo): Optional<string[]> {
+  /* istanbul ignore next */
+  if (!pkg.packageJson?.scripts?.['test']) {
+    // exclude packages without tests
+    return;
+  }
+
+  const hasCypressTests = existsSync(`${pkg.path}/cypress`);
+  const lines = [
+    `# ${pkg.name}`,
+    `${jobIdForPackage(pkg)}:`,
+    `  executor: ${hasCypressTests ? 'nodejs-browsers' : 'nodejs'}`,
+    `  resource_class: xlarge`,
+    `  steps:`,
+    ...(hasCypressTests ? [`    - install-cypress-browser`] : []),
+    `    - checkout-and-install`,
+    `    - run:`,
+    `        name: Build`,
+    `        command: |`,
+    `          pnpm --dir ${pkg.relativePath} build`,
+    `    - run:`,
+    `        name: Lint`,
+    `        command: |`,
+    `          pnpm --dir ${pkg.relativePath} lint`,
+    `    - run:`,
+    `        name: Test`,
+    `        command: |`,
+    `          pnpm --dir ${pkg.relativePath} test`,
+    `        environment:`,
+    `          JEST_JUNIT_OUTPUT_DIR: ./reports/`,
+    `    - store_test_results:`,
+    `        path: ${pkg.relativePath}/reports/`,
+  ];
+
+  if (hasCypressTests) {
+    lines.push(
+      `    - store_artifacts:`,
+      `        path: ${pkg.relativePath}/cypress/screenshots/`,
+      `    - store_artifacts:`,
+      `        path: ${pkg.relativePath}/cypress/videos/`
+    );
+  }
+
+  return lines;
+}
+
+function generateTestJobForPackage(pkg: PackageInfo): Optional<string[]> {
+  if (pkg.packageJson) {
+    return generateTestJobForNodeJsPackage(pkg);
+  }
+
+  /* istanbul ignore next */
+  throw new Error(`Unsupported package type: ${pkg.relativePath}`);
+}
+
+/**
+ * Path to the CircleCI config file.
+ */
+export const CIRCLECI_CONFIG_PATH = join(
+  __dirname,
+  '../../../.circleci/config.yml'
+);
+
+/**
+ * Generate a CircleCI config file.
+ */
+export function generateConfig(pkgs: ReadonlyMap<string, PackageInfo>): string {
+  const jobs = [...pkgs.values()].reduce((memo, pkg) => {
+    const jobLines = generateTestJobForPackage(pkg);
+    if (!jobLines) {
+      return memo;
+    }
+    return memo.set(pkg, jobLines);
+  }, new Map<PackageInfo, string[]>());
+  const jobIds = [
+    ...[...jobs.keys()].map((pkg) => jobIdForPackage(pkg)),
+    // hardcoded jobs
+    'test-services-converter-ms-sems',
+    'validate-monorepo',
+  ];
+
+  return `
+# THIS FILE IS GENERATED. DO NOT EDIT IT DIRECTLY.
+# Run \`pnpm -w generate-circleci-config\` to regenerate it.
+
+version: 2.1
+
+orbs:
+  browser-tools: circleci/browser-tools@1.4.1
+
+executors:
+  nodejs-browsers:
+    docker:
+      - image: votingworks/cimg-debian11-browsers:2.0.3
+        auth:
+          username: $VX_DOCKER_USERNAME
+          password: $VX_DOCKER_PASSWORD
+  nodejs:
+    docker:
+      - image: votingworks/cimg-debian11:2.0.3
+        auth:
+          username: $VX_DOCKER_USERNAME
+          password: $VX_DOCKER_PASSWORD
+
+jobs:
+${[...jobs.values()]
+  .map((lines) => lines.map((line) => `  ${line}`).join('\n'))
+  .join('\n\n')}
+
+  # TODO: remove this once we replace the Python code
+  test-services-converter-ms-sems:
+    executor: nodejs
+    resource_class: medium
+    steps:
+      - checkout
+      - run:
+          name: Dependencies
+          command: |
+            sudo apt update -y
+            make -C services/converter-ms-sems install-dependencies
+            make -C services/converter-ms-sems install-dev-dependencies
+      - run:
+          name: Test
+          command: |
+            make -C services/converter-ms-sems coverage
+
+  validate-monorepo:
+    executor: nodejs
+    resource_class: xlarge
+    steps:
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            pnpm --dir script build
+      - run:
+          name: Validate
+          command: |
+            ./script/validate-monorepo
+
+workflows:
+  test:
+    jobs:
+${jobIds.map((jobId) => `      - ${jobId}`).join('\n')}
+
+commands:
+  checkout-and-install:
+    description: Get the code and install dependencies.
+    steps:
+      - run:
+          name: Ensure rust is in the PATH variable
+          command: |
+            echo 'export PATH="/root/.cargo/bin:$PATH"' >> $BASH_ENV
+      - checkout
+      # Edit this comment somehow in order to invalidate the CircleCI cache.
+      # Since the contents of this file affect the cache key, editing only a
+      # comment will invalidate the cache without changing the behavior.
+      - restore_cache:
+          key:
+            dotcache-cache-{{checksum ".circleci/config.yml" }}-{{ checksum
+            "pnpm-lock.yaml" }}
+      - run:
+          name: Setup Dependencies
+          command: |
+            pnpm install --frozen-lockfile
+      - save_cache:
+          key:
+            dotcache-cache-{{checksum ".circleci/config.yml" }}-{{ checksum
+            "pnpm-lock.yaml" }}
+          paths:
+            - /root/.local/share/pnpm/store/v3
+            - /root/.cache/Cypress
+            - /root/.cargo
+  install-cypress-browser:
+    description: Installs a browser for Cypress tests.
+    steps:
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
+
+`.trim();
+}

--- a/libs/monorepo-utils/src/dependencies.test.ts
+++ b/libs/monorepo-utils/src/dependencies.test.ts
@@ -1,0 +1,115 @@
+import { join } from 'path';
+import {
+  findAllMonorepoDependencies,
+  getAllDependencies,
+} from './dependencies';
+import { getWorkspacePackageInfo } from './pnpm';
+
+test('getAllDependencies merges dependencies fields', () => {
+  expect(
+    getAllDependencies({
+      path: '/path/to/package',
+      relativePath: 'package',
+      name: 'package',
+      version: '1.0.0',
+      packageJson: {
+        name: 'package',
+        version: '1.0.0',
+        dependencies: {
+          dep1: '1.0.0',
+          dep2: '2.0.0',
+        },
+        devDependencies: {
+          devDep1: '1.0.0',
+          devDep2: '2.0.0',
+        },
+        peerDependencies: {
+          peerDep1: '1.0.0',
+          peerDep2: '2.0.0',
+        },
+      },
+      packageJsonPath: '/path/to/package/package.json',
+    })
+  ).toEqual({
+    dep1: '1.0.0',
+    dep2: '2.0.0',
+    devDep1: '1.0.0',
+    devDep2: '2.0.0',
+    peerDep1: '1.0.0',
+    peerDep2: '2.0.0',
+  });
+});
+
+test('getAllDependencies with no package.json', () => {
+  expect(
+    getAllDependencies({
+      path: '/path/to/package',
+      relativePath: 'package',
+      name: 'package',
+      version: '1.0.0',
+    })
+  ).toEqual({});
+});
+
+test.each(['dependencies', 'devDependencies', 'peerDependencies'])(
+  'getAllDependencies from %s',
+  (field) => {
+    expect(
+      getAllDependencies({
+        path: '/path/to/package',
+        relativePath: 'package',
+        name: 'package',
+        version: '1.0.0',
+        packageJson: {
+          name: 'package',
+          version: '1.0.0',
+          [field]: {
+            dep1: '1.0.0',
+            dep2: '2.0.0',
+          },
+        },
+        packageJsonPath: '/path/to/package/package.json',
+      })
+    ).toEqual({
+      dep1: '1.0.0',
+      dep2: '2.0.0',
+    });
+  }
+);
+
+test('findAllMonorepoDependencies yields all dependencies', () => {
+  const pkgs = getWorkspacePackageInfo(join(__dirname, '../../..'));
+  const basicsPkg = pkgs.get('@votingworks/basics')!;
+
+  // single dependency
+  expect([...findAllMonorepoDependencies(pkgs, basicsPkg)]).toEqual([
+    pkgs.get('eslint-plugin-vx')!,
+  ]);
+
+  // no dependencies
+  expect([
+    ...findAllMonorepoDependencies(pkgs, pkgs.get('eslint-plugin-vx')!),
+  ]).toEqual([]);
+
+  // many dependencies
+  expect(
+    [
+      ...findAllMonorepoDependencies(
+        pkgs,
+        pkgs.get('@votingworks/mark-frontend')!
+      ),
+    ].map((pkg) => pkg.name)
+  ).toEqual(
+    // this list is intentionally incomplete to avoid breaking this test
+    // when new packages are added or dependencies are changed
+    expect.arrayContaining([
+      '@votingworks/basics',
+      '@votingworks/fixtures',
+      '@votingworks/logging',
+      '@votingworks/types',
+      '@votingworks/ui',
+      '@votingworks/utils',
+      '@votingworks/mark-backend',
+    ])
+  );
+});

--- a/libs/monorepo-utils/src/dependencies.ts
+++ b/libs/monorepo-utils/src/dependencies.ts
@@ -1,0 +1,35 @@
+import { PackageInfo } from './pnpm';
+
+/**
+ * Gets all dependencies from a package.json file.
+ */
+export function getAllDependencies(pkg: PackageInfo): Record<string, string> {
+  return {
+    ...(pkg.packageJson?.dependencies ?? {}),
+    ...(pkg.packageJson?.devDependencies ?? {}),
+    ...(pkg.packageJson?.peerDependencies ?? {}),
+  };
+}
+
+/**
+ * Yields all monorepo dependencies for a package.
+ */
+export function* findAllMonorepoDependencies(
+  pkgs: Map<string, PackageInfo>,
+  pkg: PackageInfo
+): Generator<PackageInfo> {
+  const yielded = new Set<PackageInfo>([pkg]);
+  const queue = [pkg];
+
+  while (queue.length > 0) {
+    const parent = queue.shift() as PackageInfo;
+    for (const dep of Object.keys(getAllDependencies(parent))) {
+      const depPkg = pkgs.get(dep);
+      if (depPkg && !yielded.has(depPkg)) {
+        yielded.add(depPkg);
+        queue.push(depPkg);
+        yield depPkg;
+      }
+    }
+  }
+}

--- a/libs/monorepo-utils/src/index.ts
+++ b/libs/monorepo-utils/src/index.ts
@@ -1,7 +1,13 @@
 /* istanbul ignore file - no logic, just exports */
 export {
+  CIRCLECI_CONFIG_PATH,
+  generateConfig as generateCircleCiConfig,
+} from './circleci';
+export * from './dependencies';
+export {
   getWorkspacePackageInfo,
   getWorkspacePackagePaths,
   type PackageInfo,
   type PackageJson,
 } from './pnpm';
+export * from './unused';

--- a/libs/monorepo-utils/src/pnpm.test.ts
+++ b/libs/monorepo-utils/src/pnpm.test.ts
@@ -1,7 +1,18 @@
+import { relative } from 'path';
 import { getWorkspacePackageInfo, getWorkspacePackagePaths } from './pnpm';
 
 test('getWorkspacePackagePaths', () => {
   expect(getWorkspacePackagePaths(__dirname)).toEqual(
+    expect.arrayContaining([
+      // workspace root
+      '../../..',
+      // this package
+      '..',
+      // basics, as an example library
+      '../../basics',
+    ])
+  );
+  expect(getWorkspacePackagePaths(relative(process.cwd(), __dirname))).toEqual(
     expect.arrayContaining([
       // workspace root
       '../../..',

--- a/libs/monorepo-utils/src/unused.test.ts
+++ b/libs/monorepo-utils/src/unused.test.ts
@@ -1,0 +1,106 @@
+import { PackageInfo } from './pnpm';
+import { findUnusedPackages } from './unused';
+
+test('findUnusedPackages treats packages with bins as used', () => {
+  const pkgs = new Map<string, PackageInfo>([
+    [
+      'a',
+      {
+        name: 'a',
+        version: '1.0.0',
+        relativePath: 'libs/a',
+        path: '/path/to/libs/a',
+        packageJson: {
+          name: 'a',
+          version: '1.0.0',
+          bin: 'bin.js',
+        },
+      },
+    ],
+  ]);
+
+  expect(findUnusedPackages(pkgs)).toEqual(new Set());
+});
+
+test('findUnusedPackages treats non-libs as used', () => {
+  const pkgs = new Map<string, PackageInfo>([
+    [
+      'a',
+      {
+        name: 'a',
+        version: '1.0.0',
+        relativePath: 'apps/a',
+        path: '/path/to/apps/a',
+      },
+    ],
+  ]);
+
+  expect(findUnusedPackages(pkgs)).toEqual(new Set());
+});
+
+test('findUnusedPackages treats packages without package.json as used', () => {
+  const pkgs = new Map<string, PackageInfo>([
+    [
+      'a',
+      {
+        name: 'a',
+        version: '1.0.0',
+        relativePath: 'libs/a',
+        path: '/path/to/libs/a',
+      },
+    ],
+  ]);
+
+  expect(findUnusedPackages(pkgs)).toEqual(new Set());
+});
+
+test('findUnusedPackages treats depended-on packages as used', () => {
+  const pkgs = new Map<string, PackageInfo>([
+    [
+      'some-app',
+      {
+        name: 'some-app',
+        version: '1.0.0',
+        relativePath: 'apps/some-app',
+        path: '/path/to/apps/some-app',
+        packageJson: {
+          name: 'some-app',
+          version: '1.0.0',
+          dependencies: {
+            'some-lib': '1.0.0',
+          },
+        },
+      },
+    ],
+    [
+      'some-lib',
+      {
+        name: 'some-lib',
+        version: '1.0.0',
+        relativePath: 'libs/some-lib',
+        path: '/path/to/libs/some-lib',
+        packageJson: {
+          name: 'some-lib',
+          version: '1.0.0',
+        },
+      },
+    ],
+    [
+      'unreferenced-lib',
+      {
+        name: 'unreferenced-lib',
+        version: '1.0.0',
+        relativePath: 'libs/unreferenced-lib',
+        path: '/path/to/libs/unreferenced-lib',
+        packageJson: {
+          name: 'unreferenced-lib',
+          version: '1.0.0',
+        },
+      },
+    ],
+  ]);
+
+  expect(findUnusedPackages(pkgs)).toEqual(
+    new Set([pkgs.get('unreferenced-lib')])
+  );
+});

--- a/libs/monorepo-utils/src/unused.ts
+++ b/libs/monorepo-utils/src/unused.ts
@@ -1,0 +1,28 @@
+import { findAllMonorepoDependencies } from './dependencies';
+import { PackageInfo } from './pnpm';
+
+/**
+ * Finds unused packages in the monorepo.
+ */
+export function findUnusedPackages(
+  pkgs: Map<string, PackageInfo>
+): Set<PackageInfo> {
+  const usedPackages = new Set<PackageInfo>();
+
+  for (const pkg of pkgs.values()) {
+    const isInherentlyUsed = Boolean(
+      !pkg.relativePath.startsWith('libs/') ||
+        !pkg.packageJson ||
+        pkg.packageJson.bin
+    );
+
+    if (isInherentlyUsed) {
+      usedPackages.add(pkg);
+      for (const depPkg of findAllMonorepoDependencies(pkgs, pkg)) {
+        usedPackages.add(depPkg);
+      }
+    }
+  }
+
+  return new Set([...pkgs.values()].filter((pkg) => !usedPackages.has(pkg)));
+}

--- a/libs/res-to-ts/package.json
+++ b/libs/res-to-ts/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "type-check": "tsc --build",
+    "build": "pnpm type-check",
     "clean": "rm -rf build tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "pnpm type-check && eslint .",
     "lint:fix": "pnpm type-check && eslint . --fix",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "clean-all": "git clean -dfX",
+    "generate-circleci-config": "node libs/monorepo-utils/bin/generate-circleci-config",
     "prepare": "husky install",
     "configure-env": "node libs/utils/build/scripts/generate_env_file.js",
     "configure-vxdev-env": "node libs/utils/build/scripts/generate_env_file.js --isVxDev -o /vx/config/.env.local",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5170,6 +5170,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: 5.37.0
         version: 5.37.0(eslint@8.23.1)(typescript@4.6.3)
+      esbuild-runner:
+        specifier: ^2.2.2
+        version: 2.2.2(esbuild@0.14.42)
       eslint:
         specifier: 8.23.1
         version: 8.23.1
@@ -5214,7 +5217,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: ^27.0.7
-        version: 27.1.3(@babel/core@7.12.3)(@types/jest@27.4.1)(esbuild@0.16.17)(jest@27.5.1)(typescript@4.6.3)
+        version: 27.1.3(@babel/core@7.12.3)(@types/jest@27.4.1)(esbuild@0.14.42)(jest@27.5.1)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -6249,6 +6252,7 @@ packages:
       browserslist: 4.21.3
       lru-cache: 5.1.1
       semver: 6.3.0
+    dev: false
 
   /@babel/helper-compilation-targets@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
@@ -6298,6 +6302,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@babel/helper-create-class-features-plugin@7.20.12(@babel/core@7.20.12):
     resolution: {integrity: sha512-9OunRkbT0JQcednL0UFvbfXpAsUXiGjUk0a7sN8fUXX7Mue79cUSMjHGDRRi/Vz9vYlpIhLV5fMD5dKoMhhsNQ==}
@@ -6337,6 +6342,17 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-annotate-as-pure': 7.18.6
       regexpu-core: 5.2.2
+    dev: false
+
+  /@babel/helper-create-regexp-features-plugin@7.20.5(@babel/core@7.20.12):
+    resolution: {integrity: sha512-m68B1lkg3XDGX5yCvGO0kPx3v9WIYLnzjKfPcQiwntEQa5ZeRkPmo2X/ISJc8qxWGfwUr+kvZAeEzAwLec2r2w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.20.12
+      '@babel/helper-annotate-as-pure': 7.18.6
+      regexpu-core: 5.2.2
 
   /@babel/helper-define-polyfill-provider@0.3.1(@babel/core@7.20.12):
     resolution: {integrity: sha512-J9hGMpJQmtWmj46B3kBHmL38UhJGhYX7eqkcq+2gsstyYt341HmPeWspihX43yVRA0mS+8GGk2Gckc7bY/HCmA==}
@@ -6363,6 +6379,22 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.20.2
+      debug: 4.3.4(supports-color@8.1.1)
+      lodash.debounce: 4.0.8
+      resolve: 1.22.1
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@babel/helper-define-polyfill-provider@0.3.3(@babel/core@7.20.12):
+    resolution: {integrity: sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==}
+    peerDependencies:
+      '@babel/core': ^7.4.0-0
+    dependencies:
+      '@babel/core': 7.20.12
+      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.20.2
       debug: 4.3.4(supports-color@8.1.1)
       lodash.debounce: 4.0.8
@@ -6473,6 +6505,21 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.12.3
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-wrap-function': 7.20.5
+      '@babel/types': 7.20.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@babel/helper-remap-async-to-generator@7.18.9(@babel/core@7.20.12):
+    resolution: {integrity: sha512-dI7q50YKd8BAv3VEfgg7PS7yD3Rtbi2J1XMXaalXO0W0164hYLnh8zpjRS0mte9MfVp/tltvr/cfdXPvJr1opA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.20.12
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-wrap-function': 7.20.5
@@ -6605,6 +6652,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-Dgxsyg54Fx1d4Nge8UnvTrED63vrwOdPmyvPzlNN/boaliRP54pm3pGzZD1SJUwrBA+Cs/xdG8kXX6Mn/RfISQ==}
@@ -6637,6 +6685,7 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
       '@babel/plugin-proposal-optional-chaining': 7.20.7(@babel/core@7.12.3)
+    dev: false
 
   /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-sbr9+wNE5aXMBBFBICk01tt7sBf2Oc9ikRFEcem/ZORup9IMUdNhW7/wVLEbbtlWOsEubJet46mHAL2C8+2jKQ==}
@@ -6647,7 +6696,7 @@ packages:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/plugin-proposal-optional-chaining': 7.20.7(@babel/core@7.12.3)
+      '@babel/plugin-proposal-optional-chaining': 7.20.7(@babel/core@7.20.12)
 
   /@babel/plugin-proposal-async-generator-functions@7.16.8(@babel/core@7.20.12):
     resolution: {integrity: sha512-71YHIvMuiuqWJQkebWJtdhQTfd4Q4mF76q2IX37uZPkG9+olBxsX+rH1vkhFto4UeJZ9dPY2s+mDvhDm1u2BGQ==}
@@ -6676,6 +6725,7 @@ packages:
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.12.3)
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==}
@@ -6686,8 +6736,8 @@ packages:
       '@babel/core': 7.20.12
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.12.3)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.12.3)
+      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.20.12)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.20.12)
     transitivePeerDependencies:
       - supports-color
 
@@ -6715,6 +6765,7 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
@@ -6754,6 +6805,7 @@ packages:
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.12.3)
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@babel/plugin-proposal-class-static-block@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-AveGOoi9DAjUYYuUAG//Ig69GlazLnoyzMw68VCDux+c1tsnnH/OkYcpz/5xzMkEFC6UxjR5Gw1c+iY2wOGVeQ==}
@@ -6762,9 +6814,9 @@ packages:
       '@babel/core': ^7.12.0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.12.3)
+      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.12.3)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.20.12)
     transitivePeerDependencies:
       - supports-color
 
@@ -6803,6 +6855,7 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.12.3)
+    dev: false
 
   /@babel/plugin-proposal-dynamic-import@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-1auuwmK+Rz13SJj36R+jqFPMJWyKEDd7lLSdOj4oJK0UTgGueSAtkrCvz9ewmgyU/P941Rv2fQwZJN8s6QruXw==}
@@ -6812,7 +6865,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.12.3)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.20.12)
 
   /@babel/plugin-proposal-export-namespace-from@7.16.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-ZxdtqDXLRGBL64ocZcs7ovt71L3jhC1RGSyR996svrCi3PYqHNkb3SwPJCs8RIzD86s+WPpt2S73+EHCGO+NUA==}
@@ -6834,6 +6887,7 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.12.3)
+    dev: false
 
   /@babel/plugin-proposal-export-namespace-from@7.18.9(@babel/core@7.20.12):
     resolution: {integrity: sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==}
@@ -6843,7 +6897,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.12.3)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.20.12)
 
   /@babel/plugin-proposal-json-strings@7.16.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-lNZ3EEggsGY78JavgbHsK9u5P3pQaW7k4axlgFLYkMd7UBsiNahCITShLjNQschPyjtO6dADrL24757IdhBrsQ==}
@@ -6865,6 +6919,7 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.12.3)
+    dev: false
 
   /@babel/plugin-proposal-json-strings@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-lr1peyn9kOdbYc0xr0OdHTZ5FMqS6Di+H0Fz2I/JwMzGmzJETNeOFq2pBySw6X/KFL5EWDjlJuMsUGRFb8fQgQ==}
@@ -6874,7 +6929,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.12.3)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.20.12)
 
   /@babel/plugin-proposal-logical-assignment-operators@7.16.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-K3XzyZJGQCr00+EtYtrDjmwX7o7PLK6U9bi1nCwkQioRFVUv6dJoxbQjtWVtP+bCPy82bONBKG8NPyQ4+i6yjg==}
@@ -6896,6 +6951,7 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.12.3)
+    dev: false
 
   /@babel/plugin-proposal-logical-assignment-operators@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-y7C7cZgpMIjWlKE5T7eJwp+tnRYM89HmRvWM5EQuB5BoHEONjmQ8lSNmBUwOyy/GFRsohJED51YBF79hE1djug==}
@@ -6905,7 +6961,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.12.3)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.20.12)
 
   /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.12.3):
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
@@ -6916,6 +6972,7 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.12.3)
+    dev: false
 
   /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
@@ -6936,6 +6993,7 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.12.3)
+    dev: false
 
   /@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==}
@@ -6973,6 +7031,7 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.12.3)
       '@babel/plugin-transform-parameters': 7.20.7(@babel/core@7.12.3)
+    dev: false
 
   /@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==}
@@ -6982,10 +7041,10 @@ packages:
     dependencies:
       '@babel/compat-data': 7.20.10
       '@babel/core': 7.20.12
-      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.3)
+      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.12.3)
-      '@babel/plugin-transform-parameters': 7.20.7(@babel/core@7.12.3)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.20.12)
+      '@babel/plugin-transform-parameters': 7.20.7(@babel/core@7.20.12)
 
   /@babel/plugin-proposal-optional-catch-binding@7.16.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-eMOH/L4OvWSZAE1VkHbr1vckLG1WUcHGJSLqqQwl2GaUqG6QjddvrOaTUMNYiv77H5IKPMZ9U9P7EaHwvAShfA==}
@@ -7007,6 +7066,7 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.12.3)
+    dev: false
 
   /@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==}
@@ -7016,7 +7076,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.12.3)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.20.12)
 
   /@babel/plugin-proposal-optional-chaining@7.20.7(@babel/core@7.12.3):
     resolution: {integrity: sha512-T+A7b1kfjtRM51ssoOfS1+wbyCVqorfyZhT99TvxxLMirPShD8CzKMRepMlCBGM5RpHMbn8s+5MMHnPstJH6mQ==}
@@ -7028,6 +7088,7 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.12.3)
+    dev: false
 
   /@babel/plugin-proposal-optional-chaining@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-T+A7b1kfjtRM51ssoOfS1+wbyCVqorfyZhT99TvxxLMirPShD8CzKMRepMlCBGM5RpHMbn8s+5MMHnPstJH6mQ==}
@@ -7051,6 +7112,7 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
@@ -7077,6 +7139,7 @@ packages:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.12.3)
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@babel/plugin-proposal-private-property-in-object@7.20.5(@babel/core@7.20.12):
     resolution: {integrity: sha512-Vq7b9dUA12ByzB4EjQTPo25sFhY+08pQDBSZRtUAkj7lb7jahaHR5igera16QZ+3my1nYR4dKsNdYj5IjPHilQ==}
@@ -7112,6 +7175,7 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-proposal-unicode-property-regex@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==}
@@ -7120,7 +7184,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
+      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.12.3):
@@ -7180,6 +7244,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.20.12):
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
@@ -7206,6 +7271,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.20.12):
     resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
@@ -7222,6 +7288,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.20.12):
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
@@ -7258,6 +7325,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-syntax-import-assertions@7.20.0(@babel/core@7.20.12):
     resolution: {integrity: sha512-IUh1vakzNoWalR8ch/areW7qFopR2AEw03JlG7BbrDqmQ4X3q9uuipQwSGrUn7oGiemKjtSLDhNtQHzMHr1JdQ==}
@@ -7424,6 +7492,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.20.12):
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
@@ -7489,6 +7558,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-transform-arrow-functions@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-3poA5E7dzDomxj9WXWwuD6A5F3kc7VXwIJO+E+J8qtDtS+pXPAhrgEyh+9GBwBgPq1Z+bB+/JD60lp5jsN7JPQ==}
@@ -7525,6 +7595,7 @@ packages:
       '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.12.3)
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@babel/plugin-transform-async-to-generator@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-Uo5gwHPT9vgnSXQxqGtpdufUiWp96gk7yiP4Mp5bm1QMkEmLXBO7PAGYbKoJ6DhAwiNkcHFBol/x5zZZkL/t0Q==}
@@ -7535,7 +7606,7 @@ packages:
       '@babel/core': 7.20.12
       '@babel/helper-module-imports': 7.18.6
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.12.3)
+      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.20.12)
     transitivePeerDependencies:
       - supports-color
 
@@ -7557,6 +7628,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-transform-block-scoped-functions@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==}
@@ -7585,6 +7657,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-transform-block-scoping@7.20.11(@babel/core@7.20.12):
     resolution: {integrity: sha512-tA4N427a7fjf1P0/2I4ScsHGc5jcHPbb30xMbaTke2gxDuWpUfXDuX1FEymJwKk4tuGUvGcejAR6HdZVqmmPyw==}
@@ -7632,6 +7705,7 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@babel/plugin-transform-classes@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-LWYbsiXTPKl+oBlXUGlwNlJZetXD5Am+CyBdqhPsDVjM9Jc8jwBJFrKhHf900Kfk2eZG1y9MAG3UNajol7A4VQ==}
@@ -7641,7 +7715,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.3)
+      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.20.12)
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-function-name': 7.19.0
       '@babel/helper-optimise-call-expression': 7.18.6
@@ -7671,6 +7745,7 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/template': 7.20.7
+    dev: false
 
   /@babel/plugin-transform-computed-properties@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-Lz7MvBK6DTjElHAmfu6bfANzKcxpyNPeYBGEafyA6E5HtRpjpZwU+u7Qrgz/2OR0z+5TvKYbPdphfSaAcZBrYQ==}
@@ -7700,6 +7775,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-transform-destructuring@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-Xwg403sRrZb81IVB79ZPqNQME23yhugYVqgTxAhT99h485F4f+GMELFhhOsscDUB7HCswepKeCKLn/GZvUKoBA==}
@@ -7730,6 +7806,7 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-transform-dotall-regex@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-6S3jpun1eEbAxq7TdjLotAsl4WpQI9DxfkycRcKrjhQYzU87qpXdknpBg/e+TdcMehqGnLFi7tnFUBR02Vq6wg==}
@@ -7738,7 +7815,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
+      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-duplicate-keys@7.16.7(@babel/core@7.20.12):
@@ -7759,6 +7836,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-transform-duplicate-keys@7.18.9(@babel/core@7.20.12):
     resolution: {integrity: sha512-d2bmXCtZXYc59/0SanQKbiWINadaJXqtvIQIzd4+hNwkWBgyCd5F/2t1kXoUdvPMrxzPvhK6EMQRROxsue+mfw==}
@@ -7789,6 +7867,7 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.18.9
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-transform-exponentiation-operator@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-wzEtc0+2c88FVR34aQmiz56dxEkxr2g8DQb/KfaFa1JYXOFVsbhvAonFN6PwVWj++fKmku8NP80plJ5Et4wqHw==}
@@ -7828,6 +7907,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-transform-for-of@7.18.8(@babel/core@7.20.12):
     resolution: {integrity: sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==}
@@ -7860,6 +7940,7 @@ packages:
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.3)
       '@babel/helper-function-name': 7.19.0
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-transform-function-name@7.18.9(@babel/core@7.20.12):
     resolution: {integrity: sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==}
@@ -7868,7 +7949,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.3)
+      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.20.12)
       '@babel/helper-function-name': 7.19.0
       '@babel/helper-plugin-utils': 7.20.2
 
@@ -7890,6 +7971,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-transform-literals@7.18.9(@babel/core@7.20.12):
     resolution: {integrity: sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==}
@@ -7918,6 +8000,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-transform-member-expression-literals@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==}
@@ -7953,6 +8036,7 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@babel/plugin-transform-modules-amd@7.20.11(@babel/core@7.20.12):
     resolution: {integrity: sha512-NuzCt5IIYOW0O30UvqktzHYR2ud5bOWbY0yaxWZ6G+aFzOMJvrs5YHNikrbdaT15+KNO31nPOy5Fim3ku6Zb5g==}
@@ -7993,6 +8077,7 @@ packages:
       '@babel/helper-simple-access': 7.20.2
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@babel/plugin-transform-modules-commonjs@7.20.11(@babel/core@7.20.12):
     resolution: {integrity: sha512-S8e1f7WQ7cimJQ51JkAaDrEtohVEitXjgCGAS2N8S31Y42E+kWwfSz83LYz57QdBm7q9diARVqanIaH2oVgQnw==}
@@ -8036,6 +8121,7 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@babel/plugin-transform-modules-systemjs@7.20.11(@babel/core@7.20.12):
     resolution: {integrity: sha512-vVu5g9BPQKSFEmvt2TA4Da5N+QVS66EX21d8uoOihC+OCpUoGvzVsXeqFdtAEfVa5BILAeFt+U7yVmLbQnAJmw==}
@@ -8075,6 +8161,7 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@babel/plugin-transform-modules-umd@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-dcegErExVeXcRqNtkRU/z8WlBLnvD4MRnHgNs3MytRO1Mn1sHRyhbcpYbVMGclAqOjdW+9cfkdZno9dFdfKLfQ==}
@@ -8107,6 +8194,7 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-transform-named-capturing-groups-regex@7.20.5(@babel/core@7.20.12):
     resolution: {integrity: sha512-mOW4tTzi5iTLnw+78iEq3gr8Aoq4WNRGpmSlrogqaiCBoR1HFhpU4JkpQFOHfeYx3ReVIFWOQJS4aZBRvuZ6mA==}
@@ -8115,7 +8203,7 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
+      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-new-target@7.16.7(@babel/core@7.20.12):
@@ -8136,6 +8224,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-transform-new-target@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-DjwFA/9Iu3Z+vrAn+8pBUGcjhxKguSMlsFqeCKbhb9BAV756v0krzVK04CRDi/4aqmk8BsHb4a/gFcaA5joXRw==}
@@ -8170,6 +8259,7 @@ packages:
       '@babel/helper-replace-supers': 7.20.7
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@babel/plugin-transform-object-super@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==}
@@ -8201,6 +8291,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-transform-parameters@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-WiWBIkeHKVOSYPO0pWkxGPfKeWrCJyD3NJ53+Lrp/QMSZbsVPovrVl2aWZ19D/LTVnaDv5Ap7GJ/B2CTOZdrfA==}
@@ -8229,6 +8320,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-transform-property-literals@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==}
@@ -8366,6 +8458,7 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       regenerator-transform: 0.15.1
+    dev: false
 
   /@babel/plugin-transform-regenerator@7.20.5(@babel/core@7.20.12):
     resolution: {integrity: sha512-kW/oO7HPBtntbsahzQ0qSE3tFvkFwnbozz3NWFhLGqH75vLEg+sCGngLlhVkePlCs3Jv0dBBHDzCHxNiFAQKCQ==}
@@ -8395,6 +8488,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-transform-reserved-words@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-oX/4MyMoypzHjFrT1CdivfKZ+XvIPMFXwwxHp/r0Ddy2Vuomt4HDFGmft1TAY2yiTKiNSsh3kjBAzcM8kSdsjA==}
@@ -8439,6 +8533,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-transform-shorthand-properties@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==}
@@ -8469,6 +8564,7 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
+    dev: false
 
   /@babel/plugin-transform-spread@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-ewBbHQ+1U/VnH1fxltbJqDeWBU1oNLG8Dj11uIv3xVf7nrQu0bPGe5Rf716r7K5Qz+SqtAOVswoVunoiBtGhxw==}
@@ -8498,6 +8594,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-transform-sticky-regex@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-kfiDrDQ+PBsQDO85yj1icueWMfGfJFKN1KCkndygtu/C9+XUfydLC8Iv5UYJqRwy4zk8EcplRxEOeLyjq1gm6Q==}
@@ -8526,6 +8623,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-transform-template-literals@7.18.9(@babel/core@7.20.12):
     resolution: {integrity: sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==}
@@ -8554,6 +8652,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-transform-typeof-symbol@7.18.9(@babel/core@7.20.12):
     resolution: {integrity: sha512-SRfwTtF11G2aemAZWivL7PD+C9z52v9EvMqH9BuYbabyPuKUvSWks3oCg6041pT925L4zVFqaVBeECwsmlguEw==}
@@ -8595,6 +8694,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-transform-unicode-escapes@7.18.10(@babel/core@7.20.12):
     resolution: {integrity: sha512-kKAdAI+YzPgGY/ftStBFXTI1LZFju38rYThnfMykS+IXy8BVx+res7s2fxf1l8I35DV2T97ezo6+SGrXz6B3iQ==}
@@ -8625,6 +8725,7 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-transform-unicode-regex@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-gE7A6Lt7YLnNOL3Pb9BNeZvi+d8l7tcRrG4+pwJjK9hD2xX4mEvjlQW60G9EEmfXVYRPv9VRQcyegIVHCql/AA==}
@@ -8633,7 +8734,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
+      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/polyfill@7.12.1:
@@ -8813,6 +8914,7 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@babel/preset-env@7.20.2(@babel/core@7.20.12):
     resolution: {integrity: sha512-1G0efQEWR1EHkKvKHqbG+IN/QdgwfByUpM5V5QroDzGV2t3S/WXNQd693cHiHTlCFMpr9B6FkPFXDA2lQcKoDg==}
@@ -8922,6 +9024,7 @@ packages:
       '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.12.3)
       '@babel/types': 7.20.7
       esutils: 2.0.3
+    dev: false
 
   /@babel/preset-modules@0.1.5(@babel/core@7.20.12):
     resolution: {integrity: sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==}
@@ -8930,8 +9033,8 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.12.3)
-      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.20.12)
+      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.20.12)
       '@babel/types': 7.20.7
       esutils: 2.0.3
 
@@ -11856,7 +11959,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/preset-env': 7.20.2(@babel/core@7.12.3)
+      '@babel/preset-env': 7.20.2(@babel/core@7.20.12)
       '@storybook/codemod': 7.0.0-beta.31
       '@storybook/core-common': 7.0.0-beta.31
       '@storybook/core-server': 7.0.0-beta.31
@@ -14688,6 +14791,7 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /babel-plugin-polyfill-corejs2@0.3.3(@babel/core@7.20.12):
     resolution: {integrity: sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==}
@@ -14696,7 +14800,7 @@ packages:
     dependencies:
       '@babel/compat-data': 7.20.10
       '@babel/core': 7.20.12
-      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.12.3)
+      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.20.12)
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
@@ -14723,6 +14827,7 @@ packages:
       core-js-compat: 3.25.1
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /babel-plugin-polyfill-corejs3@0.6.0(@babel/core@7.20.12):
     resolution: {integrity: sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==}
@@ -14730,7 +14835,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.12.3)
+      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.20.12)
       core-js-compat: 3.25.1
     transitivePeerDependencies:
       - supports-color
@@ -14755,6 +14860,7 @@ packages:
       '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.12.3)
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /babel-plugin-polyfill-regenerator@0.4.1(@babel/core@7.20.12):
     resolution: {integrity: sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==}
@@ -14762,7 +14868,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.12.3)
+      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.20.12)
     transitivePeerDependencies:
       - supports-color
 
@@ -18409,7 +18515,6 @@ packages:
       esbuild: 0.14.42
       source-map-support: 0.5.21
       tslib: 2.4.0
-    dev: false
 
   /esbuild-runner@2.2.2(esbuild@0.16.17):
     resolution: {integrity: sha512-fRFVXcmYVmSmtYm2mL8RlUASt2TDkGh3uRcvHFOKNr/T58VrfVeKD9uT9nlgxk96u0LS0ehS/GY7Da/bXWKkhw==}
@@ -31009,6 +31114,42 @@ packages:
       '@types/jest': 27.4.1
       bs-logger: 0.2.6
       esbuild: 0.14.27
+      fast-json-stable-stringify: 2.1.0
+      jest: 27.5.1
+      jest-util: 27.5.1
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.3.2
+      typescript: 4.6.3
+      yargs-parser: 20.2.9
+    dev: true
+
+  /ts-jest@27.1.3(@babel/core@7.12.3)(@types/jest@27.4.1)(esbuild@0.14.42)(jest@27.5.1)(typescript@4.6.3):
+    resolution: {integrity: sha512-6Nlura7s6uM9BVUAoqLH7JHyMXjz8gluryjpPXxr3IxZdAXnU6FhjvVLHFtfd1vsE1p8zD1OJfskkc0jhTSnkA==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@types/jest': ^27.0.0
+      babel-jest: '>=27.0.0 <28'
+      esbuild: ~0.14.0
+      jest: ^27.0.0
+      typescript: '>=3.8 <5.0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@types/jest':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    dependencies:
+      '@babel/core': 7.12.3
+      '@types/jest': 27.4.1
+      bs-logger: 0.2.6
+      esbuild: 0.14.42
       fast-json-stable-stringify: 2.1.0
       jest: 27.5.1
       jest-util: 27.5.1

--- a/script/src/validate-monorepo/cli.ts
+++ b/script/src/validate-monorepo/cli.ts
@@ -65,17 +65,9 @@ export async function main({ stderr }: IO): Promise<number> {
         );
         break;
 
-      case circleci.ValidationIssueKind.UnusedJobIssue:
+      case circleci.ValidationIssueKind.OutdatedConfig:
         stderr.write(
-          `${relative(cwd, issue.configPath)}: unused job "${issue.jobName}"\n`
-        );
-        break;
-
-      case circleci.ValidationIssueKind.UntestedPackageIssue:
-        stderr.write(
-          `${relative(cwd, issue.configPath)}: untested package "${
-            issue.packagePath
-          }", job "${issue.expectedJobName}" was not found\n`
+          `${relative(cwd, issue.configPath)}: configuration is outdated\n`
         );
         break;
 

--- a/script/src/validate-monorepo/validation/index.ts
+++ b/script/src/validate-monorepo/validation/index.ts
@@ -41,14 +41,6 @@ export async function* validateMonorepo(): AsyncGenerator<ValidationIssue> {
     ],
     workspacePackages,
   });
-  yield* tsconfig.checkConfig({ workspacePackages });
-
-  const circleCiConfigPath = join(root, '.circleci/config.yml');
-  const circleCiConfig = await circleci.loadConfig(circleCiConfigPath);
-
-  yield* circleci.checkConfig(
-    circleCiConfig,
-    circleCiConfigPath,
-    await getWorkspacePackageInfo(root)
-  );
+  yield* tsconfig.checkConfig(workspacePackages);
+  yield* circleci.checkConfig(workspacePackages);
 }

--- a/script/src/validate-monorepo/validation/packages.ts
+++ b/script/src/validate-monorepo/validation/packages.ts
@@ -26,7 +26,7 @@ export async function* checkPackageManager({
   const properties: PackageJsonProperty[] = [];
 
   for (const pkg of workspacePackages.values()) {
-    if (pkg.name.startsWith('@types/') || pkg.name === 'prodserver') {
+    if (!pkg.packageJson || !pkg.packageJsonPath || pkg.name.startsWith('@types/') || pkg.name === 'prodserver') {
       continue;
     }
 
@@ -62,6 +62,10 @@ export async function* checkPinnedVersions({
 
     for (const pkg of workspacePackages.values()) {
       const { packageJson, packageJsonPath } = pkg;
+
+      if (!packageJson || !packageJsonPath) {
+        continue;
+      }
 
       if (packageJson.dependencies?.[pinnedPackage]) {
         versions.add(packageJson.dependencies[pinnedPackage]);

--- a/script/src/validate-monorepo/validation/tsconfig.ts
+++ b/script/src/validate-monorepo/validation/tsconfig.ts
@@ -234,15 +234,17 @@ export function* checkTsconfigReferencesMatch(
   }
 }
 
-export async function* checkConfig({
-  workspacePackages,
-}: {
-  workspacePackages: ReadonlyMap<string, PackageInfo>;
-}): AsyncGenerator<ValidationIssue> {
+export async function* checkConfig(
+  workspacePackages: ReadonlyMap<string, PackageInfo>
+): AsyncGenerator<ValidationIssue> {
   for (const pkg of workspacePackages.values()) {
     const { packageJson, packageJsonPath } = pkg;
 
-    if (!pkg.packageJson.devDependencies?.['typescript']) {
+    if (!packageJson || !packageJsonPath) {
+      continue;
+    }
+
+    if (!packageJson.devDependencies?.['typescript']) {
       continue;
     }
 


### PR DESCRIPTION

## Overview

I forked `vxsuite` for RAVE but don't want all the packages. I plan to use the scripts from this commit to remove the packages I don't want and re-generate the CircleCI config.

## Demo Video or Screenshot
n/a

## Testing Plan
- [x] New automated tests, in particular to keep CircleCI config in sync
- [x] Manually tested the added scripts

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
