### PR TITLE
VxAdmin Tally Foundations Pt. 3 - Testing & Cleanup

### DIFF
--- a/apps/admin/backend/jest.config.js
+++ b/apps/admin/backend/jest.config.js
@@ -12,10 +12,10 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/test/setupTests.ts'],
   coverageThreshold: {
     global: {
-      statements: 96,
-      branches: 89,
-      functions: 99,
-      lines: 96,
+      statements: 98,
+      branches: 95,
+      functions: 100,
+      lines: 98,
     },
   },
   coverageProvider: 'v8',

--- a/apps/admin/backend/jest.config.js
+++ b/apps/admin/backend/jest.config.js
@@ -27,6 +27,7 @@ module.exports = {
     '!src/types.ts',
     '!src/util/debug.ts',
     '!src/util/usb.ts',
+    '!src/globals.ts',
     '!test/**/*',
   ],
 };

--- a/apps/admin/backend/src/cvr_files.ts
+++ b/apps/admin/backend/src/cvr_files.ts
@@ -714,10 +714,8 @@ export async function addCastVoteRecordReport({
       castVoteRecordIndex += 1;
     }
 
-    // Update the cast vote file record with information we learned by
-    // iterating through the records. TODO: Calculate the precinct list before
-    // iterating through records after there is only one geopolitical unit
-    // per batch.
+    // TODO: Calculate the precinct list before iterating through records, once there is
+    // only one geopolitical unit per batch in the future.
     store.updateCastVoteRecordFileRecord({
       id: fileId,
       precinctIds,

--- a/apps/admin/backend/src/cvr_files.ts
+++ b/apps/admin/backend/src/cvr_files.ts
@@ -603,24 +603,26 @@ export async function addCastVoteRecordReport({
       // Add the cast vote record to the store
       const currentSnapshot = getCurrentSnapshot(cvr);
       assert(currentSnapshot);
-      const votes = JSON.stringify(
-        convertCastVoteRecordVotesToTabulationVotes(currentSnapshot)
-      );
+      const votes =
+        convertCastVoteRecordVotesToTabulationVotes(currentSnapshot);
       const addCastVoteRecordResult = store.addCastVoteRecordFileEntry({
         electionId,
         cvrFileId: fileId,
         ballotId: cvr.UniqueId as BallotId,
-        metadata: {
+        cvr: {
           ballotStyleId: cvr.BallotStyleId,
-          ballotType: cvr.vxBallotType,
+          votingMethod: cvr.vxBallotType,
           batchId: cvr.BatchId,
           precinctId: cvr.BallotStyleUnitId,
-          // sheet number was previously validated
-          sheetNumber: cvr.BallotSheetId
-            ? safeParseNumber(cvr.BallotSheetId).unsafeUnwrap()
-            : undefined,
+          card: cvr.BallotSheetId
+            ? {
+                type: 'hmpb',
+                // sheet number was previously validated
+                sheetNumber: safeParseNumber(cvr.BallotSheetId).unsafeUnwrap(),
+              }
+            : { type: 'bmd' },
+          votes,
         },
-        votes,
       });
       if (addCastVoteRecordResult.isErr()) {
         const errorType = addCastVoteRecordResult.err().type;

--- a/apps/admin/backend/src/cvr_files.ts
+++ b/apps/admin/backend/src/cvr_files.ts
@@ -97,7 +97,7 @@ export async function listCastVoteRecordFilesOnUsb(
       case 'usb-drive-not-mounted':
         // we're just polling without a USB drive in these cases, no issue
         break;
-      /* istanbul ignore next: compile-time check for completeness */
+      /* c8 ignore next 2 */
       default:
         throwIllegalValue(errorType);
     }
@@ -365,7 +365,7 @@ export function getAddCastVoteRecordReportErrorMessage(
       const messageBase = `Found an invalid cast vote record at index ${error.index} in the current report.`;
       const messageDetail = (() => {
         const subErrorType = error.error;
-        /* istanbul ignore next  - write testing when error handling requirements and implementation harden */
+        /* c8 ignore start */
         switch (subErrorType) {
           case 'invalid-election':
             return `The record references an election other than the current election.`;
@@ -386,9 +386,9 @@ export function getAddCastVoteRecordReportErrorMessage(
             return `The record references a contest which does not exist for its ballot style.`;
           case 'invalid-contest-option':
             return `The record references a contest option which does not exist for the contest.`;
-          /* istanbul ignore next: compile-time check for completeness */
           default:
             throwIllegalValue(subErrorType);
+          /* c8 ignore stop */
         }
       })();
 
@@ -398,7 +398,7 @@ export function getAddCastVoteRecordReportErrorMessage(
       return `Unable to parse a layout associated with a ballot image. Path: ${error.path}`;
     case 'ballot-id-already-exists-with-different-data':
       return `Found cast vote record at index ${error.index} that has the same ballot id as a previously imported cast vote record, but with different data.`;
-    /* istanbul ignore next: compile-time check for completeness */
+    /* c8 ignore next 2 */
     default:
       throwIllegalValue(errorType);
   }
@@ -635,7 +635,7 @@ export async function addCastVoteRecordReport({
               type: 'ballot-id-already-exists-with-different-data',
               index: castVoteRecordIndex,
             });
-          /* istanbul ignore next */
+          /* c8 ignore next 2 */
           default:
             throwIllegalValue(errorType);
         }

--- a/apps/admin/backend/src/globals.ts
+++ b/apps/admin/backend/src/globals.ts
@@ -1,5 +1,3 @@
-/* istanbul ignore file */
-
 import { unsafeParse } from '@votingworks/types';
 import { join } from 'path';
 import { z } from 'zod';

--- a/apps/admin/backend/src/server.ts
+++ b/apps/admin/backend/src/server.ts
@@ -38,7 +38,7 @@ export async function start({
   workspace,
 }: Partial<StartOptions>): Promise<Server> {
   let resolvedWorkspace = workspace;
-  /* istanbul ignore next */
+  /* c8 ignore start */
   if (!resolvedWorkspace) {
     const workspacePath = ADMIN_WORKSPACE;
     if (!workspacePath) {
@@ -53,9 +53,11 @@ export async function start({
     }
     resolvedWorkspace = createWorkspace(workspacePath);
   }
+  /* c8 ignore stop */
 
   let resolvedApp = app;
-  /* istanbul ignore next */
+
+  /* c8 ignore start */
   if (!resolvedApp) {
     const auth = new DippedSmartCardAuth({
       card:
@@ -80,6 +82,7 @@ export async function start({
       workspace: resolvedWorkspace,
     });
   }
+  /* c8 ignore stop */
 
   const server = resolvedApp.listen(port, async () => {
     await logger.log(LogEventId.ApplicationStartup, 'system', {

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -22,7 +22,6 @@ import {
   ContestOptionId,
   CVR,
   Election,
-  ElectionDefinition,
   Id,
   Iso8601Timestamp,
   safeParse,
@@ -278,10 +277,10 @@ export class Store {
    * Returns the current election definition or throws an error if it does
    * not exist.
    */
-  getCurrentElectionDefinitionOrThrow(): ElectionDefinition {
+  getCurrentElectionRecordOrThrow(): ElectionRecord {
     return assertDefined(
       this.getElection(assertDefined(this.getCurrentElectionId()))
-    ).electionDefinition;
+    );
   }
 
   /**
@@ -1231,7 +1230,9 @@ export class Store {
       return [];
     }
 
-    const { election } = this.getCurrentElectionDefinitionOrThrow();
+    const {
+      electionDefinition: { election },
+    } = this.getCurrentElectionRecordOrThrow();
 
     const officialCandidateNameLookup =
       getOfficialCandidateNameLookup(election);

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -367,13 +367,14 @@ export class Store {
     ).alreadyPresent;
   }
 
-  addInitialCastVoteRecordFileRecord({
+  addCastVoteRecordFileRecord({
     id,
     electionId,
     isTestMode,
     filename,
     exportedTimestamp,
     sha256Hash,
+    scannerIds,
   }: {
     id: Id;
     electionId: Id;
@@ -381,6 +382,7 @@ export class Store {
     filename: string;
     exportedTimestamp: Iso8601Timestamp;
     sha256Hash: string;
+    scannerIds: Set<string>;
   }): void {
     this.client.run(
       `
@@ -403,7 +405,7 @@ export class Store {
       filename,
       exportedTimestamp,
       JSON.stringify([]),
-      JSON.stringify([]),
+      JSON.stringify([...scannerIds]),
       sha256Hash
     );
   }
@@ -411,22 +413,18 @@ export class Store {
   updateCastVoteRecordFileRecord({
     id,
     precinctIds,
-    scannerIds,
   }: {
     id: Id;
     precinctIds: Set<string>;
-    scannerIds: Set<string>;
   }): void {
     this.client.run(
       `
         update cvr_files
         set
-          precinct_ids = ?,
-          scanner_ids = ?
+          precinct_ids = ?
         where id = ?
       `,
       JSON.stringify([...precinctIds]),
-      JSON.stringify([...scannerIds]),
       id
     );
   }

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -909,7 +909,9 @@ export class Store {
 
     if (filter.scannerIds) {
       whereParts.push(
-        `cvrs.scanner_id in ${asQueryPlaceholders(filter.scannerIds)}`
+        `scanner_batches.scanner_id in ${asQueryPlaceholders(
+          filter.scannerIds
+        )}`
       );
       params.push(...filter.scannerIds);
     }
@@ -1278,8 +1280,8 @@ export class Store {
     }
 
     if (groupBy.groupByScanner) {
-      cvrSelectParts.push('cvrs.scanner_id as scannerId');
-      groupByParts.push('cvrs.scanner_id');
+      cvrSelectParts.push('scanner_batches.scanner_id as scannerId');
+      groupByParts.push('scanner_batches.scanner_id');
     }
 
     if (groupBy.groupByVotingMethod) {

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -1322,22 +1322,20 @@ export class Store {
     ) as Iterable<
       WriteInTallyRow & Partial<Tabulation.CastVoteRecordAttributes>
     >) {
-      const groupSpecifier: Tabulation.GroupSpecifier = groupBy
-        ? {
-            ballotStyleId: groupBy.groupByBallotStyle
-              ? row.ballotStyleId
-              : undefined,
-            partyId: groupBy.groupByParty
-              ? ballotStylePartyLookup[assertDefined(row.ballotStyleId)]
-              : undefined,
-            batchId: groupBy.groupByBatch ? row.batchId : undefined,
-            scannerId: groupBy.groupByScanner ? row.scannerId : undefined,
-            precinctId: groupBy.groupByPrecinct ? row.precinctId : undefined,
-            votingMethod: groupBy.groupByVotingMethod
-              ? row.votingMethod
-              : undefined,
-          }
-        : {};
+      const groupSpecifier: Tabulation.GroupSpecifier = {
+        ballotStyleId: groupBy.groupByBallotStyle
+          ? row.ballotStyleId
+          : undefined,
+        partyId: groupBy.groupByParty
+          ? ballotStylePartyLookup[assertDefined(row.ballotStyleId)]
+          : undefined,
+        batchId: groupBy.groupByBatch ? row.batchId : undefined,
+        scannerId: groupBy.groupByScanner ? row.scannerId : undefined,
+        precinctId: groupBy.groupByPrecinct ? row.precinctId : undefined,
+        votingMethod: groupBy.groupByVotingMethod
+          ? row.votingMethod
+          : undefined,
+      };
 
       yield {
         ...groupSpecifier,
@@ -1758,7 +1756,7 @@ export class Store {
     );
   }
 
-  /* istanbul ignore next - debug purposes only */
+  /* c8 ignore start */
   getDebugSummary(): Map<string, number> {
     const tableNameRows = this.client.all(
       `select name from sqlite_schema where type='table' order by name;`
@@ -1778,4 +1776,5 @@ export class Store {
       )
     );
   }
+  /* c8 ignore stop */
 }

--- a/apps/admin/backend/src/tabulation/full_results.test.ts
+++ b/apps/admin/backend/src/tabulation/full_results.test.ts
@@ -6,6 +6,7 @@ import {
   BooleanEnvironmentVariableName,
   GROUP_KEY_ROOT,
   buildElectionResultsFixture,
+  buildManualResultsFixture,
   getFeatureFlagMock,
 } from '@votingworks/utils';
 import { assert } from '@votingworks/basics';
@@ -259,471 +260,535 @@ test('tabulateCastVoteRecords', () => {
   }
 });
 
-describe('tabulateElectionResults', () => {
-  test('with no grouping', async () => {
-    const store = Store.memoryStore();
+const candidateContestId =
+  'State-Representatives-Hillsborough-District-34-b1012d38';
 
-    const { electionDefinition, castVoteRecordReport } =
-      electionGridLayoutNewHampshireAmherstFixtures;
-    const electionId = store.addElection(electionDefinition.electionData);
-    store.setCurrentElectionId(electionId);
+test('tabulateElectionResults - write-in handling', async () => {
+  const store = Store.memoryStore();
 
-    const addReportResult = await addCastVoteRecordReport({
-      store,
-      reportDirectoryPath: castVoteRecordReport.asDirectoryPath(),
-      exportedTimestamp: new Date().toISOString(),
-      artifactAuthenticator: buildMockArtifactAuthenticator(),
-    });
-    const { id: fileId } = addReportResult.unsafeUnwrap();
-    expect(store.getCastVoteRecordCountByFileId(fileId)).toEqual(184);
+  const { electionDefinition, castVoteRecordReport } =
+    electionGridLayoutNewHampshireAmherstFixtures;
+  const { election } = electionDefinition;
+  const electionId = store.addElection(electionDefinition.electionData);
+  store.setCurrentElectionId(electionId);
 
-    const initialResultsWithoutWriteInDetail = tabulateElectionResults({
-      store,
-    })[GROUP_KEY_ROOT];
-    assert(initialResultsWithoutWriteInDetail);
+  const addReportResult = await addCastVoteRecordReport({
+    store,
+    reportDirectoryPath: castVoteRecordReport.asDirectoryPath(),
+    exportedTimestamp: new Date().toISOString(),
+    artifactAuthenticator: buildMockArtifactAuthenticator(),
+  });
+  const { id: fileId } = addReportResult.unsafeUnwrap();
+  expect(store.getCastVoteRecordCountByFileId(fileId)).toEqual(184);
 
-    // verify details of the results without write-in detail
-    expect(initialResultsWithoutWriteInDetail.cardCounts).toEqual({
+  /*  ******************* 
+  /*   Without WIA Data    
+  /*  ******************* */
+
+  const overallResultsNoWiaData = tabulateElectionResults({
+    electionId,
+    store,
+  })[GROUP_KEY_ROOT];
+  assert(overallResultsNoWiaData);
+
+  const partialExpectedResultsNoWiaData = buildElectionResultsFixture({
+    election,
+    cardCounts: {
       bmd: 0,
       hmpb: [184],
-    });
-
-    const candidateContestId =
-      'State-Representatives-Hillsborough-District-34-b1012d38';
-    const yesNoContestId =
-      'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc';
-
-    expect(
-      initialResultsWithoutWriteInDetail.contestResults[candidateContestId]
-    ).toEqual({
-      ballots: 184,
-      contestId: 'State-Representatives-Hillsborough-District-34-b1012d38',
-      contestType: 'candidate',
-      overvotes: 30,
-      tallies: {
-        'Abigail-Bartlett-4e46c9d4': {
-          id: 'Abigail-Bartlett-4e46c9d4',
-          name: 'Abigail Bartlett',
-          tally: 56,
-        },
-        'Elijah-Miller-a52e6988': {
-          id: 'Elijah-Miller-a52e6988',
-          name: 'Elijah Miller',
-          tally: 56,
-        },
-        'Isaac-Hill-d6c9deeb': {
-          id: 'Isaac-Hill-d6c9deeb',
-          name: 'Isaac Hill',
-          tally: 56,
-        },
-        'Jacob-Freese-b5146505': {
-          id: 'Jacob-Freese-b5146505',
-          name: 'Jacob Freese',
-          tally: 56,
-        },
-        'Mary-Baker-Eddy-350785d5': {
-          id: 'Mary-Baker-Eddy-350785d5',
-          name: 'Mary Baker Eddy',
-          tally: 58,
-        },
-        'Obadiah-Carrigan-5c95145a': {
-          id: 'Obadiah-Carrigan-5c95145a',
-          name: 'Obadiah Carrigan',
-          tally: 60,
-        },
-        'Samuel-Bell-17973275': {
-          id: 'Samuel-Bell-17973275',
-          name: 'Samuel Bell',
-          tally: 56,
-        },
-        'Samuel-Livermore-f927fef1': {
-          id: 'Samuel-Livermore-f927fef1',
-          name: 'Samuel Livermore',
-          tally: 56,
-        },
-        'write-in': {
-          id: 'write-in',
-          isWriteIn: true,
-          name: 'Write-In',
-          tally: 56,
+    },
+    contestResultsSummaries: {
+      [candidateContestId]: {
+        type: 'candidate',
+        ballots: 184,
+        overvotes: 30,
+        undervotes: 12,
+        officialOptionTallies: {
+          'Abigail-Bartlett-4e46c9d4': 56,
+          'Elijah-Miller-a52e6988': 56,
+          'Isaac-Hill-d6c9deeb': 56,
+          'Jacob-Freese-b5146505': 56,
+          'Mary-Baker-Eddy-350785d5': 58,
+          'Obadiah-Carrigan-5c95145a': 60,
+          'Samuel-Bell-17973275': 56,
+          'Samuel-Livermore-f927fef1': 56,
+          'write-in': 56,
         },
       },
-      undervotes: 12,
-      votesAllowed: 3,
-    });
-
-    expect(
-      initialResultsWithoutWriteInDetail.contestResults[yesNoContestId]
-    ).toEqual({
-      ballots: 184,
-      contestId:
-        'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc',
-      contestType: 'yesno',
-      noTally: 2,
-      overvotes: 2,
-      undervotes: 178,
-      yesTally: 2,
-    });
-
-    // since there has been no write-in adjudication yet, the result should the
-    // same if we include write-in adjudication data
-    const initialResultsWithWriteInDetail = tabulateElectionResults({
-      store,
-      includeWriteInAdjudicationResults: true,
-    })[GROUP_KEY_ROOT];
-    assert(initialResultsWithWriteInDetail);
-    expect(initialResultsWithWriteInDetail).toEqual(
-      initialResultsWithoutWriteInDetail
-    );
-
-    // now generate some write-in adjudication data
-    const writeIns = store.getWriteInRecords({
-      electionId,
-      contestId: candidateContestId,
-      status: 'pending',
-    });
-    const [writeIn1, writeIn2, writeIn3, writeIn4, writeIn5, writeIn6] =
-      writeIns;
-    store.adjudicateWriteIn({
-      writeInId: writeIn1!.id,
-      type: 'invalid',
-    });
-    store.adjudicateWriteIn({
-      writeInId: writeIn2!.id,
-      type: 'invalid',
-    });
-    store.adjudicateWriteIn({
-      writeInId: writeIn3!.id,
-      type: 'official-candidate',
-      candidateId: 'Obadiah-Carrigan-5c95145a',
-    });
-    store.adjudicateWriteIn({
-      writeInId: writeIn4!.id,
-      type: 'official-candidate',
-      candidateId: 'Abigail-Bartlett-4e46c9d4',
-    });
-    const writeInCandidate1 = store.addWriteInCandidate({
-      electionId,
-      contestId: candidateContestId,
-      name: 'Mr. Pickles',
-    });
-    store.adjudicateWriteIn({
-      writeInId: writeIn5!.id,
-      type: 'write-in-candidate',
-      candidateId: writeInCandidate1.id,
-    });
-    const writeInCandidate2 = store.addWriteInCandidate({
-      electionId,
-      contestId: candidateContestId,
-      name: 'Ms. Tomato',
-    });
-    store.adjudicateWriteIn({
-      writeInId: writeIn6!.id,
-      type: 'write-in-candidate',
-      candidateId: writeInCandidate2.id,
-    });
-
-    // verify the results are modified with write-in data appropriately
-    const modifiedResults = tabulateElectionResults({
-      store,
-      includeWriteInAdjudicationResults: true,
-    })[GROUP_KEY_ROOT];
-    assert(modifiedResults);
-    expect(modifiedResults.cardCounts).toEqual({
-      bmd: 0,
-      hmpb: [184],
-    });
-    expect(modifiedResults.contestResults[candidateContestId]).toEqual({
-      ballots: 184,
-      contestId: 'State-Representatives-Hillsborough-District-34-b1012d38',
-      contestType: 'candidate',
-      overvotes: 30,
-      tallies: {
-        'Abigail-Bartlett-4e46c9d4': {
-          id: 'Abigail-Bartlett-4e46c9d4',
-          name: 'Abigail Bartlett',
-          tally: 57,
-        },
-        'Elijah-Miller-a52e6988': {
-          id: 'Elijah-Miller-a52e6988',
-          name: 'Elijah Miller',
-          tally: 56,
-        },
-        'Isaac-Hill-d6c9deeb': {
-          id: 'Isaac-Hill-d6c9deeb',
-          name: 'Isaac Hill',
-          tally: 56,
-        },
-        'Jacob-Freese-b5146505': {
-          id: 'Jacob-Freese-b5146505',
-          name: 'Jacob Freese',
-          tally: 56,
-        },
-        'Mary-Baker-Eddy-350785d5': {
-          id: 'Mary-Baker-Eddy-350785d5',
-          name: 'Mary Baker Eddy',
-          tally: 58,
-        },
-        'Obadiah-Carrigan-5c95145a': {
-          id: 'Obadiah-Carrigan-5c95145a',
-          name: 'Obadiah Carrigan',
-          tally: 61,
-        },
-        'Samuel-Bell-17973275': {
-          id: 'Samuel-Bell-17973275',
-          name: 'Samuel Bell',
-          tally: 56,
-        },
-        'Samuel-Livermore-f927fef1': {
-          id: 'Samuel-Livermore-f927fef1',
-          name: 'Samuel Livermore',
-          tally: 56,
-        },
-        'write-in': {
-          id: 'write-in',
-          isWriteIn: true,
-          name: 'Write-In',
-          tally: 50,
-        },
-        [writeInCandidate1.id]: {
-          id: writeInCandidate1.id,
-          isWriteIn: true,
-          name: 'Mr. Pickles',
-          tally: 1,
-        },
-        [writeInCandidate2.id]: {
-          id: writeInCandidate2.id,
-          isWriteIn: true,
-          name: 'Ms. Tomato',
-          tally: 1,
-        },
-      },
-      undervotes: 14,
-      votesAllowed: 3,
-    });
+    },
+    includeGenericWriteIn: true,
   });
 
-  test('grouping & filtering by voting method', async () => {
-    const store = Store.memoryStore();
+  expect(overallResultsNoWiaData.cardCounts).toEqual(
+    partialExpectedResultsNoWiaData.cardCounts
+  );
+  expect(overallResultsNoWiaData.contestResults[candidateContestId]).toEqual(
+    partialExpectedResultsNoWiaData.contestResults[candidateContestId]
+  );
 
-    const { electionDefinition, castVoteRecordReport } =
-      electionGridLayoutNewHampshireAmherstFixtures;
-    const electionId = store.addElection(electionDefinition.electionData);
-    store.setCurrentElectionId(electionId);
+  /*  ********************** 
+  /*   With Screen WIA Data    
+  /*  ********************** */
 
-    const addReportResult = await addCastVoteRecordReport({
+  // now let's add some "screen-adjudicated" write-in adjudication
+  const writeIns = store.getWriteInRecords({
+    electionId,
+    contestId: candidateContestId,
+    status: 'pending',
+  });
+  const [writeIn1, writeIn2, writeIn3, writeIn4, writeIn5, writeIn6] = writeIns;
+  store.adjudicateWriteIn({
+    writeInId: writeIn1!.id,
+    type: 'invalid',
+  });
+  store.adjudicateWriteIn({
+    writeInId: writeIn2!.id,
+    type: 'invalid',
+  });
+  store.adjudicateWriteIn({
+    writeInId: writeIn3!.id,
+    type: 'official-candidate',
+    candidateId: 'Obadiah-Carrigan-5c95145a',
+  });
+  store.adjudicateWriteIn({
+    writeInId: writeIn4!.id,
+    type: 'official-candidate',
+    candidateId: 'Abigail-Bartlett-4e46c9d4',
+  });
+  const writeInCandidate1 = store.addWriteInCandidate({
+    electionId,
+    contestId: candidateContestId,
+    name: 'Mr. Pickles',
+  });
+  store.adjudicateWriteIn({
+    writeInId: writeIn5!.id,
+    type: 'write-in-candidate',
+    candidateId: writeInCandidate1.id,
+  });
+  const writeInCandidate2 = store.addWriteInCandidate({
+    electionId,
+    contestId: candidateContestId,
+    name: 'Ms. Tomato',
+  });
+  store.adjudicateWriteIn({
+    writeInId: writeIn6!.id,
+    type: 'write-in-candidate',
+    candidateId: writeInCandidate2.id,
+  });
+
+  // if we don't specify we need the WIA data, results are the same
+  expect(
+    tabulateElectionResults({
+      electionId,
       store,
-      reportDirectoryPath: castVoteRecordReport.asDirectoryPath(),
-      exportedTimestamp: new Date().toISOString(),
-      artifactAuthenticator: buildMockArtifactAuthenticator(),
+    })[GROUP_KEY_ROOT]
+  ).toEqual(overallResultsNoWiaData);
+
+  const overallResultsScreenWiaData = tabulateElectionResults({
+    electionId,
+    store,
+    includeWriteInAdjudicationResults: true,
+  })[GROUP_KEY_ROOT];
+  assert(overallResultsScreenWiaData);
+
+  const partialExpectedResultsScreenWiaData = buildElectionResultsFixture({
+    election,
+    cardCounts: {
+      bmd: 0,
+      hmpb: [184],
+    },
+    contestResultsSummaries: {
+      [candidateContestId]: {
+        type: 'candidate',
+        ballots: 184,
+        overvotes: 30,
+        undervotes: 14,
+        officialOptionTallies: {
+          'Abigail-Bartlett-4e46c9d4': 57,
+          'Elijah-Miller-a52e6988': 56,
+          'Isaac-Hill-d6c9deeb': 56,
+          'Jacob-Freese-b5146505': 56,
+          'Mary-Baker-Eddy-350785d5': 58,
+          'Obadiah-Carrigan-5c95145a': 61,
+          'Samuel-Bell-17973275': 56,
+          'Samuel-Livermore-f927fef1': 56,
+          'write-in': 50,
+        },
+        writeInOptionTallies: {
+          [writeInCandidate1.id]: {
+            name: 'Mr. Pickles',
+            tally: 1,
+          },
+          [writeInCandidate2.id]: {
+            name: 'Ms. Tomato',
+            tally: 1,
+          },
+        },
+      },
+    },
+    includeGenericWriteIn: true,
+  });
+
+  expect(overallResultsScreenWiaData.cardCounts).toEqual(
+    overallResultsScreenWiaData.cardCounts
+  );
+  expect(
+    overallResultsScreenWiaData.contestResults[candidateContestId]
+  ).toEqual(
+    partialExpectedResultsScreenWiaData.contestResults[candidateContestId]
+  );
+
+  /*  *******************************
+  /*   With Screen + Manual WIA Data    
+  /*  ******************************* */
+
+  const manualOnlyWriteInCandidate = store.addWriteInCandidate({
+    electionId,
+    contestId: candidateContestId,
+    name: 'New Kid',
+  });
+
+  store.setManualResults({
+    electionId,
+    precinctId: election.precincts[0]!.id,
+    ballotStyleId: election.ballotStyles[0]!.id,
+    votingMethod: 'precinct',
+    manualResults: buildManualResultsFixture({
+      election,
+      ballotCount: 5,
+      contestResultsSummaries: {
+        [candidateContestId]: {
+          type: 'candidate',
+          ballots: 5,
+          overvotes: 0,
+          undervotes: 0,
+          writeInOptionTallies: {
+            [writeInCandidate1.id]: {
+              name: 'Mr. Pickles',
+              tally: 3,
+            },
+            [manualOnlyWriteInCandidate.id]: {
+              name: 'New Kid',
+              tally: 2,
+            },
+          },
+        },
+      },
+    }),
+  });
+
+  const overallResultsScreenAndManualWiaData = tabulateElectionResults({
+    electionId,
+    store,
+    includeWriteInAdjudicationResults: true,
+    includeManualResults: true,
+  })[GROUP_KEY_ROOT];
+  assert(overallResultsScreenAndManualWiaData);
+
+  const partialExpectedResultsScreenAndManualWiaData =
+    buildElectionResultsFixture({
+      election,
+      cardCounts: {
+        bmd: 0,
+        hmpb: [184],
+        manual: 5,
+      },
+      contestResultsSummaries: {
+        [candidateContestId]: {
+          type: 'candidate',
+          ballots: 189,
+          overvotes: 30,
+          undervotes: 14,
+          officialOptionTallies: {
+            'Abigail-Bartlett-4e46c9d4': 57,
+            'Elijah-Miller-a52e6988': 56,
+            'Isaac-Hill-d6c9deeb': 56,
+            'Jacob-Freese-b5146505': 56,
+            'Mary-Baker-Eddy-350785d5': 58,
+            'Obadiah-Carrigan-5c95145a': 61,
+            'Samuel-Bell-17973275': 56,
+            'Samuel-Livermore-f927fef1': 56,
+            'write-in': 50,
+          },
+          writeInOptionTallies: {
+            [writeInCandidate1.id]: {
+              name: 'Mr. Pickles',
+              tally: 4,
+            },
+            [writeInCandidate2.id]: {
+              name: 'Ms. Tomato',
+              tally: 1,
+            },
+            [manualOnlyWriteInCandidate.id]: {
+              name: 'New Kid',
+              tally: 2,
+            },
+          },
+        },
+      },
+      includeGenericWriteIn: true,
     });
-    const { id: fileId } = addReportResult.unsafeUnwrap();
 
-    expect(store.getCastVoteRecordCountByFileId(fileId)).toEqual(184);
+  expect(overallResultsScreenAndManualWiaData.cardCounts).toEqual(
+    partialExpectedResultsScreenAndManualWiaData.cardCounts
+  );
+  expect(
+    overallResultsScreenAndManualWiaData.contestResults[candidateContestId]
+  ).toEqual(
+    partialExpectedResultsScreenAndManualWiaData.contestResults[
+      candidateContestId
+    ]
+  );
 
-    const candidateContestId =
-      'State-Representatives-Hillsborough-District-34-b1012d38';
-    const yesNoContestId =
-      'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc';
+  /*  ***********************************************
+  /*   With Screen + Manual WIA Data, Without Detail    
+  /*  *********************************************** */
 
-    // check filtered absentee results
-    const absenteeResults = tabulateElectionResults({
-      store,
-      filter: { votingMethods: ['absentee'] },
-      includeWriteInAdjudicationResults: true,
-    })[GROUP_KEY_ROOT];
-    assert(absenteeResults);
-    expect(absenteeResults.cardCounts).toEqual({
+  const overallResultsScreenAndManualNoWiaDetail = tabulateElectionResults({
+    electionId,
+    store,
+    includeManualResults: true,
+  })[GROUP_KEY_ROOT];
+  assert(overallResultsScreenAndManualNoWiaDetail);
+
+  const partialExpectedResultsScreenAndManualNoWiaDetail =
+    buildElectionResultsFixture({
+      election,
+      cardCounts: {
+        bmd: 0,
+        hmpb: [184],
+        manual: 5,
+      },
+      contestResultsSummaries: {
+        [candidateContestId]: {
+          type: 'candidate',
+          ballots: 189,
+          overvotes: 30,
+          undervotes: 12,
+          officialOptionTallies: {
+            'Abigail-Bartlett-4e46c9d4': 56,
+            'Elijah-Miller-a52e6988': 56,
+            'Isaac-Hill-d6c9deeb': 56,
+            'Jacob-Freese-b5146505': 56,
+            'Mary-Baker-Eddy-350785d5': 58,
+            'Obadiah-Carrigan-5c95145a': 60,
+            'Samuel-Bell-17973275': 56,
+            'Samuel-Livermore-f927fef1': 56,
+            'write-in': 61,
+          },
+        },
+      },
+      includeGenericWriteIn: true,
+    });
+
+  expect(overallResultsScreenAndManualNoWiaDetail.cardCounts).toEqual(
+    partialExpectedResultsScreenAndManualNoWiaDetail.cardCounts
+  );
+  expect(
+    overallResultsScreenAndManualNoWiaDetail.contestResults[candidateContestId]
+  ).toEqual(
+    partialExpectedResultsScreenAndManualNoWiaDetail.contestResults[
+      candidateContestId
+    ]
+  );
+});
+
+test('tabulateElectionResults - group and filter by voting method', async () => {
+  const store = Store.memoryStore();
+  const { electionDefinition, castVoteRecordReport } =
+    electionGridLayoutNewHampshireAmherstFixtures;
+  const { election } = electionDefinition;
+  const electionId = store.addElection(electionDefinition.electionData);
+  store.setCurrentElectionId(electionId);
+  const addReportResult = await addCastVoteRecordReport({
+    store,
+    reportDirectoryPath: castVoteRecordReport.asDirectoryPath(),
+    exportedTimestamp: new Date().toISOString(),
+    artifactAuthenticator: buildMockArtifactAuthenticator(),
+  });
+  const { id: fileId } = addReportResult.unsafeUnwrap();
+  expect(store.getCastVoteRecordCountByFileId(fileId)).toEqual(184);
+
+  // generate write-in adjudication data to confirm it is filtered
+  const writeIns = store.getWriteInRecords({
+    electionId,
+    contestId: candidateContestId,
+    status: 'pending',
+  });
+  expect(writeIns.length).toEqual(56);
+  for (const writeIn of writeIns) {
+    store.adjudicateWriteIn({
+      writeInId: writeIn.id,
+      type: 'invalid',
+    });
+  }
+
+  // check absentee results, should have received half of the adjudicated as invalid write-ins
+  const absenteeResults = tabulateElectionResults({
+    electionId,
+    store,
+    filter: { votingMethods: ['absentee'] },
+    includeWriteInAdjudicationResults: true,
+  })[GROUP_KEY_ROOT];
+  assert(absenteeResults);
+
+  const partialExpectedResults = buildElectionResultsFixture({
+    election,
+    contestResultsSummaries: {
+      [candidateContestId]: {
+        type: 'candidate',
+        ballots: 92,
+        overvotes: 15,
+        undervotes: 34,
+        officialOptionTallies: {
+          'Abigail-Bartlett-4e46c9d4': 28,
+          'Elijah-Miller-a52e6988': 28,
+          'Isaac-Hill-d6c9deeb': 28,
+          'Jacob-Freese-b5146505': 28,
+          'Mary-Baker-Eddy-350785d5': 29,
+          'Obadiah-Carrigan-5c95145a': 30,
+          'Samuel-Bell-17973275': 28,
+          'Samuel-Livermore-f927fef1': 28,
+        },
+      },
+    },
+    cardCounts: {
       bmd: 0,
       hmpb: [92],
-    });
-    expect(absenteeResults.contestResults[yesNoContestId]).toEqual({
-      ballots: 92,
-      contestId:
-        'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc',
-      contestType: 'yesno',
-      noTally: 1,
-      overvotes: 1,
-      undervotes: 89,
-      yesTally: 1,
-    });
-    expect(absenteeResults.contestResults[candidateContestId]).toEqual({
-      ballots: 92,
-      contestId: 'State-Representatives-Hillsborough-District-34-b1012d38',
-      contestType: 'candidate',
-      overvotes: 15,
-      tallies: {
-        'Abigail-Bartlett-4e46c9d4': {
-          id: 'Abigail-Bartlett-4e46c9d4',
-          name: 'Abigail Bartlett',
-          tally: 28,
-        },
-        'Elijah-Miller-a52e6988': {
-          id: 'Elijah-Miller-a52e6988',
-          name: 'Elijah Miller',
-          tally: 28,
-        },
-        'Isaac-Hill-d6c9deeb': {
-          id: 'Isaac-Hill-d6c9deeb',
-          name: 'Isaac Hill',
-          tally: 28,
-        },
-        'Jacob-Freese-b5146505': {
-          id: 'Jacob-Freese-b5146505',
-          name: 'Jacob Freese',
-          tally: 28,
-        },
-        'Mary-Baker-Eddy-350785d5': {
-          id: 'Mary-Baker-Eddy-350785d5',
-          name: 'Mary Baker Eddy',
-          tally: 29,
-        },
-        'Obadiah-Carrigan-5c95145a': {
-          id: 'Obadiah-Carrigan-5c95145a',
-          name: 'Obadiah Carrigan',
-          tally: 30,
-        },
-        'Samuel-Bell-17973275': {
-          id: 'Samuel-Bell-17973275',
-          name: 'Samuel Bell',
-          tally: 28,
-        },
-        'Samuel-Livermore-f927fef1': {
-          id: 'Samuel-Livermore-f927fef1',
-          name: 'Samuel Livermore',
-          tally: 28,
-        },
-        'write-in': {
-          id: 'write-in',
-          isWriteIn: true,
-          name: 'Write-In',
-          tally: 28,
-        },
-      },
-      undervotes: 6,
-      votesAllowed: 3,
-    });
-
-    // filtered precinct results should look the same, based on fixture
-    const precinctResults = tabulateElectionResults({
-      store,
-      filter: { votingMethods: ['precinct'] },
-      includeWriteInAdjudicationResults: true,
-    })[GROUP_KEY_ROOT];
-    assert(precinctResults);
-    expect(absenteeResults).toEqual(precinctResults);
-
-    // grouped by voting method results should be the same as when simply filtered
-    const resultsGroupedByVotingMethod = tabulateElectionResults({
-      store,
-      groupBy: { groupByVotingMethod: true },
-      includeWriteInAdjudicationResults: true,
-    });
-    expect(resultsGroupedByVotingMethod['root&absentee']).toEqual({
-      votingMethod: 'absentee',
-      ...absenteeResults,
-    });
-    expect(resultsGroupedByVotingMethod['root&precinct']).toEqual({
-      votingMethod: 'precinct',
-      ...precinctResults,
-    });
-
-    // generate write-in adjudication data to test filtering
-    const writeIns = store.getWriteInRecords({
-      electionId,
-      contestId: candidateContestId,
-      status: 'pending',
-    });
-    expect(writeIns.length).toEqual(56);
-    for (const writeIn of writeIns) {
-      store.adjudicateWriteIn({
-        writeInId: writeIn.id,
-        type: 'invalid',
-      });
-    }
-
-    // check absentee results after invalidating write-ins
-    const absenteeResultsAdjudicated = tabulateElectionResults({
-      store,
-      filter: { votingMethods: ['absentee'] },
-      includeWriteInAdjudicationResults: true,
-    })[GROUP_KEY_ROOT];
-    assert(absenteeResultsAdjudicated);
-    expect(
-      absenteeResultsAdjudicated.contestResults[candidateContestId]
-    ).toEqual({
-      ballots: 92,
-      contestId: 'State-Representatives-Hillsborough-District-34-b1012d38',
-      contestType: 'candidate',
-      overvotes: 15,
-      tallies: {
-        'Abigail-Bartlett-4e46c9d4': {
-          id: 'Abigail-Bartlett-4e46c9d4',
-          name: 'Abigail Bartlett',
-          tally: 28,
-        },
-        'Elijah-Miller-a52e6988': {
-          id: 'Elijah-Miller-a52e6988',
-          name: 'Elijah Miller',
-          tally: 28,
-        },
-        'Isaac-Hill-d6c9deeb': {
-          id: 'Isaac-Hill-d6c9deeb',
-          name: 'Isaac Hill',
-          tally: 28,
-        },
-        'Jacob-Freese-b5146505': {
-          id: 'Jacob-Freese-b5146505',
-          name: 'Jacob Freese',
-          tally: 28,
-        },
-        'Mary-Baker-Eddy-350785d5': {
-          id: 'Mary-Baker-Eddy-350785d5',
-          name: 'Mary Baker Eddy',
-          tally: 29,
-        },
-        'Obadiah-Carrigan-5c95145a': {
-          id: 'Obadiah-Carrigan-5c95145a',
-          name: 'Obadiah Carrigan',
-          tally: 30,
-        },
-        'Samuel-Bell-17973275': {
-          id: 'Samuel-Bell-17973275',
-          name: 'Samuel Bell',
-          tally: 28,
-        },
-        'Samuel-Livermore-f927fef1': {
-          id: 'Samuel-Livermore-f927fef1',
-          name: 'Samuel Livermore',
-          tally: 28,
-        },
-      },
-      undervotes: 34,
-      votesAllowed: 3,
-    });
-
-    // check results filtered by precinct voting method
-    const precinctResultsAdjudicated = tabulateElectionResults({
-      store,
-      filter: { votingMethods: ['precinct'] },
-      includeWriteInAdjudicationResults: true,
-    })[GROUP_KEY_ROOT];
-    assert(precinctResultsAdjudicated);
-    expect(absenteeResultsAdjudicated).toEqual(precinctResultsAdjudicated);
-
-    // check the grouped results
-    const adjudicatedResultsByVotingMethod = tabulateElectionResults({
-      store,
-      groupBy: { groupByVotingMethod: true },
-      includeWriteInAdjudicationResults: true,
-    });
-    expect(adjudicatedResultsByVotingMethod['root&absentee']).toEqual({
-      votingMethod: 'absentee',
-      ...absenteeResultsAdjudicated,
-    });
-    expect(adjudicatedResultsByVotingMethod['root&precinct']).toEqual({
-      votingMethod: 'precinct',
-      ...precinctResultsAdjudicated,
-    });
+    },
+    includeGenericWriteIn: false,
   });
+
+  expect(absenteeResults.cardCounts).toEqual(partialExpectedResults.cardCounts);
+  expect(absenteeResults.contestResults[candidateContestId]).toEqual(
+    partialExpectedResults.contestResults[candidateContestId]
+  );
+
+  // precinct results should match
+  const precinctResults = tabulateElectionResults({
+    electionId,
+    store,
+    filter: { votingMethods: ['precinct'] },
+    includeWriteInAdjudicationResults: true,
+  })[GROUP_KEY_ROOT];
+  assert(precinctResults);
+
+  expect(precinctResults.cardCounts).toEqual(partialExpectedResults.cardCounts);
+  expect(precinctResults.contestResults[candidateContestId]).toEqual(
+    partialExpectedResults.contestResults[candidateContestId]
+  );
+
+  // results grouped by voting method should match, with group specifiers
+  const groupedResults = tabulateElectionResults({
+    electionId,
+    store,
+    groupBy: { groupByVotingMethod: true },
+    includeWriteInAdjudicationResults: true,
+  });
+  const absenteeResultsGroup = groupedResults['root&absentee'];
+  const precinctResultsGroup = groupedResults['root&precinct'];
+  assert(absenteeResultsGroup && precinctResultsGroup);
+
+  expect(absenteeResultsGroup.cardCounts).toEqual(
+    partialExpectedResults.cardCounts
+  );
+  expect(absenteeResultsGroup.contestResults[candidateContestId]).toEqual(
+    partialExpectedResults.contestResults[candidateContestId]
+  );
+  expect(absenteeResultsGroup.votingMethod).toEqual('absentee');
+
+  expect(precinctResultsGroup.cardCounts).toEqual(
+    partialExpectedResults.cardCounts
+  );
+  expect(precinctResultsGroup.contestResults[candidateContestId]).toEqual(
+    partialExpectedResults.contestResults[candidateContestId]
+  );
+  expect(precinctResultsGroup.votingMethod).toEqual('precinct');
+
+  // if we add manual data, it will be selectively incorporated
+  store.setManualResults({
+    electionId,
+    precinctId: election.precincts[0]!.id,
+    ballotStyleId: election.ballotStyles[0]!.id,
+    votingMethod: 'absentee',
+    manualResults: buildManualResultsFixture({
+      election,
+      ballotCount: 10,
+      contestResultsSummaries: {
+        [candidateContestId]: {
+          type: 'candidate',
+          ballots: 10,
+          overvotes: 0,
+          undervotes: 0,
+          officialOptionTallies: {
+            'Obadiah-Carrigan-5c95145a': 10,
+          },
+        },
+      },
+    }),
+  });
+
+  // check absentee results again, should now have manual results added
+  const absenteeResultsWithManual = tabulateElectionResults({
+    electionId,
+    store,
+    filter: { votingMethods: ['absentee'] },
+    includeWriteInAdjudicationResults: true,
+    includeManualResults: true,
+  })[GROUP_KEY_ROOT];
+  assert(absenteeResultsWithManual);
+
+  const partialExpectedResultsWithManual = buildElectionResultsFixture({
+    election,
+    contestResultsSummaries: {
+      [candidateContestId]: {
+        type: 'candidate',
+        ballots: 102,
+        overvotes: 15,
+        undervotes: 34,
+        officialOptionTallies: {
+          'Abigail-Bartlett-4e46c9d4': 28,
+          'Elijah-Miller-a52e6988': 28,
+          'Isaac-Hill-d6c9deeb': 28,
+          'Jacob-Freese-b5146505': 28,
+          'Mary-Baker-Eddy-350785d5': 29,
+          'Obadiah-Carrigan-5c95145a': 40,
+          'Samuel-Bell-17973275': 28,
+          'Samuel-Livermore-f927fef1': 28,
+        },
+      },
+    },
+    cardCounts: {
+      bmd: 0,
+      hmpb: [92],
+      manual: 10,
+    },
+    includeGenericWriteIn: false,
+  });
+
+  expect(absenteeResultsWithManual.cardCounts).toEqual(
+    partialExpectedResultsWithManual.cardCounts
+  );
+  expect(absenteeResultsWithManual.contestResults[candidateContestId]).toEqual(
+    partialExpectedResultsWithManual.contestResults[candidateContestId]
+  );
+
+  // check precinct results again, should be the same
+  const precinctResultsWithManual = tabulateElectionResults({
+    electionId,
+    store,
+    filter: { votingMethods: ['precinct'] },
+    includeWriteInAdjudicationResults: true,
+    includeManualResults: true,
+  })[GROUP_KEY_ROOT];
+  assert(precinctResultsWithManual);
+
+  expect(precinctResultsWithManual.cardCounts).toEqual({
+    bmd: 0,
+    hmpb: [92],
+    manual: 0,
+  });
+  expect(precinctResultsWithManual.contestResults[candidateContestId]).toEqual(
+    partialExpectedResults.contestResults[candidateContestId]
+  );
 });

--- a/apps/admin/backend/src/tabulation/full_results.ts
+++ b/apps/admin/backend/src/tabulation/full_results.ts
@@ -48,13 +48,8 @@ export function tabulateElectionResults({
   // if specified
   if (includeWriteInAdjudicationResults) {
     const groupedWriteInSummaries = tabulateWriteInTallies({
-      election,
-      writeInTallies: store.getWriteInTalliesForTabulation({
-        electionId,
-        election,
-        filter,
-        groupBy,
-      }),
+      store,
+      filter,
       groupBy,
     });
 

--- a/apps/admin/backend/src/tabulation/manual_results.test.ts
+++ b/apps/admin/backend/src/tabulation/manual_results.test.ts
@@ -58,6 +58,7 @@ describe('queryManualResults', () => {
 
     expect(
       tabulateManualResults({
+        electionId,
         store,
         filter: { batchIds: ['batch-1'] },
       }).err()
@@ -72,7 +73,11 @@ describe('queryManualResults', () => {
     store.setCurrentElectionId(electionId);
 
     expect(
-      tabulateManualResults({ store, groupBy: { groupByBatch: true } }).err()
+      tabulateManualResults({
+        electionId,
+        store,
+        groupBy: { groupByBatch: true },
+      }).err()
     ).toEqual({ type: 'incompatible-group-by' });
   });
 
@@ -286,7 +291,12 @@ describe('queryManualResults', () => {
     ];
 
     for (const { filter, groupBy, expected } of testCases) {
-      const result = tabulateManualResults({ store, filter, groupBy });
+      const result = tabulateManualResults({
+        electionId,
+        store,
+        filter,
+        groupBy,
+      });
       assert(result.isOk());
 
       for (const [groupKey, ballotCount, groupSpecifier] of expected) {

--- a/apps/admin/backend/src/tabulation/manual_results.ts
+++ b/apps/admin/backend/src/tabulation/manual_results.ts
@@ -1,11 +1,11 @@
-import { Election, Tabulation } from '@votingworks/types';
+import { Election, Id, Tabulation } from '@votingworks/types';
 import {
   BallotStyleIdPartyIdLookup,
   combineManualElectionResults,
   getBallotStyleIdPartyIdLookup,
   getGroupKey,
 } from '@votingworks/utils';
-import { Result, assert, err, ok } from '@votingworks/basics';
+import { Result, assertDefined, err, ok } from '@votingworks/basics';
 import {
   ManualResultsFilter,
   ManualResultsGroupBy,
@@ -106,10 +106,12 @@ type GetManualResultsError =
  * Filters, groups, and aggregates manual results.
  */
 export function tabulateManualResults({
+  electionId,
   store,
   filter = {},
   groupBy = {},
 }: {
+  electionId: Id;
   store: Store;
   filter?: Tabulation.Filter;
   groupBy?: Tabulation.GroupBy;
@@ -125,13 +127,9 @@ export function tabulateManualResults({
     return err({ type: 'incompatible-group-by' });
   }
 
-  const electionId = store.getCurrentElectionId();
-  assert(electionId !== undefined);
-  const electionRecord = store.getElection(electionId);
-  assert(electionRecord);
   const {
     electionDefinition: { election },
-  } = electionRecord;
+  } = assertDefined(store.getElection(electionId));
 
   const manualResultsRecords = store.getManualResults({
     electionId,

--- a/apps/admin/backend/src/tabulation/write_ins.test.ts
+++ b/apps/admin/backend/src/tabulation/write_ins.test.ts
@@ -1,6 +1,9 @@
-import { electionMinimalExhaustiveSampleDefinition } from '@votingworks/fixtures';
+import {
+  electionMinimalExhaustiveSampleDefinition,
+  electionMinimalExhaustiveSampleFixtures,
+} from '@votingworks/fixtures';
 import { Tabulation, writeInCandidate } from '@votingworks/types';
-import { GROUP_KEY_ROOT, getEmptyElectionResults } from '@votingworks/utils';
+import { getEmptyElectionResults } from '@votingworks/utils';
 import {
   convertContestWriteInSummaryToWriteInTallies,
   getEmptyContestWriteInSummary,
@@ -8,7 +11,12 @@ import {
   tabulateWriteInTallies,
   modifyElectionResultsWithWriteInSummary,
 } from './write_ins';
-import { ContestWriteInSummary, WriteInTally } from '../types';
+import { ContestWriteInSummary, ElectionWriteInSummary } from '../types';
+import {
+  MockCastVoteRecordFile,
+  addMockCvrFileToStore,
+} from '../../test/mock_cvr_file';
+import { Store } from '../store';
 
 test('getEmptyElectionWriteInSummary', () => {
   const { election } = electionMinimalExhaustiveSampleDefinition;
@@ -135,261 +143,209 @@ const mockAquariumCouncilFishSummary: ContestWriteInSummary = {
   },
 };
 
-describe('tabulateWriteInTallies', () => {
-  const { election } = electionMinimalExhaustiveSampleDefinition;
+test('tabulateWriteInTallies', () => {
+  const store = Store.memoryStore();
+  const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
+  const { election, electionData } = electionDefinition;
+  const electionId = store.addElection(electionData);
+  store.setCurrentElectionId(electionId);
 
-  test('without grouping', () => {
-    expect(
-      tabulateWriteInTallies({
-        election,
-        writeInTallies: [
-          {
-            contestId: 'zoo-council-mammal',
-            status: 'pending',
-            tally: 11,
-          },
-          {
-            contestId: 'zoo-council-mammal',
-            status: 'adjudicated',
-            adjudicationType: 'invalid',
-            tally: 9,
-          },
-          {
-            contestId: 'zoo-council-mammal',
-            status: 'adjudicated',
-            adjudicationType: 'official-candidate',
-            candidateId: 'lion',
-            candidateName: 'Lion',
-            tally: 7,
-          },
-          {
-            contestId: 'zoo-council-mammal',
-            status: 'adjudicated',
-            adjudicationType: 'write-in-candidate',
-            candidateId: 'mr-pickles',
-            candidateName: 'Mr. Pickles',
-            tally: 5,
-          },
-          {
-            contestId: 'aquarium-council-fish',
-            status: 'pending',
-            tally: 25,
-          },
-        ],
-      })[GROUP_KEY_ROOT]
-    ).toEqual({
-      contestWriteInSummaries: {
-        'aquarium-council-fish': {
-          contestId: 'aquarium-council-fish',
-          invalidTally: 0,
-          pendingTally: 25,
-          totalTally: 25,
-          candidateTallies: {},
-        },
-        'zoo-council-mammal': {
-          contestId: 'zoo-council-mammal',
-          invalidTally: 9,
-          pendingTally: 11,
-          totalTally: 32,
-          candidateTallies: {
-            'mr-pickles': {
-              id: 'mr-pickles',
-              name: 'Mr. Pickles',
-              tally: 5,
-              isWriteIn: true,
-            },
-            lion: {
-              id: 'lion',
-              name: 'Lion',
-              tally: 7,
-              isWriteIn: false,
-            },
-          },
-        },
-      },
-    });
-  });
-
-  test('by ballot style', () => {
-    const writeInTallies: Array<Tabulation.GroupOf<WriteInTally>> = [
-      ...convertContestWriteInSummaryToWriteInTallies({
-        ballotStyleId: '1M',
-        ...mockZooCouncilMammalSummary,
-      }),
-      ...convertContestWriteInSummaryToWriteInTallies({
-        ballotStyleId: '2F',
-        ...mockAquariumCouncilFishSummary,
-      }),
-    ];
-
-    const groupedWriteInSummaries = tabulateWriteInTallies({
-      election,
-      writeInTallies,
-      groupBy: {
-        groupByBallotStyle: true,
-      },
-    });
-    expect(Object.entries(groupedWriteInSummaries)).toHaveLength(2);
-
-    expect(groupedWriteInSummaries['root&1M']).toEqual({
+  // add some mock cast vote records with write-ins to store
+  const mockCastVoteRecordFile: MockCastVoteRecordFile = [
+    {
       ballotStyleId: '1M',
-      contestWriteInSummaries: {
-        'zoo-council-mammal': mockZooCouncilMammalSummary,
-        'aquarium-council-fish': getEmptyContestWriteInSummary(
-          'aquarium-council-fish'
-        ),
-      },
-    });
-
-    expect(groupedWriteInSummaries['root&2F']).toEqual({
-      ballotStyleId: '2F',
-      contestWriteInSummaries: {
-        'zoo-council-mammal':
-          getEmptyContestWriteInSummary('zoo-council-mammal'),
-        'aquarium-council-fish': mockAquariumCouncilFishSummary,
-      },
-    });
-  });
-
-  test('by party', () => {
-    const writeInTallies: Array<Tabulation.GroupOf<WriteInTally>> = [
-      ...convertContestWriteInSummaryToWriteInTallies({
-        partyId: '0',
-        ...mockZooCouncilMammalSummary,
-      }),
-      ...convertContestWriteInSummaryToWriteInTallies({
-        partyId: '1',
-        ...mockAquariumCouncilFishSummary,
-      }),
-    ];
-
-    const groupedWriteInSummaries = tabulateWriteInTallies({
-      election,
-      writeInTallies,
-      groupBy: {
-        groupByParty: true,
-      },
-    });
-    expect(Object.entries(groupedWriteInSummaries)).toHaveLength(2);
-
-    expect(groupedWriteInSummaries['root&0']).toEqual({
-      partyId: '0',
-      contestWriteInSummaries: {
-        'zoo-council-mammal': mockZooCouncilMammalSummary,
-        'aquarium-council-fish': getEmptyContestWriteInSummary(
-          'aquarium-council-fish'
-        ),
-      },
-    });
-
-    expect(groupedWriteInSummaries['root&1']).toEqual({
-      partyId: '1',
-      contestWriteInSummaries: {
-        'zoo-council-mammal':
-          getEmptyContestWriteInSummary('zoo-council-mammal'),
-        'aquarium-council-fish': mockAquariumCouncilFishSummary,
-      },
-    });
-  });
-
-  test('by batch and scanner', () => {
-    const writeInTallies: Array<Tabulation.GroupOf<WriteInTally>> = [
-      ...convertContestWriteInSummaryToWriteInTallies({
-        batchId: 'batch-1',
-        scannerId: 'scanner-1',
-        ...mockZooCouncilMammalSummary,
-      }),
-      ...convertContestWriteInSummaryToWriteInTallies({
-        batchId: 'batch-1',
-        scannerId: 'scanner-1',
-        ...mockAquariumCouncilFishSummary,
-      }),
-    ];
-
-    const groupedWriteInSummaries = tabulateWriteInTallies({
-      election,
-      writeInTallies,
-      groupBy: {
-        groupByBatch: true,
-        groupByScanner: true,
-      },
-    });
-    expect(Object.entries(groupedWriteInSummaries)).toHaveLength(1);
-
-    expect(groupedWriteInSummaries['root&batch-1&scanner-1']).toEqual({
-      batchId: 'batch-1',
+      batchId: 'batch-1-1',
       scannerId: 'scanner-1',
-      contestWriteInSummaries: {
-        'zoo-council-mammal': mockZooCouncilMammalSummary,
-        'aquarium-council-fish': mockAquariumCouncilFishSummary,
-      },
-    });
-  });
+      precinctId: 'precinct-1',
+      votingMethod: 'precinct',
+      votes: { 'zoo-council-mammal': ['write-in'] },
+      card: { type: 'bmd' },
+      multiplier: 5,
+    },
+    {
+      ballotStyleId: '1M',
+      batchId: 'batch-1-1',
+      scannerId: 'scanner-1',
+      precinctId: 'precinct-1',
+      votingMethod: 'absentee',
+      votes: { 'zoo-council-mammal': ['write-in'] },
+      card: { type: 'bmd' },
+      multiplier: 6,
+    },
+    {
+      ballotStyleId: '2F',
+      batchId: 'batch-1-2',
+      scannerId: 'scanner-1',
+      precinctId: 'precinct-1',
+      votingMethod: 'precinct',
+      votes: { 'zoo-council-mammal': ['write-in'] },
+      card: { type: 'bmd' },
+      multiplier: 17,
+    },
+    {
+      ballotStyleId: '2F',
+      batchId: 'batch-2-1',
+      scannerId: 'scanner-2',
+      precinctId: 'precinct-2',
+      votingMethod: 'absentee',
+      votes: { 'zoo-council-mammal': ['write-in'] },
+      card: { type: 'bmd' },
+      multiplier: 9,
+    },
+    {
+      ballotStyleId: '2F',
+      batchId: 'batch-2-2',
+      scannerId: 'scanner-2',
+      precinctId: 'precinct-2',
+      votingMethod: 'precinct',
+      votes: { 'zoo-council-mammal': ['write-in'] },
+      card: { type: 'bmd' },
+      multiplier: 12,
+    },
+    {
+      ballotStyleId: '1M',
+      batchId: 'batch-3-1',
+      scannerId: 'scanner-3',
+      precinctId: 'precinct-2',
+      votingMethod: 'precinct',
+      votes: { 'zoo-council-mammal': ['write-in'] },
+      card: { type: 'bmd' },
+      multiplier: 34,
+    },
+  ];
+  addMockCvrFileToStore({ electionId, mockCastVoteRecordFile, store });
 
-  test('by precinct and and voting method', () => {
-    const writeInTallies: Array<Tabulation.GroupOf<WriteInTally>> = [
-      ...convertContestWriteInSummaryToWriteInTallies({
-        precinctId: 'precinct-1',
-        votingMethod: 'precinct',
-        ...mockZooCouncilMammalSummary,
-      }),
-      ...convertContestWriteInSummaryToWriteInTallies({
-        precinctId: 'precinct-2',
-        votingMethod: 'precinct',
-        ...mockZooCouncilMammalSummary,
-      }),
-      ...convertContestWriteInSummaryToWriteInTallies({
-        precinctId: 'precinct-1',
-        votingMethod: 'absentee',
-        ...mockZooCouncilMammalSummary,
-      }),
-      ...convertContestWriteInSummaryToWriteInTallies({
-        precinctId: 'precinct-2',
-        votingMethod: 'absentee',
-        ...mockZooCouncilMammalSummary,
-      }),
-    ];
+  // because we're only testing filtering
+  function getMockElectionWriteInSummary(
+    pendingTally: number
+  ): ElectionWriteInSummary {
+    const electionWriteInSummary = getEmptyElectionWriteInSummary(election);
+    const contestWriteInSummary =
+      getEmptyContestWriteInSummary('zoo-council-mammal');
+    contestWriteInSummary.pendingTally = pendingTally;
+    contestWriteInSummary.totalTally = pendingTally;
+    electionWriteInSummary.contestWriteInSummaries['zoo-council-mammal'] =
+      contestWriteInSummary;
+    return electionWriteInSummary;
+  }
 
+  const testCases: Array<{
+    filter?: Tabulation.Filter;
+    groupBy?: Tabulation.GroupBy;
+    expected: Array<
+      [
+        groupKey: Tabulation.GroupKey,
+        tally: number,
+        groupSpecifier: Tabulation.GroupSpecifier
+      ]
+    >;
+  }> = [
+    // no filter case
+    {
+      expected: [['root', 83, {}]],
+    },
+    // each filter case
+    {
+      filter: { precinctIds: ['precinct-2'] },
+      expected: [['root', 55, {}]],
+    },
+    {
+      filter: { scannerIds: ['scanner-2'] },
+      expected: [['root', 21, {}]],
+    },
+    {
+      filter: { batchIds: ['batch-2-1', 'batch-3-1'] },
+      expected: [['root', 43, {}]],
+    },
+    {
+      filter: { votingMethods: ['precinct'] },
+      expected: [['root', 68, {}]],
+    },
+    {
+      filter: { ballotStyleIds: ['1M'] },
+      expected: [['root', 45, {}]],
+    },
+    {
+      filter: { partyIds: ['0'] },
+      expected: [['root', 45, {}]],
+    },
+    // empty filter case
+    {
+      filter: { partyIds: [] },
+      expected: [['root', 0, {}]],
+    },
+    // trivial filter case
+    {
+      filter: { partyIds: ['0', '1'] },
+      expected: [['root', 83, {}]],
+    },
+    // each group case
+    {
+      groupBy: { groupByBallotStyle: true },
+      expected: [
+        ['root&1M', 45, { ballotStyleId: '1M' }],
+        ['root&2F', 38, { ballotStyleId: '2F' }],
+      ],
+    },
+    {
+      groupBy: { groupByParty: true },
+      expected: [
+        ['root&0', 45, { partyId: '0' }],
+        ['root&1', 38, { partyId: '1' }],
+      ],
+    },
+    {
+      groupBy: { groupByBatch: true },
+      expected: [
+        ['root&batch-1-1', 11, { batchId: 'batch-1-1' }],
+        ['root&batch-1-2', 17, { batchId: 'batch-1-2' }],
+        ['root&batch-2-1', 9, { batchId: 'batch-2-1' }],
+        ['root&batch-2-2', 12, { batchId: 'batch-2-2' }],
+        ['root&batch-3-1', 34, { batchId: 'batch-3-1' }],
+      ],
+    },
+    {
+      groupBy: { groupByScanner: true },
+      expected: [
+        ['root&scanner-1', 28, { scannerId: 'scanner-1' }],
+        ['root&scanner-2', 21, { scannerId: 'scanner-2' }],
+        ['root&scanner-3', 34, { scannerId: 'scanner-3' }],
+      ],
+    },
+    {
+      groupBy: { groupByPrecinct: true },
+      expected: [
+        ['root&precinct-1', 28, { precinctId: 'precinct-1' }],
+        ['root&precinct-2', 55, { precinctId: 'precinct-2' }],
+      ],
+    },
+    {
+      groupBy: { groupByVotingMethod: true },
+      expected: [
+        ['root&precinct', 68, { votingMethod: 'precinct' }],
+        ['root&absentee', 15, { votingMethod: 'absentee' }],
+      ],
+    },
+  ];
+
+  for (const { filter, groupBy, expected } of testCases) {
     const groupedWriteInSummaries = tabulateWriteInTallies({
-      election,
-      writeInTallies,
-      groupBy: {
-        groupByPrecinct: true,
-        groupByVotingMethod: true,
-      },
+      store,
+      filter,
+      groupBy,
     });
 
-    const electionWriteInSummaries = Object.values(groupedWriteInSummaries);
-    expect(electionWriteInSummaries).toHaveLength(4);
-    for (const electionWriteInSummary of electionWriteInSummaries) {
-      expect(electionWriteInSummary.contestWriteInSummaries).toEqual({
-        'zoo-council-mammal': mockZooCouncilMammalSummary,
-        'aquarium-council-fish': getEmptyContestWriteInSummary(
-          'aquarium-council-fish'
-        ),
+    for (const [groupKey, tally, groupSpecifier] of expected) {
+      expect(groupedWriteInSummaries[groupKey]).toEqual({
+        ...getMockElectionWriteInSummary(tally),
+        ...groupSpecifier,
       });
     }
-    expect(electionWriteInSummaries).toMatchObject(
-      expect.arrayContaining([
-        expect.objectContaining({
-          precinctId: 'precinct-1',
-          votingMethod: 'precinct',
-        }),
-        expect.objectContaining({
-          precinctId: 'precinct-2',
-          votingMethod: 'precinct',
-        }),
-        expect.objectContaining({
-          precinctId: 'precinct-1',
-          votingMethod: 'absentee',
-        }),
-        expect.objectContaining({
-          precinctId: 'precinct-2',
-          votingMethod: 'absentee',
-        }),
-      ])
+
+    expect(Object.values(groupedWriteInSummaries)).toHaveLength(
+      expected.length
     );
-  });
+  }
 });
 
 test('modifyElectionResultsWithWriteInSummary', () => {

--- a/apps/admin/backend/src/tabulation/write_ins.test.ts
+++ b/apps/admin/backend/src/tabulation/write_ins.test.ts
@@ -330,6 +330,7 @@ test('tabulateWriteInTallies', () => {
 
   for (const { filter, groupBy, expected } of testCases) {
     const groupedWriteInSummaries = tabulateWriteInTallies({
+      electionId,
       store,
       filter,
       groupBy,

--- a/apps/admin/backend/src/tabulation/write_ins.ts
+++ b/apps/admin/backend/src/tabulation/write_ins.ts
@@ -1,11 +1,11 @@
-import { ContestId, Election, Tabulation } from '@votingworks/types';
+import { ContestId, Election, Id, Tabulation } from '@votingworks/types';
 import {
   GROUP_KEY_ROOT,
   extractGroupSpecifier,
   getGroupKey,
   isGroupByEmpty,
 } from '@votingworks/utils';
-import { assert, throwIllegalValue } from '@votingworks/basics';
+import { assert, assertDefined, throwIllegalValue } from '@votingworks/basics';
 import {
   ContestWriteInSummary,
   ElectionWriteInSummary,
@@ -154,21 +154,20 @@ function addWriteInTallyToElectionWriteInSummary({
  * organized by contest and the optional `groupBy` parameter.
  */
 export function tabulateWriteInTallies({
+  electionId,
   store,
   filter,
   groupBy,
 }: {
+  electionId: Id;
   store: Store;
   filter?: Tabulation.Filter;
   groupBy?: Tabulation.GroupBy;
 }): Tabulation.Grouped<ElectionWriteInSummary> {
-  const electionId = store.getCurrentElectionId();
-  assert(electionId !== undefined);
-  const electionRecord = store.getElection(electionId);
-  assert(electionRecord);
   const {
     electionDefinition: { election },
-  } = electionRecord;
+  } = assertDefined(store.getElection(electionId));
+
   const writeInTallies = store.getWriteInTalliesForTabulation({
     electionId,
     election,

--- a/apps/admin/backend/src/tabulation/write_ins.ts
+++ b/apps/admin/backend/src/tabulation/write_ins.ts
@@ -11,6 +11,7 @@ import {
   ElectionWriteInSummary,
   WriteInTally,
 } from '../types';
+import { Store } from '../store';
 
 /**
  * Creates an empty contest write-in summary.
@@ -146,14 +147,28 @@ function addWriteInTallyToElectionWriteInSummary({
  * organized by contest and the optional `groupBy` parameter.
  */
 export function tabulateWriteInTallies({
-  election,
-  writeInTallies,
+  store,
+  filter,
   groupBy,
 }: {
-  election: Election;
-  writeInTallies: Iterable<Tabulation.GroupOf<WriteInTally>>;
+  store: Store;
+  filter?: Tabulation.Filter;
   groupBy?: Tabulation.GroupBy;
 }): Tabulation.Grouped<ElectionWriteInSummary> {
+  const electionId = store.getCurrentElectionId();
+  assert(electionId !== undefined);
+  const electionRecord = store.getElection(electionId);
+  assert(electionRecord);
+  const {
+    electionDefinition: { election },
+  } = electionRecord;
+  const writeInTallies = store.getWriteInTalliesForTabulation({
+    electionId,
+    election,
+    filter,
+    groupBy,
+  });
+
   const groupedElectionWriteInSummaries: Record<
     string,
     ElectionWriteInSummary

--- a/apps/admin/backend/src/tabulation/write_ins.ts
+++ b/apps/admin/backend/src/tabulation/write_ins.ts
@@ -119,24 +119,31 @@ function addWriteInTallyToElectionWriteInSummary({
 
   if (writeInTally.status === 'pending') {
     contestWriteInSummary.pendingTally += writeInTally.tally;
-  } else if (writeInTally.adjudicationType === 'invalid') {
-    contestWriteInSummary.invalidTally += writeInTally.tally;
-  } else if (writeInTally.adjudicationType === 'official-candidate') {
-    contestWriteInSummary.candidateTallies[writeInTally.candidateId] = {
-      tally: writeInTally.tally,
-      name: writeInTally.candidateName,
-      id: writeInTally.candidateId,
-      isWriteIn: false,
-    };
-  } else if (writeInTally.adjudicationType === 'write-in-candidate') {
-    contestWriteInSummary.candidateTallies[writeInTally.candidateId] = {
-      tally: writeInTally.tally,
-      name: writeInTally.candidateName,
-      id: writeInTally.candidateId,
-      isWriteIn: true,
-    };
   } else {
-    throwIllegalValue(writeInTally);
+    switch (writeInTally.adjudicationType) {
+      case 'invalid':
+        contestWriteInSummary.invalidTally += writeInTally.tally;
+        break;
+      case 'official-candidate':
+        contestWriteInSummary.candidateTallies[writeInTally.candidateId] = {
+          tally: writeInTally.tally,
+          name: writeInTally.candidateName,
+          id: writeInTally.candidateId,
+          isWriteIn: false,
+        };
+        break;
+      case 'write-in-candidate':
+        contestWriteInSummary.candidateTallies[writeInTally.candidateId] = {
+          tally: writeInTally.tally,
+          name: writeInTally.candidateName,
+          id: writeInTally.candidateId,
+          isWriteIn: true,
+        };
+        break;
+      /* c8 ignore next 2 */
+      default:
+        throwIllegalValue(writeInTally);
+    }
   }
 
   return electionWriteInSummary;

--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -1,6 +1,5 @@
 import { Result } from '@votingworks/basics';
 import {
-  CVR,
   ContestId,
   ContestOptionId,
   ElectionDefinition,
@@ -62,17 +61,6 @@ export interface CastVoteRecordFileMetadata {
   readonly scannerIds: readonly string[];
   readonly exportTimestamp: Date;
   readonly isTestModeResults: boolean;
-}
-
-/**
- * Representation of a cast vote record's metadata. Does not include ballot ID.
- */
-export interface CastVoteRecordMetadata {
-  precinctId: string;
-  ballotStyleId: string;
-  ballotType: CVR.vxBallotType;
-  batchId: string;
-  sheetNumber?: number;
 }
 
 /**

--- a/apps/admin/backend/src/util/cvrs.ts
+++ b/apps/admin/backend/src/util/cvrs.ts
@@ -6,7 +6,6 @@ import {
   ContestOptionId,
 } from '@votingworks/types';
 import { throwIllegalValue } from '@votingworks/basics';
-import { CastVoteRecordMetadata } from '../types';
 
 /**
  * Gets all the write-in options from a list.
@@ -36,22 +35,6 @@ export function deprecatedGetWriteInsFromCastVoteRecord(
   }
 
   return result;
-}
-
-/**
- * Determines whether two cast vote records have identical metadata.
- */
-export function areCastVoteRecordMetadataEqual(
-  a: CastVoteRecordMetadata,
-  b: CastVoteRecordMetadata
-): boolean {
-  return (
-    a.ballotStyleId === b.ballotStyleId &&
-    a.ballotType === b.ballotType &&
-    a.batchId === b.batchId &&
-    a.precinctId === b.precinctId &&
-    a.sheetNumber === b.sheetNumber
-  );
 }
 
 /**

--- a/apps/admin/backend/src/util/cvrs.ts
+++ b/apps/admin/backend/src/util/cvrs.ts
@@ -51,7 +51,7 @@ export function cvrBallotTypeToLegacyBallotType(
       return 'standard';
     case CVR.vxBallotType.Provisional:
       return 'provisional';
-    /* istanbul ignore next: compile-time check for completeness */
+    /* c8 ignore next 2 */
     default:
       throwIllegalValue(ballotType);
   }

--- a/apps/admin/backend/test/mock_cvr_file.ts
+++ b/apps/admin/backend/test/mock_cvr_file.ts
@@ -1,0 +1,111 @@
+import {
+  BallotId,
+  BallotPageLayout,
+  BallotType,
+  Id,
+  Tabulation,
+} from '@votingworks/types';
+import { v4 as uuid } from 'uuid';
+import { Buffer } from 'buffer';
+import { Store } from '../src/store';
+
+export type MockCastVoteRecordFile = Array<
+  Tabulation.CastVoteRecord & { multiplier?: number }
+>;
+
+const mockPageLayout: BallotPageLayout = {
+  pageSize: {
+    width: 0,
+    height: 0,
+  },
+  metadata: {
+    electionHash: '',
+    ballotStyleId: '',
+    precinctId: '',
+    pageNumber: 1,
+    isTestMode: true,
+    ballotType: BallotType.Standard,
+  },
+  contests: [],
+};
+
+/**
+ * Allows adding mock cast vote record to the store for testing tabulation.
+ * Specify a list of cast vote records with an optional `multiplier` attribute
+ * which will mean a cast vote record with the specified data will be added
+ * `multiplier` times.
+ */
+export function addMockCvrFileToStore({
+  electionId,
+  mockCastVoteRecordFile,
+  store,
+}: {
+  electionId: Id;
+  mockCastVoteRecordFile: MockCastVoteRecordFile;
+  store: Store;
+}): void {
+  const scannerIds = new Set<string>();
+  for (const mockCastVoteRecord of mockCastVoteRecordFile) {
+    store.addScannerBatch({
+      electionId,
+      batchId: mockCastVoteRecord.batchId,
+      scannerId: mockCastVoteRecord.scannerId,
+      label: mockCastVoteRecord.batchId,
+    });
+    scannerIds.add(mockCastVoteRecord.scannerId);
+  }
+  const cvrFileId = uuid();
+  store.addCastVoteRecordFileRecord({
+    id: cvrFileId,
+    electionId,
+    isTestMode: true,
+    filename: 'mock-cvr-file',
+    exportedTimestamp: new Date().toISOString(),
+    sha256Hash: 'mock-hash',
+    scannerIds,
+  });
+
+  for (const mockCastVoteRecord of mockCastVoteRecordFile) {
+    for (let i = 0; i < (mockCastVoteRecord.multiplier ?? 1); i += 1) {
+      const addCastVoteRecordResult = store.addCastVoteRecordFileEntry({
+        electionId,
+        cvrFileId,
+        ballotId: uuid() as BallotId,
+        cvr: mockCastVoteRecord,
+      });
+
+      addCastVoteRecordResult.assertOk('failed to add mock cvr');
+      const { cvrId } = addCastVoteRecordResult.unsafeUnwrap();
+
+      const writeIns: Array<[contestId: string, optionId: string]> = [];
+      for (const [contestId, optionIds] of Object.entries(
+        mockCastVoteRecord.votes
+      )) {
+        for (const optionId of optionIds) {
+          if (optionId.startsWith('write-in')) {
+            writeIns.push([contestId, optionId]);
+          }
+        }
+      }
+
+      // add write-ins, all on the "front"
+      if (writeIns.length) {
+        store.addBallotImage({
+          cvrId,
+          imageData: Buffer.from([]),
+          pageLayout: mockPageLayout,
+          side: 'front',
+        });
+
+        for (const [contestId, optionId] of writeIns) {
+          store.addWriteIn({
+            castVoteRecordId: cvrId,
+            side: 'front',
+            contestId,
+            optionId,
+          });
+        }
+      }
+    }
+  }
+}

--- a/libs/types/src/tabulation.ts
+++ b/libs/types/src/tabulation.ts
@@ -4,6 +4,7 @@ import {
   Candidate,
   CandidateId,
   ContestId,
+  ContestOptionId,
   PrecinctId,
 } from './election';
 import * as CVR from './cdf/cast-vote-records/index';
@@ -132,7 +133,7 @@ export type GroupedElectionResults = Grouped<ElectionResults>;
  * Simplified representation of votes on a scanned ballot for tabulation
  * purposes.
  */
-export type Votes = Record<ContestId, Id[]>;
+export type Votes = Record<ContestId, ContestOptionId[]>;
 
 export type CastVoteRecord = {
   readonly votes: Votes;


### PR DESCRIPTION
_review commit-by-commit, first commit is just #3541 _

## Overview

Ends the VxAdmin Tally Foundations mini-series. This PR ups test coverage to 100% for any new tabulation code. As a prerequisite to improving test coverage, it does a little refactoring and adds a test util to add CVRs to the store via a means other than cast vote record files. It refactors some of the tabulation utilities in VxAdmin and patches a couple bugs identified in testing. 

With this merged, it will be time to tackle the actual exports.
