### PR TITLE
Have VxScan use new export format for full exports

### DIFF
--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -38,6 +38,10 @@ import {
   getCastVoteRecordRootHash,
   updateCastVoteRecordHashes,
 } from '@votingworks/auth';
+import {
+  BooleanEnvironmentVariableName,
+  isFeatureFlagEnabled,
+} from '@votingworks/utils';
 import { sheetRequiresAdjudication } from './sheet_requires_adjudication';
 import { rootDebug } from './util/debug';
 
@@ -547,6 +551,14 @@ export class Store {
 
     // Allow if no ballots have been counted
     if (!this.getBallotsCounted()) {
+      return true;
+    }
+
+    if (
+      isFeatureFlagEnabled(
+        BooleanEnvironmentVariableName.ENABLE_CONTINUOUS_EXPORT
+      )
+    ) {
       return true;
     }
 

--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -455,7 +455,7 @@ test('voter can cast a ballot that scans successfully ', async () => {
       ...mockMammalPartyResults,
     },
   ]);
-  apiMock.expectExportCastVoteRecordsToUsbDrive();
+  apiMock.expectExportCastVoteRecordsToUsbDrive({ mode: 'polls_closing' });
   apiMock.authenticateAsPollWorker(electionSampleDefinition);
   await screen.findByText('Do you want to close the polls?');
 
