### PR TITLE
Detect when a newly inserted VxScan USB needs CVRs (re)synced

### DIFF
--- a/apps/scan/backend/src/scanners/custom/app_config.test.ts
+++ b/apps/scan/backend/src/scanners/custom/app_config.test.ts
@@ -301,7 +301,7 @@ test('exportCastVoteRecordsToUsbDrive when continuous export is enabled', async 
       await configureApp(apiClient, mockAuth, mockUsbDrive, { testMode: true });
       await scanBallot(mockScanner, apiClient, 0);
       await scanBallot(mockScanner, apiClient, 1);
-      await sleep(1000); // Let background continuous export to USB finish
+      await sleep(1000); // Let background continuous export to USB drive finish
 
       expect(
         await apiClient.exportCastVoteRecordsToUsbDrive({

--- a/apps/scan/backend/test/helpers/custom_helpers.ts
+++ b/apps/scan/backend/test/helpers/custom_helpers.ts
@@ -21,7 +21,7 @@ import {
 import * as grout from '@votingworks/grout';
 import { getImageChannelCount } from '@votingworks/image-utils';
 import { Logger, fakeLogger } from '@votingworks/logging';
-import { SheetOf, mapSheet } from '@votingworks/types';
+import { SheetInterpretation, SheetOf, mapSheet } from '@votingworks/types';
 import { Application } from 'express';
 import { Server } from 'http';
 import { AddressInfo } from 'net';
@@ -206,5 +206,48 @@ export function simulateScan(
   mockScanner.scan.mockImplementationOnce(() => {
     didScan = true;
     return Promise.resolve(ok(ballotImage));
+  });
+}
+
+export async function scanBallot(
+  mockScanner: jest.Mocked<CustomScanner>,
+  apiClient: grout.Client<Api>,
+  initialBallotsCounted: number
+): Promise<void> {
+  mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
+  await waitForStatus(apiClient, {
+    state: 'ready_to_scan',
+    ballotsCounted: initialBallotsCounted,
+    canUnconfigure:
+      initialBallotsCounted === 0 || (await apiClient.getConfig()).isTestMode,
+  });
+
+  const interpretation: SheetInterpretation = {
+    type: 'ValidSheet',
+  };
+
+  mockScanner.scan.mockResolvedValueOnce(ok(await ballotImages.completeBmd()));
+  await apiClient.scanBallot();
+  mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
+  await waitForStatus(apiClient, {
+    state: 'ready_to_accept',
+    interpretation,
+    ballotsCounted: initialBallotsCounted,
+    canUnconfigure: true,
+  });
+  await apiClient.acceptBallot();
+  mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_NO_PAPER));
+  await waitForStatus(apiClient, {
+    ballotsCounted: initialBallotsCounted + 1,
+    state: 'accepted',
+    interpretation,
+    canUnconfigure: true,
+  });
+
+  // Wait for transition back to no paper
+  await waitForStatus(apiClient, {
+    state: 'no_paper',
+    ballotsCounted: initialBallotsCounted + 1,
+    canUnconfigure: true,
   });
 }

--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -1008,3 +1008,14 @@ test('renders DisplaySettingsManager', async () => {
 
   expect(mockOf(DisplaySettingsManager)).toBeCalled();
 });
+
+test('renders cast vote record sync modal', async () => {
+  apiMock.expectGetConfig({ pollsState: 'polls_open' });
+  apiMock.expectGetScannerStatus(statusNoPaper);
+  apiMock.expectGetUsbDriveStatus('mounted', {
+    doesUsbDriveRequireCastVoteRecordSync: true,
+  });
+
+  renderApp();
+  await screen.findByText('CVRs need to be synced to the inserted USB drive.');
+});

--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -1017,5 +1017,8 @@ test('renders cast vote record sync modal', async () => {
   });
 
   renderApp();
-  await screen.findByText('CVRs need to be synced to the inserted USB drive.');
+  await screen.findByText(
+    'The inserted USB drive does not contain up-to-date records of the votes cast at this scanner. ' +
+      'Cast vote records (CVRs) need to be synced to the USB drive.'
+  );
 });

--- a/apps/scan/frontend/src/app_root.tsx
+++ b/apps/scan/frontend/src/app_root.tsx
@@ -48,6 +48,7 @@ import {
 import { VoterScreen } from './screens/voter_screen';
 import { LoginPromptScreen } from './screens/login_prompt_screen';
 import { LiveCheckButton } from './components/live_check_button';
+import { CastVoteRecordSyncModal } from './components/cast_vote_record_sync_modal';
 
 export interface Props {
   hardware: Hardware;
@@ -278,11 +279,14 @@ export function AppRoot({
   }
 
   return (
-    <VoterScreen
-      electionDefinition={electionDefinition}
-      isTestMode={isTestMode}
-      isSoundMuted={isSoundMuted}
-      batteryIsCharging={computer.batteryIsCharging}
-    />
+    <React.Fragment>
+      <VoterScreen
+        electionDefinition={electionDefinition}
+        isTestMode={isTestMode}
+        isSoundMuted={isSoundMuted}
+        batteryIsCharging={computer.batteryIsCharging}
+      />
+      <CastVoteRecordSyncModal />
+    </React.Fragment>
   );
 }

--- a/apps/scan/frontend/src/components/cast_vote_record_sync_modal.test.tsx
+++ b/apps/scan/frontend/src/components/cast_vote_record_sync_modal.test.tsx
@@ -34,7 +34,10 @@ test('CVR sync modal success case', async () => {
     doesUsbDriveRequireCastVoteRecordSync: true,
   });
   const modal = await screen.findByRole('alertdialog');
-  within(modal).getByText('CVRs need to be synced to the inserted USB drive.');
+  within(modal).getByText(
+    'The inserted USB drive does not contain up-to-date records of the votes cast at this scanner. ' +
+      'Cast vote records (CVRs) need to be synced to the USB drive.'
+  );
 
   apiMock.expectExportCastVoteRecordsToUsbDrive({ mode: 'full_export' });
   userEvent.click(within(modal).getByRole('button', { name: 'Sync CVRs' }));
@@ -55,7 +58,10 @@ test('CVR sync modal error case', async () => {
     doesUsbDriveRequireCastVoteRecordSync: true,
   });
   const modal = await screen.findByRole('alertdialog');
-  within(modal).getByText('CVRs need to be synced to the inserted USB drive.');
+  within(modal).getByText(
+    'The inserted USB drive does not contain up-to-date records of the votes cast at this scanner. ' +
+      'Cast vote records (CVRs) need to be synced to the USB drive.'
+  );
 
   apiMock.mockApiClient.exportCastVoteRecordsToUsbDrive
     .expectCallWith({ mode: 'full_export' })

--- a/apps/scan/frontend/src/components/cast_vote_record_sync_modal.test.tsx
+++ b/apps/scan/frontend/src/components/cast_vote_record_sync_modal.test.tsx
@@ -1,0 +1,66 @@
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { err } from '@votingworks/basics';
+import {
+  ApiMock,
+  createApiMock,
+  provideApi,
+} from '../../test/helpers/mock_api_client';
+import { render } from '../../test/react_testing_library';
+import { CastVoteRecordSyncModal } from './cast_vote_record_sync_modal';
+
+let apiMock: ApiMock;
+
+function renderComponent() {
+  render(provideApi(apiMock, <CastVoteRecordSyncModal />));
+}
+
+beforeEach(() => {
+  apiMock = createApiMock();
+  apiMock.expectGetUsbDriveStatus('no_drive');
+});
+
+afterEach(() => {
+  apiMock.mockApiClient.assertComplete();
+});
+
+test('CVR sync modal success case', async () => {
+  renderComponent();
+
+  expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+
+  apiMock.expectGetUsbDriveStatus('mounted', {
+    doesUsbDriveRequireCastVoteRecordSync: true,
+  });
+  const modal = await screen.findByRole('alertdialog');
+  within(modal).getByText('CVRs need to be synced to the inserted USB drive.');
+
+  apiMock.expectExportCastVoteRecordsToUsbDrive({ mode: 'full_export' });
+  userEvent.click(within(modal).getByRole('button', { name: 'Sync CVRs' }));
+  within(modal).getByText('Syncing CVRs');
+  apiMock.expectGetUsbDriveStatus('mounted');
+  await within(modal).findByText('Voters may continue casting ballots.');
+
+  userEvent.click(within(modal).getByRole('button', { name: 'Close' }));
+  expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+});
+
+test('CVR sync modal error case', async () => {
+  renderComponent();
+
+  expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+
+  apiMock.expectGetUsbDriveStatus('mounted', {
+    doesUsbDriveRequireCastVoteRecordSync: true,
+  });
+  const modal = await screen.findByRole('alertdialog');
+  within(modal).getByText('CVRs need to be synced to the inserted USB drive.');
+
+  apiMock.mockApiClient.exportCastVoteRecordsToUsbDrive
+    .expectCallWith({ mode: 'full_export' })
+    .resolves(err({ type: 'file-system-error', message: '' }));
+  userEvent.click(within(modal).getByRole('button', { name: 'Sync CVRs' }));
+  within(modal).getByText('Syncing CVRs');
+  await within(modal).findByText('Try inserting a different USB drive.');
+});

--- a/apps/scan/frontend/src/components/cast_vote_record_sync_modal.tsx
+++ b/apps/scan/frontend/src/components/cast_vote_record_sync_modal.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+import { throwIllegalValue } from '@votingworks/basics';
+import {
+  Button,
+  Loading,
+  Modal,
+  P,
+  useQueryChangeListener,
+} from '@votingworks/ui';
+
+import { exportCastVoteRecordsToUsbDrive, getUsbDriveStatus } from '../api';
+
+type ModalState = 'closed' | 'prompt' | 'syncing' | 'success' | 'error';
+
+export function CastVoteRecordSyncModal(): JSX.Element | null {
+  const usbDriveStatusQuery = getUsbDriveStatus.useQuery();
+  const exportCastVoteRecordsToUsbDriveMutation =
+    exportCastVoteRecordsToUsbDrive.useMutation();
+
+  const [modalState, setModalState] = useState<ModalState>('closed');
+
+  useQueryChangeListener(usbDriveStatusQuery, (newUsbDriveStatus) => {
+    if (newUsbDriveStatus.doesUsbDriveRequireCastVoteRecordSync) {
+      setModalState('prompt');
+    }
+  });
+
+  function syncCastVoteRecords() {
+    setModalState('syncing');
+    exportCastVoteRecordsToUsbDriveMutation.mutate(
+      { mode: 'full_export' },
+      {
+        onSuccess: (result) => {
+          if (result.isErr()) {
+            setModalState('error');
+            return;
+          }
+          setModalState('success');
+        },
+      }
+    );
+  }
+
+  function closeModal() {
+    setModalState('closed');
+  }
+
+  switch (modalState) {
+    case 'closed': {
+      return null;
+    }
+    case 'prompt': {
+      return (
+        <Modal
+          title="CVR Sync Required"
+          content={<P>CVRs need to be synced to the inserted USB drive.</P>}
+          actions={
+            <Button variant="primary" onPress={syncCastVoteRecords}>
+              Sync CVRs
+            </Button>
+          }
+        />
+      );
+    }
+    case 'syncing': {
+      return <Modal content={<Loading>Syncing CVRs</Loading>} />;
+    }
+    case 'success': {
+      return (
+        <Modal
+          title="CVR Sync Complete"
+          content={<P>Voters may continue casting ballots.</P>}
+          actions={<Button onPress={closeModal}>Close</Button>}
+          onOverlayClick={closeModal}
+        />
+      );
+    }
+    case 'error': {
+      return (
+        <Modal
+          title="CVR Sync Error"
+          content={<P>Try inserting a different USB drive.</P>}
+        />
+      );
+    }
+    /* istanbul ignore next: Compile-time check for completeness */
+    default: {
+      throwIllegalValue(modalState);
+    }
+  }
+}

--- a/apps/scan/frontend/src/components/cast_vote_record_sync_modal.tsx
+++ b/apps/scan/frontend/src/components/cast_vote_record_sync_modal.tsx
@@ -53,7 +53,13 @@ export function CastVoteRecordSyncModal(): JSX.Element | null {
       return (
         <Modal
           title="CVR Sync Required"
-          content={<P>CVRs need to be synced to the inserted USB drive.</P>}
+          content={
+            <P>
+              The inserted USB drive does not contain up-to-date records of the
+              votes cast at this scanner. Cast vote records (CVRs) need to be
+              synced to the USB drive.
+            </P>
+          }
           actions={
             <Button variant="primary" onPress={syncCastVoteRecords}>
               Sync CVRs

--- a/apps/scan/frontend/src/components/export_results_modal.test.tsx
+++ b/apps/scan/frontend/src/components/export_results_modal.test.tsx
@@ -87,7 +87,7 @@ test('render export modal when a usb drive is mounted as expected and allows exp
     )
   );
   getByText('USB Drive Ejected');
-  getByText('You may now take the USB Drive to VxAdmin for tabulation.');
+  getByText('You may now take the USB drive to VxAdmin for tabulation.');
 });
 
 test('render export modal with errors when appropriate', async () => {

--- a/apps/scan/frontend/src/components/export_results_modal.tsx
+++ b/apps/scan/frontend/src/components/export_results_modal.tsx
@@ -83,7 +83,7 @@ export function ExportResultsModal({
           title="USB Drive Ejected"
           content={
             <Prose>
-              <P>You may now take the USB Drive to VxAdmin for tabulation.</P>
+              <P>You may now take the USB drive to VxAdmin for tabulation.</P>
             </Prose>
           }
           onOverlayClick={onClose}

--- a/apps/scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/scan/frontend/test/helpers/mock_api_client.tsx
@@ -103,10 +103,13 @@ export function createApiMock() {
       });
     },
 
-    expectGetUsbDriveStatus(status: UsbDriveStatus['status']): void {
+    expectGetUsbDriveStatus(
+      status: UsbDriveStatus['status'],
+      options: { doesUsbDriveRequireCastVoteRecordSync?: true } = {}
+    ): void {
       mockApiClient.getUsbDriveStatus
         .expectRepeatedCallsWith()
-        .resolves(mockUsbDriveStatus(status));
+        .resolves(mockUsbDriveStatus(status, options));
     },
 
     expectGetMachineConfig(): void {

--- a/apps/scan/frontend/test/helpers/mock_usb_drive.ts
+++ b/apps/scan/frontend/test/helpers/mock_usb_drive.ts
@@ -3,14 +3,17 @@ import { throwIllegalValue } from '@votingworks/basics';
 import type { UsbDriveStatus } from '@votingworks/usb-drive';
 
 export function mockUsbDriveStatus(
-  status: UsbDriveStatus['status']
-): UsbDriveStatus {
+  status: UsbDriveStatus['status'],
+  options: { doesUsbDriveRequireCastVoteRecordSync?: true } = {}
+): UsbDriveStatus & { doesUsbDriveRequireCastVoteRecordSync?: true } {
   switch (status) {
     case 'mounted':
       return {
         status,
         mountPoint: 'test-mount-point',
         deviceName: 'test-device-name',
+        doesUsbDriveRequireCastVoteRecordSync:
+          options.doesUsbDriveRequireCastVoteRecordSync,
       };
     case 'no_drive':
     case 'ejected':


### PR DESCRIPTION
_Easiest reviewed by commit_

## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/3924

Before continuous export, if a USB was removed from a VxScan mid-day, and a different one was connected in its place, say because the original USB failed and was no longer able to mount, no additional action would need to be taken. With continuous export, if a USB is removed mid-day, and a different one is connected in its place, CVRs need to be rewritten to the new USB, i.e. the USB needs CVRs (re)synced. This PR adds code and a UX for this.

## Demo Video

In this video, you'll see that I remove a USB and insert another in its place, triggering the (re)sync UX.

https://github.com/votingworks/vxsuite/assets/12616928/a6efc717-e354-4ff7-b66f-9212622cbffe

## Testing

- [x] Added VxScan frontend and backend tests
- [x] Tested manually

`libs/backend` tests are coming in a follow-up PR

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ Adding logging in a follow-up PR
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates