### PR TITLE
VxAdmin Polish Pass

### DIFF
--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -95,6 +95,9 @@ import { getSemsExportableTallies } from './exports/sems_tallies';
 import { generateResultsCsv } from './exports/csv_results';
 import { tabulateFullCardCounts } from './tabulation/card_counts';
 import { getOverallElectionWriteInSummary } from './tabulation/write_ins';
+import { rootDebug } from './util/debug';
+
+const debug = rootDebug.extend('app');
 
 function getCurrentElectionDefinition(
   workspace: Workspace
@@ -587,7 +590,7 @@ function buildApi({
       });
     },
 
-    async getWriteInImageView(input: {
+    getWriteInImageView(input: {
       writeInId: string;
     }): Promise<WriteInImageView> {
       return getWriteInImageView({
@@ -731,6 +734,7 @@ function buildApi({
     async exportBatchResults(input: {
       path: string;
     }): Promise<ExportDataResult> {
+      debug('exporting batch results CSV file');
       const electionId = loadCurrentElectionIdOrThrow(workspace);
       const {
         electionDefinition: { election },
@@ -767,6 +771,7 @@ function buildApi({
     async getSemsExportableTallies(): Promise<SemsExportableTallies> {
       const electionId = loadCurrentElectionIdOrThrow(workspace);
 
+      debug('aggregating results for SEMS exportable tallies');
       return getSemsExportableTallies(
         await tabulateElectionResults({
           electionId,
@@ -779,6 +784,7 @@ function buildApi({
     },
 
     async exportResultsCsv(input: { path: string }): Promise<ExportDataResult> {
+      debug('exporting default results CSV file');
       const electionId = loadCurrentElectionIdOrThrow(workspace);
       const {
         electionDefinition: { election },

--- a/apps/admin/backend/src/tabulation/card_counts.ts
+++ b/apps/admin/backend/src/tabulation/card_counts.ts
@@ -9,8 +9,10 @@ import {
 } from '@votingworks/utils';
 import { CardTally } from '../types';
 import { Store } from '../store';
-
 import { tabulateManualBallotCounts } from './manual_results';
+import { rootDebug } from '../util/debug';
+
+const debug = rootDebug.extend('card-counts');
 
 /**
  * Adds a card tally to a card counts object. Mutates the card counts object
@@ -105,6 +107,7 @@ export function tabulateFullCardCounts({
   const {
     electionDefinition: { election },
   } = assertDefined(store.getElection(electionId));
+  debug('tabulating card counts for the following group by: %o', groupBy ?? {});
 
   const groupedScannedCardCounts = tabulateScannedCardCounts({
     electionId,
@@ -120,11 +123,14 @@ export function tabulateFullCardCounts({
   });
 
   if (tabulateManualBallotCountsResult.isErr()) {
+    debug(
+      'tabulated card counts, omitted manual ballot counts due to incompatible group by'
+    );
     return groupedScannedCardCounts;
   }
 
+  debug('tabulated card counts');
   const groupedManualBallotCounts = tabulateManualBallotCountsResult.ok();
-
   return mergeTabulationGroupMaps(
     groupedScannedCardCounts,
     groupedManualBallotCounts,

--- a/apps/admin/backend/src/tabulation/write_ins.ts
+++ b/apps/admin/backend/src/tabulation/write_ins.ts
@@ -15,6 +15,9 @@ import { assert, assertDefined, throwIllegalValue } from '@votingworks/basics';
 import { WriteInTally } from '../types';
 import { Store } from '../store';
 import { extractWriteInSummary, tabulateManualResults } from './manual_results';
+import { rootDebug } from '../util/debug';
+
+const debug = rootDebug.extend('write-ins-tabulation');
 
 /**
  * Creates an empty contest write-in summary.
@@ -377,6 +380,7 @@ export function getOverallElectionWriteInSummary({
   electionId: Id;
   store: Store;
 }): Tabulation.ElectionWriteInSummary {
+  debug('tabulating overall election write-in summary');
   const {
     electionDefinition: { election },
   } = assertDefined(store.getElection(electionId));
@@ -400,6 +404,7 @@ export function getOverallElectionWriteInSummary({
     manualResults: overallManualResults,
   });
 
+  debug('tabulated overall election write-in-summary');
   return combineElectionWriteInSummaries(
     scannedElectionWriteInSummary,
     overallManualWriteInSummary,

--- a/apps/admin/backend/src/util/export_file.ts
+++ b/apps/admin/backend/src/util/export_file.ts
@@ -1,5 +1,8 @@
 import { ExportDataResult, Exporter } from '@votingworks/backend';
 import { ADMIN_ALLOWED_EXPORT_PATTERNS } from '../globals';
+import { rootDebug } from './debug';
+
+const debug = rootDebug.extend('export-file');
 
 /**
  * Save a file to disk.
@@ -18,5 +21,6 @@ export function exportFile({
     getUsbDrives: () => Promise.resolve([]),
   });
 
+  debug('exporting data to file %s', path);
   return exporter.exportData(path, data);
 }

--- a/apps/admin/frontend/src/app.test.tsx
+++ b/apps/admin/frontend/src/app.test.tsx
@@ -129,6 +129,7 @@ test('configuring with a demo election definition', async () => {
   // remove the election
   apiMock.expectUnconfigure();
   apiMock.expectGetCurrentElectionMetadata(null);
+  apiMock.expectGetMachineConfig();
   fireEvent.click(getByText('Remove'));
   fireEvent.click(getByText('Remove Election Definition'));
 
@@ -395,6 +396,7 @@ test('removing election resets cvr and manual data files', async () => {
   apiMock.expectUnconfigure();
   apiMock.expectGetSystemSettings();
   apiMock.expectGetCurrentElectionMetadata(null);
+  apiMock.expectGetMachineConfig();
   fireEvent.click(getByText('Definition'));
   fireEvent.click(getByText('Remove Election'));
   fireEvent.click(getByText('Remove Election Definition'));
@@ -575,6 +577,7 @@ test('system administrator UI has expected nav when no election', async () => {
   // Remove the election definition and verify that those same tabs disappear
   apiMock.expectUnconfigure();
   apiMock.expectGetCurrentElectionMetadata(null);
+  apiMock.expectGetMachineConfig();
   userEvent.click(screen.getByText('Remove Election'));
   const modal = await screen.findByRole('alertdialog');
   userEvent.click(

--- a/apps/admin/frontend/src/components/ballot_counts_table.tsx
+++ b/apps/admin/frontend/src/components/ballot_counts_table.tsx
@@ -1,13 +1,12 @@
 import { useContext } from 'react';
 import { format, getBallotCount } from '@votingworks/utils';
 import { assert, find, throwIllegalValue } from '@votingworks/basics';
-import { LinkButton, Table, TD } from '@votingworks/ui';
+import { LinkButton, Loading, Table, TD } from '@votingworks/ui';
 import { Tabulation, TallyCategory } from '@votingworks/types';
 
 import { getPartiesWithPrimaryElections } from '../utils/election';
 
 import { AppContext } from '../contexts/app_context';
-import { Loading } from './loading';
 import { ExportBatchTallyResultsButton } from './export_batch_tally_results_button';
 import { routerPaths } from '../router_paths';
 import {
@@ -44,7 +43,7 @@ export function BallotCountsTable({
     !scannerBatchesQuery.isSuccess ||
     !manualResultsMetadataQuery.isSuccess
   ) {
-    return <Loading />;
+    return <Loading isFullscreen as="h2" />;
   }
 
   const cardCountsByCategory = cardCountsQuery.data;

--- a/apps/admin/frontend/src/screens/reports_screen.tsx
+++ b/apps/admin/frontend/src/screens/reports_screen.tsx
@@ -203,7 +203,7 @@ export function ReportsScreen(): JSX.Element {
         </P>
         <P>
           <LinkButton to={routerPaths.tallyWriteInReport}>
-            {statusPrefix} Write-In Tally Report
+            {statusPrefix} Write-In Adjudication Report
           </LinkButton>
         </P>
         {tallyResultsInfo}

--- a/apps/admin/frontend/src/screens/reports_screen.tsx
+++ b/apps/admin/frontend/src/screens/reports_screen.tsx
@@ -73,10 +73,6 @@ export function ReportsScreen(): JSX.Element {
 
   const partiesForPrimaries = getPartiesWithPrimaryElections(election);
 
-  const totalBallotCount = cardCountsQuery.data
-    ? getBallotCount(cardCountsQuery.data[0])
-    : 0;
-
   const [converterName, setConverterName] = useState('');
   useEffect(() => {
     void (async () => {
@@ -160,7 +156,11 @@ export function ReportsScreen(): JSX.Element {
   );
 
   const fileMode = castVoteRecordFileModeQuery.data;
-  const ballotCountSummaryText = (
+  const totalBallotCount = cardCountsQuery.data
+    ? getBallotCount(cardCountsQuery.data[0])
+    : 0;
+
+  const ballotCountSummaryText = cardCountsQuery.isSuccess ? (
     <P>
       <Font weight="bold">
         {format.count(totalBallotCount)}
@@ -170,6 +170,8 @@ export function ReportsScreen(): JSX.Element {
       have been counted for{' '}
       <Font weight="bold">{electionDefinition.election.title}</Font>.
     </P>
+  ) : (
+    <P>Loading total ballot count...</P>
   );
 
   // saving results is enabled once a cast vote record file is loaded


### PR DESCRIPTION
## Overview

Ultimately, I've been staring at this app a little too long to have a good polisher's eye, but I patched up some small things I've noticed along the way. I also tested the app at 1,000,000 CVRs where it performed as well as I'd expected. See video and details below. 

## Performance Discussion

Should not be taken as actual benchmarks, because they were done on my Mac M1, but I checked how long various common actions took in seconds:

| Action | Time (seconds) |
| ------------- | ------------- |
| Importing 100,000 CVR File | 330  |
| Loading CVR File List  | 5  |
| Loading Write-In Summary Page | < 1  |
| Loading Summary Ballot Counts |  < 1 |
| Generating Full Election Tally Report | 11  |
| Generating Scanner Report (10% of CVRs) | 2  |
| Generating Write-In Adjudication Report | 3  |
| Exporting Batch Results | 9  |
| Exporting Standard CSV Results | 12  |

The two that stood out as slower than expected  were importing CVR files and loading the CVR file list - some thoughts on that [here](https://docs.google.com/document/d/194ZiOUmJpataWHcvWSMBa1piG7lcgEvmc-8OGBSwjv0/edit). 

https://github.com/votingworks/vxsuite/assets/37960853/050fd628-f871-4dce-bbf4-3bfd96047b0e



## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
