### PR TITLE
[libs/ui] Remove appStrings.[date|number]

### DIFF
--- a/libs/mark-flow-ui/src/components/candidate_contest.tsx
+++ b/libs/mark-flow-ui/src/components/candidate_contest.tsx
@@ -16,7 +16,6 @@ import {
   Main,
   Modal,
   P,
-  Font,
   VirtualKeyboard,
   Caption,
   TouchTextInput,
@@ -236,9 +235,7 @@ export function CandidateContest({
         >
           <Caption>
             {appStrings.labelNumVotesRemaining()}{' '}
-            <Font weight="bold">
-              <NumberString value={contest.seats - vote.length} />
-            </Font>
+            <NumberString value={contest.seats - vote.length} weight="bold" />
             <AudioOnly>
               {appStrings.instructionsBmdContestNavigation()}
             </AudioOnly>

--- a/libs/mark-flow-ui/src/components/election_info.tsx
+++ b/libs/mark-flow-ui/src/components/election_info.tsx
@@ -13,12 +13,13 @@ import {
   H1,
   P,
   Caption,
-  Font,
   Seal,
   electionStrings,
   appStrings,
   PrecinctSelectionName,
   PrimaryElectionTitlePrefix,
+  NumberString,
+  DateString,
 } from '@votingworks/ui';
 
 const Container = styled.div`
@@ -79,7 +80,7 @@ export function ElectionInfo({
         <P
           aria-label={`${electionDate}. ${county.name}, ${state}. ${precinctName}.`}
         >
-          <Font weight="bold">{appStrings.date(new Date(date))}</Font>
+          <DateString value={new Date(date)} weight="bold" />
           <br />
           <Caption>
             {/* TODO(kofi): Use more language-agnostic delimiter (e.g. '|') or find way to translate commas. */}
@@ -109,7 +110,7 @@ export function ElectionInfo({
               <br />
               <Caption>
                 {appStrings.labelNumBallotContests()}{' '}
-                <Font weight="bold">{appStrings.number(contestCount)}</Font>
+                <NumberString value={contestCount} weight="bold" />
               </Caption>
             </React.Fragment>
           )}

--- a/libs/mark-flow-ui/src/components/review.tsx
+++ b/libs/mark-flow-ui/src/components/review.tsx
@@ -21,6 +21,7 @@ import {
   appStrings,
   CandidatePartyList,
   electionStrings,
+  NumberString,
 } from '@votingworks/ui';
 
 import { getSingleYesNoVote } from '@votingworks/utils';
@@ -68,7 +69,7 @@ function CandidateContestResult({
           ) : (
             <React.Fragment>
               {appStrings.labelNumVotesRemaining()}{' '}
-              {appStrings.number(remainingChoices)}
+              <NumberString value={remainingChoices} />
             </React.Fragment>
           )
         ) : undefined

--- a/libs/ui/src/ui_strings/app_strings.test.tsx
+++ b/libs/ui/src/ui_strings/app_strings.test.tsx
@@ -1,0 +1,10 @@
+import { AppStringKey, appStrings } from './app_strings';
+
+// TODO(kofi): Quick-and-dirty placeholder -- convert to a lint check.
+test('uiStringKeys match object keys', () => {
+  for (const objectKey of Object.keys(appStrings)) {
+    const renderedString = appStrings[objectKey as AppStringKey]();
+
+    expect(renderedString.props.uiStringKey).toEqual(objectKey);
+  }
+});

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -1,6 +1,4 @@
 import { Font } from '../typography';
-import { DateString } from './date_string';
-import { NumberString } from './number_string';
 import { UiString } from './ui_string';
 
 // TODO(kofi): Add lint rule to ensure object keys match uiStringKey props.
@@ -62,10 +60,6 @@ export const appStrings = {
   ),
 
   buttonYes: () => <UiString uiStringKey="buttonYes">Yes</UiString>,
-
-  // TODO(kofi): Remove `date` and `number` and have consumers use the
-  // components directly, since this indirection doesn't provided added value.
-  date: (value: Date) => <DateString value={value} />,
 
   instructionsBmdBallotNavigation: () => (
     <UiString uiStringKey="instructionsBmdBallotNavigation">
@@ -207,10 +201,6 @@ export const appStrings = {
     <UiString uiStringKey="labelWriteInParenthesized">(write-in)</UiString>
   ),
 
-  // TODO(kofi): Remove `date` and `number` and have consumers use the
-  // components directly, since this indirection doesn't provided added value.
-  number: (value: number) => <NumberString value={value} />,
-
   promptBmdConfirmRemoveWriteIn: () => (
     <UiString uiStringKey="promptBmdConfirmRemoveWriteIn">
       Do you want to deselect and remove your write-in candidate?
@@ -240,3 +230,5 @@ export const appStrings = {
     </UiString>
   ),
 } as const;
+
+export type AppStringKey = keyof typeof appStrings;

--- a/libs/ui/src/ui_strings/date_string.tsx
+++ b/libs/ui/src/ui_strings/date_string.tsx
@@ -1,18 +1,19 @@
 import { format } from '@votingworks/utils';
 import { useLanguageContext } from './language_context';
+import { Font, FontProps } from '../typography';
 
-export interface DateStringProps {
+export interface DateStringProps extends FontProps {
   value: Date;
 }
 export function DateString(props: DateStringProps): JSX.Element {
-  const { value } = props;
+  const { value, ...rest } = props;
 
   const languageContext = useLanguageContext();
 
   return (
     // TODO(kofi): fetch audio IDs for the given date.
-    <span data-audio-ids={undefined}>
+    <Font data-audio-ids={undefined} {...rest}>
       {format.localeLongDate(value, languageContext?.currentLanguageCode)}
-    </span>
+    </Font>
   );
 }

--- a/libs/ui/src/ui_strings/number_string.tsx
+++ b/libs/ui/src/ui_strings/number_string.tsx
@@ -1,18 +1,19 @@
 import { format } from '@votingworks/utils';
 import { useLanguageContext } from './language_context';
+import { Font, FontProps } from '../typography';
 
-export interface NumberStringProps {
+export interface NumberStringProps extends FontProps {
   value: number;
 }
 export function NumberString(props: NumberStringProps): JSX.Element {
-  const { value } = props;
+  const { value, ...rest } = props;
 
   const languageContext = useLanguageContext();
 
   return (
     // TODO(kofi): fetch audio ID(s) for the given value.
-    <span data-audio-ids={undefined}>
+    <Font data-audio-ids={undefined} {...rest}>
       {format.count(value, languageContext?.currentLanguageCode)}
-    </span>
+    </Font>
   );
 }


### PR DESCRIPTION
## Overview

Removing `appStrings.[date|number]` in favour of using `<NumberString>` and `<DateString>` directly.

Also enabled adding a stop-gap unit test to enforce matching object keys and `uiStringKey`s.

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
