### PR TITLE
apps/scan/backend: Ensure scanner mocks simulate paper status after scan

### DIFF
--- a/apps/scan/backend/src/scanners/custom/app_scan.test.ts
+++ b/apps/scan/backend/src/scanners/custom/app_scan.test.ts
@@ -32,7 +32,11 @@ import {
   waitForStatus,
 } from '../../../test/helpers/shared_helpers';
 import { SheetInterpretation } from '../../types';
-import { ballotImages, withApp } from '../../../test/helpers/custom_helpers';
+import {
+  ballotImages,
+  simulateScan,
+  withApp,
+} from '../../../test/helpers/custom_helpers';
 
 jest.setTimeout(20_000);
 /**
@@ -88,10 +92,9 @@ test('configure and scan hmpb', async () => {
         type: 'ValidSheet',
       };
 
-      mockScanner.scan.mockResolvedValue(ok(await ballotImages.completeHmpb()));
+      simulateScan(mockScanner, await ballotImages.completeHmpb());
       await apiClient.scanBallot();
       await expectStatus(apiClient, { state: 'scanning' });
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
       await waitForStatus(apiClient, {
         state: 'ready_to_accept',
         interpretation,
@@ -135,10 +138,9 @@ test('configure and scan bmd ballot', async () => {
         type: 'ValidSheet',
       };
 
-      mockScanner.scan.mockResolvedValue(ok(await ballotImages.completeBmd()));
+      simulateScan(mockScanner, await ballotImages.completeBmd());
       await apiClient.scanBallot();
       await expectStatus(apiClient, { state: 'scanning' });
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
       await waitForStatus(apiClient, {
         state: 'ready_to_accept',
         interpretation,
@@ -206,10 +208,9 @@ test('ballot needs review - return', async () => {
         ],
       };
 
-      mockScanner.scan.mockResolvedValue(ok(await ballotImages.overvoteHmpb()));
+      simulateScan(mockScanner, await ballotImages.overvoteHmpb());
       await apiClient.scanBallot();
       await expectStatus(apiClient, { state: 'scanning' });
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
       await waitForStatus(apiClient, { state: 'needs_review', interpretation });
 
       await apiClient.returnBallot();
@@ -262,12 +263,9 @@ test('invalid ballot rejected', async () => {
         reason: 'invalid_election_hash',
       };
 
-      mockScanner.scan.mockResolvedValue(
-        ok(await ballotImages.wrongElection())
-      );
+      simulateScan(mockScanner, await ballotImages.wrongElection());
       await apiClient.scanBallot();
       await expectStatus(apiClient, { state: 'scanning' });
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
       await waitForStatus(apiClient, {
         state: 'rejecting',
         interpretation,
@@ -307,10 +305,9 @@ test('blank sheet ballot rejected', async () => {
         reason: 'unknown',
       };
 
-      mockScanner.scan.mockResolvedValue(ok(await ballotImages.blankSheet()));
+      simulateScan(mockScanner, await ballotImages.blankSheet());
       await apiClient.scanBallot();
       await expectStatus(apiClient, { state: 'scanning' });
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
       await waitForStatus(apiClient, {
         state: 'rejecting',
         interpretation,

--- a/apps/scan/backend/src/scanners/custom/app_scan.test.ts
+++ b/apps/scan/backend/src/scanners/custom/app_scan.test.ts
@@ -94,7 +94,6 @@ test('configure and scan hmpb', async () => {
 
       simulateScan(mockScanner, await ballotImages.completeHmpb());
       await apiClient.scanBallot();
-      await expectStatus(apiClient, { state: 'scanning' });
       await waitForStatus(apiClient, {
         state: 'ready_to_accept',
         interpretation,
@@ -210,7 +209,6 @@ test('ballot needs review - return', async () => {
 
       simulateScan(mockScanner, await ballotImages.overvoteHmpb());
       await apiClient.scanBallot();
-      await expectStatus(apiClient, { state: 'scanning' });
       await waitForStatus(apiClient, { state: 'needs_review', interpretation });
 
       await apiClient.returnBallot();
@@ -265,7 +263,6 @@ test('invalid ballot rejected', async () => {
 
       simulateScan(mockScanner, await ballotImages.wrongElection());
       await apiClient.scanBallot();
-      await expectStatus(apiClient, { state: 'scanning' });
       await waitForStatus(apiClient, {
         state: 'rejecting',
         interpretation,
@@ -307,7 +304,6 @@ test('blank sheet ballot rejected', async () => {
 
       simulateScan(mockScanner, await ballotImages.blankSheet());
       await apiClient.scanBallot();
-      await expectStatus(apiClient, { state: 'scanning' });
       await waitForStatus(apiClient, {
         state: 'rejecting',
         interpretation,

--- a/apps/scan/backend/src/scanners/custom/app_scan_double_sheets.test.ts
+++ b/apps/scan/backend/src/scanners/custom/app_scan_double_sheets.test.ts
@@ -83,7 +83,6 @@ test('insert second ballot while first ballot is accepting', async () => {
 
       simulateScan(mockScanner, await ballotImages.completeBmd());
       await apiClient.scanBallot();
-      await expectStatus(apiClient, { state: 'scanning' });
       await waitForStatus(apiClient, {
         state: 'ready_to_accept',
         interpretation,
@@ -120,7 +119,6 @@ test('insert second ballot while first ballot needs review', async () => {
 
       simulateScan(mockScanner, await ballotImages.unmarkedHmpb());
       await apiClient.scanBallot();
-      await expectStatus(apiClient, { state: 'scanning' });
       await waitForStatus(apiClient, { state: 'needs_review', interpretation });
 
       mockScanner.getStatus.mockResolvedValue(

--- a/apps/scan/backend/src/scanners/custom/app_scan_double_sheets.test.ts
+++ b/apps/scan/backend/src/scanners/custom/app_scan_double_sheets.test.ts
@@ -9,7 +9,11 @@ import {
   waitForStatus,
 } from '../../../test/helpers/shared_helpers';
 import { SheetInterpretation } from '../../types';
-import { ballotImages, withApp } from '../../../test/helpers/custom_helpers';
+import {
+  ballotImages,
+  simulateScan,
+  withApp,
+} from '../../../test/helpers/custom_helpers';
 
 jest.setTimeout(20_000);
 
@@ -77,9 +81,8 @@ test('insert second ballot while first ballot is accepting', async () => {
       };
       mockInterpretation(interpreter, interpretation);
 
-      mockScanner.scan.mockResolvedValue(ok(await ballotImages.completeBmd()));
+      simulateScan(mockScanner, await ballotImages.completeBmd());
       await apiClient.scanBallot();
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
       await expectStatus(apiClient, { state: 'scanning' });
       await waitForStatus(apiClient, {
         state: 'ready_to_accept',
@@ -115,11 +118,9 @@ test('insert second ballot while first ballot needs review', async () => {
       const interpretation = needsReviewInterpretation;
       mockInterpretation(interpreter, interpretation);
 
-      mockScanner.scan.mockResolvedValue(ok(await ballotImages.unmarkedHmpb()));
+      simulateScan(mockScanner, await ballotImages.unmarkedHmpb());
       await apiClient.scanBallot();
       await expectStatus(apiClient, { state: 'scanning' });
-
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
       await waitForStatus(apiClient, { state: 'needs_review', interpretation });
 
       mockScanner.getStatus.mockResolvedValue(

--- a/apps/scan/backend/src/scanners/custom/app_scan_double_sheets.test.ts
+++ b/apps/scan/backend/src/scanners/custom/app_scan_double_sheets.test.ts
@@ -107,7 +107,11 @@ test('insert second ballot while first ballot is accepting', async () => {
 
 test('insert second ballot while first ballot needs review', async () => {
   await withApp(
-    {},
+    {
+      delays: {
+        DELAY_ACCEPTED_READY_FOR_NEXT_BALLOT: 3000,
+      },
+    },
     async ({ apiClient, mockScanner, interpreter, mockUsbDrive, mockAuth }) => {
       await configureApp(apiClient, mockUsbDrive, { mockAuth });
 

--- a/apps/scan/backend/src/scanners/custom/app_scan_jam.test.ts
+++ b/apps/scan/backend/src/scanners/custom/app_scan_jam.test.ts
@@ -8,7 +8,11 @@ import {
   waitForStatus,
 } from '../../../test/helpers/shared_helpers';
 import { SheetInterpretation } from '../../types';
-import { ballotImages, withApp } from '../../../test/helpers/custom_helpers';
+import {
+  ballotImages,
+  simulateScan,
+  withApp,
+} from '../../../test/helpers/custom_helpers';
 
 jest.setTimeout(20_000);
 
@@ -61,10 +65,9 @@ test('jam on accept', async () => {
       };
       mockInterpretation(interpreter, interpretation);
 
-      mockScanner.scan.mockResolvedValue(ok(await ballotImages.completeBmd()));
+      simulateScan(mockScanner, await ballotImages.completeBmd());
       await apiClient.scanBallot();
       await waitForStatus(apiClient, { state: 'scanning' });
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
       await waitForStatus(apiClient, {
         state: 'ready_to_accept',
         interpretation,
@@ -104,10 +107,9 @@ test('jam on return', async () => {
       const interpretation = needsReviewInterpretation;
       mockInterpretation(interpreter, interpretation);
 
-      mockScanner.scan.mockResolvedValue(ok(await ballotImages.unmarkedHmpb()));
+      simulateScan(mockScanner, await ballotImages.unmarkedHmpb());
       await apiClient.scanBallot();
       await expectStatus(apiClient, { state: 'scanning' });
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
       await waitForStatus(apiClient, { state: 'needs_review', interpretation });
 
       await apiClient.returnBallot();
@@ -138,12 +140,9 @@ test('jam on reject', async () => {
       };
       mockInterpretation(interpreter, interpretation);
 
-      mockScanner.scan.mockResolvedValue(
-        ok(await ballotImages.wrongElection())
-      );
+      simulateScan(mockScanner, await ballotImages.wrongElection());
       await apiClient.scanBallot();
       await expectStatus(apiClient, { state: 'scanning' });
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
       await waitForStatus(apiClient, {
         state: 'rejecting',
         interpretation,

--- a/apps/scan/backend/src/scanners/custom/app_scan_jam.test.ts
+++ b/apps/scan/backend/src/scanners/custom/app_scan_jam.test.ts
@@ -3,7 +3,6 @@ import { ok } from '@votingworks/basics';
 import { mocks } from '@votingworks/custom-scanner';
 import {
   configureApp,
-  expectStatus,
   mockInterpretation,
   waitForStatus,
 } from '../../../test/helpers/shared_helpers';
@@ -67,7 +66,6 @@ test('jam on accept', async () => {
 
       simulateScan(mockScanner, await ballotImages.completeBmd());
       await apiClient.scanBallot();
-      await waitForStatus(apiClient, { state: 'scanning' });
       await waitForStatus(apiClient, {
         state: 'ready_to_accept',
         interpretation,
@@ -109,7 +107,6 @@ test('jam on return', async () => {
 
       simulateScan(mockScanner, await ballotImages.unmarkedHmpb());
       await apiClient.scanBallot();
-      await expectStatus(apiClient, { state: 'scanning' });
       await waitForStatus(apiClient, { state: 'needs_review', interpretation });
 
       await apiClient.returnBallot();
@@ -142,7 +139,6 @@ test('jam on reject', async () => {
 
       simulateScan(mockScanner, await ballotImages.wrongElection());
       await apiClient.scanBallot();
-      await expectStatus(apiClient, { state: 'scanning' });
       await waitForStatus(apiClient, {
         state: 'rejecting',
         interpretation,

--- a/apps/scan/backend/src/scanners/custom/app_scan_power_off.test.ts
+++ b/apps/scan/backend/src/scanners/custom/app_scan_power_off.test.ts
@@ -3,7 +3,6 @@ import { ErrorCode, mocks } from '@votingworks/custom-scanner';
 import { err, ok } from '@votingworks/basics';
 import {
   configureApp,
-  expectStatus,
   mockInterpretation,
   waitForStatus,
 } from '../../../test/helpers/shared_helpers';
@@ -47,7 +46,6 @@ test('scanner powered off while scanning', async () => {
 
       simulateScan(mockScanner, await ballotImages.completeBmd());
       await apiClient.scanBallot();
-      await expectStatus(apiClient, { state: 'scanning' });
       mockScanner.getStatus.mockResolvedValue(err(ErrorCode.ScannerOffline));
       await waitForStatus(apiClient, { state: 'disconnected' });
 
@@ -73,7 +71,6 @@ test('scanner powered off while accepting', async () => {
 
       simulateScan(mockScanner, await ballotImages.completeBmd());
       await apiClient.scanBallot();
-      await expectStatus(apiClient, { state: 'scanning' });
       await waitForStatus(apiClient, {
         state: 'ready_to_accept',
         interpretation,
@@ -112,7 +109,6 @@ test('scanner powered off after accepting', async () => {
 
       simulateScan(mockScanner, await ballotImages.completeBmd());
       await apiClient.scanBallot();
-      await expectStatus(apiClient, { state: 'scanning' });
       await waitForStatus(apiClient, {
         state: 'ready_to_accept',
         interpretation,
@@ -158,7 +154,6 @@ test('scanner powered off while rejecting', async () => {
 
       simulateScan(mockScanner, await ballotImages.wrongElection());
       await apiClient.scanBallot();
-      await expectStatus(apiClient, { state: 'scanning' });
       await waitForStatus(apiClient, {
         state: 'rejecting',
         interpretation,
@@ -187,7 +182,6 @@ test('scanner powered off while returning', async () => {
 
       simulateScan(mockScanner, await ballotImages.unmarkedHmpb());
       await apiClient.scanBallot();
-      await expectStatus(apiClient, { state: 'scanning' });
       await waitForStatus(apiClient, { state: 'needs_review', interpretation });
 
       await apiClient.returnBallot();
@@ -219,7 +213,6 @@ test('scanner powered off after returning', async () => {
 
       simulateScan(mockScanner, await ballotImages.unmarkedHmpb());
       await apiClient.scanBallot();
-      await expectStatus(apiClient, { state: 'scanning' });
       await waitForStatus(apiClient, { state: 'needs_review', interpretation });
 
       await apiClient.returnBallot();

--- a/apps/scan/backend/src/scanners/custom/app_scan_power_off.test.ts
+++ b/apps/scan/backend/src/scanners/custom/app_scan_power_off.test.ts
@@ -8,7 +8,11 @@ import {
   waitForStatus,
 } from '../../../test/helpers/shared_helpers';
 import { SheetInterpretation } from '../../types';
-import { ballotImages, withApp } from '../../../test/helpers/custom_helpers';
+import {
+  ballotImages,
+  simulateScan,
+  withApp,
+} from '../../../test/helpers/custom_helpers';
 
 jest.setTimeout(20_000);
 
@@ -41,7 +45,7 @@ test('scanner powered off while scanning', async () => {
       mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
       await waitForStatus(apiClient, { state: 'ready_to_scan' });
 
-      mockScanner.scan.mockResolvedValue(ok(await ballotImages.completeBmd()));
+      simulateScan(mockScanner, await ballotImages.completeBmd());
       await apiClient.scanBallot();
       await expectStatus(apiClient, { state: 'scanning' });
       mockScanner.getStatus.mockResolvedValue(err(ErrorCode.ScannerOffline));
@@ -67,10 +71,9 @@ test('scanner powered off while accepting', async () => {
       };
       mockInterpretation(interpreter, interpretation);
 
-      mockScanner.scan.mockResolvedValue(ok(await ballotImages.completeBmd()));
+      simulateScan(mockScanner, await ballotImages.completeBmd());
       await apiClient.scanBallot();
       await expectStatus(apiClient, { state: 'scanning' });
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
       await waitForStatus(apiClient, {
         state: 'ready_to_accept',
         interpretation,
@@ -107,10 +110,9 @@ test('scanner powered off after accepting', async () => {
       };
       mockInterpretation(interpreter, interpretation);
 
-      mockScanner.scan.mockResolvedValue(ok(await ballotImages.completeBmd()));
+      simulateScan(mockScanner, await ballotImages.completeBmd());
       await apiClient.scanBallot();
       await expectStatus(apiClient, { state: 'scanning' });
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
       await waitForStatus(apiClient, {
         state: 'ready_to_accept',
         interpretation,
@@ -154,12 +156,9 @@ test('scanner powered off while rejecting', async () => {
       };
       mockInterpretation(interpreter, interpretation);
 
-      mockScanner.scan.mockResolvedValue(
-        ok(await ballotImages.wrongElection())
-      );
+      simulateScan(mockScanner, await ballotImages.wrongElection());
       await apiClient.scanBallot();
       await expectStatus(apiClient, { state: 'scanning' });
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
       await waitForStatus(apiClient, {
         state: 'rejecting',
         interpretation,
@@ -186,10 +185,9 @@ test('scanner powered off while returning', async () => {
       const interpretation = needsReviewInterpretation;
       mockInterpretation(interpreter, interpretation);
 
-      mockScanner.scan.mockResolvedValue(ok(await ballotImages.unmarkedHmpb()));
+      simulateScan(mockScanner, await ballotImages.unmarkedHmpb());
       await apiClient.scanBallot();
       await expectStatus(apiClient, { state: 'scanning' });
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
       await waitForStatus(apiClient, { state: 'needs_review', interpretation });
 
       await apiClient.returnBallot();
@@ -219,10 +217,9 @@ test('scanner powered off after returning', async () => {
       const interpretation = needsReviewInterpretation;
       mockInterpretation(interpreter, interpretation);
 
-      mockScanner.scan.mockResolvedValue(ok(await ballotImages.unmarkedHmpb()));
+      simulateScan(mockScanner, await ballotImages.unmarkedHmpb());
       await apiClient.scanBallot();
       await expectStatus(apiClient, { state: 'scanning' });
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
       await waitForStatus(apiClient, { state: 'needs_review', interpretation });
 
       await apiClient.returnBallot();

--- a/apps/scan/backend/src/scanners/custom/app_scan_precinct_config.test.ts
+++ b/apps/scan/backend/src/scanners/custom/app_scan_precinct_config.test.ts
@@ -6,7 +6,11 @@ import {
   expectStatus,
   waitForStatus,
 } from '../../../test/helpers/shared_helpers';
-import { ballotImages, withApp } from '../../../test/helpers/custom_helpers';
+import {
+  ballotImages,
+  simulateScan,
+  withApp,
+} from '../../../test/helpers/custom_helpers';
 import { SheetInterpretation } from '../../types';
 
 jest.setTimeout(20_000);
@@ -30,10 +34,9 @@ test('bmd ballot is rejected when scanned for wrong precinct', async () => {
         reason: 'invalid_precinct',
       };
 
-      mockScanner.scan.mockResolvedValue(ok(await ballotImages.completeBmd()));
+      simulateScan(mockScanner, await ballotImages.completeBmd());
       await apiClient.scanBallot();
       await expectStatus(apiClient, { state: 'scanning' });
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
       await waitForStatus(apiClient, {
         state: 'rejecting',
         interpretation,
@@ -68,10 +71,9 @@ test('bmd ballot is accepted if precinct is set for the right precinct', async (
       mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
       await waitForStatus(apiClient, { state: 'ready_to_scan' });
 
-      mockScanner.scan.mockResolvedValue(ok(await ballotImages.completeBmd()));
+      simulateScan(mockScanner, await ballotImages.completeBmd());
       await apiClient.scanBallot();
       await expectStatus(apiClient, { state: 'scanning' });
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
       await waitForStatus(apiClient, {
         state: 'ready_to_accept',
         interpretation: validInterpretation,
@@ -100,10 +102,9 @@ test('hmpb ballot is rejected when scanned for wrong precinct', async () => {
         reason: 'invalid_precinct',
       };
 
-      mockScanner.scan.mockResolvedValue(ok(await ballotImages.completeHmpb()));
+      simulateScan(mockScanner, await ballotImages.completeHmpb());
       await apiClient.scanBallot();
       await expectStatus(apiClient, { state: 'scanning' });
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
       await waitForStatus(apiClient, {
         state: 'rejecting',
         interpretation,
@@ -139,10 +140,9 @@ test('hmpb ballot is accepted if precinct is set for the right precinct', async 
       mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
       await waitForStatus(apiClient, { state: 'ready_to_scan' });
 
-      mockScanner.scan.mockResolvedValue(ok(await ballotImages.completeHmpb()));
+      simulateScan(mockScanner, await ballotImages.completeHmpb());
       await apiClient.scanBallot();
       await expectStatus(apiClient, { state: 'scanning' });
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
       await waitForStatus(apiClient, {
         state: 'ready_to_accept',
         interpretation: validInterpretation,

--- a/apps/scan/backend/src/scanners/custom/app_scan_precinct_config.test.ts
+++ b/apps/scan/backend/src/scanners/custom/app_scan_precinct_config.test.ts
@@ -3,7 +3,6 @@ import { mocks } from '@votingworks/custom-scanner';
 import { electionGridLayoutNewHampshireAmherstFixtures } from '@votingworks/fixtures';
 import {
   configureApp,
-  expectStatus,
   waitForStatus,
 } from '../../../test/helpers/shared_helpers';
 import {
@@ -36,7 +35,6 @@ test('bmd ballot is rejected when scanned for wrong precinct', async () => {
 
       simulateScan(mockScanner, await ballotImages.completeBmd());
       await apiClient.scanBallot();
-      await expectStatus(apiClient, { state: 'scanning' });
       await waitForStatus(apiClient, {
         state: 'rejecting',
         interpretation,
@@ -73,7 +71,6 @@ test('bmd ballot is accepted if precinct is set for the right precinct', async (
 
       simulateScan(mockScanner, await ballotImages.completeBmd());
       await apiClient.scanBallot();
-      await expectStatus(apiClient, { state: 'scanning' });
       await waitForStatus(apiClient, {
         state: 'ready_to_accept',
         interpretation: validInterpretation,
@@ -104,7 +101,6 @@ test('hmpb ballot is rejected when scanned for wrong precinct', async () => {
 
       simulateScan(mockScanner, await ballotImages.completeHmpb());
       await apiClient.scanBallot();
-      await expectStatus(apiClient, { state: 'scanning' });
       await waitForStatus(apiClient, {
         state: 'rejecting',
         interpretation,
@@ -142,7 +138,6 @@ test('hmpb ballot is accepted if precinct is set for the right precinct', async 
 
       simulateScan(mockScanner, await ballotImages.completeHmpb());
       await apiClient.scanBallot();
-      await expectStatus(apiClient, { state: 'scanning' });
       await waitForStatus(apiClient, {
         state: 'ready_to_accept',
         interpretation: validInterpretation,


### PR DESCRIPTION
## Overview

There's a race condition in the interaction between scanner mocks and the state machine. The state machine [tries to check the paper status](https://github.com/votingworks/vxsuite/blob/80511f6597388683b51c23126f7f31eaa971d78b/apps/scan/backend/src/scanners/custom/state_machine.ts#L828-L835) after completing the scan command. If it still says READY_TO_SCAN, then the scanner transitions to retry scanning, then checks the paper status again. If it then says READY_TO_EJECT, the state machine [moves to the rejecting state](https://github.com/votingworks/vxsuite/blob/80511f6597388683b51c23126f7f31eaa971d78b/apps/scan/backend/src/scanners/custom/state_machine.ts#L879).

Since we weren't updating the mocks to switch to a READY_TO_EJECT state soon enough, it was possible that it would switch in between these two checks. To mitigate, I built a little helper function that switches the mock scanner status return value immediately when the scan command completes. It's a small step back towards building a stateful scanner mock, which I don't love, but I couldn't think of a better way to fix the issue.

One alternative idea is to try to pause time and stop the state machine from advancing until we're able to reconfigure the mocks, but I felt like trying to mess around with fake timers would potentially create even more problems and felt like a bigger project to consider if we keep running into issues.

## Demo Video or Screenshot

## Testing Plan
Ran tests on CI ~10 times and confirmed no failures.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
