### PR TITLE
Kevin/vxmarkscan alert pollworker after invalidate

### DIFF
--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -226,6 +226,12 @@ function buildApi(
       debug('API invalidate');
       stateMachine.invalidateBallot();
     },
+
+    confirmInvalidateBallot(): void {
+      assert(stateMachine);
+
+      stateMachine.confirmInvalidateBallot();
+    },
   });
 }
 

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -442,7 +442,8 @@ export function buildMachine(
       invalidating_ballot: {
         on: {
           CONFIRM_INVALIDATE_BALLOT: 'eject_to_front',
-          NO_PAPER_ANYWHERE: 'resetting_state_machine_after_success',
+          // Even if ballot is removed from front, we still want the frontend to require pollworker auth before continuing
+          NO_PAPER_ANYWHERE: undefined,
         },
       },
       // Eject-to-rear jam handling is a little clunky. It

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -434,16 +434,15 @@ export function buildMachine(
         },
         on: {
           VOTER_VALIDATED_BALLOT: 'eject_to_rear',
-          // VOTER_INVALIDATED_BALLOT: 'eject_to_front',
           VOTER_INVALIDATED_BALLOT: 'invalidating_ballot',
+          NO_PAPER_ANYWHERE: 'resetting_state_machine_after_success',
         },
       },
+      // Ballot invalidation is a 2-stage process so the frontend can prompt the voter to get a pollworker
       invalidating_ballot: {
-        entry: async (context) => {
-          await context.driver.presentPaper();
-        },
         on: {
           CONFIRM_INVALIDATE_BALLOT: 'eject_to_front',
+          NO_PAPER_ANYWHERE: 'resetting_state_machine_after_success',
         },
       },
       // Eject-to-rear jam handling is a little clunky. It

--- a/apps/mark-scan/backend/src/custom-paper-handler/types.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/types.ts
@@ -1,36 +1,38 @@
 import { z } from 'zod';
 
 export type SimpleStatus =
-  | 'not_accepting_paper'
   | 'accepting_paper'
-  | 'loading_paper'
-  | 'waiting_for_ballot_data'
-  | 'printing_ballot'
-  | 'presenting_ballot'
-  | 'scanning'
-  | 'interpreting'
   | 'ejecting_to_front'
   | 'ejecting_to_rear'
-  | 'jammed'
+  | 'interpreting'
+  | 'invalidating_ballot'
   | 'jam_cleared'
+  | 'jammed'
+  | 'loading_paper'
+  | 'not_accepting_paper'
+  | 'presenting_ballot'
+  | 'printing_ballot'
   | 'resetting_state_machine_after_jam'
-  | 'resetting_state_machine_after_success';
+  | 'resetting_state_machine_after_success'
+  | 'scanning'
+  | 'waiting_for_ballot_data';
 
 export const SimpleStatusSchema: z.ZodSchema<SimpleStatus> = z.union([
-  z.literal('not_accepting_paper'),
   z.literal('accepting_paper'),
-  z.literal('loading_paper'),
-  z.literal('waiting_for_ballot_data'),
-  z.literal('presenting_ballot'),
-  z.literal('printing_ballot'),
-  z.literal('scanning'),
-  z.literal('interpreting'),
   z.literal('ejecting_to_front'),
   z.literal('ejecting_to_rear'),
-  z.literal('jammed'),
+  z.literal('interpreting'),
+  z.literal('invalidating_ballot'),
   z.literal('jam_cleared'),
+  z.literal('jammed'),
+  z.literal('loading_paper'),
+  z.literal('not_accepting_paper'),
+  z.literal('presenting_ballot'),
+  z.literal('printing_ballot'),
   z.literal('resetting_state_machine_after_jam'),
   z.literal('resetting_state_machine_after_success'),
+  z.literal('scanning'),
+  z.literal('waiting_for_ballot_data'),
 ]);
 
 export type SimpleServerStatus = SimpleStatus | 'no_hardware';

--- a/apps/mark-scan/backend/src/custom-paper-handler/types.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/types.ts
@@ -5,7 +5,7 @@ export type SimpleStatus =
   | 'ejecting_to_front'
   | 'ejecting_to_rear'
   | 'interpreting'
-  | 'invalidating_ballot'
+  | 'waiting_for_invalidated_ballot_confirmation'
   | 'jam_cleared'
   | 'jammed'
   | 'loading_paper'
@@ -22,7 +22,7 @@ export const SimpleStatusSchema: z.ZodSchema<SimpleStatus> = z.union([
   z.literal('ejecting_to_front'),
   z.literal('ejecting_to_rear'),
   z.literal('interpreting'),
-  z.literal('invalidating_ballot'),
+  z.literal('waiting_for_invalidated_ballot_confirmation'),
   z.literal('jam_cleared'),
   z.literal('jammed'),
   z.literal('loading_paper'),

--- a/apps/mark-scan/frontend/src/api.ts
+++ b/apps/mark-scan/frontend/src/api.ts
@@ -281,3 +281,16 @@ export const invalidateBallot = {
     });
   },
 } as const;
