### PR TITLE
VxDesign blank ballot adjudication option

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -200,6 +200,13 @@ test('Update layout options', async () => {
 test('Export setup package', async () => {
   const baseElectionDefinition =
     electionFamousNames2021Fixtures.electionDefinition;
+  const mockSystemSettings: SystemSettings = {
+    ...DEFAULT_SYSTEM_SETTINGS,
+    precinctScanAdjudicationReasons: [
+      AdjudicationReason.Overvote,
+      AdjudicationReason.UnmarkedWriteIn,
+    ],
+  };
   const { apiClient } = setupApp();
 
   const electionId = (
@@ -207,6 +214,10 @@ test('Export setup package', async () => {
       electionData: baseElectionDefinition.electionData,
     })
   ).unsafeUnwrap();
+  await apiClient.updateSystemSettings({
+    electionId,
+    systemSettings: mockSystemSettings,
+  });
   const { election: appElection } = await apiClient.getElection({ electionId });
 
   const { zipContents, electionHash } = await apiClient.exportSetupPackage({
@@ -246,7 +257,7 @@ test('Export setup package', async () => {
   const systemSettings = safeParseSystemSettings(
     await zip.file('systemSettings.json')!.async('text')
   ).unsafeUnwrap();
-  expect(systemSettings).toEqual(DEFAULT_SYSTEM_SETTINGS);
+  expect(systemSettings).toEqual(mockSystemSettings);
 });
 
 // Rendering an SVG to PDF and then generating the PDF takes about 3s per

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -6,7 +6,6 @@ import {
   Id,
   safeParseElection,
   BallotPaperSize,
-  DEFAULT_SYSTEM_SETTINGS,
   SystemSettings,
   BallotType,
   BallotPackageFileName,
@@ -225,7 +224,9 @@ function buildApi({ store }: { store: Store }) {
     async exportSetupPackage(input: {
       electionId: Id;
     }): Promise<{ zipContents: Buffer; electionHash: string }> {
-      const { election, layoutOptions } = store.getElection(input.electionId);
+      const { election, layoutOptions, systemSettings } = store.getElection(
+        input.electionId
+      );
       const { electionDefinition } = layOutAllBallotStyles({
         election,
         // Ballot type and ballot mode shouldn't change the election definition, so
@@ -239,7 +240,7 @@ function buildApi({ store }: { store: Store }) {
       zip.file(BallotPackageFileName.ELECTION, electionDefinition.electionData);
       zip.file(
         BallotPackageFileName.SYSTEM_SETTINGS,
-        JSON.stringify(DEFAULT_SYSTEM_SETTINGS, null, 2)
+        JSON.stringify(systemSettings, null, 2)
       );
 
       return {

--- a/apps/design/frontend/src/tabulation_screen.test.tsx
+++ b/apps/design/frontend/src/tabulation_screen.test.tsx
@@ -119,7 +119,7 @@ test('adjudication reasons', async () => {
     const container = screen.getByText(machine).closest('label')!;
     const select = within(container).getByRole('listbox');
     const options = within(select).getAllByRole('option');
-    expect(options).toHaveLength(4);
+    expect(options).toHaveLength(5);
     for (const option of options) {
       expect(
         within(option).getByRole('checkbox', { hidden: true })
@@ -129,6 +129,7 @@ test('adjudication reasons', async () => {
     expect(options[1]).toHaveTextContent('Undervote');
     expect(options[2]).toHaveTextContent('Marginal Mark');
     expect(options[3]).toHaveTextContent('Blank Ballot');
+    expect(options[4]).toHaveTextContent('Unmarked Write-In');
 
     userEvent.click(options[0]);
     expect(

--- a/apps/design/frontend/src/tabulation_screen.tsx
+++ b/apps/design/frontend/src/tabulation_screen.tsx
@@ -45,6 +45,14 @@ export function TabulationForm({
     { label: 'Unmarked Write-In', value: AdjudicationReason.UnmarkedWriteIn },
   ];
 
+  const isScoringUnmarkedWriteIns =
+    tabulationSettings.centralScanAdjudicationReasons.includes(
+      AdjudicationReason.UnmarkedWriteIn
+    ) ||
+    tabulationSettings.precinctScanAdjudicationReasons.includes(
+      AdjudicationReason.UnmarkedWriteIn
+    );
+
   return (
     <Form>
       <Row style={{ gap: '1rem' }}>
@@ -128,6 +136,32 @@ export function TabulationForm({
                 disabled={!isEditing}
               />
             </FormField>
+            {isScoringUnmarkedWriteIns && (
+              <FormField label="Write-In Area Threshold">
+                <Input
+                  type="number"
+                  value={
+                    tabulationSettings.markThresholds?.writeInTextArea ?? ''
+                  }
+                  onChange={(e) =>
+                    setTabulationSettings({
+                      ...tabulationSettings,
+                      markThresholds: {
+                        ...(tabulationSettings.markThresholds || {
+                          definite: 0,
+                          marginal: 0,
+                        }),
+                        writeInTextArea: e.target.valueAsNumber,
+                      },
+                    })
+                  }
+                  step={0.01}
+                  min={0}
+                  max={1}
+                  disabled={!isEditing}
+                />
+              </FormField>
+            )}
           </Column>
         </Card>
       </Row>

--- a/apps/design/frontend/src/tabulation_screen.tsx
+++ b/apps/design/frontend/src/tabulation_screen.tsx
@@ -42,6 +42,7 @@ export function TabulationForm({
     { label: 'Undervote', value: AdjudicationReason.Undervote },
     { label: 'Marginal Mark', value: AdjudicationReason.MarginalMark },
     { label: 'Blank Ballot', value: AdjudicationReason.BlankBallot },
+    { label: 'Unmarked Write-In', value: AdjudicationReason.UnmarkedWriteIn },
   ];
 
   return (


### PR DESCRIPTION
## Overview

Adds option on the Tabulation screen to adjudication unmarked write-ins. Also starts including the set system settings in the setup package - previously it was just exporting the default regardless of what was set in the app.

## Demo Video or Screenshot

<img width="509" alt="Screen Shot 2023-11-09 at 11 16 36 AM" src="https://github.com/votingworks/vxsuite/assets/37960853/da6e662e-b2d4-4cbe-9ab6-b5d1ba093d45">

## Testing Plan

Edited automated tests accordingly + tested manually.

