### PR TITLE
Paper handler driver test

### DIFF
--- a/libs/custom-paper-handler/package.json
+++ b/libs/custom-paper-handler/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@votingworks/api": "workspace:*",
     "@votingworks/basics": "workspace:*",
+    "@votingworks/custom-scanner": "workspace:*",
     "@votingworks/image-utils": "workspace:*",
     "@votingworks/message-coder": "workspace:*",
     "@votingworks/types": "workspace:*",
@@ -38,7 +39,6 @@
     "@types/w3c-web-usb": "^1.0.6",
     "@typescript-eslint/eslint-plugin": "5.37.0",
     "@typescript-eslint/parser": "5.37.0",
-    "@votingworks/custom-scanner": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
     "esbuild": "^0.16.16",
     "esbuild-runner": "^2.2.2",

--- a/libs/custom-paper-handler/src/driver/driver.test.ts
+++ b/libs/custom-paper-handler/src/driver/driver.test.ts
@@ -1,0 +1,592 @@
+import { assert } from '@votingworks/basics';
+import { mocks } from '@votingworks/custom-scanner';
+import { Buffer } from 'buffer';
+import { findByIds, WebUSBDevice } from 'usb';
+import { Uint16 } from '@votingworks/message-coder';
+import {
+  GENERIC_ENDPOINT_OUT,
+  REAL_TIME_ENDPOINT_IN,
+  REAL_TIME_ENDPOINT_OUT,
+  getPaperHandlerWebDevice,
+  PaperHandlerDriver,
+  RealTimeRequestIds,
+  ReturnCodes,
+  GENERIC_ENDPOINT_IN,
+} from './driver';
+import { TOKEN, NULL_CODE } from './constants';
+import { PrinterStatus, ScannerStatus } from './sensors';
+import { setUpMockWebUsbDevice } from './test_utils';
+
+/**
+ * message-coder (new) encodes as Buffers, but the prototype driver (legacy) sends messages as Uint8Array.
+ * This means the type of input of calls to webDevice.transferOut will differ between the legacy and new implementations.
+ * isLegacyTest=true forces tests to format the input to transferOut as Uint8Array.
+ * isLegacyTEst=false forces tests to format the input to transferOut as Buffer.
+ */
+const isLegacyTest = true;
+function formatTransferOutArg(
+  data: Buffer,
+  legacyTestOverride = false
+): Uint8Array | Buffer {
+  return isLegacyTest || legacyTestOverride ? new Uint8Array(data) : data;
+}
+type MockWebUsbDevice = mocks.MockWebUsbDevice;
+
+jest.mock('usb');
+const findByIdsMock = findByIds as jest.MockedFunction<typeof findByIds>;
+const createInstanceMock = WebUSBDevice.createInstance as jest.MockedFunction<
+  typeof WebUSBDevice.createInstance
+>;
+
+let mockWebUsbDevice: MockWebUsbDevice;
+let paperHandlerWebDevice: WebUSBDevice;
+let paperHandlerDriver: PaperHandlerDriver;
+
+export async function setUpMocksAndDriver(): Promise<void> {
+  // setUpMockWebUsbDevice creates a MockWebUsbDevice (A) that represents the paper handler.
+  // getPaperHandlerWebDevice is the driver function that returns the underlying WebUSBDevice (B).
+  // In this case, A and B are the same, but we need to return both because (A) is the mock type and (B)
+  // is the standard WebUSBDevice type. Some tests require both types.
+  const mockDevices = setUpMockWebUsbDevice(findByIdsMock, createInstanceMock);
+  mockWebUsbDevice = mockDevices.mockWebUsbDevice;
+
+  paperHandlerWebDevice = (await getPaperHandlerWebDevice()) as WebUSBDevice;
+  assert(paperHandlerWebDevice);
+
+  paperHandlerDriver = new PaperHandlerDriver(paperHandlerWebDevice);
+  await paperHandlerDriver.connect();
+}
+
+beforeEach(async () => {
+  await setUpMocksAndDriver();
+});
+
+test('initializePrinter sends the correct message', async () => {
+  const transferOutStub = jest.fn();
+  paperHandlerWebDevice.transferOut = transferOutStub;
+
+  await paperHandlerDriver.initializePrinter();
+  expect(paperHandlerWebDevice.transferOut).toHaveBeenCalledTimes(1);
+  expect(paperHandlerWebDevice.transferOut).toHaveBeenCalledWith(
+    GENERIC_ENDPOINT_OUT,
+    formatTransferOutArg(Buffer.from([0x1b, 0x40]))
+  );
+});
+
+test('getScannerStatus sends the correct message and can parse a response', async () => {
+  const transferOutSpy = jest.spyOn(mockWebUsbDevice, 'transferOut');
+
+  // How test values are chosen:
+  // Choose non-palindrome value so we know we're parsing in the right order. eg. for first byte:
+  // 8 in left position should map to 4 most significant bits in expectedStatus ie. parkSensor ... paperPreCisSensor.
+  // f in right position should map to 4 least significant bits in expected status ie. paperInputLeftInnerSensor ... paperInputRightOuterSensor
+  // 0x8f == 0b10001111 so we expect
+  // (parkSensor, ...                                  , paperInputRightOuterSensor)
+  // (true      , false, false, false, true, true, true, true                      )
+  const optionalResponseBytes = [
+    0x8f,
+    // Respect fixed null character at 0x80
+    0x4f,
+    // Respect fixed null characters from 0x10 to 0x80
+    0x08,
+    // All null characters
+    0x00,
+  ];
+
+  // See the ScannerStatus type for more information on position of these values in the bitmap
+  const expectedStatus: ScannerStatus = {
+    // First byte, MSB leftmost bit
+    parkSensor: true,
+    paperOutSensor: false,
+    paperPostCisSensor: false,
+    paperPreCisSensor: false,
+    paperInputLeftInnerSensor: true,
+    paperInputRightInnerSensor: true,
+    paperInputLeftOuterSensor: true,
+    paperInputRightOuterSensor: true,
+
+    // Second byte, MSB leftmost bit
+    // 0x80 fixed to 0
+    printHeadInPosition: true,
+    scanTimeout: false,
+    motorMove: false,
+    scanInProgress: true,
+    jamEncoder: true,
+    paperJam: true,
+    coverOpen: true,
+
+    // Third byte, MSB leftmost bit
+    // 0x80 fixed to 0
+    // 0x40 fixed to 0
+    // 0x20 fixed to 0
+    // 0x10 fixed to 0
+    optoSensor: true,
+    ballotBoxDoorSensor: false,
+    ballotBoxAttachSensor: false,
+    preHeadSensor: false,
+  };
+
+  await mockWebUsbDevice.mockAddTransferInData(
+    REAL_TIME_ENDPOINT_IN,
+    Buffer.from([
+      0x82,
+      RealTimeRequestIds.SCANNER_COMPLETE_STATUS_REQUEST_ID,
+      TOKEN,
+      ReturnCodes.POSITIVE_ACKNOWLEDGEMENT,
+      0x04,
+      ...optionalResponseBytes,
+    ])
+  );
+
+  const result = await paperHandlerDriver.getScannerStatus();
+  expect(transferOutSpy).toHaveBeenCalledTimes(1);
+  const inputAsBuffer = Buffer.from([
+    0x02,
+    RealTimeRequestIds.SCANNER_COMPLETE_STATUS_REQUEST_ID,
+    TOKEN,
+    NULL_CODE,
+  ]);
+  expect(transferOutSpy).toHaveBeenCalledWith(
+    REAL_TIME_ENDPOINT_OUT,
+    formatTransferOutArg(inputAsBuffer)
+  );
+
+  expect(result).toEqual(expectedStatus);
+});
+
+test('getPrinterStatus sends the correct message and can parse a response', async () => {
+  const transferOutSpy = jest.spyOn(mockWebUsbDevice, 'transferOut');
+  const expectedStatus: PrinterStatus = {
+    paperNotPresent: false,
+    ticketPresentInOutput: true,
+
+    dragPaperMotorOn: true,
+    spooling: true,
+    coverOpen: false,
+    printingHeadUpError: false,
+
+    notAcknowledgeCommandError: false,
+    powerSupplyVoltageError: false,
+    headNotConnected: false,
+    comError: true,
+    headTemperatureError: false,
+
+    diverterError: true,
+    headErrorLocked: false,
+    printingHeadReadyToPrint: false,
+    eepromError: false,
+    ramError: false,
+  };
+
+  const optionalDataBytes = [
+    // fixed
+    0x10,
+    // fixed
+    0x0f,
+    // paper status
+    0x20,
+    // user status
+    0x0c,
+    // recoverable error status
+    0x02,
+    // unrecoverable error status
+    0x80,
+  ];
+
+  await mockWebUsbDevice.mockAddTransferInData(
+    REAL_TIME_ENDPOINT_IN,
+    Buffer.from([
+      0x82,
+      RealTimeRequestIds.PRINTER_STATUS_REQUEST_ID,
+      TOKEN,
+      ReturnCodes.POSITIVE_ACKNOWLEDGEMENT,
+      0x06, // 6 bytes of optional data
+      ...optionalDataBytes,
+    ])
+  );
+
+  const result = await paperHandlerDriver.getPrinterStatus();
+  expect(transferOutSpy).toHaveBeenCalledTimes(1);
+  const inputAsBuffer = Buffer.from([
+    0x02,
+    RealTimeRequestIds.PRINTER_STATUS_REQUEST_ID,
+    TOKEN,
+    NULL_CODE,
+  ]);
+  expect(transferOutSpy).toHaveBeenCalledWith(
+    REAL_TIME_ENDPOINT_OUT,
+    formatTransferOutArg(inputAsBuffer)
+  );
+
+  expect(result).toEqual(expectedStatus);
+});
+
+const testsWithNoAdditionalResponseData = [
+  {
+    description: 'abortScan',
+    requestId: RealTimeRequestIds.SCAN_ABORT_REQUEST_ID,
+    functionToTest: PaperHandlerDriver.prototype.abortScan,
+  },
+  {
+    description: 'resetScan',
+    requestId: RealTimeRequestIds.SCAN_RESET_REQUEST_ID,
+    functionToTest: PaperHandlerDriver.prototype.resetScan,
+  },
+];
+test.each(testsWithNoAdditionalResponseData)(
+  `$description sends the correct message`,
+  async ({ requestId, functionToTest }) => {
+    const transferOutSpy = jest.spyOn(mockWebUsbDevice, 'transferOut');
+    await mockWebUsbDevice.mockAddTransferInData(
+      REAL_TIME_ENDPOINT_IN,
+      Buffer.from([
+        0x82,
+        requestId,
+        TOKEN,
+        ReturnCodes.POSITIVE_ACKNOWLEDGEMENT,
+        0x00, // no additional data
+      ])
+    );
+
+    await functionToTest.call(paperHandlerDriver);
+    expect(transferOutSpy).toHaveBeenCalledTimes(1);
+    const inputAsBuffer = Buffer.from([0x02, requestId, TOKEN, NULL_CODE]);
+    expect(transferOutSpy).toHaveBeenCalledWith(
+      REAL_TIME_ENDPOINT_OUT,
+      formatTransferOutArg(inputAsBuffer)
+    );
+  }
+);
+
+const scannerCommands = [
+  {
+    description: 'load paper',
+    command: [0x1c, 0x53, 0x50, 0x4c],
+    functionToTest: PaperHandlerDriver.prototype.loadPaper,
+  },
+  {
+    description: 'park paper',
+    command: [0x1c, 0x53, 0x50, 0x50],
+    functionToTest: PaperHandlerDriver.prototype.parkPaper,
+  },
+  {
+    description: 'eject paper',
+    command: [0x1c, 0x53, 0x50, 0x45],
+    functionToTest: PaperHandlerDriver.prototype.ejectPaper,
+  },
+  {
+    description: 'present paper and hold',
+    command: [0x1c, 0x53, 0x50, 0x46],
+    functionToTest: PaperHandlerDriver.prototype.presentPaper,
+  },
+  {
+    description: 'eject paper to ballot',
+    command: [0x1c, 0x53, 0x50, 0x48],
+    functionToTest: PaperHandlerDriver.prototype.ejectBallot,
+  },
+  {
+    description: 'scanner calibration',
+    command: [0x1f, 0x43],
+    functionToTest: PaperHandlerDriver.prototype.calibrate,
+  },
+  {
+    description: 'enable print',
+    command: [0x1f, 0x45],
+    functionToTest: PaperHandlerDriver.prototype.enablePrint,
+  },
+  {
+    description: 'disable print',
+    command: [0x1f, 0x65],
+    functionToTest: PaperHandlerDriver.prototype.disablePrint,
+  },
+];
+test.each(scannerCommands)(
+  `commands that take no input: "$description" sends the correct message`,
+  async ({ command, functionToTest }) => {
+    const transferOutSpy = jest.spyOn(mockWebUsbDevice, 'transferOut');
+    await mockWebUsbDevice.mockAddTransferInData(
+      GENERIC_ENDPOINT_IN,
+      Buffer.from([ReturnCodes.POSITIVE_ACKNOWLEDGEMENT])
+    );
+    await functionToTest.call(paperHandlerDriver);
+    expect(transferOutSpy).toHaveBeenCalledWith(
+      GENERIC_ENDPOINT_OUT,
+      formatTransferOutArg(Buffer.from(command))
+    );
+  }
+);
+
+function getExpectedDefaultTransferOut() {
+  return [
+    // Fixed command, 4 bytes
+    0x1c, 0x53, 0x50, 0x43,
+    // Option paper
+    0x00,
+    // Option sensor
+    0x00,
+    // Flags
+    0x00,
+    // Cis
+    0x00,
+    // Scan
+    0x05,
+    // Horizontal resolution, 2 bytes
+    0x00, 0xc8,
+    // Vertical resolution, 2 bytes
+    0x00, 0xc8,
+    // Horizontal resolution, 2 bytes
+    0x06, 0xc0,
+    // Vertical resolution max, 4 bytes
+    0x00, 0x00, 0x00, 0x00,
+  ];
+}
+
+/**
+ * Convenience function for asserting that a transfer out was successful
+ * 1. Sets up a positive ack mock transfer in response
+ * 2. Runs a function expected to wrap a PaperHandlerDriver method
+ * 3. Asserts the call to the web device's transferOut function was as expected
+ */
+async function expectScanConfigTransferOut(
+  transferOutSpy: jest.SpyInstance,
+  expectation: number[],
+  testFn: () => Promise<boolean>
+): Promise<void> {
+  await mockWebUsbDevice.mockAddTransferInData(
+    GENERIC_ENDPOINT_IN,
+    Buffer.from([ReturnCodes.POSITIVE_ACKNOWLEDGEMENT])
+  );
+
+  await testFn();
+  expect(transferOutSpy).toHaveBeenCalledWith(
+    GENERIC_ENDPOINT_OUT,
+    formatTransferOutArg(Buffer.from(expectation))
+  );
+}
+
+test('configure scanner can encode scanner config', async () => {
+  const transferOutSpy = jest.spyOn(mockWebUsbDevice, 'transferOut');
+  const expectation = getExpectedDefaultTransferOut();
+  await expectScanConfigTransferOut(
+    transferOutSpy,
+    expectation,
+    async () => await paperHandlerDriver.syncScannerConfig()
+  );
+});
+
+test('driver can update scan light config and scan data format', async () => {
+  // Position of the scan type byte in the command data
+  const SCAN_BYTE_INDEX = 8;
+
+  const transferOutSpy = jest.spyOn(mockWebUsbDevice, 'transferOut');
+  const expectation = getExpectedDefaultTransferOut();
+  await expectScanConfigTransferOut(
+    transferOutSpy,
+    expectation,
+    async () => await paperHandlerDriver.syncScannerConfig()
+  );
+
+  // Update scan type to {grayscale, red light} and expect 0x01
+  expectation[SCAN_BYTE_INDEX] = 0x01;
+  await expectScanConfigTransferOut(
+    transferOutSpy,
+    expectation,
+    async () => await paperHandlerDriver.setScanLight('red')
+  );
+
+  // Update scan type to {bw, red light} and expect 0x08
+  expectation[SCAN_BYTE_INDEX] = 0x08;
+  await expectScanConfigTransferOut(
+    transferOutSpy,
+    expectation,
+    async () => await paperHandlerDriver.setScanDataFormat('BW')
+  );
+});
+
+test('driver can update scan resolution', async () => {
+  const transferOutSpy = jest.spyOn(mockWebUsbDevice, 'transferOut');
+  const expectation = getExpectedDefaultTransferOut();
+  await expectScanConfigTransferOut(
+    transferOutSpy,
+    expectation,
+    async () => await paperHandlerDriver.syncScannerConfig()
+  );
+
+  const horizontalResolution = 300;
+  // 300 == 0x12c stored across bytes 9 and 10
+  expectation[9] = 0x01;
+  expectation[10] = 0x2c;
+
+  const verticalResolution = 150;
+  // 150 == 0x96 stored across bytes 11 and 12
+  expectation[11] = 0x00;
+  expectation[12] = 0x96;
+  await expectScanConfigTransferOut(
+    transferOutSpy,
+    expectation,
+    async () =>
+      await paperHandlerDriver.setScanResolution({
+        horizontalResolution,
+        verticalResolution,
+      })
+  );
+});
+
+test('print command', async () => {
+  const transferOutSpy = jest.spyOn(mockWebUsbDevice, 'transferOut');
+  await mockWebUsbDevice.mockAddTransferInData(
+    GENERIC_ENDPOINT_IN,
+    Buffer.from([ReturnCodes.POSITIVE_ACKNOWLEDGEMENT])
+  );
+
+  const motionUnits = 0xff;
+  const expectation = [0x1b, 0x4a, motionUnits];
+  await paperHandlerDriver.print(motionUnits);
+  expect(transferOutSpy).toHaveBeenCalledWith(
+    GENERIC_ENDPOINT_OUT,
+    formatTransferOutArg(Buffer.from(expectation))
+  );
+});
+
+test('print command defaults to 0 motion units', async () => {
+  const transferOutSpy = jest.spyOn(mockWebUsbDevice, 'transferOut');
+  await mockWebUsbDevice.mockAddTransferInData(
+    GENERIC_ENDPOINT_IN,
+    Buffer.from([ReturnCodes.POSITIVE_ACKNOWLEDGEMENT])
+  );
+
+  const expectation = [0x1b, 0x4a, 0];
+
+  await paperHandlerDriver.print();
+  expect(transferOutSpy).toHaveBeenCalledWith(
+    GENERIC_ENDPOINT_OUT,
+    formatTransferOutArg(Buffer.from(expectation))
+  );
+});
+
+interface MotionUnitTestSpec {
+  description: string;
+  motionUnits: Uint16;
+  transferOutExpectation: number[];
+  functionToTest: (motionUnits: Uint16) => void;
+}
+
+const commandsWithMotionUnits: MotionUnitTestSpec[] = [
+  {
+    description: 'setAbsolutePrintPosition',
+    // setAbsolutePrintPosition and similar functions accept a Uint16 as [nH, nL],
+    // but the actual command accepts [nL, nH], so the Uint8s are swapped in the expectation
+    motionUnits: 0xabcd,
+    transferOutExpectation: [0x1b, 0x24, 0xcd, 0xab],
+    functionToTest: PaperHandlerDriver.prototype.setAbsolutePrintPosition,
+  },
+  {
+    description: 'setRelativePrintPosition',
+    motionUnits: 0x7530,
+    transferOutExpectation: [0x1b, 0x5c, 0x30, 0x75],
+    functionToTest: PaperHandlerDriver.prototype.setRelativePrintPosition,
+  },
+  {
+    description: 'setRelativeVerticalPrintPosition',
+    motionUnits: 0x7530,
+    transferOutExpectation: [0x1b, 0x28, 0x76, 0x30, 0x75],
+    functionToTest:
+      PaperHandlerDriver.prototype.setRelativeVerticalPrintPosition,
+  },
+  {
+    description: 'setLeftMargin',
+    motionUnits: 0x7530,
+    transferOutExpectation: [0x1d, 0x4c, 0x30, 0x75],
+    functionToTest: PaperHandlerDriver.prototype.setLeftMargin,
+  },
+  {
+    description: 'setPrintingAreaWidth',
+    motionUnits: 0x0640, // 1600
+    transferOutExpectation: [0x1d, 0x57, 0x40, 0x06],
+    functionToTest: PaperHandlerDriver.prototype.setPrintingAreaWidth,
+  },
+];
+
+test.each(commandsWithMotionUnits)(
+  `driver methods with motion unit input: $description`,
+  async ({ motionUnits, transferOutExpectation, functionToTest }) => {
+    const transferOutSpy = jest.spyOn(mockWebUsbDevice, 'transferOut');
+    await mockWebUsbDevice.mockAddTransferInData(
+      GENERIC_ENDPOINT_IN,
+      Buffer.from([ReturnCodes.POSITIVE_ACKNOWLEDGEMENT])
+    );
+
+    functionToTest.call(paperHandlerDriver, motionUnits);
+    expect(transferOutSpy).toHaveBeenCalledWith(
+      GENERIC_ENDPOINT_OUT,
+      formatTransferOutArg(Buffer.from(transferOutExpectation))
+    );
+  }
+);
+
+test('setPrintingDensity', async () => {
+  const transferOutSpy = jest.spyOn(mockWebUsbDevice, 'transferOut');
+  await mockWebUsbDevice.mockAddTransferInData(
+    GENERIC_ENDPOINT_IN,
+    Buffer.from([ReturnCodes.POSITIVE_ACKNOWLEDGEMENT])
+  );
+
+  const expectation = [0x1d, 0x7c, 0x06];
+
+  await paperHandlerDriver.setPrintingDensity('+25%');
+  expect(transferOutSpy).toHaveBeenCalledWith(
+    GENERIC_ENDPOINT_OUT,
+    formatTransferOutArg(Buffer.from(expectation))
+  );
+});
+
+test('setPrintingSpeed', async () => {
+  const transferOutSpy = jest.spyOn(mockWebUsbDevice, 'transferOut');
+  await mockWebUsbDevice.mockAddTransferInData(
+    GENERIC_ENDPOINT_IN,
+    Buffer.from([ReturnCodes.POSITIVE_ACKNOWLEDGEMENT])
+  );
+
+  const expectation = [0x1d, 0xf0, 0x02];
+
+  await paperHandlerDriver.setPrintingSpeed('fast');
+  expect(transferOutSpy).toHaveBeenCalledWith(
+    GENERIC_ENDPOINT_OUT,
+    formatTransferOutArg(Buffer.from(expectation))
+  );
+});
+
+test('setMotionUnits', async () => {
+  const transferOutSpy = jest.spyOn(mockWebUsbDevice, 'transferOut');
+  await mockWebUsbDevice.mockAddTransferInData(
+    GENERIC_ENDPOINT_IN,
+    Buffer.from([ReturnCodes.POSITIVE_ACKNOWLEDGEMENT])
+  );
+
+  const x = 0xab;
+  const y = 0xcd;
+  const expectation = [0x1d, 0x50, x, y];
+
+  await paperHandlerDriver.setMotionUnits(x, y);
+  expect(transferOutSpy).toHaveBeenCalledWith(
+    GENERIC_ENDPOINT_OUT,
+    formatTransferOutArg(Buffer.from(expectation))
+  );
+});
+
+test('setLineSpacing', async () => {
+  const transferOutSpy = jest.spyOn(mockWebUsbDevice, 'transferOut');
+  await mockWebUsbDevice.mockAddTransferInData(
+    GENERIC_ENDPOINT_IN,
+    Buffer.from([ReturnCodes.POSITIVE_ACKNOWLEDGEMENT])
+  );
+
+  const n = 0xab;
+  const expectation = [0x1b, 0x33, n];
+
+  await paperHandlerDriver.setLineSpacing(n);
+  expect(transferOutSpy).toHaveBeenCalledWith(
+    GENERIC_ENDPOINT_OUT,
+    formatTransferOutArg(Buffer.from(expectation))
+  );
+});

