### PR TITLE
VSAP USB Drive Hotfix

### DIFF
--- a/libs/usb-drive/src/usb_drive.test.ts
+++ b/libs/usb-drive/src/usb_drive.test.ts
@@ -40,6 +40,7 @@ function lsblkOutput(devices: Array<Partial<BlockDeviceInfo>> = []) {
         fstype: 'vfat',
         fsver: 'FAT32',
         label: 'VxUSB-00000',
+        type: 'part',
         ...device,
       })),
     }),
@@ -58,6 +59,51 @@ describe('status', () => {
     });
 
     expect(readdirMock).toHaveBeenCalledWith('/dev/disk/by-id/');
+  });
+
+  test('completely ignores invalid devices', async () => {
+    const logger = fakeLogger();
+    const usbDrive = detectUsbDrive(logger);
+
+    readdirMock.mockResolvedValue(['usb-foobar-part23']);
+    readlinkMock.mockResolvedValue('../../sdb1');
+    execMock.mockResolvedValueOnce(
+      lsblkOutput([
+        {
+          fstype: 'LVM2',
+        },
+      ])
+    );
+    await expect(usbDrive.status()).resolves.toEqual({
+      status: 'no_drive',
+    });
+
+    readdirMock.mockResolvedValue(['usb-foobar-part23']);
+    readlinkMock.mockResolvedValue('../../sdb1');
+    execMock.mockResolvedValueOnce(
+      lsblkOutput([
+        {
+          type: 'lvm',
+        },
+      ])
+    );
+    await expect(usbDrive.status()).resolves.toEqual({
+      status: 'no_drive',
+    });
+
+    readdirMock.mockResolvedValue(['usb-foobar-part23']);
+    readlinkMock.mockResolvedValue('../../sdb1');
+    execMock.mockResolvedValueOnce(
+      lsblkOutput([
+        {
+          fstype: null,
+          mountpoint: '/',
+        },
+      ])
+    );
+    await expect(usbDrive.status()).resolves.toEqual({
+      status: 'no_drive',
+    });
   });
 
   test('one drive, mounted', async () => {
@@ -85,7 +131,7 @@ describe('status', () => {
       '-n',
       '-l',
       '-o',
-      ['NAME', 'MOUNTPOINT', 'FSTYPE', 'FSVER', 'LABEL'].join(','),
+      ['NAME', 'MOUNTPOINT', 'FSTYPE', 'FSVER', 'LABEL', 'TYPE'].join(','),
       '/dev/sdb1',
     ]);
   });
@@ -119,7 +165,7 @@ describe('status', () => {
       '-n',
       '-l',
       '-o',
-      ['NAME', 'MOUNTPOINT', 'FSTYPE', 'FSVER', 'LABEL'].join(','),
+      ['NAME', 'MOUNTPOINT', 'FSTYPE', 'FSVER', 'LABEL', 'TYPE'].join(','),
       '/dev/sdb1',
     ]);
     expect(execMock).toHaveBeenNthCalledWith(2, 'sudo', [
@@ -132,7 +178,7 @@ describe('status', () => {
       '-n',
       '-l',
       '-o',
-      ['NAME', 'MOUNTPOINT', 'FSTYPE', 'FSVER', 'LABEL'].join(','),
+      ['NAME', 'MOUNTPOINT', 'FSTYPE', 'FSVER', 'LABEL', 'TYPE'].join(','),
       '/dev/sdb1',
     ]);
 


### PR DESCRIPTION
VSAP has two "devices" which are causing problems:
- a USB partition acting as / formatted as an LVM (logical volume manager). we can disallow this by skipping drives which have a filesystem type of "LVM." There's no documentation I can find on a proper enumeration of all file types, so I'm simply excluding file systems which include "LVM" in the name
-  "logical volume" that is part of that LVM. this is easy to exclude, because we can limit our search to proper partitions
