### PR TITLE
refactor(admin): Migrate Ballot Count Displays

### DIFF
--- a/apps/admin/backend/src/app.cvr_files.test.ts
+++ b/apps/admin/backend/src/app.cvr_files.test.ts
@@ -215,6 +215,15 @@ test('happy path - mock election flow', async () => {
       .map((partialRecord) => expect.objectContaining(partialRecord))
   );
 
+  // check scanner batches
+  expect(await apiClient.getScannerBatches()).toEqual([
+    expect.objectContaining({
+      batchId: '9822c71014',
+      label: '9822c71014',
+      scannerId: 'VX-00-000',
+    }),
+  ]);
+
   // remove CVR files, expect clear state
   await apiClient.clearCastVoteRecordFiles();
   expect(await apiClient.getCastVoteRecordFiles()).toHaveLength(0);

--- a/apps/admin/backend/src/app.results.test.ts
+++ b/apps/admin/backend/src/app.results.test.ts
@@ -1,0 +1,97 @@
+import { electionMinimalExhaustiveSampleFixtures } from '@votingworks/fixtures';
+import {
+  BooleanEnvironmentVariableName,
+  buildManualResultsFixture,
+  getFeatureFlagMock,
+} from '@votingworks/utils';
+import {
+  buildTestEnvironment,
+  configureMachine,
+  mockElectionManagerAuth,
+} from '../test/app';
+
+jest.setTimeout(60_000);
+
+// mock SKIP_CVR_ELECTION_HASH_CHECK to allow us to use old cvr fixtures
+const featureFlagMock = getFeatureFlagMock();
+jest.mock('@votingworks/utils', () => {
+  return {
+    ...jest.requireActual('@votingworks/utils'),
+    isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+      featureFlagMock.isEnabled(flag),
+  };
+});
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+  featureFlagMock.enableFeatureFlag(
+    BooleanEnvironmentVariableName.SKIP_CVR_ELECTION_HASH_CHECK
+  );
+});
+
+afterEach(() => {
+  featureFlagMock.resetFeatureFlags();
+});
+
+test('card counts', async () => {
+  const { electionDefinition, castVoteRecordReport } =
+    electionMinimalExhaustiveSampleFixtures;
+  const { election } = electionDefinition;
+
+  const { apiClient, auth } = buildTestEnvironment();
+  await configureMachine(apiClient, auth, electionDefinition);
+  mockElectionManagerAuth(auth, electionDefinition.electionHash);
+
+  const loadFileResult = await apiClient.addCastVoteRecordFile({
+    path: castVoteRecordReport.asDirectoryPath(),
+  });
+  loadFileResult.assertOk('load file failed');
+
+  await apiClient.setManualResults({
+    precinctId: 'precinct-1',
+    ballotStyleId: '1M',
+    votingMethod: 'precinct',
+    manualResults: buildManualResultsFixture({
+      election,
+      ballotCount: 10,
+      contestResultsSummaries: {},
+    }),
+  });
+
+  expect(
+    await apiClient.getCardCounts({
+      groupBy: { groupByPrecinct: true, groupByBallotStyle: true },
+    })
+  ).toMatchObject(
+    expect.arrayContaining([
+      {
+        ballotStyleId: '1M',
+        precinctId: 'precinct-1',
+        bmd: 28,
+        hmpb: [],
+        manual: 10,
+      },
+      {
+        ballotStyleId: '2F',
+        precinctId: 'precinct-1',
+        bmd: 28,
+        hmpb: [],
+        manual: 0,
+      },
+      {
+        ballotStyleId: '1M',
+        precinctId: 'precinct-2',
+        bmd: 28,
+        hmpb: [],
+        manual: 0,
+      },
+      {
+        ballotStyleId: '2F',
+        precinctId: 'precinct-2',
+        bmd: 28,
+        hmpb: [],
+        manual: 0,
+      },
+    ])
+  );
+});

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -80,6 +80,7 @@ import { generateBatchResultsFile } from './exports/batch_results';
 import { tabulateElectionResults } from './tabulation/full_results';
 import { getSemsExportableTallies } from './exports/sems_tallies';
 import { generateResultsCsv } from './exports/csv_results';