--- a/libs/custom-paper-handler/src/driver/driver.test.ts
+++ b/libs/custom-paper-handler/src/driver/driver.test.ts
@@ -19,16 +19,11 @@ import { setUpMockWebUsbDevice } from './test_utils';
 
 /**
  * message-coder (new) encodes as Buffers, but the prototype driver (legacy) sends messages as Uint8Array.
- * This means the type of input of calls to webDevice.transferOut will differ between the legacy and new implementations.
- * isLegacyTest=true forces tests to format the input to transferOut as Uint8Array.
- * isLegacyTEst=false forces tests to format the input to transferOut as Buffer.
+ * This means the type of input for calls to webDevice.transferOut will differ between the legacy and new implementations.
+ * We wrap test expectations in formatTransferOutArg now so we can easily change them in the future.
  */
-const isLegacyTest = true;
-function formatTransferOutArg(
-  data: Buffer,
-  legacyTestOverride = false
-): Uint8Array | Buffer {
-  return isLegacyTest || legacyTestOverride ? new Uint8Array(data) : data;
+function formatTransferOutArg(data: Buffer): Uint8Array | Buffer {
+  return new Uint8Array(data);
 }
 type MockWebUsbDevice = mocks.MockWebUsbDevice;
 

--- a/libs/custom-paper-handler/src/driver/driver.ts
+++ b/libs/custom-paper-handler/src/driver/driver.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
 import { findByIds, WebUSBDevice } from 'usb';
 import makeDebug from 'debug';
 import { assert, Optional, sleep } from '@votingworks/basics';
@@ -34,12 +36,10 @@ import {
   ScannerConfig,
 } from './scanner_config';
 
-const serverDebug = makeDebug('paper-handler:driver');
+const serverDebug = makeDebug('custom-paper-handler:driver');
 
 function debug(message: string) {
   serverDebug(message);
-  /* eslint-disable-next-line no-console */
-  console.log(message);
 }
 
 /**
@@ -72,8 +72,6 @@ export interface PaperHandlerBitmap {
 const VENDOR_ID = 0x0dd4;
 const PRODUCT_ID = 0x4105;
 const CONFIGURATION_NUMBER = 1; // TODO verify this against manual/hardware
-// Disable no-unused-vars until this file is cleaned up
-/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 const INTERFACE_NUMBER = 0;
 export const GENERIC_ENDPOINT_IN = 1;
 export const GENERIC_ENDPOINT_OUT = 2;
@@ -106,19 +104,12 @@ const SCAN: Command = [0x1c, 0x53, 0x50, 0x53];
 
 // Ongoing Scan Status
 const OK_CONTINUE: Uint8 = 0x00;
-/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 const OK_DONE: Uint8 = 0xff;
-/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 const SCAN_ABORTED: Uint8 = 0x41;
-/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 const SCANNER_BUSY: Uint8 = 0x42;
-/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 const COVER_OPEN: Uint8 = 0x43;
-/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 const PAPER_JAM: Uint8 = 0x4a;
-/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 const TIMEOUT: Uint8 = 0x54;
-/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 const DOUBLE_SHEET_DETECTED: Uint8 = 0x55;
 
 const LOAD_PAPER: Command = [0x1c, 0x53, 0x50, 0x4c];
@@ -218,7 +209,7 @@ export class PaperHandlerDriver {
    * Send commands or data on the generic bulk out endpoint.
    */
   transferOutGeneric(
-    data: Uint8[] | Uint8Array | Buffer
+    data: Uint8[] | Uint8Array
   ): Promise<USBOutTransferResult> {
     return this.webDevice.transferOut(
       GENERIC_ENDPOINT_OUT,

--- a/libs/custom-paper-handler/src/driver/driver.ts
+++ b/libs/custom-paper-handler/src/driver/driver.ts
@@ -1,7 +1,6 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { findByIds, WebUSBDevice } from 'usb';
 import makeDebug from 'debug';
-import { assert, sleep, Optional } from '@votingworks/basics';
+import { assert, Optional, sleep } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import {
   assertNumberIsInRangeInclusive,
@@ -25,7 +24,7 @@ import {
   ScannerCapability,
 } from './scanner_capability';
 import {
-  defaultConfig,
+  getDefaultConfig,
   encodeScannerConfig,
   PaperMovementAfterScan,
   Resolution,
@@ -35,10 +34,12 @@ import {
   ScannerConfig,
 } from './scanner_config';
 
-const serverDebug = makeDebug('custom-paper-handler:driver');
+const serverDebug = makeDebug('paper-handler:driver');
 
 function debug(message: string) {
   serverDebug(message);
+  /* eslint-disable-next-line no-console */
+  console.log(message);
 }
 
 /**
@@ -70,12 +71,15 @@ export interface PaperHandlerBitmap {
 // USB Interface Information
 const VENDOR_ID = 0x0dd4;
 const PRODUCT_ID = 0x4105;
+const CONFIGURATION_NUMBER = 1; // TODO verify this against manual/hardware
+// Disable no-unused-vars until this file is cleaned up
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 const INTERFACE_NUMBER = 0;
-const GENERIC_ENDPOINT_IN = 1;
-const GENERIC_ENDPOINT_OUT = 2;
-const REAL_TIME_ENDPOINT_IN = 3;
-const REAL_TIME_ENDPOINT_OUT = 4;
-const PACKET_SIZE = 65536;
+export const GENERIC_ENDPOINT_IN = 1;
+export const GENERIC_ENDPOINT_OUT = 2;
+export const REAL_TIME_ENDPOINT_IN = 3;
+export const REAL_TIME_ENDPOINT_OUT = 4;
+export const PACKET_SIZE = 65536;
 
 // Common Bytes
 const START_OF_PACKET: Uint8 = 0x02;
@@ -83,15 +87,17 @@ const NULL_CODE: Uint8 = 0x00;
 const TOKEN: Uint8 = 0x01;
 
 // Return Codes
-const POSITIVE_ACKNOWLEDGEMENT: Uint8 = 0x06;
-const NEGATIVE_ACKNOWLEDGEMENT: Uint8 = 0x15;
-const UNKNOWN_COMMAND: Uint8 = 0x3f;
+export enum ReturnCodes {
+  POSITIVE_ACKNOWLEDGEMENT = 0x06,
+  NEGATIVE_ACKNOWLEDGEMENT = 0x15,
+}
 
-// Real Time Request IDs
-const SCAN_ABORT_REQUEST_ID: Uint8 = 0x43;
-const SCAN_RESET_REQUEST_ID: Uint8 = 0x52;
-const SCANNER_COMPLETE_STATUS_REQUEST_ID: Uint8 = 0x73;
-const PRINTER_STATUS_REQUEST_ID: Uint8 = 0x64;
+export enum RealTimeRequestIds {
+  SCANNER_COMPLETE_STATUS_REQUEST_ID = 0x73,
+  PRINTER_STATUS_REQUEST_ID = 0x64,
+  SCAN_ABORT_REQUEST_ID = 0x43,
+  SCAN_RESET_REQUEST_ID = 0x52,
+}
 
 // Generic Commands
 const GET_SCANNER_CAPABILITY: Command = [0x1c, 0x53, 0x43, 0x47];
@@ -100,12 +106,19 @@ const SCAN: Command = [0x1c, 0x53, 0x50, 0x53];
 
 // Ongoing Scan Status
 const OK_CONTINUE: Uint8 = 0x00;
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 const OK_DONE: Uint8 = 0xff;
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 const SCAN_ABORTED: Uint8 = 0x41;
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 const SCANNER_BUSY: Uint8 = 0x42;
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 const COVER_OPEN: Uint8 = 0x43;
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 const PAPER_JAM: Uint8 = 0x4a;
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 const TIMEOUT: Uint8 = 0x54;
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 const DOUBLE_SHEET_DETECTED: Uint8 = 0x55;
 
 const LOAD_PAPER: Command = [0x1c, 0x53, 0x50, 0x4c];
@@ -154,18 +167,31 @@ export async function getPaperHandlerWebDevice(): Promise<
   }
 }
 
+// Not all WebUSbDevice methods are implemented in the mock
+export type MinimalWebUsbDevice = Pick<
+  WebUSBDevice,
+  | 'open'
+  | 'close'
+  | 'transferOut'
+  | 'transferIn'
+  | 'claimInterface'
+  | 'selectConfiguration'
+>;
+
 export class PaperHandlerDriver {
   private readonly genericLock = new Lock();
   private readonly realTimeLock = new Lock();
-  private readonly scannerConfig: ScannerConfig = defaultConfig;
+  private readonly scannerConfig: ScannerConfig = getDefaultConfig();
 
-  constructor(private readonly webDevice: WebUSBDevice) {}
+  constructor(private readonly webDevice: MinimalWebUsbDevice) {}
 
   async connect(): Promise<void> {
     await this.webDevice.open();
     debug('opened web device');
-    // await this.webDevice.claimInterface(INTERFACE_NUMBER);
-    // debug('claimed usb interface');
+    await this.webDevice.selectConfiguration(CONFIGURATION_NUMBER);
+    debug(`selected configuration ${CONFIGURATION_NUMBER}`);
+    await this.webDevice.claimInterface(INTERFACE_NUMBER);
+    debug(`claimed usb interface ${INTERFACE_NUMBER}`);
   }
 
   async disconnect(): Promise<void> {
@@ -184,7 +210,7 @@ export class PaperHandlerDriver {
   /**
    * Should be private, but exposed for development.
    */
-  getWebDevice(): WebUSBDevice {
+  getWebDevice(): MinimalWebUsbDevice {
     return this.webDevice;
   }
 
@@ -192,7 +218,7 @@ export class PaperHandlerDriver {
    * Send commands or data on the generic bulk out endpoint.
    */
   transferOutGeneric(
-    data: Uint8[] | Uint8Array
+    data: Uint8[] | Uint8Array | Buffer
   ): Promise<USBOutTransferResult> {
     return this.webDevice.transferOut(
       GENERIC_ENDPOINT_OUT,
@@ -221,7 +247,7 @@ export class PaperHandlerDriver {
       ]);
       i += 1;
     }
-    console.log(`${i} packets cleared`);
+    debug(`${i} packets cleared`);
   }
 
   /**
@@ -259,7 +285,7 @@ export class PaperHandlerDriver {
     const { data } = transferInResult;
     assert(data);
     assert(data.getUint8(1) === requestId);
-    assert(data.getUint8(3) === POSITIVE_ACKNOWLEDGEMENT); // TODO: handling
+    assert(data.getUint8(3) === ReturnCodes.POSITIVE_ACKNOWLEDGEMENT); // TODO: handling
     return data;
   }
 
@@ -270,7 +296,9 @@ export class PaperHandlerDriver {
    */
   async getScannerStatus(): Promise<ScannerStatus> {
     return parseScannerStatus(
-      await this.handleRealTimeExchange(SCANNER_COMPLETE_STATUS_REQUEST_ID)
+      await this.handleRealTimeExchange(
+        RealTimeRequestIds.SCANNER_COMPLETE_STATUS_REQUEST_ID
+      )
     );
   }
 
@@ -281,17 +309,19 @@ export class PaperHandlerDriver {
    */
   async getPrinterStatus(): Promise<PrinterStatus> {
     return parsePrinterStatus(
-      await this.handleRealTimeExchange(PRINTER_STATUS_REQUEST_ID)
+      await this.handleRealTimeExchange(
+        RealTimeRequestIds.PRINTER_STATUS_REQUEST_ID
+      )
     );
   }
 
   async abortScan(): Promise<void> {
-    await this.handleRealTimeExchange(SCAN_ABORT_REQUEST_ID);
+    await this.handleRealTimeExchange(RealTimeRequestIds.SCAN_ABORT_REQUEST_ID);
   }
 
   // reset scan reconnects the scanenr, changes the device address, and requires a new WebUSBDevice
   async resetScan(): Promise<void> {
-    await this.handleRealTimeExchange(SCAN_RESET_REQUEST_ID);
+    await this.handleRealTimeExchange(RealTimeRequestIds.SCAN_RESET_REQUEST_ID);
   }
 
   /**
@@ -326,10 +356,10 @@ export class PaperHandlerDriver {
     debug(`transfer in status: ${transferInResult.status}`);
     const code = transferInResult.data?.getUint8(0);
     switch (code) {
-      case POSITIVE_ACKNOWLEDGEMENT:
+      case ReturnCodes.POSITIVE_ACKNOWLEDGEMENT:
         debug('positive acknowledgement');
         return true;
-      case NEGATIVE_ACKNOWLEDGEMENT:
+      case ReturnCodes.NEGATIVE_ACKNOWLEDGEMENT:
         debug('negative acknowledgement');
         return false;
       default:
@@ -390,7 +420,7 @@ export class PaperHandlerDriver {
   async scan(): Promise<Uint8Array> {
     await this.genericLock.acquire();
     await this.transferOutGeneric(SCAN);
-    console.log('STARTING SCAN');
+    debug('STARTING SCAN');
     let scanStatus = OK_CONTINUE;
     const imageData: Uint8Array[] = [];
 
@@ -407,16 +437,16 @@ export class PaperHandlerDriver {
 
       let dataBlockBytesReceived = header.buffer.byteLength - 16;
       while (dataBlockBytesReceived < dataBlockByteLength) {
-        console.log('Additional data...');
+        debug('Additional data...');
         const { data } = await this.transferInGeneric();
         assert(data);
-        console.log(data.byteLength);
+        debug(`${data.byteLength}`);
         imageData.push(new Uint8Array(data.buffer));
         dataBlockBytesReceived += data.byteLength;
       }
     }
     this.genericLock.release();
-    console.log('ALL BLOCKS RECEIVED');
+    debug('ALL BLOCKS RECEIVED');
     return Buffer.concat(imageData);
   }
 

--- a/libs/custom-paper-handler/src/driver/scanner_config.ts
+++ b/libs/custom-paper-handler/src/driver/scanner_config.ts
@@ -1,5 +1,4 @@
 import { Uint16toUint8, Uint32toUint8, Uint8 } from '../bits';
-import { ConfigureScannerCommand } from './coders';
 
 export type PaperMovementAfterScan =
   | 'hold_ticket'
@@ -68,24 +67,6 @@ const ScanDirectionEncoder: Encoder<ScanDirection> = {
   backward: 0x01,
   in_park: 0x03,
 };
-
-export function getScannerConfigCoderValues(
-  scannerConfig: ScannerConfig
-): ConfigureScannerCommand {
-  return {
-    optionPaperConfig:
-      PaperMovementAfterScanEncoder[scannerConfig.paperMovementAfterScan],
-    optionSensorConfig: scannerConfig.disableJamWheelSensor ? 0x04 : 0x00,
-    flags: ScanDirectionEncoder[scannerConfig.scanDirection],
-    scan: ScanTypeEncoder[scannerConfig.scanDataFormat][
-      scannerConfig.scanLight
-    ],
-    dpiX: scannerConfig.horizontalResolution,
-    dpiY: scannerConfig.verticalResolution,
-    sizeX: scannerConfig.scanHorizontalDimensionInDots,
-    sizeY: scannerConfig.scanMaxVerticalDimensionInDots,
-  };
-}
 
 export function encodeScannerConfig(scannerConfig: ScannerConfig): Uint8[] {
   const data: Uint8[] = [];

--- a/libs/custom-paper-handler/src/driver/scanner_config.ts
+++ b/libs/custom-paper-handler/src/driver/scanner_config.ts
@@ -83,6 +83,5 @@ export function encodeScannerConfig(scannerConfig: ScannerConfig): Uint8[] {
   data.push(...Uint16toUint8(scannerConfig.verticalResolution));
   data.push(...Uint16toUint8(scannerConfig.scanHorizontalDimensionInDots));
   data.push(...Uint32toUint8(scannerConfig.scanMaxVerticalDimensionInDots));
-  console.log(data);
   return data;
 }

--- a/libs/custom-paper-handler/src/driver/test_utils.ts
+++ b/libs/custom-paper-handler/src/driver/test_utils.ts
@@ -1,0 +1,78 @@
+import { Device, WebUSBDevice, findByIds } from 'usb';
+import { mocks } from '@votingworks/custom-scanner';
+import {
+  REAL_TIME_ENDPOINT_IN,
+  REAL_TIME_ENDPOINT_OUT,
+  PACKET_SIZE,
+} from './driver';
+
+type MockWebUsbDevice = mocks.MockWebUsbDevice;
+
+const TEST_ALTERNATE_INTERFACE: USBAlternateInterface = {
+  alternateSetting: 3,
+  interfaceClass: 4,
+  interfaceSubclass: 5,
+  interfaceProtocol: 6,
+  interfaceName: '7',
+  endpoints: [
+    {
+      endpointNumber: 1,
+      direction: 'in',
+      type: 'bulk',
+      packetSize: PACKET_SIZE,
+    },
+    {
+      endpointNumber: 2,
+      direction: 'out',
+      type: 'bulk',
+      packetSize: PACKET_SIZE,
+    },
+    {
+      endpointNumber: REAL_TIME_ENDPOINT_IN,
+      direction: 'in',
+      type: 'bulk',
+      packetSize: PACKET_SIZE,
+    },
+    {
+      endpointNumber: REAL_TIME_ENDPOINT_OUT,
+      direction: 'out',
+      type: 'bulk',
+      packetSize: PACKET_SIZE,
+    },
+  ],
+};
+
+const TEST_INTERFACE: USBInterface = {
+  interfaceNumber: 0,
+  alternate: TEST_ALTERNATE_INTERFACE,
+  alternates: [TEST_ALTERNATE_INTERFACE],
+  claimed: false,
+};
+
+export const TEST_CONFIGURATION: USBConfiguration = {
+  configurationValue: 1,
+  interfaces: [TEST_INTERFACE],
+  configurationName: 'test',
+};
+
+/**
+ * Sets up a mock WebUsbDevice and returns it
+ */
+export function setUpMockWebUsbDevice(
+  findByIdsMock: jest.MockedFunction<typeof findByIds>,
+  createInstanceMock: jest.MockedFunction<typeof WebUSBDevice.createInstance>
+): {
+  legacyDevice: Device;
+  mockWebUsbDevice: MockWebUsbDevice;
+} {
+  const legacyDevice = {} as unknown as Device;
+  findByIdsMock.mockReturnValueOnce(legacyDevice);
+
+  const mockWebUsbDevice = mocks.mockWebUsbDevice();
+  createInstanceMock.mockResolvedValueOnce(
+    mockWebUsbDevice as unknown as WebUSBDevice
+  );
+  mockWebUsbDevice.mockSetConfiguration(TEST_CONFIGURATION);
+
+  return { legacyDevice, mockWebUsbDevice };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3911,6 +3911,9 @@ importers:
       '@votingworks/basics':
         specifier: workspace:*
         version: link:../basics
+      '@votingworks/custom-scanner':
+        specifier: workspace:*
+        version: link:../custom-scanner
       '@votingworks/image-utils':
         specifier: workspace:*
         version: link:../image-utils
@@ -3957,9 +3960,6 @@ importers:
       '@typescript-eslint/parser':
         specifier: 5.37.0
         version: 5.37.0(eslint@8.23.1)(typescript@4.6.3)
-      '@votingworks/custom-scanner':
-        specifier: workspace:*
-        version: link:../custom-scanner
       '@votingworks/test-utils':
         specifier: workspace:*
         version: link:../test-utils
@@ -6252,7 +6252,6 @@ packages:
       browserslist: 4.21.3
       lru-cache: 5.1.1
       semver: 6.3.0
-    dev: false
 
   /@babel/helper-compilation-targets@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
@@ -6302,7 +6301,6 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/helper-create-class-features-plugin@7.20.12(@babel/core@7.20.12):
     resolution: {integrity: sha512-9OunRkbT0JQcednL0UFvbfXpAsUXiGjUk0a7sN8fUXX7Mue79cUSMjHGDRRi/Vz9vYlpIhLV5fMD5dKoMhhsNQ==}
@@ -6342,17 +6340,6 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-annotate-as-pure': 7.18.6
       regexpu-core: 5.2.2
-    dev: false
-
-  /@babel/helper-create-regexp-features-plugin@7.20.5(@babel/core@7.20.12):
-    resolution: {integrity: sha512-m68B1lkg3XDGX5yCvGO0kPx3v9WIYLnzjKfPcQiwntEQa5ZeRkPmo2X/ISJc8qxWGfwUr+kvZAeEzAwLec2r2w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-annotate-as-pure': 7.18.6
-      regexpu-core: 5.2.2
 
   /@babel/helper-define-polyfill-provider@0.3.1(@babel/core@7.20.12):
     resolution: {integrity: sha512-J9hGMpJQmtWmj46B3kBHmL38UhJGhYX7eqkcq+2gsstyYt341HmPeWspihX43yVRA0mS+8GGk2Gckc7bY/HCmA==}
@@ -6379,22 +6366,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.20.2
-      debug: 4.3.4(supports-color@8.1.1)
-      lodash.debounce: 4.0.8
-      resolve: 1.22.1
-      semver: 6.3.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@babel/helper-define-polyfill-provider@0.3.3(@babel/core@7.20.12):
-    resolution: {integrity: sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==}
-    peerDependencies:
-      '@babel/core': ^7.4.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.20.2
       debug: 4.3.4(supports-color@8.1.1)
       lodash.debounce: 4.0.8
@@ -6505,21 +6476,6 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-wrap-function': 7.20.5
-      '@babel/types': 7.20.7
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@babel/helper-remap-async-to-generator@7.18.9(@babel/core@7.20.12):
-    resolution: {integrity: sha512-dI7q50YKd8BAv3VEfgg7PS7yD3Rtbi2J1XMXaalXO0W0164hYLnh8zpjRS0mte9MfVp/tltvr/cfdXPvJr1opA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.20.12
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-wrap-function': 7.20.5
@@ -6652,7 +6608,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-Dgxsyg54Fx1d4Nge8UnvTrED63vrwOdPmyvPzlNN/boaliRP54pm3pGzZD1SJUwrBA+Cs/xdG8kXX6Mn/RfISQ==}
@@ -6685,7 +6640,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
       '@babel/plugin-proposal-optional-chaining': 7.20.7(@babel/core@7.12.3)
-    dev: false
 
   /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-sbr9+wNE5aXMBBFBICk01tt7sBf2Oc9ikRFEcem/ZORup9IMUdNhW7/wVLEbbtlWOsEubJet46mHAL2C8+2jKQ==}
@@ -6696,7 +6650,7 @@ packages:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/plugin-proposal-optional-chaining': 7.20.7(@babel/core@7.20.12)
+      '@babel/plugin-proposal-optional-chaining': 7.20.7(@babel/core@7.12.3)
 
   /@babel/plugin-proposal-async-generator-functions@7.16.8(@babel/core@7.20.12):
     resolution: {integrity: sha512-71YHIvMuiuqWJQkebWJtdhQTfd4Q4mF76q2IX37uZPkG9+olBxsX+rH1vkhFto4UeJZ9dPY2s+mDvhDm1u2BGQ==}
@@ -6725,7 +6679,6 @@ packages:
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.12.3)
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==}
@@ -6736,8 +6689,8 @@ packages:
       '@babel/core': 7.20.12
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.20.12)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.20.12)
+      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.12.3)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.12.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -6765,7 +6718,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
@@ -6805,7 +6757,6 @@ packages:
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.12.3)
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/plugin-proposal-class-static-block@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-AveGOoi9DAjUYYuUAG//Ig69GlazLnoyzMw68VCDux+c1tsnnH/OkYcpz/5xzMkEFC6UxjR5Gw1c+iY2wOGVeQ==}
@@ -6814,9 +6765,9 @@ packages:
       '@babel/core': ^7.12.0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.20.12)
+      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.12.3)
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.20.12)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.12.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -6855,7 +6806,6 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.12.3)
-    dev: false
 
   /@babel/plugin-proposal-dynamic-import@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-1auuwmK+Rz13SJj36R+jqFPMJWyKEDd7lLSdOj4oJK0UTgGueSAtkrCvz9ewmgyU/P941Rv2fQwZJN8s6QruXw==}
