### PR TITLE
Move Mark Official Button

### DIFF
--- a/apps/admin/frontend/src/components/mark_official_button.test.tsx
+++ b/apps/admin/frontend/src/components/mark_official_button.test.tsx
@@ -1,0 +1,87 @@
+import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import { Logger, fakeLogger } from '@votingworks/logging';
+import userEvent from '@testing-library/user-event';
+import { ApiMock, createApiMock } from '../../test/helpers/mock_api_client';
+import {
+  MARK_RESULTS_OFFICIAL_BUTTON_TEXT,
+  MarkResultsOfficialButton,
+} from './mark_official_button';
+import { renderInAppContext } from '../../test/render_in_app_context';
+import { screen, waitFor, within } from '../../test/react_testing_library';
+
+let logger: Logger;
+let apiMock: ApiMock;
+
+beforeEach(() => {
+  logger = fakeLogger();
+  apiMock = createApiMock();
+});
+
+afterEach(() => {
+  delete window.kiosk;
+  apiMock.assertComplete();
+});
+
+test('mark results as official', async () => {
+  const { electionDefinition } = electionFamousNames2021Fixtures;
+  apiMock.expectGetCastVoteRecordFileMode('official');
+
+  renderInAppContext(<MarkResultsOfficialButton />, {
+    electionDefinition,
+    logger,
+    apiMock,
+    isOfficialResults: false,
+  });
+
+  await waitFor(() => {
+    expect(screen.getButton(MARK_RESULTS_OFFICIAL_BUTTON_TEXT)).toBeEnabled();
+  });
+
+  // open and close modal
+  userEvent.click(screen.getButton(MARK_RESULTS_OFFICIAL_BUTTON_TEXT));
+  let modal = await screen.findByRole('alertdialog');
+  userEvent.click(within(modal).getButton('Cancel'));
+  await waitFor(() => expect(modal).not.toBeInTheDocument());
+
+  // open and mark official
+  userEvent.click(screen.getButton(MARK_RESULTS_OFFICIAL_BUTTON_TEXT));
+  modal = await screen.findByRole('alertdialog');
+  apiMock.expectMarkResultsOfficial();
+  userEvent.click(within(modal).getButton(MARK_RESULTS_OFFICIAL_BUTTON_TEXT));
+  await waitFor(() => expect(modal).not.toBeInTheDocument());
+});
+
+test('mark official results button disabled when no cvr files', async () => {
+  const { electionDefinition } = electionFamousNames2021Fixtures;
+  apiMock.expectGetCastVoteRecordFileMode('unlocked'); // no CVR files
+  renderInAppContext(<MarkResultsOfficialButton />, {
+    electionDefinition,
+    logger,
+    apiMock,
+  });
+
+  // button only can be enabled after CVR file mode query completes
+  await waitFor(() => {
+    apiMock.assertComplete();
+  });
+
+  expect(screen.getButton(MARK_RESULTS_OFFICIAL_BUTTON_TEXT)).toBeDisabled();
+});
+
+test('mark official results button disabled when already official', async () => {
+  const { electionDefinition } = electionFamousNames2021Fixtures;
+  apiMock.expectGetCastVoteRecordFileMode('official');
+  renderInAppContext(<MarkResultsOfficialButton />, {
+    electionDefinition,
+    logger,
+    apiMock,
+    isOfficialResults: true,
+  });
+
+  // button only can be enabled after CVR file mode query completes
+  await waitFor(() => {
+    apiMock.assertComplete();
+  });
+
+  expect(screen.getButton(MARK_RESULTS_OFFICIAL_BUTTON_TEXT)).toBeDisabled();
+});

--- a/apps/admin/frontend/src/components/mark_official_button.tsx
+++ b/apps/admin/frontend/src/components/mark_official_button.tsx
@@ -42,10 +42,13 @@ export function MarkResultsOfficialButton(): JSX.Element {
           content={
             <React.Fragment>
               <P>
-                Have all CVR files been loaded? Once results are marked as
-                official, no additional CVR files can be loaded.
+                Have all CVR files been loaded? Have unofficial tally reports
+                been reviewed?
               </P>
-              <P>Have all unofficial tally reports been reviewed?</P>
+              <P>
+                Once results are marked as official, no additional CVR files can
+                be loaded.
+              </P>
             </React.Fragment>
           }
           actions={

--- a/apps/admin/frontend/src/components/mark_official_button.tsx
+++ b/apps/admin/frontend/src/components/mark_official_button.tsx
@@ -1,0 +1,64 @@
+import React, { useContext, useState } from 'react';
+import { Button, Modal, P } from '@votingworks/ui';
+import { getCastVoteRecordFileMode, markResultsOfficial } from '../api';
+import { AppContext } from '../contexts/app_context';
+
+export const MARK_RESULTS_OFFICIAL_BUTTON_TEXT =
+  'Mark Election Results as Official';
+
+export function MarkResultsOfficialButton(): JSX.Element {
+  const { isOfficialResults } = useContext(AppContext);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const markResultsOfficialMutation = markResultsOfficial.useMutation();
+  const castVoteRecordFileModeQuery = getCastVoteRecordFileMode.useQuery();
+
+  const canMarkResultsOfficial =
+    castVoteRecordFileModeQuery.isSuccess &&
+    castVoteRecordFileModeQuery.data !== 'unlocked' &&
+    !isOfficialResults;
+
+  function openModal() {
+    setIsModalOpen(true);
+  }
+
+  function closeModal() {
+    setIsModalOpen(false);
+  }
+
+  function markOfficial() {
+    setIsModalOpen(false);
+    markResultsOfficialMutation.mutate();
+  }
+
+  return (
+    <React.Fragment>
+      <Button disabled={!canMarkResultsOfficial} onPress={openModal}>
+        {MARK_RESULTS_OFFICIAL_BUTTON_TEXT}
+      </Button>
+      {isModalOpen && (
+        <Modal
+          title="Mark Unofficial Election Results as Official Election Results?"
+          content={
+            <React.Fragment>
+              <P>
+                Have all CVR files been loaded? Once results are marked as
+                official, no additional CVR files can be loaded.
+              </P>
+              <P>Have all unofficial tally reports been reviewed?</P>
+            </React.Fragment>
+          }
+          actions={
+            <React.Fragment>
+              <Button variant="primary" onPress={markOfficial}>
+                Mark Election Results as Official
+              </Button>
+              <Button onPress={closeModal}>Cancel</Button>
+            </React.Fragment>
+          }
+          onOverlayClick={closeModal}
+        />
+      )}
+    </React.Fragment>
+  );
+}

--- a/apps/admin/frontend/src/screens/reporting/full_election_tally_report_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/full_election_tally_report_screen.test.tsx
@@ -1,12 +1,11 @@
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 import { Logger, fakeLogger } from '@votingworks/logging';
-import userEvent from '@testing-library/user-event';
 import { ApiMock, createApiMock } from '../../../test/helpers/mock_api_client';
 import { getSimpleMockTallyResults } from '../../../test/helpers/mock_results';
 import { FullElectionTallyReportScreen } from './full_election_tally_report_screen';
 import { renderInAppContext } from '../../../test/render_in_app_context';
 import { routerPaths } from '../../router_paths';
-import { screen, waitFor, within } from '../../../test/react_testing_library';
+import { screen } from '../../../test/react_testing_library';
 
 let logger: Logger;
 let apiMock: ApiMock;
@@ -44,95 +43,4 @@ test('displays report', async () => {
   await screen.findByTestId('tally-report');
   screen.getByText('Official Lincoln Municipal General Election Tally Report');
   expect(screen.getByTestId('total-ballot-count')).toHaveTextContent('11');
-});
-
-test('mark results as official', async () => {
-  const { election, electionDefinition } = electionFamousNames2021Fixtures;
-  apiMock.expectGetCastVoteRecordFileMode('official');
-  apiMock.expectGetScannerBatches([]);
-  apiMock.expectGetResultsForTallyReports(
-    {
-      filter: {},
-      groupBy: {},
-    },
-    [getSimpleMockTallyResults({ election, scannedBallotCount: 10 })]
-  );
-
-  renderInAppContext(<FullElectionTallyReportScreen />, {
-    electionDefinition,
-    logger,
-    apiMock,
-    route: routerPaths.tallyFullReport,
-    isOfficialResults: false,
-  });
-
-  await screen.findByTestId('tally-report');
-
-  // open and close modal
-  userEvent.click(screen.getButton('Mark Tally Results as Official'));
-  let modal = await screen.findByRole('alertdialog');
-  userEvent.click(within(modal).getButton('Cancel'));
-  await waitFor(() => expect(modal).not.toBeInTheDocument());
-
-  // open and mark official
-  userEvent.click(screen.getButton('Mark Tally Results as Official'));
-  modal = await screen.findByRole('alertdialog');
-  apiMock.expectMarkResultsOfficial();
-  userEvent.click(within(modal).getButton('Mark Tally Results as Official'));
-  await waitFor(() => expect(modal).not.toBeInTheDocument());
-});
-
-test('mark official results button disabled when no cvr files', async () => {
-  const { election, electionDefinition } = electionFamousNames2021Fixtures;
-  apiMock.expectGetCastVoteRecordFileMode('unlocked'); // no CVR files
-  apiMock.expectGetScannerBatches([]);
-  apiMock.expectGetResultsForTallyReports(
-    {
-      filter: {},
-      groupBy: {},
-    },
-    [getSimpleMockTallyResults({ election, scannedBallotCount: 10 })]
-  );
-
-  renderInAppContext(<FullElectionTallyReportScreen />, {
-    electionDefinition,
-    logger,
-    apiMock,
-    route: routerPaths.tallyFullReport,
-  });
-
-  await screen.findByTestId('tally-report');
-  expect(
-    screen.getByRole('button', {
-      name: 'Mark Tally Results as Official',
-    })
-  ).toBeDisabled();
-});
-
-test('mark official results button disabled when already official', async () => {
-  const { election, electionDefinition } = electionFamousNames2021Fixtures;
-  apiMock.expectGetCastVoteRecordFileMode('official');
-  apiMock.expectGetScannerBatches([]);
-  apiMock.expectGetResultsForTallyReports(
-    {
-      filter: {},
-      groupBy: {},
-    },
-    [getSimpleMockTallyResults({ election, scannedBallotCount: 10 })]
-  );
-
-  renderInAppContext(<FullElectionTallyReportScreen />, {
-    electionDefinition,
-    logger,
-    apiMock,
-    route: routerPaths.tallyFullReport,
-    isOfficialResults: true,
-  });
-
-  await screen.findByTestId('tally-report');
-  expect(
-    screen.getByRole('button', {
-      name: 'Mark Tally Results as Official',
-    })
-  ).toBeDisabled();
 });

--- a/apps/admin/frontend/src/screens/reporting/full_election_tally_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/full_election_tally_report_screen.tsx
@@ -1,100 +1,33 @@
-import React, { useContext, useState } from 'react';
+import { useContext } from 'react';
 import { isElectionManagerAuth } from '@votingworks/utils';
 import { assert } from '@votingworks/basics';
-import { Button, Modal, P } from '@votingworks/ui';
+import { P } from '@votingworks/ui';
 
-import styled from 'styled-components';
 import { AppContext } from '../../contexts/app_context';
 
 import { NavigationScreen } from '../../components/navigation_screen';
 
-import { getCastVoteRecordFileMode, markResultsOfficial } from '../../api';
-import { Loading } from '../../components/loading';
 import { TallyReportViewer } from '../../components/reporting/tally_report_viewer';
 import { ReportBackButton } from '../../components/reporting/shared';
 
 const SCREEN_TITLE = 'Full Election Tally Report';
 
-const TopButtonBar = styled.div`
-  display: flex;
-  gap: 1rem;
-`;
-
 export function FullElectionTallyReportScreen(): JSX.Element {
-  const { electionDefinition, isOfficialResults, auth } =
-    useContext(AppContext);
+  const { electionDefinition, auth } = useContext(AppContext);
   assert(electionDefinition);
   assert(isElectionManagerAuth(auth));
 
-  const [isMarkOfficialModalOpen, setIsMarkOfficialModalOpen] = useState(false);
-
-  const markResultsOfficialMutation = markResultsOfficial.useMutation();
-  const castVoteRecordFileModeQuery = getCastVoteRecordFileMode.useQuery();
-
-  function closeMarkOfficialModal() {
-    setIsMarkOfficialModalOpen(false);
-  }
-  function openMarkOfficialModal() {
-    setIsMarkOfficialModalOpen(true);
-  }
-  function markOfficial() {
-    setIsMarkOfficialModalOpen(false);
-    markResultsOfficialMutation.mutate();
-  }
-
-  if (!castVoteRecordFileModeQuery.isSuccess) {
-    return (
-      <NavigationScreen title={SCREEN_TITLE}>
-        <Loading />
-      </NavigationScreen>
-    );
-  }
-
-  const canMarkResultsOfficial =
-    castVoteRecordFileModeQuery.data !== 'unlocked' && !isOfficialResults;
-
   return (
-    <React.Fragment>
-      <NavigationScreen title={SCREEN_TITLE}>
-        <TopButtonBar>
-          <ReportBackButton />{' '}
-          <Button
-            disabled={!canMarkResultsOfficial}
-            onPress={openMarkOfficialModal}
-          >
-            Mark Tally Results as Official
-          </Button>
-        </TopButtonBar>
-        <TallyReportViewer
-          filter={{}}
-          groupBy={{}}
-          disabled={false}
-          autoPreview
-        />
-      </NavigationScreen>
-      {isMarkOfficialModalOpen && (
-        <Modal
-          title="Mark Unofficial Tally Results as Official Tally Results?"
-          content={
-            <React.Fragment>
-              <P>
-                Have all CVR files been loaded? Once results are marked as
-                official, no additional CVR files can be loaded.
-              </P>
-              <P>Have all unofficial tally reports been reviewed?</P>
-            </React.Fragment>
-          }
-          actions={
-            <React.Fragment>
-              <Button variant="primary" onPress={markOfficial}>
-                Mark Tally Results as Official
-              </Button>
-              <Button onPress={closeMarkOfficialModal}>Cancel</Button>
-            </React.Fragment>
-          }
-          onOverlayClick={closeMarkOfficialModal}
-        />
-      )}
-    </React.Fragment>
+    <NavigationScreen title={SCREEN_TITLE}>
+      <P>
+        <ReportBackButton />
+      </P>
+      <TallyReportViewer
+        filter={{}}
+        groupBy={{}}
+        disabled={false}
+        autoPreview
+      />
+    </NavigationScreen>
   );
 }

--- a/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
@@ -34,6 +34,7 @@ import {
   getSemsExportableTallies,
 } from '../../api';
 import { ExportBatchTallyResultsButton } from '../../components/export_batch_tally_results_button';
+import { MarkResultsOfficialButton } from '../../components/mark_official_button';
 
 export function ReportsScreen(): JSX.Element {
   const makeCancelable = useCancelablePromise();
@@ -138,6 +139,8 @@ export function ReportsScreen(): JSX.Element {
   return (
     <React.Fragment>
       <NavigationScreen title="Election Reports">
+        {ballotCountSummaryText}
+        <MarkResultsOfficialButton />
         <H2>{statusPrefix} Tally Reports</H2>
         <P>
           <LinkButton variant="primary" to={routerPaths.tallyFullReport}>
@@ -158,7 +161,7 @@ export function ReportsScreen(): JSX.Element {
           </LinkButton>
         </P>
         <H2>{statusPrefix} Ballot Count Reports</H2>
-        {ballotCountSummaryText}
+
         <P>
           <LinkButton to={routerPaths.ballotCountReportPrecinct}>
             Precinct Ballot Count Report

--- a/apps/admin/integration-testing/e2e/reports.spec.ts
+++ b/apps/admin/integration-testing/e2e/reports.spec.ts
@@ -109,19 +109,24 @@ test('viewing and exporting reports', async ({ page }) => {
   ).toMatchSnapshot();
 
   // Mark Official
+  await page.getByText('Reports', { exact: true }).click();
   await page
-    .getByRole('button', { name: 'Mark Tally Results as Official' })
+    .getByRole('button', { name: 'Mark Election Results as Official' })
     .click();
   await page
     .getByRole('alertdialog')
     .locator(
-      page.getByRole('button', { name: 'Mark Tally Results as Official' })
+      page.getByRole('button', { name: 'Mark Election Results as Official' })
     )
     .click();
 
+  // Check Official
   await expect(
-    page.getByRole('button', { name: 'Mark Tally Results as Official' })
+    page.getByRole('button', { name: 'Mark Election Results as Official' })
   ).toBeDisabled();
+  await expect(page.getByText('Official Tally Reports')).toBeVisible();
+
+  await page.getByText('Full Election Tally Report').click();
   await page
     .getByText('Official Mammal Party Example Primary Election Tally Report')
     .waitFor();


### PR DESCRIPTION
## Overview

Closes #4072. I moved the button from the Full Election Tally Report page to the Reports page. 

I also changed the language from "Mark Tally Results as Official" to "Mark Election Results as Official" because that made more sense to me, "tally results" seems a bit redundant and unfamiliar.

## Demo Video or Screenshot

#### Before

https://github.com/votingworks/vxsuite/assets/37960853/20f5205a-ee7a-4d38-b652-7edbd093468f

#### After

https://github.com/votingworks/vxsuite/assets/37960853/f6a128fd-c733-4aff-a8cc-bcf28e218180

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
