### PR TITLE
ci(custom-scanner): use `v8` coverage

### DIFF
--- a/libs/custom-scanner/jest.config.js
+++ b/libs/custom-scanner/jest.config.js
@@ -5,5 +5,12 @@ const shared = require('../../jest.config.shared');
  */
 module.exports = {
   ...shared,
-  collectCoverageFrom: [...shared.collectCoverageFrom, '!src/cli/**/*.ts'],
+  collectCoverageFrom: [
+    ...shared.collectCoverageFrom,
+    '!src/**/index.ts',
+    '!src/cli/**/*.ts',
+    '!src/mocks/**/*.ts',
+    '!src/types/**/*.ts',
+  ],
+  coverageProvider: 'v8',
 };

--- a/libs/custom-scanner/src/custom_a4_scanner.ts
+++ b/libs/custom-scanner/src/custom_a4_scanner.ts
@@ -179,7 +179,7 @@ export class CustomA4Scanner implements CustomScanner {
         createJob(channel)
       );
 
-      /* istanbul ignore next */
+      /* c8 ignore start */
       if (createJobResult.isErr()) {
         const errorCode = createJobResult.err();
         debug('create job error: %o', errorCode);
@@ -194,6 +194,7 @@ export class CustomA4Scanner implements CustomScanner {
       } else {
         break;
       }
+      /* c8 ignore stop */
     }
 
     debug('create job result: %o', createJobResult);
