### PR TITLE
test: pin `ts-jest`

### DIFF
--- a/apps/admin/backend/package.json
+++ b/apps/admin/backend/package.json
@@ -98,7 +98,7 @@
     "sort-package-json": "^1.50.0",
     "supertest": "^6.0.1",
     "tmp": "^0.2.1",
-    "ts-jest": "^26.4.4",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3"
   },
   "engines": {

--- a/apps/admin/frontend/package.json
+++ b/apps/admin/frontend/package.json
@@ -218,7 +218,7 @@
     "stylelint-config-prettier": "^8.0.1",
     "stylelint-config-styled-components": "^0.1.1",
     "stylelint-processor-styled-components": "^1.10.0",
-    "ts-jest": "^28.0.8",
+    "ts-jest": "29.0.5",
     "vite": "^2.9.12"
   },
   "packageManager": "pnpm@8.1.0",

--- a/apps/central-scan/frontend/package.json
+++ b/apps/central-scan/frontend/package.json
@@ -85,7 +85,7 @@
     "react-router-dom": "^5.2.0",
     "setimmediate": "^1.0.5",
     "styled-components": "^5.2.1",
-    "ts-jest": "^26.1.3",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3",
     "use-interval": "^1.2.1",
     "zod": "3.14.4"

--- a/apps/design/frontend/package.json
+++ b/apps/design/frontend/package.json
@@ -114,7 +114,7 @@
     "stylelint-config-styled-components": "^0.1.1",
     "stylelint-processor-styled-components": "^1.9.0",
     "tmp": "^0.2.1",
-    "ts-jest": "^26.5.6",
+    "ts-jest": "29.0.5",
     "vite": "^2.9.12"
   },
   "packageManager": "pnpm@8.1.0"

--- a/apps/mark/backend/package.json
+++ b/apps/mark/backend/package.json
@@ -83,7 +83,7 @@
     "nodemon": "^2.0.20",
     "prettier": "2.6.2",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^26.4.4",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3"
   },
   "engines": {

--- a/apps/mark/frontend/package.json
+++ b/apps/mark/frontend/package.json
@@ -182,7 +182,7 @@
     "stylelint-config-prettier": "^8.0.1",
     "stylelint-config-styled-components": "^0.1.1",
     "stylelint-processor-styled-components": "^1.10.0",
-    "ts-jest": "26",
+    "ts-jest": "29.0.5",
     "vite": "^2.9.12"
   },
   "engines": {

--- a/apps/scan/frontend/package.json
+++ b/apps/scan/frontend/package.json
@@ -138,7 +138,7 @@
     "stylelint-config-prettier": "^8.0.1",
     "stylelint-config-styled-components": "^0.1.1",
     "stylelint-processor-styled-components": "^1.9.0",
-    "ts-jest": "^26.5.6",
+    "ts-jest": "29.0.5",
     "vite": "^2.9.12"
   },
   "packageManager": "pnpm@8.1.0",

--- a/libs/api/package.json
+++ b/libs/api/package.json
@@ -60,7 +60,7 @@
     "lint-staged": "^11.0.0",
     "prettier": "2.6.2",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^27.0.7",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3"
   },
   "packageManager": "pnpm@8.1.0"

--- a/libs/auth/package.json
+++ b/libs/auth/package.json
@@ -72,7 +72,7 @@
     "lint-staged": "^11.0.0",
     "prettier": "2.6.2",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^27.0.7",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3",
     "wait-for-expect": "^3.0.2"
   },

--- a/libs/backend/package.json
+++ b/libs/backend/package.json
@@ -85,7 +85,7 @@
     "memory-streams": "^0.1.3",
     "prettier": "2.6.2",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^27.0.7",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3"
   },
   "packageManager": "pnpm@8.1.0"

--- a/libs/ballot-encoder/package.json
+++ b/libs/ballot-encoder/package.json
@@ -61,7 +61,7 @@
     "lint-staged": "^10.5.1",
     "prettier": "2.6.2",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^27.0.7",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3"
   },
   "engines": {

--- a/libs/ballot-interpreter-nh/package.json
+++ b/libs/ballot-interpreter-nh/package.json
@@ -54,7 +54,7 @@
     "is-ci-cli": "^2.2.0",
     "jest": "^29.5.0",
     "jest-watch-typeahead": "^0.6.4",
-    "ts-jest": "^29.0.5",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3"
   }
 }

--- a/libs/ballot-interpreter-vx/package.json
+++ b/libs/ballot-interpreter-vx/package.json
@@ -87,7 +87,7 @@
     "prettier": "2.6.2",
     "sort-package-json": "^1.50.0",
     "tmp": "^0.2.1",
-    "ts-jest": "^27.0.7",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3"
   },
   "packageManager": "pnpm@8.1.0"

--- a/libs/basics/package.json
+++ b/libs/basics/package.json
@@ -53,7 +53,7 @@
     "lint-staged": "^11.0.0",
     "prettier": "2.6.2",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^27.0.7",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3"
   },
   "packageManager": "pnpm@8.1.0"

--- a/libs/cdf-schema-builder/package.json
+++ b/libs/cdf-schema-builder/package.json
@@ -62,7 +62,7 @@
     "lint-staged": "^10.5.1",
     "prettier": "2.6.2",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^27.0.7",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3"
   },
   "engines": {

--- a/libs/custom-paper-handler/package.json
+++ b/libs/custom-paper-handler/package.json
@@ -55,7 +55,7 @@
     "jest-mock-extended": "^3.0.4",
     "jest-watch-typeahead": "0.6.4",
     "prettier": "2.6.2",
-    "ts-jest": "^29.0.5",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3"
   },
   "packageManager": "pnpm@8.1.0"

