### PR TITLE
[i18n/Aduio] Consolidate strings on BMD CastBallotPage screens

### DIFF
--- a/libs/mark-flow-ui/src/pages/cast_ballot_page.tsx
+++ b/libs/mark-flow-ui/src/pages/cast_ballot_page.tsx
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 
 import {
   Button,
-  Font,
   H1,
   Icons,
   InsertBallotImage,
@@ -10,6 +9,7 @@ import {
   P,
   Screen,
   VerifyBallotImage,
+  appStrings,
 } from '@votingworks/ui';
 
 const Instructions = styled.ol`
@@ -70,25 +70,24 @@ export function CastBallotPage({
     <Screen white>
       <Main padded>
         <div id="audiofocus">
-          <H1 aria-label="You’re almost done.">You’re Almost Done</H1>
-          <P>Your official ballot is printing. To finish voting you need to…</P>
+          <H1>{appStrings.titleBmdCastBallotScreen()}</H1>
+          <P>{appStrings.instructionsBmdCastBallotPreamble()}</P>
           <Instructions>
             <ListItem>
               <InstructionImageContainer>
                 <VerifyBallotImage />
               </InstructionImageContainer>
-              <span>1. Verify your official ballot.</span>
+              <span>{appStrings.instructionsBmdCastBallotStep1()}</span>
             </ListItem>
             <ListItem>
               <InstructionImageContainer>
                 <InsertBallotImage disableAnimation />
               </InstructionImageContainer>
-              <span>2. Scan your official ballot.</span>
+              <span>{appStrings.instructionsBmdCastBallotStep2()}</span>
             </ListItem>
           </Instructions>
           <P>
-            <Icons.Info /> <Font weight="bold">Need help?</Font> Ask a poll
-            worker.
+            <Icons.Info /> {appStrings.noteAskPollWorkerForHelp()}
           </P>
         </div>
         <Done>
@@ -97,7 +96,7 @@ export function CastBallotPage({
             variant="primary"
             icon="Done"
           >
-            Done
+            {appStrings.buttonDone()}
           </Button>
         </Done>
       </Main>

--- a/libs/mark-flow-ui/src/pages/print_page.tsx
+++ b/libs/mark-flow-ui/src/pages/print_page.tsx
@@ -5,10 +5,11 @@ import {
   H1,
   Main,
   printElement as DefaultPrintElement,
-  Prose,
   Screen,
   useLock,
   PrintingBallotImage,
+  appStrings,
+  Font,
 } from '@votingworks/ui';
 
 import {
@@ -85,12 +86,12 @@ export function PrintPage({
   return (
     <Screen white>
       <Main centerChild padded>
-        <Prose textCenter id="audiofocus">
+        <Font align="center" id="audiofocus">
           <PrintingBallotImage />
           <div>
-            <H1>Printing Your Official Ballot...</H1>
+            <H1>{appStrings.titleBmdPrintScreen()}</H1>
           </div>
-        </Prose>
+        </Font>
       </Main>
     </Screen>
   );

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -37,6 +37,8 @@ export const appStrings = {
 
   buttonChange: () => <UiString uiStringKey="buttonChange">Change</UiString>,
 
+  buttonDone: () => <UiString uiStringKey="buttonDone">Done</UiString>,
+
   buttonDisplaySettings: () => (
     <UiString uiStringKey="buttonDisplaySettings">Color/Size</UiString>
   ),
@@ -68,6 +70,25 @@ export const appStrings = {
       and right buttons. To navigate through contest choices, use the up and
       down buttons. To select or unselect a contest choice as your vote, use the
       select button. Press the right button now to advance to the first contest.
+    </UiString>
+  ),
+
+  instructionsBmdCastBallotPreamble: () => (
+    <UiString uiStringKey="instructionsBmdCastBallotPreamble">
+      Your official ballot is printing. Complete the following steps to finish
+      voting:
+    </UiString>
+  ),
+
+  instructionsBmdCastBallotStep1: () => (
+    <UiString uiStringKey="instructionsBmdCastBallotStep1">
+      1. Verify your official ballot.
+    </UiString>
+  ),
+
+  instructionsBmdCastBallotStep2: () => (
+    <UiString uiStringKey="instructionsBmdCastBallotStep2">
+      2. Scan your official ballot.
     </UiString>
   ),
 
@@ -201,9 +222,27 @@ export const appStrings = {
     <UiString uiStringKey="labelWriteInParenthesized">(write-in)</UiString>
   ),
 
+  noteAskPollWorkerForHelp: () => (
+    <UiString uiStringKey="noteAskPollWorkerForHelp">
+      Ask a poll worker if you need help.
+    </UiString>
+  ),
+
   promptBmdConfirmRemoveWriteIn: () => (
     <UiString uiStringKey="promptBmdConfirmRemoveWriteIn">
       Do you want to deselect and remove your write-in candidate?
+    </UiString>
+  ),
+
+  titleBmdCastBallotScreen: () => (
+    <UiString uiStringKey="titleBmdCastBallotScreen">
+      You’re Almost Done
+    </UiString>
+  ),
+
+  titleBmdPrintScreen: () => (
+    <UiString uiStringKey="titleBmdPrintScreen">
+      Printing Your Official Ballot...
     </UiString>
   ),
 


### PR DESCRIPTION
## Overview

_Related spec [here](https://docs.google.com/document/d/1a2GRj1g4aOawEssPdTCgbv-qs28d-M_dyMEfzm4I4nM/edit?usp=sharing)._

Converting voter-facing strings on the `CastBallotPage` and `PrintPage` screens in `Mark` and `Mark-Scan` to `<UiString>`s

Removing redundant `aria-label`s and deprecated `<Prose>` elements along the way.

## Demo Video or Screenshot
### CastBallotPage:
https://github.com/votingworks/vxsuite/assets/264902/d8fa56d5-a016-4f1a-a573-33e0e75a8e6f

### PrintPage:
https://github.com/votingworks/vxsuite/assets/264902/78b7f654-152b-46c0-8791-6cd4040c5612

## Testing Plan
- Manual

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
