### PR TITLE
[VxAdmin] VVSG Design Updates: ImportCvrFilesModal

### DIFF
--- a/apps/admin/frontend/src/components/import_cvrfiles_modal.tsx
+++ b/apps/admin/frontend/src/components/import_cvrfiles_modal.tsx
@@ -8,10 +8,12 @@ import {
   ModalWidth,
   Table,
   TD,
-  Prose,
   Button,
   ElectronFile,
   useExternalStateChangeListener,
+  WithScrollButtons,
+  P,
+  Font,
 } from '@votingworks/ui';
 import {
   isElectionManagerAuth,
@@ -52,8 +54,11 @@ const LabelText = styled.span`
   font-weight: 500;
 `;
 
-const TestMode = styled.span`
-  color: #ff8c00;
+const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  max-height: 100%;
+  overflow: hidden;
 `;
 
 type ModalState =
@@ -146,13 +151,11 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element | null {
       <Modal
         title="Error"
         content={
-          <Prose>
-            <p>
-              There was an error reading the contents of{' '}
-              <strong>{currentState.filename}</strong>:{' '}
-              {currentState.errorMessage}
-            </p>
-          </Prose>
+          <P>
+            There was an error reading the contents of{' '}
+            <Font weight="bold">{currentState.filename}</Font>:{' '}
+            {currentState.errorMessage}
+          </P>
         }
         onOverlayClick={onClose}
         actions={<Button onPress={onClose}>Close</Button>}
@@ -165,12 +168,10 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element | null {
       <Modal
         title="Duplicate File"
         content={
-          <Prose>
-            <p>
-              The selected file was ignored as a duplicate of a previously
-              loaded file.
-            </p>
-          </Prose>
+          <P>
+            The selected file was ignored as a duplicate of a previously loaded
+            file.
+          </P>
         }
         onOverlayClick={onClose}
         actions={<Button onPress={onClose}>Close</Button>}
@@ -183,17 +184,15 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element | null {
       <Modal
         title={`${currentState.result.newlyAdded} new CVRs Loaded`}
         content={
-          <Prose>
-            {currentState.result.alreadyPresent > 0 && (
-              <p>
-                Of the{' '}
-                {currentState.result.newlyAdded +
-                  currentState.result.alreadyPresent}{' '}
-                total CVRs in this file, {currentState.result.alreadyPresent}{' '}
-                were previously loaded.
-              </p>
-            )}
-          </Prose>
+          currentState.result.alreadyPresent > 0 && (
+            <P>
+              Of the{' '}
+              {currentState.result.newlyAdded +
+                currentState.result.alreadyPresent}{' '}
+              total CVRs in this file, {currentState.result.alreadyPresent} were
+              previously loaded.
+            </P>
+          )
         }
         onOverlayClick={onClose}
         actions={<Button onPress={onClose}>Close</Button>}
@@ -231,13 +230,11 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element | null {
       <Modal
         title="No USB Drive Detected"
         content={
-          <Prose>
-            <p>
-              <UsbImage src="/assets/usb-drive.svg" alt="Insert USB Image" />
-              Please insert a USB drive in order to load CVR files from the
-              scanner.
-            </p>
-          </Prose>
+          <P>
+            <UsbImage src="/assets/usb-drive.svg" alt="Insert USB Image" />
+            Please insert a USB drive in order to load CVR files from the
+            scanner.
+          </P>
         }
         onOverlayClick={onClose}
         actions={
@@ -285,7 +282,11 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element | null {
           {!fileModeLocked && (
             <td>
               <LabelText>
-                {isTestModeResults ? <TestMode>Test</TestMode> : 'Official'}
+                {isTestModeResults ? (
+                  <Font color="warning">Test</Font>
+                ) : (
+                  <Font color="success">Official</Font>
+                )}
               </LabelText>
             </td>
           )}
@@ -294,7 +295,6 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element | null {
               onPress={importSelectedFile}
               value={file}
               disabled={!canImport}
-              small
               variant="primary"
             >
               {canImport ? 'Load' : 'Loaded'}
@@ -345,25 +345,25 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element | null {
         modalWidth={ModalWidth.Wide}
         title={`Load ${headerModeText} CVR Files`}
         content={
-          <React.Fragment>
-            <Prose maxWidth={false}>
-              <p>{instructionalText}</p>
-            </Prose>
+          <Content>
+            <P>{instructionalText}</P>
             {fileTableRows.length > 0 && (
-              <CvrFileTable>
-                <thead>
-                  <tr>
-                    <th>Saved At</th>
-                    <th>Scanner ID</th>
-                    <th>CVR Count</th>
-                    {!fileModeLocked && <th>Ballot Type</th>}
-                    <th />
-                  </tr>
-                </thead>
-                <tbody>{fileTableRows}</tbody>
-              </CvrFileTable>
+              <WithScrollButtons>
+                <CvrFileTable>
+                  <thead>
+                    <tr>
+                      <th>Saved At</th>
+                      <th>Scanner ID</th>
+                      <th>CVR Count</th>
+                      {!fileModeLocked && <th>Ballot Type</th>}
+                      <th />
+                    </tr>
+                  </thead>
+                  <tbody>{fileTableRows}</tbody>
+                </CvrFileTable>
+              </WithScrollButtons>
             )}
-          </React.Fragment>
+          </Content>
         }
         onOverlayClick={onClose}
         actions={

--- a/libs/ui/src/__snapshots__/modal.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/modal.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`Modal can configure a wider max width 1`] = `
   background: #edeff0;
   border: 0.15rem solid #263238;
   width: 100%;
+  max-height: 100%;
   overflow: auto;
   -webkit-overflow-scrolling: touch;
 }
@@ -108,6 +109,7 @@ exports[`Modal can configure fullscreen 1`] = `
   background: #edeff0;
   border: 0 solid #263238;
   width: 100%;
+  max-height: 100%;
   overflow: auto;
   -webkit-overflow-scrolling: touch;
 }

--- a/libs/ui/src/modal.tsx
+++ b/libs/ui/src/modal.tsx
@@ -38,6 +38,7 @@ const ReactModalContent = styled('div')<ReactModalContentInterface>`
       p.fullscreen ? '0' : `${p.theme.sizes.bordersRem.medium}rem`}
     solid ${(p) => p.theme.colors.foreground};
   width: 100%;
+  max-height: 100%;
   overflow: auto;
   font-size: ${({ themeDeprecated }) => themeDeprecated?.fontSize};
   -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
## Overview

Related to: https://github.com/votingworks/vxsuite/issues/3570

Updating the `ImportCvrFilesModal` in VxAdmin to use the new theme-aware typography components and removing instances of the now-deprecated `Prose` component.

Also noticed the modal contents aren't scrollable with a lot of CVR files on the USB drive, so locking the max height of the shared `Modal` component and adding scroll controls to the CVR files table, so that the modal actions are always visible.

Out of scope for now:
- Table styling (borders, spacing, contents)

## Demo Video or Screenshot
### Before/After:
<img width="1800" alt="Screenshot 2023-06-26 at 14 16 06" src="https://github.com/votingworks/vxsuite/assets/264902/5a32946b-8922-4561-b54d-c20b620d1d8f">

https://github.com/votingworks/vxsuite/assets/264902/97c18607-5e46-4a76-adc4-4f9fa12d6dbf

## Testing Plan
- Updated changed snapshots

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
