### PR TITLE
[i18n/Audio] Wire up UI String audio IDs store and API

### DIFF
--- a/libs/backend/src/ballot_package/test_utils.ts
+++ b/libs/backend/src/ballot_package/test_utils.ts
@@ -30,6 +30,18 @@ export function createBallotPackageZipArchive(
       JSON.stringify(ballotPackage.uiStrings, null, 2)
     );
   }
+  if (ballotPackage.uiStringAudioIds) {
+    jsZip.file(
+      BallotPackageFileName.UI_STRING_AUDIO_IDS,
+      JSON.stringify(ballotPackage.uiStringAudioIds, null, 2)
+    );
+  }
+  if (ballotPackage.uiStringAudioClips) {
+    jsZip.file(
+      BallotPackageFileName.AUDIO_CLIPS,
+      JSON.stringify(ballotPackage.uiStringAudioClips, null, 2)
+    );
+  }
   return jsZip.generateAsync({ type: 'nodebuffer' });
 }
 

--- a/libs/backend/src/ui_strings/ui_strings_api.ts
+++ b/libs/backend/src/ui_strings/ui_strings_api.ts
@@ -25,9 +25,7 @@ export function createUiStringsApi(context: UiStringsApiContext): UiStringsApi {
     },
 
     getUiStringAudioIds(input) {
-      throw new Error(
-        `Not yet implemented. Requested language code: ${input.languageCode}`
-      );
+      return store.getUiStringAudioIds(input.languageCode);
     },
 
     getAudioClipsBase64(input) {

--- a/libs/backend/src/ui_strings/ui_strings_api_test_runner.ts
+++ b/libs/backend/src/ui_strings/ui_strings_api_test_runner.ts
@@ -50,10 +50,46 @@ export function runUiStringApiTests(params: {
     expect(api.getUiStrings({ languageCode: LanguageCode.SPANISH })).toBeNull();
   });
 
-  test('getUiStringAudioIds throws not-yet-implemented error', () => {
-    expect(() =>
+  test('getUiStringAudioIds', () => {
+    for (const languageCode of Object.values(LanguageCode)) {
+      expect(api.getUiStringAudioIds({ languageCode })).toBeNull();
+    }
+
+    store.addLanguage(LanguageCode.ENGLISH);
+    store.setUiStringAudioIds({
+      languageCode: LanguageCode.ENGLISH,
+      data: {
+        foo: ['123', 'abc'],
+        deeply: { nested: ['321', 'cba'] },
+      },
+    });
+
+    expect(
+      api.getUiStringAudioIds({ languageCode: LanguageCode.ENGLISH })
+    ).toEqual({
+      foo: ['123', 'abc'],
+      deeply: { nested: ['321', 'cba'] },
+    });
+
+    store.addLanguage(LanguageCode.CHINESE);
+    store.setUiStringAudioIds({
+      languageCode: LanguageCode.CHINESE,
+      data: {
+        foo: ['456', 'def'],
+        deeply: { nested: ['654', 'fed'] },
+      },
+    });
+
+    expect(
       api.getUiStringAudioIds({ languageCode: LanguageCode.CHINESE })
-    ).toThrow(/not yet implemented/i);
+    ).toEqual({
+      foo: ['456', 'def'],
+      deeply: { nested: ['654', 'fed'] },
+    });
+
+    expect(
+      api.getUiStringAudioIds({ languageCode: LanguageCode.SPANISH })
+    ).toBeNull();
   });
 
   test('getAudioClipsBase64 throws not-yet-implemented error', () => {

--- a/libs/backend/src/ui_strings/ui_strings_machine_configuration.ts
+++ b/libs/backend/src/ui_strings/ui_strings_machine_configuration.ts
@@ -28,14 +28,31 @@ function loadStrings(input: BallotPackageProcessorInput): void {
   }
 }
 
+function loadAudioIds(input: BallotPackageProcessorInput): void {
+  const { ballotPackage, store } = input;
+
+  if (!ballotPackage.uiStringAudioIds) {
+    return;
+  }
+
+  const configuredLanguages = store.getLanguages();
+  for (const languageCode of configuredLanguages) {
+    const data = ballotPackage.uiStringAudioIds[languageCode];
+
+    if (data) {
+      store.setUiStringAudioIds({ languageCode, data });
+    }
+  }
+}
+
 /**
  * Loads data related to UI Strings from the given ballot package into the
  * provided store.
  */
 export function configureUiStrings(input: BallotPackageProcessorInput): void {
   loadStrings(input);
+  loadAudioIds(input);
 
   // TODO(kofi):
-  //   loadAudioIds(input);
   //   loadAudioClips(input);
 }

--- a/libs/backend/src/ui_strings/ui_strings_machine_configuration_test_runner.ts
+++ b/libs/backend/src/ui_strings/ui_strings_machine_configuration_test_runner.ts
@@ -4,6 +4,7 @@ import {
   BallotPackage,
   ExtendedElectionDefinition,
   LanguageCode,
+  UiStringAudioIdsPackage,
   UiStringsPackage,
 } from '@votingworks/types';
 import { MockUsbDrive } from '@votingworks/usb-drive';
@@ -74,5 +75,38 @@ export function runUiStringMachineConfigurationTests(
       expectedElectionStrings[LanguageCode.ENGLISH]
     );
     expect(store.getUiStrings(LanguageCode.SPANISH)).toBeNull();
+  });
+
+  test('loads UI string audio IDs for configured languages', async () => {
+    const uiStrings: UiStringsPackage = {
+      [LanguageCode.ENGLISH]: { foo: 'bar' },
+      [LanguageCode.SPANISH]: { foo: 'bar_es' },
+    };
+
+    const uiStringAudioIds: UiStringAudioIdsPackage = {
+      [LanguageCode.ENGLISH]: { foo: ['123', 'abc'] },
+      [LanguageCode.SPANISH]: { foo: ['456', 'def'] },
+      [LanguageCode.CHINESE]: { foo: ['789', 'fff'] },
+    };
+
+    await doTestConfigure({ electionDefinition, uiStrings, uiStringAudioIds });
+
+    expect(store.getLanguages().sort()).toEqual(
+      [LanguageCode.ENGLISH, LanguageCode.SPANISH].sort()
+    );
+    expect(store.getUiStringAudioIds(LanguageCode.ENGLISH)).toEqual({
+      ...assertDefined(uiStringAudioIds[LanguageCode.ENGLISH]),
+    });
+    expect(store.getUiStringAudioIds(LanguageCode.SPANISH)).toEqual({
+      ...assertDefined(uiStringAudioIds[LanguageCode.SPANISH]),
+    });
+    expect(store.getUiStringAudioIds(LanguageCode.CHINESE)).toBeNull();
+  });
+
+  test('is a no-op for missing uiStringAudioIds package', async () => {
+    await doTestConfigure({ electionDefinition });
+
+    expect(store.getUiStringAudioIds(LanguageCode.ENGLISH)).toBeNull();
+    expect(store.getUiStringAudioIds(LanguageCode.SPANISH)).toBeNull();
   });
 }

--- a/libs/backend/src/ui_strings/ui_strings_machine_deconfiguration_test_runner.ts
+++ b/libs/backend/src/ui_strings/ui_strings_machine_deconfiguration_test_runner.ts
@@ -23,11 +23,16 @@ export function runUiStringMachineDeconfigurationTests(
       languageCode: LanguageCode.SPANISH,
       data: { foo: 'bar_es', deeply: { nested: 'value_es' } },
     });
