### PR TITLE
WIA Report Page Styling

### DIFF
--- a/apps/admin/frontend/src/components/election_manager.tsx
+++ b/apps/admin/frontend/src/components/election_manager.tsx
@@ -20,7 +20,7 @@ import { BallotListScreen } from '../screens/ballot_list_screen';
 import { PrintTestDeckScreen } from '../screens/print_test_deck_screen';
 import { UnconfiguredScreen } from '../screens/unconfigured_screen';
 import { TallyScreen } from '../screens/tally_screen';
-import { TallyWriteInReportScreen } from '../screens/write_in_adjudication_report_screen';
+import { TallyWriteInReportScreen } from '../screens/reporting/write_in_adjudication_report_screen';
 import { DefinitionViewerScreen } from '../screens/definition_viewer_screen';
 import { ManualDataSummaryScreen } from '../screens/manual_data_summary_screen';
 import { ManualDataEntryScreen } from '../screens/manual_data_entry_screen';

--- a/apps/admin/frontend/src/components/reporting/ballot_count_report_viewer.tsx
+++ b/apps/admin/frontend/src/components/reporting/ballot_count_report_viewer.tsx
@@ -2,9 +2,6 @@ import { ElectionDefinition, Tabulation } from '@votingworks/types';
 import {
   BallotCountReport,
   Button,
-  Caption,
-  Font,
-  H5,
   H6,
   Icons,
   Loading,
@@ -13,7 +10,6 @@ import {
   printElementToPdf,
 } from '@votingworks/ui';
 import React, { useContext, useMemo, useRef, useState } from 'react';
-import styled from 'styled-components';
 import { Optional, assert, assertDefined } from '@votingworks/basics';
 import { isElectionManagerAuth } from '@votingworks/utils';
 import type { ScannerBatch } from '@votingworks/admin-backend';
@@ -32,69 +28,16 @@ import {
 import { ExportReportPdfButton } from './export_report_pdf_button';
 import { FileType } from '../save_frontend_file_modal';
 import { ExportBallotCountReportCsvButton } from './export_ballot_count_report_csv_button';
-
-const ExportActions = styled.div`
-  margin-top: 1rem;
-  margin-bottom: 0.5rem;
-  display: flex;
-  justify-content: start;
-  gap: 1rem;
-`;
-
-const PreviewContainer = styled.div`
-  position: relative;
-  min-height: 11in;
-  margin-top: 0.5rem;
-  padding: 0.5rem;
-  background: rgba(0, 0, 0, 10%);
-  border-radius: 0.5rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-`;
-
-const PreviewOverlay = styled.div`
-  position: absolute;
-  inset: 0;
-  z-index: 1;
-  background: black;
-  opacity: 0.3;
-`;
-
-const PreviewReportPages = styled.div`
-  section {
-    background: white;
-    position: relative;
-    box-shadow: 0 3px 10px rgb(0, 0, 0, 20%);
-    margin-top: 1rem;
-    margin-bottom: 2rem;
-    width: 8.5in;
-    min-height: 11in;
-    padding: 0.5in;
-  }
-`;
-
-const PreviewActionContainer = styled.div`
-  position: absolute;
-  inset: 0;
-  margin-left: auto;
-  margin-right: auto;
-  margin-top: 4rem;
-  display: flex;
-  justify-content: center;
-  align-items: start;
-  z-index: 2;
-`;
-
-const LoadingTextContainer = styled.div`
-  background: white;
-  width: 35rem;
-  border-radius: 0.5rem;
-`;
-
-const NoResultsNotice = styled(H5)`
-  margin-top: 2rem;
-`;
+import {
+  ExportActions,
+  NoResultsNotice,
+  PaginationNote,
+  PreviewActionContainer,
+  PreviewContainer,
+  PreviewLoading,
+  PreviewOverlay,
+  PreviewReportPages,
+} from './shared';
 
 function Report({
   electionDefinition,
@@ -330,11 +273,7 @@ export function BallotCountReportViewer({
           disabled={disabled || areQueryResultsEmpty}
         />
       </ExportActions>
-
-      <Caption>
-        <Icons.Info /> <Font weight="bold">Note:</Font> Printed reports may be
-        paginated to more than one piece of paper.
-      </Caption>
+      <PaginationNote />
       <PreviewContainer>
         {!disabled && (
           <React.Fragment>
@@ -347,13 +286,7 @@ export function BallotCountReportViewer({
               </NoResultsNotice>
             )}
             {!previewIsFresh && <PreviewOverlay />}
-            {isFetchingForPreview && (
-              <PreviewActionContainer>
-                <LoadingTextContainer>
-                  <Loading>Generating Report</Loading>
-                </LoadingTextContainer>
-              </PreviewActionContainer>
-            )}
+            {isFetchingForPreview && <PreviewLoading />}
             {!isFetchingForPreview && !previewIsFresh && (
               <PreviewActionContainer>
                 {previewReport ? (

--- a/apps/admin/frontend/src/components/reporting/shared.tsx
+++ b/apps/admin/frontend/src/components/reporting/shared.tsx
@@ -1,0 +1,93 @@
+import { Caption, Font, H5, Icons, LinkButton, Loading } from '@votingworks/ui';
+import styled from 'styled-components';
+import { routerPaths } from '../../router_paths';
+
+export const ExportActions = styled.div`
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+  display: flex;
+  justify-content: start;
+  gap: 1rem;
+`;
+
+export const PreviewContainer = styled.div`
+  position: relative;
+  min-height: 11in;
+  margin-top: 0.5rem;
+  padding: 0.5rem;
+  background: rgba(0, 0, 0, 10%);
+  border-radius: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const PreviewOverlay = styled.div`
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  background: black;
+  opacity: 0.3;
+`;
+
+export const PreviewReportPages = styled.div`
+  section {
+    background: white;
+    position: relative;
+    box-shadow: 0 3px 10px rgb(0, 0, 0, 20%);
+    margin-top: 1rem;
+    margin-bottom: 2rem;
+    width: 8.5in;
+    min-height: 11in;
+    padding: 0.5in;
+  }
+`;
+
+export const PreviewActionContainer = styled.div`
+  position: absolute;
+  inset: 0;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 4rem;
+  display: flex;
+  justify-content: center;
+  align-items: start;
+  z-index: 2;
+`;
+
+export const LoadingTextContainer = styled.div`
+  background: white;
+  width: 35rem;
+  border-radius: 0.5rem;
+`;
+
+export const NoResultsNotice = styled(H5)`
+  margin-top: 2rem;
+`;
+
+export function PreviewLoading(): JSX.Element {
+  return (
+    <PreviewActionContainer>
+      <LoadingTextContainer>
+        <Loading>Generating Report</Loading>
+      </LoadingTextContainer>
+    </PreviewActionContainer>
+  );
+}
+
+export function ReportBackButton(): JSX.Element {
+  return (
+    <LinkButton small to={routerPaths.reports}>
+      <Icons.Previous /> Back
+    </LinkButton>
+  );
+}
+
+export function PaginationNote(): JSX.Element {
+  return (
+    <Caption>
+      <Icons.Info /> <Font weight="bold">Note:</Font> Printed reports may be
+      paginated to more than one piece of paper.
+    </Caption>
+  );
+}

--- a/apps/admin/frontend/src/components/reporting/tally_report_viewer.tsx
+++ b/apps/admin/frontend/src/components/reporting/tally_report_viewer.tsx
@@ -1,9 +1,6 @@
 import { ElectionDefinition, Tabulation } from '@votingworks/types';
 import {
   Button,
-  Caption,
-  Font,
-  H5,
   H6,
   Icons,
   Loading,
@@ -12,7 +9,6 @@ import {
   printElementToPdf,
 } from '@votingworks/ui';
 import React, { useContext, useMemo, useRef, useState } from 'react';
-import styled from 'styled-components';
 import { Optional, assert, assertDefined } from '@votingworks/basics';
 import {
   combineGroupSpecifierAndFilter,
@@ -38,69 +34,16 @@ import {
 import { ExportReportPdfButton } from './export_report_pdf_button';
 import { ExportTallyReportCsvButton } from './export_tally_report_csv_button';
 import { FileType } from '../save_frontend_file_modal';
-
-const ExportActions = styled.div`
-  margin-top: 1rem;
-  margin-bottom: 0.5rem;
-  display: flex;
-  justify-content: start;
-  gap: 1rem;
-`;
-
-const PreviewContainer = styled.div`
-  position: relative;
-  min-height: 11in;
-  margin-top: 0.5rem;
-  padding: 0.5rem;
-  background: rgba(0, 0, 0, 10%);
-  border-radius: 0.5rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-`;
-
-const PreviewOverlay = styled.div`
-  position: absolute;
-  inset: 0;
-  z-index: 1;
-  background: black;
-  opacity: 0.3;
-`;
-
-const PreviewReportPages = styled.div`
-  section {
-    background: white;
-    position: relative;
-    box-shadow: 0 3px 10px rgb(0, 0, 0, 20%);
-    margin-top: 1rem;
-    margin-bottom: 2rem;
-    width: 8.5in;
-    min-height: 11in;
-    padding: 0.5in;
-  }
-`;
-
-const PreviewActionContainer = styled.div`
-  position: absolute;
-  inset: 0;
-  margin-left: auto;
-  margin-right: auto;
-  margin-top: 4rem;
-  display: flex;
-  justify-content: center;
-  align-items: start;
-  z-index: 2;
-`;
-
-const LoadingTextContainer = styled.div`
-  background: white;
-  width: 35rem;
-  border-radius: 0.5rem;
-`;
-
-const NoResultsNotice = styled(H5)`
-  margin-top: 2rem;
-`;
+import {
+  ExportActions,
+  NoResultsNotice,
+  PaginationNote,
+  PreviewActionContainer,
+  PreviewContainer,
+  PreviewLoading,
+  PreviewOverlay,
+  PreviewReportPages,
+} from './shared';
 
 function Reports({
   electionDefinition,
@@ -339,11 +282,7 @@ export function TallyReportViewer({
           disabled={disabled || areQueryResultsEmpty}
         />
       </ExportActions>
-
-      <Caption>
-        <Icons.Info /> <Font weight="bold">Note:</Font> Printed reports may be
-        paginated to more than one piece of paper.
-      </Caption>
+      <PaginationNote />
       <PreviewContainer>
         {!disabled && (
           <React.Fragment>
@@ -356,13 +295,7 @@ export function TallyReportViewer({
               </NoResultsNotice>
             )}
             {!previewIsFresh && <PreviewOverlay />}
-            {isFetchingForPreview && (
-              <PreviewActionContainer>
-                <LoadingTextContainer>
-                  <Loading>Generating Report</Loading>
-                </LoadingTextContainer>
-              </PreviewActionContainer>
-            )}
+            {isFetchingForPreview && <PreviewLoading />}
             {!isFetchingForPreview && !previewIsFresh && (
               <PreviewActionContainer>
                 {previewReport ? (

--- a/apps/admin/frontend/src/screens/reporting/all_precincts_tally_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/all_precincts_tally_report_screen.tsx
@@ -1,11 +1,11 @@
-import { Icons, LinkButton, P } from '@votingworks/ui';
+import { P } from '@votingworks/ui';
 import { useContext } from 'react';
 import { assert } from '@votingworks/basics';
 import { isElectionManagerAuth } from '@votingworks/utils';
 import { AppContext } from '../../contexts/app_context';
 import { NavigationScreen } from '../../components/navigation_screen';
-import { routerPaths } from '../../router_paths';
 import { TallyReportViewer } from '../../components/reporting/tally_report_viewer';
+import { ReportBackButton } from '../../components/reporting/shared';
 
 export const SCREEN_TITLE = 'All Precincts Tally Report';
 
@@ -17,9 +17,7 @@ export function AllPrecinctsTallyReportScreen(): JSX.Element {
   return (
     <NavigationScreen title={SCREEN_TITLE}>
       <P>
-        <LinkButton small to={routerPaths.reports}>
-          <Icons.Previous /> Back
-        </LinkButton>
+        <ReportBackButton />
       </P>
       <TallyReportViewer
         filter={{}}

--- a/apps/admin/frontend/src/screens/reporting/ballot_count_report_builder.tsx
+++ b/apps/admin/frontend/src/screens/reporting/ballot_count_report_builder.tsx
@@ -1,4 +1,4 @@
-import { Font, H3, Icons, LinkButton, P } from '@votingworks/ui';
+import { Font, H3, P } from '@votingworks/ui';
 import { useContext, useState } from 'react';
 import { assert } from '@votingworks/basics';
 import {
@@ -10,7 +10,6 @@ import { Tabulation } from '@votingworks/types';
 import styled from 'styled-components';
 import { AppContext } from '../../contexts/app_context';
 import { NavigationScreen } from '../../components/navigation_screen';
-import { routerPaths } from '../../router_paths';
 import {
   FilterEditor,
   FilterType,
@@ -21,6 +20,7 @@ import {
 } from '../../components/reporting/group_by_editor';
 import { canonicalizeFilter, canonicalizeGroupBy } from '../../utils/reporting';
 import { BallotCountReportViewer } from '../../components/reporting/ballot_count_report_viewer';
+import { ReportBackButton } from '../../components/reporting/shared';
 
 const SCREEN_TITLE = 'Ballot Count Report Builder';
 
@@ -75,9 +75,7 @@ export function BallotCountReportBuilder(): JSX.Element {
   return (
     <NavigationScreen title={SCREEN_TITLE}>
       <P>
-        <LinkButton small to={routerPaths.reports}>
-          <Icons.Previous /> Back
-        </LinkButton>
+        <ReportBackButton />
       </P>
       <P>
         Use the report builder to create custom reports for print or export.

--- a/apps/admin/frontend/src/screens/reporting/full_election_tally_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/full_election_tally_report_screen.tsx
@@ -1,18 +1,17 @@
 import React, { useContext, useState } from 'react';
 import { isElectionManagerAuth } from '@votingworks/utils';
 import { assert } from '@votingworks/basics';
-import { Button, Icons, LinkButton, Modal, P } from '@votingworks/ui';
+import { Button, Modal, P } from '@votingworks/ui';
 
 import styled from 'styled-components';
 import { AppContext } from '../../contexts/app_context';
 
 import { NavigationScreen } from '../../components/navigation_screen';
 
-import { routerPaths } from '../../router_paths';
-
 import { getCastVoteRecordFileMode, markResultsOfficial } from '../../api';
 import { Loading } from '../../components/loading';
 import { TallyReportViewer } from '../../components/reporting/tally_report_viewer';
+import { ReportBackButton } from '../../components/reporting/shared';
 
 const SCREEN_TITLE = 'Full Election Tally Report';
 
@@ -58,9 +57,7 @@ export function FullElectionTallyReportScreen(): JSX.Element {
     <React.Fragment>
       <NavigationScreen title={SCREEN_TITLE}>
         <TopButtonBar>
-          <LinkButton small to={routerPaths.reports}>
-            <Icons.Previous /> Back
-          </LinkButton>{' '}
+          <ReportBackButton />{' '}
           <Button
             disabled={!canMarkResultsOfficial}
             onPress={openMarkOfficialModal}

--- a/apps/admin/frontend/src/screens/reporting/precinct_ballot_count_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/precinct_ballot_count_report_screen.tsx
@@ -1,11 +1,11 @@
-import { Icons, LinkButton, P } from '@votingworks/ui';
+import { P } from '@votingworks/ui';
 import { useContext } from 'react';
 import { assert } from '@votingworks/basics';
 import { isElectionManagerAuth } from '@votingworks/utils';
 import { AppContext } from '../../contexts/app_context';
 import { NavigationScreen } from '../../components/navigation_screen';
-import { routerPaths } from '../../router_paths';
 import { BallotCountReportViewer } from '../../components/reporting/ballot_count_report_viewer';
+import { ReportBackButton } from '../../components/reporting/shared';
 
 export const SCREEN_TITLE = 'Precinct Ballot Count Report';
 
@@ -17,9 +17,7 @@ export function PrecinctBallotCountReport(): JSX.Element {
   return (
     <NavigationScreen title={SCREEN_TITLE}>
       <P>
-        <LinkButton small to={routerPaths.reports}>
-          <Icons.Previous /> Back
-        </LinkButton>
+        <ReportBackButton />
       </P>
       <BallotCountReportViewer
         filter={{}}

--- a/apps/admin/frontend/src/screens/reporting/single_precinct_tally_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/single_precinct_tally_report_screen.tsx
@@ -1,12 +1,12 @@
-import { Icons, LinkButton, P, SearchSelect } from '@votingworks/ui';
+import { P, SearchSelect } from '@votingworks/ui';
 import { useContext, useState } from 'react';
 import { assert } from '@votingworks/basics';
 import { isElectionManagerAuth } from '@votingworks/utils';
 import styled from 'styled-components';
 import { AppContext } from '../../contexts/app_context';
 import { NavigationScreen } from '../../components/navigation_screen';
-import { routerPaths } from '../../router_paths';
 import { TallyReportViewer } from '../../components/reporting/tally_report_viewer';
+import { ReportBackButton } from '../../components/reporting/shared';
 
 export const SCREEN_TITLE = 'Single Precinct Tally Report';
 
@@ -33,9 +33,7 @@ export function SinglePrecinctTallyReportScreen(): JSX.Element {
   return (
     <NavigationScreen title={SCREEN_TITLE}>
       <P>
-        <LinkButton small to={routerPaths.reports}>
-          <Icons.Previous /> Back
-        </LinkButton>
+        <ReportBackButton />
       </P>
       <SelectPrecinctContainer>
         <P>Select Precinct:</P>

--- a/apps/admin/frontend/src/screens/reporting/tally_report_builder.tsx
+++ b/apps/admin/frontend/src/screens/reporting/tally_report_builder.tsx
@@ -1,4 +1,4 @@
-import { Font, H3, Icons, LinkButton, P } from '@votingworks/ui';
+import { Font, H3, P } from '@votingworks/ui';
 import { useContext, useState } from 'react';
 import { assert } from '@votingworks/basics';
 import {
@@ -10,11 +10,11 @@ import { Tabulation } from '@votingworks/types';
 import styled from 'styled-components';
 import { AppContext } from '../../contexts/app_context';
 import { NavigationScreen } from '../../components/navigation_screen';
-import { routerPaths } from '../../router_paths';
 import { FilterEditor } from '../../components/reporting/filter_editor';
 import { GroupByEditor } from '../../components/reporting/group_by_editor';
 import { TallyReportViewer } from '../../components/reporting/tally_report_viewer';
 import { canonicalizeFilter, canonicalizeGroupBy } from '../../utils/reporting';
+import { ReportBackButton } from '../../components/reporting/shared';
 
 const SCREEN_TITLE = 'Tally Report Builder';
 
@@ -50,9 +50,7 @@ export function TallyReportBuilder(): JSX.Element {
   return (
     <NavigationScreen title={SCREEN_TITLE}>
       <P>
-        <LinkButton small to={routerPaths.reports}>
-          <Icons.Previous /> Back
-        </LinkButton>
+        <ReportBackButton />
       </P>
       <P>
         Use the report builder to create custom reports for print or export.

--- a/apps/admin/frontend/src/screens/reporting/voting_method_ballot_count_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/voting_method_ballot_count_report_screen.tsx
@@ -1,11 +1,11 @@
-import { Icons, LinkButton, P } from '@votingworks/ui';
+import { P } from '@votingworks/ui';
 import { useContext } from 'react';
 import { assert } from '@votingworks/basics';
 import { isElectionManagerAuth } from '@votingworks/utils';
 import { AppContext } from '../../contexts/app_context';
 import { NavigationScreen } from '../../components/navigation_screen';
-import { routerPaths } from '../../router_paths';
 import { BallotCountReportViewer } from '../../components/reporting/ballot_count_report_viewer';
+import { ReportBackButton } from '../../components/reporting/shared';
 
 export const SCREEN_TITLE = 'Voting Method Ballot Count Report';
 
@@ -17,9 +17,7 @@ export function VotingMethodBallotCountReport(): JSX.Element {
   return (
     <NavigationScreen title={SCREEN_TITLE}>
       <P>
-        <LinkButton small to={routerPaths.reports}>
-          <Icons.Previous /> Back
-        </LinkButton>
+        <ReportBackButton />
       </P>
       <BallotCountReportViewer
         filter={{}}

--- a/apps/admin/frontend/src/screens/reporting/write_in_adjudication_report_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/write_in_adjudication_report_screen.test.tsx
@@ -7,14 +7,14 @@ import {
 import { fakeLogger, Logger } from '@votingworks/logging';
 
 import userEvent from '@testing-library/user-event';
-import { renderInAppContext } from '../../test/render_in_app_context';
-import { ApiMock, createApiMock } from '../../test/helpers/mock_api_client';
+import { renderInAppContext } from '../../../test/render_in_app_context';
+import { ApiMock, createApiMock } from '../../../test/helpers/mock_api_client';
 import { TallyWriteInReportScreen } from './write_in_adjudication_report_screen';
 import {
   screen,
   waitForElementToBeRemoved,
   within,
-} from '../../test/react_testing_library';
+} from '../../../test/react_testing_library';
 
 let mockKiosk: jest.Mocked<KioskBrowser.Kiosk>;
 let logger: Logger;

--- a/apps/admin/frontend/src/screens/reporting/write_in_adjudication_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/write_in_adjudication_report_screen.tsx
@@ -81,12 +81,7 @@ export function TallyWriteInReportScreen(): JSX.Element {
   );
 
   return (
-    <NavigationScreen
-      title={
-        `${isOfficialResults ? 'Official' : 'Unofficial'} ` +
-        `Write-In Adjudication Report`
-      }
-    >
+    <NavigationScreen title="Write-In Adjudication Report">
       <P>
         <ReportBackButton />
       </P>

--- a/apps/admin/frontend/src/screens/reporting/write_in_adjudication_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/write_in_adjudication_report_screen.tsx
@@ -8,12 +8,12 @@ import {
   P,
   WriteInAdjudicationReport,
 } from '@votingworks/ui';
-import { generateDefaultReportFilename } from '../utils/save_as_pdf';
-import { AppContext } from '../contexts/app_context';
-import { NavigationScreen } from '../components/navigation_screen';
-import { FileType } from '../components/save_frontend_file_modal';
-import { PrintButton } from '../components/print_button';
-import { getElectionWriteInSummary } from '../api';
+import { generateDefaultReportFilename } from '../../utils/save_as_pdf';
+import { AppContext } from '../../contexts/app_context';
+import { NavigationScreen } from '../../components/navigation_screen';
+import { FileType } from '../../components/save_frontend_file_modal';
+import { PrintButton } from '../../components/print_button';
+import { getElectionWriteInSummary } from '../../api';
 import {
   ExportActions,
   PaginationNote,
@@ -21,8 +21,8 @@ import {
   PreviewLoading,
   PreviewReportPages,
   ReportBackButton,
-} from '../components/reporting/shared';
-import { ExportReportPdfButton } from '../components/reporting/export_report_pdf_button';
+} from '../../components/reporting/shared';
+import { ExportReportPdfButton } from '../../components/reporting/export_report_pdf_button';
 
 export function TallyWriteInReportScreen(): JSX.Element {
   const { electionDefinition, isOfficialResults, auth, logger } =

--- a/apps/admin/frontend/src/screens/write_in_adjudication_report_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/write_in_adjudication_report_screen.test.tsx
@@ -7,12 +7,14 @@ import {
 import { fakeLogger, Logger } from '@votingworks/logging';
 
 import userEvent from '@testing-library/user-event';
-import { createMemoryHistory } from 'history';
 import { renderInAppContext } from '../../test/render_in_app_context';
 import { ApiMock, createApiMock } from '../../test/helpers/mock_api_client';
 import { TallyWriteInReportScreen } from './write_in_adjudication_report_screen';
-import { screen, within } from '../../test/react_testing_library';
-import { routerPaths } from '../router_paths';
+import {
+  screen,
+  waitForElementToBeRemoved,
+  within,
+} from '../../test/react_testing_library';
 
 let mockKiosk: jest.Mocked<KioskBrowser.Kiosk>;
 let logger: Logger;
@@ -59,15 +61,12 @@ test('renders provided data', async () => {
       },
     },
   });
-  const history = createMemoryHistory();
   renderInAppContext(<TallyWriteInReportScreen />, {
     electionDefinition,
     logger,
     apiMock,
-    history,
   });
 
-  screen.getByText('Report Preview');
   const report = await screen.findByTestId('write-in-tally-report');
   within(report).getByText(
     'Unofficial General Election Write-In Adjudication Report'
@@ -85,9 +84,8 @@ test('renders provided data', async () => {
       printed.getByText('Random Write-In').closest('tr')!
     ).toHaveTextContent('15');
   });
+  await waitForElementToBeRemoved(screen.getByRole('alertdialog'));
 
-  screen.getByText('Save Report as PDF');
-
-  userEvent.click(screen.getByText('Back to Reports'));
-  expect(history.location.pathname).toEqual(routerPaths.reports);
+  expect(screen.getButton('Back')).toBeEnabled();
+  expect(screen.getButton('Export Report PDF')).toBeEnabled();
 });

--- a/apps/admin/frontend/src/screens/write_in_adjudication_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/write_in_adjudication_report_screen.tsx
@@ -1,9 +1,8 @@
-import React, { useContext, useState, useMemo } from 'react';
+import { useContext, useMemo } from 'react';
 import { isElectionManagerAuth } from '@votingworks/utils';
 import { assert, assertDefined } from '@votingworks/basics';
 import { LogEventId } from '@votingworks/logging';
 import {
-  Button,
   printElement,
   printElementToPdf,
   P,
@@ -12,10 +11,7 @@ import {
 import { generateDefaultReportFilename } from '../utils/save_as_pdf';
 import { AppContext } from '../contexts/app_context';
 import { NavigationScreen } from '../components/navigation_screen';
-import {
-  SaveFrontendFileModal,
-  FileType,
-} from '../components/save_frontend_file_modal';
+import { FileType } from '../components/save_frontend_file_modal';
 import { PrintButton } from '../components/print_button';
 import { getElectionWriteInSummary } from '../api';
 import {
@@ -26,6 +22,7 @@ import {
   PreviewReportPages,
   ReportBackButton,
 } from '../components/reporting/shared';
+import { ExportReportPdfButton } from '../components/reporting/export_report_pdf_button';
 
 export function TallyWriteInReportScreen(): JSX.Element {
   const { electionDefinition, isOfficialResults, auth, logger } =
@@ -36,8 +33,6 @@ export function TallyWriteInReportScreen(): JSX.Element {
   const userRole = auth.user.role;
 
   const writeInSummaryQuery = getElectionWriteInSummary.useQuery();
-
-  const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
 
   const report = useMemo(() => {
     if (!writeInSummaryQuery.isSuccess) return undefined;
@@ -79,50 +74,42 @@ export function TallyWriteInReportScreen(): JSX.Element {
     }
   }
 
-  const defaultReportFilename = generateDefaultReportFilename(
+  const reportPdfFilename = generateDefaultReportFilename(
     'write-in-adjudication-report',
     election,
     'full'
   );
 
   return (
-    <React.Fragment>
-      <NavigationScreen
-        title={
-          `${isOfficialResults ? 'Official' : 'Unofficial'} ` +
-          `Write-In Adjudication Report`
-        }
-      >
-        <P>
-          <ReportBackButton />
-        </P>
-        <ExportActions>
-          <PrintButton disabled={!report} print={printReport} variant="primary">
-            Print Report
-          </PrintButton>{' '}
-          {window.kiosk && (
-            <Button disabled={!report} onPress={() => setIsSaveModalOpen(true)}>
-              Save Report as PDF
-            </Button>
-          )}
-        </ExportActions>
-        <PaginationNote />
-        <PreviewContainer>
-          {report ? (
-            <PreviewReportPages>{report}</PreviewReportPages>
-          ) : (
-            <PreviewLoading />
-          )}
-        </PreviewContainer>
-      </NavigationScreen>
-      {isSaveModalOpen && (
-        <SaveFrontendFileModal
-          onClose={() => setIsSaveModalOpen(false)}
-          generateFileContent={() => printElementToPdf(assertDefined(report))}
-          defaultFilename={defaultReportFilename}
+    <NavigationScreen
+      title={
+        `${isOfficialResults ? 'Official' : 'Unofficial'} ` +
+        `Write-In Adjudication Report`
+      }
+    >
+      <P>
+        <ReportBackButton />
+      </P>
+      <ExportActions>
+        <PrintButton disabled={!report} print={printReport} variant="primary">
+          Print Report
+        </PrintButton>{' '}
+        <ExportReportPdfButton
+          electionDefinition={electionDefinition}
+          generateReportPdf={() => printElementToPdf(assertDefined(report))}
+          defaultFilename={reportPdfFilename}
+          disabled={!report}
           fileType={FileType.WriteInAdjudicationReport}
         />
-      )}
-    </React.Fragment>
+      </ExportActions>
+      <PaginationNote />
+      <PreviewContainer>
+        {report ? (
+          <PreviewReportPages>{report}</PreviewReportPages>
+        ) : (
+          <PreviewLoading />
+        )}
+      </PreviewContainer>
+    </NavigationScreen>
   );
 }

--- a/apps/admin/frontend/src/screens/write_in_adjudication_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/write_in_adjudication_report_screen.tsx
@@ -3,29 +3,29 @@ import { isElectionManagerAuth } from '@votingworks/utils';
 import { assert, assertDefined } from '@votingworks/basics';
 import { LogEventId } from '@votingworks/logging';
 import {
-  TallyReportPreview,
-  TallyReportMetadata,
   Button,
   printElement,
   printElementToPdf,
-  LinkButton,
   P,
-  Caption,
-  Font,
-  H2,
   WriteInAdjudicationReport,
-  ReportPreviewLoading,
 } from '@votingworks/ui';
 import { generateDefaultReportFilename } from '../utils/save_as_pdf';
 import { AppContext } from '../contexts/app_context';
 import { NavigationScreen } from '../components/navigation_screen';
-import { routerPaths } from '../router_paths';
 import {
   SaveFrontendFileModal,
   FileType,
 } from '../components/save_frontend_file_modal';
 import { PrintButton } from '../components/print_button';
 import { getElectionWriteInSummary } from '../api';
+import {
+  ExportActions,
+  PaginationNote,
+  PreviewContainer,
+  PreviewLoading,
+  PreviewReportPages,
+  ReportBackButton,
+} from '../components/reporting/shared';
 
 export function TallyWriteInReportScreen(): JSX.Element {
   const { electionDefinition, isOfficialResults, auth, logger } =
@@ -93,13 +93,10 @@ export function TallyWriteInReportScreen(): JSX.Element {
           `Write-In Adjudication Report`
         }
       >
-        <TallyReportMetadata
-          generatedAtTime={
-            report ? new Date(writeInSummaryQuery.dataUpdatedAt) : undefined
-          }
-          election={election}
-        />
         <P>
+          <ReportBackButton />
+        </P>
+        <ExportActions>
           <PrintButton disabled={!report} print={printReport} variant="primary">
             Print Report
           </PrintButton>{' '}
@@ -108,27 +105,15 @@ export function TallyWriteInReportScreen(): JSX.Element {
               Save Report as PDF
             </Button>
           )}
-        </P>
-        <P>
-          <LinkButton small to={routerPaths.reports}>
-            Back to Reports
-          </LinkButton>
-        </P>
-
-        <React.Fragment>
-          <H2>Report Preview</H2>
-          <Caption>
-            <Font weight="bold">Note:</Font> Printed reports may be paginated to
-            more than one piece of paper.
-          </Caption>
+        </ExportActions>
+        <PaginationNote />
+        <PreviewContainer>
           {report ? (
-            <TallyReportPreview data-testid="report-preview">
-              {report}
-            </TallyReportPreview>
+            <PreviewReportPages>{report}</PreviewReportPages>
           ) : (
-            <ReportPreviewLoading />
+            <PreviewLoading />
           )}
-        </React.Fragment>
+        </PreviewContainer>
       </NavigationScreen>
       {isSaveModalOpen && (
         <SaveFrontendFileModal


### PR DESCRIPTION
review by commit

## Overview

Closes #4071. During the reporting revamp, all the report pages got a new look. Except the WIA report page. This PR makes it look similar to the other pages.

#### Example Tally Report Page

<img width="1154" alt="Screen Shot 2023-10-24 at 12 31 37 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/e14ff370-09ec-4fcd-9811-f4a7ea4ad91a">

#### Former WIA Report PAge

<img width="1157" alt="Screen Shot 2023-10-24 at 12 31 22 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/6ee95f60-544f-4e9c-89ae-0a3698ef3dfd">

#### New WIA Report Page

<img width="1155" alt="Screen Shot 2023-10-24 at 12 35 05 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/1e3c982b-2f78-4b40-80bd-a5493afe906b">

## Testing Plan

Manually tested print and PDF export to confirm refactor didn't break anything.

## Checklist

- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
