### PR TITLE
Vite v4

### DIFF
--- a/apps/admin/frontend/package.json
+++ b/apps/admin/frontend/package.json
@@ -153,7 +153,7 @@
     "lint-staged": "^10.0.7",
     "sort-package-json": "^1.50.0",
     "ts-jest": "29.1.1",
-    "vite": "^2.9.12"
+    "vite": "4.5.0"
   },
   "packageManager": "pnpm@8.1.0",
   "vx": {

--- a/apps/admin/frontend/vite.config.ts
+++ b/apps/admin/frontend/vite.config.ts
@@ -104,6 +104,10 @@ export default defineConfig((env) => {
       },
     ],
 
+    server: {
+      port: 3000,
+    },
+
     // Pass some environment variables to the client in `import.meta.env`.
     envPrefix,
   };

--- a/apps/central-scan/frontend/package.json
+++ b/apps/central-scan/frontend/package.json
@@ -127,7 +127,7 @@
     "sort-package-json": "^1.50.0",
     "ts-jest": "29.1.1",
     "type-fest": "^0.18.0",
-    "vite": "^2.9.12",
+    "vite": "4.5.0",
     "zip-stream": "^3.0.1"
   },
   "packageManager": "pnpm@8.1.0",

--- a/apps/central-scan/frontend/vite.config.ts
+++ b/apps/central-scan/frontend/vite.config.ts
@@ -85,6 +85,10 @@ export default defineConfig((env) => {
       },
     ],
 
+    server: {
+      port: 3000,
+    },
+
     // Pass some environment variables to the client in `import.meta.env`.
     envPrefix,
   };

--- a/apps/design/frontend/package.json
+++ b/apps/design/frontend/package.json
@@ -105,7 +105,7 @@
     "sort-package-json": "^1.50.0",
     "tmp": "^0.2.1",
     "ts-jest": "29.1.1",
-    "vite": "^2.9.12"
+    "vite": "4.5.0"
   },
   "packageManager": "pnpm@8.1.0",
   "vx": {

--- a/apps/mark-scan/frontend/package.json
+++ b/apps/mark-scan/frontend/package.json
@@ -130,7 +130,7 @@
     "react-dev-utils": "^11.0.3",
     "sort-package-json": "^1.50.0",
     "ts-jest": "29.1.1",
-    "vite": "^2.9.12"
+    "vite": "4.5.0"
   },
   "engines": {
     "node": ">= 16"

--- a/apps/mark-scan/frontend/vite.config.ts
+++ b/apps/mark-scan/frontend/vite.config.ts
@@ -81,6 +81,7 @@ export default defineConfig((env) => {
     server: {
       hmr:
         process.env.DISABLE_MARKSCAN_HOT_RELOAD === 'true' ? false : undefined,
+      port: 3000,
     },
 
     plugins: [

--- a/apps/mark/frontend/package.json
+++ b/apps/mark/frontend/package.json
@@ -129,7 +129,7 @@
     "react-dev-utils": "^11.0.3",
     "sort-package-json": "^1.50.0",
     "ts-jest": "29.1.1",
-    "vite": "^2.9.12"
+    "vite": "4.5.0"
   },
   "engines": {
     "node": ">= 16"

--- a/apps/mark/frontend/vite.config.ts
+++ b/apps/mark/frontend/vite.config.ts
@@ -85,6 +85,10 @@ export default defineConfig((env) => {
       },
     ],
 
+    server: {
+      port: 3000,
+    },
+
     // Pass some environment variables to the client in `import.meta.env`.
     envPrefix,
   };

--- a/apps/scan/frontend/package.json
+++ b/apps/scan/frontend/package.json
@@ -114,7 +114,7 @@
     "react-dev-utils": "^12.0.1",
     "sort-package-json": "^1.50.0",
     "ts-jest": "29.1.1",
-    "vite": "^2.9.12"
+    "vite": "4.5.0"
   },
   "packageManager": "pnpm@8.1.0",
   "vx": {

--- a/apps/scan/frontend/vite.config.ts
+++ b/apps/scan/frontend/vite.config.ts
@@ -86,6 +86,10 @@ export default defineConfig(async (env) => {
       },
     ],
 
+    server: {
+      port: 3000,
+    },
+
     // Pass some environment variables to the client in `import.meta.env`.
     envPrefix,
   };

--- a/libs/custom-scanner/package.json
+++ b/libs/custom-scanner/package.json
@@ -46,7 +46,7 @@
     "jest-mock-extended": "^3.0.4",
     "jest-watch-typeahead": "^2.2.2",
     "ts-jest": "29.1.1",
-    "vite": "^4.0.4"
+    "vite": "4.5.0"
   },
   "packageManager": "pnpm@8.1.0"
 }

