### PR TITLE
Implement Merkle-tree-backed scheme for efficient hashing of continuously exported CVRs

### DIFF
--- a/apps/scan/backend/schema.sql
+++ b/apps/scan/backend/schema.sql
@@ -63,3 +63,16 @@ create table export_directory_name (
   id integer primary key check (id = 1),
   export_directory_name text not null
 );
+
+create table cvr_hashes (
+  cvr_id_level_1_prefix text not null,
+  cvr_id_level_2_prefix text not null,
+  cvr_id text not null,
+  cvr_hash text not null
+);
+
+create unique index idx_cvr_hashes ON cvr_hashes (
+  cvr_id_level_1_prefix,
+  cvr_id_level_2_prefix,
+  cvr_id
+);

--- a/apps/scan/backend/schema.sql
+++ b/apps/scan/backend/schema.sql
@@ -73,8 +73,13 @@ create table cvr_hashes (
     length(cvr_id_level_2_prefix) = 2 or
     length(cvr_id_level_2_prefix) = 0
   ),
-  cvr_id text not null,
-  cvr_hash text not null
+  cvr_id text not null check (
+    length(cvr_id) = 36 or
+    length(cvr_id) = 0
+  ),
+  cvr_hash text not null check (
+    length(cvr_hash) = 64
+  )
 );
 
 create unique index idx_cvr_hashes ON cvr_hashes (

--- a/apps/scan/backend/schema.sql
+++ b/apps/scan/backend/schema.sql
@@ -65,8 +65,14 @@ create table export_directory_name (
 );
 
 create table cvr_hashes (
-  cvr_id_level_1_prefix text not null,
-  cvr_id_level_2_prefix text not null,
+  cvr_id_level_1_prefix text not null check (
+    length(cvr_id_level_1_prefix) = 1 or
+    length(cvr_id_level_1_prefix) = 0
+  ),
+  cvr_id_level_2_prefix text not null check (
+    length(cvr_id_level_2_prefix) = 2 or
+    length(cvr_id_level_2_prefix) = 0
+  ),
   cvr_id text not null,
   cvr_hash text not null
 );

--- a/apps/scan/backend/src/store.test.ts
+++ b/apps/scan/backend/src/store.test.ts
@@ -23,6 +23,7 @@ import {
   electionGridLayoutNewHampshireAmherstFixtures,
   electionMinimalExhaustiveSampleFixtures,
 } from '@votingworks/fixtures';
+import { sha256 } from 'js-sha256';
 import { zeroRect } from '../test/fixtures/zero_rect';
 import { Store } from './store';
 
@@ -864,4 +865,21 @@ test('getExportDirectoryName and setExportDirectoryName', () => {
   expect(store.getExportDirectoryName()).toEqual(exportDirectoryName1);
   store.setExportDirectoryName(exportDirectoryName2);
   expect(store.getExportDirectoryName()).toEqual(exportDirectoryName2);
+});
+
+test('getCastVoteRecordRootHash, updateCastVoteRecordHashes, and clearCastVoteRecordHashes', () => {
+  const store = Store.memoryStore();
+
+  // Just test that the store has been wired properly. Rely on libs/auth tests for more detailed
+  // coverage of hashing logic.
+  expect(store.getCastVoteRecordRootHash()).toEqual('');
+  store.updateCastVoteRecordHashes(
+    'abcd1234-0000-0000-0000-000000000000',
+    sha256('')
+  );
+  expect(store.getCastVoteRecordRootHash()).toEqual(
+    sha256(sha256(sha256(sha256(''))))
+  );
+  store.clearCastVoteRecordHashes();
+  expect(store.getCastVoteRecordRootHash()).toEqual('');
 });

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -33,6 +33,11 @@ import { DateTime } from 'luxon';
 import { join } from 'path';
 import { v4 as uuid } from 'uuid';
 import { ResultSheet } from '@votingworks/backend';
+import {
+  clearCastVoteRecordHashes,
+  getCastVoteRecordRootHash,
+  updateCastVoteRecordHashes,
+} from '@votingworks/auth';
 import { sheetRequiresAdjudication } from './sheet_requires_adjudication';
 import { rootDebug } from './util/debug';
 
@@ -938,23 +943,15 @@ export class Store {
     );
   }
 
-  //
-  // Stubs
-  //
-
-  /* c8 ignore start */
-
   getCastVoteRecordRootHash(): string {
-    return '';
+    return getCastVoteRecordRootHash(this.client);
   }
 
-  updateCastVoteRecordHashes(): void {
-    return undefined;
+  updateCastVoteRecordHashes(cvrId: string, cvrHash: string): void {
+    updateCastVoteRecordHashes(this.client, cvrId, cvrHash);
   }
 
   clearCastVoteRecordHashes(): void {
-    return undefined;
+    clearCastVoteRecordHashes(this.client);
   }
-
-  /* c8 ignore end */
 }

--- a/libs/auth/package.json
+++ b/libs/auth/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@votingworks/basics": "workspace:*",
+    "@votingworks/db": "workspace:*",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/logging": "workspace:*",
     "@votingworks/types": "workspace:*",

--- a/libs/auth/src/artifact_authentication.test.ts
+++ b/libs/auth/src/artifact_authentication.test.ts
@@ -27,7 +27,11 @@ jest.mock('@votingworks/types', (): typeof import('@votingworks/types') => ({
  * The root hash for the mock cast vote records created in the beforeEach block
  */
 const expectedCastVoteRecordRootHash =
-  'fd7e7d5ef2afde3f15a65a2f44d457d3c5b2f097bbdb6379a71946e45af262b5';
+  '9136de224abc5d5c84100eecbcb8e4f2de40a7d79be9d1b5cfad46f4fffe54c2';
+
+const cvrId1 = 'a1234567-0000-0000-0000-000000000000';
+const cvrId2 = 'a2345678-0000-0000-0000-000000000000';
+const cvrId3 = 'a3456789-0000-0000-0000-000000000000';
 
 let tempDirectoryPath: string;
 let castVoteRecords: {
@@ -54,13 +58,13 @@ beforeEach(() => {
     'cast-vote-record-export'
   );
   fs.mkdirSync(castVoteRecordExportDirectoryPath);
-  fs.mkdirSync(path.join(castVoteRecordExportDirectoryPath, '1234'));
-  fs.mkdirSync(path.join(castVoteRecordExportDirectoryPath, '2345'));
+  fs.mkdirSync(path.join(castVoteRecordExportDirectoryPath, cvrId1));
+  fs.mkdirSync(path.join(castVoteRecordExportDirectoryPath, cvrId2));
   for (const { directoryName, fileName, fileContents } of [
-    { directoryName: '1234', fileName: 'a', fileContents: 'a1' },
-    { directoryName: '1234', fileName: 'b', fileContents: 'b1' },
-    { directoryName: '2345', fileName: 'a', fileContents: 'a2' },
-    { directoryName: '2345', fileName: 'b', fileContents: 'b2' },
+    { directoryName: cvrId1, fileName: 'a', fileContents: 'a1' },
+    { directoryName: cvrId1, fileName: 'b', fileContents: 'b1' },
+    { directoryName: cvrId2, fileName: 'a', fileContents: 'a2' },
+    { directoryName: cvrId2, fileName: 'b', fileContents: 'b2' },
   ]) {
     fs.writeFileSync(
       path.join(castVoteRecordExportDirectoryPath, directoryName, fileName),
@@ -230,7 +234,7 @@ test.each<{
     tamperFn: () => {
       assert(castVoteRecords.artifactToImport.type === 'cast_vote_records');
       const { directoryPath } = castVoteRecords.artifactToImport;
-      fs.appendFileSync(path.join(directoryPath, '1234/a'), '!');
+      fs.appendFileSync(path.join(directoryPath, cvrId1, 'a'), '!');
     },
   },
   {
@@ -241,7 +245,7 @@ test.each<{
     tamperFn: () => {
       assert(castVoteRecords.artifactToImport.type === 'cast_vote_records');
       const { directoryPath } = castVoteRecords.artifactToImport;
-      fs.writeFileSync(path.join(directoryPath, '1234/c'), '');
+      fs.writeFileSync(path.join(directoryPath, cvrId1, 'c'), '');
     },
   },
   {
@@ -252,7 +256,7 @@ test.each<{
     tamperFn: () => {
       assert(castVoteRecords.artifactToImport.type === 'cast_vote_records');
       const { directoryPath } = castVoteRecords.artifactToImport;
-      fs.rmSync(path.join(directoryPath, '1234/a'));
+      fs.rmSync(path.join(directoryPath, cvrId1, 'a'));
     },
   },
   {
@@ -265,8 +269,8 @@ test.each<{
       assert(castVoteRecords.artifactToImport.type === 'cast_vote_records');
       const { directoryPath } = castVoteRecords.artifactToImport;
       fs.renameSync(
-        path.join(directoryPath, '1234/a'),
-        path.join(directoryPath, '1234/a-renamed')
+        path.join(directoryPath, cvrId1, 'a'),
+        path.join(directoryPath, cvrId1, 'a-renamed')
       );
     },
   },
@@ -278,7 +282,7 @@ test.each<{
     tamperFn: () => {
       assert(castVoteRecords.artifactToImport.type === 'cast_vote_records');
       const { directoryPath } = castVoteRecords.artifactToImport;
-      fs.mkdirSync(path.join(directoryPath, '3456'));
+      fs.mkdirSync(path.join(directoryPath, cvrId3));
     },
   },
   {
@@ -289,7 +293,7 @@ test.each<{
     tamperFn: () => {
       assert(castVoteRecords.artifactToImport.type === 'cast_vote_records');
       const { directoryPath } = castVoteRecords.artifactToImport;
-      fs.rmSync(path.join(directoryPath, '2345'), { recursive: true });
+      fs.rmSync(path.join(directoryPath, cvrId2), { recursive: true });
     },
   },
   {
@@ -304,11 +308,11 @@ test.each<{
       // cp and cpSync are experimental so not recommended for use in production but fine for use
       // in tests
       fs.cpSync(
-        path.join(directoryPath, '1234'),
-        path.join(directoryPath, '1234-renamed'),
+        path.join(directoryPath, cvrId1),
+        path.join(directoryPath, cvrId3),
         { recursive: true }
       );
-      fs.rmSync(path.join(directoryPath, '1234'), { recursive: true });
+      fs.rmSync(path.join(directoryPath, cvrId1), { recursive: true });
     },
   },
   {

--- a/libs/auth/src/cast_vote_record_hashes.test.ts
+++ b/libs/auth/src/cast_vote_record_hashes.test.ts
@@ -105,71 +105,69 @@ test('getCastVoteRecordRootHash, updateCastVoteRecordHashes, and clearCastVoteRe
   const client = Client.memoryClient();
   client.exec(CAST_VOTE_RECORD_HASHES_TABLE_SCHEMA);
 
-  function updateCastVoteRecordHashesHelper(
-    castVoteRecordId: CastVoteRecordId
-  ): string {
-    const castVoteRecordHash = computeSingleCastVoteRecordHash({
-      directoryName: castVoteRecordId,
-      files: castVoteRecords[castVoteRecordId],
+  function updateCastVoteRecordHashesHelper(cvrId: CastVoteRecordId): string {
+    const cvrHash = computeSingleCastVoteRecordHash({
+      directoryName: cvrId,
+      files: castVoteRecords[cvrId],
     });
-    updateCastVoteRecordHashes(client, castVoteRecordId, castVoteRecordHash);
-    return castVoteRecordHash;
+    updateCastVoteRecordHashes(client, cvrId, cvrHash);
+    return cvrHash;
   }
 
   expect(getCastVoteRecordRootHash(client)).toEqual('');
 
-  const leaf1Hash = updateCastVoteRecordHashesHelper(
+  const cvr1Hash = updateCastVoteRecordHashesHelper(
     'ab123456-0000-0000-0000-000000000000'
   );
-  let abHash = sha256(leaf1Hash);
+  let abHash = sha256(cvr1Hash);
   let aHash = sha256(abHash);
   let rootHash = sha256(aHash);
   expect(getCastVoteRecordRootHash(client)).toEqual(rootHash);
 
-  const leaf2Hash = updateCastVoteRecordHashesHelper(
+  const cvr2Hash = updateCastVoteRecordHashesHelper(
     'ab345678-0000-0000-0000-000000000000'
   );
-  abHash = sha256(leaf1Hash + leaf2Hash);
+  abHash = sha256(cvr1Hash + cvr2Hash);
   aHash = sha256(abHash);
   rootHash = sha256(aHash);
   expect(getCastVoteRecordRootHash(client)).toEqual(rootHash);
 
-  const leaf3Hash = updateCastVoteRecordHashesHelper(
+  const cvr3Hash = updateCastVoteRecordHashesHelper(
     'a1234567-0000-0000-0000-000000000000'
   );
-  const a1Hash = sha256(leaf3Hash);
+  const a1Hash = sha256(cvr3Hash);
   aHash = sha256(a1Hash + abHash);
   rootHash = sha256(aHash);
   expect(getCastVoteRecordRootHash(client)).toEqual(rootHash);
 
-  const leaf4Hash = updateCastVoteRecordHashesHelper(
+  const cvr4Hash = updateCastVoteRecordHashesHelper(
     'e1234567-0000-0000-0000-000000000000'
   );
-  const e1Hash = sha256(leaf4Hash);
+  const e1Hash = sha256(cvr4Hash);
   const eHash = sha256(e1Hash);
   rootHash = sha256(aHash + eHash);
   expect(getCastVoteRecordRootHash(client)).toEqual(rootHash);
 
-  const leaf5Hash = updateCastVoteRecordHashesHelper(
+  const cvr5Hash = updateCastVoteRecordHashesHelper(
     'c1234567-0000-0000-0000-000000000000'
   );
-  const c1Hash = sha256(leaf5Hash);
+  const c1Hash = sha256(cvr5Hash);
   const cHash = sha256(c1Hash);
   rootHash = sha256(aHash + cHash + eHash); // Reach branching factor of 3 at root
   expect(getCastVoteRecordRootHash(client)).toEqual(rootHash);
 
-  const leaf6Hash = updateCastVoteRecordHashesHelper(
+  const cvr6Hash = updateCastVoteRecordHashesHelper(
     'ab234567-0000-0000-0000-000000000000'
   );
-  abHash = sha256(leaf1Hash + leaf6Hash + leaf2Hash); // Reach branching factor of 3 at level 2
+  abHash = sha256(cvr1Hash + cvr6Hash + cvr2Hash); // Reach branching factor of 3 at level 2
   aHash = sha256(a1Hash + abHash);
   rootHash = sha256(aHash + cHash + eHash);
   expect(getCastVoteRecordRootHash(client)).toEqual(rootHash);
 
-  const leaf7Hash = updateCastVoteRecordHashesHelper(
+  const cvr7Hash = updateCastVoteRecordHashesHelper(
     'a2345678-0000-0000-0000-000000000000'
   );
-  const a2Hash = sha256(leaf7Hash);
+  const a2Hash = sha256(cvr7Hash);
   aHash = sha256(a1Hash + a2Hash + abHash); // Reach branching factor of 3 at level 1
   rootHash = sha256(aHash + cHash + eHash);
   expect(getCastVoteRecordRootHash(client)).toEqual(rootHash);
@@ -187,13 +185,11 @@ test('computeCastVoteRecordRootHashFromScratch', async () => {
   );
   fs.mkdirSync(exportDirectoryPath);
   fs.writeFileSync(path.join(exportDirectoryPath, 'metadata.json'), '');
-  for (const [castVoteRecordId, castVoteRecordFiles] of Object.entries(
-    castVoteRecords
-  )) {
-    fs.mkdirSync(path.join(exportDirectoryPath, castVoteRecordId));
-    for (const { fileName, fileContents } of castVoteRecordFiles) {
+  for (const [cvrId, cvrFiles] of Object.entries(castVoteRecords)) {
+    fs.mkdirSync(path.join(exportDirectoryPath, cvrId));
+    for (const { fileName, fileContents } of cvrFiles) {
       fs.writeFileSync(
-        path.join(exportDirectoryPath, castVoteRecordId, fileName),
+        path.join(exportDirectoryPath, cvrId, fileName),
         fileContents
       );
     }

--- a/libs/auth/src/cast_vote_record_hashes.test.ts
+++ b/libs/auth/src/cast_vote_record_hashes.test.ts
@@ -26,42 +26,42 @@ afterEach(() => {
 });
 
 type CastVoteRecordId =
+  | 'a1234567-0000-0000-0000-000000000000'
+  | 'a2345678-0000-0000-0000-000000000000'
   | 'ab123456-0000-0000-0000-000000000000'
+  | 'ab234567-0000-0000-0000-000000000000'
   | 'ab345678-0000-0000-0000-000000000000'
-  | 'abcd1234-0000-0000-0000-000000000000'
-  | 'abcd3456-0000-0000-0000-000000000000'
-  | 'abcd5678-0000-0000-0000-000000000000'
-  | 'cd123456-0000-0000-0000-000000000000'
-  | 'ef123456-0000-0000-0000-000000000000';
+  | 'c1234567-0000-0000-0000-000000000000'
+  | 'e1234567-0000-0000-0000-000000000000';
 
 // A minimal set of mock cast vote records for testing a branching factor of 3 at every level of
 // the Merkle tree
 const castVoteRecords: Record<CastVoteRecordId, File[]> = {
-  'ab123456-0000-0000-0000-000000000000': [
+  'a1234567-0000-0000-0000-000000000000': [
     { fileName: 'a', fileContents: 'a1' },
     { fileName: 'b', fileContents: 'b1' },
   ],
-  'ab345678-0000-0000-0000-000000000000': [
+  'a2345678-0000-0000-0000-000000000000': [
     { fileName: 'a', fileContents: 'a2' },
     { fileName: 'b', fileContents: 'b2' },
   ],
-  'abcd1234-0000-0000-0000-000000000000': [
+  'ab123456-0000-0000-0000-000000000000': [
     { fileName: 'a', fileContents: 'a3' },
     { fileName: 'b', fileContents: 'b3' },
   ],
-  'abcd3456-0000-0000-0000-000000000000': [
+  'ab234567-0000-0000-0000-000000000000': [
     { fileName: 'a', fileContents: 'a4' },
     { fileName: 'b', fileContents: 'b4' },
   ],
-  'abcd5678-0000-0000-0000-000000000000': [
+  'ab345678-0000-0000-0000-000000000000': [
     { fileName: 'a', fileContents: 'a5' },
     { fileName: 'b', fileContents: 'b5' },
   ],
-  'cd123456-0000-0000-0000-000000000000': [
+  'c1234567-0000-0000-0000-000000000000': [
     { fileName: 'a', fileContents: 'a6' },
     { fileName: 'b', fileContents: 'b6' },
   ],
-  'ef123456-0000-0000-0000-000000000000': [
+  'e1234567-0000-0000-0000-000000000000': [
     { fileName: 'a', fileContents: 'a7' },
     { fileName: 'b', fileContents: 'b7' },
   ],
@@ -71,7 +71,7 @@ const castVoteRecords: Record<CastVoteRecordId, File[]> = {
  * The root hash for the mock cast vote records represented by {@link castVoteRecords}
  */
 const expectedCastVoteRecordRootHash =
-  '282f2b50176debeec49f60de0a3e0c9c5cbcf6b4bbc800eec6b8be161d43fdec';
+  '03b88fdbe32c1115f6427953fd4364a737d85c0cf56a831249f1a4cd4c2a6b8a';
 
 test('computeSingleCastVoteRecordHash', () => {
   const hash = computeSingleCastVoteRecordHash({
@@ -119,59 +119,59 @@ test('getCastVoteRecordRootHash, updateCastVoteRecordHashes, and clearCastVoteRe
   expect(getCastVoteRecordRootHash(client)).toEqual('');
 
   const leaf1Hash = updateCastVoteRecordHashesHelper(
-    'abcd1234-0000-0000-0000-000000000000'
+    'ab123456-0000-0000-0000-000000000000'
   );
-  let abcdHash = sha256(leaf1Hash);
-  let abHash = sha256(abcdHash);
-  let rootHash = sha256(abHash);
+  let abHash = sha256(leaf1Hash);
+  let aHash = sha256(abHash);
+  let rootHash = sha256(aHash);
   expect(getCastVoteRecordRootHash(client)).toEqual(rootHash);
 
   const leaf2Hash = updateCastVoteRecordHashesHelper(
-    'abcd5678-0000-0000-0000-000000000000'
+    'ab345678-0000-0000-0000-000000000000'
   );
-  abcdHash = sha256(leaf1Hash + leaf2Hash);
-  abHash = sha256(abcdHash);
-  rootHash = sha256(abHash);
+  abHash = sha256(leaf1Hash + leaf2Hash);
+  aHash = sha256(abHash);
+  rootHash = sha256(aHash);
   expect(getCastVoteRecordRootHash(client)).toEqual(rootHash);
 
   const leaf3Hash = updateCastVoteRecordHashesHelper(
-    'ab123456-0000-0000-0000-000000000000'
+    'a1234567-0000-0000-0000-000000000000'
   );
-  const ab12Hash = sha256(leaf3Hash);
-  abHash = sha256(ab12Hash + abcdHash);
-  rootHash = sha256(abHash);
+  const a1Hash = sha256(leaf3Hash);
+  aHash = sha256(a1Hash + abHash);
+  rootHash = sha256(aHash);
   expect(getCastVoteRecordRootHash(client)).toEqual(rootHash);
 
   const leaf4Hash = updateCastVoteRecordHashesHelper(
-    'ef123456-0000-0000-0000-000000000000'
+    'e1234567-0000-0000-0000-000000000000'
   );
-  const ef12Hash = sha256(leaf4Hash);
-  const efHash = sha256(ef12Hash);
-  rootHash = sha256(abHash + efHash);
+  const e1Hash = sha256(leaf4Hash);
+  const eHash = sha256(e1Hash);
+  rootHash = sha256(aHash + eHash);
   expect(getCastVoteRecordRootHash(client)).toEqual(rootHash);
 
   const leaf5Hash = updateCastVoteRecordHashesHelper(
-    'cd123456-0000-0000-0000-000000000000'
+    'c1234567-0000-0000-0000-000000000000'
   );
-  const cd12Hash = sha256(leaf5Hash);
-  const cdHash = sha256(cd12Hash);
-  rootHash = sha256(abHash + cdHash + efHash); // Reach branching factor of 3 at root
+  const c1Hash = sha256(leaf5Hash);
+  const cHash = sha256(c1Hash);
+  rootHash = sha256(aHash + cHash + eHash); // Reach branching factor of 3 at root
   expect(getCastVoteRecordRootHash(client)).toEqual(rootHash);
 
   const leaf6Hash = updateCastVoteRecordHashesHelper(
-    'abcd3456-0000-0000-0000-000000000000'
+    'ab234567-0000-0000-0000-000000000000'
   );
-  abcdHash = sha256(leaf1Hash + leaf6Hash + leaf2Hash); // Reach branching factor of 3 at level 2
-  abHash = sha256(ab12Hash + abcdHash);
-  rootHash = sha256(abHash + cdHash + efHash);
+  abHash = sha256(leaf1Hash + leaf6Hash + leaf2Hash); // Reach branching factor of 3 at level 2
+  aHash = sha256(a1Hash + abHash);
+  rootHash = sha256(aHash + cHash + eHash);
   expect(getCastVoteRecordRootHash(client)).toEqual(rootHash);
 
   const leaf7Hash = updateCastVoteRecordHashesHelper(
-    'ab345678-0000-0000-0000-000000000000'
+    'a2345678-0000-0000-0000-000000000000'
   );
-  const ab34Hash = sha256(leaf7Hash);
-  abHash = sha256(ab12Hash + ab34Hash + abcdHash); // Reach branching factor of 3 at level 1
-  rootHash = sha256(abHash + cdHash + efHash);
+  const a2Hash = sha256(leaf7Hash);
+  aHash = sha256(a1Hash + a2Hash + abHash); // Reach branching factor of 3 at level 1
+  rootHash = sha256(aHash + cHash + eHash);
   expect(getCastVoteRecordRootHash(client)).toEqual(rootHash);
 
   expect(rootHash).toEqual(expectedCastVoteRecordRootHash);

--- a/libs/auth/src/cast_vote_record_hashes.test.ts
+++ b/libs/auth/src/cast_vote_record_hashes.test.ts
@@ -1,0 +1,207 @@
+import fs from 'fs';
+import { sha256 } from 'js-sha256';
+import path from 'path';
+import { dirSync } from 'tmp';
+import { Client } from '@votingworks/db';
+
+import {
+  CAST_VOTE_RECORD_HASHES_TABLE_SCHEMA,
+  File,
+  clearCastVoteRecordHashes,
+  computeCastVoteRecordRootHashFromScratch,
+  computeCombinedHash,
+  computeSingleCastVoteRecordHash,
+  getCastVoteRecordRootHash,
+  updateCastVoteRecordHashes,
+} from './cast_vote_record_hashes';
+
+let tempDirectoryPath: string;
+
+beforeEach(() => {
+  tempDirectoryPath = dirSync().name;
+});
+
+afterEach(() => {
+  fs.rmSync(tempDirectoryPath, { recursive: true });
+});
+
+type CastVoteRecordId =
+  | 'ab123456-0000-0000-0000-000000000000'
+  | 'ab345678-0000-0000-0000-000000000000'
+  | 'abcd1234-0000-0000-0000-000000000000'
+  | 'abcd3456-0000-0000-0000-000000000000'
+  | 'abcd5678-0000-0000-0000-000000000000'
+  | 'cd123456-0000-0000-0000-000000000000'
+  | 'ef123456-0000-0000-0000-000000000000';
+
+// A minimal set of mock cast vote records for testing a branching factor of 3 at every level of
+// the Merkle tree
+const castVoteRecords: Record<CastVoteRecordId, File[]> = {
+  'ab123456-0000-0000-0000-000000000000': [
+    { fileName: 'a', fileContents: 'a1' },
+    { fileName: 'b', fileContents: 'b1' },
+  ],
+  'ab345678-0000-0000-0000-000000000000': [
+    { fileName: 'a', fileContents: 'a2' },
+    { fileName: 'b', fileContents: 'b2' },
+  ],
+  'abcd1234-0000-0000-0000-000000000000': [
+    { fileName: 'a', fileContents: 'a3' },
+    { fileName: 'b', fileContents: 'b3' },
+  ],
+  'abcd3456-0000-0000-0000-000000000000': [
+    { fileName: 'a', fileContents: 'a4' },
+    { fileName: 'b', fileContents: 'b4' },
+  ],
+  'abcd5678-0000-0000-0000-000000000000': [
+    { fileName: 'a', fileContents: 'a5' },
+    { fileName: 'b', fileContents: 'b5' },
+  ],
+  'cd123456-0000-0000-0000-000000000000': [
+    { fileName: 'a', fileContents: 'a6' },
+    { fileName: 'b', fileContents: 'b6' },
+  ],
+  'ef123456-0000-0000-0000-000000000000': [
+    { fileName: 'a', fileContents: 'a7' },
+    { fileName: 'b', fileContents: 'b7' },
+  ],
+};
+
+/**
+ * The root hash for the mock cast vote records represented by {@link castVoteRecords}
+ */
+const expectedCastVoteRecordRootHash =
+  '282f2b50176debeec49f60de0a3e0c9c5cbcf6b4bbc800eec6b8be161d43fdec';
+
+test('computeSingleCastVoteRecordHash', () => {
+  const hash = computeSingleCastVoteRecordHash({
+    directoryName: 'directory-name',
+    files: [
+      { fileName: '2', fileContents: 'a' },
+      { fileName: '3', fileContents: 'b' },
+      { fileName: '1', fileContents: 'c' },
+    ],
+  });
+  const directorySummary = `
+${sha256('c')}  directory-name/1
+${sha256('a')}  directory-name/2
+${sha256('b')}  directory-name/3
+`.trimStart();
+  const expectedHash = sha256(directorySummary);
+  expect(hash).toEqual(expectedHash);
+});
+
+test('computeCombinedHash', () => {
+  const hash = computeCombinedHash([
+    { hash: sha256('a'), sortKey: '2' },
+    { hash: sha256('b'), sortKey: '3' },
+    { hash: sha256('c'), sortKey: '1' },
+  ]);
+  const expectedHash = sha256(sha256('c') + sha256('a') + sha256('b'));
+  expect(hash).toEqual(expectedHash);
+});
+
+test('getCastVoteRecordRootHash, updateCastVoteRecordHashes, and clearCastVoteRecordHashes', () => {
+  const client = Client.memoryClient();
+  client.exec(CAST_VOTE_RECORD_HASHES_TABLE_SCHEMA);
+
+  function updateCastVoteRecordHashesHelper(
+    castVoteRecordId: CastVoteRecordId
+  ): string {
+    const castVoteRecordHash = computeSingleCastVoteRecordHash({
+      directoryName: castVoteRecordId,
+      files: castVoteRecords[castVoteRecordId],
+    });
+    updateCastVoteRecordHashes(client, castVoteRecordId, castVoteRecordHash);
+    return castVoteRecordHash;
+  }
+
+  expect(getCastVoteRecordRootHash(client)).toEqual('');
+
+  const leaf1Hash = updateCastVoteRecordHashesHelper(
+    'abcd1234-0000-0000-0000-000000000000'
+  );
+  let abcdHash = sha256(leaf1Hash);
+  let abHash = sha256(abcdHash);
+  let rootHash = sha256(abHash);
+  expect(getCastVoteRecordRootHash(client)).toEqual(rootHash);
+
+  const leaf2Hash = updateCastVoteRecordHashesHelper(
+    'abcd5678-0000-0000-0000-000000000000'
+  );
+  abcdHash = sha256(leaf1Hash + leaf2Hash);
+  abHash = sha256(abcdHash);
+  rootHash = sha256(abHash);
+  expect(getCastVoteRecordRootHash(client)).toEqual(rootHash);
+
+  const leaf3Hash = updateCastVoteRecordHashesHelper(
+    'ab123456-0000-0000-0000-000000000000'
+  );
+  const ab12Hash = sha256(leaf3Hash);
+  abHash = sha256(ab12Hash + abcdHash);
+  rootHash = sha256(abHash);
+  expect(getCastVoteRecordRootHash(client)).toEqual(rootHash);
+
+  const leaf4Hash = updateCastVoteRecordHashesHelper(
+    'ef123456-0000-0000-0000-000000000000'
+  );
+  const ef12Hash = sha256(leaf4Hash);
+  const efHash = sha256(ef12Hash);
+  rootHash = sha256(abHash + efHash);
+  expect(getCastVoteRecordRootHash(client)).toEqual(rootHash);
+
+  const leaf5Hash = updateCastVoteRecordHashesHelper(
+    'cd123456-0000-0000-0000-000000000000'
+  );
+  const cd12Hash = sha256(leaf5Hash);
+  const cdHash = sha256(cd12Hash);
+  rootHash = sha256(abHash + cdHash + efHash); // Reach branching factor of 3 at root
+  expect(getCastVoteRecordRootHash(client)).toEqual(rootHash);
+
+  const leaf6Hash = updateCastVoteRecordHashesHelper(
+    'abcd3456-0000-0000-0000-000000000000'
+  );
+  abcdHash = sha256(leaf1Hash + leaf6Hash + leaf2Hash); // Reach branching factor of 3 at level 2
+  abHash = sha256(ab12Hash + abcdHash);
+  rootHash = sha256(abHash + cdHash + efHash);
+  expect(getCastVoteRecordRootHash(client)).toEqual(rootHash);
+
+  const leaf7Hash = updateCastVoteRecordHashesHelper(
+    'ab345678-0000-0000-0000-000000000000'
+  );
+  const ab34Hash = sha256(leaf7Hash);
+  abHash = sha256(ab12Hash + ab34Hash + abcdHash); // Reach branching factor of 3 at level 1
+  rootHash = sha256(abHash + cdHash + efHash);
+  expect(getCastVoteRecordRootHash(client)).toEqual(rootHash);
+
+  expect(rootHash).toEqual(expectedCastVoteRecordRootHash);
+
+  clearCastVoteRecordHashes(client);
+  expect(getCastVoteRecordRootHash(client)).toEqual('');
+});
+
+test('computeCastVoteRecordRootHashFromScratch', async () => {
+  const exportDirectoryPath = path.join(
+    tempDirectoryPath,
+    'cast-vote-record-export'
+  );
+  fs.mkdirSync(exportDirectoryPath);
+  fs.writeFileSync(path.join(exportDirectoryPath, 'metadata.json'), '');
+  for (const [castVoteRecordId, castVoteRecordFiles] of Object.entries(
+    castVoteRecords
+  )) {
+    fs.mkdirSync(path.join(exportDirectoryPath, castVoteRecordId));
+    for (const { fileName, fileContents } of castVoteRecordFiles) {
+      fs.writeFileSync(
+        path.join(exportDirectoryPath, castVoteRecordId, fileName),
+        fileContents
+      );
+    }
+  }
+
+  // Verify that the hash computed by computeCastVoteRecordRootHashFromScratch is equivalent to the
+  // hash computed by the SQLite-backed functions
+  expect(
+    await computeCastVoteRecordRootHashFromScratch(exportDirectoryPath)
+  ).toEqual(expectedCastVoteRecordRootHash);
+});

--- a/libs/auth/src/cast_vote_record_hashes.test.ts
+++ b/libs/auth/src/cast_vote_record_hashes.test.ts
@@ -91,6 +91,29 @@ ${sha256('b')}  directory-name/3
   expect(hash).toEqual(expectedHash);
 });
 
+test('computeSingleCastVoteRecordHash newline detection', () => {
+  /**
+   * This input will spoof the following directory summary:
+   * ${sha256('a')}  directory-name/1
+   * ${sha256('b')}  directory-name/2
+   * ${sha256('c')}  directory-name/3
+   */
+  const sneakyInput: Parameters<typeof computeSingleCastVoteRecordHash>[0] = {
+    directoryName: 'directory-name',
+    files: [
+      {
+        fileName: `1\n${sha256('b')}  directory-name/2`,
+        fileContents: 'a',
+      },
+      {
+        fileName: '3',
+        fileContents: 'c',
+      },
+    ],
+  };
+  expect(() => computeSingleCastVoteRecordHash(sneakyInput)).toThrow();
+});
+
 test('computeCombinedHash', () => {
   const hash = computeCombinedHash([
     { hash: sha256('a'), sortKey: '2' },

--- a/libs/auth/src/cast_vote_record_hashes.ts
+++ b/libs/auth/src/cast_vote_record_hashes.ts
@@ -114,6 +114,21 @@ function selectCastVoteRecordHashes(
     orderBy: 'cvr_id_level_1_prefix' | 'cvr_id_level_2_prefix' | 'cvr_id';
   }
 ): string[] {
+  // Be extra cautious and run-time validate incoming params so that we don't solely rely on
+  // compile-time validation to prevent SQL injection
+  for (const constraint of [
+    cvrIdLevel1PrefixConstraint,
+    cvrIdLevel2PrefixConstraint,
+    cvrIdConstraint,
+  ]) {
+    assert(['=', '!='].includes(constraint.type));
+  }
+  assert(
+    ['cvr_id_level_1_prefix', 'cvr_id_level_2_prefix', 'cvr_id'].includes(
+      orderBy
+    )
+  );
+
   const rows = client.all(
     `
     select cvr_hash as cvrHash

--- a/libs/auth/src/cast_vote_record_hashes.ts
+++ b/libs/auth/src/cast_vote_record_hashes.ts
@@ -185,8 +185,8 @@ export function updateCastVoteRecordHashes(
   cvrId: string,
   cvrHash: string
 ): void {
-  const cvrIdLevel1Prefix = cvrId.slice(0, 2);
-  const cvrIdLevel2Prefix = cvrId.slice(0, 4);
+  const cvrIdLevel1Prefix = cvrId.slice(0, 1);
+  const cvrIdLevel2Prefix = cvrId.slice(0, 2);
 
   client.transaction(() => {
     insertCastVoteRecordHash(client, {
@@ -289,7 +289,7 @@ export async function computeCastVoteRecordRootHashFromScratch(
 
   const level2Hashes: HashesToCombine = groupBy(
     leafHashes,
-    ({ sortKey: cvrId }) => cvrId.slice(0, 4)
+    ({ sortKey: cvrId }) => cvrId.slice(0, 2)
   ).map(([cvrIdLevel2Prefix, siblingLeafHashes]) => ({
     hash: computeCombinedHash(siblingLeafHashes),
     sortKey: cvrIdLevel2Prefix,
@@ -297,7 +297,7 @@ export async function computeCastVoteRecordRootHashFromScratch(
 
   const level1Hashes: HashesToCombine = groupBy(
     level2Hashes,
-    ({ sortKey: cvrIdLevel2Prefix }) => cvrIdLevel2Prefix.slice(0, 2)
+    ({ sortKey: cvrIdLevel2Prefix }) => cvrIdLevel2Prefix.slice(0, 1)
   ).map(([cvrIdLevel1Prefix, siblingLevel2Hashes]) => ({
     hash: computeCombinedHash(siblingLevel2Hashes),
     sortKey: cvrIdLevel1Prefix,

--- a/libs/auth/src/cast_vote_record_hashes.ts
+++ b/libs/auth/src/cast_vote_record_hashes.ts
@@ -71,8 +71,14 @@ export function computeCombinedHash(hashesToCombine: HashesToCombine): string {
  */
 export const CAST_VOTE_RECORD_HASHES_TABLE_SCHEMA = `
 create table cvr_hashes (
-  cvr_id_level_1_prefix text not null,
-  cvr_id_level_2_prefix text not null,
+  cvr_id_level_1_prefix text not null check (
+    length(cvr_id_level_1_prefix) = 1 or
+    length(cvr_id_level_1_prefix) = 0
+  ),
+  cvr_id_level_2_prefix text not null check (
+    length(cvr_id_level_2_prefix) = 2 or
+    length(cvr_id_level_2_prefix) = 0
+  ),
   cvr_id text not null,
   cvr_hash text not null
 );

--- a/libs/auth/src/cast_vote_record_hashes.ts
+++ b/libs/auth/src/cast_vote_record_hashes.ts
@@ -78,8 +78,13 @@ create table cvr_hashes (
     length(cvr_id_level_2_prefix) = 2 or
     length(cvr_id_level_2_prefix) = 0
   ),
-  cvr_id text not null,
-  cvr_hash text not null
+  cvr_id text not null check (
+    length(cvr_id) = 36 or
+    length(cvr_id) = 0
+  ),
+  cvr_hash text not null check (
+    length(cvr_hash) = 64
+  )
 );
 
 create unique index idx_cvr_hashes ON cvr_hashes (

--- a/libs/auth/src/cast_vote_record_hashes.ts
+++ b/libs/auth/src/cast_vote_record_hashes.ts
@@ -2,7 +2,7 @@ import { Buffer } from 'buffer';
 import fs from 'fs/promises';
 import { sha256 } from 'js-sha256';
 import path from 'path';
-import { groupBy } from '@votingworks/basics';
+import { assert, groupBy } from '@votingworks/basics';
 import { Client } from '@votingworks/db';
 
 /**
@@ -32,9 +32,11 @@ export function computeSingleCastVoteRecordHash({
   );
   const fileHashes: string[] = [];
   for (const { fileName, fileContents } of filesSorted) {
-    fileHashes.push(
-      `${sha256(fileContents)}  ${path.join(directoryName, fileName)}\n`
-    );
+    const filePath = path.join(directoryName, fileName);
+    // Be extra cautious and prevent spoofing the directory summary by using directory/file names
+    // with newlines
+    assert(!filePath.includes('\n'));
+    fileHashes.push(`${sha256(fileContents)}  ${filePath}\n`);
   }
   const directorySummary = fileHashes.join('');
   return sha256(directorySummary);

--- a/libs/auth/src/cast_vote_record_hashes.ts
+++ b/libs/auth/src/cast_vote_record_hashes.ts
@@ -1,0 +1,308 @@
+import { Buffer } from 'buffer';
+import fs from 'fs/promises';
+import { sha256 } from 'js-sha256';
+import path from 'path';
+import { groupBy } from '@votingworks/basics';
+import { Client } from '@votingworks/db';
+
+/**
+ * A representation of a file
+ */
+export interface File {
+  fileName: string;
+  fileContents: string | Buffer;
+}
+
+/**
+ * Computes a hash for a single cast vote record, incorporating the cast vote record's directory
+ * name, file names, and file contents. The directory summary that we hash specifically mirrors the
+ * output of:
+ *
+ * find <directoryName> -type f | sort | xargs sha256sum
+ */
+export function computeSingleCastVoteRecordHash({
+  directoryName,
+  files,
+}: {
+  directoryName: string;
+  files: File[];
+}): string {
+  const filesSorted = [...files].sort((file1, file2) =>
+    file1.fileName.localeCompare(file2.fileName)
+  );
+  const fileHashes: string[] = [];
+  for (const { fileName, fileContents } of filesSorted) {
+    fileHashes.push(
+      `${sha256(fileContents)}  ${path.join(directoryName, fileName)}\n`
+    );
+  }
+  const directorySummary = fileHashes.join('');
+  return sha256(directorySummary);
+}
+
+/**
+ * The input to {@link computeCombinedHash}
+ */
+export type HashesToCombine = Array<{ hash: string; sortKey: string }>;
+
+/**
+ * Sorts the provided hashes using the specified sort key, concatenates the hashes, and hashes the
+ * result, yielding a combined hash
+ */
+export function computeCombinedHash(hashesToCombine: HashesToCombine): string {
+  return sha256(
+    [...hashesToCombine]
+      .sort((entry1, entry2) => entry1.sortKey.localeCompare(entry2.sortKey))
+      .map((entry) => entry.hash)
+      .join('')
+  );
+}
+
+//
+// Functions for managing cast vote record hashes in a SQLite DB table. This code is relevant for
+// export-time hash computation.
+//
+
+/**
+ * A schema for a Merkle tree (https://en.wikipedia.org/wiki/Merkle_tree) that allows for efficient
+ * hashing of continuously exported cast vote records
+ */
+export const CAST_VOTE_RECORD_HASHES_TABLE_SCHEMA = `
+create table cvr_hashes (
+  cvr_id_level_1_prefix text not null,
+  cvr_id_level_2_prefix text not null,
+  cvr_id text not null,
+  cvr_hash text not null
+);
+
+create unique index idx_cvr_hashes ON cvr_hashes (
+  cvr_id_level_1_prefix,
+  cvr_id_level_2_prefix,
+  cvr_id
+);
+`;
+
+/**
+ * Using true SQLite NULL values interferes with uniqueness constraints since SQLite treats all
+ * NULL values as different, so we use a special value instead.
+ */
+const NULL_VALUE = '-';
+
+interface Constraint {
+  type: '=' | '!=';
+  value: string;
+}
+
+function selectCastVoteRecordHashes(
+  client: Client,
+  {
+    cvrIdLevel1PrefixConstraint,
+    cvrIdLevel2PrefixConstraint,
+    cvrIdConstraint,
+    orderBy,
+  }: {
+    cvrIdLevel1PrefixConstraint: Constraint;
+    cvrIdLevel2PrefixConstraint: Constraint;
+    cvrIdConstraint: Constraint;
+    orderBy: 'cvr_id_level_1_prefix' | 'cvr_id_level_2_prefix' | 'cvr_id';
+  }
+): string[] {
+  const rows = client.all(
+    `
+    select cvr_hash as cvrHash
+    from cvr_hashes
+    where
+      cvr_id_level_1_prefix ${cvrIdLevel1PrefixConstraint.type} ? and
+      cvr_id_level_2_prefix ${cvrIdLevel2PrefixConstraint.type} ? and
+      cvr_id ${cvrIdConstraint.type} ?
+    order by ${orderBy} asc
+    `,
+    cvrIdLevel1PrefixConstraint.value,
+    cvrIdLevel2PrefixConstraint.value,
+    cvrIdConstraint.value
+  ) as Array<{ cvrHash: string }>;
+  return rows.map((row) => row.cvrHash);
+}
+
+function insertCastVoteRecordHash(
+  client: Client,
+  {
+    cvrIdLevel1Prefix,
+    cvrIdLevel2Prefix,
+    cvrId,
+    cvrHash,
+  }: {
+    cvrIdLevel1Prefix: string;
+    cvrIdLevel2Prefix: string;
+    cvrId: string;
+    cvrHash: string;
+  }
+): void {
+  client.run(
+    `
+    insert or replace into cvr_hashes (
+      cvr_id_level_1_prefix,
+      cvr_id_level_2_prefix,
+      cvr_id,
+      cvr_hash
+    ) values (?, ?, ?, ?)
+    `,
+    cvrIdLevel1Prefix,
+    cvrIdLevel2Prefix,
+    cvrId,
+    cvrHash
+  );
+}
+
+/**
+ * Gets the cast vote record root hash.
+ *
+ * See {@link CAST_VOTE_RECORD_HASHES_TABLE_SCHEMA} for more context.
+ */
+export function getCastVoteRecordRootHash(client: Client): string {
+  const row = client.one(
+    `
+    select cvr_hash as cvrHash
+    from cvr_hashes
+    where
+      cvr_id_level_1_prefix = '${NULL_VALUE}' and
+      cvr_id_level_2_prefix = '${NULL_VALUE}' and
+      cvr_id = '${NULL_VALUE}'
+    `
+  ) as { cvrHash: string } | undefined;
+  return row?.cvrHash ?? '';
+}
+
+/**
+ * Inserts a cast vote record hash (a leaf node in the Merkle tree) and updates the cast vote
+ * record root hash (the root node in the Merkle tree), updating relevant intermediate hashes along
+ * the way (intermediate nodes in the Merkle tree).
+ *
+ * See {@link CAST_VOTE_RECORD_HASHES_TABLE_SCHEMA} for more context.
+ */
+export function updateCastVoteRecordHashes(
+  client: Client,
+  cvrId: string,
+  cvrHash: string
+): void {
+  const cvrIdLevel1Prefix = cvrId.slice(0, 2);
+  const cvrIdLevel2Prefix = cvrId.slice(0, 4);
+
+  client.transaction(() => {
+    insertCastVoteRecordHash(client, {
+      cvrIdLevel1Prefix,
+      cvrIdLevel2Prefix,
+      cvrId,
+      cvrHash,
+    });
+
+    const siblingLeafHashes = selectCastVoteRecordHashes(client, {
+      cvrIdLevel1PrefixConstraint: { type: '=', value: cvrIdLevel1Prefix },
+      cvrIdLevel2PrefixConstraint: { type: '=', value: cvrIdLevel2Prefix },
+      cvrIdConstraint: { type: '!=', value: NULL_VALUE },
+      orderBy: 'cvr_id',
+    });
+    const level2Hash = sha256(siblingLeafHashes.join(''));
+    insertCastVoteRecordHash(client, {
+      cvrIdLevel1Prefix,
+      cvrIdLevel2Prefix,
+      cvrId: NULL_VALUE,
+      cvrHash: level2Hash,
+    });
+
+    const siblingLevel2Hashes = selectCastVoteRecordHashes(client, {
+      cvrIdLevel1PrefixConstraint: { type: '=', value: cvrIdLevel1Prefix },
+      cvrIdLevel2PrefixConstraint: { type: '!=', value: NULL_VALUE },
+      cvrIdConstraint: { type: '=', value: NULL_VALUE },
+      orderBy: 'cvr_id_level_2_prefix',
+    });
+    const level1Hash = sha256(siblingLevel2Hashes.join(''));
+    insertCastVoteRecordHash(client, {
+      cvrIdLevel1Prefix,
+      cvrIdLevel2Prefix: NULL_VALUE,
+      cvrId: NULL_VALUE,
+      cvrHash: level1Hash,
+    });
+
+    const level1Hashes = selectCastVoteRecordHashes(client, {
+      cvrIdLevel1PrefixConstraint: { type: '!=', value: NULL_VALUE },
+      cvrIdLevel2PrefixConstraint: { type: '=', value: NULL_VALUE },
+      cvrIdConstraint: { type: '=', value: NULL_VALUE },
+      orderBy: 'cvr_id_level_1_prefix',
+    });
+    const rootHash = sha256(level1Hashes.join(''));
+    insertCastVoteRecordHash(client, {
+      cvrId: NULL_VALUE,
+      cvrIdLevel1Prefix: NULL_VALUE,
+      cvrIdLevel2Prefix: NULL_VALUE,
+      cvrHash: rootHash,
+    });
+  });
+}
+
+/**
+ * Clears all cast vote record hashes
+ */
+export function clearCastVoteRecordHashes(client: Client): void {
+  client.run('delete from cvr_hashes');
+}
+
+//
+// Functions for computing cast vote record hashes from scratch. This code is relevant for
+// import-time hash computation.
+//
+
+/**
+ * Computes the cast vote record root hash from scratch given the export directory path, reading in
+ * all files and computing hashes in memory without the aid of a SQLite DB
+ */
+export async function computeCastVoteRecordRootHashFromScratch(
+  exportDirectoryPath: string
+): Promise<string> {
+  const cvrIds = (
+    await fs.readdir(exportDirectoryPath, { withFileTypes: true })
+  )
+    .filter((entry) => entry.isDirectory())
+    .map((directory) => directory.name);
+
+  const leafHashes: HashesToCombine = [];
+  for (const cvrId of cvrIds) {
+    const cvrDirectoryPath = path.join(exportDirectoryPath, cvrId);
+    const cvrFileNames = (
+      await fs.readdir(cvrDirectoryPath, { withFileTypes: true })
+    )
+      .filter((entry) => entry.isFile())
+      .map((file) => file.name);
+    const cvrFiles: File[] = [];
+    for (const fileName of cvrFileNames) {
+      const fileContents = await fs.readFile(
+        path.join(cvrDirectoryPath, fileName)
+      );
+      cvrFiles.push({ fileName, fileContents });
+    }
+    const cvrHash = computeSingleCastVoteRecordHash({
+      directoryName: cvrId,
+      files: cvrFiles,
+    });
+    leafHashes.push({ hash: cvrHash, sortKey: cvrId });
+  }
+
+  const level2Hashes: HashesToCombine = groupBy(
+    leafHashes,
+    ({ sortKey: cvrId }) => cvrId.slice(0, 4)
+  ).map(([cvrIdLevel2Prefix, siblingLeafHashes]) => ({
+    hash: computeCombinedHash(siblingLeafHashes),
+    sortKey: cvrIdLevel2Prefix,
+  }));
+
+  const level1Hashes: HashesToCombine = groupBy(
+    level2Hashes,
+    ({ sortKey: cvrIdLevel2Prefix }) => cvrIdLevel2Prefix.slice(0, 2)
+  ).map(([cvrIdLevel1Prefix, siblingLevel2Hashes]) => ({
+    hash: computeCombinedHash(siblingLevel2Hashes),
+    sortKey: cvrIdLevel1Prefix,
+  }));
+
+  const rootHash = computeCombinedHash(level1Hashes);
+  return rootHash;
+}

--- a/libs/auth/src/cast_vote_record_hashes.ts
+++ b/libs/auth/src/cast_vote_record_hashes.ts
@@ -17,7 +17,6 @@ export interface File {
  * Computes a hash for a single cast vote record, incorporating the cast vote record's directory
  * name, file names, and file contents. The directory summary that we hash specifically mirrors the
  * output of:
- *
  * find <directoryName> -type f | sort | xargs sha256sum
  */
 export function computeSingleCastVoteRecordHash({

--- a/libs/auth/src/cast_vote_record_hashes.ts
+++ b/libs/auth/src/cast_vote_record_hashes.ts
@@ -84,9 +84,9 @@ create unique index idx_cvr_hashes ON cvr_hashes (
 
 /**
  * Using true SQLite NULL values interferes with uniqueness constraints since SQLite treats all
- * NULL values as different, so we use a special value instead.
+ * NULL values as different, so we use an empty string instead.
  */
-const NULL_VALUE = '-';
+const NULL_VALUE = '';
 
 interface Constraint {
   type: '=' | '!=';

--- a/libs/auth/src/config.ts
+++ b/libs/auth/src/config.ts
@@ -106,9 +106,6 @@ export interface ArtifactAuthenticationConfig {
   signingMachineCertPath: string;
   signingMachinePrivateKey: FileKey | TpmKey;
   vxCertAuthorityCertPath: string;
-
-  /** Only tests should provide this param */
-  isFileOnRemovableDeviceOverride?: (filePath: string) => boolean;
 }
 
 /**

--- a/libs/auth/src/index.ts
+++ b/libs/auth/src/index.ts
@@ -1,5 +1,6 @@
 export * from './artifact_authentication';
 export type { CardStatus } from './card';
+export * from './cast_vote_record_hashes';
 export * from './config';
 export * from './dipped_smart_card_auth_api';
 export * from './dipped_smart_card_auth';

--- a/libs/auth/src/java_card.ts
+++ b/libs/auth/src/java_card.ts
@@ -111,7 +111,6 @@ export const VX_ADMIN_CERT_AUTHORITY_CERT = {
  * An upper bound on the size of a single data object. Though a TLV value can be up to 65,535 bytes
  * long (0xffff in hex), OpenFIPS201 caps total TLV length (including tag and length) at 32,767
  * bytes (0x7fff in hex). This allows for a max data object size of:
- *
  * 32,767 bytes - 1 byte for the data tag - 3 bytes for the 0x82 0xXX 0xXX length = 32,763 bytes
  *
  * Confirmed that this really is the max through manual testing. Trying to store a data object of

--- a/libs/auth/src/lockout.ts
+++ b/libs/auth/src/lockout.ts
@@ -20,7 +20,6 @@ export interface CardLockoutConfig {
  * Providing an example of the lockout duration calculation, if the number of incorrect PIN
  * attempts allowed before lockout is 5, and the starting lockout duration is 15 seconds, the
  * lockout durations before each attempt will be as follows:
- *
  * - No lockout before attempt 1
  * - No lockout before attempt 2
  * - No lockout before attempt 3

--- a/libs/auth/tsconfig.build.json
+++ b/libs/auth/tsconfig.build.json
@@ -11,6 +11,7 @@
   },
   "references": [
     { "path": "../basics/tsconfig.build.json" },
+    { "path": "../db/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../fixtures/tsconfig.build.json" },
     { "path": "../logging/tsconfig.build.json" },

--- a/libs/auth/tsconfig.json
+++ b/libs/auth/tsconfig.json
@@ -12,6 +12,7 @@
   },
   "references": [
     { "path": "../basics/tsconfig.build.json" },
+    { "path": "../db/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../fixtures/tsconfig.build.json" },
     { "path": "../logging/tsconfig.build.json" },

--- a/libs/backend/src/scan/cast_vote_records/export.ts
+++ b/libs/backend/src/scan/cast_vote_records/export.ts
@@ -1,10 +1,13 @@
 /* istanbul ignore file */
 import { Buffer } from 'buffer';
 import fs from 'fs/promises';
-import { sha256 } from 'js-sha256';
 import path from 'path';
 import { Readable } from 'stream';
-import { prepareSignatureFile } from '@votingworks/auth';
+import {
+  computeSingleCastVoteRecordHash,
+  File,
+  prepareSignatureFile,
+} from '@votingworks/auth';
 import { assertDefined, err, ok, Result } from '@votingworks/basics';
 import {
   BallotIdSchema,
@@ -80,11 +83,6 @@ interface ExportContext {
   exporter: Exporter;
   scannerState: ScannerStateUnchangedByExport;
   scannerStore: ScannerStore;
-}
-
-interface File {
-  fileName: string;
-  fileContents: string | Buffer;
 }
 
 //
@@ -289,10 +287,10 @@ async function exportCastVoteRecordFilesToUsbDrive(
     }
   }
 
-  const fileHashes = [...castVoteRecordFilesToExport]
-    .sort((f1, f2) => (f1 && f2 ? f1.fileName.localeCompare(f2.fileName) : 0))
-    .map(({ fileContents }) => sha256(fileContents));
-  const castVoteRecordHash = sha256(fileHashes.join(''));
+  const castVoteRecordHash = computeSingleCastVoteRecordHash({
+    directoryName: castVoteRecordId,
+    files: castVoteRecordFilesToExport,
+  });
 
   return ok({ castVoteRecordId, castVoteRecordHash });
 }

--- a/libs/types/src/cast_vote_records.ts
+++ b/libs/types/src/cast_vote_records.ts
@@ -1,4 +1,9 @@
-import { CastVoteRecordReport } from './cdf/cast-vote-records';
+import { z } from 'zod';
+
+import {
+  CastVoteRecordReport,
+  CastVoteRecordReportSchema,
+} from './cdf/cast-vote-records';
 import { BallotId, BallotStyleId, PrecinctId } from './election';
 import { Dictionary } from './generic';
 
@@ -32,3 +37,10 @@ export interface CastVoteRecordExportMetadata {
   /** A hash of all cast vote record files in an export */
   castVoteRecordRootHash: string;
 }
+
+export const CastVoteRecordExportMetadataSchema: z.ZodSchema<CastVoteRecordExportMetadata> =
+  z.object({
+    arePollsClosed: z.boolean().optional(),
+    castVoteRecordReportMetadata: CastVoteRecordReportSchema,
+    castVoteRecordRootHash: z.string(),
+  });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2970,6 +2970,9 @@ importers:
       '@votingworks/basics':
         specifier: workspace:*
         version: link:../basics
+      '@votingworks/db':
+        specifier: workspace:*
+        version: link:../db
       '@votingworks/fixtures':
         specifier: workspace:*
         version: link:../fixtures


### PR DESCRIPTION
_Easiest reviewed by commit_

## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/3838

This PR implements the long discussed Merkle-tree-backed scheme for efficient hashing of continuously exported CVRs! Much more context can be found in the [Continuous Export Tech Spec](https://docs.google.com/document/d/1ruFBhxPbP0NvxuEDZXfl-wzz-ikBODBIbvSJKDLaIMI/edit#heading=h.adjk78a95otw).

## Testing

- [x] Added lots of automated tests
- [x] Tested manually

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A