### PR TITLE
ci(jest): reduce `maxWorkers` from 7 to 6

### DIFF
--- a/apps/admin/backend/package.json
+++ b/apps/admin/backend/package.json
@@ -17,7 +17,7 @@
     "pre-commit": "lint-staged",
     "start": "node ./build/index.js",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "TZ=UTC jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "TZ=UTC jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "TZ=UTC jest --coverage",
     "test:debug": "TZ=UTC node --inspect-brk $(which jest) --runInBand --no-cache",
     "test:perf": "TZ=UTC jest --coverage=false --roots '<rootDir>/perf' --testMatch '<rootDir>/perf/**/*.test.ts'",

--- a/apps/admin/frontend/package.json
+++ b/apps/admin/frontend/package.json
@@ -19,7 +19,7 @@
     "stylelint:run": "stylelint 'src/**/*.{js,jsx,ts,tsx}' && stylelint 'src/**/*.css' --config .stylelintrc-css.js",
     "stylelint:run:fix": "stylelint 'src/**/*.{js,jsx,ts,tsx}' --fix && stylelint 'src/**/*.css' --config .stylelintrc-css.js --fix",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "TZ=UTC node scripts/test.js --coverage --watchAll=false --reporters=default --reporters=jest-junit --maxWorkers=7 --env=jest-environment-jsdom-sixteen",
+    "test:ci": "TZ=UTC node scripts/test.js --coverage --watchAll=false --reporters=default --reporters=jest-junit --maxWorkers=6 --env=jest-environment-jsdom-sixteen",
     "test:coverage": "TZ=UTC node scripts/test.js --coverage --watchAll=false --env=jest-environment-jsdom-sixteen",
     "test:watch": "TZ=UTC node scripts/test.js --env=jest-environment-jsdom-sixteen",
     "type-check": "tsc --build"

--- a/apps/central-scan/backend/package.json
+++ b/apps/central-scan/backend/package.json
@@ -19,7 +19,7 @@
     "pre-commit": "lint-staged",
     "start": "node ./build/index.js",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "jest --coverage",
     "test:debug": "node --inspect-brk $(which jest) --runInBand --no-cache",
     "test:watch": "jest --watch",

--- a/apps/central-scan/frontend/package.json
+++ b/apps/central-scan/frontend/package.json
@@ -18,7 +18,7 @@
     "stylelint:run": "stylelint 'src/**/*.{js,jsx,ts,tsx}'",
     "stylelint:run:fix": "stylelint 'src/**/*.{js,jsx,ts,tsx}' --fix",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "TZ=UTC node scripts/test.js --coverage --watchAll=false --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "TZ=UTC node scripts/test.js --coverage --watchAll=false --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "TZ=UTC node scripts/test.js --coverage --watchAll=false",
     "test:watch": "TZ=UTC node scripts/test.js --env=jest-environment-jsdom-sixteen",
     "type-check": "tsc --build"

--- a/apps/design/backend/package.json
+++ b/apps/design/backend/package.json
@@ -20,7 +20,7 @@
     "pre-commit": "lint-staged",
     "start": "node ./build/index.js",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "jest --coverage",
     "test:debug": "node --inspect-brk $(which jest) --runInBand --no-cache",
     "test:watch": "jest --watch",

--- a/apps/design/frontend/package.json
+++ b/apps/design/frontend/package.json
@@ -18,7 +18,7 @@
     "stylelint:run": "stylelint 'src/**/*.{js,jsx,ts,tsx}'",
     "stylelint:run:fix": "stylelint 'src/**/*.{js,jsx,ts,tsx}' --fix",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "TZ=UTC node scripts/test.js --coverage --watchAll=false --reporters=default --reporters=jest-junit --maxWorkers=7 --passWithNoTests",
+    "test:ci": "TZ=UTC node scripts/test.js --coverage --watchAll=false --reporters=default --reporters=jest-junit --maxWorkers=6 --passWithNoTests",
     "test:coverage": "TZ=UTC node scripts/test.js --coverage --watchAll=false",
     "test:watch": "TZ=UTC node scripts/test.js --env=jest-environment-jsdom-sixteen",
     "type-check": "tsc --build"

