### PR TITLE
perf(auth): read file data as needed

### DIFF
--- a/libs/auth/src/cast_vote_record_hashes.test.ts
+++ b/libs/auth/src/cast_vote_record_hashes.test.ts
@@ -7,7 +7,7 @@ import { Client } from '@votingworks/db';
 
 import {
   CAST_VOTE_RECORD_HASHES_TABLE_SCHEMA,
-  File,
+  ReadableFile,
   clearCastVoteRecordHashes,
   computeCastVoteRecordRootHashFromScratch,
   computeCombinedHash,
@@ -35,7 +35,7 @@ type CastVoteRecordId =
   | 'c1234567-0000-0000-0000-000000000000'
   | 'e1234567-0000-0000-0000-000000000000';
 
-type FileWithContents = File & { fileContents: string };
+type FileWithContents = ReadableFile & { fileContents: string };
 
 function file(fileName: string, contents: string): FileWithContents {
   return {

--- a/libs/auth/src/cast_vote_record_hashes.test.ts
+++ b/libs/auth/src/cast_vote_record_hashes.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import { sha256 } from 'js-sha256';
 import path from 'path';
+import { Readable } from 'stream';
 import { dirSync } from 'tmp';
 import { Client } from '@votingworks/db';
 
@@ -40,6 +41,7 @@ function file(fileName: string, contents: string): FileWithContents {
   return {
     fileName,
     fileContents: contents,
+    open: () => Readable.from(contents),
     computeSha256Hash: () => Promise.resolve(sha256(contents)),
   };
 }

--- a/libs/auth/src/cast_vote_record_hashes.test.ts
+++ b/libs/auth/src/cast_vote_record_hashes.test.ts
@@ -34,37 +34,26 @@ type CastVoteRecordId =
   | 'c1234567-0000-0000-0000-000000000000'
   | 'e1234567-0000-0000-0000-000000000000';
 
+type FileWithContents = File & { fileContents: string };
+
+function file(fileName: string, contents: string): FileWithContents {
+  return {
+    fileName,
+    fileContents: contents,
+    computeSha256Hash: () => Promise.resolve(sha256(contents)),
+  };
+}
+
 // A minimal set of mock cast vote records for testing a branching factor of 3 at every level of
 // the Merkle tree
-const castVoteRecords: Record<CastVoteRecordId, File[]> = {
-  'a1234567-0000-0000-0000-000000000000': [
-    { fileName: 'a', fileContents: 'a1' },
-    { fileName: 'b', fileContents: 'b1' },
-  ],
-  'a2345678-0000-0000-0000-000000000000': [
-    { fileName: 'a', fileContents: 'a2' },
-    { fileName: 'b', fileContents: 'b2' },
-  ],
-  'ab123456-0000-0000-0000-000000000000': [
-    { fileName: 'a', fileContents: 'a3' },
-    { fileName: 'b', fileContents: 'b3' },
-  ],
-  'ab234567-0000-0000-0000-000000000000': [
-    { fileName: 'a', fileContents: 'a4' },
-    { fileName: 'b', fileContents: 'b4' },
-  ],
-  'ab345678-0000-0000-0000-000000000000': [
-    { fileName: 'a', fileContents: 'a5' },
-    { fileName: 'b', fileContents: 'b5' },
-  ],
-  'c1234567-0000-0000-0000-000000000000': [
-    { fileName: 'a', fileContents: 'a6' },
-    { fileName: 'b', fileContents: 'b6' },
-  ],
-  'e1234567-0000-0000-0000-000000000000': [
-    { fileName: 'a', fileContents: 'a7' },
-    { fileName: 'b', fileContents: 'b7' },
-  ],
+const castVoteRecords: Record<CastVoteRecordId, FileWithContents[]> = {
+  'a1234567-0000-0000-0000-000000000000': [file('a', 'a1'), file('b', 'b1')],
+  'a2345678-0000-0000-0000-000000000000': [file('a', 'a2'), file('b', 'b2')],
+  'ab123456-0000-0000-0000-000000000000': [file('a', 'a3'), file('b', 'b3')],
+  'ab234567-0000-0000-0000-000000000000': [file('a', 'a4'), file('b', 'b4')],
+  'ab345678-0000-0000-0000-000000000000': [file('a', 'a5'), file('b', 'b5')],
+  'c1234567-0000-0000-0000-000000000000': [file('a', 'a6'), file('b', 'b6')],
+  'e1234567-0000-0000-0000-000000000000': [file('a', 'a7'), file('b', 'b7')],
 };
 
 /**
@@ -73,14 +62,10 @@ const castVoteRecords: Record<CastVoteRecordId, File[]> = {
 const expectedCastVoteRecordRootHash =
   '03b88fdbe32c1115f6427953fd4364a737d85c0cf56a831249f1a4cd4c2a6b8a';
 
-test('computeSingleCastVoteRecordHash', () => {
-  const hash = computeSingleCastVoteRecordHash({
+test('computeSingleCastVoteRecordHash', async () => {
+  const hash = await computeSingleCastVoteRecordHash({
     directoryName: 'directory-name',
-    files: [
-      { fileName: '2', fileContents: 'a' },
-      { fileName: '3', fileContents: 'b' },
-      { fileName: '1', fileContents: 'c' },
-    ],
+    files: [file('2', 'a'), file('3', 'b'), file('1', 'c')],
   });
   const directorySummary = `
 ${sha256('c')}  directory-name/1
@@ -91,7 +76,7 @@ ${sha256('b')}  directory-name/3
   expect(hash).toEqual(expectedHash);
 });
 
-test('computeSingleCastVoteRecordHash newline detection', () => {
+test('computeSingleCastVoteRecordHash newline detection', async () => {
   /**
    * This input will spoof the following directory summary:
    * ${sha256('a')}  directory-name/1
@@ -100,18 +85,9 @@ test('computeSingleCastVoteRecordHash newline detection', () => {
    */
   const sneakyInput: Parameters<typeof computeSingleCastVoteRecordHash>[0] = {
     directoryName: 'directory-name',
-    files: [
-      {
-        fileName: `1\n${sha256('b')}  directory-name/2`,
-        fileContents: 'a',
-      },
-      {
-        fileName: '3',
-        fileContents: 'c',
-      },
-    ],
+    files: [file(`1\n${sha256('b')}  directory-name/2`, 'a'), file('3', 'c')],
   };
-  expect(() => computeSingleCastVoteRecordHash(sneakyInput)).toThrow();
+  await expect(computeSingleCastVoteRecordHash(sneakyInput)).rejects.toThrow();
 });
 
 test('computeCombinedHash', () => {
@@ -124,12 +100,14 @@ test('computeCombinedHash', () => {
   expect(hash).toEqual(expectedHash);
 });
 
-test('getCastVoteRecordRootHash, updateCastVoteRecordHashes, and clearCastVoteRecordHashes', () => {
+test('getCastVoteRecordRootHash, updateCastVoteRecordHashes, and clearCastVoteRecordHashes', async () => {
   const client = Client.memoryClient();
   client.exec(CAST_VOTE_RECORD_HASHES_TABLE_SCHEMA);
 
-  function updateCastVoteRecordHashesHelper(cvrId: CastVoteRecordId): string {
-    const cvrHash = computeSingleCastVoteRecordHash({
+  async function updateCastVoteRecordHashesHelper(
+    cvrId: CastVoteRecordId
+  ): Promise<string> {
+    const cvrHash = await computeSingleCastVoteRecordHash({
       directoryName: cvrId,
       files: castVoteRecords[cvrId],
     });
@@ -139,7 +117,7 @@ test('getCastVoteRecordRootHash, updateCastVoteRecordHashes, and clearCastVoteRe
 
   expect(getCastVoteRecordRootHash(client)).toEqual('');
 
-  const cvr1Hash = updateCastVoteRecordHashesHelper(
+  const cvr1Hash = await updateCastVoteRecordHashesHelper(
     'ab123456-0000-0000-0000-000000000000'
   );
   let abHash = sha256(cvr1Hash);
@@ -147,7 +125,7 @@ test('getCastVoteRecordRootHash, updateCastVoteRecordHashes, and clearCastVoteRe
   let rootHash = sha256(aHash);
   expect(getCastVoteRecordRootHash(client)).toEqual(rootHash);
 
-  const cvr2Hash = updateCastVoteRecordHashesHelper(
+  const cvr2Hash = await updateCastVoteRecordHashesHelper(
     'ab345678-0000-0000-0000-000000000000'
   );
   abHash = sha256(cvr1Hash + cvr2Hash);
@@ -155,7 +133,7 @@ test('getCastVoteRecordRootHash, updateCastVoteRecordHashes, and clearCastVoteRe
   rootHash = sha256(aHash);
   expect(getCastVoteRecordRootHash(client)).toEqual(rootHash);
 
-  const cvr3Hash = updateCastVoteRecordHashesHelper(
+  const cvr3Hash = await updateCastVoteRecordHashesHelper(
     'a1234567-0000-0000-0000-000000000000'
   );
   const a1Hash = sha256(cvr3Hash);
@@ -163,7 +141,7 @@ test('getCastVoteRecordRootHash, updateCastVoteRecordHashes, and clearCastVoteRe
   rootHash = sha256(aHash);
   expect(getCastVoteRecordRootHash(client)).toEqual(rootHash);
 
-  const cvr4Hash = updateCastVoteRecordHashesHelper(
+  const cvr4Hash = await updateCastVoteRecordHashesHelper(
     'e1234567-0000-0000-0000-000000000000'
   );
   const e1Hash = sha256(cvr4Hash);
@@ -171,7 +149,7 @@ test('getCastVoteRecordRootHash, updateCastVoteRecordHashes, and clearCastVoteRe
   rootHash = sha256(aHash + eHash);
   expect(getCastVoteRecordRootHash(client)).toEqual(rootHash);
 
-  const cvr5Hash = updateCastVoteRecordHashesHelper(
+  const cvr5Hash = await updateCastVoteRecordHashesHelper(
     'c1234567-0000-0000-0000-000000000000'
   );
   const c1Hash = sha256(cvr5Hash);
@@ -179,7 +157,7 @@ test('getCastVoteRecordRootHash, updateCastVoteRecordHashes, and clearCastVoteRe
   rootHash = sha256(aHash + cHash + eHash); // Reach branching factor of 3 at root
   expect(getCastVoteRecordRootHash(client)).toEqual(rootHash);
 
-  const cvr6Hash = updateCastVoteRecordHashesHelper(
+  const cvr6Hash = await updateCastVoteRecordHashesHelper(
     'ab234567-0000-0000-0000-000000000000'
   );
   abHash = sha256(cvr1Hash + cvr6Hash + cvr2Hash); // Reach branching factor of 3 at level 2
@@ -187,7 +165,7 @@ test('getCastVoteRecordRootHash, updateCastVoteRecordHashes, and clearCastVoteRe
   rootHash = sha256(aHash + cHash + eHash);
   expect(getCastVoteRecordRootHash(client)).toEqual(rootHash);
 
-  const cvr7Hash = updateCastVoteRecordHashesHelper(
+  const cvr7Hash = await updateCastVoteRecordHashesHelper(
     'a2345678-0000-0000-0000-000000000000'
   );
   const a2Hash = sha256(cvr7Hash);

--- a/libs/auth/src/cast_vote_record_hashes.ts
+++ b/libs/auth/src/cast_vote_record_hashes.ts
@@ -10,6 +10,7 @@ import { Client } from '@votingworks/db';
  */
 export interface File {
   fileName: string;
+  open(): NodeJS.ReadableStream;
   computeSha256Hash(): Promise<string>;
 }
 
@@ -329,6 +330,7 @@ export async function computeCastVoteRecordRootHashFromScratch(
       const filePath = path.join(cvrDirectoryPath, fileName);
       cvrFiles.push({
         fileName,
+        open: () => createReadStream(filePath),
         computeSha256Hash: () => computeSha256HashForFile(filePath),
       });
     }

--- a/libs/auth/src/cast_vote_record_hashes.ts
+++ b/libs/auth/src/cast_vote_record_hashes.ts
@@ -1,6 +1,6 @@
-import { Buffer } from 'buffer';
 import fs from 'fs/promises';
-import { sha256 } from 'js-sha256';
+import { createReadStream } from 'fs';
+import { Hasher, sha256 } from 'js-sha256';
 import path from 'path';
 import { assert, groupBy } from '@votingworks/basics';
 import { Client } from '@votingworks/db';
@@ -10,7 +10,7 @@ import { Client } from '@votingworks/db';
  */
 export interface File {
   fileName: string;
-  fileContents: string | Buffer;
+  computeSha256Hash(): Promise<string>;
 }
 
 /**
@@ -19,44 +19,51 @@ export interface File {
  * output of:
  * find <directoryName> -type f | sort | xargs sha256sum
  */
-export function computeSingleCastVoteRecordHash({
+export async function computeSingleCastVoteRecordHash({
   directoryName,
   files,
 }: {
   directoryName: string;
   files: File[];
-}): string {
+}): Promise<string> {
   const filesSorted = [...files].sort((file1, file2) =>
     file1.fileName.localeCompare(file2.fileName)
   );
-  const fileHashes: string[] = [];
-  for (const { fileName, fileContents } of filesSorted) {
-    const filePath = path.join(directoryName, fileName);
+  const hasher = sha256.create();
+  for (const file of filesSorted) {
+    const filePath = path.join(directoryName, file.fileName);
     // Be extra cautious and prevent spoofing the directory summary by using directory/file names
     // with newlines
     assert(!filePath.includes('\n'));
-    fileHashes.push(`${sha256(fileContents)}  ${filePath}\n`);
+    hasher.update(`${await file.computeSha256Hash()}  ${filePath}\n`);
   }
-  const directorySummary = fileHashes.join('');
-  return sha256(directorySummary);
+  return hasher.hex();
 }
 
 /**
- * The input to {@link computeCombinedHash}
+ * A hash that can be combined with other hashes using {@link computeCombinedHash}.
  */
-export type HashesToCombine = Array<{ hash: string; sortKey: string }>;
+export interface CombinableHash {
+  hash: string;
+  sortKey: string;
+}
 
 /**
  * Sorts the provided hashes using the specified sort key, concatenates the hashes, and hashes the
  * result, yielding a combined hash
  */
-export function computeCombinedHash(hashesToCombine: HashesToCombine): string {
-  return sha256(
-    [...hashesToCombine]
-      .sort((entry1, entry2) => entry1.sortKey.localeCompare(entry2.sortKey))
-      .map((entry) => entry.hash)
-      .join('')
-  );
+export function computeCombinedHash(
+  hashesToCombine: Iterable<CombinableHash>
+): string {
+  const hasher = sha256.create();
+
+  for (const { hash } of [...hashesToCombine].sort((entry1, entry2) =>
+    entry1.sortKey.localeCompare(entry2.sortKey)
+  )) {
+    hasher.update(hash);
+  }
+
+  return hasher.hex();
 }
 
 //
@@ -107,6 +114,7 @@ interface Constraint {
 
 function selectCastVoteRecordHashes(
   client: Client,
+  hasher: Hasher,
   {
     cvrIdLevel1PrefixConstraint,
     cvrIdLevel2PrefixConstraint,
@@ -118,7 +126,7 @@ function selectCastVoteRecordHashes(
     cvrIdConstraint: Constraint;
     orderBy: 'cvr_id_level_1_prefix' | 'cvr_id_level_2_prefix' | 'cvr_id';
   }
-): string[] {
+): void {
   // Be extra cautious and run-time validate incoming params so that we don't solely rely on
   // compile-time validation to prevent SQL injection
   for (const constraint of [
@@ -134,7 +142,7 @@ function selectCastVoteRecordHashes(
     )
   );
 
-  const rows = client.all(
+  for (const row of client.each(
     `
     select cvr_hash as cvrHash
     from cvr_hashes
@@ -147,8 +155,10 @@ function selectCastVoteRecordHashes(
     cvrIdLevel1PrefixConstraint.value,
     cvrIdLevel2PrefixConstraint.value,
     cvrIdConstraint.value
-  ) as Array<{ cvrHash: string }>;
-  return rows.map((row) => row.cvrHash);
+  )) {
+    const { cvrHash } = row as { cvrHash: string };
+    hasher.update(cvrHash);
+  }
 }
 
 function insertCastVoteRecordHash(
@@ -223,13 +233,14 @@ export function updateCastVoteRecordHashes(
       cvrHash,
     });
 
-    const cvrHashesForLevel2Prefix = selectCastVoteRecordHashes(client, {
+    const level2Hasher = sha256.create();
+    selectCastVoteRecordHashes(client, level2Hasher, {
       cvrIdLevel1PrefixConstraint: { type: '=', value: cvrIdLevel1Prefix },
       cvrIdLevel2PrefixConstraint: { type: '=', value: cvrIdLevel2Prefix },
       cvrIdConstraint: { type: '!=', value: NULL_VALUE },
       orderBy: 'cvr_id',
     });
-    const level2Hash = sha256(cvrHashesForLevel2Prefix.join(''));
+    const level2Hash = level2Hasher.hex();
     insertCastVoteRecordHash(client, {
       cvrIdLevel1Prefix,
       cvrIdLevel2Prefix,
@@ -237,13 +248,14 @@ export function updateCastVoteRecordHashes(
       cvrHash: level2Hash,
     });
 
-    const level2HashesForLevel1Prefix = selectCastVoteRecordHashes(client, {
+    const level1Hasher = sha256.create();
+    selectCastVoteRecordHashes(client, level1Hasher, {
       cvrIdLevel1PrefixConstraint: { type: '=', value: cvrIdLevel1Prefix },
       cvrIdLevel2PrefixConstraint: { type: '!=', value: NULL_VALUE },
       cvrIdConstraint: { type: '=', value: NULL_VALUE },
       orderBy: 'cvr_id_level_2_prefix',
     });
-    const level1Hash = sha256(level2HashesForLevel1Prefix.join(''));
+    const level1Hash = level1Hasher.hex();
     insertCastVoteRecordHash(client, {
       cvrIdLevel1Prefix,
       cvrIdLevel2Prefix: NULL_VALUE,
@@ -251,13 +263,14 @@ export function updateCastVoteRecordHashes(
       cvrHash: level1Hash,
     });
 
-    const level1Hashes = selectCastVoteRecordHashes(client, {
+    const rootHasher = sha256.create();
+    selectCastVoteRecordHashes(client, rootHasher, {
       cvrIdLevel1PrefixConstraint: { type: '!=', value: NULL_VALUE },
       cvrIdLevel2PrefixConstraint: { type: '=', value: NULL_VALUE },
       cvrIdConstraint: { type: '=', value: NULL_VALUE },
       orderBy: 'cvr_id_level_1_prefix',
     });
-    const rootHash = sha256(level1Hashes.join(''));
+    const rootHash = rootHasher.hex();
     insertCastVoteRecordHash(client, {
       cvrId: NULL_VALUE,
       cvrIdLevel1Prefix: NULL_VALUE,
@@ -279,6 +292,17 @@ export function clearCastVoteRecordHashes(client: Client): void {
 // import-time hash computation.
 //
 
+async function computeSha256HashForFile(filePath: string): Promise<string> {
+  const reader = createReadStream(filePath);
+  const hash = sha256.create();
+
+  for await (const chunk of reader) {
+    hash.update(chunk);
+  }
+
+  return hash.hex();
+}
+
 /**
  * Computes the cast vote record root hash from scratch given the export directory path, reading in
  * all files and computing hashes in memory without the aid of a SQLite DB
@@ -292,7 +316,7 @@ export async function computeCastVoteRecordRootHashFromScratch(
     .filter((entry) => entry.isDirectory())
     .map((directory) => directory.name);
 
-  const cvrHashes: HashesToCombine = [];
+  const cvrHashes: CombinableHash[] = [];
   for (const cvrId of cvrIds) {
     const cvrDirectoryPath = path.join(exportDirectoryPath, cvrId);
     const cvrFileNames = (
@@ -302,19 +326,20 @@ export async function computeCastVoteRecordRootHashFromScratch(
       .map((file) => file.name);
     const cvrFiles: File[] = [];
     for (const fileName of cvrFileNames) {
-      const fileContents = await fs.readFile(
-        path.join(cvrDirectoryPath, fileName)
-      );
-      cvrFiles.push({ fileName, fileContents });
+      const filePath = path.join(cvrDirectoryPath, fileName);
+      cvrFiles.push({
+        fileName,
+        computeSha256Hash: () => computeSha256HashForFile(filePath),
+      });
     }
-    const cvrHash = computeSingleCastVoteRecordHash({
+    const cvrHash = await computeSingleCastVoteRecordHash({
       directoryName: cvrId,
       files: cvrFiles,
     });
     cvrHashes.push({ hash: cvrHash, sortKey: cvrId });
   }
 
-  const level2Hashes: HashesToCombine = groupBy(
+  const level2Hashes: CombinableHash[] = groupBy(
     cvrHashes,
     ({ sortKey: cvrId }) => cvrId.slice(0, 2)
   ).map(([cvrIdLevel2Prefix, cvrHashesForLevel2Prefix]) => ({
@@ -322,7 +347,7 @@ export async function computeCastVoteRecordRootHashFromScratch(
     sortKey: cvrIdLevel2Prefix,
   }));
 
-  const level1Hashes: HashesToCombine = groupBy(
+  const level1Hashes: CombinableHash[] = groupBy(
     level2Hashes,
     ({ sortKey: cvrIdLevel2Prefix }) => cvrIdLevel2Prefix.slice(0, 1)
   ).map(([cvrIdLevel1Prefix, level2HashesForLevel1Prefix]) => ({

--- a/libs/backend/src/scan/cast_vote_records/export.ts
+++ b/libs/backend/src/scan/cast_vote_records/export.ts
@@ -6,8 +6,8 @@ import path from 'path';
 import { Readable } from 'stream';
 import {
   computeSingleCastVoteRecordHash,
-  File,
   prepareSignatureFile,
+  ReadableFile,
 } from '@votingworks/auth';
 import { assertDefined, err, ok, Result } from '@votingworks/basics';
 import {
@@ -113,7 +113,10 @@ function getExportDirectoryPathRelativeToUsbMountPoint(
   );
 }
 
-function fileFromData(fileName: string, fileContents: string | Buffer): File {
+function fileFromData(
+  fileName: string,
+  fileContents: string | Buffer
+): ReadableFile {
   return {
     fileName,
     open: () => Readable.from(fileContents),
@@ -121,7 +124,7 @@ function fileFromData(fileName: string, fileContents: string | Buffer): File {
   };
 }
 
-function fileFromDisk(fileName: string): File {
+function fileFromDisk(fileName: string): ReadableFile {
   return {
     fileName,
     open: () => createReadStream(fileName),
@@ -275,7 +278,7 @@ async function exportCastVoteRecordFilesToUsbDrive(
       ? canonicalizedSheet.interpretation[0].layout
       : undefined;
 
-  const castVoteRecordFilesToExport: File[] = [
+  const castVoteRecordFilesToExport: ReadableFile[] = [
     fileFromData(
       'cast-vote-record-report.json',
       JSON.stringify(castVoteRecordReport)

--- a/libs/backend/src/scan/cast_vote_records/export.ts
+++ b/libs/backend/src/scan/cast_vote_records/export.ts
@@ -1,4 +1,5 @@
 /* istanbul ignore file */
+
 import { Buffer } from 'buffer';
 import { createReadStream } from 'fs';
 import { sha256 } from 'js-sha256';


### PR DESCRIPTION
## Overview
Some perf improvements to #3898.

Rather than reading all the file data for a given directory upfront, read it at the point where we actually need it to compute the hash. Additionally, we don't need to read all the file data for a given file all at once. It can be streamed while we compute the hash incrementally.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated tests.
