### PR TITLE
[VxScan] Fix Display Settings screen routing

### DIFF
--- a/apps/scan/frontend/src/app.tsx
+++ b/apps/scan/frontend/src/app.tsx
@@ -58,7 +58,7 @@ export function App({
               <Route path={Paths.DISPLAY_SETTINGS} exact>
                 <DisplaySettingsScreen />
               </Route>
-              <Route path={Paths.APP_ROOT}>
+              <Route path={Paths.APP_ROOT} exact>
                 <AppRoot hardware={hardware} logger={logger} />
               </Route>
               <SessionTimeLimitTracker />


### PR DESCRIPTION
## Overview
Just noticed that the routing added for the Display Settings screen in VxAdmin was allowing the app content to get rendered below the settings screen (see attached video), and would show up while tabbing through the UI.

Making the main app route `exact` so it only gets rendered at the `/` path.

## Demo Video or Screenshot
https://github.com/votingworks/vxsuite/assets/264902/ceb81bb8-23c7-4f31-a5f4-9cec8891dc73

## Testing Plan
- Visual testing

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates