### PR TITLE
Revert "Kevin/vxcentralscan wait for usb eject to reattempt configure"

### DIFF
--- a/apps/central-scan/frontend/src/app.test.tsx
+++ b/apps/central-scan/frontend/src/app.test.tsx
@@ -12,7 +12,7 @@ import {
   suppressingConsoleOutput,
 } from '@votingworks/test-utils';
 import { MemoryHardware } from '@votingworks/utils';
-import { typedAs, sleep, ok, err } from '@votingworks/basics';
+import { typedAs, sleep, ok } from '@votingworks/basics';
 import { Scan } from '@votingworks/api';
 import {
   DEFAULT_SYSTEM_SETTINGS,
@@ -330,8 +330,13 @@ test('configuring election from usb ballot package works end to end', async () =
   mockKiosk.getUsbDriveInfo.mockResolvedValue([fakeUsbDrive()]);
   expectConfigureFromBallotPackageOnUsbDrive();
 
+  fetchMock.get('/central-scanner/config/election', electionSampleDefinition, {
+    overwriteRoutes: true,
+  });
+
   await act(async () => {
-    await waitFor(() => getByText('Successfully Configured'));
+    await sleep(500);
+    getByText('Successfully Configured');
   });
 
   fireEvent.click(getByText('Close'));
@@ -366,50 +371,6 @@ test('configuring election from usb ballot package works end to end', async () =
     await sleep(1000);
     getByText('Insert a USB drive containing a ballot package.');
   });
-});
-
-test('failed configuration from USB results in an error screen', async () => {
-  mockApiClient.getTestMode.expectCallWith().resolves(true);
-  const getMarkThresholdOverridesResponse: Scan.GetMarkThresholdOverridesConfigResponse =
-    {
-      status: 'ok',
-    };
-  fetchMock
-    .get('/central-scanner/config/election', { body: 'null' })
-    .get('/central-scanner/config/markThresholdOverrides', {
-      body: getMarkThresholdOverridesResponse,
-    })
-    .patchOnce('/central-scanner/config/election', {
-      body: '{"status": "ok"}',
-      status: 200,
-    });
-
-  const mockKiosk = fakeKiosk();
-  window.kiosk = mockKiosk;
-
-  const hardware = MemoryHardware.buildStandard();
-  render(<App apiClient={mockApiClient} hardware={hardware} />);
-  await authenticateAsElectionManager(
-    electionSampleDefinition,
-    'VxCentralScan is Not Configured',
-    'VxCentralScan is Not Configured'
-  );
-
-  // Insert USB drive
-  mockKiosk.getUsbDriveInfo.mockResolvedValue([fakeUsbDrive()]);
-
-  // If there are more unexpected calls to these endpoints, the app may be
-  // reattempting configuration in a loop
-  mockApiClient.configureFromBallotPackageOnUsbDrive
-    .expectCallWith()
-    .resolves(err('election_hash_mismatch'));
-  mockApiClient.getSystemSettings
-    .expectCallWith()
-    .resolves(DEFAULT_SYSTEM_SETTINGS);
-
-  await screen.findByText(
-    'The most recent ballot package found is for a different election.'
-  );
 });
 
 test('authentication works', async () => {

--- a/apps/central-scan/frontend/src/app_root.tsx
+++ b/apps/central-scan/frontend/src/app_root.tsx
@@ -476,24 +476,10 @@ export function AppRoot({
     }
   }, [electionJustLoaded, usbDrive.status]);
 
-  // We check configureMutation's status and stop configuration attempts after a failed attempt.
-  // This prevents the app from looping with continued failed configurations.
-  // If the user ejects the USB drive, we reset configureMutation's status so configuration
-  // may be attempted when a new or modified USB drive is inserted.
-  useEffect(() => {
-    if (
-      (configureMutation.isError || configureMutation?.data?.err()) &&
-      usbDrive.status === 'ejected'
-    ) {
-      configureMutation.reset();
-    }
-  }, [usbDrive.status, configureMutation]);
-
   useEffect(() => {
     async function configure() {
       if (
         !configureMutation.isLoading &&
-        !configureMutation?.data?.err() &&
         !electionDefinition &&
         authStatusQuery.data &&
         isElectionManagerAuth(authStatusQuery.data) &&
@@ -501,10 +487,8 @@ export function AppRoot({
       ) {
         const result = await configureMutation.mutateAsync();
         const electionDefinitionFromResult = result.ok();
-        // an `err` Result from this mutation is handled by UnconfiguredElectionScreen
-        if (electionDefinitionFromResult) {
-          updateElectionDefinition(electionDefinitionFromResult);
-        }
+        assert(electionDefinitionFromResult !== undefined);
+        updateElectionDefinition(electionDefinitionFromResult);
       }
     }
 
@@ -739,10 +723,6 @@ export function AppRoot({
           <Button small onPress={() => logOutMutation.mutate()}>
             Lock Machine
           </Button>
-          <UsbControllerButton
-            usbDriveStatus={usbDrive.status}
-            usbDriveEject={() => usbDrive.eject(userRole)}
-          />
         </MainNav>
         <Main centerChild>
           <UnconfiguredElectionScreen


### PR DESCRIPTION
Reverts votingworks/vxsuite#3633

@mattroe reported a bug where forcing the error caused every subsequent configure attempt to fail with the same error. It's likely the mutation is not being reattempted.