### PR TITLE
Ballot Count Report CSV

### DIFF
--- a/apps/admin/backend/jest.config.js
+++ b/apps/admin/backend/jest.config.js
@@ -36,4 +36,5 @@ module.exports = {
       '<rootDir>/node_modules/csv-stringify/dist/cjs/sync.cjs',
     '^csv-parse/sync': '<rootDir>/node_modules/csv-parse/dist/cjs/sync.cjs',
   },
+  prettierPath: null,
 };

--- a/apps/admin/backend/src/app.ballot_count_report_csv_export.test.ts
+++ b/apps/admin/backend/src/app.ballot_count_report_csv_export.test.ts
@@ -1,0 +1,234 @@
+import {
+  electionGridLayoutNewHampshireAmherstFixtures,
+  electionTwoPartyPrimaryFixtures,
+} from '@votingworks/fixtures';
+import {
+  BooleanEnvironmentVariableName,
+  buildManualResultsFixture,
+  getFeatureFlagMock,
+} from '@votingworks/utils';
+import { tmpNameSync } from 'tmp';
+import { readFileSync } from 'fs';
+import { LogEventId } from '@votingworks/logging';
+import { Tabulation } from '@votingworks/types';
+import { Client } from '@votingworks/grout';
+import { parseCsv } from '../test/csv';
+import {
+  buildTestEnvironment,
+  configureMachine,
+  mockElectionManagerAuth,
+} from '../test/app';
+import { Api } from './app';
+
+jest.setTimeout(60_000);
+
+// mock SKIP_CVR_ELECTION_HASH_CHECK to allow us to use old cvr fixtures
+const featureFlagMock = getFeatureFlagMock();
+jest.mock('@votingworks/utils', () => {
+  return {
+    ...jest.requireActual('@votingworks/utils'),
+    isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+      featureFlagMock.isEnabled(flag),
+  };
+});
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+  featureFlagMock.enableFeatureFlag(
+    BooleanEnvironmentVariableName.SKIP_CVR_ELECTION_HASH_CHECK
+  );
+  featureFlagMock.enableFeatureFlag(
+    BooleanEnvironmentVariableName.SKIP_CAST_VOTE_RECORDS_AUTHENTICATION
+  );
+});
+
+afterEach(() => {
+  featureFlagMock.resetFeatureFlags();
+});
+
+it('logs success if export succeeds', async () => {
+  const { electionDefinition, castVoteRecordExport } =
+    electionTwoPartyPrimaryFixtures;
+
+  const { apiClient, auth, logger } = buildTestEnvironment();
+  await configureMachine(apiClient, auth, electionDefinition);
+  mockElectionManagerAuth(auth, electionDefinition.electionHash);
+
+  const loadFileResult = await apiClient.addCastVoteRecordFile({
+    path: castVoteRecordExport.asDirectoryPath(),
+  });
+  loadFileResult.assertOk('load file failed');
+
+  const offLimitsPath = '/root/hidden';
+  const failedExportResult = await apiClient.exportBallotCountReportCsv({
+    path: offLimitsPath,
+    ballotCountBreakdown: 'none',
+  });
+  expect(failedExportResult.isErr()).toEqual(true);
+  expect(logger.log).toHaveBeenLastCalledWith(
+    LogEventId.FileSaved,
+    'election_manager',
+    {
+      disposition: 'failure',
+      filename: offLimitsPath,
+      message: `Failed to save ballot count report CSV file to ${offLimitsPath} on the USB drive.`,
+    }
+  );
+});
+
+it('logs failure if export fails', async () => {
+  const { electionDefinition, castVoteRecordExport } =
+    electionTwoPartyPrimaryFixtures;
+
+  const { apiClient, auth, logger } = buildTestEnvironment();
+  await configureMachine(apiClient, auth, electionDefinition);
+  mockElectionManagerAuth(auth, electionDefinition.electionHash);
+
+  const loadFileResult = await apiClient.addCastVoteRecordFile({
+    path: castVoteRecordExport.asDirectoryPath(),
+  });
+  loadFileResult.assertOk('load file failed');
+
+  const path = tmpNameSync();
+  const exportResult = await apiClient.exportBallotCountReportCsv({
+    path,
+    ballotCountBreakdown: 'none',
+  });
+  expect(exportResult.isOk()).toEqual(true);
+  expect(logger.log).toHaveBeenLastCalledWith(
+    LogEventId.FileSaved,
+    'election_manager',
+    {
+      disposition: 'success',
+      filename: path,
+      message: `Saved ballot count report CSV file to ${path} on the USB drive.`,
+    }
+  );
+});
+
+async function getParsedExport({
+  apiClient,
+  groupBy,
+  filter,
+  ballotCountBreakdown,
+}: {
+  apiClient: Client<Api>;
+  groupBy?: Tabulation.GroupBy;
+  filter?: Tabulation.Filter;
+  ballotCountBreakdown: Tabulation.BallotCountBreakdown;
+}): Promise<ReturnType<typeof parseCsv>> {
+  const path = tmpNameSync();
+  const exportResult = await apiClient.exportBallotCountReportCsv({
+    path,
+    groupBy,
+    filter,
+    ballotCountBreakdown,
+  });
+  expect(exportResult.isOk()).toEqual(true);
+  return parseCsv(readFileSync(path, 'utf-8').toString());
+}
+
+it('creates accurate ballot count reports', async () => {
+  const { electionDefinition, castVoteRecordExport } =
+    electionGridLayoutNewHampshireAmherstFixtures;
+  const { election } = electionDefinition;
+
+  const { apiClient, auth } = buildTestEnvironment();
+  await configureMachine(apiClient, auth, electionDefinition);
+  mockElectionManagerAuth(auth, electionDefinition.electionHash);
+
+  // add CVR data
+  const loadFileResult = await apiClient.addCastVoteRecordFile({
+    path: castVoteRecordExport.asDirectoryPath(),
+  });
+  loadFileResult.assertOk('load file failed');
+
+  // add manual data
+  await apiClient.setManualResults({
+    precinctId: election.precincts[0]!.id,
+    votingMethod: 'absentee',
+    ballotStyleId: election.ballotStyles[0]!.id,
+    manualResults: buildManualResultsFixture({
+      election,
+      ballotCount: 10,
+      contestResultsSummaries: {},
+    }),
+  });
+
+  expect(
+    await getParsedExport({
+      apiClient,
+      groupBy: { groupByVotingMethod: true },
+      ballotCountBreakdown: 'none',
+    })
+  ).toEqual({
+    headers: ['Voting Method', 'Total'],
+    rows: [
+      {
+        Total: '92',
+        'Voting Method': 'Precinct',
+      },
+      {
+        Total: '102',
+        'Voting Method': 'Absentee',
+      },
+    ],
+  });
+
+  expect(
+    await getParsedExport({
+      apiClient,
+      groupBy: { groupByPrecinct: true },
+      ballotCountBreakdown: 'manual',
+    })
+  ).toEqual({
+    headers: ['Precinct', 'Precinct ID', 'Manual', 'Scanned', 'Total'],
+    rows: [
+      {
+        Manual: '10',
+        Precinct: 'Test Ballot',
+        'Precinct ID': 'town-id-00701-precinct-id-',
+        Scanned: '184',
+        Total: '194',
+      },
+    ],
+  });
+
+  expect(
+    await getParsedExport({
+      apiClient,
+      groupBy: { groupByPrecinct: true, groupByVotingMethod: true },
+      ballotCountBreakdown: 'all',
+    })
+  ).toEqual({
+    headers: [
+      'Precinct',
+      'Precinct ID',
+      'Voting Method',
+      'Manual',
+      'BMD',
+      'HMPB',
+      'Total',
+    ],
+    rows: [
+      {
+        BMD: '0',
+        HMPB: '92',
+        Manual: '0',
+        Precinct: 'Test Ballot',
+        'Precinct ID': 'town-id-00701-precinct-id-',
+        Total: '92',
+        'Voting Method': 'Precinct',
+      },
+      {
+        BMD: '0',
+        HMPB: '92',
+        Manual: '10',
+        Precinct: 'Test Ballot',
+        'Precinct ID': 'town-id-00701-precinct-id-',
+        Total: '102',
+        'Voting Method': 'Absentee',
+      },
+    ],
+  });
+});

--- a/apps/admin/backend/src/app.tally_report_csv_export.test.ts
+++ b/apps/admin/backend/src/app.tally_report_csv_export.test.ts
@@ -87,7 +87,7 @@ it('exports expected results for full election', async () => {
     {
       disposition: 'success',
       filename: path,
-      message: `Saved csv results to ${path} on the USB drive.`,
+      message: `Saved tally report CSV file to ${path} on the USB drive.`,
     }
   );
 
@@ -155,7 +155,7 @@ it('logs failure if export fails for some reason', async () => {
     {
       disposition: 'failure',
       filename: offLimitsPath,
-      message: `Failed to save csv results to ${offLimitsPath} on the USB drive.`,
+      message: `Failed to save tally report CSV file to ${offLimitsPath} on the USB drive.`,
     }
   );
 });

--- a/apps/admin/backend/src/app.tally_report_csv_export.test.ts
+++ b/apps/admin/backend/src/app.tally_report_csv_export.test.ts
@@ -56,7 +56,7 @@ async function getParsedExport({
   filter?: Tabulation.Filter;
 }): Promise<ReturnType<typeof parseCsv>> {
   const path = tmpNameSync();
-  const exportResult = await apiClient.exportResultsCsv({
+  const exportResult = await apiClient.exportTallyReportCsv({
     path,
     groupBy,
     filter,
@@ -79,7 +79,7 @@ it('exports expected results for full election', async () => {
   loadFileResult.assertOk('load file failed');
 
   const path = tmpNameSync();
-  const exportResult = await apiClient.exportResultsCsv({ path });
+  const exportResult = await apiClient.exportTallyReportCsv({ path });
   expect(exportResult.isOk()).toEqual(true);
   expect(logger.log).toHaveBeenLastCalledWith(
     LogEventId.FileSaved,
@@ -145,7 +145,7 @@ it('logs failure if export fails for some reason', async () => {
   loadFileResult.assertOk('load file failed');
 
   const offLimitsPath = '/root/hidden';
-  const failedExportResult = await apiClient.exportResultsCsv({
+  const failedExportResult = await apiClient.exportTallyReportCsv({
     path: offLimitsPath,
   });
   expect(failedExportResult.isErr()).toEqual(true);

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -74,7 +74,7 @@ import { exportFile } from './util/export_file';
 import { generateBatchResultsFile } from './exports/batch_results';
 import { tabulateElectionResults } from './tabulation/full_results';
 import { getSemsExportableTallies } from './exports/sems_tallies';
-import { generateResultsCsv } from './exports/csv_results';
+import { generateTallyReportCsv } from './exports/csv_tally_report';
 import { tabulateFullCardCounts } from './tabulation/card_counts';
 import { getOverallElectionWriteInSummary } from './tabulation/write_ins';
 import { rootDebug } from './util/debug';
@@ -721,7 +721,7 @@ function buildApi({
       debug('exporting results CSV file: %o', input);
       const exportFileResult = await exportFile({
         path: input.path,
-        data: await generateResultsCsv({
+        data: await generateTallyReportCsv({
           store,
           filter: input.filter,
           groupBy: input.groupBy,

--- a/apps/admin/backend/src/exports/csv_ballot_count_report.test.ts
+++ b/apps/admin/backend/src/exports/csv_ballot_count_report.test.ts
@@ -1,0 +1,249 @@
+import { electionTwoPartyPrimaryFixtures } from '@votingworks/fixtures';
+import { DEFAULT_SYSTEM_SETTINGS, Tabulation } from '@votingworks/types';
+import { find } from '@votingworks/basics';
+import { buildManualResultsFixture } from '@votingworks/utils';
+import {
+  MockCastVoteRecordFile,
+  addMockCvrFileToStore,
+} from '../../test/mock_cvr_file';
+import { parseCsv, streamToString } from '../../test/csv';
+import { Store } from '../store';
+import { generateBallotCountReportCsv } from './csv_ballot_count_report';
+
+test('uses appropriate headers', async () => {
+  const store = Store.memoryStore();
+  const { electionDefinition } = electionTwoPartyPrimaryFixtures;
+  const { election, electionData } = electionDefinition;
+  const electionId = store.addElection({
+    electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+  });
+  store.setCurrentElectionId(electionId);
+
+  // add some mock cast vote records with one vote each
+  const mockCastVoteRecordAttributes = {
+    ballotStyleId: '1M',
+    batchId: 'batch-1',
+    scannerId: 'scanner-1',
+    precinctId: 'precinct-1',
+    votingMethod: 'precinct',
+    votes: {},
+  } as const;
+
+  const mockCastVoteRecordFile: MockCastVoteRecordFile = [
+    {
+      ...mockCastVoteRecordAttributes,
+      card: { type: 'bmd' },
+      multiplier: 1,
+    },
+    {
+      ...mockCastVoteRecordAttributes,
+      card: { type: 'hmpb', sheetNumber: 1 },
+      multiplier: 2,
+    },
+    {
+      ...mockCastVoteRecordAttributes,
+      card: { type: 'hmpb', sheetNumber: 2 },
+      multiplier: 2,
+    },
+  ];
+  addMockCvrFileToStore({ electionId, mockCastVoteRecordFile, store });
+  store.setManualResults({
+    electionId,
+    precinctId: 'precinct-1',
+    ballotStyleId: '1M',
+    votingMethod: 'precinct',
+    manualResults: buildManualResultsFixture({
+      election,
+      ballotCount: 5,
+      contestResultsSummaries: {},
+    }),
+  });
+
+  const SHARED_ROW_VALUES: Record<string, string> = {
+    'Precinct ID': 'precinct-1',
+    Precinct: 'Precinct 1',
+    'Ballot Style ID': '1M',
+    Party: 'Mammal',
+    'Party ID': '0',
+    'Voting Method': 'Precinct',
+    'Batch ID': 'batch-1',
+    'Scanner ID': 'scanner-1',
+    BMD: '1',
+    HMPB: '2',
+    Manual: '5',
+    Scanned: '3',
+    Total: '8',
+  };
+
+  const testCases: Array<{
+    filter?: Tabulation.Filter;
+    groupBy?: Tabulation.GroupBy;
+    ballotCountBreakdown: Tabulation.BallotCountBreakdown;
+    expectedHeaders: string[];
+    additionalRowAttributes?: Record<string, string>;
+  }> = [
+    // single groupings
+    {
+      groupBy: { groupByPrecinct: true },
+      ballotCountBreakdown: 'none',
+      expectedHeaders: ['Precinct', 'Precinct ID', 'Total'],
+    },
+    {
+      groupBy: { groupByParty: true },
+      ballotCountBreakdown: 'none',
+      expectedHeaders: ['Party', 'Party ID', 'Total'],
+    },
+    {
+      groupBy: { groupByVotingMethod: true },
+      ballotCountBreakdown: 'none',
+      expectedHeaders: ['Voting Method', 'Total'],
+    },
+    // multiple groupings
+    {
+      groupBy: { groupByPrecinct: true, groupByVotingMethod: true },
+      ballotCountBreakdown: 'none',
+      expectedHeaders: ['Precinct', 'Precinct ID', 'Voting Method', 'Total'],
+    },
+    // single filters
+    {
+      filter: { ballotStyleIds: ['1M'] },
+      ballotCountBreakdown: 'none',
+      expectedHeaders: ['Party', 'Party ID', 'Ballot Style ID', 'Total'],
+    },
+    // alternate breakdowns
+    {
+      groupBy: { groupByPrecinct: true },
+      ballotCountBreakdown: 'manual',
+      expectedHeaders: [
+        'Precinct',
+        'Precinct ID',
+        'Manual',
+        'Scanned',
+        'Total',
+      ],
+    },
+    {
+      groupBy: { groupByPrecinct: true },
+      ballotCountBreakdown: 'all',
+      expectedHeaders: [
+        'Precinct',
+        'Precinct ID',
+        'Manual',
+        'BMD',
+        'HMPB',
+        'Total',
+      ],
+    },
+  ];
+
+  for (const testCase of testCases) {
+    const stream = generateBallotCountReportCsv({
+      store,
+      filter: testCase.filter,
+      groupBy: testCase.groupBy,
+      ballotCountBreakdown: testCase.ballotCountBreakdown,
+    });
+    const fileContents = await streamToString(stream);
+    const { headers, rows } = parseCsv(fileContents);
+    expect(headers).toEqual([...testCase.expectedHeaders]);
+
+    const row = find(rows, (r) => r['Total'] !== '0');
+    const expectedAttributes: Record<string, string> = {
+      ...SHARED_ROW_VALUES,
+      ...(testCase.additionalRowAttributes || {}),
+    };
+    for (const [header, value] of Object.entries(row)) {
+      expect(value).toEqual(expectedAttributes[header]);
+    }
+  }
+});
+
+test('includes rows for empty but known result groups', async () => {
+  const store = Store.memoryStore();
+  const { electionDefinition } = electionTwoPartyPrimaryFixtures;
+  const { electionData } = electionDefinition;
+  const electionId = store.addElection({
+    electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+  });
+  store.setCurrentElectionId(electionId);
+
+  // no CVRs, so all groups should be empty
+  const stream = generateBallotCountReportCsv({
+    store,
+    filter: {},
+    groupBy: { groupByPrecinct: true },
+    ballotCountBreakdown: 'none',
+  });
+  const fileContents = await streamToString(stream);
+  const { rows } = parseCsv(fileContents);
+
+  find(rows, (r) => r['Precinct'] === 'Precinct 1');
+  find(rows, (r) => r['Precinct'] === 'Precinct 2');
+});
+
+test('does not include results groups when they are excluded by the filter', async () => {
+  const store = Store.memoryStore();
+  const { electionDefinition } = electionTwoPartyPrimaryFixtures;
+  const { electionData } = electionDefinition;
+  const electionId = store.addElection({
+    electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+  });
+  store.setCurrentElectionId(electionId);
+
+  // grouping on voting method should include both precinct and absentee rows
+  const byVotingMethodStream = generateBallotCountReportCsv({
+    store,
+    groupBy: { groupByVotingMethod: true },
+    ballotCountBreakdown: 'none',
+  });
+  const byVotingMethodFileContents = await streamToString(byVotingMethodStream);
+  const { rows: byVotingMethodRows } = parseCsv(byVotingMethodFileContents);
+  expect(
+    byVotingMethodRows.some((r) => r['Voting Method'] === 'Absentee')
+  ).toBeTruthy();
+  expect(
+    byVotingMethodRows.some((r) => r['Voting Method'] === 'Precinct')
+  ).toBeTruthy();
+
+  // but if we add on a filter that excludes absentee, absentee rows should not be included
+  const precinctStream = generateBallotCountReportCsv({
+    store,
+    groupBy: { groupByVotingMethod: true },
+    filter: { votingMethods: ['precinct'] },
+    ballotCountBreakdown: 'none',
+  });
+  const precinctFileContests = await streamToString(precinctStream);
+  const { rows: precinctRows } = parseCsv(precinctFileContests);
+  expect(
+    precinctRows.some((r) => r['Voting Method'] === 'Absentee')
+  ).toBeFalsy();
+  expect(
+    precinctRows.some((r) => r['Voting Method'] === 'Precinct')
+  ).toBeTruthy();
+});
+
+test('excludes Manual column for "all" reports if no manual data exists', async () => {
+  const store = Store.memoryStore();
+  const { electionDefinition } = electionTwoPartyPrimaryFixtures;
+  const { electionData } = electionDefinition;
+  const electionId = store.addElection({
+    electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+  });
+  store.setCurrentElectionId(electionId);
+
+  // no CVRs, so all groups should be empty
+  const stream = generateBallotCountReportCsv({
+    store,
+    filter: {},
+    groupBy: { groupByPrecinct: true },
+    ballotCountBreakdown: 'all',
+  });
+  const fileContents = await streamToString(stream);
+  const { headers } = parseCsv(fileContents);
+
+  expect(headers).not.toContain('Manual');
+});

--- a/apps/admin/backend/src/exports/csv_ballot_count_report.ts
+++ b/apps/admin/backend/src/exports/csv_ballot_count_report.ts
@@ -1,0 +1,210 @@
+import { stringify } from 'csv-stringify/sync';
+import {
+  Tabulation,
+  ElectionDefinition,
+  Id,
+  Election,
+} from '@votingworks/types';
+import { assert, assertDefined, throwIllegalValue } from '@votingworks/basics';
+import {
+  combineGroupSpecifierAndFilter,
+  getBallotCount,
+  getHmpbBallotCount,
+  getScannedBallotCount,
+  groupMapToGroupList,
+} from '@votingworks/utils';
+import { Readable } from 'stream';
+import { Store } from '../store';
+import {
+  CsvMetadataStructure,
+  determineCsvMetadataStructure,
+  generateBatchLookup,
+  generateCsvMetadataHeaders,
+  getCsvMetadataRowValues,
+} from './csv_shared';
+import { tabulateFullCardCounts } from '../tabulation/card_counts';
+
+function generateHeaders({
+  election,
+  metadataStructure,
+  ballotCountBreakdown,
+  hasManualTallies,
+}: {
+  election: Election;
+  metadataStructure: CsvMetadataStructure;
+  ballotCountBreakdown: Tabulation.BallotCountBreakdown;
+  hasManualTallies: boolean;
+}): string[] {
+  const headers = generateCsvMetadataHeaders({ election, metadataStructure });
+
+  switch (ballotCountBreakdown) {
+    case 'none':
+      headers.push('Total');
+      break;
+    case 'manual':
+      headers.push('Manual', 'Scanned', 'Total');
+      break;
+    case 'all':
+      if (hasManualTallies) {
+        headers.push('Manual');
+      }
+      headers.push('BMD', 'HMPB', 'Total');
+      break;
+    /* c8 ignore next 2 -- compile-time check */
+    default:
+      throwIllegalValue(ballotCountBreakdown);
+  }
+  return headers;
+}
+
+function buildRow({
+  metadataValues,
+  cardCounts,
+  ballotCountBreakdown,
+  hasManualTallies,
+}: {
+  metadataValues: string[];
+  cardCounts: Tabulation.CardCounts;
+  ballotCountBreakdown: Tabulation.BallotCountBreakdown;
+  hasManualTallies: boolean;
+}): string {
+  const values: string[] = [...metadataValues];
+
+  const counts: number[] = [];
+  /* c8 ignore next - trivial fallback case */
+  const manual = cardCounts.manual ?? 0;
+  const scanned = getScannedBallotCount(cardCounts);
+  const { bmd } = cardCounts;
+  const hmpb = getHmpbBallotCount(cardCounts);
+  const total = getBallotCount(cardCounts);
+
+  switch (ballotCountBreakdown) {
+    case 'none':
+      counts.push(total);
+      break;
+    case 'manual':
+      counts.push(manual, scanned, total);
+      break;
+    case 'all':
+      if (hasManualTallies) {
+        counts.push(manual);
+      }
+      counts.push(bmd, hmpb, total);
+      break;
+    /* c8 ignore next 2 -- compile-time check */
+    default:
+      throwIllegalValue(ballotCountBreakdown);
+  }
+
+  return stringify([[...values, ...counts.map((num) => num.toString())]]);
+}
+
+function* generateDataRows({
+  electionId,
+  electionDefinition,
+  overallExportFilter,
+  allCardCounts,
+  metadataStructure,
+  ballotCountBreakdown,
+  hasManualTallies,
+  store,
+}: {
+  electionId: Id;
+  electionDefinition: ElectionDefinition;
+  overallExportFilter: Tabulation.Filter;
+  allCardCounts: Tabulation.GroupList<Tabulation.CardCounts>;
+  metadataStructure: CsvMetadataStructure;
+  ballotCountBreakdown: Tabulation.BallotCountBreakdown;
+  hasManualTallies: boolean;
+  store: Store;
+}): Generator<string> {
+  const batchLookup = generateBatchLookup(store, assertDefined(electionId));
+
+  for (const cardCounts of allCardCounts) {
+    const groupFilter = combineGroupSpecifierAndFilter(
+      cardCounts,
+      overallExportFilter
+    );
+    const metadataValues = getCsvMetadataRowValues({
+      filter: groupFilter,
+      metadataStructure,
+      electionDefinition,
+      batchLookup,
+    });
+
+    yield buildRow({
+      metadataValues,
+      cardCounts,
+      ballotCountBreakdown,
+      hasManualTallies,
+    });
+  }
+}
+
+/**
+ * Converts a tally for an election to a CSV file (represented as a string) of tally
+ * results. Results are filtered by the `filter` parameter and grouped according to
+ * the `groupBy` parameter. Each row is labelled with metadata according to its group
+ * and the overall export's filter.
+ *
+ * Returns the file as a `NodeJS.ReadableStream` emitting line by line.
+ */
+export function generateBallotCountReportCsv({
+  store,
+  filter = {},
+  groupBy = {},
+  ballotCountBreakdown,
+}: {
+  store: Store;
+  filter?: Tabulation.Filter;
+  groupBy?: Tabulation.GroupBy;
+  ballotCountBreakdown: Tabulation.BallotCountBreakdown;
+}): NodeJS.ReadableStream {
+  const electionId = store.getCurrentElectionId();
+  assert(electionId !== undefined);
+  const { electionDefinition } = assertDefined(store.getElection(electionId));
+  const { election } = electionDefinition;
+
+  const metadataStructure = determineCsvMetadataStructure({
+    filter,
+    groupBy,
+  });
+  const allCardCounts = groupMapToGroupList(
+    tabulateFullCardCounts({
+      electionId,
+      store,
+      filter,
+      groupBy,
+    })
+  );
+  const hasManualTallies = // has any manual tallies for entire election, not just for this export
+    store.getManualResultsMetadata({ electionId }).length > 0;
+
+  const headerRow = stringify([
+    generateHeaders({
+      election,
+      metadataStructure,
+      ballotCountBreakdown,
+      hasManualTallies,
+    }),
+  ]);
+
+  function* generateAllRows() {
+    yield headerRow;
+
+    for (const dataRow of generateDataRows({
+      electionDefinition,
+      electionId: assertDefined(electionId),
+      overallExportFilter: filter,
+      allCardCounts,
+      metadataStructure,
+      ballotCountBreakdown,
+      hasManualTallies,
+      store,
+    })) {
+      yield dataRow;
+    }
+  }
+
+  return Readable.from(generateAllRows());
+}

--- a/apps/admin/backend/src/exports/csv_shared.ts
+++ b/apps/admin/backend/src/exports/csv_shared.ts
@@ -1,0 +1,110 @@
+import { Tabulation } from '@votingworks/types';
+
+/**
+ * Possible metadata attributes that can be included in the CSV, in the order
+ * the columns will appear in the CSV.
+ */
+export const CSV_METADATA_ATTRIBUTES = [
+  'precinct',
+  'party',
+  'ballotStyle',
+  'votingMethod',
+  'scanner',
+  'batch',
+] as const;
+
+type CsvMetadataAttribute = (typeof CSV_METADATA_ATTRIBUTES)[number];
+
+/**
+ * Labels for compound metadata filter columns, such as in the case where a
+ * report filters on multiple precincts or multiple ballot styles.
+ */
+export const CSV_METADATA_ATTRIBUTE_MULTI_LABEL: Record<
+  CsvMetadataAttribute,
+  string
+> = {
+  precinct: 'Precincts',
+  party: 'Parties',
+  ballotStyle: 'Ballot Styles',
+  votingMethod: 'Voting Methods',
+  scanner: 'Scanners',
+  batch: 'Batches',
+};
+
+/**
+ * Separator between values in compound metadata filter columns.
+ */
+export const CSV_MULTI_VALUE_SEPARATOR = ', ';
+
+// `all` is equivalent to having no filter for an attribute
+type Multiplicity = 'single' | 'multi' | 'all';
+
+/**
+ * Describes the metadata structure of the CSV. We distinguish between single
+ * multi attributes because "single" is the common and intuitive use case,
+ * alongside which we want to add additional related metadata. The "multi"
+ * attributes are only to ensure the CSV is self-documenting when there are
+ * filters selecting for multiple values.
+ */
+export type CsvMetadataStructure = {
+  [K in CsvMetadataAttribute]: Multiplicity;
+};
+
+/**
+ * Given a filter and group by defining a report, determines the metadata structure of the report.
+ */
+export function determineCsvMetadataStructure({
+  filter,
+  groupBy,
+}: {
+  filter: Tabulation.Filter;
+  groupBy: Tabulation.GroupBy;
+}): CsvMetadataStructure {
+  const filterStructure: CsvMetadataStructure = {
+    precinct: filter.precinctIds
+      ? filter.precinctIds.length > 1
+        ? 'multi'
+        : 'single'
+      : 'all',
+    ballotStyle: filter.ballotStyleIds
+      ? filter.ballotStyleIds.length > 1
+        ? 'multi'
+        : 'single'
+      : 'all',
+    party: filter.partyIds
+      ? filter.partyIds.length > 1
+        ? 'multi'
+        : 'single'
+      : 'all',
+    votingMethod: filter.votingMethods
+      ? filter.votingMethods.length > 1
+        ? 'multi'
+        : 'single'
+      : 'all',
+    scanner: filter.scannerIds
+      ? filter.scannerIds.length > 1
+        ? 'multi'
+        : 'single'
+      : 'all',
+    batch: filter.batchIds
+      ? filter.batchIds.length > 1
+        ? 'multi'
+        : 'single'
+      : 'all',
+  };
+
+  // If we're grouping by an attribute, it's always going to be a single.
+  // Otherwise, the multiplicity is the same as the filter.
+  return {
+    ballotStyle: groupBy.groupByBallotStyle
+      ? 'single'
+      : filterStructure.ballotStyle,
+    party: groupBy.groupByParty ? 'single' : filterStructure.party,
+    precinct: groupBy.groupByPrecinct ? 'single' : filterStructure.precinct,
+    scanner: groupBy.groupByScanner ? 'single' : filterStructure.scanner,
+    batch: groupBy.groupByBatch ? 'single' : filterStructure.batch,
+    votingMethod: groupBy.groupByVotingMethod
+      ? 'single'
+      : filterStructure.votingMethod,
+  };
+}

--- a/apps/admin/backend/src/exports/csv_tally_report.test.ts
+++ b/apps/admin/backend/src/exports/csv_tally_report.test.ts
@@ -5,7 +5,7 @@ import {
   MockCastVoteRecordFile,
   addMockCvrFileToStore,
 } from '../../test/mock_cvr_file';
-import { generateResultsCsv } from './csv_results';
+import { generateTallyReportCsv } from './csv_tally_report';
 import { parseCsv, streamToString } from '../../test/csv';
 import { Store } from '../store';
 
@@ -200,7 +200,7 @@ test('uses appropriate headers', async () => {
   ];
 
   for (const testCase of testCases) {
-    const stream = await generateResultsCsv({
+    const stream = await generateTallyReportCsv({
       store,
       filter: testCase.filter,
       groupBy: testCase.groupBy,
@@ -234,7 +234,7 @@ test('includes rows for empty but known result groups', async () => {
   store.setCurrentElectionId(electionId);
 
   // no CVRs, so all groups should be empty
-  const stream = await generateResultsCsv({
+  const stream = await generateTallyReportCsv({
     store,
     filter: {},
     groupBy: { groupByPrecinct: true },
@@ -256,7 +256,7 @@ test('included contests are specific to each results group', async () => {
   });
   store.setCurrentElectionId(electionId);
 
-  const stream = await generateResultsCsv({
+  const stream = await generateTallyReportCsv({
     store,
     filter: {},
     groupBy: { groupByBallotStyle: true },
@@ -292,7 +292,7 @@ test('included contests are restricted by the overall export filter', async () =
   });
   store.setCurrentElectionId(electionId);
 
-  const stream = await generateResultsCsv({
+  const stream = await generateTallyReportCsv({
     store,
     filter: { ballotStyleIds: ['1M'] },
   });
@@ -320,7 +320,7 @@ test('does not include results groups when they are excluded by the filter', asy
   store.setCurrentElectionId(electionId);
 
   // grouping on voting method should include both precinct and absentee rows
-  const byVotingMethodStream = await generateResultsCsv({
+  const byVotingMethodStream = await generateTallyReportCsv({
     store,
     groupBy: { groupByVotingMethod: true },
   });
@@ -334,7 +334,7 @@ test('does not include results groups when they are excluded by the filter', asy
   ).toBeTruthy();
 
   // but if we add on a filter that excludes absentee, absentee rows should not be included
-  const precinctStream = await generateResultsCsv({
+  const precinctStream = await generateTallyReportCsv({
     store,
     groupBy: { groupByVotingMethod: true },
     filter: { votingMethods: ['precinct'] },

--- a/apps/admin/backend/src/exports/csv_tally_report.ts
+++ b/apps/admin/backend/src/exports/csv_tally_report.ts
@@ -36,7 +36,7 @@ function generateHeaders({
   return headers;
 }
 
-function buildCsvRow({
+function buildRow({
   metadataValues,
   contest,
   selection,
@@ -65,7 +65,7 @@ function buildCsvRow({
   return stringify([values]);
 }
 
-function* generateRows({
+function* generateDataRows({
   electionId,
   electionDefinition,
   overallExportFilter,
@@ -122,7 +122,7 @@ function* generateRows({
         for (const candidate of contest.candidates) {
           /* c8 ignore next -- trivial fallthrough zero branch */
           const votes = contestResults.tallies[candidate.id]?.tally ?? 0;
-          yield buildCsvRow({
+          yield buildRow({
             metadataValues,
             contest,
             selection: candidate.name,
@@ -135,7 +135,7 @@ function* generateRows({
         if (contest.allowWriteIns) {
           const votes = contestResults.tallies[writeInCandidate.id]?.tally ?? 0;
           if (votes) {
-            yield buildCsvRow({
+            yield buildRow({
               metadataValues,
               contest,
               selection: writeInCandidate.name,
@@ -152,7 +152,7 @@ function* generateRows({
             contestResults.tallies[contestWriteInCandidate.id]?.tally ?? 0;
 
           if (votes) {
-            yield buildCsvRow({
+            yield buildRow({
               metadataValues,
               contest,
               selection: contestWriteInCandidate.name,
@@ -163,14 +163,14 @@ function* generateRows({
         }
       } else if (contest.type === 'yesno') {
         assert(contestResults.contestType === 'yesno');
-        yield buildCsvRow({
+        yield buildRow({
           metadataValues,
           contest,
           selection: contest.yesOption.label,
           selectionId: contest.yesOption.id,
           votes: contestResults.yesTally,
         });
-        yield buildCsvRow({
+        yield buildRow({
           metadataValues,
           contest,
           selection: contest.noOption.label,
@@ -179,7 +179,7 @@ function* generateRows({
         });
       }
 
-      yield buildCsvRow({
+      yield buildRow({
         metadataValues,
         contest,
         selection: 'Overvotes',
@@ -187,7 +187,7 @@ function* generateRows({
         votes: contestResults.overvotes,
       });
 
-      yield buildCsvRow({
+      yield buildRow({
         metadataValues,
         contest,
         selection: 'Undervotes',
@@ -206,7 +206,7 @@ function* generateRows({
  *
  * Returns the file as a `NodeJS.ReadableStream` emitting line by line.
  */
-export async function generateResultsCsv({
+export async function generateTallyReportCsv({
   store,
   filter = {},
   groupBy = {},
@@ -243,10 +243,10 @@ export async function generateResultsCsv({
     })
   );
 
-  function* generateResultsCsvRows() {
+  function* generateAllRows() {
     yield headerRow;
 
-    for (const dataRow of generateRows({
+    for (const dataRow of generateDataRows({
       electionDefinition,
       electionId: assertDefined(electionId),
       overallExportFilter: filter,
@@ -258,5 +258,5 @@ export async function generateResultsCsv({
     }
   }
 
-  return Readable.from(generateResultsCsvRows());
+  return Readable.from(generateAllRows());
 }

--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -59,6 +59,11 @@ export interface ScannerBatch extends Tabulation.ScannerBatch {
 }
 
 /**
+ * Lookup dictionary for batches, necessary to make many operations efficient.
+ */
+export type ScannerBatchLookup = Record<string, ScannerBatch>;
+
+/**
  * An election definition and associated DB metadata.
  */
 export interface ElectionRecord {

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -667,10 +667,10 @@ export const exportBatchResults = {
   },
 } as const;
 
-export const exportResultsCsv = {
+export const exportTallyReportCsv = {
   useMutation() {
     const apiClient = useApiClient();
-    return useMutation(apiClient.exportResultsCsv);
+    return useMutation(apiClient.exportTallyReportCsv);
   },
 } as const;
 

--- a/apps/admin/frontend/src/components/reporting/export_csv_button.test.tsx
+++ b/apps/admin/frontend/src/components/reporting/export_csv_button.test.tsx
@@ -43,7 +43,7 @@ test('calls mutation in happy path', async () => {
     /absentee-ballots-tally-report-by-precinct__2021-01-01_00-00-00\.csv/
   );
 
-  apiMock.expectExportResultsCsv({
+  apiMock.expectExportTallyReportCsv({
     filter,
     groupBy,
     path: 'test-mount-point/choctaw-county_mock-general-election-choctaw-2020_d6806afc49/reports/absentee-ballots-tally-report-by-precinct__2021-01-01_00-00-00.csv',

--- a/apps/admin/frontend/src/components/reporting/export_csv_button.tsx
+++ b/apps/admin/frontend/src/components/reporting/export_csv_button.tsx
@@ -5,7 +5,7 @@ import { Tabulation } from '@votingworks/types';
 import path from 'path';
 import { generateElectionBasedSubfolderName } from '@votingworks/utils';
 import { AppContext } from '../../contexts/app_context';
-import { exportResultsCsv, getCastVoteRecordFileMode } from '../../api';
+import { exportTallyReportCsv, getCastVoteRecordFileMode } from '../../api';
 import { SaveBackendFileModal } from '../save_backend_file_modal';
 import {
   REPORT_SUBFOLDER,
@@ -38,7 +38,7 @@ export function ExportCsvResultsButton({
     setExportDate(undefined);
   }
 
-  const exportResultsCsvMutation = exportResultsCsv.useMutation();
+  const exportResultsCsvMutation = exportTallyReportCsv.useMutation();
   const castVoteRecordFileModeQuery = getCastVoteRecordFileMode.useQuery();
   const isTestMode = castVoteRecordFileModeQuery.data === 'test';
 

--- a/apps/admin/frontend/test/helpers/mock_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_api_client.ts
@@ -350,7 +350,7 @@ export function createApiMock(
       apiClient.getSemsExportableTallies.expectCallWith().resolves(result);
     },
 
-    expectExportResultsCsv({
+    expectExportTallyReportCsv({
       path,
       filter,
       groupBy,
@@ -359,7 +359,7 @@ export function createApiMock(
       filter?: Tabulation.Filter;
       groupBy?: Tabulation.GroupBy;
     }) {
-      apiClient.exportResultsCsv
+      apiClient.exportTallyReportCsv
         .expectCallWith({ path, groupBy, filter })
         .resolves(ok([]));
     },

--- a/libs/types/src/tabulation.ts
+++ b/libs/types/src/tabulation.ts
@@ -207,3 +207,5 @@ export interface ScannerBatch {
 }
 
 export const BATCH_ID_DISPLAY_LENGTH = 8;
+
+export type BallotCountBreakdown = 'none' | 'manual' | 'all';

--- a/libs/ui/src/reports/ballot_count_report.test.tsx
+++ b/libs/ui/src/reports/ballot_count_report.test.tsx
@@ -3,11 +3,7 @@ import { Tabulation } from '@votingworks/types';
 import { within } from '@testing-library/react';
 import { Optional } from '@votingworks/basics';
 import { render, screen } from '../../test/react_testing_library';
-import {
-  BallotCountBreakdown,
-  BallotCountReport,
-  Column,
-} from './ballot_count_report';
+import { BallotCountReport, Column } from './ballot_count_report';
 
 const mockScannerBatches: Tabulation.ScannerBatch[] = [
   {
@@ -232,7 +228,7 @@ test('ballot count breakdowns', () => {
   ];
 
   const testCases: Array<{
-    breakdown: BallotCountBreakdown;
+    breakdown: Tabulation.BallotCountBreakdown;
     expectedColumns: Column[];
     expectedRows: RowData[];
     expectedFooter: RowData;

--- a/libs/ui/src/reports/ballot_count_report.tsx
+++ b/libs/ui/src/reports/ballot_count_report.tsx
@@ -209,8 +209,6 @@ function getCellClass(column: Column): Optional<string> {
   }
 }
 
-export type BallotCountBreakdown = 'none' | 'manual' | 'all';
-
 function BallotCountTable({
   electionDefinition,
   scannerBatches,
@@ -222,7 +220,7 @@ function BallotCountTable({
   scannerBatches: Tabulation.ScannerBatch[];
   cardCountsList: Tabulation.GroupList<Tabulation.CardCounts>;
   groupBy: Tabulation.GroupBy;
-  ballotCountBreakdown: BallotCountBreakdown;
+  ballotCountBreakdown: Tabulation.BallotCountBreakdown;
 }): JSX.Element {
   const { election } = electionDefinition;
   const batchLookup: Record<string, Tabulation.ScannerBatch> = {};
@@ -418,7 +416,7 @@ export interface BallotCountReportProps {
   groupBy: Tabulation.GroupBy;
   customFilter?: Tabulation.Filter;
   generatedAtTime?: Date;
-  ballotCountBreakdown: BallotCountBreakdown;
+  ballotCountBreakdown: Tabulation.BallotCountBreakdown;
 }
 
 export function BallotCountReport({


### PR DESCRIPTION
_review by commit_

## Overview

Closes #3990. Does not expose the new feature on the frontend, but adds the backend capability to generate a ballot count report CSV and save it to the USB drive.

## Testing Plan

100% automated coverage

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
