### PR TITLE
Write-In Adjudication Performance Changes + Flow Tweaks

### DIFF
--- a/apps/admin/backend/schema.sql
+++ b/apps/admin/backend/schema.sql
@@ -18,7 +18,8 @@ create table write_in_candidates (
 );
 
 create table write_ins (
-  id varchar(36) primary key,
+  sequence_id integer primary key autoincrement,
+  id varchar(36) not null unique,
   cvr_id varchar(36) not null,
   election_id varchar(36) not null,
   side text not null check (side = 'front' or side = 'back'),

--- a/apps/admin/backend/src/app.cvr_files.test.ts
+++ b/apps/admin/backend/src/app.cvr_files.test.ts
@@ -150,7 +150,7 @@ test('happy path - mock election flow', async () => {
   await expectCastVoteRecordCount(apiClient, 184);
 
   // check write-in records were created
-  expect(await apiClient.getWriteIns()).toHaveLength(80);
+  expect(await apiClient.getWriteInAdjudicationQueue()).toHaveLength(80);
 
   // check scanner batches
   expect(await apiClient.getScannerBatches()).toEqual([
@@ -261,7 +261,7 @@ test('adding a file with BMD cast vote records', async () => {
   await expectCastVoteRecordCount(apiClient, 112);
 
   // check that no write-in records were created
-  expect(await apiClient.getWriteIns()).toHaveLength(0);
+  expect(await apiClient.getWriteInAdjudicationQueue()).toHaveLength(0);
 });
 
 test('adding a duplicate file returns OK to client but logs an error', async () => {

--- a/apps/admin/backend/src/app.exports.test.ts
+++ b/apps/admin/backend/src/app.exports.test.ts
@@ -200,12 +200,12 @@ test('precinct / voting method results export - wia and manual data', async () =
   });
 
   // adjudicate write-ins
-  const writeIns = await apiClient.getWriteIns({
+  const writeInIds = await apiClient.getWriteInAdjudicationQueue({
     contestId: candidateContestId,
   });
-  for (const writeIn of writeIns) {
+  for (const writeInId of writeInIds) {
     await apiClient.adjudicateWriteIn({
-      writeInId: writeIn.id,
+      writeInId,
       type: 'invalid',
     });
   }

--- a/apps/admin/backend/src/app.results.test.ts
+++ b/apps/admin/backend/src/app.results.test.ts
@@ -153,28 +153,28 @@ test('tally report data - overall report & write-ins', async () => {
     contestId: writeInContestId,
     name: 'Unofficial Candidate',
   });
-  const writeIns = await apiClient.getWriteIns({
+  const writeInIds = await apiClient.getWriteInAdjudicationQueue({
     contestId: writeInContestId,
   });
-  expect(writeIns).toHaveLength(56);
+  expect(writeInIds).toHaveLength(56);
   const NUM_INVALID = 24;
   const NUM_OFFICIAL = 16;
   const NUM_UNOFFICIAL = 56 - NUM_INVALID - NUM_OFFICIAL;
-  for (const [i, writeIn] of writeIns.entries()) {
+  for (const [i, writeInId] of writeInIds.entries()) {
     if (i < NUM_INVALID) {
       await apiClient.adjudicateWriteIn({
-        writeInId: writeIn.id,
+        writeInId,
         type: 'invalid',
       });
     } else if (i < NUM_INVALID + NUM_OFFICIAL) {
       await apiClient.adjudicateWriteIn({
-        writeInId: writeIn.id,
+        writeInId,
         type: 'official-candidate',
         candidateId: officialCandidateId,
       });
     } else {
       await apiClient.adjudicateWriteIn({
-        writeInId: writeIn.id,
+        writeInId,
         type: 'write-in-candidate',
         candidateId: unofficialCandidate.id,
       });
@@ -239,13 +239,13 @@ test('tally report data - grouped report & manual data', async () => {
     contestId: writeInContestId,
     name: 'Unofficial Candidate',
   });
-  const writeIns = await apiClient.getWriteIns({
+  const writeInIds = await apiClient.getWriteInAdjudicationQueue({
     contestId: writeInContestId,
   });
-  expect(writeIns).toHaveLength(56);
-  for (const writeIn of writeIns) {
+  expect(writeInIds).toHaveLength(56);
+  for (const writeInId of writeInIds) {
     await apiClient.adjudicateWriteIn({
-      writeInId: writeIn.id,
+      writeInId,
       type: 'write-in-candidate',
       candidateId: unofficialCandidate.id,
     });
@@ -390,7 +390,7 @@ test('election write-in adjudication summary', async () => {
     totalTally: 56,
   });
 
-  const writeIns = await apiClient.getWriteIns({
+  const writeInIds = await apiClient.getWriteInAdjudicationQueue({
     contestId: writeInContestId,
   });
 
@@ -400,22 +400,22 @@ test('election write-in adjudication summary', async () => {
   });
 
   // generate some adjudication information
-  for (const [i, writeIn] of writeIns.entries()) {
+  for (const [i, writeInId] of writeInIds.entries()) {
     if (i < 24) {
       await apiClient.adjudicateWriteIn({
-        writeInId: writeIn.id,
+        writeInId,
         type: 'write-in-candidate',
         candidateId: unofficialCandidate1.id,
       });
     } else if (i < 48) {
       await apiClient.adjudicateWriteIn({
-        writeInId: writeIn.id,
+        writeInId,
         type: 'official-candidate',
         candidateId: 'Obadiah-Carrigan-5c95145a',
       });
     } else {
       await apiClient.adjudicateWriteIn({
-        writeInId: writeIn.id,
+        writeInId,
         type: 'invalid',
       });
     }

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -541,6 +541,15 @@ function buildApi({
       });
     },
 
+    getFirstPendingWriteInId(input: { contestId: ContestId }): Id | null {
+      return (
+        store.getFirstPendingWriteInId({
+          electionId: loadCurrentElectionIdOrThrow(workspace),
+          ...input,
+        }) ?? null
+      );
+    },
+
     adjudicateWriteIn(input: WriteInAdjudicationAction): void {
       store.adjudicateWriteIn(input);
     },

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -4,6 +4,7 @@ import {
   ContestId,
   DEFAULT_SYSTEM_SETTINGS,
   ElectionDefinition,
+  Id,
   safeParseElectionDefinition,
   safeParseJson,
   SystemSettings,
@@ -66,8 +67,8 @@ import {
   WriteInAdjudicationQueueMetadata,
   WriteInAdjudicationStatus,
   WriteInCandidateRecord,
-  WriteInDetailView,
-  WriteInRecord,
+  WriteInAdjudicationContext,
+  WriteInImageView,
 } from './types';
 import { Workspace } from './util/workspace';
 import {
@@ -78,7 +79,10 @@ import {
 } from './cvr_files';
 import { Usb } from './util/usb';
 import { getMachineConfig } from './machine_config';
-import { getWriteInDetailView } from './util/write_ins';
+import {
+  getWriteInAdjudicationContext,
+  getWriteInImageView,
+} from './util/write_ins';
 import { handleEnteredWriteInCandidateData } from './util/manual_results';
 import { addFileToZipStream } from './util/zip';
 import { exportFile } from './util/export_file';
@@ -526,14 +530,12 @@ function buildApi({
       );
     },
 
-    getWriteIns(
+    getWriteInAdjudicationQueue(
       input: {
         contestId?: ContestId;
-        status?: WriteInAdjudicationStatus;
-        limit?: number;
       } = {}
-    ): WriteInRecord[] {
-      return store.getWriteInRecords({
+    ): Id[] {
+      return store.getWriteInAdjudicationQueue({
         electionId: loadCurrentElectionIdOrThrow(workspace),
         ...input,
       });
@@ -576,10 +578,19 @@ function buildApi({
       });
     },
 
-    async getWriteInDetailView(input: {
+    async getWriteInImageView(input: {
       writeInId: string;
-    }): Promise<WriteInDetailView> {
-      return getWriteInDetailView({
+    }): Promise<WriteInImageView> {
+      return getWriteInImageView({
+        store: workspace.store,
+        writeInId: input.writeInId,
+      });
+    },
+
+    getWriteInAdjudicationContext(input: {
+      writeInId: string;
+    }): WriteInAdjudicationContext {
+      return getWriteInAdjudicationContext({
         store: workspace.store,
         writeInId: input.writeInId,
       });

--- a/apps/admin/backend/src/app.writeins.test.ts
+++ b/apps/admin/backend/src/app.writeins.test.ts
@@ -7,9 +7,10 @@ import {
   BooleanEnvironmentVariableName,
   getFeatureFlagMock,
 } from '@votingworks/utils';
-import { Rect } from '@votingworks/types';
+import { Id, Rect, CVR as CVRType, safeParse } from '@votingworks/types';
 import { buildTestEnvironment, configureMachine } from '../test/app';
-import { WriteInDetailView } from './types';
+import { WriteInAdjudicationContext, WriteInRecord } from './types';
+import { modifyCastVoteRecordReport } from '../test/utils';
 
 jest.setTimeout(30_000);
 
@@ -34,7 +35,7 @@ afterEach(() => {
   featureFlagMock.resetFeatureFlags();
 });
 
-test('getWriteIns', async () => {
+test('getWriteInAdjudicationQueue', async () => {
   const { auth, apiClient } = buildTestEnvironment();
   const { electionDefinition, castVoteRecordReport } =
     electionGridLayoutNewHampshireAmherstFixtures;
@@ -46,25 +47,40 @@ test('getWriteIns', async () => {
     })
   ).unsafeUnwrap();
 
-  const allWriteIns = await apiClient.getWriteIns();
+  const allWriteIns = await apiClient.getWriteInAdjudicationQueue();
   expect(allWriteIns).toHaveLength(80);
-  assert(allWriteIns.every((writeIn) => writeIn.status === 'pending'));
-
-  expect(await apiClient.getWriteIns({ status: 'pending' })).toHaveLength(80);
-  expect(await apiClient.getWriteIns({ status: 'adjudicated' })).toHaveLength(
-    0
-  );
-
-  expect(await apiClient.getWriteIns({ limit: 3 })).toHaveLength(3);
 
   expect(
-    await apiClient.getWriteIns({
+    await apiClient.getWriteInAdjudicationQueue({
       contestId: 'Sheriff-4243fe0b',
     })
   ).toHaveLength(2);
+
+  // add another file, whose write-ins should end up at the end of the queue
+  const secondReportPath = await modifyCastVoteRecordReport(
+    castVoteRecordReport.asDirectoryPath(),
+    ({ CVR }) => ({
+      CVR: CVR.map((unparsed) => {
+        const cvr = safeParse(CVRType.CVRSchema, unparsed).unsafeUnwrap();
+        return {
+          ...cvr,
+          UniqueId: `x-${cvr.UniqueId}`,
+        };
+      }),
+    })
+  );
+  (
+    await apiClient.addCastVoteRecordFile({
+      path: secondReportPath,
+    })
+  ).unsafeUnwrap();
+
+  const allWriteInsDouble = await apiClient.getWriteInAdjudicationQueue();
+  expect(allWriteInsDouble).toHaveLength(160);
+  expect(allWriteInsDouble.slice(0, 80)).toEqual(allWriteIns);
 });
 
-test('getWriteInAdjudicationQueueSizes', async () => {
+test('getWriteInAdjudicationQueueMetadata', async () => {
   const { auth, apiClient } = buildTestEnvironment();
   const { electionDefinition, castVoteRecordReport } =
     electionGridLayoutNewHampshireAmherstFixtures;
@@ -93,10 +109,16 @@ test('getWriteInAdjudicationQueueSizes', async () => {
     await apiClient.getWriteInAdjudicationQueueMetadata({
       contestId: 'Sheriff-4243fe0b',
     })
-  ).toHaveLength(1);
+  ).toEqual([
+    {
+      contestId: 'Sheriff-4243fe0b',
+      totalTally: 2,
+      pendingTally: 2,
+    },
+  ]);
 });
 
-test('e2e write-in adjudication', async () => {
+test('adjudicateWriteIn', async () => {
   const { auth, apiClient } = buildTestEnvironment();
   const { electionDefinition, castVoteRecordReport } =
     electionGridLayoutNewHampshireAmherstFixtures;
@@ -108,14 +130,22 @@ test('e2e write-in adjudication', async () => {
     })
   ).unsafeUnwrap();
 
-  // focus on this contest with two of write-ins
+  // focus on this contest with two write-ins
   const contestId = 'Sheriff-4243fe0b';
-  const contestWriteIns = await apiClient.getWriteIns({ contestId });
+  const contestWriteIns = await apiClient.getWriteInAdjudicationQueue({
+    contestId,
+  });
   expect(contestWriteIns).toHaveLength(2);
 
-  const [writeInA1, writeInB1] = contestWriteIns;
-  assert(writeInA1 && writeInB1);
-  expect(writeInA1).toMatchObject({
+  const [writeInIdA, writeInIdB] = contestWriteIns;
+  assert(writeInIdA !== undefined && writeInIdB !== undefined);
+
+  async function getWriteIn(writeInId: Id): Promise<WriteInRecord> {
+    return (await apiClient.getWriteInAdjudicationContext({ writeInId }))
+      .writeIn;
+  }
+
+  expect(await getWriteIn(writeInIdA)).toMatchObject({
     contestId,
     status: 'pending',
   });
@@ -123,13 +153,12 @@ test('e2e write-in adjudication', async () => {
   // write-in A: adjudicate for an official candidate
   const officialCandidateId = 'Edward-Randolph-bf4c848a';
   await apiClient.adjudicateWriteIn({
-    writeInId: writeInA1.id,
+    writeInId: writeInIdA,
     type: 'official-candidate',
     candidateId: officialCandidateId,
   });
 
-  const [writeInA2] = await apiClient.getWriteIns({ contestId });
-  expect(writeInA2).toMatchObject({
+  expect(await getWriteIn(writeInIdA)).toMatchObject({
     contestId,
     adjudicationType: 'official-candidate',
     candidateId: officialCandidateId,
@@ -147,12 +176,11 @@ test('e2e write-in adjudication', async () => {
 
   // write-in A: re-adjudicate as invalid
   await apiClient.adjudicateWriteIn({
-    writeInId: writeInA1.id,
+    writeInId: writeInIdA,
     type: 'invalid',
   });
 
-  const [writeInA3] = await apiClient.getWriteIns({ contestId });
-  expect(writeInA3).toMatchObject({
+  expect(await getWriteIn(writeInIdA)).toMatchObject({
     contestId,
     adjudicationType: 'invalid',
     status: 'adjudicated',
@@ -169,13 +197,12 @@ test('e2e write-in adjudication', async () => {
 
   // write-in A: re-adjudicate for the official candidate
   await apiClient.adjudicateWriteIn({
-    writeInId: writeInA1.id,
+    writeInId: writeInIdA,
     type: 'official-candidate',
     candidateId: officialCandidateId,
   });
 
-  const [writeInA4] = await apiClient.getWriteIns({ contestId });
-  expect(writeInA4).toMatchObject({
+  expect(await getWriteIn(writeInIdA)).toMatchObject({
     contestId,
     adjudicationType: 'official-candidate',
     candidateId: officialCandidateId,
@@ -201,13 +228,12 @@ test('e2e write-in adjudication', async () => {
   const [mrPickles] = await apiClient.getWriteInCandidates();
 
   await apiClient.adjudicateWriteIn({
-    writeInId: writeInB1.id,
+    writeInId: writeInIdB,
     type: 'write-in-candidate',
     candidateId: mrPickles!.id,
   });
 
-  const [, writeInB2] = await apiClient.getWriteIns({ contestId });
-  expect(writeInB2).toMatchObject({
+  expect(await getWriteIn(writeInIdB)).toMatchObject({
     contestId,
     adjudicationType: 'write-in-candidate',
     candidateId: mrPickles!.id,
@@ -233,13 +259,12 @@ test('e2e write-in adjudication', async () => {
   const [, picklesJr] = await apiClient.getWriteInCandidates();
 
   await apiClient.adjudicateWriteIn({
-    writeInId: writeInB1.id,
+    writeInId: writeInIdB,
     type: 'write-in-candidate',
     candidateId: picklesJr!.id,
   });
 
-  const [, writeInB3] = await apiClient.getWriteIns({ contestId });
-  expect(writeInB3).toMatchObject({
+  expect(await getWriteIn(writeInIdB)).toMatchObject({
     contestId,
     adjudicationType: 'write-in-candidate',
     status: 'adjudicated',
@@ -262,7 +287,7 @@ test('e2e write-in adjudication', async () => {
   ]);
 });
 
-test('getWriteInDetailView', async () => {
+test('getWriteInAdjudicationContext', async () => {
   const { auth, apiClient } = buildTestEnvironment();
   const { electionDefinition, manualCastVoteRecordReportSingle } =
     electionGridLayoutNewHampshireAmherstFixtures;
@@ -276,36 +301,142 @@ test('getWriteInDetailView', async () => {
     })
   ).unsafeUnwrap();
 
-  // look at a contest with multiple write-ins possible
+  // look at a contest that can have multiple write-ins per ballot
   const contestId = 'State-Representatives-Hillsborough-District-34-b1012d38';
-  const writeIns = await apiClient.getWriteIns({
+  const writeInIds = await apiClient.getWriteInAdjudicationQueue({
     contestId,
   });
-  expect(writeIns).toHaveLength(2);
+  expect(writeInIds).toHaveLength(2);
 
-  const [writeInA, writeInB] = writeIns;
-  assert(writeInA && writeInB);
+  const [writeInIdA, writeInIdB] = writeInIds;
+  assert(writeInIdA !== undefined && writeInIdB !== undefined);
 
-  // check initial view of first write-in
-  const writeInDetailViewA = await apiClient.getWriteInDetailView({
-    writeInId: writeInA.id,
+  // check image of first write-in
+  const writeInImageViewA = await apiClient.getWriteInImageView({
+    writeInId: writeInIdA,
   });
-  assert(writeInDetailViewA);
+  assert(writeInImageViewA);
 
-  expect(writeInDetailViewA).toMatchObject(
-    typedAs<Partial<WriteInDetailView>>({
-      markedOfficialCandidateIds: ['Obadiah-Carrigan-5c95145a'],
-      writeInAdjudicatedOfficialCandidateIds: [],
-      writeInAdjudicatedWriteInCandidateIds: [],
+  const writeInAdjudicationContextA =
+    await apiClient.getWriteInAdjudicationContext({
+      writeInId: writeInIdA,
+    });
+  assert(writeInAdjudicationContextA);
+
+  expect(writeInAdjudicationContextA).toMatchObject(
+    typedAs<Partial<WriteInAdjudicationContext>>({
+      cvrVotes: expect.objectContaining({
+        [contestId]: expect.arrayContaining(['Obadiah-Carrigan-5c95145a']),
+      }),
+      relatedWriteIns: [
+        expect.objectContaining(
+          typedAs<Partial<WriteInRecord>>({
+            status: 'pending',
+          })
+        ),
+      ],
     })
   );
+
+  // adjudicate first write-in for an official candidate
+  await apiClient.adjudicateWriteIn({
+    writeInId: writeInIdA,
+    type: 'official-candidate',
+    candidateId: 'Mary-Baker-Eddy-350785d5',
+  });
+
+  // check the second write-in detail view, which should show the just-adjudicated write-in
+  const writeInAdjudicationContextB1 =
+    await apiClient.getWriteInAdjudicationContext({
+      writeInId: writeInIdB,
+    });
+
+  expect(writeInAdjudicationContextB1).toMatchObject(
+    typedAs<Partial<WriteInAdjudicationContext>>({
+      cvrVotes: expect.objectContaining({
+        [contestId]: expect.arrayContaining(['Obadiah-Carrigan-5c95145a']),
+      }),
+      relatedWriteIns: [
+        expect.objectContaining(
+          typedAs<Partial<WriteInRecord>>({
+            status: 'adjudicated',
+            adjudicationType: 'official-candidate',
+            candidateId: 'Mary-Baker-Eddy-350785d5',
+          })
+        ),
+      ],
+    })
+  );
+
+  // re-adjudicate the first write-in for a write-in candidate and expect the ids to change
+  const { id: writeInCandidateId } = await apiClient.addWriteInCandidate({
+    contestId,
+    name: 'Bob Hope',
+  });
+  await apiClient.adjudicateWriteIn({
+    writeInId: writeInIdA,
+    type: 'write-in-candidate',
+    candidateId: writeInCandidateId,
+  });
+  const writeInAdjudicationContextB2 =
+    await apiClient.getWriteInAdjudicationContext({
+      writeInId: writeInIdB,
+    });
+
+  expect(writeInAdjudicationContextB2).toMatchObject(
+    typedAs<Partial<WriteInAdjudicationContext>>({
+      cvrVotes: expect.objectContaining({
+        [contestId]: expect.arrayContaining(['Obadiah-Carrigan-5c95145a']),
+      }),
+      relatedWriteIns: [
+        expect.objectContaining(
+          typedAs<Partial<WriteInRecord>>({
+            status: 'adjudicated',
+            adjudicationType: 'write-in-candidate',
+            candidateId: writeInCandidateId,
+          })
+        ),
+      ],
+    })
+  );
+});
+
+test('getWriteInImageView', async () => {
+  const { auth, apiClient } = buildTestEnvironment();
+  const { electionDefinition, manualCastVoteRecordReportSingle } =
+    electionGridLayoutNewHampshireAmherstFixtures;
+  await configureMachine(apiClient, auth, electionDefinition);
+
+  const reportDirectoryPath =
+    manualCastVoteRecordReportSingle.asDirectoryPath();
+  (
+    await apiClient.addCastVoteRecordFile({
+      path: reportDirectoryPath,
+    })
+  ).unsafeUnwrap();
+
+  // look at a contest that can have multiple write-ins per ballot
+  const contestId = 'State-Representatives-Hillsborough-District-34-b1012d38';
+  const writeInIds = await apiClient.getWriteInAdjudicationQueue({
+    contestId,
+  });
+  expect(writeInIds).toHaveLength(2);
+
+  const [writeInIdA, writeInIdB] = writeInIds;
+  assert(writeInIdA !== undefined && writeInIdB !== undefined);
+
+  // check image of first write-in
+  const writeInImageViewA = await apiClient.getWriteInImageView({
+    writeInId: writeInIdA,
+  });
+  assert(writeInImageViewA);
 
   const {
     imageUrl: actualImageUrl,
     ballotCoordinates: ballotCoordinatesA,
     contestCoordinates: contestCoordinatesA,
     writeInCoordinates: writeInCoordinatesA,
-  } = writeInDetailViewA;
+  } = writeInImageViewA;
 
   const expectedBallotCoordinates: Rect = {
     height: 2200,
@@ -347,32 +478,18 @@ test('getWriteInDetailView', async () => {
   );
   expect(actualImageUrl).toEqual(expectedImageUrl);
 
-  // adjudicate first write-in for an official candidate
-  await apiClient.adjudicateWriteIn({
-    writeInId: writeInA.id,
-    type: 'official-candidate',
-    candidateId: 'Mary-Baker-Eddy-350785d5',
+  // check the second write-in image view, which should have the same image
+  // but different writeInCoordinates
+  const writeInImageViewB1 = await apiClient.getWriteInImageView({
+    writeInId: writeInIdB,
   });
-
-  // check the second write-in detail view, which should the just-adjudicated write-in
-  const writeInDetailViewB1 = await apiClient.getWriteInDetailView({
-    writeInId: writeInB.id,
-  });
-
-  expect(writeInDetailViewB1).toMatchObject(
-    typedAs<Partial<WriteInDetailView>>({
-      markedOfficialCandidateIds: ['Obadiah-Carrigan-5c95145a'],
-      writeInAdjudicatedOfficialCandidateIds: ['Mary-Baker-Eddy-350785d5'],
-      writeInAdjudicatedWriteInCandidateIds: [],
-    })
-  );
 
   // contest and ballot coordinates should be the same, but write-in coordinates are different
   const {
     ballotCoordinates: ballotCoordinatesB,
     contestCoordinates: contestCoordinatesB,
     writeInCoordinates: writeInCoordinatesB,
-  } = writeInDetailViewB1;
+  } = writeInImageViewB1;
   expect(ballotCoordinatesB).toEqual(expectedBallotCoordinates);
   expect(contestCoordinatesB).toEqual(expectedContestCoordinates);
   expect(writeInCoordinatesB).toMatchInlineSnapshot(`
@@ -383,26 +500,4 @@ test('getWriteInDetailView', async () => {
       "y": 1366,
     }
   `);
-
-  // re-adjudicate the first write-in for a write-in candidate and expect the id's to change
-  const { id: writeInCandidateId } = await apiClient.addWriteInCandidate({
-    contestId,
-    name: 'Bob Hope',
-  });
-  await apiClient.adjudicateWriteIn({
-    writeInId: writeInA.id,
-    type: 'write-in-candidate',
-    candidateId: writeInCandidateId,
-  });
-  const writeInDetailViewB2 = await apiClient.getWriteInDetailView({
-    writeInId: writeInB.id,
-  });
-
-  expect(writeInDetailViewB2).toMatchObject(
-    typedAs<Partial<WriteInDetailView>>({
-      markedOfficialCandidateIds: ['Obadiah-Carrigan-5c95145a'],
-      writeInAdjudicatedOfficialCandidateIds: [],
-      writeInAdjudicatedWriteInCandidateIds: [writeInCandidateId],
-    })
-  );
 });

--- a/apps/admin/backend/src/cvr_files.ts
+++ b/apps/admin/backend/src/cvr_files.ts
@@ -520,7 +520,7 @@ export async function addCastVoteRecordReport({
   }
   const { CVR: unparsedCastVoteRecords, ...reportMetadata } =
     getCastVoteRecordReportImportResult.ok();
-  debug('read cast vote record metadata');
+  debug('read cast vote record metadata from file');
 
   // Ensure the report matches the file mode of previous imports
   const reportFileMode = isTestReport(reportMetadata) ? 'test' : 'official';
@@ -573,8 +573,8 @@ export async function addCastVoteRecordReport({
       sha256Hash,
       scannerIds,
     });
-    debug('added cast vote record file record');
-    debug('importing individual cvrs...');
+    debug('added cast vote record file record %s', fileId);
+    debug('begin importing individual cvrs...');
 
     // Iterate through all the cast vote records
     let castVoteRecordIndex = 0;
@@ -722,7 +722,7 @@ export async function addCastVoteRecordReport({
 
       castVoteRecordIndex += 1;
     }
-    debug('imported all individual cvrs');
+    debug('imported all cvrs');
 
     // TODO: Calculate the precinct list before iterating through records, once there is
     // only one geopolitical unit per batch in the future.
@@ -730,7 +730,7 @@ export async function addCastVoteRecordReport({
       id: fileId,
       precinctIds,
     });
-    debug('updated cast vote record file record');
+    debug('updated cast vote record file record %s', fileId);
 
     return ok({
       id: fileId,

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -43,8 +43,6 @@ import {
   CastVoteRecordFileRecord,
   CastVoteRecordFileRecordSchema,
   CvrFileMode,
-  DatabaseSerializedCastVoteRecordVotes,
-  DatabaseSerializedCastVoteRecordVotesSchema,
   ElectionRecord,
   ManualResultsIdentifier,
   ManualResultsMetadataRecord,
@@ -680,62 +678,84 @@ export class Store {
   }
 
   /**
-   * Returns the data necessary to display a single write-in.
+   * Returns the write-in image and layout.
    */
-  getWriteInWithDetails(writeInId: Id): {
+  getWriteInImageAndLayout(writeInId: Id): {
     writeInId: Id;
     contestId: ContestId;
     optionId: ContestOptionId;
+    cvrId: Id;
     image: Buffer;
     layout: BallotPageLayout;
-    castVoteRecordId: Id;
-    castVoteRecordVotes: DatabaseSerializedCastVoteRecordVotes;
   } {
-    const writeInWithDetails = this.client.one(
+    const row = this.client.one(
+      `
+          select
+            write_ins.id as writeInId,
+            write_ins.contest_id as contestId,
+            write_ins.option_id as optionId,
+            write_ins.cvr_id as cvrId,
+            ballot_images.image as image,
+            ballot_images.layout as layout
+          from write_ins
+          inner join
+            ballot_images on 
+              write_ins.cvr_id = ballot_images.cvr_id and 
+              write_ins.side = ballot_images.side
+          where write_ins.id = ?
+        `,
+      writeInId
+    ) as {
+      writeInId: Id;
+      contestId: ContestId;
+      optionId: ContestOptionId;
+      cvrId: string;
+      image: Buffer;
+      layout: string;
+    };
+
+    return {
+      ...row,
+      layout: safeParseJson(row.layout, BallotPageLayoutSchema).unsafeUnwrap(),
+    };
+  }
+
+  /**
+   * Returns the write-in ids with votes on the associated CVR.
+   */
+  getWriteInWithVotes(writeInId: Id): {
+    writeInId: Id;
+    contestId: ContestId;
+    optionId: ContestOptionId;
+    cvrId: Id;
+    cvrVotes: Tabulation.Votes;
+  } {
+    const row = this.client.one(
       `
         select
           write_ins.id as writeInId,
           write_ins.contest_id as contestId,
           write_ins.option_id as optionId,
-          ballot_images.image as image,
-          ballot_images.layout as layout,
-          cvrs.votes as castVoteRecordVotes,
-          write_ins.cvr_id as castVoteRecordId
+          cvrs.votes as cvrVotes,
+          write_ins.cvr_id as cvrId
         from write_ins
-        inner join
-          ballot_images on 
-            write_ins.cvr_id = ballot_images.cvr_id and 
-            write_ins.side = ballot_images.side
         inner join
           cvrs on
             write_ins.cvr_id = cvrs.id
         where write_ins.id = ?
       `,
       writeInId
-    ) as
-      | {
-          writeInId: Id;
-          contestId: ContestId;
-          optionId: ContestOptionId;
-          image: Buffer;
-          layout: string;
-          castVoteRecordVotes: string;
-          castVoteRecordId: string;
-        }
-      | undefined;
-
-    assert(writeInWithDetails, 'write-in does not exist');
+    ) as {
+      writeInId: Id;
+      contestId: ContestId;
+      optionId: ContestOptionId;
+      cvrVotes: string;
+      cvrId: string;
+    };
 
     return {
-      ...writeInWithDetails,
-      layout: safeParseJson(
-        writeInWithDetails.layout,
-        BallotPageLayoutSchema
-      ).unsafeUnwrap(),
-      castVoteRecordVotes: safeParseJson(
-        writeInWithDetails.castVoteRecordVotes,
-        DatabaseSerializedCastVoteRecordVotesSchema
-      ).unsafeUnwrap(),
+      ...row,
+      cvrVotes: JSON.parse(row.cvrVotes),
     };
   }
 
@@ -1202,7 +1222,10 @@ export class Store {
     electionId: Id;
     contestId?: ContestId;
   }): WriteInAdjudicationQueueMetadata[] {
-    debug('querying database for write-in queue metadata');
+    debug(
+      'querying database for write-in adjudication queue metadata for contest %s',
+      contestId
+    );
     const whereParts: string[] = ['write_ins.election_id = ?'];
     const params: Bindable[] = [electionId];
 
@@ -1233,7 +1256,7 @@ export class Store {
       totalTally: number;
       pendingTally: number;
     }>;
-    debug('queried database for write-in queue metadata');
+    debug('queried database for write-in adjudication queue metadata');
     return rows;
   }
 
@@ -1471,6 +1494,47 @@ export class Store {
         });
       })
       .filter((writeInRecord) => writeInRecord.status === status || !status);
+  }
+
+  /**
+   * Gets write-in record adjudication queue for a specific contest.
+   */
+  getWriteInAdjudicationQueue({
+    electionId,
+    contestId,
+  }: {
+    electionId: Id;
+    contestId?: ContestId;
+  }): Id[] {
+    this.assertElectionExists(electionId);
+
+    const whereParts: string[] = ['election_id = ?'];
+    const params: Bindable[] = [electionId];
+
+    if (contestId) {
+      whereParts.push('contest_id = ?');
+      params.push(contestId);
+    }
+
+    debug(
+      'querying database for write-in adjudication for contest %s',
+      contestId
+    );
+    const rows = this.client.all(
+      `
+        select
+          id
+        from write_ins
+        where
+          ${whereParts.join(' and ')}
+        order by
+          sequence_id
+      `,
+      ...params
+    ) as Array<{ id: Id }>;
+    debug('queried database for write-in adjudication queue');
+
+    return rows.map((r) => r.id);
   }
 
   /**

--- a/apps/admin/backend/src/util/write_ins.ts
+++ b/apps/admin/backend/src/util/write_ins.ts
@@ -1,70 +1,25 @@
-import { assertDefined } from '@votingworks/basics';
-import { CandidateId, Id, safeParseNumber } from '@votingworks/types';
+import { assertDefined, find } from '@votingworks/basics';
+import { Id, safeParseNumber } from '@votingworks/types';
 import { loadImageData, toDataUrl } from '@votingworks/image-utils';
 import { Store } from '../store';
-import {
-  WriteInDetailView,
-  WriteInRecordAdjudicatedOfficialCandidate,
-  WriteInRecordAdjudicatedWriteInCandidate,
-} from '../types';
+import { WriteInAdjudicationContext, WriteInImageView } from '../types';
+import { rootDebug } from './debug';
+
+const debug = rootDebug.extend('write-ins');
 
 /**
- * Retrieves and compiles the data necessary to adjudicate a write-in (image,
- * layout, disallowed votes)
+ * Retrieves data necessary to display a write-in image on the frontend.
  */
-export async function getWriteInDetailView({
+export async function getWriteInImageView({
   store,
   writeInId,
 }: {
   store: Store;
   writeInId: Id;
-}): Promise<WriteInDetailView> {
-  const writeInDetails = store.getWriteInWithDetails(writeInId);
-  const {
-    contestId,
-    optionId,
-    layout,
-    image,
-    castVoteRecordVotes,
-    castVoteRecordId,
-  } = writeInDetails;
-  const electionId = assertDefined(store.getCurrentElectionId());
-
-  // get valid adjudicated write-ins from same ballot, same contest, different options
-  const otherWriteIns = store
-    .getWriteInRecords({
-      electionId,
-      contestId,
-      castVoteRecordId,
-    })
-    .filter(
-      (
-        writeInRecord
-      ): writeInRecord is
-        | WriteInRecordAdjudicatedOfficialCandidate
-        | WriteInRecordAdjudicatedWriteInCandidate =>
-        writeInRecord.optionId !== writeInDetails.optionId &&
-        writeInRecord.status === 'adjudicated' &&
-        (writeInRecord.adjudicationType === 'official-candidate' ||
-          writeInRecord.adjudicationType === 'write-in-candidate')
-    );
-
-  // calculate illegal adjudications for current write-in based on the other
-  // marked or adjudicated candidates
-  const markedOfficialCandidateIds = (
-    (castVoteRecordVotes[contestId] as CandidateId[]) ?? []
-  ).filter((candidateId) => !candidateId.startsWith('write-in-'));
-
-  const writeInAdjudicatedOfficialCandidateIds: CandidateId[] = [];
-  const writeInAdjudicatedWriteInCandidateIds: string[] = [];
-
-  for (const otherWriteIn of otherWriteIns) {
-    if (otherWriteIn.adjudicationType === 'official-candidate') {
-      writeInAdjudicatedOfficialCandidateIds.push(otherWriteIn.candidateId);
-    } else if (otherWriteIn.adjudicationType === 'write-in-candidate') {
-      writeInAdjudicatedWriteInCandidateIds.push(otherWriteIn.candidateId);
-    }
-  }
+}): Promise<WriteInImageView> {
+  debug('creating write-in image view for %s...', writeInId);
+  const writeInDetails = store.getWriteInImageAndLayout(writeInId);
+  const { layout, image, contestId, optionId, cvrId } = writeInDetails;
 
   // identify the contest layout
   const contestLayout = layout.contests.find(
@@ -89,7 +44,10 @@ export async function getWriteInDetailView({
     throw new Error('unexpected write-in option index');
   }
 
+  debug('created write-in image view');
   return {
+    writeInId,
+    cvrId,
     imageUrl: toDataUrl(await loadImageData(image), 'image/jpeg'),
     ballotCoordinates: {
       ...layout.pageSize,
@@ -98,8 +56,47 @@ export async function getWriteInDetailView({
     },
     contestCoordinates: contestLayout.bounds,
     writeInCoordinates: writeInLayout.bounds,
-    markedOfficialCandidateIds,
-    writeInAdjudicatedOfficialCandidateIds,
-    writeInAdjudicatedWriteInCandidateIds,
+  };
+}
+
+/**
+ * Retrieves and compiles the data necessary to adjudicate a write-in (image,
+ * layout, disallowed votes)
+ */
+export function getWriteInAdjudicationContext({
+  store,
+  writeInId,
+}: {
+  store: Store;
+  writeInId: Id;
+}): WriteInAdjudicationContext {
+  debug('creating write-in adjudication context for %s...', writeInId);
+  debug('getting write-in record with votes...');
+  const writeInContext = store.getWriteInWithVotes(writeInId);
+  const { contestId, optionId, cvrVotes, cvrId } = writeInContext;
+  const electionId = assertDefined(store.getCurrentElectionId());
+
+  debug('getting all write-in records for the current cvr and contest...');
+  const allWriteInRecords = store.getWriteInRecords({
+    electionId,
+    contestId,
+    castVoteRecordId: cvrId,
+  });
+
+  const primaryWriteIn = find(
+    allWriteInRecords,
+    (writeInRecord) => writeInRecord.optionId === optionId
+  );
+
+  const relatedWriteIns = allWriteInRecords.filter(
+    (writeInRecord) => writeInRecord.optionId !== optionId
+  );
+
+  debug('created write-in adjudication context');
+  return {
+    writeIn: primaryWriteIn,
+    relatedWriteIns,
+    cvrId,
+    cvrVotes,
   };
 }

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -231,6 +231,25 @@ export const getWriteInAdjudicationQueue = {
   },
 } as const;
 
+type GetFirstPendingWriteInIdInput = QueryInput<'getFirstPendingWriteInId'>;
+export const getFirstPendingWriteInId = {
+  queryKey(input?: GetFirstPendingWriteInIdInput): QueryKey {
+    return input
+      ? ['getFirstPendingWriteInId', input]
+      : ['getFirstPendingWriteInId'];
+  },
+  useQuery(input: GetFirstPendingWriteInIdInput) {
+    const apiClient = useApiClient();
+    return useQuery(
+      this.queryKey(input),
+      () => apiClient.getFirstPendingWriteInId(input),
+      {
+        cacheTime: 0,
+      }
+    );
+  },
+} as const;
+
 type GetWriteInAdjudicationQueueMetadataInput =
   QueryInput<'getWriteInAdjudicationQueueMetadata'>;
 export const getWriteInAdjudicationQueueMetadata = {

--- a/apps/admin/frontend/src/components/adjudication_ballot_image_viewer.tsx
+++ b/apps/admin/frontend/src/components/adjudication_ballot_image_viewer.tsx
@@ -1,0 +1,140 @@
+import React, { useState } from 'react';
+import { Button, Icons } from '@votingworks/ui';
+import styled from 'styled-components';
+import { Rect } from '@votingworks/types';
+
+const BallotImageViewerContainer = styled.div`
+  position: relative;
+  height: 100%;
+  overflow: hidden;
+`;
+
+// We zoom in by scaling (setting the width) and then translating to center the
+// write-in on the screen (setting the top/left position).
+const ZoomedInBallotImage = styled.img<{
+  ballotBounds: Rect;
+  writeInBounds: Rect;
+  scale: number;
+}>`
+  position: absolute;
+  top: calc(
+    (
+      50% -
+        ${(props) =>
+          (props.writeInBounds.y + props.writeInBounds.height / 2) *
+          props.scale}px
+    )
+  );
+  left: calc(
+    (
+      50% -
+        ${(props) =>
+          (props.writeInBounds.x + props.writeInBounds.width / 2) *
+          props.scale}px
+    )
+  );
+  width: ${(props) => props.ballotBounds.width * props.scale}px;
+`;
+
+// We want to create a transparent overlay with a centered rectangle cut out of
+// it of the size of the write-in area. There's not a super easy way to do this
+// in CSS. Based on an idea from https://css-tricks.com/cutouts/, I used this
+// tool to design the clipping path, https://bennettfeely.com/clippy/, and then
+// parameterized it with the focus area width and height.
+const WriteInFocusOverlay = styled.div<{
+  focusWidth: number;
+  focusHeight: number;
+}>`
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
+  background: rgba(0, 0, 0, 0.5);
+  width: 100%;
+  height: 100%;
+  clip-path: polygon(
+    0% 0%,
+    0% 100%,
+    calc(50% - ${(props) => props.focusWidth / 2}px) 100%,
+    calc(50% - ${(props) => props.focusWidth / 2}px)
+      calc(50% - ${(props) => props.focusHeight / 2}px),
+    calc(50% + ${(props) => props.focusWidth / 2}px)
+      calc(50% - ${(props) => props.focusHeight / 2}px),
+    calc(50% + ${(props) => props.focusWidth / 2}px)
+      calc(50% + ${(props) => props.focusHeight / 2}px),
+    calc(50% - ${(props) => props.focusWidth / 2}px)
+      calc(50% + ${(props) => props.focusHeight / 2}px),
+    calc(50% - ${(props) => props.focusWidth / 2}px) 100%,
+    100% 100%,
+    100% 0%
+  );
+`;
+
+// Full-width image with vertical scrolling.
+const ZoomedOutBallotImageContainer = styled.div`
+  height: 100%;
+  overflow-y: scroll;
+  img {
+    width: 100%;
+  }
+`;
+
+const BallotImageViewerControls = styled.div<{ isZoomedIn: boolean }>`
+  display: flex;
+  justify-content: flex-end;
+  position: absolute;
+  top: 0;
+  z-index: 2;
+  background: ${(props) => (!props.isZoomedIn ? 'rgba(0, 0, 0, 0.5)' : 'none')};
+  width: 100%;
+  padding: 0.5rem;
+  gap: 0.5rem;
+`;
+
+export function BallotImageViewer({
+  imageUrl,
+  ballotBounds,
+  writeInBounds,
+}: {
+  imageUrl: string;
+  ballotBounds: Rect;
+  writeInBounds: Rect;
+}): JSX.Element {
+  const [isZoomedIn, setIsZoomedIn] = useState(true);
+
+  const IMAGE_SCALE = 0.5; // The images are downscaled by 50% during CVR export, this is to adjust for that.
+  const zoomedInScale =
+    (ballotBounds.width / writeInBounds.width) * IMAGE_SCALE;
+
+  return (
+    <BallotImageViewerContainer>
+      <BallotImageViewerControls isZoomedIn={isZoomedIn}>
+        <Button onPress={() => setIsZoomedIn(false)} disabled={!isZoomedIn}>
+          <Icons.ZoomOut /> Zoom Out
+        </Button>
+        <Button onPress={() => setIsZoomedIn(true)} disabled={isZoomedIn}>
+          <Icons.ZoomIn /> Zoom In
+        </Button>
+      </BallotImageViewerControls>
+      {isZoomedIn ? (
+        <React.Fragment>
+          <WriteInFocusOverlay
+            focusWidth={writeInBounds.width * zoomedInScale}
+            focusHeight={writeInBounds.height * zoomedInScale}
+          />
+          <ZoomedInBallotImage
+            src={imageUrl}
+            alt="Ballot with write-in highlighted"
+            ballotBounds={ballotBounds}
+            writeInBounds={writeInBounds}
+            scale={zoomedInScale}
+          />
+        </React.Fragment>
+      ) : (
+        <ZoomedOutBallotImageContainer>
+          <img src={imageUrl} alt="Full ballot" />
+        </ZoomedOutBallotImageContainer>
+      )}
+    </BallotImageViewerContainer>
+  );
+}

--- a/apps/admin/frontend/src/components/adjudication_double_vote_alert_modal.tsx
+++ b/apps/admin/frontend/src/components/adjudication_double_vote_alert_modal.tsx
@@ -1,0 +1,68 @@
+import { throwIllegalValue } from '@votingworks/basics';
+import { Button, Font, Modal, P } from '@votingworks/ui';
+
+export interface DoubleVoteAlert {
+  type:
+    | 'marked-official-candidate'
+    | 'adjudicated-write-in-candidate'
+    | 'adjudicated-official-candidate';
+  name: string;
+}
+
+export function DoubleVoteAlertModal({
+  doubleVoteAlert,
+  onClose,
+}: {
+  doubleVoteAlert: DoubleVoteAlert;
+  onClose: () => void;
+}): JSX.Element {
+  const { type, name } = doubleVoteAlert;
+  const text = (() => {
+    switch (type) {
+      case 'marked-official-candidate':
+        return (
+          <P>
+            The current ballot contest has a bubble selection marked for{' '}
+            <Font weight="bold">{name}</Font>, so adjudicating the current
+            write-in for <Font weight="bold">{name}</Font> would create a double
+            vote.
+            <br />
+            <br />
+            If the ballot contest does indeed contain a double vote, you can
+            invalidate this write-in by selecting{' '}
+            <Font weight="bold">Mark Write-In Invalid</Font>.
+          </P>
+        );
+      case 'adjudicated-official-candidate':
+      case 'adjudicated-write-in-candidate':
+        return (
+          <P>
+            The current ballot contest has a write-in that has already been
+            adjudicated for <Font weight="bold">{name}</Font>, so the current
+            write-in cannot also be adjudicated for{' '}
+            <Font weight="bold">{name}</Font>.
+            <br />
+            <br />
+            If the ballot contest does indeed contain a double vote, you can
+            invalidate this write-in by selecting{' '}
+            <Font weight="bold">Mark Write-In Invalid</Font>.
+          </P>
+        );
+      /* istanbul ignore next */
+      default:
+        throwIllegalValue(type);
+    }
+  })();
+
+  return (
+    <Modal
+      title="Possible Double Vote Detected"
+      content={text}
+      actions={
+        <Button variant="regular" onPress={onClose}>
+          Cancel
+        </Button>
+      }
+    />
+  );
+}

--- a/apps/admin/frontend/src/screens/write_ins_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/write_ins_adjudication_screen.test.tsx
@@ -1,11 +1,9 @@
 import { electionMinimalExhaustiveSampleDefinition as electionDefinition } from '@votingworks/fixtures';
-import { CandidateContest, ContestId } from '@votingworks/types';
+import { ContestId } from '@votingworks/types';
 import userEvent from '@testing-library/user-event';
 import {
   WriteInCandidateRecord,
-  WriteInDetailView,
-  WriteInRecord,
-  WriteInRecordPending,
+  WriteInImageView,
 } from '@votingworks/admin-backend';
 import { Route } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
@@ -17,17 +15,11 @@ import {
 import { WriteInsAdjudicationScreen } from './write_ins_adjudication_screen';
 import { ApiMock, createApiMock } from '../../test/helpers/api_mock';
 
-const contest = electionDefinition.election.contests[0] as CandidateContest;
-
-function mockWriteInRecordPending(id: string): WriteInRecordPending {
-  return {
-    id,
-    contestId: 'zoo-council-mammal',
-    optionId: 'write-in-0',
-    castVoteRecordId: 'id',
-    status: 'pending',
-  };
-}
+const mockPartialWriteInIdentifier = {
+  contestId: 'contest-id',
+  optionId: 'write-in-0',
+  castVoteRecordId: 'cast-vote-record-id',
+} as const;
 
 let apiMock: ApiMock;
 
@@ -54,8 +46,30 @@ function renderScreen(
   );
 }
 
+function expectGetQueueMetadata({
+  total,
+  pending,
+  contestId,
+}: {
+  total: number;
+  pending: number;
+  contestId: ContestId;
+}): void {
+  apiMock.expectGetWriteInAdjudicationQueueMetadata(
+    [
+      {
+        totalTally: total,
+        pendingTally: pending,
+        contestId,
+      },
+    ],
+    contestId
+  );
+}
+
 test('zoomable ballot image', async () => {
-  function fakeWriteInImage(id: string): Partial<WriteInDetailView> {
+  const contestId = 'best-animal-mammal';
+  function fakeWriteInImage(id: string): Partial<WriteInImageView> {
     return {
       imageUrl: `fake-image-data-${id}`,
       ballotCoordinates: {
@@ -78,30 +92,16 @@ test('zoomable ballot image', async () => {
       },
     };
   }
-  apiMock.expectGetWriteInDetailView('id-174', fakeWriteInImage('174'));
-  apiMock.expectGetWriteInDetailView('id-175', fakeWriteInImage('175'));
-  apiMock.expectGetWriteIns(
-    [
-      {
-        id: 'id-174',
-        status: 'pending',
-        contestId: contest.id,
-        optionId: 'write-in-0',
-        castVoteRecordId: 'id-174',
-      },
-      {
-        id: 'id-175',
-        status: 'pending',
-        contestId: contest.id,
-        optionId: 'write-in-0',
-        castVoteRecordId: 'id',
-      },
-    ],
-    contest.id
-  );
-  apiMock.expectGetWriteInCandidates([], contest.id);
 
-  renderScreen(contest.id, {
+  apiMock.expectGetWriteInAdjudicationQueue(['id-174', 'id-175'], contestId);
+  expectGetQueueMetadata({ total: 2, pending: 2, contestId });
+  apiMock.expectGetWriteInCandidates([], contestId);
+  apiMock.expectGetWriteInImageView('id-174', fakeWriteInImage('174'));
+  apiMock.expectGetWriteInAdjudicationContext('id-174');
+  apiMock.expectGetWriteInImageView('id-175', fakeWriteInImage('175'));
+  apiMock.expectGetWriteInAdjudicationContext('id-175');
+
+  renderScreen(contestId, {
     electionDefinition,
     apiMock,
   });
@@ -177,22 +177,19 @@ test('zoomable ballot image', async () => {
 });
 
 describe('preventing double votes', () => {
-  const mockWriteInRecord: WriteInRecord = {
-    id: 'id',
-    status: 'pending',
-    contestId: contest.id,
-    optionId: 'write-in-0',
-    castVoteRecordId: 'id',
-  };
+  const contestId = 'best-animal-mammal';
+  const writeInId = 'id';
 
   test('previous bubble marked official candidates', async () => {
-    apiMock.expectGetWriteIns([mockWriteInRecord], contest.id);
-    apiMock.expectGetWriteInDetailView('id', {
-      markedOfficialCandidateIds: ['fox'],
+    apiMock.expectGetWriteInAdjudicationQueue([writeInId], contestId);
+    expectGetQueueMetadata({ total: 1, pending: 1, contestId });
+    apiMock.expectGetWriteInCandidates([], contestId);
+    apiMock.expectGetWriteInImageView(writeInId);
+    apiMock.expectGetWriteInAdjudicationContext(writeInId, {
+      cvrVotes: { [contestId]: ['fox'] },
     });
-    apiMock.expectGetWriteInCandidates([], contest.id);
 
-    renderScreen(contest.id, {
+    renderScreen(contestId, {
       electionDefinition,
       apiMock,
     });
@@ -207,13 +204,25 @@ describe('preventing double votes', () => {
   });
 
   test('previous adjudicated official candidates', async () => {
-    apiMock.expectGetWriteIns([mockWriteInRecord], contest.id);
-    apiMock.expectGetWriteInDetailView('id', {
-      writeInAdjudicatedOfficialCandidateIds: ['fox'],
+    apiMock.expectGetWriteInAdjudicationQueue([writeInId], contestId);
+    expectGetQueueMetadata({ total: 1, pending: 1, contestId });
+    apiMock.expectGetWriteInCandidates([], contestId);
+    apiMock.expectGetWriteInImageView(writeInId);
+    apiMock.expectGetWriteInAdjudicationContext('id', {
+      relatedWriteIns: [
+        {
+          id: 'id',
+          status: 'adjudicated',
+          adjudicationType: 'official-candidate',
+          contestId,
+          candidateId: 'fox',
+          optionId: 'write-in-0',
+          castVoteRecordId: 'id',
+        },
+      ],
     });
-    apiMock.expectGetWriteInCandidates([], contest.id);
 
-    renderScreen(contest.id, {
+    renderScreen(contestId, {
       electionDefinition,
       apiMock,
     });
@@ -231,16 +240,29 @@ describe('preventing double votes', () => {
     const mockWriteInCandidate: WriteInCandidateRecord = {
       id: 'puma',
       electionId: 'id',
-      contestId: contest.id,
+      contestId,
       name: 'Puma',
     };
-    apiMock.expectGetWriteIns([mockWriteInRecord], contest.id);
-    apiMock.expectGetWriteInDetailView('id', {
-      writeInAdjudicatedWriteInCandidateIds: ['puma'],
-    });
-    apiMock.expectGetWriteInCandidates([mockWriteInCandidate], contest.id);
 
-    renderScreen(contest.id, {
+    apiMock.expectGetWriteInCandidates([mockWriteInCandidate], contestId);
+    apiMock.expectGetWriteInAdjudicationQueue([writeInId], contestId);
+    expectGetQueueMetadata({ total: 1, pending: 1, contestId });
+    apiMock.expectGetWriteInImageView(writeInId);
+    apiMock.expectGetWriteInAdjudicationContext('id', {
+      relatedWriteIns: [
+        {
+          id: 'id',
+          status: 'adjudicated',
+          adjudicationType: 'write-in-candidate',
+          contestId,
+          candidateId: mockWriteInCandidate.id,
+          optionId: 'write-in-0',
+          castVoteRecordId: 'id',
+        },
+      ],
+    });
+
+    renderScreen(contestId, {
       electionDefinition,
       apiMock,
     });
@@ -257,12 +279,15 @@ describe('preventing double votes', () => {
 
 test('ballot pagination', async () => {
   const contestId = 'zoo-council-mammal';
-  const mockWriteInRecords = ['0', '1', '2'].map(mockWriteInRecordPending);
-  const pageCount = mockWriteInRecords.length;
-  apiMock.expectGetWriteIns(mockWriteInRecords, contestId);
+  const writeInIds = ['0', '1', '2'];
+  const pageCount = writeInIds.length;
+
+  apiMock.expectGetWriteInAdjudicationQueue(writeInIds, contestId);
+  expectGetQueueMetadata({ total: 3, pending: 3, contestId });
   apiMock.expectGetWriteInCandidates([], contestId);
-  for (const mockWriteInRecord of mockWriteInRecords) {
-    apiMock.expectGetWriteInDetailView(mockWriteInRecord.id);
+  for (const writeInId of writeInIds) {
+    apiMock.expectGetWriteInImageView(writeInId);
+    apiMock.expectGetWriteInAdjudicationContext(writeInId);
   }
 
   const history = createMemoryHistory();
@@ -295,19 +320,23 @@ test('ballot pagination', async () => {
   }
 });
 
-test('adjudication flow', async () => {
+test('marking adjudications', async () => {
   const contestId = 'zoo-council-mammal';
-  const mockWriteInRecords = ['0', '1'].map(mockWriteInRecordPending);
-  apiMock.expectGetWriteIns(mockWriteInRecords, contestId);
+  const writeInIds = ['0', '1'];
   const mockWriteInCandidate: WriteInCandidateRecord = {
     id: 'lemur',
     name: 'Lemur',
     contestId: 'zoo-council-mammal',
     electionId: 'id',
   };
+
+  apiMock.expectGetWriteInAdjudicationQueue(writeInIds, contestId);
   apiMock.expectGetWriteInCandidates([mockWriteInCandidate], contestId);
-  apiMock.expectGetWriteInDetailView(mockWriteInRecords[0].id);
-  apiMock.expectGetWriteInDetailView(mockWriteInRecords[1].id); // prefetch
+  apiMock.expectGetWriteInImageView(writeInIds[0]);
+  apiMock.expectGetWriteInImageView(writeInIds[1]); // expected image prefetch
+  apiMock.expectGetWriteInAdjudicationContext(writeInIds[0]);
+  expectGetQueueMetadata({ total: 2, pending: 2, contestId });
+
   renderScreen(contestId, {
     electionDefinition,
     apiMock,
@@ -321,33 +350,24 @@ test('adjudication flow', async () => {
   screen.getButton('Lemur');
 
   // adjudicate for official candidate
-  const partialMockAdjudicatedWriteIn = {
-    id: '0',
-    contestId: 'zoo-council-mammal',
-    optionId: 'write-in-0',
-    castVoteRecordId: 'id',
-    status: 'adjudicated',
-  } as const;
   apiMock.apiClient.adjudicateWriteIn
     .expectCallWith({
-      writeInId: mockWriteInRecords[0].id,
+      writeInId: writeInIds[0],
       type: 'official-candidate',
       candidateId: 'zebra',
     })
     .resolves();
-  apiMock.expectGetWriteIns(
-    [
-      {
-        ...partialMockAdjudicatedWriteIn,
-        adjudicationType: 'official-candidate',
-        candidateId: 'zebra',
-      },
-      mockWriteInRecords[1],
-    ],
-    contestId
-  );
+  apiMock.expectGetWriteInAdjudicationContext(writeInIds[0], {
+    writeIn: {
+      id: writeInIds[0],
+      ...mockPartialWriteInIdentifier,
+      status: 'adjudicated',
+      adjudicationType: 'official-candidate',
+      candidateId: 'zebra',
+    },
+  });
   apiMock.expectGetWriteInCandidates([mockWriteInCandidate], contestId);
-  apiMock.expectGetWriteInDetailView(mockWriteInRecords[1].id);
+  expectGetQueueMetadata({ total: 2, pending: 1, contestId });
 
   userEvent.click(screen.getButton('Zebra'));
   await waitFor(async () =>
@@ -361,24 +381,23 @@ test('adjudication flow', async () => {
   // adjudicate for existing write-in candidate
   apiMock.apiClient.adjudicateWriteIn
     .expectCallWith({
-      writeInId: mockWriteInRecords[0].id,
+      writeInId: writeInIds[0],
       type: 'write-in-candidate',
       candidateId: 'lemur',
     })
     .resolves();
-  apiMock.expectGetWriteIns(
-    [
-      {
-        ...partialMockAdjudicatedWriteIn,
-        adjudicationType: 'write-in-candidate',
-        candidateId: 'lemur',
-      },
-      mockWriteInRecords[1],
-    ],
-    contestId
-  );
+  apiMock.expectGetWriteInAdjudicationContext(writeInIds[0], {
+    writeIn: {
+      id: writeInIds[0],
+      ...mockPartialWriteInIdentifier,
+      status: 'adjudicated',
+      adjudicationType: 'write-in-candidate',
+      candidateId: 'lemur',
+    },
+  });
   apiMock.expectGetWriteInCandidates([mockWriteInCandidate], contestId);
-  apiMock.expectGetWriteInDetailView(mockWriteInRecords[1].id);
+  expectGetQueueMetadata({ total: 2, pending: 1, contestId });
+
   userEvent.click(screen.getButton('Lemur'));
   await waitFor(async () =>
     expect(await screen.findButton('Next')).toHaveFocus()
@@ -400,22 +419,11 @@ test('adjudication flow', async () => {
     .resolves(mockNewWriteInCandidateRecord);
   apiMock.apiClient.adjudicateWriteIn
     .expectCallWith({
-      writeInId: mockWriteInRecords[0].id,
+      writeInId: writeInIds[0],
       type: 'write-in-candidate',
       candidateId: 'dh',
     })
     .resolves();
-  apiMock.expectGetWriteIns(
-    [
-      {
-        ...partialMockAdjudicatedWriteIn,
-        adjudicationType: 'official-candidate',
-        candidateId: 'dh',
-      },
-      mockWriteInRecords[1],
-    ],
-    contestId
-  );
   apiMock.expectGetWriteInCandidates(
     [mockWriteInCandidate, mockNewWriteInCandidateRecord],
     contestId
@@ -424,7 +432,16 @@ test('adjudication flow', async () => {
     [mockWriteInCandidate, mockNewWriteInCandidateRecord],
     contestId
   );
-  apiMock.expectGetWriteInDetailView(mockWriteInRecords[1].id);
+  apiMock.expectGetWriteInAdjudicationContext(writeInIds[0], {
+    writeIn: {
+      id: writeInIds[0],
+      ...mockPartialWriteInIdentifier,
+      status: 'adjudicated',
+      adjudicationType: 'write-in-candidate',
+      candidateId: 'dh',
+    },
+  });
+  expectGetQueueMetadata({ total: 2, pending: 1, contestId });
   userEvent.click(await screen.findButton(/Add New Write-In Candidate/i));
   userEvent.type(
     await screen.findByPlaceholderText('Candidate Name'),
@@ -440,22 +457,20 @@ test('adjudication flow', async () => {
   // adjudicate as invalid
   apiMock.apiClient.adjudicateWriteIn
     .expectCallWith({
-      writeInId: mockWriteInRecords[0].id,
+      writeInId: writeInIds[0],
       type: 'invalid',
     })
     .resolves();
-  apiMock.expectGetWriteIns(
-    [
-      {
-        ...partialMockAdjudicatedWriteIn,
-        adjudicationType: 'invalid',
-      },
-      mockWriteInRecords[1],
-    ],
-    contestId
-  );
+  apiMock.expectGetWriteInAdjudicationContext(writeInIds[0], {
+    writeIn: {
+      id: writeInIds[0],
+      ...mockPartialWriteInIdentifier,
+      status: 'adjudicated',
+      adjudicationType: 'invalid',
+    },
+  });
   apiMock.expectGetWriteInCandidates([mockWriteInCandidate], contestId);
-  apiMock.expectGetWriteInDetailView(mockWriteInRecords[1].id);
+  expectGetQueueMetadata({ total: 2, pending: 1, contestId });
   userEvent.click(await screen.findButton(/Mark Write-In Invalid/i));
   await waitFor(async () =>
     expect(await screen.findButton('Next')).toHaveFocus()

--- a/apps/admin/frontend/test/helpers/api_mock.ts
+++ b/apps/admin/frontend/test/helpers/api_mock.ts
@@ -8,12 +8,12 @@ import type {
   ManualResultsIdentifier,
   ManualResultsMetadataRecord,
   WriteInCandidateRecord,
-  WriteInDetailView,
-  WriteInRecord,
+  WriteInAdjudicationContext,
   SemsExportableTallies,
   ScannerBatch,
   TallyReportResults,
   WriteInAdjudicationQueueMetadata,
+  WriteInImageView,
 } from '@votingworks/admin-backend';
 import { ok } from '@votingworks/basics';
 import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
@@ -28,6 +28,7 @@ import {
   DEFAULT_SYSTEM_SETTINGS,
   DippedSmartCardAuth,
   ElectionDefinition,
+  Id,
   Rect,
   SystemSettings,
   Tabulation,
@@ -196,13 +197,15 @@ export function createApiMock(
       }
     },
 
-    expectGetWriteIns(writeInRecords: WriteInRecord[], contestId?: string) {
+    expectGetWriteInAdjudicationQueue(writeInIds: Id[], contestId?: string) {
       if (contestId) {
-        apiClient.getWriteIns
+        apiClient.getWriteInAdjudicationQueue
           .expectCallWith({ contestId })
-          .resolves(writeInRecords);
+          .resolves(writeInIds);
       } else {
-        apiClient.getWriteIns.expectCallWith().resolves(writeInRecords);
+        apiClient.getWriteInAdjudicationQueue
+          .expectCallWith()
+          .resolves(writeInIds);
       }
     },
 
@@ -230,20 +233,40 @@ export function createApiMock(
         .resolves(writeInCandidateRecord);
     },
 
-    expectGetWriteInDetailView(
+    expectGetWriteInImageView(
       writeInId: string,
-      detailView: Partial<WriteInDetailView> = {}
+      imageView: Partial<WriteInImageView> = {}
     ) {
-      apiClient.getWriteInDetailView.expectCallWith({ writeInId }).resolves({
+      apiClient.getWriteInImageView.expectCallWith({ writeInId }).resolves({
+        writeInId,
+        cvrId: 'id',
         imageUrl: 'WW91IGJlIGdvb2QsIEkgbG92ZSB5b3UuIFNlZSB5b3UgdG9tb3Jyb3cu',
         ballotCoordinates: mockRect,
         contestCoordinates: mockRect,
         writeInCoordinates: mockRect,
-        markedOfficialCandidateIds: [],
-        writeInAdjudicatedOfficialCandidateIds: [],
-        writeInAdjudicatedWriteInCandidateIds: [],
-        ...detailView,
+        ...imageView,
       });
+    },
+
+    expectGetWriteInAdjudicationContext(
+      writeInId: string,
+      adjudicationContext: Partial<WriteInAdjudicationContext> = {}
+    ) {
+      apiClient.getWriteInAdjudicationContext
+        .expectCallWith({ writeInId })
+        .resolves({
+          writeIn: {
+            id: writeInId,
+            contestId: 'id',
+            castVoteRecordId: 'id',
+            optionId: 'id',
+            status: 'pending',
+          },
+          relatedWriteIns: [],
+          cvrId: 'id',
+          cvrVotes: {},
+          ...adjudicationContext,
+        });
     },
 
     expectMarkResultsOfficial() {

--- a/apps/admin/frontend/test/helpers/api_mock.ts
+++ b/apps/admin/frontend/test/helpers/api_mock.ts
@@ -269,6 +269,15 @@ export function createApiMock(
         });
     },
 
+    expectGetFirstPendingWriteInId(
+      contestId: string,
+      writeInId: string | null
+    ) {
+      apiClient.getFirstPendingWriteInId
+        .expectCallWith({ contestId })
+        .resolves(writeInId);
+    },
+
     expectMarkResultsOfficial() {
       apiClient.markResultsOfficial.expectCallWith().resolves();
     },


### PR DESCRIPTION
@kofi-q review commit-by-commit recommended

## Overview

When loading up VxAdmin with lots of CVRs and write-ins, the write-in adjudication flow became very sluggish. We were fetching a ton of data after every adjudication. The main point of this PR is to make the data fetching more efficient so the WIA UI is more responsive.

The PR also introduces two flow tweaks to make WIA easier:
- maintains a write-in sequence, based on when a write-in was imported, such that whenever write-ins are added they are added to the end of the queue
- when you click to adjudicate a contest, will automatically drop you on the _first pending_ write-in. so you don't have to scroll forward to adjudicate a new batch, and if you accidentally miss one you can find it easily.

<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot

(has audio)

https://github.com/votingworks/vxsuite/assets/37960853/60547e3a-3245-4671-b52d-a815f8156a28


## Testing Plan
- Manual Testing
- New & Updated Automated Testing

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
