### PR TITLE
[VxScan] Fit System Admin screen to landscape ELO13

### DIFF
--- a/libs/ui/src/system_administrator_screen_contents.tsx
+++ b/libs/ui/src/system_administrator_screen_contents.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Logger } from '@votingworks/logging';
 import { isVxDev } from '@votingworks/utils';
 
+import styled from 'styled-components';
 import { Button } from './button';
 import { Main } from './main';
 import { Prose } from './prose';
@@ -24,6 +25,17 @@ interface Props {
   usbDriveStatus: UsbDriveStatus;
 }
 
+const ButtonGrid = styled.div`
+  display: grid;
+  grid-auto-rows: 1fr;
+  grid-gap: max(${(p) => p.theme.sizes.minTouchAreaSeparationPx}px, 0.25rem);
+  grid-template-columns: 1fr 1fr;
+
+  @media (orientation: landscape) {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+`;
+
 /**
  * A component for system administrator (formerly super admin) screen contents on non-VxAdmin
  * machines
@@ -45,38 +57,28 @@ export function SystemAdministratorScreenContents({
         {displayRemoveCardToLeavePrompt && (
           <P>Remove the System Administrator card to leave this screen.</P>
         )}
-        {resetPollsToPausedText && (
-          <P>
+        <ButtonGrid>
+          {resetPollsToPausedText && (
             <ResetPollsToPausedButton
               resetPollsToPausedText={resetPollsToPausedText}
               resetPollsToPaused={resetPollsToPaused}
               logger={logger}
             />
-          </P>
-        )}
-        <P>
+          )}
           <RebootFromUsbButton
             usbDriveStatus={usbDriveStatus}
             logger={logger}
           />
-        </P>
-        <P>
           <RebootToBiosButton logger={logger} />
-        </P>
-        <P>
           <PowerDownButton logger={logger} userRole="system_administrator" />
-        </P>
-        <P>
           <UnconfigureMachineButton
             unconfigureMachine={unconfigureMachine}
             isMachineConfigured={isMachineConfigured}
           />
-        </P>
-        {isVxDev() && (
-          <P>
+          {isVxDev() && (
             <Button onPress={() => window.kiosk?.quit()}>Quit</Button>
-          </P>
-        )}
+          )}
+        </ButtonGrid>
       </Prose>
     </Main>
   );

--- a/libs/ui/src/unconfigure_machine_button.tsx
+++ b/libs/ui/src/unconfigure_machine_button.tsx
@@ -56,14 +56,7 @@ export function UnconfigureMachineButton({
 
   return (
     <React.Fragment>
-      <Button
-        // TODO: Make this either regular or primary, since clicking it doesn't
-        // actually cause a destructive action. It just opens a modal which
-        // shows the actual destructive action button.
-        variant="danger"
-        onPress={openConfirmationModal}
-        disabled={!isMachineConfigured}
-      >
+      <Button onPress={openConfirmationModal} disabled={!isMachineConfigured}>
         Unconfigure Machine
       </Button>
       {isConfirmationModalOpen && (


### PR DESCRIPTION
## Overview
Updating the shared `SystemAdministratorScreenContents` component to work in both portrait an landscape formats, to allow the instance in VxScan to fit on the smaller 13" ELO.

This change affects Mark and CentralScan as well, but nothing too disruptive.

Also cleaning up an old TODO to remove the `danger` variant styling from the "Unconfigure Machine" button, since it just triggers a modal containing the actual destructive action.

## Demo Video or Screenshot
### Before/After - VxScan:
<img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/a978c2b0-128e-4a6b-963d-6d3496ac8f22" /> <img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/e9394d79-1cd5-4c98-919b-bdff080167d8" />

### After - CentralScan:
<img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/48228e68-99b4-4ab7-9af8-9dc15d19d820" />

### After - VxMark:
<img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/15bf9bf4-4356-49de-b0ae-993f3ad2ea4d" />

## Testing Plan
- Visual

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
