### PR TITLE
Prefix VxAdmin Printed Reports w/ "Test" for Test Results

### DIFF
--- a/apps/admin/frontend/src/components/admin_tally_report_by_party.test.tsx
+++ b/apps/admin/frontend/src/components/admin_tally_report_by_party.test.tsx
@@ -11,7 +11,8 @@ test('general election, full election report', () => {
   render(
     <AdminTallyReportByParty
       electionDefinition={electionDefinition}
-      tallyReportType="Official"
+      isOfficial
+      isTest={false}
       testId="tally-report"
       generatedAtTime={new Date('2020-01-01')}
       tallyReportResults={getSimpleMockTallyResults({
@@ -41,7 +42,8 @@ test('general election, precinct report with manual results', () => {
   render(
     <AdminTallyReportByParty
       electionDefinition={electionDefinition}
-      tallyReportType="Unofficial"
+      isOfficial={false}
+      isTest
       title="Precinct Tally Report"
       testId="tally-report"
       generatedAtTime={new Date('2020-01-01')}
@@ -54,7 +56,7 @@ test('general election, precinct report with manual results', () => {
   );
 
   screen.getByTestId('tally-report');
-  screen.getByText('Unofficial Precinct Tally Report');
+  screen.getByText('Test Unofficial Precinct Tally Report');
   screen.getByText('Lincoln Municipal General Election');
   screen.getByText(
     'This report was created on Wednesday, January 1, 2020 at 12:00:00 AM UTC.'
@@ -77,7 +79,8 @@ test('primary election, full election report with manual results', () => {
   render(
     <AdminTallyReportByParty
       electionDefinition={electionDefinition}
-      tallyReportType="Official"
+      isOfficial
+      isTest={false}
       testId="tally-report"
       generatedAtTime={new Date('2020-01-01')}
       tallyReportResults={getSimpleMockTallyResults({
@@ -145,7 +148,9 @@ test('primary election, party report', () => {
     <AdminTallyReportByParty
       electionDefinition={electionDefinition}
       title="Mammal Party Tally Report"
-      tallyReportType="Official"
+      isOfficial={false}
+      isTest
+      isForLogicAndAccuracyTesting
       testId="tally-report"
       generatedAtTime={new Date('2020-01-01')}
       tallyReportResults={getSimpleMockTallyResults({
@@ -162,7 +167,7 @@ test('primary election, party report', () => {
   );
 
   const mammalReport = screen.getByTestId('tally-report-0');
-  within(mammalReport).getByText('Official Mammal Party Tally Report');
+  within(mammalReport).getByText('Test Deck Mammal Party Tally Report');
   within(mammalReport).getByText('Mammal Party Example Primary Election');
   expect(
     within(mammalReport).getByTestId('total-ballot-count')
@@ -174,7 +179,7 @@ test('primary election, party report', () => {
   ).toHaveLength(0);
 
   const nonpartisanReport = screen.getByTestId('tally-report-nonpartisan');
-  within(mammalReport).getByText('Official Mammal Party Tally Report');
+  within(mammalReport).getByText('Test Deck Mammal Party Tally Report');
   within(nonpartisanReport).getByText(
     'Example Primary Election Nonpartisan Contests'
   );

--- a/apps/admin/frontend/src/components/admin_tally_report_by_party.tsx
+++ b/apps/admin/frontend/src/components/admin_tally_report_by_party.tsx
@@ -6,8 +6,6 @@ import type { TallyReportResults } from '@votingworks/admin-backend';
 import { AdminTallyReport } from '@votingworks/ui';
 import { getContestById, getEmptyCardCounts } from '@votingworks/utils';
 
-export type TallyReportType = 'Official' | 'Unofficial' | 'Test Deck';
-
 /**
  * The `AdminTallyReport` in `libs/ui` displays only a single set of election results,
  * but for primary elections all of our printed reports are separated by party. This
@@ -23,7 +21,9 @@ export function AdminTallyReportByParty({
   electionDefinition,
   tallyReportResults,
   title,
-  tallyReportType,
+  isTest,
+  isOfficial,
+  isForLogicAndAccuracyTesting,
   testId,
   generatedAtTime,
   customFilter,
@@ -31,7 +31,9 @@ export function AdminTallyReportByParty({
   electionDefinition: ElectionDefinition;
   tallyReportResults: TallyReportResults;
   title?: string;
-  tallyReportType: TallyReportType;
+  isTest: boolean;
+  isOfficial: boolean;
+  isForLogicAndAccuracyTesting?: boolean;
   testId: string;
   generatedAtTime: Date;
   customFilter?: Tabulation.Filter;
@@ -50,11 +52,10 @@ export function AdminTallyReportByParty({
         contests={contests}
         scannedElectionResults={tallyReportResults.scannedResults}
         manualElectionResults={tallyReportResults?.manualResults}
-        title={
-          title
-            ? `${tallyReportType} ${title}`
-            : `${tallyReportType} ${election.title} Tally Report`
-        }
+        title={title ?? `${election.title} Tally Report`}
+        isTest={isTest}
+        isOfficial={isOfficial}
+        isForLogicAndAccuracyTesting={isForLogicAndAccuracyTesting}
         subtitle={title ? election.title : undefined}
         generatedAtTime={generatedAtTime}
         customFilter={customFilter}
@@ -90,11 +91,10 @@ export function AdminTallyReportByParty({
         manualElectionResults={
           partyCardCounts.manual ? tallyReportResults.manualResults : undefined
         }
-        title={
-          title
-            ? `${tallyReportType} ${title}`
-            : `${tallyReportType} ${partyElectionTitle} Tally Report`
-        }
+        title={title ?? `${partyElectionTitle} Tally Report`}
+        isTest={isTest}
+        isOfficial={isOfficial}
+        isForLogicAndAccuracyTesting={isForLogicAndAccuracyTesting}
         subtitle={title ? partyElectionTitle : undefined}
         cardCountsOverride={partyCardCounts}
         customFilter={customFilter}
@@ -115,11 +115,10 @@ export function AdminTallyReportByParty({
         contests={contests.filter((c) => c.type === 'yesno' || !c.partyId)}
         scannedElectionResults={tallyReportResults.scannedResults}
         manualElectionResults={tallyReportResults.manualResults}
-        title={
-          title
-            ? `${tallyReportType} ${title}`
-            : `${tallyReportType} ${nonpartisanElectionTitle} Tally Report`
-        }
+        title={title ?? `${nonpartisanElectionTitle} Tally Report`}
+        isTest={isTest}
+        isOfficial={isOfficial}
+        isForLogicAndAccuracyTesting={isForLogicAndAccuracyTesting}
         subtitle={title ? nonpartisanElectionTitle : undefined}
         customFilter={customFilter}
       />

--- a/apps/admin/frontend/src/components/reporting/ballot_count_report_viewer.tsx
+++ b/apps/admin/frontend/src/components/reporting/ballot_count_report_viewer.tsx
@@ -42,6 +42,7 @@ function Report({
   electionDefinition,
   scannerBatches,
   isOfficialResults,
+  isTestMode,
   cardCountsList,
   filter,
   groupBy,
@@ -50,6 +51,7 @@ function Report({
   electionDefinition: ElectionDefinition;
   scannerBatches: ScannerBatch[];
   isOfficialResults: boolean;
+  isTestMode: boolean;
   cardCountsList: Tabulation.GroupList<Tabulation.CardCounts>;
   filter: Tabulation.Filter;
   groupBy: Tabulation.GroupBy;
@@ -61,24 +63,25 @@ function Report({
     scannerBatches,
     reportType: 'Ballot Count',
   });
-  const titleWithoutOfficiality = titleGeneration.isOk()
+  const title = titleGeneration.isOk()
     ? titleGeneration.ok() ?? `Full Election Ballot Count Report`
     : 'Custom Filter Ballot Count Report';
-  const title = `${
-    isOfficialResults ? 'Official ' : 'Unofficial '
-  }${titleWithoutOfficiality}`;
   const customFilter = !titleGeneration.isOk() ? filter : undefined;
 
-  return BallotCountReport({
-    title,
-    testId: 'ballot-count-report',
-    electionDefinition,
-    customFilter,
-    scannerBatches,
-    generatedAtTime,
-    groupBy,
-    cardCountsList,
-  });
+  return (
+    <BallotCountReport
+      title={title}
+      isOfficial={isOfficialResults}
+      isTest={isTestMode}
+      testId="ballot-count-report"
+      electionDefinition={electionDefinition}
+      customFilter={customFilter}
+      scannerBatches={scannerBatches}
+      generatedAtTime={generatedAtTime}
+      groupBy={groupBy}
+      cardCountsList={cardCountsList}
+    />
+  );
 }
 
 export interface BallotCountReportViewerProps {
@@ -111,6 +114,8 @@ export function BallotCountReportViewer({
     disabledFromProps ||
     !castVoteRecordFileModeQuery.isSuccess ||
     !scannerBatchesQuery.isSuccess;
+
+  const isTestMode = castVoteRecordFileModeQuery.data === 'test';
 
   const cardCountsQuery = getCardCounts.useQuery(
     {
@@ -147,18 +152,20 @@ export function BallotCountReportViewer({
         cardCountsList={cardCountsQuery.data}
         generatedAtTime={new Date(cardCountsQuery.dataUpdatedAt)}
         isOfficialResults={isOfficialResults}
+        isTestMode={isTestMode}
         scannerBatches={scannerBatchesQuery.data ?? []}
       />
     );
   }, [
     disabled,
     reportResultsAreFresh,
+    cardCountsQuery.data,
+    cardCountsQuery.dataUpdatedAt,
     electionDefinition,
     filter,
     groupBy,
-    cardCountsQuery.data,
-    cardCountsQuery.dataUpdatedAt,
     isOfficialResults,
+    isTestMode,
     scannerBatchesQuery.data,
   ]);
   previewReportRef.current = previewReport;
@@ -192,6 +199,7 @@ export function BallotCountReportViewer({
         cardCountsList={queryResults.data}
         generatedAtTime={new Date(queryResults.dataUpdatedAt)}
         isOfficialResults={isOfficialResults}
+        isTestMode={isTestMode}
         scannerBatches={scannerBatchesQuery.data ?? []}
       />
     );
@@ -231,6 +239,7 @@ export function BallotCountReportViewer({
         cardCountsList={queryResults.data}
         generatedAtTime={new Date(queryResults.dataUpdatedAt)}
         isOfficialResults={isOfficialResults}
+        isTestMode={isTestMode}
         scannerBatches={scannerBatchesQuery.data ?? []}
       />
     );

--- a/apps/admin/frontend/src/components/reporting/tally_report_viewer.tsx
+++ b/apps/admin/frontend/src/components/reporting/tally_report_viewer.tsx
@@ -47,6 +47,7 @@ import {
 function Reports({
   electionDefinition,
   isOfficialResults,
+  isTestMode,
   allTallyReportResults,
   filterUsed,
   generatedAtTime,
@@ -54,6 +55,7 @@ function Reports({
 }: {
   electionDefinition: ElectionDefinition;
   isOfficialResults: boolean;
+  isTestMode: boolean;
   allTallyReportResults: Tabulation.GroupList<TallyReportResults>;
   filterUsed: Tabulation.Filter;
   generatedAtTime: Date;
@@ -83,7 +85,8 @@ function Reports({
         key={`tally-report-${index}`}
         title={title}
         tallyReportResults={tallyReportResults}
-        tallyReportType={isOfficialResults ? 'Official' : 'Unofficial'}
+        isOfficial={isOfficialResults}
+        isTest={isTestMode}
         generatedAtTime={generatedAtTime}
         customFilter={displayedFilter}
       />
@@ -124,6 +127,8 @@ export function TallyReportViewer({
     !castVoteRecordFileModeQuery.isSuccess ||
     !scannerBatchesQuery.isSuccess;
 
+  const isTestMode = castVoteRecordFileModeQuery.data === 'test';
+
   const reportResultsQuery = getResultsForTallyReports.useQuery(
     {
       filter,
@@ -158,17 +163,19 @@ export function TallyReportViewer({
         allTallyReportResults={reportResultsQuery.data}
         generatedAtTime={new Date(reportResultsQuery.dataUpdatedAt)}
         isOfficialResults={isOfficialResults}
+        isTestMode={isTestMode}
         scannerBatches={scannerBatchesQuery.data ?? []}
       />
     );
   }, [
     disabled,
     reportResultsAreFresh,
-    electionDefinition,
-    filter,
     reportResultsQuery.data,
     reportResultsQuery.dataUpdatedAt,
+    electionDefinition,
+    filter,
     isOfficialResults,
+    isTestMode,
     scannerBatchesQuery.data,
   ]);
   previewReportRef.current = previewReport;
@@ -202,6 +209,7 @@ export function TallyReportViewer({
         allTallyReportResults={queryResults.data}
         generatedAtTime={new Date(queryResults.dataUpdatedAt)}
         isOfficialResults={isOfficialResults}
+        isTestMode={isTestMode}
         scannerBatches={scannerBatchesQuery.data ?? []}
       />
     );
@@ -240,6 +248,7 @@ export function TallyReportViewer({
         allTallyReportResults={queryResults.data}
         generatedAtTime={new Date(queryResults.dataUpdatedAt)}
         isOfficialResults={isOfficialResults}
+        isTestMode={isTestMode}
         scannerBatches={scannerBatchesQuery.data ?? []}
       />
     );

--- a/apps/admin/frontend/src/components/test_deck_tally_report.tsx
+++ b/apps/admin/frontend/src/components/test_deck_tally_report.tsx
@@ -25,7 +25,9 @@ export function TestDeckTallyReport({
             }`
           : undefined
       }
-      tallyReportType="Test Deck"
+      isOfficial={false}
+      isTest
+      isForLogicAndAccuracyTesting
       tallyReportResults={tallyReportResults}
       testId="test-deck-tally-report"
       generatedAtTime={new Date()}

--- a/apps/admin/frontend/src/screens/reporting/ballot_count_report_builder.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/ballot_count_report_builder.test.tsx
@@ -98,7 +98,9 @@ test('happy path', async () => {
   );
   userEvent.click(screen.getButton('Load Preview'));
 
-  await screen.findByText('Unofficial Absentee Ballot Ballot Count Report');
+  await screen.findByText(
+    'Test Unofficial Absentee Ballot Ballot Count Report'
+  );
   expect(screen.getByTestId('footer-total')).toHaveTextContent('10');
 
   // Change Report Parameters
@@ -123,7 +125,9 @@ test('happy path', async () => {
   );
   userEvent.click(screen.getByText('Refresh Preview'));
 
-  await screen.findByText('Unofficial Precinct Ballot Ballot Count Report');
+  await screen.findByText(
+    'Test Unofficial Precinct Ballot Ballot Count Report'
+  );
   expect(screen.getByTestId('footer-total')).toHaveTextContent('20');
   expect(screen.getByTestId('footer-bmd')).toHaveTextContent('20');
   expect(screen.queryByTestId('footer-manual')).not.toBeInTheDocument();
@@ -131,7 +135,9 @@ test('happy path', async () => {
   // Print Report
   userEvent.click(screen.getButton('Print Report'));
   await expectPrint((printResult) => {
-    printResult.getByText('Unofficial Precinct Ballot Ballot Count Report');
+    printResult.getByText(
+      'Test Unofficial Precinct Ballot Ballot Count Report'
+    );
     expect(printResult.getByTestId('footer-total')).toHaveTextContent('20');
   });
 });

--- a/apps/admin/frontend/src/screens/reporting/tally_report_builder.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/tally_report_builder.test.tsx
@@ -22,7 +22,7 @@ test('happy path', async () => {
   const electionDefinition = electionTwoPartyPrimaryDefinition;
   const { election } = electionDefinition;
 
-  apiMock.expectGetCastVoteRecordFileMode('test');
+  apiMock.expectGetCastVoteRecordFileMode('official');
   apiMock.expectGetScannerBatches([]);
   renderInAppContext(<TallyReportBuilder />, {
     electionDefinition,

--- a/apps/admin/frontend/src/screens/reporting/write_in_adjudication_report_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/write_in_adjudication_report_screen.test.tsx
@@ -38,6 +38,7 @@ afterAll(() => {
 
 test('renders provided data', async () => {
   const { electionDefinition } = electionGridLayoutNewHampshireAmherstFixtures;
+  apiMock.expectGetCastVoteRecordFileMode('official');
   apiMock.expectGetElectionWriteInSummary({
     contestWriteInSummaries: {
       'Sheriff-4243fe0b': {
@@ -69,7 +70,7 @@ test('renders provided data', async () => {
 
   const report = await screen.findByTestId('write-in-tally-report');
   within(report).getByText(
-    'Unofficial General Election Write-In Adjudication Report'
+    'Unofficial General Election Write‑In Adjudication Report'
   );
   expect(
     within(report).getByText('Random Write-In').closest('tr')!
@@ -78,7 +79,7 @@ test('renders provided data', async () => {
   userEvent.click(screen.getByText('Print Report'));
   await expectPrint((printed) => {
     printed.getByText(
-      'Unofficial General Election Write-In Adjudication Report'
+      'Unofficial General Election Write‑In Adjudication Report'
     );
     expect(
       printed.getByText('Random Write-In').closest('tr')!

--- a/apps/admin/frontend/src/screens/reporting/write_in_adjudication_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/write_in_adjudication_report_screen.tsx
@@ -13,7 +13,10 @@ import { AppContext } from '../../contexts/app_context';
 import { NavigationScreen } from '../../components/navigation_screen';
 import { FileType } from '../../components/save_frontend_file_modal';
 import { PrintButton } from '../../components/print_button';
-import { getElectionWriteInSummary } from '../../api';
+import {
+  getCastVoteRecordFileMode,
+  getElectionWriteInSummary,
+} from '../../api';
 import {
   ExportActions,
   PaginationNote,
@@ -33,7 +36,8 @@ export function TallyWriteInReportScreen(): JSX.Element {
   const userRole = auth.user.role;
 
   const writeInSummaryQuery = getElectionWriteInSummary.useQuery();
-
+  const castVoteRecordFileModeQuery = getCastVoteRecordFileMode.useQuery();
+  const isTestMode = castVoteRecordFileModeQuery.data === 'test';
   const report = useMemo(() => {
     if (!writeInSummaryQuery.isSuccess) return undefined;
 
@@ -41,13 +45,15 @@ export function TallyWriteInReportScreen(): JSX.Element {
       <WriteInAdjudicationReport
         election={election}
         electionWriteInSummary={writeInSummaryQuery.data}
-        isOfficialResults={isOfficialResults}
+        isOfficial={isOfficialResults}
+        isTest={isTestMode}
         generatedAtTime={new Date(writeInSummaryQuery.dataUpdatedAt)}
       />
     );
   }, [
     election,
     isOfficialResults,
+    isTestMode,
     writeInSummaryQuery.data,
     writeInSummaryQuery.dataUpdatedAt,
     writeInSummaryQuery.isSuccess,

--- a/libs/ui/src/reports/admin_tally_report.stories.tsx
+++ b/libs/ui/src/reports/admin_tally_report.stories.tsx
@@ -67,7 +67,9 @@ const scannedElectionResults = buildElectionResultsFixture({
 });
 
 const batchReportArgs: AdminTallyReportProps = {
-  title: 'Official Batch Tally Report for Batch 1',
+  title: 'Batch Tally Report for Batch 1',
+  isOfficial: true,
+  isTest: false,
   subtitle: election.title,
   testId: 'tally-report',
   electionDefinition,
@@ -106,7 +108,9 @@ const manualElectionResults = buildManualResultsFixture({
 });
 
 const ballotStyleManualReportArgs: AdminTallyReportProps = {
-  title: 'TEST Ballot Style Tally Report for Ballot Style 2F',
+  title: 'Ballot Style Tally Report for Ballot Style 2F',
+  isTest: true,
+  isOfficial: true,
   subtitle: election.title,
   testId: 'tally-report',
   electionDefinition,
@@ -125,7 +129,9 @@ export const BallotStyleManualReport: Story = {
 };
 
 const fullElectionWriteInReportArgs: AdminTallyReportProps = {
-  title: 'TEST Full Election Tally Report',
+  title: 'Full Election Tally Report',
+  isTest: true,
+  isOfficial: false,
   subtitle: election.title,
   testId: 'tally-report',
   electionDefinition,

--- a/libs/ui/src/reports/admin_tally_report.test.tsx
+++ b/libs/ui/src/reports/admin_tally_report.test.tsx
@@ -21,6 +21,8 @@ test('includes indicated contests', () => {
   render(
     <AdminTallyReport
       title="Title"
+      isOfficial={false}
+      isTest={false}
       electionDefinition={electionDefinition}
       contests={includedContests}
       scannedElectionResults={getEmptyElectionResults(election, true)}
@@ -33,17 +35,74 @@ test('includes indicated contests', () => {
   expect(queryForContest(excludedContest.id)).not.toBeInTheDocument();
 });
 
+test('titles', () => {
+  const testCases: Array<{
+    isTest: boolean;
+    isOfficial: boolean;
+    isForLogicAndAccuracyTesting?: boolean;
+    expectedTitle: string;
+  }> = [
+    {
+      isTest: true,
+      isOfficial: true,
+      expectedTitle: 'Test Official Title',
+    },
+    {
+      isTest: true,
+      isOfficial: false,
+      expectedTitle: 'Test Unofficial Title',
+    },
+    {
+      isTest: false,
+      isOfficial: true,
+      expectedTitle: 'Official Title',
+    },
+    {
+      isTest: false,
+      isOfficial: false,
+      expectedTitle: 'Unofficial Title',
+    },
+    {
+      isTest: true,
+      isOfficial: false,
+      isForLogicAndAccuracyTesting: true,
+      expectedTitle: 'Test Deck Title',
+    },
+  ];
+  for (const {
+    isTest,
+    isOfficial,
+    isForLogicAndAccuracyTesting,
+    expectedTitle,
+  } of testCases) {
+    const { unmount } = render(
+      <AdminTallyReport
+        title="Title"
+        isTest={isTest}
+        isOfficial={isOfficial}
+        isForLogicAndAccuracyTesting={isForLogicAndAccuracyTesting}
+        electionDefinition={electionDefinition}
+        contests={election.contests}
+        scannedElectionResults={getEmptyElectionResults(election, true)}
+      />
+    );
+    screen.getByRole('heading', { name: expectedTitle });
+    unmount();
+  }
+});
+
 test('includes subtitle', () => {
   render(
     <AdminTallyReport
       title="Title"
+      isOfficial={false}
+      isTest={false}
       subtitle="Subtitle"
       electionDefinition={electionDefinition}
       contests={election.contests}
       scannedElectionResults={getEmptyElectionResults(election, true)}
     />
   );
-  screen.getByRole('heading', { name: 'Title' });
   screen.getByRole('heading', { name: 'Subtitle' });
 });
 
@@ -51,6 +110,8 @@ test('includes specified date', () => {
   render(
     <AdminTallyReport
       title="Title"
+      isOfficial={false}
+      isTest={false}
       subtitle="Subtitle"
       electionDefinition={electionDefinition}
       contests={election.contests}
@@ -86,6 +147,8 @@ test('with only scanned results', () => {
   render(
     <AdminTallyReport
       title="Title"
+      isOfficial={false}
+      isTest={false}
       subtitle="Subtitle"
       electionDefinition={electionDefinition}
       contests={election.contests}
@@ -119,6 +182,8 @@ test('with scanned and manual results', () => {
   render(
     <AdminTallyReport
       title="Title"
+      isOfficial={false}
+      isTest={false}
       subtitle="Subtitle"
       electionDefinition={electionDefinition}
       contests={election.contests}
@@ -134,6 +199,8 @@ test('allows card counts override', () => {
   render(
     <AdminTallyReport
       title="Title"
+      isOfficial={false}
+      isTest={false}
       subtitle="Subtitle"
       electionDefinition={electionDefinition}
       contests={election.contests}
@@ -152,6 +219,8 @@ test('displays custom filter', () => {
   render(
     <AdminTallyReport
       title="Title"
+      isOfficial={false}
+      isTest={false}
       subtitle="Subtitle"
       electionDefinition={electionDefinition}
       contests={election.contests}

--- a/libs/ui/src/reports/admin_tally_report.tsx
+++ b/libs/ui/src/reports/admin_tally_report.tsx
@@ -12,10 +12,14 @@ import { TallyReportMetadata } from './tally_report_metadata';
 import { ContestResultsTable } from './contest_results_table';
 import { TallyReportCardCounts } from './tally_report_card_counts';
 import { CustomFilterSummary } from './custom_filter_summary';
+import { prefixedTitle } from './utils';
 
 export interface AdminTallyReportProps {
   title: string;
   subtitle?: string;
+  isOfficial: boolean;
+  isTest: boolean;
+  isForLogicAndAccuracyTesting?: boolean;
   testId?: string;
   electionDefinition: ElectionDefinition;
   contests: Contests;
@@ -29,6 +33,9 @@ export interface AdminTallyReportProps {
 export function AdminTallyReport({
   title,
   subtitle,
+  isOfficial,
+  isTest,
+  isForLogicAndAccuracyTesting,
   testId,
   electionDefinition,
   contests,
@@ -49,8 +56,14 @@ export function AdminTallyReport({
       <TallyReport data-testid={testId}>
         <ReportSection>
           <LogoMark />
-          <h1>{title}</h1>
-
+          <h1>
+            {prefixedTitle({
+              isOfficial,
+              isTest,
+              isForLogicAndAccuracyTesting,
+              title,
+            })}
+          </h1>
           {subtitle && <h2>{subtitle}</h2>}
           {customFilter && (
             <CustomFilterSummary

--- a/libs/ui/src/reports/ballot_count_report.stories.tsx
+++ b/libs/ui/src/reports/ballot_count_report.stories.tsx
@@ -71,7 +71,9 @@ const precinctCardCountsList: Tabulation.GroupList<Tabulation.CardCounts> =
   );
 
 const precinctReportArgs: BallotCountReportProps = {
-  title: 'Official Full Election Ballot Count Report',
+  title: 'Full Election Ballot Count Report',
+  isOfficial: true,
+  isTest: false,
   testId: 'tally-report',
   electionDefinition: electionWithMsEitherNeitherDefinition,
   scannerBatches: [],
@@ -102,7 +104,9 @@ const primaryPrecinctCardCountsList: Tabulation.GroupList<Tabulation.CardCounts>
   );
 
 const primaryPrecinctReportArgs: BallotCountReportProps = {
-  title: 'Official Full Election Ballot Count Report',
+  title: 'Full Election Ballot Count Report',
+  isOfficial: true,
+  isTest: false,
   testId: 'tally-report',
   electionDefinition: {
     ...electionWithMsEitherNeitherDefinition,
@@ -137,6 +141,8 @@ const votingMethodCardCountsList: Tabulation.GroupList<Tabulation.CardCounts> =
 
 const votingMethodReportArgs: BallotCountReportProps = {
   title: 'Full Election Ballot Count Report',
+  isOfficial: true,
+  isTest: false,
   testId: 'tally-report',
   electionDefinition: electionTwoPartyPrimaryDefinition,
   scannerBatches: [],
@@ -156,6 +162,8 @@ const noGroupsCardCountsList: Tabulation.GroupList<Tabulation.CardCounts> = [
 
 const noGroupsReportArgs: BallotCountReportProps = {
   title: 'Full Election Ballot Count Report',
+  isOfficial: true,
+  isTest: false,
   testId: 'tally-report',
   electionDefinition: electionTwoPartyPrimaryDefinition,
   scannerBatches: [],
@@ -173,6 +181,8 @@ const singleGroupCardCountsList: Tabulation.GroupList<Tabulation.CardCounts> = [
 
 const singleGroupReportArgs: BallotCountReportProps = {
   title: 'Full Election Ballot Count Report',
+  isOfficial: true,
+  isTest: false,
   testId: 'tally-report',
   electionDefinition: electionTwoPartyPrimaryDefinition,
   scannerBatches: [
@@ -248,7 +258,9 @@ const maxCardCountsList: Tabulation.GroupList<Tabulation.CardCounts> = (() => {
 })();
 
 const maxReportArgs: BallotCountReportProps = {
-  title: 'Official Full Election Ballot Count Report',
+  title: 'Full Election Ballot Count Report',
+  isOfficial: true,
+  isTest: false,
   testId: 'tally-report',
   electionDefinition: {
     ...electionTwoPartyPrimaryDefinition,

--- a/libs/ui/src/reports/ballot_count_report.test.tsx
+++ b/libs/ui/src/reports/ballot_count_report.test.tsx
@@ -119,6 +119,8 @@ test('can render all attribute columns', () => {
   const { unmount } = render(
     <BallotCountReport
       title="Full Election Ballot Count Report"
+      isOfficial={false}
+      isTest={false}
       electionDefinition={electionDefinition}
       scannerBatches={mockScannerBatches}
       groupBy={{
@@ -189,6 +191,8 @@ test('can render all attribute columns', () => {
   render(
     <BallotCountReport
       title="Full Election Ballot Count Report"
+      isOfficial={false}
+      isTest={false}
       electionDefinition={electionDefinition}
       scannerBatches={mockScannerBatches}
       groupBy={{
@@ -233,6 +237,8 @@ test('shows manual counts', () => {
   render(
     <BallotCountReport
       title="Full Election Ballot Count Report"
+      isOfficial={false}
+      isTest={false}
       electionDefinition={electionDefinition}
       scannerBatches={mockScannerBatches}
       groupBy={{
@@ -360,6 +366,8 @@ test('ungrouped case', () => {
   render(
     <BallotCountReport
       title="Full Election Ballot Count Report"
+      isOfficial={false}
+      isTest={false}
       electionDefinition={electionDefinition}
       scannerBatches={mockScannerBatches}
       groupBy={{}}
@@ -378,13 +386,14 @@ test('ungrouped case', () => {
   ]);
 });
 
-test('title, metadata, and custom filters', () => {
+test('metadata and custom filters', () => {
   const electionDefinition = electionTwoPartyPrimaryDefinition;
 
-  // render as if all columns were specified
   render(
     <BallotCountReport
       title="Custom Filter Ballot Count Report"
+      isOfficial={false}
+      isTest={false}
       electionDefinition={electionDefinition}
       scannerBatches={mockScannerBatches}
       groupBy={{}}
@@ -395,9 +404,58 @@ test('title, metadata, and custom filters', () => {
     />
   );
 
-  screen.getByText('Custom Filter Ballot Count Report');
+  screen.getByText('Unofficial Custom Filter Ballot Count Report');
   screen.getByText('Example Primary Election');
   expect(screen.getByTestId('custom-filter-summary').textContent).toEqual(
     'Precinct: Precinct 1'
   );
+});
+
+test('titles', () => {
+  const electionDefinition = electionTwoPartyPrimaryDefinition;
+
+  const testCases: Array<{
+    isTest: boolean;
+    isOfficial: boolean;
+    expectedTitle: string;
+  }> = [
+    {
+      isTest: true,
+      isOfficial: true,
+      expectedTitle: 'Test Official Title',
+    },
+    {
+      isTest: true,
+      isOfficial: false,
+      expectedTitle: 'Test Unofficial Title',
+    },
+    {
+      isTest: false,
+      isOfficial: true,
+      expectedTitle: 'Official Title',
+    },
+    {
+      isTest: false,
+      isOfficial: false,
+      expectedTitle: 'Unofficial Title',
+    },
+  ];
+  for (const { isTest, isOfficial, expectedTitle } of testCases) {
+    const { unmount } = render(
+      <BallotCountReport
+        title="Title"
+        isTest={isTest}
+        isOfficial={isOfficial}
+        electionDefinition={electionDefinition}
+        scannerBatches={mockScannerBatches}
+        groupBy={{}}
+        cardCountsList={[]}
+        customFilter={{
+          precinctIds: ['precinct-1'],
+        }}
+      />
+    );
+    screen.getByRole('heading', { name: expectedTitle });
+    unmount();
+  }
 });

--- a/libs/ui/src/reports/ballot_count_report.test.tsx
+++ b/libs/ui/src/reports/ballot_count_report.test.tsx
@@ -307,6 +307,8 @@ test('shows separate manual rows when group by is not compatible with manual res
   render(
     <BallotCountReport
       title="Full Election Ballot Count Report"
+      isTest={false}
+      isOfficial={false}
       electionDefinition={electionDefinition}
       scannerBatches={mockScannerBatches}
       groupBy={{

--- a/libs/ui/src/reports/ballot_count_report.tsx
+++ b/libs/ui/src/reports/ballot_count_report.tsx
@@ -22,7 +22,7 @@ import { ReportSection, tallyReportThemeFn, TallyReport } from './tally_report';
 import { LogoMark } from '../logo_mark';
 import { TallyReportMetadata } from './tally_report_metadata';
 import { CustomFilterSummary } from './custom_filter_summary';
-import { getBatchLabel, getScannerLabel } from './utils';
+import { getBatchLabel, getScannerLabel, prefixedTitle } from './utils';
 
 /**
  * Columns that may appear in a the ballot count report table.
@@ -390,6 +390,8 @@ function BallotCountTable({
 
 export interface BallotCountReportProps {
   title: string;
+  isTest: boolean;
+  isOfficial: boolean;
   testId?: string;
   electionDefinition: ElectionDefinition;
   scannerBatches: Tabulation.ScannerBatch[];
@@ -401,6 +403,8 @@ export interface BallotCountReportProps {
 
 export function BallotCountReport({
   title,
+  isTest,
+  isOfficial,
   testId,
   electionDefinition,
   scannerBatches,
@@ -416,7 +420,7 @@ export function BallotCountReport({
       <TallyReport data-testid={testId}>
         <ReportSection>
           <LogoMark />
-          <h1>{title}</h1>
+          <h1>{prefixedTitle({ isOfficial, isTest, title })}</h1>
           <h2>{electionDefinition.election.title}</h2>
           {customFilter && (
             <CustomFilterSummary

--- a/libs/ui/src/reports/utils.ts
+++ b/libs/ui/src/reports/utils.ts
@@ -9,3 +9,27 @@ export function getBatchLabel(batchId: string): string {
 export function getScannerLabel(scannerId: string): string {
   return scannerId === Tabulation.MANUAL_SCANNER_ID ? 'Manual' : scannerId;
 }
+
+export function prefixedTitle({
+  isOfficial,
+  isTest,
+  isForLogicAndAccuracyTesting,
+  title,
+}: {
+  isOfficial?: boolean;
+  isTest?: boolean;
+  isForLogicAndAccuracyTesting?: boolean;
+  title: string;
+}): string {
+  let prefix = '';
+  if (isForLogicAndAccuracyTesting) {
+    prefix = 'Test Deck';
+  } else {
+    if (isTest) {
+      prefix += 'Test ';
+    }
+    prefix += isOfficial ? 'Official' : 'Unofficial';
+  }
+
+  return `${prefix} ${title}`;
+}

--- a/libs/ui/src/reports/write_in_adjudication_report.stories.tsx
+++ b/libs/ui/src/reports/write_in_adjudication_report.stories.tsx
@@ -39,7 +39,8 @@ const meta: Meta<typeof WriteInTallyReportPreview> = {
 
 const generalReportArgs: WriteInAdjudicationReportProps = {
   election: electionFamousNames2021Fixtures.election,
-  isOfficialResults: false,
+  isOfficial: false,
+  isTest: false,
   generatedAtTime: new Date('2020-11-03T12:00:00.000Z'),
   electionWriteInSummary: {
     contestWriteInSummaries: {
@@ -167,7 +168,8 @@ export const GeneralReport: Story = {
 
 const primaryReportArgs: WriteInAdjudicationReportProps = {
   election,
-  isOfficialResults: true,
+  isOfficial: true,
+  isTest: false,
   generatedAtTime: new Date('2020-11-03T12:00:00.000Z'),
   electionWriteInSummary: {
     contestWriteInSummaries: {

--- a/libs/ui/src/reports/write_in_adjudication_report.test.tsx
+++ b/libs/ui/src/reports/write_in_adjudication_report.test.tsx
@@ -35,7 +35,8 @@ test('primary', () => {
           },
         },
       }}
-      isOfficialResults
+      isOfficial
+      isTest={false}
       generatedAtTime={new Date('2020-10-01')}
     />
   );
@@ -43,7 +44,7 @@ test('primary', () => {
   // mammal section
   const mammalSection = screen.getByTestId('write-in-tally-report-0');
   within(mammalSection).getByText(
-    'Official Mammal Party Example Primary Election Write-In Adjudication Report'
+    'Official Mammal Party Example Primary Election Write‑In Adjudication Report'
   );
   within(mammalSection).getByText(
     'Wednesday, September 8, 2021, Sample County, State of Sample'
@@ -64,7 +65,7 @@ test('primary', () => {
   // fish section
   const fishSection = screen.getByTestId('write-in-tally-report-1');
   within(fishSection).getByText(
-    'Official Fish Party Example Primary Election Write-In Adjudication Report'
+    'Official Fish Party Example Primary Election Write‑In Adjudication Report'
   );
 
   // should just one empty contest
@@ -87,13 +88,14 @@ test('general', () => {
     <WriteInAdjudicationReport
       election={election}
       electionWriteInSummary={{ contestWriteInSummaries: {} }}
-      isOfficialResults={false}
+      isOfficial={false}
+      isTest={false}
       generatedAtTime={new Date('2020-10-01')}
     />
   );
 
   screen.getByText(
-    'Unofficial Lincoln Municipal General Election Write-In Adjudication Report'
+    'Unofficial Lincoln Municipal General Election Write‑In Adjudication Report'
   );
 
   // one section, no other sections

--- a/libs/ui/src/reports/write_in_adjudication_report.tsx
+++ b/libs/ui/src/reports/write_in_adjudication_report.tsx
@@ -15,6 +15,7 @@ import {
 import { LogoMark } from '../logo_mark';
 import { TallyReportMetadata } from './tally_report_metadata';
 import { ContestWriteInSummaryTable } from './contest_write_in_summary_table';
+import { prefixedTitle } from './utils';
 
 function getEmptyContestWriteInSummary(
   contest: AnyContest
@@ -32,17 +33,17 @@ export interface WriteInAdjudicationReportProps {
   election: Election;
   electionWriteInSummary: Tabulation.ElectionWriteInSummary;
   generatedAtTime: Date;
-  isOfficialResults: boolean;
+  isOfficial: boolean;
+  isTest: boolean;
 }
 
 export function WriteInAdjudicationReport({
   election,
   electionWriteInSummary,
   generatedAtTime,
-  isOfficialResults,
+  isOfficial,
+  isTest,
 }: WriteInAdjudicationReportProps): JSX.Element {
-  const statusPrefix = isOfficialResults ? 'Official' : 'Unofficial';
-
   const allWriteInContests = election.contests.filter(
     (c): c is CandidateContest => c.type === 'candidate' && c.allowWriteIns
   );
@@ -71,7 +72,11 @@ export function WriteInAdjudicationReport({
             >
               <LogoMark />
               <h1>
-                {statusPrefix} {electionTitle} Write-In Adjudication Report
+                {prefixedTitle({
+                  isOfficial,
+                  isTest,
+                  title: `${electionTitle} Write‑In Adjudication Report`,
+                })}
               </h1>
               <TallyReportMetadata
                 generatedAtTime={generatedAtTime}


### PR DESCRIPTION
## Overview

Part of #4112. Currently VxAdmin reports do not show "Test" on reports when they represent test data. We definitely want them to!

## Demo Video or Screenshot

<img width="816" alt="Screen Shot 2023-10-25 at 4 48 49 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/5b75b4fe-90bc-4c6d-835e-54be8880b897">

<img width="818" alt="Screen Shot 2023-10-25 at 4 48 58 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/29891f5d-07a8-42b7-82f9-3bbdd19c0c6b">

## Checklist

- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
