### PR TITLE
fix(usb): simplify unmount to allow it to run in a systemd service

### DIFF
--- a/libs/usb-drive/src/unmount.sh
+++ b/libs/usb-drive/src/unmount.sh
@@ -13,11 +13,9 @@ fi
 
 MOUNTPOINT=$1
 
-USER=`logname`
-VX_MOUNTPOINT=/media/vx/usb-drive
-DEV_MOUNTPOINT_REGEX=^/media/$USER/[a-Z0-9-]+$
+MOUNTPOINT_REGEX=^/media/[a-Z0-9-]+/[a-Z0-9-]+$
 
-if ! [[ $MOUNTPOINT = $VX_MOUNTPOINT || $MOUNTPOINT =~ $DEV_MOUNTPOINT_REGEX ]]; then
+if ! [[ $MOUNTPOINT =~ $MOUNTPOINT_REGEX ]]; then
     echo "unmount.sh: mount point \"${MOUNTPOINT}\" is not a valid mounted USB drive"
     exit 1
 fi


### PR DESCRIPTION
technically, I made the allowable mountpoint regex more permissive, but I don't see this increasing any risk, and it is simpler with fewer dependencies like `logname` which don't work in a systemd service.