### PR TITLE
repeat spoken words on an interval.

### DIFF
--- a/frontends/bmd/src/utils/ScreenReader/aria_screen_reader.ts
+++ b/frontends/bmd/src/utils/ScreenReader/aria_screen_reader.ts
@@ -4,6 +4,8 @@ import { ScreenReader, SpeakOptions, TextToSpeech } from '../../config/types';
  * Implements `ScreenReader` using the ARIA DOM attributes.
  */
 export class AriaScreenReader implements ScreenReader {
+  private currentInterval?: ReturnType<typeof setInterval>;
+
   /**
    * @param tts A text-to-speech engine to use to speak aloud.
    */
@@ -13,14 +15,32 @@ export class AriaScreenReader implements ScreenReader {
    * Call this with an event target when a focus event occurs. Resolves when speaking is done.
    */
   async onFocus(target?: EventTarget): Promise<void> {
+    if (this.currentInterval) {
+      clearInterval(this.currentInterval);
+      this.currentInterval = undefined;
+    }
+
     await this.speakEventTarget(target);
+
+    this.currentInterval = setInterval(() => {
+      void this.speakEventTarget(target);
+    }, 15000);
   }
 
   /**
    * Call this with an event target when a click event occurs. Resolves when speaking is done.
    */
   async onClick(target?: EventTarget): Promise<void> {
+    if (this.currentInterval) {
+      clearInterval(this.currentInterval);
+      this.currentInterval = undefined;
+    }
+
     await this.speakEventTarget(target);
+
+    this.currentInterval = setInterval(() => {
+      void this.speakEventTarget(target);
+    }, 8000);
   }
 
   /**
@@ -28,6 +48,11 @@ export class AriaScreenReader implements ScreenReader {
    */
   // eslint-disable-next-line @typescript-eslint/require-await
   async onPageLoad(): Promise<void> {
+    if (this.currentInterval) {
+      clearInterval(this.currentInterval);
+      this.currentInterval = undefined;
+    }
+
     this.tts.stop();
   }
 


### PR DESCRIPTION
## Overview

If a blind voter doesn't put on the headphones at the right time, or misses a cue, they're lost. This is a small step to fixing that, by repeating the utterances on a regular interval.

## Testing Plan

manual testing

## Checklist

~- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
~- [ ] I have added a screenshot and/or video to this PR to demo the change~
- [ X ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
