### PR TITLE
Add Live Check button to remaining user roles' UIs in VxAdmin and VxScan

### DIFF
--- a/apps/admin/frontend/src/components/election_manager.tsx
+++ b/apps/admin/frontend/src/components/election_manager.tsx
@@ -41,6 +41,7 @@ import { LogicAndAccuracyScreen } from '../screens/logic_and_accuracy_screen';
 import { SettingsScreen } from '../screens/settings_screen';
 import { LogsScreen } from '../screens/logs_screen';
 import { ReportsScreen } from '../screens/reports_screen';
+import { ElectionManagerSystemScreen } from '../screens/election_manager_system_screen';
 import { SmartcardTypeRegExPattern } from '../config/types';
 import { SmartcardModal } from './smartcard_modal';
 import { checkPin } from '../api';
@@ -223,6 +224,9 @@ export function ElectionManager(): JSX.Element {
       )}
       <Route exact path={[routerPaths.testDecks]}>
         <PrintTestDeckScreen />
+      </Route>
+      <Route exact path={routerPaths.system}>
+        <ElectionManagerSystemScreen />
       </Route>
       <Redirect to={routerPaths.ballotsList} />
     </Switch>

--- a/apps/admin/frontend/src/components/navigation_screen.tsx
+++ b/apps/admin/frontend/src/components/navigation_screen.tsx
@@ -54,6 +54,10 @@ const ELECTION_MANAGER_NAV_ITEMS: readonly NavItem[] = _.compact([
     BooleanEnvironmentVariableName.WRITE_IN_ADJUDICATION
   ) && { label: 'Write-Ins', routerPath: routerPaths.writeIns },
   { label: 'Reports', routerPath: routerPaths.reports },
+  isFeatureFlagEnabled(BooleanEnvironmentVariableName.LIVECHECK) && {
+    label: 'System',
+    routerPath: routerPaths.system,
+  },
 ]);
 
 const NO_BALLOT_GENERATION_HIDDEN_PATHS: ReadonlySet<string> = new Set([

--- a/apps/admin/frontend/src/router_paths.ts
+++ b/apps/admin/frontend/src/router_paths.ts
@@ -49,4 +49,5 @@ export const routerPaths = {
   writeIns: '/write-ins',
   settings: '/settings',
   logs: '/logs',
+  system: '/system',
 } as const;

--- a/apps/admin/frontend/src/screens/election_manager_system_screen.tsx
+++ b/apps/admin/frontend/src/screens/election_manager_system_screen.tsx
@@ -1,0 +1,10 @@
+import { LiveCheckButton } from '../components/live_check_button';
+import { NavigationScreen } from '../components/navigation_screen';
+
+export function ElectionManagerSystemScreen(): JSX.Element {
+  return (
+    <NavigationScreen title="System">
+      <LiveCheckButton />
+    </NavigationScreen>
+  );
+}

--- a/apps/scan/frontend/src/app_root.tsx
+++ b/apps/scan/frontend/src/app_root.tsx
@@ -11,6 +11,8 @@ import {
   isSystemAdministratorAuth,
   isElectionManagerAuth,
   isPollWorkerAuth,
+  isFeatureFlagEnabled,
+  BooleanEnvironmentVariableName,
 } from '@votingworks/utils';
 import { Logger } from '@votingworks/logging';
 
@@ -44,6 +46,7 @@ import {
 } from './api';
 import { VoterScreen } from './screens/voter_screen';
 import { LoginPromptScreen } from './screens/login_prompt_screen';
+import { LiveCheckButton } from './components/live_check_button';
 
 export interface Props {
   hardware: Hardware;
@@ -166,6 +169,11 @@ export function AppRoot({ hardware, logger }: Props): JSX.Element | null {
           }
           isMachineConfigured={Boolean(electionDefinition)}
           usbDriveStatus={legacyUsbDriveStatus(usbDrive)}
+          additionalButtons={
+            isFeatureFlagEnabled(BooleanEnvironmentVariableName.LIVECHECK) ? (
+              <LiveCheckButton />
+            ) : undefined
+          }
         />
       </ScreenMainCenterChild>
     );

--- a/libs/ui/src/live_check_modal.tsx
+++ b/libs/ui/src/live_check_modal.tsx
@@ -47,13 +47,18 @@ export function LiveCheckModal({
               <QrCode value={qrCodeValue} />
             </QrCodeContainer>
             <Details>
-              <Caption>Machine ID: {signatureInputs.machineId}</Caption>
+              <Caption>
+                <strong>Machine ID:</strong> {signatureInputs.machineId}
+              </Caption>
               {signatureInputs.electionHashPrefix && (
                 <Caption>
-                  Election ID: {signatureInputs.electionHashPrefix}
+                  <strong>Election ID:</strong>{' '}
+                  {signatureInputs.electionHashPrefix}
                 </Caption>
               )}
-              <Caption>Date: {signatureInputs.date.toLocaleString()}</Caption>
+              <Caption>
+                <strong>Date:</strong> {signatureInputs.date.toLocaleString()}
+              </Caption>
             </Details>
           </Content>
         </React.Fragment>

--- a/libs/ui/src/system_administrator_screen_contents.tsx
+++ b/libs/ui/src/system_administrator_screen_contents.tsx
@@ -23,6 +23,7 @@ interface Props {
   resetPollsToPaused?: () => Promise<void>;
   isMachineConfigured: boolean;
   usbDriveStatus: UsbDriveStatus;
+  additionalButtons?: React.ReactNode;
 }
 
 const ButtonGrid = styled.div`
@@ -49,6 +50,7 @@ export function SystemAdministratorScreenContents({
   resetPollsToPaused,
   isMachineConfigured,
   usbDriveStatus,
+  additionalButtons,
 }: Props): JSX.Element {
   return (
     <Main padded centerChild>
@@ -75,6 +77,7 @@ export function SystemAdministratorScreenContents({
             unconfigureMachine={unconfigureMachine}
             isMachineConfigured={isMachineConfigured}
           />
+          {additionalButtons}
           {isVxDev() && (
             <Button onPress={() => window.kiosk?.quit()}>Quit</Button>
           )}


### PR DESCRIPTION
## Overview

A quick follow-up to https://github.com/votingworks/vxsuite/pull/3670, this PR adds the Live Check button to the VxAdmin election manager UI (under a new System tab) and the VxScan sys admin UI. Now, every user role can access the Live Check button on VxAdmin and VxScan (when the Live Check feature flag is enabled).

## Demo Videos

_VxAdmin election manager UI_

https://github.com/votingworks/vxsuite/assets/12616928/57ba6199-8457-49b9-a262-be91a5fc06fe

_VxScan sys admin UI_

https://github.com/votingworks/vxsuite/assets/12616928/1f667220-213e-4931-b54f-dcf2c7ec4da6

## Testing

- [x] Tested manually

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced ➡️ As with https://github.com/votingworks/vxsuite/pull/3670, punting on logging for now
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates