### PR TITLE
VxDesign: Add term description to candidate contests

### DIFF
--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -337,6 +337,15 @@ function ContestForm({
               min={1}
             />
           </FormField>
+          <FormField label="Term">
+            <Input
+              type="text"
+              value={contest.termDescription}
+              onChange={(e) =>
+                setContest({ ...contest, termDescription: e.target.value })
+              }
+            />
+          </FormField>
           <FormField label="Write-Ins Allowed?">
             <SegmentedControl
               options={[

--- a/apps/design/shared/src/layout.ts
+++ b/apps/design/shared/src/layout.ts
@@ -731,6 +731,14 @@ function CandidateContest({
             : `Vote for not more than ${contest.seats}`,
         fontStyle: m.FontStyles.BODY,
       },
+      ...(contest.termDescription
+        ? [
+            {
+              text: contest.termDescription,
+              fontStyle: m.FontStyles.BODY,
+            },
+          ]
+        : []),
     ],
   });
   const headingRowHeight = Math.round(

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -178,6 +178,7 @@ export interface CandidateContest extends Contest {
   readonly candidates: readonly Candidate[];
   readonly allowWriteIns: boolean;
   readonly partyId?: PartyId;
+  readonly termDescription?: string;
 }
 export const CandidateContestSchema: z.ZodSchema<CandidateContest> =
   ContestInternalSchema.merge(
@@ -187,6 +188,7 @@ export const CandidateContestSchema: z.ZodSchema<CandidateContest> =
       candidates: z.array(CandidateSchema),
       allowWriteIns: z.boolean(),
       partyId: PartyIdSchema.optional(),
+      termDescription: z.string().nonempty().optional(),
     })
   ).superRefine((contest, ctx) => {
     for (const [index, id] of findDuplicateIds(contest.candidates)) {


### PR DESCRIPTION


## Overview

Using a free text field so that users can enter whatever they want to show up on the ballot, rather than trying to figure out what unit should be used to define terms. E.g. they can enter "For three years" or "Term ends: May, 2024."

## Demo Video or Screenshot

<img width="447" alt="Screen Shot 2023-07-27 at 11 08 22 AM" src="https://github.com/votingworks/vxsuite/assets/530106/c6e97772-830e-43db-97c5-633bf517804b">


## Testing Plan
- Visual inspection of ballots
- Existing automated tests for interpretation

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
