### PR TITLE
admin(perf, refactor): quicker information about write-in queue sizes

### DIFF
--- a/apps/admin/backend/schema.sql
+++ b/apps/admin/backend/schema.sql
@@ -20,6 +20,7 @@ create table write_in_candidates (
 create table write_ins (
   id varchar(36) primary key,
   cvr_id varchar(36) not null,
+  election_id varchar(36) not null,
   side text not null check (side = 'front' or side = 'back'),
   contest_id text not null,
   option_id text not null,
@@ -28,6 +29,7 @@ create table write_ins (
   is_invalid boolean not null default false,
   adjudicated_at timestamp,
   created_at timestamp not null default current_timestamp,
+  foreign key (election_id) references elections(id),
   foreign key (cvr_id) references cvrs(id)
     on delete cascade,
   foreign key (cvr_id, side) references ballot_images(cvr_id, side),

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -63,11 +63,11 @@ import {
   SetSystemSettingsResult,
   TallyReportResults,
   WriteInAdjudicationAction,
+  WriteInAdjudicationQueueMetadata,
   WriteInAdjudicationStatus,
   WriteInCandidateRecord,
   WriteInDetailView,
   WriteInRecord,
-  WriteInTally,
 } from './types';
 import { Workspace } from './util/workspace';
 import {
@@ -543,13 +543,13 @@ function buildApi({
       store.adjudicateWriteIn(input);
     },
 
-    getWriteInTallies(
+    getWriteInAdjudicationQueueMetadata(
       input: {
         contestId?: ContestId;
         status?: WriteInAdjudicationStatus;
       } = {}
-    ): WriteInTally[] {
-      return store.getWriteInTallies({
+    ): WriteInAdjudicationQueueMetadata[] {
+      return store.getWriteInAdjudicationQueueMetadata({
         electionId: loadCurrentElectionIdOrThrow(workspace),
         ...input,
       });

--- a/apps/admin/backend/src/cvr_files.ts
+++ b/apps/admin/backend/src/cvr_files.ts
@@ -702,6 +702,7 @@ export async function addCastVoteRecordReport({
           // on previous validation
           if (castVoteRecordWriteIn.side) {
             store.addWriteIn({
+              electionId,
               castVoteRecordId: cvrId,
               side: castVoteRecordWriteIn.side,
               contestId: castVoteRecordWriteIn.contestId,

--- a/apps/admin/backend/src/cvr_files.ts
+++ b/apps/admin/backend/src/cvr_files.ts
@@ -55,6 +55,9 @@ import {
 } from './types';
 import { sha256File } from './util/sha256_file';
 import { Usb } from './util/usb';
+import { rootDebug } from './util/debug';
+
+const debug = rootDebug.extend('cvr-files');
 
 /**
  * Gets the metadata, including the path, of cast vote record files found in
@@ -463,6 +466,7 @@ export async function addCastVoteRecordReport({
   exportedTimestamp: Iso8601Timestamp;
   artifactAuthenticator: ArtifactAuthenticatorApi;
 }): Promise<AddCastVoteRecordReportResult> {
+  debug('attempting to add a cast vote record report');
   const electionId = store.getCurrentElectionId();
   assert(electionId !== undefined);
 
@@ -482,6 +486,7 @@ export async function addCastVoteRecordReport({
   ) {
     return err({ type: 'cast-vote-records-authentication-error' });
   }
+  debug('authenticated cast vote record report');
 
   // Check whether this directory looks like a valid report directory
   const directoryValidationResult =
@@ -497,6 +502,7 @@ export async function addCastVoteRecordReport({
     reportDirectoryPath,
     CAST_VOTE_RECORD_REPORT_FILENAME
   );
+  debug('validated cast vote record report directory');
 
   // We are hashing only the JSON report here - perhaps we should hash some
   // structure of the report directory as well or even the images.
@@ -514,6 +520,7 @@ export async function addCastVoteRecordReport({
   }
   const { CVR: unparsedCastVoteRecords, ...reportMetadata } =
     getCastVoteRecordReportImportResult.ok();
+  debug('read cast vote record metadata');
 
   // Ensure the report matches the file mode of previous imports
   const reportFileMode = isTestReport(reportMetadata) ? 'test' : 'official';
@@ -566,6 +573,8 @@ export async function addCastVoteRecordReport({
       sha256Hash,
       scannerIds,
     });
+    debug('added cast vote record file record');
+    debug('importing individual cvrs...');
 
     // Iterate through all the cast vote records
     let castVoteRecordIndex = 0;
@@ -712,6 +721,7 @@ export async function addCastVoteRecordReport({
 
       castVoteRecordIndex += 1;
     }
+    debug('imported all individual cvrs');
 
     // TODO: Calculate the precinct list before iterating through records, once there is
     // only one geopolitical unit per batch in the future.
@@ -719,6 +729,7 @@ export async function addCastVoteRecordReport({
       id: fileId,
       precinctIds,
     });
+    debug('updated cast vote record file record');
 
     return ok({
       id: fileId,

--- a/apps/admin/backend/src/server.ts
+++ b/apps/admin/backend/src/server.ts
@@ -17,6 +17,9 @@ import { ADMIN_WORKSPACE, PORT } from './globals';
 import { createWorkspace, Workspace } from './util/workspace';
 import { buildApp } from './app';
 import { Usb } from './util/usb';
+import { rootDebug } from './util/debug';
+
+const debug = rootDebug.extend('server');
 
 /**
  * Options for starting the admin service.
@@ -37,6 +40,7 @@ export async function start({
   port = PORT,
   workspace,
 }: Partial<StartOptions>): Promise<Server> {
+  debug('starting server...');
   let resolvedWorkspace = workspace;
   /* c8 ignore start */
   if (!resolvedWorkspace) {

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -68,6 +68,9 @@ import {
   CardTally,
 } from './types';
 import { replacePartyIdFilter } from './tabulation/utils';
+import { rootDebug } from './util/debug';
+
+const debug = rootDebug.extend('store');
 
 /**
  * Path to the store's schema file, i.e. the file that defines the database.
@@ -742,6 +745,7 @@ export class Store {
   }
 
   getCvrFiles(electionId: Id): CastVoteRecordFileRecord[] {
+    debug('querying database for cvr file list');
     const results = this.client.all(
       `
       select
@@ -778,6 +782,7 @@ export class Store {
       sha256Hash: string;
       createdAt: string;
     }>;
+    debug('queried database for cvr file list');
 
     return results
       .map((result) =>
@@ -1204,6 +1209,7 @@ export class Store {
     contestId?: ContestId;
     status?: WriteInAdjudicationStatus;
   }): WriteInTally[] {
+    debug('querying database for write-in tallies');
     const whereParts: string[] = ['cvrs.election_id = ?'];
     const params: Bindable[] = [electionId];
 
@@ -1247,6 +1253,7 @@ export class Store {
       `,
       ...params
     ) as WriteInTallyRow[];
+    debug('queried database for write-in tallies');
     if (rows.length === 0) {
       return [];
     }
@@ -1384,6 +1391,7 @@ export class Store {
     status?: WriteInAdjudicationStatus;
     limit?: number;
   }): WriteInRecord[] {
+    debug('querying database for write-in records');
     this.assertElectionExists(electionId);
 
     const whereParts: string[] = ['cvr_files.election_id = ?'];
@@ -1452,6 +1460,7 @@ export class Store {
       writeInCandidateId: Id | null;
       adjudicatedAt: Iso8601Timestamp | null;
     }>;
+    debug('queried database for write-in records');
 
     return writeInRows
       .map((row) => {

--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -296,6 +296,15 @@ export type WriteInAdjudicatedTally =
 export type WriteInTally = WriteInPendingTally | WriteInAdjudicatedTally;
 
 /**
+ * Description of the write-in adjudication queue size.
+ */
+export interface WriteInAdjudicationQueueMetadata {
+  contestId: ContestId;
+  pendingTally: number;
+  totalTally: number;
+}
+
+/**
  * Information necessary to adjudicate a write-in for an official candidate.
  */
 export interface WriteInAdjudicationActionOfficialCandidate {

--- a/apps/admin/backend/test/mock_cvr_file.ts
+++ b/apps/admin/backend/test/mock_cvr_file.ts
@@ -99,6 +99,7 @@ export function addMockCvrFileToStore({
 
         for (const [contestId, optionId] of writeIns) {
           store.addWriteIn({
+            electionId,
             castVoteRecordId: cvrId,
             side: 'front',
             contestId,

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -227,15 +227,18 @@ export const getWriteIns = {
   },
 } as const;
 
-type GetWriteInTalliesInput = QueryInput<'getWriteInTallies'>;
-export const getWriteInTallies = {
-  queryKey(input?: GetWriteInTalliesInput): QueryKey {
-    return input ? ['getWriteInTallies', input] : ['getWriteInTallies'];
+type GetWriteInAdjudicationQueueMetadataInput =
+  QueryInput<'getWriteInAdjudicationQueueMetadata'>;
+export const getWriteInAdjudicationQueueMetadata = {
+  queryKey(input?: GetWriteInAdjudicationQueueMetadataInput): QueryKey {
+    return input
+      ? ['getWriteInAdjudicationQueueMetadata', input]
+      : ['getWriteInAdjudicationQueueMetadata'];
   },
-  useQuery(input?: GetWriteInTalliesInput) {
+  useQuery(input?: GetWriteInAdjudicationQueueMetadataInput) {
     const apiClient = useApiClient();
     return useQuery(this.queryKey(input), () =>
-      apiClient.getWriteInTallies(input)
+      apiClient.getWriteInAdjudicationQueueMetadata(input)
     );
   },
 } as const;
@@ -408,7 +411,9 @@ function invalidateCastVoteRecordQueries(queryClient: QueryClient) {
 function invalidateWriteInQueries(queryClient: QueryClient) {
   return Promise.all([
     queryClient.invalidateQueries(getWriteIns.queryKey()),
-    queryClient.invalidateQueries(getWriteInTallies.queryKey()),
+    queryClient.invalidateQueries(
+      getWriteInAdjudicationQueueMetadata.queryKey()
+    ),
     queryClient.invalidateQueries(getWriteInCandidates.queryKey()),
     queryClient.invalidateQueries(getElectionWriteInSummary.queryKey()),
   ]);

--- a/apps/admin/frontend/src/screens/write_ins_summary_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/write_ins_summary_screen.test.tsx
@@ -1,7 +1,6 @@
 import userEvent from '@testing-library/user-event';
 import { electionMinimalExhaustiveSampleFixtures } from '@votingworks/fixtures';
 import { sleep } from '@votingworks/basics';
-import type { WriteInPendingTally } from '@votingworks/admin-backend';
 import { createMemoryHistory } from 'history';
 import { act, screen } from '../../test/react_testing_library';
 import { renderInAppContext } from '../../test/render_in_app_context';
@@ -11,17 +10,6 @@ import { ApiMock, createApiMock } from '../../test/helpers/api_mock';
 jest.setTimeout(20000);
 
 const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
-
-function mockWriteInTallyPending(
-  contestId: string,
-  tally: number
-): WriteInPendingTally {
-  return {
-    status: 'pending',
-    contestId,
-    tally,
-  };
-}
 
 let apiMock: ApiMock;
 
@@ -41,7 +29,7 @@ beforeEach(() => {
 });
 
 test('No CVRs loaded', async () => {
-  apiMock.expectGetWriteInTallies([]);
+  apiMock.expectGetWriteInAdjudicationQueueMetadata([]);
   apiMock.expectGetCastVoteRecordFiles([]);
   renderInAppContext(<WriteInsSummaryScreen />, {
     electionDefinition,
@@ -54,9 +42,17 @@ test('No CVRs loaded', async () => {
 });
 
 test('Tally results already marked as official', async () => {
-  apiMock.expectGetWriteInTallies([
-    mockWriteInTallyPending('zoo-council-mammal', 3),
-    mockWriteInTallyPending('aquarium-council-fish', 5),
+  apiMock.expectGetWriteInAdjudicationQueueMetadata([
+    {
+      contestId: 'zoo-council-mammal',
+      pendingTally: 3,
+      totalTally: 3,
+    },
+    {
+      contestId: 'zoo-council-mammal',
+      pendingTally: 5,
+      totalTally: 5,
+    },
   ]);
   apiMock.expectGetCastVoteRecordFiles([]);
   renderInAppContext(<WriteInsSummaryScreen />, {
@@ -74,8 +70,12 @@ test('Tally results already marked as official', async () => {
 });
 
 test('CVRs with write-ins loaded', async () => {
-  apiMock.expectGetWriteInTallies([
-    mockWriteInTallyPending('zoo-council-mammal', 3),
+  apiMock.expectGetWriteInAdjudicationQueueMetadata([
+    {
+      contestId: 'zoo-council-mammal',
+      pendingTally: 3,
+      totalTally: 3,
+    },
   ]);
   apiMock.expectGetCastVoteRecordFiles([]);
   const history = createMemoryHistory();

--- a/apps/admin/frontend/test/helpers/api_mock.ts
+++ b/apps/admin/frontend/test/helpers/api_mock.ts
@@ -7,15 +7,13 @@ import type {
   MachineConfig,
   ManualResultsIdentifier,
   ManualResultsMetadataRecord,
-  WriteInAdjudicationStatus,
   WriteInCandidateRecord,
   WriteInDetailView,
   WriteInRecord,
-  WriteInTally,
-  WriteInAdjudicatedTally,
   SemsExportableTallies,
   ScannerBatch,
   TallyReportResults,
+  WriteInAdjudicationQueueMetadata,
 } from '@votingworks/admin-backend';
 import { ok } from '@votingworks/basics';
 import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
@@ -26,6 +24,7 @@ import {
 } from '@votingworks/test-utils';
 import {
   BallotPackageExportResult,
+  ContestId,
   DEFAULT_SYSTEM_SETTINGS,
   DippedSmartCardAuth,
   ElectionDefinition,
@@ -180,29 +179,21 @@ export function createApiMock(
       apiClient.getCastVoteRecordFiles.expectCallWith().resolves(fileRecords);
     },
 
-    expectGetWriteInTallies(
-      writeInTallies: WriteInTally[],
-      status?: WriteInAdjudicationStatus
+    expectGetWriteInAdjudicationQueueMetadata(
+      queueMetadata: WriteInAdjudicationQueueMetadata[],
+      contestId?: ContestId
     ) {
-      if (status) {
-        apiClient.getWriteInTallies
+      if (contestId) {
+        apiClient.getWriteInAdjudicationQueueMetadata
           .expectCallWith({
-            status,
+            contestId,
           })
-          .resolves(writeInTallies);
+          .resolves(queueMetadata);
       } else {
-        apiClient.getWriteInTallies.expectCallWith().resolves(writeInTallies);
+        apiClient.getWriteInAdjudicationQueueMetadata
+          .expectCallWith()
+          .resolves(queueMetadata);
       }
-    },
-
-    expectGetWriteInTalliesAdjudicated(
-      writeInTallies: WriteInAdjudicatedTally[]
-    ) {
-      apiClient.getWriteInTallies
-        .expectCallWith({
-          status: 'adjudicated',
-        })
-        .resolves(writeInTallies);
     },
 
     expectGetWriteIns(writeInRecords: WriteInRecord[], contestId?: string) {


### PR DESCRIPTION
With 500,000 CVRs loaded up and around 600,000 write-ins, the write-in adjudication experience is super slow. #3725 made a very significant improvement, but it's still slow. The main reason is that after _every_ adjudication, the adjudication flow refetches the _entire_ list of write-ins for that contest. We need to avoid doing that! 

My idea for doing that is to:

a) fetch only the sequence of write-in IDs, with no status, so it does not have to be updated after every adjudication
b) fetch counts of completed vs. left to adjudicate separately

We _could_ do (a) even more cleanly by implementing a pagination API, but I think that will be somewhat complex given other requirements, and fetching a list of 500,000 or even 5,000,000 IDs should be OK. Leaving pagination for another day.

This PR sets up (b). Alters our over-complex endpoint for getting write-in summaries (which has been effectively replaced by backend write-in tabulation) with an endpoint that only gets the counts of adjudicated vs. pending. In addition, to avoid joining on the `cvrs` table for every `write-ins` query, denormalizes a smidgen of data. 

I'll follow this up with a PR focusing on (a).