### PR TITLE
Self-Documenting `.csv` Exports

### DIFF
--- a/apps/admin/backend/jest.config.js
+++ b/apps/admin/backend/jest.config.js
@@ -34,5 +34,6 @@ module.exports = {
   moduleNameMapper: {
     '^csv-stringify/sync':
       '<rootDir>/node_modules/csv-stringify/dist/cjs/sync.cjs',
+    '^csv-parse/sync': '<rootDir>/node_modules/csv-parse/dist/cjs/sync.cjs',
   },
 };

--- a/apps/admin/backend/package.json
+++ b/apps/admin/backend/package.json
@@ -79,6 +79,7 @@
     "@types/uuid": "^8.3.4",
     "@types/zip-stream": "workspace:0.0.1-development",
     "@votingworks/test-utils": "workspace:*",
+    "csv-parse": "^5.5.0",
     "esbuild": "^0.14.29",
     "esbuild-runner": "^2.2.1",
     "eslint-plugin-vx": "workspace:*",

--- a/apps/admin/backend/src/app.results_csv_export.test.ts
+++ b/apps/admin/backend/src/app.results_csv_export.test.ts
@@ -10,16 +10,15 @@ import {
 import { tmpNameSync } from 'tmp';
 import { readFileSync } from 'fs';
 import { LogEventId } from '@votingworks/logging';
-import { Tabulation, safeParse, CVR as CVRType } from '@votingworks/types';
+import { Tabulation } from '@votingworks/types';
 import { Client } from '@votingworks/grout';
-import { vxBallotType } from '@votingworks/types/src/cdf/cast-vote-records';
+import { parseCsv } from '../test/csv';
 import {
   buildTestEnvironment,
   configureMachine,
   mockElectionManagerAuth,
 } from '../test/app';
 import { Api } from './app';
-import { modifyCastVoteRecordReport } from '../test/utils';
 
 jest.setTimeout(60_000);
 
@@ -47,28 +46,26 @@ afterEach(() => {
   featureFlagMock.resetFeatureFlags();
 });
 
-async function exportResultsSnippet({
+async function getParsedExport({
   apiClient,
   groupBy,
   filter,
-  numLines,
 }: {
   apiClient: Client<Api>;
   groupBy?: Tabulation.GroupBy;
   filter?: Tabulation.Filter;
-  numLines?: number;
-}): Promise<string[]> {
+}): Promise<ReturnType<typeof parseCsv>> {
   const path = tmpNameSync();
-  const precinctGroupedExportResult = await apiClient.exportResultsCsv({
+  const exportResult = await apiClient.exportResultsCsv({
     path,
     groupBy,
     filter,
   });
-  expect(precinctGroupedExportResult.isOk()).toEqual(true);
-  return readFileSync(path, 'utf-8').toString().split('\n').slice(0, numLines);
+  expect(exportResult.isOk()).toEqual(true);
+  return parseCsv(readFileSync(path, 'utf-8').toString());
 }
 
-it('exports expected results, without splits or filter', async () => {
+it('exports expected results for full election', async () => {
   const { electionDefinition, castVoteRecordReport } =
     electionMinimalExhaustiveSampleFixtures;
 
@@ -95,74 +92,43 @@ it('exports expected results, without splits or filter', async () => {
   );
 
   const fileContent = readFileSync(path, 'utf-8').toString();
-  const header = fileContent.split('\n')[0];
-  expect(header).toMatchInlineSnapshot(
-    `"Contest,Contest ID,Selection,Selection ID,Votes"`
+  const { headers, rows } = parseCsv(fileContent);
+  expect(headers).toEqual([
+    'Contest',
+    'Contest ID',
+    'Selection',
+    'Selection ID',
+    'Votes',
+  ]);
+
+  const bestAnimalMammalExpectedValues: Record<string, string> = {
+    horse: '4',
+    otter: '4',
+    fox: '36',
+    overvotes: '8',
+    undervotes: '4',
+  };
+  const bestAnimalMammalRows = rows.filter(
+    (row) => row['Contest ID'] === 'best-animal-mammal'
   );
-  const bestAnimalMammalRows = fileContent
-    .split('\n')
-    .filter((line) => line.includes('best-animal-mammal'));
-  expect(bestAnimalMammalRows).toMatchInlineSnapshot(`
-      [
-        "Best Animal,best-animal-mammal,Horse,horse,4",
-        "Best Animal,best-animal-mammal,Otter,otter,4",
-        "Best Animal,best-animal-mammal,Fox,fox,36",
-        "Best Animal,best-animal-mammal,Overvotes,overvotes,8",
-        "Best Animal,best-animal-mammal,Undervotes,undervotes,4",
-      ]
-    `);
-  const fishingRows = fileContent
-    .split('\n')
-    .filter((line) => line.includes('fishing'));
-  expect(fishingRows).toMatchInlineSnapshot(`
-    [
-      "Ballot Measure 3,fishing,YES,ban-fishing,8",
-      "Ballot Measure 3,fishing,NO,allow-fishing,8",
-      "Ballot Measure 3,fishing,Overvotes,overvotes,8",
-      "Ballot Measure 3,fishing,Undervotes,undervotes,88",
-    ]
-  `);
-});
+  expect(bestAnimalMammalRows).toHaveLength(5);
+  for (const [selectionId, votes] of Object.entries(
+    bestAnimalMammalExpectedValues
+  )) {
+    expect(votes).toEqual(bestAnimalMammalExpectedValues[selectionId]);
+  }
 
-it('exports 0s if no results are loaded', async () => {
-  const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
-
-  const { apiClient, auth } = buildTestEnvironment();
-  await configureMachine(apiClient, auth, electionDefinition);
-  mockElectionManagerAuth(auth, electionDefinition.electionHash);
-
-  const path = tmpNameSync();
-  const exportResult = await apiClient.exportResultsCsv({ path });
-  expect(exportResult.isOk()).toEqual(true);
-
-  const fileContent = readFileSync(path, 'utf-8').toString();
-  const header = fileContent.split('\n')[0];
-  expect(header).toMatchInlineSnapshot(
-    `"Contest,Contest ID,Selection,Selection ID,Votes"`
-  );
-  const bestAnimalMammalRows = fileContent
-    .split('\n')
-    .filter((line) => line.includes('best-animal-mammal'));
-  expect(bestAnimalMammalRows).toMatchInlineSnapshot(`
-      [
-        "Best Animal,best-animal-mammal,Horse,horse,0",
-        "Best Animal,best-animal-mammal,Otter,otter,0",
-        "Best Animal,best-animal-mammal,Fox,fox,0",
-        "Best Animal,best-animal-mammal,Overvotes,overvotes,0",
-        "Best Animal,best-animal-mammal,Undervotes,undervotes,0",
-      ]
-    `);
-  const fishingRows = fileContent
-    .split('\n')
-    .filter((line) => line.includes('fishing'));
-  expect(fishingRows).toMatchInlineSnapshot(`
-    [
-      "Ballot Measure 3,fishing,YES,ban-fishing,0",
-      "Ballot Measure 3,fishing,NO,allow-fishing,0",
-      "Ballot Measure 3,fishing,Overvotes,overvotes,0",
-      "Ballot Measure 3,fishing,Undervotes,undervotes,0",
-    ]
-  `);
+  const fishingExpectedValues: Record<string, string> = {
+    'ban-fishing': '8',
+    'allow-fishing': '8',
+    overvotes: '8',
+    undervotes: '88',
+  };
+  const fishingRows = rows.filter((row) => row['Contest ID'] === 'fishing');
+  expect(fishingRows).toHaveLength(4);
+  for (const [selectionId, votes] of Object.entries(fishingExpectedValues)) {
+    expect(votes).toEqual(fishingExpectedValues[selectionId]);
+  }
 });
 
 it('logs failure if export fails for some reason', async () => {
@@ -194,114 +160,6 @@ it('logs failure if export fails for some reason', async () => {
   );
 });
 
-it('uses appropriate file headers based on group by', async () => {
-  const { electionDefinition, castVoteRecordReport } =
-    electionMinimalExhaustiveSampleFixtures;
-  const { apiClient, auth } = buildTestEnvironment();
-  await configureMachine(apiClient, auth, electionDefinition);
-  mockElectionManagerAuth(auth, electionDefinition.electionHash);
-
-  const loadFileResult = await apiClient.addCastVoteRecordFile({
-    path: castVoteRecordReport.asDirectoryPath(),
-  });
-  loadFileResult.assertOk('load file failed');
-
-  // test each grouping individually
-
-  expect(
-    await exportResultsSnippet({
-      apiClient,
-      groupBy: { groupByPrecinct: true },
-      numLines: 2,
-    })
-  ).toMatchInlineSnapshot(`
-      [
-        "Precinct,Precinct ID,Contest,Contest ID,Selection,Selection ID,Votes",
-        "Precinct 1,precinct-1,Best Animal,best-animal-mammal,Horse,horse,2",
-      ]
-    `);
-
-  expect(
-    await exportResultsSnippet({
-      apiClient,
-      groupBy: { groupByBatch: true },
-      numLines: 2,
-    })
-  ).toMatchInlineSnapshot(`
-      [
-        "Scanner ID,Batch ID,Contest,Contest ID,Selection,Selection ID,Votes",
-        "VX-00-000,9822c71014,Best Animal,best-animal-mammal,Horse,horse,4",
-      ]
-    `);
-
-  expect(
-    await exportResultsSnippet({
-      apiClient,
-      groupBy: { groupByScanner: true },
-      numLines: 2,
-    })
-  ).toMatchInlineSnapshot(`
-      [
-        "Scanner ID,Contest,Contest ID,Selection,Selection ID,Votes",
-        "VX-00-000,Best Animal,best-animal-mammal,Horse,horse,4",
-      ]
-    `);
-
-  expect(
-    await exportResultsSnippet({
-      apiClient,
-      groupBy: { groupByBallotStyle: true },
-      numLines: 2,
-    })
-  ).toMatchInlineSnapshot(`
-      [
-        "Party,Party ID,Ballot Style ID,Contest,Contest ID,Selection,Selection ID,Votes",
-        "Mammal,0,1M,Best Animal,best-animal-mammal,Horse,horse,4",
-      ]
-    `);
-
-  expect(
-    await exportResultsSnippet({
-      apiClient,
-      groupBy: { groupByParty: true },
-      numLines: 2,
-    })
-  ).toMatchInlineSnapshot(`
-      [
-        "Party,Party ID,Contest,Contest ID,Selection,Selection ID,Votes",
-        "Mammal,0,Best Animal,best-animal-mammal,Horse,horse,4",
-      ]
-    `);
-
-  expect(
-    await exportResultsSnippet({
-      apiClient,
-      groupBy: { groupByVotingMethod: true },
-      numLines: 2,
-    })
-  ).toMatchInlineSnapshot(`
-      [
-        "Voting Method,Contest,Contest ID,Selection,Selection ID,Votes",
-        "Precinct,Best Animal,best-animal-mammal,Horse,horse,2",
-      ]
-    `);
-
-  // try a combination
-
-  expect(
-    await exportResultsSnippet({
-      apiClient,
-      groupBy: { groupByPrecinct: true, groupByVotingMethod: true },
-      numLines: 2,
-    })
-  ).toMatchInlineSnapshot(`
-      [
-        "Voting Method,Precinct,Precinct ID,Contest,Contest ID,Selection,Selection ID,Votes",
-        "Precinct,Precinct 1,precinct-1,Best Animal,best-animal-mammal,Horse,horse,1",
-      ]
-    `);
-});
-
 it('incorporates wia and manual data', async () => {
   const { electionDefinition, castVoteRecordReport } =
     electionGridLayoutNewHampshireAmherstFixtures;
@@ -316,39 +174,44 @@ it('incorporates wia and manual data', async () => {
   });
   loadFileResult.assertOk('load file failed');
 
-  // imitate common export splits
   const groupBy: Tabulation.GroupBy = {
-    groupByPrecinct: true,
     groupByVotingMethod: true,
   };
   const candidateContestId =
     'State-Representatives-Hillsborough-District-34-b1012d38';
   const officialCandidateId = 'Obadiah-Carrigan-5c95145a';
 
-  // export without wia and manual data
-  const resultsExportInitial = await exportResultsSnippet({
+  function rowExists(
+    rows: ReturnType<typeof parseCsv>['rows'],
+    selectionId: string,
+    votingMethod: string,
+    votes: number
+  ): boolean {
+    return rows.some(
+      (row) =>
+        row['Selection ID'] === selectionId &&
+        row['Voting Method'] === votingMethod &&
+        row['Votes'] === votes.toString()
+    );
+  }
+
+  // check initial export, without wia and manual data
+  const { rows: rowsInitial } = await getParsedExport({
     apiClient,
     groupBy,
   });
-  const linesCandidateContest = resultsExportInitial.filter((line) =>
-    line.includes(candidateContestId)
-  );
-  const officialCandidateCounts = linesCandidateContest
-    .filter((line) => line.includes(officialCandidateId))
-    .map((line) => line.split(','))
-    .map((values) => [values[0], values.pop()]);
-  expect(officialCandidateCounts).toEqual([
-    ['Precinct', '30'],
-    ['Absentee', '30'],
-  ]);
-  const genericWriteInCounts = linesCandidateContest
-    .filter((line) => line.includes(',write-in,'))
-    .map((line) => line.split(','))
-    .map((values) => [values[0], values.pop()]);
-  expect(genericWriteInCounts).toEqual([
-    ['Precinct', '28'],
-    ['Absentee', '28'],
-  ]);
+
+  // initial official candidate counts
+  expect(
+    rowExists(rowsInitial, officialCandidateId, 'Precinct', 30)
+  ).toBeTruthy();
+  expect(
+    rowExists(rowsInitial, officialCandidateId, 'Absentee', 30)
+  ).toBeTruthy();
+
+  // initial generic write-in counts
+  expect(rowExists(rowsInitial, 'write-in', 'Absentee', 28)).toBeTruthy();
+  expect(rowExists(rowsInitial, 'write-in', 'Precinct', 28)).toBeTruthy();
 
   // add manual data
   await apiClient.setManualResults({
@@ -388,191 +251,34 @@ it('incorporates wia and manual data', async () => {
     });
   }
 
-  // export with wia and manual data
-  const resultsExportFinal = await exportResultsSnippet({
-    apiClient,
-    groupBy,
-  });
-  const linesCandidateContest2 = resultsExportFinal.filter((line) =>
-    line.includes(candidateContestId)
-  );
-  const officialCandidateCounts2 = linesCandidateContest2
-    .filter((line) => line.includes(officialCandidateId))
-    .map((line) => line.split(','))
-    .map((values) => [values[0], values.pop()]);
-  expect(officialCandidateCounts2).toEqual([
-    ['Precinct', '30'],
-    ['Absentee', '40'], // manual data reflected
-  ]);
-  const unofficialCandidateCounts2 = linesCandidateContest2
-    .filter((line) => line.includes(writeInCandidate.id))
-    .map((line) => line.split(','))
-    .map((values) => [values[0], values.pop()]);
-  expect(unofficialCandidateCounts2).toEqual([
-    ['Precinct', '28'], // unofficial candidate data included
-    ['Absentee', '28'],
-  ]);
-  expect(
-    linesCandidateContest2.filter((line) => line.includes(',write-in,'))
-  ).toHaveLength(0);
-});
-
-it('populates empty splits with data', async () => {
-  const { electionDefinition, castVoteRecordReport } =
-    electionGridLayoutNewHampshireAmherstFixtures;
-
-  const { apiClient, auth } = buildTestEnvironment();
-  await configureMachine(apiClient, auth, electionDefinition);
-
-  // alter fixture so there are no absentee CVRs
-  const reportDirectoryPath = await modifyCastVoteRecordReport(
-    castVoteRecordReport.asDirectoryPath(),
-    ({ CVR }) => ({
-      CVR: CVR.map((unparsed) => {
-        return {
-          ...safeParse(CVRType.CVRSchema, unparsed).unsafeUnwrap(),
-          vxBallotType: vxBallotType.Precinct,
-        };
-      }),
-    })
-  );
-
-  mockElectionManagerAuth(auth, electionDefinition.electionHash);
-
-  const loadFileResult = await apiClient.addCastVoteRecordFile({
-    path: reportDirectoryPath,
-  });
-  loadFileResult.assertOk('load file failed');
-
-  // imitate common export splits
-  const groupBy: Tabulation.GroupBy = {
-    groupByVotingMethod: true,
-  };
-
-  // export without wia and manual data
-  const resultsExport = await exportResultsSnippet({
+  // check final export, with wia and manual data
+  const { rows: rowsFinal } = await getParsedExport({
     apiClient,
     groupBy,
   });
 
-  let hasAbsenteeRows = false;
-  for (const line of resultsExport) {
-    if (line.includes('Absentee')) {
-      hasAbsenteeRows = true;
-      expect(line.endsWith('0')).toBeTruthy();
-    }
-  }
-  expect(hasAbsenteeRows).toBeTruthy();
-});
-
-it('adjusts included contests based on splits', async () => {
-  const { electionDefinition, castVoteRecordReport } =
-    electionMinimalExhaustiveSampleFixtures;
-
-  const { apiClient, auth } = buildTestEnvironment();
-  await configureMachine(apiClient, auth, electionDefinition);
-  mockElectionManagerAuth(auth, electionDefinition.electionHash);
-
-  const loadFileResult = await apiClient.addCastVoteRecordFile({
-    path: castVoteRecordReport.asDirectoryPath(),
-  });
-  loadFileResult.assertOk('load file failed');
-
-  const resultsExport = await exportResultsSnippet({
-    apiClient,
-    groupBy: { groupByBallotStyle: true },
-  });
-
-  // mammal ballot style entries should include mammal and nonpartisan contests, but not fish
+  // final official candidate counts
   expect(
-    resultsExport.some(
-      (line) => line.includes('1M') && line.includes('best-animal-mammal')
-    )
+    rowExists(rowsFinal, officialCandidateId, 'Precinct', 30)
   ).toBeTruthy();
   expect(
-    resultsExport.some(
-      (line) => line.includes('1M') && line.includes('fishing')
-    )
+    rowExists(rowsFinal, officialCandidateId, 'Absentee', 40)
+  ).toBeTruthy(); // manual data reflected
+
+  // added write-in candidate counts
+  expect(
+    rowExists(rowsFinal, writeInCandidate.id, 'Absentee', 28)
   ).toBeTruthy();
   expect(
-    resultsExport.some(
-      (line) => line.includes('1M') && line.includes('best-animal-fish')
-    )
-  ).toBeFalsy();
-
-  // fish ballot style entries should include fish and nonpartisan contests, but not mammal
-  expect(
-    resultsExport.some(
-      (line) => line.includes('2F') && line.includes('best-animal-mammal')
-    )
-  ).toBeFalsy();
-  expect(
-    resultsExport.some(
-      (line) => line.includes('2F') && line.includes('fishing')
-    )
-  ).toBeTruthy();
-  expect(
-    resultsExport.some(
-      (line) => line.includes('2F') && line.includes('best-animal-fish')
-    )
-  ).toBeTruthy();
-});
-
-it('adjusts included contests based on filter', async () => {
-  const { electionDefinition, castVoteRecordReport } =
-    electionMinimalExhaustiveSampleFixtures;
-
-  const { apiClient, auth } = buildTestEnvironment();
-  await configureMachine(apiClient, auth, electionDefinition);
-  mockElectionManagerAuth(auth, electionDefinition.electionHash);
-
-  const loadFileResult = await apiClient.addCastVoteRecordFile({
-    path: castVoteRecordReport.asDirectoryPath(),
-  });
-  loadFileResult.assertOk('load file failed');
-
-  const resultsExport = await exportResultsSnippet({
-    apiClient,
-    filter: { ballotStyleIds: ['1M'] },
-  });
-
-  expect(
-    resultsExport.some((line) => line.includes('best-animal-mammal'))
-  ).toBeTruthy();
-  expect(
-    resultsExport.some((line) => line.includes('best-animal-fish'))
-  ).toBeFalsy();
-});
-
-it('does not include splits when they are excluded by the filter', async () => {
-  const { electionDefinition, castVoteRecordReport } =
-    electionMinimalExhaustiveSampleFixtures;
-
-  const { apiClient, auth } = buildTestEnvironment();
-  await configureMachine(apiClient, auth, electionDefinition);
-  mockElectionManagerAuth(auth, electionDefinition.electionHash);
-
-  const loadFileResult = await apiClient.addCastVoteRecordFile({
-    path: castVoteRecordReport.asDirectoryPath(),
-  });
-  loadFileResult.assertOk('load file failed');
-
-  // splitting by voting method should include absentee splits
-  const resultsExportAll = await exportResultsSnippet({
-    apiClient,
-    groupBy: { groupByVotingMethod: true },
-  });
-  expect(
-    resultsExportAll.some((line) => line.includes('Absentee'))
+    rowExists(rowsFinal, writeInCandidate.id, 'Precinct', 28)
   ).toBeTruthy();
 
-  // but if we filter out precinct ballots, we should be smart enough to not include absentee splits
-  const resultsExportAbsenteeOnly = await exportResultsSnippet({
-    apiClient,
-    groupBy: { groupByVotingMethod: true },
-    filter: { votingMethods: ['precinct'] },
-  });
+  // generic write-in counts should be gone
   expect(
-    resultsExportAbsenteeOnly.some((line) => line.includes('Absentee'))
+    rowsFinal.some(
+      (r) =>
+        r['Contest ID'] === candidateContestId &&
+        r['Selection ID'] === 'write-in'
+    )
   ).toBeFalsy();
 });

--- a/apps/admin/backend/src/exports/csv_results.test.ts
+++ b/apps/admin/backend/src/exports/csv_results.test.ts
@@ -125,42 +125,42 @@ test('uses appropriate headers', async () => {
       filter: { precinctIds: ['precinct-1', 'precinct-2'] },
       additionalHeaders: ['Included Precincts'],
       additionalRowAttributes: {
-        'Included Precincts': 'Precinct 1,Precinct 2',
+        'Included Precincts': 'Precinct 1, Precinct 2',
       },
     },
     {
       filter: { votingMethods: ['absentee', 'precinct'] },
       additionalHeaders: ['Included Voting Methods'],
       additionalRowAttributes: {
-        'Included Voting Methods': 'Absentee,Precinct',
+        'Included Voting Methods': 'Absentee, Precinct',
       },
     },
     {
       filter: { ballotStyleIds: ['1M', '2F'] },
       additionalHeaders: ['Included Ballot Styles'],
       additionalRowAttributes: {
-        'Included Ballot Styles': '1M,2F',
+        'Included Ballot Styles': '1M, 2F',
       },
     },
     {
       filter: { partyIds: ['0', '1'] },
       additionalHeaders: ['Included Parties'],
       additionalRowAttributes: {
-        'Included Parties': 'Mammal,Fish',
+        'Included Parties': 'Mammal, Fish',
       },
     },
     {
       filter: { batchIds: ['batch-1', 'batch-2'] },
       additionalHeaders: ['Included Batches'],
       additionalRowAttributes: {
-        'Included Batches': 'batch-1,batch-2',
+        'Included Batches': 'batch-1, batch-2',
       },
     },
     {
       filter: { scannerIds: ['scanner-1', 'scanner-2'] },
       additionalHeaders: ['Included Scanners'],
       additionalRowAttributes: {
-        'Included Scanners': 'scanner-1,scanner-2',
+        'Included Scanners': 'scanner-1, scanner-2',
       },
     },
     // multi-filter broken up by grouping
@@ -194,7 +194,7 @@ test('uses appropriate headers', async () => {
         'Included Precincts',
       ],
       additionalRowAttributes: {
-        'Included Precincts': 'Precinct 1,Precinct 2',
+        'Included Precincts': 'Precinct 1, Precinct 2',
       },
     },
   ];

--- a/apps/admin/backend/src/exports/csv_results.test.ts
+++ b/apps/admin/backend/src/exports/csv_results.test.ts
@@ -1,0 +1,350 @@
+import { electionMinimalExhaustiveSampleFixtures } from '@votingworks/fixtures';
+import { DEFAULT_SYSTEM_SETTINGS, Tabulation } from '@votingworks/types';
+import { find } from '@votingworks/basics';
+import {
+  MockCastVoteRecordFile,
+  addMockCvrFileToStore,
+} from '../../test/mock_cvr_file';
+import { generateResultsCsv } from './csv_results';
+import { parseCsv, streamToString } from '../../test/csv';
+import { Store } from '../store';
+
+test('uses appropriate headers', async () => {
+  const store = Store.memoryStore();
+  const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
+  const { electionData } = electionDefinition;
+  const electionId = store.addElection({
+    electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+  });
+  store.setCurrentElectionId(electionId);
+
+  // add some mock cast vote records with one vote each
+  const mockCastVoteRecordFile: MockCastVoteRecordFile = [
+    {
+      ballotStyleId: '1M',
+      batchId: 'batch-1',
+      scannerId: 'scanner-1',
+      precinctId: 'precinct-1',
+      votingMethod: 'precinct',
+      votes: { fishing: ['ban-fishing'] },
+      card: { type: 'bmd' },
+      multiplier: 1,
+    },
+  ];
+  addMockCvrFileToStore({ electionId, mockCastVoteRecordFile, store });
+
+  const SHARED_HEADERS = [
+    'Contest',
+    'Contest ID',
+    'Selection',
+    'Selection ID',
+    'Votes',
+  ];
+
+  const SHARED_ROW_VALUES: Record<string, string> = {
+    'Precinct ID': 'precinct-1',
+    Precinct: 'Precinct 1',
+    'Ballot Style ID': '1M',
+    Party: 'Mammal',
+    'Party ID': '0',
+    'Voting Method': 'Precinct',
+    'Batch ID': 'batch-1',
+    'Scanner ID': 'scanner-1',
+    Contest: 'Ballot Measure 3',
+    'Contest ID': 'fishing',
+    Selection: 'YES',
+    'Selection ID': 'ban-fishing',
+    Votes: '1',
+  };
+
+  const testCases: Array<{
+    filter?: Tabulation.Filter;
+    groupBy?: Tabulation.GroupBy;
+    additionalHeaders: string[];
+    additionalRowAttributes?: Record<string, string>;
+  }> = [
+    // single groupings
+    {
+      groupBy: { groupByPrecinct: true },
+      additionalHeaders: ['Precinct', 'Precinct ID'],
+    },
+    {
+      groupBy: { groupByParty: true },
+      additionalHeaders: ['Party', 'Party ID'],
+    },
+    {
+      groupBy: { groupByBallotStyle: true },
+      additionalHeaders: ['Party', 'Party ID', 'Ballot Style ID'],
+    },
+    {
+      groupBy: { groupByVotingMethod: true },
+      additionalHeaders: ['Voting Method'],
+    },
+    {
+      groupBy: { groupByScanner: true },
+      additionalHeaders: ['Scanner ID'],
+    },
+    {
+      groupBy: { groupByBatch: true },
+      additionalHeaders: ['Scanner ID', 'Batch ID'],
+    },
+    // redundant multiple groupings
+    {
+      groupBy: { groupByParty: true, groupByBallotStyle: true },
+      additionalHeaders: ['Party', 'Party ID', 'Ballot Style ID'],
+    },
+    {
+      groupBy: { groupByScanner: true, groupByBatch: true },
+      additionalHeaders: ['Scanner ID', 'Batch ID'],
+    },
+    // multiple groupings
+    {
+      groupBy: { groupByPrecinct: true, groupByVotingMethod: true },
+      additionalHeaders: ['Precinct', 'Precinct ID', 'Voting Method'],
+    },
+    // single filters
+    {
+      filter: { ballotStyleIds: ['1M'] },
+      additionalHeaders: ['Party', 'Party ID', 'Ballot Style ID'],
+    },
+    {
+      filter: { partyIds: ['0'] },
+      additionalHeaders: ['Party', 'Party ID'],
+    },
+    {
+      filter: { scannerIds: ['scanner-1'] },
+      additionalHeaders: ['Scanner ID'],
+    },
+    {
+      filter: { batchIds: ['batch-1'] },
+      additionalHeaders: ['Scanner ID', 'Batch ID'],
+    },
+    // multi-filters requiring multi-value columns
+    {
+      filter: { precinctIds: ['precinct-1', 'precinct-2'] },
+      additionalHeaders: ['Included Precincts'],
+      additionalRowAttributes: {
+        'Included Precincts': 'Precinct 1,Precinct 2',
+      },
+    },
+    {
+      filter: { votingMethods: ['absentee', 'precinct'] },
+      additionalHeaders: ['Included Voting Methods'],
+      additionalRowAttributes: {
+        'Included Voting Methods': 'Absentee,Precinct',
+      },
+    },
+    {
+      filter: { ballotStyleIds: ['1M', '2F'] },
+      additionalHeaders: ['Included Ballot Styles'],
+      additionalRowAttributes: {
+        'Included Ballot Styles': '1M,2F',
+      },
+    },
+    {
+      filter: { partyIds: ['0', '1'] },
+      additionalHeaders: ['Included Parties'],
+      additionalRowAttributes: {
+        'Included Parties': 'Mammal,Fish',
+      },
+    },
+    {
+      filter: { batchIds: ['batch-1', 'batch-2'] },
+      additionalHeaders: ['Included Batches'],
+      additionalRowAttributes: {
+        'Included Batches': 'batch-1,batch-2',
+      },
+    },
+    {
+      filter: { scannerIds: ['scanner-1', 'scanner-2'] },
+      additionalHeaders: ['Included Scanners'],
+      additionalRowAttributes: {
+        'Included Scanners': 'scanner-1,scanner-2',
+      },
+    },
+    // multi-filter broken up by grouping
+    {
+      filter: { precinctIds: ['precinct-1', 'precinct-2'] },
+      groupBy: { groupByPrecinct: true },
+      additionalHeaders: ['Precinct', 'Precinct ID'],
+    },
+    // miscellaneous combinations
+    {
+      filter: { precinctIds: ['precinct-1'] },
+      groupBy: { groupByVotingMethod: true },
+      additionalHeaders: ['Precinct', 'Precinct ID', 'Voting Method'],
+    },
+    {
+      filter: { votingMethods: ['precinct'] },
+      groupBy: { groupByPrecinct: true },
+      additionalHeaders: ['Precinct', 'Precinct ID', 'Voting Method'],
+    },
+    {
+      filter: {
+        precinctIds: ['precinct-1', 'precinct-2'],
+        votingMethods: ['precinct'],
+      },
+      groupBy: { groupByBallotStyle: true },
+      additionalHeaders: [
+        'Party',
+        'Party ID',
+        'Ballot Style ID',
+        'Voting Method',
+        'Included Precincts',
+      ],
+      additionalRowAttributes: {
+        'Included Precincts': 'Precinct 1,Precinct 2',
+      },
+    },
+  ];
+
+  for (const testCase of testCases) {
+    const stream = await generateResultsCsv({
+      store,
+      filter: testCase.filter,
+      groupBy: testCase.groupBy,
+    });
+    const fileContents = await streamToString(stream);
+    const { headers, rows } = parseCsv(fileContents);
+    expect(headers).toEqual([...testCase.additionalHeaders, ...SHARED_HEADERS]);
+
+    const row = find(
+      rows,
+      (r) => r['Votes'] === '1' && r['Selection ID'] === 'ban-fishing'
+    );
+    const expectedAttributes: Record<string, string> = {
+      ...SHARED_ROW_VALUES,
+      ...(testCase.additionalRowAttributes || {}),
+    };
+    for (const [header, value] of Object.entries(row)) {
+      expect(value).toEqual(expectedAttributes[header]);
+    }
+  }
+});
+
+test('includes rows for empty but known result groups', async () => {
+  const store = Store.memoryStore();
+  const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
+  const { electionData } = electionDefinition;
+  const electionId = store.addElection({
+    electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+  });
+  store.setCurrentElectionId(electionId);
+
+  // no CVRs, so all groups should be empty
+  const stream = await generateResultsCsv({
+    store,
+    filter: {},
+    groupBy: { groupByPrecinct: true },
+  });
+  const fileContents = await streamToString(stream);
+  const { rows } = parseCsv(fileContents);
+
+  find(rows, (r) => r['Precinct'] === 'Precinct 1');
+  find(rows, (r) => r['Precinct'] === 'Precinct 2');
+});
+
+test('included contests are specific to each results group', async () => {
+  const store = Store.memoryStore();
+  const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
+  const { electionData } = electionDefinition;
+  const electionId = store.addElection({
+    electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+  });
+  store.setCurrentElectionId(electionId);
+
+  const stream = await generateResultsCsv({
+    store,
+    filter: {},
+    groupBy: { groupByBallotStyle: true },
+  });
+  const fileContents = await streamToString(stream);
+  const { rows } = parseCsv(fileContents);
+
+  function rowExists(contestId: string, ballotStyleId: string) {
+    return rows.some(
+      (r) =>
+        r['Contest ID'] === contestId && r['Ballot Style ID'] === ballotStyleId
+    );
+  }
+
+  // mammal ballot style entries should include mammal and nonpartisan contests, but not fish
+  expect(rowExists('best-animal-mammal', '1M')).toBeTruthy();
+  expect(rowExists('fishing', '1M')).toBeTruthy();
+  expect(rowExists('best-animal-fish', '1M')).toBeFalsy();
+
+  // fish ballot style entries should include fish and nonpartisan contests, but not mammal
+  expect(rowExists('best-animal-mammal', '2F')).toBeFalsy();
+  expect(rowExists('fishing', '2F')).toBeTruthy();
+  expect(rowExists('best-animal-fish', '2F')).toBeTruthy();
+});
+
+test('included contests are restricted by the overall export filter', async () => {
+  const store = Store.memoryStore();
+  const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
+  const { electionData } = electionDefinition;
+  const electionId = store.addElection({
+    electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+  });
+  store.setCurrentElectionId(electionId);
+
+  const stream = await generateResultsCsv({
+    store,
+    filter: { ballotStyleIds: ['1M'] },
+  });
+  const fileContents = await streamToString(stream);
+  const { rows } = parseCsv(fileContents);
+
+  function rowExists(contestId: string) {
+    return rows.some((r) => r['Contest ID'] === contestId);
+  }
+
+  // should include mammal and nonpartisan contests, but not fish
+  expect(rowExists('best-animal-mammal')).toBeTruthy();
+  expect(rowExists('fishing')).toBeTruthy();
+  expect(rowExists('best-animal-fish')).toBeFalsy();
+});
+
+test('does not include results groups when they are excluded by the filter', async () => {
+  const store = Store.memoryStore();
+  const { electionDefinition } = electionMinimalExhaustiveSampleFixtures;
+  const { electionData } = electionDefinition;
+  const electionId = store.addElection({
+    electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+  });
+  store.setCurrentElectionId(electionId);
+
+  // grouping on voting method should include both precinct and absentee rows
+  const byVotingMethodStream = await generateResultsCsv({
+    store,
+    groupBy: { groupByVotingMethod: true },
+  });
+  const byVotingMethodFileContents = await streamToString(byVotingMethodStream);
+  const { rows: byVotingMethodRows } = parseCsv(byVotingMethodFileContents);
+  expect(
+    byVotingMethodRows.some((r) => r['Voting Method'] === 'Absentee')
+  ).toBeTruthy();
+  expect(
+    byVotingMethodRows.some((r) => r['Voting Method'] === 'Precinct')
+  ).toBeTruthy();
+
+  // but if we add on a filter that excludes absentee, absentee rows should not be included
+  const precinctStream = await generateResultsCsv({
+    store,
+    groupBy: { groupByVotingMethod: true },
+    filter: { votingMethods: ['precinct'] },
+  });
+  const precinctFileContests = await streamToString(precinctStream);
+  const { rows: precinctRows } = parseCsv(precinctFileContests);
+  expect(
+    precinctRows.some((r) => r['Voting Method'] === 'Absentee')
+  ).toBeFalsy();
+  expect(
+    precinctRows.some((r) => r['Voting Method'] === 'Precinct')
+  ).toBeTruthy();
+});

--- a/apps/admin/backend/src/exports/csv_results.ts
+++ b/apps/admin/backend/src/exports/csv_results.ts
@@ -7,6 +7,7 @@ import {
   ElectionDefinition,
   Id,
   AnyContest,
+  Election,
 } from '@votingworks/types';
 import { assert, assertDefined } from '@votingworks/basics';
 import {
@@ -21,134 +22,291 @@ import { ScannerBatch } from '../types';
 import { Store } from '../store';
 import { tabulateElectionResults } from '../tabulation/full_results';
 
-function generateHeaders({
+/**
+ * Possible metadata attributes that can be included in the CSV, in the order
+ * the columns will appear in the CSV.
+ */
+const METADATA_ATTRIBUTES = [
+  'precinct',
+  'party',
+  'ballotStyle',
+  'votingMethod',
+  'scanner',
+  'batch',
+] as const;
+
+type MetadataAttribute = typeof METADATA_ATTRIBUTES[number];
+
+const METADATA_ATTRIBUTE_COMPOUND_LABEL: Record<MetadataAttribute, string> = {
+  precinct: 'Precincts',
+  party: 'Parties',
+  ballotStyle: 'Ballot Styles',
+  votingMethod: 'Voting Methods',
+  scanner: 'Scanners',
+  batch: 'Batches',
+};
+
+// `all` is equivalent to having no filter for an attribute
+type Multiplicity = 'single' | 'multi' | 'all';
+
+/**
+ * Describes the metadata structure of the CSV. We distinguish between single
+ * multi attributes because "single" is the common and intuitive use case,
+ * alongside which we want to add additional related metadata. The "multi"
+ * attributes are only to ensure the CSV is self-documenting when there are
+ * filters selecting for multiple values.
+ */
+type MetadataStructure = {
+  [K in MetadataAttribute]: Multiplicity;
+};
+
+function determineMetadataStructure({
+  filter,
   groupBy,
-  isPrimaryElection,
 }: {
+  filter: Tabulation.Filter;
   groupBy: Tabulation.GroupBy;
-  isPrimaryElection: boolean;
+}): MetadataStructure {
+  const filterStructure: MetadataStructure = {
+    precinct: filter.precinctIds
+      ? filter.precinctIds.length > 1
+        ? 'multi'
+        : 'single'
+      : 'all',
+    ballotStyle: filter.ballotStyleIds
+      ? filter.ballotStyleIds.length > 1
+        ? 'multi'
+        : 'single'
+      : 'all',
+    party: filter.partyIds
+      ? filter.partyIds.length > 1
+        ? 'multi'
+        : 'single'
+      : 'all',
+    votingMethod: filter.votingMethods
+      ? filter.votingMethods.length > 1
+        ? 'multi'
+        : 'single'
+      : 'all',
+    scanner: filter.scannerIds
+      ? filter.scannerIds.length > 1
+        ? 'multi'
+        : 'single'
+      : 'all',
+    batch: filter.batchIds
+      ? filter.batchIds.length > 1
+        ? 'multi'
+        : 'single'
+      : 'all',
+  };
+
+  // If we're grouping by an attribute, it's always going to be a single.
+  // Otherwise, the multiplicity is the same as the filter.
+  return {
+    ballotStyle: groupBy.groupByBallotStyle
+      ? 'single'
+      : filterStructure.ballotStyle,
+    party: groupBy.groupByParty ? 'single' : filterStructure.party,
+    precinct: groupBy.groupByPrecinct ? 'single' : filterStructure.precinct,
+    scanner: groupBy.groupByScanner ? 'single' : filterStructure.scanner,
+    batch: groupBy.groupByBatch ? 'single' : filterStructure.batch,
+    votingMethod: groupBy.groupByVotingMethod
+      ? 'single'
+      : filterStructure.votingMethod,
+  };
+}
+
+function generateHeaders({
+  election,
+  metadataStructure,
+}: {
+  election: Election;
+  metadataStructure: MetadataStructure;
 }): string[] {
   const headers = [];
 
-  if (groupBy.groupByVotingMethod) {
-    headers.push('Voting Method');
-  }
+  // Simple Attributes
+  // -----------------
 
-  if (groupBy.groupByPrecinct) {
+  if (metadataStructure.precinct === 'single') {
     headers.push('Precinct');
     headers.push('Precinct ID');
   }
 
   if (
-    isPrimaryElection &&
-    (groupBy.groupByParty || groupBy.groupByBallotStyle)
+    election.type === 'primary' &&
+    (metadataStructure.party === 'single' ||
+      metadataStructure.ballotStyle === 'single')
   ) {
     headers.push('Party');
     headers.push('Party ID');
   }
 
-  if (groupBy.groupByBallotStyle) {
+  if (metadataStructure.ballotStyle === 'single') {
     headers.push('Ballot Style ID');
   }
 
-  if (groupBy.groupByScanner || groupBy.groupByBatch) {
+  if (metadataStructure.votingMethod === 'single') {
+    headers.push('Voting Method');
+  }
+
+  if (
+    metadataStructure.scanner === 'single' ||
+    metadataStructure.batch === 'single'
+  ) {
     headers.push('Scanner ID');
   }
 
-  if (groupBy.groupByBatch) {
+  if (metadataStructure.batch === 'single') {
     headers.push('Batch ID');
   }
+
+  // Compound Attributes
+  // -----------------
+
+  for (const attribute of METADATA_ATTRIBUTES) {
+    if (metadataStructure[attribute] === 'multi') {
+      headers.push(`Included ${METADATA_ATTRIBUTE_COMPOUND_LABEL[attribute]}`);
+    }
+  }
+
+  // Contest, Selection, and Tally
+  // -----------------------------
 
   headers.push('Contest', 'Contest ID', 'Selection', 'Selection ID', 'Votes');
 
   return headers;
 }
 
-const VOTING_METHOD_LABEL: Record<Tabulation.VotingMethod, string> = {
-  absentee: 'Absentee',
-  precinct: 'Precinct',
-  provisional: 'Provisional',
-};
+function assertOnlyElement<T>(array?: T[]): T {
+  assert(array);
+  assert(array.length === 1);
+  return assertDefined(array[0]);
+}
 
 type BatchLookup = Record<string, ScannerBatch>;
 
 function buildCsvRow({
-  groupBy,
-  groupSpecifier,
+  filter,
+  metadataStructure,
   electionDefinition,
-  isPrimaryElection,
   batchLookup,
   contest,
   selection,
   selectionId,
   votes,
 }: {
-  groupBy: Tabulation.GroupBy;
-  groupSpecifier: Tabulation.GroupSpecifier;
+  filter: Tabulation.Filter;
+  metadataStructure: MetadataStructure;
   electionDefinition: ElectionDefinition;
-  isPrimaryElection: boolean;
   batchLookup: BatchLookup;
   contest: Contest;
   selection: string;
   selectionId: string;
   votes: number;
 }): string {
+  const { election } = electionDefinition;
   const values: string[] = [];
 
-  if (groupBy.groupByVotingMethod) {
-    assert(groupSpecifier.votingMethod !== undefined);
-    values.push(VOTING_METHOD_LABEL[groupSpecifier.votingMethod]);
-  }
+  // Single Attributes
+  // -----------------
 
-  if (groupBy.groupByPrecinct) {
-    assert(groupSpecifier.precinctId !== undefined);
-    values.push(
-      getPrecinctById(electionDefinition, groupSpecifier.precinctId).name
-    );
-    values.push(groupSpecifier.precinctId);
+  if (metadataStructure.precinct === 'single') {
+    const precinctId = assertOnlyElement(filter.precinctIds);
+    values.push(getPrecinctById(electionDefinition, precinctId).name);
+    values.push(precinctId);
   }
 
   if (
-    isPrimaryElection &&
-    (groupBy.groupByParty || groupBy.groupByBallotStyle)
+    election.type === 'primary' &&
+    (metadataStructure.party === 'single' ||
+      metadataStructure.ballotStyle === 'single')
   ) {
     const partyId = (() => {
-      if (groupBy.groupByParty) {
-        return assertDefined(groupSpecifier.partyId);
+      if (metadataStructure.party === 'single') {
+        return assertOnlyElement(filter.partyIds);
       }
 
+      const ballotStyleId = assertOnlyElement(filter.ballotStyleIds);
       return assertDefined(
-        getBallotStyleById(
-          electionDefinition,
-          assertDefined(groupSpecifier.ballotStyleId)
-        ).partyId
+        getBallotStyleById(electionDefinition, ballotStyleId).partyId
       );
     })();
 
-    values.push(assertDefined(getPartyById(electionDefinition, partyId).name));
+    values.push(getPartyById(electionDefinition, partyId).name);
     values.push(partyId);
   }
 
-  if (groupBy.groupByBallotStyle) {
-    assert(groupSpecifier.ballotStyleId !== undefined);
-    values.push(groupSpecifier.ballotStyleId);
+  if (metadataStructure.ballotStyle === 'single') {
+    values.push(assertOnlyElement(filter.ballotStyleIds));
   }
 
-  if (groupBy.groupByScanner || groupBy.groupByBatch) {
+  if (metadataStructure.votingMethod === 'single') {
+    values.push(
+      Tabulation.VOTING_METHOD_LABELS[assertOnlyElement(filter.votingMethods)]
+    );
+  }
+
+  if (
+    metadataStructure.scanner === 'single' ||
+    metadataStructure.batch === 'single'
+  ) {
     const scannerId = (() => {
-      if (groupBy.groupByScanner) {
-        return assertDefined(groupSpecifier.scannerId);
+      if (metadataStructure.scanner === 'single') {
+        return assertOnlyElement(filter.scannerIds);
       }
 
-      return assertDefined(batchLookup[assertDefined(groupSpecifier.batchId)])
+      return assertDefined(batchLookup[assertOnlyElement(filter.batchIds)])
         .scannerId;
     })();
     values.push(scannerId);
   }
 
-  if (groupBy.groupByBatch) {
-    values.push(assertDefined(groupSpecifier.batchId));
+  if (metadataStructure.batch === 'single') {
+    values.push(assertOnlyElement(filter.batchIds));
   }
+
+  // Multi Attributes
+  // -------------------
+
+  if (metadataStructure.precinct === 'multi') {
+    values.push(
+      assertDefined(filter.precinctIds)
+        .map((id) => getPrecinctById(electionDefinition, id).name)
+        .join(',')
+    );
+  }
+
+  if (metadataStructure.party === 'multi') {
+    values.push(
+      assertDefined(filter.partyIds)
+        .map((id) => getPartyById(electionDefinition, id).name)
+        .join(',')
+    );
+  }
+
+  if (metadataStructure.ballotStyle === 'multi') {
+    values.push(assertDefined(filter.ballotStyleIds).join(','));
+  }
+
+  if (metadataStructure.votingMethod === 'multi') {
+    values.push(
+      assertDefined(filter.votingMethods)
+        .map((method) => Tabulation.VOTING_METHOD_LABELS[method])
+        .join(',')
+    );
+  }
+
+  if (metadataStructure.scanner === 'multi') {
+    values.push(assertDefined(filter.scannerIds).join(','));
+  }
+
+  if (metadataStructure.batch === 'multi') {
+    values.push(assertDefined(filter.batchIds).join(','));
+  }
+
+  // Contest, Selection, and Tally
+  // -----------------------------
 
   values.push(
     contest.title,
@@ -173,32 +331,31 @@ function generateBatchLookup(store: Store, electionId: Id): BatchLookup {
 function* generateRows({
   electionId,
   electionDefinition,
-  groupBy,
+  overallExportFilter,
   resultGroups,
+  metadataStructure,
   store,
-  overallReportFilter,
 }: {
   electionId: Id;
   electionDefinition: ElectionDefinition;
-  groupBy: Tabulation.GroupBy;
+  overallExportFilter: Tabulation.Filter;
   resultGroups: Tabulation.ElectionResultsGroupList;
+  metadataStructure: MetadataStructure;
   store: Store;
-  overallReportFilter: Tabulation.Filter;
 }): Generator<string> {
   const { election } = electionDefinition;
-  const isPrimaryElection = election.type === 'primary';
   const writeInCandidates = store.getWriteInCandidates({ electionId });
   const batchLookup = generateBatchLookup(store, assertDefined(electionId));
 
   for (const resultsGroup of resultGroups) {
-    const effectiveFilter = combineGroupSpecifierAndFilter(
+    const groupFilter = combineGroupSpecifierAndFilter(
       resultsGroup,
-      overallReportFilter
+      overallExportFilter
     );
     const contestIds = new Set(
       store.getFilteredContests({
         electionId,
-        filter: effectiveFilter,
+        filter: groupFilter,
       })
     );
     const includedContests: AnyContest[] = [];
@@ -223,10 +380,9 @@ function* generateRows({
           /* c8 ignore next -- trivial fallthrough zero branch */
           const votes = contestResults.tallies[candidate.id]?.tally ?? 0;
           yield buildCsvRow({
-            groupBy,
-            groupSpecifier: resultsGroup,
+            metadataStructure,
+            filter: groupFilter,
             electionDefinition,
-            isPrimaryElection,
             batchLookup,
             contest,
             selection: candidate.name,
@@ -240,10 +396,9 @@ function* generateRows({
           const votes = contestResults.tallies[writeInCandidate.id]?.tally ?? 0;
           if (votes) {
             yield buildCsvRow({
-              groupBy,
-              groupSpecifier: resultsGroup,
+              metadataStructure,
+              filter: groupFilter,
               electionDefinition,
-              isPrimaryElection,
               batchLookup,
               contest,
               selection: writeInCandidate.name,
@@ -261,10 +416,9 @@ function* generateRows({
 
           if (votes) {
             yield buildCsvRow({
-              groupBy,
-              groupSpecifier: resultsGroup,
+              metadataStructure,
+              filter: groupFilter,
               electionDefinition,
-              isPrimaryElection,
               batchLookup,
               contest,
               selection: contestWriteInCandidate.name,
@@ -276,10 +430,9 @@ function* generateRows({
       } else if (contest.type === 'yesno') {
         assert(contestResults.contestType === 'yesno');
         yield buildCsvRow({
-          groupBy,
-          groupSpecifier: resultsGroup,
+          metadataStructure,
+          filter: groupFilter,
           electionDefinition,
-          isPrimaryElection,
           batchLookup,
           contest,
           selection: contest.yesOption.label,
@@ -287,10 +440,9 @@ function* generateRows({
           votes: contestResults.yesTally,
         });
         yield buildCsvRow({
-          groupBy,
-          groupSpecifier: resultsGroup,
+          metadataStructure,
+          filter: groupFilter,
           electionDefinition,
-          isPrimaryElection,
           batchLookup,
           contest,
           selection: contest.noOption.label,
@@ -300,10 +452,9 @@ function* generateRows({
       }
 
       yield buildCsvRow({
-        groupBy,
-        groupSpecifier: resultsGroup,
+        metadataStructure,
+        filter: groupFilter,
         electionDefinition,
-        isPrimaryElection,
         batchLookup,
         contest,
         selection: 'Overvotes',
@@ -312,10 +463,9 @@ function* generateRows({
       });
 
       yield buildCsvRow({
-        groupBy,
-        groupSpecifier: resultsGroup,
+        metadataStructure,
+        filter: groupFilter,
         electionDefinition,
-        isPrimaryElection,
         batchLookup,
         contest,
         selection: 'Undervotes',
@@ -328,18 +478,9 @@ function* generateRows({
 
 /**
  * Converts a tally for an election to a CSV file (represented as a string) of tally
- * results. Results are split according to the `groupBy` parameter. For each
- * additional split, one or more split metadata columns are added to each row.
- *  - `groupByBallotStyle` adds "Ballot Style ID" and, if a primary, "Party" and "Party ID"
- *  - `groupByParty` adds "Party" and "Party ID", if a primary
- *  - `groupByScanner` adds "Scanner ID"
- *  - `groupByBatch` adds "Batch ID" and "Scanner ID"
- *  - `groupByPrecinct` adds "Precinct" and "Precinct ID"
- *  - `groupByVotingMethod` adds "Voting Method"
- *
- * Notice that we are adding not only the metadata for the specified group but
- * metadata from inferable groups too. E.g., if we group by batch then we know
- * the scanner ID of each group.
+ * results. Results are filtered by the `filter` parameter and grouped according to
+ * the `groupBy` parameter. Each row is labelled with metadata according to its group
+ * and the overall export's filter.
  *
  * Returns the file as a `NodeJS.ReadableStream` emitting line by line.
  */
@@ -357,10 +498,15 @@ export async function generateResultsCsv({
   const { electionDefinition } = assertDefined(store.getElection(electionId));
   const { election } = electionDefinition;
 
+  const metadataStructure = determineMetadataStructure({
+    filter,
+    groupBy,
+  });
+
   const headerRow = stringify([
     generateHeaders({
-      groupBy,
-      isPrimaryElection: election.type === 'primary',
+      election,
+      metadataStructure,
     }),
   ]);
 
@@ -381,10 +527,10 @@ export async function generateResultsCsv({
     for (const dataRow of generateRows({
       electionDefinition,
       electionId: assertDefined(electionId),
-      groupBy,
+      overallExportFilter: filter,
       resultGroups,
+      metadataStructure,
       store,
-      overallReportFilter: filter,
     })) {
       yield dataRow;
     }

--- a/apps/admin/backend/src/exports/csv_results.ts
+++ b/apps/admin/backend/src/exports/csv_results.ts
@@ -37,7 +37,7 @@ const METADATA_ATTRIBUTES = [
 
 type MetadataAttribute = typeof METADATA_ATTRIBUTES[number];
 
-const METADATA_ATTRIBUTE_COMPOUND_LABEL: Record<MetadataAttribute, string> = {
+const METADATA_ATTRIBUTE_MULTI_LABEL: Record<MetadataAttribute, string> = {
   precinct: 'Precincts',
   party: 'Parties',
   ballotStyle: 'Ballot Styles',
@@ -45,6 +45,8 @@ const METADATA_ATTRIBUTE_COMPOUND_LABEL: Record<MetadataAttribute, string> = {
   scanner: 'Scanners',
   batch: 'Batches',
 };
+
+const MULTI_VALUE_SEPARATOR = ', ';
 
 // `all` is equivalent to having no filter for an attribute
 type Multiplicity = 'single' | 'multi' | 'all';
@@ -166,7 +168,7 @@ function generateHeaders({
 
   for (const attribute of METADATA_ATTRIBUTES) {
     if (metadataStructure[attribute] === 'multi') {
-      headers.push(`Included ${METADATA_ATTRIBUTE_COMPOUND_LABEL[attribute]}`);
+      headers.push(`Included ${METADATA_ATTRIBUTE_MULTI_LABEL[attribute]}`);
     }
   }
 
@@ -273,7 +275,7 @@ function buildCsvRow({
     values.push(
       assertDefined(filter.precinctIds)
         .map((id) => getPrecinctById(electionDefinition, id).name)
-        .join(',')
+        .join(MULTI_VALUE_SEPARATOR)
     );
   }
 
@@ -281,28 +283,30 @@ function buildCsvRow({
     values.push(
       assertDefined(filter.partyIds)
         .map((id) => getPartyById(electionDefinition, id).name)
-        .join(',')
+        .join(MULTI_VALUE_SEPARATOR)
     );
   }
 
   if (metadataStructure.ballotStyle === 'multi') {
-    values.push(assertDefined(filter.ballotStyleIds).join(','));
+    values.push(
+      assertDefined(filter.ballotStyleIds).join(MULTI_VALUE_SEPARATOR)
+    );
   }
 
   if (metadataStructure.votingMethod === 'multi') {
     values.push(
       assertDefined(filter.votingMethods)
         .map((method) => Tabulation.VOTING_METHOD_LABELS[method])
-        .join(',')
+        .join(MULTI_VALUE_SEPARATOR)
     );
   }
 
   if (metadataStructure.scanner === 'multi') {
-    values.push(assertDefined(filter.scannerIds).join(','));
+    values.push(assertDefined(filter.scannerIds).join(MULTI_VALUE_SEPARATOR));
   }
 
   if (metadataStructure.batch === 'multi') {
-    values.push(assertDefined(filter.batchIds).join(','));
+    values.push(assertDefined(filter.batchIds).join(MULTI_VALUE_SEPARATOR));
   }
 
   // Contest, Selection, and Tally

--- a/apps/admin/backend/test/csv.ts
+++ b/apps/admin/backend/test/csv.ts
@@ -1,0 +1,21 @@
+// eslint-disable-next-line import/no-unresolved
+import { parse } from 'csv-parse/sync';
+
+export function parseCsv(fileContents: string): {
+  headers: string[];
+  rows: Array<{ [header: string]: string }>;
+} {
+  return {
+    headers: parse(fileContents, { to: 1 })[0],
+    rows: parse(fileContents, { columns: true }),
+  };
+}
+
+export function streamToString(stream: NodeJS.ReadableStream): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: string[] = [];
+    stream.on('data', (chunk: string) => chunks.push(chunk));
+    stream.on('end', () => resolve(chunks.join('')));
+    stream.on('error', reject);
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,6 +250,9 @@ importers:
       '@votingworks/test-utils':
         specifier: workspace:*
         version: link:../../../libs/test-utils
+      csv-parse:
+        specifier: ^5.5.0
+        version: 5.5.0
       esbuild:
         specifier: ^0.14.29
         version: 0.14.42
@@ -14645,6 +14648,10 @@ packages:
 
   /csstype@3.1.2:
     resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
+
+  /csv-parse@5.5.0:
+    resolution: {integrity: sha512-RxruSK3M4XgzcD7Trm2wEN+SJ26ChIb903+IWxNOcB5q4jT2Cs+hFr6QP39J05EohshRFEvyzEBoZ/466S2sbw==}
+    dev: true
 
   /csv-stringify@6.4.0:
     resolution: {integrity: sha512-HQsw0QXiN5fdlO+R8/JzCZnR3Fqp8E87YVnhHlaPtNGJjt6ffbV0LpOkieIb1x6V1+xt878IYq77SpXHWAqKkA==}


### PR DESCRIPTION
_probably review by commit_

## Overview

Please read [this Slack conversation](https://votingworks.slack.com/archives/CEL6D3GAD/p1693945053137789) for full context. In short, we want all filters that are applied to a report to be apparent in the `.csv` export. There's an alternate approach I could have chosen (see slack convo) and I'm absolutely open to pushback if you think the alternate is better, but this way means less change for the final exports.

## Testing Plan

Alongside the change to `.csv` files, I basically rewrote all the testing for results `.csv` exports. For the better! More coverage.
