### PR TITLE
Have VxCentralScan use new export format

### DIFF
--- a/apps/central-scan/backend/schema.sql
+++ b/apps/central-scan/backend/schema.sql
@@ -56,3 +56,27 @@ create table system_settings (
   id integer primary key check (id = 1),
   data text not null -- JSON blob
 );
+
+create table cvr_hashes (
+  cvr_id_level_1_prefix text not null check (
+    length(cvr_id_level_1_prefix) = 1 or
+    length(cvr_id_level_1_prefix) = 0
+  ),
+  cvr_id_level_2_prefix text not null check (
+    length(cvr_id_level_2_prefix) = 2 or
+    length(cvr_id_level_2_prefix) = 0
+  ),
+  cvr_id text not null check (
+    length(cvr_id) = 36 or
+    length(cvr_id) = 0
+  ),
+  cvr_hash text not null check (
+    length(cvr_hash) = 64
+  )
+);
+
+create unique index idx_cvr_hashes ON cvr_hashes (
+  cvr_id_level_1_prefix,
+  cvr_id_level_2_prefix,
+  cvr_id
+);

--- a/apps/central-scan/backend/src/backup.ts
+++ b/apps/central-scan/backend/src/backup.ts
@@ -89,7 +89,7 @@ export class Backup {
         definiteMarkThreshold: this.store.getMarkThresholds().definite,
         isTestMode: this.store.getTestMode(),
         resultSheetGenerator: this.store.forEachResultSheet(),
-        batchInfo: this.store.batchStatus(),
+        batchInfo: this.store.getBatches(),
         reportContext: 'backup',
       })
     );

