### PR TITLE
VxDesign: Ballot Measures

### DIFF
--- a/apps/design/shared/src/env.d.ts
+++ b/apps/design/shared/src/env.d.ts
@@ -4,3 +4,8 @@ declare namespace NodeJS {
     readonly CI?: string;
   }
 }
+
+// Both Node and browser support console.log
+declare module console {
+  export function log(message?: any, ...optionalParams: any[]): void;
+}

--- a/apps/design/shared/src/layout.test.ts
+++ b/apps/design/shared/src/layout.test.ts
@@ -1,150 +1,188 @@
-import { layoutInColumns } from './layout';
+import { layOutInColumns } from './layout';
 
 test('layoutInColumns', () => {
   const a1 = { id: 'a', height: 1 } as const;
   const b1 = { id: 'b', height: 1 } as const;
   const c2 = { id: 'c', height: 2 } as const;
+  const d2 = { id: 'd', height: 2 } as const;
 
   expect(
-    layoutInColumns({
+    layOutInColumns({
       elements: [],
       numColumns: 1,
       maxColumnHeight: 1,
     })
   ).toEqual({
     columns: [[]],
+    height: 0,
     leftoverElements: [],
   });
 
   expect(
-    layoutInColumns({
+    layOutInColumns({
       elements: [a1],
       numColumns: 1,
       maxColumnHeight: 1,
     })
   ).toEqual({
     columns: [[a1]],
+    height: 1,
     leftoverElements: [],
   });
 
   expect(
-    layoutInColumns({
+    layOutInColumns({
       elements: [a1],
       numColumns: 2,
       maxColumnHeight: 1,
     })
   ).toEqual({
     columns: [[a1], []],
+    height: 1,
     leftoverElements: [],
   });
 
   expect(
-    layoutInColumns({
+    layOutInColumns({
       elements: [a1, b1],
       numColumns: 1,
       maxColumnHeight: 1,
     })
   ).toEqual({
     columns: [[a1]],
+    height: 1,
     leftoverElements: [b1],
   });
 
   expect(
-    layoutInColumns({
+    layOutInColumns({
       elements: [a1, b1],
       numColumns: 2,
       maxColumnHeight: 1,
     })
   ).toEqual({
     columns: [[a1], [b1]],
+    height: 1,
     leftoverElements: [],
   });
 
   expect(
-    layoutInColumns({
+    layOutInColumns({
       elements: [a1, b1],
       numColumns: 1,
       maxColumnHeight: 2,
     })
   ).toEqual({
     columns: [[a1, b1]],
+    height: 2,
     leftoverElements: [],
   });
 
   expect(
-    layoutInColumns({
+    layOutInColumns({
       elements: [a1, b1],
       numColumns: 2,
       maxColumnHeight: 2,
     })
   ).toEqual({
     columns: [[a1], [b1]],
+    height: 1,
     leftoverElements: [],
   });
 
   expect(
-    layoutInColumns({
+    layOutInColumns({
+      elements: [a1, b1],
+      numColumns: 3,
+      maxColumnHeight: 1,
+    })
+  ).toEqual({
+    columns: [[a1], [b1], []],
+    height: 1,
+    leftoverElements: [],
+  });
+
+  expect(
+    layOutInColumns({
       elements: [a1, b1, c2],
       numColumns: 1,
       maxColumnHeight: 1,
     })
   ).toEqual({
     columns: [[a1]],
+    height: 1,
     leftoverElements: [b1, c2],
   });
 
   expect(
-    layoutInColumns({
+    layOutInColumns({
       elements: [a1, b1, c2],
       numColumns: 1,
       maxColumnHeight: 2,
     })
   ).toEqual({
     columns: [[a1, b1]],
+    height: 2,
     leftoverElements: [c2],
   });
 
   expect(
-    layoutInColumns({
+    layOutInColumns({
       elements: [a1, b1, c2],
       numColumns: 2,
       maxColumnHeight: 1,
     })
   ).toEqual({
     columns: [[a1], [b1]],
+    height: 1,
     leftoverElements: [c2],
   });
 
   expect(
-    layoutInColumns({
+    layOutInColumns({
       elements: [a1, b1, c2],
       numColumns: 2,
       maxColumnHeight: 2,
     })
   ).toEqual({
     columns: [[a1, b1], [c2]],
+    height: 2,
     leftoverElements: [],
   });
 
   expect(
-    layoutInColumns({
+    layOutInColumns({
       elements: [a1, b1, c2],
       numColumns: 3,
       maxColumnHeight: 1,
     })
   ).toEqual({
     columns: [[a1], [b1], []],
+    height: 1,
     leftoverElements: [c2],
   });
 
   expect(
-    layoutInColumns({
+    layOutInColumns({
       elements: [a1, b1, c2],
       numColumns: 3,
       maxColumnHeight: 2,
     })
   ).toEqual({
     columns: [[a1], [b1], [c2]],
+    height: 2,
+    leftoverElements: [],
+  });
+
+  expect(
+    layOutInColumns({
+      elements: [c2, a1, b1, d2],
+      maxColumnHeight: 2,
+      numColumns: 3,
+    })
+  ).toEqual({
+    columns: [[c2], [a1, b1], [d2]],
+    height: 2,
     leftoverElements: [],
   });
 });

--- a/apps/design/shared/src/layout.test.ts
+++ b/apps/design/shared/src/layout.test.ts
@@ -1,0 +1,150 @@
+import { layoutInColumns } from './layout';
+
+test('layoutInColumns', () => {
+  const a1 = { id: 'a', height: 1 } as const;
+  const b1 = { id: 'b', height: 1 } as const;
+  const c2 = { id: 'c', height: 2 } as const;
+
+  expect(
+    layoutInColumns({
+      elements: [],
+      numColumns: 1,
+      maxColumnHeight: 1,
+    })
+  ).toEqual({
+    columns: [[]],
+    leftoverElements: [],
+  });
+
+  expect(
+    layoutInColumns({
+      elements: [a1],
+      numColumns: 1,
+      maxColumnHeight: 1,
+    })
+  ).toEqual({
+    columns: [[a1]],
+    leftoverElements: [],
+  });
+
+  expect(
+    layoutInColumns({
+      elements: [a1],
+      numColumns: 2,
+      maxColumnHeight: 1,
+    })
+  ).toEqual({
+    columns: [[a1], []],
+    leftoverElements: [],
+  });
+
+  expect(
+    layoutInColumns({
+      elements: [a1, b1],
+      numColumns: 1,
+      maxColumnHeight: 1,
+    })
+  ).toEqual({
+    columns: [[a1]],
+    leftoverElements: [b1],
+  });
+
+  expect(
+    layoutInColumns({
+      elements: [a1, b1],
+      numColumns: 2,
+      maxColumnHeight: 1,
+    })
+  ).toEqual({
+    columns: [[a1], [b1]],
+    leftoverElements: [],
+  });
+
+  expect(
+    layoutInColumns({
+      elements: [a1, b1],
+      numColumns: 1,
+      maxColumnHeight: 2,
+    })
+  ).toEqual({
+    columns: [[a1, b1]],
+    leftoverElements: [],
+  });
+
+  expect(
+    layoutInColumns({
+      elements: [a1, b1],
+      numColumns: 2,
+      maxColumnHeight: 2,
+    })
+  ).toEqual({
+    columns: [[a1], [b1]],
+    leftoverElements: [],
+  });
+
+  expect(
+    layoutInColumns({
+      elements: [a1, b1, c2],
+      numColumns: 1,
+      maxColumnHeight: 1,
+    })
+  ).toEqual({
+    columns: [[a1]],
+    leftoverElements: [b1, c2],
+  });
+
+  expect(
+    layoutInColumns({
+      elements: [a1, b1, c2],
+      numColumns: 1,
+      maxColumnHeight: 2,
+    })
+  ).toEqual({
+    columns: [[a1, b1]],
+    leftoverElements: [c2],
+  });
+
+  expect(
+    layoutInColumns({
+      elements: [a1, b1, c2],
+      numColumns: 2,
+      maxColumnHeight: 1,
+    })
+  ).toEqual({
+    columns: [[a1], [b1]],
+    leftoverElements: [c2],
+  });
+
+  expect(
+    layoutInColumns({
+      elements: [a1, b1, c2],
+      numColumns: 2,
+      maxColumnHeight: 2,
+    })
+  ).toEqual({
+    columns: [[a1, b1], [c2]],
+    leftoverElements: [],
+  });
+
+  expect(
+    layoutInColumns({
+      elements: [a1, b1, c2],
+      numColumns: 3,
+      maxColumnHeight: 1,
+    })
+  ).toEqual({
+    columns: [[a1], [b1], []],
+    leftoverElements: [c2],
+  });
+
+  expect(
+    layoutInColumns({
+      elements: [a1, b1, c2],
+      numColumns: 3,
+      maxColumnHeight: 2,
+    })
+  ).toEqual({
+    columns: [[a1], [b1], [c2]],
+    leftoverElements: [],
+  });
+});

--- a/apps/design/shared/src/layout.ts
+++ b/apps/design/shared/src/layout.ts
@@ -1138,7 +1138,7 @@ function layOutBallotHelper(
   let contestSectionsLeftToLayOut = contestSections;
   const pages: Page[] = [];
   const gridPositions: GridPosition[] = [];
-  while (contestSectionsLeftToLayOut.length > 0) {
+  while (contestSectionsLeftToLayOut.length > 0 || pages.length % 2 !== 0) {
     const pageNumber = pages.length + 1;
     debug(
       `Laying out page ${pageNumber}, ${contestSectionsLeftToLayOut.length} contest sections left`


### PR DESCRIPTION
## Overview

Adds support for ballot measures to the ballot layout code. For now, ballot measures all go in one section at the end (until we add support for user-defined sections) and always span the entire width of the page.

The big change is to split contest lay out into two phases:
- Figuring out the height of each contest
- Laying out the contests into columns based on their heights


There are a few notable pieces to this PR:
- Rudimentary text wrapping (using a fixed conservative estimate for character width)
- A new algorithm for laying out abstract elements in columns based on their heights
- New simplified ContestColumn and ContestSection components that take the results of the column layout algorithm

## Demo Video or Screenshot
<img width="1025" alt="Screen Shot 2023-07-13 at 9 04 22 AM" src="https://github.com/votingworks/vxsuite/assets/530106/19fe7644-7ece-4589-a57d-f5dbf40760de">

## Testing Plan
- Visual inspection of ballots
- Automated tests for interpretation

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
