### PR TITLE
ci(central-scan): use `v8` coverage

### DIFF
--- a/apps/central-scan/backend/jest.config.js
+++ b/apps/central-scan/backend/jest.config.js
@@ -10,9 +10,11 @@ module.exports = {
   // which we should probably make not be there by using smarter
   // tsconfig.json values.
   roots: ['<rootDir>/src'],
+  coverageProvider: 'v8',
   collectCoverageFrom: [
     '**/*.{ts,tsx}',
     '!**/node_modules/**',
+    '!**/*.d.ts',
     '!src/index.ts',
     '!src/types.ts',
     '!test/**/*',

--- a/apps/central-scan/backend/src/central_scanner_app.ts
+++ b/apps/central-scan/backend/src/central_scanner_app.ts
@@ -134,7 +134,8 @@ function buildApi({
       }
     },
 
-    /* istanbul ignore next - only used by Cypress */
+    /* c8 ignore start */
+    // This is only used in Cypress tests.
     async configureWithSampleBallotPackageForIntegrationTest(): Promise<void> {
       const { electionGridLayoutNewHampshireAmherstFixtures } = await import(
         '@votingworks/fixtures'
@@ -147,6 +148,7 @@ function buildApi({
       importer.configure(electionDefinition, TEST_JURISDICTION);
       store.setSystemSettings(systemSettings);
     },
+    /* c8 ignore stop */
 
     async configureFromBallotPackageOnUsbDrive(): Promise<
       Result<ElectionDefinition, BallotPackageConfigurationError>

--- a/apps/central-scan/backend/src/server.ts
+++ b/apps/central-scan/backend/src/server.ts
@@ -42,7 +42,7 @@ export async function start({
   workspace,
 }: Partial<StartOptions> = {}): Promise<Server> {
   let resolvedWorkspace = workspace;
-  /* istanbul ignore next */
+  /* c8 ignore start */
   if (!resolvedWorkspace) {
     const workspacePath = SCAN_WORKSPACE;
     if (!workspacePath) {
@@ -57,13 +57,14 @@ export async function start({
     }
     resolvedWorkspace = createWorkspace(workspacePath);
   }
+  /* c8 ignore stop */
 
   // Clear any cached data
   resolvedWorkspace.clearUploads();
   resolvedWorkspace.store.cleanupIncompleteBatches();
 
   let resolvedApp = app;
-  /* istanbul ignore next */
+  /* c8 ignore start */
   if (!resolvedApp) {
     const auth = new DippedSmartCardAuth({
       card:
@@ -99,6 +100,7 @@ export async function start({
       workspace: resolvedWorkspace,
     });
   }
+  /* c8 ignore stop */
 
   return resolvedApp.listen(port, async () => {
     await logger.log(LogEventId.ApplicationStartup, 'system', {


### PR DESCRIPTION

## Overview

Continuation of https://github.com/votingworks/vxsuite/pull/3539.

## Demo Video or Screenshot
n/a

## Testing Plan
- [x] Automated

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
