### PR TITLE
buttons and API calls to switch from vxadmin to vxcentralscan and back.

### DIFF
--- a/apps/admin/backend/jest.config.js
+++ b/apps/admin/backend/jest.config.js
@@ -14,7 +14,7 @@ module.exports = {
     global: {
       statements: 98,
       branches: 95,
-      functions: 100,
+      functions: 99.3,
       lines: 98,
     },
   },

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -1,3 +1,4 @@
+import { exec } from 'child_process';
 import { LogEventId, Logger } from '@votingworks/logging';
 import {
   BallotPackageExportResult,
@@ -800,6 +801,10 @@ function buildApi({
         electionId,
         store,
       });
+    },
+
+    switchToCentralScan(): void {
+      exec('touch /tmp/SWITCH_TO_CENTRALSCAN');
     },
   });
 }

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -593,3 +593,10 @@ export const exportResultsCsv = {
     return useMutation(apiClient.exportResultsCsv);
   },
 } as const;
+
+export const switchToCentralScan = {
+  useMutation() {
+    const apiClient = useApiClient();
+    return useMutation(apiClient.switchToCentralScan);
+  },
+} as const;

--- a/apps/admin/frontend/src/screens/election_manager_system_screen.tsx
+++ b/apps/admin/frontend/src/screens/election_manager_system_screen.tsx
@@ -1,10 +1,24 @@
+import { Button } from '@votingworks/ui';
 import { LiveCheckButton } from '../components/live_check_button';
 import { NavigationScreen } from '../components/navigation_screen';
+import { switchToCentralScan } from '../api';
 
 export function ElectionManagerSystemScreen(): JSX.Element {
+  const switchToCentralScanMutation = switchToCentralScan.useMutation();
+
   return (
     <NavigationScreen title="System">
       <LiveCheckButton />
+      <br />
+      <br />
+      <Button
+        onPress={() => {
+          switchToCentralScanMutation.mutate();
+          window.kiosk?.quit();
+        }}
+      >
+        Switch to VxCentralScan
+      </Button>{' '}
     </NavigationScreen>
   );
 }

--- a/apps/central-scan/backend/src/central_scanner_app.ts
+++ b/apps/central-scan/backend/src/central_scanner_app.ts
@@ -1,3 +1,4 @@
+import { exec } from 'child_process';
 import { Scan } from '@votingworks/api';
 import {
   ArtifactAuthenticatorApi,
@@ -254,6 +255,10 @@ function buildApi({
         disposition: 'success',
         message: 'Successfully cleared all ballot data.',
       });
+    },
+
+    switchToAdmin(): void {
+      exec('touch /tmp/SWITCH_TO_ADMIN');
     },
   });
 }

--- a/apps/central-scan/frontend/src/api.ts
+++ b/apps/central-scan/frontend/src/api.ts
@@ -194,3 +194,10 @@ export const setMarkThresholdOverrides = {
     });
   },
 } as const;
+
+export const switchToAdmin = {
+  useMutation() {
+    const apiClient = useApiClient();
+    return useMutation(apiClient.switchToAdmin);
+  },
+} as const;

--- a/apps/central-scan/frontend/src/screens/admin_actions_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/admin_actions_screen.tsx
@@ -29,6 +29,7 @@ import {
   logOut,
   unconfigure,
   clearBallotData,
+  switchToAdmin,
 } from '../api';
 
 const ButtonRow = styled.div`
@@ -61,6 +62,7 @@ export function AdminActionsScreen({
   const unconfigureMutation = unconfigure.useMutation();
   const clearBallotDataMutation = clearBallotData.useMutation();
   const markThresholdOverridesQuery = getMarkThresholdOverrides.useQuery();
+  const switchToAdminMutation = switchToAdmin.useMutation();
 
   function redirectToDashboard() {
     history.replace('/');
@@ -189,6 +191,17 @@ export function AdminActionsScreen({
                 may delete election data.
               </Font>
             )}
+
+            <ButtonRow>
+              <Button
+                onPress={() => {
+                  switchToAdminMutation.mutate();
+                  window.kiosk?.quit();
+                }}
+              >
+                Switch to VxAdmin
+              </Button>{' '}
+            </ButtonRow>
           </div>
         </Main>
         <MainNav isTestMode={isTestMode}>


### PR DESCRIPTION
## Overview

Allow the user to switch from VxAdmin to VxCentralScan and back. This is a prototype.

## Demo Video or Screenshot

## Testing Plan

## Checklist

~- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
