### PR TITLE
[mark-flow-ui] Use language-aware strings on ballot review page

### DIFF
--- a/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
@@ -3,6 +3,7 @@ import {
   fakeElectionManagerUser,
   fakeKiosk,
   expectPrintToPdf,
+  hasTextAcrossElements,
 } from '@votingworks/test-utils';
 import {
   MemoryStorage,
@@ -251,9 +252,10 @@ test('MarkAndPrint end-to-end flow', async () => {
 
   // Check for votes
   screen.getByText(presidentCandidateToVoteFor.name);
-  within(screen.getByText(measure102Contest.title).parentElement!).getByText(
-    'Yes'
-  );
+  within(
+    screen.getByRole('heading', { name: new RegExp(measure102Contest.title) })
+      .parentElement!
+  ).getByText('Yes');
 
   // Change "County Commissioners" Contest
   userEvent.click(
@@ -279,7 +281,9 @@ test('MarkAndPrint end-to-end flow', async () => {
   await screen.findByText('Review Your Votes');
   screen.getByText(countyCommissionersContest.candidates[0].name);
   screen.getByText(countyCommissionersContest.candidates[1].name);
-  screen.getByText('You may still vote for 2 more candidates.');
+  screen.getByText(
+    hasTextAcrossElements(/Votes remaining in this contest: 2/i)
+  );
 
   // Print Screen
   apiMock.expectPrintBallot();

--- a/apps/mark-scan/frontend/src/pages/validate_ballot_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/validate_ballot_page.tsx
@@ -3,12 +3,13 @@ import { useContext } from 'react';
 
 import styled from 'styled-components';
 import {
-  Prose,
   Screen,
   H1,
   WithScrollButtons,
   Main,
   Button,
+  appStrings,
+  AudioOnly,
 } from '@votingworks/ui';
 
 import { assert } from '@votingworks/basics';
@@ -76,18 +77,12 @@ export function ValidateBallotPage(): JSX.Element | null {
   return (
     <Screen>
       <Main flexColumn>
-        <ContentHeader>
-          <Prose id="audiofocus">
-            <H1>
-              <span aria-label="Review Your Votes.">Review Your Votes</span>
-              <span className="screen-reader-only">
-                To review your votes, advance through the ballot contests using
-                the up and down buttons. If your selections are correct, press
-                “My Ballot is Correct”. If there is an error, press “My Ballot
-                is Incorrect” and alert a poll worker.
-              </span>
-            </H1>
-          </Prose>
+        <ContentHeader id="audiofocus">
+          <H1>{appStrings.titleBmdReviewScreen()}</H1>
+          <AudioOnly>
+            {appStrings.instructionsBmdReviewPageNavigation()}{' '}
+            {appStrings.instructionsBmdScanReviewConfirmation()}
+          </AudioOnly>
         </ContentHeader>
         <WithScrollButtons>
           <Review
@@ -106,9 +101,11 @@ export function ValidateBallotPage(): JSX.Element | null {
           icon="Danger"
           onPress={invalidateBallotCallback}
         >
-          My Ballot is Incorrect
+          {appStrings.buttonBallotIsIncorrect()}
         </Button>
-        <Button onPress={validateBallotCallback}>My Ballot is Correct</Button>
+        <Button onPress={validateBallotCallback}>
+          {appStrings.buttonBallotIsCorrect()}
+        </Button>
       </ButtonFooter>
     </Screen>
   );

--- a/apps/mark/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark/frontend/src/app_end_to_end.test.tsx
@@ -3,6 +3,7 @@ import {
   expectPrint,
   fakeElectionManagerUser,
   fakeKiosk,
+  hasTextAcrossElements,
 } from '@votingworks/test-utils';
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 import { fakeLogger } from '@votingworks/logging';
@@ -225,9 +226,10 @@ test('MarkAndPrint end-to-end flow', async () => {
 
   // Check for votes
   screen.getByText(presidentContest.candidates[0].name);
-  within(screen.getByText(measure102Contest.title).parentElement!).getByText(
-    'Yes'
-  );
+  within(
+    screen.getByRole('heading', { name: new RegExp(measure102Contest.title) })
+      .parentElement!
+  ).getByText('Yes');
 
   // Change "County Commissioners" Contest
   userEvent.click(
@@ -253,7 +255,9 @@ test('MarkAndPrint end-to-end flow', async () => {
   await screen.findByText('Review Your Votes');
   screen.getByText(countyCommissionersContest.candidates[0].name);
   screen.getByText(countyCommissionersContest.candidates[1].name);
-  screen.getByText('You may still vote for 2 more candidates.');
+  screen.getByText(
+    hasTextAcrossElements(/Votes remaining in this contest: 2/i)
+  );
 
   // Print Screen
   userEvent.click(screen.getByText(/Print My ballot/i));

--- a/libs/mark-flow-ui/src/components/candidate_contest.tsx
+++ b/libs/mark-flow-ui/src/components/candidate_contest.tsx
@@ -247,7 +247,7 @@ export function CandidateContest({
               </Font>
             )}
             <span className="screen-reader-only">
-              {appStrings.contestNavigationInstructions()}
+              {appStrings.instructionsBmdContestNavigation()}
             </span>
           </Caption>
         </ContestHeader>

--- a/libs/mark-flow-ui/src/components/review.test.tsx
+++ b/libs/mark-flow-ui/src/components/review.test.tsx
@@ -5,6 +5,7 @@ import {
 import { CandidateContest, YesNoContest } from '@votingworks/types';
 import { assert, find } from '@votingworks/basics';
 import userEvent from '@testing-library/user-event';
+import { hasTextAcrossElements } from '@votingworks/test-utils';
 import { screen, within, render } from '../../test/react_testing_library';
 import { mergeMsEitherNeitherContests } from '../utils/ms_either_neither_contests';
 import { Review } from './review';
@@ -46,10 +47,14 @@ test('candidate contest with no votes', () => {
 });
 
 test('candidate contest with votes but still undervoted', () => {
-  const contest = electionGeneral.contests.find(
-    (c): c is CandidateContest => c.type === 'candidate' && c.seats > 1
-  );
-  assert(contest);
+  const contest: CandidateContest = {
+    ...find(
+      electionGeneral.contests,
+      (c): c is CandidateContest => c.type === 'candidate'
+    ),
+    seats: 3,
+  };
+
   const contests = [contest];
   render(
     <Review
@@ -62,7 +67,10 @@ test('candidate contest with votes but still undervoted', () => {
       returnToContest={jest.fn()}
     />
   );
-  screen.getByText(/You may still vote for \d+ more candidates?./);
+
+  screen.getByText(
+    hasTextAcrossElements(/votes remaining in this contest: 2/i)
+  );
 });
 
 test('candidate contest fully voted', () => {

--- a/libs/mark-flow-ui/src/components/review.tsx
+++ b/libs/mark-flow-ui/src/components/review.tsx
@@ -68,7 +68,7 @@ function CandidateContestResult({
       undervoteWarning={
         remainingChoices > 0 ? (
           vote.length === 0 ? (
-            appStrings.undervoteWarningNoVotes()
+            appStrings.warningNoVotesForContest()
           ) : (
             <React.Fragment>
               {appStrings.labelNumVotesRemaining()}{' '}
@@ -120,7 +120,7 @@ function YesNoContestResult({
       title={electionStrings.contestTitle(contest)}
       titleType="h2"
       undervoteWarning={
-        !yesNo ? appStrings.undervoteWarningNoVotes() : undefined
+        !yesNo ? appStrings.warningNoVotesForContest() : undefined
       }
       votes={votes}
     />
@@ -168,7 +168,7 @@ function MsEitherNeitherContestResult({
       title={electionStrings.contestTitle(contest)}
       titleType="h2"
       undervoteWarning={
-        votes.length < 2 ? appStrings.undervoteWarningNoVotes() : undefined
+        votes.length < 2 ? appStrings.warningNoVotesForContest() : undefined
       }
       votes={votes}
     />

--- a/libs/mark-flow-ui/src/pages/review_page.tsx
+++ b/libs/mark-flow-ui/src/pages/review_page.tsx
@@ -7,7 +7,8 @@ import {
   H1,
   WithScrollButtons,
   useScreenInfo,
-  Prose,
+  appStrings,
+  AudioOnly,
 } from '@votingworks/ui';
 
 import { assert } from '@votingworks/basics';
@@ -54,7 +55,7 @@ export function ReviewPage(props: ReviewPageProps): JSX.Element {
 
   const printMyBallotButton = (
     <LinkButton to={printScreenUrl} id="next" variant="primary" icon="Done">
-      Print My Ballot
+      {appStrings.buttonPrintBallot()}
     </LinkButton>
   );
 
@@ -63,19 +64,12 @@ export function ReviewPage(props: ReviewPageProps): JSX.Element {
   return (
     <Screen navRight={!screenInfo.isPortrait}>
       <Main flexColumn>
-        <ContentHeader>
-          <Prose id="audiofocus">
-            <H1>
-              <span aria-label="Review Your Votes.">Review Your Votes</span>
-              <span className="screen-reader-only">
-                To review your votes, advance through the ballot contests using
-                the up and down buttons. To change your vote in any contest, use
-                the select button to navigate to that contest. When you are
-                finished making your ballot selections and ready to print your
-                ballot, use the right button to print your ballot.
-              </span>
-            </H1>
-          </Prose>
+        <ContentHeader id="audiofocus">
+          <H1>{appStrings.titleBmdReviewScreen()}</H1>
+          <AudioOnly>
+            {appStrings.instructionsBmdReviewPageNavigation()}{' '}
+            {appStrings.instructionsBmdReviewPageChangingVotes()}
+          </AudioOnly>
         </ContentHeader>
         <WithScrollButtons>
           <Review

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -160,6 +160,13 @@ export interface Contest {
   readonly title: string;
   readonly type: ContestTypes;
 }
+
+/**
+ * Generic type-agnostic contest type, enabling common operations on canonical
+ * {@link Contest}s and BMD-specific ms-either-neither contests.
+ */
+export type ContestLike = Pick<Contest, 'id' | 'districtId' | 'title'>;
+
 const ContestInternalSchema = z.object({
   id: ContestIdSchema,
   districtId: DistrictIdSchema,

--- a/libs/types/src/election_utils.ts
+++ b/libs/types/src/election_utils.ts
@@ -5,7 +5,9 @@ import {
   Candidate,
   Contest,
   ContestId,
+  ContestLike,
   Contests,
+  District,
   DistrictId,
   Election,
   ElectionDefinition,
@@ -292,10 +294,10 @@ export function getPartyIdsInBallotStyles(
   return Array.from(new Set(election.ballotStyles.map((bs) => bs.partyId)));
 }
 
-export function getContestDistrictName(
+export function getContestDistrict(
   election: Election,
-  contest: Contest
-): string {
+  contest: ContestLike
+): District {
   const district = election.districts.find((d) => d.id === contest.districtId);
   // istanbul ignore next
   if (!district) {
@@ -303,7 +305,15 @@ export function getContestDistrictName(
       `Contest's associated district ${contest.districtId} not found.`
     );
   }
-  return district.name;
+
+  return district;
+}
+
+export function getContestDistrictName(
+  election: Election,
+  contest: Contest
+): string {
+  return getContestDistrict(election, contest).name;
 }
 
 /**

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -52,13 +52,6 @@ export const appStrings = {
 
   buttonReview: () => <UiString uiStringKey="buttonReview">Review</UiString>,
 
-  contestNavigationInstructions: () => (
-    <UiString uiStringKey="contestNavigationInstructions">
-      To navigate through the contest choices, use the down button. To move to
-      the next contest, use the right button.
-    </UiString>
-  ),
-
   date: (value: Date) => <DateString value={value} />,
 
   instructionsBmdBallotNavigation: () => (
@@ -68,6 +61,13 @@ export const appStrings = {
       and right buttons. To navigate through contest choices, use the up and
       down buttons. To select or unselect a contest choice as your vote, use the
       select button. Press the right button now to advance to the first contest.
+    </UiString>
+  ),
+
+  instructionsBmdContestNavigation: () => (
+    <UiString uiStringKey="instructionsBmdContestNavigation">
+      To navigate through the contest choices, use the down button. To move to
+      the next contest, use the right button.
     </UiString>
   ),
 
@@ -122,6 +122,7 @@ export const appStrings = {
 
   number: (value: number) => <NumberString value={value} />,
 
+  // TODO(kofi): Remove in favour of `labelNumVotesRemaining`
   numSeatsInstructions: (numSeats: number) =>
     // These are split out into individual strings instead of an interpolated
     // one to support generating non-interpolated audio for each one, for a
@@ -136,6 +137,7 @@ export const appStrings = {
       // possible votes per contest.
     })[numSeats],
 
+  // TODO(kofi): Remove in favour of `labelNumVotesRemaining`
   numVotesSelected: (numVotes: number) =>
     ({
       1: (
@@ -161,6 +163,7 @@ export const appStrings = {
       // TODO(kofi): Same as above: find numVotes upper limit.
     })[numVotes],
 
+  // TODO(kofi): Remove in favour of `labelNumVotesRemaining`
   numVotesRemaining: (numRemaining: number) =>
     ({
       1: (
@@ -190,8 +193,8 @@ export const appStrings = {
     <UiString uiStringKey="titleBmdReviewScreen">Review Your Votes</UiString>
   ),
 
-  undervoteWarningNoVotes: () => (
-    <UiString uiStringKey="undervoteWarningNoVotes">
+  warningNoVotesForContest: () => (
+    <UiString uiStringKey="warningNoVotesForContest">
       You may still vote in this contest.
     </UiString>
   ),

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -14,11 +14,37 @@ export const appStrings = {
 
   buttonBack: () => <UiString uiStringKey="buttonBack">Back</UiString>,
 
+  buttonBallotIsCorrect: () => (
+    <UiString uiStringKey="buttonBallotIsCorrect">
+      My Ballot is Correct
+    </UiString>
+  ),
+
+  buttonBallotIsIncorrect: () => (
+    <UiString uiStringKey="buttonBallotIsIncorrect">
+      My Ballot is Incorrect
+    </UiString>
+  ),
+
+  buttonBmdReviewCardAction: () => (
+    <UiString uiStringKey="buttonBmdReviewCardAction">
+      Press the select button to change your votes for this contest.
+    </UiString>
+  ),
+
+  buttonChange: () => <UiString uiStringKey="buttonChange">Change</UiString>,
+
   buttonDisplaySettings: () => (
     <UiString uiStringKey="buttonDisplaySettings">Color/Size</UiString>
   ),
 
+  buttonMore: () => <UiString uiStringKey="buttonMore">More</UiString>,
+
   buttonNext: () => <UiString uiStringKey="buttonNext">Next</UiString>,
+
+  buttonPrintBallot: () => (
+    <UiString uiStringKey="buttonPrintBallot">Print My Ballot</UiString>
+  ),
 
   buttonStartVoting: () => (
     <UiString uiStringKey="buttonStartVoting">Start Voting</UiString>
@@ -45,6 +71,31 @@ export const appStrings = {
     </UiString>
   ),
 
+  instructionsBmdReviewPageNavigation: () => (
+    <UiString uiStringKey="instructionsBmdReviewPageNavigation">
+      To review your votes, advance through the ballot contests using the up and
+      down buttons.
+    </UiString>
+  ),
+
+  instructionsBmdReviewPageChangingVotes: () => (
+    <UiString uiStringKey="instructionsBmdReviewPageChangingVotes">
+      To change your vote in any contest, use the select button to navigate to
+      that contest. When you are finished making your ballot selections and
+      ready to print your ballot, use the right button to print your ballot.
+    </UiString>
+  ),
+
+  // TODO(kofi): I think these instructions could be improved a bit. Not sure
+  // it's obvious to a vision-impaired voter that they have to navigate down to
+  // the confirm/reject buttons at the bottom of the screen.
+  instructionsBmdScanReviewConfirmation: () => (
+    <UiString uiStringKey="instructionsBmdScanReviewConfirmation">
+      If your selections are correct, press “My Ballot is Correct”. If there is
+      an error, press “My Ballot is Incorrect” and alert a poll worker.
+    </UiString>
+  ),
+
   labelAllPrecinctsSelection: () => (
     <UiString uiStringKey="labelAllPrecinctsSelection">All Precincts</UiString>
   ),
@@ -57,6 +108,16 @@ export const appStrings = {
     <UiString uiStringKey="labelNumBallotContests">
       Number of contests on your ballot:
     </UiString>
+  ),
+
+  labelNumVotesRemaining: () => (
+    <UiString uiStringKey="labelNumVotesRemaining">
+      Votes remaining in this contest:
+    </UiString>
+  ),
+
+  labelWriteInParenthesized: () => (
+    <UiString uiStringKey="labelWriteInParenthesized">(write-in)</UiString>
   ),
 
   number: (value: number) => <NumberString value={value} />,
@@ -124,4 +185,14 @@ export const appStrings = {
       ),
       // TODO(kofi): Same as above: find numRemaining upper limit.
     })[numRemaining],
+
+  titleBmdReviewScreen: () => (
+    <UiString uiStringKey="titleBmdReviewScreen">Review Your Votes</UiString>
+  ),
+
+  undervoteWarningNoVotes: () => (
+    <UiString uiStringKey="undervoteWarningNoVotes">
+      You may still vote in this contest.
+    </UiString>
+  ),
 } as const;

--- a/libs/ui/src/ui_strings/election_strings.tsx
+++ b/libs/ui/src/ui_strings/election_strings.tsx
@@ -3,6 +3,7 @@
 import {
   BallotStyleId,
   Candidate,
+  ContestLike,
   County,
   District,
   Election,
@@ -13,13 +14,6 @@ import {
 } from '@votingworks/types';
 
 import { UiString } from './ui_string';
-
-// Using more lenient typing to support both the `Contest` and the
-// `MsEitherNeitherContest` types.
-interface ContestLike {
-  id: string;
-  title: string;
-}
 
 type ContestWithDescription = ContestLike & {
   description: string;

--- a/libs/ui/src/voter_contest_summary.stories.tsx
+++ b/libs/ui/src/voter_contest_summary.stories.tsx
@@ -10,10 +10,10 @@ const initialProps: VoterContestSummaryProps = {
   title: 'City Council',
   titleType: 'h3',
   votes: [
-    { label: 'Martin Scorsese', caption: 'American' },
-    { label: 'Jean-Luc Godard', caption: 'French' },
-    { label: 'Akira Kurosawa', caption: 'Japanese' },
-    { label: 'Barney', caption: '(write-in)' },
+    { id: 'scorsese', label: 'Martin Scorsese', caption: 'American' },
+    { id: 'godard', label: 'Jean-Luc Godard', caption: 'French' },
+    { id: 'kurosawa', label: 'Akira Kurosawa', caption: 'Japanese' },
+    { id: 'barney', label: 'Barney', caption: '(write-in)' },
   ],
 };
 

--- a/libs/ui/src/voter_contest_summary.tsx
+++ b/libs/ui/src/voter_contest_summary.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import styled from 'styled-components';
 
 import { Checkbox } from './checkbox';
@@ -5,17 +6,18 @@ import { Icons } from './icons';
 import { Caption, Font, H5, HeadingProps, P } from './typography';
 
 export interface VoterContestSummaryProps {
-  districtName: string;
-  title: string;
+  districtName: React.ReactNode;
+  title: React.ReactNode;
   titleType: HeadingProps['as'];
-  undervoteWarning?: string;
+  undervoteWarning?: React.ReactNode;
   votes: ContestVote[];
   'data-testid'?: string;
 }
 
 export interface ContestVote {
-  caption?: string;
-  label: string;
+  caption?: React.ReactNode;
+  id: string;
+  label: React.ReactNode;
 }
 
 const ListContainer = styled.ul`
@@ -69,7 +71,7 @@ export function VoterContestSummary(
       )}
       <ListContainer>
         {votes.map((v) => (
-          <VoteInfo key={v.label}>
+          <VoteInfo key={v.id}>
             <CheckboxContainer color="success">
               <Checkbox checked />
             </CheckboxContainer>

--- a/libs/ui/src/with_scroll_buttons.tsx
+++ b/libs/ui/src/with_scroll_buttons.tsx
@@ -8,6 +8,7 @@ import { assert } from '@votingworks/basics';
 import { Button } from './button';
 import { Icons } from './icons';
 import { makeTheme } from './themes/make_theme';
+import { appStrings } from './ui_strings';
 
 export interface WithScrollButtonsProps {
   children: React.ReactNode;
@@ -182,7 +183,7 @@ export function WithScrollButtons(props: WithScrollButtonsProps): JSX.Element {
               <Control onPress={onScrollUp} variant="primary">
                 <ControlLabel>
                   <Icons.UpChevron />
-                  <span>More</span>
+                  {appStrings.buttonMore()}
                 </ControlLabel>
               </Control>
             )}
@@ -190,7 +191,7 @@ export function WithScrollButtons(props: WithScrollButtonsProps): JSX.Element {
             {canScrollDown && (
               <Control onPress={onScrollDown} variant="primary">
                 <ControlLabel>
-                  <span>More</span>
+                  {appStrings.buttonMore()}
                   <Icons.DownChevron />
                 </ControlLabel>
               </Control>


### PR DESCRIPTION
## Overview

Replacing strings shown on the ballot review pages in Mark/Mark-Scan with language-aware `<UiString>` versions.

Updated the undervote count warning text as described [here](https://docs.google.com/document/d/1xtt5q1Pet5j1RHVsduvOcRGrqDkGspFeKhKc1aVscKE/edit?usp=sharing), in order to avoid interpolated audio.

## Demo Video or Screenshot
|  |  |
| ------------- | ------------- |
|  ![Screenshot 2023-10-30 at 14 53 14](https://github.com/votingworks/vxsuite/assets/264902/50297448-2d54-49af-9511-74f9ea19e2e4) | ![Screenshot 2023-10-30 at 15 09 37](https://github.com/votingworks/vxsuite/assets/264902/5ece5319-0574-4c09-99c6-bca36156157a) |

## Testing Plan
- Manually testing out translated text for now - integration tests and lint checks later down the line
- Existing tests as regression guards

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
