### PR TITLE
[CentralScan] VVSG Design Updates: AdminActionsScreen

### DIFF
--- a/apps/central-scan/frontend/src/screens/admin_actions_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/admin_actions_screen.tsx
@@ -182,16 +182,13 @@ export function AdminActionsScreen({
               >
                 <Icons.Delete /> Delete Election Data from VxCentralScan
               </Button>{' '}
-              {!canUnconfigure && !isTestMode && (
-                <React.Fragment>
-                  <br />
-                  <Font color="warning">
-                    <Icons.Warning /> You must &quot;Save Backup&quot; before
-                    you may delete election data.
-                  </Font>
-                </React.Fragment>
-              )}
             </ButtonRow>
+            {!canUnconfigure && !isTestMode && (
+              <Font color="warning">
+                <Icons.Warning /> You must &quot;Save Backup&quot; before you
+                may delete election data.
+              </Font>
+            )}
           </div>
         </Main>
         <MainNav isTestMode={isTestMode}>
@@ -255,7 +252,7 @@ export function AdminActionsScreen({
       {unconfigureFlowState === 'double-confirmation' && (
         <Modal
           title="Are you sure?"
-          content={<P>This can not be undone.</P>}
+          content={<P>This cannot be undone.</P>}
           actions={
             <React.Fragment>
               <Button variant="danger" onPress={doUnconfigure}>

--- a/apps/central-scan/frontend/src/screens/admin_actions_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/admin_actions_screen.tsx
@@ -5,19 +5,22 @@ import { assert, Result } from '@votingworks/basics';
 import {
   Button,
   ExportLogsButtonRow,
+  Font,
+  H1,
+  Icons,
   LinkButton,
   Loading,
   Main,
   Modal,
+  P,
   Screen,
   SetClockButton,
-  Text,
 } from '@votingworks/ui';
 import { isElectionManagerAuth } from '@votingworks/utils';
 import { Scan } from '@votingworks/api';
 import { useHistory } from 'react-router-dom';
+import styled from 'styled-components';
 import { MainNav } from '../components/main_nav';
-import { Prose } from '../components/prose';
 import { ToggleTestModeButton } from '../components/toggle_test_mode_button';
 import { SetMarkThresholdsModal } from '../components/set_mark_thresholds_modal';
 import { AppContext } from '../contexts/app_context';
@@ -27,6 +30,12 @@ import {
   unconfigure,
   clearBallotData,
 } from '../api';
+
+const ButtonRow = styled.div`
+  &:not(:last-child) {
+    margin-bottom: 1rem;
+  }
+`;
 
 export interface AdminActionScreenProps {
   backup: () => Promise<Result<string[], Scan.BackupError | Error>>;
@@ -119,15 +128,15 @@ export function AdminActionsScreen({
     <React.Fragment>
       <Screen>
         <Main padded>
-          <Prose>
-            <h1>Admin Actions</h1>
-            <p>
+          <div>
+            <H1>Admin Actions</H1>
+            <ButtonRow>
               <ToggleTestModeButton
                 isTestMode={isTestMode}
                 canUnconfigure={canUnconfigure}
               />
-            </p>
-            <p>
+            </ButtonRow>
+            <ButtonRow>
               <Button
                 onPress={() => setIsMarkThresholdModalOpen(true)}
                 disabled={hasBatches}
@@ -136,54 +145,54 @@ export function AdminActionsScreen({
                   ? 'Reset Mark Thresholds'
                   : 'Override Mark Thresholds'}
               </Button>
-            </p>
-            {backupError && <p style={{ color: 'red' }}>{backupError}</p>}
-            <p>
+            </ButtonRow>
+            {backupError && <P style={{ color: 'red' }}>{backupError}</P>}
+            <ButtonRow>
               <Button onPress={exportBackup} disabled={isBackingUp}>
                 {isBackingUp ? 'Saving…' : 'Save Backup'}
               </Button>
-            </p>
-            <ExportLogsButtonRow
-              electionDefinition={electionDefinition}
-              usbDriveStatus={usbDriveStatus}
-              auth={auth}
-              logger={logger}
-              machineConfig={machineConfig}
-            />
-            <p>
+            </ButtonRow>
+            <ButtonRow>
+              <ExportLogsButtonRow
+                electionDefinition={electionDefinition}
+                usbDriveStatus={usbDriveStatus}
+                auth={auth}
+                logger={logger}
+                machineConfig={machineConfig}
+              />
+            </ButtonRow>
+            <ButtonRow>
               <SetClockButton logOut={() => logOutMutation.mutate()}>
                 Update Date and Time
               </SetClockButton>
-            </p>
-            <p>
+            </ButtonRow>
+            <ButtonRow>
               <Button
-                variant="danger"
                 disabled={!canUnconfigure}
                 onPress={() => setDeleteBallotDataFlowState('confirmation')}
               >
-                Delete Ballot Data
+                <Icons.Delete /> Delete Ballot Data
               </Button>
-            </p>
+            </ButtonRow>
 
-            <p>
+            <ButtonRow>
               <Button
-                variant="danger"
                 disabled={!canUnconfigure}
                 onPress={() => setUnconfigureFlowState('initial-confirmation')}
               >
-                Delete Election Data from VxCentralScan
+                <Icons.Delete /> Delete Election Data from VxCentralScan
               </Button>{' '}
               {!canUnconfigure && !isTestMode && (
                 <React.Fragment>
                   <br />
-                  <Text as="span" warning warningIcon>
-                    You must &quot;Save Backup&quot; before you may delete
-                    election data.
-                  </Text>
+                  <Font color="warning">
+                    <Icons.Warning /> You must &quot;Save Backup&quot; before
+                    you may delete election data.
+                  </Font>
                 </React.Fragment>
               )}
-            </p>
-          </Prose>
+            </ButtonRow>
+          </div>
         </Main>
         <MainNav isTestMode={isTestMode}>
           <Button small onPress={() => logOutMutation.mutate()}>
@@ -196,16 +205,13 @@ export function AdminActionsScreen({
       </Screen>
       {deleteBallotDataFlowState === 'confirmation' && (
         <Modal
-          centerContent
+          title="Delete All Scanned Ballot Data?"
           content={
-            <Prose textCenter>
-              <h1>Delete All Scanned Ballot Data?</h1>
-              <p>
-                This will permanently delete all scanned ballot data and reset
-                the scanner to only be configured with the current election,
-                with the default mark thresholds.
-              </p>
-            </Prose>
+            <P>
+              This will permanently delete all scanned ballot data and reset the
+              scanner to only be configured with the current election, with the
+              default mark thresholds.
+            </P>
           }
           actions={
             <React.Fragment>
@@ -220,18 +226,17 @@ export function AdminActionsScreen({
       )}
       {unconfigureFlowState === 'initial-confirmation' && (
         <Modal
-          centerContent
+          title="Delete all election data?"
           content={
-            <Prose textCenter>
-              <h1>Delete all election data?</h1>
-              <p>
+            <React.Fragment>
+              <P>
                 This will delete the election configuration and all the scanned
                 ballot data from VxCentralScan.
-              </p>
+              </P>
               {usbDriveStatus === 'mounted' && (
-                <p>It will also eject the USB drive.</p>
+                <P>It will also eject the USB drive.</P>
               )}
-            </Prose>
+            </React.Fragment>
           }
           actions={
             <React.Fragment>
@@ -249,13 +254,8 @@ export function AdminActionsScreen({
       )}
       {unconfigureFlowState === 'double-confirmation' && (
         <Modal
-          centerContent
-          content={
-            <Prose textCenter>
-              <h1>Are you sure?</h1>
-              <p>This can not be undone.</p>
-            </Prose>
-          }
+          title="Are you sure?"
+          content={<P>This can not be undone.</P>}
           actions={
             <React.Fragment>
               <Button variant="danger" onPress={doUnconfigure}>


### PR DESCRIPTION
## Overview

Apply VVSG design updates to the `AdminActionsScreen` in CentralScan:
- Replacing typography components with theme-aware versions and removing deprecated `<Prose>` 
- Moving modal titles into `title` prop
- Removing `danger` button variant styling from the non-destructive buttons that open confirmation modals.

## Demo Video or Screenshot
### Before:
![Screenshot 2023-07-03 at 14 43 12](https://github.com/votingworks/vxsuite/assets/264902/95dd7e81-3f81-40c3-84a4-98eaf2af11e7)

### After:
https://github.com/votingworks/vxsuite/assets/264902/6de1c25e-cca0-41d6-8670-d6af736edf05

![Screenshot 2023-07-03 at 15 55 27](https://github.com/votingworks/vxsuite/assets/264902/4eecbd29-b138-4c04-b076-1e1b8d70cd7f)

## Testing Plan
- Visual

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates