### PR TITLE
libs(custom-scanner): ignore flaky coverage lines

### DIFF
--- a/libs/custom-scanner/src/custom_a4_scanner.ts
+++ b/libs/custom-scanner/src/custom_a4_scanner.ts
@@ -416,9 +416,10 @@ export class CustomA4Scanner implements CustomScanner {
             debug('waiting for motor on and scan in progress timed out');
             void (await this.stopScanInternal());
             return err(ErrorCode.ScannerError);
-          } else {
+          } /* c8 ignore start */ else {
+            /* this branch often does not run during tests in CircleCI */
             debug('still waiting for motor on and scan in progress');
-          }
+          } /* c8 ignore stop */
         } else {
           startNoMoveNoScan = 0;
         }


### PR DESCRIPTION
see slack discussion: https://votingworks.slack.com/archives/CEL6D3GAD/p1689619057036929

I confirmed that the skipped lines are excluded from coverage reports