### PR TITLE
Safer react query handling

### DIFF
--- a/apps/mark-scan/backend/src/app.test.ts
+++ b/apps/mark-scan/backend/src/app.test.ts
@@ -114,7 +114,7 @@ test('precinct selection can be written/read to/from store', async () => {
   await setUpUsbAndConfigureElection(electionDefinition);
 
   let precinctSelectionFromStore = await apiClient.getPrecinctSelection();
-  expect(precinctSelectionFromStore.unsafeUnwrap()).toEqual(undefined);
+  expect(precinctSelectionFromStore).toEqual(undefined);
 
   const precinct = electionDefinition.election.precincts[0].id;
   const precinctSelection = singlePrecinctSelectionFor(precinct);
@@ -123,7 +123,7 @@ test('precinct selection can be written/read to/from store', async () => {
   });
 
   precinctSelectionFromStore = await apiClient.getPrecinctSelection();
-  expect(precinctSelectionFromStore.unsafeUnwrap()).toEqual(precinctSelection);
+  expect(precinctSelectionFromStore).toEqual(precinctSelection);
 });
 
 test('configureBallotPackageFromUsb reads to and writes from store', async () => {
@@ -151,9 +151,7 @@ test('configureBallotPackageFromUsb automatically writes precinct selection if o
   mockElectionManagerAuth(electionDefinition);
   await setUpUsbAndConfigureElection(electionDefinition);
 
-  const precinctSelection = (
-    await apiClient.getPrecinctSelection()
-  ).unsafeUnwrap();
+  const precinctSelection = await apiClient.getPrecinctSelection();
   assert(precinctSelection, 'Expected precinct selection to be defined');
   expect((precinctSelection as SinglePrecinctSelection).precinctId).toEqual(
     electionDefinition.election.precincts[0].id
@@ -170,9 +168,7 @@ test('configureBallotPackageFromUsb does not automatically write precinct select
   mockElectionManagerAuth(electionDefinition);
   await setUpUsbAndConfigureElection(electionDefinition);
 
-  const precinctSelection = (
-    await apiClient.getPrecinctSelection()
-  ).unsafeUnwrap();
+  const precinctSelection = await apiClient.getPrecinctSelection();
   expect(precinctSelection).toBeUndefined();
 });
 

--- a/apps/mark-scan/backend/src/app.test.ts
+++ b/apps/mark-scan/backend/src/app.test.ts
@@ -114,7 +114,7 @@ test('precinct selection can be written/read to/from store', async () => {
   await setUpUsbAndConfigureElection(electionDefinition);
 
   let precinctSelectionFromStore = await apiClient.getPrecinctSelection();
-  expect(precinctSelectionFromStore).toEqual(undefined);
+  expect(precinctSelectionFromStore).toBeNull();
 
   const precinct = electionDefinition.election.precincts[0].id;
   const precinctSelection = singlePrecinctSelectionFor(precinct);
@@ -169,7 +169,7 @@ test('configureBallotPackageFromUsb does not automatically write precinct select
   await setUpUsbAndConfigureElection(electionDefinition);
 
   const precinctSelection = await apiClient.getPrecinctSelection();
-  expect(precinctSelection).toBeUndefined();
+  expect(precinctSelection).toBeNull();
 });
 
 test('unconfigureMachine deletes system settings and election definition', async () => {

--- a/apps/mark-scan/backend/src/app.test.ts
+++ b/apps/mark-scan/backend/src/app.test.ts
@@ -114,7 +114,7 @@ test('precinct selection can be written/read to/from store', async () => {
   await setUpUsbAndConfigureElection(electionDefinition);
 
   let precinctSelectionFromStore = await apiClient.getPrecinctSelection();
-  expect(precinctSelectionFromStore).toBeNull();
+  expect(precinctSelectionFromStore).toBeUndefined();
 
   const precinct = electionDefinition.election.precincts[0].id;
   const precinctSelection = singlePrecinctSelectionFor(precinct);
@@ -169,7 +169,7 @@ test('configureBallotPackageFromUsb does not automatically write precinct select
   await setUpUsbAndConfigureElection(electionDefinition);
 
   const precinctSelection = await apiClient.getPrecinctSelection();
-  expect(precinctSelection).toBeNull();
+  expect(precinctSelection).toBeUndefined();
 });
 
 test('unconfigureMachine deletes system settings and election definition', async () => {

--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -4,7 +4,7 @@ import {
   InsertedSmartCardAuthApi,
   InsertedSmartCardAuthMachineState,
 } from '@votingworks/auth';
-import { assert, ok, Optional, Result } from '@votingworks/basics';
+import { assert, ok, Result } from '@votingworks/basics';
 import * as grout from '@votingworks/grout';
 import { Buffer } from 'buffer';
 import {
@@ -114,8 +114,8 @@ function buildApi(
       workspace.store.setPrecinctSelection(input.precinctSelection);
     },
 
-    getPrecinctSelection(): Result<Optional<PrecinctSelection>, Error> {
-      return ok(workspace.store.getPrecinctSelection());
+    getPrecinctSelection(): PrecinctSelection | null {
+      return workspace.store.getPrecinctSelection() || null;
     },
 
     unconfigureMachine() {

--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -4,7 +4,7 @@ import {
   InsertedSmartCardAuthApi,
   InsertedSmartCardAuthMachineState,
 } from '@votingworks/auth';
-import { assert, ok, Result } from '@votingworks/basics';
+import { assert, ok, Optional, Result } from '@votingworks/basics';
 import * as grout from '@votingworks/grout';
 import { Buffer } from 'buffer';
 import {
@@ -114,8 +114,8 @@ function buildApi(
       workspace.store.setPrecinctSelection(input.precinctSelection);
     },
 
-    getPrecinctSelection(): PrecinctSelection | null {
-      return workspace.store.getPrecinctSelection() || null;
+    getPrecinctSelection(): Optional<PrecinctSelection> {
+      return workspace.store.getPrecinctSelection();
     },
 
     unconfigureMachine() {

--- a/apps/mark-scan/frontend/src/api.ts
+++ b/apps/mark-scan/frontend/src/api.ts
@@ -62,7 +62,13 @@ export const getPrecinctSelection = {
   },
   useQuery() {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () => apiClient.getPrecinctSelection());
+    return useQuery(
+      this.queryKey(),
+      // Since query functions are not allowed to return undefined, coalesce undefined to null
+      async () => (await apiClient.getPrecinctSelection()) ?? null,
+      // Convert back to undefined when reading the query results
+      { select: (precinctSelection) => precinctSelection ?? undefined }
+    );
   },
 } as const;
 

--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -577,7 +577,7 @@ export function AppRoot({
     return null;
   }
   const machineConfig = machineConfigQuery.data;
-  const precinctSelection = getPrecinctSelectionQuery.data.ok();
+  const precinctSelection = getPrecinctSelectionQuery.data;
 
   if (!cardReader) {
     return <SetupCardReaderPage />;

--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -279,7 +279,6 @@ export function AppRoot({
     ? getStateMachineStateQuery.data
     : 'no_hardware';
   const getPrecinctSelectionQuery = getPrecinctSelection.useQuery();
-  const precinctSelection = getPrecinctSelectionQuery.data?.ok();
 
   const checkPinMutation = checkPin.useMutation();
   const startCardlessVoterSessionMutation =
@@ -572,11 +571,13 @@ export function AppRoot({
   if (
     !machineConfigQuery.isSuccess ||
     !authStatusQuery.isSuccess ||
-    !getStateMachineStateQuery.isSuccess
+    !getStateMachineStateQuery.isSuccess ||
+    !getPrecinctSelectionQuery.isSuccess
   ) {
     return null;
   }
   const machineConfig = machineConfigQuery.data;
+  const precinctSelection = getPrecinctSelectionQuery.data.ok();
 
   if (!cardReader) {
     return <SetupCardReaderPage />;
@@ -696,6 +697,7 @@ export function AppRoot({
           updatePollsState={updatePollsState}
           hasVotes={!!votes}
           reload={reload}
+          precinctSelection={precinctSelection}
         />
       );
     }

--- a/apps/mark-scan/frontend/src/pages/admin_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/admin_screen.test.tsx
@@ -11,7 +11,6 @@ import { fakeLogger } from '@votingworks/logging';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { mockUsbDrive } from '@votingworks/ui';
 import userEvent from '@testing-library/user-event';
-import { ok } from '@votingworks/basics';
 import {
   act,
   fireEvent,
@@ -113,7 +112,7 @@ test('can switch the precinct', async () => {
   );
   apiMock.mockApiClient.getPrecinctSelection
     .expectRepeatedCallsWith()
-    .resolves(ok(precinctSelection));
+    .resolves(precinctSelection);
 
   apiMock.expectSetPrecinctSelection(ALL_PRECINCTS_SELECTION);
   renderScreen();

--- a/apps/mark-scan/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/admin_screen.tsx
@@ -28,7 +28,6 @@ import {
 import { makeAsync } from '@votingworks/utils';
 import { Logger } from '@votingworks/logging';
 import type { MachineConfig } from '@votingworks/mark-scan-backend';
-import { Optional } from '@votingworks/basics';
 import { ScreenReader } from '../config/types';
 import { getPrecinctSelection, logOut, setPrecinctSelection } from '../api';
 
@@ -78,8 +77,7 @@ export function AdminScreen({
     return null;
   }
 
-  const precinctSelection: Optional<PrecinctSelection> =
-    getPrecinctSelectionQuery.data || undefined;
+  const precinctSelection = getPrecinctSelectionQuery.data;
 
   return (
     <Screen>

--- a/apps/mark-scan/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/admin_screen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useEffect } from 'react';
 
 import {
   P,
@@ -60,14 +60,11 @@ export function AdminScreen({
   const logOutMutation = logOut.useMutation();
   const getPrecinctSelectionQuery = getPrecinctSelection.useQuery();
   const setPrecinctSelectionMutation = setPrecinctSelection.useMutation();
-  const updatePrecinctSelection = useCallback(
-    (newPrecinctSelection: PrecinctSelection) => {
-      setPrecinctSelectionMutation.mutate({
-        precinctSelection: newPrecinctSelection,
-      });
-    },
-    [setPrecinctSelectionMutation]
-  );
+  function updatePrecinctSelection(newPrecinctSelection: PrecinctSelection) {
+    setPrecinctSelectionMutation.mutate({
+      precinctSelection: newPrecinctSelection,
+    });
+  }
 
   // Disable the audiotrack when in admin mode
   useEffect(() => {

--- a/apps/mark-scan/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/admin_screen.tsx
@@ -28,6 +28,7 @@ import {
 import { makeAsync } from '@votingworks/utils';
 import { Logger } from '@votingworks/logging';
 import type { MachineConfig } from '@votingworks/mark-scan-backend';
+import { Optional } from '@votingworks/basics';
 import { ScreenReader } from '../config/types';
 import { getPrecinctSelection, logOut, setPrecinctSelection } from '../api';
 
@@ -76,7 +77,9 @@ export function AdminScreen({
   if (!getPrecinctSelectionQuery.isSuccess) {
     return null;
   }
-  const precinctSelection = getPrecinctSelectionQuery.data.ok();
+
+  const precinctSelection: Optional<PrecinctSelection> =
+    getPrecinctSelectionQuery.data || undefined;
 
   return (
     <Screen>

--- a/apps/mark-scan/frontend/src/pages/insert_card_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/insert_card_screen.test.tsx
@@ -41,7 +41,9 @@ test('InsertCardScreen renders nothing if getPrecinctSelectionQuery is not succe
 });
 
 test('InsertCardScreen renders correctly if getPrecinctSelectionQuery returns null', async () => {
-  apiMock.mockApiClient.getPrecinctSelection.expectCallWith().resolves(null);
+  apiMock.mockApiClient.getPrecinctSelection
+    .expectCallWith()
+    .resolves(undefined);
 
   render(
     <ApiClientContext.Provider value={apiMock.mockApiClient}>

--- a/apps/mark-scan/frontend/src/pages/insert_card_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/insert_card_screen.test.tsx
@@ -1,6 +1,5 @@
 import { fakeKiosk } from '@votingworks/test-utils';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { err } from '@votingworks/basics';
 import { screen } from '../../test/react_testing_library';
 import { ApiMock, createApiMock } from '../../test/helpers/mock_api_client';
 import { render } from '../../test/test_utils';
@@ -20,10 +19,10 @@ afterEach(() => {
   apiMock.mockApiClient.assertComplete();
 });
 
-test('returns null if getPrecinctSelectionQuery is not successful', () => {
+test('InsertCardScreen renders nothing if getPrecinctSelectionQuery is not successful', () => {
   apiMock.mockApiClient.getPrecinctSelection
     .expectCallWith()
-    .resolves(err(new Error('not ok')));
+    .throws('test error');
 
   render(
     <ApiClientContext.Provider value={apiMock.mockApiClient}>
@@ -39,4 +38,23 @@ test('returns null if getPrecinctSelectionQuery is not successful', () => {
     </ApiClientContext.Provider>
   );
   expect(screen.queryByText('Election ID')).toBeNull();
+});
+
+test('InsertCardScreen renders correctly if getPrecinctSelectionQuery returns null', async () => {
+  apiMock.mockApiClient.getPrecinctSelection.expectCallWith().resolves(null);
+
+  render(
+    <ApiClientContext.Provider value={apiMock.mockApiClient}>
+      <QueryClientProvider client={createQueryClient()}>
+        <InsertCardScreen
+          electionDefinition={electionDefinition}
+          showNoChargerAttachedWarning={false}
+          isLiveMode={false}
+          pollsState="polls_closed_initial"
+          showNoAccessibleControllerWarning={false}
+        />
+      </QueryClientProvider>
+    </ApiClientContext.Provider>
+  );
+  expect(await screen.findByText('Election ID')).toBeDefined();
 });

--- a/apps/mark-scan/frontend/src/pages/insert_card_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/insert_card_screen.tsx
@@ -1,9 +1,5 @@
 import React, { useEffect } from 'react';
-import {
-  ElectionDefinition,
-  PollsState,
-  PrecinctSelection,
-} from '@votingworks/types';
+import { ElectionDefinition, PollsState } from '@votingworks/types';
 import {
   Main,
   Screen,
@@ -18,7 +14,7 @@ import {
   Font,
 } from '@votingworks/ui';
 
-import { Optional, throwIllegalValue } from '@votingworks/basics';
+import { throwIllegalValue } from '@votingworks/basics';
 import { triggerAudioFocus } from '../utils/trigger_audio_focus';
 import { getPrecinctSelection } from '../api';
 
@@ -74,8 +70,7 @@ export function InsertCardScreen({
   if (!getPrecinctSelectionQuery.isSuccess) {
     return null;
   }
-  const precinctSelection: Optional<PrecinctSelection> =
-    getPrecinctSelectionQuery.data || undefined;
+  const precinctSelection = getPrecinctSelectionQuery.data;
 
   return (
     <Screen white>

--- a/apps/mark-scan/frontend/src/pages/insert_card_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/insert_card_screen.tsx
@@ -1,5 +1,9 @@
 import React, { useEffect } from 'react';
-import { ElectionDefinition, PollsState } from '@votingworks/types';
+import {
+  ElectionDefinition,
+  PollsState,
+  PrecinctSelection,
+} from '@votingworks/types';
 import {
   Main,
   Screen,
@@ -14,7 +18,7 @@ import {
   Font,
 } from '@votingworks/ui';
 
-import { throwIllegalValue } from '@votingworks/basics';
+import { Optional, throwIllegalValue } from '@votingworks/basics';
 import { triggerAudioFocus } from '../utils/trigger_audio_focus';
 import { getPrecinctSelection } from '../api';
 
@@ -70,7 +74,8 @@ export function InsertCardScreen({
   if (!getPrecinctSelectionQuery.isSuccess) {
     return null;
   }
-  const precinctSelection = getPrecinctSelectionQuery.data.ok();
+  const precinctSelection: Optional<PrecinctSelection> =
+    getPrecinctSelectionQuery.data || undefined;
 
   return (
     <Screen white>

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.test.tsx
@@ -4,7 +4,7 @@ import {
 } from '@votingworks/fixtures';
 import { ElectionDefinition, InsertedSmartCardAuth } from '@votingworks/types';
 
-import { MemoryHardware } from '@votingworks/utils';
+import { MemoryHardware, singlePrecinctSelectionFor } from '@votingworks/utils';
 import {
   fakePollWorkerUser,
   fakeSessionExpiresAt,
@@ -32,7 +32,6 @@ let apiMock: ApiMock;
 beforeEach(() => {
   jest.useFakeTimers();
   apiMock = createApiMock();
-  apiMock.expectGetPrecinctSelection();
 });
 
 afterEach(() => {
@@ -75,6 +74,9 @@ function renderScreen(
           screenReader={new AriaScreenReader(fakeTts())}
           updatePollsState={jest.fn()}
           reload={jest.fn()}
+          precinctSelection={singlePrecinctSelectionFor(
+            electionDefinition.election.precincts[0].id
+          )}
           {...props}
         />
       </QueryClientProvider>

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
@@ -8,6 +8,7 @@ import {
   PollsState,
   PollsTransition,
   InsertedSmartCardAuth,
+  PrecinctSelection,
 } from '@votingworks/types';
 import {
   Button,
@@ -49,7 +50,7 @@ import { ScreenReader } from '../config/types';
 
 import { triggerAudioFocus } from '../utils/trigger_audio_focus';
 import { DiagnosticsScreen } from './diagnostics_screen';
-import { getPrecinctSelection, getStateMachineState } from '../api';
+import { getStateMachineState } from '../api';
 import { LoadPaperPage } from './load_paper_page';
 
 const VotingSession = styled.div`
@@ -154,6 +155,7 @@ export interface PollworkerScreenProps {
   screenReader: ScreenReader;
   updatePollsState: (pollsState: PollsState) => void;
   reload: () => void;
+  precinctSelection?: PrecinctSelection;
 }
 
 export function PollWorkerScreen({
@@ -172,6 +174,7 @@ export function PollWorkerScreen({
   updatePollsState,
   hasVotes,
   reload,
+  precinctSelection,
 }: PollworkerScreenProps): JSX.Element {
   const { election } = electionDefinition;
   const electionDate = DateTime.fromISO(electionDefinition.election.date);
@@ -179,9 +182,6 @@ export function PollWorkerScreen({
 
   const getStateMachineStateQuery = getStateMachineState.useQuery();
   const stateMachineState = getStateMachineStateQuery.data;
-
-  const getPrecinctSelectionQuery = getPrecinctSelection.useQuery();
-  const precinctSelection = getPrecinctSelectionQuery.data?.ok();
 
   const [selectedCardlessVoterPrecinctId, setSelectedCardlessVoterPrecinctId] =
     useState<PrecinctId | undefined>(

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
@@ -155,7 +155,7 @@ export interface PollworkerScreenProps {
   screenReader: ScreenReader;
   updatePollsState: (pollsState: PollsState) => void;
   reload: () => void;
-  precinctSelection?: PrecinctSelection;
+  precinctSelection: PrecinctSelection;
 }
 
 export function PollWorkerScreen({
@@ -185,7 +185,7 @@ export function PollWorkerScreen({
 
   const [selectedCardlessVoterPrecinctId, setSelectedCardlessVoterPrecinctId] =
     useState<PrecinctId | undefined>(
-      precinctSelection?.kind === 'SinglePrecinct'
+      precinctSelection.kind === 'SinglePrecinct'
         ? precinctSelection.precinctId
         : undefined
     );
@@ -337,7 +337,7 @@ export function PollWorkerScreen({
             <React.Fragment>
               <VotingSession>
                 <H4 as="h2">Start a New Voting Session</H4>
-                {precinctSelection?.kind === 'AllPrecincts' && (
+                {precinctSelection.kind === 'AllPrecincts' && (
                   <React.Fragment>
                     <H6 as="h3">1. Select Voter’s Precinct</H6>
                     <ButtonList data-testid="precincts">

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
@@ -362,7 +362,7 @@ export function PollWorkerScreen({
                   </React.Fragment>
                 )}
                 <H6 as="h3">
-                  {precinctSelection?.kind === 'AllPrecincts' ? '2. ' : ''}
+                  {precinctSelection.kind === 'AllPrecincts' ? '2. ' : ''}
                   Select Voter’s Ballot Style
                 </H6>
                 {selectedCardlessVoterPrecinctId ? (

--- a/apps/mark-scan/frontend/src/pages/replace_election_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/replace_election_screen.tsx
@@ -1,4 +1,4 @@
-import { ElectionDefinition } from '@votingworks/types';
+import { ElectionDefinition, PrecinctSelection } from '@votingworks/types';
 import {
   ElectionInfoBar,
   H2,
@@ -15,6 +15,7 @@ import type { MachineConfig } from '@votingworks/mark-scan-backend';
 import { DateTime } from 'luxon';
 import pluralize from 'pluralize';
 import { useEffect } from 'react';
+import { Optional } from '@votingworks/basics';
 import { ScreenReader } from '../config/types';
 import { getPrecinctSelection } from '../api';
 
@@ -74,7 +75,8 @@ export function ReplaceElectionScreen({
   if (!getPrecinctSelectionQuery.isSuccess) {
     return null;
   }
-  const precinctSelection = getPrecinctSelectionQuery.data.ok();
+  const precinctSelection: Optional<PrecinctSelection> =
+    getPrecinctSelectionQuery.data || undefined;
 
   return (
     <Screen>

--- a/apps/mark-scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/mark-scan/frontend/test/helpers/mock_api_client.tsx
@@ -160,7 +160,7 @@ export function createApiMock() {
     expectGetPrecinctSelection(precinctSelection?: PrecinctSelection) {
       mockApiClient.getPrecinctSelection
         .expectCallWith()
-        .resolves(precinctSelection || null);
+        .resolves(precinctSelection);
     },
 
     expectSetPrecinctSelection(

--- a/apps/mark-scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/mark-scan/frontend/test/helpers/mock_api_client.tsx
@@ -154,13 +154,13 @@ export function createApiMock() {
       );
       mockApiClient.getPrecinctSelection
         .expectCallWith()
-        .resolves(ok(singlePrecinctSelectionFor(election.precincts[0].id)));
+        .resolves(singlePrecinctSelectionFor(election.precincts[0].id));
     },
 
     expectGetPrecinctSelection(precinctSelection?: PrecinctSelection) {
       mockApiClient.getPrecinctSelection
         .expectCallWith()
-        .resolves(ok(precinctSelection));
+        .resolves(precinctSelection || null);
     },
 
     expectSetPrecinctSelection(


### PR DESCRIPTION
## Overview
* Always checks for `query.isSuccess` when querying precinct selection
* Returns null instead of an empty `Result`

## Demo Video or Screenshot
No behavior change

## Testing Plan
Updated existing tests

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.

