### PR TITLE
[mark-flow-ui] Remove app strings with interpolated values

### DIFF
--- a/apps/mark-scan/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
+++ b/apps/mark-scan/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
@@ -488,9 +488,16 @@ exports[`Single Seat Contest 1`] = `
             <span
               class=""
             >
-              Vote for 1.
+              Votes remaining in this contest:
             </span>
              
+            <span
+              class="c7"
+            >
+              <span>
+                1
+              </span>
+            </span>
             <span
               class="screen-reader-only"
             >

--- a/apps/mark-scan/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
+++ b/apps/mark-scan/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
@@ -614,16 +614,14 @@ exports[`Single Seat Contest 1`] = `
             <span
               class=""
             >
-              Vote for 4.
+              Votes remaining in this contest:
             </span>
              
             <span
               class="c7"
             >
-              <span
-                class=""
-              >
-                You have selected 4.
+              <span>
+                0
               </span>
             </span>
             <span

--- a/apps/mark-scan/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
+++ b/apps/mark-scan/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
@@ -614,16 +614,14 @@ exports[`Single Seat Contest 1`] = `
             <span
               class=""
             >
-              Vote for 1.
+              Votes remaining in this contest:
             </span>
              
             <span
               class="c7"
             >
-              <span
-                class=""
-              >
-                You have selected 1.
+              <span>
+                0
               </span>
             </span>
             <span

--- a/apps/mark-scan/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
+++ b/apps/mark-scan/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
@@ -504,9 +504,16 @@ exports[`Single Seat Contest with Write In 1`] = `
             <span
               class=""
             >
-              Vote for 1.
+              Votes remaining in this contest:
             </span>
              
+            <span
+              class="c7"
+            >
+              <span>
+                1
+              </span>
+            </span>
             <span
               class="screen-reader-only"
             >

--- a/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
@@ -266,7 +266,9 @@ test('MarkAndPrint end-to-end flow', async () => {
       )}${countyCommissionersContest.title}`
     )
   );
-  await screen.findByText(/Vote for 4/i);
+  await screen.findByText(
+    hasTextAcrossElements(/votes remaining in this contest: 4/i)
+  );
 
   // Select first candidate
   userEvent.click(

--- a/apps/mark-scan/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
+++ b/apps/mark-scan/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
@@ -457,9 +457,16 @@ exports[`Renders ContestPage 1`] = `
             <span
               class=""
             >
-              Vote for 1.
+              Votes remaining in this contest:
             </span>
              
+            <span
+              class="c6"
+            >
+              <span>
+                1
+              </span>
+            </span>
             <span
               class="screen-reader-only"
             >
@@ -1371,9 +1378,16 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
             <span
               class=""
             >
-              Vote for 1.
+              Votes remaining in this contest:
             </span>
              
+            <span
+              class="c6"
+            >
+              <span>
+                1
+              </span>
+            </span>
             <span
               class="screen-reader-only"
             >

--- a/apps/mark/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_candidate_no_party.test.tsx.snap
@@ -492,9 +492,16 @@ exports[`Single Seat Contest 1`] = `
             <span
               class=""
             >
-              Vote for 1.
+              Votes remaining in this contest:
             </span>
              
+            <span
+              class="c7"
+            >
+              <span>
+                1
+              </span>
+            </span>
             <span
               class="screen-reader-only"
             >

--- a/apps/mark/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_multi_seat.test.tsx.snap
@@ -618,16 +618,14 @@ exports[`Single Seat Contest 1`] = `
             <span
               class=""
             >
-              Vote for 4.
+              Votes remaining in this contest:
             </span>
              
             <span
               class="c7"
             >
-              <span
-                class=""
-              >
-                You have selected 4.
+              <span>
+                0
               </span>
             </span>
             <span

--- a/apps/mark/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_single_seat.test.tsx.snap
@@ -618,16 +618,14 @@ exports[`Single Seat Contest 1`] = `
             <span
               class=""
             >
-              Vote for 1.
+              Votes remaining in this contest:
             </span>
              
             <span
               class="c7"
             >
-              <span
-                class=""
-              >
-                You have selected 1.
+              <span>
+                0
               </span>
             </span>
             <span

--- a/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
+++ b/apps/mark/frontend/src/__snapshots__/app_contest_write_in.test.tsx.snap
@@ -508,9 +508,16 @@ exports[`Single Seat Contest with Write In 1`] = `
             <span
               class=""
             >
-              Vote for 1.
+              Votes remaining in this contest:
             </span>
              
