### PR TITLE
Add scaffolding for VxDesign background task processing

### DIFF
--- a/apps/admin/frontend/package.json
+++ b/apps/admin/frontend/package.json
@@ -155,6 +155,9 @@
   },
   "packageManager": "pnpm@8.1.0",
   "vx": {
+    "env": {
+      "VX_MACHINE_TYPE": "admin"
+    },
     "isBundled": true,
     "services": [
       "../backend"

--- a/apps/central-scan/frontend/package.json
+++ b/apps/central-scan/frontend/package.json
@@ -130,6 +130,9 @@
   },
   "packageManager": "pnpm@8.1.0",
   "vx": {
+    "env": {
+      "VX_MACHINE_TYPE": "central-scan"
+    },
     "isBundled": true,
     "services": [
       "../backend"

--- a/apps/design/backend/package.json
+++ b/apps/design/backend/package.json
@@ -17,7 +17,7 @@
     "lint": "pnpm type-check && eslint .",
     "lint:fix": "pnpm type-check && eslint . --fix",
     "pre-commit": "lint-staged",
-    "start": "node ./build/index.js",
+    "start": "node ./build/index.js & node ./build/worker/index.js",
     "test": "is-ci test:ci test:watch",
     "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "jest --coverage",

--- a/apps/design/backend/schema.sql
+++ b/apps/design/backend/schema.sql
@@ -6,3 +6,13 @@ create table elections (
   layout_options_data text not null,
   created_at timestamp not null default current_timestamp
 );
+
+create table background_tasks (
+  id text primary key,
+  task_name text not null,
+  payload text not null,
+  created_at timestamp not null default current_timestamp,
+  started_at timestamp,
+  completed_at timestamp,
+  error text
+);

--- a/apps/design/backend/src/store.test.ts
+++ b/apps/design/backend/src/store.test.ts
@@ -1,133 +1,104 @@
 import { Store } from './store';
 
+const taskName = 'someTaskName';
+
 test('Background task processing - task creation and retrieval', () => {
   const store = Store.memoryStore();
 
-  expect(store.getQueuedBackgroundTasks()).toEqual([]);
+  expect(store.getOldestQueuedBackgroundTask()).toEqual(undefined);
 
-  store.createBackgroundTask('someTaskName', { somePayload: 1 });
-  store.createBackgroundTask('someTaskName', { somePayload: 2 });
-  store.createBackgroundTask('someTaskName', { somePayload: 3 });
+  const task1Id = store.createBackgroundTask(taskName, {
+    somePayload: 1,
+  });
+  const task2Id = store.createBackgroundTask(taskName, {
+    somePayload: 2,
+  });
 
-  const queuedTasks = store.getQueuedBackgroundTasks();
-  expect(queuedTasks).toEqual([
-    {
-      createdAt: expect.any(Date),
-      id: expect.any(String),
-      payload: '{"somePayload":1}',
-      taskName: 'someTaskName',
-    },
-    {
-      createdAt: expect.any(Date),
-      id: expect.any(String),
-      payload: '{"somePayload":2}',
-      taskName: 'someTaskName',
-    },
-    {
-      createdAt: expect.any(Date),
-      id: expect.any(String),
-      payload: '{"somePayload":3}',
-      taskName: 'someTaskName',
-    },
-  ]);
-  const task1Id = queuedTasks[0].id;
-  const task2Id = queuedTasks[1].id;
-  const task3Id = queuedTasks[2].id;
+  expect(store.getOldestQueuedBackgroundTask()).toEqual({
+    createdAt: expect.any(Date),
+    id: task1Id,
+    payload: '{"somePayload":1}',
+    taskName,
+  });
 
   expect(store.getBackgroundTask(task1Id)).toEqual({
     createdAt: expect.any(Date),
     id: task1Id,
     payload: '{"somePayload":1}',
-    taskName: 'someTaskName',
+    taskName,
   });
   expect(store.getBackgroundTask(task2Id)).toEqual({
     createdAt: expect.any(Date),
     id: task2Id,
     payload: '{"somePayload":2}',
-    taskName: 'someTaskName',
+    taskName,
   });
-  expect(store.getBackgroundTask(task3Id)).toEqual({
-    createdAt: expect.any(Date),
-    id: task3Id,
-    payload: '{"somePayload":3}',
-    taskName: 'someTaskName',
-  });
+  expect(store.getBackgroundTask('non-existent-task-id')).toEqual(undefined);
 });
 
 test('Background task processing - starting and completing tasks', () => {
   const store = Store.memoryStore();
 
-  expect(store.getQueuedBackgroundTasks()).toEqual([]);
+  expect(store.getOldestQueuedBackgroundTask()).toEqual(undefined);
 
-  store.createBackgroundTask('someTaskName', { somePayload: 1 });
-  store.createBackgroundTask('someTaskName', { somePayload: 2 });
+  const task1Id = store.createBackgroundTask(taskName, {
+    somePayload: 1,
+  });
+  const task2Id = store.createBackgroundTask(taskName, {
+    somePayload: 2,
+  });
 
-  const queuedTasks = store.getQueuedBackgroundTasks();
-  expect(queuedTasks).toEqual([
-    {
-      createdAt: expect.any(Date),
-      id: expect.any(String),
-      payload: '{"somePayload":1}',
-      taskName: 'someTaskName',
-    },
-    {
-      createdAt: expect.any(Date),
-      id: expect.any(String),
-      payload: '{"somePayload":2}',
-      taskName: 'someTaskName',
-    },
-  ]);
-  const task1Id = queuedTasks[0].id;
-  const task2Id = queuedTasks[1].id;
+  expect(store.getOldestQueuedBackgroundTask()).toEqual({
+    createdAt: expect.any(Date),
+    id: task1Id,
+    payload: '{"somePayload":1}',
+    taskName,
+  });
 
   // Start a task
   store.startBackgroundTask(task1Id);
-  expect(store.getQueuedBackgroundTasks()).toEqual([
-    {
-      createdAt: expect.any(Date),
-      id: task2Id,
-      payload: '{"somePayload":2}',
-      taskName: 'someTaskName',
-    },
-  ]);
+  expect(store.getOldestQueuedBackgroundTask()).toEqual({
+    createdAt: expect.any(Date),
+    id: task2Id,
+    payload: '{"somePayload":2}',
+    taskName,
+  });
   expect(store.getBackgroundTask(task1Id)).toEqual({
     createdAt: expect.any(Date),
     id: task1Id,
     payload: '{"somePayload":1}',
     startedAt: expect.any(Date),
-    taskName: 'someTaskName',
+    taskName,
   });
 
   // Complete a task
   store.completeBackgroundTask(task1Id);
-  expect(store.getQueuedBackgroundTasks()).toEqual([
-    {
-      createdAt: expect.any(Date),
-      id: task2Id,
-      payload: '{"somePayload":2}',
-      taskName: 'someTaskName',
-    },
-  ]);
+  expect(store.getOldestQueuedBackgroundTask()).toEqual({
+    createdAt: expect.any(Date),
+    id: task2Id,
+    payload: '{"somePayload":2}',
+    taskName,
+  });
   expect(store.getBackgroundTask(task1Id)).toEqual({
     completedAt: expect.any(Date),
     createdAt: expect.any(Date),
     id: task1Id,
     payload: '{"somePayload":1}',
     startedAt: expect.any(Date),
-    taskName: 'someTaskName',
+    taskName,
   });
 
   // Complete a task with an error
   store.startBackgroundTask(task2Id);
-  store.completeBackgroundTask(task2Id, 'someError');
-  expect(store.getQueuedBackgroundTasks()).toEqual([]);
+  store.completeBackgroundTask(task2Id, 'Whoa!');
+  expect(store.getOldestQueuedBackgroundTask()).toEqual(undefined);
   expect(store.getBackgroundTask(task2Id)).toEqual({
     completedAt: expect.any(Date),
     createdAt: expect.any(Date),
-    error: 'someError',
+    error: 'Whoa!',
     id: task2Id,
     payload: '{"somePayload":2}',
     startedAt: expect.any(Date),
-    taskName: 'someTaskName',
+    taskName,
   });
 });

--- a/apps/design/backend/src/store.test.ts
+++ b/apps/design/backend/src/store.test.ts
@@ -1,0 +1,133 @@
+import { Store } from './store';
+
+test('Background task processing - task creation and retrieval', () => {
+  const store = Store.memoryStore();
+
+  expect(store.getQueuedBackgroundTasks()).toEqual([]);
+
+  store.createBackgroundTask('someTaskName', { somePayload: 1 });
+  store.createBackgroundTask('someTaskName', { somePayload: 2 });
+  store.createBackgroundTask('someTaskName', { somePayload: 3 });
+
+  const queuedTasks = store.getQueuedBackgroundTasks();
+  expect(queuedTasks).toEqual([
+    {
+      createdAt: expect.any(Date),
+      id: expect.any(String),
+      payload: '{"somePayload":1}',
+      taskName: 'someTaskName',
+    },
+    {
+      createdAt: expect.any(Date),
+      id: expect.any(String),
+      payload: '{"somePayload":2}',
+      taskName: 'someTaskName',
+    },
+    {
+      createdAt: expect.any(Date),
+      id: expect.any(String),
+      payload: '{"somePayload":3}',
+      taskName: 'someTaskName',
+    },
+  ]);
+  const task1Id = queuedTasks[0].id;
+  const task2Id = queuedTasks[1].id;
+  const task3Id = queuedTasks[2].id;
+
+  expect(store.getBackgroundTask(task1Id)).toEqual({
+    createdAt: expect.any(Date),
+    id: task1Id,
+    payload: '{"somePayload":1}',
+    taskName: 'someTaskName',
+  });
+  expect(store.getBackgroundTask(task2Id)).toEqual({
+    createdAt: expect.any(Date),
+    id: task2Id,
+    payload: '{"somePayload":2}',
+    taskName: 'someTaskName',
+  });
+  expect(store.getBackgroundTask(task3Id)).toEqual({
+    createdAt: expect.any(Date),
+    id: task3Id,
+    payload: '{"somePayload":3}',
+    taskName: 'someTaskName',
+  });
+});
+
+test('Background task processing - starting and completing tasks', () => {
+  const store = Store.memoryStore();
+
+  expect(store.getQueuedBackgroundTasks()).toEqual([]);
+
+  store.createBackgroundTask('someTaskName', { somePayload: 1 });
+  store.createBackgroundTask('someTaskName', { somePayload: 2 });
+
+  const queuedTasks = store.getQueuedBackgroundTasks();
+  expect(queuedTasks).toEqual([
+    {
+      createdAt: expect.any(Date),
+      id: expect.any(String),
+      payload: '{"somePayload":1}',
+      taskName: 'someTaskName',
+    },
+    {
+      createdAt: expect.any(Date),
+      id: expect.any(String),
+      payload: '{"somePayload":2}',
+      taskName: 'someTaskName',
+    },
+  ]);
+  const task1Id = queuedTasks[0].id;
+  const task2Id = queuedTasks[1].id;
+
+  // Start a task
+  store.startBackgroundTask(task1Id);
+  expect(store.getQueuedBackgroundTasks()).toEqual([
+    {
+      createdAt: expect.any(Date),
+      id: task2Id,
+      payload: '{"somePayload":2}',
+      taskName: 'someTaskName',
+    },
+  ]);
+  expect(store.getBackgroundTask(task1Id)).toEqual({
+    createdAt: expect.any(Date),
+    id: task1Id,
+    payload: '{"somePayload":1}',
+    startedAt: expect.any(Date),
+    taskName: 'someTaskName',
+  });
+
+  // Complete a task
+  store.completeBackgroundTask(task1Id);
+  expect(store.getQueuedBackgroundTasks()).toEqual([
+    {
+      createdAt: expect.any(Date),
+      id: task2Id,
+      payload: '{"somePayload":2}',
+      taskName: 'someTaskName',
+    },
+  ]);
+  expect(store.getBackgroundTask(task1Id)).toEqual({
+    completedAt: expect.any(Date),
+    createdAt: expect.any(Date),
+    id: task1Id,
+    payload: '{"somePayload":1}',
+    startedAt: expect.any(Date),
+    taskName: 'someTaskName',
+  });
+
+  // Complete a task with an error
+  store.startBackgroundTask(task2Id);
+  store.completeBackgroundTask(task2Id, 'someError');
+  expect(store.getQueuedBackgroundTasks()).toEqual([]);
+  expect(store.getBackgroundTask(task2Id)).toEqual({
+    completedAt: expect.any(Date),
+    createdAt: expect.any(Date),
+    error: 'someError',
+    id: task2Id,
+    payload: '{"somePayload":2}',
+    startedAt: expect.any(Date),
+    taskName: 'someTaskName',
+  });
+});

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -412,13 +412,13 @@ export class Store {
   // Background task processing
   //
 
-  getQueuedBackgroundTasks(): BackgroundTask[] {
+  getOldestQueuedBackgroundTask(): Optional<BackgroundTask> {
     const sql = `${getBackgroundTasksBaseQuery}
       where started_at is null
-      order by created_at asc
+      order by created_at asc limit 1
     `;
-    const rows = this.client.all(sql) as BackgroundTaskRow[];
-    return rows.map(backgroundTaskRowToBackgroundTask);
+    const row = this.client.one(sql) as Optional<BackgroundTaskRow>;
+    return row ? backgroundTaskRowToBackgroundTask(row) : undefined;
   }
 
   getBackgroundTask(taskId: Id): Optional<BackgroundTask> {

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -455,25 +455,14 @@ export class Store {
   }
 
   completeBackgroundTask(taskId: Id, error?: string): void {
-    if (error) {
-      this.client.run(
-        `
-        update background_tasks
-        set completed_at = current_timestamp, error = ?
-        where id = ?
-        `,
-        error,
-        taskId
-      );
-    } else {
-      this.client.run(
-        `
-        update background_tasks
-        set completed_at = current_timestamp
-        where id = ?
-        `,
-        taskId
-      );
-    }
+    this.client.run(
+      `
+      update background_tasks
+      set completed_at = current_timestamp, error = ?
+      where id = ?
+      `,
+      error ?? null,
+      taskId
+    );
   }
 }

--- a/apps/design/backend/src/worker/index.ts
+++ b/apps/design/backend/src/worker/index.ts
@@ -1,0 +1,30 @@
+import { ensureDirSync } from 'fs-extra';
+import path from 'path';
+import { assertDefined } from '@votingworks/basics';
+
+import { WORKSPACE } from '../globals';
+import { Store } from '../store';
+import * as worker from './worker';
+
+async function main(): Promise<void> {
+  const workspacePath = path.resolve(assertDefined(WORKSPACE));
+  ensureDirSync(workspacePath);
+  const dbPath = path.join(workspacePath, 'design-backend.db');
+  const store = Store.fileStore(dbPath);
+  worker.start({ store });
+  return Promise.resolve();
+}
+
+if (require.main === module) {
+  main()
+    .then(() => {
+      process.stdout.write('VxDesign background worker running\n');
+      process.exitCode = 0;
+    })
+    .catch((error) => {
+      process.stderr.write(
+        `Error starting VxDesign background worker:\n${error.stack}\n`
+      );
+      process.exitCode = 1;
+    });
+}

--- a/apps/design/backend/src/worker/worker.ts
+++ b/apps/design/backend/src/worker/worker.ts
@@ -14,14 +14,13 @@ async function processBackgroundTask(
 async function processBackgroundTasks(store: Store): Promise<void> {
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const queuedTasks = store.getQueuedBackgroundTasks();
+    const nextTask = store.getOldestQueuedBackgroundTask();
 
-    if (queuedTasks.length === 0) {
+    if (!nextTask) {
       await sleep(1000);
       continue;
     }
 
-    const nextTask = queuedTasks[0];
     store.startBackgroundTask(nextTask.id);
     process.stdout.write(`⏳ Processing background task ${nextTask.id}...\n`);
     try {

--- a/apps/design/backend/src/worker/worker.ts
+++ b/apps/design/backend/src/worker/worker.ts
@@ -1,0 +1,46 @@
+import { extractErrorMessage, sleep } from '@votingworks/basics';
+
+import { BackgroundTask, Store } from '../store';
+
+async function processBackgroundTask(
+  _store: Store, // eslint-disable-line @typescript-eslint/no-unused-vars
+  _task: BackgroundTask // eslint-disable-line @typescript-eslint/no-unused-vars
+): Promise<void> {
+  // Simulate a long-running operation
+  // TODO(arsalan): Implement actual processing logic
+  await sleep(3000);
+}
+
+async function processBackgroundTasks(store: Store): Promise<void> {
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const queuedTasks = store.getQueuedBackgroundTasks();
+
+    if (queuedTasks.length === 0) {
+      await sleep(1000);
+      continue;
+    }
+
+    const nextTask = queuedTasks[0];
+    store.startBackgroundTask(nextTask.id);
+    process.stdout.write(`⏳ Processing background task ${nextTask.id}...\n`);
+    try {
+      await processBackgroundTask(store, nextTask);
+    } catch (error) {
+      const errorMessage = extractErrorMessage(error);
+      store.completeBackgroundTask(nextTask.id, errorMessage);
+      process.stdout.write(
+        `❌ Error processing background task ${nextTask.id}:\n${errorMessage}\n`
+      );
+      continue;
+    }
+    store.completeBackgroundTask(nextTask.id);
+    process.stdout.write(
+      `✅ Finished processing background task ${nextTask.id}\n`
+    );
+  }
+}
+
+export function start({ store }: { store: Store }): void {
+  setTimeout(() => processBackgroundTasks(store));
+}

--- a/apps/mark-scan/frontend/package.json
+++ b/apps/mark-scan/frontend/package.json
@@ -137,6 +137,9 @@
   },
   "packageManager": "pnpm@8.1.0",
   "vx": {
+    "env": {
+      "VX_MACHINE_TYPE": "mark-scan"
+    },
     "isBundled": true,
     "services": [
       "../backend"

--- a/apps/mark/frontend/package.json
+++ b/apps/mark/frontend/package.json
@@ -136,6 +136,9 @@
   },
   "packageManager": "pnpm@8.1.0",
   "vx": {
+    "env": {
+      "VX_MACHINE_TYPE": "mark"
+    },
     "isBundled": true,
     "services": [
       "../backend"

--- a/apps/scan/frontend/package.json
+++ b/apps/scan/frontend/package.json
@@ -118,6 +118,9 @@
   },
   "packageManager": "pnpm@8.1.0",
   "vx": {
+    "env": {
+      "VX_MACHINE_TYPE": "scan"
+    },
     "isBundled": true,
     "services": [
       "../backend"

--- a/libs/auth/src/cryptography.end_to_end.test.ts
+++ b/libs/auth/src/cryptography.end_to_end.test.ts
@@ -17,8 +17,8 @@ import {
 } from './cryptography';
 
 /**
- * Whereas openssl.test.ts focuses on code coverage, openssl.end_to_end.test.ts uses no mocks and
- * verifies:
+ * Whereas cryptography.test.ts focuses on code coverage, cryptography.end_to_end.test.ts uses no
+ * mocks and verifies:
  * - The complex control flows of createCert and signMessage
  * - The correctness of OpenSSL commands
  */

--- a/script/src/run-dev/index.ts
+++ b/script/src/run-dev/index.ts
@@ -169,7 +169,9 @@ export async function main(
             npmBinCommand({
               name: `${name}:run`,
               command:
-                `while [ ! -f build/index.js ]; do echo "Waiting for build…"; sleep 1; done; nodemon --watch build --delay 1 --exitcrash --exec NODE_ENV=development VX_MACHINE_TYPE=${frontend} node build/index.js`,
+                'while [ ! -f build/index.js ]; do echo "Waiting for build…"; sleep 1; done; ' +
+                'nodemon --watch build --delay 1 --exitcrash --exec ' +
+                'NODE_ENV=development pnpm start',
               prefixColor: 'cyan',
               cwd: serviceRoot,
               env: extraEnv,


### PR DESCRIPTION
_Easiest reviewed by commit_

## Overview

This PR adds scaffolding for VxDesign background task processing, something that we need for cloud translation and audio clip generation but that could also prove useful for ballot generation, which is likely to become more time consuming as we build additional VxDesign functionality.

Everything is running locally, but I'm designing things to make the eventual transition to a Heroku deployment as easy as possible. I'm accordingly 1) running the background worker in its own process separate from the backend server process and 2) mimicking the DB schema that Arlo uses for background task processing.

## Demo Video

Here, I'm having the election-creation endpoint kick off a no-op job:

https://github.com/votingworks/vxsuite/assets/12616928/7c09d907-b680-4c3d-bfef-65bd5a3d74dd

## Testing Plan

- [x] Added unit tests for store methods
- [x] Manually tested end-to-end