### PR TITLE
Fix the design app to work with complete system build script

### DIFF
--- a/apps/design/frontend/script/build-stubs
+++ b/apps/design/frontend/script/build-stubs
@@ -1,0 +1,1 @@
+../../../../script/build-stubs

--- a/apps/design/frontend/script/prod-build
+++ b/apps/design/frontend/script/prod-build
@@ -1,0 +1,1 @@
+../../../../script/prod-build


### PR DESCRIPTION
The design app needs the script folder to be properly built by vxsuite-complete-system. It doesn't actually make sense to be built there though so I think maybe we should keep "apps" as production apps and move this somewhere else to fix the problem in a better way, but I want to unblock Ginny using VxDev. 