### PR TITLE
Tally Report Builder - Scanner + Batch Dimensions

### DIFF
--- a/apps/admin/backend/schema.sql
+++ b/apps/admin/backend/schema.sql
@@ -125,7 +125,7 @@ create table cvrs (
   created_at timestamp not null default current_timestamp,
   foreign key (election_id) references elections(id)
     on delete cascade,
-  foreign key (batch_id) references scanner_batches(id)
+  foreign key (election_id, batch_id) references scanner_batches(election_id, id)
 );
 
 create index idx_cvrs_election_id on cvrs(election_id);
@@ -136,7 +136,7 @@ create table scanner_batches (
   label text not null,
   scanner_id text not null,
   election_id varchar(36) not null,
-  primary key (id),
+  primary key (election_id, id),
   foreign key (election_id) references elections(id)
     on delete cascade
 );

--- a/apps/admin/frontend/src/components/reporting/filter_editor.test.tsx
+++ b/apps/admin/frontend/src/components/reporting/filter_editor.test.tsx
@@ -3,15 +3,29 @@ import userEvent from '@testing-library/user-event';
 import { renderInAppContext } from '../../../test/render_in_app_context';
 import { FilterEditor } from './filter_editor';
 import { screen, within } from '../../../test/react_testing_library';
+import { ApiMock, createApiMock } from '../../../test/helpers/api_mock';
 
