### PR TITLE
Manual Tally Policy - CSV Tally Reports

### DIFF
--- a/apps/admin/backend/src/app.tally_report_csv_export.test.ts
+++ b/apps/admin/backend/src/app.tally_report_csv_export.test.ts
@@ -354,7 +354,7 @@ it('incorporates wia and manual data (grouping by voting method)', async () => {
   // adjudicated write-in candidate counts
   expect(
     rowExists(rowsFinal, {
-      selection: writeInCandidate.name,
+      selection: `${writeInCandidate.name} (Write-In)`,
       selectionId: writeInCandidate.id,
       votingMethod: 'Precinct',
       manualVotes: 0,
@@ -364,7 +364,7 @@ it('incorporates wia and manual data (grouping by voting method)', async () => {
   ).toBeTruthy();
   expect(
     rowExists(rowsFinal, {
-      selection: writeInCandidate.name,
+      selection: `${writeInCandidate.name} (Write-In)`,
       selectionId: writeInCandidate.id,
       votingMethod: 'Absentee',
       manualVotes: 5,
@@ -376,7 +376,7 @@ it('incorporates wia and manual data (grouping by voting method)', async () => {
   // manual-only write-in candidate counts
   expect(
     rowExists(rowsFinal, {
-      selection: manualOnlyWriteInCandidate.name,
+      selection: `${manualOnlyWriteInCandidate.name} (Write-In)`,
       selectionId: manualOnlyWriteInCandidate.id,
       votingMethod: 'Absentee',
       manualVotes: 5,

--- a/apps/admin/backend/src/app.tally_report_csv_export.test.ts
+++ b/apps/admin/backend/src/app.tally_report_csv_export.test.ts
@@ -98,7 +98,7 @@ it('exports expected results for full election', async () => {
     'Contest ID',
     'Selection',
     'Selection ID',
-    'Votes',
+    'Total Votes',
   ]);
 
   const bestAnimalMammalExpectedValues: Record<string, string> = {
@@ -191,7 +191,7 @@ it('incorporates wia and manual data', async () => {
       (row) =>
         row['Selection ID'] === selectionId &&
         row['Voting Method'] === votingMethod &&
-        row['Votes'] === votes.toString()
+        row['Total Votes'] === votes.toString()
     );
   }
 

--- a/apps/admin/backend/src/app.tally_report_csv_export.test.ts
+++ b/apps/admin/backend/src/app.tally_report_csv_export.test.ts
@@ -160,7 +160,7 @@ it('logs failure if export fails for some reason', async () => {
   );
 });
 
-it('incorporates wia and manual data', async () => {
+it('incorporates wia and manual data (grouping by voting method)', async () => {
   const { electionDefinition, castVoteRecordExport } =
     electionGridLayoutNewHampshireAmherstFixtures;
   const { election } = electionDefinition;
@@ -180,60 +180,86 @@ it('incorporates wia and manual data', async () => {
   const candidateContestId =
     'State-Representatives-Hillsborough-District-34-b1012d38';
   const officialCandidateId = 'Obadiah-Carrigan-5c95145a';
+  const officialCandidateName = 'Obadiah Carrigan';
 
   function rowExists(
     rows: ReturnType<typeof parseCsv>['rows'],
-    selectionId: string,
-    votingMethod: string,
-    votes: number
+    {
+      selection,
+      selectionId,
+      votingMethod,
+      totalVotes,
+      scannedVotes,
+      manualVotes,
+    }: {
+      selection: string;
+      selectionId: string;
+      votingMethod: string;
+      totalVotes: number;
+      scannedVotes?: number;
+      manualVotes?: number;
+    }
   ): boolean {
     return rows.some(
       (row) =>
+        row['Selection'] === selection &&
         row['Selection ID'] === selectionId &&
         row['Voting Method'] === votingMethod &&
-        row['Total Votes'] === votes.toString()
+        row['Total Votes'] === totalVotes.toString() &&
+        (!scannedVotes || row['Scanned Votes'] === scannedVotes.toString()) &&
+        (!manualVotes || row['Manual Votes'] === manualVotes.toString())
     );
   }
 
   // check initial export, without wia and manual data
-  const { rows: rowsInitial } = await getParsedExport({
+  const { headers: headersInitial, rows: rowsInitial } = await getParsedExport({
     apiClient,
     groupBy,
   });
+  expect(headersInitial).toEqual([
+    'Voting Method',
+    'Contest',
+    'Contest ID',
+    'Selection',
+    'Selection ID',
+    'Total Votes',
+  ]);
 
   // initial official candidate counts
   expect(
-    rowExists(rowsInitial, officialCandidateId, 'Precinct', 30)
+    rowExists(rowsInitial, {
+      selection: officialCandidateName,
+      selectionId: officialCandidateId,
+      votingMethod: 'Precinct',
+      totalVotes: 30,
+    })
   ).toBeTruthy();
   expect(
-    rowExists(rowsInitial, officialCandidateId, 'Absentee', 30)
+    rowExists(rowsInitial, {
+      selection: officialCandidateName,
+      selectionId: officialCandidateId,
+      votingMethod: 'Precinct',
+      totalVotes: 30,
+    })
   ).toBeTruthy();
 
   // initial generic write-in counts
-  expect(rowExists(rowsInitial, 'write-in', 'Absentee', 28)).toBeTruthy();
-  expect(rowExists(rowsInitial, 'write-in', 'Precinct', 28)).toBeTruthy();
-
-  // add manual data
-  await apiClient.setManualResults({
-    precinctId: election.precincts[0]!.id,
-    votingMethod: 'absentee',
-    ballotStyleId: election.ballotStyles[0]!.id,
-    manualResults: buildManualResultsFixture({
-      election,
-      ballotCount: 10,
-      contestResultsSummaries: {
-        [candidateContestId]: {
-          type: 'candidate',
-          ballots: 10,
-          overvotes: 0,
-          undervotes: 0,
-          officialOptionTallies: {
-            [officialCandidateId]: 10,
-          },
-        },
-      },
-    }),
-  });
+  expect(
+    rowExists(rowsInitial, {
+      selection: Tabulation.PENDING_WRITE_IN_NAME,
+      selectionId: Tabulation.PENDING_WRITE_IN_ID,
+      votingMethod: 'Precinct',
+      totalVotes: 28,
+    })
+  ).toBeTruthy();
+  expect(
+    rowExists(rowsInitial, {
+      selection: Tabulation.PENDING_WRITE_IN_NAME,
+      selectionId: Tabulation.PENDING_WRITE_IN_ID,
+      votingMethod: 'Absentee',
+      totalVotes: 28,
+    })
+  ).toBeTruthy();
 
   // adjudicate write-ins for unofficial candidate
   const writeInCandidate = await apiClient.addWriteInCandidate({
@@ -251,34 +277,120 @@ it('incorporates wia and manual data', async () => {
     });
   }
 
+  // add manual data
+  const manualOnlyWriteInCandidate = await apiClient.addWriteInCandidate({
+    contestId: candidateContestId,
+    name: 'Ms. Bean',
+  });
+  await apiClient.setManualResults({
+    precinctId: election.precincts[0]!.id,
+    votingMethod: 'absentee',
+    ballotStyleId: election.ballotStyles[0]!.id,
+    manualResults: buildManualResultsFixture({
+      election,
+      ballotCount: 20,
+      contestResultsSummaries: {
+        [candidateContestId]: {
+          type: 'candidate',
+          ballots: 20,
+          overvotes: 0,
+          undervotes: 0,
+          officialOptionTallies: {
+            [officialCandidateId]: 10,
+          },
+          writeInOptionTallies: {
+            [writeInCandidate.id]: {
+              name: writeInCandidate.name,
+              tally: 5,
+            },
+            [manualOnlyWriteInCandidate.id]: {
+              name: manualOnlyWriteInCandidate.name,
+              tally: 5,
+            },
+          },
+        },
+      },
+    }),
+  });
+
   // check final export, with wia and manual data
-  const { rows: rowsFinal } = await getParsedExport({
+  const { headers: headersFinal, rows: rowsFinal } = await getParsedExport({
     apiClient,
     groupBy,
   });
+  expect(headersFinal).toEqual([
+    'Voting Method',
+    'Contest',
+    'Contest ID',
+    'Selection',
+    'Selection ID',
+    'Manual Votes',
+    'Scanned Votes',
+    'Total Votes',
+  ]);
 
   // final official candidate counts
   expect(
-    rowExists(rowsFinal, officialCandidateId, 'Precinct', 30)
+    rowExists(rowsFinal, {
+      selection: officialCandidateName,
+      selectionId: officialCandidateId,
+      votingMethod: 'Precinct',
+      manualVotes: 0,
+      scannedVotes: 30,
+      totalVotes: 30,
+    })
   ).toBeTruthy();
   expect(
-    rowExists(rowsFinal, officialCandidateId, 'Absentee', 40)
+    rowExists(rowsFinal, {
+      selection: officialCandidateName,
+      selectionId: officialCandidateId,
+      votingMethod: 'Absentee',
+      manualVotes: 10,
+      scannedVotes: 30,
+      totalVotes: 40,
+    })
   ).toBeTruthy(); // manual data reflected
 
-  // added write-in candidate counts
+  // adjudicated write-in candidate counts
   expect(
-    rowExists(rowsFinal, writeInCandidate.id, 'Absentee', 28)
+    rowExists(rowsFinal, {
+      selection: writeInCandidate.name,
+      selectionId: writeInCandidate.id,
+      votingMethod: 'Precinct',
+      manualVotes: 0,
+      scannedVotes: 28,
+      totalVotes: 28,
+    })
   ).toBeTruthy();
   expect(
-    rowExists(rowsFinal, writeInCandidate.id, 'Precinct', 28)
+    rowExists(rowsFinal, {
+      selection: writeInCandidate.name,
+      selectionId: writeInCandidate.id,
+      votingMethod: 'Absentee',
+      manualVotes: 5,
+      scannedVotes: 28,
+      totalVotes: 33,
+    })
   ).toBeTruthy();
 
-  // generic write-in counts should be gone
+  // manual-only write-in candidate counts
+  expect(
+    rowExists(rowsFinal, {
+      selection: manualOnlyWriteInCandidate.name,
+      selectionId: manualOnlyWriteInCandidate.id,
+      votingMethod: 'Absentee',
+      manualVotes: 5,
+      scannedVotes: 0,
+      totalVotes: 5,
+    })
+  ).toBeTruthy();
+
+  // pending write-in counts should be gone
   expect(
     rowsFinal.some(
       (r) =>
         r['Contest ID'] === candidateContestId &&
-        r['Selection ID'] === 'write-in'
+        r['Selection ID'] === Tabulation.PENDING_WRITE_IN_ID
     )
   ).toBeFalsy();
 });

--- a/apps/admin/backend/src/app.tally_reports.test.ts
+++ b/apps/admin/backend/src/app.tally_reports.test.ts
@@ -8,7 +8,7 @@ import {
   getFeatureFlagMock,
 } from '@votingworks/utils';
 import { assert, find } from '@votingworks/basics';
-import { writeInCandidate } from '@votingworks/types';
+import { Tabulation } from '@votingworks/types';
 import {
   buildTestEnvironment,
   configureMachine,
@@ -261,9 +261,9 @@ test('general, reports by voting method, manual data', async () => {
           type: 'candidate',
           ballots: 10,
           writeInOptionTallies: {
-            [writeInCandidate.id]: {
+            [Tabulation.GENERIC_WRITE_IN_ID]: {
               tally: 10,
-              name: writeInCandidate.name,
+              name: Tabulation.GENERIC_WRITE_IN_NAME,
             },
           },
         },

--- a/apps/admin/backend/src/exports/batch_results.test.ts
+++ b/apps/admin/backend/src/exports/batch_results.test.ts
@@ -1,5 +1,5 @@
 import { electionTwoPartyPrimaryDefinition } from '@votingworks/fixtures';
-import { Tabulation, writeInCandidate } from '@votingworks/types';
+import { Tabulation } from '@votingworks/types';
 import { buildElectionResultsFixture } from '@votingworks/utils';
 import { Buffer } from 'buffer';
 import { generateBatchResultsFile } from './batch_results';
@@ -22,7 +22,7 @@ test('generateBatchResultsFile', async () => {
           overvotes: 3,
           officialOptionTallies: {
             lion: 25,
-            [writeInCandidate.id]: 5,
+            [Tabulation.GENERIC_WRITE_IN_ID]: 5,
           },
         },
         fishing: {
@@ -50,7 +50,7 @@ test('generateBatchResultsFile', async () => {
           overvotes: 3,
           officialOptionTallies: {
             lion: 20,
-            [writeInCandidate.id]: 6,
+            [Tabulation.GENERIC_WRITE_IN_ID]: 6,
           },
         },
         fishing: {

--- a/apps/admin/backend/src/exports/batch_results.ts
+++ b/apps/admin/backend/src/exports/batch_results.ts
@@ -65,10 +65,11 @@ function generateResultsRow(
       }
       if (contest.allowWriteIns) {
         contestVoteTotals.push(
-          /* c8 ignore next - trivial fallback case */
+          /* c8 ignore start - trivial fallback case */
           contestResults.tallies[
             Tabulation.GENERIC_WRITE_IN_ID
           ]?.tally.toString() ?? '0'
+          /* c8 ignore end */
         );
       }
     } else if (contest.type === 'yesno') {

--- a/apps/admin/backend/src/exports/batch_results.ts
+++ b/apps/admin/backend/src/exports/batch_results.ts
@@ -1,4 +1,4 @@
-import { Election, Tabulation, writeInCandidate } from '@votingworks/types';
+import { Election, Tabulation } from '@votingworks/types';
 import { assert } from '@votingworks/basics';
 import { Readable } from 'stream';
 import { getBallotCount, groupMapToGroupList } from '@votingworks/utils';
@@ -66,7 +66,9 @@ function generateResultsRow(
       if (contest.allowWriteIns) {
         contestVoteTotals.push(
           /* c8 ignore next - trivial fallback case */
-          contestResults.tallies[writeInCandidate.id]?.tally.toString() ?? '0'
+          contestResults.tallies[
+            Tabulation.GENERIC_WRITE_IN_ID
+          ]?.tally.toString() ?? '0'
         );
       }
     } else if (contest.type === 'yesno') {

--- a/apps/admin/backend/src/exports/csv_tally_report.test.ts
+++ b/apps/admin/backend/src/exports/csv_tally_report.test.ts
@@ -1,6 +1,7 @@
 import { electionTwoPartyPrimaryFixtures } from '@votingworks/fixtures';
 import { DEFAULT_SYSTEM_SETTINGS, Tabulation } from '@votingworks/types';
 import { find } from '@votingworks/basics';
+import { buildManualResultsFixture } from '@votingworks/utils';
 import {
   MockCastVoteRecordFile,
   addMockCvrFileToStore,
@@ -347,4 +348,103 @@ test('does not include results groups when they are excluded by the filter', asy
   expect(
     precinctRows.some((r) => r['Voting Method'] === 'Precinct')
   ).toBeTruthy();
+});
+
+test('incorporates manual data', async () => {
+  const store = Store.memoryStore();
+  const { electionDefinition } = electionTwoPartyPrimaryFixtures;
+  const { election, electionData } = electionDefinition;
+  const electionId = store.addElection({
+    electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+  });
+  store.setCurrentElectionId(electionId);
+
+  // add some mock cast vote records with one vote each
+  const mockCastVoteRecordFile: MockCastVoteRecordFile = [
+    {
+      ballotStyleId: '1M',
+      batchId: 'batch-1',
+      scannerId: 'scanner-1',
+      precinctId: 'precinct-1',
+      votingMethod: 'precinct',
+      votes: {
+        'zoo-council-mammal': ['lion', 'kangaroo', 'elephant'],
+        fishing: ['ban-fishing'],
+      },
+      card: { type: 'bmd' },
+      multiplier: 1,
+    },
+  ];
+  addMockCvrFileToStore({ electionId, mockCastVoteRecordFile, store });
+
+  store.setManualResults({
+    electionId,
+    precinctId: 'precinct-1',
+    ballotStyleId: '1M',
+    votingMethod: 'absentee',
+    manualResults: buildManualResultsFixture({
+      election,
+      ballotCount: 20,
+      contestResultsSummaries: {
+        'zoo-council-mammal': {
+          type: 'candidate',
+          ballots: 20,
+          overvotes: 3,
+          undervotes: 2,
+          officialOptionTallies: {
+            lion: 10,
+            kangaroo: 5,
+          },
+        },
+        fishing: {
+          type: 'yesno',
+          ballots: 20,
+          undervotes: 6,
+          overvotes: 4,
+          yesTally: 1,
+          noTally: 9,
+        },
+      },
+    }),
+  });
+
+  const stream = await generateTallyReportCsv({
+    store,
+  });
+  const fileContents = await streamToString(stream);
+  const { rows } = parseCsv(fileContents);
+  expect(
+    rows
+      .filter((r) => r['Contest ID'] === 'zoo-council-mammal')
+      .map((row) => [
+        row['Selection ID'],
+        row['Manual Votes'],
+        row['Scanned Votes'],
+        row['Total Votes'],
+      ])
+  ).toEqual([
+    ['zebra', '0', '0', '0'],
+    ['lion', '10', '1', '11'],
+    ['kangaroo', '5', '1', '6'],
+    ['elephant', '0', '1', '1'],
+    ['overvotes', '3', '0', '3'],
+    ['undervotes', '2', '0', '2'],
+  ]);
+
+  expect(
+    rows
+      .filter((r) => r['Contest ID'] === 'fishing')
+      .map((row) => [
+        row['Selection ID'],
+        row['Manual Votes'],
+        row['Scanned Votes'],
+        row['Total Votes'],
+      ])
+  ).toEqual([
+    ['ban-fishing', '1', '1', '2'],
+    ['allow-fishing', '9', '0', '9'],
+    ['overvotes', '4', '0', '4'],
+    ['undervotes', '6', '0', '6'],
+  ]);
 });

--- a/apps/admin/backend/src/exports/csv_tally_report.test.ts
+++ b/apps/admin/backend/src/exports/csv_tally_report.test.ts
@@ -39,7 +39,7 @@ test('uses appropriate headers', async () => {
     'Contest ID',
     'Selection',
     'Selection ID',
-    'Votes',
+    'Total Votes',
   ];
 
   const SHARED_ROW_VALUES: Record<string, string> = {
@@ -55,7 +55,7 @@ test('uses appropriate headers', async () => {
     'Contest ID': 'fishing',
     Selection: 'YES',
     'Selection ID': 'ban-fishing',
-    Votes: '1',
+    'Total Votes': '1',
   };
 
   const testCases: Array<{
@@ -211,7 +211,7 @@ test('uses appropriate headers', async () => {
 
     const row = find(
       rows,
-      (r) => r['Votes'] === '1' && r['Selection ID'] === 'ban-fishing'
+      (r) => r['Total Votes'] === '1' && r['Selection ID'] === 'ban-fishing'
     );
     const expectedAttributes: Record<string, string> = {
       ...SHARED_ROW_VALUES,

--- a/apps/admin/backend/src/exports/csv_tally_report.ts
+++ b/apps/admin/backend/src/exports/csv_tally_report.ts
@@ -1,6 +1,5 @@
 import { stringify } from 'csv-stringify/sync';
 import {
-  writeInCandidate,
   Contest,
   Tabulation,
   ElectionDefinition,
@@ -133,13 +132,14 @@ function* generateDataRows({
 
         // generic write-in row
         if (contest.allowWriteIns) {
-          const votes = contestResults.tallies[writeInCandidate.id]?.tally ?? 0;
+          const votes =
+            contestResults.tallies[Tabulation.GENERIC_WRITE_IN_ID]?.tally ?? 0;
           if (votes) {
             yield buildRow({
               metadataValues,
               contest,
-              selection: writeInCandidate.name,
-              selectionId: writeInCandidate.id,
+              selection: Tabulation.GENERIC_WRITE_IN_NAME,
+              selectionId: Tabulation.GENERIC_WRITE_IN_ID,
               votes,
             });
           }

--- a/apps/admin/backend/src/tabulation/full_results.test.ts
+++ b/apps/admin/backend/src/tabulation/full_results.test.ts
@@ -437,7 +437,6 @@ test('tabulateElectionResults - write-in handling', async () => {
           'Obadiah-Carrigan-5c95145a': 61,
           'Samuel-Bell-17973275': 56,
           'Samuel-Livermore-f927fef1': 56,
-          'write-in': 50,
         },
         writeInOptionTallies: {
           [writeInCandidate1.id]: {
@@ -448,10 +447,14 @@ test('tabulateElectionResults - write-in handling', async () => {
             name: 'Ms. Tomato',
             tally: 1,
           },
+          [Tabulation.PENDING_WRITE_IN_ID]: {
+            name: Tabulation.PENDING_WRITE_IN_NAME,
+            tally: 50,
+          },
         },
       },
     },
-    includeGenericWriteIn: true,
+    includeGenericWriteIn: false,
   });
 
   expect(overallResultsScreenWiaData.cardCounts).toEqual(
@@ -535,7 +538,6 @@ test('tabulateElectionResults - write-in handling', async () => {
             'Obadiah-Carrigan-5c95145a': 61,
             'Samuel-Bell-17973275': 56,
             'Samuel-Livermore-f927fef1': 56,
-            'write-in': 50,
           },
           writeInOptionTallies: {
             [writeInCandidate1.id]: {
@@ -550,10 +552,14 @@ test('tabulateElectionResults - write-in handling', async () => {
               name: 'New Kid',
               tally: 2,
             },
+            [Tabulation.PENDING_WRITE_IN_ID]: {
+              name: Tabulation.PENDING_WRITE_IN_NAME,
+              tally: 50,
+            },
           },
         },
       },
-      includeGenericWriteIn: true,
+      includeGenericWriteIn: false,
     });
 
   expect(overallResultsScreenAndManualWiaData.cardCounts).toEqual(

--- a/apps/admin/backend/src/tabulation/full_results.ts
+++ b/apps/admin/backend/src/tabulation/full_results.ts
@@ -152,6 +152,7 @@ export async function tabulateElectionResults({
           });
         }
       );
+      /* c8 ignore next 3 - debug only */
     } else {
       debug('filter or group by is not compatible with manual results');
     }

--- a/apps/admin/backend/src/tabulation/write_ins.test.ts
+++ b/apps/admin/backend/src/tabulation/write_ins.test.ts
@@ -3,11 +3,7 @@ import {
   electionTwoPartyPrimaryDefinition,
   electionTwoPartyPrimaryFixtures,
 } from '@votingworks/fixtures';
-import {
-  DEFAULT_SYSTEM_SETTINGS,
-  Tabulation,
-  writeInCandidate,
-} from '@votingworks/types';
+import { DEFAULT_SYSTEM_SETTINGS, Tabulation } from '@votingworks/types';
 import { getEmptyElectionResults } from '@votingworks/utils';
 import {
   convertContestWriteInSummaryToWriteInTallies,
@@ -368,8 +364,8 @@ test('modifyElectionResultsWithWriteInSummary', () => {
         name: 'Lion',
         tally: 56,
       },
-      [writeInCandidate.id]: {
-        ...writeInCandidate,
+      [Tabulation.GENERIC_WRITE_IN_ID]: {
+        ...Tabulation.GENERIC_WRITE_IN_CANDIDATE,
         tally: 56,
       },
     },
@@ -405,7 +401,7 @@ test('modifyElectionResultsWithWriteInSummary', () => {
       'write-in': {
         id: 'write-in',
         isWriteIn: true,
-        name: 'Write-In',
+        name: 'Pending Write-In',
         tally: 11,
       },
     },

--- a/apps/admin/backend/src/tabulation/write_ins.test.ts
+++ b/apps/admin/backend/src/tabulation/write_ins.test.ts
@@ -401,7 +401,7 @@ test('modifyElectionResultsWithWriteInSummary', () => {
       'write-in': {
         id: 'write-in',
         isWriteIn: true,
-        name: 'Pending Write-In',
+        name: 'Unadjudicated Write-In',
         tally: 11,
       },
     },

--- a/apps/admin/backend/src/tabulation/write_ins.ts
+++ b/apps/admin/backend/src/tabulation/write_ins.ts
@@ -262,10 +262,10 @@ export function modifyElectionResultsWithWriteInSummary(
             (contestWriteInSummary.candidateTallies[candidateId]?.tally ?? 0),
         };
       } else {
-        // the generic write-in candidate now only represents pending write-ins
+        // include the pending write-in count as a "pending write-in candidate"
         if (contestWriteInSummary.pendingTally > 0) {
           modifiedCandidateTallies[candidateId] = {
-            ...candidateTally,
+            ...Tabulation.PENDING_WRITE_IN_CANDIDATE,
             tally: contestWriteInSummary.pendingTally,
           };
         }

--- a/apps/admin/integration-testing/e2e/reports.spec.ts-snapshots/viewing-and-exporting-reports-1-chromium-linux.dat
+++ b/apps/admin/integration-testing/e2e/reports.spec.ts-snapshots/viewing-and-exporting-reports-1-chromium-linux.dat
@@ -1,4 +1,4 @@
-Contest,Contest ID,Selection,Selection ID,Votes
+Contest,Contest ID,Selection,Selection ID,Total Votes
 Best Animal,best-animal-mammal,Horse,horse,4
 Best Animal,best-animal-mammal,Otter,otter,4
 Best Animal,best-animal-mammal,Fox,fox,36

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -142,11 +142,6 @@ export const WriteInCandidateSchema: z.ZodSchema<WriteInCandidate> = z.object({
   partyIds: z.array(PartyIdSchema).optional(),
 });
 
-export const writeInCandidate: Candidate = {
-  id: 'write-in',
-  name: 'Write-In',
-  isWriteIn: true,
-};
 export type OptionalCandidate = Optional<Candidate>;
 export const OptionalCandidateSchema: z.ZodSchema<OptionalCandidate> =
   CandidateSchema.optional();

--- a/libs/types/src/tabulation.ts
+++ b/libs/types/src/tabulation.ts
@@ -198,6 +198,32 @@ export interface ElectionWriteInSummary {
   contestWriteInSummaries: Record<ContestId, ContestWriteInSummary>;
 }
 
+/** ID for an unadjudicated write-in */
+export const GENERIC_WRITE_IN_ID = 'write-in';
+/** Placeholder name for an unadjudicated write-in */
+export const GENERIC_WRITE_IN_NAME = 'Write-In';
+/**
+ * Represents an unadjudicated write-in, which ultimately may not be a vote
+ * for a candidate.
+ */
+export const GENERIC_WRITE_IN_CANDIDATE: Candidate = {
+  id: GENERIC_WRITE_IN_ID,
+  name: GENERIC_WRITE_IN_NAME,
+  isWriteIn: true,
+};
+
+export const PENDING_WRITE_IN_ID = GENERIC_WRITE_IN_ID;
+export const PENDING_WRITE_IN_NAME = 'Unadjudicated Write-In';
+/**
+ * Represents a pending write-in, which ultimately may not be a vote for a
+ * candidate. Distinguished
+ */
+export const PENDING_WRITE_IN_CANDIDATE: Candidate = {
+  id: PENDING_WRITE_IN_ID,
+  name: PENDING_WRITE_IN_NAME,
+  isWriteIn: true,
+};
+
 /**
  * Minimal information about a scanner batch.
  */

--- a/libs/utils/src/compressed_tallies.test.ts
+++ b/libs/utils/src/compressed_tallies.test.ts
@@ -1,8 +1,4 @@
-import {
-  CandidateContest,
-  Tabulation,
-  writeInCandidate,
-} from '@votingworks/types';
+import { CandidateContest, Tabulation } from '@votingworks/types';
 import {
   electionTwoPartyPrimaryDefinition,
   electionGeneralDefinition,
@@ -50,7 +46,7 @@ describe('compressTally', () => {
     for (const [idx, candidate] of presidentContest.candidates.entries()) {
       officialOptionTallies[candidate.id] = idx * 2;
     }
-    officialOptionTallies[writeInCandidate.id] = 5;
+    officialOptionTallies[Tabulation.GENERIC_WRITE_IN_ID] = 5;
 
     const resultsWithPresidentTallies = buildElectionResultsFixture({
       election: electionEitherNeither,
@@ -181,8 +177,8 @@ describe('readCompressTally', () => {
       ...presidentContest.candidates.find((c) => c.id === '775031989')!,
       tally: 4,
     });
-    expect(presidentTally.tallies[writeInCandidate.id]).toEqual({
-      ...writeInCandidate,
+    expect(presidentTally.tallies[Tabulation.GENERIC_WRITE_IN_ID]).toEqual({
+      ...Tabulation.GENERIC_WRITE_IN_CANDIDATE,
       tally: 5,
     });
   });
@@ -239,7 +235,7 @@ describe('readCompressTally', () => {
       tally: 2,
     });
     expect(Object.keys(presidentTally.tallies)).not.toContain(
-      writeInCandidate.id
+      Tabulation.GENERIC_WRITE_IN_ID
     );
   });
 

--- a/libs/utils/src/compressed_tallies.ts
+++ b/libs/utils/src/compressed_tallies.ts
@@ -7,7 +7,6 @@ import {
   Election,
   Tabulation,
   unsafeParse,
-  writeInCandidate,
   YesNoContestCompressedTally,
   YesNoContestCompressedTallySchema,
 } from '@votingworks/types';
@@ -45,7 +44,7 @@ export function compressTally(
           ...contest.candidates.map(
             (candidate) => contestResults?.tallies[candidate.id]?.tally ?? 0
           ),
-          contestResults?.tallies[writeInCandidate.id]?.tally ?? 0, // writeIns
+          contestResults?.tallies[Tabulation.GENERIC_WRITE_IN_ID]?.tally ?? 0, // writeIns
         ]);
       }
 
@@ -104,8 +103,8 @@ function getContestTalliesForCompressedContest(
         // write ins will be the last thing in the array after the metadata (3 items) and all candidates
         const writeInTally = tallyByCandidate.pop();
         assert(writeInTally !== undefined);
-        candidateTallies[writeInCandidate.id] = {
-          ...writeInCandidate,
+        candidateTallies[Tabulation.GENERIC_WRITE_IN_ID] = {
+          ...Tabulation.GENERIC_WRITE_IN_CANDIDATE,
           tally: writeInTally,
         };
       }

--- a/libs/utils/src/tabulation/index.ts
+++ b/libs/utils/src/tabulation/index.ts
@@ -2,4 +2,5 @@ export * from './arguments';
 export * from './contest_filtering';
 export * from './lookups';
 export * from './tabulation';
+export * from './tally_reports';
 export * from './transformations';

--- a/libs/utils/src/tabulation/tabulation.test.ts
+++ b/libs/utils/src/tabulation/tabulation.test.ts
@@ -8,7 +8,6 @@ import { assert, assertDefined, find, typedAs } from '@votingworks/basics';
 import {
   CVR,
   Tabulation,
-  writeInCandidate,
   YesNoContest,
   safeParseJson,
   CastVoteRecordExportFileName,
@@ -440,7 +439,7 @@ test('buildElectionResultsFixture', () => {
       'zoo-council-mammal'
     ] as Tabulation.CandidateContestResults;
   expect(
-    zooCouncilMammalWithGenericWriteIn.tallies[writeInCandidate.id]
+    zooCouncilMammalWithGenericWriteIn.tallies[Tabulation.GENERIC_WRITE_IN_ID]
   ).toBeDefined();
 
   // check that manual results fixture matches the regular election fixture
@@ -1259,8 +1258,8 @@ test('mergeManualWriteInTallies', () => {
             elephant: 4,
           },
           writeInOptionTallies: {
-            [writeInCandidate.id]: {
-              name: writeInCandidate.name,
+            [Tabulation.GENERIC_WRITE_IN_ID]: {
+              name: Tabulation.GENERIC_WRITE_IN_NAME,
               tally: 5,
             },
           },

--- a/libs/utils/src/tabulation/tabulation.ts
+++ b/libs/utils/src/tabulation/tabulation.ts
@@ -11,7 +11,6 @@ import {
   PartyId,
   Tabulation,
   YesNoContest,
-  writeInCandidate,
 } from '@votingworks/types';
 import { isGroupByEmpty } from './arguments';
 
@@ -51,8 +50,8 @@ export function getEmptyCandidateContestResults(
   }
 
   if (contest.allowWriteIns && includeGenericWriteInIfAllowed) {
-    tallies[writeInCandidate.id] = {
-      ...writeInCandidate,
+    tallies[Tabulation.GENERIC_WRITE_IN_ID] = {
+      ...Tabulation.GENERIC_WRITE_IN_CANDIDATE,
       tally: 0,
     };
   }
@@ -171,7 +170,7 @@ function addCastVoteRecordToElectionResult(
       for (const optionId of optionIds) {
         if (optionId.startsWith('write-in-')) {
           const genericWriteInTally = assertDefined(
-            contestResult.tallies[writeInCandidate.id]
+            contestResult.tallies[Tabulation.GENERIC_WRITE_IN_ID]
           );
           genericWriteInTally.tally += 1;
         } else {
@@ -885,8 +884,8 @@ export function mergeWriteInTallies<
     }
 
     if (writeInTally > 0) {
-      newTallies[writeInCandidate.id] = {
-        ...writeInCandidate,
+      newTallies[Tabulation.GENERIC_WRITE_IN_ID] = {
+        ...Tabulation.GENERIC_WRITE_IN_CANDIDATE,
         tally: writeInTally,
       };
     }

--- a/libs/utils/src/tabulation/tabulation.ts
+++ b/libs/utils/src/tabulation/tabulation.ts
@@ -541,7 +541,9 @@ export function combineCandidateContestResults({
         combinedContestResults.tallies[candidateTally.id];
 
       if (!combinedCandidateTally) {
-        combinedContestResults.tallies[candidateTally.id] = candidateTally;
+        combinedContestResults.tallies[candidateTally.id] = {
+          ...candidateTally,
+        };
       } else {
         combinedCandidateTally.tally += candidateTally.tally;
       }

--- a/libs/utils/src/tabulation/tally_reports.test.ts
+++ b/libs/utils/src/tabulation/tally_reports.test.ts
@@ -1,0 +1,99 @@
+import { electionTwoPartyPrimaryFixtures } from '@votingworks/fixtures';
+import { find } from '@votingworks/basics';
+import { CandidateContest, Tabulation } from '@votingworks/types';
+import { buildContestResultsFixture } from './tabulation';
+import {
+  getTallyReportCandidateRows,
+  shorthandTallyReportCandidateRow,
+} from './tally_reports';
+
+const { electionDefinition } = electionTwoPartyPrimaryFixtures;
+const { election } = electionDefinition;
+
+const contestId = 'zoo-council-mammal';
+const contest = find(
+  election.contests,
+  (c) => c.id === contestId
+) as CandidateContest;
+
+test('getTallyReportRows', () => {
+  const scannedContestResults = buildContestResultsFixture({
+    contest,
+    includeGenericWriteIn: false,
+    contestResultsSummary: {
+      type: 'candidate',
+      ballots: 50,
+      officialOptionTallies: {
+        zebra: 40,
+      },
+      writeInOptionTallies: {
+        'write-in-1': {
+          name: 'Write-In 1',
+          tally: 5,
+        },
+        'write-in-2': {
+          name: 'Write-In 2',
+          tally: 5,
+        },
+        [Tabulation.PENDING_WRITE_IN_ID]: {
+          ...Tabulation.PENDING_WRITE_IN_CANDIDATE,
+          tally: 1,
+        },
+      },
+    },
+  }) as Tabulation.CandidateContestResults;
+
+  const manualContestResults = buildContestResultsFixture({
+    contest,
+    includeGenericWriteIn: false,
+    contestResultsSummary: {
+      type: 'candidate',
+      ballots: 50,
+      officialOptionTallies: {
+        zebra: 20,
+        lion: 20,
+      },
+      writeInOptionTallies: {
+        'write-in-1': {
+          name: 'Write-In 1',
+          tally: 5,
+        },
+        'write-in-3': {
+          name: 'Write-In 3',
+          tally: 5,
+        },
+      },
+    },
+  }) as Tabulation.CandidateContestResults;
+
+  expect(
+    getTallyReportCandidateRows({ contest, scannedContestResults }).map(
+      shorthandTallyReportCandidateRow
+    )
+  ).toEqual([
+    ['zebra', 'Zebra', 40, 0],
+    ['lion', 'Lion', 0, 0],
+    ['kangaroo', 'Kangaroo', 0, 0],
+    ['elephant', 'Elephant', 0, 0],
+    ['write-in-1', 'Write-In 1', 5, 0],
+    ['write-in-2', 'Write-In 2', 5, 0],
+    ['write-in', 'Unadjudicated Write-In', 1, 0],
+  ]);
+
+  expect(
+    getTallyReportCandidateRows({
+      contest,
+      scannedContestResults,
+      manualContestResults,
+    }).map(shorthandTallyReportCandidateRow)
+  ).toEqual([
+    ['zebra', 'Zebra', 40, 20],
+    ['lion', 'Lion', 0, 20],
+    ['kangaroo', 'Kangaroo', 0, 0],
+    ['elephant', 'Elephant', 0, 0],
+    ['write-in-1', 'Write-In 1', 5, 5],
+    ['write-in-2', 'Write-In 2', 5, 0],
+    ['write-in-3', 'Write-In 3', 0, 5],
+    ['write-in', 'Unadjudicated Write-In', 1, 0],
+  ]);
+});

--- a/libs/utils/src/tabulation/tally_reports.test.ts
+++ b/libs/utils/src/tabulation/tally_reports.test.ts
@@ -75,8 +75,8 @@ test('getTallyReportRows', () => {
     ['lion', 'Lion', 0, 0],
     ['kangaroo', 'Kangaroo', 0, 0],
     ['elephant', 'Elephant', 0, 0],
-    ['write-in-1', 'Write-In 1', 5, 0],
-    ['write-in-2', 'Write-In 2', 5, 0],
+    ['write-in-1', 'Write-In 1 (Write-In)', 5, 0],
+    ['write-in-2', 'Write-In 2 (Write-In)', 5, 0],
     ['write-in', 'Unadjudicated Write-In', 1, 0],
   ]);
 
@@ -91,9 +91,9 @@ test('getTallyReportRows', () => {
     ['lion', 'Lion', 0, 20],
     ['kangaroo', 'Kangaroo', 0, 0],
     ['elephant', 'Elephant', 0, 0],
-    ['write-in-1', 'Write-In 1', 5, 5],
-    ['write-in-2', 'Write-In 2', 5, 0],
-    ['write-in-3', 'Write-In 3', 0, 5],
+    ['write-in-1', 'Write-In 1 (Write-In)', 5, 5],
+    ['write-in-2', 'Write-In 2 (Write-In)', 5, 0],
+    ['write-in-3', 'Write-In 3 (Write-In)', 0, 5],
     ['write-in', 'Unadjudicated Write-In', 1, 0],
   ]);
 });

--- a/libs/utils/src/tabulation/tally_reports.ts
+++ b/libs/utils/src/tabulation/tally_reports.ts
@@ -1,0 +1,102 @@
+import { Candidate, CandidateContest, Tabulation } from '@votingworks/types';
+import { assertDefined } from '@votingworks/basics';
+import { combineCandidateContestResults } from './tabulation';
+
+type TallyReportCandidateRow = Candidate & {
+  scannedTally: number;
+  manualTally: number;
+};
+
+function isNonCandidateWriteInTally(
+  candidateTally: Tabulation.CandidateTally
+): boolean {
+  return (
+    candidateTally.id === Tabulation.PENDING_WRITE_IN_ID ||
+    candidateTally.id === Tabulation.GENERIC_WRITE_IN_ID
+  );
+}
+
+function getAllWriteInRows({
+  combinedContestResults,
+  scannedContestResults,
+  manualContestResults,
+}: {
+  combinedContestResults: Tabulation.CandidateContestResults;
+  scannedContestResults: Tabulation.CandidateContestResults;
+  manualContestResults?: Tabulation.CandidateContestResults;
+}): TallyReportCandidateRow[] {
+  const rows: TallyReportCandidateRow[] = [];
+  const writeInCandidateTallies: Tabulation.CandidateTally[] = [];
+  const otherWriteInTallies: Tabulation.CandidateTally[] = [];
+
+  for (const candidateTally of Object.values(combinedContestResults.tallies)) {
+    if (candidateTally.isWriteIn) {
+      if (isNonCandidateWriteInTally(candidateTally)) {
+        otherWriteInTallies.push(candidateTally);
+      } else {
+        writeInCandidateTallies.push(candidateTally);
+      }
+    }
+  }
+
+  // list write-in candidates first, then other write-in counts
+  for (const candidateTally of [
+    ...writeInCandidateTallies,
+    ...otherWriteInTallies,
+  ]) {
+    rows.push({
+      ...candidateTally,
+      scannedTally:
+        scannedContestResults.tallies[candidateTally.id]?.tally ?? 0,
+      manualTally: manualContestResults?.tallies[candidateTally.id]?.tally ?? 0,
+    });
+  }
+
+  return rows;
+}
+
+export function getTallyReportCandidateRows({
+  contest,
+  scannedContestResults,
+  manualContestResults,
+}: {
+  contest: CandidateContest;
+  scannedContestResults: Tabulation.CandidateContestResults;
+  manualContestResults?: Tabulation.CandidateContestResults;
+}): TallyReportCandidateRow[] {
+  const combinedContestResults = manualContestResults
+    ? combineCandidateContestResults({
+        contest,
+        allContestResults: [scannedContestResults, manualContestResults],
+      })
+    : scannedContestResults;
+
+  const rows: TallyReportCandidateRow[] = [];
+
+  // official candidates are always listed, in election definition order
+  for (const candidate of contest.candidates) {
+    rows.push({
+      ...candidate,
+      scannedTally: assertDefined(scannedContestResults.tallies[candidate.id])
+        .tally,
+      manualTally: manualContestResults?.tallies[candidate.id]?.tally ?? 0,
+    });
+  }
+
+  rows.push(
+    ...getAllWriteInRows({
+      combinedContestResults,
+      scannedContestResults,
+      manualContestResults,
+    })
+  );
+
+  return rows;
+}
+
+// for testing only
+export function shorthandTallyReportCandidateRow(
+  row: TallyReportCandidateRow
+): [id: string, name: string, scannedTally: number, manualTally: number] {
+  return [row.id, row.name, row.scannedTally, row.manualTally];
+}

--- a/libs/utils/src/tabulation/tally_reports.ts
+++ b/libs/utils/src/tabulation/tally_reports.ts
@@ -16,6 +16,15 @@ function isNonCandidateWriteInTally(
   );
 }
 
+function addWriteInLabelToName(
+  candidateTally: Tabulation.CandidateTally
+): Tabulation.CandidateTally {
+  return {
+    ...candidateTally,
+    name: `${candidateTally.name} (Write-In)`,
+  };
+}
+
 function getAllWriteInRows({
   combinedContestResults,
   scannedContestResults,
@@ -41,7 +50,7 @@ function getAllWriteInRows({
 
   // list write-in candidates first, then other write-in counts
   for (const candidateTally of [
-    ...writeInCandidateTallies,
+    ...writeInCandidateTallies.map(addWriteInLabelToName),
     ...otherWriteInTallies,
   ]) {
     rows.push({

--- a/libs/utils/src/votes.test.ts
+++ b/libs/utils/src/votes.test.ts
@@ -7,8 +7,8 @@ import {
 import {
   BallotTargetMark,
   CandidateContest,
+  Tabulation,
   WriteInCandidate,
-  writeInCandidate,
   YesNoContest,
 } from '@votingworks/types';
 import { find, typedAs } from '@votingworks/basics';
@@ -62,7 +62,9 @@ test('normalizeWriteInId', () => {
   expect(normalizeWriteInId('arandomword')).toEqual('arandomword');
   expect(normalizeWriteInId('writeIn-123')).toEqual('writeIn-123');
   expect(normalizeWriteInId('__write-in-123')).toEqual('__write-in-123');
-  expect(normalizeWriteInId('write-in-123456')).toEqual(writeInCandidate.id);
+  expect(normalizeWriteInId('write-in-123456')).toEqual(
+    Tabulation.GENERIC_WRITE_IN_ID
+  );
 });
 
 const ballotTargetMarkBase: Pick<
@@ -147,7 +149,7 @@ test('markInfoToVotesDict candidate', () => {
       [writeInCandidateForMayorMark]
     )
   ).toEqual({
-    [mayorContest.id]: [writeInCandidate],
+    [mayorContest.id]: [Tabulation.GENERIC_WRITE_IN_CANDIDATE],
   });
   expect(
     convertMarksToVotesDict(

--- a/libs/utils/src/votes.ts
+++ b/libs/utils/src/votes.ts
@@ -10,9 +10,9 @@ import {
   MarkThresholds,
   safeParse,
   safeParseInt,
+  Tabulation,
   Vote,
   VotesDict,
-  writeInCandidate,
   WriteInIdSchema,
   YesNoContest,
   YesNoContestOptionId,
@@ -30,7 +30,7 @@ export function getSingleYesNoVote(
 
 export function normalizeWriteInId(candidateId: CandidateId): string {
   if (candidateId.startsWith('write-in')) {
-    return writeInCandidate.id;
+    return Tabulation.GENERIC_WRITE_IN_ID;
   }
 
   return candidateId;
@@ -55,7 +55,7 @@ export function getContestVoteOptionsForCandidateContest(
 ): readonly Candidate[] {
   const options = contest.candidates;
   if (contest.allowWriteIns) {
-    return options.concat(writeInCandidate);
+    return options.concat(Tabulation.GENERIC_WRITE_IN_CANDIDATE);
   }
   return options;
 }
@@ -103,7 +103,7 @@ function markToCandidateVotes(
     const indexedWriteInMatch = mark.optionId.match(/^write-in-(\d+)$/);
 
     if (!indexedWriteInMatch) {
-      return [writeInCandidate];
+      return [Tabulation.GENERIC_WRITE_IN_CANDIDATE];
     }
 
     const writeInIndex = safeParseInt(indexedWriteInMatch[1]).assertOk(


### PR DESCRIPTION
_review by commit, there's a refactor and bug fix in the log_

## Overview

Closes #4069 alongside #4073. Updates the tally CSV exports so that they split manual and scanned results.

## Demo Video or Screenshot

N/A, example file attached:
[TEST-full-election-tally-report__2023-10-23_13-11-49.csv](https://github.com/votingworks/vxsuite/files/13078796/TEST-full-election-tally-report__2023-10-23_13-11-49.csv)


## Testing Plan

Automated testing.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
