### PR TITLE
Switch status alerts from colored text to colored icons

### DIFF
--- a/apps/admin/frontend/src/components/import_cvrfiles_modal.tsx
+++ b/apps/admin/frontend/src/components/import_cvrfiles_modal.tsx
@@ -14,6 +14,7 @@ import {
   WithScrollButtons,
   P,
   Font,
+  Icons,
 } from '@votingworks/ui';
 import {
   format,
@@ -394,13 +395,13 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element | null {
           <td data-testid="cvr-count">{format.count(cvrCount)}</td>
           {!fileModeLocked && (
             <td>
-              <LabelText>
-                {isTestModeResults ? (
-                  <Font color="warning">Test</Font>
-                ) : (
-                  <Font color="success">Official</Font>
-                )}
-              </LabelText>
+              {isTestModeResults ? (
+                <LabelText>
+                  <Icons.Warning color="warning" /> Test
+                </LabelText>
+              ) : (
+                <LabelText>Official</LabelText>
+              )}
             </td>
           )}
           <TD textAlign="right">

--- a/apps/admin/frontend/src/components/smartcard_modal/status_message.tsx
+++ b/apps/admin/frontend/src/components/smartcard_modal/status_message.tsx
@@ -78,17 +78,15 @@ export function SuccessOrErrorStatusMessage({
     }
     return (
       <P>
-        <Font color="danger">
-          <Icons.Danger />
-        </Font>{' '}
-        {text} Please try again.
+        <Icons.Danger color="danger" /> {text} Please try again.
       </P>
     );
   }
 
   if (action === 'Program') {
     return (
-      <TextLarge color="success">
+      <TextLarge>
+        <Icons.Done color="success" />{' '}
         {newPin ? (
           <React.Fragment>
             New card PIN is <Font weight="bold">{hyphenatePin(newPin)}</Font>.
@@ -103,16 +101,18 @@ export function SuccessOrErrorStatusMessage({
   if (action === 'PinReset') {
     assert(newPin !== undefined);
     return (
-      <TextLarge color="success">
-        New card PIN is <Font weight="bold">{hyphenatePin(newPin)}</Font>.
+      <TextLarge>
+        <Icons.Done color="success" /> New card PIN is{' '}
+        <Font weight="bold">{hyphenatePin(newPin)}</Font>.
       </TextLarge>
     );
   }
 
   if (action === 'Unprogram') {
     return (
-      <P color="success">
-        {actionRoleReadableString} card has been unprogrammed.
+      <P>
+        <Icons.Done color="success" /> {actionRoleReadableString} card has been
+        unprogrammed.
       </P>
     );
   }

--- a/apps/admin/frontend/src/screens/manual_data_entry_screen.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_entry_screen.tsx
@@ -688,13 +688,9 @@ export function ManualDataEntryScreen(): JSX.Element {
                     {contestValidationState === 'no-results' ? (
                       <Icons.Info />
                     ) : contestValidationState === 'invalid' ? (
-                      <Font color="warning">
-                        <Icons.Warning />
-                      </Font>
+                      <Icons.Warning color="warning" />
                     ) : (
-                      <Font color="success">
-                        <Icons.Checkbox />
-                      </Font>
+                      <Icons.Checkbox color="success" />
                     )}
                   </TD>
                   <TD>

--- a/apps/admin/frontend/src/screens/unconfigured_screen.tsx
+++ b/apps/admin/frontend/src/screens/unconfigured_screen.tsx
@@ -268,10 +268,7 @@ export function UnconfiguredScreen(): JSX.Element {
           {inputConversionFiles.map((file) =>
             file.path ? (
               <P key={file.name}>
-                <Font color="success">
-                  <Icons.Checkbox />
-                </Font>{' '}
-                Loaded {file.name}
+                <Icons.Checkbox color="success" /> Loaded {file.name}
               </P>
             ) : (
               <P key={file.name}>
@@ -312,9 +309,7 @@ export function UnconfiguredScreen(): JSX.Element {
         <P>How would you like to start?</P>
         {configureError && (
           <P>
-            <Font color="danger">
-              <Icons.Danger />
-            </Font>{' '}
+            <Icons.Danger color="danger" />{' '}
             {(() => {
               switch (configureError.type) {
                 case 'invalidElection':

--- a/apps/central-scan/frontend/src/components/delete_batch_modal.tsx
+++ b/apps/central-scan/frontend/src/components/delete_batch_modal.tsx
@@ -1,4 +1,4 @@
-import { Button, Modal, P } from '@votingworks/ui';
+import { Button, Icons, Modal, P } from '@votingworks/ui';
 import React from 'react';
 import * as api from '../api';
 
@@ -30,7 +30,9 @@ export function DeleteBatchModal({
         <React.Fragment>
           <P>This action cannot be undone.</P>
           {deleteBatchMutation.error ? (
-            <P color="danger">{`${deleteBatchMutation.error}`}</P>
+            <P>
+              <Icons.Danger color="danger" /> {`${deleteBatchMutation.error}`}
+            </P>
           ) : null}
         </React.Fragment>
       }

--- a/apps/central-scan/frontend/src/screens/admin_actions_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/admin_actions_screen.tsx
@@ -4,7 +4,6 @@ import { assert } from '@votingworks/basics';
 import {
   Button,
   ExportLogsButtonRow,
-  Font,
   H1,
   Icons,
   LinkButton,
@@ -163,10 +162,10 @@ export function AdminActionsScreen({
               </Button>{' '}
             </ButtonRow>
             {!canUnconfigure && !isTestMode && (
-              <Font color="warning">
-                <Icons.Warning /> You must &quot;Save Backup&quot; before you
-                may delete election data.
-              </Font>
+              <P>
+                <Icons.Warning color="warning" /> You must &quot;Save
+                Backup&quot; before you may delete election data.
+              </P>
             )}
           </div>
         </Main>

--- a/apps/central-scan/frontend/src/screens/dashboard_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/dashboard_screen.tsx
@@ -65,7 +65,7 @@ export function DashboardScreen({ isScanning, status }: Props): JSX.Element {
                     <TD nowrap>{shortDateTime(batch.startedAt)}</TD>
                     <TD nowrap>
                       {isScanning && !batch.endedAt ? (
-                        <Font color="success" weight="bold">
+                        <Font weight="bold">
                           <Icons.Loading /> Scanning…
                         </Font>
                       ) : batch.endedAt ? (

--- a/apps/mark-scan/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/admin_screen.tsx
@@ -167,10 +167,7 @@ export function AdminScreen({
           </P>
           <H6 as="h2">Configuration</H6>
           <P>
-            <Font color="success">
-              <Icons.Checkbox />
-            </Font>{' '}
-            Election Definition is loaded.{' '}
+            <Icons.Checkbox color="success" /> Election Definition is loaded.
           </P>
           <Button variant="danger" icon="Delete" onPress={unconfigure}>
             Unconfigure Machine

--- a/apps/mark-scan/frontend/src/pages/diagnostics_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/diagnostics_screen.test.tsx
@@ -2,27 +2,22 @@ import userEvent from '@testing-library/user-event';
 import { fakeMarkerInfo } from '@votingworks/test-utils';
 import { MemoryHardware } from '@votingworks/utils';
 import { MemoryRouter } from 'react-router-dom';
+import { render, screen, waitFor } from '../../test/react_testing_library';
 import {
-  render,
-  screen,
-  waitFor,
-  within,
-} from '../../test/react_testing_library';
-import {
-  CHECKBOX_ICON_TEST_ID,
   DiagnosticsScreen,
   DiagnosticsScreenProps,
-  WARNING_ICON_TEST_ID,
 } from './diagnostics_screen';
 import { fakeDevices } from '../../test/helpers/fake_devices';
 import { AriaScreenReader } from '../utils/ScreenReader';
 import { fakeTts } from '../../test/helpers/fake_tts';
 
 function expectToHaveSuccessIcon(element: HTMLElement) {
-  within(element).getByTestId(CHECKBOX_ICON_TEST_ID);
+  const [icon] = element.getElementsByTagName('svg');
+  expect(icon).toHaveAttribute('data-icon', 'square-check');
 }
 function expectToHaveWarningIcon(element: HTMLElement) {
-  within(element).getByTestId(WARNING_ICON_TEST_ID);
+  const [icon] = element.getElementsByTagName('svg');
+  expect(icon).toHaveAttribute('data-icon', 'triangle-exclamation');
 }
 
 function renderScreen(props: Partial<DiagnosticsScreenProps> = {}) {

--- a/apps/mark-scan/frontend/src/pages/diagnostics_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/diagnostics_screen.tsx
@@ -12,7 +12,6 @@ import {
   useCancelablePromise,
   P,
   Caption,
-  Font,
   Icons,
 } from '@votingworks/ui';
 import { formatTime, Hardware } from '@votingworks/utils';
@@ -36,19 +35,9 @@ const ButtonAndTimestamp = styled.div`
   }
 `;
 
-export const CHECKBOX_ICON_TEST_ID = 'checkboxIcon';
-const CHECKBOX_ICON = (
-  <Font color="success" data-testid={CHECKBOX_ICON_TEST_ID}>
-    <Icons.Checkbox />
-  </Font>
-);
+const CHECKBOX_ICON = <Icons.Checkbox color="success" />;
 
-export const WARNING_ICON_TEST_ID = 'warningIcon';
-const WARNING_ICON = (
-  <Font color="warning" data-testid={WARNING_ICON_TEST_ID}>
-    <Icons.Warning />
-  </Font>
-);
+const WARNING_ICON = <Icons.Warning color="warning" />;
 
 interface ComputerStatusProps {
   computer: ComputerStatusType;

--- a/apps/mark-scan/frontend/src/pages/insert_card_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/insert_card_screen.tsx
@@ -78,10 +78,10 @@ export function InsertCardScreen({
       <Main centerChild>
         <Prose textCenter id="audiofocus">
           {showNoChargerAttachedWarning && (
-            <Caption color="warning">
-              <Icons.Warning /> <Font weight="bold">No Power Detected.</Font>{' '}
-              Please ask a poll worker to plug in the power cord for this
-              machine.
+            <Caption>
+              <Icons.Warning color="warning" />{' '}
+              <Font weight="bold">No Power Detected.</Font> Please ask a poll
+              worker to plug in the power cord for this machine.
             </Caption>
           )}
           <P>

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
@@ -294,8 +294,8 @@ export function PollWorkerScreen({
         <Screen white>
           <Main centerChild padded>
             <Prose id="audiofocus">
-              <FullScreenIconWrapper align="center" color="success">
-                <Icons.Done />
+              <FullScreenIconWrapper align="center">
+                <Icons.Done color="success" />
               </FullScreenIconWrapper>
               <H2 as="h1" align="center">
                 {`Voting Session Active: ${ballotStyleId} at ${precinct.name}`}

--- a/apps/mark-scan/frontend/src/pages/replace_election_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/replace_election_screen.tsx
@@ -82,8 +82,9 @@ export function ReplaceElectionScreen({
     <Screen>
       <Main padded centerChild>
         <Prose id="audiofocus">
-          <H1 color="danger">
-            <Icons.Danger /> This card is configured for a different election.
+          <H1>
+            <Icons.Danger color="danger" /> This card is configured for a
+            different election.
           </H1>
           <Table>
             <thead>

--- a/apps/mark/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.tsx
@@ -153,10 +153,7 @@ export function AdminScreen({
           </P>
           <H6 as="h2">Configuration</H6>
           <P>
-            <Font color="success">
-              <Icons.Checkbox />
-            </Font>{' '}
-            Election Definition is loaded.{' '}
+            <Icons.Checkbox color="success" /> Election Definition is loaded.
           </P>
           <Button variant="danger" icon="Delete" onPress={unconfigure}>
             Unconfigure Machine

--- a/apps/mark/frontend/src/pages/diagnostics_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/diagnostics_screen.test.tsx
@@ -2,27 +2,22 @@ import userEvent from '@testing-library/user-event';
 import { fakeMarkerInfo } from '@votingworks/test-utils';
 import { MemoryHardware } from '@votingworks/utils';
 import { MemoryRouter } from 'react-router-dom';
+import { render, screen, waitFor } from '../../test/react_testing_library';
 import {
-  render,
-  screen,
-  waitFor,
-  within,
-} from '../../test/react_testing_library';
-import {
-  CHECKBOX_ICON_TEST_ID,
   DiagnosticsScreen,
   DiagnosticsScreenProps,
-  WARNING_ICON_TEST_ID,
 } from './diagnostics_screen';
 import { fakeDevices } from '../../test/helpers/fake_devices';
 import { AriaScreenReader } from '../utils/ScreenReader';
 import { fakeTts } from '../../test/helpers/fake_tts';
 
 function expectToHaveSuccessIcon(element: HTMLElement) {
-  within(element).getByTestId(CHECKBOX_ICON_TEST_ID);
+  const [icon] = element.getElementsByTagName('svg');
+  expect(icon).toHaveAttribute('data-icon', 'square-check');
 }
 function expectToHaveWarningIcon(element: HTMLElement) {
-  within(element).getByTestId(WARNING_ICON_TEST_ID);
+  const [icon] = element.getElementsByTagName('svg');
+  expect(icon).toHaveAttribute('data-icon', 'triangle-exclamation');
 }
 
 function renderScreen(props: Partial<DiagnosticsScreenProps> = {}) {

--- a/apps/mark/frontend/src/pages/diagnostics_screen.tsx
+++ b/apps/mark/frontend/src/pages/diagnostics_screen.tsx
@@ -12,7 +12,6 @@ import {
   useCancelablePromise,
   P,
   Caption,
-  Font,
   Icons,
 } from '@votingworks/ui';
 import { formatTime, Hardware } from '@votingworks/utils';
@@ -36,19 +35,9 @@ const ButtonAndTimestamp = styled.div`
   }
 `;
 
-export const CHECKBOX_ICON_TEST_ID = 'checkboxIcon';
-const CHECKBOX_ICON = (
-  <Font color="success" data-testid={CHECKBOX_ICON_TEST_ID}>
-    <Icons.Checkbox />
-  </Font>
-);
+const CHECKBOX_ICON = <Icons.Checkbox color="success" />;
 
-export const WARNING_ICON_TEST_ID = 'warningIcon';
-const WARNING_ICON = (
-  <Font color="warning" data-testid={WARNING_ICON_TEST_ID}>
-    <Icons.Warning />
-  </Font>
-);
+const WARNING_ICON = <Icons.Warning color="warning" />;
 
 interface ComputerStatusProps {
   computer: ComputerStatusType;

--- a/apps/mark/frontend/src/pages/insert_card_screen.tsx
+++ b/apps/mark/frontend/src/pages/insert_card_screen.tsx
@@ -77,10 +77,10 @@ export function InsertCardScreen({
       <Main centerChild>
         <Prose textCenter id="audiofocus">
           {showNoChargerAttachedWarning && (
-            <Caption color="warning">
-              <Icons.Warning /> <Font weight="bold">No Power Detected.</Font>{' '}
-              Please ask a poll worker to plug in the power cord for this
-              machine.
+            <Caption>
+              <Icons.Warning color="warning" />{' '}
+              <Font weight="bold">No Power Detected.</Font> Please ask a poll
+              worker to plug in the power cord for this machine.
             </Caption>
           )}
           <P>

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -257,8 +257,8 @@ export function PollWorkerScreen({
       <Screen white>
         <Main centerChild padded>
           <Prose id="audiofocus">
-            <FullScreenIconWrapper align="center" color="success">
-              <Icons.Done />
+            <FullScreenIconWrapper align="center">
+              <Icons.Done color="success" />
             </FullScreenIconWrapper>
             <H2 as="h1" align="center">
               {`Voting Session Active: ${ballotStyleId} at ${precinct.name}`}

--- a/apps/mark/frontend/src/pages/replace_election_screen.tsx
+++ b/apps/mark/frontend/src/pages/replace_election_screen.tsx
@@ -75,8 +75,9 @@ export function ReplaceElectionScreen({
     <Screen>
       <Main padded centerChild>
         <Prose id="audiofocus">
-          <H1 color="danger">
-            <Icons.Danger /> This card is configured for a different election.
+          <H1>
+            <Icons.Danger color="danger" /> This card is configured for a
+            different election.
           </H1>
           <Table>
             <thead>

--- a/apps/scan/frontend/src/app.tsx
+++ b/apps/scan/frontend/src/app.tsx
@@ -63,8 +63,8 @@ export function App({
         <ErrorBoundary
           errorMessage={
             <React.Fragment>
-              <FullScreenIconWrapper color="danger">
-                <Icons.Delete />
+              <FullScreenIconWrapper>
+                <Icons.Delete color="danger" />
               </FullScreenIconWrapper>
               <CenteredLargeProse>
                 <H1>Something went wrong</H1>

--- a/apps/scan/frontend/src/components/replace_ballot_bag_screen.tsx
+++ b/apps/scan/frontend/src/components/replace_ballot_bag_screen.tsx
@@ -52,8 +52,8 @@ export function ReplaceBallotBagScreen({
         <FullScreenPromptLayout
           title="Ballot Bag Full"
           image={
-            <FullScreenIconWrapper color="warning">
-              <Icons.Warning />
+            <FullScreenIconWrapper>
+              <Icons.Warning color="warning" />
             </FullScreenIconWrapper>
           }
         >

--- a/apps/scan/frontend/src/screens/insert_ballot_screen.tsx
+++ b/apps/scan/frontend/src/screens/insert_ballot_screen.tsx
@@ -25,9 +25,10 @@ export function InsertBallotScreen({
       >
         <P>Scan one ballot sheet at a time.</P>
         {showNoChargerWarning && (
-          <Caption color="warning">
-            <Icons.Warning /> <Font weight="bold">No Power Detected.</Font>{' '}
-            Please ask a poll worker to plug in the power cord.
+          <Caption>
+            <Icons.Warning color="warning" />{' '}
+            <Font weight="bold">No Power Detected.</Font> Please ask a poll
+            worker to plug in the power cord.
           </Caption>
         )}
       </FullScreenPromptLayout>

--- a/apps/scan/frontend/src/screens/poll_worker_screen.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.tsx
@@ -77,8 +77,8 @@ const BallotsAlreadyScannedScreen = (
     <FullScreenPromptLayout
       title="Ballots Already Scanned"
       image={
-        <FullScreenIconWrapper color="danger">
-          <Icons.Delete />
+        <FullScreenIconWrapper>
+          <Icons.Delete color="danger" />
         </FullScreenIconWrapper>
       }
     >

--- a/apps/scan/frontend/src/screens/polls_not_open_screen.tsx
+++ b/apps/scan/frontend/src/screens/polls_not_open_screen.tsx
@@ -41,9 +41,10 @@ export function PollsNotOpenScreen({
           <P>Insert a poll worker card to open polls.</P>
         )}
         {showNoChargerWarning && (
-          <Caption color="warning">
-            <Icons.Warning /> <strong>No Power Detected.</strong> Please ask a
-            poll worker to plug in the power cord.
+          <Caption>
+            <Icons.Warning color="warning" />{' '}
+            <strong>No Power Detected.</strong> Please ask a poll worker to plug
+            in the power cord.
           </Caption>
         )}
       </FullScreenPromptLayout>

--- a/apps/scan/frontend/src/screens/scan_busy_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_busy_screen.tsx
@@ -8,8 +8,8 @@ export function ScanBusyScreen(): JSX.Element {
       <FullScreenPromptLayout
         title="Remove Your Ballot"
         image={
-          <FullScreenIconWrapper color="warning">
-            <Icons.Warning />
+          <FullScreenIconWrapper>
+            <Icons.Warning color="warning" />
           </FullScreenIconWrapper>
         }
       >

--- a/apps/scan/frontend/src/screens/scan_double_sheet_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_double_sheet_screen.tsx
@@ -14,8 +14,8 @@ export function ScanDoubleSheetScreen({
       <FullScreenPromptLayout
         title="Ballot Not Counted"
         image={
-          <FullScreenIconWrapper color="danger">
-            <Icons.Delete />
+          <FullScreenIconWrapper>
+            <Icons.Delete color="danger" />
           </FullScreenIconWrapper>
         }
       >

--- a/apps/scan/frontend/src/screens/scan_error_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_error_screen.tsx
@@ -62,8 +62,8 @@ export function ScanErrorScreen({
       <FullScreenPromptLayout
         title="Ballot Not Counted"
         image={
-          <FullScreenIconWrapper color="danger">
-            <Icons.Delete />
+          <FullScreenIconWrapper>
+            <Icons.Delete color="danger" />
           </FullScreenIconWrapper>
         }
       >

--- a/apps/scan/frontend/src/screens/scan_jam_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_jam_screen.tsx
@@ -12,8 +12,8 @@ export function ScanJamScreen({ scannedBallotCount }: Props): JSX.Element {
       <FullScreenPromptLayout
         title="Ballot Not Counted"
         image={
-          <FullScreenIconWrapper color="danger">
-            <Icons.Delete />
+          <FullScreenIconWrapper>
+            <Icons.Delete color="danger" />
           </FullScreenIconWrapper>
         }
       >

--- a/apps/scan/frontend/src/screens/scan_success_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_success_screen.tsx
@@ -13,8 +13,8 @@ export function ScanSuccessScreen({ scannedBallotCount }: Props): JSX.Element {
       <FullScreenPromptLayout
         title="Your ballot was counted!"
         image={
-          <FullScreenIconWrapper color="success">
-            <Icons.Done />
+          <FullScreenIconWrapper>
+            <Icons.Done color="success" />
           </FullScreenIconWrapper>
         }
       >

--- a/apps/scan/frontend/src/screens/scan_warning_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_warning_screen.tsx
@@ -11,7 +11,6 @@ import {
 import {
   Button,
   Caption,
-  Font,
   FullScreenIconWrapper,
   Icons,
   Modal,
@@ -137,10 +136,7 @@ function MisvoteWarningScreen({
       <FullScreenPromptLayout
         title={
           <React.Fragment>
-            <Font color="warning">
-              <Icons.Warning />
-            </Font>{' '}
-            Review Your Ballot
+            <Icons.Warning color="warning" /> Review Your Ballot
           </React.Fragment>
         }
         actionButtons={
@@ -194,8 +190,8 @@ function BlankBallotWarningScreen(): JSX.Element {
       <FullScreenPromptLayout
         title="Review Your Ballot"
         image={
-          <FullScreenIconWrapper color="warning">
-            <Icons.Warning />
+          <FullScreenIconWrapper>
+            <Icons.Warning color="warning" />
           </FullScreenIconWrapper>
         }
         actionButtons={
@@ -239,8 +235,8 @@ function OtherReasonWarningScreen(): JSX.Element {
       <FullScreenPromptLayout
         title="Scanning Failed"
         image={
-          <FullScreenIconWrapper color="warning">
-            <Icons.Warning />
+          <FullScreenIconWrapper>
+            <Icons.Warning color="warning" />
           </FullScreenIconWrapper>
         }
         actionButtons={

--- a/libs/mark-flow-ui/src/components/candidate_contest.tsx
+++ b/libs/mark-flow-ui/src/components/candidate_contest.tsx
@@ -391,12 +391,11 @@ export function CandidateContest({
               <WriteInModalBody>
                 <WriteInForm>
                   <TouchTextInput value={writeInCandidateName} />
-                  <P
-                    align="right"
-                    color={writeInCharsRemaining ? 'default' : 'warning'}
-                  >
+                  <P align="right">
                     <Caption>
-                      {writeInCharsRemaining === 0 && <Icons.Warning />}{' '}
+                      {writeInCharsRemaining === 0 && (
+                        <Icons.Warning color="warning" />
+                      )}{' '}
                       {writeInCharsRemaining}{' '}
                       {pluralize('character', writeInCharsRemaining)} remaining
                     </Caption>

--- a/libs/ui/src/change_precinct_button.tsx
+++ b/libs/ui/src/change_precinct_button.tsx
@@ -160,12 +160,11 @@ export function ChangePrecinctButton({
             <Prose>
               <H1>Change Precinct</H1>
               <P>
-                <Font color="warning" weight="bold">
-                  <Icons.Warning /> WARNING:
-                </Font>{' '}
-                The polls are open on this machine. Changing the precinct will
-                reset the polls to closed. To resume voting, the polls must be
-                opened again. Please select a precinct and confirm below.
+                <Icons.Warning color="warning" />{' '}
+                <Font weight="bold">WARNING:</Font> The polls are open on this
+                machine. Changing the precinct will reset the polls to closed.
+                To resume voting, the polls must be opened again. Please select
+                a precinct and confirm below.
               </P>
               <Prose textCenter>{precinctSelectDropdown}</Prose>
             </Prose>

--- a/libs/ui/src/icons.stories.tsx
+++ b/libs/ui/src/icons.stories.tsx
@@ -1,11 +1,20 @@
 import { Meta } from '@storybook/react';
 import styled from 'styled-components';
 
-import { Icons } from './icons';
+import { ICON_COLORS, IconComponent, IconProps, Icons } from './icons';
 import { H1, H5, P } from './typography';
 
-const meta: Meta = {
+const meta: Meta<IconComponent> = {
   title: 'libs-ui/Icons',
+  args: {
+    color: 'default',
+  },
+  argTypes: {
+    color: {
+      type: 'select',
+      options: [undefined, ...ICON_COLORS],
+    },
+  },
 };
 export default meta;
 
@@ -16,35 +25,29 @@ const StyledCodeBlock = styled.code`
 
 const sampleCode = `import {Icons} from "@votingworks/ui";
 
-<P color="warning">
-  <Icons.Warning /> You have been warned.
-</P>
+<Icons.Warning color="warning" /> You have been warned.
 `;
 
-function renderIcon([name, Component]: [string, () => JSX.Element]) {
-  if (typeof Component !== 'function') {
-    return null;
-  }
-
-  return (
-    <P key={name}>
-      <Component /> &mdash; {name}
-    </P>
-  );
-}
-
-export function icons(): JSX.Element {
+export function icons(props: IconProps): JSX.Element {
   return (
     <div>
       <H1>Icons</H1>
       <H5 as="h2">Usage:</H5>
       <StyledCodeBlock>{sampleCode}</StyledCodeBlock>
       <br />
-      <P color="warning">
-        <Icons.Warning /> You have been warned.
+      <P>
+        <Icons.Warning color="warning" /> You have been warned.
       </P>
       <H5 as="h2">Icon List:</H5>
-      {Object.entries(Icons).map(renderIcon)}
+      {Object.entries(Icons)
+        .filter(([, Icon]) => typeof Icon === 'function')
+        .map(([name, Icon]) => {
+          return (
+            <P key={name}>
+              <Icon {...props} /> &mdash; {name}
+            </P>
+          );
+        })}
     </div>
   );
 }

--- a/libs/ui/src/icons.test.tsx
+++ b/libs/ui/src/icons.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '../test/react_testing_library';
 
-import { FullScreenIconWrapper, Icons } from './icons';
+import { FullScreenIconWrapper, IconColor, Icons } from './icons';
+import { makeTheme } from './themes/make_theme';
 
 for (const [name, Component] of Object.entries(Icons)) {
   if (typeof Component !== 'function') {
@@ -13,6 +14,27 @@ for (const [name, Component] of Object.entries(Icons)) {
     screen.getByRole('img', { hidden: true });
   });
 }
+
+test(`Icon renders with color`, () => {
+  const theme = makeTheme({ colorMode: 'desktop' });
+  const expectedColors: Record<IconColor, string> = {
+    neutral: theme.colors.onBackground,
+    primary: theme.colors.primary,
+    success: theme.colors.successAccent,
+    warning: theme.colors.warningAccent,
+    danger: theme.colors.dangerAccent,
+  };
+
+  for (const [color, expectedColor] of Object.entries(expectedColors)) {
+    const { unmount } = render(<Icons.Add color={color as IconColor} />, {
+      vxTheme: theme,
+    });
+    expect(screen.getByRole('img', { hidden: true })).toHaveStyle(
+      `color: ${expectedColor};`
+    );
+    unmount();
+  }
+});
 
 test('FullScreenIconWrapper renders child icon - portrait screen', () => {
   global.innerHeight = 1920;

--- a/libs/ui/src/icons.test.tsx
+++ b/libs/ui/src/icons.test.tsx
@@ -55,7 +55,7 @@ test('FullScreenIconWrapper renders child icon - landscape screen', () => {
   global.innerWidth = 1920;
 
   render(
-    <FullScreenIconWrapper color="danger">
+    <FullScreenIconWrapper>
       <Icons.Info />
     </FullScreenIconWrapper>
   );

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
@@ -39,10 +39,28 @@ import {
   faCircleDot,
 } from '@fortawesome/free-regular-svg-icons';
 
+import { UiTheme } from '@votingworks/types';
 import { Font, FontProps } from './typography';
 import { ScreenInfo, useScreenInfo } from './hooks/use_screen_info';
 
-interface InnerProps {
+export const ICON_COLORS = [
+  'neutral',
+  'primary',
+  'success',
+  'warning',
+  'danger',
+] as const;
+
+export type IconColor = (typeof ICON_COLORS)[number];
+
+export interface IconProps {
+  color?: IconColor;
+  style?: React.CSSProperties;
+}
+
+export type IconComponent = (props: IconProps) => JSX.Element;
+
+interface InnerProps extends IconProps {
   pulse?: boolean;
   spin?: boolean;
   type: IconDefinition;
@@ -54,10 +72,36 @@ const StyledSvgIcon = styled.svg`
   width: 1em;
 `;
 
-function FaIcon(props: InnerProps): JSX.Element {
-  const { pulse, spin, type } = props;
+function iconColor(theme: UiTheme, color?: IconColor) {
+  if (!color) {
+    return undefined;
+  }
+  const { colors } = theme;
+  return {
+    neutral: colors.onBackground,
+    primary: colors.primary,
+    success: colors.successAccent,
+    warning: colors.warningAccent,
+    danger: colors.dangerAccent,
+    default: undefined,
+  }[color];
+}
 
-  return <FontAwesomeIcon icon={type} spin={spin} pulse={pulse} />;
+function FaIcon(props: InnerProps): JSX.Element {
+  const { pulse, spin, type, color, style = {} } = props;
+  const theme = useTheme();
+
+  return (
+    <FontAwesomeIcon
+      icon={type}
+      spin={spin}
+      pulse={pulse}
+      style={{
+        color: iconColor(theme, color),
+        ...style,
+      }}
+    />
+  );
 }
 
 /**
@@ -66,31 +110,33 @@ function FaIcon(props: InnerProps): JSX.Element {
  * colors.
  */
 export const Icons = {
-  Add() {
-    return <FaIcon type={faCirclePlus} />;
+  Add(props) {
+    return <FaIcon {...props} type={faCirclePlus} />;
   },
 
-  Backspace() {
-    return <FaIcon type={faDeleteLeft} />;
+  Backspace(props) {
+    return <FaIcon {...props} type={faDeleteLeft} />;
   },
 
-  CaretDown() {
-    return <FaIcon type={faCaretDown} />;
+  CaretDown(props) {
+    return <FaIcon {...props} type={faCaretDown} />;
   },
 
-  Circle() {
-    return <FaIcon type={faCircle} />;
+  Circle(props) {
+    return <FaIcon {...props} type={faCircle} />;
   },
 
-  CircleDot() {
-    return <FaIcon type={faCircleDot} />;
+  CircleDot(props) {
+    return <FaIcon {...props} type={faCircleDot} />;
   },
 
-  Checkbox() {
-    return <FaIcon type={faCheckSquare} />;
+  Checkbox(props) {
+    return <FaIcon {...props} type={faCheckSquare} />;
   },
 
-  Checkmark() {
+  Checkmark(props) {
+    const { color, style = {} } = props;
+    const theme = useTheme();
     return (
       <StyledSvgIcon
         aria-hidden="true"
@@ -98,120 +144,124 @@ export const Icons = {
         width="100"
         height="100"
         viewBox="0 0 100 100"
+        style={{
+          color: iconColor(theme, color),
+          ...style,
+        }}
       >
         <path d="M89.7038 10.1045C88.2094 8.40006 85.759 8.40006 84.2646 10.1045L39.0198 61.5065L15.719 34.8471C14.2245 33.1364 11.7906 33.1364 10.2852 34.8471L2.12082 44.1186C0.626395 45.8105 0.626395 48.5951 2.12082 50.2996L36.2782 89.3708C37.7727 91.0628 40.2066 91.0628 41.7175 89.3708L97.8627 25.5632C99.3791 23.8587 99.3791 21.0679 97.8627 19.3572L89.7038 10.1045Z" />
       </StyledSvgIcon>
     );
   },
 
-  Closed() {
-    return <FaIcon type={faMinusCircle} />;
+  Closed(props) {
+    return <FaIcon {...props} type={faMinusCircle} />;
   },
 
-  Contrast() {
-    return <FaIcon type={faCircleHalfStroke} />;
+  Contrast(props) {
+    return <FaIcon {...props} type={faCircleHalfStroke} />;
   },
 
-  Danger() {
-    return <FaIcon type={faExclamationCircle} />;
+  Danger(props) {
+    return <FaIcon {...props} type={faExclamationCircle} />;
   },
 
-  Delete() {
-    return <FaIcon type={faXmarkCircle} />;
+  Delete(props) {
+    return <FaIcon {...props} type={faXmarkCircle} />;
   },
 
-  Disabled() {
-    return <FaIcon type={faBan} />;
+  Disabled(props) {
+    return <FaIcon {...props} type={faBan} />;
   },
 
-  Display() {
-    return <FaIcon type={faDisplay} />;
+  Display(props) {
+    return <FaIcon {...props} type={faDisplay} />;
   },
 
-  Done() {
-    return <FaIcon type={faCheckCircle} />;
+  Done(props) {
+    return <FaIcon {...props} type={faCheckCircle} />;
   },
 
-  DownChevron() {
-    return <FaIcon type={faChevronCircleDown} />;
+  DownChevron(props) {
+    return <FaIcon {...props} type={faChevronCircleDown} />;
   },
 
-  Edit() {
-    return <FaIcon type={faPencil} />;
+  Edit(props) {
+    return <FaIcon {...props} type={faPencil} />;
   },
 
-  Info() {
-    return <FaIcon type={faInfoCircle} />;
+  Info(props) {
+    return <FaIcon {...props} type={faInfoCircle} />;
   },
 
-  Loading() {
-    return <FaIcon type={faSpinner} pulse spin />;
+  Loading(props) {
+    return <FaIcon {...props} type={faSpinner} pulse spin />;
   },
 
-  Next() {
-    return <FaIcon type={faCircleRight} />;
+  Next(props) {
+    return <FaIcon {...props} type={faCircleRight} />;
   },
 
-  Paused() {
-    return <FaIcon type={faPauseCircle} />;
+  Paused(props) {
+    return <FaIcon {...props} type={faPauseCircle} />;
   },
 
-  Previous() {
-    return <FaIcon type={faCircleLeft} />;
+  Previous(props) {
+    return <FaIcon {...props} type={faCircleLeft} />;
   },
 
-  Question() {
-    return <FaIcon type={faCircleQuestion} />;
+  Question(props) {
+    return <FaIcon {...props} type={faCircleQuestion} />;
   },
 
-  RightChevron() {
-    return <FaIcon type={faChevronRight} />;
+  RightChevron(props) {
+    return <FaIcon {...props} type={faChevronRight} />;
   },
 
-  LeftChevron() {
-    return <FaIcon type={faChevronLeft} />;
+  LeftChevron(props) {
+    return <FaIcon {...props} type={faChevronLeft} />;
   },
 
-  RotateRight() {
-    return <FaIcon type={faRotateRight} />;
+  RotateRight(props) {
+    return <FaIcon {...props} type={faRotateRight} />;
   },
 
-  Save() {
-    return <FaIcon type={faFloppyDisk} />;
+  Save(props) {
+    return <FaIcon {...props} type={faFloppyDisk} />;
   },
 
-  Square() {
-    return <FaIcon type={faSquare} />;
+  Square(props) {
+    return <FaIcon {...props} type={faSquare} />;
   },
 
-  Settings() {
-    return <FaIcon type={faGear} />;
+  Settings(props) {
+    return <FaIcon {...props} type={faGear} />;
   },
 
-  TextSize() {
-    return <FaIcon type={faTextHeight} />;
+  TextSize(props) {
+    return <FaIcon {...props} type={faTextHeight} />;
   },
 
-  UpChevron() {
-    return <FaIcon type={faChevronCircleUp} />;
+  UpChevron(props) {
+    return <FaIcon {...props} type={faChevronCircleUp} />;
   },
 
-  Warning() {
-    return <FaIcon type={faExclamationTriangle} />;
+  Warning(props) {
+    return <FaIcon {...props} type={faExclamationTriangle} />;
   },
 
-  X() {
-    return <FaIcon type={faXmark} />;
+  X(props) {
+    return <FaIcon {...props} type={faXmark} />;
   },
 
-  ZoomIn() {
-    return <FaIcon type={faMagnifyingGlassPlus} />;
+  ZoomIn(props) {
+    return <FaIcon {...props} type={faMagnifyingGlassPlus} />;
   },
 
-  ZoomOut() {
-    return <FaIcon type={faMagnifyingGlassMinus} />;
+  ZoomOut(props) {
+    return <FaIcon {...props} type={faMagnifyingGlassMinus} />;
   },
-} satisfies Record<string, () => JSX.Element>;
+} satisfies Record<string, IconComponent>;
 
 export type IconName = keyof typeof Icons;
 

--- a/libs/ui/src/set_clock.tsx
+++ b/libs/ui/src/set_clock.tsx
@@ -16,7 +16,7 @@ import { Modal } from './modal';
 import { InputGroup } from './input_group';
 import { Button, ButtonProps } from './button';
 import { useNow } from './hooks/use_now';
-import { Font, H1, P } from './typography';
+import { H1, P } from './typography';
 import { Icons } from './icons';
 
 export const MIN_YEAR = 2020;
@@ -266,10 +266,8 @@ export function PickDateTimeModal({
               </InputGroup>
             </P>
             <P>
-              <Font color="warning">
-                <Icons.Warning />
-              </Font>{' '}
-              You will have to reauthenticate after changing the clock.
+              <Icons.Warning color="warning" /> You will have to reauthenticate
+              after changing the clock.
             </P>
           </div>
         </Prose>

--- a/libs/ui/src/themes/render_with_themes.test.tsx
+++ b/libs/ui/src/themes/render_with_themes.test.tsx
@@ -9,6 +9,7 @@ import {
 import { H1, P } from '../typography';
 import { makeTheme } from './make_theme';
 import { Button } from '../button';
+import { Icons } from '../icons';
 
 test('renders theme-dependent component successfully', () => {
   suppressingConsoleOutput(() =>
@@ -38,15 +39,15 @@ test('renders with specified theme settings', () => {
     sizeMode: 'touchExtraLarge',
   });
 
-  const { getByText } = renderWithThemes(<P color="warning">Warning text</P>, {
+  const { getByRole } = renderWithThemes(<Icons.Add color="warning" />, {
     vxTheme: {
       colorMode: 'contrastLow',
       sizeMode: 'touchExtraLarge',
     },
   });
 
-  expect(getByText('Warning text')).toHaveStyle({
-    color: lowContrastTheme.colors.accentWarning,
+  expect(getByRole('img', { hidden: true })).toHaveStyle({
+    color: lowContrastTheme.colors.warningAccent,
   });
 });
 

--- a/libs/ui/src/typography.stories.tsx
+++ b/libs/ui/src/typography.stories.tsx
@@ -54,22 +54,6 @@ export function Typography(props: FontProps): JSX.Element {
         <Font weight="light">de-emphasized</Font> via the `weight` prop and/or{' '}
         <Font italic>emphasized</Font> via the `italic` prop.
       </P>
-      <P {...props} weight="regular">
-        P. The `color` prop also allows for accent coloring for scenarios such
-        as{' '}
-        <Font color="danger" weight="semiBold">
-          error messaging
-        </Font>
-        ,{' '}
-        <Font color="warning" weight="semiBold">
-          warning text
-        </Font>
-        , or{' '}
-        <Font color="success" weight="semiBold">
-          success notifications
-        </Font>
-        .
-      </P>
       <Caption {...props}>
         Caption. The Caption component may be used for smaller secondary text
         and footnotes.

--- a/libs/ui/src/typography.test.tsx
+++ b/libs/ui/src/typography.test.tsx
@@ -112,37 +112,3 @@ for (const Heading of [H1, H2, H3, H4, H5, H6]) {
     });
   });
 }
-
-for (const Component of [Caption, Font, P, Pre, H1, H2, H3, H4, H5, H6]) {
-  test(`renders colored <${Component.name}>`, () => {
-    const theme = makeTheme({
-      colorMode: 'contrastMedium',
-      sizeMode: 'touchLarge',
-    });
-    render(
-      <React.Fragment>
-        <Component color="danger">danger color text</Component>
-        <Component color="default">default color text</Component>
-        <Component color="success">success color text</Component>
-        <Component color="warning">warning color text</Component>
-      </React.Fragment>,
-      { vxTheme: { colorMode: 'contrastMedium', sizeMode: 'touchLarge' } }
-    );
-
-    expect(screen.getByText('danger color text')).toHaveStyle({
-      color: theme.colors.accentDanger,
-    });
-
-    expect(screen.getByText('default color text')).toHaveStyle({
-      color: theme.colors.foreground,
-    });
-
-    expect(screen.getByText('success color text')).toHaveStyle({
-      color: theme.colors.accentSuccess,
-    });
-
-    expect(screen.getByText('warning color text')).toHaveStyle({
-      color: theme.colors.accentWarning,
-    });
-  });
-}

--- a/libs/ui/src/typography.tsx
+++ b/libs/ui/src/typography.tsx
@@ -2,10 +2,9 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 import DomPurify from 'dompurify';
 
-import { ColorString, ColorTheme, SizeTheme } from '@votingworks/types';
+import { SizeTheme } from '@votingworks/types';
 
 type Align = 'left' | 'center' | 'right';
-type AccentColor = 'danger' | 'default' | 'success' | 'warning';
 type HeadingType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
 /** Props for {@link Font}, {@link P}, and {@link Caption}. */
@@ -14,7 +13,6 @@ export interface FontProps {
   align?: Align;
   children?: React.ReactNode;
   className?: string;
-  color?: AccentColor;
   id?: string;
   italic?: boolean;
   noWrap?: boolean;
@@ -40,21 +38,7 @@ export type HeadingProps = Omit<FontProps, 'weight'> & {
   as?: HeadingType;
 };
 
-function getColor(color: AccentColor, colorTheme: ColorTheme): ColorString {
-  // Doing this instead of using a switch-case to avoid having to get test
-  // coverage over the default switch case:
-  const fontColors: Record<AccentColor, ColorString> = {
-    danger: colorTheme.accentDanger,
-    default: colorTheme.foreground,
-    success: colorTheme.accentSuccess,
-    warning: colorTheme.accentWarning,
-  };
-
-  return fontColors[color];
-}
-
 const fontStyles = css<FontProps>`
-  color: ${(p) => p.color && getColor(p.color, p.theme.colors)};
   font-size: 1em;
   font-style: ${(p) => (p.italic ? 'italic' : undefined)};
   font-weight: ${(p) =>

--- a/libs/ui/src/unlock_machine_screen.tsx
+++ b/libs/ui/src/unlock_machine_screen.tsx
@@ -92,22 +92,22 @@ export function UnlockMachineScreen({
   let primarySentence: JSX.Element = <P>Enter the card PIN to unlock.</P>;
   if (auth.error) {
     primarySentence = (
-      <P color="danger">
-        <Icons.Danger /> Error checking PIN. Please try again.
+      <P>
+        <Icons.Danger color="danger" /> Error checking PIN. Please try again.
       </P>
     );
   } else if (isLockedOut) {
     assert(auth.lockedOutUntil !== undefined);
     primarySentence = (
-      <P color="warning">
-        <Icons.Warning /> Card locked. Please try again in{' '}
+      <P>
+        <Icons.Warning color="warning" /> Card locked. Please try again in{' '}
         <Timer countDownTo={new Date(auth.lockedOutUntil)} />
       </P>
     );
   } else if (auth.wrongPinEnteredAt) {
     primarySentence = (
-      <P color="warning">
-        <Icons.Warning /> Incorrect PIN. Please try again.
+      <P>
+        <Icons.Warning color="warning" /> Incorrect PIN. Please try again.
       </P>
     );
   }

--- a/libs/ui/src/voter_contest_summary.tsx
+++ b/libs/ui/src/voter_contest_summary.tsx
@@ -63,16 +63,16 @@ export function VoterContestSummary(
         {title}
       </H5>
       {undervoteWarning && (
-        <P color="warning">
+        <P>
           <Caption>
-            <Icons.Warning /> {undervoteWarning}
+            <Icons.Warning color="warning" /> {undervoteWarning}
           </Caption>
         </P>
       )}
       <ListContainer>
         {votes.map((v) => (
           <VoteInfo key={v.id}>
-            <CheckboxContainer color="success">
+            <CheckboxContainer>
               <Checkbox checked />
             </CheckboxContainer>
             <span>


### PR DESCRIPTION
## Overview

In the new desktop theme, our accent colors for status alerts (success/warning/danger) only meet the [3:1 contrast ratio minimum](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast), which is only permitted for icons/graphical elements, not text. I did it this way in order to have a bright yellow/orange color for warnings that isn't super dark and weird looking. Thus, we can't have text with these colors.

I think this is a fine constraint, because we rarely use colored text, and it's still effective to have a colored icon to grab attention accompanied by text with the default text color.

To implement this new approach, this PR:
- Adds a `color` prop to the `Icon` components
- Removes the `color` prop from the `Font` components
- Updates all the status message use cases accordingly

_Review by commit_

## Demo Video or Screenshot
A few sample changes from VxMark
Before
<img width="376" alt="Screenshot 2023-11-01 at 10 12 17 AM" src="https://github.com/votingworks/vxsuite/assets/530106/5ec38bee-9628-4a61-b696-286d352582dc">
After
<img width="403" alt="Screenshot 2023-11-01 at 10 21 55 AM" src="https://github.com/votingworks/vxsuite/assets/530106/6ff92ead-1835-4db8-99e4-2383dc67b114">

Before
<img width="382" alt="Screenshot 2023-11-01 at 10 13 48 AM" src="https://github.com/votingworks/vxsuite/assets/530106/9b2c227b-ffe5-435c-94af-e41e4c32b206">
After
<img width="387" alt="Screenshot 2023-11-01 at 10 21 09 AM" src="https://github.com/votingworks/vxsuite/assets/530106/fc307427-1a22-473a-b341-46d6b8a5bfd4">



## Testing Plan
- Automated tests
- Visual inspection of most of the changes to make sure they are still legible

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