--- a/libs/cvr-fixture-generator/package.json
+++ b/libs/cvr-fixture-generator/package.json
@@ -54,7 +54,7 @@
     "jest-watch-typeahead": "0.6.4",
     "prettier": "2.6.2",
     "tmp": "^0.2.1",
-    "ts-jest": "^28.0.8",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3",
     "zod": "3.14.4"
   },

--- a/libs/db/package.json
+++ b/libs/db/package.json
@@ -46,7 +46,7 @@
     "jest-watch-typeahead": "0.6.4",
     "prettier": "2.6.2",
     "tmp": "^0.2.1",
-    "ts-jest": "^28.0.5",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3"
   }
 }

--- a/libs/dev-dock/backend/package.json
+++ b/libs/dev-dock/backend/package.json
@@ -62,7 +62,7 @@
     "lint-staged": "^11.0.0",
     "prettier": "2.6.2",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^27.0.7",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3"
   },
   "packageManager": "pnpm@8.1.0"

--- a/libs/dev-dock/frontend/package.json
+++ b/libs/dev-dock/frontend/package.json
@@ -73,7 +73,7 @@
     "prettier": "2.6.2",
     "react": "17.0.1",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^27.0.7",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3"
   },
   "peerDependencies": {

--- a/libs/eslint-plugin-vx/package.json
+++ b/libs/eslint-plugin-vx/package.json
@@ -55,6 +55,6 @@
     "jest-watch-typeahead": "^0.6.4",
     "prettier": "2.6.2",
     "react": "17.0.1",
-    "ts-jest": "^27.0.7"
+    "ts-jest": "29.0.5"
   }
 }

--- a/libs/fixtures/package.json
+++ b/libs/fixtures/package.json
@@ -62,7 +62,7 @@
     "lint-staged": "^11.0.0",
     "prettier": "2.6.2",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^27.0.7",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3"
   },
   "packageManager": "pnpm@8.1.0"

--- a/libs/grout/package.json
+++ b/libs/grout/package.json
@@ -58,7 +58,7 @@
     "lint-staged": "^11.0.0",
     "prettier": "2.6.2",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^27.0.7",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3"
   },
   "packageManager": "pnpm@8.1.0"

--- a/libs/grout/test-utils/package.json
+++ b/libs/grout/test-utils/package.json
@@ -53,7 +53,7 @@
     "lint-staged": "^11.0.0",
     "prettier": "2.6.2",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^27.0.7",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3"
   },
   "peerDependencies": {

--- a/libs/image-utils/package.json
+++ b/libs/image-utils/package.json
@@ -49,7 +49,7 @@
     "jest-watch-typeahead": "0.6.4",
     "prettier": "2.6.2",
     "tmp": "^0.2.1",
-    "ts-jest": "^28.0.5",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3"
   }
 }

--- a/libs/logging/package.json
+++ b/libs/logging/package.json
@@ -72,7 +72,7 @@
     "mockdate": "^3.0.2",
     "prettier": "2.6.2",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^27.0.7",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3"
   },
   "packageManager": "pnpm@8.1.0"

--- a/libs/message-coder/package.json
+++ b/libs/message-coder/package.json
@@ -39,7 +39,7 @@
     "jest-junit": "^14.0.1",
     "jest-watch-typeahead": "0.6.4",
     "prettier": "2.6.2",
-    "ts-jest": "^29.0.5",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3"
   },
   "packageManager": "pnpm@8.1.0"

--- a/libs/monorepo-utils/package.json
+++ b/libs/monorepo-utils/package.json
@@ -53,7 +53,7 @@
     "lint-staged": "^11.0.0",
     "prettier": "2.6.2",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^27.0.7",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3"
   },
   "packageManager": "pnpm@8.1.0"

--- a/libs/res-to-ts/package.json
+++ b/libs/res-to-ts/package.json
@@ -48,7 +48,7 @@
     "jest": "^27.5.1",
     "jest-junit": "^14.0.1",
     "jest-watch-typeahead": "^0.6.4",
-    "ts-jest": "^27.1.3",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3"
   }
 }

--- a/libs/test-utils/package.json
+++ b/libs/test-utils/package.json
@@ -71,7 +71,7 @@
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^27.0.7",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3"
   },
   "packageManager": "pnpm@8.1.0"

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -72,7 +72,7 @@
     "lint-staged": "^11.0.0",
     "prettier": "2.6.2",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^29.0.5",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3"
   },
   "packageManager": "pnpm@8.1.0"

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -135,7 +135,7 @@
     "stylelint-config-prettier": "^8.0.1",
     "stylelint-config-styled-components": "^0.1.1",
     "stylelint-processor-styled-components": "^1.9.0",
-    "ts-jest": "^27.0.7",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3",
     "util": "^0.12.4",
     "vite": "^4.0.4"

--- a/libs/usb-drive/package.json
+++ b/libs/usb-drive/package.json
@@ -60,7 +60,7 @@
     "lint-staged": "^11.0.0",
     "prettier": "2.6.2",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^27.0.7",
