### PR TITLE
Update loading ellipsis animation to account for font change

### DIFF
--- a/libs/ui/src/__snapshots__/loading.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/loading.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Renders Loading with defaults 1`] = `
 .c1 {
-  margin-left: -1.4em;
+  margin-left: -1em;
   text-align: center;
   white-space: nowrap;
 }

--- a/libs/ui/src/__snapshots__/progress_ellipsis.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/progress_ellipsis.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`renders ProgressEllipsis 1`] = `
 .c0 {
-  margin-left: -1.4em;
+  margin-left: -1em;
   text-align: center;
   white-space: nowrap;
 }

--- a/libs/ui/src/progress_ellipsis.tsx
+++ b/libs/ui/src/progress_ellipsis.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-const ellipsisWidth = '1.4em';
+const ellipsisWidth = '1em';
 export const ProgressEllipsis = styled.span`
   margin-left: -${ellipsisWidth};
   text-align: center;


### PR DESCRIPTION
## Overview

I've been spending lots of time looking at CVR import/export modals, and I recently noticed that the dots in the ellipsis animation are getting clipped. It just occurred to me that our recent font change 🤖 is probably responsible.

_Before_

https://github.com/votingworks/vxsuite/assets/12616928/81d9c958-da53-4b8e-a347-5aa9f27c31c7

_After :tada:_

https://github.com/votingworks/vxsuite/assets/12616928/3f15f8a5-2885-4c31-a7e7-f988908b357c