### PR TITLE
[i18n/audio] Replace a few strings in Mark[-Scan] with language-aware versions

### DIFF
--- a/apps/mark-scan/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
+++ b/apps/mark-scan/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
@@ -31,6 +31,14 @@ exports[`Single Seat Contest 1`] = `
   font-size: 0.75rem;
 }
 
+.c23 {
+  font-size: 1em;
+  font-weight: 300;
+  line-height: 1.15;
+  margin: 0;
+  font-size: 0.75rem;
+}
+
 .c21 {
   font-size: 1em;
   line-height: 1.15;
@@ -136,79 +144,6 @@ exports[`Single Seat Contest 1`] = `
 }
 
 .c13[disabled] {
-  border: 0.15rem dashed #222222;
-  box-shadow: none;
-  cursor: not-allowed;
-}
-
-.c24 {
-  display: inline-block;
-  border: none;
-  border-radius: 0.25em;
-  box-sizing: border-box;
-  background: #fafafa;
-  padding: 1em 1.75em;
-  text-align: center;
-  line-height: 1.25;
-  color: #222222;
-  font-size: 1.25em;
-  touch-action: manipulation;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  font-family: inherit;
-  font-size: 1rem;
-  font-weight: 600;
-  gap: 0.5rem;
-  -webkit-letter-spacing: 0.01em;
-  -moz-letter-spacing: 0.01em;
-  -ms-letter-spacing: 0.01em;
-  letter-spacing: 0.01em;
-  line-height: 1.15;
-  padding: 0.5em 0.6em;
-  width: auto;
-  min-height: 70.86614173228345px;
-  vertical-align: middle;
-  background: #fafafa;
-  border: 0.15rem solid #222222;
-  border-radius: 0.25rem;
-  box-shadow: none;
-  color: #222222;
-  cursor: pointer;
-  text-shadow: none;
-  -webkit-transition: 100ms ease-in;
-  transition: 100ms ease-in;
-  -webkit-transition-property: background,border,box-shadow,color;
-  transition-property: background,border,box-shadow,color;
-}
-
-.c24:hover,
-.c24:active {
-  outline: none;
-}
-
-.c24:hover,
-.c24:active {
-  outline: none;
-}
-
-.c24:active {
-  box-shadow: inset 0 0 0 0.15rem #222222;
-}
-
-.c24[disabled] {
   border: 0.15rem dashed #222222;
   box-shadow: none;
   cursor: not-allowed;
@@ -393,7 +328,7 @@ exports[`Single Seat Contest 1`] = `
   justify-content: space-between;
 }
 
-.c23 {
+.c24 {
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -412,7 +347,7 @@ exports[`Single Seat Contest 1`] = `
   padding: 0.5rem;
 }
 
