### PR TITLE
fix(precinct-scanner): properly handle all the ways plustek crashes

### DIFF
--- a/frontends/precinct-scanner/src/app_root.tsx
+++ b/frontends/precinct-scanner/src/app_root.tsx
@@ -675,12 +675,9 @@ export function AppRoot({
         return <ScanProcessingScreen />;
       case 'unrecoverable_error':
         return (
-          <ScanErrorScreen
-            error={scannerStatus.error}
-            isTestMode={isTestMode}
-            scannedBallotCount={scannerStatus.ballotsCounted}
-            restartRequired
-            powerConnected={computer.batteryIsCharging}
+          <SetupScannerScreen
+            batteryIsCharging={computer.batteryIsCharging}
+            scannedBallotCount={scannerStatus?.ballotsCounted}
           />
         );
       // If an election manager removes their card during calibration, we'll

--- a/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
+++ b/frontends/precinct-scanner/src/app_unhappy_paths.test.tsx
@@ -219,7 +219,7 @@ test('show card backwards screen when card connection error occurs', async () =>
   await screen.findByText('Polls Closed');
 });
 
-test('shows internal wiring message when there is no plustek scanner, but tablet is plugged in', async () => {
+test('shows scanner restart message when there is no plustek scanner, but tablet is plugged in', async () => {
   const card = new MemoryCard();
   const storage = new MemoryStorage();
   const hardware = MemoryHardware.buildStandard();
@@ -244,8 +244,8 @@ test('shows internal wiring message when there is no plustek scanner, but tablet
       state: 'disconnected',
     });
   render(<App card={card} storage={storage} hardware={hardware} />);
-  await screen.findByRole('heading', { name: 'Internal Connection Problem' });
-  screen.getByText('Please ask a poll worker for help.');
+  await screen.findByRole('heading', { name: 'Scanner Error' });
+  screen.getByText('Ask a poll worker to unplug the power cord.');
 });
 
 test('shows power cable message when there is no plustek scanner and tablet is not plugged in', async () => {

--- a/frontends/precinct-scanner/src/screens/scan_error_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/scan_error_screen.test.tsx
@@ -63,34 +63,3 @@ test('render correct unreadable ballot screen', async () => {
     'There was a problem reading this ballot. Please scan again.'
   );
 });
-
-test('render correct through unrecoverable error', async () => {
-  render(
-    <ScanErrorScreen
-      error="plustek_error"
-      scannedBallotCount={42}
-      restartRequired
-      powerConnected
-      isTestMode
-    />
-  );
-  await screen.findByText('Scanner Error');
-  await screen.findByText('Ask a poll worker to unplug the power cord.');
-});
-
-test('render correct through unrecoverable error with power cord unplugged', async () => {
-  render(
-    <ScanErrorScreen
-      error="plustek_error"
-      scannedBallotCount={42}
-      restartRequired
-      powerConnected={false}
-      isTestMode
-    />
-  );
-
-  await screen.findByText('Scanner Error');
-  await screen.findByText(
-    'Plug the power cord back in to restart the scanner.'
-  );
-});

--- a/frontends/precinct-scanner/src/screens/scan_error_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/scan_error_screen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { Text } from '@votingworks/ui';
 import { throwIllegalValue } from '@votingworks/utils';
 import { Scan } from '@votingworks/api';
@@ -14,21 +14,15 @@ interface Props {
   error?: Scan.InvalidInterpretationReason | Scan.PrecinctScannerErrorType;
   isTestMode: boolean;
   scannedBallotCount: number;
-  restartRequired?: boolean;
-  powerConnected?: boolean;
 }
 
 export function ScanErrorScreen({
   error,
   isTestMode,
   scannedBallotCount,
-  restartRequired = false,
-  powerConnected = true,
 }: Props): JSX.Element {
   const playError = useSound('error');
   useEffect(playError, [playError]);
-
-  const [hasUnplugged, setHasUnplugged] = useState(false);
 
   const errorMessage = (() => {
     if (!error) return undefined;
@@ -65,51 +59,18 @@ export function ScanErrorScreen({
     }
   })();
 
-  function retry() {
-    void fetch('/precinct-scanner/scanner/retry', { method: 'POST' });
-  }
-
-  useEffect(() => {
-    if (!restartRequired) {
-      return;
-    }
-
-    if (hasUnplugged && powerConnected) {
-      setHasUnplugged(false);
-      retry();
-      return;
-    }
-
-    if (!powerConnected) {
-      setHasUnplugged(true);
-    }
-  }, [hasUnplugged, powerConnected, setHasUnplugged, restartRequired]);
-
   return (
     <ScreenMainCenterChild infoBar={false}>
       <TimesCircle />
       <CenteredLargeProse>
-        {restartRequired ? (
-          <React.Fragment>
-            <h1>Scanner Error</h1>
-            {powerConnected && !hasUnplugged && (
-              <Text italic>Ask a poll worker to unplug the power cord.</Text>
-            )}
-            {!powerConnected && hasUnplugged && (
-              <Text italic>
-                Plug the power cord back in to restart the scanner.
-              </Text>
-            )}
-          </React.Fragment>
-        ) : (
-          <React.Fragment>
-            <h1>Ballot Not Counted</h1>
-            <p>{errorMessage}</p>
-            <Text small italic>
-              Ask a poll worker if you need help.
-            </Text>
-          </React.Fragment>
-        )}
+        <React.Fragment>
+          <h1>Ballot Not Counted</h1>
+          <p>{errorMessage}</p>
+          <Text small italic>
+            Ask a poll worker if you need help.
+          </Text>
+        </React.Fragment>
+        )
       </CenteredLargeProse>
       <ScannedBallotCount count={scannedBallotCount} />
     </ScreenMainCenterChild>

--- a/frontends/precinct-scanner/src/screens/setup_scanner_screen.test.tsx
+++ b/frontends/precinct-scanner/src/screens/setup_scanner_screen.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import fetchMock from 'fetch-mock';
+import { render, screen } from '@testing-library/react';
+import { advanceTimersAndPromises } from '@votingworks/test-utils';
+import { SetupScannerScreen } from './setup_scanner_screen';
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  fetchMock.reset();
+});
+
+test('the unplug/replug flow', async () => {
+  const { rerender } = render(
+    <SetupScannerScreen batteryIsCharging scannedBallotCount={42} />
+  );
+
+  await screen.findByText('Please wait...');
+
+  await advanceTimersAndPromises(3);
+
+  await screen.findByText('Scanner Error');
+  await screen.findByText('Ask a poll worker to unplug the power cord.');
+
+  rerender(
+    <SetupScannerScreen batteryIsCharging={false} scannedBallotCount={42} />
+  );
+  await screen.findByText('Scanner Error');
+  await screen.findByText('OK, now please plug the power cord back in.');
+
+  // if the scanner isn't connected yet, but the power is back on,
+  // keep the same error screen up, don't wobble.
+  // expect a retry call.
+  fetchMock.post('/precinct-scanner/scanner/retry', {});
+  rerender(<SetupScannerScreen batteryIsCharging scannedBallotCount={42} />);
+
+  expect(fetchMock.calls('/precinct-scanner/scanner/retry')).toHaveLength(1);
+
+  await screen.findByText('Scanner Error');
+  await screen.findByText('OK, now please plug the power cord back in.');
+});
+
+test('power cord is unplugged and replugged shows the right message', async () => {
+  const { rerender } = render(
+    <SetupScannerScreen batteryIsCharging={false} scannedBallotCount={42} />
+  );
+
+  await screen.findByText('No Power Detected');
+
+  rerender(<SetupScannerScreen batteryIsCharging scannedBallotCount={42} />);
+
+  await advanceTimersAndPromises(1);
+
+  // should not wobble
+  await screen.findByText('No Power Detected');
+});

--- a/frontends/precinct-scanner/src/screens/setup_scanner_screen.tsx
+++ b/frontends/precinct-scanner/src/screens/setup_scanner_screen.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Text } from '@votingworks/ui';
 import {
   ScreenMainCenterChild,
   CenteredLargeProse,
 } from '../components/layout';
 import { ScannedBallotCount } from '../components/scanned_ballot_count';
+import { useSound } from '../hooks/use_sound';
 
 interface Props {
   batteryIsCharging: boolean;
@@ -16,26 +17,110 @@ export function SetupScannerScreen({
   scannedBallotCount,
 }: Props): JSX.Element {
   // If the power cord is plugged in, but we can't detect a scanner, it's an
-  // internal wiring issue. Otherwise if we can't detect the scanner, the power
+  // internal wiring issue or a plustek crash. Otherwise if we can't detect the scanner, the power
   // cord is likely not plugged in.
-  return (
-    <ScreenMainCenterChild infoBar={false}>
-      {batteryIsCharging ? (
-        <CenteredLargeProse>
-          <h1>Internal Connection Problem</h1>
-          <Text italic>Please ask a poll worker for help.</Text>
-        </CenteredLargeProse>
-      ) : (
+
+  // However, we have an additional complication, we can't tell immediately if
+  // the power has been disconnected. It can take up to 3 seconds.
+
+  const [waitedForChargingConfirmation, setWaitedForChargingConfirmation] =
+    useState(false);
+
+  const [scannerNeedsRestart, setScannerNeedsRestart] = useState(false);
+  const [scannerNeedsPowerCord, setScannerNeedsPowerCord] = useState(false);
+
+  const [hasBeenUnplugged, setHasBeenUnplugged] = useState(false);
+
+  const playError = useSound('error');
+  const playSuccess = useSound('success');
+
+  useEffect(() => {
+    window.setTimeout(() => {
+      setWaitedForChargingConfirmation(true);
+    }, 3000);
+  }, [setWaitedForChargingConfirmation]);
+
+  useEffect(() => {
+    if (
+      !scannerNeedsRestart &&
+      !scannerNeedsPowerCord &&
+      waitedForChargingConfirmation &&
+      batteryIsCharging
+    ) {
+      setScannerNeedsRestart(true);
+      playError();
+    }
+  }, [waitedForChargingConfirmation, setScannerNeedsRestart, playError]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (!batteryIsCharging && scannerNeedsRestart) {
+      setHasBeenUnplugged(true);
+      playSuccess();
+    }
+  }, [batteryIsCharging, setHasBeenUnplugged, playSuccess]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (batteryIsCharging && hasBeenUnplugged) {
+      void fetch('/precinct-scanner/scanner/retry', { method: 'POST' });
+    }
+  }, [batteryIsCharging, hasBeenUnplugged]);
+
+  // just plug the power cord back in
+  if (scannerNeedsPowerCord || (!scannerNeedsRestart && !batteryIsCharging)) {
+    if (!scannerNeedsPowerCord) {
+      setScannerNeedsPowerCord(true);
+    }
+
+    return (
+      <ScreenMainCenterChild infoBar={false}>
         <CenteredLargeProse>
           <h1>No Power Detected</h1>
           <Text italic>
             Please ask a poll worker to plug in the power cord.
           </Text>
         </CenteredLargeProse>
-      )}
-      {scannedBallotCount !== undefined && (
-        <ScannedBallotCount count={scannedBallotCount} />
-      )}
+        {scannedBallotCount !== undefined && (
+          <ScannedBallotCount count={scannedBallotCount} />
+        )}
+      </ScreenMainCenterChild>
+    );
+  }
+
+  // we need to restart the ploostek
+  if (scannerNeedsRestart) {
+    // ok they unplugged as directed
+    if (hasBeenUnplugged) {
+      return (
+        <ScreenMainCenterChild infoBar={false}>
+          <CenteredLargeProse>
+            <h1>Scanner Error</h1>
+            <Text italic>OK, now please plug the power cord back in.</Text>
+          </CenteredLargeProse>
+          {scannedBallotCount !== undefined && (
+            <ScannedBallotCount count={scannedBallotCount} />
+          )}
+        </ScreenMainCenterChild>
+      );
+    }
+    return (
+      <ScreenMainCenterChild infoBar={false}>
+        <CenteredLargeProse>
+          <h1>Scanner Error</h1>
+          <Text italic>Ask a poll worker to unplug the power cord.</Text>
+        </CenteredLargeProse>
+        {scannedBallotCount !== undefined && (
+          <ScannedBallotCount count={scannedBallotCount} />
+        )}
+      </ScreenMainCenterChild>
+    );
+  }
+
+  // we're not sure yet.
+  return (
+    <ScreenMainCenterChild infoBar={false}>
+      <CenteredLargeProse>
+        <h1>Please wait...</h1>
+      </CenteredLargeProse>
     </ScreenMainCenterChild>
   );
 }


### PR DESCRIPTION

Rework the error handling for a disconnected plustek to always prompt for unplug / replug.

Wait 3s before deciding what to show so that we don't show an unnecessary and confusing error if the cord is unplugged.