### PR TITLE
Fix overflowing tally reports

### DIFF
--- a/libs/ui/src/reports/tally_report.tsx
+++ b/libs/ui/src/reports/tally_report.tsx
@@ -20,6 +20,9 @@ export const TallyReport = styled.div`
   @media print {
     font-size: 12px;
   }
+  @page {
+    size: letter portrait;
+  }
 `;
 
 export const TallyReportPreview = styled.div`


### PR DESCRIPTION
## Overview

Tally reports with longer content were overflowing the letter size page when printed. My guess is that the printer interpreted it as a legal size page instead of letter (I'm not sure exactly why). I couldn't find anywhere in the stack that the page size was specified, so it must be using some default logic.

I noticed that the CSS for BMD ballots specified a letter page size, so I tried adding that to the tally report CSS and that fixed the problem!

## Demo Video or Screenshot
Before (left) and after (right)
![IMG_7712](https://github.com/votingworks/vxsuite/assets/530106/ad0f6e64-3a7d-4699-9caa-983453bb73ad)

## Testing Plan
Manually tested with Polls Opened and Polls Closed reports in VxScan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
