### PR TITLE
[VxAdmin] VVSG Design Updates: WriteInsScreen

### DIFF
--- a/apps/admin/frontend/src/__snapshots__/app.test.tsx.snap
+++ b/apps/admin/frontend/src/__snapshots__/app.test.tsx.snap
@@ -186,9 +186,14 @@ exports[`L&A (logic and accuracy) flow 1`] = `
 }
 
 @media print {
+  .c6 th {
+    font-size: 0.75rem;
+  }
+}
+
+@media print {
   .c6 {
     border-top: 1px solid rgb(194,200,203);
-    font-size: 0.75rem;
   }
 }
 
@@ -1670,6 +1675,10 @@ exports[`L&A (logic and accuracy) flow 2`] = `
 
 }
 
+@media print {
+
+}
+
 <div>
   <div
     aria-hidden="true"
@@ -2940,6 +2949,10 @@ exports[`L&A (logic and accuracy) flow 3`] = `
 
 }
 
+@media print {
+
+}
+
 <div>
   <div>
     <h1>
@@ -3281,9 +3294,14 @@ exports[`tabulating CVRs 1`] = `
 }
 
 @media print {
+  .c6 th {
+    font-size: 0.75rem;
+  }
+}
+
+@media print {
   .c6 {
     border-top: 1px solid rgb(194,200,203);
-    font-size: 0.75rem;
   }
 }
 

