### PR TITLE
add absentee option to manual results

### DIFF
--- a/apps/admin/frontend/src/screens/manual_data_summary_screen.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_summary_screen.tsx
@@ -33,7 +33,10 @@ import { RemoveAllManualTalliesModal } from '../components/remove_all_manual_tal
 import { deleteManualResults, getManualResultsMetadata } from '../api';
 import { Loading } from '../components/loading';
 
-const allManualTallyBallotTypes: ManualResultsVotingMethod[] = ['precinct'];
+const allManualTallyBallotTypes: ManualResultsVotingMethod[] = [
+  'precinct',
+  'absentee',
+];
 
 function getAllPossibleManualTallyIdentifiers(
   election: Election


### PR DESCRIPTION
Was disabled in the transition period when the all manual data was either absentee or precinct, but can enable now.