@@ -6865,7 +6815,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.20.12)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.12.3)
 
   /@babel/plugin-proposal-export-namespace-from@7.16.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-ZxdtqDXLRGBL64ocZcs7ovt71L3jhC1RGSyR996svrCi3PYqHNkb3SwPJCs8RIzD86s+WPpt2S73+EHCGO+NUA==}
@@ -6887,7 +6837,6 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.12.3)
-    dev: false
 
   /@babel/plugin-proposal-export-namespace-from@7.18.9(@babel/core@7.20.12):
     resolution: {integrity: sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==}
@@ -6897,7 +6846,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.20.12)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.12.3)
 
   /@babel/plugin-proposal-json-strings@7.16.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-lNZ3EEggsGY78JavgbHsK9u5P3pQaW7k4axlgFLYkMd7UBsiNahCITShLjNQschPyjtO6dADrL24757IdhBrsQ==}
@@ -6919,7 +6868,6 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.12.3)
-    dev: false
 
   /@babel/plugin-proposal-json-strings@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-lr1peyn9kOdbYc0xr0OdHTZ5FMqS6Di+H0Fz2I/JwMzGmzJETNeOFq2pBySw6X/KFL5EWDjlJuMsUGRFb8fQgQ==}
@@ -6929,7 +6877,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.20.12)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.12.3)
 
   /@babel/plugin-proposal-logical-assignment-operators@7.16.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-K3XzyZJGQCr00+EtYtrDjmwX7o7PLK6U9bi1nCwkQioRFVUv6dJoxbQjtWVtP+bCPy82bONBKG8NPyQ4+i6yjg==}
