### PR TITLE
Custom Report Builder (alpha)

### DIFF
--- a/apps/admin/backend/src/exports/csv_results.ts
+++ b/apps/admin/backend/src/exports/csv_results.ts
@@ -11,12 +11,11 @@ import {
 } from '@votingworks/types';
 import { assert, assertDefined } from '@votingworks/basics';
 import {
-  convertGroupSpecifierToFilter,
+  combineGroupSpecifierAndFilter,
   getBallotStyleById,
   getPartyById,
   getPrecinctById,
   groupMapToGroupList,
-  mergeFilters,
 } from '@votingworks/utils';
 import { Readable } from 'stream';
 import { ScannerBatch } from '../types';
@@ -193,9 +192,9 @@ function* generateRows({
   const batchLookup = generateBatchLookup(store, assertDefined(electionId));
 
   for (const resultsGroup of resultGroups) {
-    const effectiveFilter = mergeFilters(
-      overallReportFilter,
-      convertGroupSpecifierToFilter(resultsGroup)
+    const effectiveFilter = combineGroupSpecifierAndFilter(
+      resultsGroup,
+      overallReportFilter
     );
     const contestIds = new Set(
       store.getFilteredContests({

--- a/apps/admin/backend/src/tabulation/tally_reports.ts
+++ b/apps/admin/backend/src/tabulation/tally_reports.ts
@@ -3,10 +3,9 @@ import { assert, assertDefined, mapObject } from '@votingworks/basics';
 import {
   coalesceGroupsAcrossParty,
   combineElectionResults,
+  combineGroupSpecifierAndFilter,
   combineManualElectionResults,
-  convertGroupSpecifierToFilter,
   groupMapToGroupList,
-  mergeFilters,
   mergeTabulationGroupMaps,
   mergeWriteInTallies,
 } from '@votingworks/utils';
@@ -37,10 +36,7 @@ function addContestIdsToReports<U>({
   return reports.map((report) => {
     const contestIds = store.getFilteredContests({
       electionId,
-      filter: mergeFilters(
-        overallFilter,
-        convertGroupSpecifierToFilter(report)
-      ),
+      filter: combineGroupSpecifierAndFilter(report, overallFilter),
     });
     return {
       ...report,

--- a/apps/admin/frontend/src/__snapshots__/app.test.tsx.snap
+++ b/apps/admin/frontend/src/__snapshots__/app.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
 }
 
 .c1 {
-  page-break-before: always;
+  page-break-after: always;
 }
 
 .c4 {

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -391,10 +391,15 @@ export const getResultsForTallyReports = {
       ? ['getResultsForTallyReports', input]
       : ['getResultsForTallyReports'];
   },
-  useQuery(input: GetResultsForTallyReports) {
+  useQuery(
+    input: GetResultsForTallyReports,
+    options: { enabled: boolean } = { enabled: true }
+  ) {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(input), () =>
-      apiClient.getResultsForTallyReports(input)
+    return useQuery(
+      this.queryKey(input),
+      () => apiClient.getResultsForTallyReports(input),
+      options
     );
   },
 } as const;

--- a/apps/admin/frontend/src/components/admin_tally_report_by_party.tsx
+++ b/apps/admin/frontend/src/components/admin_tally_report_by_party.tsx
@@ -1,4 +1,4 @@
-import { ElectionDefinition } from '@votingworks/types';
+import { ElectionDefinition, Tabulation } from '@votingworks/types';
 import React from 'react';
 
 import { find, unique } from '@votingworks/basics';
@@ -26,6 +26,7 @@ export function AdminTallyReportByParty({
   tallyReportType,
   testId,
   generatedAtTime,
+  customFilter,
 }: {
   electionDefinition: ElectionDefinition;
   tallyReportResults: TallyReportResults;
@@ -33,6 +34,7 @@ export function AdminTallyReportByParty({
   tallyReportType: TallyReportType;
   testId: string;
   generatedAtTime: Date;
+  customFilter?: Tabulation.Filter;
 }): JSX.Element {
   const { election } = electionDefinition;
   const contests = tallyReportResults.contestIds.map((contestId) =>
@@ -44,7 +46,7 @@ export function AdminTallyReportByParty({
     return (
       <AdminTallyReport
         testId={testId}
-        election={election}
+        electionDefinition={electionDefinition}
         contests={contests}
         scannedElectionResults={tallyReportResults.scannedResults}
         manualElectionResults={tallyReportResults?.manualResults}
@@ -55,6 +57,7 @@ export function AdminTallyReportByParty({
         }
         subtitle={title ? election.title : undefined}
         generatedAtTime={generatedAtTime}
+        customFilter={customFilter}
       />
     );
   }
@@ -79,7 +82,7 @@ export function AdminTallyReportByParty({
       <AdminTallyReport
         key={`${testId}-${partyId}`}
         testId={`${testId}-${partyId}`}
-        election={election}
+        electionDefinition={electionDefinition}
         contests={contests.filter(
           (c) => c.type === 'candidate' && c.partyId === partyId
         )}
@@ -94,6 +97,7 @@ export function AdminTallyReportByParty({
         }
         subtitle={title ? partyElectionTitle : undefined}
         cardCountsOverride={partyCardCounts}
+        customFilter={customFilter}
       />
     );
   }
@@ -107,7 +111,7 @@ export function AdminTallyReportByParty({
       <AdminTallyReport
         key={`${testId}-nonpartisan`}
         testId={`${testId}-nonpartisan`}
-        election={election}
+        electionDefinition={electionDefinition}
         contests={contests.filter((c) => c.type === 'yesno' || !c.partyId)}
         scannedElectionResults={tallyReportResults.scannedResults}
         manualElectionResults={tallyReportResults.manualResults}
@@ -117,6 +121,7 @@ export function AdminTallyReportByParty({
             : `${tallyReportType} ${nonpartisanElectionTitle} Tally Report`
         }
         subtitle={title ? nonpartisanElectionTitle : undefined}
+        customFilter={customFilter}
       />
     );
   }

--- a/apps/admin/frontend/src/components/election_manager.tsx
+++ b/apps/admin/frontend/src/components/election_manager.tsx
@@ -47,6 +47,7 @@ import { SmartcardModal } from './smartcard_modal';
 import { checkPin } from '../api';
 import { canViewAndPrintBallots } from '../utils/can_view_and_print_ballots';
 import { WriteInsAdjudicationScreen } from '../screens/write_ins_adjudication_screen';
+import { TallyReportBuilder } from '../screens/tally_report_builder';
 
 export function ElectionManager(): JSX.Element {
   const { electionDefinition, configuredAt, auth, hasCardReaderAttached } =
@@ -189,6 +190,9 @@ export function ElectionManager(): JSX.Element {
       </Route>
       <Route exact path={routerPaths.reports}>
         <ReportsScreen />
+      </Route>
+      <Route exact path={routerPaths.tallyReportBuilder}>
+        <TallyReportBuilder />
       </Route>
       <Route exact path={routerPaths.tallyFullReport}>
         <FullElectionTallyReportScreen />

--- a/apps/admin/frontend/src/components/reporting/filter_editor.test.tsx
+++ b/apps/admin/frontend/src/components/reporting/filter_editor.test.tsx
@@ -1,0 +1,93 @@
+import { electionMinimalExhaustiveSampleDefinition } from '@votingworks/fixtures';
+import userEvent from '@testing-library/user-event';
+import { renderInAppContext } from '../../../test/render_in_app_context';
+import { FilterEditor } from './filter_editor';
+import { screen, within } from '../../../test/react_testing_library';
+
+test('FilterEditor', () => {
+  const { election } = electionMinimalExhaustiveSampleDefinition;
+  const onChange = jest.fn();
+
+  renderInAppContext(<FilterEditor election={election} onChange={onChange} />);
+
+  // Add filter row, precinct
+  userEvent.click(screen.getByText('Add Filter'));
+  expect(onChange).not.toHaveBeenCalled();
+  userEvent.click(screen.getByLabelText('Select New Filter Type'));
+  userEvent.click(screen.getByText('Precinct'));
+  expect(onChange).toHaveBeenNthCalledWith(1, { precinctIds: [] });
+  userEvent.click(screen.getByLabelText('Select Filter Values'));
+  userEvent.click(screen.getByText('Precinct 1'));
+  expect(onChange).toHaveBeenNthCalledWith(2, { precinctIds: ['precinct-1'] });
+
+  // Edit selections in filter row
+  userEvent.click(screen.getByLabelText('Select Filter Values'));
+  userEvent.click(screen.getByText('Precinct 2'));
+  expect(onChange).toHaveBeenNthCalledWith(3, {
+    precinctIds: ['precinct-1', 'precinct-2'],
+  });
+  userEvent.click(screen.getByLabelText('Remove Precinct 1'));
+  expect(onChange).toHaveBeenNthCalledWith(4, {
+    precinctIds: ['precinct-2'],
+  });
+
+  // Add another filter row, voting method
+  userEvent.click(screen.getByText('Add Filter'));
+  userEvent.click(screen.getByLabelText('Select New Filter Type'));
+  userEvent.click(screen.getByText('Voting Method'));
+  expect(onChange).toHaveBeenNthCalledWith(5, {
+    precinctIds: ['precinct-2'],
+    votingMethods: [],
+  });
+  userEvent.click(
+    within(
+      screen.getByTestId('filter-editor-row-voting-method')
+    ).getByLabelText('Select Filter Values')
+  );
+  userEvent.click(screen.getByText('Absentee'));
+  expect(onChange).toHaveBeenNthCalledWith(6, {
+    precinctIds: ['precinct-2'],
+    votingMethods: ['absentee'],
+  });
+
+  // Edit type of existing filter row, ballot style
+  userEvent.click(
+    within(
+      screen.getByTestId('filter-editor-row-voting-method')
+    ).getByLabelText('Edit Filter Type')
+  );
+  userEvent.click(screen.getByText('Ballot Style'));
+  expect(onChange).toHaveBeenNthCalledWith(7, {
+    precinctIds: ['precinct-2'],
+    ballotStyleIds: [],
+  });
+  userEvent.click(
+    within(screen.getByTestId('filter-editor-row-ballot-style')).getByLabelText(
+      'Select Filter Values'
+    )
+  );
+  screen.getByText('1M');
+  screen.getByText('2F');
+
+  // Remove filter row
+  userEvent.click(
+    within(screen.getByTestId('filter-editor-row-precinct')).getByLabelText(
+      'Remove Filter'
+    )
+  );
+  expect(onChange).toHaveBeenNthCalledWith(8, {
+    ballotStyleIds: [],
+  });
+});
+
+test('FilterEditor - cancel adding filter', () => {
+  const { election } = electionMinimalExhaustiveSampleDefinition;
+  const onChange = jest.fn();
+
+  renderInAppContext(<FilterEditor election={election} onChange={onChange} />);
+
+  userEvent.click(screen.getByText('Add Filter'));
+  userEvent.click(screen.getByLabelText('Cancel Add Filter'));
+  screen.getByText('Add Filter');
+  expect(onChange).not.toHaveBeenCalled();
+});

--- a/apps/admin/frontend/src/components/reporting/filter_editor.tsx
+++ b/apps/admin/frontend/src/components/reporting/filter_editor.tsx
@@ -1,0 +1,289 @@
+import { assert, throwIllegalValue, typedAs } from '@votingworks/basics';
+import { Election, Tabulation } from '@votingworks/types';
+import { useState } from 'react';
+import styled from 'styled-components';
+import { SearchSelect, SelectOption, Icons, Button } from '@votingworks/ui';
+
+export interface FilterEditorProps {
+  onChange: (filter: Tabulation.Filter) => void;
+  election: Election;
+}
+
+const FilterEditorContainer = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+`;
+
+const FilterRow = styled.div`
+  flex-shrink: 0;
+  width: 100%;
+  display: grid;
+  grid-template-columns: 10rem 4rem 1fr 2rem;
+`;
+
+const AddSelectFilterContainer = styled.div`
+  width: 100%;
+  align-self: start;
+  margin-top: 0.1rem;
+  min-height: 3rem;
+`;
+
+const Predicate = styled.div`
+  justify-self: center;
+  display: flex;
+  margin-top: 0.5rem;
+`;
+
+const FilterValueSelectContainer = styled.div`
+  align-self: starts;
+`;
+
+const AddButton = styled(Button)`
+  min-width: 6rem;
+`;
+
+const RemoveButton = styled.button`
+  width: 1.5rem;
+  height: 1.5rem;
+  align-self: start;
+  margin-top: 0.3rem;
+  background: none;
+  border: none;
+  border-radius: 0.25rem;
+  color: ${(p) => p.theme.colors.foreground};
+  line-height: 0rem;
+
+  :focus-visible {
+    outline: ${(p) => p.theme.sizes.bordersRem.thin}rem dashed
+      ${(p) => p.theme.colors.foreground};
+  }
+`;
+
+const FILTER_TYPES = ['precinct', 'voting-method', 'ballot-style'] as const;
+type FilterType = typeof FILTER_TYPES[number];
+
+function getAllowedFilterTypes(): FilterType[] {
+  return ['precinct', 'voting-method', 'ballot-style'];
+}
+
+interface FilterRow {
+  rowId: number;
+  filterType: FilterType;
+  filterValues: string[];
+}
+type FilterRows = FilterRow[];
+
+const FILTER_TYPE_LABELS: Record<FilterType, string> = {
+  precinct: 'Precinct',
+  'voting-method': 'Voting Method',
+  'ballot-style': 'Ballot Style',
+};
+
+function getFilterTypeOption(filterType: FilterType): SelectOption<FilterType> {
+  return {
+    value: filterType,
+    label: FILTER_TYPE_LABELS[filterType],
+  };
+}
+
+function generateOptionsForFilter(
+  filterType: FilterType,
+  election: Election
+): SelectOption[] {
+  switch (filterType) {
+    case 'precinct':
+      return election.precincts.map((precinct) => ({
+        value: precinct.id,
+        label: precinct.name,
+      }));
+    case 'ballot-style':
+      return election.ballotStyles.map((bs) => ({
+        value: bs.id,
+        label: bs.id,
+      }));
+    case 'voting-method':
+      return typedAs<Array<SelectOption<Tabulation.VotingMethod>>>([
+        {
+          value: 'precinct',
+          label: 'Precinct',
+        },
+        {
+          value: 'absentee',
+          label: 'Absentee',
+        },
+      ]);
+    /* istanbul ignore next - compile-time check for completeness */
+    default:
+      throwIllegalValue(filterType);
+  }
+}
+
+// allow modifying filter during construction for convenience
+type Writeable<T> = { -readonly [P in keyof T]: T[P] };
+
+function convertFilterRowsToTabulationFilter(
+  rows: FilterRows
+): Tabulation.Filter {
+  const tabulationFilter: Writeable<Tabulation.Filter> = {};
+  for (const row of rows) {
+    const { filterType, filterValues } = row;
+    switch (filterType) {
+      case 'precinct':
+        tabulationFilter.precinctIds = filterValues;
+        break;
+      case 'voting-method':
+        tabulationFilter.votingMethods =
+          filterValues as Tabulation.VotingMethod[];
+        break;
+      case 'ballot-style':
+        tabulationFilter.ballotStyleIds = filterValues;
+        break;
+      /* istanbul ignore next - compile-time check for completeness */
+      default:
+        throwIllegalValue(filterType);
+    }
+  }
+
+  return tabulationFilter;
+}
+
+export function FilterEditor({
+  onChange,
+  election,
+}: FilterEditorProps): JSX.Element {
+  const [rows, setRows] = useState<FilterRows>([]);
+  const [nextRowId, setNextRowId] = useState(0);
+  const [isAddingRow, setIsAddingRow] = useState(false);
+
+  function onUpdatedRows(updatedRows: FilterRows) {
+    setRows(updatedRows);
+    onChange(convertFilterRowsToTabulationFilter(updatedRows));
+  }
+
+  function addRow(filterType: FilterType) {
+    onUpdatedRows([
+      ...rows,
+      {
+        rowId: nextRowId,
+        filterType,
+        filterValues: [],
+      },
+    ]);
+    setNextRowId((i) => i + 1);
+  }
+
+  function updateRowFilterType(rowId: number, newFilterType: FilterType): void {
+    onUpdatedRows(
+      rows.map((row) =>
+        row.rowId === rowId
+          ? { ...row, filterType: newFilterType, filterValues: [] }
+          : row
+      )
+    );
+  }
+
+  function updateRowFilterValues(rowId: number, filterValues: string[]) {
+    onUpdatedRows(
+      rows.map((row) => (row.rowId === rowId ? { ...row, filterValues } : row))
+    );
+  }
+
+  function deleteRow(rowId: number) {
+    onUpdatedRows(rows.filter((row) => row.rowId !== rowId));
+  }
+
+  const activeFilters: FilterType[] = rows.map((row) => row.filterType);
+  const unusedFilters: FilterType[] = getAllowedFilterTypes().filter(
+    (filterType) => !activeFilters.includes(filterType)
+  );
+
+  return (
+    <FilterEditorContainer data-testid="filter-editor">
+      {rows.map((row) => {
+        const { filterType, rowId } = row;
+        return (
+          <FilterRow
+            key={rowId}
+            data-testid={`filter-editor-row-${filterType}`}
+          >
+            <AddSelectFilterContainer>
+              <SearchSelect
+                isMulti={false}
+                isSearchable={false}
+                value={filterType}
+                options={[
+                  getFilterTypeOption(filterType),
+                  ...unusedFilters.map(getFilterTypeOption),
+                ]}
+                onChange={(newFilterType) => {
+                  assert(newFilterType !== undefined);
+                  updateRowFilterType(rowId, newFilterType);
+                }}
+                ariaLabel="Edit Filter Type"
+              />
+            </AddSelectFilterContainer>
+            <Predicate>equals</Predicate>
+            <FilterValueSelectContainer>
+              <SearchSelect
+                isMulti
+                isSearchable
+                key={filterType}
+                options={generateOptionsForFilter(filterType, election)}
+                value={row.filterValues}
+                onChange={(filterValues) => {
+                  updateRowFilterValues(rowId, filterValues);
+                }}
+                ariaLabel="Select Filter Values"
+              />
+            </FilterValueSelectContainer>
+            <RemoveButton
+              onClick={() => deleteRow(rowId)}
+              aria-label="Remove Filter"
+            >
+              <Icons.X />
+            </RemoveButton>
+          </FilterRow>
+        );
+      })}
+      {unusedFilters.length > 0 && (
+        <FilterRow key="new-row">
+          <AddSelectFilterContainer>
+            {isAddingRow ? (
+              <SearchSelect
+                key={nextRowId}
+                isMulti={false}
+                isSearchable={false}
+                options={unusedFilters
+                  .filter(
+                    (filterType) =>
+                      !rows.some((r) => r.filterType === filterType)
+                  )
+                  .map((filterType) => getFilterTypeOption(filterType))}
+                onChange={(filterType) => {
+                  assert(filterType !== undefined);
+                  addRow(filterType);
+                  setIsAddingRow(false);
+                }}
+                ariaLabel="Select New Filter Type"
+              />
+            ) : (
+              <AddButton onPress={() => setIsAddingRow(true)}>
+                <Icons.AddCircle /> Add Filter
+              </AddButton>
+            )}
+          </AddSelectFilterContainer>
+          {isAddingRow && (
+            <RemoveButton
+              onClick={() => setIsAddingRow(false)}
+              aria-label="Cancel Add Filter"
+            >
+              <Icons.X />
+            </RemoveButton>
+          )}
+        </FilterRow>
+      )}
+    </FilterEditorContainer>
+  );
+}

--- a/apps/admin/frontend/src/components/reporting/group_by_editor.test.tsx
+++ b/apps/admin/frontend/src/components/reporting/group_by_editor.test.tsx
@@ -1,5 +1,4 @@
 import { Tabulation } from '@votingworks/types';
-import { within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { GroupByEditor } from './group_by_editor';
 import { screen } from '../../../test/react_testing_library';
@@ -22,12 +21,14 @@ test('GroupByEditor', () => {
   ];
 
   for (const [label, checked] of items) {
-    const item = screen.getByText(label).parentElement!;
-    within(item).queryByRole('button', { pressed: checked });
+    const button = screen.getByRole('button', {
+      name: `Report By ${label}`,
+      pressed: checked,
+    });
+    expect(button).toHaveTextContent(label);
   }
 
-  const ballotStyleItem = screen.getByText('Ballot Style').parentElement!;
-  userEvent.click(within(ballotStyleItem).getByRole('button'));
+  userEvent.click(screen.getByText('Ballot Style'));
   expect(setGroupBy).toHaveBeenCalledWith({
     ...groupBy,
     groupByBallotStyle: true,

--- a/apps/admin/frontend/src/components/reporting/group_by_editor.test.tsx
+++ b/apps/admin/frontend/src/components/reporting/group_by_editor.test.tsx
@@ -1,0 +1,35 @@
+import { Tabulation } from '@votingworks/types';
+import { within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GroupByEditor } from './group_by_editor';
+import { screen } from '../../../test/react_testing_library';
+import { renderInAppContext } from '../../../test/render_in_app_context';
+
+test('GroupByEditor', () => {
+  const setGroupBy = jest.fn();
+  const groupBy: Tabulation.GroupBy = {
+    groupByPrecinct: true,
+  };
+
+  renderInAppContext(
+    <GroupByEditor groupBy={groupBy} setGroupBy={setGroupBy} />
+  );
+
+  const items: Array<[label: string, checked: boolean]> = [
+    ['Precinct', true],
+    ['Voting Method', false],
+    ['Ballot Style', false],
+  ];
+
+  for (const [label, checked] of items) {
+    const item = screen.getByText(label).parentElement!;
+    within(item).queryByRole('button', { pressed: checked });
+  }
+
+  const ballotStyleItem = screen.getByText('Ballot Style').parentElement!;
+  userEvent.click(within(ballotStyleItem).getByRole('button'));
+  expect(setGroupBy).toHaveBeenCalledWith({
+    ...groupBy,
+    groupByBallotStyle: true,
+  });
+});

--- a/apps/admin/frontend/src/components/reporting/group_by_editor.tsx
+++ b/apps/admin/frontend/src/components/reporting/group_by_editor.tsx
@@ -25,22 +25,28 @@ export interface GroupByEditorProps {
 const Container = styled.div`
   display: grid;
   grid-template-columns: repeat(4, min-content);
-  gap: 1rem;
+  gap: 0.75rem;
 `;
 
-const Item = styled.span`
-  margin-bottom: 0.5rem;
+const Item = styled.button`
+  margin: 0;
+  padding: 0.25rem;
+  cursor: pointer;
   display: flex;
   flex-wrap: nowrap;
   align-items: center;
   gap: 0.5rem;
+  background: none;
+  border: none;
+  font-weight: 300;
+  color: inherit;
 `;
 
 const ItemLabel = styled(Font)`
   white-space: nowrap;
 `;
 
-const CheckboxContainer = styled.button`
+const CheckboxContainer = styled.div`
   border: none;
   background: none;
   padding: 0;
@@ -65,14 +71,15 @@ export function GroupByEditor({
   return (
     <Container data-testid="group-by-editor">
       {allowedGroupings.map((grouping) => {
-        const checked = groupBy[grouping];
+        const checked = Boolean(groupBy[grouping]);
         return (
-          <Item key={grouping}>
-            <CheckboxContainer
-              onClick={() => toggleGrouping(grouping)}
-              aria-label={`Report By ${GROUPING_LABEL[grouping]}`}
-              aria-pressed={checked}
-            >
+          <Item
+            key={grouping}
+            onClick={() => toggleGrouping(grouping)}
+            aria-label={`Report By ${GROUPING_LABEL[grouping]}`}
+            aria-pressed={checked}
+          >
+            <CheckboxContainer>
               <Checkbox checked={checked} />
             </CheckboxContainer>
             <ItemLabel>{GROUPING_LABEL[grouping]}</ItemLabel>

--- a/apps/admin/frontend/src/components/reporting/group_by_editor.tsx
+++ b/apps/admin/frontend/src/components/reporting/group_by_editor.tsx
@@ -1,0 +1,84 @@
+import { Tabulation } from '@votingworks/types';
+import styled from 'styled-components';
+import { Checkbox, Font } from '@votingworks/ui';
+
+type Grouping = keyof Tabulation.GroupBy;
+
+function getAllowedGroupings(): Grouping[] {
+  return ['groupByPrecinct', 'groupByVotingMethod', 'groupByBallotStyle'];
+}
+
+const GROUPING_LABEL: Record<Grouping, string> = {
+  groupByParty: 'Party',
+  groupByPrecinct: 'Precinct',
+  groupByBallotStyle: 'Ballot Style',
+  groupByVotingMethod: 'Voting Method',
+  groupByBatch: 'Batch',
+  groupByScanner: 'Scanner',
+};
+
+export interface GroupByEditorProps {
+  groupBy: Tabulation.GroupBy;
+  setGroupBy: (groupBy: Tabulation.GroupBy) => void;
+}
+
+const Container = styled.div`
+  display: grid;
+  grid-template-columns: repeat(4, min-content);
+  gap: 1rem;
+`;
+
+const Item = styled.span`
+  margin-bottom: 0.5rem;
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  gap: 0.5rem;
+`;
+
+const ItemLabel = styled(Font)`
+  white-space: nowrap;
+`;
+
+const CheckboxContainer = styled.button`
+  border: none;
+  background: none;
+  padding: 0;
+  margin: 0;
+  flex-grow: 0;
+  flex-shrink: 0;
+  font-size: 0.8em;
+`;
+
+export function GroupByEditor({
+  groupBy,
+  setGroupBy,
+}: GroupByEditorProps): JSX.Element {
+  function toggleGrouping(grouping: Grouping): void {
+    setGroupBy({
+      ...groupBy,
+      [grouping]: !groupBy[grouping],
+    });
+  }
+
+  const allowedGroupings = getAllowedGroupings();
+  return (
+    <Container data-testid="group-by-editor">
+      {allowedGroupings.map((grouping) => {
+        const checked = groupBy[grouping];
+        return (
+          <Item key={grouping}>
+            <CheckboxContainer
+              onClick={() => toggleGrouping(grouping)}
+              aria-label={`Report By ${GROUPING_LABEL[grouping]}`}
+              aria-pressed={checked}
+            >
+              <Checkbox checked={checked} />
+            </CheckboxContainer>
+            <ItemLabel>{GROUPING_LABEL[grouping]}</ItemLabel>
+          </Item>
+        );
+      })}
+    </Container>
+  );
+}

--- a/apps/admin/frontend/src/components/reporting/tally_report_viewer.test.tsx
+++ b/apps/admin/frontend/src/components/reporting/tally_report_viewer.test.tsx
@@ -317,5 +317,3 @@ test('displays custom filter rather than specific title when necessary', async (
   screen.getByText(hasTextAcrossElements('Ballot Style: 1'));
   screen.getByText(hasTextAcrossElements('Precinct: North Lincoln'));
 });
-
-// testing for refreshing the preview and other logic on props change is covered by consumers

--- a/apps/admin/frontend/src/components/reporting/tally_report_viewer.test.tsx
+++ b/apps/admin/frontend/src/components/reporting/tally_report_viewer.test.tsx
@@ -1,0 +1,321 @@
+import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import userEvent from '@testing-library/user-event';
+import {
+  deferNextPrint,
+  expectPrint,
+  hasTextAcrossElements,
+  simulateErrorOnNextPrint,
+} from '@votingworks/test-utils';
+import {
+  waitFor,
+  waitForElementToBeRemoved,
+  within,
+} from '@testing-library/react';
+import { LogEventId, fakeLogger } from '@votingworks/logging';
+import { Tabulation } from '@votingworks/types';
+import { ApiMock, createApiMock } from '../../../test/helpers/api_mock';
+import { screen } from '../../../test/react_testing_library';
+import { renderInAppContext } from '../../../test/render_in_app_context';
+import { TallyReportViewer } from './tally_report_viewer';
+import { getSimpleMockTallyResults } from '../../../test/helpers/mock_results';
+
+let apiMock: ApiMock;
+
+beforeEach(() => {
+  apiMock = createApiMock();
+});
+
+afterEach(() => {
+  apiMock.assertComplete();
+});
+
+test('disabled shows disabled buttons and no preview', () => {
+  const { electionDefinition } = electionFamousNames2021Fixtures;
+  renderInAppContext(
+    <TallyReportViewer disabled filter={{}} groupBy={{}} autoPreview={false} />,
+    { apiMock, electionDefinition }
+  );
+
+  expect(screen.getButton('Print Report')).toBeDisabled();
+});
+
+test('autoPreview loads preview automatically', async () => {
+  const { electionDefinition } = electionFamousNames2021Fixtures;
+  const { election } = electionDefinition;
+  apiMock.expectGetResultsForTallyReports(
+    {
+      filter: {},
+      groupBy: {},
+    },
+    [
+      getSimpleMockTallyResults({
+        election,
+        scannedBallotCount: 10,
+      }),
+    ]
+  );
+
+  renderInAppContext(
+    <TallyReportViewer disabled={false} filter={{}} groupBy={{}} autoPreview />,
+    { apiMock, electionDefinition }
+  );
+
+  expect(screen.getButton('Print Report')).not.toBeDisabled();
+  await screen.findByText(
+    'Unofficial Lincoln Municipal General Election Tally Report'
+  );
+  expect(screen.getByTestId('total-ballot-count')).toHaveTextContent('10');
+});
+
+test('autoPreview = false does not load preview automatically', () => {
+  const { electionDefinition } = electionFamousNames2021Fixtures;
+
+  renderInAppContext(
+    <TallyReportViewer
+      disabled={false}
+      filter={{}}
+      groupBy={{}}
+      autoPreview={false}
+    />,
+    { apiMock, electionDefinition }
+  );
+
+  expect(screen.getButton('Print Report')).not.toBeDisabled();
+  screen.getButton('Load Preview');
+});
+
+test('print before loading preview', async () => {
+  const { electionDefinition } = electionFamousNames2021Fixtures;
+  const { election } = electionDefinition;
+  const { resolve: resolveData } = apiMock.expectGetResultsForTallyReports(
+    {
+      filter: {},
+      groupBy: {},
+    },
+    [
+      getSimpleMockTallyResults({
+        election,
+        scannedBallotCount: 10,
+      }),
+    ],
+    true
+  );
+
+  renderInAppContext(
+    <TallyReportViewer
+      disabled={false}
+      filter={{}}
+      groupBy={{}}
+      autoPreview={false}
+    />,
+    { apiMock, electionDefinition }
+  );
+
+  screen.getButton('Load Preview');
+  const { resolve: resolvePrint } = deferNextPrint();
+  userEvent.click(screen.getButton('Print Report'));
+  const modal = await screen.findByRole('alertdialog');
+  await within(modal).findByText('Generating Report');
+  resolveData();
+  await within(modal).findByText('Printing Report');
+  resolvePrint();
+  await waitForElementToBeRemoved(screen.queryByRole('alertdialog'));
+  await expectPrint((printResult) => {
+    printResult.getByText(
+      'Unofficial Lincoln Municipal General Election Tally Report'
+    );
+    expect(printResult.getByTestId('total-ballot-count')).toHaveTextContent(
+      '10'
+    );
+  });
+
+  // the preview will now show the report, because its available
+  screen.getByText(
+    'Unofficial Lincoln Municipal General Election Tally Report'
+  );
+  expect(screen.getByTestId('total-ballot-count')).toHaveTextContent('10');
+});
+
+test('print after preview loaded + test success logging', async () => {
+  const { electionDefinition } = electionFamousNames2021Fixtures;
+  const { election } = electionDefinition;
+  apiMock.expectGetResultsForTallyReports(
+    {
+      filter: {},
+      groupBy: {},
+    },
+    [
+      getSimpleMockTallyResults({
+        election,
+        scannedBallotCount: 10,
+      }),
+    ]
+  );
+
+  const logger = fakeLogger();
+  renderInAppContext(
+    <TallyReportViewer disabled={false} filter={{}} groupBy={{}} autoPreview />,
+    { apiMock, electionDefinition, logger }
+  );
+
+  await screen.findByText(
+    'Unofficial Lincoln Municipal General Election Tally Report'
+  );
+
+  const { resolve: resolvePrint } = deferNextPrint();
+  userEvent.click(screen.getButton('Print Report'));
+  const modal = await screen.findByRole('alertdialog');
+  await within(modal).findByText('Printing Report');
+  resolvePrint();
+  await waitForElementToBeRemoved(screen.queryByRole('alertdialog'));
+  await expectPrint((printResult) => {
+    printResult.getByText(
+      'Unofficial Lincoln Municipal General Election Tally Report'
+    );
+    expect(printResult.getByTestId('total-ballot-count')).toHaveTextContent(
+      '10'
+    );
+  });
+  expect(logger.log).toHaveBeenLastCalledWith(
+    LogEventId.TallyReportPrinted,
+    'election_manager',
+    {
+      disposition: 'success',
+      message: 'User printed a custom tally report from the report builder.',
+    }
+  );
+});
+
+test('print while preview is loading', async () => {
+  const { electionDefinition } = electionFamousNames2021Fixtures;
+  const { election } = electionDefinition;
+  const { resolve: resolveData } = apiMock.expectGetResultsForTallyReports(
+    {
+      filter: {},
+      groupBy: {},
+    },
+    [
+      getSimpleMockTallyResults({
+        election,
+        scannedBallotCount: 10,
+      }),
+    ],
+    true
+  );
+
+  renderInAppContext(
+    <TallyReportViewer
+      disabled={false}
+      filter={{}}
+      groupBy={{}}
+      autoPreview={false}
+    />,
+    { apiMock, electionDefinition }
+  );
+
+  userEvent.click(screen.getButton('Load Preview'));
+  await screen.findByText('Generating Report');
+  expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  const { resolve: resolvePrint } = deferNextPrint();
+  userEvent.click(screen.getButton('Print Report'));
+  const modal = await screen.findByRole('alertdialog');
+  await within(modal).findByText('Generating Report');
+  expect(screen.getAllByText('Generating Report')).toHaveLength(2);
+  resolveData();
+  await within(modal).findByText('Printing Report');
+  resolvePrint();
+  await expectPrint((printResult) => {
+    printResult.getByText(
+      'Unofficial Lincoln Municipal General Election Tally Report'
+    );
+    expect(printResult.getByTestId('total-ballot-count')).toHaveTextContent(
+      '10'
+    );
+  });
+
+  screen.getByText(
+    'Unofficial Lincoln Municipal General Election Tally Report'
+  );
+  expect(screen.getByTestId('total-ballot-count')).toHaveTextContent('10');
+});
+
+test('print failure logging', async () => {
+  const { electionDefinition } = electionFamousNames2021Fixtures;
+  const { election } = electionDefinition;
+  apiMock.expectGetResultsForTallyReports(
+    {
+      filter: {},
+      groupBy: {},
+    },
+    [
+      getSimpleMockTallyResults({
+        election,
+        scannedBallotCount: 10,
+      }),
+    ]
+  );
+
+  const logger = fakeLogger();
+  renderInAppContext(
+    <TallyReportViewer disabled={false} filter={{}} groupBy={{}} autoPreview />,
+    { apiMock, electionDefinition, logger }
+  );
+
+  await screen.findByText(
+    'Unofficial Lincoln Municipal General Election Tally Report'
+  );
+
+  simulateErrorOnNextPrint(new Error('printer broken'));
+  userEvent.click(screen.getButton('Print Report'));
+  await waitFor(() => {
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.TallyReportPrinted,
+      'election_manager',
+      {
+        disposition: 'failure',
+        message:
+          'User attempted to print a custom tally report from the report builder, but an error occurred: printer broken',
+      }
+    );
+  });
+});
+
+test('displays custom filter rather than specific title when necessary', async () => {
+  const { electionDefinition } = electionFamousNames2021Fixtures;
+  const { election } = electionDefinition;
+  const filter: Tabulation.Filter = {
+    ballotStyleIds: ['1'],
+    precinctIds: ['23'],
+    votingMethods: ['absentee'],
+  };
+
+  apiMock.expectGetResultsForTallyReports(
+    {
+      filter,
+      groupBy: {},
+    },
+    [
+      getSimpleMockTallyResults({
+        election,
+        scannedBallotCount: 10,
+      }),
+    ]
+  );
+
+  renderInAppContext(
+    <TallyReportViewer
+      disabled={false}
+      filter={filter}
+      groupBy={{}}
+      autoPreview
+    />,
+    { apiMock, electionDefinition }
+  );
+
+  await screen.findByText('Unofficial Custom Filter Tally Report');
+  screen.getByText(hasTextAcrossElements('Voting Method: Absentee'));
+  screen.getByText(hasTextAcrossElements('Ballot Style: 1'));
+  screen.getByText(hasTextAcrossElements('Precinct: North Lincoln'));
+});
+
+// testing for refreshing the preview and other logic on props change is covered by consumers

--- a/apps/admin/frontend/src/components/reporting/tally_report_viewer.tsx
+++ b/apps/admin/frontend/src/components/reporting/tally_report_viewer.tsx
@@ -236,8 +236,9 @@ export function TallyReportViewer({
         message: `User attempted to print a custom tally report from the report builder, but an error occurred: ${error.message}`,
         disposition: 'failure',
       });
+    } finally {
+      setProgressModalText(undefined);
     }
-    setProgressModalText(undefined);
   }
 
   return (

--- a/apps/admin/frontend/src/components/reporting/tally_report_viewer.tsx
+++ b/apps/admin/frontend/src/components/reporting/tally_report_viewer.tsx
@@ -1,0 +1,300 @@
+import { ElectionDefinition, Tabulation } from '@votingworks/types';
+import {
+  Button,
+  Caption,
+  Font,
+  H6,
+  Icons,
+  Loading,
+  Modal,
+  printElement,
+} from '@votingworks/ui';
+import React, { useContext, useMemo, useRef, useState } from 'react';
+import styled from 'styled-components';
+import { Optional, assert, assertDefined } from '@votingworks/basics';
+import {
+  combineGroupSpecifierAndFilter,
+  isElectionManagerAuth,
+} from '@votingworks/utils';
+import type { TallyReportResults } from '@votingworks/admin-backend';
+import { LogEventId } from '@votingworks/logging';
+import { getResultsForTallyReports } from '../../api';
+import { AppContext } from '../../contexts/app_context';
+import { AdminTallyReportByParty } from '../admin_tally_report_by_party';
+import { PrintButton } from '../print_button';
+import { generateTitleForReport } from '../../utils/reporting';
+
+const ExportActions = styled.div`
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+  display: flex;
+  justify-content: start;
+  gap: 1rem;
+`;
+
+const PreviewContainer = styled.div`
+  position: relative;
+  min-height: 11in;
+  margin-top: 0.5rem;
+  padding: 0.5rem;
+  background: rgba(0, 0, 0, 10%);
+  border-radius: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const PreviewOverlay = styled.div`
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  background: black;
+  opacity: 0.3;
+`;
+
+const PreviewReportPages = styled.div`
+  section {
+    background: white;
+    position: relative;
+    box-shadow: 0 3px 10px rgb(0, 0, 0, 20%);
+    margin-top: 1rem;
+    margin-bottom: 2rem;
+    width: 8.5in;
+    min-height: 11in;
+    padding: 0.5in;
+  }
+`;
+
+const PreviewActionContainer = styled.div`
+  position: absolute;
+  inset: 0;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 4rem;
+  display: flex;
+  justify-content: center;
+  align-items: start;
+  z-index: 2;
+`;
+
+const LoadingTextContainer = styled.div`
+  background: white;
+  width: 35rem;
+  border-radius: 0.5rem;
+`;
+
+function Reports({
+  electionDefinition,
+  isOfficialResults,
+  allTallyReportResults,
+  filterUsed,
+  generatedAtTime,
+}: {
+  electionDefinition: ElectionDefinition;
+  isOfficialResults: boolean;
+  allTallyReportResults: Tabulation.GroupList<TallyReportResults>;
+  filterUsed: Tabulation.Filter;
+  generatedAtTime: Date;
+}): JSX.Element {
+  const allReports: JSX.Element[] = [];
+
+  for (const [index, tallyReportResults] of allTallyReportResults.entries()) {
+    const sectionFilter = combineGroupSpecifierAndFilter(
+      tallyReportResults,
+      filterUsed
+    );
+    const titleGeneration = generateTitleForReport({
+      filter: sectionFilter,
+      electionDefinition,
+    });
+    const title = titleGeneration.isOk()
+      ? titleGeneration.ok()
+      : 'Custom Filter Tally Report';
+    const displayedFilter = !titleGeneration.isOk() ? sectionFilter : undefined;
+
+    allReports.push(
+      <AdminTallyReportByParty
+        electionDefinition={electionDefinition}
+        testId="tally-report"
+        key={`tally-report-${index}`}
+        title={title}
+        tallyReportResults={tallyReportResults}
+        tallyReportType={isOfficialResults ? 'Official' : 'Unofficial'}
+        generatedAtTime={generatedAtTime}
+        customFilter={displayedFilter}
+      />
+    );
+  }
+
+  return <React.Fragment>{allReports}</React.Fragment>;
+}
+
+export interface TallyReportViewerProps {
+  filter: Tabulation.Filter;
+  groupBy: Tabulation.GroupBy;
+  disabled: boolean;
+  autoPreview: boolean;
+}
+
+export function TallyReportViewer({
+  filter,
+  groupBy,
+  disabled,
+  autoPreview,
+}: TallyReportViewerProps): JSX.Element {
+  const { electionDefinition, isOfficialResults, auth, logger } =
+    useContext(AppContext);
+  assert(electionDefinition);
+  assert(isElectionManagerAuth(auth));
+  const userRole = auth.user.role;
+
+  const [isFetchingForPreview, setIsFetchingForPreview] = useState(false);
+  const [progressModalText, setProgressModalText] = useState<string>();
+
+  const reportResultsQuery = getResultsForTallyReports.useQuery(
+    {
+      filter,
+      groupBy,
+    },
+    { enabled: !disabled && autoPreview }
+  );
+  const reportResultsAreFresh =
+    reportResultsQuery.isSuccess && !reportResultsQuery.isStale;
+
+  const previewReportRef = useRef<Optional<JSX.Element>>();
+  const previewReport: Optional<JSX.Element> = useMemo(() => {
+    // Avoid populating the preview with cached data before the caller signals that the parameters are viable
+    if (disabled) {
+      return undefined;
+    }
+
+    // If there's not current fresh data, return the previous preview report
+    if (!reportResultsAreFresh) {
+      return previewReportRef.current;
+    }
+
+    return (
+      <Reports
+        electionDefinition={assertDefined(electionDefinition)}
+        filterUsed={filter}
+        allTallyReportResults={reportResultsQuery.data}
+        generatedAtTime={new Date(reportResultsQuery.dataUpdatedAt)}
+        isOfficialResults={isOfficialResults}
+      />
+    );
+  }, [
+    disabled,
+    reportResultsAreFresh,
+    electionDefinition,
+    filter,
+    reportResultsQuery.data,
+    reportResultsQuery.dataUpdatedAt,
+    isOfficialResults,
+  ]);
+  previewReportRef.current = previewReport;
+  const previewIsFresh =
+    reportResultsQuery.isSuccess && !reportResultsQuery.isStale;
+
+  async function refreshPreview() {
+    setIsFetchingForPreview(true);
+    await reportResultsQuery.refetch();
+    setIsFetchingForPreview(false);
+  }
+
+  async function getFreshQueryResult(): Promise<typeof reportResultsQuery> {
+    if (reportResultsAreFresh) {
+      return reportResultsQuery;
+    }
+
+    return reportResultsQuery.refetch({ cancelRefetch: false });
+  }
+
+  async function printReport() {
+    setProgressModalText('Generating Report');
+    const queryResults = await getFreshQueryResult();
+    assert(queryResults.isSuccess);
+    const reportToPrint = (
+      <Reports
+        electionDefinition={assertDefined(electionDefinition)}
+        filterUsed={filter}
+        allTallyReportResults={queryResults.data}
+        generatedAtTime={new Date(queryResults.dataUpdatedAt)}
+        isOfficialResults={isOfficialResults}
+      />
+    );
+
+    setProgressModalText('Printing Report');
+    try {
+      await printElement(reportToPrint, { sides: 'one-sided' });
+      await logger.log(LogEventId.TallyReportPrinted, userRole, {
+        message: `User printed a custom tally report from the report builder.`,
+        disposition: 'success',
+      });
+    } catch (error) {
+      assert(error instanceof Error);
+      await logger.log(LogEventId.TallyReportPrinted, userRole, {
+        message: `User attempted to print a custom tally report from the report builder, but an error occurred: ${error.message}`,
+        disposition: 'failure',
+      });
+    }
+    setProgressModalText(undefined);
+  }
+
+  return (
+    <React.Fragment>
+      <ExportActions>
+        <PrintButton
+          print={printReport}
+          variant="primary"
+          disabled={disabled}
+          useDefaultProgressModal={false}
+        >
+          Print Report
+        </PrintButton>
+      </ExportActions>
+
+      <Caption>
+        <Icons.Info /> <Font weight="bold">Note:</Font> Printed reports may be
+        paginated to more than one piece of paper.
+      </Caption>
+      <PreviewContainer>
+        {!disabled && (
+          <React.Fragment>
+            {previewReport && (
+              <PreviewReportPages>{previewReport}</PreviewReportPages>
+            )}
+            {!previewIsFresh && <PreviewOverlay />}
+            {isFetchingForPreview && (
+              <PreviewActionContainer>
+                <LoadingTextContainer>
+                  <Loading>Generating Report</Loading>
+                </LoadingTextContainer>
+              </PreviewActionContainer>
+            )}
+            {!isFetchingForPreview && !previewIsFresh && (
+              <PreviewActionContainer>
+                {previewReport ? (
+                  <Button onPress={refreshPreview}>
+                    <Icons.RotateRight /> Refresh Preview
+                  </Button>
+                ) : (
+                  <Button onPress={refreshPreview}>Load Preview</Button>
+                )}
+              </PreviewActionContainer>
+            )}
+          </React.Fragment>
+        )}
+      </PreviewContainer>
+      {progressModalText && (
+        <Modal
+          centerContent
+          content={
+            <H6>
+              <Loading>{progressModalText}</Loading>
+            </H6>
+          }
+        />
+      )}
+    </React.Fragment>
+  );
+}

--- a/apps/admin/frontend/src/router_paths.ts
+++ b/apps/admin/frontend/src/router_paths.ts
@@ -44,6 +44,7 @@ export const routerPaths = {
     `/reports/tally-reports/scanners/${scannerId}`,
   tallyBatchReport: ({ batchId }: BatchReportScreenProps): string =>
     `/reports/tally-reports/batches/${batchId}`,
+  tallyReportBuilder: `/reports/tally-reports/builder`,
   tallyWriteInReport: '/reports/tally-reports/writein',
   logicAndAccuracy: '/logic-and-accuracy',
   testDecks: '/logic-and-accuracy/test-decks',

--- a/apps/admin/frontend/src/screens/reports_screen.tsx
+++ b/apps/admin/frontend/src/screens/reports_screen.tsx
@@ -206,6 +206,11 @@ export function ReportsScreen(): JSX.Element {
             {statusPrefix} Write-In Adjudication Report
           </LinkButton>
         </P>
+        <P>
+          <LinkButton to={routerPaths.tallyReportBuilder}>
+            Tally Report Builder
+          </LinkButton>
+        </P>
         {tallyResultsInfo}
       </NavigationScreen>
       {isExportResultsModalOpen && (

--- a/apps/admin/frontend/src/screens/tally_report_builder.test.tsx
+++ b/apps/admin/frontend/src/screens/tally_report_builder.test.tsx
@@ -43,8 +43,7 @@ test('happy path', async () => {
   screen.getButton('Load Preview');
 
   // Add Group By
-  const precinctGroupByItem = screen.getByText('Precinct').parentElement!;
-  userEvent.click(within(precinctGroupByItem).getByRole('button'));
+  userEvent.click(screen.getButton('Report By Precinct'));
 
   // Load Preview
   apiMock.expectGetResultsForTallyReports(

--- a/apps/admin/frontend/src/screens/tally_report_builder.test.tsx
+++ b/apps/admin/frontend/src/screens/tally_report_builder.test.tsx
@@ -1,0 +1,129 @@
+import { electionMinimalExhaustiveSampleDefinition } from '@votingworks/fixtures';
+import userEvent from '@testing-library/user-event';
+import { expectPrint } from '@votingworks/test-utils';
+import { ApiMock, createApiMock } from '../../test/helpers/api_mock';
+import { renderInAppContext } from '../../test/render_in_app_context';
+import { TallyReportBuilder } from './tally_report_builder';
+import { screen, within } from '../../test/react_testing_library';
+import { getSimpleMockTallyResults } from '../../test/helpers/mock_results';
+import { canonicalizeFilter, canonicalizeGroupBy } from '../utils/reporting';
+
+let apiMock: ApiMock;
+
+beforeEach(() => {
+  apiMock = createApiMock();
+});
+
+afterEach(() => {
+  apiMock.assertComplete();
+});
+
+test('happy path', async () => {
+  const electionDefinition = electionMinimalExhaustiveSampleDefinition;
+  const { election } = electionDefinition;
+  renderInAppContext(<TallyReportBuilder />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  expect(screen.getButton('Print Report')).toBeDisabled();
+  expect(screen.queryByText('Load Preview')).not.toBeInTheDocument();
+
+  // Add Filter
+  userEvent.click(screen.getByText('Add Filter'));
+  userEvent.click(screen.getByLabelText('Select New Filter Type'));
+  userEvent.click(
+    within(screen.getByTestId('filter-editor')).getByText('Voting Method')
+  );
+  screen.getByText('equals');
+  userEvent.click(screen.getByLabelText('Select Filter Values'));
+  userEvent.click(screen.getByText('Absentee'));
+
+  expect(screen.getButton('Print Report')).not.toBeDisabled();
+  screen.getButton('Load Preview');
+
+  // Add Group By
+  const precinctGroupByItem = screen.getByText('Precinct').parentElement!;
+  userEvent.click(within(precinctGroupByItem).getByRole('button'));
+
+  // Load Preview
+  apiMock.expectGetResultsForTallyReports(
+    {
+      filter: canonicalizeFilter({
+        votingMethods: ['absentee'],
+      }),
+      groupBy: canonicalizeGroupBy({
+        groupByPrecinct: true,
+      }),
+    },
+    [
+      {
+        precinctId: 'precinct-1',
+        ...getSimpleMockTallyResults({ election, scannedBallotCount: 10 }),
+      },
+      {
+        precinctId: 'precinct-2',
+        ...getSimpleMockTallyResults({ election, scannedBallotCount: 20 }),
+      },
+    ]
+  );
+  userEvent.click(screen.getButton('Load Preview'));
+
+  await screen.findByText('Unofficial Precinct 1 Absentee Ballot Tally Report');
+  const precinct1Page = screen
+    .getByText('Unofficial Precinct 1 Absentee Ballot Tally Report')
+    .closest('section')!;
+  expect(
+    within(precinct1Page).getByTestId('total-ballot-count')
+  ).toHaveTextContent('10');
+
+  screen.getByText('Unofficial Precinct 2 Absentee Ballot Tally Report');
+
+  // Change Report Parameters
+  userEvent.click(screen.getByLabelText('Remove Absentee'));
+  userEvent.click(screen.getByLabelText('Select Filter Values'));
+  userEvent.click(
+    within(screen.getByTestId('filter-editor')).getByText('Precinct')
+  );
+  screen.getByText('Refresh Preview');
+
+  // Refresh Preview
+  apiMock.expectGetResultsForTallyReports(
+    {
+      filter: canonicalizeFilter({
+        votingMethods: ['precinct'],
+      }),
+      groupBy: canonicalizeGroupBy({
+        groupByPrecinct: true,
+      }),
+    },
+    [
+      {
+        precinctId: 'precinct-1',
+        ...getSimpleMockTallyResults({ election, scannedBallotCount: 10 }),
+      },
+      {
+        precinctId: 'precinct-2',
+        ...getSimpleMockTallyResults({ election, scannedBallotCount: 20 }),
+      },
+    ]
+  );
+  userEvent.click(screen.getByText('Refresh Preview'));
+
+  await screen.findByText('Unofficial Precinct 1 Precinct Ballot Tally Report');
+  screen.getByText('Unofficial Precinct 2 Precinct Ballot Tally Report');
+
+  // Print Report
+  userEvent.click(screen.getButton('Print Report'));
+  await expectPrint((printResult) => {
+    printResult.getByText('Unofficial Precinct 1 Precinct Ballot Tally Report');
+    const printedPrecinct1Page = printResult
+      .getByText('Unofficial Precinct 1 Precinct Ballot Tally Report')
+      .closest('section')!;
+    expect(
+      within(printedPrecinct1Page).getByTestId('total-ballot-count')
+    ).toHaveTextContent('10');
+
+    printResult.getByText('Unofficial Precinct 2 Precinct Ballot Tally Report');
+  });
+});

--- a/apps/admin/frontend/src/screens/tally_report_builder.tsx
+++ b/apps/admin/frontend/src/screens/tally_report_builder.tsx
@@ -1,0 +1,86 @@
+import { Font, H3, Icons, LinkButton, P } from '@votingworks/ui';
+import { useContext, useState } from 'react';
+import { assert } from '@votingworks/basics';
+import {
+  isElectionManagerAuth,
+  isFilterEmpty,
+  isGroupByEmpty,
+} from '@votingworks/utils';
+import { Tabulation } from '@votingworks/types';
+import styled from 'styled-components';
+import { AppContext } from '../contexts/app_context';
+import { NavigationScreen } from '../components/navigation_screen';
+import { routerPaths } from '../router_paths';
+import { FilterEditor } from '../components/reporting/filter_editor';
+import { GroupByEditor } from '../components/reporting/group_by_editor';
+import { TallyReportViewer } from '../components/reporting/tally_report_viewer';
+import { canonicalizeFilter, canonicalizeGroupBy } from '../utils/reporting';
+
+const SCREEN_TITLE = 'Tally Report Builder';
+
+const FilterEditorContainer = styled.div`
+  width: 80%;
+  margin-bottom: 2rem;
+`;
+
+const GroupByEditorContainer = styled.div`
+  width: 80%;
+  margin-top: 1rem;
+  margin-bottom: 2rem;
+`;
+
+export function TallyReportBuilder(): JSX.Element {
+  const { electionDefinition, auth } = useContext(AppContext);
+  assert(electionDefinition);
+  assert(isElectionManagerAuth(auth)); // TODO(auth) check permissions for viewing tally reports.
+  const { election } = electionDefinition;
+
+  const [filter, setFilter] = useState<Tabulation.Filter>({});
+  const [groupBy, setGroupBy] = useState<Tabulation.GroupBy>({});
+
+  function updateFilter(newFilter: Tabulation.Filter) {
+    setFilter(canonicalizeFilter(newFilter));
+  }
+
+  function updateGroupBy(newGroupBy: Tabulation.GroupBy) {
+    setGroupBy(canonicalizeGroupBy(newGroupBy));
+  }
+
+  const hasMadeSelections = !isFilterEmpty(filter) || !isGroupByEmpty(groupBy);
+  return (
+    <NavigationScreen title={SCREEN_TITLE}>
+      <P>
+        <LinkButton small to={routerPaths.reports}>
+          <Icons.Previous /> Back
+        </LinkButton>
+      </P>
+      <P>
+        Use the report builder to create custom reports for print or export.
+      </P>
+      <ul>
+        <li>
+          <Font weight="bold">Filters</Font> restrict the report to ballots
+          matching the criteria
+        </li>
+        <li>
+          <Font weight="bold">Report By</Font> organizes the results into
+          multiple reports
+        </li>
+      </ul>
+      <H3>Filters</H3>
+      <FilterEditorContainer>
+        <FilterEditor election={election} onChange={updateFilter} />
+      </FilterEditorContainer>
+      <H3>Report By</H3>
+      <GroupByEditorContainer>
+        <GroupByEditor groupBy={groupBy} setGroupBy={updateGroupBy} />
+      </GroupByEditorContainer>
+      <TallyReportViewer
+        filter={filter}
+        groupBy={groupBy}
+        disabled={!hasMadeSelections}
+        autoPreview={false}
+      />
+    </NavigationScreen>
+  );
+}

--- a/apps/admin/frontend/src/screens/tally_report_builder.tsx
+++ b/apps/admin/frontend/src/screens/tally_report_builder.tsx
@@ -25,7 +25,7 @@ const FilterEditorContainer = styled.div`
 
 const GroupByEditorContainer = styled.div`
   width: 80%;
-  margin-top: 1rem;
+  margin-top: 0.5rem;
   margin-bottom: 2rem;
 `;
 

--- a/apps/admin/frontend/src/utils/reporting.test.ts
+++ b/apps/admin/frontend/src/utils/reporting.test.ts
@@ -1,0 +1,154 @@
+import { Tabulation } from '@votingworks/types';
+import { electionMinimalExhaustiveSampleDefinition } from '@votingworks/fixtures';
+import { err, ok } from '@votingworks/basics';
+import {
+  canonicalizeFilter,
+  canonicalizeGroupBy,
+  generateTitleForReport,
+} from './reporting';
+
+test('generateTitleForReport', () => {
+  const electionDefinition = electionMinimalExhaustiveSampleDefinition;
+  const unsupportedFilters: Tabulation.Filter[] = [
+    {
+      precinctIds: ['precinct-1', 'precinct-2'],
+    },
+    {
+      ballotStyleIds: ['1M', '2F'],
+    },
+    {
+      batchIds: ['1', '2'],
+    },
+    {
+      scannerIds: ['1', '2'],
+    },
+    {
+      votingMethods: ['absentee', 'precinct'],
+    },
+    {
+      partyIds: ['0', '1'],
+    },
+    {
+      precinctIds: ['precinct-1'],
+      ballotStyleIds: ['1M'],
+      batchIds: ['1'],
+    },
+    {
+      scannerIds: ['1'],
+      votingMethods: ['absentee'],
+      partyIds: ['1'],
+    },
+    {
+      batchIds: ['1'], // TODO: add support for batchIds
+    },
+    {
+      scannerIds: ['1'], // TODO: add support for scannerIds
+    },
+  ];
+
+  for (const filter of unsupportedFilters) {
+    expect(generateTitleForReport({ filter, electionDefinition })).toEqual(
+      err('title-not-supported')
+    );
+  }
+
+  const supportedFilters: Array<[filter: Tabulation.Filter, title: string]> = [
+    [
+      {
+        precinctIds: ['precinct-1'],
+      },
+      'Precinct 1 Tally Report',
+    ],
+    [
+      {
+        ballotStyleIds: ['1M'],
+      },
+      'Ballot Style 1M Tally Report',
+    ],
+    [
+      {
+        votingMethods: ['absentee'],
+      },
+      'Absentee Ballot Tally Report',
+    ],
+    [
+      {
+        precinctIds: ['precinct-1'],
+        ballotStyleIds: ['1M'],
+      },
+      'Ballot Style 1M Precinct 1 Tally Report',
+    ],
+    [
+      {
+        precinctIds: ['precinct-1'],
+        votingMethods: ['absentee'],
+      },
+      'Precinct 1 Absentee Ballot Tally Report',
+    ],
+    [
+      {
+        ballotStyleIds: ['1M'],
+        votingMethods: ['absentee'],
+      },
+      'Ballot Style 1M Absentee Ballot Tally Report',
+    ],
+  ];
+
+  for (const [filter, title] of supportedFilters) {
+    expect(generateTitleForReport({ filter, electionDefinition })).toEqual(
+      ok(title)
+    );
+  }
+});
+
+test('canonicalizeFilter', () => {
+  expect(canonicalizeFilter({})).toEqual({});
+  expect(
+    canonicalizeFilter({
+      precinctIds: [],
+      ballotStyleIds: [],
+      batchIds: [],
+      scannerIds: [],
+      votingMethods: [],
+      partyIds: [],
+    })
+  ).toEqual({});
+  expect(
+    canonicalizeFilter({
+      precinctIds: ['b', 'a'],
+      ballotStyleIds: ['b', 'a'],
+      batchIds: ['b', 'a'],
+      scannerIds: ['b', 'a'],
+      votingMethods: ['precinct', 'absentee'],
+      partyIds: ['b', 'a'],
+    })
+  ).toEqual({
+    precinctIds: ['a', 'b'],
+    ballotStyleIds: ['a', 'b'],
+    batchIds: ['a', 'b'],
+    scannerIds: ['a', 'b'],
+    votingMethods: ['absentee', 'precinct'],
+    partyIds: ['a', 'b'],
+  });
+});
+
+test('canonicalizeGroupBy', () => {
+  expect(canonicalizeGroupBy({})).toEqual({
+    groupByScanner: false,
+    groupByBatch: false,
+    groupByBallotStyle: false,
+    groupByPrecinct: false,
+    groupByParty: false,
+    groupByVotingMethod: false,
+  });
+
+  const allTrueGroupBy: Tabulation.GroupBy = {
+    groupByScanner: true,
+    groupByBatch: true,
+    groupByBallotStyle: true,
+    groupByPrecinct: true,
+    groupByParty: true,
+    groupByVotingMethod: true,
+  };
+  expect(canonicalizeGroupBy(allTrueGroupBy)).toEqual(allTrueGroupBy);
+});

--- a/apps/admin/frontend/src/utils/reporting.ts
+++ b/apps/admin/frontend/src/utils/reporting.ts
@@ -1,0 +1,144 @@
+import { ElectionDefinition, Tabulation } from '@votingworks/types';
+import { Optional, Result, err, ok } from '@votingworks/basics';
+import { getPrecinctById } from '@votingworks/utils';
+
+const VOTING_METHOD_LABELS: Record<Tabulation.VotingMethod, string> = {
+  absentee: 'Absentee',
+  precinct: 'Precinct',
+  provisional: 'Provisional',
+};
+
+/**
+ * Attempts to generate a title for the report based on it's filter.
+ */
+export function generateTitleForReport({
+  filter,
+  electionDefinition,
+}: {
+  filter: Tabulation.Filter;
+  electionDefinition: ElectionDefinition;
+}): Result<Optional<string>, 'title-not-supported'> {
+  // If the report has any compound filters, we don't try to intelligently generate a title.
+  if (
+    (filter.partyIds && filter.partyIds.length > 1) ||
+    (filter.ballotStyleIds && filter.ballotStyleIds.length > 1) ||
+    (filter.precinctIds && filter.precinctIds.length > 1) ||
+    (filter.batchIds && filter.batchIds.length > 1) ||
+    (filter.scannerIds && filter.scannerIds.length > 1) ||
+    (filter.votingMethods && filter.votingMethods.length > 1)
+  ) {
+    return err('title-not-supported');
+  }
+
+  const ballotStyleId = filter.ballotStyleIds?.[0];
+  const precinctId = filter.precinctIds?.[0];
+  const batchId = filter.batchIds?.[0];
+  const scannerId = filter.scannerIds?.[0];
+  const votingMethod = filter.votingMethods?.[0];
+  const partyId = filter.partyIds?.[0];
+
+  const reportRank =
+    (ballotStyleId ? 1 : 0) +
+    (precinctId ? 1 : 0) +
+    (batchId ? 1 : 0) +
+    (scannerId ? 1 : 0) +
+    (votingMethod ? 1 : 0) +
+    (partyId ? 1 : 0);
+
+  // Full Election Tally Report
+  if (reportRank === 0) {
+    return ok(undefined);
+  }
+
+  if (reportRank === 1) {
+    if (precinctId) {
+      return ok(
+        `${getPrecinctById(electionDefinition, precinctId).name} Tally Report`
+      );
+    }
+
+    if (ballotStyleId) {
+      return ok(`Ballot Style ${ballotStyleId} Tally Report`);
+    }
+
+    if (votingMethod) {
+      return ok(`${VOTING_METHOD_LABELS[votingMethod]} Ballot Tally Report`);
+    }
+  }
+
+  if (reportRank === 2) {
+    if (precinctId && votingMethod) {
+      return ok(
+        `${getPrecinctById(electionDefinition, precinctId).name} ${
+          VOTING_METHOD_LABELS[votingMethod]
+        } Ballot Tally Report`
+      );
+    }
+
+    if (ballotStyleId && votingMethod) {
+      return ok(
+        `Ballot Style ${ballotStyleId} ${VOTING_METHOD_LABELS[votingMethod]} Ballot Tally Report`
+      );
+    }
+
+    if (precinctId && ballotStyleId) {
+      return ok(
+        `Ballot Style ${ballotStyleId} ${
+          getPrecinctById(electionDefinition, precinctId).name
+        } Tally Report`
+      );
+    }
+  }
+
+  return err('title-not-supported');
+}
+
+/**
+ * Canonicalize a user-provided filter to a canonical filter to prevent unnecessary changes
+ * to the rendered report and reload from cache more often.
+ * - ignores empty filters
+ * - sorts filter values alphabetically
+ */
+export function canonicalizeFilter(
+  filter: Tabulation.Filter
+): Tabulation.Filter {
+  return {
+    ballotStyleIds:
+      filter.ballotStyleIds && filter.ballotStyleIds.length > 0
+        ? [...filter.ballotStyleIds].sort()
+        : undefined,
+    partyIds:
+      filter.partyIds && filter.partyIds.length > 0
+        ? [...filter.partyIds].sort()
+        : undefined,
+    precinctIds:
+      filter.precinctIds && filter.precinctIds.length > 0
+        ? [...filter.precinctIds].sort()
+        : undefined,
+    scannerIds:
+      filter.scannerIds && filter.scannerIds.length > 0
+        ? [...filter.scannerIds].sort()
+        : undefined,
+    batchIds:
+      filter.batchIds && filter.batchIds.length > 0
+        ? [...filter.batchIds].sort()
+        : undefined,
+    votingMethods:
+      filter.votingMethods && filter.votingMethods.length > 0
+        ? [...filter.votingMethods].sort()
+        : undefined,
+  };
+}
+
+export function canonicalizeGroupBy(
+  groupBy: Tabulation.GroupBy
+): Tabulation.GroupBy {
+  return {
+    groupByBallotStyle: groupBy.groupByBallotStyle ?? false,
+    groupByParty: groupBy.groupByParty ?? false,
+    groupByPrecinct: groupBy.groupByPrecinct ?? false,
+    groupByScanner: groupBy.groupByScanner ?? false,
+    groupByVotingMethod: groupBy.groupByVotingMethod ?? false,
+    groupByBatch: groupBy.groupByBatch ?? false,
+  };
+}

--- a/apps/admin/frontend/test/helpers/api_mock.ts
+++ b/apps/admin/frontend/test/helpers/api_mock.ts
@@ -16,7 +16,7 @@ import type {
   WriteInImageView,
   ExportDataError,
 } from '@votingworks/admin-backend';
-import { Result, ok } from '@votingworks/basics';
+import { Result, deferred, ok } from '@votingworks/basics';
 import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
 import {
   fakeElectionManagerUser,
@@ -356,11 +356,24 @@ export function createApiMock(
         filter?: Tabulation.Filter;
         groupBy?: Tabulation.GroupBy;
       },
-      results: Array<Tabulation.GroupOf<TallyReportResults>>
+      results: Tabulation.GroupList<TallyReportResults>,
+      deferResult = false
     ) {
+      const { promise, resolve } =
+        deferred<Tabulation.GroupList<TallyReportResults>>();
       apiClient.getResultsForTallyReports
         .expectCallWith(input)
-        .resolves(results);
+        .returns(promise);
+
+      if (!deferResult) {
+        resolve(results);
+      }
+
+      return {
+        resolve: () => {
+          resolve(results);
+        },
+      };
     },
 
     expectGetElectionWriteInSummary(

--- a/libs/test-utils/src/expect_print.test.ts
+++ b/libs/test-utils/src/expect_print.test.ts
@@ -14,6 +14,7 @@ import {
   resetExpectPrint,
   simulateErrorOnNextPrint,
   expectPrintToMatchSnapshot,
+  deferNextPrint,
 } from './expect_print';
 
 beforeEach(() => {
@@ -198,6 +199,24 @@ test('simulateErrorOnNextPrint', async () => {
 
   await fakePrintElementWhenReady(simpleElementWithCallback, fakeOptions);
   await expectPrint();
+});
+
+test('deferNextPrint', async () => {
+  expect.assertions(1);
+
+  const { resolve } = deferNextPrint();
+  const printPromise = fakePrintElement(simpleElement, fakeOptions);
+
+  try {
+    await expectPrint();
+  } catch (error) {
+    expect(error).toBeInstanceOf(ExpectPrintError);
+  }
+
+  resolve();
+  await expectPrint();
+
+  await printPromise; // clean up
 });
 
 test('expectPrintToMatchSnapshot', async () => {

--- a/libs/test-utils/src/expect_print.ts
+++ b/libs/test-utils/src/expect_print.ts
@@ -1,6 +1,6 @@
 import { render, RenderResult, waitFor } from '@testing-library/react';
 import { ElementWithCallback, PrintOptions } from '@votingworks/types';
-import { assert, Optional } from '@votingworks/basics';
+import { assert, deferred, Optional } from '@votingworks/basics';
 
 export class ExpectPrintError extends Error {}
 
@@ -15,6 +15,7 @@ let lastPrintedElement: Optional<JSX.Element>;
 let lastPrintedElementWithCallback: Optional<ElementWithCallback>;
 let lastPrintOptions: Optional<PrintOptions>;
 let errorOnNextPrint: Optional<Error>;
+let deferredPromiseOnNextPrint: Optional<Promise<void>>;
 
 let lastPdfPrintCommand: Optional<JSX.Element>;
 
@@ -27,6 +28,7 @@ export function resetExpectPrint(): void {
   lastPrintedElementWithCallback = undefined;
   lastPrintOptions = undefined;
   errorOnNextPrint = undefined;
+  deferredPromiseOnNextPrint = undefined;
 }
 
 export function resetExpectPrintToPdf(): void {
@@ -40,6 +42,19 @@ export function resetExpectPrintToPdf(): void {
  */
 export function simulateErrorOnNextPrint(error: Error = new Error()): void {
   errorOnNextPrint = error;
+}
+
+/**
+ * Throws the provided error the next time that fakePrintElement, fakePrintElementToPdf, or
+ * fakePrintElementWhenReady are called. Used to simulate errors we
+ * may receive from the printer itself.
+ */
+export function deferNextPrint(): {
+  resolve: VoidFunction;
+} {
+  const { promise, resolve } = deferred<void>();
+  deferredPromiseOnNextPrint = promise;
+  return { resolve };
 }
 
 function expectAllPrintsAsserted(message: string) {
@@ -64,13 +79,18 @@ function expectAllPrintsAsserted(message: string) {
   }
 }
 
-export function fakePrintElement(
+export async function fakePrintElement(
   element: JSX.Element,
   printOptions: PrintOptions
 ): Promise<void> {
   expectAllPrintsAsserted(
     'You have not made any assertions against the last print before another print within a test.'
   );
+
+  if (deferredPromiseOnNextPrint) {
+    await deferredPromiseOnNextPrint;
+    deferredPromiseOnNextPrint = undefined;
+  }
 
   if (errorOnNextPrint) {
     const failedPrintPromise = Promise.reject(errorOnNextPrint);
@@ -83,12 +103,17 @@ export function fakePrintElement(
   return Promise.resolve();
 }
 
-export function fakePrintElementToPdf(
+export async function fakePrintElementToPdf(
   element: JSX.Element
 ): Promise<Uint8Array> {
   expectAllPrintsAsserted(
     'You have not made any assertions against the last PDF print before another PDF print within a test.'
   );
+
+  if (deferredPromiseOnNextPrint) {
+    await deferredPromiseOnNextPrint;
+    deferredPromiseOnNextPrint = undefined;
+  }
 
   // errorOnNextPrint unsupported. If adding support, consider whether errorOnNextPrint should
   // be shared with the physical printing mock or if there should be a separate one for PDF printing.
@@ -97,13 +122,18 @@ export function fakePrintElementToPdf(
   return Promise.resolve(new Uint8Array(0));
 }
 
-export function fakePrintElementWhenReady(
+export async function fakePrintElementWhenReady(
   elementWithCallback: ElementWithCallback,
   printOptions: PrintOptions
 ): Promise<void> {
   expectAllPrintsAsserted(
     'You have not made any assertions against the last print before another print within a test.'
   );
+
+  if (deferredPromiseOnNextPrint) {
+    await deferredPromiseOnNextPrint;
+    deferredPromiseOnNextPrint = undefined;
+  }
 
   if (errorOnNextPrint) {
     const failedPrintPromise = Promise.reject(errorOnNextPrint);

--- a/libs/test-utils/src/expect_print.ts
+++ b/libs/test-utils/src/expect_print.ts
@@ -45,9 +45,7 @@ export function simulateErrorOnNextPrint(error: Error = new Error()): void {
 }
 
 /**
- * Throws the provided error the next time that fakePrintElement, fakePrintElementToPdf, or
- * fakePrintElementWhenReady are called. Used to simulate errors we
- * may receive from the printer itself.
+ * Sets up the next print so that it does not resolve until the returned `resolve` callback is called.
  */
 export function deferNextPrint(): {
   resolve: VoidFunction;

--- a/libs/types/src/tabulation.ts
+++ b/libs/types/src/tabulation.ts
@@ -51,6 +51,12 @@ export const SUPPORTED_VOTING_METHODS: VotingMethod[] = [
   'absentee',
 ];
 
+export const VOTING_METHOD_LABELS: Record<VotingMethod, string> = {
+  absentee: 'Absentee',
+  precinct: 'Precinct',
+  provisional: 'Provisional',
+};
+
 /**
  * Indicates what cast vote records to include when calculating results.
  * Omission of a filter attribute indicates *not* filtering on it at all.

--- a/libs/ui/src/checkbox.tsx
+++ b/libs/ui/src/checkbox.tsx
@@ -2,7 +2,7 @@ import styled, { css } from 'styled-components';
 
 import { Icons } from './icons';
 
-export interface ContestChoiceButtonProps {
+export interface CheckboxProps {
   checked?: boolean;
 }
 
@@ -32,7 +32,7 @@ const OuterContainer = styled.span<StyleProps>`
   }
 `;
 
-export function Checkbox(props: ContestChoiceButtonProps): JSX.Element {
+export function Checkbox(props: CheckboxProps): JSX.Element {
   const { checked } = props;
 
   return (

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -29,6 +29,8 @@ import {
   faSquarePlus,
   faSpinner,
   faCaretDown,
+  faCirclePlus,
+  faRotateRight,
 } from '@fortawesome/free-solid-svg-icons';
 import {
   faXmarkCircle,
@@ -67,6 +69,10 @@ function FaIcon(props: InnerProps): JSX.Element {
 export const Icons = {
   Add(): JSX.Element {
     return <FaIcon type={faSquarePlus} />;
+  },
+
+  AddCircle(): JSX.Element {
+    return <FaIcon type={faCirclePlus} />;
   },
 
   Backspace(): JSX.Element {
@@ -169,6 +175,10 @@ export const Icons = {
 
   LeftChevron(): JSX.Element {
     return <FaIcon type={faChevronLeft} />;
+  },
+
+  RotateRight(): JSX.Element {
+    return <FaIcon type={faRotateRight} />;
   },
 
   Save(): JSX.Element {

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -91,3 +91,4 @@ export * from './virtual_keyboard';
 export * from './voter_contest_summary';
 export * from './with_scroll_buttons';
 export * from './search_select';
+export * from './checkbox';

--- a/libs/ui/src/reports/admin_tally_report.stories.tsx
+++ b/libs/ui/src/reports/admin_tally_report.stories.tsx
@@ -9,7 +9,8 @@ import { assertDefined } from '@votingworks/basics';
 import { AdminTallyReportProps, AdminTallyReport } from './admin_tally_report';
 import { TallyReportPreview } from './tally_report';
 
-const { election } = electionMinimalExhaustiveSampleDefinition;
+const electionDefinition = electionMinimalExhaustiveSampleDefinition;
+const { election } = electionDefinition;
 const { contests } = election;
 
 function AdminTallyReportPreview(props: AdminTallyReportProps): JSX.Element {
@@ -69,7 +70,7 @@ const batchReportArgs: AdminTallyReportProps = {
   title: 'Official Batch Tally Report for Batch 1',
   subtitle: election.title,
   testId: 'tally-report',
-  election,
+  electionDefinition,
   contests,
   scannedElectionResults,
 };
@@ -108,7 +109,7 @@ const ballotStyleManualReportArgs: AdminTallyReportProps = {
   title: 'TEST Ballot Style Tally Report for Ballot Style 2F',
   subtitle: election.title,
   testId: 'tally-report',
-  election,
+  electionDefinition,
   contests: getContests({
     election,
     ballotStyle: assertDefined(

--- a/libs/ui/src/reports/admin_tally_report.test.tsx
+++ b/libs/ui/src/reports/admin_tally_report.test.tsx
@@ -8,7 +8,8 @@ import { hasTextAcrossElements } from '@votingworks/test-utils';
 import { render, screen, within } from '../../test/react_testing_library';
 import { AdminTallyReport } from './admin_tally_report';
 
-const { election } = electionMinimalExhaustiveSampleDefinition;
+const electionDefinition = electionMinimalExhaustiveSampleDefinition;
+const { election } = electionDefinition;
 
 function queryForContest(contestId: string) {
   return screen.queryByTestId(`results-table-${contestId}`);
@@ -20,7 +21,7 @@ test('includes indicated contests', () => {
   render(
     <AdminTallyReport
       title="Title"
-      election={election}
+      electionDefinition={electionDefinition}
       contests={includedContests}
       scannedElectionResults={getEmptyElectionResults(election, true)}
     />
@@ -37,7 +38,7 @@ test('includes subtitle', () => {
     <AdminTallyReport
       title="Title"
       subtitle="Subtitle"
-      election={election}
+      electionDefinition={electionDefinition}
       contests={election.contests}
       scannedElectionResults={getEmptyElectionResults(election, true)}
     />
@@ -51,7 +52,7 @@ test('includes specified date', () => {
     <AdminTallyReport
       title="Title"
       subtitle="Subtitle"
-      election={election}
+      electionDefinition={electionDefinition}
       contests={election.contests}
       scannedElectionResults={getEmptyElectionResults(election, true)}
       generatedAtTime={new Date('2020-01-01')}
@@ -86,7 +87,7 @@ test('with only scanned results', () => {
     <AdminTallyReport
       title="Title"
       subtitle="Subtitle"
-      election={election}
+      electionDefinition={electionDefinition}
       contests={election.contests}
       scannedElectionResults={scannedElectionResults}
     />
@@ -119,7 +120,7 @@ test('with scanned and manual results', () => {
     <AdminTallyReport
       title="Title"
       subtitle="Subtitle"
-      election={election}
+      electionDefinition={electionDefinition}
       contests={election.contests}
       scannedElectionResults={scannedElectionResults}
       manualElectionResults={manualElectionResults}
@@ -134,7 +135,7 @@ test('allows card counts override', () => {
     <AdminTallyReport
       title="Title"
       subtitle="Subtitle"
-      election={election}
+      electionDefinition={electionDefinition}
       contests={election.contests}
       scannedElectionResults={scannedElectionResults}
       cardCountsOverride={{
@@ -145,4 +146,22 @@ test('allows card counts override', () => {
   );
   const bmdRow = screen.getByText('Machine Marked').closest('tr')!;
   within(bmdRow).getByText('10,000');
+});
+
+test('displays custom filter', () => {
+  render(
+    <AdminTallyReport
+      title="Title"
+      subtitle="Subtitle"
+      electionDefinition={electionDefinition}
+      contests={election.contests}
+      scannedElectionResults={scannedElectionResults}
+      cardCountsOverride={{
+        bmd: 10000,
+        hmpb: [],
+      }}
+      customFilter={{ precinctIds: ['precinct-1'] }}
+    />
+  );
+  screen.getByText(hasTextAcrossElements('Precinct: Precinct 1'));
 });

--- a/libs/ui/src/reports/admin_tally_report.tsx
+++ b/libs/ui/src/reports/admin_tally_report.tsx
@@ -1,4 +1,4 @@
-import { Contests, Election, Tabulation } from '@votingworks/types';
+import { Contests, ElectionDefinition, Tabulation } from '@votingworks/types';
 import { assert } from '@votingworks/basics';
 import { ThemeProvider } from 'styled-components';
 import {
@@ -11,30 +11,34 @@ import { LogoMark } from '../logo_mark';
 import { TallyReportMetadata } from './tally_report_metadata';
 import { ContestResultsTable } from './contest_results_table';
 import { TallyReportCardCounts } from './tally_report_card_counts';
+import { CustomFilterSummary } from './custom_filter_summary';
 
 export interface AdminTallyReportProps {
   title: string;
   subtitle?: string;
   testId?: string;
-  election: Election;
+  electionDefinition: ElectionDefinition;
   contests: Contests;
   scannedElectionResults: Tabulation.ElectionResults;
   manualElectionResults?: Tabulation.ManualElectionResults;
   cardCountsOverride?: Tabulation.CardCounts;
   generatedAtTime?: Date;
+  customFilter?: Tabulation.Filter;
 }
 
 export function AdminTallyReport({
   title,
   subtitle,
   testId,
-  election,
+  electionDefinition,
   contests,
   scannedElectionResults,
   manualElectionResults,
   cardCountsOverride,
   generatedAtTime = new Date(),
+  customFilter,
 }: AdminTallyReportProps): JSX.Element {
+  const { election } = electionDefinition;
   const cardCounts = cardCountsOverride ?? {
     ...scannedElectionResults.cardCounts,
     manual: manualElectionResults?.ballotCount,
@@ -46,11 +50,19 @@ export function AdminTallyReport({
         <ReportSection>
           <LogoMark />
           <h1>{title}</h1>
+
           {subtitle && <h2>{subtitle}</h2>}
+          {customFilter && (
+            <CustomFilterSummary
+              electionDefinition={electionDefinition}
+              filter={customFilter}
+            />
+          )}
           <TallyReportMetadata
             generatedAtTime={generatedAtTime}
             election={election}
           />
+
           <TallyReportColumns>
             <TallyReportCardCounts cardCounts={cardCounts} />
             {contests.map((contest) => {

--- a/libs/ui/src/reports/custom_filter_summary.test.tsx
+++ b/libs/ui/src/reports/custom_filter_summary.test.tsx
@@ -1,0 +1,63 @@
+import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import { render, screen } from '../../test/react_testing_library';
+import { CustomFilterSummary } from './custom_filter_summary';
+
+test('precinct filter', () => {
+  const { electionDefinition } = electionFamousNames2021Fixtures;
+  render(
+    <CustomFilterSummary
+      electionDefinition={electionDefinition}
+      filter={{ precinctIds: ['23'] }}
+    />
+  );
+  expect(screen.getByTestId('custom-filter-summary').textContent).toEqual(
+    'Precinct: North Lincoln'
+  );
+});
+
+test('ballot style filter', () => {
+  const { electionDefinition } = electionFamousNames2021Fixtures;
+  render(
+    <CustomFilterSummary
+      electionDefinition={electionDefinition}
+      filter={{ ballotStyleIds: ['1'] }}
+    />
+  );
+  expect(screen.getByTestId('custom-filter-summary').textContent).toEqual(
+    'Ballot Style: 1'
+  );
+});
+
+test('voting method filter', () => {
+  const { electionDefinition } = electionFamousNames2021Fixtures;
+  render(
+    <CustomFilterSummary
+      electionDefinition={electionDefinition}
+      filter={{ votingMethods: ['absentee'] }}
+    />
+  );
+  expect(screen.getByTestId('custom-filter-summary').textContent).toEqual(
+    'Voting Method: Absentee'
+  );
+});
+
+test('complex filter', () => {
+  const { electionDefinition } = electionFamousNames2021Fixtures;
+  render(
+    <CustomFilterSummary
+      electionDefinition={electionDefinition}
+      filter={{
+        precinctIds: ['23'],
+        ballotStyleIds: ['1'],
+        votingMethods: ['absentee'],
+      }}
+    />
+  );
+  expect(screen.getByTestId('custom-filter-summary').textContent).toEqual(
+    [
+      'Voting Method: Absentee',
+      'Precinct: North Lincoln',
+      'Ballot Style: 1',
+    ].join('')
+  );
+});

--- a/libs/ui/src/reports/custom_filter_summary.tsx
+++ b/libs/ui/src/reports/custom_filter_summary.tsx
@@ -1,0 +1,59 @@
+import { ElectionDefinition, Tabulation } from '@votingworks/types';
+
+import { getPrecinctById } from '@votingworks/utils';
+
+import pluralize from 'pluralize';
+import styled from 'styled-components';
+import { Font } from '../typography';
+
+interface Props {
+  electionDefinition: ElectionDefinition;
+  filter: Tabulation.Filter;
+}
+
+const FilterDisplayRow = styled.p`
+  margin: 0;
+`;
+
+export function CustomFilterSummary({
+  electionDefinition,
+  filter,
+}: Props): JSX.Element {
+  return (
+    <div data-testid="custom-filter-summary">
+      {filter.votingMethods && (
+        <FilterDisplayRow>
+          <Font weight="semiBold">
+            {pluralize('Voting Method', filter.votingMethods.length)}:
+          </Font>{' '}
+          {filter.votingMethods
+            .map(
+              (votingMethod) => Tabulation.VOTING_METHOD_LABELS[votingMethod]
+            )
+            .join(', ')}
+        </FilterDisplayRow>
+      )}
+      {filter.precinctIds && (
+        <FilterDisplayRow>
+          <Font weight="semiBold">
+            {pluralize('Precinct', filter.precinctIds.length)}:
+          </Font>{' '}
+          {filter.precinctIds
+            .map(
+              (precinctId) =>
+                getPrecinctById(electionDefinition, precinctId).name
+            )
+            .join(', ')}
+        </FilterDisplayRow>
+      )}
+      {filter.ballotStyleIds && (
+        <FilterDisplayRow>
+          <Font weight="semiBold">
+            {pluralize('Ballot Styles', filter.ballotStyleIds.length)}:
+          </Font>{' '}
+          {filter.ballotStyleIds.join(', ')}
+        </FilterDisplayRow>
+      )}
+    </div>
+  );
+}

--- a/libs/ui/src/reports/tally_report.tsx
+++ b/libs/ui/src/reports/tally_report.tsx
@@ -4,7 +4,7 @@ import { H3 } from '../typography';
 import { makeTheme } from '../themes/make_theme';
 
 export const ReportSection = styled.section`
-  page-break-before: always;
+  page-break-after: always;
 `;
 
 export const TallyReportTitle = styled.h1`

--- a/libs/ui/src/search_select.tsx
+++ b/libs/ui/src/search_select.tsx
@@ -58,6 +58,13 @@ export type SearchSelectProps<T extends string = string> =
   | SearchSelectSingleProps<T>
   | SearchSelectMultiProps<T>;
 
+function findOption<T extends string = string>(
+  options: Array<SelectOption<T>>,
+  value: T
+): SelectOption<T> | undefined {
+  return options.find((option) => option.value === value);
+}
+
 export function SearchSelect<T extends string = string>({
   isMulti,
   isSearchable,
@@ -74,8 +81,19 @@ export function SearchSelect<T extends string = string>({
       isSearchable={isSearchable}
       isClearable={false}
       options={options}
-      defaultValue={value}
-      onChange={onChange}
+      defaultValue={
+        Array.isArray(value)
+          ? value.map((v) => findOption(options, v))
+          : value
+          ? findOption(options, value)
+          : null
+      }
+      onChange={
+        isMulti
+          ? (selectedOptions: Array<SelectOption<T>>) =>
+              onChange(selectedOptions.map((o) => o.value))
+          : (selectedOption: SelectOption<T>) => onChange(selectedOption.value)
+      }
       placeholder={null}
       aria-label={ariaLabel}
       unstyled

--- a/libs/utils/src/tabulation/arguments.ts
+++ b/libs/utils/src/tabulation/arguments.ts
@@ -1,47 +1,20 @@
 import { Tabulation } from '@votingworks/types';
 
-export function convertGroupSpecifierToFilter(
-  group: Tabulation.GroupSpecifier
+export function combineGroupSpecifierAndFilter(
+  group: Tabulation.GroupSpecifier,
+  filter: Tabulation.Filter
 ): Tabulation.Filter {
   return {
-    ballotStyleIds: group.ballotStyleId ? [group.ballotStyleId] : undefined,
-    partyIds: group.partyId ? [group.partyId] : undefined,
-    precinctIds: group.precinctId ? [group.precinctId] : undefined,
-    scannerIds: group.scannerId ? [group.scannerId] : undefined,
-    batchIds: group.batchId ? [group.batchId] : undefined,
-    votingMethods: group.votingMethod ? [group.votingMethod] : undefined,
-  };
-}
-
-export function mergeFilters(
-  filter1: Tabulation.Filter,
-  filter2: Tabulation.Filter
-): Tabulation.Filter {
-  return {
-    ballotStyleIds:
-      filter1.ballotStyleIds || filter2.ballotStyleIds
-        ? [...(filter1.ballotStyleIds || []), ...(filter2.ballotStyleIds || [])]
-        : undefined,
-    partyIds:
-      filter1.partyIds || filter2.partyIds
-        ? [...(filter1.partyIds || []), ...(filter2.partyIds || [])]
-        : undefined,
-    precinctIds:
-      filter1.precinctIds || filter2.precinctIds
-        ? [...(filter1.precinctIds || []), ...(filter2.precinctIds || [])]
-        : undefined,
-    scannerIds:
-      filter1.scannerIds || filter2.scannerIds
-        ? [...(filter1.scannerIds || []), ...(filter2.scannerIds || [])]
-        : undefined,
-    batchIds:
-      filter1.batchIds || filter2.batchIds
-        ? [...(filter1.batchIds || []), ...(filter2.batchIds || [])]
-        : undefined,
-    votingMethods:
-      filter1.votingMethods || filter2.votingMethods
-        ? [...(filter1.votingMethods || []), ...(filter2.votingMethods || [])]
-        : undefined,
+    ballotStyleIds: group.ballotStyleId
+      ? [group.ballotStyleId]
+      : filter.ballotStyleIds,
+    partyIds: group.partyId ? [group.partyId] : filter.partyIds,
+    precinctIds: group.precinctId ? [group.precinctId] : filter.precinctIds,
+    scannerIds: group.scannerId ? [group.scannerId] : filter.scannerIds,
+    batchIds: group.batchId ? [group.batchId] : filter.batchIds,
+    votingMethods: group.votingMethod
+      ? [group.votingMethod]
+      : filter.votingMethods,
   };
 }
 
@@ -67,5 +40,16 @@ export function isGroupByEmpty(groupBy: Tabulation.GroupBy): boolean {
     groupBy.groupByParty ||
     groupBy.groupByScanner ||
     groupBy.groupByVotingMethod
+  );
+}
+
+export function isFilterEmpty(filter: Tabulation.Filter): boolean {
+  return !(
+    filter.ballotStyleIds ||
+    filter.partyIds ||
+    filter.precinctIds ||
+    filter.scannerIds ||
+    filter.batchIds ||
+    filter.votingMethods
   );
 }


### PR DESCRIPTION
_review by commit_

## Overview

Adds an initial version of the custom report builder. It includes:
- Filtering and grouping on Voting Method, Precinct, and/or Ballot Style
- Report previews
- Report printing

It does not include, but will quickly be followed up by:
- Export Report to PDF
- Export CSV
- Scanner / Batch filtering and grouping

These are excluded from this PR not due to the amount of work but mostly to keep this PR as manageably reviewable as it can be with the number of new components it introduces. They will be done in immediate follow-ups.

Even this limited report builder satisfies the target VVSG requirements, I think.

cc @mattroe I decided to _not_ include filters or groupings on party in the tally report builder. All our tally reports are already split by party (on contests) so it's mostly redundant. There are only two cases where using "Party" as a dimension might matter:
- Case 1: There are non-partisan contests on a primary ballot. In this case, you could filter the results of the of the non-partisan contests by party. I think that this is far more of a footgun for users than a useful feature. But if you _really_ want those results by party, you could accomplish the same with the current feature by filtering on ballot styles.
- Case 2: You just want to print one of the party pages. A reasonable use case, although Warren County couldn't think of why they'd want this at the moment. It may come up later, but I think this needs to be handled as a separate option, outside of the filter/grouping settings, because it's really sorting on _contest_ not on _ballots_.

## Demo Video or Screenshot

Narrated Walkthrough:

https://github.com/votingworks/vxsuite/assets/37960853/d5e1c083-ff1d-4221-a5bf-a4d38866bc6a



## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
