### PR TITLE
VxAdmin: Store system settings with election

### DIFF
--- a/apps/admin/backend/schema.sql
+++ b/apps/admin/backend/schema.sql
@@ -1,6 +1,7 @@
 create table elections (
   id serial primary key,
-  data text not null,
+  election_data text not null,
+  system_settings_data text not null,
   is_official_results boolean not null default false,
   created_at timestamp not null default current_timestamp,
   deleted_at timestamp
@@ -196,12 +197,6 @@ create table manual_result_write_in_candidate_references (
     on delete cascade,
   foreign key (write_in_candidate_id) references write_in_candidates(id)
     on delete cascade
-);
-
-create table system_settings (
-  -- enforce singleton table
-  id integer primary key check (id = 1),
-  data text not null -- JSON blob
 );
 
 create table settings (

--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -5,7 +5,6 @@ import {
 } from '@votingworks/fixtures';
 import { LogEventId } from '@votingworks/logging';
 
-import { mockOf, suppressingConsoleOutput } from '@votingworks/test-utils';
 import { DEFAULT_SYSTEM_SETTINGS } from '@votingworks/types';
 import {
   buildTestEnvironment,
@@ -51,16 +50,30 @@ test('managing the current election', async () => {
   expect(await apiClient.getCurrentElectionMetadata()).toBeNull();
 
   // try configuring with malformed election data
-  const badConfigureResult = await apiClient.configure({ electionData: '{}' });
+  const badConfigureResult = await apiClient.configure({
+    electionData: '{}',
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+  });
   assert(badConfigureResult.isErr());
-  expect(badConfigureResult.err().type).toEqual('parsing');
+  expect(badConfigureResult.err().type).toEqual('invalidElection');
 
   const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
   const { electionData, electionHash } = electionDefinition;
 
-  // configure with well-formed election data
+  // try configuring with malformed system settings data
+  const badSystemSettingsConfigureResult = await apiClient.configure({
+    electionData,
+    systemSettingsData: '{}',
+  });
+  assert(badSystemSettingsConfigureResult.isErr());
+  expect(badSystemSettingsConfigureResult.err().type).toEqual(
+    'invalidSystemSettings'
+  );
+
+  // configure with well-formed data
   const configureResult = await apiClient.configure({
     electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
   });
   assert(configureResult.isOk());
   const { electionId } = configureResult.ok();
@@ -113,6 +126,7 @@ test('managing the current election', async () => {
   // confirm we can reconfigure on same app instance
   void (await apiClient.configure({
     electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
   }));
   expect(await apiClient.getCurrentElectionMetadata()).toMatchObject({
     isOfficialResults: false,
@@ -130,6 +144,7 @@ test('configuring with a CDF election', async () => {
   // configure with well-formed election data
   const configureResult = await apiClient.configure({
     electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
   });
   assert(configureResult.isOk());
   configureResult.ok();
@@ -152,100 +167,19 @@ test('configuring with a CDF election', async () => {
   );
 });
 
-test('setSystemSettings happy path', async () => {
-  const { apiClient, auth, logger } = buildTestEnvironment();
-
-  const { electionDefinition, systemSettings } =
-    electionMinimalExhaustiveSampleFixtures;
-  await configureMachine(apiClient, auth, electionDefinition);
-
-  mockSystemAdministratorAuth(auth);
-
-  const result = await apiClient.setSystemSettings({
-    systemSettings: systemSettings.asText(),
-  });
-  assert(result.isOk());
-
-  // Logger call 1 is made by configureMachine when loading the election definition
-  expect(logger.log).toHaveBeenNthCalledWith(
-    2,
-    LogEventId.SystemSettingsSaveInitiated,
-    'system_administrator',
-    { disposition: 'na' }
-  );
-  expect(logger.log).toHaveBeenNthCalledWith(
-    3,
-    LogEventId.SystemSettingsSaved,
-    'system_administrator',
-    { disposition: 'success' }
-  );
-});
-
-test('setSystemSettings throws error when store.saveSystemSettings fails', async () => {
-  const { apiClient, auth, workspace, logger } = buildTestEnvironment();
-  const { electionDefinition, systemSettings } =
-    electionMinimalExhaustiveSampleFixtures;
-  await configureMachine(apiClient, auth, electionDefinition);
-  mockOf(logger.log).mockClear(); // Clear log calls from configureMachine
-  const errorString = 'db error at saveSystemSettings';
-  workspace.store.saveSystemSettings = jest.fn(() => {
-    throw new Error(errorString);
-  });
-
-  mockSystemAdministratorAuth(auth);
-
-  await suppressingConsoleOutput(async () => {
-    await expect(
-      apiClient.setSystemSettings({ systemSettings: systemSettings.asText() })
-    ).rejects.toThrow(errorString);
-  });
-
-  expect(logger.log).toHaveBeenNthCalledWith(
-    1,
-    LogEventId.SystemSettingsSaveInitiated,
-    'system_administrator',
-    { disposition: 'na' }
-  );
-  expect(logger.log).toHaveBeenNthCalledWith(
-    2,
-    LogEventId.SystemSettingsSaved,
-    'system_administrator',
-    { disposition: 'failure', error: errorString }
-  );
-});
-
-test('setSystemSettings returns an error for malformed input', async () => {
-  const { apiClient, auth } = buildTestEnvironment();
-
-  const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
-  await configureMachine(apiClient, auth, electionDefinition);
-
-  mockSystemAdministratorAuth(auth);
-
-  const malformedInput = {
-    invalidField: 'hello',
-  } as const;
-
-  const result = await apiClient.setSystemSettings({
-    systemSettings: JSON.stringify(malformedInput),
-  });
-  expect(result).toEqual(err({ type: 'parsing', message: expect.any(String) }));
-});
-
 test('getSystemSettings happy path', async () => {
   const { apiClient, auth } = buildTestEnvironment();
 
   const { electionDefinition, systemSettings } =
     electionMinimalExhaustiveSampleFixtures;
-  await configureMachine(apiClient, auth, electionDefinition);
+  await configureMachine(
+    apiClient,
+    auth,
+    electionDefinition,
+    JSON.parse(systemSettings.asText())
+  );
 
   mockSystemAdministratorAuth(auth);
-
-  // configure with well-formed system settings
-  const setResult = await apiClient.setSystemSettings({
-    systemSettings: systemSettings.asText(),
-  });
-  assert(setResult.isOk());
 
   const systemSettingsResult = await apiClient.getSystemSettings();
   assert(systemSettingsResult);

--- a/apps/admin/backend/src/store.test.ts
+++ b/apps/admin/backend/src/store.test.ts
@@ -3,9 +3,9 @@ import {
   electionMinimalExhaustiveSampleFixtures,
 } from '@votingworks/fixtures';
 import {
-  safeParseSystemSettings,
   CandidateContest,
   Tabulation,
+  DEFAULT_SYSTEM_SETTINGS,
 } from '@votingworks/types';
 import { find, typedAs } from '@votingworks/basics';
 import { promises as fs } from 'fs';
@@ -36,9 +36,12 @@ test('create a memory store', () => {
 
 test('add an election', () => {
   const store = Store.memoryStore();
-  const electionId = store.addElection(
-    electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
-  );
+  const electionId = store.addElection({
+    electionData:
+      electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+  });
+
   store.assertElectionExists(electionId);
   expect(store.getElections().map((r) => r.id)).toContain(electionId);
   expect(store.getElection(electionId)).toMatchObject({
@@ -58,9 +61,11 @@ test('assert election exists', () => {
 
 test('setElectionResultsOfficial', () => {
   const store = Store.memoryStore();
-  const electionId = store.addElection(
-    electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
-  );
+  const electionId = store.addElection({
+    electionData:
+      electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+  });
 
   expect(store.getElection(electionId)).toEqual(
     expect.objectContaining(
@@ -93,9 +98,11 @@ test('setElectionResultsOfficial', () => {
 
 test('current election id', () => {
   const store = Store.memoryStore();
-  const electionId = store.addElection(
-    electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
-  );
+  const electionId = store.addElection({
+    electionData:
+      electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+  });
 
   expect(store.getCurrentElectionId()).toBeUndefined();
 
@@ -106,21 +113,16 @@ test('current election id', () => {
   expect(store.getCurrentElectionId()).toBeUndefined();
 });
 
-/**
- * System settings tests
- */
-function makeSystemSettings() {
-  return safeParseSystemSettings(
-    electionMinimalExhaustiveSampleFixtures.systemSettings.asText()
-  ).unsafeUnwrap();
-}
-
 test('saveSystemSettings and getSystemSettings write and read system settings', () => {
   const store = Store.memoryStore();
-  const systemSettings = makeSystemSettings();
-  store.saveSystemSettings(systemSettings);
+  const electionId = store.addElection({
+    electionData:
+      electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+  });
+  store.setCurrentElectionId(electionId);
   const retrievedSystemSettings = store.getSystemSettings();
-  expect(retrievedSystemSettings).toEqual(systemSettings);
+  expect(retrievedSystemSettings).toEqual(DEFAULT_SYSTEM_SETTINGS);
 });
 
 test('getSystemSettings returns undefined when no system settings exist', () => {
@@ -131,9 +133,11 @@ test('getSystemSettings returns undefined when no system settings exist', () => 
 
 test('scanner batches', () => {
   const store = Store.memoryStore();
-  const electionId = store.addElection(
-    electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
-  );
+  const electionId = store.addElection({
+    electionData:
+      electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+  });
   expect(store.getScannerBatches(electionId)).toEqual([]);
 
   const scannerBatch: ScannerBatch = {
@@ -154,7 +158,10 @@ test('manual results', () => {
   const { electionData, election } = electionDefinition;
 
   const store = Store.memoryStore();
-  const electionId = store.addElection(electionData);
+  const electionId = store.addElection({
+    electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+  });
   const contestId = 'zoo-council-mammal';
   const writeInCandidate = store.addWriteInCandidate({
     electionId,
@@ -279,7 +286,10 @@ function expectArrayMatch<T>(a: T[], b: T[]) {
 
 describe('getTabulationGroups', () => {
   const store = Store.memoryStore();
-  const electionId = store.addElection(electionComplexGeoSample.asText());
+  const electionId = store.addElection({
+    electionData: electionComplexGeoSample.asText(),
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+  });
   const { election } = electionComplexGeoSample;
 
   test('no groupings', () => {
@@ -455,7 +465,10 @@ describe('getTabulationGroups', () => {
 
 describe('getFilteredContests', () => {
   const store = Store.memoryStore();
-  const electionId = store.addElection(electionComplexGeoSample.asText());
+  const electionId = store.addElection({
+    electionData: electionComplexGeoSample.asText(),
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+  });
   const { election } = electionComplexGeoSample;
 
   test('no filter', () => {

--- a/apps/admin/backend/src/tabulation/card_counts.test.ts
+++ b/apps/admin/backend/src/tabulation/card_counts.test.ts
@@ -1,5 +1,5 @@
 import { electionMinimalExhaustiveSampleFixtures } from '@votingworks/fixtures';
-import { Tabulation } from '@votingworks/types';
+import { DEFAULT_SYSTEM_SETTINGS, Tabulation } from '@votingworks/types';
 import { GROUP_KEY_ROOT, groupMapToGroupList } from '@votingworks/utils';
 import { typedAs } from '@votingworks/basics';
 import { Store } from '../store';
@@ -13,7 +13,10 @@ test('tabulateScannedCardCounts - grouping', () => {
   const store = Store.memoryStore();
   const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
   const { electionData } = electionDefinition;
-  const electionId = store.addElection(electionData);
+  const electionId = store.addElection({
+    electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+  });
   store.setCurrentElectionId(electionId);
 
   // add some mock cast vote records with one vote each
@@ -160,7 +163,10 @@ test('tabulateScannedCardCounts - merging card tallies', () => {
   const store = Store.memoryStore();
   const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
   const { electionData } = electionDefinition;
-  const electionId = store.addElection(electionData);
+  const electionId = store.addElection({
+    electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+  });
   store.setCurrentElectionId(electionId);
 
   // add some mock cast vote records with one vote each
@@ -224,7 +230,10 @@ test('tabulateFullCardCounts - blankBallots', () => {
   const store = Store.memoryStore();
   const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
   const { electionData } = electionDefinition;
-  const electionId = store.addElection(electionData);
+  const electionId = store.addElection({
+    electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+  });
   store.setCurrentElectionId(electionId);
 
   // add some mock cast vote records with one vote each

--- a/apps/admin/backend/src/tabulation/full_results.test.ts
+++ b/apps/admin/backend/src/tabulation/full_results.test.ts
@@ -10,7 +10,7 @@ import {
   getFeatureFlagMock,
 } from '@votingworks/utils';
 import { assert } from '@votingworks/basics';
-import { Tabulation } from '@votingworks/types';
+import { DEFAULT_SYSTEM_SETTINGS, Tabulation } from '@votingworks/types';
 import {
   tabulateCastVoteRecords,
   tabulateElectionResults,
@@ -50,7 +50,10 @@ test('tabulateCastVoteRecords', async () => {
   const store = Store.memoryStore();
   const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
   const { election, electionData } = electionDefinition;
-  const electionId = store.addElection(electionData);
+  const electionId = store.addElection({
+    electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+  });
   store.setCurrentElectionId(electionId);
 
   // add some mock cast vote records with one vote each
@@ -257,7 +260,10 @@ test('tabulateElectionResults - includes empty groups', async () => {
   const store = Store.memoryStore();
   const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
   const { electionData } = electionDefinition;
-  const electionId = store.addElection(electionData);
+  const electionId = store.addElection({
+    electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+  });
   store.setCurrentElectionId(electionId);
 
   const groupedElectionResults = await tabulateCastVoteRecords({
@@ -282,7 +288,10 @@ test('tabulateElectionResults - write-in handling', async () => {
   const { electionDefinition, castVoteRecordReport } =
     electionGridLayoutNewHampshireAmherstFixtures;
   const { election } = electionDefinition;
-  const electionId = store.addElection(electionDefinition.electionData);
+  const electionId = store.addElection({
+    electionData: electionDefinition.electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+  });
   store.setCurrentElectionId(electionId);
 
   const addReportResult = await addCastVoteRecordReport({
@@ -619,8 +628,11 @@ test('tabulateElectionResults - group and filter by voting method', async () => 
   const store = Store.memoryStore();
   const { electionDefinition, castVoteRecordReport } =
     electionGridLayoutNewHampshireAmherstFixtures;
-  const { election } = electionDefinition;
-  const electionId = store.addElection(electionDefinition.electionData);
+  const { election, electionData } = electionDefinition;
+  const electionId = store.addElection({
+    electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+  });
   store.setCurrentElectionId(electionId);
   const addReportResult = await addCastVoteRecordReport({
     store,

--- a/apps/admin/backend/src/tabulation/manual_results.test.ts
+++ b/apps/admin/backend/src/tabulation/manual_results.test.ts
@@ -1,7 +1,7 @@
 import { electionMinimalExhaustiveSampleFixtures } from '@votingworks/fixtures';
 import { buildManualResultsFixture } from '@votingworks/utils';
 import { assert } from '@votingworks/basics';
-import { Tabulation } from '@votingworks/types';
+import { DEFAULT_SYSTEM_SETTINGS, Tabulation } from '@votingworks/types';
 import { Store } from '../store';
 import {
   extractWriteInSummary,
@@ -53,9 +53,11 @@ test('isGroupByCompatibleWithManualResults', () => {
 describe('tabulateManualResults & tabulateManualBallotCounts', () => {
   test('on incompatible filter', () => {
     const store = Store.memoryStore();
-    const electionId = store.addElection(
-      electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData
-    );
+    const electionId = store.addElection({
+      electionData:
+        electionMinimalExhaustiveSampleFixtures.electionDefinition.electionData,
+      systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    });
     store.setCurrentElectionId(electionId);
 
     expect(
@@ -71,7 +73,10 @@ describe('tabulateManualResults & tabulateManualBallotCounts', () => {
     const store = Store.memoryStore();
     const { electionData, election } =
       electionMinimalExhaustiveSampleFixtures.electionDefinition;
-    const electionId = store.addElection(electionData);
+    const electionId = store.addElection({
+      electionData,
+      systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    });
     store.setCurrentElectionId(electionId);
 
     expect(
@@ -95,7 +100,10 @@ describe('tabulateManualResults & tabulateManualBallotCounts', () => {
     const store = Store.memoryStore();
     const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
     const { election, electionData } = electionDefinition;
-    const electionId = store.addElection(electionData);
+    const electionId = store.addElection({
+      electionData,
+      systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    });
     store.setCurrentElectionId(electionId);
 
     // since we're only interested in how results are combined, we can use

--- a/apps/admin/backend/src/tabulation/write_ins.test.ts
+++ b/apps/admin/backend/src/tabulation/write_ins.test.ts
@@ -3,7 +3,11 @@ import {
   electionMinimalExhaustiveSampleDefinition,
   electionMinimalExhaustiveSampleFixtures,
 } from '@votingworks/fixtures';
-import { Tabulation, writeInCandidate } from '@votingworks/types';
+import {
+  DEFAULT_SYSTEM_SETTINGS,
+  Tabulation,
+  writeInCandidate,
+} from '@votingworks/types';
 import { getEmptyElectionResults } from '@votingworks/utils';
 import {
   convertContestWriteInSummaryToWriteInTallies,
@@ -148,7 +152,10 @@ test('tabulateWriteInTallies', () => {
   const store = Store.memoryStore();
   const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
   const { election, electionData } = electionDefinition;
-  const electionId = store.addElection(electionData);
+  const electionId = store.addElection({
+    electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+  });
   store.setCurrentElectionId(electionId);
 
   // add some mock cast vote records with write-ins to store

--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -1,4 +1,3 @@
-import { Result } from '@votingworks/basics';
 import {
   ContestId,
   ContestOptionId,
@@ -29,23 +28,11 @@ export interface MachineConfig {
 }
 
 /**
- * Result of attempt to configure the app with a new election definition
+ * Errors that can occur when attempting to configure from an election package.
  */
-export type ConfigureResult = Result<
-  { electionId: Id },
-  { type: 'parsing'; message: string }
->;
-
-/**
- * Result of attempt to store and apply system settings
- */
-export type SetSystemSettingsResult = Result<
-  Record<string, never>,
-  {
-    type: 'parsing' | 'database';
-    message: string;
-  }
->;
+export type ConfigureError =
+  | { type: 'invalidElection'; message: string }
+  | { type: 'invalidSystemSettings'; message: string };
 
 /**
  * Metadata about a cast vote record file found on a USB drive.

--- a/apps/admin/backend/test/app.ts
+++ b/apps/admin/backend/test/app.ts
@@ -162,11 +162,7 @@ export async function configureMachine(
   const { electionId } = (
     await apiClient.configure({
       electionData,
-    })
-  ).unsafeUnwrap();
-  (
-    await apiClient.setSystemSettings({
-      systemSettings: JSON.stringify(systemSettings),
+      systemSettingsData: JSON.stringify(systemSettings),
     })
   ).unsafeUnwrap();
   return electionId;

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -475,6 +475,7 @@ export const configure = {
         await queryClient.invalidateQueries(
           getCurrentElectionMetadata.queryKey()
         );
+        await queryClient.invalidateQueries(getSystemSettings.queryKey());
       },
     });
   },
@@ -593,18 +594,6 @@ export const adjudicateWriteIn = {
     return useMutation(apiClient.adjudicateWriteIn, {
       async onSuccess() {
         await invalidateWriteInQueries(queryClient);
-      },
-    });
-  },
-} as const;
-
-export const setSystemSettings = {
-  useMutation() {
-    const apiClient = useApiClient();
-    const queryClient = useQueryClient();
-    return useMutation(apiClient.setSystemSettings, {
-      async onSuccess() {
-        await queryClient.invalidateQueries(getSystemSettings.queryKey());
       },
     });
   },

--- a/apps/admin/frontend/src/app.test.tsx
+++ b/apps/admin/frontend/src/app.test.tsx
@@ -106,8 +106,10 @@ test('configuring with a demo election definition', async () => {
   await screen.findByText('Load Demo Election Definition');
 
   // expecting configure and resulting refetch
-  apiMock.expectConfigure(electionDefinition.electionData);
-  apiMock.expectSetSystemSettings(JSON.stringify(DEFAULT_SYSTEM_SETTINGS));
+  apiMock.expectConfigure(
+    electionDefinition.electionData,
+    JSON.stringify(DEFAULT_SYSTEM_SETTINGS)
+  );
   apiMock.expectGetSystemSettings();
   apiMock.expectGetCurrentElectionMetadata({ electionDefinition });
   fireEvent.click(screen.getByText('Load Demo Election Definition'));
@@ -565,8 +567,10 @@ test('system administrator UI has expected nav when no election', async () => {
   userEvent.click(screen.getByText('Definition'));
   await screen.findByRole('heading', { name: 'Configure VxAdmin' });
   const { electionDefinition } = electionFamousNames2021Fixtures;
-  apiMock.expectConfigure(electionDefinition.electionData);
-  apiMock.expectSetSystemSettings(JSON.stringify(DEFAULT_SYSTEM_SETTINGS));
+  apiMock.expectConfigure(
+    electionDefinition.electionData,
+    JSON.stringify(DEFAULT_SYSTEM_SETTINGS)
+  );
   apiMock.expectGetSystemSettings();
   apiMock.expectGetCurrentElectionMetadata({ electionDefinition });
   userEvent.click(

--- a/apps/admin/frontend/src/screens/unconfigured_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/unconfigured_screen.test.tsx
@@ -33,8 +33,10 @@ test('renders a button to load setup package', async () => {
 test('handles an uploaded file', async () => {
   const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
 
-  apiMock.expectConfigure(electionDefinition.electionData);
-  apiMock.expectSetSystemSettings(systemSettings.asText());
+  apiMock.expectConfigure(
+    electionDefinition.electionData,
+    systemSettings.asText()
+  );
 
   renderInAppContext(<UnconfiguredScreen />, {
     apiMock,
@@ -60,8 +62,10 @@ test('handles an uploaded file', async () => {
 test('uploads default system settings if loading only an election.json file', async () => {
   const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
 
-  apiMock.expectConfigure(electionDefinition.electionData);
-  apiMock.expectSetSystemSettings(JSON.stringify(DEFAULT_SYSTEM_SETTINGS));
+  apiMock.expectConfigure(
+    electionDefinition.electionData,
+    JSON.stringify(DEFAULT_SYSTEM_SETTINGS)
+  );
 
   renderInAppContext(<UnconfiguredScreen />, {
     apiMock,
@@ -83,8 +87,10 @@ test('uploads default system settings if loading only an election.json file', as
 test('uploads default system settings if loading the default election', async () => {
   const { electionDefinition } = electionFamousNames2021Fixtures;
 
-  apiMock.expectConfigure(electionDefinition.electionData);
-  apiMock.expectSetSystemSettings(JSON.stringify(DEFAULT_SYSTEM_SETTINGS));
+  apiMock.expectConfigure(
+    electionDefinition.electionData,
+    JSON.stringify(DEFAULT_SYSTEM_SETTINGS)
+  );
 
   renderInAppContext(<UnconfiguredScreen />, {
     apiMock,

--- a/apps/admin/frontend/src/screens/unconfigured_screen.tsx
+++ b/apps/admin/frontend/src/screens/unconfigured_screen.tsx
@@ -84,7 +84,7 @@ export function UnconfiguredScreen(): JSX.Element {
         }
         return result;
       } catch {
-        // Do nothing
+        // Handled by default query client error handling
       }
     },
     [configureMutateAsync]

--- a/apps/admin/frontend/test/helpers/api_mock.ts
+++ b/apps/admin/frontend/test/helpers/api_mock.ts
@@ -150,20 +150,17 @@ export function createApiMock(
       );
     },
 
-    expectConfigure(electionData: string) {
+    expectConfigure(
+      electionData: string,
+      systemSettingsData: string = JSON.stringify(DEFAULT_SYSTEM_SETTINGS)
+    ) {
       apiClient.configure
-        .expectCallWith({ electionData })
+        .expectCallWith({ electionData, systemSettingsData })
         .resolves(ok({ electionId: 'anything' }));
     },
 
     expectUnconfigure() {
       apiClient.unconfigure.expectCallWith().resolves();
-    },
-
-    expectSetSystemSettings(systemSettings: string) {
-      apiClient.setSystemSettings
-        .expectCallWith({ systemSettings })
-        .resolves(ok({}));
     },
 
     expectGetSystemSettings(systemSettings?: SystemSettings) {


### PR DESCRIPTION

## Overview

System settings are election-specific, since they are imported at the same time (in the election package). Since the backend of VxAdmin supports storing multiple elections, it makes sense to store the system settings with each election.

In making this change, I also thought it made sense for the API to configure the election to reflect this change as well.

## Demo Video or Screenshot
N/A

## Testing Plan
- Updated automated tests
- Manually tested configuring/unconfiguring

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
