### PR TITLE
refactor(backend): reference base type for intellisense

### DIFF
--- a/libs/backend/src/scan/cast_vote_records/build_cast_vote_record.ts
+++ b/libs/backend/src/scan/cast_vote_records/build_cast_vote_record.ts
@@ -500,7 +500,7 @@ export function buildCastVoteRecord({
     election,
   })?.partyId;
 
-  const cvrMetadata = {
+  const cvrMetadata: Omit<CVR.CVR, 'CVRSnapshot' | 'CurrentSnapshotId'> = {
     '@type': 'CVR.CVR',
     BallotStyleId: ballotMetadata.ballotStyleId,
     BallotStyleUnitId: ballotMetadata.precinctId, // VVSG 2.0 1.1.5-G.3
@@ -511,7 +511,7 @@ export function buildCastVoteRecord({
     BatchSequenceId: indexInBatch, // VVSG 2.0 1.1.5-G.7
     UniqueId: castVoteRecordId,
     vxBallotType: toCdfBallotType(ballotMetadata.ballotType),
-  } as const;
+  };
 
   // CVR for machine-marked ballot, only has "original" snapshot because the
   // restrictions of the ballot marking device already applied basic contest rules.


### PR DESCRIPTION
## Overview
Referencing the base type of `CVR.CVR` means we get hover tooltips for properties.

## Demo Video or Screenshot
<img width="614" alt="image" src="https://github.com/votingworks/vxsuite/assets/1938/67074968-94eb-4143-9488-4ddb54cc2ed0">

## Testing Plan
n/a

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