+            <span
+              class="c7"
+            >
+              <span>
+                1
+              </span>
+            </span>
             <span
               class="screen-reader-only"
             >

--- a/apps/mark/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark/frontend/src/app_end_to_end.test.tsx
@@ -240,7 +240,9 @@ test('MarkAndPrint end-to-end flow', async () => {
       )}${countyCommissionersContest.title}`
     )
   );
-  await screen.findByText(/Vote for 4/i);
+  await screen.findByText(
+    hasTextAcrossElements(/votes remaining in this contest: 4/i)
+  );
 
   // Select first candidate
   userEvent.click(

--- a/apps/mark/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
+++ b/apps/mark/frontend/src/pages/__snapshots__/contest_page.test.tsx.snap
@@ -457,9 +457,16 @@ exports[`Renders ContestPage 1`] = `
             <span
               class=""
             >
-              Vote for 1.
+              Votes remaining in this contest:
             </span>
              
+            <span
+              class="c6"
+            >
+              <span>
+                1
+              </span>
+            </span>
             <span
               class="screen-reader-only"
             >
@@ -1371,9 +1378,16 @@ exports[`Renders ContestPage in Landscape orientation 1`] = `
             <span
               class=""
             >
-              Vote for 1.
+              Votes remaining in this contest:
             </span>
              
+            <span
+              class="c6"
+            >
+              <span>
+                1
+              </span>
+            </span>
             <span
               class="screen-reader-only"
             >

--- a/libs/mark-flow-ui/src/components/__snapshots__/contest.test.tsx.snap
+++ b/libs/mark-flow-ui/src/components/__snapshots__/contest.test.tsx.snap
@@ -1,6 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders 1`] = `
+.c6 {
+  font-size: 1em;
+  font-weight: 600;
+  line-height: 1.3;
+  margin: 0;
+}
+
 .c3 {
   font-size: 1em;
   font-weight: 500;
@@ -16,7 +23,7 @@ exports[`renders 1`] = `
   font-size: 0.75rem;
 }
 
