### PR TITLE
[VxScan] Ensure voter has the ability to review all overvote/undervote contests

### DIFF
--- a/apps/scan/frontend/src/components/full_screen_prompt_layout.tsx
+++ b/apps/scan/frontend/src/components/full_screen_prompt_layout.tsx
@@ -5,11 +5,11 @@ import styled from 'styled-components';
 interface FullScreenPromptLayoutProps {
   actionButtons?: React.ReactNode;
   children?: React.ReactNode;
-  image: React.ReactNode;
+  image?: React.ReactNode;
   title: React.ReactNode;
 }
 
-const HORIZONTAL_PADDING_REM = 0.75;
+const HORIZONTAL_PADDING_REM = 0.5;
 
 const OuterContainer = styled.div`
   display: flex;
@@ -52,16 +52,12 @@ const Text = styled.div`
 `;
 
 const Footer = styled.div`
-  display: flex;
-  gap: ${HORIZONTAL_PADDING_REM}rem;
+  display: grid;
+  grid-gap: ${HORIZONTAL_PADDING_REM}rem;
+  grid-template-columns: 1fr 1fr;
   justify-content: end;
-  padding: 0 ${HORIZONTAL_PADDING_REM}rem 0.5rem;
+  padding: 0 7.5vw 0.25rem;
   width: 100%;
