### PR TITLE
Decrease VxScan backend test flakiness and introduce proper recovery from failures midway through a CVR export operation

### DIFF
--- a/apps/scan/backend/src/app_results.test.ts
+++ b/apps/scan/backend/src/app_results.test.ts
@@ -32,13 +32,9 @@ test('end-to-end tabulated results', async () => {
       await configureApp(apiClient, mockAuth, mockUsbDrive, { testMode: true });
 
       // scan a few ballots
-      await scanBallot(mockScanner, apiClient, 0, {
-        skipWaitForContinuousExportToUsbDrive: true,
-      });
-      await scanBallot(mockScanner, apiClient, 1, {
-        skipWaitForContinuousExportToUsbDrive: true,
-      });
-      await scanBallot(mockScanner, apiClient, 2);
+      await scanBallot(mockScanner, mockUsbDrive, apiClient, 0);
+      await scanBallot(mockScanner, mockUsbDrive, apiClient, 1);
+      await scanBallot(mockScanner, mockUsbDrive, apiClient, 2);
 
       const allResults = await apiClient.getScannerResultsByParty();
       expect(allResults).toHaveLength(1);

--- a/apps/scan/backend/src/app_usb_drive.test.ts
+++ b/apps/scan/backend/src/app_usb_drive.test.ts
@@ -58,7 +58,8 @@ test('doesUsbDriveRequireCastVoteRecordSync is properly populated', async () => 
       await expect(apiClient.getUsbDriveStatus()).resolves.toEqual(
         mountedUsbDriveStatus
       );
-      await scanBallot(mockScanner, apiClient, 0);
+
+      await scanBallot(mockScanner, mockUsbDrive, apiClient, 0);
       await expect(apiClient.getUsbDriveStatus()).resolves.toEqual(
         mountedUsbDriveStatus
       );

--- a/apps/scan/backend/src/scanners/custom/app_scan.test.ts
+++ b/apps/scan/backend/src/scanners/custom/app_scan.test.ts
@@ -21,7 +21,6 @@ import { MAX_FAILED_SCAN_ATTEMPTS } from './state_machine';
 import {
   configureApp,
   expectStatus,
-  waitForContinuousExportToUsbDrive,
   waitForStatus,
 } from '../../../test/helpers/shared_helpers';
 import {
@@ -122,7 +121,6 @@ test('configure and scan hmpb', async () => {
       });
 
       checkLogs(logger);
-      await waitForContinuousExportToUsbDrive();
     }
   );
 });
@@ -185,7 +183,6 @@ test('configure and scan bmd ballot', async () => {
       });
 
       checkLogs(logger);
-      await waitForContinuousExportToUsbDrive();
     }
   );
 });

--- a/apps/scan/backend/src/scanners/custom/app_scan_double_sheets.test.ts
+++ b/apps/scan/backend/src/scanners/custom/app_scan_double_sheets.test.ts
@@ -15,7 +15,6 @@ import { electionGridLayoutNewHampshireAmherstFixtures } from '@votingworks/fixt
 import {
   configureApp,
   expectStatus,
-  waitForContinuousExportToUsbDrive,
   waitForStatus,
 } from '../../../test/helpers/shared_helpers';
 import {
@@ -77,8 +76,6 @@ test('insert second ballot before first ballot accept', async () => {
         ballotsCounted: 1,
         canUnconfigure: true,
       });
-
-      await waitForContinuousExportToUsbDrive();
     }
   );
 });
@@ -122,8 +119,6 @@ test('insert second ballot while first ballot is accepting', async () => {
         ballotsCounted: 1,
         canUnconfigure: true,
       });
-
-      await waitForContinuousExportToUsbDrive();
     }
   );
 });
@@ -186,8 +181,6 @@ test('insert second ballot while first ballot needs review', async () => {
         interpretation,
         ballotsCounted: 1,
       });
-
-      await waitForContinuousExportToUsbDrive();
     }
   );
 });

