### PR TITLE
Avoid completely mocking safeParseJson in artifact authentication tests

### DIFF
--- a/libs/auth/README.md
+++ b/libs/auth/README.md
@@ -170,13 +170,14 @@ The following command generates keys and certs for tests:
 
 ### Common Access Card (CAC) Certificate Retrieval Script
 
-This script gets a CAC certificate from a CAC card. It's meant to be used for
+This script gets a Common Access Card's certificate. It's meant to be used for
 development and testing.
 
 ```
-./scripts/get-cac-cert
+# With a card reader connected and a Common Access Card in the card reader
+./scripts/cac-get-cert
 ```
 
-Prints the certificate in PEM format to stdout by default. Use the `--output`
-option to write the certificate to a file, or the `--json` option to print the
-certificate metadata in JSON format.
+The script prints the certificate to stdout in PEM format by default. Use the
+`--output` option to write the certificate to a file, or the `--json` option to
+print the certificate metadata in JSON format.


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/4100

I'd previously mocked `safeParseJson` in artifact authentication tests to avoid having to prepare a complete `CastVoteRecordExportMetadata` object. But my original mock of `safeParseJson` was incorrect and masked a bug (the mock expected an object, but the real `safeParseJson` expects a string) . The mock has since been fixed, but this PR takes things one step further to prevent future mistakes and mocks the `CastVoteRecordExportMetadata` Zod schema instead.