### PR TITLE
[i18n/Audio] <UiString>-ify the 'Ask Poll Worker For Help' pages in Mark-Scan

### DIFF
--- a/apps/mark-scan/frontend/src/components/centered_page_layout.tsx
+++ b/apps/mark-scan/frontend/src/components/centered_page_layout.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import { Font, H1, Main, Screen } from '@votingworks/ui';
+import { ButtonFooter } from '@votingworks/mark-flow-ui';
+
+export interface CenteredPageLayoutProps {
+  buttons?: React.ReactNode;
+  children: React.ReactNode;
+  title?: React.ReactNode;
+  voterFacing: boolean;
+}
+
+export function CenteredPageLayout(
+  props: CenteredPageLayoutProps
+): JSX.Element {
+  const { buttons, children, title, voterFacing } = props;
+
+  return (
+    <Screen>
+      <Main padded centerChild>
+        <Font align="center" id={voterFacing ? 'audiofocus' : undefined}>
+          {title && <H1>{title}</H1>}
+          {children}
+        </Font>
+      </Main>
+      {buttons && <ButtonFooter>{buttons}</ButtonFooter>}
+    </Screen>
+  );
+}

--- a/apps/mark-scan/frontend/src/pages/ask_poll_worker_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/ask_poll_worker_page.tsx
@@ -1,72 +1,36 @@
-import React from 'react';
-import { Screen, H1, Main, Button, Text } from '@votingworks/ui';
+import { appStrings, P } from '@votingworks/ui';
 
 import { InsertedSmartCardAuth } from '@votingworks/types';
-import { isCardlessVoterAuth, isPollWorkerAuth } from '@votingworks/utils';
+import { isPollWorkerAuth } from '@votingworks/utils';
 
