### PR TITLE
Fix VSCode workspace TypeScript path

### DIFF
--- a/vxsuite.code-workspace
+++ b/vxsuite.code-workspace
@@ -194,6 +194,9 @@
     },
     {
       "path": "docs"
+    },
+    {
+      "path": "."
     }
   ],
   "settings": {
@@ -258,7 +261,7 @@
       "**/build": true,
       "**/coverage": true
     },
-    "typescript.tsdk": "libs/types/node_modules/typescript/lib"
+    "typescript.tsdk": "vxsuite/node_modules/typescript/lib"
   },
   "extensions": {
     "recommendations": [


### PR DESCRIPTION
Since moving the TypeScript dependency to the top level of the workspace (instead of nested in each package), VS Code has been giving me an error about not being able to find TypeScript. This points the workspace settings to the top-level install.

In order to make it work, I had to add the root directory to the list of folders. I think this has a nice side effect of also allowing easy searching for files in that folder (which until now don't show up in the file search bar). So far it doesn't seem to have any negative side effects that I've noticed.
