### PR TITLE
Add scripts for testing Google Cloud API integrations

### DIFF
--- a/apps/design/backend/scripts/.eslintrc.json
+++ b/apps/design/backend/scripts/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-console": "off"
+  }
+}

--- a/apps/design/backend/scripts/synthesize-speech
+++ b/apps/design/backend/scripts/synthesize-speech
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+require('esbuild-runner/register');
+require('./synthesize_speech.ts').main(process.argv.slice(2));

--- a/apps/design/backend/scripts/synthesize_speech.ts
+++ b/apps/design/backend/scripts/synthesize_speech.ts
@@ -1,0 +1,64 @@
+import { Buffer } from 'buffer';
+import fs from 'fs';
+import { extractErrorMessage } from '@votingworks/basics';
+import { LanguageCode } from '@votingworks/types';
+
+import { GoogleCloudSpeechSynthesizer } from '../src/language_and_audio/speech_synthesizer';
+import { Store } from '../src/store';
+
+const languageCodes: string[] = [
+  LanguageCode.CHINESE,
+  LanguageCode.ENGLISH,
+  LanguageCode.SPANISH,
+];
+const usageMessage = `Usage: synthesize-speech 'Text to convert to speech' <language-code> <output-file-path>
+
+Arguments:
+  <language-code>\t${[...languageCodes].sort().join(' | ')}
+  <output-file-path>\tShould end in .mp3`;
+
+interface SynthesizeSpeechInput {
+  languageCode: LanguageCode;
+  outputFilePath: string;
+  text: string;
+}
+
+function parseCommandLineArgs(args: readonly string[]): SynthesizeSpeechInput {
+  if (args.length !== 3 || !languageCodes.includes(args[1])) {
+    console.log(usageMessage);
+    process.exit(0);
+  }
+  const [text, languageCode, outputFilePath] = args as [
+    string,
+    LanguageCode,
+    string,
+  ];
+  return { languageCode, outputFilePath, text };
+}
+
+async function synthesizeSpeech({
+  languageCode,
+  outputFilePath,
+  text,
+}: SynthesizeSpeechInput): Promise<void> {
+  const store = Store.memoryStore();
+  const speechSynthesizer = new GoogleCloudSpeechSynthesizer({ store });
+  const speechBase64 = await speechSynthesizer.synthesizeSpeech(
+    text,
+    languageCode
+  );
+  fs.writeFileSync(outputFilePath, Buffer.from(speechBase64, 'base64'));
+}
+
+/**
+ * A script for synthesizing speech using the Google Cloud Text-to-Speech API
+ */
+export async function main(args: readonly string[]): Promise<void> {
+  try {
+    await synthesizeSpeech(parseCommandLineArgs(args));
+    process.exit(0);
+  } catch (error) {
+    console.error(`❌ ${extractErrorMessage(error)}`);
+    process.exit(1);
+  }
+}

--- a/apps/design/backend/scripts/translate-text
+++ b/apps/design/backend/scripts/translate-text
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+require('esbuild-runner/register');
+require('./translate_text.ts').main(process.argv.slice(2));

--- a/apps/design/backend/scripts/translate_text.ts
+++ b/apps/design/backend/scripts/translate_text.ts
@@ -1,0 +1,51 @@
+import { extractErrorMessage } from '@votingworks/basics';
+import { LanguageCode } from '@votingworks/types';
+
+import { GoogleCloudTranslator } from '../src/language_and_audio/translator';
+import { Store } from '../src/store';
+
+const languageCodes: string[] = [LanguageCode.CHINESE, LanguageCode.SPANISH];
+const usageMessage = `Usage: translate-text 'Text to translate' <target-language-code>
+
+Arguments:
+  <target-language-code>\t${[...languageCodes].sort().join(' | ')}`;
+
+interface TranslateTextInput {
+  targetLanguageCode: LanguageCode;
+  text: string;
+}
+
+function parseCommandLineArgs(args: readonly string[]): TranslateTextInput {
+  if (args.length !== 2 || !languageCodes.includes(args[1])) {
+    console.log(usageMessage);
+    process.exit(0);
+  }
+  const [text, targetLanguageCode] = args as [string, LanguageCode];
+  return { targetLanguageCode, text };
+}
+
+async function translateText({
+  targetLanguageCode,
+  text,
+}: TranslateTextInput): Promise<void> {
+  const store = Store.memoryStore();
+  const translator = new GoogleCloudTranslator({ store });
+  const [translatedText] = await translator.translateText(
+    [text],
+    targetLanguageCode
+  );
+  console.log(translatedText);
+}
+
+/**
+ * A script for translating text using the Google Cloud Translation API
+ */
+export async function main(args: readonly string[]): Promise<void> {
+  try {
+    await translateText(parseCommandLineArgs(args));
+    process.exit(0);
+  } catch (error) {
+    console.error(`❌ ${extractErrorMessage(error)}`);
+    process.exit(1);
+  }
+}

