### PR TITLE
[i18n/Audio] Adding renderers and helpers for remaining election strings

### DIFF
--- a/apps/mark/frontend/src/app_cardless_voting.test.tsx
+++ b/apps/mark/frontend/src/app_cardless_voting.test.tsx
@@ -153,7 +153,7 @@ test('Cardless Voting Flow', async () => {
   });
 
   // Voter Ballot Style is active
-  await findByTextWithMarkup('Your ballot has 20 contests.');
+  await findByTextWithMarkup('Number of contests on your ballot: 20');
   screen.getByText(/(12)/);
   fireEvent.click(screen.getByText('Start Voting'));
 
@@ -198,7 +198,7 @@ test('Cardless Voting Flow', async () => {
   });
 
   // Voter Ballot Style is active
-  await findByTextWithMarkup('Your ballot has 20 contests.');
+  await findByTextWithMarkup('Number of contests on your ballot: 20');
   screen.getByText(/(12)/);
   fireEvent.click(screen.getByText('Start Voting'));
 
@@ -289,7 +289,7 @@ test('Another Voter submits blank ballot and clicks Done', async () => {
   });
 
   // Voter Ballot Style is active
-  await findByTextWithMarkup('Your ballot has 20 contests.');
+  await findByTextWithMarkup('Number of contests on your ballot: 20');
   screen.getByText(/(12)/);
   fireEvent.click(screen.getByText('Start Voting'));
 
@@ -444,7 +444,7 @@ test('poll worker must select a precinct first', async () => {
   });
 
   // Voter Ballot Style is active
-  await findByTextWithMarkup('Your ballot has 20 contests.');
+  await findByTextWithMarkup('Number of contests on your ballot: 20');
   screen.getByText(/(12)/);
   userEvent.click(screen.getByText('Start Voting'));
 
@@ -493,7 +493,7 @@ test('poll worker must select a precinct first', async () => {
   });
 
   // Voter Ballot Style is active
-  await findByTextWithMarkup('Your ballot has 20 contests.');
+  await findByTextWithMarkup('Number of contests on your ballot: 20');
   screen.getByText(/(12)/);
   fireEvent.click(screen.getByText('Start Voting'));
 

--- a/apps/mark/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark/frontend/src/app_end_to_end.test.tsx
@@ -192,7 +192,7 @@ test('MarkAndPrint end-to-end flow', async () => {
     precinctId: '23',
   });
 
-  await findByTextWithMarkup('Your ballot has 20 contests.');
+  await findByTextWithMarkup('Number of contests on your ballot: 20');
   screen.getByText(/Center Springfield/);
   screen.getByText(/(12)/);
 

--- a/apps/mark/frontend/src/components/__snapshots__/election_info.test.tsx.snap
+++ b/apps/mark/frontend/src/components/__snapshots__/election_info.test.tsx.snap
@@ -268,7 +268,12 @@ exports[`renders ElectionInfo with hash when specified 1`] = `
       <h1
         class="c2"
       >
-         General Election
+         
+        <span
+          class=""
+        >
+          General Election
+        </span>
       </h1>
       <p
         aria-label="November 3, 2020. Franklin County, State of Hamilton. Center Springfield."
@@ -277,7 +282,9 @@ exports[`renders ElectionInfo with hash when specified 1`] = `
         <span
           class="c4"
         >
-          November 3, 2020
+          <span>
+            November 3, 2020
+          </span>
         </span>
         <br />
         <span
@@ -286,12 +293,26 @@ exports[`renders ElectionInfo with hash when specified 1`] = `
           <span
             class="c6"
           >
-            Center Springfield
-            , 
+            <span
+              class=""
+            >
+              Center Springfield
+            </span>
+            ,
+             
           </span>
-          Franklin County
-          , 
-          State of Hamilton
+          <span
+            class=""
+          >
+            Franklin County
+          </span>
+          ,
+           
+          <span
+            class=""
+          >
+            State of Hamilton
+          </span>
         </span>
       </p>
     </div>
@@ -567,7 +588,12 @@ exports[`renders ElectionInfo without hash by default 1`] = `
       <h1
         class="c2"
       >
-         General Election
+         
+        <span
+          class=""
+        >
+          General Election
+        </span>
       </h1>
       <p
         aria-label="November 3, 2020. Franklin County, State of Hamilton. Center Springfield."
@@ -576,7 +602,9 @@ exports[`renders ElectionInfo without hash by default 1`] = `
         <span
           class="c4"
         >
-          November 3, 2020
+          <span>
+            November 3, 2020
+          </span>
         </span>
         <br />
         <span
@@ -585,12 +613,26 @@ exports[`renders ElectionInfo without hash by default 1`] = `
           <span
             class="c6"
           >
-            Center Springfield
-            , 
+            <span
+              class=""
+            >
+              Center Springfield
+            </span>
+            ,
+             
           </span>
-          Franklin County
-          , 
-          State of Hamilton
+          <span
+            class=""
+          >
+            Franklin County
+          </span>
+          ,
+           
+          <span
+            class=""
+          >
+            State of Hamilton
+          </span>
         </span>
       </p>
     </div>

--- a/apps/mark/frontend/src/components/election_info.test.tsx
+++ b/apps/mark/frontend/src/components/election_info.test.tsx
@@ -1,6 +1,7 @@
 import { singlePrecinctSelectionFor } from '@votingworks/utils';
 
 import { electionGeneralDefinition as electionDefinition } from '@votingworks/fixtures';
+import { hasTextAcrossElements } from '@votingworks/test-utils';
 import { render, screen } from '../../test/react_testing_library';
 import { ElectionInfo } from './election_info';
 
@@ -33,5 +34,5 @@ test('renders with ballot style id', () => {
     />
   );
   screen.getByText(/Center Springfield/);
-  screen.getByText(/ballot style: 12/i);
+  screen.getByText(hasTextAcrossElements(/ballot style: 12/i));
 });

--- a/apps/mark/frontend/src/components/election_info.tsx
+++ b/apps/mark/frontend/src/components/election_info.tsx
@@ -4,13 +4,22 @@ import styled from 'styled-components';
 import {
   BallotStyleId,
   ElectionDefinition,
-  getPartyPrimaryAdjectiveFromBallotStyle,
   PrecinctSelection,
 } from '@votingworks/types';
-import { getPrecinctSelectionName, format } from '@votingworks/utils';
+import { format, getPrecinctSelectionName } from '@votingworks/utils';
 
