### PR TITLE
test(custom-scanner): use seed for flaky fast-check test

### DIFF
--- a/libs/custom-scanner/src/protocol.test.ts
+++ b/libs/custom-scanner/src/protocol.test.ts
@@ -801,7 +801,10 @@ test('getImageData', async () => {
         );
         expect(onRead).toHaveBeenCalledTimes(1);
       }
-    )
+    ),
+    {
+      seed: 0, // with a random seed, some branches are sporadically missed
+    }
   );
 });
 


### PR DESCRIPTION
Another `fast-check` case of flakiness, I addressed this one by fixing the random seed.
