### PR TITLE
[VxAdmin] VVSG Design Updates: MachineLockedScreen

### DIFF
--- a/apps/admin/frontend/src/screens/machine_locked_screen.tsx
+++ b/apps/admin/frontend/src/screens/machine_locked_screen.tsx
@@ -1,10 +1,4 @@
-import {
-  fontSizeTheme,
-  ElectionInfoBar,
-  Main,
-  Prose,
-  Screen,
-} from '@votingworks/ui';
+import { ElectionInfoBar, Main, Screen, H1, P } from '@votingworks/ui';
 import React, { useContext } from 'react';
 import styled from 'styled-components';
 import { AppContext } from '../contexts/app_context';
@@ -23,18 +17,12 @@ export function MachineLockedScreen(): JSX.Element {
       <Main centerChild>
         <div>
           <LockedImage src="/locked.svg" alt="Locked Icon" />
-          <Prose
-            textCenter
-            themeDeprecated={fontSizeTheme.medium}
-            maxWidth={false}
-          >
-            <h1>VxAdmin is Locked</h1>
-            <p>
-              {electionDefinition
-                ? 'Insert System Administrator or Election Manager card to unlock.'
-                : 'Insert System Administrator card to unlock.'}
-            </p>
-          </Prose>
+          <H1 align="center">VxAdmin is Locked</H1>
+          <P align="center">
+            {electionDefinition
+              ? 'Insert System Administrator or Election Manager card to unlock.'
+              : 'Insert System Administrator card to unlock.'}
+          </P>
         </div>
       </Main>
       {electionDefinition && (


### PR DESCRIPTION
## Overview

Applying VVSG design updates to the `MachineLockedScreen` in VxAdmin:
- Replace typography components with theme-aware versions
- Remove deprecated `Prose` component

## Demo Video or Screenshot
![Screenshot 2023-06-28 at 10 51 34](https://github.com/votingworks/vxsuite/assets/264902/b853b219-6c26-420c-b114-48b5864c3cbc)

## Testing Plan
- Visual

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
