### PR TITLE
[VxScan] Hide election info bar in large size modes

### DIFF
--- a/apps/scan/frontend/src/components/layout.tsx
+++ b/apps/scan/frontend/src/components/layout.tsx
@@ -16,7 +16,10 @@ import { ScreenHeader } from './screen_header';
  * At larger text sizes, the election info bar takes up too much valuable screen
  * space, so we're hiding it in cases where a voter increases text size.
  */
-const ELECTION_BAR_HIDDEN_SIZE_MODES: ReadonlySet<SizeMode> = new Set(['l', 'xl']);
+const ELECTION_BAR_HIDDEN_SIZE_MODES: ReadonlySet<SizeMode> = new Set([
+  'l',
+  'xl',
+]);
 
 export interface ScreenProps {
   ballotCountOverride?: number;

--- a/apps/scan/frontend/src/components/layout.tsx
+++ b/apps/scan/frontend/src/components/layout.tsx
@@ -16,7 +16,7 @@ import { ScreenHeader } from './screen_header';
  * At larger text sizes, the election info bar takes up too much valuable screen
  * space, so we're hiding it in cases where a voter increases text size.
  */
-const ELECTION_BAR_HIDDEN_SIZE_MODES: Set<SizeMode> = new Set(['l', 'xl']);
+const ELECTION_BAR_HIDDEN_SIZE_MODES: ReadonlySet<SizeMode> = new Set(['l', 'xl']);
 
 export interface ScreenProps {
   ballotCountOverride?: number;


### PR DESCRIPTION
## Overview

Since we're moving from the 15" ELO screen to the smaller 13" (and switching to a landscape orientation), the election info bar no longer really works at larger size modes.

Briefly discussed with @mattroe the possibility of hiding the bar on some screens like we used to, but we fortunately don't need to at the default size. Makes sense to hide it when a voter explicitly decides to bump up the text size.

## Demo Video or Screenshot
### At default size (M) vs largest (XL):
<img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/3489eca3-d16d-49bb-8e36-c74b4a136f5f" /> <img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/8143fc1b-cbe0-4017-a25e-fdfbde05b928" />

## Testing Plan
- Manual

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
