### PR TITLE
refactor(message-coder): fix flaky test

### DIFF
--- a/libs/custom-paper-handler/src/driver/coders.ts
+++ b/libs/custom-paper-handler/src/driver/coders.ts
@@ -1,6 +1,5 @@
 import {
   CoderType,
-  byteArrayWithLengthPrefix,
   literal,
   message,
   padding,
@@ -115,7 +114,7 @@ export const RealTimeExchangeResponseWithoutData = message({
   requestId: uint8(),
   token: literal(TOKEN),
   returnCode: uint8(),
-  optionalBytes: byteArrayWithLengthPrefix(0),
+  optionalBytes: padding(1),
 });
 export type RealTimeExchangeResponseWithoutData = CoderType<
   typeof RealTimeExchangeResponseWithoutData

--- a/libs/message-coder/src/byte_array_with_length_prefix.test.ts
+++ b/libs/message-coder/src/byte_array_with_length_prefix.test.ts
@@ -3,7 +3,7 @@ import { assert, err, ok } from '@votingworks/basics';
 import fc from 'fast-check';
 import { byteArrayWithLengthPrefix } from './byte_array_with_length_prefix';
 import { uint8 } from './uint8_coder';
-import { MAX_UINT16, MAX_UINT8, MIN_UINT8 } from './constants';
+import { MAX_UINT16, MAX_UINT8 } from './constants';
 
 test('canEncode', () => {
   const coder = byteArrayWithLengthPrefix(uint8());
@@ -52,7 +52,7 @@ test('encode with length too large', () => {
 
 test('fixed length (8-bit)', () => {
   fc.assert(
-    fc.property(fc.integer({ min: MIN_UINT8, max: MAX_UINT8 }), (length) => {
+    fc.property(fc.integer({ min: 1, max: MAX_UINT8 }), (length) => {
       const coder = byteArrayWithLengthPrefix(length);
       expect(coder.bitLength(new Uint8Array(length))).toEqual(
         ok(8 + length * 8)

--- a/libs/message-coder/src/byte_array_with_length_prefix.ts
+++ b/libs/message-coder/src/byte_array_with_length_prefix.ts
@@ -85,7 +85,6 @@ class FixedLengthByteArrayCoder extends BaseCoder<Uint8Array> {
     // we only support uint16 and smaller for now,
     // because otherwise the buffer sizes get too large
     switch (bytesRequired) {
-      case 0:
       case 1:
         this.lengthCoder = uint8();
         break;


### PR DESCRIPTION
This flake conforms to @eventualbuddha's `fast-check` hypothesis, that sometimes `fast-check` generates values that lead to 100% coverage and sometimes they don't. 

In this case I actually refactor the code so that `bytesRequired` is never 0, because we always require at least one byte for a number. A semantic change, really, which helps avoid the flaky switch case.