### PR TITLE
feat(admin): Add "No Results" Warning to Report Builders

### DIFF
--- a/apps/admin/frontend/src/components/reporting/ballot_count_report_viewer.test.tsx
+++ b/apps/admin/frontend/src/components/reporting/ballot_count_report_viewer.test.tsx
@@ -107,6 +107,40 @@ test('autoPreview = false does not load preview automatically', async () => {
   await screen.findButton('Load Preview');
 });
 
+test('shows no results warning when no results', async () => {
+  const { electionDefinition } = electionTwoPartyPrimaryFixtures;
+  apiMock.expectGetCardCounts(
+    {
+      filter: {},
+      groupBy: { groupByBatch: true },
+    },
+    []
+  );
+
+  renderInAppContext(
+    <BallotCountReportViewer
+      disabled={false}
+      filter={{}}
+      groupBy={{ groupByBatch: true }}
+      ballotCountBreakdown="none"
+      autoPreview
+    />,
+    { apiMock, electionDefinition }
+  );
+
+  await screen.findByText(
+    'No results found given the current report parameters.'
+  );
+
+  for (const buttonLabel of [
+    'Print Report',
+    'Export Report PDF',
+    'Export Report CSV',
+  ]) {
+    expect(screen.getButton(buttonLabel)).toBeDisabled();
+  }
+});
+
 test('print before loading preview', async () => {
   const { electionDefinition } = electionFamousNames2021Fixtures;
   const { resolve: resolveData } = apiMock.expectGetCardCounts(

--- a/apps/admin/frontend/src/components/reporting/ballot_count_report_viewer.tsx
+++ b/apps/admin/frontend/src/components/reporting/ballot_count_report_viewer.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   Caption,
   Font,
+  H5,
   H6,
   Icons,
   Loading,
@@ -89,6 +90,10 @@ const LoadingTextContainer = styled.div`
   background: white;
   width: 35rem;
   border-radius: 0.5rem;
+`;
+
+const NoResultsNotice = styled(H5)`
+  margin-top: 2rem;
 `;
 
 function Report({
@@ -192,6 +197,11 @@ export function BallotCountReportViewer({
       return previewReportRef.current;
     }
 
+    // If there's no data, don't render anything
+    if (cardCountsQuery.data.length === 0) {
+      return undefined;
+    }
+
     return (
       <Report
         electionDefinition={assertDefined(electionDefinition)}
@@ -218,6 +228,8 @@ export function BallotCountReportViewer({
   ]);
   previewReportRef.current = previewReport;
   const previewIsFresh = cardCountsQuery.isSuccess && !cardCountsQuery.isStale;
+  const areQueryResultsEmpty =
+    cardCountsQuery.isSuccess && cardCountsQuery.data.length === 0;
 
   async function refreshPreview() {
     setIsFetchingForPreview(true);
@@ -309,7 +321,7 @@ export function BallotCountReportViewer({
         <PrintButton
           print={printReport}
           variant="primary"
-          disabled={disabled}
+          disabled={disabled || areQueryResultsEmpty}
           useDefaultProgressModal={false}
         >
           Print Report
@@ -318,14 +330,14 @@ export function BallotCountReportViewer({
           electionDefinition={electionDefinition}
           generateReportPdf={generateReportPdf}
           defaultFilename={reportPdfFilename}
-          disabled={disabled}
+          disabled={disabled || areQueryResultsEmpty}
           fileType={FileType.BallotCountReport}
         />
         <ExportBallotCountReportCsvButton
           filter={filter}
           groupBy={groupBy}
           ballotCountBreakdown={ballotCountBreakdown}
-          disabled={disabled}
+          disabled={disabled || areQueryResultsEmpty}
         />
       </ExportActions>
 
@@ -338,6 +350,11 @@ export function BallotCountReportViewer({
           <React.Fragment>
             {previewReport && (
               <PreviewReportPages>{previewReport}</PreviewReportPages>
+            )}
+            {areQueryResultsEmpty && (
+              <NoResultsNotice>
+                No results found given the current report parameters.
+              </NoResultsNotice>
             )}
             {!previewIsFresh && <PreviewOverlay />}
             {isFetchingForPreview && (

--- a/apps/admin/frontend/src/components/reporting/tally_report_viewer.test.tsx
+++ b/apps/admin/frontend/src/components/reporting/tally_report_viewer.test.tsx
@@ -1,4 +1,7 @@
-import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import {
+  electionFamousNames2021Fixtures,
+  electionTwoPartyPrimaryFixtures,
+} from '@votingworks/fixtures';
 import userEvent from '@testing-library/user-event';
 import {
   deferNextPrint,
@@ -85,6 +88,39 @@ test('autoPreview = false does not load preview automatically', async () => {
   );
 
   await screen.findButton('Load Preview');
+});
+
+test('shows no results warning when no results', async () => {
+  const { electionDefinition } = electionTwoPartyPrimaryFixtures;
+  apiMock.expectGetResultsForTallyReports(
+    {
+      filter: {},
+      groupBy: { groupByBatch: true },
+    },
+    []
+  );
+
+  renderInAppContext(
+    <TallyReportViewer
+      disabled={false}
+      filter={{}}
+      groupBy={{ groupByBatch: true }}
+      autoPreview
+    />,
+    { apiMock, electionDefinition }
+  );
+
+  await screen.findByText(
+    'No results found given the current report parameters.'
+  );
+
+  for (const buttonLabel of [
+    'Print Report',
+    'Export Report PDF',
+    'Export Report CSV',
+  ]) {
+    expect(screen.getButton(buttonLabel)).toBeDisabled();
+  }
 });
 
 test('print before loading preview', async () => {

--- a/apps/admin/frontend/src/components/reporting/tally_report_viewer.tsx
+++ b/apps/admin/frontend/src/components/reporting/tally_report_viewer.tsx
@@ -3,6 +3,7 @@ import {
   Button,
   Caption,
   Font,
+  H5,
   H6,
   Icons,
   Loading,
@@ -95,6 +96,10 @@ const LoadingTextContainer = styled.div`
   background: white;
   width: 35rem;
   border-radius: 0.5rem;
+`;
+
+const NoResultsNotice = styled(H5)`
+  margin-top: 2rem;
 `;
 
 function Reports({
@@ -199,6 +204,11 @@ export function TallyReportViewer({
       return previewReportRef.current;
     }
 
+    // If there's no data, don't render anything
+    if (reportResultsQuery.data.length === 0) {
+      return undefined;
+    }
+
     return (
       <Reports
         electionDefinition={assertDefined(electionDefinition)}
@@ -222,6 +232,8 @@ export function TallyReportViewer({
   previewReportRef.current = previewReport;
   const previewIsFresh =
     reportResultsQuery.isSuccess && !reportResultsQuery.isStale;
+  const areQueryResultsEmpty =
+    reportResultsQuery.isSuccess && reportResultsQuery.data.length === 0;
 
   async function refreshPreview() {
     setIsFetchingForPreview(true);
@@ -309,7 +321,7 @@ export function TallyReportViewer({
         <PrintButton
           print={printReport}
           variant="primary"
-          disabled={disabled}
+          disabled={disabled || areQueryResultsEmpty}
           useDefaultProgressModal={false}
         >
           Print Report
@@ -318,13 +330,13 @@ export function TallyReportViewer({
           electionDefinition={electionDefinition}
           generateReportPdf={generateReportPdf}
           defaultFilename={reportPdfFilename}
-          disabled={disabled}
+          disabled={disabled || areQueryResultsEmpty}
           fileType={FileType.TallyReport}
         />
         <ExportTallyReportCsvButton
           filter={filter}
           groupBy={groupBy}
-          disabled={disabled}
+          disabled={disabled || areQueryResultsEmpty}
         />
       </ExportActions>
 
@@ -337,6 +349,11 @@ export function TallyReportViewer({
           <React.Fragment>
             {previewReport && (
               <PreviewReportPages>{previewReport}</PreviewReportPages>
+            )}
+            {areQueryResultsEmpty && (
+              <NoResultsNotice>
+                No results found given the current report parameters.
+              </NoResultsNotice>
             )}
             {!previewIsFresh && <PreviewOverlay />}
             {isFetchingForPreview && (


### PR DESCRIPTION
## Overview

Currently, if you create a combination of filters and group by clauses in a report builder such that there are no results at all, the report viewing area will just be blank. Although this should be rare, I wanted to add in some sort of warning text in this situation so a user does not think the app is broken. Examples where this might show up:

1) User tries to "group by batch" but no CVRs are loaded. There are no batches, so nothing to group by.
2) User creates an impossible filter (e.g. filtering for ballots associated with the democratic party but with republican ballot styles) and applies a grouping

This does not apply in some cases. For example, imagine a case (3) in which you set up an impossible filter as in example (2) but _do not_ have a grouping - you'll just get a zero or blank report. 

There may be other ways to resolve these. For example, we could analyze the filter for an impossible filter (probably hitting the backend would be easiest) and give a more specific warning to the filter. This would better catch cases (2) and (3). And for (1), maybe we disable those groupings until CVRs are added.

I wanted to do the least lift solution here because these cases are all rare, and I just don't want the screen to be confusingly empty in these rare cases.

The change prevents printing and exporting reports once an empty report is previewed, but if you print or export the report before the previewing, it will still print an empty page, export an empty PDF, or export an empty CSV. It's a lot more complicated to do otherwise, so I left this corner case alone.

## Demo Video or Screenshot

<img width="1344" alt="Screen Shot 2023-10-04 at 4 56 17 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/98969e24-0d75-4cfe-9920-266ed35f6f7a">

## Testing Plan
added automated tests, checked manually

## Checklist

- [ ] ~~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