@@ -6951,7 +6899,6 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.12.3)
-    dev: false
 
   /@babel/plugin-proposal-logical-assignment-operators@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-y7C7cZgpMIjWlKE5T7eJwp+tnRYM89HmRvWM5EQuB5BoHEONjmQ8lSNmBUwOyy/GFRsohJED51YBF79hE1djug==}
@@ -6961,7 +6908,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.20.12)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.12.3)
 
   /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.12.3):
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
@@ -6972,7 +6919,6 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.12.3)
-    dev: false
 
   /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
@@ -6993,7 +6939,6 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.12.3)
-    dev: false
 
   /@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==}
@@ -7031,7 +6976,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.12.3)
       '@babel/plugin-transform-parameters': 7.20.7(@babel/core@7.12.3)
-    dev: false
 
   /@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==}
@@ -7041,10 +6985,10 @@ packages:
     dependencies:
       '@babel/compat-data': 7.20.10
       '@babel/core': 7.20.12
-      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.20.12)
+      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.3)
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.20.12)
-      '@babel/plugin-transform-parameters': 7.20.7(@babel/core@7.20.12)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.12.3)
+      '@babel/plugin-transform-parameters': 7.20.7(@babel/core@7.12.3)
 
   /@babel/plugin-proposal-optional-catch-binding@7.16.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-eMOH/L4OvWSZAE1VkHbr1vckLG1WUcHGJSLqqQwl2GaUqG6QjddvrOaTUMNYiv77H5IKPMZ9U9P7EaHwvAShfA==}
@@ -7066,7 +7010,6 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.12.3)
-    dev: false
 
   /@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==}
@@ -7076,7 +7019,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.20.12)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.12.3)
 
   /@babel/plugin-proposal-optional-chaining@7.20.7(@babel/core@7.12.3):
     resolution: {integrity: sha512-T+A7b1kfjtRM51ssoOfS1+wbyCVqorfyZhT99TvxxLMirPShD8CzKMRepMlCBGM5RpHMbn8s+5MMHnPstJH6mQ==}
@@ -7088,7 +7031,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.12.3)
-    dev: false
 
   /@babel/plugin-proposal-optional-chaining@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-T+A7b1kfjtRM51ssoOfS1+wbyCVqorfyZhT99TvxxLMirPShD8CzKMRepMlCBGM5RpHMbn8s+5MMHnPstJH6mQ==}
@@ -7112,7 +7054,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
@@ -7139,7 +7080,6 @@ packages:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.12.3)
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/plugin-proposal-private-property-in-object@7.20.5(@babel/core@7.20.12):
     resolution: {integrity: sha512-Vq7b9dUA12ByzB4EjQTPo25sFhY+08pQDBSZRtUAkj7lb7jahaHR5igera16QZ+3my1nYR4dKsNdYj5IjPHilQ==}
