### PR TITLE
Add Commas to Number in CVR Modal

### DIFF
--- a/apps/admin/frontend/src/components/import_cvrfiles_modal.test.tsx
+++ b/apps/admin/frontend/src/components/import_cvrfiles_modal.test.tsx
@@ -25,7 +25,7 @@ const LIVE_FILE1 = 'machine_0002__10_ballots__2020-12-09_15-59-32.jsonl';
 
 const mockCastVoteRecordImportInfo: CvrFileImportInfo = {
   wasExistingFile: false,
-  newlyAdded: 0,
+  newlyAdded: 1000,
   alreadyPresent: 0,
   exportedTimestamp: new Date().toISOString(),
   fileMode: 'test',
@@ -157,7 +157,7 @@ describe('when USB is properly mounted', () => {
     apiMock.expectGetCastVoteRecordFileMode('test');
     apiMock.expectGetCastVoteRecordFiles([]);
 
-    await screen.findByText('0 new CVRs Loaded');
+    await screen.findByText('1,000 new CVRs Loaded');
 
     delete window.kiosk;
   });
@@ -208,7 +208,7 @@ describe('when USB is properly mounted', () => {
 
     userEvent.click(domGetByText(tableRows[0], 'Load'));
     await screen.findByText('Loading');
-    await screen.findByText('0 new CVRs Loaded');
+    await screen.findByText('1,000 new CVRs Loaded');
   });
 
   test('locks to test mode when in test mode & shows previously loaded files as loaded', async () => {

--- a/apps/admin/frontend/src/components/import_cvrfiles_modal.tsx
+++ b/apps/admin/frontend/src/components/import_cvrfiles_modal.tsx
@@ -16,6 +16,7 @@ import {
   Font,
 } from '@votingworks/ui';
 import {
+  format,
   isElectionManagerAuth,
   isSystemAdministratorAuth,
 } from '@votingworks/utils';
@@ -182,15 +183,20 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element | null {
   if (currentState.state === 'success') {
     return (
       <Modal
-        title={`${currentState.result.newlyAdded} new CVRs Loaded`}
+        title={`${format.count(
+          currentState.result.newlyAdded
+        )} new CVRs Loaded`}
         content={
           currentState.result.alreadyPresent > 0 && (
             <P>
               Of the{' '}
-              {currentState.result.newlyAdded +
-                currentState.result.alreadyPresent}{' '}
-              total CVRs in this file, {currentState.result.alreadyPresent} were
-              previously loaded.
+              {format.count(
+                currentState.result.newlyAdded +
+                  currentState.result.alreadyPresent
+              )}{' '}
+              total CVRs in this file,{' '}
+              {format.count(currentState.result.alreadyPresent)} were previously
+              loaded.
             </P>
           )
         }


### PR DESCRIPTION
CVR import modal shows "X CVRs Loaded" but when it's in the thousands it needs to be number formatted to be readable.