### PR TITLE
ci(scan): use `v8` coverage

### DIFF
--- a/apps/scan/backend/jest.config.js
+++ b/apps/scan/backend/jest.config.js
@@ -10,7 +10,15 @@ module.exports = {
   // which we should probably make not be there by using smarter
   // tsconfig.json values.
   roots: ['<rootDir>/src'],
-  collectCoverageFrom: ['**/*.{ts,tsx}', '!**/node_modules/**', '!test/**/*'],
+  coverageProvider: 'v8',
+  collectCoverageFrom: [
+    '**/*.{ts,tsx}',
+    '!**/node_modules/**',
+    '!test/**/*',
+    '!**/*.d.ts',
+    '!**/types.ts',
+    '!src/**/index.ts',
+  ],
   coverageThreshold: {
     global: {
       statements: 75,

--- a/apps/scan/backend/src/scanners/custom/state_machine.ts
+++ b/apps/scan/backend/src/scanners/custom/state_machine.ts
@@ -1329,7 +1329,7 @@ export function createPrecinctScannerStateMachine({
               type: interpretation.type,
               reasons: interpretation.reasons,
             };
-          /* istanbul ignore next - compile time check */
+          /* c8 ignore next 2 */
           default:
             throwIllegalValue(interpretation, 'type');
         }

--- a/apps/scan/backend/src/server.ts
+++ b/apps/scan/backend/src/server.ts
@@ -40,7 +40,7 @@ export function start({
   precinctScannerStateMachine,
   workspace,
 }: StartOptions): void {
-  /* istanbul ignore next */
+  /* c8 ignore start */
   const resolvedAuth =
     auth ??
     new InsertedSmartCardAuth({
@@ -52,6 +52,7 @@ export function start({
       config: {},
       logger,
     });
+  /* c8 ignore stop */
   const resolvedArtifactAuthenticator =
     artifactAuthenticator ?? new ArtifactAuthenticator();
 


### PR DESCRIPTION
## Overview

Continuation of https://github.com/votingworks/vxsuite/pull/3538.

## Demo Video or Screenshot
n/a

## Testing Plan
- [x] Automated

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
