### PR TITLE
Fix ballot package exports

### DIFF
--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -29,7 +29,7 @@ import {
 } from '@votingworks/auth';
 import * as grout from '@votingworks/grout';
 import { useDevDockRouter } from '@votingworks/dev-dock-backend';
-import { existsSync, promises as fs, Stats } from 'fs';
+import { createReadStream, existsSync, promises as fs, Stats } from 'fs';
 import { basename, dirname, join } from 'path';
 import {
   BALLOT_PACKAGE_FOLDER,
@@ -230,9 +230,9 @@ function buildApi({
           usbBallotPackageDirectory,
           ballotPackageFileName
         );
-        await fs.copyFile(
-          tempDirectoryBallotPackageFilePath,
-          usbBallotPackageFilePath
+        await fs.writeFile(
+          usbBallotPackageFilePath,
+          createReadStream(tempDirectoryBallotPackageFilePath)
         );
 
         await artifactAuthenticator.writeSignatureFile(


### PR DESCRIPTION
## Overview

Both @kshen0 and I get a permissions error when the ballot package export code uses `fs.copyFile`:

```
[backend:run] [Error: EPERM: operation not permitted, copyfile '/tmp/tmp-498487-NDSXKpjA9TXF/franklin-county_lincoln-municipal-general-election_b4e07814b4__2023-06-07_13-41-04.zip' -> '/media/vx/usb-drive/ballot-packages/franklin-county_lincoln-municipal-general-election_b4e07814b4__2023-06-07_13-41-04.zip'] {
[backend:run]   errno: -1,
[backend:run]   code: 'EPERM',
[backend:run]   syscall: 'copyfile',
[backend:run]   path: '/tmp/tmp-498487-NDSXKpjA9TXF/franklin-county_lincoln-municipal-general-election_b4e07814b4__2023-06-07_13-41-04.zip',
[backend:run]   dest: '/media/vx/usb-drive/ballot-packages/franklin-county_lincoln-municipal-general-election_b4e07814b4__2023-06-07_13-41-04.zip'
[backend:run] }
```

Interestingly, I don't get an error when using `fs.cp`, but that's an experimental function not recommended for production. I also don't get an error when copying by creating a new read stream and using `fs.writeFile`, so I've gone ahead and changed the code to do that.

Can dig deeper into why `fs.copyFile` doesn't work but want to get this fix out so main isn't broken.

## Testing

- [x] Manually tested ballot package export and import