### PR TITLE
Kevin/polish rear eject

### DIFF
--- a/apps/mark-scan/backend/src/custom-paper-handler/constants.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/constants.ts
@@ -10,8 +10,9 @@ export const AUTH_STATUS_POLLING_TIMEOUT_MS = 30_000;
 export const RESET_DELAY_MS = 8_000;
 export const RESET_AFTER_JAM_DELAY_MS = 3_000;
 // The delay the state machine will wait for paper to eject before
-// declaring a jam state during rear ejection
-export const DELAY_BEFORE_DECLARING_REAR_JAM_MS = 3_000;
+// declaring a jam state during rear ejection. Expected time for a successful
+// ballot cast is is about 3.5 seconds.
+export const DELAY_BEFORE_DECLARING_REAR_JAM_MS = 7_000;
 
 export const SCAN_DPI = 72;
 export const PRINT_DPI = 200;

--- a/apps/mark-scan/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
+++ b/apps/mark-scan/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
@@ -8,16 +8,16 @@ exports[`Single Seat Contest 1`] = `
   margin: 0;
 }
 
-.c9 {
+.c23 {
   font-size: 1em;
+  font-weight: 300;
   line-height: 1.15;
   margin: 0;
   font-size: 0.75rem;
 }
 
-.c5 {
+.c9 {
   font-size: 1em;
-  font-weight: 500;
   line-height: 1.15;
   margin: 0;
   font-size: 0.75rem;
@@ -31,9 +31,9 @@ exports[`Single Seat Contest 1`] = `
   font-size: 0.75rem;
 }
 
