### PR TITLE
refactor: use `mapSheet` with split sheet data

### DIFF
--- a/libs/backend/src/cast_vote_records/import.ts
+++ b/libs/backend/src/cast_vote_records/import.ts
@@ -183,13 +183,11 @@ async function* castVoteRecordGenerator(
         (imageRelativePath) =>
           path.join(castVoteRecordDirectoryPath, imageRelativePath)
       );
-      const imageFiles: SheetOf<ReferencedImageFile> = mapSheet(
-        [0, 1] as const,
-        (i) =>
-          new ReferencedImageFile({
-            expectedFileHash: imageHashes[i],
-            filePath: imagePaths[i],
-          })
+      const imageFiles = mapSheet(
+        imageHashes,
+        imagePaths,
+        (expectedFileHash, filePath) =>
+          new ReferencedImageFile({ expectedFileHash, filePath })
       );
 
       let layoutFiles: SheetOf<ReferencedLayoutFile> | undefined;
@@ -205,14 +203,18 @@ async function* castVoteRecordGenerator(
           castVoteRecord.BallotImage[0].vxLayoutFileHash,
           castVoteRecord.BallotImage[1].vxLayoutFileHash,
         ];
-        layoutFiles = mapSheet([0, 1] as const, (i) => {
-          const { dir, name } = path.parse(imagePaths[i]);
-          const layoutFilePath = path.join(dir, `${name}.layout.json`);
-          return new ReferencedLayoutFile({
-            expectedFileHash: layoutFileHashes[i],
-            filePath: layoutFilePath,
-          });
-        });
+        layoutFiles = mapSheet(
+          imagePaths,
+          layoutFileHashes,
+          (imagePath, expectedFileHash) => {
+            const { dir, name } = path.parse(imagePath);
+            const layoutFilePath = path.join(dir, `${name}.layout.json`);
+            return new ReferencedLayoutFile({
+              expectedFileHash,
+              filePath: layoutFilePath,
+            });
+          }
+        );
       }
 
       referencedFiles = { imageFiles, layoutFiles };

