### PR TITLE
dev-dock: Increase mock USB drive size from 100MB to 1GB

### DIFF
--- a/libs/dev-dock/backend/src/dev_dock_api.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.ts
@@ -49,7 +49,7 @@ async function clearUsbDrive(): Promise<void> {
   await execFile('sudo', [
     join(MOCK_USB_SCRIPT_DIRECTORY, 'initialize.sh'),
     '-s',
-    '100',
+    '1000', // 1GB
   ]);
 }
 


### PR DESCRIPTION

## Overview

Decrease the likelihood of running out of space when exporting large files.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
