### PR TITLE
yield to event loop during CVR tabulation

### DIFF
--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -687,15 +687,15 @@ function buildApi({
       );
     },
 
-    getResultsForTallyReports(
+    async getResultsForTallyReports(
       input: {
         filter?: Tabulation.Filter;
         groupBy?: Tabulation.GroupBy;
       } = {}
-    ): Tabulation.GroupList<TallyReportResults> {
+    ): Promise<Tabulation.GroupList<TallyReportResults>> {
       const electionId = loadCurrentElectionIdOrThrow(workspace);
       return groupMapToGroupList(
-        tabulateTallyReportResults({
+        await tabulateTallyReportResults({
           electionId,
           store,
           filter: input.filter,
@@ -720,7 +720,7 @@ function buildApi({
         path: input.path,
         data: generateBatchResultsFile({
           election,
-          batchGroupedResults: tabulateElectionResults({
+          batchGroupedResults: await tabulateElectionResults({
             electionId,
             store,
             groupBy: { groupByBatch: true },
@@ -744,11 +744,11 @@ function buildApi({
       return exportFileResult;
     },
 
-    getSemsExportableTallies(): SemsExportableTallies {
+    async getSemsExportableTallies(): Promise<SemsExportableTallies> {
       const electionId = loadCurrentElectionIdOrThrow(workspace);
 
       return getSemsExportableTallies(
-        tabulateElectionResults({
+        await tabulateElectionResults({
           electionId,
           store,
           groupBy: { groupByPrecinct: true },
@@ -768,13 +768,14 @@ function buildApi({
         path: input.path,
         data: generateResultsCsv({
           election,
-          electionResultsByPrecinctAndVotingMethod: tabulateElectionResults({
-            electionId,
-            store,
-            groupBy: { groupByPrecinct: true, groupByVotingMethod: true },
-            includeManualResults: true,
-            includeWriteInAdjudicationResults: true,
-          }),
+          electionResultsByPrecinctAndVotingMethod:
+            await tabulateElectionResults({
+              electionId,
+              store,
+              groupBy: { groupByPrecinct: true, groupByVotingMethod: true },
+              includeManualResults: true,
+              includeWriteInAdjudicationResults: true,
+            }),
           writeInCandidates: store.getWriteInCandidates({ electionId }),
         }),
       });

--- a/apps/admin/backend/src/tabulation/full_results.test.ts
+++ b/apps/admin/backend/src/tabulation/full_results.test.ts
@@ -44,7 +44,7 @@ afterEach(() => {
   featureFlagMock.resetFeatureFlags();
 });
 
-test('tabulateCastVoteRecords', () => {
+test('tabulateCastVoteRecords', async () => {
   const store = Store.memoryStore();
   const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
   const { election, electionData } = electionDefinition;
@@ -234,7 +234,7 @@ test('tabulateCastVoteRecords', () => {
   ];
 
   for (const { filter, groupBy, expected } of testCases) {
-    const groupedWriteInSummaries = tabulateCastVoteRecords({
+    const groupedWriteInSummaries = await tabulateCastVoteRecords({
       electionId,
       store,
       filter,
@@ -278,10 +278,12 @@ test('tabulateElectionResults - write-in handling', async () => {
   /*   Without WIA Data    
   /*  ******************* */
 
-  const overallResultsNoWiaData = tabulateElectionResults({
-    electionId,
-    store,
-  })[GROUP_KEY_ROOT];
+  const overallResultsNoWiaData = (
+    await tabulateElectionResults({
+      electionId,
+      store,
+    })
+  )[GROUP_KEY_ROOT];
   assert(overallResultsNoWiaData);
 
   const partialExpectedResultsNoWiaData = buildElectionResultsFixture({
@@ -371,17 +373,21 @@ test('tabulateElectionResults - write-in handling', async () => {
 
   // if we don't specify we need the WIA data, results are the same
   expect(
-    tabulateElectionResults({
-      electionId,
-      store,
-    })[GROUP_KEY_ROOT]
+    (
+      await tabulateElectionResults({
+        electionId,
+        store,
+      })
+    )[GROUP_KEY_ROOT]
   ).toEqual(overallResultsNoWiaData);
 
-  const overallResultsScreenWiaData = tabulateElectionResults({
-    electionId,
-    store,
-    includeWriteInAdjudicationResults: true,
-  })[GROUP_KEY_ROOT];
+  const overallResultsScreenWiaData = (
+    await tabulateElectionResults({
+      electionId,
+      store,
+      includeWriteInAdjudicationResults: true,
+    })
+  )[GROUP_KEY_ROOT];
   assert(overallResultsScreenWiaData);
 
   const partialExpectedResultsScreenWiaData = buildElectionResultsFixture({
@@ -470,12 +476,14 @@ test('tabulateElectionResults - write-in handling', async () => {
     }),
   });
 
-  const overallResultsScreenAndManualWiaData = tabulateElectionResults({
-    electionId,
-    store,
-    includeWriteInAdjudicationResults: true,
-    includeManualResults: true,
-  })[GROUP_KEY_ROOT];
+  const overallResultsScreenAndManualWiaData = (
+    await tabulateElectionResults({
+      electionId,
+      store,
+      includeWriteInAdjudicationResults: true,
+      includeManualResults: true,
+    })
+  )[GROUP_KEY_ROOT];
   assert(overallResultsScreenAndManualWiaData);
 
   const partialExpectedResultsScreenAndManualWiaData =
@@ -537,11 +545,13 @@ test('tabulateElectionResults - write-in handling', async () => {
   /*   With Screen + Manual WIA Data, Without Detail    
   /*  *********************************************** */
 
-  const overallResultsScreenAndManualNoWiaDetail = tabulateElectionResults({
-    electionId,
-    store,
-    includeManualResults: true,
-  })[GROUP_KEY_ROOT];
+  const overallResultsScreenAndManualNoWiaDetail = (
+    await tabulateElectionResults({
+      electionId,
+      store,
+      includeManualResults: true,
+    })
+  )[GROUP_KEY_ROOT];
   assert(overallResultsScreenAndManualNoWiaDetail);
 
   const partialExpectedResultsScreenAndManualNoWiaDetail =
@@ -617,12 +627,14 @@ test('tabulateElectionResults - group and filter by voting method', async () => 
   }
 
   // check absentee results, should have received half of the adjudicated as invalid write-ins
-  const absenteeResults = tabulateElectionResults({
-    electionId,
-    store,
-    filter: { votingMethods: ['absentee'] },
-    includeWriteInAdjudicationResults: true,
-  })[GROUP_KEY_ROOT];
+  const absenteeResults = (
+    await tabulateElectionResults({
+      electionId,
+      store,
+      filter: { votingMethods: ['absentee'] },
+      includeWriteInAdjudicationResults: true,
+    })
+  )[GROUP_KEY_ROOT];
   assert(absenteeResults);
 
   const partialExpectedResults = buildElectionResultsFixture({
@@ -658,12 +670,14 @@ test('tabulateElectionResults - group and filter by voting method', async () => 
   );
 
   // precinct results should match
-  const precinctResults = tabulateElectionResults({
-    electionId,
-    store,
-    filter: { votingMethods: ['precinct'] },
-    includeWriteInAdjudicationResults: true,
-  })[GROUP_KEY_ROOT];
+  const precinctResults = (
+    await tabulateElectionResults({
+      electionId,
+      store,
+      filter: { votingMethods: ['precinct'] },
+      includeWriteInAdjudicationResults: true,
+    })
+  )[GROUP_KEY_ROOT];
   assert(precinctResults);
 
   expect(precinctResults.cardCounts).toEqual(partialExpectedResults.cardCounts);
@@ -672,7 +686,7 @@ test('tabulateElectionResults - group and filter by voting method', async () => 
   );
 
   // results grouped by voting method should match, with group specifiers
-  const groupedResults = tabulateElectionResults({
+  const groupedResults = await tabulateElectionResults({
     electionId,
     store,
     groupBy: { groupByVotingMethod: true },
@@ -720,13 +734,15 @@ test('tabulateElectionResults - group and filter by voting method', async () => 
   });
 
   // check absentee results again, should now have manual results added
-  const absenteeResultsWithManual = tabulateElectionResults({
-    electionId,
-    store,
-    filter: { votingMethods: ['absentee'] },
-    includeWriteInAdjudicationResults: true,
-    includeManualResults: true,
-  })[GROUP_KEY_ROOT];
+  const absenteeResultsWithManual = (
+    await tabulateElectionResults({
+      electionId,
+      store,
+      filter: { votingMethods: ['absentee'] },
+      includeWriteInAdjudicationResults: true,
+      includeManualResults: true,
+    })
+  )[GROUP_KEY_ROOT];
   assert(absenteeResultsWithManual);
 
   const partialExpectedResultsWithManual = buildElectionResultsFixture({
@@ -765,13 +781,15 @@ test('tabulateElectionResults - group and filter by voting method', async () => 
   );
 
   // check precinct results again, should be the same
-  const precinctResultsWithManual = tabulateElectionResults({
-    electionId,
-    store,
-    filter: { votingMethods: ['precinct'] },
-    includeWriteInAdjudicationResults: true,
-    includeManualResults: true,
-  })[GROUP_KEY_ROOT];
+  const precinctResultsWithManual = (
+    await tabulateElectionResults({
+      electionId,
+      store,
+      filter: { votingMethods: ['precinct'] },
+      includeWriteInAdjudicationResults: true,
+      includeManualResults: true,
+    })
+  )[GROUP_KEY_ROOT];
   assert(precinctResultsWithManual);
 
   expect(precinctResultsWithManual.cardCounts).toEqual({

--- a/apps/admin/backend/src/tabulation/full_results.ts
+++ b/apps/admin/backend/src/tabulation/full_results.ts
@@ -29,7 +29,7 @@ export function tabulateCastVoteRecords({
   store: Store;
   filter?: Tabulation.Filter;
   groupBy?: Tabulation.GroupBy;
-}): Tabulation.ElectionResultsGroupMap {
+}): Promise<Tabulation.ElectionResultsGroupMap> {
   const {
     electionDefinition: { election },
   } = assertDefined(store.getElection(electionId));
@@ -38,13 +38,14 @@ export function tabulateCastVoteRecords({
     cvrs: store.getCastVoteRecords({ electionId, election, filter }),
     election,
     groupBy,
+    yieldToEventLoopEvery: 1000,
   });
 }
 
 /**
  * Tabulate election results including all scanned and adjudicated information.
  */
-export function tabulateElectionResults({
+export async function tabulateElectionResults({
   electionId,
   store,
   filter = {},
@@ -58,13 +59,13 @@ export function tabulateElectionResults({
   groupBy?: Tabulation.GroupBy;
   includeWriteInAdjudicationResults?: boolean;
   includeManualResults?: boolean;
-}): Tabulation.ElectionResultsGroupMap {
+}): Promise<Tabulation.ElectionResultsGroupMap> {
   const {
     electionDefinition: { election },
   } = assertDefined(store.getElection(electionId));
 
   // basic cast vote record tally with bucketed write-in counts
-  let groupedElectionResults = tabulateCastVoteRecords({
+  let groupedElectionResults = await tabulateCastVoteRecords({
     electionId,
     store,
     filter,
@@ -144,7 +145,7 @@ export function tabulateElectionResults({
  * adjusted with write-in adjudication data (but combining all unofficial write-ins)
  * and manual results separately.
  */
-export function tabulateTallyReportResults({
+export async function tabulateTallyReportResults({
   electionId,
   store,
   filter = {},
@@ -154,13 +155,13 @@ export function tabulateTallyReportResults({
   store: Store;
   filter?: Tabulation.Filter;
   groupBy?: Tabulation.GroupBy;
-}): Tabulation.GroupMap<TallyReportResults> {
+}): Promise<Tabulation.GroupMap<TallyReportResults>> {
   const {
     electionDefinition: { election },
   } = assertDefined(store.getElection(electionId));
 
   const groupedScannedResults = mapObject(
-    tabulateElectionResults({
+    await tabulateElectionResults({
       electionId,
       store,
       filter,

--- a/apps/admin/backend/src/tabulation/full_results.ts
+++ b/apps/admin/backend/src/tabulation/full_results.ts
@@ -38,7 +38,6 @@ export function tabulateCastVoteRecords({
     cvrs: store.getCastVoteRecords({ electionId, election, filter }),
     election,
     groupBy,
-    yieldToEventLoopEvery: 1000,
   });
 }
 

--- a/apps/admin/frontend/src/app.test.tsx
+++ b/apps/admin/frontend/src/app.test.tsx
@@ -310,6 +310,9 @@ test('L&A (logic and accuracy) flow', async () => {
 
   // Test printing full test deck tally
   userEvent.click(screen.getByText('L&A'));
+  await waitFor(() => {
+    expect(screen.getByText('Print Full Test Deck Tally Report')).toBeEnabled();
+  });
   userEvent.click(screen.getByText('Print Full Test Deck Tally Report'));
 
   await screen.findByText('Printing');

--- a/apps/admin/frontend/src/components/full_test_deck_tally_report_button.test.tsx
+++ b/apps/admin/frontend/src/components/full_test_deck_tally_report_button.test.tsx
@@ -10,7 +10,7 @@ import {
   fakeUsbDrive,
 } from '@votingworks/test-utils';
 import { mockUsbDrive } from '@votingworks/ui';
-import { screen, within } from '../../test/react_testing_library';
+import { screen, waitFor, within } from '../../test/react_testing_library';
 import { renderInAppContext } from '../../test/render_in_app_context';
 import { FullTestDeckTallyReportButton } from './full_test_deck_tally_report_button';
 
@@ -79,6 +79,11 @@ test('renders SaveFileToUsb component for saving PDF', async () => {
     electionDefinition: electionFamousNames2021Fixtures.electionDefinition,
     usbDrive,
   });
+  await waitFor(() => {
+    expect(
+      screen.getByText('Save Full Test Deck Tally Report as PDF')
+    ).toBeEnabled();
+  });
   userEvent.click(screen.getByText('Save Full Test Deck Tally Report as PDF'));
   const modal = await screen.findByRole('alertdialog');
   within(modal).getByText('Save Test Deck Tally Report');
@@ -89,6 +94,11 @@ test('closes SaveFileToUsb modal', async () => {
   renderInAppContext(<FullTestDeckTallyReportButton />, {
     electionDefinition: electionFamousNames2021Fixtures.electionDefinition,
     usbDrive,
+  });
+  await waitFor(() => {
+    expect(
+      screen.getByText('Save Full Test Deck Tally Report as PDF')
+    ).toBeEnabled();
   });
   userEvent.click(screen.getByText('Save Full Test Deck Tally Report as PDF'));
   const modal = await screen.findByRole('alertdialog');

--- a/apps/admin/frontend/src/components/full_test_deck_tally_report_button.tsx
+++ b/apps/admin/frontend/src/components/full_test_deck_tally_report_button.tsx
@@ -1,12 +1,23 @@
-import React, { useContext, useCallback, useState, useMemo } from 'react';
-import { assert } from '@votingworks/basics';
+import React, {
+  useContext,
+  useCallback,
+  useState,
+  useMemo,
+  useEffect,
+} from 'react';
+import { assert, assertDefined } from '@votingworks/basics';
 import { LogEventId } from '@votingworks/logging';
 
 import { Button, printElement, printElementToPdf } from '@votingworks/ui';
 import { isElectionManagerAuth } from '@votingworks/utils';
+import { Tabulation } from '@votingworks/types';
+import type { TallyReportResults } from '@votingworks/admin-backend';
 import { AppContext } from '../contexts/app_context';
 import { TestDeckTallyReport } from './test_deck_tally_report';
-import { generateTestDeckBallots } from '../utils/election';
+import {
+  generateResultsFromTestDeckBallots,
+  generateTestDeckBallots,
+} from '../utils/election';
 import { generateDefaultReportFilename } from '../utils/save_as_pdf';
 import { SaveFrontendFileModal, FileType } from './save_frontend_file_modal';
 import { PrintButton } from './print_button';
@@ -14,38 +25,52 @@ import { PrintButton } from './print_button';
 export function FullTestDeckTallyReportButton(): JSX.Element {
   const { auth, electionDefinition, logger } = useContext(AppContext);
   const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
+  const [fullTestDeckTallyReportResults, setFullTestDeckTallyReportResults] =
+    useState<Tabulation.GroupList<TallyReportResults>>();
   assert(isElectionManagerAuth(auth));
   const userRole = auth.user.role;
 
   assert(electionDefinition);
   const { election } = electionDefinition;
 
-  const hmpbBallots = generateTestDeckBallots({
-    election,
-    markingMethod: 'hand',
-  });
-  const bmdBallots = generateTestDeckBallots({
-    election,
-    markingMethod: 'machine',
-  });
+  useEffect(() => {
+    void (async () => {
+      const hmpbBallots = generateTestDeckBallots({
+        election,
+        markingMethod: 'hand',
+      });
+      const bmdBallots = generateTestDeckBallots({
+        election,
+        markingMethod: 'machine',
+      });
+      const tallyReportResults = await generateResultsFromTestDeckBallots({
+        election,
+        testDeckBallots: [
+          ...hmpbBallots,
+          ...hmpbBallots,
+          ...bmdBallots,
+          ...bmdBallots,
+        ],
+      });
+      setFullTestDeckTallyReportResults(tallyReportResults);
+    })();
+  }, [election]);
+
   // Full test deck tallies should be 4 times that of a single test deck because
   // it counts scanning 2 test decks (BMD + HMPB) twice (VxScan + VxCentralScan)
-  const fullTestDeckTallyReport = useMemo(
-    () => (
+  const fullTestDeckTallyReport = useMemo(() => {
+    if (!fullTestDeckTallyReportResults) return undefined;
+
+    return (
       <TestDeckTallyReport
         election={election}
-        testDeckBallots={[
-          ...hmpbBallots,
-          ...hmpbBallots,
-          ...bmdBallots,
-          ...bmdBallots,
-        ]}
+        tallyReportResults={fullTestDeckTallyReportResults}
       />
-    ),
-    [election, hmpbBallots, bmdBallots]
-  );
+    );
+  }, [election, fullTestDeckTallyReportResults]);
 
   const printFullTestDeckTallyReport = useCallback(async () => {
+    assert(fullTestDeckTallyReport);
     try {
       await printElement(fullTestDeckTallyReport, { sides: 'one-sided' });
       await logger.log(LogEventId.TestDeckTallyReportPrinted, userRole, {
@@ -77,18 +102,26 @@ export function FullTestDeckTallyReportButton(): JSX.Element {
 
   return (
     <React.Fragment>
-      <PrintButton print={printFullTestDeckTallyReport}>
+      <PrintButton
+        print={printFullTestDeckTallyReport}
+        disabled={!fullTestDeckTallyReport}
+      >
         Print Full Test Deck Tally Report
       </PrintButton>{' '}
       {window.kiosk && (
-        <Button onPress={onClickSaveFullTestDeckTallyReportToPdf}>
+        <Button
+          onPress={onClickSaveFullTestDeckTallyReportToPdf}
+          disabled={!fullTestDeckTallyReport}
+        >
           Save Full Test Deck Tally Report as PDF
         </Button>
       )}
       {isSaveModalOpen && (
         <SaveFrontendFileModal
           onClose={() => setIsSaveModalOpen(false)}
-          generateFileContent={() => printElementToPdf(fullTestDeckTallyReport)}
+          generateFileContent={() =>
+            printElementToPdf(assertDefined(fullTestDeckTallyReport))
+          }
           defaultFilename={defaultReportFilename}
           fileType={FileType.TestDeckTallyReport}
         />

--- a/apps/admin/frontend/src/components/test_deck_tally_report.tsx
+++ b/apps/admin/frontend/src/components/test_deck_tally_report.tsx
@@ -1,78 +1,20 @@
-import {
-  CandidateVote,
-  Election,
-  Tabulation,
-  YesNoVote,
-  electionHasPrimaryContest,
-} from '@votingworks/types';
-import {
-  getRelevantContests,
-  groupMapToGroupList,
-  tabulateCastVoteRecords,
-} from '@votingworks/utils';
-import { find, mapObject } from '@votingworks/basics';
-import { TestDeckBallot } from '../utils/election';
+import { Election, Tabulation } from '@votingworks/types';
+import { getRelevantContests } from '@votingworks/utils';
+import { find } from '@votingworks/basics';
+import type { TallyReportResults } from '@votingworks/admin-backend';
 import { AdminTallyReportByParty } from './admin_tally_report_by_party';
 
 export interface TestDeckTallyReportProps {
   election: Election;
-  testDeckBallots: TestDeckBallot[];
+  tallyReportResults: Tabulation.GroupList<TallyReportResults>;
   precinctId?: string;
-}
-
-function testDeckBallotToCastVoteRecord(
-  testDeckBallot: TestDeckBallot
-): Tabulation.CastVoteRecord {
-  const votes: Tabulation.CastVoteRecord['votes'] = {};
-
-  for (const [contestId, vote] of Object.entries(testDeckBallot.votes)) {
-    if (vote) {
-      if (typeof vote[0] === 'string') {
-        // yes no vote
-        const yesNoVote = vote as YesNoVote;
-        votes[contestId] = [...yesNoVote];
-      } else {
-        // candidate vote
-        const candidates = vote as CandidateVote;
-        votes[contestId] = candidates.map((c) => c.id);
-      }
-    }
-  }
-
-  return {
-    votes,
-    precinctId: testDeckBallot.precinctId,
-    ballotStyleId: testDeckBallot.ballotStyleId,
-    votingMethod: 'precinct',
-    scannerId: 'test-deck',
-    batchId: 'test-deck',
-    card:
-      testDeckBallot.markingMethod === 'machine'
-        ? { type: 'bmd' }
-        : { type: 'hmpb', sheetNumber: 1 },
-  };
 }
 
 export function TestDeckTallyReport({
   election,
-  testDeckBallots,
+  tallyReportResults,
   precinctId,
 }: TestDeckTallyReportProps): JSX.Element {
-  const tallyReportResults = groupMapToGroupList(
-    mapObject(
-      tabulateCastVoteRecords({
-        election,
-        cvrs: testDeckBallots.map((testDeckBallot) =>
-          testDeckBallotToCastVoteRecord(testDeckBallot)
-        ),
-        groupBy: electionHasPrimaryContest(election)
-          ? { groupByParty: true }
-          : undefined,
-      }),
-      (scannedResults) => ({ scannedResults })
-    )
-  );
-
   return (
     <AdminTallyReportByParty
       election={election}

--- a/libs/utils/src/tabulation.test.ts
+++ b/libs/utils/src/tabulation.test.ts
@@ -632,9 +632,9 @@ describe('tabulateCastVoteRecords', () => {
     electionMinimalExhaustiveSampleFixtures.castVoteRecordReport.asDirectoryPath()
   );
 
-  test('without grouping', () => {
+  test('without grouping', async () => {
     // empty election
-    const emptyResults = tabulateCastVoteRecords({ cvrs: [], election });
+    const emptyResults = await tabulateCastVoteRecords({ cvrs: [], election });
     expect(Object.values(emptyResults)).toHaveLength(1);
     expect(emptyResults[GROUP_KEY_ROOT]).toEqual(
       getEmptyElectionResults(election)
@@ -648,55 +648,57 @@ describe('tabulateCastVoteRecords', () => {
       scannerId: 'scanner-1',
     } as const;
 
-    const electionResult = tabulateCastVoteRecords({
-      cvrs: [
-        {
-          card: { type: 'bmd' },
-          votes: {
-            'best-animal-mammal': ['fox'],
-            'zoo-council-mammal': ['elephant', 'lion', 'write-in-0'],
-            'new-zoo-either': ['yes'],
-            'new-zoo-pick': ['no'],
-            fishing: ['yes'],
+    const electionResult = (
+      await tabulateCastVoteRecords({
+        cvrs: [
+          {
+            card: { type: 'bmd' },
+            votes: {
+              'best-animal-mammal': ['fox'],
+              'zoo-council-mammal': ['elephant', 'lion', 'write-in-0'],
+              'new-zoo-either': ['yes'],
+              'new-zoo-pick': ['no'],
+              fishing: ['yes'],
+            },
+            ...someMetadata,
           },
-          ...someMetadata,
-        },
-        {
-          card: { type: 'hmpb', sheetNumber: 1 },
-          votes: {
-            'best-animal-mammal': ['fox', 'horse'],
-            'zoo-council-mammal': ['elephant', 'lion', 'zebra', 'kangaroo'],
-            'new-zoo-either': ['yes', 'no'],
-            'new-zoo-pick': ['yes', 'no'],
-            fishing: ['yes', 'no'],
+          {
+            card: { type: 'hmpb', sheetNumber: 1 },
+            votes: {
+              'best-animal-mammal': ['fox', 'horse'],
+              'zoo-council-mammal': ['elephant', 'lion', 'zebra', 'kangaroo'],
+              'new-zoo-either': ['yes', 'no'],
+              'new-zoo-pick': ['yes', 'no'],
+              fishing: ['yes', 'no'],
+            },
+            ...someMetadata,
           },
-          ...someMetadata,
-        },
-        {
-          card: { type: 'hmpb', sheetNumber: 1 },
-          votes: {
-            'best-animal-fish': ['seahorse'],
-            'aquarium-council-fish': ['manta-ray', 'pufferfish'],
-            'new-zoo-either': ['no'],
-            'new-zoo-pick': ['yes'],
-            fishing: ['yes'],
+          {
+            card: { type: 'hmpb', sheetNumber: 1 },
+            votes: {
+              'best-animal-fish': ['seahorse'],
+              'aquarium-council-fish': ['manta-ray', 'pufferfish'],
+              'new-zoo-either': ['no'],
+              'new-zoo-pick': ['yes'],
+              fishing: ['yes'],
+            },
+            ...someMetadata,
           },
-          ...someMetadata,
-        },
-        {
-          card: { type: 'bmd' },
-          votes: {
-            'best-animal-fish': [],
-            'aquarium-council-fish': ['manta-ray'],
-            'new-zoo-either': [],
-            'new-zoo-pick': [],
-            fishing: [],
+          {
+            card: { type: 'bmd' },
+            votes: {
+              'best-animal-fish': [],
+              'aquarium-council-fish': ['manta-ray'],
+              'new-zoo-either': [],
+              'new-zoo-pick': [],
+              fishing: [],
+            },
+            ...someMetadata,
           },
-          ...someMetadata,
-        },
-      ],
-      election,
-    })[GROUP_KEY_ROOT];
+        ],
+        election,
+      })
+    )[GROUP_KEY_ROOT];
 
     assert(electionResult);
     expect(electionResult).toEqual(
@@ -774,14 +776,8 @@ describe('tabulateCastVoteRecords', () => {
     );
   });
 
-  // use ungrouped results, verified in last test, to compare against for grouped results
-  const ungroupedResults = tabulateCastVoteRecords({ cvrs, election })[
-    GROUP_KEY_ROOT
-  ];
-  assert(ungroupedResults);
-
-  test('by ballot style or party', () => {
-    const resultsByBallotStyle = tabulateCastVoteRecords({
+  test('by ballot style or party', async () => {
+    const resultsByBallotStyle = await tabulateCastVoteRecords({
       cvrs,
       election,
       groupBy: {
@@ -799,7 +795,7 @@ describe('tabulateCastVoteRecords', () => {
       )
     ).toEqual([56, 56]);
 
-    const resultsByParty = tabulateCastVoteRecords({
+    const resultsByParty = await tabulateCastVoteRecords({
       cvrs,
       election,
       groupBy: {
@@ -827,9 +823,9 @@ describe('tabulateCastVoteRecords', () => {
     ).toEqual(resultsByParty['root&partyId=1']?.contestResults);
   });
 
-  test('by batch and scanner', () => {
+  test('by batch and scanner', async () => {
     // dataset only has one batch and one scanner, so the grouping is trivial
-    const resultsByBatchAndScanner = tabulateCastVoteRecords({
+    const resultsByBatchAndScanner = await tabulateCastVoteRecords({
       cvrs,
       election,
       groupBy: {
@@ -840,11 +836,15 @@ describe('tabulateCastVoteRecords', () => {
     expect(Object.values(resultsByBatchAndScanner)).toHaveLength(1);
     const results =
       resultsByBatchAndScanner['root&batchId=9822c71014&scannerId=VX-00-000']!;
-    expect(results).toMatchObject(ungroupedResults);
+
+    // use ungrouped results, verified in previous test, to compare against for grouped results
+    expect(results).toMatchObject(
+      (await tabulateCastVoteRecords({ cvrs, election }))[GROUP_KEY_ROOT]!
+    );
   });
 
-  test('by voting method and precinct', () => {
-    const resultsByMethodAndPrecinct = tabulateCastVoteRecords({
+  test('by voting method and precinct', async () => {
+    const resultsByMethodAndPrecinct = await tabulateCastVoteRecords({
       cvrs,
       election,
       groupBy: {

--- a/libs/utils/src/tabulation.ts
+++ b/libs/utils/src/tabulation.ts
@@ -417,6 +417,8 @@ export async function yieldToEventLoop(): Promise<void> {
   });
 }
 
+const YIELD_TO_EVENT_LOOP_EVERY_N_CVRS = 1000;
+
 /**
  * Tabulates iterable cast vote records into election results, grouped by
  * the attributes specified {@link Tabulation.GroupBy} parameter.
@@ -425,12 +427,10 @@ export async function tabulateCastVoteRecords({
   election,
   cvrs,
   groupBy,
-  yieldToEventLoopEvery = 0,
 }: {
   cvrs: Iterable<Tabulation.CastVoteRecord>;
   election: Election;
   groupBy?: Tabulation.GroupBy;
-  yieldToEventLoopEvery?: number;
 }): Promise<Tabulation.ElectionResultsGroupMap> {
   const groupedElectionResults: Tabulation.ElectionResultsGroupMap = {};
 
@@ -443,7 +443,7 @@ export async function tabulateCastVoteRecords({
       addCastVoteRecordToElectionResult(electionResults, cvr);
 
       i += 1;
-      if (yieldToEventLoopEvery && i % yieldToEventLoopEvery === 0) {
+      if (i % YIELD_TO_EVENT_LOOP_EVERY_N_CVRS === 0) {
         await yieldToEventLoop();
       }
     }
@@ -472,7 +472,7 @@ export async function tabulateCastVoteRecords({
     }
 
     i += 1;
-    if (yieldToEventLoopEvery && i % yieldToEventLoopEvery === 0) {
+    if (i % YIELD_TO_EVENT_LOOP_EVERY_N_CVRS === 0) {
       await yieldToEventLoop();
     }
   }


### PR DESCRIPTION
## Overview

A performance issue in VxAdmin, which a few PRs will address, is long-running backend methods. It's completely reasonable, with the current scale of our customers, that things like tabulation take some seconds or even minutes. E.g. tallying a full election with 500,000 votes taking 7 seconds - we wish it were better, but all things considered, not bad.

What's _not_ OK is when these methods are synchronous, because it means that as long as they're running, all other backend methods will hang including statuses like `getAuthStatus`. I wonder if things like `getAuthStatus` should be running in another process... but that's a bigger change, out of scope, and not strictly necessary. For now, I'm simply identifying the bottlenecks and making synchronous methods `async`, or speeding them up where possible. 

In this case, I don't like how asynchronous tabulation forces frontend components to be altered, but I couldn't think of another way without duplicating code paths.

## Demo Video or Screenshot

hard refresh when backend method was sync, you'll see other queries are blocked:

https://github.com/votingworks/vxsuite/assets/37960853/d30d454e-b2f3-4f62-9ce2-b266b8ceed4c

hard refresh now that backend method is async. you'll see there's still a moment where queries freeze - that's write-in aggregation I believe, which I'll address in a separate PR

https://github.com/votingworks/vxsuite/assets/37960853/13bbb4a6-443e-4b7d-b1cf-b8fc47cb8d52

## Testing Plan
refactor, no testing changes
