### PR TITLE
Get the new CVR export functions in libs/backend up to 100% code coverage

### DIFF
--- a/apps/scan/backend/src/app_config.test.ts
+++ b/apps/scan/backend/src/app_config.test.ts
@@ -35,8 +35,8 @@ import {
 } from '@votingworks/backend';
 import { InsertedSmartCardAuthApi } from '@votingworks/auth';
 import { CVR, ElectionDefinition } from '@votingworks/types';
-import { configureApp } from '../../../test/helpers/shared_helpers';
-import { scanBallot, withApp } from '../../../test/helpers/custom_helpers';
+import { configureApp } from '../test/helpers/shared_helpers';
+import { scanBallot, withApp } from '../test/helpers/custom_helpers';
 
 jest.setTimeout(20_000);
 

--- a/libs/auth/README.md
+++ b/libs/auth/README.md
@@ -105,15 +105,16 @@ role, and election hash.
 ./scripts/read-java-card-details
 ```
 
-### Check PIN Script
+### PIN Checking Script
 
-This script prompts you for a PIN and asks the Java Card to verify it.
+This script prompts you for a PIN and returns whether or not the PIN is correct
+for the inserted Java Card.
 
 ```
-# check a VxSuite card's PIN
+# Check a VxSuite card PIN
 VX_MACHINE_TYPE=admin ./scripts/check-pin --vxsuite
 
-# check a Common Access Card (CAC) PIN
+# Check a Common Access Card (CAC) PIN
 ./scripts/check-pin --cac
 ```
 
@@ -167,7 +168,7 @@ The following command generates keys and certs for tests:
 ./scripts/generate-test-keys-and-certs
 ```
 
-### Get Common Access Card (CAC) Certificate Script
+### Common Access Card (CAC) Certificate Retrieval Script
 
 This script gets a CAC certificate from a CAC card. It's meant to be used for
 development and testing.

--- a/libs/auth/jest.config.js
+++ b/libs/auth/jest.config.js
@@ -6,11 +6,11 @@ const shared = require('../../jest.config.shared');
 module.exports = {
   ...shared,
   coveragePathIgnorePatterns: [
-    'src/index.ts',
     'src/cac/index.ts',
+    'src/index.ts',
+    'src/integration_test_utils.ts',
     'src/intermediate-scripts',
     'src/jurisdictions.ts',
     'src/test_utils.ts',
-    'src/integration_test_utils.ts',
   ],
 };

