### PR TITLE
Add signing to new CVR export function

### DIFF
--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -214,5 +214,7 @@ test('saveBallotPackageToUsb when no USB drive', async () => {
   await configureMachine(apiClient, auth, electionDefinition);
 
   const response = await apiClient.saveBallotPackageToUsb();
-  expect(response).toEqual(err('no_usb_drive'));
+  expect(response).toEqual(
+    err({ type: 'missing-usb-drive', message: 'No USB drive found' })
+  );
 });

--- a/apps/admin/backend/src/cvr_files.ts
+++ b/apps/admin/backend/src/cvr_files.ts
@@ -473,8 +473,8 @@ export async function addCastVoteRecordReport({
 
   const artifactAuthenticationResult =
     await authenticateArtifactUsingSignatureFile({
-      type: 'cast_vote_records',
-      path: reportDirectoryPath,
+      type: 'legacy_cast_vote_records',
+      directoryPath: reportDirectoryPath,
     });
   if (
     artifactAuthenticationResult.isErr() &&

--- a/apps/admin/frontend/src/components/export_election_ballot_package_modal_button.test.tsx
+++ b/apps/admin/frontend/src/components/export_election_ballot_package_modal_button.test.tsx
@@ -139,12 +139,16 @@ test('Modal renders error message appropriately', async () => {
   fireEvent.click(getByText('Save Ballot Package'));
   await waitFor(() => getByText('Save'));
 
-  apiMock.expectSaveBallotPackageToUsb(err('no_usb_drive'));
+  apiMock.expectSaveBallotPackageToUsb(
+    err({ type: 'missing-usb-drive', message: '' })
+  );
   userEvent.click(screen.getButton('Save'));
 
   await waitFor(() => getByText('Failed to Save Ballot Package'));
   expect(queryAllByTestId('modal')).toHaveLength(1);
-  expect(queryAllByText(/An error occurred: No USB drive/)).toHaveLength(1);
+  expect(
+    queryAllByText(/An error occurred: No USB drive detected/)
+  ).toHaveLength(1);
 
   fireEvent.click(getByText('Close'));
   expect(queryAllByTestId('modal')).toHaveLength(0);

--- a/apps/admin/frontend/src/components/export_election_ballot_package_modal_button.tsx
+++ b/apps/admin/frontend/src/components/export_election_ballot_package_modal_button.tsx
@@ -6,7 +6,7 @@ import {
 } from '@votingworks/utils';
 import { assert, throwIllegalValue } from '@votingworks/basics';
 import { Button, Modal, P, UsbControllerButton } from '@votingworks/ui';
-import { BallotPackageExportError } from '@votingworks/types';
+import type { ExportDataError } from '@votingworks/admin-backend';
 
 import { saveBallotPackageToUsb as saveBallotPackageToUsbBase } from '../api';
 import { AppContext } from '../contexts/app_context';
@@ -22,10 +22,13 @@ type SaveState =
   | { state: 'unsaved' }
   | { state: 'saving' }
   | { state: 'saved' }
-  | { state: 'error'; error: BallotPackageExportError };
+  | { state: 'error'; error: ExportDataError };
 
-const ErrorMessages: Record<BallotPackageExportError, string> = {
-  no_usb_drive: 'No USB drive detected',
+const ErrorMessages: Record<ExportDataError['type'], string> = {
+  'file-system-error': 'Error reading from USB',
+  'missing-usb-drive': 'No USB drive detected',
+  'permission-denied': 'Error reading from USB',
+  'relative-file-path': 'Error reading from USB',
 };
 
 export function ExportElectionBallotPackageModalButton(): JSX.Element {
@@ -148,7 +151,9 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
     case 'error': {
       actions = <Button onPress={closeModal}>Close</Button>;
       title = 'Failed to Save Ballot Package';
-      mainContent = <P>An error occurred: {ErrorMessages[saveState.error]}.</P>;
+      mainContent = (
+        <P>An error occurred: {ErrorMessages[saveState.error.type]}.</P>
+      );
       break;
     }
 

--- a/apps/admin/frontend/test/helpers/api_mock.ts
+++ b/apps/admin/frontend/test/helpers/api_mock.ts
@@ -14,8 +14,9 @@ import type {
   TallyReportResults,
   WriteInAdjudicationQueueMetadata,
   WriteInImageView,
+  ExportDataError,
 } from '@votingworks/admin-backend';
-import { ok } from '@votingworks/basics';
+import { Result, ok } from '@votingworks/basics';
 import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
 import {
   fakeElectionManagerUser,
@@ -23,7 +24,6 @@ import {
   fakeSystemAdministratorUser,
 } from '@votingworks/test-utils';
 import {
-  BallotPackageExportResult,
   ContestId,
   DEFAULT_SYSTEM_SETTINGS,
   DippedSmartCardAuth,
@@ -322,7 +322,7 @@ export function createApiMock(
       apiClient.getManualResultsMetadata.expectCallWith().resolves(records);
     },
 
-    expectSaveBallotPackageToUsb(result: BallotPackageExportResult = ok()) {
+    expectSaveBallotPackageToUsb(result: Result<void, ExportDataError> = ok()) {
       apiClient.saveBallotPackageToUsb.expectCallWith().resolves(result);
     },
 

--- a/libs/auth/src/apdu.ts
+++ b/libs/auth/src/apdu.ts
@@ -79,9 +79,9 @@ function splitEvery2Characters(s: string): string[] {
 }
 
 /**
- * Input to a {@link CommandAdpu}.
+ * The input to a {@link CommandApdu}
  */
-export type CommandAdpuInput =
+export type CommandApduInput =
   | {
       cla?: { chained?: boolean; secure?: boolean };
       ins: Byte;
@@ -118,7 +118,7 @@ export class CommandApdu {
   /** Data */
   private readonly data: Buffer;
 
-  constructor(input: CommandAdpuInput) {
+  constructor(input: CommandApduInput) {
     const cla = this.determineCla(input.cla);
     const lc = 'lc' in input ? input.lc : input.data.length;
     const data = 'lc' in input ? Buffer.of() : input.data;

--- a/libs/auth/src/artifact_authentication.test.ts
+++ b/libs/auth/src/artifact_authentication.test.ts
@@ -1,37 +1,85 @@
 import fs from 'fs';
 import path from 'path';
 import { dirSync } from 'tmp';
-import { err, ok } from '@votingworks/basics';
+import { assert, err, ok } from '@votingworks/basics';
+import { CastVoteRecordExportMetadata, CVR } from '@votingworks/types';
 
 import { getTestFilePath } from '../test/utils';
 import {
-  Artifact,
+  ArtifactToExport,
+  ArtifactToImport,
   authenticateArtifactUsingSignatureFile,
-  writeSignatureFile,
+  prepareSignatureFile,
 } from './artifact_authentication';
 import { ArtifactAuthenticationConfig } from './config';
-import * as shell from './shell';
 
 let tempDirectoryPath: string;
-let tempFile1Path: string;
-let tempFile2Path: string;
-let tempSubDirectoryPath: string;
-let tempFile3Path: string;
+let mockElectionPackage: {
+  artifactToExport: ArtifactToExport;
+  artifactToImport: ArtifactToImport;
+};
+let mockCastVoteRecords: {
+  artifactToExport: ArtifactToExport;
+  artifactToImport: ArtifactToImport;
+};
 
 beforeEach(() => {
   tempDirectoryPath = dirSync().name;
-  tempFile1Path = path.join(tempDirectoryPath, 'file-1.txt');
-  tempFile2Path = path.join(tempDirectoryPath, 'file-2.txt');
-  tempSubDirectoryPath = path.join(tempDirectoryPath, 'sub-dir');
-  tempFile3Path = path.join(tempSubDirectoryPath, 'file-3.txt');
-  fs.writeFileSync(tempFile1Path, 'abcd');
-  fs.writeFileSync(tempFile2Path, 'efgh');
-  fs.mkdirSync(tempSubDirectoryPath);
-  fs.writeFileSync(tempFile3Path, 'ijkl');
+
+  // Prepare mock election package
+  const mockElectionPackagePath = path.join(
+    tempDirectoryPath,
+    'election-package.zip'
+  );
+  fs.writeFileSync(mockElectionPackagePath, 'abcd');
+  mockElectionPackage = {
+    artifactToExport: {
+      type: 'election_package',
+      filePath: mockElectionPackagePath,
+    },
+    artifactToImport: {
+      type: 'election_package',
+      filePath: mockElectionPackagePath,
+    },
+  };
+
+  // Prepare mock cast vote records
+  const mockCastVoteRecordsPath = path.join(
+    tempDirectoryPath,
+    'cast-vote-records'
+  );
+  fs.mkdirSync(mockCastVoteRecordsPath);
+  fs.mkdirSync(path.join(mockCastVoteRecordsPath, '1'));
+  fs.writeFileSync(path.join(mockCastVoteRecordsPath, '1', 'a'), 'abcd');
+  fs.writeFileSync(path.join(mockCastVoteRecordsPath, '1', 'b'), 'efgh');
+  fs.mkdirSync(path.join(mockCastVoteRecordsPath, '2'));
+  fs.writeFileSync(path.join(mockCastVoteRecordsPath, '2', 'a'), 'ijkl');
+  fs.writeFileSync(path.join(mockCastVoteRecordsPath, '2', 'b'), 'mnop');
+  const mockCastVoteRecordExportMetadata: CastVoteRecordExportMetadata = {
+    arePollsClosed: true,
+    castVoteRecordReportMetadata: {} as unknown as CVR.CastVoteRecordReport,
+    castVoteRecordRootHash: 'abcd1234',
+  };
+  fs.writeFileSync(
+    path.join(mockCastVoteRecordsPath, 'metadata.json'),
+    JSON.stringify(mockCastVoteRecordExportMetadata)
+  );
+  mockCastVoteRecords = {
+    artifactToExport: {
+      type: 'cast_vote_records',
+      context: 'export',
+      directoryName: path.basename(mockCastVoteRecordsPath),
+      metadataFileContents: JSON.stringify(mockCastVoteRecordExportMetadata),
+    },
+    artifactToImport: {
+      type: 'cast_vote_records',
+      context: 'import',
+      directoryPath: mockCastVoteRecordsPath,
+    },
+  };
 });
 
 afterEach(() => {
-  jest.restoreAllMocks(); // Clear spies
   fs.rmSync(tempDirectoryPath, { recursive: true });
 });
 
@@ -66,7 +114,10 @@ const vxScanTestConfig: ArtifactAuthenticationConfig = {
  * being used before they're assigned to in the beforeEach block, so we use functions to defer
  * variable access.
  */
-type ArtifactGenerator = () => Artifact;
+type ArtifactGenerator = () => {
+  artifactToExport: ArtifactToExport;
+  artifactToImport: ArtifactToImport;
+};
 
 test.each<{
   description: string;
@@ -75,35 +126,36 @@ test.each<{
   importingMachineConfig: ArtifactAuthenticationConfig;
 }>([
   {
-    description: 'ballot package',
-    artifactGenerator: () => ({
-      type: 'ballot_package',
-      path: tempFile1Path,
-    }),
-    exportingMachineConfig: vxAdminTestConfig,
-    importingMachineConfig: vxScanTestConfig,
-  },
-  {
     description: 'cast vote records',
-    artifactGenerator: () => ({
-      type: 'cast_vote_records',
-      path: tempDirectoryPath,
-    }),
+    artifactGenerator: () => mockCastVoteRecords,
     exportingMachineConfig: vxScanTestConfig,
     importingMachineConfig: vxAdminTestConfig,
   },
+  {
+    description: 'election package',
+    artifactGenerator: () => mockElectionPackage,
+    exportingMachineConfig: vxAdminTestConfig,
+    importingMachineConfig: vxScanTestConfig,
+  },
 ])(
-  'Writing signature file and authenticating artifact using signature file - $description',
+  'Preparing signature file and authenticating artifact using signature file - $description',
   async ({
     artifactGenerator,
     exportingMachineConfig,
     importingMachineConfig,
   }) => {
-    const artifact = artifactGenerator();
-    await writeSignatureFile(artifact, undefined, exportingMachineConfig);
+    const { artifactToExport, artifactToImport } = artifactGenerator();
+    const signatureFile = await prepareSignatureFile(
+      artifactToExport,
+      exportingMachineConfig
+    );
+    fs.writeFileSync(
+      path.join(tempDirectoryPath, signatureFile.fileName),
+      signatureFile.fileContents
+    );
     expect(
       await authenticateArtifactUsingSignatureFile(
-        artifact,
+        artifactToImport,
         importingMachineConfig
       )
     ).toEqual(ok());
@@ -118,34 +170,35 @@ test.each<{
   tamperFn: () => void;
 }>([
   {
-    description: 'ballot package',
-    artifactGenerator: () => ({
-      type: 'ballot_package',
-      path: tempFile1Path,
-    }),
+    description: 'election package',
+    artifactGenerator: () => mockElectionPackage,
     exportingMachineConfig: vxAdminTestConfig,
     importingMachineConfig: vxScanTestConfig,
-    tamperFn: () => fs.appendFileSync(tempFile1Path, 'e'),
+    tamperFn: () => {
+      assert(mockElectionPackage.artifactToImport.type === 'election_package');
+      fs.appendFileSync(mockElectionPackage.artifactToImport.filePath, 'e');
+    },
   },
   {
-    description: 'cast vote records, file is modified',
-    artifactGenerator: () => ({
-      type: 'cast_vote_records',
-      path: tempDirectoryPath,
-    }),
+    description: 'cast vote records',
+    artifactGenerator: () => mockCastVoteRecords,
     exportingMachineConfig: vxScanTestConfig,
     importingMachineConfig: vxAdminTestConfig,
-    tamperFn: () => fs.appendFileSync(tempFile1Path, 'e'),
-  },
-  {
-    description: 'cast vote records, file is deleted',
-    artifactGenerator: () => ({
-      type: 'cast_vote_records',
-      path: tempDirectoryPath,
-    }),
-    exportingMachineConfig: vxScanTestConfig,
-    importingMachineConfig: vxAdminTestConfig,
-    tamperFn: () => fs.rmSync(tempFile2Path),
+    tamperFn: () => {
+      assert(mockCastVoteRecords.artifactToImport.type === 'cast_vote_records');
+      const metadataFilePath = path.join(
+        mockCastVoteRecords.artifactToImport.directoryPath,
+        'metadata.json'
+      );
+      const metadataFileContents = fs
+        .readFileSync(metadataFilePath)
+        .toString('utf-8');
+      const metadataFileContentsAltered = JSON.stringify({
+        ...JSON.parse(metadataFileContents),
+        castVoteRecordRootHash: 'efgh5678',
+      });
+      fs.writeFileSync(metadataFilePath, metadataFileContentsAltered);
+    },
   },
 ])(
   'Detecting that an artifact has been tampered with - $description',
@@ -155,40 +208,21 @@ test.each<{
     importingMachineConfig,
     tamperFn,
   }) => {
-    const artifact = artifactGenerator();
-    await writeSignatureFile(artifact, undefined, exportingMachineConfig);
+    const { artifactToExport, artifactToImport } = artifactGenerator();
+    const signatureFile = await prepareSignatureFile(
+      artifactToExport,
+      exportingMachineConfig
+    );
+    fs.writeFileSync(
+      path.join(tempDirectoryPath, signatureFile.fileName),
+      signatureFile.fileContents
+    );
     tamperFn();
     expect(
       await authenticateArtifactUsingSignatureFile(
-        artifact,
+        artifactToImport,
         importingMachineConfig
       )
-    ).toEqual(
-      err(
-        new Error(`Error authenticating ${artifact.path} using signature file`)
-      )
-    );
+    ).toEqual(err(expect.any(Error)));
   }
 );
-
-test('Writing signature file to a USB drive', async () => {
-  const mockUsbDriveMountPoint = path.join(tempDirectoryPath, 'usb-drive');
-  fs.mkdirSync(mockUsbDriveMountPoint);
-  jest.spyOn(shell, 'runCommand');
-
-  const config: ArtifactAuthenticationConfig = {
-    ...vxScanTestConfig,
-    isFileOnRemovableDeviceOverride: (filePath: string) =>
-      filePath.startsWith(mockUsbDriveMountPoint),
-  };
-  await writeSignatureFile(
-    { type: 'cast_vote_records', path: tempDirectoryPath },
-    mockUsbDriveMountPoint,
-    config
-  );
-  expect(shell.runCommand).toHaveBeenCalledWith([
-    'sync',
-    '-f',
-    expect.stringMatching(new RegExp(`^${mockUsbDriveMountPoint}`)),
-  ]);
-});

--- a/libs/auth/src/artifact_authentication.ts
+++ b/libs/auth/src/artifact_authentication.ts
@@ -286,7 +286,7 @@ function constructSignatureFilePath(artifact: ArtifactToImport): string {
 }
 
 // eslint-disable-next-line @typescript-eslint/require-await
-async function performArtifactSpecificValidation(
+async function performArtifactSpecificAuthenticationChecks(
   artifact: ArtifactToImport
 ): Promise<void> {
   switch (artifact.type) {
@@ -345,7 +345,7 @@ export async function authenticateArtifactUsingSignatureFile(
       artifact,
       artifactSignatureBundle
     );
-    await performArtifactSpecificValidation(artifact);
+    await performArtifactSpecificAuthenticationChecks(artifact);
   } catch {
     // TODO: Log raw error
     return err(

--- a/libs/backend/src/ballot_package/ballot_package_io.test.ts
+++ b/libs/backend/src/ballot_package/ballot_package_io.test.ts
@@ -106,8 +106,10 @@ test('readBallotPackageFromUsb can read a ballot package from usb', async () => 
   );
   expect(authenticateArtifactUsingSignatureFile).toHaveBeenCalledTimes(1);
   expect(authenticateArtifactUsingSignatureFile).toHaveBeenNthCalledWith(1, {
-    type: 'ballot_package',
-    path: expect.stringContaining('/ballot-packages/test-ballot-package.zip'),
+    type: 'election_package',
+    filePath: expect.stringContaining(
+      '/ballot-packages/test-ballot-package.zip'
+    ),
   });
 });
 

--- a/libs/backend/src/ballot_package/ballot_package_io.ts
+++ b/libs/backend/src/ballot_package/ballot_package_io.ts
@@ -96,8 +96,8 @@ export async function readBallotPackageFromUsb(
 
   const artifactAuthenticationResult =
     await authenticateArtifactUsingSignatureFile({
-      type: 'ballot_package',
-      path: filepathResult.ok(),
+      type: 'election_package',
+      filePath: filepathResult.ok(),
     });
   if (
     artifactAuthenticationResult.isErr() &&

--- a/libs/backend/src/exporter.ts
+++ b/libs/backend/src/exporter.ts
@@ -4,6 +4,7 @@ import { any } from 'micromatch';
 import { isAbsolute, join, normalize, parse } from 'path';
 import { Readable } from 'stream';
 import { createReadStream, lstatSync } from 'fs';
+import { Buffer } from 'buffer';
 import { splitToFiles } from './split';
 import { execFile } from './utils/exec';
 import { UsbDrive } from './get_usb_drives';
@@ -59,7 +60,7 @@ export class Exporter {
    */
   async exportData(
     path: string,
-    data: string | NodeJS.ReadableStream,
+    data: string | Buffer | NodeJS.ReadableStream,
     {
       maximumFileSize,
     }: {
@@ -78,7 +79,9 @@ export class Exporter {
     await mkdir(pathParts.dir, { recursive: true });
 
     const paths = await splitToFiles(
-      typeof data === 'string' ? Readable.from(data) : data,
+      typeof data === 'string' || Buffer.isBuffer(data)
+        ? Readable.from(data)
+        : data,
       {
         size: maximumFileSize ?? Infinity,
         nextPath: (index) =>
@@ -114,7 +117,7 @@ export class Exporter {
   async exportDataToUsbDrive(
     bucket: string,
     name: string,
-    data: string | NodeJS.ReadableStream,
+    data: string | Buffer | NodeJS.ReadableStream,
     {
       machineDirectoryToWriteToFirst,
       maximumFileSize = MAXIMUM_FAT32_FILE_SIZE,

--- a/libs/backend/src/scan/globals.ts
+++ b/libs/backend/src/scan/globals.ts
@@ -30,7 +30,7 @@ const defaultAllowedExportPatterns =
       ]
     : [
         '/media/**/*', // Real USB drive location
-        '/tmp/**/*', // Where data is first written for signature file creation
+        '/tmp/**/*', // Where data is sometimes first written for signature file creation
       ];
 
 /**

--- a/libs/types/src/ballot_package.ts
+++ b/libs/types/src/ballot_package.ts
@@ -1,5 +1,3 @@
-import { Result } from '@votingworks/basics';
-
 import {
   BallotStyleId,
   ContestId,
@@ -26,6 +24,3 @@ export interface BallotConfig extends BallotStyleData {
   isLiveMode: boolean;
   isAbsentee: boolean;
 }
-
-export type BallotPackageExportError = 'no_usb_drive';
-export type BallotPackageExportResult = Result<void, BallotPackageExportError>;

--- a/libs/types/src/cast_vote_records.ts
+++ b/libs/types/src/cast_vote_records.ts
@@ -1,3 +1,4 @@
+import { CastVoteRecordReport } from './cdf/cast-vote-records';
 import { BallotId, BallotStyleId, PrecinctId } from './election';
 import { Dictionary } from './generic';
 
@@ -19,4 +20,15 @@ export interface CastVoteRecord
   readonly _batchLabel: string;
   readonly _testBallot: boolean;
   readonly _scannerId: string;
+}
+
+/**
+ * Metadata stored in the top-level metadata file for a cast vote record export
+ */
+export interface CastVoteRecordExportMetadata {
+  arePollsClosed?: boolean;
+  /** Global data relevant to all cast vote records in an export, e.g. election info */
+  castVoteRecordReportMetadata: CastVoteRecordReport;
+  /** A hash of all cast vote record files in an export */
+  castVoteRecordRootHash: string;
 }

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -3,7 +3,7 @@ export * from './auth';
 export * from './ballot_package';
 export * from './byte';
 export * from './hmpb';
-export * from './cast_vote_record';
+export * from './cast_vote_records';
 export * as EventLogging from './cdf/election-event-logging';
 export * as CVR from './cdf/cast-vote-records';
 export * as BallotDefinition from './cdf/ballot-definition';

--- a/libs/types/src/tallies.ts
+++ b/libs/types/src/tallies.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { CastVoteRecord } from './cast_vote_record';
+import { CastVoteRecord } from './cast_vote_records';
 import { Candidate, AnyContest } from './election';
 import { Dictionary } from './generic';
 


### PR DESCRIPTION
_Easiest reviewed by commit_

## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/3838

This PR adds signing to the new CVR export function for continuous export. Alongside each CVR export directory will now be a `.vxsig` file that contains a signature of the export's top-level metadata file, where that metadata file further contains a hash of all the contents of the CVR export directory. (The hashing logic is coming in its own PR.) To accomplish this, I made a number of changes to artifact auth functions in the auth lib, highlighted in PR comments.

## Testing Plan

- [x] Updated automated tests
- [x] Tested election package export and import manually 
- [x] Tested CVR export and import manually

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A