-.c23 > *:not(:first-child,:last-child) {
+.c24 > *:not(:first-child,:last-child) {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -524,20 +459,30 @@ exports[`Single Seat Contest 1`] = `
             <h1
               class="c8"
             >
-              President and Vice-President
+              <span
+                class=""
+              >
+                President and Vice-President
+              </span>
             </h1>
           </div>
           <span
             class="c9"
           >
-            Vote for 
-            1
-            .
+            <span
+              class=""
+            >
+              Vote for 1.
+            </span>
              
             <span
               class="screen-reader-only"
             >
-              To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
+              <span
+                class=""
+              >
+                To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
+              </span>
             </span>
           </span>
         </div>
@@ -594,6 +539,9 @@ exports[`Single Seat Contest 1`] = `
                     >
                       Joseph Barchi and Joseph Hallaren
                     </p>
+                    <span
+                      class="c23"
+                    />
                   </span>
                 </span>
               </span>
@@ -639,6 +587,9 @@ exports[`Single Seat Contest 1`] = `
                     >
                       Adam Cramer and Greg Vuocolo
                     </p>
+                    <span
+                      class="c23"
+                    />
                   </span>
                 </span>
               </span>
@@ -684,6 +635,9 @@ exports[`Single Seat Contest 1`] = `
                     >
                       Daniel Court and Amy Blumhardt
                     </p>
+                    <span
+                      class="c23"
+                    />
                   </span>
                 </span>
               </span>
@@ -729,6 +683,9 @@ exports[`Single Seat Contest 1`] = `
                     >
                       Alvin Boone and James Lian
                     </p>
+                    <span
+                      class="c23"
+                    />
                   </span>
                 </span>
               </span>
@@ -774,6 +731,9 @@ exports[`Single Seat Contest 1`] = `
                     >
                       Ashley Hildebrand-McDougall and James Garritty
                     </p>
+                    <span
+                      class="c23"
+                    />
                   </span>
                 </span>
               </span>
@@ -819,6 +779,9 @@ exports[`Single Seat Contest 1`] = `
                     >
                       Martin Patterson and Clay Lariviere
                     </p>
+                    <span
+                      class="c23"
+                    />
                   </span>
                 </span>
               </span>
@@ -828,11 +791,11 @@ exports[`Single Seat Contest 1`] = `
       </div>
     </main>
     <nav
-      class="c23"
+      class="c24"
     >
       <button
         aria-label="previous contest"
-        class="c24"
+        class="c13"
         id="previous"
         type="button"
       >
@@ -858,7 +821,11 @@ exports[`Single Seat Contest 1`] = `
         <span
           class="c15"
         >
-          Back
+          <span
+            class=""
+          >
+            Back
+          </span>
         </span>
       </button>
       <button
@@ -886,7 +853,9 @@ exports[`Single Seat Contest 1`] = `
                 fill="currentColor"
               />
             </svg>
-            <span>
+            <span
+              class=""
+            >
               Color/Size
             </span>
           </span>
@@ -920,7 +889,11 @@ exports[`Single Seat Contest 1`] = `
         <span
           class="c15"
         >
-          Next
+          <span
+            class=""
+          >
+            Next
+          </span>
         </span>
       </button>
     </nav>

--- a/apps/mark-scan/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
+++ b/apps/mark-scan/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
@@ -149,79 +149,6 @@ exports[`Single Seat Contest 1`] = `
   cursor: not-allowed;
 }
 
-.c28 {
-  display: inline-block;
-  border: none;
-  border-radius: 0.25em;
-  box-sizing: border-box;
-  background: #fafafa;
-  padding: 1em 1.75em;
-  text-align: center;
-  line-height: 1.25;
-  color: #222222;
-  font-size: 1.25em;
-  touch-action: manipulation;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  font-family: inherit;
-  font-size: 1rem;
-  font-weight: 600;
-  gap: 0.5rem;
-  -webkit-letter-spacing: 0.01em;
-  -moz-letter-spacing: 0.01em;
-  -ms-letter-spacing: 0.01em;
-  letter-spacing: 0.01em;
-  line-height: 1.15;
-  padding: 0.5em 0.6em;
-  width: auto;
-  min-height: 70.86614173228345px;
-  vertical-align: middle;
-  background: #fafafa;
-  border: 0.15rem solid #222222;
-  border-radius: 0.25rem;
-  box-shadow: none;
-  color: #222222;
-  cursor: pointer;
-  text-shadow: none;
-  -webkit-transition: 100ms ease-in;
-  transition: 100ms ease-in;
-  -webkit-transition-property: background,border,box-shadow,color;
-  transition-property: background,border,box-shadow,color;
-}
-
-.c28:hover,
-.c28:active {
-  outline: none;
-}
-
-.c28:hover,
-.c28:active {
-  outline: none;
-}
-
-.c28:active {
-  box-shadow: inset 0 0 0 0.15rem #222222;
-}
-
-.c28[disabled] {
-  border: 0.15rem dashed #222222;
-  box-shadow: none;
-  cursor: not-allowed;
-}
-
 .c13 {
   display: inline-block;
   border: none;
@@ -294,7 +221,7 @@ exports[`Single Seat Contest 1`] = `
   cursor: not-allowed;
 }
 
-.c29 {
+.c28 {
   display: inline-block;
 }
 
@@ -545,7 +472,7 @@ exports[`Single Seat Contest 1`] = `
   flex-grow: 1;
 }
 
-.c30 {
+.c29 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -670,27 +597,39 @@ exports[`Single Seat Contest 1`] = `
             <h1
               class="c8"
             >
-              County Commissioners
+              <span
+                class=""
+              >
+                County Commissioners
+              </span>
             </h1>
           </div>
           <span
             class="c9"
           >
-            Vote for 
-            4
-            .
+            <span
+              class=""
+            >
+              Vote for 4.
+            </span>
              
             <span
               class="c7"
             >
-              You have selected 
-              4
-              .
+              <span
+                class=""
+              >
+                You have selected 4.
+              </span>
             </span>
             <span
               class="screen-reader-only"
             >
-              To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
+              <span
+                class=""
+              >
+                To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
+              </span>
             </span>
           </span>
         </div>
@@ -750,7 +689,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      Federalist
+                      <span
+                        class=""
+                      >
+                        Federalist
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -800,7 +743,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      Federalist
+                      <span
+                        class=""
+                      >
+                        Federalist
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -850,7 +797,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      Federalist
+                      <span
+                        class=""
+                      >
+                        Federalist
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -900,7 +851,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      People’s
+                      <span
+                        class=""
+                      >
+                        People’s
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -950,7 +905,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      People’s
+                      <span
+                        class=""
+                      >
+                        People’s
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1000,7 +959,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      People’s
+                      <span
+                        class=""
+                      >
+                        People’s
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1050,7 +1013,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      People’s
+                      <span
+                        class=""
+                      >
+                        People’s
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1100,7 +1067,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      Liberty
+                      <span
+                        class=""
+                      >
+                        Liberty
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1150,7 +1121,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      Constitution
+                      <span
+                        class=""
+                      >
+                        Constitution
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1200,7 +1175,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      Constitution
+                      <span
+                        class=""
+                      >
+                        Constitution
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1250,7 +1229,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      Independent
+                      <span
+                        class=""
+                      >
+                        Independent
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1310,7 +1293,12 @@ exports[`Single Seat Contest 1`] = `
                             fill="currentColor"
                           />
                         </svg>
-                         add write-in candidate
+                         
+                        <span
+                          class=""
+                        >
+                          add write-in candidate
+                        </span>
                       </span>
                     </p>
                   </span>
@@ -1326,12 +1314,12 @@ exports[`Single Seat Contest 1`] = `
     >
       <button
         aria-label="previous contest"
-        class="c28"
+        class="c24"
         id="previous"
         type="button"
       >
         <span
-          class="c29"
+          class="c28"
         >
           <svg
             aria-hidden="true"
@@ -1352,7 +1340,11 @@ exports[`Single Seat Contest 1`] = `
         <span
           class="c15"
         >
-          Back
+          <span
+            class=""
+          >
+            Back
+          </span>
         </span>
       </button>
       <button
@@ -1363,7 +1355,7 @@ exports[`Single Seat Contest 1`] = `
           class="c15"
         >
           <span
-            class="c30"
+            class="c29"
           >
             <svg
               aria-hidden="true"
@@ -1380,7 +1372,9 @@ exports[`Single Seat Contest 1`] = `
                 fill="currentColor"
               />
             </svg>
-            <span>
+            <span
+              class=""
+            >
               Color/Size
             </span>
           </span>
@@ -1393,7 +1387,7 @@ exports[`Single Seat Contest 1`] = `
         type="button"
       >
         <span
-          class="c29"
+          class="c28"
         >
           <svg
             aria-hidden="true"
@@ -1414,7 +1408,11 @@ exports[`Single Seat Contest 1`] = `
         <span
           class="c15"
         >
-          Next
+          <span
+            class=""
+          >
+            Next
+          </span>
         </span>
       </button>
     </nav>

--- a/apps/mark-scan/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
+++ b/apps/mark-scan/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
@@ -149,79 +149,6 @@ exports[`Single Seat Contest 1`] = `
   cursor: not-allowed;
 }
 
-.c28 {
-  display: inline-block;
-  border: none;
-  border-radius: 0.25em;
-  box-sizing: border-box;
-  background: #fafafa;
-  padding: 1em 1.75em;
-  text-align: center;
-  line-height: 1.25;
-  color: #222222;
-  font-size: 1.25em;
-  touch-action: manipulation;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  font-family: inherit;
-  font-size: 1rem;
-  font-weight: 600;
-  gap: 0.5rem;
-  -webkit-letter-spacing: 0.01em;
-  -moz-letter-spacing: 0.01em;
-  -ms-letter-spacing: 0.01em;
-  letter-spacing: 0.01em;
-  line-height: 1.15;
-  padding: 0.5em 0.6em;
-  width: auto;
-  min-height: 70.86614173228345px;
-  vertical-align: middle;
-  background: #fafafa;
-  border: 0.15rem solid #222222;
-  border-radius: 0.25rem;
-  box-shadow: none;
-  color: #222222;
-  cursor: pointer;
-  text-shadow: none;
-  -webkit-transition: 100ms ease-in;
-  transition: 100ms ease-in;
-  -webkit-transition-property: background,border,box-shadow,color;
-  transition-property: background,border,box-shadow,color;
-}
-
-.c28:hover,
-.c28:active {
-  outline: none;
-}
-
-.c28:hover,
-.c28:active {
-  outline: none;
-}
-
-.c28:active {
-  box-shadow: inset 0 0 0 0.15rem #222222;
-}
-
-.c28[disabled] {
-  border: 0.15rem dashed #222222;
-  box-shadow: none;
-  cursor: not-allowed;
-}
-
 .c13 {
   display: inline-block;
   border: none;
@@ -294,7 +221,7 @@ exports[`Single Seat Contest 1`] = `
   cursor: not-allowed;
 }
 
-.c29 {
+.c28 {
   display: inline-block;
 }
 
@@ -545,7 +472,7 @@ exports[`Single Seat Contest 1`] = `
   flex-grow: 1;
 }
 
-.c30 {
+.c29 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -670,27 +597,39 @@ exports[`Single Seat Contest 1`] = `
             <h1
               class="c8"
             >
-              President and Vice-President
+              <span
+                class=""
+              >
+                President and Vice-President
+              </span>
             </h1>
           </div>
           <span
             class="c9"
           >
-            Vote for 
-            1
-            .
+            <span
+              class=""
+            >
+              Vote for 1.
+            </span>
              
             <span
               class="c7"
             >
-              You have selected 
-              1
-              .
+              <span
+                class=""
+              >
+                You have selected 1.
+              </span>
             </span>
             <span
               class="screen-reader-only"
             >
-              To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
+              <span
+                class=""
+              >
+                To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
+              </span>
             </span>
           </span>
         </div>
@@ -750,7 +689,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      Federalist
+                      <span
+                        class=""
+                      >
+                        Federalist
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -800,7 +743,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      People’s
+                      <span
+                        class=""
+                      >
+                        People’s
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -850,7 +797,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      Liberty
+                      <span
+                        class=""
+                      >
+                        Liberty
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -900,7 +851,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      Constitution
+                      <span
+                        class=""
+                      >
+                        Constitution
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -950,7 +905,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      Whig
+                      <span
+                        class=""
+                      >
+                        Whig
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1000,7 +959,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      Labor
+                      <span
+                        class=""
+                      >
+                        Labor
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1015,12 +978,12 @@ exports[`Single Seat Contest 1`] = `
     >
       <button
         aria-label="previous contest"
-        class="c28"
+        class="c24"
         id="previous"
         type="button"
       >
         <span
-          class="c29"
+          class="c28"
         >
           <svg
             aria-hidden="true"
@@ -1041,7 +1004,11 @@ exports[`Single Seat Contest 1`] = `
         <span
           class="c15"
         >
-          Back
+          <span
+            class=""
+          >
+            Back
+          </span>
         </span>
       </button>
       <button
@@ -1052,7 +1019,7 @@ exports[`Single Seat Contest 1`] = `
           class="c15"
         >
           <span
-            class="c30"
+            class="c29"
           >
             <svg
               aria-hidden="true"
@@ -1069,7 +1036,9 @@ exports[`Single Seat Contest 1`] = `
                 fill="currentColor"
               />
             </svg>
-            <span>
+            <span
+              class=""
+            >
               Color/Size
             </span>
           </span>
@@ -1082,7 +1051,7 @@ exports[`Single Seat Contest 1`] = `
         type="button"
       >
         <span
-          class="c29"
+          class="c28"
         >
           <svg
             aria-hidden="true"
@@ -1103,7 +1072,11 @@ exports[`Single Seat Contest 1`] = `
         <span
           class="c15"
         >
-          Next
+          <span
+            class=""
+          >
+            Next
+          </span>
         </span>
       </button>
     </nav>

--- a/apps/mark-scan/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
+++ b/apps/mark-scan/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
@@ -151,79 +151,6 @@ exports[`Single Seat Contest with Write In 1`] = `
 
 .c25 {
   display: inline-block;
-  border: none;
-  border-radius: 0.25em;
-  box-sizing: border-box;
-  background: #fafafa;
-  padding: 1em 1.75em;
-  text-align: center;
-  line-height: 1.25;
-  color: #222222;
-  font-size: 1.25em;
-  touch-action: manipulation;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  font-family: inherit;
-  font-size: 1rem;
-  font-weight: 600;
-  gap: 0.5rem;
-  -webkit-letter-spacing: 0.01em;
-  -moz-letter-spacing: 0.01em;
-  -ms-letter-spacing: 0.01em;
-  letter-spacing: 0.01em;
-  line-height: 1.15;
-  padding: 0.5em 0.6em;
-  width: auto;
-  min-height: 70.86614173228345px;
-  vertical-align: middle;
-  background: #fafafa;
-  border: 0.15rem solid #222222;
-  border-radius: 0.25rem;
-  box-shadow: none;
-  color: #222222;
-  cursor: pointer;
-  text-shadow: none;
-  -webkit-transition: 100ms ease-in;
-  transition: 100ms ease-in;
-  -webkit-transition-property: background,border,box-shadow,color;
-  transition-property: background,border,box-shadow,color;
-}
-
-.c25:hover,
-.c25:active {
-  outline: none;
-}
-
-.c25:hover,
-.c25:active {
-  outline: none;
-}
-
-.c25:active {
-  box-shadow: inset 0 0 0 0.15rem #222222;
-}
-
-.c25[disabled] {
-  border: 0.15rem dashed #222222;
-  box-shadow: none;
-  cursor: not-allowed;
-}
-
-.c26 {
-  display: inline-block;
 }
 
 .c15 {
@@ -427,7 +354,7 @@ exports[`Single Seat Contest with Write In 1`] = `
   flex-grow: 1;
 }
 
-.c27 {
+.c26 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -548,20 +475,30 @@ exports[`Single Seat Contest with Write In 1`] = `
             <h1
               class="c8"
             >
-              Registrar of Wills
+              <span
+                class=""
+              >
+                Registrar of Wills
+              </span>
             </h1>
           </div>
           <span
             class="c9"
           >
-            Vote for 
-            1
-            .
+            <span
+              class=""
+            >
+              Vote for 1.
+            </span>
              
             <span
               class="screen-reader-only"
             >
-              To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
+              <span
+                class=""
+              >
+                To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
+              </span>
             </span>
           </span>
         </div>
@@ -621,7 +558,11 @@ exports[`Single Seat Contest with Write In 1`] = `
                     <span
                       class="c23"
                     >
-                      Independent
+                      <span
+                        class=""
+                      >
+                        Independent
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -681,7 +622,12 @@ exports[`Single Seat Contest with Write In 1`] = `
                             fill="currentColor"
                           />
                         </svg>
-                         add write-in candidate
+                         
+                        <span
+                          class=""
+                        >
+                          add write-in candidate
+                        </span>
                       </span>
                     </p>
                   </span>
@@ -697,12 +643,12 @@ exports[`Single Seat Contest with Write In 1`] = `
     >
       <button
         aria-label="previous contest"
-        class="c25"
+        class="c13"
         id="previous"
         type="button"
       >
         <span
-          class="c26"
+          class="c25"
         >
           <svg
             aria-hidden="true"
@@ -723,7 +669,11 @@ exports[`Single Seat Contest with Write In 1`] = `
         <span
           class="c15"
         >
-          Back
+          <span
+            class=""
+          >
+            Back
+          </span>
         </span>
       </button>
       <button
@@ -734,7 +684,7 @@ exports[`Single Seat Contest with Write In 1`] = `
           class="c15"
         >
           <span
-            class="c27"
+            class="c26"
           >
             <svg
               aria-hidden="true"
@@ -751,7 +701,9 @@ exports[`Single Seat Contest with Write In 1`] = `
                 fill="currentColor"
               />
             </svg>
-            <span>
+            <span
+              class=""
+            >
               Color/Size
             </span>
           </span>
@@ -764,7 +716,7 @@ exports[`Single Seat Contest with Write In 1`] = `
         type="button"
       >
         <span
-          class="c26"
+          class="c25"
         >
           <svg
             aria-hidden="true"
@@ -785,7 +737,11 @@ exports[`Single Seat Contest with Write In 1`] = `
         <span
           class="c15"
         >
-          Next
+          <span
+            class=""
+          >
+            Next
+          </span>
         </span>
       </button>
     </nav>

--- a/apps/mark-scan/frontend/src/components/display_settings_button.tsx
+++ b/apps/mark-scan/frontend/src/components/display_settings_button.tsx
@@ -1,4 +1,4 @@
-import { Button, Icons } from '@votingworks/ui';
+import { Button, Icons, appStrings } from '@votingworks/ui';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 import { Paths } from '../config/globals';
@@ -19,7 +19,7 @@ export function DisplaySettingsButton(): JSX.Element | null {
     <Button onPress={history.push} value={Paths.DISPLAY_SETTINGS}>
       <LabelContainer>
         <Icons.Display />
-        <span>Color/Size</span>
+        {appStrings.buttonDisplaySettings()}
       </LabelContainer>
     </Button>
   );

--- a/apps/mark-scan/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
+++ b/apps/mark-scan/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
@@ -96,25 +96,6 @@ exports[`Renders ContestPage 1`] = `
 }
 
 .c24 {
-  display: inline-block;
-  border: none;
-  border-radius: 0.25em;
-  box-sizing: border-box;
-  background: #d3d3d3;
-  padding: 1em 1.75em;
-  text-align: center;
-  line-height: 1.25;
-  color: #000000;
-  font-size: 1.25em;
-  touch-action: manipulation;
-}
-
-.c24:hover,
-.c24:active {
-  outline: none;
-}
-
-.c25 {
   display: none;
 }
 
@@ -319,7 +300,7 @@ exports[`Renders ContestPage 1`] = `
   flex-grow: 1;
 }
 
-.c26 {
+.c25 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -401,20 +382,30 @@ exports[`Renders ContestPage 1`] = `
             <h1
               class="c7"
             >
-              President and Vice-President
+              <span
+                class=""
+              >
+                President and Vice-President
+              </span>
             </h1>
           </div>
           <span
             class="c8"
           >
-            Vote for 
-            1
-            .
+            <span
+              class=""
+            >
+              Vote for 1.
+            </span>
              
             <span
               class="screen-reader-only"
             >
-              To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
+              <span
+                class=""
+              >
+                To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
+              </span>
             </span>
           </span>
         </div>
@@ -474,7 +465,11 @@ exports[`Renders ContestPage 1`] = `
                     <span
                       class="c22"
                     >
-                      Federalist
+                      <span
+                        class=""
+                      >
+                        Federalist
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -524,7 +519,11 @@ exports[`Renders ContestPage 1`] = `
                     <span
                       class="c22"
                     >
-                      People’s
+                      <span
+                        class=""
+                      >
+                        People’s
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -574,7 +573,11 @@ exports[`Renders ContestPage 1`] = `
                     <span
                       class="c22"
                     >
-                      Liberty
+                      <span
+                        class=""
+                      >
+                        Liberty
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -624,7 +627,11 @@ exports[`Renders ContestPage 1`] = `
                     <span
                       class="c22"
                     >
-                      Constitution
+                      <span
+                        class=""
+                      >
+                        Constitution
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -674,7 +681,11 @@ exports[`Renders ContestPage 1`] = `
                     <span
                       class="c22"
                     >
-                      Whig
+                      <span
+                        class=""
+                      >
+                        Whig
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -724,7 +735,11 @@ exports[`Renders ContestPage 1`] = `
                     <span
                       class="c22"
                     >
-                      Labor
+                      <span
+                        class=""
+                      >
+                        Labor
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -739,12 +754,12 @@ exports[`Renders ContestPage 1`] = `
     >
       <button
         aria-label="previous contest"
-        class="c24"
+        class="c12"
         id="previous"
         type="button"
       >
         <span
-          class="c25"
+          class="c24"
         >
           <svg
             aria-hidden="true"
@@ -765,7 +780,11 @@ exports[`Renders ContestPage 1`] = `
         <span
           class="c14"
         >
-          Back
+          <span
+            class=""
+          >
+            Back
+          </span>
         </span>
       </button>
       <button
@@ -776,7 +795,7 @@ exports[`Renders ContestPage 1`] = `
           class="c14"
         >
           <span
-            class="c26"
+            class="c25"
           >
             <svg
               aria-hidden="true"
@@ -793,7 +812,9 @@ exports[`Renders ContestPage 1`] = `
                 fill="currentColor"
               />
             </svg>
-            <span>
+            <span
+              class=""
+            >
               Color/Size
             </span>
           </span>
@@ -806,7 +827,7 @@ exports[`Renders ContestPage 1`] = `
         type="button"
       >
         <span
-          class="c25"
+          class="c24"
         >
           <svg
             aria-hidden="true"
@@ -827,7 +848,11 @@ exports[`Renders ContestPage 1`] = `
         <span
           class="c14"
         >
-          Next
+          <span
+            class=""
+          >
+            Next
+          </span>
         </span>
       </button>
     </nav>
@@ -1496,20 +1521,30 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
             <h1
               class="c7"
             >
-              President and Vice-President
+              <span
+                class=""
+              >
+                President and Vice-President
+              </span>
             </h1>
           </div>
           <span
             class="c8"
           >
-            Vote for 
-            1
-            .
+            <span
+              class=""
+            >
+              Vote for 1.
+            </span>
              
             <span
               class="screen-reader-only"
             >
-              To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
+              <span
+                class=""
+              >
+                To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
+              </span>
             </span>
           </span>
         </div>
@@ -1569,7 +1604,11 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                     <span
                       class="c22"
                     >
-                      Federalist
+                      <span
+                        class=""
+                      >
+                        Federalist
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1619,7 +1658,11 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                     <span
                       class="c22"
                     >
-                      People’s
+                      <span
+                        class=""
+                      >
+                        People’s
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1669,7 +1712,11 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                     <span
                       class="c22"
                     >
-                      Liberty
+                      <span
+                        class=""
+                      >
+                        Liberty
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1719,7 +1766,11 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                     <span
                       class="c22"
                     >
-                      Constitution
+                      <span
+                        class=""
+                      >
+                        Constitution
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1769,7 +1820,11 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                     <span
                       class="c22"
                     >
-                      Whig
+                      <span
+                        class=""
+                      >
+                        Whig
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1819,7 +1874,11 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                     <span
                       class="c22"
                     >
-                      Labor
+                      <span
+                        class=""
+                      >
+                        Labor
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1886,7 +1945,11 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
               <span
                 class="c14"
               >
-                Next
+                <span
+                  class=""
+                >
+                  Next
+                </span>
               </span>
             </button>
           </p>
@@ -1921,7 +1984,11 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
               <span
                 class="c14"
               >
-                Back
+                <span
+                  class=""
+                >
+                  Back
+                </span>
               </span>
             </button>
           </p>
@@ -1958,7 +2025,9 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                     fill="currentColor"
                   />
                 </svg>
-                <span>
+                <span
+                  class=""
+                >
                   Color/Size
                 </span>
               </span>

--- a/apps/mark-scan/frontend/src/pages/__snapshots__/start_page.test.tsx.snap
+++ b/apps/mark-scan/frontend/src/pages/__snapshots__/start_page.test.tsx.snap
@@ -652,7 +652,9 @@ exports[`renders StartPage with inline SVG seal 1`] = `
                 fill="currentColor"
               />
             </svg>
-            <span>
+            <span
+              class=""
+            >
               Color/Size
             </span>
           </span>

--- a/apps/mark-scan/frontend/src/pages/contest_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/contest_page.tsx
@@ -1,5 +1,12 @@
 import { CandidateVote } from '@votingworks/types';
-import { Screen, Prose, P, Font, LinkButton } from '@votingworks/ui';
+import {
+  Screen,
+  Prose,
+  P,
+  Font,
+  LinkButton,
+  appStrings,
+} from '@votingworks/ui';
 import { singlePrecinctSelectionFor } from '@votingworks/utils';
 import React, { useContext } from 'react';
 import { assert, throwIllegalValue } from '@votingworks/basics';
@@ -81,30 +88,29 @@ export function ContestPage(): JSX.Element {
       aria-label="next contest"
       to={nextContest ? `/contests/${nextContestIndex}` : '/review'}
     >
-      Next
+      {appStrings.buttonNext()}
     </LinkButton>
   );
 
   const previousContestButton = (
     <LinkButton
       variant="previous"
-      large={isPortrait}
       id="previous"
       aria-label="previous contest"
       to={prevContest ? `/contests/${prevContestIndex}` : '/'}
     >
-      Back
+      {/* TODO(kofi): Maybe something like "Previous" would translate better in this context? */}
+      {appStrings.buttonBack()}
     </LinkButton>
   );
 
   const reviewScreenButton = (
     <LinkButton
-      large
       variant={isVoteComplete ? 'next' : 'nextSecondary'}
       to={`/review#contest-${contest.id}`}
       id="next"
     >
-      Review
+      {appStrings.buttonReview()}
     </LinkButton>
   );
 

