### PR TITLE
change ballot package location on USB

### DIFF
--- a/apps/central-scan/backend/src/end_to_end_hmpb.test.ts
+++ b/apps/central-scan/backend/src/end_to_end_hmpb.test.ts
@@ -1,8 +1,8 @@
 import getPort from 'get-port';
 import {
-  createBallotPackageZipArchive,
   getCastVoteRecordExportDirectoryPaths,
   isTestReport,
+  mockBallotPackageFileTree,
   readCastVoteRecordExport,
 } from '@votingworks/backend';
 import {
@@ -143,21 +143,19 @@ test('going through the whole process works', async () => {
     BooleanEnvironmentVariableName.SKIP_BALLOT_PACKAGE_AUTHENTICATION
   );
 
-  mockUsbDrive.insertUsbDrive({
-    'ballot-packages': {
-      'ballot-package.zip': await createBallotPackageZipArchive(
-        electionGridLayoutNewHampshireAmherstFixtures.electionJson.toBallotPackage(
-          {
-            ...DEFAULT_SYSTEM_SETTINGS,
-            markThresholds: {
-              definite: 0.08,
-              marginal: 0.05,
-            },
-          }
-        )
-      ),
-    },
-  });
+  mockUsbDrive.insertUsbDrive(
+    await mockBallotPackageFileTree(
+      electionGridLayoutNewHampshireAmherstFixtures.electionJson.toBallotPackage(
+        {
+          ...DEFAULT_SYSTEM_SETTINGS,
+          markThresholds: {
+            definite: 0.08,
+            marginal: 0.05,
+          },
+        }
+      )
+    )
+  );
   const configureResult =
     await apiClient.configureFromBallotPackageOnUsbDrive();
   expect(configureResult.err()).toBeUndefined();

--- a/apps/central-scan/integration-testing/e2e/configuration.spec.ts
+++ b/apps/central-scan/integration-testing/e2e/configuration.spec.ts
@@ -1,5 +1,5 @@
 import test from '@playwright/test';
-import { createBallotPackageZipArchive } from '@votingworks/backend';
+import { mockBallotPackageFileTree } from '@votingworks/backend';
 import { getMockFileUsbDriveHandler } from '@votingworks/usb-drive';
 import { electionGridLayoutNewHampshireAmherstFixtures } from '@votingworks/fixtures';
 import { logInAsElectionManager, forceReset } from './helpers';
@@ -15,13 +15,11 @@ test('configure + scan', async ({ page }) => {
 
   await logInAsElectionManager(page, electionDefinition.electionHash);
 
-  usbHandler.insert({
-    'ballot-packages': {
-      'ballot-package.zip': await createBallotPackageZipArchive(
-        electionGridLayoutNewHampshireAmherstFixtures.electionJson.toBallotPackage()
-      ),
-    },
-  });
+  usbHandler.insert(
+    await mockBallotPackageFileTree(
+      electionGridLayoutNewHampshireAmherstFixtures.electionJson.toBallotPackage()
+    )
+  );
   await page.getByText('No ballots have been scanned').waitFor();
   usbHandler.remove();
 

--- a/apps/mark-scan/backend/test/app_helpers.ts
+++ b/apps/mark-scan/backend/test/app_helpers.ts
@@ -7,7 +7,7 @@ import { Application } from 'express';
 import { AddressInfo } from 'net';
 import { fakeLogger, Logger } from '@votingworks/logging';
 import tmp from 'tmp';
-import { createBallotPackageZipArchive } from '@votingworks/backend';
+import { mockBallotPackageFileTree } from '@votingworks/backend';
 import { Server } from 'http';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 import {
@@ -128,13 +128,11 @@ export async function configureApp(
       sessionExpiresAt: fakeSessionExpiresAt(),
     })
   );
-  mockUsbDrive.insertUsbDrive({
-    'ballot-packages': {
-      'test-ballot-package.zip': await createBallotPackageZipArchive(
-        electionJson.toBallotPackage(systemSettings)
-      ),
-    },
-  });
+  mockUsbDrive.insertUsbDrive(
+    await mockBallotPackageFileTree(
+      electionJson.toBallotPackage(systemSettings)
+    )
+  );
   const result = await apiClient.configureBallotPackageFromUsb();
   expect(result.isOk()).toEqual(true);
   mockOf(mockAuth.getAuthStatus).mockImplementation(() =>

--- a/apps/mark/backend/test/app_helpers.ts
+++ b/apps/mark/backend/test/app_helpers.ts
@@ -7,7 +7,7 @@ import { Application } from 'express';
 import { AddressInfo } from 'net';
 import { fakeLogger } from '@votingworks/logging';
 import tmp from 'tmp';
-import { createBallotPackageZipArchive } from '@votingworks/backend';
+import { mockBallotPackageFileTree } from '@votingworks/backend';
 import { Server } from 'http';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 import {
@@ -71,13 +71,11 @@ export async function configureApp(
       sessionExpiresAt: fakeSessionExpiresAt(),
     })
   );
-  mockUsbDrive.insertUsbDrive({
-    'ballot-packages': {
-      'test-ballot-package.zip': await createBallotPackageZipArchive(
-        electionJson.toBallotPackage(systemSettings)
-      ),
-    },
-  });
+  mockUsbDrive.insertUsbDrive(
+    await mockBallotPackageFileTree(
+      electionJson.toBallotPackage(systemSettings)
+    )
+  );
   const result = await apiClient.configureBallotPackageFromUsb();
   expect(result.isOk()).toEqual(true);
   mockOf(mockAuth.getAuthStatus).mockImplementation(() =>

--- a/apps/mark/integration-testing/e2e/scroll_buttons.spec.ts
+++ b/apps/mark/integration-testing/e2e/scroll_buttons.spec.ts
@@ -4,7 +4,7 @@ import {
   electionGeneralJson,
 } from '@votingworks/fixtures';
 import { getMockFileUsbDriveHandler } from '@votingworks/usb-drive';
-import { createBallotPackageZipArchive } from '@votingworks/backend';
+import { mockBallotPackageFileTree } from '@votingworks/backend';
 import assert from 'assert';
 import {
   mockCardRemoval,
@@ -37,13 +37,9 @@ test('configure, open polls, and test contest scroll buttons', async ({
   await enterPin(page);
   await page.getByText('VxMark is Not Configured').waitFor();
 
-  usbHandler.insert({
-    'ballot-packages': {
-      'ballot-package.zip': await createBallotPackageZipArchive(
-        electionGeneralJson.toBallotPackage()
-      ),
-    },
-  });
+  usbHandler.insert(
+    await mockBallotPackageFileTree(electionGeneralJson.toBallotPackage())
+  );
 
   // Election Manager: set precinct
   await page.getByText('Precinct', { exact: true }).waitFor();

--- a/apps/scan/backend/test/helpers/shared_helpers.ts
+++ b/apps/scan/backend/test/helpers/shared_helpers.ts
@@ -2,7 +2,7 @@ import { InsertedSmartCardAuthApi } from '@votingworks/auth';
 import { ok } from '@votingworks/basics';
 import {
   areOrWereCastVoteRecordsBeingExportedToUsbDrive,
-  createBallotPackageZipArchive,
+  mockBallotPackageFileTree,
 } from '@votingworks/backend';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 import * as grout from '@votingworks/grout';
@@ -80,12 +80,7 @@ export async function configureApp(
     })
   );
 
-  mockUsbDrive.insertUsbDrive({
-    'ballot-packages': {
-      'test-ballot-package.zip':
-        await createBallotPackageZipArchive(ballotPackage),
-    },
-  });
+  mockUsbDrive.insertUsbDrive(await mockBallotPackageFileTree(ballotPackage));
 
   expect(await apiClient.configureFromBallotPackageOnUsbDrive()).toEqual(ok());
 

--- a/apps/scan/frontend/src/config/globals.ts
+++ b/apps/scan/frontend/src/config/globals.ts
@@ -1,5 +1,3 @@
-export const PRECINCT_SCANNER_FOLDER = 'ballot-packages';
-
 export const FONT_SIZES = [18, 24, 28, 32];
 export const DEFAULT_FONT_SIZE = 1;
 export const LARGE_DISPLAY_FONT_SIZE = 3;

--- a/libs/backend/src/ballot_package/test_utils.ts
+++ b/libs/backend/src/ballot_package/test_utils.ts
@@ -1,6 +1,11 @@
 import JsZip from 'jszip';
 import { BallotPackage, BallotPackageFileName } from '@votingworks/types';
 import { Buffer } from 'buffer';
+import {
+  BALLOT_PACKAGE_FOLDER,
+  generateElectionBasedSubfolderName,
+} from '@votingworks/utils';
+import { MockFileTree } from '@votingworks/usb-drive';
 
 /**
  * Builds a ballot package zip archive from a BallotPackage object.
@@ -26,4 +31,22 @@ export function createBallotPackageZipArchive(
     );
   }
   return jsZip.generateAsync({ type: 'nodebuffer' });
+}
+
+/**
+ * Helper for mocking the file contents of on a USB drive with a ballot package
+ * saved to it.
+ */
+export async function mockBallotPackageFileTree(
+  ballotPackage: BallotPackage
+): Promise<MockFileTree> {
+  const { election, electionHash } = ballotPackage.electionDefinition;
+  return {
+    [generateElectionBasedSubfolderName(election, electionHash)]: {
+      [BALLOT_PACKAGE_FOLDER]: {
+        'test-ballot-package.zip':
+          await createBallotPackageZipArchive(ballotPackage),
+      },
+    },
+  };
 }

--- a/libs/backend/src/cast_vote_records/test_utils.ts
+++ b/libs/backend/src/cast_vote_records/test_utils.ts
@@ -14,7 +14,6 @@ import {
 } from '@votingworks/types';
 import { UsbDrive } from '@votingworks/usb-drive';
 import {
-  BALLOT_PACKAGE_FOLDER,
   getExportedCastVoteRecordIds,
   SCANNER_RESULTS_FOLDER,
 } from '@votingworks/utils';
@@ -144,9 +143,7 @@ export async function getCastVoteRecordExportDirectoryPaths(
     usbDriveStatus.status === 'mounted' ? usbDriveStatus.mountPoint : undefined;
   assert(usbMountPoint !== undefined);
 
-  const electionDirectoryNames = fs
-    .readdirSync(usbMountPoint)
-    .filter((name) => name !== BALLOT_PACKAGE_FOLDER);
+  const electionDirectoryNames = fs.readdirSync(usbMountPoint);
   assert(electionDirectoryNames.length === 1);
 
   const electionResultsDirectoryPath = path.join(

--- a/libs/backend/src/ui_strings/ui_strings_machine_configuration_test_runner.ts
+++ b/libs/backend/src/ui_strings/ui_strings_machine_configuration_test_runner.ts
@@ -10,7 +10,7 @@ import { MockUsbDrive } from '@votingworks/usb-drive';
 import { extractCdfUiStrings } from '@votingworks/utils';
 import { Result, assertDefined } from '@votingworks/basics';
 import { UiStringsStore } from './ui_strings_store';
-import { createBallotPackageZipArchive } from '../ballot_package/test_utils';
+import { mockBallotPackageFileTree } from '../ballot_package/test_utils';
 
 type MockUsbDriveLike = Pick<MockUsbDrive, 'insertUsbDrive'>;
 
@@ -37,12 +37,9 @@ export function runUiStringMachineConfigurationTests(
   );
 
   async function doTestConfigure(usbBallotPackage: BallotPackage) {
-    getMockUsbDrive().insertUsbDrive({
-      'ballot-packages': {
-        'test-ballot-package.zip':
-          await createBallotPackageZipArchive(usbBallotPackage),
-      },
-    });
+    getMockUsbDrive().insertUsbDrive(
+      await mockBallotPackageFileTree(usbBallotPackage)
+    );
 
     const result = await runConfigureMachine();
     expect(result.err()).toBeUndefined();

--- a/libs/utils/src/filenames.test.ts
+++ b/libs/utils/src/filenames.test.ts
@@ -3,111 +3,17 @@ import {
   electionGeneralDefinition,
   electionWithMsEitherNeitherDefinition,
 } from '@votingworks/fixtures';
-import { Election, ElectionDefinition } from '@votingworks/types';
-import { typedAs } from '@votingworks/basics';
+import { Election } from '@votingworks/types';
 import {
-  parseBallotExportPackageInfoFromFilename,
   generateElectionBasedSubfolderName,
   generateFilenameForBallotExportPackage,
-  generateFinalExportDefaultFilename,
-  ElectionData,
-  generateFilenameForBallotExportPackageFromElectionData,
-  generateBatchResultsDefaultFilename,
   generateLogFilename,
   LogFileType,
   generateSemsFinalExportDefaultFilename,
-  CastVoteRecordReportListing,
-  generateCastVoteRecordReportDirectoryName,
-  parseCastVoteRecordReportDirectoryName,
   generateCastVoteRecordExportDirectoryName,
   CastVoteRecordExportDirectoryNameComponents,
   parseCastVoteRecordReportExportDirectoryName,
 } from './filenames';
-
-describe('parseBallotExportPackageInfoFromFilename', () => {
-  test('parses a basic name properly', () => {
-    const name =
-      'choctaw-county_2020-general-election_a5753d5776__2020-12-02_09-42-50.zip';
-
-    const parsedInfo = parseBallotExportPackageInfoFromFilename(name);
-    expect(parsedInfo).toBeTruthy();
-    const { electionCounty, electionName, electionHash, timestamp } =
-      parsedInfo!;
-    expect(electionCounty).toEqual('choctaw county');
-    expect(electionName).toEqual('2020 general election');
-    expect(electionHash).toEqual('a5753d5776');
-    expect(timestamp).toStrictEqual(new Date(2020, 11, 2, 9, 42, 50));
-  });
-
-  test('fails to parse a name with the section separator twice', () => {
-    const name =
-      'choctaw-county_2020-general-election__a5753d5776__2020-12-02_09-42-50.zip';
-
-    expect(parseBallotExportPackageInfoFromFilename(name)).toBeUndefined();
-  });
-
-  test('fails to parse a name with a bad election string', () => {
-    const name =
-      'choctaw-county_2020-general_election_a5753d5776__2020-12-02_09-42-50.zip';
-
-    expect(parseBallotExportPackageInfoFromFilename(name)).toBeUndefined();
-  });
-
-  test('fails to parse a name with no section separator', () => {
-    expect(parseBallotExportPackageInfoFromFilename('string')).toBeUndefined();
-  });
-
-  test('fails to parse a name without all election segments', () => {
-    const name = 'string__2020-12-02_09-42-50.zip';
-    expect(parseBallotExportPackageInfoFromFilename(name)).toBeUndefined();
-  });
-
-  test('uses placeholders for parts that get sanitized away', () => {
-    const timestamp = new Date(2020, 3, 14);
-    expect(
-      generateFilenameForBallotExportPackageFromElectionData({
-        electionCounty: '!!!', // sanitized as empty string
-        electionHash: 'abcdefg',
-        electionName: '???', // sanitized as empty string
-        timestamp,
-      })
-    ).toEqual('county_election_abcdefg__2020-04-14_00-00-00.zip');
-  });
-
-  test('works end to end when generating ballot package name', () => {
-    const time = new Date(2020, 3, 14);
-    expect(
-      parseBallotExportPackageInfoFromFilename(
-        generateFilenameForBallotExportPackage(electionGeneralDefinition, time)
-      )
-    ).toEqual({
-      electionCounty:
-        electionGeneralDefinition.election.county.name.toLocaleLowerCase(),
-      electionName:
-        electionGeneralDefinition.election.title.toLocaleLowerCase(),
-      electionHash: electionGeneralDefinition.electionHash.slice(0, 10),
-      timestamp: time,
-    });
-    expect(
-      parseBallotExportPackageInfoFromFilename(
-        generateFilenameForBallotExportPackage(
-          electionWithMsEitherNeitherDefinition,
-          time
-        )
-      )
-    ).toEqual({
-      electionCounty:
-        electionWithMsEitherNeitherDefinition.election.county.name.toLocaleLowerCase(),
-      electionName:
-        electionWithMsEitherNeitherDefinition.election.title.toLocaleLowerCase(),
-      electionHash: electionWithMsEitherNeitherDefinition.electionHash.slice(
-        0,
-        10
-      ),
-      timestamp: time,
-    });
-  });
-});
 
 describe('generateElectionBasedSubfolderName', () => {
   test('generates basic election subfolder name as expected', () => {
@@ -155,104 +61,10 @@ describe('generateElectionBasedSubfolderName', () => {
   });
 });
 
-describe('generateCastVoteRecordReportDirectoryName', () => {
-  test('generates basic scanning results filename in test mode', () => {
-    const time = new Date(2019, 2, 14, 15, 9, 26);
-    expect(
-      generateCastVoteRecordReportDirectoryName('1', 0, true, time)
-    ).toEqual('TEST__machine_1__0_ballots__2019-03-14_15-09-26');
-
-    expect(
-      generateCastVoteRecordReportDirectoryName('po!n@y:__', 35, true, time)
-    ).toEqual('TEST__machine_pony__35_ballots__2019-03-14_15-09-26');
-  });
-
-  test('generates basic scanning results filename not in test mode', () => {
-    const time = new Date(2019, 2, 14, 15, 9, 26);
-    expect(
-      generateCastVoteRecordReportDirectoryName('1', 0, false, time)
-    ).toEqual('machine_1__0_ballots__2019-03-14_15-09-26');
-    expect(
-      generateCastVoteRecordReportDirectoryName(
-        '<3-u!n#icorn<3',
-        1,
-        false,
-        time
-      )
-    ).toEqual('machine_3unicorn3__1_ballot__2019-03-14_15-09-26');
-  });
-
-  test('generates basic scanning results filename with default time', () => {
-    expect(generateCastVoteRecordReportDirectoryName('1', 0, false)).toEqual(
-      expect.stringMatching('machine_1__0_ballots__')
-    );
-  });
-});
-
-test('generates ballot export package names as expected with simple inputs', () => {
-  const mockElection: ElectionDefinition = {
-    election: {
-      ...electionWithMsEitherNeitherDefinition.election,
-      county: { name: 'King County', id: '' },
-      title: 'General Election',
-    },
-    electionHash: 'testHash12',
-    electionData: '',
-  };
-  const time = new Date(2019, 2, 14, 15, 9, 26);
-  expect(generateFilenameForBallotExportPackage(mockElection, time)).toEqual(
-    'king-county_general-election_testHash12__2019-03-14_15-09-26.zip'
-  );
-});
-
-test('generates ballot export package names as expected when election information has weird characters', () => {
-  const mockElection: ElectionDefinition = {
-    election: {
-      ...electionWithMsEitherNeitherDefinition.election,
-      county: { name: 'King County!!', id: '' },
-      title: '-_General__Election$$',
-    },
-    electionHash: 'testHash12',
-    electionData: '',
-  };
-  const time = new Date(2019, 2, 14, 15, 9, 26);
-  expect(generateFilenameForBallotExportPackage(mockElection, time)).toEqual(
-    'king-county_general-election_testHash12__2019-03-14_15-09-26.zip'
-  );
-  expect(generateFilenameForBallotExportPackage(mockElection)).toEqual(
-    expect.stringMatching('king-county_general-election_testHash12__')
-  );
-});
-
-test('generates ballot export package name with truncated election hash', () => {
-  const mockElection: ElectionDefinition = {
-    election: {
-      ...electionWithMsEitherNeitherDefinition.election,
-      county: { name: 'King County', id: '' },
-      title: 'General Election',
-    },
-    electionHash: 'testHash123456789',
-    electionData: '',
-  };
-  const time = new Date(2019, 2, 14, 15, 9, 26);
-  expect(generateFilenameForBallotExportPackage(mockElection, time)).toEqual(
-    'king-county_general-election_testHash12__2019-03-14_15-09-26.zip'
-  );
-});
-
 test('generates ballot export package name with zero padded time pieces', () => {
-  const mockElection: ElectionDefinition = {
-    election: {
-      ...electionWithMsEitherNeitherDefinition.election,
-      county: { name: 'King County', id: '' },
-      title: 'General Election',
-    },
-    electionHash: 'testHash12',
-    electionData: '',
-  };
   const time = new Date(2019, 2, 1, 1, 9, 2);
-  expect(generateFilenameForBallotExportPackage(mockElection, time)).toEqual(
-    'king-county_general-election_testHash12__2019-03-01_01-09-02.zip'
+  expect(generateFilenameForBallotExportPackage(time)).toEqual(
+    'ballot-package__2019-03-01_01-09-02.zip'
   );
 });
 
@@ -291,167 +103,6 @@ describe('generateSemsFinalExportDefaultFilename', () => {
   });
 });
 
-describe('generateFinalExportDefaultFilename', () => {
-  test('generates the correct filename for test mode', () => {
-    const mockElection: Election = {
-      ...electionWithMsEitherNeitherDefinition.election,
-      county: { name: 'King County', id: '' },
-      title: 'General Election',
-    };
-    const time = new Date(2019, 2, 1, 1, 9, 2);
-    expect(
-      generateFinalExportDefaultFilename(true, mockElection, time)
-    ).toEqual(
-      'votingworks-test-results_king-county_general-election_2019-03-01_01-09-02.csv'
-    );
-  });
-
-  test('generates the correct filename for live mode', () => {
-    const time = new Date(2019, 2, 1, 1, 9, 2);
-    const mockElection: Election = {
-      ...electionWithMsEitherNeitherDefinition.election,
-      county: { name: 'King County', id: '' },
-      title: 'General Election',
-    };
-    expect(
-      generateFinalExportDefaultFilename(false, mockElection, time)
-    ).toEqual(
-      'votingworks-live-results_king-county_general-election_2019-03-01_01-09-02.csv'
-    );
-    expect(generateFinalExportDefaultFilename(false, mockElection)).toEqual(
-      expect.stringMatching(
-        'votingworks-live-results_king-county_general-election'
-      )
-    );
-  });
-});
-
-describe('parseCastVoteRecordReportDirectoryName', () => {
-  test('parses a basic name not in test mode properly', () => {
-    const name = 'machine_5__1_ballots__2020-12-08_10-42-02';
-    const results = parseCastVoteRecordReportDirectoryName(name);
-    expect(results).toEqual({
-      isTestModeResults: false,
-      machineId: '5',
-      numberOfBallots: 1,
-      timestamp: new Date(2020, 11, 8, 10, 42, 2),
-    });
-  });
-
-  test('parses a basic name in test mode properly', () => {
-    const name = 'TEST__machine_0002__54_ballots__2020-12-08_10-42-02';
-    const results = parseCastVoteRecordReportDirectoryName(name);
-    expect(results).toEqual({
-      isTestModeResults: true,
-      machineId: '0002',
-      numberOfBallots: 54,
-      timestamp: new Date(2020, 11, 8, 10, 42, 2),
-    });
-  });
-
-  test('undefined when the format of the filename is unexpected', () => {
-    expect(
-      parseCastVoteRecordReportDirectoryName(
-        'INVALID__machine_0002__54_ballots__2020-12-08_10-42-02'
-      )
-    ).toBeUndefined();
-    expect(
-      parseCastVoteRecordReportDirectoryName(
-        '__machine_0002__54_ballots__2020-12-08_10-42-02'
-      )
-    ).toBeUndefined();
-    expect(
-      parseCastVoteRecordReportDirectoryName(
-        'TEST__machine_0002__54_ballots__bad_timestamp'
-      )
-    ).toBeUndefined();
-    expect(
-      parseCastVoteRecordReportDirectoryName(
-        'TEST__machine_0002__blah_ballots__2020-12-08_10-42-02'
-      )
-    ).toBeUndefined();
-    expect(
-      parseCastVoteRecordReportDirectoryName(
-        'machine_0002__54_ballots__2020-12-08__10-42-02'
-      )
-    ).toBeUndefined();
-    expect(
-      parseCastVoteRecordReportDirectoryName(
-        'TEST__something__machine_0002__54_ballots__2020-12-08_10-42-02'
-      )
-    ).toBeUndefined();
-    expect(
-      parseCastVoteRecordReportDirectoryName(
-        'TEST__unicorn_0002__54_ballots__2020-12-08_10-42-02'
-      )
-    ).toBeUndefined();
-    expect(
-      parseCastVoteRecordReportDirectoryName(
-        'TEST__machine_0002__54_puppies__2020-12-08_10-42-02'
-      )
-    ).toBeUndefined();
-    expect(
-      parseCastVoteRecordReportDirectoryName(
-        'TEST__machine_0002__54__2020-12-08_10-42-02'
-      )
-    ).toBeUndefined();
-    expect(
-      parseCastVoteRecordReportDirectoryName(
-        'TEST__0002__54_ballots__2020-12-08_10-42-02'
-      )
-    ).toBeUndefined();
-  });
-
-  test('works end to end with generating the report directory name', () => {
-    const time = new Date(2020, 3, 14);
-    const generatedName = generateCastVoteRecordReportDirectoryName(
-      'machine',
-      1234,
-      true,
-      time
-    );
-    expect(parseCastVoteRecordReportDirectoryName(generatedName)).toEqual({
-      machineId: 'machine',
-      numberOfBallots: 1234,
-      isTestModeResults: true,
-      timestamp: time,
-    });
-
-    const generatedName2 = generateCastVoteRecordReportDirectoryName(
-      '0004',
-      0,
-      false,
-      time
-    );
-    expect(parseCastVoteRecordReportDirectoryName(generatedName2)).toEqual({
-      machineId: '0004',
-      numberOfBallots: 0,
-      isTestModeResults: false,
-      timestamp: time,
-    });
-
-    const generatedName3 = generateCastVoteRecordReportDirectoryName(
-      '0004',
-      1,
-      false,
-      time
-    );
-    expect(parseCastVoteRecordReportDirectoryName(generatedName3)).toEqual({
-      machineId: '0004',
-      numberOfBallots: 1,
-      isTestModeResults: false,
-      timestamp: time,
-    });
-  });
-});
-
-function arbitraryMachineId(): fc.Arbitrary<string> {
-  return fc.stringOf(
-    fc.constantFrom(...'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-'),
-    { minLength: 1 }
-  );
-}
-
 function arbitraryTimestampDate(): fc.Arbitrary<Date> {
   return (
     fc
@@ -465,35 +116,6 @@ function arbitraryTimestampDate(): fc.Arbitrary<Date> {
   );
 }
 
-function arbitraryCastVoteRecordReportListing(): fc.Arbitrary<CastVoteRecordReportListing> {
-  return fc.record({
-    machineId: arbitraryMachineId(),
-    numberOfBallots: fc.nat(),
-    isTestModeResults: fc.boolean(),
-    timestamp: arbitraryTimestampDate(),
-  });
-}
-
-test('generate/parse CVR file fuzzing', () => {
-  fc.assert(
-    fc.property(
-      arbitraryCastVoteRecordReportListing(),
-      (castVoteRecordReportListing) => {
-        expect(
-          parseCastVoteRecordReportDirectoryName(
-            generateCastVoteRecordReportDirectoryName(
-              castVoteRecordReportListing.machineId,
-              castVoteRecordReportListing.numberOfBallots,
-              castVoteRecordReportListing.isTestModeResults,
-              castVoteRecordReportListing.timestamp
-            )
-          )
-        ).toEqual(castVoteRecordReportListing);
-      }
-    )
-  );
-});
-
 function arbitrarySafeName(): fc.Arbitrary<string> {
   return fc
     .stringOf(
@@ -505,53 +127,6 @@ function arbitrarySafeName(): fc.Arbitrary<string> {
     .map((s) => s.trim().replace(/\s+/g, ' '))
     .filter((s) => s.length >= 1);
 }
-
-function arbitraryElectionData(): fc.Arbitrary<ElectionData> {
-  return fc.record({
-    electionCounty: arbitrarySafeName(),
-    electionName: arbitrarySafeName(),
-    electionHash: fc.hexaString({ minLength: 20, maxLength: 20 }),
-    timestamp: arbitraryTimestampDate(),
-  });
-}
-
-test('generate/parse ballot package filename fuzzing', () => {
-  fc.assert(
-    fc.property(arbitraryElectionData(), (electionData) => {
-      expect(
-        parseBallotExportPackageInfoFromFilename(
-          generateFilenameForBallotExportPackageFromElectionData(electionData)
-        )
-      ).toEqual(
-        typedAs<ElectionData>({
-          electionCounty: electionData.electionCounty.toLocaleLowerCase(),
-          electionHash: electionData.electionHash
-            .toLocaleLowerCase()
-            .slice(0, 10),
-          electionName: electionData.electionName.toLocaleLowerCase(),
-          timestamp: electionData.timestamp,
-        })
-      );
-    })
-  );
-});
-
-test('generateBatchResultsDefaultFilename', () => {
-  fc.assert(
-    fc.property(
-      fc.boolean(),
-      fc.constant(electionGeneralDefinition.election),
-      fc.oneof(fc.constant(undefined), arbitraryTimestampDate()),
-      (isTestModeResults, election, time) => {
-        expect(
-          generateBatchResultsDefaultFilename(isTestModeResults, election, time)
-        ).toMatch(
-          /^votingworks-(test|live)-batch-results_franklin-county_general-election_\d\d\d\d-\d\d-\d\d_\d\d-\d\d-\d\d.csv$/
-        );
-      }
-    )
-  );
-});
 
 test('generateLogFilename', () => {
   fc.assert(


### PR DESCRIPTION
## Overview

Closes #3935. Previously, ballot packages would be exported to a USB drive like so:

```./ballot-packages/sample-county_example-primary-election_06414087b1__2023-10-30_12-57-46.zip```

Now, we export them like this:

```./sample-county_example-primary-election_06414087b1/ballot-packages/ballot-package__2023-10-30_12-56-55.zip```

This means that all of our in-system files are being exported in the same way, to a top-level election directory, a file type subdirectory, then a filename. I kept `ballot-package` in the file name for the ballot package so that it wouldn't be _just_ a date if it got out of context. Could add file hash in too if desirable.

## Testing Plan
- updated automated testing, added a test
- manually tested exporting from VxAdmin and loading into VxMark

