### PR TITLE
chore(dev-deps): upgrade `ts-jest`

### DIFF
--- a/apps/admin/backend/package.json
+++ b/apps/admin/backend/package.json
@@ -93,7 +93,7 @@
     "nodemon": "^2.0.20",
     "sort-package-json": "^1.50.0",
     "supertest": "^6.0.1",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "29.1.1"
   },
   "engines": {
     "node": ">= 16"

--- a/apps/admin/frontend/package.json
+++ b/apps/admin/frontend/package.json
@@ -167,7 +167,7 @@
     "lint-staged": "^10.0.7",
     "react-refresh": "^0.9.0",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^29.1.1",
+    "ts-jest": "29.1.1",
     "vite": "^2.9.12"
   },
   "packageManager": "pnpm@8.1.0",

--- a/apps/central-scan/backend/package.json
+++ b/apps/central-scan/backend/package.json
@@ -97,7 +97,7 @@
     "nodemon": "^2.0.20",
     "sort-package-json": "^1.50.0",
     "supertest": "^6.0.1",
-    "ts-jest": "29.0.5"
+    "ts-jest": "29.1.1"
   },
   "engines": {
     "node": ">= 12"

--- a/apps/central-scan/frontend/package.json
+++ b/apps/central-scan/frontend/package.json
@@ -122,7 +122,7 @@
     "react-dev-utils": "^12.0.1",
     "react-refresh": "^0.9.0",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^29.1.1",
+    "ts-jest": "29.1.1",
     "type-fest": "^0.18.0",
     "vite": "^2.9.12",
     "zip-stream": "^3.0.1"

--- a/apps/design/backend/package.json
+++ b/apps/design/backend/package.json
@@ -86,7 +86,7 @@
     "nodemon": "^2.0.20",
     "sort-package-json": "^1.50.0",
     "tmp": "^0.2.1",
-    "ts-jest": "29.0.5"
+    "ts-jest": "29.1.1"
   },
   "engines": {
     "node": ">= 12"

--- a/apps/design/frontend/package.json
+++ b/apps/design/frontend/package.json
@@ -104,7 +104,7 @@
     "react-dev-utils": "^12.0.1",
     "sort-package-json": "^1.50.0",
     "tmp": "^0.2.1",
-    "ts-jest": "^29.1.1",
+    "ts-jest": "29.1.1",
     "vite": "^2.9.12"
   },
   "packageManager": "pnpm@8.1.0",

--- a/apps/mark-scan/backend/package.json
+++ b/apps/mark-scan/backend/package.json
@@ -84,7 +84,7 @@
     "lint-staged": "^10.5.3",
     "nodemon": "^2.0.20",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "29.1.1"
   },
   "engines": {
     "node": ">= 16"

--- a/apps/mark-scan/frontend/package.json
+++ b/apps/mark-scan/frontend/package.json
@@ -140,7 +140,7 @@
     "react-dev-utils": "^11.0.3",
     "react-refresh": "^0.10.0",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^29.1.1",
+    "ts-jest": "29.1.1",
     "vite": "^2.9.12"
   },
   "engines": {

--- a/apps/mark/backend/package.json
+++ b/apps/mark/backend/package.json
@@ -74,7 +74,7 @@
     "lint-staged": "^10.5.3",
     "nodemon": "^2.0.20",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "29.1.1"
   },
   "engines": {
     "node": ">= 16"

--- a/apps/mark/frontend/package.json
+++ b/apps/mark/frontend/package.json
@@ -139,7 +139,7 @@
     "react-dev-utils": "^11.0.3",
     "react-refresh": "^0.10.0",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^29.1.1",
+    "ts-jest": "29.1.1",
     "vite": "^2.9.12"
   },
   "engines": {

--- a/apps/scan/backend/package.json
+++ b/apps/scan/backend/package.json
@@ -99,7 +99,7 @@
     "nodemon": "^2.0.20",
     "sort-package-json": "^1.50.0",
     "supertest": "^6.0.1",
-    "ts-jest": "29.0.5",
+    "ts-jest": "29.1.1",
     "wait-for-expect": "^3.0.2"
   },
   "engines": {

--- a/apps/scan/frontend/package.json
+++ b/apps/scan/frontend/package.json
@@ -114,7 +114,7 @@
     "react-dev-utils": "^12.0.1",
     "react-refresh": "^0.9.0",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^29.1.1",
+    "ts-jest": "29.1.1",
     "vite": "^2.9.12"
   },
   "packageManager": "pnpm@8.1.0",

