### PR TITLE
support a large top margin on bmd_paper_ballot

### DIFF
--- a/apps/admin/frontend/src/__snapshots__/app.test.tsx.snap
+++ b/apps/admin/frontend/src/__snapshots__/app.test.tsx.snap
@@ -1184,6 +1184,10 @@ exports[`L&A (logic and accuracy) flow 2`] = `
   page-break-after: always;
 }
 
+.c0 > .large-top-margin {
+  margin-top: 1.75in;
+}
+
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1371,6 +1375,7 @@ exports[`L&A (logic and accuracy) flow 2`] = `
   >
     <div
       class="c1"
+      data-testid="header"
     >
       <div
         class="seal"
@@ -1847,6 +1852,7 @@ House Bill 1796 - Flag Referendum
   >
     <div
       class="c1"
+      data-testid="header"
     >
       <div
         class="seal"
@@ -2323,6 +2329,7 @@ House Bill 1796 - Flag Referendum
   >
     <div
       class="c1"
+      data-testid="header"
     >
       <div
         class="seal"
@@ -2799,6 +2806,7 @@ House Bill 1796 - Flag Referendum
   >
     <div
       class="c1"
+      data-testid="header"
     >
       <div
         class="seal"

--- a/apps/admin/frontend/src/__snapshots__/app.test.tsx.snap
+++ b/apps/admin/frontend/src/__snapshots__/app.test.tsx.snap
@@ -1184,10 +1184,6 @@ exports[`L&A (logic and accuracy) flow 2`] = `
   page-break-after: always;
 }
 
-.c0 > .large-top-margin {
-  margin-top: 1.75in;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -372,20 +372,24 @@ export function buildMachine(
         },
       },
       printing_ballot: {
-        invoke: pollPaperStatus(),
-        entry: (context, event) => {
-          // Need to hint to Typescript that we want the 'VOTER_INITIATED_PRINT' event in our union type of events
-          if ('pdfData' in event) {
-            void driverPrintBallot(context.driver, event.pdfData, {});
-          } else {
-            throw new Error(
-              `printing_ballot entry called by unsupported event type: ${event.type}`
-            );
-          }
-        },
-        on: {
-          PAPER_IN_OUTPUT: 'scanning',
-        },
+        invoke: [
+          {
+            id: 'printBallot',
+            src: (context, event) => {
+              // Need to hint to Typescript that we want the 'VOTER_INITIATED_PRINT' event in our union type of events
+              if ('pdfData' in event) {
+                return driverPrintBallot(context.driver, event.pdfData, {});
+              }
+              throw new Error(
+                `printing_ballot entry called by unsupported event type: ${event.type}`
+              );
+            },
+            onDone: {
+              target: 'scanning',
+            },
+          },
+          pollPaperStatus(),
+        ],
       },
       scanning: {
         invoke: [

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -376,13 +376,8 @@ export function buildMachine(
           {
             id: 'printBallot',
             src: (context, event) => {
-              // Need to hint to Typescript that we want the 'VOTER_INITIATED_PRINT' event in our union type of events
-              if ('pdfData' in event) {
-                return driverPrintBallot(context.driver, event.pdfData, {});
-              }
-              throw new Error(
-                `printing_ballot entry called by unsupported event type: ${event.type}`
-              );
+              assert(event.type === 'VOTER_INITIATED_PRINT');
+              return driverPrintBallot(context.driver, event.pdfData, {});
             },
             onDone: {
               target: 'scanning',

--- a/apps/mark-scan/frontend/src/pages/print_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/print_page.tsx
@@ -29,9 +29,8 @@ export function PrintPage(): JSX.Element | null {
     options: PrintOptions
   ): Promise<void> {
     debug(`Ignoring print options with keys: ${Object.keys(options)}`);
-    const pdfData = await printElementToPdf(element);
-    debug(`got pdf data length ${pdfData.byteLength}`);
-    printBallotMutation.mutate({ pdfData: Buffer.from(pdfData) });
+    const pdfData = Buffer.from(await printElementToPdf(element));
+    printBallotMutation.mutate({ pdfData });
   }
 
   function onPrintStarted() {
@@ -48,6 +47,7 @@ export function PrintPage(): JSX.Element | null {
       generateBallotId={generateBallotId}
       onPrintStarted={onPrintStarted}
       printElement={printElementToCustomPaperHandler}
+      largeTopMargin
     />
   );
 }

--- a/libs/mark-flow-ui/src/pages/__snapshots__/print_page.test.tsx.snap
+++ b/libs/mark-flow-ui/src/pages/__snapshots__/print_page.test.tsx.snap
@@ -105,6 +105,10 @@ exports[`no votes 1`] = `
   page-break-after: always;
 }
 
