### PR TITLE
wait for USB eject before attempting configuration again

### DIFF
--- a/apps/central-scan/frontend/src/app.test.tsx
+++ b/apps/central-scan/frontend/src/app.test.tsx
@@ -12,7 +12,7 @@ import {
   suppressingConsoleOutput,
 } from '@votingworks/test-utils';
 import { MemoryHardware } from '@votingworks/utils';
-import { typedAs, sleep, ok } from '@votingworks/basics';
+import { typedAs, sleep, ok, err } from '@votingworks/basics';
 import { Scan } from '@votingworks/api';
 import {
   DEFAULT_SYSTEM_SETTINGS,
@@ -330,13 +330,8 @@ test('configuring election from usb ballot package works end to end', async () =
   mockKiosk.getUsbDriveInfo.mockResolvedValue([fakeUsbDrive()]);
   expectConfigureFromBallotPackageOnUsbDrive();
 
-  fetchMock.get('/central-scanner/config/election', electionSampleDefinition, {
-    overwriteRoutes: true,
-  });
-
   await act(async () => {
-    await sleep(500);
-    getByText('Successfully Configured');
+    await waitFor(() => getByText('Successfully Configured'));
   });
 
   fireEvent.click(getByText('Close'));
@@ -370,6 +365,56 @@ test('configuring election from usb ballot package works end to end', async () =
   await act(async () => {
     await sleep(1000);
     getByText('Insert a USB drive containing a ballot package.');
+  });
+});
+
+test('failed configuration from USB results in an error screen', async () => {
+  mockApiClient.getTestMode.expectCallWith().resolves(true);
+  const getMarkThresholdOverridesResponse: Scan.GetMarkThresholdOverridesConfigResponse =
+    {
+      status: 'ok',
+    };
+  fetchMock
+    .get('/central-scanner/config/election', { body: 'null' })
+    .get('/central-scanner/config/markThresholdOverrides', {
+      body: getMarkThresholdOverridesResponse,
+    })
+    .patchOnce('/central-scanner/config/election', {
+      body: '{"status": "ok"}',
+      status: 200,
+    });
+
+  const mockKiosk = fakeKiosk();
+  window.kiosk = mockKiosk;
+
+  const hardware = MemoryHardware.buildStandard();
+  const { getByText } = render(
+    <App apiClient={mockApiClient} hardware={hardware} />
+  );
+  await authenticateAsElectionManager(
+    electionSampleDefinition,
+    'VxCentralScan is Not Configured',
+    'VxCentralScan is Not Configured'
+  );
+
+  // Insert USB drive
+  mockKiosk.getUsbDriveInfo.mockResolvedValue([fakeUsbDrive()]);
+
+  // If there are more unexpected calls to these endpoints, the app may be
+  // reattempting configuration in a loop
+  mockApiClient.configureFromBallotPackageOnUsbDrive
+    .expectCallWith()
+    .resolves(err('election_hash_mismatch'));
+  mockApiClient.getSystemSettings
+    .expectCallWith()
+    .resolves(DEFAULT_SYSTEM_SETTINGS);
+
+  await act(async () => {
+    await waitFor(() =>
+      getByText(
+        'The most recent ballot package found is for a different election.'
+      )
+    );
   });
 });
 

--- a/apps/central-scan/frontend/src/app.test.tsx
+++ b/apps/central-scan/frontend/src/app.test.tsx
@@ -388,9 +388,7 @@ test('failed configuration from USB results in an error screen', async () => {
   window.kiosk = mockKiosk;
 
   const hardware = MemoryHardware.buildStandard();
-  const { getByText } = render(
-    <App apiClient={mockApiClient} hardware={hardware} />
-  );
+  render(<App apiClient={mockApiClient} hardware={hardware} />);
   await authenticateAsElectionManager(
     electionSampleDefinition,
     'VxCentralScan is Not Configured',
@@ -409,13 +407,9 @@ test('failed configuration from USB results in an error screen', async () => {
     .expectCallWith()
     .resolves(DEFAULT_SYSTEM_SETTINGS);
 
-  await act(async () => {
-    await waitFor(() =>
-      getByText(
-        'The most recent ballot package found is for a different election.'
-      )
-    );
-  });
+  await screen.findByText(
+    'The most recent ballot package found is for a different election.'
+  );
 });
 
 test('authentication works', async () => {

--- a/apps/central-scan/frontend/src/app_root.tsx
+++ b/apps/central-scan/frontend/src/app_root.tsx
@@ -476,10 +476,24 @@ export function AppRoot({
     }
   }, [electionJustLoaded, usbDrive.status]);
 
+  // We check configureMutation's status and stop configuration attempts after a failed attempt.
+  // This prevents the app from looping with continued failed configurations.
+  // If the user ejects the USB drive, we reset configureMutation's status so configuration
+  // may be attempted when a new or modified USB drive is inserted.
+  useEffect(() => {
+    if (
+      (configureMutation.isError || configureMutation?.data?.err) &&
+      usbDrive.status === 'ejected'
+    ) {
+      configureMutation.reset();
+    }
+  }, [usbDrive.status, configureMutation]);
+
   useEffect(() => {
     async function configure() {
       if (
         !configureMutation.isLoading &&
+        !configureMutation?.data?.err() &&
         !electionDefinition &&
         authStatusQuery.data &&
         isElectionManagerAuth(authStatusQuery.data) &&
@@ -723,6 +737,10 @@ export function AppRoot({
           <Button small onPress={() => logOutMutation.mutate()}>
             Lock Machine
           </Button>
+          <UsbControllerButton
+            usbDriveStatus={usbDrive.status}
+            usbDriveEject={() => usbDrive.eject(userRole)}
+          />
         </MainNav>
         <Main centerChild>
           <UnconfiguredElectionScreen

--- a/apps/central-scan/frontend/src/app_root.tsx
+++ b/apps/central-scan/frontend/src/app_root.tsx
@@ -482,7 +482,7 @@ export function AppRoot({
   // may be attempted when a new or modified USB drive is inserted.
   useEffect(() => {
     if (
-      (configureMutation.isError || configureMutation?.data?.err) &&
+      (configureMutation.isError || configureMutation?.data?.err()) &&
       usbDrive.status === 'ejected'
     ) {
       configureMutation.reset();

--- a/apps/central-scan/frontend/src/app_root.tsx
+++ b/apps/central-scan/frontend/src/app_root.tsx
@@ -501,8 +501,10 @@ export function AppRoot({
       ) {
         const result = await configureMutation.mutateAsync();
         const electionDefinitionFromResult = result.ok();
-        assert(electionDefinitionFromResult !== undefined);
-        updateElectionDefinition(electionDefinitionFromResult);
+        // an `err` Result from this mutation is handled by UnconfiguredElectionScreen
+        if (electionDefinitionFromResult) {
+          updateElectionDefinition(electionDefinitionFromResult);
+        }
       }
     }
 


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/3584

Fixes a bug where failed configuration of VxCentralScan from USB would result in a loop of attempting and failing to configure.

## Demo Video or Screenshot

**Before**
* Auth with a `primary election` election manager card
* Insert a mock USB with a `general election` ballot package

https://github.com/votingworks/vxsuite/assets/1060688/bef38369-de79-443a-ac45-00d1605470bb

**After**
1. Auth with a `general election` election manager card
2. Insert a mock USB with both `general` and `primary` ballot packages, but `primary` is newer
  a. ![Screenshot 2023-06-22 at 6 58 53 PM](https://github.com/votingworks/vxsuite/assets/1060688/595d1412-5157-47e9-aa8f-e1046766534d)
3. Configuration fails and error message successfully displays
4. Delete `primary` ballot package, leaving only correct `general` ballot package
5. Eject USB drive
6. Remount USB drive
7. Configuration succeeds

https://github.com/votingworks/vxsuite/assets/1060688/27d8c595-fe85-4664-a460-9f57162ac019



## Testing Plan
- [x] Add automated tests for unhappy path
- [x] Also manually verified fix with 2 physical USB drives, one with correct ballot package and one without

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