@@ -7175,7 +7115,6 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-proposal-unicode-property-regex@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==}
@@ -7184,7 +7123,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.20.12)
+      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.12.3):
@@ -7244,7 +7183,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.20.12):
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
@@ -7271,7 +7209,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.20.12):
     resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
@@ -7288,7 +7225,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.20.12):
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
@@ -7325,7 +7261,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-syntax-import-assertions@7.20.0(@babel/core@7.20.12):
     resolution: {integrity: sha512-IUh1vakzNoWalR8ch/areW7qFopR2AEw03JlG7BbrDqmQ4X3q9uuipQwSGrUn7oGiemKjtSLDhNtQHzMHr1JdQ==}
@@ -7492,7 +7427,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.20.12):
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
@@ -7558,7 +7492,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-transform-arrow-functions@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-3poA5E7dzDomxj9WXWwuD6A5F3kc7VXwIJO+E+J8qtDtS+pXPAhrgEyh+9GBwBgPq1Z+bB+/JD60lp5jsN7JPQ==}
@@ -7595,7 +7528,6 @@ packages:
       '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.12.3)
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/plugin-transform-async-to-generator@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-Uo5gwHPT9vgnSXQxqGtpdufUiWp96gk7yiP4Mp5bm1QMkEmLXBO7PAGYbKoJ6DhAwiNkcHFBol/x5zZZkL/t0Q==}
@@ -7606,7 +7538,7 @@ packages:
       '@babel/core': 7.20.12
       '@babel/helper-module-imports': 7.18.6
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.20.12)
+      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.12.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -7628,7 +7560,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-transform-block-scoped-functions@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==}
@@ -7657,7 +7588,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-transform-block-scoping@7.20.11(@babel/core@7.20.12):
     resolution: {integrity: sha512-tA4N427a7fjf1P0/2I4ScsHGc5jcHPbb30xMbaTke2gxDuWpUfXDuX1FEymJwKk4tuGUvGcejAR6HdZVqmmPyw==}
