### PR TITLE
feat(admin): Tally Report Builder - Export Report PDF

### DIFF
--- a/apps/admin/frontend/src/components/reporting/export_report_pdf_button.test.tsx
+++ b/apps/admin/frontend/src/components/reporting/export_report_pdf_button.test.tsx
@@ -1,0 +1,38 @@
+import { electionMinimalExhaustiveSampleDefinition } from '@votingworks/fixtures';
+import { fakeKiosk } from '@votingworks/test-utils';
+import { renderInAppContext } from '../../../test/render_in_app_context';
+import { ExportReportPdfButton } from './export_report_pdf_button';
+import { screen } from '../../../test/react_testing_library';
+
+afterEach(() => {
+  delete window.kiosk;
+});
+
+test('disabled by disabled prop', () => {
+  window.kiosk = fakeKiosk();
+
+  expect(window.kiosk).toBeDefined();
+  renderInAppContext(
+    <ExportReportPdfButton
+      electionDefinition={electionMinimalExhaustiveSampleDefinition}
+      generateReportPdf={() => Promise.resolve(new Uint8Array())}
+      defaultFilename="some-file"
+      disabled
+    />
+  );
+
+  expect(screen.getButton('Export Report PDF')).toBeDisabled();
+});
+
+test('disabled when window.kiosk is undefined', () => {
+  renderInAppContext(
+    <ExportReportPdfButton
+      electionDefinition={electionMinimalExhaustiveSampleDefinition}
+      generateReportPdf={() => Promise.resolve(new Uint8Array())}
+      defaultFilename="some-file"
+      disabled={false}
+    />
+  );
+
+  expect(screen.getButton('Export Report PDF')).toBeDisabled();
+});

--- a/apps/admin/frontend/src/components/reporting/export_report_pdf_button.tsx
+++ b/apps/admin/frontend/src/components/reporting/export_report_pdf_button.tsx
@@ -1,0 +1,47 @@
+import { Button } from '@votingworks/ui';
+import React from 'react';
+import { generateElectionBasedSubfolderName } from '@votingworks/utils';
+import { ElectionDefinition } from '@votingworks/types';
+import path from 'path';
+import { FileType, SaveFrontendFileModal } from '../save_frontend_file_modal';
+
+const REPORT_PDF_SUBFOLDER = 'report-pdfs';
+
+export function ExportReportPdfButton({
+  electionDefinition,
+  generateReportPdf,
+  defaultFilename,
+  disabled,
+}: {
+  electionDefinition: ElectionDefinition;
+  generateReportPdf: () => Promise<Uint8Array>;
+  defaultFilename: string;
+  disabled?: boolean;
+}): JSX.Element {
+  const [isModalOpen, setIsModalOpen] = React.useState(false);
+  return (
+    <React.Fragment>
+      <Button
+        onPress={() => setIsModalOpen(true)}
+        disabled={disabled || !window.kiosk}
+      >
+        Export Report PDF
+      </Button>
+      {isModalOpen && (
+        <SaveFrontendFileModal
+          onClose={() => setIsModalOpen(false)}
+          generateFileContent={generateReportPdf}
+          defaultFilename={defaultFilename}
+          defaultDirectory={path.join(
+            generateElectionBasedSubfolderName(
+              electionDefinition.election,
+              electionDefinition.electionHash
+            ),
+            REPORT_PDF_SUBFOLDER
+          )}
+          fileType={FileType.TallyReport}
+        />
+      )}
+    </React.Fragment>
+  );
+}

