### PR TITLE
[VxAdmin] Enable new VVSG theme

### DIFF
--- a/apps/admin/frontend/src/app.tsx
+++ b/apps/admin/frontend/src/app.tsx
@@ -1,4 +1,3 @@
-import { ColorMode } from '@votingworks/types';
 import { AppBase } from '@votingworks/ui';
 import {
   getHardware,
@@ -12,6 +11,9 @@ import { LogSource, Logger } from '@votingworks/logging';
 import { AppRoot, Props as AppRootProps } from './app_root';
 import { SessionTimeLimitTracker } from './components/session_time_limit_tracker';
 
+/* Copied from old App.css */
+const PRINT_FONT_SIZE_PX = 14;
+
 export type Props = Partial<AppRootProps>;
 
 export function App({
@@ -21,19 +23,13 @@ export function App({
   logger = new Logger(LogSource.VxAdminFrontend, window.kiosk),
   generateBallotId,
 }: Props): JSX.Element {
-  // Copied from old App.css
-  const baseFontSizePx = 20;
-  const printFontSizePx = 14;
-
-  // TODO: Default to medium contrast and vary based on user selection.
-  const colorMode: ColorMode = 'legacy';
-
   return (
     <BrowserRouter>
       <AppBase
-        defaultColorMode={colorMode}
-        legacyBaseFontSizePx={baseFontSizePx}
-        legacyPrintFontSizePx={printFontSizePx}
+        defaultColorMode="contrastMedium"
+        defaultSizeMode="s"
+        screenType="lenovoThinkpad15"
+        legacyPrintFontSizePx={PRINT_FONT_SIZE_PX}
       >
         <AppRoot
           printer={printer}


### PR DESCRIPTION
## Overview

Related to: https://github.com/votingworks/vxsuite/issues/3570

Enabling the new VVSG2-compatible theme in VxAdmin.

Not all components have been updated to their theme-aware versions yet, but this is close enough to the final state that it unblocks code freeze and documentation pass for the m17a release.

## Demo Video or Screenshot
### Before/After:
![Screenshot 2023-06-21 at 13 52 50](https://github.com/votingworks/vxsuite/assets/264902/34918201-e7fa-493a-8db8-92b6381972a1)
![Screenshot 2023-06-21 at 13 52 11](https://github.com/votingworks/vxsuite/assets/264902/c8c44da0-0017-4476-805c-2970d6aea99c)


## Testing Plan
- Did a click-through of the app to make sure nothing's too severely wonky (see [slack thread](https://votingworks.slack.com/archives/C05BNBX5C3G/p1687367406860259) for video/discussion).

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
