### PR TITLE
style(ballot-interpreter): use variable directly

### DIFF
--- a/libs/ballot-interpreter/src/hmpb-rust/js/mod.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/js/mod.rs
@@ -106,8 +106,7 @@ pub fn interpret(mut cx: FunctionContext) -> JsResult<JsObject> {
             }
 
             return cx.throw_error(format!(
-                "failed to interpret ballot card; further, the error could not be serialized: {:?}",
-                err
+                "failed to interpret ballot card; further, the error could not be serialized: {err:?}"
             ));
         }
     };


### PR DESCRIPTION
## Overview
This has been a `clippy` lint for quite some time, but I thought it was a bug in `clippy`. Turns out you can use `Debug` formatting with inline variables too.

## Demo Video or Screenshot
n/a
## Testing Plan
Automated.