### PR TITLE
Desktop SegmentedButton

### DIFF
--- a/libs/ui/src/button.test.tsx
+++ b/libs/ui/src/button.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import parseCssColor from 'parse-css-color';
 import { Color, ColorMode, SizeMode } from '@votingworks/types';
 import { assert } from '@votingworks/basics';
 import userEvent from '@testing-library/user-event';
@@ -172,9 +171,6 @@ describe('Button', () => {
 
     render(
       <div>
-        <Button onPress={onPress} variant="danger">
-          Enabled Button
-        </Button>
         <Button onPress={onPress} variant="danger" disabled>
           Disabled Button
         </Button>
@@ -182,8 +178,8 @@ describe('Button', () => {
       { vxTheme: { colorMode: 'contrastLow', sizeMode: 'touchMedium' } }
     );
 
-    const enabledButton = screen.getButton('Enabled Button');
     const disabledButton = screen.getButton('Disabled Button');
+    expect(disabledButton).toBeDisabled();
 
     // Ignores click/tap events:
     userEvent.click(disabledButton);
@@ -194,13 +190,7 @@ describe('Button', () => {
     fireEvent.touchEnd(disabledButton, createTouchEndEventProperties(100, 100));
     expect(onPress).not.toHaveBeenCalled();
 
-    const enabledButtonColor =
-      window.getComputedStyle(enabledButton).backgroundColor;
-    const disabledButtonColor =
-      window.getComputedStyle(disabledButton).backgroundColor;
-    expect(parseCssColor(disabledButtonColor)).not.toEqual(
-      parseCssColor(enabledButtonColor)
-    );
+    expect(disabledButton).toHaveStyleRule('border-style: dashed');
   });
 
   test('fills in background of outlined disabled buttons in desktop theme', () => {

--- a/libs/ui/src/button.tsx
+++ b/libs/ui/src/button.tsx
@@ -283,14 +283,9 @@ function disabledStyles(p: ThemedStyledButtonProps): CSSObject {
     };
   }
 
-  const [foregroundColor, backgroundColor] = isInverse(color)
-    ? [colors.onInverse, colors.inverseBackground]
-    : [colors.onBackground, colors.background];
   return {
     borderStyle: 'dashed',
-    color: foregroundColor,
-    backgroundColor,
-    borderColor: foregroundColor,
+    borderColor: 'currentColor',
   };
 }
 
@@ -336,11 +331,11 @@ export const buttonStyles = css<StyledButtonProps>`
 
   ${(p) => css(colorAndFillStyles(p))}
 
-  &:active {
+  &:active:enabled {
     ${(p) => css(activeStyles(p))}
   }
 
-  &:hover:not(:active) {
+  &:hover:not(:active):enabled {
     ${(p) => css(hoverStyles(p))}
   }
 

--- a/libs/ui/src/segmented_button.test.tsx
+++ b/libs/ui/src/segmented_button.test.tsx
@@ -1,6 +1,7 @@
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '../test/react_testing_library';
 import { SegmentedButton, SegmentedButtonOption } from './segmented_button';
+import { makeTheme } from './themes/make_theme';
 
 type TestOptionId = 'a' | 'b' | 'c';
 
@@ -67,4 +68,37 @@ test('optionally hides label', () => {
 
   // Verify the options are still rendered in an accessible listbox:
   screen.getByRole('listbox', { name: 'Test Label' });
+});
+
+test('with desktop theme', () => {
+  render(
+    <SegmentedButton
+      label="Test Label"
+      onChange={jest.fn()}
+      options={TEST_OPTIONS}
+      selectedOptionId="b"
+    />,
+    { vxTheme: makeTheme({ sizeMode: 'desktop', colorMode: 'desktop' }) }
+  );
+  screen.getByRole('listbox', { name: 'Test Label' });
+  screen.getByRole('option', { name: 'Option A', selected: false });
+  screen.getByRole('option', { name: 'Option B', selected: true });
+  screen.getByRole('option', { name: 'Enable Option C', selected: false });
+});
+
+test('with desktop theme, vertical', () => {
+  render(
+    <SegmentedButton
+      label="Test Label"
+      onChange={jest.fn()}
+      options={TEST_OPTIONS}
+      selectedOptionId="b"
+      vertical
+    />,
+    { vxTheme: makeTheme({ sizeMode: 'desktop', colorMode: 'desktop' }) }
+  );
+  screen.getByRole('listbox', { name: 'Test Label' });
+  screen.getByRole('option', { name: 'Option A', selected: false });
+  screen.getByRole('option', { name: 'Option B', selected: true });
+  screen.getByRole('option', { name: 'Enable Option C', selected: false });
 });

--- a/libs/ui/src/segmented_button.tsx
+++ b/libs/ui/src/segmented_button.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { css, useTheme } from 'styled-components';
 
 import { Button } from './button';
 import { Caption } from './typography';
@@ -37,20 +37,54 @@ const OuterContainer = styled.span`
 
 const LabelContainer = styled(Caption)`
   display: block;
+  margin-bottom: 0.125rem;
 `;
 
 interface OptionsContainerProps {
   isVertical?: boolean;
+  disabled?: boolean;
 }
 
+const desktopStyles = css<OptionsContainerProps>`
+  button:first-child {
+    border-top-left-radius: 0;
+    ${(p) =>
+      p.isVertical
+        ? 'border-top-right-radius: 0;'
+        : 'border-bottom-left-radius: 0;'}
+  }
+
+  button:last-child {
+    ${(p) =>
+      p.isVertical
+        ? 'border-bottom-left-radius: 0;'
+        : 'border-top-right-radius: 0;'}
+    border-bottom-right-radius: 0;
+  }
+
+  &[disabled] {
+    border-style: dashed;
+
+    button {
+      border-color: transparent;
+    }
+
+    background-color: ${(p) => p.theme.colors.containerLow};
+  }
+`;
+
 const OptionsContainer = styled.span<OptionsContainerProps>`
-  border: ${(p) => p.theme.sizes.bordersRem.hairline}rem solid
-    ${(p) => p.theme.colors.foreground};
-  border-radius: 0.25rem;
+  border: ${(p) => p.theme.sizes.bordersRem.thin}rem solid
+    ${(p) => p.theme.colors.outline};
+  border-radius: ${(p) =>
+    p.theme.sizeMode === 'desktop' ? '0.5rem' : '0.25rem'};
   display: inline-flex;
   flex-direction: ${(p) => (p.isVertical ? 'column' : 'row')};
   gap: ${(p) => p.theme.sizes.minTouchAreaSeparationPx}px;
-  padding: 0.75rem;
+  padding: ${(p) => (p.theme.sizeMode === 'desktop' ? undefined : '0.75rem')};
+  overflow: hidden;
+
+  ${(p) => p.theme.colorMode === 'desktop' && desktopStyles}
 `;
 
 /**
@@ -66,6 +100,7 @@ const OptionsContainer = styled.span<OptionsContainerProps>`
 export function SegmentedButton<T extends SegmentedButtonOptionId>(
   props: SegmentedButtonProps<T>
 ): JSX.Element {
+  const theme = useTheme();
   const {
     disabled,
     hideLabel,
@@ -84,26 +119,37 @@ export function SegmentedButton<T extends SegmentedButtonOptionId>(
         </LabelContainer>
       )}
       <OptionsContainer
+        disabled={disabled}
         aria-disabled={disabled}
         aria-label={label}
         aria-orientation={vertical ? 'vertical' : 'horizontal'}
         isVertical={vertical}
         role="listbox"
       >
-        {options.map((o) => (
-          <Button
-            aria-label={o.ariaLabel}
-            aria-selected={o.id === selectedOptionId}
-            disabled={disabled}
-            key={o.id}
-            onPress={onChange}
-            role="option"
-            value={o.id}
-            variant={o.id === selectedOptionId ? 'primary' : 'neutral'}
-          >
-            {o.label}
-          </Button>
-        ))}
+        {options.map((o) => {
+          const isSelected = o.id === selectedOptionId;
+          return (
+            <Button
+              aria-label={o.ariaLabel}
+              aria-selected={o.id === selectedOptionId}
+              disabled={disabled}
+              key={o.id}
+              onPress={onChange}
+              role="option"
+              value={o.id}
+              variant={isSelected ? 'primary' : 'neutral'}
+              fill={
+                theme.colorMode === 'desktop'
+                  ? isSelected
+                    ? 'tinted'
+                    : 'transparent'
+                  : undefined
+              }
+            >
+              {o.label}
+            </Button>
+          );
+        })}
       </OptionsContainer>
     </OuterContainer>
   );


### PR DESCRIPTION
## Overview

Updates SegmentedButton to work with the desktop theme.

This required also tweaking Button, which previously rendered all disabled buttons with the same background in the touchscreen theme. This doesn't work well for segmented buttons, which need to show which button is selected even when disabled. So I nixed that and removed the background color changes for disabled buttons in touchscreen themes.


## Demo Video or Screenshot

https://github.com/votingworks/vxsuite/assets/530106/ff3f4410-44fe-407f-a57a-50edbf23d59c



## Testing Plan
Updated existing automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
