### PR TITLE
[VxScan] Lock TestMode banner size mode to 'small'

### DIFF
--- a/libs/ui/src/__snapshots__/test_mode.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/test_mode.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`renders TestMode - VVSG styling 1`] = `
   font-weight: 500;
   line-height: 1.1700000000000002;
   margin-bottom: 0.3em;
-  font-size: 1.75rem;
+  font-size: 2.25rem;
   font-weight: 600;
 }
 
@@ -30,6 +30,7 @@ exports[`renders TestMode - VVSG styling 1`] = `
   background-image: linear-gradient( 135deg, #ff8c00 21.43%, #333333 21.43%, #333333 50%, #ff8c00 50%, #ff8c00 71.43%, #333333 71.43%, #333333 100% );
   background-size: 98.99px 98.99px;
   width: 100%;
+  font-size: 15.052945967960904px;
 }
 
 .c0 > div {
@@ -38,6 +39,10 @@ exports[`renders TestMode - VVSG styling 1`] = `
   padding: 0.125rem;
   text-align: center;
   color: #333333;
+}
+
+.c2 {
+  font-size: 2.25em;
 }
 
 @media print {
@@ -58,7 +63,7 @@ exports[`renders TestMode - VVSG styling 1`] = `
   >
     <div>
       <h1
-        class="c1"
+        class="c1 c2"
       >
         Test Ballot Mode
       </h1>
@@ -75,7 +80,7 @@ exports[`renders TestMode - legacy styling 1`] = `
   font-weight: 500;
   line-height: 1.08;
   margin-bottom: 0.3em;
-  font-size: 1.25rem;
+  font-size: 1.5rem;
   font-weight: 600;
 }
 
@@ -97,6 +102,7 @@ exports[`renders TestMode - legacy styling 1`] = `
   background-image: linear-gradient( 135deg, #ff8c00 21.43%, #333333 21.43%, #333333 50%, #ff8c00 50%, #ff8c00 71.43%, #333333 71.43%, #333333 100% );
   background-size: 98.99px 98.99px;
   width: 100%;
+  font-size: 16px;
 }
 
 .c0 > div {
@@ -105,6 +111,10 @@ exports[`renders TestMode - legacy styling 1`] = `
   padding: 0.125rem;
   text-align: center;
   color: #333333;
+}
+
+.c2 {
+  font-size: 1.5em;
 }
 
 @media print {
@@ -125,7 +135,7 @@ exports[`renders TestMode - legacy styling 1`] = `
   >
     <div>
       <h1
-        class="c1"
+        class="c1 c2"
       >
         Test Ballot Mode
       </h1>

--- a/libs/ui/src/test_mode.tsx
+++ b/libs/ui/src/test_mode.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled, { ThemeProvider } from 'styled-components';
-import { H2 } from './typography';
+import { H1 } from './typography';
 import { makeTheme } from './themes/make_theme';
 
 const TestingModeContainer = styled.div`
@@ -19,6 +19,8 @@ const TestingModeContainer = styled.div`
   );
   background-size: 98.99px 98.99px;
   width: 100%;
+  font-size: ${(p) => p.theme.sizes.fontDefault}px;
+
   & > div {
     margin: 0.5rem 0;
     background: #ff8c00;
@@ -26,6 +28,10 @@ const TestingModeContainer = styled.div`
     text-align: center;
     color: #333333;
   }
+`;
+
+const Heading = styled(H1)`
+  font-size: ${(p) => p.theme.sizes.headingsRem.h1}em;
 `;
 
 export function TestMode(): JSX.Element {
@@ -36,13 +42,14 @@ export function TestMode(): JSX.Element {
       theme={(theme) =>
         makeTheme({
           colorMode: theme.colorMode,
+          screenType: theme.screenType,
           sizeMode: theme.sizeMode === 'legacy' ? 'legacy' : 's',
         })
       }
     >
       <TestingModeContainer>
         <div>
-          <H2 as="h1">Test Ballot Mode</H2>
+          <Heading>Test Ballot Mode</Heading>
         </div>
       </TestingModeContainer>
     </ThemeProvider>


### PR DESCRIPTION
## Overview

Previously tried to lock the `TestMode` banner to the 's' size mode by overriding the active theme, but missed the fact that component sizes are based on the root font size, which isn't affected by theme overrides. This became a little more obvious in landscape mode.

Updating this to explicitly use the `fontDefault` on the locked theme as the base font size instead.

## Demo Video or Screenshot
### Before/After in XL mode:
<img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/8cffc0d6-b80f-4061-a82e-9e7592d44571" /> <img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/ac8f27cd-9cb4-4aaf-963b-94b8ec2e516d" />

## Testing Plan
- Manual

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