+    "ts-jest": "29.0.5",
     "typescript": "4.6.3"
   },
   "packageManager": "pnpm@8.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,8 +288,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       ts-jest:
-        specifier: ^26.4.4
-        version: 26.5.6(jest@26.6.3)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -787,8 +787,8 @@ importers:
         specifier: ^1.10.0
         version: 1.10.0
       ts-jest:
-        specifier: ^28.0.8
-        version: 28.0.8(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       vite:
         specifier: ^2.9.12
         version: 2.9.13
@@ -1108,7 +1108,7 @@ importers:
         version: 6.1.1
       ts-jest:
         specifier: 29.0.5
-        version: 29.0.5(@babel/core@7.12.3)(@jest/types@29.5.0)(esbuild@0.14.42)(jest@29.5.0)(typescript@4.6.3)
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -1218,8 +1218,8 @@ importers:
         specifier: ^5.2.1
         version: 5.2.3(react-dom@17.0.1)(react-is@18.2.0)(react@17.0.1)
       ts-jest:
-        specifier: ^26.1.3
-        version: 26.5.6(jest@26.6.3)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -1692,8 +1692,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       ts-jest:
-        specifier: ^26.5.6
-        version: 26.5.6(jest@26.6.3)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       vite:
         specifier: ^2.9.12
         version: 2.9.13
@@ -1843,8 +1843,8 @@ importers:
         specifier: ^1.50.0
         version: 1.53.1
       ts-jest:
-        specifier: ^26.4.4
-        version: 26.5.6(jest@26.6.3)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -2210,8 +2210,8 @@ importers:
         specifier: ^1.10.0
         version: 1.10.0
       ts-jest:
-        specifier: '26'
-        version: 26.5.6(jest@26.6.0)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       vite:
         specifier: ^2.9.12
         version: 2.9.13
@@ -2528,7 +2528,7 @@ importers:
         version: 6.1.1
       ts-jest:
         specifier: 29.0.5
-        version: 29.0.5(@babel/core@7.12.3)(@jest/types@29.5.0)(esbuild@0.14.42)(jest@29.5.0)(typescript@4.6.3)
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -2792,8 +2792,8 @@ importers:
         specifier: ^1.9.0
         version: 1.10.0
       ts-jest:
-        specifier: ^26.5.6
-        version: 26.5.6(jest@26.6.3)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       vite:
         specifier: ^2.9.12
         version: 2.9.13
@@ -2980,8 +2980,8 @@ importers:
         specifier: ^1.50.0
         version: 1.53.1
       ts-jest:
-        specifier: ^27.0.7
-        version: 27.1.3(@babel/core@7.12.3)(@types/jest@27.4.1)(esbuild@0.16.17)(jest@27.5.1)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -3107,8 +3107,8 @@ importers:
         specifier: ^1.50.0
         version: 1.53.1
       ts-jest:
-        specifier: ^27.0.7
-        version: 27.1.5(@babel/core@7.12.3)(@types/jest@27.4.1)(esbuild@0.14.42)(jest@27.5.1)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -3267,8 +3267,8 @@ importers:
         specifier: ^1.50.0
         version: 1.53.1
       ts-jest:
-        specifier: ^27.0.7
-        version: 27.1.5(@babel/core@7.12.3)(@types/jest@27.4.1)(esbuild@0.16.17)(jest@27.5.1)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -3361,8 +3361,8 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       ts-jest:
-        specifier: ^27.0.7
-        version: 27.0.7(@babel/core@7.12.3)(@types/jest@27.0.3)(jest@27.3.1)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -3458,8 +3458,8 @@ importers:
         specifier: ^0.6.4
         version: 0.6.5(jest@29.5.0)
       ts-jest:
-        specifier: ^29.0.5
-        version: 29.0.5(@babel/core@7.12.3)(@jest/types@29.5.0)(esbuild@0.17.11)(jest@29.5.0)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -3609,8 +3609,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       ts-jest:
-        specifier: ^27.0.7
-        version: 27.0.7(@babel/core@7.12.3)(@types/jest@27.0.3)(jest@27.3.1)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -3679,8 +3679,8 @@ importers:
         specifier: ^1.50.0
         version: 1.53.1
       ts-jest:
-        specifier: ^27.0.7
-        version: 27.1.5(@babel/core@7.12.3)(@types/jest@27.4.1)(esbuild@0.16.17)(jest@27.5.1)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -3764,8 +3764,8 @@ importers:
         specifier: ^1.50.0
         version: 1.53.1
       ts-jest:
-        specifier: ^27.0.7
-        version: 27.1.1(@babel/core@7.12.3)(@types/jest@27.0.3)(esbuild@0.16.17)(jest@27.4.5)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -3898,7 +3898,7 @@ importers:
         version: 0.6.5(jest@29.4.3)
       ts-jest:
         specifier: 29.0.5
-        version: 29.0.5(@babel/core@7.12.3)(@jest/types@27.5.1)(esbuild@0.14.25)(jest@29.4.3)(typescript@4.6.3)
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -4009,8 +4009,8 @@ importers:
         specifier: 2.6.2
         version: 2.6.2
       ts-jest:
-        specifier: ^29.0.5
-        version: 29.0.5(@babel/core@7.12.3)(@jest/types@27.5.1)(esbuild@0.14.25)(jest@29.4.3)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -4116,7 +4116,7 @@ importers:
         version: 2.6.2
       ts-jest:
         specifier: 29.0.5
-        version: 29.0.5(@babel/core@7.12.3)(@jest/types@27.5.1)(esbuild@0.14.25)(jest@29.4.3)(typescript@4.6.3)
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -4227,8 +4227,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       ts-jest:
-        specifier: ^28.0.8
-        version: 28.0.8(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -4312,8 +4312,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       ts-jest:
-        specifier: ^28.0.5
-        version: 28.0.8(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -4409,8 +4409,8 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       ts-jest:
-        specifier: ^27.0.7
-        version: 27.1.3(@babel/core@7.12.3)(@types/jest@27.4.1)(esbuild@0.16.17)(jest@27.5.1)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -4542,8 +4542,8 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       ts-jest:
-        specifier: ^27.0.7
-        version: 27.1.3(@babel/core@7.12.3)(@types/jest@27.4.1)(esbuild@0.16.17)(jest@27.5.1)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -4636,8 +4636,8 @@ importers:
         specifier: 17.0.1
         version: 17.0.1
       ts-jest:
-        specifier: ^27.0.7
-        version: 27.0.7(@babel/core@7.12.3)(@types/jest@27.0.3)(jest@27.3.1)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
 
   libs/fixtures:
     dependencies:
@@ -4715,8 +4715,8 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       ts-jest:
-        specifier: ^27.0.7
-        version: 27.0.7(@babel/core@7.12.3)(@types/jest@27.0.3)(jest@27.3.1)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -4800,8 +4800,8 @@ importers:
         specifier: ^1.50.0
         version: 1.53.1
       ts-jest:
-        specifier: ^27.0.7
-        version: 27.1.5(@babel/core@7.12.3)(@types/jest@27.4.1)(esbuild@0.16.17)(jest@27.5.1)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -4870,8 +4870,8 @@ importers:
         specifier: ^1.50.0
         version: 1.53.1
       ts-jest:
-        specifier: ^27.0.7
-        version: 27.1.5(@babel/core@7.12.3)(@types/jest@27.4.1)(esbuild@0.16.17)(jest@27.5.1)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -4964,8 +4964,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       ts-jest:
-        specifier: ^28.0.5
-        version: 28.0.7(@babel/core@7.12.3)(@jest/types@28.1.3)(esbuild@0.16.17)(jest@28.1.3)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -5082,8 +5082,8 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       ts-jest:
-        specifier: ^27.0.7
-        version: 27.0.7(@babel/core@7.12.3)(@types/jest@27.0.3)(jest@27.3.1)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -5146,8 +5146,8 @@ importers:
         specifier: 2.6.2
         version: 2.6.2
       ts-jest:
-        specifier: ^29.0.5
-        version: 29.0.5(@babel/core@7.12.3)(@jest/types@27.5.1)(esbuild@0.14.25)(jest@29.4.3)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -5213,8 +5213,8 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       ts-jest:
-        specifier: ^27.0.7
-        version: 27.1.3(@babel/core@7.12.3)(@types/jest@27.4.1)(esbuild@0.16.17)(jest@27.5.1)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -5295,8 +5295,8 @@ importers:
         specifier: ^0.6.4
         version: 0.6.5(jest@27.5.1)
       ts-jest:
-        specifier: ^27.1.3
-        version: 27.1.3(@babel/core@7.12.3)(@types/jest@27.4.1)(esbuild@0.14.27)(jest@27.5.1)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -5413,8 +5413,8 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       ts-jest:
-        specifier: ^27.0.7
-        version: 27.0.7(@babel/core@7.12.3)(@types/jest@27.0.3)(jest@27.3.1)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -5522,8 +5522,8 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       ts-jest:
-        specifier: ^29.0.5
-        version: 29.0.5(@babel/core@7.12.3)(@jest/types@27.5.1)(esbuild@0.14.25)(jest@29.4.3)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -5820,8 +5820,8 @@ importers:
         specifier: ^1.9.0
         version: 1.10.0
       ts-jest:
-        specifier: ^27.0.7
-        version: 27.0.7(@babel/core@7.12.3)(@types/jest@27.0.3)(jest@27.3.1)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -5917,8 +5917,8 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       ts-jest:
-        specifier: ^27.0.7
-        version: 27.1.3(@babel/core@7.12.3)(@types/jest@27.4.1)(esbuild@0.17.11)(jest@27.5.1)(typescript@4.6.3)
+        specifier: 29.0.5
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -6063,7 +6063,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.0.5
-        version: 29.0.5(@babel/core@7.12.3)(@jest/types@27.5.1)(esbuild@0.14.25)(jest@29.4.3)(typescript@4.6.3)
+        version: 29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3)
       typescript:
         specifier: 4.6.3
         version: 4.6.3
@@ -9240,7 +9240,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-arm64@0.17.11:
@@ -9276,7 +9275,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-arm@0.17.11:
@@ -9303,7 +9301,6 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-x64@0.17.11:
@@ -9330,7 +9327,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-arm64@0.17.11:
@@ -9357,7 +9353,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-x64@0.17.11:
@@ -9384,7 +9379,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-arm64@0.17.11:
@@ -9411,7 +9405,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-x64@0.17.11:
@@ -9438,7 +9431,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-arm64@0.17.11:
@@ -9465,7 +9457,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-arm@0.17.11:
@@ -9492,7 +9483,6 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ia32@0.17.11:
@@ -9537,7 +9527,6 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-loong64@0.17.11:
@@ -9564,7 +9553,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-mips64el@0.17.11:
@@ -9591,7 +9579,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ppc64@0.17.11:
@@ -9618,7 +9605,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-riscv64@0.17.11:
@@ -9645,7 +9631,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-s390x@0.17.11:
@@ -9672,7 +9657,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-x64@0.17.11:
@@ -9699,7 +9683,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/netbsd-x64@0.17.11:
@@ -9726,7 +9709,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/openbsd-x64@0.17.11:
@@ -9753,7 +9735,6 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/sunos-x64@0.17.11:
@@ -9780,7 +9761,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-arm64@0.17.11:
@@ -9807,7 +9787,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-ia32@0.17.11:
@@ -9834,7 +9813,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-x64@0.17.11:
@@ -10773,7 +10751,6 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@sinclair/typebox': 0.24.51
-    dev: true
 
   /@jest/schemas@29.4.3:
     resolution: {integrity: sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==}
@@ -11065,7 +11042,6 @@ packages:
       '@types/node': 16.18.23
       '@types/yargs': 17.0.12
       chalk: 4.1.2
-    dev: true
 
   /@jest/types@29.4.2:
     resolution: {integrity: sha512-CKlngyGP0fwlgC1BRUtPZSiWLBhyS9dKwKmyGxk8Z6M82LBEGB2aLQSg+U1MyLsU+M7UjnlLllBM2BLWKVm/Uw==}
@@ -11319,7 +11295,6 @@ packages:
 
   /@sinclair/typebox@0.24.51:
     resolution: {integrity: sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==}
-    dev: true
 
   /@sinclair/typebox@0.25.21:
     resolution: {integrity: sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g==}
@@ -13416,7 +13391,6 @@ packages:
     resolution: {integrity: sha512-Nz4MPhecOFArtm81gFQvQqdV7XYCrWKx5uUt6GNHredFHn1i2mtWqXTON7EPXMtNi1qjtjEM/VCHDhcHsAMLXQ==}
     dependencies:
       '@types/yargs-parser': 21.0.0
-    dev: true
 
   /@types/yargs@17.0.22:
     resolution: {integrity: sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==}
@@ -18899,7 +18873,6 @@ packages:
       '@esbuild/win32-arm64': 0.16.17
       '@esbuild/win32-ia32': 0.16.17
       '@esbuild/win32-x64': 0.16.17
-    dev: true
 
   /esbuild@0.17.11:
     resolution: {integrity: sha512-pAMImyokbWDtnA/ufPxjQg0fYo2DDuzAlqwnDvbXqHLphe+m80eF++perYKVm8LeTuj2zUuFXC+xgSVxyoHUdg==}
@@ -24260,30 +24233,6 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /jest-util@27.3.1:
-    resolution: {integrity: sha512-8fg+ifEH3GDryLQf/eKZck1DEs2YuVPBCMOaHQxVVLmQwl/CDhWzrvChTX4efLZxGrw+AA0mSXv78cyytBt/uw==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    dependencies:
-      '@jest/types': 27.5.1
-      '@types/node': 16.18.23
-      chalk: 4.1.2
-      ci-info: 3.3.2
-      graceful-fs: 4.2.10
-      picomatch: 2.3.1
-    dev: true
-
-  /jest-util@27.4.2:
-    resolution: {integrity: sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    dependencies:
-      '@jest/types': 27.5.1
-      '@types/node': 16.18.23
-      chalk: 4.1.2
-      ci-info: 3.3.2
-      graceful-fs: 4.2.10
-      picomatch: 2.3.1
-    dev: true
-
   /jest-util@27.5.1:
     resolution: {integrity: sha512-Kv2o/8jNvX1MQ0KGtw480E/w4fBCDOnH6+6DmeKi6LZUIlKA5kwY0YNdlzaWTiVgxqAqik11QyxDOKk543aKXw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -24301,18 +24250,6 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 16.18.23
-      chalk: 4.1.2
-      ci-info: 3.3.2
-      graceful-fs: 4.2.10
-      picomatch: 2.3.1
-    dev: true
-
-  /jest-util@29.4.3:
-    resolution: {integrity: sha512-ToSGORAz4SSSoqxDSylWX8JzkOQR7zoBtNRsA7e+1WUX5F8jrOwaNpuh1YfJHJKDHXLHmObv5eOjejUd+/Ws+Q==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@jest/types': 29.5.0
       '@types/node': 16.18.23
       chalk: 4.1.2
       ci-info: 3.3.2
@@ -24761,7 +24698,6 @@ packages:
       - supports-color
       - ts-node
       - utf-8-validate
-    dev: true
 
   /jest@26.6.3:
     resolution: {integrity: sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==}
@@ -24777,6 +24713,7 @@ packages:
       - supports-color
       - ts-node
       - utf-8-validate
+    dev: true
 
   /jest@27.3.1(canvas@2.9.1):
     resolution: {integrity: sha512-U2AX0AgQGd5EzMsiZpYt8HyZ+nSVIh5ujQ9CPp9EQZJMjXIiSZpJNweZl0swatKRoqHWgGKM3zaSwm4Zaz87ng==}
@@ -25184,20 +25121,6 @@ packages:
     hasBin: true
     dependencies:
       minimist: 1.2.6
-
-  /json5@2.2.0:
-    resolution: {integrity: sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==}
-    engines: {node: '>=6'}
-    hasBin: true
-    dependencies:
-      minimist: 1.2.6
-    dev: true
-
-  /json5@2.2.1:
-    resolution: {integrity: sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==}
-    engines: {node: '>=6'}
-    hasBin: true
-    dev: true
 
   /json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -30873,343 +30796,16 @@ packages:
       typescript: 4.6.3
     dev: true
 
-  /ts-jest@26.5.6(jest@26.6.0)(typescript@4.6.3):
-    resolution: {integrity: sha512-rua+rCP8DxpA8b4DQD/6X2HQS8Zy/xzViVYfEs2OQu68tkCuKLV0Md8pmX55+W24uRIyAsf/BajRfxOs+R2MKA==}
-    engines: {node: '>= 10'}
-    hasBin: true
-    peerDependencies:
-      jest: '>=26 <27'
-      typescript: '>=3.8 <5.0'
-    dependencies:
-      bs-logger: 0.2.6
-      buffer-from: 1.1.2
-      fast-json-stable-stringify: 2.1.0
-      jest: 26.6.0(canvas@2.9.1)
-      jest-util: 26.6.2
-      json5: 2.2.3
-      lodash: 4.17.21
-      make-error: 1.3.6
-      mkdirp: 1.0.4
-      semver: 7.3.7
-      typescript: 4.6.3
-      yargs-parser: 20.2.9
-    dev: true
-
-  /ts-jest@26.5.6(jest@26.6.3)(typescript@4.6.3):
-    resolution: {integrity: sha512-rua+rCP8DxpA8b4DQD/6X2HQS8Zy/xzViVYfEs2OQu68tkCuKLV0Md8pmX55+W24uRIyAsf/BajRfxOs+R2MKA==}
-    engines: {node: '>= 10'}
-    hasBin: true
-    peerDependencies:
-      jest: '>=26 <27'
-      typescript: '>=3.8 <5.0'
-    dependencies:
-      bs-logger: 0.2.6
-      buffer-from: 1.1.2
-      fast-json-stable-stringify: 2.1.0
-      jest: 26.6.3
-      jest-util: 26.6.2
-      json5: 2.2.3
-      lodash: 4.17.21
-      make-error: 1.3.6
-      mkdirp: 1.0.4
-      semver: 7.3.7
-      typescript: 4.6.3
-      yargs-parser: 20.2.9
-
-  /ts-jest@27.0.7(@babel/core@7.12.3)(@types/jest@27.0.3)(jest@27.3.1)(typescript@4.6.3):
-    resolution: {integrity: sha512-O41shibMqzdafpuP+CkrOL7ykbmLh+FqQrXEmV9CydQ5JBk0Sj0uAEF5TNNe94fZWKm3yYvWa/IbyV4Yg1zK2Q==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+  /ts-jest@29.0.5(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3):
+    resolution: {integrity: sha512-PL3UciSgIpQ7f6XjVOmbi96vmDHUqAyqDr8YxzopDqX3kfgYtX1cuNeBjP+L9sFXi6nzsGGA6R3fP3DDDJyrxA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
     peerDependencies:
       '@babel/core': '>=7.0.0-beta.0 <8'
-      '@types/jest': ^27.0.0
-      babel-jest: '>=27.0.0 <28'
-      jest: ^27.0.0
-      typescript: '>=3.8 <5.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@types/jest':
-        optional: true
-      babel-jest:
-        optional: true
-    dependencies:
-      '@babel/core': 7.12.3
-      '@types/jest': 27.0.3
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      jest: 27.3.1(canvas@2.9.1)
-      jest-util: 27.3.1
-      json5: 2.2.0
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.3.7
-      typescript: 4.6.3
-      yargs-parser: 20.2.9
-    dev: true
-
-  /ts-jest@27.1.1(@babel/core@7.12.3)(@types/jest@27.0.3)(esbuild@0.16.17)(jest@27.4.5)(typescript@4.6.3):
-    resolution: {integrity: sha512-Ds0VkB+cB+8g2JUmP/GKWndeZcCKrbe6jzolGrVWdqVUFByY/2KDHqxJ7yBSon7hDB1TA4PXxjfZ+JjzJisvgA==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@types/jest': ^27.0.0
-      babel-jest: '>=27.0.0 <28'
-      esbuild: ~0.14.0
-      jest: ^27.0.0
-      typescript: '>=3.8 <5.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@types/jest':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      '@babel/core': 7.12.3
-      '@types/jest': 27.0.3
-      bs-logger: 0.2.6
-      esbuild: 0.16.17
-      fast-json-stable-stringify: 2.1.0
-      jest: 27.4.5
-      jest-util: 27.4.2
-      json5: 2.2.0
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.3.7
-      typescript: 4.6.3
-      yargs-parser: 20.2.9
-    dev: true
-
-  /ts-jest@27.1.3(@babel/core@7.12.3)(@types/jest@27.4.1)(esbuild@0.14.27)(jest@27.5.1)(typescript@4.6.3):
-    resolution: {integrity: sha512-6Nlura7s6uM9BVUAoqLH7JHyMXjz8gluryjpPXxr3IxZdAXnU6FhjvVLHFtfd1vsE1p8zD1OJfskkc0jhTSnkA==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@types/jest': ^27.0.0
-      babel-jest: '>=27.0.0 <28'
-      esbuild: ~0.14.0
-      jest: ^27.0.0
-      typescript: '>=3.8 <5.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@types/jest':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      '@babel/core': 7.12.3
-      '@types/jest': 27.4.1
-      bs-logger: 0.2.6
-      esbuild: 0.14.27
-      fast-json-stable-stringify: 2.1.0
-      jest: 27.5.1
-      jest-util: 27.5.1
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.3.2
-      typescript: 4.6.3
-      yargs-parser: 20.2.9
-    dev: true
-
-  /ts-jest@27.1.3(@babel/core@7.12.3)(@types/jest@27.4.1)(esbuild@0.16.17)(jest@27.5.1)(typescript@4.6.3):
-    resolution: {integrity: sha512-6Nlura7s6uM9BVUAoqLH7JHyMXjz8gluryjpPXxr3IxZdAXnU6FhjvVLHFtfd1vsE1p8zD1OJfskkc0jhTSnkA==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@types/jest': ^27.0.0
-      babel-jest: '>=27.0.0 <28'
-      esbuild: ~0.14.0
-      jest: ^27.0.0
-      typescript: '>=3.8 <5.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@types/jest':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      '@babel/core': 7.12.3
-      '@types/jest': 27.4.1
-      bs-logger: 0.2.6
-      esbuild: 0.16.17
-      fast-json-stable-stringify: 2.1.0
-      jest: 27.5.1
-      jest-util: 27.5.1
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.3.2
-      typescript: 4.6.3
-      yargs-parser: 20.2.9
-    dev: true
-
-  /ts-jest@27.1.3(@babel/core@7.12.3)(@types/jest@27.4.1)(esbuild@0.17.11)(jest@27.5.1)(typescript@4.6.3):
-    resolution: {integrity: sha512-6Nlura7s6uM9BVUAoqLH7JHyMXjz8gluryjpPXxr3IxZdAXnU6FhjvVLHFtfd1vsE1p8zD1OJfskkc0jhTSnkA==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@types/jest': ^27.0.0
-      babel-jest: '>=27.0.0 <28'
-      esbuild: ~0.14.0
-      jest: ^27.0.0
-      typescript: '>=3.8 <5.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@types/jest':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      '@babel/core': 7.12.3
-      '@types/jest': 27.4.1
-      bs-logger: 0.2.6
-      esbuild: 0.17.11
-      fast-json-stable-stringify: 2.1.0
-      jest: 27.5.1
-      jest-util: 27.5.1
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.3.2
-      typescript: 4.6.3
-      yargs-parser: 20.2.9
-    dev: true
-
-  /ts-jest@27.1.5(@babel/core@7.12.3)(@types/jest@27.4.1)(esbuild@0.14.42)(jest@27.5.1)(typescript@4.6.3):
-    resolution: {integrity: sha512-Xv6jBQPoBEvBq/5i2TeSG9tt/nqkbpcurrEG1b+2yfBrcJelOZF9Ml6dmyMh7bcW9JyFbRYpR5rxROSlBLTZHA==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@types/jest': ^27.0.0
-      babel-jest: '>=27.0.0 <28'
+      '@jest/types': ^29.0.0
+      babel-jest: ^29.0.0
       esbuild: '*'
-      jest: ^27.0.0
-      typescript: '>=3.8 <5.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@types/jest':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      '@babel/core': 7.12.3
-      '@types/jest': 27.4.1
-      bs-logger: 0.2.6
-      esbuild: 0.14.42
-      fast-json-stable-stringify: 2.1.0
-      jest: 27.5.1
-      jest-util: 27.5.1
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.3.7
-      typescript: 4.6.3
-      yargs-parser: 20.2.9
-    dev: true
-
-  /ts-jest@27.1.5(@babel/core@7.12.3)(@types/jest@27.4.1)(esbuild@0.16.17)(jest@27.5.1)(typescript@4.6.3):
-    resolution: {integrity: sha512-Xv6jBQPoBEvBq/5i2TeSG9tt/nqkbpcurrEG1b+2yfBrcJelOZF9Ml6dmyMh7bcW9JyFbRYpR5rxROSlBLTZHA==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@types/jest': ^27.0.0
-      babel-jest: '>=27.0.0 <28'
-      esbuild: '*'
-      jest: ^27.0.0
-      typescript: '>=3.8 <5.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@types/jest':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      '@babel/core': 7.12.3
-      '@types/jest': 27.4.1
-      bs-logger: 0.2.6
-      esbuild: 0.16.17
-      fast-json-stable-stringify: 2.1.0
-      jest: 27.5.1
-      jest-util: 27.5.1
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.3.7
-      typescript: 4.6.3
-      yargs-parser: 20.2.9
-    dev: true
-
-  /ts-jest@28.0.7(@babel/core@7.12.3)(@jest/types@28.1.3)(esbuild@0.16.17)(jest@28.1.3)(typescript@4.6.3):
-    resolution: {integrity: sha512-wWXCSmTwBVmdvWrOpYhal79bDpioDy4rTT+0vyUnE3ZzM7LOAAGG9NXwzkEL/a516rQEgnMmS/WKP9jBPCVJyA==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@jest/types': ^28.0.0
-      babel-jest: ^28.0.0
-      esbuild: '*'
-      jest: ^28.0.0
-      typescript: '>=4.3'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@jest/types':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      '@babel/core': 7.12.3
-      '@jest/types': 28.1.3
-      bs-logger: 0.2.6
-      esbuild: 0.16.17
-      fast-json-stable-stringify: 2.1.0
-      jest: 28.1.3(@types/node@16.18.23)
-      jest-util: 28.1.3
-      json5: 2.2.1
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.3.7
-      typescript: 4.6.3
-      yargs-parser: 21.0.1
-    dev: true
-
-  /ts-jest@28.0.8(@babel/core@7.12.3)(@jest/types@28.1.3)(babel-jest@26.6.3)(esbuild@0.16.17)(jest@26.6.0)(typescript@4.6.3):
-    resolution: {integrity: sha512-5FaG0lXmRPzApix8oFG8RKjAz4ehtm8yMKOTy5HX3fY6W8kmvOrmcY0hKDElW52FJov+clhUbrKAqofnj4mXTg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@jest/types': ^28.0.0
-      babel-jest: ^28.0.0
-      esbuild: '*'
-      jest: ^28.0.0
+      jest: ^29.0.0
       typescript: '>=4.3'
     peerDependenciesMeta:
       '@babel/core':
@@ -31228,122 +30824,13 @@ packages:
       esbuild: 0.16.17
       fast-json-stable-stringify: 2.1.0
       jest: 26.6.0(canvas@2.9.1)
-      jest-util: 28.1.3
-      json5: 2.2.1
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.3.7
-      typescript: 4.6.3
-      yargs-parser: 21.1.1
-    dev: true
-
-  /ts-jest@29.0.5(@babel/core@7.12.3)(@jest/types@27.5.1)(esbuild@0.14.25)(jest@29.4.3)(typescript@4.6.3):
-    resolution: {integrity: sha512-PL3UciSgIpQ7f6XjVOmbi96vmDHUqAyqDr8YxzopDqX3kfgYtX1cuNeBjP+L9sFXi6nzsGGA6R3fP3DDDJyrxA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@jest/types': ^29.0.0
-      babel-jest: ^29.0.0
-      esbuild: '*'
-      jest: ^29.0.0
-      typescript: '>=4.3'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@jest/types':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      '@babel/core': 7.12.3
-      '@jest/types': 27.5.1
-      bs-logger: 0.2.6
-      esbuild: 0.14.25
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.4.3(@types/node@16.18.23)
-      jest-util: 29.4.3
+      jest-util: 29.5.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.3.7
+      semver: 7.3.2
       typescript: 4.6.3
       yargs-parser: 21.1.1
-    dev: true
-
-  /ts-jest@29.0.5(@babel/core@7.12.3)(@jest/types@29.5.0)(esbuild@0.14.42)(jest@29.5.0)(typescript@4.6.3):
-    resolution: {integrity: sha512-PL3UciSgIpQ7f6XjVOmbi96vmDHUqAyqDr8YxzopDqX3kfgYtX1cuNeBjP+L9sFXi6nzsGGA6R3fP3DDDJyrxA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@jest/types': ^29.0.0
-      babel-jest: ^29.0.0
-      esbuild: '*'
-      jest: ^29.0.0
-      typescript: '>=4.3'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@jest/types':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      '@babel/core': 7.12.3
-      '@jest/types': 29.5.0
-      bs-logger: 0.2.6
-      esbuild: 0.14.42
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.5.0(@types/node@16.18.23)
-      jest-util: 29.4.3
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.3.7
-      typescript: 4.6.3
-      yargs-parser: 21.1.1
-    dev: true
-
-  /ts-jest@29.0.5(@babel/core@7.12.3)(@jest/types@29.5.0)(esbuild@0.17.11)(jest@29.5.0)(typescript@4.6.3):
-    resolution: {integrity: sha512-PL3UciSgIpQ7f6XjVOmbi96vmDHUqAyqDr8YxzopDqX3kfgYtX1cuNeBjP+L9sFXi6nzsGGA6R3fP3DDDJyrxA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@jest/types': ^29.0.0
-      babel-jest: ^29.0.0
-      esbuild: '*'
-      jest: ^29.0.0
-      typescript: '>=4.3'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@jest/types':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      '@babel/core': 7.12.3
-      '@jest/types': 29.5.0
-      bs-logger: 0.2.6
-      esbuild: 0.17.11
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.5.0(@types/node@16.18.23)
-      jest-util: 29.4.3
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.3.7
-      typescript: 4.6.3
-      yargs-parser: 21.1.1
-    dev: true
 
   /ts-morph@12.2.0:
     resolution: {integrity: sha512-WHXLtFDcIRwoqaiu0elAoZ/AmI+SwwDafnPKjgJmdwJ2gRVO0jMKBt88rV2liT/c6MTsXyuWbGFiHe9MRddWJw==}
@@ -32765,11 +32252,6 @@ packages:
   /yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
-
-  /yargs-parser@21.0.1:
-    resolution: {integrity: sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==}
-    engines: {node: '>=12'}
-    dev: true
 
   /yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}

--- a/script/src/validate-monorepo/validation/index.ts
+++ b/script/src/validate-monorepo/validation/index.ts
@@ -37,6 +37,7 @@ export async function* validateMonorepo(): AsyncGenerator<ValidationIssue> {
       'prettier',
       'react',
       'react-dom',
+      'ts-jest',
       'typescript',
     ],
     workspacePackages,


### PR DESCRIPTION
## Overview
This may help with an out-of-memory issue we've been seeing in CI that may be related to the version of `ts-jest` or one of its dependencies.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
