### PR TITLE
ci: build any/all rust addons during setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1234,8 +1234,8 @@ commands:
           name: Setup Dependencies
           command: |
             pnpm install --frozen-lockfile
-            pnpm --dir libs/ballot-interpreter install:rust-addon
-            pnpm --dir libs/ballot-interpreter build:rust-addon
+            pnpm --recursive install:rust-addon
+            pnpm --recursive build:rust-addon
       - save_cache:
           key:
             dotcache-cache-{{checksum ".circleci/config.yml" }}-{{ checksum

--- a/libs/monorepo-utils/src/circleci.ts
+++ b/libs/monorepo-utils/src/circleci.ts
@@ -179,8 +179,8 @@ commands:
           name: Setup Dependencies
           command: |
             pnpm install --frozen-lockfile
-            pnpm --dir libs/ballot-interpreter install:rust-addon
-            pnpm --dir libs/ballot-interpreter build:rust-addon
+            pnpm --recursive install:rust-addon
+            pnpm --recursive build:rust-addon
       - save_cache:
           key:
             dotcache-cache-{{checksum ".circleci/config.yml" }}-{{ checksum


### PR DESCRIPTION

## Overview

In the event we rename `ballot-interpreter` or add any other Rust addons this will ensure everything is set up properly.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated.
