### PR TITLE
VxAdmin Polish: file export naming

### DIFF
--- a/apps/admin/frontend/src/components/reporting/ballot_count_report_viewer.tsx
+++ b/apps/admin/frontend/src/components/reporting/ballot_count_report_viewer.tsx
@@ -252,6 +252,7 @@ export function BallotCountReportViewer({
     filter,
     groupBy,
     isTestMode: castVoteRecordFileModeQuery.data === 'test',
+    isOfficialResults,
     time: cardCountsQuery.dataUpdatedAt
       ? new Date(cardCountsQuery.dataUpdatedAt)
       : undefined,

--- a/apps/admin/frontend/src/components/reporting/export_ballot_count_report_csv_button.test.tsx
+++ b/apps/admin/frontend/src/components/reporting/export_ballot_count_report_csv_button.test.tsx
@@ -40,13 +40,13 @@ test('calls mutation in happy path', async () => {
   const modal = await screen.findByRole('alertdialog');
   await within(modal).findByText('Save Ballot Count Report');
   within(modal).getByText(
-    /absentee-ballots-ballot-count-report-by-precinct__2021-01-01_00-00-00\.csv/
+    /unofficial-absentee-ballots-ballot-count-report-by-precinct__2021-01-01_00-00-00\.csv/
   );
 
   apiMock.expectExportBallotCountReportCsv({
     filter,
     groupBy,
-    path: 'test-mount-point/choctaw-county_mock-general-election-choctaw-2020_d6806afc49/reports/absentee-ballots-ballot-count-report-by-precinct__2021-01-01_00-00-00.csv',
+    path: 'test-mount-point/choctaw-county_mock-general-election-choctaw-2020_d6806afc49/reports/unofficial-absentee-ballots-ballot-count-report-by-precinct__2021-01-01_00-00-00.csv',
   });
   userEvent.click(within(modal).getButton('Save'));
   await screen.findByText('Ballot Count Report Saved');

--- a/apps/admin/frontend/src/components/reporting/export_ballot_count_report_csv_button.tsx
+++ b/apps/admin/frontend/src/components/reporting/export_ballot_count_report_csv_button.tsx
@@ -24,7 +24,7 @@ export function ExportBallotCountReportCsvButton({
   groupBy: Tabulation.GroupBy;
   disabled?: boolean;
 }): JSX.Element {
-  const { electionDefinition } = useContext(AppContext);
+  const { electionDefinition, isOfficialResults } = useContext(AppContext);
   assert(electionDefinition);
   const { election } = electionDefinition;
 
@@ -51,6 +51,7 @@ export function ExportBallotCountReportCsvButton({
     filter,
     groupBy,
     isTestMode,
+    isOfficialResults,
     time: exportDate,
   });
   const defaultFilePath = path.join(

--- a/apps/admin/frontend/src/components/reporting/export_tally_report_csv_button.test.tsx
+++ b/apps/admin/frontend/src/components/reporting/export_tally_report_csv_button.test.tsx
@@ -40,13 +40,13 @@ test('calls mutation in happy path', async () => {
   const modal = await screen.findByRole('alertdialog');
   await within(modal).findByText('Save Results');
   within(modal).getByText(
-    /absentee-ballots-tally-report-by-precinct__2021-01-01_00-00-00\.csv/
+    /unofficial-absentee-ballots-tally-report-by-precinct__2021-01-01_00-00-00\.csv/
   );
 
   apiMock.expectExportTallyReportCsv({
     filter,
     groupBy,
-    path: 'test-mount-point/choctaw-county_mock-general-election-choctaw-2020_d6806afc49/reports/absentee-ballots-tally-report-by-precinct__2021-01-01_00-00-00.csv',
+    path: 'test-mount-point/choctaw-county_mock-general-election-choctaw-2020_d6806afc49/reports/unofficial-absentee-ballots-tally-report-by-precinct__2021-01-01_00-00-00.csv',
   });
   userEvent.click(within(modal).getButton('Save'));
   await screen.findByText('Results Saved');

--- a/apps/admin/frontend/src/components/reporting/export_tally_report_csv_button.tsx
+++ b/apps/admin/frontend/src/components/reporting/export_tally_report_csv_button.tsx
@@ -21,7 +21,7 @@ export function ExportTallyReportCsvButton({
   groupBy: Tabulation.GroupBy;
   disabled?: boolean;
 }): JSX.Element {
-  const { electionDefinition } = useContext(AppContext);
+  const { electionDefinition, isOfficialResults } = useContext(AppContext);
   assert(electionDefinition);
   const { election } = electionDefinition;
 
@@ -47,6 +47,7 @@ export function ExportTallyReportCsvButton({
     filter,
     groupBy,
     isTestMode,
+    isOfficialResults,
     time: exportDate,
   });
   const defaultFilePath = path.join(

--- a/apps/admin/frontend/src/components/reporting/tally_report_viewer.tsx
+++ b/apps/admin/frontend/src/components/reporting/tally_report_viewer.tsx
@@ -261,6 +261,7 @@ export function TallyReportViewer({
     filter,
     groupBy,
     isTestMode: castVoteRecordFileModeQuery.data === 'test',
+    isOfficialResults,
     time: reportResultsQuery.dataUpdatedAt
       ? new Date(reportResultsQuery.dataUpdatedAt)
       : undefined,

--- a/apps/admin/frontend/src/screens/reporting/write_in_adjudication_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/write_in_adjudication_report_screen.tsx
@@ -37,7 +37,6 @@ export function TallyWriteInReportScreen(): JSX.Element {
 
   const castVoteRecordFileModeQuery = getCastVoteRecordFileMode.useQuery();
   const writeInSummaryQuery = getElectionWriteInSummary.useQuery();
-  const castVoteRecordFileModeQuery = getCastVoteRecordFileMode.useQuery();
   const isTestMode = castVoteRecordFileModeQuery.data === 'test';
   const report = useMemo(() => {
     if (!writeInSummaryQuery.isSuccess) return undefined;

--- a/apps/admin/frontend/src/screens/reporting/write_in_adjudication_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/write_in_adjudication_report_screen.tsx
@@ -8,7 +8,6 @@ import {
   P,
   WriteInAdjudicationReport,
 } from '@votingworks/ui';
-import { generateDefaultReportFilename } from '../../utils/save_as_pdf';
 import { AppContext } from '../../contexts/app_context';
 import { NavigationScreen } from '../../components/navigation_screen';
 import { FileType } from '../../components/save_frontend_file_modal';
@@ -26,15 +25,17 @@ import {
   ReportBackButton,
 } from '../../components/reporting/shared';
 import { ExportReportPdfButton } from '../../components/reporting/export_report_pdf_button';
+import { generateReportFilename } from '../../utils/reporting';
 
 export function TallyWriteInReportScreen(): JSX.Element {
   const { electionDefinition, isOfficialResults, auth, logger } =
     useContext(AppContext);
   assert(electionDefinition);
   const { election } = electionDefinition;
-  assert(isElectionManagerAuth(auth)); // TODO(auth) check permissions for viewing tally reports.
+  assert(isElectionManagerAuth(auth));
   const userRole = auth.user.role;
 
+  const castVoteRecordFileModeQuery = getCastVoteRecordFileMode.useQuery();
   const writeInSummaryQuery = getElectionWriteInSummary.useQuery();
   const castVoteRecordFileModeQuery = getCastVoteRecordFileMode.useQuery();
   const isTestMode = castVoteRecordFileModeQuery.data === 'test';
@@ -80,11 +81,16 @@ export function TallyWriteInReportScreen(): JSX.Element {
     }
   }
 
-  const reportPdfFilename = generateDefaultReportFilename(
-    'write-in-adjudication-report',
+  const reportPdfFilename = generateReportFilename({
     election,
-    'full'
-  );
+    filter: {},
+    groupBy: {},
+    type: 'write-in-adjudication-report',
+    isTestMode: castVoteRecordFileModeQuery.data === 'test',
+    isOfficialResults,
+    extension: 'pdf',
+    time: new Date(),
+  });
 
   return (
     <NavigationScreen title="Write-In Adjudication Report">

--- a/apps/admin/frontend/src/utils/reporting.test.ts
+++ b/apps/admin/frontend/src/utils/reporting.test.ts
@@ -259,40 +259,51 @@ test('generateReportPdfFilename', () => {
     groupBy?: Tabulation.GroupBy;
     expectedFilename: string;
     isTestMode?: boolean;
+    isOfficialResults?: boolean;
   }> = [
     {
-      expectedFilename: 'full-election-tally-report__2023-12-09_15-59-32.pdf',
+      expectedFilename:
+        'unofficial-full-election-tally-report__2023-12-09_15-59-32.pdf',
+    },
+    {
+      isOfficialResults: true,
+      expectedFilename:
+        'official-full-election-tally-report__2023-12-09_15-59-32.pdf',
     },
     {
       groupBy: { groupByBallotStyle: true },
       expectedFilename:
-        'tally-reports-by-ballot-style__2023-12-09_15-59-32.pdf',
+        'unofficial-tally-reports-by-ballot-style__2023-12-09_15-59-32.pdf',
     },
     {
       groupBy: { groupByPrecinct: true },
-      expectedFilename: 'tally-reports-by-precinct__2023-12-09_15-59-32.pdf',
+      expectedFilename:
+        'unofficial-tally-reports-by-precinct__2023-12-09_15-59-32.pdf',
     },
     {
       groupBy: { groupByVotingMethod: true },
       expectedFilename:
-        'tally-reports-by-voting-method__2023-12-09_15-59-32.pdf',
+        'unofficial-tally-reports-by-voting-method__2023-12-09_15-59-32.pdf',
     },
     {
       groupBy: { groupByBatch: true },
-      expectedFilename: 'tally-reports-by-batch__2023-12-09_15-59-32.pdf',
+      expectedFilename:
+        'unofficial-tally-reports-by-batch__2023-12-09_15-59-32.pdf',
     },
     {
       groupBy: { groupByScanner: true },
-      expectedFilename: 'tally-reports-by-scanner__2023-12-09_15-59-32.pdf',
+      expectedFilename:
+        'unofficial-tally-reports-by-scanner__2023-12-09_15-59-32.pdf',
     },
     {
       groupBy: { groupByPrecinct: true, groupByVotingMethod: true },
       expectedFilename:
-        'tally-reports-by-precinct-and-voting-method__2023-12-09_15-59-32.pdf',
+        'unofficial-tally-reports-by-precinct-and-voting-method__2023-12-09_15-59-32.pdf',
     },
     {
       filter: { precinctIds: ['precinct-1', 'precinct-2'] },
-      expectedFilename: 'custom-tally-report__2023-12-09_15-59-32.pdf',
+      expectedFilename:
+        'unofficial-custom-tally-report__2023-12-09_15-59-32.pdf',
     },
     {
       filter: {
@@ -300,39 +311,43 @@ test('generateReportPdfFilename', () => {
         ballotStyleIds: ['1M'],
         votingMethods: ['absentee'],
       },
-      expectedFilename: 'custom-tally-report__2023-12-09_15-59-32.pdf',
+      expectedFilename:
+        'unofficial-custom-tally-report__2023-12-09_15-59-32.pdf',
     },
     {
       filter: {
         precinctIds: ['precinct-1'],
       },
-      expectedFilename: 'precinct-1-tally-report__2023-12-09_15-59-32.pdf',
+      expectedFilename:
+        'unofficial-precinct-1-tally-report__2023-12-09_15-59-32.pdf',
     },
     {
       filter: {
         ballotStyleIds: ['1M'],
       },
-      expectedFilename: 'ballot-style-1M-tally-report__2023-12-09_15-59-32.pdf',
+      expectedFilename:
+        'unofficial-ballot-style-1M-tally-report__2023-12-09_15-59-32.pdf',
     },
     {
       filter: {
         votingMethods: ['absentee'],
       },
       expectedFilename:
-        'absentee-ballots-tally-report__2023-12-09_15-59-32.pdf',
+        'unofficial-absentee-ballots-tally-report__2023-12-09_15-59-32.pdf',
     },
     {
       filter: {
         scannerIds: ['VX-00-000'],
       },
       expectedFilename:
-        'scanner-VX-00-000-tally-report__2023-12-09_15-59-32.pdf',
+        'unofficial-scanner-VX-00-000-tally-report__2023-12-09_15-59-32.pdf',
     },
     {
       filter: {
         batchIds: ['12345678-0000-0000-0000-000000000000'],
       },
-      expectedFilename: 'batch-12345678-tally-report__2023-12-09_15-59-32.pdf',
+      expectedFilename:
+        'unofficial-batch-12345678-tally-report__2023-12-09_15-59-32.pdf',
     },
     {
       filter: {
@@ -340,7 +355,7 @@ test('generateReportPdfFilename', () => {
         votingMethods: ['absentee'],
       },
       expectedFilename:
-        'ballot-style-1M-absentee-ballots-tally-report__2023-12-09_15-59-32.pdf',
+        'unofficial-ballot-style-1M-absentee-ballots-tally-report__2023-12-09_15-59-32.pdf',
     },
     {
       filter: {
@@ -348,7 +363,7 @@ test('generateReportPdfFilename', () => {
       },
       groupBy: { groupByPrecinct: true },
       expectedFilename:
-        'absentee-ballots-tally-reports-by-precinct__2023-12-09_15-59-32.pdf',
+        'unofficial-absentee-ballots-tally-reports-by-precinct__2023-12-09_15-59-32.pdf',
     },
     {
       filter: {
@@ -356,7 +371,7 @@ test('generateReportPdfFilename', () => {
       },
       isTestMode: true,
       expectedFilename:
-        'TEST-absentee-ballots-tally-report__2023-12-09_15-59-32.pdf',
+        'TEST-unofficial-absentee-ballots-tally-report__2023-12-09_15-59-32.pdf',
     },
   ];
 
@@ -367,6 +382,7 @@ test('generateReportPdfFilename', () => {
         filter: testCase.filter ?? {},
         groupBy: testCase.groupBy ?? {},
         isTestMode: testCase.isTestMode ?? false,
+        isOfficialResults: testCase.isOfficialResults ?? false,
         time: new Date(2023, 11, 9, 15, 59, 32),
       })
     ).toEqual(testCase.expectedFilename);
@@ -394,7 +410,8 @@ test('generateReportPdfFilename when too long', () => {
       filter: { precinctIds: ['precinct-1'] },
       groupBy: {},
       isTestMode: false,
+      isOfficialResults: false,
       time: new Date(2022, 4, 11, 15, 2, 3),
     })
-  ).toEqual('custom-tally-report__2022-05-11_15-02-03.pdf');
+  ).toEqual('unofficial-custom-tally-report__2022-05-11_15-02-03.pdf');
 });

--- a/apps/admin/frontend/src/utils/reporting.ts
+++ b/apps/admin/frontend/src/utils/reporting.ts
@@ -15,6 +15,8 @@ const VOTING_METHOD_LABELS: Record<Tabulation.VotingMethod, string> = {
   provisional: 'Provisional',
 };
 
+const FAT_FILENAME_CHAR_LIMIT = 255;
+
 /**
  * Checks whether the report has any filters which have multiple values selected.
  */
@@ -368,6 +370,7 @@ function generateReportFilename({
   filter,
   groupBy,
   isTestMode,
+  isOfficialResults,
   extension,
   type: typeSingular,
   typePlural,
@@ -377,6 +380,7 @@ function generateReportFilename({
   filter: Tabulation.Filter;
   groupBy: Tabulation.GroupBy;
   isTestMode: boolean;
+  isOfficialResults: boolean;
   extension: string;
   type: string;
   typePlural?: string;
@@ -391,12 +395,18 @@ function generateReportFilename({
   });
 
   const descriptionParts: string[] = [];
-  const shortDescriptionParts: string[] = []; // in case description is too long
+  // description could be too long for the FAT filename limit of 255 characters
+  // so we also generate a short description
+  const shortDescriptionParts: string[] = [];
 
   if (isTestMode) {
     descriptionParts.push(TEST_FILE_PREFIX);
     shortDescriptionParts.push(TEST_FILE_PREFIX);
   }
+
+  const officiality = isOfficialResults ? 'official' : 'unofficial';
+  descriptionParts.push(officiality);
+  shortDescriptionParts.push(officiality);
 
   if (descriptionFilterPrefix) {
     descriptionParts.push(descriptionFilterPrefix);
@@ -421,7 +431,7 @@ function generateReportFilename({
     SECTION_SEPARATOR
   )}.${extension}`;
 
-  if (filename.length <= 255) {
+  if (filename.length <= FAT_FILENAME_CHAR_LIMIT) {
     return filename;
   }
 
@@ -440,12 +450,14 @@ export function generateTallyReportPdfFilename({
   filter,
   groupBy,
   isTestMode,
+  isOfficialResults,
   time = new Date(),
 }: {
   election: Election;
   filter: Tabulation.Filter;
   groupBy: Tabulation.GroupBy;
   isTestMode: boolean;
+  isOfficialResults: boolean;
   time?: Date;
 }): string {
   return generateReportFilename({
@@ -453,6 +465,7 @@ export function generateTallyReportPdfFilename({
     filter,
     groupBy,
     isTestMode,
+    isOfficialResults,
     extension: 'pdf',
     type: 'tally-report',
     typePlural: 'tally-reports',
@@ -465,12 +478,14 @@ export function generateTallyReportCsvFilename({
   filter,
   groupBy,
   isTestMode,
+  isOfficialResults,
   time = new Date(),
 }: {
   election: Election;
   filter: Tabulation.Filter;
   groupBy: Tabulation.GroupBy;
   isTestMode: boolean;
+  isOfficialResults: boolean;
   time?: Date;
 }): string {
   return generateReportFilename({
@@ -478,6 +493,7 @@ export function generateTallyReportCsvFilename({
     filter,
     groupBy,
     isTestMode,
+    isOfficialResults,
     extension: 'csv',
     type: 'tally-report',
     time,
@@ -489,12 +505,14 @@ export function generateBallotCountReportPdfFilename({
   filter,
   groupBy,
   isTestMode,
+  isOfficialResults,
   time = new Date(),
 }: {
   election: Election;
   filter: Tabulation.Filter;
   groupBy: Tabulation.GroupBy;
   isTestMode: boolean;
+  isOfficialResults: boolean;
   time?: Date;
 }): string {
   return generateReportFilename({
@@ -502,6 +520,7 @@ export function generateBallotCountReportPdfFilename({
     filter,
     groupBy,
     isTestMode,
+    isOfficialResults,
     extension: 'pdf',
     type: 'ballot-count-report',
     time,
@@ -513,12 +532,14 @@ export function generateBallotCountReportCsvFilename({
   filter,
   groupBy,
   isTestMode,
+  isOfficialResults,
   time = new Date(),
 }: {
   election: Election;
   filter: Tabulation.Filter;
   groupBy: Tabulation.GroupBy;
   isTestMode: boolean;
+  isOfficialResults: boolean;
   time?: Date;
 }): string {
   return generateReportFilename({
@@ -526,6 +547,7 @@ export function generateBallotCountReportCsvFilename({
     filter,
     groupBy,
     isTestMode,
+    isOfficialResults,
     extension: 'csv',
     type: 'ballot-count-report',
     time,

--- a/apps/admin/frontend/src/utils/reporting.ts
+++ b/apps/admin/frontend/src/utils/reporting.ts
@@ -1,6 +1,7 @@
 import { Election, ElectionDefinition, Tabulation } from '@votingworks/types';
 import { Optional, Result, err, find, ok } from '@votingworks/basics';
 import {
+  TEST_FILE_PREFIX,
   getPartyById,
   getPrecinctById,
   sanitizeStringForFilename,
@@ -265,8 +266,6 @@ const WORD_SEPARATOR = '-';
 const SUBSECTION_SEPARATOR = '_';
 const TIME_FORMAT_STRING = `YYYY${WORD_SEPARATOR}MM${WORD_SEPARATOR}DD${SUBSECTION_SEPARATOR}HH${WORD_SEPARATOR}mm${WORD_SEPARATOR}ss`;
 
-const TEST_MODE_PREFIX = 'TEST';
-
 function generateReportFilenameFilterPrefix({
   election,
   filter,
@@ -395,8 +394,8 @@ function generateReportFilename({
   const shortDescriptionParts: string[] = []; // in case description is too long
 
   if (isTestMode) {
-    descriptionParts.push(TEST_MODE_PREFIX);
-    shortDescriptionParts.push(TEST_MODE_PREFIX);
+    descriptionParts.push(TEST_FILE_PREFIX);
+    shortDescriptionParts.push(TEST_FILE_PREFIX);
   }
 
   if (descriptionFilterPrefix) {

--- a/apps/admin/frontend/src/utils/reporting.ts
+++ b/apps/admin/frontend/src/utils/reporting.ts
@@ -365,7 +365,7 @@ function generateReportFilenameGroupByPostfix({
   return postfixes.join(`${WORD_SEPARATOR}and${WORD_SEPARATOR}`);
 }
 
-function generateReportFilename({
+export function generateReportFilename({
   election,
   filter,
   groupBy,

--- a/libs/utils/src/filenames.ts
+++ b/libs/utils/src/filenames.ts
@@ -17,6 +17,7 @@ const TIME_FORMAT_STRING = `YYYY${WORD_SEPARATOR}MM${WORD_SEPARATOR}DD${SUBSECTI
 export const BALLOT_PACKAGE_FOLDER = 'ballot-packages';
 export const SCANNER_RESULTS_FOLDER = 'cast-vote-records';
 export const SCANNER_BACKUPS_FOLDER = 'scanner-backups';
+export const TEST_FILE_PREFIX = 'TEST';
 
 /**
  * @deprecated
@@ -126,7 +127,9 @@ export function generateCastVoteRecordReportDirectoryName(
   }`;
   const timeInformation = moment(time).format(TIME_FORMAT_STRING);
   const filename = `${machineString}${SECTION_SEPARATOR}${ballotString}${SECTION_SEPARATOR}${timeInformation}`;
-  return isTestMode ? `TEST${SECTION_SEPARATOR}${filename}` : filename;
+  return isTestMode
+    ? `${TEST_FILE_PREFIX}${SECTION_SEPARATOR}${filename}`
+    : filename;
 }
 
 /**
@@ -145,7 +148,8 @@ export function parseCastVoteRecordReportDirectoryName(
   // TODO: no need to ignore extension once we don't accept .jsonl
   const fileBasename = basename(filename);
   const segments = fileBasename.split(SECTION_SEPARATOR);
-  const isTestModeResults = segments.length === 4 && segments[0] === 'TEST';
+  const isTestModeResults =
+    segments.length === 4 && segments[0] === TEST_FILE_PREFIX;
 
   const postTestPrefixSegments = isTestModeResults
     ? segments.slice(1)
@@ -331,7 +335,7 @@ export function generateCastVoteRecordExportDirectoryName({
   const timeString = moment(time).format(TIME_FORMAT_STRING);
   const directoryNameComponents = [machineString, timeString];
   if (inTestMode) {
-    directoryNameComponents.unshift('TEST');
+    directoryNameComponents.unshift(TEST_FILE_PREFIX);
   }
   return directoryNameComponents.join(SECTION_SEPARATOR);
 }
@@ -343,7 +347,7 @@ export function parseCastVoteRecordReportExportDirectoryName(
   exportDirectoryName: string
 ): Optional<CastVoteRecordExportDirectoryNameComponents> {
   const sections = exportDirectoryName.split(SECTION_SEPARATOR);
-  const inTestMode = sections.length === 3 && sections[0] === 'TEST';
+  const inTestMode = sections.length === 3 && sections[0] === TEST_FILE_PREFIX;
   const postTestPrefixSections = inTestMode ? sections.slice(1) : sections;
   if (postTestPrefixSections.length !== 2) {
     return;


### PR DESCRIPTION
By commit...
1. refactor to maintain "test" prefix more consistent across repo
2. adds "official" or "unofficial" to report files exported from VxAdmin
3. standardizes WIA .pdf export filename to match the others.
