### PR TITLE
[Mark|Mark-Scan] Replace text on IdlePage screens with <UiString>s

### DIFF
--- a/apps/mark-scan/frontend/src/app_quit_on_idle.test.tsx
+++ b/apps/mark-scan/frontend/src/app_quit_on_idle.test.tsx
@@ -3,6 +3,10 @@ import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 
 import userEvent from '@testing-library/user-event';
 import { createMocks as createReactIdleTimerMocks } from 'react-idle-timer';
+import {
+  IDLE_RESET_TIMEOUT_SECONDS,
+  IDLE_TIMEOUT_SECONDS,
+} from '@votingworks/mark-flow-ui';
 import { render, screen, waitFor } from '../test/react_testing_library';
 import { App } from './app';
 
@@ -14,11 +18,7 @@ import {
   setStateInStorage,
 } from '../test/helpers/election';
 
-import {
-  IDLE_RESET_TIMEOUT_SECONDS,
-  IDLE_TIMEOUT_SECONDS,
-  QUIT_KIOSK_IDLE_SECONDS,
-} from './config/globals';
+import { QUIT_KIOSK_IDLE_SECONDS } from './config/globals';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
 let apiMock: ApiMock;

--- a/apps/mark-scan/frontend/src/components/ballot.tsx
+++ b/apps/mark-scan/frontend/src/components/ballot.tsx
@@ -1,6 +1,10 @@
 import { useState } from 'react';
 import { Route, Switch } from 'react-router-dom';
-import { IdleTimerProvider } from 'react-idle-timer';
+import {
+  DEFAULT_EVENTS,
+  EventsType,
+  IdleTimerProvider,
+} from 'react-idle-timer';
 
 import { IDLE_TIMEOUT_SECONDS, Paths } from '@votingworks/mark-flow-ui';
 import { ContestScreen } from '../pages/contest_screen';
@@ -11,6 +15,16 @@ import { PrintPage } from '../pages/print_page';
 import { ReviewScreen } from '../pages/review_screen';
 import { StartScreen } from '../pages/start_screen';
 import { ContinueToReviewPage } from '../pages/continue_to_review_page';
