### PR TITLE
[VxAdmin] Prune UI related to ballot generation when not relevant

### DIFF
--- a/apps/admin/frontend/src/app.test.tsx
+++ b/apps/admin/frontend/src/app.test.tsx
@@ -751,17 +751,14 @@ test('can not view or print ballots', async () => {
   renderApp();
 
   await apiMock.authenticateAsSystemAdministrator();
-  fireEvent.click(screen.getByText('Ballots'));
-  await screen.findByText(
-    'VxAdmin does not produce ballots for this election.'
-  );
-  expect(screen.queryByText('Save Ballot Package')).toBeNull();
+  expect(
+    within(screen.getByRole('navigation')).queryByRole('button', {
+      name: 'Ballots',
+    })
+  ).not.toBeInTheDocument();
 
   await apiMock.logOut();
   await apiMock.authenticateAsElectionManager(electionDefinition);
-  await screen.findByText(
-    'VxAdmin does not produce ballots for this election.'
-  );
   screen.getByText('Save Ballot Package');
 });
 
@@ -805,7 +802,6 @@ test('system administrator UI has expected nav', async () => {
 
   userEvent.click(screen.getByText('Definition'));
   await screen.findByRole('heading', { name: 'Election Definition' });
-  userEvent.click(screen.getByText('Ballots'));
   userEvent.click(screen.getByText('Smartcards'));
   await screen.findByRole('heading', { name: 'Election Cards' });
   userEvent.click(screen.getByText('Settings'));
@@ -832,7 +828,6 @@ test('system administrator UI has expected nav when no election', async () => {
   await screen.findByRole('heading', { name: 'Logs' });
   screen.getByRole('button', { name: 'Lock Machine' });
 
-  expect(screen.queryByText('Ballots')).not.toBeInTheDocument();
   expect(screen.queryByText('Smartcards')).not.toBeInTheDocument();
 
   // Create an election definition and verify that previously hidden tabs appear
@@ -850,7 +845,6 @@ test('system administrator UI has expected nav when no election', async () => {
       screen.queryByRole('heading', { name: 'Configure VxAdmin' })
     ).not.toBeInTheDocument()
   );
-  screen.getByText('Ballots');
   screen.getByText('Smartcards');
 
   // Remove the election definition and verify that those same tabs disappear
@@ -867,9 +861,8 @@ test('system administrator UI has expected nav when no election', async () => {
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
   );
   await waitFor(() =>
-    expect(screen.queryByText('Ballots')).not.toBeInTheDocument()
+    expect(screen.queryByText('Smartcards')).not.toBeInTheDocument()
   );
-  expect(screen.queryByText('Smartcards')).not.toBeInTheDocument();
 });
 
 test('system administrator Smartcards screen navigation', async () => {

--- a/apps/admin/frontend/src/components/election_manager.tsx
+++ b/apps/admin/frontend/src/components/election_manager.tsx
@@ -36,6 +36,7 @@ import { ReportsScreen } from '../screens/reports_screen';
 import { SmartcardTypeRegExPattern } from '../config/types';
 import { SmartcardModal } from './smartcard_modal';
 import { checkPin } from '../api';
+import { canViewAndPrintBallots } from '../utils/can_view_and_print_ballots';
 
 export function ElectionManager(): JSX.Element {
   const { electionDefinition, configuredAt, auth, hasCardReaderAttached } =
@@ -116,9 +117,6 @@ export function ElectionManager(): JSX.Element {
             path={routerPaths.definitionContest({ contestId: ':contestId' })}
           >
             <DefinitionContestsScreen />
-          </Route>
-          <Route exact path={routerPaths.ballotsList}>
-            <BallotListScreen />
           </Route>
           <Route exact path={routerPaths.smartcards}>
             <Redirect
@@ -228,9 +226,11 @@ export function ElectionManager(): JSX.Element {
       >
         <TallyReportScreen />
       </Route>
-      <Route exact path={routerPaths.logicAndAccuracy}>
-        <LogicAndAccuracyScreen />
-      </Route>
+      {election && canViewAndPrintBallots(election) && (
+        <Route exact path={routerPaths.logicAndAccuracy}>
+          <LogicAndAccuracyScreen />
+        </Route>
+      )}
       <Route exact path={[routerPaths.testDecks]}>
         <PrintTestDeckScreen />
       </Route>

--- a/apps/admin/frontend/src/screens/ballot_list_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_list_screen.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 
 import { assert } from '@votingworks/basics';
 import { Prose } from '@votingworks/ui';
-import { isElectionManagerAuth } from '@votingworks/utils';
 import { AppContext } from '../contexts/app_context';
 
 import { NavigationScreen } from '../components/navigation_screen';
@@ -16,32 +15,19 @@ const Header = styled.div`
 `;
 
 export function BallotListScreen(): JSX.Element {
-  const { auth, configuredAt, electionDefinition } = useContext(AppContext);
+  const { configuredAt, electionDefinition } = useContext(AppContext);
   assert(electionDefinition && typeof configuredAt === 'string');
 
   return (
     <NavigationScreen title="Ballots">
       <Header>
         <Prose>
-          <p>VxAdmin does not produce ballots for this election.</p>
-          {isElectionManagerAuth(auth) ? (
-            <React.Fragment>
-              <p>
-                Save the Ballot Package to USB to configure VxCentralScan or
-                VxScan.
-              </p>
-              <p>
-                <ExportElectionBallotPackageModalButton />
-              </p>
-            </React.Fragment>
-          ) : (
-            <p>
-              <em>
-                Lock machine, then insert Election Manager card to save the
-                Ballot Package.
-              </em>
-            </p>
-          )}
+          <p>
+            Save the Ballot Package to USB to configure VxCentralScan or VxScan.
+          </p>
+          <p>
+            <ExportElectionBallotPackageModalButton />
+          </p>
         </Prose>
       </Header>
     </NavigationScreen>

--- a/apps/admin/frontend/src/screens/logic_and_accuracy_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/logic_and_accuracy_screen.test.tsx
@@ -1,8 +1,5 @@
 import React from 'react';
-import {
-  electionGridLayoutNewHampshireHudsonFixtures,
-  electionMinimalExhaustiveSampleDefinition,
-} from '@votingworks/fixtures';
+import { electionMinimalExhaustiveSampleDefinition } from '@votingworks/fixtures';
 import { fakeKiosk, fakePrinterInfo } from '@votingworks/test-utils';
 import { fakeLogger, Logger } from '@votingworks/logging';
 import { screen } from '@testing-library/react';
@@ -74,18 +71,4 @@ test('l&a documents not accessible in official mode', async () => {
   expect(
     screen.queryByText('Print Full Test Deck Tally Report')
   ).not.toBeInTheDocument();
-});
-
-test('l&a documents not accessible in gridLayouts election', async () => {
-  apiMock.expectGetCastVoteRecordFileMode('unlocked');
-
-  renderInAppContext(<LogicAndAccuracyScreen />, {
-    electionDefinition:
-      electionGridLayoutNewHampshireHudsonFixtures.electionDefinition,
-    logger,
-    apiMock,
-  });
-  await screen.findByText(
-    'VxAdmin does not produce ballots or L&A documents for this election.'
-  );
 });

--- a/apps/admin/frontend/src/screens/logic_and_accuracy_screen.tsx
+++ b/apps/admin/frontend/src/screens/logic_and_accuracy_screen.tsx
@@ -1,69 +1,71 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { LinkButton, Prose } from '@votingworks/ui';
 
 import { NavigationScreen } from '../components/navigation_screen';
 import { routerPaths } from '../router_paths';
 import { FullTestDeckTallyReportButton } from '../components/full_test_deck_tally_report_button';
-import { AppContext } from '../contexts/app_context';
-import { canViewAndPrintBallots } from '../utils/can_view_and_print_ballots';
 import { getCastVoteRecordFileMode } from '../api';
+import { Loading } from '../components/loading';
 
 export function LogicAndAccuracyScreen(): JSX.Element {
-  const { electionDefinition } = useContext(AppContext);
   const castVoteRecordFileModeQuery = getCastVoteRecordFileMode.useQuery();
 
-  return (
-    <NavigationScreen title="L&A Testing Documents">
-      <Prose>
-        {electionDefinition &&
-        !canViewAndPrintBallots(electionDefinition.election) ? (
-          <p>
-            VxAdmin does not produce ballots or L&A documents for this election.
-          </p>
-        ) : !castVoteRecordFileModeQuery.isSuccess ? null : castVoteRecordFileModeQuery.data ===
-          'official' ? (
-          <p>
-            L&A testing documents are not available after official election CVRs
-            have been loaded.
-          </p>
-        ) : (
-          <React.Fragment>
-            <p>
-              Print the following reports and ballot packages in preparation for
-              L&A testing.
-            </p>
-            <h2>1. Unofficial Full Election Tally Report</h2>
-            <p>
-              Print the Full Election Tally Report to document that no votes
-              have been tallied before L&A testing begins.
-            </p>
-            <p>
-              <em>
-                Go to the Reports tab and select the “Unofficial Full Election
-                Tally Report” button at the top of the page to print the report.
-              </em>
-            </p>
-            <h2>2. Precinct L&A Packages</h2>
-            <p>
-              Each Precinct L&A Package contains marked test ballots, unmarked
-              test ballots, and a tally report with expected results.
-            </p>
-            <p>
-              <LinkButton to={routerPaths.testDecks}>
-                List Precinct L&A Packages
-              </LinkButton>
-            </p>
-            <h2>3. Test Deck Tally Report for All Precincts</h2>
-            <p>
-              This report has the results that are expected after scanning all
-              the test ballots.
-            </p>
-            <p>
-              <FullTestDeckTallyReportButton />
-            </p>
-          </React.Fragment>
-        )}
-      </Prose>
-    </NavigationScreen>
+  function renderScreen(content?: React.ReactNode) {
+    return (
+      <NavigationScreen title="L&A Testing Documents">
+        <Prose>{content}</Prose>
+      </NavigationScreen>
+    );
+  }
+
+  if (!castVoteRecordFileModeQuery.isSuccess) {
+    return renderScreen(<Loading />);
+  }
+
+  if (castVoteRecordFileModeQuery.data === 'official') {
+    return renderScreen(
+      <p>
+        L&A testing documents are not available after official election CVRs
+        have been loaded.
+      </p>
+    );
+  }
+
+  return renderScreen(
+    <React.Fragment>
+      <p>
+        Print the following reports and ballot packages in preparation for L&A
+        testing.
+      </p>
+      <h2>1. Unofficial Full Election Tally Report</h2>
+      <p>
+        Print the Full Election Tally Report to document that no votes have been
+        tallied before L&A testing begins.
+      </p>
+      <p>
+        <em>
+          Go to the Reports tab and select the “Unofficial Full Election Tally
+          Report” button at the top of the page to print the report.
+        </em>
+      </p>
+      <h2>2. Precinct L&A Packages</h2>
+      <p>
+        Each Precinct L&A Package contains marked test ballots, unmarked test
+        ballots, and a tally report with expected results.
+      </p>
+      <p>
+        <LinkButton to={routerPaths.testDecks}>
+          List Precinct L&A Packages
+        </LinkButton>
+      </p>
+      <h2>3. Test Deck Tally Report for All Precincts</h2>
+      <p>
+        This report has the results that are expected after scanning all the
+        test ballots.
+      </p>
+      <p>
+        <FullTestDeckTallyReportButton />
+      </p>
+    </React.Fragment>
   );
 }


### PR DESCRIPTION
## Overview

In recent threads related to documentation, we've decided to remove the "VxAdmin does not produce ballots for this election" messaging and just not show the relevant UI in those cases:
- Removing the "Ballots" nav button and screen from the System Administrator view, since it just contained instructions to log in as an Election Manager to save ballot packages.
- Removing the "L&A" nav button and screen from the Election Manager view for elections where we don't produce ballots/L&A packages
- Removing the "does not produce ballots" messaging from the "Ballots" screen - looks like remnants of deprecated functionality.

## Demo Video or Screenshot
### Before/After - Sys Admin View:
<img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/6c7071e6-48d1-40e7-9f60-813c73a3f040" /> <img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/09c37a8c-6afd-4d1b-82e2-f02571b447d0" />


### Before/After - Election Manager View:
<img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/9d2fd66a-2458-4ac5-b66e-a6fd2ca632c5" /> <img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/2f3bb7b0-13b6-4743-9d9d-6945e85a8adb" />


## Testing Plan
- Updated existing tests

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
