### PR TITLE
Store system settings as JSON blob in db

### DIFF
--- a/apps/admin/backend/schema.sql
+++ b/apps/admin/backend/schema.sql
@@ -138,11 +138,7 @@ create table manual_result_write_in_candidate_references (
 create table system_settings (
   -- enforce singleton table
   id integer primary key check (id = 1),
-  are_poll_worker_card_pins_enabled boolean not null,
-  inactive_session_time_limit_minutes integer not null,
-  num_incorrect_pin_attempts_allowed_before_card_lockout integer not null,
-  overall_session_time_limit_hours integer not null,
-  starting_card_lockout_duration_seconds integer not null
+  data text not null -- JSON blob
 );
 
 create table settings (

--- a/apps/central-scan/backend/schema.sql
+++ b/apps/central-scan/backend/schema.sql
@@ -56,9 +56,5 @@ create table sheets (
 create table system_settings (
   -- enforce singleton table
   id integer primary key check (id = 1),
-  are_poll_worker_card_pins_enabled boolean not null,
-  inactive_session_time_limit_minutes integer not null,
-  num_incorrect_pin_attempts_allowed_before_card_lockout integer not null,
-  overall_session_time_limit_hours integer not null,
-  starting_card_lockout_duration_seconds integer not null
+  data text not null -- JSON blob
 );

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -24,7 +24,6 @@ import {
   SheetOf,
   Side,
   SystemSettings,
-  SystemSettingsDbRow,
 } from '@votingworks/types';
 import { assert, Optional } from '@votingworks/basics';
 import makeDebug from 'debug';
@@ -34,6 +33,7 @@ import { DateTime } from 'luxon';
 import { dirname, join } from 'path';
 import { v4 as uuid } from 'uuid';
 import { ResultSheet } from '@votingworks/backend';
+import { safeParseSystemSettings } from '@votingworks/utils';
 import { sheetRequiresAdjudication } from './sheet_requires_adjudication';
 import { normalizeAndJoin } from './util/path';
 
@@ -172,27 +172,15 @@ export class Store {
   }
 
   /**
-   * Creates a system settings record
+   * Stores the system settings.
    */
   setSystemSettings(systemSettings: SystemSettings): void {
     this.client.run('delete from system_settings');
     this.client.run(
       `
-      insert into system_settings (
-        are_poll_worker_card_pins_enabled,
-        inactive_session_time_limit_minutes,
-        num_incorrect_pin_attempts_allowed_before_card_lockout,
-        overall_session_time_limit_hours,
-        starting_card_lockout_duration_seconds
-      ) values (
-        ?, ?, ?, ?, ?
-      )
+      insert into system_settings (data) values (?)
       `,
-      systemSettings.arePollWorkerCardPinsEnabled ? 1 : 0,
-      systemSettings.inactiveSessionTimeLimitMinutes,
-      systemSettings.numIncorrectPinAttemptsAllowedBeforeCardLockout,
-      systemSettings.overallSessionTimeLimitHours,
-      systemSettings.startingCardLockoutDurationSeconds
+      JSON.stringify(systemSettings)
     );
   }
 
@@ -200,25 +188,12 @@ export class Store {
    * Gets system settings or undefined if they aren't loaded yet
    */
   getSystemSettings(): SystemSettings | undefined {
-    const result = this.client.one(
-      `
-      select
-        are_poll_worker_card_pins_enabled as arePollWorkerCardPinsEnabled,
-        inactive_session_time_limit_minutes as inactiveSessionTimeLimitMinutes,
-        num_incorrect_pin_attempts_allowed_before_card_lockout as numIncorrectPinAttemptsAllowedBeforeCardLockout,
-        overall_session_time_limit_hours as overallSessionTimeLimitHours,
-        starting_card_lockout_duration_seconds as startingCardLockoutDurationSeconds
-      from system_settings
-      `
-    ) as SystemSettingsDbRow | undefined;
+    const result = this.client.one(`select data from system_settings`) as
+      | { data: string }
+      | undefined;
 
-    if (!result) {
-      return undefined;
-    }
-    return {
-      ...result,
-      arePollWorkerCardPinsEnabled: result.arePollWorkerCardPinsEnabled === 1,
-    };
+    if (!result) return undefined;
+    return safeParseSystemSettings(result.data).unsafeUnwrap();
   }
 
   /**

--- a/apps/mark-scan/backend/schema.sql
+++ b/apps/mark-scan/backend/schema.sql
@@ -10,9 +10,5 @@ create table election (
 create table system_settings (
   -- enforce singleton table
   id integer primary key check (id = 1),
-  are_poll_worker_card_pins_enabled boolean not null,
-  inactive_session_time_limit_minutes integer not null,
-  num_incorrect_pin_attempts_allowed_before_card_lockout integer not null,
-  overall_session_time_limit_hours integer not null,
-  starting_card_lockout_duration_seconds integer not null
+  data text not null -- JSON blob
 );

--- a/apps/mark-scan/backend/src/store.test.ts
+++ b/apps/mark-scan/backend/src/store.test.ts
@@ -1,10 +1,6 @@
 import { safeParseSystemSettings } from '@votingworks/utils';
 import { electionMinimalExhaustiveSampleFixtures } from '@votingworks/fixtures';
-import {
-  DEFAULT_SYSTEM_SETTINGS,
-  SystemSettings,
-  TEST_JURISDICTION,
-} from '@votingworks/types';
+import { TEST_JURISDICTION } from '@votingworks/types';
 import { Store } from './store';
 
 // We pause in some of these tests so we need to increase the timeout
@@ -49,27 +45,6 @@ test('get/set/delete system settings', () => {
 
   store.deleteSystemSettings();
   expect(store.getSystemSettings()).toBeUndefined();
-});
-
-test('setSystemSettings can handle boolean values in input', () => {
-  const store = Store.memoryStore();
-  const systemSettingsWithTrue: SystemSettings = {
-    ...DEFAULT_SYSTEM_SETTINGS,
-    arePollWorkerCardPinsEnabled: true,
-  };
-
-  store.setSystemSettings(systemSettingsWithTrue);
-  let settings = store.getSystemSettings();
-  expect(settings?.arePollWorkerCardPinsEnabled).toEqual(true);
-
-  store.reset();
-  const systemSettingsWithFalse: SystemSettings = {
-    ...systemSettingsWithTrue,
-    arePollWorkerCardPinsEnabled: false,
-  };
-  store.setSystemSettings(systemSettingsWithFalse);
-  settings = store.getSystemSettings();
-  expect(settings?.arePollWorkerCardPinsEnabled).toEqual(false);
 });
 
 test('errors when election definition cannot be parsed', () => {

--- a/apps/mark-scan/backend/src/store.ts
+++ b/apps/mark-scan/backend/src/store.ts
@@ -11,8 +11,8 @@ import {
   safeParseElectionDefinition,
   safeParseJson,
   SystemSettings,
-  SystemSettingsDbRow,
 } from '@votingworks/types';
+import { safeParseSystemSettings } from '@votingworks/utils';
 import { join } from 'path';
 
 const SchemaPath = join(__dirname, '../schema.sql');
@@ -161,52 +161,27 @@ export class Store {
   }
 
   /**
-   * Creates a system settings record
+   * Stores the system settings.
    */
   setSystemSettings(systemSettings: SystemSettings): void {
     this.client.run('delete from system_settings');
     this.client.run(
       `
-      insert into system_settings (
-        are_poll_worker_card_pins_enabled,
-        inactive_session_time_limit_minutes,
-        num_incorrect_pin_attempts_allowed_before_card_lockout,
-        overall_session_time_limit_hours,
-        starting_card_lockout_duration_seconds
-      ) values (
-        ?, ?, ?, ?, ?
-      )
+      insert into system_settings (data) values (?)
       `,
-      systemSettings.arePollWorkerCardPinsEnabled ? 1 : 0,
-      systemSettings.inactiveSessionTimeLimitMinutes,
-      systemSettings.numIncorrectPinAttemptsAllowedBeforeCardLockout,
-      systemSettings.overallSessionTimeLimitHours,
-      systemSettings.startingCardLockoutDurationSeconds
+      JSON.stringify(systemSettings)
     );
   }
 
   /**
-   * Gets system settings or undefined if they aren't loaded yet
+   * Retrieves the system settings.
    */
   getSystemSettings(): SystemSettings | undefined {
-    const result = this.client.one(
-      `
-      select
-        are_poll_worker_card_pins_enabled as arePollWorkerCardPinsEnabled,
-        inactive_session_time_limit_minutes as inactiveSessionTimeLimitMinutes,
-        num_incorrect_pin_attempts_allowed_before_card_lockout as numIncorrectPinAttemptsAllowedBeforeCardLockout,
-        overall_session_time_limit_hours as overallSessionTimeLimitHours,
-        starting_card_lockout_duration_seconds as startingCardLockoutDurationSeconds
-      from system_settings
-      `
-    ) as SystemSettingsDbRow | undefined;
+    const result = this.client.one(`select data from system_settings`) as
+      | { data: string }
+      | undefined;
 
-    if (!result) {
-      return undefined;
-    }
-    return {
-      ...result,
-      arePollWorkerCardPinsEnabled: result.arePollWorkerCardPinsEnabled === 1,
-    };
+    if (!result) return undefined;
+    return safeParseSystemSettings(result.data).unsafeUnwrap();
   }
 }

--- a/apps/mark/backend/schema.sql
+++ b/apps/mark/backend/schema.sql
@@ -9,9 +9,5 @@ create table election (
 create table system_settings (
   -- enforce singleton table
   id integer primary key check (id = 1),
-  are_poll_worker_card_pins_enabled boolean not null,
-  inactive_session_time_limit_minutes integer not null,
-  num_incorrect_pin_attempts_allowed_before_card_lockout integer not null,
-  overall_session_time_limit_hours integer not null,
-  starting_card_lockout_duration_seconds integer not null
+  data text not null -- JSON blob
 );

--- a/apps/mark/backend/src/store.ts
+++ b/apps/mark/backend/src/store.ts
@@ -7,8 +7,8 @@ import {
   ElectionDefinition,
   safeParseElectionDefinition,
   SystemSettings,
-  SystemSettingsDbRow,
 } from '@votingworks/types';
+import { safeParseSystemSettings } from '@votingworks/utils';
 import { join } from 'path';
 
 const SchemaPath = join(__dirname, '../schema.sql');
@@ -116,52 +116,27 @@ export class Store {
   }
 
   /**
-   * Creates a system settings record
+   * Stores the system settings.
    */
   setSystemSettings(systemSettings: SystemSettings): void {
     this.client.run('delete from system_settings');
     this.client.run(
       `
-      insert into system_settings (
-        are_poll_worker_card_pins_enabled,
-        inactive_session_time_limit_minutes,
-        num_incorrect_pin_attempts_allowed_before_card_lockout,
-        overall_session_time_limit_hours,
-        starting_card_lockout_duration_seconds
-      ) values (
-        ?, ?, ?, ?, ?
-      )
+      insert into system_settings (data) values (?)
       `,
-      systemSettings.arePollWorkerCardPinsEnabled ? 1 : 0,
-      systemSettings.inactiveSessionTimeLimitMinutes,
-      systemSettings.numIncorrectPinAttemptsAllowedBeforeCardLockout,
-      systemSettings.overallSessionTimeLimitHours,
-      systemSettings.startingCardLockoutDurationSeconds
+      JSON.stringify(systemSettings)
     );
   }
 
   /**
-   * Gets system settings or undefined if they aren't loaded yet
+   * Retrieves the system settings.
    */
   getSystemSettings(): SystemSettings | undefined {
-    const result = this.client.one(
-      `
-      select
-        are_poll_worker_card_pins_enabled as arePollWorkerCardPinsEnabled,
-        inactive_session_time_limit_minutes as inactiveSessionTimeLimitMinutes,
-        num_incorrect_pin_attempts_allowed_before_card_lockout as numIncorrectPinAttemptsAllowedBeforeCardLockout,
-        overall_session_time_limit_hours as overallSessionTimeLimitHours,
-        starting_card_lockout_duration_seconds as startingCardLockoutDurationSeconds
-      from system_settings
-      `
-    ) as SystemSettingsDbRow | undefined;
+    const result = this.client.one(`select data from system_settings`) as
+      | { data: string }
+      | undefined;
 
-    if (!result) {
-      return undefined;
-    }
-    return {
-      ...result,
-      arePollWorkerCardPinsEnabled: result.arePollWorkerCardPinsEnabled === 1,
-    };
+    if (!result) return undefined;
+    return safeParseSystemSettings(result.data).unsafeUnwrap();
   }
 }

--- a/apps/scan/backend/schema.sql
+++ b/apps/scan/backend/schema.sql
@@ -57,9 +57,5 @@ create table sheets (
 create table system_settings (
   -- enforce singleton table
   id integer primary key check (id = 1),
-  are_poll_worker_card_pins_enabled boolean not null,
-  inactive_session_time_limit_minutes integer not null,
-  num_incorrect_pin_attempts_allowed_before_card_lockout integer not null,
-  overall_session_time_limit_hours integer not null,
-  starting_card_lockout_duration_seconds integer not null
+  data text not null -- JSON blob
 );

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -23,7 +23,6 @@ import {
   safeParseJson,
   SheetOf,
   SystemSettings,
-  SystemSettingsDbRow,
 } from '@votingworks/types';
 import { assert, Optional } from '@votingworks/basics';
 import * as fs from 'fs-extra';
@@ -32,6 +31,7 @@ import { DateTime } from 'luxon';
 import { join } from 'path';
 import { v4 as uuid } from 'uuid';
 import { ResultSheet } from '@votingworks/backend';
+import { safeParseSystemSettings } from '@votingworks/utils';
 import { sheetRequiresAdjudication } from './sheet_requires_adjudication';
 import { rootDebug } from './util/debug';
 
@@ -945,52 +945,27 @@ export class Store {
   }
 
   /**
-   * Creates a system settings record
+   * Stores the system settings.
    */
   setSystemSettings(systemSettings: SystemSettings): void {
     this.client.run('delete from system_settings');
     this.client.run(
       `
-      insert into system_settings (
-        are_poll_worker_card_pins_enabled,
-        inactive_session_time_limit_minutes,
-        num_incorrect_pin_attempts_allowed_before_card_lockout,
-        overall_session_time_limit_hours,
-        starting_card_lockout_duration_seconds
-      ) values (
-        ?, ?, ?, ?, ?
-      )
+      insert into system_settings (data) values (?)
       `,
-      systemSettings.arePollWorkerCardPinsEnabled ? 1 : 0,
-      systemSettings.inactiveSessionTimeLimitMinutes,
-      systemSettings.numIncorrectPinAttemptsAllowedBeforeCardLockout,
-      systemSettings.overallSessionTimeLimitHours,
-      systemSettings.startingCardLockoutDurationSeconds
+      JSON.stringify(systemSettings)
     );
   }
 
   /**
-   * Gets system settings or undefined if they aren't loaded yet
+   * Retrieves the system settings.
    */
   getSystemSettings(): SystemSettings | undefined {
-    const result = this.client.one(
-      `
-      select
-        are_poll_worker_card_pins_enabled as arePollWorkerCardPinsEnabled,
-        inactive_session_time_limit_minutes as inactiveSessionTimeLimitMinutes,
-        num_incorrect_pin_attempts_allowed_before_card_lockout as numIncorrectPinAttemptsAllowedBeforeCardLockout,
-        overall_session_time_limit_hours as overallSessionTimeLimitHours,
-        starting_card_lockout_duration_seconds as startingCardLockoutDurationSeconds
-      from system_settings
-      `
-    ) as SystemSettingsDbRow | undefined;
+    const result = this.client.one(`select data from system_settings`) as
+      | { data: string }
+      | undefined;
 
-    if (!result) {
-      return undefined;
-    }
-    return {
-      ...result,
-      arePollWorkerCardPinsEnabled: result.arePollWorkerCardPinsEnabled === 1,
-    };
+    if (!result) return undefined;
+    return safeParseSystemSettings(result.data).unsafeUnwrap();
   }
 }

--- a/libs/types/src/system_settings.ts
+++ b/libs/types/src/system_settings.ts
@@ -14,11 +14,11 @@ import {
   StartingCardLockoutDurationSeconds,
   StartingCardLockoutDurationSecondsSchema,
 } from './auth';
-import { Id, Iso8601Timestamp } from './generic';
 
 /**
- * System settings as used by frontends and APIs. Several database fields are hidden from the app
- * because they are omitted in this model; see schema.sql.
+ * Settings for various parts of the system that are not part of the election
+ * definition. These settings can be changed without changing the election hash
+ * (and therefore not needing to reprint ballots, for example).
  */
 export interface SystemSettings {
   arePollWorkerCardPinsEnabled: boolean;
@@ -46,16 +46,3 @@ export const DEFAULT_SYSTEM_SETTINGS: SystemSettings = {
   startingCardLockoutDurationSeconds:
     DEFAULT_STARTING_CARD_LOCKOUT_DURATION_SECONDS,
 };
-
-/**
- * System settings as used by the db.
- */
-export interface SystemSettingsDbRow {
-  id: Id;
-  created: Iso8601Timestamp;
-  arePollWorkerCardPinsEnabled: 0 | 1; // sqlite3 does not support booleans
-  inactiveSessionTimeLimitMinutes: InactiveSessionTimeLimitMinutes;
-  numIncorrectPinAttemptsAllowedBeforeCardLockout: NumIncorrectPinAttemptsAllowedBeforeCardLockout;
-  overallSessionTimeLimitHours: OverallSessionTimeLimitHours;
-  startingCardLockoutDurationSeconds: StartingCardLockoutDurationSeconds;
-}


### PR DESCRIPTION


## Overview

As the system settings grows to encompass more complex data, it's easier to store the JSON blob rather than convert it to SQL columns. We use a schema to validate the data on retrieval to ensure that it complies with the current type definition.

## Demo Video or Screenshot
N/A

## Testing Plan
- Existing automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
