### PR TITLE
VxDesign: Fix election date timezone bug

### DIFF
--- a/apps/design/shared/src/layout.ts
+++ b/apps/design/shared/src/layout.ts
@@ -442,6 +442,7 @@ function HeaderAndInstructions({
               month: 'long',
               day: 'numeric',
               year: 'numeric',
+              timeZone: 'UTC',
             }).format(new Date(election.date)),
             fontStyle: { ...m.FontStyles.H3, fontWeight: FontWeights.NORMAL },
           },


### PR DESCRIPTION

## Overview

It was rendering the date in the current user's timezone rather than UTC, which could make it off by a day.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
