### PR TITLE
[VxAdmin] VVSG Design Updates: UnconfiguredScreen

### DIFF
--- a/apps/admin/frontend/src/screens/unconfigured_screen.tsx
+++ b/apps/admin/frontend/src/screens/unconfigured_screen.tsx
@@ -8,14 +8,7 @@ import React, {
 import { useHistory } from 'react-router-dom';
 
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
-import {
-  Button,
-  Font,
-  Icons,
-  P,
-  Prose,
-  useMountedState,
-} from '@votingworks/ui';
+import { Button, Font, Icons, P, useMountedState } from '@votingworks/ui';
 import { assert } from '@votingworks/basics';
 
 import type { ConfigureResult } from '@votingworks/admin-backend';
@@ -304,7 +297,7 @@ export function UnconfiguredScreen(): JSX.Element {
         centerChild
         title={`Convert from ${client?.getDisplayName()} files`}
       >
-        <Prose textCenter>
+        <Font align="center">
           <P> Select the following files from a USB drive, etc.</P>
           {inputConversionFiles.map((file) =>
             file.path ? (
@@ -346,14 +339,14 @@ export function UnconfiguredScreen(): JSX.Element {
               Back
             </Button>
           </P>
-        </Prose>
+        </Font>
       </NavigationScreen>
     );
   }
 
   return (
     <NavigationScreen centerChild title="Configure VxAdmin">
-      <Prose textCenter>
+      <Font align="center">
         <P>How would you like to start?</P>
         {vxElectionFileIsInvalid && (
           <P>
@@ -400,7 +393,7 @@ export function UnconfiguredScreen(): JSX.Element {
             Load Demo Election Definition
           </Button>
         </P>
-      </Prose>
+      </Font>
     </NavigationScreen>
   );
 }

--- a/apps/admin/frontend/src/screens/unconfigured_screen.tsx
+++ b/apps/admin/frontend/src/screens/unconfigured_screen.tsx
@@ -6,10 +6,16 @@ import React, {
   useMemo,
 } from 'react';
 import { useHistory } from 'react-router-dom';
-import styled from 'styled-components';
 
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
-import { Button, Prose, useMountedState } from '@votingworks/ui';
+import {
+  Button,
+  Font,
+  Icons,
+  P,
+  Prose,
+  useMountedState,
+} from '@votingworks/ui';
 import { assert } from '@votingworks/basics';
 
 import type { ConfigureResult } from '@votingworks/admin-backend';
@@ -31,21 +37,6 @@ import { HorizontalRule } from '../components/horizontal_rule';
 import { Loading } from '../components/loading';
 import { NavigationScreen } from '../components/navigation_screen';
 import { configure, setSystemSettings } from '../api';
-
-const Loaded = styled.p`
-  line-height: 2.5rem;
-  color: rgb(0, 128, 0);
-  &::before {
-    content: '✓ ';
-  }
-`;
-const Invalid = styled.p`
-  line-height: 2.5rem;
-  color: rgb(128, 0, 0);
-  &::before {
-    content: '✘ ';
-  }
-`;
 
 interface InputFile {
   name: string;
@@ -314,12 +305,17 @@ export function UnconfiguredScreen(): JSX.Element {
         title={`Convert from ${client?.getDisplayName()} files`}
       >
         <Prose textCenter>
-          <p> Select the following files from a USB drive, etc.</p>
+          <P> Select the following files from a USB drive, etc.</P>
           {inputConversionFiles.map((file) =>
             file.path ? (
-              <Loaded key={file.name}>{`Loaded ${file.name}`}</Loaded>
+              <P key={file.name}>
+                <Font color="success">
+                  <Icons.Checkbox />
+                </Font>{' '}
+                Loaded {file.name}
+              </P>
             ) : (
-              <p key={file.name}>
+              <P key={file.name}>
                 <FileInputButton
                   accept={file.accept}
                   buttonProps={{
@@ -330,27 +326,26 @@ export function UnconfiguredScreen(): JSX.Element {
                 >
                   {file.name}
                 </FileInputButton>
-              </p>
+              </P>
             )
           )}
-          <p>
+          <P>
             <Button
               disabled={
                 !someFilesExist(inputConversionFiles) &&
                 !vxElectionFileIsInvalid
               }
-              small
               onPress={resetUploadFiles}
             >
               Reset Files
             </Button>
-          </p>
+          </P>
           <HorizontalRule />
-          <p>
-            <Button small onPress={resetUploadFilesAndGoBack}>
+          <P>
+            <Button variant="previous" onPress={resetUploadFilesAndGoBack}>
               Back
             </Button>
-          </p>
+          </P>
         </Prose>
       </NavigationScreen>
     );
@@ -359,47 +354,52 @@ export function UnconfiguredScreen(): JSX.Element {
   return (
     <NavigationScreen centerChild title="Configure VxAdmin">
       <Prose textCenter>
-        <p>How would you like to start?</p>
+        <P>How would you like to start?</P>
         {vxElectionFileIsInvalid && (
-          <Invalid>Invalid Vx Election Definition file.</Invalid>
+          <P>
+            <Font color="danger">
+              <Icons.Danger />
+            </Font>{' '}
+            Invalid Vx Election Definition file.
+          </P>
         )}
         {systemSettingsFileIsInvalid && (
-          <Invalid>Invalid System Settings file.</Invalid>
+          <P>
+            <Font color="danger">
+              <Icons.Danger />
+            </Font>{' '}
+            Invalid System Settings file.
+          </P>
         )}
-        <p>
+        <P>
           <FileInputButton
             accept=".json,application/json"
             onChange={handleVxElectionFile}
           >
             Select Existing Election Definition File
           </FileInputButton>
-        </p>
-        <HorizontalRule>or</HorizontalRule>
-        <p>
+        </P>
+        <P>
           <FileInputButton
             accept=".zip,application/zip"
             onChange={handleSetupPackageFile}
           >
             Select Existing Setup Package Zip File
           </FileInputButton>
-        </p>
+        </P>
 
-        {client && inputConversionFiles.length > 0 && (
-          <React.Fragment>
-            <HorizontalRule>or</HorizontalRule>
-            {!isUsingConverter && (
-              <Button onPress={() => setIsUsingConverter(true)}>
-                Convert from {client.getDisplayName()} files
-              </Button>
-            )}
-          </React.Fragment>
+        {client && inputConversionFiles.length > 0 && !isUsingConverter && (
+          <P>
+            <Button onPress={() => setIsUsingConverter(true)}>
+              Convert from {client.getDisplayName()} files
+            </Button>
+          </P>
         )}
-        <HorizontalRule>or</HorizontalRule>
-        <p>
+        <P>
           <Button onPress={loadDemoElection}>
             Load Demo Election Definition
           </Button>
-        </p>
+        </P>
       </Prose>
     </NavigationScreen>
   );


### PR DESCRIPTION
## Overview

Related to: https://github.com/votingworks/vxsuite/issues/3570

Applying the new VVSG design updates to the `UnconfiguredScreen` in VxAdmin.

## Demo Video or Screenshot
### Before/After:
<img width="400" src="https://github.com/votingworks/vxsuite/assets/264902/6a0dc459-573f-4137-a3c3-ebf83c8f2692" /> <img width="400" src="https://github.com/votingworks/vxsuite/assets/264902/e260f0cb-d876-4d18-9c2c-e86e6c913e45" />

<img width="400" src="https://github.com/votingworks/vxsuite/assets/264902/5c9fec0c-7174-4e72-a82e-d73b85aa858c" /> <img width="400" src="https://github.com/votingworks/vxsuite/assets/264902/ed95acf1-bc0b-41c3-a712-adba7e9eff15" />

<img width="400" src="https://github.com/votingworks/vxsuite/assets/264902/f7195b42-331d-46ba-a771-6defc636b1a4" /> <img width="400" src="https://github.com/votingworks/vxsuite/assets/264902/73e85ebe-c677-4995-be07-4717672ac927" />

## Testing Plan
- N/A - no functional changes

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