-.c23 {
+.c5 {
   font-size: 1em;
-  font-weight: 300;
+  font-weight: 500;
   line-height: 1.15;
   margin: 0;
   font-size: 0.75rem;

--- a/apps/mark-scan/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
+++ b/apps/mark-scan/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
@@ -8,16 +8,16 @@ exports[`Single Seat Contest 1`] = `
   margin: 0;
 }
 
-.c9 {
+.c23 {
   font-size: 1em;
+  font-weight: 300;
   line-height: 1.15;
   margin: 0;
   font-size: 0.75rem;
 }
 
-.c5 {
+.c9 {
   font-size: 1em;
-  font-weight: 500;
   line-height: 1.15;
   margin: 0;
   font-size: 0.75rem;
@@ -31,9 +31,9 @@ exports[`Single Seat Contest 1`] = `
   font-size: 0.75rem;
 }
 
-.c23 {
+.c5 {
   font-size: 1em;
-  font-weight: 300;
+  font-weight: 500;
   line-height: 1.15;
   margin: 0;
   font-size: 0.75rem;

--- a/apps/mark-scan/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
+++ b/apps/mark-scan/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
@@ -8,16 +8,16 @@ exports[`Single Seat Contest 1`] = `
   margin: 0;
 }
 
-.c9 {
+.c23 {
   font-size: 1em;
+  font-weight: 300;
   line-height: 1.15;
   margin: 0;
   font-size: 0.75rem;
 }
 
-.c5 {
+.c9 {
   font-size: 1em;
-  font-weight: 500;
   line-height: 1.15;
   margin: 0;
   font-size: 0.75rem;
@@ -31,9 +31,9 @@ exports[`Single Seat Contest 1`] = `
   font-size: 0.75rem;
 }
 
-.c23 {
+.c5 {
   font-size: 1em;
-  font-weight: 300;
+  font-weight: 500;
   line-height: 1.15;
   margin: 0;
   font-size: 0.75rem;

--- a/apps/mark-scan/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
+++ b/apps/mark-scan/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
@@ -8,16 +8,16 @@ exports[`Single Seat Contest with Write In 1`] = `
   margin: 0;
 }
 
-.c9 {
+.c23 {
   font-size: 1em;
+  font-weight: 300;
   line-height: 1.15;
   margin: 0;
   font-size: 0.75rem;
 }
 
-.c5 {
+.c9 {
   font-size: 1em;
-  font-weight: 500;
   line-height: 1.15;
   margin: 0;
   font-size: 0.75rem;
@@ -31,9 +31,9 @@ exports[`Single Seat Contest with Write In 1`] = `
   font-size: 0.75rem;
 }
 
-.c23 {
+.c5 {
   font-size: 1em;
-  font-weight: 300;
+  font-weight: 500;
   line-height: 1.15;
   margin: 0;
   font-size: 0.75rem;

--- a/apps/mark-scan/frontend/src/api.ts
+++ b/apps/mark-scan/frontend/src/api.ts
@@ -9,7 +9,6 @@ import {
   useQueryClient,
 } from '@tanstack/react-query';
 import {
-  AUTH_STATUS_POLLING_INTERVAL_MS,
   QUERY_CLIENT_DEFAULT_OPTIONS,
   USB_DRIVE_STATUS_POLLING_INTERVAL_MS,
   createUiStringsApi,
@@ -18,7 +17,10 @@ import {
 import type { UsbDriveStatus } from '@votingworks/usb-drive';
 import isEqual from 'lodash.isequal';
 import { typedAs } from '@votingworks/basics';
-import { STATE_MACHINE_POLLING_INTERVAL_MS } from './constants';
+import {
+  AUTH_STATUS_POLLING_INTERVAL_MS_OVERRIDE,
+  STATE_MACHINE_POLLING_INTERVAL_MS,
+} from './constants';
 
 export type ApiClient = grout.Client<Api>;
 
@@ -151,7 +153,7 @@ export const getAuthStatus = {
   useQuery() {
     const apiClient = useApiClient();
     return useQuery(this.queryKey(), () => apiClient.getAuthStatus(), {
-      refetchInterval: AUTH_STATUS_POLLING_INTERVAL_MS,
+      refetchInterval: AUTH_STATUS_POLLING_INTERVAL_MS_OVERRIDE,
     });
   },
 } as const;

--- a/apps/mark-scan/frontend/src/app_cardless_voting.test.tsx
+++ b/apps/mark-scan/frontend/src/app_cardless_voting.test.tsx
@@ -17,7 +17,6 @@ import {
   screen,
   within,
 } from '../test/react_testing_library';
-import * as GLOBALS from './config/globals';
 
 import { App } from './app';
 
@@ -37,6 +36,7 @@ beforeEach(() => {
   apiMock = createApiMock();
   kiosk = fakeKiosk();
   window.kiosk = kiosk;
+  apiMock.setPaperHandlerState('waiting_for_ballot_data');
 });
 
 afterEach(() => {
@@ -257,16 +257,9 @@ test('Cardless Voting Flow', async () => {
   apiMock.expectGetInterpretation(mockInterpretation);
   userEvent.click(screen.getByText('My Ballot is Correct'));
 
-  // Reset Ballot is called
-  // Show Verify and Scan Instructions
-  await screen.findByText('You’re Almost Done');
-  expect(
-    screen.queryByText('3. Return the card to a poll worker.')
-  ).toBeFalsy();
+  apiMock.setPaperHandlerState('ejecting_to_rear');
+  await screen.findByText('Casting Ballot');
 
-  // Wait for timeout to return to Insert Card screen
-  apiMock.mockApiClient.endCardlessVoterSession.expectCallWith().resolves();
-  await advanceTimersAndPromises(GLOBALS.BALLOT_INSTRUCTIONS_TIMEOUT_SECONDS);
   apiMock.setAuthStatusLoggedOut();
   await screen.findByText('Insert Card');
 });
@@ -411,14 +404,9 @@ test('Voter can submit a blank ballot', async () => {
   apiMock.expectGetInterpretation(mockInterpretation);
   userEvent.click(screen.getByText('My Ballot is Correct'));
 
-  // Reset Ballot is called
-  // Show Verify and Scan Instructions
-  await screen.findByText('You’re Almost Done');
-  expect(screen.queryByText('3. Return the card.')).toBeFalsy();
+  apiMock.setPaperHandlerState('ejecting_to_rear');
+  await screen.findByText('Casting Ballot');
 
-  // Click "Done" to get back to Insert Card screen
-  apiMock.mockApiClient.endCardlessVoterSession.expectCallWith().resolves();
-  fireEvent.click(screen.getByText('Done'));
   apiMock.setAuthStatusLoggedOut();
   await screen.findByText('Insert Card');
 });
@@ -635,16 +623,9 @@ test('poll worker must select a precinct first', async () => {
   apiMock.expectGetInterpretation(mockInterpretation);
   userEvent.click(screen.getByText('My Ballot is Correct'));
 
-  // Reset Ballot is called
-  // Show Verify and Scan Instructions
-  await screen.findByText('You’re Almost Done');
-  expect(
-    screen.queryByText('3. Return the card to a poll worker.')
-  ).toBeFalsy();
+  apiMock.setPaperHandlerState('ejecting_to_rear');
+  await screen.findByText('Casting Ballot');
 
-  // Wait for timeout to return to Insert Card screen
-  apiMock.mockApiClient.endCardlessVoterSession.expectCallWith().resolves();
-  await advanceTimersAndPromises(GLOBALS.BALLOT_INSTRUCTIONS_TIMEOUT_SECONDS);
   apiMock.setAuthStatusLoggedOut();
   await screen.findByText('Insert Card');
 });

--- a/apps/mark-scan/frontend/src/app_cardless_voting.test.tsx
+++ b/apps/mark-scan/frontend/src/app_cardless_voting.test.tsx
@@ -258,7 +258,7 @@ test('Cardless Voting Flow', async () => {
   userEvent.click(screen.getByText('My Ballot is Correct'));
 
   apiMock.setPaperHandlerState('ejecting_to_rear');
-  await screen.findByText('Casting Ballot');
+  await screen.findByText('Casting Ballot...');
 
   apiMock.setAuthStatusLoggedOut();
   await screen.findByText('Insert Card');
@@ -405,7 +405,7 @@ test('Voter can submit a blank ballot', async () => {
   userEvent.click(screen.getByText('My Ballot is Correct'));
 
   apiMock.setPaperHandlerState('ejecting_to_rear');
-  await screen.findByText('Casting Ballot');
+  await screen.findByText('Casting Ballot...');
 
   apiMock.setAuthStatusLoggedOut();
   await screen.findByText('Insert Card');
@@ -624,7 +624,7 @@ test('poll worker must select a precinct first', async () => {
   userEvent.click(screen.getByText('My Ballot is Correct'));
 
   apiMock.setPaperHandlerState('ejecting_to_rear');
-  await screen.findByText('Casting Ballot');
+  await screen.findByText('Casting Ballot...');
 
   apiMock.setAuthStatusLoggedOut();
   await screen.findByText('Insert Card');

--- a/apps/mark-scan/frontend/src/app_contest_candidate_no_party.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_candidate_no_party.test.tsx
@@ -42,6 +42,7 @@ beforeEach(() => {
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
   apiMock.expectGetElectionDefinition(null);
+  apiMock.setPaperHandlerState('waiting_for_ballot_data');
 });
 
 afterEach(() => {

--- a/apps/mark-scan/frontend/src/app_contest_ms_either_neither.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_ms_either_neither.test.tsx
@@ -42,6 +42,7 @@ beforeEach(() => {
   jest.useFakeTimers();
   window.location.href = '/';
   apiMock = createApiMock();
+  apiMock.setPaperHandlerState('waiting_for_ballot_data');
 });
 
 afterEach(() => {

--- a/apps/mark-scan/frontend/src/app_contest_multi_seat.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_multi_seat.test.tsx
@@ -22,6 +22,7 @@ beforeEach(() => {
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
   apiMock.expectGetElectionDefinition(null);
+  apiMock.setPaperHandlerState('waiting_for_ballot_data');
 });
 
 afterEach(() => {

--- a/apps/mark-scan/frontend/src/app_contest_single_seat.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_single_seat.test.tsx
@@ -22,6 +22,7 @@ beforeEach(() => {
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
   apiMock.expectGetElectionDefinition(null);
+  apiMock.setPaperHandlerState('waiting_for_ballot_data');
 });
 
 afterEach(() => {

--- a/apps/mark-scan/frontend/src/app_contest_write_in.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_write_in.test.tsx
@@ -50,6 +50,7 @@ beforeEach(() => {
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
   apiMock.expectGetElectionDefinition(null);
+  apiMock.setPaperHandlerState('waiting_for_ballot_data');
 });
 
 afterEach(() => {

--- a/apps/mark-scan/frontend/src/app_contest_yes_no.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_yes_no.test.tsx
@@ -32,6 +32,7 @@ beforeEach(() => {
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
   apiMock.expectGetElectionDefinition(null);
+  apiMock.setPaperHandlerState('waiting_for_ballot_data');
 });
 
 afterEach(() => {

--- a/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
@@ -293,10 +293,9 @@ test('MarkAndPrint end-to-end flow', async () => {
   // Validate Ballot page
   await screen.findByText('Review Your Votes');
   apiMock.expectValidateBallot();
-  apiMock.mockApiClient.endCardlessVoterSession.expectCallWith().resolves();
   apiMock.expectGetInterpretation(mockInterpretation);
   userEvent.click(screen.getByText('My Ballot is Correct'));
-  userEvent.click(await screen.findByText('Done'));
+
   apiMock.setAuthStatusLoggedOut();
 
   // ---------------

--- a/apps/mark-scan/frontend/src/app_quit_on_idle.test.tsx
+++ b/apps/mark-scan/frontend/src/app_quit_on_idle.test.tsx
@@ -32,6 +32,7 @@ beforeEach(() => {
   apiMock.expectGetSystemSettings();
   apiMock.expectGetElectionDefinition(null);
   apiMock.expectGetPrecinctSelectionResolvesDefault(election);
+  apiMock.setPaperHandlerState('waiting_for_ballot_data');
 });
 
 afterEach(() => {

--- a/apps/mark-scan/frontend/src/constants.ts
+++ b/apps/mark-scan/frontend/src/constants.ts
@@ -1,2 +1,4 @@
-/* istanbul ignore next */
+/* istanbul ignore file */
 export const STATE_MACHINE_POLLING_INTERVAL_MS = 300;
+// Overrides shorter libs/ui polling interval
+export const AUTH_STATUS_POLLING_INTERVAL_MS_OVERRIDE = 300;

--- a/apps/mark-scan/frontend/src/constants.ts
+++ b/apps/mark-scan/frontend/src/constants.ts
@@ -1,2 +1,2 @@
 /* istanbul ignore next */
-export const STATE_MACHINE_POLLING_INTERVAL_MS = 100;
+export const STATE_MACHINE_POLLING_INTERVAL_MS = 300;

--- a/apps/mark-scan/frontend/src/lib/gamepad.test.tsx
+++ b/apps/mark-scan/frontend/src/lib/gamepad.test.tsx
@@ -40,6 +40,7 @@ beforeEach(() => {
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
   apiMock.expectGetElectionDefinition(null);
+  apiMock.setPaperHandlerState('waiting_for_ballot_data');
 });
 
 afterEach(() => {

--- a/apps/mark-scan/frontend/src/pages/casting_ballot_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/casting_ballot_page.tsx
@@ -1,0 +1,12 @@
+import { Main, Screen, InsertBallotImage, P } from '@votingworks/ui';
+
+export function CastingBallotPage(): JSX.Element {
+  return (
+    <Screen white>
+      <Main centerChild padded>
+        <InsertBallotImage />
+        <P>Casting Ballot...</P>
+      </Main>
+    </Screen>
+  );
+}

--- a/apps/mark-scan/frontend/test/helpers/timers.ts
+++ b/apps/mark-scan/frontend/test/helpers/timers.ts
@@ -1,9 +1,9 @@
 import { advanceTimers as advanceTimersBase } from '@votingworks/test-utils';
-import { AUTH_STATUS_POLLING_INTERVAL_MS } from '@votingworks/ui';
 import { waitFor } from '../react_testing_library';
+import { AUTH_STATUS_POLLING_INTERVAL_MS_OVERRIDE } from '../../src/constants';
 
 export function advanceTimers(seconds = 0): void {
-  advanceTimersBase(seconds || AUTH_STATUS_POLLING_INTERVAL_MS / 1000);
+  advanceTimersBase(seconds || AUTH_STATUS_POLLING_INTERVAL_MS_OVERRIDE / 1000);
 }
 
 export async function advanceTimersAndPromises(seconds = 0): Promise<void> {


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/3945
https://github.com/votingworks/vxsuite/issues/3971

* Fixes a bug where a jam would be triggered on rear eject too early
* Adds a screen shown when the ballot is being cast, which fixes a bug where the "Printing ballot" screen is shown when casting the ballot
* Removes the post-voting instructions. These were left over from VxMark and are not relevant for MarkScan's ballot cast flow.

## Demo Video or Screenshot


https://github.com/votingworks/vxsuite/assets/1060688/95ee357c-935a-4f5d-b856-158a40e28783



## Testing Plan

- [x] Update existing frontend tests to check for new screen header

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced. (No user actions)
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