+    store.setUiStringAudioIds({
+      languageCode: LanguageCode.ENGLISH,
+      data: { foo: ['123', 'abc'] },
+    });
 
     await runUnconfigureMachine();
 
     expect(store.getLanguages()).toEqual([]);
     expect(store.getUiStrings(LanguageCode.ENGLISH)).toBeNull();
     expect(store.getUiStrings(LanguageCode.SPANISH)).toBeNull();
+    expect(store.getUiStringAudioIds(LanguageCode.ENGLISH)).toBeNull();
   });
 }

--- a/libs/utils/src/ballot_package.ts
+++ b/libs/utils/src/ballot_package.ts
@@ -4,6 +4,8 @@ import {
   BallotPackage,
   BallotPackageFileName,
   DEFAULT_SYSTEM_SETTINGS,
+  UiStringAudioIdsPackage,
+  UiStringAudioIdsPackageSchema,
   UiStringsPackage,
   UiStringsPackageSchema,
   safeParseElectionDefinitionExtended,
@@ -72,13 +74,28 @@ export async function readBallotPackageFromBuffer(
     _.merge(uiStrings, electionStrings);
   }
 
-  // TODO(kofi): Load metadata, audio key, and audio clips from zip file.
+  // UI String Audio IDs:
+
+  let uiStringAudioIds: UiStringAudioIdsPackage | undefined;
+  const audioIdsEntry = maybeGetFileByName(
+    entries,
+    BallotPackageFileName.UI_STRING_AUDIO_IDS
+  );
+  if (audioIdsEntry) {
+    uiStringAudioIds = safeParseJson(
+      await readTextEntry(audioIdsEntry),
+      UiStringAudioIdsPackageSchema
+    ).unsafeUnwrap();
+  }
+
+  // TODO(kofi): Load metadata and audio clips from zip file.
   // TODO(kofi): Verify package version matches machine build version.
 
   return {
     electionDefinition,
     systemSettings: safeParseSystemSettings(systemSettingsData).unsafeUnwrap(),
     uiStrings,
+    uiStringAudioIds,
   };
 }
 


### PR DESCRIPTION
## Overview

_Related tech spec [here](https://docs.google.com/document/d/1a2GRj1g4aOawEssPdTCgbv-qs28d-M_dyMEfzm4I4nM/edit?usp=sharing)._

Piping data from the `uiStringAudioIds.json` ballot package file through to the app backend DB and exposing via the `getUiStringAudioIds()` API.

This file contains mappings from UI string keys to audio clip IDs for each supported language in a given election.

## Testing Plan
- Added test cases for parsing the file, loading it into the DB and fetching via the API.

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