--- a/libs/api/package.json
+++ b/libs/api/package.json
@@ -49,7 +49,7 @@
     "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "^11.0.0",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "29.1.1"
   },
   "packageManager": "pnpm@8.1.0"
 }

--- a/libs/auth/package.json
+++ b/libs/auth/package.json
@@ -67,7 +67,7 @@
     "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "^11.0.0",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^29.1.1",
+    "ts-jest": "29.1.1",
     "wait-for-expect": "^3.0.2"
   },
   "packageManager": "pnpm@8.1.0"

--- a/libs/backend/package.json
+++ b/libs/backend/package.json
@@ -74,7 +74,7 @@
     "lint-staged": "^11.0.0",
     "memory-streams": "^0.1.3",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "29.1.1"
   },
   "packageManager": "pnpm@8.1.0"
 }

--- a/libs/ballot-encoder/package.json
+++ b/libs/ballot-encoder/package.json
@@ -51,7 +51,7 @@
     "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "^10.5.1",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "29.1.1"
   },
   "engines": {
     "node": ">= 12"

--- a/libs/ballot-interpreter/package.json
+++ b/libs/ballot-interpreter/package.json
@@ -75,7 +75,7 @@
     "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "^11.0.0",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "29.1.1"
   },
   "packageManager": "pnpm@8.1.0"
 }

--- a/libs/basics/package.json
+++ b/libs/basics/package.json
@@ -46,7 +46,7 @@
     "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "^11.0.0",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "29.1.1"
   },
   "packageManager": "pnpm@8.1.0"
 }

--- a/libs/cdf-schema-builder/package.json
+++ b/libs/cdf-schema-builder/package.json
@@ -52,7 +52,7 @@
     "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "^10.5.1",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "29.1.1"
   },
   "engines": {
     "node": ">= 12"

--- a/libs/converter-nh-accuvote/package.json
+++ b/libs/converter-nh-accuvote/package.json
@@ -55,6 +55,6 @@
     "jest": "^29.6.2",
     "jest-junit": "^16.0.0",
     "jest-watch-typeahead": "^2.2.2",
-    "ts-jest": "29.0.5"
+    "ts-jest": "29.1.1"
   }
 }

--- a/libs/custom-paper-handler/package.json
+++ b/libs/custom-paper-handler/package.json
@@ -45,7 +45,7 @@
     "jest-junit": "^16.0.0",
     "jest-mock-extended": "^3.0.4",
     "jest-watch-typeahead": "^2.2.2",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "29.1.1"
   },
   "packageManager": "pnpm@8.1.0"
 }

--- a/libs/custom-scanner/package.json
+++ b/libs/custom-scanner/package.json
@@ -45,7 +45,7 @@
     "jest-junit": "^16.0.0",
     "jest-mock-extended": "^3.0.4",
     "jest-watch-typeahead": "^2.2.2",
-    "ts-jest": "29.0.5",
+    "ts-jest": "29.1.1",
     "vite": "^4.0.4"
   },
   "packageManager": "pnpm@8.1.0"

--- a/libs/cvr-fixture-generator/package.json
+++ b/libs/cvr-fixture-generator/package.json
@@ -48,7 +48,7 @@
     "jest-junit": "^16.0.0",
     "jest-watch-typeahead": "^2.2.2",
     "tmp": "^0.2.1",
-    "ts-jest": "^29.1.1",
+    "ts-jest": "29.1.1",
     "zod": "3.14.4"
   },
   "packageManager": "pnpm@8.1.0"

--- a/libs/db/package.json
+++ b/libs/db/package.json
@@ -37,6 +37,6 @@
     "jest-junit": "^16.0.0",
     "jest-watch-typeahead": "^2.2.2",
     "tmp": "^0.2.1",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "29.1.1"
   }
 }

