### PR TITLE
[libs/ui] Maintain only one instance of Vx fonts across re-mounts

### DIFF
--- a/libs/ui/.storybook/preview.tsx
+++ b/libs/ui/.storybook/preview.tsx
@@ -137,16 +137,18 @@ export const decorators: DecoratorFunction[] = [
     context
   ) => {
     return (
-      <AppBase
-        defaultColorMode={context.globals.colorMode}
-        defaultSizeMode={context.globals.sizeMode}
-        enableScroll
-        screenType={context.globals.screenType}
-      >
-        <StoryWrapper context={context}>
-          <Story />
-        </StoryWrapper>
-      </AppBase>
+      <React.StrictMode>
+        <AppBase
+          defaultColorMode={context.globals.colorMode}
+          defaultSizeMode={context.globals.sizeMode}
+          enableScroll
+          screenType={context.globals.screenType}
+        >
+          <StoryWrapper context={context}>
+            <Story />
+          </StoryWrapper>
+        </AppBase>
+      </React.StrictMode>
     );
   },
 ];

--- a/libs/ui/src/app_base.tsx
+++ b/libs/ui/src/app_base.tsx
@@ -5,7 +5,7 @@ import { ColorMode, ScreenType, SizeMode, UiTheme } from '@votingworks/types';
 import { GlobalStyles } from './global_styles';
 import { ThemeManagerContext } from './theme_manager_context';
 import { VxThemeProvider } from './themes/vx_theme_provider';
-import { loadFonts } from './fonts/load_fonts';
+import { loadFonts, unloadFonts } from './fonts/load_fonts';
 
 declare module 'styled-components' {
   /**
@@ -61,6 +61,13 @@ export function AppBase(props: AppBaseProps): JSX.Element {
     }
 
     setFontsLoaded(true);
+
+    // In practice, AppBase is rendered once at the root of each app and never
+    // unloaded throughout the lifetime of the app, but in development, React
+    // runs an extra render/cleanup cycle, causing `loadFonts` to run twice.
+    // This cleanup ensures that we only install one instance of the fonts.
+    // https://react.dev/reference/react/useEffect#caveats
+    return () => unloadFonts();
   }, [disableFontsForTests]);
 
   const resetThemes = useCallback(() => {

--- a/libs/ui/src/fonts/load_fonts.tsx
+++ b/libs/ui/src/fonts/load_fonts.tsx
@@ -5,13 +5,24 @@ import {
   ROBOTO_ITALIC_FONT_DECLARATIONS,
 } from './roboto';
 
+const VX_FONTS_NODE_ID = 'vx-font-declarations';
+
 export function loadFonts(): void {
   const fontDeclarations = document.createElement('style');
   fontDeclarations.setAttribute('type', 'text/css');
+  fontDeclarations.setAttribute('id', VX_FONTS_NODE_ID);
   fontDeclarations.innerHTML = [
     ROBOTO_REGULAR_FONT_DECLARATIONS,
     ROBOTO_ITALIC_FONT_DECLARATIONS,
   ].join('\n');
 
   document.head.appendChild(fontDeclarations);
+}
+
+export function unloadFonts(): void {
+  const fontDeclarations = document.getElementById(VX_FONTS_NODE_ID);
+
+  if (fontDeclarations && fontDeclarations.parentElement === document.head) {
+    document.head.removeChild(fontDeclarations);
+  }
 }


### PR DESCRIPTION
## Overview

Came up in https://github.com/votingworks/vxsuite/pull/4022 that we could end up with multiple instances of our font declarations in dev (due to [react dev quirks in strict mode](https://github.com/votingworks/vxsuite/pull/4022) and/or HMR).

- Adding an `unloadFonts()` cleanup step to make sure we only have one copy of the fonts installed.
- Also wrapping Storybook preview in `<React.StrictMode>` to mirror what we do in our apps.

## Testing Plan
- Manual

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~