### PR TITLE
[Admin] Use Modal `title` prop for consistent/theme-appropriate styling

### DIFF
--- a/apps/admin/frontend/src/components/export_election_ballot_package_modal_button.tsx
+++ b/apps/admin/frontend/src/components/export_election_ballot_package_modal_button.tsx
@@ -54,6 +54,7 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
     setSaveState({ state: 'saved' });
   }
 
+  let title = '';
   let mainContent: React.ReactNode = null;
   let actions: React.ReactNode = null;
 
@@ -64,9 +65,9 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
         case 'ejected':
         case 'bad_format':
           actions = <Button onPress={closeModal}>Cancel</Button>;
+          title = 'No USB Drive Detected';
           mainContent = (
             <Prose>
-              <h1>No USB Drive Detected</h1>
               <p>
                 <UsbImage src="/assets/usb-drive.svg" alt="Insert USB Image" />
                 Please insert a USB drive in order to save the ballot
@@ -93,9 +94,9 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
               <Button onPress={closeModal}>Cancel</Button>
             </React.Fragment>
           );
+          title = 'Save Ballot Package';
           mainContent = (
             <Prose>
-              <h1>Save Ballot Package</h1>
               <p>
                 <UsbImage src="/assets/usb-drive.svg" alt="Insert USB Image" />A
                 zip archive will automatically be saved to the default location
@@ -117,9 +118,9 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
           Cancel
         </Button>
       );
+      title = 'Saving…';
       mainContent = (
         <Prose>
-          <h1>Saving…</h1>
           <p>Closing zip file.</p>
         </Prose>
       );
@@ -142,9 +143,9 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
       } else {
         actions = <Button onPress={closeModal}>Close</Button>;
       }
