### PR TITLE
unreadable pages in the NH legacy adapter should show up as unreadable pages, not as scanning errors

### DIFF
--- a/libs/ballot-interpreter/src/__snapshots__/interpret_nh_hmpb.test.ts.snap
+++ b/libs/ballot-interpreter/src/__snapshots__/interpret_nh_hmpb.test.ts.snap
@@ -7459,3 +7459,16 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 79`] = `
   ],
 }
 `;
+
+exports[`blank sheet of paper 1`] = `
+[
+  {
+    "reason": "missingTimingMarks",
+    "type": "UnreadablePage",
+  },
+  {
+    "reason": "missingTimingMarks",
+    "type": "UnreadablePage",
+  },
+]
+`;

--- a/libs/ballot-interpreter/src/interpret.ts
+++ b/libs/ballot-interpreter/src/interpret.ts
@@ -117,17 +117,19 @@ function validateInterpretResults(
 /**
  * Interpret a NH HMPB ballot sheet.
  */
-function interpretAndConvertNhHmpbResult(
+async function interpretAndConvertNhHmpbResult(
   electionDefinition: ElectionDefinition,
   sheet: SheetOf<string>,
   options: InterpreterOptions
-): SheetOf<InterpretFileResult> {
+): Promise<SheetOf<InterpretFileResult>> {
   const result = interpretNhHmpbBallotSheet(electionDefinition, sheet, {
     scoreWriteIns: shouldScoreWriteIns(options),
   });
 
   return validateInterpretResults(
-    convertNhInterpretResultToLegacyResult(options, result).unsafeUnwrap(),
+    (
+      await convertNhInterpretResultToLegacyResult(options, result, sheet)
+    ).unsafeUnwrap(),
     {
       electionHash: electionDefinition.electionHash,
       precinctSelection: options.precinctSelection,
@@ -153,7 +155,7 @@ export async function interpretSheet(
 
   try {
     if (electionDefinition.election.gridLayouts) {
-      return interpretAndConvertNhHmpbResult(electionDefinition, sheet, {
+      return await interpretAndConvertNhHmpbResult(electionDefinition, sheet, {
         electionDefinition,
         precinctSelection,
         testMode,

--- a/libs/ballot-interpreter/src/interpret_nh_hmpb.test.ts
+++ b/libs/ballot-interpreter/src/interpret_nh_hmpb.test.ts
@@ -1,5 +1,8 @@
 import { assert, unique } from '@votingworks/basics';
-import { electionGridLayoutNewHampshireAmherstFixtures } from '@votingworks/fixtures';
+import {
+  electionGridLayoutNewHampshireAmherstFixtures,
+  sampleBallotImages,
+} from '@votingworks/fixtures';
 import {
   SheetOf,
   mapSheet,
@@ -251,4 +254,29 @@ describe('HMPB - m17 backup', () => {
       expect({ [ballotId]: interpretation }).toMatchSnapshot();
     }
   });
+});
+
+test('blank sheet of paper', async () => {
+  const sheet: SheetOf<string> = [
+    sampleBallotImages.blankPage.asFilePath(),
+    sampleBallotImages.blankPage.asFilePath(),
+  ];
+
+  const interpretationWithImages = await interpretSheet(
+    {
+      electionDefinition:
+        electionGridLayoutNewHampshireAmherstFixtures.electionDefinition,
+      precinctSelection: ALL_PRECINCTS_SELECTION,
+      testMode: false,
+      markThresholds: DEFAULT_MARK_THRESHOLDS,
+      adjudicationReasons: [],
+    },
+    sheet
+  );
+
+  const interpretation = mapSheet(
+    interpretationWithImages,
+    (page) => page.interpretation
+  );
+  expect(interpretation).toMatchSnapshot();
 });

--- a/libs/ballot-interpreter/src/legacy_adapter.ts
+++ b/libs/ballot-interpreter/src/legacy_adapter.ts
@@ -21,6 +21,7 @@ import {
   GridPosition,
   HmpbBallotPageMetadata,
   InterpretedHmpbPage,
+  mapSheet,
   MarkInfo,
   MarkStatus,
   Rect,
@@ -415,22 +416,15 @@ export async function convertNhInterpretResultToLegacyResult(
 ): Promise<InterpretResult> {
   /* istanbul ignore next */
   if (nextResult.isErr()) {
-    return ok([
-      {
+    return ok(
+      await mapSheet(sheet, async (page) => ({
         interpretation: {
           type: 'UnreadablePage',
           reason: nextResult.err().type,
         },
-        normalizedImage: await loadImageData(sheet[0]),
-      },
-      {
-        interpretation: {
-          type: 'UnreadablePage',
-          reason: nextResult.err().type,
-        },
-        normalizedImage: await loadImageData(sheet[1]),
-      },
-    ]);
+        normalizedImage: await loadImageData(page),
+      }))
+    );
   }
 
   const ballotCard = nextResult.ok();


### PR DESCRIPTION
In the NH legacy ballot adapter, we were treating uninterpretable ballots as scanning errors, which in central-scanner just interrupt the batch scanning and effectively cause one ballot go unaccounted for.

This PR fixes the error that gets reported in this case.

We should probably also fix the silent swallowed error.

~TODO: needs a test, probably a high-level test, to make sure the right error gets surfaced when scanning, say, a blank sheet of paper.~