### PR TITLE
Add build in thinkpad card reader support

### DIFF
--- a/libs/utils/src/Hardware/utils.ts
+++ b/libs/utils/src/Hardware/utils.ts
@@ -16,16 +16,22 @@ export const OmniKeyCardReaderManufacturer = 'HID Global';
 export const OmniKeyCardReaderVendorId = 0x076b;
 export const OmniKeyCardReaderProductId = 0x3031;
 
+export const LenovoBuiltInCardReaderVendorId = 0x2ce3;
+export const LenovoBuiltInCardReaderProductId = 0x9563;
+
 /**
  * Determines whether a device is the card reader.
  */
 export function isCardReader(device: KioskBrowser.Device): boolean {
-  return (
+  const isOmniKeyReader =
     (device.manufacturer.replace(/_/g, ' ') === OmniKeyCardReaderManufacturer &&
       device.deviceName.replace(/_/g, ' ') === OmniKeyCardReaderDeviceName) ||
     (device.vendorId === OmniKeyCardReaderVendorId &&
-      device.productId === OmniKeyCardReaderProductId)
-  );
+      device.productId === OmniKeyCardReaderProductId);
+  const isBuiltInReader =
+    device.vendorId === LenovoBuiltInCardReaderVendorId &&
+    device.productId === LenovoBuiltInCardReaderProductId;
+  return isOmniKeyReader || isBuiltInReader;
 }
 
 export const BrotherHll5100DnVendorId = 0x04f9;


### PR DESCRIPTION
## Overview
Adds support for the build in card reader on the new lenovo thinkpad model 
<!-- add a link to a GitHub Issue here -->
https://github.com/votingworks/vxsuite/issues/4164 

## Demo Video or Screenshot
n/a

## Testing Plan
Run on new lenovo thinkpad, did not see card reader not detected screen, used built in card reader successfully 

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
