### PR TITLE
[libs/ui] Add theme configuration for the 'lenovo' screen type

### DIFF
--- a/libs/types/src/ui_theme.ts
+++ b/libs/types/src/ui_theme.ts
@@ -1,5 +1,5 @@
 /** Supported screen types for VxSuite apps. */
-export type ScreenType = 'builtIn' | 'elo13' | 'elo15';
+export type ScreenType = 'builtIn' | 'elo13' | 'elo15' | 'lenovo';
 
 /** Options for supported UI color themes. */
 export type ColorMode =

--- a/libs/ui/.storybook/preview.tsx
+++ b/libs/ui/.storybook/preview.tsx
@@ -26,6 +26,7 @@ const screenTypeToolBarItems: Record<ScreenType, ScreenTypeToolBarItem> = {
   builtIn: { title: 'Generic Built-In Screen', value: 'builtIn' },
   elo13: { title: 'ELO 13" Screen', value: 'elo13' },
   elo15: { title: 'ELO 15" Screen', value: 'elo15' },
+  lenovo: { title: 'Lenovo Thinkpad', value: 'lenovo' },
 };
 
 const DEFAULT_SIZE_MODE: SizeMode = "m";

--- a/libs/ui/src/themes/make_theme.test.ts
+++ b/libs/ui/src/themes/make_theme.test.ts
@@ -46,6 +46,12 @@ test('varies sizes based on screen type', () => {
     screenType: 'elo15',
     sizeMode: 's',
   });
+  const lenovoScreenTheme = makeTheme({
+    colorMode: 'contrastMedium',
+    screenType: 'lenovo',
+    sizeMode: 's',
+  });
 
   expect(elo13ScreenTheme.sizes).not.toEqual(elo15ScreenTheme.sizes);
+  expect(elo15ScreenTheme.sizes).not.toEqual(lenovoScreenTheme.sizes);
 });

--- a/libs/ui/src/themes/make_theme.ts
+++ b/libs/ui/src/themes/make_theme.ts
@@ -107,6 +107,9 @@ const SCREEN_WIDTH_INCHES_ELO_15 = 7.62;
 const SCREEN_WIDTH_PIXELS_ELO_13 = 1080;
 const SCREEN_WIDTH_INCHES_ELO_13 = 6.51;
 
+const SCREEN_WIDTH_PIXELS_LENOVO = 1920;
+const SCREEN_WIDTH_INCHES_LENOVO = 14.81;
+
 interface SizeThemeParams {
   screenType: ScreenType;
   sizeMode: SizeMode;
@@ -117,6 +120,7 @@ const devicePixelsPerInch: Record<ScreenType, () => number> = {
   builtIn: () => window.devicePixelRatio * PIXELS_PER_INCH_WEB,
   elo13: () => SCREEN_WIDTH_PIXELS_ELO_13 / SCREEN_WIDTH_INCHES_ELO_13,
   elo15: () => SCREEN_WIDTH_PIXELS_ELO_15 / SCREEN_WIDTH_INCHES_ELO_15,
+  lenovo: () => SCREEN_WIDTH_PIXELS_LENOVO / SCREEN_WIDTH_INCHES_LENOVO,
 };
 
 function mmToPx(mm: number, screenType: ScreenType): number {


### PR DESCRIPTION
## Overview

Adding a `'lenovo'` screen type, for UI theme generation, with dimensions and pixel density matching the Lenovo machines used for VxAdmin builds. Ensures that sizes are scaled more appropriately/consistently than the `'builtIn'` screen type allows for.

## Testing Plan
- Dimensions from Lenovo tech specs, rendering tested on Thinkpad

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