-.c19 {
+.c20 {
   font-size: 1em;
   font-weight: 300;
   line-height: 1.3;
@@ -24,7 +31,7 @@ exports[`renders 1`] = `
   font-size: 0.75rem;
 }
 
-.c17 {
+.c18 {
   font-size: 1em;
   line-height: 1.3;
   margin: 0;
@@ -56,13 +63,13 @@ exports[`renders 1`] = `
   margin-top: 0 !important;
 }
 
-.c15 {
+.c16 {
   fill: currentColor;
   height: 1em;
   width: 1em;
 }
 
-.c9 {
+.c10 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -107,22 +114,22 @@ exports[`renders 1`] = `
   vertical-align: middle;
 }
 
-.c9:hover,
-.c9:active {
+.c10:hover,
+.c10:active {
   outline: none;
 }
 
-.c9:active {
+.c10:active {
   box-shadow: inset 0 0 0 0.15rem #222222;
 }
 
-.c9[disabled] {
+.c10[disabled] {
   border: 0.15rem dashed #222222;
   box-shadow: none;
   cursor: not-allowed;
 }
 
-.c11 {
+.c12 {
   display: inline-block;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -133,7 +140,7 @@ exports[`renders 1`] = `
   flex-shrink: 1;
 }
 
-.c14 {
+.c15 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -153,13 +160,13 @@ exports[`renders 1`] = `
   width: 1.75em;
 }
 
-.c14 > * {
+.c15 > * {
   opacity: 0;
   -webkit-transition: opacity 100ms ease-in;
   transition: opacity 100ms ease-in;
 }
 
-.c10 {
+.c11 {
   border: 0.06rem solid currentColor;
   -webkit-box-pack: start;
   -webkit-justify-content: start;
@@ -173,11 +180,11 @@ exports[`renders 1`] = `
   width: 100%;
 }
 
-.c10:active {
+.c11:active {
   border: 0.06rem solid #00437d;
 }
 
-.c12 {
+.c13 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -192,7 +199,7 @@ exports[`renders 1`] = `
   gap: 0.5rem;
 }
 
-.c13 {
+.c14 {
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
@@ -202,7 +209,7 @@ exports[`renders 1`] = `
   flex-shrink: 0;
 }
 
-.c16 {
+.c17 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -210,7 +217,7 @@ exports[`renders 1`] = `
   line-height: 1;
 }
 
-.c18 {
+.c19 {
   line-height: inherit;
   margin-bottom: 0;
 }
@@ -229,7 +236,7 @@ exports[`renders 1`] = `
   overflow: auto;
 }
 
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -239,7 +246,7 @@ exports[`renders 1`] = `
   position: relative;
 }
 
-.c7 {
+.c8 {
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -264,7 +271,7 @@ exports[`renders 1`] = `
   padding-bottom: 0;
 }
 
-.c8 {
+.c9 {
   display: grid;
   grid-auto-rows: minmax(auto,1fr);
   grid-gap: 0.5rem;
@@ -335,9 +342,16 @@ exports[`renders 1`] = `
           <span
             class=""
           >
-            Vote for 1.
+            Votes remaining in this contest:
           </span>
            
+          <span
+            class="c6"
+          >
+            <span>
+              1
+            </span>
+          </span>
           <span
             class="screen-reader-only"
           >
@@ -351,38 +365,38 @@ exports[`renders 1`] = `
       </div>
     </div>
     <div
-      class="c6"
+      class="c7"
     >
       <div
-        class="c7"
+        class="c8"
       >
         <div
           aria-multiselectable="true"
-          class="c8"
+          class="c9"
           role="listbox"
         >
           <button
             aria-label=" Joseph Barchi and Joseph Hallaren, Federalist."
             aria-selected="false"
-            class="c9 c10"
+            class="c10 c11"
             role="option"
             type="button"
           >
             <span
-              class="c11"
+              class="c12"
             >
               <span
-                class="c12"
+                class="c13"
               >
                 <span
-                  class="c13"
+                  class="c14"
                 >
                   <span
-                    class="c14"
+                    class="c15"
                   >
                     <svg
                       aria-hidden="true"
-                      class="c15"
+                      class="c16"
                       height="100"
                       role="img"
                       viewBox="0 0 100 100"
@@ -395,15 +409,15 @@ exports[`renders 1`] = `
                   </span>
                 </span>
                 <span
-                  class="c16"
+                  class="c17"
                 >
                   <p
-                    class="c17 c18"
+                    class="c18 c19"
                   >
                     Joseph Barchi and Joseph Hallaren
                   </p>
                   <span
-                    class="c19"
+                    class="c20"
                   >
                     <span
                       class=""
@@ -418,25 +432,25 @@ exports[`renders 1`] = `
           <button
             aria-label=" Adam Cramer and Greg Vuocolo, People’s."
             aria-selected="false"
-            class="c9 c10"
+            class="c10 c11"
             role="option"
             type="button"
           >
             <span
-              class="c11"
+              class="c12"
             >
               <span
-                class="c12"
+                class="c13"
               >
                 <span
-                  class="c13"
+                  class="c14"
                 >
                   <span
-                    class="c14"
+                    class="c15"
                   >
                     <svg
                       aria-hidden="true"
-                      class="c15"
+                      class="c16"
                       height="100"
                       role="img"
                       viewBox="0 0 100 100"
@@ -449,15 +463,15 @@ exports[`renders 1`] = `
                   </span>
                 </span>
                 <span
-                  class="c16"
+                  class="c17"
                 >
                   <p
-                    class="c17 c18"
+                    class="c18 c19"
                   >
                     Adam Cramer and Greg Vuocolo
                   </p>
                   <span
-                    class="c19"
+                    class="c20"
                   >
                     <span
                       class=""
@@ -472,25 +486,25 @@ exports[`renders 1`] = `
           <button
             aria-label=" Daniel Court and Amy Blumhardt, Liberty."
             aria-selected="false"
-            class="c9 c10"
+            class="c10 c11"
             role="option"
             type="button"
           >
             <span
-              class="c11"
+              class="c12"
             >
               <span
-                class="c12"
+                class="c13"
               >
                 <span
-                  class="c13"
+                  class="c14"
                 >
                   <span
-                    class="c14"
+                    class="c15"
                   >
                     <svg
                       aria-hidden="true"
-                      class="c15"
+                      class="c16"
                       height="100"
                       role="img"
                       viewBox="0 0 100 100"
@@ -503,15 +517,15 @@ exports[`renders 1`] = `
                   </span>
                 </span>
                 <span
-                  class="c16"
+                  class="c17"
                 >
                   <p
-                    class="c17 c18"
+                    class="c18 c19"
                   >
                     Daniel Court and Amy Blumhardt
                   </p>
                   <span
-                    class="c19"
+                    class="c20"
                   >
                     <span
                       class=""
@@ -526,25 +540,25 @@ exports[`renders 1`] = `
           <button
             aria-label=" Alvin Boone and James Lian, Constitution."
             aria-selected="false"
-            class="c9 c10"
+            class="c10 c11"
             role="option"
             type="button"
           >
             <span
-              class="c11"
+              class="c12"
             >
               <span
-                class="c12"
+                class="c13"
               >
                 <span
-                  class="c13"
+                  class="c14"
                 >
                   <span
-                    class="c14"
+                    class="c15"
                   >
                     <svg
                       aria-hidden="true"
-                      class="c15"
+                      class="c16"
                       height="100"
                       role="img"
                       viewBox="0 0 100 100"
@@ -557,15 +571,15 @@ exports[`renders 1`] = `
                   </span>
                 </span>
                 <span
-                  class="c16"
+                  class="c17"
                 >
                   <p
-                    class="c17 c18"
+                    class="c18 c19"
                   >
                     Alvin Boone and James Lian
                   </p>
                   <span
-                    class="c19"
+                    class="c20"
                   >
                     <span
                       class=""
@@ -580,25 +594,25 @@ exports[`renders 1`] = `
           <button
             aria-label=" Ashley Hildebrand-McDougall and James Garritty, Whig."
             aria-selected="false"
-            class="c9 c10"
+            class="c10 c11"
             role="option"
             type="button"
           >
             <span
-              class="c11"
+              class="c12"
             >
               <span
-                class="c12"
+                class="c13"
               >
                 <span
-                  class="c13"
+                  class="c14"
                 >
                   <span
-                    class="c14"
+                    class="c15"
                   >
                     <svg
                       aria-hidden="true"
-                      class="c15"
+                      class="c16"
                       height="100"
                       role="img"
                       viewBox="0 0 100 100"
@@ -611,15 +625,15 @@ exports[`renders 1`] = `
                   </span>
                 </span>
                 <span
-                  class="c16"
+                  class="c17"
                 >
                   <p
-                    class="c17 c18"
+                    class="c18 c19"
                   >
                     Ashley Hildebrand-McDougall and James Garritty
                   </p>
                   <span
-                    class="c19"
+                    class="c20"
                   >
                     <span
                       class=""
@@ -634,25 +648,25 @@ exports[`renders 1`] = `
           <button
             aria-label=" Martin Patterson and Clay Lariviere, Labor."
             aria-selected="false"
-            class="c9 c10"
+            class="c10 c11"
             role="option"
             type="button"
           >
             <span
-              class="c11"
+              class="c12"
             >
               <span
-                class="c12"
+                class="c13"
               >
                 <span
-                  class="c13"
+                  class="c14"
                 >
                   <span
-                    class="c14"
+                    class="c15"
                   >
                     <svg
                       aria-hidden="true"
-                      class="c15"
+                      class="c16"
                       height="100"
                       role="img"
                       viewBox="0 0 100 100"
@@ -665,15 +679,15 @@ exports[`renders 1`] = `
                   </span>
                 </span>
                 <span
-                  class="c16"
+                  class="c17"
                 >
                   <p
-                    class="c17 c18"
+                    class="c18 c19"
                   >
                     Martin Patterson and Clay Lariviere
                   </p>
                   <span
-                    class="c19"
+                    class="c20"
                   >
                     <span
                       class=""

--- a/libs/mark-flow-ui/src/components/candidate_contest.tsx
+++ b/libs/mark-flow-ui/src/components/candidate_contest.tsx
@@ -27,6 +27,7 @@ import {
   useScreenInfo,
   appStrings,
   CandidatePartyList,
+  NumberString,
 } from '@votingworks/ui';
 import { assert } from '@votingworks/basics';
 
@@ -235,17 +236,10 @@ export function CandidateContest({
           districtName={districtName}
         >
           <Caption>
-            {appStrings.numSeatsInstructions(contest.seats)}{' '}
-            {vote.length === contest.seats && (
-              <Font weight="bold">
-                {appStrings.numVotesSelected(contest.seats)}
-              </Font>
-            )}
-            {vote.length < contest.seats && vote.length !== 0 && (
-              <Font weight="bold">
-                {appStrings.numVotesRemaining(contest.seats - vote.length)}
-              </Font>
-            )}
+            {appStrings.labelNumVotesRemaining()}{' '}
+            <Font weight="bold">
+              <NumberString value={contest.seats - vote.length} />
+            </Font>
             <span className="screen-reader-only">
               {appStrings.instructionsBmdContestNavigation()}
             </span>

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -52,6 +52,8 @@ export const appStrings = {
 
   buttonReview: () => <UiString uiStringKey="buttonReview">Review</UiString>,
 
+  // TODO(kofi): Remove `date` and `number` and have consumers use the
+  // components directly, since this indirection doesn't provided added value.
   date: (value: Date) => <DateString value={value} />,
 
   instructionsBmdBallotNavigation: () => (
@@ -120,74 +122,9 @@ export const appStrings = {
     <UiString uiStringKey="labelWriteInParenthesized">(write-in)</UiString>
   ),
 
+  // TODO(kofi): Remove `date` and `number` and have consumers use the
+  // components directly, since this indirection doesn't provided added value.
   number: (value: number) => <NumberString value={value} />,
-
-  // TODO(kofi): Remove in favour of `labelNumVotesRemaining`
-  numSeatsInstructions: (numSeats: number) =>
-    // These are split out into individual strings instead of an interpolated
-    // one to support generating non-interpolated audio for each one, for a
-    // better voter experience.
-    // This pattern only makes sense when there's a very limited value space.
-    ({
-      1: <UiString uiStringKey="numSeatsInstructions.1">Vote for 1.</UiString>,
-      2: <UiString uiStringKey="numSeatsInstructions.2">Vote for 2.</UiString>,
-      3: <UiString uiStringKey="numSeatsInstructions.3">Vote for 3.</UiString>,
-      4: <UiString uiStringKey="numSeatsInstructions.4">Vote for 4.</UiString>,
-      // TODO(kofi): Find out what a reasonable upper limit is for the number of
-      // possible votes per contest.
-    })[numSeats],
-
-  // TODO(kofi): Remove in favour of `labelNumVotesRemaining`
-  numVotesSelected: (numVotes: number) =>
-    ({
-      1: (
-        <UiString uiStringKey="numVotesSelected.1">
-          You have selected 1.
-        </UiString>
-      ),
-      2: (
-        <UiString uiStringKey="numVotesSelected.2">
-          You have selected 2.
-        </UiString>
-      ),
-      3: (
-        <UiString uiStringKey="numVotesSelected.3">
-          You have selected 3.
-        </UiString>
-      ),
-      4: (
-        <UiString uiStringKey="numVotesSelected.4">
-          You have selected 4.
-        </UiString>
-      ),
-      // TODO(kofi): Same as above: find numVotes upper limit.
-    })[numVotes],
-
-  // TODO(kofi): Remove in favour of `labelNumVotesRemaining`
-  numVotesRemaining: (numRemaining: number) =>
-    ({
-      1: (
-        <UiString uiStringKey="numVotesRemaining.1">
-          You may select 1 more.
-        </UiString>
-      ),
-      2: (
-        <UiString uiStringKey="numVotesRemaining.2">
-          You may select 2 more.
-        </UiString>
-      ),
-      3: (
-        <UiString uiStringKey="numVotesRemaining.3">
-          You may select 3 more.
-        </UiString>
-      ),
-      4: (
-        <UiString uiStringKey="numVotesRemaining.4">
-          You may select 4 more.
-        </UiString>
-      ),
-      // TODO(kofi): Same as above: find numRemaining upper limit.
-    })[numRemaining],
 
   titleBmdReviewScreen: () => (
     <UiString uiStringKey="titleBmdReviewScreen">Review Your Votes</UiString>

--- a/libs/ui/src/ui_strings/index.ts
+++ b/libs/ui/src/ui_strings/index.ts
@@ -1,5 +1,7 @@
 export * from './app_strings';
 export * from './audio_only';
+export * from './date_string';
 export * from './election_strings';
+export * from './number_string';
 export * from './ui_strings_context';
 export * from './utils';


### PR DESCRIPTION
## Overview

Replacing the vote counter strings in the header of the BMD contest screens with non-interpolated alternatives (see [string updates doc](https://docs.google.com/document/d/1xtt5q1Pet5j1RHVsduvOcRGrqDkGspFeKhKc1aVscKE/edit#heading=h.sh408d16sc6) for more context).

This simplifies translation/text-to-speech as well as our audio playback logic.

## Demo Video or Screenshot
https://github.com/votingworks/vxsuite/assets/264902/e220b344-db32-484a-aee3-237aeb757f6f

## Testing Plan
- Added unit tests to verify counter updates based on selected votes.
- Manual verification for string translation for now

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
