### PR TITLE
Update VxAdmin to support importing new CVR export format

### DIFF
--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -68,7 +68,7 @@ import {
   addCastVoteRecordReport,
   getAddCastVoteRecordReportErrorMessage,
   listCastVoteRecordFilesOnUsb,
-} from './cvr_files';
+} from './legacy_cast_vote_records';
 import { getMachineConfig } from './machine_config';
 import {
   getWriteInAdjudicationContext,

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -32,9 +32,11 @@ import { createReadStream, createWriteStream, promises as fs, Stats } from 'fs';
 import { basename, dirname, join } from 'path';
 import {
   BALLOT_PACKAGE_FOLDER,
+  BooleanEnvironmentVariableName,
   CAST_VOTE_RECORD_REPORT_FILENAME,
   generateFilenameForBallotExportPackage,
   groupMapToGroupList,
+  isFeatureFlagEnabled,
   isIntegrationTest,
   parseCastVoteRecordReportDirectoryName,
 } from '@votingworks/utils';
@@ -48,6 +50,7 @@ import {
   CvrFileMode,
   ElectionRecord,
   ExportDataResult,
+  ImportCastVoteRecordsError,
   ManualResultsIdentifier,
   ManualResultsMetadataRecord,
   ManualResultsRecord,
@@ -86,6 +89,7 @@ import { getOverallElectionWriteInSummary } from './tabulation/write_ins';
 import { rootDebug } from './util/debug';
 import { tabulateTallyReportResults } from './tabulation/tally_reports';
 import { buildExporter } from './util/exporter';
+import { importCastVoteRecords } from './cast_vote_records';
 
 const debug = rootDebug.extend('app');
 
@@ -404,9 +408,39 @@ function buildApi({
     }): Promise<
       Result<
         CvrFileImportInfo,
-        AddCastVoteRecordReportError & { message: string }
+        | (AddCastVoteRecordReportError & { message: string })
+        | ImportCastVoteRecordsError
       >
     > {
+      /* c8 ignore start */
+      if (
+        isFeatureFlagEnabled(
+          BooleanEnvironmentVariableName.ENABLE_CONTINUOUS_EXPORT
+        )
+      ) {
+        const userRole = assertDefined(await getUserRole());
+        const importResult = await importCastVoteRecords(store, input.path);
+        if (importResult.isErr()) {
+          await logger.log(LogEventId.CvrLoaded, userRole, {
+            disposition: 'failure',
+            errorDetails: JSON.stringify(importResult.err()),
+            errorType: importResult.err().type,
+            exportDirectoryPath: input.path,
+            result: 'Cast vote records not imported, error shown to user.',
+          });
+        } else {
+          await logger.log(LogEventId.CvrLoaded, userRole, {
+            disposition: 'success',
+            exportDirectoryPath: input.path,
+            numberOfBallotsImported: importResult.ok().newlyAdded,
+            numberOfDuplicateBallotsIgnored: importResult.ok().alreadyPresent,
+            result: 'Cast vote records imported.',
+          });
+        }
+        return importResult;
+      }
+      /* c8 ignore stop */
+
       const userRole = assertDefined(await getUserRole());
       const { path: inputPath } = input;
       // the path passed to the backend may be for the report directory or the

--- a/apps/admin/backend/src/cast_vote_records.ts
+++ b/apps/admin/backend/src/cast_vote_records.ts
@@ -1,0 +1,283 @@
+/* c8 ignore start */
+import * as fs from 'fs/promises';
+import { sha256 } from 'js-sha256';
+import path from 'path';
+import { v4 as uuid } from 'uuid';
+import { isTestReport, readCastVoteRecordExport } from '@votingworks/backend';
+import { assert, assertDefined, err, ok, Result } from '@votingworks/basics';
+import {
+  BallotId,
+  BallotPageLayoutSchema,
+  CVR,
+  ElectionDefinition,
+  getBallotStyle,
+  getContests,
+  getPrecinctById,
+  safeParseJson,
+} from '@votingworks/types';
+import {
+  BooleanEnvironmentVariableName,
+  castVoteRecordHasValidContestReferences,
+  convertCastVoteRecordVotesToTabulationVotes,
+  isFeatureFlagEnabled,
+} from '@votingworks/utils';
+
+import { Store } from './store';
+import {
+  CastVoteRecordElectionDefinitionValidationError,
+  CvrFileImportInfo,
+  CvrFileMode,
+  ImportCastVoteRecordsError,
+} from './types';
+
+/**
+ * Validates that the fields in a cast vote record and the election definition correspond
+ */
+function validateCastVoteRecordAgainstElectionDefinition(
+  castVoteRecord: CVR.CVR,
+  electionDefinition: ElectionDefinition
+): Result<void, CastVoteRecordElectionDefinitionValidationError> {
+  function wrapError(
+    error: Omit<CastVoteRecordElectionDefinitionValidationError, 'type'>
+  ): Result<void, CastVoteRecordElectionDefinitionValidationError> {
+    return err({ ...error, type: 'invalid-cast-vote-record' });
+  }
+
+  const { election, electionHash } = electionDefinition;
+
+  if (
+    castVoteRecord.ElectionId !== electionHash &&
+    !isFeatureFlagEnabled(
+      BooleanEnvironmentVariableName.SKIP_CVR_ELECTION_HASH_CHECK
+    )
+  ) {
+    return wrapError({ subType: 'election-mismatch' });
+  }
+
+  const precinct = getPrecinctById({
+    election,
+    precinctId: castVoteRecord.BallotStyleUnitId,
+  });
+  if (!precinct) {
+    return wrapError({ subType: 'precinct-not-found' });
+  }
+
+  const ballotStyle = getBallotStyle({
+    ballotStyleId: castVoteRecord.BallotStyleId,
+    election,
+  });
+  if (!ballotStyle) {
+    return wrapError({ subType: 'ballot-style-not-found' });
+  }
+
+  const contestValidationResult = castVoteRecordHasValidContestReferences(
+    castVoteRecord,
+    getContests({ ballotStyle, election })
+  );
+  if (contestValidationResult.isErr()) {
+    return wrapError({ subType: contestValidationResult.err() });
+  }
+
+  return ok();
+}
+
+/**
+ * Imports cast vote records given a cast vote record export directory path
+ */
+export async function importCastVoteRecords(
+  store: Store,
+  exportDirectoryPath: string
+): Promise<Result<CvrFileImportInfo, ImportCastVoteRecordsError>> {
+  const electionId = assertDefined(store.getCurrentElectionId());
+  const { electionDefinition } = assertDefined(store.getElection(electionId));
+
+  const readResult = await readCastVoteRecordExport(exportDirectoryPath);
+  if (readResult.isErr()) {
+    return readResult;
+  }
+  const { castVoteRecordExportMetadata, castVoteRecords } = readResult.ok();
+  const { castVoteRecordReportMetadata } = castVoteRecordExportMetadata;
+
+  const exportDirectoryName = path.basename(exportDirectoryPath);
+  // Hashing the export metadata, which includes a root hash of all the individual cast vote
+  // records, gives us a complete hash of the entire export
+  const exportHash = sha256(JSON.stringify(castVoteRecordExportMetadata));
+  const exportedTimestamp = castVoteRecordReportMetadata.GeneratedDate;
+
+  // Ensure that the records to be imported match the mode (test vs. official) of previously
+  // imported records
+  const mode: CvrFileMode = isTestReport(castVoteRecordReportMetadata)
+    ? 'test'
+    : 'official';
+  const currentMode = store.getCurrentCvrFileModeForElection(electionId);
+  if (currentMode !== 'unlocked' && mode !== currentMode) {
+    return err({ type: 'invalid-mode', currentMode });
+  }
+
+  const existingImportId = store.getCastVoteRecordFileByHash(
+    electionId,
+    exportHash
+  );
+  if (existingImportId) {
+    return ok({
+      id: existingImportId,
+      alreadyPresent: store.getCastVoteRecordCountByFileId(existingImportId),
+      exportedTimestamp,
+      fileMode: mode,
+      fileName: exportDirectoryName,
+      newlyAdded: 0,
+      wasExistingFile: true,
+    });
+  }
+
+  return await store.withTransaction(async () => {
+    const scannerIds = new Set<string>();
+    for (const vxBatch of castVoteRecordReportMetadata.vxBatch) {
+      store.addScannerBatch({
+        batchId: vxBatch['@id'],
+        electionId,
+        label: vxBatch.BatchLabel,
+        scannerId: vxBatch.CreatingDeviceId,
+      });
+      scannerIds.add(vxBatch.CreatingDeviceId);
+    }
+
+    // Create a top-level record for the import
+    const importId = uuid();
+    store.addCastVoteRecordFileRecord({
+      id: importId,
+      electionId,
+      exportedTimestamp,
+      filename: exportDirectoryName,
+      isTestMode: isTestReport(castVoteRecordReportMetadata),
+      scannerIds,
+      sha256Hash: exportHash,
+    });
+
+    let castVoteRecordIndex = 0;
+    let newlyAdded = 0;
+    let alreadyPresent = 0;
+    const precinctIds = new Set<string>();
+    for await (const castVoteRecordResult of castVoteRecords) {
+      if (castVoteRecordResult.isErr()) {
+        return err({
+          ...castVoteRecordResult.err(),
+          index: castVoteRecordIndex,
+        });
+      }
+      const {
+        castVoteRecord,
+        castVoteRecordBallotSheetId,
+        castVoteRecordCurrentSnapshot,
+        castVoteRecordWriteIns,
+        referencedFiles,
+      } = castVoteRecordResult.ok();
+
+      const validationResult = validateCastVoteRecordAgainstElectionDefinition(
+        castVoteRecord,
+        electionDefinition
+      );
+      if (validationResult.isErr()) {
+        return err({ ...validationResult.err(), index: castVoteRecordIndex });
+      }
+
+      // Add an individual cast vote record to the import
+      const votes = convertCastVoteRecordVotesToTabulationVotes(
+        castVoteRecordCurrentSnapshot
+      );
+      const addCastVoteRecordResult = store.addCastVoteRecordFileEntry({
+        ballotId: castVoteRecord.UniqueId as BallotId,
+        cvr: {
+          ballotStyleId: castVoteRecord.BallotStyleId,
+          batchId: castVoteRecord.BatchId,
+          card: castVoteRecordBallotSheetId
+            ? { type: 'hmpb', sheetNumber: castVoteRecordBallotSheetId }
+            : { type: 'bmd' },
+          precinctId: castVoteRecord.BallotStyleUnitId,
+          votes,
+          votingMethod: castVoteRecord.vxBallotType,
+        },
+        cvrFileId: importId,
+        electionId,
+      });
+      if (addCastVoteRecordResult.isErr()) {
+        return err({
+          ...addCastVoteRecordResult.err(),
+          index: castVoteRecordIndex,
+        });
+      }
+      const { cvrId: castVoteRecordId, isNew: isCastVoteRecordNew } =
+        addCastVoteRecordResult.ok();
+
+      if (isCastVoteRecordNew) {
+        const hmpbCastVoteRecordWriteIns = castVoteRecordWriteIns.filter(
+          (castVoteRecordWriteIn) => castVoteRecordWriteIn.side
+        );
+        if (hmpbCastVoteRecordWriteIns.length > 0) {
+          // Guaranteed to exist given validation in readCastVoteRecordExport
+          assert(referencedFiles !== undefined);
+
+          for (const i of [0, 1] as const) {
+            const imageData = await fs.readFile(
+              referencedFiles.imageFilePaths[i]
+            );
+            const parseLayoutResult = safeParseJson(
+              await fs.readFile(referencedFiles.layoutFilePaths[i], 'utf8'),
+              BallotPageLayoutSchema
+            );
+            if (parseLayoutResult.isErr()) {
+              return err({
+                type: 'invalid-cast-vote-record',
+                subType: 'layout-parse-error',
+                index: castVoteRecordIndex,
+              });
+            }
+            store.addBallotImage({
+              cvrId: castVoteRecordId,
+              imageData,
+              pageLayout: parseLayoutResult.ok(),
+              side: (['front', 'back'] as const)[i],
+            });
+          }
+
+          for (const hmpbCastVoteRecordWriteIn of hmpbCastVoteRecordWriteIns) {
+            store.addWriteIn({
+              castVoteRecordId,
+              contestId: hmpbCastVoteRecordWriteIn.contestId,
+              electionId,
+              optionId: hmpbCastVoteRecordWriteIn.optionId,
+              side: assertDefined(hmpbCastVoteRecordWriteIn.side),
+            });
+          }
+        }
+      }
+
+      if (isCastVoteRecordNew) {
+        newlyAdded += 1;
+      } else {
+        alreadyPresent += 1;
+      }
+      precinctIds.add(castVoteRecord.BallotStyleUnitId);
+
+      castVoteRecordIndex += 1;
+    }
+
+    // TODO: Calculate the precinct list before iterating through cast vote records, once there is
+    // only one geopolitical unit per batch
+    store.updateCastVoteRecordFileRecord({
+      id: importId,
+      precinctIds,
+    });
+
+    return ok({
+      id: importId,
+      alreadyPresent,
+      exportedTimestamp,
+      fileMode: mode,
+      fileName: exportDirectoryName,
+      newlyAdded,
+      wasExistingFile: false,
+    });
+  });
+}
+/* c8 ignore stop */

--- a/apps/admin/backend/src/cast_vote_records.ts
+++ b/apps/admin/backend/src/cast_vote_records.ts
@@ -10,15 +10,15 @@ import {
   BallotPageLayoutSchema,
   CVR,
   ElectionDefinition,
-  getBallotStyle,
   getContests,
-  getPrecinctById,
   safeParseJson,
 } from '@votingworks/types';
 import {
   BooleanEnvironmentVariableName,
   castVoteRecordHasValidContestReferences,
   convertCastVoteRecordVotesToTabulationVotes,
+  getBallotStyleById,
+  getPrecinctById,
   isFeatureFlagEnabled,
 } from '@votingworks/utils';
 
@@ -54,18 +54,18 @@ function validateCastVoteRecordAgainstElectionDefinition(
     return wrapError({ subType: 'election-mismatch' });
   }
 
-  const precinct = getPrecinctById({
-    election,
-    precinctId: castVoteRecord.BallotStyleUnitId,
-  });
+  const precinct = getPrecinctById(
+    electionDefinition,
+    castVoteRecord.BallotStyleUnitId
+  );
   if (!precinct) {
     return wrapError({ subType: 'precinct-not-found' });
   }
 
-  const ballotStyle = getBallotStyle({
-    ballotStyleId: castVoteRecord.BallotStyleId,
-    election,
-  });
+  const ballotStyle = getBallotStyleById(
+    electionDefinition,
+    castVoteRecord.BallotStyleId
+  );
   if (!ballotStyle) {
     return wrapError({ subType: 'ballot-style-not-found' });
   }

--- a/apps/admin/backend/src/legacy_cast_vote_records.test.ts
+++ b/apps/admin/backend/src/legacy_cast_vote_records.test.ts
@@ -6,7 +6,7 @@ import { createMockUsbDrive } from '@votingworks/usb-drive';
 import {
   listCastVoteRecordFilesOnUsb,
   validateCastVoteRecord,
-} from './cvr_files';
+} from './legacy_cast_vote_records';
 
 const electionDefinition = electionTwoPartyPrimaryDefinition;
 const file = Buffer.from([]);
@@ -361,7 +361,7 @@ describe('validateCastVoteRecord', () => {
       reportBatchIds: ['batch-1'],
     });
 
-    expect(result.err()).toEqual('invalid-contest');
+    expect(result.err()).toEqual('contest-not-found');
   });
 
   test('error on invalid contest option id', () => {
@@ -392,7 +392,7 @@ describe('validateCastVoteRecord', () => {
       reportBatchIds: ['batch-1'],
     });
 
-    expect(result.err()).toEqual('invalid-contest-option');
+    expect(result.err()).toEqual('contest-option-not-found');
   });
 
   test('error on unknown ballot image', () => {

--- a/apps/admin/backend/src/tabulation/full_results.test.ts
+++ b/apps/admin/backend/src/tabulation/full_results.test.ts
@@ -16,7 +16,7 @@ import {
   tabulateElectionResults,
 } from './full_results';
 import { Store } from '../store';
-import { addCastVoteRecordReport } from '../cvr_files';
+import { addCastVoteRecordReport } from '../legacy_cast_vote_records';
 import {
   MockCastVoteRecordFile,
   addMockCvrFileToStore,

--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -1,4 +1,8 @@
 import {
+  ReadCastVoteRecordError,
+  ReadCastVoteRecordExportError,
+} from '@votingworks/backend';
+import {
   ContestId,
   ContestOptionId,
   ElectionDefinition,
@@ -497,3 +501,33 @@ export type PartySplitTallyReportResults = TallyReportResultsBase & {
 export type TallyReportResults =
   | SingleTallyReportResults
   | PartySplitTallyReportResults;
+
+/**
+ * An error involving the correspondence between the fields in a cast vote record and the election
+ * definition
+ */
+export type CastVoteRecordElectionDefinitionValidationError = {
+  type: 'invalid-cast-vote-record';
+} & (
+  | { subType: 'ballot-style-not-found' }
+  | { subType: 'contest-not-found' }
+  | { subType: 'contest-option-not-found' }
+  | { subType: 'election-mismatch' }
+  | { subType: 'precinct-not-found' }
+);
+
+type WithIndex<T> = T & { index: number };
+
+/**
+ * An error encountered while importing cast vote records
+ */
+export type ImportCastVoteRecordsError =
+  | ReadCastVoteRecordExportError
+  | WithIndex<ReadCastVoteRecordError>
+  | WithIndex<CastVoteRecordElectionDefinitionValidationError>
+  | { type: 'invalid-mode'; currentMode: 'official' | 'test' }
+  | WithIndex<{ type: 'ballot-id-already-exists-with-different-data' }>
+  | WithIndex<{
+      type: 'invalid-cast-vote-record';
+      subType: 'layout-parse-error';
+    }>;

--- a/libs/auth/scripts/mock_card.ts
+++ b/libs/auth/scripts/mock_card.ts
@@ -91,9 +91,7 @@ async function parseCommandLineArgs(): Promise<MockCardInput> {
         `Must specify election definition for election manager and poll worker cards\n\n${helpMessage}`
       );
     }
-    const electionData = fs
-      .readFileSync(args.electionDefinition)
-      .toString('utf-8');
+    const electionData = fs.readFileSync(args.electionDefinition, 'utf-8');
     if (!safeParseElection(electionData).isOk()) {
       throw new Error(
         `${args.electionDefinition} isn't a valid election definition`

--- a/libs/auth/src/artifact_authentication.ts
+++ b/libs/auth/src/artifact_authentication.ts
@@ -13,9 +13,8 @@ import {
   throwIllegalValue,
 } from '@votingworks/basics';
 import {
-  CastVoteRecordExportMetadata,
   CastVoteRecordExportMetadataSchema,
-  unsafeParse,
+  safeParseJson,
 } from '@votingworks/types';
 
 import { computeCastVoteRecordRootHashFromScratch } from './cast_vote_record_hashes';
@@ -296,18 +295,26 @@ async function performArtifactSpecificAuthenticationChecks(
 ): Promise<void> {
   switch (artifact.type) {
     case 'cast_vote_records': {
-      const metadataFileContents = (
-        await fs.readFile(path.join(artifact.directoryPath, 'metadata.json'))
-      ).toString('utf-8');
-      const metadata: CastVoteRecordExportMetadata = unsafeParse(
-        CastVoteRecordExportMetadataSchema,
-        metadataFileContents
+      const metadataFileContents = await fs.readFile(
+        path.join(artifact.directoryPath, 'metadata.json'),
+        'utf-8'
       );
+      const parseResult = safeParseJson(
+        metadataFileContents,
+        CastVoteRecordExportMetadataSchema
+      );
+      if (parseResult.isErr()) {
+        throw new Error(
+          `Error parsing metadata file: ${parseResult.err().message}`
+        );
+      }
+      const metadata = parseResult.ok();
       const castVoteRecordRootHash =
         await computeCastVoteRecordRootHashFromScratch(artifact.directoryPath);
       assert(
         metadata.castVoteRecordRootHash === castVoteRecordRootHash,
-        "Cast vote record root hash in metadata file doesn't match recomputed hash"
+        `Cast vote record root hash in metadata file doesn't match recomputed hash: ` +
+          `${metadata.castVoteRecordRootHash} != ${castVoteRecordRootHash}`
       );
       break;
     }

--- a/libs/auth/src/live_check.ts
+++ b/libs/auth/src/live_check.ts
@@ -59,13 +59,12 @@ export class LiveCheck {
       signingPrivateKey: this.machinePrivateKey,
     });
 
-    const machineCert = await fs.readFile(this.machineCertPath);
+    const machineCert = await fs.readFile(this.machineCertPath, 'utf-8');
 
     const qrCodeValueParts: string[] = [
       message,
       messageSignature.toString('base64'),
       machineCert
-        .toString('utf-8')
         // Remove the standard PEM header and footer to make the QR code as small as possible
         .replace('-----BEGIN CERTIFICATE-----', '')
         .replace('-----END CERTIFICATE-----', ''),

--- a/libs/backend/src/cast_vote_records/import.ts
+++ b/libs/backend/src/cast_vote_records/import.ts
@@ -1,0 +1,268 @@
+/* istanbul ignore file */
+import { existsSync } from 'fs';
+import fs from 'fs/promises';
+import path from 'path';
+import { authenticateArtifactUsingSignatureFile } from '@votingworks/auth';
+import {
+  assertDefined,
+  AsyncIteratorPlus,
+  err,
+  iter,
+  ok,
+  Result,
+} from '@votingworks/basics';
+import {
+  CastVoteRecordExportMetadata,
+  CastVoteRecordExportMetadataSchema,
+  CVR,
+  safeParseJson,
+  safeParseNumber,
+} from '@votingworks/types';
+import {
+  BooleanEnvironmentVariableName,
+  CastVoteRecordWriteIn,
+  getCurrentSnapshot,
+  getWriteInsFromCastVoteRecord,
+  isCastVoteRecordWriteInValid,
+  isFeatureFlagEnabled,
+} from '@votingworks/utils';
+
+type ReadCastVoteRecordExportMetadataError =
+  | { type: 'metadata-file-not-found' }
+  | { type: 'metadata-file-parse-error' };
+
+/**
+ * An error encountered while reading an individual cast vote record
+ */
+export type ReadCastVoteRecordError = { type: 'invalid-cast-vote-record' } & (
+  | { subType: 'batch-id-not-found' }
+  | { subType: 'image-file-not-found' }
+  | { subType: 'invalid-ballot-image-field' }
+  | { subType: 'invalid-ballot-sheet-id' }
+  | { subType: 'invalid-write-in-field' }
+  | { subType: 'layout-file-not-found' }
+  | { subType: 'no-current-snapshot' }
+  | { subType: 'parse-error' }
+);
+
+/**
+ * A top-level error encountered while reading a cast vote record export. Does not include errors
+ * encountered while reading individual cast vote records.
+ */
+export type ReadCastVoteRecordExportError =
+  | ReadCastVoteRecordExportMetadataError
+  | { type: 'authentication-error' };
+
+interface ReferencedFiles {
+  imageFilePaths: [string, string]; // [front, back]
+  layoutFilePaths: [string, string]; // [front, back]
+}
+
+interface CastVoteRecordAndReferencedFiles {
+  castVoteRecord: CVR.CVR;
+  castVoteRecordBallotSheetId?: number;
+  castVoteRecordCurrentSnapshot: CVR.CVRSnapshot;
+  castVoteRecordWriteIns: CastVoteRecordWriteIn[];
+  referencedFiles?: ReferencedFiles;
+}
+
+interface CastVoteRecordExportContents {
+  castVoteRecordExportMetadata: CastVoteRecordExportMetadata;
+  castVoteRecords: AsyncIteratorPlus<
+    Result<CastVoteRecordAndReferencedFiles, ReadCastVoteRecordError>
+  >;
+}
+
+/**
+ * Reads and parses a cast vote record export's metadata file. Does *not* authenticate the export
+ * so should only be used if you're 1) handling authentication elsewhere or 2) using the metadata
+ * for a non-critical purpose like listing exports in a UI before import.
+ */
+export async function readCastVoteRecordExportMetadata(
+  exportDirectoryPath: string
+): Promise<
+  Result<CastVoteRecordExportMetadata, ReadCastVoteRecordExportMetadataError>
+> {
+  const metadataFilePath = path.join(exportDirectoryPath, 'metadata.json');
+  if (!existsSync(metadataFilePath)) {
+    return err({ type: 'metadata-file-not-found' });
+  }
+  const metadataFileContents = await fs.readFile(metadataFilePath, 'utf-8');
+  const parseResult = safeParseJson(
+    metadataFileContents,
+    CastVoteRecordExportMetadataSchema
+  );
+  if (parseResult.isErr()) {
+    return err({ type: 'metadata-file-parse-error' });
+  }
+  return parseResult;
+}
+
+async function* castVoteRecordGenerator(
+  exportDirectoryPath: string,
+  batchIds: Set<string>
+): AsyncGenerator<
+  Result<CastVoteRecordAndReferencedFiles, ReadCastVoteRecordError>
+> {
+  function wrapError(
+    error: Omit<ReadCastVoteRecordError, 'type'>
+  ): Result<CastVoteRecordAndReferencedFiles, ReadCastVoteRecordError> {
+    return err({ ...error, type: 'invalid-cast-vote-record' });
+  }
+
+  const castVoteRecordIds = (
+    await fs.readdir(exportDirectoryPath, { withFileTypes: true })
+  )
+    .filter((entry) => entry.isDirectory())
+    .map((directory) => directory.name);
+
+  for (const castVoteRecordId of castVoteRecordIds) {
+    const castVoteRecordDirectoryPath = path.join(
+      exportDirectoryPath,
+      castVoteRecordId
+    );
+    const castVoteRecordReport = await fs.readFile(
+      path.join(castVoteRecordDirectoryPath, 'cast-vote-record-report.json'),
+      'utf-8'
+    );
+    const parseResult = safeParseJson(
+      castVoteRecordReport,
+      CVR.CastVoteRecordReportSchema
+    );
+    if (parseResult.isErr()) {
+      yield wrapError({ subType: 'parse-error' });
+      return;
+    }
+    if (parseResult.ok().CVR?.length !== 1) {
+      yield wrapError({ subType: 'parse-error' });
+      return;
+    }
+    const castVoteRecord = assertDefined(parseResult.ok().CVR?.[0]);
+
+    if (!batchIds.has(castVoteRecord.BatchId)) {
+      yield wrapError({ subType: 'batch-id-not-found' });
+      return;
+    }
+
+    // Only relevant for HMPBs
+    let castVoteRecordBallotSheetId: number | undefined;
+    if (castVoteRecord.BallotSheetId) {
+      const parseBallotSheetIdResult = safeParseNumber(
+        castVoteRecord.BallotSheetId
+      );
+      if (parseResult.isErr()) {
+        yield wrapError({ subType: 'invalid-ballot-sheet-id' });
+        return;
+      }
+      castVoteRecordBallotSheetId = parseBallotSheetIdResult.ok();
+    }
+
+    const castVoteRecordCurrentSnapshot = getCurrentSnapshot(castVoteRecord);
+    if (!castVoteRecordCurrentSnapshot) {
+      yield wrapError({ subType: 'no-current-snapshot' });
+      return;
+    }
+
+    const castVoteRecordWriteIns =
+      getWriteInsFromCastVoteRecord(castVoteRecord);
+    if (!castVoteRecordWriteIns.every(isCastVoteRecordWriteInValid)) {
+      yield wrapError({ subType: 'invalid-write-in-field' });
+      return;
+    }
+
+    let referencedFiles: ReferencedFiles | undefined;
+    if (castVoteRecord.BallotImage) {
+      if (
+        castVoteRecord.BallotImage.length !== 2 ||
+        !castVoteRecord.BallotImage[0]?.Location?.startsWith('file:') ||
+        !castVoteRecord.BallotImage[1]?.Location?.startsWith('file:')
+      ) {
+        yield wrapError({ subType: 'invalid-ballot-image-field' });
+        return;
+      }
+      const ballotImageLocations: [string, string] = [
+        castVoteRecord.BallotImage[0].Location.replace('file:', ''),
+        castVoteRecord.BallotImage[1].Location.replace('file:', ''),
+      ];
+
+      const imageFilePaths = ballotImageLocations.map((location) =>
+        path.join(castVoteRecordDirectoryPath, location)
+      ) as [string, string];
+      const layoutFilePaths = ballotImageLocations.map((location) =>
+        path.join(
+          castVoteRecordDirectoryPath,
+          `${path.parse(location).name}.layout.json`
+        )
+      ) as [string, string];
+
+      if (!imageFilePaths.every((filePath) => existsSync(filePath))) {
+        yield wrapError({ subType: 'image-file-not-found' });
+        return;
+      }
+      if (!layoutFilePaths.every((filePath) => existsSync(filePath))) {
+        yield wrapError({ subType: 'layout-file-not-found' });
+        return;
+      }
+
+      referencedFiles = { imageFilePaths, layoutFilePaths };
+    }
+
+    yield ok({
+      castVoteRecord,
+      castVoteRecordBallotSheetId,
+      castVoteRecordCurrentSnapshot,
+      castVoteRecordWriteIns,
+      referencedFiles,
+    });
+  }
+}
+
+/**
+ * Reads and parses a cast vote record export, authenticating the export in the process. The
+ * export's metadata file is parsed upfront whereas the cast vote records are parsed lazily.
+ *
+ * Basic validation is performed on the cast vote records. Referenced image files and layout files
+ * are not read/parsed, but their existence is validated such that consumers can safely access
+ * them.
+ */
+export async function readCastVoteRecordExport(
+  exportDirectoryPath: string
+): Promise<
+  Result<CastVoteRecordExportContents, ReadCastVoteRecordExportError>
+> {
+  const authenticationResult = await authenticateArtifactUsingSignatureFile({
+    type: 'cast_vote_records',
+    context: 'import',
+    directoryPath: exportDirectoryPath,
+  });
+  if (
+    authenticationResult.isErr() &&
+    !isFeatureFlagEnabled(
+      BooleanEnvironmentVariableName.SKIP_CAST_VOTE_RECORDS_AUTHENTICATION
+    )
+  ) {
+    return err({ type: 'authentication-error' });
+  }
+
+  const metadataResult = await readCastVoteRecordExportMetadata(
+    exportDirectoryPath
+  );
+  if (metadataResult.isErr()) {
+    return metadataResult;
+  }
+  const castVoteRecordExportMetadata = metadataResult.ok();
+
+  const batchIds = new Set(
+    castVoteRecordExportMetadata.castVoteRecordReportMetadata.vxBatch.map(
+      (batch) => batch['@id']
+    )
+  );
+  const castVoteRecords = iter(
+    castVoteRecordGenerator(exportDirectoryPath, batchIds)
+  );
+
+  return ok({
+    castVoteRecordExportMetadata,
+    castVoteRecords,
+  });
+}

--- a/libs/backend/src/cast_vote_records/index.ts
+++ b/libs/backend/src/cast_vote_records/index.ts
@@ -2,5 +2,6 @@
 export { buildCVRContestsFromVotes } from './build_cast_vote_record';
 export { buildCastVoteRecordReportMetadata } from './build_report_metadata';
 export * from './export';
+export * from './import';
 export * from './legacy_export';
 export * from './legacy_import';

--- a/libs/utils/src/filenames.test.ts
+++ b/libs/utils/src/filenames.test.ts
@@ -20,6 +20,8 @@ import {
   generateCastVoteRecordReportDirectoryName,
   parseCastVoteRecordReportDirectoryName,
   generateCastVoteRecordExportDirectoryName,
+  CastVoteRecordExportDirectoryNameComponents,
+  parseCastVoteRecordReportExportDirectoryName,
 } from './filenames';
 
 describe('parseBallotExportPackageInfoFromFilename', () => {
@@ -186,39 +188,6 @@ describe('generateCastVoteRecordReportDirectoryName', () => {
     );
   });
 });
-
-test.each<{
-  inTestMode: boolean;
-  machineId: string;
-  time: Date;
-  expectedDirectoryName: string;
-}>([
-  {
-    inTestMode: true,
-    machineId: 'SCAN-0001',
-    time: new Date(2023, 7, 16, 17, 2, 24),
-    expectedDirectoryName: 'TEST__machine_SCAN-0001__2023-08-16_17-02-24',
-  },
-  {
-    inTestMode: false,
-    machineId: 'SCAN-0001',
-    time: new Date(2023, 7, 16, 17, 2, 24),
-    expectedDirectoryName: 'machine_SCAN-0001__2023-08-16_17-02-24',
-  },
-  {
-    inTestMode: true,
-    machineId: '<3-u!n#icorn<3',
-    time: new Date(2023, 7, 16, 17, 2, 24),
-    expectedDirectoryName: 'TEST__machine_3unicorn3__2023-08-16_17-02-24',
-  },
-])(
-  'generateCastVoteRecordExportDirectoryName',
-  ({ expectedDirectoryName, ...input }) => {
-    expect(generateCastVoteRecordExportDirectoryName(input)).toEqual(
-      expectedDirectoryName
-    );
-  }
-);
 
 test('generates ballot export package names as expected with simple inputs', () => {
   const mockElection: ElectionDefinition = {
@@ -600,3 +569,110 @@ test('generateLogFilename', () => {
     )
   );
 });
+
+test.each<{
+  input: CastVoteRecordExportDirectoryNameComponents;
+  expectedDirectoryName: string;
+}>([
+  {
+    input: {
+      inTestMode: true,
+      machineId: 'SCAN-0001',
+      time: new Date(2023, 7, 16, 17, 2, 24),
+    },
+    expectedDirectoryName: 'TEST__machine_SCAN-0001__2023-08-16_17-02-24',
+  },
+  {
+    input: {
+      inTestMode: false,
+      machineId: 'SCAN-0001',
+      time: new Date(2023, 7, 16, 17, 2, 24),
+    },
+    expectedDirectoryName: 'machine_SCAN-0001__2023-08-16_17-02-24',
+  },
+  {
+    input: {
+      inTestMode: true,
+      machineId: '<3-u!n#icorn<3',
+      time: new Date(2023, 7, 16, 17, 2, 24),
+    },
+    expectedDirectoryName: 'TEST__machine_3unicorn3__2023-08-16_17-02-24',
+  },
+])(
+  'generateCastVoteRecordExportDirectoryName',
+  ({ input, expectedDirectoryName }) => {
+    expect(generateCastVoteRecordExportDirectoryName(input)).toEqual(
+      expectedDirectoryName
+    );
+  }
+);
+
+test.each<{
+  directoryName: string;
+  expectedDirectoryNameComponents?: CastVoteRecordExportDirectoryNameComponents;
+}>([
+  {
+    directoryName: 'TEST__machine_SCAN-0001__2023-08-16_17-02-24',
+    expectedDirectoryNameComponents: {
+      inTestMode: true,
+      machineId: 'SCAN-0001',
+      time: new Date(2023, 7, 16, 17, 2, 24),
+    },
+  },
+  {
+    directoryName: 'machine_SCAN-0001__2023-08-16_17-02-24',
+    expectedDirectoryNameComponents: {
+      inTestMode: false,
+      machineId: 'SCAN-0001',
+      time: new Date(2023, 7, 16, 17, 2, 24),
+    },
+  },
+  {
+    directoryName:
+      'TEST__machine_SCAN-0001__2023-08-16_17-02-24__extra-section',
+    expectedDirectoryNameComponents: undefined,
+  },
+  {
+    directoryName: 'machine_SCAN-0001__2023-08-16_17-02-24__extra-section',
+    expectedDirectoryNameComponents: undefined,
+  },
+  {
+    directoryName: 'TEST__machine_SCAN-0001', // Missing time section
+    expectedDirectoryNameComponents: undefined,
+  },
+  {
+    directoryName: 'machine_SCAN-0001', // Missing time section
+    expectedDirectoryNameComponents: undefined,
+  },
+  {
+    directoryName: 'TEST__SCAN-0001__2023-08-16_17-02-24', // Missing machine_ prefix
+    expectedDirectoryNameComponents: undefined,
+  },
+  {
+    directoryName: 'SCAN-0001__2023-08-16_17-02-24', // Missing machine_ prefix
+    expectedDirectoryNameComponents: undefined,
+  },
+  {
+    directoryName: 'TEST__wrong-prefix_SCAN-0001__2023-08-16_17-02-24',
+    expectedDirectoryNameComponents: undefined,
+  },
+  {
+    directoryName: 'wrong-prefix_SCAN-0001__2023-08-16_17-02-24',
+    expectedDirectoryNameComponents: undefined,
+  },
+  {
+    directoryName: 'TEST__machine_SCAN-0001__invalid-time',
+    expectedDirectoryNameComponents: undefined,
+  },
+  {
+    directoryName: 'machine_SCAN-0001__invalid-time',
+    expectedDirectoryNameComponents: undefined,
+  },
+])(
+  'parseCastVoteRecordReportExportDirectoryName',
+  ({ directoryName, expectedDirectoryNameComponents }) => {
+    expect(parseCastVoteRecordReportExportDirectoryName(directoryName)).toEqual(
+      expectedDirectoryNameComponents
+    );
+  }
+);


### PR DESCRIPTION
_Easiest reviewed by commit_

## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/3926

This PR completes the end-to-end wiring of continuous export! It specifically updates VxAdmin to support importing the new CVR export format. The user experience is unchanged by this PR. Just a lot of under-the-hood tweaks.

All of the new logic is feature flag gated. Once I merge this PR, I'll work on pruning the feature flag and old CVR export/import logic.

## Testing

- [x] Tested CVR export and import manually
- [x] Updated some unit tests

I've mostly punted on automated tests, which I'll add in follow-up PRs, since this PR is large enough as is.

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced