### PR TITLE
make row striping darker for print

### DIFF
--- a/libs/ui/src/reports/ballot_count_report.tsx
+++ b/libs/ui/src/reports/ballot_count_report.tsx
@@ -116,6 +116,10 @@ const BallotCountGrid = styled.div<{
     for (let i = 1; i <= numColumns; i += 1) {
       css += `span:nth-child(${2 * numColumns}n + ${i}) { 
         background-color: #f5f5f5;
+
+        @media print {
+          background-color: #e8e8e8;
+        }
        }`;
     }
     return css;


### PR DESCRIPTION
## Overview

Would close #4021.

The ballot count reports are row striped for readability. But on print, the rows show up a lot lighter than in digital documents. Or it's possible it's due the screen I use in development.

Anyway, here I make the rows darker for print, which doesn't affect the previews but does affect the printed and exported PDFs. 

It is worth noting that the architecture we want is where a PDF is generated on the backend and that is what is shown to the frontend, so there's no difference between printed and previewed styles... but I'll worry about that once we get there. Setting the shading to the midpoint of these two colors would have also been fine, if not quite as tuned.

## Demo Video or Screenshot

#### Preview (looks fine)
<img width="818" alt="Screen Shot 2023-11-01 at 4 21 42 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/f5b8f913-53bf-434c-ac6f-0a764ee6f3ae">


#### Print Before
![IMG_8836](https://github.com/votingworks/vxsuite/assets/37960853/d2bb815f-e6d0-4807-b839-072785c7ea01)

#### Print After
![IMG_8837](https://github.com/votingworks/vxsuite/assets/37960853/dd03da6d-1668-4985-8ce4-60cbe5a27e7f)

#### PDF Export Before
<img width="1067" alt="Screen Shot 2023-11-01 at 4 22 13 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/6f6acdeb-cb79-4f5a-9a22-ea4eee022a77">

#### PDF Export After
<img width="1054" alt="Screen Shot 2023-11-01 at 4 22 24 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/faacd720-ab89-4f6a-a8e2-bec931724812">
