### PR TITLE
Ballot Count Report Component

### DIFF
--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -53,10 +53,8 @@ export interface CastVoteRecordFileMetadata {
 /**
  * Most basic information about a scanner batch.
  */
-export interface ScannerBatch {
-  batchId: string;
+export interface ScannerBatch extends Tabulation.ScannerBatch {
   label: string;
-  scannerId: string;
   electionId: string;
 }
 

--- a/libs/types/src/tabulation.ts
+++ b/libs/types/src/tabulation.ts
@@ -197,3 +197,13 @@ export interface ContestWriteInSummary {
 export interface ElectionWriteInSummary {
   contestWriteInSummaries: Record<ContestId, ContestWriteInSummary>;
 }
+
+/**
+ * Minimal information about a scanner batch.
+ */
+export interface ScannerBatch {
+  batchId: string;
+  scannerId: string;
+}
+
+export const BATCH_ID_DISPLAY_LENGTH = 8;

--- a/libs/ui/src/reports/ballot_count_report.stories.tsx
+++ b/libs/ui/src/reports/ballot_count_report.stories.tsx
@@ -1,0 +1,289 @@
+import { Meta, StoryObj } from '@storybook/react';
+import {
+  electionTwoPartyPrimaryDefinition,
+  electionWithMsEitherNeitherDefinition,
+} from '@votingworks/fixtures';
+import { Tabulation } from '@votingworks/types';
+import styled from 'styled-components';
+import {
+  BallotCountReport,
+  BallotCountReportProps,
+} from './ballot_count_report';
+
+const ReportPreview = styled.div`
+  section {
+    background: #fff;
+    width: 8.5in;
+    min-height: 11in;
+    padding: 0.5in;
+  }
+
+  @media print {
+    section {
+      margin: 0;
+      padding: 0;
+    }
+  }
+`;
+
+function BallotCountReportPreview(props: BallotCountReportProps): JSX.Element {
+  return (
+    <ReportPreview>
+      <BallotCountReport {...props} />
+    </ReportPreview>
+  );
+}
+
+type Story = StoryObj<typeof BallotCountReportPreview>;
+
+const meta: Meta<typeof BallotCountReportPreview> = {
+  title: 'libs-ui/BallotCountReport',
+  component: BallotCountReportPreview,
+  parameters: {
+    backgrounds: {
+      default: 'light gray',
+      values: [
+        { name: 'light gray', value: '#D3D3D3' },
+        { name: 'black', value: '#000000' },
+      ],
+    },
+  },
+};
+
+function cc(
+  bmd: number,
+  manual?: number,
+  ...hmpb: number[]
+): Tabulation.CardCounts {
+  return {
+    bmd,
+    manual,
+    hmpb,
+  };
+}
+
+const precinctCardCountsList: Tabulation.GroupList<Tabulation.CardCounts> =
+  electionWithMsEitherNeitherDefinition.election.precincts.map(
+    (precinct, index) => ({
+      ...cc(index * 10000, index * 30000, index * 50000),
+      precinctId: precinct.id,
+    })
+  );
+
+const precinctReportArgs: BallotCountReportProps = {
+  ballotCountBreakdown: 'none',
+  title: 'Official Full Election Ballot Count Report',
+  testId: 'tally-report',
+  electionDefinition: electionWithMsEitherNeitherDefinition,
+  scannerBatches: [],
+  groupBy: {
+    groupByPrecinct: true,
+  },
+  cardCountsList: precinctCardCountsList,
+};
+
+export const PrecinctReport: Story = {
+  args: precinctReportArgs,
+};
+
+const primaryPrecinctCardCountsList: Tabulation.GroupList<Tabulation.CardCounts> =
+  electionWithMsEitherNeitherDefinition.election.precincts.flatMap(
+    (precinct, index) => [
+      {
+        ...cc(index, index * 3, index * 5),
+        precinctId: precinct.id,
+        partyId: '2',
+      },
+      {
+        ...cc(index * 2, index * 4, index * 6),
+        precinctId: precinct.id,
+        partyId: '3',
+      },
+    ]
+  );
+
+const primaryPrecinctReportArgs: BallotCountReportProps = {
+  ballotCountBreakdown: 'none',
+  title: 'Official Full Election Ballot Count Report',
+  testId: 'tally-report',
+  electionDefinition: {
+    ...electionWithMsEitherNeitherDefinition,
+    election: {
+      ...electionWithMsEitherNeitherDefinition.election,
+      type: 'primary',
+    },
+  },
+  scannerBatches: [],
+  groupBy: {
+    groupByPrecinct: true,
+    groupByParty: true,
+  },
+  cardCountsList: primaryPrecinctCardCountsList,
+};
+
+export const PrimaryPrecinctReport: Story = {
+  args: primaryPrecinctReportArgs,
+};
+
+const votingMethodCardCountsList: Tabulation.GroupList<Tabulation.CardCounts> =
+  [
+    {
+      ...cc(342, 174, 237),
+      votingMethod: 'absentee',
+    },
+    {
+      ...cc(132, 777, 342),
+      votingMethod: 'precinct',
+    },
+  ];
+
+const votingMethodReportArgs: BallotCountReportProps = {
+  ballotCountBreakdown: 'none',
+  title: 'Full Election Ballot Count Report',
+  testId: 'tally-report',
+  electionDefinition: electionTwoPartyPrimaryDefinition,
+  scannerBatches: [],
+  groupBy: {
+    groupByVotingMethod: true,
+  },
+  cardCountsList: votingMethodCardCountsList,
+};
+
+export const VotingMethodReport: Story = {
+  args: votingMethodReportArgs,
+};
+
+const noGroupsCardCountsList: Tabulation.GroupList<Tabulation.CardCounts> = [
+  cc(12312, 324234, 234233),
+];
+
+const noGroupsReportArgs: BallotCountReportProps = {
+  ballotCountBreakdown: 'none',
+  title: 'Full Election Ballot Count Report',
+  testId: 'tally-report',
+  electionDefinition: electionTwoPartyPrimaryDefinition,
+  scannerBatches: [],
+  groupBy: {},
+  cardCountsList: noGroupsCardCountsList,
+};
+
+export const NoGroupsReport: Story = {
+  args: noGroupsReportArgs,
+};
+
+const singleGroupCardCountsList: Tabulation.GroupList<Tabulation.CardCounts> = [
+  { ...cc(12312, 324234, 234233), batchId: 'batch-1' },
+];
+
+const singleGroupReportArgs: BallotCountReportProps = {
+  ballotCountBreakdown: 'none',
+  title: 'Full Election Ballot Count Report',
+  testId: 'tally-report',
+  electionDefinition: electionTwoPartyPrimaryDefinition,
+  scannerBatches: [
+    {
+      batchId: 'batch-1',
+      scannerId: 'scanner-1',
+    },
+  ],
+  groupBy: { groupByBatch: true },
+  cardCountsList: singleGroupCardCountsList,
+};
+
+export const SingleGroupReport: Story = {
+  args: singleGroupReportArgs,
+};
+
+const maxReportScannerBatches: Tabulation.ScannerBatch[] = [
+  {
+    batchId: 'batch-10',
+    scannerId: 'scanner-1',
+  },
+  {
+    batchId: 'batch-11',
+    scannerId: 'scanner-1',
+  },
+  {
+    batchId: 'batch-20',
+    scannerId: 'scanner-2',
+  },
+  {
+    batchId: 'batch-21',
+    scannerId: 'scanner-2',
+  },
+  {
+    batchId: 'batch-22',
+    scannerId: 'scanner-2',
+  },
+  {
+    batchId: 'batch-30',
+    scannerId: 'scanner-3',
+  },
+  {
+    batchId: 'batch-31',
+    scannerId: 'scanner-3',
+  },
+  {
+    batchId: 'batch-32',
+    scannerId: 'scanner-3',
+  },
+];
+
+const maxCardCountsList: Tabulation.GroupList<Tabulation.CardCounts> = (() => {
+  const list: Tabulation.GroupList<Tabulation.CardCounts> = [];
+  const { election } = electionTwoPartyPrimaryDefinition;
+  let i = 0;
+  for (const ballotStyle of election.ballotStyles) {
+    for (const precinctId of ballotStyle.precincts) {
+      for (const batch of maxReportScannerBatches) {
+        for (const votingMethod of Tabulation.SUPPORTED_VOTING_METHODS) {
+          list.push({
+            ...cc(i, i * 2, i * 3),
+            precinctId,
+            ballotStyleId: ballotStyle.id,
+            votingMethod,
+            batchId: batch.batchId,
+          });
+          i += 1;
+        }
+      }
+    }
+  }
+  return list;
+})();
+
+const maxReportArgs: BallotCountReportProps = {
+  ballotCountBreakdown: 'none',
+  title: 'Official Full Election Ballot Count Report',
+  testId: 'tally-report',
+  electionDefinition: {
+    ...electionTwoPartyPrimaryDefinition,
+    election: {
+      ...electionTwoPartyPrimaryDefinition.election,
+      precincts: [
+        {
+          id: 'precinct-1',
+          name: 'Precinct 1',
+        },
+        {
+          id: 'precinct-2',
+          name: 'Precinct With Super Duper Long Name',
+        },
+      ],
+    },
+  },
+  scannerBatches: maxReportScannerBatches,
+  groupBy: {
+    groupByPrecinct: true,
+    groupByBatch: true,
+    groupByVotingMethod: true,
+    groupByBallotStyle: true,
+  },
+  cardCountsList: maxCardCountsList,
+};
+
+export const MaxReport: Story = {
+  args: maxReportArgs,
+};
+
+export default meta;

--- a/libs/ui/src/reports/ballot_count_report.test.tsx
+++ b/libs/ui/src/reports/ballot_count_report.test.tsx
@@ -1,0 +1,379 @@
+import { electionTwoPartyPrimaryDefinition } from '@votingworks/fixtures';
+import { Tabulation } from '@votingworks/types';
+import { within } from '@testing-library/react';
+import { Optional } from '@votingworks/basics';
+import { render, screen } from '../../test/react_testing_library';
+import {
+  BallotCountBreakdown,
+  BallotCountReport,
+  ColumnType,
+} from './ballot_count_report';
+
+const mockScannerBatches: Tabulation.ScannerBatch[] = [
+  {
+    batchId: 'batch-10',
+    scannerId: 'scanner-1',
+  },
+  {
+    batchId: 'batch-11',
+    scannerId: 'scanner-1',
+  },
+  {
+    batchId: 'batch-20',
+    scannerId: 'scanner-2',
+  },
+];
+
+// shorthand for creating a card counts object
+function cc(
+  bmd: number,
+  manual?: number,
+  ...hmpb: number[]
+): Tabulation.CardCounts {
+  return {
+    bmd,
+    manual,
+    hmpb,
+  };
+}
+
+type RowData = {
+  [T in ColumnType]?: string;
+};
+
+/**
+ * Parses on screen grid into an array of headers, an array of row text content keyed
+ * by column, and the footer if expected.
+ */
+function parseGrid({ expectFooter }: { expectFooter: boolean }) {
+  const grid = screen.getByTestId('ballot-count-grid');
+
+  const columns = within(grid)
+    .getAllByTestId(/header-/)
+    .map((cell) =>
+      cell.getAttribute('data-testid')?.replace('header-', '')
+    ) as ColumnType[];
+
+  const width = columns.length;
+  const allCells = grid.childNodes;
+  expect(allCells.length % width).toEqual(0);
+
+  const numRows = allCells.length / width;
+  const numDataRows = expectFooter ? numRows - 2 : numRows - 1;
+
+  const rows: RowData[] = [];
+  for (let i = 0; i < numDataRows; i += 1) {
+    const row: RowData = {};
+    const cells = [...allCells].slice((i + 1) * width, (i + 2) * width);
+    for (let j = 0; j < width; j += 1) {
+      if (columns[j] === 'filler') continue;
+      row[columns[j]] = cells[j].textContent ?? undefined;
+    }
+    rows.push(row);
+  }
+
+  const FOOTER_COLUMNS: ColumnType[] = [
+    'scanned',
+    'manual',
+    'hmpb',
+    'bmd',
+    'total',
+  ];
+  let footer: Optional<RowData>;
+  if (expectFooter) {
+    screen.getByText(/Sum Total/);
+    footer = {};
+    const cells = [...allCells].slice((numRows - 1) * width, numRows * width);
+    for (let j = 0; j < width; j += 1) {
+      const column = columns[j];
+      if (!FOOTER_COLUMNS.includes(column)) continue;
+      footer[column] = cells[j].textContent ?? undefined;
+    }
+  }
+
+  return {
+    columns,
+    rows,
+    footer,
+  };
+}
+
+// actual reports like this are not practical, but we can test every column
+test('can render all attribute columns', () => {
+  const electionDefinition = electionTwoPartyPrimaryDefinition;
+
+  const maximalAttributeCardCountsList: Tabulation.GroupList<Tabulation.CardCounts> =
+    [
+      {
+        ...cc(5),
+        ballotStyleId: '1M',
+        precinctId: 'precinct-1',
+        partyId: '0',
+        votingMethod: 'precinct',
+        batchId: 'batch-10',
+        scannerId: 'scanner-1',
+      },
+      {
+        ...cc(5),
+        ballotStyleId: '2F',
+        precinctId: 'precinct-2',
+        partyId: '1',
+        votingMethod: 'absentee',
+        batchId: 'batch-20',
+        scannerId: 'scanner-2',
+      },
+    ];
+
+  // render as if all columns were specified
+  const { unmount } = render(
+    <BallotCountReport
+      title="Full Election Ballot Count Report"
+      electionDefinition={electionDefinition}
+      scannerBatches={mockScannerBatches}
+      groupBy={{
+        groupByPrecinct: true,
+        groupByBallotStyle: true,
+        groupByParty: true,
+        groupByVotingMethod: true,
+        groupByScanner: true,
+        groupByBatch: true,
+      }}
+      cardCountsList={maximalAttributeCardCountsList}
+      ballotCountBreakdown="none"
+    />
+  );
+
+  const expectedColumns: ColumnType[] = [
+    'precinct',
+    'ballot-style',
+    'party',
+    'voting-method',
+    'scanner',
+    'batch',
+    'filler',
+    'total',
+  ];
+  const expectedRows: RowData[] = [
+    {
+      'ballot-style': '1M',
+      batch: 'batch-10',
+      party: 'Ma',
+      precinct: 'Precinct 1',
+      scanner: 'scanner-1',
+      total: '5',
+      'voting-method': 'Precinct',
+    },
+    {
+      'ballot-style': '2F',
+      batch: 'batch-20',
+      party: 'F',
+      precinct: 'Precinct 2',
+      scanner: 'scanner-2',
+      total: '5',
+      'voting-method': 'Absentee',
+    },
+  ];
+  const expectedFooter: RowData = {
+    total: '10',
+  };
+
+  {
+    const { columns, rows, footer } = parseGrid({ expectFooter: true });
+    expect(columns).toEqual(expectedColumns);
+    expect(rows).toEqual(expectedRows);
+    expect(footer).toEqual(expectedFooter);
+  }
+
+  unmount();
+
+  // expect same report, but report should infer the inferrable columns (scanner, party)
+  render(
+    <BallotCountReport
+      title="Full Election Ballot Count Report"
+      electionDefinition={electionDefinition}
+      scannerBatches={mockScannerBatches}
+      groupBy={{
+        groupByPrecinct: true,
+        groupByBallotStyle: true,
+        groupByVotingMethod: true,
+        groupByBatch: true,
+      }}
+      cardCountsList={maximalAttributeCardCountsList.map((cardCounts) => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { scannerId, partyId, ...rest } = cardCounts;
+        return rest;
+      })}
+      ballotCountBreakdown="none"
+    />
+  );
+
+  {
+    const { columns, rows, footer } = parseGrid({ expectFooter: true });
+    expect(columns).toEqual(expectedColumns);
+    expect(rows).toEqual(expectedRows);
+    expect(footer).toEqual(expectedFooter);
+  }
+});
+
+test('ballot count breakdowns', () => {
+  const electionDefinition = electionTwoPartyPrimaryDefinition;
+
+  const cardCountsList: Tabulation.GroupList<Tabulation.CardCounts> = [
+    {
+      ...cc(5, undefined, 10),
+      precinctId: 'precinct-1',
+    },
+    {
+      ...cc(1, 4, 5),
+      precinctId: 'precinct-2',
+    },
+  ];
+
+  const testCases: Array<{
+    breakdown: BallotCountBreakdown;
+    expectedColumns: ColumnType[];
+    expectedRows: RowData[];
+    expectedFooter: RowData;
+  }> = [
+    {
+      breakdown: 'none',
+      expectedColumns: ['precinct', 'filler', 'total'],
+      expectedRows: [
+        {
+          precinct: 'Precinct 1',
+          total: '15',
+        },
+        {
+          precinct: 'Precinct 2',
+          total: '10',
+        },
+      ],
+      expectedFooter: {
+        total: '25',
+      },
+    },
+    {
+      breakdown: 'manual',
+      expectedColumns: ['precinct', 'filler', 'manual', 'scanned', 'total'],
+      expectedRows: [
+        {
+          precinct: 'Precinct 1',
+          manual: '0',
+          scanned: '15',
+          total: '15',
+        },
+        {
+          precinct: 'Precinct 2',
+          manual: '4',
+          scanned: '6',
+          total: '10',
+        },
+      ],
+      expectedFooter: {
+        manual: '4',
+        scanned: '21',
+        total: '25',
+      },
+    },
+    {
+      breakdown: 'all',
+      expectedColumns: ['precinct', 'filler', 'manual', 'bmd', 'hmpb', 'total'],
+      expectedRows: [
+        {
+          precinct: 'Precinct 1',
+          manual: '0',
+          bmd: '5',
+          hmpb: '10',
+          total: '15',
+        },
+        {
+          precinct: 'Precinct 2',
+          manual: '4',
+          bmd: '1',
+          hmpb: '5',
+          total: '10',
+        },
+      ],
+      expectedFooter: {
+        manual: '4',
+        bmd: '6',
+        hmpb: '15',
+        total: '25',
+      },
+    },
+  ];
+
+  for (const testCase of testCases) {
+    const { breakdown, expectedColumns, expectedRows, expectedFooter } =
+      testCase;
+    const { unmount } = render(
+      <BallotCountReport
+        title="Full Election Ballot Count Report"
+        electionDefinition={electionDefinition}
+        scannerBatches={mockScannerBatches}
+        groupBy={{
+          groupByPrecinct: true,
+        }}
+        cardCountsList={cardCountsList}
+        ballotCountBreakdown={breakdown}
+      />
+    );
+    const { columns, rows, footer } = parseGrid({ expectFooter: true });
+    expect(columns).toEqual(expectedColumns);
+    expect(rows).toEqual(expectedRows);
+    expect(footer).toEqual(expectedFooter);
+    unmount();
+  }
+});
+
+test('ungrouped case', () => {
+  const electionDefinition = electionTwoPartyPrimaryDefinition;
+
+  const cardCounts: Tabulation.CardCounts = cc(10, undefined, 15);
+
+  // render as if all columns were specified
+  render(
+    <BallotCountReport
+      title="Full Election Ballot Count Report"
+      electionDefinition={electionDefinition}
+      scannerBatches={mockScannerBatches}
+      groupBy={{}}
+      cardCountsList={[cardCounts]}
+      ballotCountBreakdown="all"
+    />
+  );
+
+  const { columns, rows } = parseGrid({ expectFooter: false });
+  expect(columns).toEqual(['bmd', 'hmpb', 'total']);
+  expect(rows).toEqual([
+    {
+      bmd: '10',
+      hmpb: '15',
+      total: '25',
+    },
+  ]);
+});
+
+test('title, metadata, and custom filters', () => {
+  const electionDefinition = electionTwoPartyPrimaryDefinition;
+
+  // render as if all columns were specified
+  render(
+    <BallotCountReport
+      title="Custom Filter Ballot Count Report"
+      electionDefinition={electionDefinition}
+      scannerBatches={mockScannerBatches}
+      groupBy={{}}
+      cardCountsList={[]}
+      ballotCountBreakdown="none"
+      customFilter={{
+        precinctIds: ['precinct-1'],
+      }}
+    />
+  );
+
+  screen.getByText('Custom Filter Ballot Count Report');
+  expect(screen.getByTestId('custom-filter-summary').textContent).toEqual(
+    'Precinct: Precinct 1'
+  );
+});

--- a/libs/ui/src/reports/ballot_count_report.test.tsx
+++ b/libs/ui/src/reports/ballot_count_report.test.tsx
@@ -50,8 +50,8 @@ function parseGrid({ expectFooter }: { expectFooter: boolean }) {
 
   const columns = within(grid)
     .getAllByTestId(/header-/)
-    .map(
-      (cell) => cell.getAttribute('data-testid')?.replace('header-', '')
+    .map((cell) =>
+      cell.getAttribute('data-testid')?.replace('header-', '')
     ) as Column[];
 
   const width = columns.length;

--- a/libs/ui/src/reports/ballot_count_report.tsx
+++ b/libs/ui/src/reports/ballot_count_report.tsx
@@ -43,7 +43,7 @@ const COLUMNS = [
   'right-fill', // spacing to bring the total away from the right margin
 ] as const;
 
-export type Column = (typeof COLUMNS)[number];
+export type Column = typeof COLUMNS[number];
 
 const COLUMN_LABELS: Record<Column, string> = {
   precinct: 'Precinct',

--- a/libs/ui/src/reports/ballot_count_report.tsx
+++ b/libs/ui/src/reports/ballot_count_report.tsx
@@ -1,0 +1,425 @@
+import { ElectionDefinition, Tabulation } from '@votingworks/types';
+import { assert, assertDefined, throwIllegalValue } from '@votingworks/basics';
+import styled, { ThemeProvider } from 'styled-components';
+import {
+  combineCardCounts,
+  determinePartyId,
+  format,
+  getBallotCount,
+  getGroupKey,
+  getHmpbBallotCount,
+  getPartyById,
+  getPrecinctById,
+  getScannedBallotCount,
+  isGroupByEmpty,
+} from '@votingworks/utils';
+import React from 'react';
+import { ReportSection, tallyReportThemeFn, TallyReport } from './tally_report';
+import { LogoMark } from '../logo_mark';
+import { TallyReportMetadata } from './tally_report_metadata';
+import { CustomFilterSummary } from './custom_filter_summary';
+
+/**
+ * Columns that may appear in a the ballot count report table.
+ */
+const COLUMN_TYPES = [
+  'precinct',
+  'ballot-style',
+  'party',
+  'voting-method',
+  'scanner',
+  'batch',
+  'filler', // spacing between the attributes and the counts
+  'manual',
+  'scanned',
+  'bmd',
+  'hmpb',
+  'total',
+] as const;
+
+export type ColumnType = typeof COLUMN_TYPES[number];
+
+const COLUMN_LABELS: Record<ColumnType, string> = {
+  precinct: 'Precinct',
+  'ballot-style': 'Ballot Style',
+  party: 'Party',
+  'voting-method': 'Voting Method',
+  scanner: 'Scanner ID',
+  batch: 'Batch ID',
+  filler: '',
+  manual: 'Manual',
+  scanned: 'Scanned',
+  bmd: 'BMD',
+  hmpb: 'HMPB',
+  total: 'Total',
+};
+
+// minmax(0, max-content) = fit to content unless table is overflowing
+// max-content = fit to content
+// fr = expand to fit remaining space proportionally
+const COLUMN_WIDTHS: Record<ColumnType, string> = {
+  precinct: 'minmax(0, max-content)',
+  'ballot-style': 'minmax(0, max-content)',
+  party: 'minmax(0, max-content)',
+  'voting-method': 'minmax(0, max-content)',
+  scanner: 'minmax(0, max-content)',
+  batch: 'minmax(0, max-content)',
+  filler: '5fr',
+  manual: 'max-content',
+  scanned: 'max-content',
+  bmd: 'max-content',
+  hmpb: 'max-content',
+  total: 'minmax(min-content, 2fr)',
+};
+
+const BallotCountGrid = styled.div<{
+  columns: ColumnType[];
+  hasGroups: boolean;
+}>`
+  width: 7.5in;
+  display: grid;
+  grid-template-columns: ${({ columns }) =>
+    columns.map((c) => COLUMN_WIDTHS[c]).join(' ')};
+  page-break-inside: auto;
+  font-size: 14px;
+
+  span {
+    border-bottom: 0.5px solid #ddd;
+    padding: 0.25em 0.5em 0.25em 0.25em;
+    white-space: nowrap;
+    text-align: left;
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+  }
+
+  /* vertical borders */
+  ${({ columns }) => {
+    const numColumns = columns.length;
+    let css = ``;
+    for (let i = 2; i <= numColumns; i += 1) {
+      css += `span:nth-child(${numColumns}n + ${i}) { 
+        border-left: 1px solid #ddd;
+       }`;
+    }
+    return css;
+  }}
+
+  /* row striping */
+  ${({ columns }) => {
+    const numColumns = columns.length;
+    let css = ``;
+    for (let i = 1; i <= numColumns; i += 1) {
+      css += `span:nth-child(${2 * numColumns}n + ${i}) { 
+        background-color: #f5f5f5;
+       }`;
+    }
+    return css;
+  }}
+
+  /* header */
+  span:nth-child(-n + ${({ columns }) => columns.length}) {
+    font-weight: 500;
+    background-color: white;
+    border-bottom-width: 2px;
+  }
+
+  /* footer */
+  span:nth-last-child(-n + ${({ columns }) => columns.length}) {
+    background-color: white;
+    border-bottom: none;
+    font-weight: ${({ hasGroups }) => (hasGroups ? 500 : 400)};
+    border-top: ${({ hasGroups }) => (hasGroups ? '1.5px' : '0')} solid #ddd;
+  }
+
+  .no-border-left {
+    border-left: none !important;
+  }
+
+  .sum-total {
+    position: relative;
+    overflow-x: visible;
+    text-overflow: unset;
+  }
+`;
+
+type NumberColumnType = Extract<
+  ColumnType,
+  'manual' | 'scanned' | 'bmd' | 'hmpb' | 'total'
+>;
+
+function getCount(
+  cardCounts: Tabulation.CardCounts,
+  column: NumberColumnType
+): string {
+  const number = (() => {
+    switch (column) {
+      case 'manual':
+        return cardCounts.manual ?? 0;
+      case 'scanned':
+        return getScannedBallotCount(cardCounts);
+      case 'bmd':
+        return cardCounts.bmd;
+      case 'hmpb':
+        return getHmpbBallotCount(cardCounts);
+      case 'total':
+        return getBallotCount(cardCounts);
+      // istanbul ignore next - compile time check for completeness
+      default:
+        throwIllegalValue(column);
+    }
+  })();
+
+  return format.count(number);
+}
+
+export type BallotCountBreakdown = 'none' | 'manual' | 'all';
+
+function BallotCountTable({
+  electionDefinition,
+  scannerBatches,
+  cardCountsList,
+  groupBy,
+  ballotCountBreakdown,
+}: {
+  electionDefinition: ElectionDefinition;
+  scannerBatches: Tabulation.ScannerBatch[];
+  cardCountsList: Tabulation.GroupList<Tabulation.CardCounts>;
+  groupBy: Tabulation.GroupBy;
+  ballotCountBreakdown: BallotCountBreakdown;
+}): JSX.Element {
+  const { election } = electionDefinition;
+  const batchLookup: Record<string, Tabulation.ScannerBatch> = {};
+  for (const scannerBatch of scannerBatches) {
+    batchLookup[scannerBatch.batchId] = scannerBatch;
+  }
+
+  const columns: ColumnType[] = [];
+  const hasGroups = !isGroupByEmpty(groupBy);
+
+  if (groupBy.groupByPrecinct) {
+    columns.push('precinct');
+  }
+  if (groupBy.groupByBallotStyle) {
+    columns.push('ballot-style');
+  }
+  if (
+    election.type === 'primary' &&
+    (groupBy.groupByParty || groupBy.groupByBallotStyle)
+  ) {
+    columns.push('party');
+  }
+  if (groupBy.groupByVotingMethod) {
+    columns.push('voting-method');
+  }
+  if (groupBy.groupByScanner || groupBy.groupByBatch) {
+    columns.push('scanner');
+  }
+  if (groupBy.groupByBatch) {
+    columns.push('batch');
+  }
+
+  if (hasGroups) {
+    columns.push('filler');
+  }
+
+  const hasNonZeroManualData = cardCountsList.some((cc) => !!cc.manual);
+  if (
+    ballotCountBreakdown === 'manual' ||
+    (ballotCountBreakdown === 'all' && hasNonZeroManualData)
+  ) {
+    columns.push('manual');
+  }
+  if (ballotCountBreakdown === 'manual') {
+    columns.push('scanned');
+  }
+  if (ballotCountBreakdown === 'all') {
+    columns.push('bmd');
+    columns.push('hmpb');
+  }
+  columns.push('total');
+
+  const totalCardCounts = combineCardCounts(cardCountsList);
+
+  return (
+    <BallotCountGrid
+      columns={columns}
+      hasGroups={hasGroups}
+      data-testid="ballot-count-grid"
+    >
+      {/* Header */}
+      {columns.map((column) => (
+        <span
+          key={column}
+          className={column === 'filler' ? 'no-border-left' : undefined}
+          data-testid={`header-${column}`}
+        >
+          {COLUMN_LABELS[column]}
+        </span>
+      ))}
+      {/* Body */}
+      {cardCountsList.map((cardCounts) => {
+        const partyId = determinePartyId(electionDefinition, cardCounts);
+        const scannerId =
+          cardCounts.scannerId ??
+          (cardCounts.batchId
+            ? batchLookup[cardCounts.batchId].scannerId
+            : undefined);
+        const rowKey = getGroupKey(cardCounts, groupBy);
+        return (
+          <React.Fragment key={rowKey}>
+            {columns.map((column) => {
+              let content = '';
+              switch (column) {
+                case 'precinct':
+                  content = getPrecinctById(
+                    electionDefinition,
+                    assertDefined(cardCounts.precinctId)
+                  ).name;
+                  break;
+                case 'ballot-style':
+                  content = assertDefined(cardCounts.ballotStyleId);
+                  break;
+                case 'party':
+                  content = getPartyById(
+                    electionDefinition,
+                    assertDefined(partyId)
+                  ).abbrev;
+                  break;
+                case 'voting-method':
+                  content =
+                    Tabulation.VOTING_METHOD_LABELS[
+                      assertDefined(cardCounts.votingMethod)
+                    ];
+                  break;
+                case 'scanner':
+                  content = assertDefined(scannerId);
+                  break;
+                case 'batch':
+                  content = assertDefined(cardCounts.batchId).slice(
+                    0,
+                    Tabulation.BATCH_ID_DISPLAY_LENGTH
+                  );
+                  break;
+                case 'filler':
+                  break;
+                case 'manual':
+                case 'scanned':
+                case 'bmd':
+                case 'hmpb':
+                case 'total':
+                  content = getCount(cardCounts, column);
+                  break;
+                // istanbul ignore next - compile time check for completeness
+                default:
+                  throwIllegalValue(column);
+              }
+              return (
+                <span
+                  key={column}
+                  className={column === 'filler' ? 'no-border-left' : undefined}
+                  data-testid={`data-${column}`}
+                >
+                  {content}
+                </span>
+              );
+            })}
+          </React.Fragment>
+        );
+      })}
+      {/* Footer */}
+      {hasGroups && (
+        <React.Fragment>
+          <span className="sum-total">
+            {ballotCountBreakdown === 'none' ? 'Sum Total' : 'Sum Totals'}
+          </span>
+          {/* eslint-disable-next-line array-callback-return */}
+          {columns.slice(1).map((column) => {
+            assert(column !== COLUMN_TYPES[0]);
+            switch (column) {
+              case 'ballot-style':
+              case 'party':
+              case 'voting-method':
+              case 'scanner':
+              case 'batch':
+              case 'filler':
+                return (
+                  <span
+                    key={column}
+                    data-testid={`footer-${column}`}
+                    className="no-border-left"
+                  />
+                );
+              case 'manual':
+              case 'scanned':
+              case 'bmd':
+              case 'hmpb':
+              case 'total':
+                return (
+                  <span key={column} data-testid={`footer-${column}`}>
+                    {getCount(totalCardCounts, column)}
+                  </span>
+                );
+              // istanbul ignore next - compile time check for completeness
+              default:
+                throwIllegalValue(column);
+            }
+          })}
+        </React.Fragment>
+      )}
+    </BallotCountGrid>
+  );
+}
+
+export interface BallotCountReportProps {
+  title: string;
+  testId?: string;
+  electionDefinition: ElectionDefinition;
+  scannerBatches: Tabulation.ScannerBatch[];
+  cardCountsList: Tabulation.GroupList<Tabulation.CardCounts>;
+  groupBy: Tabulation.GroupBy;
+  customFilter?: Tabulation.Filter;
+  generatedAtTime?: Date;
+  ballotCountBreakdown: BallotCountBreakdown;
+}
+
+export function BallotCountReport({
+  title,
+  testId,
+  electionDefinition,
+  scannerBatches,
+  cardCountsList,
+  groupBy,
+  customFilter,
+  generatedAtTime = new Date(),
+  ballotCountBreakdown,
+}: BallotCountReportProps): JSX.Element {
+  const { election } = electionDefinition;
+
+  return (
+    <ThemeProvider theme={tallyReportThemeFn}>
+      <TallyReport data-testid={testId}>
+        <ReportSection>
+          <LogoMark />
+          <h1>{title}</h1>
+          {customFilter && (
+            <CustomFilterSummary
+              electionDefinition={electionDefinition}
+              filter={customFilter}
+            />
+          )}
+          <TallyReportMetadata
+            generatedAtTime={generatedAtTime}
+            election={election}
+          />
+          <BallotCountTable
+            electionDefinition={electionDefinition}
+            scannerBatches={scannerBatches}
+            cardCountsList={cardCountsList}
+            groupBy={groupBy}
+            ballotCountBreakdown={ballotCountBreakdown}
+          />
+        </ReportSection>
+      </TallyReport>
+    </ThemeProvider>
+  );
+}

--- a/libs/ui/src/reports/index.ts
+++ b/libs/ui/src/reports/index.ts
@@ -6,3 +6,4 @@ export * from './tally_report_metadata';
 export * from './tally_report';
 export * from './admin_tally_report';
 export * from './write_in_adjudication_report';
+export * from './ballot_count_report';

--- a/libs/utils/src/tabulation/lookups.test.ts
+++ b/libs/utils/src/tabulation/lookups.test.ts
@@ -1,4 +1,4 @@
-import { ElectionDefinition } from '@votingworks/types';
+import { ElectionDefinition, Tabulation } from '@votingworks/types';
 import { electionTwoPartyPrimaryDefinition } from '@votingworks/fixtures';
 import {
   getContestById,
@@ -7,6 +7,7 @@ import {
   getPrecinctById,
   getBallotStylesByPartyId,
   getBallotStylesByPrecinctId,
+  determinePartyId,
 } from './lookups';
 
 test('getPrecinctById', () => {
@@ -88,4 +89,34 @@ test('getBallotStylesByPrecinct', () => {
       (bs) => bs.id
     )
   ).toEqual(['1M', '2F']);
+});
+
+test('determinePartyId', () => {
+  const electionDefinition = electionTwoPartyPrimaryDefinition;
+
+  const partyCardCounts: Tabulation.GroupOf<Tabulation.CardCounts> = {
+    partyId: '0',
+    bmd: 1,
+    hmpb: [1],
+  };
+
+  const ballotStyleCardCounts: Tabulation.GroupOf<Tabulation.CardCounts> = {
+    ballotStyleId: '1M',
+    bmd: 1,
+    hmpb: [1],
+  };
+
+  const precinctCardCounts: Tabulation.GroupOf<Tabulation.CardCounts> = {
+    precinctId: 'precinct-1',
+    bmd: 1,
+    hmpb: [1],
+  };
+
+  expect(determinePartyId(electionDefinition, partyCardCounts)).toEqual('0');
+  expect(determinePartyId(electionDefinition, ballotStyleCardCounts)).toEqual(
+    '0'
+  );
+  expect(determinePartyId(electionDefinition, precinctCardCounts)).toEqual(
+    undefined
+  );
 });

--- a/libs/utils/src/tabulation/lookups.ts
+++ b/libs/utils/src/tabulation/lookups.ts
@@ -1,4 +1,4 @@
-import { assert, assertDefined } from '@votingworks/basics';
+import { Optional, assert, assertDefined } from '@votingworks/basics';
 import {
   AnyContest,
   BallotStyle,
@@ -8,6 +8,7 @@ import {
   Party,
   Precinct,
   PrecinctId,
+  Tabulation,
 } from '@votingworks/types';
 
 /**
@@ -113,3 +114,17 @@ export const getBallotStylesByPrecinctId = createElectionMetadataLookupFunction(
     return lookup;
   }
 );
+
+/**
+ * Tries to determine party ID from ballot style ID if not available directly.
+ */
+export function determinePartyId<T>(
+  electionDefinition: ElectionDefinition,
+  group: Tabulation.GroupOf<T>
+): Optional<string> {
+  if (group.partyId) return group.partyId;
+
+  if (!group.ballotStyleId) return undefined;
+
+  return getBallotStyleById(electionDefinition, group.ballotStyleId).partyId;
+}

--- a/libs/utils/src/tabulation/tabulation.test.ts
+++ b/libs/utils/src/tabulation/tabulation.test.ts
@@ -34,6 +34,8 @@ import {
   getGroupKey,
   getGroupSpecifierFromGroupKey,
   getSheetCount,
+  getScannedBallotCount,
+  getHmpbBallotCount,
 } from './tabulation';
 import { CAST_VOTE_RECORD_REPORT_FILENAME } from '../filenames';
 import {
@@ -454,6 +456,38 @@ test('getBallotCount', () => {
       manual: 7,
     })
   ).toEqual(22);
+});
+
+test('getHmpbBallotCount', () => {
+  expect(
+    getHmpbBallotCount({
+      bmd: 10,
+      hmpb: [10, 10],
+    })
+  ).toEqual(10);
+  expect(
+    getHmpbBallotCount({
+      bmd: 10,
+      hmpb: [5, 4, 4, 4],
+      manual: 7,
+    })
+  ).toEqual(5);
+});
+
+test('getScannedBallotCount', () => {
+  expect(
+    getScannedBallotCount({
+      bmd: 10,
+      hmpb: [10, 10],
+    })
+  ).toEqual(20);
+  expect(
+    getScannedBallotCount({
+      bmd: 10,
+      hmpb: [5, 4, 4, 4],
+      manual: 7,
+    })
+  ).toEqual(15);
 });
 
 test('getSheetCount', () => {

--- a/libs/utils/src/tabulation/tabulation.ts
+++ b/libs/utils/src/tabulation/tabulation.ts
@@ -456,11 +456,30 @@ export async function tabulateCastVoteRecords({
 }
 
 /**
- * Applies our current, simple method of determining and overall ballot count,
- * which is taking the count of the first cards of HMPBs plus BMD count.
+ * Applies our current, simple method of determining the hand-marked paper ballot
+ * count, which is taking the count of the first ballot cards.
+ */
+export function getHmpbBallotCount(cardCounts: Tabulation.CardCounts): number {
+  return cardCounts.hmpb[0] ?? 0;
+}
+
+/**
+ * Gets total ballot count including HMPB, BMD, and manually entered ballots.
  */
 export function getBallotCount(cardCounts: Tabulation.CardCounts): number {
-  return cardCounts.bmd + (cardCounts.hmpb[0] ?? 0) + (cardCounts.manual ?? 0);
+  return (
+    cardCounts.bmd + getHmpbBallotCount(cardCounts) + (cardCounts.manual ?? 0)
+  );
+}
+
+/**
+ * Gets scanned ballot count including HMPB and BMD ballots. Does not include
+ * manually entered ballots.
+ */
+export function getScannedBallotCount(
+  cardCounts: Tabulation.CardCounts
+): number {
+  return cardCounts.bmd + getHmpbBallotCount(cardCounts);
 }
 
 /**


### PR DESCRIPTION
## Overview

Adds a `BallotCountReport` component to `libs/ui`, with testing and lots of stories.

@kofi-q in terms of table layout, I ended up getting exactly what I wanted with `grid`. I'm not able to set preferences on _which_ attribute columns to prioritize over others, but I am able to have number rows always fit content, attribute rows usually fit content, and filler rows to expand for appearance.

It's not easy to do through `storybook`, but I confirmed that this prints almost as well as `<table>` when the content stretches across multiple pages.

## Demo Video or Screenshot

| Report Description | Screenshot |
| ------------- | ------------- |
| most common expected use case - by precinct | <img width="817" alt="Screen Shot 2023-09-15 at 3 29 41 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/efe03b5d-f504-4417-b15c-2d7a995add3e"> |
| by precinct, splitting manual results   | <img width="814" alt="Screen Shot 2023-09-15 at 3 31 44 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/ee52da50-84f7-461f-8dfa-93a3f7e9e145">  |
| by precinct, splitting ballot type. shows manual column only if non-zero | <img width="814" alt="Screen Shot 2023-09-15 at 3 31 18 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/e90f33bb-57fd-41f8-bbd6-e4034c5321e5"> |
| all attributes report, impractical but useful for edge case testing  | <img width="817" alt="Screen Shot 2023-09-15 at 3 31 03 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/8388dbc2-86f0-4ea4-9730-9e959ccf3d2d"> |
| only one row  | <img width="814" alt="Screen Shot 2023-09-15 at 3 30 48 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/515e34cd-2007-41ef-9f7a-a9bb60bcc081"> |
| filter only, no groups, all counts - this looks pretty bare and i'm open to special casing it in future PRs, but not worth it yet | <img width="812" alt="Screen Shot 2023-09-15 at 3 30 37 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/7971cfdd-02e6-439c-99a4-78bfd15359f9"> |
| filter only, no groups, total only - this looks *very* bare and i'm open to special casing it in future PRs  | <img width="813" alt="Screen Shot 2023-09-15 at 3 30 22 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/05c56338-3442-40dd-9ec1-6d7ff7b9a3aa">  |
| by voting method  | <img width="818" alt="Screen Shot 2023-09-15 at 3 30 13 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/25a3efb2-ff5c-4695-b013-79ae0de8ef9a">  |
| by precinct + party  | <img width="816" alt="Screen Shot 2023-09-15 at 3 30 00 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/4e9c35d6-c038-4685-8266-e1425fb7f06d"> |


## Testing Plan

## Checklist

- [ ] ~~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