--- a/libs/dev-dock/backend/package.json
+++ b/libs/dev-dock/backend/package.json
@@ -52,7 +52,7 @@
     "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "^11.0.0",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "29.1.1"
   },
   "packageManager": "pnpm@8.1.0"
 }

--- a/libs/dev-dock/frontend/package.json
+++ b/libs/dev-dock/frontend/package.json
@@ -65,7 +65,7 @@
     "react": "18.2.0",
     "sort-package-json": "^1.50.0",
     "styled-components": "^5.3.11",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "29.1.1"
   },
   "peerDependencies": {
     "@tanstack/react-query": "^4.22.0",

--- a/libs/eslint-plugin-vx/package.json
+++ b/libs/eslint-plugin-vx/package.json
@@ -51,6 +51,6 @@
     "jest-junit": "^16.0.0",
     "jest-watch-typeahead": "^2.2.2",
     "react": "18.2.0",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "29.1.1"
   }
 }

--- a/libs/fixtures/package.json
+++ b/libs/fixtures/package.json
@@ -53,7 +53,7 @@
     "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "^11.0.0",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "29.1.1"
   },
   "packageManager": "pnpm@8.1.0"
 }

--- a/libs/grout/package.json
+++ b/libs/grout/package.json
@@ -49,7 +49,7 @@
     "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "^11.0.0",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "29.1.1"
   },
   "packageManager": "pnpm@8.1.0"
 }

--- a/libs/grout/test-utils/package.json
+++ b/libs/grout/test-utils/package.json
@@ -44,7 +44,7 @@
     "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "^11.0.0",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "29.1.1"
   },
   "peerDependencies": {
     "@votingworks/grout": "workspace:*"

--- a/libs/hmpb/layout/package.json
+++ b/libs/hmpb/layout/package.json
@@ -58,7 +58,7 @@
     "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "^10.5.4",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "29.1.1"
   },
   "peerDependencies": {
     "react": "18.2.0",

--- a/libs/hmpb/render-backend/package.json
+++ b/libs/hmpb/render-backend/package.json
@@ -67,7 +67,7 @@
     "lint-staged": "^10.5.3",
     "sort-package-json": "^1.50.0",
     "tmp": "^0.2.1",
-    "ts-jest": "29.0.5"
+    "ts-jest": "29.1.1"
   },
   "engines": {
     "node": ">= 12"

--- a/libs/image-utils/package.json
+++ b/libs/image-utils/package.json
@@ -55,6 +55,6 @@
     "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "^11.0.0",
     "tmp": "^0.2.1",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "29.1.1"
   }
 }

--- a/libs/logging/package.json
+++ b/libs/logging/package.json
@@ -61,7 +61,7 @@
     "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "^11.0.0",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "29.1.1"
   },
   "packageManager": "pnpm@8.1.0"
 }

--- a/libs/mark-flow-ui/package.json
+++ b/libs/mark-flow-ui/package.json
@@ -116,7 +116,7 @@
     "sort-package-json": "^1.50.0",
     "stream-browserify": "^3.0.0",
     "styled-components": "^5.3.11",
-    "ts-jest": "^29.1.1",
+    "ts-jest": "29.1.1",
     "util": "^0.12.4",
     "vite": "^4.0.4"
   },

--- a/libs/message-coder/package.json
+++ b/libs/message-coder/package.json
@@ -30,7 +30,7 @@
     "jest": "^29.6.2",
     "jest-junit": "^16.0.0",
     "jest-watch-typeahead": "^2.2.2",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "29.1.1"
   },
   "packageManager": "pnpm@8.1.0"
 }

--- a/libs/monorepo-utils/package.json
+++ b/libs/monorepo-utils/package.json
@@ -55,7 +55,7 @@
     "lint-staged": "^11.0.0",
     "prettier": "3.0.3",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^29.1.1",
+    "ts-jest": "29.1.1",
     "typescript": "5.2.2"
   },
   "packageManager": "pnpm@8.1.0"

