### PR TITLE
[CentralScan] Enable VVSG Themes

### DIFF
--- a/apps/central-scan/frontend/src/app.tsx
+++ b/apps/central-scan/frontend/src/app.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { getHardware } from '@votingworks/utils';
 import { BrowserRouter } from 'react-router-dom';
 import { Logger, LogSource } from '@votingworks/logging';
-import { ColorMode } from '@votingworks/types';
-import { AppBase, ErrorBoundary, Prose, Text } from '@votingworks/ui';
+import { AppBase, ErrorBoundary, H1, P } from '@votingworks/ui';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AppRoot, AppRootProps } from './app_root';
 import {
@@ -27,34 +26,29 @@ export function App({
   apiClient = createApiClient(),
   queryClient = createQueryClient(),
 }: Props): JSX.Element {
-  // Copied from old App.css
-  const baseFontSizePx = 24;
-
-  // TODO: Default to medium contrast and vary based on user selection.
-  const colorMode: ColorMode = 'legacy';
-
   return (
     <BrowserRouter>
-      <ErrorBoundary
-        errorMessage={
-          <Prose textCenter>
-            <h1>Something went wrong</h1>
-            <Text>Please restart the machine.</Text>
-          </Prose>
-        }
+      <AppBase
+        defaultColorMode="contrastMedium"
+        defaultSizeMode="s"
+        screenType="lenovoThinkpad15"
       >
-        <ApiClientContext.Provider value={apiClient}>
-          <QueryClientProvider client={queryClient}>
-            <AppBase
-              defaultColorMode={colorMode}
-              legacyBaseFontSizePx={baseFontSizePx}
-            >
+        <ErrorBoundary
+          errorMessage={
+            <React.Fragment>
+              <H1>Something went wrong</H1>
+              <P>Please restart the machine.</P>
+            </React.Fragment>
+          }
+        >
+          <ApiClientContext.Provider value={apiClient}>
+            <QueryClientProvider client={queryClient}>
               <AppRoot hardware={hardware} logger={logger} />
               <SessionTimeLimitTracker />
-            </AppBase>
-          </QueryClientProvider>
-        </ApiClientContext.Provider>
-      </ErrorBoundary>
+            </QueryClientProvider>
+          </ApiClientContext.Provider>
+        </ErrorBoundary>
+      </AppBase>
     </BrowserRouter>
   );
 }


### PR DESCRIPTION
## Overview

Related to: https://github.com/votingworks/vxsuite/issues/3570

Enabling the VVSG themes in CentralScan for consistency across VxSuite. Setting the color mode to the VVSG default medium contrast and text size mode to "small" for a start, similar to VxAdmin.

Will be updating typography/colors to their theme-aware versions over the course of the next few PRs and fixing anything that might look off as a result of switching to the new themes.

Also moving the global styles component to the top of the render tree and replacing typography components in the `ErrorBoundary` while I'm here.

## Demo Video or Screenshot
### Clickthrough of the Election Manager view:
https://github.com/votingworks/vxsuite/assets/264902/c4c92d00-5d18-490d-8e6b-014b388623a8

### System Admin View:
![Screenshot 2023-06-29 at 11 31 37](https://github.com/votingworks/vxsuite/assets/264902/a00bcd45-1e06-48f3-9ad8-a7b3ab7f7833)

## Testing Plan
- Manual spot checks

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