-import { NoWrap, H1, P, Caption, Font, Seal } from '@votingworks/ui';
-import pluralize from 'pluralize';
+import {
+  NoWrap,
+  H1,
+  P,
+  Caption,
+  Font,
+  Seal,
+  renderPrecinctSelectionName,
+  electionStrings,
+  appStrings,
+  renderPrimaryElectionTitlePrefix,
+} from '@votingworks/ui';
 
 const Container = styled.div`
   align-items: center;
@@ -36,18 +45,28 @@ export function ElectionInfo({
   contestCount,
 }: Props): JSX.Element {
   const { election } = electionDefinition;
-  const { title: t, state, county, date, seal } = election;
+  const { state, county, date, seal } = election;
+
   const precinctName =
     precinctSelection &&
     getPrecinctSelectionName(election.precincts, precinctSelection);
-  const partyPrimaryAdjective = ballotStyleId
-    ? getPartyPrimaryAdjectiveFromBallotStyle({
-        election,
-        ballotStyleId,
-      })
-    : '';
-  const title = `${partyPrimaryAdjective} ${t}`;
+
+  const partyPrimaryAdjective = (
+    <React.Fragment>
+      {ballotStyleId &&
+        renderPrimaryElectionTitlePrefix(ballotStyleId, election)}{' '}
+    </React.Fragment>
+  );
+
+  const title = (
+    <React.Fragment>
+      {partyPrimaryAdjective}
+      {electionStrings.electionTitle(election)}
+    </React.Fragment>
+  );
+
   const electionDate = format.localeLongDate(new Date(date));
+
   return (
     <Container>
       <Seal seal={seal} />
@@ -56,27 +75,37 @@ export function ElectionInfo({
         <P
           aria-label={`${electionDate}. ${county.name}, ${state}. ${precinctName}.`}
         >
-          <Font weight="bold">{electionDate}</Font>
+          <Font weight="bold">{appStrings.date(new Date(date))}</Font>
           <br />
           <Caption>
-            {precinctName && <NoWrap>{precinctName}, </NoWrap>}
-            {county.name}, {state}
+            {/* TODO(kofi): Use more language-agnostic delimiter (e.g. '|') or find way to translate commas. */}
+            {precinctSelection && (
+              <NoWrap>
+                {renderPrecinctSelectionName(
+                  election.precincts,
+                  precinctSelection
+                )}
+                ,{' '}
+              </NoWrap>
+            )}
+            {electionStrings.countyName(county)},{' '}
+            {electionStrings.stateName(election)}
           </Caption>
           {ballotStyleId && (
             <React.Fragment>
               <br />
-              <Caption>Ballot style: {ballotStyleId}</Caption>
+              <Caption>
+                {appStrings.labelBallotStyle()}{' '}
+                {electionStrings.ballotStyleId(ballotStyleId)}
+              </Caption>
             </React.Fragment>
           )}
           {contestCount && (
             <React.Fragment>
               <br />
               <Caption>
-                Your ballot has{' '}
-                <Font weight="bold">
-                  {pluralize('contest', contestCount, true)}
-                </Font>
-                .
+                {appStrings.labelNumBallotContests()}{' '}
+                <Font weight="bold">{appStrings.number(contestCount)}</Font>
               </Caption>
             </React.Fragment>
           )}

--- a/apps/mark/frontend/src/components/election_info.tsx
+++ b/apps/mark/frontend/src/components/election_info.tsx
@@ -15,10 +15,10 @@ import {
   Caption,
   Font,
   Seal,
-  renderPrecinctSelectionName,
   electionStrings,
   appStrings,
-  renderPrimaryElectionTitlePrefix,
+  PrecinctSelectionName,
+  PrimaryElectionTitlePrefix,
 } from '@votingworks/ui';
 
 const Container = styled.div`
