### PR TITLE
[i18n/audio] Add CDF string extractors for precinct/district names

### DIFF
--- a/libs/types/src/cdf/ballot-definition/convert.ts
+++ b/libs/types/src/cdf/ballot-definition/convert.ts
@@ -444,6 +444,17 @@ export function convertVxfElectionToCdfBallotDefinition(
   };
 }
 
+export function getElectionDistricts(
+  cdfBallotDefinition: Cdf.BallotDefinition
+): Cdf.ReportingUnit[] {
+  // Any GpUnit that is associated with contests is a "district" in VXF
+  return cdfBallotDefinition.GpUnit.filter((gpUnit) =>
+    cdfBallotDefinition.Election[0].Contest.some(
+      (contest) => contest.ElectionDistrictId === gpUnit['@id']
+    )
+  );
+}
+
 export function convertCdfBallotDefinitionToVxfElection(
   cdfBallotDefinition: Cdf.BallotDefinition
 ): Vxf.Election {
@@ -461,11 +472,7 @@ export function convertCdfBallotDefinitionToVxfElection(
   );
 
   // Any GpUnit that is associated with contests is a "district" in VXF
-  const districts = gpUnits.filter((gpUnit) =>
-    election.Contest.some(
-      (contest) => contest.ElectionDistrictId === gpUnit['@id']
-    )
-  );
+  const districts = getElectionDistricts(cdfBallotDefinition);
 
   const precincts = gpUnits.filter(
     (gpUnit) => gpUnit.Type === Cdf.ReportingUnitType.Precinct

--- a/libs/utils/src/extract_cdf_ui_strings.test.ts
+++ b/libs/utils/src/extract_cdf_ui_strings.test.ts
@@ -329,7 +329,69 @@ const tests: Record<ElectionStringKey, () => void> = {
   },
 
   [ElectionStringKey.DISTRICT_NAME]() {
-    // TODO(kofi): Implement
+    const uiStrings = extractCdfUiStrings({
+      ...testCdfBallotDefinition,
+      GpUnit: [
+        {
+          '@id': 'district9',
+          '@type': 'BallotDefinition.ReportingUnit',
+          Name: buildInternationalizedText({
+            [LanguageCode.ENGLISH]: 'District 9',
+            [LanguageCode.SPANISH]: 'Distrito 9',
+            unsupported_lang: '👽',
+          }),
+          Type: BallotDefinition.ReportingUnitType.Other,
+        },
+        {
+          '@id': 'notADistrict',
+          '@type': 'BallotDefinition.ReportingUnit',
+          Name: buildInternationalizedText({
+            [LanguageCode.ENGLISH]: 'Not A District',
+          }),
+          Type: BallotDefinition.ReportingUnitType.Other,
+        },
+        {
+          '@id': 'district10',
+          '@type': 'BallotDefinition.ReportingUnit',
+          Name: buildInternationalizedText({
+            [LanguageCode.ENGLISH]: 'District 10',
+            [LanguageCode.SPANISH]: 'Distrito 10',
+            unsupported_lang: '🛸',
+          }),
+          Type: BallotDefinition.ReportingUnitType.Other,
+        },
+      ],
+      Election: [
+        {
+          ...ORIGINAL_ELECTION,
+          Contest: [
+            {
+              ...assertDefined(ORIGINAL_ELECTION.Contest[0]),
+              ElectionDistrictId: 'district9',
+            },
+            {
+              ...assertDefined(ORIGINAL_ELECTION.Contest[1]),
+              ElectionDistrictId: 'district10',
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(uiStrings).toEqual({
+      [LanguageCode.ENGLISH]: expect.objectContaining({
+        [ElectionStringKey.DISTRICT_NAME]: {
+          district9: 'District 9',
+          district10: 'District 10',
+        },
+      }),
+      [LanguageCode.SPANISH]: expect.objectContaining({
+        [ElectionStringKey.DISTRICT_NAME]: {
+          district9: 'Distrito 9',
+          district10: 'Distrito 10',
+        },
+      }),
+    });
   },
 
   [ElectionStringKey.ELECTION_TITLE]() {
@@ -440,7 +502,54 @@ const tests: Record<ElectionStringKey, () => void> = {
   },
 
   [ElectionStringKey.PRECINCT_NAME]() {
-    // TODO(kofi): Implement
+    const uiStrings = extractCdfUiStrings({
+      ...testCdfBallotDefinition,
+      GpUnit: [
+        {
+          '@id': 'brooklyn99',
+          '@type': 'BallotDefinition.ReportingUnit',
+          Name: buildInternationalizedText({
+            [LanguageCode.ENGLISH]: 'Brooklyn Nine-Nine',
+            [LanguageCode.SPANISH]: 'Brooklyn Nueve-Nueve',
+            unsupported_lang: '9️⃣',
+          }),
+          Type: BallotDefinition.ReportingUnitType.Precinct,
+        },
+        {
+          '@id': 'westRiver',
+          '@type': 'BallotDefinition.ReportingUnit',
+          Name: buildInternationalizedText({
+            [LanguageCode.ENGLISH]: 'West River',
+            [LanguageCode.SPANISH]: 'Río Oeste',
+            unsupported_lang: '⬅️',
+          }),
+          Type: BallotDefinition.ReportingUnitType.Precinct,
+        },
+        {
+          '@id': 'district9',
+          '@type': 'BallotDefinition.ReportingUnit',
+          Name: buildInternationalizedText({
+            [LanguageCode.ENGLISH]: 'District9',
+          }),
+          Type: BallotDefinition.ReportingUnitType.Other,
+        },
+      ],
+    });
+
+    expect(uiStrings).toEqual({
+      [LanguageCode.ENGLISH]: expect.objectContaining({
+        [ElectionStringKey.PRECINCT_NAME]: {
+          brooklyn99: 'Brooklyn Nine-Nine',
+          westRiver: 'West River',
+        },
+      }),
+      [LanguageCode.SPANISH]: expect.objectContaining({
+        [ElectionStringKey.PRECINCT_NAME]: {
+          brooklyn99: 'Brooklyn Nueve-Nueve',
+          westRiver: 'Río Oeste',
+        },
+      }),
+    });
   },
 
   [ElectionStringKey.STATE_NAME]() {

--- a/libs/utils/src/extract_cdf_ui_strings.ts
+++ b/libs/utils/src/extract_cdf_ui_strings.ts
@@ -1,5 +1,4 @@
 // TODO(kofi): Remove once extractors are implemented.
-/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import _ from 'lodash';
 
@@ -8,6 +7,7 @@ import {
   ElectionStringKey,
   LanguageCode,
   UiStringsPackage,
+  getElectionDistricts,
 } from '@votingworks/types';
 import { assertDefined } from '@votingworks/basics';
 
@@ -151,8 +151,16 @@ const extractorFns: Record<
     });
   },
 
-  [ElectionStringKey.DISTRICT_NAME](_cdfElection, _uiStrings) {
-    // TODO(kofi): Implement
+  [ElectionStringKey.DISTRICT_NAME](cdfElection, uiStrings) {
+    const districts = getElectionDistricts(cdfElection);
+
+    for (const district of districts) {
+      setInternationalizedUiStrings({
+        stringKey: [ElectionStringKey.DISTRICT_NAME, district['@id']],
+        uiStrings,
+        values: district.Name.Text,
+      });
+    }
   },
 
   [ElectionStringKey.ELECTION_TITLE](cdfElection, uiStrings) {
@@ -183,8 +191,18 @@ const extractorFns: Record<
     }
   },
 
-  [ElectionStringKey.PRECINCT_NAME](_cdfElection, _uiStrings) {
-    // TODO(kofi): Implement
+  [ElectionStringKey.PRECINCT_NAME](cdfElection, uiStrings) {
+    for (const gpUnit of cdfElection.GpUnit) {
+      if (gpUnit.Type !== BallotDefinition.ReportingUnitType.Precinct) {
+        continue;
+      }
+
+      setInternationalizedUiStrings({
+        stringKey: [ElectionStringKey.PRECINCT_NAME, gpUnit['@id']],
+        uiStrings,
+        values: gpUnit.Name.Text,
+      });
+    }
   },
 
   [ElectionStringKey.STATE_NAME](cdfElection, uiStrings) {


### PR DESCRIPTION
## Overview

Adding CDF string extractors for the last couple remaining election strings.

## Testing Plan
- Added unit test coverage

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