+      title = 'Ballot Package Saved';
       mainContent = (
         <Prose>
-          <h1>Ballot Package Saved</h1>
           <p>
             You may now eject the USB drive. Use the saved ballot package on
             this USB drive to configure VxScan or VxCentralScan.
@@ -156,9 +157,9 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
 
     case 'error': {
       actions = <Button onPress={closeModal}>Close</Button>;
+      title = 'Failed to Save Ballot Package';
       mainContent = (
         <Prose>
-          <h1>Failed to Save Ballot Package</h1>
           <p>An error occurred: {ErrorMessages[saveState.error]}.</p>
         </Prose>
       );
@@ -177,6 +178,7 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
       </Button>
       {isModalOpen && (
         <Modal
+          title={title}
           content={mainContent}
           onOverlayClick={closeModal}
           actions={actions}

--- a/apps/admin/frontend/src/components/format_usb_modal.tsx
+++ b/apps/admin/frontend/src/components/format_usb_modal.tsx
@@ -55,9 +55,9 @@ function FormatUsbFlow({ onClose }: FormatUsbModalProps): JSX.Element {
         case 'mounted': {
           return (
             <Modal
+              title="Format USB Drive"
               content={
                 <Prose>
-                  <h1>Format USB Drive</h1>
                   <p>
                     {usbDrive.status === 'bad_format'
                       ? 'The format of the inserted USB drive is not VotingWorks compatible. Would you like to format the USB drive?'
@@ -88,9 +88,9 @@ function FormatUsbFlow({ onClose }: FormatUsbModalProps): JSX.Element {
     case 'confirm':
       return (
         <Modal
+          title="Confirm Format USB Drive"
           content={
             <Prose>
-              <h1>Confirm Format USB Drive</h1>
               <p>
                 <strong>Warning:</strong> formatting will delete all files on
                 the USB drive. Back up USB drive files before formatting.
@@ -113,9 +113,9 @@ function FormatUsbFlow({ onClose }: FormatUsbModalProps): JSX.Element {
     case 'done':
       return (
         <Modal
+          title="USB Drive Formatted"
           content={
             <Prose>
-              <h1>USB Drive Formatted</h1>
               <p>
                 USB drive successfully reformatted. It is now ready to use with
                 VotingWorks devices.
@@ -129,9 +129,9 @@ function FormatUsbFlow({ onClose }: FormatUsbModalProps): JSX.Element {
     case 'error':
       return (
         <Modal
+          title="Failed to Format USB Drive"
           content={
             <Prose>
-              <h1>Failed to Format USB Drive</h1>
               <p>Failed to format USB drive: {state.message}</p>
             </Prose>
           }
@@ -150,9 +150,9 @@ export function FormatUsbModal({ onClose }: FormatUsbModalProps): JSX.Element {
   if (usbDrive.status === 'absent') {
     return (
       <Modal
+        title="No USB Drive Detected"
         content={
           <Prose>
-            <h1>No USB Drive Detected</h1>
             <p>
               <UsbImage />
               Insert a USB drive you would like to format.

--- a/apps/admin/frontend/src/components/import_cvrfiles_modal.test.tsx
+++ b/apps/admin/frontend/src/components/import_cvrfiles_modal.test.tsx
@@ -223,10 +223,8 @@ describe('when USB is properly mounted', () => {
       usbDrive: mockUsbDrive('mounted'),
       apiMock,
     });
-    await waitFor(() => {
-      expect(screen.getByTestId('modal-title')).toHaveTextContent(
-        'Load Test Ballot Mode CVR Files'
-      );
+    await screen.findByRole('heading', {
+      name: 'Load Test Ballot Mode CVR Files',
     });
 
     const tableRows = screen.getAllByTestId('table-row');

--- a/apps/admin/frontend/src/components/import_cvrfiles_modal.tsx
+++ b/apps/admin/frontend/src/components/import_cvrfiles_modal.tsx
@@ -144,9 +144,9 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element | null {
   if (currentState.state === 'error') {
     return (
       <Modal
+        title="Error"
         content={
           <Prose>
-            <h1>Error</h1>
             <p>
               There was an error reading the contents of{' '}
               <strong>{currentState.filename}</strong>:{' '}
@@ -163,9 +163,9 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element | null {
   if (currentState.state === 'duplicate') {
     return (
       <Modal
+        title="Duplicate File"
         content={
           <Prose>
-            <h1>Duplicate File</h1>
             <p>
               The selected file was ignored as a duplicate of a previously
               loaded file.
@@ -181,9 +181,9 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element | null {
   if (currentState.state === 'success') {
     return (
       <Modal
+        title={`${currentState.result.newlyAdded} new CVRs Loaded`}
         content={
           <Prose>
-            <h1>{currentState.result.newlyAdded} new CVRs Loaded</h1>
             {currentState.result.alreadyPresent > 0 && (
               <p>
                 Of the{' '}
@@ -229,9 +229,9 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element | null {
   ) {
     return (
       <Modal
+        title="No USB Drive Detected"
         content={
           <Prose>
-            <h1>No USB Drive Detected</h1>
             <p>
               <UsbImage src="/assets/usb-drive.svg" alt="Insert USB Image" />
               Please insert a USB drive in order to load CVR files from the
@@ -311,13 +311,11 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element | null {
     }
     // Set the header and instructional text for the modal
     const headerModeText =
-      fileMode === 'test' ? (
-        <TestMode>Test Ballot Mode</TestMode>
-      ) : fileMode === 'official' ? (
-        'Official Ballot Mode'
-      ) : (
-        ''
-      );
+      fileMode === 'test'
+        ? 'Test Ballot Mode'
+        : fileMode === 'official'
+        ? 'Official Ballot Mode'
+        : '';
 
     let instructionalText: JSX.Element | string;
     if (numberOfNewFiles === 0) {
@@ -345,12 +343,10 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element | null {
     return (
       <Modal
         modalWidth={ModalWidth.Wide}
+        title={`Load ${headerModeText} CVR Files`}
         content={
           <React.Fragment>
             <Prose maxWidth={false}>
-              <h1 data-testid="modal-title">
-                Load {headerModeText} CVR Files{' '}
-              </h1>
               <p>{instructionalText}</p>
             </Prose>
             {fileTableRows.length > 0 && (

--- a/apps/admin/frontend/src/components/print_button.tsx
+++ b/apps/admin/frontend/src/components/print_button.tsx
@@ -5,7 +5,6 @@ import {
   StyledButtonProps,
   Modal,
   useCancelablePromise,
-  Prose,
 } from '@votingworks/ui';
 import { sleep } from '@votingworks/basics';
 import { Loading } from './loading';
@@ -26,17 +25,16 @@ function PrinterNotConnectedModal({
 }: PrinterNotConnectedModalProps): JSX.Element {
   return (
     <Modal
+      title={
+        isNotConnected
+          ? 'The printer is not connected.'
+          : 'The printer is now connected.'
+      }
       content={
         isNotConnected ? (
-          <Prose>
-            <h2>The printer is not connected.</h2>
-            <p>Please connect the printer.</p>
-          </Prose>
+          <p>Please connect the printer.</p>
         ) : (
-          <Prose>
-            <h2>The printer is now connected.</h2>
-            <p>You may continue printing.</p>
-          </Prose>
+          <p>You may continue printing.</p>
         )
       }
       actions={

--- a/apps/admin/frontend/src/components/printer_not_connected_modal.tsx
+++ b/apps/admin/frontend/src/components/printer_not_connected_modal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Modal, Prose } from '@votingworks/ui';
+import { Button, Modal } from '@votingworks/ui';
 
 interface Props {
   onClose: VoidFunction;
@@ -8,12 +8,8 @@ interface Props {
 export function PrinterNotConnectedModal({ onClose }: Props): JSX.Element {
   return (
     <Modal
-      content={
-        <Prose>
-          <h2>The printer is not connected.</h2>
-          <p>Please connect the printer and try again.</p>
-        </Prose>
-      }
+      title="The printer is not connected."
+      content={<p>Please connect the printer and try again.</p>}
       actions={<Button onPress={onClose}>Okay</Button>}
     />
   );

--- a/apps/admin/frontend/src/components/remove_all_manual_tallies_modal.tsx
+++ b/apps/admin/frontend/src/components/remove_all_manual_tallies_modal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Modal, Button, P, Font, H1 } from '@votingworks/ui';
+import { Modal, Button, P, Font } from '@votingworks/ui';
 import { deleteAllManualResults } from '../api';
 
 export interface Props {
@@ -18,14 +18,12 @@ export function RemoveAllManualTalliesModal({
   }
   return (
     <Modal
+      title="Remove Manually Entered Results"
       content={
-        <React.Fragment>
-          <H1>Remove Manually Entered Results</H1>
-          <P>
-            Do you want to remove <Font weight="bold">all</Font> manually
-            entered results?
-          </P>
-        </React.Fragment>
+        <P>
+          Do you want to remove <Font weight="bold">all</Font> manually entered
+          results?
+        </P>
       }
       actions={
         <React.Fragment>

--- a/apps/admin/frontend/src/components/save_file_to_usb.tsx
+++ b/apps/admin/frontend/src/components/save_file_to_usb.tsx
@@ -159,13 +159,11 @@ export function SaveFileToUsb({
   if (currentState === ModalState.ERROR) {
     return (
       <Modal
+        title={`Failed to Save ${title}`}
         content={
-          <Prose>
-            <h1>Failed to Save {title}</h1>
-            <p>
-              Failed to save {fileName}. {errorMessage}
-            </p>
-          </Prose>
+          <p>
+            Failed to save {fileName}. {errorMessage}
+          </p>
         }
         onOverlayClick={onClose}
         actions={<Button onPress={onClose}>Close</Button>}
@@ -190,9 +188,9 @@ export function SaveFileToUsb({
     }
     return (
       <Modal
+        title={`${title} Saved`}
         content={
           <Prose>
-            <h1>{title} Saved</h1>
             {promptToEjectUsb && <p>You may now eject the USB drive.</p>}
             <p>
               {fileName.charAt(0).toUpperCase() + fileName.slice(1)}{' '}
@@ -228,9 +226,9 @@ export function SaveFileToUsb({
       // on the machine for internal debugging use
       return (
         <Modal
+          title="No USB Drive Detected"
           content={
             <Prose>
-              <h1>No USB Drive Detected</h1>
               <p>
                 <UsbImage
                   src="/assets/usb-drive.svg"
@@ -271,9 +269,9 @@ export function SaveFileToUsb({
     case 'mounted': {
       return (
         <Modal
+          title={`Save ${title}`}
           content={
             <Prose>
-              <h1>Save {title}</h1>
               <p>
                 Save the {fileName} as <strong>{defaultFilename}</strong> on the
                 inserted USB drive?

--- a/apps/admin/frontend/src/screens/manual_data_summary_screen.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_summary_screen.tsx
@@ -8,7 +8,6 @@ import {
   Table,
   TD,
   LinkButton,
-  H1,
   P,
   H4,
   Select,
@@ -89,9 +88,9 @@ function RemoveManualTallyModal({
 
   return (
     <Modal
+      title="Remove Manually Entered Results"
       content={
         <React.Fragment>
-          <H1>Remove Manually Entered Results</H1>
           <P>
             Do you want to remove the manually entered results for the following
             type of ballots cast?

--- a/apps/admin/frontend/src/screens/print_test_deck_screen.tsx
+++ b/apps/admin/frontend/src/screens/print_test_deck_screen.tsx
@@ -181,9 +181,9 @@ function PrintingModal({
     return (
       <Modal
         centerContent
+        title="Change Paper"
         content={
           <Prose textCenter>
-            <h1>Change Paper</h1>
             <p>
               Load printer with{' '}
               <strong>

--- a/apps/admin/frontend/src/screens/tally_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally_report_screen.tsx
@@ -308,9 +308,9 @@ export function TallyReportScreen(): JSX.Element {
       {isMarkOfficialModalOpen && (
         <Modal
           centerContent
+          title="Mark Unofficial Tally Results as Official Tally Results?"
           content={
             <Prose textCenter>
-              <h1>Mark Unofficial Tally Results as Official Tally Results?</h1>
               <p>
                 Have all CVR files been loaded? Once results are marked as
                 official, no additional CVR files can be loaded.

--- a/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
@@ -18,7 +18,6 @@ import {
   HorizontalRule,
   Icons,
   Modal,
-  H1,
   P,
   Font,
 } from '@votingworks/ui';
@@ -293,12 +292,8 @@ function DoubleVoteAlertModal({
 
   return (
     <Modal
-      content={
-        <React.Fragment>
-          <H1>Possible Double Vote Detected</H1>
-          {text}
-        </React.Fragment>
-      }
+      title="Possible Double Vote Detected"
+      content={text}
       actions={
         <Button variant="regular" onPress={onClose}>
           Cancel


### PR DESCRIPTION
# Overview

Doing a VVSG typography pass on VxAdmin before we enable the new themes. This updates modals to use the new `title` prop to fix sizing/spacing.

## Demo Video or Screenshot
<img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/ab048ff8-0249-4d0c-b51e-512ebb4c15d9" /> <img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/de927bb4-9457-4bfb-a774-8e27d810ad0d" />

## Testing Plan
- Updated affected existing tests

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