+.c0 > .large-top-margin {
+  margin-top: 1.75in;
+}
+
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -268,6 +272,7 @@ exports[`no votes 1`] = `
   >
     <div
       class="c1"
+      data-testid="header"
     >
       <div
         class="seal"
@@ -860,6 +865,10 @@ exports[`with votes 1`] = `
   page-break-after: always;
 }
 
+.c0 > .large-top-margin {
+  margin-top: 1.75in;
+}
+
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1023,6 +1032,7 @@ exports[`with votes 1`] = `
   >
     <div
       class="c1"
+      data-testid="header"
     >
       <div
         class="seal"
@@ -1612,6 +1622,10 @@ exports[`without votes and inline seal 1`] = `
   page-break-after: always;
 }
 
+.c0 > .large-top-margin {
+  margin-top: 1.75in;
+}
+
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1775,6 +1789,7 @@ exports[`without votes and inline seal 1`] = `
   >
     <div
       class="c1"
+      data-testid="header"
     >
       <div
         class="seal"

--- a/libs/mark-flow-ui/src/pages/__snapshots__/print_page.test.tsx.snap
+++ b/libs/mark-flow-ui/src/pages/__snapshots__/print_page.test.tsx.snap
@@ -105,10 +105,6 @@ exports[`no votes 1`] = `
   page-break-after: always;
 }
 
