### PR TITLE
Fix production builds

### DIFF
--- a/script/src/prod-build/index.ts
+++ b/script/src/prod-build/index.ts
@@ -44,6 +44,8 @@ export function main({ stdout }: IO): void {
     'pnpm-lock.yaml',
     'pnpm-workspace.yaml',
     '.pnpmfile.cjs',
+    'Cargo.toml',
+    'Cargo.lock',
   ]) {
     fs.copyFileSync(join(WORKSPACE_ROOT, file), join(outRoot, basename(file)));
   }


### PR DESCRIPTION
Production builds have been failing due to a breaking change in a Rust dependency (`half@2.3.1` requires Rust 1.70.0, but we're only on Rust 1.68.0). Our [Cargo.lock specifies a compatible version of that dependency](https://github.com/votingworks/vxsuite/blob/7010d9a3a17d22ed9cd1c69fe438e51ac42c2dbe/Cargo.lock#L372-L373), yet we aren't using that version (`half@2.2.1`).

The issue turned out to be a bug/gap in vxsuite's production build script. The script forgets to copy over our Cargo.toml and Cargo.lock to production build workspaces so that we use correct locked dependency versions. This PR fixes that 🛠️