### PR TITLE
VxDesign: Primary elections

### DIFF
--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -22,7 +22,7 @@ import JsZip from 'jszip';
 import { renderDocumentToPdf } from '@votingworks/hmpb-render-backend';
 import { ElectionRecord, Precinct, Store } from './store';
 
-function createBlankElection(): Election {
+export function createBlankElection(): Election {
   return {
     type: 'general',
     title: '',

--- a/apps/design/backend/src/index.ts
+++ b/apps/design/backend/src/index.ts
@@ -12,9 +12,11 @@ export type {
   PrecinctWithSplits,
   PrecinctWithoutSplits,
 } from './store';
-export { generateBallotStyles } from './store';
-export { convertVxfPrecincts } from './app';
 export type { Api } from './app';
+
+// Frontend tests import these for generating test data
+export { generateBallotStyles } from './store';
+export { createBlankElection, convertVxfPrecincts } from './app';
 
 function main(): Promise<number> {
   if (!WORKSPACE) {

--- a/apps/design/backend/test/helpers.ts
+++ b/apps/design/backend/test/helpers.ts
@@ -8,6 +8,8 @@ import type { Api } from '../src/app';
 
 tmp.setGracefulCleanup();
 
+export type ApiClient = grout.Client<Api>;
+
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function testSetupHelpers() {
   const servers: Server[] = [];

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -29,7 +29,13 @@ export function useApiClient(): ApiClient {
 }
 
 export function createQueryClient(): QueryClient {
-  return new QueryClient();
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        refetchOnWindowFocus: false,
+      },
+    },
+  });
 }
 
 export const listElections = {

--- a/apps/design/frontend/src/ballot_viewer.tsx
+++ b/apps/design/frontend/src/ballot_viewer.tsx
@@ -1,11 +1,12 @@
 /* eslint-disable react/no-array-index-key */
 import { useRef, useState, useMemo, useCallback } from 'react';
-import { throwIllegalValue } from '@votingworks/basics';
+import { assertDefined, throwIllegalValue } from '@votingworks/basics';
 import {
   BallotPaperSize,
   BallotStyle,
   BallotType,
   Election,
+  getPartyForBallotStyle,
   Precinct,
 } from '@votingworks/types';
 import styled from 'styled-components';
@@ -319,6 +320,18 @@ export function BallotViewer({
           <Column style={{ gap: '1rem' }}>
             <FormField label="Ballot Style">{ballotStyle.id}</FormField>
             <FormField label="Precinct">{precinct.name}</FormField>
+            {election.type === 'primary' && (
+              <FormField label="Party">
+                {
+                  assertDefined(
+                    getPartyForBallotStyle({
+                      election,
+                      ballotStyleId: ballotStyle.id,
+                    })
+                  ).fullName
+                }
+              </FormField>
+            )}
             <FormField label="Page Size">
               {paperSizeLabels[paperSize]}{' '}
             </FormField>

--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -99,18 +99,20 @@ function ContestsTab(): JSX.Element | null {
                 </option>
               ))}
             </Select>
-            <Select
-              value={filterPartyId}
-              onChange={(e) => setFilterPartyId(e.target.value)}
-            >
-              <option value="all">All Parties</option>
-              <option value="nonpartisan">Nonpartisan</option>
-              {parties.map((party) => (
-                <option key={party.id} value={party.id}>
-                  {party.name}
-                </option>
-              ))}
-            </Select>
+            {election.type === 'primary' && (
+              <Select
+                value={filterPartyId}
+                onChange={(e) => setFilterPartyId(e.target.value)}
+              >
+                <option value="all">All Parties</option>
+                <option value="nonpartisan">Nonpartisan</option>
+                {parties.map((party) => (
+                  <option key={party.id} value={party.id}>
+                    {party.name}
+                  </option>
+                ))}
+              </Select>
+            )}
           </React.Fragment>
         )}
         <LinkButton variant="primary" to={contestRoutes.addContest.path}>
@@ -120,7 +122,10 @@ function ContestsTab(): JSX.Element | null {
       {contests.length > 0 &&
         (filteredContests.length === 0 ? (
           <React.Fragment>
-            <P>There are no contests for the district/party you selected.</P>
+            <P>
+              There are no contests for the district
+              {election.type === 'primary' ? '/party' : ''} you selected.
+            </P>
             <P>
               <Button
                 onPress={() => {
@@ -139,7 +144,7 @@ function ContestsTab(): JSX.Element | null {
                 <TH>Title</TH>
                 <TH>ID</TH>
                 <TH>District</TH>
-                <TH>Party</TH>
+                {election.type === 'primary' && <TH>Party</TH>}
                 <TH />
               </tr>
             </thead>
@@ -149,11 +154,13 @@ function ContestsTab(): JSX.Element | null {
                   <TD>{contest.title}</TD>
                   <TD>{contest.id}</TD>
                   <TD nowrap>{districtIdToName[contest.districtId]}</TD>
-                  <TD nowrap>
-                    {contest.type === 'candidate' &&
-                      contest.partyId !== undefined &&
-                      partyIdToName[contest.partyId]}
-                  </TD>
+                  {election.type === 'primary' && (
+                    <TD nowrap>
+                      {contest.type === 'candidate' &&
+                        contest.partyId !== undefined &&
+                        partyIdToName[contest.partyId]}
+                    </TD>
+                  )}
                   <TD nowrap>
                     <LinkButton to={contestRoutes.editContest(contest.id).path}>
                       <Icons.Edit /> Edit
@@ -314,26 +321,28 @@ function ContestForm({
 
       {contest.type === 'candidate' && (
         <React.Fragment>
-          <FormField label="Party">
-            <Select
-              value={contest.partyId ?? ''}
-              onChange={(e) =>
-                setContest({
-                  ...contest,
-                  partyId: e.target.value
-                    ? (e.target.value as PartyId)
-                    : undefined,
-                })
-              }
-            >
-              <option value="">No Party Affiliation</option>
-              {savedElection.parties.map((party) => (
-                <option key={party.id} value={party.id}>
-                  {party.name}
-                </option>
-              ))}
-            </Select>
-          </FormField>
+          {savedElection.type === 'primary' && (
+            <FormField label="Party">
+              <Select
+                value={contest.partyId ?? ''}
+                onChange={(e) =>
+                  setContest({
+                    ...contest,
+                    partyId: e.target.value
+                      ? (e.target.value as PartyId)
+                      : undefined,
+                  })
+                }
+              >
+                <option value="">No Party Affiliation</option>
+                {savedElection.parties.map((party) => (
+                  <option key={party.id} value={party.id}>
+                    {party.name}
+                  </option>
+                ))}
+              </Select>
+            </FormField>
+          )}
           <FormField label="Seats">
             <Input
               type="number"

--- a/apps/design/frontend/src/election_info_screen.test.tsx
+++ b/apps/design/frontend/src/election_info_screen.test.tsx
@@ -1,0 +1,201 @@
+import userEvent from '@testing-library/user-event';
+import { Election } from '@votingworks/types';
+import { Buffer } from 'buffer';
+import { createMemoryHistory } from 'history';
+import {
+  MockApiClient,
+  createMockApiClient,
+  provideApi,
+} from '../test/api_helpers';
+import {
+  blankElectionRecord,
+  electionId,
+  generalElectionRecord,
+} from '../test/fixtures';
+import { render, screen, waitFor, within } from '../test/react_testing_library';
+import { withRoute } from '../test/routing_helpers';
+import { ElectionInfoScreen } from './election_info_screen';
+import { routes } from './routes';
+
+let apiMock: MockApiClient;
+
+beforeEach(() => {
+  apiMock = createMockApiClient();
+});
+
+afterEach(() => {
+  apiMock.assertComplete();
+});
+
+function renderScreen() {
+  const { path } = routes.election(electionId).electionInfo;
+  const history = createMemoryHistory({ initialEntries: [path] });
+  render(
+    provideApi(
+      apiMock,
+      withRoute(<ElectionInfoScreen />, {
+        paramPath: routes.election(':electionId').electionInfo.path,
+        history,
+      })
+    )
+  );
+  return history;
+}
+
+test('newly created election starts in edit mode', async () => {
+  apiMock.getElection
+    .expectCallWith({ electionId })
+    .resolves(blankElectionRecord);
+  renderScreen();
+  await screen.findByRole('heading', { name: 'Election Info' });
+
+  const titleInput = screen.getByLabelText('Title');
+  expect(titleInput).toHaveValue('');
+  expect(titleInput).toBeEnabled();
+
+  const dateInput = screen.getByLabelText('Date');
+  expect(dateInput).toHaveValue('');
+  expect(dateInput).toBeEnabled();
+
+  const typeInput = within(
+    screen.getByText('Type').closest('label')!
+  ).getByRole('radiogroup');
+  expect(within(typeInput).getByLabelText('General')).toBeChecked();
+  expect(within(typeInput).getByLabelText('Primary')).not.toBeChecked();
+  for (const option of within(typeInput).getAllByRole('radio')) {
+    expect(option).toBeEnabled();
+  }
+
+  const stateInput = screen.getByLabelText('State');
+  expect(stateInput).toHaveValue('');
+  expect(stateInput).toBeEnabled();
+
+  const countyInput = screen.getByLabelText('County');
+  expect(countyInput).toHaveValue('');
+  expect(countyInput).toBeEnabled();
+
+  const sealInput = screen.getByText('Seal').closest('label')!;
+  expect(within(sealInput).queryByRole('img')).not.toBeInTheDocument();
+  expect(within(sealInput).getByLabelText('Upload Seal Image')).toBeEnabled();
+
+  screen.getByRole('button', { name: 'Save' });
+  userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+  screen.getByRole('button', { name: 'Edit' });
+  screen.getByRole('button', { name: 'Delete Election' });
+});
+
+test('edit and save election', async () => {
+  const { election } = generalElectionRecord;
+  apiMock.getElection
+    .expectCallWith({ electionId })
+    .resolves(generalElectionRecord);
+  renderScreen();
+  await screen.findByRole('heading', { name: 'Election Info' });
+
+  const titleInput = screen.getByLabelText('Title');
+  expect(titleInput).toHaveValue(election.title);
+  expect(titleInput).toBeDisabled();
+
+  const dateInput = screen.getByLabelText('Date');
+  expect(dateInput).toHaveValue(election.date);
+  expect(dateInput).toBeDisabled();
+
+  const typeInput = within(
+    screen.getByText('Type').closest('label')!
+  ).getByRole('radiogroup');
+  expect(within(typeInput).getByLabelText('General')).toBeChecked();
+  for (const option of within(typeInput).getAllByRole('radio')) {
+    expect(option).toBeDisabled();
+  }
+
+  const stateInput = screen.getByLabelText('State');
+  expect(stateInput).toHaveValue(election.state);
+  expect(stateInput).toBeDisabled();
+
+  const countyInput = screen.getByLabelText('County');
+  expect(countyInput).toHaveValue(election.county.name);
+  expect(countyInput).toBeDisabled();
+
+  const sealInput = screen.getByText('Seal').closest('label')!;
+  expect(within(sealInput).getByRole('img')).toHaveAttribute(
+    'src',
+    `data:image/svg+xml;base64,${Buffer.from(election.seal).toString('base64')}`
+  );
+  expect(
+    within(sealInput).queryByLabelText('Upload Seal Image')
+  ).not.toBeInTheDocument();
+
+  userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+  userEvent.clear(titleInput);
+  userEvent.type(titleInput, 'New Title');
+  expect(titleInput).toHaveValue('New Title');
+
+  userEvent.clear(dateInput);
+  userEvent.type(dateInput, '2023-09-06');
+  expect(dateInput).toHaveValue('2023-09-06');
+
+  userEvent.click(within(typeInput).getByLabelText('Primary'));
+  expect(within(typeInput).getByLabelText('General')).not.toBeChecked();
+  expect(within(typeInput).getByLabelText('Primary')).toBeChecked();
+
+  userEvent.clear(stateInput);
+  userEvent.type(stateInput, 'New State');
+  expect(stateInput).toHaveValue('New State');
+
+  userEvent.clear(countyInput);
+  userEvent.type(countyInput, 'New County');
+  expect(countyInput).toHaveValue('New County');
+
+  userEvent.upload(
+    within(sealInput).getByLabelText('Upload Seal Image'),
+    new File(['<svg>updated seal</svg>'], 'new_seal.svg')
+  );
+  await waitFor(() =>
+    expect(within(sealInput).getByRole('img')).toHaveAttribute(
+      'src',
+      `data:image/svg+xml;base64,${Buffer.from(
+        '<svg>updated seal</svg>'
+      ).toString('base64')}`
+    )
+  );
+
+  const updatedElection: Election = {
+    ...election,
+    title: 'New Title',
+    date: '2023-09-06',
+    type: 'primary',
+    state: 'New State',
+    county: {
+      id: 'county-id',
+      name: 'New County',
+    },
+    seal: '<svg>updated seal</svg>',
+  };
+  apiMock.updateElection
+    .expectCallWith({ electionId, election: updatedElection })
+    .resolves();
+  apiMock.getElection
+    .expectCallWith({ electionId })
+    .resolves({ ...generalElectionRecord, election: updatedElection });
+
+  userEvent.click(screen.getByRole('button', { name: 'Save' }));
+  await screen.findByRole('button', { name: 'Edit' });
+});
+
+test('delete election', async () => {
+  apiMock.getElection
+    .expectCallWith({ electionId })
+    .resolves(generalElectionRecord);
+  const history = renderScreen();
+  await screen.findByRole('heading', { name: 'Election Info' });
+
+  apiMock.deleteElection.expectCallWith({ electionId }).resolves();
+
+  userEvent.click(screen.getByRole('button', { name: 'Delete Election' }));
+  // Redirects to elections list
+  await waitFor(() =>
+    expect(history.location.pathname).toEqual(routes.root.path)
+  );
+});

--- a/apps/design/frontend/src/election_info_screen.tsx
+++ b/apps/design/frontend/src/election_info_screen.tsx
@@ -9,10 +9,11 @@ import { Form, FormField, Input, FormActionsRow } from './layout';
 import { ElectionNavScreen } from './nav_screen';
 import { routes } from './routes';
 import { FileInputButton } from './file_input_button';
+import { SegmentedControl } from './segmented_control';
 
 type ElectionInfo = Pick<
   Election,
-  'title' | 'date' | 'state' | 'county' | 'seal'
+  'title' | 'date' | 'type' | 'state' | 'county' | 'seal'
 >;
 
 function hasBlankElectionInfo(election: Election): boolean {
@@ -83,6 +84,17 @@ function ElectionInfoForm({
             new Date(electionInfo.date).toISOString().slice(0, 10)
           }
           onChange={onInputChange('date')}
+          disabled={!isEditing}
+        />
+      </FormField>
+      <FormField label="Type">
+        <SegmentedControl
+          options={[
+            { label: 'General', value: 'general' },
+            { label: 'Primary', value: 'primary' },
+          ]}
+          value={electionInfo.type}
+          onChange={(type) => setElectionInfo({ ...electionInfo, type })}
           disabled={!isEditing}
         />
       </FormField>

--- a/apps/design/frontend/src/export_screen.test.tsx
+++ b/apps/design/frontend/src/export_screen.test.tsx
@@ -28,11 +28,10 @@ function renderScreen() {
   render(
     provideApi(
       apiMock,
-      withRoute(
-        <ExportScreen />,
-        routes.election(':electionId').export.path,
-        routes.election(electionId).export.path
-      )
+      withRoute(<ExportScreen />, {
+        paramPath: routes.election(':electionId').export.path,
+        path: routes.election(electionId).export.path,
+      })
     )
   );
 }

--- a/apps/design/frontend/src/tabulation_screen.test.tsx
+++ b/apps/design/frontend/src/tabulation_screen.test.tsx
@@ -13,7 +13,7 @@ import {
 import { withRoute } from '../test/routing_helpers';
 import { routes } from './routes';
 import { TabulationScreen } from './tabulation_screen';
-import { electionId, electionRecord } from '../test/fixtures';
+import { electionId, generalElectionRecord } from '../test/fixtures';
 
 let apiMock: MockApiClient;
 
@@ -29,21 +29,18 @@ function renderScreen() {
   render(
     provideApi(
       apiMock,
-      withRoute(
-        <TabulationScreen />,
-        routes.election(':electionId').export.path,
-        routes.election(electionId).export.path
-      )
+      withRoute(<TabulationScreen />, {
+        paramPath: routes.election(':electionId').tabulation.path,
+        path: routes.election(electionId).tabulation.path,
+      })
     )
   );
 }
 
 test('mark thresholds', async () => {
   apiMock.getElection
-    .expectCallWith({
-      electionId,
-    })
-    .resolves(electionRecord);
+    .expectCallWith({ electionId })
+    .resolves(generalElectionRecord);
   renderScreen();
   await screen.findByRole('heading', { name: 'Tabulation' });
 
@@ -54,7 +51,7 @@ test('mark thresholds', async () => {
   });
   expect(definiteInput).toBeDisabled();
   expect(definiteInput).toHaveValue(
-    electionRecord.systemSettings.markThresholds.definite
+    generalElectionRecord.systemSettings.markThresholds.definite
   );
 
   const marginalInput = screen.getByRole('spinbutton', {
@@ -62,7 +59,7 @@ test('mark thresholds', async () => {
   });
   expect(marginalInput).toBeDisabled();
   expect(marginalInput).toHaveValue(
-    electionRecord.systemSettings.markThresholds.marginal
+    generalElectionRecord.systemSettings.markThresholds.marginal
   );
 
   userEvent.click(screen.getByRole('button', { name: 'Edit' }));
@@ -80,19 +77,12 @@ test('mark thresholds', async () => {
     },
   };
   apiMock.updateSystemSettings
-    .expectCallWith({
-      electionId,
-      systemSettings: updatedSystemSettings,
-    })
+    .expectCallWith({ electionId, systemSettings: updatedSystemSettings })
     .resolves();
-  apiMock.getElection
-    .expectCallWith({
-      electionId,
-    })
-    .resolves({
-      ...electionRecord,
-      systemSettings: updatedSystemSettings,
-    });
+  apiMock.getElection.expectCallWith({ electionId }).resolves({
+    ...generalElectionRecord,
+    systemSettings: updatedSystemSettings,
+  });
 
   userEvent.click(screen.getByRole('button', { name: 'Save' }));
 
@@ -110,10 +100,8 @@ test('mark thresholds', async () => {
 
 test('adjudication reasons', async () => {
   apiMock.getElection
-    .expectCallWith({
-      electionId,
-    })
-    .resolves(electionRecord);
+    .expectCallWith({ electionId })
+    .resolves(generalElectionRecord);
   renderScreen();
   await screen.findByRole('heading', { name: 'Tabulation' });
 
@@ -153,19 +141,12 @@ test('adjudication reasons', async () => {
     centralScanAdjudicationReasons: [AdjudicationReason.Overvote],
   };
   apiMock.updateSystemSettings
-    .expectCallWith({
-      electionId,
-      systemSettings: updatedSystemSettings,
-    })
+    .expectCallWith({ electionId, systemSettings: updatedSystemSettings })
     .resolves();
-  apiMock.getElection
-    .expectCallWith({
-      electionId,
-    })
-    .resolves({
-      ...electionRecord,
-      systemSettings: updatedSystemSettings,
-    });
+  apiMock.getElection.expectCallWith({ electionId }).resolves({
+    ...generalElectionRecord,
+    systemSettings: updatedSystemSettings,
+  });
 
   userEvent.click(screen.getByRole('button', { name: 'Save' }));
 

--- a/apps/design/frontend/test/fixtures.ts
+++ b/apps/design/frontend/test/fixtures.ts
@@ -1,33 +1,43 @@
 import type { ElectionRecord } from '@votingworks/design-backend';
 import {
+  createBlankElection,
   convertVxfPrecincts,
   generateBallotStyles,
 } from '@votingworks/design-backend';
-import { electionSample } from '@votingworks/fixtures';
+import {
+  electionComplexGeoSample,
+  electionSample,
+} from '@votingworks/fixtures';
 import { DEFAULT_LAYOUT_OPTIONS } from '@votingworks/hmpb-layout';
 import { DEFAULT_SYSTEM_SETTINGS, Election } from '@votingworks/types';
 
 export const electionId = 'election-id-1';
-const baseElection = electionSample;
-export const precincts = convertVxfPrecincts(baseElection);
-export const ballotStyles = generateBallotStyles(baseElection, precincts);
-export const election: Election = {
-  ...baseElection,
-  ballotStyles: ballotStyles.map((ballotStyle) => ({
-    ...ballotStyle,
-    precincts: ballotStyle.precinctsOrSplits.map((p) => p.precinctId),
-    districts: ballotStyle.districtIds,
-  })),
-};
 
-export const electionRecord: ElectionRecord = {
-  id: electionId,
-  election,
-  systemSettings: DEFAULT_SYSTEM_SETTINGS,
-  // TODO more realistic data for precincts and ballot styles in tests in
-  // general, even though they are not used here
-  precincts,
-  ballotStyles,
-  layoutOptions: DEFAULT_LAYOUT_OPTIONS,
-  createdAt: new Date().toISOString(),
-};
+function makeElectionRecord(baseElection: Election): ElectionRecord {
+  const precincts = convertVxfPrecincts(baseElection);
+  const ballotStyles = generateBallotStyles(baseElection, precincts);
+  const election: Election = {
+    ...baseElection,
+    ballotStyles: ballotStyles.map((ballotStyle) => ({
+      id: ballotStyle.id,
+      precincts: ballotStyle.precinctsOrSplits.map((p) => p.precinctId),
+      districts: ballotStyle.districtIds,
+      partyId: ballotStyle.partyId,
+    })),
+  };
+  return {
+    id: electionId,
+    election,
+    systemSettings: DEFAULT_SYSTEM_SETTINGS,
+    precincts,
+    ballotStyles,
+    layoutOptions: DEFAULT_LAYOUT_OPTIONS,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+export const blankElectionRecord = makeElectionRecord(createBlankElection());
+export const generalElectionRecord = makeElectionRecord(electionSample);
+export const primaryElectionRecord = makeElectionRecord(
+  electionComplexGeoSample.election
+);

--- a/apps/design/frontend/test/fixtures.ts
+++ b/apps/design/frontend/test/fixtures.ts
@@ -10,7 +10,7 @@ import { DEFAULT_SYSTEM_SETTINGS, Election } from '@votingworks/types';
 export const electionId = 'election-id-1';
 const baseElection = electionSample;
 export const precincts = convertVxfPrecincts(baseElection);
-export const ballotStyles = generateBallotStyles(precincts);
+export const ballotStyles = generateBallotStyles(baseElection, precincts);
 export const election: Election = {
   ...baseElection,
   ballotStyles: ballotStyles.map((ballotStyle) => ({

--- a/apps/design/frontend/test/routing_helpers.tsx
+++ b/apps/design/frontend/test/routing_helpers.tsx
@@ -1,19 +1,18 @@
 import React from 'react';
 import { Route, Router } from 'react-router-dom';
-import { createMemoryHistory } from 'history';
-
-export function withRouter(ui: React.ReactElement, path = '/'): JSX.Element {
-  return (
-    <Router history={createMemoryHistory({ initialEntries: [path] })}>
-      {ui}
-    </Router>
-  );
-}
+import { createMemoryHistory, History } from 'history';
 
 export function withRoute(
   ui: React.ReactElement,
-  paramPath = '/',
-  path = '/'
+  {
+    paramPath = '/',
+    path = '/',
+    history = createMemoryHistory({ initialEntries: [path] }),
+  }: { paramPath?: string; path?: string; history?: History }
 ): JSX.Element {
-  return withRouter(<Route path={paramPath}>{ui}</Route>, path);
+  return (
+    <Router history={history}>
+      <Route path={paramPath}>{ui}</Route>
+    </Router>
+  );
 }

--- a/libs/hmpb/layout/src/layout.ts
+++ b/libs/hmpb/layout/src/layout.ts
@@ -20,6 +20,7 @@ import {
   ElectionDefinition,
   getCandidatePartiesDescription,
   getContests,
+  getPartyForBallotStyle,
   getPrecinctById,
   GridLayout,
   GridPosition,
@@ -392,6 +393,7 @@ export function TimingMarkGrid({ m }: { m: Measurements }): AnyElement {
 
 function HeaderAndInstructions({
   election,
+  ballotStyle,
   precinct,
   pageNumber,
   ballotType,
@@ -399,6 +401,7 @@ function HeaderAndInstructions({
   m,
 }: {
   election: Election;
+  ballotStyle: BallotStyle;
   precinct: Precinct;
   pageNumber: number;
   ballotType: BallotType;
@@ -422,6 +425,14 @@ function HeaderAndInstructions({
     [BallotType.Provisional]: ' Provisional',
   };
   const title = `${ballotModeLabel[ballotMode]}${ballotTypeLabel[ballotType]} Ballot`;
+  const party =
+    election.type === 'primary'
+      ? ` • ${
+          assertDefined(
+            getPartyForBallotStyle({ election, ballotStyleId: ballotStyle.id })
+          ).fullName
+        }`
+      : '';
 
   const date = Intl.DateTimeFormat('en-US', {
     month: 'long',
@@ -444,7 +455,7 @@ function HeaderAndInstructions({
         width: gridWidth(m.CONTENT_AREA_COLUMN_WIDTH - 1, m),
         textGroups: [
           {
-            text: title,
+            text: `${title}${party}`,
             fontStyle: {
               ...m.FontStyles.H1,
               lineHeight: m.FontStyles.H1.lineHeight * 0.85,
@@ -1542,6 +1553,7 @@ function layOutBallotHelper({
     );
     const headerAndInstructions = HeaderAndInstructions({
       election,
+      ballotStyle,
       precinct,
       pageNumber,
       ballotType,

--- a/libs/types/src/election_utils.ts
+++ b/libs/types/src/election_utils.ts
@@ -10,6 +10,7 @@ import {
   Election,
   ElectionDefinition,
   Parties,
+  Party,
   PartyId,
   Precinct,
   PrecinctId,
@@ -188,6 +189,20 @@ export function getPartyPrimaryAdjectiveFromBallotStyle({
 }
 
 /**
+ * Gets the party for a ballot style, if any.
+ */
+export function getPartyForBallotStyle({
+  ballotStyleId,
+  election,
+}: {
+  ballotStyleId: BallotStyleId;
+  election: Election;
+}): Party | undefined {
+  const ballotStyle = getBallotStyle({ ballotStyleId, election });
+  return election.parties.find((p) => p.id === ballotStyle?.partyId);
+}
+
+/**
  * Gets the full name of the political party for a primary election,
  * e.g. "Republican Party" or "Democratic Party".
  */
@@ -198,8 +213,7 @@ export function getPartyFullNameFromBallotStyle({
   ballotStyleId: BallotStyleId;
   election: Election;
 }): string {
-  const ballotStyle = getBallotStyle({ ballotStyleId, election });
-  const party = election.parties.find((p) => p.id === ballotStyle?.partyId);
+  const party = getPartyForBallotStyle({ ballotStyleId, election });
   return party?.fullName ?? '';
 }
 


### PR DESCRIPTION
## Overview

Adds basic support for primary elections to VxDesign, including:
- A field to select either a "general" or "primary" election type
- Only showing the field to add party associations to contests for primary elections
- Generating party-specific ballot styles
- Displaying the party associated with each ballot style
- Displaying the party name on primary election ballots

_Review by commits_

## Demo Video or Screenshot
(sound on!)

https://github.com/votingworks/vxsuite/assets/530106/278adfa0-60ad-4eaa-a431-519e2b9f31cb



## Testing Plan
- Updated automated tests
- Visual confirmation of ballot design

(Note: since I don't have basic test coverage for a lot of VxDesign from the prototyping phase, I'm trying to add it as I improve various features. I did that for most of this PR, but ran out of time to cover the contests screen)

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
