### PR TITLE
lint: add rule to prevent using mutations as dependencies in react hook dep arrays

### DIFF
--- a/apps/central-scan/frontend/src/app_root.tsx
+++ b/apps/central-scan/frontend/src/app_root.tsx
@@ -95,6 +95,7 @@ export function AppRoot({
 
   const electionDefinitionQuery = getElectionDefinition.useQuery();
   const unconfigureMutation = unconfigure.useMutation();
+  const unconfigureMutate = unconfigureMutation.mutate;
 
   const [isExportingCvrs, setIsExportingCvrs] = useState(false);
 
@@ -197,8 +198,8 @@ export function AppRoot({
   }, [setStatus]);
 
   const systemAdministratorUnconfigure = useCallback(() => {
-    unconfigureMutation.mutate({ ignoreBackupRequirement: true });
-  }, [unconfigureMutation]);
+    unconfigureMutate({ ignoreBackupRequirement: true });
+  }, [unconfigureMutate]);
 
   const scanBatch = useCallback(async () => {
     setIsScanning(true);

--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -283,8 +283,14 @@ export function AppRoot({
   const checkPinMutation = checkPin.useMutation();
   const startCardlessVoterSessionMutation =
     startCardlessVoterSession.useMutation();
+  const startCardlessVoterSessionMutate =
+    startCardlessVoterSessionMutation.mutate;
   const endCardlessVoterSessionMutation = endCardlessVoterSession.useMutation();
+  const endCardlessVoterSessionMutate = endCardlessVoterSessionMutation.mutate;
+  const endCardlessVoterSessionMutateAsync =
+    endCardlessVoterSessionMutation.mutateAsync;
   const unconfigureMachineMutation = unconfigureMachine.useMutation();
+  const unconfigureMachineMutateAsync = unconfigureMachineMutation.mutateAsync;
 
   const precinctId = isCardlessVoterAuth(authStatus)
     ? authStatus.user.precinctId
@@ -367,12 +373,12 @@ export function AppRoot({
 
   const hidePostVotingInstructions = useCallback(() => {
     clearTimeout(PostVotingInstructionsTimeout.current);
-    endCardlessVoterSessionMutation.mutate(undefined, {
+    endCardlessVoterSessionMutate(undefined, {
       onSuccess() {
         resetBallot();
       },
     });
-  }, [endCardlessVoterSessionMutation, resetBallot]);
+  }, [endCardlessVoterSessionMutate, resetBallot]);
 
   // Hide Verify and Scan Instructions
   useEffect(() => {
@@ -394,10 +400,10 @@ export function AppRoot({
 
   const unconfigure = useCallback(async () => {
     await storage.clear();
-    await unconfigureMachineMutation.mutateAsync();
+    await unconfigureMachineMutateAsync();
     dispatchAppState({ type: 'unconfigure' });
     history.push('/');
-  }, [storage, history, unconfigureMachineMutation]);
+  }, [storage, history, unconfigureMachineMutateAsync]);
 
   const updateVote = useCallback((contestId: ContestId, vote: OptionalVote) => {
     dispatchAppState({ type: 'updateVote', contestId, vote });
@@ -456,7 +462,7 @@ export function AppRoot({
   const activateCardlessBallot = useCallback(
     (sessionPrecinctId: PrecinctId, sessionBallotStyleId: BallotStyleId) => {
       assert(isPollWorkerAuth(authStatus));
-      startCardlessVoterSessionMutation.mutate(
+      startCardlessVoterSessionMutate(
         {
           ballotStyleId: sessionBallotStyleId,
           precinctId: sessionPrecinctId,
@@ -468,17 +474,17 @@ export function AppRoot({
         }
       );
     },
-    [authStatus, resetBallot, startCardlessVoterSessionMutation]
+    [authStatus, resetBallot, startCardlessVoterSessionMutate]
   );
 
   const resetCardlessBallot = useCallback(() => {
     assert(isPollWorkerAuth(authStatus));
-    endCardlessVoterSessionMutation.mutate(undefined, {
+    endCardlessVoterSessionMutate(undefined, {
       onSuccess() {
         history.push('/');
       },
     });
-  }, [authStatus, endCardlessVoterSessionMutation, history]);
+  }, [authStatus, endCardlessVoterSessionMutate, history]);
 
   useEffect(() => {
     function resetBallotOnLogout() {
@@ -495,11 +501,11 @@ export function AppRoot({
 
   const endVoterSession = useCallback(async () => {
     try {
-      await endCardlessVoterSessionMutation.mutateAsync();
+      await endCardlessVoterSessionMutateAsync();
     } catch {
       // Handled by default query client error handling
     }
-  }, [endCardlessVoterSessionMutation]);
+  }, [endCardlessVoterSessionMutateAsync]);
 
   // Handle Keyboard Input
   useEffect(() => {

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -300,8 +300,14 @@ export function AppRoot({
   const checkPinMutation = checkPin.useMutation();
   const startCardlessVoterSessionMutation =
     startCardlessVoterSession.useMutation();
+  const startCardlessVoterSessionMutate =
+    startCardlessVoterSessionMutation.mutate;
   const endCardlessVoterSessionMutation = endCardlessVoterSession.useMutation();
+  const endCardlessVoterSessionMutate = endCardlessVoterSessionMutation.mutate;
+  const endCardlessVoterSessionMutateAsync =
+    endCardlessVoterSessionMutation.mutateAsync;
   const unconfigureMachineMutation = unconfigureMachine.useMutation();
+  const unconfigureMachineMutateAsync = unconfigureMachineMutation.mutateAsync;
 
   const precinctId = isCardlessVoterAuth(authStatus)
     ? authStatus.user.precinctId
@@ -384,12 +390,12 @@ export function AppRoot({
 
   const hidePostVotingInstructions = useCallback(() => {
     clearTimeout(PostVotingInstructionsTimeout.current);
-    endCardlessVoterSessionMutation.mutate(undefined, {
+    endCardlessVoterSessionMutate(undefined, {
       onSuccess() {
         resetBallot();
       },
     });
-  }, [endCardlessVoterSessionMutation, resetBallot]);
+  }, [endCardlessVoterSessionMutate, resetBallot]);
 
   // Hide Verify and Scan Instructions
   useEffect(() => {
@@ -411,10 +417,10 @@ export function AppRoot({
 
   const unconfigure = useCallback(async () => {
     await storage.clear();
-    await unconfigureMachineMutation.mutateAsync();
+    await unconfigureMachineMutateAsync();
     dispatchAppState({ type: 'unconfigure' });
     history.push('/');
-  }, [storage, history, unconfigureMachineMutation]);
+  }, [storage, history, unconfigureMachineMutateAsync]);
 
   const updateVote = useCallback((contestId: ContestId, vote: OptionalVote) => {
     dispatchAppState({ type: 'updateVote', contestId, vote });
@@ -480,7 +486,7 @@ export function AppRoot({
   const activateCardlessBallot = useCallback(
     (sessionPrecinctId: PrecinctId, sessionBallotStyleId: BallotStyleId) => {
       assert(isPollWorkerAuth(authStatus));
-      startCardlessVoterSessionMutation.mutate(
+      startCardlessVoterSessionMutate(
         {
           ballotStyleId: sessionBallotStyleId,
           precinctId: sessionPrecinctId,
@@ -492,17 +498,17 @@ export function AppRoot({
         }
       );
     },
-    [authStatus, resetBallot, startCardlessVoterSessionMutation]
+    [authStatus, resetBallot, startCardlessVoterSessionMutate]
   );
 
   const resetCardlessBallot = useCallback(() => {
     assert(isPollWorkerAuth(authStatus));
-    endCardlessVoterSessionMutation.mutate(undefined, {
+    endCardlessVoterSessionMutate(undefined, {
       onSuccess() {
         history.push('/');
       },
     });
-  }, [authStatus, endCardlessVoterSessionMutation, history]);
+  }, [authStatus, endCardlessVoterSessionMutate, history]);
 
   useEffect(() => {
     function resetBallotOnLogout() {
@@ -519,11 +525,11 @@ export function AppRoot({
 
   const endVoterSession = useCallback(async () => {
     try {
-      await endCardlessVoterSessionMutation.mutateAsync();
+      await endCardlessVoterSessionMutateAsync();
     } catch {
       // Handled by default query client error handling
     }
-  }, [endCardlessVoterSessionMutation]);
+  }, [endCardlessVoterSessionMutateAsync]);
 
   // Handle Hardware Observer Subscription
   useEffect(() => {

--- a/libs/eslint-plugin-vx/src/configs/react.ts
+++ b/libs/eslint-plugin-vx/src/configs/react.ts
@@ -40,5 +40,6 @@ export = {
     'react/jsx-wrap-multilines': 'off',
     'react/prop-types': 'off',
     'react/require-default-props': 'off',
+    'vx/no-react-hook-mutation-dependency': 'error',
   },
 };

--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -72,7 +72,6 @@ export = {
     'vx/no-assert-truthiness': 'error',
     'vx/no-floating-results': ['error', { ignoreVoid: true }],
     'vx/no-import-workspace-subfolders': 'error',
-    'vx/no-jest-to-be': 'error',
 
     // Disallow awaiting a value that is not Thenable which often indicates an error.
     '@typescript-eslint/await-thenable': 'error',
@@ -172,6 +171,7 @@ export = {
         'jest/no-identical-title': 'error',
         'jest/no-focused-tests': 'error',
         'jest/valid-expect': ['error', { alwaysAwait: true }],
+        'vx/no-jest-to-be': 'error',
       },
     },
     {

--- a/libs/eslint-plugin-vx/src/rules/index.ts
+++ b/libs/eslint-plugin-vx/src/rules/index.ts
@@ -30,6 +30,7 @@ import noAssertStringOrNumber from './no_assert_truthiness';
 import noFloatingVoids from './no_floating_results';
 import noImportSubfolders from './no_import_workspace_subfolders';
 import noJestToBe from './no_jest_to_be';
+import noReactHookMutationDependency from './no_react_hook_mutation_dependency';
 
 const rules: Record<string, Rule.RuleModule> = {
   'gts-array-type-style': gtsArrayTypeStyle,
@@ -63,6 +64,7 @@ const rules: Record<string, Rule.RuleModule> = {
   'no-floating-results': noFloatingVoids,
   'no-import-workspace-subfolders': noImportSubfolders,
   'no-jest-to-be': noJestToBe,
+  'no-react-hook-mutation-dependency': noReactHookMutationDependency,
 } as unknown as Record<string, Rule.RuleModule>;
 
 export default rules;

--- a/libs/eslint-plugin-vx/src/rules/no_react_hook_mutation_dependency.ts
+++ b/libs/eslint-plugin-vx/src/rules/no_react_hook_mutation_dependency.ts
@@ -1,0 +1,71 @@
+import { AST_NODE_TYPES, TSESLint, TSESTree } from '@typescript-eslint/utils';
+import { createRule } from '../util';
+
+const HOOKS_WITH_DEPS = [
+  'useEffect',
+  'useLayoutEffect',
+  'useMemo',
+  'useCallback',
+  'useImperativeHandle',
+];
+
+const MUTATION_TYPE_NAME = 'UseMutationResult';
+
+const rule: TSESLint.RuleModule<'badMutationDependency', readonly unknown[]> =
+  createRule({
+    name: 'no-react-hook-mutation-dependency',
+    meta: {
+      docs: {
+        description:
+          'Prevents react query mutation objects from being used as dependencies in react hooks.',
+        recommended: 'error',
+        suggestion: false,
+        requiresTypeChecking: true,
+      },
+      messages: {
+        badMutationDependency:
+          'Mutations change identity on every render, so they should not be used as dependencies in React hooks. Instead, pass the properties of the mutation (e.g. `mutate` or `mutateAsync`) since they are stable references.',
+      },
+      schema: [],
+      type: 'problem',
+    },
+    defaultOptions: [],
+
+    create(context) {
+      return {
+        CallExpression(node: TSESTree.CallExpression) {
+          if (
+            node.callee.type !== AST_NODE_TYPES.Identifier ||
+            !HOOKS_WITH_DEPS.includes(node.callee.name)
+          ) {
+            return;
+          }
+
+          const deps = node.arguments[1];
+          if (!deps || deps.type !== AST_NODE_TYPES.ArrayExpression) {
+            return;
+          }
+
+          const { parserServices } = context.getSourceCode();
+          const tsNodeMap = parserServices.esTreeNodeToTSNodeMap;
+          const typeChecker = parserServices.program.getTypeChecker();
+
+          const mutation = deps.elements.find((element) => {
+            const type = typeChecker.getTypeAtLocation(tsNodeMap.get(element));
+            // istanbul ignore next - unsure how to reproduce aliasSymbol in tests
+            const typeName = type.symbol?.name ?? type.aliasSymbol?.name;
+            return typeName === MUTATION_TYPE_NAME;
+          });
+
+          if (mutation) {
+            context.report({
+              node: mutation,
+              messageId: 'badMutationDependency',
+            });
+          }
+        },
+      };
+    },
+  });
+
+export default rule;

--- a/libs/eslint-plugin-vx/tests/rules/no_react_hook_mutation_dependency.test.ts
+++ b/libs/eslint-plugin-vx/tests/rules/no_react_hook_mutation_dependency.test.ts
@@ -1,0 +1,52 @@
+import { ESLintUtils } from '@typescript-eslint/utils';
+import { join } from 'path';
+import rule from '../../src/rules/no_react_hook_mutation_dependency';
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    tsconfigRootDir: join(__dirname, '../fixtures'),
+    project: './tsconfig.json',
+  },
+  parser: '@typescript-eslint/parser',
+});
+
+const validExample1 = `
+useEffect(() => {
+  console.log('noop');
+});`;
+
+const validExample2 = `
+const num: number = 1;
+
+useEffect(() => {
+  console.log(num);
+}, [num]);`;
+
+const invalidCode = `
+interface UseMutationResult {
+  mutate: number;
+};
+
+function useMutation(): UseMutationResult {
+  return {
+    mutate: 5,
+  };
+}
+
+const result = useMutation();
+
+useEffect(() => {
+  console.log(result.mutate)
+}, [result]);
+`;
+
+ruleTester.run('no-react-hook-mutation-dependency', rule, {
+  valid: [validExample1, validExample2],
+  invalid: [
+    {
+      code: invalidCode,
+      errors: [{ line: 16, messageId: 'badMutationDependency' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Overview

Closes #3794. We've seen a bug or two related to re-render cycles due to mutations changing on every render. The resulting pattern is not cute, but it avoids bugs! 

