### PR TITLE
s/MARK_WORKSPACE/MARK_SCAN_WORKSPACE

### DIFF
--- a/apps/mark-scan/backend/src/custom-paper-handler/cli/state_machine_cli.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/cli/state_machine_cli.ts
@@ -7,7 +7,7 @@ import { getPaperHandlerDriver } from '@votingworks/custom-paper-handler';
 import { join } from 'path';
 import { LogSource, Logger } from '@votingworks/logging';
 import { createWorkspace } from '../../util/workspace';
-import { MARK_WORKSPACE } from '../../globals';
+import { MARK_SCAN_WORKSPACE } from '../../globals';
 import { DEV_PAPER_HANDLER_STATUS_POLLING_INTERVAL_MS } from '../constants';
 import {
   PaperHandlerStateMachine,
@@ -67,7 +67,7 @@ async function logStatus(
 
 export async function main(): Promise<number> {
   printUsage();
-  const workspacePath = MARK_WORKSPACE;
+  const workspacePath = MARK_SCAN_WORKSPACE;
   assert(workspacePath !== undefined, 'expected workspace path');
   const workspace = createWorkspace(workspacePath);
 

--- a/apps/mark-scan/backend/src/globals.ts
+++ b/apps/mark-scan/backend/src/globals.ts
@@ -26,8 +26,8 @@ export const NODE_ENV = unsafeParse(
 /**
  * Where should the database and audio files go?
  */
-export const MARK_WORKSPACE =
-  process.env.MARK_WORKSPACE ??
+export const MARK_SCAN_WORKSPACE =
+  process.env.MARK_SCAN_WORKSPACE ??
   (NODE_ENV === 'development'
     ? join(__dirname, '../dev-workspace')
     : undefined);

--- a/apps/mark-scan/backend/src/index.ts
+++ b/apps/mark-scan/backend/src/index.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import * as dotenv from 'dotenv';
 import * as dotenvExpand from 'dotenv-expand';
 import * as server from './server';
-import { MARK_WORKSPACE, NODE_ENV, PORT } from './globals';
+import { MARK_SCAN_WORKSPACE, NODE_ENV, PORT } from './globals';
 import { createWorkspace, Workspace } from './util/workspace';
 
 export type { Api } from './app';
@@ -38,15 +38,15 @@ for (const dotenvFile of dotenvFiles) {
 const logger = new Logger(LogSource.VxMarkScanBackend);
 
 async function resolveWorkspace(): Promise<Workspace> {
-  const workspacePath = MARK_WORKSPACE;
+  const workspacePath = MARK_SCAN_WORKSPACE;
   if (!workspacePath) {
     await logger.log(LogEventId.ScanServiceConfigurationMessage, 'system', {
       message:
-        'workspace path could not be determined; pass a workspace or run with MARK_WORKSPACE',
+        'workspace path could not be determined; pass a workspace or run with MARK_SCAN_WORKSPACE',
       disposition: 'failure',
     });
     throw new Error(
-      'workspace path could not be determined; pass a workspace or run with MARK_WORKSPACE'
+      'workspace path could not be determined; pass a workspace or run with MARK_SCAN_WORKSPACE'
     );
   }
   return createWorkspace(workspacePath);

--- a/apps/mark-scan/integration-testing/Makefile
+++ b/apps/mark-scan/integration-testing/Makefile
@@ -1,6 +1,6 @@
 APP := ..
 export PIPENV_VENV_IN_PROJECT=1
-export MARK_WORKSPACE=/tmp/mark-integration-testing
+export MARK_SCAN_WORKSPACE=/tmp/mark-scan-integration-testing
 
 build-frontend:
 	make -C $(APP)/frontend install; \
@@ -13,8 +13,8 @@ build-backend:
 build: build-frontend build-backend
 
 run:
-	rm -rf $(MARK_WORKSPACE)
-	mkdir $(MARK_WORKSPACE)
+	rm -rf $(MARK_SCAN_WORKSPACE)
+	mkdir $(MARK_SCAN_WORKSPACE)
 	NODE_ENV=production IS_INTEGRATION_TEST=true VX_MACHINE_TYPE=mark \
 		./node_modules/.bin/concurrently -n frontend,backend --kill-others \
 		"make -C $(APP)/frontend run" \


### PR DESCRIPTION
## Overview

Replaces the env var `MARK_WORKSPACE` with `MARK_SCAN_WORKSPACE` in VxMarkScan.

## Demo Video or Screenshot
N/A

## Testing Plan
Built and ran locally

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced. (N/A)
