### PR TITLE
Sign CVRs using data on machine rather than USB

### DIFF
--- a/libs/backend/src/scan/cast_vote_records/export.test.ts
+++ b/libs/backend/src/scan/cast_vote_records/export.test.ts
@@ -273,19 +273,22 @@ test('exportCastVoteRecordReportToUsbDrive, with write-in image', async () => {
     1,
     expectedReportPath,
     CAST_VOTE_RECORD_REPORT_FILENAME,
-    expect.anything()
+    expect.anything(),
+    { machineDirectoryToWriteToFirst: expect.stringContaining('/tmp/') }
   );
   expect(exportDataToUsbDriveMock).toHaveBeenNthCalledWith(
     2,
     expectedReportPath,
     'ballot-images/batch-1/front.jpg',
-    'mock-image-data'
+    'mock-image-data',
+    { machineDirectoryToWriteToFirst: expect.stringContaining('/tmp/') }
   );
   expect(exportDataToUsbDriveMock).toHaveBeenNthCalledWith(
     3,
     expectedReportPath,
     'ballot-layouts/batch-1/front.layout.json',
-    JSON.stringify(interpretedHmpbPage1WithWriteIn.layout, undefined, 2)
+    JSON.stringify(interpretedHmpbPage1WithWriteIn.layout, undefined, 2),
+    { machineDirectoryToWriteToFirst: expect.stringContaining('/tmp/') }
   );
   expect(mockArtifactAuthenticator.writeSignatureFile).toHaveBeenCalledTimes(1);
 

--- a/libs/backend/src/scan/globals.ts
+++ b/libs/backend/src/scan/globals.ts
@@ -25,8 +25,13 @@ export const NODE_ENV = unsafeParse(
  */
 const defaultAllowedExportPatterns =
   NODE_ENV === 'test'
-    ? ['/tmp/**/*'] // Mock USB drive location
-    : ['/media/**/*']; // Real USB drive location
+    ? [
+        '/tmp/**/*', // Mock USB drive location
+      ]
+    : [
+        '/media/**/*', // Real USB drive location
+        '/tmp/**/*', // Where data is first written for signature file creation
+      ];
 
 /**
  * Where are exported files allowed to be written to?


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/2866

The equivalent of https://github.com/votingworks/vxsuite/pull/3554 but for CVRs. Copying from that PR's description:

>  If we write data to USB and then sign that USB data, our security narrative relies on USBs not being compromised/faulty, as a compromised/faulty USB could claim to have written the data that we asked it to but actually have written something else. So even if the artifact and its signature match, the underlying artifact might be invalid. While it's highly unlikely that this situation would arise in practice, let's harden our security narrative by signing data on machine rather than USB.

This PR applies this change to CVR signing.

## Testing

- [x] Updated automated tests
- [x] Tested CVR export and import manually

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A