### PR TITLE
Bugfix: Fix VxMark review screen Change button

### DIFF
--- a/libs/mark-flow-ui/src/components/review.test.tsx
+++ b/libs/mark-flow-ui/src/components/review.test.tsx
@@ -116,8 +116,10 @@ describe('yesno contest', () => {
           returnToContest={returnToContest}
         />
       );
-      screen.getByText(contest.title);
-      screen.getByText(
+      const contestCard = screen
+        .getByText(contest.title)
+        .closest('div[role="button"]') as HTMLElement;
+      within(contestCard).getByText(
         !vote
           ? 'You may still vote in this contest.'
           : vote === contest.yesOption.id
@@ -125,7 +127,7 @@ describe('yesno contest', () => {
           : 'No'
       );
 
-      userEvent.click(screen.getByText('Change'));
+      userEvent.click(within(contestCard).getButton(/Change/));
       expect(returnToContest).toHaveBeenCalledWith(contest.id);
     }
   );

--- a/libs/mark-flow-ui/src/components/review.tsx
+++ b/libs/mark-flow-ui/src/components/review.tsx
@@ -8,6 +8,7 @@ import {
   VotesDict,
   PrecinctId,
   getContestDistrict,
+  ContestId,
 } from '@votingworks/types';
 import {
   Caption,
@@ -187,24 +188,26 @@ export function Review({
   returnToContest,
   selectionsAreEditable = true,
 }: ReviewProps): JSX.Element {
+  function onChangeClick(contestId: ContestId) {
+    if (!returnToContest) {
+      return;
+    }
+    returnToContest(contestId);
+  }
+
   return (
     <React.Fragment>
       {contests.map((contest) => (
         <Contest
           id={`contest-${contest.id}`}
           key={contest.id}
-          onClick={() => {
-            if (!returnToContest) {
-              return;
-            }
-            returnToContest(contest.id);
-          }}
+          onClick={() => onChangeClick(contest.id)}
         >
           <Card
             footerAlign={selectionsAreEditable ? 'right' : undefined}
             footer={
               selectionsAreEditable && (
-                <Button tabIndex={-1} onPress={() => {}}>
+                <Button tabIndex={-1} onPress={() => onChangeClick(contest.id)}>
                   <Caption>
                     {/*
                      * TODO(kofi): Add a <NoAudio> wrapper component for

--- a/libs/mark-flow-ui/src/components/review.tsx
+++ b/libs/mark-flow-ui/src/components/review.tsx
@@ -32,7 +32,7 @@ import {
 
 import { ContestsWithMsEitherNeither } from '../utils/ms_either_neither_contests';
 
-const Contest = styled.button`
+const Contest = styled.div`
   display: block;
   margin: 0 0 0.75rem;
   border: none;
@@ -199,6 +199,8 @@ export function Review({
     <React.Fragment>
       {contests.map((contest) => (
         <Contest
+          tabIndex={0}
+          role="button"
           id={`contest-${contest.id}`}
           key={contest.id}
           onClick={() => onChangeClick(contest.id)}


### PR DESCRIPTION
## Overview

This got broken in a rebase as identified here: https://github.com/votingworks/vxsuite/pull/4144#discussion_r1377166409. I also fixed the DOM nesting warning for nested buttons while I was at it.

## Demo Video or Screenshot

## Testing Plan
For some reason that I couldn't figure out, the automated test passes even with this bug. It seems like the onPress event from the Change button bubbles up successfully in the test DOM, but not in the actual DOM. I couldn't figure out any way to make the test fail, so I gave up.

Instead, manually tested and confirmed that the tabbing/screen reader still works.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
