### PR TITLE
[VxMarkOld] Use side nav layout for contest and review screens

### DIFF
--- a/apps/mark/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
@@ -243,9 +243,9 @@ exports[`Single Seat Contest 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   height: 100%;
 }
 
@@ -321,29 +321,10 @@ exports[`Single Seat Contest 1`] = `
 }
 
 .c23 {
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-  border-top: 0.25rem solid #222222;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0.5rem;
-  -webkit-box-pack: right;
-  -webkit-justify-content: right;
-  -ms-flex-pack: right;
-  justify-content: right;
-  min-height: 4.5rem;
-  padding: 0.5rem;
-}
-
-.c23 > *:not(:first-child):not(:last-child) {
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
 }
 
 .c25 {
@@ -387,8 +368,55 @@ exports[`Single Seat Contest 1`] = `
 }
 
 @media print {
+
+}
+
+@media print {
   .c1 {
     display: none;
+  }
+}
+
+@media (orientation:portrait) {
+  .c23 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+    border-top: 0.25rem solid #222222;
+    gap: 0.5rem;
+    -webkit-box-pack: right;
+    -webkit-justify-content: right;
+    -ms-flex-pack: right;
+    justify-content: right;
+    min-height: 4.5rem;
+    padding: 0.5rem;
+  }
+
+  .c23 > *:not(:first-child):not(:last-child) {
+    -webkit-box-flex: 1;
+    -webkit-flex-grow: 1;
+    -ms-flex-positive: 1;
+    flex-grow: 1;
+  }
+}
+
+@media (orientation:landscape) {
+  .c23 {
+    border-left: 0.25rem solid #222222;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    gap: 1rem;
+    -webkit-box-pack: center;
+    -webkit-justify-content: center;
+    -ms-flex-pack: center;
+    justify-content: center;
+    padding: 0.5rem;
+  }
+
+  .c23 > * {
+    min-height: 3rem;
   }
 }
 

--- a/apps/mark/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
@@ -369,9 +369,9 @@ exports[`Single Seat Contest 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   height: 100%;
 }
 
@@ -447,29 +447,10 @@ exports[`Single Seat Contest 1`] = `
 }
 
 .c27 {
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-  border-top: 0.25rem solid #222222;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0.5rem;
-  -webkit-box-pack: right;
-  -webkit-justify-content: right;
-  -ms-flex-pack: right;
-  justify-content: right;
-  min-height: 4.5rem;
-  padding: 0.5rem;
-}
-
-.c27 > *:not(:first-child):not(:last-child) {
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
 }
 
 .c29 {
@@ -517,6 +498,10 @@ exports[`Single Seat Contest 1`] = `
 }
 
 @media print {
+
+}
+
+@media print {
   .c1 {
     display: none;
   }
@@ -536,6 +521,49 @@ exports[`Single Seat Contest 1`] = `
 
 @media print {
 
+}
+
+@media (orientation:portrait) {
+  .c27 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+    border-top: 0.25rem solid #222222;
+    gap: 0.5rem;
+    -webkit-box-pack: right;
+    -webkit-justify-content: right;
+    -ms-flex-pack: right;
+    justify-content: right;
+    min-height: 4.5rem;
+    padding: 0.5rem;
+  }
+
+  .c27 > *:not(:first-child):not(:last-child) {
+    -webkit-box-flex: 1;
+    -webkit-flex-grow: 1;
+    -ms-flex-positive: 1;
+    flex-grow: 1;
+  }
+}
+
+@media (orientation:landscape) {
+  .c27 {
+    border-left: 0.25rem solid #222222;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    gap: 1rem;
+    -webkit-box-pack: center;
+    -webkit-justify-content: center;
+    -ms-flex-pack: center;
+    justify-content: center;
+    padding: 0.5rem;
+  }
+
+  .c27 > * {
+    min-height: 3rem;
+  }
 }
 
 @media (orientation:portrait) {

--- a/apps/mark/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
@@ -369,9 +369,9 @@ exports[`Single Seat Contest 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   height: 100%;
 }
 
