### PR TITLE
[VxScan] Fit voter-facing screens to landscape ELO13

### DIFF
--- a/apps/mark/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
@@ -373,6 +373,7 @@ exports[`Single Seat Contest 1`] = `
   justify-content: stretch;
   overflow: scroll;
   padding: 0 0.5rem;
+  padding-bottom: 0;
 }
 
 .c6 {

--- a/apps/mark/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
@@ -499,6 +499,7 @@ exports[`Single Seat Contest 1`] = `
   justify-content: stretch;
   overflow: scroll;
   padding: 0 0.5rem;
+  padding-bottom: 0;
 }
 
 .c6 {

--- a/apps/mark/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
@@ -499,6 +499,7 @@ exports[`Single Seat Contest 1`] = `
   justify-content: stretch;
   overflow: scroll;
   padding: 0 0.5rem;
+  padding-bottom: 0;
 }
 
 .c6 {

--- a/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
@@ -381,6 +381,7 @@ exports[`Single Seat Contest with Write In 1`] = `
   justify-content: stretch;
   overflow: scroll;
   padding: 0 0.5rem;
+  padding-bottom: 0;
 }
 
 .c6 {

--- a/apps/mark/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
@@ -354,6 +354,7 @@ exports[`Renders ContestPage 1`] = `
   justify-content: stretch;
   overflow: scroll;
   padding: 0 0.5rem;
+  padding-bottom: 0;
 }
 
 .c5 {
@@ -1372,6 +1373,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
   justify-content: stretch;
   overflow: scroll;
   padding: 0 0.5rem;
+  padding-bottom: 0;
 }
 
 .c2 {

--- a/apps/scan/frontend/src/components/full_screen_prompt_layout.tsx
+++ b/apps/scan/frontend/src/components/full_screen_prompt_layout.tsx
@@ -1,0 +1,85 @@
+/* stylelint-disable order/properties-order */
+import { H1, WithScrollButtons } from '@votingworks/ui';
+import React from 'react';
+import styled from 'styled-components';
+
+interface FullScreenPromptLayoutProps {
+  actionButtons?: React.ReactNode;
+  children?: React.ReactNode;
+  image: React.ReactNode;
+  title: React.ReactNode;
+}
+
+const HORIZONTAL_PADDING_REM = 0.75;
+
+const OuterContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+`;
+
+const Body = styled.div`
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  overflow: hidden;
+  margin-bottom: 0.5rem;
+  width: 100%;
+`;
+
+const ImageContainer = styled.div`
+  align-items: center;
+  border-right: ${(p) => p.theme.sizes.bordersRem.thin}rem dotted
+    ${(p) => p.theme.colors.foreground};
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 0 ${HORIZONTAL_PADDING_REM}rem;
+`;
+
+const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+`;
+
+const Text = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  justify-content: center;
+  padding: 0 ${HORIZONTAL_PADDING_REM}rem;
+`;
+
+const Footer = styled.div`
+  display: grid;
+  grid-gap: ${HORIZONTAL_PADDING_REM}rem;
+  grid-template-columns: 1fr 1fr;
+  margin: 0 auto;
+  padding: 0 ${HORIZONTAL_PADDING_REM}rem 0.5rem;
+  width: 100%;
+`;
+
+export function FullScreenPromptLayout(
+  props: FullScreenPromptLayoutProps
+): JSX.Element {
+  const { actionButtons, children, image, title } = props;
+
+  return (
+    <OuterContainer>
+      <Body>
+        <ImageContainer>{image}</ImageContainer>
+        <Content>
+          <WithScrollButtons noPadding>
+            <Text>
+              <H1>{title}</H1>
+              {children}
+            </Text>
+          </WithScrollButtons>
+        </Content>
+      </Body>
+      {actionButtons && <Footer>{actionButtons}</Footer>}
+    </OuterContainer>
+  );
+}

--- a/apps/scan/frontend/src/components/replace_ballot_bag_screen.tsx
+++ b/apps/scan/frontend/src/components/replace_ballot_bag_screen.tsx
@@ -10,9 +10,10 @@ import {
   useExternalStateChangeListener,
 } from '@votingworks/ui';
 import { LogEventId, Logger, LogSource } from '@votingworks/logging';
-import { ScreenMainCenterChild } from './layout';
+import { Screen } from './layout';
 import { BALLOT_BAG_CAPACITY } from '../config/globals';
 import { recordBallotBagReplaced } from '../api';
+import { FullScreenPromptLayout } from './full_screen_prompt_layout';
 
 interface Props {
   scannedBallotCount: number;
@@ -48,19 +49,20 @@ export function ReplaceBallotBagScreen({
   const mainContent = (() => {
     if (!confirmed && !pollWorkerAuthenticated) {
       return (
-        <React.Fragment>
-          <FullScreenIconWrapper color="warning">
-            <Icons.Warning />
-          </FullScreenIconWrapper>
-          <CenteredLargeProse>
-            <H1>Ballot Bag Full</H1>
-            <P>
-              A poll worker must replace the full ballot bag with a new empty
-              ballot bag.
-            </P>
-            <Caption>Insert a poll worker card to continue.</Caption>
-          </CenteredLargeProse>
-        </React.Fragment>
+        <FullScreenPromptLayout
+          title="Ballot Bag Full"
+          image={
+            <FullScreenIconWrapper color="warning">
+              <Icons.Warning />
+            </FullScreenIconWrapper>
+          }
+        >
+          <P>
+            A poll worker must replace the full ballot bag with a new empty
+            ballot bag.
+          </P>
+          <Caption>Insert a poll worker card to continue.</Caption>
+        </FullScreenPromptLayout>
       );
     }
 
@@ -90,9 +92,9 @@ export function ReplaceBallotBagScreen({
   })();
 
   return (
-    <ScreenMainCenterChild ballotCountOverride={scannedBallotCount}>
+    <Screen centerContent ballotCountOverride={scannedBallotCount}>
       {mainContent}
-    </ScreenMainCenterChild>
+    </Screen>
   );
 }
 

--- a/apps/scan/frontend/src/preview_app.tsx
+++ b/apps/scan/frontend/src/preview_app.tsx
@@ -16,6 +16,7 @@ import * as InvalidCardScreen from './screens/invalid_card_screen';
 import * as LoadingConfigurationScreen from './screens/loading_configuration_screen';
 import * as PollsNotOpenScreen from './screens/polls_not_open_screen';
 import * as PollWorkerScreen from './screens/poll_worker_screen';
+import * as ScanDoubleSheetScreen from './screens/scan_double_sheet_screen';
 import * as ScanErrorScreen from './screens/scan_error_screen';
 import * as ScanProcessingScreen from './screens/scan_processing_screen';
 import * as ScanSuccessScreen from './screens/scan_success_screen';
@@ -46,6 +47,7 @@ export function PreviewApp(): JSX.Element {
           LoadingConfigurationScreen,
           PollsNotOpenScreen,
           PollWorkerScreen,
+          ScanDoubleSheetScreen,
           ScanErrorScreen,
           ScanProcessingScreen,
           ScanSuccessScreen,

--- a/apps/scan/frontend/src/scan_app_base.tsx
+++ b/apps/scan/frontend/src/scan_app_base.tsx
@@ -8,7 +8,7 @@ export interface AppBaseProps {
 }
 
 const DEFAULT_COLOR_MODE: ColorMode = 'contrastMedium';
-const DEFAULT_SCREEN_TYPE: ScreenType = 'elo15';
+const DEFAULT_SCREEN_TYPE: ScreenType = 'elo13';
 const DEFAULT_SIZE_MODE: SizeMode = 'm';
 
 /**

--- a/apps/scan/frontend/src/screens/insert_ballot_screen.tsx
+++ b/apps/scan/frontend/src/screens/insert_ballot_screen.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
-import {
-  Caption,
-  CenteredLargeProse,
-  Font,
-  H1,
-  Icons,
-  InsertBallotImage,
-  P,
-} from '@votingworks/ui';
-import { ScreenMainCenterChild } from '../components/layout';
+import { Caption, Font, Icons, InsertBallotImage, P } from '@votingworks/ui';
+import { Screen } from '../components/layout';
+import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout';
 
 interface Props {
   isLiveMode: boolean;
@@ -22,13 +15,15 @@ export function InsertBallotScreen({
   showNoChargerWarning,
 }: Props): JSX.Element {
   return (
-    <ScreenMainCenterChild
+    <Screen
+      centerContent
       isLiveMode={isLiveMode}
       ballotCountOverride={scannedBallotCount}
     >
-      <InsertBallotImage ballotFeedLocation="top" />
-      <CenteredLargeProse>
-        <H1>Insert Your Ballot Above</H1>
+      <FullScreenPromptLayout
+        title="Insert Your Ballot Above"
+        image={<InsertBallotImage ballotFeedLocation="top" />}
+      >
         <P>Scan one ballot sheet at a time.</P>
         {showNoChargerWarning && (
           <Caption color="warning">
@@ -36,8 +31,8 @@ export function InsertBallotScreen({
             Please ask a poll worker to plug in the power cord.
           </Caption>
         )}
-      </CenteredLargeProse>
-    </ScreenMainCenterChild>
+      </FullScreenPromptLayout>
+    </Screen>
   );
 }
 

--- a/apps/scan/frontend/src/screens/scan_busy_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_busy_screen.tsx
@@ -1,26 +1,23 @@
 import React from 'react';
-import {
-  Caption,
-  CenteredLargeProse,
-  FullScreenIconWrapper,
-  H1,
-  Icons,
-  P,
-} from '@votingworks/ui';
-import { ScreenMainCenterChild } from '../components/layout';
+import { Caption, FullScreenIconWrapper, Icons, P } from '@votingworks/ui';
+import { Screen } from '../components/layout';
+import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout';
 
 export function ScanBusyScreen(): JSX.Element {
   return (
-    <ScreenMainCenterChild>
-      <FullScreenIconWrapper color="warning">
-        <Icons.Warning />
-      </FullScreenIconWrapper>
-      <CenteredLargeProse>
-        <H1>Remove Your Ballot</H1>
+    <Screen centerContent>
+      <FullScreenPromptLayout
+        title="Remove Your Ballot"
+        image={
+          <FullScreenIconWrapper color="warning">
+            <Icons.Warning />
+          </FullScreenIconWrapper>
+        }
+      >
         <P>Another ballot is being scanned.</P>
         <Caption>Ask a poll worker if you need help.</Caption>
-      </CenteredLargeProse>
-    </ScreenMainCenterChild>
+      </FullScreenPromptLayout>
+    </Screen>
   );
 }
 

--- a/apps/scan/frontend/src/screens/scan_double_sheet_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_double_sheet_screen.tsx
@@ -1,13 +1,7 @@
 import React from 'react';
-import {
-  Caption,
-  CenteredLargeProse,
-  FullScreenIconWrapper,
-  H1,
-  Icons,
-  P,
-} from '@votingworks/ui';
-import { ScreenMainCenterChild } from '../components/layout';
+import { Caption, FullScreenIconWrapper, Icons, P } from '@votingworks/ui';
+import { Screen } from '../components/layout';
+import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout';
 
 interface Props {
   scannedBallotCount: number;
@@ -17,16 +11,19 @@ export function ScanDoubleSheetScreen({
   scannedBallotCount,
 }: Props): JSX.Element {
   return (
-    <ScreenMainCenterChild ballotCountOverride={scannedBallotCount}>
-      <FullScreenIconWrapper color="danger">
-        <Icons.DangerX />
-      </FullScreenIconWrapper>
-      <CenteredLargeProse>
-        <H1>Ballot Not Counted</H1>
+    <Screen centerContent ballotCountOverride={scannedBallotCount}>
+      <FullScreenPromptLayout
+        title="Ballot Not Counted"
+        image={
+          <FullScreenIconWrapper color="danger">
+            <Icons.DangerX />
+          </FullScreenIconWrapper>
+        }
+      >
         <P>Multiple sheets detected.</P>
         <Caption>Remove your ballot and insert one sheet at a time.</Caption>
-      </CenteredLargeProse>
-    </ScreenMainCenterChild>
+      </FullScreenPromptLayout>
+    </Screen>
   );
 }
 

--- a/apps/scan/frontend/src/screens/scan_error_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_error_screen.tsx
@@ -1,18 +1,12 @@
 import React from 'react';
-import {
-  Caption,
-  CenteredLargeProse,
-  FullScreenIconWrapper,
-  H1,
-  Icons,
-  P,
-} from '@votingworks/ui';
+import { Caption, FullScreenIconWrapper, Icons, P } from '@votingworks/ui';
 import { throwIllegalValue } from '@votingworks/basics';
 import type {
   InvalidInterpretationReason,
   PrecinctScannerErrorType,
 } from '@votingworks/scan-backend';
-import { ScreenMainCenterChild } from '../components/layout';
+import { Screen } from '../components/layout';
+import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout';
 
 export interface Props {
   error?: InvalidInterpretationReason | PrecinctScannerErrorType;
@@ -63,23 +57,27 @@ export function ScanErrorScreen({
     }
   })();
   return (
-    <ScreenMainCenterChild
+    <Screen
+      centerContent
       isLiveMode={!isTestMode}
       ballotCountOverride={scannedBallotCount}
     >
-      <FullScreenIconWrapper color="danger">
-        <Icons.DangerX />
-      </FullScreenIconWrapper>
-      <CenteredLargeProse>
-        <H1>Ballot Not Counted</H1>
+      <FullScreenPromptLayout
+        title="Ballot Not Counted"
+        image={
+          <FullScreenIconWrapper color="danger">
+            <Icons.DangerX />
+          </FullScreenIconWrapper>
+        }
+      >
         <P>{errorMessage}</P>
         {restartRequired ? (
           <P>Ask a poll worker to restart the scanner.</P>
         ) : (
           <Caption>Ask a poll worker if you need help.</Caption>
         )}
-      </CenteredLargeProse>
-    </ScreenMainCenterChild>
+      </FullScreenPromptLayout>
+    </Screen>
   );
 }
 

--- a/apps/scan/frontend/src/screens/scan_jam_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_jam_screen.tsx
@@ -1,13 +1,7 @@
 import React from 'react';
-import {
-  Caption,
-  CenteredLargeProse,
-  FullScreenIconWrapper,
-  H1,
-  Icons,
-  P,
-} from '@votingworks/ui';
-import { ScreenMainCenterChild } from '../components/layout';
+import { Caption, FullScreenIconWrapper, Icons, P } from '@votingworks/ui';
+import { Screen } from '../components/layout';
+import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout';
 
 interface Props {
   scannedBallotCount: number;
@@ -15,16 +9,19 @@ interface Props {
 
 export function ScanJamScreen({ scannedBallotCount }: Props): JSX.Element {
   return (
-    <ScreenMainCenterChild ballotCountOverride={scannedBallotCount}>
-      <FullScreenIconWrapper color="danger">
-        <Icons.DangerX />
-      </FullScreenIconWrapper>
-      <CenteredLargeProse>
-        <H1>Ballot Not Counted</H1>
+    <Screen centerContent ballotCountOverride={scannedBallotCount}>
+      <FullScreenPromptLayout
+        title="Ballot Not Counted"
+        image={
+          <FullScreenIconWrapper color="danger">
+            <Icons.DangerX />
+          </FullScreenIconWrapper>
+        }
+      >
         <P>The ballot is jammed in the scanner.</P>
         <Caption>Ask a poll worker for help.</Caption>
-      </CenteredLargeProse>
-    </ScreenMainCenterChild>
+      </FullScreenPromptLayout>
+    </Screen>
   );
 }
 

--- a/apps/scan/frontend/src/screens/scan_success_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_success_screen.tsx
@@ -1,13 +1,8 @@
 import React from 'react';
-import {
-  CenteredLargeProse,
-  FullScreenIconWrapper,
-  H1,
-  Icons,
-  P,
-} from '@votingworks/ui';
+import { FullScreenIconWrapper, Icons, P } from '@votingworks/ui';
 
-import { ScreenMainCenterChild } from '../components/layout';
+import { Screen } from '../components/layout';
+import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout';
 
 interface Props {
   scannedBallotCount: number;
@@ -15,15 +10,18 @@ interface Props {
 
 export function ScanSuccessScreen({ scannedBallotCount }: Props): JSX.Element {
   return (
-    <ScreenMainCenterChild ballotCountOverride={scannedBallotCount}>
-      <FullScreenIconWrapper color="success">
-        <Icons.Done />
-      </FullScreenIconWrapper>
-      <CenteredLargeProse>
-        <H1>Your ballot was counted!</H1>
+    <Screen centerContent ballotCountOverride={scannedBallotCount}>
+      <FullScreenPromptLayout
+        title="Your ballot was counted!"
+        image={
+          <FullScreenIconWrapper color="success">
+            <Icons.Done />
+          </FullScreenIconWrapper>
+        }
+      >
         <P>Thank you for voting.</P>
-      </CenteredLargeProse>
-    </ScreenMainCenterChild>
+      </FullScreenPromptLayout>
+    </Screen>
   );
 }
 

--- a/apps/scan/frontend/src/screens/scan_warning_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_warning_screen.tsx
@@ -11,7 +11,6 @@ import {
 import {
   Button,
   Caption,
-  CenteredLargeProse,
   fontSizeTheme,
   FullScreenIconWrapper,
   H1,
@@ -27,27 +26,13 @@ import {
 } from '@votingworks/utils';
 import { assert, find, integers } from '@votingworks/basics';
 import pluralize from 'pluralize';
-import styled from 'styled-components';
 
-import { ScreenMainCenterChild } from '../components/layout';
+import { Screen } from '../components/layout';
 
 import { toSentence } from '../utils/to_sentence';
 import { acceptBallot, returnBallot } from '../api';
 import { usePreviewContext } from '../preview_dashboard';
-
-const ResponsiveButtonParagraph = styled.p`
-  @media (orientation: portrait) {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.5em;
-    & > button {
-      flex: 1 auto;
-      padding-right: 0.25em;
-      padding-left: 0.25em;
-    }
-  }
-`;
+import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout';
 
 interface ConfirmModalProps {
   content?: React.ReactNode;
@@ -61,14 +46,14 @@ function ConfirmModal({ content, onConfirm, onCancel }: ConfirmModalProps) {
   return (
     <Modal
       themeDeprecated={fontSizeTheme.large}
-      modalWidth={ModalWidth.Wide}
+      modalWidth={ModalWidth.Standard}
       title="Are you sure?"
       centerContent
       content={content}
       actions={
         <React.Fragment>
           <Button
-            variant="primary"
+            variant="done"
             onPress={() => {
               setConfirmed(true);
               onConfirm();
@@ -116,36 +101,37 @@ function OvervoteWarningScreen({
     .map((c) => c.title);
 
   return (
-    <ScreenMainCenterChild>
-      <FullScreenIconWrapper color="warning">
-        <Icons.Warning />
-      </FullScreenIconWrapper>
-      <CenteredLargeProse>
-        <H1>Too Many Votes</H1>
+    <Screen centerContent>
+      <FullScreenPromptLayout
+        title="Too Many Votes"
+        image={
+          <FullScreenIconWrapper color="warning">
+            <Icons.Warning />
+          </FullScreenIconWrapper>
+        }
+        actionButtons={
+          <React.Fragment>
+            <Button
+              variant="primary"
+              onPress={() => returnBallotMutation.mutate()}
+            >
+              Return Ballot
+            </Button>
+            {allowCastingOvervotes && (
+              <Button onPress={() => setConfirmTabulate(true)}>
+                Cast Ballot As Is <Icons.Next />
+              </Button>
+            )}
+          </React.Fragment>
+        }
+      >
         <P>
           There are too many votes marked in the{' '}
           {pluralize('contest', contestNames.length)}:{' '}
           {toSentence(contestNames)}.
         </P>
-        <ResponsiveButtonParagraph>
-          <Button
-            variant="primary"
-            onPress={() => returnBallotMutation.mutate()}
-          >
-            Return Ballot
-          </Button>
-          {allowCastingOvervotes && (
-            <React.Fragment>
-              {' '}
-              or{' '}
-              <Button onPress={() => setConfirmTabulate(true)}>
-                Cast Ballot As Is
-              </Button>
-            </React.Fragment>
-          )}
-        </ResponsiveButtonParagraph>
         <Caption>Ask a poll worker if you need help.</Caption>
-      </CenteredLargeProse>
+      </FullScreenPromptLayout>
       {confirmTabulate && (
         <ConfirmModal
           content={
@@ -160,7 +146,7 @@ function OvervoteWarningScreen({
           onCancel={() => setConfirmTabulate(false)}
         />
       )}
-    </ScreenMainCenterChild>
+    </Screen>
   );
 }
 
@@ -204,12 +190,28 @@ function UndervoteWarningScreen({
   }
 
   return (
-    <ScreenMainCenterChild>
-      <FullScreenIconWrapper color="warning">
-        <Icons.Warning />
-      </FullScreenIconWrapper>
-      <CenteredLargeProse>
-        <H1>Review Your Ballot</H1>
+    <Screen centerContent>
+      <FullScreenPromptLayout
+        title="Review Your Ballot"
+        image={
+          <FullScreenIconWrapper color="warning">
+            <Icons.Warning />
+          </FullScreenIconWrapper>
+        }
+        actionButtons={
+          <React.Fragment>
+            <Button
+              variant="primary"
+              onPress={() => returnBallotMutation.mutate()}
+            >
+              Return Ballot
+            </Button>
+            <Button onPress={() => setConfirmTabulate(true)}>
+              Cast Ballot As Is
+            </Button>
+          </React.Fragment>
+        }
+      >
         {blankContestNames.length > 0 && (
           <P>
             No votes detected in{' '}
@@ -224,24 +226,12 @@ function UndervoteWarningScreen({
             {toSentence(truncateContestNames(partiallyVotedContestNames))}.
           </P>
         )}
-        <ResponsiveButtonParagraph>
-          <Button
-            variant="primary"
-            onPress={() => returnBallotMutation.mutate()}
-          >
-            Return Ballot
-          </Button>{' '}
-          or{' '}
-          <Button onPress={() => setConfirmTabulate(true)}>
-            Cast Ballot As Is
-          </Button>
-        </ResponsiveButtonParagraph>
         <Caption>
           Your votes will count, even if you leave some blank.
           <br />
           Ask a poll worker if you need help.
         </Caption>
-      </CenteredLargeProse>
+      </FullScreenPromptLayout>
       {confirmTabulate && (
         <ConfirmModal
           content={
@@ -275,7 +265,7 @@ function UndervoteWarningScreen({
           onCancel={() => setConfirmTabulate(false)}
         />
       )}
-    </ScreenMainCenterChild>
+    </Screen>
   );
 }
 
@@ -284,31 +274,35 @@ function BlankBallotWarningScreen(): JSX.Element {
   const acceptBallotMutation = acceptBallot.useMutation();
   const [confirmTabulate, setConfirmTabulate] = useState(false);
   return (
-    <ScreenMainCenterChild>
-      <FullScreenIconWrapper color="warning">
-        <Icons.Warning />
-      </FullScreenIconWrapper>
-      <CenteredLargeProse>
-        <H1>Review Your Ballot</H1>
+    <Screen centerContent>
+      <FullScreenPromptLayout
+        title="Review Your Ballot"
+        image={
+          <FullScreenIconWrapper color="warning">
+            <Icons.Warning />
+          </FullScreenIconWrapper>
+        }
+        actionButtons={
+          <React.Fragment>
+            <Button
+              variant="primary"
+              onPress={() => returnBallotMutation.mutate()}
+            >
+              Return Ballot
+            </Button>
+            <Button onPress={() => setConfirmTabulate(true)}>
+              Cast Ballot As Is
+            </Button>
+          </React.Fragment>
+        }
+      >
         <P>No votes were found when scanning this ballot.</P>
-        <ResponsiveButtonParagraph>
-          <Button
-            variant="primary"
-            onPress={() => returnBallotMutation.mutate()}
-          >
-            Return Ballot
-          </Button>{' '}
-          or{' '}
-          <Button onPress={() => setConfirmTabulate(true)}>
-            Cast Ballot As Is
-          </Button>
-        </ResponsiveButtonParagraph>
         <Caption>
           Your votes will count, even if you leave some blank.
           <br />
           Ask a poll worker if you need help.
         </Caption>
-      </CenteredLargeProse>
+      </FullScreenPromptLayout>
       {confirmTabulate && (
         <ConfirmModal
           content={
@@ -320,7 +314,7 @@ function BlankBallotWarningScreen(): JSX.Element {
           onCancel={() => setConfirmTabulate(false)}
         />
       )}
-    </ScreenMainCenterChild>
+    </Screen>
   );
 }
 
@@ -329,27 +323,31 @@ function OtherReasonWarningScreen(): JSX.Element {
   const acceptBallotMutation = acceptBallot.useMutation();
   const [confirmTabulate, setConfirmTabulate] = useState(false);
   return (
-    <ScreenMainCenterChild>
-      <FullScreenIconWrapper color="warning">
-        <Icons.Warning />
-      </FullScreenIconWrapper>
-      <CenteredLargeProse>
-        <H1>Scanning Failed</H1>
+    <Screen centerContent>
+      <FullScreenPromptLayout
+        title="Scanning Failed"
+        image={
+          <FullScreenIconWrapper color="warning">
+            <Icons.Warning />
+          </FullScreenIconWrapper>
+        }
+        actionButtons={
+          <React.Fragment>
+            <Button
+              variant="primary"
+              onPress={() => returnBallotMutation.mutate()}
+            >
+              Return Ballot
+            </Button>
+            <Button onPress={() => setConfirmTabulate(true)}>
+              Cast Ballot As Is
+            </Button>
+          </React.Fragment>
+        }
+      >
         <P>There was a problem scanning this ballot.</P>
-        <ResponsiveButtonParagraph>
-          <Button
-            variant="primary"
-            onPress={() => returnBallotMutation.mutate()}
-          >
-            Return Ballot
-          </Button>{' '}
-          or{' '}
-          <Button onPress={() => setConfirmTabulate(true)}>
-            Cast Ballot As Is
-          </Button>
-        </ResponsiveButtonParagraph>
         <Caption>Ask a poll worker if you need help.</Caption>
-      </CenteredLargeProse>
+      </FullScreenPromptLayout>
       {confirmTabulate && (
         <ConfirmModal
           content={
@@ -362,7 +360,7 @@ function OtherReasonWarningScreen(): JSX.Element {
           onCancel={() => setConfirmTabulate(false)}
         />
       )}
-    </ScreenMainCenterChild>
+    </Screen>
   );
 }
 

--- a/libs/mark-flow-ui/src/components/__snapshots__/contest.test.tsx.snap
+++ b/libs/mark-flow-ui/src/components/__snapshots__/contest.test.tsx.snap
@@ -304,6 +304,7 @@ exports[`renders 1`] = `
   justify-content: stretch;
   overflow: scroll;
   padding: 0 0.5rem;
+  padding-bottom: 0;
 }
 
 .c1 {

--- a/libs/mark-flow-ui/src/components/__snapshots__/yes_no_contest.test.tsx.snap
+++ b/libs/mark-flow-ui/src/components/__snapshots__/yes_no_contest.test.tsx.snap
@@ -371,6 +371,7 @@ exports[`changing votes 1`] = `
   justify-content: stretch;
   overflow: scroll;
   padding: 0 0.5rem;
+  padding-bottom: 0;
 }
 
 .c1 {
@@ -879,6 +880,7 @@ exports[`voting for both yes and no 1`] = `
   justify-content: stretch;
   overflow: scroll;
   padding: 0 0.5rem;
+  padding-bottom: 0;
 }
 
 .c1 {

--- a/libs/mark-flow-ui/src/pages/__snapshots__/cast_ballot_page.test.tsx.snap
+++ b/libs/mark-flow-ui/src/pages/__snapshots__/cast_ballot_page.test.tsx.snap
@@ -103,8 +103,12 @@ exports[`renders CastBallotPage 1`] = `
 
 .c7 {
   fill: #263238;
-  margin: 0 auto 1rem;
-  width: 40vw;
+  margin: 0 auto;
+  width: min(40vw,40vh);
+}
+
+.c7:not(:last-child) {
+  margin-bottom: 1rem;
 }
 
 .c13 {

--- a/libs/ui/src/svg.tsx
+++ b/libs/ui/src/svg.tsx
@@ -12,8 +12,12 @@ export class Svg {
 
   static FullScreenSvg = styled.svg`
     fill: ${(p) => p.theme.colors.foreground};
-    margin: 0 auto 1rem;
-    width: 40vw;
+    margin: 0 auto;
+    width: min(40vw, 40vh);
+
+    &:not(:last-child) {
+      margin-bottom: 1rem;
+    }
   `;
 
   static PurpleFillPath = styled.path`

--- a/libs/ui/src/with_scroll_buttons.tsx
+++ b/libs/ui/src/with_scroll_buttons.tsx
@@ -11,6 +11,7 @@ import { makeTheme } from './themes/make_theme';
 
 export interface WithScrollButtonsProps {
   children: React.ReactNode;
+  noPadding?: boolean;
 }
 
 const SCROLL_DISTANCE_TO_CONTENT_HEIGHT_RATIO = 0.75;
@@ -32,6 +33,7 @@ const Container = styled.div`
 `;
 
 interface ContentProps {
+  noPadding?: boolean;
   scrollEnabled: boolean;
 }
 
@@ -42,7 +44,8 @@ const Content = styled.div<ContentProps>`
   flex-grow: 1;
   justify-content: stretch;
   overflow: scroll;
-  padding: ${(p) => (p.scrollEnabled ? '0.5rem' : '0')} 0.5rem;
+  padding: 0 ${(p) => (p.noPadding ? 0 : 0.5)}rem;
+  padding-bottom: ${(p) => (p.scrollEnabled ? '0.5rem' : '0')};
 `;
 
 const Controls = styled.div`
@@ -101,7 +104,7 @@ const BottomShadow = styled.div`
  * which has an explicit height/max height set.
  */
 export function WithScrollButtons(props: WithScrollButtonsProps): JSX.Element {
-  const { children } = props;
+  const { children, noPadding } = props;
 
   const [canScrollUp, setCanScrollUp] = React.useState(false);
   const [canScrollDown, setCanScrollDown] = React.useState(false);
@@ -158,6 +161,7 @@ export function WithScrollButtons(props: WithScrollButtonsProps): JSX.Element {
         ref={contentRef}
         scrollEnabled={scrollEnabled}
         onScroll={updateScrollState}
+        noPadding={noPadding}
       >
         {children}
       </Content>


### PR DESCRIPTION
## Overview

Re-arranging content on voter-facing screens to make sure things fit in the new landscape orientation on the 13" ELO screen. Also updating the `screenType` setting for theme generation to `'elo13'`, now that most screens are compatible.

Expecting the styling to get tweaked a bit after design feedback, but this should at least unblock SLI testing on the new hardware configuration.

A few sample screen updates shown below - all updated screens use the same shared `FullScreenPromptLayout` component, so they all follow the same pattern.

For wordy screens (or in L/XL mode where there's bound to be content overflow), scroll buttons will appear - there's still some future work pending to update how we list out problem contests, but that's out of scope for now.

## Demo Video or Screenshot
### At default size (M) and largest (XL):
<img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/60d63859-6c33-41e7-8ad0-722e6acb6786" /> <img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/07915a75-7fb2-4975-ae55-b0a434a013e5" />

<img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/57e09cd3-9598-4a56-bddb-3bb69491c0b9" /> <img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/5bdf5a28-99fd-441f-92c0-5ac24e2870ed" />

<img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/9dc56687-1364-41b0-9fe0-d840b364e945" /> <img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/fc8446dd-c615-4b69-a488-533ebdcc0745" /> 

## Testing Plan
- Manual

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
