### PR TITLE
Update libs/auth scripts such that they can be run from anywhere

### DIFF
--- a/libs/auth/README.md
+++ b/libs/auth/README.md
@@ -39,9 +39,6 @@ frontend error boundary, which throwing errors on the backend typically does.
 
 ## Scripts
 
-Note that all scripts are meant to be run from `libs/auth/` and not
-`libs/auth/scripts/`.
-
 ### Initial Java Card Configuration Script
 
 This script configures a Java Card for use with VotingWorks machines. The script
@@ -111,10 +108,14 @@ This script prompts you for a PIN and returns whether or not the PIN is correct
 for the inserted Java Card.
 
 ```
-# Check a VxSuite card PIN
-VX_MACHINE_TYPE=admin ./scripts/check-pin --vxsuite
+# With a card reader connected and a Java Card in the card reader
+./scripts/check-pin
+```
 
-# Check a Common Access Card (CAC) PIN
+The script works not only with VxSuite cards but also with Common Access Cards:
+
+```
+# With a card reader connected and a Common Access Card in the card reader
 ./scripts/check-pin --cac
 ```
 
@@ -168,7 +169,7 @@ The following command generates keys and certs for tests:
 ./scripts/generate-test-keys-and-certs
 ```
 
-### Common Access Card (CAC) Certificate Retrieval Script
+### Common Access Card Certificate Retrieval Script
 
 This script gets a Common Access Card's certificate. It's meant to be used for
 development and testing.
@@ -181,3 +182,5 @@ development and testing.
 The script prints the certificate to stdout in PEM format by default. Use the
 `--output` option to write the certificate to a file, or the `--json` option to
 print the certificate metadata in JSON format.
+
+More on Common Access Cards [here](./src/cac/README.md).

--- a/libs/auth/scripts/check_pin.ts
+++ b/libs/auth/scripts/check_pin.ts
@@ -11,7 +11,7 @@ const usageMessage = 'Usage: check-pin [--cac|--vxsuite (default)]';
 type CardType = 'cac' | 'vxsuite';
 
 function parseCommandLineArgs(args: readonly string[]): { cardType: CardType } {
-  if (![undefined, '--cac', '--vxsuite'].includes(args[0]) || args.length > 1) {
+  if (args.length > 1 || ![undefined, '--cac', '--vxsuite'].includes(args[0])) {
     console.log(usageMessage);
     process.exit(0);
   }

--- a/libs/auth/scripts/configure-dev-java-card
+++ b/libs/auth/scripts/configure-dev-java-card
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
-VX_CERT_AUTHORITY_CERT_PATH=./certs/dev/vx-cert-authority-cert.pem \
-    VX_PRIVATE_KEY_PATH=./certs/dev/vx-private-key.pem \
-    ./scripts/configure-java-card
+SCRIPTS_DIRECTORY="$(dirname "${BASH_SOURCE[0]}")"
+
+VX_CERT_AUTHORITY_CERT_PATH="${SCRIPTS_DIRECTORY}/../certs/dev/vx-cert-authority-cert.pem" \
+    VX_PRIVATE_KEY_PATH="${SCRIPTS_DIRECTORY}/../certs/dev/vx-private-key.pem" \
+    "${SCRIPTS_DIRECTORY}/configure-java-card"

--- a/libs/auth/scripts/configure_java_card.ts
+++ b/libs/auth/scripts/configure_java_card.ts
@@ -1,5 +1,6 @@
 import { Buffer } from 'buffer';
 import { existsSync } from 'fs';
+import path from 'path';
 import { extractErrorMessage } from '@votingworks/basics';
 import { Byte } from '@votingworks/types';
 
@@ -23,8 +24,11 @@ import {
 import { runCommand } from '../src/shell';
 import { waitForReadyCardStatus } from './utils';
 
-const APPLET_PATH = 'applets/OpenFIPS201-v1.10.2-with-vx-mods.cap';
-const GLOBAL_PLATFORM_JAR_FILE_PATH = 'scripts/gp.jar';
+const APPLET_PATH = path.join(
+  __dirname,
+  '../applets/OpenFIPS201-v1.10.2-with-vx-mods.cap'
+);
+const GLOBAL_PLATFORM_JAR_FILE_PATH = path.join(__dirname, '../scripts/gp.jar');
 
 /**
  * CHANGE REFERENCE DATA ADMIN is an OpenFIPS201-specific extension of the PIV-standard CHANGE
@@ -84,7 +88,7 @@ function globalPlatformCommand(command: string[]): string[] {
 function checkForScriptDependencies(): void {
   if (!existsSync(GLOBAL_PLATFORM_JAR_FILE_PATH)) {
     throw new Error(
-      'Missing script dependencies; install using `make install-script-dependencies`'
+      'Missing script dependencies; install using `make install-script-dependencies` in libs/auth'
     );
   }
 }

--- a/libs/auth/scripts/generate-test-keys-and-certs
+++ b/libs/auth/scripts/generate-test-keys-and-certs
@@ -2,10 +2,14 @@
 
 set -euo pipefail
 
-rm -r ./certs/test
+SCRIPTS_DIRECTORY="$(dirname "${BASH_SOURCE[0]}")"
 
-echo -n 'Generating keys and certs in ./certs/test/set-1... '
-./scripts/generate-dev-keys-and-certs --for-tests --output-dir ./certs/test/set-1
+rm -r "${SCRIPTS_DIRECTORY}/../certs/test"
 
-echo -n 'Generating keys and certs in ./certs/test/set-2... '
-./scripts/generate-dev-keys-and-certs --for-tests --output-dir ./certs/test/set-2
+echo -n 'Generating keys and certs in libs/auth/certs/test/set-1... '
+"${SCRIPTS_DIRECTORY}/generate-dev-keys-and-certs" \
+    --for-tests --output-dir "${SCRIPTS_DIRECTORY}/../certs/test/set-1"
+
+echo -n 'Generating keys and certs in libs/auth/certs/test/set-2... '
+"${SCRIPTS_DIRECTORY}/generate-dev-keys-and-certs" \
+    --for-tests --output-dir "${SCRIPTS_DIRECTORY}/../certs/test/set-2"

--- a/libs/auth/scripts/generate_dev_keys_and_certs.ts
+++ b/libs/auth/scripts/generate_dev_keys_and_certs.ts
@@ -1,5 +1,6 @@
 import { Buffer } from 'buffer';
 import fs from 'fs/promises';
+import path from 'path';
 import yargs from 'yargs/yargs';
 import { extractErrorMessage } from '@votingworks/basics';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
@@ -72,16 +73,16 @@ async function parseCommandLineArgs() {
       'output-dir': {
         description: 'The directory to output generated keys and certs to',
         type: 'string',
-        default: './certs/dev',
+        default: path.join(__dirname, '../certs/dev'),
       },
     })
     .hide('help')
     .version(false)
-    .example('$ ./scripts/generate-dev-keys-and-certs --help', '')
-    .example('$ ./scripts/generate-dev-keys-and-certs', '')
+    .example('$ generate-dev-keys-and-certs --help', '')
+    .example('$ generate-dev-keys-and-certs', '')
     .example(
-      '$ ./scripts/generate-dev-keys-and-certs \\\n' +
-        '--for-tests --output-dir ./certs/test/set-1',
+      '$ generate-dev-keys-and-certs \\\n' +
+        '--for-tests --output-dir path/to/output-dir',
       ''
     )
     .strict();

--- a/libs/auth/scripts/mock_card.ts
+++ b/libs/auth/scripts/mock_card.ts
@@ -43,25 +43,25 @@ async function parseCommandLineArgs(): Promise<MockCardInput> {
     })
     .hide('help')
     .version(false)
-    .example('$ ./scripts/mock-card --help', '')
-    .example('$ ./scripts/mock-card --card-type system-administrator', '')
+    .example('$ mock-card --help', '')
+    .example('$ mock-card --card-type system-administrator', '')
     .example(
-      '$ ./scripts/mock-card --card-type election-manager \\\n' +
-        '--election-definition ../fixtures/data/electionFamousNames2021/election.json',
+      '$ mock-card --card-type election-manager \\\n' +
+        '--election-definition path/to/election.json',
       ''
     )
     .example(
-      '$ ./scripts/mock-card --card-type poll-worker \\\n' +
-        '--election-definition ../fixtures/data/electionGeneral/election.json',
+      '$ mock-card --card-type poll-worker \\\n' +
+        '--election-definition path/to/election.json',
       ''
     )
     .example(
-      '$ ./scripts/mock-card --card-type poll-worker-with-pin \\\n' +
-        '--election-definition ../fixtures/data/electionGeneral/election.json',
+      '$ mock-card --card-type poll-worker-with-pin \\\n' +
+        '--election-definition path/to/election.json',
       ''
     )
-    .example('$ ./scripts/mock-card --card-type unprogrammed', '')
-    .example('$ ./scripts/mock-card --card-type no-card', '')
+    .example('$ mock-card --card-type unprogrammed', '')
+    .example('$ mock-card --card-type no-card', '')
     .strict();
 
   const helpMessage = await argParser.getHelp();

--- a/libs/auth/scripts/program-dev-system-administrator-java-card
+++ b/libs/auth/scripts/program-dev-system-administrator-java-card
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+SCRIPTS_DIRECTORY="$(dirname "${BASH_SOURCE[0]}")"
+
 NODE_ENV=development \
     VX_MACHINE_TYPE=admin \
-    ./scripts/program-system-administrator-java-card
+    "${SCRIPTS_DIRECTORY}/program-system-administrator-java-card"

--- a/libs/auth/scripts/program_system_administrator_java_card.ts
+++ b/libs/auth/scripts/program_system_administrator_java_card.ts
@@ -20,8 +20,8 @@ const jurisdiction = isProduction
 const initialJavaCardConfigurationScriptReminder = `
 ${
   isProduction
-    ? 'Have you run this card through the initial Java Card configuration script on VxCertifier yet?'
-    : 'Have you run `./scripts/configure-dev-java-card` on this card yet?'
+    ? 'Have you run this card through the configure-java-card yet?'
+    : 'Have you run this card through the configure-dev-java-card script yet?'
 }
 If not, that's likely the cause of this error.
 Run that and then retry.


### PR DESCRIPTION
_Easiest reviewed by commit_

## Overview

Was working on some scripts for testing the Google Cloud Translation and Text-to-Speech API integrations and took a quick detour to make some low-hanging improvements to `libs/auth` scripts.

Main update is that `libs/auth` scripts can now be run from anywhere. Previously, many had to be run from the root of the `libs/auth` directory, as noted in the `libs/auth` README:

> Note that all scripts are meant to be run from `libs/auth/` and not `libs/auth/scripts/`.

I also made some tweaks to the recently added PIN-checking script, most notably no longer requiring specifying `VX_MACHINE_TYPE=admin` when checking a VxSuite card's PIN.

## Testing Plan

- [x] Manually tested all modified scripts