-
-  & > * {
-    flex-grow: 1;
-    max-width: 50%;
-  }
 `;
 
 export function FullScreenPromptLayout(
@@ -72,7 +68,7 @@ export function FullScreenPromptLayout(
   return (
     <OuterContainer>
       <Body>
-        <ImageContainer>{image}</ImageContainer>
+        {image && <ImageContainer>{image}</ImageContainer>}
         <Content>
           <WithScrollButtons noPadding>
             <Text>

--- a/apps/scan/frontend/src/components/misvote_warnings/constants.ts
+++ b/apps/scan/frontend/src/components/misvote_warnings/constants.ts
@@ -1,0 +1,38 @@
+import { SizeMode } from '@votingworks/types';
+import { MisvoteWarningsConfig } from './types';
+
+/**
+ * Layout configuration params for each {@link SizeMode} - these were manually
+ * tuned to make sure we display the full warning details whenever we can fit
+ * them all on the main ScanWarningScreen without needing to scroll and display
+ * a summary with a details modal button otherwise.
+ *
+ * Can be tweaked as needed, as the product evolves.
+ */
+export const CONFIG: Readonly<Record<SizeMode, MisvoteWarningsConfig>> = {
+  s: {
+    maxCardsPerRow: 3,
+    maxColumnsPerCard: 3,
+    maxPreviewContestRows: 8,
+  },
+  m: {
+    maxCardsPerRow: 2,
+    maxColumnsPerCard: 2,
+    maxPreviewContestRows: 4,
+  },
+  l: {
+    maxCardsPerRow: 1,
+    maxColumnsPerCard: 2,
+    maxPreviewContestRows: 3,
+  },
+  xl: {
+    maxCardsPerRow: 1,
+    maxColumnsPerCard: 1,
+    maxPreviewContestRows: 2,
+  },
+  legacy: {
+    maxCardsPerRow: 3,
+    maxColumnsPerCard: 3,
+    maxPreviewContestRows: 8,
+  },
+};

--- a/apps/scan/frontend/src/components/misvote_warnings/contest_list.test.tsx
+++ b/apps/scan/frontend/src/components/misvote_warnings/contest_list.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '../../../test/react_testing_library';
+import { ContestList } from './contest_list';
+import { generateContests } from './test_utils.test';
+
+test('renders all provided info', () => {
+  const contests = generateContests(4);
+
+  render(
+    <ContestList
+      title="Too many votes:"
+      helpNote="These votes won't count."
+      contests={contests}
+      maxColumns={2}
+    />
+  );
+
+  screen.getByText('Too many votes:');
+  screen.getByText("These votes won't count.");
+
+  const listItems = screen.getAllByRole('listitem').map((li) => li.textContent);
+  expect(listItems).toEqual(contests.map((c) => c.title));
+});

--- a/apps/scan/frontend/src/components/misvote_warnings/contest_list.tsx
+++ b/apps/scan/frontend/src/components/misvote_warnings/contest_list.tsx
@@ -1,0 +1,46 @@
+import styled from 'styled-components';
+
+import { AnyContest } from '@votingworks/types';
+import { Caption, Font, Icons, List, ListItem } from '@votingworks/ui';
+
+export interface ContestListProps {
+  contests: readonly AnyContest[];
+  helpNote: string;
+  maxColumns: number;
+  title: string;
+}
+
+const Container = styled.div`
+  border: ${(p) => p.theme.sizes.bordersRem.hairline}rem solid
+    ${(p) => p.theme.colors.foreground};
+  border-radius: 0.1rem;
+  padding: 0.25rem 0.5rem 0.5rem;
+`;
+
+const HelpNote = styled(Caption)`
+  display: flex;
+  gap: 0.25rem;
+  line-height: 1;
+  margin: 0.25rem 0 0.5rem;
+`;
+
+export function ContestList(props: ContestListProps): JSX.Element {
+  const { contests, helpNote, maxColumns, title } = props;
+
+  return (
+    <Container>
+      <Font weight="bold">{title}</Font>
+      <HelpNote weight="semiBold">
+        <Icons.Info />
+        <span>{helpNote}</span>
+      </HelpNote>
+      <List maxColumns={maxColumns}>
+        {contests.map((c) => (
+          <Caption key={c.id}>
+            <ListItem>{c.title}</ListItem>
+          </Caption>
+        ))}
+      </List>
+    </Container>
+  );
+}

--- a/apps/scan/frontend/src/components/misvote_warnings/index.ts
+++ b/apps/scan/frontend/src/components/misvote_warnings/index.ts
@@ -1,0 +1,2 @@
+export * from './misvote_warnings';
+export * from './warning_details';

--- a/apps/scan/frontend/src/components/misvote_warnings/misvote_warnings.test.tsx
+++ b/apps/scan/frontend/src/components/misvote_warnings/misvote_warnings.test.tsx
@@ -1,0 +1,92 @@
+import { mockOf } from '@votingworks/test-utils';
+import { render, screen } from '../../../test/react_testing_library';
+import { WarningDetails } from './warning_details';
+import { generateContests } from './test_utils.test';
+import { WarningsSummary } from './warnings_summary';
+import { useLayoutConfig } from './use_layout_config_hook';
+import { MisvoteWarnings } from './misvote_warnings';
+
+jest.mock('./warning_details', (): typeof import('./warning_details') => ({
+  ...jest.requireActual('./warning_details'),
+  WarningDetails: jest.fn(),
+}));
+
+jest.mock('./warnings_summary', (): typeof import('./warnings_summary') => ({
+  ...jest.requireActual('./warnings_summary'),
+  WarningsSummary: jest.fn(),
+}));
+
+jest.mock(
+  './use_layout_config_hook',
+  (): typeof import('./use_layout_config_hook') => ({
+    ...jest.requireActual('./use_layout_config_hook'),
+    useLayoutConfig: jest.fn(),
+  })
+);
+
+const contests = generateContests(6);
+const blankContests = contests.slice(0, 3);
+const partiallyVotedContests = contests.slice(3, 5);
+const overvoteContests = contests.slice(5);
+
+beforeEach(() => {
+  mockOf(WarningDetails).mockImplementation(() => (
+    <div data-testid="mockWarningDetails" />
+  ));
+
+  mockOf(WarningsSummary).mockImplementation(() => (
+    <div data-testid="mockWarningsSummary" />
+  ));
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test('renders summary when necessary', () => {
+  mockOf(useLayoutConfig).mockReturnValue({
+    maxColumnsPerCard: 2,
+    numCardsPerRow: 2,
+    showSummaryInPreview: true,
+  });
+
+  render(
+    <MisvoteWarnings
+      blankContests={blankContests}
+      overvoteContests={overvoteContests}
+      partiallyVotedContests={partiallyVotedContests}
+    />
+  );
+
+  expect(screen.queryByTestId('mockWarningDetails')).not.toBeInTheDocument();
+
+  screen.getByTestId('mockWarningsSummary');
+  expect(mockOf(WarningsSummary)).toBeCalledWith(
+    { blankContests, overvoteContests, partiallyVotedContests },
+    {}
+  );
+});
+
+test('renders details when possible', () => {
+  mockOf(useLayoutConfig).mockReturnValue({
+    maxColumnsPerCard: 2,
+    numCardsPerRow: 2,
+    showSummaryInPreview: false,
+  });
+
+  render(
+    <MisvoteWarnings
+      blankContests={blankContests}
+      overvoteContests={overvoteContests}
+      partiallyVotedContests={partiallyVotedContests}
+    />
+  );
+
+  expect(screen.queryByTestId('mockWarningsSummary')).not.toBeInTheDocument();
+
+  screen.getByTestId('mockWarningDetails');
+  expect(mockOf(WarningDetails)).toBeCalledWith(
+    { blankContests, overvoteContests, partiallyVotedContests },
+    {}
+  );
+});

--- a/apps/scan/frontend/src/components/misvote_warnings/misvote_warnings.tsx
+++ b/apps/scan/frontend/src/components/misvote_warnings/misvote_warnings.tsx
@@ -1,0 +1,29 @@
+import { useLayoutConfig } from './use_layout_config_hook';
+import { WarningsSummary } from './warnings_summary';
+import { WarningDetails } from './warning_details';
+import { MisvoteWarningsProps } from './types';
+
+export function MisvoteWarnings(props: MisvoteWarningsProps): JSX.Element {
+  const { blankContests, overvoteContests, partiallyVotedContests } = props;
+  const layout = useLayoutConfig(props);
+
+  // Show a summary of warnings with button to view details if we can't fit all
+  // the details on the main ScanWarningScreen without needing to scroll.
+  if (layout.showSummaryInPreview) {
+    return (
+      <WarningsSummary
+        blankContests={blankContests}
+        overvoteContests={overvoteContests}
+        partiallyVotedContests={partiallyVotedContests}
+      />
+    );
+  }
+
+  return (
+    <WarningDetails
+      blankContests={blankContests}
+      overvoteContests={overvoteContests}
+      partiallyVotedContests={partiallyVotedContests}
+    />
+  );
+}

--- a/apps/scan/frontend/src/components/misvote_warnings/test_utils.test.ts
+++ b/apps/scan/frontend/src/components/misvote_warnings/test_utils.test.ts
@@ -1,0 +1,23 @@
+import { electionSample } from '@votingworks/fixtures';
+import { AnyContest } from '@votingworks/types';
+
+const CONTEST_TEMPLATE: AnyContest = electionSample.contests[0];
+
+export function generateContests(count: number): AnyContest[] {
+  const contests: AnyContest[] = [];
+
+  for (let i = 0; i < count; i += 1) {
+    contests.push({
+      ...CONTEST_TEMPLATE,
+      id: `${i}`,
+      title: `[TEST ${i}] ${CONTEST_TEMPLATE.title}`,
+    });
+  }
+
+  return contests;
+}
+
+test('generates contests', () => {
+  const contests = generateContests(2);
+  expect(contests[0]).not.toEqual(contests[1]);
+});

--- a/apps/scan/frontend/src/components/misvote_warnings/types.ts
+++ b/apps/scan/frontend/src/components/misvote_warnings/types.ts
@@ -1,0 +1,19 @@
+import { AnyContest } from '@votingworks/types';
+
+export interface MisvoteWarningsProps {
+  blankContests: readonly AnyContest[];
+  overvoteContests: readonly AnyContest[];
+  partiallyVotedContests: readonly AnyContest[];
+}
+
+export interface MisvoteWarningsConfig {
+  maxCardsPerRow: number;
+  maxColumnsPerCard: number;
+  maxPreviewContestRows: number;
+}
+
+export interface Layout {
+  maxColumnsPerCard: number;
+  numCardsPerRow: number;
+  showSummaryInPreview?: boolean;
+}

--- a/apps/scan/frontend/src/components/misvote_warnings/use_layout_config_hook.test.tsx
+++ b/apps/scan/frontend/src/components/misvote_warnings/use_layout_config_hook.test.tsx
@@ -1,0 +1,168 @@
+import { SizeMode } from '@votingworks/types';
+import { render } from '../../../test/react_testing_library';
+import { Layout, MisvoteWarningsProps } from './types';
+import { useLayoutConfig } from './use_layout_config_hook';
+import { CONFIG } from './constants';
+import { generateContests } from './test_utils.test';
+
+let hookResult: Layout | null = null;
+
+function TestComponent(props: MisvoteWarningsProps) {
+  hookResult = useLayoutConfig(props);
+
+  return <div>foo</div>;
+}
+
+beforeEach(() => {
+  hookResult = null;
+});
+
+test('varies according to size mode', () => {
+  const props: MisvoteWarningsProps = {
+    blankContests: generateContests(2),
+    overvoteContests: generateContests(1),
+    partiallyVotedContests: generateContests(3),
+  };
+
+  render(<TestComponent {...props} />, { vxTheme: { sizeMode: 'xl' } });
+  const layoutXl = hookResult;
+
+  render(<TestComponent {...props} />, { vxTheme: { sizeMode: 'm' } });
+  const layoutM = hookResult;
+
+  expect(layoutXl).not.toEqual(layoutM);
+});
+
+test('sets numCardsPerRow appropriately', () => {
+  const sizeMode: SizeMode = 'm';
+  const config = CONFIG[sizeMode];
+
+  const { rerender } = render(
+    <TestComponent
+      blankContests={generateContests(1)}
+      overvoteContests={generateContests(1)}
+      partiallyVotedContests={generateContests(1)}
+    />,
+    { vxTheme: { sizeMode } }
+  );
+  expect(hookResult).toEqual(
+    expect.objectContaining<Partial<Layout>>({
+      numCardsPerRow: config.maxCardsPerRow,
+    })
+  );
+
+  rerender(
+    <TestComponent
+      blankContests={generateContests(1)}
+      overvoteContests={[]}
+      partiallyVotedContests={[]}
+    />
+  );
+  expect(hookResult).toEqual(
+    expect.objectContaining<Partial<Layout>>({
+      numCardsPerRow: 1,
+    })
+  );
+});
+
+test('sets maxColumnsPerCard appropriately', () => {
+  const sizeMode: SizeMode = 's';
+  const config = CONFIG[sizeMode];
+
+  // Should be `1` if there are multiple warning cards:
+  const { rerender } = render(
+    <TestComponent
+      blankContests={generateContests(1)}
+      overvoteContests={generateContests(1)}
+      partiallyVotedContests={generateContests(1)}
+    />,
+    { vxTheme: { sizeMode } }
+  );
+  expect(hookResult).toEqual(
+    expect.objectContaining<Partial<Layout>>({
+      maxColumnsPerCard: 1,
+    })
+  );
+
+  // Should be the configured maximum if only one warning card will be rendered:
+  rerender(
+    <TestComponent
+      blankContests={generateContests(1)}
+      overvoteContests={[]}
+      partiallyVotedContests={[]}
+    />
+  );
+  expect(hookResult).toEqual(
+    expect.objectContaining<Partial<Layout>>({
+      maxColumnsPerCard: config.maxColumnsPerCard,
+    })
+  );
+});
+
+test('sets showSummaryInPreview appropriately', () => {
+  const sizeMode: SizeMode = 'm';
+  const config = CONFIG[sizeMode];
+
+  // Make sure if the config gets changed, we know to update these test
+  // assumptions:
+  expect(config.maxCardsPerRow).toEqual(2);
+
+  // Should be true when the warning cards wouldn't fit on a single row:
+  const { rerender } = render(
+    <TestComponent
+      blankContests={generateContests(1)}
+      overvoteContests={generateContests(1)}
+      partiallyVotedContests={generateContests(1)}
+    />,
+    { vxTheme: { sizeMode } }
+  );
+  expect(hookResult).toEqual(
+    expect.objectContaining<Partial<Layout>>({
+      showSummaryInPreview: true,
+    })
+  );
+
+  // Should be true if any of the cards wouldn't fit vertically:
+  rerender(
+    <TestComponent
+      blankContests={generateContests(config.maxPreviewContestRows + 1)}
+      overvoteContests={generateContests(1)}
+      partiallyVotedContests={[]}
+    />
+  );
+  expect(hookResult).toEqual(
+    expect.objectContaining<Partial<Layout>>({
+      showSummaryInPreview: true,
+    })
+  );
+
+  // Should be false if all contests would fit on-screen, based on config params:
+  rerender(
+    <TestComponent
+      blankContests={generateContests(
+        config.maxPreviewContestRows * config.maxColumnsPerCard
+      )}
+      overvoteContests={[]}
+      partiallyVotedContests={[]}
+    />
+  );
+  expect(hookResult).toEqual(
+    expect.objectContaining<Partial<Layout>>({
+      showSummaryInPreview: false,
+    })
+  );
+
+  // Same as above with multiple cards containing the max number of contest rows:
+  rerender(
+    <TestComponent
+      blankContests={generateContests(config.maxPreviewContestRows)}
+      overvoteContests={[]}
+      partiallyVotedContests={generateContests(config.maxPreviewContestRows)}
+    />
+  );
+  expect(hookResult).toEqual(
+    expect.objectContaining<Partial<Layout>>({
+      showSummaryInPreview: false,
+    })
+  );
+});

--- a/apps/scan/frontend/src/components/misvote_warnings/use_layout_config_hook.ts
+++ b/apps/scan/frontend/src/components/misvote_warnings/use_layout_config_hook.ts
@@ -1,0 +1,44 @@
+import React from 'react';
+import { useTheme } from 'styled-components';
+
+import { CONFIG } from './constants';
+import { Layout, MisvoteWarningsProps } from './types';
+
+export function useLayoutConfig(props: MisvoteWarningsProps): Layout {
+  const { blankContests, overvoteContests, partiallyVotedContests } = props;
+  const { sizeMode } = useTheme();
+  const config = CONFIG[sizeMode];
+
+  return React.useMemo(() => {
+    const numCards = [
+      blankContests,
+      overvoteContests,
+      partiallyVotedContests,
+    ].filter((contests) => contests.length > 0).length;
+    const numCardsPerRow = Math.min(numCards, config.maxCardsPerRow);
+
+    const maxColumnsPerCard = Math.max(
+      1,
+      Math.floor(config.maxColumnsPerCard / numCardsPerRow)
+    );
+
+    const maxContestListLength = Math.max(
+      blankContests.length,
+      overvoteContests.length,
+      partiallyVotedContests.length
+    );
+    const maxContestRows = maxContestListLength / maxColumnsPerCard;
+
+    // NOTE: The main ScanWarningScreen only has enough room for 1 row of cards
+    // at all sizes.
+    const showSummaryInPreview =
+      numCards > config.maxCardsPerRow ||
+      maxContestRows > config.maxPreviewContestRows;
+
+    return {
+      maxColumnsPerCard,
+      numCardsPerRow,
+      showSummaryInPreview,
+    };
+  }, [config, blankContests, overvoteContests, partiallyVotedContests]);
+}

--- a/apps/scan/frontend/src/components/misvote_warnings/warning_details.test.tsx
+++ b/apps/scan/frontend/src/components/misvote_warnings/warning_details.test.tsx
@@ -1,0 +1,123 @@
+import { mockOf } from '@votingworks/test-utils';
+import { ContestList } from './contest_list';
+import { render, screen, within } from '../../../test/react_testing_library';
+import { WarningDetails } from './warning_details';
+import { generateContests } from './test_utils.test';
+import { useLayoutConfig } from './use_layout_config_hook';
+
+jest.mock('./contest_list', (): typeof import('./contest_list') => ({
+  ...jest.requireActual('./contest_list'),
+  ContestList: jest.fn(),
+}));
+
+jest.mock(
+  './use_layout_config_hook',
+  (): typeof import('./use_layout_config_hook') => ({
+    ...jest.requireActual('./use_layout_config_hook'),
+    useLayoutConfig: jest.fn(),
+  })
+);
+
+beforeEach(() => {
+  mockOf(ContestList).mockImplementation((props) => (
+    <div data-testid="mockContestList">
+      <div>title: {props.title}</div>
+      <div>helpNote: {props.helpNote}</div>
+      <div>maxColumns: {props.maxColumns}</div>
+      <div>
+        contests:{' '}
+        {props.contests.map((c) => (
+          <div key={c.id}>{c.title}</div>
+        ))}
+      </div>
+    </div>
+  ));
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test('renders all relevant warnings', () => {
+  mockOf(useLayoutConfig).mockReturnValue({
+    maxColumnsPerCard: 2,
+    numCardsPerRow: 2,
+    showSummaryInPreview: true,
+  });
+
+  const contests = generateContests(6);
+  const blankContests = contests.slice(0, 3);
+  const partiallyVotedContests = contests.slice(3, 5);
+  const overvoteContests = contests.slice(5);
+
+  render(
+    <WarningDetails
+      blankContests={blankContests}
+      overvoteContests={overvoteContests}
+      partiallyVotedContests={partiallyVotedContests}
+    />
+  );
+
+  const contestLists = screen.getAllByTestId('mockContestList');
+  expect(contestLists).toHaveLength(3);
+
+  const blankContestWarnings = within(contestLists[0]);
+  blankContestWarnings.getByText(/title:.+no votes/i);
+  blankContestWarnings.getByText(
+    /helpNote:.+did you mean to leave these contests blank?/i
+  );
+  blankContestWarnings.getByText(/maxColumns: 2/i);
+  for (const c of blankContests) {
+    blankContestWarnings.getByText(c.title);
+  }
+
+  const partialVoteWarnings = within(contestLists[1]);
+  partialVoteWarnings.getByText(/title:.+you may add one or more/i);
+  partialVoteWarnings.getByText(
+    /helpNote:.+all other votes in these contests will count/i
+  );
+  partialVoteWarnings.getByText(/maxColumns: 2/i);
+  for (const c of partiallyVotedContests) {
+    partialVoteWarnings.getByText(c.title);
+  }
+
+  const overvoteWarnings = within(contestLists[2]);
+  overvoteWarnings.getByText(/title:.+too many votes/i);
+  overvoteWarnings.getByText(
+    /helpNote:.+votes in this contest will not be counted/i
+  );
+  overvoteWarnings.getByText(/maxColumns: 2/i);
+  for (const c of overvoteContests) {
+    overvoteWarnings.getByText(c.title);
+  }
+});
+
+test('omits warnings with no contests', () => {
+  mockOf(useLayoutConfig).mockReturnValue({
+    maxColumnsPerCard: 3,
+    numCardsPerRow: 2,
+    showSummaryInPreview: true,
+  });
+
+  const overvoteContests = generateContests(2);
+
+  render(
+    <WarningDetails
+      blankContests={[]}
+      overvoteContests={overvoteContests}
+      partiallyVotedContests={[]}
+    />
+  );
+
+  const contestList = screen.getByTestId('mockContestList');
+
+  const overvoteWarnings = within(contestList);
+  overvoteWarnings.getByText(/title:.+too many votes/i);
+  overvoteWarnings.getByText(
+    /helpNote:.+votes in these contests will not be counted/i
+  );
+  overvoteWarnings.getByText(/maxColumns: 3/i);
+  for (const c of overvoteContests) {
+    overvoteWarnings.getByText(c.title);
+  }
+});

--- a/apps/scan/frontend/src/components/misvote_warnings/warning_details.tsx
+++ b/apps/scan/frontend/src/components/misvote_warnings/warning_details.tsx
@@ -1,0 +1,68 @@
+import styled from 'styled-components';
+
+import { AnyContest } from '@votingworks/types';
+
+import pluralize from 'pluralize';
+import { ContestList } from './contest_list';
+import { useLayoutConfig } from './use_layout_config_hook';
+import { MisvoteWarningsProps } from './types';
+
+interface ContainerProps {
+  numCardsPerRow: number;
+}
+
+const Container = styled.div<ContainerProps>`
+  display: grid;
+  flex-direction: column;
+  grid-template-columns: repeat(${(p) => p.numCardsPerRow}, 1fr);
+  grid-gap: 0.5rem;
+`;
+
+function pluralizeThisContestPhrase(contests: readonly AnyContest[]) {
+  return `${pluralize('this', contests.length)} ${pluralize(
+    'contest',
+    contests.length
+  )}`;
+}
+
+export function WarningDetails(props: MisvoteWarningsProps): JSX.Element {
+  const { blankContests, overvoteContests, partiallyVotedContests } = props;
+  const layout = useLayoutConfig(props);
+
+  return (
+    <Container numCardsPerRow={layout.numCardsPerRow}>
+      {blankContests.length > 0 && (
+        <ContestList
+          contests={blankContests}
+          maxColumns={layout.maxColumnsPerCard}
+          title="No votes marked:"
+          helpNote={`Did you mean to leave ${pluralizeThisContestPhrase(
+            blankContests
+          )} blank?`}
+        />
+      )}
+
+      {partiallyVotedContests.length > 0 && (
+        <ContestList
+          contests={partiallyVotedContests}
+          maxColumns={layout.maxColumnsPerCard}
+          title="You may add one or more votes:"
+          helpNote={`All other votes in ${pluralizeThisContestPhrase(
+            partiallyVotedContests
+          )} will count, even if you leave some blank.`}
+        />
+      )}
+
+      {overvoteContests.length > 0 && (
+        <ContestList
+          contests={overvoteContests}
+          maxColumns={layout.maxColumnsPerCard}
+          title="Too many votes marked:"
+          helpNote={`Your votes in ${pluralizeThisContestPhrase(
+            overvoteContests
+          )} will not be counted.`}
+        />
+      )}
+    </Container>
+  );
+}

--- a/apps/scan/frontend/src/components/misvote_warnings/warning_details_modal_button.test.tsx
+++ b/apps/scan/frontend/src/components/misvote_warnings/warning_details_modal_button.test.tsx
@@ -1,0 +1,64 @@
+import { mockOf } from '@votingworks/test-utils';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '../../../test/react_testing_library';
+import { WarningDetails } from './warning_details';
+import { generateContests } from './test_utils.test';
+import { WarningDetailsModalButton } from './warning_details_modal_button';
+
+jest.mock('./warning_details', (): typeof import('./warning_details') => ({
+  ...jest.requireActual('./warning_details'),
+  WarningDetails: jest.fn(),
+}));
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test('renders modal on button press', () => {
+  mockOf(WarningDetails).mockImplementation(() => (
+    <div data-testid="mockWarningDetails" />
+  ));
+
+  const contests = generateContests(6);
+  const blankContests = contests.slice(0, 3);
+  const partiallyVotedContests = contests.slice(3, 5);
+  const overvoteContests = contests.slice(5);
+
+  render(
+    <WarningDetailsModalButton
+      blankContests={blankContests}
+      overvoteContests={overvoteContests}
+      partiallyVotedContests={partiallyVotedContests}
+    />
+  );
+  expect(screen.queryByTestId('mockWarningDetails')).not.toBeInTheDocument();
+
+  userEvent.click(screen.getButton(/view contests/i));
+
+  screen.getByTestId('mockWarningDetails');
+  expect(mockOf(WarningDetails)).toBeCalledWith(
+    { blankContests, overvoteContests, partiallyVotedContests },
+    {}
+  );
+});
+
+test('closes modal', () => {
+  mockOf(WarningDetails).mockImplementation(() => (
+    <div data-testid="mockWarningDetails" />
+  ));
+
+  render(
+    <WarningDetailsModalButton
+      blankContests={[]}
+      overvoteContests={[]}
+      partiallyVotedContests={[]}
+    />
+  );
+  expect(screen.queryByTestId('mockWarningDetails')).not.toBeInTheDocument();
+
+  userEvent.click(screen.getButton(/view contests/i));
+  screen.getByTestId('mockWarningDetails');
+
+  userEvent.click(screen.getButton(/close/i));
+  expect(screen.queryByTestId('mockWarningDetails')).not.toBeInTheDocument();
+});

--- a/apps/scan/frontend/src/components/misvote_warnings/warning_details_modal_button.tsx
+++ b/apps/scan/frontend/src/components/misvote_warnings/warning_details_modal_button.tsx
@@ -1,0 +1,40 @@
+import { Button, Modal, ModalWidth, WithScrollButtons } from '@votingworks/ui';
+import React from 'react';
+import { MisvoteWarningsProps } from './types';
+import { WarningDetails } from './warning_details';
+
+export function WarningDetailsModalButton(
+  props: MisvoteWarningsProps
+): JSX.Element {
+  const { blankContests, overvoteContests, partiallyVotedContests } = props;
+  const [isModalOpen, setIsModalOpen] = React.useState(false);
+
+  if (isModalOpen) {
+    return (
+      <Modal
+        modalWidth={ModalWidth.Wide}
+        content={
+          <WithScrollButtons>
+            <WarningDetails
+              blankContests={blankContests}
+              overvoteContests={overvoteContests}
+              partiallyVotedContests={partiallyVotedContests}
+            />
+          </WithScrollButtons>
+        }
+        actions={
+          <Button onPress={setIsModalOpen} value={false} variant="primary">
+            Close
+          </Button>
+        }
+        onOverlayClick={() => setIsModalOpen(false)}
+      />
+    );
+  }
+
+  return (
+    <Button onPress={setIsModalOpen} value>
+      View contests
+    </Button>
+  );
+}

--- a/apps/scan/frontend/src/components/misvote_warnings/warnings_summary.test.tsx
+++ b/apps/scan/frontend/src/components/misvote_warnings/warnings_summary.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '../../../test/react_testing_library';
+import { generateContests } from './test_utils.test';
+import { WarningsSummary } from './warnings_summary';
+
+test('renders all relevant warnings', () => {
+  render(
+    <WarningsSummary
+      blankContests={generateContests(3)}
+      overvoteContests={generateContests(2)}
+      partiallyVotedContests={generateContests(1)}
+    />
+  );
+
+  const listItems = screen.getAllByRole('listitem').map((li) => li.textContent);
+  expect(listItems).toEqual([
+    expect.stringMatching(/no votes .+ 3 contests/i),
+    expect.stringMatching(/you may add .+ 1 contest/i),
+    expect.stringMatching(/too many votes .+ 2 contests/i),
+  ]);
+});
+
+test('omits warnings with no contests listed', () => {
+  render(
+    <WarningsSummary
+      blankContests={[]}
+      overvoteContests={generateContests(2)}
+      partiallyVotedContests={[]}
+    />
+  );
+
+  const listItems = screen.getAllByRole('listitem').map((li) => li.textContent);
+  expect(listItems).toEqual([
+    expect.stringMatching(/too many votes .+ 2 contests/i),
+  ]);
+});

--- a/apps/scan/frontend/src/components/misvote_warnings/warnings_summary.tsx
+++ b/apps/scan/frontend/src/components/misvote_warnings/warnings_summary.tsx
@@ -1,0 +1,44 @@
+import { Caption, Font, List, ListItem } from '@votingworks/ui';
+import pluralize from 'pluralize';
+import React from 'react';
+import { WarningDetailsModalButton } from './warning_details_modal_button';
+import { MisvoteWarningsProps } from './types';
+
+export function WarningsSummary(props: MisvoteWarningsProps): JSX.Element {
+  const { blankContests, overvoteContests, partiallyVotedContests } = props;
+
+  return (
+    <React.Fragment>
+      <List>
+        {blankContests.length > 0 && (
+          <Caption>
+            <ListItem>
+              No votes marked in{' '}
+              <Font weight="bold">{blankContests.length}</Font>{' '}
+              {pluralize('contest', blankContests.length)}.
+            </ListItem>
+          </Caption>
+        )}
+        {partiallyVotedContests.length > 0 && (
+          <Caption>
+            <ListItem>
+              You may add one or more votes in{' '}
+              <Font weight="bold">{partiallyVotedContests.length}</Font>{' '}
+              {pluralize('contest', partiallyVotedContests.length)}.
+            </ListItem>
+          </Caption>
+        )}
+        {overvoteContests.length > 0 && (
+          <Caption>
+            <ListItem>
+              Too many votes marked in{' '}
+              <Font weight="bold">{overvoteContests.length}</Font>{' '}
+              {pluralize('contest', overvoteContests.length)}.
+            </ListItem>
+          </Caption>
+        )}
+      </List>
+      <WarningDetailsModalButton {...props} />
+    </React.Fragment>
+  );
+}

--- a/libs/ui/src/__snapshots__/button_bar.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/button_bar.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`renders ButtonBar 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   border-top: 0.05rem solid #263238;
-  padding: 0.75rem;
+  padding: 7.2px;
   gap: 7.2px;
 }
 

