### PR TITLE
pre-warm cache of tts

### DIFF
--- a/frontends/bmd/src/config/types.ts
+++ b/frontends/bmd/src/config/types.ts
@@ -156,6 +156,7 @@ export type PartialUserSettings = Partial<UserSettings>;
 // Screen Reader
 export interface SpeakOptions {
   now?: boolean;
+  cacheOnly?: boolean;
 }
 
 export interface TextToSpeech {

--- a/frontends/bmd/src/pages/__snapshots__/cast_ballot_page.test.tsx.snap
+++ b/frontends/bmd/src/pages/__snapshots__/cast_ballot_page.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`renders CastBallotPage 1`] = `
       id="audiofocus"
     >
       <h1
-        aria-label="You’re almost done."
+        aria-label="You're almost done."
       >
         You’re Almost Done
       </h1>

--- a/frontends/bmd/src/pages/cast_ballot_page.tsx
+++ b/frontends/bmd/src/pages/cast_ballot_page.tsx
@@ -45,7 +45,7 @@ export function CastBallotPage({
     <Screen white>
       <Main centerChild>
         <Prose textCenter maxWidth={false} id="audiofocus">
-          <h1 aria-label="You’re almost done.">You’re Almost Done</h1>
+          <h1 aria-label="You're almost done.">You’re Almost Done</h1>
           <p>Your official ballot is printing. To finish voting you need to…</p>
           <Instructions>
             <li>

--- a/frontends/bmd/src/utils/ScreenReader/kiosk_text_to_speech.test.ts
+++ b/frontends/bmd/src/utils/ScreenReader/kiosk_text_to_speech.test.ts
@@ -13,6 +13,7 @@ it('speaks an utterance when given text to speak', async () => {
   await tts.speak('hello world');
   expect(window.kiosk.cancelSpeak).toHaveBeenCalled();
   expect(window.kiosk.speak).toHaveBeenCalledWith('hello world', {
+    cacheOnly: false,
     volume: 44,
   });
 });
@@ -33,6 +34,7 @@ it('is unmuted by default, which means utterances are spoken', async () => {
   expect(tts.isMuted()).toBe(false);
   await tts.speak('hello world');
   expect(window.kiosk.speak).toHaveBeenCalledWith('hello world', {
+    cacheOnly: false,
     volume: 44,
   });
 });
@@ -55,6 +57,7 @@ it('can be muted and then unmuted, which means utterances are spoken', async () 
   tts.unmute();
   await tts.speak('hello world');
   expect(window.kiosk.speak).toHaveBeenCalledWith('hello world', {
+    cacheOnly: false,
     volume: 44,
   });
 });
@@ -88,6 +91,7 @@ it('changeVolume cycles through volumes and announces the change', async () => {
   // check initial volume
   await tts.speak('hello world');
   expect(window.kiosk.speak).toHaveBeenCalledWith('hello world', {
+    cacheOnly: false,
     volume: 44,
   });
 
@@ -98,6 +102,7 @@ it('changeVolume cycles through volumes and announces the change', async () => {
       expect(window.kiosk!.speak).toHaveBeenLastCalledWith(
         `Increased volume to ${i} out of 10.`,
         {
+          cacheOnly: false,
           volume: 20 + i * 8,
         }
       );
@@ -107,6 +112,7 @@ it('changeVolume cycles through volumes and announces the change', async () => {
   // check that changed volume applies to other requests
   await tts.speak('hello world');
   expect(window.kiosk.speak).toHaveBeenLastCalledWith('hello world', {
+    cacheOnly: false,
     volume: 100,
   });
 
@@ -117,6 +123,7 @@ it('changeVolume cycles through volumes and announces the change', async () => {
       expect(window.kiosk!.speak).toHaveBeenLastCalledWith(
         `Decreased volume to ${i} out of 10.`,
         {
+          cacheOnly: false,
           volume: 20 + i * 8,
         }
       );
@@ -130,6 +137,7 @@ it('changeVolume cycles through volumes and announces the change', async () => {
       expect(window.kiosk!.speak).toHaveBeenLastCalledWith(
         `Increased volume to ${i} out of 10.`,
         {
+          cacheOnly: false,
           volume: 20 + i * 8,
         }
       );

--- a/frontends/bmd/src/utils/ScreenReader/kiosk_text_to_speech.ts
+++ b/frontends/bmd/src/utils/ScreenReader/kiosk_text_to_speech.ts
@@ -31,20 +31,24 @@ export class KioskTextToSpeech implements TextToSpeech {
    * Directly triggers speech of text. Resolves when speaking is finished
    * or cancelled.
    */
-  async speak(text: string, { now = true }: SpeakOptions = {}): Promise<void> {
+  async speak(
+    text: string,
+    { now = true, cacheOnly = false }: SpeakOptions = {}
+  ): Promise<void> {
     assert(now, 'method "speak"  with "options.now = false" is not supported');
     assert(window.kiosk);
 
-    if (this.isMuted()) {
+    if (!cacheOnly && this.isMuted()) {
       return;
     }
 
-    if (now) {
+    if (!cacheOnly && now) {
       await window.kiosk.cancelSpeak();
     }
 
     await window.kiosk.speak(text, {
       volume: incrementToVolume(this.volumeIncrement),
+      cacheOnly,
     });
   }
 

--- a/libs/@types/kiosk-browser/kiosk-browser.d.ts
+++ b/libs/@types/kiosk-browser/kiosk-browser.d.ts
@@ -115,6 +115,7 @@ declare namespace KioskBrowser {
 
   export interface SpeakOptions {
     volume: number;
+    cacheOnly?: boolean;
   }
 
   export interface FileFilter {


### PR DESCRIPTION
## Overview

Make use of the new kiosk-browser API that caches spoken utterances, to warm the text-to-speech cache.

## Testing Plan

Tested manually

## Checklist

~- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
