### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,25 +4,15 @@
 
 # The order of this file is important. The last matching rule will take precedence.
 
-# By default assign the vxsuite-eng group. Code reviews will be randomly round-robined within this group to assign someone on the team for a general code review.
-* @votingworks/vxsuite-eng
 
 # More specific ownership rules for more knowledge-specific reviews.
-# It is recommended to continue to include the vxsuite-eng group in these so knowledge doesn't get too siloed and people gain context on code outside of what they own.
-libs/ballot-encoder/ @eventualbuddha @votingworks/vxsuite-eng
-libs/ballot-interpreter-nh/ @eventualbuddha @votingworks/vxsuite-eng
-libs/ballot-interpreter-nh-next/ @eventualbuddha @votingworks/vxsuite-eng
-libs/eslint-plugin-vx/ @eventualbuddha @votingworks/vxsuite-eng
-frontends/election-manager/src/utils/exportable_tallies* @carolinemodic @votingworks/vxsuite-eng 
-frontends/election-manager/src/utils/external_tallies* @carolinemodic @votingworks/vxsuite-eng
-frontends/election-manager/src/utils/sems_tallies* @carolinemodic @votingworks/vxsuite-eng
-frontends/election-manager/src/lib/votecounting* @carolinemodic @votingworks/vxsuite-eng
-libs/utils/src/tallies* @carolinemodic @votingworks/vxsuite-eng
-libs/utils/src/votes* @carolinemodic @votingworks/vxsuite-eng
-libs/utils/src/compressed_tallies* @carolinemodic @votingworks/vxsuite-eng
-libs/logging/ @carolinemodic @votingworks/vxsuite-eng
-.github/ @carolinemodic @votingworks/vxsuite-eng
-libs/auth/ @arsalansufi @votingworks/vxsuite-eng
-libs/dev-dock/ @jonahkagan @votingworks/vxsuite-eng
-libs/grout/ @jonahkagan @votingworks/vxsuite-eng
-libs/usb-drive/ @jonahkagan @votingworks/vxsuite-eng
+libs/ballot-encoder/ @eventualbuddha
+libs/ballot-interpreter-nh/ @eventualbuddha
+libs/ballot-interpreter-nh-next/ @eventualbuddha
+libs/eslint-plugin-vx/ @eventualbuddha
+libs/logging/ @carolinemodic
+.github/ @carolinemodic
+libs/auth/ @arsalansufi
+libs/dev-dock/ @jonahkagan
+libs/grout/ @jonahkagan
+libs/usb-drive/ @jonahkagan

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,15 +4,12 @@
 
 # The order of this file is important. The last matching rule will take precedence.
 
-
-# More specific ownership rules for more knowledge-specific reviews.
 libs/ballot-encoder/ @eventualbuddha
-libs/ballot-interpreter-nh/ @eventualbuddha
-libs/ballot-interpreter-nh-next/ @eventualbuddha
+libs/ballot-interpreter/ @eventualbuddha
 libs/eslint-plugin-vx/ @eventualbuddha
 libs/logging/ @carolinemodic
 .github/ @carolinemodic
 libs/auth/ @arsalansufi
 libs/dev-dock/ @jonahkagan
 libs/grout/ @jonahkagan
-libs/usb-drive/ @jonahkagan
+libs/usb-drive/ @adghayes


### PR DESCRIPTION
Remove random auto-assignment to the vxsuite-eng group on PRs and update some out of date code ownership rules I had around tallies that are mostly to codepaths that no longer exist 