--- a/apps/design/shared/package.json
+++ b/apps/design/shared/package.json
@@ -16,7 +16,7 @@
     "lint:fix": "pnpm type-check && eslint . --fix",
     "pre-commit": "lint-staged",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "TZ=UTC jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=7 --passWithNoTests",
+    "test:ci": "TZ=UTC jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=6 --passWithNoTests",
     "test:coverage": "TZ=UTC jest --coverage",
     "test:watch": "TZ=UTC jest --watch",
     "type-check": "tsc --build"

--- a/apps/mark-scan/backend/package.json
+++ b/apps/mark-scan/backend/package.json
@@ -16,7 +16,7 @@
     "pre-commit": "lint-staged",
     "start": "node ./build/index.js",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "jest --coverage",
     "test:debug": "node --inspect-brk $(which jest) --runInBand --no-cache",
     "test:watch": "jest --watch",

--- a/apps/mark-scan/frontend/package.json
+++ b/apps/mark-scan/frontend/package.json
@@ -17,7 +17,7 @@
     "start:core": "pnpm -w run-dev vm-mark-scan --core-only",
     "stylelint:run": "stylelint 'src/**/*.{js,jsx,ts,tsx}'",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "TZ=UTC CI=true node scripts/test.js --maxWorkers=7 --env=jest-environment-jsdom-sixteen --coverage --reporters=default --reporters=jest-junit",
+    "test:ci": "TZ=UTC CI=true node scripts/test.js --maxWorkers=6 --env=jest-environment-jsdom-sixteen --coverage --reporters=default --reporters=jest-junit",
     "test:coverage": "TZ=UTC node scripts/test.js --coverage --watchAll=false --env=jest-environment-jsdom-sixteen",
     "test:update": "TZ=UTC node scripts/test.js -u  --watchAll=false --env=jest-environment-jsdom-sixteen",
     "test:watch": "TZ=UTC node scripts/test.js --env=jest-environment-jsdom-sixteen",

--- a/apps/mark/backend/package.json
+++ b/apps/mark/backend/package.json
@@ -16,7 +16,7 @@
     "pre-commit": "lint-staged",
     "start": "node ./build/index.js",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "jest --coverage",
     "test:debug": "node --inspect-brk $(which jest) --runInBand --no-cache",
     "test:watch": "jest --watch",

--- a/apps/mark/frontend/package.json
+++ b/apps/mark/frontend/package.json
@@ -17,7 +17,7 @@
     "start:core": "pnpm -w run-dev vm-mark --core-only",
     "stylelint:run": "stylelint 'src/**/*.{js,jsx,ts,tsx}'",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "TZ=UTC CI=true node scripts/test.js --maxWorkers=7 --env=jest-environment-jsdom-sixteen --coverage --reporters=default --reporters=jest-junit",
+    "test:ci": "TZ=UTC CI=true node scripts/test.js --maxWorkers=6 --env=jest-environment-jsdom-sixteen --coverage --reporters=default --reporters=jest-junit",
     "test:coverage": "TZ=UTC node scripts/test.js --coverage --watchAll=false --env=jest-environment-jsdom-sixteen",
     "test:update": "TZ=UTC node scripts/test.js -u  --watchAll=false --env=jest-environment-jsdom-sixteen",
     "test:watch": "TZ=UTC node scripts/test.js --env=jest-environment-jsdom-sixteen",

--- a/apps/scan/backend/package.json
+++ b/apps/scan/backend/package.json
@@ -19,7 +19,7 @@
     "pre-commit": "lint-staged",
     "start": "node ./build/index.js",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "jest --coverage",
     "test:debug": "node --inspect-brk $(which jest) --runInBand --no-cache",
     "test:watch": "jest --watch",

