### PR TITLE
Fix manually created CVR fixture

### DIFF
--- a/libs/fixtures/data/electionGridLayoutNewHampshireAmherst/castVoteRecords/manual/864a2854-ee26-4223-8097-9633b7bed096/cast-vote-record-report.json
+++ b/libs/fixtures/data/electionGridLayoutNewHampshireAmherst/castVoteRecords/manual/864a2854-ee26-4223-8097-9633b7bed096/cast-vote-record-report.json
@@ -993,10 +993,10 @@
                           "Hash": {
                             "@type": "CVR.Hash",
                             "Type": "sha-256",
-                            "Value": "9acc41877beaf6d7569da0408ac4a229f777612ec69a4acd38da31fcc10a0f68"
+                            "Value": "ac62ce77e7afb3a7d2a8d99f8abbef6129366e94dd295b559f4d3be07aa1201c"
                           },
-                          "Location": "file:864a2854-ee26-4223-8097-9633b7bed096-front.jpg",
-                          "vxLayoutFileHash": "be434f1cc96d2b955ebafc70e4f095a2b3bf5e1cb45311cbbd4ea258806e7174"
+                          "Location": "file:864a2854-ee26-4223-8097-9633b7bed096-back.jpg",
+                          "vxLayoutFileHash": "8bb4495e85b427e3eeefd89c70e7264581a70f8c6ef7cc4342651cf9dd6c5bcd"
                         }
                       }
                     }
@@ -1029,10 +1029,10 @@
                           "Hash": {
                             "@type": "CVR.Hash",
                             "Type": "sha-256",
-                            "Value": "9acc41877beaf6d7569da0408ac4a229f777612ec69a4acd38da31fcc10a0f68"
+                            "Value": "ac62ce77e7afb3a7d2a8d99f8abbef6129366e94dd295b559f4d3be07aa1201c"
                           },
-                          "Location": "file:864a2854-ee26-4223-8097-9633b7bed096-front.jpg",
-                          "vxLayoutFileHash": "be434f1cc96d2b955ebafc70e4f095a2b3bf5e1cb45311cbbd4ea258806e7174"
+                          "Location": "file:864a2854-ee26-4223-8097-9633b7bed096-back.jpg",
+                          "vxLayoutFileHash": "8bb4495e85b427e3eeefd89c70e7264581a70f8c6ef7cc4342651cf9dd6c5bcd"
                         }
                       }
                     }


### PR DESCRIPTION
While testing write-in adjudication, @adghayes identified an inconsistency in our one manually created CVR fixture. All the `WriteInImage` fields reference the front image, but two of the contests with write-ins are actually on the back of the ballot and should reference the back image.

Our actual CVR export logic is doing the right thing. The reason this fixture has an issue is because I recently modified it by hand to use the new CVR export format and made a human error 🙈.
