### PR TITLE
Drew/libs usb logging

### DIFF
--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -232,6 +232,8 @@ test('usbDrive', async () => {
   const { electionDefinition } = electionTwoPartyPrimaryFixtures;
   await configureMachine(apiClient, auth, electionDefinition);
 
+  mockSystemAdministratorAuth(auth);
+
   usbDrive.status.expectCallWith().resolves({ status: 'no_drive' });
   expect(await apiClient.getUsbDriveStatus()).toEqual({
     status: 'no_drive',
@@ -245,13 +247,13 @@ test('usbDrive', async () => {
     reason: 'bad_format',
   });
 
-  usbDrive.eject.expectCallWith().resolves();
+  usbDrive.eject.expectCallWith('system_administrator').resolves();
   await apiClient.ejectUsbDrive();
 
-  usbDrive.format.expectCallWith().resolves();
+  usbDrive.format.expectCallWith('system_administrator').resolves();
   (await apiClient.formatUsbDrive()).assertOk('format failed');
 
   const error = new Error('format failed');
-  usbDrive.format.expectCallWith().throws(error);
+  usbDrive.format.expectCallWith('system_administrator').throws(error);
   expect(await apiClient.formatUsbDrive()).toEqual(err(error));
 });

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -202,13 +202,13 @@ function buildApi({
       return usbDrive.status();
     },
 
-    ejectUsbDrive(): Promise<void> {
-      return usbDrive.eject();
+    async ejectUsbDrive(): Promise<void> {
+      return usbDrive.eject(assertDefined(await getUserRole()));
     },
 
     async formatUsbDrive(): Promise<Result<void, Error>> {
       try {
-        await usbDrive.format();
+        await usbDrive.format(assertDefined(await getUserRole()));
         return ok();
       } catch (error) {
         return err(error as Error);

--- a/apps/admin/backend/src/server.ts
+++ b/apps/admin/backend/src/server.ts
@@ -62,7 +62,7 @@ export async function start({
   /* c8 ignore start */
   const resolvedUsbDrive =
     usbDrive ??
-    (isIntegrationTest() ? new MockFileUsbDrive() : detectUsbDrive());
+    (isIntegrationTest() ? new MockFileUsbDrive() : detectUsbDrive(logger));
   /* c8 ignore stop */
 
   let resolvedApp = app;

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -98,8 +98,13 @@ function buildApi(
       return usbDrive.status();
     },
 
-    ejectUsbDrive(): Promise<void> {
-      return usbDrive.eject();
+    async ejectUsbDrive(): Promise<void> {
+      const authStatus = await auth.getAuthStatus(
+        constructAuthMachineState(workspace)
+      );
+      return usbDrive.eject(
+        authStatus.status === 'logged_in' ? authStatus.user.role : 'unknown'
+      );
     },
 
     async configureFromBallotPackageOnUsbDrive(): Promise<

--- a/apps/scan/backend/src/app_usb_drive.test.ts
+++ b/apps/scan/backend/src/app_usb_drive.test.ts
@@ -17,7 +17,7 @@ test('getUsbDriveStatus', async () => {
 
 test('ejectUsbDrive', async () => {
   await withApp({}, async ({ apiClient, mockUsbDrive }) => {
-    mockUsbDrive.usbDrive.eject.expectCallWith().resolves();
+    mockUsbDrive.usbDrive.eject.expectCallWith('unknown').resolves();
     await expect(apiClient.ejectUsbDrive()).resolves.toBeUndefined();
   });
 });

--- a/apps/scan/backend/src/index.ts
+++ b/apps/scan/backend/src/index.ts
@@ -56,7 +56,7 @@ async function resolveWorkspace(): Promise<Workspace> {
 
 async function main(): Promise<number> {
   const workspace = await resolveWorkspace();
-  const usbDrive = detectUsbDrive();
+  const usbDrive = detectUsbDrive(logger);
 
   const precinctScannerStateMachine =
     customStateMachine.createPrecinctScannerStateMachine({
@@ -70,6 +70,7 @@ async function main(): Promise<number> {
     precinctScannerStateMachine,
     workspace,
     usbDrive,
+    logger,
   });
 
   return 0;

--- a/apps/scan/backend/src/server.ts
+++ b/apps/scan/backend/src/server.ts
@@ -49,7 +49,7 @@ export function start({
     });
   /* c8 ignore stop */
 
-  const resolvedUsbDrive = usbDrive ?? detectUsbDrive();
+  const resolvedUsbDrive = usbDrive ?? detectUsbDrive(logger);
 
   // Clear any cached data
   workspace.clearUploads();

--- a/libs/usb-drive/jest.config.js
+++ b/libs/usb-drive/jest.config.js
@@ -5,4 +5,5 @@ const shared = require('../../jest.config.shared');
  */
 module.exports = {
   ...shared,
+  coveragePathIgnorePatterns: ['src/cli.ts'],
 };

--- a/libs/usb-drive/package.json
+++ b/libs/usb-drive/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@votingworks/basics": "workspace:*",
+    "@votingworks/logging": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
     "debug": "^4.3.2",
     "tmp": "^0.2.1"

--- a/libs/usb-drive/src/cli.ts
+++ b/libs/usb-drive/src/cli.ts
@@ -1,5 +1,6 @@
 /* istanbul ignore file */
 import { sleep } from '@votingworks/basics';
+import { Logger, LogSource } from '@votingworks/logging';
 import { detectUsbDrive, UsbDrive } from './usb_drive';
 
 async function printStatus(usbDrive: UsbDrive, stdout: NodeJS.WriteStream) {
@@ -20,20 +21,20 @@ const USAGE = `Usage: usb-drive status|eject|format|watch\n`;
 export async function main(args: string[]): Promise<number> {
   const { stdout, stderr } = process;
   const command = args[2];
-  const usbDrive = detectUsbDrive();
+  const usbDrive = detectUsbDrive(new Logger(LogSource.System));
   switch (command) {
     case 'status': {
       await printStatus(usbDrive, stdout);
       break;
     }
     case 'eject': {
-      await usbDrive.eject();
+      await usbDrive.eject('election_manager');
       stdout.write('Ejected\n');
       await printStatus(usbDrive, stdout);
       break;
     }
     case 'format': {
-      await usbDrive.format();
+      await usbDrive.format('system_administrator');
       stdout.write('Formatted\n');
       await printStatus(usbDrive, stdout);
       break;

--- a/libs/usb-drive/src/usb_drive.test.ts
+++ b/libs/usb-drive/src/usb_drive.test.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'fs';
 import { deferred } from '@votingworks/basics';
 import { backendWaitFor } from '@votingworks/test-utils';
 import { join } from 'path';
+import { LogEventId, fakeLogger } from '@votingworks/logging';
 import {
   BlockDeviceInfo,
   VX_USB_LABEL_REGEXP,
@@ -48,7 +49,8 @@ function lsblkOutput(device: Partial<BlockDeviceInfo> = {}) {
 
 describe('status', () => {
   test('no drive', async () => {
-    const usbDrive = detectUsbDrive();
+    const logger = fakeLogger();
+    const usbDrive = detectUsbDrive(logger);
 
     readdirMock.mockResolvedValueOnce([]);
 
@@ -60,7 +62,8 @@ describe('status', () => {
   });
 
   test('one drive, mounted', async () => {
-    const usbDrive = detectUsbDrive();
+    const logger = fakeLogger();
+    const usbDrive = detectUsbDrive(logger);
 
     readdirMock.mockResolvedValueOnce(['usb-foobar-part23']);
     readlinkMock.mockResolvedValueOnce('../../sdb1');
@@ -89,7 +92,8 @@ describe('status', () => {
   });
 
   test('one drive, unmounted', async () => {
-    const usbDrive = detectUsbDrive();
+    const logger = fakeLogger();
+    const usbDrive = detectUsbDrive(logger);
 
     readdirMock.mockResolvedValue(['usb-foobar-part23']);
     readlinkMock.mockResolvedValue('../../sdb1');
@@ -132,10 +136,24 @@ describe('status', () => {
       ['NAME', 'MOUNTPOINT', 'FSTYPE', 'FSVER', 'LABEL'].join(','),
       '/dev/sdb1',
     ]);
+
+    // check logging
+    expect(logger.log).toHaveBeenNthCalledWith(
+      1,
+      LogEventId.UsbDriveMountInit,
+      'system'
+    );
+    expect(logger.log).toHaveBeenNthCalledWith(
+      2,
+      LogEventId.UsbDriveMounted,
+      'system',
+      expect.objectContaining({ disposition: 'success' })
+    );
   });
 
   test('multiple usb devices', async () => {
-    const usbDrive = detectUsbDrive();
+    const logger = fakeLogger();
+    const usbDrive = detectUsbDrive(logger);
 
     readdirMock.mockResolvedValue([
       'notausb-bazbar-part21', // Should be ignored
@@ -154,7 +172,8 @@ describe('status', () => {
   });
 
   test('error getting block device info', async () => {
-    const usbDrive = detectUsbDrive();
+    const logger = fakeLogger();
+    const usbDrive = detectUsbDrive(logger);
 
     readdirMock.mockResolvedValueOnce(['usb-foobar-part23']);
     readlinkMock.mockResolvedValueOnce('../../sdb1');
@@ -166,7 +185,8 @@ describe('status', () => {
   });
 
   test('bad format', async () => {
-    const usbDrive = detectUsbDrive();
+    const logger = fakeLogger();
+    const usbDrive = detectUsbDrive(logger);
 
     readdirMock.mockResolvedValue(['usb-foobar-part23']);
     readlinkMock.mockResolvedValue('../../sdb1');
@@ -192,6 +212,30 @@ describe('status', () => {
       reason: 'bad_format',
     });
   });
+
+  test('fails to mount', async () => {
+    const logger = fakeLogger();
+    const usbDrive = detectUsbDrive(logger);
+
+    readdirMock.mockResolvedValue(['usb-foobar-part23']);
+    readlinkMock.mockResolvedValue('../../sdb1');
+    // Initial status
+    execMock.mockResolvedValueOnce(lsblkOutput({ mountpoint: null }));
+    // Mount
+    execMock.mockRejectedValueOnce(new Error('Failed'));
+
+    // While mounting, status is 'no_drive'
+    await expect(usbDrive.status()).resolves.toEqual({ status: 'no_drive' });
+
+    // check logging
+    await backendWaitFor(() => {
+      expect(logger.log).toHaveBeenCalledWith(
+        LogEventId.UsbDriveMounted,
+        'system',
+        expect.objectContaining({ disposition: 'failure' })
+      );
+    });
+  });
 });
 
 function mockBlockDeviceOnce(device: Partial<BlockDeviceInfo> = {}): void {
@@ -202,30 +246,33 @@ function mockBlockDeviceOnce(device: Partial<BlockDeviceInfo> = {}): void {
 
 describe('eject', () => {
   test('no drive - no op', async () => {
-    const usbDrive = detectUsbDrive();
+    const logger = fakeLogger();
+    const usbDrive = detectUsbDrive(logger);
 
     readdirMock.mockResolvedValueOnce([]);
 
-    await expect(usbDrive.eject()).resolves.toBeUndefined();
+    await expect(usbDrive.eject('election_manager')).resolves.toBeUndefined();
   });
 
   test('not mounted - no op', async () => {
-    const usbDrive = detectUsbDrive();
+    const logger = fakeLogger();
+    const usbDrive = detectUsbDrive(logger);
 
     mockBlockDeviceOnce({ mountpoint: null });
 
-    await expect(usbDrive.eject()).resolves.toBeUndefined();
+    await expect(usbDrive.eject('election_manager')).resolves.toBeUndefined();
   });
 
   test('mounted', async () => {
-    const usbDrive = detectUsbDrive();
+    const logger = fakeLogger();
+    const usbDrive = detectUsbDrive(logger);
 
     mockBlockDeviceOnce({ mountpoint: '/media/usb-drive-sdb1' });
 
     // Unmount
     execMock.mockResolvedValueOnce({ stdout: '' });
 
-    await expect(usbDrive.eject()).resolves.toBeUndefined();
+    await expect(usbDrive.eject('election_manager')).resolves.toBeUndefined();
 
     expect(execMock).toHaveBeenNthCalledWith(2, 'sudo', [
       '-n',
@@ -249,26 +296,63 @@ describe('eject', () => {
       mountPoint: '/media/vx/usb-drive',
       deviceName: 'sdb1',
     });
+
+    // check logging
+    expect(logger.log).toHaveBeenNthCalledWith(
+      1,
+      LogEventId.UsbDriveEjectInit,
+      'election_manager'
+    );
+    expect(logger.log).toHaveBeenNthCalledWith(
+      2,
+      LogEventId.UsbDriveEjected,
+      'election_manager',
+      expect.objectContaining({ disposition: 'success' })
+    );
+  });
+
+  test('fails to eject', async () => {
+    const logger = fakeLogger();
+    const usbDrive = detectUsbDrive(logger);
+
+    mockBlockDeviceOnce({ mountpoint: '/media/usb-drive-sdb1' });
+
+    // Unmount
+    execMock.mockRejectedValueOnce(new Error('Failed'));
+
+    await expect(usbDrive.eject('election_manager')).rejects.toThrowError(
+      new Error('Failed')
+    );
+
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.UsbDriveEjected,
+      'election_manager',
+      expect.objectContaining({ disposition: 'failure' })
+    );
   });
 });
 
 describe('format', () => {
   test('no drive - no op', async () => {
-    const usbDrive = detectUsbDrive();
+    const logger = fakeLogger();
+    const usbDrive = detectUsbDrive(logger);
     readdirMock.mockResolvedValueOnce([]);
 
-    await expect(usbDrive.format()).resolves.toBeUndefined();
+    await expect(
+      usbDrive.format('system_administrator')
+    ).resolves.toBeUndefined();
     expect(execMock).not.toHaveBeenCalled();
   });
 
   test('on mounted, previously formatted drive', async () => {
-    const usbDrive = detectUsbDrive();
+    const logger = fakeLogger();
+    const usbDrive = detectUsbDrive(logger);
     mockBlockDeviceOnce({ mountpoint: '/media/usb-drive-sdb1' });
     execMock.mockResolvedValueOnce({ stdout: '' }); // unmount
     execMock.mockResolvedValueOnce({ stdout: '' }); // format
 
     // format should call unmount and format scripts
-    await usbDrive.format();
+    await usbDrive.format('system_administrator');
     expect(execMock).toHaveBeenNthCalledWith(2, 'sudo', [
       '-n',
       `${MOUNT_SCRIPT_PATH}/unmount.sh`,
@@ -284,15 +368,29 @@ describe('format', () => {
     // status should be ejected
     mockBlockDeviceOnce({ mountpoint: null });
     await expect(usbDrive.status()).resolves.toEqual({ status: 'ejected' });
+
+    // check logging
+    expect(logger.log).toHaveBeenNthCalledWith(
+      1,
+      LogEventId.UsbDriveFormatInit,
+      'system_administrator'
+    );
+    expect(logger.log).toHaveBeenNthCalledWith(
+      2,
+      LogEventId.UsbDriveFormatted,
+      'system_administrator',
+      expect.objectContaining({ disposition: 'success' })
+    );
   });
 
   test('on bad format drive', async () => {
-    const usbDrive = detectUsbDrive();
+    const logger = fakeLogger();
+    const usbDrive = detectUsbDrive(logger);
     mockBlockDeviceOnce({ fstype: 'exfat', mountpoint: null, label: 'DATA' });
     execMock.mockResolvedValueOnce({ stdout: '' }); // format
 
     // format should call format script only
-    await usbDrive.format();
+    await usbDrive.format('system_administrator');
     expect(execMock).toHaveBeenNthCalledWith(2, 'sudo', [
       '-n',
       `${MOUNT_SCRIPT_PATH}/format_fat32.sh`,
@@ -306,20 +404,31 @@ describe('format', () => {
   });
 
   test('on format failure', async () => {
-    const usbDrive = detectUsbDrive();
+    const logger = fakeLogger();
+    const usbDrive = detectUsbDrive(logger);
     mockBlockDeviceOnce({ fstype: 'unknown', mountpoint: null, label: null });
     execMock.mockRejectedValueOnce(new Error('Command: failed')); // format
 
     // format should call format script only
-    await expect(usbDrive.format()).rejects.toThrow('Command: failed');
+    await expect(usbDrive.format('system_administrator')).rejects.toThrow(
+      'Command: failed'
+    );
 
     // status should be ejected
     mockBlockDeviceOnce({ mountpoint: null });
     await expect(usbDrive.status()).resolves.toEqual({ status: 'ejected' });
+
+    // check logging
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.UsbDriveFormatted,
+      'system_administrator',
+      expect.objectContaining({ disposition: 'failure' })
+    );
   });
 
   test('status polling while formatting', async () => {
-    const usbDrive = detectUsbDrive();
+    const logger = fakeLogger();
+    const usbDrive = detectUsbDrive(logger);
     mockBlockDeviceOnce({ mountpoint: '/media/usb-drive-sdb1' });
     execMock.mockResolvedValueOnce({ stdout: '' }); // unmount
     const { promise: formatScriptPromise, resolve: formatScriptResolve } =
@@ -328,7 +437,7 @@ describe('format', () => {
       }>();
     execMock.mockReturnValueOnce(formatScriptPromise); // format
 
-    const formatPromise = usbDrive.format();
+    const formatPromise = usbDrive.format('system_administrator');
 
     await backendWaitFor(async () => {
       expect(await usbDrive.status()).toEqual({ status: 'ejected' });

--- a/libs/usb-drive/tsconfig.build.json
+++ b/libs/usb-drive/tsconfig.build.json
@@ -12,6 +12,7 @@
   "references": [
     { "path": "../basics/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
+    { "path": "../logging/tsconfig.build.json" },
     { "path": "../test-utils/tsconfig.build.json" }
   ]
 }

--- a/libs/usb-drive/tsconfig.json
+++ b/libs/usb-drive/tsconfig.json
@@ -13,6 +13,7 @@
   "references": [
     { "path": "../basics/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
+    { "path": "../logging/tsconfig.build.json" },
     { "path": "../test-utils/tsconfig.build.json" }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5407,6 +5407,9 @@ importers:
       '@votingworks/basics':
         specifier: workspace:*
         version: link:../basics
+      '@votingworks/logging':
+        specifier: workspace:*
+        version: link:../logging
       '@votingworks/test-utils':
         specifier: workspace:*
         version: link:../test-utils


### PR DESCRIPTION
## Overview

Closes #3949. Adds logging to `libs/usb-drive`. Copies logging mostly verbatim from `use_usb_drive.ts`. For mounting, ejecting, and formatting we log an "init" event and then a success or failure "complete" event. 

## Testing Plan
Added logging testing.

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.