--- a/apps/central-scan/backend/src/central_scanner_app.ts
+++ b/apps/central-scan/backend/src/central_scanner_app.ts
@@ -117,7 +117,7 @@ function buildApi({
     async deleteBatch({ batchId }: { batchId: string }) {
       const userRole = await getUserRole();
       const numberOfBallotsInBatch = workspace.store
-        .batchStatus()
+        .getBatches()
         .find((batch) => batch.id === batchId)?.count;
 
       await logger.log(LogEventId.DeleteScanBatchInit, userRole, {

--- a/apps/central-scan/backend/src/central_scanner_app.ts
+++ b/apps/central-scan/backend/src/central_scanner_app.ts
@@ -10,6 +10,7 @@ import {
   Usb,
   readBallotPackageFromUsb,
   getContestsForBallotPage,
+  exportCastVoteRecordsToUsbDrive,
 } from '@votingworks/backend';
 import {
   BallotPackageConfigurationError,
@@ -353,20 +354,29 @@ export function buildCentralScannerApp({
       return;
     }
 
-    const exportResult = await exportCastVoteRecordReportToUsbDrive(
-      {
-        electionDefinition,
-        isTestMode: store.getTestMode(),
-        ballotsCounted: store.getBallotsCounted(),
-        batchInfo: store.batchStatus(),
-        getResultSheetGenerator: store.forEachResultSheet.bind(store),
-        definiteMarkThreshold: store.getMarkThresholds().definite,
-        disableOriginalSnapshots: isFeatureFlagEnabled(
-          BooleanEnvironmentVariableName.DISABLE_CVR_ORIGINAL_SNAPSHOTS
-        ),
-      },
-      usb.getUsbDrives
-    );
+    const exportResult = isFeatureFlagEnabled(
+      BooleanEnvironmentVariableName.ENABLE_CONTINUOUS_EXPORT
+    )
+      ? await exportCastVoteRecordsToUsbDrive(
+          store,
+          usb,
+          store.forEachResultSheet(),
+          { scannerType: 'central' }
+        )
+      : await exportCastVoteRecordReportToUsbDrive(
+          {
+            electionDefinition,
+            isTestMode: store.getTestMode(),
+            ballotsCounted: store.getBallotsCounted(),
+            batchInfo: store.getBatches(),
+            getResultSheetGenerator: store.forEachResultSheet.bind(store),
+            definiteMarkThreshold: store.getMarkThresholds().definite,
+            disableOriginalSnapshots: isFeatureFlagEnabled(
+              BooleanEnvironmentVariableName.DISABLE_CVR_ORIGINAL_SNAPSHOTS
+            ),
+          },
+          usb.getUsbDrives
+        );
 
     if (exportResult.isErr()) {
       response.status(500).json({

--- a/apps/central-scan/backend/src/importer.ts
+++ b/apps/central-scan/backend/src/importer.ts
@@ -366,7 +366,7 @@ export class Importer {
   getStatus(): Scan.ScanStatus {
     const electionDefinition = this.workspace.store.getElectionDefinition();
     const canUnconfigure = this.workspace.store.getCanUnconfigure();
-    const batches = this.workspace.store.batchStatus();
+    const batches = this.workspace.store.getBatches();
     const adjudication = this.workspace.store.adjudicationStatus();
 
     return {

--- a/apps/central-scan/backend/src/store.test.ts
+++ b/apps/central-scan/backend/src/store.test.ts
@@ -20,6 +20,7 @@ import { v4 as uuid } from 'uuid';
 import { sleep, typedAs } from '@votingworks/basics';
 import { ResultSheet } from '@votingworks/backend';
 import { electionGridLayoutNewHampshireAmherstFixtures } from '@votingworks/fixtures';
+import { sha256 } from 'js-sha256';
 import { zeroRect } from '../test/fixtures/zero_rect';
 import { Store } from './store';
 
@@ -167,7 +168,7 @@ test('batch cleanup works correctly', () => {
   store.finishBatch({ batchId: firstBatchId });
   store.cleanupIncompleteBatches();
 
-  const batches = store.batchStatus();
+  const batches = store.getBatches();
   expect(batches).toHaveLength(1);
   expect(batches[0].id).toEqual(firstBatchId);
   expect(batches[0].batchNumber).toEqual(1);
@@ -177,7 +178,7 @@ test('batch cleanup works correctly', () => {
   store.addBatch();
   store.finishBatch({ batchId: thirdBatchId });
   store.cleanupIncompleteBatches();
-  const updatedBatches = store.batchStatus();
+  const updatedBatches = store.getBatches();
   expect(
     [...updatedBatches].sort((a, b) => a.label.localeCompare(b.label))
   ).toEqual([
@@ -194,7 +195,7 @@ test('batch cleanup works correctly', () => {
   ]);
 });
 
-test('batchStatus', () => {
+test('getBatches', () => {
   const store = Store.memoryStore();
 
   // Create a batch and add a sheet to it
@@ -229,25 +230,25 @@ test('batchStatus', () => {
       },
     },
   ]);
-  let batches = store.batchStatus();
+  let batches = store.getBatches();
   expect(batches).toHaveLength(1);
   expect(batches[0].count).toEqual(2);
 
   // Delete one of the sheets
   store.deleteSheet(sheetId);
-  batches = store.batchStatus();
+  batches = store.getBatches();
   expect(batches).toHaveLength(1);
   expect(batches[0].count).toEqual(1);
 
-  // Delete the last sheet, then confirm that store.batchStatus() results still include the batch
+  // Delete the last sheet, then confirm that store.getBatches() results still include the batch
   store.deleteSheet(sheetId2);
-  batches = store.batchStatus();
+  batches = store.getBatches();
   expect(batches).toHaveLength(1);
   expect(batches[0].count).toEqual(0);
 
   // Confirm that batches marked as deleted are not included
   store.deleteBatch(batchId);
-  batches = store.batchStatus();
+  batches = store.getBatches();
   expect(batches).toHaveLength(0);
 });
 
@@ -663,7 +664,7 @@ test('resetElectionSession', () => {
   store.addBatch();
   expect(
     store
-      .batchStatus()
+      .getBatches()
       .map((batch) => batch.label)
       .sort((a, b) => a.localeCompare(b))
   ).toEqual(['Batch 1', 'Batch 2']);
@@ -678,14 +679,14 @@ test('resetElectionSession', () => {
   expect(store.getScannerBackupTimestamp()).toBeFalsy();
   expect(store.getCvrsBackupTimestamp()).toBeFalsy();
   // resetElectionSession should clear all batches
-  expect(store.batchStatus()).toEqual([]);
+  expect(store.getBatches()).toEqual([]);
 
   // resetElectionSession should reset the autoincrement in the batch label
   store.addBatch();
   store.addBatch();
   expect(
     store
-      .batchStatus()
+      .getBatches()
       .map((batch) => batch.label)
       .sort((a, b) => a.localeCompare(b))
   ).toEqual(['Batch 1', 'Batch 2']);
@@ -772,4 +773,21 @@ test('systemSettings can set/get/delete', () => {
   expect(systemSettingsInStore).toEqual(DEFAULT_SYSTEM_SETTINGS);
   store.deleteSystemSettings();
   expect(store.getSystemSettings()).toBeUndefined();
+});
+
+test('getCastVoteRecordRootHash, updateCastVoteRecordHashes, and clearCastVoteRecordHashes', () => {
+  const store = Store.memoryStore();
+
+  // Just test that the store has been wired properly. Rely on libs/auth tests for more detailed
+  // coverage of hashing logic.
+  expect(store.getCastVoteRecordRootHash()).toEqual('');
+  store.updateCastVoteRecordHashes(
+    'abcd1234-0000-0000-0000-000000000000',
+    sha256('')
+  );
+  expect(store.getCastVoteRecordRootHash()).toEqual(
+    sha256(sha256(sha256(sha256(''))))
+  );
+  store.clearCastVoteRecordHashes();
+  expect(store.getCastVoteRecordRootHash()).toEqual('');
 });

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -35,6 +35,11 @@ import { DateTime } from 'luxon';
 import { dirname, join } from 'path';
 import { v4 as uuid } from 'uuid';
 import { ResultSheet } from '@votingworks/backend';
+import {
+  clearCastVoteRecordHashes,
+  getCastVoteRecordRootHash,
+  updateCastVoteRecordHashes,
+} from '@votingworks/auth';
 import { sheetRequiresAdjudication } from './sheet_requires_adjudication';
 import { normalizeAndJoin } from './util/path';
 
@@ -778,7 +783,7 @@ export class Store {
   /**
    * Gets all batches, including their sheet count.
    */
-  batchStatus(): BatchInfo[] {
+  getBatches(): BatchInfo[] {
     interface SqliteBatchInfo {
       id: string;
       batchNumber: number;
@@ -894,5 +899,17 @@ export class Store {
         backImagePath: row.backImagePath,
       };
     }
+  }
+
+  getCastVoteRecordRootHash(): string {
+    return getCastVoteRecordRootHash(this.client);
+  }
+
+  updateCastVoteRecordHashes(cvrId: string, cvrHash: string): void {
+    updateCastVoteRecordHashes(this.client, cvrId, cvrHash);
+  }
+
+  clearCastVoteRecordHashes(): void {
+    clearCastVoteRecordHashes(this.client);
   }
 }

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -265,15 +265,16 @@ function buildApi(
       ) {
         switch (input.mode) {
           case 'full_export': {
-            return await exportCastVoteRecordsToUsbDrive(
+            return exportCastVoteRecordsToUsbDrive(
               store,
               usbDrive,
               store.forEachResultSheet(),
-              { isFullExport: true }
+              { scannerType: 'precinct', isFullExport: true }
             );
           }
           case 'polls_closing': {
-            return await exportCastVoteRecordsToUsbDrive(store, usbDrive, [], {
+            return exportCastVoteRecordsToUsbDrive(store, usbDrive, [], {
+              scannerType: 'precinct',
               arePollsClosing: true,
             });
           }

--- a/apps/scan/backend/src/scanners/custom/state_machine.ts
+++ b/apps/scan/backend/src/scanners/custom/state_machine.ts
@@ -446,9 +446,12 @@ async function recordAcceptedSheet(
     )
   ) {
     (
-      await exportCastVoteRecordsToUsbDrive(store, usbDrive, [
-        assertDefined(store.getResultSheet(sheetId)),
-      ])
+      await exportCastVoteRecordsToUsbDrive(
+        store,
+        usbDrive,
+        [assertDefined(store.getResultSheet(sheetId))],
+        { scannerType: 'precinct' }
+      )
     ).unsafeUnwrap();
   }
   debug('Stored accepted sheet: %s', sheetId);

--- a/libs/backend/src/scan/cast_vote_records/export.ts
+++ b/libs/backend/src/scan/cast_vote_records/export.ts
@@ -49,7 +49,7 @@ import {
 import { ResultSheet } from './legacy_export';
 import { buildElectionOptionPositionMap } from './option_map';
 
-type ExportCastVoteRecordToUsbDriveError =
+type ExportCastVoteRecordsToUsbDriveError =
   | { type: 'invalid-sheet-found'; message: string }
   | ExportDataError;
 
@@ -258,7 +258,7 @@ async function exportCastVoteRecordFilesToUsbDrive(
 ): Promise<
   Result<
     { castVoteRecordId: string; castVoteRecordHash: string },
-    ExportCastVoteRecordToUsbDriveError
+    ExportCastVoteRecordsToUsbDriveError
   >
 > {
   const { exporter } = exportContext;
@@ -350,7 +350,7 @@ async function exportMetadataFileToUsbDrive(
   castVoteRecordRootHash: string,
   exportDirectoryPathRelativeToUsbMountPoint: string
 ): Promise<
-  Result<{ metadataFileContents: string }, ExportCastVoteRecordToUsbDriveError>
+  Result<{ metadataFileContents: string }, ExportCastVoteRecordsToUsbDriveError>
 > {
   const { exporter, exportOptions, scannerState } = exportContext;
   const { pollsState } = scannerState;
@@ -401,7 +401,7 @@ async function exportSignatureFileToUsbDrive(
   exportContext: ExportContext,
   metadataFileContents: string,
   exportDirectoryPathRelativeToUsbMountPoint: string
-): Promise<Result<void, ExportCastVoteRecordToUsbDriveError>> {
+): Promise<Result<void, ExportCastVoteRecordsToUsbDriveError>> {
   const { exporter } = exportContext;
 
   const signatureFile = await prepareSignatureFile({
@@ -437,7 +437,7 @@ export async function exportCastVoteRecordsToUsbDrive(
   usbDrive: UsbDrive | LegacyUsb,
   resultSheets: ResultSheet[] | Generator<ResultSheet>,
   exportOptions: ExportOptions
-): Promise<Result<void, ExportCastVoteRecordToUsbDriveError>> {
+): Promise<Result<void, ExportCastVoteRecordsToUsbDriveError>> {
   const exportContext: ExportContext = {
     exporter: new Exporter({
       allowedExportPatterns: SCAN_ALLOWED_EXPORT_PATTERNS,

--- a/libs/backend/src/scan/cast_vote_records/export.ts
+++ b/libs/backend/src/scan/cast_vote_records/export.ts
@@ -8,7 +8,14 @@ import {
   readableFileFromData,
   readableFileFromDisk,
 } from '@votingworks/auth';
-import { assertDefined, err, ok, Result } from '@votingworks/basics';
+import {
+  assert,
+  assertDefined,
+  err,
+  ok,
+  Result,
+  throwIllegalValue,
+} from '@votingworks/basics';
 import {
   BallotIdSchema,
   BallotPageLayout,
@@ -30,6 +37,7 @@ import {
 } from '@votingworks/utils';
 
 import { ExportDataError, Exporter } from '../../exporter';
+import { Usb as LegacyUsb } from '../../mock_usb';
 import { SCAN_ALLOWED_EXPORT_PATTERNS, VX_MACHINE_ID } from '../globals';
 import { buildCastVoteRecord as baseBuildCastVoteRecord } from './build_cast_vote_record';
 import { buildCastVoteRecordReportMetadata as baseBuildCastVoteRecordReportMetadata } from './build_report_metadata';
@@ -53,15 +61,16 @@ export interface ScannerStore {
   getBatches(): BatchInfo[];
   getCastVoteRecordRootHash(): string;
   getElectionDefinition(): ElectionDefinition | undefined;
-  getExportDirectoryName(): string | undefined;
   getMarkThresholds(): MarkThresholds;
-  getPollsState(): PollsState | undefined;
   getTestMode(): boolean;
   updateCastVoteRecordHashes(
     castVoteRecordId: string,
     castVoteRecordHash: string
   ): void;
-  setExportDirectoryName(exportDirectoryName: string): void;
+
+  getExportDirectoryName?(): string | undefined;
+  getPollsState?(): PollsState;
+  setExportDirectoryName?(exportDirectoryName: string): void;
 }
 
 /**
@@ -76,10 +85,17 @@ interface ScannerStateUnchangedByExport {
   pollsState?: PollsState;
 }
 
-interface ExportOptions {
+interface CentralScannerOptions {
+  scannerType: 'central';
+}
+
+interface PrecinctScannerOptions {
+  scannerType: 'precinct';
   arePollsClosing?: boolean;
   isFullExport?: boolean;
 }
+
+type ExportOptions = CentralScannerOptions | PrecinctScannerOptions;
 
 /**
  * A grouping of inputs needed by helpers throughout this file
@@ -110,14 +126,34 @@ function getExportDirectoryPathRelativeToUsbMountPoint(
   const { electionDefinition, inTestMode } = scannerState;
   const { election, electionHash } = electionDefinition;
 
-  let exportDirectoryName = scannerStore.getExportDirectoryName();
-  if (!exportDirectoryName || exportOptions.isFullExport) {
-    exportDirectoryName = generateCastVoteRecordExportDirectoryName({
-      inTestMode,
-      machineId: VX_MACHINE_ID,
-    });
-    scannerStore.setExportDirectoryName(exportDirectoryName);
+  let exportDirectoryName: string | undefined;
+  switch (exportOptions.scannerType) {
+    case 'central': {
+      exportDirectoryName = generateCastVoteRecordExportDirectoryName({
+        inTestMode,
+        machineId: VX_MACHINE_ID,
+      });
+      break;
+    }
+    case 'precinct': {
+      assert(scannerStore.getExportDirectoryName !== undefined);
+      assert(scannerStore.setExportDirectoryName !== undefined);
+      exportDirectoryName = scannerStore.getExportDirectoryName();
+      if (!exportDirectoryName || exportOptions.isFullExport) {
+        exportDirectoryName = generateCastVoteRecordExportDirectoryName({
+          inTestMode,
+          machineId: VX_MACHINE_ID,
+        });
+        scannerStore.setExportDirectoryName(exportDirectoryName);
+      }
+      break;
+    }
+    /* istanbul ignore next: Compile-time check for completeness */
+    default: {
+      throwIllegalValue(exportOptions, 'scannerType');
+    }
   }
+
   return path.join(
     SCANNER_RESULTS_FOLDER,
     generateElectionBasedSubfolderName(election, electionHash),
@@ -319,12 +355,27 @@ async function exportMetadataFileToUsbDrive(
   const { exporter, exportOptions, scannerState } = exportContext;
   const { pollsState } = scannerState;
 
+  let arePollsClosed: boolean | undefined;
+  switch (exportOptions.scannerType) {
+    case 'central': {
+      arePollsClosed = undefined;
+      break;
+    }
+    case 'precinct': {
+      assert(pollsState !== undefined);
+      arePollsClosed = Boolean(
+        pollsState === 'polls_closed_final' || exportOptions.arePollsClosing
+      );
+      break;
+    }
+    /* istanbul ignore next: Compile-time check for completeness */
+    default: {
+      throwIllegalValue(exportOptions, 'scannerType');
+    }
+  }
+
   const metadata: CastVoteRecordExportMetadata = {
-    arePollsClosed: pollsState
-      ? Boolean(
-          pollsState === 'polls_closed_final' || exportOptions.arePollsClosing
-        )
-      : undefined, // Irrelevant for VxCentralScan
+    arePollsClosed,
     castVoteRecordReportMetadata:
       buildCastVoteRecordReportMetadata(exportContext),
     castVoteRecordRootHash,
@@ -383,17 +434,20 @@ async function exportSignatureFileToUsbDrive(
  */
 export async function exportCastVoteRecordsToUsbDrive(
   scannerStore: ScannerStore,
-  usbDrive: UsbDrive,
+  usbDrive: UsbDrive | LegacyUsb,
   resultSheets: ResultSheet[] | Generator<ResultSheet>,
-  exportOptions: ExportOptions = {}
+  exportOptions: ExportOptions
 ): Promise<Result<void, ExportCastVoteRecordToUsbDriveError>> {
   const exportContext: ExportContext = {
     exporter: new Exporter({
       allowedExportPatterns: SCAN_ALLOWED_EXPORT_PATTERNS,
-      getUsbDrives: async () => {
-        const drive = await usbDrive.status();
-        return drive.status === 'mounted' ? [drive] : [];
-      },
+      getUsbDrives:
+        'getUsbDrives' in usbDrive
+          ? usbDrive.getUsbDrives
+          : async () => {
+              const drive = await usbDrive.status();
+              return drive.status === 'mounted' ? [drive] : [];
+            },
     }),
     exportOptions,
     scannerState: {
@@ -401,7 +455,7 @@ export async function exportCastVoteRecordsToUsbDrive(
       electionDefinition: assertDefined(scannerStore.getElectionDefinition()),
       inTestMode: scannerStore.getTestMode(),
       markThresholds: scannerStore.getMarkThresholds(),
-      pollsState: scannerStore.getPollsState(),
+      pollsState: scannerStore.getPollsState?.(),
     },
     scannerStore,
   };
@@ -409,7 +463,7 @@ export async function exportCastVoteRecordsToUsbDrive(
   // Before a full export, clear cast vote record hashes so that they can be recomputed from
   // scratch. This is particularly important for VxCentralScan, where batches can be deleted
   // between exports.
-  if (exportOptions.isFullExport) {
+  if (exportOptions.scannerType === 'central' || exportOptions.isFullExport) {
     scannerStore.clearCastVoteRecordHashes();
   }
 


### PR DESCRIPTION
_Easiest reviewed by commit_

## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/3918

While we're aren't bringing continuous export to VxCentralScan, we do still want to use the new export format on VxCentralScan (multiple CVR JSON files instead of just one) so that VxAdmin only has to worry about one format on import. This PR has VxCentralScan use the new export format, when the continuous export feature flag is enabled.

We've talked about using a slightly modified version of the format on VxCentralScan, where each directory and CVR JSON file corresponds to a batch instead of a single CVR. But I'm not going to make that change until I do some performance testing on the current format. If there's a significant performance benefit to exporting by batch, I'll make changes. Otherwise, the fewer formats, the better.

We've also talked about VxCentralScan only exporting what VxAdmin needs, i.e. skipping images for CVRs without write-ins, with the option to export everything if desired. I plan on introducing that functionality in follow-up PRs. Just focusing on the basics here.

## Testing

- [x] Added/updated automated tests
- [x] Tested manually

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced ➡️ Left existing logging intact