### PR TITLE
refactor(admin): use DB for contest filtering

### DIFF
--- a/apps/admin/backend/schema.sql
+++ b/apps/admin/backend/schema.sql
@@ -35,6 +35,31 @@ create table ballot_styles_to_precincts(
     on delete cascade
 );
 
+create index idx_ballot_styles_to_precincts_precinct_id on 
+  ballot_styles_to_precincts(election_id, precinct_id);
+
+create table ballot_styles_to_districts(
+  election_id text not null,
+  ballot_style_id text not null,
+  district_id text not null,
+  primary key (election_id, ballot_style_id, district_id),
+  foreign key (election_id, ballot_style_id) references ballot_styles(election_id, id)
+    on delete cascade
+);
+
+create index idx_ballot_styles_to_districts_district_id on 
+  ballot_styles_to_districts(election_id, district_id);
+
+create table contests(
+  election_id text not null,
+  id text not null,
+  district_id text not null,
+  party_id text,
+  primary key (election_id, id),
+  foreign key (election_id) references elections(id)
+    on delete cascade
+);
+
 create table voting_methods(
   election_id integer not null,
   voting_method text not null 

--- a/apps/admin/backend/src/store.test.ts
+++ b/apps/admin/backend/src/store.test.ts
@@ -449,3 +449,103 @@ describe('getTabulationGroups', () => {
     );
   });
 });
+
+describe('getFilteredContests', () => {
+  const store = Store.memoryStore();
+  const electionId = store.addElection(electionComplexGeoSample.asText());
+  const { election } = electionComplexGeoSample;
+
+  test('no filter', () => {
+    expectArrayMatch(
+      store.getFilteredContests({ electionId }),
+      election.contests.map((c) => c.id)
+    );
+  });
+
+  test('precinct filter', () => {
+    expectArrayMatch(
+      store.getFilteredContests({
+        electionId,
+        filter: {
+          precinctIds: ['precinct-c1-w2'],
+        },
+      }),
+      [
+        'county-leader-mammal',
+        'county-leader-fish',
+        'congressional-1-mammal',
+        'congressional-1-fish',
+        'water-2-fishing',
+      ]
+    );
+  });
+
+  test('ballot style filter', () => {
+    expectArrayMatch(
+      store.getFilteredContests({
+        electionId,
+        filter: {
+          ballotStyleIds: ['m-c1-w1'],
+        },
+      }),
+      ['county-leader-mammal', 'congressional-1-mammal', 'water-1-fishing']
+    );
+  });
+
+  test('party filter', () => {
+    expectArrayMatch(
+      store.getFilteredContests({
+        electionId,
+        filter: {
+          partyIds: ['0'],
+        },
+      }),
+      [
+        'county-leader-mammal',
+        'congressional-1-mammal',
+        'congressional-2-mammal',
+        'water-1-fishing',
+        'water-2-fishing',
+      ]
+    );
+  });
+
+  test('impossible cross-filter, no matches', () => {
+    expectArrayMatch(
+      store.getFilteredContests({
+        electionId,
+        filter: {
+          partyIds: ['0'],
+          ballotStyleIds: ['f-c1-w1'],
+        },
+      }),
+      []
+    );
+  });
+
+  test('party + ballot style cross-filter ', () => {
+    expectArrayMatch(
+      store.getFilteredContests({
+        electionId,
+        filter: {
+          partyIds: ['1'],
+          ballotStyleIds: ['f-c1-w1'],
+        },
+      }),
+      ['water-1-fishing', 'congressional-1-fish', 'county-leader-fish']
+    );
+  });
+
+  test('party + precinct cross-filter ', () => {
+    expectArrayMatch(
+      store.getFilteredContests({
+        electionId,
+        filter: {
+          partyIds: ['1'],
+          precinctIds: ['precinct-c1-w1-1'],
+        },
+      }),
+      ['water-1-fishing', 'congressional-1-fish', 'county-leader-fish']
+    );
+  });
+});

--- a/apps/admin/frontend/src/components/test_deck_tally_report.tsx
+++ b/apps/admin/frontend/src/components/test_deck_tally_report.tsx
@@ -1,8 +1,5 @@
 import { ElectionDefinition, Tabulation } from '@votingworks/types';
-import {
-  mapContestIdsToContests,
-  getContestIdsForFilter,
-} from '@votingworks/utils';
+import { getContestsForPrecinct } from '@votingworks/utils';
 import { find } from '@votingworks/basics';
 import type { TallyReportResults } from '@votingworks/admin-backend';
 import { AdminTallyReportByParty } from './admin_tally_report_by_party';
