### PR TITLE
[i18n/Audio] Clear UI Strings store on unconfigure

### DIFF
--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -111,8 +111,7 @@ export function buildApi(
     },
 
     unconfigureMachine() {
-      workspace.store.setElectionAndJurisdiction(undefined);
-      workspace.store.deleteSystemSettings();
+      workspace.store.reset();
     },
 
     configureWithSampleBallotPackageForIntegrationTest(): Result<

--- a/apps/mark-scan/backend/src/app.ui_strings.test.ts
+++ b/apps/mark-scan/backend/src/app.ui_strings.test.ts
@@ -6,6 +6,7 @@ import {
   createMockUsb,
   runUiStringApiTests,
   runUiStringMachineConfigurationTests,
+  runUiStringMachineDeconfigurationTests,
 } from '@votingworks/backend';
 import { fakeLogger } from '@votingworks/logging';
 import { buildMockInsertedSmartCardAuth } from '@votingworks/auth';
@@ -84,6 +85,22 @@ describe('configureBallotPackageFromUsb', () => {
     electionPackage,
     getMockUsbDrive: () => mockUsbDrive,
     runConfigureMachine: () => api.configureBallotPackageFromUsb(),
+    store: store.getUiStringsStore(),
+  });
+});
+
+describe('unconfigureMachine', () => {
+  const api = buildApi(
+    mockAuth,
+    createMockUsb().mock,
+    fakeLogger(),
+    workspace,
+    undefined,
+    os.tmpdir()
+  );
+
+  runUiStringMachineDeconfigurationTests({
+    runUnconfigureMachine: () => api.unconfigureMachine(),
     store: store.getUiStringsStore(),
   });
 });

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -98,8 +98,7 @@ export function buildApi(
     },
 
     unconfigureMachine() {
-      workspace.store.setElectionAndJurisdiction(undefined);
-      workspace.store.deleteSystemSettings();
+      workspace.store.reset();
     },
 
     configureWithSampleBallotPackageForIntegrationTest(): Result<

--- a/apps/mark/backend/src/app.ui_strings.test.ts
+++ b/apps/mark/backend/src/app.ui_strings.test.ts
@@ -5,6 +5,7 @@ import {
   createMockUsb,
   runUiStringApiTests,
   runUiStringMachineConfigurationTests,
+  runUiStringMachineDeconfigurationTests,
 } from '@votingworks/backend';
 import { fakeLogger } from '@votingworks/logging';
 import { buildMockInsertedSmartCardAuth } from '@votingworks/auth';
@@ -76,6 +77,15 @@ describe('configureBallotPackageFromUsb', () => {
     electionPackage,
     getMockUsbDrive: () => mockUsbDrive,
     runConfigureMachine: () => api.configureBallotPackageFromUsb(),
+    store: store.getUiStringsStore(),
+  });
+});
+
+describe('unconfigureMachine', () => {
+  const api = buildApi(mockAuth, createMockUsb().mock, fakeLogger(), workspace);
+
+  runUiStringMachineDeconfigurationTests({
+    runUnconfigureMachine: () => api.unconfigureMachine(),
     store: store.getUiStringsStore(),
   });
 });

--- a/apps/scan/backend/src/app_ui_strings.test.ts
+++ b/apps/scan/backend/src/app_ui_strings.test.ts
@@ -3,6 +3,7 @@ import tmp from 'tmp';
 import {
   runUiStringApiTests,
   runUiStringMachineConfigurationTests,
+  runUiStringMachineDeconfigurationTests,
 } from '@votingworks/backend';
 import { buildMockInsertedSmartCardAuth } from '@votingworks/auth';
 import { fakeLogger } from '@votingworks/logging';
@@ -96,6 +97,27 @@ describe('configureFromBallotPackageOnUsbDrive', () => {
     electionPackage,
     getMockUsbDrive: () => mockUsbDrive,
     runConfigureMachine: () => api.configureFromBallotPackageOnUsbDrive(),
+    store: store.getUiStringsStore(),
+  });
+});
+
+describe('unconfigureElection', () => {
+  const api = buildApi(
+    mockAuth,
+    {
+      accept: jest.fn(),
+      return: jest.fn(),
+      scan: jest.fn(),
+      status: jest.fn(),
+      supportsUltrasonic: jest.fn(),
+    },
+    workspace,
+    mockUsbDrive.usbDrive,
+    fakeLogger()
+  );
+
+  runUiStringMachineDeconfigurationTests({
+    runUnconfigureMachine: () => api.unconfigureElection({}),
     store: store.getUiStringsStore(),
   });
 });

--- a/libs/backend/src/ui_strings/index.ts
+++ b/libs/backend/src/ui_strings/index.ts
@@ -4,3 +4,4 @@ export * from './ui_strings_api_test_runner';
 export * from './ui_strings_store';
 export * from './ui_strings_machine_configuration';
 export * from './ui_strings_machine_configuration_test_runner';
+export * from './ui_strings_machine_deconfiguration_test_runner';

--- a/libs/backend/src/ui_strings/ui_strings_machine_deconfiguration_test_runner.ts
+++ b/libs/backend/src/ui_strings/ui_strings_machine_deconfiguration_test_runner.ts
@@ -1,0 +1,33 @@
+/* istanbul ignore file - test util */
+
+import { LanguageCode } from '@votingworks/types';
+import { UiStringsStore } from './ui_strings_store';
+
+/** Test context for {@link runUiStringMachineDeconfigurationTests}. */
+export interface UiStringDeconfigurationTestContext {
+  runUnconfigureMachine(): void | Promise<void>;
+  store: UiStringsStore;
+}
+
+/** Tests that all UI String data is cleared when unconfiguring a machine. */
+export function runUiStringMachineDeconfigurationTests(
+  context: UiStringDeconfigurationTestContext
+): void {
+  const { runUnconfigureMachine, store } = context;
+  test('clears all UI String data from store', async () => {
+    store.setUiStrings({
+      languageCode: LanguageCode.ENGLISH,
+      data: { foo: 'bar', deeply: { nested: 'value' } },
+    });
+    store.setUiStrings({
+      languageCode: LanguageCode.SPANISH,
+      data: { foo: 'bar_es', deeply: { nested: 'value_es' } },
+    });
+
+    await runUnconfigureMachine();
+
+    expect(store.getLanguages()).toEqual([]);
+    expect(store.getUiStrings(LanguageCode.ENGLISH)).toBeNull();
+    expect(store.getUiStrings(LanguageCode.SPANISH)).toBeNull();
+  });
+}


### PR DESCRIPTION
## Overview

Updating the "unconfigure machine" API endpoints in `Mark` and `Mark-Scan` to `reset()` the store completely, matching what we're doing in `Scan`, instead of explicitly deleting data from each table.

We would need to revert back to explicitly clearing individual tables if we ever add a table that needs to persist across multiple configure/unconfigure events, but that seems unlikely (at least, in the short/medium term).

__TODO for later:__ noticed the "unconfigure" endpoints are unguarded WRT user type, so might be worth adding an  "is EM or SysAdmin" check, at least for consistency with the "configure" endpoints.

## Testing Plan
- Added a shared test runner for the `UiStringsStore` to verify all UI String data is cleared when unconfiguring machines.

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
