### PR TITLE
Prevent bypassing session time limits by changing the clock

### DIFF
--- a/apps/admin/frontend/src/screens/settings_screen.tsx
+++ b/apps/admin/frontend/src/screens/settings_screen.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+import { assert } from '@votingworks/basics';
 import {
   CurrentDateAndTime,
   Prose,
@@ -6,20 +7,36 @@ import {
   RebootToBiosButton,
   SetClockButton,
 } from '@votingworks/ui';
+import { isSystemAdministratorAuth } from '@votingworks/utils';
 
 import { AppContext } from '../contexts/app_context';
 import { NavigationScreen } from '../components/navigation_screen';
 import { FormatUsbButton } from '../components/format_usb_modal';
+import { updateSessionExpiry } from '../api';
 
 export function SettingsScreen(): JSX.Element {
-  const { logger, usbDrive } = useContext(AppContext);
+  const { auth, logger, usbDrive } = useContext(AppContext);
+  const updateSessionExpiryMutation = updateSessionExpiry.useMutation();
+
+  assert(isSystemAdministratorAuth(auth));
 
   return (
     <NavigationScreen title="Settings">
       <Prose maxWidth={false}>
         <h2>Current Date and Time</h2>
         <p>
-          <SetClockButton>
+          <SetClockButton
+            sessionExpiresAt={auth.sessionExpiresAt}
+            updateSessionExpiry={async (sessionExpiresAt: Date) => {
+              try {
+                await updateSessionExpiryMutation.mutateAsync({
+                  sessionExpiresAt,
+                });
+              } catch {
+                // Handled by default query client error handling
+              }
+            }}
+          >
             <CurrentDateAndTime />
           </SetClockButton>
         </p>

--- a/apps/admin/frontend/test/helpers/api_mock.ts
+++ b/apps/admin/frontend/test/helpers/api_mock.ts
@@ -355,6 +355,12 @@ export function createApiMock(
     expectGetScannerBatches(result: ScannerBatch[]) {
       apiClient.getScannerBatches.expectCallWith().resolves(result);
     },
+
+    expectUpdateSessionExpiry(sessionExpiresAt: Date) {
+      apiClient.updateSessionExpiry
+        .expectCallWith({ sessionExpiresAt })
+        .resolves();
+    },
   };
 }
 

--- a/apps/central-scan/frontend/src/screens/admin_actions_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/admin_actions_screen.test.tsx
@@ -287,6 +287,9 @@ test('clicking "Update Date and Time" shows modal to set clock', async () => {
   userEvent.selectOptions(selectYear, '2025');
 
   // Save date
+  mockApiClient.updateSessionExpiry
+    .expectCallWith({ sessionExpiresAt: new Date('2025-10-31T12:00:00.000Z') })
+    .resolves();
   userEvent.click(within(modal).getByRole('button', { name: 'Save' }));
   await waitFor(() => {
     expect(window.kiosk?.setClock).toHaveBeenCalledWith({

--- a/apps/central-scan/frontend/src/screens/admin_actions_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/admin_actions_screen.tsx
@@ -20,7 +20,7 @@ import { Prose } from '../components/prose';
 import { ToggleTestModeButton } from '../components/toggle_test_mode_button';
 import { SetMarkThresholdsModal } from '../components/set_mark_thresholds_modal';
 import { AppContext } from '../contexts/app_context';
-import { logOut } from '../api';
+import { logOut, updateSessionExpiry } from '../api';
 
 export interface AdminActionScreenProps {
   unconfigureServer: () => Promise<void>;
@@ -54,6 +54,7 @@ export function AdminActionsScreen({
   assert(isElectionManagerAuth(auth));
   const userRole = auth.user.role;
   const logOutMutation = logOut.useMutation();
+  const updateSessionExpiryMutation = updateSessionExpiry.useMutation();
   const [isConfirmingUnconfigure, setIsConfirmingUnconfigure] = useState(false);
   const [isDoubleConfirmingUnconfigure, setIsDoubleConfirmingUnconfigure] =
     useState(false);
@@ -155,7 +156,20 @@ export function AdminActionsScreen({
               machineConfig={machineConfig}
             />
             <p>
-              <SetClockButton>Update Date and Time</SetClockButton>
+              <SetClockButton
+                sessionExpiresAt={auth.sessionExpiresAt}
+                updateSessionExpiry={async (sessionExpiresAt: Date) => {
+                  try {
+                    await updateSessionExpiryMutation.mutateAsync({
+                      sessionExpiresAt,
+                    });
+                  } catch {
+                    // Handled by default query client error handling
+                  }
+                }}
+              >
+                Update Date and Time
+              </SetClockButton>
             </p>
             <p>
               <Button

--- a/apps/mark-scan/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/admin_screen.tsx
@@ -25,10 +25,12 @@ import {
   PollsState,
   PrecinctSelection,
 } from '@votingworks/types';
-import { makeAsync } from '@votingworks/utils';
+import { isElectionManagerAuth, makeAsync } from '@votingworks/utils';
 import { Logger } from '@votingworks/logging';
 import type { MachineConfig } from '@votingworks/mark-scan-backend';
+import { assert } from '@votingworks/basics';
 import { ScreenReader } from '../config/types';
+import { getAuthStatus, updateSessionExpiry } from '../api';
 
 export interface AdminScreenProps {
   appPrecinct?: PrecinctSelection;
@@ -58,8 +60,10 @@ export function AdminScreen({
   pollsState,
   logger,
   usbDrive,
-}: AdminScreenProps): JSX.Element {
+}: AdminScreenProps): JSX.Element | null {
   const { election } = electionDefinition;
+  const authStatusQuery = getAuthStatus.useQuery();
+  const updateSessionExpiryMutation = updateSessionExpiry.useMutation();
 
   // Disable the audiotrack when in admin mode
   useEffect(() => {
@@ -67,6 +71,12 @@ export function AdminScreen({
     screenReader.mute();
     return () => screenReader.toggleMuted(initialMuted);
   }, [screenReader]);
+
+  if (!authStatusQuery.isSuccess) {
+    return null;
+  }
+  const authStatus = authStatusQuery.data;
+  assert(isElectionManagerAuth(authStatus));
 
   return (
     <Screen>
@@ -144,7 +154,20 @@ export function AdminScreen({
             </Caption>
           </P>
           <P>
-            <SetClockButton>Update Date and Time</SetClockButton>
+            <SetClockButton
+              sessionExpiresAt={authStatus.sessionExpiresAt}
+              updateSessionExpiry={async (sessionExpiresAt: Date) => {
+                try {
+                  await updateSessionExpiryMutation.mutateAsync({
+                    sessionExpiresAt,
+                  });
+                } catch {
+                  // Handled by default query client error handling
+                }
+              }}
+            >
+              Update Date and Time
+            </SetClockButton>
           </P>
           <H6 as="h2">Configuration</H6>
           <P>

--- a/apps/mark-scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/mark-scan/frontend/test/helpers/mock_api_client.tsx
@@ -184,6 +184,12 @@ export function createApiMock() {
         .expectCallWith()
         .resolves(result);
     },
+
+    expectUpdateSessionExpiry(sessionExpiresAt: Date): void {
+      mockApiClient.updateSessionExpiry
+        .expectCallWith({ sessionExpiresAt })
+        .resolves();
+    },
   };
 }
 

--- a/apps/mark/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/mark/frontend/test/helpers/mock_api_client.tsx
@@ -184,6 +184,12 @@ export function createApiMock() {
         .expectCallWith()
         .resolves(result);
     },
+
+    expectUpdateSessionExpiry(sessionExpiresAt: Date): void {
+      mockApiClient.updateSessionExpiry
+        .expectCallWith({ sessionExpiresAt })
+        .resolves();
+    },
   };
 }
 

--- a/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
@@ -48,6 +48,9 @@ afterEach(() => {
 function renderScreen(
   props: Partial<ElectionManagerScreenProps> = {}
 ): RenderResult {
+  apiMock.authenticateAsElectionManager(
+    props.electionDefinition ?? electionSampleDefinition
+  );
   return render(
     provideApi(
       apiMock,
@@ -85,6 +88,7 @@ test('renders date and time settings modal', async () => {
   userEvent.selectOptions(selectYear, optionYear);
 
   // Save Date and Timezone
+  apiMock.expectUpdateSessionExpiry(new Date('2025-10-31T12:00:00.000Z'));
   // eslint-disable-next-line @typescript-eslint/require-await
   await act(async () => {
     userEvent.click(within(screen.getByTestId('modal')).getByText('Save'));

--- a/apps/scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/scan/frontend/test/helpers/mock_api_client.tsx
@@ -180,6 +180,12 @@ export function createApiMock() {
         .expectCallWith()
         .resolves(supportsUltrasonic);
     },
+
+    expectUpdateSessionExpiry(sessionExpiresAt: Date): void {
+      mockApiClient.updateSessionExpiry
+        .expectCallWith({ sessionExpiresAt })
+        .resolves();
+    },
   };
 }
 


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/3324

![image](https://github.com/votingworks/vxsuite/assets/12616928/2049aab3-eef5-40a4-af20-5c9c58d2ad13)

Updating the clock can have funky consequences! As noted in the linked issue:

> You can currently bypass session time limits by changing the clock to a time in the past. Similarly, if you change the clock to a time far enough in the future, you'll be automatically logged out.

This PR addresses both of the above by updating the session expiry whenever we update the clock. We update the session expiry such that the time remaining on the session is maintained, e.g. if 1 hour remained before the clock update, 1 hour will remain after the clock update.

## Testing

- [x] Added/updated unit tests

Working on testing manually ahead of m17a rc2 image creation but may ultimately end up testing on real hardware through those images.