--- a/apps/admin/frontend/src/screens/tally_report_builder.test.tsx
+++ b/apps/admin/frontend/src/screens/tally_report_builder.test.tsx
@@ -21,6 +21,8 @@ afterEach(() => {
 test('happy path', async () => {
   const electionDefinition = electionMinimalExhaustiveSampleDefinition;
   const { election } = electionDefinition;
+
+  apiMock.expectGetCastVoteRecordFileMode('test');
   renderInAppContext(<TallyReportBuilder />, {
     electionDefinition,
     apiMock,

--- a/apps/admin/frontend/src/setupTests.ts
+++ b/apps/admin/frontend/src/setupTests.ts
@@ -8,6 +8,7 @@ import {
   expectTestToEndWithAllPrintsAsserted,
   fakePrintElement as mockPrintElement,
   fakePrintElementWhenReady as mockPrintElementWhenReady,
+  fakePrintElementToPdf as mockPrintElementToPdf,
 } from '@votingworks/test-utils';
 import { configure } from '../test/react_testing_library';
 
@@ -19,6 +20,7 @@ jest.mock('@votingworks/ui', (): typeof import('@votingworks/ui') => {
     ...original,
     printElementWhenReady: mockPrintElementWhenReady,
     printElement: mockPrintElement,
+    printElementToPdf: mockPrintElementToPdf,
   };
 });
 

--- a/apps/admin/frontend/src/utils/reporting.ts
+++ b/apps/admin/frontend/src/utils/reporting.ts
@@ -1,6 +1,6 @@
-import { ElectionDefinition, Tabulation } from '@votingworks/types';
-import { Optional, Result, err, ok } from '@votingworks/basics';
-import { getPrecinctById } from '@votingworks/utils';
+import { Election, ElectionDefinition, Tabulation } from '@votingworks/types';
+import { Optional, Result, err, find, ok } from '@votingworks/basics';
+import { getPrecinctById, sanitizeStringForFilename } from '@votingworks/utils';
 
 const VOTING_METHOD_LABELS: Record<Tabulation.VotingMethod, string> = {
   absentee: 'Absentee',
@@ -9,7 +9,35 @@ const VOTING_METHOD_LABELS: Record<Tabulation.VotingMethod, string> = {
 };
 
 /**
- * Attempts to generate a title for the report based on it's filter.
+ * Checks whether the report has any filters which have multiple values selected.
+ */
+function isCompoundFilter(filter: Tabulation.Filter): boolean {
+  return Boolean(
+    (filter.partyIds && filter.partyIds.length > 1) ||
+      (filter.ballotStyleIds && filter.ballotStyleIds.length > 1) ||
+      (filter.precinctIds && filter.precinctIds.length > 1) ||
+      (filter.batchIds && filter.batchIds.length > 1) ||
+      (filter.scannerIds && filter.scannerIds.length > 1) ||
+      (filter.votingMethods && filter.votingMethods.length > 1)
+  );
+}
+
+/**
+ * Returns the number of dimensions being filtered on.
+ */
+function getFilterRank(filter: Tabulation.Filter): number {
+  return (
+    (filter.ballotStyleIds?.[0] ? 1 : 0) +
+    (filter.precinctIds?.[0] ? 1 : 0) +
+    (filter.batchIds?.[0] ? 1 : 0) +
+    (filter.scannerIds?.[0] ? 1 : 0) +
+    (filter.votingMethods?.[0] ? 1 : 0) +
+    (filter.partyIds?.[0] ? 1 : 0)
+  );
+}
+
+/**
+ * Attempts to generate a title for an individual tally report based on its filter.
  */
 export function generateTitleForReport({
   filter,
@@ -18,32 +46,15 @@ export function generateTitleForReport({
   filter: Tabulation.Filter;
   electionDefinition: ElectionDefinition;
 }): Result<Optional<string>, 'title-not-supported'> {
-  // If the report has any compound filters, we don't try to intelligently generate a title.
-  if (
-    (filter.partyIds && filter.partyIds.length > 1) ||
-    (filter.ballotStyleIds && filter.ballotStyleIds.length > 1) ||
-    (filter.precinctIds && filter.precinctIds.length > 1) ||
-    (filter.batchIds && filter.batchIds.length > 1) ||
-    (filter.scannerIds && filter.scannerIds.length > 1) ||
-    (filter.votingMethods && filter.votingMethods.length > 1)
-  ) {
+  if (isCompoundFilter(filter)) {
     return err('title-not-supported');
   }
 
   const ballotStyleId = filter.ballotStyleIds?.[0];
   const precinctId = filter.precinctIds?.[0];
-  const batchId = filter.batchIds?.[0];
-  const scannerId = filter.scannerIds?.[0];
   const votingMethod = filter.votingMethods?.[0];
-  const partyId = filter.partyIds?.[0];
 
-  const reportRank =
-    (ballotStyleId ? 1 : 0) +
-    (precinctId ? 1 : 0) +
-    (batchId ? 1 : 0) +
-    (scannerId ? 1 : 0) +
-    (votingMethod ? 1 : 0) +
-    (partyId ? 1 : 0);
+  const reportRank = getFilterRank(filter);
 
   // Full Election Tally Report
   if (reportRank === 0) {
@@ -141,4 +152,131 @@ export function canonicalizeGroupBy(
     groupByVotingMethod: groupBy.groupByVotingMethod ?? false,
     groupByBatch: groupBy.groupByBatch ?? false,
   };
+}
+
+const WORD_SEPARATOR = '-';
+
+function generateReportFilenameFilterPrefix({
+  election,
+  filter,
+}: {
+  election: Election;
+  filter: Tabulation.Filter;
+}): string {
+  if (isCompoundFilter(filter)) {
+    return 'custom';
+  }
+
+  const filterRank = getFilterRank(filter);
+
+  // Full Election Tally Report
+  if (filterRank === 0) {
+    return '';
+  }
+
+  if (filterRank > 2) {
+    return 'custom';
+  }
+
+  const filterPrefixes: string[] = [];
+
+  const ballotStyleId = filter.ballotStyleIds?.[0];
+  const precinctId = filter.precinctIds?.[0];
+  const votingMethod = filter.votingMethods?.[0];
+
+  if (ballotStyleId) {
+    filterPrefixes.push(`ballot-style-${ballotStyleId}`);
+  }
+
+  if (precinctId) {
+    const precinctName = find(
+      election.precincts,
+      (p) => p.id === precinctId
+    ).name;
+    filterPrefixes.push(
+      sanitizeStringForFilename(precinctName, {
+        replaceInvalidCharsWith: WORD_SEPARATOR,
+      })
+    );
+  }
+
+  if (votingMethod) {
+    filterPrefixes.push(`${votingMethod}-ballots`);
+  }
+
+  return filterPrefixes.join(WORD_SEPARATOR);
+}
+
+function generateReportFilenameGroupByPostfix({
+  groupBy,
+}: {
+  groupBy: Tabulation.GroupBy;
+}): string {
+  const postfixes: string[] = [];
+
+  if (groupBy.groupByBallotStyle) {
+    postfixes.push('ballot-style');
+  }
+
+  if (groupBy.groupByParty) {
+    postfixes.push('party');
+  }
+
+  if (groupBy.groupByPrecinct) {
+    postfixes.push('precinct');
+  }
+
+  if (groupBy.groupByScanner) {
+    postfixes.push('scanner');
+  }
+
+  if (groupBy.groupByVotingMethod) {
+    postfixes.push('voting-method');
+  }
+
+  if (groupBy.groupByBatch) {
+    postfixes.push('batch');
+  }
+
+  return postfixes.join(`${WORD_SEPARATOR}and${WORD_SEPARATOR}`);
+}
+
+export function generateReportPdfFilename({
+  election,
+  filter,
+  groupBy,
+  isTestMode,
+}: {
+  election: Election;
+  filter: Tabulation.Filter;
+  groupBy: Tabulation.GroupBy;
+  isTestMode: boolean;
+}): string {
+  const prefix = generateReportFilenameFilterPrefix({ election, filter });
+  const postfix = generateReportFilenameGroupByPostfix({ groupBy });
+
+  const filenameParts: string[] = [];
+
+  if (isTestMode) {
+    filenameParts.push('TEST');
+  }
+
+  if (prefix) {
+    filenameParts.push(prefix);
+  } else if (!postfix) {
+    filenameParts.push('full-election');
+  }
+
+  if (postfix) {
+    filenameParts.push('tally-reports');
+  } else {
+    filenameParts.push('tally-report');
+  }
+
+  if (postfix) {
+    filenameParts.push('by');
+    filenameParts.push(postfix);
+  }
+
+  return `${filenameParts.join(WORD_SEPARATOR)}.pdf`;
 }

--- a/libs/utils/src/filenames.ts
+++ b/libs/utils/src/filenames.ts
@@ -34,7 +34,7 @@ export interface CastVoteRecordReportListing {
   timestamp: Date;
 }
 
-function sanitizeString(
+export function sanitizeStringForFilename(
   input: string,
   { replaceInvalidCharsWith = '', defaultValue = 'placeholder' } = {}
 ): string {
@@ -84,11 +84,11 @@ export function generateElectionBasedSubfolderName(
   election: Election,
   electionHash: string
 ): string {
-  const electionCountyName = sanitizeString(election.county.name, {
+  const electionCountyName = sanitizeStringForFilename(election.county.name, {
     replaceInvalidCharsWith: WORD_SEPARATOR,
     defaultValue: 'county',
   });
-  const electionTitle = sanitizeString(election.title, {
+  const electionTitle = sanitizeStringForFilename(election.title, {
     replaceInvalidCharsWith: WORD_SEPARATOR,
     defaultValue: 'election',
   });
@@ -110,7 +110,7 @@ export function generateCastVoteRecordReportDirectoryName(
   time: Date = new Date()
 ): string {
   const machineString = `machine${SUBSECTION_SEPARATOR}${
-    maybeParse(MachineId, machineId) ?? sanitizeString(machineId)
+    maybeParse(MachineId, machineId) ?? sanitizeStringForFilename(machineId)
   }`;
   const ballotString = `${numBallotsScanned}${SUBSECTION_SEPARATOR}${
     numBallotsScanned === 1 ? 'ballot' : 'ballots'
@@ -134,7 +134,7 @@ export function generateCastVoteRecordExportDirectoryName({
 }): string {
   const machineString = [
     'machine',
-    maybeParse(MachineId, machineId) ?? sanitizeString(machineId),
+    maybeParse(MachineId, machineId) ?? sanitizeStringForFilename(machineId),
   ].join(SUBSECTION_SEPARATOR);
   const timeString = moment(time).format(TIME_FORMAT_STRING);
   const directoryNameComponents = [machineString, timeString];
@@ -201,11 +201,11 @@ export function parseCastVoteRecordReportDirectoryName(
 
 /* Get the name of an election to use in a filename from the Election object */
 function generateElectionName(election: Election): string {
-  const electionCountyName = sanitizeString(election.county.name, {
+  const electionCountyName = sanitizeStringForFilename(election.county.name, {
     replaceInvalidCharsWith: WORD_SEPARATOR,
     defaultValue: 'county',
   });
-  const electionTitle = sanitizeString(election.title, {
+  const electionTitle = sanitizeStringForFilename(election.title, {
     replaceInvalidCharsWith: WORD_SEPARATOR,
     defaultValue: 'election',
   });
@@ -230,11 +230,11 @@ export function generateFilenameForBallotExportPackageFromElectionData({
   electionHash,
   timestamp,
 }: ElectionData): string {
-  const electionCountyName = sanitizeString(electionCounty, {
+  const electionCountyName = sanitizeStringForFilename(electionCounty, {
     replaceInvalidCharsWith: WORD_SEPARATOR,
     defaultValue: 'county',
   });
-  const electionTitle = sanitizeString(electionName, {
+  const electionTitle = sanitizeStringForFilename(electionName, {
     replaceInvalidCharsWith: WORD_SEPARATOR,
     defaultValue: 'election',
   });


### PR DESCRIPTION
## Overview

Follow up to #3927, adding ability to export reports as PDFs to the report builder. Functionality already exists for other tally pages so it should look familiar.

For the file names, I took the same approach as with the report titling - if there are only two levels of simple filters, generate a name. Otherwise, just call it "custom." We hit "custom" in fewer cases here because the filename represents all reports in a list rather than just one, so the filter is only the `filter` and the `groupBy` is separately encoded in the filename. Whereas for report titles, we try to combine the `filter` and the identity of the current group.

For example, say you have "Absentee" filter and "By Precinct" grouping. The report names might be:

1. Precinct 1 Absentee Ballots Tally Report
2. Precinct 2 Absentee Ballots Tally Report

Whereas the file name _containing_ both those reports will be `absentee-tally-reports-by-precinct.pdf`.

## Demo Video or Screenshot

https://github.com/votingworks/vxsuite/assets/37960853/b672f1c2-717c-4865-9858-976e43c6fcd5

## Testing Plan
- automated testing added
- re-used the `SaveFrontendFileModal` component, so a lot of cases are already covered
- manual testing

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
