### PR TITLE
Revert CircleCI Workaround Fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1285,7 +1285,5 @@ commands:
   install-cypress-browser:
     description: Installs a browser for Cypress tests.
     steps:
-      - run: sudo apt update # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
-      - browser-tools/install-chrome:
-          chrome-version: 114.0.5735.90 # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
+      - browser-tools/install-chrome
       - browser-tools/install-chromedriver

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.1
+  browser-tools: circleci/browser-tools@1.4.3
 
 executors:
   nodejs-browsers:

--- a/libs/monorepo-utils/src/circleci.ts
+++ b/libs/monorepo-utils/src/circleci.ts
@@ -95,7 +95,7 @@ export function generateConfig(pkgs: ReadonlyMap<string, PackageInfo>): string {
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.1
+  browser-tools: circleci/browser-tools@1.4.3
 
 executors:
   nodejs-browsers:

--- a/libs/monorepo-utils/src/circleci.ts
+++ b/libs/monorepo-utils/src/circleci.ts
@@ -183,9 +183,7 @@ commands:
   install-cypress-browser:
     description: Installs a browser for Cypress tests.
     steps:
-      - run: sudo apt update # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
-      - browser-tools/install-chrome:
-          chrome-version: 114.0.5735.90 # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
+      - browser-tools/install-chrome
       - browser-tools/install-chromedriver
 
 `.trim();


### PR DESCRIPTION
The CircleCI plugin we use for downloading chrome for integration tests broke, so we had to apply a workaround, but they applied a bug fix so we can revert the workaround. 

Issue: https://github.com/CircleCI-Public/browser-tools-orb/issues/75#issuecomment-1640923560