### PR TITLE
Require Election.ballotLayout

### DIFF
--- a/apps/admin/frontend/src/components/hand_marked_paper_ballot.tsx
+++ b/apps/admin/frontend/src/components/hand_marked_paper_ballot.tsx
@@ -626,7 +626,7 @@ export function HandMarkedPaperBallot({
                 <div>
                   <Text small left as="div">
                     {ballotStyle?.partyId && primaryPartyName
-                      ? `${ballotStyle?.partyId && primaryPartyName} ${title}`
+                      ? `${ballotStyle.partyId && primaryPartyName} ${title}`
                       : election.title}
                   </Text>
                 </div>
@@ -764,7 +764,7 @@ export function HandMarkedPaperBallot({
                       vote={votes?.[contest.id] as CandidateVote | undefined}
                       density={layoutDensity}
                       targetMarkPosition={
-                        election.ballotLayout?.targetMarkPosition
+                        election.ballotLayout.targetMarkPosition
                       }
                     />
                   </React.Fragment>
@@ -800,7 +800,7 @@ export function HandMarkedPaperBallot({
 
                       <Text bold>
                         <BubbleMark
-                          position={election.ballotLayout?.targetMarkPosition}
+                          position={election.ballotLayout.targetMarkPosition}
                           checked={hasVote(votes?.[contest.id], 'yes')}
                         >
                           <span>{contest.yesOption?.label || 'Yes'}</span>
@@ -808,7 +808,7 @@ export function HandMarkedPaperBallot({
                       </Text>
                       <Text bold>
                         <BubbleMark
-                          position={election.ballotLayout?.targetMarkPosition}
+                          position={election.ballotLayout.targetMarkPosition}
                           checked={hasVote(votes?.[contest.id], 'no')}
                         >
                           <span>{contest.noOption?.label || 'No'}</span>

--- a/apps/admin/frontend/src/utils/get_ballot_layout_density.ts
+++ b/apps/admin/frontend/src/utils/get_ballot_layout_density.ts
@@ -1,5 +1,5 @@
 import { Election } from '@votingworks/types';
 
 export function getBallotLayoutDensity(election: Election): number {
-  return election.ballotLayout?.layoutDensity || 0;
+  return election.ballotLayout.layoutDensity || 0;
 }

--- a/apps/admin/frontend/src/utils/get_ballot_layout_page_size.ts
+++ b/apps/admin/frontend/src/utils/get_ballot_layout_page_size.ts
@@ -1,7 +1,7 @@
 import { BallotPaperSize, Election } from '@votingworks/types';
 
 export function getBallotLayoutPageSize(election: Election): BallotPaperSize {
-  return election.ballotLayout?.paperSize || BallotPaperSize.Letter;
+  return election.ballotLayout.paperSize;
 }
 
 export function getBallotLayoutPageSizeReadableString(

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -315,7 +315,7 @@ export class Store {
   getBallotPaperSizeForElection(): BallotPaperSize {
     const electionDefinition = this.getElectionDefinition();
     return (
-      electionDefinition?.election.ballotLayout?.paperSize ??
+      electionDefinition?.election.ballotLayout.paperSize ??
       BallotPaperSize.Letter
     );
   }
@@ -539,7 +539,7 @@ export class Store {
       return undefined;
     }
 
-    return dateTimeFromNoOffsetSqliteDate(row?.scannerBackedUpAt);
+    return dateTimeFromNoOffsetSqliteDate(row.scannerBackedUpAt);
   }
 
   /**
@@ -553,7 +553,7 @@ export class Store {
       return undefined;
     }
 
-    return dateTimeFromNoOffsetSqliteDate(row?.cvrsBackedUpAt);
+    return dateTimeFromNoOffsetSqliteDate(row.cvrsBackedUpAt);
   }
 
   getBallotsCounted(): number {

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -9,6 +9,7 @@ import {
   Id,
   Precinct as VxPrecinct,
   safeParseElection,
+  BallotPaperSize,
 } from '@votingworks/types';
 import express, { Application } from 'express';
 import { assertDefined, ok, Result } from '@votingworks/basics';
@@ -32,6 +33,9 @@ function createBlankElection(): Election {
     contests: [],
     parties: [],
     ballotStyles: [],
+    ballotLayout: {
+      paperSize: BallotPaperSize.Letter,
+    },
   };
 }
 

--- a/apps/design/backend/src/ballot_interpretation.test.ts
+++ b/apps/design/backend/src/ballot_interpretation.test.ts
@@ -320,7 +320,7 @@ for (const targetMarkPosition of Object.values(BallotTargetMarkPosition)) {
         const election: Election = {
           ...electionSample,
           ballotLayout: {
-            ...assertDefined(electionSample.ballotLayout),
+            ...electionSample.ballotLayout,
             targetMarkPosition,
             paperSize,
           },

--- a/apps/design/frontend/src/ballot_viewer.tsx
+++ b/apps/design/frontend/src/ballot_viewer.tsx
@@ -242,7 +242,7 @@ export function BallotViewer({
   const exportBallotMutation = exportBallot.useMutation();
   const [showGridLines, setShowGridLines] = useState(false);
 
-  const paperSize = election.ballotLayout?.paperSize ?? BallotPaperSize.Letter;
+  const { paperSize } = election.ballotLayout;
   const grid = gridForPaper(paperSize);
 
   const [dimensions, setDimensions] = useState<{

--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -44,7 +44,7 @@ function BallotDesignForm({
   const [isEditing, setIsEditing] = useState(false);
   const [ballotLayout, setBallotLayout] = useState<Required<BallotLayout>>({
     ...defaultBallotLayout,
-    ...(savedElection.ballotLayout ?? {}),
+    ...savedElection.ballotLayout,
   });
   const updateElectionMutation = updateElection.useMutation();
 

--- a/apps/design/shared/src/layout.ts
+++ b/apps/design/shared/src/layout.ts
@@ -707,7 +707,7 @@ function CandidateContest({
   assert(contest.type === 'candidate');
 
   const bubblePosition =
-    election.ballotLayout?.targetMarkPosition ?? BallotTargetMarkPosition.Left;
+    election.ballotLayout.targetMarkPosition ?? BallotTargetMarkPosition.Left;
 
   // Temp hack until we can change the timing mark grid dimensions since they
   // don't evenly divide into three columns: expand the last contest column (if
@@ -981,7 +981,7 @@ function BallotMeasure({
 
   const optionPositions: GridPosition[] = [];
   const side = pageNumber % 2 === 1 ? 'front' : 'back';
-  const bubblePosition = election.ballotLayout?.targetMarkPosition ?? 'left';
+  const bubblePosition = election.ballotLayout.targetMarkPosition ?? 'left';
 
   const choices = [
     { id: 'yes', label: 'Yes' },
@@ -1372,8 +1372,8 @@ function layOutBallotHelper(
   precinct: Precinct,
   ballotStyle: BallotStyle
 ) {
-  const paperSize = election.ballotLayout?.paperSize ?? BallotPaperSize.Letter;
-  const density = election.ballotLayout?.layoutDensity ?? 0;
+  const { paperSize } = election.ballotLayout;
+  const density = election.ballotLayout.layoutDensity ?? 0;
   assert(density <= 2);
   const m = measurements(paperSize, density);
 
@@ -1440,7 +1440,7 @@ function layOutBallotHelper(
             // within CandidateContest, we need to trigger the smallest width
             // option to get the largest possible height of the contest here,
             // regardless of which column it ends up in.
-            election.ballotLayout?.targetMarkPosition === 'left' ? 0 : 20,
+            election.ballotLayout.targetMarkPosition === 'left' ? 0 : 20,
           pageNumber: 0,
           m,
         });

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -300,7 +300,7 @@ export class Store {
   getBallotPaperSizeForElection(): BallotPaperSize {
     const electionDefinition = this.getElectionDefinition();
     return (
-      electionDefinition?.election.ballotLayout?.paperSize ??
+      electionDefinition?.election.ballotLayout.paperSize ??
       BallotPaperSize.Letter
     );
   }

--- a/libs/ballot-encoder/src/stats.test.ts
+++ b/libs/ballot-encoder/src/stats.test.ts
@@ -1,5 +1,6 @@
 import { asElectionDefinition } from '@votingworks/fixtures';
 import {
+  BallotPaperSize,
   BallotType,
   DistrictIdSchema,
   Election,
@@ -28,6 +29,9 @@ const election: Election = {
       description: 'See ya round, kid.',
     },
   ],
+  ballotLayout: {
+    paperSize: BallotPaperSize.Letter,
+  },
 };
 const { electionHash } = asElectionDefinition(election);
 

--- a/libs/converter-nh-accuvote/src/convert/convert_election_definition.ts
+++ b/libs/converter-nh-accuvote/src/convert/convert_election_definition.ts
@@ -68,7 +68,7 @@ export function convertElectionDefinition(
       ];
     }
 
-    let paperSize = election.ballotLayout?.paperSize;
+    let { paperSize } = election.ballotLayout;
 
     const frontExpectedPaperSize =
       frontGridAndBubbles.grid.geometry.ballotPaperSize;
@@ -194,7 +194,7 @@ export function convertElectionDefinition(
     const result: Election = {
       ...election,
       ballotLayout: {
-        ...(election.ballotLayout ?? {}),
+        ...election.ballotLayout,
         paperSize,
       },
       ballotStyles: [

--- a/libs/converter-nh-accuvote/src/convert/convert_election_definition_header.test.ts
+++ b/libs/converter-nh-accuvote/src/convert/convert_election_definition_header.test.ts
@@ -31,7 +31,7 @@ test('letter-size card definition', () => {
     hudsonBallotCardDefinition
   ).unsafeUnwrap();
 
-  expect(header.election?.ballotLayout?.paperSize).toEqual(
+  expect(header.election.ballotLayout.paperSize).toEqual(
     BallotPaperSize.Letter
   );
 });
@@ -175,7 +175,7 @@ test('multi-party endorsement', () => {
 
   expect(
     convertElectionDefinitionHeader(amherstBallotCardDefinition).unsafeUnwrap()
-      .election?.contests
+      .election.contests
   ).toEqual(
     expect.arrayContaining([
       expect.objectContaining(
@@ -246,9 +246,7 @@ test('constitutional questions become yesno contests', async () => {
     amherstBallotCardDefinition.definition
   ).unsafeUnwrap();
 
-  expect(
-    converted.election?.contests.filter((c) => c.type === 'yesno')
-  ).toEqual(
+  expect(converted.election.contests.filter((c) => c.type === 'yesno')).toEqual(
     typedAs<YesNoContest[]>([
       {
         type: 'yesno',

--- a/libs/cvr-fixture-generator/src/cli/generate/main.ts
+++ b/libs/cvr-fixture-generator/src/cli/generate/main.ts
@@ -262,7 +262,7 @@ export async function main(
       const pageWidthInches = 8.5;
       let pageHeightInches: number;
 
-      switch (election.ballotLayout?.paperSize) {
+      switch (election.ballotLayout.paperSize) {
         case BallotPaperSize.Legal:
           pageHeightInches = 14;
           break;

--- a/libs/cvr-fixture-generator/src/generate_cvrs.ts
+++ b/libs/cvr-fixture-generator/src/generate_cvrs.ts
@@ -140,7 +140,7 @@ export function generateBallotPageLayouts(
     );
   }
 
-  const paperSize = election.ballotLayout?.paperSize ?? BallotPaperSize.Letter;
+  const { paperSize } = election.ballotLayout;
   const pageSize: Size = {
     width: 200 * 8.5,
     height: 200 * (paperSize === BallotPaperSize.Letter ? 11 : 14),

--- a/libs/types/src/cdf/ballot-definition/convert.test.ts
+++ b/libs/types/src/cdf/ballot-definition/convert.test.ts
@@ -58,6 +58,7 @@ function normalizeVxf(vxfElection: Election) {
     parties,
     contests,
     ballotStyles,
+    ballotLayout,
   } = vxfElection;
   const dateWithoutTime = new Date(date.split('T')[0]);
   const isoDateString = `${dateWithoutTime.toISOString().split('.')[0]}Z`;
@@ -86,6 +87,7 @@ function normalizeVxf(vxfElection: Election) {
         : contest
     ),
     ballotStyles,
+    ballotLayout,
   };
 }
 

--- a/libs/types/src/cdf/ballot-definition/convert.ts
+++ b/libs/types/src/cdf/ballot-definition/convert.ts
@@ -406,6 +406,10 @@ export function convertCdfBallotDefinitionToVxfElection(
         partyId: ballotStyle.PartyIds?.[0] as Vxf.PartyId | undefined,
       };
     }),
+
+    ballotLayout: {
+      paperSize: Vxf.BallotPaperSize.Letter,
+    },
   };
 }
 

--- a/libs/types/src/cdf/ballot-definition/fixtures.ts
+++ b/libs/types/src/cdf/ballot-definition/fixtures.ts
@@ -5,7 +5,7 @@ import {
   ReportingUnitType,
   BallotDefinitionVersion,
 } from '.';
-import { DistrictId, Election, PartyId } from '../../election';
+import { BallotPaperSize, DistrictId, Election, PartyId } from '../../election';
 
 export const mockNow = '2023-02-08T00:00:00Z';
 
@@ -124,6 +124,9 @@ export const testVxfElection: Election = {
       districts: ['district-1' as DistrictId],
     },
   ],
+  ballotLayout: {
+    paperSize: BallotPaperSize.Letter,
+  },
 };
 
 export const testCdfBallotDefinition: BallotDefinition = {

--- a/libs/types/src/election.test.ts
+++ b/libs/types/src/election.test.ts
@@ -539,7 +539,9 @@ test('getDisplayElectionHash', () => {
   const electionDefinition = safeParseElectionDefinition(
     JSON.stringify(election)
   ).unsafeUnwrap();
-  expect(getDisplayElectionHash(electionDefinition)).toEqual('7dcbb8f101');
+  expect(getDisplayElectionHash(electionDefinition)).toMatchInlineSnapshot(
+    `"b470e13247"`
+  );
 });
 
 test('safeParseElection converts CDF to VXF', () => {

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -462,7 +462,7 @@ export const GridLayoutSchema: z.ZodSchema<GridLayout> = z.object({
 });
 
 export interface Election {
-  readonly ballotLayout?: BallotLayout;
+  readonly ballotLayout: BallotLayout;
   readonly ballotStyles: readonly BallotStyle[];
   readonly centralScanAdjudicationReasons?: readonly AdjudicationReason[];
   readonly contests: Contests;
@@ -482,7 +482,7 @@ export interface Election {
 }
 export const ElectionSchema: z.ZodSchema<Election> = z
   .object({
-    ballotLayout: BallotLayoutSchema.optional(),
+    ballotLayout: BallotLayoutSchema,
     ballotStyles: BallotStylesSchema,
     centralScanAdjudicationReasons: z
       .array(z.lazy(() => AdjudicationReasonSchema))

--- a/libs/types/src/election_utils.ts
+++ b/libs/types/src/election_utils.ts
@@ -6,6 +6,7 @@ import { safeParseCdfBallotDefinition } from './cdf/ballot-definition/convert';
 import {
   AdjudicationReason,
   AnyContest,
+  BallotPaperSize,
   BallotStyle,
   BallotStyleId,
   Candidate,
@@ -520,6 +521,13 @@ function preprocessElection(value: unknown): unknown {
         }),
       };
     }
+  }
+
+  if (!('ballotLayout' in election)) {
+    election = {
+      ...election,
+      ballotLayout: { paperSize: BallotPaperSize.Letter },
+    };
   }
 
   return election;


### PR DESCRIPTION
## Overview

We're relying on this field more and more in VxDesign and the interpreter, so we should make it a required part of the election definition rather than setting independent defaults in various locations where we try to use it.

_Review by commit_

## Demo Video or Screenshot
N/A

## Testing Plan
Updated all test fixtures.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
