### PR TITLE
[VxMark] Reset display settings whenever a new voting session is started

### DIFF
--- a/apps/mark-scan/frontend/src/app.test.tsx
+++ b/apps/mark-scan/frontend/src/app.test.tsx
@@ -1,4 +1,8 @@
-import { fakeKiosk, suppressingConsoleOutput } from '@votingworks/test-utils';
+import {
+  fakeKiosk,
+  mockOf,
+  suppressingConsoleOutput,
+} from '@votingworks/test-utils';
 import {
   ALL_PRECINCTS_SELECTION,
   MemoryHardware,
@@ -7,6 +11,7 @@ import {
 
 import fetchMock from 'fetch-mock';
 import { electionSampleDefinition } from '@votingworks/fixtures';
+import { useDisplaySettingsManager } from '@votingworks/mark-flow-ui';
 import userEvent from '@testing-library/user-event';
 import { fireEvent, screen, waitFor } from '../test/react_testing_library';
 import {
@@ -19,6 +24,15 @@ import { render } from '../test/test_utils';
 import { App } from './app';
 import { AriaScreenReader } from './utils/ScreenReader';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
+import { buildApp } from '../test/helpers/build_app';
+
+jest.mock(
+  '@votingworks/mark-flow-ui',
+  (): typeof import('@votingworks/mark-flow-ui') => ({
+    ...jest.requireActual('@votingworks/mark-flow-ui'),
+    useDisplaySettingsManager: jest.fn(),
+  })
+);
 
 let apiMock: ApiMock;
 
@@ -29,6 +43,7 @@ beforeEach(() => {
 
 afterEach(() => {
   apiMock.mockApiClient.assertComplete();
+  mockOf(useDisplaySettingsManager).mockReset();
 });
 
 it('will throw an error when using default api', async () => {
@@ -124,6 +139,21 @@ it('changes screen reader settings based on keyboard inputs', async () => {
   await waitFor(() => {
     expect(screenReader.changeVolume).toHaveBeenCalledTimes(1);
   });
+});
+
+it('uses display settings management hook', async () => {
+  apiMock.expectGetMachineConfig();
+  apiMock.expectGetSystemSettings();
+  apiMock.expectGetElectionDefinition(null);
+
+  const { storage, renderApp } = buildApp(apiMock);
+  await setElectionInStorage(storage);
+  await setStateInStorage(storage);
+  renderApp();
+
+  await advanceTimersAndPromises();
+
+  expect(mockOf(useDisplaySettingsManager)).toBeCalled();
 });
 
 // This test is only really here to provide coverage for the default value for

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useReducer, useRef } from 'react';
+import React, { useCallback, useEffect, useReducer, useRef } from 'react';
 import {
   ElectionDefinition,
   OptionalElectionDefinition,
@@ -38,12 +38,14 @@ import {
   useUsbDrive,
   UnlockMachineScreen,
   useQueryChangeListener,
+  ThemeManagerContext,
 } from '@votingworks/ui';
 
 import { assert, Optional, throwIllegalValue } from '@votingworks/basics';
 import {
   mergeMsEitherNeitherContests,
   CastBallotPage,
+  useDisplaySettingsManager,
 } from '@votingworks/mark-flow-ui';
 import {
   checkPin,
@@ -275,6 +277,8 @@ export function AppRoot({
 
   const history = useHistory();
 
+  const themeManager = React.useContext(ThemeManagerContext);
+
   const machineConfigQuery = getMachineConfig.useQuery();
 
   const devices = useDevices({ hardware, logger });
@@ -368,18 +372,24 @@ export function AppRoot({
         showPostVotingInstructions: newShowPostVotingInstructions,
       });
       history.push('/');
+
+      if (!newShowPostVotingInstructions) {
+        // [VVSG 2.0 7.1-A] Reset to default theme when voter is done marking
+        // their ballot:
+        themeManager.resetThemes();
+      }
     },
-    [history]
+    [history, themeManager]
   );
 
   const hidePostVotingInstructions = useCallback(() => {
     clearTimeout(PostVotingInstructionsTimeout.current);
     endCardlessVoterSessionMutation.mutate(undefined, {
       onSuccess() {
-        dispatchAppState({ type: 'resetBallot' });
+        resetBallot();
       },
     });
-  }, [endCardlessVoterSessionMutation]);
+  }, [endCardlessVoterSessionMutation, resetBallot]);
 
   // Hide Verify and Scan Instructions
   useEffect(() => {
@@ -593,6 +603,8 @@ export function AppRoot({
     storage,
     initializedFromStorage,
   ]);
+
+  useDisplaySettingsManager({ authStatus, votes });
 
   if (!machineConfigQuery.isSuccess || !authStatusQuery.isSuccess) {
     return null;

--- a/libs/mark-flow-ui/src/hooks/use_display_settings_manager.test.tsx
+++ b/libs/mark-flow-ui/src/hooks/use_display_settings_manager.test.tsx
@@ -1,0 +1,178 @@
+import { DefaultTheme, ThemeContext } from 'styled-components';
+import React from 'react';
+import {
+  ThemeManagerContext,
+  ThemeManagerContextInterface,
+} from '@votingworks/ui';
+import {
+  fakeCardlessVoterUser,
+  fakeElectionManagerUser,
+  fakeSessionExpiresAt,
+} from '@votingworks/test-utils';
+import { VotesDict } from '@votingworks/types';
+import { act, render } from '../../test/react_testing_library';
+import {
+  UseDisplaySettingsManagerParams,
+  useDisplaySettingsManager,
+} from './use_display_settings_manager';
+
+const DEFAULT_THEME: Partial<DefaultTheme> = {
+  colorMode: 'contrastMedium',
+  sizeMode: 'm',
+};
+const ACTIVE_VOTING_SESSION_VOTES: VotesDict = {};
+const NEW_VOTING_SESSION_VOTES = undefined;
+
+let currentTheme: DefaultTheme;
+let themeManager: ThemeManagerContextInterface;
+
+function TestHookWrapper(props: UseDisplaySettingsManagerParams): null {
+  currentTheme = React.useContext(ThemeContext);
+  themeManager = React.useContext(ThemeManagerContext);
+
+  useDisplaySettingsManager(props);
+
+  return null;
+}
+
+test('Resets theme when election official logs in', () => {
+  const { rerender } = render(
+    <TestHookWrapper
+      authStatus={{
+        status: 'logged_in',
+        user: fakeCardlessVoterUser(),
+        sessionExpiresAt: fakeSessionExpiresAt(),
+      }}
+      votes={ACTIVE_VOTING_SESSION_VOTES}
+    />,
+    { vxTheme: DEFAULT_THEME }
+  );
+
+  expect(currentTheme).toEqual(
+    expect.objectContaining<Partial<DefaultTheme>>({
+      colorMode: 'contrastMedium',
+      sizeMode: 'm',
+    })
+  );
+
+  // Simulate changing display settings as voter:
+  act(() => {
+    themeManager.setColorMode('contrastLow');
+    themeManager.setSizeMode('xl');
+  });
+  expect(currentTheme).toEqual(
+    expect.objectContaining<Partial<DefaultTheme>>({
+      colorMode: 'contrastLow',
+      sizeMode: 'xl',
+    })
+  );
+
+  // Should reset display settings on Election Manager login:
+  rerender(
+    <TestHookWrapper
+      authStatus={{
+        status: 'logged_in',
+        user: fakeElectionManagerUser(),
+        sessionExpiresAt: fakeSessionExpiresAt(),
+      }}
+      votes={ACTIVE_VOTING_SESSION_VOTES}
+    />
+  );
+  expect(currentTheme).toEqual(
+    expect.objectContaining<Partial<DefaultTheme>>(DEFAULT_THEME)
+  );
+
+  // Simulate changing display settings as Election Manager:
+  act(() => {
+    themeManager.setColorMode('contrastHighDark');
+    themeManager.setSizeMode('s');
+  });
+  expect(currentTheme).toEqual(
+    expect.objectContaining<Partial<DefaultTheme>>({
+      colorMode: 'contrastHighDark',
+      sizeMode: 's',
+    })
+  );
+
+  // Should return to voter settings on return to voter session:
+  rerender(
+    <TestHookWrapper
+      authStatus={{
+        status: 'logged_in',
+        user: fakeCardlessVoterUser(),
+        sessionExpiresAt: fakeSessionExpiresAt(),
+      }}
+      votes={ACTIVE_VOTING_SESSION_VOTES}
+    />
+  );
+  expect(currentTheme).toEqual(
+    expect.objectContaining<Partial<DefaultTheme>>({
+      colorMode: 'contrastLow',
+      sizeMode: 'xl',
+    })
+  );
+});
+
+test('Resets theme to default if returning to a new voter session', () => {
+  const { rerender } = render(
+    <TestHookWrapper
+      authStatus={{
+        status: 'logged_in',
+        user: fakeCardlessVoterUser(),
+        sessionExpiresAt: fakeSessionExpiresAt(),
+      }}
+      votes={ACTIVE_VOTING_SESSION_VOTES}
+    />,
+    { vxTheme: DEFAULT_THEME }
+  );
+
+  // Simulate changing display settings as voter:
+  act(() => {
+    themeManager.setColorMode('contrastLow');
+    themeManager.setSizeMode('xl');
+  });
+
+  expect(currentTheme).toEqual(
+    expect.objectContaining<Partial<DefaultTheme>>({
+      colorMode: 'contrastLow',
+      sizeMode: 'xl',
+    })
+  );
+
+  // Simulate logging in ang changing display settings as Election Manager:
+  rerender(
+    <TestHookWrapper
+      authStatus={{
+        status: 'logged_in',
+        user: fakeElectionManagerUser(),
+        sessionExpiresAt: fakeSessionExpiresAt(),
+      }}
+      votes={ACTIVE_VOTING_SESSION_VOTES}
+    />
+  );
+  act(() => {
+    themeManager.setColorMode('contrastHighDark');
+    themeManager.setSizeMode('s');
+  });
+  expect(currentTheme).toEqual(
+    expect.objectContaining<Partial<DefaultTheme>>({
+      colorMode: 'contrastHighDark',
+      sizeMode: 's',
+    })
+  );
+
+  // Should reset to default if voter session has been reset:
+  rerender(
+    <TestHookWrapper
+      authStatus={{
+        status: 'logged_in',
+        user: fakeCardlessVoterUser(),
+        sessionExpiresAt: fakeSessionExpiresAt(),
+      }}
+      votes={NEW_VOTING_SESSION_VOTES}
+    />
+  );
+  expect(currentTheme).toEqual(
+    expect.objectContaining<Partial<DefaultTheme>>(DEFAULT_THEME)
+  );
+});

--- a/libs/mark-flow-ui/src/hooks/use_display_settings_manager.ts
+++ b/libs/mark-flow-ui/src/hooks/use_display_settings_manager.ts
@@ -1,0 +1,59 @@
+import React from 'react';
+import { DefaultTheme, ThemeContext } from 'styled-components';
+
+import { isCardlessVoterAuth } from '@votingworks/utils';
+import { ThemeManagerContext } from '@votingworks/ui';
+import { InsertedSmartCardAuth, VotesDict } from '@votingworks/types';
+
+export interface UseDisplaySettingsManagerParams {
+  authStatus: InsertedSmartCardAuth.AuthStatus;
+  votes?: VotesDict;
+}
+
+export function useDisplaySettingsManager(
+  params: UseDisplaySettingsManagerParams
+): void {
+  const { authStatus, votes } = params;
+
+  const previousAuthStatus = React.useRef<InsertedSmartCardAuth.AuthStatus>();
+
+  const themeManager = React.useContext(ThemeManagerContext);
+  const currentTheme = React.useContext(ThemeContext);
+  const [voterSessionTheme, setVoterSessionTheme] =
+    React.useState<DefaultTheme | null>(null);
+
+  React.useEffect(() => {
+    const wasPreviouslyLoggedInAsVoter =
+      previousAuthStatus.current &&
+      isCardlessVoterAuth(previousAuthStatus.current);
+    const isLoggedInAsVoter = isCardlessVoterAuth(authStatus);
+    const isVotingSessionActive = !!votes;
+
+    // Reset to default theme when election official logs in, since
+    // non-voter-facing screens are not optimised for larger text sizes:
+    if (wasPreviouslyLoggedInAsVoter && !isLoggedInAsVoter) {
+      setVoterSessionTheme(currentTheme);
+      themeManager.resetThemes();
+    }
+
+    if (
+      !wasPreviouslyLoggedInAsVoter &&
+      isLoggedInAsVoter &&
+      voterSessionTheme
+    ) {
+      if (isVotingSessionActive) {
+        // Reset to previous display settings for the active voter session when
+        // when election official logs out:
+        themeManager.setColorMode(voterSessionTheme.colorMode);
+        themeManager.setSizeMode(voterSessionTheme.sizeMode);
+      } else {
+        // [VVSG 2.0 7.1-A] Reset themes to default if this is a new voting
+        // session:
+        themeManager.resetThemes();
+      }
+      setVoterSessionTheme(null);
+    }
+
+    previousAuthStatus.current = authStatus;
+  }, [authStatus, currentTheme, themeManager, voterSessionTheme, votes]);
+}

--- a/libs/mark-flow-ui/src/index.ts
+++ b/libs/mark-flow-ui/src/index.ts
@@ -1,6 +1,7 @@
 /* istanbul ignore file - no real logic here */
 export * from './components/contest';
 export * from './components/review';
+export * from './hooks/use_display_settings_manager';
 export * from './pages/cast_ballot_page';
 export * from './pages/idle_page';
 export * from './pages/print_page';


### PR DESCRIPTION
## Overview

From VVSG 2.0:
> 7.1-A – Reset to default settings
> If the adjustable settings of the voter interface have been changed by the voter or election worker during the voting session, the system must automatically reset to the default setting when the voter finishes voting, verifying, and casting.

- Add a step to the `resetBallot` app state function to also reset the display settings (since this marks the start of a new voter session).
- Adds a shared react hook to `libs/mark-flow-ui` that monitors auth status and voting session changes and resets to the default settings whenever an election official card is inserted, since non-voter-facing screens are optimised for the default display settings.
  - When the card is removed, we restore the display settings to the previous voter state before the card was inserted (or reset the themes completely if the ballot was reset by the official).

## Demo Video or Screenshot
https://github.com/votingworks/vxsuite/assets/264902/22494595-1ee7-44d3-9b5e-b86741c9aeed

## Testing Plan
- Unit tests for new react hook
- Unit tests to verify hook is called when app root is rendered (in both VxMark and VxMarkScan)

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