--- a/apps/design/backend/tsconfig.json
+++ b/apps/design/backend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../../tsconfig.shared.json",
-  "include": ["src", "test"],
+  "include": ["scripts", "src", "test"],
   "exclude": [],
   "compilerOptions": {
     "allowJs": true,

--- a/libs/auth/scripts/check_pin.ts
+++ b/libs/auth/scripts/check_pin.ts
@@ -1,16 +1,18 @@
 import { createInterface } from 'readline';
 import { extractErrorMessage, throwIllegalValue } from '@votingworks/basics';
 
-import { JavaCard } from '../src';
 import { CommonAccessCard, CommonAccessCardDetails } from '../src/cac';
 import { CardDetails, PinProtectedCard, StatefulCard } from '../src/card';
+import { JavaCard } from '../src/java_card';
 import { waitForReadyCardStatus } from './utils';
 
 const usageMessage = 'Usage: check-pin [--cac|--vxsuite (default)]';
 
-type CardType = 'cac' | 'vxsuite';
+interface CheckPinInput {
+  cardType: 'cac' | 'vxsuite';
+}
 
-function parseCommandLineArgs(args: readonly string[]): { cardType: CardType } {
+function parseCommandLineArgs(args: readonly string[]): CheckPinInput {
   if (args.length > 1 || ![undefined, '--cac', '--vxsuite'].includes(args[0])) {
     console.log(usageMessage);
     process.exit(0);
@@ -18,7 +20,7 @@ function parseCommandLineArgs(args: readonly string[]): { cardType: CardType } {
   return { cardType: args[0] === '--cac' ? 'cac' : 'vxsuite' };
 }
 
-async function checkPin(cardType: CardType): Promise<void> {
+async function checkPin({ cardType }: CheckPinInput): Promise<void> {
   const pin = await new Promise<string>((resolve) => {
     createInterface(process.stdin, process.stdout).question(
       'Enter PIN: ',
@@ -53,11 +55,10 @@ async function checkPin(cardType: CardType): Promise<void> {
  */
 export async function main(args: readonly string[]): Promise<void> {
   try {
-    const { cardType } = parseCommandLineArgs(args);
-    await checkPin(cardType);
+    await checkPin(parseCommandLineArgs(args));
+    process.exit(0);
   } catch (error) {
     console.error(`❌ ${extractErrorMessage(error)}`);
     process.exit(1);
   }
-  process.exit(0);
 }

--- a/libs/auth/scripts/configure_java_card.ts
+++ b/libs/auth/scripts/configure_java_card.ts
@@ -285,10 +285,10 @@ export async function main(): Promise<void> {
     await installApplet();
     await runAppletConfigurationCommands();
     await createAndStoreCardVxCert();
+    sectionLog('✅', 'Done!');
+    process.exit(0);
   } catch (error) {
     console.error(`❌ ${extractErrorMessage(error)}`);
     process.exit(1);
   }
-  sectionLog('✅', 'Done!');
-  process.exit(0);
 }

--- a/libs/auth/scripts/create_production_machine_cert_signing_request.ts
+++ b/libs/auth/scripts/create_production_machine_cert_signing_request.ts
@@ -1,4 +1,3 @@
-import { Buffer } from 'buffer';
 import { extractErrorMessage } from '@votingworks/basics';
 
 import { constructMachineCertSubject } from '../src/certs';
@@ -11,24 +10,23 @@ const jurisdiction =
     ? getRequiredEnvVar('VX_MACHINE_JURISDICTION')
     : undefined;
 
-async function createProductionMachineCertSigningRequest(): Promise<Buffer> {
-  return await createCertSigningRequest({
+async function createProductionMachineCertSigningRequest(): Promise<void> {
+  const certSigningRequest = await createCertSigningRequest({
     certKey: { source: 'tpm' },
     certSubject: constructMachineCertSubject(machineType, jurisdiction),
   });
+  process.stdout.write(certSigningRequest);
 }
 
 /**
  * A script for creating a production machine cert signing request, using the machine's TPM key
  */
 export async function main(): Promise<void> {
-  let certSigningRequest: Buffer;
   try {
-    certSigningRequest = await createProductionMachineCertSigningRequest();
+    await createProductionMachineCertSigningRequest();
+    process.exit(0);
   } catch (error) {
     console.error(`❌ ${extractErrorMessage(error)}`);
     process.exit(1);
   }
-  process.stdout.write(certSigningRequest);
-  process.exit(0);
 }

--- a/libs/auth/scripts/generate_dev_keys_and_certs.ts
+++ b/libs/auth/scripts/generate_dev_keys_and_certs.ts
@@ -267,6 +267,8 @@ async function generateDevKeysAndCerts({
       );
     }
   }
+
+  console.log('✅ Done!');
 }
 
 /**
@@ -298,12 +300,10 @@ async function generateDevKeysAndCerts({
  */
 export async function main(): Promise<void> {
   try {
-    const generateDevKeysAndCertsInput = await parseCommandLineArgs();
-    await generateDevKeysAndCerts(generateDevKeysAndCertsInput);
+    await generateDevKeysAndCerts(await parseCommandLineArgs());
+    process.exit(0);
   } catch (error) {
     console.error(`❌ ${extractErrorMessage(error)}`);
     process.exit(1);
   }
-  console.log('✅ Done!');
-  process.exit(0);
 }

--- a/libs/auth/scripts/mock_card.ts
+++ b/libs/auth/scripts/mock_card.ts
@@ -204,11 +204,10 @@ function mockCardWrapper({ cardType, electionHash }: MockCardInput) {
  */
 export async function main(): Promise<void> {
   try {
-    const mockCardInput = await parseCommandLineArgs();
-    mockCardWrapper(mockCardInput);
+    mockCardWrapper(await parseCommandLineArgs());
+    process.exit(0);
   } catch (error) {
     console.error(`❌ ${extractErrorMessage(error)}`);
     process.exit(1);
   }
-  process.exit(0);
 }

--- a/libs/auth/scripts/program_system_administrator_java_card.ts
+++ b/libs/auth/scripts/program_system_administrator_java_card.ts
@@ -27,7 +27,7 @@ If not, that's likely the cause of this error.
 Run that and then retry.
 `;
 
-async function programSystemAdministratorJavaCard(): Promise<string> {
+async function programSystemAdministratorJavaCard(): Promise<void> {
   const card = new JavaCard(); // Uses NODE_ENV to determine which config to use
   await waitForReadyCardStatus(card);
 
@@ -45,7 +45,7 @@ async function programSystemAdministratorJavaCard(): Promise<string> {
     }
     throw error;
   }
-  return pin;
+  console.log(`✅ Done! Card PIN is ${hyphenatePin(pin)}.`);
 }
 
 /**
@@ -56,13 +56,11 @@ async function programSystemAdministratorJavaCard(): Promise<string> {
  * Programming a production card requires additional production-machine-specific env vars.
  */
 export async function main(): Promise<void> {
-  let pin: string;
   try {
-    pin = await programSystemAdministratorJavaCard();
+    await programSystemAdministratorJavaCard();
+    process.exit(0);
   } catch (error) {
     console.error(`❌ ${extractErrorMessage(error)}`);
     process.exit(1);
   }
-  console.log(`✅ Done! Card PIN is ${hyphenatePin(pin)}.`);
-  process.exit(0);
 }

--- a/libs/auth/scripts/read_java_card_details.ts
+++ b/libs/auth/scripts/read_java_card_details.ts
@@ -1,10 +1,10 @@
 import { extractErrorMessage } from '@votingworks/basics';
 
+import { CardDetails } from '../src/card';
 import {
   DEV_VX_CERT_AUTHORITY_CERT_PATH,
   PROD_VX_CERT_AUTHORITY_CERT_PATH,
-} from '../src';
-import { CardDetails } from '../src/card';
+} from '../src/config';
 import { verifyFirstCertWasSignedBySecondCert } from '../src/cryptography';
 import { JavaCard } from '../src/java_card';
 import { waitForReadyCardStatus } from './utils';
@@ -52,19 +52,20 @@ async function readJavaCardDetails(): Promise<ExtendedCardDetails | undefined> {
   return undefined;
 }
 
-function formatCardDetails(extendedCardDetails?: ExtendedCardDetails): string {
+function printCardDetails(extendedCardDetails?: ExtendedCardDetails): void {
   const { cardDetails, env } = extendedCardDetails ?? {};
   const { jurisdiction, role } = cardDetails?.user ?? {};
   const electionHash =
     cardDetails?.user.role !== 'system_administrator'
       ? cardDetails?.user.electionHash
       : undefined;
-  return `
+  const formattedCardDetails = `
 Env:           ${env ?? '-'}
 Jurisdiction:  ${jurisdiction ?? '-'}
 User role:     ${role ?? '-'}
 Election hash: ${electionHash ?? '-'}
 `;
+  console.log(formattedCardDetails);
 }
 
 /**
@@ -72,14 +73,11 @@ Election hash: ${electionHash ?? '-'}
  * election hash
  */
 export async function main(): Promise<void> {
-  let formattedCardDetails: string;
   try {
-    const cardDetails = await readJavaCardDetails();
-    formattedCardDetails = formatCardDetails(cardDetails);
+    printCardDetails(await readJavaCardDetails());
+    process.exit(0);
   } catch (error) {
     console.error(`❌ ${extractErrorMessage(error)}`);
     process.exit(1);
   }
-  console.log(formattedCardDetails);
-  process.exit(0);
 }


### PR DESCRIPTION
## Overview

As I've been iterating on the Google Cloud API integrations in VxDesign for language and audio file generation, I've been finding it helpful to be able to test the integrations end-to-end via scripts. Automated tests give me some assurance that things will work, but they (intentionally) mock the Google Cloud API clients so don't give full assurance.

I've added one script for testing text translation:

```
Usage: translate-text 'Text to translate' <target-language-code>

Arguments:
  <target-language-code>	es | zh
```

And another script for testing speech synthesis:

```
Usage: synthesize-speech 'Text to convert to speech' <language-code> <output-file-path>

Arguments:
  <language-code>	en | es | zh
  <output-file-path>	Should end in .mp3
```

## Testing Plan

- [x] Tested manually