### PR TITLE
CVR Subdirectory Structure

### DIFF
--- a/apps/admin/backend/src/app.cvr_files.test.ts
+++ b/apps/admin/backend/src/app.cvr_files.test.ts
@@ -830,8 +830,8 @@ test.each<{
         electionDefinition.electionHash
       );
       return {
-        [SCANNER_RESULTS_FOLDER]: {
-          [electionSubDirectoryName]: Buffer.of(),
+        [electionSubDirectoryName]: {
+          [SCANNER_RESULTS_FOLDER]: Buffer.of(),
         },
       };
     },
@@ -855,8 +855,8 @@ test.each<{
         machineId: '0001',
       });
       return {
-        [SCANNER_RESULTS_FOLDER]: {
-          [electionSubDirectoryName]: {
+        [electionSubDirectoryName]: {
+          [SCANNER_RESULTS_FOLDER]: {
             'not-an-export-directory-name': {}, // Should be ignored
             [emptyExportDirectoryName]: {}, // Should be ignored
             [exportDirectoryName]: castVoteRecordExport.asDirectoryPath(),

--- a/apps/admin/backend/src/cast_vote_records.ts
+++ b/apps/admin/backend/src/cast_vote_records.ts
@@ -115,8 +115,8 @@ export async function listCastVoteRecordExportsOnUsbDrive(
   const listDirectoryResult = await listDirectoryOnUsbDrive(
     usbDrive,
     path.join(
-      SCANNER_RESULTS_FOLDER,
-      generateElectionBasedSubfolderName(election, electionHash)
+      generateElectionBasedSubfolderName(election, electionHash),
+      SCANNER_RESULTS_FOLDER
     )
   );
   if (listDirectoryResult.isErr()) {

--- a/apps/admin/backend/test/app.ts
+++ b/apps/admin/backend/test/app.ts
@@ -42,9 +42,8 @@ export function mockCastVoteRecordFileTree(
 ): MockFileTree {
   const { election, electionHash } = electionDefinition;
   return {
-    [SCANNER_RESULTS_FOLDER]: {
-      [generateElectionBasedSubfolderName(election, electionHash)]:
-        mockDirectory,
+    [generateElectionBasedSubfolderName(election, electionHash)]: {
+      [SCANNER_RESULTS_FOLDER]: mockDirectory,
     },
   };
 }

--- a/apps/admin/integration-testing/e2e/reports.spec.ts
+++ b/apps/admin/integration-testing/e2e/reports.spec.ts
@@ -59,8 +59,8 @@ test('viewing and exporting reports', async ({ page }) => {
   const testReportDirectoryPath =
     electionTwoPartyPrimaryFixtures.castVoteRecordExport.asDirectoryPath();
   usbHandler.insert({
-    [SCANNER_RESULTS_FOLDER]: {
-      [electionDirectory]: {
+    [electionDirectory]: {
+      [SCANNER_RESULTS_FOLDER]: {
         [testReportDirectoryName]: testReportDirectoryPath,
       },
     },

--- a/libs/backend/src/cast_vote_records/export.ts
+++ b/libs/backend/src/cast_vote_records/export.ts
@@ -234,8 +234,8 @@ async function getExportDirectoryPathRelativeToUsbMountPoint(
   }
 
   const exportDirectoryPathRelativeToUsbMountPoint = path.join(
-    SCANNER_RESULTS_FOLDER,
     generateElectionBasedSubfolderName(election, electionHash),
+    SCANNER_RESULTS_FOLDER,
     exportDirectoryName
   );
   await fs.mkdir(
@@ -863,8 +863,8 @@ export async function doesUsbDriveRequireCastVoteRecordSync(
     }
     const exportDirectoryPath = path.join(
       usbMountPoint,
-      SCANNER_RESULTS_FOLDER,
       generateElectionBasedSubfolderName(election, electionHash),
+      SCANNER_RESULTS_FOLDER,
       exportDirectoryName
     );
     const metadataResult =

--- a/libs/backend/src/cast_vote_records/test_utils.ts
+++ b/libs/backend/src/cast_vote_records/test_utils.ts
@@ -14,6 +14,7 @@ import {
 } from '@votingworks/types';
 import { UsbDrive } from '@votingworks/usb-drive';
 import {
+  BALLOT_PACKAGE_FOLDER,
   getExportedCastVoteRecordIds,
   SCANNER_RESULTS_FOLDER,
 } from '@votingworks/utils';
@@ -143,17 +144,20 @@ export async function getCastVoteRecordExportDirectoryPaths(
     usbDriveStatus.status === 'mounted' ? usbDriveStatus.mountPoint : undefined;
   assert(usbMountPoint !== undefined);
 
-  const resultsDirectoryPath = path.join(usbMountPoint, SCANNER_RESULTS_FOLDER);
-  const electionDirectoryNames = fs.readdirSync(resultsDirectoryPath);
+  const electionDirectoryNames = fs
+    .readdirSync(usbMountPoint)
+    .filter((name) => name !== BALLOT_PACKAGE_FOLDER);
   assert(electionDirectoryNames.length === 1);
-  const electionDirectoryPath = path.join(
-    resultsDirectoryPath,
-    assertDefined(electionDirectoryNames[0])
+
+  const electionResultsDirectoryPath = path.join(
+    usbMountPoint,
+    assertDefined(electionDirectoryNames[0]),
+    SCANNER_RESULTS_FOLDER
   );
   const castVoteRecordExportDirectoryPaths = fs
-    .readdirSync(electionDirectoryPath)
+    .readdirSync(electionResultsDirectoryPath)
     // Filter out signature files
     .filter((entryName) => !entryName.endsWith(SIGNATURE_FILE_EXTENSION))
-    .map((entryName) => path.join(electionDirectoryPath, entryName));
+    .map((entryName) => path.join(electionResultsDirectoryPath, entryName));
   return [...castVoteRecordExportDirectoryPaths].sort();
 }


### PR DESCRIPTION
## Overview

Part of #3935. See [discussion](https://votingworks.slack.com/archives/CEL6D3GAD/p1693940716686119). Instead of exporting CVRs to a path (relative to USB drive) of `./cast-vote-records/election-XXXXXXXX`, export to `./election-XXXXXXXX/cast-vote-records`.
