### PR TITLE
interpreter: Guard against missing left/right timing marks

### DIFF
--- a/libs/ballot-interpreter-nh/src/timing_marks.rs
+++ b/libs/ballot-interpreter-nh/src/timing_marks.rs
@@ -403,7 +403,7 @@ pub fn find_timing_mark_shapes(
     let candidate_timing_marks = contours
         .iter()
         .enumerate()
-        .filter_map(|(i, contour)| {
+        .filter_map(|(_i, contour)| {
             if contour.border_type == BorderType::Hole {
                 let contour_bounds = get_contour_bounding_rect(contour).offset(
                     -PixelPosition::from(BORDER_SIZE),
@@ -411,7 +411,6 @@ pub fn find_timing_mark_shapes(
                 );
                 if rect_could_be_timing_mark(geometry, &contour_bounds)
                     && is_contour_rectangular(contour)
-                    && contours.iter().all(|c| c.parent != Some(i))
                 {
                     return Some(contour_bounds);
                 }

--- a/libs/ballot-interpreter-nh/src/timing_marks.rs
+++ b/libs/ballot-interpreter-nh/src/timing_marks.rs
@@ -697,6 +697,13 @@ pub fn find_complete_timing_marks_from_partial_timing_marks(
     let left_line = &partial_timing_marks.left_rects;
     let right_line = &partial_timing_marks.right_rects;
 
+    let min_left_right_timing_marks = (geometry.grid_size.height as f32 * 0.25).ceil() as usize;
+    if left_line.len() < min_left_right_timing_marks
+        || right_line.len() < min_left_right_timing_marks
+    {
+        return None;
+    }
+
     let mut horizontal_distances = vec![];
     horizontal_distances.append(&mut distances_between_rects(top_line));
     horizontal_distances.append(&mut distances_between_rects(bottom_line));


### PR DESCRIPTION
## Overview

If for whatever reason, the interpreter can't find any timing marks on the left or right edge, we should reject the ballot.

Previously, we would infer the entire column of timing marks using the corner marks found from the top and bottom row. This could be problematic if the top and bottom row didn't match up (e.g. since the bottom row is sparsely encoded metadata).

An example of when this could happen is detailed in #3737.

To fix this, before inferring missing timing marks for the left/right edges, we check that we found at least 25% of the expected number of timing marks on that edge. This makes sure that we're still liberal in allowing for missing timing marks, but we have enough timing marks to have confidence in our best fit line.

## Demo Video or Screenshot
An example of inferring an incorrect left-side timing mark best fit line due to not having enough timing marks. With this guard in place, this ballot is rejected as unreadable.
![image](https://github.com/votingworks/vxsuite/assets/530106/cb241e1c-eb57-4f5a-98f5-3d8013bdfe27)

## Testing Plan
Manually tested on various scan backups.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
