### PR TITLE
Allow increasing inactive session time limit for SLI testing

### DIFF
--- a/libs/auth/src/sessions.test.ts
+++ b/libs/auth/src/sessions.test.ts
@@ -2,13 +2,11 @@ import { DEFAULT_OVERALL_SESSION_TIME_LIMIT_HOURS } from '@votingworks/types';
 import { computeSessionEndTime, SessionConfig } from './sessions';
 
 test('computeSessionEndTime with default config params', () => {
+  const defaultSessionConfig: SessionConfig = {
+    overallSessionTimeLimitHours: DEFAULT_OVERALL_SESSION_TIME_LIMIT_HOURS,
+  };
   const startTime = new Date();
-  const endTime = computeSessionEndTime(
-    {
-      overallSessionTimeLimitHours: DEFAULT_OVERALL_SESSION_TIME_LIMIT_HOURS,
-    },
-    startTime
-  );
+  const endTime = computeSessionEndTime(defaultSessionConfig, startTime);
   expect(endTime).toEqual(new Date(startTime.getTime() + 12 * 60 * 60 * 1000));
 });
 

--- a/libs/backend/src/ballot_package/ballot_package_io.test.ts
+++ b/libs/backend/src/ballot_package/ballot_package_io.test.ts
@@ -252,7 +252,7 @@ test('configures using the most recently created ballot package for an election'
     ...DEFAULT_SYSTEM_SETTINGS,
     auth: {
       ...DEFAULT_SYSTEM_SETTINGS.auth,
-      inactiveSessionTimeLimitMinutes: 25,
+      inactiveSessionTimeLimitMinutes: 20,
       overallSessionTimeLimitHours: 11,
       numIncorrectPinAttemptsAllowedBeforeCardLockout: 7,
     },

--- a/libs/types/src/auth/auth.ts
+++ b/libs/types/src/auth/auth.ts
@@ -79,14 +79,17 @@ export const DEFAULT_STARTING_CARD_LOCKOUT_DURATION_SECONDS: StartingCardLockout
  * The inactive/idle session time limit, after which the user must reauthenticate - a VVSG2
  * requirement
  */
-export type InactiveSessionTimeLimitMinutes = 10 | 15 | 20 | 25 | 30;
+export type InactiveSessionTimeLimitMinutes = 10 | 15 | 20 | 30 | 360;
 export const InactiveSessionTimeLimitMinutesSchema: z.ZodSchema<InactiveSessionTimeLimitMinutes> =
   z.union([
     z.literal(10),
     z.literal(15),
     z.literal(20),
-    z.literal(25),
     z.literal(30),
+    // Allow significantly increasing the inactive session time limit for cert/pre-cert testing,
+    // which can involve long-running exports
+    // TODO: Pause the inactive session time limit timer during export operations
+    z.literal(360),
   ]);
 export const DEFAULT_INACTIVE_SESSION_TIME_LIMIT_MINUTES: InactiveSessionTimeLimitMinutes = 30;
 


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/4128

A short-term precautionary measure to make sure that SLI doesn't hit the inactive session time limit when exporting large numbers of CVRs on VxCentralScan. We'll need to remember to set the higher time limit in the system settings file in the election package that we provide them, which I'll open an issue to track. Will also open an issue to track the longer-term fix of pausing the inactive session time limit timer during export operations.