### PR TITLE
Get the new CVR import functions in libs/backend up to 100% code coverage

### DIFF
--- a/libs/backend/jest.config.js
+++ b/libs/backend/jest.config.js
@@ -5,11 +5,14 @@ const shared = require('../../jest.config.shared');
  */
 module.exports = {
   ...shared,
+  coveragePathIgnorePatterns: [
+    'test',
+  ],
   coverageThreshold: {
     global: {
       statements: 97,
-      branches: 93,
-      functions: 99,
+      branches: 94,
+      functions: 100,
       lines: 98,
     },
   },

--- a/libs/backend/package.json
+++ b/libs/backend/package.json
@@ -61,6 +61,7 @@
     "@types/debug": "^4.1.7",
     "@types/fs-extra": "^11.0.1",
     "@types/jest": "^29.5.3",
+    "@types/lodash.set": "^4.3.7",
     "@types/micromatch": "^4.0.2",
     "@types/node": "16.18.23",
     "@types/stream-chain": "^2.0.1",
@@ -75,6 +76,7 @@
     "jest-junit": "^16.0.0",
     "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "^11.0.0",
+    "lodash.set": "^4.3.2",
     "memory-streams": "^0.1.3",
     "sort-package-json": "^1.50.0",
     "ts-jest": "29.1.1"

--- a/libs/backend/src/cast_vote_records/import.test.ts
+++ b/libs/backend/src/cast_vote_records/import.test.ts
@@ -1,7 +1,325 @@
-import { CVR } from '@votingworks/types';
+import { Buffer } from 'buffer';
+import fs from 'fs';
+import set from 'lodash.set';
+import path from 'path';
+import { assert, assertDefined, err } from '@votingworks/basics';
+import { electionGridLayoutNewHampshireAmherstFixtures } from '@votingworks/fixtures';
+import { CastVoteRecordExportFileName, CVR } from '@votingworks/types';
+import {
+  BooleanEnvironmentVariableName,
+  getCastVoteRecordExportSubDirectoryNames,
+  getFeatureFlagMock,
+} from '@votingworks/utils';
 
 import { TEST_OTHER_REPORT_TYPE } from './build_report_metadata';
-import { isTestReport } from './import';
+import { isTestReport, readCastVoteRecordExport } from './import';
+import {
+  CastVoteRecordExportModifications,
+  modifyCastVoteRecordExport,
+} from './test_utils';
+
+const mockFeatureFlagger = getFeatureFlagMock();
+
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
+  return {
+    ...jest.requireActual('@votingworks/utils'),
+    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+  };
+});
+
+beforeEach(() => {
+  process.env['VX_MACHINE_TYPE'] = 'admin';
+  mockFeatureFlagger.resetFeatureFlags();
+});
+
+const { castVoteRecordExport } = electionGridLayoutNewHampshireAmherstFixtures;
+
+test('successful import', async () => {
+  const exportDirectoryPath = castVoteRecordExport.asDirectoryPath();
+
+  const readResult = await readCastVoteRecordExport(exportDirectoryPath);
+  expect(readResult.isOk()).toEqual(true);
+  assert(readResult.isOk());
+  const { castVoteRecordExportMetadata, castVoteRecordIterator } =
+    readResult.ok();
+  expect(castVoteRecordExportMetadata).toEqual({
+    arePollsClosed: true,
+    castVoteRecordReportMetadata: expect.any(Object),
+    castVoteRecordRootHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+  });
+
+  let encounteredReferencedImageFiles = false;
+  let encounteredReferencedLayoutFiles = false;
+  for await (const castVoteRecordResult of castVoteRecordIterator) {
+    expect(castVoteRecordResult.isOk()).toEqual(true);
+    assert(castVoteRecordResult.isOk());
+    const { castVoteRecord, referencedFiles } = castVoteRecordResult.ok();
+    expect(castVoteRecord).toEqual(expect.any(Object));
+
+    if (referencedFiles) {
+      encounteredReferencedImageFiles = true;
+      for (const i of [0, 1] as const) {
+        const imageFileReadResult = await referencedFiles.imageFiles[i].read();
+        expect(imageFileReadResult.isOk()).toEqual(true);
+        assert(imageFileReadResult.isOk());
+        const image = imageFileReadResult.ok();
+        expect(image).toEqual(expect.any(Buffer));
+
+        if (referencedFiles.layoutFiles) {
+          encounteredReferencedLayoutFiles = true;
+          const layoutFileReadResult =
+            await referencedFiles.layoutFiles[i].read();
+          expect(layoutFileReadResult.isOk()).toEqual(true);
+          assert(layoutFileReadResult.isOk());
+          const layout = layoutFileReadResult.ok();
+          expect(layout).toEqual(expect.any(Object));
+        }
+      }
+    }
+  }
+  expect(encounteredReferencedImageFiles).toEqual(true);
+  expect(encounteredReferencedLayoutFiles).toEqual(true);
+});
+
+test('authentication error during import', async () => {
+  const exportDirectoryPath = castVoteRecordExport.asDirectoryPath();
+  fs.appendFileSync(
+    path.join(exportDirectoryPath, CastVoteRecordExportFileName.METADATA),
+    '\n'
+  );
+
+  expect(await readCastVoteRecordExport(exportDirectoryPath)).toEqual(
+    err({ type: 'authentication-error' })
+  );
+});
+
+test('metadata file not found during import', async () => {
+  mockFeatureFlagger.enableFeatureFlag(
+    BooleanEnvironmentVariableName.SKIP_CAST_VOTE_RECORDS_AUTHENTICATION
+  );
+  const exportDirectoryPath = castVoteRecordExport.asDirectoryPath();
+  fs.rmSync(
+    path.join(exportDirectoryPath, CastVoteRecordExportFileName.METADATA)
+  );
+
+  expect(await readCastVoteRecordExport(exportDirectoryPath)).toEqual(
+    err({ type: 'metadata-file-not-found' })
+  );
+});
+
+test('metadata file parse error during import', async () => {
+  mockFeatureFlagger.enableFeatureFlag(
+    BooleanEnvironmentVariableName.SKIP_CAST_VOTE_RECORDS_AUTHENTICATION
+  );
+  const exportDirectoryPath = castVoteRecordExport.asDirectoryPath();
+  fs.appendFileSync(
+    path.join(exportDirectoryPath, CastVoteRecordExportFileName.METADATA),
+    '}'
+  );
+
+  expect(await readCastVoteRecordExport(exportDirectoryPath)).toEqual(
+    err({ type: 'metadata-file-parse-error' })
+  );
+});
+
+test.each<{ modifier: (castVoteRecordReportPath: string) => void }>([
+  {
+    modifier: (castVoteRecordReportPath) =>
+      fs.appendFileSync(castVoteRecordReportPath, '}'),
+  },
+  {
+    modifier: (castVoteRecordReportPath) =>
+      fs.writeFileSync(castVoteRecordReportPath, JSON.stringify({})),
+  },
+  {
+    modifier: (castVoteRecordReportPath) =>
+      fs.writeFileSync(castVoteRecordReportPath, JSON.stringify({ CVR: [] })),
+  },
+])('cast vote record parse error during import', async ({ modifier }) => {
+  mockFeatureFlagger.enableFeatureFlag(
+    BooleanEnvironmentVariableName.SKIP_CAST_VOTE_RECORDS_AUTHENTICATION
+  );
+  const exportDirectoryPath = await modifyCastVoteRecordExport(
+    castVoteRecordExport.asDirectoryPath(),
+    { numCastVoteRecordsToKeep: 1 }
+  );
+  const castVoteRecordExportSubDirectoryNames =
+    await getCastVoteRecordExportSubDirectoryNames(exportDirectoryPath);
+  expect(castVoteRecordExportSubDirectoryNames).toHaveLength(1);
+  const castVoteRecordId = assertDefined(
+    castVoteRecordExportSubDirectoryNames[0]
+  );
+  const castVoteRecordReportPath = path.join(
+    exportDirectoryPath,
+    castVoteRecordId,
+    CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT
+  );
+  modifier(castVoteRecordReportPath);
+
+  const { castVoteRecordIterator } = (
+    await readCastVoteRecordExport(exportDirectoryPath)
+  ).unsafeUnwrap();
+  const castVoteRecordResults = await castVoteRecordIterator.toArray();
+  expect(castVoteRecordResults).toHaveLength(1);
+  const castVoteRecordResult = assertDefined(castVoteRecordResults[0]);
+  expect(castVoteRecordResult).toEqual(
+    err({ type: 'invalid-cast-vote-record', subType: 'parse-error' })
+  );
+});
+
+test.each<{
+  description: string;
+  modifications: CastVoteRecordExportModifications;
+  expectedErrorSubType: string;
+}>([
+  {
+    description: 'non-existent batch ID',
+    modifications: {
+      castVoteRecordModifier: (castVoteRecord) => ({
+        ...castVoteRecord,
+        BatchId: 'non-existent-batch-id',
+      }),
+      numCastVoteRecordsToKeep: 1,
+    },
+    expectedErrorSubType: 'batch-id-not-found',
+  },
+  {
+    description: 'invalid ballot sheet ID',
+    modifications: {
+      castVoteRecordModifier: (castVoteRecord) => ({
+        ...castVoteRecord,
+        BallotSheetId: 'not-a-number',
+      }),
+      numCastVoteRecordsToKeep: 1,
+    },
+    expectedErrorSubType: 'invalid-ballot-sheet-id',
+  },
+  {
+    description: 'no current snapshot',
+    modifications: {
+      castVoteRecordModifier: (castVoteRecord) => ({
+        ...castVoteRecord,
+        CurrentSnapshotId: 'non-existent-snapshot-id',
+      }),
+      numCastVoteRecordsToKeep: 1,
+    },
+    expectedErrorSubType: 'no-current-snapshot',
+  },
+  {
+    description: 'invalid write-in field',
+    modifications: {
+      castVoteRecordModifier: (castVoteRecord) =>
+        castVoteRecord.BallotImage
+          ? set(
+              castVoteRecord,
+              'BallotImage[0].Location',
+              'file:reference-that-write-in-field-will-not-match.jpg'
+            )
+          : castVoteRecord,
+      numCastVoteRecordsToKeep: 10,
+    },
+    expectedErrorSubType: 'invalid-write-in-field',
+  },
+  {
+    description: 'invalid ballot image field',
+    modifications: {
+      castVoteRecordModifier: (castVoteRecord) =>
+        castVoteRecord.BallotImage
+          ? set(castVoteRecord, 'BallotImage[2]', castVoteRecord.BallotImage[0])
+          : castVoteRecord,
+      numCastVoteRecordsToKeep: 10,
+    },
+    expectedErrorSubType: 'invalid-ballot-image-field',
+  },
+  {
+    description: 'invalid ballot image field',
+    modifications: {
+      castVoteRecordModifier: (castVoteRecord) =>
+        castVoteRecord.BallotImage
+          ? set(castVoteRecord, 'BallotImage[0].Hash', undefined)
+          : castVoteRecord,
+      numCastVoteRecordsToKeep: 10,
+    },
+    expectedErrorSubType: 'invalid-ballot-image-field',
+  },
+  {
+    description: 'invalid ballot image field',
+    modifications: {
+      castVoteRecordModifier: (castVoteRecord) =>
+        castVoteRecord.BallotImage
+          ? set(castVoteRecord, 'BallotImage[1].Hash', undefined)
+          : castVoteRecord,
+      numCastVoteRecordsToKeep: 10,
+    },
+    expectedErrorSubType: 'invalid-ballot-image-field',
+  },
+  {
+    description: 'invalid ballot image field',
+    modifications: {
+      castVoteRecordModifier: (castVoteRecord) =>
+        castVoteRecord.BallotImage
+          ? set(castVoteRecord, 'BallotImage[0].Hash.Value', '')
+          : castVoteRecord,
+      numCastVoteRecordsToKeep: 10,
+    },
+    expectedErrorSubType: 'invalid-ballot-image-field',
+  },
+  {
+    description: 'invalid ballot image field',
+    modifications: {
+      castVoteRecordModifier: (castVoteRecord) =>
+        castVoteRecord.BallotImage
+          ? set(castVoteRecord, 'BallotImage[1].Hash.Value', '')
+          : castVoteRecord,
+      numCastVoteRecordsToKeep: 10,
+    },
+    expectedErrorSubType: 'invalid-ballot-image-field',
+  },
+  {
+    description: 'invalid ballot image field',
+    modifications: {
+      castVoteRecordModifier: (castVoteRecord) =>
+        castVoteRecord.BallotImage
+          ? set(castVoteRecord, 'BallotImage[0].vxLayoutFileHash', '')
+          : castVoteRecord,
+      numCastVoteRecordsToKeep: 10,
+    },
+    expectedErrorSubType: 'invalid-ballot-image-field',
+  },
+  {
+    description: 'invalid ballot image field',
+    modifications: {
+      castVoteRecordModifier: (castVoteRecord) =>
+        castVoteRecord.BallotImage
+          ? set(castVoteRecord, 'BallotImage[1].vxLayoutFileHash', '')
+          : castVoteRecord,
+      numCastVoteRecordsToKeep: 10,
+    },
+    expectedErrorSubType: 'invalid-ballot-image-field',
+  },
+])(
+  'cast vote record parse error during import - $description',
+  async ({ modifications, expectedErrorSubType }) => {
+    mockFeatureFlagger.enableFeatureFlag(
+      BooleanEnvironmentVariableName.SKIP_CAST_VOTE_RECORDS_AUTHENTICATION
+    );
+    const exportDirectoryPath = await modifyCastVoteRecordExport(
+      castVoteRecordExport.asDirectoryPath(),
+      modifications
+    );
+
+    const { castVoteRecordIterator } = (
+      await readCastVoteRecordExport(exportDirectoryPath)
+    ).unsafeUnwrap();
+    const castVoteRecordResults = await castVoteRecordIterator.toArray();
+    const castVoteRecordErrorResult = castVoteRecordResults.find(
+      (castVoteRecordResult) => castVoteRecordResult.isErr()
+    );
+    expect(castVoteRecordErrorResult).toEqual(
+      err({ type: 'invalid-cast-vote-record', subType: expectedErrorSubType })
+    );
+  }
+);
 
 test.each<{ report: CVR.CastVoteRecordReport; expectedResult: boolean }>([
   {
@@ -31,6 +349,19 @@ test.each<{ report: CVR.CastVoteRecordReport; expectedResult: boolean }>([
       ReportGeneratingDeviceIds: [],
       ReportingDevice: [],
       ReportType: [CVR.ReportType.OriginatingDeviceExport],
+      Version: CVR.CastVoteRecordVersion.v1_0_0,
+      vxBatch: [],
+    },
+    expectedResult: false,
+  },
+  {
+    report: {
+      '@type': 'CVR.CastVoteRecordReport',
+      Election: [],
+      GeneratedDate: new Date().toISOString(),
+      GpUnit: [],
+      ReportGeneratingDeviceIds: [],
+      ReportingDevice: [],
       Version: CVR.CastVoteRecordVersion.v1_0_0,
       vxBatch: [],
     },

--- a/libs/backend/src/cast_vote_records/import.test.ts
+++ b/libs/backend/src/cast_vote_records/import.test.ts
@@ -162,11 +162,9 @@ test.each<{
       await readCastVoteRecordExport(exportDirectoryPath)
     ).unsafeUnwrap();
     const castVoteRecordResults = await castVoteRecordIterator.toArray();
-    expect(castVoteRecordResults).toHaveLength(1);
-    const castVoteRecordResult = assertDefined(castVoteRecordResults[0]);
-    expect(castVoteRecordResult).toEqual(
-      err({ type: 'invalid-cast-vote-record', subType: 'parse-error' })
-    );
+    expect(castVoteRecordResults).toEqual([
+      err({ type: 'invalid-cast-vote-record', subType: 'parse-error' }),
+    ]);
   }
 );
 
@@ -316,10 +314,7 @@ test.each<{
       await readCastVoteRecordExport(exportDirectoryPath)
     ).unsafeUnwrap();
     const castVoteRecordResults = await castVoteRecordIterator.toArray();
-    const castVoteRecordErrorResult = castVoteRecordResults.find(
-      (castVoteRecordResult) => castVoteRecordResult.isErr()
-    );
-    expect(castVoteRecordErrorResult).toEqual(
+    expect(castVoteRecordResults).toContainEqual(
       err({ type: 'invalid-cast-vote-record', subType: expectedErrorSubType })
     );
   }

--- a/libs/backend/src/cast_vote_records/import.test.ts
+++ b/libs/backend/src/cast_vote_records/import.test.ts
@@ -2,7 +2,7 @@ import { Buffer } from 'buffer';
 import fs from 'fs';
 import set from 'lodash.set';
 import path from 'path';
-import { assert, assertDefined, err } from '@votingworks/basics';
+import { assertDefined, err } from '@votingworks/basics';
 import { electionGridLayoutNewHampshireAmherstFixtures } from '@votingworks/fixtures';
 import { CastVoteRecordExportFileName, CVR } from '@votingworks/types';
 import {
@@ -37,11 +37,9 @@ const { castVoteRecordExport } = electionGridLayoutNewHampshireAmherstFixtures;
 test('successful import', async () => {
   const exportDirectoryPath = castVoteRecordExport.asDirectoryPath();
 
-  const readResult = await readCastVoteRecordExport(exportDirectoryPath);
-  expect(readResult.isOk()).toEqual(true);
-  assert(readResult.isOk());
-  const { castVoteRecordExportMetadata, castVoteRecordIterator } =
-    readResult.ok();
+  const { castVoteRecordExportMetadata, castVoteRecordIterator } = (
+    await readCastVoteRecordExport(exportDirectoryPath)
+  ).unsafeUnwrap();
   expect(castVoteRecordExportMetadata).toEqual({
     arePollsClosed: true,
     castVoteRecordReportMetadata: expect.any(Object),
@@ -51,27 +49,23 @@ test('successful import', async () => {
   let encounteredReferencedImageFiles = false;
   let encounteredReferencedLayoutFiles = false;
   for await (const castVoteRecordResult of castVoteRecordIterator) {
-    expect(castVoteRecordResult.isOk()).toEqual(true);
-    assert(castVoteRecordResult.isOk());
-    const { castVoteRecord, referencedFiles } = castVoteRecordResult.ok();
+    const { castVoteRecord, referencedFiles } =
+      castVoteRecordResult.unsafeUnwrap();
     expect(castVoteRecord).toEqual(expect.any(Object));
 
     if (referencedFiles) {
       encounteredReferencedImageFiles = true;
       for (const i of [0, 1] as const) {
-        const imageFileReadResult = await referencedFiles.imageFiles[i].read();
-        expect(imageFileReadResult.isOk()).toEqual(true);
-        assert(imageFileReadResult.isOk());
-        const image = imageFileReadResult.ok();
+        const image = (
+          await referencedFiles.imageFiles[i].read()
+        ).unsafeUnwrap();
         expect(image).toEqual(expect.any(Buffer));
 
         if (referencedFiles.layoutFiles) {
           encounteredReferencedLayoutFiles = true;
-          const layoutFileReadResult =
-            await referencedFiles.layoutFiles[i].read();
-          expect(layoutFileReadResult.isOk()).toEqual(true);
-          assert(layoutFileReadResult.isOk());
-          const layout = layoutFileReadResult.ok();
+          const layout = (
+            await referencedFiles.layoutFiles[i].read()
+          ).unsafeUnwrap();
           expect(layout).toEqual(expect.any(Object));
         }
       }

--- a/libs/backend/src/cast_vote_records/import.ts
+++ b/libs/backend/src/cast_vote_records/import.ts
@@ -121,7 +121,7 @@ async function* castVoteRecordGenerator(
       return;
     }
     const castVoteRecordReport = parseResult.ok();
-    if (castVoteRecordReport.CVR?.length !== 1) {
+    if (!castVoteRecordReport.CVR || castVoteRecordReport.CVR.length !== 1) {
       yield wrapError({ subType: 'parse-error' });
       return;
     }

--- a/libs/backend/src/cast_vote_records/import.ts
+++ b/libs/backend/src/cast_vote_records/import.ts
@@ -3,6 +3,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { authenticateArtifactUsingSignatureFile } from '@votingworks/auth';
 import {
+  assert,
   assertDefined,
   AsyncIteratorPlus,
   err,
@@ -161,10 +162,13 @@ async function* castVoteRecordGenerator(
 
     let referencedFiles: ReferencedFiles | undefined;
     if (castVoteRecord.BallotImage) {
+      if (castVoteRecord.BallotImage.length !== 2) {
+        yield wrapError({ subType: 'invalid-ballot-image-field' });
+        return;
+      }
+      assert(castVoteRecord.BallotImage[0]);
+      assert(castVoteRecord.BallotImage[1]);
       if (
-        castVoteRecord.BallotImage.length !== 2 ||
-        !castVoteRecord.BallotImage[0] ||
-        !castVoteRecord.BallotImage[1] ||
         !castVoteRecord.BallotImage[0].Hash?.Value ||
         !castVoteRecord.BallotImage[1].Hash?.Value ||
         !castVoteRecord.BallotImage[0].Location ||

--- a/libs/backend/src/cast_vote_records/import.ts
+++ b/libs/backend/src/cast_vote_records/import.ts
@@ -1,4 +1,3 @@
-/* istanbul ignore file */
 import { existsSync } from 'fs';
 import fs from 'fs/promises';
 import path from 'path';
@@ -164,10 +163,16 @@ async function* castVoteRecordGenerator(
     if (castVoteRecord.BallotImage) {
       if (
         castVoteRecord.BallotImage.length !== 2 ||
-        !castVoteRecord.BallotImage[0]?.Hash?.Value ||
-        !castVoteRecord.BallotImage[1]?.Hash?.Value ||
-        !castVoteRecord.BallotImage[0]?.Location?.startsWith('file:') ||
-        !castVoteRecord.BallotImage[1]?.Location?.startsWith('file:')
+        !castVoteRecord.BallotImage[0] ||
+        !castVoteRecord.BallotImage[1] ||
+        !castVoteRecord.BallotImage[0].Hash?.Value ||
+        !castVoteRecord.BallotImage[1].Hash?.Value ||
+        // These next two conditions are hard to trigger without first triggering the invalid
+        // write-in case above.
+        /* istanbul ignore next */ !castVoteRecord.BallotImage[0].Location ||
+        /* istanbul ignore next */ !castVoteRecord.BallotImage[1].Location ||
+        !castVoteRecord.BallotImage[0].Location.startsWith('file:') ||
+        !castVoteRecord.BallotImage[1].Location.startsWith('file:')
       ) {
         yield wrapError({ subType: 'invalid-ballot-image-field' });
         return;
@@ -195,8 +200,8 @@ async function* castVoteRecordGenerator(
       let layoutFiles: SheetOf<ReferencedFile<BallotPageLayout>> | undefined;
       if (isHandMarkedPaperBallot) {
         if (
-          !castVoteRecord.BallotImage[0]?.vxLayoutFileHash ||
-          !castVoteRecord.BallotImage[1]?.vxLayoutFileHash
+          !castVoteRecord.BallotImage[0].vxLayoutFileHash ||
+          !castVoteRecord.BallotImage[1].vxLayoutFileHash
         ) {
           yield wrapError({ subType: 'invalid-ballot-image-field' });
           return;

--- a/libs/backend/src/cast_vote_records/import.ts
+++ b/libs/backend/src/cast_vote_records/import.ts
@@ -167,10 +167,8 @@ async function* castVoteRecordGenerator(
         !castVoteRecord.BallotImage[1] ||
         !castVoteRecord.BallotImage[0].Hash?.Value ||
         !castVoteRecord.BallotImage[1].Hash?.Value ||
-        // These next two conditions are hard to trigger without first triggering the invalid
-        // write-in case above.
-        /* istanbul ignore next */ !castVoteRecord.BallotImage[0].Location ||
-        /* istanbul ignore next */ !castVoteRecord.BallotImage[1].Location ||
+        !castVoteRecord.BallotImage[0].Location ||
+        !castVoteRecord.BallotImage[1].Location ||
         !castVoteRecord.BallotImage[0].Location.startsWith('file:') ||
         !castVoteRecord.BallotImage[1].Location.startsWith('file:')
       ) {

--- a/libs/types/src/cast_vote_records.ts
+++ b/libs/types/src/cast_vote_records.ts
@@ -74,7 +74,7 @@ export type CastVoteRecordReportWithoutMetadata = Pick<
 
 export const CastVoteRecordReportWithoutMetadataSchema: z.ZodSchema<CastVoteRecordReportWithoutMetadata> =
   z.object({
-    CVR: z.array(CVRSchema),
+    CVR: z.array(CVRSchema).optional(),
   });
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2992,6 +2992,9 @@ importers:
       '@types/jest':
         specifier: ^29.5.3
         version: 29.5.3
+      '@types/lodash.set':
+        specifier: ^4.3.7
+        version: 4.3.7
       '@types/micromatch':
         specifier: ^4.0.2
         version: 4.0.2
@@ -3034,6 +3037,9 @@ importers:
       lint-staged:
         specifier: ^11.0.0
         version: 11.0.0
+      lodash.set:
+        specifier: ^4.3.2
+        version: 4.3.2
       memory-streams:
         specifier: ^0.1.3
         version: 0.1.3


### PR DESCRIPTION
_Easiest reviewed by commit_

## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/4058

The counterpart to https://github.com/votingworks/vxsuite/pull/4090, this PR gets the new CVR import functions in `libs/backend` up to 💯% code coverage. It also adds one e2e test of export and subsequent import of that export.