@@ -447,29 +447,10 @@ exports[`Single Seat Contest 1`] = `
 }
 
 .c27 {
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-  border-top: 0.25rem solid #222222;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0.5rem;
-  -webkit-box-pack: right;
-  -webkit-justify-content: right;
-  -ms-flex-pack: right;
-  justify-content: right;
-  min-height: 4.5rem;
-  padding: 0.5rem;
-}
-
-.c27 > *:not(:first-child):not(:last-child) {
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
 }
 
 .c29 {
@@ -517,6 +498,10 @@ exports[`Single Seat Contest 1`] = `
 }
 
 @media print {
+
+}
+
+@media print {
   .c1 {
     display: none;
   }
@@ -536,6 +521,49 @@ exports[`Single Seat Contest 1`] = `
 
 @media print {
 
+}
+
+@media (orientation:portrait) {
+  .c27 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+    border-top: 0.25rem solid #222222;
+    gap: 0.5rem;
+    -webkit-box-pack: right;
+    -webkit-justify-content: right;
+    -ms-flex-pack: right;
+    justify-content: right;
+    min-height: 4.5rem;
+    padding: 0.5rem;
+  }
+
+  .c27 > *:not(:first-child):not(:last-child) {
+    -webkit-box-flex: 1;
+    -webkit-flex-grow: 1;
+    -ms-flex-positive: 1;
+    flex-grow: 1;
+  }
+}
+
+@media (orientation:landscape) {
+  .c27 {
+    border-left: 0.25rem solid #222222;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    gap: 1rem;
+    -webkit-box-pack: center;
+    -webkit-justify-content: center;
+    -ms-flex-pack: center;
+    justify-content: center;
+    padding: 0.5rem;
+  }
+
+  .c27 > * {
+    min-height: 3rem;
+  }
 }
 
 @media (orientation:portrait) {

--- a/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
@@ -251,9 +251,9 @@ exports[`Single Seat Contest with Write In 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   height: 100%;
 }
 
@@ -329,29 +329,10 @@ exports[`Single Seat Contest with Write In 1`] = `
 }
 
 .c24 {
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-  border-top: 0.25rem solid #222222;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0.5rem;
-  -webkit-box-pack: right;
-  -webkit-justify-content: right;
-  -ms-flex-pack: right;
-  justify-content: right;
-  min-height: 4.5rem;
-  padding: 0.5rem;
-}
-
-.c24 > *:not(:first-child):not(:last-child) {
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
 }
 
 .c26 {
@@ -399,6 +380,10 @@ exports[`Single Seat Contest with Write In 1`] = `
 }
 
 @media print {
+
+}
+
+@media print {
   .c1 {
     display: none;
   }
@@ -418,6 +403,49 @@ exports[`Single Seat Contest with Write In 1`] = `
 
 @media print {
 
+}
+
+@media (orientation:portrait) {
+  .c24 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+    border-top: 0.25rem solid #222222;
+    gap: 0.5rem;
+    -webkit-box-pack: right;
+    -webkit-justify-content: right;
+    -ms-flex-pack: right;
+    justify-content: right;
+    min-height: 4.5rem;
+    padding: 0.5rem;
+  }
+
+  .c24 > *:not(:first-child):not(:last-child) {
+    -webkit-box-flex: 1;
+    -webkit-flex-grow: 1;
+    -ms-flex-positive: 1;
+    flex-grow: 1;
+  }
+}
+
+@media (orientation:landscape) {
+  .c24 {
+    border-left: 0.25rem solid #222222;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    gap: 1rem;
+    -webkit-box-pack: center;
+    -webkit-justify-content: center;
+    -ms-flex-pack: center;
+    justify-content: center;
+    padding: 0.5rem;
+  }
+
+  .c24 > * {
+    min-height: 3rem;
+  }
 }
 
 @media (orientation:portrait) {

--- a/apps/mark/frontend/src/components/button_footer.tsx
+++ b/apps/mark/frontend/src/components/button_footer.tsx
@@ -1,11 +1,10 @@
-/* stylelint-disable order/properties-order */
-import styled from 'styled-components';
+/* stylelint-disable order/properties-order, value-keyword-case */
+import styled, { css } from 'styled-components';
 
-export const ButtonFooter = styled.nav`
+const portraitStyles = css`
   align-items: stretch;
   border-top: ${(p) => p.theme.sizes.bordersRem.thick}rem solid
     ${(p) => p.theme.colors.foreground};
-  display: flex;
   gap: 0.5rem;
   justify-content: right;
   min-height: 4.5rem;
@@ -15,5 +14,30 @@ export const ButtonFooter = styled.nav`
     &:not(:first-child):not(:last-child) {
       flex-grow: 1;
     }
+  }
+`;
+
+const landscapeStyles = css`
+  border-left: ${(p) => p.theme.sizes.bordersRem.thick}rem solid
+    ${(p) => p.theme.colors.foreground};
+  flex-direction: column;
+  gap: 1rem;
+  justify-content: center;
+  padding: 0.5rem;
+
+  & > * {
+    min-height: 3rem;
+  }
+`;
+
+export const ButtonFooter = styled.nav`
+  display: flex;
+
+  @media (orientation: portrait) {
+    ${portraitStyles}
+  }
+
+  @media (orientation: landscape) {
+    ${landscapeStyles}
   }
 `;

--- a/apps/mark/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
@@ -197,9 +197,9 @@ exports[`Renders ContestPage 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   height: 100%;
 }
 