+
+export const confirmInvalidateBallot = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.confirmInvalidateBallot, {
+      async onSuccess() {
+        await queryClient.invalidateQueries(getStateMachineState.queryKey());
+        await queryClient.invalidateQueries(getInterpretation.queryKey());
+      },
+    });
+  },
+} as const;

--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -700,7 +700,7 @@ export function AppRoot({
     if (
       isPollWorkerAuth(authStatus) &&
       // Ballot invalidation requires BallotContext, handled below
-      stateMachineState !== 'invalidating_ballot'
+      stateMachineState !== 'waiting_for_invalidated_ballot_confirmation'
     ) {
       return (
         <PollWorkerScreen
@@ -737,7 +737,7 @@ export function AppRoot({
         isCardlessVoterAuth(authStatus) ||
         // Special case poll worker auth because both poll worker auth and BallotContext are needed to invalidate the ballot
         (isPollWorkerAuth(authStatus) &&
-          stateMachineState === 'invalidating_ballot')
+          stateMachineState === 'waiting_for_invalidated_ballot_confirmation')
       ) {
         let ballotContextProviderChild = <Ballot />;
 
@@ -747,7 +747,9 @@ export function AppRoot({
         if (stateMachineState === 'presenting_ballot') {
           ballotContextProviderChild = <ValidateBallotPage />;
         }
-        if (stateMachineState === 'invalidating_ballot') {
+        if (
+          stateMachineState === 'waiting_for_invalidated_ballot_confirmation'
+        ) {
           ballotContextProviderChild = (
             <BallotInvalidatedPage authStatus={authStatus} />
           );

--- a/apps/mark-scan/frontend/src/app_states.test.tsx
+++ b/apps/mark-scan/frontend/src/app_states.test.tsx
@@ -92,3 +92,24 @@ test('`resetting_state_machine_after_jam` state renders jam cleared page', async
   await screen.findByText('Jam Cleared');
   screen.getByText(/The hardware has been reset/);
 });
+
+test('`invalidating_ballot` state renders ballot invalidation page', async () => {
+  const hardware = MemoryHardware.buildStandard();
+  const storage = new MemoryStorage();
+  await setElectionInStorage(storage);
+  await setStateInStorage(storage);
+  apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
+  apiMock.setPaperHandlerState('invalidating_ballot');
+
+  render(
+    <App
+      hardware={hardware}
+      storage={storage}
+      apiClient={apiMock.mockApiClient}
+      reload={jest.fn()}
+    />
+  );
+
+  await screen.findByText('Ballot Invalidated');
+  screen.getByText(/You have indicated your ballot needs changes./);
+});

--- a/apps/mark-scan/frontend/src/app_states.test.tsx
+++ b/apps/mark-scan/frontend/src/app_states.test.tsx
@@ -124,6 +124,5 @@ test('`invalidating_ballot` state renders ballot invalidation page', async () =>
     ballotStyleId: electionDefinition.election.ballotStyles[0].id,
     precinctId: electionDefinition.election.precincts[0].id,
   });
-  await screen.findByText('Ballot Invalidated');
-  screen.getByText(/You have indicated your ballot needs changes./);
+  await screen.findByText('Ask a Poll Worker for Help');
 });

--- a/apps/mark-scan/frontend/src/app_states.test.tsx
+++ b/apps/mark-scan/frontend/src/app_states.test.tsx
@@ -94,7 +94,7 @@ test('`resetting_state_machine_after_jam` state renders jam cleared page', async
   screen.getByText(/The hardware has been reset/);
 });
 
-test('`invalidating_ballot` state renders ballot invalidation page with cardless voter auth', async () => {
+test('`waiting_for_invalidated_ballot_confirmation` state renders ballot invalidation page with cardless voter auth', async () => {
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
   await setElectionInStorage(storage);
@@ -119,7 +119,7 @@ test('`invalidating_ballot` state renders ballot invalidation page with cardless
   );
   await screen.findByText(hasTextAcrossElements('Polls: Open'));
 
-  apiMock.setPaperHandlerState('invalidating_ballot');
+  apiMock.setPaperHandlerState('waiting_for_invalidated_ballot_confirmation');
   apiMock.setAuthStatusCardlessVoterLoggedIn({
     ballotStyleId: electionDefinition.election.ballotStyles[0].id,
     precinctId: electionDefinition.election.precincts[0].id,
@@ -127,7 +127,7 @@ test('`invalidating_ballot` state renders ballot invalidation page with cardless
   await screen.findByText('Ask a Poll Worker for Help');
 });
 
-test('`invalidating_ballot` state renders ballot invalidation page with poll worker auth', async () => {
+test('`waiting_for_invalidated_ballot_confirmation` state renders ballot invalidation page with poll worker auth', async () => {
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
   await setElectionInStorage(storage);
@@ -152,7 +152,7 @@ test('`invalidating_ballot` state renders ballot invalidation page with poll wor
   );
   await screen.findByText(hasTextAcrossElements('Polls: Open'));
 
-  apiMock.setPaperHandlerState('invalidating_ballot');
+  apiMock.setPaperHandlerState('waiting_for_invalidated_ballot_confirmation');
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
     cardlessVoterUserParams: {
       ballotStyleId: electionDefinition.election.ballotStyles[0].id,

--- a/apps/mark-scan/frontend/src/pages/ask_poll_worker_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/ask_poll_worker_page.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+import { Screen, H1, Main, Button, Text } from '@votingworks/ui';
+
+import { InsertedSmartCardAuth } from '@votingworks/types';
+import { isCardlessVoterAuth } from '@votingworks/utils';
+
+import { ButtonFooter } from '../components/button_footer';
+
+interface Props {
+  authStatus:
+    | InsertedSmartCardAuth.CardlessVoterLoggedIn
+    | InsertedSmartCardAuth.PollWorkerLoggedIn;
+  cardlessVoterContent: {
+    body: JSX.Element;
+  };
+  pollWorkerContent: {
+    headerText: string;
+    body: JSX.Element;
+    buttonText: string;
+    onButtonPress: () => Promise<void>;
+  };
+}
+
+// Component with 2 stages
+// 1. Voter stage: tells the voter to ask a poll worker for help. Does not allow the voter to advance the state.
+// 2. Poll worker stage: after auth, gives instructions and a button to advance the state.
+export function AskPollWorkerPage(props: Props): JSX.Element | null {
+  const { authStatus, cardlessVoterContent, pollWorkerContent } = props;
+
+  let mainContents = (
+    <React.Fragment>
+      <H1>{pollWorkerContent.headerText}</H1>
+      {pollWorkerContent.body}
+    </React.Fragment>
+  );
+  let button = (
+    <Button onPress={() => pollWorkerContent.onButtonPress()}>
+      {pollWorkerContent.buttonText}
+    </Button>
+  );
+
+  if (isCardlessVoterAuth(authStatus)) {
+    mainContents = (
+      <React.Fragment>
+        <H1>
+          <span aria-label="Ask a Poll Worker for Help">
+            Ask a Poll Worker for Help
+          </span>
+        </H1>
+        {cardlessVoterContent.body}
+      </React.Fragment>
+    );
+    button = (
+      // onPress is a required prop but we want the button to no op
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      <Button disabled onPress={() => {}}>
+        Insert a Poll Worker Card to Continue
+      </Button>
+    );
+  }
+
+  return (
+    <Screen>
+      <Main padded centerChild>
+        <Text center>{mainContents}</Text>
+      </Main>
+      <ButtonFooter>{button}</ButtonFooter>
+    </Screen>
+  );
+}

--- a/apps/mark-scan/frontend/src/pages/ask_poll_worker_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/ask_poll_worker_page.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Screen, H1, Main, Button, Text } from '@votingworks/ui';
 
 import { InsertedSmartCardAuth } from '@votingworks/types';
-import { isCardlessVoterAuth } from '@votingworks/utils';
+import { isCardlessVoterAuth, isPollWorkerAuth } from '@votingworks/utils';
 
 import { ButtonFooter } from '../components/button_footer';
 
@@ -33,11 +33,6 @@ export function AskPollWorkerPage(props: Props): JSX.Element {
       {pollWorkerContent.body}
     </React.Fragment>
   );
-  const button = (
-    <Button onPress={() => pollWorkerContent.onButtonPress()}>
-      {pollWorkerContent.buttonText}
-    </Button>
-  );
 
   if (isCardlessVoterAuth(authStatus)) {
     mainContents = (
@@ -48,14 +43,8 @@ export function AskPollWorkerPage(props: Props): JSX.Element {
           </span>
         </H1>
         {cardlessVoterContent.body}
+        <p>Insert a poll worker card to continue.</p>
       </React.Fragment>
-    );
-    button = (
-      // onPress is a required prop but we want the button to no op
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      <Button disabled onPress={() => {}}>
-        Insert a Poll Worker Card to Continue
-      </Button>
     );
   }
 
@@ -64,7 +53,13 @@ export function AskPollWorkerPage(props: Props): JSX.Element {
       <Main padded centerChild>
         <Text center>{mainContents}</Text>
       </Main>
-      <ButtonFooter>{button}</ButtonFooter>
+      {isPollWorkerAuth(authStatus) && (
+        <ButtonFooter>
+          <Button onPress={() => pollWorkerContent.onButtonPress()}>
+            {pollWorkerContent.buttonText}
+          </Button>
+        </ButtonFooter>
+      )}
     </Screen>
   );
 }

--- a/apps/mark-scan/frontend/src/pages/ask_poll_worker_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/ask_poll_worker_page.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import { Screen, H1, Main, Button, Text } from '@votingworks/ui';
 
 import { InsertedSmartCardAuth } from '@votingworks/types';
@@ -25,7 +24,7 @@ interface Props {
 // Component with 2 stages
 // 1. Voter stage: tells the voter to ask a poll worker for help. Does not allow the voter to advance the state.
 // 2. Poll worker stage: after auth, gives instructions and a button to advance the state.
-export function AskPollWorkerPage(props: Props): JSX.Element | null {
+export function AskPollWorkerPage(props: Props): JSX.Element {
   const { authStatus, cardlessVoterContent, pollWorkerContent } = props;
 
   let mainContents = (

--- a/apps/mark-scan/frontend/src/pages/ask_poll_worker_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/ask_poll_worker_page.tsx
@@ -33,7 +33,7 @@ export function AskPollWorkerPage(props: Props): JSX.Element {
       {pollWorkerContent.body}
     </React.Fragment>
   );
-  let button = (
+  const button = (
     <Button onPress={() => pollWorkerContent.onButtonPress()}>
       {pollWorkerContent.buttonText}
     </Button>

--- a/apps/mark-scan/frontend/src/pages/ballot_invalidated_page.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/ballot_invalidated_page.test.tsx
@@ -56,6 +56,6 @@ describe('with cardless voter auth', () => {
     renderWithAuthAndBallotContext(electionDefinition, auth);
 
     await screen.findByText('Ask a Poll Worker for Help');
-    await screen.findByText('Insert a Poll Worker Card to Continue');
+    await screen.findByText('Insert a poll worker card to continue.');
   });
 });

--- a/apps/mark-scan/frontend/src/pages/ballot_invalidated_page.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/ballot_invalidated_page.test.tsx
@@ -1,9 +1,15 @@
 import userEvent from '@testing-library/user-event';
 import { electionGeneralDefinition } from '@votingworks/fixtures';
+import { ElectionDefinition, InsertedSmartCardAuth } from '@votingworks/types';
+import { VxRenderResult } from '@votingworks/ui';
 import { render as renderWithBallotContext } from '../../test/test_utils';
 import { createApiMock, ApiMock } from '../../test/helpers/mock_api_client';
 import { screen } from '../../test/react_testing_library';
 import { BallotInvalidatedPage } from './ballot_invalidated_page';
+import {
+  fakeCardlessVoterLoggedInAuth,
+  fakePollWorkerAuth,
+} from '../../test/helpers/fake_auth';
 
 let apiMock: ApiMock;
 beforeEach(() => {
@@ -14,15 +20,42 @@ afterEach(() => {
   apiMock.mockApiClient.assertComplete();
 });
 
-test('calls confirmInvalidateBallot when voter clicks button', async () => {
-  const electionDefinition = electionGeneralDefinition;
-  apiMock.expectConfirmInvalidateBallot();
-  renderWithBallotContext(<BallotInvalidatedPage />, {
-    precinctId: electionDefinition.election.precincts[0].id,
-    ballotStyleId: electionDefinition.election.ballotStyles[0].id,
-    apiMock,
-  });
+function renderWithAuthAndBallotContext(
+  electionDefinition: ElectionDefinition,
+  authStatus:
+    | InsertedSmartCardAuth.CardlessVoterLoggedIn
+    | InsertedSmartCardAuth.PollWorkerLoggedIn
+): VxRenderResult {
+  return renderWithBallotContext(
+    <BallotInvalidatedPage authStatus={authStatus} />,
+    {
+      precinctId: electionDefinition.election.precincts[0].id,
+      ballotStyleId: electionDefinition.election.ballotStyles[0].id,
+      apiMock,
+    }
+  );
+}
 
-  await screen.findByText('Ballot Invalidated');
-  userEvent.click(screen.getByText('I Have Alerted a Poll Worker'));
+describe('with poll worker auth', () => {
+  test('calls confirmInvalidateBallot button is clicked', async () => {
+    const electionDefinition = electionGeneralDefinition;
+    apiMock.expectConfirmInvalidateBallot();
+    const auth = fakePollWorkerAuth(electionDefinition);
+    renderWithAuthAndBallotContext(electionDefinition, auth);
+
+    await screen.findByText('Remove Ballot');
+    userEvent.click(screen.getByText('Start a New Voter Session'));
+  });
+});
+
+describe('with cardless voter auth', () => {
+  test('renders instructions to alert a poll worker', async () => {
+    const electionDefinition = electionGeneralDefinition;
+
+    const auth = fakeCardlessVoterLoggedInAuth(electionDefinition);
+    renderWithAuthAndBallotContext(electionDefinition, auth);
+
+    await screen.findByText('Ask a Poll Worker for Help');
+    await screen.findByText('Insert a Poll Worker Card to Continue');
+  });
 });

--- a/apps/mark-scan/frontend/src/pages/ballot_invalidated_page.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/ballot_invalidated_page.test.tsx
@@ -1,0 +1,28 @@
+import userEvent from '@testing-library/user-event';
+import { electionGeneralDefinition } from '@votingworks/fixtures';
+import { render as renderWithBallotContext } from '../../test/test_utils';
+import { createApiMock, ApiMock } from '../../test/helpers/mock_api_client';
+import { screen } from '../../test/react_testing_library';
+import { BallotInvalidatedPage } from './ballot_invalidated_page';
+
+let apiMock: ApiMock;
+beforeEach(() => {
+  apiMock = createApiMock();
+});
+
+afterEach(() => {
+  apiMock.mockApiClient.assertComplete();
+});
+
+test('calls confirmInvalidateBallot when voter clicks button', async () => {
+  const electionDefinition = electionGeneralDefinition;
+  apiMock.expectConfirmInvalidateBallot();
+  renderWithBallotContext(<BallotInvalidatedPage />, {
+    precinctId: electionDefinition.election.precincts[0].id,
+    ballotStyleId: electionDefinition.election.ballotStyles[0].id,
+    apiMock,
+  });
+
+  await screen.findByText('Ballot Invalidated');
+  userEvent.click(screen.getByText('I Have Alerted a Poll Worker'));
+});

--- a/apps/mark-scan/frontend/src/pages/ballot_invalidated_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/ballot_invalidated_page.tsx
@@ -1,0 +1,44 @@
+/* istanbul ignore file - placeholder component that will change */
+import { useContext } from 'react';
+
+import { Screen, H1, Main, Button, CenteredLargeProse } from '@votingworks/ui';
+
+import { confirmInvalidateBallot } from '../api';
+
+import { BallotContext } from '../contexts/ballot_context';
+import { ButtonFooter } from '../components/button_footer';
+
+export function BallotInvalidatedPage(): JSX.Element | null {
+  const { resetBallot, endVoterSession } = useContext(BallotContext);
+
+  const confirmInvalidateBallotMutation = confirmInvalidateBallot.useMutation();
+
+  function onPressContinue() {
+    confirmInvalidateBallotMutation.mutate(undefined, {
+      async onSuccess() {
+        resetBallot();
+        await endVoterSession();
+      },
+    });
+  }
+
+  return (
+    <Screen>
+      <Main flexColumn>
+        <CenteredLargeProse>
+          <H1>
+            <span aria-label="Ballot Invalidated.">Ballot Invalidated</span>
+          </H1>
+          <p>
+            You have indicated your ballot needs changes. Please alert a poll
+            worker to spoil your incorrect ballot and restart your voting
+            session.
+          </p>
+        </CenteredLargeProse>
+      </Main>
+      <ButtonFooter>
+        <Button onPress={onPressContinue}>I Have Alerted a Poll Worker</Button>
+      </ButtonFooter>
+    </Screen>
+  );
+}

--- a/apps/mark-scan/frontend/src/pages/ballot_invalidated_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/ballot_invalidated_page.tsx
@@ -1,14 +1,10 @@
-/* istanbul ignore file - placeholder component that will change */
-import React, { useContext } from 'react';
-
-import { Screen, H1, Main, Button, Text } from '@votingworks/ui';
+import { useContext } from 'react';
 
 import { InsertedSmartCardAuth } from '@votingworks/types';
-import { isCardlessVoterAuth } from '@votingworks/utils';
-import { confirmInvalidateBallot } from '../api';
 
+import { confirmInvalidateBallot } from '../api';
 import { BallotContext } from '../contexts/ballot_context';
-import { ButtonFooter } from '../components/button_footer';
+import { AskPollWorkerPage } from './ask_poll_worker_page';
 
 interface Props {
   authStatus:
@@ -16,9 +12,7 @@ interface Props {
     | InsertedSmartCardAuth.PollWorkerLoggedIn;
 }
 
-export function BallotInvalidatedPage({
-  authStatus,
-}: Props): JSX.Element | null {
+export function BallotInvalidatedPage({ authStatus }: Props): JSX.Element {
   const { resetBallot, endVoterSession } = useContext(BallotContext);
 
   const confirmInvalidateBallotMutation = confirmInvalidateBallot.useMutation();
@@ -31,48 +25,29 @@ export function BallotInvalidatedPage({
     confirmInvalidateBallotMutation.mutate(undefined);
   }
 
-  let mainContents = (
-    <React.Fragment>
-      <H1>Remove Ballot</H1>
-      <p>
-        Remove the ballot and press below to start a new voter session. Remember
-        to spoil the old ballot.
-      </p>
-    </React.Fragment>
-  );
-  let button = (
-    <Button onPress={onPressContinue}>Start a New Voter Session</Button>
-  );
-  if (isCardlessVoterAuth(authStatus)) {
-    mainContents = (
-      <React.Fragment>
-        <H1>
-          <span aria-label="Ask a Poll Worker for Help">
-            Ask a Poll Worker for Help
-          </span>
-        </H1>
-        <p>
-          You have indicated your ballot needs changes. Please alert a poll
-          worker to invalidate your incorrect ballot and restart your voting
-          session.
-        </p>
-      </React.Fragment>
-    );
-    button = (
-      // onPress is a required prop but we want the button to no op
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      <Button disabled onPress={() => {}}>
-        Insert a Poll Worker Card to Continue
-      </Button>
-    );
-  }
-
   return (
-    <Screen>
-      <Main padded centerChild>
-        <Text center>{mainContents}</Text>
-      </Main>
-      <ButtonFooter>{button}</ButtonFooter>
-    </Screen>
+    <AskPollWorkerPage
+      authStatus={authStatus}
+      cardlessVoterContent={{
+        body: (
+          <p>
+            You have indicated your ballot needs changes. Please alert a poll
+            worker to invalidate your incorrect ballot and restart your voting
+            session.
+          </p>
+        ),
+      }}
+      pollWorkerContent={{
+        headerText: 'Remove Ballot',
+        body: (
+          <p>
+            Remove the ballot and press below to start a new voter session.
+            Remember to spoil the old ballot.
+          </p>
+        ),
+        buttonText: 'Start a New Voter Session',
+        onButtonPress: onPressContinue,
+      }}
+    />
   );
 }

--- a/apps/mark-scan/frontend/src/pages/ballot_invalidated_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/ballot_invalidated_page.tsx
@@ -1,7 +1,7 @@
 /* istanbul ignore file - placeholder component that will change */
 import { useContext } from 'react';
 
-import { Screen, H1, Main, Button, CenteredLargeProse } from '@votingworks/ui';
+import { Screen, H1, Main, Button, Text } from '@votingworks/ui';
 
 import { confirmInvalidateBallot } from '../api';
 
@@ -24,8 +24,8 @@ export function BallotInvalidatedPage(): JSX.Element | null {
 
   return (
     <Screen>
-      <Main flexColumn>
-        <CenteredLargeProse>
+      <Main padded centerChild>
+        <Text center>
           <H1>
             <span aria-label="Ballot Invalidated.">Ballot Invalidated</span>
           </H1>
@@ -34,7 +34,7 @@ export function BallotInvalidatedPage(): JSX.Element | null {
             worker to spoil your incorrect ballot and restart your voting
             session.
           </p>
-        </CenteredLargeProse>
+        </Text>
       </Main>
       <ButtonFooter>
         <Button onPress={onPressContinue}>I Have Alerted a Poll Worker</Button>

--- a/apps/mark-scan/frontend/src/pages/ballot_invalidated_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/ballot_invalidated_page.tsx
@@ -23,13 +23,12 @@ export function BallotInvalidatedPage({
 
   const confirmInvalidateBallotMutation = confirmInvalidateBallot.useMutation();
 
-  function onPressContinue() {
-    confirmInvalidateBallotMutation.mutate(undefined, {
-      async onSuccess() {
-        await endVoterSession();
-        resetBallot();
-      },
-    });
+  async function onPressContinue() {
+    // Reset session and ballot before changing the state machine state. If done
+    // in the reverse order the screen will flicker
+    await endVoterSession();
+    resetBallot();
+    confirmInvalidateBallotMutation.mutate(undefined);
   }
 
   let mainContents = (

--- a/apps/mark-scan/frontend/src/pages/ballot_invalidated_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/ballot_invalidated_page.tsx
@@ -1,14 +1,24 @@
 /* istanbul ignore file - placeholder component that will change */
-import { useContext } from 'react';
+import React, { useContext } from 'react';
 
 import { Screen, H1, Main, Button, Text } from '@votingworks/ui';
 
+import { InsertedSmartCardAuth } from '@votingworks/types';
+import { isCardlessVoterAuth } from '@votingworks/utils';
 import { confirmInvalidateBallot } from '../api';
 
 import { BallotContext } from '../contexts/ballot_context';
 import { ButtonFooter } from '../components/button_footer';
 
-export function BallotInvalidatedPage(): JSX.Element | null {
+interface Props {
+  authStatus:
+    | InsertedSmartCardAuth.CardlessVoterLoggedIn
+    | InsertedSmartCardAuth.PollWorkerLoggedIn;
+}
+
+export function BallotInvalidatedPage({
+  authStatus,
+}: Props): JSX.Element | null {
   const { resetBallot, endVoterSession } = useContext(BallotContext);
 
   const confirmInvalidateBallotMutation = confirmInvalidateBallot.useMutation();
@@ -16,29 +26,54 @@ export function BallotInvalidatedPage(): JSX.Element | null {
   function onPressContinue() {
     confirmInvalidateBallotMutation.mutate(undefined, {
       async onSuccess() {
-        resetBallot();
         await endVoterSession();
+        resetBallot();
       },
     });
+  }
+
+  let mainContents = (
+    <React.Fragment>
+      <H1>Remove Ballot</H1>
+      <p>
+        Remove the ballot and press below to start a new voter session. Remember
+        to spoil the old ballot.
+      </p>
+    </React.Fragment>
+  );
+  let button = (
+    <Button onPress={onPressContinue}>Start a New Voter Session</Button>
+  );
+  if (isCardlessVoterAuth(authStatus)) {
+    mainContents = (
+      <React.Fragment>
+        <H1>
+          <span aria-label="Ask a Poll Worker for Help">
+            Ask a Poll Worker for Help
+          </span>
+        </H1>
+        <p>
+          You have indicated your ballot needs changes. Please alert a poll
+          worker to invalidate your incorrect ballot and restart your voting
+          session.
+        </p>
+      </React.Fragment>
+    );
+    button = (
+      // onPress is a required prop but we want the button to no op
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      <Button disabled onPress={() => {}}>
+        Insert a Poll Worker Card to Continue
+      </Button>
+    );
   }
 
   return (
     <Screen>
       <Main padded centerChild>
-        <Text center>
-          <H1>
-            <span aria-label="Ballot Invalidated.">Ballot Invalidated</span>
-          </H1>
-          <p>
-            You have indicated your ballot needs changes. Please alert a poll
-            worker to spoil your incorrect ballot and restart your voting
-            session.
-          </p>
-        </Text>
+        <Text center>{mainContents}</Text>
       </Main>
-      <ButtonFooter>
-        <Button onPress={onPressContinue}>I Have Alerted a Poll Worker</Button>
-      </ButtonFooter>
+      <ButtonFooter>{button}</ButtonFooter>
     </Screen>
   );
 }

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.test.tsx
@@ -5,12 +5,7 @@ import {
 import { ElectionDefinition, InsertedSmartCardAuth } from '@votingworks/types';
 
 import { MemoryHardware, singlePrecinctSelectionFor } from '@votingworks/utils';
-import {
-  fakeCardlessVoterUser,
-  fakePollWorkerUser,
-  fakeSessionExpiresAt,
-  hasTextAcrossElements,
-} from '@votingworks/test-utils';
+import { hasTextAcrossElements } from '@votingworks/test-utils';
 import userEvent from '@testing-library/user-event';
 
 import { QueryClientProvider } from '@tanstack/react-query';
@@ -25,6 +20,10 @@ import { AriaScreenReader } from '../utils/ScreenReader';
 import { fakeTts } from '../../test/helpers/fake_tts';
 import { ApiClientContext, createQueryClient } from '../api';
 import { ApiMock, createApiMock } from '../../test/helpers/mock_api_client';
+import {
+  fakeCardlessVoterAuth,
+  fakePollWorkerAuth,
+} from '../../test/helpers/fake_auth';
 
 const { election } = electionGeneralDefinition;
 
@@ -38,31 +37,6 @@ beforeEach(() => {
 afterEach(() => {
   apiMock.mockApiClient.assertComplete();
 });
-
-function fakePollWorkerAuth(
-  electionDefinition: ElectionDefinition
-): InsertedSmartCardAuth.PollWorkerLoggedIn {
-  return {
-    status: 'logged_in',
-    user: fakePollWorkerUser({ electionHash: electionDefinition.electionHash }),
-    sessionExpiresAt: fakeSessionExpiresAt(),
-  };
-}
-
-function fakeCardlessVoterAuth(
-  electionDefinition: ElectionDefinition
-): InsertedSmartCardAuth.PollWorkerLoggedIn {
-  const ballotStyleId = electionDefinition.election.ballotStyles[0].id;
-  const precinctId = electionDefinition.election.precincts[0].id;
-
-  return {
-    ...fakePollWorkerAuth(electionDefinition),
-    cardlessVoterUser: fakeCardlessVoterUser({
-      ballotStyleId,
-      precinctId,
-    }),
-  };
-}
 
 function renderScreen(
   props: Partial<PollworkerScreenProps> = {},

--- a/apps/mark-scan/frontend/src/pages/validate_ballot_page.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/validate_ballot_page.test.tsx
@@ -22,7 +22,6 @@ test('calls invalidateBallot if voter indicates their ballot is incorrect', asyn
   apiMock.expectGetElectionDefinition(electionDefinition);
   apiMock.expectInvalidateBallot();
   renderWithBallotContext(<ValidateBallotPage />, {
-    route: '/validate',
     precinctId: electionDefinition.election.precincts[0].id,
     ballotStyleId: electionDefinition.election.ballotStyles[0].id,
     apiMock,

--- a/apps/mark-scan/frontend/src/pages/validate_ballot_page.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/validate_ballot_page.test.tsx
@@ -1,5 +1,4 @@
 import userEvent from '@testing-library/user-event';
-import { Route } from 'react-router-dom';
 import { electionGeneralDefinition } from '@votingworks/fixtures';
 import { render as renderWithBallotContext } from '../../test/test_utils';
 import { createApiMock, ApiMock } from '../../test/helpers/mock_api_client';
@@ -22,15 +21,12 @@ test('calls invalidateBallot if voter indicates their ballot is incorrect', asyn
   apiMock.expectGetInterpretation(mockInterpretation);
   apiMock.expectGetElectionDefinition(electionDefinition);
   apiMock.expectInvalidateBallot();
-  renderWithBallotContext(
-    <Route path="/validate" component={ValidateBallotPage} />,
-    {
-      route: '/validate',
-      precinctId: electionDefinition.election.precincts[0].id,
-      ballotStyleId: electionDefinition.election.ballotStyles[0].id,
-      apiMock,
-    }
-  );
+  renderWithBallotContext(<ValidateBallotPage />, {
+    route: '/validate',
+    precinctId: electionDefinition.election.precincts[0].id,
+    ballotStyleId: electionDefinition.election.ballotStyles[0].id,
+    apiMock,
+  });
 
   await screen.findByText('Review Your Votes');
   apiMock.expectGetInterpretation(mockInterpretation);

--- a/apps/mark-scan/frontend/src/pages/validate_ballot_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/validate_ballot_page.tsx
@@ -32,8 +32,7 @@ export function ValidateBallotPage(): JSX.Element | null {
   const getInterpretationQuery = getInterpretation.useQuery();
   const getElectionDefinitionQuery = getElectionDefinition.useQuery();
   // We use the contest data stored in BallotContext but vote data from the interpreted ballot
-  const { contests, precinctId, resetBallot, endVoterSession } =
-    useContext(BallotContext);
+  const { contests, precinctId, resetBallot } = useContext(BallotContext);
 
   assert(
     typeof precinctId !== 'undefined',
@@ -45,12 +44,7 @@ export function ValidateBallotPage(): JSX.Element | null {
   const invalidateBallotMutation = invalidateBallot.useMutation();
   const validateBallotMutation = validateBallot.useMutation();
   function invalidateBallotCallback() {
-    invalidateBallotMutation.mutate(undefined, {
-      async onSuccess() {
-        resetBallot();
-        await endVoterSession();
-      },
-    });
+    invalidateBallotMutation.mutate(undefined);
   }
   function validateBallotCallback() {
     validateBallotMutation.mutate(undefined, {

--- a/apps/mark-scan/frontend/test/helpers/fake_auth.ts
+++ b/apps/mark-scan/frontend/test/helpers/fake_auth.ts
@@ -1,0 +1,46 @@
+import {
+  fakeCardlessVoterUser,
+  fakePollWorkerUser,
+  fakeSessionExpiresAt,
+} from '@votingworks/test-utils';
+import { ElectionDefinition, InsertedSmartCardAuth } from '@votingworks/types';
+
+export function fakePollWorkerAuth(
+  electionDefinition: ElectionDefinition
+): InsertedSmartCardAuth.PollWorkerLoggedIn {
+  return {
+    status: 'logged_in',
+    user: fakePollWorkerUser({ electionHash: electionDefinition.electionHash }),
+    sessionExpiresAt: fakeSessionExpiresAt(),
+  };
+}
+
+export function fakeCardlessVoterAuth(
+  electionDefinition: ElectionDefinition
+): InsertedSmartCardAuth.PollWorkerLoggedIn {
+  const ballotStyleId = electionDefinition.election.ballotStyles[0].id;
+  const precinctId = electionDefinition.election.precincts[0].id;
+
+  return {
+    ...fakePollWorkerAuth(electionDefinition),
+    cardlessVoterUser: fakeCardlessVoterUser({
+      ballotStyleId,
+      precinctId,
+    }),
+  };
+}
+
+export function fakeCardlessVoterLoggedInAuth(
+  electionDefinition: ElectionDefinition
+): InsertedSmartCardAuth.CardlessVoterLoggedIn {
+  const ballotStyleId = electionDefinition.election.ballotStyles[0].id;
+  const precinctId = electionDefinition.election.precincts[0].id;
+
+  return {
+    ...fakePollWorkerAuth(electionDefinition),
+    user: fakeCardlessVoterUser({
+      ballotStyleId,
+      precinctId,
+    }),
+  };
+}

--- a/apps/mark-scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/mark-scan/frontend/test/helpers/mock_api_client.tsx
@@ -217,6 +217,10 @@ export function createApiMock() {
       mockApiClient.invalidateBallot.expectCallWith().resolves();
     },
 
+    expectConfirmInvalidateBallot(): void {
+      mockApiClient.confirmInvalidateBallot.expectCallWith().resolves();
+    },
+
     // Some e2e tests repeatedly reset voter session. Each time a voter session is activated
     // setAcceptingPaperState is called.
     expectRepeatedSetAcceptingPaperState(): void {


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/3883

On ballot invalidation, displays a screen telling the voter to alert a pollworker for assistance. The pollworker must authenticate before continuing.

In the long term we'll want this state to allow the voter to go back to edit their selections, tracked in https://github.com/votingworks/vxsuite/issues/3909


## Demo Video or Screenshot
n.b. there's some rendering lag in the middle of the video. You may want to skip ahead past it.

https://github.com/votingworks/vxsuite/assets/1060688/09d74659-6c9c-46eb-b878-d9e31cf29e6f



## Testing Plan
* Added tests for different auth statuses in invalidation page.
* Added top-level state tests to keep coverage at 100

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
