### PR TITLE
[VxScan] Stop assuming exactly 2 buttons in FullScreenPromptLayout

### DIFF
--- a/apps/scan/frontend/src/components/full_screen_prompt_layout.tsx
+++ b/apps/scan/frontend/src/components/full_screen_prompt_layout.tsx
@@ -53,12 +53,16 @@ const Text = styled.div`
 `;
 
 const Footer = styled.div`
-  display: grid;
-  grid-gap: ${HORIZONTAL_PADDING_REM}rem;
-  grid-template-columns: 1fr 1fr;
-  margin: 0 auto;
+  display: flex;
+  gap: ${HORIZONTAL_PADDING_REM}rem;
+  justify-content: end;
   padding: 0 ${HORIZONTAL_PADDING_REM}rem 0.5rem;
   width: 100%;
+
+  & > * {
+    flex-grow: 1;
+    max-width: 50%;
+  }
 `;
 
 export function FullScreenPromptLayout(


### PR DESCRIPTION
## Overview

Previous footer implementation for the FullScreenPromptLayout was a little brittle, assuming either 0 or 2 action buttons - noticed while testing an NH election that we get a weirdly left-aligned button when there's only one action.
Making the footer a little more flexible to handle that case.

## Demo Video or Screenshot
### Single Action:
![Screenshot 2023-06-06 at 15 57 54](https://github.com/votingworks/vxsuite/assets/264902/6fad6a93-4acd-4274-9f72-35f85831bb25)

### Multiple Actions:
![Screenshot 2023-06-06 at 15 58 26](https://github.com/votingworks/vxsuite/assets/264902/097f58a3-ddb5-4845-bc29-82396e490edf)
![Screenshot 2023-06-06 at 16 19 13](https://github.com/votingworks/vxsuite/assets/264902/c42e9b0a-e5b8-4625-b993-abc1796671a4)

## Testing Plan
- Manual

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
