### PR TITLE
[i18n/Audio] <UiString>-ify the DisplaySettings menu

### DIFF
--- a/libs/ui/src/display_settings/color_settings.tsx
+++ b/libs/ui/src/display_settings/color_settings.tsx
@@ -6,6 +6,7 @@ import { RadioGroup } from '../radio_group';
 import { ThemeManagerContext } from '../theme_manager_context';
 import { ThemeLabel } from './theme_label';
 import { useScreenInfo } from '../hooks/use_screen_info';
+import { appStrings } from '../ui_strings';
 
 export interface ColorSettingsProps {
   /** @default ['contrastLow', 'contrastMedium', 'contrastHighLight', 'contrastHighDark'] */
@@ -19,11 +20,11 @@ const DEFAULT_COLOR_MODES: TouchColorMode[] = [
   'contrastHighLight',
 ];
 
-const ORDERED_COLOR_MODE_LABELS: Record<TouchColorMode, string> = {
-  contrastHighDark: 'White text, black background',
-  contrastLow: 'Gray text, dark background',
-  contrastMedium: 'Dark text, light background',
-  contrastHighLight: 'Black text, white background',
+const ORDERED_COLOR_MODE_LABELS: Record<TouchColorMode, JSX.Element> = {
+  contrastHighDark: appStrings.labelThemesContrastHighDark(),
+  contrastLow: appStrings.labelThemesContrastLow(),
+  contrastMedium: appStrings.labelThemesContrastMedium(),
+  contrastHighLight: appStrings.labelThemesContrastHighLight(),
 };
 
 export function ColorSettings(props: ColorSettingsProps): JSX.Element {

--- a/libs/ui/src/display_settings/index.tsx
+++ b/libs/ui/src/display_settings/index.tsx
@@ -9,6 +9,7 @@ import { H2 } from '../typography';
 import { Button } from '../button';
 import { ThemeManagerContext } from '../theme_manager_context';
 import { useScreenInfo } from '../hooks/use_screen_info';
+import { appStrings } from '../ui_strings';
 
 export interface DisplaySettingsProps {
   /** @default ['contrastLow', 'contrastMedium', 'contrastHighLight', 'contrastHighDark'] */
@@ -71,7 +72,7 @@ export function DisplaySettings(props: DisplaySettingsProps): JSX.Element {
   return (
     <Container>
       <Header portrait={screenInfo.isPortrait}>
-        <H2 as="h1">Display Settings:</H2>
+        <H2 as="h1">{appStrings.titleDisplaySettings()}</H2>
         <TabBar
           activePaneId={activePaneId}
           grow={!screenInfo.isPortrait}
@@ -87,9 +88,9 @@ export function DisplaySettings(props: DisplaySettingsProps): JSX.Element {
         )}
       </ActivePaneContainer>
       <Footer>
-        <Button onPress={resetThemes}>Reset</Button>
+        <Button onPress={resetThemes}>{appStrings.buttonReset()}</Button>
         <Button onPress={onClose} variant="primary" icon="Done">
-          Done
+          {appStrings.buttonDone()}
         </Button>
       </Footer>
     </Container>

--- a/libs/ui/src/display_settings/size_settings.tsx
+++ b/libs/ui/src/display_settings/size_settings.tsx
@@ -6,6 +6,7 @@ import { RadioGroup } from '../radio_group';
 import { ThemeManagerContext } from '../theme_manager_context';
 import { ThemeLabel } from './theme_label';
 import { useScreenInfo } from '../hooks/use_screen_info';
+import { appStrings } from '../ui_strings';
 
 export interface SizeSettingsProps {
   /** @default ['touchSmall', 'touchMedium', 'touchLarge', 'touchExtraLarge'] */
@@ -19,11 +20,11 @@ const DEFAULT_SIZE_MODES: SizeMode[] = [
   'touchExtraLarge',
 ];
 
-const ORDERED_SIZE_MODE_LABELS: Record<TouchSizeMode, string> = {
-  touchSmall: 'Small',
-  touchMedium: 'Medium',
-  touchLarge: 'Large',
-  touchExtraLarge: 'Extra-Large',
+const ORDERED_SIZE_MODE_LABELS: Record<TouchSizeMode, JSX.Element> = {
+  touchSmall: appStrings.labelThemesSizeSmall(),
+  touchMedium: appStrings.labelThemesSizeMedium(),
+  touchLarge: appStrings.labelThemesSizeLarge(),
+  touchExtraLarge: appStrings.labelThemesSizeExtraLarge(),
 };
 
 export function SizeSettings(props: SizeSettingsProps): JSX.Element {

--- a/libs/ui/src/display_settings/tab_bar.tsx
+++ b/libs/ui/src/display_settings/tab_bar.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 
 import { PANE_IDS, SettingsPaneId } from './types';
 import { Button } from '../button';
+import { appStrings } from '../ui_strings';
 
 export interface TabBarProps {
   activePaneId: SettingsPaneId;
@@ -34,8 +35,8 @@ const TabLabel = styled.span`
 `;
 
 const TAB_LABELS: Record<SettingsPaneId, JSX.Element> = {
-  displaySettingsColor: <span>Color</span>,
-  displaySettingsSize: <span>Text Size</span>,
+  displaySettingsColor: appStrings.titleDisplaySettingsColor(),
+  displaySettingsSize: appStrings.titleDisplaySettingsSize(),
 };
 
 /**

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -55,6 +55,8 @@ export const appStrings = {
 
   buttonOkay: () => <UiString uiStringKey="buttonOkay">Okay</UiString>,
 
+  buttonReset: () => <UiString uiStringKey="buttonReset">Reset</UiString>,
+
   buttonPrintBallot: () => (
     <UiString uiStringKey="buttonPrintBallot">Print My Ballot</UiString>
   ),
@@ -233,6 +235,46 @@ export const appStrings = {
     <UiString uiStringKey="labelSelectedOption">Selected option:</UiString>
   ),
 
+  labelThemesContrastHighDark: () => (
+    <UiString uiStringKey="labelThemesContrastHighDark">
+      White text, black background
+    </UiString>
+  ),
+
+  labelThemesContrastHighLight: () => (
+    <UiString uiStringKey="labelThemesContrastHighLight">
+      Black text, white background
+    </UiString>
+  ),
+
+  labelThemesContrastLow: () => (
+    <UiString uiStringKey="labelThemesContrastLow">
+      Gray text, dark background
+    </UiString>
+  ),
+
+  labelThemesContrastMedium: () => (
+    <UiString uiStringKey="labelThemesContrastMedium">
+      Dark text, light background
+    </UiString>
+  ),
+
+  labelThemesSizeExtraLarge: () => (
+    <UiString uiStringKey="labelThemesSizeExtraLarge">Extra-Large</UiString>
+  ),
+
+  labelThemesSizeLarge: () => (
+    <UiString uiStringKey="labelThemesSizeLarge">Large</UiString>
+  ),
+
+  labelThemesSizeMedium: () => (
+    <UiString uiStringKey="labelThemesSizeMedium">Medium</UiString>
+  ),
+
+  labelThemesSizeSmall: () => (
+    <UiString uiStringKey="labelThemesSizeSmall">Small</UiString>
+  ),
+
   labelTotalContests: () => (
     <UiString uiStringKey="labelTotalContests">Total contests:</UiString>
   ),
@@ -352,6 +394,18 @@ export const appStrings = {
 
   titleBmdReviewScreen: () => (
     <UiString uiStringKey="titleBmdReviewScreen">Review Your Votes</UiString>
+  ),
+
+  titleDisplaySettings: () => (
+    <UiString uiStringKey="titleDisplaySettings">Display Settings:</UiString>
+  ),
+
+  titleDisplaySettingsColor: () => (
+    <UiString uiStringKey="titleDisplaySettingsColor">Color</UiString>
+  ),
+
+  titleDisplaySettingsSize: () => (
+    <UiString uiStringKey="titleDisplaySettingsSize">Text Size</UiString>
   ),
 
   warningBmdInactiveSession: () => (


### PR DESCRIPTION
## Overview

Converting text in the shared `DisplaySettings` menu component to language-aware `<UiString>`s.

## Demo Video or Screenshot
### With sample translations:
<img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/fdf013ec-9e3e-485f-b21e-795b86983998" /> 
<img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/d134432e-ce13-4c3c-bbf2-96e467aa26e4" />

## Testing Plan
- Manual verification + existing tests as regression checks

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
