### PR TITLE
[VxMarkOld] Move write-in modal to vertical sidebar in landscape mode

### DIFF
--- a/apps/mark-scan/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
+++ b/apps/mark-scan/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
@@ -467,10 +467,6 @@ exports[`Single Seat Contest with Write In 1`] = `
 
 }
 
-@media (min-width:480px) {
-
-}
-
 @media print {
   .c1 {
     display: none;

--- a/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
@@ -375,10 +375,6 @@ exports[`Single Seat Contest with Write In 1`] = `
 
 }
 
-@media (min-width:480px) {
-
-}
-
 @media print {
 
 }

--- a/apps/mark/frontend/src/pages/contest_page.tsx
+++ b/apps/mark/frontend/src/pages/contest_page.tsx
@@ -1,5 +1,5 @@
 import { CandidateVote } from '@votingworks/types';
-import { Screen, LinkButton } from '@votingworks/ui';
+import { Screen, LinkButton, useScreenInfo } from '@votingworks/ui';
 import React, { useContext } from 'react';
 import { assert, throwIllegalValue } from '@votingworks/basics';
 import { useHistory, useParams } from 'react-router-dom';
@@ -19,6 +19,8 @@ export function ContestPage(): JSX.Element {
 
   const { contests, electionDefinition, precinctId, updateVote, votes } =
     useContext(BallotContext);
+
+  const screenInfo = useScreenInfo();
 
   // eslint-disable-next-line vx/gts-safe-number-parse
   const currentContestIndex = parseInt(contestNumber, 10);
@@ -97,7 +99,7 @@ export function ContestPage(): JSX.Element {
   const settingsButton = <DisplaySettingsButton />;
 
   return (
-    <Screen navRight>
+    <Screen navRight={!screenInfo.isPortrait}>
       <MarkFlowContest
         breadcrumbs={{
           ballotContestCount: ballotContestsLength,

--- a/apps/mark/frontend/src/pages/review_page.tsx
+++ b/apps/mark/frontend/src/pages/review_page.tsx
@@ -7,6 +7,7 @@ import {
   Screen,
   H1,
   WithScrollButtons,
+  useScreenInfo,
 } from '@votingworks/ui';
 
 import { assert } from '@votingworks/basics';
@@ -26,6 +27,8 @@ export function ReviewPage(): JSX.Element {
   const { contests, electionDefinition, precinctId, votes } =
     useContext(BallotContext);
 
+  const screenInfo = useScreenInfo();
+
   assert(
     electionDefinition,
     'electionDefinition is required to render ReviewPage'
@@ -44,7 +47,7 @@ export function ReviewPage(): JSX.Element {
   const settingsButton = <DisplaySettingsButton />;
 
   return (
-    <Screen navRight>
+    <Screen navRight={!screenInfo.isPortrait}>
       <Main flexColumn>
         <ContentHeader>
           <Prose id="audiofocus">

--- a/libs/mark-flow-ui/src/components/candidate_contest.tsx
+++ b/libs/mark-flow-ui/src/components/candidate_contest.tsx
@@ -1,3 +1,4 @@
+/* stylelint-disable order/properties-order */
 import camelCase from 'lodash.camelcase';
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
@@ -23,6 +24,8 @@ import {
   Caption,
   TouchTextInput,
   WithScrollButtons,
+  ModalWidth,
+  useScreenInfo,
 } from '@votingworks/ui';
 import { assert } from '@votingworks/basics';
 
@@ -44,6 +47,28 @@ interface Props {
   vote: CandidateVote;
   updateVote: UpdateVoteFunction;
 }
+
+const WriteInModalBody = styled.div`
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+`;
+
+const WriteInForm = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  justify-content: center;
+  flex-shrink: 1;
+  max-width: 100%;
+`;
+
+const WriteInModalActionsSidebar = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  justify-content: center;
+`;
 
 function findCandidateById(candidates: readonly Candidate[], id: string) {
   return candidates.find((c) => c.id === id);
@@ -70,6 +95,8 @@ export function CandidateContest({
     useState(false);
   const [writeInCandidateName, setWriteInCandidateName] = useState('');
   const [deselectedCandidate, setDeselectedCandidate] = useState('');
+
+  const screenInfo = useScreenInfo();
 
   useEffect(() => {
     if (deselectedCandidate !== '') {
@@ -185,6 +212,19 @@ export function CandidateContest({
   }
 
   const hasReachedMaxSelections = contest.seats === vote.length;
+
+  const modalActions = (
+    <React.Fragment>
+      <Button
+        variant="done"
+        onPress={addWriteInCandidate}
+        disabled={normalizeCandidateName(writeInCandidateName).length === 0}
+      >
+        Accept
+      </Button>
+      <Button onPress={cancelWriteInCandidateModal}>Cancel</Button>
+    </React.Fragment>
+  );
 
   return (
     <React.Fragment>
@@ -335,49 +375,46 @@ export function CandidateContest({
       {writeInCandidateModalIsOpen && (
         <Modal
           ariaLabel=""
+          modalWidth={ModalWidth.Wide}
           title={`Write-In: ${contest.title}`}
           content={
             <WriteInModalContent>
-              <Prose id="modalaudiofocus" maxWidth={false}>
+              <div id="modalaudiofocus">
                 <P>
                   <Caption aria-label="Enter the name of a person who is not on the ballot. Use the up and down buttons to navigate between the letters of a standard keyboard. Use the select button to select the current letter.">
                     <Icons.Info /> Enter the name of a person who is{' '}
                     <Font weight="bold">not</Font> on the ballot:
                   </Caption>
                 </P>
-              </Prose>
-              <TouchTextInput value={writeInCandidateName} />
-              <P
-                align="right"
-                color={writeInCharsRemaining ? 'default' : 'warning'}
-              >
-                <Caption>
-                  {writeInCharsRemaining === 0 && <Icons.Warning />}{' '}
-                  {writeInCharsRemaining}{' '}
-                  {pluralize('character', writeInCharsRemaining)} remaining
-                </Caption>
-              </P>
-              <VirtualKeyboard
-                onBackspace={onKeyboardBackspace}
-                onKeyPress={onKeyboardInput}
-                keyDisabled={keyDisabled}
-              />
+              </div>
+              <WriteInModalBody>
+                <WriteInForm>
+                  <TouchTextInput value={writeInCandidateName} />
+                  <P
+                    align="right"
+                    color={writeInCharsRemaining ? 'default' : 'warning'}
+                  >
+                    <Caption>
+                      {writeInCharsRemaining === 0 && <Icons.Warning />}{' '}
+                      {writeInCharsRemaining}{' '}
+                      {pluralize('character', writeInCharsRemaining)} remaining
+                    </Caption>
+                  </P>
+                  <VirtualKeyboard
+                    onBackspace={onKeyboardBackspace}
+                    onKeyPress={onKeyboardInput}
+                    keyDisabled={keyDisabled}
+                  />
+                </WriteInForm>
+                {!screenInfo.isPortrait && (
+                  <WriteInModalActionsSidebar>
+                    {modalActions}
+                  </WriteInModalActionsSidebar>
+                )}
+              </WriteInModalBody>
             </WriteInModalContent>
           }
-          actions={
-            <React.Fragment>
-              <Button
-                variant="done"
-                onPress={addWriteInCandidate}
-                disabled={
-                  normalizeCandidateName(writeInCandidateName).length === 0
-                }
-              >
-                Accept
-              </Button>
-              <Button onPress={cancelWriteInCandidateModal}>Cancel</Button>
-            </React.Fragment>
-          }
+          actions={screenInfo.isPortrait ? modalActions : undefined}
         />
       )}
     </React.Fragment>

--- a/libs/ui/src/__snapshots__/modal.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/modal.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`Modal can configure a wider max width 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   overflow: auto;
-  padding: 1rem;
+  padding: 0.5rem 0.75rem;
 }
 
 @media (min-width:480px) {

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -24,6 +24,7 @@ export * from './hooks/use_lock';
 export * from './hooks/use_mounted_state';
 export * from './hooks/use_now';
 export * from './hooks/use_previous';
+export * from './hooks/use_screen_info';
 export * from './hooks/use_stored_state';
 export * from './hooks/use_usb_drive';
 export * from './horizontal_rule';

--- a/libs/ui/src/modal.tsx
+++ b/libs/ui/src/modal.tsx
@@ -88,7 +88,7 @@ const ModalContent = styled('div')<ModalContentInterface>`
   justify-content: ${({ centerContent = false }) =>
     centerContent ? 'center' : undefined};
   overflow: auto;
-  padding: ${({ fullscreen }) => !fullscreen && '1rem'};
+  padding: ${({ fullscreen }) => !fullscreen && '0.5rem 0.75rem'};
 `;
 
 /** Props for {@link Modal}. */


### PR DESCRIPTION
## Overview

In order to continue to support/upgrade old landscape VxMark machines, this updates the newly re-styled write-in modal to fit in a landscape format.
- Moving modal action buttons to a vertical column on the right when the screen is in a landscape orientation.
- Expanding the max width of the write-in modal to accommodate the new layout.

Also fixing a minor bug from a previous PR to make sure the contest page and review page only use the side nav layout when in landscape mode.

## Demo Video or Screenshot
### Before (Landscape at XL text size):
![Screenshot 2023-07-17 at 15 04 38](https://github.com/votingworks/vxsuite/assets/264902/b09dd5b2-4b20-495f-8e04-40f46faa32c5)

### After (Landscape):
https://github.com/votingworks/vxsuite/assets/264902/0e093918-178d-4f0f-b9c8-2e0091d6419b

### After (Portrait - no change):
<img width="400" src="https://github.com/votingworks/vxsuite/assets/264902/6fb4609c-a813-43aa-a39f-05fd18e68d8d" />

## Testing Plan
- Manual

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
