### PR TITLE
[CentralScan] VVSG Design Updates: DeleteBatchModal

### DIFF
--- a/apps/central-scan/frontend/src/components/delete_batch_modal.tsx
+++ b/apps/central-scan/frontend/src/components/delete_batch_modal.tsx
@@ -1,4 +1,4 @@
-import { Button, Modal, Prose, Text } from '@votingworks/ui';
+import { Button, Modal, P } from '@votingworks/ui';
 import React from 'react';
 import * as api from '../api';
 
@@ -24,16 +24,15 @@ export function DeleteBatchModal({
 
   return (
     <Modal
-      centerContent
       onOverlayClick={onClose}
+      title={`Delete ‘${batchLabel}’?`}
       content={
-        <Prose textCenter>
-          <h1>Delete ‘{batchLabel}’?</h1>
-          <p>This action cannot be undone.</p>
+        <React.Fragment>
+          <P>This action cannot be undone.</P>
           {deleteBatchMutation.error && (
-            <Text error>{`${deleteBatchMutation.error}`}</Text>
+            <P color="danger">{`${deleteBatchMutation.error}`}</P>
           )}
-        </Prose>
+        </React.Fragment>
       }
       actions={
         <React.Fragment>


### PR DESCRIPTION
## Overview

Apply VVSG design updates to the `DeleteBatchModal`:
- Replacing typography components with theme-aware versions and removing deprecated `<Prose>` 
- Moving title into `title` prop
- Removing text centring for readability

## Demo Video or Screenshot
### Before:
![Screenshot 2023-07-03 at 11 02 06](https://github.com/votingworks/vxsuite/assets/264902/65c586e7-fd5a-4dc3-8d4c-28b95c9ae27c)

### After:
![Screenshot 2023-07-03 at 11 01 49](https://github.com/votingworks/vxsuite/assets/264902/a49f85ce-b419-4935-922b-8a530bd487cd)

## Testing Plan
- Visual

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