-test('FilterEditor', () => {
+let apiMock: ApiMock;
+
+beforeEach(() => {
+  apiMock = createApiMock();
+});
+
+afterEach(() => {
+  apiMock.assertComplete();
+});
+
+test('general flow + precinct, voting method, ballot style selection', () => {
   const { election } = electionMinimalExhaustiveSampleDefinition;
   const onChange = jest.fn();
 
-  renderInAppContext(<FilterEditor election={election} onChange={onChange} />);
+  apiMock.expectGetScannerBatches([]);
+  renderInAppContext(<FilterEditor election={election} onChange={onChange} />, {
+    apiMock,
+  });
 
   // Add filter row, precinct
-  userEvent.click(screen.getByText('Add Filter'));
+  userEvent.click(screen.getButton('Add Filter'));
   expect(onChange).not.toHaveBeenCalled();
   userEvent.click(screen.getByLabelText('Select New Filter Type'));
   userEvent.click(screen.getByText('Precinct'));
@@ -80,13 +94,69 @@ test('FilterEditor', () => {
   });
 });
 
-test('FilterEditor - cancel adding filter', () => {
+test('scanner + batch selection', async () => {
   const { election } = electionMinimalExhaustiveSampleDefinition;
   const onChange = jest.fn();
 
-  renderInAppContext(<FilterEditor election={election} onChange={onChange} />);
+  apiMock.expectGetScannerBatches([
+    {
+      batchId: '12345678-0000-0000-0000-000000000000',
+      scannerId: 'scanner-1',
+      label: 'Batch 1',
+      electionId: 'id',
+    },
+    {
+      batchId: '23456789-0000-0000-0000-000000000000',
+      scannerId: 'scanner-1',
+      label: 'Batch 2',
+      electionId: 'id',
+    },
+    {
+      batchId: '34567890-0000-0000-0000-000000000000',
+      scannerId: 'scanner-2',
+      label: 'Batch 3',
+      electionId: 'id',
+    },
+  ]);
+  renderInAppContext(<FilterEditor election={election} onChange={onChange} />, {
+    apiMock,
+  });
 
-  userEvent.click(screen.getByText('Add Filter'));
+  // add scanner filter
+  userEvent.click(screen.getButton('Add Filter'));
+  userEvent.click(screen.getByLabelText('Select New Filter Type'));
+  userEvent.click(screen.getByText('Scanner'));
+  expect(onChange).toHaveBeenNthCalledWith(1, { scannerIds: [] });
+  userEvent.click(screen.getByLabelText('Select Filter Values'));
+  await screen.findByText('scanner-1'); // list populates after query completes
+  screen.getByText('scanner-2');
+  userEvent.click(screen.getByText('scanner-1'));
+  expect(onChange).toHaveBeenNthCalledWith(2, { scannerIds: ['scanner-1'] });
+
+  // switch to batch filter
+  userEvent.click(screen.getByLabelText('Edit Filter Type'));
+  userEvent.click(screen.getByText('Batch'));
+  expect(onChange).toHaveBeenNthCalledWith(3, { batchIds: [] });
+  userEvent.click(screen.getByLabelText('Select Filter Values'));
+  screen.getByText('scanner-1 • 12345678');
+  screen.getByText('scanner-1 • 23456789');
+  screen.getByText('scanner-2 • 34567890');
+  userEvent.click(screen.getByText('scanner-1 • 12345678'));
+  expect(onChange).toHaveBeenNthCalledWith(4, {
+    batchIds: ['12345678-0000-0000-0000-000000000000'],
+  });
+});
+
+test('can cancel adding a filter', () => {
+  const { election } = electionMinimalExhaustiveSampleDefinition;
+  const onChange = jest.fn();
+
+  apiMock.expectGetScannerBatches([]);
+  renderInAppContext(<FilterEditor election={election} onChange={onChange} />, {
+    apiMock,
+  });
+
+  userEvent.click(screen.getButton('Add Filter'));
   userEvent.click(screen.getByLabelText('Cancel Add Filter'));
   screen.getByText('Add Filter');
   expect(onChange).not.toHaveBeenCalled();

--- a/apps/admin/frontend/src/components/reporting/filter_editor.tsx
+++ b/apps/admin/frontend/src/components/reporting/filter_editor.tsx
@@ -1,8 +1,15 @@
-import { assert, throwIllegalValue, typedAs } from '@votingworks/basics';
+import {
+  assert,
+  throwIllegalValue,
+  typedAs,
+  unique,
+} from '@votingworks/basics';
 import { Election, Tabulation } from '@votingworks/types';
 import { useState } from 'react';
 import styled from 'styled-components';
 import { SearchSelect, SelectOption, Icons, Button } from '@votingworks/ui';
+import type { ScannerBatch } from '@votingworks/admin-backend';
+import { getScannerBatches } from '../../api';
 
 export interface FilterEditorProps {
   onChange: (filter: Tabulation.Filter) => void;
@@ -61,11 +68,17 @@ const RemoveButton = styled.button`
   }
 `;
 
-const FILTER_TYPES = ['precinct', 'voting-method', 'ballot-style'] as const;
+const FILTER_TYPES = [
+  'precinct',
+  'voting-method',
+  'ballot-style',
+  'scanner',
+  'batch',
+] as const;
 type FilterType = typeof FILTER_TYPES[number];
 
 function getAllowedFilterTypes(): FilterType[] {
-  return ['precinct', 'voting-method', 'ballot-style'];
+  return ['precinct', 'voting-method', 'ballot-style', 'scanner', 'batch'];
 }
 
 interface FilterRow {
@@ -79,6 +92,8 @@ const FILTER_TYPE_LABELS: Record<FilterType, string> = {
   precinct: 'Precinct',
   'voting-method': 'Voting Method',
   'ballot-style': 'Ballot Style',
+  scanner: 'Scanner',
+  batch: 'Batch',
 };
 
 function getFilterTypeOption(filterType: FilterType): SelectOption<FilterType> {
@@ -88,10 +103,15 @@ function getFilterTypeOption(filterType: FilterType): SelectOption<FilterType> {
   };
 }
 
-function generateOptionsForFilter(
-  filterType: FilterType,
-  election: Election
-): SelectOption[] {
+function generateOptionsForFilter({
+  filterType,
+  election,
+  scannerBatches,
+}: {
+  filterType: FilterType;
+  election: Election;
+  scannerBatches: ScannerBatch[];
+}): SelectOption[] {
   switch (filterType) {
     case 'precinct':
       return election.precincts.map((precinct) => ({
@@ -114,6 +134,18 @@ function generateOptionsForFilter(
           label: 'Absentee',
         },
       ]);
+    case 'scanner':
+      return unique(scannerBatches.map((sb) => sb.scannerId)).map(
+        (scannerId) => ({
+          value: scannerId,
+          label: scannerId,
+        })
+      );
+    case 'batch':
+      return scannerBatches.map((sb) => ({
+        value: sb.batchId,
+        label: `${sb.scannerId} • ${sb.batchId.slice(0, 8)}`,
+      }));
     /* istanbul ignore next - compile-time check for completeness */
     default:
       throwIllegalValue(filterType);
@@ -140,6 +172,12 @@ function convertFilterRowsToTabulationFilter(
       case 'ballot-style':
         tabulationFilter.ballotStyleIds = filterValues;
         break;
+      case 'scanner':
+        tabulationFilter.scannerIds = filterValues;
+        break;
+      case 'batch':
+        tabulationFilter.batchIds = filterValues;
+        break;
       /* istanbul ignore next - compile-time check for completeness */
       default:
         throwIllegalValue(filterType);
@@ -156,6 +194,9 @@ export function FilterEditor({
   const [rows, setRows] = useState<FilterRows>([]);
   const [nextRowId, setNextRowId] = useState(0);
   const [isAddingRow, setIsAddingRow] = useState(false);
+
+  const scannerBatchesQuery = getScannerBatches.useQuery();
+  const scannerBatches = scannerBatchesQuery.data ?? [];
 
   function onUpdatedRows(updatedRows: FilterRows) {
     setRows(updatedRows);
@@ -230,7 +271,11 @@ export function FilterEditor({
                 isMulti
                 isSearchable
                 key={filterType}
-                options={generateOptionsForFilter(filterType, election)}
+                options={generateOptionsForFilter({
+                  filterType,
+                  election,
+                  scannerBatches,
+                })}
                 value={row.filterValues}
                 onChange={(filterValues) => {
                   updateRowFilterValues(rowId, filterValues);

--- a/apps/admin/frontend/src/components/reporting/group_by_editor.test.tsx
+++ b/apps/admin/frontend/src/components/reporting/group_by_editor.test.tsx
@@ -18,6 +18,8 @@ test('GroupByEditor', () => {
     ['Precinct', true],
     ['Voting Method', false],
     ['Ballot Style', false],
+    ['Scanner', false],
+    ['Batch', false],
   ];
 
   for (const [label, checked] of items) {

--- a/apps/admin/frontend/src/components/reporting/group_by_editor.tsx
+++ b/apps/admin/frontend/src/components/reporting/group_by_editor.tsx
@@ -46,6 +46,7 @@ const Item = styled.button`
   border: none;
   font-weight: 300;
   color: inherit;
+  -webkit-tap-highlight-color: transparent;
 `;
 
 const ItemLabel = styled(Font)`

--- a/apps/admin/frontend/src/components/reporting/group_by_editor.tsx
+++ b/apps/admin/frontend/src/components/reporting/group_by_editor.tsx
@@ -5,7 +5,13 @@ import { Checkbox, Font } from '@votingworks/ui';
 type Grouping = keyof Tabulation.GroupBy;
 
 function getAllowedGroupings(): Grouping[] {
-  return ['groupByPrecinct', 'groupByVotingMethod', 'groupByBallotStyle'];
+  return [
+    'groupByPrecinct',
+    'groupByVotingMethod',
+    'groupByBallotStyle',
+    'groupByScanner',
+    'groupByBatch',
+  ];
 }
 
 const GROUPING_LABEL: Record<Grouping, string> = {
@@ -24,7 +30,7 @@ export interface GroupByEditorProps {
 
 const Container = styled.div`
   display: grid;
-  grid-template-columns: repeat(4, min-content);
+  grid-template-columns: repeat(5, min-content);
   gap: 0.75rem;
 `;
 

--- a/apps/admin/frontend/src/components/reporting/tally_report_viewer.test.tsx
+++ b/apps/admin/frontend/src/components/reporting/tally_report_viewer.test.tsx
@@ -25,6 +25,7 @@ let apiMock: ApiMock;
 beforeEach(() => {
   apiMock = createApiMock();
   apiMock.expectGetCastVoteRecordFileMode('official');
+  apiMock.expectGetScannerBatches([]);
 });
 
 afterEach(() => {
@@ -65,14 +66,13 @@ test('autoPreview loads preview automatically', async () => {
     { apiMock, electionDefinition }
   );
 
-  expect(screen.getButton('Print Report')).not.toBeDisabled();
   await screen.findByText(
     'Unofficial Lincoln Municipal General Election Tally Report'
   );
   expect(screen.getByTestId('total-ballot-count')).toHaveTextContent('10');
 });
 
-test('autoPreview = false does not load preview automatically', () => {
+test('autoPreview = false does not load preview automatically', async () => {
   const { electionDefinition } = electionFamousNames2021Fixtures;
 
   renderInAppContext(
@@ -85,8 +85,7 @@ test('autoPreview = false does not load preview automatically', () => {
     { apiMock, electionDefinition }
   );
 
-  expect(screen.getButton('Print Report')).not.toBeDisabled();
-  screen.getButton('Load Preview');
+  await screen.findButton('Load Preview');
 });
 
 test('print before loading preview', async () => {
@@ -116,7 +115,7 @@ test('print before loading preview', async () => {
     { apiMock, electionDefinition }
   );
 
-  screen.getButton('Load Preview');
+  await screen.findButton('Load Preview');
   const { resolve: resolvePrint } = deferNextPrint();
   userEvent.click(screen.getButton('Print Report'));
   const modal = await screen.findByRole('alertdialog');
@@ -218,7 +217,7 @@ test('print while preview is loading', async () => {
     { apiMock, electionDefinition }
   );
 
-  userEvent.click(screen.getButton('Load Preview'));
+  userEvent.click(await screen.findButton('Load Preview'));
   await screen.findByText('Generating Report');
   expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
   const { resolve: resolvePrint } = deferNextPrint();
@@ -361,6 +360,7 @@ test('exporting report PDF', async () => {
     { apiMock, electionDefinition, usbDrive: mockUsbDrive('mounted') }
   );
 
+  await screen.findButton('Load Preview');
   userEvent.click(screen.getButton('Export Report PDF'));
   const modal = await screen.findByRole('alertdialog');
   within(modal).getByText('Save Unofficial Tally Report');

--- a/apps/admin/frontend/src/screens/tally_report_builder.test.tsx
+++ b/apps/admin/frontend/src/screens/tally_report_builder.test.tsx
@@ -23,13 +23,14 @@ test('happy path', async () => {
   const { election } = electionDefinition;
 
   apiMock.expectGetCastVoteRecordFileMode('test');
+  apiMock.expectGetScannerBatches([]);
   renderInAppContext(<TallyReportBuilder />, {
     electionDefinition,
     apiMock,
   });
 
-  expect(screen.getButton('Print Report')).toBeDisabled();
   expect(screen.queryByText('Load Preview')).not.toBeInTheDocument();
+  expect(screen.getButton('Print Report')).toBeDisabled();
 
   // Add Filter
   userEvent.click(screen.getByText('Add Filter'));
@@ -41,8 +42,8 @@ test('happy path', async () => {
   userEvent.click(screen.getByLabelText('Select Filter Values'));
   userEvent.click(screen.getByText('Absentee'));
 
+  await screen.findButton('Load Preview');
   expect(screen.getButton('Print Report')).not.toBeDisabled();
-  screen.getButton('Load Preview');
 
   // Add Group By
   userEvent.click(screen.getButton('Report By Precinct'));

--- a/libs/ui/src/reports/custom_filter_summary.test.tsx
+++ b/libs/ui/src/reports/custom_filter_summary.test.tsx
@@ -41,6 +41,32 @@ test('voting method filter', () => {
   );
 });
 
+test('scanner filter', () => {
+  const { electionDefinition } = electionFamousNames2021Fixtures;
+  render(
+    <CustomFilterSummary
+      electionDefinition={electionDefinition}
+      filter={{ scannerIds: ['VX-00-000'] }}
+    />
+  );
+  expect(screen.getByTestId('custom-filter-summary').textContent).toEqual(
+    'Scanner: VX-00-000'
+  );
+});
+
+test('batch filter', () => {
+  const { electionDefinition } = electionFamousNames2021Fixtures;
+  render(
+    <CustomFilterSummary
+      electionDefinition={electionDefinition}
+      filter={{ batchIds: ['12345678-0000-0000-0000-000000000000'] }}
+    />
+  );
+  expect(screen.getByTestId('custom-filter-summary').textContent).toEqual(
+    'Batch: 12345678'
+  );
+});
+
 test('complex filter', () => {
   const { electionDefinition } = electionFamousNames2021Fixtures;
   render(

--- a/libs/ui/src/reports/custom_filter_summary.tsx
+++ b/libs/ui/src/reports/custom_filter_summary.tsx
@@ -49,9 +49,25 @@ export function CustomFilterSummary({
       {filter.ballotStyleIds && (
         <FilterDisplayRow>
           <Font weight="semiBold">
-            {pluralize('Ballot Styles', filter.ballotStyleIds.length)}:
+            {pluralize('Ballot Style', filter.ballotStyleIds.length)}:
           </Font>{' '}
           {filter.ballotStyleIds.join(', ')}
+        </FilterDisplayRow>
+      )}
+      {filter.scannerIds && (
+        <FilterDisplayRow>
+          <Font weight="semiBold">
+            {pluralize('Scanner', filter.scannerIds.length)}:
+          </Font>{' '}
+          {filter.scannerIds.join(', ')}
+        </FilterDisplayRow>
+      )}
+      {filter.batchIds && (
+        <FilterDisplayRow>
+          <Font weight="semiBold">
+            {pluralize('Batch', filter.batchIds.length)}:
+          </Font>{' '}
+          {filter.batchIds.map((id) => id.slice(0, 8)).join(', ')}
         </FilterDisplayRow>
       )}
     </div>


### PR DESCRIPTION
## Overview

Adds "Scanner" and "Batch" to the filtering and grouping options of the report builder.

## Demo Video or Screenshot

https://github.com/votingworks/vxsuite/assets/37960853/612b61bf-10f1-4fe7-bae9-242268860cbe

## Checklist

- [ ] ~~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
