### PR TITLE
Kevin/vxscan add log export

### DIFF
--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -877,6 +877,17 @@ test('system administrator sees system administrator screen after logging in to 
   await screen.findByRole('button', { name: 'Reboot from USB' });
 });
 
+test('system administrator sees log export buttons', async () => {
+  apiMock.expectGetConfig({ electionDefinition: undefined });
+  apiMock.expectGetUsbDriveStatus('mounted');
+  apiMock.expectGetScannerStatus(statusNoPaper);
+  apiMock.authenticateAsSystemAdministrator();
+  renderApp();
+
+  await screen.findByRole('button', { name: 'Save Log File' });
+  await screen.findByRole('button', { name: 'Save CDF Log File' });
+});
+
 test('system administrator can reset polls to paused', async () => {
   apiMock.expectGetConfig({
     pollsState: 'polls_closed_final',

--- a/apps/scan/frontend/src/app_root.tsx
+++ b/apps/scan/frontend/src/app_root.tsx
@@ -5,6 +5,7 @@ import {
   useDevices,
   UnlockMachineScreen,
   SystemAdministratorScreenContents,
+  ExportLogsButtonGroup,
 } from '@votingworks/ui';
 import {
   Hardware,
@@ -149,6 +150,20 @@ export function AppRoot({
   }
 
   if (isSystemAdministratorAuth(authStatus)) {
+    const additionalButtons = (
+      <React.Fragment>
+        {isFeatureFlagEnabled(BooleanEnvironmentVariableName.LIVECHECK) ? (
+          <LiveCheckButton />
+        ) : undefined}
+        <ExportLogsButtonGroup
+          electionDefinition={electionDefinition}
+          usbDriveStatus={usbDrive}
+          auth={authStatus}
+          logger={logger}
+          machineConfig={machineConfig}
+        />
+      </React.Fragment>
+    );
     return (
       <ScreenMainCenterChild>
         <SystemAdministratorScreenContents
@@ -173,11 +188,7 @@ export function AppRoot({
           }
           isMachineConfigured={Boolean(electionDefinition)}
           usbDriveStatus={usbDrive}
-          additionalButtons={
-            isFeatureFlagEnabled(BooleanEnvironmentVariableName.LIVECHECK) ? (
-              <LiveCheckButton />
-            ) : undefined
-          }
+          additionalButtons={additionalButtons}
         />
       </ScreenMainCenterChild>
     );

--- a/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
@@ -38,6 +38,7 @@ beforeEach(() => {
   apiMock.expectGetMachineConfig();
   apiMock.expectGetScannerStatus(statusNoPaper);
   apiMock.expectGetUsbDriveStatus('mounted');
+  apiMock.authenticateAsElectionManager(electionGeneralDefinition);
 });
 
 afterEach(() => {
@@ -495,4 +496,18 @@ test('machine *can* be unconfigured if CVR sync is required but in test mode', a
   within(modal).getByText(
     'Do you want to remove all election information and data from this machine?'
   );
+});
+
+test('renders buttons for saving logs', async () => {
+  apiMock.expectGetConfig();
+  renderScreen({
+    scannerStatus: statusNoPaper,
+    usbDrive: mockUsbDriveStatus('no_drive'),
+  });
+  await screen.findByRole('heading', { name: 'Election Manager Settings' });
+
+  userEvent.click(screen.getByRole('tab', { name: /data/i }));
+  await screen.findByRole('heading', { name: 'Election Manager Settings' });
+  await screen.findByText('Save Log File');
+  await screen.findByText('Save CDF Log File');
 });

--- a/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
@@ -499,6 +499,8 @@ test('machine *can* be unconfigured if CVR sync is required but in test mode', a
 });
 
 test('renders buttons for saving logs', async () => {
+  // Log saving is tested fully in src/components/export_logs_modal.test.tsx
+
   apiMock.expectGetConfig();
   renderScreen({
     scannerStatus: statusNoPaper,
@@ -508,6 +510,12 @@ test('renders buttons for saving logs', async () => {
 
   userEvent.click(screen.getByRole('tab', { name: /data/i }));
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
-  await screen.findByText('Save Log File');
-  await screen.findByText('Save CDF Log File');
+
+  userEvent.click(screen.getByText('Save Log File'));
+  await screen.findByText('No Log File Present');
+  userEvent.click(screen.getByText('Close'));
+
+  userEvent.click(screen.getByText('Save CDF Log File'));
+  await screen.findByText('No Log File Present');
+  userEvent.click(screen.getByText('Close'));
 });

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -190,6 +190,9 @@ export function ElectionManagerScreen({
 
   const dataExportButtons = (
     <React.Fragment>
+      <P>
+        <Button onPress={() => setIsExportingResults(true)}>Save CVRs</Button>{' '}
+      </P>
       <ExportLogsButtonRow
         electionDefinition={electionDefinition}
         usbDriveStatus={usbDrive}
@@ -197,9 +200,6 @@ export function ElectionManagerScreen({
         logger={logger}
         machineConfig={machineConfig}
       />
-      <P>
-        <Button onPress={() => setIsExportingResults(true)}>Save CVRs</Button>{' '}
-      </P>
     </React.Fragment>
   );
 

--- a/libs/ui/src/export_logs_modal.test.tsx
+++ b/libs/ui/src/export_logs_modal.test.tsx
@@ -13,7 +13,11 @@ import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 import { DippedSmartCardAuth } from '@votingworks/types';
 import type { UsbDriveStatus } from '@votingworks/usb-drive';
 import { act, render, screen, waitFor } from '../test/react_testing_library';
-import { ExportLogsButton, ExportLogsButtonRow } from './export_logs_modal';
+import {
+  ExportLogsButton,
+  ExportLogsButtonGroup,
+  ExportLogsButtonRow,
+} from './export_logs_modal';
 import { mockUsbDriveStatus } from './test-utils/mock_usb_drive';
 
 const machineConfig = {
@@ -361,6 +365,22 @@ test('failed save to custom location', async () => {
 test('button row renders both buttons', () => {
   render(
     <ExportLogsButtonRow
+      usbDriveStatus={mockUsbDriveStatus('mounted')}
+      logger={fakeLogger()}
+      auth={electionManagerAuthStatus}
+      machineConfig={machineConfig}
+    />
+  );
+
+  expect(screen.getButton('Save Log File')).toBeEnabled();
+
+  // without an election definition, CDF button should be disabled
+  expect(screen.getButton('Save CDF Log File')).toBeDisabled();
+});
+
+test('button group renders both buttons', () => {
+  render(
+    <ExportLogsButtonGroup
       usbDriveStatus={mockUsbDriveStatus('mounted')}
       logger={fakeLogger()}
       auth={electionManagerAuthStatus}

--- a/libs/ui/src/export_logs_modal.tsx
+++ b/libs/ui/src/export_logs_modal.tsx
@@ -339,7 +339,7 @@ export function ExportLogsButtonGroup(
 ): JSX.Element {
   return (
     <React.Fragment>
-      <ExportLogsButton logFileType={LogFileType.Raw} {...sharedProps} />{' '}
+      <ExportLogsButton logFileType={LogFileType.Raw} {...sharedProps} />
       <ExportLogsButton logFileType={LogFileType.Cdf} {...sharedProps} />
     </React.Fragment>
   );

--- a/libs/ui/src/export_logs_modal.tsx
+++ b/libs/ui/src/export_logs_modal.tsx
@@ -15,7 +15,11 @@ import {
   Logger,
 } from '@votingworks/logging';
 
-import { DippedSmartCardAuth, ElectionDefinition } from '@votingworks/types';
+import {
+  DippedSmartCardAuth,
+  ElectionDefinition,
+  InsertedSmartCardAuth,
+} from '@votingworks/types';
 import { assert, sleep, throwIllegalValue } from '@votingworks/basics';
 import type { UsbDriveStatus } from '@votingworks/usb-drive';
 import { Button } from './button';
@@ -27,7 +31,7 @@ import { Font, P } from './typography';
 
 export interface ExportLogsModalProps {
   usbDriveStatus: UsbDriveStatus;
-  auth: DippedSmartCardAuth.AuthStatus;
+  auth: DippedSmartCardAuth.AuthStatus | InsertedSmartCardAuth.AuthStatus;
   logFileType: LogFileType;
   logger: Logger;
   electionDefinition?: ElectionDefinition;

--- a/libs/ui/src/export_logs_modal.tsx
+++ b/libs/ui/src/export_logs_modal.tsx
@@ -330,3 +330,17 @@ export function ExportLogsButtonRow(
     </P>
   );
 }
+
+/*
+ * Renders raw and CDF log export buttons without formatting
+ */
+export function ExportLogsButtonGroup(
+  sharedProps: ExportLogsButtonRowProps
+): JSX.Element {
+  return (
+    <React.Fragment>
+      <ExportLogsButton logFileType={LogFileType.Raw} {...sharedProps} />{' '}
+      <ExportLogsButton logFileType={LogFileType.Cdf} {...sharedProps} />
+    </React.Fragment>
+  );
+}

--- a/libs/utils/src/auth.ts
+++ b/libs/utils/src/auth.ts
@@ -8,6 +8,12 @@ export function isSystemAdministratorAuth(
 ): auth is InsertedSmartCardAuth.SystemAdministratorLoggedIn;
 export function isSystemAdministratorAuth(
   auth: DippedSmartCardAuth.AuthStatus | InsertedSmartCardAuth.AuthStatus
+): auth is
+  | InsertedSmartCardAuth.SystemAdministratorLoggedIn
+  | DippedSmartCardAuth.SystemAdministratorLoggedIn;
+
+export function isSystemAdministratorAuth(
+  auth: DippedSmartCardAuth.AuthStatus | InsertedSmartCardAuth.AuthStatus
 ): boolean {
   return (
     auth.status === 'logged_in' && auth.user.role === 'system_administrator'
@@ -20,6 +26,11 @@ export function isElectionManagerAuth(
 export function isElectionManagerAuth(
   auth: InsertedSmartCardAuth.AuthStatus
 ): auth is InsertedSmartCardAuth.ElectionManagerLoggedIn;
+export function isElectionManagerAuth(
+  auth: DippedSmartCardAuth.AuthStatus | InsertedSmartCardAuth.AuthStatus
+): auth is
+  | InsertedSmartCardAuth.ElectionManagerLoggedIn
+  | DippedSmartCardAuth.ElectionManagerLoggedIn;
 export function isElectionManagerAuth(
   auth: DippedSmartCardAuth.AuthStatus | InsertedSmartCardAuth.AuthStatus
 ): boolean {


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/4035

Adds UI for log export to VxScan for both system admins and election managers.

Placement for these buttons for election managers is up for debate. I put them in the "Election Data" tab because there's another data export button there, and "System Settings" has its own meaning.

## Demo Video or Screenshot
![Screenshot 2023-10-31 at 7 09 27 PM](https://github.com/votingworks/vxsuite/assets/1060688/ba23e047-3281-42b6-a32a-4f011ea20b48)
![Screenshot 2023-10-31 at 7 09 33 PM](https://github.com/votingworks/vxsuite/assets/1060688/e638f01e-dbf4-4f54-93c2-566467eea15a)
![Screenshot 2023-10-31 at 7 09 37 PM](https://github.com/votingworks/vxsuite/assets/1060688/df4aff2b-9e55-4020-8484-fe9d5bca8e5e)
![Screenshot 2023-10-31 at 7 09 46 PM](https://github.com/votingworks/vxsuite/assets/1060688/9daf8165-a390-41ac-a576-a89a0c4479fa)



## Testing Plan
Added tests comparable to those in VxAdmin. Full export behavior is tested in the component so we just need to test that the component is rendered.

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced. (Logging exists in existing component)
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
