### PR TITLE
refactor(admin): track ballot style party ids in store

### DIFF
--- a/apps/admin/backend/schema.sql
+++ b/apps/admin/backend/schema.sql
@@ -6,6 +6,15 @@ create table elections (
   deleted_at timestamp
 );
 
+create table ballot_styles (
+  election_id integer not null,
+  id text not null,
+  party_id text,
+  primary key (election_id, id),
+  foreign key (election_id) references elections(id)
+    on delete cascade
+);
+
 create table write_in_candidates (
   id varchar(36) primary key,
   election_id varchar(36) not null,

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -681,9 +681,13 @@ function buildApi({
     ): ManualResultsRecord | null {
       const [manualResultsRecord] = store.getManualResults({
         electionId: loadCurrentElectionIdOrThrow(workspace),
-        precinctIds: input.precinctId ? [input.precinctId] : undefined,
-        ballotStyleIds: input.ballotStyleId ? [input.ballotStyleId] : undefined,
-        votingMethods: input.votingMethod ? [input.votingMethod] : undefined,
+        filter: {
+          precinctIds: input.precinctId ? [input.precinctId] : undefined,
+          ballotStyleIds: input.ballotStyleId
+            ? [input.ballotStyleId]
+            : undefined,
+          votingMethods: input.votingMethod ? [input.votingMethod] : undefined,
+        },
       });
 
       return manualResultsRecord ?? null;

--- a/apps/admin/backend/src/store.test.ts
+++ b/apps/admin/backend/src/store.test.ts
@@ -200,9 +200,11 @@ test('manual results', () => {
   expect(
     store.getManualResults({
       electionId,
-      precinctIds: [precinctId],
-      ballotStyleIds: [ballotStyleId],
-      votingMethods: [votingMethod],
+      filter: {
+        precinctIds: [precinctId],
+        ballotStyleIds: [ballotStyleId],
+        votingMethods: [votingMethod],
+      },
     })
   ).toMatchObject([{ precinctId, ballotStyleId, votingMethod, manualResults }]);
   expect(store.getWriteInCandidates({ electionId })).toHaveLength(1);

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -137,7 +137,6 @@ export class Store {
    *
    * Returns the result of the function.
    */
-  withTransaction<T>(fn: () => Promise<T>): Promise<T>;
   withTransaction<T>(fn: () => T): T {
     return this.client.transaction(fn, (result: T) => {
       if (isResult(result)) {
@@ -153,12 +152,15 @@ export class Store {
    */
   addElection(electionData: string): Id {
     const id = uuid();
-    this.client.run(
-      'insert into elections (id, data) values (?, ?)',
-      id,
-      electionData
-    );
-    this.createElectionMetadataRecords(id);
+    this.withTransaction(() => {
+      this.client.run(
+        'insert into elections (id, data) values (?, ?)',
+        id,
+        electionData
+      );
+      this.createElectionMetadataRecords(id);
+    });
+
     return id;
   }
 

--- a/apps/admin/backend/src/tabulation/card_counts.ts
+++ b/apps/admin/backend/src/tabulation/card_counts.ts
@@ -52,13 +52,8 @@ export function tabulateScannedCardCounts({
   groupBy?: Tabulation.GroupBy;
   blankBallotsOnly?: boolean;
 }): Tabulation.GroupMap<Tabulation.CardCounts> {
-  const {
-    electionDefinition: { election },
-  } = assertDefined(store.getElection(electionId));
-
   const cardTallies = store.getCardTallies({
     electionId,
-    election,
     groupBy,
     blankBallotsOnly,
   });
@@ -145,6 +140,7 @@ export function tabulateFullCardCounts({
     groupedManualBallotCounts,
     (scannedCardCounts, manualBallotCount) => {
       return {
+        // eslint-disable-next-line vx/gts-spread-like-types
         ...(scannedCardCounts ?? getEmptyCardCounts()),
         manual: manualBallotCount ?? 0,
       };

--- a/apps/admin/backend/src/tabulation/full_results.ts
+++ b/apps/admin/backend/src/tabulation/full_results.ts
@@ -38,7 +38,7 @@ export function tabulateCastVoteRecords({
   } = assertDefined(store.getElection(electionId));
 
   return tabulateFilteredCastVoteRecords({
-    cvrs: store.getCastVoteRecords({ electionId, election, filter }),
+    cvrs: store.getCastVoteRecords({ electionId, filter }),
     election,
     groupBy,
   });

--- a/apps/admin/backend/src/tabulation/manual_results.ts
+++ b/apps/admin/backend/src/tabulation/manual_results.ts
@@ -14,7 +14,6 @@ import {
   ManualResultsRecord,
 } from '../types';
 import { Store } from '../store';
-import { replacePartyIdFilter } from './utils';
 
 function getManualResultsGroupSpecifier(
   manualResultsIdentifier: ManualResultsIdentifier,
@@ -125,7 +124,7 @@ export function tabulateManualResults({
 
   const manualResultsRecords = store.getManualResults({
     electionId,
-    ...replacePartyIdFilter(filter, election),
+    filter,
   });
 
   return ok(

--- a/apps/admin/backend/src/tabulation/utils.test.ts
+++ b/apps/admin/backend/src/tabulation/utils.test.ts
@@ -1,55 +1,7 @@
-import { electionMinimalExhaustiveSampleDefinition } from '@votingworks/fixtures';
-import { replacePartyIdFilter } from './utils';
+import { isBlankSheet } from './utils';
 
-test('replacePartyIdFilter', () => {
-  const { election } = electionMinimalExhaustiveSampleDefinition;
-
-  expect(
-    replacePartyIdFilter(
-      {
-        partyIds: ['0'],
-      },
-      election
-    )
-  ).toEqual({
-    ballotStyleIds: ['1M'],
-  });
-
-  expect(
-    replacePartyIdFilter(
-      {
-        partyIds: ['0', '1'],
-      },
-      election
-    )
-  ).toEqual({
-    ballotStyleIds: ['1M', '2F'],
-  });
-
-  // doesn't touch other filters when no party id
-  expect(
-    replacePartyIdFilter(
-      {
-        ballotStyleIds: ['1M', '2F'],
-        votingMethods: ['absentee'],
-      },
-      election
-    )
-  ).toEqual({
-    ballotStyleIds: ['1M', '2F'],
-    votingMethods: ['absentee'],
-  });
-
-  // intersects explicit ballot style ids and implied ballot style ids
-  expect(
-    replacePartyIdFilter(
-      {
-        partyIds: ['0'],
-        ballotStyleIds: ['1M', '2F'],
-      },
-      election
-    )
-  ).toEqual({
-    ballotStyleIds: ['1M'],
-  });
+test('isBlankSheet', () => {
+  expect(isBlankSheet({})).toEqual(true);
+  expect(isBlankSheet({ contest: [] })).toEqual(true);
+  expect(isBlankSheet({ contest: ['id'] })).toEqual(false);
 });

--- a/apps/admin/backend/src/tabulation/utils.ts
+++ b/apps/admin/backend/src/tabulation/utils.ts
@@ -1,35 +1,4 @@
-import { BallotStyleId, Election, Tabulation } from '@votingworks/types';
-
-/**
- * Replaces the `partyIds` filter in a {@link Tabulation.Filter} with
- * an equivalent `ballotStyleIds` filter.
- */
-export function replacePartyIdFilter(
-  filter: Tabulation.Filter,
-  election: Election
-): Omit<Tabulation.Filter, 'partyIds'> {
-  if (!filter.partyIds) return filter;
-
-  const ballotStyleIds: BallotStyleId[] = [];
-
-  for (const ballotStyle of election.ballotStyles) {
-    if (
-      ballotStyle.partyId &&
-      filter.partyIds.includes(ballotStyle.partyId) &&
-      (!filter.ballotStyleIds || filter.ballotStyleIds.includes(ballotStyle.id))
-    ) {
-      ballotStyleIds.push(ballotStyle.id);
-    }
-  }
-
-  return {
-    ballotStyleIds,
-    precinctIds: filter.precinctIds,
-    votingMethods: filter.votingMethods,
-    scannerIds: filter.scannerIds,
-    batchIds: filter.batchIds,
-  };
-}
+import { Tabulation } from '@votingworks/types';
 
 /**
  * Tests whether CVR votes are empty.

--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -419,19 +419,11 @@ export interface ManualResultsMetadataRecord extends ManualResultsIdentifier {
 }
 
 /**
- * Subset of cast vote records filters that we support with manual results.
+ * Subset of cast vote record filters that we can filter on for manual results.
  */
-export type ManualResultsFilter = Pick<
+export type ManualResultsFilter = Omit<
   Tabulation.Filter,
-  'ballotStyleIds' | 'partyIds' | 'precinctIds' | 'votingMethods'
->;
-
-/**
- * Subset of manual results filter that the store itself can filter on.
- */
-export type ManualResultsStoreFilter = Pick<
-  ManualResultsFilter,
-  'ballotStyleIds' | 'precinctIds' | 'votingMethods'
+  'scannerIds' | 'batchIds'
 >;
 
 /**

--- a/apps/admin/frontend/src/utils/election.ts
+++ b/apps/admin/frontend/src/utils/election.ts
@@ -18,6 +18,7 @@ import {
 import { assert, find, mapObject } from '@votingworks/basics';
 import type { TallyReportResults } from '@votingworks/admin-backend';
 import {
+  getBallotStyleIdPartyIdLookup,
   groupMapToGroupList,
   tabulateCastVoteRecords,
 } from '@votingworks/utils';
@@ -268,13 +269,16 @@ export async function generateResultsFromTestDeckBallots({
   election: Election;
   testDeckBallots: TestDeckBallot[];
 }): Promise<Tabulation.GroupList<TallyReportResults>> {
+  const ballotStyleIdPartyIdLookup = getBallotStyleIdPartyIdLookup(election);
+
   return groupMapToGroupList(
     mapObject(
       await tabulateCastVoteRecords({
         election,
-        cvrs: testDeckBallots.map((testDeckBallot) =>
-          testDeckBallotToCastVoteRecord(testDeckBallot)
-        ),
+        cvrs: testDeckBallots.map((testDeckBallot) => ({
+          ...testDeckBallotToCastVoteRecord(testDeckBallot),
+          partyId: ballotStyleIdPartyIdLookup[testDeckBallot.ballotStyleId],
+        })),
         groupBy: electionHasPrimaryContest(election)
           ? { groupByParty: true }
           : undefined,

--- a/libs/types/src/tabulation.ts
+++ b/libs/types/src/tabulation.ts
@@ -69,6 +69,7 @@ export interface CastVoteRecordAttributes {
   readonly votingMethod: VotingMethod;
   readonly batchId: Id;
   readonly scannerId: Id;
+  readonly partyId?: Id;
 }
 
 /**
@@ -83,9 +84,7 @@ export type Card = { type: 'bmd' } | { type: 'hmpb'; sheetNumber: number };
  */
 export type GroupSpecifier = Partial<{
   -readonly [K in keyof CastVoteRecordAttributes]: CastVoteRecordAttributes[K];
-}> & {
-  partyId?: Id;
-};
+}>;
 
 /**
  * The cast vote record attributes we can use to group election results. For

--- a/libs/utils/src/tabulation/tabulation.test.ts
+++ b/libs/utils/src/tabulation/tabulation.test.ts
@@ -64,6 +64,7 @@ function loadCastVoteRecordsFromReport(
       ballotStyleId: cvr.BallotStyleId,
       batchId: cvr.BatchId,
       scannerId: cvr.CreatingDeviceId,
+      partyId: cvr.PartyIds?.[0],
       precinctId: cvr.BallotStyleUnitId,
       votingMethod: cvr.vxBallotType as Tabulation.VotingMethod,
       card: cvr.BallotSheetId

--- a/libs/utils/src/tabulation/tabulation.ts
+++ b/libs/utils/src/tabulation/tabulation.ts
@@ -236,8 +236,7 @@ export function isGroupByEmpty(groupBy: Tabulation.GroupBy): boolean {
 
 function getCastVoteRecordGroupSpecifier(
   cvr: Tabulation.CastVoteRecord,
-  groupBy: Tabulation.GroupBy,
-  partyIdLookup: BallotStyleIdPartyIdLookup
+  groupBy: Tabulation.GroupBy
 ): Tabulation.GroupSpecifier {
   return {
     ballotStyleId: groupBy.groupByBallotStyle ? cvr.ballotStyleId : undefined,
@@ -245,9 +244,7 @@ function getCastVoteRecordGroupSpecifier(
     batchId: groupBy.groupByBatch ? cvr.batchId : undefined,
     scannerId: groupBy.groupByScanner ? cvr.scannerId : undefined,
     votingMethod: groupBy.groupByVotingMethod ? cvr.votingMethod : undefined,
-    partyId: groupBy.groupByParty
-      ? partyIdLookup[cvr.ballotStyleId]
-      : undefined,
+    partyId: groupBy.groupByParty ? cvr.partyId : undefined,
   };
 }
 
@@ -445,14 +442,9 @@ export async function tabulateCastVoteRecords({
   }
 
   // general case, grouping results by specified group by clause
-  const partyIdLookup = getBallotStyleIdPartyIdLookup(election);
   let i = 0;
   for (const cvr of cvrs) {
-    const groupSpecifier = getCastVoteRecordGroupSpecifier(
-      cvr,
-      groupBy,
-      partyIdLookup
-    );
+    const groupSpecifier = getCastVoteRecordGroupSpecifier(cvr, groupBy);
     const groupKey = getGroupKey(groupSpecifier, groupBy);
     const existingElectionResult = groupedElectionResults[groupKey];
     if (existingElectionResult) {


### PR DESCRIPTION
## Overview

Rather than translate / lookup ballot styles into their party affiliations in our tabulation code, put that lookup into the persistent store and use the database to gather that information. It's still not hiccup-free but I think this is clearer / safer.

## Testing Plan

Existing testing passes.