@@ -266,9 +267,9 @@ export class CustomA4Scanner implements CustomScanner {
   scan(
     scanParameters: ScanParameters,
     {
-      /* istanbul ignore next */
+      /* c8 ignore next */
       maxTimeoutNoMoveNoScan = 5_000,
-      /* istanbul ignore next */
+      /* c8 ignore next */
       maxRetries = 3,
     }: { maxTimeoutNoMoveNoScan?: number; maxRetries?: number } = {}
   ): Promise<Result<SheetOf<ImageFromScanner>, ErrorCode>> {
@@ -343,7 +344,7 @@ export class CustomA4Scanner implements CustomScanner {
           const getImagePortionBySideResult =
             await this.getImagePortionBySideInternal(currentSide, pageSize);
 
-          /* istanbul ignore next */
+          /* c8 ignore start */
           if (getImagePortionBySideResult.isErr()) {
             readImageDataErrorCount += 1;
             if (readImageDataErrorCount < maxRetries) {
@@ -353,6 +354,7 @@ export class CustomA4Scanner implements CustomScanner {
 
             return getImagePortionBySideResult;
           }
+          /* c8 ignore stop */
 
           scannerImage.imageBuffer = Buffer.concat([
             scannerImage.imageBuffer,
@@ -460,7 +462,7 @@ export class CustomA4Scanner implements CustomScanner {
           ).okOrElse(fail);
         }
 
-        /* istanbul ignore next */
+        /* c8 ignore start */
         if (
           status.isScanInProgress &&
           a4Status.pageSizeSideA === 0 &&
@@ -468,6 +470,7 @@ export class CustomA4Scanner implements CustomScanner {
         ) {
           debug('scan in progress but no data available');
         }
+        /* c8 ignore stop */
 
         return ok('continue');
       };
@@ -479,7 +482,7 @@ export class CustomA4Scanner implements CustomScanner {
         for (;;) {
           const action = (await scanLoopTick()).okOrElse(fail);
 
-          /* istanbul ignore else */
+          /* c8 ignore start */
           if (action === 'continue') {
             continue;
           } else if (action === 'break') {
@@ -487,6 +490,7 @@ export class CustomA4Scanner implements CustomScanner {
           } else {
             throwIllegalValue(action);
           }
+          /* c8 ignore stop */
         }
       } finally {
         unlock();
@@ -508,10 +512,11 @@ export class CustomA4Scanner implements CustomScanner {
     scanSide: ScanSide,
     imagePortionSize: number
   ): Promise<Result<Buffer, ErrorCode>> {
-    /* istanbul ignore next */
+    /* c8 ignore start */
     if (imagePortionSize === 0) {
       return ok(Buffer.alloc(0));
     }
+    /* c8 ignore stop */
 
     return await this.channelMutex.withLock((channel) =>
       getImageData(

--- a/libs/custom-scanner/src/index.ts
+++ b/libs/custom-scanner/src/index.ts
@@ -1,4 +1,3 @@
-/* istanbul ignore file */
 export * from './custom_a4_scanner';
 export * as mocks from './mocks';
 export * from './open_scanner';

--- a/libs/custom-scanner/src/mocks/coder.ts
+++ b/libs/custom-scanner/src/mocks/coder.ts
@@ -4,10 +4,11 @@
 
 import { Coder } from '@votingworks/message-coder';
 
-/* istanbul ignore next */
+/* c8 ignore start */
 function notImplemented() {
   throw new Error('not implemented');
 }
+/* c8 ignore stop */
 
 /**
  * Creates a mock coder.

--- a/libs/custom-scanner/src/mocks/protocol.ts
+++ b/libs/custom-scanner/src/mocks/protocol.ts
@@ -111,7 +111,7 @@ export function usbChannelWithMockProtocol({
   function setNextReadBuffer(buffer: Buffer | Result<Buffer, unknown>): void {
     const newBuffer = Buffer.isBuffer(buffer) ? buffer : buffer.unsafeUnwrap();
 
-    /* istanbul ignore next */
+    /* c8 ignore start */
     if (readBuffer) {
       throw new Error(
         `read buffer already set: ${inspect(
@@ -119,6 +119,7 @@ export function usbChannelWithMockProtocol({
         )}, cannot use new buffer: ${inspect(newBuffer.toString())}`
       );
     }
+    /* c8 ignore stop */
 
     readBuffer = Buffer.isBuffer(buffer) ? buffer : buffer.unsafeUnwrap();
   }

--- a/libs/custom-scanner/src/mocks/simple_scanner.ts
+++ b/libs/custom-scanner/src/mocks/simple_scanner.ts
@@ -1,4 +1,3 @@
-/* istanbul ignore file - mock */
 import { ok } from '@votingworks/basics';
 import { ScannerStatus, SensorStatus } from '../types';
 import { CustomScanner } from '../types/custom_scanner';

--- a/libs/custom-scanner/src/mocks/web_usb_device.ts
+++ b/libs/custom-scanner/src/mocks/web_usb_device.ts
@@ -3,7 +3,6 @@ import { debug as baseDebug } from '../debug';
 
 const debug = baseDebug.extend('mock-usb-device');
 
-/* istanbul ignore next */
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -30,72 +29,58 @@ export class MockWebUsbDevice implements USBDevice {
   private readonly mockStalledEndpoints = new Set<number>();
   private readonly mockNextTransferLimit = new Map<number, number[]>();
 
-  /* istanbul ignore next */
   get usbVersionMajor(): number {
     return 0;
   }
 
-  /* istanbul ignore next */
   get usbVersionMinor(): number {
     return 0;
   }
 
-  /* istanbul ignore next */
   get usbVersionSubminor(): number {
     return 0;
   }
 
-  /* istanbul ignore next */
   get deviceClass(): number {
     return 0;
   }
 
-  /* istanbul ignore next */
   get deviceSubclass(): number {
     return 0;
   }
 
-  /* istanbul ignore next */
   get deviceProtocol(): number {
     return 0;
   }
 
-  /* istanbul ignore next */
   get vendorId(): number {
     return 0;
   }
 
-  /* istanbul ignore next */
   get productId(): number {
     return 0;
   }
 
-  /* istanbul ignore next */
   get deviceVersionMajor(): number {
     return 0;
   }
 
-  /* istanbul ignore next */
   get deviceVersionMinor(): number {
     return 0;
   }
 
-  /* istanbul ignore next */
   get deviceVersionSubminor(): number {
     return 0;
   }
 
-  /* istanbul ignore next */
   get manufacturerName(): string | undefined {
     return 'mock manufacturer';
   }
 
-  /* istanbul ignore next */
   get productName(): string | undefined {
     return 'mock product';
   }
 
-  /* istanbul ignore next */
   get serialNumber(): string | undefined {
     return 'mock serial number';
   }
@@ -213,7 +198,6 @@ export class MockWebUsbDevice implements USBDevice {
     usbInterface.alternate = alternate;
   }
 
-  /* istanbul ignore next */
   controlTransferIn(
     setup: USBControlTransferParameters,
     length: number
@@ -222,7 +206,6 @@ export class MockWebUsbDevice implements USBDevice {
     throw new Error('not implemented');
   }
 
-  /* istanbul ignore next */
   controlTransferOut(
     setup: USBControlTransferParameters,
     data?: BufferSource
@@ -295,7 +278,6 @@ export class MockWebUsbDevice implements USBDevice {
     return { status: 'ok', bytesWritten };
   }
 
-  /* istanbul ignore next */
   isochronousTransferIn(
     endpointNumber: number,
     packetLengths: number[]
@@ -304,7 +286,6 @@ export class MockWebUsbDevice implements USBDevice {
     throw new Error('not implemented');
   }
 
-  /* istanbul ignore next */
   isochronousTransferOut(
     endpointNumber: number,
     data: BufferSource,
@@ -314,7 +295,6 @@ export class MockWebUsbDevice implements USBDevice {
     throw new Error('not implemented');
   }
 
-  /* istanbul ignore next */
   reset(): Promise<void> {
     throw new Error('not implemented');
   }

--- a/libs/custom-scanner/src/parameters.ts
+++ b/libs/custom-scanner/src/parameters.ts
@@ -52,7 +52,7 @@ function convertToUltrasonicSensorLevelInternal(
       return UltrasonicSensorLevelInternal.Level3;
     case DoubleSheetDetectOpt.Level4:
       return UltrasonicSensorLevelInternal.Level4;
-    // istanbul ignore next
+    /* c8 ignore next 2 */
     default:
       throwIllegalValue(option);
   }

--- a/libs/custom-scanner/src/protocol.ts
+++ b/libs/custom-scanner/src/protocol.ts
@@ -667,7 +667,7 @@ class GetImageDataRequestScanSideCoder extends BaseCoder<ScanSide> {
         case GetImageDataRequestScanSideCoder.SideB:
           return { value: ScanSide.B, bitOffset: decoded.bitOffset };
 
-        /* istanbul ignore next */
+        /* c8 ignore next 2 */
         default:
           return err('InvalidValue');
       }
@@ -819,7 +819,7 @@ export function checkAnswer(data: Buffer): CheckAnswerResult {
       case ResponseErrorCode.INVALID_JOB_ID:
         return { type: 'error', errorCode: ErrorCode.JobNotValid };
 
-      /* istanbul ignore next */
+      /* c8 ignore next 2 */
       default:
         throwIllegalValue(errorCode);
     }
@@ -856,7 +856,7 @@ function mapCoderError<T>(result: Result<T, CoderError>): Result<T, ErrorCode> {
     case 'UnsupportedOffset':
       throw new Error(`BUG: unsupported offset`);
 
-    /* istanbul ignore next */
+    /* c8 ignore next 2 */
     default:
       throwIllegalValue(coderError);
   }

--- a/libs/custom-scanner/src/usb_channel.ts
+++ b/libs/custom-scanner/src/usb_channel.ts
@@ -9,12 +9,13 @@ const debug = makeDebug('custom:usb-channel');
 const READ_RETRY_MAX = 5;
 const WRITE_RETRY_MAX = 3;
 
-/* istanbul ignore next - only used for debugging */
+/* c8 ignore start */
 function truncateStringForDisplay(string: string, maxLength = 100): string {
   return string.length > maxLength
     ? `${string.slice(0, maxLength - 1)}…`
     : string;
 }
+/* c8 ignore stop */
 
 /**
  * Options for building a `UsbChannel`.


### PR DESCRIPTION

## Overview

Continuation of https://github.com/votingworks/vxsuite/pull/3537.

## Demo Video or Screenshot
n/a

## Testing Plan
- [x] Automated

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