--- a/apps/scan/backend/src/scanners/custom/app_scan_power_off.test.ts
+++ b/apps/scan/backend/src/scanners/custom/app_scan_power_off.test.ts
@@ -8,7 +8,6 @@ import {
 import {
   configureApp,
   mockInterpret,
-  waitForContinuousExportToUsbDrive,
   waitForStatus,
 } from '../../../test/helpers/shared_helpers';
 import {
@@ -108,8 +107,6 @@ test('scanner powered off while accepting', async () => {
         state: 'rejected',
         error: 'paper_in_back_after_reconnect',
       });
-
-      await waitForContinuousExportToUsbDrive();
     }
   );
 });
@@ -158,8 +155,6 @@ test('scanner powered off after accepting', async () => {
         ballotsCounted: 1,
         canUnconfigure: true,
       });
-
-      await waitForContinuousExportToUsbDrive();
     }
   );
 });

--- a/apps/scan/backend/test/helpers/custom_helpers.ts
+++ b/apps/scan/backend/test/helpers/custom_helpers.ts
@@ -21,7 +21,7 @@ import {
 import * as grout from '@votingworks/grout';
 import { getImageChannelCount } from '@votingworks/image-utils';
 import { Logger, fakeLogger } from '@votingworks/logging';
-import { SheetInterpretation, SheetOf, mapSheet } from '@votingworks/types';
+import { SheetOf, mapSheet } from '@votingworks/types';
 import { Application } from 'express';
 import { Server } from 'http';
 import { AddressInfo } from 'net';
@@ -228,29 +228,18 @@ export async function scanBallot(
       initialBallotsCounted === 0 || (await apiClient.getConfig()).isTestMode,
   });
 
-  const interpretation: SheetInterpretation = {
-    type: 'ValidSheet',
-  };
-
   mockScanner.scan.mockResolvedValueOnce(ok(await ballotImages.completeBmd()));
   await apiClient.scanBallot();
   mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
   await waitForStatus(apiClient, {
     state: 'ready_to_accept',
-    interpretation,
     ballotsCounted: initialBallotsCounted,
     canUnconfigure: true,
-  });
-  await apiClient.acceptBallot();
-  mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_NO_PAPER));
-  await waitForStatus(apiClient, {
-    ballotsCounted: initialBallotsCounted + 1,
-    state: 'accepted',
-    interpretation,
-    canUnconfigure: true,
+    interpretation: { type: 'ValidSheet' },
   });
 
-  // Wait for transition back to no paper
+  await apiClient.acceptBallot();
+  mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_NO_PAPER));
   await waitForStatus(apiClient, {
     state: 'no_paper',
     ballotsCounted: initialBallotsCounted + 1,

--- a/apps/scan/backend/test/helpers/custom_helpers.ts
+++ b/apps/scan/backend/test/helpers/custom_helpers.ts
@@ -123,6 +123,7 @@ export async function withApp(
     });
     mockUsbDrive.assertComplete();
   } finally {
+    await waitForContinuousExportToUsbDrive(mockUsbDrive);
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
     });
