### PR TITLE
[VxScan] Reset voter display settings after each session

### DIFF
--- a/apps/scan/backend/src/types.ts
+++ b/apps/scan/backend/src/types.ts
@@ -20,27 +20,30 @@ export interface PageInterpretationWithAdjudication<
   contestIds?: readonly string[];
 }
 
-export type PrecinctScannerState =
-  | 'connecting'
-  | 'disconnected'
-  | 'no_paper'
-  | 'ready_to_scan'
-  | 'scanning'
-  | 'returning_to_rescan'
-  | 'ready_to_accept'
-  | 'accepting'
-  | 'accepted'
-  | 'needs_review'
-  | 'accepting_after_review'
-  | 'returning'
-  | 'returned'
-  | 'rejecting'
-  | 'rejected'
-  | 'jammed'
-  | 'both_sides_have_paper'
-  | 'recovering_from_error'
-  | 'double_sheet_jammed'
-  | 'unrecoverable_error';
+export const PRECINCT_SCANNER_STATES = [
+  'connecting',
+  'disconnected',
+  'no_paper',
+  'ready_to_scan',
+  'scanning',
+  'returning_to_rescan',
+  'ready_to_accept',
+  'accepting',
+  'accepted',
+  'needs_review',
+  'accepting_after_review',
+  'returning',
+  'returned',
+  'rejecting',
+  'rejected',
+  'jammed',
+  'both_sides_have_paper',
+  'recovering_from_error',
+  'double_sheet_jammed',
+  'unrecoverable_error',
+] as const;
+
+export type PrecinctScannerState = typeof PRECINCT_SCANNER_STATES[number];
 
 export type InvalidInterpretationReason =
   | 'invalid_test_mode'

--- a/apps/scan/frontend/src/app.tsx
+++ b/apps/scan/frontend/src/app.tsx
@@ -23,6 +23,7 @@ import { ScanAppBase } from './scan_app_base';
 import { SessionTimeLimitTracker } from './components/session_time_limit_tracker';
 import { Paths } from './constants';
 import { DisplaySettingsScreen } from './screens/display_settings_screen';