--- a/libs/mark-flow-ui/.storybook/main.ts
+++ b/libs/mark-flow-ui/.storybook/main.ts
@@ -21,7 +21,6 @@ const config: StorybookConfig = {
     autodocs: 'tag',
   },
   staticDirs: ['../.storybook-static'],
-  // @ts-expect-error - vite and @storybook/react-vite are using different InlineConfig types
   async viteFinal(config: InlineConfig): Promise<InlineConfig> {
     const workspacePackages = getWorkspacePackageInfo(
       path.join(__dirname, '../..')

--- a/libs/mark-flow-ui/package.json
+++ b/libs/mark-flow-ui/package.json
@@ -118,7 +118,7 @@
     "styled-components": "^5.3.11",
     "ts-jest": "29.1.1",
     "util": "^0.12.4",
-    "vite": "^4.0.4"
+    "vite": "4.5.0"
   },
   "peerDependencies": {
     "react": "18.2.0",

--- a/libs/ui/.storybook/main.ts
+++ b/libs/ui/.storybook/main.ts
@@ -23,7 +23,6 @@ const config: StorybookConfig = {
     autodocs:'tag'
   },
   staticDirs: ['../.storybook-static'],
-  // @ts-expect-error - vite and @storybook/react-vite are using different InlineConfig types
   async viteFinal(config: InlineConfig): Promise<InlineConfig> {
     const workspacePackages = getWorkspacePackageInfo(
       path.join(__dirname, '../..')

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -122,7 +122,7 @@
     "styled-components": "^5.3.11",
     "ts-jest": "29.1.1",
     "util": "^0.12.4",
-    "vite": "^4.0.4"
+    "vite": "4.5.0"
   },
   "peerDependencies": {
     "@tanstack/react-query": "^4.32.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
         version: 7.2.2(react-dom@18.2.0)(react@18.2.0)
       '@storybook/builder-vite':
         specifier: ^7.2.2
-        version: 7.2.2(typescript@5.2.2)(vite@4.4.8)
+        version: 7.2.2(typescript@5.2.2)(vite@4.5.0)
       '@storybook/channel-postmessage':
         specifier: ^7.2.2
         version: 7.2.2
@@ -77,7 +77,7 @@ importers:
         version: 7.2.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
       '@storybook/react-vite':
         specifier: ^7.2.2
-        version: 7.2.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(vite@4.4.8)
+        version: 7.2.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(vite@4.5.0)
       '@storybook/theming':
         specifier: ^7.2.2
         version: 7.2.2(react-dom@18.2.0)(react@18.2.0)
@@ -603,8 +603,8 @@ importers:
         specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
       vite:
-        specifier: ^2.9.12
-        version: 2.9.13
+        specifier: 4.5.0
+        version: 4.5.0(@types/node@16.18.23)
 
   apps/admin/frontend/prodserver:
     dependencies:
@@ -1092,8 +1092,8 @@ importers:
         specifier: ^0.18.0
         version: 0.18.1
       vite:
-        specifier: ^2.9.12
-        version: 2.9.13
+        specifier: 4.5.0
+        version: 4.5.0(@types/node@16.18.23)
       zip-stream:
         specifier: ^3.0.1
         version: 3.0.1
@@ -1467,8 +1467,8 @@ importers:
         specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
       vite:
-        specifier: ^2.9.12
-        version: 2.9.13
+        specifier: 4.5.0
+        version: 4.5.0(@types/node@16.18.23)
 
   apps/mark-scan/backend:
     dependencies:
@@ -1871,8 +1871,8 @@ importers:
         specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
       vite:
-        specifier: ^2.9.12
-        version: 2.9.13
+        specifier: 4.5.0
+        version: 4.5.0(@types/node@16.18.23)
 
   apps/mark-scan/frontend/prodserver:
     dependencies:
@@ -2279,8 +2279,8 @@ importers:
         specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
       vite:
-        specifier: ^2.9.12
-        version: 2.9.13
+        specifier: 4.5.0
+        version: 4.5.0(@types/node@16.18.23)
 
   apps/mark/frontend/prodserver:
     dependencies:
@@ -2717,8 +2717,8 @@ importers:
         specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
       vite:
-        specifier: ^2.9.12
-        version: 2.9.13
+        specifier: 4.5.0
+        version: 4.5.0(@types/node@16.18.23)
 
   apps/scan/frontend/prodserver:
     dependencies:
@@ -3564,8 +3564,8 @@ importers:
         specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.6)(jest@29.6.2)(typescript@5.2.2)
       vite:
-        specifier: ^4.0.4
-        version: 4.0.4(@types/node@16.18.23)
+        specifier: 4.5.0
+        version: 4.5.0(@types/node@16.18.23)
 
   libs/cvr-fixture-generator:
     dependencies:
@@ -4684,8 +4684,8 @@ importers:
         specifier: ^0.12.4
         version: 0.12.4
       vite:
-        specifier: ^4.0.4
-        version: 4.0.4(@types/node@16.18.23)
+        specifier: 4.5.0
+        version: 4.5.0(@types/node@16.18.23)
 
   libs/message-coder:
     dependencies:
@@ -5269,8 +5269,8 @@ importers:
         specifier: ^0.12.4
         version: 0.12.4
       vite:
-        specifier: ^4.0.4
-        version: 4.0.4(@types/node@16.18.23)
+        specifier: 4.5.0
+        version: 4.5.0(@types/node@16.18.23)
 
   libs/usb-drive:
     dependencies:
@@ -9380,7 +9380,7 @@ packages:
       '@types/yargs': 17.0.24
       chalk: 4.1.2
 
-  /@joshwooding/vite-plugin-react-docgen-typescript@0.2.1(typescript@5.2.2)(vite@4.4.8):
+  /@joshwooding/vite-plugin-react-docgen-typescript@0.2.1(typescript@5.2.2)(vite@4.5.0):
     resolution: {integrity: sha512-ou4ZJSXMMWHqGS4g8uNRbC5TiTWxAgQZiVucoUrOCWuPrTbkpJbmVyIi9jU72SBry7gQtuMEDp4YR8EEXAg7VQ==}
     peerDependencies:
       typescript: '>= 4.3.x'
@@ -9394,7 +9394,7 @@ packages:
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@5.2.2)
       typescript: 5.2.2
-      vite: 4.4.8
+      vite: 4.5.0(@types/node@16.18.23)
     dev: true
 
   /@jridgewell/gen-mapping@0.3.3:
@@ -10403,7 +10403,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/builder-vite@7.2.2(typescript@5.2.2)(vite@4.4.8):
+  /@storybook/builder-vite@7.2.2(typescript@5.2.2)(vite@4.5.0):
     resolution: {integrity: sha512-3YDxZPJsHOsRQob/85X2Xf6pYfwbQilJBsEcuwmEV0JEO4p3JijOlO8xV58uCjkZSpuJ0ARl6t5oCMBo89DKCQ==}
     peerDependencies:
       '@preact/preset-vite': '*'
@@ -10438,7 +10438,7 @@ packages:
       remark-slug: 6.1.0
       rollup: 3.27.2
       typescript: 5.2.2
-      vite: 4.4.8
+      vite: 4.5.0(@types/node@16.18.23)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -10831,7 +10831,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
-  /@storybook/react-vite@7.2.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(vite@4.4.8):
+  /@storybook/react-vite@7.2.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(vite@4.5.0):
     resolution: {integrity: sha512-j77ckWdQaVVHLXFUkDCkZRqFcYkwi3usBdg60goe+NRAdX56WKPScwL2VMKpj3hR38E9jZwNgjjB2EGp0tam8w==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -10839,17 +10839,17 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
       vite: ^3.0.0 || ^4.0.0
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.2.1(typescript@5.2.2)(vite@4.4.8)
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.2.1(typescript@5.2.2)(vite@4.5.0)
       '@rollup/pluginutils': 5.0.3
-      '@storybook/builder-vite': 7.2.2(typescript@5.2.2)(vite@4.4.8)
+      '@storybook/builder-vite': 7.2.2(typescript@5.2.2)(vite@4.5.0)
       '@storybook/react': 7.2.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
-      '@vitejs/plugin-react': 3.0.1(vite@4.4.8)
+      '@vitejs/plugin-react': 3.0.1(vite@4.5.0)
       ast-types: 0.14.2
       magic-string: 0.30.2
       react: 18.2.0
       react-docgen: 6.0.0-alpha.3
       react-dom: 18.2.0(react@18.2.0)
-      vite: 4.4.8
+      vite: 4.5.0(@types/node@16.18.23)
     transitivePeerDependencies:
       - '@preact/preset-vite'
       - encoding
@@ -11979,7 +11979,7 @@ packages:
       - supports-color
     dev: true
 
-  /@vitejs/plugin-react@3.0.1(vite@4.4.8):
+  /@vitejs/plugin-react@3.0.1(vite@4.5.0):
     resolution: {integrity: sha512-mx+QvYwIbbpOIJw+hypjnW1lAbKDHtWK5ibkF/V1/oMBu8HU/chb+SnqJDAsLq1+7rGqjktCEomMTM5KShzUKQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -11990,7 +11990,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.19.6(@babel/core@7.22.9)
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 4.4.8
+      vite: 4.5.0(@types/node@16.18.23)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -20983,24 +20983,6 @@ packages:
   /postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  /postcss@8.4.14:
-    resolution: {integrity: sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==}
-    engines: {node: ^10 || ^12 || >=14}
-    dependencies:
-      nanoid: 3.3.6
-      picocolors: 1.0.0
-      source-map-js: 1.0.2
-    dev: true
-
-  /postcss@8.4.21:
-    resolution: {integrity: sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==}
-    engines: {node: ^10 || ^12 || >=14}
-    dependencies:
-      nanoid: 3.3.6
-      picocolors: 1.0.0
-      source-map-js: 1.0.2
-    dev: true
-
   /postcss@8.4.27:
     resolution: {integrity: sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -22179,22 +22161,6 @@ packages:
     dependencies:
       hash-base: 3.1.0
       inherits: 2.0.4
-
-  /rollup@2.75.5:
-    resolution: {integrity: sha512-JzNlJZDison3o2mOxVmb44Oz7t74EfSd1SQrplQk0wSaXV7uLQXtVdHbxlcT3w+8tZ1TL4r/eLfc7nAbz38BBA==}
-    engines: {node: '>=10.0.0'}
-    hasBin: true
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
-
-  /rollup@3.11.0:
-    resolution: {integrity: sha512-+uWPPkpWQ2H3Qi7sNBcRfhhHJyUNgBYhG4wKe5wuGRj2m55kpo+0p5jubKNBjQODyPe6tSBE3tNpdDwEisQvAQ==}
-    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
-    hasBin: true
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
 
   /rollup@3.27.2:
     resolution: {integrity: sha512-YGwmHf7h2oUHkVBT248x0yt6vZkYQ3/rvE5iQuVBh3WO8GcJ6BNeOkpoX1yMHIiBm18EMLjBPIoUDkhgnyxGOQ==}
@@ -24108,66 +24074,8 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  /vite@2.9.13:
-    resolution: {integrity: sha512-AsOBAaT0AD7Mhe8DuK+/kE4aWYFMx/i0ZNi98hJclxb4e0OhQcZYUrvLjIaQ8e59Ui7txcvKMiJC1yftqpQoDw==}
-    engines: {node: '>=12.2.0'}
-    hasBin: true
-    peerDependencies:
-      less: '*'
-      sass: '*'
-      stylus: '*'
-    peerDependenciesMeta:
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-    dependencies:
-      esbuild: 0.14.42
-      postcss: 8.4.14
-      resolve: 1.22.1
-      rollup: 2.75.5
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
-
-  /vite@4.0.4(@types/node@16.18.23):
-    resolution: {integrity: sha512-xevPU7M8FU0i/80DMR+YhgrzR5KS2ORy1B4xcX/cXLsvnUWvfHuqMmVU6N0YiJ4JWGRJJsLCgjEzKjG9/GKoSw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 16.18.23
-      esbuild: 0.16.17
-      postcss: 8.4.21
-      resolve: 1.22.1
-      rollup: 3.11.0
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
-
-  /vite@4.4.8:
-    resolution: {integrity: sha512-LONawOUUjxQridNWGQlNizfKH89qPigK36XhMI7COMGztz8KNY0JHim7/xDd71CZwGT4HtSRgI7Hy+RlhG0Gvg==}
+  /vite@4.5.0(@types/node@16.18.23):
+    resolution: {integrity: sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
@@ -24194,6 +24102,7 @@ packages:
       terser:
         optional: true
     dependencies:
+      '@types/node': 16.18.23
       esbuild: 0.18.17
       postcss: 8.4.27
       rollup: 3.27.2

--- a/script/src/validate-monorepo/validation/index.ts
+++ b/script/src/validate-monorepo/validation/index.ts
@@ -32,6 +32,7 @@ export async function* validateMonorepo(): AsyncGenerator<ValidationIssue> {
       'react',
       'react-dom',
       'typescript',
+      'vite'
     ],
     workspacePackages,
   });


### PR DESCRIPTION
## Overview

Upgrades Vite to v4.0.5 and pins it across the monorepo. This will ensure that our dev servers can actually run code that uses the latest TS features (since we recently upgraded TS).

_Review by commit_

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
