### PR TITLE
Properly handle CVR exports that aren't perfect duplicates of another but also contain no new CVRs

### DIFF
--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -1137,7 +1137,7 @@ export class Store {
         sha256_hash as sha256Hash,
         datetime(cvr_files.created_at, 'localtime') as createdAt
       from cvr_files
-      join (
+      left join (
         select
           cvr_file_entries.cvr_id,
           min(cvr_files.created_at) as min_import_date,


### PR DESCRIPTION
## Overview

Both @carolinemodic and I recently stumbled across the following unexpected edge case behavior in the VxAdmin CVR import flow. If you try to import a file that's not a perfect duplicate of another but also contains no new CVRs, you first see a message indicating that the import was successful but that no new CVRs were added, which is expected. What's unexpected is that you can then still try to import the export again. And on the second import attempt, you see a different message, indicating that the export is a duplicate. Ideally, after the first import attempt, you shouldn't be able to import the export again.

The bug fix ended up being a 1-word addition to a SQL query 😅. As Beyonce once famously said, "to the **left**" (join).

## Demo Videos

_Before_ 😢

https://github.com/votingworks/vxsuite/assets/12616928/63243123-bd3d-4131-b85a-67ea55f10127

_After_ 🎉

https://github.com/votingworks/vxsuite/assets/12616928/9ca60014-263e-4b25-aa04-97d9dc43efd6

## Testing Plan

- [x] Tested the fix manually
- [x] Added an automated test to prevent regressions

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A