@@ -215,9 +216,9 @@ export function simulateScan(
 
 export async function scanBallot(
   mockScanner: jest.Mocked<CustomScanner>,
+  mockUsbDrive: MockUsbDrive,
   apiClient: grout.Client<Api>,
-  initialBallotsCounted: number,
-  options: { skipWaitForContinuousExportToUsbDrive?: boolean } = {}
+  initialBallotsCounted: number
 ): Promise<void> {
   mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
   await waitForStatus(apiClient, {
@@ -256,7 +257,5 @@ export async function scanBallot(
     canUnconfigure: true,
   });
 
-  if (!options.skipWaitForContinuousExportToUsbDrive) {
-    await waitForContinuousExportToUsbDrive();
-  }
+  await waitForContinuousExportToUsbDrive(mockUsbDrive);
 }

--- a/apps/scan/backend/test/helpers/shared_helpers.ts
+++ b/apps/scan/backend/test/helpers/shared_helpers.ts
@@ -1,6 +1,9 @@
 import { InsertedSmartCardAuthApi } from '@votingworks/auth';
-import { ok, sleep } from '@votingworks/basics';
-import { createBallotPackageZipArchive } from '@votingworks/backend';
+import { ok } from '@votingworks/basics';
+import {
+  areOrWereCastVoteRecordsBeingExportedToUsbDrive,
+  createBallotPackageZipArchive,
+} from '@votingworks/backend';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 import * as grout from '@votingworks/grout';
 import {
@@ -139,8 +142,19 @@ export function mockInterpret(
  * before continuous export finishes can result in errors due to directories getting cleaned up
  * while they're still being read from / written to.
  */
-export function waitForContinuousExportToUsbDrive(): Promise<void> {
-  // TODO: Replace this with a less arbitrary method, like actually checking the contents of the
-  // mock USB drive
-  return sleep(3000);
+export async function waitForContinuousExportToUsbDrive(
+  mockUsbDrive: MockUsbDrive
+): Promise<void> {
+  // Check that mockUsbDrive.usbDrive.status has been configured before calling it
+  if (mockUsbDrive.usbDrive.status.hasExpectedCalls()) {
+    const usbDriveStatus = await mockUsbDrive.usbDrive.status();
+    await waitForExpect(
+      () =>
+        expect(
+          areOrWereCastVoteRecordsBeingExportedToUsbDrive(usbDriveStatus)
+        ).toEqual(false),
+      10000,
+      250
+    );
+  }
 }

--- a/libs/auth/src/artifact_authentication.ts
+++ b/libs/auth/src/artifact_authentication.ts
@@ -31,6 +31,11 @@ import {
 } from './cryptography';
 import { constructPrefixedMessage } from './signatures';
 
+/**
+ * The file extension for VotingWorks signature files
+ */
+export const SIGNATURE_FILE_EXTENSION = '.vxsig';
+
 interface CastVoteRecordsToExport {
   type: 'cast_vote_records';
   context: 'export';
@@ -214,10 +219,10 @@ async function authenticateArtifactUsingArtifactSignatureBundle(
 function constructSignatureFileName(artifact: ArtifactToExport): string {
   switch (artifact.type) {
     case 'cast_vote_records': {
-      return `${artifact.directoryName}.vxsig`;
+      return `${artifact.directoryName}${SIGNATURE_FILE_EXTENSION}`;
     }
     case 'election_package': {
-      return `${path.basename(artifact.filePath)}.vxsig`;
+      return `${path.basename(artifact.filePath)}${SIGNATURE_FILE_EXTENSION}`;
     }
     /* istanbul ignore next: Compile-time check for completeness */
     default: {
@@ -229,10 +234,10 @@ function constructSignatureFileName(artifact: ArtifactToExport): string {
 function constructSignatureFilePath(artifact: ArtifactToImport): string {
   switch (artifact.type) {
     case 'cast_vote_records': {
-      return `${artifact.directoryPath}.vxsig`;
+      return `${artifact.directoryPath}${SIGNATURE_FILE_EXTENSION}`;
     }
     case 'election_package': {
-      return `${artifact.filePath}.vxsig`;
+      return `${artifact.filePath}${SIGNATURE_FILE_EXTENSION}`;
     }
     /* istanbul ignore next: Compile-time check for completeness */
     default: {

--- a/libs/backend/src/cast_vote_records/export.ts
+++ b/libs/backend/src/cast_vote_records/export.ts
@@ -731,8 +731,8 @@ export async function exportCastVoteRecordsToUsbDrive(
     return exportSignatureFileResult;
   }
 
-  clearDoesUsbDriveRequireCastVoteRecordSyncCachedResult();
   await markCastVoteRecordExportAsComplete(usbMountPoint);
+  clearDoesUsbDriveRequireCastVoteRecordSyncCachedResult();
 
   return ok();
 }

--- a/libs/backend/src/cast_vote_records/export.ts
+++ b/libs/backend/src/cast_vote_records/export.ts
@@ -573,7 +573,7 @@ async function randomlyUpdateCreationTimestamps(
 function getCastVoteRecordExportInProgressMarkerFilePath(
   usbMountPoint: string
 ): string {
-  return path.join(usbMountPoint, '.export-in-progress');
+  return path.join(usbMountPoint, '.vx-export-in-progress');
 }
 
 async function markCastVoteRecordExportAsInProgress(

--- a/libs/backend/src/cast_vote_records/export.ts
+++ b/libs/backend/src/cast_vote_records/export.ts
@@ -798,7 +798,7 @@ export async function doesUsbDriveRequireCastVoteRecordSync(
     }
     const castVoteRecordRootHash = scannerStore.getCastVoteRecordRootHash();
 
-    // A previous export may have failed midway
+    // A previous export operation may have failed midway
     if (areOrWereCastVoteRecordsBeingExportedToUsbDrive(usbDriveStatus)) {
       return true;
     }

--- a/libs/test-utils/src/mock_function.test.ts
+++ b/libs/test-utils/src/mock_function.test.ts
@@ -332,4 +332,22 @@ describe('mockFunction', () => {
 
     addMock.assertComplete();
   });
+
+  it('properly tracks whether expected calls have been set up', () => {
+    const addMock = mockFunction<typeof add>('add');
+
+    expect(addMock.hasExpectedCalls()).toEqual(false);
+
+    addMock.expectCallWith(1, 2).returns(3);
+    expect(addMock.hasExpectedCalls()).toEqual(true);
+
+    addMock.reset();
+    expect(addMock.hasExpectedCalls()).toEqual(false);
+
+    addMock.expectRepeatedCallsWith(1, 2).returns(3);
+    expect(addMock.hasExpectedCalls()).toEqual(true);
+
+    addMock.reset();
+    expect(addMock.hasExpectedCalls()).toEqual(false);
+  });
 });

--- a/libs/test-utils/src/mock_function.ts
+++ b/libs/test-utils/src/mock_function.ts
@@ -46,6 +46,7 @@ export interface MockFunction<Func extends AnyFunc> {
     : Omit<ReturnHelpers<Func>, 'throws'>;
   reset(): void;
   assertComplete(): void;
+  hasExpectedCalls(): boolean;
 }
 
 interface MockFunctionState<Func extends AnyFunc> {
@@ -313,6 +314,8 @@ export function mockFunction<Func extends AnyFunc>(
       throw new MockFunctionError(message);
     }
   };
+
+  mock.hasExpectedCalls = () => state.expectedCalls.length > 0;
 
   return mock;
 }


### PR DESCRIPTION
_Easiest reviewed by commit_

## Overview

VxScan backend tests have gotten quite flaky since my recent merge to enable continuous export by default, without a feature flag. Unsurprisingly, my [rudimentary approach](https://github.com/votingworks/vxsuite/blob/2a1441689e87312d56041930dd8fd8c19ac7ceda/apps/scan/backend/test/helpers/shared_helpers.ts#L137-L146) for waiting for continuous export to finish in tests isn't quite cutting it 😅.

This PR introduces a more robust waiting mechanism. Whenever a CVR export operation starts, we write a hidden `.export-in-progress` file to the USB drive. And when the operation completes, we delete that file. Tests can check for the lack of that file.

I've also combined this mechanism with https://github.com/votingworks/vxsuite/pull/3984 to introduce proper recovery from failures midway through a CVR export operation, which previously could've gone uncaught. Now, if an export operation fails midway, and the "something went wrong" screen prompts a poll worker to restart (existing behavior), the scanner will recognize that a resync is required on reboot :tada:. Lots of room for further optimization here (e.g. being smart about what we have to resync, etc.).

## Testing

- [x] Updated automated tests
- [x] Tested recovery from failures midway through an export manually

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A