### PR TITLE
[CentralScan] VVSG Design Updates: SetMarkThresholdsModal

### DIFF
--- a/apps/central-scan/frontend/src/components/set_mark_thresholds_modal.test.tsx
+++ b/apps/central-scan/frontend/src/components/set_mark_thresholds_modal.test.tsx
@@ -1,13 +1,15 @@
+import React from 'react';
 import { electionSample } from '@votingworks/fixtures';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 import userEvent from '@testing-library/user-event';
+import { assert } from '@votingworks/basics';
 import {
   render,
   fireEvent,
-  getByText as domGetByText,
   waitFor,
   screen,
+  within,
 } from '../../test/react_testing_library';
 
 import { SetMarkThresholdsModal } from './set_mark_thresholds_modal';
@@ -59,13 +61,18 @@ test('renders reset modal when overrides are set', async () => {
     markThresholdOverrides: { definite: 0.32, marginal: 0.24 },
   });
   screen.getByText('Reset Mark Thresholds');
-  const currentThresholds = screen.getByText('Current Thresholds');
-  domGetByText(currentThresholds, /Definite: 0.32/);
-  domGetByText(currentThresholds, /Marginal: 0.24/);
 
-  const defaultThresholds = screen.getByText('Default Thresholds');
-  domGetByText(defaultThresholds, /Definite: 0.25/);
-  domGetByText(defaultThresholds, /Marginal: 0.17/);
+  const currentThresholdsSection =
+    screen.getByText('Current Thresholds').parentElement;
+  assert(currentThresholdsSection);
+  within(currentThresholdsSection).getByText(/Definite: 0.32/);
+  within(currentThresholdsSection).getByText(/Marginal: 0.24/);
+
+  const defaultThresholdsSection =
+    screen.getByText('Default Thresholds').parentElement;
+  assert(defaultThresholdsSection);
+  within(defaultThresholdsSection).getByText(/Definite: 0.25/);
+  within(defaultThresholdsSection).getByText(/Marginal: 0.17/);
 
   userEvent.click(screen.getButton('Close'));
   expect(onClose).toHaveBeenCalled();

--- a/apps/central-scan/frontend/src/components/set_mark_thresholds_modal.tsx
+++ b/apps/central-scan/frontend/src/components/set_mark_thresholds_modal.tsx
@@ -2,10 +2,9 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 
 import { MarkThresholds } from '@votingworks/types';
-import { Button, Modal, Text } from '@votingworks/ui';
+import { Button, H6, Modal, P } from '@votingworks/ui';
 
 import { assert, throwIllegalValue } from '@votingworks/basics';
-import { Prose } from './prose';
 import { Loading } from './loading';
 import { TextInput } from './text_input';
 import { setMarkThresholdOverrides } from '../api';
