### PR TITLE
Tally Report Part 1 - Backend Methods

### DIFF
--- a/apps/admin/backend/src/app.results.test.ts
+++ b/apps/admin/backend/src/app.results.test.ts
@@ -1,9 +1,14 @@
-import { electionMinimalExhaustiveSampleFixtures } from '@votingworks/fixtures';
+import {
+  electionGridLayoutNewHampshireAmherstFixtures,
+  electionMinimalExhaustiveSampleFixtures,
+} from '@votingworks/fixtures';
 import {
   BooleanEnvironmentVariableName,
   buildManualResultsFixture,
   getFeatureFlagMock,
 } from '@votingworks/utils';
+import { assert, find } from '@votingworks/basics';
+import { writeInCandidate } from '@votingworks/types';
 import {
   buildTestEnvironment,
   configureMachine,
@@ -93,5 +98,264 @@ test('card counts', async () => {
         manual: 0,
       },
     ])
+  );
+});
+
+test('tally report data - overall report & write-ins', async () => {
+  const { electionDefinition, castVoteRecordReport } =
+    electionGridLayoutNewHampshireAmherstFixtures;
+
+  const { apiClient, auth } = buildTestEnvironment();
+  await configureMachine(apiClient, auth, electionDefinition);
+  mockElectionManagerAuth(auth, electionDefinition.electionHash);
+
+  const loadFileResult = await apiClient.addCastVoteRecordFile({
+    path: castVoteRecordReport.asDirectoryPath(),
+  });
+  loadFileResult.assertOk('load file failed');
+
+  const writeInContestId =
+    'State-Representatives-Hillsborough-District-34-b1012d38';
+  const officialCandidateId = 'Obadiah-Carrigan-5c95145a';
+
+  // try overall election results
+  const overallTallyReportResult = await apiClient.getResultsForTallyReports();
+  expect(overallTallyReportResult).toHaveLength(1);
+  const [overallTallyReport] = overallTallyReportResult;
+  assert(overallTallyReport);
+  expect(overallTallyReport.manualResults).toBeUndefined();
+  expect(overallTallyReport.scannedResults.cardCounts).toMatchObject({
+    bmd: 0,
+    hmpb: [184],
+  });
+  expect(
+    overallTallyReport.scannedResults.contestResults[writeInContestId]
+  ).toMatchObject({
+    ballots: 184,
+    undervotes: 12,
+    tallies: {
+      'Obadiah-Carrigan-5c95145a': {
+        id: 'Obadiah-Carrigan-5c95145a',
+        name: 'Obadiah Carrigan',
+        tally: 60,
+      },
+      'write-in': {
+        id: 'write-in',
+        isWriteIn: true,
+        name: 'Write-In',
+        tally: 56,
+      },
+    },
+  });
+
+  // adjudicate some write-ins
+  const unofficialCandidate = await apiClient.addWriteInCandidate({
+    contestId: writeInContestId,
+    name: 'Unofficial Candidate',
+  });
+  const writeIns = await apiClient.getWriteIns({
+    contestId: writeInContestId,
+  });
+  expect(writeIns).toHaveLength(56);
+  const NUM_INVALID = 24;
+  const NUM_OFFICIAL = 16;
+  const NUM_UNOFFICIAL = 56 - NUM_INVALID - NUM_OFFICIAL;
+  for (const [i, writeIn] of writeIns.entries()) {
+    if (i < NUM_INVALID) {
+      await apiClient.adjudicateWriteIn({
+        writeInId: writeIn.id,
+        type: 'invalid',
+      });
+    } else if (i < NUM_INVALID + NUM_OFFICIAL) {
+      await apiClient.adjudicateWriteIn({
+        writeInId: writeIn.id,
+        type: 'official-candidate',
+        candidateId: officialCandidateId,
+      });
+    } else {
+      await apiClient.adjudicateWriteIn({
+        writeInId: writeIn.id,
+        type: 'write-in-candidate',
+        candidateId: unofficialCandidate.id,
+      });
+    }
+  }
+
+  const overallTallyReportAdjudicatedResult =
+    await apiClient.getResultsForTallyReports();
+  expect(overallTallyReportAdjudicatedResult).toHaveLength(1);
+  const [overallTallyReportAdjudicated] = overallTallyReportAdjudicatedResult;
+  assert(overallTallyReportAdjudicated);
+  expect(overallTallyReportAdjudicated.manualResults).toBeUndefined();
+  expect(overallTallyReportAdjudicated.scannedResults.cardCounts).toMatchObject(
+    {
+      bmd: 0,
+      hmpb: [184],
+    }
+  );
+  expect(
+    overallTallyReportAdjudicated.scannedResults.contestResults[
+      writeInContestId
+    ]
+  ).toMatchObject({
+    ballots: 184,
+    undervotes: 12 + NUM_INVALID,
+    tallies: {
+      'Obadiah-Carrigan-5c95145a': {
+        id: 'Obadiah-Carrigan-5c95145a',
+        name: 'Obadiah Carrigan',
+        tally: 60 + NUM_OFFICIAL,
+      },
+      'write-in': {
+        id: 'write-in',
+        isWriteIn: true,
+        name: 'Write-In',
+        tally: NUM_UNOFFICIAL,
+      },
+    },
+  });
+});
+
+test('tally report data - grouped report & manual data', async () => {
+  const { electionDefinition, castVoteRecordReport } =
+    electionGridLayoutNewHampshireAmherstFixtures;
+  const { election } = electionDefinition;
+
+  const { apiClient, auth } = buildTestEnvironment();
+  await configureMachine(apiClient, auth, electionDefinition);
+  mockElectionManagerAuth(auth, electionDefinition.electionHash);
+
+  const loadFileResult = await apiClient.addCastVoteRecordFile({
+    path: castVoteRecordReport.asDirectoryPath(),
+  });
+  loadFileResult.assertOk('load file failed');
+
+  const writeInContestId =
+    'State-Representatives-Hillsborough-District-34-b1012d38';
+
+  // adjudicate all write-ins for unofficial candidate, to confirm that it is
+  // represented as the generic write-in
+  const unofficialCandidate = await apiClient.addWriteInCandidate({
+    contestId: writeInContestId,
+    name: 'Unofficial Candidate',
+  });
+  const writeIns = await apiClient.getWriteIns({
+    contestId: writeInContestId,
+  });
+  expect(writeIns).toHaveLength(56);
+  for (const writeIn of writeIns) {
+    await apiClient.adjudicateWriteIn({
+      writeInId: writeIn.id,
+      type: 'write-in-candidate',
+      candidateId: unofficialCandidate.id,
+    });
+  }
+
+  // add manual results
+  const absenteeManualResults = buildManualResultsFixture({
+    election,
+    ballotCount: 10,
+    contestResultsSummaries: {
+      [writeInContestId]: {
+        type: 'candidate',
+        ballots: 10,
+        writeInOptionTallies: {
+          [unofficialCandidate.id]: {
+            tally: 10,
+            name: unofficialCandidate.name,
+          },
+        },
+      },
+    },
+  });
+  await apiClient.setManualResults({
+    precinctId: election.precincts[0]!.id,
+    ballotStyleId: election.ballotStyles[0]!.id,
+    votingMethod: 'absentee',
+    manualResults: absenteeManualResults,
+  });
+
+  const votingMethodTallyReportResult =
+    await apiClient.getResultsForTallyReports({
+      groupBy: { groupByVotingMethod: true },
+    });
+  expect(votingMethodTallyReportResult).toHaveLength(2);
+  const absenteeTallyReport = find(
+    votingMethodTallyReportResult,
+    (report) => report.votingMethod === 'absentee'
+  );
+  const precinctTallyReport = find(
+    votingMethodTallyReportResult,
+    (report) => report.votingMethod === 'precinct'
+  );
+
+  // scanned results should be the same
+  expect(absenteeTallyReport.scannedResults).toEqual(
+    precinctTallyReport.scannedResults
+  );
+  expect(absenteeTallyReport.scannedResults.cardCounts).toMatchObject({
+    bmd: 0,
+    hmpb: [92],
+  });
+  expect(
+    absenteeTallyReport.scannedResults.contestResults[writeInContestId]
+  ).toMatchObject({
+    ballots: 92,
+    undervotes: 6,
+    tallies: {
+      'Obadiah-Carrigan-5c95145a': {
+        id: 'Obadiah-Carrigan-5c95145a',
+        name: 'Obadiah Carrigan',
+        tally: 30,
+      },
+      'write-in': {
+        id: 'write-in',
+        isWriteIn: true,
+        name: 'Write-In',
+        tally: 28, // unofficial write-in candidate tally properly included here
+      },
+    },
+  });
+
+  expect(precinctTallyReport.manualResults).toBeUndefined();
+  const returnedAbsenteeManualResults = absenteeTallyReport.manualResults;
+  expect(returnedAbsenteeManualResults).toBeDefined();
+
+  expect(returnedAbsenteeManualResults).toMatchObject(
+    buildManualResultsFixture({
+      election,
+      ballotCount: 10,
+      contestResultsSummaries: {
+        [writeInContestId]: {
+          type: 'candidate',
+          ballots: 10,
+          writeInOptionTallies: {
+            [writeInCandidate.id]: {
+              tally: 10,
+              name: writeInCandidate.name,
+            },
+          },
+        },
+      },
+    })
+  );
+
+  // with a filter incompatible with manual results, manual results should be undefined
+  const batchVotingMethodTallyReportResult =
+    await apiClient.getResultsForTallyReports({
+      groupBy: { groupByBatch: true, groupByVotingMethod: true },
+    });
+  expect(batchVotingMethodTallyReportResult).toHaveLength(2);
+  const batchPrecinctTallyReport = find(
+    batchVotingMethodTallyReportResult,
+    (report) => report.votingMethod === 'precinct'
+  );
+
+  // manual results not included
+  expect(batchPrecinctTallyReport.manualResults).toBeUndefined();
+
+  // scanned results still correct, correctly handling write-ins
+  expect(batchPrecinctTallyReport.scannedResults).toEqual(
+    precinctTallyReport.scannedResults
   );
 });

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -35,6 +35,7 @@ import {
   BALLOT_PACKAGE_FOLDER,
   CAST_VOTE_RECORD_REPORT_FILENAME,
   generateFilenameForBallotExportPackage,
+  groupMapToGroupList,
   isIntegrationTest,
   parseCastVoteRecordReportDirectoryName,
 } from '@votingworks/utils';
