### PR TITLE
[i18n/audio] Pipe data through to getUiStrings react-query client

### DIFF
--- a/libs/backend/src/ui_strings/ui_strings_api.ts
+++ b/libs/backend/src/ui_strings/ui_strings_api.ts
@@ -1,14 +1,7 @@
 /* istanbul ignore file - tested via VxSuite apps. */
 
-import { Optional } from '@votingworks/basics';
 import { Logger } from '@votingworks/logging';
-import {
-  Dictionary,
-  LanguageCode,
-  UiStringAudioIds,
-  UiStringTranslations,
-  UiStringsApi,
-} from '@votingworks/types';
+import { UiStringsApi } from '@votingworks/types';
 
 import { UiStringsStore } from './ui_strings_store';
 
@@ -23,30 +16,21 @@ export function createUiStringsApi(context: UiStringsApiContext): UiStringsApi {
   const { store } = context;
 
   return {
-    getAvailableLanguages(): LanguageCode[] {
+    getAvailableLanguages() {
       return store.getLanguages();
     },
 
-    getUiStrings(input: {
-      languageCode: LanguageCode;
-    }): Optional<UiStringTranslations> {
+    getUiStrings(input) {
+      return store.getUiStrings(input.languageCode);
+    },
+
+    getUiStringAudioIds(input) {
       throw new Error(
         `Not yet implemented. Requested language code: ${input.languageCode}`
       );
     },
 
-    getUiStringAudioIds(input: {
-      languageCode: LanguageCode;
-    }): Optional<UiStringAudioIds> {
-      throw new Error(
-        `Not yet implemented. Requested language code: ${input.languageCode}`
-      );
-    },
-
-    getAudioClipsBase64(input: {
-      languageCode: LanguageCode;
-      audioIds: string[];
-    }): Dictionary<string> {
+    getAudioClipsBase64(input) {
       throw new Error(
         `Not yet implemented. Requested language code: ${input.languageCode} | audioIds: ${input.audioIds}`
       );

--- a/libs/backend/src/ui_strings/ui_strings_api_test_runner.ts
+++ b/libs/backend/src/ui_strings/ui_strings_api_test_runner.ts
@@ -27,10 +27,27 @@ export function runUiStringApiTests(params: {
     );
   });
 
-  test('getUiStrings throws not-yet-implemented error', () => {
-    expect(() =>
-      api.getUiStrings({ languageCode: LanguageCode.SPANISH })
-    ).toThrow(/not yet implemented/i);
+  test('getUiStrings', () => {
+    expect(api.getUiStrings({ languageCode: LanguageCode.ENGLISH })).toBeNull();
+    expect(api.getUiStrings({ languageCode: LanguageCode.CHINESE })).toBeNull();
+    expect(api.getUiStrings({ languageCode: LanguageCode.SPANISH })).toBeNull();
+
+    store.setUiStrings({
+      languageCode: LanguageCode.ENGLISH,
+      data: { foo: 'bar' },
+    });
+    store.setUiStrings({
+      languageCode: LanguageCode.CHINESE,
+      data: { foo: 'bar_zh' },
+    });
+
+    expect(api.getUiStrings({ languageCode: LanguageCode.ENGLISH })).toEqual({
+      foo: 'bar',
+    });
+    expect(api.getUiStrings({ languageCode: LanguageCode.CHINESE })).toEqual({
+      foo: 'bar_zh',
+    });
+    expect(api.getUiStrings({ languageCode: LanguageCode.SPANISH })).toBeNull();
   });
 
   test('getUiStringAudioIds throws not-yet-implemented error', () => {

--- a/libs/types/src/ui_strings_api.ts
+++ b/libs/types/src/ui_strings_api.ts
@@ -1,5 +1,3 @@
-import { Optional } from '@votingworks/basics';
-
 import { Dictionary } from './generic';
 import { LanguageCode } from './language_code';
 import { UiStringAudioIds } from './ui_string_audio_ids';
@@ -10,11 +8,11 @@ export interface UiStringsApi {
 
   getUiStrings(input: {
     languageCode: LanguageCode;
-  }): Optional<UiStringTranslations>;
+  }): UiStringTranslations | null;
 
   getUiStringAudioIds(input: {
     languageCode: LanguageCode;
-  }): Optional<UiStringAudioIds>;
+  }): UiStringAudioIds | null;
 
   /**
    * Returns a map of the given audio IDs to corresponding audio data in

--- a/libs/ui/src/hooks/ui_strings_api.ts
+++ b/libs/ui/src/hooks/ui_strings_api.ts
@@ -1,5 +1,5 @@
 import { QueryClient, QueryKey, useQuery } from '@tanstack/react-query';
-import { UiStringsApi } from '@votingworks/types';
+import { LanguageCode, UiStringsApi } from '@votingworks/types';
 import * as grout from '@votingworks/grout';
 
 // Unable to use `grout.Client<UseStringsApi>` directly due to some mismatched
@@ -25,12 +25,29 @@ function createReactQueryApi(getApiClient: () => UiStringsApiClient) {
       },
     },
 
+    getUiStrings: {
+      queryKeyPrefix: 'getUiStrings',
+
+      getQueryKey(languageCode: LanguageCode): QueryKey {
+        return [this.queryKeyPrefix, languageCode];
+      },
+
+      useQuery(languageCode: LanguageCode) {
+        const apiClient = getApiClient();
+
+        return useQuery(this.getQueryKey(languageCode), () =>
+          apiClient.getUiStrings({ languageCode })
+        );
+      },
+    },
+
     async onMachineConfigurationChange(
       queryClient: QueryClient
     ): Promise<void> {
       await queryClient.invalidateQueries(
         this.getAvailableLanguages.getQueryKey()
       );
+      await queryClient.invalidateQueries([this.getUiStrings.queryKeyPrefix]);
     },
 
     // TODO(kofi): Fill out.


### PR DESCRIPTION
## Overview

Wiring up a `getUiStrings` react-query client API to the backend store for future use with our string translation library.

Also updating the nullable return types in the API from `Optional<T>` to `T | null`, since react-query doesn't like `undefined` query data values.

## Testing Plan
- Updated backend and frontend API tests

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