--- a/libs/types/src/hmpb.test.ts
+++ b/libs/types/src/hmpb.test.ts
@@ -5,12 +5,27 @@ test('mapSheet sync', () => {
 
   const fn = jest.fn<void, []>();
   mapSheet([1, 2], fn);
-  expect(fn).toHaveBeenNthCalledWith(1, 1, 'front');
-  expect(fn).toHaveBeenNthCalledWith(2, 2, 'back');
+  expect(fn).toHaveBeenNthCalledWith(1, 1, 'front', 0);
+  expect(fn).toHaveBeenNthCalledWith(2, 2, 'back', 1);
 });
 
 test('mapSheet async', async () => {
   expect(await mapSheet([1, 2], (x) => Promise.resolve(x + 1))).toEqual([2, 3]);
+});
+
+test('mapSheet multiple sync', () => {
+  expect(mapSheet([1, 2], [3, 4], (x, y) => x + y)).toEqual([4, 6]);
+
+  const fn = jest.fn<void, []>();
+  mapSheet([1, 2], [3, 4], fn);
+  expect(fn).toHaveBeenNthCalledWith(1, 1, 3, 'front', 0);
+  expect(fn).toHaveBeenNthCalledWith(2, 2, 4, 'back', 1);
+});
+
+test('mapSheet multiple async', async () => {
+  expect(
+    await mapSheet([1, 2], [3, 4], (x, y) => Promise.resolve(x + y))
+  ).toEqual([4, 6]);
 });
 
 test('asSheet', () => {

--- a/libs/types/src/hmpb.ts
+++ b/libs/types/src/hmpb.ts
@@ -1,4 +1,4 @@
-import { assert } from '@votingworks/basics';
+import { assert, assertDefined } from '@votingworks/basics';
 import { z } from 'zod';
 import {
   ContestId,
@@ -85,24 +85,110 @@ export type SheetOf<T> = readonly [T, T];
  */
 export function mapSheet<T, U>(
   sheet: SheetOf<T>,
-  fn: (page: T, side: Side) => Promise<U>
+  fn: (page: T, side: Side, index: 0 | 1) => Promise<U>
 ): Promise<SheetOf<U>>;
 export function mapSheet<T, U>(
   sheet: SheetOf<T>,
-  fn: (page: T, side: Side) => U
+  fn: (page: T, side: Side, index: 0 | 1) => U
 ): SheetOf<U>;
-export function mapSheet<T, U>(
-  sheet: SheetOf<T>,
-  fn: (page: T, side: Side) => U
-): SheetOf<U> | Promise<SheetOf<U>> {
-  const front = fn(sheet[0], 'front');
-  const back = fn(sheet[1], 'back');
+export function mapSheet<T, U, V>(
+  sheet1: SheetOf<T>,
+  sheet2: SheetOf<U>,
+  fn: (page1: T, page2: U, side: Side, index: 0 | 1) => Promise<V>
+): Promise<SheetOf<V>>;
+export function mapSheet<T, U, V>(
+  sheet1: SheetOf<T>,
+  sheet2: SheetOf<U>,
+  fn: (page1: T, page2: U, side: Side, index: 0 | 1) => V
+): SheetOf<V>;
+export function mapSheet<T, U, V, W>(
+  sheet1: SheetOf<T>,
+  sheet2: SheetOf<U>,
+  sheet3: SheetOf<W>,
+  fn: (page1: T, page2: U, page3: V, side: Side, index: 0 | 1) => Promise<W>
+): Promise<SheetOf<W>>;
+export function mapSheet<T, U, V, W>(
+  sheet1: SheetOf<T>,
+  sheet2: SheetOf<U>,
+  sheet3: SheetOf<V>,
+  fn: (page1: T, page2: U, page3: V, side: Side, index: 0 | 1) => W
+): SheetOf<W>;
+export function mapSheet<T, U, V, W, X>(
+  sheet1: SheetOf<T>,
+  sheet2: SheetOf<U>,
+  sheet3: SheetOf<V>,
+  sheet4: SheetOf<W>,
+  fn: (
+    page1: T,
+    page2: U,
+    page3: V,
+    page4: W,
+    side: Side,
+    index: 0 | 1
+  ) => Promise<X>
+): Promise<SheetOf<W>>;
+export function mapSheet<T, U, V, W, X>(
+  sheet1: SheetOf<T>,
+  sheet2: SheetOf<U>,
+  sheet3: SheetOf<V>,
+  sheet4: SheetOf<W>,
+  fn: (page1: T, page2: U, page3: V, page4: W, side: Side, index: 0 | 1) => X
+): SheetOf<X>;
+export function mapSheet<T, U, V, W, X, Y>(
+  sheet1: SheetOf<T>,
+  sheet2: SheetOf<U>,
+  sheet3: SheetOf<V>,
+  sheet4: SheetOf<W>,
+  sheet5: SheetOf<X>,
+  fn: (
+    page1: T,
+    page2: U,
+    page3: V,
+    page4: W,
+    page5: X,
+    side: Side,
+    index: 0 | 1
+  ) => Promise<Y>
+): Promise<SheetOf<Y>>;
+export function mapSheet<T, U, V, W, X, Y>(
+  sheet1: SheetOf<T>,
+  sheet2: SheetOf<U>,
+  sheet3: SheetOf<V>,
+  sheet4: SheetOf<W>,
+  sheet5: SheetOf<X>,
+  fn: (
+    page1: T,
+    page2: U,
+    page3: V,
+    page4: W,
+    page5: X,
+    side: Side,
+    index: 0 | 1
+  ) => Y
+): SheetOf<Y>;
+export function mapSheet<F extends (...args: unknown[]) => unknown>(
+  ...args: [...sheets: Array<SheetOf<unknown>>, fn: F]
+): SheetOf<unknown> | Promise<SheetOf<unknown>> {
+  const fn = assertDefined(args.pop()) as unknown as (
+    ...args: [...pages: readonly unknown[], side: Side, index: 0 | 1]
+  ) => unknown | Promise<unknown>;
+  const sheets = args as ReadonlyArray<SheetOf<unknown>>;
+  const front = fn(
+    ...(sheets.map((sheet) => sheet[0]) as readonly unknown[]),
+    'front',
+    0
+  );
+  const back = fn(
+    ...(sheets.map((sheet) => sheet[1]) as readonly unknown[]),
+    'back',
+    1
+  );
 
   if (
     front &&
     back &&
-    typeof (front as unknown as PromiseLike<U>).then === 'function' &&
-    typeof (back as unknown as PromiseLike<U>).then === 'function'
+    typeof (front as unknown as PromiseLike<unknown>).then === 'function' &&
+    typeof (back as unknown as PromiseLike<unknown>).then === 'function'
   ) {
     return Promise.all([front, back]);
   }


### PR DESCRIPTION
## Overview

We fairly often have data for a single sheet spread across multiple tuples rather than nested within a single tuple. To make this easier to work with, `mapSheet` now accepts multiple `SheetOf` values and spreads the pages from each in the call to the provided function.

## Demo Video or Screenshot
```ts
expect(mapSheet([1, 2], [3, 4], (x, y) => x + y)).toEqual([4, 6]);
```

## Testing Plan
Automated.
