### PR TITLE
base test deck tally on mock CVRs

### DIFF
--- a/frontends/election-manager/src/components/full_test_deck_tally_report_button.tsx
+++ b/frontends/election-manager/src/components/full_test_deck_tally_report_button.tsx
@@ -17,7 +17,6 @@ export function FullTestDeckTallyReportButton(): JSX.Element {
   const { election } = electionDefinition;
 
   const ballots = generateTestDeckBallots({ election });
-  const votes = ballots.map((b) => b.votes);
 
   const afterPrint = useCallback(() => {
     void logger.log(LogEventId.TestDeckTallyReportPrinted, userRole, {
@@ -43,7 +42,7 @@ export function FullTestDeckTallyReportButton(): JSX.Element {
   const fullTestDeckTallyReport = (
     <TestDeckTallyReport
       election={election}
-      votes={[...votes, ...votes, ...votes, ...votes]}
+      testDeckBallots={[...ballots, ...ballots, ...ballots, ...ballots]}
     />
   );
 

--- a/frontends/election-manager/src/components/test_deck_tally_report.tsx
+++ b/frontends/election-manager/src/components/test_deck_tally_report.tsx
@@ -1,55 +1,63 @@
 import React from 'react';
 import {
+  Candidate,
+  CastVoteRecord,
+  Dictionary,
   Election,
-  FullElectionTally,
-  Tally,
   TallyCategory,
   VotesDict,
-  VotingMethod,
 } from '@votingworks/types';
-import { tallyVotesByContest } from '@votingworks/utils';
+import { computeTallyWithPrecomputedCategories } from '@votingworks/utils';
 import { ElectionManagerTallyReport } from './election_manager_tally_report';
+import { TestDeckBallot } from '../utils/election';
 
 export interface TestDeckTallyReportProps {
   election: Election;
-  votes: VotesDict[];
+  testDeckBallots: TestDeckBallot[];
   precinctId?: string;
+}
+
+function votesDictToIdDict(votesDict: VotesDict): Dictionary<string[]> {
+  const idDict: Dictionary<string[]> = {};
+  for (const [contestId, votes] of Object.entries(votesDict)) {
+    if (!votes) continue;
+    if (votes.length === 0) {
+      idDict[contestId] = [];
+    }
+    if (typeof votes[0] === 'string') {
+      idDict[contestId] = votes as unknown as string[];
+    } else {
+      idDict[contestId] = (votes as unknown as Candidate[]).map((v) => v.id);
+    }
+  }
+  return idDict;
 }
 
 export function TestDeckTallyReport({
   election,
-  votes,
+  testDeckBallots,
   precinctId,
 }: TestDeckTallyReportProps): JSX.Element {
-  const tally: Tally = {
-    numberOfBallotsCounted: votes.length,
-    castVoteRecords: new Set(),
-    contestTallies: tallyVotesByContest({
-      election,
-      votes,
-    }),
-    ballotCountsByVotingMethod: {
-      [VotingMethod.Precinct]: votes.length,
-      [VotingMethod.Absentee]: 0,
-    },
-  };
-
-  const fullElectionTally: FullElectionTally = (() => {
-    if (precinctId) {
-      const resultsByCategory = new Map();
-      resultsByCategory.set(TallyCategory.Precinct, {
-        [precinctId]: tally,
-      });
+  const castVoteRecords: CastVoteRecord[] = testDeckBallots.map(
+    (testDeckBallot) => {
       return {
-        overallTally: tally,
-        resultsByCategory,
+        _ballotStyleId: testDeckBallot.ballotStyleId,
+        _batchId: 'test-deck',
+        _batchLabel: 'Test Deck',
+        _scannerId: 'test-deck',
+        _ballotType: 'standard',
+        _precinctId: testDeckBallot.precinctId,
+        _testBallot: true,
+        ...votesDictToIdDict(testDeckBallot.votes),
       };
     }
-    return {
-      overallTally: tally,
-      resultsByCategory: new Map(),
-    };
-  })();
+  );
+
+  const fullElectionTally = computeTallyWithPrecomputedCategories(
+    election,
+    new Set(castVoteRecords),
+    [TallyCategory.Precinct, TallyCategory.Party]
+  );
 
   return (
     <ElectionManagerTallyReport

--- a/frontends/election-manager/src/screens/print_test_deck_screen.tsx
+++ b/frontends/election-manager/src/screens/print_test_deck_screen.tsx
@@ -54,7 +54,6 @@ function PrecinctTallyReport({
   onRendered,
 }: PrecinctTallyReportProps): JSX.Element {
   const ballots = generateTestDeckBallots({ election, precinctId });
-  const votes = ballots.map((b) => b.votes);
 
   useEffect(() => {
     const parties = new Set(election.ballotStyles.map((bs) => bs.partyId));
@@ -66,7 +65,7 @@ function PrecinctTallyReport({
   return (
     <TestDeckTallyReport
       election={election}
-      votes={[...votes, ...votes]}
+      testDeckBallots={[...ballots, ...ballots]}
       precinctId={precinctId}
     />
   );

--- a/frontends/election-manager/src/utils/election.ts
+++ b/frontends/election-manager/src/utils/election.ts
@@ -22,7 +22,7 @@ import { BallotMode } from '../config/types';
 
 import { sortBy } from './sort_by';
 
-export interface Ballot {
+export interface TestDeckBallot {
   ballotStyleId: BallotStyleId;
   precinctId: PrecinctId;
   votes: VotesDict;
@@ -248,12 +248,12 @@ interface GenerateTestDeckParams {
 export function generateTestDeckBallots({
   election,
   precinctId,
-}: GenerateTestDeckParams): Ballot[] {
+}: GenerateTestDeckParams): TestDeckBallot[] {
   const precincts: string[] = precinctId
     ? [precinctId]
     : election.precincts.map((p) => p.id);
 
-  const ballots: Ballot[] = [];
+  const ballots: TestDeckBallot[] = [];
 
   for (const currentPrecinctId of precincts) {
     const precinct = find(
@@ -313,8 +313,8 @@ export function generateBlankBallots({
   election: Election;
   precinctId: PrecinctId;
   numBlanks: number;
-}): Ballot[] {
-  const ballots: Ballot[] = [];
+}): TestDeckBallot[] {
+  const ballots: TestDeckBallot[] = [];
 
   const blankBallotStyle = election.ballotStyles.find((bs) =>
     bs.precincts.includes(precinctId)
@@ -344,7 +344,7 @@ export function generateOvervoteBallot({
 }: {
   election: Election;
   precinctId: PrecinctId;
-}): Ballot | undefined {
+}): TestDeckBallot | undefined {
   const precinctBallotStyles = election.ballotStyles.filter((bs) =>
     bs.precincts.includes(precinctId)
   );


### PR DESCRIPTION
## Overview

Correct how we determine test deck tallies on `m16-dev`. Currently we create a full election tally and try to "manually" precompute the important subtallies. Instead, we can convert each test ballot to a mock CVR and use the election tally utilities to create subtallies as the system normally would.

Addresses bug in 2023 MS primary in which primary test decks showed up with 0 counts.
