### PR TITLE
libs/auth: Require machine state configuration params

### DIFF
--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -5,7 +5,7 @@ import {
 } from '@votingworks/fixtures';
 import { LogEventId } from '@votingworks/logging';
 
-import { suppressingConsoleOutput } from '@votingworks/test-utils';
+import { mockOf, suppressingConsoleOutput } from '@votingworks/test-utils';
 import { DEFAULT_SYSTEM_SETTINGS } from '@votingworks/types';
 import {
   buildTestEnvironment,
@@ -186,6 +186,7 @@ test('setSystemSettings throws error when store.saveSystemSettings fails', async
   const { electionDefinition, systemSettings } =
     electionMinimalExhaustiveSampleFixtures;
   await configureMachine(apiClient, auth, electionDefinition);
+  mockOf(logger.log).mockClear(); // Clear log calls from configureMachine
   const errorString = 'db error at saveSystemSettings';
   workspace.store.saveSystemSettings = jest.fn(() => {
     throw new Error(errorString);
@@ -199,15 +200,14 @@ test('setSystemSettings throws error when store.saveSystemSettings fails', async
     ).rejects.toThrow(errorString);
   });
 
-  // Logger call 1 is made by configureMachine when loading the election definition
   expect(logger.log).toHaveBeenNthCalledWith(
-    2,
+    1,
     LogEventId.SystemSettingsSaveInitiated,
     'system_administrator',
     { disposition: 'na' }
   );
   expect(logger.log).toHaveBeenNthCalledWith(
-    3,
+    2,
     LogEventId.SystemSettingsSaved,
     'system_administrator',
     { disposition: 'failure', error: errorString }

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -293,11 +293,10 @@ function buildApi({
     async setSystemSettings(input: {
       systemSettings: string;
     }): Promise<SetSystemSettingsResult> {
-      await logger.log(
-        LogEventId.SystemSettingsSaveInitiated,
-        assertDefined(await getUserRole()),
-        { disposition: 'na' }
-      );
+      const userRole = assertDefined(await getUserRole());
+      await logger.log(LogEventId.SystemSettingsSaveInitiated, userRole, {
+        disposition: 'na',
+      });
 
       const { systemSettings } = input;
       const validatedSystemSettings = safeParseJson(
@@ -315,19 +314,16 @@ function buildApi({
         store.saveSystemSettings(validatedSystemSettings.ok());
       } catch (error) {
         const typedError = error as Error;
-        await logger.log(
-          LogEventId.SystemSettingsSaved,
-          assertDefined(await getUserRole()),
-          { disposition: 'failure', error: typedError.message }
-        );
+        await logger.log(LogEventId.SystemSettingsSaved, userRole, {
+          disposition: 'failure',
+          error: typedError.message,
+        });
         throw error;
       }
 
-      await logger.log(
-        LogEventId.SystemSettingsSaved,
-        assertDefined(await getUserRole()),
-        { disposition: 'success' }
-      );
+      await logger.log(LogEventId.SystemSettingsSaved, userRole, {
+        disposition: 'success',
+      });
 
       return ok({});
     },

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -116,7 +116,7 @@ function constructAuthMachineState(
   const electionDefinition = getCurrentElectionDefinition(workspace);
   const systemSettings = workspace.store.getSystemSettings();
   return {
-    ...(systemSettings ?? {}),
+    ...(systemSettings ?? DEFAULT_SYSTEM_SETTINGS),
     electionHash: electionDefinition?.electionHash,
     jurisdiction: isIntegrationTest()
       ? TEST_JURISDICTION

--- a/apps/admin/backend/test/app.ts
+++ b/apps/admin/backend/test/app.ts
@@ -9,7 +9,12 @@ import {
   fakeSystemAdministratorUser,
   mockOf,
 } from '@votingworks/test-utils';
-import { DippedSmartCardAuth, ElectionDefinition } from '@votingworks/types';
+import {
+  DEFAULT_SYSTEM_SETTINGS,
+  DippedSmartCardAuth,
+  ElectionDefinition,
+  SystemSettings,
+} from '@votingworks/types';
 import * as grout from '@votingworks/grout';
 import { assert } from '@votingworks/basics';
 import { fakeLogger } from '@votingworks/logging';
@@ -150,15 +155,22 @@ export function mockElectionManagerAuth(
 export async function configureMachine(
   apiClient: grout.Client<Api>,
   auth: DippedSmartCardAuthApi,
-  electionDefinition: ElectionDefinition
+  electionDefinition: ElectionDefinition,
+  systemSettings: SystemSettings = DEFAULT_SYSTEM_SETTINGS
 ): Promise<string> {
   mockSystemAdministratorAuth(auth);
   const { electionData } = electionDefinition;
-  const configureResult = await apiClient.configure({
-    electionData,
-  });
-  assert(configureResult.isOk());
-  return configureResult.ok().electionId;
+  const { electionId } = (
+    await apiClient.configure({
+      electionData,
+    })
+  ).unsafeUnwrap();
+  (
+    await apiClient.setSystemSettings({
+      systemSettings: JSON.stringify(systemSettings),
+    })
+  ).unsafeUnwrap();
+  return electionId;
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types

--- a/apps/central-scan/backend/src/central_scanner_app.ts
+++ b/apps/central-scan/backend/src/central_scanner_app.ts
@@ -55,7 +55,7 @@ function constructAuthMachineState(
   const jurisdiction = workspace.store.getJurisdiction();
   const systemSettings = workspace.store.getSystemSettings();
   return {
-    ...(systemSettings ?? {}),
+    ...(systemSettings ?? DEFAULT_SYSTEM_SETTINGS),
     electionHash: electionDefinition?.electionHash,
     jurisdiction,
   };

--- a/apps/mark-scan/backend/src/app.auth.test.ts
+++ b/apps/mark-scan/backend/src/app.auth.test.ts
@@ -1,11 +1,16 @@
 import { DateTime } from 'luxon';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
-import { DEFAULT_SYSTEM_SETTINGS, TEST_JURISDICTION } from '@votingworks/types';
+import {
+  DEFAULT_SYSTEM_SETTINGS,
+  SystemSettings,
+  TEST_JURISDICTION,
+} from '@votingworks/types';
 import * as grout from '@votingworks/grout';
 
 import { InsertedSmartCardAuthApi } from '@votingworks/auth';
 import { MockUsb } from '@votingworks/backend';
 import { Server } from 'http';
+import { mockOf } from '@votingworks/test-utils';
 import { configureApp, createApp } from '../test/app_helpers';
 import { Api } from './app';
 import { PaperHandlerStateMachine } from './custom-paper-handler';
@@ -13,12 +18,23 @@ import { PaperHandlerStateMachine } from './custom-paper-handler';
 const jurisdiction = TEST_JURISDICTION;
 const { electionDefinition } = electionFamousNames2021Fixtures;
 const { electionHash } = electionDefinition;
+const systemSettings: SystemSettings = {
+  arePollWorkerCardPinsEnabled: true,
+  inactiveSessionTimeLimitMinutes: 10,
+  overallSessionTimeLimitHours: 1,
+  numIncorrectPinAttemptsAllowedBeforeCardLockout: 3,
+  startingCardLockoutDurationSeconds: 15,
+};
 
 let apiClient: grout.Client<Api>;
 let mockAuth: InsertedSmartCardAuthApi;
 let mockUsb: MockUsb;
 let server: Server;
 let stateMachine: PaperHandlerStateMachine;
+
+beforeAll(() => {
+  expect(systemSettings).not.toEqual(DEFAULT_SYSTEM_SETTINGS);
+});
 
 beforeEach(async () => {
   const result = await createApp();
@@ -35,46 +51,44 @@ afterEach(() => {
 });
 
 test('getAuthStatus', async () => {
-  await configureApp(apiClient, mockAuth, mockUsb);
-
-  // Gets called once during configuration
-  expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(1);
+  await configureApp(apiClient, mockAuth, mockUsb, systemSettings);
+  mockOf(mockAuth.getAuthStatus).mockClear(); // Clear mock calls from configureApp
 
   await apiClient.getAuthStatus();
-  expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(2);
-  expect(mockAuth.getAuthStatus).toHaveBeenNthCalledWith(2, {
-    ...DEFAULT_SYSTEM_SETTINGS,
+  expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(1);
+  expect(mockAuth.getAuthStatus).toHaveBeenNthCalledWith(1, {
+    ...systemSettings,
     electionHash,
     jurisdiction,
   });
 });
 
 test('checkPin', async () => {
-  await configureApp(apiClient, mockAuth, mockUsb);
+  await configureApp(apiClient, mockAuth, mockUsb, systemSettings);
 
   await apiClient.checkPin({ pin: '123456' });
   expect(mockAuth.checkPin).toHaveBeenCalledTimes(1);
   expect(mockAuth.checkPin).toHaveBeenNthCalledWith(
     1,
-    { ...DEFAULT_SYSTEM_SETTINGS, electionHash, jurisdiction },
+    { ...systemSettings, electionHash, jurisdiction },
     { pin: '123456' }
   );
 });
 
 test('logOut', async () => {
-  await configureApp(apiClient, mockAuth, mockUsb);
+  await configureApp(apiClient, mockAuth, mockUsb, systemSettings);
 
   await apiClient.logOut();
   expect(mockAuth.logOut).toHaveBeenCalledTimes(1);
   expect(mockAuth.logOut).toHaveBeenNthCalledWith(1, {
-    ...DEFAULT_SYSTEM_SETTINGS,
+    ...systemSettings,
     electionHash,
     jurisdiction,
   });
 });
 
 test('updateSessionExpiry', async () => {
-  await configureApp(apiClient, mockAuth, mockUsb);
+  await configureApp(apiClient, mockAuth, mockUsb, systemSettings);
 
   await apiClient.updateSessionExpiry({
     sessionExpiresAt: DateTime.now().plus({ seconds: 60 }).toJSDate(),
@@ -82,13 +96,13 @@ test('updateSessionExpiry', async () => {
   expect(mockAuth.updateSessionExpiry).toHaveBeenCalledTimes(1);
   expect(mockAuth.updateSessionExpiry).toHaveBeenNthCalledWith(
     1,
-    { ...DEFAULT_SYSTEM_SETTINGS, electionHash, jurisdiction },
+    { ...systemSettings, electionHash, jurisdiction },
     { sessionExpiresAt: expect.any(Date) }
   );
 });
 
 test('startCardlessVoterSession', async () => {
-  await configureApp(apiClient, mockAuth, mockUsb);
+  await configureApp(apiClient, mockAuth, mockUsb, systemSettings);
 
   await apiClient.startCardlessVoterSession({
     ballotStyleId: 'b1',
@@ -97,18 +111,18 @@ test('startCardlessVoterSession', async () => {
   expect(mockAuth.startCardlessVoterSession).toHaveBeenCalledTimes(1);
   expect(mockAuth.startCardlessVoterSession).toHaveBeenNthCalledWith(
     1,
-    { ...DEFAULT_SYSTEM_SETTINGS, electionHash, jurisdiction },
+    { ...systemSettings, electionHash, jurisdiction },
     { ballotStyleId: 'b1', precinctId: 'p1' }
   );
 });
 
 test('endCardlessVoterSession', async () => {
-  await configureApp(apiClient, mockAuth, mockUsb);
+  await configureApp(apiClient, mockAuth, mockUsb, systemSettings);
 
   await apiClient.endCardlessVoterSession();
   expect(mockAuth.endCardlessVoterSession).toHaveBeenCalledTimes(1);
   expect(mockAuth.endCardlessVoterSession).toHaveBeenNthCalledWith(1, {
-    ...DEFAULT_SYSTEM_SETTINGS,
+    ...systemSettings,
     electionHash,
     jurisdiction,
   });
@@ -117,19 +131,26 @@ test('endCardlessVoterSession', async () => {
 test('getAuthStatus before election definition has been configured', async () => {
   await apiClient.getAuthStatus();
   expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(1);
-  expect(mockAuth.getAuthStatus).toHaveBeenNthCalledWith(1, {});
+  expect(mockAuth.getAuthStatus).toHaveBeenNthCalledWith(
+    1,
+    DEFAULT_SYSTEM_SETTINGS
+  );
 });
 
 test('checkPin before election definition has been configured', async () => {
   await apiClient.checkPin({ pin: '123456' });
   expect(mockAuth.checkPin).toHaveBeenCalledTimes(1);
-  expect(mockAuth.checkPin).toHaveBeenNthCalledWith(1, {}, { pin: '123456' });
+  expect(mockAuth.checkPin).toHaveBeenNthCalledWith(
+    1,
+    DEFAULT_SYSTEM_SETTINGS,
+    { pin: '123456' }
+  );
 });
 
 test('logOut before election definition has been configured', async () => {
   await apiClient.logOut();
   expect(mockAuth.logOut).toHaveBeenCalledTimes(1);
-  expect(mockAuth.logOut).toHaveBeenNthCalledWith(1, {});
+  expect(mockAuth.logOut).toHaveBeenNthCalledWith(1, DEFAULT_SYSTEM_SETTINGS);
 });
 
 test('updateSessionExpiry before election definition has been configured', async () => {
@@ -139,7 +160,7 @@ test('updateSessionExpiry before election definition has been configured', async
   expect(mockAuth.updateSessionExpiry).toHaveBeenCalledTimes(1);
   expect(mockAuth.updateSessionExpiry).toHaveBeenNthCalledWith(
     1,
-    {},
+    DEFAULT_SYSTEM_SETTINGS,
     { sessionExpiresAt: expect.any(Date) }
   );
 });
@@ -152,7 +173,7 @@ test('startCardlessVoterSession before election definition has been configured',
   expect(mockAuth.startCardlessVoterSession).toHaveBeenCalledTimes(1);
   expect(mockAuth.startCardlessVoterSession).toHaveBeenNthCalledWith(
     1,
-    {},
+    DEFAULT_SYSTEM_SETTINGS,
     { ballotStyleId: 'b1', precinctId: 'p1' }
   );
 });
@@ -160,5 +181,8 @@ test('startCardlessVoterSession before election definition has been configured',
 test('endCardlessVoterSession before election definition has been configured', async () => {
   await apiClient.endCardlessVoterSession();
   expect(mockAuth.endCardlessVoterSession).toHaveBeenCalledTimes(1);
-  expect(mockAuth.endCardlessVoterSession).toHaveBeenNthCalledWith(1, {});
+  expect(mockAuth.endCardlessVoterSession).toHaveBeenNthCalledWith(
+    1,
+    DEFAULT_SYSTEM_SETTINGS
+  );
 });

--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -43,7 +43,7 @@ function constructAuthMachineState(
   const jurisdiction = workspace.store.getJurisdiction();
   const systemSettings = workspace.store.getSystemSettings();
   return {
-    ...(systemSettings ?? {}),
+    ...(systemSettings ?? DEFAULT_SYSTEM_SETTINGS),
     electionHash: electionDefinition?.electionHash,
     jurisdiction,
   };

--- a/apps/mark-scan/backend/test/app_helpers.ts
+++ b/apps/mark-scan/backend/test/app_helpers.ts
@@ -22,7 +22,11 @@ import {
   fakeSessionExpiresAt,
   mockOf,
 } from '@votingworks/test-utils';
-import { TEST_JURISDICTION } from '@votingworks/types';
+import {
+  DEFAULT_SYSTEM_SETTINGS,
+  SystemSettings,
+  TEST_JURISDICTION,
+} from '@votingworks/types';
 import {
   MinimalWebUsbDevice,
   PaperHandlerDriver,
@@ -160,7 +164,8 @@ export async function createApp(): Promise<MockAppContents> {
 export async function configureApp(
   apiClient: grout.Client<Api>,
   mockAuth: InsertedSmartCardAuthApi,
-  mockUsb: MockUsb
+  mockUsb: MockUsb,
+  systemSettings: SystemSettings = DEFAULT_SYSTEM_SETTINGS
 ): Promise<void> {
   const jurisdiction = TEST_JURISDICTION;
   const { electionJson, electionDefinition } = electionFamousNames2021Fixtures;
@@ -175,7 +180,7 @@ export async function configureApp(
   mockUsb.insertUsbDrive({
     'ballot-packages': {
       'test-ballot-package.zip': await createBallotPackageZipArchive(
-        electionJson.toBallotPackage()
+        electionJson.toBallotPackage(systemSettings)
       ),
     },
   });

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -31,7 +31,7 @@ function constructAuthMachineState(
   const jurisdiction = workspace.store.getJurisdiction();
   const systemSettings = workspace.store.getSystemSettings();
   return {
-    ...(systemSettings ?? {}),
+    ...(systemSettings ?? DEFAULT_SYSTEM_SETTINGS),
     electionHash: electionDefinition?.electionHash,
     jurisdiction,
   };

--- a/apps/mark/backend/test/app_helpers.ts
+++ b/apps/mark/backend/test/app_helpers.ts
@@ -21,7 +21,11 @@ import {
   fakeSessionExpiresAt,
   mockOf,
 } from '@votingworks/test-utils';
-import { TEST_JURISDICTION } from '@votingworks/types';
+import {
+  DEFAULT_SYSTEM_SETTINGS,
+  SystemSettings,
+  TEST_JURISDICTION,
+} from '@votingworks/types';
 import { Api, buildApp } from '../src/app';
 import { createWorkspace } from '../src/util/workspace';
 
@@ -68,7 +72,8 @@ export function createApp(): MockAppContents {
 export async function configureApp(
   apiClient: grout.Client<Api>,
   mockAuth: InsertedSmartCardAuthApi,
-  mockUsb: MockUsb
+  mockUsb: MockUsb,
+  systemSettings: SystemSettings = DEFAULT_SYSTEM_SETTINGS
 ): Promise<void> {
   const jurisdiction = TEST_JURISDICTION;
   const { electionJson, electionDefinition } = electionFamousNames2021Fixtures;
@@ -83,7 +88,7 @@ export async function configureApp(
   mockUsb.insertUsbDrive({
     'ballot-packages': {
       'test-ballot-package.zip': await createBallotPackageZipArchive(
-        electionJson.toBallotPackage()
+        electionJson.toBallotPackage(systemSettings)
       ),
     },
   });

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -48,7 +48,7 @@ function constructAuthMachineState(
   const jurisdiction = workspace.store.getJurisdiction();
   const systemSettings = workspace.store.getSystemSettings();
   return {
-    ...(systemSettings ?? {}),
+    ...(systemSettings ?? DEFAULT_SYSTEM_SETTINGS),
     electionHash: electionDefinition?.electionHash,
     jurisdiction,
   };

--- a/apps/scan/backend/src/app_auth.test.ts
+++ b/apps/scan/backend/src/app_auth.test.ts
@@ -1,24 +1,40 @@
 import { DateTime } from 'luxon';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
-import { DEFAULT_SYSTEM_SETTINGS, TEST_JURISDICTION } from '@votingworks/types';
+import {
+  DEFAULT_SYSTEM_SETTINGS,
+  SystemSettings,
+  TEST_JURISDICTION,
+} from '@votingworks/types';
 
+import { mockOf } from '@votingworks/test-utils';
 import { withApp } from '../test/helpers/custom_helpers';
 import { configureApp } from '../test/helpers/shared_helpers';
 
 const jurisdiction = TEST_JURISDICTION;
 const { electionHash } = electionFamousNames2021Fixtures.electionDefinition;
+const systemSettings: SystemSettings = {
+  arePollWorkerCardPinsEnabled: true,
+  inactiveSessionTimeLimitMinutes: 10,
+  overallSessionTimeLimitHours: 1,
+  numIncorrectPinAttemptsAllowedBeforeCardLockout: 3,
+  startingCardLockoutDurationSeconds: 15,
+};
+const ballotPackage =
+  electionFamousNames2021Fixtures.electionJson.toBallotPackage(systemSettings);
+
+beforeAll(() => {
+  expect(systemSettings).not.toEqual(DEFAULT_SYSTEM_SETTINGS);
+});
 
 test('getAuthStatus', async () => {
   await withApp({}, async ({ apiClient, mockAuth, mockUsbDrive }) => {
-    await configureApp(apiClient, mockAuth, mockUsbDrive);
-
-    // Gets called once during configuration
-    expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(1);
+    await configureApp(apiClient, mockAuth, mockUsbDrive, { ballotPackage });
+    mockOf(mockAuth.getAuthStatus).mockClear(); // Clear mock calls from configureApp
 
     await apiClient.getAuthStatus();
-    expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(2);
-    expect(mockAuth.getAuthStatus).toHaveBeenNthCalledWith(2, {
-      ...DEFAULT_SYSTEM_SETTINGS,
+    expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(1);
+    expect(mockAuth.getAuthStatus).toHaveBeenNthCalledWith(1, {
+      ...systemSettings,
       electionHash,
       jurisdiction,
     });
@@ -27,13 +43,13 @@ test('getAuthStatus', async () => {
 
 test('checkPin', async () => {
   await withApp({}, async ({ apiClient, mockAuth, mockUsbDrive }) => {
-    await configureApp(apiClient, mockAuth, mockUsbDrive);
+    await configureApp(apiClient, mockAuth, mockUsbDrive, { ballotPackage });
 
     await apiClient.checkPin({ pin: '123456' });
     expect(mockAuth.checkPin).toHaveBeenCalledTimes(1);
     expect(mockAuth.checkPin).toHaveBeenNthCalledWith(
       1,
-      { ...DEFAULT_SYSTEM_SETTINGS, electionHash, jurisdiction },
+      { ...systemSettings, electionHash, jurisdiction },
       { pin: '123456' }
     );
   });
@@ -41,12 +57,12 @@ test('checkPin', async () => {
 
 test('logOut', async () => {
   await withApp({}, async ({ apiClient, mockAuth, mockUsbDrive }) => {
-    await configureApp(apiClient, mockAuth, mockUsbDrive);
+    await configureApp(apiClient, mockAuth, mockUsbDrive, { ballotPackage });
 
     await apiClient.logOut();
     expect(mockAuth.logOut).toHaveBeenCalledTimes(1);
     expect(mockAuth.logOut).toHaveBeenNthCalledWith(1, {
-      ...DEFAULT_SYSTEM_SETTINGS,
+      ...systemSettings,
       electionHash,
       jurisdiction,
     });
@@ -55,7 +71,7 @@ test('logOut', async () => {
 
 test('updateSessionExpiry', async () => {
   await withApp({}, async ({ apiClient, mockAuth, mockUsbDrive }) => {
-    await configureApp(apiClient, mockAuth, mockUsbDrive);
+    await configureApp(apiClient, mockAuth, mockUsbDrive, { ballotPackage });
 
     await apiClient.updateSessionExpiry({
       sessionExpiresAt: DateTime.now().plus({ seconds: 60 }).toJSDate(),
@@ -63,7 +79,7 @@ test('updateSessionExpiry', async () => {
     expect(mockAuth.updateSessionExpiry).toHaveBeenCalledTimes(1);
     expect(mockAuth.updateSessionExpiry).toHaveBeenNthCalledWith(
       1,
-      { ...DEFAULT_SYSTEM_SETTINGS, electionHash, jurisdiction },
+      { ...systemSettings, electionHash, jurisdiction },
       { sessionExpiresAt: expect.any(Date) }
     );
   });
@@ -73,7 +89,10 @@ test('getAuthStatus before election definition has been configured', async () =>
   await withApp({}, async ({ apiClient, mockAuth }) => {
     await apiClient.getAuthStatus();
     expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(1);
-    expect(mockAuth.getAuthStatus).toHaveBeenNthCalledWith(1, {});
+    expect(mockAuth.getAuthStatus).toHaveBeenNthCalledWith(
+      1,
+      DEFAULT_SYSTEM_SETTINGS
+    );
   });
 });
 
@@ -81,7 +100,11 @@ test('checkPin before election definition has been configured', async () => {
   await withApp({}, async ({ apiClient, mockAuth }) => {
     await apiClient.checkPin({ pin: '123456' });
     expect(mockAuth.checkPin).toHaveBeenCalledTimes(1);
-    expect(mockAuth.checkPin).toHaveBeenNthCalledWith(1, {}, { pin: '123456' });
+    expect(mockAuth.checkPin).toHaveBeenNthCalledWith(
+      1,
+      DEFAULT_SYSTEM_SETTINGS,
+      { pin: '123456' }
+    );
   });
 });
 
@@ -89,7 +112,7 @@ test('logOut before election definition has been configured', async () => {
   await withApp({}, async ({ apiClient, mockAuth }) => {
     await apiClient.logOut();
     expect(mockAuth.logOut).toHaveBeenCalledTimes(1);
-    expect(mockAuth.logOut).toHaveBeenNthCalledWith(1, {});
+    expect(mockAuth.logOut).toHaveBeenNthCalledWith(1, DEFAULT_SYSTEM_SETTINGS);
   });
 });
 
@@ -101,7 +124,7 @@ test('updateSessionExpiry before election definition has been configured', async
     expect(mockAuth.updateSessionExpiry).toHaveBeenCalledTimes(1);
     expect(mockAuth.updateSessionExpiry).toHaveBeenNthCalledWith(
       1,
-      {},
+      DEFAULT_SYSTEM_SETTINGS,
       { sessionExpiresAt: expect.any(Date) }
     );
   });

--- a/libs/auth/src/dipped_smart_card_auth.test.ts
+++ b/libs/auth/src/dipped_smart_card_auth.test.ts
@@ -17,6 +17,9 @@ import {
   mockOf,
 } from '@votingworks/test-utils';
 import {
+  DEFAULT_NUM_INCORRECT_PIN_ATTEMPTS_ALLOWED_BEFORE_CARD_LOCKOUT,
+  DEFAULT_OVERALL_SESSION_TIME_LIMIT_HOURS,
+  DEFAULT_STARTING_CARD_LOCKOUT_DURATION_SECONDS,
   DippedSmartCardAuth as DippedSmartCardAuthTypes,
   TEST_JURISDICTION,
 } from '@votingworks/types';
@@ -73,6 +76,12 @@ const defaultConfig: DippedSmartCardAuthConfig = {};
 const defaultMachineState: DippedSmartCardAuthMachineState = {
   electionHash,
   jurisdiction,
+  arePollWorkerCardPinsEnabled: false,
+  numIncorrectPinAttemptsAllowedBeforeCardLockout:
+    DEFAULT_NUM_INCORRECT_PIN_ATTEMPTS_ALLOWED_BEFORE_CARD_LOCKOUT,
+  startingCardLockoutDurationSeconds:
+    DEFAULT_STARTING_CARD_LOCKOUT_DURATION_SECONDS,
+  overallSessionTimeLimitHours: DEFAULT_OVERALL_SESSION_TIME_LIMIT_HOURS,
 };
 const systemAdministratorUser = fakeSystemAdministratorUser({ jurisdiction });
 const electionManagerUser = fakeElectionManagerUser({

--- a/libs/auth/src/dipped_smart_card_auth_api.ts
+++ b/libs/auth/src/dipped_smart_card_auth_api.ts
@@ -51,10 +51,10 @@ export interface DippedSmartCardAuthConfig {
  * Machine state that the consumer is responsible for providing
  */
 export interface DippedSmartCardAuthMachineState {
-  arePollWorkerCardPinsEnabled?: boolean;
   electionHash?: string;
   jurisdiction?: string;
-  numIncorrectPinAttemptsAllowedBeforeCardLockout?: NumIncorrectPinAttemptsAllowedBeforeCardLockout;
-  overallSessionTimeLimitHours?: OverallSessionTimeLimitHours;
-  startingCardLockoutDurationSeconds?: StartingCardLockoutDurationSeconds;
+  arePollWorkerCardPinsEnabled: boolean;
+  numIncorrectPinAttemptsAllowedBeforeCardLockout: NumIncorrectPinAttemptsAllowedBeforeCardLockout;
+  overallSessionTimeLimitHours: OverallSessionTimeLimitHours;
+  startingCardLockoutDurationSeconds: StartingCardLockoutDurationSeconds;
 }

--- a/libs/auth/src/inserted_smart_card_auth.test.ts
+++ b/libs/auth/src/inserted_smart_card_auth.test.ts
@@ -20,6 +20,9 @@ import {
   mockOf,
 } from '@votingworks/test-utils';
 import {
+  DEFAULT_NUM_INCORRECT_PIN_ATTEMPTS_ALLOWED_BEFORE_CARD_LOCKOUT,
+  DEFAULT_OVERALL_SESSION_TIME_LIMIT_HOURS,
+  DEFAULT_STARTING_CARD_LOCKOUT_DURATION_SECONDS,
   ElectionSchema,
   InsertedSmartCardAuth as InsertedSmartCardAuthTypes,
   TEST_JURISDICTION,
@@ -78,6 +81,12 @@ const defaultConfig: InsertedSmartCardAuthConfig = {};
 const defaultMachineState: InsertedSmartCardAuthMachineState = {
   electionHash,
   jurisdiction,
+  arePollWorkerCardPinsEnabled: false,
+  numIncorrectPinAttemptsAllowedBeforeCardLockout:
+    DEFAULT_NUM_INCORRECT_PIN_ATTEMPTS_ALLOWED_BEFORE_CARD_LOCKOUT,
+  startingCardLockoutDurationSeconds:
+    DEFAULT_STARTING_CARD_LOCKOUT_DURATION_SECONDS,
+  overallSessionTimeLimitHours: DEFAULT_OVERALL_SESSION_TIME_LIMIT_HOURS,
 };
 const systemAdministratorUser = fakeSystemAdministratorUser({ jurisdiction });
 const electionManagerUser = fakeElectionManagerUser({

--- a/libs/auth/src/inserted_smart_card_auth_api.ts
+++ b/libs/auth/src/inserted_smart_card_auth_api.ts
@@ -69,10 +69,10 @@ export interface InsertedSmartCardAuthConfig {
  * Machine state that the consumer is responsible for providing
  */
 export interface InsertedSmartCardAuthMachineState {
-  arePollWorkerCardPinsEnabled?: boolean;
   electionHash?: string;
   jurisdiction?: string;
-  numIncorrectPinAttemptsAllowedBeforeCardLockout?: NumIncorrectPinAttemptsAllowedBeforeCardLockout;
-  overallSessionTimeLimitHours?: OverallSessionTimeLimitHours;
-  startingCardLockoutDurationSeconds?: StartingCardLockoutDurationSeconds;
+  arePollWorkerCardPinsEnabled: boolean;
+  numIncorrectPinAttemptsAllowedBeforeCardLockout: NumIncorrectPinAttemptsAllowedBeforeCardLockout;
+  overallSessionTimeLimitHours: OverallSessionTimeLimitHours;
+  startingCardLockoutDurationSeconds: StartingCardLockoutDurationSeconds;
 }

--- a/libs/auth/src/lockout.test.ts
+++ b/libs/auth/src/lockout.test.ts
@@ -1,4 +1,8 @@
 import { assert } from '@votingworks/basics';
+import {
+  DEFAULT_NUM_INCORRECT_PIN_ATTEMPTS_ALLOWED_BEFORE_CARD_LOCKOUT,
+  DEFAULT_STARTING_CARD_LOCKOUT_DURATION_SECONDS,
+} from '@votingworks/types';
 
 import { CardLockoutConfig, computeCardLockoutEndTime } from './lockout';
 
@@ -30,7 +34,12 @@ test.each<{
   ({ numIncorrectPinAttempts, expectedCardLockoutDurationSeconds }) => {
     const startTime = new Date();
     const endTime = computeCardLockoutEndTime(
-      {},
+      {
+        numIncorrectPinAttemptsAllowedBeforeCardLockout:
+          DEFAULT_NUM_INCORRECT_PIN_ATTEMPTS_ALLOWED_BEFORE_CARD_LOCKOUT,
+        startingCardLockoutDurationSeconds:
+          DEFAULT_STARTING_CARD_LOCKOUT_DURATION_SECONDS,
+      },
       numIncorrectPinAttempts,
       startTime
     );

--- a/libs/auth/src/lockout.ts
+++ b/libs/auth/src/lockout.ts
@@ -1,8 +1,6 @@
 import { DateTime } from 'luxon';
 import { Optional } from '@votingworks/basics';
 import {
-  DEFAULT_NUM_INCORRECT_PIN_ATTEMPTS_ALLOWED_BEFORE_CARD_LOCKOUT,
-  DEFAULT_STARTING_CARD_LOCKOUT_DURATION_SECONDS,
   NumIncorrectPinAttemptsAllowedBeforeCardLockout,
   StartingCardLockoutDurationSeconds,
 } from '@votingworks/types';
@@ -11,8 +9,8 @@ import {
  * Config params for card lockout
  */
 export interface CardLockoutConfig {
-  numIncorrectPinAttemptsAllowedBeforeCardLockout?: NumIncorrectPinAttemptsAllowedBeforeCardLockout;
-  startingCardLockoutDurationSeconds?: StartingCardLockoutDurationSeconds;
+  numIncorrectPinAttemptsAllowedBeforeCardLockout: NumIncorrectPinAttemptsAllowedBeforeCardLockout;
+  startingCardLockoutDurationSeconds: StartingCardLockoutDurationSeconds;
 }
 
 /**
@@ -40,8 +38,8 @@ export function computeCardLockoutEndTime(
   cardLockoutStartTime = new Date()
 ): Optional<Date> {
   const {
-    numIncorrectPinAttemptsAllowedBeforeCardLockout = DEFAULT_NUM_INCORRECT_PIN_ATTEMPTS_ALLOWED_BEFORE_CARD_LOCKOUT,
-    startingCardLockoutDurationSeconds = DEFAULT_STARTING_CARD_LOCKOUT_DURATION_SECONDS,
+    numIncorrectPinAttemptsAllowedBeforeCardLockout,
+    startingCardLockoutDurationSeconds,
   } = cardLockoutConfig;
 
   const numRemainingPinAttemptsWithoutCardLockout = Math.max(

--- a/libs/auth/src/sessions.test.ts
+++ b/libs/auth/src/sessions.test.ts
@@ -1,8 +1,14 @@
+import { DEFAULT_OVERALL_SESSION_TIME_LIMIT_HOURS } from '@votingworks/types';
 import { computeSessionEndTime, SessionConfig } from './sessions';
 
 test('computeSessionEndTime with default config params', () => {
   const startTime = new Date();
-  const endTime = computeSessionEndTime({}, startTime);
+  const endTime = computeSessionEndTime(
+    {
+      overallSessionTimeLimitHours: DEFAULT_OVERALL_SESSION_TIME_LIMIT_HOURS,
+    },
+    startTime
+  );
   expect(endTime).toEqual(new Date(startTime.getTime() + 12 * 60 * 60 * 1000));
 });
 

--- a/libs/auth/src/sessions.ts
+++ b/libs/auth/src/sessions.ts
@@ -1,14 +1,11 @@
 import { DateTime } from 'luxon';
-import {
-  DEFAULT_OVERALL_SESSION_TIME_LIMIT_HOURS,
-  OverallSessionTimeLimitHours,
-} from '@votingworks/types';
+import { OverallSessionTimeLimitHours } from '@votingworks/types';
 
 /**
  * Config params for sessions
  */
 export interface SessionConfig {
-  overallSessionTimeLimitHours?: OverallSessionTimeLimitHours;
+  overallSessionTimeLimitHours: OverallSessionTimeLimitHours;
 }
 
 /**
@@ -18,9 +15,7 @@ export function computeSessionEndTime(
   sessionConfig: SessionConfig,
   sessionStartTime = new Date()
 ): Date {
-  const {
-    overallSessionTimeLimitHours = DEFAULT_OVERALL_SESSION_TIME_LIMIT_HOURS,
-  } = sessionConfig;
+  const { overallSessionTimeLimitHours } = sessionConfig;
 
   return DateTime.fromJSDate(sessionStartTime)
     .plus({ hours: overallSessionTimeLimitHours })


### PR DESCRIPTION
## Overview

This helps avoid errors where a field is accidentally omitted and falls
back to the default, as discussed here: https://github.com/votingworks/vxsuite/pull/3852#discussion_r1301848429.

## Demo Video or Screenshot
N/A

## Testing Plan
Automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
