### PR TITLE
Counting Blank Ballots Backend

### DIFF
--- a/apps/admin/backend/schema.sql
+++ b/apps/admin/backend/schema.sql
@@ -56,6 +56,7 @@ create table cvrs (
   precinct_id text not null,
   sheet_number integer check (sheet_number is null or sheet_number > 0),
   votes text not null,
+  is_blank boolean not null,
   created_at timestamp not null default current_timestamp,
   foreign key (election_id) references elections(id)
     on delete cascade,

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -587,7 +587,7 @@ function buildApi({
       });
     },
 
-    async getWriteInImageView(input: {
+    getWriteInImageView(input: {
       writeInId: string;
     }): Promise<WriteInImageView> {
       return getWriteInImageView({
@@ -695,6 +695,7 @@ function buildApi({
     getCardCounts(
       input: {
         groupBy?: Tabulation.GroupBy;
+        blankBallotsOnly?: boolean;
       } = {}
     ): Array<Tabulation.GroupOf<Tabulation.CardCounts>> {
       const electionId = loadCurrentElectionIdOrThrow(workspace);
@@ -702,7 +703,7 @@ function buildApi({
         tabulateFullCardCounts({
           electionId,
           store,
-          groupBy: input.groupBy,
+          ...input,
         })
       );
     },

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -66,7 +66,7 @@ import {
   CardTally,
   WriteInAdjudicationQueueMetadata,
 } from './types';
-import { isBlankVotes, replacePartyIdFilter } from './tabulation/utils';
+import { isBlankSheet, replacePartyIdFilter } from './tabulation/utils';
 import { rootDebug } from './util/debug';
 
 const debug = rootDebug.extend('store');
@@ -517,7 +517,7 @@ export class Store {
         cvr.precinctId,
         cvrSheetNumber,
         serializedVotes,
-        isBlankVotes(cvr.votes) ? 1 : 0
+        isBlankSheet(cvr.votes) ? 1 : 0
       );
     }
 

--- a/apps/admin/backend/src/tabulation/card_counts.ts
+++ b/apps/admin/backend/src/tabulation/card_counts.ts
@@ -43,10 +43,12 @@ export function tabulateScannedCardCounts({
   electionId,
   store,
   groupBy,
+  blankBallotsOnly = false,
 }: {
   electionId: Id;
   store: Store;
   groupBy?: Tabulation.GroupBy;
+  blankBallotsOnly?: boolean;
 }): Tabulation.GroupMap<Tabulation.CardCounts> {
   const {
     electionDefinition: { election },
@@ -56,6 +58,7 @@ export function tabulateScannedCardCounts({
     electionId,
     election,
     groupBy,
+    blankBallotsOnly,
   });
 
   const cardCountsGroupMap: Tabulation.GroupMap<Tabulation.CardCounts> = {};
@@ -97,10 +100,12 @@ export function tabulateFullCardCounts({
   electionId,
   store,
   groupBy,
+  blankBallotsOnly = false,
 }: {
   electionId: Id;
   store: Store;
   groupBy?: Tabulation.GroupBy;
+  blankBallotsOnly?: boolean;
 }): Tabulation.GroupMap<Tabulation.CardCounts> {
   const {
     electionDefinition: { election },
@@ -111,6 +116,11 @@ export function tabulateFullCardCounts({
     store,
     groupBy,
   });
+  if (blankBallotsOnly) {
+    // we do not manage manually entered blank ballots within the system
+    return groupedScannedCardCounts;
+  }
+
   const tabulateManualBallotCountsResult = tabulateManualBallotCounts({
     election,
     manualResultsMetadataRecords: store.getManualResultsMetadata({
@@ -118,7 +128,6 @@ export function tabulateFullCardCounts({
     }),
     groupBy,
   });
-
   if (tabulateManualBallotCountsResult.isErr()) {
     return groupedScannedCardCounts;
   }

--- a/apps/admin/backend/src/tabulation/utils.ts
+++ b/apps/admin/backend/src/tabulation/utils.ts
@@ -30,3 +30,10 @@ export function replacePartyIdFilter(
     batchIds: filter.batchIds,
   };
 }
+
+/**
+ * Tests whether CVR votes are empty.
+ */
+export function isBlankVotes(votes: Tabulation.Votes): boolean {
+  return Object.values(votes).every((selections) => selections.length === 0);
+}

--- a/apps/admin/backend/src/tabulation/utils.ts
+++ b/apps/admin/backend/src/tabulation/utils.ts
@@ -34,6 +34,6 @@ export function replacePartyIdFilter(
 /**
  * Tests whether CVR votes are empty.
  */
-export function isBlankVotes(votes: Tabulation.Votes): boolean {
+export function isBlankSheet(votes: Tabulation.Votes): boolean {
   return Object.values(votes).every((selections) => selections.length === 0);
 }


### PR DESCRIPTION
## Overview

To meet VVSG 1.1.9-B.5, we must be able to offer a count of blank ballots. It was quick to add this to the backend, so just did it now while `admin-backend` is fresh for me. We can build the UI when we build the other reporting UI. Although I wonder if these counts will be more useful in an expanded ballot adjudication flow. Either way.
