### PR TITLE
grout: Increase request size limit

### DIFF
--- a/libs/grout/src/server.ts
+++ b/libs/grout/src/server.ts
@@ -120,7 +120,12 @@ export function buildRouter(
   express: typeof Express
 ): Express.Router {
   const router = express.Router();
-  router.use(express.text({ type: 'application/json' }));
+  router.use(
+    express.text({
+      type: 'application/json',
+      limit: '10mb', // Allow large-ish payloads like election definitions
+    })
+  );
 
   for (const [methodName, method] of Object.entries<AnyRpcMethod>(api)) {
     const path = `/${methodName}`;


### PR DESCRIPTION


## Overview

Fixes #3592 

Quick fix for a bug where VxAdmin couldn't load large election definitions. In the long term, it might not be necessary to support large request payloads in Grout, since we generally try to process large data on the backend. But this will temporarily resolve the blocking issue for today.

## Demo Video or Screenshot
N/A

## Testing Plan
Manually tested

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
