### PR TITLE
Speed up VxAdmin CVR imports

### DIFF
--- a/apps/admin/backend/src/cvr_files.ts
+++ b/apps/admin/backend/src/cvr_files.ts
@@ -163,12 +163,11 @@ function snapshotHasValidContestReferences(
     );
     if (!electionContest) return err('invalid-contest');
 
+    const validContestOptions = new Set(
+      getValidContestOptions(electionContest)
+    );
     for (const cvrContestSelection of cvrContest.CVRContestSelection) {
-      if (
-        !getValidContestOptions(electionContest).includes(
-          cvrContestSelection.ContestSelectionId
-        )
-      ) {
+      if (!validContestOptions.has(cvrContestSelection.ContestSelectionId)) {
         return err('invalid-contest-option');
       }
     }


### PR DESCRIPTION
## Overview

A tweak similar in spirit to https://github.com/votingworks/vxsuite/pull/3621 and https://github.com/votingworks/vxsuite/pull/3623, this PR speeds up VxAdmin CVR imports, specifically for ballots with large numbers of candidates (as is the case for the all-bubble ballot SLI will be using).

## Testing

On my Mac VM, I'm seeing an import of 715 filled all-bubble ballot CVRs go from 12:40 minutes to 5:40 minutes!