### PR TITLE
chore(monorepo): make `pnpm install` less noisy

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -4,7 +4,7 @@ module.exports = {
   hooks: {
     readPackage,
   },
-}
+};
 
 /**
  * @typedef {object} Package
@@ -28,22 +28,13 @@ module.exports = {
  * @returns {Package}
  */
 function readPackage(pkg, context) {
-  if (pkg.name === 'any-observable') {
-    // Error: Cannot find any-observable implementation nor global.Observable. You must install polyfill or call require("any-observable/register") with your preferred implementation, e.g. require("any-observable/register")('rxjs') on application load prior to any require("any-observable").
-    pkg.dependencies = {
-      ...pkg.dependencies,
-      rxjs: '*',
-    }
-    context.log('any-observable implicitly depends on rxjs')
-  }
-
   if (pkg.name === 'fetch-mock') {
     // Cannot find module 'node-fetch' from 'server.js'
     pkg.dependencies = {
       ...pkg.dependencies,
       'node-fetch': '*',
-    }
-    context.log('fetch-mock implicitly depends on node-fetch')
+    };
+    context.log('fetch-mock implicitly depends on node-fetch');
   }
 
   if (pkg.name === 'react-idle-timer') {
@@ -51,26 +42,8 @@ function readPackage(pkg, context) {
     pkg.dependencies = {
       ...pkg.dependencies,
       'prop-types': '*',
-    }
-    context.log('react-idle-timer implicitly depends on prop-types')
-  }
-
-  if (pkg.name === 'styled-components') {
-    // Cannot find module 'react-is' from '../../node_modules/.pnpm/styled-components@5.2.1_react-dom@17.0.1+react@17.0.1/node_modules/styled-components/dist/styled-components.cjs.js'
-    pkg.dependencies = {
-      ...pkg.dependencies,
-      'react-is': '*',
-    }
-    context.log('styled-components implicitly depends on react-is')
-  }
-
-  if (pkg.name === '@votingworks/qrcode.react') {
-    // JSX element class does not support attributes because it does not have a 'props' property.
-    pkg.dependencies = {
-      ...pkg.dependencies,
-      '@types/react': '*',
-    }
-    context.log('@votingworks/qrcode.react implicitly depends on @types/react')
+    };
+    context.log('react-idle-timer implicitly depends on prop-types');
   }
 
   if (pkg.name === 'react-idle-timer') {
@@ -78,8 +51,8 @@ function readPackage(pkg, context) {
     pkg.dependencies = {
       ...pkg.dependencies,
       '@types/react': '*',
-    }
-    context.log('react-idle-timer implicitly depends on @types/react')
+    };
+    context.log('react-idle-timer implicitly depends on @types/react');
   }
 
   if (pkg.name === '@typescript-eslint/utils') {
@@ -87,37 +60,11 @@ function readPackage(pkg, context) {
     pkg.dependencies = {
       ...pkg.dependencies,
       '@typescript-eslint/parser': '*',
-    }
-    context.log('eslint-module-utils requires the parser named in the eslint config, @typescript-eslint/parser')
+    };
+    context.log(
+      'eslint-module-utils requires the parser named in the eslint config, @typescript-eslint/parser'
+    );
   }
 
-  if (pkg.name === 'jest-circus') {
-    // Cannot find module 'prettier'
-    pkg.dependencies = {
-      ...pkg.dependencies,
-      'prettier': '*',
-    }
-    context.log('jest-circus requires prettier to format code for inline snapshots')
-  }
-
-  if (pkg.name === '@testing-library/user-event') {
-    // Cannot find module '@testing-library/dom'
-    pkg.dependencies = {
-      ...pkg.dependencies,
-      '@testing-library/dom': '*',
-    }
-    context.log('@testing-library/user-event requires @testing-library/dom')
-  }
-
-  if (/^\^?4\.2\./.test(pkg.dependencies['graceful-fs'])) {
-    // Object prototype may only be an Object or null: undefined
-    // Caused by https://github.com/isaacs/node-graceful-fs/commit/c55c1b8cb32510f92bd33d7c833364ecd3964dea
-    //
-    // Also avoids the issue fixed by https://github.com/isaacs/node-graceful-fs/pull/220
-    // where jest thinks it cannot find `ts-jest`.
-    pkg.dependencies['graceful-fs'] = '4.2.10'
-    context.log(`${pkg.name}@${pkg.version} may use Object.setPrototypeOf with fs.read, which is undefined in the browser, which crashes`)
-  }
-
-  return pkg
+  return pkg;
 }

