### PR TITLE
[VxScan] Update 'Insert Ballot' copy to exclude tray location

### DIFF
--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -386,7 +386,7 @@ async function scanBallot() {
 
   apiMock.expectGetScannerStatus(statusBallotCounted);
   jest.advanceTimersByTime(POLLING_INTERVAL_FOR_SCANNER_STATUS_MS);
-  await screen.findByText('Insert Your Ballot Above');
+  await screen.findByText(/Insert Your Ballot/i);
   expect(screen.getByTestId('ballot-count').textContent).toEqual('1');
 }
 
@@ -398,7 +398,7 @@ test('voter can cast a ballot that scans successfully ', async () => {
   apiMock.expectGetUsbDriveStatus('mounted');
   apiMock.expectGetScannerStatus(statusNoPaper);
   renderApp();
-  await screen.findByText('Insert Your Ballot Above');
+  await screen.findByText(/Insert Your Ballot/i);
   screen.getByText('Scan one ballot sheet at a time.');
   screen.getByText('General Election');
   screen.getByText(/Franklin County/);
@@ -511,7 +511,7 @@ test('voter can cast a ballot that needs review and adjudicate as desired', asyn
   apiMock.expectGetUsbDriveStatus('mounted');
   apiMock.expectGetScannerStatus(statusNoPaper);
   renderApp();
-  await screen.findByText('Insert Your Ballot Above');
+  await screen.findByText(/Insert Your Ballot/i);
 
   const interpretation: SheetInterpretation = {
     type: 'NeedsReviewSheet',
@@ -550,7 +550,7 @@ test('voter can cast a ballot that needs review and adjudicate as desired', asyn
     scannerStatus({ state: 'no_paper', ballotsCounted: 1 })
   );
   jest.advanceTimersByTime(POLLING_INTERVAL_FOR_SCANNER_STATUS_MS);
-  await screen.findByText('Insert Your Ballot Above');
+  await screen.findByText(/Insert Your Ballot/i);
   expect(screen.getByTestId('ballot-count').textContent).toEqual('1');
 });
 
@@ -559,7 +559,7 @@ test('voter tries to cast ballot that is rejected', async () => {
   apiMock.expectGetUsbDriveStatus('mounted');
   apiMock.expectGetScannerStatus(statusNoPaper);
   renderApp();
-  await screen.findByText('Insert Your Ballot Above');
+  await screen.findByText(/Insert Your Ballot/i);
 
   apiMock.expectGetScannerStatus(scannerStatus({ state: 'ready_to_scan' }));
   apiMock.mockApiClient.scanBallot.expectCallWith().resolves();
@@ -584,7 +584,7 @@ test('voter tries to cast ballot that is rejected', async () => {
 
   // When the voter removes the ballot return to the insert ballot screen
   apiMock.expectGetScannerStatus(statusNoPaper);
-  await screen.findByText('Insert Your Ballot Above');
+  await screen.findByText(/Insert Your Ballot/i);
 });
 
 test('voter can cast another ballot while the success screen is showing', async () => {
@@ -657,7 +657,7 @@ test('no printer: poll worker can open and close polls without scanning any ball
     'Insert poll worker card into VxMark to print the report.'
   );
   apiMock.removeCard();
-  await screen.findByText('Insert Your Ballot Above');
+  await screen.findByText(/Insert Your Ballot/i);
 
   // Close Polls Flow
   apiMock.expectGetCastVoteRecordsForTally([]);
@@ -704,7 +704,7 @@ test('with printer: poll worker can open and close polls without scanning any ba
   screen.getByRole('button', { name: 'Print Additional Polls Opened Report' });
   screen.getByText('Remove the poll worker card', { exact: false });
   apiMock.removeCard();
-  await screen.findByText('Insert Your Ballot Above');
+  await screen.findByText(/Insert Your Ballot/i);
 
   // Close Polls Flow
   apiMock.expectGetCastVoteRecordsForTally([]);
@@ -749,7 +749,7 @@ test('no printer: open polls, scan ballot, close polls, save results', async () 
     apiMock.mockApiClient.saveScannerReportDataToCard
   ).toHaveBeenCalledTimes(1);
   apiMock.removeCard();
-  await screen.findByText('Insert Your Ballot Above');
+  await screen.findByText(/Insert Your Ballot/i);
 
   await scanBallot();
 
@@ -828,7 +828,7 @@ test('poll worker can open, pause, unpause, and close poll without scanning any 
     'Insert poll worker card into VxMark to print the report.'
   );
   apiMock.removeCard();
-  await screen.findByText('Insert Your Ballot Above');
+  await screen.findByText(/Insert Your Ballot/i);
 
   // Pause Voting Flow
   apiMock.expectGetCastVoteRecordsForTally([]);
@@ -856,7 +856,7 @@ test('poll worker can open, pause, unpause, and close poll without scanning any 
     'Insert poll worker card into VxMark to print the report.'
   );
   apiMock.removeCard();
-  await screen.findByText('Insert Your Ballot Above');
+  await screen.findByText(/Insert Your Ballot/i);
 
   // Close Polls Flow
   apiMock.expectGetCastVoteRecordsForTally([]);
@@ -973,7 +973,7 @@ test('replace ballot bag flow', async () => {
   apiMock.expectGetUsbDriveStatus('mounted');
   apiMock.expectGetScannerStatus(statusNoPaper);
   const { logger } = renderApp();
-  await screen.findByText('Insert Your Ballot Above');
+  await screen.findByText(/Insert Your Ballot/i);
 
   await scanBallot();
 
@@ -1015,7 +1015,7 @@ test('replace ballot bag flow', async () => {
   });
   apiMock.removeCard();
   await advanceTimersAndPromises(3);
-  await screen.findByText('Insert Your Ballot Above');
+  await screen.findByText(/Insert Your Ballot/i);
 
   expect(logger.log).toHaveBeenCalledWith(
     LogEventId.BallotBagReplaced,
@@ -1031,7 +1031,7 @@ test('replace ballot bag flow', async () => {
     })
   );
   await advanceTimersAndPromises(1);
-  await screen.findByText('Insert Your Ballot Above');
+  await screen.findByText(/Insert Your Ballot/i);
 
   // Prompts again if new threshold has been reached
   apiMock.expectGetScannerStatus(

--- a/apps/scan/frontend/src/app_tally_report_paths.test.tsx
+++ b/apps/scan/frontend/src/app_tally_report_paths.test.tsx
@@ -347,7 +347,7 @@ test('printing: polls closed, primary election, all precincts + quickresults on'
   apiMock.expectGetConfig({ electionDefinition, pollsState: 'polls_open' });
   apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 3 });
   renderApp({ connectPrinter: true });
-  await screen.findByText('Insert Your Ballot Above');
+  await screen.findByText(/Insert Your Ballot/i);
 
   // Close the polls
   await closePolls({
@@ -619,7 +619,7 @@ test('saving to card: polls closed, primary election, all precincts', async () =
   apiMock.expectGetConfig({ electionDefinition, pollsState: 'polls_open' });
   apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 3 });
   renderApp({ connectPrinter: false });
-  await screen.findByText('Insert Your Ballot Above');
+  await screen.findByText(/Insert Your Ballot/i);
 
   // Close the polls
   await closePolls({
@@ -744,7 +744,7 @@ test('printing: polls closed, primary election, single precinct + check addition
   });
   apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 3 });
   renderApp({ connectPrinter: true });
-  await screen.findByText('Insert Your Ballot Above');
+  await screen.findByText(/Insert Your Ballot/i);
 
   // Close the polls
   await closePolls({
@@ -892,7 +892,7 @@ test('saving to card: polls closed, primary election, single precinct', async ()
   });
   apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 3 });
   renderApp({ connectPrinter: false });
-  await screen.findByText('Insert Your Ballot Above');
+  await screen.findByText(/Insert Your Ballot/i);
 
   // Close the polls
   await closePolls({
@@ -974,7 +974,7 @@ test('printing: polls closed, general election, all precincts', async () => {
   apiMock.expectGetConfig({ electionDefinition, pollsState: 'polls_open' });
   apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 });
   renderApp({ connectPrinter: true });
-  await screen.findByText('Insert Your Ballot Above');
+  await screen.findByText(/Insert Your Ballot/i);
 
   // Close the polls
   await closePolls({
@@ -1062,7 +1062,7 @@ test('saving to card: polls closed, general election, all precincts', async () =
   apiMock.expectGetConfig({ electionDefinition, pollsState: 'polls_open' });
   apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 });
   renderApp({ connectPrinter: false });
-  await screen.findByText('Insert Your Ballot Above');
+  await screen.findByText(/Insert Your Ballot/i);
 
   // Close the polls
   await closePolls({
@@ -1151,7 +1151,7 @@ test('printing: polls closed, general election, single precinct', async () => {
   });
   apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 });
   renderApp({ connectPrinter: true });
-  await screen.findByText('Insert Your Ballot Above');
+  await screen.findByText(/Insert Your Ballot/i);
 
   // Close the polls
   await closePolls({
@@ -1216,7 +1216,7 @@ test('saving to card: polls closed, general election, single precinct', async ()
   });
   apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 });
   renderApp({ connectPrinter: false });
-  await screen.findByText('Insert Your Ballot Above');
+  await screen.findByText(/Insert Your Ballot/i);
 
   // Close the polls
   await closePolls({
@@ -1268,7 +1268,7 @@ test('printing: polls paused', async () => {
   });
   apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 });
   renderApp({ connectPrinter: true });
-  await screen.findByText('Insert Your Ballot Above');
+  await screen.findByText(/Insert Your Ballot/i);
 
   // Pause the polls
   apiMock.expectGetCastVoteRecordsForTally(GENERAL_SINGLE_PRECINCT_CVRS);
@@ -1308,7 +1308,7 @@ test('saving to card: polls paused', async () => {
   });
   apiMock.expectGetScannerStatus({ ...statusNoPaper, ballotsCounted: 2 });
   renderApp({ connectPrinter: false });
-  await screen.findByText('Insert Your Ballot Above');
+  await screen.findByText(/Insert Your Ballot/i);
 
   // Pause the polls
   apiMock.expectGetCastVoteRecordsForTally(GENERAL_SINGLE_PRECINCT_CVRS);

--- a/apps/scan/frontend/src/app_unhappy_paths.test.tsx
+++ b/apps/scan/frontend/src/app_unhappy_paths.test.tsx
@@ -247,7 +247,7 @@ test('App shows warning message to connect to power when disconnected', async ()
 
   // Remove pollworker card
   apiMock.removeCard();
-  await screen.findByText('Insert Your Ballot Above');
+  await screen.findByText(/Insert Your Ballot/i);
   // There should be no warning about power
   expect(screen.queryByText('No Power Detected.')).toBeNull();
   // Disconnect from power and check for warning

--- a/apps/scan/frontend/src/screens/insert_ballot_screen.tsx
+++ b/apps/scan/frontend/src/screens/insert_ballot_screen.tsx
@@ -21,7 +21,7 @@ export function InsertBallotScreen({
       ballotCountOverride={scannedBallotCount}
     >
       <FullScreenPromptLayout
-        title="Insert Your Ballot Above"
+        title="Insert Your Ballot"
         image={<InsertBallotImage ballotFeedLocation="top" />}
       >
         <P>Scan one ballot sheet at a time.</P>


### PR DESCRIPTION
## Overview

We switched from "insert ballot below" to "insert ballot above" for the last machine build - switching back to a ballot tray below the screen, but now dropping the "above/below" wording altogether with the assumption that it's intuitive enough with the current build.

## Demo Video or Screenshot
![Screenshot 2023-06-07 at 11 05 20](https://github.com/votingworks/vxsuite/assets/264902/fe9aafda-ad24-42f0-9fb5-3f9bcdae27a0)

## Testing Plan
- Updated existing tests

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
