### PR TITLE
style(jsx): remove unnecessary `React` from scope

### DIFF
--- a/apps/admin/frontend/babel.config.js
+++ b/apps/admin/frontend/babel.config.js
@@ -2,5 +2,5 @@
  * @type {import('@babel/core').TransformOptions}
  */
 module.exports = {
-  presets: ['react-app'],
+  presets: [['react-app', { runtime: 'automatic' }]],
 };

--- a/apps/admin/frontend/src/app.tsx
+++ b/apps/admin/frontend/src/app.tsx
@@ -3,7 +3,6 @@ import {
   getPrinter,
   getConverterClientType,
 } from '@votingworks/utils';
-import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import './App.css';
 import { LogSource, Logger } from '@votingworks/logging';

--- a/apps/admin/frontend/src/app_root.test.tsx
+++ b/apps/admin/frontend/src/app_root.test.tsx
@@ -1,6 +1,5 @@
 import { MemoryHardware, NullPrinter } from '@votingworks/utils';
 import fetchMock from 'fetch-mock';
-import React from 'react';
 import { BrowserRouter, Route } from 'react-router-dom';
 import { electionMinimalExhaustiveSampleDefinition } from '@votingworks/fixtures';
 import { LogSource, Logger } from '@votingworks/logging';

--- a/apps/admin/frontend/src/app_root.tsx
+++ b/apps/admin/frontend/src/app_root.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { LogEventId, Logger } from '@votingworks/logging';
 import { Printer, ConverterClientType } from '@votingworks/types';
 import {

--- a/apps/admin/frontend/src/components/__mocks__/hand_marked_paper_ballot.tsx
+++ b/apps/admin/frontend/src/components/__mocks__/hand_marked_paper_ballot.tsx
@@ -1,5 +1,5 @@
 import { getPrecinctById } from '@votingworks/types';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { HandMarkedPaperBallotProps } from '../hand_marked_paper_ballot';
 
 export function HandMarkedPaperBallot({

--- a/apps/admin/frontend/src/components/admin_tally_report_by_party.test.tsx
+++ b/apps/admin/frontend/src/components/admin_tally_report_by_party.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   electionFamousNames2021Fixtures,
   electionMinimalExhaustiveSampleDefinition,

--- a/apps/admin/frontend/src/components/ballot_counts_table.test.tsx
+++ b/apps/admin/frontend/src/components/ballot_counts_table.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import {
   electionWithMsEitherNeither,
   multiPartyPrimaryElectionDefinition,

--- a/apps/admin/frontend/src/components/ballot_counts_table.tsx
+++ b/apps/admin/frontend/src/components/ballot_counts_table.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { format, getBallotCount } from '@votingworks/utils';
 import { assert, find, throwIllegalValue } from '@votingworks/basics';
 import { LinkButton, Table, TD } from '@votingworks/ui';

--- a/apps/admin/frontend/src/components/bubble_mark.test.tsx
+++ b/apps/admin/frontend/src/components/bubble_mark.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '../../test/react_testing_library';
 
 import { Bubble } from './bubble_mark';

--- a/apps/admin/frontend/src/components/export_election_ballot_package_modal_button.test.tsx
+++ b/apps/admin/frontend/src/components/export_election_ballot_package_modal_button.test.tsx
@@ -5,7 +5,6 @@ import {
   fakeKiosk,
   fakeUsbDrive,
 } from '@votingworks/test-utils';
-import React from 'react';
 import { UsbDriveStatus, mockUsbDrive } from '@votingworks/ui';
 import userEvent from '@testing-library/user-event';
 import { err } from '@votingworks/basics';

--- a/apps/admin/frontend/src/components/full_test_deck_tally_report_button.test.tsx
+++ b/apps/admin/frontend/src/components/full_test_deck_tally_report_button.test.tsx
@@ -9,7 +9,6 @@ import {
   fakeKiosk,
   fakeUsbDrive,
 } from '@votingworks/test-utils';
-import React from 'react';
 import { mockUsbDrive } from '@votingworks/ui';
 import { screen, within } from '../../test/react_testing_library';
 import { renderInAppContext } from '../../test/render_in_app_context';

--- a/apps/admin/frontend/src/components/import_cvrfiles_modal.test.tsx
+++ b/apps/admin/frontend/src/components/import_cvrfiles_modal.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { fakeKiosk } from '@votingworks/test-utils';
 
 import { ElectronFile, UsbDriveStatus, mockUsbDrive } from '@votingworks/ui';

--- a/apps/admin/frontend/src/components/layout/logo.tsx
+++ b/apps/admin/frontend/src/components/layout/logo.tsx
@@ -1,5 +1,4 @@
 /* stylelint-disable order/properties-order */
-import React from 'react';
 import styled from 'styled-components';
 
 import { LogoMark } from '@votingworks/ui';

--- a/apps/admin/frontend/src/components/loading.tsx
+++ b/apps/admin/frontend/src/components/loading.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'styled-components';
 
 import { ProgressEllipsis } from '@votingworks/ui';

--- a/apps/admin/frontend/src/components/print_button.test.tsx
+++ b/apps/admin/frontend/src/components/print_button.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { advancePromises, fakeKiosk } from '@votingworks/test-utils';
 
 import userEvent from '@testing-library/user-event';

--- a/apps/admin/frontend/src/components/save_backend_file_modal.test.tsx
+++ b/apps/admin/frontend/src/components/save_backend_file_modal.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   advancePromises,
   fakeKiosk,

--- a/apps/admin/frontend/src/components/save_frontend_file_modal.test.tsx
+++ b/apps/admin/frontend/src/components/save_frontend_file_modal.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils';
 
 import { fakeLogger, LogEventId } from '@votingworks/logging';

--- a/apps/admin/frontend/src/components/session_time_limit_tracker.tsx
+++ b/apps/admin/frontend/src/components/session_time_limit_tracker.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { SessionTimeLimitTracker as SessionTimeLimitTrackerBase } from '@votingworks/ui';
 
 import {

--- a/apps/admin/frontend/src/components/test_deck_tally_report.tsx
+++ b/apps/admin/frontend/src/components/test_deck_tally_report.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   CandidateVote,
   Election,

--- a/apps/admin/frontend/src/components/write_in_line.tsx
+++ b/apps/admin/frontend/src/components/write_in_line.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'styled-components';
 
 interface Props {

--- a/apps/admin/frontend/src/screens/ballot_list_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_list_screen.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 
 import { assert } from '@votingworks/basics';
 import { P } from '@votingworks/ui';

--- a/apps/admin/frontend/src/screens/logic_and_accuracy_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/logic_and_accuracy_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { electionMinimalExhaustiveSampleDefinition } from '@votingworks/fixtures';
 import { fakeKiosk, fakePrinterInfo } from '@votingworks/test-utils';
 import { fakeLogger, Logger } from '@votingworks/logging';

--- a/apps/admin/frontend/src/screens/logs_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/logs_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { fakeKiosk } from '@votingworks/test-utils';
 import { screen } from '../../test/react_testing_library';

--- a/apps/admin/frontend/src/screens/logs_screen.tsx
+++ b/apps/admin/frontend/src/screens/logs_screen.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { ExportLogsButtonRow } from '@votingworks/ui';
 
 import { AppContext } from '../contexts/app_context';

--- a/apps/admin/frontend/src/screens/machine_locked_screen.tsx
+++ b/apps/admin/frontend/src/screens/machine_locked_screen.tsx
@@ -1,5 +1,5 @@
 import { ElectionInfoBar, Main, Screen, H1, P } from '@votingworks/ui';
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import styled from 'styled-components';
 import { AppContext } from '../contexts/app_context';
 

--- a/apps/admin/frontend/src/screens/manual_data_entry_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_entry_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { electionMinimalExhaustiveSampleDefinition } from '@votingworks/fixtures';
 import { Route } from 'react-router-dom';
 

--- a/apps/admin/frontend/src/screens/manual_data_summary_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_summary_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { electionMinimalExhaustiveSampleDefinition } from '@votingworks/fixtures';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
 import { createMemoryHistory } from 'history';

--- a/apps/admin/frontend/src/screens/print_test_deck_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/print_test_deck_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   electionMinimalExhaustiveSampleDefinition,
   asElectionDefinition,

--- a/apps/admin/frontend/src/screens/reports_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/reports_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import MockDate from 'mockdate';
 import { electionMinimalExhaustiveSampleDefinition } from '@votingworks/fixtures';
 import fetchMock from 'fetch-mock';

--- a/apps/admin/frontend/src/screens/settings_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/settings_screen.test.tsx
@@ -1,5 +1,4 @@
 import MockDate from 'mockdate';
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { fakeKiosk } from '@votingworks/test-utils';
 import { screen, waitFor, within } from '../../test/react_testing_library';

--- a/apps/admin/frontend/src/screens/settings_screen.tsx
+++ b/apps/admin/frontend/src/screens/settings_screen.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import {
   CurrentDateAndTime,
   H2,

--- a/apps/admin/frontend/src/screens/smartcards_screen.tsx
+++ b/apps/admin/frontend/src/screens/smartcards_screen.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'styled-components';
 import { assert } from '@votingworks/basics';
 import { LinkButton, P } from '@votingworks/ui';

--- a/apps/admin/frontend/src/screens/tally_report_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/tally_report_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   electionFamousNames2021Fixtures,
   electionMinimalExhaustiveSampleDefinition,

--- a/apps/admin/frontend/src/screens/tally_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/tally_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { electionMinimalExhaustiveSampleDefinition } from '@votingworks/fixtures';
 import { createMemoryHistory } from 'history';
 import { Router } from 'react-router-dom';

--- a/apps/admin/frontend/src/screens/tally_writein_report_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/tally_writein_report_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { electionMinimalExhaustiveSampleFixtures } from '@votingworks/fixtures';
 import { fakeKiosk, fakePrinterInfo } from '@votingworks/test-utils';
 import { fakeLogger, Logger } from '@votingworks/logging';

--- a/apps/admin/frontend/src/screens/unconfigured_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/unconfigured_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   electionFamousNames2021Fixtures,
   electionMinimalExhaustiveSampleFixtures,

--- a/apps/admin/frontend/src/screens/unconfigured_screen.tsx
+++ b/apps/admin/frontend/src/screens/unconfigured_screen.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useContext,
-  useState,
-  useEffect,
-  useCallback,
-  useMemo,
-} from 'react';
+import { useContext, useState, useEffect, useCallback, useMemo } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';

--- a/apps/admin/frontend/src/screens/write_ins_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/write_ins_adjudication_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { electionMinimalExhaustiveSampleDefinition as electionDefinition } from '@votingworks/fixtures';
 import { CandidateContest } from '@votingworks/types';
 import userEvent from '@testing-library/user-event';

--- a/apps/admin/frontend/src/screens/write_ins_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/write_ins_screen.test.tsx
@@ -1,7 +1,6 @@
 import userEvent from '@testing-library/user-event';
 import { electionMinimalExhaustiveSampleFixtures } from '@votingworks/fixtures';
 import { sleep } from '@votingworks/basics';
-import React from 'react';
 import type {
   WriteInCandidateRecord,
   WriteInRecordPending,

--- a/apps/admin/frontend/src/screens/write_ins_screen.tsx
+++ b/apps/admin/frontend/src/screens/write_ins_screen.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo, useState } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import styled from 'styled-components';
 
 import { Button, Font, Icons, P, Table, TD, TH } from '@votingworks/ui';

--- a/apps/central-scan/frontend/src/app.test.tsx
+++ b/apps/central-scan/frontend/src/app.test.tsx
@@ -1,5 +1,4 @@
 import fetchMock from 'fetch-mock';
-import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { electionSampleDefinition } from '@votingworks/fixtures';
 import {

--- a/apps/central-scan/frontend/src/app.tsx
+++ b/apps/central-scan/frontend/src/app.tsx
@@ -1,4 +1,5 @@
 import { getHardware } from '@votingworks/utils';
+import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { Logger, LogSource } from '@votingworks/logging';
 import { AppBase, ErrorBoundary, H1, P } from '@votingworks/ui';

--- a/apps/central-scan/frontend/src/app.tsx
+++ b/apps/central-scan/frontend/src/app.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { getHardware } from '@votingworks/utils';
 import { BrowserRouter } from 'react-router-dom';
 import { Logger, LogSource } from '@votingworks/logging';

--- a/apps/central-scan/frontend/src/components/delete_batch_modal.test.tsx
+++ b/apps/central-scan/frontend/src/components/delete_batch_modal.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { MockApiClient, createMockApiClient, provideApi } from '../../test/api';
 import { render, screen, waitFor } from '../../test/react_testing_library';

--- a/apps/central-scan/frontend/src/components/export_results_modal.test.tsx
+++ b/apps/central-scan/frontend/src/components/export_results_modal.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 import fetchMock from 'fetch-mock';

--- a/apps/central-scan/frontend/src/components/loading.tsx
+++ b/apps/central-scan/frontend/src/components/loading.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'styled-components';
 
 import { ProgressEllipsis } from '@votingworks/ui';

--- a/apps/central-scan/frontend/src/components/scan_button.test.tsx
+++ b/apps/central-scan/frontend/src/components/scan_button.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { fakeKiosk } from '@votingworks/test-utils';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '../../test/react_testing_library';

--- a/apps/central-scan/frontend/src/components/scan_button.tsx
+++ b/apps/central-scan/frontend/src/components/scan_button.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Button } from '@votingworks/ui';
 
 export interface Props {

--- a/apps/central-scan/frontend/src/components/session_time_limit_tracker.tsx
+++ b/apps/central-scan/frontend/src/components/session_time_limit_tracker.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { SessionTimeLimitTracker as SessionTimeLimitTrackerBase } from '@votingworks/ui';
 
 import {

--- a/apps/central-scan/frontend/src/components/set_mark_thresholds_modal.test.tsx
+++ b/apps/central-scan/frontend/src/components/set_mark_thresholds_modal.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { electionSample } from '@votingworks/fixtures';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';

--- a/apps/central-scan/frontend/src/screens/admin_actions_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/admin_actions_screen.test.tsx
@@ -7,7 +7,6 @@ import {
 } from '@votingworks/test-utils';
 import { err, ok, deferred } from '@votingworks/basics';
 import MockDate from 'mockdate';
-import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
 import { screen, waitFor, within } from '../../test/react_testing_library';

--- a/apps/central-scan/frontend/src/screens/ballot_eject_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/ballot_eject_screen.test.tsx
@@ -7,7 +7,6 @@ import {
 import { Scan } from '@votingworks/api';
 import { typedAs } from '@votingworks/basics';
 import fetchMock from 'fetch-mock';
-import React from 'react';
 import { act } from 'react-dom/test-utils';
 import userEvent from '@testing-library/user-event';
 import {

--- a/apps/central-scan/frontend/src/screens/dashboard_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/dashboard_screen.test.tsx
@@ -1,7 +1,6 @@
 import { Scan } from '@votingworks/api';
 import { AdjudicationStatus } from '@votingworks/types';
 import { createMemoryHistory } from 'history';
-import React from 'react';
 import { Router } from 'react-router-dom';
 import { render } from '../../test/react_testing_library';
 import { DashboardScreen } from './dashboard_screen';

--- a/apps/central-scan/frontend/src/screens/unconfigured_election_screen_wrapper.tsx
+++ b/apps/central-scan/frontend/src/screens/unconfigured_election_screen_wrapper.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   Button,
   Main,

--- a/apps/design/backend/src/render_ballot.tsx
+++ b/apps/design/backend/src/render_ballot.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactDomServer from 'react-dom/server';
 import { throwIllegalValue } from '@votingworks/basics';
 import fs, { readFileSync } from 'fs';

--- a/apps/design/frontend/src/ballot_viewer.tsx
+++ b/apps/design/frontend/src/ballot_viewer.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-array-index-key */
-import React, { useRef, useState, useMemo, useCallback } from 'react';
+import { useRef, useState, useMemo, useCallback } from 'react';
 import { throwIllegalValue } from '@votingworks/basics';
 import { BallotStyle, Election, Precinct } from '@votingworks/types';
 import styled from 'styled-components';

--- a/apps/mark-scan/frontend/src/apimachine_config.test.tsx
+++ b/apps/mark-scan/frontend/src/apimachine_config.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { MemoryStorage } from '@votingworks/utils';
 import { advanceTimersAndPromises } from '@votingworks/test-utils';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';

--- a/apps/mark-scan/frontend/src/app.test.tsx
+++ b/apps/mark-scan/frontend/src/app.test.tsx
@@ -6,7 +6,6 @@ import {
 } from '@votingworks/utils';
 
 import fetchMock from 'fetch-mock';
-import * as React from 'react';
 import { electionSampleDefinition } from '@votingworks/fixtures';
 import userEvent from '@testing-library/user-event';
 import { fireEvent, screen, waitFor } from '../test/react_testing_library';

--- a/apps/mark-scan/frontend/src/app_ballot_package_config.test.tsx
+++ b/apps/mark-scan/frontend/src/app_ballot_package_config.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { FakeKiosk, fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils';
 import { fakeLogger } from '@votingworks/logging';
 import { electionSampleDefinition } from '@votingworks/fixtures';

--- a/apps/mark-scan/frontend/src/app_card_unhappy_paths.test.tsx
+++ b/apps/mark-scan/frontend/src/app_card_unhappy_paths.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { electionSampleDefinition } from '@votingworks/fixtures';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';

--- a/apps/mark-scan/frontend/src/app_cardless_voting.test.tsx
+++ b/apps/mark-scan/frontend/src/app_cardless_voting.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 import { FakeKiosk, expectPrint, fakeKiosk } from '@votingworks/test-utils';
 import { electionSampleDefinition } from '@votingworks/fixtures';

--- a/apps/mark-scan/frontend/src/app_contest_candidate_no_party.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_candidate_no_party.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 
 import { CandidateContest, Election } from '@votingworks/types';

--- a/apps/mark-scan/frontend/src/app_contest_ms_either_neither.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_ms_either_neither.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   MemoryStorage,
   MemoryHardware,

--- a/apps/mark-scan/frontend/src/app_contest_multi_seat.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_multi_seat.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 
 import userEvent from '@testing-library/user-event';

--- a/apps/mark-scan/frontend/src/app_contest_single_seat.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_single_seat.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 
 import userEvent from '@testing-library/user-event';

--- a/apps/mark-scan/frontend/src/app_contest_write_in.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_write_in.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { expectPrint } from '@votingworks/test-utils';
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 import userEvent from '@testing-library/user-event';

--- a/apps/mark-scan/frontend/src/app_contest_yes_no.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_yes_no.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { electionSample } from '@votingworks/fixtures';
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 

--- a/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import {
   getZeroCompressedTally,

--- a/apps/mark-scan/frontend/src/app_quit_on_idle.test.tsx
+++ b/apps/mark-scan/frontend/src/app_quit_on_idle.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { fakeKiosk } from '@votingworks/test-utils';
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 

--- a/apps/mark-scan/frontend/src/app_replace_election.test.tsx
+++ b/apps/mark-scan/frontend/src/app_replace_election.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MemoryHardware, MemoryStorage } from '@votingworks/utils';
 import {
   electionSample2Definition,

--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useReducer, useRef } from 'react';
+import { useCallback, useEffect, useReducer, useRef } from 'react';
 import {
   ElectionDefinition,
   OptionalElectionDefinition,

--- a/apps/mark-scan/frontend/src/app_setup_errors.test.tsx
+++ b/apps/mark-scan/frontend/src/app_setup_errors.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 
 import {

--- a/apps/mark-scan/frontend/src/app_single_precinct_election.test.tsx
+++ b/apps/mark-scan/frontend/src/app_single_precinct_election.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MemoryHardware, MemoryStorage } from '@votingworks/utils';
 import { electionMinimalExhaustiveSampleSinglePrecinctDefinition } from '@votingworks/fixtures';
 import { getDisplayElectionHash } from '@votingworks/types';

--- a/apps/mark-scan/frontend/src/app_test_mode.test.tsx
+++ b/apps/mark-scan/frontend/src/app_test_mode.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import {
   asElectionDefinition,

--- a/apps/mark-scan/frontend/src/components/ballot.test.tsx
+++ b/apps/mark-scan/frontend/src/components/ballot.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { createMemoryHistory } from 'history';
 import userEvent from '@testing-library/user-event';
 

--- a/apps/mark-scan/frontend/src/components/ballot.tsx
+++ b/apps/mark-scan/frontend/src/components/ballot.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import { IdleTimerProvider } from 'react-idle-timer';
 

--- a/apps/mark-scan/frontend/src/components/display_settings_button.test.tsx
+++ b/apps/mark-scan/frontend/src/components/display_settings_button.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 import userEvent from '@testing-library/user-event';

--- a/apps/mark-scan/frontend/src/components/display_settings_button.tsx
+++ b/apps/mark-scan/frontend/src/components/display_settings_button.tsx
@@ -1,5 +1,4 @@
 /* stylelint-disable order/properties-order */
-import React from 'react';
 import { Button, Icons } from '@votingworks/ui';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';

--- a/apps/mark-scan/frontend/src/components/election_info.test.tsx
+++ b/apps/mark-scan/frontend/src/components/election_info.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { singlePrecinctSelectionFor } from '@votingworks/utils';
 
 import { electionSampleDefinition as electionDefinition } from '@votingworks/fixtures';

--- a/apps/mark-scan/frontend/src/components/focus_manager.test.tsx
+++ b/apps/mark-scan/frontend/src/components/focus_manager.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen, waitFor } from '../../test/react_testing_library';
 import { render } from '../../test/test_utils';
 

--- a/apps/mark-scan/frontend/src/components/session_time_limit_tracker.tsx
+++ b/apps/mark-scan/frontend/src/components/session_time_limit_tracker.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { SessionTimeLimitTracker as SessionTimeLimitTrackerBase } from '@votingworks/ui';
 
 import {

--- a/apps/mark-scan/frontend/src/lib/gamepad.test.tsx
+++ b/apps/mark-scan/frontend/src/lib/gamepad.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 import { fireEvent, render, screen } from '../../test/react_testing_library';
 import { App } from '../app';

--- a/apps/mark-scan/frontend/src/pages/accessible_controller_diagnostic_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/accessible_controller_diagnostic_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import MockDate from 'mockdate';
 import { DateTime } from 'luxon';

--- a/apps/mark-scan/frontend/src/pages/accessible_controller_diagnostic_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/accessible_controller_diagnostic_screen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button, Font, H1, Main, P, Prose, Screen } from '@votingworks/ui';
 import { DateTime } from 'luxon';
 import styled from 'styled-components';

--- a/apps/mark-scan/frontend/src/pages/admin_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/admin_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import MockDate from 'mockdate';
 
 import {

--- a/apps/mark-scan/frontend/src/pages/card_error_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/card_error_screen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 import { Main, Screen, Prose, RotateCardImage, H1, P } from '@votingworks/ui';
 import { triggerAudioFocus } from '../utils/trigger_audio_focus';

--- a/apps/mark-scan/frontend/src/pages/contest_page.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/contest_page.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Route } from 'react-router-dom';
 import { electionSampleDefinition } from '@votingworks/fixtures';
 import userEvent from '@testing-library/user-event';

--- a/apps/mark-scan/frontend/src/pages/diagnostics_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/diagnostics_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import MockDate from 'mockdate';
 import { fakeMarkerInfo } from '@votingworks/test-utils';

--- a/apps/mark-scan/frontend/src/pages/display_settings_page.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/display_settings_page.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 import userEvent from '@testing-library/user-event';

--- a/apps/mark-scan/frontend/src/pages/display_settings_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/display_settings_page.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { DisplaySettings } from '@votingworks/ui';

--- a/apps/mark-scan/frontend/src/pages/idle_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/idle_page.tsx
@@ -1,5 +1,5 @@
 import { IdlePage as MarkFlowIdlePage } from '@votingworks/mark-flow-ui';
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { BallotContext } from '../contexts/ballot_context';
 
 export function IdlePage(): JSX.Element {

--- a/apps/mark-scan/frontend/src/pages/not_found_page.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/not_found_page.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Route } from 'react-router-dom';
 import { fireEvent, screen } from '../../test/react_testing_library';
 

--- a/apps/mark-scan/frontend/src/pages/not_found_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/not_found_page.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { Button, Main, Screen, Prose, H1, P } from '@votingworks/ui';

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import {
   asElectionDefinition,
   electionSampleDefinition,

--- a/apps/mark-scan/frontend/src/pages/print_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/print_page.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { PrintPage as MarkFlowPrintPage } from '@votingworks/mark-flow-ui';
 import { assert } from '@votingworks/basics';
 import { BallotContext } from '../contexts/ballot_context';

--- a/apps/mark-scan/frontend/src/pages/replace_election_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/replace_election_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   electionSampleDefinition,
   primaryElectionSampleDefinition,

--- a/apps/mark-scan/frontend/src/pages/replace_election_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/replace_election_screen.tsx
@@ -14,7 +14,7 @@ import { formatLongDate } from '@votingworks/utils';
 import type { MachineConfig } from '@votingworks/mark-scan-backend';
 import { DateTime } from 'luxon';
 import pluralize from 'pluralize';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { ScreenReader } from '../config/types';
 
 export interface ReplaceElectionScreenProps {

--- a/apps/mark-scan/frontend/src/pages/review_page.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/review_page.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Route } from 'react-router-dom';
 import { electionSampleDefinition } from '@votingworks/fixtures';
 import { createMemoryHistory } from 'history';

--- a/apps/mark-scan/frontend/src/pages/setup_power_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/setup_power_page.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Main, NoWrap, Screen, Prose, H1, P } from '@votingworks/ui';
 
 export function SetupPowerPage(): JSX.Element {

--- a/apps/mark-scan/frontend/src/pages/setup_printer_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/setup_printer_page.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Main, Screen, Prose, H1, P } from '@votingworks/ui';
 
 export function SetupPrinterPage(): JSX.Element {

--- a/apps/mark-scan/frontend/src/pages/start_page.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/start_page.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Route } from 'react-router-dom';
 import {
   primaryElectionSampleDefinition,

--- a/apps/mark-scan/frontend/src/pages/system_administrator_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/system_administrator_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { fakeLogger } from '@votingworks/logging';
 import { screen } from '../../test/react_testing_library';
 

--- a/apps/mark-scan/frontend/src/pages/unconfigured_election_screen_wrapper.tsx
+++ b/apps/mark-scan/frontend/src/pages/unconfigured_election_screen_wrapper.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import {
   UnconfiguredElectionScreen,
   UsbDriveStatus,

--- a/apps/mark-scan/frontend/src/pages/unconfigured_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/unconfigured_screen.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Main, Screen, CenteredLargeProse, H1, P } from '@votingworks/ui';
 
 interface Props {

--- a/apps/mark-scan/frontend/src/pages/wrong_election_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/wrong_election_screen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 import { Main, Screen, Prose, H1, P } from '@votingworks/ui';
 

--- a/apps/mark-scan/frontend/test/helpers/build_app.tsx
+++ b/apps/mark-scan/frontend/test/helpers/build_app.tsx
@@ -1,6 +1,5 @@
 import { fakeLogger, Logger } from '@votingworks/logging';
 import { MemoryHardware, MemoryStorage } from '@votingworks/utils';
-import React from 'react';
 import { render, RenderResult } from '../react_testing_library';
 import { App } from '../../src/app';
 import { ScreenReader, TextToSpeech } from '../../src/config/types';

--- a/apps/mark/frontend/src/apimachine_config.test.tsx
+++ b/apps/mark/frontend/src/apimachine_config.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { MemoryStorage } from '@votingworks/utils';
 import { advanceTimersAndPromises } from '@votingworks/test-utils';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';

--- a/apps/mark/frontend/src/app.test.tsx
+++ b/apps/mark/frontend/src/app.test.tsx
@@ -6,7 +6,6 @@ import {
 } from '@votingworks/utils';
 
 import fetchMock from 'fetch-mock';
-import * as React from 'react';
 import { electionSampleDefinition } from '@votingworks/fixtures';
 import userEvent from '@testing-library/user-event';
 import { fireEvent, screen, waitFor } from '../test/react_testing_library';

--- a/apps/mark/frontend/src/app_ballot_package_config.test.tsx
+++ b/apps/mark/frontend/src/app_ballot_package_config.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { FakeKiosk, fakeKiosk, fakeUsbDrive } from '@votingworks/test-utils';
 import { fakeLogger } from '@votingworks/logging';
 import { electionSampleDefinition } from '@votingworks/fixtures';

--- a/apps/mark/frontend/src/app_card_unhappy_paths.test.tsx
+++ b/apps/mark/frontend/src/app_card_unhappy_paths.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { electionSampleDefinition } from '@votingworks/fixtures';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';

--- a/apps/mark/frontend/src/app_cardless_voting.test.tsx
+++ b/apps/mark/frontend/src/app_cardless_voting.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 import { FakeKiosk, expectPrint, fakeKiosk } from '@votingworks/test-utils';
 import { electionSampleDefinition } from '@votingworks/fixtures';

--- a/apps/mark/frontend/src/app_contest_candidate_no_party.test.tsx
+++ b/apps/mark/frontend/src/app_contest_candidate_no_party.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 
 import { CandidateContest, Election } from '@votingworks/types';

--- a/apps/mark/frontend/src/app_contest_ms_either_neither.test.tsx
+++ b/apps/mark/frontend/src/app_contest_ms_either_neither.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   MemoryStorage,
   MemoryHardware,

--- a/apps/mark/frontend/src/app_contest_multi_seat.test.tsx
+++ b/apps/mark/frontend/src/app_contest_multi_seat.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 
 import userEvent from '@testing-library/user-event';

--- a/apps/mark/frontend/src/app_contest_single_seat.test.tsx
+++ b/apps/mark/frontend/src/app_contest_single_seat.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 
 import userEvent from '@testing-library/user-event';

--- a/apps/mark/frontend/src/app_contest_write_in.test.tsx
+++ b/apps/mark/frontend/src/app_contest_write_in.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { expectPrint } from '@votingworks/test-utils';
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 import userEvent from '@testing-library/user-event';

--- a/apps/mark/frontend/src/app_contest_yes_no.test.tsx
+++ b/apps/mark/frontend/src/app_contest_yes_no.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { electionSample } from '@votingworks/fixtures';
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 

--- a/apps/mark/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark/frontend/src/app_end_to_end.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import {
   getZeroCompressedTally,

--- a/apps/mark/frontend/src/app_quit_on_idle.test.tsx
+++ b/apps/mark/frontend/src/app_quit_on_idle.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { fakeKiosk } from '@votingworks/test-utils';
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 

--- a/apps/mark/frontend/src/app_replace_election.test.tsx
+++ b/apps/mark/frontend/src/app_replace_election.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MemoryHardware, MemoryStorage } from '@votingworks/utils';
 import {
   electionSample2Definition,

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useReducer, useRef } from 'react';
+import { useCallback, useEffect, useReducer, useRef } from 'react';
 import {
   ElectionDefinition,
   OptionalElectionDefinition,

--- a/apps/mark/frontend/src/app_setup_errors.test.tsx
+++ b/apps/mark/frontend/src/app_setup_errors.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 
 import {

--- a/apps/mark/frontend/src/app_single_precinct_election.test.tsx
+++ b/apps/mark/frontend/src/app_single_precinct_election.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MemoryHardware, MemoryStorage } from '@votingworks/utils';
 import { electionMinimalExhaustiveSampleSinglePrecinctDefinition } from '@votingworks/fixtures';
 import { getDisplayElectionHash } from '@votingworks/types';

--- a/apps/mark/frontend/src/app_test_mode.test.tsx
+++ b/apps/mark/frontend/src/app_test_mode.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import {
   asElectionDefinition,

--- a/apps/mark/frontend/src/components/ballot.test.tsx
+++ b/apps/mark/frontend/src/components/ballot.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { createMemoryHistory } from 'history';
 import userEvent from '@testing-library/user-event';
 

--- a/apps/mark/frontend/src/components/ballot.tsx
+++ b/apps/mark/frontend/src/components/ballot.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import { IdleTimerProvider } from 'react-idle-timer';
 

--- a/apps/mark/frontend/src/components/display_settings_button.test.tsx
+++ b/apps/mark/frontend/src/components/display_settings_button.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 import userEvent from '@testing-library/user-event';

--- a/apps/mark/frontend/src/components/display_settings_button.tsx
+++ b/apps/mark/frontend/src/components/display_settings_button.tsx
@@ -1,5 +1,4 @@
 /* stylelint-disable order/properties-order */
-import React from 'react';
 import { Button, Icons } from '@votingworks/ui';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';

--- a/apps/mark/frontend/src/components/election_info.test.tsx
+++ b/apps/mark/frontend/src/components/election_info.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { singlePrecinctSelectionFor } from '@votingworks/utils';
 
 import { electionSampleDefinition as electionDefinition } from '@votingworks/fixtures';

--- a/apps/mark/frontend/src/components/focus_manager.test.tsx
+++ b/apps/mark/frontend/src/components/focus_manager.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen, waitFor } from '../../test/react_testing_library';
 import { render } from '../../test/test_utils';
 

--- a/apps/mark/frontend/src/components/session_time_limit_tracker.tsx
+++ b/apps/mark/frontend/src/components/session_time_limit_tracker.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { SessionTimeLimitTracker as SessionTimeLimitTrackerBase } from '@votingworks/ui';
 
 import {

--- a/apps/mark/frontend/src/lib/gamepad.test.tsx
+++ b/apps/mark/frontend/src/lib/gamepad.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 import { fireEvent, render, screen } from '../../test/react_testing_library';
 import { App } from '../app';

--- a/apps/mark/frontend/src/pages/accessible_controller_diagnostic_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/accessible_controller_diagnostic_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import MockDate from 'mockdate';
 import { DateTime } from 'luxon';

--- a/apps/mark/frontend/src/pages/accessible_controller_diagnostic_screen.tsx
+++ b/apps/mark/frontend/src/pages/accessible_controller_diagnostic_screen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button, Font, H1, Main, P, Prose, Screen } from '@votingworks/ui';
 import { DateTime } from 'luxon';
 import styled from 'styled-components';

--- a/apps/mark/frontend/src/pages/admin_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import MockDate from 'mockdate';
 
 import {

--- a/apps/mark/frontend/src/pages/card_error_screen.tsx
+++ b/apps/mark/frontend/src/pages/card_error_screen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 import { Main, Screen, Prose, RotateCardImage, H1, P } from '@votingworks/ui';
 import { triggerAudioFocus } from '../utils/trigger_audio_focus';

--- a/apps/mark/frontend/src/pages/contest_page.test.tsx
+++ b/apps/mark/frontend/src/pages/contest_page.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Route } from 'react-router-dom';
 import { electionSampleDefinition } from '@votingworks/fixtures';
 import userEvent from '@testing-library/user-event';

--- a/apps/mark/frontend/src/pages/diagnostics_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/diagnostics_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import MockDate from 'mockdate';
 import { fakeMarkerInfo } from '@votingworks/test-utils';

--- a/apps/mark/frontend/src/pages/display_settings_page.test.tsx
+++ b/apps/mark/frontend/src/pages/display_settings_page.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 import userEvent from '@testing-library/user-event';

--- a/apps/mark/frontend/src/pages/display_settings_page.tsx
+++ b/apps/mark/frontend/src/pages/display_settings_page.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { DisplaySettings } from '@votingworks/ui';

--- a/apps/mark/frontend/src/pages/idle_page.tsx
+++ b/apps/mark/frontend/src/pages/idle_page.tsx
@@ -1,5 +1,5 @@
 import { IdlePage as MarkFlowIdlePage } from '@votingworks/mark-flow-ui';
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { BallotContext } from '../contexts/ballot_context';
 
 export function IdlePage(): JSX.Element {

--- a/apps/mark/frontend/src/pages/not_found_page.test.tsx
+++ b/apps/mark/frontend/src/pages/not_found_page.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Route } from 'react-router-dom';
 import { fireEvent, screen } from '../../test/react_testing_library';
 

--- a/apps/mark/frontend/src/pages/not_found_page.tsx
+++ b/apps/mark/frontend/src/pages/not_found_page.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { Button, Main, Screen, Prose, H1, P } from '@votingworks/ui';

--- a/apps/mark/frontend/src/pages/poll_worker_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import {
   asElectionDefinition,
   electionSampleDefinition,

--- a/apps/mark/frontend/src/pages/print_page.tsx
+++ b/apps/mark/frontend/src/pages/print_page.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { PrintPage as MarkFlowPrintPage } from '@votingworks/mark-flow-ui';
 import { assert } from '@votingworks/basics';
 import { BallotContext } from '../contexts/ballot_context';

--- a/apps/mark/frontend/src/pages/replace_election_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/replace_election_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   electionSampleDefinition,
   primaryElectionSampleDefinition,

--- a/apps/mark/frontend/src/pages/replace_election_screen.tsx
+++ b/apps/mark/frontend/src/pages/replace_election_screen.tsx
@@ -14,7 +14,7 @@ import { formatLongDate } from '@votingworks/utils';
 import type { MachineConfig } from '@votingworks/mark-backend';
 import { DateTime } from 'luxon';
 import pluralize from 'pluralize';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { ScreenReader } from '../config/types';
 
 export interface ReplaceElectionScreenProps {

--- a/apps/mark/frontend/src/pages/review_page.test.tsx
+++ b/apps/mark/frontend/src/pages/review_page.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Route } from 'react-router-dom';
 import { electionSampleDefinition } from '@votingworks/fixtures';
 import { createMemoryHistory } from 'history';

--- a/apps/mark/frontend/src/pages/setup_power_page.tsx
+++ b/apps/mark/frontend/src/pages/setup_power_page.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Main, NoWrap, Screen, Prose, H1, P } from '@votingworks/ui';
 
 export function SetupPowerPage(): JSX.Element {

--- a/apps/mark/frontend/src/pages/setup_printer_page.tsx
+++ b/apps/mark/frontend/src/pages/setup_printer_page.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Main, Screen, Prose, H1, P } from '@votingworks/ui';
 
 export function SetupPrinterPage(): JSX.Element {

--- a/apps/mark/frontend/src/pages/start_page.test.tsx
+++ b/apps/mark/frontend/src/pages/start_page.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Route } from 'react-router-dom';
 import {
   primaryElectionSampleDefinition,

--- a/apps/mark/frontend/src/pages/system_administrator_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/system_administrator_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { fakeLogger } from '@votingworks/logging';
 import { screen } from '../../test/react_testing_library';
 

--- a/apps/mark/frontend/src/pages/unconfigured_election_screen_wrapper.tsx
+++ b/apps/mark/frontend/src/pages/unconfigured_election_screen_wrapper.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import {
   UnconfiguredElectionScreen,
   UsbDriveStatus,

--- a/apps/mark/frontend/src/pages/unconfigured_screen.tsx
+++ b/apps/mark/frontend/src/pages/unconfigured_screen.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Main, Screen, CenteredLargeProse, H1, P } from '@votingworks/ui';
 
 interface Props {

--- a/apps/mark/frontend/src/pages/wrong_election_screen.tsx
+++ b/apps/mark/frontend/src/pages/wrong_election_screen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 import { Main, Screen, Prose, H1, P } from '@votingworks/ui';
 

--- a/apps/mark/frontend/test/helpers/build_app.tsx
+++ b/apps/mark/frontend/test/helpers/build_app.tsx
@@ -1,6 +1,5 @@
 import { fakeLogger, Logger } from '@votingworks/logging';
 import { MemoryHardware, MemoryStorage } from '@votingworks/utils';
-import React from 'react';
 import { render, RenderResult } from '../react_testing_library';
 import { App } from '../../src/app';
 import { ScreenReader, TextToSpeech } from '../../src/config/types';

--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   ALL_PRECINCTS_SELECTION,
   ReportSourceMachineType,

--- a/apps/scan/frontend/src/app_tally_report_paths.test.tsx
+++ b/apps/scan/frontend/src/app_tally_report_paths.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   electionMinimalExhaustiveSample,
   electionMinimalExhaustiveSampleDefinition,

--- a/apps/scan/frontend/src/app_unhappy_paths.test.tsx
+++ b/apps/scan/frontend/src/app_unhappy_paths.test.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-import React from 'react';
 import { electionSampleDefinition } from '@votingworks/fixtures';
 import {
   advanceTimersAndPromises,

--- a/apps/scan/frontend/src/components/absolute.test.tsx
+++ b/apps/scan/frontend/src/components/absolute.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '../../test/react_testing_library';
 import { Absolute } from './absolute';
 

--- a/apps/scan/frontend/src/components/display_settings_button.test.tsx
+++ b/apps/scan/frontend/src/components/display_settings_button.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 import userEvent from '@testing-library/user-event';

--- a/apps/scan/frontend/src/components/display_settings_button.tsx
+++ b/apps/scan/frontend/src/components/display_settings_button.tsx
@@ -1,5 +1,4 @@
 /* stylelint-disable order/properties-order */
-import React from 'react';
 import { Button, Icons } from '@votingworks/ui';
 import styled from 'styled-components';
 import { useHistory } from 'react-router-dom';

--- a/apps/scan/frontend/src/components/export_backup_modal.test.tsx
+++ b/apps/scan/frontend/src/components/export_backup_modal.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { err, ok } from '@votingworks/basics';
-// eslint-disable-next-line vx/gts-no-import-export-type
+
 import type { UsbDriveStatus } from '@votingworks/usb-drive';
 import { render, screen } from '../../test/react_testing_library';
 import {

--- a/apps/scan/frontend/src/components/export_backup_modal.tsx
+++ b/apps/scan/frontend/src/components/export_backup_modal.tsx
@@ -7,7 +7,7 @@ import {
   Prose,
   UsbControllerButton,
 } from '@votingworks/ui';
-// eslint-disable-next-line vx/gts-no-import-export-type
+
 import type { UsbDriveStatus } from '@votingworks/usb-drive';
 import React, { useState } from 'react';
 import styled from 'styled-components';

--- a/apps/scan/frontend/src/components/export_results_modal.test.tsx
+++ b/apps/scan/frontend/src/components/export_results_modal.test.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import { err } from '@votingworks/basics';
-// eslint-disable-next-line vx/gts-no-import-export-type
+
 import type { UsbDriveStatus } from '@votingworks/usb-drive';
 import userEvent from '@testing-library/user-event';
 import { render, waitFor } from '../../test/react_testing_library';

--- a/apps/scan/frontend/src/components/export_results_modal.tsx
+++ b/apps/scan/frontend/src/components/export_results_modal.tsx
@@ -10,7 +10,7 @@ import {
   P,
 } from '@votingworks/ui';
 import { throwIllegalValue } from '@votingworks/basics';
-// eslint-disable-next-line vx/gts-no-import-export-type
+
 import type { UsbDriveStatus } from '@votingworks/usb-drive';
 import {
   ejectUsbDrive,

--- a/apps/scan/frontend/src/components/live_check_modal.test.tsx
+++ b/apps/scan/frontend/src/components/live_check_modal.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import MockDate from 'mockdate';
 
 import { electionSampleDefinition as electionDefinition } from '@votingworks/fixtures';

--- a/apps/scan/frontend/src/components/live_check_modal.tsx
+++ b/apps/scan/frontend/src/components/live_check_modal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button, Prose, Modal, QrCode } from '@votingworks/ui';
 import styled from 'styled-components';
 import { ElectionDefinition } from '@votingworks/types';

--- a/apps/scan/frontend/src/components/replace_ballot_bag_screen.tsx
+++ b/apps/scan/frontend/src/components/replace_ballot_bag_screen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import {
   Button,
   Caption,

--- a/apps/scan/frontend/src/components/scanned_ballot_count.tsx
+++ b/apps/scan/frontend/src/components/scanned_ballot_count.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { BigMetric } from '@votingworks/ui';
 import styled from 'styled-components';
 

--- a/apps/scan/frontend/src/components/screen_header.tsx
+++ b/apps/scan/frontend/src/components/screen_header.tsx
@@ -1,5 +1,4 @@
 /* stylelint-disable order/properties-order */
-import React from 'react';
 import styled from 'styled-components';
 
 import { ScannedBallotCount } from './scanned_ballot_count';

--- a/apps/scan/frontend/src/components/session_time_limit_tracker.tsx
+++ b/apps/scan/frontend/src/components/session_time_limit_tracker.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { SessionTimeLimitTracker as SessionTimeLimitTrackerBase } from '@votingworks/ui';
 
 import { getAuthStatus, getConfig, logOut, updateSessionExpiry } from '../api';

--- a/apps/scan/frontend/src/components/set_mark_thresholds_modal.test.tsx
+++ b/apps/scan/frontend/src/components/set_mark_thresholds_modal.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { electionSample } from '@votingworks/fixtures';
 import userEvent from '@testing-library/user-event';
 import {

--- a/apps/scan/frontend/src/preview_app.tsx
+++ b/apps/scan/frontend/src/preview_app.tsx
@@ -7,7 +7,6 @@ import {
   electionWithMsEitherNeitherDefinition,
   primaryElectionSampleDefinition,
 } from '@votingworks/fixtures';
-import React from 'react';
 import { PreviewDashboard } from './preview_dashboard';
 import * as CardErrorScreen from './screens/card_error_screen';
 import * as ElectionManagerScreen from './screens/election_manager_screen';

--- a/apps/scan/frontend/src/screens/card_error_screen.tsx
+++ b/apps/scan/frontend/src/screens/card_error_screen.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { CenteredLargeProse, H1, P, RotateCardImage } from '@votingworks/ui';
 import { ScreenMainCenterChild } from '../components/layout';
 

--- a/apps/scan/frontend/src/screens/display_settings_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/display_settings_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 import userEvent from '@testing-library/user-event';

--- a/apps/scan/frontend/src/screens/display_settings_screen.tsx
+++ b/apps/scan/frontend/src/screens/display_settings_screen.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { DisplaySettings } from '@votingworks/ui';

--- a/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import {
   electionMinimalExhaustiveSampleSinglePrecinctDefinition,

--- a/apps/scan/frontend/src/screens/insert_ballot_screen.tsx
+++ b/apps/scan/frontend/src/screens/insert_ballot_screen.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Caption, Font, Icons, InsertBallotImage, P } from '@votingworks/ui';
 import { Screen } from '../components/layout';
 import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout';

--- a/apps/scan/frontend/src/screens/insert_usb_screen.tsx
+++ b/apps/scan/frontend/src/screens/insert_usb_screen.tsx
@@ -1,5 +1,4 @@
 import { CenteredLargeProse, H1, P } from '@votingworks/ui';
-import React from 'react';
 import { ScreenMainCenterChild } from '../components/layout';
 
 export function InsertUsbScreen(): JSX.Element {

--- a/apps/scan/frontend/src/screens/invalid_card_screen.tsx
+++ b/apps/scan/frontend/src/screens/invalid_card_screen.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { InvalidCardScreen as SharedInvalidCardScreen } from '@votingworks/ui';
 import { ScreenMainCenterChild } from '../components/layout';
 

--- a/apps/scan/frontend/src/screens/loading_configuration_screen.tsx
+++ b/apps/scan/frontend/src/screens/loading_configuration_screen.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { CenteredLargeProse, H1, LoadingAnimation } from '@votingworks/ui';
 import { ScreenMainCenterChild } from '../components/layout';
 

--- a/apps/scan/frontend/src/screens/login_prompt_screen.tsx
+++ b/apps/scan/frontend/src/screens/login_prompt_screen.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Main, Screen, CenteredLargeProse, H1, P } from '@votingworks/ui';
 
 /**

--- a/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
@@ -4,7 +4,6 @@ import {
   isFeatureFlagEnabled,
 } from '@votingworks/utils';
 import MockDate from 'mockdate';
-import React from 'react';
 import { mocked } from 'ts-jest/utils';
 import userEvent from '@testing-library/user-event';
 import { fakeLogger, LogEventId } from '@votingworks/logging';

--- a/apps/scan/frontend/src/screens/polls_not_open_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/polls_not_open_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { singlePrecinctSelectionFor } from '@votingworks/utils';
 import { render, screen } from '../../test/react_testing_library';
 import {

--- a/apps/scan/frontend/src/screens/polls_not_open_screen.tsx
+++ b/apps/scan/frontend/src/screens/polls_not_open_screen.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Caption, FullScreenIconWrapper, Icons, P } from '@votingworks/ui';
 import { PollsState } from '@votingworks/types';
 import { Screen } from '../components/layout';

--- a/apps/scan/frontend/src/screens/scan_busy_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_busy_screen.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Caption, FullScreenIconWrapper, Icons, P } from '@votingworks/ui';
 import { Screen } from '../components/layout';
 import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout';

--- a/apps/scan/frontend/src/screens/scan_double_sheet_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/scan_double_sheet_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '../../test/react_testing_library';
 import { ScanDoubleSheetScreen } from './scan_double_sheet_screen';
 import {

--- a/apps/scan/frontend/src/screens/scan_double_sheet_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_double_sheet_screen.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Caption, FullScreenIconWrapper, Icons, P } from '@votingworks/ui';
 import { Screen } from '../components/layout';
 import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout';

--- a/apps/scan/frontend/src/screens/scan_error_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/scan_error_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '../../test/react_testing_library';
 import { ScanErrorScreen } from './scan_error_screen';
 import {

--- a/apps/scan/frontend/src/screens/scan_error_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_error_screen.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Caption, FullScreenIconWrapper, Icons, P } from '@votingworks/ui';
 import { throwIllegalValue } from '@votingworks/basics';
 import type {

--- a/apps/scan/frontend/src/screens/scan_jam_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_jam_screen.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Caption, FullScreenIconWrapper, Icons, P } from '@votingworks/ui';
 import { Screen } from '../components/layout';
 import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout';

--- a/apps/scan/frontend/src/screens/scan_processing_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_processing_screen.tsx
@@ -1,5 +1,4 @@
 import { CenteredLargeProse, H1, LoadingAnimation, P } from '@votingworks/ui';
-import React from 'react';
 import { ScreenMainCenterChild } from '../components/layout';
 
 export function ScanProcessingScreen(): JSX.Element {

--- a/apps/scan/frontend/src/screens/scan_returned_ballot_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_returned_ballot_screen.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Caption, CenteredLargeProse, H1 } from '@votingworks/ui';
 import { ScreenMainCenterChild } from '../components/layout';
 

--- a/apps/scan/frontend/src/screens/scan_success_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_success_screen.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FullScreenIconWrapper, Icons, P } from '@votingworks/ui';
 
 import { Screen } from '../components/layout';

--- a/apps/scan/frontend/src/screens/scan_warning_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/scan_warning_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { electionSampleDefinition } from '@votingworks/fixtures';
 import { AdjudicationReason, CandidateContest } from '@votingworks/types';

--- a/apps/scan/frontend/src/screens/setup_scanner_screen.tsx
+++ b/apps/scan/frontend/src/screens/setup_scanner_screen.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { CenteredLargeProse, H1, P } from '@votingworks/ui';
 import { ScreenMainCenterChild } from '../components/layout';
 

--- a/apps/scan/frontend/src/screens/unconfigured_election_screen_wrapper.tsx
+++ b/apps/scan/frontend/src/screens/unconfigured_election_screen_wrapper.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   UnconfiguredElectionScreen,
   useQueryChangeListener,

--- a/apps/scan/frontend/src/screens/unconfigured_precinct_screen.tsx
+++ b/apps/scan/frontend/src/screens/unconfigured_precinct_screen.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { CenteredLargeProse, H1, P } from '@votingworks/ui';
 import { ScreenMainCenterChild } from '../components/layout';
 

--- a/apps/scan/frontend/src/screens/voter_screen.tsx
+++ b/apps/scan/frontend/src/screens/voter_screen.tsx
@@ -1,7 +1,6 @@
 import { ElectionDefinition } from '@votingworks/types';
 import { useQueryChangeListener } from '@votingworks/ui';
 import { assert, throwIllegalValue } from '@votingworks/basics';
-import React from 'react';
 import { acceptBallot, getScannerStatus, scanBallot } from '../api';
 import { POLLING_INTERVAL_FOR_SCANNER_STATUS_MS } from '../config/globals';
 import { useSound } from '../utils/use_sound';

--- a/apps/scan/frontend/test/helpers/fake_usb_drive.ts
+++ b/apps/scan/frontend/test/helpers/fake_usb_drive.ts
@@ -1,5 +1,5 @@
 import { throwIllegalValue } from '@votingworks/basics';
-// eslint-disable-next-line vx/gts-no-import-export-type
+
 import type { UsbDriveStatus } from '@votingworks/usb-drive';
 
 export function fakeUsbDriveStatus(

--- a/libs/dev-dock/frontend/src/usb_drive_icon.tsx
+++ b/libs/dev-dock/frontend/src/usb_drive_icon.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Colors } from './colors';
 
 export function UsbDriveIcon({

--- a/libs/eslint-plugin-vx/src/configs/react.ts
+++ b/libs/eslint-plugin-vx/src/configs/react.ts
@@ -12,6 +12,7 @@ export = {
       .filter((name) => name !== 'plugin:prettier/recommended'),
     'airbnb/hooks',
     'plugin:react/recommended',
+    'plugin:react/jsx-runtime',
     'plugin:jsx-a11y/recommended',
     'plugin:prettier/recommended', // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
   ],

--- a/libs/eslint-plugin-vx/tests/fixtures/react.tsx
+++ b/libs/eslint-plugin-vx/tests/fixtures/react.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 export function Component(): JSX.Element {
   return <div />;
 }

--- a/libs/mark-flow-ui/src/components/candidate_contest.test.tsx
+++ b/libs/mark-flow-ui/src/components/candidate_contest.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { CandidateContest as CandidateContestInterface } from '@votingworks/types';
 import { electionSampleDefinition } from '@votingworks/fixtures';
 

--- a/libs/mark-flow-ui/src/components/contest.test.tsx
+++ b/libs/mark-flow-ui/src/components/contest.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   electionSampleDefinition,
   electionWithMsEitherNeitherDefinition,

--- a/libs/mark-flow-ui/src/components/contest_title.tsx
+++ b/libs/mark-flow-ui/src/components/contest_title.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Caption, H2 } from '@votingworks/ui';
 import styled from 'styled-components';
 

--- a/libs/mark-flow-ui/src/components/ms_either_neither_contest.test.tsx
+++ b/libs/mark-flow-ui/src/components/ms_either_neither_contest.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { electionWithMsEitherNeither } from '@votingworks/fixtures';
 import { find } from '@votingworks/basics';
 import userEvent from '@testing-library/user-event';

--- a/libs/mark-flow-ui/src/components/ms_either_neither_contest.tsx
+++ b/libs/mark-flow-ui/src/components/ms_either_neither_contest.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import {
   ContestChoiceButton,

--- a/libs/mark-flow-ui/src/components/review.test.tsx
+++ b/libs/mark-flow-ui/src/components/review.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   electionSampleDefinition,
   electionWithMsEitherNeitherDefinition,

--- a/libs/mark-flow-ui/src/components/yes_no_contest.test.tsx
+++ b/libs/mark-flow-ui/src/components/yes_no_contest.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { electionMinimalExhaustiveSample } from '@votingworks/fixtures';
 import { YesNoContest as YesNoContestInterface } from '@votingworks/types';
 import userEvent from '@testing-library/user-event';

--- a/libs/mark-flow-ui/src/pages/cast_ballot_page.test.tsx
+++ b/libs/mark-flow-ui/src/pages/cast_ballot_page.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '../../test/react_testing_library';
 import { CastBallotPage } from './cast_ballot_page';
 

--- a/libs/mark-flow-ui/src/pages/cast_ballot_page.tsx
+++ b/libs/mark-flow-ui/src/pages/cast_ballot_page.tsx
@@ -1,5 +1,4 @@
 /* stylelint-disable order/properties-order */
-import React from 'react';
 import styled from 'styled-components';
 
 import {

--- a/libs/mark-flow-ui/src/pages/idle_page.test.tsx
+++ b/libs/mark-flow-ui/src/pages/idle_page.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { advanceTimersAndPromises } from '@votingworks/test-utils';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '../../test/react_testing_library';

--- a/libs/mark-flow-ui/src/pages/idle_page.tsx
+++ b/libs/mark-flow-ui/src/pages/idle_page.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import pluralize from 'pluralize';
 import useInterval from 'use-interval';
 

--- a/libs/mark-flow-ui/src/pages/print_page.test.tsx
+++ b/libs/mark-flow-ui/src/pages/print_page.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   electionSample,
   electionSampleNoSealDefinition,

--- a/libs/mark-flow-ui/src/pages/print_page.tsx
+++ b/libs/mark-flow-ui/src/pages/print_page.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import {
   BmdPaperBallot,

--- a/libs/ui/src/big_metric.test.tsx
+++ b/libs/ui/src/big_metric.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { render, screen } from '../test/react_testing_library';
 import { BigMetric } from './big_metric';
 

--- a/libs/ui/src/bmd_paper_ballot.test.tsx
+++ b/libs/ui/src/bmd_paper_ballot.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   BallotStyleId,
   Candidate,

--- a/libs/ui/src/button_bar.test.tsx
+++ b/libs/ui/src/button_bar.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '../test/react_testing_library';
 
 import { ButtonBar } from './button_bar';

--- a/libs/ui/src/button_list.test.tsx
+++ b/libs/ui/src/button_list.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '../test/react_testing_library';
 
 import { Button } from './button';

--- a/libs/ui/src/card.stories.tsx
+++ b/libs/ui/src/card.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Meta } from '@storybook/react';
 
 import { LoremIpsum } from 'lorem-ipsum';

--- a/libs/ui/src/card.test.tsx
+++ b/libs/ui/src/card.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '../test/react_testing_library';
 
 import { Card } from './card';

--- a/libs/ui/src/change_precinct_button.test.tsx
+++ b/libs/ui/src/change_precinct_button.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { electionMinimalExhaustiveSample } from '@votingworks/fixtures';
 import {
   ALL_PRECINCTS_SELECTION,

--- a/libs/ui/src/checkbox.tsx
+++ b/libs/ui/src/checkbox.tsx
@@ -1,5 +1,4 @@
 /* stylelint-disable order/properties-order, value-keyword-case */
-import React from 'react';
 import styled, { css } from 'styled-components';
 
 import { Icons } from './icons';

--- a/libs/ui/src/contest_choice_button.test.tsx
+++ b/libs/ui/src/contest_choice_button.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '../test/react_testing_library';
 import { ContestChoiceButton } from './contest_choice_button';

--- a/libs/ui/src/display_settings/color_settings.test.tsx
+++ b/libs/ui/src/display_settings/color_settings.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { UiTheme } from '@votingworks/types';
 import { ThemeConsumer } from 'styled-components';
 import userEvent from '@testing-library/user-event';

--- a/libs/ui/src/display_settings/display_settings.test.tsx
+++ b/libs/ui/src/display_settings/display_settings.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { ThemeConsumer } from 'styled-components';
 import { UiTheme } from '@votingworks/types';

--- a/libs/ui/src/display_settings/size_settings.test.tsx
+++ b/libs/ui/src/display_settings/size_settings.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { UiTheme } from '@votingworks/types';
 import { ThemeConsumer } from 'styled-components';
 import userEvent from '@testing-library/user-event';

--- a/libs/ui/src/display_settings/tab_bar.test.tsx
+++ b/libs/ui/src/display_settings/tab_bar.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, screen, within } from '../../test/react_testing_library';
 import { TabBar } from './tab_bar';

--- a/libs/ui/src/display_settings/tab_bar.tsx
+++ b/libs/ui/src/display_settings/tab_bar.tsx
@@ -1,5 +1,4 @@
 /* stylelint-disable order/properties-order */
-import React from 'react';
 import styled from 'styled-components';
 
 import { PANE_IDS, SettingsPaneId } from './types';

--- a/libs/ui/src/display_settings/theme_preview.tsx
+++ b/libs/ui/src/display_settings/theme_preview.tsx
@@ -1,5 +1,4 @@
 /* stylelint-disable order/properties-order */
-import React from 'react';
 import styled, { ThemeProvider } from 'styled-components';
 
 import { ColorMode, SizeMode } from '@votingworks/types';

--- a/libs/ui/src/election_info_bar.test.tsx
+++ b/libs/ui/src/election_info_bar.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   electionSampleDefinition,
   primaryElectionSampleDefinition,

--- a/libs/ui/src/error_boundary.test.tsx
+++ b/libs/ui/src/error_boundary.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { suppressingConsoleOutput } from '@votingworks/test-utils';
 import { render, screen } from '../test/react_testing_library';
 import { ErrorBoundary } from './error_boundary';

--- a/libs/ui/src/export_logs_modal.test.tsx
+++ b/libs/ui/src/export_logs_modal.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import {
   fakeKiosk,
   fakeUsbDrive,

--- a/libs/ui/src/graphics.tsx
+++ b/libs/ui/src/graphics.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'styled-components';
 
 export const Graphic = styled.img`

--- a/libs/ui/src/hand_marked_paper_ballot_prose.test.tsx
+++ b/libs/ui/src/hand_marked_paper_ballot_prose.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '../test/react_testing_library';
 
 import { HandMarkedPaperBallotProse } from './hand_marked_paper_ballot_prose';

--- a/libs/ui/src/hooks/use_autocomplete.test.tsx
+++ b/libs/ui/src/hooks/use_autocomplete.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from '@testing-library/user-event';
-import React, { useCallback, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { render, screen, waitFor } from '../../test/react_testing_library';
 import { AutocompleteProps, useAutocomplete } from './use_autocomplete';
 

--- a/libs/ui/src/hooks/use_current_theme.test.tsx
+++ b/libs/ui/src/hooks/use_current_theme.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { DefaultTheme } from 'styled-components';
 import { render } from '../../test/react_testing_library';
 import { useCurrentTheme } from './use_current_theme';

--- a/libs/ui/src/hooks/use_usb_drive.test.tsx
+++ b/libs/ui/src/hooks/use_usb_drive.test.tsx
@@ -6,7 +6,6 @@ import {
   fakeKiosk,
   fakeUsbDrive,
 } from '@votingworks/test-utils';
-import React from 'react';
 import { render, screen, waitFor } from '../../test/react_testing_library';
 import { UsbControllerButton } from '../usbcontroller_button';
 import {

--- a/libs/ui/src/horizontal_rule.test.tsx
+++ b/libs/ui/src/horizontal_rule.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '../test/react_testing_library';
 
 import { HorizontalRule } from './horizontal_rule';

--- a/libs/ui/src/icons.stories.tsx
+++ b/libs/ui/src/icons.stories.tsx
@@ -1,5 +1,4 @@
 /* stylelint-disable order/properties-order */
-import React from 'react';
 import { Meta } from '@storybook/react';
 import styled from 'styled-components';
 

--- a/libs/ui/src/icons.test.tsx
+++ b/libs/ui/src/icons.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '../test/react_testing_library';
 
 import { FullScreenIconWrapper, Icons } from './icons';

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -1,5 +1,4 @@
 /* stylelint-disable order/properties-order */
-import React from 'react';
 import styled from 'styled-components';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';

--- a/libs/ui/src/input_group.test.tsx
+++ b/libs/ui/src/input_group.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '../test/react_testing_library';
 
 import { InputGroup } from './input_group';

--- a/libs/ui/src/insert_ballot_image.tsx
+++ b/libs/ui/src/insert_ballot_image.tsx
@@ -1,5 +1,4 @@
 /* stylelint-disable order/properties-order, value-keyword-case */
-import React from 'react';
 import styled, { css, keyframes } from 'styled-components';
 
 import { Svg } from './svg';

--- a/libs/ui/src/insert_card_image.tsx
+++ b/libs/ui/src/insert_card_image.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Svg } from './svg';
 
 export function InsertCardImage(): JSX.Element {

--- a/libs/ui/src/invalid_card_screen.test.tsx
+++ b/libs/ui/src/invalid_card_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '../test/react_testing_library';
 
 import { InvalidCardScreen, Props } from './invalid_card_screen';

--- a/libs/ui/src/invalid_card_screen.tsx
+++ b/libs/ui/src/invalid_card_screen.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { DippedSmartCardAuth, InsertedSmartCardAuth } from '@votingworks/types';
 
 import { fontSizeTheme } from './themes';

--- a/libs/ui/src/labelled_text.test.tsx
+++ b/libs/ui/src/labelled_text.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { render, screen } from '../test/react_testing_library';
 import { LabelledText } from './labelled_text';
 

--- a/libs/ui/src/link_button.test.tsx
+++ b/libs/ui/src/link_button.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Router, StaticRouter } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 

--- a/libs/ui/src/link_button.tsx
+++ b/libs/ui/src/link_button.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { Button, ButtonProps } from './button';
 

--- a/libs/ui/src/loading.test.tsx
+++ b/libs/ui/src/loading.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '../test/react_testing_library';
 
 import { Loading } from './loading';

--- a/libs/ui/src/loading.tsx
+++ b/libs/ui/src/loading.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'styled-components';
 import { ProgressEllipsis } from './progress_ellipsis';
 import { Prose } from './prose';

--- a/libs/ui/src/loading_animation.tsx
+++ b/libs/ui/src/loading_animation.tsx
@@ -1,5 +1,4 @@
 /* stylelint-disable order/properties-order */
-import React from 'react';
 import styled, { DefaultTheme } from 'styled-components';
 
 const SvgContainer = styled.svg`

--- a/libs/ui/src/logo_mark.tsx
+++ b/libs/ui/src/logo_mark.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'styled-components';
 
 const LogoMarkStyled = styled.img`

--- a/libs/ui/src/main.test.tsx
+++ b/libs/ui/src/main.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '../test/react_testing_library';
 
 import { Main } from './main';

--- a/libs/ui/src/modal.tsx
+++ b/libs/ui/src/modal.tsx
@@ -1,5 +1,5 @@
 /* stylelint-disable order/properties-order, value-keyword-case, order/order */
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import ReactModal from 'react-modal';
 import styled from 'styled-components';
 import { rgba } from 'polished';

--- a/libs/ui/src/number_pad.test.tsx
+++ b/libs/ui/src/number_pad.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { fireEvent, render, screen } from '../test/react_testing_library';
 

--- a/libs/ui/src/power_down_button.test.tsx
+++ b/libs/ui/src/power_down_button.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { fakeKiosk } from '@votingworks/test-utils';
 import { Logger, LogSource } from '@votingworks/logging';

--- a/libs/ui/src/power_down_button.tsx
+++ b/libs/ui/src/power_down_button.tsx
@@ -1,6 +1,6 @@
 import { LogEventId, Logger } from '@votingworks/logging';
 import { assert } from '@votingworks/basics';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { UserRole } from '@votingworks/types';
 import { Button } from './button';
 import { Loading } from './loading';

--- a/libs/ui/src/print_element.tsx
+++ b/libs/ui/src/print_element.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import ReactDom from 'react-dom';
 import styled from 'styled-components';
 

--- a/libs/ui/src/printing_ballot_image.tsx
+++ b/libs/ui/src/printing_ballot_image.tsx
@@ -1,5 +1,4 @@
 /* stylelint-disable order/properties-order */
-import React from 'react';
 import styled, { keyframes } from 'styled-components';
 
 import { Svg } from './svg';

--- a/libs/ui/src/progress_bar.test.tsx
+++ b/libs/ui/src/progress_bar.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '../test/react_testing_library';
 
 import { ProgressBar } from './progress_bar';

--- a/libs/ui/src/progress_ellipsis.test.tsx
+++ b/libs/ui/src/progress_ellipsis.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '../test/react_testing_library';
 
 import { ProgressEllipsis } from './progress_ellipsis';

--- a/libs/ui/src/qrcode.stories.tsx
+++ b/libs/ui/src/qrcode.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Meta, StoryFn } from '@storybook/react';
 
 import styled from 'styled-components';

--- a/libs/ui/src/qrcode.test.tsx
+++ b/libs/ui/src/qrcode.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '../test/react_testing_library';
 
 import { QrCode } from './qrcode';

--- a/libs/ui/src/qrcode.tsx
+++ b/libs/ui/src/qrcode.tsx
@@ -1,5 +1,4 @@
 import { QRCodeSVG } from 'qrcode.react';
-import React from 'react';
 import styled from 'styled-components';
 
 const ResponsiveSvgWrapper = styled.div`

--- a/libs/ui/src/radio_group/index.tsx
+++ b/libs/ui/src/radio_group/index.tsx
@@ -1,5 +1,4 @@
 /* stylelint-disable order/properties-order */
-import React from 'react';
 import styled from 'styled-components';
 
 import { Caption } from '../typography';

--- a/libs/ui/src/radio_group/radio.tsx
+++ b/libs/ui/src/radio_group/radio.tsx
@@ -1,5 +1,5 @@
 /* stylelint-disable order/properties-order, value-keyword-case */
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import styled, { css } from 'styled-components';
 
 import { OptionProps, RadioGroupOptionId } from './types';

--- a/libs/ui/src/radio_group/radio_button.tsx
+++ b/libs/ui/src/radio_group/radio_button.tsx
@@ -1,5 +1,4 @@
 /* stylelint-disable order/properties-order, value-keyword-case */
-import React from 'react';
 import styled from 'styled-components';
 
 import { ButtonProps, buttonStyles } from '../button';

--- a/libs/ui/src/radio_group/radio_group.test.tsx
+++ b/libs/ui/src/radio_group/radio_group.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import userEvent from '@testing-library/user-event';
 import { render, screen, within } from '../../test/react_testing_library';
 import { RadioGroup } from '.';

--- a/libs/ui/src/reboot_from_usb_button.test.tsx
+++ b/libs/ui/src/reboot_from_usb_button.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { fakeKiosk } from '@votingworks/test-utils';
 import { Logger, LogSource } from '@votingworks/logging';
 import { fireEvent, render, screen } from '../test/react_testing_library';

--- a/libs/ui/src/reboot_to_bios_button.test.tsx
+++ b/libs/ui/src/reboot_to_bios_button.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { fakeKiosk } from '@votingworks/test-utils';
 import { Logger, LogSource } from '@votingworks/logging';

--- a/libs/ui/src/reboot_to_bios_button.tsx
+++ b/libs/ui/src/reboot_to_bios_button.tsx
@@ -1,6 +1,6 @@
 import { LogEventId, Logger } from '@votingworks/logging';
 import { assert } from '@votingworks/basics';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Button } from './button';
 import { Loading } from './loading';
 import { Modal } from './modal';

--- a/libs/ui/src/remove_card_screen.test.tsx
+++ b/libs/ui/src/remove_card_screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '../test/react_testing_library';
 
 import { RemoveCardScreen } from './remove_card_screen';

--- a/libs/ui/src/remove_card_screen.tsx
+++ b/libs/ui/src/remove_card_screen.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'styled-components';
 import { Screen } from './screen';
 import { Main } from './main';

--- a/libs/ui/src/reports/admin_tally_report.stories.tsx
+++ b/libs/ui/src/reports/admin_tally_report.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { electionMinimalExhaustiveSampleDefinition } from '@votingworks/fixtures';
 import {

--- a/libs/ui/src/reports/admin_tally_report.test.tsx
+++ b/libs/ui/src/reports/admin_tally_report.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { electionMinimalExhaustiveSampleDefinition } from '@votingworks/fixtures';
 import {
   buildElectionResultsFixture,

--- a/libs/ui/src/reports/admin_tally_report.tsx
+++ b/libs/ui/src/reports/admin_tally_report.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Contests, Election, Tabulation } from '@votingworks/types';
 import { assert } from '@votingworks/basics';
 import { ReportSection, TallyReport, TallyReportColumns } from './tally_report';

--- a/libs/ui/src/reports/contest_results_table.test.tsx
+++ b/libs/ui/src/reports/contest_results_table.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { buildContestResultsFixture } from '@votingworks/utils';
 import { electionMinimalExhaustiveSampleFixtures } from '@votingworks/fixtures';
 import { hasTextAcrossElements } from '@votingworks/test-utils';

--- a/libs/ui/src/reports/contest_tally.test.tsx
+++ b/libs/ui/src/reports/contest_tally.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { computeTallyWithPrecomputedCategories } from '@votingworks/utils';
 import { ManualTally, TallyCategory } from '@votingworks/types';
 import { electionMinimalExhaustiveSampleFixtures } from '@votingworks/fixtures';

--- a/libs/ui/src/reports/contest_writein_tally.test.tsx
+++ b/libs/ui/src/reports/contest_writein_tally.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ContestId, Election } from '@votingworks/types';
 import { electionSample2Fixtures } from '@votingworks/fixtures';
 import { render, screen, within } from '../../test/react_testing_library';

--- a/libs/ui/src/reports/precinct_scanner_ballot_count_report.test.tsx
+++ b/libs/ui/src/reports/precinct_scanner_ballot_count_report.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import MockDate from 'mockdate';
 import { electionSampleDefinition } from '@votingworks/fixtures';
 import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';

--- a/libs/ui/src/reports/precinct_scanner_ballot_count_report.tsx
+++ b/libs/ui/src/reports/precinct_scanner_ballot_count_report.tsx
@@ -10,7 +10,6 @@ import {
   getPollsTransitionDestinationState,
 } from '@votingworks/utils';
 import { DateTime } from 'luxon';
-import React from 'react';
 import styled from 'styled-components';
 import { PrecinctScannerReportHeader } from './precinct_scanner_report_header';
 import { Prose } from '../prose';

--- a/libs/ui/src/reports/precinct_scanner_report_header.test.tsx
+++ b/libs/ui/src/reports/precinct_scanner_report_header.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   ALL_PRECINCTS_SELECTION,
   singlePrecinctSelectionFor,

--- a/libs/ui/src/reports/precinct_scanner_tally_qrcode.test.tsx
+++ b/libs/ui/src/reports/precinct_scanner_tally_qrcode.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   electionSample,
   electionSampleDefinition,

--- a/libs/ui/src/reports/precinct_scanner_tally_qrcode.tsx
+++ b/libs/ui/src/reports/precinct_scanner_tally_qrcode.tsx
@@ -5,7 +5,6 @@ import {
 } from '@votingworks/types';
 import { format, formatFullDateTimeZone } from '@votingworks/utils';
 import { DateTime } from 'luxon';
-import React from 'react';
 import styled from 'styled-components';
 import { LogoMark } from '../logo_mark';
 import { Prose } from '../prose';

--- a/libs/ui/src/reports/precinct_scanner_tally_report.test.tsx
+++ b/libs/ui/src/reports/precinct_scanner_tally_report.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   electionMinimalExhaustiveSample,
   electionMinimalExhaustiveSampleDefinition,

--- a/libs/ui/src/reports/precinct_scanner_tally_report.tsx
+++ b/libs/ui/src/reports/precinct_scanner_tally_report.tsx
@@ -5,7 +5,6 @@ import {
   StandardPollsTransition,
   Tally,
 } from '@votingworks/types';
-import React from 'react';
 import { ContestTally } from './contest_tally';
 import { PrecinctScannerReportHeader } from './precinct_scanner_report_header';
 import {

--- a/libs/ui/src/reports/precinct_scanner_tally_reports.test.tsx
+++ b/libs/ui/src/reports/precinct_scanner_tally_reports.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   electionFamousNames2021Fixtures,
   electionMinimalExhaustiveSampleDefinition,

--- a/libs/ui/src/reports/tally_report_card_counts.test.tsx
+++ b/libs/ui/src/reports/tally_report_card_counts.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { within } from '@testing-library/react';
 import { render, screen } from '../../test/react_testing_library';
 

--- a/libs/ui/src/reports/tally_report_metadata.test.tsx
+++ b/libs/ui/src/reports/tally_report_metadata.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import MockDate from 'mockdate';
 
 import { electionWithMsEitherNeither } from '@votingworks/fixtures';

--- a/libs/ui/src/reports/tally_report_metadata.tsx
+++ b/libs/ui/src/reports/tally_report_metadata.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Election } from '@votingworks/types';
 
 import { format } from '@votingworks/utils';

--- a/libs/ui/src/reports/tally_report_summary.test.tsx
+++ b/libs/ui/src/reports/tally_report_summary.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Tally, VotingMethod } from '@votingworks/types';
 import {
   electionSampleDefinition,

--- a/libs/ui/src/reports/tally_report_summary.tsx
+++ b/libs/ui/src/reports/tally_report_summary.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'styled-components';
 
 import {

--- a/libs/ui/src/reset_polls_to_paused_button.test.tsx
+++ b/libs/ui/src/reset_polls_to_paused_button.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { fakeLogger, LogEventId } from '@votingworks/logging';
 import { render, screen, waitFor, within } from '../test/react_testing_library';

--- a/libs/ui/src/rotate_card_image.tsx
+++ b/libs/ui/src/rotate_card_image.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import styled from 'styled-components';
 import { Svg } from './svg';
 

--- a/libs/ui/src/screen.test.tsx
+++ b/libs/ui/src/screen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '../test/react_testing_library';
 
 import { Screen } from './screen';

--- a/libs/ui/src/seal.stories.tsx
+++ b/libs/ui/src/seal.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Meta } from '@storybook/react';
 
 import { Seal, SealProps } from './seal';

--- a/libs/ui/src/seal.test.tsx
+++ b/libs/ui/src/seal.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   electionSampleDefinition,
   primaryElectionSampleDefinition,

--- a/libs/ui/src/seal.tsx
+++ b/libs/ui/src/seal.tsx
@@ -1,5 +1,4 @@
 /* stylelint-disable order/properties-order, value-keyword-case */
-import React from 'react';
 import styled, { css } from 'styled-components';
 
 import { ColorMode } from '@votingworks/types';

--- a/libs/ui/src/segmented_button.test.tsx
+++ b/libs/ui/src/segmented_button.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '../test/react_testing_library';
 import { SegmentedButton, SegmentedButtonOption } from './segmented_button';

--- a/libs/ui/src/select.test.tsx
+++ b/libs/ui/src/select.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '../test/react_testing_library';
 
 import { Select } from './select';

--- a/libs/ui/src/set_clock.test.tsx
+++ b/libs/ui/src/set_clock.test.tsx
@@ -1,6 +1,5 @@
 import { DateTime } from 'luxon';
 import MockDate from 'mockdate';
-import React from 'react';
 import fc from 'fast-check';
 import { arbitraryDateTime, fakeKiosk } from '@votingworks/test-utils';
 import { act } from '@testing-library/react-hooks';

--- a/libs/ui/src/setup_card_reader_page.test.tsx
+++ b/libs/ui/src/setup_card_reader_page.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '../test/react_testing_library';
 
 import { SetupCardReaderPage } from './setup_card_reader_page';

--- a/libs/ui/src/setup_card_reader_page.tsx
+++ b/libs/ui/src/setup_card_reader_page.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Main } from './main';
 import { Prose } from './prose';
 import { Screen } from './screen';

--- a/libs/ui/src/system_administrator_screen_contents.test.tsx
+++ b/libs/ui/src/system_administrator_screen_contents.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { fakeKiosk, mockOf } from '@votingworks/test-utils';
 import { fakeLogger } from '@votingworks/logging';

--- a/libs/ui/src/table.test.tsx
+++ b/libs/ui/src/table.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '../test/react_testing_library';
 
 import { Table, TD, TH } from './table';

--- a/libs/ui/src/test_mode.test.tsx
+++ b/libs/ui/src/test_mode.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '../test/react_testing_library';
 
 import { TestMode } from './test_mode';

--- a/libs/ui/src/test_mode.tsx
+++ b/libs/ui/src/test_mode.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled, { ThemeProvider } from 'styled-components';
 import { H1 } from './typography';
 import { makeTheme } from './themes/make_theme';

--- a/libs/ui/src/text.test.tsx
+++ b/libs/ui/src/text.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
 import { render, screen } from '../test/react_testing_library';
 

--- a/libs/ui/src/themes/render_with_themes.test.tsx
+++ b/libs/ui/src/themes/render_with_themes.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 
 import { suppressingConsoleOutput } from '@votingworks/test-utils';

--- a/libs/ui/src/timer.test.tsx
+++ b/libs/ui/src/timer.test.tsx
@@ -1,5 +1,4 @@
 import MockDate from 'mockdate';
-import React from 'react';
 
 import { act, render, screen } from '@testing-library/react';
 import { hasTextAcrossElements } from '@votingworks/test-utils';

--- a/libs/ui/src/touch_text_input.tsx
+++ b/libs/ui/src/touch_text_input.tsx
@@ -1,5 +1,4 @@
 /* stylelint-disable order/properties-order */
-import React from 'react';
 import styled, { keyframes } from 'styled-components';
 
 export interface TouchTextInputProps {

--- a/libs/ui/src/typography.test.tsx
+++ b/libs/ui/src/typography.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '../test/react_testing_library';
 
 import { Caption, Font, H1, H2, H3, H4, H5, H6, P, Pre } from './typography';

--- a/libs/ui/src/unconfigure_machine_button.test.tsx
+++ b/libs/ui/src/unconfigure_machine_button.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { sleep } from '@votingworks/basics';
 import { render, screen, waitFor, within } from '../test/react_testing_library';

--- a/libs/ui/src/unconfigured_election_screen.test.tsx
+++ b/libs/ui/src/unconfigured_election_screen.test.tsx
@@ -1,5 +1,4 @@
 import { BallotPackageConfigurationError } from '@votingworks/types';
-import React from 'react';
 import { render, screen } from '../test/react_testing_library';
 
 import { UnconfiguredElectionScreen } from './unconfigured_election_screen';

--- a/libs/ui/src/unconfigured_election_screen.tsx
+++ b/libs/ui/src/unconfigured_election_screen.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { BallotPackageConfigurationError } from '@votingworks/types';
 import { throwIllegalValue } from '@votingworks/basics';
 import { UsbDriveStatus } from './hooks/use_usb_drive';

--- a/libs/ui/src/unlock_machine_screen.test.tsx
+++ b/libs/ui/src/unlock_machine_screen.test.tsx
@@ -1,6 +1,5 @@
 import { DateTime } from 'luxon';
 import MockDate from 'mockdate';
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import {
   fakeSystemAdministratorUser,

--- a/libs/ui/src/unlock_machine_screen.tsx
+++ b/libs/ui/src/unlock_machine_screen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import styled from 'styled-components';
 import { DippedSmartCardAuth, InsertedSmartCardAuth } from '@votingworks/types';
 import { assert } from '@votingworks/basics';

--- a/libs/ui/src/usbcontroller_button.test.tsx
+++ b/libs/ui/src/usbcontroller_button.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   cleanup,
   fireEvent,

--- a/libs/ui/src/usbcontroller_button.tsx
+++ b/libs/ui/src/usbcontroller_button.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Button, ButtonVariant } from './button';
 import { UsbDriveStatus } from './hooks/use_usb_drive';
 

--- a/libs/ui/src/verify_ballot_image.tsx
+++ b/libs/ui/src/verify_ballot_image.tsx
@@ -1,5 +1,4 @@
 /* stylelint-disable order/properties-order */
-import React from 'react';
 import styled from 'styled-components';
 
 import { Svg } from './svg';

--- a/libs/ui/src/virtual_keyboard.test.tsx
+++ b/libs/ui/src/virtual_keyboard.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '../test/react_testing_library';
 import { VirtualKeyboard } from './virtual_keyboard';

--- a/libs/ui/src/virtual_keyboard.tsx
+++ b/libs/ui/src/virtual_keyboard.tsx
@@ -1,5 +1,4 @@
 /* stylelint-disable order/properties-order */
-import React from 'react';
 import styled, { DefaultTheme } from 'styled-components';
 import { Button } from './button';
 import { Icons } from './icons';

--- a/libs/ui/src/voter_contest_summary.tsx
+++ b/libs/ui/src/voter_contest_summary.tsx
@@ -1,5 +1,4 @@
 /* stylelint-disable order/properties-order */
-import React from 'react';
 import styled from 'styled-components';
 
 import { Checkbox } from './checkbox';

--- a/libs/ui/src/with_scoll_buttons.stories.tsx
+++ b/libs/ui/src/with_scoll_buttons.stories.tsx
@@ -1,5 +1,4 @@
 /* stylelint-disable order/properties-order */
-import React from 'react';
 import { Meta, StoryFn } from '@storybook/react';
 
 import { LoremIpsum } from 'lorem-ipsum';

--- a/remove-imports.rb
+++ b/remove-imports.rb
@@ -1,0 +1,27 @@
+require 'fileutils'
+
+REACT_IMPORT_REGEX = /import React(?:,\s*(\{.*\})\s*|\s+)?from 'react';\n/m
+REACT_REFERENCE_REGEX = /\bReact\b/
+
+def remove_unused_react_import(file_path)
+  content = File.read(file_path)
+
+  if content.scan(REACT_REFERENCE_REGEX).length != 1
+    return
+  end
+
+  match = content.match(REACT_IMPORT_REGEX)
+  if match
+    puts "Removing unused React import in #{file_path}"
+    content.gsub!(REACT_IMPORT_REGEX, if match[1] then "import #{match[1]} from 'react';\n" else "" end)
+    File.write(file_path, content)
+  end
+end
+
+def process_files()
+  Dir.glob("**/*.tsx").each do |file_path|
+    remove_unused_react_import(file_path)
+  end
+end
+
+process_files()


### PR DESCRIPTION
## Overview

Per the [docs on `react/react-in-jsx-scope`][1], the rule is only needed when not using the `react-jsx` runtime, which we are using. So we disable it by extending the `jsx-runtime` config as described in the note at the bottom.

[1]: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md

## Demo Video or Screenshot
n/a

## Testing Plan
Automated.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
