### PR TITLE
Make sure that catalog values are properly updated

### DIFF
--- a/libs/ui/i18next-parser.config.ts
+++ b/libs/ui/i18next-parser.config.ts
@@ -89,7 +89,7 @@ export default {
   //   description: "${maxLength}", // t('my-key', {maxLength: 150})
   // }
 
-  resetDefaultValueLocale: null,
+  resetDefaultValueLocale: 'en',
   // The locale to compare with default values to determine whether a default value has been changed.
   // If this is set and a default value differs from a translation in the specified locale, all entries
   // for that key across locales are reset to the default value, and existing translations are moved to


### PR DESCRIPTION
## Overview

Noticed a quirk in app string catalog generation. While the new catalog generation logic handles the addition and removal of strings to `app_strings.tsx`, it doesn't handle updates to existing strings.

-----

So imagine we have the following in `app_strings.tsx`:

```ts
buttonDone: () => <UiString uiStringKey="buttonDone">Done</UiString>,
```

The catalog will contain:

```json
"buttonDone": "Done",
```

If we then edit `app_strings.tsx`, e.g.:

```ts
buttonDone: () => <UiString uiStringKey="buttonDone">Done!</UiString>,
```

The catalog should read:

```json
"buttonDone": "Done!",
```

But it'll currently remain unchanged.

-----

This PR addresses this gap with a config tweak. The relevant config field is a bit abstractly named. But you can see how it does what we want by following this issue to its conclusion: https://github.com/i18next/i18next-parser/issues/267 ➡️  https://github.com/i18next/i18next-parser/pull/451.

## Testing Plan

- [x] Tested manually