### PR TITLE
fix(custom-scanner): write `sideB` to `sideB.pgm`

### DIFF
--- a/libs/custom-scanner/src/cli/demo/index.ts
+++ b/libs/custom-scanner/src/cli/demo/index.ts
@@ -236,7 +236,7 @@ export async function main(): Promise<number> {
                   Buffer.from('P5\n'),
                   Buffer.from(`${sideB.imageWidth} ${sideB.imageHeight}\n`),
                   Buffer.from('255\n'),
-                  sideA.imageBuffer,
+                  sideB.imageBuffer,
                 ])
               );
               void (await scanner.move(FormMovement.EJECT_PAPER_FORWARD));


### PR DESCRIPTION
## Overview
We were accidentally writing the image data for `sideA`.

## Demo Video or Screenshot
n/a

## Testing Plan
Tested manually.
