### PR TITLE
[VxScan] Fit Election Manager screen to landscape 13" screen

### DIFF
--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -314,6 +314,9 @@ test('election manager and poll worker configuration', async () => {
   };
   apiMock.expectGetConfig(config);
   userEvent.click(await screen.findByText('Yes, Open the Polls'));
+
+  await hackActuallyCleanUpReactModal();
+
   await screen.findByText(
     'Insert poll worker card into VxMark to print the report.'
   );
@@ -330,6 +333,9 @@ test('election manager and poll worker configuration', async () => {
   await screen.findByText('Election Manager Settings');
   // Confirm we can't unconfigure just by changing precinct
   expect(await screen.findByTestId('selectPrecinct')).toBeDisabled();
+
+  userEvent.click(screen.getByRole('tab', { name: /data/i }));
+
   userEvent.click(
     await screen.findByText('Delete All Election Data from VxScan')
   );
@@ -472,6 +478,9 @@ test('voter can cast a ballot that scans successfully ', async () => {
   // Insert Election Manager Card
   apiMock.authenticateAsElectionManager(electionSampleDefinition);
   await screen.findByText('Election Manager Settings');
+
+  userEvent.click(screen.getByRole('tab', { name: /data/i }));
+
   userEvent.click(await screen.findByText('Save CVRs'));
   await screen.findByText('No USB Drive Detected');
   userEvent.click(await screen.findByText('Cancel'));

--- a/apps/scan/frontend/src/app_unhappy_paths.test.tsx
+++ b/apps/scan/frontend/src/app_unhappy_paths.test.tsx
@@ -78,6 +78,8 @@ test('backend fails to unconfigure', async () => {
   renderApp();
   apiMock.authenticateAsElectionManager(electionSampleDefinition);
 
+  userEvent.click(await screen.findByRole('tab', { name: /data/i }));
+
   await suppressingConsoleOutput(async () => {
     userEvent.click(
       await screen.findByText('Delete All Election Data from VxScan')

--- a/apps/scan/frontend/src/components/layout.tsx
+++ b/apps/scan/frontend/src/components/layout.tsx
@@ -1,7 +1,7 @@
 /* stylelint-disable order/properties-order */
 import React from 'react';
 import {
-  Screen,
+  Screen as ScreenBase,
   Main,
   ElectionInfoBar,
   InfoBarMode,
@@ -10,19 +10,26 @@ import {
 import { getConfig, getMachineConfig, getScannerStatus } from '../api';
 import { ScreenHeader } from './screen_header';
 
-interface CenteredScreenProps {
+export interface ScreenProps {
   ballotCountOverride?: number;
+  centerContent?: boolean;
   children: React.ReactNode;
   isLiveMode?: boolean;
   infoBarMode?: InfoBarMode;
+  padded?: boolean;
 }
 
-export function ScreenMainCenterChild({
-  ballotCountOverride,
-  children,
-  infoBarMode,
-  isLiveMode = true,
-}: CenteredScreenProps): JSX.Element | null {
+export type CenteredScreenProps = Omit<ScreenProps, 'centered' | 'padded'>;
+
+export function Screen(props: ScreenProps): JSX.Element | null {
+  const {
+    children,
+    ballotCountOverride,
+    centerContent,
+    infoBarMode,
+    isLiveMode = true,
+    padded,
+  } = props;
   const machineConfigQuery = getMachineConfig.useQuery();
   const configQuery = getConfig.useQuery();
   const scannerStatusQuery = getScannerStatus.useQuery();
@@ -37,12 +44,16 @@ export function ScreenMainCenterChild({
     ballotCountOverride ?? scannerStatusQuery.data?.ballotsCounted;
 
   return (
-    <Screen>
+    <ScreenBase>
       {!isLiveMode && <TestMode />}
       <ScreenHeader
         ballotCount={electionDefinition ? ballotCount : undefined}
       />
-      <Main padded centerChild style={{ position: 'relative' }}>
+      <Main
+        padded={padded}
+        centerChild={centerContent}
+        style={{ position: 'relative' }}
+      >
         {children}
       </Main>
       {electionDefinition && (
@@ -54,6 +65,12 @@ export function ScreenMainCenterChild({
           machineId={machineId}
         />
       )}
-    </Screen>
+    </ScreenBase>
   );
+}
+
+export function ScreenMainCenterChild(
+  props: CenteredScreenProps
+): JSX.Element | null {
+  return <Screen {...props} centerContent padded />;
 }

--- a/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
@@ -68,6 +68,8 @@ test('renders date and time settings modal', async () => {
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
 
+  userEvent.click(screen.getByRole('tab', { name: /system/i }));
+
   // We just do a simple happy path test here, since the libs/ui/set_clock unit
   // tests cover full behavior
   const startDate = 'Sat, Oct 31, 2020, 12:00 AM UTC';
@@ -130,6 +132,8 @@ test('export from admin screen', async () => {
   apiMock.expectGetConfig();
   renderScreen();
 
+  userEvent.click(await screen.findByRole('tab', { name: /data/i }));
+
   userEvent.click(await screen.findByText('Save Backup'));
   await screen.findByRole('heading', { name: 'No USB Drive Detected' });
   // Tested in export_backup_modal.test.tsx
@@ -143,6 +147,8 @@ test('unconfigure does not eject a usb drive that is not mounted', async () => {
     usbDrive: fakeUsbDriveStatus('no_drive'),
   });
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
+
+  userEvent.click(screen.getByRole('tab', { name: /data/i }));
 
   apiMock.mockApiClient.unconfigureElection.expectCallWith({}).resolves();
   apiMock.expectGetConfig({ electionDefinition: undefined });
@@ -164,6 +170,8 @@ test('unconfigure ejects a usb drive when it is mounted', async () => {
   });
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
 
+  userEvent.click(screen.getByRole('tab', { name: /data/i }));
+
   apiMock.mockApiClient.unconfigureElection.expectCallWith({}).resolves();
   apiMock.expectGetConfig({ electionDefinition: undefined });
   apiMock.mockApiClient.ejectUsbDrive.expectCallWith().resolves();
@@ -179,6 +187,8 @@ test('unconfigure button is disabled when the machine cannot be unconfigured', a
   apiMock.expectGetConfig();
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
+
+  userEvent.click(screen.getByRole('tab', { name: /data/i }));
 
   userEvent.click(screen.getByText('Delete All Election Data from VxScan'));
   expect(screen.queryByText('Unconfigure Machine?')).toBeNull();
@@ -200,6 +210,8 @@ test('allows overriding mark thresholds', async () => {
   apiMock.expectGetConfig();
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
+
+  userEvent.click(screen.getByRole('tab', { name: /system/i }));
 
   userEvent.click(screen.getByText('Override Mark Thresholds'));
   userEvent.click(screen.getByText('Proceed to Override Thresholds'));
@@ -229,6 +241,9 @@ test('when sounds are not muted, shows a button to mute sounds', async () => {
     .expectCallWith({ isSoundMuted: true })
     .resolves();
   apiMock.expectGetConfig({ isSoundMuted: true });
+
+  userEvent.click(screen.getByRole('tab', { name: /system/i }));
+
   userEvent.click(screen.getByRole('button', { name: 'Mute Sounds' }));
   await screen.findByRole('button', { name: 'Unmute Sounds' });
 });
@@ -243,6 +258,9 @@ test('when sounds are muted, shows a button to unmute sounds', async () => {
     .expectCallWith({ isSoundMuted: false })
     .resolves();
   apiMock.expectGetConfig({ isSoundMuted: false });
+
+  userEvent.click(screen.getByRole('tab', { name: /system/i }));
+
   userEvent.click(screen.getByRole('button', { name: 'Unmute Sounds' }));
   await screen.findByRole('button', { name: 'Mute Sounds' });
 });
@@ -252,6 +270,9 @@ test('does not show ultrasonic button if not supported', async () => {
   apiMock.expectGetConfig();
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
+
+  userEvent.click(screen.getByRole('tab', { name: /system/i }));
+
   expect(screen.queryByText('Disable Double Sheet Detection')).toBeNull();
 });
 
@@ -260,6 +281,9 @@ test('shows ultrasonic toggle when supported', async () => {
   apiMock.expectGetConfig();
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
+
+  userEvent.click(screen.getByRole('tab', { name: /system/i }));
+
   await screen.findByText('Disable Double Sheet Detection');
 });
 
@@ -268,6 +292,9 @@ test('prompts to enable ultrasonic when disabled ', async () => {
   apiMock.expectGetConfig({ isUltrasonicDisabled: true });
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
+
+  userEvent.click(screen.getByRole('tab', { name: /system/i }));
+
   await screen.findByText('Enable Double Sheet Detection');
 });
 
@@ -276,6 +303,8 @@ test('disables ultrasonic properly', async () => {
   apiMock.expectGetConfig();
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
+
+  userEvent.click(screen.getByRole('tab', { name: /system/i }));
 
   apiMock.mockApiClient.setIsUltrasonicDisabled
     .expectCallWith({ isUltrasonicDisabled: true })

--- a/libs/ui/jest.config.js
+++ b/libs/ui/jest.config.js
@@ -19,6 +19,7 @@ module.exports = {
     'src/printing_ballot_image.tsx',
     'src/rotate_card_image.tsx',
     'src/svg.tsx',
+    'src/tabbed_section/.*.tsx?',
     'src/touch_text_input.tsx',
     'src/verify_ballot_image.tsx',
     'src/voter_contest_summary.tsx',

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -62,6 +62,7 @@ export * from './select';
 export * from './session_time_limit_tracker';
 export * from './setup_card_reader_page';
 export * from './set_clock';
+export * from './tabbed_section';
 export * from './table';
 export * from './tally_report';
 export * from './tally_report_metadata';

--- a/libs/ui/src/tabbed_section/index.ts
+++ b/libs/ui/src/tabbed_section/index.ts
@@ -1,0 +1,1 @@
+export * from './tabbed_section';

--- a/libs/ui/src/tabbed_section/tab_bar.tsx
+++ b/libs/ui/src/tabbed_section/tab_bar.tsx
@@ -1,0 +1,86 @@
+/* stylelint-disable order/properties-order */
+import React from 'react';
+import styled from 'styled-components';
+import { Button } from '../button';
+import { Icons } from '../icons';
+
+export interface TabBarProps<Id extends string = string> {
+  activePaneId?: Id;
+  onChange: (selectedPaneId: Id) => void;
+  tabs: ReadonlyArray<TabInfo<Id>>;
+}
+
+export interface TabInfo<Id extends string = string> {
+  label: React.ReactNode;
+  paneId: Id;
+}
+
+const Container = styled.div`
+  border-right: ${(p) => p.theme.sizes.bordersRem.hairline}rem dotted
+    ${(p) => p.theme.colors.foreground};
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 1;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.25rem 0.5rem 0.75rem;
+`;
+
+const IconContainer = styled.span``;
+
+interface TabLabelContainerProps {
+  active?: boolean;
+}
+
+const TabLabelContainer = styled.span<TabLabelContainerProps>`
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+  text-align: left;
+
+  & ${IconContainer} {
+    opacity: ${(p) => (p.active ? 1 : 0)};
+    transition: opacity 100ms ease-out;
+  }
+`;
+
+const TabLabel = styled.span`
+  flex-grow: 1;
+`;
+
+/**
+ * TODO: Not fully accessible yet - need to set tabIndex to -1 for all
+ * unselected tabs and manually handle arrow keys cycling through the tabs.
+ */
+export function TabBar<Id extends string = string>(
+  props: TabBarProps<Id>
+): JSX.Element {
+  const { activePaneId, onChange, tabs } = props;
+
+  return (
+    <Container
+      aria-label="Display settings"
+      aria-orientation="vertical"
+      role="tablist"
+    >
+      {tabs.map(({ label, paneId }) => (
+        <Button
+          aria-controls={paneId}
+          aria-selected={activePaneId === paneId}
+          key={paneId}
+          onPress={onChange}
+          role="tab"
+          value={paneId}
+          variant={activePaneId === paneId ? 'primary' : 'regular'}
+        >
+          <TabLabelContainer active={activePaneId === paneId}>
+            <TabLabel>{label}</TabLabel>
+            <IconContainer>
+              <Icons.RightChevron />
+            </IconContainer>
+          </TabLabelContainer>
+        </Button>
+      ))}
+    </Container>
+  );
+}

--- a/libs/ui/src/tabbed_section/tabbed_section.tsx
+++ b/libs/ui/src/tabbed_section/tabbed_section.tsx
@@ -1,0 +1,46 @@
+/* stylelint-disable order/properties-order */
+import React from 'react';
+import styled from 'styled-components';
+import { TabBar, TabInfo } from './tab_bar';
+
+export interface TabbedSectionProps<Id extends string = string> {
+  ariaLabel: string;
+  tabs: ReadonlyArray<TabConfig<Id>>;
+}
+
+export interface TabConfig<Id extends string = string> extends TabInfo<Id> {
+  content: React.ReactNode;
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-grow: 1;
+  width: 100%;
+`;
+
+const Content = styled.div.attrs({ role: 'tabpanel' })`
+  flex-grow: 1;
+  padding: 0.25rem 0.5rem;
+`;
+
+export function TabbedSection<Id extends string = string>(
+  props: TabbedSectionProps<Id>
+): JSX.Element {
+  const { ariaLabel, tabs } = props;
+
+  const [activePaneId, setActivePaneId] = React.useState<Id>(tabs[0].paneId);
+
+  const currentTab = tabs.find((t) => t.paneId === activePaneId);
+
+  return (
+    <Container>
+      <TabBar
+        activePaneId={activePaneId}
+        aria-label={ariaLabel}
+        onChange={setActivePaneId}
+        tabs={tabs}
+      />
+      <Content id={currentTab?.paneId}>{currentTab?.content}</Content>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Overview
Updating the Election Manager Settings screen to fit within a landscape 13" ELO layout.

Had to break out the various actions into separate tabs so everything could fit above the fold. Got some input from the team on categories tab grouping/naming (https://uxmetrics.com/card_sort_reports/iIydf7) and used that as a starting point,  but I'm sure we'll tweak as needed over time.

## Demo Video or Screenshot
https://github.com/votingworks/vxsuite/assets/264902/1978d4e0-1bdd-4b8b-98f2-5f654e5ccc95

## Testing Plan
- Visual testing
- Updated automated tests to expect a tabbed layout.

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