--- a/apps/scan/frontend/package.json
+++ b/apps/scan/frontend/package.json
@@ -19,7 +19,7 @@
     "stylelint:run": "stylelint 'src/**/*.{js,jsx,ts,tsx}'",
     "stylelint:run:fix": "stylelint 'src/**/*.{js,jsx,ts,tsx}' --fix",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "TZ=UTC node scripts/test.js --coverage --watchAll=false --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "TZ=UTC node scripts/test.js --coverage --watchAll=false --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "TZ=UTC node scripts/test.js --coverage --watchAll=false",
     "test:watch": "TZ=UTC node scripts/test.js --env=jest-environment-jsdom-sixteen",
     "type-check": "tsc --build"

--- a/libs/api/package.json
+++ b/libs/api/package.json
@@ -17,7 +17,7 @@
     "lint:fix": "pnpm type-check && eslint . --fix",
     "pre-commit": "lint-staged",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "type-check": "tsc --build"

--- a/libs/auth/package.json
+++ b/libs/auth/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "pnpm type-check && eslint . --fix",
     "pre-commit": "lint-staged",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "type-check": "tsc --build"

--- a/libs/backend/package.json
+++ b/libs/backend/package.json
@@ -17,7 +17,7 @@
     "lint:fix": "pnpm type-check && eslint . --fix",
     "pre-commit": "lint-staged",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "TZ=UTC pnpm build && pnpm test:coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "TZ=UTC pnpm build && pnpm test:coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "TZ=UTC jest --coverage",
     "test:watch": "TZ=UTC jest --watch",
     "type-check": "tsc --build"

--- a/libs/ballot-encoder/package.json
+++ b/libs/ballot-encoder/package.json
@@ -13,7 +13,7 @@
     "lint": "pnpm type-check && eslint .",
     "lint:fix": "pnpm type-check && eslint . --fix",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --ci --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "jest --ci --coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "jest --coverage",
     "test:debug": "node --inspect-brk $(which jest) --runInBand --no-cache",
     "test:watch": "jest --watch",

--- a/libs/ballot-interpreter-vx/package.json
+++ b/libs/ballot-interpreter-vx/package.json
@@ -21,7 +21,7 @@
     "lint:fix": "pnpm type-check && eslint . --fix",
     "prepack": "tsc --build",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "pnpm test:coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "pnpm test:coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "pre-commit": "lint-staged"

--- a/libs/ballot-interpreter/package.json
+++ b/libs/ballot-interpreter/package.json
@@ -17,7 +17,7 @@
     "lint:fix": "pnpm type-check && eslint . --fix",
     "pre-commit": "lint-staged",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "pnpm build && pnpm test:coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "pnpm build && pnpm test:coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "type-check": "tsc --build"

--- a/libs/basics/package.json
+++ b/libs/basics/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "pnpm type-check && eslint . --fix",
     "pre-commit": "lint-staged",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "TZ=UTC pnpm build && pnpm test:coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "TZ=UTC pnpm build && pnpm test:coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "TZ=UTC jest --coverage",
     "test:watch": "TZ=UTC jest --watch",
     "type-check": "tsc --build"

--- a/libs/cdf-schema-builder/package.json
+++ b/libs/cdf-schema-builder/package.json
@@ -17,7 +17,7 @@
     "lint:fix": "pnpm type-check && eslint . --fix",
     "pre-commit": "lint-staged",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --ci --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "jest --ci --coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "jest --coverage",
     "test:debug": "node --inspect-brk $(which jest) --runInBand --no-cache",
     "test:watch": "jest --watch",

--- a/libs/converter-nh-accuvote/package.json
+++ b/libs/converter-nh-accuvote/package.json
@@ -14,7 +14,7 @@
     "lint": "pnpm type-check && eslint .",
     "lint:fix": "pnpm type-check && eslint . --fix",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --coverage --ci --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "jest --coverage --ci --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch"
   },

--- a/libs/custom-paper-handler/package.json
+++ b/libs/custom-paper-handler/package.json
@@ -13,7 +13,7 @@
     "lint:fix": "pnpm type-check && eslint . --fix",
     "pre-commit": "lint-staged",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --ci --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "jest --ci --coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "type-check": "tsc --build"

--- a/libs/custom-scanner/package.json
+++ b/libs/custom-scanner/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "pnpm type-check && eslint . --fix",
     "pre-commit": "lint-staged",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --ci --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "jest --ci --coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "type-check": "tsc --build"

