### PR TITLE
VxAdmin Reports: Voter Privacy Warning

### DIFF
--- a/apps/admin/frontend/src/components/reporting/tally_report_privacy_warning.tsx
+++ b/apps/admin/frontend/src/components/reporting/tally_report_privacy_warning.tsx
@@ -1,0 +1,55 @@
+import { Optional } from '@votingworks/basics';
+import { Tabulation } from '@votingworks/types';
+import { getScannedBallotCount } from '@votingworks/utils';
+import pluralize from 'pluralize';
+
+export type PrivacyWarningStatus =
+  | {
+      type: 'none';
+    }
+  | {
+      type: 'low-ballot-count';
+      scannedBallotCount: number;
+      isSingleReport: boolean;
+    };
+
+function isBallotCountPrivacyRisk(scannedBallotCount: number): boolean {
+  return (
+    scannedBallotCount > 0 &&
+    scannedBallotCount < Tabulation.TALLY_REPORT_PRIVACY_THRESHOLD
+  );
+}
+
+export function getPrivacyWarningStatus(
+  allCardCounts: Tabulation.GroupList<Tabulation.CardCounts>
+): PrivacyWarningStatus {
+  for (const cardCounts of allCardCounts) {
+    const scannedBallotCount = getScannedBallotCount(cardCounts);
+    if (isBallotCountPrivacyRisk(scannedBallotCount)) {
+      return {
+        type: 'low-ballot-count',
+        scannedBallotCount,
+        isSingleReport: allCardCounts.length === 1,
+      };
+    }
+  }
+
+  return { type: 'none' };
+}
+
+export function getPrivacyWarningText(
+  privacyWarningStatus: PrivacyWarningStatus
+): Optional<string> {
+  if (privacyWarningStatus.type === 'low-ballot-count') {
+    const { scannedBallotCount, isSingleReport } = privacyWarningStatus;
+
+    if (isSingleReport) {
+      return `The currently specified tally report contains only ${pluralize(
+        'scanned ballot',
+        scannedBallotCount,
+        true
+      )}, which may be a voter privacy risk.`;
+    }
+    return `A section of the currently specified tally report contains fewer than ${Tabulation.TALLY_REPORT_PRIVACY_THRESHOLD} scanned ballots, which may be a voter privacy risk.`;
+  }
+}

--- a/apps/admin/frontend/src/components/reporting/tally_report_privacy_warning.tsx
+++ b/apps/admin/frontend/src/components/reporting/tally_report_privacy_warning.tsx
@@ -38,18 +38,24 @@ export function getPrivacyWarningStatus(
 }
 
 export function getPrivacyWarningText(
-  privacyWarningStatus: PrivacyWarningStatus
+  privacyWarningStatus: PrivacyWarningStatus,
+  isDynamicReport: boolean
 ): Optional<string> {
   if (privacyWarningStatus.type === 'low-ballot-count') {
     const { scannedBallotCount, isSingleReport } = privacyWarningStatus;
+    const reportName = isDynamicReport
+      ? 'the currently specified tally report'
+      : 'this tally report';
+    const reportNameCapitalized =
+      reportName.charAt(0).toUpperCase() + reportName.slice(1);
 
     if (isSingleReport) {
-      return `The currently specified tally report contains only ${pluralize(
+      return `${reportNameCapitalized} contains only ${pluralize(
         'scanned ballot',
         scannedBallotCount,
         true
       )}, which may be a voter privacy risk.`;
     }
-    return `A section of the currently specified tally report contains fewer than ${Tabulation.TALLY_REPORT_PRIVACY_THRESHOLD} scanned ballots, which may be a voter privacy risk.`;
+    return `A section of ${reportName} contains fewer than ${Tabulation.TALLY_REPORT_PRIVACY_THRESHOLD} scanned ballots, which may be a voter privacy risk.`;
   }
 }

--- a/apps/admin/frontend/src/components/reporting/tally_report_viewer.tsx
+++ b/apps/admin/frontend/src/components/reporting/tally_report_viewer.tsx
@@ -284,7 +284,8 @@ export function TallyReportViewer({
     <React.Fragment>
       {!cardCountsQuery.isFetching && privacyWarningStatus.type !== 'none' && (
         <P>
-          <Icons.Warning /> {getPrivacyWarningText(privacyWarningStatus)}
+          <Icons.Warning />{' '}
+          {getPrivacyWarningText(privacyWarningStatus, autoPreview)}
         </P>
       )}
       <ExportActions>

--- a/libs/types/src/tabulation.ts
+++ b/libs/types/src/tabulation.ts
@@ -236,3 +236,5 @@ export interface ScannerBatch {
 }
 
 export const BATCH_ID_DISPLAY_LENGTH = 8;
+
+export const TALLY_REPORT_PRIVACY_THRESHOLD = 30;


### PR DESCRIPTION
## Overview

Closes #3993. Adds a voter privacy warning to tally report pages when the number of ballots in any section of the report is less than a set threshold.

- Need to determine a threshold
- Appearance / location
- Need to determine warning text

warning text for dynamic reports...
"A section of the currently specified tally report contains less than X scanned ballots, which may be a voter privacy risk."
"The currently specified tally report contains only 28 scanned ballots, which may be a voter privacy risk."

warning text for static reports...
"A section of this tally report contains less than X scanned ballots, which may be a voter privacy risk."
"This tally report contains only 28 scanned ballots, which may be a voter privacy risk."

## Demo Video or Screenshot

Threshold of 30 is purely for testing, ignore specifics:

https://github.com/votingworks/vxsuite/assets/37960853/001e21b7-a2d9-412c-98ee-f316160f9607

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
