### PR TITLE
[fix/uistrings] Avoid numeric entity IDs getting treated as array indices

### DIFF
--- a/libs/utils/src/extract_cdf_ui_strings.test.ts
+++ b/libs/utils/src/extract_cdf_ui_strings.test.ts
@@ -583,3 +583,36 @@ const tests: Record<ElectionStringKey, () => void> = {
 test.each(Object.entries(tests))('extract %s', (_electionStringKey, testFn) =>
   testFn()
 );
+
+test('handles legacy numeric entity IDs', () => {
+  const uiStrings = extractCdfUiStrings({
+    ...testCdfBallotDefinition,
+    GpUnit: [
+      {
+        '@id': '0',
+        '@type': 'BallotDefinition.ReportingUnit',
+        Name: buildInternationalizedText({
+          [LanguageCode.ENGLISH]: 'Brooklyn Nine-Nine',
+        }),
+        Type: BallotDefinition.ReportingUnitType.Precinct,
+      },
+      {
+        '@id': '1',
+        '@type': 'BallotDefinition.ReportingUnit',
+        Name: buildInternationalizedText({
+          [LanguageCode.ENGLISH]: 'West River',
+        }),
+        Type: BallotDefinition.ReportingUnitType.Precinct,
+      },
+    ],
+  });
+
+  expect(uiStrings).toEqual({
+    [LanguageCode.ENGLISH]: expect.objectContaining({
+      [ElectionStringKey.PRECINCT_NAME]: {
+        '0': 'Brooklyn Nine-Nine',
+        '1': 'West River',
+      },
+    }),
+  });
+});

--- a/libs/utils/src/extract_cdf_ui_strings.ts
+++ b/libs/utils/src/extract_cdf_ui_strings.ts
@@ -40,7 +40,7 @@ function setInternationalizedUiStrings(params: {
     }
 
     const valuePath = [languageCode, stringKey].flat();
-    _.set(uiStrings, valuePath, value.Content);
+    _.setWith(uiStrings, valuePath, value.Content, Object);
   }
 }
 
@@ -56,7 +56,7 @@ function setStaticUiString(params: {
   const { stringKey, uiStrings, value } = params;
 
   const valuePath = [LanguageCode.ENGLISH, stringKey].flat();
-  _.set(uiStrings, valuePath, value);
+  _.setWith(uiStrings, valuePath, value, Object);
 }
 
 const extractorFns: Record<


### PR DESCRIPTION
## Overview

@adghayes ran into a bug with ui string extraction where older Vx election fixtures with numeric IDs (precinct ID, party ID, etc) would cause issues when converted to CDF elections and imported into voter-facing apps.

This change explicitly sets numeric IDs in the `UiStringTranslations` object.

Before:
```ts
{
  precinctName: [
    'Precinct A',
    'Precinct B',
  ],
}
```

After:
```ts
{
  precinctName: {
    '0': 'Precinct A',
    '1': 'Precinct B',
  },
}
```

## Testing Plan
- Added a unit test to repro the bug and then verify the fix

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
