### PR TITLE
Add TestErrorBoundary to test helpers

### DIFF
--- a/apps/admin/frontend/test/render_in_app_context.tsx
+++ b/apps/admin/frontend/test/render_in_app_context.tsx
@@ -19,7 +19,7 @@ import {
   fakeSystemAdministratorUser,
 } from '@votingworks/test-utils';
 import type { MachineConfig } from '@votingworks/admin-backend';
-import { UsbDrive, mockUsbDrive } from '@votingworks/ui';
+import { UsbDrive, mockUsbDrive, TestErrorBoundary } from '@votingworks/ui';
 import { render as testRender, RenderResult } from './react_testing_library';
 import { AppContext } from '../src/contexts/app_context';
 import { Iso8601Timestamp } from '../src/config/types';
@@ -64,11 +64,13 @@ export function renderRootElement(
   } = {}
 ): RenderResult {
   return testRender(
-    <ApiClientContext.Provider value={apiClient}>
-      <QueryClientProvider client={queryClient}>
-        {component}
-      </QueryClientProvider>
-    </ApiClientContext.Provider>
+    <TestErrorBoundary>
+      <ApiClientContext.Provider value={apiClient}>
+        <QueryClientProvider client={queryClient}>
+          {component}
+        </QueryClientProvider>
+      </ApiClientContext.Provider>
+    </TestErrorBoundary>
   );
 }
 

--- a/apps/central-scan/frontend/test/api.tsx
+++ b/apps/central-scan/frontend/test/api.tsx
@@ -3,6 +3,7 @@ import type { Api } from '@votingworks/central-scan-backend';
 import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
 import { DippedSmartCardAuth } from '@votingworks/types';
 import { QueryClientProvider } from '@tanstack/react-query';
+import { TestErrorBoundary } from '@votingworks/ui';
 import { ApiClientContext, createQueryClient } from '../src/api';
 
 export type MockApiClient = MockClient<Api>;
@@ -23,10 +24,12 @@ export function provideApi(
   children: React.ReactNode
 ): JSX.Element {
   return (
-    <ApiClientContext.Provider value={apiMock}>
-      <QueryClientProvider client={createQueryClient()}>
-        {children}
-      </QueryClientProvider>
-    </ApiClientContext.Provider>
+    <TestErrorBoundary>
+      <ApiClientContext.Provider value={apiMock}>
+        <QueryClientProvider client={createQueryClient()}>
+          {children}
+        </QueryClientProvider>
+      </ApiClientContext.Provider>
+    </TestErrorBoundary>
   );
 }

--- a/apps/central-scan/frontend/test/render_in_app_context.tsx
+++ b/apps/central-scan/frontend/test/render_in_app_context.tsx
@@ -1,7 +1,7 @@
 import { electionSampleDefinition as testElectionDefinition } from '@votingworks/fixtures';
 import { LogSource, Logger } from '@votingworks/logging';
 import { DippedSmartCardAuth, ElectionDefinition } from '@votingworks/types';
-import { UsbDriveStatus } from '@votingworks/ui';
+import { TestErrorBoundary, UsbDriveStatus } from '@votingworks/ui';
 import { createMemoryHistory, MemoryHistory } from 'history';
 import React from 'react';
 import { Router } from 'react-router-dom';
@@ -70,22 +70,24 @@ export function wrapInAppContext(
   }: RenderInAppContextParams = {}
 ): React.ReactElement {
   return (
-    <ApiClientContext.Provider value={apiClient}>
-      <QueryClientProvider client={queryClient}>
-        <AppContext.Provider
-          value={makeAppContext({
-            electionDefinition,
-            machineConfig: { machineId, codeVersion: 'TEST' },
-            usbDriveStatus,
-            usbDriveEject,
-            auth,
-            logger,
-          })}
-        >
-          <Router history={history}>{component}</Router>
-        </AppContext.Provider>
-      </QueryClientProvider>
-    </ApiClientContext.Provider>
+    <TestErrorBoundary>
+      <ApiClientContext.Provider value={apiClient}>
+        <QueryClientProvider client={queryClient}>
+          <AppContext.Provider
+            value={makeAppContext({
+              electionDefinition,
+              machineConfig: { machineId, codeVersion: 'TEST' },
+              usbDriveStatus,
+              usbDriveEject,
+              auth,
+              logger,
+            })}
+          >
+            <Router history={history}>{component}</Router>
+          </AppContext.Provider>
+        </QueryClientProvider>
+      </ApiClientContext.Provider>
+    </TestErrorBoundary>
   );
 }
 

