### PR TITLE
VxDesign ballot interpretation tests

### DIFF
--- a/apps/design/backend/package.json
+++ b/apps/design/backend/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@votingworks/basics": "workspace:*",
     "@votingworks/db": "workspace:*",
-    "@votingworks/design-shared": "workspace:^0.1.0",
+    "@votingworks/design-shared": "workspace:*",
     "@votingworks/grout": "workspace:*",
     "@votingworks/types": "workspace:*",
     "@votingworks/utils": "workspace:*",
@@ -74,6 +74,9 @@
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "5.37.0",
     "@typescript-eslint/parser": "5.37.0",
+    "@votingworks/ballot-interpreter": "workspace:*",
+    "@votingworks/fixtures": "workspace:*",
+    "@votingworks/image-utils": "workspace:*",
     "esbuild": "^0.14.29",
     "esbuild-runner": "^2.2.1",
     "eslint": "8.23.1",

--- a/apps/design/backend/src/ballot_interpretation.test.ts
+++ b/apps/design/backend/src/ballot_interpretation.test.ts
@@ -1,0 +1,294 @@
+import {
+  assert,
+  assertDefined,
+  find,
+  iter,
+  Optional,
+} from '@votingworks/basics';
+import { Buffer } from 'buffer';
+import { pdfToImages, writeImageData } from '@votingworks/image-utils';
+import { interpretSheet } from '@votingworks/ballot-interpreter';
+import {
+  Document,
+  TextBox,
+  layOutBallot,
+  gridPosition,
+  range,
+  AnyElement,
+} from '@votingworks/design-shared';
+import {
+  asElectionDefinition,
+  electionFamousNames2021Fixtures,
+} from '@votingworks/fixtures';
+import { singlePrecinctSelectionFor } from '@votingworks/utils';
+import { tmpNameSync } from 'tmp';
+import {
+  Candidate,
+  CandidateVote,
+  Election,
+  GridLayout,
+  Precinct,
+  SheetOf,
+  Vote,
+  VotesDict,
+} from '@votingworks/types';
+import { renderDocumentToPdf } from './render_ballot';
+import {
+  allBubbleBallotBlankBallot,
+  allBubbleBallotCyclingTestDeck,
+  allBubbleBallotElection,
+  allBubbleBallotFilledBallot,
+} from './all_bubble_ballots';
+
+async function pdfToBuffer(pdf: PDFKit.PDFDocument): Promise<Buffer> {
+  const promise = new Promise<Buffer>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    pdf.on('data', (chunk) => chunks.push(chunk));
+    pdf.on('error', reject);
+    pdf.on('end', () => resolve(Buffer.concat(chunks)));
+  });
+  pdf.end();
+  return promise;
+}
+
+async function interpretBallot({
+  election,
+  precinct,
+  ballot,
+}: {
+  election: Election;
+  precinct: Precinct;
+  ballot: Document;
+}) {
+  const pdfStream = renderDocumentToPdf(ballot);
+  const pdfBuffer = await pdfToBuffer(pdfStream);
+  const pageImages = await iter(
+    pdfToImages(pdfBuffer, { scale: 200 / 72 })
+  ).toArray();
+  expect(pageImages.length).toEqual(2);
+  const pageImagePaths: SheetOf<string> = [
+    tmpNameSync({ postfix: '.jpg' }),
+    tmpNameSync({ postfix: '.jpg' }),
+  ];
+  await writeImageData(pageImagePaths[0], pageImages[0].page);
+  await writeImageData(pageImagePaths[1], pageImages[1].page);
+
+  return interpretSheet(
+    {
+      electionDefinition: asElectionDefinition(election),
+      precinctSelection: singlePrecinctSelectionFor(precinct.id),
+      testMode: true,
+    },
+    pageImagePaths
+  );
+}
+
+function voteToOptionId(vote: Vote[number]) {
+  return vote === 'yes' || vote === 'no' ? vote : vote.id;
+}
+
+function sortVotes(vote: Vote) {
+  return [...vote].sort((a, b) =>
+    voteToOptionId(a).localeCompare(voteToOptionId(b))
+  );
+}
+
+function sortVotesDict(votes: VotesDict) {
+  return Object.fromEntries(
+    Object.entries(votes).map(([contestId, candidates]) => [
+      contestId,
+      sortVotes(candidates ?? []),
+    ])
+  );
+}
+
+describe('All bubble ballot', () => {
+  const election = allBubbleBallotElection;
+  const precinct = assertDefined(election.precincts[0]);
+
+  const [frontContest, backContest] = election.contests;
+  assert(frontContest.type === 'candidate');
+  assert(backContest.type === 'candidate');
+
+  test('Blank ballot interpretation', async () => {
+    const [frontResult, backResult] = await interpretBallot({
+      election,
+      precinct,
+      ballot: allBubbleBallotBlankBallot,
+    });
+
+    assert(frontResult.interpretation.type === 'InterpretedHmpbPage');
+    expect(frontResult.interpretation.votes).toEqual({});
+
+    assert(backResult.interpretation.type === 'InterpretedHmpbPage');
+    expect(backResult.interpretation.votes).toEqual({});
+  });
+
+  test('Filled ballot interpretation', async () => {
+    const [frontResult, backResult] = await interpretBallot({
+      election,
+      precinct,
+      ballot: allBubbleBallotFilledBallot,
+    });
+
+    assert(frontResult.interpretation.type === 'InterpretedHmpbPage');
+    expect(frontResult.interpretation.votes).toEqual({
+      [frontContest.id]: frontContest.candidates,
+    });
+
+    assert(backResult.interpretation.type === 'InterpretedHmpbPage');
+    expect(backResult.interpretation.votes).toEqual({
+      [backContest.id]: backContest.candidates,
+    });
+  });
+
+  test('Cycling test deck interpretation', async () => {
+    const votes = {
+      [frontContest.id]: [] as Candidate[],
+      [backContest.id]: [] as Candidate[],
+    } as const;
+
+    for (const card of range(0, 6)) {
+      const [frontResult, backResult] = await interpretBallot({
+        election,
+        precinct,
+        ballot: {
+          ...allBubbleBallotCyclingTestDeck,
+          pages: allBubbleBallotCyclingTestDeck.pages.slice(
+            card * 2,
+            (card + 1) * 2
+          ),
+        },
+      });
+      assert(frontResult.interpretation.type === 'InterpretedHmpbPage');
+      assert(backResult.interpretation.type === 'InterpretedHmpbPage');
+
+      for (const [contestId, candidates] of Object.entries({
+        ...frontResult.interpretation.votes,
+        ...backResult.interpretation.votes,
+      })) {
+        votes[contestId].push(
+          ...((candidates as Optional<CandidateVote>) ?? [])
+        );
+      }
+    }
+
+    expect(sortVotesDict(votes)).toEqual(
+      sortVotesDict({
+        [frontContest.id]: frontContest.candidates,
+        [backContest.id]: backContest.candidates,
+      })
+    );
+  }, 20_000);
+});
+
+function markBallot(
+  ballot: Document,
+  gridLayout: GridLayout,
+  votesToMark: VotesDict
+) {
+  assert(ballot.pages.length === 2, 'Only two page ballots are supported');
+  function marksForPage(page: number): AnyElement[] {
+    const side = page === 1 ? 'front' : 'back';
+    const pagePositions = gridLayout.gridPositions.filter(
+      (position) => position.side === side
+    );
+    return Object.entries(votesToMark).flatMap(([contestId, votes]) => {
+      if (!votes) return [];
+      const contestPositions = pagePositions.filter(
+        (position) => position.contestId === contestId
+      );
+      if (contestPositions.length === 0) return []; // Contest not on this page
+      return votes?.map((vote): TextBox => {
+        const optionPosition = find(
+          contestPositions,
+          (position) =>
+            position.type === 'option' &&
+            position.optionId === voteToOptionId(vote)
+        );
+        // Add offset to get bubble center
+        const position = gridPosition({
+          column: optionPosition.column + 1,
+          row: optionPosition.row + 1,
+        });
+        return {
+          type: 'TextBox',
+          // Offset by half bubble width/height
+          x: position.x - 3,
+          y: position.y - 5,
+          width: 10,
+          height: 10,
+          textLines: ['X'],
+          lineHeight: 10,
+          fontSize: 10,
+          fontWeight: 700,
+        };
+      });
+    });
+  }
+  return {
+    ...ballot,
+    pages: ballot.pages.map((page, i) => ({
+      ...page,
+      children: page.children.concat(marksForPage(i + 1)),
+    })),
+  };
+}
+
+describe('Laid out ballots', () => {
+  const { election } = electionFamousNames2021Fixtures;
+  const ballotStyle = election.ballotStyles[0];
+
+  test('Blank ballot interpretation', async () => {
+    const precinct = election.precincts[1];
+
+    const ballotResult = layOutBallot(election, precinct, ballotStyle);
+    assert(ballotResult.isOk());
+    const { document: ballot, gridLayout } = ballotResult.ok();
+
+    const [frontResult, backResult] = await interpretBallot({
+      election: { ...election, gridLayouts: [gridLayout] },
+      precinct,
+      ballot,
+    });
+
+    assert(frontResult.interpretation.type === 'InterpretedHmpbPage');
+    expect(frontResult.interpretation.votes).toEqual({});
+    assert(backResult.interpretation.type === 'InterpretedHmpbPage');
+    expect(backResult.interpretation.votes).toEqual({});
+  });
+
+  test('Marked ballot interpretation', async () => {
+    const precinct = election.precincts[2];
+
+    const votes: VotesDict = Object.fromEntries(
+      election.contests.map((contest, i) => {
+        assert(contest.type === 'candidate');
+        const candidates = range(0, contest.seats).map(
+          (j) => contest.candidates[(i + j) % contest.candidates.length]
+        );
+        return [contest.id, candidates];
+      })
+    );
+
+    const ballotResult = layOutBallot(election, precinct, ballotStyle);
+    assert(ballotResult.isOk());
+    const { document: ballot, gridLayout } = ballotResult.ok();
+    const markedBallot = markBallot(ballot, gridLayout, votes);
+
+    const [frontResult, backResult] = await interpretBallot({
+      election: { ...election, gridLayouts: [gridLayout] },
+      precinct,
+      ballot: markedBallot,
+    });
+
+    assert(frontResult.interpretation.type === 'InterpretedHmpbPage');
+    assert(backResult.interpretation.type === 'InterpretedHmpbPage');
+    expect(
+      sortVotesDict({
+        ...frontResult.interpretation.votes,
+        ...backResult.interpretation.votes,
+      })
+    ).toEqual(sortVotesDict(votes));
+  });
+});

