### PR TITLE
[CentralScan] VVSG Design Updates: Typography Odds & Ends

### DIFF
--- a/apps/central-scan/frontend/src/app_root.tsx
+++ b/apps/central-scan/frontend/src/app_root.tsx
@@ -22,6 +22,7 @@ import {
   useUsbDrive,
   LinkButton,
   Button,
+  H1,
 } from '@votingworks/ui';
 import { LogEventId, Logger } from '@votingworks/logging';
 import { assert, Result, ok, err } from '@votingworks/basics';
@@ -330,7 +331,7 @@ export function AppRoot({
     return (
       <Screen>
         <Main padded centerChild>
-          <h1>Loading Configuration...</h1>
+          <H1>Loading Configuration...</H1>
         </Main>
       </Screen>
     );

--- a/apps/central-scan/frontend/src/components/toggle_test_mode_button.tsx
+++ b/apps/central-scan/frontend/src/components/toggle_test_mode_button.tsx
@@ -1,7 +1,6 @@
-import { Button, Modal } from '@votingworks/ui';
+import { Button, Modal, P } from '@votingworks/ui';
 import React, { useCallback, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { Prose } from './prose';
 import { setTestMode } from '../api';
 
 export interface Props {
@@ -55,20 +54,17 @@ export function ToggleTestModeButton({
       </Button>
       {flowState === 'confirmation' && (
         <Modal
-          centerContent
+          title={
+            isTestMode
+              ? 'Toggle to Official Ballot Mode'
+              : 'Toggle to Test Ballot Mode'
+          }
           content={
-            <Prose textCenter>
-              <h1>
-                {isTestMode
-                  ? 'Toggle to Official Ballot Mode'
-                  : 'Toggle to Test Ballot Mode'}
-              </h1>
-              <p>
-                {`Toggling to ${
-                  isTestMode ? 'Official' : 'Test'
-                } Ballot Mode will zero out your scanned ballots. Are you sure?`}
-              </p>
-            </Prose>
+            <P>
+              {`Toggling to ${
+                isTestMode ? 'Official' : 'Test'
+              } Ballot Mode will zero out your scanned ballots. Are you sure?`}
+            </P>
           }
           actions={
             <React.Fragment>
@@ -91,17 +87,12 @@ export function ToggleTestModeButton({
       )}
       {flowState === 'toggling' && (
         <Modal
-          centerContent
-          content={
-            <Prose textCenter>
-              <h1>
-                {isTestMode
-                  ? 'Toggling to Official Ballot Mode'
-                  : 'Toggling to Test Ballot Mode'}
-              </h1>
-              <p>Zeroing out scanned ballots and reloading…</p>
-            </Prose>
+          title={
+            isTestMode
+              ? 'Toggling to Official Ballot Mode'
+              : 'Toggling to Test Ballot Mode'
           }
+          content={<P>Zeroing out scanned ballots and reloading…</P>}
         />
       )}
     </React.Fragment>

--- a/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
@@ -9,11 +9,13 @@ import { Scan } from '@votingworks/api';
 import { assert } from '@votingworks/basics';
 import {
   Button,
+  Caption,
   ElectionInfoBar,
+  H4,
   Main,
   Modal,
+  P,
   Screen,
-  Text,
 } from '@votingworks/ui';
 import { isElectionManagerAuth } from '@votingworks/utils';
 import React, { useCallback, useContext, useEffect, useState } from 'react';
@@ -21,7 +23,6 @@ import styled from 'styled-components';
 import { fetchNextBallotSheetToReview } from '../api/hmpb';
 import { BallotSheetImage } from '../components/ballot_sheet_image';
 import { MainNav } from '../components/main_nav';
-import { Prose } from '../components/prose';
 import { AppContext } from '../contexts/app_context';
 
 const MainChildFlexRow = styled.div`
@@ -313,8 +314,8 @@ export function BallotEjectScreen({
         <MainNav />
         <Main>
           <MainChildFlexRow>
-            <Prose maxWidth={false}>
-              <h1>
+            <div>
+              <H4 as="h1">
                 <span style={{ fontSize: '2em' }}>
                   {isInvalidTestModeSheet
                     ? isTestMode
@@ -332,28 +333,28 @@ export function BallotEjectScreen({
                     ? 'Undervote'
                     : 'Unknown Reason'}
                 </span>
-              </h1>
+              </H4>
               {isOvervotedSheet ? (
-                <p>
+                <P>
                   The last scanned ballot was not tabulated because an overvote
                   was detected.
-                </p>
+                </P>
               ) : isBlankSheet ? (
-                <p>
+                <P>
                   The last scanned ballot was not tabulated because no votes
                   were detected.
-                </p>
+                </P>
               ) : isUndervotedSheet ? (
-                <p>
+                <P>
                   The last scanned ballot was not tabulated because an undervote
                   was detected.
-                </p>
+                </P>
               ) : (
-                <p>The last scanned ballot was not tabulated.</p>
+                <P>The last scanned ballot was not tabulated.</P>
               )}
               {allowBallotDuplication ? (
                 <React.Fragment>
-                  <p>
+                  <P>
                     <Button
                       fullWidth
                       variant="primary"
@@ -361,8 +362,8 @@ export function BallotEjectScreen({
                     >
                       Remove to Adjudicate
                     </Button>
-                  </p>
-                  <p>
+                  </P>
+                  <P>
                     <Button
                       fullWidth
                       variant="primary"
@@ -370,36 +371,36 @@ export function BallotEjectScreen({
                     >
                       Tabulate As Is
                     </Button>
-                  </p>
+                  </P>
                 </React.Fragment>
               ) : isInvalidTestModeSheet ? (
                 isTestMode ? (
-                  <p>Remove the OFFICIAL ballot before continuing.</p>
+                  <P>Remove the OFFICIAL ballot before continuing.</P>
                 ) : (
-                  <p>Remove the TEST ballot before continuing.</p>
+                  <P>Remove the TEST ballot before continuing.</P>
                 )
               ) : isInvalidElectionHashSheet ? (
                 <React.Fragment>
-                  <p>
+                  <P>
                     The scanned ballot does not match the election this scanner
                     is configured for. Remove the invalid ballot before
                     continuing.
-                  </p>
-                  <Text small>
+                  </P>
+                  <Caption>
                     Ballot Election Hash: {actualElectionHash?.slice(0, 10)}
-                  </Text>
+                  </Caption>
                 </React.Fragment>
               ) : (
                 // Unreadable
                 <React.Fragment>
-                  <p>
+                  <P>
                     There was a problem reading the ballot. Remove ballot and
                     reload in the scanner to try again.
-                  </p>
-                  <p>
+                  </P>
+                  <P>
                     If the error persists remove ballot and create a duplicate
                     ballot for the Resolution Board to review.
-                  </p>
+                  </P>
                 </React.Fragment>
               )}
               {!allowBallotDuplication && (
@@ -411,7 +412,7 @@ export function BallotEjectScreen({
                   The ballot has been removed
                 </Button>
               )}
-            </Prose>
+            </div>
             <RectoVerso>
               <BallotSheetImage
                 imageUrl={reviewInfo.interpreted.front.image.url}
@@ -439,12 +440,9 @@ export function BallotEjectScreen({
       </Screen>
       {ballotState === 'removeBallot' && (
         <Modal
-          centerContent
+          title="Remove the Ballot"
           content={
-            <Prose textCenter>
-              <h1>Remove the Ballot</h1>
-              <p>Remove the ballot and provide it to the resolution board.</p>
-            </Prose>
+            <P>Remove the ballot and provide it to the resolution board.</P>
           }
           actions={
             <React.Fragment>
@@ -462,12 +460,9 @@ export function BallotEjectScreen({
       )}
       {ballotState === 'acceptBallot' && (
         <Modal
-          centerContent
+          title="Tabulate Ballot As Is?"
           content={
-            <Prose textCenter>
-              <h1>Tabulate Ballot As Is?</h1>
-              <p>Please confirm you wish to tabulate this ballot as is.</p>
-            </Prose>
+            <P>Please confirm you wish to tabulate this ballot as is.</P>
           }
           actions={
             <React.Fragment>

--- a/apps/central-scan/frontend/src/screens/machine_locked_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/machine_locked_screen.tsx
@@ -1,10 +1,4 @@
-import {
-  ElectionInfoBar,
-  fontSizeTheme,
-  Main,
-  Prose,
-  Screen,
-} from '@votingworks/ui';
+import { ElectionInfoBar, Font, H1, Main, P, Screen } from '@votingworks/ui';
 import React, { useContext } from 'react';
 import styled from 'styled-components';
 
@@ -24,23 +18,19 @@ export function MachineLockedScreen(): JSX.Element {
       <Main padded centerChild>
         <div>
           <LockedImage src="/locked.svg" alt="Locked Icon" />
-          <Prose
-            textCenter
-            themeDeprecated={fontSizeTheme.medium}
-            maxWidth={false}
-          >
+          <Font align="center">
             {electionDefinition ? (
               <React.Fragment>
-                <h1>VxCentralScan is Locked</h1>
-                <p>Insert Election Manager card to unlock.</p>
+                <H1>VxCentralScan is Locked</H1>
+                <P>Insert Election Manager card to unlock.</P>
               </React.Fragment>
             ) : (
               <React.Fragment>
-                <h1>VxCentralScan is Not Configured</h1>
-                <p>Insert Election Manager card to configure.</p>
+                <H1>VxCentralScan is Not Configured</H1>
+                <P>Insert Election Manager card to configure.</P>
               </React.Fragment>
             )}
-          </Prose>
+          </Font>
         </div>
       </Main>
       {electionDefinition && (


### PR DESCRIPTION
## Overview

Closes: https://github.com/votingworks/vxsuite/issues/3570

Applying the last few bits of VVSG design updates to CentralScan:
- Replace heading and paragraph components with theme-aware versions
- Remove deprecated "Prose" elements
- Move modal titles into the `Modal.title` prop and remove unnecessary text centring

## Demo Video or Screenshot
![Screenshot 2023-07-05 at 12 23 25](https://github.com/votingworks/vxsuite/assets/264902/7e3fc22e-95f1-42e7-9d28-daa505247b60)

![Screenshot 2023-07-05 at 12 22 00](https://github.com/votingworks/vxsuite/assets/264902/99744a2b-4ead-4437-89db-a330c271f600)

![Screenshot 2023-07-05 at 12 21 36](https://github.com/votingworks/vxsuite/assets/264902/5b3f49b3-2226-4a83-8cac-0c2971ed5223)

![Screenshot 2023-07-05 at 12 11 26](https://github.com/votingworks/vxsuite/assets/264902/a6b8bf6e-dbd3-45d1-b730-e878fdb9720d)


## Testing Plan
- Visual

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
