### PR TITLE
interpreter: Fix timing mark detection for partially grainy marks

### DIFF
--- a/libs/ballot-interpreter-nh/src/timing_marks.rs
+++ b/libs/ballot-interpreter-nh/src/timing_marks.rs
@@ -403,7 +403,7 @@ pub fn find_timing_mark_shapes(
     let candidate_timing_marks = contours
         .iter()
         .enumerate()
-        .filter_map(|(i, contour)| {
+        .filter_map(|(_i, contour)| {
             if contour.border_type == BorderType::Hole {
                 let contour_bounds = get_contour_bounding_rect(contour).offset(
                     -PixelPosition::from(BORDER_SIZE),
@@ -411,7 +411,6 @@ pub fn find_timing_mark_shapes(
                 );
                 if rect_could_be_timing_mark(geometry, &contour_bounds)
                     && is_contour_rectangular(contour)
-                    && contours.iter().all(|c| c.parent != Some(i))
                 {
                     return Some(contour_bounds);
                 }


### PR DESCRIPTION
## Overview

Sometimes based on lighting conditions, there can be a strip of grainy pixels on one side of a ballot image. This causes any timing marks on a full-bleed ballot to be partially grainy. The contour detection algorithm sometimes finds contours in the grainy area, which can lead to rejected timing marks.

To fix this, we remove the logic to filter out timing marks contours that contain other contours inside of them. We think this filter was actually unnecessarily strict.

## Demo Video or Screenshot
![image](https://github.com/votingworks/vxsuite/assets/530106/60239208-f0e7-4ebd-b3af-5c55cb8dab26)


## Testing Plan
Manually tested with various scan backups, diffed the results and found negligible differences in scored marks.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