@@ -53,8 +53,12 @@ export function ElectionInfo({
 
   const partyPrimaryAdjective = (
     <React.Fragment>
-      {ballotStyleId &&
-        renderPrimaryElectionTitlePrefix(ballotStyleId, election)}{' '}
+      {ballotStyleId && (
+        <PrimaryElectionTitlePrefix
+          ballotStyleId={ballotStyleId}
+          election={election}
+        />
+      )}{' '}
     </React.Fragment>
   );
 
@@ -81,10 +85,10 @@ export function ElectionInfo({
             {/* TODO(kofi): Use more language-agnostic delimiter (e.g. '|') or find way to translate commas. */}
             {precinctSelection && (
               <NoWrap>
-                {renderPrecinctSelectionName(
-                  election.precincts,
-                  precinctSelection
-                )}
+                <PrecinctSelectionName
+                  electionPrecincts={election.precincts}
+                  precinctSelection={precinctSelection}
+                />
                 ,{' '}
               </NoWrap>
             )}

--- a/apps/mark/frontend/src/pages/__snapshots__/start_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/start_page.test.tsx.snap
@@ -430,7 +430,12 @@ exports[`renders StartPage with inline SVG 1`] = `
           <h1
             class="c5"
           >
-             General Election
+             
+            <span
+              class=""
+            >
+              General Election
+            </span>
           </h1>
           <p
             aria-label="November 3, 2020. Franklin County, State of Hamilton. Center Springfield."
@@ -439,7 +444,9 @@ exports[`renders StartPage with inline SVG 1`] = `
             <span
               class="c7"
             >
-              November 3, 2020
+              <span>
+                November 3, 2020
+              </span>
             </span>
             <br />
             <span
@@ -448,32 +455,60 @@ exports[`renders StartPage with inline SVG 1`] = `
               <span
                 class="c9"
               >
-                Center Springfield
-                , 
+                <span
+                  class=""
+                >
+                  Center Springfield
+                </span>
+                ,
+                 
               </span>
-              Franklin County
-              , 
-              State of Hamilton
+              <span
+                class=""
+              >
+                Franklin County
+              </span>
+              ,
+               
+              <span
+                class=""
+              >
+                State of Hamilton
+              </span>
             </span>
             <br />
             <span
               class="c8"
             >
-              Ballot style: 
-              12
+              <span
+                class=""
+              >
+                Ballot style:
+              </span>
+               
+              <span
+                class=""
+              >
+                12
+              </span>
             </span>
             <br />
             <span
               class="c8"
             >
-              Your ballot has
+              <span
+                class=""
+              >
+                Number of contests on your ballot:
+              </span>
                
               <span
                 class="c7"
               >
-                20 contests
+                <span>
+                  20
+                </span>
               </span>
-              .
             </span>
           </p>
         </div>
@@ -512,7 +547,12 @@ exports[`renders StartPage with inline SVG 1`] = `
                   fill="currentColor"
                 />
               </svg>
-               Start Voting
+               
+              <span
+                class=""
+              >
+                Start Voting
+              </span>
             </span>
           </span>
         </button>

--- a/apps/mark/frontend/src/pages/start_page.test.tsx
+++ b/apps/mark/frontend/src/pages/start_page.test.tsx
@@ -7,7 +7,6 @@ import { createMemoryHistory } from 'history';
 import userEvent from '@testing-library/user-event';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
 import { screen } from '../../test/react_testing_library';
-import { fakeMachineConfig } from '../../test/helpers/fake_machine_config';
 import { render } from '../../test/test_utils';
 import { StartPage } from './start_page';
 import { Paths } from '../config/globals';
@@ -20,31 +19,17 @@ test('renders StartPage', () => {
     precinctId: 'precinct-1',
     route: '/',
   });
-  screen.getByRole('heading', { name: 'Example Primary Election' });
-  screen.getByText('September 8, 2021');
-  screen.getByText(
-    hasTextAcrossElements('Precinct 1, Sample County, State of Sample')
-  );
-  screen.getByText('Ballot style: 1M');
-  screen.getByText(hasTextAcrossElements('Your ballot has 7 contests.'));
-});
-
-test('renders StartPage in Landscape Orientation', () => {
-  const electionDefinition = electionTwoPartyPrimaryDefinition;
-  render(<Route path="/" component={StartPage} />, {
-    ballotStyleId: '1M',
-    electionDefinition,
-    precinctId: 'precinct-1',
-    route: '/',
-    machineConfig: fakeMachineConfig({ screenOrientation: 'landscape' }),
+  screen.getByRole('heading', {
+    name: 'Mammal Party Example Primary Election',
   });
-  screen.getByRole('heading', { name: 'Example Primary Election' });
   screen.getByText('September 8, 2021');
   screen.getByText(
     hasTextAcrossElements('Precinct 1, Sample County, State of Sample')
   );
-  screen.getByText('Ballot style: 1M');
-  screen.getByText(hasTextAcrossElements('Your ballot has 7 contests.'));
+  screen.getByText(hasTextAcrossElements('Ballot style: 1M'));
+  screen.getByText(
+    hasTextAcrossElements('Number of contests on your ballot: 7')
+  );
 });
 
 test('renders StartPage with inline SVG', () => {

--- a/apps/mark/frontend/src/pages/start_page.tsx
+++ b/apps/mark/frontend/src/pages/start_page.tsx
@@ -2,7 +2,7 @@ import { singlePrecinctSelectionFor } from '@votingworks/utils';
 import { useContext, useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import { useHistory } from 'react-router-dom';
-import { Screen, Button, P, Icons } from '@votingworks/ui';
+import { Screen, Button, P, Icons, appStrings } from '@votingworks/ui';
 
 import { assert } from '@votingworks/basics';
 import { BallotContext } from '../contexts/ballot_context';
@@ -89,7 +89,7 @@ export function StartPage(): JSX.Element {
         aria-label="Press the right button to advance to the first contest."
       >
         <LargeButtonText>
-          <Icons.Next /> Start Voting
+          <Icons.Next /> {appStrings.buttonStartVoting()}
         </LargeButtonText>
       </Button>
     </Wobble>

--- a/libs/mark-flow-ui/src/components/candidate_contest.tsx
+++ b/libs/mark-flow-ui/src/components/candidate_contest.tsx
@@ -26,7 +26,7 @@ import {
   ModalWidth,
   useScreenInfo,
   appStrings,
-  renderCandidatePartyList,
+  CandidatePartyList,
 } from '@votingworks/ui';
 import { assert } from '@votingworks/basics';
 
@@ -280,10 +280,12 @@ export function CandidateContest({
                     candidate.name
                   )}${partiesDescription ? `, ${partiesDescription}` : ''}.`}
                   label={candidate.name}
-                  caption={renderCandidatePartyList(
-                    candidate,
-                    election.parties
-                  )}
+                  caption={
+                    <CandidatePartyList
+                      candidate={candidate}
+                      electionParties={election.parties}
+                    />
+                  }
                 />
               );
             })}

--- a/libs/types/src/ui_string_translations.ts
+++ b/libs/types/src/ui_string_translations.ts
@@ -15,6 +15,7 @@ export enum ElectionStringKey {
   COUNTY_NAME = 'countyName',
   DISTRICT_NAME = 'districtName',
   ELECTION_TITLE = 'electionTitle',
+  PARTY_FULL_NAME = 'partyFullName',
   PARTY_NAME = 'partyName',
   PRECINCT_NAME = 'precinctName',
   STATE_NAME = 'stateName',

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -1,3 +1,5 @@
+import { DateString } from './date_string';
+import { NumberString } from './number_string';
 import { UiString } from './ui_string';
 
 // TODO(kofi): Add lint rule to ensure object keys match uiStringKey props.
@@ -18,6 +20,10 @@ export const appStrings = {
 
   buttonNext: () => <UiString uiStringKey="buttonNext">Next</UiString>,
 
+  buttonStartVoting: () => (
+    <UiString uiStringKey="buttonStartVoting">Start Voting</UiString>
+  ),
+
   buttonReview: () => <UiString uiStringKey="buttonReview">Review</UiString>,
 
   contestNavigationInstructions: () => (
@@ -26,6 +32,24 @@ export const appStrings = {
       the next contest, use the right button.
     </UiString>
   ),
+
+  date: (value: Date) => <DateString value={value} />,
+
+  labelAllPrecinctsSelection: () => (
+    <UiString uiStringKey="labelAllPrecinctsSelection">All Precincts</UiString>
+  ),
+
+  labelBallotStyle: () => (
+    <UiString uiStringKey="labelBallotStyle">Ballot style:</UiString>
+  ),
+
+  labelNumBallotContests: () => (
+    <UiString uiStringKey="labelNumBallotContests">
+      Number of contests on your ballot:
+    </UiString>
+  ),
+
+  number: (value: number) => <NumberString value={value} />,
 
   numSeatsInstructions: (numSeats: number) =>
     // These are split out into individual strings instead of an interpolated

--- a/libs/ui/src/ui_strings/date_string.test.tsx
+++ b/libs/ui/src/ui_strings/date_string.test.tsx
@@ -1,0 +1,43 @@
+import { LanguageCode } from '@votingworks/types';
+import { format } from '@votingworks/utils';
+import { H1 } from '..';
+import {
+  act,
+  render as renderWithoutContext,
+  screen,
+} from '../../test/react_testing_library';
+import { newTestContext } from '../../test/ui_strings/test_utils';
+import { DateString } from './date_string';
+
+const TEST_DATE = new Date('2023/10/12');
+const ENGLISH_FORMAT = format.localeLongDate(TEST_DATE, LanguageCode.ENGLISH);
+const SPANISH_FORMAT = format.localeLongDate(TEST_DATE, LanguageCode.SPANISH);
+
+test('formats based on current language code', async () => {
+  const { getLanguageContext, mockBackendApi, render } = newTestContext();
+
+  mockBackendApi.getAvailableLanguages.mockResolvedValue([]);
+  mockBackendApi.getUiStrings.mockResolvedValue({});
+
+  render(
+    <H1>
+      <DateString value={TEST_DATE} />
+    </H1>
+  );
+
+  await screen.findByRole('heading', { name: ENGLISH_FORMAT });
+
+  act(() => getLanguageContext()?.setLanguage(LanguageCode.SPANISH));
+
+  await screen.findByRole('heading', { name: SPANISH_FORMAT });
+});
+
+test('uses default language code with language context', async () => {
+  renderWithoutContext(
+    <H1>
+      <DateString value={TEST_DATE} />
+    </H1>
+  );
+
+  await screen.findByRole('heading', { name: ENGLISH_FORMAT });
+});

--- a/libs/ui/src/ui_strings/date_string.tsx
+++ b/libs/ui/src/ui_strings/date_string.tsx
@@ -1,0 +1,18 @@
+import { format } from '@votingworks/utils';
+import { useLanguageContext } from './language_context';
+
+export interface DateStringProps {
+  value: Date;
+}
+export function DateString(props: DateStringProps): JSX.Element {
+  const { value } = props;
+
+  const languageContext = useLanguageContext();
+
+  return (
+    // TODO(kofi): fetch audio IDs for the given date.
+    <span data-audio-ids={undefined}>
+      {format.localeLongDate(value, languageContext?.currentLanguageCode)}
+    </span>
+  );
+}

--- a/libs/ui/src/ui_strings/election_strings.tsx
+++ b/libs/ui/src/ui_strings/election_strings.tsx
@@ -1,22 +1,104 @@
-import { Party } from '@votingworks/types';
+/* eslint-disable react/destructuring-assignment */
+
+import {
+  BallotStyleId,
+  Candidate,
+  County,
+  District,
+  Election,
+  ElectionStringKey as Key,
+  Party,
+  Precinct,
+  YesNoOption,
+} from '@votingworks/types';
 
 import { UiString } from './ui_string';
 
+// Using more lenient typing to support both the `Contest` and the
+// `MsEitherNeitherContest` types.
+interface ContestLike {
+  id: string;
+  title: string;
+}
+
+type ContestWithDescription = ContestLike & {
+  description: string;
+};
+
+/**
+ * Election-specific strings that need to be translated and/or spoken.
+ */
 /* istanbul ignore next - mostly presentational, tested via apps where relevant */
 export const electionStrings = {
   // TODO(kofi): Fill out.
 
-  // NOTE: Using more lenient typing to support both the `Contest` and the
-  // `MsEitherNeitherContest` types.
-  contestTitle: (contest: { id: string; title: string }) => (
-    <UiString uiStringKey="contestTitle" uiStringSubKey={contest.id}>
+  [Key.BALLOT_STYLE_ID]: (id: BallotStyleId) => (
+    <UiString uiStringKey={Key.BALLOT_STYLE_ID} uiStringSubKey={id}>
+      {id}
+    </UiString>
+  ),
+
+  [Key.CANDIDATE_NAME]: (candidate: Candidate) => (
+    <UiString uiStringKey={Key.CANDIDATE_NAME} uiStringSubKey={candidate.id}>
+      {candidate.name}
+    </UiString>
+  ),
+
+  [Key.CONTEST_DESCRIPTION]: (contest: ContestWithDescription) => (
+    <UiString uiStringKey={Key.CONTEST_DESCRIPTION} uiStringSubKey={contest.id}>
+      {contest.description}
+    </UiString>
+  ),
+
+  [Key.CONTEST_OPTION_LABEL]: (option: YesNoOption) => (
+    <UiString uiStringKey={Key.CONTEST_OPTION_LABEL} uiStringSubKey={option.id}>
+      {option.label}
+    </UiString>
+  ),
+
+  [Key.CONTEST_TITLE]: (contest: ContestLike) => (
+    <UiString uiStringKey={Key.CONTEST_TITLE} uiStringSubKey={contest.id}>
       {contest.title}
     </UiString>
   ),
 
-  partyName: (party: Party) => (
-    <UiString uiStringKey="partyName" uiStringSubKey={party.id}>
+  [Key.COUNTY_NAME]: (county: County) => (
+    <UiString uiStringKey={Key.COUNTY_NAME} uiStringSubKey={county.id}>
+      {county.name}
+    </UiString>
+  ),
+
+  [Key.DISTRICT_NAME]: (district: District) => (
+    <UiString uiStringKey={Key.DISTRICT_NAME} uiStringSubKey={district.id}>
+      {district.name}
+    </UiString>
+  ),
+
+  [Key.ELECTION_TITLE]: (election: Election) => (
+    <UiString uiStringKey={Key.ELECTION_TITLE}>{election.title}</UiString>
+  ),
+
+  [Key.PARTY_FULL_NAME]: (party: Party) => (
+    <UiString uiStringKey={Key.PARTY_NAME} uiStringSubKey={party.id}>
+      {party.fullName}
+    </UiString>
+  ),
+
+  [Key.PARTY_NAME]: (party: Party) => (
+    <UiString uiStringKey={Key.PARTY_NAME} uiStringSubKey={party.id}>
       {party.name}
     </UiString>
   ),
+
+  [Key.PRECINCT_NAME]: (precinct: Precinct) => (
+    <UiString uiStringKey={Key.PRECINCT_NAME} uiStringSubKey={precinct.id}>
+      {precinct.name}
+    </UiString>
+  ),
+
+  [Key.STATE_NAME]: (election: Election) => (
+    <UiString uiStringKey={Key.STATE_NAME}>{election.state}</UiString>
+  ),
 } as const;
+// TODO(kofi): Update esbuild so we can use the `satisfies` operator here:
+// } satisfies Record<Key, unknown>;

--- a/libs/ui/src/ui_strings/election_strings.tsx
+++ b/libs/ui/src/ui_strings/election_strings.tsx
@@ -1,11 +1,4 @@
-import React from 'react';
-
-import {
-  Candidate,
-  Parties,
-  Party,
-  getCandidateParties,
-} from '@votingworks/types';
+import { Party } from '@votingworks/types';
 
 import { UiString } from './ui_string';
 
@@ -27,29 +20,3 @@ export const electionStrings = {
     </UiString>
   ),
 } as const;
-
-/**
- * Convenience function for rendering a translated list of parties associated
- * with a given candidate, along with the relevant audio.
- */
-export function renderCandidatePartyList(
-  candidate: Candidate,
-  electionParties: Parties
-): JSX.Element {
-  return (
-    <React.Fragment>
-      {getCandidateParties(electionParties, candidate).map((party, i) => (
-        <React.Fragment key={party.id}>
-          {/*
-           * TODO(kofi): This comma-delimiting isn't properly
-           * internationalized (comma character is rendered differently in
-           * different languages/character sets) -- need to figure out a clean
-           * way to do this.
-           */}
-          {i > 0 && <React.Fragment>, </React.Fragment>}
-          {electionStrings.partyName(party)}
-        </React.Fragment>
-      ))}
-    </React.Fragment>
-  );
-}

--- a/libs/ui/src/ui_strings/index.ts
+++ b/libs/ui/src/ui_strings/index.ts
@@ -1,3 +1,4 @@
 export * from './app_strings';
 export * from './election_strings';
 export * from './ui_strings_context';
+export * from './utils';

--- a/libs/ui/src/ui_strings/number_string.test.tsx
+++ b/libs/ui/src/ui_strings/number_string.test.tsx
@@ -1,0 +1,38 @@
+import { LanguageCode } from '@votingworks/types';
+import { H1 } from '..';
+import {
+  act,
+  render as renderWithoutContext,
+  screen,
+} from '../../test/react_testing_library';
+import { newTestContext } from '../../test/ui_strings/test_utils';
+import { NumberString } from './number_string';
+
+test('formats based on current language code', async () => {
+  const { getLanguageContext, mockBackendApi, render } = newTestContext();
+
+  mockBackendApi.getAvailableLanguages.mockResolvedValue([]);
+  mockBackendApi.getUiStrings.mockResolvedValue({});
+
+  render(
+    <H1>
+      <NumberString value={100000} />
+    </H1>
+  );
+
+  await screen.findByRole('heading', { name: '100,000' });
+
+  act(() => getLanguageContext()?.setLanguage(LanguageCode.SPANISH));
+
+  await screen.findByRole('heading', { name: '100.000' });
+});
+
+test('uses default language code with language context', async () => {
+  renderWithoutContext(
+    <H1>
+      <NumberString value={100000} />
+    </H1>
+  );
+
+  await screen.findByRole('heading', { name: '100,000' });
+});

--- a/libs/ui/src/ui_strings/number_string.tsx
+++ b/libs/ui/src/ui_strings/number_string.tsx
@@ -1,0 +1,18 @@
+import { format } from '@votingworks/utils';
+import { useLanguageContext } from './language_context';
+
+export interface NumberStringProps {
+  value: number;
+}
+export function NumberString(props: NumberStringProps): JSX.Element {
+  const { value } = props;
+
+  const languageContext = useLanguageContext();
+
+  return (
+    // TODO(kofi): fetch audio ID(s) for the given value.
+    <span data-audio-ids={undefined}>
+      {format.count(value, languageContext?.currentLanguageCode)}
+    </span>
+  );
+}

--- a/libs/ui/src/ui_strings/utils.test.tsx
+++ b/libs/ui/src/ui_strings/utils.test.tsx
@@ -1,5 +1,5 @@
 import { Candidate, LanguageCode, Parties, PartyId } from '@votingworks/types';
-import { renderCandidatePartyList } from './election_strings';
+import { renderCandidatePartyList } from './utils';
 import { newTestContext } from '../../test/ui_strings/test_utils';
 import { H1 } from '..';
 import { screen } from '../../test/react_testing_library';

--- a/libs/ui/src/ui_strings/utils.test.tsx
+++ b/libs/ui/src/ui_strings/utils.test.tsx
@@ -10,9 +10,13 @@ import {
 import { electionGeneral } from '@votingworks/fixtures';
 import { assertDefined } from '@votingworks/basics';
 import {
-  renderCandidatePartyList,
-  renderPrecinctSelectionName,
-  renderPrimaryElectionTitlePrefix,
+  ALL_PRECINCTS_SELECTION,
+  singlePrecinctSelectionFor,
+} from '@votingworks/utils';
+import {
+  CandidatePartyList,
+  PrecinctSelectionName,
+  PrimaryElectionTitlePrefix,
 } from './utils';
 import { newTestContext } from '../../test/ui_strings/test_utils';
 import { H1 } from '..';
@@ -38,7 +42,7 @@ const CANDIDATE: Readonly<Candidate> = {
   name: 'Professor Xavier',
 };
 
-test('renderCandidatePartyList - single-party association', async () => {
+test('CandidatePartyList - single-party association', async () => {
   const { mockBackendApi, render } = newTestContext();
   mockBackendApi.getAvailableLanguages.mockResolvedValue([
     LanguageCode.SPANISH,
@@ -53,20 +57,20 @@ test('renderCandidatePartyList - single-party association', async () => {
   render(
     <H1>
       Parties:{' '}
-      {renderCandidatePartyList(
-        {
+      <CandidatePartyList
+        candidate={{
           ...CANDIDATE,
           partyIds: [ELECTION_PARTIES[1].id],
-        },
-        ELECTION_PARTIES
-      )}
+        }}
+        electionParties={ELECTION_PARTIES}
+      />
     </H1>
   );
 
   await screen.findByRole('heading', { name: 'Parties: Federalista' });
 });
 
-test('renderCandidatePartyList - multi-party association', async () => {
+test('CandidatePartyList - multi-party association', async () => {
   const { mockBackendApi, render } = newTestContext();
   mockBackendApi.getAvailableLanguages.mockResolvedValue([
     LanguageCode.SPANISH,
@@ -81,13 +85,13 @@ test('renderCandidatePartyList - multi-party association', async () => {
   render(
     <H1>
       Parties:{' '}
-      {renderCandidatePartyList(
-        {
+      <CandidatePartyList
+        candidate={{
           ...CANDIDATE,
           partyIds: [ELECTION_PARTIES[1].id, ELECTION_PARTIES[0].id],
-        },
-        ELECTION_PARTIES
-      )}
+        }}
+        electionParties={ELECTION_PARTIES}
+      />
     </H1>
   );
 
@@ -99,21 +103,25 @@ test('renderCandidatePartyList - multi-party association', async () => {
   });
 });
 
-test('renderPrecinctSelectionName - all-precinct selection', async () => {
+test('PrecinctSelectionName - all-precinct selection', async () => {
   const { mockBackendApi, render } = newTestContext();
   mockBackendApi.getAvailableLanguages.mockResolvedValue([]);
   mockBackendApi.getUiStrings.mockResolvedValue(null);
 
   render(
     <H1>
-      Precincts: {renderPrecinctSelectionName([], { kind: 'AllPrecincts' })}
+      Precincts:{' '}
+      <PrecinctSelectionName
+        electionPrecincts={[]}
+        precinctSelection={ALL_PRECINCTS_SELECTION}
+      />
     </H1>
   );
 
   await screen.findByRole('heading', { name: 'Precincts: All Precincts' });
 });
 
-test('renderPrecinctSelectionName - single-precinct selection', async () => {
+test('PrecinctSelectionName - single-precinct selection', async () => {
   const selectedPrecinct: Precinct = {
     id: 'precinctIdOldTown',
     name: 'Old Town',
@@ -136,17 +144,17 @@ test('renderPrecinctSelectionName - single-precinct selection', async () => {
   render(
     <H1>
       Precincts:{' '}
-      {renderPrecinctSelectionName(precincts, {
-        kind: 'SinglePrecinct',
-        precinctId: 'precinctIdOldTown',
-      })}
+      <PrecinctSelectionName
+        electionPrecincts={precincts}
+        precinctSelection={singlePrecinctSelectionFor('precinctIdOldTown')}
+      />
     </H1>
   );
 
   await screen.findByRole('heading', { name: 'Precincts: Ciutat Vella' });
 });
 
-test('renderPrecinctSelectionName - no selection', async () => {
+test('PrecinctSelectionName - no selection', async () => {
   const precincts: readonly Precinct[] = [
     { id: 'precinctA', name: 'New Town' },
   ];
@@ -162,13 +170,15 @@ test('renderPrecinctSelectionName - no selection', async () => {
   });
 
   render(
-    <H1>Precincts: {renderPrecinctSelectionName(precincts, undefined)}</H1>
+    <H1>
+      Precincts: <PrecinctSelectionName electionPrecincts={precincts} />
+    </H1>
   );
 
   await screen.findByRole('heading', { name: 'Precincts:' });
 });
 
-test('renderPrimaryElectionTitlePrefix - party-specific ballot', async () => {
+test('PrimaryElectionTitlePrefix - party-specific ballot', async () => {
   const myParty: Party = {
     id: 'itsMyParty' as PartyId,
     fullName: "And I'll Cry If I Want To",
@@ -201,13 +211,19 @@ test('renderPrimaryElectionTitlePrefix - party-specific ballot', async () => {
   });
 
   render(
-    <H1>Prefix: {renderPrimaryElectionTitlePrefix('imp-ballot', election)}</H1>
+    <H1>
+      Prefix:{' '}
+      <PrimaryElectionTitlePrefix
+        ballotStyleId="imp-ballot"
+        election={election}
+      />
+    </H1>
   );
 
   await screen.findByRole('heading', { name: 'Prefix: Lloro Si Quiero' });
 });
 
-test('renderPrecinctSelectionName - non-party-specific ballot', async () => {
+test('PrecinctSelectionName - non-party-specific ballot', async () => {
   const election = electionGeneral;
   const ballotStyle = assertDefined(election.ballotStyles[0]);
 
@@ -217,7 +233,11 @@ test('renderPrecinctSelectionName - non-party-specific ballot', async () => {
 
   render(
     <H1>
-      Prefix: {renderPrimaryElectionTitlePrefix(ballotStyle.id, election)}
+      Prefix:{' '}
+      <PrimaryElectionTitlePrefix
+        ballotStyleId={ballotStyle.id}
+        election={election}
+      />
     </H1>
   );
 

--- a/libs/ui/src/ui_strings/utils.test.tsx
+++ b/libs/ui/src/ui_strings/utils.test.tsx
@@ -1,5 +1,19 @@
-import { Candidate, LanguageCode, Parties, PartyId } from '@votingworks/types';
-import { renderCandidatePartyList } from './utils';
+import {
+  Candidate,
+  Election,
+  LanguageCode,
+  Parties,
+  Party,
+  PartyId,
+  Precinct,
+} from '@votingworks/types';
+import { electionGeneral } from '@votingworks/fixtures';
+import { assertDefined } from '@votingworks/basics';
+import {
+  renderCandidatePartyList,
+  renderPrecinctSelectionName,
+  renderPrimaryElectionTitlePrefix,
+} from './utils';
 import { newTestContext } from '../../test/ui_strings/test_utils';
 import { H1 } from '..';
 import { screen } from '../../test/react_testing_library';
@@ -83,4 +97,129 @@ test('renderCandidatePartyList - multi-party association', async () => {
     // browser, so using a slightly more lenient regex here.
     name: /Parties: Federalista\s?, Libertad/,
   });
+});
+
+test('renderPrecinctSelectionName - all-precinct selection', async () => {
+  const { mockBackendApi, render } = newTestContext();
+  mockBackendApi.getAvailableLanguages.mockResolvedValue([]);
+  mockBackendApi.getUiStrings.mockResolvedValue(null);
+
+  render(
+    <H1>
+      Precincts: {renderPrecinctSelectionName([], { kind: 'AllPrecincts' })}
+    </H1>
+  );
+
+  await screen.findByRole('heading', { name: 'Precincts: All Precincts' });
+});
+
+test('renderPrecinctSelectionName - single-precinct selection', async () => {
+  const selectedPrecinct: Precinct = {
+    id: 'precinctIdOldTown',
+    name: 'Old Town',
+  };
+  const precincts: readonly Precinct[] = [
+    { id: 'precinctIdNewTown', name: 'New Town' },
+    selectedPrecinct,
+  ];
+
+  const { mockBackendApi, render } = newTestContext();
+  mockBackendApi.getAvailableLanguages.mockResolvedValue([
+    LanguageCode.SPANISH,
+  ]);
+  mockBackendApi.getUiStrings.mockResolvedValue({
+    precinctName: {
+      precinctIdOldTown: 'Ciutat Vella',
+    },
+  });
+
+  render(
+    <H1>
+      Precincts:{' '}
+      {renderPrecinctSelectionName(precincts, {
+        kind: 'SinglePrecinct',
+        precinctId: 'precinctIdOldTown',
+      })}
+    </H1>
+  );
+
+  await screen.findByRole('heading', { name: 'Precincts: Ciutat Vella' });
+});
+
+test('renderPrecinctSelectionName - no selection', async () => {
+  const precincts: readonly Precinct[] = [
+    { id: 'precinctA', name: 'New Town' },
+  ];
+
+  const { mockBackendApi, render } = newTestContext();
+  mockBackendApi.getAvailableLanguages.mockResolvedValue([
+    LanguageCode.SPANISH,
+  ]);
+  mockBackendApi.getUiStrings.mockResolvedValue({
+    precinctName: {
+      precinctB: 'Ciutat Vella',
+    },
+  });
+
+  render(
+    <H1>Precincts: {renderPrecinctSelectionName(precincts, undefined)}</H1>
+  );
+
+  await screen.findByRole('heading', { name: 'Precincts:' });
+});
+
+test('renderPrimaryElectionTitlePrefix - party-specific ballot', async () => {
+  const myParty: Party = {
+    id: 'itsMyParty' as PartyId,
+    fullName: "And I'll Cry If I Want To",
+    name: 'Cry If I Want To',
+    abbrev: 'IMP',
+  };
+
+  const election: Election = {
+    ...electionGeneral,
+    ballotStyles: [
+      ...electionGeneral.ballotStyles,
+      {
+        id: 'imp-ballot',
+        districts: [],
+        precincts: [],
+        partyId: myParty.id,
+      },
+    ],
+    parties: [...electionGeneral.parties, myParty],
+  };
+
+  const { mockBackendApi, render } = newTestContext();
+  mockBackendApi.getAvailableLanguages.mockResolvedValue([
+    LanguageCode.SPANISH,
+  ]);
+  mockBackendApi.getUiStrings.mockResolvedValue({
+    partyName: {
+      itsMyParty: 'Lloro Si Quiero',
+    },
+  });
+
+  render(
+    <H1>Prefix: {renderPrimaryElectionTitlePrefix('imp-ballot', election)}</H1>
+  );
+
+  await screen.findByRole('heading', { name: 'Prefix: Lloro Si Quiero' });
+});
+
+test('renderPrecinctSelectionName - non-party-specific ballot', async () => {
+  const election = electionGeneral;
+  const ballotStyle = assertDefined(election.ballotStyles[0]);
+
+  const { mockBackendApi, render } = newTestContext();
+  mockBackendApi.getAvailableLanguages.mockResolvedValue([]);
+  mockBackendApi.getUiStrings.mockResolvedValue({});
+
+  render(
+    <H1>
+      Prefix: {renderPrimaryElectionTitlePrefix(ballotStyle.id, election)}
+    </H1>
+  );
+
+  await screen.findByRole('heading', { name: 'Prefix:' });
 });

--- a/libs/ui/src/ui_strings/utils.tsx
+++ b/libs/ui/src/ui_strings/utils.tsx
@@ -16,13 +16,15 @@ import { appStrings } from './app_strings';
 import { electionStrings } from './election_strings';
 
 /**
- * Convenience function for rendering a translated list of parties associated
+ * Convenience component for rendering a translated list of parties associated
  * with a given candidate, along with the relevant audio.
  */
-export function renderCandidatePartyList(
-  candidate: Candidate,
-  electionParties: Parties
-): JSX.Element {
+export function CandidatePartyList(props: {
+  candidate: Candidate;
+  electionParties: Parties;
+}): JSX.Element {
+  const { candidate, electionParties } = props;
+
   return (
     <React.Fragment>
       {getCandidateParties(electionParties, candidate).map((party, i) => (
@@ -41,10 +43,12 @@ export function renderCandidatePartyList(
   );
 }
 
-export function renderPrecinctSelectionName(
-  electionPrecincts: readonly Precinct[],
-  precinctSelection?: PrecinctSelection
-): React.ReactNode {
+export function PrecinctSelectionName(props: {
+  electionPrecincts: readonly Precinct[];
+  precinctSelection?: PrecinctSelection;
+}): React.ReactNode {
+  const { electionPrecincts, precinctSelection } = props;
+
   if (!precinctSelection) {
     return null;
   }
@@ -58,10 +62,11 @@ export function renderPrecinctSelectionName(
   return electionStrings.precinctName(precinct);
 }
 
-export function renderPrimaryElectionTitlePrefix(
-  ballotStyleId: BallotStyleId,
-  election: Election
-): React.ReactNode {
+export function PrimaryElectionTitlePrefix(props: {
+  ballotStyleId: BallotStyleId;
+  election: Election;
+}): React.ReactNode {
+  const { ballotStyleId, election } = props;
   const party = getPartyForBallotStyle({ ballotStyleId, election });
   if (!party) {
     return null;

--- a/libs/ui/src/ui_strings/utils.tsx
+++ b/libs/ui/src/ui_strings/utils.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import { Candidate, Parties, getCandidateParties } from '@votingworks/types';
+
+import { electionStrings } from './election_strings';
+
+/**
+ * Convenience function for rendering a translated list of parties associated
+ * with a given candidate, along with the relevant audio.
+ */
+export function renderCandidatePartyList(
+  candidate: Candidate,
+  electionParties: Parties
+): JSX.Element {
+  return (
+    <React.Fragment>
+      {getCandidateParties(electionParties, candidate).map((party, i) => (
+        <React.Fragment key={party.id}>
+          {/*
+           * TODO(kofi): This comma-delimiting isn't properly
+           * internationalized (comma character is rendered differently in
+           * different languages/character sets) -- need to figure out a clean
+           * way to do this.
+           */}
+          {i > 0 && <React.Fragment>, </React.Fragment>}
+          {electionStrings.partyName(party)}
+        </React.Fragment>
+      ))}
+    </React.Fragment>
+  );
+}

--- a/libs/ui/src/ui_strings/utils.tsx
+++ b/libs/ui/src/ui_strings/utils.tsx
@@ -1,7 +1,18 @@
 import React from 'react';
 
-import { Candidate, Parties, getCandidateParties } from '@votingworks/types';
+import {
+  BallotStyleId,
+  Candidate,
+  Election,
+  Parties,
+  Precinct,
+  PrecinctSelection,
+  getCandidateParties,
+  getPartyForBallotStyle,
+} from '@votingworks/types';
+import { getPrecinctSelection } from '@votingworks/utils';
 
+import { appStrings } from './app_strings';
 import { electionStrings } from './election_strings';
 
 /**
@@ -28,4 +39,33 @@ export function renderCandidatePartyList(
       ))}
     </React.Fragment>
   );
+}
+
+export function renderPrecinctSelectionName(
+  electionPrecincts: readonly Precinct[],
+  precinctSelection?: PrecinctSelection
+): React.ReactNode {
+  if (!precinctSelection) {
+    return null;
+  }
+
+  if (precinctSelection.kind === 'AllPrecincts') {
+    return appStrings.labelAllPrecinctsSelection();
+  }
+
+  const precinct = getPrecinctSelection(electionPrecincts, precinctSelection);
+
+  return electionStrings.precinctName(precinct);
+}
+
+export function renderPrimaryElectionTitlePrefix(
+  ballotStyleId: BallotStyleId,
+  election: Election
+): React.ReactNode {
+  const party = getPartyForBallotStyle({ ballotStyleId, election });
+  if (!party) {
+    return null;
+  }
+
+  return electionStrings.partyFullName(party);
 }

--- a/libs/utils/src/extract_cdf_ui_strings.test.ts
+++ b/libs/utils/src/extract_cdf_ui_strings.test.ts
@@ -162,6 +162,10 @@ const tests: Record<ElectionStringKey, () => void> = {
     });
   },
 
+  [ElectionStringKey.PARTY_FULL_NAME]() {
+    // TODO(kofi): Implement
+  },
+
   [ElectionStringKey.PARTY_NAME]() {
     // TODO(kofi): Implement
   },

--- a/libs/utils/src/extract_cdf_ui_strings.ts
+++ b/libs/utils/src/extract_cdf_ui_strings.ts
@@ -121,6 +121,10 @@ const extractorFns: Record<
     });
   },
 
+  [ElectionStringKey.PARTY_FULL_NAME](_cdfElection, _uiStrings) {
+    // TODO(kofi): Implement
+  },
+
   [ElectionStringKey.PARTY_NAME](_cdfElection, _uiStrings) {
     // TODO(kofi): Implement
   },

--- a/libs/utils/src/format.test.ts
+++ b/libs/utils/src/format.test.ts
@@ -1,3 +1,4 @@
+import { LanguageCode } from '@votingworks/types';
 import * as format from './format';
 
 test('formats counts properly', () => {
@@ -14,6 +15,8 @@ test('formats counts properly', () => {
   expect(format.count(-3141)).toEqual('-3,141');
   expect(format.count(-1000000)).toEqual('-1,000,000');
   expect(format.count(-3141098210928)).toEqual('-3,141,098,210,928');
+  expect(format.count(40240, LanguageCode.ENGLISH)).toEqual('40,240');
+  expect(format.count(40240, LanguageCode.SPANISH)).toEqual('40.240');
 });
 
 test('formats locale long date and time properly', () => {
@@ -32,6 +35,24 @@ test('formats locale long date properly', () => {
   expect(format.localeLongDate(new Date(2020, 3, 14, 1, 15, 9, 26))).toEqual(
     'April 14, 2020'
   );
+  expect(
+    format.localeLongDate(
+      new Date(2020, 3, 14, 1, 15, 9, 26),
+      LanguageCode.ENGLISH
+    )
+  ).toEqual('April 14, 2020');
+  expect(
+    format.localeLongDate(
+      new Date(2020, 3, 14, 1, 15, 9, 26),
+      LanguageCode.SPANISH
+    )
+  ).toEqual('14 de abril de 2020');
+  expect(
+    format.localeLongDate(
+      new Date(2020, 3, 14, 1, 15, 9, 26),
+      LanguageCode.CHINESE
+    )
+  ).toEqual('2020年4月14日');
 });
 
 test('formats locale date properly', () => {

--- a/libs/utils/src/format.ts
+++ b/libs/utils/src/format.ts
@@ -1,10 +1,15 @@
-const countFormatter = new Intl.NumberFormat(undefined, { useGrouping: true });
+import { LanguageCode } from '@votingworks/types';
+
+export const DEFAULT_LOCALE: LanguageCode = LanguageCode.ENGLISH;
 
 /**
  * Format integers for display as whole numbers, i.e. a count of something.
  */
-export function count(value: number): string {
-  return countFormatter.format(value);
+export function count(
+  value: number,
+  locale: LanguageCode = DEFAULT_LOCALE
+): string {
+  return new Intl.NumberFormat(locale, { useGrouping: true }).format(value);
 }
 
 /**
@@ -25,8 +30,6 @@ export function percent(
   });
   return percentFormatter.format(value);
 }
-
-export const DEFAULT_LOCALE = 'en-US';
 
 export function localeLongDateAndTime(time?: number | Date): string {
   return new Intl.DateTimeFormat(DEFAULT_LOCALE, {
@@ -50,8 +53,11 @@ export function localeWeekdayAndDate(time?: number | Date): string {
   }).format(time);
 }
 
-export function localeLongDate(time?: number | Date): string {
-  return new Intl.DateTimeFormat(DEFAULT_LOCALE, {
+export function localeLongDate(
+  time?: number | Date,
+  locale: LanguageCode = DEFAULT_LOCALE
+): string {
+  return new Intl.DateTimeFormat(locale, {
     month: 'long',
     day: 'numeric',
     year: 'numeric',

--- a/libs/utils/src/precinct_selection.ts
+++ b/libs/utils/src/precinct_selection.ts
@@ -22,6 +22,13 @@ export const ALL_PRECINCTS_SELECTION: AllPrecinctsSelection = {
 
 export const ALL_PRECINCTS_NAME = 'All Precincts';
 
+export function getPrecinctSelection(
+  precincts: readonly Precinct[],
+  precinctSelection: SinglePrecinctSelection
+): Precinct {
+  return find(precincts, (p) => p.id === precinctSelection.precinctId);
+}
+
 export function getPrecinctSelectionName(
   precincts: readonly Precinct[],
   precinctSelection: PrecinctSelection
@@ -30,7 +37,7 @@ export function getPrecinctSelectionName(
     return ALL_PRECINCTS_NAME;
   }
 
-  return find(precincts, (p) => p.id === precinctSelection.precinctId).name;
+  return getPrecinctSelection(precincts, precinctSelection).name;
 }
 
 export function areEqualPrecinctSelections(


### PR DESCRIPTION
## Overview

_Easier by commit_

_Related spec [here](https://docs.google.com/document/d/1a2GRj1g4aOawEssPdTCgbv-qs28d-M_dyMEfzm4I4nM/edit?usp=sharing)._

Fleshing out `@votingworks/ui/electionStrings` to include all the translatable/spoken strings in the election definition so far.

Making the `VxMark` `StartPage` language-aware to test out the new election strings, which led to adding support for number and date i18n -- the audio piece of that is going to require a bit more planning and coordination with the VxDesign work, so I'll start writing up some thoughts in the spec.
- Also, to avoid audio interpolation, the previous `"Your ballot contains x contests."` string is now `"Number of contests on your ballot: x"`

## Demo Video or Screenshot

https://github.com/votingworks/vxsuite/assets/264902/481d65a7-4c80-4d98-bcdd-3794d9613fca

## Testing Plan
- Unit tests for the new ui string utils
- Updated expectations in existing tests for changed strings/HTML structures
- Manually tested `StartPage` in different languages with mock translations.

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
