### PR TITLE
More flaky test fixes

### DIFF
--- a/apps/scan/backend/jest.config.js
+++ b/apps/scan/backend/jest.config.js
@@ -22,10 +22,10 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      statements: 96,
-      branches: 89,
+      statements: 95,
+      branches: 88,
       functions: 90,
-      lines: 96,
+      lines: 95,
     },
   },
 };

--- a/apps/scan/backend/src/scanners/custom/app_config.test.ts
+++ b/apps/scan/backend/src/scanners/custom/app_config.test.ts
@@ -415,7 +415,7 @@ test('ballot batching', async () => {
       expect(batchIds).toHaveLength(3);
     }
   );
-});
+}, 30_000);
 
 test('unconfiguring machine', async () => {
   await withApp(

--- a/apps/scan/backend/test/helpers/custom_helpers.ts
+++ b/apps/scan/backend/test/helpers/custom_helpers.ts
@@ -87,7 +87,7 @@ export async function withApp(
     delays: {
       DELAY_RECONNECT: 100,
       DELAY_ACCEPTED_READY_FOR_NEXT_BALLOT: 100,
-      DELAY_ACCEPTED_RESET_TO_NO_PAPER: 200,
+      DELAY_ACCEPTED_RESET_TO_NO_PAPER: 500,
       DELAY_PAPER_STATUS_POLLING_INTERVAL: 50,
       ...delays,
     },


### PR DESCRIPTION
## Overview

VxScan backend tests are still a little bit flaky, even after https://github.com/votingworks/vxsuite/pull/4009. One issue in particular has been around for a while:

<table>
<img width="560" alt="error" src="https://github.com/votingworks/vxsuite/assets/12616928/37c2968c-4a41-4b57-8f51-bc08ff02c1bf">
</table>

Looks like tests can rapidly hop from the `accepted` state to the `no_paper` state, such that checks for the `accepted` state fail, even though we do pass through that state. This PR increases the delay in the default test state machine to ensure that we don't "miss" the `accepted` state.

This PR also bumps a timeout for an expectedly long running test and drops the code coverage threshold. There seems to be an element of randomness involved in how much code VxScan backend tests cover - we sometimes fall below the current thresholds, even when all tests succeed.