### PR TITLE
Clean up CVR-related logging and no longer have backends prepare UI copy

### DIFF
--- a/apps/admin/frontend/src/components/import_cvrfiles_modal.tsx
+++ b/apps/admin/frontend/src/components/import_cvrfiles_modal.tsx
@@ -65,7 +65,7 @@ const Content = styled.div`
   overflow: hidden;
 `;
 
-function userReadableMessageFromError(
+function userReadableMessageFromImportError(
   error: ImportCastVoteRecordsError
 ): string {
   switch (error.type) {
@@ -182,7 +182,7 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element | null {
             const error = addCastVoteRecordFileResult.err();
             setCurrentState({
               state: 'error',
-              errorMessage: userReadableMessageFromError(error),
+              errorMessage: userReadableMessageFromImportError(error),
               filename,
             });
           } else if (addCastVoteRecordFileResult.ok().wasExistingFile) {

--- a/apps/admin/frontend/src/components/save_backend_file_modal.tsx
+++ b/apps/admin/frontend/src/components/save_backend_file_modal.tsx
@@ -206,13 +206,12 @@ export function SaveBackendFileModal({
         return 'Permission denied.';
       case 'file-system-error':
         return 'There may be an issue with the USB drive.';
-        break;
       case 'missing-usb-drive':
       case 'relative-file-path':
         return 'Application error.';
       // istanbul ignore next
       default:
-        throwIllegalValue(error);
+        throwIllegalValue(error.type);
     }
   })();
 

--- a/apps/central-scan/frontend/src/components/export_results_modal.test.tsx
+++ b/apps/central-scan/frontend/src/components/export_results_modal.test.tsx
@@ -110,11 +110,11 @@ test('render export modal with errors when appropriate', async () => {
 
   mockApiClient.exportCastVoteRecordsToUsbDrive
     .expectCallWith({ isMinimalExport: true })
-    .resolves(err({ type: 'file-system-error', message: 'Uh oh' }));
+    .resolves(err({ type: 'file-system-error' }));
   fireEvent.click(getByText('Save'));
-  await waitFor(() => getByText('Failed to Save CVRs'));
-  getByText(/Failed to save CVRs./);
-  getByText(/Uh oh/);
+  await waitFor(() =>
+    getByText('Failed to save CVRs. Unable to write to USB drive.')
+  );
 
   fireEvent.click(getByText('Close'));
   expect(closeFn).toHaveBeenCalled();

--- a/apps/central-scan/frontend/src/components/export_results_modal.tsx
+++ b/apps/central-scan/frontend/src/components/export_results_modal.tsx
@@ -1,7 +1,13 @@
 import React, { useContext, useState } from 'react';
 import styled from 'styled-components';
 
-import { Button, Modal, P, UsbControllerButton } from '@votingworks/ui';
+import {
+  Button,
+  Modal,
+  P,
+  UsbControllerButton,
+  userReadableMessageFromExportError,
+} from '@votingworks/ui';
 import { isElectionManagerAuth } from '@votingworks/utils';
 
 import { assert } from '@votingworks/basics';
@@ -47,7 +53,10 @@ export function ExportResultsModal({ onClose }: Props): JSX.Element {
       {
         onSuccess: (result) => {
           if (result.isErr()) {
-            setErrorMessage(`Failed to save CVRs. ${result.err().message}`);
+            const errorDetails = userReadableMessageFromExportError(
+              result.err()
+            );
+            setErrorMessage(`Failed to save CVRs. ${errorDetails}`);
             setCurrentState(ModalState.ERROR);
           } else {
             setCurrentState(ModalState.DONE);

--- a/apps/central-scan/frontend/src/screens/admin_actions_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/admin_actions_screen.test.tsx
@@ -130,7 +130,7 @@ test('backup error shows message', async () => {
 
   mockApiClient.exportCastVoteRecordsToUsbDrive
     .expectCallWith({ isMinimalExport: false })
-    .resolves(err({ type: 'permission-denied', message: 'Uh oh' }));
+    .resolves(err({ type: 'permission-denied' }));
   userEvent.click(await screen.findByText('Save Backup'));
 
   const modal = await screen.findByRole('alertdialog');
@@ -139,7 +139,7 @@ test('backup error shows message', async () => {
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
   );
   screen.getByText('Save Backup');
-  screen.getByText('Uh oh');
+  screen.getByText('Unable to write to USB drive.');
 });
 
 test('clicking "Update Date and Time" shows modal to set clock', async () => {

--- a/apps/central-scan/frontend/src/screens/admin_actions_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/admin_actions_screen.tsx
@@ -14,6 +14,7 @@ import {
   P,
   Screen,
   SetClockButton,
+  userReadableMessageFromExportError,
 } from '@votingworks/ui';
 import { isElectionManagerAuth } from '@votingworks/utils';
 import { useHistory } from 'react-router-dom';
@@ -100,7 +101,7 @@ export function AdminActionsScreen({
       {
         onSuccess(result) {
           if (result.isErr()) {
-            setBackupError(result.err().message);
+            setBackupError(userReadableMessageFromExportError(result.err()));
           }
           setIsBackingUp(false);
         },

--- a/apps/scan/frontend/src/components/export_results_modal.test.tsx
+++ b/apps/scan/frontend/src/components/export_results_modal.test.tsx
@@ -97,11 +97,11 @@ test('render export modal with errors when appropriate', async () => {
 
   apiMock.mockApiClient.exportCastVoteRecordsToUsbDrive
     .expectCallWith({ mode: 'full_export' })
-    .resolves(
-      err({ type: 'file-system-error', message: 'Something went wrong.' })
-    );
+    .resolves(err({ type: 'file-system-error' }));
   userEvent.click(getByText('Save'));
-  await waitFor(() => getByText('Failed to save CVRs. Something went wrong.'));
+  await waitFor(() =>
+    getByText('Failed to save CVRs. Unable to write to USB drive.')
+  );
 
   userEvent.click(getByText('Close'));
   expect(onClose).toHaveBeenCalled();

--- a/apps/scan/frontend/src/components/export_results_modal.tsx
+++ b/apps/scan/frontend/src/components/export_results_modal.tsx
@@ -8,6 +8,7 @@ import {
   Modal,
   UsbControllerButton,
   P,
+  userReadableMessageFromExportError,
 } from '@votingworks/ui';
 import { throwIllegalValue } from '@votingworks/basics';
 
@@ -52,7 +53,10 @@ export function ExportResultsModal({
       {
         onSuccess: (result) => {
           if (result.isErr()) {
-            setErrorMessage(`Failed to save CVRs. ${result.err().message}`);
+            const errorDetails = userReadableMessageFromExportError(
+              result.err()
+            );
+            setErrorMessage(`Failed to save CVRs. ${errorDetails}`);
             setCurrentState(ModalState.ERROR);
           } else {
             setCurrentState(ModalState.DONE);

--- a/libs/backend/src/cast_vote_records/build_cast_vote_record.ts
+++ b/libs/backend/src/cast_vote_records/build_cast_vote_record.ts
@@ -160,7 +160,6 @@ type CVRContestRequiredBallotPageOptions =
     }
   | {
       ballotMarkingMode: 'hand';
-      // TODO: make this required when we separate image files from the CVR
       imageFileUri?: string;
     };
 

--- a/libs/backend/src/cast_vote_records/canonicalize.test.ts
+++ b/libs/backend/src/cast_vote_records/canonicalize.test.ts
@@ -1,11 +1,11 @@
-import { BallotType, BlankPage, SheetOf } from '@votingworks/types';
-import { typedAs } from '@votingworks/basics';
 import {
-  describeSheetValidationError,
-  canonicalizeSheet,
+  BallotType,
+  BlankPage,
+  SheetOf,
   SheetValidationError,
-  SheetValidationErrorType,
-} from './canonicalize';
+} from '@votingworks/types';
+import { typedAs } from '@votingworks/basics';
+import { canonicalizeSheet } from './canonicalize';
 import {
   interpretedBmdPage,
   interpretedHmpbPage1,
@@ -72,12 +72,10 @@ test('BMD ballot with two BMD sides', () => {
   ).unsafeUnwrapErr();
   expect(error).toEqual(
     typedAs<SheetValidationError>({
-      type: SheetValidationErrorType.InvalidFrontBackPageTypes,
-      types: ['InterpretedBmdPage', 'InterpretedBmdPage'],
+      type: 'invalid-sheet',
+      subType: 'incompatible-interpretation-types',
+      interpretationTypes: ['InterpretedBmdPage', 'InterpretedBmdPage'],
     })
-  );
-  expect(describeSheetValidationError(error)).toEqual(
-    `expected the back of a BMD page to be blank, but got 'InterpretedBmdPage'`
   );
 });
 
@@ -88,12 +86,10 @@ test('HMPB ballot with non-consecutive pages', () => {
   ).unsafeUnwrapErr();
   expect(error).toEqual(
     typedAs<SheetValidationError>({
-      type: SheetValidationErrorType.NonConsecutivePages,
+      type: 'invalid-sheet',
+      subType: 'non-consecutive-page-numbers',
       pageNumbers: [1, 1],
     })
-  );
-  expect(describeSheetValidationError(error)).toEqual(
-    `expected a sheet to have consecutive page numbers, but got front=1 back=1`
   );
 });
 
@@ -110,12 +106,10 @@ test('HMPB ballot with mismatched ballot style', () => {
   ).unsafeUnwrapErr();
   expect(error).toEqual(
     typedAs<SheetValidationError>({
-      type: SheetValidationErrorType.MismatchedBallotStyle,
+      type: 'invalid-sheet',
+      subType: 'mismatched-ballot-style-ids',
       ballotStyleIds: ['2F', '1M'],
     })
-  );
-  expect(describeSheetValidationError(error)).toEqual(
-    `expected a sheet to have the same ballot style, but got front=2F back=1M`
   );
 });
 
@@ -136,12 +130,10 @@ test('HMPB ballot with mismatched precinct', () => {
 
   expect(error).toEqual(
     typedAs<SheetValidationError>({
-      type: SheetValidationErrorType.MismatchedPrecinct,
+      type: 'invalid-sheet',
+      subType: 'mismatched-precinct-ids',
       precinctIds: ['precinct-1', 'precinct-2'],
     })
-  );
-  expect(describeSheetValidationError(error)).toEqual(
-    `expected a sheet to have the same precinct, but got front=precinct-1 back=precinct-2`
   );
 });
 
@@ -162,12 +154,10 @@ test('HMPB ballot with mismatched election', () => {
 
   expect(error).toEqual(
     typedAs<SheetValidationError>({
-      type: SheetValidationErrorType.MismatchedElectionHash,
+      type: 'invalid-sheet',
+      subType: 'mismatched-election-hashes',
       electionHashes: ['abc', 'def'],
     })
-  );
-  expect(describeSheetValidationError(error)).toEqual(
-    `expected a sheet to have the same election hash, but got front=abc back=def`
   );
 });
 
@@ -188,12 +178,10 @@ test('HMPB ballot with mismatched ballot type', () => {
 
   expect(error).toEqual(
     typedAs<SheetValidationError>({
-      type: SheetValidationErrorType.MismatchedBallotType,
+      type: 'invalid-sheet',
+      subType: 'mismatched-ballot-types',
       ballotTypes: [BallotType.Precinct, BallotType.Absentee],
     })
-  );
-  expect(describeSheetValidationError(error)).toEqual(
-    `expected a sheet to have the same ballot type, but got front=precinct back=absentee`
   );
 });
 
@@ -204,12 +192,10 @@ test('sheet with HMPB and BMD pages', () => {
   ).unsafeUnwrapErr();
   expect(error).toEqual(
     typedAs<SheetValidationError>({
-      type: SheetValidationErrorType.InvalidFrontBackPageTypes,
-      types: ['InterpretedHmpbPage', 'InterpretedBmdPage'],
+      type: 'invalid-sheet',
+      subType: 'incompatible-interpretation-types',
+      interpretationTypes: ['InterpretedHmpbPage', 'InterpretedBmdPage'],
     })
-  );
-  expect(describeSheetValidationError(error)).toEqual(
-    `expected the a HMPB page to be another HMPB page, but got 'InterpretedBmdPage'`
   );
 });
 
@@ -220,11 +206,9 @@ test('sheet with BMD and HMPB pages', () => {
   ).unsafeUnwrapErr();
   expect(error).toEqual(
     typedAs<SheetValidationError>({
-      type: SheetValidationErrorType.InvalidFrontBackPageTypes,
-      types: ['InterpretedBmdPage', 'InterpretedHmpbPage'],
+      type: 'invalid-sheet',
+      subType: 'incompatible-interpretation-types',
+      interpretationTypes: ['InterpretedBmdPage', 'InterpretedHmpbPage'],
     })
-  );
-  expect(describeSheetValidationError(error)).toEqual(
-    `expected the back of a BMD page to be blank, but got 'InterpretedHmpbPage'`
   );
 });

--- a/libs/backend/src/exporter.ts
+++ b/libs/backend/src/exporter.ts
@@ -5,6 +5,7 @@ import { isAbsolute, join, normalize, parse } from 'path';
 import { Readable } from 'stream';
 import { createReadStream, lstatSync } from 'fs';
 import { Buffer } from 'buffer';
+import { ExportDataError as BaseExportDataError } from '@votingworks/types';
 import { splitToFiles } from './split';
 import { execFile } from './exec';
 import { UsbDrive } from './get_usb_drives';
@@ -19,11 +20,10 @@ const MAXIMUM_FAT32_FILE_SIZE = 2 ** 32 - 1;
 /**
  * Possible export errors.
  */
-export type ExportDataError =
-  | { type: 'relative-file-path'; message: string }
-  | { type: 'permission-denied'; message: string }
-  | { type: 'file-system-error'; message: string }
-  | { type: 'missing-usb-drive'; message: string };
+export interface ExportDataError {
+  type: BaseExportDataError;
+  message: string;
+}
 
 /**
  * Result of exporting data to the file system.

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -146,14 +146,26 @@ IDs are logged with each log to identify the log being written.
 **Type:** [user-action](#user-action)  
 **Description:** A smart card has been unprogrammed (or failed to be unprogrammed). The previous (or current in the case of failure) smart card user role is indicated by the previousProgrammedUserRole key (or programmedUserRole key in the case of failure).  
 **Machines:** vx-admin-service
-### cvr-loaded
+### list-cast-vote-record-exports-on-usb-drive
 **Type:** [user-action](#user-action)  
-**Description:** User loaded CVR to the machine. Success or failure indicated by disposition.  
-**Machines:** vx-admin-frontend
-### cvr-files-read-from-usb
+**Description:** Cast vote record exports on the inserted USB drive were listed.  
+**Machines:** vx-admin-service
+### import-cast-vote-records-init
 **Type:** [user-action](#user-action)  
-**Description:** User opened load CVR modal and usb is searched for possible CVR files to load.  
-**Machines:** vx-admin-frontend
+**Description:** Cast vote records are being imported from a USB drive.  
+**Machines:** vx-admin-service
+### import-cast-vote-records-complete
+**Type:** [user-action](#user-action)  
+**Description:** Cast vote records have been imported from a USB drive (or failed to be imported).  
+**Machines:** vx-admin-service
+### clear-imported-cast-vote-records-init
+**Type:** [user-action](#user-action)  
+**Description:** Imported cast vote records are being cleared.  
+**Machines:** vx-admin-service
+### clear-imported-cast-vote-records-complete
+**Type:** [user-action](#user-action)  
+**Description:** Imported cast vote records have been cleared (or failed to be cleared).  
+**Machines:** vx-admin-service
 ### recompute-tally-init
 **Type:** [user-action](#user-action)  
 **Description:** New cast vote record files seen, initiating recomputation of tally data.  
@@ -173,10 +185,6 @@ IDs are logged with each log to identify the log being written.
 ### marked-tally-results-official
 **Type:** [user-action](#user-action)  
 **Description:** User marked the tally results as official. This disables loading more CVR files or editing manual tally data.  
-**Machines:** vx-admin-service
-### cast-vote-record-file-removed
-**Type:** [user-action](#user-action)  
-**Description:** The user removed one or more CVR files.  
 **Machines:** vx-admin-service
 ### tally-report-previewed
 **Type:** [user-action](#user-action)  
@@ -261,14 +269,6 @@ IDs are logged with each log to identify the log being written.
 ### scanner-configure-complete
 **Type:** [user-action](#user-action)  
 **Description:** The final configuration steps for the scanner for the ballot package have completed. Success or failure indicated by disposition.  
-**Machines:** vx-central-scan-frontend, vx-scan-frontend
-### save-cvr-init
-**Type:** [user-action](#user-action)  
-**Description:** User has initiated saving CVR file to the USB drive.  
-**Machines:** vx-central-scan-frontend, vx-scan-frontend
-### save-cvr-complete
-**Type:** [user-action](#user-action)  
-**Description:** User has finished saving a CVR file of all results to the USB drive. Success or failure indicated by disposition. On success, number of ballots included in CVR specified by `numberOfBallots`.  
 **Machines:** vx-central-scan-frontend, vx-scan-frontend
 ### delete-cvr-batch-init
 **Type:** [user-action](#user-action)  
@@ -358,6 +358,14 @@ IDs are logged with each log to identify the log being written.
 **Type:** [user-action](#user-action)  
 **Description:** The ballot package has been read from the USB drive. Success or failure indicated by disposition.  
 **Machines:** vx-central-scan-frontend, vx-scan-frontend
+### export-cast-vote-records-init
+**Type:** [user-action](#user-action)  
+**Description:** Cast vote records are being exported to a USB drive.  
+**Machines:** vx-central-scan-service, vx-scan-backend
+### export-cast-vote-records-complete
+**Type:** [user-action](#user-action)  
+**Description:** Cast vote records have been exported to a USB drive (or failed to be exported).  
+**Machines:** vx-central-scan-service, vx-scan-backend
 ### polls-opened
 **Type:** [user-action](#user-action)  
 **Description:** User has opened the polls.  

--- a/libs/logging/src/log_documentation.test.ts
+++ b/libs/logging/src/log_documentation.test.ts
@@ -26,11 +26,11 @@ describe('test cdf documentation generation', () => {
     expect(structuredData.DeviceModel).toEqual('VxAdmin 1.0');
     expect(structuredData.GeneratedDate).toEqual('2020-07-24T00:00:00.000Z');
     expect(structuredData.EventTypeDescription).toHaveLength(5);
-    expect(structuredData.EventIdDescription).toHaveLength(50);
+    expect(structuredData.EventIdDescription).toHaveLength(48);
     // Make sure VxAdminFrontend specific logs are included.
     expect(structuredData.EventIdDescription).toContainEqual(
       expect.objectContaining({
-        Id: LogEventId.CvrLoaded,
+        Id: LogEventId.RecomputingTally,
       })
     );
     // Make sure a generic log to all apps is included
@@ -64,7 +64,7 @@ describe('test cdf documentation generation', () => {
     expect(structuredData.DeviceModel).toEqual('VxCentralScan');
     expect(structuredData.GeneratedDate).toEqual('2020-07-24T00:00:00.000Z');
     expect(structuredData.EventTypeDescription).toHaveLength(5);
-    expect(structuredData.EventIdDescription).toHaveLength(61);
+    expect(structuredData.EventIdDescription).toHaveLength(59);
     // Make sure VxCentralScanApp specific logs are included.
     expect(structuredData.EventIdDescription).toContainEqual(
       expect.objectContaining({
@@ -80,7 +80,7 @@ describe('test cdf documentation generation', () => {
     // Make sure VxAdminFrontend specific logs are NOT included
     expect(structuredData.EventIdDescription).not.toContainEqual(
       expect.objectContaining({
-        Id: LogEventId.CvrLoaded,
+        Id: LogEventId.RecomputingTally,
       })
     );
   });

--- a/libs/logging/src/log_event_ids.ts
+++ b/libs/logging/src/log_event_ids.ts
@@ -15,16 +15,19 @@ export enum LogEventId {
   // Election configuration logs
   ElectionConfigured = 'election-configured',
   ElectionUnconfigured = 'election-unconfigured',
+
   // System level logs
   MachineBootInit = 'machine-boot-init',
   MachineBootComplete = 'machine-boot-complete',
   MachineShutdownInit = 'machine-shutdown-init',
   MachineShutdownComplete = 'machine-shutdown-complete',
   UsbDeviceChangeDetected = 'usb-device-change-detected',
+
   // Auth logs
   AuthPinEntry = 'auth-pin-entry',
   AuthLogin = 'auth-login',
   AuthLogout = 'auth-logout',
+
   // USB related logs
   UsbDriveDetected = 'usb-drive-detected',
   UsbDriveRemoved = 'usb-drive-removed',
@@ -34,18 +37,22 @@ export enum LogEventId {
   UsbDriveMounted = 'usb-drive-mount-complete',
   UsbDriveFormatInit = 'usb-drive-format-init',
   UsbDriveFormatted = 'usb-drive-format-complete',
+
   // App Startup
   ApplicationStartup = 'application-startup',
+
   // External Device Related Logs
   PrinterConfigurationAdded = 'printer-config-added',
   PrinterConfigurationRemoved = 'printer-config-removed',
   PrinterConnectionUpdate = 'printer-connection-update',
   DeviceAttached = 'device-attached',
   DeviceUnattached = 'device-unattached',
+
   // Storage logs
   LoadFromStorage = 'load-from-storage',
   SaveToStorage = 'save-to-storage',
   FileSaved = 'file-saved',
+
   // VxAdmin specific user action logs
   SaveBallotPackageInit = 'save-ballot-package-init',
   SaveBallotPackageComplete = 'save-ballot-package-complete',
@@ -53,14 +60,16 @@ export enum LogEventId {
   SmartCardProgramComplete = 'smart-card-program-complete',
   SmartCardUnprogramInit = 'smart-card-unprogram-init',
   SmartCardUnprogramComplete = 'smart-card-unprogram-complete',
-  CvrLoaded = 'cvr-loaded',
-  CvrFilesReadFromUsb = 'cvr-files-read-from-usb',
+  ListCastVoteRecordExportsOnUsbDrive = 'list-cast-vote-record-exports-on-usb-drive',
+  ImportCastVoteRecordsInit = 'import-cast-vote-records-init',
+  ImportCastVoteRecordsComplete = 'import-cast-vote-records-complete',
+  ClearImportedCastVoteRecordsInit = 'clear-imported-cast-vote-records-init',
+  ClearImportedCastVoteRecordsComplete = 'clear-imported-cast-vote-records-complete',
   RecomputingTally = 'recompute-tally-init',
   RecomputedTally = 'recompute-tally-complete',
   ManualTallyDataEdited = 'manual-tally-data-edited',
   ManualTallyDataRemoved = 'manual-tally-data-removed',
   MarkedTallyResultsOfficial = 'marked-tally-results-official',
-  CaseVoteRecordFileRemoved = 'cast-vote-record-file-removed',
   TallyReportPreviewed = 'tally-report-previewed',
   TallyReportPrinted = 'tally-report-printed',
   ConvertingResultsToSemsFormat = 'converting-to-sems',
@@ -71,6 +80,7 @@ export enum LogEventId {
   SystemSettingsSaveInitiated = 'system-settings-save-initiated',
   SystemSettingsSaved = 'system-settings-saved',
   SystemSettingsRetrieved = 'system-settings-retrieved',
+
   // VxCentralScan specific user action logs
   TogglingTestMode = 'toggle-test-mode-init',
   ToggledTestMode = 'toggled-test-mode',
@@ -83,8 +93,6 @@ export enum LogEventId {
   BallotPackageFilesReadFromUsb = 'ballot-package-files-read-from-usb',
   BallotConfiguredOnMachine = 'ballot-configure-machine-complete',
   ScannerConfigured = 'scanner-configure-complete',
-  SaveCvrInit = 'save-cvr-init',
-  SaveCvrComplete = 'save-cvr-complete',
   DeleteScanBatchInit = 'delete-cvr-batch-init',
   DeleteScanBatchComplete = 'delete-cvr-batch-complete',
   ScanBatchInit = 'scan-batch-init',
@@ -107,6 +115,10 @@ export enum LogEventId {
   RebootMachine = 'reboot-machine',
   PowerDown = 'power-down-machine',
   BallotPackageLoadedFromUsb = 'ballot-package-load-from-usb-complete',
+
+  // Scanners, central and precinct
+  ExportCastVoteRecordsInit = 'export-cast-vote-records-init',
+  ExportCastVoteRecordsComplete = 'export-cast-vote-records-complete',
 
   // Precinct Machine (VxMark, VxScan, VxMarkScan) State
   PollsOpened = 'polls-opened',
@@ -350,6 +362,7 @@ const SmartCardProgramComplete: LogDetails = {
     'A smart card has been programmed (or failed to be programmed). The new smart card user role is indicated by the programmedUserRole key.',
   restrictInDocumentationToApps: [LogSource.VxAdminService],
 };
+
 const SmartCardUnprogramInit: LogDetails = {
   eventId: LogEventId.SmartCardUnprogramInit,
   eventType: LogEventType.UserAction,
@@ -365,20 +378,43 @@ const SmartCardUnprogramComplete: LogDetails = {
   restrictInDocumentationToApps: [LogSource.VxAdminService],
 };
 
-const CvrLoaded: LogDetails = {
-  eventId: LogEventId.CvrLoaded,
+const ListCastVoteRecordExportsOnUsbDrive: LogDetails = {
+  eventId: LogEventId.ListCastVoteRecordExportsOnUsbDrive,
   eventType: LogEventType.UserAction,
   documentationMessage:
-    'User loaded CVR to the machine. Success or failure indicated by disposition.',
-  restrictInDocumentationToApps: [LogSource.VxAdminFrontend],
+    'Cast vote record exports on the inserted USB drive were listed.',
+  restrictInDocumentationToApps: [LogSource.VxAdminService],
 };
-const CvrFilesReadFromUsb: LogDetails = {
-  eventId: LogEventId.CvrFilesReadFromUsb,
+
+const ImportCastVoteRecordsInit: LogDetails = {
+  eventId: LogEventId.ImportCastVoteRecordsInit,
   eventType: LogEventType.UserAction,
   documentationMessage:
-    'User opened load CVR modal and usb is searched for possible CVR files to load.',
-  restrictInDocumentationToApps: [LogSource.VxAdminFrontend],
+    'Cast vote records are being imported from a USB drive.',
+  restrictInDocumentationToApps: [LogSource.VxAdminService],
 };
+const ImportCastVoteRecordsComplete: LogDetails = {
+  eventId: LogEventId.ImportCastVoteRecordsComplete,
+  eventType: LogEventType.UserAction,
+  documentationMessage:
+    'Cast vote records have been imported from a USB drive (or failed to be imported).',
+  restrictInDocumentationToApps: [LogSource.VxAdminService],
+};
+
+const ClearImportedCastVoteRecordsInit: LogDetails = {
+  eventId: LogEventId.ClearImportedCastVoteRecordsInit,
+  eventType: LogEventType.UserAction,
+  documentationMessage: 'Imported cast vote records are being cleared.',
+  restrictInDocumentationToApps: [LogSource.VxAdminService],
+};
+const ClearImportedCastVoteRecordsComplete: LogDetails = {
+  eventId: LogEventId.ClearImportedCastVoteRecordsComplete,
+  eventType: LogEventType.UserAction,
+  documentationMessage:
+    'Imported cast vote records have been cleared (or failed to be cleared).',
+  restrictInDocumentationToApps: [LogSource.VxAdminService],
+};
+
 const RecomputingTally: LogDetails = {
   eventId: LogEventId.RecomputingTally,
   eventType: LogEventType.UserAction,
@@ -413,12 +449,6 @@ const MarkedTallyResultsOfficial: LogDetails = {
   eventType: LogEventType.UserAction,
   documentationMessage:
     'User marked the tally results as official. This disables loading more CVR files or editing manual tally data.',
-  restrictInDocumentationToApps: [LogSource.VxAdminService],
-};
-const CastVoteRecordFileRemoved: LogDetails = {
-  eventId: LogEventId.CaseVoteRecordFileRemoved,
-  eventType: LogEventType.UserAction,
-  documentationMessage: 'The user removed one or more CVR files.',
   restrictInDocumentationToApps: [LogSource.VxAdminService],
 };
 const TallyReportPrinted: LogDetails = {
@@ -585,26 +615,27 @@ const BallotPackageFilesReadFromUsb: LogDetails = {
     LogSource.VxScanFrontend,
   ],
 };
-const SaveCvrInit: LogDetails = {
-  eventId: LogEventId.SaveCvrInit,
+
+const ExportCastVoteRecordsInit: LogDetails = {
+  eventId: LogEventId.ExportCastVoteRecordsInit,
   eventType: LogEventType.UserAction,
-  documentationMessage: 'User has initiated saving CVR file to the USB drive.',
-  defaultMessage: 'Saving CVR file to USB...',
+  documentationMessage: 'Cast vote records are being exported to a USB drive.',
   restrictInDocumentationToApps: [
-    LogSource.VxCentralScanFrontend,
-    LogSource.VxScanFrontend,
+    LogSource.VxCentralScanService,
+    LogSource.VxScanBackend,
   ],
 };
-const SaveCvrComplete: LogDetails = {
-  eventId: LogEventId.SaveCvrComplete,
+const ExportCastVoteRecordsComplete: LogDetails = {
+  eventId: LogEventId.ExportCastVoteRecordsComplete,
   eventType: LogEventType.UserAction,
   documentationMessage:
-    'User has finished saving a CVR file of all results to the USB drive. Success or failure indicated by disposition. On success, number of ballots included in CVR specified by `numberOfBallots`.',
+    'Cast vote records have been exported to a USB drive (or failed to be exported).',
   restrictInDocumentationToApps: [
-    LogSource.VxCentralScanFrontend,
-    LogSource.VxScanFrontend,
+    LogSource.VxCentralScanService,
+    LogSource.VxScanBackend,
   ],
 };
+
 const DeleteScanBatchInit: LogDetails = {
   eventId: LogEventId.DeleteScanBatchInit,
   eventType: LogEventType.UserAction,
@@ -964,10 +995,16 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return SmartCardUnprogramInit;
     case LogEventId.SmartCardUnprogramComplete:
       return SmartCardUnprogramComplete;
-    case LogEventId.CvrFilesReadFromUsb:
-      return CvrFilesReadFromUsb;
-    case LogEventId.CvrLoaded:
-      return CvrLoaded;
+    case LogEventId.ListCastVoteRecordExportsOnUsbDrive:
+      return ListCastVoteRecordExportsOnUsbDrive;
+    case LogEventId.ImportCastVoteRecordsInit:
+      return ImportCastVoteRecordsInit;
+    case LogEventId.ImportCastVoteRecordsComplete:
+      return ImportCastVoteRecordsComplete;
+    case LogEventId.ClearImportedCastVoteRecordsInit:
+      return ClearImportedCastVoteRecordsInit;
+    case LogEventId.ClearImportedCastVoteRecordsComplete:
+      return ClearImportedCastVoteRecordsComplete;
     case LogEventId.RecomputingTally:
       return RecomputingTally;
     case LogEventId.RecomputedTally:
@@ -978,8 +1015,6 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return ManualTallyDataRemoved;
     case LogEventId.MarkedTallyResultsOfficial:
       return MarkedTallyResultsOfficial;
-    case LogEventId.CaseVoteRecordFileRemoved:
-      return CastVoteRecordFileRemoved;
     case LogEventId.TallyReportPrinted:
       return TallyReportPrinted;
     case LogEventId.TallyReportPreviewed:
@@ -1016,10 +1051,10 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return ScannerConfigured;
     case LogEventId.BallotPackageFilesReadFromUsb:
       return BallotPackageFilesReadFromUsb;
-    case LogEventId.SaveCvrInit:
-      return SaveCvrInit;
-    case LogEventId.SaveCvrComplete:
-      return SaveCvrComplete;
+    case LogEventId.ExportCastVoteRecordsInit:
+      return ExportCastVoteRecordsInit;
+    case LogEventId.ExportCastVoteRecordsComplete:
+      return ExportCastVoteRecordsComplete;
     case LogEventId.DeleteScanBatchInit:
       return DeleteScanBatchInit;
     case LogEventId.DeleteScanBatchComplete:

--- a/libs/types/src/cast_vote_records.ts
+++ b/libs/types/src/cast_vote_records.ts
@@ -4,8 +4,20 @@ import {
   CastVoteRecordReport,
   CastVoteRecordReportSchema,
 } from './cdf/cast-vote-records';
-import { BallotId, BallotStyleId, PrecinctId } from './election';
+import {
+  BallotId,
+  BallotStyle,
+  BallotStyleId,
+  BallotType,
+  ElectionDefinition,
+  HmpbBallotPageMetadata,
+  Precinct,
+  PrecinctId,
+} from './election';
+import { ExportDataError } from './errors';
 import { Dictionary } from './generic';
+import { SheetOf } from './hmpb';
+import { PageInterpretation } from './interpretation';
 
 /**
  * Legacy type, slightly different than the CDF ballot type.
@@ -50,3 +62,42 @@ export enum CastVoteRecordExportFileName {
   METADATA = 'metadata.json',
   REJECTED_SHEET_SUB_DIRECTORY_NAME_PREFIX = 'rejected-',
 }
+
+/**
+ * An error encountered while validating a sheet
+ */
+export type SheetValidationError = {
+  type: 'invalid-sheet';
+} & (
+  | {
+      subType: 'incompatible-interpretation-types';
+      interpretationTypes: SheetOf<PageInterpretation['type']>;
+    }
+  | {
+      subType: 'mismatched-ballot-style-ids';
+      ballotStyleIds: SheetOf<BallotStyle['id']>;
+    }
+  | {
+      subType: 'mismatched-ballot-types';
+      ballotTypes: SheetOf<BallotType>;
+    }
+  | {
+      subType: 'mismatched-election-hashes';
+      electionHashes: SheetOf<ElectionDefinition['electionHash']>;
+    }
+  | {
+      subType: 'mismatched-precinct-ids';
+      precinctIds: SheetOf<Precinct['id']>;
+    }
+  | {
+      subType: 'non-consecutive-page-numbers';
+      pageNumbers: SheetOf<HmpbBallotPageMetadata['pageNumber']>;
+    }
+);
+
+/**
+ * An error encountered while exporting cast vote records to a USB drive
+ */
+export type ExportCastVoteRecordsToUsbDriveError =
+  | { type: ExportDataError }
+  | SheetValidationError;

--- a/libs/types/src/errors.ts
+++ b/libs/types/src/errors.ts
@@ -6,3 +6,9 @@ export type BallotPackageConfigurationError =
   | 'auth_required_before_ballot_package_load'
   | 'ballot_package_authentication_error'
   | 'election_hash_mismatch';
+
+export type ExportDataError =
+  | 'file-system-error'
+  | 'missing-usb-drive'
+  | 'permission-denied'
+  | 'relative-file-path';

--- a/libs/ui/src/cast_vote_records.test.ts
+++ b/libs/ui/src/cast_vote_records.test.ts
@@ -1,0 +1,92 @@
+import {
+  BallotType,
+  ExportCastVoteRecordsToUsbDriveError,
+} from '@votingworks/types';
+
+import { userReadableMessageFromExportError } from './cast_vote_records';
+
+test.each<{
+  error: ExportCastVoteRecordsToUsbDriveError;
+  expectedMessage: string;
+}>([
+  {
+    error: {
+      type: 'file-system-error',
+    },
+    expectedMessage: 'Unable to write to USB drive.',
+  },
+  {
+    error: {
+      type: 'missing-usb-drive',
+    },
+    expectedMessage: 'No USB drive detected.',
+  },
+  {
+    error: {
+      type: 'permission-denied',
+    },
+    expectedMessage: 'Unable to write to USB drive.',
+  },
+  {
+    error: {
+      type: 'relative-file-path',
+    },
+    expectedMessage: 'Invalid file path.',
+  },
+  {
+    error: {
+      type: 'invalid-sheet',
+      subType: 'incompatible-interpretation-types',
+      interpretationTypes: ['InterpretedBmdPage', 'InterpretedHmpbPage'],
+    },
+    expectedMessage:
+      'Encountered an invalid sheet with incompatible interpretation types: front = InterpretedBmdPage, back = InterpretedHmpbPage.',
+  },
+  {
+    error: {
+      type: 'invalid-sheet',
+      subType: 'mismatched-ballot-style-ids',
+      ballotStyleIds: ['1', '2'],
+    },
+    expectedMessage:
+      'Encountered an invalid sheet with mismatched ballot styles: front = 1, back = 2.',
+  },
+  {
+    error: {
+      type: 'invalid-sheet',
+      subType: 'mismatched-ballot-types',
+      ballotTypes: [BallotType.Absentee, BallotType.Precinct],
+    },
+    expectedMessage:
+      'Encountered an invalid sheet with mismatched ballot types: front = absentee, back = precinct.',
+  },
+  {
+    error: {
+      type: 'invalid-sheet',
+      subType: 'mismatched-election-hashes',
+      electionHashes: ['1', '2'],
+    },
+    expectedMessage:
+      'Encountered an invalid sheet with mismatched election hashes: front = 1, back = 2.',
+  },
+  {
+    error: {
+      type: 'invalid-sheet',
+      subType: 'mismatched-precinct-ids',
+      precinctIds: ['1', '2'],
+    },
+    expectedMessage:
+      'Encountered an invalid sheet with mismatched precincts: front = 1, back = 2.',
+  },
+  {
+    error: {
+      type: 'invalid-sheet',
+      subType: 'non-consecutive-page-numbers',
+      pageNumbers: [1, 3],
+    },
+    expectedMessage:
+      'Encountered an invalid sheet with non-consecutive page numbers: front = 1, back = 3.',
+  },
+])('userReadableMessageFromExportError', ({ error, expectedMessage }) => {
+  expect(userReadableMessageFromExportError(error)).toEqual(expectedMessage);
+});

--- a/libs/ui/src/cast_vote_records.ts
+++ b/libs/ui/src/cast_vote_records.ts
@@ -1,0 +1,72 @@
+import { throwIllegalValue } from '@votingworks/basics';
+import {
+  ExportCastVoteRecordsToUsbDriveError,
+  SheetOf,
+} from '@votingworks/types';
+
+function sheetValuesToString<T extends string | number>(
+  sheetValues: SheetOf<T>
+): string {
+  return `front = ${sheetValues[0]}, back = ${sheetValues[1]}`;
+}
+
+export function userReadableMessageFromExportError(
+  error: ExportCastVoteRecordsToUsbDriveError
+): string {
+  switch (error.type) {
+    case 'file-system-error':
+    case 'permission-denied': {
+      return 'Unable to write to USB drive.';
+    }
+    case 'missing-usb-drive': {
+      return 'No USB drive detected.';
+    }
+    case 'relative-file-path': {
+      return 'Invalid file path.';
+    }
+    case 'invalid-sheet': {
+      return (() => {
+        switch (error.subType) {
+          case 'incompatible-interpretation-types': {
+            return `Encountered an invalid sheet with incompatible interpretation types: ${sheetValuesToString(
+              error.interpretationTypes
+            )}.`;
+          }
+          case 'mismatched-ballot-style-ids': {
+            return `Encountered an invalid sheet with mismatched ballot styles: ${sheetValuesToString(
+              error.ballotStyleIds
+            )}.`;
+          }
+          case 'mismatched-ballot-types': {
+            return `Encountered an invalid sheet with mismatched ballot types: ${sheetValuesToString(
+              error.ballotTypes
+            )}.`;
+          }
+          case 'mismatched-election-hashes': {
+            return `Encountered an invalid sheet with mismatched election hashes: ${sheetValuesToString(
+              error.electionHashes
+            )}.`;
+          }
+          case 'mismatched-precinct-ids': {
+            return `Encountered an invalid sheet with mismatched precincts: ${sheetValuesToString(
+              error.precinctIds
+            )}.`;
+          }
+          case 'non-consecutive-page-numbers': {
+            return `Encountered an invalid sheet with non-consecutive page numbers: ${sheetValuesToString(
+              error.pageNumbers
+            )}.`;
+          }
+          /* istanbul ignore next: Compile-time check for completeness */
+          default: {
+            throwIllegalValue(error, 'subType');
+          }
+        }
+      })();
+    }
+    /* istanbul ignore next: Compile-time check for completeness */
+    default: {
+      throwIllegalValue(error, 'type');
+    }
+  }
+}

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -7,6 +7,7 @@ export * from './button';
 export * from './button_bar';
 export * from './button_list';
 export * from './card';
+export * from './cast_vote_records';
 export * from './centered_large_prose';
 export * from './contest_choice_button';
 export * from './display_settings';


### PR DESCRIPTION
_Easiest reviewed by commit_

## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/3917

This PR handles miscellaneous continuous-export / CVR-related cleanup. Most notably, it:

- Cleans up CVR-related logging, consistently handling this logging in app backends
- No longer has backends prepare UI copy and shifts this logic to frontends

## Testing

- [x] Updated automated tests

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced (what half of this PR was for!)