### PR TITLE
chore(backend): remove unused `image-utils` dependency

### DIFF
--- a/libs/backend/package.json
+++ b/libs/backend/package.json
@@ -37,7 +37,6 @@
     "@votingworks/auth": "workspace:*",
     "@votingworks/basics": "workspace:*",
     "@votingworks/fixtures": "workspace:*",
-    "@votingworks/image-utils": "workspace:*",
     "@votingworks/logging": "workspace:*",
     "@votingworks/types": "workspace:*",
     "@votingworks/utils": "workspace:*",

--- a/libs/backend/tsconfig.build.json
+++ b/libs/backend/tsconfig.build.json
@@ -13,7 +13,6 @@
     { "path": "../../libs/basics/tsconfig.build.json" },
     { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../../libs/fixtures/tsconfig.build.json" },
-    { "path": "../../libs/image-utils/tsconfig.build.json" },
     { "path": "../../libs/logging/tsconfig.build.json" },
     { "path": "../../libs/test-utils/tsconfig.build.json" },
     { "path": "../../libs/types/tsconfig.build.json" },

--- a/libs/backend/tsconfig.json
+++ b/libs/backend/tsconfig.json
@@ -19,7 +19,6 @@
     { "path": "../../libs/basics/tsconfig.build.json" },
     { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../../libs/fixtures/tsconfig.build.json" },
-    { "path": "../../libs/image-utils/tsconfig.build.json" },
     { "path": "../../libs/logging/tsconfig.build.json" },
     { "path": "../../libs/test-utils/tsconfig.build.json" },
     { "path": "../../libs/types/tsconfig.build.json" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4092,9 +4092,6 @@ importers:
       '@votingworks/fixtures':
         specifier: workspace:*
         version: link:../fixtures
-      '@votingworks/image-utils':
-        specifier: workspace:*
-        version: link:../image-utils
       '@votingworks/logging':
         specifier: workspace:*
         version: link:../logging


### PR DESCRIPTION
## Overview
<!-- add a link to a GitHub Issue here -->
Just noticed this while pruning dependencies in `rave`.

## Demo Video or Screenshot
n/a

## Testing Plan
n/a

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