@@ -507,7 +507,7 @@ test('voter can cast a ballot that scans successfully ', async () => {
   userEvent.click(await screen.findButton('Save CVRs'));
   await screen.findByRole('heading', { name: 'Save CVRs' });
 
-  apiMock.expectExportCastVoteRecordsToUsbDrive();
+  apiMock.expectExportCastVoteRecordsToUsbDrive({ mode: 'full_export' });
   userEvent.click(await screen.findByText('Save'));
   await screen.findByText('CVRs Saved to USB Drive');
 
@@ -732,7 +732,7 @@ test('open polls, scan ballot, close polls, save results', async () => {
       ...mockMammalPartyResults,
     },
   ]);
-  apiMock.expectExportCastVoteRecordsToUsbDrive();
+  apiMock.expectExportCastVoteRecordsToUsbDrive({ mode: 'polls_closing' });
   apiMock.authenticateAsPollWorker(electionDefinition);
   await screen.findByText('Do you want to close the polls?');
   apiMock.expectSetPollsState('polls_closed_final');

--- a/apps/scan/frontend/src/app_tally_report_paths.test.tsx
+++ b/apps/scan/frontend/src/app_tally_report_paths.test.tsx
@@ -174,7 +174,7 @@ async function closePolls({
   if (latestScannerResultsByParty) {
     apiMock.expectGetScannerResultsByParty(latestScannerResultsByParty);
   }
-  apiMock.expectExportCastVoteRecordsToUsbDrive();
+  apiMock.expectExportCastVoteRecordsToUsbDrive({ mode: 'polls_closing' });
   apiMock.authenticateAsPollWorker(electionDefinition);
   await screen.findByText('Do you want to close the polls?');
   apiMock.expectSetPollsState('polls_closed_final');
@@ -486,7 +486,7 @@ test('polls closed from paused', async () => {
 
   // Close the polls
   apiMock.expectGetScannerResultsByParty(GENERAL_ELECTION_RESULTS);
-  apiMock.expectExportCastVoteRecordsToUsbDrive();
+  apiMock.expectExportCastVoteRecordsToUsbDrive({ mode: 'polls_closing' });
   apiMock.authenticateAsPollWorker(electionDefinition);
   await screen.findByText('Do you want to resume voting?');
   userEvent.click(screen.getByText('No'));

--- a/apps/scan/frontend/src/components/export_results_modal.test.tsx
+++ b/apps/scan/frontend/src/components/export_results_modal.test.tsx
@@ -69,7 +69,7 @@ test('render export modal when a usb drive is mounted as expected and allows exp
   });
   getByText('Save CVRs');
 
-  apiMock.expectExportCastVoteRecordsToUsbDrive();
+  apiMock.expectExportCastVoteRecordsToUsbDrive({ mode: 'full_export' });
   userEvent.click(getByText('Save'));
   await waitFor(() => getByText('CVRs Saved to USB Drive'));
 
@@ -96,7 +96,7 @@ test('render export modal with errors when appropriate', async () => {
   getByText('Save CVRs');
 
   apiMock.mockApiClient.exportCastVoteRecordsToUsbDrive
-    .expectCallWith()
+    .expectCallWith({ mode: 'full_export' })
     .resolves(
       err({ type: 'file-system-error', message: 'Something went wrong.' })
     );

--- a/apps/scan/frontend/src/components/export_results_modal.tsx
+++ b/apps/scan/frontend/src/components/export_results_modal.tsx
@@ -46,16 +46,19 @@ export function ExportResultsModal({
 
   function exportResults() {
     setCurrentState(ModalState.SAVING);
-    exportMutation.mutate(undefined, {
-      onSuccess: (result) => {
-        if (result.isErr()) {
-          setErrorMessage(`Failed to save CVRs. ${result.err().message}`);
-          setCurrentState(ModalState.ERROR);
-        } else {
-          setCurrentState(ModalState.DONE);
-        }
-      },
-    });
+    exportMutation.mutate(
+      { mode: 'full_export' },
+      {
+        onSuccess: (result) => {
+          if (result.isErr()) {
+            setErrorMessage(`Failed to save CVRs. ${result.err().message}`);
+            setCurrentState(ModalState.ERROR);
+          } else {
+            setCurrentState(ModalState.DONE);
+          }
+        },
+      }
+    );
   }
 
   if (currentState === ModalState.ERROR) {

--- a/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
@@ -167,7 +167,7 @@ describe('transitions from polls open', () => {
   });
 
   test('close polls happy path', async () => {
-    apiMock.expectExportCastVoteRecordsToUsbDrive();
+    apiMock.expectExportCastVoteRecordsToUsbDrive({ mode: 'polls_closing' });
     apiMock.expectSetPollsState('polls_closed_final');
     apiMock.expectGetConfig({ pollsState: 'polls_closed_final' });
     userEvent.click(screen.getByText('Yes, Close the Polls'));
@@ -185,7 +185,7 @@ describe('transitions from polls open', () => {
   });
 
   test('close polls from landing screen', async () => {
-    apiMock.expectExportCastVoteRecordsToUsbDrive();
+    apiMock.expectExportCastVoteRecordsToUsbDrive({ mode: 'polls_closing' });
     apiMock.expectSetPollsState('polls_closed_final');
     apiMock.expectGetConfig({ pollsState: 'polls_closed_final' });
     userEvent.click(screen.getByText('No'));
@@ -278,7 +278,7 @@ describe('transitions from polls paused', () => {
   test('close polls from landing screen', async () => {
     apiMock.expectSetPollsState('polls_closed_final');
     apiMock.expectGetConfig({ pollsState: 'polls_closed_final' });
-    apiMock.expectExportCastVoteRecordsToUsbDrive();
+    apiMock.expectExportCastVoteRecordsToUsbDrive({ mode: 'polls_closing' });
     userEvent.click(screen.getByText('No'));
     userEvent.click(await screen.findByText('Close Polls'));
     await screen.findByText('Closing Polls…');

--- a/apps/scan/frontend/src/screens/poll_worker_screen.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.tsx
@@ -251,7 +251,11 @@ export function PollWorkerScreen({
           : DEFAULT_NUMBER_POLL_REPORT_COPIES
       );
       if (pollsTransition === 'close_polls' && scannedBallotCount > 0) {
-        (await exportCastVoteRecordsMutation.mutateAsync()).unsafeUnwrap();
+        (
+          await exportCastVoteRecordsMutation.mutateAsync({
+            mode: 'polls_closing',
+          })
+        ).unsafeUnwrap();
       }
       setCurrentPollsTransitionTime(timePollsTransitioned);
       await setPollsStateMutation.mutateAsync({

--- a/apps/scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/scan/frontend/test/helpers/mock_api_client.tsx
@@ -144,9 +144,11 @@ export function createApiMock() {
       mockApiClient.getScannerResultsByParty.expectCallWith().resolves(results);
     },
 
-    expectExportCastVoteRecordsToUsbDrive(): void {
+    expectExportCastVoteRecordsToUsbDrive(input: {
+      mode: 'full_export' | 'polls_closing';
+    }): void {
       mockApiClient.exportCastVoteRecordsToUsbDrive
-        .expectCallWith()
+        .expectCallWith(input)
         .resolves(ok());
     },
 


### PR DESCRIPTION
_Easiest reviewed by commit_

## Overview

Issue links: https://github.com/votingworks/vxsuite/issues/3914, https://github.com/votingworks/vxsuite/issues/3916

This PR has VxScan use the new export format for full exports, when the continuous export feature flag is enabled. It also has VxScan update the export metadata on polls close (to indicate that polls have been closed).

## Testing

- [x] Added/updated automated tests
- [x] Tested manually

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ Will revisit logging in later PRs