--- a/apps/admin/frontend/src/__snapshots__/app.test.tsx.snap
+++ b/apps/admin/frontend/src/__snapshots__/app.test.tsx.snap
@@ -30,7 +30,6 @@ exports[`L&A (logic and accuracy) flow 1`] = `
 
 .c6 th {
   border-top: 1px solid rgb(194,200,203);
-  font-size: 0.75rem;
 }
 
 .c7 {
@@ -189,6 +188,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
 @media print {
   .c6 {
     border-top: 1px solid rgb(194,200,203);
+    font-size: 0.75rem;
   }
 }
 
@@ -3149,7 +3149,6 @@ exports[`tabulating CVRs 1`] = `
 
 .c6 th {
   border-top: 1px solid rgb(194,200,203);
-  font-size: 0.75rem;
 }
 
 .c7 {
@@ -3284,6 +3283,7 @@ exports[`tabulating CVRs 1`] = `
 @media print {
   .c6 {
     border-top: 1px solid rgb(194,200,203);
+    font-size: 0.75rem;
   }
 }
 

--- a/apps/admin/frontend/src/screens/write_ins_screen.tsx
+++ b/apps/admin/frontend/src/screens/write_ins_screen.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useMemo, useState } from 'react';
 import styled from 'styled-components';
 
-import { Button, Modal, Prose, Table, TD, Text, TH } from '@votingworks/ui';
+import { Button, Font, Icons, P, Table, TD, TH } from '@votingworks/ui';
 import {
   CandidateContest,
   getContestDistrictName,
@@ -21,10 +21,6 @@ const ContentWrapper = styled.div`
   button {
     min-width: 9rem;
   }
-`;
-
-const ResultsFinalizedNotice = styled.p`
-  color: rgb(71, 167, 75);
 `;
 
 export function WriteInsScreen(): JSX.Element {
@@ -63,10 +59,19 @@ export function WriteInsScreen(): JSX.Element {
   if (!election) {
     return (
       <NavigationScreen title="Write-In Adjudication">
-        <Prose>
-          <p>Election must be defined.</p>
-        </Prose>
+        <P>Election must be defined.</P>
       </NavigationScreen>
+    );
+  }
+
+  if (contestBeingAdjudicated) {
+    return (
+      <WriteInsAdjudicationScreen
+        key={contestBeingAdjudicated?.id}
+        election={election}
+        contest={contestBeingAdjudicated}
+        onClose={() => setContestBeingAdjudicated(undefined)}
+      />
     );
   }
 
@@ -79,9 +84,10 @@ export function WriteInsScreen(): JSX.Element {
   function renderHeaderText() {
     if (isOfficialResults) {
       return (
-        <ResultsFinalizedNotice>
-          Tally results have been finalized. No further changes may be made.
-        </ResultsFinalizedNotice>
+        <P>
+          <Icons.Info /> Tally results have been finalized. No further changes
+          may be made.
+        </P>
       );
     }
 
@@ -90,9 +96,9 @@ export function WriteInsScreen(): JSX.Element {
       castVoteRecordFilesQuery.data.length === 0
     ) {
       return (
-        <p>
-          <em>Load CVRs to begin adjudicating write-in votes.</em>
-        </p>
+        <P>
+          <Icons.Info /> Load CVRs to begin adjudicating write-in votes.
+        </P>
       );
     }
 
@@ -102,7 +108,7 @@ export function WriteInsScreen(): JSX.Element {
   return (
     <NavigationScreen title="Write-In Adjudication">
       <ContentWrapper>
-        <Prose maxWidth={false}>
+        <div>
           {renderHeaderText()}
           <Table>
             <thead>
@@ -126,27 +132,25 @@ export function WriteInsScreen(): JSX.Element {
                 return (
                   <tr key={contest.id}>
                     <TD nowrap>
-                      <Text as="span" muted={!hasWriteIns}>
+                      <Font weight={hasWriteIns ? 'semiBold' : 'light'}>
                         {getContestDistrictName(election, contest)},{' '}
-                        <strong>{contest.title}</strong>
-                      </Text>
+                        {contest.title}
+                      </Font>
                     </TD>
                     {isPrimaryElection && (
                       <TD nowrap>
-                        <Text as="span" muted={!hasWriteIns}>
+                        <Font weight={hasWriteIns ? 'semiBold' : 'light'}>
                           {contest.partyId &&
                             `(${getPartyAbbreviationByPartyId({
                               partyId: contest.partyId,
                               election,
                             })})`}
-                        </Text>
+                        </Font>
                       </TD>
                     )}
                     <TD nowrap textAlign="center">
                       {!hasWriteIns ? (
-                        <Text as="span" muted>
-                          –
-                        </Text>
+                        <Font weight="light">–</Font>
                       ) : (
                         <Button
                           disabled={isOfficialResults}
@@ -161,9 +165,7 @@ export function WriteInsScreen(): JSX.Element {
                     </TD>
                     <TD nowrap textAlign="center">
                       {!hasWriteIns ? (
-                        <Text as="span" muted>
-                          –
-                        </Text>
+                        <Font weight="light">–</Font>
                       ) : (
                         format.count(completedCount)
                       )}
@@ -173,21 +175,8 @@ export function WriteInsScreen(): JSX.Element {
               })}
             </tbody>
           </Table>
-        </Prose>
+        </div>
       </ContentWrapper>
-      {contestBeingAdjudicated && (
-        <Modal
-          content={
-            <WriteInsAdjudicationScreen
-              key={contestBeingAdjudicated?.id}
-              election={election}
-              contest={contestBeingAdjudicated}
-              onClose={() => setContestBeingAdjudicated(undefined)}
-            />
-          }
-          fullscreen
-        />
-      )}
     </NavigationScreen>
   );
 }

--- a/libs/ui/src/table.tsx
+++ b/libs/ui/src/table.tsx
@@ -27,10 +27,10 @@ export const Table = styled.table<TableProps>`
   }
   & th {
     border-top: 1px solid ${tableBorderColor};
-    font-size: 0.75rem;
   }
   @media print {
     border-top: 1px solid ${tableBorderColor};
+    font-size: 0.75rem;
   }
 `;
 

--- a/libs/ui/src/table.tsx
+++ b/libs/ui/src/table.tsx
@@ -27,10 +27,13 @@ export const Table = styled.table<TableProps>`
   }
   & th {
     border-top: 1px solid ${tableBorderColor};
+
+    @media print {
+      font-size: 0.75rem;
+    }
   }
   @media print {
     border-top: 1px solid ${tableBorderColor};
-    font-size: 0.75rem;
   }
 `;
 


### PR DESCRIPTION
## Overview

Applying VVSG design updates to the `WriteInsScreen` in VxAdmin:
- Replacing typography elements with theme-aware versions
- Removing deprecated `Prose` and `Text` instances
- Replaced `<Text muted>` with `<Font weight="light">` where appropriate - the former was applying a faded gray, which we don't currently have in the default color theme, so using font weight to convey which rows require action instead.
- Changed the table header font size to the document default, since it looked noticeably small compared to the table body.

Additional cleanup to render the adjudication flow screen as a full-page screen instead of a `<Modal fullscreen>`

## Demo Video or Screenshot
### Before:
![Screenshot 2023-06-28 at 11 55 08](https://github.com/votingworks/vxsuite/assets/264902/60269f65-b778-4f9d-9e3b-f9fa5d88ad8b)

### After:
![Screenshot 2023-06-28 at 11 50 46](https://github.com/votingworks/vxsuite/assets/264902/912b2c93-2606-4b33-88c2-87fbf96fb39b)

![Screenshot 2023-06-28 at 11 50 18](https://github.com/votingworks/vxsuite/assets/264902/885a7d4a-b156-45ee-b187-9c02272ec3c6)

![Screenshot 2023-06-28 at 11 51 37](https://github.com/votingworks/vxsuite/assets/264902/ae6c019f-9e4e-4a5f-b5ba-5dd2ad2b08d7)

## Testing Plan
- Manual - no functional changes

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