@@ -692,7 +693,7 @@ function buildApi({
       groupBy: Tabulation.GroupBy;
     }): Array<Tabulation.GroupOf<Tabulation.CardCounts>> {
       const electionId = loadCurrentElectionIdOrThrow(workspace);
-      return Object.values(
+      return groupMapToGroupList(
         tabulateFullCardCounts({
           electionId,
           store,

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -55,6 +55,7 @@ import {
   SemsExportableTallies,
   ServerFullElectionManualTally,
   SetSystemSettingsResult,
+  TallyReportResults,
   WriteInAdjudicationAction,
   WriteInAdjudicationStatus,
   WriteInCandidateRecord,
@@ -79,7 +80,10 @@ import {
 import { addFileToZipStream } from './util/zip';
 import { exportFile } from './util/export_file';
 import { generateBatchResultsFile } from './exports/batch_results';
-import { tabulateElectionResults } from './tabulation/full_results';
+import {
+  tabulateElectionResults,
+  tabulateTallyReportResults,
+} from './tabulation/full_results';
 import { getSemsExportableTallies } from './exports/sems_tallies';
 import { generateResultsCsv } from './exports/csv_results';
 import { tabulateFullCardCounts } from './tabulation/card_counts';
@@ -697,6 +701,23 @@ function buildApi({
         tabulateFullCardCounts({
           electionId,
           store,
+          groupBy: input.groupBy,
+        })
+      );
+    },
+
+    getResultsForTallyReports(
+      input: {
+        filter?: Tabulation.Filter;
+        groupBy?: Tabulation.GroupBy;
+      } = {}
+    ): Tabulation.GroupList<TallyReportResults> {
+      const electionId = loadCurrentElectionIdOrThrow(workspace);
+      return groupMapToGroupList(
+        tabulateTallyReportResults({
+          electionId,
+          store,
+          filter: input.filter,
           groupBy: input.groupBy,
         })
       );

--- a/apps/admin/backend/src/exports/batch_results.test.ts
+++ b/apps/admin/backend/src/exports/batch_results.test.ts
@@ -7,69 +7,63 @@ import { ScannerBatch } from '../types';
 
 test('generateBatchResultsFile', async () => {
   const { election } = electionMinimalExhaustiveSampleDefinition;
-  const batchGroupedResults: Tabulation.GroupedElectionResults = {
-    'root&batch-1': {
-      batchId: 'batch-1',
-      ...buildElectionResultsFixture({
-        election,
-        cardCounts: {
-          hmpb: [30, 29],
-          bmd: 5,
-        },
-        contestResultsSummaries: {
-          'zoo-council-mammal': {
-            type: 'candidate',
-            ballots: 35,
-            undervotes: 2,
-            overvotes: 3,
-            officialOptionTallies: {
-              lion: 25,
-              [writeInCandidate.id]: 5,
-            },
-          },
-          fishing: {
-            type: 'yesno',
-            ballots: 34,
-            undervotes: 1,
-            overvotes: 3,
-            yesTally: 25,
-            noTally: 5,
+  const batchGroupedResults: Tabulation.ElectionResultsGroupMap = {
+    'root&batchId=batch-1': buildElectionResultsFixture({
+      election,
+      cardCounts: {
+        hmpb: [30, 29],
+        bmd: 5,
+      },
+      contestResultsSummaries: {
+        'zoo-council-mammal': {
+          type: 'candidate',
+          ballots: 35,
+          undervotes: 2,
+          overvotes: 3,
+          officialOptionTallies: {
+            lion: 25,
+            [writeInCandidate.id]: 5,
           },
         },
-        includeGenericWriteIn: true,
-      }),
-    },
-    'root&batch-2': {
-      batchId: 'batch-2',
-      ...buildElectionResultsFixture({
-        election,
-        cardCounts: {
-          hmpb: [29, 29],
-          bmd: 1,
+        fishing: {
+          type: 'yesno',
+          ballots: 34,
+          undervotes: 1,
+          overvotes: 3,
+          yesTally: 25,
+          noTally: 5,
         },
-        contestResultsSummaries: {
-          'zoo-council-mammal': {
-            type: 'candidate',
-            ballots: 30,
-            undervotes: 1,
-            overvotes: 3,
-            officialOptionTallies: {
-              lion: 20,
-              [writeInCandidate.id]: 6,
-            },
-          },
-          fishing: {
-            type: 'yesno',
-            ballots: 30,
-            undervotes: 1,
-            overvotes: 5,
-            yesTally: 20,
-            noTally: 4,
+      },
+      includeGenericWriteIn: true,
+    }),
+    'root&batchId=batch-2': buildElectionResultsFixture({
+      election,
+      cardCounts: {
+        hmpb: [29, 29],
+        bmd: 1,
+      },
+      contestResultsSummaries: {
+        'zoo-council-mammal': {
+          type: 'candidate',
+          ballots: 30,
+          undervotes: 1,
+          overvotes: 3,
+          officialOptionTallies: {
+            lion: 20,
+            [writeInCandidate.id]: 6,
           },
         },
-        includeGenericWriteIn: true,
-      }),
-    },
+        fishing: {
+          type: 'yesno',
+          ballots: 30,
+          undervotes: 1,
+          overvotes: 5,
+          yesTally: 20,
+          noTally: 4,
+        },
+      },
+      includeGenericWriteIn: true,
+    }),
   };
 
   const allBatchMetadata: ScannerBatch[] = [

--- a/apps/admin/backend/src/exports/batch_results.ts
+++ b/apps/admin/backend/src/exports/batch_results.ts
@@ -1,7 +1,7 @@
 import { Election, Tabulation, writeInCandidate } from '@votingworks/types';
 import { assert } from '@votingworks/basics';
 import { Readable } from 'stream';
-import { getBallotCount } from '@votingworks/utils';
+import { getBallotCount, groupMapToGroupList } from '@votingworks/utils';
 // eslint-disable-next-line import/no-unresolved
 import { stringify } from 'csv-stringify/sync';
 import { ScannerBatch } from '../types';
@@ -99,9 +99,10 @@ export function generateBatchResultsFile({
   allBatchMetadata,
 }: {
   election: Election;
-  batchGroupedResults: Tabulation.GroupedElectionResults;
+  batchGroupedResults: Tabulation.ElectionResultsGroupMap;
   allBatchMetadata: ScannerBatch[];
 }): NodeJS.ReadableStream {
+  const electionResultsList = groupMapToGroupList(batchGroupedResults);
   const batchMetadataLookup: Record<string, ScannerBatch> = {};
   for (const batchMetadata of allBatchMetadata) {
     batchMetadataLookup[batchMetadata.batchId] = batchMetadata;
@@ -110,7 +111,7 @@ export function generateBatchResultsFile({
   function* generateBatchResultsFileRows() {
     yield generateHeaderRow(election);
 
-    for (const batchResults of Object.values(batchGroupedResults)) {
+    for (const batchResults of electionResultsList) {
       // expect batch results to be grouped by batchId
       assert(batchResults.batchId !== undefined);
 

--- a/apps/admin/backend/src/exports/csv_results.test.ts
+++ b/apps/admin/backend/src/exports/csv_results.test.ts
@@ -8,12 +8,10 @@ import { WriteInCandidateRecord } from '../types';
 test('generateResultsCsv', async () => {
   const { election } =
     electionMinimalExhaustiveSampleFixtures.electionDefinition;
-  const electionResultsByPrecinctAndVotingMethod: Tabulation.GroupedElectionResults =
+  const electionResultsByPrecinctAndVotingMethod: Tabulation.ElectionResultsGroupMap =
     {
-      'root&precinct-1&absentee': {
-        precinctId: 'precinct-1',
-        votingMethod: 'absentee',
-        ...buildElectionResultsFixture({
+      'root&precinctId=precinct-1&votingMethod=absentee':
+        buildElectionResultsFixture({
           election,
           includeGenericWriteIn: true,
           cardCounts: {
@@ -39,11 +37,9 @@ test('generateResultsCsv', async () => {
             },
           },
         }),
-      },
-      'root&precinct-2&precinct': {
-        precinctId: 'precinct-2',
-        votingMethod: 'precinct',
-        ...buildElectionResultsFixture({
+
+      'root&precinctId=precinct-2&votingMethod=precinct':
+        buildElectionResultsFixture({
           election,
           includeGenericWriteIn: true,
           cardCounts: {
@@ -61,7 +57,6 @@ test('generateResultsCsv', async () => {
             },
           },
         }),
-      },
     };
 
   const writeInCandidates: WriteInCandidateRecord[] = [

--- a/apps/admin/backend/src/exports/csv_results.ts
+++ b/apps/admin/backend/src/exports/csv_results.ts
@@ -8,7 +8,10 @@ import {
   Tabulation,
 } from '@votingworks/types';
 import { assert, throwIllegalValue } from '@votingworks/basics';
-import { getEmptyElectionResults } from '@votingworks/utils';
+import {
+  getEmptyElectionResults,
+  groupMapToGroupList,
+} from '@votingworks/utils';
 import { Readable } from 'stream';
 import { WriteInCandidateRecord } from '../types';
 
@@ -58,14 +61,17 @@ function* generateRows({
   election,
   writeInCandidates,
 }: {
-  electionResultsByPrecinctAndVotingMethod: Tabulation.GroupedElectionResults;
+  electionResultsByPrecinctAndVotingMethod: Tabulation.ElectionResultsGroupMap;
   election: Election;
   writeInCandidates: WriteInCandidateRecord[];
 }): Generator<string> {
+  const electionResultsList = groupMapToGroupList(
+    electionResultsByPrecinctAndVotingMethod
+  );
   for (const precinct of election.precincts) {
     for (const votingMethod of INCLUDED_VOTING_METHODS) {
       const electionResults =
-        Object.values(electionResultsByPrecinctAndVotingMethod).find(
+        electionResultsList.find(
           (er) =>
             er.precinctId === precinct.id && er.votingMethod === votingMethod
         ) || getEmptyElectionResults(election);
@@ -171,7 +177,7 @@ export function generateResultsCsv({
   election,
   writeInCandidates,
 }: {
-  electionResultsByPrecinctAndVotingMethod: Tabulation.GroupedElectionResults;
+  electionResultsByPrecinctAndVotingMethod: Tabulation.ElectionResultsGroupMap;
   election: Election;
   writeInCandidates: WriteInCandidateRecord[];
 }): NodeJS.ReadableStream {

--- a/apps/admin/backend/src/exports/sems_tallies.ts
+++ b/apps/admin/backend/src/exports/sems_tallies.ts
@@ -1,5 +1,6 @@
 import { Tabulation } from '@votingworks/types';
 import { assert } from '@votingworks/basics';
+import { groupMapToGroupList } from '@votingworks/utils';
 import {
   SemsExportableContestTally,
   SemsExportableTallies,
@@ -42,10 +43,11 @@ function convertElectionResultsToSemsExportableTally(
  * Formats election results grouped by precinct to the format required by the SEMS converter.
  */
 export function getSemsExportableTallies(
-  electionResultsByPrecinct: Tabulation.GroupedElectionResults
+  electionResultsByPrecinct: Tabulation.ElectionResultsGroupMap
 ): SemsExportableTallies {
   const talliesByPrecinct: SemsExportableTallies['talliesByPrecinct'] = {};
-  for (const electionResults of Object.values(electionResultsByPrecinct)) {
+  const electionResultsList = groupMapToGroupList(electionResultsByPrecinct);
+  for (const electionResults of electionResultsList) {
     assert(electionResults.precinctId !== undefined);
     const { precinctId } = electionResults;
     talliesByPrecinct[precinctId] =

--- a/apps/admin/backend/src/tabulation/card_counts.test.ts
+++ b/apps/admin/backend/src/tabulation/card_counts.test.ts
@@ -82,63 +82,57 @@ test('tabulateScannedCardCounts - grouping', () => {
 
   const testCases: Array<{
     groupBy?: Tabulation.GroupBy;
-    expected: Array<
-      [
-        groupKey: Tabulation.GroupKey,
-        tally: number,
-        groupSpecifier: Tabulation.GroupSpecifier
-      ]
-    >;
+    expected: Array<[groupKey: Tabulation.GroupKey, tally: number]>;
   }> = [
     // no filter case
     {
-      expected: [['root', 83, {}]],
+      expected: [['root', 83]],
     },
     // each group case
     {
       groupBy: { groupByBallotStyle: true },
       expected: [
-        ['root&1M', 45, { ballotStyleId: '1M' }],
-        ['root&2F', 38, { ballotStyleId: '2F' }],
+        ['root&ballotStyleId=1M', 45],
+        ['root&ballotStyleId=2F', 38],
       ],
     },
     {
       groupBy: { groupByParty: true },
       expected: [
-        ['root&0', 45, { partyId: '0' }],
-        ['root&1', 38, { partyId: '1' }],
+        ['root&partyId=0', 45],
+        ['root&partyId=1', 38],
       ],
     },
     {
       groupBy: { groupByBatch: true },
       expected: [
-        ['root&batch-1-1', 11, { batchId: 'batch-1-1' }],
-        ['root&batch-1-2', 17, { batchId: 'batch-1-2' }],
-        ['root&batch-2-1', 9, { batchId: 'batch-2-1' }],
-        ['root&batch-2-2', 12, { batchId: 'batch-2-2' }],
-        ['root&batch-3-1', 34, { batchId: 'batch-3-1' }],
+        ['root&batchId=batch-1-1', 11],
+        ['root&batchId=batch-1-2', 17],
+        ['root&batchId=batch-2-1', 9],
+        ['root&batchId=batch-2-2', 12],
+        ['root&batchId=batch-3-1', 34],
       ],
     },
     {
       groupBy: { groupByScanner: true },
       expected: [
-        ['root&scanner-1', 28, { scannerId: 'scanner-1' }],
-        ['root&scanner-2', 21, { scannerId: 'scanner-2' }],
-        ['root&scanner-3', 34, { scannerId: 'scanner-3' }],
+        ['root&scannerId=scanner-1', 28],
+        ['root&scannerId=scanner-2', 21],
+        ['root&scannerId=scanner-3', 34],
       ],
     },
     {
       groupBy: { groupByPrecinct: true },
       expected: [
-        ['root&precinct-1', 28, { precinctId: 'precinct-1' }],
-        ['root&precinct-2', 55, { precinctId: 'precinct-2' }],
+        ['root&precinctId=precinct-1', 28],
+        ['root&precinctId=precinct-2', 55],
       ],
     },
     {
       groupBy: { groupByVotingMethod: true },
       expected: [
-        ['root&precinct', 68, { votingMethod: 'precinct' }],
-        ['root&absentee', 15, { votingMethod: 'absentee' }],
+        ['root&votingMethod=precinct', 68],
+        ['root&votingMethod=absentee', 15],
       ],
     },
   ];
@@ -150,11 +144,10 @@ test('tabulateScannedCardCounts - grouping', () => {
       groupBy,
     });
 
-    for (const [groupKey, tally, groupSpecifier] of expected) {
+    for (const [groupKey, tally] of expected) {
       expect(groupedCardCounts[groupKey]).toEqual({
         bmd: tally,
         hmpb: [],
-        ...groupSpecifier,
       });
     }
 
@@ -219,9 +212,8 @@ test('tabulateScannedCardCounts - merging card tallies', () => {
       electionId,
       store,
       groupBy: { groupByScanner: true },
-    })['root&scanner-1']
+    })['root&scannerId=scanner-1']
   ).toEqual({
-    scannerId: 'scanner-1',
     bmd: 5,
     hmpb: [6, 7],
   });

--- a/apps/admin/backend/src/tabulation/card_counts.ts
+++ b/apps/admin/backend/src/tabulation/card_counts.ts
@@ -6,6 +6,7 @@ import {
   getEmptyCardCounts,
   getGroupKey,
   isGroupByEmpty,
+  mergeTabulationGroups,
 } from '@votingworks/utils';
 import { CardTally } from '../types';
 import { Store } from '../store';
@@ -128,21 +129,14 @@ export function tabulateFullCardCounts({
 
   const groupedManualBallotCounts = tabulateManualBallotCountsResult.ok();
 
-  const groupedFullCardCounts: Tabulation.GroupedCardCounts = {};
-
-  const allKeys = [
-    ...new Set([
-      ...Object.keys(groupedScannedCardCounts),
-      ...Object.keys(groupedManualBallotCounts),
-    ]),
-  ];
-
-  for (const key of allKeys) {
-    groupedFullCardCounts[key] = {
-      ...(groupedScannedCardCounts[key] ?? getEmptyCardCounts()),
-      manual: groupedManualBallotCounts[key]?.ballotCount ?? 0,
-    };
-  }
-
-  return groupedFullCardCounts;
+  return mergeTabulationGroups(
+    groupedScannedCardCounts,
+    groupedManualBallotCounts,
+    (scannedCardCounts, manualBallotCount) => {
+      return {
+        ...(scannedCardCounts ?? getEmptyCardCounts()),
+        manual: manualBallotCount?.ballotCount ?? 0,
+      };
+    }
+  );
 }

--- a/apps/admin/backend/src/tabulation/full_results.test.ts
+++ b/apps/admin/backend/src/tabulation/full_results.test.ts
@@ -143,98 +143,92 @@ test('tabulateCastVoteRecords', () => {
   const testCases: Array<{
     filter?: Tabulation.Filter;
     groupBy?: Tabulation.GroupBy;
-    expected: Array<
-      [
-        groupKey: Tabulation.GroupKey,
-        tally: number,
-        groupSpecifier: Tabulation.GroupSpecifier
-      ]
-    >;
+    expected: Array<[groupKey: Tabulation.GroupKey, tally: number]>;
   }> = [
     // no filter case
     {
-      expected: [['root', 83, {}]],
+      expected: [['root', 83]],
     },
     // each filter case
     {
       filter: { precinctIds: ['precinct-2'] },
-      expected: [['root', 55, {}]],
+      expected: [['root', 55]],
     },
     {
       filter: { scannerIds: ['scanner-2'] },
-      expected: [['root', 21, {}]],
+      expected: [['root', 21]],
     },
     {
       filter: { batchIds: ['batch-2-1', 'batch-3-1'] },
-      expected: [['root', 43, {}]],
+      expected: [['root', 43]],
     },
     {
       filter: { votingMethods: ['precinct'] },
-      expected: [['root', 68, {}]],
+      expected: [['root', 68]],
     },
     {
       filter: { ballotStyleIds: ['1M'] },
-      expected: [['root', 45, {}]],
+      expected: [['root', 45]],
     },
     {
       filter: { partyIds: ['0'] },
-      expected: [['root', 45, {}]],
+      expected: [['root', 45]],
     },
     // empty filter case
     {
       filter: { partyIds: [] },
-      expected: [['root', 0, {}]],
+      expected: [['root', 0]],
     },
     // trivial filter case
     {
       filter: { partyIds: ['0', '1'] },
-      expected: [['root', 83, {}]],
+      expected: [['root', 83]],
     },
     // each group case
     {
       groupBy: { groupByBallotStyle: true },
       expected: [
-        ['root&1M', 45, { ballotStyleId: '1M' }],
-        ['root&2F', 38, { ballotStyleId: '2F' }],
+        ['root&ballotStyleId=1M', 45],
+        ['root&ballotStyleId=2F', 38],
       ],
     },
     {
       groupBy: { groupByParty: true },
       expected: [
-        ['root&0', 45, { partyId: '0' }],
-        ['root&1', 38, { partyId: '1' }],
+        ['root&partyId=0', 45],
+        ['root&partyId=1', 38],
       ],
     },
     {
       groupBy: { groupByBatch: true },
       expected: [
-        ['root&batch-1-1', 11, { batchId: 'batch-1-1' }],
-        ['root&batch-1-2', 17, { batchId: 'batch-1-2' }],
-        ['root&batch-2-1', 9, { batchId: 'batch-2-1' }],
-        ['root&batch-2-2', 12, { batchId: 'batch-2-2' }],
-        ['root&batch-3-1', 34, { batchId: 'batch-3-1' }],
+        ['root&batchId=batch-1-1', 11],
+        ['root&batchId=batch-1-2', 17],
+        ['root&batchId=batch-2-1', 9],
+        ['root&batchId=batch-2-2', 12],
+        ['root&batchId=batch-3-1', 34],
       ],
     },
     {
       groupBy: { groupByScanner: true },
       expected: [
-        ['root&scanner-1', 28, { scannerId: 'scanner-1' }],
-        ['root&scanner-2', 21, { scannerId: 'scanner-2' }],
-        ['root&scanner-3', 34, { scannerId: 'scanner-3' }],
+        ['root&scannerId=scanner-1', 28],
+        ['root&scannerId=scanner-2', 21],
+        ['root&scannerId=scanner-3', 34],
       ],
     },
     {
       groupBy: { groupByPrecinct: true },
       expected: [
-        ['root&precinct-1', 28, { precinctId: 'precinct-1' }],
-        ['root&precinct-2', 55, { precinctId: 'precinct-2' }],
+        ['root&precinctId=precinct-1', 28],
+        ['root&precinctId=precinct-2', 55],
       ],
     },
     {
       groupBy: { groupByVotingMethod: true },
       expected: [
-        ['root&precinct', 68, { votingMethod: 'precinct' }],
-        ['root&absentee', 15, { votingMethod: 'absentee' }],
+        ['root&votingMethod=precinct', 68],
+        ['root&votingMethod=absentee', 15],
       ],
     },
   ];
@@ -247,11 +241,10 @@ test('tabulateCastVoteRecords', () => {
       groupBy,
     });
 
-    for (const [groupKey, tally, groupSpecifier] of expected) {
-      expect(groupedWriteInSummaries[groupKey]).toEqual({
-        ...getMockElectionResults(tally),
-        ...groupSpecifier,
-      });
+    for (const [groupKey, tally] of expected) {
+      expect(groupedWriteInSummaries[groupKey]).toEqual(
+        getMockElectionResults(tally)
+      );
     }
 
     expect(Object.values(groupedWriteInSummaries)).toHaveLength(
@@ -685,8 +678,8 @@ test('tabulateElectionResults - group and filter by voting method', async () => 
     groupBy: { groupByVotingMethod: true },
     includeWriteInAdjudicationResults: true,
   });
-  const absenteeResultsGroup = groupedResults['root&absentee'];
-  const precinctResultsGroup = groupedResults['root&precinct'];
+  const absenteeResultsGroup = groupedResults['root&votingMethod=absentee'];
+  const precinctResultsGroup = groupedResults['root&votingMethod=precinct'];
   assert(absenteeResultsGroup && precinctResultsGroup);
 
   expect(absenteeResultsGroup.cardCounts).toEqual(
@@ -695,7 +688,6 @@ test('tabulateElectionResults - group and filter by voting method', async () => 
   expect(absenteeResultsGroup.contestResults[candidateContestId]).toEqual(
     partialExpectedResults.contestResults[candidateContestId]
   );
-  expect(absenteeResultsGroup.votingMethod).toEqual('absentee');
 
   expect(precinctResultsGroup.cardCounts).toEqual(
     partialExpectedResults.cardCounts
@@ -703,7 +695,6 @@ test('tabulateElectionResults - group and filter by voting method', async () => 
   expect(precinctResultsGroup.contestResults[candidateContestId]).toEqual(
     partialExpectedResults.contestResults[candidateContestId]
   );
-  expect(precinctResultsGroup.votingMethod).toEqual('precinct');
 
   // if we add manual data, it will be selectively incorporated
   store.setManualResults({

--- a/apps/admin/backend/src/tabulation/manual_results.test.ts
+++ b/apps/admin/backend/src/tabulation/manual_results.test.ts
@@ -177,34 +177,28 @@ describe('tabulateManualResults & tabulateManualBallotCounts', () => {
     const testCases: Array<{
       filter?: ManualResultsFilter;
       groupBy?: ManualResultsGroupBy;
-      expected: Array<
-        [
-          groupKey: Tabulation.GroupKey,
-          tally: number,
-          groupSpecifier: Tabulation.GroupSpecifier
-        ]
-      >;
+      expected: Array<[groupKey: Tabulation.GroupKey, tally: number]>;
     }> = [
       // no filter or group case
       {
-        expected: [['root', 114, {}]],
+        expected: [['root', 114]],
       },
       // each filter case
       {
         filter: { precinctIds: ['precinct-1'] },
-        expected: [['root', 36, {}]],
+        expected: [['root', 36]],
       },
       {
         filter: { ballotStyleIds: ['1M'] },
-        expected: [['root', 47, {}]],
+        expected: [['root', 47]],
       },
       {
         filter: { partyIds: ['0'] },
-        expected: [['root', 47, {}]],
+        expected: [['root', 47]],
       },
       {
         filter: { votingMethods: ['precinct'] },
-        expected: [['root', 50, {}]],
+        expected: [['root', 50]],
       },
       // empty filter case
       {
@@ -214,87 +208,55 @@ describe('tabulateManualResults & tabulateManualBallotCounts', () => {
       // trivial filter case
       {
         filter: { votingMethods: ['precinct', 'absentee'] },
-        expected: [['root', 114, {}]],
+        expected: [['root', 114]],
       },
       // each grouping case
       {
         groupBy: { groupByBallotStyle: true },
         expected: [
-          ['root&1M', 47, { ballotStyleId: '1M' }],
-          ['root&2F', 67, { ballotStyleId: '2F' }],
+          ['root&ballotStyleId=1M', 47],
+          ['root&ballotStyleId=2F', 67],
         ],
       },
       {
         groupBy: { groupByParty: true },
         expected: [
-          ['root&0', 47, { partyId: '0' }],
-          ['root&1', 67, { partyId: '1' }],
+          ['root&partyId=0', 47],
+          ['root&partyId=1', 67],
         ],
       },
       {
         groupBy: { groupByPrecinct: true },
         expected: [
-          ['root&precinct-1', 36, { precinctId: 'precinct-1' }],
-          ['root&precinct-2', 78, { precinctId: 'precinct-2' }],
+          ['root&precinctId=precinct-1', 36],
+          ['root&precinctId=precinct-2', 78],
         ],
       },
       {
         groupBy: { groupByVotingMethod: true },
         expected: [
-          ['root&precinct', 50, { votingMethod: 'precinct' }],
-          ['root&absentee', 64, { votingMethod: 'absentee' }],
+          ['root&votingMethod=precinct', 50],
+          ['root&votingMethod=absentee', 64],
         ],
       },
       // composite filter & group cases
       {
         groupBy: { groupByVotingMethod: true, groupByPrecinct: true },
         expected: [
-          [
-            'root&precinct-1&precinct',
-            11,
-            { precinctId: 'precinct-1', votingMethod: 'precinct' },
-          ],
-          [
-            'root&precinct-1&absentee',
-            25,
-            { precinctId: 'precinct-1', votingMethod: 'absentee' },
-          ],
-          [
-            'root&precinct-2&precinct',
-            39,
-            { precinctId: 'precinct-2', votingMethod: 'precinct' },
-          ],
-          [
-            'root&precinct-2&absentee',
-            39,
-            { precinctId: 'precinct-2', votingMethod: 'absentee' },
-          ],
+          ['root&precinctId=precinct-1&votingMethod=precinct', 11],
+          ['root&precinctId=precinct-1&votingMethod=absentee', 25],
+          ['root&precinctId=precinct-2&votingMethod=precinct', 39],
+          ['root&precinctId=precinct-2&votingMethod=absentee', 39],
         ],
       },
       {
         filter: { ballotStyleIds: ['1M'] },
         groupBy: { groupByVotingMethod: true, groupByPrecinct: true },
         expected: [
-          [
-            'root&precinct-1&precinct',
-            3,
-            { precinctId: 'precinct-1', votingMethod: 'precinct' },
-          ],
-          [
-            'root&precinct-1&absentee',
-            11,
-            { precinctId: 'precinct-1', votingMethod: 'absentee' },
-          ],
-          [
-            'root&precinct-2&precinct',
-            18,
-            { precinctId: 'precinct-2', votingMethod: 'precinct' },
-          ],
-          [
-            'root&precinct-2&absentee',
-            15,
-            { precinctId: 'precinct-2', votingMethod: 'absentee' },
-          ],
+          ['root&precinctId=precinct-1&votingMethod=precinct', 3],
+          ['root&precinctId=precinct-1&votingMethod=absentee', 11],
+          ['root&precinctId=precinct-2&votingMethod=precinct', 18],
+          ['root&precinctId=precinct-2&votingMethod=absentee', 15],
         ],
       },
     ];
@@ -308,11 +270,10 @@ describe('tabulateManualResults & tabulateManualBallotCounts', () => {
       });
       assert(result.isOk());
 
-      for (const [groupKey, ballotCount, groupSpecifier] of expected) {
-        expect(result.ok()[groupKey]).toEqual({
-          ...groupSpecifier,
-          ...getSimpleManualResultsFixture(ballotCount),
-        });
+      for (const [groupKey, ballotCount] of expected) {
+        expect(result.ok()[groupKey]).toEqual(
+          getSimpleManualResultsFixture(ballotCount)
+        );
       }
 
       expect(Object.values(result.ok())).toHaveLength(
@@ -332,11 +293,8 @@ describe('tabulateManualResults & tabulateManualBallotCounts', () => {
       });
       assert(result.isOk());
 
-      for (const [groupKey, ballotCount, groupSpecifier] of expected) {
-        expect(result.ok()[groupKey]).toEqual({
-          ...groupSpecifier,
-          ballotCount,
-        });
+      for (const [groupKey, ballotCount] of expected) {
+        expect(result.ok()[groupKey]).toEqual(ballotCount);
       }
 
       expect(Object.values(result.ok())).toHaveLength(

--- a/apps/admin/backend/src/tabulation/write_ins.test.ts
+++ b/apps/admin/backend/src/tabulation/write_ins.test.ts
@@ -232,98 +232,92 @@ test('tabulateWriteInTallies', () => {
   const testCases: Array<{
     filter?: Tabulation.Filter;
     groupBy?: Tabulation.GroupBy;
-    expected: Array<
-      [
-        groupKey: Tabulation.GroupKey,
-        tally: number,
-        groupSpecifier: Tabulation.GroupSpecifier
-      ]
-    >;
+    expected: Array<[groupKey: Tabulation.GroupKey, tally: number]>;
   }> = [
     // no filter case
     {
-      expected: [['root', 83, {}]],
+      expected: [['root', 83]],
     },
     // each filter case
     {
       filter: { precinctIds: ['precinct-2'] },
-      expected: [['root', 55, {}]],
+      expected: [['root', 55]],
     },
     {
       filter: { scannerIds: ['scanner-2'] },
-      expected: [['root', 21, {}]],
+      expected: [['root', 21]],
     },
     {
       filter: { batchIds: ['batch-2-1', 'batch-3-1'] },
-      expected: [['root', 43, {}]],
+      expected: [['root', 43]],
     },
     {
       filter: { votingMethods: ['precinct'] },
-      expected: [['root', 68, {}]],
+      expected: [['root', 68]],
     },
     {
       filter: { ballotStyleIds: ['1M'] },
-      expected: [['root', 45, {}]],
+      expected: [['root', 45]],
     },
     {
       filter: { partyIds: ['0'] },
-      expected: [['root', 45, {}]],
+      expected: [['root', 45]],
     },
     // empty filter case
     {
       filter: { partyIds: [] },
-      expected: [['root', 0, {}]],
+      expected: [['root', 0]],
     },
     // trivial filter case
     {
       filter: { partyIds: ['0', '1'] },
-      expected: [['root', 83, {}]],
+      expected: [['root', 83]],
     },
     // each group case
     {
       groupBy: { groupByBallotStyle: true },
       expected: [
-        ['root&1M', 45, { ballotStyleId: '1M' }],
-        ['root&2F', 38, { ballotStyleId: '2F' }],
+        ['root&ballotStyleId=1M', 45],
+        ['root&ballotStyleId=2F', 38],
       ],
     },
     {
       groupBy: { groupByParty: true },
       expected: [
-        ['root&0', 45, { partyId: '0' }],
-        ['root&1', 38, { partyId: '1' }],
+        ['root&partyId=0', 45],
+        ['root&partyId=1', 38],
       ],
     },
     {
       groupBy: { groupByBatch: true },
       expected: [
-        ['root&batch-1-1', 11, { batchId: 'batch-1-1' }],
-        ['root&batch-1-2', 17, { batchId: 'batch-1-2' }],
-        ['root&batch-2-1', 9, { batchId: 'batch-2-1' }],
-        ['root&batch-2-2', 12, { batchId: 'batch-2-2' }],
-        ['root&batch-3-1', 34, { batchId: 'batch-3-1' }],
+        ['root&batchId=batch-1-1', 11],
+        ['root&batchId=batch-1-2', 17],
+        ['root&batchId=batch-2-1', 9],
+        ['root&batchId=batch-2-2', 12],
+        ['root&batchId=batch-3-1', 34],
       ],
     },
     {
       groupBy: { groupByScanner: true },
       expected: [
-        ['root&scanner-1', 28, { scannerId: 'scanner-1' }],
-        ['root&scanner-2', 21, { scannerId: 'scanner-2' }],
-        ['root&scanner-3', 34, { scannerId: 'scanner-3' }],
+        ['root&scannerId=scanner-1', 28],
+        ['root&scannerId=scanner-2', 21],
+        ['root&scannerId=scanner-3', 34],
       ],
     },
     {
       groupBy: { groupByPrecinct: true },
       expected: [
-        ['root&precinct-1', 28, { precinctId: 'precinct-1' }],
-        ['root&precinct-2', 55, { precinctId: 'precinct-2' }],
+        ['root&precinctId=precinct-1', 28],
+        ['root&precinctId=precinct-2', 55],
       ],
     },
     {
       groupBy: { groupByVotingMethod: true },
       expected: [
-        ['root&precinct', 68, { votingMethod: 'precinct' }],
-        ['root&absentee', 15, { votingMethod: 'absentee' }],
+        ['root&votingMethod=precinct', 68],
+        ['root&votingMethod=absentee', 15],
       ],
     },
   ];
@@ -336,11 +330,10 @@ test('tabulateWriteInTallies', () => {
       groupBy,
     });
 
-    for (const [groupKey, tally, groupSpecifier] of expected) {
-      expect(groupedWriteInSummaries[groupKey]).toEqual({
-        ...getMockElectionWriteInSummary(tally),
-        ...groupSpecifier,
-      });
+    for (const [groupKey, tally] of expected) {
+      expect(groupedWriteInSummaries[groupKey]).toEqual(
+        getMockElectionWriteInSummary(tally)
+      );
     }
 
     expect(Object.values(groupedWriteInSummaries)).toHaveLength(

--- a/apps/admin/backend/src/tabulation/write_ins.ts
+++ b/apps/admin/backend/src/tabulation/write_ins.ts
@@ -163,7 +163,7 @@ export function tabulateWriteInTallies({
   store: Store;
   filter?: Tabulation.Filter;
   groupBy?: Tabulation.GroupBy;
-}): Tabulation.Grouped<ElectionWriteInSummary> {
+}): Tabulation.GroupMap<ElectionWriteInSummary> {
   const {
     electionDefinition: { election },
   } = assertDefined(store.getElection(electionId));
@@ -175,10 +175,8 @@ export function tabulateWriteInTallies({
     groupBy,
   });
 
-  const groupedElectionWriteInSummaries: Record<
-    string,
-    ElectionWriteInSummary
-  > = {};
+  const electionWriteInSummaryGroupMap: Record<string, ElectionWriteInSummary> =
+    {};
 
   // optimized special case, when the results do not need to be grouped
   if (!groupBy || isGroupByEmpty(groupBy)) {
@@ -189,28 +187,25 @@ export function tabulateWriteInTallies({
         electionWriteInSummary,
       });
     }
-    groupedElectionWriteInSummaries[GROUP_KEY_ROOT] = electionWriteInSummary;
-    return groupedElectionWriteInSummaries;
+    electionWriteInSummaryGroupMap[GROUP_KEY_ROOT] = electionWriteInSummary;
+    return electionWriteInSummaryGroupMap;
   }
 
   // general case, grouping results by specified group by clause
   for (const writeInTally of writeInTallies) {
     const groupKey = getGroupKey(writeInTally, groupBy);
 
-    const existingSummary = groupedElectionWriteInSummaries[groupKey];
-    const summary = existingSummary ?? {
-      ...getEmptyElectionWriteInSummary(election),
-      ...extractGroupSpecifier(writeInTally),
-    };
+    const existingSummary = electionWriteInSummaryGroupMap[groupKey];
+    const summary = existingSummary ?? getEmptyElectionWriteInSummary(election);
 
-    groupedElectionWriteInSummaries[groupKey] =
+    electionWriteInSummaryGroupMap[groupKey] =
       addWriteInTallyToElectionWriteInSummary({
         writeInTally,
         electionWriteInSummary: summary,
       });
   }
 
-  return groupedElectionWriteInSummaries;
+  return electionWriteInSummaryGroupMap;
 }
 
 /**

--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -516,3 +516,11 @@ export interface CardTally {
   card: Tabulation.Card;
   tally: number;
 }
+
+/**
+ * Results that inform a tally report.
+ */
+export interface TallyReportResults {
+  scannedResults: Tabulation.ElectionResults;
+  manualResults?: Tabulation.ManualElectionResults;
+}

--- a/libs/types/src/tabulation.ts
+++ b/libs/types/src/tabulation.ts
@@ -81,8 +81,10 @@ export type Card = { type: 'bmd' } | { type: 'hmpb'; sheetNumber: number };
  * In situations where we're generating grouped results, specifiers can be
  * included in {@link ElectionResults} to indicate what it is a grouping of.
  */
-export type GroupSpecifier = Partial<CastVoteRecordAttributes> & {
-  readonly partyId?: Id;
+export type GroupSpecifier = Partial<{
+  -readonly [K in keyof CastVoteRecordAttributes]: CastVoteRecordAttributes[K];
+}> & {
+  partyId?: Id;
 };
 
 /**
@@ -124,11 +126,22 @@ export interface ElectionResults {
 }
 
 export type GroupKey = string;
-export type GroupOf<T> = T & GroupSpecifier;
-export type Grouped<T> = Record<GroupKey, GroupOf<T>>;
+/**
+ * Simply a map of keys to some values relevant to tabulation. The keys contain encoded
+ * metadata about the group, defined in `libs/utils`. The consumer can convert the
+ * {@link GroupMap} to a {@link GroupList}.
+ */
+export type GroupMap<T> = Record<GroupKey, T>;
 
-export type GroupedElectionResults = Grouped<ElectionResults>;
-export type GroupedCardCounts = Grouped<CardCounts>;
+export type GroupOf<T> = T & GroupSpecifier;
+/**
+ * A {@link GroupList} is a list of objects relevant to tabulation with metadata
+ * as part of each object identifying the group.
+ */
+export type GroupList<T> = Array<GroupOf<T>>;
+
+export type ElectionResultsGroupMap = GroupMap<ElectionResults>;
+export type ElectionResultsGroupList = GroupList<ElectionResults>;
 
 /**
  * Simplified representation of votes on a scanned ballot for tabulation
@@ -149,7 +162,7 @@ export type CastVoteRecord = {
 export type ManualElectionResults = Omit<ElectionResults, 'cardCounts'> & {
   ballotCount: number;
 };
+export type ManualResultsGroupMap = GroupMap<ManualElectionResults>;
+export type ManualResultsGroupList = GroupList<ManualElectionResults>;
 
-export type GroupedManualBallotCounts = Grouped<{
-  ballotCount: number;
-}>;
+export type ManualBallotCountsGroupMap = GroupMap<number>;

--- a/libs/utils/src/tabulation.test.ts
+++ b/libs/utils/src/tabulation.test.ts
@@ -31,6 +31,7 @@ import {
   convertManualElectionResults,
   combineElectionResults,
   mergeManualWriteInTallies,
+  mergeTabulationGroups,
 } from './tabulation';
 import { CAST_VOTE_RECORD_REPORT_FILENAME } from './filenames';
 import {
@@ -1125,4 +1126,47 @@ test('mergeManualWriteInTallies', () => {
       },
     })
   );
+});
+
+test('mergeTabulationGroups', () => {
+  const revenues: Tabulation.Grouped<{ count: number }> = {
+    a: {
+      count: 5,
+    },
+    b: {
+      count: 10,
+    },
+    c: {
+      count: 15,
+    },
+    e: {
+      count: 20,
+    },
+  };
+
+  const expenses: Tabulation.Grouped<{ count: number }> = {
+    b: {
+      count: 7,
+    },
+    c: {
+      count: 14,
+    },
+    d: {
+      count: 21,
+    },
+  };
+
+  expect(
+    mergeTabulationGroups(
+      revenues,
+      expenses,
+      (revenue, expense) => (revenue?.count ?? 0) - (expense?.count ?? 0)
+    )
+  ).toEqual({
+    a: 5,
+    b: 3,
+    c: 1,
+    d: -21,
+    e: 20,
+  });
 });

--- a/libs/utils/src/tabulation.test.ts
+++ b/libs/utils/src/tabulation.test.ts
@@ -30,7 +30,7 @@ import {
   combineCardCounts,
   convertManualElectionResults,
   combineElectionResults,
-  mergeManualWriteInTallies,
+  mergeWriteInTallies,
   mergeTabulationGroupMaps,
   getGroupKey,
   getGroupSpecifierFromGroupKey,
@@ -1110,7 +1110,7 @@ test('mergeManualWriteInTallies', () => {
   const { election } = electionMinimalExhaustiveSampleDefinition;
 
   expect(
-    mergeManualWriteInTallies(
+    mergeWriteInTallies(
       buildManualResultsFixture({
         election,
         ballotCount: 7,

--- a/libs/utils/src/tabulation.ts
+++ b/libs/utils/src/tabulation.ts
@@ -741,3 +741,21 @@ export function mergeManualWriteInTallies(
     contestResults: newElectionContestResults,
   };
 }
+
+export function mergeTabulationGroups<T, U, V>(
+  groupedT: Tabulation.Grouped<T>,
+  groupedU: Tabulation.Grouped<U>,
+  merge: (
+    t?: Tabulation.GroupOf<T>,
+    u?: Tabulation.GroupOf<U>
+  ) => Tabulation.GroupOf<V>
+): Tabulation.Grouped<V> {
+  const merged: Tabulation.Grouped<V> = {};
+  const allGroupKeys = [
+    ...new Set([...Object.keys(groupedT), ...Object.keys(groupedU)]),
+  ];
+  for (const groupKey of allGroupKeys) {
+    merged[groupKey] = merge(groupedT[groupKey], groupedU[groupKey]);
+  }
+  return merged;
+}

--- a/libs/utils/src/tabulation.ts
+++ b/libs/utils/src/tabulation.ts
@@ -785,16 +785,16 @@ export function buildElectionResultsFixture({
 }
 
 /**
- * Combine all specific write-ins entered for manual results into a single
+ * Combine all specific write-ins for specific candidates into a single
  * generic write-in tally.
  */
-export function mergeManualWriteInTallies(
-  manualResults: Tabulation.ManualElectionResults
-): Tabulation.ManualElectionResults {
+export function mergeWriteInTallies<
+  T extends Pick<Tabulation.ElectionResults, 'contestResults'>
+>(anyResults: T): T {
   const newElectionContestResults: Tabulation.ManualElectionResults['contestResults'] =
     {};
 
-  for (const contestResults of Object.values(manualResults.contestResults)) {
+  for (const contestResults of Object.values(anyResults.contestResults)) {
     if (contestResults.contestType === 'yesno') {
       newElectionContestResults[contestResults.contestId] = contestResults;
       continue;
@@ -825,7 +825,8 @@ export function mergeManualWriteInTallies(
   }
 
   return {
-    ...manualResults,
+    // eslint-disable-next-line vx/gts-spread-like-types
+    ...anyResults,
     contestResults: newElectionContestResults,
   };
 }


### PR DESCRIPTION
_highly recommend commit-by-commit review_

## Overview

Part of #3452. Adds methods to get data for tally report from the frontend. Specifically, that is: scanned results with write-in adjudication information, but write-ins grouped and, separately, manual results. 

The first two commits are refactors of the tabulation infrastructure that I've been building. The first adds a helper to help merge tabulation groups. The second is a bigger change - tabulation groups are now keyed with keys that can be converted into their group specifiers, so it's not required that the groups always maintain group specifiers. This was beginning to look like a footgun - e.g. you merge some tabulation groups and forget to include the `precinctId` labels, making the groups impossible to distinguish at the end of the tabulation pipeline.
