### PR TITLE
[CentralScan] Trim the Test Mode banner text to fit better

### DIFF
--- a/apps/central-scan/frontend/src/components/main_nav.tsx
+++ b/apps/central-scan/frontend/src/components/main_nav.tsx
@@ -77,7 +77,7 @@ export function MainNav({ children, isTestMode = false }: Props): JSX.Element {
           </MakeName>
           <ModelName>VxCentralScan</ModelName>
         </Brand>
-        {isTestMode && <TestMode>Machine is in Test Ballot Mode</TestMode>}
+        {isTestMode && <TestMode>Test Mode</TestMode>}
         <NavButtons>
           <SessionTimeLimitTimer authStatus={authStatusQuery.data} />
           {children}


### PR DESCRIPTION
## Overview

Flagged in the [#m17b-qa channel](https://votingworks.slack.com/archives/C05GPCQTV53/p1689194820043139) - the test mode banner title is wrapping due to limited space in the nav bar, so we're trimming the text down to fit.

## Demo Video or Screenshot
### Before/After:
<img width="400" src="https://github.com/votingworks/vxsuite/assets/264902/12dd9151-3b57-42da-9a7f-5987f1eed2de" /> <img width="400" src="https://github.com/votingworks/vxsuite/assets/264902/5134a3bb-4d63-473c-acb2-ee3860212977" />

## Testing Plan
Visual

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
