### PR TITLE
[i18n/Audio] <UiString>ify simple voter-facing screens in Mark-Scan

### DIFF
--- a/apps/mark-scan/frontend/src/pages/casting_ballot_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/casting_ballot_page.tsx
@@ -1,11 +1,17 @@
-import { Main, Screen, InsertBallotImage, P } from '@votingworks/ui';
+import {
+  Main,
+  Screen,
+  InsertBallotImage,
+  P,
+  appStrings,
+} from '@votingworks/ui';
 
 export function CastingBallotPage(): JSX.Element {
   return (
     <Screen white>
-      <Main centerChild padded>
+      <Main centerChild padded id="audiofocus">
         <InsertBallotImage />
-        <P>Casting Ballot...</P>
+        <P>{appStrings.noteBmdCastingBallot()}</P>
       </Main>
     </Screen>
   );

--- a/apps/mark-scan/frontend/src/pages/jam_cleared_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/jam_cleared_page.tsx
@@ -1,4 +1,4 @@
-import { Main, Screen, Text, H1 } from '@votingworks/ui';
+import { Main, Screen, H1, appStrings, P, Font } from '@votingworks/ui';
 
 interface Props {
   stateMachineState: 'jam_cleared' | 'resetting_state_machine_after_jam';
@@ -7,16 +7,18 @@ interface Props {
 export function JamClearedPage({ stateMachineState }: Props): JSX.Element {
   const statusMessage =
     stateMachineState === 'jam_cleared'
-      ? 'The hardware is resetting'
-      : 'The hardware has been reset';
+      ? appStrings.noteBmdHardwareResetting()
+      : appStrings.noteBmdHardwareReset();
 
   return (
     <Screen white>
       <Main padded centerChild>
-        <Text center>
-          <H1>Jam Cleared</H1>
-          <p>{statusMessage}. Your voting session will restart shortly.</p>
-        </Text>
+        <Font align="center" id="audiofocus">
+          <H1>{appStrings.titleBmdJamClearedScreen()}</H1>
+          <P>
+            {statusMessage} {appStrings.noteBmdSessionRestart()}
+          </P>
+        </Font>
       </Main>
     </Screen>
   );

--- a/apps/mark-scan/frontend/src/pages/jammed_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/jammed_page.tsx
@@ -1,16 +1,13 @@
-import { Main, Screen, Text, H1 } from '@votingworks/ui';
+import { Main, Screen, H1, Font, appStrings, P } from '@votingworks/ui';
 
 export function JammedPage(): JSX.Element {
   return (
     <Screen white>
       <Main padded centerChild>
-        <Text center>
-          <H1>Paper is Jammed</H1>
-          <p>
-            Please alert a poll worker to clear the jam, opening the printer
-            cover or ballot box if necessary.
-          </p>
-        </Text>
+        <Font align="center" id="audiofocus">
+          <H1>{appStrings.titleBmdJammedScreen()}</H1>
+          <P>{appStrings.instructionsBmdPaperJam()}</P>
+        </Font>
       </Main>
     </Screen>
   );

--- a/apps/mark-scan/frontend/src/pages/load_paper_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/load_paper_page.tsx
@@ -1,16 +1,13 @@
-import { Main, Screen, Text, H1 } from '@votingworks/ui';
+import { Main, Screen, H1, P, Font, appStrings } from '@votingworks/ui';
 
 export function LoadPaperPage(): JSX.Element {
   return (
     <Screen white>
       <Main padded centerChild>
-        <Text center>
-          <H1>Load Blank Ballot Sheet</H1>
-          <p>
-            Please feed one sheet of paper into the front input tray. The
-            printer will automatically grab the paper when positioned correctly.
-          </p>
-        </Text>
+        <Font align="center" id="audiofocus">
+          <H1>{appStrings.titleBmdLoadPaperScreen()}</H1>
+          <P>{appStrings.instructionsBmdLoadPaper()}</P>
+        </Font>
       </Main>
     </Screen>
   );

--- a/libs/mark-flow-ui/src/pages/idle_page.tsx
+++ b/libs/mark-flow-ui/src/pages/idle_page.tsx
@@ -58,7 +58,7 @@ export function IdlePage({
     <Screen navRight>
       <Main centerChild padded>
         {isLoading ? (
-          <Loading>{appStrings.noteClearingBallot()}</Loading>
+          <Loading>{appStrings.noteBmdClearingBallot()}</Loading>
         ) : (
           <Font align="center">
             {/*

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -269,8 +269,8 @@ export const appStrings = {
     <UiString uiStringKey="noteBmdCastingBallot">Casting Ballot...</UiString>
   ),
 
-  noteClearingBallot: () => (
-    <UiString uiStringKey="noteClearingBallot">Clearing ballot</UiString>
+  noteBmdClearingBallot: () => (
+    <UiString uiStringKey="noteBmdClearingBallot">Clearing ballot</UiString>
   ),
 
   noteBmdHardwareReset: () => (

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -109,6 +109,20 @@ export const appStrings = {
     </UiString>
   ),
 
+  instructionsBmdLoadPaper: () => (
+    <UiString uiStringKey="instructionsBmdLoadPaper">
+      Please feed one sheet of paper into the front input tray. The printer will
+      automatically grab the paper when positioned correctly.
+    </UiString>
+  ),
+
+  instructionsBmdPaperJam: () => (
+    <UiString uiStringKey="instructionsBmdPaperJam">
+      Please alert a poll worker to clear the jam, opening the printer cover or
+      ballot box if necessary.
+    </UiString>
+  ),
+
   instructionsBmdReviewPageNavigation: () => (
     <UiString uiStringKey="instructionsBmdReviewPageNavigation">
       To review your votes, advance through the ballot contests using the up and
@@ -251,8 +265,30 @@ export const appStrings = {
     </UiString>
   ),
 
+  noteBmdCastingBallot: () => (
+    <UiString uiStringKey="noteBmdCastingBallot">Casting Ballot...</UiString>
+  ),
+
   noteClearingBallot: () => (
     <UiString uiStringKey="noteClearingBallot">Clearing ballot</UiString>
+  ),
+
+  noteBmdHardwareReset: () => (
+    <UiString uiStringKey="noteBmdHardwareReset">
+      The hardware has been reset.
+    </UiString>
+  ),
+
+  noteBmdHardwareResetting: () => (
+    <UiString uiStringKey="noteBmdHardwareResetting">
+      The hardware is resetting.
+    </UiString>
+  ),
+
+  noteBmdSessionRestart: () => (
+    <UiString uiStringKey="noteBmdSessionRestart">
+      Your voting session will restart shortly.
+    </UiString>
   ),
 
   promptBmdConfirmRemoveWriteIn: () => (
@@ -269,6 +305,20 @@ export const appStrings = {
 
   titleBmdIdleScreen: () => (
     <UiString uiStringKey="titleBmdIdleScreen">Are you still voting?</UiString>
+  ),
+
+  titleBmdJamClearedScreen: () => (
+    <UiString uiStringKey="titleBmdJamClearedScreen">Jam Cleared</UiString>
+  ),
+
+  titleBmdJammedScreen: () => (
+    <UiString uiStringKey="titleBmdJammedScreen">Paper is Jammed</UiString>
+  ),
+
+  titleBmdLoadPaperScreen: () => (
+    <UiString uiStringKey="titleBmdLoadPaperScreen">
+      Load Blank Ballot Sheet
+    </UiString>
   ),
 
   titleBmdPrintScreen: () => (


### PR DESCRIPTION
## Overview

Converting text on a few remaining screens in `Mark-Scan` to language-aware `<UiString>`s.

Adding `id="audiofocus"` where relevant (although, starting to think through how to get our new speech engine to automatically read out the relevant text without us having to remember to tag every page/modal).

## Demo Video or Screenshot
### E.g. - Paper Jam Screen:
| Default  | Sample Translation |
| ------------- | ------------- |
| <img width="434" alt="Screenshot 2023-11-08 at 10 15 46" src="https://github.com/votingworks/vxsuite/assets/264902/df3b2d86-3f0e-492b-9c9d-f0ef653c0692">  | <img width="434" alt="Screenshot 2023-11-08 at 10 16 06" src="https://github.com/votingworks/vxsuite/assets/264902/c919a882-cda6-4d5c-b881-5b67ff079127">  |

## Testing Plan
- Manually verified translation works as expected
- Existing tests as regression guards

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
