### PR TITLE
[libs/types] Add translation/audio schemas to BallotPackage

### DIFF
--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -1,5 +1,6 @@
 import { LogEventId, Logger } from '@votingworks/logging';
 import {
+  BallotPackageFileName,
   ContestId,
   DEFAULT_SYSTEM_SETTINGS,
   Id,
@@ -247,13 +248,16 @@ function buildApi({
           createWriteStream(tempDirectoryBallotPackageFilePath)
         );
         await addFileToZipStream(ballotPackageZipStream, {
-          path: 'election.json',
+          path: BallotPackageFileName.ELECTION,
           contents: electionDefinition.electionData,
         });
         await addFileToZipStream(ballotPackageZipStream, {
-          path: 'systemSettings.json',
+          path: BallotPackageFileName.SYSTEM_SETTINGS,
           contents: JSON.stringify(systemSettings, null, 2),
         });
+
+        // TODO(kofi): Include translation/audio files in the package export.
+
         ballotPackageZipStream.finish();
         await ballotPackageZipPromise.promise;
 

--- a/apps/admin/frontend/src/utils/initial_setup_package.ts
+++ b/apps/admin/frontend/src/utils/initial_setup_package.ts
@@ -7,6 +7,7 @@ import {
   readTextEntry,
   getFileByName,
 } from '@votingworks/utils';
+import { BallotPackageFileName } from '@votingworks/types';
 
 // InitialAdminSetupPackage models the zip file read in by VxAdmin when a system admin configures the machine.
 // It's the delivery method for the system settings file.
@@ -24,11 +25,16 @@ async function readInitialAdminSetupPackageFromBuffer(
   const zipfile = await openZip(source);
   const entries = getEntries(zipfile);
 
-  const electionEntry = getFileByName(entries, 'election.json');
+  const electionEntry = getFileByName(entries, BallotPackageFileName.ELECTION);
   const electionString = await readTextEntry(electionEntry);
 
-  const systemSettingsEntry = getFileByName(entries, 'systemSettings.json');
+  const systemSettingsEntry = getFileByName(
+    entries,
+    BallotPackageFileName.SYSTEM_SETTINGS
+  );
   const systemSettingsString = await readTextEntry(systemSettingsEntry);
+
+  // TODO(kofi): Import translation/audio files as well.
 
   return {
     electionString,

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_SYSTEM_SETTINGS,
   SystemSettings,
   BallotType,
+  BallotPackageFileName,
 } from '@votingworks/types';
 import express, { Application } from 'express';
 import { assertDefined, find, groupBy, ok, Result } from '@votingworks/basics';
@@ -235,9 +236,9 @@ function buildApi({ store }: { store: Store }) {
       }).unsafeUnwrap();
 
       const zip = new JsZip();
-      zip.file('election.json', electionDefinition.electionData);
+      zip.file(BallotPackageFileName.ELECTION, electionDefinition.electionData);
       zip.file(
-        'systemSettings.json',
+        BallotPackageFileName.SYSTEM_SETTINGS,
         JSON.stringify(DEFAULT_SYSTEM_SETTINGS, null, 2)
       );
 

--- a/libs/backend/src/ballot_package/test_utils.ts
+++ b/libs/backend/src/ballot_package/test_utils.ts
@@ -1,5 +1,5 @@
 import JsZip from 'jszip';
-import { BallotPackage } from '@votingworks/types';
+import { BallotPackage, BallotPackageFileName } from '@votingworks/types';
 import { Buffer } from 'buffer';
 
 /**
@@ -9,10 +9,13 @@ export function createBallotPackageZipArchive(
   ballotPackage: BallotPackage
 ): Promise<Buffer> {
   const jsZip = new JsZip();
-  jsZip.file('election.json', ballotPackage.electionDefinition.electionData);
+  jsZip.file(
+    BallotPackageFileName.ELECTION,
+    ballotPackage.electionDefinition.electionData
+  );
   if (ballotPackage.systemSettings) {
     jsZip.file(
-      'systemSettings.json',
+      BallotPackageFileName.SYSTEM_SETTINGS,
       JSON.stringify(ballotPackage.systemSettings, null, 2)
     );
   }

--- a/libs/types/src/ballot_package.ts
+++ b/libs/types/src/ballot_package.ts
@@ -5,11 +5,28 @@ import {
   PrecinctId,
 } from './election';
 import { SystemSettings } from './system_settings';
+import { BallotPackageMetadata } from './ballot_package_metadata';
+import { UiStringAudioClips } from './ui_string_audio_clips';
+import { UiStringAudioKeysPackage } from './ui_string_audio_keys';
+import { UiStringsPackage } from './ui_string_translations';
+
+export enum BallotPackageFileName {
+  APP_STRINGS = 'appStrings.json',
+  AUDIO_CLIPS = 'audioClips.jsonl',
+  AUDIO_KEYS = 'audioKeys.json',
+  ELECTION = 'election.json',
+  METADATA = 'metadata.json',
+  SYSTEM_SETTINGS = 'systemSettings.json',
+}
 
 export interface BallotPackage {
   electionDefinition: ElectionDefinition;
+  metadata?: BallotPackageMetadata; // TODO(kofi): Make required
   // TODO(kevin) once all machines support system settings, make systemSettings required
   systemSettings?: SystemSettings;
+  uiStringAudioClips?: UiStringAudioClips; // TODO(kofi): Make required
+  uiStringAudioKeys?: UiStringAudioKeysPackage; // TODO(kofi): Make required
+  uiStrings?: UiStringsPackage; // TODO(kofi): Make required
 }
 
 export interface BallotStyleData {

--- a/libs/types/src/ballot_package_metadata.ts
+++ b/libs/types/src/ballot_package_metadata.ts
@@ -1,0 +1,11 @@
+/* istanbul ignore file - will eventually be tested via consumers. */
+import { z } from 'zod';
+
+export interface BallotPackageMetadata {
+  version: string;
+}
+
+export const BallotPackageMetadataSchema: z.ZodType<BallotPackageMetadata> =
+  z.object({
+    version: z.string(),
+  });

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -26,5 +26,8 @@ export * from './printing';
 export * from './system_settings';
 export * as Tabulation from './tabulation';
 export * from './tallies';
+export * from './ui_string_audio_clips';
+export * from './ui_string_audio_keys';
+export * from './ui_string_translations';
 export * from './ui_theme';
 export * from './voting_method';

--- a/libs/types/src/language_code.ts
+++ b/libs/types/src/language_code.ts
@@ -1,0 +1,6 @@
+/* ISO 639-1 codes for supported VxSuite languages.  */
+export enum LanguageCode {
+  CHINESE = 'zh',
+  ENGLISH = 'en',
+  SPANISH = 'es',
+}

--- a/libs/types/src/ui_string_audio_clips.test.ts
+++ b/libs/types/src/ui_string_audio_clips.test.ts
@@ -1,0 +1,46 @@
+import { safeParseJson } from './generic';
+import { LanguageCode } from './language_code';
+import { UiStringAudioClipJsonSchema } from './ui_string_audio_clips';
+
+test('valid structure', () => {
+  const result = safeParseJson(
+    JSON.stringify({
+      data: 'test data',
+      key: 'testKey',
+      lang: LanguageCode.CHINESE,
+    }),
+    UiStringAudioClipJsonSchema
+  );
+
+  expect(result.isOk()).toEqual(true);
+  expect(result.ok()).toEqual({
+    data: 'test data',
+    key: 'testKey',
+    lang: LanguageCode.CHINESE,
+  });
+});
+
+test('invalid language code', () => {
+  const result = safeParseJson(
+    JSON.stringify({
+      data: 'test data',
+      key: 'testKey',
+      lang: 'Klingon',
+    }),
+    UiStringAudioClipJsonSchema
+  );
+
+  expect(result.isOk()).toEqual(false);
+});
+
+test('missing field', () => {
+  const result = safeParseJson(
+    JSON.stringify({
+      data: 'test data',
+      lang: LanguageCode.SPANISH,
+    }),
+    UiStringAudioClipJsonSchema
+  );
+
+  expect(result.isOk()).toEqual(false);
+});

--- a/libs/types/src/ui_string_audio_clips.test.ts
+++ b/libs/types/src/ui_string_audio_clips.test.ts
@@ -1,6 +1,6 @@
 import { safeParseJson } from './generic';
 import { LanguageCode } from './language_code';
-import { UiStringAudioClipJsonSchema } from './ui_string_audio_clips';
+import { UiStringAudioClipSchema } from './ui_string_audio_clips';
 
 test('valid structure', () => {
   const result = safeParseJson(
@@ -9,7 +9,7 @@ test('valid structure', () => {
       key: 'testKey',
       lang: LanguageCode.CHINESE,
     }),
-    UiStringAudioClipJsonSchema
+    UiStringAudioClipSchema
   );
 
   expect(result.isOk()).toEqual(true);
@@ -27,7 +27,7 @@ test('invalid language code', () => {
       key: 'testKey',
       lang: 'Klingon',
     }),
-    UiStringAudioClipJsonSchema
+    UiStringAudioClipSchema
   );
 
   expect(result.isOk()).toEqual(false);
@@ -39,7 +39,7 @@ test('missing field', () => {
       data: 'test data',
       lang: LanguageCode.SPANISH,
     }),
-    UiStringAudioClipJsonSchema
+    UiStringAudioClipSchema
   );
 
   expect(result.isOk()).toEqual(false);

--- a/libs/types/src/ui_string_audio_clips.ts
+++ b/libs/types/src/ui_string_audio_clips.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+import { LanguageCode } from './language_code';
+
+/**
+ * A single audio clip record in the audio clips JSONL file in a ballot package.
+ */
+export interface UiStringAudioClip {
+  data: string;
+  key: string;
+  lang: LanguageCode;
+}
+
+/**
+ * A single audio clip record in the audio clips JSONL file in a ballot package.
+ */
+export const UiStringAudioClipJsonSchema: z.ZodType<UiStringAudioClip> =
+  z.object({
+    data: z.string(),
+    key: z.string(),
+    lang: z.nativeEnum(LanguageCode),
+  });
+
+/**
+ * Audio clip records from the audio clips JSONL file in a ballot package.
+ */
+export type UiStringAudioClips = readonly UiStringAudioClip[];

--- a/libs/types/src/ui_string_audio_clips.ts
+++ b/libs/types/src/ui_string_audio_clips.ts
@@ -14,12 +14,11 @@ export interface UiStringAudioClip {
 /**
  * A single audio clip record in the audio clips JSONL file in a ballot package.
  */
-export const UiStringAudioClipJsonSchema: z.ZodType<UiStringAudioClip> =
-  z.object({
-    data: z.string(),
-    key: z.string(),
-    lang: z.nativeEnum(LanguageCode),
-  });
+export const UiStringAudioClipSchema: z.ZodType<UiStringAudioClip> = z.object({
+  data: z.string(),
+  key: z.string(),
+  lang: z.nativeEnum(LanguageCode),
+});
 
 /**
  * Audio clip records from the audio clips JSONL file in a ballot package.

--- a/libs/types/src/ui_string_audio_keys.test.ts
+++ b/libs/types/src/ui_string_audio_keys.test.ts
@@ -1,0 +1,77 @@
+import { safeParseJson } from './generic';
+import { LanguageCode } from './language_code';
+import {
+  UiStringAudioKeysPackage,
+  UiStringAudioKeysPackageSchema,
+} from './ui_string_audio_keys';
+
+test('valid structure', () => {
+  const testPackage: UiStringAudioKeysPackage = {
+    [LanguageCode.SPANISH]: {
+      appString: ['a1b2c3', 'f5e6d7'],
+      appStringNested: {
+        nestedA: ['aaa123'],
+        nestedB: ['bbb333'],
+      },
+    },
+    [LanguageCode.ENGLISH]: {
+      appString: ['4f4f4f', '3d3d3d'],
+    },
+  };
+
+  const result = safeParseJson(
+    JSON.stringify(testPackage),
+    UiStringAudioKeysPackageSchema
+  );
+
+  expect(result.isOk()).toEqual(true);
+  expect(result.ok()).toEqual(testPackage);
+});
+
+test('invalid language code', () => {
+  const result = safeParseJson(
+    JSON.stringify({
+      [LanguageCode.SPANISH]: {
+        appString: ['a1b2c3', 'f5e6d7'],
+      },
+      Klingon: {
+        appString: ['4f4f4f', '3d3d3d'],
+      },
+    }),
+    UiStringAudioKeysPackageSchema
+  );
+
+  expect(result.isOk()).toEqual(false);
+});
+
+test('invalid values', () => {
+  const result = safeParseJson(
+    JSON.stringify({
+      [LanguageCode.SPANISH]: {
+        valid: ['a1b2c3', 'f5e6d7'],
+        invalid: '4f4f4f',
+      },
+    }),
+    UiStringAudioKeysPackageSchema
+  );
+
+  expect(result.isOk()).toEqual(false);
+});
+
+test('invalid nesting', () => {
+  const result = safeParseJson(
+    JSON.stringify({
+      [LanguageCode.SPANISH]: {
+        appString: ['a1b2c3', 'f5e6d7'],
+        nested: {
+          too: {
+            deeply: ['only one level of nesting supported for translations'],
+          },
+        },
+      },
+    }),
+    UiStringAudioKeysPackageSchema
+  );
+
+  expect(result.isOk()).toEqual(false);
+});

--- a/libs/types/src/ui_string_audio_keys.ts
+++ b/libs/types/src/ui_string_audio_keys.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+
+import { Dictionary } from './generic';
+import { LanguageCode } from './language_code';
+
+type AudioKeyList = string[];
+
+/**
+ * Map of UI string key to a sequence of related speech audio clip keys.
+ *
+ * Follows i18next key schema and supports one level of nesting.
+ * See: https://www.i18next.com/misc/json-format
+ */
+export type UiStringAudioKeys = Dictionary<
+  AudioKeyList | Dictionary<AudioKeyList>
+>;
+
+const AudioKeyListSchema: z.ZodType<AudioKeyList> = z.array(z.string());
+
+/**
+ * Map of UI string key to a sequence of related speech audio clip keys.
+ *
+ * Follows i18next key schema and supports one level of nesting.
+ * See: https://www.i18next.com/misc/json-format
+ */
+export const UiStringAudioKeysSchema: z.ZodType<UiStringAudioKeys> = z.record(
+  z.union([AudioKeyListSchema, z.record(AudioKeyListSchema)])
+);
+
+/**
+ * Map of language code to {@link UiStringAudioKeys}.
+ */
+export type UiStringAudioKeysPackage = Partial<
+  Record<LanguageCode, UiStringAudioKeys>
+>;
+
+/**
+ * Map of language code to {@link UiStringAudioKeys}.
+ */
+export const UiStringAudioKeysPackageSchema: z.ZodType<UiStringAudioKeysPackage> =
+  z.record(z.nativeEnum(LanguageCode), UiStringAudioKeysSchema);

--- a/libs/types/src/ui_string_translations.test.ts
+++ b/libs/types/src/ui_string_translations.test.ts
@@ -1,0 +1,63 @@
+import { safeParseJson } from './generic';
+import { LanguageCode } from './language_code';
+import {
+  UiStringsPackage,
+  UiStringsPackageSchema,
+} from './ui_string_translations';
+
+test('valid structure', () => {
+  const testPackage: UiStringsPackage = {
+    [LanguageCode.SPANISH]: {
+      appString: 'ES app string translation',
+      appStringNested: {
+        nestedA: 'nested app string translation A',
+        nestedB: 'nested app string translation B',
+      },
+    },
+    [LanguageCode.ENGLISH]: {
+      appString: 'EN app string translation',
+    },
+  };
+
+  const result = safeParseJson(
+    JSON.stringify(testPackage),
+    UiStringsPackageSchema
+  );
+
+  expect(result.isOk()).toEqual(true);
+  expect(result.ok()).toEqual(testPackage);
+});
+
+test('invalid language code', () => {
+  const result = safeParseJson(
+    JSON.stringify({
+      [LanguageCode.SPANISH]: {
+        appString: 'ES app string translation',
+      },
+      Klingon: {
+        appString: 'Klingon app string translation',
+      },
+    }),
+    UiStringsPackageSchema
+  );
+
+  expect(result.isOk()).toEqual(false);
+});
+
+test('invalid structure', () => {
+  const result = safeParseJson(
+    JSON.stringify({
+      [LanguageCode.SPANISH]: {
+        appString: 'ES app string translation',
+        nested: {
+          too: {
+            deeply: 'only one level of nesting supported for translations',
+          },
+        },
+      },
+    }),
+    UiStringsPackageSchema
+  );
+
+  expect(result.isOk()).toEqual(false);
+});

--- a/libs/types/src/ui_string_translations.ts
+++ b/libs/types/src/ui_string_translations.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+import { Dictionary } from './generic';
+import { LanguageCode } from './language_code';
+
+/**
+ * Map of UI string key to related translation in a given language.
+ *
+ * Follows i18next key schema and supports one level of nesting.
+ * See: https://www.i18next.com/misc/json-format
+ */
+export type UiStringTranslations = Dictionary<string | Dictionary<string>>;
+
+/**
+ * Map of UI string key to related translation in a given language.
+ *
+ * Follows i18next key schema and supports one level of nesting.
+ * See: https://www.i18next.com/misc/json-format
+ */
+export const UiStringTranslationsSchema: z.ZodType<UiStringTranslations> =
+  z.record(z.union([z.string(), z.record(z.string())]));
+
+/**
+ * Map of language code to {@link UiStringTranslations}.
+ */
+export type UiStringsPackage = Partial<
+  Record<LanguageCode, UiStringTranslations>
+>;
+
+/**
+ * Map of language code to {@link UiStringTranslations}.
+ */
+export const UiStringsPackageSchema: z.ZodType<UiStringsPackage> = z.record(
+  z.nativeEnum(LanguageCode),
+  UiStringTranslationsSchema
+);

--- a/libs/utils/src/ballot_package.ts
+++ b/libs/utils/src/ballot_package.ts
@@ -1,5 +1,6 @@
 import {
   BallotPackage,
+  BallotPackageFileName,
   DEFAULT_SYSTEM_SETTINGS,
   safeParseElectionDefinition,
   safeParseSystemSettings,
@@ -21,19 +22,25 @@ export async function readBallotPackageFromBuffer(
   const zipfile = await openZip(source);
   const zipName = 'ballot package';
   const entries = getEntries(zipfile);
-  const electionEntry = getFileByName(entries, 'election.json', zipName);
+  const electionEntry = getFileByName(
+    entries,
+    BallotPackageFileName.ELECTION,
+    zipName
+  );
 
   let systemSettingsData = JSON.stringify(DEFAULT_SYSTEM_SETTINGS);
 
   const systemSettingsEntry = maybeGetFileByName(
     entries,
-    'systemSettings.json'
+    BallotPackageFileName.SYSTEM_SETTINGS
   );
   if (systemSettingsEntry) {
     systemSettingsData = await readTextEntry(systemSettingsEntry);
   }
 
   const electionData = await readTextEntry(electionEntry);
+
+  // TODO(kofi): Load metadata, translations, audio from zip file.
 
   return {
     electionDefinition:


### PR DESCRIPTION
## Overview

Related tech spec [here](https://docs.google.com/document/d/1a2GRj1g4aOawEssPdTCgbv-qs28d-M_dyMEfzm4I4nM/edit?usp=sharing).

Adding new types/schemas for translation/audio-related data files we'll be adding to the election package zip file:
- `BallotPackageMetadata`: Will be loaded from `metadata.json` - currently just contains a `version` field which will allow us to verify the ballot package version and the machine build version match up. Wasn't sure if this might make sense to add to the existing `SystemSettings` instead - LMK if you think so.
- `UiStringsPackage`: Per-language string translations for all enabled languages - to be loaded from `appStrings.json` and merged with additional election strings translations from the election CDF.
- `UiStringAudioClips`: List of audio clips, with associated metadata. These will load from an `audioClips.jsonl` file in the zip package - went with that instead of a single JSON object just in case we need to stream them to the DB in the future, instead of loading them all into memory first.
- `UiStringAudioKeysPackage`: Per-language mappings from string key to a sequence of audio keys, to be loaded from `audioKeys.json`.

## Testing Plan
- Added a few JSON parsing unit tests to verify the schemas are set up properly

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