--- a/libs/api/package.json
+++ b/libs/api/package.json
@@ -43,10 +43,8 @@
   "devDependencies": {
     "@types/jest": "^29.5.3",
     "eslint-plugin-vx": "workspace:*",
-    "fetch-mock": "^9.10.7",
     "is-ci-cli": "^2.2.0",
     "jest": "^29.6.2",
-    "jest-fetch-mock": "^3.0.3",
     "jest-junit": "^16.0.0",
     "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "^11.0.0",

--- a/libs/auth/package.json
+++ b/libs/auth/package.json
@@ -60,7 +60,6 @@
     "@votingworks/test-utils": "workspace:*",
     "esbuild-runner": "^2.2.1",
     "eslint-plugin-vx": "workspace:*",
-    "fetch-mock": "^9.11.0",
     "is-ci-cli": "^2.2.0",
     "jest": "^29.6.2",
     "jest-junit": "^16.0.0",

--- a/libs/logging/package.json
+++ b/libs/logging/package.json
@@ -54,7 +54,6 @@
     "esbuild-runner": "^2.2.1",
     "eslint-plugin-vx": "workspace:*",
     "fast-check": "2.23.2",
-    "fetch-mock": "^9.9.0",
     "fs-extra": "^10.0.0",
     "is-ci-cli": "^2.2.0",
     "jest": "^29.6.2",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
   "pnpm": {
     "overrides": {
       "@types/eslint": "8.4.1",
-      "typescript": "4.6.3"
+      "typescript": "4.6.3",
+      "graceful-fs": "^4.2.9"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,7 @@ lockfileVersion: '6.0'
 overrides:
   '@types/eslint': 8.4.1
   typescript: 4.6.3
+  graceful-fs: ^4.2.9
 
 importers:
 
@@ -2924,18 +2925,12 @@ importers:
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
-      fetch-mock:
-        specifier: ^9.10.7
-        version: 9.11.0(node-fetch@2.6.7)
       is-ci-cli:
         specifier: ^2.2.0
         version: 2.2.0
       jest:
         specifier: ^29.6.2
         version: 29.6.2(@types/node@16.18.23)
-      jest-fetch-mock:
-        specifier: ^3.0.3
-        version: 3.0.3
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -3036,9 +3031,6 @@ importers:
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
-      fetch-mock:
-        specifier: ^9.11.0
-        version: 9.11.0(node-fetch@2.6.7)
       is-ci-cli:
         specifier: ^2.2.0
         version: 2.2.0
@@ -4529,9 +4521,6 @@ importers:
       fast-check:
         specifier: 2.23.2
         version: 2.23.2
-      fetch-mock:
-        specifier: ^9.9.0
-        version: 9.11.0(node-fetch@2.6.7)
       fs-extra:
         specifier: ^10.0.0
         version: 10.0.0
@@ -14469,7 +14458,7 @@ packages:
     resolution: {integrity: sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==}
     engines: {node: '>=10.13.0'}
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       tapable: 2.2.1
 
   /enquirer@2.3.6:
@@ -25104,7 +25093,7 @@ packages:
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       json-parse-even-better-errors: 2.3.1
       loader-runner: 4.3.0
       mime-types: 2.1.35
@@ -25144,7 +25133,7 @@ packages:
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       json-parse-even-better-errors: 2.3.1
       loader-runner: 4.3.0
       mime-types: 2.1.35


### PR DESCRIPTION
Our `pnpm install` is noisy because we're logging changes / checks we're doing of our dependencies, some of which are no longer necessary. See comments.
