### PR TITLE
build lookup for contest option indices so we don't have log(n^2) 

### DIFF
--- a/libs/backend/src/scan/cast_vote_records/export.ts
+++ b/libs/backend/src/scan/cast_vote_records/export.ts
@@ -35,6 +35,7 @@ import {
 } from '../../get_usb_drives';
 import { SCAN_ALLOWED_EXPORT_PATTERNS, VX_MACHINE_ID } from '../globals';
 import { buildCastVoteRecordReportMetadata } from './build_report_metadata';
+import { buildElectionOptionPositionMap } from './option_map';
 
 /**
  * Properties of each sheet that are needed to generate a cast vote record
@@ -119,6 +120,7 @@ function* getCastVoteRecordGenerator({
   reportContext,
 }: GetCastVoteRecordGeneratorParams): Generator<CVR.CVR> {
   const { electionHash, election } = electionDefinition;
+  const electionOptionPositionMap = buildElectionOptionPositionMap(election);
   const electionId = electionHash;
   const scannerId = VX_MACHINE_ID;
 
@@ -157,6 +159,7 @@ function* getCastVoteRecordGenerator({
         indexInBatch,
         ballotMarkingMode: 'machine',
         interpretation: canonicalizedSheet.interpretation,
+        electionOptionPositionMap,
       });
 
       continue;
@@ -198,6 +201,7 @@ function* getCastVoteRecordGenerator({
           }),
         },
       ],
+      electionOptionPositionMap,
     });
   }
 }

--- a/libs/backend/src/scan/cast_vote_records/option_map.test.ts
+++ b/libs/backend/src/scan/cast_vote_records/option_map.test.ts
@@ -1,0 +1,46 @@
+import { electionMinimalExhaustiveSampleDefinition } from '@votingworks/fixtures';
+import { buildElectionOptionPositionMap } from './option_map';
+
+test('buildElectionOptionMap', () => {
+  const { election } = electionMinimalExhaustiveSampleDefinition;
+  expect(buildElectionOptionPositionMap(election)).toEqual({
+    'aquarium-council-fish': {
+      'manta-ray': 0,
+      pufferfish: 1,
+      rockfish: 2,
+      triggerfish: 3,
+      'write-in-0': 4,
+      'write-in-1': 5,
+    },
+    'best-animal-fish': {
+      salmon: 1,
+      seahorse: 0,
+    },
+    'best-animal-mammal': {
+      fox: 2,
+      horse: 0,
+      otter: 1,
+    },
+    fishing: {
+      no: 1,
+      yes: 0,
+    },
+    'new-zoo-either': {
+      no: 1,
+      yes: 0,
+    },
+    'new-zoo-pick': {
+      no: 1,
+      yes: 0,
+    },
+    'zoo-council-mammal': {
+      elephant: 3,
+      kangaroo: 2,
+      lion: 1,
+      'write-in-0': 4,
+      'write-in-1': 5,
+      'write-in-2': 6,
+      zebra: 0,
+    },
+  });
+});

--- a/libs/backend/src/scan/cast_vote_records/option_map.ts
+++ b/libs/backend/src/scan/cast_vote_records/option_map.ts
@@ -1,0 +1,43 @@
+import { ContestId, ContestOptionId, Election } from '@votingworks/types';
+
+/**
+ * Options for a contest mapped to their position on the ballot.
+ */
+export type ContestOptionPositionMap = Record<ContestOptionId, number>;
+
+/**
+ * All contest option maps for an eleciton.
+ */
+export type ElectionOptionPositionMap = Record<
+  ContestId,
+  ContestOptionPositionMap
+>;
+
+/**
+ * Build a lookup structure for option positions on the ballot.
+ */
+export function buildElectionOptionPositionMap(
+  election: Election
+): ElectionOptionPositionMap {
+  const electionMap: ElectionOptionPositionMap = {};
+  for (const contest of election.contests) {
+    if (contest.type === 'yesno') {
+      electionMap[contest.id] = {
+        yes: 0,
+        no: 1,
+      };
+    } else {
+      const contestMap: ContestOptionPositionMap = {};
+      for (const [index, candidate] of contest.candidates.entries()) {
+        contestMap[candidate.id] = index;
+      }
+      if (contest.allowWriteIns) {
+        for (let i = 0; i < contest.seats; i += 1) {
+          contestMap[`write-in-${i}`] = contest.candidates.length + i;
+        }
+      }
+      electionMap[contest.id] = contestMap;
+    }
+  }
+  return electionMap;
+}


### PR DESCRIPTION
## Overview

Addresses a time complexity issue that arises when contests have many candidates, as in the bubble ballot. I'm hoping this will speed up the export.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