+import { tabulateFullCardCounts } from './tabulation/card_counts';
 
 function getCurrentElectionDefinition(
   workspace: Workspace
@@ -684,6 +685,19 @@ function buildApi({
         .map((record) => ({ ...record }));
       // TODO: grout is having trouble serializing records from the store
       // without destructuring them. need to investigate
+    },
+
+    getCardCounts(input: {
+      groupBy: Tabulation.GroupBy;
+    }): Array<Tabulation.GroupOf<Tabulation.CardCounts>> {
+      const electionId = loadCurrentElectionIdOrThrow(workspace);
+      return Object.values(
+        tabulateFullCardCounts({
+          electionId,
+          store,
+          groupBy: input.groupBy,
+        })
+      );
     },
 
     async exportBatchResults(input: {

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -50,6 +50,7 @@ import {
   ManualResultsIdentifier,
   ManualResultsMetadataRecord,
   ManualResultsRecord,
+  ScannerBatch,
   SemsExportableTallies,
   ServerFullElectionManualTally,
   SetSystemSettingsResult,
@@ -698,6 +699,10 @@ function buildApi({
           groupBy: input.groupBy,
         })
       );
+    },
+
+    getScannerBatches(): ScannerBatch[] {
+      return store.getScannerBatches(loadCurrentElectionIdOrThrow(workspace));
     },
 
     async exportBatchResults(input: {

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -702,7 +702,11 @@ function buildApi({
     },
 
     getScannerBatches(): ScannerBatch[] {
-      return store.getScannerBatches(loadCurrentElectionIdOrThrow(workspace));
+      return store
+        .getScannerBatches(loadCurrentElectionIdOrThrow(workspace))
+        .map((record) => ({ ...record }));
+      // TODO: grout is having trouble serializing records from the store
+      // without destructuring them. need to investigate;
     },
 
     async exportBatchResults(input: {

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -991,31 +991,31 @@ export class Store {
     election: Election;
     groupBy?: Tabulation.GroupBy;
   }): Generator<Tabulation.GroupOf<CardTally>> {
-    const cvrSelectParts: string[] = [];
+    const selectParts: string[] = [];
     const groupByParts: string[] = [];
 
     if (groupBy.groupByBallotStyle || groupBy.groupByParty) {
-      cvrSelectParts.push('cvrs.ballot_style_id as ballotStyleId');
+      selectParts.push('cvrs.ballot_style_id as ballotStyleId');
       groupByParts.push('cvrs.ballot_style_id');
     }
 
     if (groupBy.groupByBatch) {
-      cvrSelectParts.push('cvrs.batch_id as batchId');
+      selectParts.push('cvrs.batch_id as batchId');
       groupByParts.push('cvrs.batch_id');
     }
 
     if (groupBy.groupByPrecinct) {
-      cvrSelectParts.push('cvrs.precinct_id as precinctId');
+      selectParts.push('cvrs.precinct_id as precinctId');
       groupByParts.push('cvrs.precinct_id');
     }
 
     if (groupBy.groupByScanner) {
-      cvrSelectParts.push('scanner_batches.scanner_id as scannerId');
+      selectParts.push('scanner_batches.scanner_id as scannerId');
       groupByParts.push('scanner_batches.scanner_id');
     }
 
     if (groupBy.groupByVotingMethod) {
-      cvrSelectParts.push('cvrs.ballot_type as votingMethod');
+      selectParts.push('cvrs.ballot_type as votingMethod');
       groupByParts.push('cvrs.ballot_type');
     }
 
@@ -1024,7 +1024,7 @@ export class Store {
     for (const row of this.client.each(
       `
           select
-            ${cvrSelectParts.map((line) => `${line},`).join('\n')}
+            ${selectParts.map((line) => `${line},`).join('\n')}
             cvrs.sheet_number as sheetNumber,
             count(cvrs.id) as tally
           from cvrs
@@ -1353,31 +1353,31 @@ export class Store {
       replacePartyIdFilter(filter, election)
     );
 
-    const cvrSelectParts: string[] = [];
+    const selectParts: string[] = [];
     const groupByParts: string[] = [];
 
     if (groupBy.groupByBallotStyle || groupBy.groupByParty) {
-      cvrSelectParts.push('cvrs.ballot_style_id as ballotStyleId');
+      selectParts.push('cvrs.ballot_style_id as ballotStyleId');
       groupByParts.push('cvrs.ballot_style_id');
     }
 
     if (groupBy.groupByBatch) {
-      cvrSelectParts.push('cvrs.batch_id as batchId');
+      selectParts.push('cvrs.batch_id as batchId');
       groupByParts.push('cvrs.batch_id');
     }
 
     if (groupBy.groupByPrecinct) {
-      cvrSelectParts.push('cvrs.precinct_id as precinctId');
+      selectParts.push('cvrs.precinct_id as precinctId');
       groupByParts.push('cvrs.precinct_id');
     }
 
     if (groupBy.groupByScanner) {
-      cvrSelectParts.push('scanner_batches.scanner_id as scannerId');
+      selectParts.push('scanner_batches.scanner_id as scannerId');
       groupByParts.push('scanner_batches.scanner_id');
     }
 
     if (groupBy.groupByVotingMethod) {
-      cvrSelectParts.push('cvrs.ballot_type as votingMethod');
+      selectParts.push('cvrs.ballot_type as votingMethod');
       groupByParts.push('cvrs.ballot_type');
     }
 
@@ -1388,7 +1388,7 @@ export class Store {
     for (const row of this.client.each(
       `
           select
-            ${cvrSelectParts.map((line) => `${line},`).join('\n')}
+            ${selectParts.map((line) => `${line},`).join('\n')}
             write_ins.contest_id as contestId,
             write_ins.official_candidate_id as officialCandidateId,
             write_ins.write_in_candidate_id as writeInCandidateId,

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -67,6 +67,7 @@ import {
   WriteInAdjudicatedWriteInCandidateTally,
   WriteInPendingTally,
   ManualResultsStoreFilter,
+  CardTally,
 } from './types';
 import { cvrBallotTypeToLegacyBallotType } from './util/cvrs';
 import { replacePartyIdFilter } from './tabulation/utils';
@@ -918,6 +919,12 @@ export class Store {
     return [whereParts, params];
   }
 
+  private convertSheetNumberToCard(
+    sheetNumber: number | null
+  ): Tabulation.Card {
+    return sheetNumber ? { type: 'hmpb', sheetNumber } : { type: 'bmd' };
+  }
+
   /**
    * Returns an iterator of cast vote records for tabulation purposes. Filters
    * the cast vote records by specified filters.
@@ -966,10 +973,94 @@ export class Store {
         batchId: row.batchId,
         scannerId: row.scannerId,
         precinctId: row.precinctId,
-        card: row.sheetNumber
-          ? { type: 'hmpb', sheetNumber: row.sheetNumber }
-          : { type: 'bmd' },
+        card: this.convertSheetNumberToCard(row.sheetNumber),
         votes: JSON.parse(row.votes),
+      };
+    }
+  }
+
+  /**
+   * Gets card tallies grouped by cast vote record attributes.
+   */
+  *getCardTallies({
+    electionId,
+    election,
+    groupBy = {},
+  }: {
+    electionId: Id;
+    election: Election;
+    groupBy?: Tabulation.GroupBy;
+  }): Generator<Tabulation.GroupOf<CardTally>> {
+    const cvrSelectParts: string[] = [];
+    const groupByParts: string[] = [];
+
+    if (groupBy.groupByBallotStyle || groupBy.groupByParty) {
+      cvrSelectParts.push('cvrs.ballot_style_id as ballotStyleId');
+      groupByParts.push('cvrs.ballot_style_id');
+    }
+
+    if (groupBy.groupByBatch) {
+      cvrSelectParts.push('cvrs.batch_id as batchId');
+      groupByParts.push('cvrs.batch_id');
+    }
+
+    if (groupBy.groupByPrecinct) {
+      cvrSelectParts.push('cvrs.precinct_id as precinctId');
+      groupByParts.push('cvrs.precinct_id');
+    }
+
+    if (groupBy.groupByScanner) {
+      cvrSelectParts.push('scanner_batches.scanner_id as scannerId');
+      groupByParts.push('scanner_batches.scanner_id');
+    }
+
+    if (groupBy.groupByVotingMethod) {
+      cvrSelectParts.push('cvrs.ballot_type as votingMethod');
+      groupByParts.push('cvrs.ballot_type');
+    }
+
+    const ballotStylePartyLookup = getBallotStyleIdPartyIdLookup(election);
+
+    for (const row of this.client.each(
+      `
+          select
+            ${cvrSelectParts.map((line) => `${line},`).join('\n')}
+            cvrs.sheet_number as sheetNumber,
+            count(cvrs.id) as tally
+          from cvrs
+          inner join
+            scanner_batches on scanner_batches.id = cvrs.batch_id
+          where cvrs.election_id = ?
+          group by
+            ${groupByParts.map((line) => `${line},`).join('\n')}
+            sheetNumber
+        `,
+      electionId
+    ) as Iterable<
+      Partial<Tabulation.CastVoteRecordAttributes> & {
+        sheetNumber: number | null;
+        tally: number;
+      }
+    >) {
+      const groupSpecifier: Tabulation.GroupSpecifier = {
+        ballotStyleId: groupBy.groupByBallotStyle
+          ? row.ballotStyleId
+          : undefined,
+        partyId: groupBy.groupByParty
+          ? ballotStylePartyLookup[assertDefined(row.ballotStyleId)]
+          : undefined,
+        batchId: groupBy.groupByBatch ? row.batchId : undefined,
+        scannerId: groupBy.groupByScanner ? row.scannerId : undefined,
+        precinctId: groupBy.groupByPrecinct ? row.precinctId : undefined,
+        votingMethod: groupBy.groupByVotingMethod
+          ? row.votingMethod
+          : undefined,
+      };
+
+      yield {
+        ...groupSpecifier,
+        card: this.convertSheetNumberToCard(row.sheetNumber),
+        tally: row.tally,
       };
     }
   }

--- a/apps/admin/backend/src/tabulation/card_counts.test.ts
+++ b/apps/admin/backend/src/tabulation/card_counts.test.ts
@@ -1,0 +1,228 @@
+import { electionMinimalExhaustiveSampleFixtures } from '@votingworks/fixtures';
+import { Tabulation } from '@votingworks/types';
+import { GROUP_KEY_ROOT } from '@votingworks/utils';
+import { Store } from '../store';
+import {
+  MockCastVoteRecordFile,
+  addMockCvrFileToStore,
+} from '../../test/mock_cvr_file';
+import { tabulateScannedCardCounts } from './card_counts';
+
+test('tabulateScannedCardCounts - grouping', () => {
+  const store = Store.memoryStore();
+  const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
+  const { electionData } = electionDefinition;
+  const electionId = store.addElection(electionData);
+  store.setCurrentElectionId(electionId);
+
+  // add some mock cast vote records with one vote each
+  const mockCastVoteRecordFile: MockCastVoteRecordFile = [
+    {
+      ballotStyleId: '1M',
+      batchId: 'batch-1-1',
+      scannerId: 'scanner-1',
+      precinctId: 'precinct-1',
+      votingMethod: 'precinct',
+      votes: { fishing: ['yes'] },
+      card: { type: 'bmd' },
+      multiplier: 5,
+    },
+    {
+      ballotStyleId: '1M',
+      batchId: 'batch-1-1',
+      scannerId: 'scanner-1',
+      precinctId: 'precinct-1',
+      votingMethod: 'absentee',
+      votes: { fishing: ['yes'] },
+      card: { type: 'bmd' },
+      multiplier: 6,
+    },
+    {
+      ballotStyleId: '2F',
+      batchId: 'batch-1-2',
+      scannerId: 'scanner-1',
+      precinctId: 'precinct-1',
+      votingMethod: 'precinct',
+      votes: { fishing: ['yes'] },
+      card: { type: 'bmd' },
+      multiplier: 17,
+    },
+    {
+      ballotStyleId: '2F',
+      batchId: 'batch-2-1',
+      scannerId: 'scanner-2',
+      precinctId: 'precinct-2',
+      votingMethod: 'absentee',
+      votes: { fishing: ['yes'] },
+      card: { type: 'bmd' },
+      multiplier: 9,
+    },
+    {
+      ballotStyleId: '2F',
+      batchId: 'batch-2-2',
+      scannerId: 'scanner-2',
+      precinctId: 'precinct-2',
+      votingMethod: 'precinct',
+      votes: { fishing: ['yes'] },
+      card: { type: 'bmd' },
+      multiplier: 12,
+    },
+    {
+      ballotStyleId: '1M',
+      batchId: 'batch-3-1',
+      scannerId: 'scanner-3',
+      precinctId: 'precinct-2',
+      votingMethod: 'precinct',
+      votes: { fishing: ['yes'] },
+      card: { type: 'bmd' },
+      multiplier: 34,
+    },
+  ];
+  addMockCvrFileToStore({ electionId, mockCastVoteRecordFile, store });
+
+  const testCases: Array<{
+    groupBy?: Tabulation.GroupBy;
+    expected: Array<
+      [
+        groupKey: Tabulation.GroupKey,
+        tally: number,
+        groupSpecifier: Tabulation.GroupSpecifier
+      ]
+    >;
+  }> = [
+    // no filter case
+    {
+      expected: [['root', 83, {}]],
+    },
+    // each group case
+    {
+      groupBy: { groupByBallotStyle: true },
+      expected: [
+        ['root&1M', 45, { ballotStyleId: '1M' }],
+        ['root&2F', 38, { ballotStyleId: '2F' }],
+      ],
+    },
+    {
+      groupBy: { groupByParty: true },
+      expected: [
+        ['root&0', 45, { partyId: '0' }],
+        ['root&1', 38, { partyId: '1' }],
+      ],
+    },
+    {
+      groupBy: { groupByBatch: true },
+      expected: [
+        ['root&batch-1-1', 11, { batchId: 'batch-1-1' }],
+        ['root&batch-1-2', 17, { batchId: 'batch-1-2' }],
+        ['root&batch-2-1', 9, { batchId: 'batch-2-1' }],
+        ['root&batch-2-2', 12, { batchId: 'batch-2-2' }],
+        ['root&batch-3-1', 34, { batchId: 'batch-3-1' }],
+      ],
+    },
+    {
+      groupBy: { groupByScanner: true },
+      expected: [
+        ['root&scanner-1', 28, { scannerId: 'scanner-1' }],
+        ['root&scanner-2', 21, { scannerId: 'scanner-2' }],
+        ['root&scanner-3', 34, { scannerId: 'scanner-3' }],
+      ],
+    },
+    {
+      groupBy: { groupByPrecinct: true },
+      expected: [
+        ['root&precinct-1', 28, { precinctId: 'precinct-1' }],
+        ['root&precinct-2', 55, { precinctId: 'precinct-2' }],
+      ],
+    },
+    {
+      groupBy: { groupByVotingMethod: true },
+      expected: [
+        ['root&precinct', 68, { votingMethod: 'precinct' }],
+        ['root&absentee', 15, { votingMethod: 'absentee' }],
+      ],
+    },
+  ];
+
+  for (const { groupBy, expected } of testCases) {
+    const groupedCardCounts = tabulateScannedCardCounts({
+      electionId,
+      store,
+      groupBy,
+    });
+
+    for (const [groupKey, tally, groupSpecifier] of expected) {
+      expect(groupedCardCounts[groupKey]).toEqual({
+        bmd: tally,
+        hmpb: [],
+        ...groupSpecifier,
+      });
+    }
+
+    expect(Object.values(groupedCardCounts)).toHaveLength(expected.length);
+  }
+});
+
+test('tabulateScannedCardCounts - merging card tallies', () => {
+  const store = Store.memoryStore();
+  const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
+  const { electionData } = electionDefinition;
+  const electionId = store.addElection(electionData);
+  store.setCurrentElectionId(electionId);
+
+  // add some mock cast vote records with one vote each
+  const mockCastVoteRecordFile: MockCastVoteRecordFile = [
+    {
+      ballotStyleId: '1M',
+      batchId: 'batch-1-1',
+      scannerId: 'scanner-1',
+      precinctId: 'precinct-1',
+      votingMethod: 'precinct',
+      votes: { fishing: ['yes'] },
+      card: { type: 'bmd' },
+      multiplier: 5,
+    },
+    {
+      ballotStyleId: '1M',
+      batchId: 'batch-1-1',
+      scannerId: 'scanner-1',
+      precinctId: 'precinct-1',
+      votingMethod: 'precinct',
+      votes: { fishing: ['yes'] },
+      card: { type: 'hmpb', sheetNumber: 2 },
+      multiplier: 7,
+    },
+    {
+      ballotStyleId: '1M',
+      batchId: 'batch-1-1',
+      scannerId: 'scanner-1',
+      precinctId: 'precinct-1',
+      votingMethod: 'precinct',
+      votes: { fishing: ['yes'] },
+      card: { type: 'hmpb', sheetNumber: 1 },
+      multiplier: 6,
+    },
+  ];
+  addMockCvrFileToStore({ electionId, mockCastVoteRecordFile, store });
+
+  expect(
+    tabulateScannedCardCounts({
+      electionId,
+      store,
+    })[GROUP_KEY_ROOT]
+  ).toEqual({
+    bmd: 5,
+    hmpb: [6, 7],
+  });
+
+  expect(
+    tabulateScannedCardCounts({
+      electionId,
+      store,
+      groupBy: { groupByScanner: true },
+    })['root&scanner-1']
+  ).toEqual({
+    scannerId: 'scanner-1',
+    bmd: 5,
+    hmpb: [6, 7],
+  });
+});

--- a/apps/admin/backend/src/tabulation/card_counts.ts
+++ b/apps/admin/backend/src/tabulation/card_counts.ts
@@ -14,7 +14,7 @@ import { tabulateManualBallotCounts } from './manual_results';
 
 /**
  * Adds a card tally to a card counts object. Mutates the card counts object
- * in place, and assumes overwrites previous value for the same card.
+ * in place and overwrites the previous count for the same card.
  */
 function addCardTallyToCardCounts({
   cardCounts,

--- a/apps/admin/backend/src/tabulation/card_counts.ts
+++ b/apps/admin/backend/src/tabulation/card_counts.ts
@@ -1,0 +1,148 @@
+import { Id, Tabulation } from '@votingworks/types';
+import { assertDefined } from '@votingworks/basics';
+import {
+  GROUP_KEY_ROOT,
+  extractGroupSpecifier,
+  getEmptyCardCounts,
+  getGroupKey,
+  isGroupByEmpty,
+} from '@votingworks/utils';
+import { CardTally } from '../types';
+import { Store } from '../store';
+
+import { tabulateManualBallotCounts } from './manual_results';
+
+/**
+ * Adds a card tally to a card counts object. Mutates the card counts object
+ * in place, and assumes overwrites previous value for the same card.
+ */
+function addCardTallyToCardCounts({
+  cardCounts,
+  cardTally,
+}: {
+  cardCounts: Tabulation.CardCounts;
+  cardTally: CardTally;
+}): Tabulation.CardCounts {
+  const { card, tally } = cardTally;
+  if (card.type === 'bmd') {
+    // eslint-disable-next-line no-param-reassign
+    cardCounts.bmd += tally;
+  } else {
+    // eslint-disable-next-line no-param-reassign
+    cardCounts.hmpb[card.sheetNumber - 1] =
+      (cardCounts.hmpb[card.sheetNumber - 1] ?? 0) + tally;
+  }
+
+  return cardCounts;
+}
+
+/**
+ * Tabulates card tallies aggregated by the store into card counts.
+ */
+export function tabulateScannedCardCounts({
+  electionId,
+  store,
+  groupBy,
+}: {
+  electionId: Id;
+  store: Store;
+  groupBy?: Tabulation.GroupBy;
+}): Tabulation.GroupedCardCounts {
+  const {
+    electionDefinition: { election },
+  } = assertDefined(store.getElection(electionId));
+
+  const cardTallies = store.getCardTallies({
+    electionId,
+    election,
+    groupBy,
+  });
+
+  const groupedCardCounts: Tabulation.GroupedCardCounts = {};
+
+  // optimized special case, when the results do not need to be grouped
+  if (!groupBy || isGroupByEmpty(groupBy)) {
+    const cardCounts = getEmptyCardCounts();
+    for (const cardTally of cardTallies) {
+      addCardTallyToCardCounts({
+        cardCounts,
+        cardTally,
+      });
+    }
+    groupedCardCounts[GROUP_KEY_ROOT] = cardCounts;
+    return groupedCardCounts;
+  }
+
+  // general case, grouping results by specified group by clause
+  for (const cardTally of cardTallies) {
+    const groupKey = getGroupKey(cardTally, groupBy);
+
+    const existingCardCounts = groupedCardCounts[groupKey];
+    const cardCounts = existingCardCounts ?? {
+      ...getEmptyCardCounts(),
+      ...extractGroupSpecifier(cardTally),
+    };
+
+    groupedCardCounts[groupKey] = addCardTallyToCardCounts({
+      cardCounts,
+      cardTally,
+    });
+  }
+
+  return groupedCardCounts;
+}
+
+/**
+ * Calculate card counts, optionally grouped, including both scanned cards
+ * and manual ballot counts.
+ */
+export function tabulateFullCardCounts({
+  electionId,
+  store,
+  groupBy,
+}: {
+  electionId: Id;
+  store: Store;
+  groupBy?: Tabulation.GroupBy;
+}): Tabulation.GroupedCardCounts {
+  const {
+    electionDefinition: { election },
+  } = assertDefined(store.getElection(electionId));
+
+  const groupedScannedCardCounts = tabulateScannedCardCounts({
+    electionId,
+    store,
+    groupBy,
+  });
+  const tabulateManualBallotCountsResult = tabulateManualBallotCounts({
+    election,
+    manualResultsMetadataRecords: store.getManualResultsMetadata({
+      electionId,
+    }),
+    groupBy,
+  });
+
+  if (tabulateManualBallotCountsResult.isErr()) {
+    return groupedScannedCardCounts;
+  }
+
+  const groupedManualBallotCounts = tabulateManualBallotCountsResult.ok();
+
+  const groupedFullCardCounts: Tabulation.GroupedCardCounts = {};
+
+  const allKeys = [
+    ...new Set([
+      ...Object.keys(groupedScannedCardCounts),
+      ...Object.keys(groupedManualBallotCounts),
+    ]),
+  ];
+
+  for (const key of allKeys) {
+    groupedFullCardCounts[key] = {
+      ...(groupedScannedCardCounts[key] ?? getEmptyCardCounts()),
+      manual: groupedManualBallotCounts[key]?.ballotCount ?? 0,
+    };
+  }
+
+  return groupedFullCardCounts;
+}

--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -507,3 +507,12 @@ export type SemsExportableTally = Dictionary<SemsExportableContestTally>;
 export interface SemsExportableTallies {
   readonly talliesByPrecinct: Dictionary<SemsExportableTally>;
 }
+
+/**
+ * A count of a specific kind of card. For representation of aggregate values
+ * pulled from the store.
+ */
+export interface CardTally {
+  card: Tabulation.Card;
+  tally: number;
+}

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -362,6 +362,16 @@ export const getCardCounts = {
   },
 } as const;
 
+export const getScannerBatches = {
+  queryKey(): QueryKey {
+    return ['getScannerBatches'];
+  },
+  useQuery() {
+    const apiClient = useApiClient();
+    return useQuery(this.queryKey(), () => apiClient.getScannerBatches());
+  },
+} as const;
+
 // Grouped Invalidations
 
 function invalidateCastVoteRecordQueries(queryClient: QueryClient) {
@@ -371,6 +381,7 @@ function invalidateCastVoteRecordQueries(queryClient: QueryClient) {
     queryClient.invalidateQueries(getCastVoteRecords.queryKey()),
     queryClient.invalidateQueries(getSemsExportableTallies.queryKey()),
     queryClient.invalidateQueries(getCardCounts.queryKey()),
+    queryClient.invalidateQueries(getScannerBatches.queryKey()),
   ]);
 }
 

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -351,6 +351,17 @@ export const getSemsExportableTallies = {
   },
 } as const;
 
+type GetCardCountsInput = QueryInput<'getCardCounts'>;
+export const getCardCounts = {
+  queryKey(input?: GetCardCountsInput): QueryKey {
+    return ['getCardCounts', input];
+  },
+  useQuery(input: GetCardCountsInput = { groupBy: {} }) {
+    const apiClient = useApiClient();
+    return useQuery(this.queryKey(), () => apiClient.getCardCounts(input));
+  },
+} as const;
+
 // Grouped Invalidations
 
 function invalidateCastVoteRecordQueries(queryClient: QueryClient) {
@@ -359,6 +370,7 @@ function invalidateCastVoteRecordQueries(queryClient: QueryClient) {
     queryClient.invalidateQueries(getCastVoteRecordFiles.queryKey()),
     queryClient.invalidateQueries(getCastVoteRecords.queryKey()),
     queryClient.invalidateQueries(getSemsExportableTallies.queryKey()),
+    queryClient.invalidateQueries(getCardCounts.queryKey()),
   ]);
 }
 
@@ -376,6 +388,7 @@ function invalidateManualResultsQueries(queryClient: QueryClient) {
     queryClient.invalidateQueries(getFullElectionManualTally.queryKey()),
     queryClient.invalidateQueries(getManualResultsMetadata.queryKey()),
     queryClient.invalidateQueries(getSemsExportableTallies.queryKey()),
+    queryClient.invalidateQueries(getCardCounts.queryKey()),
   ]);
 }
 

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -358,7 +358,7 @@ export const getCardCounts = {
   },
   useQuery(input: GetCardCountsInput = { groupBy: {} }) {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () => apiClient.getCardCounts(input));
+    return useQuery(this.queryKey(input), () => apiClient.getCardCounts(input));
   },
 } as const;
 

--- a/apps/admin/frontend/src/app_write_in_flows.test.tsx
+++ b/apps/admin/frontend/src/app_write_in_flows.test.tsx
@@ -16,6 +16,7 @@ import { buildApp } from '../test/helpers/build_app';
 import { fileDataToCastVoteRecords } from '../test/util/cast_vote_records';
 import { VxFiles } from './lib/converters';
 import { getMockWriteInCandidate } from '../test/api_mock_data';
+import { expectReportsScreenCardCountQueries } from '../test/helpers/api_expect_helpers';
 
 const nonOfficialAdjudicationSummaryMammal: WriteInAdjudicatedTally = {
   status: 'adjudicated',
@@ -75,6 +76,12 @@ test('manually added write-in results appears in reports', async () => {
   apiMock.expectGetWriteInTalliesAdjudicated([
     nonOfficialAdjudicationSummaryMammal,
   ]);
+  expectReportsScreenCardCountQueries({
+    apiMock,
+    isPrimary: true,
+  });
+  apiMock.expectGetScannerBatches([]);
+  apiMock.expectGetManualResultsMetadata([]);
 
   // mock manual data
   const precinct1ManualTally = buildSpecificManualTally(election, 8, {

--- a/apps/admin/frontend/src/components/ballot_counts_table.test.tsx
+++ b/apps/admin/frontend/src/components/ballot_counts_table.test.tsx
@@ -4,24 +4,17 @@ import {
   electionWithMsEitherNeither,
   multiPartyPrimaryElectionDefinition,
 } from '@votingworks/fixtures';
-import {
-  Dictionary,
-  BatchTally,
-  ManualTally,
-  Tally,
-  TallyCategory,
-  VotingMethod,
-  FullElectionTally,
-  FullElectionManualTally,
-} from '@votingworks/types';
+import { TallyCategory, Tabulation } from '@votingworks/types';
 
 import { assert } from '@votingworks/basics';
-import { getMockManualTally } from '@votingworks/utils';
-import { getByText as domGetByText } from '../../test/react_testing_library';
+import { ScannerBatch } from '@votingworks/admin-backend';
+import {
+  getByText as domGetByText,
+  screen,
+} from '../../test/react_testing_library';
 import { renderInAppContext } from '../../test/render_in_app_context';
 
 import { BallotCountsTable } from './ballot_counts_table';
-import { fakeTally } from '../../test/helpers/fake_tally';
 import { ApiMock, createApiMock } from '../../test/helpers/api_mock';
 
 let apiMock: ApiMock;
@@ -34,61 +27,54 @@ afterEach(() => {
   apiMock.assertComplete();
 });
 
+function mockCardCounts(bmdCount: number): Tabulation.CardCounts {
+  return {
+    bmd: bmdCount,
+    hmpb: [],
+  };
+}
+
+/**
+ * To match backend input exactly, per `MockFunction` requirements, mock out
+ * false values instead of undefined.
+ */
+function mockGroupBy(groupBy: Tabulation.GroupBy): Tabulation.GroupBy {
+  return {
+    groupByBatch: false,
+    groupByParty: false,
+    groupByPrecinct: false,
+    groupByScanner: false,
+    groupByVotingMethod: false,
+    ...groupBy,
+  };
+}
+
 describe('Ballot Counts by Precinct', () => {
-  const resultsByPrecinct: Dictionary<Tally> = {
-    // French Camp
-    '6526': fakeTally({
-      numberOfBallotsCounted: 25,
-    }),
-    // Kenego
-    '6529': fakeTally({
-      numberOfBallotsCounted: 52,
-    }),
-    // District 5
-    '6522': fakeTally({
-      numberOfBallotsCounted: 0,
-    }),
-  };
-  const resultsByCategory = new Map();
-  resultsByCategory.set(TallyCategory.Precinct, resultsByPrecinct);
+  const cardCountsByPrecinct: Array<Tabulation.GroupOf<Tabulation.CardCounts>> =
+    [
+      {
+        precinctId: '6526',
+        ...mockCardCounts(38),
+      },
+      {
+        precinctId: '6529',
+        ...mockCardCounts(52),
+      },
+      {
+        precinctId: '6528',
+        ...mockCardCounts(22),
+      },
+    ];
 
-  const manualResultsByPrecinct: Dictionary<ManualTally> = {
-    // French Camp
-    '6526': getMockManualTally({
-      numberOfBallotsCounted: 13,
-    }),
-    // East Weir
-    '6525': getMockManualTally({
-      numberOfBallotsCounted: 0,
-    }),
-    // Hebron
-    '6528': getMockManualTally({
-      numberOfBallotsCounted: 22,
-    }),
-  };
-  const manualResultsByCategory = new Map();
-  manualResultsByCategory.set(TallyCategory.Precinct, manualResultsByPrecinct);
-
-  const fullElectionTally: FullElectionTally = {
-    overallTally: fakeTally({
-      numberOfBallotsCounted: 77,
-    }),
-    resultsByCategory,
-  };
-  const fullElectionManualTally: FullElectionManualTally = {
-    overallTally: getMockManualTally({
-      numberOfBallotsCounted: 54,
-    }),
-    resultsByCategory: manualResultsByCategory,
-    votingMethod: VotingMethod.Precinct,
-    timestampCreated: new Date(),
-  };
-
-  it('renders as expected when there is no tally data', () => {
+  it('renders as expected when there is no tally data', async () => {
+    apiMock.expectGetCardCounts(mockGroupBy({ groupByPrecinct: true }), []);
+    apiMock.expectGetScannerBatches([]);
+    apiMock.expectGetManualResultsMetadata([]);
     const { getByText, getAllByTestId } = renderInAppContext(
       <BallotCountsTable breakdownCategory={TallyCategory.Precinct} />,
       { apiMock }
     );
+    await screen.findByText('Precinct');
     for (const precinct of electionWithMsEitherNeither.precincts) {
       getByText(precinct.name);
       const tableRow = getByText(precinct.name).closest('tr');
@@ -112,18 +98,25 @@ describe('Ballot Counts by Precinct', () => {
     );
   });
 
-  it('renders as expected when there is tally data', () => {
+  it('renders as expected when there is tally data', async () => {
+    apiMock.expectGetCardCounts(
+      mockGroupBy({ groupByPrecinct: true }),
+      cardCountsByPrecinct
+    );
+    apiMock.expectGetScannerBatches([]);
+    apiMock.expectGetManualResultsMetadata([]);
     const { getByText, getAllByTestId } = renderInAppContext(
       <BallotCountsTable breakdownCategory={TallyCategory.Precinct} />,
       {
-        fullElectionTally,
         apiMock,
       }
     );
+    await screen.findByText('Precinct');
     for (const precinct of electionWithMsEitherNeither.precincts) {
       // Expect that 0 ballots are counted when the precinct is missing in the dictionary or the tally says there are 0 ballots
       const expectedNumberOfBallots =
-        resultsByPrecinct[precinct.id]?.numberOfBallotsCounted ?? 0;
+        cardCountsByPrecinct.find((cc) => cc.precinctId === precinct.id)?.bmd ??
+        0;
       getByText(precinct.name);
       const tableRow = getByText(precinct.name).closest('tr');
       expect(tableRow).toBeDefined();
@@ -137,45 +130,7 @@ describe('Ballot Counts by Precinct', () => {
     getByText('Total Ballot Count');
     const tableRow = getByText('Total Ballot Count').closest('tr');
     expect(tableRow).toBeDefined();
-    expect(domGetByText(tableRow!, 77)).toBeInTheDocument();
-    expect(
-      domGetByText(tableRow!, 'Unofficial Tally Reports for All Precincts')
-    ).toBeInTheDocument();
-
-    // There should be 2 more rows then the number of precincts (header row and totals row)
-    expect(getAllByTestId('table-row').length).toEqual(
-      electionWithMsEitherNeither.precincts.length + 2
-    );
-  });
-
-  it('renders as expected when there is tally data and manual data', () => {
-    const { getByText, getAllByTestId } = renderInAppContext(
-      <BallotCountsTable breakdownCategory={TallyCategory.Precinct} />,
-      {
-        fullElectionTally,
-        fullElectionManualTally,
-        apiMock,
-      }
-    );
-    for (const precinct of electionWithMsEitherNeither.precincts) {
-      // Expect that 0 ballots are counted when the precinct is missing in the dictionary or the tally says there are 0 ballots
-      const expectedNumberOfBallots =
-        (resultsByPrecinct[precinct.id]?.numberOfBallotsCounted ?? 0) +
-        (manualResultsByPrecinct[precinct.id]?.numberOfBallotsCounted ?? 0);
-      getByText(precinct.name);
-      const tableRow = getByText(precinct.name).closest('tr');
-      expect(tableRow).toBeDefined();
-      expect(
-        domGetByText(tableRow!, expectedNumberOfBallots)
-      ).toBeInTheDocument();
-      expect(
-        domGetByText(tableRow!, `Unofficial ${precinct.name} Tally Report`)
-      ).toBeInTheDocument();
-    }
-    getByText('Total Ballot Count');
-    const tableRow = getByText('Total Ballot Count').closest('tr');
-    expect(tableRow).toBeDefined();
-    expect(domGetByText(tableRow!, 131)).toBeInTheDocument();
+    expect(domGetByText(tableRow!, 112)).toBeInTheDocument();
     expect(
       domGetByText(tableRow!, 'Unofficial Tally Reports for All Precincts')
     ).toBeInTheDocument();
@@ -188,42 +143,29 @@ describe('Ballot Counts by Precinct', () => {
 });
 
 describe('Ballot Counts by Scanner', () => {
-  const resultsByScanner: Dictionary<Tally> = {
-    'scanner-1': fakeTally({
-      numberOfBallotsCounted: 25,
-    }),
-    'scanner-2': fakeTally({
-      numberOfBallotsCounted: 52,
-    }),
-    'scanner-3': fakeTally({
-      numberOfBallotsCounted: 0,
-    }),
-  };
-  const resultsByCategory = new Map();
-  resultsByCategory.set(TallyCategory.Scanner, resultsByScanner);
+  const cardCountsByScanner: Array<Tabulation.GroupOf<Tabulation.CardCounts>> =
+    [
+      {
+        scannerId: 'scanner-1',
+        ...mockCardCounts(25),
+      },
+      {
+        scannerId: 'scanner-2',
+        ...mockCardCounts(52),
+      },
+    ];
+  const scannerIds = ['scanner-1', 'scanner-2'];
 
-  const fullElectionTally: FullElectionTally = {
-    overallTally: fakeTally({
-      numberOfBallotsCounted: 77,
-    }),
-    resultsByCategory,
-  };
-  const fullElectionManualTally: FullElectionManualTally = {
-    overallTally: getMockManualTally({
-      numberOfBallotsCounted: 54,
-    }),
-    votingMethod: VotingMethod.Precinct,
-    resultsByCategory: new Map(),
-    timestampCreated: new Date(),
-  };
-
-  it('renders as expected when there is no tally data', () => {
+  it('renders as expected when there is no tally data', async () => {
+    apiMock.expectGetCardCounts(mockGroupBy({ groupByScanner: true }), []);
+    apiMock.expectGetScannerBatches([]);
+    apiMock.expectGetManualResultsMetadata([]);
     const { getByText, getAllByTestId } = renderInAppContext(
       <BallotCountsTable breakdownCategory={TallyCategory.Scanner} />,
       { apiMock }
     );
 
-    getByText('Total Ballot Count');
+    await screen.findByText('Total Ballot Count');
     const tableRow = getByText('Total Ballot Count').closest('tr');
     expect(tableRow).toBeDefined();
     expect(domGetByText(tableRow!, 0)).toBeInTheDocument();
@@ -232,21 +174,24 @@ describe('Ballot Counts by Scanner', () => {
     expect(getAllByTestId('table-row').length).toEqual(2);
   });
 
-  it('renders as expected when there is tally data', () => {
+  it('renders as expected when there is tally data', async () => {
+    apiMock.expectGetCardCounts(
+      mockGroupBy({ groupByScanner: true }),
+      cardCountsByScanner
+    );
+    apiMock.expectGetScannerBatches([]);
+    apiMock.expectGetManualResultsMetadata([]);
     const { getByText, getAllByTestId } = renderInAppContext(
       <BallotCountsTable breakdownCategory={TallyCategory.Scanner} />,
       {
-        fullElectionTally,
         apiMock,
       }
     );
 
-    const scannerIds = ['scanner-1', 'scanner-2', 'scanner-3'];
-
+    await screen.findByText('Scanner ID');
     for (const scannerId of scannerIds) {
-      // Expect that 0 ballots are counted when the precinct is missing in the dictionary or the tally says there are 0 ballots
       const expectedNumberOfBallots =
-        resultsByScanner[scannerId]?.numberOfBallotsCounted ?? 0;
+        cardCountsByScanner.find((cc) => cc.scannerId === scannerId)?.bmd ?? 0;
       getByText(scannerId);
       const tableRow = getByText(scannerId).closest('tr');
       expect(tableRow).toBeDefined();
@@ -270,37 +215,29 @@ describe('Ballot Counts by Scanner', () => {
     expect(getAllByTestId('table-row').length).toEqual(scannerIds.length + 2);
   });
 
-  it('renders as expected when there is tally data and manual data', () => {
+  it('renders as expected when there is tally data and manual data', async () => {
+    apiMock.expectGetCardCounts(
+      mockGroupBy({ groupByScanner: true }),
+      cardCountsByScanner
+    );
+    apiMock.expectGetScannerBatches([]);
+    apiMock.expectGetManualResultsMetadata([
+      {
+        precinctId: 'any',
+        ballotStyleId: 'any',
+        votingMethod: 'precinct',
+        ballotCount: 54,
+        createdAt: 'any',
+      },
+    ]);
     const { getByText, getAllByTestId } = renderInAppContext(
       <BallotCountsTable breakdownCategory={TallyCategory.Scanner} />,
       {
-        fullElectionTally,
-        fullElectionManualTally,
         apiMock,
       }
     );
 
-    const scannerIds = ['scanner-1', 'scanner-2', 'scanner-3'];
-
-    for (const scannerId of scannerIds) {
-      // Expect that 0 ballots are counted when the precinct is missing in the dictionary or the tally says there are 0 ballots
-      const expectedNumberOfBallots =
-        resultsByScanner[scannerId]?.numberOfBallotsCounted ?? 0;
-      getByText(scannerId);
-      const tableRow = getByText(scannerId).closest('tr');
-      expect(tableRow).toBeDefined();
-      expect(
-        domGetByText(tableRow!, expectedNumberOfBallots)
-      ).toBeInTheDocument();
-      if (expectedNumberOfBallots > 0) {
-        expect(
-          domGetByText(
-            tableRow!,
-            `Unofficial Scanner ${scannerId} Tally Report`
-          )
-        ).toBeInTheDocument();
-      }
-    }
+    await screen.findByText('Scanner ID');
 
     getByText('Manually Entered Results');
     let tableRow = getByText('Manually Entered Results').closest('tr');
@@ -318,63 +255,27 @@ describe('Ballot Counts by Scanner', () => {
 
 // Test party ballot counts
 describe('Ballots Counts by Party', () => {
-  const resultsByParty: Dictionary<Tally> = {
-    // Liberty
-    '0': fakeTally({
-      numberOfBallotsCounted: 25,
-    }),
-    // Federalist
-    '4': fakeTally({
-      numberOfBallotsCounted: 52,
-    }),
-  };
-  const resultsByCategory = new Map();
-  resultsByCategory.set(TallyCategory.Party, resultsByParty);
+  const cardCountsByParty: Array<Tabulation.GroupOf<Tabulation.CardCounts>> = [
+    {
+      partyId: '0',
+      ...mockCardCounts(25),
+    },
+    {
+      partyId: '4',
+      ...mockCardCounts(52),
+    },
+  ];
 
-  const manualResultsByParty: Dictionary<ManualTally> = {
-    // Liberty
-    '0': getMockManualTally({
-      numberOfBallotsCounted: 13,
-    }),
-    // Constitution
-    '3': getMockManualTally({
-      numberOfBallotsCounted: 73,
-    }),
-  };
-  const manualResultsByCategory = new Map();
-  manualResultsByCategory.set(TallyCategory.Party, manualResultsByParty);
+  const expectedParties = [
+    { partyName: 'Constitution Party', partyId: '3' },
+    { partyName: 'Federalist Party', partyId: '4' },
+    { partyName: 'Liberty Party', partyId: '0' },
+  ];
 
-  const fullElectionTally: FullElectionTally = {
-    overallTally: fakeTally({
-      numberOfBallotsCounted: 77,
-    }),
-    resultsByCategory,
-  };
-
-  const fullElectionManualTally: FullElectionManualTally = {
-    overallTally: getMockManualTally({
-      numberOfBallotsCounted: 54,
-    }),
-    resultsByCategory: manualResultsByCategory,
-    votingMethod: VotingMethod.Precinct,
-    timestampCreated: new Date(),
-  };
-
-  it('does not render when the election has not ballot styles with parties', () => {
-    // The default election is not a primary
-    const { container } = renderInAppContext(
-      <BallotCountsTable breakdownCategory={TallyCategory.Party} />,
-      { apiMock }
-    );
-    expect(container.firstChild).toBeNull();
-  });
-
-  it('renders as expected when there is no data', () => {
-    const expectedParties = [
-      'Constitution Party',
-      'Federalist Party',
-      'Liberty Party',
-    ];
+  it('renders as expected when there is no data', async () => {
+    apiMock.expectGetCardCounts(mockGroupBy({ groupByParty: true }), []);
+    apiMock.expectGetScannerBatches([]);
+    apiMock.expectGetManualResultsMetadata([]);
     const { getByText, getAllByTestId } = renderInAppContext(
       <BallotCountsTable breakdownCategory={TallyCategory.Party} />,
       {
@@ -386,7 +287,9 @@ describe('Ballots Counts by Party', () => {
       }
     );
 
-    for (const partyName of expectedParties) {
+    await screen.findByText('Party');
+
+    for (const { partyName } of expectedParties) {
       getByText(partyName);
       const tableRow = getByText(partyName).closest('tr');
       expect(tableRow).toBeDefined();
@@ -406,12 +309,13 @@ describe('Ballots Counts by Party', () => {
     );
   });
 
-  it('renders as expected when there is tally data', () => {
-    const expectedParties = [
-      { partyName: 'Constitution Party', partyId: '3' },
-      { partyName: 'Federalist Party', partyId: '4' },
-      { partyName: 'Liberty Party', partyId: '0' },
-    ];
+  it('renders as expected when there is tally data', async () => {
+    apiMock.expectGetCardCounts(
+      mockGroupBy({ groupByParty: true }),
+      cardCountsByParty
+    );
+    apiMock.expectGetScannerBatches([]);
+    apiMock.expectGetManualResultsMetadata([]);
     const { getByText, getAllByTestId } = renderInAppContext(
       <BallotCountsTable breakdownCategory={TallyCategory.Party} />,
       {
@@ -419,14 +323,15 @@ describe('Ballots Counts by Party', () => {
           ...multiPartyPrimaryElectionDefinition,
           electionData: '',
         },
-        fullElectionTally,
         apiMock,
       }
     );
 
+    await screen.findByText('Party');
+
     for (const { partyName, partyId } of expectedParties) {
       const expectedNumberOfBallots =
-        resultsByParty[partyId]?.numberOfBallotsCounted ?? 0;
+        cardCountsByParty.find((cc) => cc.partyId === partyId)?.bmd ?? 0;
       getByText(partyName);
       const tableRow = getByText(partyName).closest('tr');
       expect(tableRow).toBeDefined();
@@ -442,50 +347,6 @@ describe('Ballots Counts by Party', () => {
     const tableRow = getByText('Total Ballot Count').closest('tr');
     expect(tableRow).toBeDefined();
     expect(domGetByText(tableRow!, 77)).toBeInTheDocument();
-
-    expect(getAllByTestId('table-row').length).toEqual(
-      expectedParties.length + 2
-    );
-  });
-
-  it('renders as expected where there is tally data and manual data', () => {
-    const expectedParties = [
-      { partyName: 'Constitution Party', partyId: '3' },
-      { partyName: 'Federalist Party', partyId: '4' },
-      { partyName: 'Liberty Party', partyId: '0' },
-    ];
-    const { getByText, getAllByTestId } = renderInAppContext(
-      <BallotCountsTable breakdownCategory={TallyCategory.Party} />,
-      {
-        electionDefinition: {
-          ...multiPartyPrimaryElectionDefinition,
-          electionData: '',
-        },
-        fullElectionTally,
-        fullElectionManualTally,
-        apiMock,
-      }
-    );
-
-    for (const { partyName, partyId } of expectedParties) {
-      const expectedNumberOfBallots =
-        (resultsByParty[partyId]?.numberOfBallotsCounted ?? 0) +
-        (manualResultsByParty[partyId]?.numberOfBallotsCounted ?? 0);
-      getByText(partyName);
-      const tableRow = getByText(partyName).closest('tr');
-      expect(tableRow).toBeDefined();
-      expect(
-        domGetByText(tableRow!, expectedNumberOfBallots)
-      ).toBeInTheDocument();
-      expect(
-        domGetByText(tableRow!, `Unofficial ${partyName} Tally Report`)
-      ).toBeInTheDocument();
-    }
-
-    getByText('Total Ballot Count');
-    const tableRow = getByText('Total Ballot Count').closest('tr');
-    expect(tableRow).toBeDefined();
-    expect(domGetByText(tableRow!, 131)).toBeInTheDocument();
 
     expect(getAllByTestId('table-row').length).toEqual(
       expectedParties.length + 2
@@ -494,47 +355,37 @@ describe('Ballots Counts by Party', () => {
 });
 
 describe('Ballots Counts by VotingMethod', () => {
-  const resultsByVotingMethod: Dictionary<Tally> = {
-    [VotingMethod.Absentee]: fakeTally({
-      numberOfBallotsCounted: 25,
-    }),
-    [VotingMethod.Precinct]: fakeTally({
-      numberOfBallotsCounted: 42,
-    }),
-    [VotingMethod.Unknown]: fakeTally({
-      numberOfBallotsCounted: 10,
-    }),
-  };
-  const resultsByCategory = new Map();
-  resultsByCategory.set(TallyCategory.VotingMethod, resultsByVotingMethod);
+  const cardCountsByVotingMethod: Array<
+    Tabulation.GroupOf<Tabulation.CardCounts>
+  > = [
+    {
+      votingMethod: 'absentee',
+      ...mockCardCounts(25),
+    },
+    {
+      votingMethod: 'precinct',
+      ...mockCardCounts(42),
+    },
+  ];
+  const expectedLabels = [
+    {
+      method: 'absentee',
+      label: 'Absentee',
+    },
+    { method: 'precinct', label: 'Precinct' },
+  ];
 
-  const fullElectionTally: FullElectionTally = {
-    overallTally: fakeTally({
-      numberOfBallotsCounted: 77,
-    }),
-    resultsByCategory,
-  };
-
-  const numManualBallots = 54;
-
-  const fullElectionManualTally: FullElectionManualTally = {
-    overallTally: getMockManualTally({
-      numberOfBallotsCounted: numManualBallots,
-    }),
-    resultsByCategory: new Map(),
-    votingMethod: VotingMethod.Precinct,
-    timestampCreated: new Date(),
-  };
-
-  it('renders as expected when there is no data', () => {
-    // No row for "Other" ballots renders when there are 0 CVRs for that category.
-    const expectedLabels = ['Absentee', 'Precinct'];
+  it('renders as expected when there is no data', async () => {
+    apiMock.expectGetCardCounts(mockGroupBy({ groupByVotingMethod: true }), []);
+    apiMock.expectGetScannerBatches([]);
+    apiMock.expectGetManualResultsMetadata([]);
     const { getByText, getAllByTestId } = renderInAppContext(
       <BallotCountsTable breakdownCategory={TallyCategory.VotingMethod} />,
       { apiMock }
     );
 
-    for (const label of expectedLabels) {
+    await screen.findByText('Voting Method');
+    for (const { label } of expectedLabels) {
       getByText(label);
       const tableRow = getByText(label).closest('tr');
       expect(tableRow).toBeDefined();
@@ -554,23 +405,24 @@ describe('Ballots Counts by VotingMethod', () => {
     );
   });
 
-  it('renders as expected when there is tally data', () => {
-    const expectedLabels = [
-      {
-        method: VotingMethod.Absentee,
-        label: 'Absentee',
-      },
-      { method: VotingMethod.Precinct, label: 'Precinct' },
-      { method: VotingMethod.Unknown, label: 'Other' },
-    ];
+  it('renders as expected when there is tally data', async () => {
+    apiMock.expectGetCardCounts(
+      mockGroupBy({ groupByVotingMethod: true }),
+      cardCountsByVotingMethod
+    );
+    apiMock.expectGetScannerBatches([]);
+    apiMock.expectGetManualResultsMetadata([]);
+
     const { getByText, getAllByTestId } = renderInAppContext(
       <BallotCountsTable breakdownCategory={TallyCategory.VotingMethod} />,
-      { fullElectionTally, apiMock }
+      { apiMock }
     );
 
+    await screen.findByText('Voting Method');
     for (const { method, label } of expectedLabels) {
       const expectedNumberOfBallots =
-        resultsByVotingMethod[method]?.numberOfBallotsCounted ?? 0;
+        cardCountsByVotingMethod.find((cc) => cc.votingMethod === method)
+          ?.bmd ?? 0;
       getByText(label);
       const tableRow = getByText(label).closest('tr');
       expect(tableRow).toBeDefined();
@@ -585,54 +437,7 @@ describe('Ballots Counts by VotingMethod', () => {
     getByText('Total Ballot Count');
     const tableRow = getByText('Total Ballot Count').closest('tr');
     expect(tableRow).toBeDefined();
-    expect(domGetByText(tableRow!, 77)).toBeInTheDocument();
-
-    expect(getAllByTestId('table-row').length).toEqual(
-      expectedLabels.length + 2
-    );
-  });
-
-  it('renders as expected where there is tally data and manual data', () => {
-    const expectedLabels = [
-      {
-        method: VotingMethod.Absentee,
-        label: 'Absentee',
-      },
-      { method: VotingMethod.Precinct, label: 'Precinct' },
-      { method: VotingMethod.Unknown, label: 'Other' },
-    ];
-    const { getByText, getAllByTestId } = renderInAppContext(
-      <BallotCountsTable breakdownCategory={TallyCategory.VotingMethod} />,
-      {
-        fullElectionTally,
-        fullElectionManualTally,
-        apiMock,
-      }
-    );
-
-    // The manual tally is configured to be labelled as precinct data.
-
-    for (const { method, label } of expectedLabels) {
-      let expectedNumberOfBallots =
-        resultsByVotingMethod[method]?.numberOfBallotsCounted ?? 0;
-      if (method === VotingMethod.Precinct) {
-        expectedNumberOfBallots += numManualBallots;
-      }
-      getByText(label);
-      const tableRow = getByText(label).closest('tr');
-      expect(tableRow).toBeDefined();
-      expect(
-        domGetByText(tableRow!, expectedNumberOfBallots)
-      ).toBeInTheDocument();
-      expect(
-        domGetByText(tableRow!, `Unofficial ${label} Ballot Tally Report`)
-      ).toBeInTheDocument();
-    }
-
-    getByText('Total Ballot Count');
-    const tableRow = getByText('Total Ballot Count').closest('tr');
-    expect(tableRow).toBeDefined();
-    expect(domGetByText(tableRow!, 131)).toBeInTheDocument();
+    expect(domGetByText(tableRow!, 67)).toBeInTheDocument();
 
     expect(getAllByTestId('table-row').length).toEqual(
       expectedLabels.length + 2
@@ -645,65 +450,52 @@ describe('Ballots Counts by Batch', () => {
     apiMock.expectGetCastVoteRecordFileMode('official');
   });
 
-  const resultsByBatch: Dictionary<BatchTally> = {
-    '12341': {
-      ...fakeTally({
-        numberOfBallotsCounted: 25,
-      }),
-      batchLabel: 'Batch 1',
-      scannerIds: ['001'],
+  const cardCountsByBatch: Array<Tabulation.GroupOf<Tabulation.CardCounts>> = [
+    {
+      batchId: '12341',
+      ...mockCardCounts(25),
     },
-    '12342': {
-      ...fakeTally({
-        numberOfBallotsCounted: 15,
-      }),
-      batchLabel: 'Batch 2',
-      scannerIds: ['001'],
+    {
+      batchId: '12342',
+      ...mockCardCounts(15),
     },
-    '12343': {
-      ...fakeTally({
-        numberOfBallotsCounted: 32,
-      }),
-      batchLabel: 'Batch 1',
-      scannerIds: ['002'],
+    {
+      batchId: '12343',
+      ...mockCardCounts(32),
     },
-    'missing-batch-id': {
-      ...fakeTally({
-        numberOfBallotsCounted: 50,
-      }),
-      scannerIds: ['003', '004'],
-      batchLabel: 'Missing Batch',
+  ];
+
+  const scannerBatches: ScannerBatch[] = [
+    {
+      electionId: 'any',
+      batchId: '12341',
+      label: 'Batch 1',
+      scannerId: '001',
     },
-  };
-  const resultsByCategory = new Map();
-  resultsByCategory.set(TallyCategory.Batch, resultsByBatch);
+    {
+      electionId: 'any',
+      batchId: '12342',
+      label: 'Batch 2',
+      scannerId: '001',
+    },
+    {
+      electionId: 'any',
+      batchId: '12343',
+      label: 'Batch 1',
+      scannerId: '002',
+    },
+  ];
 
-  const fullElectionTally: FullElectionTally = {
-    overallTally: fakeTally({
-      numberOfBallotsCounted: 122,
-    }),
-    resultsByCategory,
-  };
-
-  const numManualBallots = 54;
-
-  const fullElectionManualTally: FullElectionManualTally = {
-    overallTally: getMockManualTally({
-      numberOfBallotsCounted: numManualBallots,
-    }),
-    resultsByCategory: new Map(),
-    votingMethod: VotingMethod.Precinct,
-    timestampCreated: new Date(),
-  };
-
-  it('renders as expected when there is no data', () => {
-    // No row for "Other" ballots renders when there are 0 CVRs for that category.
+  it('renders as expected when there is no data', async () => {
+    apiMock.expectGetCardCounts(mockGroupBy({ groupByBatch: true }), []);
+    apiMock.expectGetScannerBatches(scannerBatches);
+    apiMock.expectGetManualResultsMetadata([]);
     const { getByText, getAllByTestId } = renderInAppContext(
       <BallotCountsTable breakdownCategory={TallyCategory.Batch} />,
       { apiMock }
     );
 
-    getByText('Total Ballot Count');
+    await screen.findByText('Total Ballot Count');
     const tableRow = getByText('Total Ballot Count').closest('tr');
     expect(tableRow).toBeDefined();
     expect(domGetByText(tableRow!, 0)).toBeInTheDocument();
@@ -711,37 +503,41 @@ describe('Ballots Counts by Batch', () => {
     expect(getAllByTestId('table-row').length).toEqual(2);
   });
 
-  it('renders as expected when there is tally data', () => {
-    const expectedLabels = [
-      {
-        batchId: '12341',
-        label: 'Batch 1',
-        scannerLabel: '001',
-      },
-      {
-        batchId: '12342',
-        label: 'Batch 2',
-        scannerLabel: '001',
-      },
-      {
-        batchId: '12343',
-        label: 'Batch 1',
-        scannerLabel: '002',
-      },
-      {
-        batchId: 'missing-batch-id',
-        label: 'Missing Batch',
-        scannerLabel: '003, 004',
-      },
-    ];
+  const expectedLabels = [
+    {
+      batchId: '12341',
+      label: 'Batch 1',
+      scannerLabel: '001',
+    },
+    {
+      batchId: '12342',
+      label: 'Batch 2',
+      scannerLabel: '001',
+    },
+    {
+      batchId: '12343',
+      label: 'Batch 1',
+      scannerLabel: '002',
+    },
+  ];
+
+  it('renders as expected when there is tally data', async () => {
+    apiMock.expectGetCardCounts(
+      mockGroupBy({ groupByBatch: true }),
+      cardCountsByBatch
+    );
+    apiMock.expectGetScannerBatches(scannerBatches);
+    apiMock.expectGetManualResultsMetadata([]);
     const { getByText, getAllByTestId } = renderInAppContext(
       <BallotCountsTable breakdownCategory={TallyCategory.Batch} />,
-      { fullElectionTally, apiMock }
+      { apiMock }
     );
+
+    await screen.findByText('Batch Name');
 
     for (const { batchId, label, scannerLabel } of expectedLabels) {
       const expectedNumberOfBallots =
-        resultsByBatch[batchId]?.numberOfBallotsCounted ?? 0;
+        cardCountsByBatch.find((cc) => cc.batchId === batchId)?.bmd ?? 0;
       const tableRow = getAllByTestId(`batch-${batchId}`)[0].closest('tr');
       assert(tableRow);
       expect(domGetByText(tableRow, label)).toBeInTheDocument();
@@ -757,7 +553,7 @@ describe('Ballots Counts by Batch', () => {
     getByText('Total Ballot Count');
     const tableRow = getByText('Total Ballot Count').closest('tr');
     expect(tableRow).toBeDefined();
-    expect(domGetByText(tableRow!, 122)).toBeInTheDocument();
+    expect(domGetByText(tableRow!, 72)).toBeInTheDocument();
 
     // There should be 2 extra table rows in addition to the batches, one for the headers, and one for the total row.
     expect(getAllByTestId('table-row').length).toEqual(
@@ -765,60 +561,38 @@ describe('Ballots Counts by Batch', () => {
     );
   });
 
-  it('renders as expected where there is tally data and manual data', () => {
-    const expectedLabels = [
+  it('renders as expected where there is tally data and manual data', async () => {
+    apiMock.expectGetCardCounts(
+      mockGroupBy({ groupByBatch: true }),
+      cardCountsByBatch
+    );
+    apiMock.expectGetScannerBatches(scannerBatches);
+    apiMock.expectGetManualResultsMetadata([
       {
-        batchId: '12341',
-        label: 'Batch 1',
-        scannerLabel: '001',
+        precinctId: 'any',
+        ballotStyleId: 'any',
+        votingMethod: 'precinct',
+        ballotCount: 54,
+        createdAt: 'any',
       },
-      {
-        batchId: '12342',
-        label: 'Batch 2',
-        scannerLabel: '001',
-      },
-      {
-        batchId: '12343',
-        label: 'Batch 1',
-        scannerLabel: '002',
-      },
-      {
-        batchId: 'missing-batch-id',
-        label: 'Missing Batch',
-        scannerLabel: '003, 004',
-      },
-    ];
+    ]);
     const { getByText, getAllByTestId } = renderInAppContext(
       <BallotCountsTable breakdownCategory={TallyCategory.Batch} />,
       {
-        fullElectionTally,
-        fullElectionManualTally,
         apiMock,
       }
     );
 
-    // The manual tally is configured to be labelled as precinct data.
-
-    for (const { batchId, label, scannerLabel } of expectedLabels) {
-      const expectedNumberOfBallots =
-        resultsByBatch[batchId]?.numberOfBallotsCounted ?? 0;
-      const tableRow = getAllByTestId(`batch-${batchId}`)[0].closest('tr');
-      expect(tableRow).toBeDefined();
-      domGetByText(tableRow!, label);
-      domGetByText(tableRow!, expectedNumberOfBallots);
-      domGetByText(tableRow!, scannerLabel);
-      domGetByText(tableRow!, `Unofficial ${label} Tally Report`);
-    }
-
+    await screen.findByText('Batch Name');
     const manualTableRow = getAllByTestId('batch-manual')[0].closest('tr');
     assert(manualTableRow);
     domGetByText(manualTableRow, 'Manually Entered Results');
-    domGetByText(manualTableRow, numManualBallots);
+    domGetByText(manualTableRow, 54);
 
     getByText('Total Ballot Count');
     const tableRow = getByText('Total Ballot Count').closest('tr');
     assert(tableRow);
-    domGetByText(tableRow, 176);
+    domGetByText(tableRow, 126);
 
     // There should be 3 extra table rows in addition to the batches, one for the headers, one for the manual data, and one for the total row.
     expect(getAllByTestId('table-row').length).toEqual(

--- a/apps/admin/frontend/src/components/ballot_counts_table.test.tsx
+++ b/apps/admin/frontend/src/components/ballot_counts_table.test.tsx
@@ -16,6 +16,7 @@ import { renderInAppContext } from '../../test/render_in_app_context';
 
 import { BallotCountsTable } from './ballot_counts_table';
 import { ApiMock, createApiMock } from '../../test/helpers/api_mock';
+import { mockBallotCountsTableGroupBy } from '../../test/helpers/api_expect_helpers';
 
 let apiMock: ApiMock;
 
@@ -31,21 +32,6 @@ function mockCardCounts(bmdCount: number): Tabulation.CardCounts {
   return {
     bmd: bmdCount,
     hmpb: [],
-  };
-}
-
-/**
- * To match backend input exactly, per `MockFunction` requirements, mock out
- * false values instead of undefined.
- */
-function mockGroupBy(groupBy: Tabulation.GroupBy): Tabulation.GroupBy {
-  return {
-    groupByBatch: false,
-    groupByParty: false,
-    groupByPrecinct: false,
-    groupByScanner: false,
-    groupByVotingMethod: false,
-    ...groupBy,
   };
 }
 
@@ -67,7 +53,10 @@ describe('Ballot Counts by Precinct', () => {
     ];
 
   it('renders as expected when there is no tally data', async () => {
-    apiMock.expectGetCardCounts(mockGroupBy({ groupByPrecinct: true }), []);
+    apiMock.expectGetCardCounts(
+      mockBallotCountsTableGroupBy({ groupByPrecinct: true }),
+      []
+    );
     apiMock.expectGetScannerBatches([]);
     apiMock.expectGetManualResultsMetadata([]);
     const { getByText, getAllByTestId } = renderInAppContext(
@@ -100,7 +89,7 @@ describe('Ballot Counts by Precinct', () => {
 
   it('renders as expected when there is tally data', async () => {
     apiMock.expectGetCardCounts(
-      mockGroupBy({ groupByPrecinct: true }),
+      mockBallotCountsTableGroupBy({ groupByPrecinct: true }),
       cardCountsByPrecinct
     );
     apiMock.expectGetScannerBatches([]);
@@ -157,7 +146,10 @@ describe('Ballot Counts by Scanner', () => {
   const scannerIds = ['scanner-1', 'scanner-2'];
 
   it('renders as expected when there is no tally data', async () => {
-    apiMock.expectGetCardCounts(mockGroupBy({ groupByScanner: true }), []);
+    apiMock.expectGetCardCounts(
+      mockBallotCountsTableGroupBy({ groupByScanner: true }),
+      []
+    );
     apiMock.expectGetScannerBatches([]);
     apiMock.expectGetManualResultsMetadata([]);
     const { getByText, getAllByTestId } = renderInAppContext(
@@ -176,7 +168,7 @@ describe('Ballot Counts by Scanner', () => {
 
   it('renders as expected when there is tally data', async () => {
     apiMock.expectGetCardCounts(
-      mockGroupBy({ groupByScanner: true }),
+      mockBallotCountsTableGroupBy({ groupByScanner: true }),
       cardCountsByScanner
     );
     apiMock.expectGetScannerBatches([]);
@@ -217,7 +209,7 @@ describe('Ballot Counts by Scanner', () => {
 
   it('renders as expected when there is tally data and manual data', async () => {
     apiMock.expectGetCardCounts(
-      mockGroupBy({ groupByScanner: true }),
+      mockBallotCountsTableGroupBy({ groupByScanner: true }),
       cardCountsByScanner
     );
     apiMock.expectGetScannerBatches([]);
@@ -273,7 +265,10 @@ describe('Ballots Counts by Party', () => {
   ];
 
   it('renders as expected when there is no data', async () => {
-    apiMock.expectGetCardCounts(mockGroupBy({ groupByParty: true }), []);
+    apiMock.expectGetCardCounts(
+      mockBallotCountsTableGroupBy({ groupByParty: true }),
+      []
+    );
     apiMock.expectGetScannerBatches([]);
     apiMock.expectGetManualResultsMetadata([]);
     const { getByText, getAllByTestId } = renderInAppContext(
@@ -311,7 +306,7 @@ describe('Ballots Counts by Party', () => {
 
   it('renders as expected when there is tally data', async () => {
     apiMock.expectGetCardCounts(
-      mockGroupBy({ groupByParty: true }),
+      mockBallotCountsTableGroupBy({ groupByParty: true }),
       cardCountsByParty
     );
     apiMock.expectGetScannerBatches([]);
@@ -376,7 +371,10 @@ describe('Ballots Counts by VotingMethod', () => {
   ];
 
   it('renders as expected when there is no data', async () => {
-    apiMock.expectGetCardCounts(mockGroupBy({ groupByVotingMethod: true }), []);
+    apiMock.expectGetCardCounts(
+      mockBallotCountsTableGroupBy({ groupByVotingMethod: true }),
+      []
+    );
     apiMock.expectGetScannerBatches([]);
     apiMock.expectGetManualResultsMetadata([]);
     const { getByText, getAllByTestId } = renderInAppContext(
@@ -407,7 +405,7 @@ describe('Ballots Counts by VotingMethod', () => {
 
   it('renders as expected when there is tally data', async () => {
     apiMock.expectGetCardCounts(
-      mockGroupBy({ groupByVotingMethod: true }),
+      mockBallotCountsTableGroupBy({ groupByVotingMethod: true }),
       cardCountsByVotingMethod
     );
     apiMock.expectGetScannerBatches([]);
@@ -487,7 +485,10 @@ describe('Ballots Counts by Batch', () => {
   ];
 
   it('renders as expected when there is no data', async () => {
-    apiMock.expectGetCardCounts(mockGroupBy({ groupByBatch: true }), []);
+    apiMock.expectGetCardCounts(
+      mockBallotCountsTableGroupBy({ groupByBatch: true }),
+      []
+    );
     apiMock.expectGetScannerBatches(scannerBatches);
     apiMock.expectGetManualResultsMetadata([]);
     const { getByText, getAllByTestId } = renderInAppContext(
@@ -523,7 +524,7 @@ describe('Ballots Counts by Batch', () => {
 
   it('renders as expected when there is tally data', async () => {
     apiMock.expectGetCardCounts(
-      mockGroupBy({ groupByBatch: true }),
+      mockBallotCountsTableGroupBy({ groupByBatch: true }),
       cardCountsByBatch
     );
     apiMock.expectGetScannerBatches(scannerBatches);
@@ -563,7 +564,7 @@ describe('Ballots Counts by Batch', () => {
 
   it('renders as expected where there is tally data and manual data', async () => {
     apiMock.expectGetCardCounts(
-      mockGroupBy({ groupByBatch: true }),
+      mockBallotCountsTableGroupBy({ groupByBatch: true }),
       cardCountsByBatch
     );
     apiMock.expectGetScannerBatches(scannerBatches);

--- a/apps/admin/frontend/src/components/ballot_counts_table.tsx
+++ b/apps/admin/frontend/src/components/ballot_counts_table.tsx
@@ -115,9 +115,7 @@ export function BallotCountsTable({
                 <strong>Total Ballot Count</strong>
               </TD>
               <TD>
-                <strong data-testid="total-ballot-count">
-                  {format.count(totalBallotCount)}
-                </strong>
+                <strong>{format.count(totalBallotCount)}</strong>
               </TD>
               <TD>
                 <LinkButton
@@ -244,9 +242,7 @@ export function BallotCountsTable({
                 <strong>Total Ballot Count</strong>
               </TD>
               <TD>
-                <strong data-testid="total-ballot-count">
-                  {format.count(totalBallotCount)}
-                </strong>
+                <strong>{format.count(totalBallotCount)}</strong>
               </TD>
               <TD />
             </tr>
@@ -333,16 +329,14 @@ export function BallotCountsTable({
                   <TD>{batch.scannerId}</TD>
                   <TD>{format.count(ballotCount)}</TD>
                   <TD>
-                    {ballotCount > 0 && (
-                      <LinkButton
-                        small
-                        to={routerPaths.tallyBatchReport({
-                          batchId,
-                        })}
-                      >
-                        {statusPrefix} {batch.label} Tally Report
-                      </LinkButton>
-                    )}
+                    <LinkButton
+                      small
+                      to={routerPaths.tallyBatchReport({
+                        batchId,
+                      })}
+                    >
+                      {statusPrefix} {batch.label} Tally Report
+                    </LinkButton>
                   </TD>
                 </tr>
               );

--- a/apps/admin/frontend/src/screens/reports_screen.tsx
+++ b/apps/admin/frontend/src/screens/reports_screen.tsx
@@ -170,7 +170,7 @@ export function ReportsScreen(): JSX.Element {
       <strong>
         {format.count(totalBallotCount)}
         {fileMode === 'unlocked' ? ' ' : ` ${fileMode} `}
-        {pluralize('ballot', totalBallotCount, false)}{' '}
+        {pluralize('ballot', totalBallotCount, false)}
       </strong>{' '}
       have been counted for <strong>{electionDefinition.election.title}</strong>
       .

--- a/apps/admin/frontend/src/screens/reports_screen.tsx
+++ b/apps/admin/frontend/src/screens/reports_screen.tsx
@@ -6,6 +6,7 @@ import {
   generateSemsFinalExportDefaultFilename,
   format,
   isElectionManagerAuth,
+  getBallotCount,
 } from '@votingworks/utils';
 import {
   Button,
@@ -31,7 +32,11 @@ import {
 } from '../components/save_frontend_file_modal';
 import { getTallyConverterClient } from '../lib/converters';
 import { SaveResultsButton } from '../components/save_results_button';
-import { getCastVoteRecordFileMode, getSemsExportableTallies } from '../api';
+import {
+  getCardCounts,
+  getCastVoteRecordFileMode,
+  getSemsExportableTallies,
+} from '../api';
 
 export function ReportsScreen(): JSX.Element {
   const makeCancelable = useCancelablePromise();
@@ -41,8 +46,6 @@ export function ReportsScreen(): JSX.Element {
     converter,
     isOfficialResults,
     isTabulationRunning,
-    fullElectionTally,
-    fullElectionManualTally,
     configuredAt,
     logger,
     auth,
@@ -52,6 +55,7 @@ export function ReportsScreen(): JSX.Element {
   assert(electionDefinition && typeof configuredAt === 'string');
   const { election } = electionDefinition;
 
+  const cardCountsQuery = getCardCounts.useQuery();
   const castVoteRecordFileModeQuery = getCastVoteRecordFileMode.useQuery();
   const semsExportableTalliesQuery = getSemsExportableTallies.useQuery({
     enabled: converter === 'ms-sems',
@@ -69,11 +73,9 @@ export function ReportsScreen(): JSX.Element {
 
   const partiesForPrimaries = getPartiesWithPrimaryElections(election);
 
-  const totalBallotCountInternal =
-    fullElectionTally?.overallTally.numberOfBallotsCounted ?? 0;
-  const totalBallotCountManual =
-    fullElectionManualTally?.overallTally.numberOfBallotsCounted ?? 0;
-  const totalBallotCount = totalBallotCountInternal + totalBallotCountManual;
+  const totalBallotCount = cardCountsQuery.data
+    ? getBallotCount(cardCountsQuery.data[0])
+    : 0;
 
   const [converterName, setConverterName] = useState('');
   useEffect(() => {

--- a/apps/admin/frontend/test/helpers/api_expect_helpers.ts
+++ b/apps/admin/frontend/test/helpers/api_expect_helpers.ts
@@ -1,0 +1,57 @@
+import { Tabulation } from '@votingworks/types';
+import { getEmptyCardCounts } from '@votingworks/utils';
+import { ApiMock } from './api_mock';
+
+/**
+ * To match backend input exactly, per `MockFunction` requirements, mock out
+ * false values instead of undefined.
+ */
+export function mockBallotCountsTableGroupBy(
+  groupBy: Tabulation.GroupBy
+): Tabulation.GroupBy {
+  return {
+    groupByBatch: false,
+    groupByParty: false,
+    groupByPrecinct: false,
+    groupByScanner: false,
+    groupByVotingMethod: false,
+    ...groupBy,
+  };
+}
+
+/**
+ * The reports screen fires off a number of queries of the same type, but they are
+ * always ordered the same way. This helper function mocks out the expected queries.
+ *
+ * This is a temporary solution until we redesign the reports screen to remove the
+ * excessive ballot counts (e.g. precinct, scanner, and batch do not make sense).
+ */
+export function expectReportsScreenCardCountQueries({
+  apiMock,
+  isPrimary,
+  overallCardCount = getEmptyCardCounts(),
+}: {
+  apiMock: ApiMock;
+  isPrimary: boolean;
+  overallCardCount?: Tabulation.CardCounts;
+}): void {
+  apiMock.expectGetCardCounts(
+    mockBallotCountsTableGroupBy({ groupByPrecinct: true }),
+    []
+  );
+  apiMock.expectGetCardCounts(
+    mockBallotCountsTableGroupBy({ groupByVotingMethod: true }),
+    []
+  );
+  if (isPrimary) {
+    apiMock.expectGetCardCounts(
+      mockBallotCountsTableGroupBy({ groupByParty: true }),
+      []
+    );
+  }
+  apiMock.expectGetCardCounts(
+    mockBallotCountsTableGroupBy({ groupByScanner: true }),
+    []
+  );
+  apiMock.expectGetCardCounts({}, [overallCardCount]);
+}

--- a/apps/admin/frontend/test/helpers/api_mock.ts
+++ b/apps/admin/frontend/test/helpers/api_mock.ts
@@ -14,6 +14,7 @@ import type {
   WriteInTally,
   WriteInAdjudicatedTally,
   SemsExportableTallies,
+  ScannerBatch,
 } from '@votingworks/admin-backend';
 import { collections, ok } from '@votingworks/basics';
 import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
@@ -342,6 +343,17 @@ export function createApiMock(
 
     expectExportResultsCsv(path: string) {
       apiClient.exportResultsCsv.expectCallWith({ path }).resolves(ok([]));
+    },
+
+    expectGetCardCounts(
+      groupBy: Tabulation.GroupBy,
+      result: Array<Tabulation.GroupOf<Tabulation.CardCounts>>
+    ) {
+      apiClient.getCardCounts.expectCallWith({ groupBy }).resolves(result);
+    },
+
+    expectGetScannerBatches(result: ScannerBatch[]) {
+      apiClient.getScannerBatches.expectCallWith().resolves(result);
     },
   };
 }

--- a/libs/types/src/tabulation.ts
+++ b/libs/types/src/tabulation.ts
@@ -128,6 +128,7 @@ export type GroupOf<T> = T & GroupSpecifier;
 export type Grouped<T> = Record<GroupKey, GroupOf<T>>;
 
 export type GroupedElectionResults = Grouped<ElectionResults>;
+export type GroupedCardCounts = Grouped<CardCounts>;
 
 /**
  * Simplified representation of votes on a scanned ballot for tabulation
@@ -148,3 +149,7 @@ export type CastVoteRecord = {
 export type ManualElectionResults = Omit<ElectionResults, 'cardCounts'> & {
   ballotCount: number;
 };
+
+export type GroupedManualBallotCounts = Grouped<{
+  ballotCount: number;
+}>;

--- a/libs/utils/src/tabulation.ts
+++ b/libs/utils/src/tabulation.ts
@@ -64,6 +64,13 @@ export function getEmptyCandidateContestResults(
   };
 }
 
+export function getEmptyCardCounts(): Tabulation.CardCounts {
+  return {
+    bmd: 0,
+    hmpb: [],
+  };
+}
+
 /**
  * Generate an empty {@link Tabulation.ElectionResults} with empty tallies for
  * all contests in the election.
@@ -85,10 +92,7 @@ export function getEmptyElectionResults(
 
   return {
     contestResults,
-    cardCounts: {
-      bmd: 0,
-      hmpb: [],
-    },
+    cardCounts: getEmptyCardCounts(),
   };
 }
 


### PR DESCRIPTION
## Overview

Closes #3455.

We have the "Ballot Counts Tables" on the reports screen that give a ballot count for each precinct, each party (if primary election), each voting method, each scanner and each batch (if selected). This is not a design that we will certify on. It does not scale, and is inflexible. In the future, we might show ballot counts for voting method and party, maybe on the reports page and maybe elsewhere. Given that, I wanted to create the backend methods for getting those ballot counts in a way that will continue to be useful when we move to another format. Instead of giving the frontend a blob with all the different category breakdowns, each one is a different query. For the short term, this leads a less than ideal scenario where the reports page is making 5 - 7 requests for ballot counts, each one involving table scans. I think that's fine for the short term, and I'd much rather the endpoints be reusable.

## Testing Plan
- Automated
- Manual
