### PR TITLE
[VxScan] Always reset display settings when paper leaves the scanner

### DIFF
--- a/apps/scan/backend/src/types.ts
+++ b/apps/scan/backend/src/types.ts
@@ -7,6 +7,7 @@ import {
   PrecinctSelection,
   SystemSettings,
 } from '@votingworks/types';
+import { PrecinctScannerState } from '@votingworks/types/src/precinct_scanner';
 
 export interface MachineConfig {
   machineId: string;
@@ -19,31 +20,6 @@ export interface PageInterpretationWithAdjudication<
   interpretation: T;
   contestIds?: readonly string[];
 }
-
-export const PRECINCT_SCANNER_STATES = [
-  'connecting',
-  'disconnected',
-  'no_paper',
-  'ready_to_scan',
-  'scanning',
-  'returning_to_rescan',
-  'ready_to_accept',
-  'accepting',
-  'accepted',
-  'needs_review',
-  'accepting_after_review',
-  'returning',
-  'returned',
-  'rejecting',
-  'rejected',
-  'jammed',
-  'both_sides_have_paper',
-  'recovering_from_error',
-  'double_sheet_jammed',
-  'unrecoverable_error',
-] as const;
-
-export type PrecinctScannerState = typeof PRECINCT_SCANNER_STATES[number];
 
 export type InvalidInterpretationReason =
   | 'invalid_test_mode'

--- a/apps/scan/backend/test/helpers/shared_helpers.ts
+++ b/apps/scan/backend/test/helpers/shared_helpers.ts
@@ -15,13 +15,10 @@ import {
 } from '@votingworks/utils';
 import waitForExpect from 'wait-for-expect';
 import { MockUsbDrive } from '@votingworks/usb-drive';
+import { PrecinctScannerState } from '@votingworks/types/src/precinct_scanner';
 import { Api } from '../../src/app';
 import { PrecinctScannerInterpreter } from '../../src/interpret';
-import {
-  PrecinctScannerState,
-  PrecinctScannerStatus,
-  SheetInterpretation,
-} from '../../src/types';
+import { PrecinctScannerStatus, SheetInterpretation } from '../../src/types';
 
 export async function expectStatus(
   apiClient: grout.Client<Api>,

--- a/apps/scan/frontend/src/components/display_settings_manager.test.tsx
+++ b/apps/scan/frontend/src/components/display_settings_manager.test.tsx
@@ -5,8 +5,8 @@ import {
   ThemeManagerContextInterface,
 } from '@votingworks/ui';
 import { electionSampleDefinition } from '@votingworks/fixtures';
-import { PRECINCT_SCANNER_STATES } from '@votingworks/scan-backend';
 import { advanceTimersAndPromises } from '@votingworks/test-utils';
+import { PRECINCT_SCANNER_STATES } from '@votingworks/types';
 import { act, render, waitFor } from '../../test/react_testing_library';
 import { DisplaySettingsManager } from './display_settings_manager';
 import {

--- a/apps/scan/frontend/src/components/display_settings_manager.tsx
+++ b/apps/scan/frontend/src/components/display_settings_manager.tsx
@@ -39,10 +39,13 @@ export function DisplaySettingsManager(): JSX.Element | null {
     }
   });
 
-  // [VVSG 2.0 7.1-A] Reset to default theme when voter is done scanning:
+  // [VVSG 2.0 7.1-A] Reset to default theme when voter is done scanning. We
+  // have chosen to interpret that as whenever paper leaves the scanner (either
+  // into the ballot box, or retrieved by the user after a ballot rejection).
   useQueryChangeListener(scannerStatusQuery, (newStatus, previousStatus) => {
     if (
-      previousStatus?.state === 'accepted' &&
+      previousStatus &&
+      previousStatus.state !== 'no_paper' &&
       newStatus.state === 'no_paper'
     ) {
       themeManager.resetThemes();

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -17,6 +17,7 @@ export * from './image';
 export * from './interpretation';
 export * from './numeric';
 export * from './polls';
+export * from './precinct_scanner';
 export * from './precinct_selection';
 export * from './printing';
 export * from './system_settings';

--- a/libs/types/src/precinct_scanner.ts
+++ b/libs/types/src/precinct_scanner.ts
@@ -1,0 +1,24 @@
+export const PRECINCT_SCANNER_STATES = [
+  'connecting',
+  'disconnected',
+  'no_paper',
+  'ready_to_scan',
+  'scanning',
+  'returning_to_rescan',
+  'ready_to_accept',
+  'accepting',
+  'accepted',
+  'needs_review',
+  'accepting_after_review',
+  'returning',
+  'returned',
+  'rejecting',
+  'rejected',
+  'jammed',
+  'both_sides_have_paper',
+  'recovering_from_error',
+  'double_sheet_jammed',
+  'unrecoverable_error',
+] as const;
+
+export type PrecinctScannerState = typeof PRECINCT_SCANNER_STATES[number];


### PR DESCRIPTION
## Overview

Followup from https://github.com/votingworks/vxsuite/pull/3706, addressing VVSG 7.1-A (Reset to display default settings).

Got guidance from @mattroe about how to handle rejected ballots:
> I think we should reset once a ballot leaves the document scanner -- whether it's casted in the box or a voter takes it from the machine.

Updating the reset logic to always reset when the scanner moves into the `no_paper` state (vs when moving from `accepted` to `no_paper` as before).

## Demo Video or Screenshot
https://github.com/votingworks/vxsuite/assets/264902/378a12d9-794b-4192-a612-cb2746714b63

## Testing Plan
- Updating the existing unit test accordingly

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change~
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
