### PR TITLE
Show Significant Write-Ins in Tally Reports

### DIFF
--- a/apps/admin/backend/src/app.tally_reports.test.ts
+++ b/apps/admin/backend/src/app.tally_reports.test.ts
@@ -85,10 +85,8 @@ test('general, full election, write in adjudication', async () => {
         name: 'Obadiah Carrigan',
         tally: 60,
       },
-      'write-in': {
-        id: 'write-in',
-        isWriteIn: true,
-        name: 'Write-In',
+      [Tabulation.PENDING_WRITE_IN_ID]: {
+        ...Tabulation.PENDING_WRITE_IN_CANDIDATE,
         tally: 56,
       },
     },
@@ -150,10 +148,10 @@ test('general, full election, write in adjudication', async () => {
         name: 'Obadiah Carrigan',
         tally: 60 + NUM_OFFICIAL,
       },
-      'write-in': {
-        id: 'write-in',
+      [unofficialCandidate.id]: {
+        id: unofficialCandidate.id,
         isWriteIn: true,
-        name: 'Write-In',
+        name: unofficialCandidate.name,
         tally: NUM_UNOFFICIAL,
       },
     },
@@ -249,27 +247,7 @@ test('general, reports by voting method, manual data', async () => {
   expect(precinctTallyReport.manualResults).toBeUndefined();
   const receivedAbsenteeManualResults = absenteeTallyReport.manualResults;
   expect(receivedAbsenteeManualResults).toBeDefined();
-
-  // the received manual results should be the same as the ones we sent but
-  // with specific unofficial write-in candidates bucketed together
-  expect(receivedAbsenteeManualResults).toMatchObject(
-    buildManualResultsFixture({
-      election,
-      ballotCount: 10,
-      contestResultsSummaries: {
-        [writeInContestId]: {
-          type: 'candidate',
-          ballots: 10,
-          writeInOptionTallies: {
-            [Tabulation.GENERIC_WRITE_IN_ID]: {
-              tally: 10,
-              name: Tabulation.GENERIC_WRITE_IN_NAME,
-            },
-          },
-        },
-      },
-    })
-  );
+  expect(receivedAbsenteeManualResults).toMatchObject(absenteeManualResults);
 
   // with a filter incompatible with manual results, manual results should be undefined
   const batchVotingMethodTallyReportResult =

--- a/apps/admin/backend/src/exports/csv_tally_report.ts
+++ b/apps/admin/backend/src/exports/csv_tally_report.ts
@@ -151,6 +151,7 @@ function* generateDataRows({
           contest,
           scannedContestResults,
           manualContestResults,
+          aggregateInsignificantWriteIns: false,
         })) {
           yield buildRow({
             metadataValues,

--- a/apps/admin/frontend/src/__snapshots__/app.test.tsx.snap
+++ b/apps/admin/frontend/src/__snapshots__/app.test.tsx.snap
@@ -134,6 +134,11 @@ exports[`L&A (logic and accuracy) flow 1`] = `
   font-weight: 400;
 }
 
+.c11 th.option-label {
+  padding: 0.25em 0.5em;
+  line-height: 1;
+}
+
 .c11 th:first-child {
   padding-left: 0.25em;
   text-align: left;

--- a/libs/ui/jest.config.js
+++ b/libs/ui/jest.config.js
@@ -26,6 +26,7 @@ module.exports = {
     'src/voter_contest_summary.tsx',
     'src/reports/tally_report.tsx'
   ],
+  prettierPath: null,
   transform: {
     '^.+\\.css$': '<rootDir>/config/jest/cssTransform.js',
   },

--- a/libs/ui/src/reports/admin_tally_report.stories.tsx
+++ b/libs/ui/src/reports/admin_tally_report.stories.tsx
@@ -4,7 +4,7 @@ import {
   buildElectionResultsFixture,
   buildManualResultsFixture,
 } from '@votingworks/utils';
-import { getBallotStyle, getContests } from '@votingworks/types';
+import { Tabulation, getBallotStyle, getContests } from '@votingworks/types';
 import { assertDefined } from '@votingworks/basics';
 import { AdminTallyReportProps, AdminTallyReport } from './admin_tally_report';
 import { TallyReportPreview } from './tally_report';
@@ -122,6 +122,78 @@ const ballotStyleManualReportArgs: AdminTallyReportProps = {
 
 export const BallotStyleManualReport: Story = {
   args: ballotStyleManualReportArgs,
+};
+
+const fullElectionWriteInReportArgs: AdminTallyReportProps = {
+  title: 'TEST Full Election Tally Report',
+  subtitle: election.title,
+  testId: 'tally-report',
+  electionDefinition,
+  contests: election.contests,
+  scannedElectionResults: buildElectionResultsFixture({
+    election,
+    cardCounts: {
+      bmd: 0,
+      hmpb: [100],
+    },
+    includeGenericWriteIn: false,
+    contestResultsSummaries: {
+      'zoo-council-mammal': {
+        type: 'candidate',
+        ballots: 100,
+        officialOptionTallies: {
+          zebra: 50,
+          lion: 15,
+          kangaroo: 10,
+          elephant: 5,
+        },
+        writeInOptionTallies: {
+          'write-in-1': {
+            name: 'Salty Sally',
+            tally: 15,
+          },
+          'write-in-2': {
+            name: 'Joe Handsome',
+            tally: 3,
+          },
+          'write-in-3': {
+            name: 'Faux Francis',
+            tally: 2,
+          },
+          [Tabulation.PENDING_WRITE_IN_ID]: {
+            ...Tabulation.PENDING_WRITE_IN_CANDIDATE,
+            tally: 10,
+          },
+        },
+      },
+    },
+  }),
+  manualElectionResults: buildManualResultsFixture({
+    election,
+    ballotCount: 50,
+    contestResultsSummaries: {
+      'zoo-council-mammal': {
+        type: 'candidate',
+        ballots: 50,
+        officialOptionTallies: {
+          zebra: 10,
+          lion: 5,
+          kangaroo: 5,
+          elephant: 0,
+        },
+        writeInOptionTallies: {
+          'write-in-4': {
+            name: 'Billy Bob',
+            tally: 30,
+          },
+        },
+      },
+    },
+  }),
+};
+
+export const FullElectionWriteInReport: Story = {
+  args: fullElectionWriteInReportArgs,
 };
 
 export default meta;

--- a/libs/ui/src/reports/contest_results_table.test.tsx
+++ b/libs/ui/src/reports/contest_results_table.test.tsx
@@ -201,3 +201,42 @@ test('numbers are formatted with commas when necessary', () => {
   within(fishing).getByText(hasTextAcrossElements('Yes3,000'));
   within(fishing).getByText(hasTextAcrossElements('No500'));
 });
+
+test('uses write-in adjudication aggregation', () => {
+  render(
+    <ContestResultsTable
+      election={election}
+      contest={candidateWriteInContest}
+      scannedContestResults={buildContestResultsFixture({
+        contest: candidateWriteInContest,
+        contestResultsSummary: {
+          type: 'candidate',
+          ballots: 6000,
+          overvotes: 1000,
+          undervotes: 1500,
+          officialOptionTallies: {
+            zebra: 50,
+            lion: 50,
+            elephant: 50,
+          },
+          writeInOptionTallies: {
+            'write-in-1': {
+              name: 'Giraffe',
+              tally: 40,
+            },
+            'write-in-2': {
+              name: 'Gazelle',
+              tally: 20,
+            },
+          },
+        },
+      })}
+    />
+  );
+  const fishing = screen.getByTestId('results-table-zoo-council-mammal');
+  within(fishing).getByText(hasTextAcrossElements('Zebra50'));
+  within(fishing).getByText(hasTextAcrossElements('Lion50'));
+  within(fishing).getByText(hasTextAcrossElements('Elephant50'));
+  within(fishing).getByText(hasTextAcrossElements('Giraffe (Write-In)40'));
+  within(fishing).getByText(hasTextAcrossElements('Other Write-In20'));
+});

--- a/libs/ui/src/reports/contest_results_table.tsx
+++ b/libs/ui/src/reports/contest_results_table.tsx
@@ -8,10 +8,7 @@ import {
   Tabulation,
   AnyContest,
 } from '@votingworks/types';
-import {
-  getContestVoteOptionsForCandidateContest,
-  format,
-} from '@votingworks/utils';
+import { format, getTallyReportCandidateRows } from '@votingworks/utils';
 import { throwIllegalValue, assert, Optional } from '@votingworks/basics';
 
 import { Text, NoWrap } from '../text';
@@ -219,21 +216,21 @@ export function ContestResultsTable({
       assertIsOptional<Tabulation.CandidateContestResults>(
         manualContestResults
       );
-      for (const candidate of getContestVoteOptionsForCandidateContest(
-        contest
-      )) {
-        const key = `${contest.id}-${candidate.id}`;
+      const candidateReportTallies = getTallyReportCandidateRows({
+        contest,
+        scannedContestResults,
+        manualContestResults,
+        aggregateInsignificantWriteIns: true,
+      });
+      for (const candidateReportTally of candidateReportTallies) {
+        const key = `${contest.id}-${candidateReportTally.id}`;
         contestTableRows.push(
           <ContestOptionRow
             key={key}
             testId={key}
-            optionLabel={candidate.name}
-            scannedTally={
-              scannedContestResults.tallies[candidate.id]?.tally ?? 0
-            }
-            manualTally={
-              manualContestResults?.tallies[candidate.id]?.tally ?? 0
-            }
+            optionLabel={candidateReportTally.name}
+            scannedTally={candidateReportTally.scannedTally}
+            manualTally={candidateReportTally.manualTally}
             showManualTally={hasManualResults}
           />
         );

--- a/libs/ui/src/reports/contest_results_table.tsx
+++ b/libs/ui/src/reports/contest_results_table.tsx
@@ -70,6 +70,11 @@ const ContestTable = styled.table`
     text-align: right;
     font-weight: 400;
 
+    &.option-label {
+      padding: 0.25em 0.5em;
+      line-height: 1;
+    }
+
     &:first-child {
       padding-left: 0.25em;
       text-align: left;
@@ -101,7 +106,7 @@ function ContestOptionRow({
   if (showManualTally) {
     return (
       <tr data-testid={testId}>
-        <th>{optionLabel}</th>
+        <th className="option-label">{optionLabel.replace('-', '‑')}</th>
         <td>{format.count(scannedTally)}</td>
         <td>
           {manualTally === 0 ? (

--- a/libs/utils/src/tabulation/tally_reports.test.ts
+++ b/libs/utils/src/tabulation/tally_reports.test.ts
@@ -1,6 +1,6 @@
 import { electionTwoPartyPrimaryFixtures } from '@votingworks/fixtures';
 import { find } from '@votingworks/basics';
-import { CandidateContest, Tabulation } from '@votingworks/types';
+import { CandidateContest, DistrictId, Tabulation } from '@votingworks/types';
 import { buildContestResultsFixture } from './tabulation';
 import {
   getTallyReportCandidateRows,
@@ -16,7 +16,7 @@ const contest = find(
   (c) => c.id === contestId
 ) as CandidateContest;
 
-test('getTallyReportRows', () => {
+test('getTallyReportRows - no aggregation', () => {
   const scannedContestResults = buildContestResultsFixture({
     contest,
     includeGenericWriteIn: false,
@@ -67,9 +67,11 @@ test('getTallyReportRows', () => {
   }) as Tabulation.CandidateContestResults;
 
   expect(
-    getTallyReportCandidateRows({ contest, scannedContestResults }).map(
-      shorthandTallyReportCandidateRow
-    )
+    getTallyReportCandidateRows({
+      contest,
+      scannedContestResults,
+      aggregateInsignificantWriteIns: false,
+    }).map(shorthandTallyReportCandidateRow)
   ).toEqual([
     ['zebra', 'Zebra', 40, 0],
     ['lion', 'Lion', 0, 0],
@@ -85,6 +87,7 @@ test('getTallyReportRows', () => {
       contest,
       scannedContestResults,
       manualContestResults,
+      aggregateInsignificantWriteIns: false,
     }).map(shorthandTallyReportCandidateRow)
   ).toEqual([
     ['zebra', 'Zebra', 40, 20],
@@ -96,4 +99,287 @@ test('getTallyReportRows', () => {
     ['write-in-3', 'Write-In 3 (Write-In)', 0, 5],
     ['write-in', 'Unadjudicated Write-In', 1, 0],
   ]);
+});
+
+describe('getTallyReportRows - aggregating insignificant write-ins', () => {
+  const preAdjudicationScannedContestResults: Tabulation.CandidateContestResults =
+    buildContestResultsFixture({
+      contest,
+      contestResultsSummary: {
+        type: 'candidate',
+        ballots: 100,
+        officialOptionTallies: {
+          zebra: 50,
+          lion: 15,
+          kangaroo: 10,
+          elephant: 5,
+        },
+        writeInOptionTallies: {
+          [Tabulation.PENDING_WRITE_IN_ID]: {
+            ...Tabulation.PENDING_WRITE_IN_CANDIDATE,
+            tally: 30,
+          },
+        },
+      },
+    }) as Tabulation.CandidateContestResults;
+
+  const midAdjudicationScannedContestResults: Tabulation.CandidateContestResults =
+    buildContestResultsFixture({
+      contest,
+      contestResultsSummary: {
+        type: 'candidate',
+        ballots: 100,
+        officialOptionTallies: {
+          zebra: 50,
+          lion: 15,
+          kangaroo: 10,
+          elephant: 5,
+        },
+        writeInOptionTallies: {
+          'write-in-1': {
+            name: 'Write-In 1',
+            tally: 15,
+          },
+          'write-in-2': {
+            name: 'Write-In 2',
+            tally: 3,
+          },
+          'write-in-3': {
+            name: 'Write-In 3',
+            tally: 2,
+          },
+          [Tabulation.PENDING_WRITE_IN_ID]: {
+            ...Tabulation.PENDING_WRITE_IN_CANDIDATE,
+            tally: 10,
+          },
+        },
+      },
+    }) as Tabulation.CandidateContestResults;
+
+  const postAdjudicationScannedContestResults: Tabulation.CandidateContestResults =
+    buildContestResultsFixture({
+      contest,
+      contestResultsSummary: {
+        type: 'candidate',
+        ballots: 100,
+        officialOptionTallies: {
+          zebra: 50,
+          lion: 15,
+          kangaroo: 10,
+          elephant: 5,
+        },
+        writeInOptionTallies: {
+          'write-in-1': {
+            name: 'Write-In 1',
+            tally: 25,
+          },
+          'write-in-2': {
+            name: 'Write-In 2',
+            tally: 3,
+          },
+          'write-in-3': {
+            name: 'Write-In 3',
+            tally: 2,
+          },
+        },
+      },
+      includeGenericWriteIn: false,
+    }) as Tabulation.CandidateContestResults;
+
+  const manualContestResults: Tabulation.CandidateContestResults =
+    buildContestResultsFixture({
+      contest,
+      contestResultsSummary: {
+        type: 'candidate',
+        ballots: 50,
+        officialOptionTallies: {
+          zebra: 10,
+          lion: 5,
+          kangaroo: 5,
+          elephant: 0,
+        },
+        writeInOptionTallies: {
+          'write-in-4': {
+            name: 'Write-In 4',
+            tally: 30,
+          },
+        },
+      },
+      includeGenericWriteIn: false,
+    }) as Tabulation.CandidateContestResults;
+
+  test('with manual results', () => {
+    expect(
+      getTallyReportCandidateRows({
+        contest,
+        scannedContestResults: preAdjudicationScannedContestResults,
+        manualContestResults,
+        aggregateInsignificantWriteIns: true,
+      }).map(shorthandTallyReportCandidateRow)
+    ).toEqual([
+      ['zebra', 'Zebra', 50, 10],
+      ['lion', 'Lion', 15, 5],
+      ['kangaroo', 'Kangaroo', 10, 5],
+      ['elephant', 'Elephant', 5, 0],
+      ['write-in-4', 'Write-In 4 (Write-In)', 0, 30],
+      ['write-in', 'Unadjudicated Write-In', 30, 0],
+    ]);
+
+    expect(
+      getTallyReportCandidateRows({
+        contest,
+        scannedContestResults: midAdjudicationScannedContestResults,
+        manualContestResults,
+        aggregateInsignificantWriteIns: true,
+      }).map(shorthandTallyReportCandidateRow)
+    ).toEqual([
+      ['zebra', 'Zebra', 50, 10],
+      ['lion', 'Lion', 15, 5],
+      ['kangaroo', 'Kangaroo', 10, 5],
+      ['elephant', 'Elephant', 5, 0],
+      ['write-in-4', 'Write-In 4 (Write-In)', 0, 30],
+      ['write-in-1', 'Write-In 1 (Write-In)', 15, 0],
+      ['write-in-other', 'Other Write-In', 5, 0],
+      ['write-in', 'Unadjudicated Write-In', 10, 0],
+    ]);
+
+    expect(
+      getTallyReportCandidateRows({
+        contest,
+        scannedContestResults: postAdjudicationScannedContestResults,
+        manualContestResults,
+        aggregateInsignificantWriteIns: true,
+      }).map(shorthandTallyReportCandidateRow)
+    ).toEqual([
+      ['zebra', 'Zebra', 50, 10],
+      ['lion', 'Lion', 15, 5],
+      ['kangaroo', 'Kangaroo', 10, 5],
+      ['elephant', 'Elephant', 5, 0],
+      ['write-in-4', 'Write-In 4 (Write-In)', 0, 30],
+      ['write-in-1', 'Write-In 1 (Write-In)', 25, 0],
+      ['write-in-other', 'Other Write-In', 5, 0],
+    ]);
+  });
+
+  test('without manual results', () => {
+    expect(
+      getTallyReportCandidateRows({
+        contest,
+        scannedContestResults: postAdjudicationScannedContestResults,
+        aggregateInsignificantWriteIns: true,
+      }).map(shorthandTallyReportCandidateRow)
+    ).toEqual([
+      ['zebra', 'Zebra', 50, 0],
+      ['lion', 'Lion', 15, 0],
+      ['kangaroo', 'Kangaroo', 10, 0],
+      ['elephant', 'Elephant', 5, 0],
+      ['write-in-1', 'Write-In 1 (Write-In)', 25, 0],
+      ['write-in-other', 'Other Write-In', 5, 0],
+    ]);
+  });
+
+  test('when no significant write-ins, buckets all write-ins', () => {
+    expect(
+      getTallyReportCandidateRows({
+        contest,
+        scannedContestResults: buildContestResultsFixture({
+          contest,
+          contestResultsSummary: {
+            type: 'candidate',
+            ballots: 100,
+            officialOptionTallies: {
+              zebra: 50,
+              lion: 25,
+              kangaroo: 15,
+              elephant: 5,
+            },
+            writeInOptionTallies: {
+              'write-in-1': {
+                name: 'Write-In 1',
+                tally: 5,
+              },
+            },
+          },
+        }) as Tabulation.CandidateContestResults,
+        aggregateInsignificantWriteIns: true,
+      }).map(shorthandTallyReportCandidateRow)
+    ).toEqual([
+      ['zebra', 'Zebra', 50, 0],
+      ['lion', 'Lion', 25, 0],
+      ['kangaroo', 'Kangaroo', 15, 0],
+      ['elephant', 'Elephant', 5, 0],
+      ['write-in-other', 'Write-In', 5, 0],
+    ]);
+  });
+
+  test('when contest has more seats than candidates, shows all write-in candidates', () => {
+    const mockContest: CandidateContest = {
+      type: 'candidate',
+      seats: 3,
+      allowWriteIns: true,
+      districtId: 'id' as DistrictId,
+      title: 'Title',
+      id: 'id',
+      candidates: [
+        {
+          id: 'official',
+          name: 'Official',
+        },
+      ],
+    };
+
+    expect(
+      getTallyReportCandidateRows({
+        contest: mockContest,
+        scannedContestResults: buildContestResultsFixture({
+          contest: mockContest,
+          contestResultsSummary: {
+            type: 'candidate',
+            ballots: 100,
+            officialOptionTallies: {
+              official: 70,
+            },
+            writeInOptionTallies: {
+              'write-in-1': {
+                name: 'Write-In 1',
+                tally: 30,
+              },
+            },
+          },
+        }) as Tabulation.CandidateContestResults,
+        aggregateInsignificantWriteIns: true,
+      }).map(shorthandTallyReportCandidateRow)
+    ).toEqual([
+      ['official', 'Official', 70, 0],
+      ['write-in-1', 'Write-In 1 (Write-In)', 30, 0],
+    ]);
+  });
+
+  test('when there is no write-in data at all, a placeholder row is included for write-in contests', () => {
+    expect(
+      getTallyReportCandidateRows({
+        contest,
+        scannedContestResults: buildContestResultsFixture({
+          contest,
+          contestResultsSummary: {
+            type: 'candidate',
+            ballots: 100,
+            officialOptionTallies: {
+              zebra: 70,
+              lion: 15,
+              kangaroo: 10,
+              elephant: 5,
+            },
+          },
+        }) as Tabulation.CandidateContestResults,
+        aggregateInsignificantWriteIns: true,
+      }).map(shorthandTallyReportCandidateRow)
+    ).toEqual([
+      ['zebra', 'Zebra', 70, 0],
+      ['lion', 'Lion', 15, 0],
+      ['kangaroo', 'Kangaroo', 10, 0],
+      ['elephant', 'Elephant', 5, 0],
+      ['write-in', 'Write-In', 0, 0],
+    ]);
+  });
 });


### PR DESCRIPTION
## Overview

Closes #4014. Updates tally reports such that contest tables include significant tallies for write-in candidates. Insignificant write-ins are shown as "Other Write-In" or "Write-In." It works by adding the WIA candidates with the most votes until it is clear from the table who the winners are (the "Other Write-In" category is smaller than the winners).

## Demo Video or Screenshot

### Pre-Adjudication
![TEST-full-election-tally-report__2023-10-24_10-07-48](https://github.com/votingworks/vxsuite/assets/37960853/caacfeed-8ad3-46e2-82ed-ecc5c4eae708)

### Early Adjudication
![TEST-full-election-tally-report__2023-10-24_10-10-34](https://github.com/votingworks/vxsuite/assets/37960853/c1ceb1b4-cc41-46e5-8588-04bafafda866)

### Late Adjudication
![TEST-full-election-tally-report__2023-10-24_10-24-34](https://github.com/votingworks/vxsuite/assets/37960853/d1758fee-c801-48ed-af34-34b88beed93f)

### w/ Manual Results
![TEST-full-election-tally-report__2023-10-24_10-27-09](https://github.com/votingworks/vxsuite/assets/37960853/2f77174c-4e17-4dd1-85f5-549ceb1b8050)

## Testing Plan

Added automated testing of algorithm and its appearance in reports. Manually tested full flow with a robust data set to confirm it performs end-to-end, in a variety of WIA situations.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
