### PR TITLE
Fix L&A Primary Tally Reports

### DIFF
--- a/frontends/election-manager/src/components/ballot_counts_table.tsx
+++ b/frontends/election-manager/src/components/ballot_counts_table.tsx
@@ -423,6 +423,8 @@ export function BallotCountsTable({
         </Table>
       );
     }
+    case TallyCategory.PartyPrecinct:
+      throw new Error('unsupported');
     default:
       throwIllegalValue(breakdownCategory);
   }

--- a/frontends/election-manager/src/components/full_test_deck_tally_report_button.test.tsx
+++ b/frontends/election-manager/src/components/full_test_deck_tally_report_button.test.tsx
@@ -1,0 +1,60 @@
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  electionFamousNames2021Fixtures,
+  electionMinimalExhaustiveSampleDefinition,
+} from '@votingworks/fixtures';
+import { expectPrint } from '@votingworks/test-utils';
+import React from 'react';
+import { renderInAppContext } from '../../test/render_in_app_context';
+import { FullTestDeckTallyReportButton } from './full_test_deck_tally_report_button';
+
+test('prints appropriate reports for primary election', async () => {
+  renderInAppContext(<FullTestDeckTallyReportButton />, {
+    electionDefinition: electionMinimalExhaustiveSampleDefinition,
+  });
+
+  userEvent.click(await screen.findByText('Print Full Test Deck Tally Report'));
+  await screen.findByText('Printing');
+
+  await expectPrint((printedElement, printOptions) => {
+    const reports = printedElement.getAllByTestId('election-full-tally-report');
+    const mammalReport = within(reports[0]);
+    mammalReport.getByText(
+      'Test Deck Mammal Party Example Primary Election Tally Report'
+    );
+    expect(mammalReport.getByTestId('total')).toHaveTextContent(
+      'Total Ballots Cast56'
+    );
+
+    const fishReport = within(reports[1]);
+    fishReport.getByText(
+      'Test Deck Fish Party Example Primary Election Tally Report'
+    );
+    expect(fishReport.getByTestId('total')).toHaveTextContent(
+      'Total Ballots Cast48'
+    );
+
+    expect(printOptions).toMatchObject({ sides: 'one-sided' });
+  });
+});
+
+test('prints appropriate report for general election', async () => {
+  renderInAppContext(<FullTestDeckTallyReportButton />, {
+    electionDefinition: electionFamousNames2021Fixtures.electionDefinition,
+  });
+
+  userEvent.click(await screen.findByText('Print Full Test Deck Tally Report'));
+  await screen.findByText('Printing');
+
+  await expectPrint((printedElement, printOptions) => {
+    printedElement.getByText(
+      'Test Deck Lincoln Municipal General Election Tally Report'
+    );
+    expect(printedElement.getByTestId('total')).toHaveTextContent(
+      'Total Ballots Cast208'
+    );
+
+    expect(printOptions).toMatchObject({ sides: 'one-sided' });
+  });
+});

