### PR TITLE
[VxAdmin] VVSG Design Updates: TallyScreen

### DIFF
--- a/apps/admin/frontend/src/screens/tally_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally_screen.tsx
@@ -3,7 +3,16 @@ import moment from 'moment';
 
 import { format, isElectionManagerAuth } from '@votingworks/utils';
 import { assert, find, throwIllegalValue, unique } from '@votingworks/basics';
-import { Button, Prose, Table, TD, Text, LinkButton } from '@votingworks/ui';
+import {
+  Button,
+  Table,
+  TD,
+  LinkButton,
+  H2,
+  P,
+  Icons,
+  Caption,
+} from '@votingworks/ui';
 import { ResultsFileType } from '../config/types';
 
 import { AppContext } from '../contexts/app_context';
@@ -121,143 +130,137 @@ export function TallyScreen(): JSX.Element | null {
   return (
     <React.Fragment>
       <NavigationScreen title="Cast Vote Record (CVR) Management">
-        <Prose maxWidth={false}>
-          {fileModeText && <Text>{fileModeText}</Text>}
-          {isOfficialResults && (
-            <Button
-              variant="danger"
-              disabled={!hasAnyFiles}
-              onPress={() => beginConfirmRemoveFiles(ResultsFileType.All)}
-            >
-              Clear All Tallies and Results
-            </Button>
-          )}
+        {fileModeText && <P>{fileModeText}</P>}
+        {isOfficialResults && (
+          <Button
+            variant="danger"
+            disabled={!hasAnyFiles}
+            onPress={() => beginConfirmRemoveFiles(ResultsFileType.All)}
+          >
+            Clear All Tallies and Results
+          </Button>
+        )}
 
-          <p>
-            <Button
-              variant="primary"
-              disabled={isOfficialResults}
-              onPress={() => setIsImportCvrModalOpen(true)}
-            >
-              Load CVR Files
-            </Button>{' '}
-            <Button
-              disabled={fileMode === 'unlocked' || isOfficialResults}
-              onPress={() =>
-                beginConfirmRemoveFiles(ResultsFileType.CastVoteRecord)
-              }
-            >
-              Remove CVR Files
-            </Button>
-          </p>
-          <Table data-testid="loaded-file-table">
-            <tbody>
-              {hasAnyFiles ? (
-                <React.Fragment>
-                  <tr>
-                    <TD as="th" narrow nowrap textAlign="right">
-                      #
-                    </TD>
-                    <TD as="th" narrow nowrap>
-                      Created At
-                    </TD>
-                    <TD as="th" nowrap>
-                      CVR Count
-                    </TD>
-                    <TD as="th" narrow nowrap>
-                      Source
-                    </TD>
-                    <TD as="th" nowrap>
-                      Precinct
-                    </TD>
-                  </tr>
-                  {castVoteRecordFileList.map(
-                    (
-                      {
-                        filename,
-                        exportTimestamp,
-                        numCvrsImported,
-                        scannerIds,
-                        precinctIds,
-                      },
-                      cvrFileIndex
-                    ) => (
-                      <tr key={filename}>
-                        <TD narrow nowrap textAlign="right">
-                          {cvrFileIndex + 1}.
-                        </TD>
-                        <TD narrow nowrap>
-                          {moment(exportTimestamp).format(
-                            'MM/DD/YYYY hh:mm:ss A'
-                          )}
-                        </TD>
-                        <TD nowrap>{format.count(numCvrsImported)} </TD>
-                        <TD narrow nowrap>
-                          {scannerIds.join(', ')}
-                        </TD>
-                        <TD>{getPrecinctNames(precinctIds)}</TD>
-                      </tr>
-                    )
-                  )}
-                  {hasManualTally ? (
-                    <tr key="manual-data">
-                      <TD />
-                      <TD narrow nowrap>
-                        {moment(manualTallyFirstAdded).format(TIME_FORMAT)}
-                      </TD>
-                      <TD narrow>
-                        {format.count(manualTallyTotalBallotCount)}
-                      </TD>
-                      <TD narrow nowrap>
-                        Manually Entered Results
-                      </TD>
-                      <TD>{getPrecinctNames(manualTallyPrecinctIds)}</TD>
-                    </tr>
-                  ) : null}
-                  <tr>
-                    <TD />
-                    <TD as="th" narrow nowrap>
-                      Total CVRs Count
-                    </TD>
-                    <TD as="th" narrow data-testid="total-cvr-count">
-                      {format.count(
-                        castVoteRecordFileList.reduce(
-                          (prev, curr) => prev + curr.numCvrsImported,
-                          0
-                        ) + manualTallyTotalBallotCount
-                      )}
-                    </TD>
-                    <TD />
-                    <TD as="th" />
-                  </tr>
-                </React.Fragment>
-              ) : (
+        <P>
+          <Button
+            variant="primary"
+            disabled={isOfficialResults}
+            onPress={() => setIsImportCvrModalOpen(true)}
+          >
+            Load CVR Files
+          </Button>{' '}
+          <Button
+            disabled={fileMode === 'unlocked' || isOfficialResults}
+            onPress={() =>
+              beginConfirmRemoveFiles(ResultsFileType.CastVoteRecord)
+            }
+          >
+            Remove CVR Files
+          </Button>
+        </P>
+        <Table data-testid="loaded-file-table">
+          <tbody>
+            {hasAnyFiles ? (
+              <React.Fragment>
                 <tr>
-                  <TD colSpan={3}>
-                    <em>No CVR files loaded.</em>
+                  <TD as="th" narrow nowrap textAlign="right">
+                    #
+                  </TD>
+                  <TD as="th" narrow nowrap>
+                    Created At
+                  </TD>
+                  <TD as="th" nowrap>
+                    CVR Count
+                  </TD>
+                  <TD as="th" narrow nowrap>
+                    Source
+                  </TD>
+                  <TD as="th" nowrap>
+                    Precinct
                   </TD>
                 </tr>
-              )}
-            </tbody>
-          </Table>
-          <h2>Manually Entered Results</h2>
-          <p>
-            <LinkButton
-              to={routerPaths.manualDataSummary}
-              disabled={isOfficialResults}
-            >
-              {hasManualTally
-                ? 'Edit Manually Entered Results'
-                : 'Add Manually Entered Results'}
-            </LinkButton>{' '}
-            <Button
-              disabled={!hasManualTally || isOfficialResults}
-              onPress={() => setIsConfirmingRemoveAllManualTallies(true)}
-            >
-              Remove Manually Entered Results
-            </Button>
-          </p>
-        </Prose>
+                {castVoteRecordFileList.map(
+                  (
+                    {
+                      filename,
+                      exportTimestamp,
+                      numCvrsImported,
+                      scannerIds,
+                      precinctIds,
+                    },
+                    cvrFileIndex
+                  ) => (
+                    <tr key={filename}>
+                      <TD narrow nowrap textAlign="right">
+                        {cvrFileIndex + 1}.
+                      </TD>
+                      <TD narrow nowrap>
+                        {moment(exportTimestamp).format(
+                          'MM/DD/YYYY hh:mm:ss A'
+                        )}
+                      </TD>
+                      <TD nowrap>{format.count(numCvrsImported)} </TD>
+                      <TD narrow nowrap>
+                        {scannerIds.join(', ')}
+                      </TD>
+                      <TD>{getPrecinctNames(precinctIds)}</TD>
+                    </tr>
+                  )
+                )}
+                {hasManualTally ? (
+                  <tr key="manual-data">
+                    <TD />
+                    <TD narrow nowrap>
+                      {moment(manualTallyFirstAdded).format(TIME_FORMAT)}
+                    </TD>
+                    <TD narrow>{format.count(manualTallyTotalBallotCount)}</TD>
+                    <TD narrow nowrap>
+                      Manually Entered Results
+                    </TD>
+                    <TD>{getPrecinctNames(manualTallyPrecinctIds)}</TD>
+                  </tr>
+                ) : null}
+                <tr>
+                  <TD />
+                  <TD as="th" narrow nowrap>
+                    Total CVRs Count
+                  </TD>
+                  <TD as="th" narrow data-testid="total-cvr-count">
+                    {format.count(
+                      castVoteRecordFileList.reduce(
+                        (prev, curr) => prev + curr.numCvrsImported,
+                        0
+                      ) + manualTallyTotalBallotCount
+                    )}
+                  </TD>
+                  <TD />
+                  <TD as="th" />
+                </tr>
+              </React.Fragment>
+            ) : (
+              <Caption>
+                <Icons.Info /> No CVR files loaded.
+              </Caption>
+            )}
+          </tbody>
+        </Table>
+        <H2>Manually Entered Results</H2>
+        <P>
+          <LinkButton
+            to={routerPaths.manualDataSummary}
+            disabled={isOfficialResults}
+          >
+            {hasManualTally
+              ? 'Edit Manually Entered Results'
+              : 'Add Manually Entered Results'}
+          </LinkButton>{' '}
+          <Button
+            disabled={!hasManualTally || isOfficialResults}
+            onPress={() => setIsConfirmingRemoveAllManualTallies(true)}
+          >
+            Remove Manually Entered Results
+          </Button>
+        </P>
       </NavigationScreen>
       {confirmingRemoveFileType && (
         <ConfirmRemovingFileModal

--- a/apps/admin/frontend/src/screens/tally_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally_screen.tsx
@@ -89,7 +89,7 @@ export function TallyScreen(): JSX.Element | null {
     !manualTallyMetadataQuery.isSuccess
   ) {
     return (
-      <NavigationScreen title="Cast Vote Record (CVR) Management">
+      <NavigationScreen title="Tally">
         <Loading isFullscreen />
       </NavigationScreen>
     );
@@ -129,7 +129,8 @@ export function TallyScreen(): JSX.Element | null {
 
   return (
     <React.Fragment>
-      <NavigationScreen title="Cast Vote Record (CVR) Management">
+      <NavigationScreen title="Tally">
+        <H2>Cast Vote Record (CVR) Management</H2>
         {fileModeText && <P>{fileModeText}</P>}
         {isOfficialResults && (
           <Button


### PR DESCRIPTION
## Overview

Related to: https://github.com/votingworks/vxsuite/issues/3570

__(Easier to review with the `?w=1` query param)__

Updating the `TallyScreen` in VxAdmin to use the new theme-aware typography components and removing instances of the now-deprecated `Prose` component.

Also removing italics for a11y/readability as recommended at http://www.tader.info/display.html

## Demo Video or Screenshot
### Before/After:
<img width="400" alt="Screenshot 2023-06-26 at 14 45 37" src="https://github.com/votingworks/vxsuite/assets/264902/4365262e-dad5-4794-aba5-e7e3026a4b33"> <img width="400" alt="Screenshot 2023-06-26 at 14 45 19" src="https://github.com/votingworks/vxsuite/assets/264902/f7b7a387-000e-4dd7-8341-d7523a80eec4">

<img width="400" alt="Screenshot 2023-06-26 at 14 55 22" src="https://github.com/votingworks/vxsuite/assets/264902/788ccac4-8fdd-4647-934f-1de30f0a3af7"> <img width="400" alt="Screenshot 2023-06-26 at 14 56 26" src="https://github.com/votingworks/vxsuite/assets/264902/45a9a45a-94cc-4e18-9320-7090625f4bdc">

## Testing Plan
- Visual spot checks

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
