### PR TITLE
bump continuous export test timeout

### DIFF
--- a/apps/scan/backend/src/app_config.test.ts
+++ b/apps/scan/backend/src/app_config.test.ts
@@ -38,7 +38,7 @@ import { CVR, ElectionDefinition } from '@votingworks/types';
 import { configureApp } from '../test/helpers/shared_helpers';
 import { scanBallot, withApp } from '../test/helpers/custom_helpers';
 
-jest.setTimeout(20_000);
+jest.setTimeout(30_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 


### PR DESCRIPTION
test is being flaky with a confusing error message ([example](https://app.circleci.com/pipelines/github/votingworks/vxsuite/12630/workflows/f3c18897-8403-4dc0-b88c-8afd281142d7/jobs/427840)), but i'm guessing it's just due to test timeout. bumping