@@ -22,16 +19,7 @@ export function TestDeckTallyReport({
   return (
     <AdminTallyReportByParty
       election={election}
-      contests={
-        precinctId
-          ? mapContestIdsToContests(
-              electionDefinition,
-              getContestIdsForFilter(electionDefinition, {
-                precinctIds: [precinctId],
-              })
-            )
-          : election.contests
-      }
+      contests={getContestsForPrecinct(electionDefinition, precinctId)}
       title={
         precinctId
           ? `Precinct Tally Report for ${

--- a/libs/ui/src/reports/precinct_scanner_tally_reports.tsx
+++ b/libs/ui/src/reports/precinct_scanner_tally_reports.tsx
@@ -7,9 +7,8 @@ import {
 } from '@votingworks/types';
 import {
   combineElectionResults,
-  getContestIdsForFilter,
+  getContestsForPrecinct,
   getEmptyElectionResults,
-  mapContestIdsToContests,
 } from '@votingworks/utils';
 import { ThemeProvider } from 'styled-components';
 import { PrecinctScannerTallyQrCode } from './precinct_scanner_tally_qrcode';
@@ -49,14 +48,11 @@ export function PrecinctScannerTallyReports({
     allElectionResults: electionResultsByParty,
   });
   const partyIds = getPartyIdsWithContests(electionDefinition.election);
-  const allContests = mapContestIdsToContests(
+  const allContests = getContestsForPrecinct(
     electionDefinition,
-    getContestIdsForFilter(electionDefinition, {
-      precinctIds:
-        precinctSelection.kind === 'SinglePrecinct'
-          ? [precinctSelection.precinctId]
-          : undefined,
-    })
+    precinctSelection.kind === 'SinglePrecinct'
+      ? precinctSelection.precinctId
+      : undefined
   );
   const showQuickResults =
     electionDefinition.election.quickResultsReportingUrl &&

--- a/libs/utils/src/tabulation/contest_filtering.test.ts
+++ b/libs/utils/src/tabulation/contest_filtering.test.ts
@@ -4,7 +4,6 @@ import {
   getContestIdsForFilter,
   getContestIdsForParty,
   getContestIdsForPrecinct,
-  getContestIdsForSplit,
   intersectSets,
   unionSets,
 } from './contest_filtering';
@@ -193,79 +192,6 @@ describe('getContestIdsForFilter', () => {
         }),
       ],
       ['congressional-1-mammal', 'town-mammal', 'water-2-mammal']
-    );
-  });
-});
-
-describe('getContestIdsForSplit', () => {
-  const electionDefinition = complexBallotStyleElectionDefinition;
-  test('ballot style', () => {
-    expectArrayContentsEqual(
-      [
-        ...getContestIdsForSplit(electionDefinition, {
-          ballotStyleId: 'c1-w1-mammal',
-        }),
-      ],
-      ['congressional-1-mammal', 'town-mammal', 'water-1-mammal']
-    );
-  });
-
-  test('party', () => {
-    expectArrayContentsEqual(
-      [
-        ...getContestIdsForSplit(electionDefinition, {
-          partyId: '0',
-        }),
-      ],
-      [
-        'congressional-1-mammal',
-        'congressional-2-mammal',
-        'town-mammal',
-        'water-1-mammal',
-        'water-2-mammal',
-      ]
-    );
-  });
-
-  test('precinct', () => {
-    expectArrayContentsEqual(
-      [
-        ...getContestIdsForSplit(electionDefinition, {
-          precinctId: 'c1-w1-1',
-        }),
-      ],
-      [
-        'congressional-1-mammal',
-        'town-mammal',
-        'water-1-mammal',
-        'congressional-1-fish',
-        'town-fish',
-        'water-1-fish',
-      ]
-    );
-  });
-
-  test('precinct * party', () => {
-    expectArrayContentsEqual(
-      [
-        ...getContestIdsForSplit(electionDefinition, {
-          partyId: '0',
-          precinctId: 'c1-w1-1',
-        }),
-      ],
-      ['congressional-1-mammal', 'town-mammal', 'water-1-mammal']
-    );
-  });
-
-  test('invalid combo', () => {
-    expectArrayContentsEqual(
-      [
-        ...getContestIdsForSplit(electionDefinition, {
-          ballotStyleId: 'c1-w2-mammal',
-          precinctId: 'c1-w1-1',
-        }),
-      ],
-      []
     );
   });
 });

--- a/libs/utils/src/tabulation/contest_filtering.ts
+++ b/libs/utils/src/tabulation/contest_filtering.ts
@@ -6,6 +6,7 @@ import {
   PrecinctId,
   Tabulation,
   AnyContest,
+  Contests,
 } from '@votingworks/types';
 import { assert } from '@votingworks/basics';
 import {
@@ -247,4 +248,17 @@ export function mergeFilters(
         ? [...(filter1.votingMethods || []), ...(filter2.votingMethods || [])]
         : undefined,
   };
+}
+
+export function getContestsForPrecinct(
+  electionDefinition: ElectionDefinition,
+  precinctId?: PrecinctId
+): Contests {
+  const { election } = electionDefinition;
+  if (!precinctId) {
+    return election.contests;
+  }
+
+  const contestIds = getContestIdsForPrecinct(electionDefinition, precinctId);
+  return mapContestIdsToContests(electionDefinition, contestIds);
 }

--- a/libs/utils/src/tabulation/contest_filtering.ts
+++ b/libs/utils/src/tabulation/contest_filtering.ts
@@ -204,57 +204,47 @@ export function mapContestIdsToContests(
   );
 }
 
-/**
- * Different splits will have different contests i.e. different ballot styles.
- * An invalid split would contain no contests.
- */
-export function getBallotStyleIdsForSplit(
-  electionDefinition: ElectionDefinition,
-  split: Tabulation.GroupSpecifier
-): Set<ContestId> {
-  let ballotStyleIds = new Set(
-    electionDefinition.election.ballotStyles.map((bs) => bs.id)
-  );
-
-  if (split.ballotStyleId) {
-    // if we assumed that all splits passed to this function were valid, we
-    // could short-circuit here, but we're not making that assumption here
-    ballotStyleIds = new Set([split.ballotStyleId]);
-  }
-
-  if (split.partyId) {
-    ballotStyleIds = intersectSets([
-      ballotStyleIds,
-      new Set(
-        getBallotStylesByPartyId(electionDefinition, split.partyId).map(
-          (bs) => bs.id
-        )
-      ),
-    ]);
-  }
-
-  if (split.precinctId) {
-    ballotStyleIds = intersectSets([
-      ballotStyleIds,
-      new Set(
-        getBallotStylesByPrecinctId(electionDefinition, split.precinctId).map(
-          (bs) => bs.id
-        )
-      ),
-    ]);
-  }
-
-  return ballotStyleIds;
+export function convertGroupSpecifierToFilter(
+  group: Tabulation.GroupSpecifier
+): Tabulation.Filter {
+  return {
+    ballotStyleIds: group.ballotStyleId ? [group.ballotStyleId] : undefined,
+    partyIds: group.partyId ? [group.partyId] : undefined,
+    precinctIds: group.precinctId ? [group.precinctId] : undefined,
+    scannerIds: group.scannerId ? [group.scannerId] : undefined,
+    batchIds: group.batchId ? [group.batchId] : undefined,
+    votingMethods: group.votingMethod ? [group.votingMethod] : undefined,
+  };
 }
 
-/**
- * Splits often contain only certain ballot styles and thus only certain contests.
- */
-export function getContestIdsForSplit(
-  electionDefinition: ElectionDefinition,
-  split: Tabulation.GroupSpecifier
-): Set<ContestId> {
-  return getContestIdsForBallotStyleIds(electionDefinition, [
-    ...getBallotStyleIdsForSplit(electionDefinition, split),
-  ]);
+export function mergeFilters(
+  filter1: Tabulation.Filter,
+  filter2: Tabulation.Filter
+): Tabulation.Filter {
+  return {
+    ballotStyleIds:
+      filter1.ballotStyleIds || filter2.ballotStyleIds
+        ? [...(filter1.ballotStyleIds || []), ...(filter2.ballotStyleIds || [])]
+        : undefined,
+    partyIds:
+      filter1.partyIds || filter2.partyIds
+        ? [...(filter1.partyIds || []), ...(filter2.partyIds || [])]
+        : undefined,
+    precinctIds:
+      filter1.precinctIds || filter2.precinctIds
+        ? [...(filter1.precinctIds || []), ...(filter2.precinctIds || [])]
+        : undefined,
+    scannerIds:
+      filter1.scannerIds || filter2.scannerIds
+        ? [...(filter1.scannerIds || []), ...(filter2.scannerIds || [])]
+        : undefined,
+    batchIds:
+      filter1.batchIds || filter2.batchIds
+        ? [...(filter1.batchIds || []), ...(filter2.batchIds || [])]
+        : undefined,
+    votingMethods:
+      filter1.votingMethods || filter2.votingMethods
+        ? [...(filter1.votingMethods || []), ...(filter2.votingMethods || [])]
+        : undefined,
+  };
 }


### PR DESCRIPTION
## Overview

Adds ability to filter contests (decide which contests should appear in a report) into the VxAdmin store and uses the new logic for CSV exports. In the second commit, I replace some of the consumers of the complex util from #3788 with a simpler util. 

I'm not able to remove all the old code yet because I need to refactor the way tally report data is served to the VxAdmin frontend, which I will work on next.

## Testing Plan

Added contest filtering testing to `store.test.ts`.