--- a/frontends/election-manager/src/components/full_test_deck_tally_report_button.tsx
+++ b/frontends/election-manager/src/components/full_test_deck_tally_report_button.tsx
@@ -17,7 +17,6 @@ export function FullTestDeckTallyReportButton(): JSX.Element {
   const { election } = electionDefinition;
 
   const ballots = generateTestDeckBallots({ election });
-  const votes = ballots.map((b) => b.votes);
 
   const afterPrint = useCallback(() => {
     void logger.log(LogEventId.TestDeckTallyReportPrinted, userRole, {
@@ -43,7 +42,7 @@ export function FullTestDeckTallyReportButton(): JSX.Element {
   const fullTestDeckTallyReport = (
     <TestDeckTallyReport
       election={election}
-      votes={[...votes, ...votes, ...votes, ...votes]}
+      testDeckBallots={[...ballots, ...ballots, ...ballots, ...ballots]}
     />
   );
 

--- a/frontends/election-manager/src/components/test_deck_tally_report.tsx
+++ b/frontends/election-manager/src/components/test_deck_tally_report.tsx
@@ -1,53 +1,100 @@
 import React from 'react';
 import {
+  Dictionary,
   Election,
   FullElectionTally,
+  getBallotStyle,
+  PartyId,
   Tally,
   TallyCategory,
-  VotesDict,
   VotingMethod,
 } from '@votingworks/types';
 import { tallyVotesByContest } from '@votingworks/utils';
 import { ElectionManagerTallyReport } from './election_manager_tally_report';
+import {
+  getPartiesWithPrimaryElections,
+  TestDeckBallot,
+} from '../utils/election';
 
 export interface TestDeckTallyReportProps {
   election: Election;
-  votes: VotesDict[];
+  testDeckBallots: TestDeckBallot[];
   precinctId?: string;
+}
+
+function getTallyFromTestDeckBallots({
+  election,
+  testDeckBallots,
+  partyId,
+}: {
+  election: Election;
+  testDeckBallots: TestDeckBallot[];
+  partyId?: PartyId;
+}): Tally {
+  let filteredTestDeckBallots = testDeckBallots;
+
+  if (partyId) {
+    filteredTestDeckBallots = testDeckBallots.filter((testDeckBallot) => {
+      return (
+        getBallotStyle({
+          election,
+          ballotStyleId: testDeckBallot.ballotStyleId,
+        })?.partyId === partyId
+      );
+    });
+  }
+
+  return {
+    numberOfBallotsCounted: filteredTestDeckBallots.length,
+    castVoteRecords: new Set(),
+    contestTallies: tallyVotesByContest({
+      election,
+      votes: filteredTestDeckBallots.map(({ votes }) => votes),
+      filterContestsByParty: partyId,
+    }),
+    ballotCountsByVotingMethod: {
+      [VotingMethod.Precinct]: filteredTestDeckBallots.length,
+      [VotingMethod.Absentee]: 0,
+    },
+  };
 }
 
 export function TestDeckTallyReport({
   election,
-  votes,
+  testDeckBallots,
   precinctId,
 }: TestDeckTallyReportProps): JSX.Element {
-  const tally: Tally = {
-    numberOfBallotsCounted: votes.length,
-    castVoteRecords: new Set(),
-    contestTallies: tallyVotesByContest({
-      election,
-      votes,
-    }),
-    ballotCountsByVotingMethod: {
-      [VotingMethod.Precinct]: votes.length,
-      [VotingMethod.Absentee]: 0,
-    },
-  };
+  const overallTally = getTallyFromTestDeckBallots({
+    election,
+    testDeckBallots,
+  });
 
   const fullElectionTally: FullElectionTally = (() => {
+    const resultsByCategory = new Map();
+
     if (precinctId) {
-      const resultsByCategory = new Map();
       resultsByCategory.set(TallyCategory.Precinct, {
-        [precinctId]: tally,
+        [precinctId]: overallTally,
       });
-      return {
-        overallTally: tally,
-        resultsByCategory,
-      };
     }
+
+    const primaryParties = getPartiesWithPrimaryElections(election);
+    if (primaryParties.length > 1) {
+      const resultsByParty: Dictionary<Tally> = {};
+      for (const party of primaryParties) {
+        resultsByParty[party.id] = getTallyFromTestDeckBallots({
+          election,
+          testDeckBallots,
+          partyId: party.id,
+        });
+      }
+
+      resultsByCategory.set(TallyCategory.Party, resultsByParty);
+    }
+
     return {
-      overallTally: tally,
-      resultsByCategory: new Map(),
+      overallTally,
+      resultsByCategory,
     };
   })();
 

--- a/frontends/election-manager/src/components/test_deck_tally_report.tsx
+++ b/frontends/election-manager/src/components/test_deck_tally_report.tsx
@@ -81,15 +81,26 @@ export function TestDeckTallyReport({
     const primaryParties = getPartiesWithPrimaryElections(election);
     if (primaryParties.length > 1) {
       const resultsByParty: Dictionary<Tally> = {};
+      const resultsByPartyPrecinct: Dictionary<Tally> = {};
       for (const party of primaryParties) {
-        resultsByParty[party.id] = getTallyFromTestDeckBallots({
+        const tally = getTallyFromTestDeckBallots({
           election,
           testDeckBallots,
           partyId: party.id,
         });
+        resultsByParty[party.id] = tally;
+        if (precinctId) {
+          resultsByPartyPrecinct[`${party.id}${precinctId}`] = tally;
+        }
       }
 
       resultsByCategory.set(TallyCategory.Party, resultsByParty);
+      if (precinctId) {
+        resultsByCategory.set(
+          TallyCategory.PartyPrecinct,
+          resultsByPartyPrecinct
+        );
+      }
     }
 
     return {

--- a/frontends/election-manager/src/screens/print_test_deck_screen.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.tsx
@@ -54,7 +54,6 @@ function PrecinctTallyReport({
   onRendered,
 }: PrecinctTallyReportProps): JSX.Element {
   const ballots = generateTestDeckBallots({ election, precinctId });
-  const votes = ballots.map((b) => b.votes);
 
   useEffect(() => {
     const parties = new Set(election.ballotStyles.map((bs) => bs.partyId));
@@ -66,7 +65,7 @@ function PrecinctTallyReport({
   return (
     <TestDeckTallyReport
       election={election}
-      votes={[...votes, ...votes]}
+      testDeckBallots={[...ballots, ...ballots]}
       precinctId={precinctId}
     />
   );

--- a/frontends/election-manager/src/utils/election.ts
+++ b/frontends/election-manager/src/utils/election.ts
@@ -22,7 +22,7 @@ import { BallotMode } from '../config/types';
 
 import { sortBy } from './sort_by';
 
-export interface Ballot {
+export interface TestDeckBallot {
   ballotStyleId: BallotStyleId;
   precinctId: PrecinctId;
   votes: VotesDict;
@@ -248,12 +248,12 @@ interface GenerateTestDeckParams {
 export function generateTestDeckBallots({
   election,
   precinctId,
-}: GenerateTestDeckParams): Ballot[] {
+}: GenerateTestDeckParams): TestDeckBallot[] {
   const precincts: string[] = precinctId
     ? [precinctId]
     : election.precincts.map((p) => p.id);
 
-  const ballots: Ballot[] = [];
+  const ballots: TestDeckBallot[] = [];
 
   for (const currentPrecinctId of precincts) {
     const precinct = find(
@@ -313,8 +313,8 @@ export function generateBlankBallots({
   election: Election;
   precinctId: PrecinctId;
   numBlanks: number;
-}): Ballot[] {
-  const ballots: Ballot[] = [];
+}): TestDeckBallot[] {
+  const ballots: TestDeckBallot[] = [];
 
   const blankBallotStyle = election.ballotStyles.find((bs) =>
     bs.precincts.includes(precinctId)
@@ -344,7 +344,7 @@ export function generateOvervoteBallot({
 }: {
   election: Election;
   precinctId: PrecinctId;
-}): Ballot | undefined {
+}): TestDeckBallot | undefined {
   const precinctBallotStyles = election.ballotStyles.filter((bs) =>
     bs.precincts.includes(precinctId)
   );

--- a/libs/types/src/tallies.ts
+++ b/libs/types/src/tallies.ts
@@ -47,6 +47,7 @@ export enum TallyCategory {
   Party = 'party',
   VotingMethod = 'votingmethod',
   Batch = 'batch',
+  PartyPrecinct = 'party-precinct', // used for test deck tally reports
 }
 
 export interface FullElectionTally {

--- a/libs/utils/src/votes.ts
+++ b/libs/utils/src/votes.ts
@@ -360,6 +360,8 @@ export function computeTallyWithPrecomputedCategories(
         // do nothing no initialization needed
         break;
       /* istanbul ignore next - compile time check for completeness */
+      case TallyCategory.PartyPrecinct:
+        throw new Error('unsupported');
       default:
         throwIllegalValue(tallyCategory);
     }
@@ -532,6 +534,24 @@ export function filterTalliesByParams(
       getEmptyTally()
     );
   }
+
+  // HACK for test deck tallying check for a precomputed tally by party and precinct
+  // The PartyPrecinct tally category is only populated for test deck tallies
+  if (
+    partyId &&
+    precinctId &&
+    !scannerId &&
+    !votingMethod &&
+    !batchId &&
+    resultsByCategory.has(TallyCategory.PartyPrecinct)
+  ) {
+    return (
+      resultsByCategory.get(TallyCategory.PartyPrecinct)?.[
+        `${partyId}${precinctId}`
+      ] || getEmptyTally()
+    );
+  }
+
   const cvrFiles: Set<CastVoteRecord> = new Set();
   const allVotes: VotesDict[] = [];
 


### PR DESCRIPTION
Fixes tally reports for L&A Test decks, by pulling in https://github.com/votingworks/vxsuite/pull/2818/commits which fixes the overall tally report in the first commit, and the second commit has a hack that fixes the tally reports by precinct and party. That one is much hackier as those reports are NOT precomputed and generated on the fly in general and it changes it to only "precompute" for test decks but not non-test decks. 