### PR TITLE
[libs/ui] Add landscape layout to DisplaySettings component

### DIFF
--- a/libs/ui/.storybook/preview.tsx
+++ b/libs/ui/.storybook/preview.tsx
@@ -7,7 +7,7 @@ import {
 } from '@storybook/types';
 
 import { AppBase, ThemeManagerContext } from '../src';
-import { ColorMode, SizeMode } from '@votingworks/types';
+import { ColorMode, ScreenType, SizeMode } from '@votingworks/types';
 
 // TODO: Find the storybook.js type declaration for this. Doesn't seem to be in
 // the @storybook/types repo.
@@ -15,9 +15,18 @@ interface ToolbarItem<T> {
   value: T, title: string, left?: string
 }
 
+type ScreenTypeToolBarItem = ToolbarItem<ScreenType>;
+
 type ColorModeToolBarItem = ToolbarItem<ColorMode>;
 
 type SizeModeToolBarItem = ToolbarItem<SizeMode>;
+
+const DEFAULT_SCREEN_TYPE: ScreenType = 'builtIn';
+const screenTypeToolBarItems: Record<ScreenType, ScreenTypeToolBarItem> = {
+  builtIn: { title: 'Generic Built-In Screen', value: 'builtIn' },
+  elo13: { title: 'ELO 13" Screen', value: 'elo13' },
+  elo15: { title: 'ELO 15" Screen', value: 'elo15' },
+};
 
 const DEFAULT_SIZE_MODE: SizeMode = "m";
 const sizeThemeToolBarItems: Record<SizeMode, SizeModeToolBarItem> = {
@@ -45,6 +54,15 @@ const colorThemeToolBarItems: Record<ColorMode, ColorModeToolBarItem> = {
  * for all components that support theming.
  */
 export const globalTypes: GlobalTypes = {
+  screenType: {
+    name: 'Screen Type',
+    toolbar: {
+      icon: 'tablet',
+      items: Object.values(screenTypeToolBarItems),
+      dynamicTitle: true,
+    },
+    defaultValue: DEFAULT_SCREEN_TYPE,
+  },
   colorMode: {
     name: 'Color Theme',
     toolbar: {
@@ -122,6 +140,7 @@ export const decorators: DecoratorFunction[] = [
         defaultColorMode={context.globals.colorMode}
         defaultSizeMode={context.globals.sizeMode}
         enableScroll
+        screenType={context.globals.screenType}
       >
         <StoryWrapper context={context}>
           <Story />

--- a/libs/ui/src/display_settings/color_settings.test.tsx
+++ b/libs/ui/src/display_settings/color_settings.test.tsx
@@ -13,25 +13,25 @@ test('renders with default color options', () => {
 
   // contractHighDark:
   screen.getByRole('radio', {
-    name: /white text on black background/i,
+    name: /white text.+black background/i,
     checked: false,
   });
 
   // contrastLow:
   screen.getByRole('radio', {
-    name: /gray text on dark background/i,
+    name: /gray text.+dark background/i,
     checked: true,
   });
 
   // contrastMedium:
   screen.getByRole('radio', {
-    name: /dark text on light background/i,
+    name: /dark text.+light background/i,
     checked: false,
   });
 
   // contrastHighLight:
   screen.getByRole('radio', {
-    name: /black text on white background/i,
+    name: /black text.+white background/i,
     checked: false,
   });
 });
@@ -45,13 +45,13 @@ test('renders with specified color options', () => {
 
   // contrastLow:
   screen.getByRole('radio', {
-    name: /gray text on dark background/i,
+    name: /gray text.+dark background/i,
     checked: true,
   });
 
   // contrastMedium:
   screen.getByRole('radio', {
-    name: /dark text on light background/i,
+    name: /dark text.+light background/i,
     checked: false,
   });
 });
@@ -87,7 +87,7 @@ test('option selections trigger theme updates', () => {
   );
 
   userEvent.click(
-    screen.getByRole('radio', { name: /gray text on dark background/i })
+    screen.getByRole('radio', { name: /gray text.+dark background/i })
   );
 
   expect(currentTheme).toEqual(

--- a/libs/ui/src/display_settings/color_settings.tsx
+++ b/libs/ui/src/display_settings/color_settings.tsx
@@ -5,6 +5,7 @@ import { SettingsPane } from './settings_pane';
 import { RadioGroup } from '../radio_group';
 import { ThemeManagerContext } from '../theme_manager_context';
 import { ThemeLabel } from './theme_label';
+import { useScreenInfo } from '../hooks/use_screen_info';
 
 export interface ColorSettingsProps {
   /** @default ['contrastLow', 'contrastMedium', 'contrastHighLight', 'contrastHighDark'] */
@@ -19,10 +20,10 @@ const DEFAULT_COLOR_MODES: ColorMode[] = [
 ];
 
 const ORDERED_COLOR_MODE_LABELS: Record<ColorMode, string> = {
-  contrastHighDark: 'White text on black background',
-  contrastLow: 'Gray text on dark background',
-  contrastMedium: 'Dark text on light background',
-  contrastHighLight: 'Black text on white background',
+  contrastHighDark: 'White text, black background',
+  contrastLow: 'Gray text, dark background',
+  contrastMedium: 'Dark text, light background',
+  contrastHighLight: 'Black text, white background',
   legacy: 'DEV ONLY: Pre-VVSG styling',
 };
 
@@ -30,11 +31,16 @@ export function ColorSettings(props: ColorSettingsProps): JSX.Element {
   const { colorModes = DEFAULT_COLOR_MODES } = props;
   const enabledColorModes = new Set(colorModes);
 
+  const screenInfo = useScreenInfo();
+
   const { setColorMode } = React.useContext(ThemeManagerContext);
 
   const orderedColorModes = (
     Object.keys(ORDERED_COLOR_MODE_LABELS) as ColorMode[]
   ).filter((m) => enabledColorModes.has(m));
+
+  /* istanbul ignore next */
+  const numColumns = screenInfo.isPortrait ? 1 : 2;
 
   return (
     <ThemeConsumer>
@@ -43,6 +49,7 @@ export function ColorSettings(props: ColorSettingsProps): JSX.Element {
           <RadioGroup
             hideLabel
             label="Color Contrast Settings"
+            numColumns={numColumns}
             onChange={setColorMode}
             options={orderedColorModes.map((mode) => ({
               id: mode,

--- a/libs/ui/src/display_settings/display_settings.test.tsx
+++ b/libs/ui/src/display_settings/display_settings.test.tsx
@@ -8,8 +8,8 @@ import { DisplaySettings } from '.';
 test('renders expected subcomponents', () => {
   render(<DisplaySettings onClose={jest.fn()} />);
 
-  screen.getByRole('heading', { name: 'Display Settings' });
-  screen.getByRole('tablist', { name: 'Display settings' });
+  screen.getByRole('heading', { name: /Display Settings/i });
+  screen.getByRole('tablist', { name: /Display settings/i });
   screen.getByRole('tabpanel');
   screen.getByRole('radiogroup', { name: 'Color Contrast Settings' });
 });

--- a/libs/ui/src/display_settings/index.tsx
+++ b/libs/ui/src/display_settings/index.tsx
@@ -6,9 +6,10 @@ import { SettingsPaneId } from './types';
 import { TabBar } from './tab_bar';
 import { ColorSettings, ColorSettingsProps } from './color_settings';
 import { SizeSettings, SizeSettingsProps } from './size_settings';
-import { H1 } from '../typography';
+import { H2 } from '../typography';
 import { Button } from '../button';
 import { ThemeManagerContext } from '../theme_manager_context';
+import { useScreenInfo } from '../hooks/use_screen_info';
 
 export interface DisplaySettingsProps {
   /** @default ['contrastLow', 'contrastMedium', 'contrastHighLight', 'contrastHighDark'] */
@@ -24,8 +25,19 @@ const Container = styled.div`
   height: 100vh;
 `;
 
-const Header = styled.div`
-  padding: 0.5rem 0.5rem 0.125rem;
+interface HeaderProps {
+  portrait?: boolean;
+}
+
+/* istanbul ignore next */
+const Header = styled.div<HeaderProps>`
+  align-items: ${(p) => (p.portrait ? 'stretch' : 'center')};
+  border-bottom: ${(p) => p.theme.sizes.bordersRem.hairline}rem dotted
+    ${(p) => p.theme.colors.foreground};
+  display: flex;
+  flex-direction: ${(p) => (p.portrait ? 'column' : 'row')};
+  gap: ${(p) => (p.portrait ? 0.25 : 0.5)}rem;
+  padding: 0.25rem 0.5rem 0.5rem;
 `;
 
 const ActivePaneContainer = styled.div`
@@ -36,7 +48,8 @@ const Footer = styled.div`
   display: flex;
   gap: 0.5rem;
   justify-content: end;
-  padding: 0.25rem 0.5rem 0.5rem;
+  padding: max(0.25rem, ${(p) => p.theme.sizes.minTouchAreaSeparationPx}px)
+    0.5rem;
 `;
 
 /**
@@ -48,6 +61,8 @@ const Footer = styled.div`
 export function DisplaySettings(props: DisplaySettingsProps): JSX.Element {
   const { colorModes, onClose, sizeModes } = props;
 
+  const screenInfo = useScreenInfo();
+
   const [activePaneId, setActivePaneId] = React.useState<SettingsPaneId>(
     'displaySettingsColor'
   );
@@ -56,10 +71,14 @@ export function DisplaySettings(props: DisplaySettingsProps): JSX.Element {
 
   return (
     <Container>
-      <Header>
-        <H1>Display Settings</H1>
+      <Header portrait={screenInfo.isPortrait}>
+        <H2 as="h1">Display Settings:</H2>
+        <TabBar
+          activePaneId={activePaneId}
+          grow={!screenInfo.isPortrait}
+          onChange={setActivePaneId}
+        />
       </Header>
-      <TabBar activePaneId={activePaneId} onChange={setActivePaneId} />
       <ActivePaneContainer>
         {activePaneId === 'displaySettingsColor' && (
           <ColorSettings colorModes={colorModes} />

--- a/libs/ui/src/display_settings/settings_pane.tsx
+++ b/libs/ui/src/display_settings/settings_pane.tsx
@@ -11,7 +11,8 @@ export interface SettingsPaneProps {
 const Container = styled.div.attrs({ role: 'tabpanel' })`
   display: flex;
   flex-direction: column;
-  padding: 0.75rem 0.5rem;
+  flex-grow: 1;
+  padding: 0.5rem;
 `;
 
 export function SettingsPane(props: SettingsPaneProps): JSX.Element {

--- a/libs/ui/src/display_settings/size_settings.tsx
+++ b/libs/ui/src/display_settings/size_settings.tsx
@@ -5,6 +5,7 @@ import { SettingsPane } from './settings_pane';
 import { RadioGroup } from '../radio_group';
 import { ThemeManagerContext } from '../theme_manager_context';
 import { ThemeLabel } from './theme_label';
+import { useScreenInfo } from '../hooks/use_screen_info';
 
 export interface SizeSettingsProps {
   /** @default ['s', 'm', 'l', 'xl'] */
@@ -25,11 +26,16 @@ export function SizeSettings(props: SizeSettingsProps): JSX.Element {
   const { sizeModes = DEFAULT_SIZE_MODES } = props;
   const enabledSizeModes = new Set(sizeModes);
 
+  const screenInfo = useScreenInfo();
+
   const { setSizeMode } = React.useContext(ThemeManagerContext);
 
   const orderedSizeModes = (
     Object.keys(ORDERED_SIZE_MODE_LABELS) as SizeMode[]
   ).filter((m) => enabledSizeModes.has(m));
+
+  /* istanbul ignore next */
+  const numColumns = screenInfo.isPortrait ? 1 : 2;
 
   return (
     <ThemeConsumer>
@@ -38,6 +44,7 @@ export function SizeSettings(props: SizeSettingsProps): JSX.Element {
           <RadioGroup
             hideLabel
             label="Text Size Settings"
+            numColumns={numColumns}
             onChange={setSizeMode}
             options={orderedSizeModes.map((m) => ({
               id: m,

--- a/libs/ui/src/display_settings/tab_bar.tsx
+++ b/libs/ui/src/display_settings/tab_bar.tsx
@@ -3,21 +3,24 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { PANE_IDS, SettingsPaneId } from './types';
-import { Icons } from '../icons';
 import { Button } from '../button';
 
 export interface TabBarProps {
   activePaneId: SettingsPaneId;
+  className?: string;
+  grow?: boolean;
   onChange: (selectedPaneId: SettingsPaneId) => void;
 }
 
-const Container = styled.div`
-  border-bottom: ${(p) => p.theme.sizes.bordersRem.hairline}rem dotted
-    ${(p) => p.theme.colors.foreground};
+interface ContainerProps {
+  grow?: boolean;
+}
+
+const Container = styled.div<ContainerProps>`
   display: flex;
+  flex-grow: ${(p) => (p.grow ? 1 : 0)};
   flex-wrap: wrap;
-  gap: 0.5rem;
-  padding: 0.25rem 0.5rem 0.75rem;
+  gap: max(0.25rem, ${(p) => p.theme.sizes.minTouchAreaSeparationPx}px);
 
   & > * {
     max-width: ${100 / PANE_IDS.length}%;
@@ -33,16 +36,8 @@ const TabLabel = styled.span`
 `;
 
 const TAB_LABELS: Record<SettingsPaneId, JSX.Element> = {
-  displaySettingsColor: (
-    <React.Fragment>
-      <Icons.Contrast /> <span>Color</span>
-    </React.Fragment>
-  ),
-  displaySettingsSize: (
-    <React.Fragment>
-      <Icons.TextSize /> <span>Text Size</span>
-    </React.Fragment>
-  ),
+  displaySettingsColor: <span>Color</span>,
+  displaySettingsSize: <span>Text Size</span>,
 };
 
 /**
@@ -50,10 +45,15 @@ const TAB_LABELS: Record<SettingsPaneId, JSX.Element> = {
  * unselected tabs and manually handle arrow keys cycling through the tabs.
  */
 export function TabBar(props: TabBarProps): JSX.Element {
-  const { activePaneId, onChange } = props;
+  const { activePaneId, className, grow, onChange } = props;
 
   return (
-    <Container aria-label="Display settings" role="tablist">
+    <Container
+      aria-label="Display settings"
+      className={className}
+      grow={grow}
+      role="tablist"
+    >
       {[...PANE_IDS].map((paneId) => (
         <Button
           aria-controls={paneId}

--- a/libs/ui/src/display_settings/theme_label.tsx
+++ b/libs/ui/src/display_settings/theme_label.tsx
@@ -16,7 +16,7 @@ export interface ThemeLabelProps {
 const Container = styled.span`
   align-items: center;
   display: flex;
-  gap: 0.5rem;
+  gap: 0.25rem;
 `;
 
 const LabelText = styled(Font)`

--- a/libs/ui/src/radio_group/index.tsx
+++ b/libs/ui/src/radio_group/index.tsx
@@ -16,13 +16,17 @@ export interface RadioGroupProps<T extends RadioGroupOptionId> {
    * still allowing it to be assigned to the control for screen readers.
    */
   label: string;
+  /** @default 1 */
+  numColumns?: number;
   onChange: (newId: T) => void;
   options: ReadonlyArray<RadioGroupOption<T>>;
   selectedOptionId?: T;
 }
 
 const OuterContainer = styled.fieldset.attrs({ role: 'radiogroup' })`
-  display: inline-block;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
 `;
 
 const LabelContainer = styled.legend`
@@ -30,12 +34,26 @@ const LabelContainer = styled.legend`
   margin-bottom: 0.5rem;
 `;
 
-const OptionsContainer = styled.span`
+interface OptionsContainerProps {
+  numColumns: number;
+}
+
+const OPTION_SPACING_REM = 0.5;
+
+const OptionsContainer = styled.span<OptionsContainerProps>`
+  align-items: stretch;
   border-radius: 0.25rem;
   display: flex;
-  flex-direction: column;
-  gap: 1rem;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: ${OPTION_SPACING_REM}rem;
+  height: 100%;
   margin-bottom: 0.35rem;
+
+  & > * {
+    flex-grow: 1;
+    width: calc(100% / ${(p) => p.numColumns} - ${OPTION_SPACING_REM}rem);
+  }
 `;
 
 /**
@@ -45,7 +63,8 @@ const OptionsContainer = styled.span`
 export function RadioGroup<T extends RadioGroupOptionId>(
   props: RadioGroupProps<T>
 ): JSX.Element {
-  const { hideLabel, label, onChange, options, selectedOptionId } = props;
+  const { hideLabel, label, numColumns, onChange, options, selectedOptionId } =
+    props;
 
   return (
     <OuterContainer aria-label={label}>
@@ -54,7 +73,7 @@ export function RadioGroup<T extends RadioGroupOptionId>(
           <Caption weight="semiBold">{label}</Caption>
         </LabelContainer>
       )}
-      <OptionsContainer>
+      <OptionsContainer numColumns={numColumns || 1}>
         {options.map((o) => (
           <RadioButton
             {...o}

--- a/libs/ui/src/radio_group/radio_button.tsx
+++ b/libs/ui/src/radio_group/radio_button.tsx
@@ -16,8 +16,10 @@ const Container = styled.label<OptionContainerProps>`
   border-width: ${(p) => p.theme.sizes.bordersRem.hairline}rem;
   display: flex;
   flex-wrap: nowrap;
+  gap: 0.25rem;
   justify-content: start;
   min-height: 2.5rem;
+  padding: 0.25rem;
   text-align: left;
 
   &[disabled] {


### PR DESCRIPTION
## Overview
Since we're moving to the 13" ELO in landscape mode for VxScan, this updates `DisplaySettings` to support a landscape layout and reduces some of the whitespace to make sure things fit reasonably at the `XL` size setting.

## Demo Video or Screenshot
### Landscape:
https://github.com/votingworks/vxsuite/assets/264902/190e55c4-1bc9-4ec5-bfa8-c71ef71b1010

### Portrait:
https://github.com/votingworks/vxsuite/assets/264902/b279dbc6-2876-4991-b5fb-bd6e023abd4f

## Testing Plan
- Manual testing
- A few test updates to account for the added colon in the heading

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
