### PR TITLE
[VxScan] Fit Poll Worker screens to the landscape ELO13

### DIFF
--- a/apps/scan/frontend/src/screens/polls_not_open_screen.tsx
+++ b/apps/scan/frontend/src/screens/polls_not_open_screen.tsx
@@ -1,14 +1,8 @@
 import React from 'react';
-import {
-  Caption,
-  CenteredLargeProse,
-  FullScreenIconWrapper,
-  H1,
-  Icons,
-  P,
-} from '@votingworks/ui';
+import { Caption, FullScreenIconWrapper, Icons, P } from '@votingworks/ui';
 import { PollsState } from '@votingworks/types';
-import { ScreenMainCenterChild } from '../components/layout';
+import { Screen } from '../components/layout';
+import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout';
 
 export interface PollsNotOpenScreenProps {
   isLiveMode: boolean;
@@ -24,18 +18,24 @@ export function PollsNotOpenScreen({
   scannedBallotCount,
 }: PollsNotOpenScreenProps): JSX.Element {
   return (
-    <ScreenMainCenterChild
+    <Screen
+      centerContent
       isLiveMode={isLiveMode}
       infoBarMode="pollworker"
       ballotCountOverride={scannedBallotCount}
     >
-      <FullScreenIconWrapper>
-        {pollsState === 'polls_paused' ? <Icons.Paused /> : <Icons.Closed />}
-      </FullScreenIconWrapper>
-      <CenteredLargeProse>
-        <H1>
-          {pollsState === 'polls_paused' ? 'Polls Paused' : 'Polls Closed'}
-        </H1>
+      <FullScreenPromptLayout
+        title={pollsState === 'polls_paused' ? 'Polls Paused' : 'Polls Closed'}
+        image={
+          <FullScreenIconWrapper>
+            {pollsState === 'polls_paused' ? (
+              <Icons.Paused />
+            ) : (
+              <Icons.Closed />
+            )}
+          </FullScreenIconWrapper>
+        }
+      >
         {pollsState === 'polls_closed_final' ? (
           <P>Voting is complete.</P>
         ) : (
@@ -47,8 +47,8 @@ export function PollsNotOpenScreen({
             poll worker to plug in the power cord.
           </Caption>
         )}
-      </CenteredLargeProse>
-    </ScreenMainCenterChild>
+      </FullScreenPromptLayout>
+    </Screen>
   );
 }
 


### PR DESCRIPTION
## Overview

Updating the last few (Poll Worker) screens that weren't fitting properly in the new landscape 13" ELO format

## Demo Video or Screenshot
### Poll Worker Actions - Before/After:
<img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/e1c53178-b117-4c58-9591-4ac994b954f3" /> <img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/1690af22-f6be-4e14-b103-fd23d9586b76" />

### Other Updated Screens:
<img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/9704e4ca-e679-4879-9efe-38545153bc89" />

<img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/e796e498-16e4-48c1-a2eb-bb944cdb55a7" />

## Testing Plan
- Visual

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
