### PR TITLE
Add documentation for Google Cloud authentication

### DIFF
--- a/apps/design/backend/README.md
+++ b/apps/design/backend/README.md
@@ -1,7 +1,5 @@
 # VxDesign (Backend)
 
-**Experimental Prototype**
-
 Backend server for VxDesign.
 
 ## Setup
@@ -15,6 +13,12 @@ frontend, which will automatically run the backend.
 cd apps/design/frontend
 pnpm start
 ```
+
+### Google Cloud Authentication
+
+Follow the instructions
+[here](./src/language_and_audio/README.md#google-cloud-authentication) to
+authenticate with Google Cloud for language and audio file generation.
 
 ## Configuration
 

--- a/apps/design/backend/src/language_and_audio/README.md
+++ b/apps/design/backend/src/language_and_audio/README.md
@@ -1,0 +1,17 @@
+# Language and Audio
+
+## Google Cloud Authentication
+
+We've created a
+[Google Cloud service account](https://cloud.google.com/iam/docs/service-account-overview)
+for VxDesign that has access to the Google Cloud Translation and Text-to-Speech
+APIs. VxDesign will be deployed with the VxDesign service account key.
+
+For local development, VotingWorks employees can impersonate the VxDesign
+service account. To do this, you'll need to
+[install the Google Cloud CLI](https://cloud.google.com/sdk/docs/install-sdk)
+and run the following command:
+
+```sh
+gcloud auth application-default login --impersonate-service-account vxdesign@astral-pursuit-395520.iam.gserviceaccount.com
+```

--- a/apps/design/frontend/README.md
+++ b/apps/design/frontend/README.md
@@ -1,7 +1,5 @@
 # VxDesign
 
-**Experimental Prototype**
-
 An application for designing ballots.
 
 ## Setup
@@ -14,3 +12,9 @@ pnpm start
 ```
 
 The server will be available at http://localhost:3000/.
+
+### Google Cloud Authentication
+
+Follow the instructions
+[here](../backend/src/language_and_audio/README.md#google-cloud-authentication)
+to authenticate with Google Cloud for language and audio file generation.


### PR DESCRIPTION
## Overview

This PR adds documentation for Google Cloud authentication, specifically when running VxDesign locally. This authentication is necessary if you want to be able to generate language and audio files.