--- a/libs/auth/src/cac/common_access_card_api.ts
+++ b/libs/auth/src/cac/common_access_card_api.ts
@@ -1,5 +1,6 @@
-import { Id } from '@votingworks/types';
-import { CertificateProviderCard, SigningCard, StatefulCard } from '../card';
+import { Buffer } from 'buffer';
+import { Byte, Id } from '@votingworks/types';
+import { StatefulCard } from '../card';
 
 /**
  * Details about a Common Access Card.
@@ -9,6 +10,23 @@ export interface CommonAccessCardDetails {
   givenName: string;
   middleName?: string;
   familyName: string;
+}
+
+/**
+ * The API for a smart card that can sign a payload.
+ */
+export interface SigningCard {
+  generateSignature(
+    message: Buffer,
+    options: { privateKeyId: Byte; pin?: string }
+  ): Promise<Buffer>;
+}
+
+/**
+ * The API for a smart card that has stored certificates.
+ */
+export interface CertificateProviderCard {
+  getCertificate(options: { objectId: Buffer }): Promise<Buffer>;
 }
 
 /**

--- a/libs/auth/src/card.ts
+++ b/libs/auth/src/card.ts
@@ -1,6 +1,5 @@
 import { Buffer } from 'buffer';
 import {
-  Byte,
   ElectionManagerUser,
   PollWorkerUser,
   SystemAdministratorUser,
@@ -101,21 +100,21 @@ export type CheckPinResponse =
   | CheckPinResponseIncorrect;
 
 /**
- * The API for a card that can provide its status.
+ * The API for a card that can provide its status
  */
 export interface StatefulCard<T = CardDetails> {
   getCardStatus(): Promise<CardStatus<T>>;
 }
 
 /**
- * The API for a smart card that has a PIN.
+ * The API for a card that has a PIN
  */
 export interface PinProtectedCard {
   checkPin(pin: string): Promise<CheckPinResponse>;
 }
 
 /**
- * The API for a programmable smart card.
+ * The API for a card that can be programmed
  */
 export interface ProgrammableCard extends PinProtectedCard {
   program(
@@ -128,7 +127,7 @@ export interface ProgrammableCard extends PinProtectedCard {
 }
 
 /**
- * The API for a smart card that can store data.
+ * The API for a card that can store data
  */
 export interface DataCard {
   readData(): Promise<Buffer>;
@@ -137,26 +136,9 @@ export interface DataCard {
 }
 
 /**
- * The API for a smart card that can sign a payload.
+ * The API for a VxSuite-compatible card
  */
-export interface SigningCard {
-  generateSignature(
-    message: Buffer,
-    options: { privateKeyId: Byte; pin?: string }
-  ): Promise<Buffer>;
-}
-
-/**
- * The API for a smart card that has stored certificates.
- */
-export interface CertificateProviderCard {
-  getCertificate(options: { objectId: Buffer }): Promise<Buffer>;
-}
-
-/**
- * The API for a VxSuite-compatible smart card.
- */
-export type Card = StatefulCard<CardDetails> &
+export type Card = StatefulCard &
   PinProtectedCard &
   ProgrammableCard &
   DataCard;

--- a/libs/auth/src/index.ts
+++ b/libs/auth/src/index.ts
@@ -1,15 +1,15 @@
 export * from './artifact_authentication';
+export * as cac from './cac';
 export type { CardStatus } from './card';
 export * from './cast_vote_record_hashes';
-export * as cac from './cac';
 export * from './config';
 export * from './dipped_smart_card_auth_api';
 export * from './dipped_smart_card_auth';
 export * from './inserted_smart_card_auth_api';
 export * from './inserted_smart_card_auth';
+export * from './integration_test_utils';
 export * from './java_card';
 export * from './jurisdictions';
 export * from './live_check';
 export * from './mock_file_card';
 export * from './test_utils';
-export * from './integration_test_utils';

--- a/libs/auth/src/integration_test_utils.ts
+++ b/libs/auth/src/integration_test_utils.ts
@@ -1,14 +1,14 @@
 import { TEST_JURISDICTION } from '@votingworks/types';
+
 import { mockCard } from './mock_file_card';
 
 /**
- * The default PIN used to log in as election manager or system administrator
- * in integration tests.
+ * The default PIN used in integration tests
  */
 export const INTEGRATION_TEST_DEFAULT_PIN = '000000';
 
 /**
- * Insert a mock System Administrator card.
+ * Mocks system administrator card insertion
  */
 export function mockSystemAdministratorCardInsertion(): void {
   mockCard({
@@ -26,7 +26,7 @@ export function mockSystemAdministratorCardInsertion(): void {
 }
 
 /**
- * Insert a mock Election Manager card.
+ * Mocks election manager card insertion
  */
 export function mockElectionManagerCardInsertion({
   electionHash,
@@ -49,7 +49,7 @@ export function mockElectionManagerCardInsertion({
 }
 
 /**
- * Insert a mock Poll Worker card.
+ * Mocks poll worker card insertion
  */
 export function mockPollWorkerCardInsertion({
   electionHash,
@@ -72,7 +72,7 @@ export function mockPollWorkerCardInsertion({
 }
 
 /**
- * Mocks the card being removed.
+ * Mocks card removal
  */
 export function mockCardRemoval(): void {
   mockCard({

--- a/libs/auth/src/piv.test.ts
+++ b/libs/auth/src/piv.test.ts
@@ -45,9 +45,26 @@ test.each<{ pin: string; expectedBuffer: Buffer }>([
 test('isIncorrectPinStatusWord', () => {
   expect(isIncorrectPinStatusWord([0x63, 0xc0])).toEqual(true);
   expect(isIncorrectPinStatusWord([0x63, 0xcf])).toEqual(true);
-  expect(isIncorrectPinStatusWord([0x73, 0xc0])).toEqual(false);
+  expect(isIncorrectPinStatusWord([0x62, 0xc0])).toEqual(false);
   expect(isIncorrectPinStatusWord([0x64, 0xc0])).toEqual(false);
+  expect(isIncorrectPinStatusWord([0x63, 0xb0])).toEqual(false);
   expect(isIncorrectPinStatusWord([0x63, 0xd0])).toEqual(false);
+});
+
+test('isSecurityConditionNotSatisfiedStatusWord', () => {
+  expect(isSecurityConditionNotSatisfiedStatusWord([0x69, 0x82])).toEqual(true);
+  expect(isSecurityConditionNotSatisfiedStatusWord([0x68, 0x82])).toEqual(
+    false
+  );
+  expect(isSecurityConditionNotSatisfiedStatusWord([0x70, 0x82])).toEqual(
+    false
+  );
+  expect(isSecurityConditionNotSatisfiedStatusWord([0x69, 0x81])).toEqual(
+    false
+  );
+  expect(isSecurityConditionNotSatisfiedStatusWord([0x69, 0x83])).toEqual(
+    false
+  );
 });
 
 test.each<{ sw2: Byte; expectedNumRemainingPinAttempts: number }>([
@@ -80,17 +97,4 @@ test('numRemainingPinAttemptsFromIncorrectPinStatusWord validation', () => {
   expect(() =>
     numRemainingPinAttemptsFromIncorrectPinStatusWord([0x90, 0x00])
   ).toThrow();
-});
-
-test('isSecurityConditionNotSatisfiedStatusWord', () => {
-  expect(isSecurityConditionNotSatisfiedStatusWord([0x69, 0x82])).toEqual(true);
-  expect(isSecurityConditionNotSatisfiedStatusWord([0x69, 0x83])).toEqual(
-    false
-  );
-  expect(isSecurityConditionNotSatisfiedStatusWord([0x68, 0x82])).toEqual(
-    false
-  );
-  expect(isSecurityConditionNotSatisfiedStatusWord([0x69, 0x81])).toEqual(
-    false
-  );
 });

--- a/libs/auth/src/piv.ts
+++ b/libs/auth/src/piv.ts
@@ -5,12 +5,14 @@ import { Byte } from '@votingworks/types';
 import { STATUS_WORD } from './apdu';
 
 /**
- * PIV-specific IDs for different cryptographic algorithms, e.g. ECC, RSA, etc.
- *
- * @see https://nvlpubs.nist.gov/nistpubs/specialpublications/nist.sp.800-73-4.pdf
+ * See https://nvlpubs.nist.gov/nistpubs/specialpublications/nist.sp.800-73-4.pdf for the full NIST
+ * PIV spec.
+ */
+
+/**
+ * PIV IDs for different cryptographic algorithms, e.g. elliptic curve cryptography, RSA, etc.
  */
 export const CRYPTOGRAPHIC_ALGORITHM_IDENTIFIER = {
-  /** Elliptic curve cryptography, curve P-256 */
   ECC256: 0x11,
   RSA2048: 0x07,
 } as const;
@@ -83,13 +85,6 @@ export const VERIFY = {
 } as const;
 
 /**
- * SEQUENCE is a PIV encoding for a sequence of TLV-encoded data objects.
- */
-export const SEQUENCE = {
-  TAG: 0x30,
-} as const;
-
-/**
  * Data object IDs of the format 0x5f 0xc1 0xXX are a PIV convention.
  */
 export function pivDataObjectId(uniqueByte: Byte): Buffer {
@@ -117,14 +112,13 @@ export function isIncorrectPinStatusWord(statusWord: [Byte, Byte]): boolean {
 }
 
 /**
- * Some cards respond to the VERIFY command with a status word of 0x6982 when the
- * PIN is incorrect.
+ * The security-condition-not-satisfied status word is returned when an operation requiring PIN
+ * verification is attempted without PIN verification.
  */
 export function isSecurityConditionNotSatisfiedStatusWord(
   statusWord: [Byte, Byte]
 ): boolean {
   const [sw1, sw2] = statusWord;
-
   return (
     sw1 === STATUS_WORD.SECURITY_CONDITION_NOT_SATISFIED.SW1 &&
     sw2 === STATUS_WORD.SECURITY_CONDITION_NOT_SATISFIED.SW2

--- a/libs/backend/jest.config.js
+++ b/libs/backend/jest.config.js
@@ -7,10 +7,10 @@ module.exports = {
   ...shared,
   coverageThreshold: {
     global: {
-      statements: 94,
-      branches: 89,
-      functions: 98,
-      lines: 95,
+      statements: 97,
+      branches: 93,
+      functions: 99,
+      lines: 98,
     },
   },
 };

--- a/libs/backend/package.json
+++ b/libs/backend/package.json
@@ -34,6 +34,7 @@
     ]
   },
   "dependencies": {
+    "@types/uuid": "^9.0.5",
     "@votingworks/auth": "workspace:*",
     "@votingworks/basics": "workspace:*",
     "@votingworks/db": "workspace:*",
@@ -53,6 +54,7 @@
     "stream-chopper": "^3.0.1",
     "stream-json": "^1.7.5",
     "tmp": "^0.2.1",
+    "uuid": "^9.0.1",
     "zod": "3.14.4"
   },
   "devDependencies": {

--- a/libs/backend/src/cast_vote_records/build_cast_vote_record.test.ts
+++ b/libs/backend/src/cast_vote_records/build_cast_vote_record.test.ts
@@ -8,7 +8,6 @@ import {
   CVR,
   getBallotStyle,
   getContests,
-  InterpretedHmpbPage,
   unsafeParse,
 } from '@votingworks/types';
 import {
@@ -17,6 +16,7 @@ import {
   fishingContest,
   interpretedBmdPage,
   interpretedHmpbPage1,
+  interpretedHmpbPage1WithWriteIn,
   interpretedHmpbPage2,
 } from '../../test/fixtures/interpretations';
 import {
@@ -685,15 +685,6 @@ describe('buildCastVoteRecord - HMPB Ballot', () => {
 });
 
 test('buildCastVoteRecord - HMPB ballot with write-in', () => {
-  const interpretedHmpbPage1WithWriteIn: InterpretedHmpbPage = {
-    ...interpretedHmpbPage1,
-    votes: {
-      [fishCouncilContest.id]: [
-        { id: 'write-in-1', name: 'Write In #1', isWriteIn: true },
-      ],
-    },
-  };
-
   const castVoteRecord = buildCastVoteRecord({
     election,
     electionId,

--- a/libs/backend/src/cast_vote_records/export.test.ts
+++ b/libs/backend/src/cast_vote_records/export.test.ts
@@ -1,0 +1,1027 @@
+import fs from 'fs';
+import path from 'path';
+import { dirSync } from 'tmp';
+import { v4 as uuid } from 'uuid';
+import { assert, assertDefined, err, ok, sleep } from '@votingworks/basics';
+import { electionTwoPartyPrimaryFixtures } from '@votingworks/fixtures';
+import {
+  BatchInfo,
+  CastVoteRecordExportFileName,
+  CVR,
+  PageInterpretation,
+  SheetOf,
+} from '@votingworks/types';
+import { createMockUsbDrive, MockUsbDrive } from '@votingworks/usb-drive';
+import {
+  BooleanEnvironmentVariableName,
+  getFeatureFlagMock,
+} from '@votingworks/utils';
+
+import {
+  bestFishContest,
+  fishCouncilContest,
+  fishingContest,
+  interpretedBmdBallot,
+  interpretedBmdPage,
+  interpretedHmpb,
+  interpretedHmpbPage1,
+  interpretedHmpbWithWriteIn,
+} from '../../test/fixtures/interpretations';
+import {
+  MockCentralScannerStore,
+  MockPrecinctScannerStore,
+  summarizeDirectoryContents,
+} from '../../test/utils';
+import {
+  AcceptedSheet,
+  areOrWereCastVoteRecordsBeingExportedToUsbDrive,
+  clearDoesUsbDriveRequireCastVoteRecordSyncCachedResult,
+  doesUsbDriveRequireCastVoteRecordSync,
+  exportCastVoteRecordsToUsbDrive,
+  ExportOptions,
+  markCastVoteRecordExportAsInProgress,
+  RejectedSheet,
+  Sheet,
+} from './export';
+import { readCastVoteRecordExportMetadata } from './import';
+import {
+  getCastVoteRecordExportDirectoryPaths,
+  readCastVoteRecord,
+} from './test_utils';
+
+const mockFeatureFlagger = getFeatureFlagMock();
+
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
+  return {
+    ...jest.requireActual('@votingworks/utils'),
+    // Mock this function because it expects the election definition to have gridLayouts, and the
+    // election definition fixture that we're using does not
+    getContestsForBallotPage: ({ ballotPageMetadata }) =>
+      ballotPageMetadata.pageNumber === 1
+        ? [bestFishContest, fishCouncilContest]
+        : [fishingContest],
+    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+  };
+});
+
+const { electionDefinition } = electionTwoPartyPrimaryFixtures;
+
+const batch1Id = uuid();
+const batch1: BatchInfo = {
+  id: batch1Id,
+  batchNumber: 1,
+  count: 0,
+  label: 'Batch 1',
+  startedAt: new Date().toISOString(),
+};
+
+let mockCentralScannerStore: MockCentralScannerStore;
+let mockPrecinctScannerStore: MockPrecinctScannerStore;
+let mockUsbDrive: MockUsbDrive;
+let tempDirectoryPath: string;
+
+beforeEach(() => {
+  mockFeatureFlagger.resetFeatureFlags();
+
+  mockUsbDrive = createMockUsbDrive();
+  mockCentralScannerStore = new MockCentralScannerStore();
+  mockPrecinctScannerStore = new MockPrecinctScannerStore();
+  tempDirectoryPath = dirSync().name;
+
+  mockUsbDrive.insertUsbDrive({});
+  mockCentralScannerStore.setElectionDefinition(electionDefinition);
+  mockCentralScannerStore.setBatches([batch1]);
+  mockPrecinctScannerStore.setElectionDefinition(electionDefinition);
+  mockPrecinctScannerStore.setPollsState('polls_open');
+  mockPrecinctScannerStore.setBatches([batch1]);
+});
+
+afterEach(() => {
+  fs.rmSync(tempDirectoryPath, { recursive: true });
+  clearDoesUsbDriveRequireCastVoteRecordSyncCachedResult();
+});
+
+const sheet1Id = uuid();
+const sheet2Id = uuid();
+const sheet3Id = uuid();
+const sheet4Id = uuid();
+const sheet5Id = uuid();
+
+function generateMockImages(sheetId: string): SheetOf<string> {
+  const imagePaths: SheetOf<string> = [
+    path.join(tempDirectoryPath, `${sheetId}-front.jpg`),
+    path.join(tempDirectoryPath, `${sheetId}-back.jpg`),
+  ];
+  fs.writeFileSync(imagePaths[0], Math.random().toString());
+  fs.writeFileSync(imagePaths[1], Math.random().toString());
+  return imagePaths;
+}
+
+function newAcceptedSheet(
+  interpretation: SheetOf<PageInterpretation>,
+  sheetId: string = uuid()
+): AcceptedSheet {
+  const imagePaths = generateMockImages(sheetId);
+  return {
+    type: 'accepted',
+    id: sheetId,
+    batchId: batch1Id,
+    interpretation,
+    frontImagePath: imagePaths[0],
+    backImagePath: imagePaths[1],
+  };
+}
+
+function newRejectedSheet(sheetId: string = uuid()): RejectedSheet {
+  const imagePaths = generateMockImages(sheetId);
+  return {
+    type: 'rejected',
+    id: sheetId,
+    frontImagePath: imagePaths[0],
+    backImagePath: imagePaths[1],
+  };
+}
+
+const anyCastVoteRecordHash: CVR.Hash = {
+  '@type': 'CVR.Hash',
+  Type: CVR.HashType.Sha256,
+  Value: expect.any(String),
+};
+
+test.each<{
+  description: string;
+  sheetGenerator: () => AcceptedSheet | RejectedSheet;
+  exportOptions: ExportOptions;
+  expectedDirectoryContents: string[];
+  expectedBallotImageField?: SheetOf<CVR.ImageData>;
+}>([
+  {
+    description: 'accepted HMPB on precinct scanner',
+    sheetGenerator: () => newAcceptedSheet(interpretedHmpb, sheet1Id),
+    exportOptions: { scannerType: 'precinct' },
+    expectedDirectoryContents: [
+      CastVoteRecordExportFileName.METADATA,
+      `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+      `${sheet1Id}/${sheet1Id}-front.jpg`,
+      `${sheet1Id}/${sheet1Id}-back.jpg`,
+      `${sheet1Id}/${sheet1Id}-front.layout.json`,
+      `${sheet1Id}/${sheet1Id}-back.layout.json`,
+    ],
+    expectedBallotImageField: [
+      {
+        '@type': 'CVR.ImageData',
+        Hash: anyCastVoteRecordHash,
+        Location: `file:${sheet1Id}-front.jpg`,
+        vxLayoutFileHash: expect.any(String),
+      },
+      {
+        '@type': 'CVR.ImageData',
+        Hash: anyCastVoteRecordHash,
+        Location: `file:${sheet1Id}-back.jpg`,
+        vxLayoutFileHash: expect.any(String),
+      },
+    ],
+  },
+  {
+    description: 'accepted HMPB on central scanner, non-minimal export',
+    sheetGenerator: () => newAcceptedSheet(interpretedHmpb, sheet1Id),
+    exportOptions: { scannerType: 'central', isMinimalExport: false },
+    expectedDirectoryContents: [
+      CastVoteRecordExportFileName.METADATA,
+      `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+      `${sheet1Id}/${sheet1Id}-front.jpg`,
+      `${sheet1Id}/${sheet1Id}-back.jpg`,
+      `${sheet1Id}/${sheet1Id}-front.layout.json`,
+      `${sheet1Id}/${sheet1Id}-back.layout.json`,
+    ],
+    expectedBallotImageField: [
+      {
+        '@type': 'CVR.ImageData',
+        Hash: anyCastVoteRecordHash,
+        Location: `file:${sheet1Id}-front.jpg`,
+        vxLayoutFileHash: expect.any(String),
+      },
+      {
+        '@type': 'CVR.ImageData',
+        Hash: anyCastVoteRecordHash,
+        Location: `file:${sheet1Id}-back.jpg`,
+        vxLayoutFileHash: expect.any(String),
+      },
+    ],
+  },
+  {
+    description: 'accepted HMPB on central scanner, minimal export',
+    sheetGenerator: () => newAcceptedSheet(interpretedHmpb, sheet1Id),
+    exportOptions: { scannerType: 'central', isMinimalExport: true },
+    expectedDirectoryContents: [
+      CastVoteRecordExportFileName.METADATA,
+      `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+    ],
+    expectedBallotImageField: undefined,
+  },
+
+  {
+    description: 'accepted HMPB with write-in on precinct scanner',
+    sheetGenerator: () =>
+      newAcceptedSheet(interpretedHmpbWithWriteIn, sheet1Id),
+    exportOptions: { scannerType: 'precinct' },
+    expectedDirectoryContents: [
+      CastVoteRecordExportFileName.METADATA,
+      `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+      `${sheet1Id}/${sheet1Id}-front.jpg`,
+      `${sheet1Id}/${sheet1Id}-back.jpg`,
+      `${sheet1Id}/${sheet1Id}-front.layout.json`,
+      `${sheet1Id}/${sheet1Id}-back.layout.json`,
+    ],
+    expectedBallotImageField: [
+      {
+        '@type': 'CVR.ImageData',
+        Hash: anyCastVoteRecordHash,
+        Location: `file:${sheet1Id}-front.jpg`,
+        vxLayoutFileHash: expect.any(String),
+      },
+      {
+        '@type': 'CVR.ImageData',
+        Hash: anyCastVoteRecordHash,
+        Location: `file:${sheet1Id}-back.jpg`,
+        vxLayoutFileHash: expect.any(String),
+      },
+    ],
+  },
+  {
+    description:
+      'accepted HMPB with write-in on central scanner, non-minimal export',
+    sheetGenerator: () =>
+      newAcceptedSheet(interpretedHmpbWithWriteIn, sheet1Id),
+    exportOptions: { scannerType: 'central', isMinimalExport: false },
+    expectedDirectoryContents: [
+      CastVoteRecordExportFileName.METADATA,
+      `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+      `${sheet1Id}/${sheet1Id}-front.jpg`,
+      `${sheet1Id}/${sheet1Id}-back.jpg`,
+      `${sheet1Id}/${sheet1Id}-front.layout.json`,
+      `${sheet1Id}/${sheet1Id}-back.layout.json`,
+    ],
+    expectedBallotImageField: [
+      {
+        '@type': 'CVR.ImageData',
+        Hash: anyCastVoteRecordHash,
+        Location: `file:${sheet1Id}-front.jpg`,
+        vxLayoutFileHash: expect.any(String),
+      },
+      {
+        '@type': 'CVR.ImageData',
+        Hash: anyCastVoteRecordHash,
+        Location: `file:${sheet1Id}-back.jpg`,
+        vxLayoutFileHash: expect.any(String),
+      },
+    ],
+  },
+  {
+    description:
+      'accepted HMPB with write-in on central scanner, minimal export',
+    sheetGenerator: () =>
+      newAcceptedSheet(interpretedHmpbWithWriteIn, sheet1Id),
+    exportOptions: { scannerType: 'central', isMinimalExport: true },
+    expectedDirectoryContents: [
+      CastVoteRecordExportFileName.METADATA,
+      `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+      `${sheet1Id}/${sheet1Id}-front.jpg`,
+      `${sheet1Id}/${sheet1Id}-back.jpg`,
+      `${sheet1Id}/${sheet1Id}-front.layout.json`,
+      `${sheet1Id}/${sheet1Id}-back.layout.json`,
+    ],
+    expectedBallotImageField: [
+      {
+        '@type': 'CVR.ImageData',
+        Hash: anyCastVoteRecordHash,
+        Location: `file:${sheet1Id}-front.jpg`,
+        vxLayoutFileHash: expect.any(String),
+      },
+      {
+        '@type': 'CVR.ImageData',
+        Hash: anyCastVoteRecordHash,
+        Location: `file:${sheet1Id}-back.jpg`,
+        vxLayoutFileHash: expect.any(String),
+      },
+    ],
+  },
+  {
+    description: 'accepted BMD ballot on precinct scanner',
+    sheetGenerator: () => newAcceptedSheet(interpretedBmdBallot, sheet1Id),
+    exportOptions: { scannerType: 'precinct' },
+    expectedDirectoryContents: [
+      CastVoteRecordExportFileName.METADATA,
+      `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+      `${sheet1Id}/${sheet1Id}-front.jpg`,
+      `${sheet1Id}/${sheet1Id}-back.jpg`,
+    ],
+    expectedBallotImageField: [
+      {
+        '@type': 'CVR.ImageData',
+        Hash: anyCastVoteRecordHash,
+        Location: `file:${sheet1Id}-front.jpg`,
+      },
+      {
+        '@type': 'CVR.ImageData',
+        Hash: anyCastVoteRecordHash,
+        Location: `file:${sheet1Id}-back.jpg`,
+      },
+    ],
+  },
+  {
+    description: 'accepted BMD ballot on central scanner, non-minimal export',
+    sheetGenerator: () => newAcceptedSheet(interpretedBmdBallot, sheet1Id),
+    exportOptions: { scannerType: 'central', isMinimalExport: false },
+    expectedDirectoryContents: [
+      CastVoteRecordExportFileName.METADATA,
+      `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+      `${sheet1Id}/${sheet1Id}-front.jpg`,
+      `${sheet1Id}/${sheet1Id}-back.jpg`,
+    ],
+    expectedBallotImageField: [
+      {
+        '@type': 'CVR.ImageData',
+        Hash: anyCastVoteRecordHash,
+        Location: `file:${sheet1Id}-front.jpg`,
+      },
+      {
+        '@type': 'CVR.ImageData',
+        Hash: anyCastVoteRecordHash,
+        Location: `file:${sheet1Id}-back.jpg`,
+      },
+    ],
+  },
+  {
+    description: 'accepted BMD ballot on central scanner, minimal export',
+    sheetGenerator: () => newAcceptedSheet(interpretedBmdBallot, sheet1Id),
+    exportOptions: { scannerType: 'central', isMinimalExport: true },
+    expectedDirectoryContents: [
+      CastVoteRecordExportFileName.METADATA,
+      `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+    ],
+    expectedBallotImageField: undefined,
+  },
+  {
+    description: 'rejected sheet on precinct scanner',
+    sheetGenerator: () => newRejectedSheet(sheet1Id),
+    exportOptions: { scannerType: 'precinct' },
+    expectedDirectoryContents: [
+      CastVoteRecordExportFileName.METADATA,
+      `rejected-${sheet1Id}/${sheet1Id}-front.jpg`,
+      `rejected-${sheet1Id}/${sheet1Id}-back.jpg`,
+    ],
+  },
+  {
+    description: 'rejected sheet on central scanner, non-minimal export',
+    sheetGenerator: () => newRejectedSheet(sheet1Id),
+    exportOptions: { scannerType: 'central', isMinimalExport: false },
+    expectedDirectoryContents: [
+      CastVoteRecordExportFileName.METADATA,
+      `rejected-${sheet1Id}/${sheet1Id}-front.jpg`,
+      `rejected-${sheet1Id}/${sheet1Id}-back.jpg`,
+    ],
+  },
+])(
+  'one-sheet export - $description',
+  async ({
+    sheetGenerator,
+    exportOptions,
+    expectedDirectoryContents,
+    expectedBallotImageField,
+  }) => {
+    const sheet = sheetGenerator();
+    expect(
+      await exportCastVoteRecordsToUsbDrive(
+        exportOptions.scannerType === 'central'
+          ? mockCentralScannerStore
+          : mockPrecinctScannerStore,
+        mockUsbDrive.usbDrive,
+        [sheet],
+        exportOptions
+      )
+    ).toEqual(ok());
+
+    const exportDirectoryPaths = await getCastVoteRecordExportDirectoryPaths(
+      mockUsbDrive.usbDrive
+    );
+    expect(exportDirectoryPaths).toHaveLength(1);
+    const exportDirectoryPath = assertDefined(exportDirectoryPaths[0]);
+    const exportDirectoryContents =
+      await summarizeDirectoryContents(exportDirectoryPath);
+    expect(exportDirectoryContents).toEqual(
+      [...expectedDirectoryContents].sort()
+    );
+
+    if (sheet.type === 'accepted') {
+      const { castVoteRecord } = readCastVoteRecord(
+        path.join(exportDirectoryPath, sheet1Id)
+      );
+      expect(castVoteRecord.BallotImage).toEqual(expectedBallotImageField);
+    }
+  }
+);
+
+test('precinct scanner continuous export', async () => {
+  for (const sheet of [
+    newAcceptedSheet(interpretedHmpb, sheet1Id),
+    newAcceptedSheet(interpretedHmpbWithWriteIn, sheet2Id),
+    newAcceptedSheet(interpretedBmdBallot, sheet3Id),
+    newRejectedSheet(sheet4Id),
+  ]) {
+    expect(
+      await exportCastVoteRecordsToUsbDrive(
+        mockPrecinctScannerStore,
+        mockUsbDrive.usbDrive,
+        [sheet],
+        { scannerType: 'precinct' }
+      )
+    ).toEqual(ok());
+  }
+
+  const exportDirectoryPaths = await getCastVoteRecordExportDirectoryPaths(
+    mockUsbDrive.usbDrive
+  );
+  expect(exportDirectoryPaths).toHaveLength(1);
+  const exportDirectoryPath = assertDefined(exportDirectoryPaths[0]);
+  const exportDirectoryContents =
+    await summarizeDirectoryContents(exportDirectoryPath);
+  const expectedExportDirectoryContents = [
+    CastVoteRecordExportFileName.METADATA,
+    `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+    `${sheet1Id}/${sheet1Id}-front.jpg`,
+    `${sheet1Id}/${sheet1Id}-back.jpg`,
+    `${sheet1Id}/${sheet1Id}-front.layout.json`,
+    `${sheet1Id}/${sheet1Id}-back.layout.json`,
+    `${sheet2Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+    `${sheet2Id}/${sheet2Id}-front.jpg`,
+    `${sheet2Id}/${sheet2Id}-back.jpg`,
+    `${sheet2Id}/${sheet2Id}-front.layout.json`,
+    `${sheet2Id}/${sheet2Id}-back.layout.json`,
+    `${sheet3Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+    `${sheet3Id}/${sheet3Id}-front.jpg`,
+    `${sheet3Id}/${sheet3Id}-back.jpg`,
+    `rejected-${sheet4Id}/${sheet4Id}-front.jpg`,
+    `rejected-${sheet4Id}/${sheet4Id}-back.jpg`,
+  ].sort();
+  expect(exportDirectoryContents).toEqual(expectedExportDirectoryContents);
+  let metadata = (
+    await readCastVoteRecordExportMetadata(exportDirectoryPath)
+  ).unsafeUnwrap();
+  expect(metadata.arePollsClosed).toEqual(false);
+
+  expect(
+    await exportCastVoteRecordsToUsbDrive(
+      mockPrecinctScannerStore,
+      mockUsbDrive.usbDrive,
+      [],
+      { scannerType: 'precinct', arePollsClosing: true }
+    )
+  ).toEqual(ok());
+
+  expect(exportDirectoryContents).toEqual(expectedExportDirectoryContents);
+  metadata = (
+    await readCastVoteRecordExportMetadata(exportDirectoryPath)
+  ).unsafeUnwrap();
+  expect(metadata.arePollsClosed).toEqual(true);
+});
+
+test('precinct scanner full export', async () => {
+  // Perform two full exports and verify that a separate directory is created for each
+  for (let i = 0; i < 2; i += 1) {
+    const sheets = [
+      newAcceptedSheet(interpretedHmpb, sheet1Id),
+      newAcceptedSheet(interpretedHmpbWithWriteIn, sheet2Id),
+      newAcceptedSheet(interpretedBmdBallot, sheet3Id),
+      newRejectedSheet(sheet4Id),
+    ];
+    expect(
+      await exportCastVoteRecordsToUsbDrive(
+        mockPrecinctScannerStore,
+        mockUsbDrive.usbDrive,
+        sheets,
+        { scannerType: 'precinct', isFullExport: true }
+      )
+    ).toEqual(ok());
+
+    const exportDirectoryPaths = await getCastVoteRecordExportDirectoryPaths(
+      mockUsbDrive.usbDrive
+    );
+    expect(exportDirectoryPaths).toHaveLength(i + 1);
+    const exportDirectoryPath = assertDefined(exportDirectoryPaths[i]);
+    let exportDirectoryContents =
+      await summarizeDirectoryContents(exportDirectoryPath);
+    let expectedExportDirectoryContents = [
+      CastVoteRecordExportFileName.METADATA,
+      `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+      `${sheet1Id}/${sheet1Id}-front.jpg`,
+      `${sheet1Id}/${sheet1Id}-back.jpg`,
+      `${sheet1Id}/${sheet1Id}-front.layout.json`,
+      `${sheet1Id}/${sheet1Id}-back.layout.json`,
+      `${sheet2Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+      `${sheet2Id}/${sheet2Id}-front.jpg`,
+      `${sheet2Id}/${sheet2Id}-back.jpg`,
+      `${sheet2Id}/${sheet2Id}-front.layout.json`,
+      `${sheet2Id}/${sheet2Id}-back.layout.json`,
+      `${sheet3Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+      `${sheet3Id}/${sheet3Id}-front.jpg`,
+      `${sheet3Id}/${sheet3Id}-back.jpg`,
+      `rejected-${sheet4Id}/${sheet4Id}-front.jpg`,
+      `rejected-${sheet4Id}/${sheet4Id}-back.jpg`,
+    ].sort();
+    expect(exportDirectoryContents).toEqual(expectedExportDirectoryContents);
+
+    // Sleep 1 second after the first export to guarantee that the second export directory has a
+    // different name than the first
+    if (i === 0) {
+      await sleep(1000);
+    }
+
+    // Export one more record after the second export and verify that it's added to the second
+    // export directory
+    if (i === 1) {
+      expect(
+        await exportCastVoteRecordsToUsbDrive(
+          mockPrecinctScannerStore,
+          mockUsbDrive.usbDrive,
+          [newAcceptedSheet(interpretedHmpb, sheet5Id)],
+          { scannerType: 'precinct', isFullExport: false }
+        )
+      ).toEqual(ok());
+
+      exportDirectoryContents =
+        await summarizeDirectoryContents(exportDirectoryPath);
+      expectedExportDirectoryContents = [
+        ...expectedExportDirectoryContents,
+        `${sheet5Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+        `${sheet5Id}/${sheet5Id}-front.jpg`,
+        `${sheet5Id}/${sheet5Id}-back.jpg`,
+        `${sheet5Id}/${sheet5Id}-front.layout.json`,
+        `${sheet5Id}/${sheet5Id}-back.layout.json`,
+      ].sort();
+      expect(exportDirectoryContents).toEqual(expectedExportDirectoryContents);
+    }
+  }
+});
+
+test('central scanner multiple-sheet export, minimal and non-minimal', async () => {
+  // Perform a minimal export
+  const sheets: Sheet[] = [
+    newAcceptedSheet(interpretedHmpb, sheet1Id),
+    newAcceptedSheet(interpretedHmpbWithWriteIn, sheet2Id),
+    newAcceptedSheet(interpretedBmdBallot, sheet3Id),
+  ];
+  expect(
+    await exportCastVoteRecordsToUsbDrive(
+      mockCentralScannerStore,
+      mockUsbDrive.usbDrive,
+      sheets,
+      { scannerType: 'central', isMinimalExport: true }
+    )
+  ).toEqual(ok());
+
+  let exportDirectoryPaths = await getCastVoteRecordExportDirectoryPaths(
+    mockUsbDrive.usbDrive
+  );
+  expect(exportDirectoryPaths).toHaveLength(1);
+  let exportDirectoryPath = assertDefined(exportDirectoryPaths[0]);
+  let exportDirectoryContents =
+    await summarizeDirectoryContents(exportDirectoryPath);
+  let expectedExportDirectoryContents = [
+    CastVoteRecordExportFileName.METADATA,
+    `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+    `${sheet2Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+    `${sheet2Id}/${sheet2Id}-front.jpg`,
+    `${sheet2Id}/${sheet2Id}-back.jpg`,
+    `${sheet2Id}/${sheet2Id}-front.layout.json`,
+    `${sheet2Id}/${sheet2Id}-back.layout.json`,
+    `${sheet3Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+  ].sort();
+  expect(exportDirectoryContents).toEqual(expectedExportDirectoryContents);
+
+  // Sleep 1 second to guarantee that the second export directory has a different name than the
+  // first
+  await sleep(1000);
+
+  // Perform a non-minimal export
+  sheets.push(newRejectedSheet(sheet4Id));
+  expect(
+    await exportCastVoteRecordsToUsbDrive(
+      mockCentralScannerStore,
+      mockUsbDrive.usbDrive,
+      sheets,
+      { scannerType: 'central', isMinimalExport: false }
+    )
+  ).toEqual(ok());
+
+  exportDirectoryPaths = await getCastVoteRecordExportDirectoryPaths(
+    mockUsbDrive.usbDrive
+  );
+  expect(exportDirectoryPaths).toHaveLength(2);
+  exportDirectoryPath = assertDefined(exportDirectoryPaths[1]);
+  exportDirectoryContents =
+    await summarizeDirectoryContents(exportDirectoryPath);
+  expectedExportDirectoryContents = [
+    ...expectedExportDirectoryContents,
+    `${sheet1Id}/${sheet1Id}-front.jpg`,
+    `${sheet1Id}/${sheet1Id}-back.jpg`,
+    `${sheet1Id}/${sheet1Id}-front.layout.json`,
+    `${sheet1Id}/${sheet1Id}-back.layout.json`,
+    `${sheet3Id}/${sheet3Id}-front.jpg`,
+    `${sheet3Id}/${sheet3Id}-back.jpg`,
+    `rejected-${sheet4Id}/${sheet4Id}-front.jpg`,
+    `rejected-${sheet4Id}/${sheet4Id}-back.jpg`,
+  ].sort();
+  expect(exportDirectoryContents).toEqual(expectedExportDirectoryContents);
+});
+
+test('detecting invalid sheet with incompatible interpretation types', async () => {
+  const invalidSheet = newAcceptedSheet([
+    interpretedHmpbPage1,
+    interpretedBmdPage,
+  ]);
+  expect(
+    await exportCastVoteRecordsToUsbDrive(
+      mockPrecinctScannerStore,
+      mockUsbDrive.usbDrive,
+      [invalidSheet],
+      { scannerType: 'precinct' }
+    )
+  ).toEqual(
+    err({
+      type: 'invalid-sheet',
+      subType: 'incompatible-interpretation-types',
+      interpretationTypes: ['InterpretedHmpbPage', 'InterpretedBmdPage'],
+    })
+  );
+});
+
+test('central scanner minimal export does not allow rejected sheets', async () => {
+  await expect(
+    exportCastVoteRecordsToUsbDrive(
+      mockCentralScannerStore,
+      mockUsbDrive.usbDrive,
+      [newRejectedSheet()],
+      { scannerType: 'central', isMinimalExport: true }
+    )
+  ).rejects.toThrow(
+    'Encountered an unexpected rejected sheet while performing a minimal export. ' +
+      'Minimal exports should only include accepted sheets.'
+  );
+});
+
+test('exporting when no USB drive', async () => {
+  mockUsbDrive.removeUsbDrive();
+
+  expect(
+    await exportCastVoteRecordsToUsbDrive(
+      mockPrecinctScannerStore,
+      mockUsbDrive.usbDrive,
+      [newAcceptedSheet(interpretedHmpb)],
+      { scannerType: 'precinct' }
+    )
+  ).toEqual(err({ type: 'missing-usb-drive' }));
+});
+
+test('CAST_VOTE_RECORD_OPTIMIZATION_EXCLUDE_REDUNDANT_METADATA feature flag', async () => {
+  const sheet = newAcceptedSheet(interpretedHmpb, sheet1Id);
+  const castVoteRecords: CVR.CVR[] = [];
+  for (const isOptimizationEnabled of [true, false] as const) {
+    mockUsbDrive.removeUsbDrive();
+    mockUsbDrive.insertUsbDrive({});
+
+    if (isOptimizationEnabled) {
+      mockFeatureFlagger.enableFeatureFlag(
+        BooleanEnvironmentVariableName.CAST_VOTE_RECORD_OPTIMIZATION_EXCLUDE_REDUNDANT_METADATA
+      );
+    } else {
+      mockFeatureFlagger.disableFeatureFlag(
+        BooleanEnvironmentVariableName.CAST_VOTE_RECORD_OPTIMIZATION_EXCLUDE_REDUNDANT_METADATA
+      );
+    }
+
+    expect(
+      await exportCastVoteRecordsToUsbDrive(
+        mockPrecinctScannerStore,
+        mockUsbDrive.usbDrive,
+        [sheet],
+        { scannerType: 'precinct' }
+      )
+    ).toEqual(ok());
+
+    const exportDirectoryPaths = await getCastVoteRecordExportDirectoryPaths(
+      mockUsbDrive.usbDrive
+    );
+    expect(exportDirectoryPaths).toHaveLength(1);
+    const exportDirectoryPath = assertDefined(exportDirectoryPaths[0]);
+    const { castVoteRecord, castVoteRecordReportContents } = readCastVoteRecord(
+      path.join(exportDirectoryPath, sheet1Id)
+    );
+
+    castVoteRecords.push(castVoteRecord);
+    const numberOfKeysInCastVoteRecordReport = Object.keys(
+      JSON.parse(castVoteRecordReportContents)
+    ).length;
+    if (isOptimizationEnabled) {
+      expect(numberOfKeysInCastVoteRecordReport).toEqual(1);
+    } else {
+      expect(numberOfKeysInCastVoteRecordReport).toBeGreaterThan(1);
+    }
+  }
+
+  // Verify that the parsed cast vote record is unaffected by the optimization
+  expect(castVoteRecords).toHaveLength(2);
+  expect(castVoteRecords[0]).toBeDefined();
+  expect(castVoteRecords[1]).toBeDefined();
+  expect(castVoteRecords[0]).toEqual(castVoteRecords[1]);
+});
+
+test.each<{
+  description: string;
+  setupFn: () => void | Promise<void>;
+  shouldUsbDriveRequireCastVoteRecordSync: boolean;
+}>([
+  {
+    description: 'no USB drive, unconfigured machine',
+    setupFn: () => {
+      mockUsbDrive.removeUsbDrive();
+      mockPrecinctScannerStore.setElectionDefinition(undefined);
+      mockPrecinctScannerStore.setPollsState('polls_closed_initial');
+    },
+    shouldUsbDriveRequireCastVoteRecordSync: false,
+  },
+  {
+    description: 'unconfigured machine',
+    setupFn: () => {
+      mockUsbDrive.insertUsbDrive({});
+      mockPrecinctScannerStore.setElectionDefinition(undefined);
+      mockPrecinctScannerStore.setPollsState('polls_closed_initial');
+    },
+    shouldUsbDriveRequireCastVoteRecordSync: false,
+  },
+  {
+    description: 'configured machine, polls closed',
+    setupFn: () => {
+      mockUsbDrive.insertUsbDrive({});
+      mockPrecinctScannerStore.setElectionDefinition(electionDefinition);
+      mockPrecinctScannerStore.setPollsState('polls_closed_initial');
+    },
+    shouldUsbDriveRequireCastVoteRecordSync: false,
+  },
+  {
+    description: 'polls open, no ballots cast',
+    setupFn: () => {
+      mockUsbDrive.insertUsbDrive({});
+      mockPrecinctScannerStore.setElectionDefinition(electionDefinition);
+      mockPrecinctScannerStore.setPollsState('polls_open');
+    },
+    shouldUsbDriveRequireCastVoteRecordSync: false,
+  },
+  {
+    description: 'ballots cast, nothing on USB drive',
+    setupFn: () => {
+      mockUsbDrive.insertUsbDrive({});
+      mockPrecinctScannerStore.setElectionDefinition(electionDefinition);
+      mockPrecinctScannerStore.setPollsState('polls_open');
+      mockPrecinctScannerStore.setBallotsCounted(1);
+    },
+    shouldUsbDriveRequireCastVoteRecordSync: true,
+  },
+  {
+    description:
+      'ballots cast, previous export operation may have failed midway',
+    setupFn: async () => {
+      mockUsbDrive.insertUsbDrive({});
+      mockPrecinctScannerStore.setElectionDefinition(electionDefinition);
+      mockPrecinctScannerStore.setPollsState('polls_open');
+      mockPrecinctScannerStore.setBallotsCounted(1);
+      const usbDriveStatus = await mockUsbDrive.usbDrive.status();
+      assert(usbDriveStatus.status === 'mounted');
+      await markCastVoteRecordExportAsInProgress(usbDriveStatus.mountPoint);
+    },
+    shouldUsbDriveRequireCastVoteRecordSync: true,
+  },
+  {
+    description: 'ballots cast and exported to USB drive',
+    setupFn: async () => {
+      mockUsbDrive.insertUsbDrive({});
+      mockPrecinctScannerStore.setElectionDefinition(electionDefinition);
+      mockPrecinctScannerStore.setPollsState('polls_open');
+      mockPrecinctScannerStore.setBallotsCounted(1);
+      (
+        await exportCastVoteRecordsToUsbDrive(
+          mockPrecinctScannerStore,
+          mockUsbDrive.usbDrive,
+          [newAcceptedSheet(interpretedHmpb)],
+          { scannerType: 'precinct' }
+        )
+      ).unsafeUnwrap();
+    },
+    shouldUsbDriveRequireCastVoteRecordSync: false,
+  },
+  {
+    description:
+      'ballots cast and exported to USB drive, but USB drive replaced',
+    setupFn: async () => {
+      mockUsbDrive.insertUsbDrive({});
+      mockPrecinctScannerStore.setElectionDefinition(electionDefinition);
+      mockPrecinctScannerStore.setPollsState('polls_open');
+      mockPrecinctScannerStore.setBallotsCounted(1);
+      (
+        await exportCastVoteRecordsToUsbDrive(
+          mockPrecinctScannerStore,
+          mockUsbDrive.usbDrive,
+          [newAcceptedSheet(interpretedHmpb)],
+          { scannerType: 'precinct' }
+        )
+      ).unsafeUnwrap();
+      mockUsbDrive.removeUsbDrive();
+      mockUsbDrive.insertUsbDrive({});
+    },
+    shouldUsbDriveRequireCastVoteRecordSync: true,
+  },
+  {
+    description:
+      'cast vote record root hash in metadata file does not match that on machine',
+    setupFn: async () => {
+      mockUsbDrive.insertUsbDrive({});
+      mockPrecinctScannerStore.setElectionDefinition(electionDefinition);
+      mockPrecinctScannerStore.setPollsState('polls_open');
+      mockPrecinctScannerStore.setBallotsCounted(1);
+      (
+        await exportCastVoteRecordsToUsbDrive(
+          mockPrecinctScannerStore,
+          mockUsbDrive.usbDrive,
+          [newAcceptedSheet(interpretedHmpb)],
+          { scannerType: 'precinct' }
+        )
+      ).unsafeUnwrap();
+      const exportDirectoryPaths = await getCastVoteRecordExportDirectoryPaths(
+        mockUsbDrive.usbDrive
+      );
+      expect(exportDirectoryPaths).toHaveLength(1);
+      const exportDirectoryPath = assertDefined(exportDirectoryPaths[0]);
+      const metadataFilePath = path.join(
+        exportDirectoryPath,
+        CastVoteRecordExportFileName.METADATA
+      );
+      const metadata = JSON.parse(fs.readFileSync(metadataFilePath, 'utf-8'));
+      fs.writeFileSync(
+        metadataFilePath,
+        JSON.stringify({
+          ...metadata,
+          castVoteRecordRootHash: 'incorrect-hash',
+        })
+      );
+    },
+    shouldUsbDriveRequireCastVoteRecordSync: true,
+  },
+])(
+  'doesUsbDriveRequireCastVoteRecordSync - $description',
+  async ({ setupFn, shouldUsbDriveRequireCastVoteRecordSync }) => {
+    await setupFn();
+    const usbDriveStatus = await mockUsbDrive.usbDrive.status();
+
+    expect(
+      await doesUsbDriveRequireCastVoteRecordSync(
+        mockPrecinctScannerStore,
+        usbDriveStatus
+      )
+    ).toEqual(shouldUsbDriveRequireCastVoteRecordSync);
+  }
+);
+
+test('doesUsbDriveRequireCastVoteRecordSync caching works', async () => {
+  const getElectionDefinitionSpy = jest.spyOn(
+    mockPrecinctScannerStore,
+    'getElectionDefinition'
+  );
+
+  mockUsbDrive.insertUsbDrive({});
+  const usbDriveStatus = await mockUsbDrive.usbDrive.status();
+
+  expect(
+    await doesUsbDriveRequireCastVoteRecordSync(
+      mockPrecinctScannerStore,
+      usbDriveStatus
+    )
+  ).toEqual(false);
+  expect(getElectionDefinitionSpy).toHaveBeenCalledTimes(1);
+  getElectionDefinitionSpy.mockClear();
+
+  expect(
+    await doesUsbDriveRequireCastVoteRecordSync(
+      mockPrecinctScannerStore,
+      usbDriveStatus
+    )
+  ).toEqual(false);
+  expect(getElectionDefinitionSpy).not.toHaveBeenCalled();
+});
+
+test('change in USB drive status clears doesUsbDriveRequireCastVoteRecordSync cache', async () => {
+  const getElectionDefinitionSpy = jest.spyOn(
+    mockPrecinctScannerStore,
+    'getElectionDefinition'
+  );
+
+  mockUsbDrive.insertUsbDrive({});
+  let usbDriveStatus = await mockUsbDrive.usbDrive.status();
+
+  expect(
+    await doesUsbDriveRequireCastVoteRecordSync(
+      mockPrecinctScannerStore,
+      usbDriveStatus
+    )
+  ).toEqual(false);
+  expect(getElectionDefinitionSpy).toHaveBeenCalledTimes(1);
+  getElectionDefinitionSpy.mockClear();
+
+  mockUsbDrive.removeUsbDrive();
+  usbDriveStatus = await mockUsbDrive.usbDrive.status();
+
+  expect(
+    await doesUsbDriveRequireCastVoteRecordSync(
+      mockPrecinctScannerStore,
+      usbDriveStatus
+    )
+  ).toEqual(false);
+  expect(getElectionDefinitionSpy).not.toHaveBeenCalled();
+
+  mockUsbDrive.insertUsbDrive({});
+  usbDriveStatus = await mockUsbDrive.usbDrive.status();
+
+  expect(
+    await doesUsbDriveRequireCastVoteRecordSync(
+      mockPrecinctScannerStore,
+      usbDriveStatus
+    )
+  ).toEqual(false);
+  expect(getElectionDefinitionSpy).toHaveBeenCalledTimes(1);
+});
+
+test('cast vote record export clears doesUsbDriveRequireCastVoteRecordSync cache', async () => {
+  mockUsbDrive.insertUsbDrive({});
+  let usbDriveStatus = await mockUsbDrive.usbDrive.status();
+  mockPrecinctScannerStore.setElectionDefinition(electionDefinition);
+  mockPrecinctScannerStore.setPollsState('polls_open');
+  mockPrecinctScannerStore.setBallotsCounted(1);
+
+  const sheet = newAcceptedSheet(interpretedHmpb, sheet1Id);
+  expect(
+    await exportCastVoteRecordsToUsbDrive(
+      mockPrecinctScannerStore,
+      mockUsbDrive.usbDrive,
+      [sheet],
+      { scannerType: 'precinct' }
+    )
+  ).toEqual(ok());
+
+  expect(
+    await doesUsbDriveRequireCastVoteRecordSync(
+      mockPrecinctScannerStore,
+      usbDriveStatus
+    )
+  ).toEqual(false);
+
+  mockUsbDrive.removeUsbDrive();
+  usbDriveStatus = await mockUsbDrive.usbDrive.status();
+
+  expect(
+    await doesUsbDriveRequireCastVoteRecordSync(
+      mockPrecinctScannerStore,
+      usbDriveStatus
+    )
+  ).toEqual(false);
+
+  mockUsbDrive.insertUsbDrive({});
+  usbDriveStatus = await mockUsbDrive.usbDrive.status();
+
+  expect(
+    await doesUsbDriveRequireCastVoteRecordSync(
+      mockPrecinctScannerStore,
+      usbDriveStatus
+    )
+  ).toEqual(true);
+
+  expect(
+    await exportCastVoteRecordsToUsbDrive(
+      mockPrecinctScannerStore,
+      mockUsbDrive.usbDrive,
+      [sheet],
+      { scannerType: 'precinct' }
+    )
+  ).toEqual(ok());
+
+  expect(
+    await doesUsbDriveRequireCastVoteRecordSync(
+      mockPrecinctScannerStore,
+      usbDriveStatus
+    )
+  ).toEqual(false);
+});
+
+test('areOrWereCastVoteRecordsBeingExportedToUsbDrive returns false when no USB drive', () => {
+  expect(
+    areOrWereCastVoteRecordsBeingExportedToUsbDrive({ status: 'no_drive' })
+  ).toEqual(false);
+});

--- a/libs/backend/src/cast_vote_records/export.test.ts
+++ b/libs/backend/src/cast_vote_records/export.test.ts
@@ -81,6 +81,9 @@ let mockUsbDrive: MockUsbDrive;
 let tempDirectoryPath: string;
 
 beforeEach(() => {
+  // While this should technically be set to "central-scan" for tests emulating VxCentralScan
+  // behavior, always using "scan" is fine for the purposes of these tests.
+  process.env['VX_MACHINE_TYPE'] = 'scan';
   mockFeatureFlagger.resetFeatureFlags();
 
   mockUsbDrive = createMockUsbDrive();

--- a/libs/backend/src/cast_vote_records/export.ts
+++ b/libs/backend/src/cast_vote_records/export.ts
@@ -1,4 +1,3 @@
-/* istanbul ignore file */
 import crypto from 'crypto';
 import { existsSync } from 'fs';
 import fs from 'fs/promises';
@@ -111,7 +110,10 @@ interface PrecinctScannerOptions {
   isFullExport?: boolean;
 }
 
-type ExportOptions = CentralScannerOptions | PrecinctScannerOptions;
+/**
+ * Options for {@link exportCastVoteRecordsToUsbDrive}
+ */
+export type ExportOptions = CentralScannerOptions | PrecinctScannerOptions;
 
 /**
  * A grouping of inputs needed by helpers throughout this file
@@ -177,7 +179,7 @@ let doesUsbDriveRequireCastVoteRecordSyncCachedResult:
 /**
  * Clears {@link doesUsbDriveRequireCastVoteRecordSyncCachedResult}
  */
-function clearDoesUsbDriveRequireCastVoteRecordSyncCachedResult(): void {
+export function clearDoesUsbDriveRequireCastVoteRecordSyncCachedResult(): void {
   doesUsbDriveRequireCastVoteRecordSyncCachedResult = undefined;
 }
 
@@ -431,6 +433,7 @@ async function exportCastVoteRecordFilesToUsbDrive(
       path.join(castVoteRecordId, file.fileName),
       file.open()
     );
+    /* istanbul ignore next: Hard to trigger without significant mocking */
     if (exportResult.isErr()) {
       return exportResult;
     }
@@ -464,6 +467,7 @@ async function exportRejectedSheetToUsbDrive(
       path.join(subDirectoryName, file.fileName),
       file.open()
     );
+    /* istanbul ignore next: Hard to trigger without significant mocking */
     if (exportResult.isErr()) {
       return exportResult;
     }
@@ -517,6 +521,7 @@ async function exportMetadataFileToUsbDrive(
     CastVoteRecordExportFileName.METADATA,
     metadataFileContents
   );
+  /* istanbul ignore next: Hard to trigger without significant mocking */
   if (exportResult.isErr()) {
     return exportResult;
   }
@@ -547,6 +552,7 @@ async function exportSignatureFileToUsbDrive(
     signatureFile.fileName,
     signatureFile.fileContents
   );
+  /* istanbul ignore next: Hard to trigger without significant mocking */
   if (exportResult.isErr()) {
     return exportResult;
   }
@@ -604,7 +610,10 @@ function getCastVoteRecordExportInProgressMarkerFilePath(
   return path.join(usbMountPoint, '.vx-export-in-progress');
 }
 
-async function markCastVoteRecordExportAsInProgress(
+/**
+ * Marks a cast vote record export as in progress, by writing a hidden file to the USB drive
+ */
+export async function markCastVoteRecordExportAsInProgress(
   usbMountPoint: string
 ): Promise<void> {
   await fs.writeFile(
@@ -613,6 +622,9 @@ async function markCastVoteRecordExportAsInProgress(
   );
 }
 
+/**
+ * The counterpart to {@link markCastVoteRecordExportAsInProgress}
+ */
 async function markCastVoteRecordExportAsComplete(
   usbMountPoint: string
 ): Promise<void> {
@@ -705,6 +717,7 @@ export async function exportCastVoteRecordsToUsbDrive(
         sheet,
         exportDirectoryPathRelativeToUsbMountPoint
       );
+      /* istanbul ignore next: Hard to trigger without significant mocking */
       if (exportResult.isErr()) {
         return exportResult;
       }
@@ -752,6 +765,7 @@ export async function exportCastVoteRecordsToUsbDrive(
     updatedCastVoteRecordRootHash,
     exportDirectoryPathRelativeToUsbMountPoint
   );
+  /* istanbul ignore next: Hard to trigger without significant mocking */
   if (exportMetadataFileResult.isErr()) {
     return exportMetadataFileResult;
   }
@@ -762,6 +776,7 @@ export async function exportCastVoteRecordsToUsbDrive(
     metadataFileContents,
     exportDirectoryPathRelativeToUsbMountPoint
   );
+  /* istanbul ignore next: Hard to trigger without significant mocking */
   if (exportSignatureFileResult.isErr()) {
     return exportSignatureFileResult;
   }
@@ -824,10 +839,6 @@ export async function doesUsbDriveRequireCastVoteRecordSync(
     if (!electionDefinition) {
       return false;
     }
-    const exportDirectoryName = scannerStore.getExportDirectoryName();
-    if (!exportDirectoryName) {
-      return false;
-    }
     const pollsState = scannerStore.getPollsState();
     if (
       pollsState === 'polls_closed_initial' ||
@@ -839,7 +850,6 @@ export async function doesUsbDriveRequireCastVoteRecordSync(
     if (ballotsCounted === 0) {
       return false;
     }
-    const castVoteRecordRootHash = scannerStore.getCastVoteRecordRootHash();
 
     // A previous export operation may have failed midway
     if (areOrWereCastVoteRecordsBeingExportedToUsbDrive(usbDriveStatus)) {
@@ -847,6 +857,10 @@ export async function doesUsbDriveRequireCastVoteRecordSync(
     }
 
     const { election, electionHash } = electionDefinition;
+    const exportDirectoryName = scannerStore.getExportDirectoryName();
+    if (!exportDirectoryName) {
+      return true;
+    }
     const exportDirectoryPath = path.join(
       usbMountPoint,
       SCANNER_RESULTS_FOLDER,
@@ -861,7 +875,7 @@ export async function doesUsbDriveRequireCastVoteRecordSync(
     const castVoteRecordExportMetadata = metadataResult.ok();
     if (
       castVoteRecordExportMetadata.castVoteRecordRootHash !==
-      castVoteRecordRootHash
+      scannerStore.getCastVoteRecordRootHash()
     ) {
       return true;
     }

--- a/libs/backend/src/cast_vote_records/export.ts
+++ b/libs/backend/src/cast_vote_records/export.ts
@@ -55,6 +55,7 @@ import {
 } from './build_cast_vote_record';
 import { buildCastVoteRecordReportMetadata as baseBuildCastVoteRecordReportMetadata } from './build_report_metadata';
 import { CanonicalizedSheet, canonicalizeSheet } from './canonicalize';
+import { updateCreationTimestampOfDirectoryAndChildrenFiles } from './file_system_utils';
 import { readCastVoteRecordExportMetadata } from './import';
 import { buildElectionOptionPositionMap } from './option_map';
 
@@ -551,46 +552,6 @@ async function exportSignatureFileToUsbDrive(
   }
 
   return ok();
-}
-
-/**
- * Updates the creation timestamp of a directory and its children files (assuming no
- * sub-directories) using the one method guaranteed to work:
- * ```
- * cp -r <directory-path> <directory-path>-temp
- * rm -r <directory-path>
- * mv <directory-path>-temp <directory-path>
- * ```
- *
- * Doesn't use fs.cp(src, dest, { recursive: true }) under the hood because fs.cp is still
- * experimental.
- */
-export async function updateCreationTimestampOfDirectoryAndChildrenFiles(
-  directoryPath: string
-): Promise<void> {
-  await fs.mkdir(`${directoryPath}-temp`);
-  const fileNames = (
-    await fs.readdir(directoryPath, { withFileTypes: true })
-  ).map((entry) => {
-    assert(
-      entry.isFile(),
-      `Unexpected sub-directory ${entry.name} in ${directoryPath}`
-    );
-    return entry.name;
-  });
-  for (const fileName of fileNames) {
-    await fs.copyFile(
-      path.join(directoryPath, fileName),
-      path.join(`${directoryPath}-temp`, fileName)
-    );
-  }
-  // In case the system loses power while deleting the original directory, mark the copied
-  // directory as complete to facilitate recovery on reboot. On reboot, if we see a *-temp
-  // directory, we can safely delete it, and if we see a *-temp-complete directory, we can safely
-  // delete the original directory and move the *-temp-complete directory to the original path.
-  await fs.rename(`${directoryPath}-temp`, `${directoryPath}-temp-complete`);
-  await fs.rm(directoryPath, { recursive: true });
-  await fs.rename(`${directoryPath}-temp-complete`, directoryPath);
 }
 
 /**

--- a/libs/backend/src/cast_vote_records/file_system_utils.test.ts
+++ b/libs/backend/src/cast_vote_records/file_system_utils.test.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { dirSync } from 'tmp';
 import { sleep } from '@votingworks/basics';
 
-import { updateCreationTimestampOfDirectoryAndChildrenFiles } from './export';
+import { updateCreationTimestampOfDirectoryAndChildrenFiles } from './file_system_utils';
 
 let tempDirectoryPath: string;
 

--- a/libs/backend/src/cast_vote_records/file_system_utils.ts
+++ b/libs/backend/src/cast_vote_records/file_system_utils.ts
@@ -1,0 +1,43 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { assert } from '@votingworks/basics';
+
+/**
+ * Updates the creation timestamp of a directory and its children files (assuming no
+ * sub-directories) using the one method guaranteed to work:
+ * ```
+ * cp -r <directory-path> <directory-path>-temp
+ * rm -r <directory-path>
+ * mv <directory-path>-temp <directory-path>
+ * ```
+ *
+ * Doesn't use fs.cp(src, dest, { recursive: true }) under the hood because fs.cp is still
+ * experimental.
+ */
+export async function updateCreationTimestampOfDirectoryAndChildrenFiles(
+  directoryPath: string
+): Promise<void> {
+  await fs.mkdir(`${directoryPath}-temp`);
+  const fileNames = (
+    await fs.readdir(directoryPath, { withFileTypes: true })
+  ).map((entry) => {
+    assert(
+      entry.isFile(),
+      `Unexpected sub-directory ${entry.name} in ${directoryPath}`
+    );
+    return entry.name;
+  });
+  for (const fileName of fileNames) {
+    await fs.copyFile(
+      path.join(directoryPath, fileName),
+      path.join(`${directoryPath}-temp`, fileName)
+    );
+  }
+  // In case the system loses power while deleting the original directory, mark the copied
+  // directory as complete to facilitate recovery on reboot. On reboot, if we see a *-temp
+  // directory, we can safely delete it, and if we see a *-temp-complete directory, we can safely
+  // delete the original directory and move the *-temp-complete directory to the original path.
+  await fs.rename(`${directoryPath}-temp`, `${directoryPath}-temp-complete`);
+  await fs.rm(directoryPath, { recursive: true });
+  await fs.rename(`${directoryPath}-temp-complete`, directoryPath);
+}

--- a/libs/backend/src/cast_vote_records/test_utils.ts
+++ b/libs/backend/src/cast_vote_records/test_utils.ts
@@ -120,7 +120,6 @@ export async function getCastVoteRecordExportDirectoryPaths(
   const usbDriveStatus = await usbDrive.status();
   const usbMountPoint =
     usbDriveStatus.status === 'mounted' ? usbDriveStatus.mountPoint : undefined;
-
   assert(usbMountPoint !== undefined);
 
   const resultsDirectoryPath = path.join(usbMountPoint, SCANNER_RESULTS_FOLDER);

--- a/libs/backend/src/cast_vote_records/test_utils.ts
+++ b/libs/backend/src/cast_vote_records/test_utils.ts
@@ -8,6 +8,7 @@ import {
 import { assert, assertDefined } from '@votingworks/basics';
 import {
   CastVoteRecordExportFileName,
+  CastVoteRecordReportWithoutMetadataSchema,
   CVR,
   safeParseJson,
 } from '@votingworks/types';
@@ -16,10 +17,36 @@ import {
   getExportedCastVoteRecordIds,
   SCANNER_RESULTS_FOLDER,
 } from '@votingworks/utils';
+
 import { readCastVoteRecordExportMetadata } from './import';
 
 function identifyFunction<T>(input: T): T {
   return input;
+}
+
+/**
+ * Reads and parses a cast vote record given the path to an individual cast vote record directory.
+ * Also returns the raw contents of the cast vote record report.
+ */
+export function readCastVoteRecord(castVoteRecordDirectoryPath: string): {
+  castVoteRecord: CVR.CVR;
+  castVoteRecordReportContents: string;
+} {
+  const castVoteRecordReportContents = fs.readFileSync(
+    path.join(
+      castVoteRecordDirectoryPath,
+      CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT
+    ),
+    'utf-8'
+  );
+  const castVoteRecordReportWithoutMetadata = safeParseJson(
+    castVoteRecordReportContents,
+    CastVoteRecordReportWithoutMetadataSchema
+  ).unsafeUnwrap();
+  const castVoteRecord = assertDefined(
+    castVoteRecordReportWithoutMetadata.CVR?.[0]
+  );
+  return { castVoteRecord, castVoteRecordReportContents };
 }
 
 /**
@@ -67,22 +94,16 @@ export async function modifyCastVoteRecordExport(
       continue;
     }
 
-    const castVoteRecordReportPath = path.join(
-      castVoteRecordDirectoryPath,
-      CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT
+    const { castVoteRecord, castVoteRecordReportContents } = readCastVoteRecord(
+      castVoteRecordDirectoryPath
     );
-    const castVoteRecordReport = safeParseJson(
-      fs.readFileSync(castVoteRecordReportPath, 'utf-8'),
-      CVR.CastVoteRecordReportSchema
-    ).unsafeUnwrap();
-    const castVoteRecord = assertDefined(castVoteRecordReport.CVR?.[0]);
     fs.writeFileSync(
       path.join(
         castVoteRecordDirectoryPath,
         CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT
       ),
       JSON.stringify({
-        ...castVoteRecordReport,
+        ...JSON.parse(castVoteRecordReportContents),
         CVR: [castVoteRecordModifier(castVoteRecord)],
       })
     );

--- a/libs/backend/test/fixtures/interpretations.ts
+++ b/libs/backend/test/fixtures/interpretations.ts
@@ -4,9 +4,12 @@ import {
   AdjudicationInfo,
   BallotMetadata,
   BallotType,
+  BlankPage,
   CandidateContest,
   InterpretedBmdPage,
   InterpretedHmpbPage,
+  PageInterpretation,
+  SheetOf,
   TargetShape,
   YesNoContest,
 } from '@votingworks/types';
@@ -180,3 +183,31 @@ export const interpretedBmdPage: InterpretedBmdPage = {
     [fishCouncilContest.id]: fishCouncilContest.candidates.slice(0, 1),
   },
 };
+
+export const interpretedHmpbPage1WithWriteIn: InterpretedHmpbPage = {
+  ...interpretedHmpbPage1,
+  votes: {
+    [fishCouncilContest.id]: [
+      { id: 'write-in-1', name: 'Write In #1', isWriteIn: true },
+    ],
+  },
+};
+
+export const blankPage: BlankPage = {
+  type: 'BlankPage',
+};
+
+export const interpretedHmpb: SheetOf<PageInterpretation> = [
+  interpretedHmpbPage1,
+  interpretedHmpbPage2,
+];
+
+export const interpretedBmdBallot: SheetOf<PageInterpretation> = [
+  interpretedBmdPage,
+  blankPage,
+];
+
+export const interpretedHmpbWithWriteIn: SheetOf<PageInterpretation> = [
+  interpretedHmpbPage1WithWriteIn,
+  interpretedHmpbPage2,
+];

--- a/libs/backend/test/utils.ts
+++ b/libs/backend/test/utils.ts
@@ -1,0 +1,143 @@
+/* eslint-disable max-classes-per-file */
+import {
+  CAST_VOTE_RECORD_HASHES_TABLE_SCHEMA,
+  clearCastVoteRecordHashes,
+  getCastVoteRecordRootHash,
+  updateCastVoteRecordHashes,
+} from '@votingworks/auth';
+import { Client } from '@votingworks/db';
+import {
+  BatchInfo,
+  DEFAULT_MARK_THRESHOLDS,
+  ElectionDefinition,
+  MarkThresholds,
+  PollsState,
+} from '@votingworks/types';
+
+import { ScannerStore } from '../src/cast_vote_records/export';
+
+class MockScannerStore implements ScannerStore {
+  private ballotsCounted: number;
+  private batches: BatchInfo[];
+  private readonly client: Client;
+  private electionDefinition?: ElectionDefinition;
+  private testMode: boolean;
+
+  constructor() {
+    this.ballotsCounted = 0;
+    this.batches = [];
+    this.client = Client.memoryClient();
+    this.electionDefinition = undefined;
+    this.testMode = true;
+
+    this.client.exec(CAST_VOTE_RECORD_HASHES_TABLE_SCHEMA);
+  }
+
+  //
+  // Cast vote record hash methods
+  //
+
+  getCastVoteRecordRootHash(): string {
+    return getCastVoteRecordRootHash(this.client);
+  }
+
+  updateCastVoteRecordHashes(
+    castVoteRecordId: string,
+    castVoteRecordHash: string
+  ): void {
+    return updateCastVoteRecordHashes(
+      this.client,
+      castVoteRecordId,
+      castVoteRecordHash
+    );
+  }
+
+  clearCastVoteRecordHashes(): void {
+    return clearCastVoteRecordHashes(this.client);
+  }
+
+  //
+  // Other getters
+  //
+
+  getBatches(): BatchInfo[] {
+    return this.batches;
+  }
+
+  getElectionDefinition(): ElectionDefinition | undefined {
+    return this.electionDefinition;
+  }
+
+  getMarkThresholds(): MarkThresholds {
+    return DEFAULT_MARK_THRESHOLDS;
+  }
+
+  getTestMode(): boolean {
+    return this.testMode;
+  }
+
+  //
+  // Methods to facilitate testing, beyond the ScannerStore interface
+  //
+
+  getBallotsCounted(): number {
+    return this.ballotsCounted;
+  }
+
+  setBallotsCounted(ballotsCounted: number): void {
+    this.ballotsCounted = ballotsCounted;
+  }
+
+  setBatches(batches: BatchInfo[]): void {
+    this.batches = batches;
+  }
+
+  setElectionDefinition(electionDefinition?: ElectionDefinition): void {
+    this.electionDefinition = electionDefinition;
+  }
+
+  setTestMode(testMode: boolean): void {
+    this.testMode = testMode;
+  }
+}
+
+/**
+ * A mock central scanner store
+ */
+export class MockCentralScannerStore extends MockScannerStore {
+  constructor() {
+    super();
+    process.env['VX_MACHINE_TYPE'] = 'central-scan';
+  }
+}
+
+/**
+ * A mock precinct scanner store
+ */
+export class MockPrecinctScannerStore extends MockScannerStore {
+  private exportDirectoryName?: string;
+  private pollsState: PollsState;
+
+  constructor() {
+    super();
+    this.exportDirectoryName = undefined;
+    this.pollsState = 'polls_closed_initial';
+    process.env['VX_MACHINE_TYPE'] = 'scan';
+  }
+
+  getExportDirectoryName(): string | undefined {
+    return this.exportDirectoryName;
+  }
+
+  setExportDirectoryName(exportDirectoryName: string): void {
+    this.exportDirectoryName = exportDirectoryName;
+  }
+
+  getPollsState(): PollsState {
+    return this.pollsState;
+  }
+
+  setPollsState(pollsState: PollsState): void {
+    this.pollsState = pollsState;
+  }
+}

--- a/libs/backend/test/utils.ts
+++ b/libs/backend/test/utils.ts
@@ -108,12 +108,7 @@ class MockScannerStore implements ScannerStore {
 /**
  * A mock central scanner store
  */
-export class MockCentralScannerStore extends MockScannerStore {
-  constructor() {
-    super();
-    process.env['VX_MACHINE_TYPE'] = 'central-scan';
-  }
-}
+export class MockCentralScannerStore extends MockScannerStore {}
 
 /**
  * A mock precinct scanner store
@@ -126,7 +121,6 @@ export class MockPrecinctScannerStore extends MockScannerStore {
     super();
     this.exportDirectoryName = undefined;
     this.pollsState = 'polls_closed_initial';
-    process.env['VX_MACHINE_TYPE'] = 'scan';
   }
 
   getExportDirectoryName(): string | undefined {

--- a/libs/types/src/byte.ts
+++ b/libs/types/src/byte.ts
@@ -277,5 +277,5 @@ export function isByte(n: number): n is Byte {
  * - asHexString(0x3f) --> '3f'
  */
 export function asHexString(byte: Byte): string {
-  return `0${byte.toString(16)}`.slice(-2);
+  return byte.toString(16).padStart(2, '0');
 }

--- a/libs/usb-drive/src/mocks/memory_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/memory_usb_drive.ts
@@ -65,6 +65,7 @@ export function createMockUsbDrive(): MockUsbDrive {
         prefix: TMP_DIR_PREFIX,
       });
       writeMockFileTree(mockUsbTmpDir.name, contents);
+      usbDrive.status.reset();
       usbDrive.status.expectRepeatedCallsWith().resolves({
         status: 'mounted',
         mountPoint: mockUsbTmpDir.name,
@@ -74,6 +75,7 @@ export function createMockUsbDrive(): MockUsbDrive {
     removeUsbDrive() {
       mockUsbTmpDir?.removeCallback();
       mockUsbTmpDir = undefined;
+      usbDrive.status.reset();
       usbDrive.status
         .expectRepeatedCallsWith()
         .resolves({ status: 'no_drive' });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2916,6 +2916,9 @@ importers:
 
   libs/backend:
     dependencies:
+      '@types/uuid':
+        specifier: ^9.0.5
+        version: 9.0.5
       '@votingworks/auth':
         specifier: workspace:*
         version: link:../auth
@@ -2973,6 +2976,9 @@ importers:
       tmp:
         specifier: ^0.2.1
         version: 0.2.1
+      uuid:
+        specifier: ^9.0.1
+        version: 9.0.1
       zod:
         specifier: 3.14.4
         version: 3.14.4
@@ -11726,6 +11732,10 @@ packages:
   /@types/uuid@9.0.4:
     resolution: {integrity: sha512-zAuJWQflfx6dYJM62vna+Sn5aeSWhh3OB+wfUEACNcqUSc0AGc5JKl+ycL1vrH7frGTXhJchYjE1Hak8L819dA==}
     dev: true
+
+  /@types/uuid@9.0.5:
+    resolution: {integrity: sha512-xfHdwa1FMJ082prjSJpoEI57GZITiQz10r3vEJCHa2khEFQjKy91aWKz6+zybzssCvXUwE1LQWgWVwZ4nYUvHQ==}
+    dev: false
 
   /@types/w3c-web-usb@1.0.6:
     resolution: {integrity: sha512-cSjhgrr8g4KbPnnijAr/KJDNKa/bBa+ixYkywFRvrhvi9n1WEl7yYbtRyzE6jqNQiSxxJxoAW3STaOQwJHndaw==}


### PR DESCRIPTION
_Easiest reviewed by commit_

## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/4058

Finally adding the tests that I've punted on for so so long. This PR gets the new CVR export functions in `libs/backend` up to 💯% code coverage. I'll be opening a separate PR for the new CVR import functions.