### PR TITLE
No longer write full election definition to election manager cards 

### DIFF
--- a/apps/admin/backend/src/app.auth.test.ts
+++ b/apps/admin/backend/src/app.auth.test.ts
@@ -10,7 +10,7 @@ beforeEach(() => {
 
 const jurisdiction = TEST_JURISDICTION;
 const { electionDefinition } = electionFamousNames2021Fixtures;
-const { electionData, electionHash } = electionDefinition;
+const { electionHash } = electionDefinition;
 
 test('getAuthStatus', async () => {
   const { apiClient, auth } = buildTestEnvironment();
@@ -84,7 +84,15 @@ test('programCard', async () => {
   expect(auth.programCard).toHaveBeenNthCalledWith(
     2,
     { electionHash, jurisdiction },
-    { userRole: 'election_manager', electionData }
+    { userRole: 'election_manager' }
+  );
+
+  void (await apiClient.programCard({ userRole: 'poll_worker' }));
+  expect(auth.programCard).toHaveBeenCalledTimes(3);
+  expect(auth.programCard).toHaveBeenNthCalledWith(
+    3,
+    { electionHash, jurisdiction },
+    { userRole: 'poll_worker' }
   );
 });
 

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -167,17 +167,7 @@ function buildApi({
     programCard(input: {
       userRole: 'system_administrator' | 'election_manager' | 'poll_worker';
     }) {
-      const machineState = constructAuthMachineState(workspace);
-      if (input.userRole === 'election_manager') {
-        const electionDefinition = getCurrentElectionDefinition(workspace);
-        assert(electionDefinition !== undefined);
-        const { electionData } = electionDefinition;
-        return auth.programCard(machineState, {
-          userRole: 'election_manager',
-          electionData,
-        });
-      }
-      return auth.programCard(machineState, {
+      return auth.programCard(constructAuthMachineState(workspace), {
         userRole: input.userRole,
       });
     },

--- a/apps/admin/integration-testing/cypress/support/auth.ts
+++ b/apps/admin/integration-testing/cypress/support/auth.ts
@@ -28,10 +28,8 @@ export function mockSystemAdministratorCardInsertion(): void {
 }
 
 export function mockElectionManagerCardInsertion({
-  electionData,
   electionHash,
 }: {
-  electionData: string;
   electionHash: string;
 }): void {
   mockCardCypress({
@@ -45,7 +43,6 @@ export function mockElectionManagerCardInsertion({
         },
       },
     },
-    data: Buffer.from(electionData, 'utf-8'),
     pin: PIN,
   });
 }

--- a/apps/central-scan/integration-testing/cypress/e2e/configuration.cy.ts
+++ b/apps/central-scan/integration-testing/cypress/e2e/configuration.cy.ts
@@ -1,4 +1,3 @@
-import { Buffer } from 'buffer';
 import { sha256 } from 'js-sha256';
 import { methodUrl } from '@votingworks/grout';
 import { TEST_JURISDICTION } from '@votingworks/types';
@@ -17,7 +16,6 @@ function mockCardCypress(mockFileContents: MockFileContents): void {
 function mockElectionManagerCard() {
   cy.readFile('cypress/fixtures/election.json', null).then(
     (electionBytes: Uint8Array) => {
-      const electionData = Buffer.from(electionBytes);
       const electionHash = sha256(electionBytes);
       mockCardCypress({
         cardStatus: {
@@ -30,7 +28,6 @@ function mockElectionManagerCard() {
             },
           },
         },
-        data: electionData,
         pin: PIN,
       });
     }

--- a/apps/mark/integration-testing/cypress/support/e2e.js
+++ b/apps/mark/integration-testing/cypress/support/e2e.js
@@ -44,7 +44,6 @@ function insertElectionManagerCard() {
         },
       },
     },
-    data: Buffer.from(electionData, 'utf-8'),
     pin: PIN,
   });
 }

--- a/libs/auth/src/card.ts
+++ b/libs/auth/src/card.ts
@@ -102,7 +102,7 @@ export interface Card {
   program(
     input:
       | { user: SystemAdministratorUser; pin: string }
-      | { user: ElectionManagerUser; pin: string; electionData: string }
+      | { user: ElectionManagerUser; pin: string }
       | { user: PollWorkerUser; pin?: string }
   ): Promise<void>;
   unprogram(): Promise<void>;

--- a/libs/auth/src/dipped_smart_card_auth.test.ts
+++ b/libs/auth/src/dipped_smart_card_auth.test.ts
@@ -67,7 +67,7 @@ afterEach(() => {
 
 const jurisdiction = TEST_JURISDICTION;
 const otherJurisdiction = `${TEST_JURISDICTION}-2`;
-const { electionData, electionHash } = electionSampleDefinition;
+const { electionHash } = electionSampleDefinition;
 const otherElectionHash = electionSample2Definition.electionHash;
 const defaultConfig: DippedSmartCardAuthConfig = {};
 const defaultMachineState: DippedSmartCardAuthMachineState = {
@@ -688,11 +688,10 @@ test.each<{
   {
     description: 'election manager cards',
     machineState: defaultMachineState,
-    input: { userRole: 'election_manager', electionData },
+    input: { userRole: 'election_manager' },
     expectedCardProgramInput: {
       user: { role: 'election_manager', jurisdiction, electionHash },
       pin,
-      electionData,
     },
     expectedProgramResult: ok({ pin }),
     cardDetailsAfterProgramming: {

--- a/libs/auth/src/dipped_smart_card_auth.ts
+++ b/libs/auth/src/dipped_smart_card_auth.ts
@@ -244,7 +244,7 @@ export class DippedSmartCardAuth implements DippedSmartCardAuthApi {
     machineState: DippedSmartCardAuthMachineState,
     input:
       | { userRole: 'system_administrator' }
-      | { userRole: 'election_manager'; electionData: string }
+      | { userRole: 'election_manager' }
       | { userRole: 'poll_worker' }
   ): Promise<Result<{ pin?: string }, Error>> {
     await this.logger.log(
@@ -333,7 +333,7 @@ export class DippedSmartCardAuth implements DippedSmartCardAuthApi {
     machineState: DippedSmartCardAuthMachineState,
     input:
       | { userRole: 'system_administrator' }
-      | { userRole: 'election_manager'; electionData: string }
+      | { userRole: 'election_manager' }
       | { userRole: 'poll_worker' }
   ): Promise<string | undefined> {
     await this.checkCardReaderAndUpdateAuthStatus(machineState);
@@ -361,7 +361,6 @@ export class DippedSmartCardAuth implements DippedSmartCardAuthApi {
         await this.card.program({
           user: { role: 'election_manager', jurisdiction, electionHash },
           pin,
-          electionData: input.electionData,
         });
         return pin;
       }

--- a/libs/auth/src/dipped_smart_card_auth_api.ts
+++ b/libs/auth/src/dipped_smart_card_auth_api.ts
@@ -32,7 +32,7 @@ export interface DippedSmartCardAuthApi {
     machineState: DippedSmartCardAuthMachineState,
     input:
       | { userRole: SystemAdministratorUser['role'] }
-      | { userRole: ElectionManagerUser['role']; electionData: string }
+      | { userRole: ElectionManagerUser['role'] }
       | { userRole: PollWorkerUser['role'] }
   ): Promise<Result<{ pin?: string }, Error>>;
   unprogramCard(

--- a/libs/auth/src/intermediate-scripts/create_cert.ts
+++ b/libs/auth/src/intermediate-scripts/create_cert.ts
@@ -4,7 +4,7 @@ import { extractErrorMessage } from '@votingworks/basics';
 import { createCertHelper, parseCreateCertInput } from '../openssl';
 
 /**
- * An intermediate component of createCert in ./openssl.ts, needed for permissions purposes. See
+ * An intermediate component of createCert in src/openssl.ts, needed for permissions purposes. See
  * createCert for more context.
  */
 export async function main(): Promise<void> {

--- a/libs/auth/src/intermediate-scripts/sign_message.ts
+++ b/libs/auth/src/intermediate-scripts/sign_message.ts
@@ -7,7 +7,7 @@ import {
 } from '../openssl';
 
 /**
- * An intermediate component of signMessage in ./openssl.ts, needed for permissions purposes. See
+ * An intermediate component of signMessage in src/openssl.ts, needed for permissions purposes. See
  * signMessage for more context.
  */
 export async function main(): Promise<void> {

--- a/libs/auth/src/java_card.ts
+++ b/libs/auth/src/java_card.ts
@@ -254,7 +254,7 @@ export class JavaCard implements Card {
   async program(
     input:
       | { user: SystemAdministratorUser; pin: string }
-      | { user: ElectionManagerUser; pin: string; electionData: string }
+      | { user: ElectionManagerUser; pin: string }
       | { user: PollWorkerUser; pin?: string }
   ): Promise<void> {
     assert(
@@ -320,10 +320,6 @@ export class JavaCard implements Card {
       VX_ADMIN_CERT_AUTHORITY_CERT.OBJECT_ID,
       vxAdminCertAuthorityCert
     );
-
-    if ('electionData' in input) {
-      await this.writeData(Buffer.from(input.electionData, 'utf-8'));
-    }
 
     this.cardStatus = { status: 'ready', cardDetails };
   }

--- a/libs/auth/src/mock_file_card.test.ts
+++ b/libs/auth/src/mock_file_card.test.ts
@@ -108,7 +108,6 @@ test('MockFileCard basic mocking', async () => {
         user: electionManagerUser,
       },
     },
-    data: undefined,
     pin,
   });
   expect(await card.getCardStatus()).toEqual({

--- a/libs/auth/src/mock_file_card.test.ts
+++ b/libs/auth/src/mock_file_card.test.ts
@@ -16,7 +16,7 @@ import {
   serializeMockFileContents,
 } from './mock_file_card';
 
-const { electionData, electionHash } = electionSampleDefinition;
+const { electionHash } = electionSampleDefinition;
 const pin = '123456';
 const wrongPin = '234567';
 
@@ -47,7 +47,7 @@ test.each<MockFileContents>([
         user: electionManagerUser,
       },
     },
-    data: Buffer.from(electionData, 'utf-8'),
+    data: undefined,
     pin,
   },
   {
@@ -108,7 +108,7 @@ test('MockFileCard basic mocking', async () => {
         user: electionManagerUser,
       },
     },
-    data: Buffer.from(electionData, 'utf-8'),
+    data: undefined,
     pin,
   });
   expect(await card.getCardStatus()).toEqual({
@@ -212,7 +212,7 @@ test('MockFileCard programming', async () => {
     cardDetails: undefined,
   });
 
-  await card.program({ user: electionManagerUser, pin, electionData });
+  await card.program({ user: electionManagerUser, pin });
   expect(await card.getCardStatus()).toEqual({
     status: 'ready',
     cardDetails: {
@@ -220,14 +220,12 @@ test('MockFileCard programming', async () => {
     },
   });
   expect(await card.checkPin(pin)).toEqual({ response: 'correct' });
-  expect((await card.readData()).toString('utf-8')).toEqual(electionData);
 
   await card.unprogram();
   expect(await card.getCardStatus()).toEqual({
     status: 'ready',
     cardDetails: undefined,
   });
-  expect(await card.readData()).toEqual(Buffer.from([]));
 
   await card.program({ user: pollWorkerUser });
   expect(await card.getCardStatus()).toEqual({

--- a/libs/auth/src/mock_file_card.ts
+++ b/libs/auth/src/mock_file_card.ts
@@ -157,7 +157,7 @@ export class MockFileCard implements Card {
   program(
     input:
       | { user: SystemAdministratorUser; pin: string }
-      | { user: ElectionManagerUser; pin: string; electionData: string }
+      | { user: ElectionManagerUser; pin: string }
       | { user: PollWorkerUser; pin?: string }
   ): Promise<void> {
     const { user, pin } = input;
@@ -175,13 +175,11 @@ export class MockFileCard implements Card {
         break;
       }
       case 'election_manager': {
-        assert('electionData' in input);
         writeToMockFile({
           cardStatus: {
             status: 'ready',
             cardDetails: { user },
           },
-          data: Buffer.from(input.electionData, 'utf-8'),
           pin,
         });
         break;


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/3602

This PR updates card programming code to no longer write the full election definition to election manager cards. Now that VxMark is also configured via USB, nowhere in VxSuite do we now read the full election definition from election manager cards.

This cleanup has become more urgent because the all-bubble-ballot election definitions that SLI will be using are too large to fit on a Java Card and result in card programming errors with the current code.

## Testing

- [x] Updated unit tests
- [x] Tested manually