--- a/apps/mark/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
@@ -31,6 +31,14 @@ exports[`Single Seat Contest 1`] = `
   font-size: 0.75rem;
 }
 
+.c23 {
+  font-size: 1em;
+  font-weight: 300;
+  line-height: 1.15;
+  margin: 0;
+  font-size: 0.75rem;
+}
+
 .c21 {
   font-size: 1em;
   line-height: 1.15;
@@ -141,7 +149,7 @@ exports[`Single Seat Contest 1`] = `
   cursor: not-allowed;
 }
 
-.c24 {
+.c25 {
   display: inline-block;
 }
 
@@ -320,14 +328,14 @@ exports[`Single Seat Contest 1`] = `
   justify-content: space-between;
 }
 
-.c23 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c25 {
+.c26 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -378,7 +386,7 @@ exports[`Single Seat Contest 1`] = `
 }
 
 @media (orientation:portrait) {
-  .c23 {
+  .c24 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -393,7 +401,7 @@ exports[`Single Seat Contest 1`] = `
     padding: 0.5rem;
   }
 
-  .c23 > *:not(:first-child,:last-child) {
+  .c24 > *:not(:first-child,:last-child) {
     -webkit-box-flex: 1;
     -webkit-flex-grow: 1;
     -ms-flex-positive: 1;
@@ -402,7 +410,7 @@ exports[`Single Seat Contest 1`] = `
 }
 
 @media (orientation:landscape) {
-  .c23 {
+  .c24 {
     border-left: 0.25rem solid #222222;
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
@@ -415,7 +423,7 @@ exports[`Single Seat Contest 1`] = `
     padding: 0.5rem;
   }
 
-  .c23 > * {
+  .c24 > * {
     min-height: 3rem;
   }
 }
@@ -487,20 +495,30 @@ exports[`Single Seat Contest 1`] = `
             <h1
               class="c8"
             >
-              President and Vice-President
+              <span
+                class=""
+              >
+                President and Vice-President
+              </span>
             </h1>
           </div>
           <span
             class="c9"
           >
-            Vote for 
-            1
-            .
+            <span
+              class=""
+            >
+              Vote for 1.
+            </span>
              
             <span
               class="screen-reader-only"
             >
-              To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
+              <span
+                class=""
+              >
+                To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
+              </span>
             </span>
           </span>
         </div>
@@ -557,6 +575,9 @@ exports[`Single Seat Contest 1`] = `
                     >
                       Joseph Barchi and Joseph Hallaren
                     </p>
+                    <span
+                      class="c23"
+                    />
                   </span>
                 </span>
               </span>
@@ -602,6 +623,9 @@ exports[`Single Seat Contest 1`] = `
                     >
                       Adam Cramer and Greg Vuocolo
                     </p>
+                    <span
+                      class="c23"
+                    />
                   </span>
                 </span>
               </span>
@@ -647,6 +671,9 @@ exports[`Single Seat Contest 1`] = `
                     >
                       Daniel Court and Amy Blumhardt
                     </p>
+                    <span
+                      class="c23"
+                    />
                   </span>
                 </span>
               </span>
@@ -692,6 +719,9 @@ exports[`Single Seat Contest 1`] = `
                     >
                       Alvin Boone and James Lian
                     </p>
+                    <span
+                      class="c23"
+                    />
                   </span>
                 </span>
               </span>
@@ -737,6 +767,9 @@ exports[`Single Seat Contest 1`] = `
                     >
                       Ashley Hildebrand-McDougall and James Garritty
                     </p>
+                    <span
+                      class="c23"
+                    />
                   </span>
                 </span>
               </span>
@@ -782,6 +815,9 @@ exports[`Single Seat Contest 1`] = `
                     >
                       Martin Patterson and Clay Lariviere
                     </p>
+                    <span
+                      class="c23"
+                    />
                   </span>
                 </span>
               </span>
@@ -791,7 +827,7 @@ exports[`Single Seat Contest 1`] = `
       </div>
     </main>
     <nav
-      class="c23"
+      class="c24"
     >
       <button
         aria-label="previous contest"
@@ -800,7 +836,7 @@ exports[`Single Seat Contest 1`] = `
         type="button"
       >
         <span
-          class="c24"
+          class="c25"
         >
           <svg
             aria-hidden="true"
@@ -821,7 +857,11 @@ exports[`Single Seat Contest 1`] = `
         <span
           class="c15"
         >
-          Back
+          <span
+            class=""
+          >
+            Back
+          </span>
         </span>
       </button>
       <button
@@ -832,7 +872,7 @@ exports[`Single Seat Contest 1`] = `
           class="c15"
         >
           <span
-            class="c25"
+            class="c26"
           >
             <svg
               aria-hidden="true"
@@ -849,7 +889,9 @@ exports[`Single Seat Contest 1`] = `
                 fill="currentColor"
               />
             </svg>
-            <span>
+            <span
+              class=""
+            >
               Color/Size
             </span>
           </span>
@@ -862,7 +904,7 @@ exports[`Single Seat Contest 1`] = `
         type="button"
       >
         <span
-          class="c24"
+          class="c25"
         >
           <svg
             aria-hidden="true"
@@ -883,7 +925,11 @@ exports[`Single Seat Contest 1`] = `
         <span
           class="c15"
         >
-          Next
+          <span
+            class=""
+          >
+            Next
+          </span>
         </span>
       </button>
     </nav>

--- a/apps/mark/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
@@ -633,27 +633,39 @@ exports[`Single Seat Contest 1`] = `
             <h1
               class="c8"
             >
-              County Commissioners
+              <span
+                class=""
+              >
+                County Commissioners
+              </span>
             </h1>
           </div>
           <span
             class="c9"
           >
-            Vote for 
-            4
-            .
+            <span
+              class=""
+            >
+              Vote for 4.
+            </span>
              
             <span
               class="c7"
             >
-              You have selected 
-              4
-              .
+              <span
+                class=""
+              >
+                You have selected 4.
+              </span>
             </span>
             <span
               class="screen-reader-only"
             >
-              To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
+              <span
+                class=""
+              >
+                To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
+              </span>
             </span>
           </span>
         </div>
@@ -713,7 +725,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      Federalist
+                      <span
+                        class=""
+                      >
+                        Federalist
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -763,7 +779,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      Federalist
+                      <span
+                        class=""
+                      >
+                        Federalist
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -813,7 +833,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      Federalist
+                      <span
+                        class=""
+                      >
+                        Federalist
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -863,7 +887,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      People’s
+                      <span
+                        class=""
+                      >
+                        People’s
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -913,7 +941,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      People’s
+                      <span
+                        class=""
+                      >
+                        People’s
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -963,7 +995,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      People’s
+                      <span
+                        class=""
+                      >
+                        People’s
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1013,7 +1049,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      People’s
+                      <span
+                        class=""
+                      >
+                        People’s
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1063,7 +1103,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      Liberty
+                      <span
+                        class=""
+                      >
+                        Liberty
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1113,7 +1157,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      Constitution
+                      <span
+                        class=""
+                      >
+                        Constitution
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1163,7 +1211,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      Constitution
+                      <span
+                        class=""
+                      >
+                        Constitution
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1213,7 +1265,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      Independent
+                      <span
+                        class=""
+                      >
+                        Independent
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1273,7 +1329,12 @@ exports[`Single Seat Contest 1`] = `
                             fill="currentColor"
                           />
                         </svg>
-                         add write-in candidate
+                         
+                        <span
+                          class=""
+                        >
+                          add write-in candidate
+                        </span>
                       </span>
                     </p>
                   </span>
@@ -1315,7 +1376,11 @@ exports[`Single Seat Contest 1`] = `
         <span
           class="c15"
         >
-          Back
+          <span
+            class=""
+          >
+            Back
+          </span>
         </span>
       </button>
       <button
@@ -1343,7 +1408,9 @@ exports[`Single Seat Contest 1`] = `
                 fill="currentColor"
               />
             </svg>
-            <span>
+            <span
+              class=""
+            >
               Color/Size
             </span>
           </span>
@@ -1377,7 +1444,11 @@ exports[`Single Seat Contest 1`] = `
         <span
           class="c15"
         >
-          Next
+          <span
+            class=""
+          >
+            Next
+          </span>
         </span>
       </button>
     </nav>

--- a/apps/mark/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
@@ -633,27 +633,39 @@ exports[`Single Seat Contest 1`] = `
             <h1
               class="c8"
             >
-              President and Vice-President
+              <span
+                class=""
+              >
+                President and Vice-President
+              </span>
             </h1>
           </div>
           <span
             class="c9"
           >
-            Vote for 
-            1
-            .
+            <span
+              class=""
+            >
+              Vote for 1.
+            </span>
              
             <span
               class="c7"
             >
-              You have selected 
-              1
-              .
+              <span
+                class=""
+              >
+                You have selected 1.
+              </span>
             </span>
             <span
               class="screen-reader-only"
             >
-              To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
+              <span
+                class=""
+              >
+                To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
+              </span>
             </span>
           </span>
         </div>
@@ -713,7 +725,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      Federalist
+                      <span
+                        class=""
+                      >
+                        Federalist
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -763,7 +779,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      People’s
+                      <span
+                        class=""
+                      >
+                        People’s
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -813,7 +833,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      Liberty
+                      <span
+                        class=""
+                      >
+                        Liberty
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -863,7 +887,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      Constitution
+                      <span
+                        class=""
+                      >
+                        Constitution
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -913,7 +941,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      Whig
+                      <span
+                        class=""
+                      >
+                        Whig
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -963,7 +995,11 @@ exports[`Single Seat Contest 1`] = `
                     <span
                       class="c23"
                     >
-                      Labor
+                      <span
+                        class=""
+                      >
+                        Labor
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1004,7 +1040,11 @@ exports[`Single Seat Contest 1`] = `
         <span
           class="c15"
         >
-          Back
+          <span
+            class=""
+          >
+            Back
+          </span>
         </span>
       </button>
       <button
@@ -1032,7 +1072,9 @@ exports[`Single Seat Contest 1`] = `
                 fill="currentColor"
               />
             </svg>
-            <span>
+            <span
+              class=""
+            >
               Color/Size
             </span>
           </span>
@@ -1066,7 +1108,11 @@ exports[`Single Seat Contest 1`] = `
         <span
           class="c15"
         >
-          Next
+          <span
+            class=""
+          >
+            Next
+          </span>
         </span>
       </button>
     </nav>

--- a/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
@@ -511,20 +511,30 @@ exports[`Single Seat Contest with Write In 1`] = `
             <h1
               class="c8"
             >
-              Registrar of Wills
+              <span
+                class=""
+              >
+                Registrar of Wills
+              </span>
             </h1>
           </div>
           <span
             class="c9"
           >
-            Vote for 
-            1
-            .
+            <span
+              class=""
+            >
+              Vote for 1.
+            </span>
              
             <span
               class="screen-reader-only"
             >
-              To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
+              <span
+                class=""
+              >
+                To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
+              </span>
             </span>
           </span>
         </div>
@@ -584,7 +594,11 @@ exports[`Single Seat Contest with Write In 1`] = `
                     <span
                       class="c23"
                     >
-                      Independent
+                      <span
+                        class=""
+                      >
+                        Independent
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -644,7 +658,12 @@ exports[`Single Seat Contest with Write In 1`] = `
                             fill="currentColor"
                           />
                         </svg>
-                         add write-in candidate
+                         
+                        <span
+                          class=""
+                        >
+                          add write-in candidate
+                        </span>
                       </span>
                     </p>
                   </span>
@@ -686,7 +705,11 @@ exports[`Single Seat Contest with Write In 1`] = `
         <span
           class="c15"
         >
-          Back
+          <span
+            class=""
+          >
+            Back
+          </span>
         </span>
       </button>
       <button
@@ -714,7 +737,9 @@ exports[`Single Seat Contest with Write In 1`] = `
                 fill="currentColor"
               />
             </svg>
-            <span>
+            <span
+              class=""
+            >
               Color/Size
             </span>
           </span>
@@ -748,7 +773,11 @@ exports[`Single Seat Contest with Write In 1`] = `
         <span
           class="c15"
         >
-          Next
+          <span
+            class=""
+          >
+            Next
+          </span>
         </span>
       </button>
     </nav>

--- a/apps/mark/frontend/src/components/display_settings_button.tsx
+++ b/apps/mark/frontend/src/components/display_settings_button.tsx
@@ -1,4 +1,4 @@
-import { Button, Icons } from '@votingworks/ui';
+import { Button, Icons, appStrings } from '@votingworks/ui';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 import { Paths } from '../config/globals';
@@ -19,7 +19,7 @@ export function DisplaySettingsButton(): JSX.Element | null {
     <Button onPress={history.push} value={Paths.DISPLAY_SETTINGS}>
       <LabelContainer>
         <Icons.Display />
-        <span>Color/Size</span>
+        {appStrings.buttonDisplaySettings()}
       </LabelContainer>
     </Button>
   );

--- a/apps/mark/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
@@ -406,20 +406,30 @@ exports[`Renders ContestPage 1`] = `
             <h1
               class="c7"
             >
-              President and Vice-President
+              <span
+                class=""
+              >
+                President and Vice-President
+              </span>
             </h1>
           </div>
           <span
             class="c8"
           >
-            Vote for 
-            1
-            .
+            <span
+              class=""
+            >
+              Vote for 1.
+            </span>
              
             <span
               class="screen-reader-only"
             >
-              To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
+              <span
+                class=""
+              >
+                To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
+              </span>
             </span>
           </span>
         </div>
@@ -479,7 +489,11 @@ exports[`Renders ContestPage 1`] = `
                     <span
                       class="c22"
                     >
-                      Federalist
+                      <span
+                        class=""
+                      >
+                        Federalist
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -529,7 +543,11 @@ exports[`Renders ContestPage 1`] = `
                     <span
                       class="c22"
                     >
-                      People’s
+                      <span
+                        class=""
+                      >
+                        People’s
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -579,7 +597,11 @@ exports[`Renders ContestPage 1`] = `
                     <span
                       class="c22"
                     >
-                      Liberty
+                      <span
+                        class=""
+                      >
+                        Liberty
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -629,7 +651,11 @@ exports[`Renders ContestPage 1`] = `
                     <span
                       class="c22"
                     >
-                      Constitution
+                      <span
+                        class=""
+                      >
+                        Constitution
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -679,7 +705,11 @@ exports[`Renders ContestPage 1`] = `
                     <span
                       class="c22"
                     >
-                      Whig
+                      <span
+                        class=""
+                      >
+                        Whig
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -729,7 +759,11 @@ exports[`Renders ContestPage 1`] = `
                     <span
                       class="c22"
                     >
-                      Labor
+                      <span
+                        class=""
+                      >
+                        Labor
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -770,7 +804,11 @@ exports[`Renders ContestPage 1`] = `
         <span
           class="c14"
         >
-          Back
+          <span
+            class=""
+          >
+            Back
+          </span>
         </span>
       </button>
       <button
@@ -798,7 +836,9 @@ exports[`Renders ContestPage 1`] = `
                 fill="currentColor"
               />
             </svg>
-            <span>
+            <span
+              class=""
+            >
               Color/Size
             </span>
           </span>
@@ -832,7 +872,11 @@ exports[`Renders ContestPage 1`] = `
         <span
           class="c14"
         >
-          Next
+          <span
+            class=""
+          >
+            Next
+          </span>
         </span>
       </button>
     </nav>
@@ -1246,20 +1290,30 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
             <h1
               class="c7"
             >
-              President and Vice-President
+              <span
+                class=""
+              >
+                President and Vice-President
+              </span>
             </h1>
           </div>
           <span
             class="c8"
           >
-            Vote for 
-            1
-            .
+            <span
+              class=""
+            >
+              Vote for 1.
+            </span>
              
             <span
               class="screen-reader-only"
             >
-              To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
+              <span
+                class=""
+              >
+                To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
+              </span>
             </span>
           </span>
         </div>
@@ -1319,7 +1373,11 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                     <span
                       class="c22"
                     >
-                      Federalist
+                      <span
+                        class=""
+                      >
+                        Federalist
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1369,7 +1427,11 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                     <span
                       class="c22"
                     >
-                      People’s
+                      <span
+                        class=""
+                      >
+                        People’s
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1419,7 +1481,11 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                     <span
                       class="c22"
                     >
-                      Liberty
+                      <span
+                        class=""
+                      >
+                        Liberty
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1469,7 +1535,11 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                     <span
                       class="c22"
                     >
-                      Constitution
+                      <span
+                        class=""
+                      >
+                        Constitution
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1519,7 +1589,11 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                     <span
                       class="c22"
                     >
-                      Whig
+                      <span
+                        class=""
+                      >
+                        Whig
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1569,7 +1643,11 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                     <span
                       class="c22"
                     >
-                      Labor
+                      <span
+                        class=""
+                      >
+                        Labor
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -1610,7 +1688,11 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
         <span
           class="c14"
         >
-          Back
+          <span
+            class=""
+          >
+            Back
+          </span>
         </span>
       </button>
       <button
@@ -1638,7 +1720,9 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
                 fill="currentColor"
               />
             </svg>
-            <span>
+            <span
+              class=""
+            >
               Color/Size
             </span>
           </span>
@@ -1672,7 +1756,11 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
         <span
           class="c14"
         >
-          Next
+          <span
+            class=""
+          >
+            Next
+          </span>
         </span>
       </button>
     </nav>

--- a/apps/mark/frontend/src/pages/__snapshots__/start_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/start_page.test.tsx.snap
@@ -552,7 +552,9 @@ exports[`renders StartPage with inline SVG 1`] = `
               fill="currentColor"
             />
           </svg>
-          <span>
+          <span
+            class=""
+          >
             Color/Size
           </span>
         </span>

--- a/apps/mark/frontend/src/pages/contest_page.tsx
+++ b/apps/mark/frontend/src/pages/contest_page.tsx
@@ -1,5 +1,5 @@
 import { CandidateVote } from '@votingworks/types';
-import { Screen, LinkButton, useScreenInfo } from '@votingworks/ui';
+import { Screen, LinkButton, useScreenInfo, appStrings } from '@votingworks/ui';
 import React, { useContext } from 'react';
 import { assert, throwIllegalValue } from '@votingworks/basics';
 import { useHistory, useParams } from 'react-router-dom';
@@ -71,7 +71,7 @@ export function ContestPage(): JSX.Element {
       aria-label="next contest"
       to={nextContest ? `/contests/${nextContestIndex}` : '/review'}
     >
-      Next
+      {appStrings.buttonNext()}
     </LinkButton>
   );
 
@@ -82,18 +82,18 @@ export function ContestPage(): JSX.Element {
       aria-label="previous contest"
       to={prevContest ? `/contests/${prevContestIndex}` : '/'}
     >
-      Back
+      {/* TODO(kofi): Maybe something like "Previous" would translate better in this context? */}
+      {appStrings.buttonBack()}
     </LinkButton>
   );
 
   const reviewScreenButton = (
     <LinkButton
-      large
       variant={isVoteComplete ? 'next' : 'nextSecondary'}
       to={`/review#contest-${contest.id}`}
       id="next"
     >
-      Review
+      {appStrings.buttonReview()}
     </LinkButton>
   );
 

--- a/libs/mark-flow-ui/src/components/__snapshots__/contest.test.tsx.snap
+++ b/libs/mark-flow-ui/src/components/__snapshots__/contest.test.tsx.snap
@@ -280,20 +280,30 @@ exports[`renders 1`] = `
           <h1
             class="c4"
           >
-            President and Vice-President
+            <span
+              class=""
+            >
+              President and Vice-President
+            </span>
           </h1>
         </div>
         <span
           class="c5"
         >
-          Vote for 
-          1
-          .
+          <span
+            class=""
+          >
+            Vote for 1.
+          </span>
            
           <span
             class="screen-reader-only"
           >
-            To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
+            <span
+              class=""
+            >
+              To navigate through the contest choices, use the down button. To move to the next contest, use the right button.
+            </span>
           </span>
         </span>
       </div>
@@ -353,7 +363,11 @@ exports[`renders 1`] = `
                   <span
                     class="c19"
                   >
-                    Federalist
+                    <span
+                      class=""
+                    >
+                      Federalist
+                    </span>
                   </span>
                 </span>
               </span>
@@ -403,7 +417,11 @@ exports[`renders 1`] = `
                   <span
                     class="c19"
                   >
-                    People’s
+                    <span
+                      class=""
+                    >
+                      People’s
+                    </span>
                   </span>
                 </span>
               </span>
@@ -453,7 +471,11 @@ exports[`renders 1`] = `
                   <span
                     class="c19"
                   >
-                    Liberty
+                    <span
+                      class=""
+                    >
+                      Liberty
+                    </span>
                   </span>
                 </span>
               </span>
@@ -503,7 +525,11 @@ exports[`renders 1`] = `
                   <span
                     class="c19"
                   >
-                    Constitution
+                    <span
+                      class=""
+                    >
+                      Constitution
+                    </span>
                   </span>
                 </span>
               </span>
@@ -553,7 +579,11 @@ exports[`renders 1`] = `
                   <span
                     class="c19"
                   >
-                    Whig
+                    <span
+                      class=""
+                    >
+                      Whig
+                    </span>
                   </span>
                 </span>
               </span>
@@ -603,7 +633,11 @@ exports[`renders 1`] = `
                   <span
                     class="c19"
                   >
-                    Labor
+                    <span
+                      class=""
+                    >
+                      Labor
+                    </span>
                   </span>
                 </span>
               </span>

--- a/libs/mark-flow-ui/src/components/__snapshots__/yes_no_contest.test.tsx.snap
+++ b/libs/mark-flow-ui/src/components/__snapshots__/yes_no_contest.test.tsx.snap
@@ -353,7 +353,11 @@ exports[`changing votes 1`] = `
           <h1
             class="c4"
           >
-            Ballot Measure 3
+            <span
+              class=""
+            >
+              Ballot Measure 3
+            </span>
           </h1>
         </div>
         <span
@@ -788,7 +792,11 @@ exports[`voting for both yes and no 1`] = `
           <h1
             class="c4"
           >
-            Ballot Measure 3
+            <span
+              class=""
+            >
+              Ballot Measure 3
+            </span>
           </h1>
         </div>
         <span

--- a/libs/mark-flow-ui/src/components/candidate_contest.tsx
+++ b/libs/mark-flow-ui/src/components/candidate_contest.tsx
@@ -25,6 +25,8 @@ import {
   WithScrollButtons,
   ModalWidth,
   useScreenInfo,
+  appStrings,
+  renderCandidatePartyList,
 } from '@votingworks/ui';
 import { assert } from '@votingworks/basics';
 
@@ -228,22 +230,23 @@ export function CandidateContest({
       <Main flexColumn>
         <ContestHeader
           breadcrumbs={breadcrumbs}
+          contest={contest}
           districtName={districtName}
-          title={contest.title}
         >
           <Caption>
-            Vote for {contest.seats}.{' '}
+            {appStrings.numSeatsInstructions(contest.seats)}{' '}
             {vote.length === contest.seats && (
-              <Font weight="bold">You have selected {contest.seats}.</Font>
+              <Font weight="bold">
+                {appStrings.numVotesSelected(contest.seats)}
+              </Font>
             )}
             {vote.length < contest.seats && vote.length !== 0 && (
               <Font weight="bold">
-                You may select {contest.seats - vote.length} more.
+                {appStrings.numVotesRemaining(contest.seats - vote.length)}
               </Font>
             )}
             <span className="screen-reader-only">
-              To navigate through the contest choices, use the down button. To
-              move to the next contest, use the right button.
+              {appStrings.contestNavigationInstructions()}
             </span>
           </Caption>
         </ContestHeader>
@@ -277,7 +280,10 @@ export function CandidateContest({
                     candidate.name
                   )}${partiesDescription ? `, ${partiesDescription}` : ''}.`}
                   label={candidate.name}
-                  caption={partiesDescription}
+                  caption={renderCandidatePartyList(
+                    candidate,
+                    election.parties
+                  )}
                 />
               );
             })}