+
+const USER_ACTIVITY_EVENT_TYPES: EventsType[] = (() => {
+  const allEvents = new Set(DEFAULT_EVENTS);
+  // The IdlePage has an autofocus button to enable gamepad interaction,
+  // ends up triggering a focus event that would reset the idle timer.
+  // Ignoring focus events here, since we expect that any user-triggered
+  // focus event would be preceded by a touch/mouse/keyboard event.
+  allEvents.delete('focus');
+  return [...allEvents];
+})();
 
 export function Ballot(): JSX.Element {
   const [isIdle, setIsIdle] = useState(false);
@@ -29,6 +43,7 @@ export function Ballot(): JSX.Element {
   return (
     <IdleTimerProvider
       element={document}
+      events={USER_ACTIVITY_EVENT_TYPES}
       onActive={onActive}
       onIdle={onIdle}
       debounce={250}

--- a/apps/mark-scan/frontend/src/components/ballot.tsx
+++ b/apps/mark-scan/frontend/src/components/ballot.tsx
@@ -2,8 +2,7 @@ import { useState } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import { IdleTimerProvider } from 'react-idle-timer';
 
-import { Paths } from '@votingworks/mark-flow-ui';
-import { IDLE_TIMEOUT_SECONDS } from '../config/globals';
+import { IDLE_TIMEOUT_SECONDS, Paths } from '@votingworks/mark-flow-ui';
 import { ContestScreen } from '../pages/contest_screen';
 import { DisplaySettingsPage } from '../pages/display_settings_page';
 import { IdlePage } from '../pages/idle_page';

--- a/apps/mark-scan/frontend/src/components/ballot.tsx
+++ b/apps/mark-scan/frontend/src/components/ballot.tsx
@@ -19,7 +19,7 @@ import { ContinueToReviewPage } from '../pages/continue_to_review_page';
 const USER_ACTIVITY_EVENT_TYPES: EventsType[] = (() => {
   const allEvents = new Set(DEFAULT_EVENTS);
   // The IdlePage has an autofocus button to enable gamepad interaction,
-  // ends up triggering a focus event that would reset the idle timer.
+  // which ends up triggering a focus event that would reset the idle timer.
   // Ignoring focus events here, since we expect that any user-triggered
   // focus event would be preceded by a touch/mouse/keyboard event.
   allEvents.delete('focus');

--- a/apps/mark-scan/frontend/src/config/globals.ts
+++ b/apps/mark-scan/frontend/src/config/globals.ts
@@ -1,5 +1,3 @@
-export const IDLE_TIMEOUT_SECONDS = 5 * 60; // VVSG Requirement: 2–5 minutes
-export const IDLE_RESET_TIMEOUT_SECONDS = 45; // VVSG Requirement: 20–45 seconds
 export const RECENT_PRINT_EXPIRATION_SECONDS = 1 * 60; // 1 minute
 export const CARD_LONG_VALUE_WRITE_DELAY = 1000;
 export const BALLOT_PRINTING_TIMEOUT_SECONDS = 5;

--- a/apps/mark/frontend/src/app_quit_on_idle.test.tsx
+++ b/apps/mark/frontend/src/app_quit_on_idle.test.tsx
@@ -4,6 +4,10 @@ import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 import { electionGeneralDefinition } from '@votingworks/fixtures';
 import userEvent from '@testing-library/user-event';
 import { createMocks as createReactIdleTimerMocks } from 'react-idle-timer';
+import {
+  IDLE_RESET_TIMEOUT_SECONDS,
+  IDLE_TIMEOUT_SECONDS,
+} from '@votingworks/mark-flow-ui';
 import { render, screen, waitFor } from '../test/react_testing_library';
 import { App } from './app';
 
@@ -14,11 +18,7 @@ import {
   setStateInStorage,
 } from '../test/helpers/election';
 
-import {
-  IDLE_RESET_TIMEOUT_SECONDS,
-  IDLE_TIMEOUT_SECONDS,
-  QUIT_KIOSK_IDLE_SECONDS,
-} from './config/globals';
+import { QUIT_KIOSK_IDLE_SECONDS } from './config/globals';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
 let apiMock: ApiMock;

--- a/apps/mark/frontend/src/components/ballot.tsx
+++ b/apps/mark/frontend/src/components/ballot.tsx
@@ -1,6 +1,10 @@
 import { useState } from 'react';
 import { Route, Switch } from 'react-router-dom';
-import { IdleTimerProvider } from 'react-idle-timer';
+import {
+  DEFAULT_EVENTS,
+  EventsType,
+  IdleTimerProvider,
+} from 'react-idle-timer';
 
 import { IDLE_TIMEOUT_SECONDS, Paths } from '@votingworks/mark-flow-ui';
 import { ContestScreen } from '../pages/contest_screen';
@@ -10,6 +14,16 @@ import { NotFoundPage } from '../pages/not_found_page';
 import { PrintPage } from '../pages/print_page';
 import { ReviewScreen } from '../pages/review_screen';
 import { StartScreen } from '../pages/start_screen';
+
+const USER_ACTIVITY_EVENT_TYPES: EventsType[] = (() => {
+  const allEvents = new Set(DEFAULT_EVENTS);
+  // The IdlePage has an autofocus button to enable gamepad interaction,
+  // ends up triggering a focus event that would reset the idle timer.
+  // Ignoring focus events here, since we expect that any user-triggered
+  // focus event would be preceded by a touch/mouse/keyboard event.
+  allEvents.delete('focus');
+  return [...allEvents];
+})();
 
 export function Ballot(): JSX.Element {
   const [isIdle, setIsIdle] = useState(false);
@@ -28,6 +42,7 @@ export function Ballot(): JSX.Element {
   return (
     <IdleTimerProvider
       element={document}
+      events={USER_ACTIVITY_EVENT_TYPES}
       onActive={onActive}
       onIdle={onIdle}
       debounce={250}

--- a/apps/mark/frontend/src/components/ballot.tsx
+++ b/apps/mark/frontend/src/components/ballot.tsx
@@ -2,8 +2,7 @@ import { useState } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import { IdleTimerProvider } from 'react-idle-timer';
 
-import { Paths } from '@votingworks/mark-flow-ui';
-import { IDLE_TIMEOUT_SECONDS } from '../config/globals';
+import { IDLE_TIMEOUT_SECONDS, Paths } from '@votingworks/mark-flow-ui';
 import { ContestScreen } from '../pages/contest_screen';
 import { DisplaySettingsPage } from '../pages/display_settings_page';
 import { IdlePage } from '../pages/idle_page';

--- a/apps/mark/frontend/src/components/ballot.tsx
+++ b/apps/mark/frontend/src/components/ballot.tsx
@@ -18,7 +18,7 @@ import { StartScreen } from '../pages/start_screen';
 const USER_ACTIVITY_EVENT_TYPES: EventsType[] = (() => {
   const allEvents = new Set(DEFAULT_EVENTS);
   // The IdlePage has an autofocus button to enable gamepad interaction,
-  // ends up triggering a focus event that would reset the idle timer.
+  // which ends up triggering a focus event that would reset the idle timer.
   // Ignoring focus events here, since we expect that any user-triggered
   // focus event would be preceded by a touch/mouse/keyboard event.
   allEvents.delete('focus');

--- a/apps/mark/frontend/src/config/globals.ts
+++ b/apps/mark/frontend/src/config/globals.ts
@@ -1,5 +1,3 @@
-export const IDLE_TIMEOUT_SECONDS = 5 * 60; // VVSG Requirement: 2–5 minutes
-export const IDLE_RESET_TIMEOUT_SECONDS = 45; // VVSG Requirement: 20–45 seconds
 export const RECENT_PRINT_EXPIRATION_SECONDS = 1 * 60; // 1 minute
 export const CARD_LONG_VALUE_WRITE_DELAY = 1000;
 export const BALLOT_PRINTING_TIMEOUT_SECONDS = 5;

--- a/libs/mark-flow-ui/src/config/globals.ts
+++ b/libs/mark-flow-ui/src/config/globals.ts
@@ -1,4 +1,9 @@
+import { appStrings } from '@votingworks/ui';
+
+// NOTE: Keep in sync with the value of appStrings.warningBmdInactiveSession:
 export const IDLE_TIMEOUT_SECONDS = 5 * 60; // VVSG Requirement: 2–5 minutes
+export const idleTimeoutWarningStringFn = appStrings.warningBmdInactiveSession;
+
 export const IDLE_RESET_TIMEOUT_SECONDS = 45; // VVSG Requirement: 20–45 seconds
 export const WRITE_IN_CANDIDATE_MAX_LENGTH = 40;
 export enum Paths {

--- a/libs/mark-flow-ui/src/pages/idle_page.tsx
+++ b/libs/mark-flow-ui/src/pages/idle_page.tsx
@@ -1,12 +1,22 @@
-import { useState } from 'react';
-import pluralize from 'pluralize';
+import React, { useState } from 'react';
 import useInterval from 'use-interval';
 
-import { Button, H1, Loading, Main, Prose, Screen, P } from '@votingworks/ui';
+import {
+  Button,
+  H1,
+  Loading,
+  Main,
+  Screen,
+  P,
+  Font,
+  appStrings,
+  AudioOnly,
+  NumberString,
+} from '@votingworks/ui';
 
 import {
   IDLE_RESET_TIMEOUT_SECONDS,
-  IDLE_TIMEOUT_SECONDS,
+  idleTimeoutWarningStringFn,
 } from '../config/globals';
 
 const timeoutSeconds = IDLE_RESET_TIMEOUT_SECONDS;
@@ -31,40 +41,54 @@ export function IdlePage({
   onDismiss = noop,
   onCountdownEnd = noop,
 }: IdlePageProps): JSX.Element {
-  const [countdown, setCountdown] = useState(timeoutSeconds);
+  const [numSecondsRemaining, setNumSecondsRemaining] =
+    useState(timeoutSeconds);
   const [isLoading, setIsLoading] = useState(false);
 
   useInterval(() => {
-    if (countdown === 0 && !isLoading) {
+    if (numSecondsRemaining === 0 && !isLoading) {
       setIsLoading(true);
       onCountdownEnd();
     } else if (!isLoading) {
-      setCountdown((previous) => previous - 1);
+      setNumSecondsRemaining((previous) => previous - 1);
     }
   }, 1000);
 
   return (
     <Screen navRight>
-      <Main centerChild>
+      <Main centerChild padded>
         {isLoading ? (
-          <Loading>Clearing ballot</Loading>
+          <Loading>{appStrings.noteClearingBallot()}</Loading>
         ) : (
-          <Prose textCenter>
-            <H1 aria-label="Are you still voting?">Are you still voting?</H1>
-            <P>
-              This voting station has been inactive for more than{' '}
-              {pluralize('minute', IDLE_TIMEOUT_SECONDS / 60, true)}.
-            </P>
-            {countdown <= timeoutSeconds / 2 && (
-              <P>
-                To protect your privacy, this ballot will be cleared in{' '}
-                <strong>{pluralize('second', countdown, true)}</strong>.
-              </P>
-            )}
-            <Button variant="primary" onPress={onDismiss}>
-              Yes, I’m still voting.
+          <Font align="center">
+            {/*
+             * TODO(kofi): the old "audiofocus" pattern only works for one-time
+             * readouts of static text. Need to introduce configurable
+             * functionality for re-initiating speech when text gets
+             * added/replaced (e.g. when we move from this text to
+             * "Clearing ballot" above).
+             */}
+            <div id="audiofocus">
+              <H1>{appStrings.titleBmdIdleScreen()}</H1>
+              <P>{idleTimeoutWarningStringFn()}</P>
+              <AudioOnly>
+                {appStrings.instructionsBmdSelectToContinue()}
+              </AudioOnly>
+              {numSecondsRemaining <= timeoutSeconds / 2 && (
+                <React.Fragment>
+                  <P>{appStrings.warningBmdInactiveTimeRemaining()}</P>
+                  <P>
+                    {appStrings.labelBmdSecondsRemaining()}{' '}
+                    {/* TODO(kofi): Repeat audio when value changes: */}
+                    <NumberString weight="bold" value={numSecondsRemaining} />
+                  </P>
+                </React.Fragment>
+              )}
+            </div>
+            <Button autoFocus variant="primary" onPress={onDismiss}>
+              {appStrings.buttonStillVoting()}
             </Button>
-          </Prose>
+          </Font>
         )}
       </Main>
     </Screen>

--- a/libs/ui/src/loading.tsx
+++ b/libs/ui/src/loading.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import styled from 'styled-components';
 import { ProgressEllipsis } from './progress_ellipsis';
 import { Prose } from './prose';
@@ -10,7 +11,7 @@ const Fullscreen = styled.div`
 `;
 
 interface LoadingProps {
-  children?: string;
+  children?: React.ReactNode;
   isFullscreen?: boolean;
   as?: keyof JSX.IntrinsicElements;
 }

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -49,6 +49,10 @@ export const appStrings = {
 
   buttonNo: () => <UiString uiStringKey="buttonNo">No</UiString>,
 
+  buttonStillVoting: () => (
+    <UiString uiStringKey="buttonStillVoting">Yes, I’m still voting.</UiString>
+  ),
+
   buttonOkay: () => <UiString uiStringKey="buttonOkay">Okay</UiString>,
 
   buttonPrintBallot: () => (
@@ -145,6 +149,12 @@ export const appStrings = {
     <UiString uiStringKey="labelBallotStyle">Ballot style:</UiString>
   ),
 
+  labelBmdSecondsRemaining: () => (
+    <UiString uiStringKey="labelBmdSecondsRemaining">
+      Number of seconds remaining:
+    </UiString>
+  ),
+
   labelBmdWriteInForm: () => (
     <UiString uiStringKey="labelBmdWriteInForm">
       Enter the name of a person who is <Font weight="bold">not</Font> on the
@@ -228,6 +238,10 @@ export const appStrings = {
     </UiString>
   ),
 
+  noteClearingBallot: () => (
+    <UiString uiStringKey="noteClearingBallot">Clearing ballot</UiString>
+  ),
+
   promptBmdConfirmRemoveWriteIn: () => (
     <UiString uiStringKey="promptBmdConfirmRemoveWriteIn">
       Do you want to deselect and remove your write-in candidate?
@@ -240,6 +254,10 @@ export const appStrings = {
     </UiString>
   ),
 
+  titleBmdIdleScreen: () => (
+    <UiString uiStringKey="titleBmdIdleScreen">Are you still voting?</UiString>
+  ),
+
   titleBmdPrintScreen: () => (
     <UiString uiStringKey="titleBmdPrintScreen">
       Printing Your Official Ballot...
@@ -248,6 +266,19 @@ export const appStrings = {
 
   titleBmdReviewScreen: () => (
     <UiString uiStringKey="titleBmdReviewScreen">Review Your Votes</UiString>
+  ),
+
+  warningBmdInactiveSession: () => (
+    <UiString uiStringKey="warningBmdInactiveSession">
+      This voting station has been inactive for more than 5 minutes.
+    </UiString>
+  ),
+
+  warningBmdInactiveTimeRemaining: () => (
+    <UiString uiStringKey="warningBmdInactiveTimeRemaining">
+      To protect your privacy, this ballot will be cleared when the timer runs
+      out.
+    </UiString>
   ),
 
   warningOvervoteCandidateContest: () => (


### PR DESCRIPTION
## Overview

Converting text on the BMD `IdlePage` screens to use the language-aware `<UiString>`. 

Some wording changes were needed to enable better-sounding audio, but might need some tweaking in the future.

## Demo Video or Screenshot
| Default  | Sample Translation |
| ------------- | ------------- |
| ![Screenshot 2023-11-07 at 12 32 17](https://github.com/votingworks/vxsuite/assets/264902/8cf05836-de9f-47fb-9871-bdb5d20fb298) | ![Screenshot 2023-11-07 at 12 33 39](https://github.com/votingworks/vxsuite/assets/264902/40633c9c-2954-4a8c-8e2e-474141256dc1) |
| ![Screenshot 2023-11-07 at 12 32 41](https://github.com/votingworks/vxsuite/assets/264902/7224b46a-9903-4515-95b0-2083d9d55114) | ![Screenshot 2023-11-07 at 12 34 05](https://github.com/votingworks/vxsuite/assets/264902/560e03d9-ff33-472e-a1ad-a4938ddbbc02) |
| ![Screenshot 2023-11-07 at 12 34 28](https://github.com/votingworks/vxsuite/assets/264902/fd77abfe-29d5-4fb4-ab3d-f563442be890) | ![Screenshot 2023-11-07 at 12 35 53](https://github.com/votingworks/vxsuite/assets/264902/b6111012-079a-4f6b-a7a9-b2363c1b272d) |

## Testing Plan
- Manual

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
