### PR TITLE
Log out after clock changes

### DIFF
--- a/apps/admin/frontend/src/screens/settings_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/settings_screen.test.tsx
@@ -36,6 +36,7 @@ test('Setting current date and time', async () => {
   const modal = screen.getByRole('alertdialog');
   within(modal).getByText('Wed, Jun 22, 2022, 12:00 AM');
   userEvent.selectOptions(within(modal).getByTestId('selectYear'), '2023');
+  apiMock.expectLogOut();
   userEvent.click(within(modal).getByRole('button', { name: 'Save' }));
   await waitFor(() => {
     expect(mockKiosk.setClock).toHaveBeenCalledWith({
@@ -44,9 +45,6 @@ test('Setting current date and time', async () => {
       IANAZone: 'UTC',
     });
   });
-
-  // Date and time are reset to system time after save to kiosk-browser
-  screen.getByText(startDateTime);
 });
 
 test('Rebooting from USB', async () => {

--- a/apps/admin/frontend/src/screens/settings_screen.tsx
+++ b/apps/admin/frontend/src/screens/settings_screen.tsx
@@ -10,16 +10,26 @@ import {
 import { AppContext } from '../contexts/app_context';
 import { NavigationScreen } from '../components/navigation_screen';
 import { FormatUsbButton } from '../components/format_usb_modal';
+import { logOut } from '../api';
 
 export function SettingsScreen(): JSX.Element {
   const { logger, usbDrive } = useContext(AppContext);
+  const logOutMutation = logOut.useMutation();
 
   return (
     <NavigationScreen title="Settings">
       <Prose maxWidth={false}>
         <h2>Current Date and Time</h2>
         <p>
-          <SetClockButton>
+          <SetClockButton
+            logOut={async () => {
+              try {
+                await logOutMutation.mutateAsync();
+              } catch {
+                // Handled by default query client error handling
+              }
+            }}
+          >
             <CurrentDateAndTime />
           </SetClockButton>
         </p>

--- a/apps/admin/frontend/src/screens/settings_screen.tsx
+++ b/apps/admin/frontend/src/screens/settings_screen.tsx
@@ -21,15 +21,7 @@ export function SettingsScreen(): JSX.Element {
       <Prose maxWidth={false}>
         <h2>Current Date and Time</h2>
         <p>
-          <SetClockButton
-            logOut={async () => {
-              try {
-                await logOutMutation.mutateAsync();
-              } catch {
-                // Handled by default query client error handling
-              }
-            }}
-          >
+          <SetClockButton logOut={() => logOutMutation.mutate()}>
             <CurrentDateAndTime />
           </SetClockButton>
         </p>

--- a/apps/central-scan/frontend/src/screens/admin_actions_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/admin_actions_screen.test.tsx
@@ -287,6 +287,7 @@ test('clicking "Update Date and Time" shows modal to set clock', async () => {
   userEvent.selectOptions(selectYear, '2025');
 
   // Save date
+  mockApiClient.logOut.expectCallWith().resolves();
   userEvent.click(within(modal).getByRole('button', { name: 'Save' }));
   await waitFor(() => {
     expect(window.kiosk?.setClock).toHaveBeenCalledWith({

--- a/apps/central-scan/frontend/src/screens/admin_actions_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/admin_actions_screen.tsx
@@ -155,15 +155,7 @@ export function AdminActionsScreen({
               machineConfig={machineConfig}
             />
             <p>
-              <SetClockButton
-                logOut={async () => {
-                  try {
-                    await logOutMutation.mutateAsync();
-                  } catch {
-                    // Handled by default query client error handling
-                  }
-                }}
-              >
+              <SetClockButton logOut={() => logOutMutation.mutate()}>
                 Update Date and Time
               </SetClockButton>
             </p>

--- a/apps/central-scan/frontend/src/screens/admin_actions_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/admin_actions_screen.tsx
@@ -155,7 +155,17 @@ export function AdminActionsScreen({
               machineConfig={machineConfig}
             />
             <p>
-              <SetClockButton>Update Date and Time</SetClockButton>
+              <SetClockButton
+                logOut={async () => {
+                  try {
+                    await logOutMutation.mutateAsync();
+                  } catch {
+                    // Handled by default query client error handling
+                  }
+                }}
+              >
+                Update Date and Time
+              </SetClockButton>
             </p>
             <p>
               <Button

--- a/apps/mark-scan/frontend/src/pages/admin_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/admin_screen.test.tsx
@@ -97,6 +97,7 @@ test('renders date and time settings modal', async () => {
   fireEvent.change(selectYear, { target: { value: optionYear } });
 
   // Save Date and Timezone
+  apiMock.expectLogOut();
   // eslint-disable-next-line @typescript-eslint/require-await
   await act(async () => {
     fireEvent.click(within(screen.getByTestId('modal')).getByText('Save'));

--- a/apps/mark-scan/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/admin_screen.tsx
@@ -29,6 +29,7 @@ import { makeAsync } from '@votingworks/utils';
 import { Logger } from '@votingworks/logging';
 import type { MachineConfig } from '@votingworks/mark-scan-backend';
 import { ScreenReader } from '../config/types';
+import { logOut } from '../api';
 
 export interface AdminScreenProps {
   appPrecinct?: PrecinctSelection;
@@ -60,6 +61,7 @@ export function AdminScreen({
   usbDrive,
 }: AdminScreenProps): JSX.Element {
   const { election } = electionDefinition;
+  const logOutMutation = logOut.useMutation();
 
   // Disable the audiotrack when in admin mode
   useEffect(() => {
@@ -144,7 +146,17 @@ export function AdminScreen({
             </Caption>
           </P>
           <P>
-            <SetClockButton>Update Date and Time</SetClockButton>
+            <SetClockButton
+              logOut={async () => {
+                try {
+                  await logOutMutation.mutateAsync();
+                } catch {
+                  // Handled by default query client error handling
+                }
+              }}
+            >
+              Update Date and Time
+            </SetClockButton>
           </P>
           <H6 as="h2">Configuration</H6>
           <P>

--- a/apps/mark-scan/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/admin_screen.tsx
@@ -146,15 +146,7 @@ export function AdminScreen({
             </Caption>
           </P>
           <P>
-            <SetClockButton
-              logOut={async () => {
-                try {
-                  await logOutMutation.mutateAsync();
-                } catch {
-                  // Handled by default query client error handling
-                }
-              }}
-            >
+            <SetClockButton logOut={() => logOutMutation.mutate()}>
               Update Date and Time
             </SetClockButton>
           </P>

--- a/apps/mark-scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/mark-scan/frontend/test/helpers/mock_api_client.tsx
@@ -184,6 +184,10 @@ export function createApiMock() {
         .expectCallWith()
         .resolves(result);
     },
+
+    expectLogOut() {
+      mockApiClient.logOut.expectCallWith().resolves();
+    },
   };
 }
 

--- a/apps/mark/frontend/src/pages/admin_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.test.tsx
@@ -97,6 +97,7 @@ test('renders date and time settings modal', async () => {
   fireEvent.change(selectYear, { target: { value: optionYear } });
 
   // Save Date and Timezone
+  apiMock.expectLogOut();
   // eslint-disable-next-line @typescript-eslint/require-await
   await act(async () => {
     fireEvent.click(within(screen.getByTestId('modal')).getByText('Save'));

--- a/apps/mark/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.tsx
@@ -29,6 +29,7 @@ import { makeAsync } from '@votingworks/utils';
 import { Logger } from '@votingworks/logging';
 import type { MachineConfig } from '@votingworks/mark-backend';
 import { ScreenReader } from '../config/types';
+import { logOut } from '../api';
 
 export interface AdminScreenProps {
   appPrecinct?: PrecinctSelection;
@@ -60,6 +61,7 @@ export function AdminScreen({
   usbDrive,
 }: AdminScreenProps): JSX.Element {
   const { election } = electionDefinition;
+  const logOutMutation = logOut.useMutation();
 
   // Disable the audiotrack when in admin mode
   useEffect(() => {
@@ -144,7 +146,17 @@ export function AdminScreen({
             </Caption>
           </P>
           <P>
-            <SetClockButton>Update Date and Time</SetClockButton>
+            <SetClockButton
+              logOut={async () => {
+                try {
+                  await logOutMutation.mutateAsync();
+                } catch {
+                  // Handled by default query client error handling
+                }
+              }}
+            >
+              Update Date and Time
+            </SetClockButton>
           </P>
           <H6 as="h2">Configuration</H6>
           <P>

--- a/apps/mark/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.tsx
@@ -146,15 +146,7 @@ export function AdminScreen({
             </Caption>
           </P>
           <P>
-            <SetClockButton
-              logOut={async () => {
-                try {
-                  await logOutMutation.mutateAsync();
-                } catch {
-                  // Handled by default query client error handling
-                }
-              }}
-            >
+            <SetClockButton logOut={() => logOutMutation.mutate()}>
               Update Date and Time
             </SetClockButton>
           </P>

--- a/apps/mark/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/mark/frontend/test/helpers/mock_api_client.tsx
@@ -184,6 +184,10 @@ export function createApiMock() {
         .expectCallWith()
         .resolves(result);
     },
+
+    expectLogOut() {
+      mockApiClient.logOut.expectCallWith().resolves();
+    },
   };
 }
 

--- a/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
@@ -85,6 +85,7 @@ test('renders date and time settings modal', async () => {
   userEvent.selectOptions(selectYear, optionYear);
 
   // Save Date and Timezone
+  apiMock.expectLogOut();
   // eslint-disable-next-line @typescript-eslint/require-await
   await act(async () => {
     userEvent.click(within(screen.getByTestId('modal')).getByText('Save'));

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -24,6 +24,7 @@ import { SetMarkThresholdsModal } from '../components/set_mark_thresholds_modal'
 import {
   ejectUsbDrive,
   getConfig,
+  logOut,
   setIsSoundMuted,
   setIsUltrasonicDisabled,
   setPrecinctSelection,
@@ -58,6 +59,7 @@ export function ElectionManagerScreen({
   const setIsUltrasonicDisabledMutation = setIsUltrasonicDisabled.useMutation();
   const unconfigureMutation = unconfigureElection.useMutation();
   const ejectUsbDriveMutation = ejectUsbDrive.useMutation();
+  const logOutMutation = logOut.useMutation();
 
   const [
     isShowingToggleTestModeWarningModal,
@@ -152,7 +154,16 @@ export function ElectionManagerScreen({
 
   const dateTimeButton = (
     <P>
-      <SetClockButton large>
+      <SetClockButton
+        large
+        logOut={async () => {
+          try {
+            await logOutMutation.mutateAsync();
+          } catch {
+            // Handled by default query client error handling
+          }
+        }}
+      >
         <span role="img" aria-label="Clock">
           🕓
         </span>{' '}

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -154,16 +154,7 @@ export function ElectionManagerScreen({
 
   const dateTimeButton = (
     <P>
-      <SetClockButton
-        large
-        logOut={async () => {
-          try {
-            await logOutMutation.mutateAsync();
-          } catch {
-            // Handled by default query client error handling
-          }
-        }}
-      >
+      <SetClockButton large logOut={() => logOutMutation.mutate()}>
         <span role="img" aria-label="Clock">
           🕓
         </span>{' '}

--- a/apps/scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/scan/frontend/test/helpers/mock_api_client.tsx
@@ -180,6 +180,10 @@ export function createApiMock() {
         .expectCallWith()
         .resolves(supportsUltrasonic);
     },
+
+    expectLogOut() {
+      mockApiClient.logOut.expectCallWith().resolves();
+    },
   };
 }
 

--- a/libs/ui/src/set_clock.test.tsx
+++ b/libs/ui/src/set_clock.test.tsx
@@ -247,7 +247,10 @@ describe('SetClockButton', () => {
   });
 
   test('renders date and time settings modal when clicked', async () => {
-    render(<SetClockButton>Update Date and Time</SetClockButton>);
+    const logOut = jest.fn();
+    render(
+      <SetClockButton logOut={logOut}>Update Date and Time</SetClockButton>
+    );
 
     // Open Modal and change date
     fireEvent.click(screen.getByText('Update Date and Time'));
@@ -371,6 +374,7 @@ describe('SetClockButton', () => {
       IANAZone: 'America/Los_Angeles',
       isoDatetime: '2020-10-21T11:00:00.000-07:00',
     });
+    expect(logOut).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/libs/ui/src/set_clock.tsx
+++ b/libs/ui/src/set_clock.tsx
@@ -16,7 +16,8 @@ import { Modal } from './modal';
 import { InputGroup } from './input_group';
 import { Button, ButtonProps } from './button';
 import { useNow } from './hooks/use_now';
-import { H1, P } from './typography';
+import { Font, H1, P } from './typography';
+import { Icons } from './icons';
 
 export const MIN_YEAR = 2020;
 export const MAX_YEAR = 2030;
@@ -264,6 +265,12 @@ export function PickDateTimeModal({
                 </Select>
               </InputGroup>
             </P>
+            <P>
+              <Font color="warning">
+                <Icons.Warning />
+              </Font>{' '}
+              You will have to reauthenticate after changing the clock.
+            </P>
           </div>
         </Prose>
       }
@@ -281,9 +288,14 @@ export function PickDateTimeModal({
   );
 }
 
-type SetClockButtonProps = Omit<ButtonProps, 'onPress'>;
+type SetClockButtonProps = Omit<ButtonProps, 'onPress'> & {
+  logOut: () => void;
+};
 
-export function SetClockButton(props: SetClockButtonProps): JSX.Element {
+export function SetClockButton({
+  logOut,
+  ...buttonProps
+}: SetClockButtonProps): JSX.Element {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isSettingClock, setIsSettingClock] = useState(false);
   const systemDate = useNow();
@@ -303,11 +315,12 @@ export function SetClockButton(props: SetClockButtonProps): JSX.Element {
     } finally {
       setIsSettingClock(false);
     }
+    logOut();
   }
 
   return (
     <React.Fragment>
-      <Button {...props} onPress={() => setIsModalOpen(true)} />
+      <Button {...buttonProps} onPress={() => setIsModalOpen(true)} />
       {isModalOpen && (
         <PickDateTimeModal
           disabled={isSettingClock}


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/3324

This PR updates VxSuite apps to log out after clock changes as a heavy-handed means of preventing people from bypassing the session time limit by changing the clock.

As noted in the linked issue:

> You can currently bypass session time limits by changing the clock to a time in the past. Similarly, if you change the clock to a time far enough in the future, you'll be automatically logged out.

My first attempt at a fix (https://github.com/votingworks/vxsuite/pull/3608) 1) introduced other bugs, like flashing modals or the inactive session timeout being triggered, all stemming from the fact that changing the clock and updating the session expiry weren't an atomic operation, and 2) pushed us farther away from a desired long-term state where clock changes happen on the backend.

This new fix, though heavy-handed, is easy to reason about and requires minimal code. It'll do the trick for upcoming SLI and CISA testing, and we can always revisit down the road.

# Demo Screenshot and Video

<img src='https://github.com/votingworks/vxsuite/assets/12616928/a5a450d4-1ceb-4dcf-a20f-c37c9ea54d38' alt='modal' width=400 />

https://github.com/votingworks/vxsuite/assets/12616928/230e1f9e-f494-4ad0-92e3-f02ed5ef3519

## Testing

- [x] Updated unit tests
- [x] Tested manually

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates