### PR TITLE
Update libs/cvr-fixture-generator to use new CVR export format (plus other small tweaks)

### DIFF
--- a/apps/admin/backend/src/cast_vote_records.ts
+++ b/apps/admin/backend/src/cast_vote_records.ts
@@ -95,7 +95,8 @@ export async function importCastVoteRecords(
   if (readResult.isErr()) {
     return readResult;
   }
-  const { castVoteRecordExportMetadata, castVoteRecords } = readResult.ok();
+  const { castVoteRecordExportMetadata, castVoteRecordIterator } =
+    readResult.ok();
   const { castVoteRecordReportMetadata } = castVoteRecordExportMetadata;
 
   const exportDirectoryName = path.basename(exportDirectoryPath);
@@ -158,7 +159,7 @@ export async function importCastVoteRecords(
     let newlyAdded = 0;
     let alreadyPresent = 0;
     const precinctIds = new Set<string>();
-    for await (const castVoteRecordResult of castVoteRecords) {
+    for await (const castVoteRecordResult of castVoteRecordIterator) {
       if (castVoteRecordResult.isErr()) {
         return err({
           ...castVoteRecordResult.err(),
@@ -216,6 +217,7 @@ export async function importCastVoteRecords(
         if (hmpbCastVoteRecordWriteIns.length > 0) {
           // Guaranteed to exist given validation in readCastVoteRecordExport
           assert(referencedFiles !== undefined);
+          assert(referencedFiles.layoutFilePaths !== undefined);
 
           for (const i of [0, 1] as const) {
             const imageData = await fs.readFile(

--- a/libs/backend/src/ballot_package/ballot_package_io.ts
+++ b/libs/backend/src/ballot_package/ballot_package_io.ts
@@ -94,17 +94,15 @@ export async function readBallotPackageFromUsb(
     return filepathResult;
   }
 
-  const artifactAuthenticationResult =
-    await authenticateArtifactUsingSignatureFile({
-      type: 'election_package',
-      filePath: filepathResult.ok(),
-    });
-  if (
-    artifactAuthenticationResult.isErr() &&
-    !isFeatureFlagEnabled(
-      BooleanEnvironmentVariableName.SKIP_BALLOT_PACKAGE_AUTHENTICATION
-    )
-  ) {
+  const artifactAuthenticationResult = isFeatureFlagEnabled(
+    BooleanEnvironmentVariableName.SKIP_BALLOT_PACKAGE_AUTHENTICATION
+  )
+    ? ok()
+    : await authenticateArtifactUsingSignatureFile({
+        type: 'election_package',
+        filePath: filepathResult.ok(),
+      });
+  if (artifactAuthenticationResult.isErr()) {
     await logger.log(LogEventId.BallotPackageLoadedFromUsb, 'system', {
       disposition: 'failure',
       message: 'Ballot package authentication erred.',

--- a/libs/backend/src/cast_vote_records/export.ts
+++ b/libs/backend/src/cast_vote_records/export.ts
@@ -24,8 +24,11 @@ import {
   CastVoteRecordExportMetadata,
   CVR,
   ElectionDefinition,
+  Id,
   MarkThresholds,
+  PageInterpretation,
   PollsState,
+  SheetOf,
   unsafeParse,
 } from '@votingworks/types';
 import { UsbDrive, UsbDriveStatus } from '@votingworks/usb-drive';
@@ -48,12 +51,7 @@ import {
   describeSheetValidationError,
 } from './canonicalize';
 import { readCastVoteRecordExportMetadata } from './import';
-import { ResultSheet } from './legacy_export';
 import { buildElectionOptionPositionMap } from './option_map';
-
-type ExportCastVoteRecordsToUsbDriveError =
-  | { type: 'invalid-sheet-found'; message: string }
-  | ExportDataError;
 
 /**
  * The subset of scanner store methods relevant to exporting cast vote records
@@ -109,6 +107,32 @@ interface ExportContext {
   scannerStore: ScannerStore;
   usbMountPoint: string;
 }
+
+/**
+ * A sheet to be included in a CVR export
+ */
+export interface ResultSheet {
+  readonly id: Id;
+  readonly batchId: Id;
+  readonly interpretation: SheetOf<PageInterpretation>;
+  readonly frontImagePath: string;
+  readonly backImagePath: string;
+
+  /**
+   * Required per VVSG 2.0 1.1.5-G.7 but only relevant for central scanners. On precinct scanners,
+   * this would compromise voter privacy.
+   */
+  readonly indexInBatch?: number;
+
+  /**
+   * TODO: Determine whether this field is still used and, if not, remove
+   */
+  readonly batchLabel?: string;
+}
+
+type ExportCastVoteRecordsToUsbDriveError =
+  | { type: 'invalid-sheet-found'; message: string }
+  | ExportDataError;
 
 //
 // Helpers

--- a/libs/backend/src/cast_vote_records/import.test.ts
+++ b/libs/backend/src/cast_vote_records/import.test.ts
@@ -1,0 +1,41 @@
+import { CVR } from '@votingworks/types';
+
+import { TEST_OTHER_REPORT_TYPE } from './build_report_metadata';
+import { isTestReport } from './import';
+
+test.each<{ report: CVR.CastVoteRecordReport; expectedResult: boolean }>([
+  {
+    report: {
+      '@type': 'CVR.CastVoteRecordReport',
+      Election: [],
+      GeneratedDate: new Date().toISOString(),
+      GpUnit: [],
+      OtherReportType: TEST_OTHER_REPORT_TYPE,
+      ReportGeneratingDeviceIds: [],
+      ReportingDevice: [],
+      ReportType: [
+        CVR.ReportType.OriginatingDeviceExport,
+        CVR.ReportType.Other,
+      ],
+      Version: CVR.CastVoteRecordVersion.v1_0_0,
+      vxBatch: [],
+    },
+    expectedResult: true,
+  },
+  {
+    report: {
+      '@type': 'CVR.CastVoteRecordReport',
+      Election: [],
+      GeneratedDate: new Date().toISOString(),
+      GpUnit: [],
+      ReportGeneratingDeviceIds: [],
+      ReportingDevice: [],
+      ReportType: [CVR.ReportType.OriginatingDeviceExport],
+      Version: CVR.CastVoteRecordVersion.v1_0_0,
+      vxBatch: [],
+    },
+    expectedResult: false,
+  },
+])('isTestReport', ({ report, expectedResult }) => {
+  expect(isTestReport(report)).toEqual(expectedResult);
+});

--- a/libs/backend/src/cast_vote_records/legacy_export.test.ts
+++ b/libs/backend/src/cast_vote_records/legacy_export.test.ts
@@ -28,8 +28,8 @@ import {
   exportCastVoteRecordReportToUsbDrive,
   getCastVoteRecordReportStream,
   InvalidSheetFoundError,
-  ResultSheet,
 } from './legacy_export';
+import { ResultSheet } from './export';
 
 jest.mock('@votingworks/auth', (): typeof import('@votingworks/auth') => ({
   ...jest.requireActual('@votingworks/auth'),

--- a/libs/backend/src/cast_vote_records/legacy_export.ts
+++ b/libs/backend/src/cast_vote_records/legacy_export.ts
@@ -4,9 +4,6 @@ import {
   BatchInfo,
   CVR,
   ElectionDefinition,
-  Id,
-  PageInterpretation,
-  SheetOf,
   unsafeParse,
 } from '@votingworks/types';
 import { err, ok, Optional, Result } from '@votingworks/basics';
@@ -37,26 +34,7 @@ import {
 import { SCAN_ALLOWED_EXPORT_PATTERNS, VX_MACHINE_ID } from '../scan_globals';
 import { buildCastVoteRecordReportMetadata } from './build_report_metadata';
 import { buildElectionOptionPositionMap } from './option_map';
-
-/**
- * Properties of each sheet that are needed to generate a cast vote record
- * for that sheet.
- */
-export interface ResultSheet {
-  readonly id: Id;
-  readonly batchId: Id;
-  /**
-   * `indexInBatch` only applies to the central scanner. It is required in cast
-   * vote records per VVSG 2.0 1.1.5-G.7, but is not included for the precinct
-   * scanner because that would compromise voter privacy.
-   */
-  readonly indexInBatch?: number;
-  // TODO: remove once the deprecated CVR export is no longer using batchLabel
-  readonly batchLabel?: string;
-  readonly interpretation: SheetOf<PageInterpretation>;
-  readonly frontImagePath: string;
-  readonly backImagePath: string;
-}
+import { ResultSheet } from './export';
 
 /**
  * In cast vote record exports, the subdirectory under which images are

--- a/libs/backend/src/cast_vote_records/legacy_import.test.ts
+++ b/libs/backend/src/cast_vote_records/legacy_import.test.ts
@@ -6,14 +6,12 @@ import { rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import {
   getCastVoteRecordReportImport,
-  isTestReport,
   validateCastVoteRecordReportDirectoryStructure,
 } from './legacy_import';
 import {
   CVR_BALLOT_IMAGES_SUBDIRECTORY,
   CVR_BALLOT_LAYOUTS_SUBDIRECTORY,
 } from './legacy_export';
-import { TEST_OTHER_REPORT_TYPE } from './build_report_metadata';
 
 const cdfCvrReport =
   electionGridLayoutNewHampshireAmherstFixtures.castVoteRecordReport;
@@ -160,43 +158,5 @@ describe('validateCastVoteRecordReportDirectoryStructure', () => {
       await validateCastVoteRecordReportDirectoryStructure(directoryPath);
     expect(validationResult.isErr()).toBeTruthy();
     expect(validationResult.err()).toMatchObject({ type: 'invalid-directory' });
-  });
-});
-
-describe('isTestReport', () => {
-  test('when test', () => {
-    expect(
-      isTestReport({
-        '@type': 'CVR.CastVoteRecordReport',
-        ReportType: [
-          CVR.ReportType.OriginatingDeviceExport,
-          CVR.ReportType.Other,
-        ],
-        OtherReportType: TEST_OTHER_REPORT_TYPE,
-        GeneratedDate: Date.now().toString(),
-        GpUnit: [],
-        Election: [],
-        ReportGeneratingDeviceIds: [],
-        ReportingDevice: [],
-        Version: CVR.CastVoteRecordVersion.v1_0_0,
-        vxBatch: [],
-      })
-    ).toBeTruthy();
-  });
-
-  test('when not test', () => {
-    expect(
-      isTestReport({
-        '@type': 'CVR.CastVoteRecordReport',
-        ReportType: [CVR.ReportType.OriginatingDeviceExport],
-        GeneratedDate: Date.now().toString(),
-        GpUnit: [],
-        Election: [],
-        ReportGeneratingDeviceIds: [],
-        ReportingDevice: [],
-        Version: CVR.CastVoteRecordVersion.v1_0_0,
-        vxBatch: [],
-      })
-    ).toBeFalsy();
   });
 });

--- a/libs/backend/src/cast_vote_records/legacy_import.ts
+++ b/libs/backend/src/cast_vote_records/legacy_import.ts
@@ -20,10 +20,7 @@ import {
   CVR_BALLOT_IMAGES_SUBDIRECTORY,
   CVR_BALLOT_LAYOUTS_SUBDIRECTORY,
 } from './legacy_export';
-import {
-  CastVoteRecordReportMetadata,
-  TEST_OTHER_REPORT_TYPE,
-} from './build_report_metadata';
+import { CastVoteRecordReportMetadata } from './build_report_metadata';
 
 /**
  * Variant of {@link CastVoteRecordReport} in which the `CVR` array is replaced
@@ -223,23 +220,4 @@ export async function validateCastVoteRecordReportDirectoryStructure(
   }
 
   return ok(relativeImagePaths);
-}
-
-/**
- * Determines whether a cast vote record report is a test report or not. A report
- * is a test report if `CVR.ReportType` contains `ReportType.Other` and
- * `CVR.OtherReportType`, as a comma-separated list of strings, contains
- * {@link TEST_OTHER_REPORT_TYPE}.
- */
-export function isTestReport(metadata: CastVoteRecordReportMetadata): boolean {
-  const containsOtherReportType = metadata.ReportType?.some(
-    (reportType) => reportType === CVR.ReportType.Other
-  );
-  if (!containsOtherReportType) return false;
-
-  const otherReportTypeContainsTest = metadata.OtherReportType?.split(
-    ','
-  ).includes(TEST_OTHER_REPORT_TYPE);
-
-  return Boolean(otherReportTypeContainsTest);
 }

--- a/libs/cvr-fixture-generator/package.json
+++ b/libs/cvr-fixture-generator/package.json
@@ -34,6 +34,7 @@
     "esbuild-runner": "^2.2.1",
     "js-sha256": "^0.9.0",
     "lodash.clonedeep": "^4.5.0",
+    "uuid": "^9.0.1",
     "yargs": "^17.5.1"
   },
   "devDependencies": {
@@ -41,6 +42,7 @@
     "@types/lodash.clonedeep": "^4.5.7",
     "@types/node": "16.18.23",
     "@types/tmp": "^0.2.3",
+    "@types/uuid": "^9.0.4",
     "@types/yargs": "^17.0.12",
     "@votingworks/test-utils": "*",
     "eslint-plugin-vx": "*",

--- a/libs/cvr-fixture-generator/package.json
+++ b/libs/cvr-fixture-generator/package.json
@@ -22,6 +22,7 @@
     "pre-commit": "lint-staged"
   },
   "dependencies": {
+    "@votingworks/auth": "*",
     "@votingworks/backend": "*",
     "@votingworks/basics": "*",
     "@votingworks/converter-nh-accuvote": "workspace:^",

--- a/libs/cvr-fixture-generator/src/cli/generate/main.test.ts
+++ b/libs/cvr-fixture-generator/src/cli/generate/main.test.ts
@@ -258,13 +258,15 @@ test('including ballot images', async () => {
       const castVoteRecordDirectoryContents = (
         await fs.readdir(join(outputDirectory.name, castVoteRecord.UniqueId))
       ).sort();
-      expect(castVoteRecordDirectoryContents).toEqual([
-        `${castVoteRecord.UniqueId}-back.jpg`,
-        `${castVoteRecord.UniqueId}-back.layout.json`,
-        `${castVoteRecord.UniqueId}-front.jpg`,
-        `${castVoteRecord.UniqueId}-front.layout.json`,
-        'cast-vote-record-report.json',
-      ]);
+      expect(castVoteRecordDirectoryContents).toEqual(
+        [
+          `${castVoteRecord.UniqueId}-back.jpg`,
+          `${castVoteRecord.UniqueId}-back.layout.json`,
+          `${castVoteRecord.UniqueId}-front.jpg`,
+          `${castVoteRecord.UniqueId}-front.layout.json`,
+          'cast-vote-record-report.json',
+        ].sort()
+      );
     }
   }
 });

--- a/libs/cvr-fixture-generator/src/cli/generate/main.test.ts
+++ b/libs/cvr-fixture-generator/src/cli/generate/main.test.ts
@@ -3,35 +3,23 @@ import {
   electionGridLayoutNewHampshireAmherstFixtures,
 } from '@votingworks/fixtures';
 import { fakeReadable, fakeWritable } from '@votingworks/test-utils';
-import { safeParseJson, CVR, unsafeParse } from '@votingworks/types';
-import { readFileSync } from 'fs';
+import { CVR } from '@votingworks/types';
 import fs from 'fs/promises';
 import { join, resolve } from 'path';
 import { dirSync } from 'tmp';
 import {
-  CAST_VOTE_RECORD_REPORT_FILENAME,
   getWriteInsFromCastVoteRecord,
   isBmdWriteIn,
 } from '@votingworks/utils';
-import { getCastVoteRecordReportImport } from '@votingworks/backend';
+import { readCastVoteRecordExport } from '@votingworks/backend';
 import { assert } from '@votingworks/basics';
-import { DEFAULT_SCANNER_ID, main } from './main';
-import { getBatchIdForScannerId } from '../../utils';
+import { main } from './main';
+import { IMAGE_URI_REGEX } from '../../utils';
 
 jest.setTimeout(30_000);
 
 const electionDefinitionPathAmherst =
   electionGridLayoutNewHampshireAmherstFixtures.electionJson.asFilePath();
-
-function reportFromFile(directory: string) {
-  const filename = join(directory, CAST_VOTE_RECORD_REPORT_FILENAME);
-  const reportParseResult = safeParseJson(
-    readFileSync(filename, 'utf8'),
-    CVR.CastVoteRecordReportSchema
-  );
-  expect(reportParseResult.isOk()).toBeTruthy();
-  return reportParseResult.unsafeUnwrap();
-}
 
 async function run(
   args: string[]
@@ -49,6 +37,29 @@ async function run(
     exitCode,
     stdout: stdout.toString(),
     stderr: stderr.toString(),
+  };
+}
+
+async function readAndValidateCastVoteRecordExport(
+  exportDirectoryPath: string
+): Promise<{
+  castVoteRecordReportMetadata: CVR.CastVoteRecordReport;
+  castVoteRecords: CVR.CVR[];
+}> {
+  const readResult = await readCastVoteRecordExport(exportDirectoryPath);
+  assert(readResult.isOk());
+  const { castVoteRecordExportMetadata, castVoteRecordIterator } =
+    readResult.ok();
+  const castVoteRecords: CVR.CVR[] = [];
+  for await (const castVoteRecordResult of castVoteRecordIterator) {
+    assert(castVoteRecordResult.isOk());
+    const { castVoteRecord } = castVoteRecordResult.ok();
+    castVoteRecords.push(castVoteRecord);
+  }
+  return {
+    castVoteRecordReportMetadata:
+      castVoteRecordExportMetadata.castVoteRecordReportMetadata,
+    castVoteRecords,
   };
 }
 
@@ -101,8 +112,10 @@ test('generate with defaults', async () => {
     stderr: '',
   });
 
-  const report = reportFromFile(outputDirectory.name);
-  expect(report.CVR).toHaveLength(184);
+  const { castVoteRecords } = await readAndValidateCastVoteRecordExport(
+    outputDirectory.name
+  );
+  expect(castVoteRecords).toHaveLength(184);
 });
 
 test('generate with custom number of records below the suggested number', async () => {
@@ -124,8 +137,10 @@ test('generate with custom number of records below the suggested number', async 
     stderr: expect.stringContaining('WARNING:'),
   });
 
-  const report = reportFromFile(outputDirectory.name);
-  expect(report.CVR).toHaveLength(100);
+  const { castVoteRecords } = await readAndValidateCastVoteRecordExport(
+    outputDirectory.name
+  );
+  expect(castVoteRecords).toHaveLength(100);
 });
 
 test('generate with custom number of records above the suggested number', async () => {
@@ -149,20 +164,13 @@ test('generate with custom number of records above the suggested number', async 
     stderr: '',
   });
 
-  const castVoteRecordReportImport = (
-    await getCastVoteRecordReportImport(
-      join(outputDirectory.name, CAST_VOTE_RECORD_REPORT_FILENAME)
-    )
-  ).assertOk('generated cast vote record should be valid');
-
-  let cvrCount = 0;
-  for await (const unparsedCastVoteRecord of castVoteRecordReportImport.CVR) {
-    const castVoteRecord = unsafeParse(CVR.CVRSchema, unparsedCastVoteRecord);
-    expect(castVoteRecord.UniqueId).toEqual(`pre-${cvrCount}`);
-    cvrCount += 1;
+  const { castVoteRecords } = await readAndValidateCastVoteRecordExport(
+    outputDirectory.name
+  );
+  expect(castVoteRecords).toHaveLength(500);
+  for (const castVoteRecord of castVoteRecords) {
+    expect(castVoteRecord.UniqueId).toEqual(expect.stringMatching(/pre-(.+)/));
   }
-
-  expect(cvrCount).toEqual(500);
 });
 
 test('generate live mode CVRs', async () => {
@@ -179,8 +187,9 @@ test('generate live mode CVRs', async () => {
     '10',
   ]);
 
-  const report = reportFromFile(outputDirectory.name);
-  expect(report.OtherReportType).toBeUndefined();
+  const { castVoteRecordReportMetadata } =
+    await readAndValidateCastVoteRecordExport(outputDirectory.name);
+  expect(castVoteRecordReportMetadata.OtherReportType).toBeUndefined();
 });
 
 test('generate test mode CVRs', async () => {
@@ -196,8 +205,11 @@ test('generate test mode CVRs', async () => {
     '10',
   ]);
 
-  const report = reportFromFile(outputDirectory.name);
-  expect(report.OtherReportType?.split(',')).toContain('test');
+  const { castVoteRecordReportMetadata } =
+    await readAndValidateCastVoteRecordExport(outputDirectory.name);
+  expect(castVoteRecordReportMetadata.OtherReportType?.split(',')).toContain(
+    'test'
+  );
 });
 
 test('specifying scanner ids', async () => {
@@ -213,9 +225,11 @@ test('specifying scanner ids', async () => {
     'scanner1,scanner2',
   ]);
 
-  const report = reportFromFile(outputDirectory.name);
-  for (const cvr of report.CVR!) {
-    expect(cvr.CreatingDeviceId).toMatch(/scanner[12]/);
+  const { castVoteRecords } = await readAndValidateCastVoteRecordExport(
+    outputDirectory.name
+  );
+  for (const castVoteRecord of castVoteRecords) {
+    expect(castVoteRecord.CreatingDeviceId).toMatch(/scanner[12]/);
   }
 });
 
@@ -230,52 +244,29 @@ test('including ballot images', async () => {
     outputDirectory.name,
   ]);
 
-  const report = reportFromFile(outputDirectory.name);
-  const imageFileUris = new Set<string>();
-  assert(report.CVR);
-  for (const cvr of report.CVR) {
-    const ballotImages = cvr.BallotImage;
-    if (ballotImages) {
-      if (ballotImages[0]?.Location) {
-        imageFileUris.add(ballotImages[0]?.Location);
-      }
-      if (ballotImages[1]?.Location) {
-        imageFileUris.add(ballotImages[1]?.Location);
-      }
+  const { castVoteRecords } = await readAndValidateCastVoteRecordExport(
+    outputDirectory.name
+  );
+  for (const castVoteRecord of castVoteRecords) {
+    if (castVoteRecord.BallotImage) {
+      expect(castVoteRecord.BallotImage[0]?.Location).toEqual(
+        expect.stringMatching(IMAGE_URI_REGEX)
+      );
+      expect(castVoteRecord.BallotImage[1]?.Location).toEqual(
+        expect.stringMatching(IMAGE_URI_REGEX)
+      );
+      const castVoteRecordDirectoryContents = (
+        await fs.readdir(join(outputDirectory.name, castVoteRecord.UniqueId))
+      ).sort();
+      expect(castVoteRecordDirectoryContents).toEqual([
+        `${castVoteRecord.UniqueId}-back.jpg`,
+        `${castVoteRecord.UniqueId}-back.layout.json`,
+        `${castVoteRecord.UniqueId}-front.jpg`,
+        `${castVoteRecord.UniqueId}-front.layout.json`,
+        'cast-vote-record-report.json',
+      ]);
     }
   }
-
-  const defaultBatchId = getBatchIdForScannerId(DEFAULT_SCANNER_ID);
-
-  // files referenced from the report
-  expect(Array.from(imageFileUris)).toMatchObject([
-    `file:ballot-images/${defaultBatchId}/card-number-3__town-id-00701-precinct-id-__2.jpg`,
-    `file:ballot-images/${defaultBatchId}/card-number-3__town-id-00701-precinct-id-__1.jpg`,
-  ]);
-
-  // images exported
-  expect(
-    await fs.readdir(
-      join(outputDirectory.name, 'ballot-images', defaultBatchId)
-    )
-  ).toMatchInlineSnapshot(`
-    [
-      "card-number-3__town-id-00701-precinct-id-__1.jpg",
-      "card-number-3__town-id-00701-precinct-id-__2.jpg",
-    ]
-  `);
-
-  // layouts exported
-  expect(
-    await fs.readdir(
-      join(outputDirectory.name, 'ballot-layouts', defaultBatchId)
-    )
-  ).toMatchInlineSnapshot(`
-    [
-      "card-number-3__town-id-00701-precinct-id-__1.layout.json",
-      "card-number-3__town-id-00701-precinct-id-__2.layout.json",
-    ]
-  `);
 });
 
 test('generating as BMD ballots (non-gridlayouts election)', async () => {
@@ -296,17 +287,18 @@ test('generating as BMD ballots (non-gridlayouts election)', async () => {
     stderr: '',
   });
 
-  const report = reportFromFile(outputDirectory.name);
-  assert(report.CVR);
-  for (const [index, cvr] of report.CVR.entries()) {
-    expect(cvr.BallotImage).toBeUndefined();
-    expect(cvr.UniqueId).toEqual(index.toString());
+  const { castVoteRecords } = await readAndValidateCastVoteRecordExport(
+    outputDirectory.name
+  );
+  for (const castVoteRecord of castVoteRecords) {
+    expect(castVoteRecord.BallotImage).toBeUndefined();
+    expect(castVoteRecord.UniqueId).toEqual(expect.stringMatching(/[0-9]+/));
     expect(
-      getWriteInsFromCastVoteRecord(cvr).every((castVoteRecordWriteIn) =>
-        Boolean(castVoteRecordWriteIn.text)
+      getWriteInsFromCastVoteRecord(castVoteRecord).every(
+        (castVoteRecordWriteIn) => Boolean(castVoteRecordWriteIn.text)
       )
     ).toEqual(true);
-    const writeIns = cvr.CVRSnapshot[0]!.CVRContest.flatMap(
+    const writeIns = castVoteRecord.CVRSnapshot[0]!.CVRContest.flatMap(
       (contest) => contest.CVRContestSelection
     )
       .flatMap((contestSelection) => contestSelection.SelectionPosition)

--- a/libs/cvr-fixture-generator/src/generate_cvrs.ts
+++ b/libs/cvr-fixture-generator/src/generate_cvrs.ts
@@ -314,18 +314,14 @@ export function* generateCvrs({
                 const sheetHasWriteIns = frontHasWriteIns || backHasWriteIns;
 
                 const frontImageFileUri = `file:${generateBallotAssetPath({
-                  ballotStyleId: ballotStyle.id,
-                  precinctId,
-                  batchId,
+                  castVoteRecordId: castVoteRecordId.toString(),
                   assetType: 'image',
-                  pageNumber: sheetIndex * 2 + 1,
+                  frontOrBack: 'front',
                 })}`;
                 const backImageFileUri = `file:${generateBallotAssetPath({
-                  ballotStyleId: ballotStyle.id,
-                  precinctId,
-                  batchId,
+                  castVoteRecordId: castVoteRecordId.toString(),
                   assetType: 'image',
-                  pageNumber: sheetIndex * 2 + 2,
+                  frontOrBack: 'back',
                 })}`;
 
                 yield {
@@ -371,15 +367,11 @@ export function* generateCvrs({
                     ? [
                         {
                           '@type': 'CVR.ImageData',
-                          Location: frontHasWriteIns
-                            ? frontImageFileUri
-                            : undefined,
+                          Location: frontImageFileUri,
                         },
                         {
                           '@type': 'CVR.ImageData',
-                          Location: backHasWriteIns
-                            ? backImageFileUri
-                            : undefined,
+                          Location: backImageFileUri,
                         },
                       ]
                     : undefined,

--- a/libs/cvr-fixture-generator/src/generate_cvrs.ts
+++ b/libs/cvr-fixture-generator/src/generate_cvrs.ts
@@ -1,3 +1,4 @@
+import { v4 as uuid } from 'uuid';
 import { buildCVRContestsFromVotes } from '@votingworks/backend';
 import { iter, throwIllegalValue } from '@votingworks/basics';
 import {
@@ -198,7 +199,6 @@ export function* generateCvrs({
   // not be realistic since they cannot currently be scanned.
   const bmdBallots = Boolean(!election.gridLayouts);
 
-  let castVoteRecordId = 0;
   for (const ballotStyle of ballotStyles) {
     const { precincts: precinctIds, id: ballotStyleId, partyId } = ballotStyle;
     // For each contest, determine all possible contest choices
@@ -259,6 +259,7 @@ export function* generateCvrs({
 
           // Add the generated vote combinations as CVRs
           for (const votes of voteConfigurations) {
+            const castVoteRecordId = uuid();
             if (bmdBallots) {
               yield {
                 '@type': 'CVR.CVR',
@@ -288,8 +289,6 @@ export function* generateCvrs({
                   },
                 ],
               };
-
-              castVoteRecordId += 1;
             } else {
               // Since this is HMPB, we generate a CVR for each sheet (not fully supported yet)
               const contestsBySheet = arrangeContestsBySheet(
@@ -376,8 +375,6 @@ export function* generateCvrs({
                       ]
                     : undefined,
                 };
-
-                castVoteRecordId += 1;
               }
             }
           }

--- a/libs/cvr-fixture-generator/src/utils.ts
+++ b/libs/cvr-fixture-generator/src/utils.ts
@@ -1,11 +1,8 @@
-import {
-  CVR_BALLOT_IMAGES_SUBDIRECTORY,
-  CVR_BALLOT_LAYOUTS_SUBDIRECTORY,
-} from '@votingworks/backend';
 import { assert, assertDefined } from '@votingworks/basics';
 import { sha256 } from 'js-sha256';
 import {
   BallotPageLayout,
+  BallotPaperSize,
   Contests,
   CVR,
   Election,
@@ -14,6 +11,18 @@ import {
   SheetOf,
   VotesDict,
 } from '@votingworks/types';
+
+/**
+ * A mapping from ballot paper size to page height, in inches
+ */
+export const PAGE_HEIGHT_INCHES: Record<BallotPaperSize, number> = {
+  [BallotPaperSize.Letter]: 11,
+  [BallotPaperSize.Legal]: 14,
+  [BallotPaperSize.Custom17]: 17,
+  [BallotPaperSize.Custom18]: 18,
+  [BallotPaperSize.Custom21]: 21,
+  [BallotPaperSize.Custom22]: 22,
+};
 
 /**
  * Generate all combinations of an array.
@@ -139,34 +148,22 @@ export function filterVotesByContests(
 /**
  * Format of the image URIs used in generated fixtures.
  */
-export const IMAGE_URI_REGEX = new RegExp(
-  String.raw`file:${CVR_BALLOT_IMAGES_SUBDIRECTORY}\/(.+)\/(.+)__(.+)__(.+)\.jpg`
-);
+export const IMAGE_URI_REGEX = /file:(.+)-(front|back)\.jpg/;
 
 /**
- * Generates the relative path, from the root of a cast vote record directory,
- * to an asset specified by the parameters.
+ * Generates the path to a ballot asset, relative to an individual cast vote record directory.
  */
 export function generateBallotAssetPath({
-  ballotStyleId,
-  precinctId,
-  batchId,
-  pageNumber,
+  castVoteRecordId,
   assetType,
+  frontOrBack,
 }: {
-  ballotStyleId: string;
-  batchId: string;
-  precinctId: string;
-  pageNumber: number;
+  castVoteRecordId: string;
   assetType: 'image' | 'layout';
+  frontOrBack: 'front' | 'back';
 }): string {
-  return `${
-    assetType === 'image'
-      ? CVR_BALLOT_IMAGES_SUBDIRECTORY
-      : CVR_BALLOT_LAYOUTS_SUBDIRECTORY
-  }/${batchId}/${ballotStyleId}__${precinctId}__${pageNumber}.${
-    assetType === 'image' ? 'jpg' : 'layout.json'
-  }`;
+  const fileExtension = assetType === 'image' ? '.jpg' : '.layout.json';
+  return `${castVoteRecordId}-${frontOrBack}${fileExtension}`;
 }
 
 /**

--- a/libs/cvr-fixture-generator/tsconfig.build.json
+++ b/libs/cvr-fixture-generator/tsconfig.build.json
@@ -9,6 +9,7 @@
     "declaration": true
   },
   "references": [
+    { "path": "../auth/tsconfig.build.json" },
     { "path": "../basics/tsconfig.build.json" },
     { "path": "../converter-nh-accuvote/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },

--- a/libs/cvr-fixture-generator/tsconfig.json
+++ b/libs/cvr-fixture-generator/tsconfig.json
@@ -11,6 +11,7 @@
     "skipLibCheck": true
   },
   "references": [
+    { "path": "../auth/tsconfig.build.json" },
     { "path": "../basics/tsconfig.build.json" },
     { "path": "../converter-nh-accuvote/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3602,6 +3602,9 @@ importers:
 
   libs/cvr-fixture-generator:
     dependencies:
+      '@votingworks/auth':
+        specifier: '*'
+        version: link:../auth
       '@votingworks/backend':
         specifier: '*'
         version: link:../backend

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3638,6 +3638,9 @@ importers:
       lodash.clonedeep:
         specifier: ^4.5.0
         version: 4.5.0
+      uuid:
+        specifier: ^9.0.1
+        version: 9.0.1
       yargs:
         specifier: ^17.5.1
         version: 17.5.1
@@ -3654,6 +3657,9 @@ importers:
       '@types/tmp':
         specifier: ^0.2.3
         version: 0.2.3
+      '@types/uuid':
+        specifier: ^9.0.4
+        version: 9.0.4
       '@types/yargs':
         specifier: ^17.0.12
         version: 17.0.12
@@ -10028,7 +10034,7 @@ packages:
       react-inspector: 6.0.1(react@18.2.0)
       telejson: 7.0.4
       ts-dedent: 2.2.0
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -11683,6 +11689,10 @@ packages:
 
   /@types/uuid@9.0.2:
     resolution: {integrity: sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==}
+    dev: true
+
+  /@types/uuid@9.0.4:
+    resolution: {integrity: sha512-zAuJWQflfx6dYJM62vna+Sn5aeSWhh3OB+wfUEACNcqUSc0AGc5JKl+ycL1vrH7frGTXhJchYjE1Hak8L819dA==}
     dev: true
 
   /@types/w3c-web-usb@1.0.6:
@@ -24819,6 +24829,11 @@ packages:
 
   /uuid@9.0.0:
     resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
+    hasBin: true
+    dev: false
+
+  /uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
 
   /v8-to-istanbul@9.1.0:


### PR DESCRIPTION
_Easiest reviewed by commit_

## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/3890

A very first step in removing old CVR code, this PR updates `libs/cvr-fixture-generator` to use the new CVR export format. In my next PR, I'll actually generate new fixtures and have app tests use them.

This PR also makes various small tweaks to `libs/backend` functions, all geared around prep for removal of old CVR code.

## Testing

- [x] Updated automated CVR fixture generator tests
- [x] Ran CVR fixture generator and manually validated the generated contents

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A