--- a/apps/design/backend/tsconfig.build.json
+++ b/apps/design/backend/tsconfig.build.json
@@ -12,9 +12,12 @@
   "references": [
     { "path": "../shared/tsconfig.build.json" },
     { "path": "../../../libs/basics/tsconfig.build.json" },
+    { "path": "../../../libs/ballot-interpreter/tsconfig.build.json" },
     { "path": "../../../libs/db/tsconfig.build.json" },
     { "path": "../../../libs/eslint-plugin-vx/tsconfig.build.json" },
+    { "path": "../../../libs/fixtures/tsconfig.build.json" },
     { "path": "../../../libs/grout/tsconfig.build.json" },
+    { "path": "../../../libs/image-utils/tsconfig.build.json" },
     { "path": "../../../libs/types/tsconfig.build.json" },
     { "path": "../../../libs/utils/tsconfig.build.json" }
   ]

--- a/apps/design/backend/tsconfig.json
+++ b/apps/design/backend/tsconfig.json
@@ -20,9 +20,12 @@
   "references": [
     { "path": "../shared/tsconfig.build.json" },
     { "path": "../../../libs/basics/tsconfig.build.json" },
+    { "path": "../../../libs/ballot-interpreter/tsconfig.build.json" },
     { "path": "../../../libs/db/tsconfig.build.json" },
     { "path": "../../../libs/eslint-plugin-vx/tsconfig.build.json" },
+    { "path": "../../../libs/fixtures/tsconfig.build.json" },
     { "path": "../../../libs/grout/tsconfig.build.json" },
+    { "path": "../../../libs/image-utils/tsconfig.build.json" },
     { "path": "../../../libs/types/tsconfig.build.json" },
     { "path": "../../../libs/utils/tsconfig.build.json" }
   ]

--- a/apps/design/shared/src/layout.ts
+++ b/apps/design/shared/src/layout.ts
@@ -107,7 +107,7 @@ export interface PixelPoint {
   y: number;
 }
 
-function gridPosition({ row, column }: GridPoint): PixelPoint {
+export function gridPosition({ row, column }: GridPoint): PixelPoint {
   return {
     x: column * COLUMN_GAP,
     y: row * ROW_GAP,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1529,7 +1529,7 @@ importers:
         specifier: workspace:*
         version: link:../../../libs/db
       '@votingworks/design-shared':
-        specifier: workspace:^0.1.0
+        specifier: workspace:*
         version: link:../shared
       '@votingworks/grout':
         specifier: workspace:*
@@ -1625,6 +1625,15 @@ importers:
       '@typescript-eslint/parser':
         specifier: 5.37.0
         version: 5.37.0(eslint@8.23.1)(typescript@4.6.3)
+      '@votingworks/ballot-interpreter':
+        specifier: workspace:*
+        version: link:../../../libs/ballot-interpreter
+      '@votingworks/fixtures':
+        specifier: workspace:*
+        version: link:../../../libs/fixtures
+      '@votingworks/image-utils':
+        specifier: workspace:*
+        version: link:../../../libs/image-utils
       esbuild:
         specifier: ^0.14.29
         version: 0.14.42


### PR DESCRIPTION


## Overview

Add some basic tests to make sure we maintain the interpretability of ballots created by VxDesign.

This is a landmark moment (IMHO) because it these are the first tests that use dynamically generated ballots which can never get outdated (rather than fixtures).

I thought about putting these tests in libs/ballot-interpreter with the rest of our interpretation tests, but decided to keep them here for now since I'll be doing the majority of my development in apps/design for the moment. Open to feedback on this

## Demo Video or Screenshot
A dynamically generated and marked ballot
![image](https://github.com/votingworks/vxsuite/assets/530106/6b56db35-8aeb-4345-bc17-7a073da54841)


## Testing Plan


## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