@@ -7705,7 +7635,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/plugin-transform-classes@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-LWYbsiXTPKl+oBlXUGlwNlJZetXD5Am+CyBdqhPsDVjM9Jc8jwBJFrKhHf900Kfk2eZG1y9MAG3UNajol7A4VQ==}
@@ -7715,7 +7644,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.20.12)
+      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.3)
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-function-name': 7.19.0
       '@babel/helper-optimise-call-expression': 7.18.6
@@ -7745,7 +7674,6 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/template': 7.20.7
-    dev: false
 
   /@babel/plugin-transform-computed-properties@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-Lz7MvBK6DTjElHAmfu6bfANzKcxpyNPeYBGEafyA6E5HtRpjpZwU+u7Qrgz/2OR0z+5TvKYbPdphfSaAcZBrYQ==}
@@ -7775,7 +7703,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-transform-destructuring@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-Xwg403sRrZb81IVB79ZPqNQME23yhugYVqgTxAhT99h485F4f+GMELFhhOsscDUB7HCswepKeCKLn/GZvUKoBA==}
@@ -7806,7 +7733,6 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-transform-dotall-regex@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-6S3jpun1eEbAxq7TdjLotAsl4WpQI9DxfkycRcKrjhQYzU87qpXdknpBg/e+TdcMehqGnLFi7tnFUBR02Vq6wg==}
@@ -7815,7 +7741,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.20.12)
+      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-duplicate-keys@7.16.7(@babel/core@7.20.12):
@@ -7836,7 +7762,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-transform-duplicate-keys@7.18.9(@babel/core@7.20.12):
     resolution: {integrity: sha512-d2bmXCtZXYc59/0SanQKbiWINadaJXqtvIQIzd4+hNwkWBgyCd5F/2t1kXoUdvPMrxzPvhK6EMQRROxsue+mfw==}
@@ -7867,7 +7792,6 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.18.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-transform-exponentiation-operator@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-wzEtc0+2c88FVR34aQmiz56dxEkxr2g8DQb/KfaFa1JYXOFVsbhvAonFN6PwVWj++fKmku8NP80plJ5Et4wqHw==}
@@ -7907,7 +7831,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-transform-for-of@7.18.8(@babel/core@7.20.12):
     resolution: {integrity: sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==}
@@ -7940,7 +7863,6 @@ packages:
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.3)
       '@babel/helper-function-name': 7.19.0
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-transform-function-name@7.18.9(@babel/core@7.20.12):
     resolution: {integrity: sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==}
@@ -7949,7 +7871,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.20.12)
+      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.3)
       '@babel/helper-function-name': 7.19.0
       '@babel/helper-plugin-utils': 7.20.2
 
