### PR TITLE
[CentralScan] VVSG Nav Bar

### DIFF
--- a/apps/central-scan/frontend/src/components/main_nav.tsx
+++ b/apps/central-scan/frontend/src/components/main_nav.tsx
@@ -15,7 +15,9 @@ const NavWrapper = styled('div')<NavProps>`
     isTestMode &&
     'linear-gradient( 135deg, #ff8c00 21.43%, #333333 21.43%, #333333 50%, #ff8c00 50%, #ff8c00 71.43%, #333333 71.43%, #333333 100% ) '};
   background-size: ${({ isTestMode }) => isTestMode && '98.99px 98.99px'};
-  background-color: ${({ isTestMode }) => !isTestMode && '#455a64'};
+  background-color: ${(p) => !p.isTestMode && p.theme.colors.background};
+  border-bottom: ${(p) => p.theme.sizes.bordersRem.thick}rem solid
+    ${(p) => p.theme.colors.foreground};
   order: -1;
 `;
 
@@ -31,7 +33,7 @@ const Brand = styled.div`
   display: inline-block;
   margin: 0.75rem 1rem;
   white-space: nowrap;
-  color: #ffffff;
+  color: ${(p) => p.theme.colors.foreground};
   font-size: 1.3rem;
   font-weight: 600;
   & span {
@@ -59,10 +61,6 @@ const TestMode = styled.span`
   text-align: center;
 `;
 
-const SessionTimeLimitTimerWrapper = styled.span`
-  color: #ffffff;
-`;
-
 interface Props extends NavProps {
   children?: React.ReactNode;
 }
@@ -81,9 +79,7 @@ export function MainNav({ children, isTestMode = false }: Props): JSX.Element {
         </Brand>
         {isTestMode && <TestMode>Machine is in Test Ballot Mode</TestMode>}
         <NavButtons>
-          <SessionTimeLimitTimerWrapper>
-            <SessionTimeLimitTimer authStatus={authStatusQuery.data} />
-          </SessionTimeLimitTimerWrapper>
+          <SessionTimeLimitTimer authStatus={authStatusQuery.data} />
           {children}
         </NavButtons>
       </Nav>


### PR DESCRIPTION
## Overview

Related to: https://github.com/votingworks/vxsuite/issues/3570

Updating the CentralScan nav bar to use colors from the global theme. Mostly matching VxAdmin in the header-only mode (on the adjudication screen), but punting for now on updating the logo to match.

Side note for later:
Would actually prefer a solid background for visual separation, but with the current default theme, there isn't really a good option that doesn't look too intense (black or the dark vx purple) - thinking we can add a central-system-specific color theme that's somewhere in-between the low contrast and medium contrast modes so we have a bit more flexibility (prompted by some discussion with Jonah on previous PRs).

## Demo Video or Screenshot
### Before:
![Screenshot 2023-06-29 at 15 45 12](https://github.com/votingworks/vxsuite/assets/264902/128ba689-abe3-4733-9f3f-abc0dfda1ad1)

### After:
![Screenshot 2023-06-29 at 15 42 08](https://github.com/votingworks/vxsuite/assets/264902/91b20fb8-c619-4aec-8525-d43e0da952ce)

![Screenshot 2023-06-29 at 16 17 42](https://github.com/votingworks/vxsuite/assets/264902/9f2d6e25-fd65-494c-9b5c-c0e15d96ad41)

## Testing Plan
- Manual/visual

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