-.c0 > .large-top-margin {
-  margin-top: 1.75in;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -865,10 +861,6 @@ exports[`with votes 1`] = `
   page-break-after: always;
 }
 
-.c0 > .large-top-margin {
-  margin-top: 1.75in;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1620,10 +1612,6 @@ exports[`without votes and inline seal 1`] = `
   font-family: 'Vx Helvetica Neue','Noto Emoji','Helvetica Neue',sans-serif;
   font-size: 16px;
   page-break-after: always;
-}
-
-.c0 > .large-top-margin {
-  margin-top: 1.75in;
 }
 
 .c1 {

--- a/libs/mark-flow-ui/src/pages/print_page.tsx
+++ b/libs/mark-flow-ui/src/pages/print_page.tsx
@@ -33,6 +33,7 @@ export interface PrintPageProps {
     element: JSX.Element,
     printOptions: PrintOptions
   ) => Promise<void>;
+  largeTopMargin?: boolean;
 }
 
 export function PrintPage({
@@ -44,6 +45,7 @@ export function PrintPage({
   generateBallotId,
   onPrintStarted,
   printElement = DefaultPrintElement,
+  largeTopMargin,
 }: PrintPageProps): JSX.Element {
   const printLock = useLock();
 
@@ -58,6 +60,7 @@ export function PrintPage({
         isLiveMode={isLiveMode}
         precinctId={precinctId}
         votes={votes}
+        largeTopMargin={largeTopMargin}
       />,
       { sides: 'one-sided' }
     );
@@ -72,6 +75,7 @@ export function PrintPage({
     votes,
     onPrintStarted,
     printElement,
+    largeTopMargin,
   ]);
 
   useEffect(() => {

--- a/libs/ui/src/__snapshots__/bmd_paper_ballot.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/bmd_paper_ballot.test.tsx.snap
@@ -112,10 +112,6 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
   page-break-after: always;
 }
 
-.c0 > .large-top-margin {
-  margin-top: 1.75in;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;

--- a/libs/ui/src/__snapshots__/bmd_paper_ballot.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/bmd_paper_ballot.test.tsx.snap
@@ -112,6 +112,10 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
   page-break-after: always;
 }
 
+.c0 > .large-top-margin {
+  margin-top: 1.75in;
+}
+
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -271,6 +275,7 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
   >
     <div
       class="c1"
+      data-testid="header"
     >
       <div
         class="seal"

--- a/libs/ui/src/bmd_paper_ballot.test.tsx
+++ b/libs/ui/src/bmd_paper_ballot.test.tsx
@@ -57,6 +57,7 @@ function renderBmdPaperBallot({
   votes,
   isLiveMode = false,
   onRendered,
+  largeTopMargin,
 }: {
   electionDefinition: ElectionDefinition;
   ballotStyleId: BallotStyleId;
@@ -64,6 +65,7 @@ function renderBmdPaperBallot({
   votes: { [key: string]: string | string[] | Candidate };
   isLiveMode?: boolean;
   onRendered?: () => void;
+  largeTopMargin?: boolean;
 }) {
   return render(
     <BmdPaperBallot
@@ -82,6 +84,7 @@ function renderBmdPaperBallot({
         votes
       )}
       onRendered={onRendered}
+      largeTopMargin={largeTopMargin}
     />
   );
 }
@@ -197,6 +200,31 @@ test('BmdPaperBallot renders remaining choices for multi-seat contests', () => {
   });
 
   screen.getByText('[no selection for 1 of 3 choices]');
+});
+
+test('BmdPaperBallot renders a large top margin when prop is passed', () => {
+  renderBmdPaperBallot({
+    electionDefinition: electionWithMsEitherNeitherDefinition,
+    ballotStyleId: '1',
+    precinctId: '6525',
+    votes: {},
+    largeTopMargin: true,
+  });
+
+  const header = screen.getByTestId('header');
+  expect(header.className).toContain('large-top-margin');
+});
+
+test('BmdPaperBallot does not render a large top margin when prop is not passed', () => {
+  renderBmdPaperBallot({
+    electionDefinition: electionWithMsEitherNeitherDefinition,
+    ballotStyleId: '1',
+    precinctId: '6525',
+    votes: {},
+  });
+
+  const header = screen.getByTestId('header');
+  expect(header.className).not.toContain('large-top-margin');
 });
 
 test('BmdPaperBallot renders seal', () => {

--- a/libs/ui/src/bmd_paper_ballot.test.tsx
+++ b/libs/ui/src/bmd_paper_ballot.test.tsx
@@ -202,31 +202,6 @@ test('BmdPaperBallot renders remaining choices for multi-seat contests', () => {
   screen.getByText('[no selection for 1 of 3 choices]');
 });
 
-test('BmdPaperBallot renders a large top margin when prop is passed', () => {
-  renderBmdPaperBallot({
-    electionDefinition: electionWithMsEitherNeitherDefinition,
-    ballotStyleId: '1',
-    precinctId: '6525',
-    votes: {},
-    largeTopMargin: true,
-  });
-
-  const header = screen.getByTestId('header');
-  expect(header.className).toContain('large-top-margin');
-});
-
-test('BmdPaperBallot does not render a large top margin when prop is not passed', () => {
-  renderBmdPaperBallot({
-    electionDefinition: electionWithMsEitherNeitherDefinition,
-    ballotStyleId: '1',
-    precinctId: '6525',
-    votes: {},
-  });
-
-  const header = screen.getByTestId('header');
-  expect(header.className).not.toContain('large-top-margin');
-});
-
 test('BmdPaperBallot renders seal', () => {
   renderBmdPaperBallot({
     electionDefinition: electionWithMsEitherNeitherDefinition,
@@ -291,4 +266,29 @@ describe('BmdPaperBallot calls onRendered', () => {
 
     expect(onRendered).toHaveBeenCalledTimes(1);
   });
+});
+
+test('BmdPaperBallot renders a large top margin when prop is passed', () => {
+  renderBmdPaperBallot({
+    electionDefinition: electionWithMsEitherNeitherDefinition,
+    ballotStyleId: '1',
+    precinctId: '6525',
+    votes: {},
+    largeTopMargin: true,
+  });
+
+  const header = screen.getByTestId('header');
+  expect(header).toHaveStyle(`margin-top: 1.75in`);
+});
+
+test('BmdPaperBallot does not render a large top margin when prop is not passed', () => {
+  renderBmdPaperBallot({
+    electionDefinition: electionWithMsEitherNeitherDefinition,
+    ballotStyleId: '1',
+    precinctId: '6525',
+    votes: {},
+  });
+
+  const header = screen.getByTestId('header');
+  expect(header).not.toHaveStyle(`margin-top: 1.75in`);
 });

--- a/libs/ui/src/bmd_paper_ballot.tsx
+++ b/libs/ui/src/bmd_paper_ballot.tsx
@@ -49,17 +49,17 @@ const Ballot = styled.div`
     margin: 0.375in;
     size: letter portrait;
   }
-
-  & > .large-top-margin {
-    margin-top: 1.75in;
-  }
 `;
 
-const Header = styled.div`
+interface StyledHeaderProps {
+  largeTopMargin?: boolean;
+}
+const Header = styled.div<StyledHeaderProps>`
   display: flex;
   flex-direction: row;
   align-items: center;
   border-bottom: 0.2em solid #000;
+  margin-top: ${(p) => (p.largeTopMargin ? '1.75in' : undefined)};
 
   & > .seal {
     margin: 0.25em 0;
@@ -281,10 +281,7 @@ export function BmdPaperBallot({
 
   return withPrintTheme(
     <Ballot aria-hidden>
-      <Header
-        className={largeTopMargin ? 'large-top-margin' : undefined}
-        data-testid="header"
-      >
+      <Header largeTopMargin={largeTopMargin}>
         <div
           className="seal"
           dangerouslySetInnerHTML={{ __html: seal }} // eslint-disable-line react/no-danger

--- a/libs/ui/src/bmd_paper_ballot.tsx
+++ b/libs/ui/src/bmd_paper_ballot.tsx
@@ -49,6 +49,10 @@ const Ballot = styled.div`
     margin: 0.375in;
     size: letter portrait;
   }
+
+  & > .large-top-margin {
+    margin-top: 1.75in;
+  }
 `;
 
 const Header = styled.div`
@@ -217,6 +221,7 @@ interface Props {
   precinctId: PrecinctId;
   votes: VotesDict;
   onRendered?: () => void;
+  largeTopMargin?: boolean;
 }
 
 /**
@@ -242,6 +247,7 @@ export function BmdPaperBallot({
   precinctId,
   votes,
   onRendered,
+  largeTopMargin,
 }: Props): JSX.Element {
   const ballotId = generateBallotId();
   const {
@@ -275,7 +281,10 @@ export function BmdPaperBallot({
 
   return withPrintTheme(
     <Ballot aria-hidden>
-      <Header>
+      <Header
+        className={largeTopMargin ? 'large-top-margin' : undefined}
+        data-testid="header"
+      >
         <div
           className="seal"
           dangerouslySetInnerHTML={{ __html: seal }} // eslint-disable-line react/no-danger

--- a/libs/ui/src/bmd_paper_ballot.tsx
+++ b/libs/ui/src/bmd_paper_ballot.tsx
@@ -281,7 +281,7 @@ export function BmdPaperBallot({
 
   return withPrintTheme(
     <Ballot aria-hidden>
-      <Header largeTopMargin={largeTopMargin}>
+      <Header largeTopMargin={largeTopMargin} data-testid="header">
         <div
           className="seal"
           dangerouslySetInnerHTML={{ __html: seal }} // eslint-disable-line react/no-danger


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/3872

* Adds an optional 1.75in margin to the BMD ballot component so the top of the ballot isn't cut off when presenting the ballot for validation
* Changes the implementation of the print state
  * The old implementation triggered the scan state too early. When printing longer ballots, the paper would advance such that `paperInOutput` would return true in the middle of a print, causing the paper to be pulled into the scanner before printing was done.

## Demo Video or Screenshot

**Before**
![IMG_4236](https://github.com/votingworks/vxsuite/assets/1060688/a72ad17b-bd40-460b-9909-f246c572fc8e)

**After**
![IMG_4238](https://github.com/votingworks/vxsuite/assets/1060688/df84c9b2-4b05-4b18-8ff1-09806040d2a2)
![IMG_4237](https://github.com/votingworks/vxsuite/assets/1060688/c21a5230-3df7-437b-9611-9c2f4e7cb2ad)



## Testing Plan
* Added test to BMD ballot component

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