@@ -7971,7 +7893,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-transform-literals@7.18.9(@babel/core@7.20.12):
     resolution: {integrity: sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==}
@@ -8000,7 +7921,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-transform-member-expression-literals@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==}
@@ -8036,7 +7956,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/plugin-transform-modules-amd@7.20.11(@babel/core@7.20.12):
     resolution: {integrity: sha512-NuzCt5IIYOW0O30UvqktzHYR2ud5bOWbY0yaxWZ6G+aFzOMJvrs5YHNikrbdaT15+KNO31nPOy5Fim3ku6Zb5g==}
@@ -8077,7 +7996,6 @@ packages:
       '@babel/helper-simple-access': 7.20.2
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/plugin-transform-modules-commonjs@7.20.11(@babel/core@7.20.12):
     resolution: {integrity: sha512-S8e1f7WQ7cimJQ51JkAaDrEtohVEitXjgCGAS2N8S31Y42E+kWwfSz83LYz57QdBm7q9diARVqanIaH2oVgQnw==}
@@ -8121,7 +8039,6 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/plugin-transform-modules-systemjs@7.20.11(@babel/core@7.20.12):
     resolution: {integrity: sha512-vVu5g9BPQKSFEmvt2TA4Da5N+QVS66EX21d8uoOihC+OCpUoGvzVsXeqFdtAEfVa5BILAeFt+U7yVmLbQnAJmw==}
@@ -8161,7 +8078,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/plugin-transform-modules-umd@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-dcegErExVeXcRqNtkRU/z8WlBLnvD4MRnHgNs3MytRO1Mn1sHRyhbcpYbVMGclAqOjdW+9cfkdZno9dFdfKLfQ==}
@@ -8194,7 +8110,6 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-transform-named-capturing-groups-regex@7.20.5(@babel/core@7.20.12):
     resolution: {integrity: sha512-mOW4tTzi5iTLnw+78iEq3gr8Aoq4WNRGpmSlrogqaiCBoR1HFhpU4JkpQFOHfeYx3ReVIFWOQJS4aZBRvuZ6mA==}
@@ -8203,7 +8118,7 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.20.12)
+      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-new-target@7.16.7(@babel/core@7.20.12):
@@ -8224,7 +8139,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-transform-new-target@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-DjwFA/9Iu3Z+vrAn+8pBUGcjhxKguSMlsFqeCKbhb9BAV756v0krzVK04CRDi/4aqmk8BsHb4a/gFcaA5joXRw==}
@@ -8259,7 +8173,6 @@ packages:
       '@babel/helper-replace-supers': 7.20.7
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/plugin-transform-object-super@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==}
@@ -8291,7 +8204,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-transform-parameters@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-WiWBIkeHKVOSYPO0pWkxGPfKeWrCJyD3NJ53+Lrp/QMSZbsVPovrVl2aWZ19D/LTVnaDv5Ap7GJ/B2CTOZdrfA==}
@@ -8320,7 +8232,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-transform-property-literals@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==}
@@ -8458,7 +8369,6 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       regenerator-transform: 0.15.1
-    dev: false
 
   /@babel/plugin-transform-regenerator@7.20.5(@babel/core@7.20.12):
     resolution: {integrity: sha512-kW/oO7HPBtntbsahzQ0qSE3tFvkFwnbozz3NWFhLGqH75vLEg+sCGngLlhVkePlCs3Jv0dBBHDzCHxNiFAQKCQ==}
@@ -8488,7 +8398,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-transform-reserved-words@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-oX/4MyMoypzHjFrT1CdivfKZ+XvIPMFXwwxHp/r0Ddy2Vuomt4HDFGmft1TAY2yiTKiNSsh3kjBAzcM8kSdsjA==}
@@ -8533,7 +8442,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-transform-shorthand-properties@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==}
@@ -8564,7 +8472,6 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-    dev: false
 
   /@babel/plugin-transform-spread@7.20.7(@babel/core@7.20.12):
     resolution: {integrity: sha512-ewBbHQ+1U/VnH1fxltbJqDeWBU1oNLG8Dj11uIv3xVf7nrQu0bPGe5Rf716r7K5Qz+SqtAOVswoVunoiBtGhxw==}
@@ -8594,7 +8501,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-transform-sticky-regex@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-kfiDrDQ+PBsQDO85yj1icueWMfGfJFKN1KCkndygtu/C9+XUfydLC8Iv5UYJqRwy4zk8EcplRxEOeLyjq1gm6Q==}
@@ -8623,7 +8529,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-transform-template-literals@7.18.9(@babel/core@7.20.12):
     resolution: {integrity: sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==}
@@ -8652,7 +8557,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-transform-typeof-symbol@7.18.9(@babel/core@7.20.12):
     resolution: {integrity: sha512-SRfwTtF11G2aemAZWivL7PD+C9z52v9EvMqH9BuYbabyPuKUvSWks3oCg6041pT925L4zVFqaVBeECwsmlguEw==}
@@ -8694,7 +8598,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-transform-unicode-escapes@7.18.10(@babel/core@7.20.12):
     resolution: {integrity: sha512-kKAdAI+YzPgGY/ftStBFXTI1LZFju38rYThnfMykS+IXy8BVx+res7s2fxf1l8I35DV2T97ezo6+SGrXz6B3iQ==}
@@ -8725,7 +8628,6 @@ packages:
       '@babel/core': 7.12.3
       '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-transform-unicode-regex@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-gE7A6Lt7YLnNOL3Pb9BNeZvi+d8l7tcRrG4+pwJjK9hD2xX4mEvjlQW60G9EEmfXVYRPv9VRQcyegIVHCql/AA==}
@@ -8734,7 +8636,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.20.12)
+      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/polyfill@7.12.1:
@@ -8914,7 +8816,6 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/preset-env@7.20.2(@babel/core@7.20.12):
     resolution: {integrity: sha512-1G0efQEWR1EHkKvKHqbG+IN/QdgwfByUpM5V5QroDzGV2t3S/WXNQd693cHiHTlCFMpr9B6FkPFXDA2lQcKoDg==}
@@ -9024,7 +8925,6 @@ packages:
       '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.12.3)
       '@babel/types': 7.20.7
       esutils: 2.0.3
-    dev: false
 
   /@babel/preset-modules@0.1.5(@babel/core@7.20.12):
     resolution: {integrity: sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==}
@@ -9033,8 +8933,8 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.20.12)
-      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.20.12)
+      '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.12.3)
       '@babel/types': 7.20.7
       esutils: 2.0.3
 
@@ -11959,7 +11859,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/preset-env': 7.20.2(@babel/core@7.20.12)
+      '@babel/preset-env': 7.20.2(@babel/core@7.12.3)
       '@storybook/codemod': 7.0.0-beta.31
       '@storybook/core-common': 7.0.0-beta.31
       '@storybook/core-server': 7.0.0-beta.31
@@ -14791,7 +14691,6 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /babel-plugin-polyfill-corejs2@0.3.3(@babel/core@7.20.12):
     resolution: {integrity: sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==}
@@ -14800,7 +14699,7 @@ packages:
     dependencies:
       '@babel/compat-data': 7.20.10
       '@babel/core': 7.20.12
-      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.20.12)
+      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.12.3)
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
@@ -14827,7 +14726,6 @@ packages:
       core-js-compat: 3.25.1
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /babel-plugin-polyfill-corejs3@0.6.0(@babel/core@7.20.12):
     resolution: {integrity: sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==}
@@ -14835,7 +14733,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.20.12)
+      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.12.3)
       core-js-compat: 3.25.1
     transitivePeerDependencies:
       - supports-color
@@ -14860,7 +14758,6 @@ packages:
       '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.12.3)
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /babel-plugin-polyfill-regenerator@0.4.1(@babel/core@7.20.12):
     resolution: {integrity: sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==}
@@ -14868,7 +14765,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.20.12)
+      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.12.3)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Overview
Adds tests for most commands in the existing paper handler driver (ie. tests for legacy implementation). After this merges and #3443 is rebased on main, the test file diff should be easier to read.

## Demo Video or Screenshot
N/A

## Testing Plan
Automated

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced. (No user actions or storage writes introduced. Error handling is not done yet so logging would be premature.)

