### PR TITLE
[VxAdmin] VVSG Design Updates: Tally Report Screen

### DIFF
--- a/apps/admin/frontend/src/__snapshots__/app.test.tsx.snap
+++ b/apps/admin/frontend/src/__snapshots__/app.test.tsx.snap
@@ -3265,10 +3265,6 @@ exports[`tabulating CVRs 1`] = `
 
 }
 
-@media print {
-
-}
-
 @media (min-width:480px) {
 
 }

--- a/apps/admin/frontend/src/screens/tally_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally_report_screen.tsx
@@ -13,14 +13,17 @@ import {
 } from '@votingworks/types';
 import {
   Button,
+  Caption,
+  Font,
+  H2,
+  Icons,
   LinkButton,
   Modal,
+  P,
   printElement,
   printElementToPdf,
-  Prose,
   TallyReportMetadata,
   TallyReportPreview,
-  Text,
 } from '@votingworks/ui';
 import { UseQueryResult } from '@tanstack/react-query';
 import type { WriteInAdjudicatedTally } from '@votingworks/admin-backend';
@@ -238,9 +241,7 @@ export function TallyReportScreen(): JSX.Element {
   if (isTabulationRunning) {
     return (
       <NavigationScreen centerChild title="Building Tabulation Report...">
-        <Prose textCenter>
-          <p>This may take a few seconds.</p>
-        </Prose>
+        <P>This may take a few seconds.</P>
       </NavigationScreen>
     );
   }
@@ -254,48 +255,44 @@ export function TallyReportScreen(): JSX.Element {
   return (
     <React.Fragment>
       <NavigationScreen title={reportDisplayTitle}>
-        <Prose>
-          <TallyReportMetadata
-            generatedAtTime={generatedAtTime}
-            election={election}
-          />
-          <p>
-            <PrintButton variant="primary" print={printTallyReport}>
-              Print Report
-            </PrintButton>{' '}
-            {window.kiosk && (
-              <Button onPress={() => setIsSaveModalOpen(true)}>
-                Save Report as PDF
-              </Button>
-            )}
-          </p>
-          {location.pathname === routerPaths.tallyFullReport && (
-            <p>
-              <Button
-                disabled={
-                  !castVoteRecordFileModeQuery.isSuccess ||
-                  castVoteRecordFileModeQuery.data === 'unlocked' ||
-                  isOfficialResults
-                }
-                onPress={openMarkOfficialModal}
-              >
-                Mark Tally Results as Official
-              </Button>
-            </p>
+        <TallyReportMetadata
+          generatedAtTime={generatedAtTime}
+          election={election}
+        />
+        <P>
+          <PrintButton variant="primary" print={printTallyReport}>
+            Print Report
+          </PrintButton>{' '}
+          {window.kiosk && (
+            <Button onPress={() => setIsSaveModalOpen(true)}>
+              Save Report as PDF
+            </Button>
           )}
-          <p>
-            <LinkButton small to={routerPaths.reports}>
-              Back to Reports
-            </LinkButton>
-          </p>
-          <React.Fragment>
-            <h2>Report Preview</h2>
-            <Text italic small>
-              <strong>Note:</strong> Printed reports may be paginated to more
-              than one piece of paper.
-            </Text>
-          </React.Fragment>
-        </Prose>
+        </P>
+        {location.pathname === routerPaths.tallyFullReport && (
+          <P>
+            <Button
+              disabled={
+                !castVoteRecordFileModeQuery.isSuccess ||
+                castVoteRecordFileModeQuery.data === 'unlocked' ||
+                isOfficialResults
+              }
+              onPress={openMarkOfficialModal}
+            >
+              Mark Tally Results as Official
+            </Button>
+          </P>
+        )}
+        <P>
+          <LinkButton small to={routerPaths.reports}>
+            Back to Reports
+          </LinkButton>
+        </P>
+        <H2>Report Preview</H2>
+        <Caption>
+          <Icons.Info /> <Font weight="bold">Note:</Font> Printed reports may be
+          paginated to more than one piece of paper.
+        </Caption>
         <TallyReportPreview data-testid="report-preview">
           {tallyReport}
         </TallyReportPreview>
@@ -310,16 +307,15 @@ export function TallyReportScreen(): JSX.Element {
       )}
       {isMarkOfficialModalOpen && (
         <Modal
-          centerContent
           title="Mark Unofficial Tally Results as Official Tally Results?"
           content={
-            <Prose textCenter>
-              <p>
+            <React.Fragment>
+              <P>
                 Have all CVR files been loaded? Once results are marked as
                 official, no additional CVR files can be loaded.
-              </p>
-              <p>Have all unofficial tally reports been reviewed?</p>
-            </Prose>
+              </P>
+              <P>Have all unofficial tally reports been reviewed?</P>
+            </React.Fragment>
           }
           actions={
             <React.Fragment>


### PR DESCRIPTION
## Overview

Related to: https://github.com/votingworks/vxsuite/issues/3570

Applying VVSG design updates to the `TallyReportScreen`:
- Replacing typography components with theme-aware versions
- Removing instances of the deprecated `Prose` component
- Not changing the shared `TallyReportMetadata` component, since that's also used for printouts - don't want to break any styling there until we can look at print components more holistically.

## Demo Video or Screenshot
### Before/After:
#### Main Screen:
![Screenshot 2023-06-22 at 13 24 01](https://github.com/votingworks/vxsuite/assets/264902/b771567e-5ab3-4bbb-9bc1-65af4ec5058a)

![Screenshot 2023-06-22 at 13 23 45](https://github.com/votingworks/vxsuite/assets/264902/d39e0fb5-8c87-48cd-a7e7-84d4dd33eda9)

#### Mark Official Results Modal:
![Screenshot 2023-06-22 at 13 24 06](https://github.com/votingworks/vxsuite/assets/264902/af28170e-7c02-44d2-901a-8707f3f1b97e)

![Screenshot 2023-06-22 at 13 15 16](https://github.com/votingworks/vxsuite/assets/264902/c2197f11-5bb8-495e-8c98-f9f933c19320)


## Testing Plan
- Visual check

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
