### PR TITLE
fix(precinct-scanner): show the unplug-replug screen only on unrecoverable_error

### DIFF
--- a/frontends/precinct-scanner/jest.config.js
+++ b/frontends/precinct-scanner/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      statements: 94.96,
+      statements: 94.95,
       branches: 87,
       functions: 88.34,
       lines: 95,

--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -472,20 +472,6 @@ export function AppRoot({
   }
 
   if (scannerStatus?.state === 'disconnected') {
-    if (computer.batteryIsCharging) {
-      // this means either a serious internal connection problem (USB cable not connected)
-      // or more likely the plustek crashed before scanning, and so now it thinks there's
-      // no plustek connected. Let's instead guide the poll worker to do the right thing.
-      return (
-        <ScanErrorScreen
-          error={scannerStatus.error}
-          isTestMode={isTestMode}
-          scannedBallotCount={scannerStatus.ballotsCounted}
-          restartRequired
-          powerConnected={computer.batteryIsCharging}
-        />
-      );
-    }
     return (
       <SetupScannerScreen
         batteryIsCharging={computer.batteryIsCharging}

--- a/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
+++ b/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
@@ -244,8 +244,8 @@ test('shows internal wiring message when there is no plustek scanner, but tablet
       state: 'disconnected',
     });
   render(<App card={card} storage={storage} hardware={hardware} />);
-  await screen.findByRole('heading', { name: 'Scanner Error' });
-  screen.getByText('Ask a poll worker to unplug the power cord.');
+  await screen.findByRole('heading', { name: 'Internal Connection Problem' });
+  screen.getByText('Please ask a poll worker for help.');
 });
 
 test('shows power cable message when there is no plustek scanner and tablet is not plugged in', async () => {


### PR DESCRIPTION

Before, we were aggressively showing it also on disconnected errors, but then it becomes tricky to show a stable error screen because the battery status takes a couple seconds to update. It appears to be safe to just show our new unplug/replug screens on unrecoverable_error, so we remove this additional special case.