--- a/libs/cvr-fixture-generator/package.json
+++ b/libs/cvr-fixture-generator/package.json
@@ -18,7 +18,7 @@
     "test": "is-ci test:ci test:watch",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
-    "test:ci": "jest --coverage --ci --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "jest --coverage --ci --reporters=default --reporters=jest-junit --maxWorkers=6",
     "pre-commit": "lint-staged"
   },
   "dependencies": {

--- a/libs/db/package.json
+++ b/libs/db/package.json
@@ -12,7 +12,7 @@
     "lint": "pnpm type-check && eslint .",
     "lint:fix": "pnpm type-check && eslint . --fix",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --coverage --ci --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "jest --coverage --ci --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch"
   },

--- a/libs/dev-dock/backend/package.json
+++ b/libs/dev-dock/backend/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "pnpm type-check && eslint . --fix",
     "pre-commit": "lint-staged",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "TZ=UTC pnpm build && pnpm test:coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "TZ=UTC pnpm build && pnpm test:coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "TZ=UTC jest --coverage",
     "test:watch": "TZ=UTC jest --watch",
     "type-check": "tsc --build"

--- a/libs/dev-dock/frontend/package.json
+++ b/libs/dev-dock/frontend/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "pnpm type-check && eslint . --fix",
     "pre-commit": "lint-staged",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "TZ=UTC pnpm build && pnpm test:coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "TZ=UTC pnpm build && pnpm test:coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "TZ=UTC jest --coverage",
     "test:watch": "TZ=UTC jest --watch",
     "type-check": "tsc --build"

--- a/libs/eslint-plugin-vx/package.json
+++ b/libs/eslint-plugin-vx/package.json
@@ -21,7 +21,7 @@
     "test": "is-ci test:ci test:watch",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=7"
+    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=6"
   },
   "packageManager": "pnpm@8.1.0",
   "dependencies": {

--- a/libs/fixtures/package.json
+++ b/libs/fixtures/package.json
@@ -21,7 +21,7 @@
     "test": "is-ci test:ci test:watch",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
-    "test:ci": "jest --coverage --ci --reporters=default --reporters=jest-junit --maxWorkers=7 && pnpm build:resources --check",
+    "test:ci": "jest --coverage --ci --reporters=default --reporters=jest-junit --maxWorkers=6 && pnpm build:resources --check",
     "pre-commit": "lint-staged"
   },
   "lint-staged": {

--- a/libs/grout/package.json
+++ b/libs/grout/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "pnpm type-check && eslint . --fix",
     "pre-commit": "lint-staged",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "type-check": "tsc --build"

--- a/libs/grout/test-utils/package.json
+++ b/libs/grout/test-utils/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "pnpm type-check && eslint . --fix",
     "pre-commit": "lint-staged",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "type-check": "tsc --build"

--- a/libs/image-utils/package.json
+++ b/libs/image-utils/package.json
@@ -11,7 +11,7 @@
     "lint": "pnpm type-check && eslint .",
     "lint:fix": "pnpm type-check && eslint . --fix",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --coverage --ci --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "jest --coverage --ci --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch"
   },

--- a/libs/logging/package.json
+++ b/libs/logging/package.json
@@ -19,7 +19,7 @@
     "test": "is-ci test:ci test:watch",
     "test:watch": "TZ=UTC jest --watch",
     "test:coverage": "TZ=UTC jest --coverage",
-    "test:ci": "TZ=UTC pnpm build && pnpm test:coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "TZ=UTC pnpm build && pnpm test:coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "pre-commit": "lint-staged"
   },
   "lint-staged": {

--- a/libs/mark-flow-ui/package.json
+++ b/libs/mark-flow-ui/package.json
@@ -20,7 +20,7 @@
     "stylelint:run": "stylelint 'src/**/*.{js,jsx,ts,tsx}'",
     "test": "is-ci test:ci test:watch",
     "test:coverage": "TZ=UTC jest --coverage",
-    "test:ci": "TZ=UTC jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "TZ=UTC jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:watch": "TZ=UTC jest --watch",
     "pre-commit": "lint-staged"
   },