@@ -308,7 +314,7 @@ export function CandidateContest({
                 }
                 label={
                   <span>
-                    <Icons.Edit /> add write-in candidate
+                    <Icons.Edit /> {appStrings.buttonAddWriteIn()}
                   </span>
                 }
               />

--- a/libs/mark-flow-ui/src/components/contest_header.tsx
+++ b/libs/mark-flow-ui/src/components/contest_header.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { Caption, Font, H2 } from '@votingworks/ui';
+import { Caption, Font, H2, electionStrings } from '@votingworks/ui';
+import { Contest } from '@votingworks/types';
+import { MsEitherNeitherContest } from '../utils/ms_either_neither_contests';
 
 export interface ContestHeaderProps {
   breadcrumbs?: BreadcrumbMetadata;
   children?: React.ReactNode;
+  contest: Contest | MsEitherNeitherContest;
   districtName: string;
-  title: string;
 }
 
 export interface BreadcrumbMetadata {
@@ -26,7 +28,7 @@ const ContestInfo = styled.div`
 `;
 
 export function ContestHeader(props: ContestHeaderProps): JSX.Element {
-  const { breadcrumbs, children, districtName, title } = props;
+  const { breadcrumbs, children, contest, districtName } = props;
 
   return (
     <Container id="contest-header">
@@ -41,7 +43,7 @@ export function ContestHeader(props: ContestHeaderProps): JSX.Element {
           )}
         </ContestInfo>
         <div>
-          <H2 as="h1">{title}</H2>
+          <H2 as="h1">{electionStrings.contestTitle(contest)}</H2>
         </div>
         {children}
       </div>

--- a/libs/mark-flow-ui/src/components/ms_either_neither_contest.tsx
+++ b/libs/mark-flow-ui/src/components/ms_either_neither_contest.tsx
@@ -117,8 +117,8 @@ export function MsEitherNeitherContest({
     <Main flexColumn>
       <ContestHeader
         breadcrumbs={breadcrumbs}
+        contest={contest}
         districtName={districtName}
-        title={contest.title}
       >
         <Caption>
           {eitherNeitherVote && pickOneVote ? (

--- a/libs/mark-flow-ui/src/components/yes_no_contest.tsx
+++ b/libs/mark-flow-ui/src/components/yes_no_contest.tsx
@@ -75,8 +75,8 @@ export function YesNoContest({
       <Main flexColumn>
         <ContestHeader
           breadcrumbs={breadcrumbs}
+          contest={contest}
           districtName={districtName}
-          title={contest.title}
         >
           <Caption>
             Vote <strong>Yes</strong> or <strong>No</strong>.

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -1,0 +1,109 @@
+import { UiString } from './ui_string';
+
+// TODO(kofi): Add lint rule to ensure object keys match uiStringKey props.
+
+/* istanbul ignore next - mostly presentational, tested via apps where relevant */
+export const appStrings = {
+  // TODO(kofi): Fill out.
+
+  buttonAddWriteIn: () => (
+    <UiString uiStringKey="buttonAddWriteIn">add write-in candidate</UiString>
+  ),
+
+  buttonBack: () => <UiString uiStringKey="buttonBack">Back</UiString>,
+
+  buttonDisplaySettings: () => (
+    <UiString uiStringKey="buttonDisplaySettings">Color/Size</UiString>
+  ),
+
+  buttonNext: () => <UiString uiStringKey="buttonNext">Next</UiString>,
+
+  buttonReview: () => <UiString uiStringKey="buttonReview">Review</UiString>,
+
+  contestNavigationInstructions: () => (
+    <UiString uiStringKey="contestNavigationInstructions">
+      To navigate through the contest choices, use the down button. To move to
+      the next contest, use the right button.
+    </UiString>
+  ),
+
+  numSeatsInstructions: (numSeats: number) =>
+    // These are split out into individual strings instead of an interpolated
+    // one to support generating non-interpolated audio for each one, for a
+    // better voter experience.
+    // This pattern only makes sense when there's a very limited value space.
+    ({
+      1: (
+        <UiString uiStringKey="numSeatsInstructions" uiStringSubKey="1">
+          Vote for 1.
+        </UiString>
+      ),
+      2: (
+        <UiString uiStringKey="numSeatsInstructions" uiStringSubKey="2">
+          Vote for 2.
+        </UiString>
+      ),
+      3: (
+        <UiString uiStringKey="numSeatsInstructions" uiStringSubKey="3">
+          Vote for 3.
+        </UiString>
+      ),
+      4: (
+        <UiString uiStringKey="numSeatsInstructions" uiStringSubKey="4">
+          Vote for 4.
+        </UiString>
+      ),
+      // TODO(kofi): Find out what a reasonable upper limit is for the number of
+      // possible votes per contest.
+    })[numSeats],
+
+  numVotesSelected: (numVotes: number) =>
+    ({
+      1: (
+        <UiString uiStringKey="numVotesSelected" uiStringSubKey="1">
+          You have selected 1.
+        </UiString>
+      ),
+      2: (
+        <UiString uiStringKey="numVotesSelected" uiStringSubKey="2">
+          You have selected 2.
+        </UiString>
+      ),
+      3: (
+        <UiString uiStringKey="numVotesSelected" uiStringSubKey="3">
+          You have selected 3.
+        </UiString>
+      ),
+      4: (
+        <UiString uiStringKey="numVotesSelected" uiStringSubKey="4">
+          You have selected 4.
+        </UiString>
+      ),
+      // TODO(kofi): Same as above: find numVotes upper limit.
+    })[numVotes],
+
+  numVotesRemaining: (numRemaining: number) =>
+    ({
+      1: (
+        <UiString uiStringKey="numVotesRemaining" uiStringSubKey="1">
+          You may select 1 more.
+        </UiString>
+      ),
+      2: (
+        <UiString uiStringKey="numVotesRemaining" uiStringSubKey="2">
+          You may select 2 more.
+        </UiString>
+      ),
+      3: (
+        <UiString uiStringKey="numVotesRemaining" uiStringSubKey="3">
+          You may select 3 more.
+        </UiString>
+      ),
+      4: (
+        <UiString uiStringKey="numVotesRemaining" uiStringSubKey="4">
+          You may select 4 more.
+        </UiString>
+      ),
+      // TODO(kofi): Same as above: find numRemaining upper limit.
+    })[numRemaining],
+} as const;

--- a/libs/ui/src/ui_strings/election_strings.test.tsx
+++ b/libs/ui/src/ui_strings/election_strings.test.tsx
@@ -1,0 +1,86 @@
+import { Candidate, LanguageCode, Parties, PartyId } from '@votingworks/types';
+import { renderCandidatePartyList } from './election_strings';
+import { newTestContext } from '../../test/ui_strings/test_utils';
+import { H1 } from '..';
+import { screen } from '../../test/react_testing_library';
+
+const ELECTION_PARTIES: Readonly<Parties> = [
+  {
+    abbrev: 'Lb',
+    fullName: 'Liberty Party',
+    id: 'party1' as PartyId,
+    name: 'Liberty',
+  },
+  {
+    abbrev: 'Fe',
+    fullName: 'Federalist Party',
+    id: 'party2' as PartyId,
+    name: 'Federalist',
+  },
+];
+
+const CANDIDATE: Readonly<Candidate> = {
+  id: 'candidateX',
+  name: 'Professor Xavier',
+};
+
+test('renderCandidatePartyList - single-party association', async () => {
+  const { mockBackendApi, render } = newTestContext();
+  mockBackendApi.getAvailableLanguages.mockResolvedValue([
+    LanguageCode.SPANISH,
+  ]);
+  mockBackendApi.getUiStrings.mockResolvedValue({
+    partyName: {
+      party1: 'Libertad',
+      party2: 'Federalista',
+    },
+  });
+
+  render(
+    <H1>
+      Parties:{' '}
+      {renderCandidatePartyList(
+        {
+          ...CANDIDATE,
+          partyIds: [ELECTION_PARTIES[1].id],
+        },
+        ELECTION_PARTIES
+      )}
+    </H1>
+  );
+
+  await screen.findByRole('heading', { name: 'Parties: Federalista' });
+});
+
+test('renderCandidatePartyList - multi-party association', async () => {
+  const { mockBackendApi, render } = newTestContext();
+  mockBackendApi.getAvailableLanguages.mockResolvedValue([
+    LanguageCode.SPANISH,
+  ]);
+  mockBackendApi.getUiStrings.mockResolvedValue({
+    partyName: {
+      party1: 'Libertad',
+      party2: 'Federalista',
+    },
+  });
+
+  render(
+    <H1>
+      Parties:{' '}
+      {renderCandidatePartyList(
+        {
+          ...CANDIDATE,
+          partyIds: [ELECTION_PARTIES[1].id, ELECTION_PARTIES[0].id],
+        },
+        ELECTION_PARTIES
+      )}
+    </H1>
+  );
+
+  await screen.findByRole('heading', {
+    // react-testing-library seems to be interpreting a gap between the first
+    // party and the comma, even though they're rendered adjacent in the
+    // browser, so using a slightly more lenient regex here.
+    name: /Parties: Federalista\s?, Libertad/,
+  });
+});

--- a/libs/ui/src/ui_strings/election_strings.tsx
+++ b/libs/ui/src/ui_strings/election_strings.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import {
   Candidate,
-  Contest,
   Parties,
   Party,
   getCandidateParties,
@@ -14,9 +13,9 @@ import { UiString } from './ui_string';
 export const electionStrings = {
   // TODO(kofi): Fill out.
 
-  // NOTE: Omitting 'type' to support both the `Contest` and the
+  // NOTE: Using more lenient typing to support both the `Contest` and the
   // `MsEitherNeitherContest` types.
-  contestTitle: (contest: Omit<Contest, 'type'>) => (
+  contestTitle: (contest: { id: string; title: string }) => (
     <UiString uiStringKey="contestTitle" uiStringSubKey={contest.id}>
       {contest.title}
     </UiString>
@@ -44,7 +43,7 @@ export function renderCandidatePartyList(
           {/*
            * TODO(kofi): This comma-delimiting isn't properly
            * internationalized (comma character is rendered differently in
-           * different languages/character sets -- need to figure out a clean
+           * different languages/character sets) -- need to figure out a clean
            * way to do this.
            */}
           {i > 0 && <React.Fragment>, </React.Fragment>}

--- a/libs/ui/src/ui_strings/election_strings.tsx
+++ b/libs/ui/src/ui_strings/election_strings.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import {
+  Candidate,
+  Contest,
+  Parties,
+  Party,
+  getCandidateParties,
+} from '@votingworks/types';
+
+import { UiString } from './ui_string';
+
+/* istanbul ignore next - mostly presentational, tested via apps where relevant */
+export const electionStrings = {
+  // TODO(kofi): Fill out.
+
+  // NOTE: Omitting 'type' to support both the `Contest` and the
+  // `MsEitherNeitherContest` types.
+  contestTitle: (contest: Omit<Contest, 'type'>) => (
+    <UiString uiStringKey="contestTitle" uiStringSubKey={contest.id}>
+      {contest.title}
+    </UiString>
+  ),
+
+  partyName: (party: Party) => (
+    <UiString uiStringKey="partyName" uiStringSubKey={party.id}>
+      {party.name}
+    </UiString>
+  ),
+} as const;
+
+/**
+ * Convenience function for rendering a translated list of parties associated
+ * with a given candidate, along with the relevant audio.
+ */
+export function renderCandidatePartyList(
+  candidate: Candidate,
+  electionParties: Parties
+): JSX.Element {
+  return (
+    <React.Fragment>
+      {getCandidateParties(electionParties, candidate).map((party, i) => (
+        <React.Fragment key={party.id}>
+          {/*
+           * TODO(kofi): This comma-delimiting isn't properly
+           * internationalized (comma character is rendered differently in
+           * different languages/character sets -- need to figure out a clean
+           * way to do this.
+           */}
+          {i > 0 && <React.Fragment>, </React.Fragment>}
+          {electionStrings.partyName(party)}
+        </React.Fragment>
+      ))}
+    </React.Fragment>
+  );
+}

--- a/libs/ui/src/ui_strings/index.ts
+++ b/libs/ui/src/ui_strings/index.ts
@@ -1,1 +1,3 @@
+export * from './app_strings';
+export * from './election_strings';
 export * from './ui_strings_context';

--- a/libs/ui/src/ui_strings/ui_string.tsx
+++ b/libs/ui/src/ui_strings/ui_string.tsx
@@ -27,9 +27,11 @@ export function UiString(props: UiStringProps): JSX.Element {
   if (!languageContext) {
     // Enable tests to run without the need for a UiStringContext:
     return (
-      <Trans i18nKey={i18nKey} count={pluralCount}>
-        {children}
-      </Trans>
+      <Container>
+        <Trans i18nKey={i18nKey} count={pluralCount}>
+          {children}
+        </Trans>
+      </Container>
     );
   }
 


### PR DESCRIPTION
## Overview

_Easier by commit_

_Related spec [here](https://docs.google.com/document/d/1a2GRj1g4aOawEssPdTCgbv-qs28d-M_dyMEfzm4I4nM/edit?usp=sharing)._

Adding `@votingworks/ui/appStrings` and `@votingworks/ui/electionStrings` shared string component renderers (building off `<UiString>`) and starting off with a few proof-of-concept strings to try out different usage patterns.

Replacing a few strings on the `CandidateContest` pages in `Mark` and `Mark-Scan`.

## Demo Video or Screenshot

https://github.com/votingworks/vxsuite/assets/264902/aaee2716-ddc2-4f62-b6c7-a80358c11958

## Testing Plan
- Manual: populated the DB with test translations and added the `UiStringContextProvider` to the app root of `Mark` to verify functionality. Using a stand-in language picker for testing until we have an actual voter-facing component.
- Added unit tests for the `renderCandidatePartyList` helper function.
- Will later add some sanity check tests for things like making sure the object keys match the `uiStringKey`s, since that feels easy to mess up or end up with copy/paste errors.

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
