### PR TITLE
fix(monorepo): remove `services` directory

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,9 +5,6 @@ packages:
   - 'apps/*/backend'
   - 'apps/*/integration-testing'
 
-  # include all the services
-  - 'services/*'
-
   # include all the libraries and our custom types
   - 'libs/*'
   - 'libs/@types/*'

--- a/script/src/validate-monorepo/validation/index.ts
+++ b/script/src/validate-monorepo/validation/index.ts
@@ -12,15 +12,9 @@ export type ValidationIssue =
 
 export async function* validateMonorepo(): AsyncGenerator<ValidationIssue> {
   const root = join(__dirname, '../../../..');
-  const apps = await readdir(join(root, 'apps'));
-  const appPackages = (await Promise.all(apps.map(readdir))).flat();
-  const services = await readdir(join(root, 'services'));
-  const libs = await readdir(join(root, 'libs'));
-  const packages = [...services, ...libs, ...appPackages];
   const workspacePackages = getWorkspacePackageInfo(root);
 
   yield* pkgs.checkConfig({
-    packages: [root, ...packages],
     // It's important that these packages are pinned to a specific version.
     // Otherwise, we can end up with multiple versions of the same package
     // in the same monorepo, which can cause issues. For example, if we

--- a/script/src/validate-monorepo/validation/packages.ts
+++ b/script/src/validate-monorepo/validation/packages.ts
@@ -26,7 +26,12 @@ export async function* checkPackageManager({
   const properties: PackageJsonProperty[] = [];
 
   for (const pkg of workspacePackages.values()) {
-    if (!pkg.packageJson || !pkg.packageJsonPath || pkg.name.startsWith('@types/') || pkg.name === 'prodserver') {
+    if (
+      !pkg.packageJson ||
+      !pkg.packageJsonPath ||
+      pkg.name.startsWith('@types/') ||
+      pkg.name === 'prodserver'
+    ) {
       continue;
     }
 
@@ -101,11 +106,9 @@ export async function* checkPinnedVersions({
 }
 
 export async function* checkConfig({
-  packages,
   pinnedPackages,
   workspacePackages,
 }: {
-  packages: readonly string[];
   pinnedPackages: readonly string[];
   workspacePackages: ReadonlyMap<string, PackageInfo>;
 }): AsyncGenerator<ValidationIssue> {


### PR DESCRIPTION
## Overview
We no longer have any node packages in there, so just remove it from `validate-monorepo` etc.

## Demo Video or Screenshot
n/a

## Testing Plan
Manually ran `script/validate-monorepo`.

## Checklist
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
