### PR TITLE
ignore unmounted usb drives from mark-scan

### DIFF
--- a/apps/mark-scan/backend/src/server.ts
+++ b/apps/mark-scan/backend/src/server.ts
@@ -82,7 +82,7 @@ export async function start({
 
   const usbDrive = isIntegrationTest()
     ? new MockFileUsbDrive()
-    : detectUsbDrive(logger);
+    : detectUsbDrive(logger, { allowUnmountedDataDrive: false });
 
   const app = buildApp(resolvedAuth, logger, workspace, usbDrive, stateMachine);
 

--- a/libs/usb-drive/src/usb_drive.test.ts
+++ b/libs/usb-drive/src/usb_drive.test.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 import { LogEventId, fakeLogger } from '@votingworks/logging';
 import {
   BlockDeviceInfo,
+  DetectUsbDriveOptions,
   UsbDriveStatus,
   VX_USB_LABEL_REGEXP,
   detectUsbDrive,
@@ -156,6 +157,7 @@ describe('status', () => {
       sdc1: Partial<BlockDeviceInfo>;
       expectedStatus: UsbDriveStatus;
       newMountPoint?: string;
+      options?: DetectUsbDriveOptions;
     }> = [
       {
         sdb1: { mountpoint: '/media/usb-drive-sdb1' },
@@ -187,11 +189,23 @@ describe('status', () => {
         expectedStatus: { status: 'no_drive' },
         newMountPoint: '/dev/sdc1',
       },
+      {
+        sdb1: { mountpoint: undefined },
+        sdc1: { mountpoint: '/media/usb-drive-sdc1' },
+        expectedStatus: {
+          status: 'mounted',
+          mountPoint: '/media/usb-drive-sdc1',
+          deviceName: 'sdc1',
+        },
+        options: {
+          allowUnmountedDataDrive: false,
+        },
+      },
     ];
 
     for (const testCase of testCases) {
       const logger = fakeLogger();
-      const usbDrive = detectUsbDrive(logger);
+      const usbDrive = detectUsbDrive(logger, testCase.options);
       readdirMock.mockResolvedValue([
         'notausb-bazbar-part21', // this device should be ignored
         'usb-foobar-part23',

--- a/libs/usb-drive/src/usb_drive.ts
+++ b/libs/usb-drive/src/usb_drive.ts
@@ -89,10 +89,16 @@ function isDataUsbDrive(
   allowUnmounted: boolean
 ): boolean {
   if (allowUnmounted) {
-    return !blockDeviceInfo.mountpoint;
+    return (
+      !blockDeviceInfo.mountpoint ||
+      blockDeviceInfo.mountpoint.startsWith(DEFAULT_MEDIA_MOUNT_DIR)
+    );
   }
 
-  return !!blockDeviceInfo.mountpoint?.startsWith(DEFAULT_MEDIA_MOUNT_DIR);
+  return (
+    !!blockDeviceInfo.mountpoint &&
+    blockDeviceInfo.mountpoint.startsWith(DEFAULT_MEDIA_MOUNT_DIR)
+  );
 }
 
 async function getUsbDriveDeviceInfo(

--- a/libs/usb-drive/src/usb_drive.ts
+++ b/libs/usb-drive/src/usb_drive.ts
@@ -279,9 +279,13 @@ async function mount(
   }
 }
 
+export interface DetectUsbDriveOptions {
+  allowUnmountedDataDrive: boolean;
+}
+
 export function detectUsbDrive(
   logger: Logger,
-  options: { allowUnmountedDataDrive: boolean } = {
+  options: DetectUsbDriveOptions = {
     allowUnmountedDataDrive: true,
   }
 ): UsbDrive {


### PR DESCRIPTION
## Overview
Hotfix: makes it optional to ignore unmounted drives when checking for data drives.

When looking for a data USB for election packages, libs/usb-drive picks the first drive that is (a) unmounted or (b) mounted to `/media.*`. VxMarkScan has an unmounted LVM drive that takes priority over the data drive mounted to `/media`. The result is the USB lib detects the LVM drive as a data drive, but doesn't try to mount it because it's not FAT32. Then the true media drive is ignored and mark-scan can't be configured.

## Demo Video or Screenshot
N/A

## Testing Plan
Manually tested on hardware.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