--- a/apps/mark-scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/mark-scan/frontend/test/helpers/mock_api_client.tsx
@@ -26,6 +26,7 @@ import {
 import { assert, err, ok, Result } from '@votingworks/basics';
 import { SimpleServerStatus } from '@votingworks/mark-scan-backend';
 import { singlePrecinctSelectionFor } from '@votingworks/utils';
+import { TestErrorBoundary } from '@votingworks/ui';
 import { ApiClientContext, createQueryClient } from '../../src/api';
 import { fakeMachineConfig } from './fake_machine_config';
 
@@ -243,10 +244,12 @@ export function provideApi(
   children: React.ReactNode
 ): JSX.Element {
   return (
-    <ApiClientContext.Provider value={apiMock.mockApiClient}>
-      <QueryClientProvider client={createQueryClient()}>
-        {children}
-      </QueryClientProvider>
-    </ApiClientContext.Provider>
+    <TestErrorBoundary>
+      <ApiClientContext.Provider value={apiMock.mockApiClient}>
+        <QueryClientProvider client={createQueryClient()}>
+          {children}
+        </QueryClientProvider>
+      </ApiClientContext.Provider>
+    </TestErrorBoundary>
   );
 }

--- a/apps/mark/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/mark/frontend/test/helpers/mock_api_client.tsx
@@ -20,6 +20,7 @@ import {
   fakeSystemAdministratorUser,
 } from '@votingworks/test-utils';
 import { err, ok, Result } from '@votingworks/basics';
+import { TestErrorBoundary } from '@votingworks/ui';
 import { ApiClientContext, createQueryClient } from '../../src/api';
 import { fakeMachineConfig } from './fake_machine_config';
 
@@ -182,10 +183,12 @@ export function provideApi(
   children: React.ReactNode
 ): JSX.Element {
   return (
-    <ApiClientContext.Provider value={apiMock.mockApiClient}>
-      <QueryClientProvider client={createQueryClient()}>
-        {children}
-      </QueryClientProvider>
-    </ApiClientContext.Provider>
+    <TestErrorBoundary>
+      <ApiClientContext.Provider value={apiMock.mockApiClient}>
+        <QueryClientProvider client={createQueryClient()}>
+          {children}
+        </QueryClientProvider>
+      </ApiClientContext.Provider>
+    </TestErrorBoundary>
   );
 }

--- a/apps/scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/scan/frontend/test/helpers/mock_api_client.tsx
@@ -26,6 +26,7 @@ import {
   fakeSystemAdministratorUser,
 } from '@votingworks/test-utils';
 import { UsbDriveStatus } from '@votingworks/usb-drive';
+import { TestErrorBoundary } from '@votingworks/ui';
 import { ApiClientContext, createQueryClient } from '../../src/api';
 import { fakeUsbDriveStatus } from './fake_usb_drive';
 
@@ -188,10 +189,12 @@ export function provideApi(
   children: React.ReactNode
 ): JSX.Element {
   return (
-    <ApiClientContext.Provider value={apiMock.mockApiClient}>
-      <QueryClientProvider client={createQueryClient()}>
-        {children}
-      </QueryClientProvider>
-    </ApiClientContext.Provider>
+    <TestErrorBoundary>
+      <ApiClientContext.Provider value={apiMock.mockApiClient}>
+        <QueryClientProvider client={createQueryClient()}>
+          {children}
+        </QueryClientProvider>
+      </ApiClientContext.Provider>
+    </TestErrorBoundary>
   );
 }

--- a/libs/ui/src/error_boundary.test.tsx
+++ b/libs/ui/src/error_boundary.test.tsx
@@ -1,11 +1,12 @@
 import { suppressingConsoleOutput } from '@votingworks/test-utils';
 import { render, screen } from '../test/react_testing_library';
-import { ErrorBoundary } from './error_boundary';
+import { ErrorBoundary, TestErrorBoundary } from './error_boundary';
+
+function ThrowError(): JSX.Element {
+  throw new Error('this is an error');
+}
 
 test('renders error when there is an error', async () => {
-  function ThrowError(): JSX.Element {
-    throw new Error('error');
-  }
   await suppressingConsoleOutput(async () => {
     render(
       <ErrorBoundary errorMessage="jellyfish">
@@ -20,4 +21,16 @@ test('renders children when there is no error', async () => {
   render(<ErrorBoundary errorMessage="jellyfish">Kangaroo</ErrorBoundary>);
   await screen.findByText('Kangaroo');
   expect(screen.queryAllByText('jellyfish')).toHaveLength(0);
+});
+
+test('TestErrorBoundary shows caught error message', async () => {
+  await suppressingConsoleOutput(async () => {
+    render(
+      <TestErrorBoundary>
+        <ThrowError />
+      </TestErrorBoundary>
+    );
+    await screen.findByText('Test Error Boundary');
+    screen.getByText('Error: this is an error');
+  });
 });

--- a/libs/ui/src/error_boundary.tsx
+++ b/libs/ui/src/error_boundary.tsx
@@ -4,7 +4,7 @@ import { Screen } from './screen';
 import { Main } from './main';
 
 type Props = React.PropsWithChildren<{
-  errorMessage: React.ReactNode;
+  errorMessage: React.ReactNode | ((error: unknown) => React.ReactNode);
 }>;
 
 interface State {
@@ -67,14 +67,40 @@ export class ErrorBoundary extends React.Component<Props, State> {
   render(): React.ReactNode {
     const { error } = this.state;
     const { errorMessage, children } = this.props;
+    const errorMessageString =
+      typeof errorMessage === 'function' ? errorMessage(error) : errorMessage;
     if (error) {
       return (
         <Screen>
-          <Main centerChild>{errorMessage}</Main>
+          <Main centerChild>{errorMessageString}</Main>
         </Screen>
       );
     }
 
     return children;
   }
+}
+
+/**
+ * An error boundary designed to be used in tests. It shows the error message
+ * from the caught error to aid in debugging.
+ */
+export function TestErrorBoundary({
+  children,
+}: {
+  children: React.ReactNode;
+}): JSX.Element {
+  return (
+    <ErrorBoundary
+      // eslint-disable-next-line react/no-unstable-nested-components
+      errorMessage={(error) => (
+        <React.Fragment>
+          Test Error Boundary
+          {error ? <pre>{(error as Error).toString()}</pre> : undefined}
+        </React.Fragment>
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  );
 }


### PR DESCRIPTION


## Overview

In order to catch API mock errors and display their messages in test output, we make sure that test helpers that provide an API are wrapped in an error boundary. That way, when a `screen.getByText(...)` fails, the DOM output will be the text of the actual mock error, not just a confusing random bit of DOM.
## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