-import { assert } from '@votingworks/basics';
-import { ButtonFooter } from '@votingworks/mark-flow-ui';
+import { CenteredPageLayout } from '../components/centered_page_layout';
 
 interface Props {
   authStatus:
     | InsertedSmartCardAuth.CardlessVoterLoggedIn
     | InsertedSmartCardAuth.PollWorkerLoggedIn;
-  cardlessVoterContent: {
-    body: JSX.Element;
-  };
-  pollWorkerContent: {
-    headerText: string;
-    body: JSX.Element;
-    buttonText?: string;
-    onButtonPress?: () => Promise<void>;
-  };
+  children: JSX.Element;
+  pollWorkerPage: JSX.Element;
 }
 
 // Component with 2 stages
 // 1. Voter stage: tells the voter to ask a poll worker for help. Does not allow the voter to advance the state.
 // 2. Poll worker stage: after auth, gives instructions and a button to advance the state.
 export function AskPollWorkerPage(props: Props): JSX.Element {
-  const { authStatus, cardlessVoterContent, pollWorkerContent } = props;
+  const { authStatus, children, pollWorkerPage } = props;
 
-  let mainContents = (
-    <React.Fragment>
-      <H1>{pollWorkerContent.headerText}</H1>
-      {pollWorkerContent.body}
-    </React.Fragment>
-  );
-  const button = isPollWorkerAuth(authStatus) &&
-    pollWorkerContent.buttonText &&
-    pollWorkerContent.onButtonPress && (
-      <Button
-        onPress={async (): Promise<void> => {
-          assert(pollWorkerContent.onButtonPress);
-          await pollWorkerContent.onButtonPress();
-        }}
-      >
-        {pollWorkerContent.buttonText}
-      </Button>
-    );
-
-  if (isCardlessVoterAuth(authStatus)) {
-    mainContents = (
-      <React.Fragment>
-        <H1>
-          <span aria-label="Ask a Poll Worker for Help">
-            Ask a Poll Worker for Help
-          </span>
-        </H1>
-        {cardlessVoterContent.body}
-        <p>Insert a poll worker card to continue.</p>
-      </React.Fragment>
-    );
+  if (isPollWorkerAuth(authStatus)) {
+    return pollWorkerPage;
   }
 
   return (
-    <Screen>
-      <Main padded centerChild>
-        <Text center>{mainContents}</Text>
-      </Main>
-      {button && <ButtonFooter>{button}</ButtonFooter>}
-    </Screen>
+    <CenteredPageLayout
+      title={appStrings.titleBmdAskForHelpScreen()}
+      voterFacing
+    >
+      <div>{children}</div>
+      {/* Poll Worker string - not translated: */}
+      <P>Insert a poll worker card to continue.</P>
+    </CenteredPageLayout>
   );
 }

--- a/apps/mark-scan/frontend/src/pages/ballot_invalidated_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/ballot_invalidated_page.tsx
@@ -1,10 +1,8 @@
-import { useContext } from 'react';
-
 import { InsertedSmartCardAuth } from '@votingworks/types';
 
-import { confirmInvalidateBallot } from '../api';
-import { BallotContext } from '../contexts/ballot_context';
+import { P, appStrings } from '@votingworks/ui';
 import { AskPollWorkerPage } from './ask_poll_worker_page';
+import { RemoveInvalidatedBallotPage } from './remove_invalidated_ballot_page';
 
 interface Props {
   authStatus:
@@ -13,41 +11,12 @@ interface Props {
 }
 
 export function BallotInvalidatedPage({ authStatus }: Props): JSX.Element {
-  const { resetBallot, endVoterSession } = useContext(BallotContext);
-
-  const confirmInvalidateBallotMutation = confirmInvalidateBallot.useMutation();
-
-  async function onPressContinue() {
-    // Reset session and ballot before changing the state machine state. If done
-    // in the reverse order the screen will flicker
-    await endVoterSession();
-    resetBallot();
-    confirmInvalidateBallotMutation.mutate(undefined);
-  }
-
   return (
     <AskPollWorkerPage
       authStatus={authStatus}
-      cardlessVoterContent={{
-        body: (
-          <p>
-            You have indicated your ballot needs changes. Please alert a poll
-            worker to invalidate your incorrect ballot and restart your voting
-            session.
-          </p>
-        ),
-      }}
-      pollWorkerContent={{
-        headerText: 'Remove Ballot',
-        body: (
-          <p>
-            Remove the ballot and press below to start a new voter session.
-            Remember to spoil the old ballot.
-          </p>
-        ),
-        buttonText: 'Start a New Voter Session',
-        onButtonPress: onPressContinue,
-      }}
-    />
+      pollWorkerPage={<RemoveInvalidatedBallotPage />}
+    >
+      <P>{appStrings.instructionsBmdInvalidatedBallot()}</P>
+    </AskPollWorkerPage>
   );
 }

--- a/apps/mark-scan/frontend/src/pages/blank_page_interpretation_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/blank_page_interpretation_page.tsx
@@ -1,6 +1,8 @@
 import { InsertedSmartCardAuth } from '@votingworks/types';
 
+import { P, appStrings } from '@votingworks/ui';
 import { AskPollWorkerPage } from './ask_poll_worker_page';
+import { ReplaceBlankSheetPage } from './replace_blank_sheet_page';
 
 interface Props {
   authStatus:
@@ -14,19 +16,9 @@ export function BlankPageInterpretationPage({
   return (
     <AskPollWorkerPage
       authStatus={authStatus}
-      cardlessVoterContent={{
-        body: <p>There was a problem interpreting your ballot.</p>,
-      }}
-      pollWorkerContent={{
-        headerText: 'Load New Ballot Sheet',
-        body: (
-          <p>
-            The ballot page is blank after printing. It may have been loaded
-            with the print side facing down. Please remove the ballot sheet and
-            load a new sheet.
-          </p>
-        ),
-      }}
-    />
+      pollWorkerPage={<ReplaceBlankSheetPage />}
+    >
+      <P>{appStrings.noteBmdInterpretationProblem()}</P>
+    </AskPollWorkerPage>
   );
 }

--- a/apps/mark-scan/frontend/src/pages/casting_ballot_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/casting_ballot_page.tsx
@@ -1,18 +1,11 @@
-import {
-  Main,
-  Screen,
-  InsertBallotImage,
-  P,
-  appStrings,
-} from '@votingworks/ui';
+import { InsertBallotImage, P, appStrings } from '@votingworks/ui';
+import { CenteredPageLayout } from '../components/centered_page_layout';
 
 export function CastingBallotPage(): JSX.Element {
   return (
-    <Screen white>
-      <Main centerChild padded id="audiofocus">
-        <InsertBallotImage />
-        <P>{appStrings.noteBmdCastingBallot()}</P>
-      </Main>
-    </Screen>
+    <CenteredPageLayout voterFacing>
+      <InsertBallotImage />
+      <P>{appStrings.noteBmdCastingBallot()}</P>
+    </CenteredPageLayout>
   );
 }

--- a/apps/mark-scan/frontend/src/pages/continue_to_review_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/continue_to_review_page.tsx
@@ -1,29 +1,14 @@
-import { ButtonFooter } from '@votingworks/mark-flow-ui';
-import {
-  Main,
-  Screen,
-  H1,
-  LinkButton,
-  appStrings,
-  AudioOnly,
-  Font,
-  P,
-} from '@votingworks/ui';
+import { LinkButton, appStrings, AudioOnly, P } from '@votingworks/ui';
+import { CenteredPageLayout } from '../components/centered_page_layout';
 
 // This page is rendered as part of the blank ballot interpretation flow immediately after
 // the poll worker card is removed. To protect voter privacy, we render this screen first to
 // ask the voter to approve before showing ballot selections on screen.
 export function ContinueToReviewPage(): JSX.Element {
   return (
-    <Screen white>
-      <Main padded centerChild>
-        <Font align="center" id="audiofocus">
-          <H1>{appStrings.titleBmdReadyToReview()}</H1>
-          <P>{appStrings.noteBmdBallotSheetLoaded()}</P>
-          <AudioOnly>{appStrings.instructionsBmdSelectToContinue()}</AudioOnly>
-        </Font>
-      </Main>
-      <ButtonFooter>
+    <CenteredPageLayout
+      title={appStrings.titleBmdReadyToReview()}
+      buttons={
         <LinkButton
           autoFocus
           to="/review"
@@ -33,7 +18,11 @@ export function ContinueToReviewPage(): JSX.Element {
         >
           {appStrings.buttonReturnToBallotReview()}
         </LinkButton>
-      </ButtonFooter>
-    </Screen>
+      }
+      voterFacing
+    >
+      <P>{appStrings.noteBmdBallotSheetLoaded()}</P>
+      <AudioOnly>{appStrings.instructionsBmdSelectToContinue()}</AudioOnly>
+    </CenteredPageLayout>
   );
 }

--- a/apps/mark-scan/frontend/src/pages/jam_cleared_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/jam_cleared_page.tsx
@@ -1,4 +1,5 @@
-import { Main, Screen, H1, appStrings, P, Font } from '@votingworks/ui';
+import { appStrings, P } from '@votingworks/ui';
+import { CenteredPageLayout } from '../components/centered_page_layout';
 
 interface Props {
   stateMachineState: 'jam_cleared' | 'resetting_state_machine_after_jam';
@@ -11,15 +12,13 @@ export function JamClearedPage({ stateMachineState }: Props): JSX.Element {
       : appStrings.noteBmdHardwareReset();
 
   return (
-    <Screen white>
-      <Main padded centerChild>
-        <Font align="center" id="audiofocus">
-          <H1>{appStrings.titleBmdJamClearedScreen()}</H1>
-          <P>
-            {statusMessage} {appStrings.noteBmdSessionRestart()}
-          </P>
-        </Font>
-      </Main>
-    </Screen>
+    <CenteredPageLayout
+      title={appStrings.titleBmdJamClearedScreen()}
+      voterFacing
+    >
+      <P>
+        {statusMessage} {appStrings.noteBmdSessionRestart()}
+      </P>
+    </CenteredPageLayout>
   );
 }

--- a/apps/mark-scan/frontend/src/pages/jammed_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/jammed_page.tsx
@@ -1,14 +1,10 @@
-import { Main, Screen, H1, Font, appStrings, P } from '@votingworks/ui';
+import { appStrings, P } from '@votingworks/ui';
+import { CenteredPageLayout } from '../components/centered_page_layout';
 
 export function JammedPage(): JSX.Element {
   return (
-    <Screen white>
-      <Main padded centerChild>
-        <Font align="center" id="audiofocus">
-          <H1>{appStrings.titleBmdJammedScreen()}</H1>
-          <P>{appStrings.instructionsBmdPaperJam()}</P>
-        </Font>
-      </Main>
-    </Screen>
+    <CenteredPageLayout title={appStrings.titleBmdJammedScreen()} voterFacing>
+      <P>{appStrings.instructionsBmdPaperJam()}</P>
+    </CenteredPageLayout>
   );
 }

--- a/apps/mark-scan/frontend/src/pages/load_paper_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/load_paper_page.tsx
@@ -1,14 +1,13 @@
-import { Main, Screen, H1, P, Font, appStrings } from '@votingworks/ui';
+import { P, appStrings } from '@votingworks/ui';
+import { CenteredPageLayout } from '../components/centered_page_layout';
 
 export function LoadPaperPage(): JSX.Element {
   return (
-    <Screen white>
-      <Main padded centerChild>
-        <Font align="center" id="audiofocus">
-          <H1>{appStrings.titleBmdLoadPaperScreen()}</H1>
-          <P>{appStrings.instructionsBmdLoadPaper()}</P>
-        </Font>
-      </Main>
-    </Screen>
+    <CenteredPageLayout
+      title={appStrings.titleBmdLoadPaperScreen()}
+      voterFacing
+    >
+      <P>{appStrings.instructionsBmdLoadPaper()}</P>
+    </CenteredPageLayout>
   );
 }

--- a/apps/mark-scan/frontend/src/pages/remove_invalidated_ballot_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/remove_invalidated_ballot_page.tsx
@@ -1,0 +1,35 @@
+import { useContext } from 'react';
+
+import { Button, P } from '@votingworks/ui';
+import { confirmInvalidateBallot } from '../api';
+import { BallotContext } from '../contexts/ballot_context';
+import { CenteredPageLayout } from '../components/centered_page_layout';
+
+export function RemoveInvalidatedBallotPage(): JSX.Element {
+  const { resetBallot, endVoterSession } = useContext(BallotContext);
+
+  const confirmInvalidateBallotMutation = confirmInvalidateBallot.useMutation();
+
+  async function onPressContinue() {
+    // Reset session and ballot before changing the state machine state. If done
+    // in the reverse order the screen will flicker
+    await endVoterSession();
+    resetBallot();
+    confirmInvalidateBallotMutation.mutate(undefined);
+  }
+
+  return (
+    <CenteredPageLayout
+      title="Remove Ballot"
+      buttons={
+        <Button onPress={onPressContinue}>Start a New Voter Session</Button>
+      }
+      voterFacing={false}
+    >
+      <P>
+        Remove the ballot and press below to start a new voter session. Remember
+        to spoil the old ballot.
+      </P>
+    </CenteredPageLayout>
+  );
+}

--- a/apps/mark-scan/frontend/src/pages/replace_blank_sheet_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/replace_blank_sheet_page.tsx
@@ -1,0 +1,14 @@
+import { P } from '@votingworks/ui';
+import { CenteredPageLayout } from '../components/centered_page_layout';
+
+export function ReplaceBlankSheetPage(): JSX.Element {
+  return (
+    <CenteredPageLayout title="Load New Ballot Sheet" voterFacing={false}>
+      <P>
+        The ballot page is blank after printing. It may have been loaded with
+        the print side facing down. Please remove the ballot sheet and load a
+        new sheet.
+      </P>
+    </CenteredPageLayout>
+  );
+}

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -109,6 +109,13 @@ export const appStrings = {
     </UiString>
   ),
 
+  instructionsBmdInvalidatedBallot: () => (
+    <UiString uiStringKey="instructionsBmdInvalidatedBallot">
+      You have indicated your ballot needs changes. Please alert a poll worker
+      to invalidate your incorrect ballot and restart your voting session.
+    </UiString>
+  ),
+
   instructionsBmdLoadPaper: () => (
     <UiString uiStringKey="instructionsBmdLoadPaper">
       Please feed one sheet of paper into the front input tray. The printer will
@@ -294,6 +301,12 @@ export const appStrings = {
   promptBmdConfirmRemoveWriteIn: () => (
     <UiString uiStringKey="promptBmdConfirmRemoveWriteIn">
       Do you want to deselect and remove your write-in candidate?
+    </UiString>
+  ),
+
+  titleBmdAskForHelpScreen: () => (
+    <UiString uiStringKey="titleBmdAskForHelpScreen">
+      Ask a Poll Worker for Help
     </UiString>
   ),
 

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -292,6 +292,12 @@ export const appStrings = {
     </UiString>
   ),
 
+  noteBmdInterpretationProblem: () => (
+    <UiString uiStringKey="noteBmdInterpretationProblem">
+      There was a problem interpreting your ballot.
+    </UiString>
+  ),
+
   noteBmdSessionRestart: () => (
     <UiString uiStringKey="noteBmdSessionRestart">
       Your voting session will restart shortly.


### PR DESCRIPTION
## Overview

Converting strings on the `Mark-Scan` `AskPollWorkerPage` screens to language-aware `<UiString>`s.

Chose to split out the poll-worker-facing pieces of these screens to separate screen components  - this will make it easier in the future to add file-level eslint rule exceptions when we introduce linting to enforce translations for voter-facing strings.

Also opportunistically consolidated the structure for some voter-facing screens  into a `CenteredPageLayout` to simplify.

## Demo Video or Screenshot
| Default  | Sample Translation | With Card Inserted |
| ------------- | ------------- | ------------- |
| ![Screenshot 2023-11-08 at 11 46 44](https://github.com/votingworks/vxsuite/assets/264902/2b1a2a30-80b7-4f48-a533-886347538bd5) | ![Screenshot 2023-11-08 at 11 48 49](https://github.com/votingworks/vxsuite/assets/264902/3db06291-a825-4d0a-bd50-8af1bf3afd0c) | ![Screenshot 2023-11-08 at 11 48 56](https://github.com/votingworks/vxsuite/assets/264902/59d5948e-2166-412e-bf84-241b3a23a7cb) |
| ![Screenshot 2023-11-08 at 11 50 34](https://github.com/votingworks/vxsuite/assets/264902/46df984a-ca0b-48d6-964f-49456317f834) | ![Screenshot 2023-11-08 at 11 50 29](https://github.com/votingworks/vxsuite/assets/264902/54063da6-eaec-45ed-a289-c62fbfdd1458) | ![Screenshot 2023-11-08 at 11 50 41](https://github.com/votingworks/vxsuite/assets/264902/58fe9077-23ef-436f-affe-5a936d912089) |

## Testing Plan
- Manual verification for translations
- Existing tests as regression guard

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