--- a/libs/message-coder/package.json
+++ b/libs/message-coder/package.json
@@ -13,7 +13,7 @@
     "lint:fix": "pnpm type-check && eslint . --fix",
     "pre-commit": "lint-staged",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --ci --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "jest --ci --coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "jest --coverage",
     "test:watch": "TZ=UTC jest --watch",
     "type-check": "tsc --build"

--- a/libs/res-to-ts/package.json
+++ b/libs/res-to-ts/package.json
@@ -17,7 +17,7 @@
     "lint": "pnpm type-check && eslint .",
     "lint:fix": "pnpm type-check && eslint . --fix",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --coverage --ci --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "jest --coverage --ci --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch"
   },

--- a/libs/test-utils/package.json
+++ b/libs/test-utils/package.json
@@ -17,7 +17,7 @@
     "lint:fix": "pnpm type-check && eslint . --fix",
     "test": "is-ci test:ci test:watch",
     "test:coverage": "jest --coverage",
-    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:watch": "jest --watch",
     "pre-commit": "lint-staged"
   },

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "pnpm type-check && eslint . --fix",
     "test": "is-ci test:ci test:watch",
     "test:coverage": "jest --coverage",
-    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:watch": "jest --watch",
     "pre-commit": "lint-staged",
     "cdf:ballot-definition:build-schema": "cdf-schema-builder data/cdf/ballot-definition/nist-schema.xsd src/cdf/ballot-definition/vx-schema.json > src/cdf/ballot-definition/index.ts",

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -20,7 +20,7 @@
     "stylelint:run": "stylelint 'src/**/*.{js,jsx,ts,tsx}'",
     "test": "is-ci test:ci test:watch",
     "test:coverage": "TZ=UTC jest --coverage",
-    "test:ci": "TZ=UTC jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "TZ=UTC jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:watch": "TZ=UTC jest --watch",
     "pre-commit": "lint-staged"
   },

--- a/libs/usb-drive/package.json
+++ b/libs/usb-drive/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "pnpm type-check && eslint . --fix",
     "pre-commit": "lint-staged",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "TZ=UTC pnpm build && pnpm test:coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "TZ=UTC pnpm build && pnpm test:coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "TZ=UTC jest --coverage",
     "test:watch": "TZ=UTC jest --watch",
     "type-check": "tsc --build"

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -19,7 +19,7 @@
     "test": "is-ci test:ci test:watch",
     "test:watch": "TZ=UTC jest --watch",
     "test:coverage": "TZ=UTC jest --coverage",
-    "test:ci": "TZ=UTC pnpm build && pnpm test:coverage --reporters=default --reporters=jest-junit --maxWorkers=7",
+    "test:ci": "TZ=UTC pnpm build && pnpm test:coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "pre-commit": "lint-staged"
   },
   "lint-staged": {


### PR DESCRIPTION
## Overview

I've been seeing test flakes [like this one](https://app.circleci.com/pipelines/github/votingworks/vxsuite/10735/workflows/a0758bcf-a6eb-4533-812e-f718bb6f4afb/jobs/333432) where a worker process is killed by... something:
```
● Test suite failed to run

    A jest worker process (pid=4166) was terminated by another process: signal=SIGKILL, exitCode=null. Operating system logs may contain more information on why this occurred.

      at ChildProcessWorker._onExit (../../node_modules/.pnpm/jest-worker@29.5.0/node_modules/jest-worker/build/workers/ChildProcessWorker.js:370:23)
```

I can easily reproduce this locally by running `pnpm test:ci`, and then I can fix the issue by reducing `--maxWorkers`. In #2626, we set `maxWorkers` to 7.  This is what `jest` would automatically set it if it had an accurate read of the number of CPUs available in CI (there are 8 cores but it thinks there are more because it's a shared machine). But I think `jest` is being a little overambitious. 

Reducing the `maxWorkers` makes most test suites run faster, not slower, based on the times I compared before and after. If you want a more exhaustive audit I can do that, but I think `jest` was biting off more than it can chew before and tripping itself up, going a bit slower and occasionally failing.