### PR TITLE
VxDesign: Ballot styles/ballot layout tabs

### DIFF
--- a/apps/design/frontend/src/routes.ts
+++ b/apps/design/frontend/src/routes.ts
@@ -94,6 +94,14 @@ export const routes = {
           label: 'Ballots',
           path: `${root}/ballots`,
         },
+        ballotStyles: {
+          label: 'Ballot Styles',
+          path: `${root}/ballots/ballot-styles`,
+        },
+        ballotLayout: {
+          label: 'Ballot Layout',
+          path: `${root}/ballots/layout`,
+        },
         viewBallot: (ballotStyleId: string, precinctId: string) => ({
           label: 'View Ballot',
           path: `${root}/ballots/${ballotStyleId}/${precinctId}`,


### PR DESCRIPTION
## Overview

Splits the Ballots screen into two tabs, one for the list of ballot styles and one for the ballot layout settings. While this does move the settings one click further away from the ballot previews, I think it helps with the overall organization of the app. Plus, these settings won't actually be modified very much, since they are global settings. Definitely room to improve on this in the future, but a small cleanup for now.

## Demo Video or Screenshot


https://github.com/votingworks/vxsuite/assets/530106/1f7f3123-fd36-4135-a1ea-5ba4fb6af49a



## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
