### PR TITLE
Ensure CVR export signature files are flushed to USB drives

### DIFF
--- a/libs/auth/src/config.ts
+++ b/libs/auth/src/config.ts
@@ -55,10 +55,11 @@ export interface JavaCardConfig {
     vxAdminCertAuthorityCertPath: string;
     vxAdminPrivateKey: FileKey | TpmKey;
   };
-  /** Only tests should provide this param, to make challenge generation non-random */
-  customChallengeGenerator?: () => string;
   /** The path to the VotingWorks cert authority cert */
   vxCertAuthorityCertPath: string;
+
+  /** Only tests should provide this param, to make challenge generation non-random */
+  customChallengeGenerator?: () => string;
 }
 
 /**
@@ -89,6 +90,9 @@ export interface ArtifactAuthenticatorConfig {
   signingMachineCertPath: string;
   signingMachinePrivateKey: FileKey | TpmKey;
   vxCertAuthorityCertPath: string;
+
+  /** Only tests should provide this param, to simplify mocking */
+  customDataFlusher?: (filePath: string) => Promise<void>;
 }
 
 /**

--- a/libs/auth/src/config.ts
+++ b/libs/auth/src/config.ts
@@ -59,7 +59,7 @@ export interface JavaCardConfig {
   vxCertAuthorityCertPath: string;
 
   /** Only tests should provide this param, to make challenge generation non-random */
-  customChallengeGenerator?: () => string;
+  generateChallengeOverride?: () => string;
 }
 
 /**
@@ -91,8 +91,8 @@ export interface ArtifactAuthenticatorConfig {
   signingMachinePrivateKey: FileKey | TpmKey;
   vxCertAuthorityCertPath: string;
 
-  /** Only tests should provide this param, to simplify mocking */
-  customDataFlusher?: (filePath: string) => Promise<void>;
+  /** Only tests should provide this param */
+  isFileOnRemovableDeviceOverride?: (filePath: string) => boolean;
 }
 
 /**

--- a/libs/auth/src/java_card.test.ts
+++ b/libs/auth/src/java_card.test.ts
@@ -92,12 +92,12 @@ const electionManagerUser = fakeElectionManagerUser({ electionHash });
 const pollWorkerUser = fakePollWorkerUser({ electionHash });
 
 const mockChallenge = 'VotingWorks';
-function customChallengeGenerator(): string {
+function generateChallengeOverride(): string {
   return mockChallenge;
 }
 
 const config: JavaCardConfig = {
-  customChallengeGenerator,
+  generateChallengeOverride,
   vxCertAuthorityCertPath: getTestFilePath({
     fileType: 'vx-cert-authority-cert.pem',
   }),
@@ -331,7 +331,7 @@ function mockCardPutDataRequest(dataObjectId: Buffer, data: Buffer): void {
 
 test('Non-ready card statuses', async () => {
   const javaCard = new JavaCard({
-    customChallengeGenerator,
+    generateChallengeOverride,
     vxCertAuthorityCertPath: getTestFilePath({
       fileType: 'vx-cert-authority-cert.pem',
     }),
@@ -573,7 +573,7 @@ test.each<{
     expectedCardDetails,
   }) => {
     const javaCard = new JavaCard({
-      customChallengeGenerator,
+      generateChallengeOverride,
       vxCertAuthorityCertPath: getTestFilePath({
         setId: vxCertAuthorityCert,
         fileType: 'vx-cert-authority-cert.pem',

--- a/libs/auth/src/java_card.ts
+++ b/libs/auth/src/java_card.ts
@@ -141,11 +141,6 @@ export const GENERIC_STORAGE_SPACE = {
   ],
 } as const;
 
-/* istanbul ignore next */
-function generateChallenge(): string {
-  return `VotingWorks/${new Date().toISOString()}/${uuid()}`;
-}
-
 /**
  * An implementation of the card API that uses a Java Card running our fork of the OpenFIPS201
  * applet (https://github.com/votingworks/openfips201) and X.509 certs. The implementation takes
@@ -167,8 +162,9 @@ export class JavaCard implements Card {
     this.cardProgrammingConfig = input.cardProgrammingConfig;
     this.cardStatus = { status: 'no_card' };
     this.generateChallenge =
-      input.customChallengeGenerator ??
-      /* istanbul ignore next */ generateChallenge;
+      input.generateChallengeOverride ??
+      /* istanbul ignore next */ (() =>
+        `VotingWorks/${new Date().toISOString()}/${uuid()}`);
     this.vxCertAuthorityCertPath = input.vxCertAuthorityCertPath;
 
     this.cardReader = new CardReader({


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/3581

Both @kofi-q and I have encountered sporadic auth errors when importing CVRs exported by VxScan in prod for m17a QA.

<img src='https://user-images.githubusercontent.com/12616928/245618992-ff0039bb-8ede-42b0-a10d-573699efe213.jpg' width=400 />

In these error cases, the CVRs are missing a corresponding `.vxsig` signature file. Turns out, the signature file isn't being flushed to the USB drive before the USB drive is removed. We make use of `sync -f` throughout the codebase to ensure data is written to USBs before their removal. We were just missing a `sync -f` in this specific code path. As we continue to hash out `libs/usb-drive`, I'm sure we can find a way to make this even more foolproof.

## Testing

- [x] Tested manually in prod
- [x] Maintained 100% code coverage in `libs/auth`

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A