### PR TITLE
VxDesign: Bubble position option (left/right)

### DIFF
--- a/apps/design/backend/src/ballot_interpretation.test.ts
+++ b/apps/design/backend/src/ballot_interpretation.test.ts
@@ -24,6 +24,7 @@ import {
 import { singlePrecinctSelectionFor } from '@votingworks/utils';
 import { tmpNameSync } from 'tmp';
 import {
+  BallotTargetMarkPosition,
   Candidate,
   CandidateVote,
   Election,
@@ -298,89 +299,95 @@ describe('Laid out ballots - Famous Names', () => {
   });
 });
 
-describe('Laid out ballots - electionSample ', () => {
-  const election: Election = {
-    ...electionSample,
-    // Fill in missing mark thresholds
-    markThresholds: electionFamousNames2021Fixtures.election.markThresholds,
-  };
-  // Has ballot measures
-  const ballotStyle = assertDefined(
-    getBallotStyle({ election, ballotStyleId: '5' })
-  );
-  const precinct = assertDefined(
-    getPrecinctById({ election, precinctId: ballotStyle.precincts[0] })
-  );
-
-  test('Blank ballot interpretation', async () => {
-    const ballotResult = layOutBallot(election, precinct, ballotStyle);
-    assert(ballotResult.isOk());
-    const { document: ballot, gridLayout } = ballotResult.ok();
-    // We only support single-sheet ballots for now
-    ballot.pages = ballot.pages.slice(0, 2);
-
-    const [frontResult, backResult] = await interpretBallot({
-      election: { ...election, gridLayouts: [gridLayout] },
-      precinct,
-      ballot,
-    });
-
-    assert(frontResult.interpretation.type === 'InterpretedHmpbPage');
-    expect(frontResult.interpretation.votes).toEqual({});
-    assert(backResult.interpretation.type === 'InterpretedHmpbPage');
-    expect(backResult.interpretation.votes).toEqual({});
-  });
-
-  test('Marked ballot interpretation', async () => {
-    // Since we currently only support interpreting single-sheet ballots, we can
-    // only evaluate interpreting contests that we know will fit on two pages.
-    const contestsOnFirstSheet = assertDefined(
-      getContests({ election, ballotStyle })
-    ).filter((contest) =>
-      [
-        'president',
-        'representative-district-6',
-        'lieutenant-governor',
-        'state-senator-district-31',
-        'state-assembly-district-54',
-        'county-registrar-of-wills',
-        'judicial-robert-demergue',
-        'question-a',
-        'question-b',
-      ].includes(contest.id)
+for (const targetMarkPosition of Object.values(BallotTargetMarkPosition)) {
+  describe(`Laid out ballots - electionSample - bubbles on ${targetMarkPosition}`, () => {
+    const election: Election = {
+      ...electionSample,
+      ballotLayout: {
+        ...assertDefined(electionSample.ballotLayout),
+        targetMarkPosition,
+      },
+      // Fill in missing mark thresholds
+      markThresholds: electionFamousNames2021Fixtures.election.markThresholds,
+    };
+    // Has ballot measures
+    const ballotStyle = assertDefined(
+      getBallotStyle({ election, ballotStyleId: '5' })
     );
-    const votes: VotesDict = Object.fromEntries(
-      contestsOnFirstSheet.map((contest, i) => {
-        if (contest.type === 'candidate') {
-          const candidates = range(0, contest.seats).map(
-            (j) => contest.candidates[(i + j) % contest.candidates.length]
-          );
-          return [contest.id, candidates];
-        }
-        return [contest.id, i % 2 === 0 ? ['yes'] : ['no']];
-      })
+    const precinct = assertDefined(
+      getPrecinctById({ election, precinctId: ballotStyle.precincts[0] })
     );
 
-    const ballotResult = layOutBallot(election, precinct, ballotStyle);
-    assert(ballotResult.isOk());
-    const { document: ballot, gridLayout } = ballotResult.ok();
-    // We only support single-sheet ballots for now
-    ballot.pages = ballot.pages.slice(0, 2);
-    const markedBallot = markBallot(ballot, gridLayout, votes);
+    test(`Blank ballot interpretation`, async () => {
+      const ballotResult = layOutBallot(election, precinct, ballotStyle);
+      assert(ballotResult.isOk());
+      const { document: ballot, gridLayout } = ballotResult.ok();
+      // We only support single-sheet ballots for now
+      ballot.pages = ballot.pages.slice(0, 2);
 
-    const [frontResult, backResult] = await interpretBallot({
-      election: { ...election, gridLayouts: [gridLayout] },
-      precinct,
-      ballot: markedBallot,
+      const [frontResult, backResult] = await interpretBallot({
+        election: { ...election, gridLayouts: [gridLayout] },
+        precinct,
+        ballot,
+      });
+
+      assert(frontResult.interpretation.type === 'InterpretedHmpbPage');
+      expect(frontResult.interpretation.votes).toEqual({});
+      assert(backResult.interpretation.type === 'InterpretedHmpbPage');
+      expect(backResult.interpretation.votes).toEqual({});
     });
 
-    assert(frontResult.interpretation.type === 'InterpretedHmpbPage');
-    assert(backResult.interpretation.type === 'InterpretedHmpbPage');
-    expect(
-      sortVotesDict({
-        ...frontResult.interpretation.votes,
-        ...backResult.interpretation.votes,
-      })
-    ).toEqual(sortVotesDict(votes));
+    test(`Marked ballot interpretation`, async () => {
+      // Since we currently only support interpreting single-sheet ballots, we can
+      // only evaluate interpreting contests that we know will fit on two pages.
+      const contestsOnFirstSheet = assertDefined(
+        getContests({ election, ballotStyle })
+      ).filter((contest) =>
+        [
+          'president',
+          'representative-district-6',
+          'lieutenant-governor',
+          'state-senator-district-31',
+          'state-assembly-district-54',
+          'county-registrar-of-wills',
+          'judicial-robert-demergue',
+          'question-a',
+          'question-b',
+        ].includes(contest.id)
+      );
+      const votes: VotesDict = Object.fromEntries(
+        contestsOnFirstSheet.map((contest, i) => {
+          if (contest.type === 'candidate') {
+            const candidates = range(0, contest.seats).map(
+              (j) => contest.candidates[(i + j) % contest.candidates.length]
+            );
+            return [contest.id, candidates];
+          }
+          return [contest.id, i % 2 === 0 ? ['yes'] : ['no']];
+        })
+      );
+
+      const ballotResult = layOutBallot(election, precinct, ballotStyle);
+      assert(ballotResult.isOk());
+      const { document: ballot, gridLayout } = ballotResult.ok();
+      // We only support single-sheet ballots for now
+      ballot.pages = ballot.pages.slice(0, 2);
+      const markedBallot = markBallot(ballot, gridLayout, votes);
+
+      const [frontResult, backResult] = await interpretBallot({
+        election: { ...election, gridLayouts: [gridLayout] },
+        precinct,
+        ballot: markedBallot,
+      });
+
+      assert(frontResult.interpretation.type === 'InterpretedHmpbPage');
+      assert(backResult.interpretation.type === 'InterpretedHmpbPage');
+      expect(
+        sortVotesDict({
+          ...frontResult.interpretation.votes,
+          ...backResult.interpretation.votes,
+        })
+      ).toEqual(sortVotesDict(votes));
+    });
   });
-});
+}

--- a/apps/design/frontend/src/app.tsx
+++ b/apps/design/frontend/src/app.tsx
@@ -54,10 +54,13 @@ const StyleOverrides = styled.div`
     cursor: pointer;
   }
   h1 {
-    margin-bottom: 1rem;
+    margin-bottom: 1.2rem;
     &:not(:first-child) {
       margin-top: 1rem;
     }
+  }
+  h2 {
+    margin-bottom: 0.8rem;
   }
   a {
     color: ${({ theme }) => theme.colors.foreground};

--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -9,7 +9,6 @@ import {
   H1,
   LinkButton,
   P,
-  SegmentedButton,
 } from '@votingworks/ui';
 import {
   Redirect,
@@ -43,6 +42,7 @@ import { ElectionNavScreen } from './nav_screen';
 import { ElectionIdParams, electionParamRoutes, routes } from './routes';
 import { TabPanel, TabBar } from './tabs';
 import { getElection, updateElection } from './api';
+import { SegmentedControl } from './segmented_control';
 
 const FILTER_ALL = 'all';
 const FILTER_NONPARTISAN = 'nonpartisan';
@@ -287,9 +287,12 @@ function ContestForm({
         </Select>
       </FormField>
       <FormField label="Type">
-        <SegmentedButton
-          label=""
-          selectedOptionId={contest.type}
+        <SegmentedControl
+          options={[
+            { value: 'candidate', label: 'Candidate Contest' },
+            { value: 'yesno', label: 'Ballot Measure' },
+          ]}
+          value={contest.type}
           onChange={(type) =>
             setContest({
               ...(type === 'candidate'
@@ -299,10 +302,6 @@ function ContestForm({
               districtId: contest.districtId,
             })
           }
-          options={[
-            { id: 'candidate', label: 'Candidate Contest' },
-            { id: 'yesno', label: 'Ballot Measure' },
-          ]}
         />
       </FormField>
 
@@ -339,16 +338,15 @@ function ContestForm({
             />
           </FormField>
           <FormField label="Write-Ins Allowed?">
-            <SegmentedButton
-              label=""
-              selectedOptionId={contest.allowWriteIns ? 'yes' : 'no'}
+            <SegmentedControl
+              options={[
+                { value: 'yes', label: 'Yes' },
+                { value: 'no', label: 'No' },
+              ]}
+              value={contest.allowWriteIns ? 'yes' : 'no'}
               onChange={(value) =>
                 setContest({ ...contest, allowWriteIns: value === 'yes' })
               }
-              options={[
-                { id: 'yes', label: 'Yes' },
-                { id: 'no', label: 'No' },
-              ]}
             />
           </FormField>
           <FormField label="Candidates">

--- a/apps/design/frontend/src/layout.tsx
+++ b/apps/design/frontend/src/layout.tsx
@@ -46,7 +46,7 @@ export function FormField({
   return (
     <div style={{ marginBottom: '1.5rem' }}>
       <label
-        style={{ display: 'block', marginBottom: '0.2rem', fontWeight: 'bold' }}
+        style={{ display: 'block', marginBottom: '0.4rem', fontWeight: 'bold' }}
       >
         {label}
       </label>

--- a/apps/design/frontend/src/segmented_control.tsx
+++ b/apps/design/frontend/src/segmented_control.tsx
@@ -1,0 +1,54 @@
+import { Color } from '@votingworks/types';
+import { Button } from '@votingworks/ui';
+import styled from 'styled-components';
+
+interface Option<V extends string> {
+  value: V;
+  label: string;
+}
+
+const ControlContainer = styled.div`
+  display: inline-block;
+  border-radius: 0.25rem;
+  background: ${Color.LEGACY_BUTTON_BACKGROUND};
+`;
+
+const ControlOption = styled(Button)<{ isSelected: boolean }>`
+  background: ${(p) =>
+    p.isSelected
+      ? p.disabled
+        ? Color.LEGACY_FOREGROUND_DISABLED
+        : p.theme.colors.accentPrimary
+      : 'none'};
+  color: ${(p) => (p.isSelected ? 'white' : 'currentColor')};
+  &:disabled {
+    cursor: default;
+  }
+`;
+
+export function SegmentedControl<V extends string>({
+  options,
+  value,
+  onChange,
+  disabled,
+}: {
+  options: Array<Option<V>>;
+  value: V;
+  onChange: (value: V) => void;
+  disabled?: boolean;
+}): JSX.Element {
+  return (
+    <ControlContainer>
+      {options.map((option) => (
+        <ControlOption
+          key={option.value}
+          onPress={() => onChange(option.value)}
+          disabled={disabled}
+          isSelected={option.value === value}
+        >
+          {option.label}
+        </ControlOption>
+      ))}
+    </ControlContainer>
+  );
+}

--- a/apps/design/shared/src/document_svg.tsx
+++ b/apps/design/shared/src/document_svg.tsx
@@ -50,7 +50,10 @@ export function SvgTextBox({
         <text
           // eslint-disable-next-line react/no-array-index-key
           key={textLine + index}
-          x={align === 'right' ? width : 0}
+          // Adjust x coordinate if textAnchor is 'end' so that the overall
+          // content box location stays the same, since 'end' moves the text to
+          // the other side of the x coordinate.
+          x={align === 'left' ? 0 : width}
           y={(index + 1) * lineHeight}
           textAnchor={align === 'left' ? 'start' : 'end'}
           {...textProps}

--- a/apps/design/shared/src/document_svg.tsx
+++ b/apps/design/shared/src/document_svg.tsx
@@ -41,6 +41,7 @@ export function SvgTextBox({
   height,
   textLines,
   lineHeight,
+  align = 'left',
   ...textProps
 }: SvgTextBoxProps): JSX.Element {
   return (
@@ -49,8 +50,9 @@ export function SvgTextBox({
         <text
           // eslint-disable-next-line react/no-array-index-key
           key={textLine + index}
-          x={0}
+          x={align === 'right' ? width : 0}
           y={(index + 1) * lineHeight}
+          textAnchor={align === 'left' ? 'start' : 'end'}
           {...textProps}
         >
           {textLine}

--- a/apps/design/shared/src/document_types.ts
+++ b/apps/design/shared/src/document_types.ts
@@ -28,6 +28,7 @@ export interface TextBox extends ElementBase {
   fontSize: number;
   fontWeight: number;
   lineHeight: number;
+  align?: 'left' | 'right';
 }
 
 export interface Image extends ElementBase {

--- a/apps/design/shared/src/layout.ts
+++ b/apps/design/shared/src/layout.ts
@@ -532,8 +532,10 @@ function CandidateContest({
 
   const bubblePosition =
     election.ballotLayout?.targetMarkPosition ?? BallotTargetMarkPosition.Left;
-  // Temp hack until we can change the timing mark grid dimensions: expand the
-  // last contest column to fill the page
+
+  // Temp hack until we can change the timing mark grid dimensions since they
+  // don't evenly divide into three columns: expand the last contest column (if
+  // bubbles on left) or first contest column (if bubbles on right)
   const width = (
     bubblePosition === BallotTargetMarkPosition.Left
       ? gridColumn > 20
@@ -594,6 +596,13 @@ function CandidateContest({
   const optionPostions: GridPosition[] = [];
   const side = pageNumber % 2 === 1 ? 'front' : 'back';
 
+  const bubbleColumn =
+    bubblePosition === BallotTargetMarkPosition.Left ? 1 : width - 1;
+  const optionLabelColumn =
+    bubblePosition === BallotTargetMarkPosition.Left ? 1.75 : 0.5;
+  const optionTextAlign =
+    bubblePosition === BallotTargetMarkPosition.Left ? 'left' : 'right';
+
   const optionRowHeight = 2;
   const options: Rectangle[] = [];
   for (const [index, candidate] of contest.candidates.entries()) {
@@ -610,16 +619,14 @@ function CandidateContest({
       children: [
         Bubble({
           row: 1,
-          column:
-            bubblePosition === BallotTargetMarkPosition.Left ? 1 : width - 1,
+          column: bubbleColumn,
           isFilled: false,
         }),
         {
           type: 'TextBox',
           ...gridPosition({
             row: 0.6,
-            column:
-              bubblePosition === BallotTargetMarkPosition.Left ? 1.75 : 0.5,
+            column: optionLabelColumn,
           }),
           width: gridWidth(width - 2.25),
           height: gridHeight(1),
@@ -627,22 +634,19 @@ function CandidateContest({
           textLines: [candidate.name],
           ...FontStyles.BODY,
           fontWeight: FontWeights.BOLD,
-          align:
-            bubblePosition === BallotTargetMarkPosition.Left ? 'left' : 'right',
+          align: optionTextAlign,
         },
         {
           type: 'TextBox',
           ...gridPosition({
             row: 1.3,
-            column:
-              bubblePosition === BallotTargetMarkPosition.Left ? 1.75 : 0.5,
+            column: optionLabelColumn,
           }),
           width: gridWidth(width - 2.25),
           height: gridHeight(1),
           textLines: [getCandidatePartiesDescription(election, candidate)],
           ...FontStyles.BODY,
-          align:
-            bubblePosition === BallotTargetMarkPosition.Left ? 'left' : 'right',
+          align: optionTextAlign,
         },
       ],
     });
@@ -651,7 +655,7 @@ function CandidateContest({
       type: 'option',
       side,
       contestId: contest.id,
-      column: gridColumn,
+      column: gridColumn + bubbleColumn - 1,
       row: gridRow + optionRow,
       optionId: candidate.id,
     });
@@ -674,16 +678,14 @@ function CandidateContest({
         children: [
           Bubble({
             row: 1,
-            column:
-              bubblePosition === BallotTargetMarkPosition.Left ? 1 : width - 1,
+            column: bubbleColumn,
             isFilled: false,
           }),
           {
             type: 'Rectangle', // Line?
             ...gridPosition({
               row: 1.25,
-              column:
-                bubblePosition === BallotTargetMarkPosition.Left ? 1.75 : 0.5,
+              column: optionLabelColumn,
             }),
             width: gridWidth(width - 2.25),
             height: 1,
@@ -693,17 +695,13 @@ function CandidateContest({
             type: 'TextBox',
             ...gridPosition({
               row: 1.3,
-              column:
-                bubblePosition === BallotTargetMarkPosition.Left ? 1.75 : 0.5,
+              column: optionLabelColumn,
             }),
             width: gridWidth(width - 2.5),
             height: gridHeight(1),
             textLines: ['write-in'],
             ...FontStyles.SMALL,
-            align:
-              bubblePosition === BallotTargetMarkPosition.Left
-                ? 'left'
-                : 'right',
+            align: optionTextAlign,
           },
         ],
       });
@@ -712,7 +710,7 @@ function CandidateContest({
         type: 'write-in',
         side,
         contestId: contest.id,
-        column: gridColumn,
+        column: gridColumn + bubbleColumn - 1,
         row: gridRow + optionRow,
         writeInIndex,
       });
@@ -822,6 +820,13 @@ function BallotMeasure({
     { id: 'no', label: 'No' },
   ];
 
+  const bubbleColumn =
+    bubblePosition === BallotTargetMarkPosition.Left ? 1 : width - 1;
+  const optionLabelColumn =
+    bubblePosition === BallotTargetMarkPosition.Left ? 1.75 : 0.5;
+  const optionTextAlign =
+    bubblePosition === BallotTargetMarkPosition.Left ? 'left' : 'right';
+
   const optionRowHeight = 1;
   const options: Rectangle[] = [];
   for (const [index, choice] of choices.entries()) {
@@ -838,24 +843,21 @@ function BallotMeasure({
       children: [
         Bubble({
           row: 1,
-          column:
-            bubblePosition === BallotTargetMarkPosition.Left ? 1 : width - 1,
+          column: bubbleColumn,
           isFilled: false,
         }),
         {
           type: 'TextBox',
           ...gridPosition({
             row: 0.65,
-            column:
-              bubblePosition === BallotTargetMarkPosition.Left ? 1.75 : 0.5,
+            column: optionLabelColumn,
           }),
           width: gridWidth(width - 2.25),
           height: gridHeight(1),
           textLines: [choice.label],
           ...FontStyles.BODY,
           fontWeight: FontWeights.BOLD,
-          align:
-            bubblePosition === BallotTargetMarkPosition.Left ? 'left' : 'right',
+          align: optionTextAlign,
         },
       ],
     });
@@ -864,7 +866,7 @@ function BallotMeasure({
       type: 'option',
       side,
       contestId: contest.id,
-      column: gridColumn,
+      column: gridColumn + bubbleColumn - 1,
       row: gridRow + optionRow,
       optionId: choice.id,
     });
@@ -1102,7 +1104,7 @@ function ContestColumn({
   const column: Rectangle = {
     type: 'Rectangle',
     ...gridPosition({ row: gridRow, column: gridColumn }),
-    width: contestRectangles[0].width,
+    width: contestRectangles[0]?.width ?? 0,
     height: gridHeight(lastContestRow),
     children: contestRectangles,
   };


### PR DESCRIPTION
## Overview

Adds a new toggle in VxDesign to lay out bubbles on the left or the right. Updates the ballot layout code accordingly. Note that moving bubbles to the right also means right-aligning all of the text, which required some new SVG rendering functionality.

## Demo Video or Screenshot


<img width="1050" alt="Screen Shot 2023-07-13 at 10 46 05 AM" src="https://github.com/votingworks/vxsuite/assets/530106/1cbbf63b-ee28-49f1-90d5-f27cd4cff159">


https://github.com/votingworks/vxsuite/assets/530106/1e2e656e-b1b3-4d9e-9978-6e7326030abc



## Testing Plan
- Visual inspection of ballots
- Automated tests for interpretation

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
