### PR TITLE
[i18n/audio] Install UiStringContextProvider in voter-facing apps

### DIFF
--- a/apps/mark-scan/frontend/src/app.tsx
+++ b/apps/mark-scan/frontend/src/app.tsx
@@ -9,7 +9,14 @@ import {
 } from '@votingworks/utils';
 import { Logger, LogSource } from '@votingworks/logging';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { AppBase, ErrorBoundary, H1, P, Text } from '@votingworks/ui';
+import {
+  AppBase,
+  ErrorBoundary,
+  H1,
+  P,
+  Text,
+  UiStringsContextProvider,
+} from '@votingworks/ui';
 import { ColorMode, ScreenType, SizeMode } from '@votingworks/types';
 import { memoize } from './utils/memoize';
 import {
@@ -27,6 +34,7 @@ import {
   ApiClientContext,
   createApiClient,
   createQueryClient,
+  uiStringsApi,
 } from './api';
 import { SessionTimeLimitTracker } from './components/session_time_limit_tracker';
 
@@ -46,6 +54,7 @@ export interface Props {
   logger?: AppRootProps['logger'];
   apiClient?: ApiClient;
   queryClient?: QueryClient;
+  enableStringTranslation?: boolean;
 }
 
 export function App({
@@ -60,6 +69,7 @@ export function App({
   logger = new Logger(LogSource.VxMarkScanFrontend, window.kiosk),
   /* istanbul ignore next */ apiClient = createApiClient(),
   queryClient = createQueryClient(),
+  enableStringTranslation,
 }: Props): JSX.Element {
   screenReader.mute();
   /* istanbul ignore next - need to figure out how to test this */
@@ -149,14 +159,19 @@ export function App({
           >
             <ApiClientContext.Provider value={apiClient}>
               <QueryClientProvider client={queryClient}>
-                <AppRoot
-                  hardware={hardware}
-                  storage={storage}
-                  screenReader={screenReader}
-                  reload={reload}
-                  logger={logger}
-                />
-                <SessionTimeLimitTracker />
+                <UiStringsContextProvider
+                  api={uiStringsApi}
+                  disabledForTesting={!enableStringTranslation}
+                >
+                  <AppRoot
+                    hardware={hardware}
+                    storage={storage}
+                    screenReader={screenReader}
+                    reload={reload}
+                    logger={logger}
+                  />
+                  <SessionTimeLimitTracker />
+                </UiStringsContextProvider>
               </QueryClientProvider>
             </ApiClientContext.Provider>
           </FocusManager>

--- a/apps/mark-scan/frontend/src/index.tsx
+++ b/apps/mark-scan/frontend/src/index.tsx
@@ -36,7 +36,7 @@ const root = createRoot(rootElement);
 
 root.render(
   <React.Fragment>
-    <App screenReader={screenReader} />
+    <App enableStringTranslation screenReader={screenReader} />
     <DevDock />
   </React.Fragment>
 );

--- a/apps/mark/frontend/src/app.tsx
+++ b/apps/mark/frontend/src/app.tsx
@@ -9,7 +9,14 @@ import {
 } from '@votingworks/utils';
 import { Logger, LogSource } from '@votingworks/logging';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { AppBase, ErrorBoundary, H1, P, Prose } from '@votingworks/ui';
+import {
+  AppBase,
+  ErrorBoundary,
+  H1,
+  P,
+  Prose,
+  UiStringsContextProvider,
+} from '@votingworks/ui';
 import { ColorMode, ScreenType, SizeMode } from '@votingworks/types';
 import { memoize } from './utils/memoize';
 import {
@@ -27,6 +34,7 @@ import {
   ApiClientContext,
   createApiClient,
   createQueryClient,
+  uiStringsApi,
 } from './api';
 import { SessionTimeLimitTracker } from './components/session_time_limit_tracker';
 
@@ -46,6 +54,7 @@ export interface Props {
   logger?: AppRootProps['logger'];
   apiClient?: ApiClient;
   queryClient?: QueryClient;
+  enableStringTranslation?: boolean;
 }
 
 export function App({
@@ -60,6 +69,7 @@ export function App({
   logger = new Logger(LogSource.VxMarkFrontend, window.kiosk),
   /* istanbul ignore next */ apiClient = createApiClient(),
   queryClient = createQueryClient(),
+  enableStringTranslation,
 }: Props): JSX.Element {
   screenReader.mute();
   /* istanbul ignore next - need to figure out how to test this */
@@ -149,14 +159,19 @@ export function App({
           >
             <ApiClientContext.Provider value={apiClient}>
               <QueryClientProvider client={queryClient}>
-                <AppRoot
-                  hardware={hardware}
-                  storage={storage}
-                  screenReader={screenReader}
-                  reload={reload}
-                  logger={logger}
-                />
-                <SessionTimeLimitTracker />
+                <UiStringsContextProvider
+                  api={uiStringsApi}
+                  disabledForTesting={!enableStringTranslation}
+                >
+                  <AppRoot
+                    hardware={hardware}
+                    storage={storage}
+                    screenReader={screenReader}
+                    reload={reload}
+                    logger={logger}
+                  />
+                  <SessionTimeLimitTracker />
+                </UiStringsContextProvider>
               </QueryClientProvider>
             </ApiClientContext.Provider>
           </FocusManager>

--- a/apps/mark/frontend/src/index.tsx
+++ b/apps/mark/frontend/src/index.tsx
@@ -36,7 +36,7 @@ const root = createRoot(rootElement);
 
 root.render(
   <React.Fragment>
-    <App screenReader={screenReader} />
+    <App enableStringTranslation screenReader={screenReader} />
     <DevDock />
   </React.Fragment>
 );

--- a/apps/scan/frontend/src/app.tsx
+++ b/apps/scan/frontend/src/app.tsx
@@ -15,6 +15,7 @@ import {
   H1,
   Icons,
   P,
+  UiStringsContextProvider,
 } from '@votingworks/ui';
 import { PrecinctReportDestination } from '@votingworks/types';
 import { Optional } from '@votingworks/basics';
@@ -24,6 +25,7 @@ import {
   ApiClientContext,
   createApiClient,
   createQueryClient,
+  uiStringsApi,
 } from './api';
 import { ScanAppBase } from './scan_app_base';
 import { SessionTimeLimitTracker } from './components/session_time_limit_tracker';
@@ -43,6 +45,7 @@ export interface AppProps {
   apiClient?: ApiClient;
   queryClient?: QueryClient;
   precinctReportDestination?: PrecinctReportDestination;
+  enableStringTranslation?: boolean;
 }
 
 export function App({
@@ -52,6 +55,7 @@ export function App({
   queryClient = createQueryClient(),
   precinctReportDestination = envPrecinctReportDestination ??
     DEFAULT_PRECINCT_REPORT_DESTINATION,
+  enableStringTranslation,
 }: AppProps): JSX.Element {
   return (
     <ScanAppBase>
@@ -71,18 +75,24 @@ export function App({
         >
           <ApiClientContext.Provider value={apiClient}>
             <QueryClientProvider client={queryClient}>
-              <Route path={Paths.DISPLAY_SETTINGS} exact>
-                <DisplaySettingsScreen />
-              </Route>
-              <Route path={Paths.APP_ROOT} exact>
-                <AppRoot
-                  hardware={hardware}
-                  logger={logger}
-                  precinctReportDestination={precinctReportDestination}
-                />
-              </Route>
-              <SessionTimeLimitTracker />
-              <DisplaySettingsManager />
+              <UiStringsContextProvider
+                api={uiStringsApi}
+                disabledForTesting={!enableStringTranslation}
+                noAudio
+              >
+                <Route path={Paths.DISPLAY_SETTINGS} exact>
+                  <DisplaySettingsScreen />
+                </Route>
+                <Route path={Paths.APP_ROOT} exact>
+                  <AppRoot
+                    hardware={hardware}
+                    logger={logger}
+                    precinctReportDestination={precinctReportDestination}
+                  />
+                </Route>
+                <SessionTimeLimitTracker />
+                <DisplaySettingsManager />
+              </UiStringsContextProvider>
             </QueryClientProvider>
           </ApiClientContext.Provider>
         </ErrorBoundary>

--- a/apps/scan/frontend/src/index.tsx
+++ b/apps/scan/frontend/src/index.tsx
@@ -17,7 +17,7 @@ root.render(
       <PreviewApp />
     ) : (
       <React.Fragment>
-        <App />
+        <App enableStringTranslation />
         <DevDock />
       </React.Fragment>
     )}

--- a/libs/ui/src/ui_strings/ui_strings_context.test.tsx
+++ b/libs/ui/src/ui_strings/ui_strings_context.test.tsx
@@ -1,5 +1,5 @@
 import { LanguageCode } from '@votingworks/types';
-import { waitFor } from '../../test/react_testing_library';
+import { screen, waitFor } from '../../test/react_testing_library';
 import { newTestContext } from '../../test/ui_strings/test_utils';
 
 test('includes both language and audio contexts', async () => {
@@ -27,5 +27,22 @@ test('skips audio context when `noAudio` is true', async () => {
   render(<div>foo</div>);
 
   await waitFor(() => expect(getLanguageContext()).toBeDefined());
+  expect(getAudioContext()).toBeUndefined();
+});
+
+test('omits both contexts when `disableForTesting` is true', async () => {
+  const { getAudioContext, getLanguageContext, mockBackendApi, render } =
+    newTestContext({ disableForTesting: true });
+
+  mockBackendApi.getAvailableLanguages.mockResolvedValue([
+    LanguageCode.ENGLISH,
+  ]);
+
+  mockBackendApi.getUiStrings.mockResolvedValue(null);
+
+  render(<div>foo</div>);
+
+  await screen.findByText('foo');
+  expect(getLanguageContext()).toBeUndefined();
   expect(getAudioContext()).toBeUndefined();
 });

--- a/libs/ui/src/ui_strings/ui_strings_context.tsx
+++ b/libs/ui/src/ui_strings/ui_strings_context.tsx
@@ -7,13 +7,18 @@ import { AudioContextProvider } from './audio_context';
 export interface UiStringsContextProviderProps {
   api: UiStringsReactQueryApi;
   children: React.ReactNode;
+  disabledForTesting?: boolean;
   noAudio?: boolean;
 }
 
 export function UiStringsContextProvider(
   props: UiStringsContextProviderProps
 ): JSX.Element {
-  const { api, children, noAudio } = props;
+  const { api, children, disabledForTesting, noAudio } = props;
+
+  if (disabledForTesting) {
+    return <React.Fragment>{children}</React.Fragment>;
+  }
 
   return (
     <LanguageContextProvider api={api}>

--- a/libs/ui/test/ui_strings/test_utils.tsx
+++ b/libs/ui/test/ui_strings/test_utils.tsx
@@ -27,6 +27,7 @@ export interface UiStringsTestContext {
 
 export function newTestContext(
   options: {
+    disableForTesting?: boolean;
     noAudio?: boolean;
   } = {}
 ): UiStringsTestContext {
@@ -61,6 +62,7 @@ export function newTestContext(
       <QueryClientProvider client={queryClient}>
         <UiStringsContextProvider
           api={mockUiStringsApi}
+          disabledForTesting={options.disableForTesting}
           noAudio={options.noAudio}
         >
           <ContextConsumer />


### PR DESCRIPTION
## Overview

_Related spec [here](https://docs.google.com/document/d/1a2GRj1g4aOawEssPdTCgbv-qs28d-M_dyMEfzm4I4nM/edit?usp=sharing)._

Installing the shared `UiStringContextProvider` in `Vx[Scan|Mark|Mark-Scan]` to connect `<UiString>` instances to the backend API.

Only enabling the context provider for dev/prod app instances (and integration tests) and leaving it disabled for the functional jest tests, since it was going to be too much unnecessary overhead to add mock versions of the UiString API endpoints and set up expectations in all existing tests that render the root `<App>` component directly.

## Testing Plan
- Unit test coverage for the added conditional provider installation
- Planning on following up later integration test coverage to verify e2e functionality from configuration through changing languages, once all the pieces are ready.

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
