### PR TITLE
VxDesign: Basic desktop size theme

### DIFF
--- a/apps/admin/frontend/src/index.tsx
+++ b/apps/admin/frontend/src/index.tsx
@@ -27,7 +27,7 @@ root.render(
   <React.StrictMode>
     <AppBase
       defaultColorMode="contrastMedium"
-      defaultSizeMode="s"
+      defaultSizeMode="touchSmall"
       screenType="lenovoThinkpad15"
       legacyPrintFontSizePx={PRINT_FONT_SIZE_PX}
     >

--- a/apps/central-scan/frontend/src/app.tsx
+++ b/apps/central-scan/frontend/src/app.tsx
@@ -30,7 +30,7 @@ export function App({
     <BrowserRouter>
       <AppBase
         defaultColorMode="contrastMedium"
-        defaultSizeMode="s"
+        defaultSizeMode="touchSmall"
         screenType="lenovoThinkpad15"
       >
         <ErrorBoundary

--- a/apps/design/frontend/src/app.tsx
+++ b/apps/design/frontend/src/app.tsx
@@ -74,7 +74,7 @@ const StyleOverrides = styled.div`
 
 export function App(): JSX.Element {
   return (
-    <AppBase defaultColorMode="contrastMedium" defaultSizeMode="s">
+    <AppBase defaultColorMode="contrastMedium" defaultSizeMode="touchSmall">
       <StyleOverrides>
         <ApiClientContext.Provider value={createApiClient()}>
           <QueryClientProvider client={createQueryClient()}>

--- a/apps/design/frontend/src/app.tsx
+++ b/apps/design/frontend/src/app.tsx
@@ -74,7 +74,7 @@ const StyleOverrides = styled.div`
 
 export function App(): JSX.Element {
   return (
-    <AppBase defaultColorMode="contrastMedium" defaultSizeMode="touchSmall">
+    <AppBase defaultColorMode="contrastMedium" defaultSizeMode="desktop">
       <StyleOverrides>
         <ApiClientContext.Provider value={createApiClient()}>
           <QueryClientProvider client={createQueryClient()}>

--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -484,7 +484,7 @@ function ContestForm({
                             })
                           }
                         >
-                          <Icons.DangerX /> Remove Candidate
+                          Remove Candidate
                         </Button>
                       </TD>
                     </tr>
@@ -522,7 +522,7 @@ function ContestForm({
         {contestId && (
           <FormActionsRow style={{ marginTop: '1rem' }}>
             <Button variant="danger" onPress={onDeletePress}>
-              <Icons.DangerX /> Delete Contest
+              Delete Contest
             </Button>
           </FormActionsRow>
         )}

--- a/apps/design/frontend/src/election_info_screen.tsx
+++ b/apps/design/frontend/src/election_info_screen.tsx
@@ -190,7 +190,7 @@ function ElectionInfoForm({
               onPress={onDeletePress}
               disabled={deleteElectionMutation.isLoading}
             >
-              <Icons.DangerX /> Delete Election
+              Delete Election
             </Button>
           </FormActionsRow>
         </div>

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -230,7 +230,7 @@ function DistrictForm({
               onPress={onDeletePress}
               disabled={updateElectionMutation.isLoading}
             >
-              <Icons.DangerX /> Delete District
+              Delete District
             </Button>
           </FormActionsRow>
         )}
@@ -572,7 +572,7 @@ function PrecinctForm({
                     />
                   </FormField>
                   <Button onPress={() => onRemoveSplitPress(split.id)}>
-                    <Icons.DangerX /> Remove Split
+                    Remove Split
                   </Button>
                 </Card>
               ))}

--- a/apps/design/frontend/src/tabs.tsx
+++ b/apps/design/frontend/src/tabs.tsx
@@ -14,14 +14,16 @@ interface TabBarProps {
 
 const TabRow = styled(Row)`
   gap: 0.5rem;
-  border-bottom: 2px solid ${({ theme }) => theme.colors.foreground};
+  border-bottom: 2px solid ${(p) => p.theme.colors.foreground};
 `;
 
 const TabButton = styled(Button)<{ isActive: boolean }>`
   min-width: 8rem;
   border-radius: 0.25rem 0.25rem 0 0;
   border-bottom-width: 0;
-  background: ${({ isActive }) => (isActive ? '' : 'none')};
+  color: ${(p) =>
+    p.isActive ? p.theme.colors.background : p.theme.colors.foreground};
+  background: ${(p) => (p.isActive ? p.theme.colors.foreground : 'none')};
 `;
 
 export function TabBar({ tabs }: TabBarProps): JSX.Element {

--- a/apps/mark-scan/frontend/src/app.tsx
+++ b/apps/mark-scan/frontend/src/app.tsx
@@ -36,7 +36,7 @@ window.oncontextmenu = (e: MouseEvent): void => {
 
 const DEFAULT_COLOR_MODE: ColorMode = 'contrastMedium';
 const DEFAULT_SCREEN_TYPE: ScreenType = 'elo15';
-const DEFAULT_SIZE_MODE: SizeMode = 'm';
+const DEFAULT_SIZE_MODE: SizeMode = 'touchMedium';
 
 export interface Props {
   hardware?: AppRootProps['hardware'];

--- a/apps/mark/frontend/src/app.tsx
+++ b/apps/mark/frontend/src/app.tsx
@@ -36,7 +36,7 @@ window.oncontextmenu = (e: MouseEvent): void => {
 
 const DEFAULT_COLOR_MODE: ColorMode = 'contrastMedium';
 const DEFAULT_SCREEN_TYPE: ScreenType = 'elo15';
-const DEFAULT_SIZE_MODE: SizeMode = 'm';
+const DEFAULT_SIZE_MODE: SizeMode = 'touchMedium';
 
 export interface Props {
   hardware?: AppRootProps['hardware'];

--- a/apps/scan/frontend/src/components/display_settings_manager.test.tsx
+++ b/apps/scan/frontend/src/components/display_settings_manager.test.tsx
@@ -49,7 +49,7 @@ beforeEach(() => {
     {
       vxTheme: {
         colorMode: 'contrastMedium',
-        sizeMode: 'm',
+        sizeMode: 'touchMedium',
       },
     }
   );
@@ -57,7 +57,7 @@ beforeEach(() => {
   expect(currentTheme).toEqual(
     expect.objectContaining<Partial<DefaultTheme>>({
       colorMode: 'contrastMedium',
-      sizeMode: 'm',
+      sizeMode: 'touchMedium',
     })
   );
 });
@@ -70,13 +70,13 @@ test('Resets theme when election official logs in', async () => {
   // Simulate changing display settings as voter:
   act(() => {
     themeManager.setColorMode('contrastLow');
-    themeManager.setSizeMode('xl');
+    themeManager.setSizeMode('touchExtraLarge');
   });
 
   expect(currentTheme).toEqual(
     expect.objectContaining<Partial<DefaultTheme>>({
       colorMode: 'contrastLow',
-      sizeMode: 'xl',
+      sizeMode: 'touchExtraLarge',
     })
   );
 
@@ -86,7 +86,7 @@ test('Resets theme when election official logs in', async () => {
     expect(currentTheme).toEqual(
       expect.objectContaining<Partial<DefaultTheme>>({
         colorMode: 'contrastMedium',
-        sizeMode: 'm',
+        sizeMode: 'touchMedium',
       })
     )
   );
@@ -94,13 +94,13 @@ test('Resets theme when election official logs in', async () => {
   // Simulate changing display settings as Election Manager:
   act(() => {
     themeManager.setColorMode('contrastHighDark');
-    themeManager.setSizeMode('s');
+    themeManager.setSizeMode('touchSmall');
   });
   await waitFor(() =>
     expect(currentTheme).toEqual(
       expect.objectContaining<Partial<DefaultTheme>>({
         colorMode: 'contrastHighDark',
-        sizeMode: 's',
+        sizeMode: 'touchSmall',
       })
     )
   );
@@ -111,7 +111,7 @@ test('Resets theme when election official logs in', async () => {
     expect(currentTheme).toEqual(
       expect.objectContaining<Partial<DefaultTheme>>({
         colorMode: 'contrastLow',
-        sizeMode: 'xl',
+        sizeMode: 'touchExtraLarge',
       })
     )
   );
@@ -128,12 +128,12 @@ test('Resets theme after successful scan', async () => {
       // Simulate initial voter display settings:
       act(() => {
         themeManager.setColorMode('contrastHighDark');
-        themeManager.setSizeMode('xl');
+        themeManager.setSizeMode('touchExtraLarge');
       });
       expect(currentTheme).toEqual(
         expect.objectContaining<Partial<DefaultTheme>>({
           colorMode: 'contrastHighDark',
-          sizeMode: 'xl',
+          sizeMode: 'touchExtraLarge',
         })
       );
 
@@ -148,7 +148,7 @@ test('Resets theme after successful scan', async () => {
           expect(currentTheme).toEqual(
             expect.objectContaining<Partial<DefaultTheme>>({
               colorMode: 'contrastMedium',
-              sizeMode: 'm',
+              sizeMode: 'touchMedium',
             })
           )
         );
@@ -158,7 +158,7 @@ test('Resets theme after successful scan', async () => {
           expect(currentTheme).toEqual(
             expect.objectContaining<Partial<DefaultTheme>>({
               colorMode: 'contrastHighDark',
-              sizeMode: 'xl',
+              sizeMode: 'touchExtraLarge',
             })
           )
         );

--- a/apps/scan/frontend/src/components/layout.tsx
+++ b/apps/scan/frontend/src/components/layout.tsx
@@ -16,8 +16,8 @@ import { ScreenHeader } from './screen_header';
  * space, so we're hiding it in cases where a voter increases text size.
  */
 const ELECTION_BAR_HIDDEN_SIZE_MODES: ReadonlySet<SizeMode> = new Set([
-  'l',
-  'xl',
+  'touchLarge',
+  'touchExtraLarge',
 ]);
 
 export interface ScreenProps {

--- a/apps/scan/frontend/src/components/misvote_warnings/constants.ts
+++ b/apps/scan/frontend/src/components/misvote_warnings/constants.ts
@@ -10,22 +10,22 @@ import { MisvoteWarningsConfig } from './types';
  * Can be tweaked as needed, as the product evolves.
  */
 export const CONFIG: Readonly<Record<SizeMode, MisvoteWarningsConfig>> = {
-  s: {
+  touchSmall: {
     maxCardsPerRow: 3,
     maxColumnsPerCard: 3,
     maxPreviewContestRows: 8,
   },
-  m: {
+  touchMedium: {
     maxCardsPerRow: 2,
     maxColumnsPerCard: 2,
     maxPreviewContestRows: 4,
   },
-  l: {
+  touchLarge: {
     maxCardsPerRow: 1,
     maxColumnsPerCard: 2,
     maxPreviewContestRows: 3,
   },
-  xl: {
+  touchExtraLarge: {
     maxCardsPerRow: 1,
     maxColumnsPerCard: 1,
     maxPreviewContestRows: 2,

--- a/apps/scan/frontend/src/components/misvote_warnings/constants.ts
+++ b/apps/scan/frontend/src/components/misvote_warnings/constants.ts
@@ -1,15 +1,15 @@
-import { SizeMode } from '@votingworks/types';
+import { TouchSizeMode } from '@votingworks/types';
 import { MisvoteWarningsConfig } from './types';
 
 /**
- * Layout configuration params for each {@link SizeMode} - these were manually
+ * Layout configuration params for each {@link TouchSizeMode} - these were manually
  * tuned to make sure we display the full warning details whenever we can fit
  * them all on the main ScanWarningScreen without needing to scroll and display
  * a summary with a details modal button otherwise.
  *
  * Can be tweaked as needed, as the product evolves.
  */
-export const CONFIG: Readonly<Record<SizeMode, MisvoteWarningsConfig>> = {
+export const CONFIG: Readonly<Record<TouchSizeMode, MisvoteWarningsConfig>> = {
   touchSmall: {
     maxCardsPerRow: 3,
     maxColumnsPerCard: 3,

--- a/apps/scan/frontend/src/components/misvote_warnings/use_layout_config_hook.test.tsx
+++ b/apps/scan/frontend/src/components/misvote_warnings/use_layout_config_hook.test.tsx
@@ -24,17 +24,21 @@ test('varies according to size mode', () => {
     partiallyVotedContests: generateContests(3),
   };
 
-  render(<TestComponent {...props} />, { vxTheme: { sizeMode: 'xl' } });
+  render(<TestComponent {...props} />, {
+    vxTheme: { sizeMode: 'touchExtraLarge' },
+  });
   const layoutXl = hookResult;
 
-  render(<TestComponent {...props} />, { vxTheme: { sizeMode: 'm' } });
+  render(<TestComponent {...props} />, {
+    vxTheme: { sizeMode: 'touchMedium' },
+  });
   const layoutM = hookResult;
 
   expect(layoutXl).not.toEqual(layoutM);
 });
 
 test('sets numCardsPerRow appropriately', () => {
-  const sizeMode: SizeMode = 'm';
+  const sizeMode: SizeMode = 'touchMedium';
   const config = CONFIG[sizeMode];
 
   const { rerender } = render(
@@ -66,7 +70,7 @@ test('sets numCardsPerRow appropriately', () => {
 });
 
 test('sets maxColumnsPerCard appropriately', () => {
-  const sizeMode: SizeMode = 's';
+  const sizeMode: SizeMode = 'touchSmall';
   const config = CONFIG[sizeMode];
 
   // Should be `1` if there are multiple warning cards:
@@ -100,7 +104,7 @@ test('sets maxColumnsPerCard appropriately', () => {
 });
 
 test('sets showSummaryInPreview appropriately', () => {
-  const sizeMode: SizeMode = 'm';
+  const sizeMode: SizeMode = 'touchMedium';
   const config = CONFIG[sizeMode];
 
   // Make sure if the config gets changed, we know to update these test

--- a/apps/scan/frontend/src/components/misvote_warnings/use_layout_config_hook.ts
+++ b/apps/scan/frontend/src/components/misvote_warnings/use_layout_config_hook.ts
@@ -1,12 +1,15 @@
 import React from 'react';
 import { useTheme } from 'styled-components';
 
+import { isTouchSizeMode } from '@votingworks/types';
+import { assert } from '@votingworks/basics';
 import { CONFIG } from './constants';
 import { Layout, MisvoteWarningsProps } from './types';
 
 export function useLayoutConfig(props: MisvoteWarningsProps): Layout {
   const { blankContests, overvoteContests, partiallyVotedContests } = props;
   const { sizeMode } = useTheme();
+  assert(isTouchSizeMode(sizeMode));
   const config = CONFIG[sizeMode];
 
   return React.useMemo(() => {

--- a/apps/scan/frontend/src/scan_app_base.tsx
+++ b/apps/scan/frontend/src/scan_app_base.tsx
@@ -9,7 +9,7 @@ export interface AppBaseProps {
 
 const DEFAULT_COLOR_MODE: ColorMode = 'contrastMedium';
 const DEFAULT_SCREEN_TYPE: ScreenType = 'elo13';
-const DEFAULT_SIZE_MODE: SizeMode = 'm';
+const DEFAULT_SIZE_MODE: SizeMode = 'touchMedium';
 
 /**
  * Installs global styles and UI themes - should be rendered at the root of the

--- a/libs/mark-flow-ui/.storybook/preview.tsx
+++ b/libs/mark-flow-ui/.storybook/preview.tsx
@@ -21,12 +21,12 @@ type ColorModeToolBarItem = ToolbarItem<ColorMode>;
 
 type SizeModeToolBarItem = ToolbarItem<SizeMode>;
 
-const DEFAULT_SIZE_MODE: SizeMode = 'm';
+const DEFAULT_SIZE_MODE: SizeMode = 'touchMedium';
 const sizeThemeToolBarItems: Record<SizeMode, SizeModeToolBarItem> = {
-  s: { title: 'Size Theme - S', value: 's' },
-  m: { title: 'Size Theme - M', value: 'm' },
-  l: { title: 'Size Theme - L', value: 'l' },
-  xl: { title: 'Size Theme - XL', value: 'xl' },
+  touchSmall: { title: 'Size Theme - S', value: 'touchSmall' },
+  touchMedium: { title: 'Size Theme - M', value: 'touchMedium' },
+  touchLarge: { title: 'Size Theme - L', value: 'touchLarge' },
+  touchExtraLarge: { title: 'Size Theme - XL', value: 'touchExtraLarge' },
 };
 
 const DEFAULT_COLOR_MODE: ColorMode = 'contrastHighLight';

--- a/libs/mark-flow-ui/.storybook/preview.tsx
+++ b/libs/mark-flow-ui/.storybook/preview.tsx
@@ -6,7 +6,7 @@ import {
   StoryContext,
 } from '@storybook/types';
 
-import { ColorMode, SizeMode } from '@votingworks/types';
+import { ColorMode, TouchSizeMode } from '@votingworks/types';
 import { AppBase, ThemeManagerContext } from '@votingworks/ui';
 
 // TODO: Find the storybook.js type declaration for this. Doesn't seem to be in
@@ -19,14 +19,17 @@ interface ToolbarItem<T> {
 
 type ColorModeToolBarItem = ToolbarItem<ColorMode>;
 
-type SizeModeToolBarItem = ToolbarItem<SizeMode>;
+type SizeModeToolBarItem = ToolbarItem<TouchSizeMode>;
 
-const DEFAULT_SIZE_MODE: SizeMode = 'touchMedium';
-const sizeThemeToolBarItems: Record<SizeMode, SizeModeToolBarItem> = {
-  touchSmall: { title: 'Size Theme - S', value: 'touchSmall' },
-  touchMedium: { title: 'Size Theme - M', value: 'touchMedium' },
-  touchLarge: { title: 'Size Theme - L', value: 'touchLarge' },
-  touchExtraLarge: { title: 'Size Theme - XL', value: 'touchExtraLarge' },
+const DEFAULT_SIZE_MODE: TouchSizeMode = 'touchMedium';
+const sizeThemeToolBarItems: Record<TouchSizeMode, SizeModeToolBarItem> = {
+  touchSmall: { title: 'Small (Touch)', value: 'touchSmall' },
+  touchMedium: { title: 'Medium (Touch)', value: 'touchMedium' },
+  touchLarge: { title: 'Large (Touch)', value: 'touchLarge' },
+  touchExtraLarge: {
+    title: 'Extra Large (Touch)',
+    value: 'touchExtraLarge',
+  },
 };
 
 const DEFAULT_COLOR_MODE: ColorMode = 'contrastHighLight';
@@ -101,7 +104,7 @@ function StoryWrapper(props: {
   const { children, context } = props;
   const globals = context.globals as {
     colorMode: ColorMode;
-    sizeMode: SizeMode;
+    sizeMode: TouchSizeMode;
   };
 
   const { setColorMode, setSizeMode } = React.useContext(ThemeManagerContext);
@@ -127,7 +130,7 @@ export const decorators: DecoratorFunction[] = [
   ) => {
     const globals = context.globals as {
       colorMode: ColorMode;
-      sizeMode: SizeMode;
+      sizeMode: TouchSizeMode;
     };
     return (
       <AppBase

--- a/libs/mark-flow-ui/src/hooks/use_display_settings_manager.test.tsx
+++ b/libs/mark-flow-ui/src/hooks/use_display_settings_manager.test.tsx
@@ -18,7 +18,7 @@ import {
 
 const DEFAULT_THEME: Partial<DefaultTheme> = {
   colorMode: 'contrastMedium',
-  sizeMode: 'm',
+  sizeMode: 'touchMedium',
 };
 const ACTIVE_VOTING_SESSION_VOTES: VotesDict = {};
 const NEW_VOTING_SESSION_VOTES = undefined;
@@ -51,19 +51,19 @@ test('Resets theme when election official logs in', () => {
   expect(currentTheme).toEqual(
     expect.objectContaining<Partial<DefaultTheme>>({
       colorMode: 'contrastMedium',
-      sizeMode: 'm',
+      sizeMode: 'touchMedium',
     })
   );
 
   // Simulate changing display settings as voter:
   act(() => {
     themeManager.setColorMode('contrastLow');
-    themeManager.setSizeMode('xl');
+    themeManager.setSizeMode('touchExtraLarge');
   });
   expect(currentTheme).toEqual(
     expect.objectContaining<Partial<DefaultTheme>>({
       colorMode: 'contrastLow',
-      sizeMode: 'xl',
+      sizeMode: 'touchExtraLarge',
     })
   );
 
@@ -85,12 +85,12 @@ test('Resets theme when election official logs in', () => {
   // Simulate changing display settings as Election Manager:
   act(() => {
     themeManager.setColorMode('contrastHighDark');
-    themeManager.setSizeMode('s');
+    themeManager.setSizeMode('touchSmall');
   });
   expect(currentTheme).toEqual(
     expect.objectContaining<Partial<DefaultTheme>>({
       colorMode: 'contrastHighDark',
-      sizeMode: 's',
+      sizeMode: 'touchSmall',
     })
   );
 
@@ -108,7 +108,7 @@ test('Resets theme when election official logs in', () => {
   expect(currentTheme).toEqual(
     expect.objectContaining<Partial<DefaultTheme>>({
       colorMode: 'contrastLow',
-      sizeMode: 'xl',
+      sizeMode: 'touchExtraLarge',
     })
   );
 });
@@ -129,13 +129,13 @@ test('Resets theme to default if returning to a new voter session', () => {
   // Simulate changing display settings as voter:
   act(() => {
     themeManager.setColorMode('contrastLow');
-    themeManager.setSizeMode('xl');
+    themeManager.setSizeMode('touchExtraLarge');
   });
 
   expect(currentTheme).toEqual(
     expect.objectContaining<Partial<DefaultTheme>>({
       colorMode: 'contrastLow',
-      sizeMode: 'xl',
+      sizeMode: 'touchExtraLarge',
     })
   );
 
@@ -152,12 +152,12 @@ test('Resets theme to default if returning to a new voter session', () => {
   );
   act(() => {
     themeManager.setColorMode('contrastHighDark');
-    themeManager.setSizeMode('s');
+    themeManager.setSizeMode('touchSmall');
   });
   expect(currentTheme).toEqual(
     expect.objectContaining<Partial<DefaultTheme>>({
       colorMode: 'contrastHighDark',
-      sizeMode: 's',
+      sizeMode: 'touchSmall',
     })
   );
 

--- a/libs/types/src/ui_theme.test.tsx
+++ b/libs/types/src/ui_theme.test.tsx
@@ -1,0 +1,9 @@
+import { isTouchSizeMode } from '.';
+
+test('isTouchSizeMode', () => {
+  expect(isTouchSizeMode('desktop')).toEqual(false);
+  expect(isTouchSizeMode('touchSmall')).toEqual(true);
+  expect(isTouchSizeMode('touchMedium')).toEqual(true);
+  expect(isTouchSizeMode('touchLarge')).toEqual(true);
+  expect(isTouchSizeMode('touchExtraLarge')).toEqual(true);
+});

--- a/libs/types/src/ui_theme.ts
+++ b/libs/types/src/ui_theme.ts
@@ -8,12 +8,26 @@ export type ColorMode =
   | 'contrastMedium'
   | 'contrastLow';
 
+export const TOUCH_SIZE_MODES = [
+  'touchSmall',
+  'touchMedium',
+  'touchLarge',
+  'touchExtraLarge',
+] as const;
+
+/**  VVSG 2.0 compliant touchscreen size modes, used for voter-facing apps. */
+export type TouchSizeMode = (typeof TOUCH_SIZE_MODES)[number];
+
+/** Standard size mode for non-voter-facing desktop apps. */
+export type DesktopSizeMode = 'desktop';
+
 /** Options for supported UI sizing themes. */
-export type SizeMode =
-  | 'touchSmall'
-  | 'touchMedium'
-  | 'touchLarge'
-  | 'touchExtraLarge';
+export type SizeMode = DesktopSizeMode | TouchSizeMode;
+
+export function isTouchSizeMode(sizeMode: SizeMode): sizeMode is TouchSizeMode {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return TOUCH_SIZE_MODES.includes(sizeMode as any);
+}
 
 /** VX CSS color definitions. */
 export enum Color {

--- a/libs/types/src/ui_theme.ts
+++ b/libs/types/src/ui_theme.ts
@@ -9,7 +9,11 @@ export type ColorMode =
   | 'contrastLow';
 
 /** Options for supported UI sizing themes. */
-export type SizeMode = 's' | 'm' | 'l' | 'xl';
+export type SizeMode =
+  | 'touchSmall'
+  | 'touchMedium'
+  | 'touchLarge'
+  | 'touchExtraLarge';
 
 /** VX CSS color definitions. */
 export enum Color {

--- a/libs/ui/.storybook/preview.tsx
+++ b/libs/ui/.storybook/preview.tsx
@@ -31,10 +31,11 @@ const screenTypeToolBarItems: Record<ScreenType, ScreenTypeToolBarItem> = {
 
 const DEFAULT_SIZE_MODE: SizeMode = "touchMedium";
 const sizeThemeToolBarItems: Record<SizeMode, SizeModeToolBarItem> = {
-  touchSmall: { title: 'Size Theme - S', value: 'touchSmall'},
-  touchMedium: { title: 'Size Theme - M', value: 'touchMedium'},
-  touchLarge: { title: 'Size Theme - L', value: 'touchLarge'},
-  touchExtraLarge: { title: 'Size Theme - XL', value: 'touchExtraLarge'},
+  desktop: { title: 'Desktop', value: 'desktop'},
+  touchSmall: { title: 'Small (Touch)', value: 'touchSmall'},
+  touchMedium: { title: 'Medium (Touch)', value: 'touchMedium'},
+  touchLarge: { title: 'Large (Touch)', value: 'touchLarge'},
+  touchExtraLarge: { title: 'Extra Large (Touch)', value: 'touchExtraLarge'},
 }
 
 const DEFAULT_COLOR_MODE: ColorMode = 'contrastHighLight';

--- a/libs/ui/.storybook/preview.tsx
+++ b/libs/ui/.storybook/preview.tsx
@@ -29,12 +29,12 @@ const screenTypeToolBarItems: Record<ScreenType, ScreenTypeToolBarItem> = {
   lenovoThinkpad15: { title: 'Lenovo Thinkpad 15"', value: 'lenovoThinkpad15' },
 };
 
-const DEFAULT_SIZE_MODE: SizeMode = "m";
+const DEFAULT_SIZE_MODE: SizeMode = "touchMedium";
 const sizeThemeToolBarItems: Record<SizeMode, SizeModeToolBarItem> = {
-  s: { title: 'Size Theme - S', value: 's'},
-  m: { title: 'Size Theme - M', value: 'm'},
-  l: { title: 'Size Theme - L', value: 'l'},
-  xl: { title: 'Size Theme - XL', value: 'xl'},
+  touchSmall: { title: 'Size Theme - S', value: 'touchSmall'},
+  touchMedium: { title: 'Size Theme - M', value: 'touchMedium'},
+  touchLarge: { title: 'Size Theme - L', value: 'touchLarge'},
+  touchExtraLarge: { title: 'Size Theme - XL', value: 'touchExtraLarge'},
 }
 
 const DEFAULT_COLOR_MODE: ColorMode = 'contrastHighLight';

--- a/libs/ui/src/app_base.test.tsx
+++ b/libs/ui/src/app_base.test.tsx
@@ -25,7 +25,7 @@ test('renders with touchscreen-specific styles', () => {
     <AppBase
       isTouchscreen
       defaultColorMode="contrastMedium"
-      defaultSizeMode="s"
+      defaultSizeMode="touchSmall"
     >
       <div>foo</div>
     </AppBase>
@@ -40,7 +40,7 @@ test('renders with legacy font sizes', () => {
       legacyBaseFontSizePx={48}
       legacyPrintFontSizePx={18}
       defaultColorMode="contrastMedium"
-      defaultSizeMode="s"
+      defaultSizeMode="touchSmall"
     >
       <div>foo</div>
     </AppBase>
@@ -58,7 +58,10 @@ test('renders with legacy font sizes', () => {
 
 test('renders with selected themes', () => {
   const { container } = render(
-    <AppBase defaultColorMode="contrastHighDark" defaultSizeMode="xl">
+    <AppBase
+      defaultColorMode="contrastHighDark"
+      defaultSizeMode="touchExtraLarge"
+    >
       <div>foo</div>
     </AppBase>
   );
@@ -67,7 +70,7 @@ test('renders with selected themes', () => {
 
   const expectedTheme = makeTheme({
     colorMode: 'contrastHighDark',
-    sizeMode: 'xl',
+    sizeMode: 'touchExtraLarge',
   });
 
   const htmlNode = document.body.parentElement;
@@ -89,7 +92,11 @@ test('renders with selected themes', () => {
 
 test('renders with enableScroll', () => {
   const { container } = render(
-    <AppBase enableScroll defaultColorMode="contrastMedium" defaultSizeMode="s">
+    <AppBase
+      enableScroll
+      defaultColorMode="contrastMedium"
+      defaultSizeMode="touchSmall"
+    >
       <div>foo</div>
     </AppBase>
   );
@@ -121,7 +128,7 @@ test('implements ThemeManagerContext interface', () => {
   }
 
   render(
-    <AppBase defaultColorMode="contrastLow" defaultSizeMode="l">
+    <AppBase defaultColorMode="contrastLow" defaultSizeMode="touchLarge">
       <TestComponent />
     </AppBase>
   );
@@ -129,7 +136,7 @@ test('implements ThemeManagerContext interface', () => {
   expect(currentTheme).toEqual(
     expect.objectContaining<Partial<UiTheme>>({
       colorMode: 'contrastLow',
-      sizeMode: 'l',
+      sizeMode: 'touchLarge',
     })
   );
 
@@ -138,16 +145,16 @@ test('implements ThemeManagerContext interface', () => {
   expect(currentTheme).toEqual(
     expect.objectContaining<Partial<UiTheme>>({
       colorMode: 'contrastHighDark',
-      sizeMode: 'l',
+      sizeMode: 'touchLarge',
     })
   );
 
-  act(() => manager?.setSizeMode('s'));
+  act(() => manager?.setSizeMode('touchSmall'));
 
   expect(currentTheme).toEqual(
     expect.objectContaining<Partial<UiTheme>>({
       colorMode: 'contrastHighDark',
-      sizeMode: 's',
+      sizeMode: 'touchSmall',
     })
   );
 
@@ -156,7 +163,7 @@ test('implements ThemeManagerContext interface', () => {
   expect(currentTheme).toEqual(
     expect.objectContaining<Partial<UiTheme>>({
       colorMode: 'contrastLow',
-      sizeMode: 'l',
+      sizeMode: 'touchLarge',
     })
   );
 });

--- a/libs/ui/src/bmd_paper_ballot.tsx
+++ b/libs/ui/src/bmd_paper_ballot.tsx
@@ -231,7 +231,7 @@ interface Props {
  */
 function withPrintTheme(ballot: JSX.Element): JSX.Element {
   return (
-    <VxThemeProvider colorMode="contrastHighLight" sizeMode="s">
+    <VxThemeProvider colorMode="contrastHighLight" sizeMode="touchSmall">
       {ballot}
     </VxThemeProvider>
   );

--- a/libs/ui/src/button.test.tsx
+++ b/libs/ui/src/button.test.tsx
@@ -58,10 +58,10 @@ describe('renders Button', () => {
       return remToPx(window.getComputedStyle(button).fontSize);
     }
 
-    const smallButtonFontSizePx = getButtonFontSizePx('s');
-    const mediumButtonFontSizePx = getButtonFontSizePx('m');
-    const largeButtonFontSizePx = getButtonFontSizePx('l');
-    const xLargeButtonFontSizePx = getButtonFontSizePx('xl');
+    const smallButtonFontSizePx = getButtonFontSizePx('touchSmall');
+    const mediumButtonFontSizePx = getButtonFontSizePx('touchMedium');
+    const largeButtonFontSizePx = getButtonFontSizePx('touchLarge');
+    const xLargeButtonFontSizePx = getButtonFontSizePx('touchExtraLarge');
 
     expect(mediumButtonFontSizePx).toBeGreaterThan(smallButtonFontSizePx);
     expect(largeButtonFontSizePx).toBeGreaterThan(mediumButtonFontSizePx);
@@ -72,14 +72,14 @@ describe('renders Button', () => {
     const onPress = jest.fn();
 
     function verifyPrimaryButtonColor(colorMode: ColorMode) {
-      const expectedTheme = makeTheme({ colorMode, sizeMode: 's' });
+      const expectedTheme = makeTheme({ colorMode, sizeMode: 'touchSmall' });
 
       render(
         <Button onPress={onPress} variant="primary">
           {colorMode} button
         </Button>,
         {
-          vxTheme: { colorMode, sizeMode: 's' },
+          vxTheme: { colorMode, sizeMode: 'touchSmall' },
         }
       );
 
@@ -134,7 +134,7 @@ describe('renders Button', () => {
           Disabled Button
         </Button>
       </div>,
-      { vxTheme: { colorMode: 'contrastLow', sizeMode: 'm' } }
+      { vxTheme: { colorMode: 'contrastLow', sizeMode: 'touchMedium' } }
     );
 
     const enabledButton = screen.getButton('Enabled Button');

--- a/libs/ui/src/button.tsx
+++ b/libs/ui/src/button.tsx
@@ -145,10 +145,10 @@ function getBorderColor(p: ThemedStyledButtonProps): Color | undefined {
 }
 
 const paddingStyles: Record<SizeMode, string | undefined> = {
-  s: '0.5em 0.6em',
-  m: '0.5em 0.6em',
-  l: '0.4em 0.5em',
-  xl: '0.3em 0.4em',
+  touchSmall: '0.5em 0.6em',
+  touchMedium: '0.5em 0.6em',
+  touchLarge: '0.4em 0.5em',
+  touchExtraLarge: '0.3em 0.4em',
 };
 
 function getPadding(p: StyledButtonProps & { theme: DefaultTheme }) {

--- a/libs/ui/src/button.tsx
+++ b/libs/ui/src/button.tsx
@@ -145,6 +145,7 @@ function getBorderColor(p: ThemedStyledButtonProps): Color | undefined {
 }
 
 const paddingStyles: Record<SizeMode, string | undefined> = {
+  desktop: '0.5em 0.6em',
   touchSmall: '0.5em 0.6em',
   touchMedium: '0.5em 0.6em',
   touchLarge: '0.4em 0.5em',

--- a/libs/ui/src/display_settings/color_settings.test.tsx
+++ b/libs/ui/src/display_settings/color_settings.test.tsx
@@ -7,7 +7,7 @@ import { H1 } from '../typography';
 
 test('renders with default color options', () => {
   render(<ColorSettings />, {
-    vxTheme: { colorMode: 'contrastLow', sizeMode: 'l' },
+    vxTheme: { colorMode: 'contrastLow', sizeMode: 'touchLarge' },
   });
 
   // contractHighDark:
@@ -37,7 +37,7 @@ test('renders with default color options', () => {
 
 test('renders with specified color options', () => {
   render(<ColorSettings colorModes={['contrastLow', 'contrastMedium']} />, {
-    vxTheme: { colorMode: 'contrastLow', sizeMode: 'l' },
+    vxTheme: { colorMode: 'contrastLow', sizeMode: 'touchLarge' },
   });
 
   expect(screen.queryAllByRole('radio')).toHaveLength(2);
@@ -75,13 +75,13 @@ test('option selections trigger theme updates', () => {
   }
 
   render(<TestComponent />, {
-    vxTheme: { colorMode: 'contrastHighDark', sizeMode: 'l' },
+    vxTheme: { colorMode: 'contrastHighDark', sizeMode: 'touchLarge' },
   });
 
   expect(currentTheme).toEqual(
     expect.objectContaining<Partial<UiTheme>>({
       colorMode: 'contrastHighDark',
-      sizeMode: 'l',
+      sizeMode: 'touchLarge',
     })
   );
 
@@ -92,7 +92,7 @@ test('option selections trigger theme updates', () => {
   expect(currentTheme).toEqual(
     expect.objectContaining<Partial<UiTheme>>({
       colorMode: 'contrastLow',
-      sizeMode: 'l',
+      sizeMode: 'touchLarge',
     })
   );
 });

--- a/libs/ui/src/display_settings/display_settings.test.tsx
+++ b/libs/ui/src/display_settings/display_settings.test.tsx
@@ -38,13 +38,13 @@ test('resets button resets global theme', () => {
   }
 
   render(<TestComponent />, {
-    vxTheme: { colorMode: 'contrastHighDark', sizeMode: 'l' },
+    vxTheme: { colorMode: 'contrastHighDark', sizeMode: 'touchLarge' },
   });
 
   expect(currentTheme).toEqual(
     expect.objectContaining<Partial<UiTheme>>({
       colorMode: 'contrastHighDark',
-      sizeMode: 'l',
+      sizeMode: 'touchLarge',
     })
   );
 
@@ -57,7 +57,7 @@ test('resets button resets global theme', () => {
   expect(currentTheme).toEqual(
     expect.objectContaining<Partial<UiTheme>>({
       colorMode: 'contrastLow',
-      sizeMode: 's',
+      sizeMode: 'touchSmall',
     })
   );
 
@@ -66,7 +66,7 @@ test('resets button resets global theme', () => {
   expect(currentTheme).toEqual(
     expect.objectContaining<Partial<UiTheme>>({
       colorMode: 'contrastHighDark',
-      sizeMode: 'l',
+      sizeMode: 'touchLarge',
     })
   );
 });

--- a/libs/ui/src/display_settings/index.tsx
+++ b/libs/ui/src/display_settings/index.tsx
@@ -14,7 +14,7 @@ export interface DisplaySettingsProps {
   /** @default ['contrastLow', 'contrastMedium', 'contrastHighLight', 'contrastHighDark'] */
   colorModes?: ColorSettingsProps['colorModes'];
   onClose: () => void;
-  /** @default ['s', 'm', 'l', 'xl'] */
+  /** @default ['touchSmall', 'touchMedium', 'touchLarge', 'touchExtraLarge'] */
   sizeModes?: SizeSettingsProps['sizeModes'];
 }
 

--- a/libs/ui/src/display_settings/size_settings.test.tsx
+++ b/libs/ui/src/display_settings/size_settings.test.tsx
@@ -7,7 +7,7 @@ import { H1 } from '../typography';
 
 test('renders with default size options', () => {
   render(<SizeSettings />, {
-    vxTheme: { colorMode: 'contrastLow', sizeMode: 'l' },
+    vxTheme: { colorMode: 'contrastLow', sizeMode: 'touchLarge' },
   });
 
   screen.getByRole('radio', {
@@ -32,8 +32,8 @@ test('renders with default size options', () => {
 });
 
 test('renders with specified size options', () => {
-  render(<SizeSettings sizeModes={['m', 'l']} />, {
-    vxTheme: { colorMode: 'contrastLow', sizeMode: 'l' },
+  render(<SizeSettings sizeModes={['touchMedium', 'touchLarge']} />, {
+    vxTheme: { colorMode: 'contrastLow', sizeMode: 'touchLarge' },
   });
 
   expect(screen.queryAllByRole('radio')).toHaveLength(2);
@@ -69,13 +69,13 @@ test('option selections trigger theme updates', () => {
   }
 
   render(<TestComponent />, {
-    vxTheme: { colorMode: 'contrastHighDark', sizeMode: 'l' },
+    vxTheme: { colorMode: 'contrastHighDark', sizeMode: 'touchLarge' },
   });
 
   expect(currentTheme).toEqual(
     expect.objectContaining<Partial<UiTheme>>({
       colorMode: 'contrastHighDark',
-      sizeMode: 'l',
+      sizeMode: 'touchLarge',
     })
   );
 
@@ -84,7 +84,7 @@ test('option selections trigger theme updates', () => {
   expect(currentTheme).toEqual(
     expect.objectContaining<Partial<UiTheme>>({
       colorMode: 'contrastHighDark',
-      sizeMode: 's',
+      sizeMode: 'touchSmall',
     })
   );
 });

--- a/libs/ui/src/display_settings/size_settings.tsx
+++ b/libs/ui/src/display_settings/size_settings.tsx
@@ -8,17 +8,22 @@ import { ThemeLabel } from './theme_label';
 import { useScreenInfo } from '../hooks/use_screen_info';
 
 export interface SizeSettingsProps {
-  /** @default ['s', 'm', 'l', 'xl'] */
+  /** @default ['touchSmall', 'touchMedium', 'touchLarge', 'touchExtraLarge'] */
   sizeModes?: SizeMode[];
 }
 
-const DEFAULT_SIZE_MODES: SizeMode[] = ['s', 'm', 'l', 'xl'];
+const DEFAULT_SIZE_MODES: SizeMode[] = [
+  'touchSmall',
+  'touchMedium',
+  'touchLarge',
+  'touchExtraLarge',
+];
 
 const ORDERED_SIZE_MODE_LABELS: Record<SizeMode, string> = {
-  s: 'Small',
-  m: 'Medium',
-  l: 'Large',
-  xl: 'Extra-Large',
+  touchSmall: 'Small',
+  touchMedium: 'Medium',
+  touchLarge: 'Large',
+  touchExtraLarge: 'Extra-Large',
 };
 
 export function SizeSettings(props: SizeSettingsProps): JSX.Element {

--- a/libs/ui/src/display_settings/size_settings.tsx
+++ b/libs/ui/src/display_settings/size_settings.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SizeMode } from '@votingworks/types';
+import { SizeMode, TouchSizeMode } from '@votingworks/types';
 import { ThemeConsumer } from 'styled-components';
 import { SettingsPane } from './settings_pane';
 import { RadioGroup } from '../radio_group';
@@ -9,7 +9,7 @@ import { useScreenInfo } from '../hooks/use_screen_info';
 
 export interface SizeSettingsProps {
   /** @default ['touchSmall', 'touchMedium', 'touchLarge', 'touchExtraLarge'] */
-  sizeModes?: SizeMode[];
+  sizeModes?: TouchSizeMode[];
 }
 
 const DEFAULT_SIZE_MODES: SizeMode[] = [
@@ -19,7 +19,7 @@ const DEFAULT_SIZE_MODES: SizeMode[] = [
   'touchExtraLarge',
 ];
 
-const ORDERED_SIZE_MODE_LABELS: Record<SizeMode, string> = {
+const ORDERED_SIZE_MODE_LABELS: Record<TouchSizeMode, string> = {
   touchSmall: 'Small',
   touchMedium: 'Medium',
   touchLarge: 'Large',
@@ -35,7 +35,7 @@ export function SizeSettings(props: SizeSettingsProps): JSX.Element {
   const { setSizeMode } = React.useContext(ThemeManagerContext);
 
   const orderedSizeModes = (
-    Object.keys(ORDERED_SIZE_MODE_LABELS) as SizeMode[]
+    Object.keys(ORDERED_SIZE_MODE_LABELS) as TouchSizeMode[]
   ).filter((m) => enabledSizeModes.has(m));
 
   /* istanbul ignore next */

--- a/libs/ui/src/hooks/use_current_theme.test.tsx
+++ b/libs/ui/src/hooks/use_current_theme.test.tsx
@@ -12,10 +12,13 @@ test('useCurrentTheme', () => {
   }
 
   render(<TestComponent />, {
-    vxTheme: { colorMode: 'contrastLow', sizeMode: 'xl' },
+    vxTheme: { colorMode: 'contrastLow', sizeMode: 'touchExtraLarge' },
   });
 
   expect(currentTheme).toEqual(
-    expect.objectContaining({ colorMode: 'contrastLow', sizeMode: 'xl' })
+    expect.objectContaining({
+      colorMode: 'contrastLow',
+      sizeMode: 'touchExtraLarge',
+    })
   );
 });

--- a/libs/ui/src/prose.test.tsx
+++ b/libs/ui/src/prose.test.tsx
@@ -49,7 +49,7 @@ describe('renders Prose', () => {
         {proseContent}
       </Prose>,
       {
-        vxTheme: { colorMode: 'contrastLow', sizeMode: 'm' },
+        vxTheme: { colorMode: 'contrastLow', sizeMode: 'touchMedium' },
       }
     );
     expect(container.firstChild).toMatchSnapshot();

--- a/libs/ui/src/reports/tally_report.tsx
+++ b/libs/ui/src/reports/tally_report.tsx
@@ -44,7 +44,7 @@ export const TallyReportPreview = styled.div`
 export function tallyReportThemeFn(theme?: DefaultTheme): DefaultTheme {
   return makeTheme({
     screenType: theme?.screenType,
-    sizeMode: 's',
+    sizeMode: 'touchSmall',
     colorMode: 'contrastHighLight',
   });
 }

--- a/libs/ui/src/test_mode.test.tsx
+++ b/libs/ui/src/test_mode.test.tsx
@@ -4,7 +4,7 @@ import { TestMode } from './test_mode';
 
 test('renders TestMode - VVSG styling', () => {
   const { container } = render(<TestMode />, {
-    vxTheme: { sizeMode: 'l' },
+    vxTheme: { sizeMode: 'touchLarge' },
   });
   screen.getByText('Test Ballot Mode');
   expect(container).toMatchSnapshot();

--- a/libs/ui/src/test_mode.tsx
+++ b/libs/ui/src/test_mode.tsx
@@ -42,7 +42,7 @@ export function TestMode(): JSX.Element {
         makeTheme({
           colorMode: theme.colorMode,
           screenType: theme.screenType,
-          sizeMode: 's',
+          sizeMode: 'touchSmall',
         })
       }
     >

--- a/libs/ui/src/themes/make_theme.test.ts
+++ b/libs/ui/src/themes/make_theme.test.ts
@@ -35,6 +35,16 @@ test('varies theme based on selected modes', () => {
   );
 });
 
+test('desktop theme', () => {
+  const desktopTheme = makeTheme({
+    colorMode: 'contrastMedium',
+    screenType: 'builtIn',
+    sizeMode: 'desktop',
+  });
+
+  expect<number>(desktopTheme.sizes.fontDefault).toEqual(16);
+});
+
 test('varies sizes based on screen type', () => {
   const elo13ScreenTheme = makeTheme({
     colorMode: 'contrastMedium',

--- a/libs/ui/src/themes/make_theme.test.ts
+++ b/libs/ui/src/themes/make_theme.test.ts
@@ -6,7 +6,7 @@ test('defaults', () => {
   const theme = makeTheme({});
 
   expect<ColorMode>(theme.colorMode).toEqual('contrastMedium');
-  expect<SizeMode>(theme.sizeMode).toEqual('s');
+  expect<SizeMode>(theme.sizeMode).toEqual('touchSmall');
   expect<Color>(theme.colors.background).toEqual(Color.OFF_WHITE);
   expect<Color>(theme.colors.foreground).toEqual(Color.GRAY_DARK);
 });
@@ -14,18 +14,18 @@ test('defaults', () => {
 test('varies theme based on selected modes', () => {
   const lightThemeS = makeTheme({
     colorMode: 'contrastHighLight',
-    sizeMode: 's',
+    sizeMode: 'touchSmall',
   });
   const darkThemeXl = makeTheme({
     colorMode: 'contrastHighDark',
-    sizeMode: 'xl',
+    sizeMode: 'touchExtraLarge',
   });
 
   expect<ColorMode>(lightThemeS.colorMode).toEqual('contrastHighLight');
-  expect<SizeMode>(lightThemeS.sizeMode).toEqual('s');
+  expect<SizeMode>(lightThemeS.sizeMode).toEqual('touchSmall');
 
   expect<ColorMode>(darkThemeXl.colorMode).toEqual('contrastHighDark');
-  expect<SizeMode>(darkThemeXl.sizeMode).toEqual('xl');
+  expect<SizeMode>(darkThemeXl.sizeMode).toEqual('touchExtraLarge');
 
   expect<Color>(lightThemeS.colors.background).not.toEqual(
     darkThemeXl.colors.background
@@ -39,17 +39,17 @@ test('varies sizes based on screen type', () => {
   const elo13ScreenTheme = makeTheme({
     colorMode: 'contrastMedium',
     screenType: 'elo13',
-    sizeMode: 's',
+    sizeMode: 'touchSmall',
   });
   const elo15ScreenTheme = makeTheme({
     colorMode: 'contrastMedium',
     screenType: 'elo15',
-    sizeMode: 's',
+    sizeMode: 'touchSmall',
   });
   const thinkpad15ScreenTheme = makeTheme({
     colorMode: 'contrastMedium',
     screenType: 'lenovoThinkpad15',
-    sizeMode: 's',
+    sizeMode: 'touchSmall',
   });
 
   expect(elo13ScreenTheme.sizes).not.toEqual(elo15ScreenTheme.sizes);

--- a/libs/ui/src/themes/make_theme.ts
+++ b/libs/ui/src/themes/make_theme.ts
@@ -1,3 +1,4 @@
+import { assert } from '@votingworks/basics';
 import {
   Color,
   ColorMode,
@@ -5,7 +6,9 @@ import {
   ScreenType,
   SizeMode,
   SizeTheme,
+  TouchSizeMode,
   UiTheme,
+  isTouchSizeMode,
 } from '@votingworks/types';
 
 /**
@@ -13,7 +16,7 @@ import {
  * capital letter height in millimeters.
  */
 const VVSG_CAPITAL_LETTER_HEIGHTS_MM: Record<
-  SizeMode,
+  TouchSizeMode,
   { max: number; min: number }
 > = {
   touchSmall: { max: 4.2, min: 3.5 },
@@ -118,6 +121,7 @@ function mmToPx(mm: number, screenType: ScreenType): number {
 }
 
 function getFontSize({ screenType, sizeMode }: SizeThemeParams): number {
+  assert(isTouchSizeMode(sizeMode));
   // Use the average midpoint value of the relevant VVSG size range.
   const capitalLetterHeightMm =
     (VVSG_CAPITAL_LETTER_HEIGHTS_MM[sizeMode].min +
@@ -135,6 +139,33 @@ const VVSG_MIN_TOUCH_AREA_SIZE_MM = 12.7;
 const VVSG_MIN_TOUCH_AREA_SEPARATION_MM = 2.54;
 
 const sizeThemes: Record<SizeMode, (p: SizeThemeParams) => SizeTheme> = {
+  desktop: () => ({
+    bordersRem: {
+      hairline: 0.06,
+      thin: 0.1,
+      medium: 0.15,
+      thick: 0.25,
+    },
+    fontDefault: 16,
+    fontWeight: {
+      light: 200,
+      regular: 400,
+      semiBold: 500,
+      bold: 600,
+    },
+    headingsRem: {
+      h1: 2.25,
+      h2: 1.75,
+      h3: 1.5,
+      h4: 1.25,
+      h5: 1.125,
+      h6: 1,
+    },
+    letterSpacingEm: 0.01,
+    lineHeight: 1.3,
+    minTouchAreaSeparationPx: 0, // Not used on desktop
+    minTouchAreaSizePx: 0, // Not used on desktop
+  }),
   touchSmall: (p) => ({
     bordersRem: {
       hairline: 0.06,

--- a/libs/ui/src/themes/make_theme.ts
+++ b/libs/ui/src/themes/make_theme.ts
@@ -16,10 +16,10 @@ const VVSG_CAPITAL_LETTER_HEIGHTS_MM: Record<
   SizeMode,
   { max: number; min: number }
 > = {
-  s: { max: 4.2, min: 3.5 },
-  m: { max: 5.6, min: 4.8 },
-  l: { max: 7.1, min: 6.4 },
-  xl: { max: 9.0, min: 8.5 },
+  touchSmall: { max: 4.2, min: 3.5 },
+  touchMedium: { max: 5.6, min: 4.8 },
+  touchLarge: { max: 7.1, min: 6.4 },
+  touchExtraLarge: { max: 9.0, min: 8.5 },
 };
 
 /**
@@ -135,7 +135,7 @@ const VVSG_MIN_TOUCH_AREA_SIZE_MM = 12.7;
 const VVSG_MIN_TOUCH_AREA_SEPARATION_MM = 2.54;
 
 const sizeThemes: Record<SizeMode, (p: SizeThemeParams) => SizeTheme> = {
-  s: (p) => ({
+  touchSmall: (p) => ({
     bordersRem: {
       hairline: 0.06,
       thin: 0.1,
@@ -165,7 +165,7 @@ const sizeThemes: Record<SizeMode, (p: SizeThemeParams) => SizeTheme> = {
     ),
     minTouchAreaSizePx: mmToPx(VVSG_MIN_TOUCH_AREA_SIZE_MM, p.screenType),
   }),
-  m: (p) => ({
+  touchMedium: (p) => ({
     bordersRem: {
       hairline: 0.055,
       thin: 0.1,
@@ -195,7 +195,7 @@ const sizeThemes: Record<SizeMode, (p: SizeThemeParams) => SizeTheme> = {
     ),
     minTouchAreaSizePx: mmToPx(VVSG_MIN_TOUCH_AREA_SIZE_MM, p.screenType),
   }),
-  l: (p) => ({
+  touchLarge: (p) => ({
     bordersRem: {
       hairline: 0.05,
       thin: 0.1,
@@ -225,7 +225,7 @@ const sizeThemes: Record<SizeMode, (p: SizeThemeParams) => SizeTheme> = {
     ),
     minTouchAreaSizePx: mmToPx(VVSG_MIN_TOUCH_AREA_SIZE_MM, p.screenType),
   }),
-  xl: (p) => ({
+  touchExtraLarge: (p) => ({
     bordersRem: {
       hairline: 0.05,
       thin: 0.075,
@@ -263,7 +263,7 @@ const sizeThemes: Record<SizeMode, (p: SizeThemeParams) => SizeTheme> = {
 export function makeTheme({
   colorMode = 'contrastMedium',
   screenType = 'builtIn',
-  sizeMode = 's',
+  sizeMode = 'touchSmall',
 }: {
   colorMode?: ColorMode;
   screenType?: ScreenType;

--- a/libs/ui/src/themes/render_with_themes.test.tsx
+++ b/libs/ui/src/themes/render_with_themes.test.tsx
@@ -35,13 +35,13 @@ test('renders theme-dependent component successfully', () => {
 test('renders with specified theme settings', () => {
   const lowContrastTheme = makeTheme({
     colorMode: 'contrastLow',
-    sizeMode: 'xl',
+    sizeMode: 'touchExtraLarge',
   });
 
   const { getByText } = renderWithThemes(<P color="warning">Warning text</P>, {
     vxTheme: {
       colorMode: 'contrastLow',
-      sizeMode: 'xl',
+      sizeMode: 'touchExtraLarge',
     },
   });
 

--- a/libs/ui/src/themes/render_with_themes.tsx
+++ b/libs/ui/src/themes/render_with_themes.tsx
@@ -51,7 +51,7 @@ export function renderWithThemes(
     return (
       <AppBase
         defaultColorMode={vxTheme.colorMode ?? 'contrastMedium'}
-        defaultSizeMode={vxTheme.sizeMode ?? 's'}
+        defaultSizeMode={vxTheme.sizeMode ?? 'touchSmall'}
         disableFontsForTests
         {...props}
       />

--- a/libs/ui/src/themes/vx_theme_provider.test.tsx
+++ b/libs/ui/src/themes/vx_theme_provider.test.tsx
@@ -35,8 +35,16 @@ test('uses defaults when no params specified', () => {
 
 test('sets theme according to specified params', () => {
   render(
-    <VxThemeProvider colorMode="contrastMedium" sizeMode="m" screenType="elo15">
-      <VxThemeProvider colorMode="contrastLow" sizeMode="s" screenType="elo13">
+    <VxThemeProvider
+      colorMode="contrastMedium"
+      sizeMode="touchMedium"
+      screenType="elo15"
+    >
+      <VxThemeProvider
+        colorMode="contrastLow"
+        sizeMode="touchSmall"
+        screenType="elo13"
+      >
         <TestThemeConsumer />
       </VxThemeProvider>
     </VxThemeProvider>
@@ -45,7 +53,7 @@ test('sets theme according to specified params', () => {
   expect(currentTheme).toEqual(
     makeTheme({
       colorMode: 'contrastLow',
-      sizeMode: 's',
+      sizeMode: 'touchSmall',
       screenType: 'elo13',
     })
   );
@@ -53,7 +61,11 @@ test('sets theme according to specified params', () => {
 
 test('inherits unspecified params from parent', () => {
   const { rerender } = render(
-    <VxThemeProvider colorMode="contrastMedium" sizeMode="m" screenType="elo15">
+    <VxThemeProvider
+      colorMode="contrastMedium"
+      sizeMode="touchMedium"
+      screenType="elo15"
+    >
       <VxThemeProvider>
         <TestThemeConsumer />
       </VxThemeProvider>
@@ -63,14 +75,18 @@ test('inherits unspecified params from parent', () => {
   expect(currentTheme).toEqual(
     makeTheme({
       colorMode: 'contrastMedium',
-      sizeMode: 'm',
+      sizeMode: 'touchMedium',
       screenType: 'elo15',
     })
   );
 
   rerender(
-    <VxThemeProvider colorMode="contrastMedium" sizeMode="m" screenType="elo15">
-      <VxThemeProvider sizeMode="xl">
+    <VxThemeProvider
+      colorMode="contrastMedium"
+      sizeMode="touchMedium"
+      screenType="elo15"
+    >
+      <VxThemeProvider sizeMode="touchExtraLarge">
         <TestThemeConsumer />
       </VxThemeProvider>
     </VxThemeProvider>
@@ -79,7 +95,7 @@ test('inherits unspecified params from parent', () => {
   expect(currentTheme).toEqual(
     makeTheme({
       colorMode: 'contrastMedium',
-      sizeMode: 'xl',
+      sizeMode: 'touchExtraLarge',
       screenType: 'elo15',
     })
   );

--- a/libs/ui/src/typography.test.tsx
+++ b/libs/ui/src/typography.test.tsx
@@ -8,7 +8,7 @@ for (const Component of [Caption, Font, P, Pre]) {
   test(`renders <${Component.name}>`, () => {
     const theme = makeTheme({
       colorMode: 'contrastHighDark',
-      sizeMode: 'm',
+      sizeMode: 'touchMedium',
     });
     render(
       <React.Fragment>
@@ -20,7 +20,7 @@ for (const Component of [Caption, Font, P, Pre]) {
         <Component align="center">center-aligned text</Component>
         <Component noWrap>no-wrap text</Component>
       </React.Fragment>,
-      { vxTheme: { colorMode: 'contrastHighDark', sizeMode: 'm' } }
+      { vxTheme: { colorMode: 'contrastHighDark', sizeMode: 'touchMedium' } }
     );
 
     expect(screen.getByText('regular text')).toHaveStyle({
@@ -52,7 +52,7 @@ for (const Heading of [H1, H2, H3, H4, H5, H6]) {
   test(`renders <${Heading.name}>`, () => {
     const theme = makeTheme({
       colorMode: 'contrastHighLight',
-      sizeMode: 'xl',
+      sizeMode: 'touchExtraLarge',
     });
     render(
       <React.Fragment>
@@ -62,7 +62,12 @@ for (const Heading of [H1, H2, H3, H4, H5, H6]) {
         <Heading align="center">center-aligned heading</Heading>
         <Heading noWrap>no-wrap heading</Heading>
       </React.Fragment>,
-      { vxTheme: { colorMode: 'contrastHighLight', sizeMode: 'xl' } }
+      {
+        vxTheme: {
+          colorMode: 'contrastHighLight',
+          sizeMode: 'touchExtraLarge',
+        },
+      }
     );
 
     const { headingsRem } = theme.sizes;
@@ -112,7 +117,7 @@ for (const Component of [Caption, Font, P, Pre, H1, H2, H3, H4, H5, H6]) {
   test(`renders colored <${Component.name}>`, () => {
     const theme = makeTheme({
       colorMode: 'contrastMedium',
-      sizeMode: 'l',
+      sizeMode: 'touchLarge',
     });
     render(
       <React.Fragment>
@@ -121,7 +126,7 @@ for (const Component of [Caption, Font, P, Pre, H1, H2, H3, H4, H5, H6]) {
         <Component color="success">success color text</Component>
         <Component color="warning">warning color text</Component>
       </React.Fragment>,
-      { vxTheme: { colorMode: 'contrastMedium', sizeMode: 'l' } }
+      { vxTheme: { colorMode: 'contrastMedium', sizeMode: 'touchLarge' } }
     );
 
     expect(screen.getByText('danger color text')).toHaveStyle({

--- a/libs/ui/src/usbcontroller_button.test.tsx
+++ b/libs/ui/src/usbcontroller_button.test.tsx
@@ -35,7 +35,7 @@ test('shows No USB if usb absent', () => {
 
 test('renders as primary button variant', () => {
   const renderOptions: RenderOptions = {
-    vxTheme: { colorMode: 'contrastLow', sizeMode: 'm' },
+    vxTheme: { colorMode: 'contrastLow', sizeMode: 'touchMedium' },
   };
 
   const nonPrimaryResult = render(

--- a/libs/ui/src/virtual_keyboard.tsx
+++ b/libs/ui/src/virtual_keyboard.tsx
@@ -5,7 +5,7 @@ import { Icons } from './icons';
 /* istanbul ignore next */
 function getBorderWidthRem(p: { theme: DefaultTheme }): number {
   switch (p.theme.sizeMode) {
-    case 'xl':
+    case 'touchExtraLarge':
       return p.theme.sizes.bordersRem.hairline;
     default:
       return p.theme.sizes.bordersRem.thin;

--- a/libs/ui/src/with_scroll_buttons.tsx
+++ b/libs/ui/src/with_scroll_buttons.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import styled, { ThemeProvider } from 'styled-components';
 
 import { rgba } from 'polished';
-import { SizeMode } from '@votingworks/types';
+import { TouchSizeMode, isTouchSizeMode } from '@votingworks/types';
+import { assert } from '@votingworks/basics';
 import { Button } from './button';
 import { Icons } from './icons';
 import { makeTheme } from './themes/make_theme';
@@ -15,13 +16,14 @@ export interface WithScrollButtonsProps {
 
 const SCROLL_DISTANCE_TO_CONTENT_HEIGHT_RATIO = 0.75;
 
-const SCROLL_BUTTON_SIZE_MODE_OVERRIDES: Readonly<Record<SizeMode, SizeMode>> =
-  {
-    touchSmall: 'touchSmall',
-    touchMedium: 'touchMedium',
-    touchLarge: 'touchMedium',
-    touchExtraLarge: 'touchMedium',
-  };
+const SCROLL_BUTTON_SIZE_MODE_OVERRIDES: Readonly<
+  Record<TouchSizeMode, TouchSizeMode>
+> = {
+  touchSmall: 'touchSmall',
+  touchMedium: 'touchMedium',
+  touchLarge: 'touchMedium',
+  touchExtraLarge: 'touchMedium',
+};
 
 const Container = styled.div`
   display: flex;
@@ -166,13 +168,14 @@ export function WithScrollButtons(props: WithScrollButtonsProps): JSX.Element {
       </Content>
       {scrollEnabled && (
         <ThemeProvider
-          theme={(theme) =>
-            makeTheme({
+          theme={(theme) => {
+            assert(isTouchSizeMode(theme.sizeMode));
+            return makeTheme({
               colorMode: theme.colorMode,
               screenType: theme.screenType,
               sizeMode: SCROLL_BUTTON_SIZE_MODE_OVERRIDES[theme.sizeMode],
-            })
-          }
+            });
+          }}
         >
           <Controls aria-hidden>
             {canScrollUp && (

--- a/libs/ui/src/with_scroll_buttons.tsx
+++ b/libs/ui/src/with_scroll_buttons.tsx
@@ -17,10 +17,10 @@ const SCROLL_DISTANCE_TO_CONTENT_HEIGHT_RATIO = 0.75;
 
 const SCROLL_BUTTON_SIZE_MODE_OVERRIDES: Readonly<Record<SizeMode, SizeMode>> =
   {
-    s: 's',
-    m: 'm',
-    l: 'm',
-    xl: 'm',
+    touchSmall: 'touchSmall',
+    touchMedium: 'touchMedium',
+    touchLarge: 'touchMedium',
+    touchExtraLarge: 'touchMedium',
   };
 
 const Container = styled.div`


### PR DESCRIPTION
## Overview

Follow up to #4085. Adds a basic desktop size theme so VxDesign can look a bit more reasonable while I work on the full desktop theme.

_Review by commits_

## Demo Video or Screenshot
Before
<img width="1312" alt="Screenshot 2023-10-12 at 9 37 14 AM" src="https://github.com/votingworks/vxsuite/assets/530106/f5041c60-1d7f-4605-a8d9-bbdd711f1e3e">

After
<img width="1312" alt="Screenshot 2023-10-12 at 12 01 13 PM" src="https://github.com/votingworks/vxsuite/assets/530106/9ed26e97-6bc5-4587-97f6-b0c57d442184">


## Testing Plan
Automated tests and visual inspection

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
