### PR TITLE
VxDesign: Ballot paper size option

### DIFF
--- a/apps/admin/frontend/src/utils/get_ballot_layout_page_size.ts
+++ b/apps/admin/frontend/src/utils/get_ballot_layout_page_size.ts
@@ -14,7 +14,10 @@ export function getBallotLayoutPageSizeReadableString(
   > = {
     [BallotPaperSize.Letter]: 'letter',
     [BallotPaperSize.Legal]: 'legal',
-    [BallotPaperSize.Custom8Point5X17]: 'custom 8.5x17',
+    [BallotPaperSize.Custom17]: '8.5 x 17',
+    [BallotPaperSize.Custom18]: '8.5 x 18',
+    [BallotPaperSize.Custom21]: '8.5 x 21',
+    [BallotPaperSize.Custom22]: '8.5 x 22',
   };
   const readableString =
     ballotPaperSizeToReadableStringMapping[getBallotLayoutPageSize(election)];

--- a/apps/central-scan/backend/src/fujitsu_scanner.ts
+++ b/apps/central-scan/backend/src/fujitsu_scanner.ts
@@ -1,4 +1,4 @@
-import { assert, deferredQueue, throwIllegalValue } from '@votingworks/basics';
+import { assert, deferredQueue } from '@votingworks/basics';
 import makeDebug from 'debug';
 import { join } from 'path';
 import { dirSync } from 'tmp';
@@ -89,12 +89,12 @@ export class FujitsuScanner implements BatchScanner {
 
     if (pageSize === BallotPaperSize.Legal) {
       args.push('--page-width', '215.872', '--page-height', '355.6'); // values in millimeters
-    } else if (pageSize === BallotPaperSize.Custom8Point5X17) {
+    } else if (pageSize === BallotPaperSize.Custom17) {
       args.push('--page-width', '215.872', '--page-height', '431.8'); // values in millimeters
     } else if (pageSize === BallotPaperSize.Letter) {
       // this is the default, no changes needed.
     } else {
-      throwIllegalValue(pageSize);
+      throw new Error(`Unsupported page size: ${pageSize}`);
     }
 
     if (this.mode) {

--- a/apps/design/backend/src/all_bubble_ballots.ts
+++ b/apps/design/backend/src/all_bubble_ballots.ts
@@ -10,9 +10,7 @@ import {
 import {
   Bubble,
   Document,
-  DOCUMENT_HEIGHT,
-  DOCUMENT_WIDTH,
-  GRID,
+  measurements,
   range,
   TimingMarkGrid,
 } from '@votingworks/design-shared';
@@ -20,6 +18,9 @@ import {
 interface AllBubbleBallotOptions {
   fillBubble: (page: number, row: number, column: number) => boolean;
 }
+
+const m = measurements(BallotPaperSize.Letter);
+const { DOCUMENT_HEIGHT, DOCUMENT_WIDTH, GRID } = m;
 
 function createBallotCard({ fillBubble }: AllBubbleBallotOptions): Document {
   function bubbles(page: number) {
@@ -29,6 +30,7 @@ function createBallotCard({ fillBubble }: AllBubbleBallotOptions): Document {
           row,
           column,
           isFilled: fillBubble(page, row, column),
+          m,
         })
       )
     );
@@ -42,13 +44,13 @@ function createBallotCard({ fillBubble }: AllBubbleBallotOptions): Document {
     pages: [
       {
         children: [
-          TimingMarkGrid({ pageNumber: 1, ballotStyleIndex, precinctIndex }),
+          TimingMarkGrid({ pageNumber: 1, ballotStyleIndex, precinctIndex, m }),
           ...bubbles(1),
         ],
       },
       {
         children: [
-          TimingMarkGrid({ pageNumber: 2, ballotStyleIndex, precinctIndex }),
+          TimingMarkGrid({ pageNumber: 2, ballotStyleIndex, precinctIndex, m }),
           ...bubbles(2),
         ],
       },

--- a/apps/design/frontend/src/ballot_viewer.tsx
+++ b/apps/design/frontend/src/ballot_viewer.tsx
@@ -20,7 +20,6 @@ import {
   GridDimensions,
   layOutBallot,
   gridForPaper,
-  dimensionsForPaper,
 } from '@votingworks/design-shared';
 import fileDownload from 'js-file-download';
 import { useParams } from 'react-router-dom';
@@ -220,16 +219,14 @@ const ErrorMessage = styled.div`
   justify-content: center;
 `;
 
-function prettyPaperSize(paperSize: BallotPaperSize): string {
-  switch (paperSize) {
-    case BallotPaperSize.Letter:
-      return 'Letter';
-    case BallotPaperSize.Legal:
-      return 'Legal';
-    default:
-      throw new Error(`Unsupported paper size: ${paperSize}`);
-  }
-}
+export const paperSizeLabels: Record<BallotPaperSize, string> = {
+  [BallotPaperSize.Letter]: '8.5 x 11 inches (Letter)',
+  [BallotPaperSize.Legal]: '8.5 x 14 inches (Legal)',
+  [BallotPaperSize.Custom17]: '8.5 x 17 inches',
+  [BallotPaperSize.Custom18]: '8.5 x 18 inches',
+  [BallotPaperSize.Custom21]: '8.5 x 21 inches',
+  [BallotPaperSize.Custom22]: '8.5 x 22 inches',
+};
 
 export function BallotViewer({
   election,
@@ -247,7 +244,6 @@ export function BallotViewer({
 
   const paperSize = election.ballotLayout?.paperSize ?? BallotPaperSize.Letter;
   const grid = gridForPaper(paperSize);
-  const paperDimensions = dimensionsForPaper(paperSize);
 
   const [dimensions, setDimensions] = useState<{
     width: number;
@@ -305,10 +301,7 @@ export function BallotViewer({
           <H3>Precinct</H3>
           <P>{precinct.name}</P>
           <H3>Page Size</H3>
-          <P>
-            {prettyPaperSize(paperSize)} &mdash; {paperDimensions.width} x{' '}
-            {paperDimensions.height} inches
-          </P>
+          <P>{paperSizeLabels[paperSize]}</P>
           <H3>Timing Marks</H3>
           <P>
             {grid.columns} columns x {grid.rows} rows

--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -26,6 +26,7 @@ import { hasSplits } from './geography_screen';
 import { BallotScreen } from './ballot_screen';
 import { SegmentedControl } from './segmented_control';
 import { paperSizeLabels } from './ballot_viewer';
+import { RadioGroup } from './radio';
 
 const defaultBallotLayout: Required<BallotLayout> = {
   targetMarkPosition: BallotTargetMarkPosition.Left,
@@ -63,17 +64,19 @@ function BallotDesignForm({
   return (
     <Form>
       <FormField label="Paper Size">
-        <SegmentedControl
+        <RadioGroup
           options={Object.entries(paperSizeLabels).map(([value, label]) => ({
-            value: value as BallotPaperSize,
+            value,
             label,
           }))}
           value={ballotLayout.paperSize}
           onChange={(paperSize) =>
-            setBallotLayout({ ...ballotLayout, paperSize })
+            setBallotLayout({
+              ...ballotLayout,
+              paperSize: paperSize as BallotPaperSize,
+            })
           }
           disabled={!isEditing}
-          vertical
         />
       </FormField>
       <FormField label="Bubble Position">

--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -25,6 +25,7 @@ import { ElectionIdParams, electionParamRoutes, routes } from './routes';
 import { hasSplits } from './geography_screen';
 import { BallotScreen } from './ballot_screen';
 import { SegmentedControl } from './segmented_control';
+import { paperSizeLabels } from './ballot_viewer';
 
 const defaultBallotLayout: Required<BallotLayout> = {
   targetMarkPosition: BallotTargetMarkPosition.Left,
@@ -63,15 +64,16 @@ function BallotDesignForm({
     <Form>
       <FormField label="Paper Size">
         <SegmentedControl
-          options={[
-            { value: BallotPaperSize.Letter, label: 'Letter' },
-            { value: BallotPaperSize.Legal, label: 'Legal' },
-          ]}
+          options={Object.entries(paperSizeLabels).map(([value, label]) => ({
+            value: value as BallotPaperSize,
+            label,
+          }))}
           value={ballotLayout.paperSize}
           onChange={(paperSize) =>
             setBallotLayout({ ...ballotLayout, paperSize })
           }
           disabled={!isEditing}
+          vertical
         />
       </FormField>
       <FormField label="Bubble Position">

--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -61,6 +61,19 @@ function BallotDesignForm({
 
   return (
     <Form>
+      <FormField label="Paper Size">
+        <SegmentedControl
+          options={[
+            { value: BallotPaperSize.Letter, label: 'Letter' },
+            { value: BallotPaperSize.Legal, label: 'Legal' },
+          ]}
+          value={ballotLayout.paperSize}
+          onChange={(paperSize) =>
+            setBallotLayout({ ...ballotLayout, paperSize })
+          }
+          disabled={!isEditing}
+        />
+      </FormField>
       <FormField label="Bubble Position">
         <SegmentedControl
           options={[

--- a/apps/design/frontend/src/radio.tsx
+++ b/apps/design/frontend/src/radio.tsx
@@ -1,0 +1,72 @@
+import { Color } from '@votingworks/types';
+import { Icons } from '@votingworks/ui';
+import styled from 'styled-components';
+
+interface Option {
+  label: string;
+  value: string;
+}
+
+interface RadioGroupProps {
+  options: Option[];
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+}
+
+const Container = styled.span`
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.2rem;
+`;
+
+const Option = styled.label<{ isSelected: boolean; disabled: boolean }>`
+  padding: 0.5rem 1rem;
+  background: ${(p) =>
+    p.isSelected
+      ? p.disabled
+        ? Color.LEGACY_BUTTON_BACKGROUND
+        : p.theme.colors.accentPrimary
+      : 'none'};
+  color: ${(p) => (p.isSelected && !p.disabled ? 'white' : 'currentColor')};
+  border-radius: 0.25rem;
+  cursor: ${(p) => (p.disabled ? 'default' : 'pointer')};
+  input {
+    &:checked {
+      background: ${(p) => p.theme.colors.accentPrimary};
+    }
+  }
+`;
+
+export function RadioGroup({
+  options,
+  value,
+  onChange,
+  disabled = false,
+}: RadioGroupProps): JSX.Element {
+  return (
+    <Container>
+      {options.map((option) => {
+        const isSelected = value === option.value;
+        return (
+          <Option
+            key={option.label}
+            isSelected={isSelected}
+            disabled={disabled}
+          >
+            {isSelected ? <Icons.CircleDot /> : <Icons.Circle />}
+            <input
+              style={{ visibility: 'hidden' }}
+              type="radio"
+              value={option.value}
+              checked={isSelected}
+              onChange={() => onChange(option.value)}
+              disabled={disabled}
+            />
+            <span>{option.label}</span>
+          </Option>
+        );
+      })}
+    </Container>
+  );
+}

--- a/apps/design/frontend/src/segmented_control.tsx
+++ b/apps/design/frontend/src/segmented_control.tsx
@@ -7,13 +7,17 @@ interface Option<V extends string> {
   label: string;
 }
 
-const ControlContainer = styled.div`
-  display: inline-block;
+const ControlContainer = styled.div<{ vertical?: boolean }>`
+  display: inline-flex;
+  flex-direction: ${(p) => (p.vertical ? 'column' : 'row')};
   border-radius: 0.25rem;
   background: ${Color.LEGACY_BUTTON_BACKGROUND};
 `;
 
-const ControlOption = styled(Button)<{ isSelected: boolean }>`
+const ControlOption = styled(Button)<{
+  isSelected: boolean;
+  vertical?: boolean;
+}>`
   background: ${(p) =>
     p.isSelected
       ? p.disabled
@@ -21,6 +25,7 @@ const ControlOption = styled(Button)<{ isSelected: boolean }>`
         : p.theme.colors.accentPrimary
       : 'none'};
   color: ${(p) => (p.isSelected ? 'white' : 'currentColor')};
+  text-align: ${(p) => (p.vertical ? 'left' : 'center')};
   &:disabled {
     cursor: default;
   }
@@ -31,20 +36,23 @@ export function SegmentedControl<V extends string>({
   value,
   onChange,
   disabled,
+  vertical,
 }: {
   options: Array<Option<V>>;
   value: V;
   onChange: (value: V) => void;
   disabled?: boolean;
+  vertical?: boolean;
 }): JSX.Element {
   return (
-    <ControlContainer>
+    <ControlContainer vertical={vertical}>
       {options.map((option) => (
         <ControlOption
           key={option.value}
           onPress={() => onChange(option.value)}
           disabled={disabled}
           isSelected={option.value === value}
+          vertical={vertical}
         >
           {option.label}
         </ControlOption>

--- a/apps/design/shared/src/layout.test.ts
+++ b/apps/design/shared/src/layout.test.ts
@@ -1,4 +1,5 @@
-import { layOutInColumns } from './layout';
+import { BallotPaperSize } from '@votingworks/types';
+import { gridForPaper, layOutInColumns } from './layout';
 
 test('layoutInColumns', () => {
   const a1 = { id: 'a', height: 1 } as const;
@@ -184,5 +185,17 @@ test('layoutInColumns', () => {
     columns: [[c2], [a1, b1], [d2]],
     height: 2,
     leftoverElements: [],
+  });
+});
+
+test('gridForPaper', () => {
+  // These values are hardcoded in the interpreter, so they should not change.
+  expect(gridForPaper(BallotPaperSize.Letter)).toEqual({
+    rows: 41,
+    columns: 34,
+  });
+  expect(gridForPaper(BallotPaperSize.Legal)).toEqual({
+    rows: 53,
+    columns: 34,
   });
 });

--- a/apps/design/shared/src/layout.ts
+++ b/apps/design/shared/src/layout.ts
@@ -4,6 +4,7 @@ import {
   iter,
   ok,
   Result,
+  throwIllegalValue,
   wrapException,
 } from '@votingworks/basics';
 import {
@@ -124,26 +125,39 @@ export function dimensionsForPaper(paperSize: BallotPaperSize): {
         width: 8.5,
         height: 14,
       };
+    case BallotPaperSize.Custom17:
+      return {
+        width: 8.5,
+        height: 17,
+      };
+    case BallotPaperSize.Custom18:
+      return {
+        width: 8.5,
+        height: 18,
+      };
+    case BallotPaperSize.Custom21:
+      return {
+        width: 8.5,
+        height: 21,
+      };
+    case BallotPaperSize.Custom22:
+      return {
+        width: 8.5,
+        height: 22,
+      };
     default:
-      throw new Error(`Unsupported paper size: ${paperSize}`);
+      throwIllegalValue(paperSize);
   }
 }
 
 export function gridForPaper(paperSize: BallotPaperSize): GridDimensions {
-  switch (paperSize) {
-    case BallotPaperSize.Letter:
-      return {
-        rows: 41,
-        columns: 34,
-      };
-    case BallotPaperSize.Legal:
-      return {
-        rows: 53,
-        columns: 34,
-      };
-    default:
-      throw new Error(`Unsupported paper size: ${paperSize}`);
-  }
+  const columnsPerInch = 4;
+  const rowsPerInch = 4;
+  const dimensions = dimensionsForPaper(paperSize);
+  return {
+    rows: dimensions.height * rowsPerInch - 3,
+    columns: dimensions.width * columnsPerInch,
+  };
 }
 
 export const PPI = 72;

--- a/libs/cvr-fixture-generator/src/cli/generate/main.ts
+++ b/libs/cvr-fixture-generator/src/cli/generate/main.ts
@@ -267,7 +267,7 @@ export async function main(
           pageHeightInches = 14;
           break;
 
-        case BallotPaperSize.Custom8Point5X17:
+        case BallotPaperSize.Custom17:
           pageHeightInches = 17;
           break;
 

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -332,7 +332,10 @@ export const CountySchema: z.ZodSchema<County> = z.object({
 export enum BallotPaperSize {
   Letter = 'letter',
   Legal = 'legal',
-  Custom8Point5X17 = 'custom8.5x17',
+  Custom17 = 'custom-8.5x17',
+  Custom18 = 'custom-8.5x18',
+  Custom21 = 'custom-8.5x21',
+  Custom22 = 'custom-8.5x22',
 }
 export const BallotPaperSizeSchema: z.ZodSchema<BallotPaperSize> =
   z.nativeEnum(BallotPaperSize);

--- a/libs/types/src/schema.test.ts
+++ b/libs/types/src/schema.test.ts
@@ -321,13 +321,16 @@ test('supports ballot layout paper size', () => {
         "options": [
           "letter",
           "legal",
-          "custom8.5x17"
+          "custom-8.5x17",
+          "custom-8.5x18",
+          "custom-8.5x21",
+          "custom-8.5x22"
         ],
         "path": [
           "ballotLayout",
           "paperSize"
         ],
-        "message": "Invalid enum value. Expected 'letter' | 'legal' | 'custom8.5x17'"
+        "message": "Invalid enum value. Expected 'letter' | 'legal' | 'custom-8.5x17' | 'custom-8.5x18' | 'custom-8.5x21' | 'custom-8.5x22'"
       }
     ]]
   `);

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -34,6 +34,8 @@ import {
   faXmarkCircle,
   faPauseCircle,
   faSquare,
+  faCircle,
+  faCircleDot,
 } from '@fortawesome/free-regular-svg-icons';
 
 import { Font, FontProps } from './typography';
@@ -69,6 +71,14 @@ export const Icons = {
 
   Backspace(): JSX.Element {
     return <FaIcon type={faDeleteLeft} />;
+  },
+
+  Circle(): JSX.Element {
+    return <FaIcon type={faCircle} />;
+  },
+
+  CircleDot(): JSX.Element {
+    return <FaIcon type={faCircleDot} />;
   },
 
   Checkbox(): JSX.Element {


### PR DESCRIPTION
## Overview

Adds a toggle in VxDesign to switch between letter, legal, and custom longer paper sizes.

Legal ballots are already supported by the interpreter (which detects their dimensions from the scanned image), so there's no change needed there. We don't need to support interpreting the custom longer sizes yet.

The only adjustments needed were to configure the page size and timing mark grid in the layout algorithm.

## Demo Video or Screenshot
Legal ballot
<img width="919" alt="Screen Shot 2023-07-13 at 3 00 00 PM" src="https://github.com/votingworks/vxsuite/assets/530106/582e59df-4786-4c16-ac1f-600883f3a638">



https://github.com/votingworks/vxsuite/assets/530106/7cbcfca9-be1f-4256-80e4-a74bd7ac40bd


## Testing Plan
- Visual inspection of ballots
- Automated testing of interpretation

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
