### PR TITLE
fix(admin): a few loading modals in VxAdmin are clipping text

### DIFF
--- a/apps/admin/frontend/src/components/save_backend_file_modal.tsx
+++ b/apps/admin/frontend/src/components/save_backend_file_modal.tsx
@@ -15,6 +15,7 @@ import {
   P,
   useExternalStateChangeListener,
   Font,
+  ModalWidth,
 } from '@votingworks/ui';
 
 import { MutationStatus } from '@tanstack/react-query';
@@ -183,7 +184,13 @@ export function SaveBackendFileModal({
   }
 
   if (saveFileStatus === 'loading') {
-    return <Modal content={<Loading>Saving {fileTypeTitle}</Loading>} />;
+    return (
+      <Modal
+        centerContent
+        modalWidth={ModalWidth.Wide}
+        content={<Loading>Saving {fileTypeTitle}</Loading>}
+      />
+    );
   }
 
   if (saveFileStatus === 'success' && assertDefined(saveFileResult).isOk()) {

--- a/apps/admin/frontend/src/components/save_frontend_file_modal.tsx
+++ b/apps/admin/frontend/src/components/save_frontend_file_modal.tsx
@@ -9,7 +9,14 @@ import {
   isSystemAdministratorAuth,
 } from '@votingworks/utils';
 
-import { Button, Modal, UsbControllerButton, P, Font } from '@votingworks/ui';
+import {
+  Button,
+  Modal,
+  UsbControllerButton,
+  P,
+  Font,
+  ModalWidth,
+} from '@votingworks/ui';
 
 import { LogEventId } from '@votingworks/logging';
 import { PromiseOr } from '@votingworks/types';
@@ -213,7 +220,13 @@ export function SaveFrontendFileModal({
   }
 
   if (currentState === ModalState.SAVING) {
-    return <Modal content={<Loading>Saving {title}</Loading>} />;
+    return (
+      <Modal
+        centerContent
+        modalWidth={ModalWidth.Wide}
+        content={<Loading>Saving {title}</Loading>}
+      />
+    );
   }
 
   if (currentState !== ModalState.INIT) {

--- a/apps/admin/frontend/src/screens/print_test_deck_screen.tsx
+++ b/apps/admin/frontend/src/screens/print_test_deck_screen.tsx
@@ -21,6 +21,7 @@ import {
   P,
   H6,
   Font,
+  ModalWidth,
 } from '@votingworks/ui';
 import {
   isElectionManagerAuth,
@@ -254,6 +255,7 @@ function PrintingModal({
   return (
     <Modal
       centerContent
+      modalWidth={ModalWidth.Wide}
       content={
         <React.Fragment>
           <P weight="bold">


### PR DESCRIPTION
## Overview

a few loading modals in VxAdmin are clipping text because they have fixed lengths that are too short. we should have a setting for variable length modals but I wanted a quick polish fix for m17b by just using the wide setting on these modals

## Demo Video or Screenshot

Before
<img width="962" alt="Screen Shot 2023-07-13 at 11 24 22 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/9c2c37f7-1e98-4688-8e95-d8aca92f3aaf">

After
<img width="962" alt="Screen Shot 2023-07-13 at 11 23 27 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/e0f25326-9873-475c-84a9-4fa4553494a7">