--- a/libs/ui/src/button_bar.tsx
+++ b/libs/ui/src/button_bar.tsx
@@ -7,7 +7,7 @@ export const ButtonBar = styled('div')`
   justify-content: center;
   border-top: ${(p) => p.theme.sizes.bordersRem.hairline}rem solid
     ${(p) => p.theme.colors.foreground};
-  padding: 0.75rem;
+  padding: ${(p) => p.theme.sizes.minTouchAreaSeparationPx}px;
   gap: ${(p) => p.theme.sizes.minTouchAreaSeparationPx}px;
 
   & > * {

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -3,6 +3,7 @@ import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faCheckCircle,
+  faCircle as faCircleSolid,
   faCircleHalfStroke,
   faCircleLeft,
   faCircleRight,
@@ -72,14 +73,6 @@ export const Icons = {
     return <FaIcon type={faDeleteLeft} />;
   },
 
-  Circle(): JSX.Element {
-    return <FaIcon type={faCircle} />;
-  },
-
-  CircleDot(): JSX.Element {
-    return <FaIcon type={faCircleDot} />;
-  },
-
   Checkbox(): JSX.Element {
     return <FaIcon type={faCheckSquare} />;
   },
@@ -96,6 +89,18 @@ export const Icons = {
         <path d="M89.7038 10.1045C88.2094 8.40006 85.759 8.40006 84.2646 10.1045L39.0198 61.5065L15.719 34.8471C14.2245 33.1364 11.7906 33.1364 10.2852 34.8471L2.12082 44.1186C0.626395 45.8105 0.626395 48.5951 2.12082 50.2996L36.2782 89.3708C37.7727 91.0628 40.2066 91.0628 41.7175 89.3708L97.8627 25.5632C99.3791 23.8587 99.3791 21.0679 97.8627 19.3572L89.7038 10.1045Z" />
       </StyledSvgIcon>
     );
+  },
+
+  Circle(): JSX.Element {
+    return <FaIcon type={faCircle} />;
+  },
+
+  CircleDot(): JSX.Element {
+    return <FaIcon type={faCircleDot} />;
+  },
+
+  CircleSolid(): JSX.Element {
+    return <FaIcon type={faCircleSolid} />;
   },
 
   Closed(): JSX.Element {

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -33,6 +33,8 @@ export * from './insert_ballot_image';
 export * from './insert_card_image';
 export * from './labelled_text';
 export * from './link_button';
+export * from './list';
+export * from './list_item';
 export * from './live_check_modal';
 export * from './loading';
 export * from './loading_animation';

--- a/libs/ui/src/list.test.tsx
+++ b/libs/ui/src/list.test.tsx
@@ -1,0 +1,59 @@
+import { List } from './list';
+import { ListItem } from './list_item';
+import { render, screen } from '../test/react_testing_library';
+
+test('renders number of specified columns', () => {
+  render(
+    <List maxColumns={3}>
+      <ListItem>one</ListItem>
+      <ListItem>two</ListItem>
+      <ListItem>three</ListItem>
+      <ListItem>four</ListItem>
+    </List>
+  );
+
+  expect(screen.getByRole('list')).toHaveStyleRule(
+    'grid-template-columns',
+    'repeat(3,1fr)'
+  );
+});
+
+test('renders only as many columns as needed if all list items fit on one row', () => {
+  const { rerender } = render(
+    <List maxColumns={3}>
+      <ListItem>one</ListItem>
+    </List>
+  );
+
+  expect(screen.getByRole('list')).toHaveStyleRule(
+    'grid-template-columns',
+    'repeat(1,1fr)'
+  );
+
+  rerender(
+    <List maxColumns={3}>
+      <ListItem>one</ListItem>
+      <ListItem>two</ListItem>
+    </List>
+  );
+
+  expect(screen.getByRole('list')).toHaveStyleRule(
+    'grid-template-columns',
+    'repeat(2,1fr)'
+  );
+});
+
+test('defaults to 1 column', () => {
+  render(
+    <List>
+      <ListItem>one</ListItem>
+      <ListItem>two</ListItem>
+      <ListItem>three</ListItem>
+    </List>
+  );
+
+  expect(screen.getByRole('list')).toHaveStyleRule(
+    'grid-template-columns',
+    'repeat(1,1fr)'
+  );
+});

--- a/libs/ui/src/list.tsx
+++ b/libs/ui/src/list.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import styled from 'styled-components';
+
+export interface ListProps {
+  children: React.ReactNode;
+  className?: string;
+  maxColumns?: number;
+}
+
+interface ContainerProps {
+  numColumns: number;
+}
+
+const Container = styled.ul<ContainerProps>`
+  display: grid;
+  grid-gap: 0.5rem;
+  grid-template-columns: repeat(${(p) => p.numColumns}, 1fr);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+
+  &:not(:last-child) {
+    margin-bottom: 0.35rem;
+  }
+`;
+
+export function List(props: ListProps): JSX.Element {
+  const { children, className, maxColumns = 1 } = props;
+
+  const numItems = React.Children.count(children);
+  const numColumns = Math.min(numItems, maxColumns);
+
+  return (
+    <Container className={className} numColumns={numColumns}>
+      {children}
+    </Container>
+  );
+}

--- a/libs/ui/src/list_item.tsx
+++ b/libs/ui/src/list_item.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Icons } from './icons';
+
+export interface ListItemProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+const Container = styled.li`
+  align-items: start;
+  display: flex;
+  gap: 0.25rem;
+  margin: 0;
+  padding-left: 0.5rem;
+`;
+
+const IconContainer = styled.span`
+  align-items: center;
+  display: flex;
+  height: ${(p) => p.theme.sizes.lineHeight}em;
+
+  & > * {
+    font-size: 0.5em;
+  }
+`;
+
+export function ListItem(props: ListItemProps): JSX.Element {
+  const { children, className } = props;
+
+  return (
+    <Container className={className}>
+      <IconContainer>
+        <Icons.CircleSolid />
+      </IconContainer>
+      <span>{children}</span>
+    </Container>
+  );
+}

--- a/libs/ui/src/with_scroll_buttons.tsx
+++ b/libs/ui/src/with_scroll_buttons.tsx
@@ -120,7 +120,7 @@ export function WithScrollButtons(props: WithScrollButtonsProps): JSX.Element {
       );
     }
   }
-  React.useLayoutEffect(updateScrollState);
+  React.useLayoutEffect(updateScrollState, [children, contentRef]);
 
   const onScrollUp = React.useCallback(() => {
     if (contentRef.current) {


### PR DESCRIPTION
## Overview

Addressing VVSG2.0 7.3-H and 7.3-I:

> 7.3-H – Overvotes
> 2. A scanner or other device that a voter uses to cast a paper ballot must be capable of
providing feedback that identifies specific contests that have been overvoted in visual
format, and with either audio format or sound cues.

> 7.3-I – Undervotes
The voting system must notify voters in both visual and audio formats of the specific contest
in which they select fewer than the allowable number of options (that is, for undervotes).

This updates the `ScanWarningScreen` in VxScan to list out all contests with undervotes/overvotes - we list them all out on the main screen if the list is short enough to fit; otherwise, we render a summary along with a button to see the full list.

This also combines the previously separate overvote and undervote warnings, since in the previous case, it was possible to dismiss the overvote warning and have your ballot cast without the undervotes being surfaced.

## Demo Video or Screenshot

https://github.com/votingworks/vxsuite/assets/264902/085e8cbd-0544-431c-9a90-3530ba9514a0

## Testing Plan
- Added unit tests for the new components and updated existing functional tests for `ScanWarningScreen`

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
