### PR TITLE
refactor(grout): Grout Serialization Plain Object Prototype Requirement Tweak

### DIFF
--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -679,13 +679,9 @@ function buildApi({
     },
 
     getManualResultsMetadata(): ManualResultsMetadataRecord[] {
-      return store
-        .getManualResultsMetadata({
-          electionId: loadCurrentElectionIdOrThrow(workspace),
-        })
-        .map((record) => ({ ...record }));
-      // TODO: grout is having trouble serializing records from the store
-      // without destructuring them. need to investigate
+      return store.getManualResultsMetadata({
+        electionId: loadCurrentElectionIdOrThrow(workspace),
+      });
     },
 
     getCardCounts(input: {
@@ -702,11 +698,7 @@ function buildApi({
     },
 
     getScannerBatches(): ScannerBatch[] {
-      return store
-        .getScannerBatches(loadCurrentElectionIdOrThrow(workspace))
-        .map((record) => ({ ...record }));
-      // TODO: grout is having trouble serializing records from the store
-      // without destructuring them. need to investigate;
+      return store.getScannerBatches(loadCurrentElectionIdOrThrow(workspace));
     },
 
     async exportBatchResults(input: {

--- a/libs/grout/src/util.test.ts
+++ b/libs/grout/src/util.test.ts
@@ -96,6 +96,9 @@ test('isPlainObject', () => {
   expect(isPlainObject('')).toEqual(false);
   expect(isPlainObject([])).toEqual(false);
   expect(isPlainObject(() => 0)).toEqual(false);
+
+  // an object with a distinct null prototype is still a plain object
+  expect(isPlainObject(Object.create(Object.create(null)))).toEqual(true);
 });
 
 test('isFunction', () => {

--- a/libs/grout/src/util.ts
+++ b/libs/grout/src/util.ts
@@ -25,8 +25,7 @@ export function isPlainObject(
 ): value is Record<string, unknown> {
   return (
     isObject(value) &&
-    Object.getPrototypeOf(value) === Object.prototype &&
-    value.constructor.name === Object.name
+    Object.getPrototypeOf(Object.getPrototypeOf(value)) === null
   );
 }
 


### PR DESCRIPTION
## Overview

I've come across an issue in the VxAdmin backend where, if I send records pulled directly from the store through `grout`, serialization fails. It says the records are not plain objects because their prototypes do not equal `Object.prototype`. Actually, both of the prototypes are "null prototypes", but two different null prototypes don't evaluate as equal. Why `better-sqlite3` returns objects with a different null prototype, I do not know.
