### PR TITLE
interpret: Fix SQL query for multiple sheet ids from backup

### DIFF
--- a/libs/ballot-interpreter-nh/ts/src/cli.ts
+++ b/libs/ballot-interpreter-nh/ts/src/cli.ts
@@ -356,9 +356,9 @@ async function interpretWorkspace(
     sheetIdsArray.length
       ? db
           .prepare(
-            'SELECT id, front_image_path as frontPath, back_image_path as backPath FROM sheets WHERE id IN ?'
+            'SELECT id, front_image_path as frontPath, back_image_path as backPath FROM sheets WHERE id IN (?)'
           )
-          .all(sheetIdsArray)
+          .all(sheetIdsArray.join(','))
       : db
           .prepare(
             'SELECT id, front_image_path as frontPath, back_image_path as backPath FROM sheets'


### PR DESCRIPTION
## Overview

I was getting an error when trying to use the interpreter CLI to pick out a specific sheet from a backup. Seems like better-sqlite3 doesn't support interpolating arrays, so to fix I just joined the array of sheet ids into a string.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