--- a/libs/res-to-ts/package.json
+++ b/libs/res-to-ts/package.json
@@ -41,6 +41,6 @@
     "jest": "^29.6.2",
     "jest-junit": "^16.0.0",
     "jest-watch-typeahead": "^2.2.2",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "29.1.1"
   }
 }

--- a/libs/test-utils/package.json
+++ b/libs/test-utils/package.json
@@ -63,7 +63,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "29.1.1"
   },
   "packageManager": "pnpm@8.1.0"
 }

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -63,7 +63,7 @@
     "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "^11.0.0",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "29.1.1"
   },
   "packageManager": "pnpm@8.1.0"
 }

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -114,7 +114,7 @@
     "sort-package-json": "^1.50.0",
     "stream-browserify": "^3.0.0",
     "styled-components": "^5.3.11",
-    "ts-jest": "^29.1.1",
+    "ts-jest": "29.1.1",
     "util": "^0.12.4",
     "vite": "^4.0.4"
   },

--- a/libs/usb-drive/package.json
+++ b/libs/usb-drive/package.json
@@ -51,7 +51,7 @@
     "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "^11.0.0",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "29.1.1"
   },
   "packageManager": "pnpm@8.1.0"
 }

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -71,7 +71,7 @@
     "lint-staged": "^11.0.0",
     "node-fetch": "^2.6.0",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "29.0.5"
+    "ts-jest": "29.1.1"
   },
   "packageManager": "pnpm@8.1.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,7 +293,7 @@ importers:
         specifier: ^6.0.1
         version: 6.1.1
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.14.42)(jest@29.6.2)(typescript@5.2.2)
 
   apps/admin/frontend:
@@ -636,7 +636,7 @@ importers:
         specifier: ^1.50.0
         version: 1.53.1
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
       vite:
         specifier: ^2.9.12
@@ -869,8 +869,8 @@ importers:
         specifier: ^6.0.1
         version: 6.1.1
       ts-jest:
-        specifier: 29.0.5
-        version: 29.0.5(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.14.42)(jest@29.6.2)(typescript@5.2.2)
+        specifier: 29.1.1
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.14.42)(jest@29.6.2)(typescript@5.2.2)
 
   apps/central-scan/frontend:
     dependencies:
@@ -1092,7 +1092,7 @@ importers:
         specifier: ^1.50.0
         version: 1.53.1
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
       type-fest:
         specifier: ^0.18.0
@@ -1292,8 +1292,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       ts-jest:
-        specifier: 29.0.5
-        version: 29.0.5(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.14.42)(jest@29.6.2)(typescript@5.2.2)
+        specifier: 29.1.1
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.14.42)(jest@29.6.2)(typescript@5.2.2)
 
   apps/design/frontend:
     dependencies:
@@ -1461,7 +1461,7 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
       vite:
         specifier: ^2.9.12
@@ -1615,7 +1615,7 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.14.30)(jest@29.6.2)(typescript@5.2.2)
 
   apps/mark-scan/frontend:
@@ -1883,7 +1883,7 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
       vite:
         specifier: ^2.9.12
@@ -2050,7 +2050,7 @@ importers:
         specifier: ^1.50.0
         version: 1.53.1
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.14.42)(jest@29.6.2)(typescript@5.2.2)
 
   apps/mark/frontend:
@@ -2315,7 +2315,7 @@ importers:
         specifier: ^1.50.0
         version: 1.53.1
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
       vite:
         specifier: ^2.9.12
@@ -2548,8 +2548,8 @@ importers:
         specifier: ^6.0.1
         version: 6.1.1
       ts-jest:
-        specifier: 29.0.5
-        version: 29.0.5(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.14.42)(jest@29.6.2)(typescript@5.2.2)
+        specifier: 29.1.1
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.14.42)(jest@29.6.2)(typescript@5.2.2)
       wait-for-expect:
         specifier: ^3.0.2
         version: 3.0.2
@@ -2747,7 +2747,7 @@ importers:
         specifier: ^1.50.0
         version: 1.53.1
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
       vite:
         specifier: ^2.9.12
@@ -2835,7 +2835,7 @@ importers:
         specifier: ^1.50.0
         version: 1.53.1
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
 
   libs/auth:
@@ -2944,7 +2944,7 @@ importers:
         specifier: ^1.50.0
         version: 1.53.1
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
       wait-for-expect:
         specifier: ^3.0.2
@@ -3068,7 +3068,7 @@ importers:
         specifier: ^1.50.0
         version: 1.53.1
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
 
   libs/ballot-encoder:
@@ -3129,7 +3129,7 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
 
   libs/ballot-interpreter:
@@ -3235,7 +3235,7 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
 
   libs/basics:
@@ -3281,7 +3281,7 @@ importers:
         specifier: ^1.50.0
         version: 1.53.1
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
 
   libs/cdf-schema-builder:
@@ -3333,7 +3333,7 @@ importers:
         specifier: ^1.50.0
         version: 1.53.1
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
 
   libs/converter-nh-accuvote:
@@ -3439,8 +3439,8 @@ importers:
         specifier: ^2.2.2
         version: 2.2.2(jest@29.6.2)
       ts-jest:
-        specifier: 29.0.5
-        version: 29.0.5(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.14.25)(jest@29.6.2)(typescript@5.2.2)
+        specifier: 29.1.1
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.14.25)(jest@29.6.2)(typescript@5.2.2)
 
   libs/custom-paper-handler:
     dependencies:
@@ -3518,7 +3518,7 @@ importers:
         specifier: ^2.2.2
         version: 2.2.2(jest@29.6.2)
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
 
   libs/custom-scanner:
@@ -3594,8 +3594,8 @@ importers:
         specifier: ^2.2.2
         version: 2.2.2(jest@29.6.2)
       ts-jest:
-        specifier: 29.0.5
-        version: 29.0.5(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.14.30)(jest@29.6.2)(typescript@5.2.2)
+        specifier: 29.1.1
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
       vite:
         specifier: ^4.0.4
         version: 4.0.4(@types/node@16.18.23)
@@ -3676,7 +3676,7 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
       zod:
         specifier: 3.14.4
@@ -3731,7 +3731,7 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
 
   libs/dev-dock/backend:
@@ -3795,7 +3795,7 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
 
   libs/dev-dock/frontend:
@@ -3901,7 +3901,7 @@ importers:
         specifier: ^5.3.11
         version: 5.3.11(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
 
   libs/eslint-plugin-vx:
@@ -3980,7 +3980,7 @@ importers:
         specifier: 18.2.0
         version: 18.2.0
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
 
   libs/fixtures:
@@ -4032,7 +4032,7 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
 
   libs/grout:
@@ -4087,7 +4087,7 @@ importers:
         specifier: ^1.50.0
         version: 1.53.1
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
 
   libs/grout/test-utils:
@@ -4127,7 +4127,7 @@ importers:
         specifier: ^1.50.0
         version: 1.53.1
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
 
   libs/hmpb/layout:
@@ -4209,7 +4209,7 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
 
   libs/hmpb/render-backend:
@@ -4303,8 +4303,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       ts-jest:
-        specifier: 29.0.5
-        version: 29.0.5(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.14.30)(jest@29.6.2)(typescript@5.2.2)
+        specifier: 29.1.1
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.14.30)(jest@29.6.2)(typescript@5.2.2)
 
   libs/image-utils:
     dependencies:
@@ -4379,7 +4379,7 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
 
   libs/logging:
@@ -4461,7 +4461,7 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
 
   libs/mark-flow-ui:
