### PR TITLE
fix(auth): follow the protocol more closely

### DIFF
--- a/libs/auth/src/apdu.test.ts
+++ b/libs/auth/src/apdu.test.ts
@@ -25,6 +25,7 @@ test.each<{
     ins: 0x01,
     p1: 0x02,
     p2: 0x03,
+    data: Buffer.of(),
   });
   expect(apdu.asBuffer()).toEqual(
     Buffer.from([expectedFirstByte, 0x01, 0x02, 0x03, 0x00])

--- a/libs/auth/src/apdu.ts
+++ b/libs/auth/src/apdu.ts
@@ -79,6 +79,25 @@ function splitEvery2Characters(s: string): string[] {
 }
 
 /**
+ * Input to a {@link CommandAdpu}.
+ */
+export type CommandAdpuInput =
+  | {
+      cla?: { chained?: boolean; secure?: boolean };
+      ins: Byte;
+      p1: Byte;
+      p2: Byte;
+      data: Buffer;
+    }
+  | {
+      cla?: { chained?: boolean; secure?: boolean };
+      ins: Byte;
+      p1: Byte;
+      p2: Byte;
+      lc: Byte;
+    };
+
+/**
  * An APDU, or application protocol data unit, is the communication unit between a smart card
  * reader and a smart card. The smart card reader issues command APDUs to the smart card, and the
  * smart card sends response APDUs back.
@@ -99,21 +118,15 @@ export class CommandApdu {
   /** Data */
   private readonly data: Buffer;
 
-  constructor(input: {
-    cla?: { chained?: boolean; secure?: boolean };
-    ins: Byte;
-    p1: Byte;
-    p2: Byte;
-    data?: Buffer;
-  }) {
+  constructor(input: CommandAdpuInput) {
     const cla = this.determineCla(input.cla);
-    const data = input.data ?? Buffer.from([]);
+    const lc = 'lc' in input ? input.lc : input.data.length;
+    const data = 'lc' in input ? Buffer.of() : input.data;
 
-    if (data.length > MAX_COMMAND_APDU_DATA_LENGTH) {
+    if (lc > MAX_COMMAND_APDU_DATA_LENGTH) {
       throw new Error('APDU data exceeds max command APDU data length');
     }
-    assert(isByte(data.length));
-    const lc = data.length;
+    assert(isByte(lc));
 
     this.cla = cla;
     this.ins = input.ins;

--- a/libs/auth/src/card_reader.test.ts
+++ b/libs/auth/src/card_reader.test.ts
@@ -361,7 +361,7 @@ test('CardReader command transmission - chained response', async () => {
       GET_RESPONSE.INS,
       GET_RESPONSE.P1,
       GET_RESPONSE.P2,
-      0x00,
+      0x0a,
     ]),
     MAX_APDU_LENGTH,
     mockConnectProtocol,


### PR DESCRIPTION
## Overview
This changes `CardReader::transmit` to record the number of bytes still available to be read and to then request exactly that number of bytes while reading the response.

Some Java cards, like CAC cards, are pretty strict about this. This commit backports some of @benadida's changes made to support CAC cards.

## Demo Video or Screenshot
n/a

## Testing Plan
- [x] verified that installing the applet on a Java card and setting it up as a VxSuite sysadmin card still works
