### PR TITLE
refactor(mark): more generic print page callback

### DIFF
--- a/libs/mark-flow-ui/src/config/globals.ts
+++ b/libs/mark-flow-ui/src/config/globals.ts
@@ -1,6 +1,5 @@
 export const IDLE_TIMEOUT_SECONDS = 5 * 60; // VVSG Requirement: 2–5 minutes
 export const IDLE_RESET_TIMEOUT_SECONDS = 45; // VVSG Requirement: 20–45 seconds
-export const BALLOT_PRINTING_TIMEOUT_SECONDS = 5;
 export const WRITE_IN_CANDIDATE_MAX_LENGTH = 40;
 export enum Paths {
   DISPLAY_SETTINGS = '/display-settings',

--- a/libs/mark-flow-ui/src/pages/print_page.test.tsx
+++ b/libs/mark-flow-ui/src/pages/print_page.test.tsx
@@ -17,8 +17,7 @@ test('no votes', async () => {
       generateBallotId={() => 'CHhgYxfN5GeqnK8KaVOt1w'}
       isLiveMode={false}
       votes={{}}
-      updateTally={jest.fn()}
-      resetBallot={jest.fn()}
+      onPrintStarted={jest.fn()}
     />
   );
   await expectPrintToMatchSnapshot();
@@ -47,8 +46,7 @@ test('with votes', async () => {
         }
       )}
       isLiveMode={false}
-      updateTally={jest.fn()}
-      resetBallot={jest.fn()}
+      onPrintStarted={jest.fn()}
     />
   );
   await expectPrintToMatchSnapshot();
@@ -64,8 +62,7 @@ test('without votes and inline seal', async () => {
       generateBallotId={() => 'CHhgYxfN5GeqnK8KaVOt1w'}
       isLiveMode={false}
       votes={{}}
-      updateTally={jest.fn()}
-      resetBallot={jest.fn()}
+      onPrintStarted={jest.fn()}
     />
   );
   await expectPrintToMatchSnapshot();
@@ -81,8 +78,7 @@ test('without votes and no seal', async () => {
       generateBallotId={() => 'CHhgYxfN5GeqnK8KaVOt1w'}
       isLiveMode={false}
       votes={{}}
-      updateTally={jest.fn()}
-      resetBallot={jest.fn()}
+      onPrintStarted={jest.fn()}
     />
   );
   await expectPrintToMatchSnapshot();

--- a/libs/mark-flow-ui/src/pages/print_page.tsx
+++ b/libs/mark-flow-ui/src/pages/print_page.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import {
   BmdPaperBallot,
@@ -17,7 +17,6 @@ import {
   PrecinctId,
   VotesDict,
 } from '@votingworks/types';
-import { BALLOT_PRINTING_TIMEOUT_SECONDS } from '../config/globals';
 
 export const printingMessageTimeoutSeconds = 5;
 
@@ -28,8 +27,7 @@ export interface PrintPageProps {
   isLiveMode: boolean;
   votes: VotesDict;
   generateBallotId: () => string;
-  updateTally: () => void;
-  resetBallot: (showPostVotingInstructions?: boolean) => void;
+  onPrintStarted?: () => void;
 }
 
 export function PrintPage({
@@ -39,10 +37,8 @@ export function PrintPage({
   isLiveMode,
   votes,
   generateBallotId,
-  updateTally,
-  resetBallot,
+  onPrintStarted,
 }: PrintPageProps): JSX.Element {
-  const printerTimer = useRef(0);
   const printLock = useLock();
 
   const printBallot = useCallback(async () => {
@@ -59,10 +55,7 @@ export function PrintPage({
       />,
       { sides: 'one-sided' }
     );
-    updateTally();
-    printerTimer.current = window.setTimeout(() => {
-      resetBallot(true);
-    }, BALLOT_PRINTING_TIMEOUT_SECONDS * 1000);
+    onPrintStarted?.();
   }, [
     printLock,
     ballotStyleId,
@@ -71,20 +64,12 @@ export function PrintPage({
     isLiveMode,
     precinctId,
     votes,
-    updateTally,
-    resetBallot,
+    onPrintStarted,
   ]);
 
   useEffect(() => {
     void printBallot();
   }, [printBallot]);
-
-  // Make sure we clean up any pending timeout on unmount
-  useEffect(() => {
-    return () => {
-      clearTimeout(printerTimer.current);
-    };
-  }, []);
 
   return (
     <Screen white>


### PR DESCRIPTION
## Overview
Rather than assuming that all users of this component has `updateTally` and `resetBallot` steps, just call back once the print job has started and let the parent component handle it.

I plan to use this in `rave-mark`.

## Demo Video or Screenshot
n/a

## Testing Plan
n/a

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
