### PR TITLE
[i18n/Audio] Replace BMD contest page strings with language-aware <UiString>s

### DIFF
--- a/apps/mark-scan/frontend/src/app_cardless_voting.test.tsx
+++ b/apps/mark-scan/frontend/src/app_cardless_voting.test.tsx
@@ -232,7 +232,7 @@ test('Cardless Voting Flow', async () => {
   for (let i = 0; i < voterContests.length; i += 1) {
     const { title } = voterContests[i];
 
-    await screen.findByText(title);
+    await screen.findByRole('heading', { name: title });
 
     // Vote for a candidate contest
     if (title === presidentContest.title) {
@@ -383,7 +383,7 @@ test('Voter can submit a blank ballot', async () => {
     const { title } = voterContests[i];
 
     await advanceTimersAndPromises();
-    screen.getByText(title);
+    screen.getByRole('heading', { name: title });
 
     fireEvent.click(screen.getByText('Next'));
   }
@@ -597,7 +597,7 @@ test('poll worker must select a precinct first', async () => {
     const { title } = voterContests[i];
 
     await advanceTimersAndPromises();
-    screen.getByText(title);
+    screen.getByRole('heading', { name: title });
 
     // Vote for a candidate contest
     if (title === presidentContest.title) {

--- a/apps/mark-scan/frontend/src/app_contest_multi_seat.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_multi_seat.test.tsx
@@ -1,7 +1,12 @@
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 
 import userEvent from '@testing-library/user-event';
-import { fireEvent, render, screen } from '../test/react_testing_library';
+import {
+  fireEvent,
+  render,
+  screen,
+  within,
+} from '../test/react_testing_library';
 import { App } from './app';
 
 import { advanceTimersAndPromises } from '../test/helpers/timers';
@@ -87,9 +92,8 @@ it('Single Seat Contest', async () => {
   await advanceTimersAndPromises();
 
   // Overvote modal is displayed
-  screen.getByText(
-    `You may only select ${countyCommissionersContest.seats} candidates in this contest. To vote for ${candidate4.name}, you must first unselect the selected candidates.`
-  );
+
+  within(screen.getByRole('alertdialog')).getByText(/you must first deselect/i);
 
   // Go to Review Screen
   while (!screen.queryByText('Review Your Votes')) {

--- a/apps/mark-scan/frontend/src/app_contest_single_seat.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_single_seat.test.tsx
@@ -1,7 +1,13 @@
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 
 import userEvent from '@testing-library/user-event';
-import { fireEvent, render, act, screen } from '../test/react_testing_library';
+import {
+  fireEvent,
+  render,
+  act,
+  screen,
+  within,
+} from '../test/react_testing_library';
 import { App } from './app';
 
 import { advanceTimersAndPromises } from '../test/helpers/timers';
@@ -76,9 +82,7 @@ it('Single Seat Contest', async () => {
   await advanceTimersAndPromises();
 
   // Overvote modal is displayed
-  screen.getByText(
-    `You may only select ${presidentContest.seats} candidate in this contest. To vote for ${candidate1}, you must first unselect the selected candidate.`
-  );
+  within(screen.getByRole('alertdialog')).getByText(/you must first deselect/i);
 
   // Close the modal
   fireEvent.click(screen.getByText('Okay'));
@@ -105,9 +109,6 @@ it('Single Seat Contest', async () => {
   act(() => {
     jest.advanceTimersByTime(101);
   });
-  expect(
-    screen.getByText(candidate0).closest('button')?.getAttribute('aria-label')
-  ).not.toContain('Deselected,');
   screen.getByRole('option', {
     name: new RegExp(`^${candidate0}`),
     selected: false,

--- a/apps/mark-scan/frontend/src/app_contest_write_in.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_write_in.test.tsx
@@ -110,7 +110,9 @@ it('Single Seat Contest with Write In', async () => {
   fireEvent.click(
     screen.getByText('add write-in candidate').closest('button')!
   );
-  screen.getByText(`Write-In: ${singleSeatContestWithWriteIn.title}`);
+  screen.getByRole('heading', {
+    name: `Write-In: ${singleSeatContestWithWriteIn.title}`,
+  });
 
   // Enter Write-in Candidate Name
   fireEvent.click(getWithinKeyboard('B'));
@@ -123,7 +125,7 @@ it('Single Seat Contest with Write In', async () => {
 
   // Remove Write-In Candidate
   fireEvent.click(screen.getByText('BOB').closest('button')!);
-  fireEvent.click(screen.getByText('Yes, Remove.'));
+  fireEvent.click(screen.getButton('Yes'));
   advanceTimers();
 
   // Add Different Write-In Candidate
@@ -145,18 +147,14 @@ it('Single Seat Contest with Write In', async () => {
       .getByText(singleSeatContestWithWriteIn.candidates[0].name)
       .closest('button')!
   );
-  screen.getByText(
-    `You may only select ${singleSeatContestWithWriteIn.seats} candidate in this contest. To vote for ${singleSeatContestWithWriteIn.candidates[0].name}, you must first unselect the selected candidate.`
-  );
+  within(screen.getByRole('alertdialog')).getByText(/you must first deselect/i);
   fireEvent.click(screen.getByText('Okay'));
 
   // Try to add another write-in when max candidates are selected.
   fireEvent.click(
     screen.getByText('add write-in candidate').closest('button')!
   );
-  screen.getByText(
-    `You may only select ${singleSeatContestWithWriteIn.seats} candidate in this contest. To vote for a write-in candidate, you must first unselect the selected candidate.`
-  );
+  within(screen.getByRole('alertdialog')).getByText(/you must first deselect/i);
   fireEvent.click(screen.getByText('Okay'));
 
   // Go to review page and confirm write in exists

--- a/apps/mark-scan/frontend/src/app_contest_yes_no.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_yes_no.test.tsx
@@ -75,7 +75,7 @@ it('Single Seat Contest', async () => {
   const getByTextWithMarkup = withMarkup(screen.getByText);
 
   // Advance to multi-seat contest
-  while (!screen.queryByText(measure102Contest.title)) {
+  while (!screen.queryByRole('heading', { name: measure102Contest.title })) {
     fireEvent.click(screen.getByText('Next'));
     await advanceTimersAndPromises();
   }
@@ -94,11 +94,11 @@ it('Single Seat Contest', async () => {
     name: /Deselected.+Yes/,
     selected: false,
   });
-  contestChoices.getByRole('option', { name: /^No/, selected: false });
+  contestChoices.getByRole('option', { name: /\bNo\b/, selected: false });
   act(() => {
     jest.advanceTimersByTime(101);
   });
-  contestChoices.getByRole('option', { name: /^Yes/, selected: false });
+  contestChoices.getByRole('option', { name: /\bYes\b/, selected: false });
 
   // Select Yes
   fireEvent.click(contestChoices.getByText('Yes'));
@@ -107,15 +107,13 @@ it('Single Seat Contest', async () => {
   // Select No
   fireEvent.click(contestChoices.getByText('No'));
   contestChoices.getByRole('option', {
-    name: /^No/,
+    name: /\bNo\b/,
     hidden: true, // Hidden by overvote modal.
     selected: false,
   });
 
   // Overvote modal is displayed
-  getByTextWithMarkup(
-    'Do you want to change your vote to No? To change your vote, first unselect your vote for Yes.'
-  );
+  within(screen.getByRole('alertdialog')).getByText(/first deselect/i);
   fireEvent.click(screen.getByText('Okay'));
   await advanceTimersAndPromises(); // For 200ms Delay in closing modal
 

--- a/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
@@ -230,7 +230,7 @@ test('MarkAndPrint end-to-end flow', async () => {
   for (let i = 0; i < voterContests.length; i += 1) {
     const { title } = voterContests[i];
 
-    await screen.findByText(title);
+    await screen.findByRole('heading', { name: title });
 
     // Vote for candidate contest
     if (title === presidentContest.title) {

--- a/apps/mark-scan/frontend/src/lib/gamepad.test.tsx
+++ b/apps/mark-scan/frontend/src/lib/gamepad.test.tsx
@@ -127,7 +127,7 @@ it('gamepad controls work', async () => {
   handleGamepadButtonDown('DPadDown'); // selects Okay button
   handleGamepadButtonDown('DPadDown'); // Okay button should still be selected
   handleGamepadButtonDown('DPadDown'); // Okay button should still be selected
-  expect(getActiveElement().textContent).toEqual('Okay');
+  expect(screen.getButton(/Okay/i)).toHaveFocus();
 
   await advanceTimersAndPromises();
 });

--- a/apps/mark-scan/frontend/src/pages/contest_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/contest_screen.test.tsx
@@ -23,8 +23,8 @@ it('Renders ContestScreen', () => {
     }
   );
   screen.getByRole('heading', { name: firstContestTitle });
-  screen.getByRole('button', { name: 'next contest' });
-  screen.getByRole('button', { name: 'previous contest' });
+  screen.getButton(/next/i);
+  screen.getButton(/back/i);
   screen.getByRole('button', { name: 'Color/Size' });
 });
 

--- a/apps/mark/frontend/src/app_cardless_voting.test.tsx
+++ b/apps/mark/frontend/src/app_cardless_voting.test.tsx
@@ -206,7 +206,7 @@ test('Cardless Voting Flow', async () => {
   for (let i = 0; i < voterContests.length; i += 1) {
     const { title } = voterContests[i];
 
-    await screen.findByText(title);
+    await screen.findByRole('heading', { name: title });
 
     // Vote for a candidate contest
     if (title === presidentContest.title) {
@@ -298,7 +298,7 @@ test('Another Voter submits blank ballot and clicks Done', async () => {
     const { title } = voterContests[i];
 
     await advanceTimersAndPromises();
-    screen.getByText(title);
+    screen.getByRole('heading', { name: title });
 
     fireEvent.click(screen.getByText('Next'));
   }
@@ -502,7 +502,7 @@ test('poll worker must select a precinct first', async () => {
     const { title } = voterContests[i];
 
     await advanceTimersAndPromises();
-    screen.getByText(title);
+    screen.getByRole('heading', { name: title });
 
     // Vote for a candidate contest
     if (title === presidentContest.title) {

--- a/apps/mark/frontend/src/app_contest_multi_seat.test.tsx
+++ b/apps/mark/frontend/src/app_contest_multi_seat.test.tsx
@@ -1,7 +1,12 @@
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 
 import userEvent from '@testing-library/user-event';
-import { fireEvent, render, screen } from '../test/react_testing_library';
+import {
+  fireEvent,
+  render,
+  screen,
+  within,
+} from '../test/react_testing_library';
 import { App } from './app';
 
 import { advanceTimersAndPromises } from '../test/helpers/timers';
@@ -84,9 +89,7 @@ it('Single Seat Contest', async () => {
   await advanceTimersAndPromises();
 
   // Overvote modal is displayed
-  screen.getByText(
-    `You may only select ${countyCommissionersContest.seats} candidates in this contest. To vote for ${candidate4.name}, you must first unselect the selected candidates.`
-  );
+  within(screen.getByRole('alertdialog')).getByText(/you must first deselect/i);
 
   // Go to Review Screen
   while (!screen.queryByText('Review Your Votes')) {

--- a/apps/mark/frontend/src/app_contest_single_seat.test.tsx
+++ b/apps/mark/frontend/src/app_contest_single_seat.test.tsx
@@ -1,7 +1,13 @@
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 
 import userEvent from '@testing-library/user-event';
-import { fireEvent, render, act, screen } from '../test/react_testing_library';
+import {
+  fireEvent,
+  render,
+  act,
+  screen,
+  within,
+} from '../test/react_testing_library';
 import { App } from './app';
 
 import { advanceTimersAndPromises } from '../test/helpers/timers';
@@ -73,9 +79,7 @@ it('Single Seat Contest', async () => {
   await advanceTimersAndPromises();
 
   // Overvote modal is displayed
-  screen.getByText(
-    `You may only select ${presidentContest.seats} candidate in this contest. To vote for ${candidate1}, you must first unselect the selected candidate.`
-  );
+  within(screen.getByRole('alertdialog')).getByText(/you must first deselect/i);
 
   // Close the modal
   fireEvent.click(screen.getByText('Okay'));
@@ -102,9 +106,6 @@ it('Single Seat Contest', async () => {
   act(() => {
     jest.advanceTimersByTime(101);
   });
-  expect(
-    screen.getByText(candidate0).closest('button')?.getAttribute('aria-label')
-  ).not.toContain('Deselected,');
   screen.getByRole('option', {
     name: new RegExp(`^${candidate0}`),
     selected: false,

--- a/apps/mark/frontend/src/app_contest_write_in.test.tsx
+++ b/apps/mark/frontend/src/app_contest_write_in.test.tsx
@@ -104,7 +104,9 @@ it('Single Seat Contest with Write In', async () => {
   fireEvent.click(
     screen.getByText('add write-in candidate').closest('button')!
   );
-  screen.getByText(`Write-In: ${singleSeatContestWithWriteIn.title}`);
+  screen.getByRole('heading', {
+    name: `Write-In: ${singleSeatContestWithWriteIn.title}`,
+  });
 
   // Enter Write-in Candidate Name
   fireEvent.click(getWithinKeyboard('B'));
@@ -117,7 +119,7 @@ it('Single Seat Contest with Write In', async () => {
 
   // Remove Write-In Candidate
   fireEvent.click(screen.getByText('BOB').closest('button')!);
-  fireEvent.click(screen.getByText('Yes, Remove.'));
+  fireEvent.click(screen.getButton('Yes'));
   advanceTimers();
 
   // Add Different Write-In Candidate
@@ -139,18 +141,14 @@ it('Single Seat Contest with Write In', async () => {
       .getByText(singleSeatContestWithWriteIn.candidates[0].name)
       .closest('button')!
   );
-  screen.getByText(
-    `You may only select ${singleSeatContestWithWriteIn.seats} candidate in this contest. To vote for ${singleSeatContestWithWriteIn.candidates[0].name}, you must first unselect the selected candidate.`
-  );
+  within(screen.getByRole('alertdialog')).getByText(/you must first deselect/i);
   fireEvent.click(screen.getByText('Okay'));
 
   // Try to add another write-in when max candidates are selected.
   fireEvent.click(
     screen.getByText('add write-in candidate').closest('button')!
   );
-  screen.getByText(
-    `You may only select ${singleSeatContestWithWriteIn.seats} candidate in this contest. To vote for a write-in candidate, you must first unselect the selected candidate.`
-  );
+  within(screen.getByRole('alertdialog')).getByText(/you must first deselect/i);
   fireEvent.click(screen.getByText('Okay'));
 
   // Go to review page and confirm write in exists

--- a/apps/mark/frontend/src/app_contest_yes_no.test.tsx
+++ b/apps/mark/frontend/src/app_contest_yes_no.test.tsx
@@ -72,7 +72,7 @@ it('Single Seat Contest', async () => {
   const getByTextWithMarkup = withMarkup(screen.getByText);
 
   // Advance to multi-seat contest
-  while (!screen.queryByText(measure102Contest.title)) {
+  while (!screen.queryByRole('heading', { name: measure102Contest.title })) {
     fireEvent.click(screen.getByText('Next'));
     await advanceTimersAndPromises();
   }
@@ -91,11 +91,11 @@ it('Single Seat Contest', async () => {
     name: /Deselected.+Yes/,
     selected: false,
   });
-  contestChoices.getByRole('option', { name: /^No/, selected: false });
+  contestChoices.getByRole('option', { name: /\bNo\b/, selected: false });
   act(() => {
     jest.advanceTimersByTime(101);
   });
-  contestChoices.getByRole('option', { name: /^Yes/, selected: false });
+  contestChoices.getByRole('option', { name: /\bYes\b/, selected: false });
 
   // Select Yes
   fireEvent.click(contestChoices.getByText('Yes'));
@@ -104,15 +104,13 @@ it('Single Seat Contest', async () => {
   // Select No
   fireEvent.click(contestChoices.getByText('No'));
   contestChoices.getByRole('option', {
-    name: /^No/,
+    name: /\bNo\b/,
     hidden: true, // Hidden by overvote modal.
     selected: false,
   });
 
   // Overvote modal is displayed
-  getByTextWithMarkup(
-    'Do you want to change your vote to No? To change your vote, first unselect your vote for Yes.'
-  );
+  within(screen.getByRole('alertdialog')).getByText(/first deselect/i);
   fireEvent.click(screen.getByText('Okay'));
   await advanceTimersAndPromises(); // For 200ms Delay in closing modal
 

--- a/apps/mark/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark/frontend/src/app_end_to_end.test.tsx
@@ -204,7 +204,7 @@ test('MarkAndPrint end-to-end flow', async () => {
   for (let i = 0; i < voterContests.length; i += 1) {
     const { title } = voterContests[i];
 
-    await screen.findByText(title);
+    await screen.findByRole('heading', { name: title });
 
     // Vote for candidate contest
     if (title === presidentContest.title) {

--- a/apps/mark/frontend/src/lib/gamepad.test.tsx
+++ b/apps/mark/frontend/src/lib/gamepad.test.tsx
@@ -124,7 +124,7 @@ it('gamepad controls work', async () => {
   handleGamepadButtonDown('DPadDown'); // selects Okay button
   handleGamepadButtonDown('DPadDown'); // Okay button should still be selected
   handleGamepadButtonDown('DPadDown'); // Okay button should still be selected
-  expect(getActiveElement().textContent).toEqual('Okay');
+  expect(screen.getButton(/Okay/i)).toHaveFocus();
 
   await advanceTimersAndPromises();
 });

--- a/apps/mark/frontend/src/pages/contest_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/contest_screen.test.tsx
@@ -23,8 +23,8 @@ it('Renders ContestScreen', () => {
     }
   );
   screen.getByRole('heading', { name: firstContestTitle });
-  screen.getByRole('button', { name: 'next contest' });
-  screen.getByRole('button', { name: 'previous contest' });
+  screen.getButton(/next/i);
+  screen.getButton(/back/i);
   screen.getByRole('button', { name: 'Color/Size' });
 });
 

--- a/apps/mark/integration-testing/e2e/scroll_buttons.spec.ts
+++ b/apps/mark/integration-testing/e2e/scroll_buttons.spec.ts
@@ -73,18 +73,18 @@ test('configure, open polls, and test contest scroll buttons', async ({
     })
     .click();
 
-  await page.getByText('Contest 1 of 20').waitFor();
-  await page.getByRole('button', { name: 'next contest' }).click();
-  await page.getByText('Contest 2 of 20').waitFor();
-  await page.getByRole('button', { name: 'next contest' }).click();
-  await page.getByText('Contest 3 of 20').waitFor();
+  await page.getByText(/contest number: 1/i).waitFor();
+  await page.getByRole('button', { name: /next/i }).click();
+  await page.getByText(/contest number: 2/i).waitFor();
+  await page.getByRole('button', { name: /next/i }).click();
+  await page.getByText(/contest number: 3/i).waitFor();
 
   await expect(page.getByText('Brad Plunkard')).toBeInViewport();
 
   expect(await findMoreButtons(page)).toHaveLength(0);
 
-  await page.getByRole('button', { name: 'next contest' }).click();
-  await page.getByText('Contest 4 of 20').waitFor();
+  await page.getByRole('button', { name: /next/i }).click();
+  await page.getByText(/contest number: 4/i).waitFor();
 
   // first candidate in the list should be visible
   await expect(page.getByText('Charlene Franz')).toBeInViewport();

--- a/libs/mark-flow-ui/src/components/candidate_contest.test.tsx
+++ b/libs/mark-flow-ui/src/components/candidate_contest.test.tsx
@@ -234,15 +234,17 @@ describe('supports write-in candidates', () => {
 
     const modal = within(screen.getByRole('alertdialog'));
 
-    modal.getByText(`Write-In: ${candidateContestWithWriteIns.title}`);
-    modal.getByText(/40 characters remaining/);
+    modal.getByRole('heading', {
+      name: `Write-In: ${candidateContestWithWriteIns.title}`,
+    });
+    modal.getByText(hasTextAcrossElements(/characters remaining: 40/i));
 
     // type LIZARD PEOPLE, then backspace to remove the E, then add it back
     typeKeysInVirtualKeyboard('LIZARD PEOPLE');
     userEvent.click(modal.getByText(/delete/i).closest('button')!);
-    modal.getByText(/28 characters remaining/);
+    modal.getByText(hasTextAcrossElements(/characters remaining: 28/i));
     typeKeysInVirtualKeyboard('E');
-    modal.getByText(/27 characters remaining/);
+    modal.getByText(hasTextAcrossElements(/characters remaining: 27/i));
 
     userEvent.click(modal.getByText('Accept'));
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
@@ -275,8 +277,8 @@ describe('supports write-in candidates', () => {
     userEvent.click(screen.getByText('LIZARD PEOPLE').closest('button')!);
 
     const modal = within(screen.getByRole('alertdialog'));
-    modal.getByText('Do you want to unselect and remove LIZARD PEOPLE?');
-    userEvent.click(modal.getByText('Yes, Remove.'));
+    modal.getByText(/do you want to deselect/i);
+    userEvent.click(modal.getByText('Yes'));
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
     expect(updateVote).toHaveBeenCalledWith(
       candidateContestWithWriteIns.id,
@@ -300,9 +302,11 @@ describe('supports write-in candidates', () => {
 
     const modal = within(screen.getByRole('alertdialog'));
 
-    modal.getByText(`Write-In: ${candidateContestWithWriteIns.title}`);
+    modal.getByRole('heading', {
+      name: `Write-In: ${candidateContestWithWriteIns.title}`,
+    });
     typeKeysInVirtualKeyboard('JACOB JOHANSON JINGLEHEIMMER SCHMIDTT');
-    modal.getByText(/3 characters remaining/);
+    modal.getByText(hasTextAcrossElements(/characters remaining: 3/i));
     userEvent.click(modal.getByText('Cancel'));
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
 
@@ -332,7 +336,7 @@ describe('supports write-in candidates', () => {
     );
 
     const modal = within(screen.getByRole('alertdialog'));
-    modal.getByText(/You may only select \d+ candidates? in this contest\./);
+    modal.getByText(/you must first deselect/i);
     userEvent.click(modal.getByText('Okay'));
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
   });
@@ -353,11 +357,13 @@ describe('supports write-in candidates', () => {
 
     const modal = within(screen.getByRole('alertdialog'));
 
-    modal.getByText(`Write-In: ${candidateContestWithWriteIns.title}`);
+    modal.getByRole('heading', {
+      name: `Write-In: ${candidateContestWithWriteIns.title}`,
+    });
     const writeInCandidate =
       "JACOB JOHANSON JINGLEHEIMMER SCHMIDTT, THAT'S MY NAME TOO";
     typeKeysInVirtualKeyboard(writeInCandidate);
-    modal.getByText(/0 characters remaining/);
+    modal.getByText(hasTextAcrossElements(/characters remaining: 0/i));
 
     expect(
       modal.getByText('space').closest('button')!.hasAttribute('disabled')
@@ -414,7 +420,7 @@ describe('audio cues', () => {
 
     // the candidate is now selected
     expect(firstCandidateChoice).toHaveAccessibleName(
-      expect.stringContaining(`Selected, ${candidate.name}`)
+      new RegExp(`Selected.+${candidate.name}`, 'i')
     );
 
     // deselect the candidate and manually update the vote
@@ -430,7 +436,7 @@ describe('audio cues', () => {
 
     // the candidate is no longer selected
     expect(firstCandidateChoice).toHaveAccessibleName(
-      expect.stringContaining(`Deselected, ${candidate.name}`)
+      new RegExp(`Deselected.+${candidate.name}`, 'i')
     );
 
     // after a short delay, the candidate is no longer selected/deselected

--- a/libs/mark-flow-ui/src/components/contest.test.tsx
+++ b/libs/mark-flow-ui/src/components/contest.test.tsx
@@ -5,6 +5,7 @@ import {
 import userEvent from '@testing-library/user-event';
 import { find } from '@votingworks/basics';
 import { CandidateContest, YesNoContest } from '@votingworks/types';
+import { hasTextAcrossElements } from '@votingworks/test-utils';
 import { render, screen } from '../../test/react_testing_library';
 
 import { Contest } from './contest';
@@ -59,7 +60,7 @@ test('yesno contest', () => {
       updateVote={jest.fn()}
     />
   );
-  screen.getByText(yesnoContest.title);
+  screen.getByRole('heading', { name: yesnoContest.title });
   // Tested further in yes_no_contest.test.tsx
 });
 
@@ -87,4 +88,19 @@ test('renders ms-either-neither contests', () => {
     msEitherNeitherContest.secondOption.id,
   ]);
   // Tested further in ms_either_neither_contest.test.tsx
+});
+
+test('renders breadcrumbs', () => {
+  render(
+    <Contest
+      breadcrumbs={{ ballotContestCount: 15, contestNumber: 3 }}
+      contest={yesnoContest}
+      election={electionGeneral}
+      updateVote={jest.fn()}
+      votes={{}}
+    />
+  );
+
+  screen.getByText(hasTextAcrossElements(/contest number: 3/i));
+  screen.getByText(hasTextAcrossElements(/total contests: 15/i));
 });

--- a/libs/mark-flow-ui/src/components/contest_header.tsx
+++ b/libs/mark-flow-ui/src/components/contest_header.tsx
@@ -1,15 +1,21 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { Caption, Font, H2, electionStrings } from '@votingworks/ui';
-import { Contest } from '@votingworks/types';
+import {
+  Caption,
+  Font,
+  H2,
+  appStrings,
+  electionStrings,
+} from '@votingworks/ui';
+import { Contest, District } from '@votingworks/types';
 import { MsEitherNeitherContest } from '../utils/ms_either_neither_contests';
 
 export interface ContestHeaderProps {
   breadcrumbs?: BreadcrumbMetadata;
   children?: React.ReactNode;
   contest: Contest | MsEitherNeitherContest;
-  districtName: string;
+  district: District;
 }
 
 export interface BreadcrumbMetadata {
@@ -27,20 +33,30 @@ const ContestInfo = styled.div`
   justify-content: space-between;
 `;
 
+function Breadcrumbs(props: BreadcrumbMetadata) {
+  const { ballotContestCount, contestNumber } = props;
+
+  return (
+    <Caption noWrap>
+      {appStrings.labelContestNumber()}{' '}
+      <Font weight="bold">{contestNumber}</Font> |{' '}
+      {appStrings.labelTotalContests()}{' '}
+      <Font weight="bold">{ballotContestCount}</Font>{' '}
+    </Caption>
+  );
+}
+
 export function ContestHeader(props: ContestHeaderProps): JSX.Element {
-  const { breadcrumbs, children, contest, districtName } = props;
+  const { breadcrumbs, children, contest, district } = props;
 
   return (
     <Container id="contest-header">
       <div id="audiofocus">
         <ContestInfo>
-          <Caption weight="semiBold">{districtName}</Caption>
-          {breadcrumbs && (
-            <Caption noWrap>
-              Contest <Font weight="bold">{breadcrumbs.contestNumber}</Font> of{' '}
-              <Font weight="bold">{breadcrumbs.ballotContestCount}</Font>
-            </Caption>
-          )}
+          <Caption weight="semiBold">
+            {electionStrings.districtName(district)}
+          </Caption>
+          {breadcrumbs && <Breadcrumbs {...breadcrumbs} />}
         </ContestInfo>
         <div>
           <H2 as="h1">{electionStrings.contestTitle(contest)}</H2>

--- a/libs/mark-flow-ui/src/components/ms_either_neither_contest.tsx
+++ b/libs/mark-flow-ui/src/components/ms_either_neither_contest.tsx
@@ -8,13 +8,10 @@ import {
   WithScrollButtons,
 } from '@votingworks/ui';
 
-import { YesNoVote, Election } from '@votingworks/types';
+import { YesNoVote, Election, getContestDistrict } from '@votingworks/types';
 
 import { UpdateVoteFunction } from '../config/types';
-import {
-  getContestDistrictName,
-  MsEitherNeitherContest as MsEitherNeitherContestInterface,
-} from '../utils/ms_either_neither_contests';
+import { MsEitherNeitherContest as MsEitherNeitherContestInterface } from '../utils/ms_either_neither_contests';
 import { BreadcrumbMetadata, ContestHeader } from './contest_header';
 
 const ChoicesGrid = styled.div`
@@ -91,7 +88,7 @@ export function MsEitherNeitherContest({
     updateVote(contest.pickOneContestId, newVote);
   }
 
-  const districtName = getContestDistrictName(election, contest);
+  const district = getContestDistrict(election, contest);
   const eitherNeitherVote = eitherNeitherContestVote?.[0];
   const forEither = '“for either”';
   const againstBoth = '“against both”';
@@ -118,7 +115,7 @@ export function MsEitherNeitherContest({
       <ContestHeader
         breadcrumbs={breadcrumbs}
         contest={contest}
-        districtName={districtName}
+        district={district}
       >
         <Caption>
           {eitherNeitherVote && pickOneVote ? (

--- a/libs/mark-flow-ui/src/components/yes_no_contest.tsx
+++ b/libs/mark-flow-ui/src/components/yes_no_contest.tsx
@@ -1,21 +1,22 @@
-import React, { useEffect, useState } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 import {
   YesNoVote,
   YesNoContest as YesNoContestInterface,
-  getContestDistrictName,
   Election,
   YesNoContestOptionId,
+  getContestDistrict,
 } from '@votingworks/types';
 import {
   Button,
   ContestChoiceButton,
   Main,
   Modal,
-  Prose,
   P,
   Caption,
-  Pre,
   WithScrollButtons,
+  AudioOnly,
+  electionStrings,
+  appStrings,
 } from '@votingworks/ui';
 
 import { getSingleYesNoVote } from '@votingworks/utils';
@@ -40,7 +41,7 @@ export function YesNoContest({
   vote,
   updateVote,
 }: Props): JSX.Element {
-  const districtName = getContestDistrictName(election, contest);
+  const district = getContestDistrict(election, contest);
 
   const [overvoteSelection, setOvervoteSelection] =
     useState<Optional<YesNoContestOptionId>>();
@@ -76,21 +77,17 @@ export function YesNoContest({
         <ContestHeader
           breadcrumbs={breadcrumbs}
           contest={contest}
-          districtName={districtName}
+          district={district}
         >
           <Caption>
-            Vote <strong>Yes</strong> or <strong>No</strong>.
-            <span className="screen-reader-only">
-              {contest.description}
-              To navigate through the contest choices, use the down button. To
-              move to the next contest, use the right button.
-            </span>
+            <AudioOnly>
+              {electionStrings.contestDescription(contest)}
+              {appStrings.instructionsBmdContestNavigation()}
+            </AudioOnly>
           </Caption>
         </ContestHeader>
         <WithScrollButtons>
-          <Caption>
-            <Pre>{contest.description}</Pre>
-          </Caption>
+          <Caption>{electionStrings.contestDescription(contest)}</Caption>
         </WithScrollButtons>
         <ContestFooter>
           <ChoicesGrid data-testid="contest-choices">
@@ -100,11 +97,11 @@ export function YesNoContest({
               function handleDisabledClick() {
                 handleChangeVoteAlert(option.id);
               }
-              let prefixAudioText = '';
+              let prefixAudioText: ReactNode = null;
               if (isChecked) {
-                prefixAudioText = 'Selected,';
+                prefixAudioText = appStrings.labelSelectedOption();
               } else if (deselectedVote === option.id) {
-                prefixAudioText = 'Deselected,';
+                prefixAudioText = appStrings.labelDeselectedOption();
               }
               return (
                 <ContestChoiceButton
@@ -114,8 +111,15 @@ export function YesNoContest({
                   onPress={
                     isDisabled ? handleDisabledClick : handleUpdateSelection
                   }
-                  ariaLabel={`${prefixAudioText} ${option.label} on ${contest.title}`}
-                  label={option.label}
+                  label={
+                    <React.Fragment>
+                      <AudioOnly>
+                        {prefixAudioText}
+                        {electionStrings.contestTitle(contest)} |{' '}
+                      </AudioOnly>
+                      {electionStrings.contestOptionLabel(option)}
+                    </React.Fragment>
+                  }
                 />
               );
             })}
@@ -126,29 +130,19 @@ export function YesNoContest({
         <Modal
           centerContent
           content={
-            <Prose>
-              {overvoteSelection && (
-                <P id="modalaudiofocus">
-                  Do you want to change your vote to{' '}
-                  <strong>
-                    {overvoteSelection === contest.yesOption.id
-                      ? contest.yesOption.label
-                      : contest.noOption.label}
-                  </strong>
-                  ? To change your vote, first unselect your vote for{' '}
-                  <strong>
-                    {overvoteSelection === contest.yesOption.id
-                      ? contest.noOption.label
-                      : contest.yesOption.label}
-                  </strong>
-                  .
-                </P>
-              )}
-            </Prose>
+            <P id="modalaudiofocus">
+              {appStrings.warningOvervoteYesNoContest()}
+              <AudioOnly>
+                {appStrings.instructionsBmdSelectToContinue()}
+              </AudioOnly>
+            </P>
           }
           actions={
             <Button variant="primary" autoFocus onPress={closeOvervoteAlert}>
-              Okay
+              {appStrings.buttonOkay()}
+              <AudioOnly>
+                {appStrings.instructionsBmdSelectToContinue()}
+              </AudioOnly>
             </Button>
           }
         />

--- a/libs/mark-flow-ui/src/pages/contest_page.tsx
+++ b/libs/mark-flow-ui/src/pages/contest_page.tsx
@@ -97,7 +97,6 @@ export function ContestPage(props: ContestPageProps): JSX.Element {
       id="next"
       rightIcon="Next"
       variant={isVoteComplete ? 'primary' : 'neutral'}
-      aria-label="next contest"
       to={nextContest ? getContestUrl(nextContestIndex) : getReviewPageUrl()}
     >
       {appStrings.buttonNext()}
@@ -108,7 +107,6 @@ export function ContestPage(props: ContestPageProps): JSX.Element {
     <LinkButton
       icon="Previous"
       id="previous"
-      aria-label="previous contest"
       to={prevContest ? getContestUrl(prevContestIndex) : getStartPageUrl()}
     >
       {/* TODO(kofi): Maybe something like "Previous" would translate better in this context? */}

--- a/libs/mark-flow-ui/src/utils/strip_quotes.ts
+++ b/libs/mark-flow-ui/src/utils/strip_quotes.ts
@@ -1,3 +1,0 @@
-export function stripQuotes(string: string): string {
-  return string.replace(/['‘’"“”]/g, '');
-}

--- a/libs/ui/src/modal.tsx
+++ b/libs/ui/src/modal.tsx
@@ -117,7 +117,7 @@ export interface ModalProps {
   fullscreen?: boolean;
   modalWidth?: ModalWidth;
   themeDeprecated?: Theme;
-  title?: string;
+  title?: ReactNode;
 }
 
 /* istanbul ignore next - unclear why this isn't covered */

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -1,3 +1,4 @@
+import { Font } from '../typography';
 import { DateString } from './date_string';
 import { NumberString } from './number_string';
 import { UiString } from './ui_string';
@@ -7,6 +8,8 @@ import { UiString } from './ui_string';
 /* istanbul ignore next - mostly presentational, tested via apps where relevant */
 export const appStrings = {
   // TODO(kofi): Fill out.
+
+  buttonAccept: () => <UiString uiStringKey="buttonAccept">Accept</UiString>,
 
   buttonAddWriteIn: () => (
     <UiString uiStringKey="buttonAddWriteIn">add write-in candidate</UiString>
@@ -32,6 +35,8 @@ export const appStrings = {
     </UiString>
   ),
 
+  buttonCancel: () => <UiString uiStringKey="buttonCancel">Cancel</UiString>,
+
   buttonChange: () => <UiString uiStringKey="buttonChange">Change</UiString>,
 
   buttonDisplaySettings: () => (
@@ -42,15 +47,21 @@ export const appStrings = {
 
   buttonNext: () => <UiString uiStringKey="buttonNext">Next</UiString>,
 
+  buttonNo: () => <UiString uiStringKey="buttonNo">No</UiString>,
+
+  buttonOkay: () => <UiString uiStringKey="buttonOkay">Okay</UiString>,
+
   buttonPrintBallot: () => (
     <UiString uiStringKey="buttonPrintBallot">Print My Ballot</UiString>
   ),
+
+  buttonReview: () => <UiString uiStringKey="buttonReview">Review</UiString>,
 
   buttonStartVoting: () => (
     <UiString uiStringKey="buttonStartVoting">Start Voting</UiString>
   ),
 
-  buttonReview: () => <UiString uiStringKey="buttonReview">Review</UiString>,
+  buttonYes: () => <UiString uiStringKey="buttonYes">Yes</UiString>,
 
   // TODO(kofi): Remove `date` and `number` and have consumers use the
   // components directly, since this indirection doesn't provided added value.
@@ -98,12 +109,56 @@ export const appStrings = {
     </UiString>
   ),
 
+  instructionsBmdSelectToContinue: () => (
+    <UiString uiStringKey="instructionsBmdSelectToContinue">
+      Press the select button to continue.
+    </UiString>
+  ),
+
+  instructionsBmdWriteInFormNavigation: () => (
+    <UiString uiStringKey="instructionsBmdWriteInFormNavigation">
+      Use the up and down buttons to navigate between the letters of a standard
+      keyboard. Use the select button to select the current letter.
+    </UiString>
+  ),
+
   labelAllPrecinctsSelection: () => (
     <UiString uiStringKey="labelAllPrecinctsSelection">All Precincts</UiString>
   ),
 
   labelBallotStyle: () => (
     <UiString uiStringKey="labelBallotStyle">Ballot style:</UiString>
+  ),
+
+  labelBmdWriteInForm: () => (
+    <UiString uiStringKey="labelBmdWriteInForm">
+      Enter the name of a person who is <Font weight="bold">not</Font> on the
+      ballot:
+    </UiString>
+  ),
+
+  labelCharactersRemaining: () => (
+    <UiString uiStringKey="labelCharactersRemaining">
+      Characters remaining:
+    </UiString>
+  ),
+
+  labelContestsRemaining: () => (
+    <UiString uiStringKey="labelContestsRemaining">
+      Contests remaining:
+    </UiString>
+  ),
+
+  labelContestNumber: () => (
+    <UiString uiStringKey="labelContestNumber">Contest number:</UiString>
+  ),
+
+  labelDeselectedCandidate: () => (
+    <UiString uiStringKey="labelDeselectedCandidate">Deselected:</UiString>
+  ),
+
+  labelDeselectedOption: () => (
+    <UiString uiStringKey="labelDeselectedOption">Deselected option:</UiString>
   ),
 
   labelNumBallotContests: () => (
@@ -118,6 +173,36 @@ export const appStrings = {
     </UiString>
   ),
 
+  labelSelectedCandidate: () => (
+    <UiString uiStringKey="labelSelectedCandidate">Selected:</UiString>
+  ),
+
+  labelSelectedOption: () => (
+    <UiString uiStringKey="labelSelectedOption">Selected option:</UiString>
+  ),
+
+  labelTotalContests: () => (
+    <UiString uiStringKey="labelTotalContests">Total contests:</UiString>
+  ),
+
+  labelWriteInCandidateName: () => (
+    <UiString uiStringKey="labelWriteInCandidateName">
+      Write-In Candidate
+    </UiString>
+  ),
+
+  // TODO(kofi): Could potentially leverage i18next post-processors to apply
+  // letter case transforms at render-time to avoid maintaining separate, but
+  // we'd need to find a reliable way of applying locale-specific capitalization
+  // rules.
+  labelWriteInTitleCase: () => (
+    <UiString uiStringKey="labelWriteInTitleCase">Write-In</UiString>
+  ),
+
+  labelWriteInTitleCaseColon: () => (
+    <UiString uiStringKey="labelWriteInTitleCaseColon">Write-In:</UiString>
+  ),
+
   labelWriteInParenthesized: () => (
     <UiString uiStringKey="labelWriteInParenthesized">(write-in)</UiString>
   ),
@@ -126,8 +211,27 @@ export const appStrings = {
   // components directly, since this indirection doesn't provided added value.
   number: (value: number) => <NumberString value={value} />,
 
+  promptBmdConfirmRemoveWriteIn: () => (
+    <UiString uiStringKey="promptBmdConfirmRemoveWriteIn">
+      Do you want to deselect and remove your write-in candidate?
+    </UiString>
+  ),
+
   titleBmdReviewScreen: () => (
     <UiString uiStringKey="titleBmdReviewScreen">Review Your Votes</UiString>
+  ),
+
+  warningOvervoteCandidateContest: () => (
+    <UiString uiStringKey="warningOvervoteCandidateContest">
+      To vote for another candidate, you must first deselect a previously
+      selected candidate.
+    </UiString>
+  ),
+
+  warningOvervoteYesNoContest: () => (
+    <UiString uiStringKey="warningOvervoteYesNoContest">
+      To change your vote, first deselect your previous vote.
+    </UiString>
   ),
 
   warningNoVotesForContest: () => (

--- a/libs/ui/src/ui_strings/election_strings.tsx
+++ b/libs/ui/src/ui_strings/election_strings.tsx
@@ -14,6 +14,7 @@ import {
 } from '@votingworks/types';
 
 import { UiString } from './ui_string';
+import { Pre } from '../typography';
 
 type ContestWithDescription = ContestLike & {
   description: string;
@@ -39,7 +40,11 @@ export const electionStrings = {
   ),
 
   [Key.CONTEST_DESCRIPTION]: (contest: ContestWithDescription) => (
-    <UiString uiStringKey={Key.CONTEST_DESCRIPTION} uiStringSubKey={contest.id}>
+    <UiString
+      as={Pre}
+      uiStringKey={Key.CONTEST_DESCRIPTION}
+      uiStringSubKey={contest.id}
+    >
       {contest.description}
     </UiString>
   ),

--- a/libs/ui/src/ui_strings/ui_string.test.tsx
+++ b/libs/ui/src/ui_strings/ui_string.test.tsx
@@ -10,6 +10,7 @@ import {
   testUiStrings,
 } from '../../test/ui_strings/test_strings';
 import { newTestContext } from '../../test/ui_strings/test_utils';
+import { UiString } from './ui_string';
 
 const { getLanguageContext, mockBackendApi, render } = newTestContext();
 
@@ -47,5 +48,15 @@ test('renders deeply nested translations', async () => {
   await screen.findByRole('heading', { name: 'Mercury' });
 
   rerender(<H1>{testUiStrings.planetName('planet9')}</H1>);
+  await screen.findByRole('heading', { name: 'Pluto' });
+});
+
+test('renders within optional element type override', async () => {
+  render(
+    <UiString as="h1" uiStringKey="planetName" uiStringSubKey="planet9">
+      Fallback text
+    </UiString>
+  );
+
   await screen.findByRole('heading', { name: 'Pluto' });
 });

--- a/libs/ui/src/ui_strings/ui_string.tsx
+++ b/libs/ui/src/ui_strings/ui_string.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import _ from 'lodash';
 import { Trans } from 'react-i18next';
 import styled from 'styled-components';
@@ -6,6 +7,7 @@ import { ReactUiString } from './types';
 import { useLanguageContext } from './language_context';
 
 export interface UiStringProps {
+  as?: string | React.ComponentType<never>;
   children: ReactUiString;
   pluralCount?: number;
   uiStringKey: string;
@@ -17,7 +19,7 @@ const Container = styled.span`
 `;
 
 export function UiString(props: UiStringProps): JSX.Element {
-  const { children, pluralCount, uiStringKey, uiStringSubKey } = props;
+  const { as, children, pluralCount, uiStringKey, uiStringSubKey } = props;
 
   const languageContext = useLanguageContext();
 
@@ -28,7 +30,7 @@ export function UiString(props: UiStringProps): JSX.Element {
     // Enable tests to run without the need for a UiStringContext:
     return (
       <Container>
-        <Trans i18nKey={i18nKey} count={pluralCount}>
+        <Trans i18nKey={i18nKey} count={pluralCount} parent={as}>
           {children}
         </Trans>
       </Container>
@@ -43,6 +45,7 @@ export function UiString(props: UiStringProps): JSX.Element {
         i18nKey={i18nKey}
         count={pluralCount}
         i18n={i18next}
+        parent={as}
         t={translationFunction}
       >
         {children}


### PR DESCRIPTION
## Overview

Moving voter-facing strings in `Mark` and `Mark-Scan` to `@votingworks/ui/appStrings` to support translation and pre-generated audio. Supplemental audio-only strings that were previously rendered as `aria-label`s are now rendered alongside visible strings in an `<AudioOnly>` wrapper.

Making changes to interpolated strings to improve the audio experience (some context in [this doc](https://docs.google.com/document/d/1xtt5q1Pet5j1RHVsduvOcRGrqDkGspFeKhKc1aVscKE/edit?usp=sharing)).

Updated `CandidateContest` and `YesNoContest` -- leaving out `MsEitherNeitherContest` for now, since that's a little more involved.

Will also follow up with i18n for the virtual keyboard later.

## Demo Video or Screenshot

### Candidate Contests:
https://github.com/votingworks/vxsuite/assets/264902/53e5ebfa-9a60-4fdd-b784-58a82345de4a

### Yes/No Contests:
https://github.com/votingworks/vxsuite/assets/264902/fd0679b0-6681-4348-a70b-96945c342786

## Testing Plan
- Updated test expectations for changed strings

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
