### PR TITLE
VxScan: remove "Official" label from reports

### DIFF
--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -468,7 +468,7 @@ test('voter can cast a ballot that scans successfully ', async () => {
   await screen.findByText('Polls are closed.');
   await expectPrint((printResult) => {
     expect(
-      printResult.getAllByText(`TEST Polls Closed Report for All Precincts`)
+      printResult.getAllByText(`Test Polls Closed Report for All Precincts`)
     ).toHaveLength(3); // report for each party and a non-partisan report
 
     // confirm results are in report
@@ -747,7 +747,7 @@ test('open polls, scan ballot, close polls, save results', async () => {
   );
   await expectPrint((printResult) => {
     expect(
-      printResult.getAllByText(`TEST Polls Closed Report for All Precincts`)
+      printResult.getAllByText(`Test Polls Closed Report for All Precincts`)
     ).toHaveLength(3); // report for each party and a non-partisan report
 
     // confirm scanned results are in report

--- a/apps/scan/frontend/src/app_tally_report_paths.test.tsx
+++ b/apps/scan/frontend/src/app_tally_report_paths.test.tsx
@@ -217,7 +217,7 @@ test('polls open, All Precincts, primary election + check additional report', as
       // correct number of sub-reports
       expect(
         printedElement.getAllByText(
-          'TEST Polls Opened Report for All Precincts'
+          'Test Polls Opened Report for All Precincts'
         )
       ).toHaveLength(election.parties.length + 1);
 
@@ -288,7 +288,7 @@ test('polls closed, primary election, single precinct + quickresults on', async 
   await expectPrint((printedElement) => {
     // correct number of sub-reports
     expect(
-      printedElement.getAllByText('TEST Polls Closed Report for Precinct 1')
+      printedElement.getAllByText('Test Polls Closed Report for Precinct 1')
     ).toHaveLength(election.parties.length + 1);
 
     // check mammal zero report: title, total ballots, number of contests
@@ -351,7 +351,7 @@ test('polls open, general election, single precinct', async () => {
   await screen.findByText('Polls are open.');
 
   await expectPrint((printedElement) => {
-    printedElement.getByText('TEST Polls Opened Report for Center Springfield');
+    printedElement.getByText('Test Polls Opened Report for Center Springfield');
     printedElement.getByText('General Election:');
     within(printedElement.getByTestId('total-ballots')).getByText('0');
     expect(printedElement.getAllByTestId(/results-table-/)).toHaveLength(
@@ -381,7 +381,7 @@ test('polls closed, general election, all precincts', async () => {
   });
 
   await expectPrint((printedElement) => {
-    printedElement.getByText('TEST Polls Closed Report for All Precincts');
+    printedElement.getByText('Test Polls Closed Report for All Precincts');
     printedElement.getByText('General Election:');
     within(printedElement.getByTestId('total-ballots')).getByText('100');
     expect(printedElement.getAllByTestId(/results-table-/)).toHaveLength(
@@ -425,7 +425,7 @@ test('polls paused', async () => {
   await expectPrint((printedElement) => {
     // Check heading
     printedElement.getByText(
-      'TEST Voting Paused Report for Center Springfield'
+      'Test Voting Paused Report for Center Springfield'
     );
     printedElement.getByText('Voting Paused:');
     // Check contents
@@ -468,7 +468,7 @@ test('polls unpaused', async () => {
   await expectPrint((printedElement) => {
     // Check heading
     printedElement.getByText(
-      'TEST Voting Resumed Report for Center Springfield'
+      'Test Voting Resumed Report for Center Springfield'
     );
     printedElement.getByText('Voting Resumed:');
     // Check contents
@@ -509,7 +509,7 @@ test('polls closed from paused', async () => {
   await screen.findByText('Polls are closed.');
 
   await expectPrint((printedElement) => {
-    printedElement.getByText('TEST Polls Closed Report for All Precincts');
+    printedElement.getByText('Test Polls Closed Report for All Precincts');
     printedElement.getByText('General Election:');
     within(printedElement.getByTestId('total-ballots')).getByText('100');
     expect(printedElement.getAllByTestId(/results-table-/)).toHaveLength(

--- a/libs/ui/src/reports/precinct_scanner_ballot_count_report.test.tsx
+++ b/libs/ui/src/reports/precinct_scanner_ballot_count_report.test.tsx
@@ -22,7 +22,7 @@ test('renders info properly', () => {
   );
 
   // Check header
-  screen.getByText('TEST Voting Paused Report for All Precincts');
+  screen.getByText('Test Voting Paused Report for All Precincts');
   const electionTitle = screen.getByText('General Election:');
   expect(electionTitle.parentElement).toHaveTextContent(
     'General Election: Nov 3, 2020, Franklin County, State of Hamilton'

--- a/libs/ui/src/reports/precinct_scanner_report_header.test.tsx
+++ b/libs/ui/src/reports/precinct_scanner_report_header.test.tsx
@@ -29,7 +29,7 @@ test('general election, all precincts, polls open, test mode', () => {
     />
   );
   expect(screen.queryByText('Party')).toBeNull();
-  screen.getByText('TEST Polls Opened Report for All Precincts');
+  screen.getByText('Test Polls Opened Report for All Precincts');
   const electionTitle = screen.getByText('Lincoln Municipal General Election:');
   expect(electionTitle.parentElement).toHaveTextContent(
     'Lincoln Municipal General Election: Jun 6, 2021, Franklin County, State of Hamilton'
@@ -60,7 +60,7 @@ test('primary election, single precinct, polls closed, live mode', () => {
     />
   );
   expect(screen.queryByText('Party')).toBeNull();
-  screen.getByText('Official Polls Closed Report for Precinct 1');
+  screen.getByText('Polls Closed Report for Precinct 1');
   const electionTitle = screen.getByText(
     'Mammal Party Example Primary Election:'
   );

--- a/libs/ui/src/reports/precinct_scanner_report_header.tsx
+++ b/libs/ui/src/reports/precinct_scanner_report_header.tsx
@@ -114,9 +114,9 @@ export function PrecinctScannerReportHeader({
     election.precincts,
     precinctSelection
   );
-  const reportTitle = `${
-    isLiveMode ? 'Official' : 'TEST'
-  } ${getPollsReportTitle(pollsTransition)} for ${precinctName}`;
+  const reportTitle = `${isLiveMode ? '' : 'Test '}${getPollsReportTitle(
+    pollsTransition
+  )} for ${precinctName}`;
   const electionDate = Intl.DateTimeFormat('en-US', {
     month: 'short',
     day: 'numeric',

--- a/libs/ui/src/reports/precinct_scanner_tally_report.test.tsx
+++ b/libs/ui/src/reports/precinct_scanner_tally_report.test.tsx
@@ -62,7 +62,7 @@ test('renders as expected for a single precinct in a general election', () => {
     />
   );
   expect(screen.queryByText('Party')).toBeNull();
-  screen.getByText('TEST Polls Opened Report for North Lincoln');
+  screen.getByText('Test Polls Opened Report for North Lincoln');
   const electionTitle = screen.getByText('Lincoln Municipal General Election:');
   expect(electionTitle.parentElement).toHaveTextContent(
     'Lincoln Municipal General Election: Jun 6, 2021, Franklin County, State of Hamilton'
@@ -130,7 +130,7 @@ test('renders as expected for all precincts in a primary election', () => {
       partyId={'0' as PartyId}
     />
   );
-  screen.getByText('Official Polls Opened Report for All Precincts');
+  screen.getByText('Polls Opened Report for All Precincts');
   const electionTitle = screen.getByText(
     'Mammal Party Example Primary Election:'
   );

--- a/libs/ui/src/reports/precinct_scanner_tally_reports.test.tsx
+++ b/libs/ui/src/reports/precinct_scanner_tally_reports.test.tsx
@@ -103,7 +103,7 @@ test('polls open, primary, single precinct, live mode', () => {
   );
 
   expect(
-    screen.getAllByText('Official Polls Opened Report for Precinct 1')
+    screen.getAllByText('Polls Opened Report for Precinct 1')
   ).toHaveLength(3);
 
   // checking mammal report
@@ -189,7 +189,7 @@ test('polls closed, general, All Precincts, test mode', () => {
   );
 
   expect(screen.getAllByTestId(/tally-report-/)).toHaveLength(1);
-  screen.getByText('TEST Polls Closed Report for All Precincts');
+  screen.getByText('Test Polls Closed Report for All Precincts');
   within(screen.getByTestId('bmd')).getByText('100');
   expect(
     screen.queryByText('Automatic Election Results Reporting')


### PR DESCRIPTION
## Overview

As we standardize report naming in VxAdmin (see #4122), we [agreed](https://votingworks.slack.com/archives/CEL6D3GAD/p1698179698723679) that we should be careful with the word "Official" and it shouldn't appear on VxScan reports.

#### Before

<img width="817" alt="Screen Shot 2023-10-25 at 5 08 05 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/2572e6ca-0f5f-4a26-8325-34d0c544a34a">

<img width="816" alt="Screen Shot 2023-10-25 at 5 08 21 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/b86f9330-8254-4d2f-83f5-5049a49ac5d9">

#### After

<img width="817" alt="Screen Shot 2023-10-25 at 5 08 53 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/d41ef2fd-40bb-4527-a484-309d19082f07">

<img width="822" alt="Screen Shot 2023-10-26 at 10 41 11 AM" src="https://github.com/votingworks/vxsuite/assets/37960853/9a9d0999-4edb-4118-94e1-3edc961c4388">