@@ -22,6 +21,12 @@ const ThresholdColumns = styled.div`
   > div {
     flex: 1;
   }
+`;
+
+const Inputs = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 `;
 
 enum ModalState {
@@ -110,12 +115,8 @@ export function SetMarkThresholdsModal({
     case ModalState.ERROR:
       return (
         <Modal
-          content={
-            <Prose>
-              <h1>Error</h1>
-              <p>{errorMessage}</p>
-            </Prose>
-          }
+          title="Error"
+          content={<P>{errorMessage}</P>}
           onOverlayClick={onClose}
           actions={<Button onPress={onClose}>Close</Button>}
         />
@@ -123,15 +124,13 @@ export function SetMarkThresholdsModal({
     case ModalState.CONFIRM_INTENT:
       return (
         <Modal
+          title="Override Mark Thresholds"
           content={
-            <Prose>
-              <h1>Override Mark Thresholds</h1>
-              <p>
-                WARNING: Do not proceed unless you have been instructed to do so
-                by a member of VotingWorks staff. Changing mark thresholds will
-                impact the performance of your scanner.
-              </p>
-            </Prose>
+            <P>
+              WARNING: Do not proceed unless you have been instructed to do so
+              by a member of VotingWorks staff. Changing mark thresholds will
+              impact the performance of your scanner.
+            </P>
           }
           onOverlayClick={onClose}
           actions={
@@ -153,26 +152,34 @@ export function SetMarkThresholdsModal({
     case ModalState.SET_THRESHOLDS:
       return (
         <Modal
+          title="Override Mark Thresholds"
           content={
-            <Prose>
-              <h1>Override Mark Thresholds</h1>
-              <Text>Definite:</Text>
-              <TextInput
-                data-testid="definite-text-input"
-                value={definiteThreshold}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  setDefiniteThreshold(e.target.value)
-                }
-              />
-              <Text>Marginal:</Text>
-              <TextInput
-                data-testid="marginal-text-input"
-                value={marginalThreshold}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  setMarginalThreshold(e.target.value)
-                }
-              />
-            </Prose>
+            <Inputs>
+              {/* This eslint rule is failing to detect `TextInput` as an `input` element. */}
+              {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+              <label>
+                <H6 as="h2">Definite:</H6>
+                <TextInput
+                  data-testid="definite-text-input"
+                  value={definiteThreshold}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setDefiniteThreshold(e.target.value)
+                  }
+                />
+              </label>
+              {/* This eslint rule is failing to detect `TextInput` as an `input` element. */}
+              {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+              <label>
+                <H6 as="h2">Marginal:</H6>
+                <TextInput
+                  data-testid="marginal-text-input"
+                  value={marginalThreshold}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setMarginalThreshold(e.target.value)
+                  }
+                />
+              </label>
+            </Inputs>
           }
           onOverlayClick={onClose}
           actions={
@@ -194,29 +201,29 @@ export function SetMarkThresholdsModal({
       assert(markThresholdOverrides);
       return (
         <Modal
+          title="Reset Mark Thresholds"
           content={
-            <Prose>
-              <h1>Reset Mark Thresholds</h1>
-              <p>Reset thresholds to the election defaults?</p>
+            <React.Fragment>
+              <P>Reset thresholds to the election defaults?</P>
               <ThresholdColumns>
                 <div>
-                  Current Thresholds
-                  <Text small>
+                  <H6 as="h2">Current Thresholds</H6>
+                  <P>
                     Definite: {markThresholdOverrides.definite}
                     <br />
                     Marginal: {markThresholdOverrides.marginal}
-                  </Text>
+                  </P>
                 </div>
                 <div>
-                  Default Thresholds
-                  <Text small>
+                  <H6 as="h2">Default Thresholds</H6>
+                  <P>
                     Definite: {defaultMarkThresholds.definite}
                     <br />
                     Marginal: {defaultMarkThresholds.marginal}
-                  </Text>
+                  </P>
                 </div>
               </ThresholdColumns>
-            </Prose>
+            </React.Fragment>
           }
           onOverlayClick={onClose}
           actions={


### PR DESCRIPTION
## Overview

Apply VVSG design updates to the `SetMarkThresholdsModal`:
- Replacing typography components with theme-aware versions and removing deprecated `<Prose>` 
- Moving title into `title` prop
- Minor typography tweaks to try to improve readability/a11y

## Demo Video or Screenshot
### Before/After:
<img width="400" src="https://github.com/votingworks/vxsuite/assets/264902/9c265d30-6da8-4965-91dd-d551a307c9fb" /> <img width="400" src="https://github.com/votingworks/vxsuite/assets/264902/4da22304-8ea2-4be8-8e7b-58656b813fe9" />

<img width="400" src="https://github.com/votingworks/vxsuite/assets/264902/69b71977-7f62-4db7-8293-8673c0fcb0cd" /> <img width="400" src="https://github.com/votingworks/vxsuite/assets/264902/edadc0bb-37bc-44e0-9652-654c9718f196" />

## Testing Plan
- Visual

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
