### PR TITLE
[libs/ui] Fix BmdPaperBallot printout styling

### DIFF
--- a/apps/admin/frontend/src/__snapshots__/app.test.tsx.snap
+++ b/apps/admin/frontend/src/__snapshots__/app.test.tsx.snap
@@ -1080,28 +1080,97 @@ House Bill 1796 - Flag Referendum
 `;
 
 exports[`L&A (logic and accuracy) flow 2`] = `
-.c11 {
-  word-break: break-word;
-}
-
-.c12 {
+.c15 {
+  font-size: 1em;
   font-weight: 600;
+  line-height: 1.3;
+  margin: 0;
 }
 
-.c13 {
-  font-weight: 600;
-  word-break: break-word;
-}
-
-.c6 {
-  white-space: nowrap;
+.c5 {
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0;
+  font-size: 1rem;
+  margin-bottom: 0.5em;
 }
 
 .c3 {
-  max-width: 66ch;
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0;
+  font-weight: 500;
+  line-height: 1.1700000000000002;
+  margin-bottom: 0.3em;
+  font-size: 1.25rem;
 }
 
-.c5 > svg {
+.c3:not(:first-child) {
+  margin-top: 1.25em;
+}
+
+.c3 + h1,
+.c3 + h2,
+.c3 + h3,
+.c3 + h4,
+.c3 + h5,
+.c3 + h6 {
+  margin-top: 0 !important;
+}
+
+.c4 {
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0;
+  font-weight: 500;
+  line-height: 1.1700000000000002;
+  margin-bottom: 0.3em;
+  font-size: 1.125rem;
+}
+
+.c4:not(:first-child) {
+  margin-top: 1.25em;
+}
+
+.c4 + h1,
+.c4 + h2,
+.c4 + h3,
+.c4 + h4,
+.c4 + h5,
+.c4 + h6 {
+  margin-top: 0 !important;
+}
+
+.c12 {
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0;
+  font-weight: 500;
+  line-height: 1.1700000000000002;
+  margin-bottom: 0.3em;
+  font-size: 1rem;
+  line-height: 1.105;
+  font-weight: 600;
+}
+
+.c12:not(:first-child) {
+  margin-top: 1.25em;
+}
+
+.c12 + h1,
+.c12 + h2,
+.c12 + h3,
+.c12 + h4,
+.c12 + h5,
+.c12 + h6 {
+  margin-top: 0 !important;
+}
+
+.c8 {
+  white-space: nowrap;
+}
+
+.c7 > svg {
   display: block;
   width: 100%;
   height: auto;
@@ -1155,7 +1224,7 @@ exports[`L&A (logic and accuracy) flow 2`] = `
   max-width: 100%;
 }
 
-.c4 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1175,12 +1244,12 @@ exports[`L&A (logic and accuracy) flow 2`] = `
   padding: 0.25em;
 }
 
-.c4 > div:first-child {
+.c6 > div:first-child {
   margin-right: 0.25em;
   width: 1.1in;
 }
 
-.c4 > div:last-child {
+.c6 > div:last-child {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1190,7 +1259,7 @@ exports[`L&A (logic and accuracy) flow 2`] = `
   flex: 1;
 }
 
-.c4 > div:last-child > div {
+.c6 > div:last-child > div {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1207,33 +1276,33 @@ exports[`L&A (logic and accuracy) flow 2`] = `
   font-size: 0.8em;
 }
 
-.c4 > div:last-child > div > div {
+.c6 > div:last-child > div > div {
   margin-bottom: 0.9375em;
 }
 
-.c4 > div:last-child > div > div:last-child {
+.c6 > div:last-child > div > div:last-child {
   margin-bottom: 0;
 }
 
-.c4 > div:last-child > div strong {
+.c6 > div:last-child > div strong {
   font-size: 1.25em;
   word-break: break-word;
 }
 
-.c7 {
+.c9 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
 }
 
-.c8 {
+.c10 {
   -webkit-columns: 2;
   columns: 2;
   -webkit-column-gap: 2em;
   column-gap: 2em;
 }
 
-.c9 {
+.c11 {
   border-bottom: 0.01em solid #000;
   padding: 0.5em 0;
   -webkit-break-inside: avoid;
@@ -1241,21 +1310,16 @@ exports[`L&A (logic and accuracy) flow 2`] = `
   page-break-inside: avoid;
 }
 
-.c10 > h3 {
-  font-size: 0.875em;
-  font-weight: 400;
+.c13 {
+  font-weight: normal;
 }
 
-@media print {
-
+.c14 {
+  display: block;
 }
 
-@media print {
-
-}
-
-@media print {
-
+.c14:not(:last-child) {
+  margin-bottom: 0.125em;
 }
 
 @media print {
@@ -1325,17 +1389,23 @@ exports[`L&A (logic and accuracy) flow 2`] = `
         />
       </div>
       <div
-        class="c3 ballot-header-content"
+        class="ballot-header-content"
       >
-        <h2>
+        <h4
+          class="c3"
+        >
           Unofficial TEST Ballot
-        </h2>
-        <h3>
+        </h4>
+        <h5
+          class="c4"
+        >
           
            
           Mock General Election Choctaw 2020
-        </h3>
-        <p>
+        </h5>
+        <p
+          class="c5"
+        >
           August 26, 2020
           <br />
           Choctaw County
@@ -1344,10 +1414,10 @@ exports[`L&A (logic and accuracy) flow 2`] = `
         </p>
       </div>
       <div
-        class="c4"
+        class="c6"
       >
         <div
-          class="c5"
+          class="c7"
         >
           <svg
             height="128"
@@ -1389,7 +1459,7 @@ exports[`L&A (logic and accuracy) flow 2`] = `
                 Ballot ID
               </div>
               <strong
-                class="c6"
+                class="c8"
               >
                 Asdf1234Asdf12
               </strong>
@@ -1399,206 +1469,222 @@ exports[`L&A (logic and accuracy) flow 2`] = `
       </div>
     </div>
     <div
-      class="c7"
+      class="c9"
     >
       <div
-        class="c8"
+        class="c10"
       >
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               President
-            </h3>
-            <p
-              class="c11"
+            </h6>
+            <span
+              class="c14"
             >
               <span
-                class="c12"
+                class="c15"
               >
                 Presidential Electors for Joe Biden for President and Kamala Harris for Vice President
               </span>
                
               / Democrat
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               Senate 
-            </h3>
-            <p
-              class="c11"
+            </h6>
+            <span
+              class="c14"
             >
               <span
-                class="c12"
+                class="c15"
               >
                 Mike Espy
               </span>
                
               / Democrat
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               1st Congressional District
-            </h3>
-            <p
-              class="c11"
+            </h6>
+            <span
+              class="c14"
             >
               <span
-                class="c12"
+                class="c15"
               >
                 Antonia Eliason
               </span>
                
               / Democrat
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               Supreme Court District 3(Northern) Position 3
-            </h3>
-            <p
-              class="c11"
+            </h6>
+            <span
+              class="c14"
             >
               <span
-                class="c12"
+                class="c15"
               >
                 Josiah Dennis Coleman
               </span>
                
               / Nonpartisan
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               Election Commissioner 05
-            </h3>
-            <p
-              class="c11"
+            </h6>
+            <span
+              class="c14"
             >
               <span
-                class="c12"
+                class="c15"
               >
                 Ouida A Loper
               </span>
                
               / Independent
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               School Board 05
-            </h3>
-            <p
-              class="c11"
+            </h6>
+            <span
+              class="c14"
             >
               <span
-                class="c12"
+                class="c15"
               >
                 Michael D Thomas
               </span>
                
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               Ballot Measure 2
 House Concurrent Resolution No. 47
-            </h3>
-            <p
-              class="c13"
+            </h6>
+            <span
+              class="c14"
             >
-              YES
-            </p>
+              <span
+                class="c15"
+              >
+                YES
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               Ballot Measure 3
 House Bill 1796 - Flag Referendum
-            </h3>
-            <p
-              class="c13"
+            </h6>
+            <span
+              class="c14"
             >
-              YES
-            </p>
+              <span
+                class="c15"
+              >
+                YES
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
-              Ballot Measure 1
-            </h3>
-            <p
-              class="c13"
+          <div>
+            <h6
+              class="c12 c13"
             >
-              FOR APPROVAL OF EITHER Initiative No. 65 OR Alternative Measure No. 65 A
-            </p>
+              Ballot Measure 1
+            </h6>
+            <span
+              class="c14"
+            >
+              <span
+                class="c15"
+              >
+                FOR APPROVAL OF EITHER Initiative No. 65 OR Alternative Measure No. 65 A
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
-              Ballot Measure 1
-            </h3>
-            <p
-              class="c13"
+          <div>
+            <h6
+              class="c12 c13"
             >
-              FOR Initiative Measure No. 65
-            </p>
+              Ballot Measure 1
+            </h6>
+            <span
+              class="c14"
+            >
+              <span
+                class="c15"
+              >
+                FOR Initiative Measure No. 65
+              </span>
+            </span>
           </div>
         </div>
       </div>
@@ -1624,17 +1710,23 @@ House Bill 1796 - Flag Referendum
         />
       </div>
       <div
-        class="c3 ballot-header-content"
+        class="ballot-header-content"
       >
-        <h2>
+        <h4
+          class="c3"
+        >
           Unofficial TEST Ballot
-        </h2>
-        <h3>
+        </h4>
+        <h5
+          class="c4"
+        >
           
            
           Mock General Election Choctaw 2020
-        </h3>
-        <p>
+        </h5>
+        <p
+          class="c5"
+        >
           August 26, 2020
           <br />
           Choctaw County
@@ -1643,10 +1735,10 @@ House Bill 1796 - Flag Referendum
         </p>
       </div>
       <div
-        class="c4"
+        class="c6"
       >
         <div
-          class="c5"
+          class="c7"
         >
           <svg
             height="128"
@@ -1688,7 +1780,7 @@ House Bill 1796 - Flag Referendum
                 Ballot ID
               </div>
               <strong
-                class="c6"
+                class="c8"
               >
                 Asdf1234Asdf12
               </strong>
@@ -1698,206 +1790,222 @@ House Bill 1796 - Flag Referendum
       </div>
     </div>
     <div
-      class="c7"
+      class="c9"
     >
       <div
-        class="c8"
+        class="c10"
       >
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               President
-            </h3>
-            <p
-              class="c11"
+            </h6>
+            <span
+              class="c14"
             >
               <span
-                class="c12"
+                class="c15"
               >
                 Presidential Electors for Donald J. Trump for President and Michael R. Pence for Vice President
               </span>
                
               / Republican
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               Senate 
-            </h3>
-            <p
-              class="c11"
+            </h6>
+            <span
+              class="c14"
             >
               <span
-                class="c12"
+                class="c15"
               >
                 Cindy Hyde-Smith
               </span>
                
               / Republican
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               1st Congressional District
-            </h3>
-            <p
-              class="c11"
+            </h6>
+            <span
+              class="c14"
             >
               <span
-                class="c12"
+                class="c15"
               >
                 Trent Kelly
               </span>
                
               / Republican
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               Supreme Court District 3(Northern) Position 3
-            </h3>
-            <p
-              class="c11"
+            </h6>
+            <span
+              class="c14"
             >
               <span
-                class="c12"
+                class="c15"
               >
                 Percy L. Lynchard
               </span>
                
               / Nonpartisan
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               Election Commissioner 05
-            </h3>
-            <p
-              class="c11"
+            </h6>
+            <span
+              class="c14"
             >
               <span
-                class="c12"
+                class="c15"
               >
                 Wayne McLeod
               </span>
                
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               School Board 05
-            </h3>
-            <p
-              class="c11"
+            </h6>
+            <span
+              class="c14"
             >
               <span
-                class="c12"
+                class="c15"
               >
                 WRITE-IN
               </span>
                
               (write-in)
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               Ballot Measure 2
 House Concurrent Resolution No. 47
-            </h3>
-            <p
-              class="c13"
+            </h6>
+            <span
+              class="c14"
             >
-              NO
-            </p>
+              <span
+                class="c15"
+              >
+                NO
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               Ballot Measure 3
 House Bill 1796 - Flag Referendum
-            </h3>
-            <p
-              class="c13"
+            </h6>
+            <span
+              class="c14"
             >
-              NO
-            </p>
+              <span
+                class="c15"
+              >
+                NO
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
-              Ballot Measure 1
-            </h3>
-            <p
-              class="c13"
+          <div>
+            <h6
+              class="c12 c13"
             >
-              AGAINST BOTH Initiative Measure No. 65 AND Alternative Measure No. 65 A
-            </p>
+              Ballot Measure 1
+            </h6>
+            <span
+              class="c14"
+            >
+              <span
+                class="c15"
+              >
+                AGAINST BOTH Initiative Measure No. 65 AND Alternative Measure No. 65 A
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
-              Ballot Measure 1
-            </h3>
-            <p
-              class="c13"
+          <div>
+            <h6
+              class="c12 c13"
             >
-              FOR Alternative Measure 65 A
-            </p>
+              Ballot Measure 1
+            </h6>
+            <span
+              class="c14"
+            >
+              <span
+                class="c15"
+              >
+                FOR Alternative Measure 65 A
+              </span>
+            </span>
           </div>
         </div>
       </div>
@@ -1923,17 +2031,23 @@ House Bill 1796 - Flag Referendum
         />
       </div>
       <div
-        class="c3 ballot-header-content"
+        class="ballot-header-content"
       >
-        <h2>
+        <h4
+          class="c3"
+        >
           Unofficial TEST Ballot
-        </h2>
-        <h3>
+        </h4>
+        <h5
+          class="c4"
+        >
           
            
           Mock General Election Choctaw 2020
-        </h3>
-        <p>
+        </h5>
+        <p
+          class="c5"
+        >
           August 26, 2020
           <br />
           Choctaw County
@@ -1942,10 +2056,10 @@ House Bill 1796 - Flag Referendum
         </p>
       </div>
       <div
-        class="c4"
+        class="c6"
       >
         <div
-          class="c5"
+          class="c7"
         >
           <svg
             height="128"
@@ -1987,7 +2101,7 @@ House Bill 1796 - Flag Referendum
                 Ballot ID
               </div>
               <strong
-                class="c6"
+                class="c8"
               >
                 Asdf1234Asdf12
               </strong>
@@ -1997,206 +2111,222 @@ House Bill 1796 - Flag Referendum
       </div>
     </div>
     <div
-      class="c7"
+      class="c9"
     >
       <div
-        class="c8"
+        class="c10"
       >
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               President
-            </h3>
-            <p
-              class="c11"
+            </h6>
+            <span
+              class="c14"
             >
               <span
-                class="c12"
+                class="c15"
               >
                 Presidential Electors for Phil Collins for President and Bill Parker for Vice President
               </span>
                
               / Independent
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               Senate 
-            </h3>
-            <p
-              class="c11"
+            </h6>
+            <span
+              class="c14"
             >
               <span
-                class="c12"
+                class="c15"
               >
                 Jimmy Edwards
               </span>
                
               / Libertarian
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               1st Congressional District
-            </h3>
-            <p
-              class="c11"
+            </h6>
+            <span
+              class="c14"
             >
               <span
-                class="c12"
+                class="c15"
               >
                 WRITE-IN
               </span>
                
               (write-in)
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               Supreme Court District 3(Northern) Position 3
-            </h3>
-            <p
-              class="c11"
+            </h6>
+            <span
+              class="c14"
             >
               <span
-                class="c12"
+                class="c15"
               >
                 WRITE-IN
               </span>
                
               (write-in)
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               Election Commissioner 05
-            </h3>
-            <p
-              class="c11"
+            </h6>
+            <span
+              class="c14"
             >
               <span
-                class="c12"
+                class="c15"
               >
                 WRITE-IN
               </span>
                
               (write-in)
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               School Board 05
-            </h3>
-            <p
-              class="c11"
+            </h6>
+            <span
+              class="c14"
             >
               <span
-                class="c12"
+                class="c15"
               >
                 Michael D Thomas
               </span>
                
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               Ballot Measure 2
 House Concurrent Resolution No. 47
-            </h3>
-            <p
-              class="c13"
+            </h6>
+            <span
+              class="c14"
             >
-              YES
-            </p>
+              <span
+                class="c15"
+              >
+                YES
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               Ballot Measure 3
 House Bill 1796 - Flag Referendum
-            </h3>
-            <p
-              class="c13"
+            </h6>
+            <span
+              class="c14"
             >
-              YES
-            </p>
+              <span
+                class="c15"
+              >
+                YES
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
-              Ballot Measure 1
-            </h3>
-            <p
-              class="c13"
+          <div>
+            <h6
+              class="c12 c13"
             >
-              FOR APPROVAL OF EITHER Initiative No. 65 OR Alternative Measure No. 65 A
-            </p>
+              Ballot Measure 1
+            </h6>
+            <span
+              class="c14"
+            >
+              <span
+                class="c15"
+              >
+                FOR APPROVAL OF EITHER Initiative No. 65 OR Alternative Measure No. 65 A
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
-              Ballot Measure 1
-            </h3>
-            <p
-              class="c13"
+          <div>
+            <h6
+              class="c12 c13"
             >
-              FOR Initiative Measure No. 65
-            </p>
+              Ballot Measure 1
+            </h6>
+            <span
+              class="c14"
+            >
+              <span
+                class="c15"
+              >
+                FOR Initiative Measure No. 65
+              </span>
+            </span>
           </div>
         </div>
       </div>
@@ -2222,17 +2352,23 @@ House Bill 1796 - Flag Referendum
         />
       </div>
       <div
-        class="c3 ballot-header-content"
+        class="ballot-header-content"
       >
-        <h2>
+        <h4
+          class="c3"
+        >
           Unofficial TEST Ballot
-        </h2>
-        <h3>
+        </h4>
+        <h5
+          class="c4"
+        >
           
            
           Mock General Election Choctaw 2020
-        </h3>
-        <p>
+        </h5>
+        <p
+          class="c5"
+        >
           August 26, 2020
           <br />
           Choctaw County
@@ -2241,10 +2377,10 @@ House Bill 1796 - Flag Referendum
         </p>
       </div>
       <div
-        class="c4"
+        class="c6"
       >
         <div
-          class="c5"
+          class="c7"
         >
           <svg
             height="128"
@@ -2286,7 +2422,7 @@ House Bill 1796 - Flag Referendum
                 Ballot ID
               </div>
               <strong
-                class="c6"
+                class="c8"
               >
                 Asdf1234Asdf12
               </strong>
@@ -2296,207 +2432,223 @@ House Bill 1796 - Flag Referendum
       </div>
     </div>
     <div
-      class="c7"
+      class="c9"
     >
       <div
-        class="c8"
+        class="c10"
       >
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               President
-            </h3>
-            <p
-              class="c11"
+            </h6>
+            <span
+              class="c14"
             >
               <span
-                class="c12"
+                class="c15"
               >
                 WRITE-IN
               </span>
                
               (write-in)
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               Senate 
-            </h3>
-            <p
-              class="c11"
+            </h6>
+            <span
+              class="c14"
             >
               <span
-                class="c12"
+                class="c15"
               >
                 WRITE-IN
               </span>
                
               (write-in)
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               1st Congressional District
-            </h3>
-            <p
-              class="c11"
+            </h6>
+            <span
+              class="c14"
             >
               <span
-                class="c12"
+                class="c15"
               >
                 Antonia Eliason
               </span>
                
               / Democrat
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               Supreme Court District 3(Northern) Position 3
-            </h3>
-            <p
-              class="c11"
+            </h6>
+            <span
+              class="c14"
             >
               <span
-                class="c12"
+                class="c15"
               >
                 Josiah Dennis Coleman
               </span>
                
               / Nonpartisan
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               Election Commissioner 05
-            </h3>
-            <p
-              class="c11"
+            </h6>
+            <span
+              class="c14"
             >
               <span
-                class="c12"
+                class="c15"
               >
                 Ouida A Loper
               </span>
                
               / Independent
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               School Board 05
-            </h3>
-            <p
-              class="c11"
+            </h6>
+            <span
+              class="c14"
             >
               <span
-                class="c12"
+                class="c15"
               >
                 WRITE-IN
               </span>
                
               (write-in)
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               Ballot Measure 2
 House Concurrent Resolution No. 47
-            </h3>
-            <p
-              class="c13"
+            </h6>
+            <span
+              class="c14"
             >
-              NO
-            </p>
+              <span
+                class="c15"
+              >
+                NO
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c12 c13"
+            >
               Ballot Measure 3
 House Bill 1796 - Flag Referendum
-            </h3>
-            <p
-              class="c13"
+            </h6>
+            <span
+              class="c14"
             >
-              NO
-            </p>
+              <span
+                class="c15"
+              >
+                NO
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
-              Ballot Measure 1
-            </h3>
-            <p
-              class="c13"
+          <div>
+            <h6
+              class="c12 c13"
             >
-              AGAINST BOTH Initiative Measure No. 65 AND Alternative Measure No. 65 A
-            </p>
+              Ballot Measure 1
+            </h6>
+            <span
+              class="c14"
+            >
+              <span
+                class="c15"
+              >
+                AGAINST BOTH Initiative Measure No. 65 AND Alternative Measure No. 65 A
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c9"
+          class="c11"
         >
-          <div
-            class="c3 c10"
-          >
-            <h3>
-              Ballot Measure 1
-            </h3>
-            <p
-              class="c13"
+          <div>
+            <h6
+              class="c12 c13"
             >
-              FOR Alternative Measure 65 A
-            </p>
+              Ballot Measure 1
+            </h6>
+            <span
+              class="c14"
+            >
+              <span
+                class="c15"
+              >
+                FOR Alternative Measure 65 A
+              </span>
+            </span>
           </div>
         </div>
       </div>
@@ -2506,18 +2658,6 @@ House Bill 1796 - Flag Referendum
 `;
 
 exports[`L&A (logic and accuracy) flow 3`] = `
-@media print {
-
-}
-
-@media print {
-
-}
-
-@media print {
-
-}
-
 @media print {
 
 }

--- a/apps/mark-scan/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
+++ b/apps/mark-scan/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
@@ -942,6 +942,45 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
   white-space: nowrap;
 }
 
+.c18 {
+  fill: currentColor;
+  height: 1em;
+  width: 1em;
+}
+
+.c12 {
+  display: inline-block;
+  border: none;
+  border-radius: 0.25em;
+  box-sizing: border-box;
+  background: #d3d3d3;
+  padding: 0.75em 1em;
+  text-align: center;
+  line-height: 1.25;
+  color: #000000;
+  touch-action: manipulation;
+}
+
+.c12:hover,
+.c12:active {
+  outline: none;
+}
+
+.c27 {
+  display: none;
+}
+
+.c14 {
+  display: inline-block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+}
+
 .c25 {
   max-width: 66ch;
   line-height: 1.2;
@@ -1110,45 +1149,6 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
 .c34 hr {
   border: 0;
   border-top: 0.1em solid #666;
-}
-
-.c18 {
-  fill: currentColor;
-  height: 1em;
-  width: 1em;
-}
-
-.c12 {
-  display: inline-block;
-  border: none;
-  border-radius: 0.25em;
-  box-sizing: border-box;
-  background: #d3d3d3;
-  padding: 0.75em 1em;
-  text-align: center;
-  line-height: 1.25;
-  color: #000000;
-  touch-action: manipulation;
-}
-
-.c12:hover,
-.c12:active {
-  outline: none;
-}
-
-.c27 {
-  display: none;
-}
-
-.c14 {
-  display: inline-block;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
 }
 
 .c17 {

--- a/apps/mark-scan/frontend/src/pages/__snapshots__/not_found_page.test.tsx.snap
+++ b/apps/mark-scan/frontend/src/pages/__snapshots__/not_found_page.test.tsx.snap
@@ -33,6 +33,35 @@ exports[`renders NotFoundPage 1`] = `
   margin-top: 0 !important;
 }
 
+.c5 {
+  display: inline-block;
+  border: none;
+  border-radius: 0.25em;
+  box-sizing: border-box;
+  background: #d3d3d3;
+  padding: 0.75em 1em;
+  text-align: center;
+  line-height: 1.25;
+  color: #000000;
+  touch-action: manipulation;
+}
+
+.c5:hover,
+.c5:active {
+  outline: none;
+}
+
+.c6 {
+  display: inline-block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+}
+
 .c2 {
   margin: 0 auto;
   max-width: 66ch;
@@ -118,35 +147,6 @@ exports[`renders NotFoundPage 1`] = `
 .c2 hr {
   border: 0;
   border-top: 0.1em solid #666;
-}
-
-.c5 {
-  display: inline-block;
-  border: none;
-  border-radius: 0.25em;
-  box-sizing: border-box;
-  background: #d3d3d3;
-  padding: 0.75em 1em;
-  text-align: center;
-  line-height: 1.25;
-  color: #000000;
-  touch-action: manipulation;
-}
-
-.c5:hover,
-.c5:active {
-  outline: none;
-}
-
-.c6 {
-  display: inline-block;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
 }
 
 .c0 {

--- a/apps/mark-scan/frontend/src/pages/__snapshots__/start_page.test.tsx.snap
+++ b/apps/mark-scan/frontend/src/pages/__snapshots__/start_page.test.tsx.snap
@@ -83,6 +83,54 @@ exports[`renders StartPage 1`] = `
   white-space: nowrap;
 }
 
+.c12 {
+  display: inline-block;
+  border: none;
+  border-radius: 0.25em;
+  box-sizing: border-box;
+  background: #47a74b;
+  padding: 1em 1.75em;
+  text-align: center;
+  line-height: 1.25;
+  color: #ffffff;
+  font-size: 1.25em;
+  touch-action: manipulation;
+}
+
+.c12:hover,
+.c12:active {
+  outline: none;
+}
+
+.c19 {
+  display: inline-block;
+  border: none;
+  border-radius: 0.25em;
+  box-sizing: border-box;
+  background: #d3d3d3;
+  padding: 0.75em 1em;
+  text-align: center;
+  line-height: 1.25;
+  color: #000000;
+  touch-action: manipulation;
+}
+
+.c19:hover,
+.c19:active {
+  outline: none;
+}
+
+.c13 {
+  display: inline-block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+}
+
 .c5 {
   margin: 0 auto;
   max-width: 66ch;
@@ -168,54 +216,6 @@ exports[`renders StartPage 1`] = `
 .c5 hr {
   border: 0;
   border-top: 0.1em solid #666;
-}
-
-.c12 {
-  display: inline-block;
-  border: none;
-  border-radius: 0.25em;
-  box-sizing: border-box;
-  background: #47a74b;
-  padding: 1em 1.75em;
-  text-align: center;
-  line-height: 1.25;
-  color: #ffffff;
-  font-size: 1.25em;
-  touch-action: manipulation;
-}
-
-.c12:hover,
-.c12:active {
-  outline: none;
-}
-
-.c19 {
-  display: inline-block;
-  border: none;
-  border-radius: 0.25em;
-  box-sizing: border-box;
-  background: #d3d3d3;
-  padding: 0.75em 1em;
-  text-align: center;
-  line-height: 1.25;
-  color: #000000;
-  touch-action: manipulation;
-}
-
-.c19:hover,
-.c19:active {
-  outline: none;
-}
-
-.c13 {
-  display: inline-block;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
 }
 
 .c0 {
@@ -591,6 +591,54 @@ exports[`renders StartPage with inline SVG 1`] = `
   white-space: nowrap;
 }
 
+.c11 {
+  display: inline-block;
+  border: none;
+  border-radius: 0.25em;
+  box-sizing: border-box;
+  background: #47a74b;
+  padding: 1em 1.75em;
+  text-align: center;
+  line-height: 1.25;
+  color: #ffffff;
+  font-size: 1.25em;
+  touch-action: manipulation;
+}
+
+.c11:hover,
+.c11:active {
+  outline: none;
+}
+
+.c18 {
+  display: inline-block;
+  border: none;
+  border-radius: 0.25em;
+  box-sizing: border-box;
+  background: #d3d3d3;
+  padding: 0.75em 1em;
+  text-align: center;
+  line-height: 1.25;
+  color: #000000;
+  touch-action: manipulation;
+}
+
+.c18:hover,
+.c18:active {
+  outline: none;
+}
+
+.c12 {
+  display: inline-block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+}
+
 .c4 {
   margin: 0 auto;
   max-width: 66ch;
@@ -676,54 +724,6 @@ exports[`renders StartPage with inline SVG 1`] = `
 .c4 hr {
   border: 0;
   border-top: 0.1em solid #666;
-}
-
-.c11 {
-  display: inline-block;
-  border: none;
-  border-radius: 0.25em;
-  box-sizing: border-box;
-  background: #47a74b;
-  padding: 1em 1.75em;
-  text-align: center;
-  line-height: 1.25;
-  color: #ffffff;
-  font-size: 1.25em;
-  touch-action: manipulation;
-}
-
-.c11:hover,
-.c11:active {
-  outline: none;
-}
-
-.c18 {
-  display: inline-block;
-  border: none;
-  border-radius: 0.25em;
-  box-sizing: border-box;
-  background: #d3d3d3;
-  padding: 0.75em 1em;
-  text-align: center;
-  line-height: 1.25;
-  color: #000000;
-  touch-action: manipulation;
-}
-
-.c18:hover,
-.c18:active {
-  outline: none;
-}
-
-.c12 {
-  display: inline-block;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
 }
 
 .c0 {
@@ -1253,6 +1253,54 @@ exports[`renders StartPage with no seal 1`] = `
   white-space: nowrap;
 }
 
+.c11 {
+  display: inline-block;
+  border: none;
+  border-radius: 0.25em;
+  box-sizing: border-box;
+  background: #47a74b;
+  padding: 1em 1.75em;
+  text-align: center;
+  line-height: 1.25;
+  color: #ffffff;
+  font-size: 1.25em;
+  touch-action: manipulation;
+}
+
+.c11:hover,
+.c11:active {
+  outline: none;
+}
+
+.c18 {
+  display: inline-block;
+  border: none;
+  border-radius: 0.25em;
+  box-sizing: border-box;
+  background: #d3d3d3;
+  padding: 0.75em 1em;
+  text-align: center;
+  line-height: 1.25;
+  color: #000000;
+  touch-action: manipulation;
+}
+
+.c18:hover,
+.c18:active {
+  outline: none;
+}
+
+.c12 {
+  display: inline-block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+}
+
 .c4 {
   margin: 0 auto;
   max-width: 66ch;
@@ -1338,54 +1386,6 @@ exports[`renders StartPage with no seal 1`] = `
 .c4 hr {
   border: 0;
   border-top: 0.1em solid #666;
-}
-
-.c11 {
-  display: inline-block;
-  border: none;
-  border-radius: 0.25em;
-  box-sizing: border-box;
-  background: #47a74b;
-  padding: 1em 1.75em;
-  text-align: center;
-  line-height: 1.25;
-  color: #ffffff;
-  font-size: 1.25em;
-  touch-action: manipulation;
-}
-
-.c11:hover,
-.c11:active {
-  outline: none;
-}
-
-.c18 {
-  display: inline-block;
-  border: none;
-  border-radius: 0.25em;
-  box-sizing: border-box;
-  background: #d3d3d3;
-  padding: 0.75em 1em;
-  text-align: center;
-  line-height: 1.25;
-  color: #000000;
-  touch-action: manipulation;
-}
-
-.c18:hover,
-.c18:active {
-  outline: none;
-}
-
-.c12 {
-  display: inline-block;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
 }
 
 .c0 {

--- a/apps/mark/frontend/src/pages/__snapshots__/not_found_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/not_found_page.test.tsx.snap
@@ -33,6 +33,35 @@ exports[`renders NotFoundPage 1`] = `
   margin-top: 0 !important;
 }
 
+.c5 {
+  display: inline-block;
+  border: none;
+  border-radius: 0.25em;
+  box-sizing: border-box;
+  background: #d3d3d3;
+  padding: 0.75em 1em;
+  text-align: center;
+  line-height: 1.25;
+  color: #000000;
+  touch-action: manipulation;
+}
+
+.c5:hover,
+.c5:active {
+  outline: none;
+}
+
+.c6 {
+  display: inline-block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+}
+
 .c2 {
   margin: 0 auto;
   max-width: 66ch;
@@ -118,35 +147,6 @@ exports[`renders NotFoundPage 1`] = `
 .c2 hr {
   border: 0;
   border-top: 0.1em solid #666;
-}
-
-.c5 {
-  display: inline-block;
-  border: none;
-  border-radius: 0.25em;
-  box-sizing: border-box;
-  background: #d3d3d3;
-  padding: 0.75em 1em;
-  text-align: center;
-  line-height: 1.25;
-  color: #000000;
-  touch-action: manipulation;
-}
-
-.c5:hover,
-.c5:active {
-  outline: none;
-}
-
-.c6 {
-  display: inline-block;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
 }
 
 .c0 {

--- a/libs/mark-flow-ui/src/pages/__snapshots__/print_page.test.tsx.snap
+++ b/libs/mark-flow-ui/src/pages/__snapshots__/print_page.test.tsx.snap
@@ -1,20 +1,97 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`no votes 1`] = `
-.c10 {
-  color: gray;
-  font-style: italic;
+.c14 {
+  font-size: 1em;
+  font-weight: 200;
+  line-height: 1.3;
+  margin: 0;
 }
 
-.c5 {
-  white-space: nowrap;
+.c4 {
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0;
+  font-size: 1rem;
+  margin-bottom: 0.5em;
 }
 
 .c2 {
-  max-width: 66ch;
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0;
+  font-weight: 500;
+  line-height: 1.1700000000000002;
+  margin-bottom: 0.3em;
+  font-size: 1.25rem;
 }
 
-.c4 > svg {
+.c2:not(:first-child) {
+  margin-top: 1.25em;
+}
+
+.c2 + h1,
+.c2 + h2,
+.c2 + h3,
+.c2 + h4,
+.c2 + h5,
+.c2 + h6 {
+  margin-top: 0 !important;
+}
+
+.c3 {
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0;
+  font-weight: 500;
+  line-height: 1.1700000000000002;
+  margin-bottom: 0.3em;
+  font-size: 1.125rem;
+}
+
+.c3:not(:first-child) {
+  margin-top: 1.25em;
+}
+
+.c3 + h1,
+.c3 + h2,
+.c3 + h3,
+.c3 + h4,
+.c3 + h5,
+.c3 + h6 {
+  margin-top: 0 !important;
+}
+
+.c11 {
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0;
+  font-weight: 500;
+  line-height: 1.1700000000000002;
+  margin-bottom: 0.3em;
+  font-size: 1rem;
+  line-height: 1.105;
+  font-weight: 600;
+}
+
+.c11:not(:first-child) {
+  margin-top: 1.25em;
+}
+
+.c11 + h1,
+.c11 + h2,
+.c11 + h3,
+.c11 + h4,
+.c11 + h5,
+.c11 + h6 {
+  margin-top: 0 !important;
+}
+
+.c7 {
+  white-space: nowrap;
+}
+
+.c6 > svg {
   display: block;
   width: 100%;
   height: auto;
@@ -64,7 +141,7 @@ exports[`no votes 1`] = `
   max-width: 100%;
 }
 
-.c3 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -84,12 +161,12 @@ exports[`no votes 1`] = `
   padding: 0.25em;
 }
 
-.c3 > div:first-child {
+.c5 > div:first-child {
   margin-right: 0.25em;
   width: 1.1in;
 }
 
-.c3 > div:last-child {
+.c5 > div:last-child {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -99,7 +176,7 @@ exports[`no votes 1`] = `
   flex: 1;
 }
 
-.c3 > div:last-child > div {
+.c5 > div:last-child > div {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -116,33 +193,33 @@ exports[`no votes 1`] = `
   font-size: 0.8em;
 }
 
-.c3 > div:last-child > div > div {
+.c5 > div:last-child > div > div {
   margin-bottom: 0.9375em;
 }
 
-.c3 > div:last-child > div > div:last-child {
+.c5 > div:last-child > div > div:last-child {
   margin-bottom: 0;
 }
 
-.c3 > div:last-child > div strong {
+.c5 > div:last-child > div strong {
   font-size: 1.25em;
   word-break: break-word;
 }
 
-.c6 {
+.c8 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
 }
 
-.c7 {
+.c9 {
   -webkit-columns: 2;
   columns: 2;
   -webkit-column-gap: 2em;
   column-gap: 2em;
 }
 
-.c8 {
+.c10 {
   border-bottom: 0.01em solid #000;
   padding: 0.5em 0;
   -webkit-break-inside: avoid;
@@ -150,9 +227,16 @@ exports[`no votes 1`] = `
   page-break-inside: avoid;
 }
 
-.c9 > h3 {
-  font-size: 0.875em;
-  font-weight: 400;
+.c12 {
+  font-weight: normal;
+}
+
+.c13 {
+  display: block;
+}
+
+.c13:not(:last-child) {
+  margin-bottom: 0.125em;
 }
 
 @media print {
@@ -165,12 +249,6 @@ exports[`no votes 1`] = `
 
 @media print {
 
-}
-
-@media print {
-  .c10 {
-    color: black;
-  }
 }
 
 @media screen {
@@ -360,17 +438,23 @@ exports[`no votes 1`] = `
         </svg>
       </div>
       <div
-        class="c2 ballot-header-content"
+        class="ballot-header-content"
       >
-        <h2>
+        <h4
+          class="c2"
+        >
           Unofficial TEST Ballot
-        </h2>
-        <h3>
+        </h4>
+        <h5
+          class="c3"
+        >
           
            
           General Election
-        </h3>
-        <p>
+        </h5>
+        <p
+          class="c4"
+        >
           November 3, 2020
           <br />
           Franklin County
@@ -379,10 +463,10 @@ exports[`no votes 1`] = `
         </p>
       </div>
       <div
-        class="c3"
+        class="c5"
       >
         <div
-          class="c4"
+          class="c6"
         >
           <svg
             height="128"
@@ -424,7 +508,7 @@ exports[`no votes 1`] = `
                 Ballot ID
               </div>
               <strong
-                class="c5"
+                class="c7"
               >
                 CHhgYxfN5GeqnK8KaVOt1w
               </strong>
@@ -434,185 +518,229 @@ exports[`no votes 1`] = `
       </div>
     </div>
     <div
-      class="c6"
+      class="c8"
     >
       <div
-        class="c7"
+        class="c9"
       >
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               President and Vice-President
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Representative, District 6
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Lieutenant Governor
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Senator, District 31
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Assembly Member, District 54
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Registrar of Wills
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Retain Robert Demergue as Chief Justice?
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Question A: Recovery of Property Damages
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Question B: Separation of Powers
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Proposition 1: Gambling in Franklin and Fromwit Counties
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
-              Measure 102: Vehicle Abatement Program
-            </h3>
-            <p
-              class="c10"
+          <div>
+            <h6
+              class="c11 c12"
             >
-              [no selection]
-            </p>
+              Measure 102: Vehicle Abatement Program
+            </h6>
+            <span
+              class="c13"
+            >
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
       </div>
@@ -622,33 +750,104 @@ exports[`no votes 1`] = `
 `;
 
 exports[`with votes 1`] = `
-.c10 {
-  word-break: break-word;
-}
-
-.c11 {
+.c14 {
+  font-size: 1em;
   font-weight: 600;
+  line-height: 1.3;
+  margin: 0;
 }
 
-.c12 {
-  color: gray;
-  font-style: italic;
+.c15 {
+  font-size: 1em;
+  font-weight: 200;
+  line-height: 1.3;
+  margin: 0;
 }
 
-.c13 {
-  font-weight: 600;
-  word-break: break-word;
-}
-
-.c5 {
-  white-space: nowrap;
+.c4 {
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0;
+  font-size: 1rem;
+  margin-bottom: 0.5em;
 }
 
 .c2 {
-  max-width: 66ch;
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0;
+  font-weight: 500;
+  line-height: 1.1700000000000002;
+  margin-bottom: 0.3em;
+  font-size: 1.25rem;
 }
 
-.c4 > svg {
+.c2:not(:first-child) {
+  margin-top: 1.25em;
+}
+
+.c2 + h1,
+.c2 + h2,
+.c2 + h3,
+.c2 + h4,
+.c2 + h5,
+.c2 + h6 {
+  margin-top: 0 !important;
+}
+
+.c3 {
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0;
+  font-weight: 500;
+  line-height: 1.1700000000000002;
+  margin-bottom: 0.3em;
+  font-size: 1.125rem;
+}
+
+.c3:not(:first-child) {
+  margin-top: 1.25em;
+}
+
+.c3 + h1,
+.c3 + h2,
+.c3 + h3,
+.c3 + h4,
+.c3 + h5,
+.c3 + h6 {
+  margin-top: 0 !important;
+}
+
+.c11 {
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0;
+  font-weight: 500;
+  line-height: 1.1700000000000002;
+  margin-bottom: 0.3em;
+  font-size: 1rem;
+  line-height: 1.105;
+  font-weight: 600;
+}
+
+.c11:not(:first-child) {
+  margin-top: 1.25em;
+}
+
+.c11 + h1,
+.c11 + h2,
+.c11 + h3,
+.c11 + h4,
+.c11 + h5,
+.c11 + h6 {
+  margin-top: 0 !important;
+}
+
+.c7 {
+  white-space: nowrap;
+}
+
+.c6 > svg {
   display: block;
   width: 100%;
   height: auto;
@@ -698,7 +897,7 @@ exports[`with votes 1`] = `
   max-width: 100%;
 }
 
-.c3 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -718,12 +917,12 @@ exports[`with votes 1`] = `
   padding: 0.25em;
 }
 
-.c3 > div:first-child {
+.c5 > div:first-child {
   margin-right: 0.25em;
   width: 1.1in;
 }
 
-.c3 > div:last-child {
+.c5 > div:last-child {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -733,7 +932,7 @@ exports[`with votes 1`] = `
   flex: 1;
 }
 
-.c3 > div:last-child > div {
+.c5 > div:last-child > div {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -750,33 +949,33 @@ exports[`with votes 1`] = `
   font-size: 0.8em;
 }
 
-.c3 > div:last-child > div > div {
+.c5 > div:last-child > div > div {
   margin-bottom: 0.9375em;
 }
 
-.c3 > div:last-child > div > div:last-child {
+.c5 > div:last-child > div > div:last-child {
   margin-bottom: 0;
 }
 
-.c3 > div:last-child > div strong {
+.c5 > div:last-child > div strong {
   font-size: 1.25em;
   word-break: break-word;
 }
 
-.c6 {
+.c8 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
 }
 
-.c7 {
+.c9 {
   -webkit-columns: 2;
   columns: 2;
   -webkit-column-gap: 2em;
   column-gap: 2em;
 }
 
-.c8 {
+.c10 {
   border-bottom: 0.01em solid #000;
   padding: 0.5em 0;
   -webkit-break-inside: avoid;
@@ -784,27 +983,16 @@ exports[`with votes 1`] = `
   page-break-inside: avoid;
 }
 
-.c9 > h3 {
-  font-size: 0.875em;
-  font-weight: 400;
+.c12 {
+  font-weight: normal;
 }
 
-@media print {
-
+.c13 {
+  display: block;
 }
 
-@media print {
-
-}
-
-@media print {
-  .c12 {
-    color: black;
-  }
-}
-
-@media print {
-
+.c13:not(:last-child) {
+  margin-bottom: 0.125em;
 }
 
 @media screen {
@@ -1006,17 +1194,23 @@ exports[`with votes 1`] = `
         </svg>
       </div>
       <div
-        class="c2 ballot-header-content"
+        class="ballot-header-content"
       >
-        <h2>
+        <h4
+          class="c2"
+        >
           Unofficial TEST Ballot
-        </h2>
-        <h3>
+        </h4>
+        <h5
+          class="c3"
+        >
           
            
           General Election
-        </h3>
-        <p>
+        </h5>
+        <p
+          class="c4"
+        >
           November 3, 2020
           <br />
           Franklin County
@@ -1025,10 +1219,10 @@ exports[`with votes 1`] = `
         </p>
       </div>
       <div
-        class="c3"
+        class="c5"
       >
         <div
-          class="c4"
+          class="c6"
         >
           <svg
             height="128"
@@ -1070,7 +1264,7 @@ exports[`with votes 1`] = `
                 Ballot ID
               </div>
               <strong
-                class="c5"
+                class="c7"
               >
                 CHhgYxfN5GeqnK8KaVOt1w
               </strong>
@@ -1080,197 +1274,233 @@ exports[`with votes 1`] = `
       </div>
     </div>
     <div
-      class="c6"
+      class="c8"
     >
       <div
-        class="c7"
+        class="c9"
       >
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               President and Vice-President
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
               <span
-                class="c11"
+                class="c14"
               >
                 Joseph Barchi and Joseph Hallaren
               </span>
                
               / Federalist
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
-              Representative, District 6
-            </h3>
-            <p
-              class="c12"
+          <div>
+            <h6
+              class="c11 c12"
             >
-              [no selection]
-            </p>
-          </div>
-        </div>
-        <div
-          class="c8"
-        >
-          <div
-            class="c2 c9"
-          >
-            <h3>
-              Lieutenant Governor
-            </h3>
-            <p
-              class="c10"
+              Representative, District 6
+            </h6>
+            <span
+              class="c13"
             >
               <span
-                class="c11"
+                class="c15"
+              >
+                [no selection]
+              </span>
+            </span>
+          </div>
+        </div>
+        <div
+          class="c10"
+        >
+          <div>
+            <h6
+              class="c11 c12"
+            >
+              Lieutenant Governor
+            </h6>
+            <span
+              class="c13"
+            >
+              <span
+                class="c14"
               >
                 Chris Norberg
               </span>
                
               / Federalist
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Senator, District 31
-            </h3>
-            <p
-              class="c12"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c15"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Assembly Member, District 54
-            </h3>
-            <p
-              class="c12"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c15"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Registrar of Wills
-            </h3>
-            <p
-              class="c12"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c15"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Retain Robert Demergue as Chief Justice?
-            </h3>
-            <p
-              class="c12"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c15"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Question A: Recovery of Property Damages
-            </h3>
-            <p
+            </h6>
+            <span
               class="c13"
             >
-              No
-            </p>
+              <span
+                class="c14"
+              >
+                No
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Question B: Separation of Powers
-            </h3>
-            <p
+            </h6>
+            <span
               class="c13"
             >
-              Yes
-            </p>
+              <span
+                class="c14"
+              >
+                Yes
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Proposition 1: Gambling in Franklin and Fromwit Counties
-            </h3>
-            <p
-              class="c12"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c15"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
-              Measure 102: Vehicle Abatement Program
-            </h3>
-            <p
-              class="c12"
+          <div>
+            <h6
+              class="c11 c12"
             >
-              [no selection]
-            </p>
+              Measure 102: Vehicle Abatement Program
+            </h6>
+            <span
+              class="c13"
+            >
+              <span
+                class="c15"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
       </div>
@@ -1280,20 +1510,97 @@ exports[`with votes 1`] = `
 `;
 
 exports[`without votes and inline seal 1`] = `
-.c10 {
-  color: gray;
-  font-style: italic;
+.c14 {
+  font-size: 1em;
+  font-weight: 200;
+  line-height: 1.3;
+  margin: 0;
 }
 
-.c5 {
-  white-space: nowrap;
+.c4 {
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0;
+  font-size: 1rem;
+  margin-bottom: 0.5em;
 }
 
 .c2 {
-  max-width: 66ch;
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0;
+  font-weight: 500;
+  line-height: 1.1700000000000002;
+  margin-bottom: 0.3em;
+  font-size: 1.25rem;
 }
 
-.c4 > svg {
+.c2:not(:first-child) {
+  margin-top: 1.25em;
+}
+
+.c2 + h1,
+.c2 + h2,
+.c2 + h3,
+.c2 + h4,
+.c2 + h5,
+.c2 + h6 {
+  margin-top: 0 !important;
+}
+
+.c3 {
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0;
+  font-weight: 500;
+  line-height: 1.1700000000000002;
+  margin-bottom: 0.3em;
+  font-size: 1.125rem;
+}
+
+.c3:not(:first-child) {
+  margin-top: 1.25em;
+}
+
+.c3 + h1,
+.c3 + h2,
+.c3 + h3,
+.c3 + h4,
+.c3 + h5,
+.c3 + h6 {
+  margin-top: 0 !important;
+}
+
+.c11 {
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0;
+  font-weight: 500;
+  line-height: 1.1700000000000002;
+  margin-bottom: 0.3em;
+  font-size: 1rem;
+  line-height: 1.105;
+  font-weight: 600;
+}
+
+.c11:not(:first-child) {
+  margin-top: 1.25em;
+}
+
+.c11 + h1,
+.c11 + h2,
+.c11 + h3,
+.c11 + h4,
+.c11 + h5,
+.c11 + h6 {
+  margin-top: 0 !important;
+}
+
+.c7 {
+  white-space: nowrap;
+}
+
+.c6 > svg {
   display: block;
   width: 100%;
   height: auto;
@@ -1343,7 +1650,7 @@ exports[`without votes and inline seal 1`] = `
   max-width: 100%;
 }
 
-.c3 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1363,12 +1670,12 @@ exports[`without votes and inline seal 1`] = `
   padding: 0.25em;
 }
 
-.c3 > div:first-child {
+.c5 > div:first-child {
   margin-right: 0.25em;
   width: 1.1in;
 }
 
-.c3 > div:last-child {
+.c5 > div:last-child {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1378,7 +1685,7 @@ exports[`without votes and inline seal 1`] = `
   flex: 1;
 }
 
-.c3 > div:last-child > div {
+.c5 > div:last-child > div {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1395,33 +1702,33 @@ exports[`without votes and inline seal 1`] = `
   font-size: 0.8em;
 }
 
-.c3 > div:last-child > div > div {
+.c5 > div:last-child > div > div {
   margin-bottom: 0.9375em;
 }
 
-.c3 > div:last-child > div > div:last-child {
+.c5 > div:last-child > div > div:last-child {
   margin-bottom: 0;
 }
 
-.c3 > div:last-child > div strong {
+.c5 > div:last-child > div strong {
   font-size: 1.25em;
   word-break: break-word;
 }
 
-.c6 {
+.c8 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
 }
 
-.c7 {
+.c9 {
   -webkit-columns: 2;
   columns: 2;
   -webkit-column-gap: 2em;
   column-gap: 2em;
 }
 
-.c8 {
+.c10 {
   border-bottom: 0.01em solid #000;
   padding: 0.5em 0;
   -webkit-break-inside: avoid;
@@ -1429,15 +1736,16 @@ exports[`without votes and inline seal 1`] = `
   page-break-inside: avoid;
 }
 
-.c9 > h3 {
-  font-size: 0.875em;
-  font-weight: 400;
+.c12 {
+  font-weight: normal;
 }
 
-@media print {
-  .c10 {
-    color: black;
-  }
+.c13 {
+  display: block;
+}
+
+.c13:not(:last-child) {
+  margin-bottom: 0.125em;
 }
 
 @media screen {
@@ -1639,17 +1947,23 @@ exports[`without votes and inline seal 1`] = `
         </svg>
       </div>
       <div
-        class="c2 ballot-header-content"
+        class="ballot-header-content"
       >
-        <h2>
+        <h4
+          class="c2"
+        >
           Unofficial TEST Ballot
-        </h2>
-        <h3>
+        </h4>
+        <h5
+          class="c3"
+        >
           
            
           General Election
-        </h3>
-        <p>
+        </h5>
+        <p
+          class="c4"
+        >
           November 3, 2020
           <br />
           Franklin County
@@ -1658,10 +1972,10 @@ exports[`without votes and inline seal 1`] = `
         </p>
       </div>
       <div
-        class="c3"
+        class="c5"
       >
         <div
-          class="c4"
+          class="c6"
         >
           <svg
             height="128"
@@ -1703,7 +2017,7 @@ exports[`without votes and inline seal 1`] = `
                 Ballot ID
               </div>
               <strong
-                class="c5"
+                class="c7"
               >
                 CHhgYxfN5GeqnK8KaVOt1w
               </strong>
@@ -1713,185 +2027,229 @@ exports[`without votes and inline seal 1`] = `
       </div>
     </div>
     <div
-      class="c6"
+      class="c8"
     >
       <div
-        class="c7"
+        class="c9"
       >
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               President and Vice-President
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Representative, District 6
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Lieutenant Governor
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Senator, District 31
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Assembly Member, District 54
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Registrar of Wills
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Retain Robert Demergue as Chief Justice?
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Question A: Recovery of Property Damages
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Question B: Separation of Powers
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Proposition 1: Gambling in Franklin and Fromwit Counties
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
-              Measure 102: Vehicle Abatement Program
-            </h3>
-            <p
-              class="c10"
+          <div>
+            <h6
+              class="c11 c12"
             >
-              [no selection]
-            </p>
+              Measure 102: Vehicle Abatement Program
+            </h6>
+            <span
+              class="c13"
+            >
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
       </div>
@@ -1901,20 +2259,97 @@ exports[`without votes and inline seal 1`] = `
 `;
 
 exports[`without votes and no seal 1`] = `
-.c10 {
-  color: gray;
-  font-style: italic;
+.c14 {
+  font-size: 1em;
+  font-weight: 200;
+  line-height: 1.3;
+  margin: 0;
 }
 
-.c5 {
-  white-space: nowrap;
+.c4 {
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0;
+  font-size: 1rem;
+  margin-bottom: 0.5em;
 }
 
 .c2 {
-  max-width: 66ch;
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0;
+  font-weight: 500;
+  line-height: 1.1700000000000002;
+  margin-bottom: 0.3em;
+  font-size: 1.25rem;
 }
 
-.c4 > svg {
+.c2:not(:first-child) {
+  margin-top: 1.25em;
+}
+
+.c2 + h1,
+.c2 + h2,
+.c2 + h3,
+.c2 + h4,
+.c2 + h5,
+.c2 + h6 {
+  margin-top: 0 !important;
+}
+
+.c3 {
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0;
+  font-weight: 500;
+  line-height: 1.1700000000000002;
+  margin-bottom: 0.3em;
+  font-size: 1.125rem;
+}
+
+.c3:not(:first-child) {
+  margin-top: 1.25em;
+}
+
+.c3 + h1,
+.c3 + h2,
+.c3 + h3,
+.c3 + h4,
+.c3 + h5,
+.c3 + h6 {
+  margin-top: 0 !important;
+}
+
+.c11 {
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0;
+  font-weight: 500;
+  line-height: 1.1700000000000002;
+  margin-bottom: 0.3em;
+  font-size: 1rem;
+  line-height: 1.105;
+  font-weight: 600;
+}
+
+.c11:not(:first-child) {
+  margin-top: 1.25em;
+}
+
+.c11 + h1,
+.c11 + h2,
+.c11 + h3,
+.c11 + h4,
+.c11 + h5,
+.c11 + h6 {
+  margin-top: 0 !important;
+}
+
+.c7 {
+  white-space: nowrap;
+}
+
+.c6 > svg {
   display: block;
   width: 100%;
   height: auto;
@@ -1964,7 +2399,7 @@ exports[`without votes and no seal 1`] = `
   max-width: 100%;
 }
 
-.c3 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1984,12 +2419,12 @@ exports[`without votes and no seal 1`] = `
   padding: 0.25em;
 }
 
-.c3 > div:first-child {
+.c5 > div:first-child {
   margin-right: 0.25em;
   width: 1.1in;
 }
 
-.c3 > div:last-child {
+.c5 > div:last-child {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1999,7 +2434,7 @@ exports[`without votes and no seal 1`] = `
   flex: 1;
 }
 
-.c3 > div:last-child > div {
+.c5 > div:last-child > div {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2016,33 +2451,33 @@ exports[`without votes and no seal 1`] = `
   font-size: 0.8em;
 }
 
-.c3 > div:last-child > div > div {
+.c5 > div:last-child > div > div {
   margin-bottom: 0.9375em;
 }
 
-.c3 > div:last-child > div > div:last-child {
+.c5 > div:last-child > div > div:last-child {
   margin-bottom: 0;
 }
 
-.c3 > div:last-child > div strong {
+.c5 > div:last-child > div strong {
   font-size: 1.25em;
   word-break: break-word;
 }
 
-.c6 {
+.c8 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
 }
 
-.c7 {
+.c9 {
   -webkit-columns: 2;
   columns: 2;
   -webkit-column-gap: 2em;
   column-gap: 2em;
 }
 
-.c8 {
+.c10 {
   border-bottom: 0.01em solid #000;
   padding: 0.5em 0;
   -webkit-break-inside: avoid;
@@ -2050,15 +2485,16 @@ exports[`without votes and no seal 1`] = `
   page-break-inside: avoid;
 }
 
-.c9 > h3 {
-  font-size: 0.875em;
-  font-weight: 400;
+.c12 {
+  font-weight: normal;
 }
 
-@media print {
-  .c10 {
-    color: black;
-  }
+.c13 {
+  display: block;
+}
+
+.c13:not(:last-child) {
+  margin-bottom: 0.125em;
 }
 
 @media screen {
@@ -2092,17 +2528,23 @@ exports[`without votes and no seal 1`] = `
       class="c1"
     >
       <div
-        class="c2 ballot-header-content"
+        class="ballot-header-content"
       >
-        <h2>
+        <h4
+          class="c2"
+        >
           Unofficial TEST Ballot
-        </h2>
-        <h3>
+        </h4>
+        <h5
+          class="c3"
+        >
           
            
           General Election
-        </h3>
-        <p>
+        </h5>
+        <p
+          class="c4"
+        >
           November 3, 2020
           <br />
           Franklin County
@@ -2111,10 +2553,10 @@ exports[`without votes and no seal 1`] = `
         </p>
       </div>
       <div
-        class="c3"
+        class="c5"
       >
         <div
-          class="c4"
+          class="c6"
         >
           <svg
             height="128"
@@ -2156,7 +2598,7 @@ exports[`without votes and no seal 1`] = `
                 Ballot ID
               </div>
               <strong
-                class="c5"
+                class="c7"
               >
                 CHhgYxfN5GeqnK8KaVOt1w
               </strong>
@@ -2166,185 +2608,229 @@ exports[`without votes and no seal 1`] = `
       </div>
     </div>
     <div
-      class="c6"
+      class="c8"
     >
       <div
-        class="c7"
+        class="c9"
       >
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               President and Vice-President
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Representative, District 6
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Lieutenant Governor
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Senator, District 31
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Assembly Member, District 54
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Registrar of Wills
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Retain Robert Demergue as Chief Justice?
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Question A: Recovery of Property Damages
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Question B: Separation of Powers
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Proposition 1: Gambling in Franklin and Fromwit Counties
-            </h3>
-            <p
-              class="c10"
+            </h6>
+            <span
+              class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c2 c9"
-          >
-            <h3>
-              Measure 102: Vehicle Abatement Program
-            </h3>
-            <p
-              class="c10"
+          <div>
+            <h6
+              class="c11 c12"
             >
-              [no selection]
-            </p>
+              Measure 102: Vehicle Abatement Program
+            </h6>
+            <span
+              class="c13"
+            >
+              <span
+                class="c14"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
       </div>

--- a/libs/ui/src/__snapshots__/bmd_paper_ballot.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/bmd_paper_ballot.test.tsx.snap
@@ -1,202 +1,107 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests 1`] = `
-.c11 {
-  word-break: break-word;
-}
-
-.c12 {
-  font-weight: 600;
-}
-
-.c13 {
-  color: gray;
-  font-style: italic;
-}
-
-.c14 {
-  font-weight: 600;
-  word-break: break-word;
-}
-
-.c5 {
+.c7 {
   white-space: nowrap;
 }
 
-.c2 {
-  max-width: 66ch;
-  line-height: 1.2;
-}
-
-.c2 p {
-  font-size: 1em;
-}
-
-.c2 h1 {
-  margin: 2em 0 1em;
-  line-height: 1.1;
-  font-size: 1.5em;
-}
-
-.c2 h2 {
-  margin: 1.5em 0 0.75em;
-  font-size: 1.25em;
-}
-
-.c2 h3 {
-  font-size: 1.17em;
-}
-
-.c2 h4 {
-  font-size: 1em;
-}
-
-.c2 h5 {
-  font-size: 0.9em;
-}
-
-.c2 h3,
-.c2 h4,
-.c2 h5,
-.c2 p,
-.c2 ol,
-.c2 ul,
-.c2 hr {
-  margin-top: 1em;
-  margin-bottom: 1em;
-}
-
-.c2 h1 + p,
-.c2 h2 + p,
-.c2 h1 + ol,
-.c2 h2 + ol,
-.c2 h1 + ul,
-.c2 h2 + ul {
-  margin-top: -0.75em;
-}
-
-.c2 h1 + h2 {
-  margin-top: -0.75em;
-}
-
-.c2 h3 + p,
-.c2 h4 + p,
-.c2 h5 + p,
-.c2 h3 + ol,
-.c2 h4 + ol,
-.c2 h5 + ol,
-.c2 h3 + ul,
-.c2 h4 + ul,
-.c2 h5 + ul {
-  margin-top: -1em;
-}
-
-.c2 > :not(.ignore-prose):first-child {
-  margin-top: 0;
-}
-
-.c2 > :not(.ignore-prose):last-child {
-  margin-bottom: 0;
-}
-
-.c2 dl {
-  margin: 1em 0;
-}
-
-.c2 hr {
-  border: 0;
-  border-top: 0.1em solid #666;
-}
-
-.c9 {
-  max-width: 66ch;
-  line-height: 1.2;
-}
-
-.c9 p {
-  font-size: 1em;
-}
-
-.c9 h1 {
-  margin: 2em 0 1em;
-  line-height: 1.1;
-  font-size: 1.5em;
-}
-
-.c9 h2 {
-  margin: 1.5em 0 0.75em;
-  font-size: 1.25em;
-}
-
-.c9 h3 {
-  font-size: 1.17em;
-}
-
-.c9 h4 {
-  font-size: 1em;
-}
-
-.c9 h5 {
-  font-size: 0.9em;
-}
-
-.c9 h3,
-.c9 h4,
-.c9 h5,
-.c9 p,
-.c9 ol,
-.c9 ul,
-.c9 hr {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c9 h1 + p,
-.c9 h2 + p,
-.c9 h1 + ol,
-.c9 h2 + ol,
-.c9 h1 + ul,
-.c9 h2 + ul {
-  margin-top: -0.75em;
-}
-
-.c9 h1 + h2 {
-  margin-top: -0.75em;
-}
-
-.c9 h3 + p,
-.c9 h4 + p,
-.c9 h5 + p,
-.c9 h3 + ol,
-.c9 h4 + ol,
-.c9 h5 + ol,
-.c9 h3 + ul,
-.c9 h4 + ul,
-.c9 h5 + ul {
-  margin-top: 0;
-}
-
-.c9 > :not(.ignore-prose):first-child {
-  margin-top: 0;
-}
-
-.c9 > :not(.ignore-prose):last-child {
-  margin-bottom: 0;
-}
-
-.c9 dl {
-  margin: 1em 0;
-}
-
-.c9 hr {
-  border: 0;
-  border-top: 0.1em solid #666;
-}
-
-.c4 > svg {
+.c6 > svg {
   display: block;
   width: 100%;
   height: auto;
+}
+
+.c14 {
+  font-size: 1em;
+  font-weight: 600;
+  line-height: 1.3;
+  margin: 0;
+}
+
+.c15 {
+  font-size: 1em;
+  font-weight: 200;
+  line-height: 1.3;
+  margin: 0;
+}
+
+.c4 {
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0;
+  font-size: 1rem;
+  margin-bottom: 0.5em;
+}
+
+.c2 {
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0;
+  font-weight: 500;
+  line-height: 1.1700000000000002;
+  margin-bottom: 0.3em;
+  font-size: 1.25rem;
+}
+
+.c2:not(:first-child) {
+  margin-top: 1.25em;
+}
+
+.c2 + h1,
+.c2 + h2,
+.c2 + h3,
+.c2 + h4,
+.c2 + h5,
+.c2 + h6 {
+  margin-top: 0 !important;
+}
+
+.c3 {
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0;
+  font-weight: 500;
+  line-height: 1.1700000000000002;
+  margin-bottom: 0.3em;
+  font-size: 1.125rem;
+}
+
+.c3:not(:first-child) {
+  margin-top: 1.25em;
+}
+
+.c3 + h1,
+.c3 + h2,
+.c3 + h3,
+.c3 + h4,
+.c3 + h5,
+.c3 + h6 {
+  margin-top: 0 !important;
+}
+
+.c11 {
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0;
+  font-weight: 500;
+  line-height: 1.1700000000000002;
+  margin-bottom: 0.3em;
+  font-size: 1rem;
+  line-height: 1.105;
+  font-weight: 600;
+}
+
+.c11:not(:first-child) {
+  margin-top: 1.25em;
+}
+
+.c11 + h1,
+.c11 + h2,
+.c11 + h3,
+.c11 + h4,
+.c11 + h5,
+.c11 + h6 {
+  margin-top: 0 !important;
 }
 
 .c0 {
@@ -243,7 +148,7 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
   max-width: 100%;
 }
 
-.c3 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -263,12 +168,12 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
   padding: 0.25em;
 }
 
-.c3 > div:first-child {
+.c5 > div:first-child {
   margin-right: 0.25em;
   width: 1.1in;
 }
 
-.c3 > div:last-child {
+.c5 > div:last-child {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -278,7 +183,7 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
   flex: 1;
 }
 
-.c3 > div:last-child > div {
+.c5 > div:last-child > div {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -295,33 +200,33 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
   font-size: 0.8em;
 }
 
-.c3 > div:last-child > div > div {
+.c5 > div:last-child > div > div {
   margin-bottom: 0.9375em;
 }
 
-.c3 > div:last-child > div > div:last-child {
+.c5 > div:last-child > div > div:last-child {
   margin-bottom: 0;
 }
 
-.c3 > div:last-child > div strong {
+.c5 > div:last-child > div strong {
   font-size: 1.25em;
   word-break: break-word;
 }
 
-.c6 {
+.c8 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
 }
 
-.c7 {
+.c9 {
   -webkit-columns: 2;
   columns: 2;
   -webkit-column-gap: 2em;
   column-gap: 2em;
 }
 
-.c8 {
+.c10 {
   border-bottom: 0.01em solid #000;
   padding: 0.5em 0;
   -webkit-break-inside: avoid;
@@ -329,9 +234,16 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
   page-break-inside: avoid;
 }
 
-.c10 > h3 {
-  font-size: 0.875em;
-  font-weight: 400;
+.c12 {
+  font-weight: normal;
+}
+
+.c13 {
+  display: block;
+}
+
+.c13:not(:last-child) {
+  margin-bottom: 0.125em;
 }
 
 @media print {
@@ -340,24 +252,6 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
 
 @media print {
 
-}
-
-@media print {
-
-}
-
-@media print {
-
-}
-
-@media print {
-
-}
-
-@media print {
-  .c13 {
-    color: black;
-  }
 }
 
 @media print {
@@ -547,17 +441,23 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
         </svg>
       </div>
       <div
-        class="c2 ballot-header-content"
+        class="ballot-header-content"
       >
-        <h2>
+        <h4
+          class="c2"
+        >
           Unofficial TEST Ballot
-        </h2>
-        <h3>
+        </h4>
+        <h5
+          class="c3"
+        >
           
            
           General Election
-        </h3>
-        <p>
+        </h5>
+        <p
+          class="c4"
+        >
           November 3, 2020
           <br />
           Franklin County
@@ -566,10 +466,10 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
         </p>
       </div>
       <div
-        class="c3"
+        class="c5"
       >
         <div
-          class="c4"
+          class="c6"
         >
           <svg
             height="128"
@@ -611,7 +511,7 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
                 Ballot ID
               </div>
               <strong
-                class="c5"
+                class="c7"
               >
                 CHhgYxfN5GeqnK8KaVOt1w
               </strong>
@@ -621,197 +521,233 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
       </div>
     </div>
     <div
-      class="c6"
+      class="c8"
     >
       <div
-        class="c7"
+        class="c9"
       >
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c9 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               President and Vice-President
-            </h3>
-            <p
-              class="c11"
+            </h6>
+            <span
+              class="c13"
             >
               <span
-                class="c12"
+                class="c14"
               >
                 Joseph Barchi and Joseph Hallaren
               </span>
                
               / Federalist
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c9 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Representative, District 6
-            </h3>
-            <p
+            </h6>
+            <span
               class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c15"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c9 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Lieutenant Governor
-            </h3>
-            <p
-              class="c11"
+            </h6>
+            <span
+              class="c13"
             >
               <span
-                class="c12"
+                class="c14"
               >
                 Chris Norberg
               </span>
                
               / Federalist
-            </p>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c9 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Senator, District 31
-            </h3>
-            <p
+            </h6>
+            <span
               class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c15"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c9 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Assembly Member, District 54
-            </h3>
-            <p
+            </h6>
+            <span
               class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c15"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c9 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Registrar of Wills
-            </h3>
-            <p
+            </h6>
+            <span
               class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c15"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c9 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Retain Robert Demergue as Chief Justice?
-            </h3>
-            <p
+            </h6>
+            <span
               class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c15"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c9 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Question A: Recovery of Property Damages
-            </h3>
-            <p
-              class="c14"
+            </h6>
+            <span
+              class="c13"
             >
-              Yes
-            </p>
+              <span
+                class="c14"
+              >
+                Yes
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c9 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Question B: Separation of Powers
-            </h3>
-            <p
-              class="c14"
+            </h6>
+            <span
+              class="c13"
             >
-              No
-            </p>
+              <span
+                class="c14"
+              >
+                No
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c9 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Proposition 1: Gambling in Franklin and Fromwit Counties
-            </h3>
-            <p
+            </h6>
+            <span
               class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c15"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         >
-          <div
-            class="c9 c10"
-          >
-            <h3>
+          <div>
+            <h6
+              class="c11 c12"
+            >
               Measure 102: Vehicle Abatement Program
-            </h3>
-            <p
+            </h6>
+            <span
               class="c13"
             >
-              [no selection]
-            </p>
+              <span
+                class="c15"
+              >
+                [no selection]
+              </span>
+            </span>
           </div>
         </div>
       </div>

--- a/libs/ui/src/app_base.tsx
+++ b/libs/ui/src/app_base.tsx
@@ -1,11 +1,10 @@
-import React, { useCallback, useMemo } from 'react';
-import { ThemeProvider } from 'styled-components';
+import React, { useCallback } from 'react';
 
 import { ColorMode, ScreenType, SizeMode, UiTheme } from '@votingworks/types';
 
 import { GlobalStyles } from './global_styles';
-import { makeTheme } from './themes/make_theme';
 import { ThemeManagerContext } from './theme_manager_context';
+import { VxThemeProvider } from './themes/vx_theme_provider';
 
 declare module 'styled-components' {
   /**
@@ -56,11 +55,6 @@ export function AppBase(props: AppBaseProps): JSX.Element {
     setSizeMode(defaultSizeMode);
   }, [defaultColorMode, defaultSizeMode]);
 
-  const theme = useMemo(
-    () => makeTheme({ colorMode, screenType, sizeMode }),
-    [colorMode, screenType, sizeMode]
-  );
-
   return (
     <ThemeManagerContext.Provider
       value={{
@@ -69,7 +63,11 @@ export function AppBase(props: AppBaseProps): JSX.Element {
         setSizeMode,
       }}
     >
-      <ThemeProvider theme={theme}>
+      <VxThemeProvider
+        colorMode={colorMode}
+        screenType={screenType}
+        sizeMode={sizeMode}
+      >
         <GlobalStyles
           enableScroll={enableScroll}
           isTouchscreen={isTouchscreen}
@@ -77,7 +75,7 @@ export function AppBase(props: AppBaseProps): JSX.Element {
           legacyPrintFontSizePx={legacyPrintFontSizePx}
         />
         {children}
-      </ThemeProvider>
+      </VxThemeProvider>
     </ThemeManagerContext.Provider>
   );
 }

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -54,6 +54,7 @@ export * from './reboot_to_bios_button';
 export * from './rotate_card_image';
 export * from './segmented_button';
 export * from './themes/render_with_themes';
+export * from './themes/vx_theme_provider';
 export * from './screen';
 export * from './seal';
 export * from './select';

--- a/libs/ui/src/themes/vx_theme_provider.test.tsx
+++ b/libs/ui/src/themes/vx_theme_provider.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { DefaultTheme, ThemeContext } from 'styled-components';
+
+import { render } from '@testing-library/react';
+import { VxThemeProvider } from './vx_theme_provider';
+import { makeTheme } from './make_theme';
+
+let currentTheme: DefaultTheme;
+
+function TestThemeConsumer(): JSX.Element {
+  currentTheme = React.useContext(ThemeContext);
+
+  return <div>foo</div>;
+}
+
+test('renders child nodes', () => {
+  const { container } = render(
+    <VxThemeProvider>
+      <TestThemeConsumer />
+    </VxThemeProvider>
+  );
+
+  expect(container).toContainHTML('<div>foo</div>');
+});
+
+test('uses defaults when no params specified', () => {
+  render(
+    <VxThemeProvider>
+      <TestThemeConsumer />
+    </VxThemeProvider>
+  );
+
+  expect(currentTheme).toEqual(makeTheme({}));
+});
+
+test('sets theme according to specified params', () => {
+  render(
+    <VxThemeProvider colorMode="contrastMedium" sizeMode="m" screenType="elo15">
+      <VxThemeProvider colorMode="contrastLow" sizeMode="s" screenType="elo13">
+        <TestThemeConsumer />
+      </VxThemeProvider>
+    </VxThemeProvider>
+  );
+
+  expect(currentTheme).toEqual(
+    makeTheme({
+      colorMode: 'contrastLow',
+      sizeMode: 's',
+      screenType: 'elo13',
+    })
+  );
+});
+
+test('inherits unspecified params from parent', () => {
+  const { rerender } = render(
+    <VxThemeProvider colorMode="contrastMedium" sizeMode="m" screenType="elo15">
+      <VxThemeProvider>
+        <TestThemeConsumer />
+      </VxThemeProvider>
+    </VxThemeProvider>
+  );
+
+  expect(currentTheme).toEqual(
+    makeTheme({
+      colorMode: 'contrastMedium',
+      sizeMode: 'm',
+      screenType: 'elo15',
+    })
+  );
+
+  rerender(
+    <VxThemeProvider colorMode="contrastMedium" sizeMode="m" screenType="elo15">
+      <VxThemeProvider sizeMode="xl">
+        <TestThemeConsumer />
+      </VxThemeProvider>
+    </VxThemeProvider>
+  );
+
+  expect(currentTheme).toEqual(
+    makeTheme({
+      colorMode: 'contrastMedium',
+      sizeMode: 'xl',
+      screenType: 'elo15',
+    })
+  );
+});

--- a/libs/ui/src/themes/vx_theme_provider.tsx
+++ b/libs/ui/src/themes/vx_theme_provider.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+
+import { ColorMode, ScreenType, SizeMode } from '@votingworks/types';
+
+import { makeTheme } from './make_theme';
+
+export interface VxThemeProviderProps {
+  children: React.ReactNode;
+  colorMode?: ColorMode;
+  sizeMode?: SizeMode;
+  screenType?: ScreenType;
+}
+
+/**
+ * Renders the provided child element(s) within the styled-components theme
+ * context required by theme-dependent components.
+ *
+ * If this is a nested provider, any unspecified theme settings will be
+ * inherited from the parent theme.
+ */
+export function VxThemeProvider(props: VxThemeProviderProps): JSX.Element {
+  const { children, colorMode, sizeMode, screenType } = props;
+
+  return (
+    <ThemeProvider
+      theme={(theme) =>
+        makeTheme({
+          colorMode: colorMode || theme?.colorMode,
+          sizeMode: sizeMode || theme?.sizeMode,
+          screenType: screenType || theme?.screenType,
+        })
+      }
+    >
+      {children}
+    </ThemeProvider>
+  );
+}


### PR DESCRIPTION
## Overview

With the new UI themes enabled, most of the `Prose` component's text-specific styling gets stripped - this breaks the styling of the `BmdPaperBallot` a bit, so updating the layout and styling, using the newer typography components, to more closely match the pre-themes styling.

Also adding a `VxThemeProvider` wrapper around the `styled-components/ThemeProvider` to simplify theme installation, since `BmdPaperBallot` now relies on themed components.

## Demo Video or Screenshot
### New Styling:
<img width="550" alt="Screenshot 2023-08-02 at 12 26 58" src="https://github.com/votingworks/vxsuite/assets/264902/c7900178-c866-4f71-ae65-854da9ecfeba">

### Pre-Themes Styling:
<img width="550" alt="Screenshot 2023-08-02 at 12 26 29" src="https://github.com/votingworks/vxsuite/assets/264902/b28d83ec-bbfb-4308-9f70-999a7541ace3">

### Existing Post-Themes Styling:
<img width="550" alt="Screenshot 2023-08-02 at 12 39 40" src="https://github.com/votingworks/vxsuite/assets/264902/3904b736-bf07-4cc9-83b5-fb0e089af632">

## Testing Plan
- Manual testing in VxMark (ballot printing) and VxAdmin (L&A packages) to verify styling
- Updated affected tests/snapshots

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
