### PR TITLE
Manual Counts Policy - Ballot Count Reporting

### DIFF
--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -777,7 +777,6 @@ function buildApi({
       path: string;
       filter?: Tabulation.Filter;
       groupBy?: Tabulation.GroupBy;
-      ballotCountBreakdown: Tabulation.BallotCountBreakdown;
     }): Promise<ExportDataResult> {
       debug('exporting ballot count report CSV file: %o', input);
       const exportFileResult = await exportFile({
@@ -786,7 +785,6 @@ function buildApi({
           store,
           filter: input.filter,
           groupBy: input.groupBy,
-          ballotCountBreakdown: input.ballotCountBreakdown,
         }),
       });
 

--- a/apps/admin/frontend/src/components/reporting/ballot_count_report_viewer.test.tsx
+++ b/apps/admin/frontend/src/components/reporting/ballot_count_report_viewer.test.tsx
@@ -54,7 +54,6 @@ test('disabled shows disabled buttons and no preview', () => {
       disabled
       filter={{}}
       groupBy={{}}
-      ballotCountBreakdown="none"
       autoPreview={false}
     />,
     { apiMock, electionDefinition }
@@ -80,7 +79,6 @@ test('autoPreview loads preview automatically', async () => {
       disabled={false}
       filter={{}}
       groupBy={{ groupByVotingMethod: true }}
-      ballotCountBreakdown="none"
       autoPreview
     />,
     { apiMock, electionDefinition }
@@ -98,7 +96,6 @@ test('autoPreview = false does not load preview automatically', async () => {
       disabled={false}
       filter={{}}
       groupBy={{}}
-      ballotCountBreakdown="none"
       autoPreview={false}
     />,
     { apiMock, electionDefinition }
@@ -122,7 +119,6 @@ test('shows no results warning when no results', async () => {
       disabled={false}
       filter={{}}
       groupBy={{ groupByBatch: true }}
-      ballotCountBreakdown="none"
       autoPreview
     />,
     { apiMock, electionDefinition }
@@ -157,7 +153,6 @@ test('print before loading preview', async () => {
       disabled={false}
       filter={{}}
       groupBy={{ groupByVotingMethod: true }}
-      ballotCountBreakdown="none"
       autoPreview={false}
     />,
     { apiMock, electionDefinition }
@@ -198,7 +193,6 @@ test('print after preview loaded + test success logging', async () => {
       disabled={false}
       filter={{}}
       groupBy={{ groupByVotingMethod: true }}
-      ballotCountBreakdown="none"
       autoPreview
     />,
     { apiMock, electionDefinition, logger }
@@ -244,7 +238,6 @@ test('print while preview is loading', async () => {
       disabled={false}
       filter={{}}
       groupBy={{ groupByVotingMethod: true }}
-      ballotCountBreakdown="none"
       autoPreview={false}
     />,
     { apiMock, electionDefinition }
@@ -286,7 +279,6 @@ test('print failure logging', async () => {
       disabled={false}
       filter={{}}
       groupBy={{ groupByVotingMethod: true }}
-      ballotCountBreakdown="none"
       autoPreview
     />,
     { apiMock, electionDefinition, logger }
@@ -332,7 +324,6 @@ test('displays custom filter rather than specific title when necessary', async (
       disabled={false}
       filter={filter}
       groupBy={{}}
-      ballotCountBreakdown="none"
       autoPreview
     />,
     { apiMock, electionDefinition }
@@ -368,7 +359,6 @@ test('exporting report PDF', async () => {
       groupBy={{
         groupByVotingMethod: true,
       }}
-      ballotCountBreakdown="none"
       autoPreview={false}
     />,
     {

--- a/apps/admin/frontend/src/components/reporting/ballot_count_report_viewer.tsx
+++ b/apps/admin/frontend/src/components/reporting/ballot_count_report_viewer.tsx
@@ -103,7 +103,6 @@ function Report({
   cardCountsList,
   filter,
   groupBy,
-  ballotCountBreakdown,
   generatedAtTime,
 }: {
   electionDefinition: ElectionDefinition;
@@ -112,7 +111,6 @@ function Report({
   cardCountsList: Tabulation.GroupList<Tabulation.CardCounts>;
   filter: Tabulation.Filter;
   groupBy: Tabulation.GroupBy;
-  ballotCountBreakdown: Tabulation.BallotCountBreakdown;
   generatedAtTime: Date;
 }): JSX.Element {
   const titleGeneration = generateTitleForReport({
@@ -137,7 +135,6 @@ function Report({
     scannerBatches,
     generatedAtTime,
     groupBy,
-    ballotCountBreakdown,
     cardCountsList,
   });
 }
@@ -145,7 +142,6 @@ function Report({
 export interface BallotCountReportViewerProps {
   filter: Tabulation.Filter;
   groupBy: Tabulation.GroupBy;
-  ballotCountBreakdown: Tabulation.BallotCountBreakdown;
   disabled: boolean;
   autoPreview: boolean;
 }
@@ -153,7 +149,6 @@ export interface BallotCountReportViewerProps {
 export function BallotCountReportViewer({
   filter,
   groupBy,
-  ballotCountBreakdown,
   disabled: disabledFromProps,
   autoPreview,
 }: BallotCountReportViewerProps): JSX.Element {
@@ -207,7 +202,6 @@ export function BallotCountReportViewer({
         electionDefinition={assertDefined(electionDefinition)}
         filter={filter}
         groupBy={groupBy}
-        ballotCountBreakdown={ballotCountBreakdown}
         cardCountsList={cardCountsQuery.data}
         generatedAtTime={new Date(cardCountsQuery.dataUpdatedAt)}
         isOfficialResults={isOfficialResults}
@@ -220,7 +214,6 @@ export function BallotCountReportViewer({
     electionDefinition,
     filter,
     groupBy,
-    ballotCountBreakdown,
     cardCountsQuery.data,
     cardCountsQuery.dataUpdatedAt,
     isOfficialResults,
@@ -254,7 +247,6 @@ export function BallotCountReportViewer({
         electionDefinition={assertDefined(electionDefinition)}
         filter={filter}
         groupBy={groupBy}
-        ballotCountBreakdown={ballotCountBreakdown}
         cardCountsList={queryResults.data}
         generatedAtTime={new Date(queryResults.dataUpdatedAt)}
         isOfficialResults={isOfficialResults}
@@ -294,7 +286,6 @@ export function BallotCountReportViewer({
         electionDefinition={assertDefined(electionDefinition)}
         filter={filter}
         groupBy={groupBy}
-        ballotCountBreakdown={ballotCountBreakdown}
         cardCountsList={queryResults.data}
         generatedAtTime={new Date(queryResults.dataUpdatedAt)}
         isOfficialResults={isOfficialResults}
@@ -336,7 +327,6 @@ export function BallotCountReportViewer({
         <ExportBallotCountReportCsvButton
           filter={filter}
           groupBy={groupBy}
-          ballotCountBreakdown={ballotCountBreakdown}
           disabled={disabled || areQueryResultsEmpty}
         />
       </ExportActions>

--- a/apps/admin/frontend/src/components/reporting/export_ballot_count_report_csv_button.test.tsx
+++ b/apps/admin/frontend/src/components/reporting/export_ballot_count_report_csv_button.test.tsx
@@ -29,11 +29,7 @@ test('calls mutation in happy path', async () => {
   };
 
   renderInAppContext(
-    <ExportBallotCountReportCsvButton
-      filter={filter}
-      groupBy={groupBy}
-      ballotCountBreakdown="none"
-    />,
+    <ExportBallotCountReportCsvButton filter={filter} groupBy={groupBy} />,
     {
       apiMock,
       usbDriveStatus: mockUsbDriveStatus('mounted'),
@@ -50,7 +46,6 @@ test('calls mutation in happy path', async () => {
   apiMock.expectExportBallotCountReportCsv({
     filter,
     groupBy,
-    ballotCountBreakdown: 'none',
     path: 'test-mount-point/choctaw-county_mock-general-election-choctaw-2020_d6806afc49/reports/absentee-ballots-ballot-count-report-by-precinct__2021-01-01_00-00-00.csv',
   });
   userEvent.click(within(modal).getButton('Save'));
@@ -64,12 +59,7 @@ test('calls mutation in happy path', async () => {
 
 test('disabled by disabled prop', () => {
   renderInAppContext(
-    <ExportBallotCountReportCsvButton
-      disabled
-      filter={{}}
-      groupBy={{}}
-      ballotCountBreakdown="none"
-    />,
+    <ExportBallotCountReportCsvButton disabled filter={{}} groupBy={{}} />,
     { apiMock }
   );
 

--- a/apps/admin/frontend/src/components/reporting/export_ballot_count_report_csv_button.tsx
+++ b/apps/admin/frontend/src/components/reporting/export_ballot_count_report_csv_button.tsx
@@ -18,12 +18,10 @@ import {
 export function ExportBallotCountReportCsvButton({
   filter,
   groupBy,
-  ballotCountBreakdown,
   disabled,
 }: {
   filter: Tabulation.Filter;
   groupBy: Tabulation.GroupBy;
-  ballotCountBreakdown: Tabulation.BallotCountBreakdown;
   disabled?: boolean;
 }): JSX.Element {
   const { electionDefinition } = useContext(AppContext);
@@ -77,7 +75,6 @@ export function ExportBallotCountReportCsvButton({
               path: savePath,
               filter,
               groupBy,
-              ballotCountBreakdown,
             })
           }
           saveFileResult={exportBallotCountReportCsvMutation.data}

--- a/apps/admin/frontend/src/screens/reporting/ballot_count_report_builder.tsx
+++ b/apps/admin/frontend/src/screens/reporting/ballot_count_report_builder.tsx
@@ -1,12 +1,4 @@
-import {
-  Font,
-  H3,
-  Icons,
-  LinkButton,
-  P,
-  SearchSelect,
-  SelectOption,
-} from '@votingworks/ui';
+import { Font, H3, Icons, LinkButton, P } from '@votingworks/ui';
 import { useContext, useState } from 'react';
 import { assert } from '@votingworks/basics';
 import {
@@ -29,7 +21,6 @@ import {
 } from '../../components/reporting/group_by_editor';
 import { canonicalizeFilter, canonicalizeGroupBy } from '../../utils/reporting';
 import { BallotCountReportViewer } from '../../components/reporting/ballot_count_report_viewer';
-import { getManualResultsMetadata } from '../../api';
 
 const SCREEN_TITLE = 'Ballot Count Report Builder';
 
@@ -44,28 +35,14 @@ const GroupByEditorContainer = styled.div`
   margin-bottom: 2rem;
 `;
 
-const BreakdownSelectContainer = styled.div`
-  display: grid;
-  grid-template-columns: min-content 20%;
-  align-items: center;
-  gap: 1rem;
-  margin-top: 0.5rem;
-  margin-bottom: 2rem;
-  white-space: nowrap;
-`;
-
 export function BallotCountReportBuilder(): JSX.Element {
   const { electionDefinition, auth } = useContext(AppContext);
   assert(electionDefinition);
   assert(isElectionManagerAuth(auth));
   const { election } = electionDefinition;
 
-  const getManualResultsMetadataQuery = getManualResultsMetadata.useQuery();
-
   const [filter, setFilter] = useState<Tabulation.Filter>({});
   const [groupBy, setGroupBy] = useState<Tabulation.GroupBy>({});
-  const [breakdown, setBreakdown] =
-    useState<Tabulation.BallotCountBreakdown>('none');
 
   function updateFilter(newFilter: Tabulation.Filter) {
     setFilter(canonicalizeFilter(newFilter));
@@ -92,27 +69,6 @@ export function BallotCountReportBuilder(): JSX.Element {
   if (electionDefinition.election.type === 'primary') {
     allowedFilters.push('party');
     allowedGroupBys.push('groupByParty');
-  }
-
-  const breakdownOptions: Array<SelectOption<Tabulation.BallotCountBreakdown>> =
-    [
-      {
-        value: 'none',
-        label: 'None',
-      },
-      {
-        value: 'all',
-        label: 'Full',
-      },
-    ];
-  if (
-    getManualResultsMetadataQuery.data &&
-    getManualResultsMetadataQuery.data.length > 0
-  ) {
-    breakdownOptions.push({
-      value: 'manual',
-      label: 'Manual',
-    });
   }
 
   const hasMadeSelections = !isFilterEmpty(filter) || !isGroupByEmpty(groupBy);
@@ -152,25 +108,9 @@ export function BallotCountReportBuilder(): JSX.Element {
           allowedGroupings={allowedGroupBys}
         />
       </GroupByEditorContainer>
-      <H3>Options</H3>
-
-      <BreakdownSelectContainer>
-        <Font>Ballot Count Breakdown:</Font>
-        <SearchSelect
-          isMulti={false}
-          isSearchable={false}
-          value={breakdown}
-          options={breakdownOptions}
-          onChange={(value) =>
-            setBreakdown(value as Tabulation.BallotCountBreakdown)
-          }
-          ariaLabel="Select Breakdown Type"
-        />
-      </BreakdownSelectContainer>
       <BallotCountReportViewer
         filter={filter}
         groupBy={groupBy}
-        ballotCountBreakdown={breakdown}
         disabled={!hasMadeSelections}
         autoPreview={false}
       />

--- a/apps/admin/frontend/src/screens/reporting/precinct_ballot_count_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/precinct_ballot_count_report_screen.tsx
@@ -27,7 +27,6 @@ export function PrecinctBallotCountReport(): JSX.Element {
           groupByPrecinct: true,
           groupByParty: electionDefinition.election.type === 'primary',
         }}
-        ballotCountBreakdown="all"
         disabled={false}
         autoPreview
       />

--- a/apps/admin/frontend/src/screens/reporting/voting_method_ballot_count_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/voting_method_ballot_count_report_screen.tsx
@@ -27,7 +27,6 @@ export function VotingMethodBallotCountReport(): JSX.Element {
           groupByVotingMethod: true,
           groupByParty: electionDefinition.election.type === 'primary',
         }}
-        ballotCountBreakdown="all"
         disabled={false}
         autoPreview
       />

--- a/apps/admin/frontend/test/helpers/mock_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_api_client.ts
@@ -368,15 +368,13 @@ export function createApiMock(
       path,
       filter,
       groupBy,
-      ballotCountBreakdown,
     }: {
       path: string;
       filter?: Tabulation.Filter;
       groupBy?: Tabulation.GroupBy;
-      ballotCountBreakdown: Tabulation.BallotCountBreakdown;
     }) {
       apiClient.exportBallotCountReportCsv
-        .expectCallWith({ path, groupBy, filter, ballotCountBreakdown })
+        .expectCallWith({ path, groupBy, filter })
         .resolves(ok([]));
     },
 

--- a/libs/types/src/tabulation.ts
+++ b/libs/types/src/tabulation.ts
@@ -207,5 +207,3 @@ export interface ScannerBatch {
 }
 
 export const BATCH_ID_DISPLAY_LENGTH = 8;
-
-export type BallotCountBreakdown = 'none' | 'manual' | 'all';

--- a/libs/ui/src/reports/ballot_count_report.stories.tsx
+++ b/libs/ui/src/reports/ballot_count_report.stories.tsx
@@ -71,7 +71,6 @@ const precinctCardCountsList: Tabulation.GroupList<Tabulation.CardCounts> =
   );
 
 const precinctReportArgs: BallotCountReportProps = {
-  ballotCountBreakdown: 'none',
   title: 'Official Full Election Ballot Count Report',
   testId: 'tally-report',
   electionDefinition: electionWithMsEitherNeitherDefinition,
@@ -103,7 +102,6 @@ const primaryPrecinctCardCountsList: Tabulation.GroupList<Tabulation.CardCounts>
   );
 
 const primaryPrecinctReportArgs: BallotCountReportProps = {
-  ballotCountBreakdown: 'none',
   title: 'Official Full Election Ballot Count Report',
   testId: 'tally-report',
   electionDefinition: {
@@ -138,7 +136,6 @@ const votingMethodCardCountsList: Tabulation.GroupList<Tabulation.CardCounts> =
   ];
 
 const votingMethodReportArgs: BallotCountReportProps = {
-  ballotCountBreakdown: 'none',
   title: 'Full Election Ballot Count Report',
   testId: 'tally-report',
   electionDefinition: electionTwoPartyPrimaryDefinition,
@@ -158,7 +155,6 @@ const noGroupsCardCountsList: Tabulation.GroupList<Tabulation.CardCounts> = [
 ];
 
 const noGroupsReportArgs: BallotCountReportProps = {
-  ballotCountBreakdown: 'none',
   title: 'Full Election Ballot Count Report',
   testId: 'tally-report',
   electionDefinition: electionTwoPartyPrimaryDefinition,
@@ -176,7 +172,6 @@ const singleGroupCardCountsList: Tabulation.GroupList<Tabulation.CardCounts> = [
 ];
 
 const singleGroupReportArgs: BallotCountReportProps = {
-  ballotCountBreakdown: 'none',
   title: 'Full Election Ballot Count Report',
   testId: 'tally-report',
   electionDefinition: electionTwoPartyPrimaryDefinition,
@@ -253,7 +248,6 @@ const maxCardCountsList: Tabulation.GroupList<Tabulation.CardCounts> = (() => {
 })();
 
 const maxReportArgs: BallotCountReportProps = {
-  ballotCountBreakdown: 'none',
   title: 'Official Full Election Ballot Count Report',
   testId: 'tally-report',
   electionDefinition: {


### PR DESCRIPTION
## Overview

@mattroe and I discussed how our policy with manual results is that we _always_ show them separately on reports where they contribute to the overall ballot count or vote count. This is what we do for the tally reports - if there are any manual results, the reports flip to show manual counts.

When I built the ballot count reporting (PDF and CSV), I included options to show the ballot count breakdown differently. 'none' would never show manual counts, and 'manual' would always show manual counts. This is in violation of our decided policy.

In this PR, I simply remove the idea the ballot count breakdown as an editable feature - it is always the maximal option - BMD, HMPB, Total and, if applicable, Manual.
