### PR TITLE
[libs/ui] Update print base styles to always set font color to black.

### DIFF
--- a/libs/ui/src/global_styles.tsx
+++ b/libs/ui/src/global_styles.tsx
@@ -44,6 +44,7 @@ export const GlobalStyles = createGlobalStyle<GlobalStylesProps>`
   @media print {
     html {
       background: #ffffff;
+      color: #000000;
 
       /* Adjust printed ballot font-size */
       /* stylelint-disable-next-line declaration-no-important */


### PR DESCRIPTION
## Overview

Fixes https://github.com/votingworks/vxsuite/issues/3128:

The global styles installed by the shared `AppBase` component already include a `background-color` override for `@media print`, but is missing a `color` override, which means when the on-screen theme is changed to a dark-mode theme, text is printed with a lighter/white color.

This locks the font color for prints to black, to maintain the expected print contrast.

## Demo Video or Screenshot
### Before/After:
<img width="400" alt="Screenshot 2023-07-31 at 15 27 18" src="https://github.com/votingworks/vxsuite/assets/264902/98cfc490-268a-4a83-990b-7396460f68ff"> <img width="400" alt="Screenshot 2023-07-31 at 15 26 57" src="https://github.com/votingworks/vxsuite/assets/264902/d5ad4b21-3b7d-40c8-9c1c-1e2c0453e187">

## Testing Plan
Manual

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