@@ -275,29 +275,10 @@ exports[`Renders ContestPage 1`] = `
 }
 
 .c23 {
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-  border-top: 0.25rem solid #263238;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0.5rem;
-  -webkit-box-pack: right;
-  -webkit-justify-content: right;
-  -ms-flex-pack: right;
-  justify-content: right;
-  min-height: 4.5rem;
-  padding: 0.5rem;
-}
-
-.c23 > *:not(:first-child):not(:last-child) {
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
 }
 
 .c25 {
@@ -335,6 +316,49 @@ exports[`Renders ContestPage 1`] = `
 @media print {
   .c0 {
     display: none;
+  }
+}
+
+@media (orientation:portrait) {
+  .c23 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+    border-top: 0.25rem solid #263238;
+    gap: 0.5rem;
+    -webkit-box-pack: right;
+    -webkit-justify-content: right;
+    -ms-flex-pack: right;
+    justify-content: right;
+    min-height: 4.5rem;
+    padding: 0.5rem;
+  }
+
+  .c23 > *:not(:first-child):not(:last-child) {
+    -webkit-box-flex: 1;
+    -webkit-flex-grow: 1;
+    -ms-flex-positive: 1;
+    flex-grow: 1;
+  }
+}
+
+@media (orientation:landscape) {
+  .c23 {
+    border-left: 0.25rem solid #263238;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    gap: 1rem;
+    -webkit-box-pack: center;
+    -webkit-justify-content: center;
+    -ms-flex-pack: center;
+    justify-content: center;
+    padding: 0.5rem;
+  }
+
+  .c23 > * {
+    min-height: 3rem;
   }
 }
 
@@ -1013,9 +1037,9 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   height: 100%;
 }
 
@@ -1091,29 +1115,10 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
 }
 
 .c23 {
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-  border-top: 0.25rem solid #263238;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0.5rem;
-  -webkit-box-pack: right;
-  -webkit-justify-content: right;
-  -ms-flex-pack: right;
-  justify-content: right;
-  min-height: 4.5rem;
-  padding: 0.5rem;
-}
-
-.c23 > *:not(:first-child):not(:last-child) {
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
 }
 
 .c25 {
@@ -1139,6 +1144,49 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
 @media print {
   .c0 {
     display: none;
+  }
+}
+
+@media (orientation:portrait) {
+  .c23 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+    border-top: 0.25rem solid #263238;
+    gap: 0.5rem;
+    -webkit-box-pack: right;
+    -webkit-justify-content: right;
+    -ms-flex-pack: right;
+    justify-content: right;
+    min-height: 4.5rem;
+    padding: 0.5rem;
+  }
+
+  .c23 > *:not(:first-child):not(:last-child) {
+    -webkit-box-flex: 1;
+    -webkit-flex-grow: 1;
+    -ms-flex-positive: 1;
+    flex-grow: 1;
+  }
+}
+
+@media (orientation:landscape) {
+  .c23 {
+    border-left: 0.25rem solid #263238;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    gap: 1rem;
+    -webkit-box-pack: center;
+    -webkit-justify-content: center;
+    -ms-flex-pack: center;
+    justify-content: center;
+    padding: 0.5rem;
+  }
+
+  .c23 > * {
+    min-height: 3rem;
   }
 }
 

--- a/apps/mark/frontend/src/pages/contest_page.tsx
+++ b/apps/mark/frontend/src/pages/contest_page.tsx
@@ -97,7 +97,7 @@ export function ContestPage(): JSX.Element {
   const settingsButton = <DisplaySettingsButton />;
 
   return (
-    <Screen>
+    <Screen navRight>
       <MarkFlowContest
         breadcrumbs={{
           ballotContestCount: ballotContestsLength,

--- a/apps/mark/frontend/src/pages/review_page.tsx
+++ b/apps/mark/frontend/src/pages/review_page.tsx
@@ -44,7 +44,7 @@ export function ReviewPage(): JSX.Element {
   const settingsButton = <DisplaySettingsButton />;
 
   return (
-    <Screen>
+    <Screen navRight>
       <Main flexColumn>
         <ContentHeader>
           <Prose id="audiofocus">


### PR DESCRIPTION
## Overview

**Context:** We would like to be able to continue upgrading older 14" landscape VxMark machines, so we need to make sure the updated styling also fits that screen format.

Updating the `ContestPage` and `ReviewPage` to fit better (especially at larger text sizes) in landscape mode:
- Moving the button nav bar to the right side of the screen in landscape mode
- Switching from a horizontal to vertical layout for the nav buttons in landscape mode

Looks a little meh to me (very technical design verdict), so let me know if you have ideas for any tweaks/different approaches.

Initially considered a split column approach, which would allow us display a ton more candidates above the fold, but it would've created too much code complexity with handling all the edge cases and not sure it's worth the work for a legacy system, but I'm open to the time investment if folks feel strongly:
<img width="400" src="https://github.com/votingworks/vxsuite/assets/264902/036cb289-7e4a-46a6-a95a-a0ac60686ced" />

## Demo Video or Screenshot
https://github.com/votingworks/vxsuite/assets/264902/ea041df2-9e38-4a16-a572-d657cffc8f85

## Testing Plan
Visual

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
