### PR TITLE
[i18n/Audio] <UiString>ify the Mark-Scan ContinueToReviewPage

### DIFF
--- a/apps/mark-scan/frontend/src/pages/continue_to_review_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/continue_to_review_page.tsx
@@ -1,5 +1,14 @@
 import { ButtonFooter } from '@votingworks/mark-flow-ui';
-import { Main, Screen, Text, H1, LinkButton } from '@votingworks/ui';
+import {
+  Main,
+  Screen,
+  H1,
+  LinkButton,
+  appStrings,
+  AudioOnly,
+  Font,
+  P,
+} from '@votingworks/ui';
 
 // This page is rendered as part of the blank ballot interpretation flow immediately after
 // the poll worker card is removed. To protect voter privacy, we render this screen first to
@@ -8,17 +17,21 @@ export function ContinueToReviewPage(): JSX.Element {
   return (
     <Screen white>
       <Main padded centerChild>
-        <Text center>
-          <H1>Ready to Review</H1>
-          <p>
-            The ballot sheet has been loaded. You will have a chance to review
-            your selections before reprinting your ballot.
-          </p>
-        </Text>
+        <Font align="center" id="audiofocus">
+          <H1>{appStrings.titleBmdReadyToReview()}</H1>
+          <P>{appStrings.noteBmdBallotSheetLoaded()}</P>
+          <AudioOnly>{appStrings.instructionsBmdSelectToContinue()}</AudioOnly>
+        </Font>
       </Main>
       <ButtonFooter>
-        <LinkButton to="/review" id="next" variant="primary" icon="Done">
-          Return to Ballot Review
+        <LinkButton
+          autoFocus
+          to="/review"
+          id="next"
+          variant="primary"
+          icon="Done"
+        >
+          {appStrings.buttonReturnToBallotReview()}
         </LinkButton>
       </ButtonFooter>
     </Screen>

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -59,6 +59,12 @@ export const appStrings = {
     <UiString uiStringKey="buttonPrintBallot">Print My Ballot</UiString>
   ),
 
+  buttonReturnToBallotReview: () => (
+    <UiString uiStringKey="buttonReturnToBallotReview">
+      Return to Ballot Review
+    </UiString>
+  ),
+
   buttonReview: () => <UiString uiStringKey="buttonReview">Review</UiString>,
 
   buttonStartVoting: () => (
@@ -238,6 +244,13 @@ export const appStrings = {
     </UiString>
   ),
 
+  noteBmdBallotSheetLoaded: () => (
+    <UiString uiStringKey="noteBmdBallotSheetLoaded">
+      The ballot sheet has been loaded. You will have a chance to review your
+      selections before reprinting your ballot.
+    </UiString>
+  ),
+
   noteClearingBallot: () => (
     <UiString uiStringKey="noteClearingBallot">Clearing ballot</UiString>
   ),
@@ -262,6 +275,10 @@ export const appStrings = {
     <UiString uiStringKey="titleBmdPrintScreen">
       Printing Your Official Ballot...
     </UiString>
+  ),
+
+  titleBmdReadyToReview: () => (
+    <UiString uiStringKey="titleBmdReadyToReview">Ready to Review</UiString>
   ),
 
   titleBmdReviewScreen: () => (


### PR DESCRIPTION
## Overview

Converting text on the `Mark-Scan` `ContinueToReviewPage` to language-aware `<UiString>`s and adding audio prompts/button autofocus for voters relying on audio.

## Demo Video or Screenshot
| Default  | Sample Translation |
| ------------- | ------------- |
| ![Screenshot 2023-11-07 at 14 39 43](https://github.com/votingworks/vxsuite/assets/264902/9c62b7f1-65ef-4344-9cc9-ae3aabd3676e) | ![Screenshot 2023-11-07 at 14 39 36](https://github.com/votingworks/vxsuite/assets/264902/74d001c8-7353-4e9c-a29e-d69506e17e35) |

## Testing Plan
- Manual

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