+import { DisplaySettingsManager } from './components/display_settings_manager';
 
 export interface AppProps {
   hardware?: AppRootProps['hardware'];
@@ -62,6 +63,7 @@ export function App({
                 <AppRoot hardware={hardware} logger={logger} />
               </Route>
               <SessionTimeLimitTracker />
+              <DisplaySettingsManager />
             </QueryClientProvider>
           </ApiClientContext.Provider>
         </ErrorBoundary>

--- a/apps/scan/frontend/src/components/display_settings_manager.test.tsx
+++ b/apps/scan/frontend/src/components/display_settings_manager.test.tsx
@@ -1,0 +1,176 @@
+import { DefaultTheme, ThemeContext } from 'styled-components';
+import React from 'react';
+import {
+  ThemeManagerContext,
+  ThemeManagerContextInterface,
+} from '@votingworks/ui';
+import { electionSampleDefinition } from '@votingworks/fixtures';
+import { PRECINCT_SCANNER_STATES } from '@votingworks/scan-backend';
+import { advanceTimersAndPromises } from '@votingworks/test-utils';
+import { act, render, waitFor } from '../../test/react_testing_library';
+import { DisplaySettingsManager } from './display_settings_manager';
+import {
+  ApiMock,
+  createApiMock,
+  provideApi,
+  statusNoPaper,
+} from '../../test/helpers/mock_api_client';
+import { getScannerStatus } from '../api';
+import { scannerStatus } from '../../test/helpers/helpers';
+
+let apiMock: ApiMock;
+let currentTheme: DefaultTheme;
+let themeManager: ThemeManagerContextInterface;
+let scannerStatusQuery: ReturnType<typeof getScannerStatus.useQuery>;
+
+function TestThemeInspector(): null {
+  currentTheme = React.useContext(ThemeContext);
+  themeManager = React.useContext(ThemeManagerContext);
+
+  scannerStatusQuery = getScannerStatus.useQuery();
+
+  return null;
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  apiMock = createApiMock();
+  apiMock.removeCard();
+  apiMock.expectGetScannerStatus(statusNoPaper);
+
+  render(
+    provideApi(
+      apiMock,
+      <div>
+        <DisplaySettingsManager />
+        <TestThemeInspector />
+      </div>
+    ),
+    {
+      vxTheme: {
+        colorMode: 'contrastMedium',
+        sizeMode: 'm',
+      },
+    }
+  );
+
+  expect(currentTheme).toEqual(
+    expect.objectContaining<Partial<DefaultTheme>>({
+      colorMode: 'contrastMedium',
+      sizeMode: 'm',
+    })
+  );
+});
+
+afterEach(() => {
+  apiMock.mockApiClient.assertComplete();
+});
+
+test('Resets theme when election official logs in', async () => {
+  // Simulate changing display settings as voter:
+  act(() => {
+    themeManager.setColorMode('contrastLow');
+    themeManager.setSizeMode('xl');
+  });
+
+  expect(currentTheme).toEqual(
+    expect.objectContaining<Partial<DefaultTheme>>({
+      colorMode: 'contrastLow',
+      sizeMode: 'xl',
+    })
+  );
+
+  // Should reset display settings on Election Manager login:
+  act(() => apiMock.authenticateAsElectionManager(electionSampleDefinition));
+  await waitFor(() =>
+    expect(currentTheme).toEqual(
+      expect.objectContaining<Partial<DefaultTheme>>({
+        colorMode: 'contrastMedium',
+        sizeMode: 'm',
+      })
+    )
+  );
+
+  // Simulate changing display settings as Election Manager:
+  act(() => {
+    themeManager.setColorMode('contrastHighDark');
+    themeManager.setSizeMode('s');
+  });
+  await waitFor(() =>
+    expect(currentTheme).toEqual(
+      expect.objectContaining<Partial<DefaultTheme>>({
+        colorMode: 'contrastHighDark',
+        sizeMode: 's',
+      })
+    )
+  );
+
+  // Should return to voter settings on logout:
+  act(() => apiMock.removeCard());
+  await waitFor(() =>
+    expect(currentTheme).toEqual(
+      expect.objectContaining<Partial<DefaultTheme>>({
+        colorMode: 'contrastLow',
+        sizeMode: 'xl',
+      })
+    )
+  );
+});
+
+test('Resets theme after successful scan', async () => {
+  // Simulate changing display settings as voter:
+  act(() => {
+    themeManager.setColorMode('contrastHighDark');
+    themeManager.setSizeMode('xl');
+  });
+  expect(currentTheme).toEqual(
+    expect.objectContaining<Partial<DefaultTheme>>({
+      colorMode: 'contrastHighDark',
+      sizeMode: 'xl',
+    })
+  );
+
+  // Should be a no-op if scanner status change doesn't represent session end:
+  for (const oldState of PRECINCT_SCANNER_STATES) {
+    apiMock.expectGetScannerStatus(scannerStatus({ state: oldState }));
+    await scannerStatusQuery.refetch();
+    await advanceTimersAndPromises();
+
+    for (const newState of PRECINCT_SCANNER_STATES) {
+      if (oldState === 'accepted' && newState === 'no_paper') {
+        continue;
+      }
+
+      apiMock.expectGetScannerStatus(scannerStatus({ state: newState }));
+      await scannerStatusQuery.refetch();
+      await advanceTimersAndPromises();
+
+      await waitFor(() =>
+        expect(currentTheme).toEqual(
+          expect.objectContaining<Partial<DefaultTheme>>({
+            colorMode: 'contrastHighDark',
+            sizeMode: 'xl',
+          })
+        )
+      );
+    }
+  }
+
+  // Should reset theme after successful scan:
+  apiMock.expectGetScannerStatus(scannerStatus({ state: 'accepted' }));
+  await scannerStatusQuery.refetch();
+  await advanceTimersAndPromises();
+
+  apiMock.expectGetScannerStatus(scannerStatus({ state: 'no_paper' }));
+  await scannerStatusQuery.refetch();
+  await advanceTimersAndPromises();
+
+  await waitFor(() =>
+    expect(currentTheme).toEqual(
+      expect.objectContaining<Partial<DefaultTheme>>({
+        colorMode: 'contrastMedium',
+        sizeMode: 'm',
+      })
+    )
+  );
+});

--- a/apps/scan/frontend/src/components/display_settings_manager.tsx
+++ b/apps/scan/frontend/src/components/display_settings_manager.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { ThemeManagerContext, useQueryChangeListener } from '@votingworks/ui';
+import { DefaultTheme, ThemeContext } from 'styled-components';
+import { getAuthStatus, getScannerStatus } from '../api';
+
+/**
+ * Side-effect component for monitoring for auth and voter session changes and
+ * resetting/restoring voter display settings as needed.
+ */
+export function DisplaySettingsManager(): JSX.Element | null {
+  const themeManager = React.useContext(ThemeManagerContext);
+  const currentTheme = React.useContext(ThemeContext);
+
+  const authStatusQuery = getAuthStatus.useQuery();
+  const scannerStatusQuery = getScannerStatus.useQuery();
+
+  const [voterSessionTheme, setVoterSessionTheme] =
+    React.useState<DefaultTheme | null>(null);
+
+  useQueryChangeListener(authStatusQuery, (newStatus, previousStatus) => {
+    // Reset to default theme when election official logs in:
+    if (
+      previousStatus?.status === 'logged_out' &&
+      newStatus.status !== 'logged_out'
+    ) {
+      setVoterSessionTheme(currentTheme);
+      themeManager.resetThemes();
+    }
+
+    // Reset to previous voter settings when election official logs out:
+    if (
+      previousStatus?.status !== 'logged_out' &&
+      newStatus.status === 'logged_out' &&
+      voterSessionTheme
+    ) {
+      themeManager.setColorMode(voterSessionTheme.colorMode);
+      themeManager.setSizeMode(voterSessionTheme.sizeMode);
+      setVoterSessionTheme(null);
+    }
+  });
+
+  // [VVSG 2.0 7.1-A] Reset to default theme when voter is done scanning:
+  useQueryChangeListener(scannerStatusQuery, (newStatus, previousStatus) => {
+    if (
+      previousStatus?.state === 'accepted' &&
+      newStatus.state === 'no_paper'
+    ) {
+      themeManager.resetThemes();
+    }
+  });
+
+  return null;
+}


### PR DESCRIPTION
## Overview

From VVSG 2.0:
> 7.1-A – Reset to default settings
> If the adjustable settings of the voter interface have been changed by the voter or election worker during the voting session, the system must automatically reset to the default setting when the voter finishes voting, verifying, and casting.

- Adds a utility component that monitors the scanner status and resets the display settings to the default when we detect the end of a scanning session (currently, when we move from `'accepted'` to `'no_paper'`).
- Additionally, resetting to the default settings whenever an election official card is inserted, since non-voter-facing screens are optimised for the default display settings.
  - When the card is removed, we restore the display settings to the previous voter state before the card was inserted.

### Limitations:
- This currently doesn't cover the potential case where a voter is unable to complete the scanning process - will try to address that in a follow-up, but open to ideas on covering that edge case if you think of anything off the top.

## Demo Video or Screenshot

https://github.com/votingworks/vxsuite/assets/264902/a7290710-733c-45e2-b5fe-220a7f4ac9b3

## Testing Plan
- Added unit tests verifying the logic in the utility component and verifying that it's rendered at the app root.

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