@@ -4696,7 +4696,7 @@ importers:
         specifier: ^5.3.11
         version: 5.3.11(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
       util:
         specifier: ^0.12.4
@@ -4736,7 +4736,7 @@ importers:
         specifier: ^2.2.2
         version: 2.2.2(jest@29.6.2)
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
 
   libs/monorepo-utils:
@@ -4806,7 +4806,7 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
       typescript:
         specifier: 5.2.2
@@ -4864,7 +4864,7 @@ importers:
         specifier: ^2.2.2
         version: 2.2.2(jest@29.6.2)
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
 
   libs/test-utils:
@@ -4955,7 +4955,7 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
 
   libs/types:
@@ -5034,7 +5034,7 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
 
   libs/ui:
@@ -5263,7 +5263,7 @@ importers:
         specifier: ^5.3.11
         version: 5.3.11(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
       util:
         specifier: ^0.12.4
@@ -5330,7 +5330,7 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       ts-jest:
-        specifier: ^29.1.1
+        specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
 
   libs/utils:
@@ -5442,8 +5442,8 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       ts-jest:
-        specifier: 29.0.5
-        version: 29.0.5(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.14.30)(jest@29.6.2)(typescript@5.2.2)
+        specifier: 29.1.1
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
 
   script:
     dependencies:
@@ -19211,7 +19211,7 @@ packages:
       '@types/node': 16.18.23
       chalk: 4.1.2
       ci-info: 3.8.0
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       picomatch: 2.3.1
 
   /jest-validate@29.6.2:
@@ -24150,8 +24150,8 @@ packages:
       typescript: 5.2.2
     dev: true
 
-  /ts-jest@29.0.5(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.14.25)(jest@29.6.2)(typescript@5.2.2):
-    resolution: {integrity: sha512-PL3UciSgIpQ7f6XjVOmbi96vmDHUqAyqDr8YxzopDqX3kfgYtX1cuNeBjP+L9sFXi6nzsGGA6R3fP3DDDJyrxA==}
+  /ts-jest@29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.14.25)(jest@29.6.2)(typescript@5.2.2):
+    resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
     peerDependencies:
@@ -24160,7 +24160,7 @@ packages:
       babel-jest: ^29.0.0
       esbuild: '*'
       jest: ^29.0.0
-      typescript: '>=4.3'
+      typescript: '>=4.3 <6'
     peerDependenciesMeta:
       '@babel/core':
         optional: true
@@ -24175,78 +24175,6 @@ packages:
       '@jest/types': 29.6.1
       bs-logger: 0.2.6
       esbuild: 0.14.25
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.6.2(@types/node@16.18.23)
-      jest-util: 29.6.2
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.5.4
-      typescript: 5.2.2
-      yargs-parser: 21.1.1
-    dev: true
-
-  /ts-jest@29.0.5(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.14.30)(jest@29.6.2)(typescript@5.2.2):
-    resolution: {integrity: sha512-PL3UciSgIpQ7f6XjVOmbi96vmDHUqAyqDr8YxzopDqX3kfgYtX1cuNeBjP+L9sFXi6nzsGGA6R3fP3DDDJyrxA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@jest/types': ^29.0.0
-      babel-jest: ^29.0.0
-      esbuild: '*'
-      jest: ^29.0.0
-      typescript: '>=4.3'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@jest/types':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      '@babel/core': 7.22.9
-      '@jest/types': 29.6.1
-      bs-logger: 0.2.6
-      esbuild: 0.14.30
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.6.2(@types/node@16.18.23)
-      jest-util: 29.6.2
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.5.4
-      typescript: 5.2.2
-      yargs-parser: 21.1.1
-    dev: true
-
-  /ts-jest@29.0.5(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.14.42)(jest@29.6.2)(typescript@5.2.2):
-    resolution: {integrity: sha512-PL3UciSgIpQ7f6XjVOmbi96vmDHUqAyqDr8YxzopDqX3kfgYtX1cuNeBjP+L9sFXi6nzsGGA6R3fP3DDDJyrxA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@jest/types': ^29.0.0
-      babel-jest: ^29.0.0
-      esbuild: '*'
-      jest: ^29.0.0
-      typescript: '>=4.3'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@jest/types':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      '@babel/core': 7.22.9
-      '@jest/types': 29.6.1
-      bs-logger: 0.2.6
-      esbuild: 0.14.42
       fast-json-stable-stringify: 2.1.0
       jest: 29.6.2(@types/node@16.18.23)
       jest-util: 29.6.2


### PR DESCRIPTION
## Overview
Prevents warnings about the TypeScript version, mainly.

## Demo Video or Screenshot
Previously, this warning appeared with `ts-jest < 29.1.0`:
```
ts-jest[versions] (WARN) Version 5.2.2 of typescript installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=4.3.0 <5.0.0-0). Please do not report issues in ts-jest if you are using unsupported versions.
```

## Testing Plan
Automated.
