### PR TITLE
Clean text before text-to-speech processing

### DIFF
--- a/apps/design/backend/src/language_and_audio/speech_synthesizer.test.ts
+++ b/apps/design/backend/src/language_and_audio/speech_synthesizer.test.ts
@@ -43,3 +43,20 @@ test('GoogleCloudSpeechSynthesizer', async () => {
   );
   expect(textToSpeechClient.synthesizeSpeech).not.toHaveBeenCalled();
 });
+
+test('GoogleCloudSpeechSynthesizer text cleaning', async () => {
+  const store = Store.memoryStore();
+  const textToSpeechClient = new MockGoogleCloudTextToSpeechClient();
+  const speechSynthesizer = new GoogleCloudSpeechSynthesizer({
+    store,
+    textToSpeechClient,
+  });
+
+  const audioClipBase64 = await speechSynthesizer.synthesizeSpeech(
+    'Do you prefer <1>apple pie</1> or <3>orange marmalade</3>?',
+    LanguageCode.ENGLISH
+  );
+  expect(Buffer.from(audioClipBase64, 'base64').toString('utf-8')).toEqual(
+    'Do you prefer apple pie or orange marmalade? (audio)'
+  );
+});

--- a/apps/design/backend/src/language_and_audio/speech_synthesizer.ts
+++ b/apps/design/backend/src/language_and_audio/speech_synthesizer.ts
@@ -32,6 +32,15 @@ export type MinimalGoogleCloudTextToSpeechClient = Pick<
 >;
 
 /**
+ * i18next catalog strings can contain tags that interfere with speech synthesis, e.g.
+ * "Do you prefer <1>apple pie</1> or <3>orange marmalade</3>?". This function cleans text in
+ * preparation for speech synthesis accordingly.
+ */
+export function cleanText(text: string): string {
+  return text.replace(/<\/?\d+>/g, '');
+}
+
+/**
  * An implementation of {@link SpeechSynthesizer} that uses the Google Cloud Text-to-Speech API
  */
 export class GoogleCloudSpeechSynthesizer implements SpeechSynthesizer {
@@ -60,7 +69,7 @@ export class GoogleCloudSpeechSynthesizer implements SpeechSynthesizer {
     }
 
     const audioClipBase64 = await this.synthesizeSpeechWithGoogleCloud(
-      text,
+      cleanText(text),
       languageCode
     );
     this.store.addSpeechSynthesisCacheEntry({


### PR DESCRIPTION
## Overview

@kofi-q proactively pointed out an edge case in his review of https://github.com/votingworks/vxsuite/pull/4171#pullrequestreview-1717995232.  i18next catalog strings can contain tags that interfere with speech synthesis, e.g. "Do you prefer <1>apple pie</1> or <3>orange marmalade</3>?" (an apples-to-oranges comparison, I know 😉). This PR cleans text in preparation for speech synthesis accordingly.

## Demo

```
./synthesize-speech 'Do you prefer <1>apple pie</1> or <3>orange marmalade</3>?' en audioClip.mp3
```

_Before this PR_

https://github.com/votingworks/vxsuite/assets/12616928/d3256a48-4c64-4df9-8bf8-058df9e8caf8

I will not stop finding this audio clip hilarious 😆

_After this PR_

https://github.com/votingworks/vxsuite/assets/12616928/d15fcad3-6d9f-4c09-8d93-7b42dbbfc838

Less comedic, more user-friendly

## Testing Plan

- [x] Added unit tests
- [x] Tested end-to-end via script (see above)

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A