### PR TITLE
admin(feat): include manual results when grouping by scanner or batch

### DIFF
--- a/apps/admin/backend/src/exports/csv_shared.ts
+++ b/apps/admin/backend/src/exports/csv_shared.ts
@@ -255,8 +255,11 @@ export function getCsvMetadataRowValues({
         return assertOnlyElement(filter.scannerIds);
       }
 
-      return assertDefined(batchLookup[assertOnlyElement(filter.batchIds)])
-        .scannerId;
+      const batchId = assertOnlyElement(filter.batchIds);
+      if (batchId === Tabulation.MANUAL_BATCH_ID) {
+        return Tabulation.MANUAL_SCANNER_ID;
+      }
+      return assertDefined(batchLookup[batchId]).scannerId;
     })();
     values.push(scannerId);
   }

--- a/apps/admin/backend/src/exports/csv_tally_report.ts
+++ b/apps/admin/backend/src/exports/csv_tally_report.ts
@@ -10,6 +10,7 @@ import {
 import { Optional, assert, assertDefined } from '@votingworks/basics';
 import {
   combineGroupSpecifierAndFilter,
+  getEmptyElectionResults,
   getTallyReportCandidateRows,
   groupMapToGroupList,
   mergeTabulationGroupMaps,
@@ -261,9 +262,8 @@ export async function generateTallyReportCsv({
         allScannedResults,
         allManualResults,
         (scannedResults, manualResults) => {
-          assert(scannedResults);
           return {
-            scannedResults,
+            scannedResults: scannedResults ?? getEmptyElectionResults(election),
             manualResults,
           };
         }

--- a/apps/admin/backend/src/tabulation/card_counts.test.ts
+++ b/apps/admin/backend/src/tabulation/card_counts.test.ts
@@ -280,25 +280,7 @@ test('tabulateFullCardCounts - manual results', () => {
     }),
   });
 
-  // manual ballot counts should be ignored if incompatible with parameters
-  const batchCardCounts = groupMapToGroupList(
-    tabulateFullCardCounts({
-      electionId,
-      store,
-      groupBy: {
-        groupByBatch: true,
-      },
-    })
-  );
-  expect(batchCardCounts).toEqual([
-    {
-      batchId: 'batch-1',
-      bmd: 30,
-      hmpb: [],
-    },
-  ]);
-
-  // manual ballot counts should be merged into results if compatible with parameters
+  // Case 1: manual ballot counts should be merged into results if compatible with parameters
   const precinctCardCounts = groupMapToGroupList(
     tabulateFullCardCounts({
       electionId,
@@ -344,6 +326,46 @@ test('tabulateFullCardCounts - manual results', () => {
       hmpb: [],
       manual: 20,
       votingMethod: 'absentee',
+    },
+  ]);
+
+  // Case 2: manual ballot counts should excluded separately if incompatible with filter
+  const scannerCardCounts = groupMapToGroupList(
+    tabulateFullCardCounts({
+      electionId,
+      store,
+      filter: { scannerIds: ['scanner-1'] },
+    })
+  );
+  expect(scannerCardCounts).toEqual([
+    {
+      bmd: 30,
+      hmpb: [],
+    },
+  ]);
+
+  // Case 3: manual ballot counts should included separately if incompatible with grouping
+  const byBatchCardCounts = groupMapToGroupList(
+    tabulateFullCardCounts({
+      electionId,
+      store,
+      groupBy: {
+        groupByBatch: true,
+      },
+    })
+  );
+  expect(byBatchCardCounts).toEqual([
+    {
+      batchId: 'batch-1',
+      bmd: 30,
+      hmpb: [],
+      manual: 0,
+    },
+    {
+      batchId: Tabulation.MANUAL_BATCH_ID,
+      bmd: 0,
+      hmpb: [],
+      manual: 20,
     },
   ]);
 });

--- a/apps/admin/backend/src/tabulation/card_counts.ts
+++ b/apps/admin/backend/src/tabulation/card_counts.ts
@@ -7,7 +7,6 @@ import {
   isGroupByEmpty,
   mergeTabulationGroupMaps,
 } from '@votingworks/utils';
-import { assertDefined } from '@votingworks/basics';
 import { CardTally } from '../types';
 import { Store } from '../store';
 import { tabulateManualBallotCounts } from './manual_results';
@@ -160,7 +159,7 @@ export function tabulateFullCardCounts({
     groupedManualBallotCounts,
     (scannedCardCounts, manualBallotCount) => {
       return {
-        ...assertDefined(scannedCardCounts),
+        ...(scannedCardCounts ?? getEmptyCardCounts()),
         manual: manualBallotCount ?? 0,
       };
     }

--- a/apps/admin/backend/src/tabulation/tally_reports.ts
+++ b/apps/admin/backend/src/tabulation/tally_reports.ts
@@ -5,6 +5,8 @@ import {
   combineElectionResults,
   combineGroupSpecifierAndFilter,
   combineManualElectionResults,
+  getEmptyCardCounts,
+  getEmptyElectionResults,
   groupMapToGroupList,
   mergeTabulationGroupMaps,
 } from '@votingworks/utils';
@@ -93,7 +95,7 @@ export async function tabulateTallyReportResults({
     groupBy: primarySensitiveGroupBy,
   });
   if (manualTabulationResult.isErr()) {
-    debug('filter or group by is not compatible with manual results');
+    debug('filter is not compatible with manual results');
   } else {
     allManualResults = manualTabulationResult.ok();
   }
@@ -106,13 +108,12 @@ export async function tabulateTallyReportResults({
       allScannedResults,
       allManualResults,
       (scannedResults, manualResults) => {
-        assert(scannedResults);
         return {
-          scannedResults,
+          scannedResults: scannedResults || getEmptyElectionResults(election),
           manualResults,
           hasPartySplits: false,
           cardCounts: {
-            ...scannedResults.cardCounts,
+            ...(scannedResults?.cardCounts ?? getEmptyCardCounts()),
             manual: manualResults?.ballotCount,
           },
         };

--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -419,17 +419,6 @@ export type ManualResultsFilter = Omit<
 >;
 
 /**
- * Subset of cast vote record groupings that we can group manual results on.
- */
-export type ManualResultsGroupBy = Pick<
-  Tabulation.GroupBy,
-  | 'groupByBallotStyle'
-  | 'groupByParty'
-  | 'groupByPrecinct'
-  | 'groupByVotingMethod'
->;
-
-/**
  * Subset of tabulation filters that we can use to directly filter cast
  * vote records.
  */

--- a/apps/admin/frontend/src/utils/reporting.test.ts
+++ b/apps/admin/frontend/src/utils/reporting.test.ts
@@ -162,6 +162,25 @@ test('generateTitleForReport', () => {
       },
       'Precinct 1 Scanner VX-00-001 Tally Report',
     ],
+    [
+      {
+        batchIds: [Tabulation.MANUAL_BATCH_ID],
+      },
+      'Manual Batch Tally Report',
+    ],
+    [
+      {
+        batchIds: [Tabulation.MANUAL_BATCH_ID],
+        scannerIds: [Tabulation.MANUAL_SCANNER_ID],
+      },
+      'Manual Batch Tally Report',
+    ],
+    [
+      {
+        scannerIds: [Tabulation.MANUAL_SCANNER_ID],
+      },
+      'Manual Batch Tally Report',
+    ],
   ];
 
   for (const [filter, title] of supportedFilters) {

--- a/apps/admin/frontend/src/utils/reporting.ts
+++ b/apps/admin/frontend/src/utils/reporting.ts
@@ -42,7 +42,11 @@ function getFilterRank(filter: Tabulation.Filter): number {
   );
 }
 
-export const BATCH_ID_TRUNCATE_LENGTH = 8;
+function getBatchLabel(batchId: string): string {
+  return `Batch ${batchId.slice(0, Tabulation.BATCH_ID_DISPLAY_LENGTH)}`;
+}
+
+const MANUAL_BATCH_REPORT_LABEL = 'Manual Batch';
 
 /**
  * Attempts to generate a title for an individual report based on its filter.
@@ -96,16 +100,27 @@ export function generateTitleForReport({
     }
 
     if (batchId) {
-      const batch = find(scannerBatches, (b) => b.batchId === batchId);
+      if (batchId === Tabulation.MANUAL_BATCH_ID) {
+        return ok(`${MANUAL_BATCH_REPORT_LABEL} ${reportType} Report`);
+      }
+
+      const { scannerId: resolvedScannerId } = find(
+        scannerBatches,
+        (b) => b.batchId === batchId
+      );
+
       return ok(
-        `Scanner ${batch.scannerId} Batch ${batch.batchId.slice(
-          0,
-          BATCH_ID_TRUNCATE_LENGTH
+        `Scanner ${resolvedScannerId} ${getBatchLabel(
+          batchId
         )} ${reportType} Report`
       );
     }
 
     if (scannerId) {
+      if (scannerId === Tabulation.MANUAL_SCANNER_ID) {
+        return ok(`${MANUAL_BATCH_REPORT_LABEL} ${reportType} Report`);
+      }
+
       return ok(`Scanner ${scannerId} ${reportType} Report`);
     }
 
@@ -182,11 +197,12 @@ export function generateTitleForReport({
     // Other Combinations
 
     if (scannerId && batchId) {
+      if (batchId === Tabulation.MANUAL_BATCH_ID) {
+        return ok(`${MANUAL_BATCH_REPORT_LABEL} ${reportType} Report`);
+      }
+
       return ok(
-        `Scanner ${scannerId} Batch ${batchId.slice(
-          0,
-          BATCH_ID_TRUNCATE_LENGTH
-        )} ${reportType} Report`
+        `Scanner ${scannerId} ${getBatchLabel(batchId)} ${reportType} Report`
       );
     }
   }
@@ -306,7 +322,9 @@ function generateReportFilenameFilterPrefix({
   }
 
   if (batchId) {
-    filterPrefixes.push(`batch-${batchId.slice(0, BATCH_ID_TRUNCATE_LENGTH)}`);
+    filterPrefixes.push(
+      `batch-${batchId.slice(0, Tabulation.BATCH_ID_DISPLAY_LENGTH)}`
+    );
   }
 
   return filterPrefixes.join(WORD_SEPARATOR);

--- a/libs/types/src/tabulation.ts
+++ b/libs/types/src/tabulation.ts
@@ -90,6 +90,9 @@ export interface CastVoteRecordAttributes {
  */
 export type Card = { type: 'bmd' } | { type: 'hmpb'; sheetNumber: number };
 
+export const MANUAL_BATCH_ID = 'NO_BATCH__MANUAL';
+export const MANUAL_SCANNER_ID = 'NO_SCANNER__MANUAL';
+
 /**
  * In situations where we're generating grouped results, specifiers can be
  * included in {@link ElectionResults} to indicate what it is a grouping of.

--- a/libs/ui/src/reports/ballot_count_report.test.tsx
+++ b/libs/ui/src/reports/ballot_count_report.test.tsx
@@ -284,6 +284,73 @@ test('shows manual counts', () => {
   expect(footer).toEqual(expectedFooter);
 });
 
+test('shows separate manual rows when group by is not compatible with manual results', () => {
+  const electionDefinition = electionTwoPartyPrimaryDefinition;
+
+  const batchCardCountsList: Tabulation.GroupList<Tabulation.CardCounts> = [
+    {
+      ...cc(3),
+      batchId: 'batch-10',
+    },
+    {
+      ...cc(0, 2),
+      batchId: Tabulation.MANUAL_BATCH_ID,
+    },
+  ];
+
+  render(
+    <BallotCountReport
+      title="Full Election Ballot Count Report"
+      electionDefinition={electionDefinition}
+      scannerBatches={mockScannerBatches}
+      groupBy={{
+        groupByBatch: true,
+      }}
+      cardCountsList={batchCardCountsList}
+    />
+  );
+
+  const expectedColumns: Column[] = [
+    'scanner',
+    'batch',
+    'center-fill',
+    'manual',
+    'bmd',
+    'hmpb',
+    'total',
+    'right-fill',
+  ];
+  const expectedRows: RowData[] = [
+    {
+      scanner: 'scanner-1',
+      batch: 'batch-10',
+      manual: '0',
+      bmd: '3',
+      hmpb: '0',
+      total: '3',
+    },
+    {
+      scanner: 'Manual',
+      batch: 'Manual',
+      manual: '2',
+      bmd: '0',
+      hmpb: '0',
+      total: '2',
+    },
+  ];
+  const expectedFooter: RowData = {
+    manual: '2',
+    bmd: '3',
+    hmpb: '0',
+    total: '5',
+  };
+
+  const { columns, rows, footer } = parseGrid({ expectFooter: true });
+  expect(columns).toEqual(expectedColumns);
+  expect(rows).toEqual(expectedRows);
+  expect(footer).toEqual(expectedFooter);
+});
+
 test('ungrouped case', () => {
   const electionDefinition = electionTwoPartyPrimaryDefinition;
 

--- a/libs/ui/src/reports/ballot_count_report.tsx
+++ b/libs/ui/src/reports/ballot_count_report.tsx
@@ -202,6 +202,16 @@ function getCellClass(column: Column): Optional<string> {
   }
 }
 
+function getBatchLabel(batchId: string): string {
+  return batchId === Tabulation.MANUAL_BATCH_ID
+    ? 'Manual'
+    : batchId.slice(0, Tabulation.BATCH_ID_DISPLAY_LENGTH);
+}
+
+function getScannerLabel(scannerId: string): string {
+  return scannerId === Tabulation.MANUAL_SCANNER_ID ? 'Manual' : scannerId;
+}
+
 function BallotCountTable({
   electionDefinition,
   scannerBatches,
@@ -282,7 +292,9 @@ function BallotCountTable({
         const partyId = determinePartyId(electionDefinition, cardCounts);
         const scannerId =
           cardCounts.scannerId ??
-          (cardCounts.batchId
+          (cardCounts.batchId === Tabulation.MANUAL_BATCH_ID
+            ? Tabulation.MANUAL_SCANNER_ID
+            : cardCounts.batchId
             ? batchLookup[cardCounts.batchId].scannerId
             : undefined);
         const rowKey = getGroupKey(cardCounts, groupBy);
@@ -313,13 +325,10 @@ function BallotCountTable({
                     ];
                   break;
                 case 'scanner':
-                  content = assertDefined(scannerId);
+                  content = getScannerLabel(assertDefined(scannerId));
                   break;
                 case 'batch':
-                  content = assertDefined(cardCounts.batchId).slice(
-                    0,
-                    Tabulation.BATCH_ID_DISPLAY_LENGTH
-                  );
+                  content = getBatchLabel(assertDefined(cardCounts.batchId));
                   break;
                 case 'center-fill':
                 case 'right-fill':

--- a/libs/ui/src/reports/ballot_count_report.tsx
+++ b/libs/ui/src/reports/ballot_count_report.tsx
@@ -22,6 +22,7 @@ import { ReportSection, tallyReportThemeFn, TallyReport } from './tally_report';
 import { LogoMark } from '../logo_mark';
 import { TallyReportMetadata } from './tally_report_metadata';
 import { CustomFilterSummary } from './custom_filter_summary';
+import { getBatchLabel, getScannerLabel } from './utils';
 
 /**
  * Columns that may appear in a the ballot count report table.
@@ -200,16 +201,6 @@ function getCellClass(column: Column): Optional<string> {
     default:
       throwIllegalValue(column);
   }
-}
-
-function getBatchLabel(batchId: string): string {
-  return batchId === Tabulation.MANUAL_BATCH_ID
-    ? 'Manual'
-    : batchId.slice(0, Tabulation.BATCH_ID_DISPLAY_LENGTH);
-}
-
-function getScannerLabel(scannerId: string): string {
-  return scannerId === Tabulation.MANUAL_SCANNER_ID ? 'Manual' : scannerId;
 }
 
 function BallotCountTable({

--- a/libs/ui/src/reports/custom_filter_summary.tsx
+++ b/libs/ui/src/reports/custom_filter_summary.tsx
@@ -5,6 +5,7 @@ import { getPrecinctById } from '@votingworks/utils';
 import pluralize from 'pluralize';
 import styled from 'styled-components';
 import { Font } from '../typography';
+import { getBatchLabel, getScannerLabel } from './utils';
 
 interface Props {
   electionDefinition: ElectionDefinition;
@@ -59,7 +60,7 @@ export function CustomFilterSummary({
           <Font weight="semiBold">
             {pluralize('Scanner', filter.scannerIds.length)}:
           </Font>{' '}
-          {filter.scannerIds.join(', ')}
+          {filter.scannerIds.map(getScannerLabel).join(', ')}
         </FilterDisplayRow>
       )}
       {filter.batchIds && (
@@ -67,7 +68,7 @@ export function CustomFilterSummary({
           <Font weight="semiBold">
             {pluralize('Batch', filter.batchIds.length)}:
           </Font>{' '}
-          {filter.batchIds.map((id) => id.slice(0, 8)).join(', ')}
+          {filter.batchIds.map(getBatchLabel).join(', ')}
         </FilterDisplayRow>
       )}
     </div>

--- a/libs/ui/src/reports/utils.ts
+++ b/libs/ui/src/reports/utils.ts
@@ -1,0 +1,11 @@
+import { Tabulation } from '@votingworks/types';
+
+export function getBatchLabel(batchId: string): string {
+  return batchId === Tabulation.MANUAL_BATCH_ID
+    ? 'Manual'
+    : batchId.slice(0, Tabulation.BATCH_ID_DISPLAY_LENGTH);
+}
+
+export function getScannerLabel(scannerId: string): string {
+  return scannerId === Tabulation.MANUAL_SCANNER_ID ? 'Manual' : scannerId;
+}


### PR DESCRIPTION
## Overview

Closes #4116. Currently, when you group by batch or scanner in the report builders, manual results are just silently dropped. This PR starts including them.

In tally reports, they end up on a separate page:
<img width="616" alt="Screen Shot 2023-10-25 at 11 35 28 AM" src="https://github.com/votingworks/vxsuite/assets/37960853/b6db4367-181b-4ed7-819a-7d215628d9d8">

If the filters are too specific, it will be called "Manual" in the custom filter description:
<img width="492" alt="Screen Shot 2023-10-25 at 1 58 21 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/b62a0196-6127-483d-bfaa-627080f813e4">


In ballot count reports, they are separated into different rows:
<img width="614" alt="Screen Shot 2023-10-25 at 11 35 08 AM" src="https://github.com/votingworks/vxsuite/assets/37960853/4902ca8a-cf17-434d-8f0a-e75032932bdd">

In the CSV exports, they are represented by a placeholder ID in separate rows:
<img width="928" alt="Screen Shot 2023-10-25 at 11 38 22 AM" src="https://github.com/votingworks/vxsuite/assets/37960853/3e2ee7f5-54ae-446f-932c-9c7583917bca">
<img width="686" alt="Screen Shot 2023-10-25 at 11 38 48 AM" src="https://github.com/votingworks/vxsuite/assets/37960853/34848d6c-4586-4ffc-82ad-29a6277b6d63">

## Testing Plan
Updated testing across the board to account, manually tested.
