### PR TITLE
Check election hash for VxDesign ballots

### DIFF
--- a/apps/design/backend/package.json
+++ b/apps/design/backend/package.json
@@ -51,7 +51,6 @@
     "dotenv-expand": "^9.0.0",
     "express": "^4.18.0",
     "fs-extra": "^9.0.1",
-    "js-sha256": "^0.9.0",
     "jszip": "^3.9.1",
     "pdfkit": "^0.13.0",
     "react": "17.0.1",

--- a/apps/design/backend/src/all_bubble_ballots.ts
+++ b/apps/design/backend/src/all_bubble_ballots.ts
@@ -6,6 +6,7 @@ import {
   Election,
   ElectionDefinition,
   GridLayout,
+  safeParseElectionDefinition,
 } from '@votingworks/types';
 import {
   Bubble,
@@ -15,7 +16,6 @@ import {
   range,
   TimingMarkGrid,
 } from '@votingworks/design-shared';
-import { sha256 } from 'js-sha256';
 
 const m = measurements(BallotPaperSize.Letter, 0);
 const { DOCUMENT_HEIGHT, DOCUMENT_WIDTH, GRID } = m;
@@ -126,11 +126,8 @@ function createElection(): Election {
 
 export const allBubbleBallotElection = createElection();
 const electionData = JSON.stringify(allBubbleBallotElection);
-export const allBubbleBallotElectionDefinition: ElectionDefinition = {
-  electionData,
-  election: allBubbleBallotElection,
-  electionHash: sha256(electionData),
-};
+export const allBubbleBallotElectionDefinition: ElectionDefinition =
+  safeParseElectionDefinition(electionData).unsafeUnwrap();
 
 interface AllBubbleBallotOptions {
   fillBubble: (page: number, row: number, column: number) => boolean;
@@ -159,12 +156,13 @@ function createBallotCard({ fillBubble }: AllBubbleBallotOptions): Document {
           TimingMarkGrid({ m }),
           ...bubbles(1),
           Footer({
-            electionDefinition: allBubbleBallotElectionDefinition,
+            election: allBubbleBallotElection,
             ballotStyle: allBubbleBallotElection.ballotStyles[0],
             precinct: allBubbleBallotElection.precincts[0],
             isTestMode: true,
             pageNumber: 1,
             totalPages: 2,
+            electionHash: allBubbleBallotElectionDefinition.electionHash,
             m,
           }),
         ],
@@ -174,12 +172,13 @@ function createBallotCard({ fillBubble }: AllBubbleBallotOptions): Document {
           TimingMarkGrid({ m }),
           ...bubbles(2),
           Footer({
-            electionDefinition: allBubbleBallotElectionDefinition,
+            election: allBubbleBallotElection,
             ballotStyle: allBubbleBallotElection.ballotStyles[0],
             precinct: allBubbleBallotElection.precincts[0],
             isTestMode: true,
             pageNumber: 2,
             totalPages: 2,
+            electionHash: allBubbleBallotElectionDefinition.electionHash,
             m,
           }),
         ],

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -1,20 +1,15 @@
 import * as grout from '@votingworks/grout';
 import { Buffer } from 'buffer';
 import {
-  BallotStyle as VxBallotStyle,
   Election,
-  ElectionDefinition,
-  getBallotStyle,
   getPrecinctById,
-  GridLayout,
   Id,
-  Precinct as VxPrecinct,
   safeParseElection,
   BallotPaperSize,
 } from '@votingworks/types';
 import express, { Application } from 'express';
-import { assertDefined, ok, Result } from '@votingworks/basics';
-import { layOutBallot } from '@votingworks/design-shared';
+import { assertDefined, find, ok, Result } from '@votingworks/basics';
+import { layOutAllBallots } from '@votingworks/design-shared';
 import JsZip from 'jszip';
 import { ElectionRecord, Precinct, Store } from './store';
 import { renderDocumentToPdf } from './render_ballot';
@@ -50,27 +45,6 @@ function streamToBuffer(stream: NodeJS.ReadableStream): Promise<Buffer> {
   });
 }
 
-function exportBallotToPdf(
-  electionDefinition: ElectionDefinition,
-  precinct: VxPrecinct,
-  ballotStyle: VxBallotStyle
-) {
-  const ballotResult = layOutBallot({
-    electionDefinition,
-    precinct,
-    ballotStyle,
-    isTestMode: true,
-  });
-  if (ballotResult.isErr()) {
-    throw new Error(
-      `Error generating ballot for precinct ${precinct.name}, ballot style ${
-        ballotStyle.id
-      }: ${ballotResult.err().message}`
-    );
-  }
-  return renderDocumentToPdf(ballotResult.ok().document);
-}
-
 function buildApi({ store }: { store: Store }) {
   return grout.createApi({
     listElections(): ElectionRecord[] {
@@ -94,8 +68,7 @@ function buildApi({ store }: { store: Store }) {
     },
 
     updateElection(input: { electionId: Id; election: Election }): void {
-      const { electionDefinition } = store.getElection(input.electionId);
-      const { election } = electionDefinition;
+      const { election } = store.getElection(input.electionId);
       // TODO validate election
       store.updateElection(input.electionId, {
         ...election,
@@ -112,27 +85,26 @@ function buildApi({ store }: { store: Store }) {
     },
 
     async exportAllBallots(input: { electionId: Id }): Promise<Buffer> {
-      const { electionDefinition } = store.getElection(input.electionId);
-      const { election } = electionDefinition;
+      const { election } = store.getElection(input.electionId);
+      const { ballots } = layOutAllBallots({
+        election,
+        isTestMode: true,
+      }).unsafeUnwrap();
 
       const zip = new JsZip();
 
-      for (const ballotStyle of election.ballotStyles) {
-        for (const precinctId of ballotStyle.precincts) {
-          const precinct = assertDefined(
-            getPrecinctById({ election, precinctId })
-          );
-          const pdf = exportBallotToPdf(
-            electionDefinition,
-            precinct,
-            ballotStyle
-          );
-          const fileName = `ballot-${precinct.name.replace(' ', '_')}-${
-            ballotStyle.id
-          }.pdf`;
-          zip.file(fileName, pdf);
-          pdf.end();
-        }
+      for (const { document, gridLayout } of ballots) {
+        const { precinctId, ballotStyleId } = gridLayout;
+        const precinct = assertDefined(
+          getPrecinctById({ election, precinctId })
+        );
+        const pdf = renderDocumentToPdf(document);
+        const fileName = `ballot-${precinct.name.replace(
+          ' ',
+          '_'
+        )}-${ballotStyleId}.pdf`;
+        zip.file(fileName, pdf);
+        pdf.end();
       }
 
       return zip.generateAsync({ type: 'nodebuffer' });
@@ -143,59 +115,29 @@ function buildApi({ store }: { store: Store }) {
       precinctId: string;
       ballotStyleId: string;
     }): Promise<Buffer> {
-      const { electionDefinition } = store.getElection(input.electionId);
-      const { election } = electionDefinition;
-      const precinct = getPrecinctById({
+      const { election } = store.getElection(input.electionId);
+      const { ballots } = layOutAllBallots({
         election,
-        precinctId: input.precinctId,
-      });
-      const ballotStyle = getBallotStyle({
-        election,
-        ballotStyleId: input.ballotStyleId,
-      });
-      const pdf = exportBallotToPdf(
-        electionDefinition,
-        assertDefined(precinct),
-        assertDefined(ballotStyle)
+        isTestMode: true,
+      }).unsafeUnwrap();
+      const { document } = find(
+        ballots,
+        ({ gridLayout }) =>
+          gridLayout.precinctId === input.precinctId &&
+          gridLayout.ballotStyleId === input.ballotStyleId
       );
+      const pdf = renderDocumentToPdf(document);
       pdf.end();
       return streamToBuffer(pdf);
     },
 
     exportBallotDefinition(input: { electionId: Id }): Election {
-      const { electionDefinition } = store.getElection(input.electionId);
-      const { election } = electionDefinition;
-
-      const gridLayouts: GridLayout[] = [];
-      for (const ballotStyle of election.ballotStyles) {
-        for (const precinctId of ballotStyle.precincts) {
-          const precinct = assertDefined(
-            getPrecinctById({ election, precinctId })
-          );
-          const ballotResult = layOutBallot({
-            electionDefinition,
-            precinct,
-            ballotStyle,
-            isTestMode: true,
-          });
-          if (ballotResult.isErr()) {
-            throw new Error(
-              `Error generating ballot for precinct ${
-                precinct.name
-              }, ballot style ${ballotStyle.id}: ${ballotResult.err().message}`
-            );
-          }
-          gridLayouts.push(ballotResult.ok().gridLayout);
-        }
-      }
-
-      // TODO catch-22: we need the hash of the election definition in the QR
-      // code on the ballot, but we also need to lay out the ballot first to get
-      // the gridLayouts to put in the election definition. Likely will need to
-      // do two passes of laying out the ballot - one to generate the
-      // gridLayouts, then one to actually generate the ballots. Then we'll need
-      // to export these at the same time.
-      return { ...election, gridLayouts };
+      const { election } = store.getElection(input.electionId);
+      const { electionDefinition } = layOutAllBallots({
+        election,
+        isTestMode: true,
+      }).unsafeUnwrap();
+      return electionDefinition.election;
     },
   });
 }

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -6,15 +6,13 @@ import {
   DistrictId,
   PrecinctId,
   BallotStyleId,
-  ElectionDefinition,
 } from '@votingworks/types';
 import deepEqual from 'deep-eql';
 import { join } from 'path';
-import { sha256 } from 'js-sha256';
 
 export interface ElectionRecord {
   id: Id;
-  electionDefinition: ElectionDefinition;
+  election: Election;
   precincts: Precinct[];
   ballotStyles: BallotStyle[];
   createdAt: Iso8601Timestamp;
@@ -166,17 +164,9 @@ function hydrateElection(row: {
       rawElection.sealUrl ?? '/seals/state-of-hamilton-official-seal.svg',
   };
 
-  const electionData = JSON.stringify(election);
-
-  const electionDefinition: ElectionDefinition = {
-    election,
-    electionData,
-    electionHash: sha256(electionData),
-  };
-
   return {
     id: row.id,
-    electionDefinition,
+    election,
     precincts,
     ballotStyles,
     createdAt: convertSqliteTimestampToIso8601(row.createdAt),

--- a/apps/design/frontend/src/ballot_screen.tsx
+++ b/apps/design/frontend/src/ballot_screen.tsx
@@ -17,15 +17,14 @@ export function BallotScreen(): JSX.Element | null {
     return null; // Initial loading state
   }
 
-  const { electionDefinition } = getElectionQuery.data;
-  const { election } = electionDefinition;
+  const { election } = getElectionQuery.data;
   const precinct = getPrecinctById({ election, precinctId });
   const ballotStyle = getBallotStyle({ election, ballotStyleId });
 
   return (
     <Screen>
       <BallotViewer
-        electionDefinition={electionDefinition}
+        election={election}
         precinct={assertDefined(precinct)}
         ballotStyle={assertDefined(ballotStyle)}
       />

--- a/apps/design/frontend/src/ballot_viewer.tsx
+++ b/apps/design/frontend/src/ballot_viewer.tsx
@@ -4,7 +4,7 @@ import { throwIllegalValue } from '@votingworks/basics';
 import {
   BallotPaperSize,
   BallotStyle,
-  ElectionDefinition,
+  Election,
   Precinct,
 } from '@votingworks/types';
 import styled from 'styled-components';
@@ -229,15 +229,14 @@ export const paperSizeLabels: Record<BallotPaperSize, string> = {
 };
 
 export function BallotViewer({
-  electionDefinition,
+  election,
   precinct,
   ballotStyle,
 }: {
-  electionDefinition: ElectionDefinition;
+  election: Election;
   precinct: Precinct;
   ballotStyle: BallotStyle;
 }): JSX.Element | null {
-  const { election } = electionDefinition;
   const { electionId } = useParams<ElectionIdParams>();
   const ballotRoutes = routes.election(electionId).ballots;
   const exportBallotMutation = exportBallot.useMutation();
@@ -257,7 +256,7 @@ export function BallotViewer({
   }, []);
 
   const ballotResult = layOutBallot({
-    electionDefinition,
+    election,
     precinct,
     ballotStyle,
     isTestMode: true,

--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -222,8 +222,7 @@ function BallotLayoutTab(): JSX.Element | null {
     return null;
   }
 
-  const { electionDefinition } = getElectionQuery.data;
-  const { election } = electionDefinition;
+  const { election } = getElectionQuery.data;
 
   return (
     <TabPanel>

--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -57,8 +57,8 @@ function ContestsTab(): JSX.Element | null {
     return null;
   }
 
-  const { electionDefinition } = getElectionQuery.data;
-  const { contests, districts, parties } = electionDefinition.election;
+  const { election } = getElectionQuery.data;
+  const { contests, districts, parties } = election;
   const contestRoutes = routes.election(electionId).contests.contests;
 
   const filteredContests = contests.filter((contest) => {
@@ -521,8 +521,7 @@ function AddContestForm(): JSX.Element | null {
     return null;
   }
 
-  const { electionDefinition } = getElectionQuery.data;
-  const { election } = electionDefinition;
+  const { election } = getElectionQuery.data;
 
   return (
     <React.Fragment>
@@ -549,8 +548,7 @@ function EditContestForm(): JSX.Element | null {
     return null;
   }
 
-  const { electionDefinition } = getElectionQuery.data;
-  const { election } = electionDefinition;
+  const { election } = getElectionQuery.data;
 
   return (
     <React.Fragment>
@@ -578,8 +576,9 @@ function PartiesTab(): JSX.Element | null {
     return null;
   }
 
-  const { electionDefinition } = getElectionQuery.data;
-  const { parties } = electionDefinition.election;
+  const {
+    election: { parties },
+  } = getElectionQuery.data;
   const partyRoutes = routes.election(electionId).contests.parties;
 
   return (
@@ -772,8 +771,7 @@ function AddPartyForm(): JSX.Element | null {
     return null;
   }
 
-  const { electionDefinition } = getElectionQuery.data;
-  const { election } = electionDefinition;
+  const { election } = getElectionQuery.data;
 
   return (
     <React.Fragment>
@@ -795,8 +793,7 @@ function EditPartyForm(): JSX.Element | null {
     return null;
   }
 
-  const { electionDefinition } = getElectionQuery.data;
-  const { election } = electionDefinition;
+  const { election } = getElectionQuery.data;
 
   return (
     <React.Fragment>

--- a/apps/design/frontend/src/election_info_screen.tsx
+++ b/apps/design/frontend/src/election_info_screen.tsx
@@ -147,8 +147,7 @@ export function ElectionInfoScreen(): JSX.Element | null {
     return null;
   }
 
-  const { electionDefinition } = getElectionQuery.data;
-  const { election } = electionDefinition;
+  const { election } = getElectionQuery.data;
 
   return (
     <ElectionNavScreen electionId={electionId}>

--- a/apps/design/frontend/src/elections_screen.tsx
+++ b/apps/design/frontend/src/elections_screen.tsx
@@ -73,7 +73,7 @@ export function ElectionsScreen(): JSX.Element | null {
           </P>
         ) : (
           <ElectionList>
-            {elections.map(({ id, electionDefinition: { election } }) => (
+            {elections.map(({ id, election }) => (
               <li key={id}>
                 <LinkButton to={`/elections/${id}`}>
                   {election.title

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -54,8 +54,9 @@ function DistrictsTab(): JSX.Element | null {
     return null;
   }
 
-  const { electionDefinition } = getElectionQuery.data;
-  const { districts } = electionDefinition.election;
+  const {
+    election: { districts },
+  } = getElectionQuery.data;
   const districtsRoutes = routes.election(electionId).geography.districts;
 
   return (
@@ -246,8 +247,7 @@ function AddDistrictForm(): JSX.Element | null {
     return null;
   }
 
-  const { electionDefinition } = getElectionQuery.data;
-  const { election } = electionDefinition;
+  const { election } = getElectionQuery.data;
 
   return (
     <React.Fragment>
@@ -274,8 +274,7 @@ function EditDistrictForm(): JSX.Element | null {
     return null;
   }
 
-  const { electionDefinition, precincts } = getElectionQuery.data;
-  const { election } = electionDefinition;
+  const { election, precincts } = getElectionQuery.data;
 
   return (
     <React.Fragment>
@@ -305,8 +304,7 @@ function PrecinctsTab(): JSX.Element | null {
     return null;
   }
 
-  const { precincts, electionDefinition } = getElectionQuery.data;
-  const { election } = electionDefinition;
+  const { precincts, election } = getElectionQuery.data;
 
   const districtIdToName = Object.fromEntries(
     election.districts.map((district) => [district.id, district.name])
@@ -643,8 +641,7 @@ function AddPrecinctForm(): JSX.Element | null {
     return null;
   }
 
-  const { precincts, electionDefinition } = getElectionQuery.data;
-  const { election } = electionDefinition;
+  const { precincts, election } = getElectionQuery.data;
 
   return (
     <React.Fragment>
@@ -675,8 +672,7 @@ function EditPrecinctForm(): JSX.Element | null {
     return null;
   }
 
-  const { precincts, electionDefinition } = getElectionQuery.data;
-  const { election } = electionDefinition;
+  const { precincts, election } = getElectionQuery.data;
 
   return (
     <React.Fragment>

--- a/apps/design/frontend/src/tabulation_screen.tsx
+++ b/apps/design/frontend/src/tabulation_screen.tsx
@@ -148,8 +148,7 @@ export function TabulationScreen(): JSX.Element | null {
     return null;
   }
 
-  const { electionDefinition } = getElectionQuery.data;
-  const { election } = electionDefinition;
+  const { election } = getElectionQuery.data;
 
   return (
     <ElectionNavScreen electionId={electionId}>

--- a/apps/design/shared/src/encode_metadata.ts
+++ b/apps/design/shared/src/encode_metadata.ts
@@ -8,16 +8,17 @@ const { QrCode } = qrcodegen;
 type Bit = 0 | 1;
 export type QrCodeData = Array<Bit[]>;
 
+export function encodeInQrCode(data: Uint8Array): QrCodeData {
+  const qrCode = QrCode.encodeBinary(Array.from(data), QrCode.Ecc.LOW);
+  return range(0, qrCode.size).map((x) =>
+    range(0, qrCode.size).map((y) => (qrCode.getModule(x, y) ? 1 : 0))
+  );
+}
+
 export function encodeMetadataInQrCode(
   election: Election,
   metadata: HmpbBallotPageMetadata
 ): QrCodeData {
   const encodedMetadata = encodeHmpbBallotPageMetadata(election, metadata);
-  const qrCode = QrCode.encodeBinary(
-    Array.from(encodedMetadata),
-    QrCode.Ecc.LOW
-  );
-  return range(0, qrCode.size).map((x) =>
-    range(0, qrCode.size).map((y) => (qrCode.getModule(x, y) ? 1 : 0))
-  );
+  return encodeInQrCode(encodedMetadata);
 }

--- a/apps/design/shared/src/layout.ts
+++ b/apps/design/shared/src/layout.ts
@@ -1736,13 +1736,10 @@ function layOutAllBallotsHelper({
  * election (for every ballot style/precinct combo). Returns the laid out
  * ballots as well as the election definition with gridLayouts.
  *
- * We have to lay out all of the ballots at once in order to make sure the
- * correct election hash is encoded in the ballot metadata. The election hash
- * needs to be from the completed election with gridLayouts defined.
- *
- * To do this, we lay out the ballots once just to compute gridLayouts,
- * add those gridLayouts to the election, hash the resulting election, and then
- * lay out the ballots again with the resulting election hash.
+ * We lay out the ballots once just to compute gridLayouts, add those
+ * gridLayouts to the election, hash the resulting election, and then lay out
+ * the ballots again with the resulting election hash (which is encoded in the
+ * ballot metadata).
  */
 export function layOutAllBallots({
   election,

--- a/libs/ballot-interpreter/package.json
+++ b/libs/ballot-interpreter/package.json
@@ -34,6 +34,7 @@
     ]
   },
   "dependencies": {
+    "@votingworks/ballot-encoder": "workspace:*",
     "@votingworks/ballot-interpreter-nh": "workspace:*",
     "@votingworks/ballot-interpreter-vx": "workspace:*",
     "@votingworks/basics": "workspace:*",

--- a/libs/ballot-interpreter/tsconfig.build.json
+++ b/libs/ballot-interpreter/tsconfig.build.json
@@ -9,6 +9,7 @@
     "declaration": true
   },
   "references": [
+    { "path": "../../libs/ballot-encoder/tsconfig.build.json" },
     { "path": "../../libs/ballot-interpreter-nh/tsconfig.build.json" },
     { "path": "../../libs/ballot-interpreter-vx/tsconfig.build.json" },
     { "path": "../../libs/basics/tsconfig.build.json" },

--- a/libs/ballot-interpreter/tsconfig.json
+++ b/libs/ballot-interpreter/tsconfig.json
@@ -15,6 +15,7 @@
     "resolveJsonModule": true
   },
   "references": [
+    { "path": "../../libs/ballot-encoder/tsconfig.build.json" },
     { "path": "../../libs/ballot-interpreter-nh/tsconfig.build.json" },
     { "path": "../../libs/ballot-interpreter-vx/tsconfig.build.json" },
     { "path": "../../libs/basics/tsconfig.build.json" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1216,9 +1216,6 @@ importers:
       fs-extra:
         specifier: ^9.0.1
         version: 9.1.0
-      js-sha256:
-        specifier: ^0.9.0
-        version: 0.9.0
       jszip:
         specifier: ^3.9.1
         version: 3.9.1
@@ -3341,6 +3338,9 @@ importers:
 
   libs/ballot-interpreter:
     dependencies:
+      '@votingworks/ballot-encoder':
+        specifier: workspace:*
+        version: link:../ballot-encoder
       '@votingworks/ballot-interpreter-nh':
         specifier: workspace:*
         version: link:../ballot-interpreter-nh


### PR DESCRIPTION


## Overview

Modifies libs/ballot-interpreter to check the election hash (there was already logic for checking precinct/test mode).

In order to have the correct election hash encoded in the ballot metadata QR code, we have to first lay out all of the ballots to compute gridLayouts. To support this change, we also undo passing an ElectionDefinition around in VxDesign, since we only need the Election data until we're finally ready to layout the ballots and compute the hash.

Also changes VxDesign to show a placeholder QR code in ballot previews to help distinguish them from real ballots that have an encoded election hash.

## Demo Video or Screenshot

In browser preview with placeholder QR code
<img width="515" alt="Screen Shot 2023-08-08 at 11 56 44 AM" src="https://github.com/votingworks/vxsuite/assets/530106/d22098f3-f1a6-4029-b00d-bb1fa3c49f9a">


## Testing Plan
Updated existing automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
