### PR TITLE
VxCentralScan: Support all paper sizes

### DIFF
--- a/apps/central-scan/backend/src/fujitsu_scanner.test.ts
+++ b/apps/central-scan/backend/src/fujitsu_scanner.test.ts
@@ -60,9 +60,14 @@ test('fujitsu scanner can scan with letter size', () => {
       'Press Ctrl + D to terminate.\n',
     ].join('')
   );
-  expect(exec).not.toHaveBeenCalledWith(
+  expect(exec).toHaveBeenCalledWith(
     'scanimage',
-    expect.arrayContaining(['--page-height'])
+    expect.arrayContaining([
+      '--page-width',
+      '215.872',
+      '--page-height',
+      '279.364',
+    ])
   );
 });
 
@@ -85,7 +90,12 @@ test('fujitsu scanner can scan with legal size', () => {
   );
   expect(exec).toHaveBeenCalledWith(
     'scanimage',
-    expect.arrayContaining(['--page-height'])
+    expect.arrayContaining([
+      '--page-width',
+      '215.872',
+      '--page-height',
+      '355.554',
+    ])
   );
 });
 

--- a/libs/cvr-fixture-generator/src/cli/generate/main.ts
+++ b/libs/cvr-fixture-generator/src/cli/generate/main.ts
@@ -3,6 +3,7 @@ import {
   CVR,
   CastVoteRecordExportFileName,
   CastVoteRecordExportMetadata,
+  ballotPaperDimensions,
   safeParseElectionDefinition,
 } from '@votingworks/types';
 import { assert, assertDefined, iter } from '@votingworks/basics';
@@ -22,11 +23,7 @@ import {
   generateCvrs,
   populateImageAndLayoutFileHashes,
 } from '../../generate_cvrs';
