### PR TITLE
admin: Ballot Count Report Builder Backend

### DIFF
--- a/apps/admin/backend/src/app.results.test.ts
+++ b/apps/admin/backend/src/app.results.test.ts
@@ -66,40 +66,23 @@ test('card counts', async () => {
 
   expect(
     await apiClient.getCardCounts({
-      groupBy: { groupByPrecinct: true, groupByBallotStyle: true },
+      filter: { ballotStyleIds: ['1M'] },
+      groupBy: { groupByPrecinct: true },
     })
-  ).toMatchObject(
-    expect.arrayContaining([
-      {
-        ballotStyleId: '1M',
-        precinctId: 'precinct-1',
-        bmd: 28,
-        hmpb: [],
-        manual: 10,
-      },
-      {
-        ballotStyleId: '2F',
-        precinctId: 'precinct-1',
-        bmd: 28,
-        hmpb: [],
-        manual: 0,
-      },
-      {
-        ballotStyleId: '1M',
-        precinctId: 'precinct-2',
-        bmd: 28,
-        hmpb: [],
-        manual: 0,
-      },
-      {
-        ballotStyleId: '2F',
-        precinctId: 'precinct-2',
-        bmd: 28,
-        hmpb: [],
-        manual: 0,
-      },
-    ])
-  );
+  ).toEqual([
+    {
+      precinctId: 'precinct-1',
+      bmd: 28,
+      hmpb: [],
+      manual: 10,
+    },
+    {
+      precinctId: 'precinct-2',
+      bmd: 28,
+      hmpb: [],
+      manual: 0,
+    },
+  ]);
 });
 
 test('election write-in adjudication summary', async () => {

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -675,6 +675,7 @@ function buildApi({
     getCardCounts(
       input: {
         groupBy?: Tabulation.GroupBy;
+        filter?: Tabulation.Filter;
         blankBallotsOnly?: boolean;
       } = {}
     ): Array<Tabulation.GroupOf<Tabulation.CardCounts>> {

--- a/apps/admin/backend/src/tabulation/manual_results.test.ts
+++ b/apps/admin/backend/src/tabulation/manual_results.test.ts
@@ -67,12 +67,19 @@ describe('tabulateManualResults & tabulateManualBallotCounts', () => {
         filter: { batchIds: ['batch-1'] },
       }).err()
     ).toEqual({ type: 'incompatible-filter' });
+
+    expect(
+      tabulateManualBallotCounts({
+        electionId,
+        store,
+        filter: { batchIds: ['batch-1'] },
+      }).err()
+    ).toEqual({ type: 'incompatible-filter' });
   });
 
   test('on incompatible group by', () => {
     const store = Store.memoryStore();
-    const { electionData, election } =
-      electionTwoPartyPrimaryFixtures.electionDefinition;
+    const { electionData } = electionTwoPartyPrimaryFixtures.electionDefinition;
     const electionId = store.addElection({
       electionData,
       systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
@@ -89,8 +96,8 @@ describe('tabulateManualResults & tabulateManualBallotCounts', () => {
 
     expect(
       tabulateManualBallotCounts({
-        election,
-        manualResultsMetadataRecords: [],
+        electionId,
+        store,
         groupBy: { groupByBatch: true },
       }).err()
     ).toEqual({ type: 'incompatible-group-by' });
@@ -290,14 +297,11 @@ describe('tabulateManualResults & tabulateManualBallotCounts', () => {
       );
     }
 
-    for (const { groupBy, expected } of testCases.filter(
-      (testCase) => testCase.filter === undefined
-    )) {
+    for (const { filter, groupBy, expected } of testCases) {
       const result = tabulateManualBallotCounts({
-        election,
-        manualResultsMetadataRecords: store.getManualResultsMetadata({
-          electionId,
-        }),
+        electionId,
+        store,
+        filter,
         groupBy,
       });
       assert(result.isOk());


### PR DESCRIPTION
## Overview

We already have code to generate ballot counts, but the original use case was only to make the precinct or voting method breakdowns that appear on the reports page. It supported grouping, but not filtering.

We'll be creating a "Ballot Count Report Builder" similar to the "Tally Report Builder," which will require filtering of results. This PR adds that capability to the VxAdmin backend, leaving the frontend untouched for now.
