### PR TITLE
Button icon via props

### DIFF
--- a/apps/admin/frontend/src/components/adjudication_ballot_image_viewer.tsx
+++ b/apps/admin/frontend/src/components/adjudication_ballot_image_viewer.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Button, Icons } from '@votingworks/ui';
+import { Button } from '@votingworks/ui';
 import styled from 'styled-components';
 import { Rect } from '@votingworks/types';
 
@@ -111,11 +111,19 @@ export function BallotImageViewer({
   return (
     <BallotImageViewerContainer>
       <BallotImageViewerControls isZoomedIn={isZoomedIn}>
-        <Button onPress={() => setIsZoomedIn(false)} disabled={!isZoomedIn}>
-          <Icons.ZoomOut /> Zoom Out
+        <Button
+          icon="ZoomOut"
+          onPress={() => setIsZoomedIn(false)}
+          disabled={!isZoomedIn}
+        >
+          Zoom Out
         </Button>
-        <Button onPress={() => setIsZoomedIn(true)} disabled={isZoomedIn}>
-          <Icons.ZoomIn /> Zoom In
+        <Button
+          icon="ZoomIn"
+          onPress={() => setIsZoomedIn(true)}
+          disabled={isZoomedIn}
+        >
+          Zoom In
         </Button>
       </BallotImageViewerControls>
       {isZoomedIn ? (

--- a/apps/admin/frontend/src/components/adjudication_double_vote_alert_modal.tsx
+++ b/apps/admin/frontend/src/components/adjudication_double_vote_alert_modal.tsx
@@ -59,7 +59,7 @@ export function DoubleVoteAlertModal({
       title="Possible Double Vote Detected"
       content={text}
       actions={
-        <Button variant="regular" onPress={onClose}>
+        <Button variant="neutral" onPress={onClose}>
           Cancel
         </Button>
       }

--- a/apps/admin/frontend/src/components/confirm_removing_file_modal.tsx
+++ b/apps/admin/frontend/src/components/confirm_removing_file_modal.tsx
@@ -75,7 +75,7 @@ export function ConfirmRemovingFileModal({
       actions={
         <React.Fragment>
           <Button
-            icon="DangerX"
+            icon="Delete"
             variant="danger"
             onPress={() => onConfirm(fileType)}
           >

--- a/apps/admin/frontend/src/components/confirm_removing_file_modal.tsx
+++ b/apps/admin/frontend/src/components/confirm_removing_file_modal.tsx
@@ -74,7 +74,11 @@ export function ConfirmRemovingFileModal({
       content={mainContent}
       actions={
         <React.Fragment>
-          <Button variant="danger" onPress={() => onConfirm(fileType)}>
+          <Button
+            icon="DangerX"
+            variant="danger"
+            onPress={() => onConfirm(fileType)}
+          >
             Remove {!singleFileRemoval && 'All'} {fileTypeName}
           </Button>
           <Button onPress={onCancel}>Cancel</Button>

--- a/apps/admin/frontend/src/components/layout/sidebar.tsx
+++ b/apps/admin/frontend/src/components/layout/sidebar.tsx
@@ -99,7 +99,7 @@ export function Sidebar(props: SidebarProps): JSX.Element {
             <NavListItem key={routerPath}>
               <NavButton
                 to={routerPath}
-                variant={isActivePath(routerPath) ? 'primary' : 'regular'}
+                variant={isActivePath(routerPath) ? 'primary' : 'neutral'}
               >
                 <NavButtonLabel>
                   <span>{label}</span>

--- a/apps/admin/frontend/src/components/remove_all_manual_tallies_modal.tsx
+++ b/apps/admin/frontend/src/components/remove_all_manual_tallies_modal.tsx
@@ -27,7 +27,7 @@ export function RemoveAllManualTalliesModal({
       }
       actions={
         <React.Fragment>
-          <Button variant="danger" onPress={onConfirm}>
+          <Button icon="DangerX" variant="danger" onPress={onConfirm}>
             Remove All Manually Entered Results
           </Button>
           <Button onPress={onClose}>Cancel</Button>

--- a/apps/admin/frontend/src/components/remove_all_manual_tallies_modal.tsx
+++ b/apps/admin/frontend/src/components/remove_all_manual_tallies_modal.tsx
@@ -27,7 +27,7 @@ export function RemoveAllManualTalliesModal({
       }
       actions={
         <React.Fragment>
-          <Button icon="DangerX" variant="danger" onPress={onConfirm}>
+          <Button icon="Delete" variant="danger" onPress={onConfirm}>
             Remove All Manually Entered Results
           </Button>
           <Button onPress={onClose}>Cancel</Button>

--- a/apps/admin/frontend/src/components/remove_election_modal.tsx
+++ b/apps/admin/frontend/src/components/remove_election_modal.tsx
@@ -33,7 +33,7 @@ export function RemoveElectionModal({ onClose }: Props): JSX.Element {
       onOverlayClick={onClose}
       actions={
         <React.Fragment>
-          <Button variant="danger" onPress={unconfigureElection}>
+          <Button icon="DangerX" variant="danger" onPress={unconfigureElection}>
             Remove Election Definition
           </Button>
           <Button onPress={onClose}>Cancel</Button>

--- a/apps/admin/frontend/src/components/remove_election_modal.tsx
+++ b/apps/admin/frontend/src/components/remove_election_modal.tsx
@@ -33,7 +33,7 @@ export function RemoveElectionModal({ onClose }: Props): JSX.Element {
       onOverlayClick={onClose}
       actions={
         <React.Fragment>
-          <Button icon="DangerX" variant="danger" onPress={unconfigureElection}>
+          <Button icon="Delete" variant="danger" onPress={unconfigureElection}>
             Remove Election Definition
           </Button>
           <Button onPress={onClose}>Cancel</Button>

--- a/apps/admin/frontend/src/components/reporting/ballot_count_report_viewer.tsx
+++ b/apps/admin/frontend/src/components/reporting/ballot_count_report_viewer.tsx
@@ -3,7 +3,6 @@ import {
   BallotCountReport,
   Button,
   H6,
-  Icons,
   Loading,
   Modal,
   printElement,
@@ -290,8 +289,8 @@ export function BallotCountReportViewer({
             {!isFetchingForPreview && !previewIsFresh && (
               <PreviewActionContainer>
                 {previewReport ? (
-                  <Button onPress={refreshPreview}>
-                    <Icons.RotateRight /> Refresh Preview
+                  <Button icon="RotateRight" onPress={refreshPreview}>
+                    Refresh Preview
                   </Button>
                 ) : (
                   <Button onPress={refreshPreview}>Load Preview</Button>

--- a/apps/admin/frontend/src/components/reporting/filter_editor.tsx
+++ b/apps/admin/frontend/src/components/reporting/filter_editor.tsx
@@ -323,8 +323,8 @@ export function FilterEditor({
                 ariaLabel="Select New Filter Type"
               />
             ) : (
-              <AddButton onPress={() => setIsAddingRow(true)}>
-                <Icons.AddCircle /> Add Filter
+              <AddButton icon="Add" onPress={() => setIsAddingRow(true)}>
+                Add Filter
               </AddButton>
             )}
           </AddSelectFilterContainer>

--- a/apps/admin/frontend/src/components/reporting/shared.tsx
+++ b/apps/admin/frontend/src/components/reporting/shared.tsx
@@ -77,8 +77,8 @@ export function PreviewLoading(): JSX.Element {
 
 export function ReportBackButton(): JSX.Element {
   return (
-    <LinkButton small to={routerPaths.reports}>
-      <Icons.Previous /> Back
+    <LinkButton icon="Previous" small to={routerPaths.reports}>
+      Back
     </LinkButton>
   );
 }

--- a/apps/admin/frontend/src/components/reporting/tally_report_viewer.tsx
+++ b/apps/admin/frontend/src/components/reporting/tally_report_viewer.tsx
@@ -2,7 +2,6 @@ import { ElectionDefinition, Tabulation } from '@votingworks/types';
 import {
   Button,
   H6,
-  Icons,
   Loading,
   Modal,
   printElement,
@@ -299,8 +298,8 @@ export function TallyReportViewer({
             {!isFetchingForPreview && !previewIsFresh && (
               <PreviewActionContainer>
                 {previewReport ? (
-                  <Button onPress={refreshPreview}>
-                    <Icons.RotateRight /> Refresh Preview
+                  <Button icon="RotateRight" onPress={refreshPreview}>
+                    Refresh Preview
                   </Button>
                 ) : (
                   <Button onPress={refreshPreview}>Load Preview</Button>

--- a/apps/admin/frontend/src/screens/definition_screen.tsx
+++ b/apps/admin/frontend/src/screens/definition_screen.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { format } from '@votingworks/utils';
 import { assert } from '@votingworks/basics';
 
-import { Button, Font, H3, Icons, LinkButton, P, Seal } from '@votingworks/ui';
+import { Button, Font, H3, LinkButton, P, Seal } from '@votingworks/ui';
 import { AppContext } from '../contexts/app_context';
 
 import { routerPaths } from '../router_paths';
@@ -55,8 +55,8 @@ export function DefinitionScreen(): JSX.Element {
           <LinkButton to={routerPaths.definitionViewer}>
             View Definition JSON
           </LinkButton>
-          <Button onPress={() => setIsRemovingElection(true)}>
-            <Icons.Delete /> Remove Election
+          <Button icon="Delete" onPress={() => setIsRemovingElection(true)}>
+            Remove Election
           </Button>
         </ButtonList>
       </NavigationScreen>

--- a/apps/admin/frontend/src/screens/definition_viewer_screen.tsx
+++ b/apps/admin/frontend/src/screens/definition_viewer_screen.tsx
@@ -4,7 +4,7 @@ import fileDownload from 'js-file-download';
 
 import dashify from 'dashify';
 
-import { Button, Icons, Pre, WithScrollButtons } from '@votingworks/ui';
+import { Button, Pre, WithScrollButtons } from '@votingworks/ui';
 import { AppContext } from '../contexts/app_context';
 
 import { ButtonBar } from '../components/button_bar';
@@ -42,11 +42,11 @@ export function DefinitionViewerScreen(): JSX.Element {
           <div />
           <div />
           <div />
-          <Button onPress={downloadElectionDefinition}>
-            <Icons.Save /> Save
+          <Button icon="Save" onPress={downloadElectionDefinition}>
+            Save
           </Button>
-          <Button onPress={initConfirmingUnconfig}>
-            <Icons.Delete /> Remove
+          <Button icon="Delete" onPress={initConfirmingUnconfig}>
+            Remove
           </Button>
         </ButtonBar>
         <WithScrollButtons>

--- a/apps/admin/frontend/src/screens/manual_data_entry_screen.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_entry_screen.tsx
@@ -721,6 +721,7 @@ export function ManualDataEntryScreen(): JSX.Element {
         );
       })}
       <P weight="semiBold">
+        <Icons.Warning />{' '}
         {someContestHasInvalidResults
           ? 'At least one contest above has invalid results entered'
           : someContestHasNoResults
@@ -729,14 +730,7 @@ export function ManualDataEntryScreen(): JSX.Element {
       </P>
       <P>
         <LinkButton to={routerPaths.manualDataSummary}>Cancel</LinkButton>{' '}
-        <Button
-          variant={
-            someContestHasInvalidResults || someContestHasNoResults
-              ? 'warning'
-              : 'primary'
-          }
-          onPress={saveResults}
-        >
+        <Button variant="primary" onPress={saveResults}>
           Save Results
         </Button>{' '}
       </P>

--- a/apps/admin/frontend/src/screens/manual_data_summary_screen.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_summary_screen.tsx
@@ -111,7 +111,7 @@ function RemoveManualTallyModal({
       }
       actions={
         <React.Fragment>
-          <Button variant="danger" onPress={onConfirm}>
+          <Button icon="DangerX" variant="danger" onPress={onConfirm}>
             Remove Manually Entered Results
           </Button>
           <Button onPress={onClose}>Cancel</Button>
@@ -391,6 +391,7 @@ export function ManualDataSummaryScreen(): JSX.Element {
         <br />
         <P>
           <Button
+            icon="DangerX"
             variant="danger"
             disabled={!hasManualTally}
             onPress={() => setIsClearingAll(true)}

--- a/apps/admin/frontend/src/screens/manual_data_summary_screen.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_summary_screen.tsx
@@ -111,7 +111,7 @@ function RemoveManualTallyModal({
       }
       actions={
         <React.Fragment>
-          <Button icon="DangerX" variant="danger" onPress={onConfirm}>
+          <Button icon="Delete" variant="danger" onPress={onConfirm}>
             Remove Manually Entered Results
           </Button>
           <Button onPress={onClose}>Cancel</Button>
@@ -391,7 +391,7 @@ export function ManualDataSummaryScreen(): JSX.Element {
         <br />
         <P>
           <Button
-            icon="DangerX"
+            icon="Delete"
             variant="danger"
             disabled={!hasManualTally}
             onPress={() => setIsClearingAll(true)}

--- a/apps/admin/frontend/src/screens/tally_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally_screen.tsx
@@ -137,7 +137,7 @@ export function TallyScreen(): JSX.Element | null {
             <Button
               disabled={!hasAnyFiles}
               onPress={() => beginConfirmRemoveFiles(ResultsFileType.All)}
-              icon="DangerX"
+              icon="Delete"
               variant="danger"
             >
               Clear All Tallies and Results

--- a/apps/admin/frontend/src/screens/tally_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally_screen.tsx
@@ -137,6 +137,7 @@ export function TallyScreen(): JSX.Element | null {
             <Button
               disabled={!hasAnyFiles}
               onPress={() => beginConfirmRemoveFiles(ResultsFileType.All)}
+              icon="DangerX"
               variant="danger"
             >
               Clear All Tallies and Results

--- a/apps/admin/frontend/src/screens/unconfigured_screen.tsx
+++ b/apps/admin/frontend/src/screens/unconfigured_screen.tsx
@@ -300,7 +300,7 @@ export function UnconfiguredScreen(): JSX.Element {
           </P>
           <HorizontalRule />
           <P>
-            <Button variant="previous" onPress={resetUploadFilesAndGoBack}>
+            <Button icon="Previous" onPress={resetUploadFilesAndGoBack}>
               Back
             </Button>
           </P>

--- a/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
@@ -451,11 +451,7 @@ export function WriteInsAdjudicationScreen(): JSX.Element {
           <Font weight="bold">{currentWriteInId.substring(0, 4)}</Font>
         </LabelledText>
         <AdjudicationNav>
-          <Button
-            disabled={offset === 0}
-            onPress={goPrevious}
-            variant="previous"
-          >
+          <Button disabled={offset === 0} onPress={goPrevious} icon="Previous">
             Previous
           </Button>
           <Caption weight="semiBold">
@@ -464,10 +460,9 @@ export function WriteInsAdjudicationScreen(): JSX.Element {
           <Button
             ref={nextButton}
             variant={
-              currentWriteIn?.status === 'adjudicated'
-                ? 'next'
-                : 'nextSecondary'
+              currentWriteIn?.status === 'adjudicated' ? 'primary' : 'neutral'
             }
+            rightIcon="Next"
             disabled={isLastAdjudication}
             onPress={goNext}
           >

--- a/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
@@ -583,7 +583,7 @@ export function WriteInsAdjudicationScreen(): JSX.Element {
                 }}
                 variant={currentWriteInMarkedInvalid ? 'secondary' : 'neutral'}
               >
-                <Icons.DangerX /> Mark write-in invalid
+                <Icons.Delete /> Mark write-in invalid
               </Button>
             </div>
           </AdjudicationForm>

--- a/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
@@ -243,7 +243,7 @@ export function WriteInsAdjudicationScreen(): JSX.Element {
         <ScreenHeader
           title="Write-In Adjudication"
           actions={
-            <LinkButton small variant="regular" to={routerPaths.writeIns}>
+            <LinkButton small variant="neutral" to={routerPaths.writeIns}>
               Back to All Write-Ins
             </LinkButton>
           }
@@ -420,7 +420,7 @@ export function WriteInsAdjudicationScreen(): JSX.Element {
             </span>
             <LinkButton
               small
-              variant={areAllWriteInsAdjudicated ? 'primary' : 'regular'}
+              variant={areAllWriteInsAdjudicated ? 'primary' : 'neutral'}
               to={routerPaths.writeIns}
             >
               Back to All Write-Ins
@@ -501,7 +501,7 @@ export function WriteInsAdjudicationScreen(): JSX.Element {
                     <Button
                       key={candidate.id}
                       ref={i === 0 ? firstAdjudicationButton : undefined}
-                      variant={isCurrentAdjudication ? 'secondary' : 'regular'}
+                      variant={isCurrentAdjudication ? 'secondary' : 'neutral'}
                       onPress={() => {
                         if (
                           isWriteInAdjudicationContextFresh &&
@@ -527,7 +527,7 @@ export function WriteInsAdjudicationScreen(): JSX.Element {
                   return (
                     <Button
                       key={candidate.id}
-                      variant={isCurrentAdjudication ? 'secondary' : 'regular'}
+                      variant={isCurrentAdjudication ? 'secondary' : 'neutral'}
                       onPress={() => {
                         if (
                           isWriteInAdjudicationContextFresh &&
@@ -586,7 +586,7 @@ export function WriteInsAdjudicationScreen(): JSX.Element {
                     adjudicateAsInvalid();
                   }
                 }}
-                variant={currentWriteInMarkedInvalid ? 'secondary' : 'regular'}
+                variant={currentWriteInMarkedInvalid ? 'secondary' : 'neutral'}
               >
                 <Icons.DangerX /> Mark write-in invalid
               </Button>

--- a/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
@@ -13,7 +13,6 @@ import {
   Button,
   Main,
   Screen,
-  Icons,
   P,
   Font,
   Caption,
@@ -567,8 +566,11 @@ export function WriteInsAdjudicationScreen(): JSX.Element {
                     </Button>
                   </InlineForm>
                 ) : (
-                  <Button onPress={() => setShowNewWriteInCandidateForm(true)}>
-                    <Icons.Add /> Add new write-in candidate
+                  <Button
+                    icon="Add"
+                    onPress={() => setShowNewWriteInCandidateForm(true)}
+                  >
+                    Add new write-in candidate
                   </Button>
                 )}
               </P>
@@ -582,8 +584,9 @@ export function WriteInsAdjudicationScreen(): JSX.Element {
                   }
                 }}
                 variant={currentWriteInMarkedInvalid ? 'secondary' : 'neutral'}
+                icon="Delete"
               >
-                <Icons.Delete /> Mark write-in invalid
+                Mark write-in invalid
               </Button>
             </div>
           </AdjudicationForm>

--- a/apps/admin/frontend/src/screens/write_ins_summary_screen.tsx
+++ b/apps/admin/frontend/src/screens/write_ins_summary_screen.tsx
@@ -139,7 +139,7 @@ export function WriteInsSummaryScreen(): JSX.Element {
                       ) : (
                         <LinkButton
                           disabled={isOfficialResults}
-                          variant={pendingCount ? 'primary' : 'regular'}
+                          variant={pendingCount ? 'primary' : 'neutral'}
                           to={routerPaths.writeInsAdjudication({
                             contestId: contest.id,
                           })}

--- a/apps/central-scan/frontend/src/components/delete_batch_modal.tsx
+++ b/apps/central-scan/frontend/src/components/delete_batch_modal.tsx
@@ -37,6 +37,7 @@ export function DeleteBatchModal({
       actions={
         <React.Fragment>
           <Button
+            icon="DangerX"
             variant="danger"
             onPress={doDeleteBatch}
             disabled={!deleteBatchMutation.isIdle}

--- a/apps/central-scan/frontend/src/components/delete_batch_modal.tsx
+++ b/apps/central-scan/frontend/src/components/delete_batch_modal.tsx
@@ -37,7 +37,7 @@ export function DeleteBatchModal({
       actions={
         <React.Fragment>
           <Button
-            icon="DangerX"
+            icon="Delete"
             variant="danger"
             onPress={doDeleteBatch}
             disabled={!deleteBatchMutation.isIdle}

--- a/apps/central-scan/frontend/src/screens/admin_actions_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/admin_actions_screen.tsx
@@ -145,19 +145,21 @@ export function AdminActionsScreen({
             </ButtonRow>
             <ButtonRow>
               <Button
+                icon="Delete"
                 disabled={!canUnconfigure}
                 onPress={() => setDeleteBallotDataFlowState('confirmation')}
               >
-                <Icons.Delete /> Delete Ballot Data
+                Delete Ballot Data
               </Button>
             </ButtonRow>
 
             <ButtonRow>
               <Button
+                icon="Delete"
                 disabled={!canUnconfigure}
                 onPress={() => setUnconfigureFlowState('initial-confirmation')}
               >
-                <Icons.Delete /> Delete Election Data from VxCentralScan
+                Delete Election Data from VxCentralScan
               </Button>{' '}
             </ButtonRow>
             {!canUnconfigure && !isTestMode && (

--- a/apps/central-scan/frontend/src/screens/admin_actions_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/admin_actions_screen.tsx
@@ -189,11 +189,7 @@ export function AdminActionsScreen({
           actions={
             <React.Fragment>
               <Button onPress={resetDeleteBallotDataFlow}>Cancel</Button>
-              <Button
-                variant="danger"
-                icon="DangerX"
-                onPress={deleteBallotData}
-              >
+              <Button variant="danger" icon="Delete" onPress={deleteBallotData}>
                 Yes, Delete Ballot Data
               </Button>
             </React.Fragment>
@@ -219,7 +215,7 @@ export function AdminActionsScreen({
             <React.Fragment>
               <Button
                 variant="danger"
-                icon="DangerX"
+                icon="Delete"
                 onPress={() => setUnconfigureFlowState('double-confirmation')}
               >
                 Yes, Delete Election Data
@@ -236,7 +232,7 @@ export function AdminActionsScreen({
           content={<P>This cannot be undone.</P>}
           actions={
             <React.Fragment>
-              <Button variant="danger" icon="DangerX" onPress={doUnconfigure}>
+              <Button variant="danger" icon="Delete" onPress={doUnconfigure}>
                 I am sure. Delete all election data.
               </Button>
               <Button onPress={resetUnconfigureFlow}>Cancel</Button>

--- a/apps/central-scan/frontend/src/screens/admin_actions_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/admin_actions_screen.tsx
@@ -189,7 +189,11 @@ export function AdminActionsScreen({
           actions={
             <React.Fragment>
               <Button onPress={resetDeleteBallotDataFlow}>Cancel</Button>
-              <Button variant="danger" onPress={deleteBallotData}>
+              <Button
+                variant="danger"
+                icon="DangerX"
+                onPress={deleteBallotData}
+              >
                 Yes, Delete Ballot Data
               </Button>
             </React.Fragment>
@@ -215,6 +219,7 @@ export function AdminActionsScreen({
             <React.Fragment>
               <Button
                 variant="danger"
+                icon="DangerX"
                 onPress={() => setUnconfigureFlowState('double-confirmation')}
               >
                 Yes, Delete Election Data
@@ -231,7 +236,7 @@ export function AdminActionsScreen({
           content={<P>This cannot be undone.</P>}
           actions={
             <React.Fragment>
-              <Button variant="danger" onPress={doUnconfigure}>
+              <Button variant="danger" icon="DangerX" onPress={doUnconfigure}>
                 I am sure. Delete all election data.
               </Button>
               <Button onPress={resetUnconfigureFlow}>Cancel</Button>

--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -1,13 +1,4 @@
-import {
-  H1,
-  Table,
-  TH,
-  TD,
-  LinkButton,
-  P,
-  Icons,
-  Button,
-} from '@votingworks/ui';
+import { H1, Table, TH, TD, LinkButton, P, Button } from '@votingworks/ui';
 import { Redirect, Route, Switch, useParams } from 'react-router-dom';
 import { assertDefined } from '@votingworks/basics';
 import {
@@ -129,14 +120,18 @@ function BallotDesignForm({
           >
             Cancel
           </Button>
-          <Button onPress={onSavePress} variant="primary">
-            <Icons.Checkmark /> Save
+          <Button onPress={onSavePress} variant="primary" icon="Done">
+            Save
           </Button>
         </FormActionsRow>
       ) : (
         <FormActionsRow>
-          <Button onPress={() => setIsEditing(true)} variant="primary">
-            <Icons.Edit /> Edit
+          <Button
+            onPress={() => setIsEditing(true)}
+            variant="primary"
+            icon="Edit"
+          >
+            Edit
           </Button>
         </FormActionsRow>
       )}

--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -115,8 +115,12 @@ function ContestsTab(): JSX.Element | null {
             )}
           </React.Fragment>
         )}
-        <LinkButton variant="primary" to={contestRoutes.addContest.path}>
-          <Icons.Add /> Add Contest
+        <LinkButton
+          variant="primary"
+          icon="Add"
+          to={contestRoutes.addContest.path}
+        >
+          Add Contest
         </LinkButton>
       </TableActionsRow>
       {contests.length > 0 &&

--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -522,7 +522,7 @@ function ContestForm({
         </FormActionsRow>
         {contestId && (
           <FormActionsRow style={{ marginTop: '1rem' }}>
-            <Button variant="danger" icon="DangerX" onPress={onDeletePress}>
+            <Button variant="danger" icon="Delete" onPress={onDeletePress}>
               Delete Contest
             </Button>
           </FormActionsRow>
@@ -775,7 +775,7 @@ function PartyForm({
         </FormActionsRow>
         {partyId && (
           <FormActionsRow style={{ marginTop: '1rem' }}>
-            <Button variant="danger" icon="DangerX" onPress={onDeletePress}>
+            <Button variant="danger" icon="Delete" onPress={onDeletePress}>
               Delete Party
             </Button>
           </FormActionsRow>

--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -514,14 +514,15 @@ function ContestForm({
           <Button
             onPress={onSavePress}
             variant="primary"
+            icon="Checkmark"
             disabled={updateElectionMutation.isLoading}
           >
-            <Icons.Checkmark /> Save
+            Save
           </Button>
         </FormActionsRow>
         {contestId && (
           <FormActionsRow style={{ marginTop: '1rem' }}>
-            <Button variant="danger" onPress={onDeletePress}>
+            <Button variant="danger" icon="DangerX" onPress={onDeletePress}>
               Delete Contest
             </Button>
           </FormActionsRow>
@@ -766,15 +767,16 @@ function PartyForm({
           <Button
             onPress={onSavePress}
             variant="primary"
+            icon="Checkmark"
             disabled={updateElectionMutation.isLoading}
           >
-            <Icons.Checkmark /> Save
+            Save
           </Button>
         </FormActionsRow>
         {partyId && (
           <FormActionsRow style={{ marginTop: '1rem' }}>
-            <Button variant="danger" onPress={onDeletePress}>
-              <Icons.DangerX /> Delete Party
+            <Button variant="danger" icon="DangerX" onPress={onDeletePress}>
+              Delete Party
             </Button>
           </FormActionsRow>
         )}

--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import {
   Select,
   Button,
-  Icons,
   Table,
   TH,
   TD,
@@ -166,8 +165,11 @@ function ContestsTab(): JSX.Element | null {
                     </TD>
                   )}
                   <TD nowrap>
-                    <LinkButton to={contestRoutes.editContest(contest.id).path}>
-                      <Icons.Edit /> Edit
+                    <LinkButton
+                      icon="Edit"
+                      to={contestRoutes.editContest(contest.id).path}
+                    >
+                      Edit
                     </LinkButton>
                   </TD>
                 </tr>
@@ -386,6 +388,7 @@ function ContestForm({
             )}
             <TableActionsRow>
               <Button
+                icon="Add"
                 onPress={() =>
                   setContest({
                     ...contest,
@@ -398,7 +401,7 @@ function ContestForm({
                   })
                 }
               >
-                <Icons.Add /> Add Candidate
+                Add Candidate
               </Button>
             </TableActionsRow>
             {contest.candidates.length > 0 && (
@@ -518,7 +521,7 @@ function ContestForm({
           <Button
             onPress={onSavePress}
             variant="primary"
-            icon="Checkmark"
+            icon="Done"
             disabled={updateElectionMutation.isLoading}
           >
             Save
@@ -611,8 +614,8 @@ function PartiesTab(): JSX.Element | null {
         <P>You haven&apos;t added any parties to this election yet.</P>
       )}
       <TableActionsRow>
-        <LinkButton variant="primary" to={partyRoutes.addParty.path}>
-          <Icons.Add /> Add Party
+        <LinkButton icon="Add" variant="primary" to={partyRoutes.addParty.path}>
+          Add Party
         </LinkButton>
       </TableActionsRow>
       {parties.length > 0 && (
@@ -632,8 +635,11 @@ function PartiesTab(): JSX.Element | null {
                 <TD>{party.id}</TD>
                 <TD>{party.abbrev}</TD>
                 <TD>
-                  <LinkButton to={partyRoutes.editParty(party.id).path}>
-                    <Icons.Edit /> Edit
+                  <LinkButton
+                    icon="Edit"
+                    to={partyRoutes.editParty(party.id).path}
+                  >
+                    Edit
                   </LinkButton>
                 </TD>
               </tr>
@@ -771,7 +777,7 @@ function PartyForm({
           <Button
             onPress={onSavePress}
             variant="primary"
-            icon="Checkmark"
+            icon="Done"
             disabled={updateElectionMutation.isLoading}
           >
             Save

--- a/apps/design/frontend/src/election_info_screen.tsx
+++ b/apps/design/frontend/src/election_info_screen.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Election, Id } from '@votingworks/types';
-import { Button, H1, Icons } from '@votingworks/ui';
+import { Button, H1 } from '@votingworks/ui';
 import { Buffer } from 'buffer';
 import { useHistory, useParams } from 'react-router-dom';
 import DomPurify from 'dompurify';
@@ -171,22 +171,28 @@ function ElectionInfoForm({
           </Button>
           <Button
             variant="primary"
+            icon="Done"
             onPress={onSaveButtonPress}
             disabled={updateElectionMutation.isLoading}
           >
-            <Icons.Checkmark /> Save
+            Save
           </Button>
         </FormActionsRow>
       ) : (
         <div>
           <FormActionsRow>
-            <Button variant="primary" onPress={() => setIsEditing(true)}>
-              <Icons.Edit /> Edit
+            <Button
+              variant="primary"
+              icon="Edit"
+              onPress={() => setIsEditing(true)}
+            >
+              Edit
             </Button>
           </FormActionsRow>
           <FormActionsRow style={{ marginTop: '1rem' }}>
             <Button
               variant="danger"
+              icon="Delete"
               onPress={onDeletePress}
               disabled={deleteElectionMutation.isLoading}
             >

--- a/apps/design/frontend/src/elections_screen.tsx
+++ b/apps/design/frontend/src/elections_screen.tsx
@@ -90,10 +90,11 @@ export function ElectionsScreen(): JSX.Element | null {
         <Row style={{ gap: '0.5rem' }}>
           <Button
             variant={elections.length === 0 ? 'primary' : undefined}
+            icon="Add"
             onPress={onCreateElectionPress}
             disabled={createElectionMutation.isLoading}
           >
-            <Icons.Add /> Create Election
+            Create Election
           </Button>
           <FileInputButton
             accept=".json"

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -1,14 +1,5 @@
 import React, { useState } from 'react';
-import {
-  Button,
-  Icons,
-  Table,
-  TH,
-  TD,
-  H1,
-  LinkButton,
-  P,
-} from '@votingworks/ui';
+import { Button, Table, TH, TD, H1, LinkButton, P } from '@votingworks/ui';
 import {
   Switch,
   Route,
@@ -227,6 +218,7 @@ function DistrictForm({
           <FormActionsRow style={{ marginTop: '1rem' }}>
             <Button
               variant="danger"
+              icon="DangerX"
               onPress={onDeletePress}
               disabled={updateElectionMutation.isLoading}
             >
@@ -615,6 +607,7 @@ function PrecinctForm({
           </LinkButton>
           <Button
             variant="primary"
+            icon="Checkmark"
             onPress={onSavePress}
             disabled={updatePrecinctsMutation.isLoading}
           >
@@ -625,6 +618,7 @@ function PrecinctForm({
           <FormActionsRow style={{ marginTop: '1rem' }}>
             <Button
               variant="danger"
+              icon="DangerX"
               onPress={onDeletePress}
               disabled={updatePrecinctsMutation.isLoading}
             >

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -218,7 +218,7 @@ function DistrictForm({
           <FormActionsRow style={{ marginTop: '1rem' }}>
             <Button
               variant="danger"
-              icon="DangerX"
+              icon="Delete"
               onPress={onDeletePress}
               disabled={updateElectionMutation.isLoading}
             >
@@ -618,11 +618,11 @@ function PrecinctForm({
           <FormActionsRow style={{ marginTop: '1rem' }}>
             <Button
               variant="danger"
-              icon="DangerX"
+              icon="Delete"
               onPress={onDeletePress}
               disabled={updatePrecinctsMutation.isLoading}
             >
-              <Icons.DangerX /> Delete Precinct
+              <Icons.Delete /> Delete Precinct
             </Button>
           </FormActionsRow>
         )}

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -53,8 +53,12 @@ function DistrictsTab(): JSX.Element | null {
         <P>You haven&apos;t added any districts to this election yet.</P>
       )}
       <TableActionsRow>
-        <LinkButton variant="primary" to={districtsRoutes.addDistrict.path}>
-          <Icons.Add /> Add District
+        <LinkButton
+          icon="Add"
+          variant="primary"
+          to={districtsRoutes.addDistrict.path}
+        >
+          Add District
         </LinkButton>
       </TableActionsRow>
       {districts.length > 0 && (
@@ -73,9 +77,10 @@ function DistrictsTab(): JSX.Element | null {
                 <TD>{district.id}</TD>
                 <TD>
                   <LinkButton
+                    icon="Edit"
                     to={districtsRoutes.editDistrict(district.id).path}
                   >
-                    <Icons.Edit /> Edit
+                    Edit
                   </LinkButton>
                 </TD>
               </tr>
@@ -208,10 +213,11 @@ function DistrictForm({
           </LinkButton>
           <Button
             variant="primary"
+            icon="Done"
             onPress={onSavePress}
             disabled={updateElectionMutation.isLoading}
           >
-            <Icons.Checkmark /> Save
+            Save
           </Button>
         </FormActionsRow>
         {districtId && (
@@ -311,9 +317,10 @@ function PrecinctsTab(): JSX.Element | null {
       <TableActionsRow>
         <LinkButton
           variant="primary"
+          icon="Add"
           to={geographyRoutes.precincts.addPrecinct.path}
         >
-          <Icons.Add /> Add Precinct
+          Add Precinct
         </LinkButton>
       </TableActionsRow>
       {precincts.length > 0 && (
@@ -340,11 +347,12 @@ function PrecinctsTab(): JSX.Element | null {
                   </TD>
                   <TD>
                     <LinkButton
+                      icon="Edit"
                       to={
                         geographyRoutes.precincts.editPrecinct(precinct.id).path
                       }
                     >
-                      <Icons.Edit /> Edit
+                      Edit
                     </LinkButton>
                   </TD>
                 </tr>
@@ -569,8 +577,8 @@ function PrecinctForm({
                 </Card>
               ))}
               <div>
-                <Button onPress={onAddSplitPress}>
-                  <Icons.Add /> Add Split
+                <Button icon="Add" onPress={onAddSplitPress}>
+                  Add Split
                 </Button>
               </div>
             </React.Fragment>
@@ -592,8 +600,8 @@ function PrecinctForm({
                 />
               </div>
               <div>
-                <Button onPress={onAddSplitPress}>
-                  <Icons.Add /> Add Split
+                <Button icon="Add" onPress={onAddSplitPress}>
+                  Add Split
                 </Button>
               </div>
             </React.Fragment>
@@ -607,11 +615,11 @@ function PrecinctForm({
           </LinkButton>
           <Button
             variant="primary"
-            icon="Checkmark"
+            icon="Done"
             onPress={onSavePress}
             disabled={updatePrecinctsMutation.isLoading}
           >
-            <Icons.Checkmark /> Save
+            Save
           </Button>
         </FormActionsRow>
         {precinctId && (
@@ -622,7 +630,7 @@ function PrecinctForm({
               onPress={onDeletePress}
               disabled={updatePrecinctsMutation.isLoading}
             >
-              <Icons.Delete /> Delete Precinct
+              Delete Precinct
             </Button>
           </FormActionsRow>
         )}

--- a/apps/design/frontend/src/tabulation_screen.tsx
+++ b/apps/design/frontend/src/tabulation_screen.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { H1, H2, Button, Icons } from '@votingworks/ui';
+import { H1, H2, Button } from '@votingworks/ui';
 import { useParams } from 'react-router-dom';
 import { AdjudicationReason, Id, SystemSettings } from '@votingworks/types';
 import {
@@ -148,14 +148,18 @@ export function TabulationForm({
           >
             Cancel
           </Button>
-          <Button onPress={onSaveButtonPress} variant="primary">
-            <Icons.Checkmark /> Save
+          <Button onPress={onSaveButtonPress} variant="primary" icon="Done">
+            Save
           </Button>
         </FormActionsRow>
       ) : (
         <FormActionsRow>
-          <Button variant="primary" onPress={() => setIsEditing(true)}>
-            <Icons.Edit /> Edit
+          <Button
+            variant="primary"
+            icon="Edit"
+            onPress={() => setIsEditing(true)}
+          >
+            Edit
           </Button>
         </FormActionsRow>
       )}

--- a/apps/mark-scan/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
+++ b/apps/mark-scan/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
@@ -137,10 +137,6 @@ exports[`Single Seat Contest 1`] = `
   cursor: not-allowed;
 }
 
-.c25 {
-  display: inline-block;
-}
-
 .c15 {
   display: inline-block;
   -webkit-box-flex: 1;
@@ -316,7 +312,7 @@ exports[`Single Seat Contest 1`] = `
   justify-content: space-between;
 }
 
-.c26 {
+.c25 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -795,25 +791,21 @@ exports[`Single Seat Contest 1`] = `
         id="previous"
         type="button"
       >
-        <span
-          class="c25"
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-circle-left "
+          data-icon="circle-left"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <svg
-            aria-hidden="true"
-            class="svg-inline--fa fa-circle-left "
-            data-icon="circle-left"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M512 256A256 256 0 1 0 0 256a256 256 0 1 0 512 0zM217.4 376.9L117.5 269.8c-3.5-3.8-5.5-8.7-5.5-13.8s2-10.1 5.5-13.8l99.9-107.1c4.2-4.5 10.1-7.1 16.3-7.1c12.3 0 22.3 10 22.3 22.3l0 57.7 96 0c17.7 0 32 14.3 32 32l0 32c0 17.7-14.3 32-32 32l-96 0 0 57.7c0 12.3-10 22.3-22.3 22.3c-6.2 0-12.1-2.6-16.3-7.1z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
+          <path
+            d="M512 256A256 256 0 1 0 0 256a256 256 0 1 0 512 0zM217.4 376.9L117.5 269.8c-3.5-3.8-5.5-8.7-5.5-13.8s2-10.1 5.5-13.8l99.9-107.1c4.2-4.5 10.1-7.1 16.3-7.1c12.3 0 22.3 10 22.3 22.3l0 57.7 96 0c17.7 0 32 14.3 32 32l0 32c0 17.7-14.3 32-32 32l-96 0 0 57.7c0 12.3-10 22.3-22.3 22.3c-6.2 0-12.1-2.6-16.3-7.1z"
+            fill="currentColor"
+          />
+        </svg>
         <span
           class="c15"
         >
@@ -832,7 +824,7 @@ exports[`Single Seat Contest 1`] = `
           class="c15"
         >
           <span
-            class="c26"
+            class="c25"
           >
             <svg
               aria-hidden="true"
@@ -864,25 +856,6 @@ exports[`Single Seat Contest 1`] = `
         type="button"
       >
         <span
-          class="c25"
-        >
-          <svg
-            aria-hidden="true"
-            class="svg-inline--fa fa-circle-right "
-            data-icon="circle-right"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M0 256a256 256 0 1 0 512 0A256 256 0 1 0 0 256zM294.6 135.1l99.9 107.1c3.5 3.8 5.5 8.7 5.5 13.8s-2 10.1-5.5 13.8L294.6 376.9c-4.2 4.5-10.1 7.1-16.3 7.1C266 384 256 374 256 361.7l0-57.7-96 0c-17.7 0-32-14.3-32-32l0-32c0-17.7 14.3-32 32-32l96 0 0-57.7c0-12.3 10-22.3 22.3-22.3c6.2 0 12.1 2.6 16.3 7.1z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
-        <span
           class="c15"
         >
           <span
@@ -891,6 +864,21 @@ exports[`Single Seat Contest 1`] = `
             Next
           </span>
         </span>
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-circle-right "
+          data-icon="circle-right"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M0 256a256 256 0 1 0 512 0A256 256 0 1 0 0 256zM294.6 135.1l99.9 107.1c3.5 3.8 5.5 8.7 5.5 13.8s-2 10.1-5.5 13.8L294.6 376.9c-4.2 4.5-10.1 7.1-16.3 7.1C266 384 256 374 256 361.7l0-57.7-96 0c-17.7 0-32-14.3-32-32l0-32c0-17.7 14.3-32 32-32l96 0 0-57.7c0-12.3 10-22.3 22.3-22.3c6.2 0 12.1 2.6 16.3 7.1z"
+            fill="currentColor"
+          />
+        </svg>
       </button>
     </nav>
   </div>

--- a/apps/mark-scan/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
+++ b/apps/mark-scan/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
@@ -197,10 +197,6 @@ exports[`Single Seat Contest 1`] = `
   cursor: not-allowed;
 }
 
-.c28 {
-  display: inline-block;
-}
-
 .c15 {
   display: inline-block;
   -webkit-box-flex: 1;
@@ -422,7 +418,7 @@ exports[`Single Seat Contest 1`] = `
   justify-content: space-between;
 }
 
-.c29 {
+.c28 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1302,25 +1298,21 @@ exports[`Single Seat Contest 1`] = `
         id="previous"
         type="button"
       >
-        <span
-          class="c28"
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-circle-left "
+          data-icon="circle-left"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <svg
-            aria-hidden="true"
-            class="svg-inline--fa fa-circle-left "
-            data-icon="circle-left"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M512 256A256 256 0 1 0 0 256a256 256 0 1 0 512 0zM217.4 376.9L117.5 269.8c-3.5-3.8-5.5-8.7-5.5-13.8s2-10.1 5.5-13.8l99.9-107.1c4.2-4.5 10.1-7.1 16.3-7.1c12.3 0 22.3 10 22.3 22.3l0 57.7 96 0c17.7 0 32 14.3 32 32l0 32c0 17.7-14.3 32-32 32l-96 0 0 57.7c0 12.3-10 22.3-22.3 22.3c-6.2 0-12.1-2.6-16.3-7.1z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
+          <path
+            d="M512 256A256 256 0 1 0 0 256a256 256 0 1 0 512 0zM217.4 376.9L117.5 269.8c-3.5-3.8-5.5-8.7-5.5-13.8s2-10.1 5.5-13.8l99.9-107.1c4.2-4.5 10.1-7.1 16.3-7.1c12.3 0 22.3 10 22.3 22.3l0 57.7 96 0c17.7 0 32 14.3 32 32l0 32c0 17.7-14.3 32-32 32l-96 0 0 57.7c0 12.3-10 22.3-22.3 22.3c-6.2 0-12.1-2.6-16.3-7.1z"
+            fill="currentColor"
+          />
+        </svg>
         <span
           class="c15"
         >
@@ -1339,7 +1331,7 @@ exports[`Single Seat Contest 1`] = `
           class="c15"
         >
           <span
-            class="c29"
+            class="c28"
           >
             <svg
               aria-hidden="true"
@@ -1371,25 +1363,6 @@ exports[`Single Seat Contest 1`] = `
         type="button"
       >
         <span
-          class="c28"
-        >
-          <svg
-            aria-hidden="true"
-            class="svg-inline--fa fa-circle-right "
-            data-icon="circle-right"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M0 256a256 256 0 1 0 512 0A256 256 0 1 0 0 256zM294.6 135.1l99.9 107.1c3.5 3.8 5.5 8.7 5.5 13.8s-2 10.1-5.5 13.8L294.6 376.9c-4.2 4.5-10.1 7.1-16.3 7.1C266 384 256 374 256 361.7l0-57.7-96 0c-17.7 0-32-14.3-32-32l0-32c0-17.7 14.3-32 32-32l96 0 0-57.7c0-12.3 10-22.3 22.3-22.3c6.2 0 12.1 2.6 16.3 7.1z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
-        <span
           class="c15"
         >
           <span
@@ -1398,6 +1371,21 @@ exports[`Single Seat Contest 1`] = `
             Next
           </span>
         </span>
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-circle-right "
+          data-icon="circle-right"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M0 256a256 256 0 1 0 512 0A256 256 0 1 0 0 256zM294.6 135.1l99.9 107.1c3.5 3.8 5.5 8.7 5.5 13.8s-2 10.1-5.5 13.8L294.6 376.9c-4.2 4.5-10.1 7.1-16.3 7.1C266 384 256 374 256 361.7l0-57.7-96 0c-17.7 0-32-14.3-32-32l0-32c0-17.7 14.3-32 32-32l96 0 0-57.7c0-12.3 10-22.3 22.3-22.3c6.2 0 12.1 2.6 16.3 7.1z"
+            fill="currentColor"
+          />
+        </svg>
       </button>
     </nav>
   </div>

--- a/apps/mark-scan/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
+++ b/apps/mark-scan/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
@@ -197,10 +197,6 @@ exports[`Single Seat Contest 1`] = `
   cursor: not-allowed;
 }
 
-.c28 {
-  display: inline-block;
-}
-
 .c15 {
   display: inline-block;
   -webkit-box-flex: 1;
@@ -422,7 +418,7 @@ exports[`Single Seat Contest 1`] = `
   justify-content: space-between;
 }
 
-.c29 {
+.c28 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -966,25 +962,21 @@ exports[`Single Seat Contest 1`] = `
         id="previous"
         type="button"
       >
-        <span
-          class="c28"
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-circle-left "
+          data-icon="circle-left"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <svg
-            aria-hidden="true"
-            class="svg-inline--fa fa-circle-left "
-            data-icon="circle-left"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M512 256A256 256 0 1 0 0 256a256 256 0 1 0 512 0zM217.4 376.9L117.5 269.8c-3.5-3.8-5.5-8.7-5.5-13.8s2-10.1 5.5-13.8l99.9-107.1c4.2-4.5 10.1-7.1 16.3-7.1c12.3 0 22.3 10 22.3 22.3l0 57.7 96 0c17.7 0 32 14.3 32 32l0 32c0 17.7-14.3 32-32 32l-96 0 0 57.7c0 12.3-10 22.3-22.3 22.3c-6.2 0-12.1-2.6-16.3-7.1z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
+          <path
+            d="M512 256A256 256 0 1 0 0 256a256 256 0 1 0 512 0zM217.4 376.9L117.5 269.8c-3.5-3.8-5.5-8.7-5.5-13.8s2-10.1 5.5-13.8l99.9-107.1c4.2-4.5 10.1-7.1 16.3-7.1c12.3 0 22.3 10 22.3 22.3l0 57.7 96 0c17.7 0 32 14.3 32 32l0 32c0 17.7-14.3 32-32 32l-96 0 0 57.7c0 12.3-10 22.3-22.3 22.3c-6.2 0-12.1-2.6-16.3-7.1z"
+            fill="currentColor"
+          />
+        </svg>
         <span
           class="c15"
         >
@@ -1003,7 +995,7 @@ exports[`Single Seat Contest 1`] = `
           class="c15"
         >
           <span
-            class="c29"
+            class="c28"
           >
             <svg
               aria-hidden="true"
@@ -1035,25 +1027,6 @@ exports[`Single Seat Contest 1`] = `
         type="button"
       >
         <span
-          class="c28"
-        >
-          <svg
-            aria-hidden="true"
-            class="svg-inline--fa fa-circle-right "
-            data-icon="circle-right"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M0 256a256 256 0 1 0 512 0A256 256 0 1 0 0 256zM294.6 135.1l99.9 107.1c3.5 3.8 5.5 8.7 5.5 13.8s-2 10.1-5.5 13.8L294.6 376.9c-4.2 4.5-10.1 7.1-16.3 7.1C266 384 256 374 256 361.7l0-57.7-96 0c-17.7 0-32-14.3-32-32l0-32c0-17.7 14.3-32 32-32l96 0 0-57.7c0-12.3 10-22.3 22.3-22.3c6.2 0 12.1 2.6 16.3 7.1z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
-        <span
           class="c15"
         >
           <span
@@ -1062,6 +1035,21 @@ exports[`Single Seat Contest 1`] = `
             Next
           </span>
         </span>
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-circle-right "
+          data-icon="circle-right"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M0 256a256 256 0 1 0 512 0A256 256 0 1 0 0 256zM294.6 135.1l99.9 107.1c3.5 3.8 5.5 8.7 5.5 13.8s-2 10.1-5.5 13.8L294.6 376.9c-4.2 4.5-10.1 7.1-16.3 7.1C266 384 256 374 256 361.7l0-57.7-96 0c-17.7 0-32-14.3-32-32l0-32c0-17.7 14.3-32 32-32l96 0 0-57.7c0-12.3 10-22.3 22.3-22.3c6.2 0 12.1 2.6 16.3 7.1z"
+            fill="currentColor"
+          />
+        </svg>
       </button>
     </nav>
   </div>

--- a/apps/mark-scan/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
+++ b/apps/mark-scan/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
@@ -137,10 +137,6 @@ exports[`Single Seat Contest with Write In 1`] = `
   cursor: not-allowed;
 }
 
-.c25 {
-  display: inline-block;
-}
-
 .c15 {
   display: inline-block;
   -webkit-box-flex: 1;
@@ -316,7 +312,7 @@ exports[`Single Seat Contest with Write In 1`] = `
   justify-content: space-between;
 }
 
-.c26 {
+.c25 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -643,25 +639,21 @@ exports[`Single Seat Contest with Write In 1`] = `
         id="previous"
         type="button"
       >
-        <span
-          class="c25"
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-circle-left "
+          data-icon="circle-left"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <svg
-            aria-hidden="true"
-            class="svg-inline--fa fa-circle-left "
-            data-icon="circle-left"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M512 256A256 256 0 1 0 0 256a256 256 0 1 0 512 0zM217.4 376.9L117.5 269.8c-3.5-3.8-5.5-8.7-5.5-13.8s2-10.1 5.5-13.8l99.9-107.1c4.2-4.5 10.1-7.1 16.3-7.1c12.3 0 22.3 10 22.3 22.3l0 57.7 96 0c17.7 0 32 14.3 32 32l0 32c0 17.7-14.3 32-32 32l-96 0 0 57.7c0 12.3-10 22.3-22.3 22.3c-6.2 0-12.1-2.6-16.3-7.1z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
+          <path
+            d="M512 256A256 256 0 1 0 0 256a256 256 0 1 0 512 0zM217.4 376.9L117.5 269.8c-3.5-3.8-5.5-8.7-5.5-13.8s2-10.1 5.5-13.8l99.9-107.1c4.2-4.5 10.1-7.1 16.3-7.1c12.3 0 22.3 10 22.3 22.3l0 57.7 96 0c17.7 0 32 14.3 32 32l0 32c0 17.7-14.3 32-32 32l-96 0 0 57.7c0 12.3-10 22.3-22.3 22.3c-6.2 0-12.1-2.6-16.3-7.1z"
+            fill="currentColor"
+          />
+        </svg>
         <span
           class="c15"
         >
@@ -680,7 +672,7 @@ exports[`Single Seat Contest with Write In 1`] = `
           class="c15"
         >
           <span
-            class="c26"
+            class="c25"
           >
             <svg
               aria-hidden="true"
@@ -712,25 +704,6 @@ exports[`Single Seat Contest with Write In 1`] = `
         type="button"
       >
         <span
-          class="c25"
-        >
-          <svg
-            aria-hidden="true"
-            class="svg-inline--fa fa-circle-right "
-            data-icon="circle-right"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M0 256a256 256 0 1 0 512 0A256 256 0 1 0 0 256zM294.6 135.1l99.9 107.1c3.5 3.8 5.5 8.7 5.5 13.8s-2 10.1-5.5 13.8L294.6 376.9c-4.2 4.5-10.1 7.1-16.3 7.1C266 384 256 374 256 361.7l0-57.7-96 0c-17.7 0-32-14.3-32-32l0-32c0-17.7 14.3-32 32-32l96 0 0-57.7c0-12.3 10-22.3 22.3-22.3c6.2 0 12.1 2.6 16.3 7.1z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
-        <span
           class="c15"
         >
           <span
@@ -739,6 +712,21 @@ exports[`Single Seat Contest with Write In 1`] = `
             Next
           </span>
         </span>
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-circle-right "
+          data-icon="circle-right"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M0 256a256 256 0 1 0 512 0A256 256 0 1 0 0 256zM294.6 135.1l99.9 107.1c3.5 3.8 5.5 8.7 5.5 13.8s-2 10.1-5.5 13.8L294.6 376.9c-4.2 4.5-10.1 7.1-16.3 7.1C266 384 256 374 256 361.7l0-57.7-96 0c-17.7 0-32-14.3-32-32l0-32c0-17.7 14.3-32 32-32l96 0 0-57.7c0-12.3 10-22.3 22.3-22.3c6.2 0 12.1 2.6 16.3 7.1z"
+            fill="currentColor"
+          />
+        </svg>
       </button>
     </nav>
   </div>

--- a/apps/mark-scan/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
+++ b/apps/mark-scan/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
@@ -137,10 +137,6 @@ exports[`Renders ContestPage 1`] = `
   cursor: not-allowed;
 }
 
-.c24 {
-  display: inline-block;
-}
-
 .c14 {
   display: inline-block;
   -webkit-box-flex: 1;
@@ -316,7 +312,7 @@ exports[`Renders ContestPage 1`] = `
   justify-content: space-between;
 }
 
-.c25 {
+.c24 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -800,25 +796,21 @@ exports[`Renders ContestPage 1`] = `
         id="previous"
         type="button"
       >
-        <span
-          class="c24"
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-circle-left "
+          data-icon="circle-left"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <svg
-            aria-hidden="true"
-            class="svg-inline--fa fa-circle-left "
-            data-icon="circle-left"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M512 256A256 256 0 1 0 0 256a256 256 0 1 0 512 0zM217.4 376.9L117.5 269.8c-3.5-3.8-5.5-8.7-5.5-13.8s2-10.1 5.5-13.8l99.9-107.1c4.2-4.5 10.1-7.1 16.3-7.1c12.3 0 22.3 10 22.3 22.3l0 57.7 96 0c17.7 0 32 14.3 32 32l0 32c0 17.7-14.3 32-32 32l-96 0 0 57.7c0 12.3-10 22.3-22.3 22.3c-6.2 0-12.1-2.6-16.3-7.1z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
+          <path
+            d="M512 256A256 256 0 1 0 0 256a256 256 0 1 0 512 0zM217.4 376.9L117.5 269.8c-3.5-3.8-5.5-8.7-5.5-13.8s2-10.1 5.5-13.8l99.9-107.1c4.2-4.5 10.1-7.1 16.3-7.1c12.3 0 22.3 10 22.3 22.3l0 57.7 96 0c17.7 0 32 14.3 32 32l0 32c0 17.7-14.3 32-32 32l-96 0 0 57.7c0 12.3-10 22.3-22.3 22.3c-6.2 0-12.1-2.6-16.3-7.1z"
+            fill="currentColor"
+          />
+        </svg>
         <span
           class="c14"
         >
@@ -837,7 +829,7 @@ exports[`Renders ContestPage 1`] = `
           class="c14"
         >
           <span
-            class="c25"
+            class="c24"
           >
             <svg
               aria-hidden="true"
@@ -869,25 +861,6 @@ exports[`Renders ContestPage 1`] = `
         type="button"
       >
         <span
-          class="c24"
-        >
-          <svg
-            aria-hidden="true"
-            class="svg-inline--fa fa-circle-right "
-            data-icon="circle-right"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M0 256a256 256 0 1 0 512 0A256 256 0 1 0 0 256zM294.6 135.1l99.9 107.1c3.5 3.8 5.5 8.7 5.5 13.8s-2 10.1-5.5 13.8L294.6 376.9c-4.2 4.5-10.1 7.1-16.3 7.1C266 384 256 374 256 361.7l0-57.7-96 0c-17.7 0-32-14.3-32-32l0-32c0-17.7 14.3-32 32-32l96 0 0-57.7c0-12.3 10-22.3 22.3-22.3c6.2 0 12.1 2.6 16.3 7.1z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
-        <span
           class="c14"
         >
           <span
@@ -896,6 +869,21 @@ exports[`Renders ContestPage 1`] = `
             Next
           </span>
         </span>
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-circle-right "
+          data-icon="circle-right"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M0 256a256 256 0 1 0 512 0A256 256 0 1 0 0 256zM294.6 135.1l99.9 107.1c3.5 3.8 5.5 8.7 5.5 13.8s-2 10.1-5.5 13.8L294.6 376.9c-4.2 4.5-10.1 7.1-16.3 7.1C266 384 256 374 256 361.7l0-57.7-96 0c-17.7 0-32-14.3-32-32l0-32c0-17.7 14.3-32 32-32l96 0 0-57.7c0-12.3 10-22.3 22.3-22.3c6.2 0 12.1 2.6 16.3 7.1z"
+            fill="currentColor"
+          />
+        </svg>
       </button>
     </nav>
   </div>
@@ -1037,10 +1025,6 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
   border: 0.15rem dashed #222222;
   box-shadow: none;
   cursor: not-allowed;
-}
-
-.c24 {
-  display: inline-block;
 }
 
 .c14 {
@@ -1218,7 +1202,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
   justify-content: space-between;
 }
 
-.c25 {
+.c24 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1702,25 +1686,21 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
         id="previous"
         type="button"
       >
-        <span
-          class="c24"
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-circle-left "
+          data-icon="circle-left"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <svg
-            aria-hidden="true"
-            class="svg-inline--fa fa-circle-left "
-            data-icon="circle-left"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M512 256A256 256 0 1 0 0 256a256 256 0 1 0 512 0zM217.4 376.9L117.5 269.8c-3.5-3.8-5.5-8.7-5.5-13.8s2-10.1 5.5-13.8l99.9-107.1c4.2-4.5 10.1-7.1 16.3-7.1c12.3 0 22.3 10 22.3 22.3l0 57.7 96 0c17.7 0 32 14.3 32 32l0 32c0 17.7-14.3 32-32 32l-96 0 0 57.7c0 12.3-10 22.3-22.3 22.3c-6.2 0-12.1-2.6-16.3-7.1z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
+          <path
+            d="M512 256A256 256 0 1 0 0 256a256 256 0 1 0 512 0zM217.4 376.9L117.5 269.8c-3.5-3.8-5.5-8.7-5.5-13.8s2-10.1 5.5-13.8l99.9-107.1c4.2-4.5 10.1-7.1 16.3-7.1c12.3 0 22.3 10 22.3 22.3l0 57.7 96 0c17.7 0 32 14.3 32 32l0 32c0 17.7-14.3 32-32 32l-96 0 0 57.7c0 12.3-10 22.3-22.3 22.3c-6.2 0-12.1-2.6-16.3-7.1z"
+            fill="currentColor"
+          />
+        </svg>
         <span
           class="c14"
         >
@@ -1739,7 +1719,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
           class="c14"
         >
           <span
-            class="c25"
+            class="c24"
           >
             <svg
               aria-hidden="true"
@@ -1771,25 +1751,6 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
         type="button"
       >
         <span
-          class="c24"
-        >
-          <svg
-            aria-hidden="true"
-            class="svg-inline--fa fa-circle-right "
-            data-icon="circle-right"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M0 256a256 256 0 1 0 512 0A256 256 0 1 0 0 256zM294.6 135.1l99.9 107.1c3.5 3.8 5.5 8.7 5.5 13.8s-2 10.1-5.5 13.8L294.6 376.9c-4.2 4.5-10.1 7.1-16.3 7.1C266 384 256 374 256 361.7l0-57.7-96 0c-17.7 0-32-14.3-32-32l0-32c0-17.7 14.3-32 32-32l96 0 0-57.7c0-12.3 10-22.3 22.3-22.3c6.2 0 12.1 2.6 16.3 7.1z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
-        <span
           class="c14"
         >
           <span
@@ -1798,6 +1759,21 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
             Next
           </span>
         </span>
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-circle-right "
+          data-icon="circle-right"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M0 256a256 256 0 1 0 512 0A256 256 0 1 0 0 256zM294.6 135.1l99.9 107.1c3.5 3.8 5.5 8.7 5.5 13.8s-2 10.1-5.5 13.8L294.6 376.9c-4.2 4.5-10.1 7.1-16.3 7.1C266 384 256 374 256 361.7l0-57.7-96 0c-17.7 0-32-14.3-32-32l0-32c0-17.7 14.3-32 32-32l96 0 0-57.7c0-12.3 10-22.3 22.3-22.3c6.2 0 12.1 2.6 16.3 7.1z"
+            fill="currentColor"
+          />
+        </svg>
       </button>
     </nav>
   </div>

--- a/apps/mark-scan/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/admin_screen.tsx
@@ -172,7 +172,7 @@ export function AdminScreen({
             </Font>{' '}
             Election Definition is loaded.{' '}
           </P>
-          <Button variant="danger" small onPress={unconfigure}>
+          <Button variant="danger" icon="DangerX" small onPress={unconfigure}>
             Unconfigure Machine
           </Button>
           <H6 as="h2">USB</H6>

--- a/apps/mark-scan/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/admin_screen.tsx
@@ -172,7 +172,7 @@ export function AdminScreen({
             </Font>{' '}
             Election Definition is loaded.{' '}
           </P>
-          <Button variant="danger" icon="DangerX" small onPress={unconfigure}>
+          <Button variant="danger" icon="Delete" small onPress={unconfigure}>
             Unconfigure Machine
           </Button>
           <H6 as="h2">USB</H6>

--- a/apps/mark-scan/frontend/src/pages/contest_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/contest_page.tsx
@@ -76,7 +76,8 @@ export function ContestPage(): JSX.Element {
   const nextContestButton = (
     <LinkButton
       id="next"
-      variant={isVoteComplete ? 'next' : 'nextSecondary'}
+      rightIcon="Next"
+      variant={isVoteComplete ? 'primary' : 'neutral'}
       aria-label="next contest"
       to={nextContest ? `/contests/${nextContestIndex}` : '/review'}
     >
@@ -86,7 +87,7 @@ export function ContestPage(): JSX.Element {
 
   const previousContestButton = (
     <LinkButton
-      variant="previous"
+      icon="Previous"
       id="previous"
       aria-label="previous contest"
       to={prevContest ? `/contests/${prevContestIndex}` : '/'}
@@ -98,7 +99,8 @@ export function ContestPage(): JSX.Element {
 
   const reviewScreenButton = (
     <LinkButton
-      variant={isVoteComplete ? 'next' : 'nextSecondary'}
+      rightIcon="Next"
+      variant={isVoteComplete ? 'primary' : 'neutral'}
       to={`/review#contest-${contest.id}`}
       id="next"
     >

--- a/apps/mark-scan/frontend/src/pages/continue_to_review_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/continue_to_review_page.tsx
@@ -17,7 +17,7 @@ export function ContinueToReviewPage(): JSX.Element {
         </Text>
       </Main>
       <ButtonFooter>
-        <LinkButton to="/review" id="next" variant="done">
+        <LinkButton to="/review" id="next" variant="primary" icon="Done">
           Return to Ballot Review
         </LinkButton>
       </ButtonFooter>

--- a/apps/mark-scan/frontend/src/pages/diagnostics_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/diagnostics_screen.tsx
@@ -302,7 +302,11 @@ export function DiagnosticsScreen({
             <Prose compact maxWidth={false}>
               <H1>System Diagnostics</H1>
               <P>
-                <Button variant="previousPrimary" onPress={onBackButtonPress}>
+                <Button
+                  icon="Previous"
+                  variant="primary"
+                  onPress={onBackButtonPress}
+                >
                   Back to Poll Worker Actions
                 </Button>
               </P>

--- a/apps/mark-scan/frontend/src/pages/pat_device_identification/confirm_exit_pat_device_identification_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/pat_device_identification/confirm_exit_pat_device_identification_page.tsx
@@ -21,10 +21,10 @@ export function ConfirmExitPatDeviceIdentificationPage({
         </PortraitStepInnerContainer>
       </Main>
       <ButtonFooter>
-        <Button variant="previous" onPress={onPressBack}>
+        <Button icon="Previous" onPress={onPressBack}>
           Back
         </Button>
-        <Button variant="next" onPress={onPressContinue}>
+        <Button variant="primary" rightIcon="Next" onPress={onPressContinue}>
           Continue with Voting
         </Button>
       </ButtonFooter>

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
@@ -256,7 +256,7 @@ export function PollWorkerScreen({
             <P>
               <Button
                 variant="danger"
-                icon="DangerX"
+                icon="Delete"
                 onPress={resetCardlessVoterSession}
               >
                 Reset Ballot

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
@@ -254,7 +254,11 @@ export function PollWorkerScreen({
               Remove card to allow voter to continue voting, or reset ballot.
             </P>
             <P>
-              <Button variant="danger" onPress={resetCardlessVoterSession}>
+              <Button
+                variant="danger"
+                icon="DangerX"
+                onPress={resetCardlessVoterSession}
+              >
                 Reset Ballot
               </Button>
             </P>
@@ -437,7 +441,8 @@ export function PollWorkerScreen({
                 <React.Fragment>
                   <P>
                     <Button
-                      variant="previousPrimary"
+                      variant="primary"
+                      icon="Previous"
                       onPress={() => setIsHidingSelectBallotStyle(false)}
                     >
                       Back to Ballot Style Selection
@@ -493,7 +498,11 @@ export function PollWorkerScreen({
           }
           actions={
             <React.Fragment>
-              <Button variant="danger" onPress={confirmEnableLiveMode}>
+              <Button
+                variant="danger"
+                icon="Danger"
+                onPress={confirmEnableLiveMode}
+              >
                 Switch to Official Ballot Mode
               </Button>
               <Button onPress={cancelEnableLiveMode}>Cancel</Button>

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
@@ -111,7 +111,7 @@ function UpdatePollsButton({
   return (
     <React.Fragment>
       <Button
-        variant={isPrimaryButton ? 'primary' : 'regular'}
+        variant={isPrimaryButton ? 'primary' : 'neutral'}
         onPress={() => setIsConfirmationModalOpen(true)}
       >
         {action}
@@ -384,7 +384,7 @@ export function PollWorkerScreen({
                           variant={
                             selectedCardlessVoterPrecinctId === precinct.id
                               ? 'primary'
-                              : 'regular'
+                              : 'neutral'
                           }
                         >
                           {precinct.name}

--- a/apps/mark-scan/frontend/src/pages/review_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/review_page.tsx
@@ -38,7 +38,7 @@ export function ReviewPage(): JSX.Element {
   );
 
   const printMyBallotButton = (
-    <LinkButton to="/print" id="next" variant="done">
+    <LinkButton to="/print" id="next" variant="primary" icon="Done">
       Print My Ballot
     </LinkButton>
   );

--- a/apps/mark-scan/frontend/src/pages/validate_ballot_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/validate_ballot_page.tsx
@@ -98,7 +98,11 @@ export function ValidateBallotPage(): JSX.Element | null {
       </Main>
       <ButtonFooter>
         {settingsButton}
-        <Button variant="danger" onPress={invalidateBallotCallback}>
+        <Button
+          variant="danger"
+          icon="Danger"
+          onPress={invalidateBallotCallback}
+        >
           My Ballot is Incorrect
         </Button>
         <Button onPress={validateBallotCallback}>My Ballot is Correct</Button>

--- a/apps/mark/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
@@ -137,10 +137,6 @@ exports[`Single Seat Contest 1`] = `
   cursor: not-allowed;
 }
 
-.c25 {
-  display: inline-block;
-}
-
 .c15 {
   display: inline-block;
   -webkit-box-flex: 1;
@@ -316,7 +312,7 @@ exports[`Single Seat Contest 1`] = `
   justify-content: space-between;
 }
 
-.c26 {
+.c25 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -823,25 +819,21 @@ exports[`Single Seat Contest 1`] = `
         id="previous"
         type="button"
       >
-        <span
-          class="c25"
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-circle-left "
+          data-icon="circle-left"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <svg
-            aria-hidden="true"
-            class="svg-inline--fa fa-circle-left "
-            data-icon="circle-left"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M512 256A256 256 0 1 0 0 256a256 256 0 1 0 512 0zM217.4 376.9L117.5 269.8c-3.5-3.8-5.5-8.7-5.5-13.8s2-10.1 5.5-13.8l99.9-107.1c4.2-4.5 10.1-7.1 16.3-7.1c12.3 0 22.3 10 22.3 22.3l0 57.7 96 0c17.7 0 32 14.3 32 32l0 32c0 17.7-14.3 32-32 32l-96 0 0 57.7c0 12.3-10 22.3-22.3 22.3c-6.2 0-12.1-2.6-16.3-7.1z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
+          <path
+            d="M512 256A256 256 0 1 0 0 256a256 256 0 1 0 512 0zM217.4 376.9L117.5 269.8c-3.5-3.8-5.5-8.7-5.5-13.8s2-10.1 5.5-13.8l99.9-107.1c4.2-4.5 10.1-7.1 16.3-7.1c12.3 0 22.3 10 22.3 22.3l0 57.7 96 0c17.7 0 32 14.3 32 32l0 32c0 17.7-14.3 32-32 32l-96 0 0 57.7c0 12.3-10 22.3-22.3 22.3c-6.2 0-12.1-2.6-16.3-7.1z"
+            fill="currentColor"
+          />
+        </svg>
         <span
           class="c15"
         >
@@ -860,7 +852,7 @@ exports[`Single Seat Contest 1`] = `
           class="c15"
         >
           <span
-            class="c26"
+            class="c25"
           >
             <svg
               aria-hidden="true"
@@ -892,25 +884,6 @@ exports[`Single Seat Contest 1`] = `
         type="button"
       >
         <span
-          class="c25"
-        >
-          <svg
-            aria-hidden="true"
-            class="svg-inline--fa fa-circle-right "
-            data-icon="circle-right"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M0 256a256 256 0 1 0 512 0A256 256 0 1 0 0 256zM294.6 135.1l99.9 107.1c3.5 3.8 5.5 8.7 5.5 13.8s-2 10.1-5.5 13.8L294.6 376.9c-4.2 4.5-10.1 7.1-16.3 7.1C266 384 256 374 256 361.7l0-57.7-96 0c-17.7 0-32-14.3-32-32l0-32c0-17.7 14.3-32 32-32l96 0 0-57.7c0-12.3 10-22.3 22.3-22.3c6.2 0 12.1 2.6 16.3 7.1z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
-        <span
           class="c15"
         >
           <span
@@ -919,6 +892,21 @@ exports[`Single Seat Contest 1`] = `
             Next
           </span>
         </span>
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-circle-right "
+          data-icon="circle-right"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M0 256a256 256 0 1 0 512 0A256 256 0 1 0 0 256zM294.6 135.1l99.9 107.1c3.5 3.8 5.5 8.7 5.5 13.8s-2 10.1-5.5 13.8L294.6 376.9c-4.2 4.5-10.1 7.1-16.3 7.1C266 384 256 374 256 361.7l0-57.7-96 0c-17.7 0-32-14.3-32-32l0-32c0-17.7 14.3-32 32-32l96 0 0-57.7c0-12.3 10-22.3 22.3-22.3c6.2 0 12.1 2.6 16.3 7.1z"
+            fill="currentColor"
+          />
+        </svg>
       </button>
     </nav>
   </div>

--- a/apps/mark/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
@@ -197,10 +197,6 @@ exports[`Single Seat Contest 1`] = `
   cursor: not-allowed;
 }
 
-.c28 {
-  display: inline-block;
-}
-
 .c15 {
   display: inline-block;
   -webkit-box-flex: 1;
@@ -422,7 +418,7 @@ exports[`Single Seat Contest 1`] = `
   justify-content: space-between;
 }
 
-.c29 {
+.c28 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1330,25 +1326,21 @@ exports[`Single Seat Contest 1`] = `
         id="previous"
         type="button"
       >
-        <span
-          class="c28"
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-circle-left "
+          data-icon="circle-left"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <svg
-            aria-hidden="true"
-            class="svg-inline--fa fa-circle-left "
-            data-icon="circle-left"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M512 256A256 256 0 1 0 0 256a256 256 0 1 0 512 0zM217.4 376.9L117.5 269.8c-3.5-3.8-5.5-8.7-5.5-13.8s2-10.1 5.5-13.8l99.9-107.1c4.2-4.5 10.1-7.1 16.3-7.1c12.3 0 22.3 10 22.3 22.3l0 57.7 96 0c17.7 0 32 14.3 32 32l0 32c0 17.7-14.3 32-32 32l-96 0 0 57.7c0 12.3-10 22.3-22.3 22.3c-6.2 0-12.1-2.6-16.3-7.1z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
+          <path
+            d="M512 256A256 256 0 1 0 0 256a256 256 0 1 0 512 0zM217.4 376.9L117.5 269.8c-3.5-3.8-5.5-8.7-5.5-13.8s2-10.1 5.5-13.8l99.9-107.1c4.2-4.5 10.1-7.1 16.3-7.1c12.3 0 22.3 10 22.3 22.3l0 57.7 96 0c17.7 0 32 14.3 32 32l0 32c0 17.7-14.3 32-32 32l-96 0 0 57.7c0 12.3-10 22.3-22.3 22.3c-6.2 0-12.1-2.6-16.3-7.1z"
+            fill="currentColor"
+          />
+        </svg>
         <span
           class="c15"
         >
@@ -1367,7 +1359,7 @@ exports[`Single Seat Contest 1`] = `
           class="c15"
         >
           <span
-            class="c29"
+            class="c28"
           >
             <svg
               aria-hidden="true"
@@ -1399,25 +1391,6 @@ exports[`Single Seat Contest 1`] = `
         type="button"
       >
         <span
-          class="c28"
-        >
-          <svg
-            aria-hidden="true"
-            class="svg-inline--fa fa-circle-right "
-            data-icon="circle-right"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M0 256a256 256 0 1 0 512 0A256 256 0 1 0 0 256zM294.6 135.1l99.9 107.1c3.5 3.8 5.5 8.7 5.5 13.8s-2 10.1-5.5 13.8L294.6 376.9c-4.2 4.5-10.1 7.1-16.3 7.1C266 384 256 374 256 361.7l0-57.7-96 0c-17.7 0-32-14.3-32-32l0-32c0-17.7 14.3-32 32-32l96 0 0-57.7c0-12.3 10-22.3 22.3-22.3c6.2 0 12.1 2.6 16.3 7.1z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
-        <span
           class="c15"
         >
           <span
@@ -1426,6 +1399,21 @@ exports[`Single Seat Contest 1`] = `
             Next
           </span>
         </span>
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-circle-right "
+          data-icon="circle-right"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M0 256a256 256 0 1 0 512 0A256 256 0 1 0 0 256zM294.6 135.1l99.9 107.1c3.5 3.8 5.5 8.7 5.5 13.8s-2 10.1-5.5 13.8L294.6 376.9c-4.2 4.5-10.1 7.1-16.3 7.1C266 384 256 374 256 361.7l0-57.7-96 0c-17.7 0-32-14.3-32-32l0-32c0-17.7 14.3-32 32-32l96 0 0-57.7c0-12.3 10-22.3 22.3-22.3c6.2 0 12.1 2.6 16.3 7.1z"
+            fill="currentColor"
+          />
+        </svg>
       </button>
     </nav>
   </div>

--- a/apps/mark/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
@@ -197,10 +197,6 @@ exports[`Single Seat Contest 1`] = `
   cursor: not-allowed;
 }
 
-.c28 {
-  display: inline-block;
-}
-
 .c15 {
   display: inline-block;
   -webkit-box-flex: 1;
@@ -422,7 +418,7 @@ exports[`Single Seat Contest 1`] = `
   justify-content: space-between;
 }
 
-.c29 {
+.c28 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -994,25 +990,21 @@ exports[`Single Seat Contest 1`] = `
         id="previous"
         type="button"
       >
-        <span
-          class="c28"
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-circle-left "
+          data-icon="circle-left"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <svg
-            aria-hidden="true"
-            class="svg-inline--fa fa-circle-left "
-            data-icon="circle-left"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M512 256A256 256 0 1 0 0 256a256 256 0 1 0 512 0zM217.4 376.9L117.5 269.8c-3.5-3.8-5.5-8.7-5.5-13.8s2-10.1 5.5-13.8l99.9-107.1c4.2-4.5 10.1-7.1 16.3-7.1c12.3 0 22.3 10 22.3 22.3l0 57.7 96 0c17.7 0 32 14.3 32 32l0 32c0 17.7-14.3 32-32 32l-96 0 0 57.7c0 12.3-10 22.3-22.3 22.3c-6.2 0-12.1-2.6-16.3-7.1z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
+          <path
+            d="M512 256A256 256 0 1 0 0 256a256 256 0 1 0 512 0zM217.4 376.9L117.5 269.8c-3.5-3.8-5.5-8.7-5.5-13.8s2-10.1 5.5-13.8l99.9-107.1c4.2-4.5 10.1-7.1 16.3-7.1c12.3 0 22.3 10 22.3 22.3l0 57.7 96 0c17.7 0 32 14.3 32 32l0 32c0 17.7-14.3 32-32 32l-96 0 0 57.7c0 12.3-10 22.3-22.3 22.3c-6.2 0-12.1-2.6-16.3-7.1z"
+            fill="currentColor"
+          />
+        </svg>
         <span
           class="c15"
         >
@@ -1031,7 +1023,7 @@ exports[`Single Seat Contest 1`] = `
           class="c15"
         >
           <span
-            class="c29"
+            class="c28"
           >
             <svg
               aria-hidden="true"
@@ -1063,25 +1055,6 @@ exports[`Single Seat Contest 1`] = `
         type="button"
       >
         <span
-          class="c28"
-        >
-          <svg
-            aria-hidden="true"
-            class="svg-inline--fa fa-circle-right "
-            data-icon="circle-right"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M0 256a256 256 0 1 0 512 0A256 256 0 1 0 0 256zM294.6 135.1l99.9 107.1c3.5 3.8 5.5 8.7 5.5 13.8s-2 10.1-5.5 13.8L294.6 376.9c-4.2 4.5-10.1 7.1-16.3 7.1C266 384 256 374 256 361.7l0-57.7-96 0c-17.7 0-32-14.3-32-32l0-32c0-17.7 14.3-32 32-32l96 0 0-57.7c0-12.3 10-22.3 22.3-22.3c6.2 0 12.1 2.6 16.3 7.1z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
-        <span
           class="c15"
         >
           <span
@@ -1090,6 +1063,21 @@ exports[`Single Seat Contest 1`] = `
             Next
           </span>
         </span>
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-circle-right "
+          data-icon="circle-right"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M0 256a256 256 0 1 0 512 0A256 256 0 1 0 0 256zM294.6 135.1l99.9 107.1c3.5 3.8 5.5 8.7 5.5 13.8s-2 10.1-5.5 13.8L294.6 376.9c-4.2 4.5-10.1 7.1-16.3 7.1C266 384 256 374 256 361.7l0-57.7-96 0c-17.7 0-32-14.3-32-32l0-32c0-17.7 14.3-32 32-32l96 0 0-57.7c0-12.3 10-22.3 22.3-22.3c6.2 0 12.1 2.6 16.3 7.1z"
+            fill="currentColor"
+          />
+        </svg>
       </button>
     </nav>
   </div>

--- a/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
@@ -137,10 +137,6 @@ exports[`Single Seat Contest with Write In 1`] = `
   cursor: not-allowed;
 }
 
-.c25 {
-  display: inline-block;
-}
-
 .c15 {
   display: inline-block;
   -webkit-box-flex: 1;
@@ -316,7 +312,7 @@ exports[`Single Seat Contest with Write In 1`] = `
   justify-content: space-between;
 }
 
-.c26 {
+.c25 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -671,25 +667,21 @@ exports[`Single Seat Contest with Write In 1`] = `
         id="previous"
         type="button"
       >
-        <span
-          class="c25"
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-circle-left "
+          data-icon="circle-left"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <svg
-            aria-hidden="true"
-            class="svg-inline--fa fa-circle-left "
-            data-icon="circle-left"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M512 256A256 256 0 1 0 0 256a256 256 0 1 0 512 0zM217.4 376.9L117.5 269.8c-3.5-3.8-5.5-8.7-5.5-13.8s2-10.1 5.5-13.8l99.9-107.1c4.2-4.5 10.1-7.1 16.3-7.1c12.3 0 22.3 10 22.3 22.3l0 57.7 96 0c17.7 0 32 14.3 32 32l0 32c0 17.7-14.3 32-32 32l-96 0 0 57.7c0 12.3-10 22.3-22.3 22.3c-6.2 0-12.1-2.6-16.3-7.1z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
+          <path
+            d="M512 256A256 256 0 1 0 0 256a256 256 0 1 0 512 0zM217.4 376.9L117.5 269.8c-3.5-3.8-5.5-8.7-5.5-13.8s2-10.1 5.5-13.8l99.9-107.1c4.2-4.5 10.1-7.1 16.3-7.1c12.3 0 22.3 10 22.3 22.3l0 57.7 96 0c17.7 0 32 14.3 32 32l0 32c0 17.7-14.3 32-32 32l-96 0 0 57.7c0 12.3-10 22.3-22.3 22.3c-6.2 0-12.1-2.6-16.3-7.1z"
+            fill="currentColor"
+          />
+        </svg>
         <span
           class="c15"
         >
@@ -708,7 +700,7 @@ exports[`Single Seat Contest with Write In 1`] = `
           class="c15"
         >
           <span
-            class="c26"
+            class="c25"
           >
             <svg
               aria-hidden="true"
@@ -740,25 +732,6 @@ exports[`Single Seat Contest with Write In 1`] = `
         type="button"
       >
         <span
-          class="c25"
-        >
-          <svg
-            aria-hidden="true"
-            class="svg-inline--fa fa-circle-right "
-            data-icon="circle-right"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M0 256a256 256 0 1 0 512 0A256 256 0 1 0 0 256zM294.6 135.1l99.9 107.1c3.5 3.8 5.5 8.7 5.5 13.8s-2 10.1-5.5 13.8L294.6 376.9c-4.2 4.5-10.1 7.1-16.3 7.1C266 384 256 374 256 361.7l0-57.7-96 0c-17.7 0-32-14.3-32-32l0-32c0-17.7 14.3-32 32-32l96 0 0-57.7c0-12.3 10-22.3 22.3-22.3c6.2 0 12.1 2.6 16.3 7.1z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
-        <span
           class="c15"
         >
           <span
@@ -767,6 +740,21 @@ exports[`Single Seat Contest with Write In 1`] = `
             Next
           </span>
         </span>
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-circle-right "
+          data-icon="circle-right"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M0 256a256 256 0 1 0 512 0A256 256 0 1 0 0 256zM294.6 135.1l99.9 107.1c3.5 3.8 5.5 8.7 5.5 13.8s-2 10.1-5.5 13.8L294.6 376.9c-4.2 4.5-10.1 7.1-16.3 7.1C266 384 256 374 256 361.7l0-57.7-96 0c-17.7 0-32-14.3-32-32l0-32c0-17.7 14.3-32 32-32l96 0 0-57.7c0-12.3 10-22.3 22.3-22.3c6.2 0 12.1 2.6 16.3 7.1z"
+            fill="currentColor"
+          />
+        </svg>
       </button>
     </nav>
   </div>

--- a/apps/mark/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
@@ -137,10 +137,6 @@ exports[`Renders ContestPage 1`] = `
   cursor: not-allowed;
 }
 
-.c24 {
-  display: inline-block;
-}
-
 .c14 {
   display: inline-block;
   -webkit-box-flex: 1;
@@ -316,7 +312,7 @@ exports[`Renders ContestPage 1`] = `
   justify-content: space-between;
 }
 
-.c25 {
+.c24 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -824,25 +820,21 @@ exports[`Renders ContestPage 1`] = `
         id="previous"
         type="button"
       >
-        <span
-          class="c24"
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-circle-left "
+          data-icon="circle-left"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <svg
-            aria-hidden="true"
-            class="svg-inline--fa fa-circle-left "
-            data-icon="circle-left"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M512 256A256 256 0 1 0 0 256a256 256 0 1 0 512 0zM217.4 376.9L117.5 269.8c-3.5-3.8-5.5-8.7-5.5-13.8s2-10.1 5.5-13.8l99.9-107.1c4.2-4.5 10.1-7.1 16.3-7.1c12.3 0 22.3 10 22.3 22.3l0 57.7 96 0c17.7 0 32 14.3 32 32l0 32c0 17.7-14.3 32-32 32l-96 0 0 57.7c0 12.3-10 22.3-22.3 22.3c-6.2 0-12.1-2.6-16.3-7.1z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
+          <path
+            d="M512 256A256 256 0 1 0 0 256a256 256 0 1 0 512 0zM217.4 376.9L117.5 269.8c-3.5-3.8-5.5-8.7-5.5-13.8s2-10.1 5.5-13.8l99.9-107.1c4.2-4.5 10.1-7.1 16.3-7.1c12.3 0 22.3 10 22.3 22.3l0 57.7 96 0c17.7 0 32 14.3 32 32l0 32c0 17.7-14.3 32-32 32l-96 0 0 57.7c0 12.3-10 22.3-22.3 22.3c-6.2 0-12.1-2.6-16.3-7.1z"
+            fill="currentColor"
+          />
+        </svg>
         <span
           class="c14"
         >
@@ -861,7 +853,7 @@ exports[`Renders ContestPage 1`] = `
           class="c14"
         >
           <span
-            class="c25"
+            class="c24"
           >
             <svg
               aria-hidden="true"
@@ -893,25 +885,6 @@ exports[`Renders ContestPage 1`] = `
         type="button"
       >
         <span
-          class="c24"
-        >
-          <svg
-            aria-hidden="true"
-            class="svg-inline--fa fa-circle-right "
-            data-icon="circle-right"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M0 256a256 256 0 1 0 512 0A256 256 0 1 0 0 256zM294.6 135.1l99.9 107.1c3.5 3.8 5.5 8.7 5.5 13.8s-2 10.1-5.5 13.8L294.6 376.9c-4.2 4.5-10.1 7.1-16.3 7.1C266 384 256 374 256 361.7l0-57.7-96 0c-17.7 0-32-14.3-32-32l0-32c0-17.7 14.3-32 32-32l96 0 0-57.7c0-12.3 10-22.3 22.3-22.3c6.2 0 12.1 2.6 16.3 7.1z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
-        <span
           class="c14"
         >
           <span
@@ -920,6 +893,21 @@ exports[`Renders ContestPage 1`] = `
             Next
           </span>
         </span>
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-circle-right "
+          data-icon="circle-right"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M0 256a256 256 0 1 0 512 0A256 256 0 1 0 0 256zM294.6 135.1l99.9 107.1c3.5 3.8 5.5 8.7 5.5 13.8s-2 10.1-5.5 13.8L294.6 376.9c-4.2 4.5-10.1 7.1-16.3 7.1C266 384 256 374 256 361.7l0-57.7-96 0c-17.7 0-32-14.3-32-32l0-32c0-17.7 14.3-32 32-32l96 0 0-57.7c0-12.3 10-22.3 22.3-22.3c6.2 0 12.1 2.6 16.3 7.1z"
+            fill="currentColor"
+          />
+        </svg>
       </button>
     </nav>
   </div>
@@ -1063,10 +1051,6 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
   cursor: not-allowed;
 }
 
-.c24 {
-  display: inline-block;
-}
-
 .c14 {
   display: inline-block;
   -webkit-box-flex: 1;
@@ -1242,7 +1226,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
   justify-content: space-between;
 }
 
-.c25 {
+.c24 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1750,25 +1734,21 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
         id="previous"
         type="button"
       >
-        <span
-          class="c24"
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-circle-left "
+          data-icon="circle-left"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <svg
-            aria-hidden="true"
-            class="svg-inline--fa fa-circle-left "
-            data-icon="circle-left"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M512 256A256 256 0 1 0 0 256a256 256 0 1 0 512 0zM217.4 376.9L117.5 269.8c-3.5-3.8-5.5-8.7-5.5-13.8s2-10.1 5.5-13.8l99.9-107.1c4.2-4.5 10.1-7.1 16.3-7.1c12.3 0 22.3 10 22.3 22.3l0 57.7 96 0c17.7 0 32 14.3 32 32l0 32c0 17.7-14.3 32-32 32l-96 0 0 57.7c0 12.3-10 22.3-22.3 22.3c-6.2 0-12.1-2.6-16.3-7.1z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
+          <path
+            d="M512 256A256 256 0 1 0 0 256a256 256 0 1 0 512 0zM217.4 376.9L117.5 269.8c-3.5-3.8-5.5-8.7-5.5-13.8s2-10.1 5.5-13.8l99.9-107.1c4.2-4.5 10.1-7.1 16.3-7.1c12.3 0 22.3 10 22.3 22.3l0 57.7 96 0c17.7 0 32 14.3 32 32l0 32c0 17.7-14.3 32-32 32l-96 0 0 57.7c0 12.3-10 22.3-22.3 22.3c-6.2 0-12.1-2.6-16.3-7.1z"
+            fill="currentColor"
+          />
+        </svg>
         <span
           class="c14"
         >
@@ -1787,7 +1767,7 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
           class="c14"
         >
           <span
-            class="c25"
+            class="c24"
           >
             <svg
               aria-hidden="true"
@@ -1819,25 +1799,6 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
         type="button"
       >
         <span
-          class="c24"
-        >
-          <svg
-            aria-hidden="true"
-            class="svg-inline--fa fa-circle-right "
-            data-icon="circle-right"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M0 256a256 256 0 1 0 512 0A256 256 0 1 0 0 256zM294.6 135.1l99.9 107.1c3.5 3.8 5.5 8.7 5.5 13.8s-2 10.1-5.5 13.8L294.6 376.9c-4.2 4.5-10.1 7.1-16.3 7.1C266 384 256 374 256 361.7l0-57.7-96 0c-17.7 0-32-14.3-32-32l0-32c0-17.7 14.3-32 32-32l96 0 0-57.7c0-12.3 10-22.3 22.3-22.3c6.2 0 12.1 2.6 16.3 7.1z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
-        <span
           class="c14"
         >
           <span
@@ -1846,6 +1807,21 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
             Next
           </span>
         </span>
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-circle-right "
+          data-icon="circle-right"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M0 256a256 256 0 1 0 512 0A256 256 0 1 0 0 256zM294.6 135.1l99.9 107.1c3.5 3.8 5.5 8.7 5.5 13.8s-2 10.1-5.5 13.8L294.6 376.9c-4.2 4.5-10.1 7.1-16.3 7.1C266 384 256 374 256 361.7l0-57.7-96 0c-17.7 0-32-14.3-32-32l0-32c0-17.7 14.3-32 32-32l96 0 0-57.7c0-12.3 10-22.3 22.3-22.3c6.2 0 12.1 2.6 16.3 7.1z"
+            fill="currentColor"
+          />
+        </svg>
       </button>
     </nav>
   </div>

--- a/apps/mark/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.tsx
@@ -158,7 +158,7 @@ export function AdminScreen({
             </Font>{' '}
             Election Definition is loaded.{' '}
           </P>
-          <Button variant="danger" icon="DangerX" small onPress={unconfigure}>
+          <Button variant="danger" icon="Delete" small onPress={unconfigure}>
             Unconfigure Machine
           </Button>
           <H6 as="h2">USB</H6>

--- a/apps/mark/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.tsx
@@ -158,7 +158,7 @@ export function AdminScreen({
             </Font>{' '}
             Election Definition is loaded.{' '}
           </P>
-          <Button variant="danger" small onPress={unconfigure}>
+          <Button variant="danger" icon="DangerX" small onPress={unconfigure}>
             Unconfigure Machine
           </Button>
           <H6 as="h2">USB</H6>

--- a/apps/mark/frontend/src/pages/contest_page.tsx
+++ b/apps/mark/frontend/src/pages/contest_page.tsx
@@ -69,7 +69,8 @@ export function ContestPage(): JSX.Element {
   const nextContestButton = (
     <LinkButton
       id="next"
-      variant={isVoteComplete ? 'next' : 'nextSecondary'}
+      rightIcon="Next"
+      variant={isVoteComplete ? 'primary' : 'neutral'}
       aria-label="next contest"
       to={nextContest ? `/contests/${nextContestIndex}` : '/review'}
     >
@@ -79,7 +80,7 @@ export function ContestPage(): JSX.Element {
 
   const previousContestButton = (
     <LinkButton
-      variant="previous"
+      icon="Previous"
       id="previous"
       aria-label="previous contest"
       to={prevContest ? `/contests/${prevContestIndex}` : '/'}
@@ -91,7 +92,8 @@ export function ContestPage(): JSX.Element {
 
   const reviewScreenButton = (
     <LinkButton
-      variant={isVoteComplete ? 'next' : 'nextSecondary'}
+      rightIcon="Next"
+      variant={isVoteComplete ? 'primary' : 'neutral'}
       to={`/review#contest-${contest.id}`}
       id="next"
     >

--- a/apps/mark/frontend/src/pages/diagnostics_screen.tsx
+++ b/apps/mark/frontend/src/pages/diagnostics_screen.tsx
@@ -302,7 +302,11 @@ export function DiagnosticsScreen({
             <Prose compact maxWidth={false}>
               <H1>System Diagnostics</H1>
               <P>
-                <Button variant="previousPrimary" onPress={onBackButtonPress}>
+                <Button
+                  icon="Previous"
+                  variant="primary"
+                  onPress={onBackButtonPress}
+                >
                   Back to Poll Worker Actions
                 </Button>
               </P>

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -237,7 +237,7 @@ export function PollWorkerScreen({
             <P>
               <Button
                 variant="danger"
-                icon="DangerX"
+                icon="Delete"
                 onPress={resetCardlessVoterSession}
               >
                 Reset Ballot

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -105,7 +105,7 @@ function UpdatePollsButton({
   return (
     <React.Fragment>
       <Button
-        variant={isPrimaryButton ? 'primary' : 'regular'}
+        variant={isPrimaryButton ? 'primary' : 'neutral'}
         onPress={() => setIsConfirmationModalOpen(true)}
       >
         {action}
@@ -339,7 +339,7 @@ export function PollWorkerScreen({
                           variant={
                             selectedCardlessVoterPrecinctId === precinct.id
                               ? 'primary'
-                              : 'regular'
+                              : 'neutral'
                           }
                         >
                           {precinct.name}

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -235,7 +235,11 @@ export function PollWorkerScreen({
               Remove card to allow voter to continue voting, or reset ballot.
             </P>
             <P>
-              <Button variant="danger" onPress={resetCardlessVoterSession}>
+              <Button
+                variant="danger"
+                icon="DangerX"
+                onPress={resetCardlessVoterSession}
+              >
                 Reset Ballot
               </Button>
             </P>
@@ -388,7 +392,8 @@ export function PollWorkerScreen({
                 <React.Fragment>
                   <P>
                     <Button
-                      variant="previousPrimary"
+                      icon="Previous"
+                      variant="primary"
                       onPress={() => setIsHidingSelectBallotStyle(false)}
                     >
                       Back to Ballot Style Selection
@@ -444,7 +449,11 @@ export function PollWorkerScreen({
           }
           actions={
             <React.Fragment>
-              <Button variant="danger" onPress={confirmEnableLiveMode}>
+              <Button
+                variant="danger"
+                icon="Danger"
+                onPress={confirmEnableLiveMode}
+              >
                 Switch to Official Ballot Mode
               </Button>
               <Button onPress={cancelEnableLiveMode}>Cancel</Button>

--- a/apps/mark/frontend/src/pages/review_page.tsx
+++ b/apps/mark/frontend/src/pages/review_page.tsx
@@ -38,7 +38,7 @@ export function ReviewPage(): JSX.Element {
   );
 
   const printMyBallotButton = (
-    <LinkButton to="/print" id="next" variant="done">
+    <LinkButton to="/print" id="next" variant="primary" icon="Done">
       Print My Ballot
     </LinkButton>
   );

--- a/apps/scan/frontend/src/app.tsx
+++ b/apps/scan/frontend/src/app.tsx
@@ -60,7 +60,7 @@ export function App({
           errorMessage={
             <React.Fragment>
               <FullScreenIconWrapper color="danger">
-                <Icons.DangerX />
+                <Icons.Delete />
               </FullScreenIconWrapper>
               <CenteredLargeProse>
                 <H1>Something went wrong</H1>

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -290,7 +290,7 @@ export function ElectionManagerScreen({
               }
               actions={
                 <React.Fragment>
-                  <Button onPress={switchMode} variant="danger">
+                  <Button onPress={switchMode} variant="danger" icon="Danger">
                     Yes, Switch
                   </Button>
                   <Button
@@ -329,7 +329,7 @@ export function ElectionManagerScreen({
               }
               actions={
                 <React.Fragment>
-                  <Button onPress={unconfigure} variant="danger">
+                  <Button onPress={unconfigure} variant="danger" icon="DangerX">
                     Yes, Delete All
                   </Button>
                   <Button onPress={() => setIsConfirmingUnconfigure(false)}>

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -329,7 +329,7 @@ export function ElectionManagerScreen({
               }
               actions={
                 <React.Fragment>
-                  <Button onPress={unconfigure} variant="danger" icon="DangerX">
+                  <Button onPress={unconfigure} variant="danger" icon="Delete">
                     Yes, Delete All
                   </Button>
                   <Button onPress={() => setIsConfirmingUnconfigure(false)}>

--- a/apps/scan/frontend/src/screens/poll_worker_screen.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.tsx
@@ -78,7 +78,7 @@ const BallotsAlreadyScannedScreen = (
       title="Ballots Already Scanned"
       image={
         <FullScreenIconWrapper color="danger">
-          <Icons.DangerX />
+          <Icons.Delete />
         </FullScreenIconWrapper>
       }
     >

--- a/apps/scan/frontend/src/screens/scan_double_sheet_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_double_sheet_screen.tsx
@@ -15,7 +15,7 @@ export function ScanDoubleSheetScreen({
         title="Ballot Not Counted"
         image={
           <FullScreenIconWrapper color="danger">
-            <Icons.DangerX />
+            <Icons.Delete />
           </FullScreenIconWrapper>
         }
       >

--- a/apps/scan/frontend/src/screens/scan_error_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_error_screen.tsx
@@ -63,7 +63,7 @@ export function ScanErrorScreen({
         title="Ballot Not Counted"
         image={
           <FullScreenIconWrapper color="danger">
-            <Icons.DangerX />
+            <Icons.Delete />
           </FullScreenIconWrapper>
         }
       >

--- a/apps/scan/frontend/src/screens/scan_jam_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_jam_screen.tsx
@@ -13,7 +13,7 @@ export function ScanJamScreen({ scannedBallotCount }: Props): JSX.Element {
         title="Ballot Not Counted"
         image={
           <FullScreenIconWrapper color="danger">
-            <Icons.DangerX />
+            <Icons.Delete />
           </FullScreenIconWrapper>
         }
       >

--- a/apps/scan/frontend/src/screens/scan_warning_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_warning_screen.tsx
@@ -52,7 +52,8 @@ function ConfirmModal({ content, onConfirm, onCancel }: ConfirmModalProps) {
       actions={
         <React.Fragment>
           <Button
-            variant="done"
+            variant="primary"
+            icon="Done"
             onPress={() => {
               setConfirmed(true);
               onConfirm();

--- a/libs/mark-flow-ui/src/components/candidate_contest.tsx
+++ b/libs/mark-flow-ui/src/components/candidate_contest.tsx
@@ -215,7 +215,8 @@ export function CandidateContest({
   const modalActions = (
     <React.Fragment>
       <Button
-        variant="done"
+        variant="primary"
+        icon="Done"
         onPress={addWriteInCandidate}
         disabled={normalizeCandidateName(writeInCandidateName).length === 0}
       >
@@ -367,6 +368,7 @@ export function CandidateContest({
             <React.Fragment>
               <Button
                 variant="danger"
+                icon="DangerX"
                 onPress={confirmRemovePendingWriteInCandidate}
               >
                 Yes, Remove.

--- a/libs/mark-flow-ui/src/components/candidate_contest.tsx
+++ b/libs/mark-flow-ui/src/components/candidate_contest.tsx
@@ -368,7 +368,7 @@ export function CandidateContest({
             <React.Fragment>
               <Button
                 variant="danger"
-                icon="DangerX"
+                icon="Delete"
                 onPress={confirmRemovePendingWriteInCandidate}
               >
                 Yes, Remove.

--- a/libs/mark-flow-ui/src/pages/cast_ballot_page.tsx
+++ b/libs/mark-flow-ui/src/pages/cast_ballot_page.tsx
@@ -92,7 +92,11 @@ export function CastBallotPage({
           </P>
         </div>
         <Done>
-          <Button onPress={hidePostVotingInstructions} variant="done">
+          <Button
+            onPress={hidePostVotingInstructions}
+            variant="primary"
+            icon="Done"
+          >
             Done
           </Button>
         </Done>

--- a/libs/ui/src/button.test.tsx
+++ b/libs/ui/src/button.test.tsx
@@ -5,6 +5,7 @@ import { assert } from '@votingworks/basics';
 import { fireEvent, render, screen } from '../test/react_testing_library';
 import { ALL_BUTTON_VARIANTS, Button, DecoyButton } from './button';
 import { makeTheme } from './themes/make_theme';
+import { Icons } from './icons';
 
 function createTouchStartEventProperties(x: number, y: number) {
   return { touches: [{ clientX: x, clientY: y }] };
@@ -158,6 +159,46 @@ describe('renders Button', () => {
     );
   });
 
+  test('with icon component', () => {
+    render(
+      <Button icon={<Icons.Add />} onPress={jest.fn()}>
+        Add
+      </Button>
+    );
+    const button = screen.getButton('Add');
+    expect(button.getElementsByTagName('svg')).toHaveLength(1);
+  });
+
+  test('with icon name', () => {
+    render(
+      <Button icon="Add" onPress={jest.fn()}>
+        Add
+      </Button>
+    );
+    const button = screen.getButton('Add');
+    expect(button.getElementsByTagName('svg')).toHaveLength(1);
+  });
+
+  test('with rightIcon component', () => {
+    render(
+      <Button rightIcon={<Icons.Add />} onPress={jest.fn()}>
+        Add
+      </Button>
+    );
+    const button = screen.getButton('Add');
+    expect(button.getElementsByTagName('svg')).toHaveLength(1);
+  });
+
+  test('with rightIcon name', () => {
+    render(
+      <Button rightIcon="Add" onPress={jest.fn()}>
+        Add
+      </Button>
+    );
+    const button = screen.getButton('Add');
+    expect(button.getElementsByTagName('svg')).toHaveLength(1);
+  });
+
   test('focus()/blur() API', () => {
     const buttonRef = React.createRef<Button>();
 
@@ -193,10 +234,9 @@ describe('renders Button', () => {
     expect(screen.getButton('Confirm')).toHaveFocus();
   });
 
-  test('as DecoyButton with variant warning', () => {
-    render(<DecoyButton variant="warning">DecoyButton</DecoyButton>);
-    const button = screen.getByText('DecoyButton');
-    expect(button).toHaveStyleRule('background', Color.GRAY_DARK);
+  test('as DecoyButton ', () => {
+    render(<DecoyButton>DecoyButton</DecoyButton>);
+    screen.getByText('DecoyButton');
   });
 
   test('and tests clicks and touches', () => {

--- a/libs/ui/src/button.tsx
+++ b/libs/ui/src/button.tsx
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import styled, { css, DefaultTheme, StyledComponent } from 'styled-components';
 import { Color, SizeMode, UiTheme } from '@votingworks/types';
 
-import { Icons } from './icons';
+import { Icons, IconName } from './icons';
 
 const FONT_SIZE_REM = 1;
 
@@ -26,6 +26,8 @@ export interface StyledButtonProps {
   id?: string;
   role?: string;
   variant?: ButtonVariant;
+  icon?: IconName | JSX.Element;
+  rightIcon?: IconName | JSX.Element;
 
   /** @deprecated Place the button within a flex or grid container instead. */
   readonly fullWidth?: boolean;
@@ -66,9 +68,16 @@ export type ButtonInterface = Pick<
   'fullWidth' | 'large' | 'small' | 'variant'
 >;
 
+function resolveIcon(icon: IconName | JSX.Element): JSX.Element {
+  if (typeof icon === 'string') {
+    const Component = Icons[icon];
+    return <Component />;
+  }
+  return icon;
+}
+
 interface VariantConfig {
   color: keyof UiTheme['colors'];
-  icon?: React.ComponentType;
   isSolidColor?: boolean;
 }
 
@@ -76,7 +85,7 @@ const variantConfigs: Record<ButtonVariant, VariantConfig> = {
   regular: { color: 'foreground' },
   primary: { color: 'accentPrimary', isSolidColor: true },
   secondary: { color: 'accentSecondary', isSolidColor: true },
-  danger: { color: 'accentDanger', icon: Icons.Danger, isSolidColor: true },
+  danger: { color: 'accentDanger', isSolidColor: true },
 };
 
 function getVariantConfig(p: StyledButtonProps): VariantConfig {
@@ -191,10 +200,6 @@ const StyledButton = styled('button').attrs(({ type = 'button' }) => ({
   ${buttonStyles}
 `;
 
-const IconContainer = styled.span`
-  display: inline-block;
-`;
-
 const TextContainer = styled.span`
   display: inline-block;
   flex-grow: 1;
@@ -270,10 +275,10 @@ export class Button<T = undefined> extends PureComponent<
       nonAccessibleTitle,
       value, // eslint-disable-line @typescript-eslint/no-unused-vars
       variant,
+      icon,
+      rightIcon,
       ...rest
     } = this.props;
-
-    const Icon = variantConfigs[variant || 'neutral'].icon;
 
     return (
       <Component
@@ -286,12 +291,9 @@ export class Button<T = undefined> extends PureComponent<
         title={nonAccessibleTitle}
         variant={variant}
       >
-        {Icon && (
-          <IconContainer>
-            <Icon />
-          </IconContainer>
-        )}
+        {icon && resolveIcon(icon)}
         {children && <TextContainer>{children}</TextContainer>}
+        {rightIcon && resolveIcon(rightIcon)}
       </Component>
     );
   }

--- a/libs/ui/src/button.tsx
+++ b/libs/ui/src/button.tsx
@@ -8,7 +8,7 @@ import { Icons } from './icons';
 const FONT_SIZE_REM = 1;
 
 export const ALL_BUTTON_VARIANTS = [
-  'regular',
+  'neutral',
   'primary',
   'secondary',
   'danger',
@@ -80,7 +80,7 @@ const variantConfigs: Record<ButtonVariant, VariantConfig> = {
 };
 
 function getVariantConfig(p: StyledButtonProps): VariantConfig {
-  return variantConfigs[p.variant || 'regular'];
+  return variantConfigs[p.variant || 'neutral'];
 }
 
 type ThemedStyledButtonProps = StyledButtonProps & { theme: UiTheme };
@@ -107,7 +107,7 @@ function getForegroundColor(p: ThemedStyledButtonProps): Color | undefined {
     return p.theme.colors.foregroundDisabled;
   }
 
-  const variantConfig = variantConfigs[p.variant || 'regular'];
+  const variantConfig = variantConfigs[p.variant || 'neutral'];
   if (variantConfig.isSolidColor) {
     return p.theme.colors.background;
   }
@@ -116,7 +116,7 @@ function getForegroundColor(p: ThemedStyledButtonProps): Color | undefined {
 }
 
 function getBorderColor(p: ThemedStyledButtonProps): Color | undefined {
-  const variantConfig = variantConfigs[p.variant || 'regular'];
+  const variantConfig = variantConfigs[p.variant || 'neutral'];
   if (variantConfig.isSolidColor) {
     return getBackgroundColor(p);
   }
@@ -273,7 +273,7 @@ export class Button<T = undefined> extends PureComponent<
       ...rest
     } = this.props;
 
-    const Icon = variantConfigs[variant || 'regular'].icon;
+    const Icon = variantConfigs[variant || 'neutral'].icon;
 
     return (
       <Component

--- a/libs/ui/src/button.tsx
+++ b/libs/ui/src/button.tsx
@@ -82,7 +82,7 @@ interface VariantConfig {
 }
 
 const variantConfigs: Record<ButtonVariant, VariantConfig> = {
-  regular: { color: 'foreground' },
+  neutral: { color: 'foreground' },
   primary: { color: 'accentPrimary', isSolidColor: true },
   secondary: { color: 'accentSecondary', isSolidColor: true },
   danger: { color: 'accentDanger', isSolidColor: true },

--- a/libs/ui/src/button.tsx
+++ b/libs/ui/src/button.tsx
@@ -8,18 +8,10 @@ import { Icons } from './icons';
 const FONT_SIZE_REM = 1;
 
 export const ALL_BUTTON_VARIANTS = [
-  'danger',
-  'done',
-  'edit',
-  'next',
-  'nextSecondary',
-  'previous',
-  'previousPrimary',
-  'primary',
   'regular',
+  'primary',
   'secondary',
-  'settings',
-  'warning',
+  'danger',
 ] as const;
 
 export type ButtonVariant = (typeof ALL_BUTTON_VARIANTS)[number];
@@ -81,22 +73,10 @@ interface VariantConfig {
 }
 
 const variantConfigs: Record<ButtonVariant, VariantConfig> = {
-  danger: { color: 'accentDanger', icon: Icons.Danger, isSolidColor: true },
-  done: { color: 'accentPrimary', icon: Icons.Done, isSolidColor: true },
-  edit: { color: 'foreground', icon: Icons.Edit },
-  next: { color: 'accentPrimary', icon: Icons.Next, isSolidColor: true },
-  nextSecondary: { color: 'foreground', icon: Icons.Next, isSolidColor: false },
-  previous: { color: 'foreground', icon: Icons.Previous },
-  previousPrimary: {
-    color: 'accentPrimary',
-    icon: Icons.Previous,
-    isSolidColor: true,
-  },
-  primary: { color: 'accentPrimary', isSolidColor: true },
   regular: { color: 'foreground' },
+  primary: { color: 'accentPrimary', isSolidColor: true },
   secondary: { color: 'accentSecondary', isSolidColor: true },
-  settings: { color: 'foreground', icon: Icons.Settings },
-  warning: { color: 'accentWarning', icon: Icons.Warning, isSolidColor: true },
+  danger: { color: 'accentDanger', icon: Icons.Danger, isSolidColor: true },
 };
 
 function getVariantConfig(p: StyledButtonProps): VariantConfig {

--- a/libs/ui/src/buttons.stories.tsx
+++ b/libs/ui/src/buttons.stories.tsx
@@ -41,10 +41,10 @@ export function UsageExamples(props: ButtonProps<unknown>): JSX.Element {
         footerAlign="right"
         footer={
           <React.Fragment>
-            <Button {...props} variant="previous">
+            <Button {...props} icon="Previous">
               Previous
             </Button>
-            <Button {...props} variant="done">
+            <Button {...props} icon="Checkmark" variant="primary">
               Save and exit
             </Button>
           </React.Fragment>
@@ -59,7 +59,7 @@ export function UsageExamples(props: ButtonProps<unknown>): JSX.Element {
         footer={
           <React.Fragment>
             <Button {...props}>Cancel</Button>
-            <Button {...props} variant="danger">
+            <Button {...props} variant="danger" icon="DangerX">
               Delete everything
             </Button>
           </React.Fragment>
@@ -73,26 +73,14 @@ export function UsageExamples(props: ButtonProps<unknown>): JSX.Element {
         footerAlign="right"
         footer={
           <React.Fragment>
-            <Button {...props}>Cancel</Button>
-            <Button {...props} variant="warning">
-              Fix the thing
+            <Button {...props} icon="Previous">
+              Back
             </Button>
-          </React.Fragment>
-        }
-      >
-        <H4 as="h2">Warning! You forgot something.</H4>
-        <P>{testParagraph}</P>
-      </Card>
-
-      <Card
-        footerAlign="right"
-        footer={
-          <React.Fragment>
-            <Button {...props}>Cancel</Button>
             <Button
               {...props}
               disabled={fakeTextInputValue.length < 2}
-              variant="next"
+              variant="primary"
+              rightIcon="Next"
             >
               Continue
             </Button>

--- a/libs/ui/src/buttons.stories.tsx
+++ b/libs/ui/src/buttons.stories.tsx
@@ -44,7 +44,7 @@ export function UsageExamples(props: ButtonProps<unknown>): JSX.Element {
             <Button {...props} icon="Previous">
               Previous
             </Button>
-            <Button {...props} icon="Checkmark" variant="primary">
+            <Button {...props} icon="Done" variant="primary">
               Save and exit
             </Button>
           </React.Fragment>
@@ -59,7 +59,7 @@ export function UsageExamples(props: ButtonProps<unknown>): JSX.Element {
         footer={
           <React.Fragment>
             <Button {...props}>Cancel</Button>
-            <Button {...props} variant="danger" icon="DangerX">
+            <Button {...props} variant="danger" icon="Delete">
               Delete everything
             </Button>
           </React.Fragment>

--- a/libs/ui/src/contest_choice_button.tsx
+++ b/libs/ui/src/contest_choice_button.tsx
@@ -86,7 +86,7 @@ export function ContestChoiceButton<T extends string>(
       isSelected={!!isSelected}
       onPress={handlePress}
       role="option"
-      variant={isSelected ? 'primary' : 'regular'}
+      variant={isSelected ? 'primary' : 'neutral'}
     >
       <Content>
         <CheckboxContainer>

--- a/libs/ui/src/display_settings/index.tsx
+++ b/libs/ui/src/display_settings/index.tsx
@@ -88,7 +88,7 @@ export function DisplaySettings(props: DisplaySettingsProps): JSX.Element {
       </ActivePaneContainer>
       <Footer>
         <Button onPress={resetThemes}>Reset</Button>
-        <Button onPress={onClose} variant="done">
+        <Button onPress={onClose} variant="primary" icon="Done">
           Done
         </Button>
       </Footer>

--- a/libs/ui/src/display_settings/tab_bar.tsx
+++ b/libs/ui/src/display_settings/tab_bar.tsx
@@ -60,7 +60,7 @@ export function TabBar(props: TabBarProps): JSX.Element {
           onPress={onChange}
           role="tab"
           value={paneId}
-          variant={activePaneId === paneId ? 'primary' : 'regular'}
+          variant={activePaneId === paneId ? 'primary' : 'neutral'}
         >
           <TabLabel>{TAB_LABELS[paneId]}</TabLabel>
         </Button>

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -15,7 +15,6 @@ import {
   faInfoCircle,
   faMinusCircle,
   faPencil,
-  faTrashCan,
   faXmark,
   faMagnifyingGlassPlus,
   faMagnifyingGlassMinus,
@@ -122,12 +121,8 @@ export const Icons = {
     return <FaIcon type={faExclamationCircle} />;
   },
 
-  DangerX(): JSX.Element {
-    return <FaIcon type={faXmarkCircle} />;
-  },
-
   Delete(): JSX.Element {
-    return <FaIcon type={faTrashCan} />;
+    return <FaIcon type={faXmarkCircle} />;
   },
 
   Disabled(): JSX.Element {

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -25,7 +25,6 @@ import {
   faChevronCircleDown,
   faChevronRight,
   faChevronLeft,
-  faSquarePlus,
   faSpinner,
   faCaretDown,
   faCirclePlus,
@@ -68,10 +67,6 @@ function FaIcon(props: InnerProps): JSX.Element {
  */
 export const Icons = {
   Add(): JSX.Element {
-    return <FaIcon type={faSquarePlus} />;
-  },
-
-  AddCircle(): JSX.Element {
     return <FaIcon type={faCirclePlus} />;
   },
 
@@ -242,7 +237,7 @@ const FullScreenIconContainer = styled(Font)<FullScreenIconContainerProps>`
  * Sample Usage:
  * ```
  * <FullScreenIconWrapper color="success">
- *   <Icons.Checkmark />
+ *   <Icons.Done />
  * </FullScreenIconWrapper>
  * ```
  */

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -223,6 +223,8 @@ export const Icons = {
   },
 } as const;
 
+export type IconName = keyof typeof Icons;
+
 /** Props for {@link FullScreenIconWrapper}. */
 export type FullScreenIconWrapperProps = FontProps;
 

--- a/libs/ui/src/modal.stories.tsx
+++ b/libs/ui/src/modal.stories.tsx
@@ -29,7 +29,12 @@ export function Modal(props: ModalProps): JSX.Element {
         <Component
           actions={
             <React.Fragment>
-              <Button onPress={setIsOpen} value={false} variant="done">
+              <Button
+                onPress={setIsOpen}
+                value={false}
+                variant="primary"
+                icon="Done"
+              >
                 Save
               </Button>
               <Button onPress={setIsOpen} value={false}>

--- a/libs/ui/src/radio_group/radio_button.tsx
+++ b/libs/ui/src/radio_group/radio_button.tsx
@@ -40,7 +40,7 @@ export function RadioButton<T extends RadioGroupOptionId>(
     <Container
       aria-label={ariaLabel}
       disabled={disabled}
-      variant={selected ? 'primary' : 'regular'}
+      variant={selected ? 'primary' : 'neutral'}
     >
       <Radio {...props} />
       <Label>{label}</Label>

--- a/libs/ui/src/segmented_button.tsx
+++ b/libs/ui/src/segmented_button.tsx
@@ -99,7 +99,7 @@ export function SegmentedButton<T extends SegmentedButtonOptionId>(
             onPress={onChange}
             role="option"
             value={o.id}
-            variant={o.id === selectedOptionId ? 'primary' : 'regular'}
+            variant={o.id === selectedOptionId ? 'primary' : 'neutral'}
           >
             {o.label}
           </Button>

--- a/libs/ui/src/set_clock.tsx
+++ b/libs/ui/src/set_clock.tsx
@@ -276,7 +276,12 @@ export function PickDateTimeModal({
       }
       actions={
         <React.Fragment>
-          <Button disabled={disabled} variant="done" onPress={saveDateAndZone}>
+          <Button
+            disabled={disabled}
+            variant="primary"
+            icon="Done"
+            onPress={saveDateAndZone}
+          >
             {saveLabel}
           </Button>
           <Button disabled={disabled} onPress={onCancel}>

--- a/libs/ui/src/tabbed_section/tab_bar.tsx
+++ b/libs/ui/src/tabbed_section/tab_bar.tsx
@@ -71,7 +71,7 @@ export function TabBar<Id extends string = string>(
           onPress={onChange}
           role="tab"
           value={paneId}
-          variant={activePaneId === paneId ? 'primary' : 'regular'}
+          variant={activePaneId === paneId ? 'primary' : 'neutral'}
         >
           <TabLabelContainer active={activePaneId === paneId}>
             <TabLabel>{label}</TabLabel>

--- a/libs/ui/src/usbcontroller_button.tsx
+++ b/libs/ui/src/usbcontroller_button.tsx
@@ -33,7 +33,7 @@ export function UsbControllerButton({
   return (
     <Button
       small={small}
-      variant={primary ? 'primary' : 'regular'}
+      variant={primary ? 'primary' : 'neutral'}
       disabled={extendedUsbDriveStatus !== 'mounted'}
       onPress={usbDriveEject}
     >


### PR DESCRIPTION
## Overview

This separates out button icons from the concept of button variants. A few motivations for this:
- There were times where we wanted to change just the color but not the icon, which was starting to lead to a variant explosion (e.g. `previousPrimary` for when we wanted a previous icon with primary coloring).
- There are a lot of cases where we don't use a preset variant but still want to add an icon. This approach standardizes these cases with the variant cases.
- The problem that this is trying to solve (standardizing which icons get used in certain semantic button roles in the UI) can be better solved by having a simplified set of icons with clear names.

To implement this change, this PR:
- Changes the `Button` component to take an `icon` prop to add an icon on the left of the label. Also adds a `rightIcon` prop for more rarely used icons on the right (e.g. for a directional "next" button).
- Removes all of the variants that specify an icon
- Cleans up our icons a bit to make it easier to be consistent

_Review by commits_

## Demo Video or Screenshot
Shouldn't change much visually. The notable change is that some places that were previously using the "danger" variant (which used the "Danger" icon by default) now use the "Delete" icon (X in a circle), which I felt was more appropriate for "delete"/"remove" actions. The "Danger" icon is still in use for other dangerous actions.

## Testing Plan
Automated testing, plus some visual spot checks

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