-import {
-  replaceUniqueId,
-  getBatchIdForScannerId,
-  PAGE_HEIGHT_INCHES,
-} from '../../utils';
+import { replaceUniqueId, getBatchIdForScannerId } from '../../utils';
 
 /**
  * Script to generate a cast vote record file for a given election.
@@ -240,18 +237,16 @@ export async function main(
         );
         const layoutFilePath = imageFilePath.replace('.jpg', '.layout.json');
 
-        const pageHeightInches =
-          PAGE_HEIGHT_INCHES[election.ballotLayout.paperSize];
-        const pageWidthInches = 8.5;
+        const { width, height } = ballotPaperDimensions(
+          election.ballotLayout.paperSize
+        );
         const pageDpi = 200;
         await writeImageData(
           imageFilePath,
           createImageData(
-            new Uint8ClampedArray(
-              pageWidthInches * pageDpi * pageHeightInches * pageDpi * 4
-            ),
-            pageWidthInches * pageDpi,
-            pageHeightInches * pageDpi
+            new Uint8ClampedArray(width * pageDpi * height * pageDpi * 4),
+            width * pageDpi,
+            height * pageDpi
           )
         );
 

--- a/libs/cvr-fixture-generator/src/generate_cvrs.ts
+++ b/libs/cvr-fixture-generator/src/generate_cvrs.ts
@@ -9,7 +9,7 @@ import {
   BallotPageContestLayout,
   BallotPageContestOptionLayout,
   BallotPageLayout,
-  BallotPaperSize,
+  ballotPaperDimensions,
   BallotType,
   Candidate,
   CandidateContest,
@@ -137,9 +137,11 @@ export function generateBallotPageLayouts(
   }
 
   const { paperSize } = election.ballotLayout;
+  const { width, height } = ballotPaperDimensions(paperSize);
+  const PPI = 200;
   const pageSize: Size = {
-    width: 200 * 8.5,
-    height: 200 * (paperSize === BallotPaperSize.Letter ? 11 : 14),
+    width: PPI * width,
+    height: PPI * height,
   };
   return mapSheet([1, 2], (pageNumber, side) => ({
     pageSize,

--- a/libs/cvr-fixture-generator/src/utils.ts
+++ b/libs/cvr-fixture-generator/src/utils.ts
@@ -2,7 +2,6 @@ import { assert, assertDefined } from '@votingworks/basics';
 import { sha256 } from 'js-sha256';
 import {
   BallotPageLayout,
-  BallotPaperSize,
   Contests,
   CVR,
   Election,
@@ -11,18 +10,6 @@ import {
   SheetOf,
   VotesDict,
 } from '@votingworks/types';
-
-/**
- * A mapping from ballot paper size to page height, in inches
- */
-export const PAGE_HEIGHT_INCHES: Record<BallotPaperSize, number> = {
-  [BallotPaperSize.Letter]: 11,
-  [BallotPaperSize.Legal]: 14,
-  [BallotPaperSize.Custom17]: 17,
-  [BallotPaperSize.Custom18]: 18,
-  [BallotPaperSize.Custom21]: 21,
-  [BallotPaperSize.Custom22]: 22,
-};
 
 /**
  * Generate all combinations of an array.

--- a/libs/hmpb/layout/src/layout.ts
+++ b/libs/hmpb/layout/src/layout.ts
@@ -5,12 +5,12 @@ import {
   ok,
   range,
   Result,
-  throwIllegalValue,
   uniqueBy,
   wrapException,
 } from '@votingworks/basics';
 import {
   AnyContest,
+  ballotPaperDimensions,
   BallotPaperSize,
   BallotStyle,
   BallotType,
@@ -146,54 +146,13 @@ export interface GridDimensions {
   columns: number;
 }
 
-// In inches
-export function dimensionsForPaper(paperSize: BallotPaperSize): {
-  width: number;
-  height: number;
-} {
-  switch (paperSize) {
-    case BallotPaperSize.Letter:
-      return {
-        width: 8.5,
-        height: 11,
-      };
-    case BallotPaperSize.Legal:
-      return {
-        width: 8.5,
-        height: 14,
-      };
-    case BallotPaperSize.Custom17:
-      return {
-        width: 8.5,
-        height: 17,
-      };
-    case BallotPaperSize.Custom18:
-      return {
-        width: 8.5,
-        height: 18,
-      };
-    case BallotPaperSize.Custom21:
-      return {
-        width: 8.5,
-        height: 21,
-      };
-    case BallotPaperSize.Custom22:
-      return {
-        width: 8.5,
-        height: 22,
-      };
-    default:
-      throwIllegalValue(paperSize);
-  }
-}
-
 export function gridForPaper(paperSize: BallotPaperSize): GridDimensions {
   // Corresponds to the NH Accuvote ballot grid, which we mimic so that our
   // interpreter can support both Accuvote-style ballots and our ballots.
   // This formula is replicated in libs/ballot-interpreter/src/ballot_card.rs.
   const columnsPerInch = 4;
   const rowsPerInch = 4;
-  const dimensions = dimensionsForPaper(paperSize);
+  const dimensions = ballotPaperDimensions(paperSize);
   return {
     rows: dimensions.height * rowsPerInch - 3,
     columns: dimensions.width * columnsPerInch,
@@ -225,7 +184,7 @@ export function measurements(
   const WRITE_IN_ROW_HEIGHT = [2, 1, 1][density];
   const BALLOT_MEASURE_OPTION_POSITION = ['block', 'block', 'inline'][density];
 
-  const dimensions = dimensionsForPaper(paperSize);
+  const dimensions = ballotPaperDimensions(paperSize);
   const DOCUMENT_WIDTH = dimensions.width * PPI;
   const DOCUMENT_HEIGHT = dimensions.height * PPI;
   const COLUMN_GAP = DOCUMENT_WIDTH / (grid.columns + 1);

--- a/libs/types/src/election.test.ts
+++ b/libs/types/src/election.test.ts
@@ -1,6 +1,7 @@
 import * as fc from 'fast-check';
 import { sha256 } from 'js-sha256';
 import {
+  ballotPaperDimensions,
   getBallotStyle,
   getCandidateParties,
   getCandidatePartiesDescription,
@@ -28,6 +29,7 @@ import {
 } from '../test/election';
 import {
   BallotIdSchema,
+  BallotPaperSize,
   CandidateContest,
   CandidateSchema,
   ElectionDefinitionSchema,
@@ -538,4 +540,31 @@ test('safeParseElection shows VXF and CDF parsing errors', () => {
   expect(error.message).toContain('VXF error:');
   expect(error.message).toContain('CDF error:');
   expect(error).toMatchSnapshot();
+});
+
+test('ballotPaperDimensions', () => {
+  expect(ballotPaperDimensions(BallotPaperSize.Letter)).toEqual({
+    width: 8.5,
+    height: 11,
+  });
+  expect(ballotPaperDimensions(BallotPaperSize.Legal)).toEqual({
+    width: 8.5,
+    height: 14,
+  });
+  expect(ballotPaperDimensions(BallotPaperSize.Custom17)).toEqual({
+    width: 8.5,
+    height: 17,
+  });
+  expect(ballotPaperDimensions(BallotPaperSize.Custom18)).toEqual({
+    width: 8.5,
+    height: 18,
+  });
+  expect(ballotPaperDimensions(BallotPaperSize.Custom21)).toEqual({
+    width: 8.5,
+    height: 21,
+  });
+  expect(ballotPaperDimensions(BallotPaperSize.Custom22)).toEqual({
+    width: 8.5,
+    height: 22,
+  });
 });

--- a/libs/types/src/election_utils.ts
+++ b/libs/types/src/election_utils.ts
@@ -1,5 +1,7 @@
+import { throwIllegalValue } from '@votingworks/basics';
 import {
   AnyContest,
+  BallotPaperSize,
   BallotStyle,
   BallotStyleId,
   Candidate,
@@ -394,4 +396,46 @@ export function getDisplayElectionHash(
   electionDefinition: Pick<ElectionDefinition, 'electionHash'>
 ): string {
   return electionDefinition.electionHash.slice(0, ELECTION_HASH_DISPLAY_LENGTH);
+}
+
+// In inches
+export function ballotPaperDimensions(paperSize: BallotPaperSize): {
+  width: number;
+  height: number;
+} {
+  switch (paperSize) {
+    case BallotPaperSize.Letter:
+      return {
+        width: 8.5,
+        height: 11,
+      };
+    case BallotPaperSize.Legal:
+      return {
+        width: 8.5,
+        height: 14,
+      };
+    case BallotPaperSize.Custom17:
+      return {
+        width: 8.5,
+        height: 17,
+      };
+    case BallotPaperSize.Custom18:
+      return {
+        width: 8.5,
+        height: 18,
+      };
+    case BallotPaperSize.Custom21:
+      return {
+        width: 8.5,
+        height: 21,
+      };
+    case BallotPaperSize.Custom22:
+      return {
+        width: 8.5,
+        height: 22,
+      };
+    /* istanbul ignore next */
+    default:
+      return throwIllegalValue(paperSize);
+  }
 }


### PR DESCRIPTION
## Overview

Adds support to VxCentralScan for all of our ballot paper sizes. Also consolidates specification of ballot paper sizes to a single util function.

## Demo Video or Screenshot

## Testing Plan
I have not yet tested the actual functionality of this change, since I don't have long paper sizes or a Fujitsu.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
