### PR TITLE
docs: remove explicit build steps for git

### DIFF
--- a/docs/commit_signing.md
+++ b/docs/commit_signing.md
@@ -26,17 +26,9 @@ Linux VM.
    **TWICE**, once as a signing key and once as an authentication key. If you
    have the 1Password extension for your browser it should offer to fill in the
    details.
-5. [VM] Install Git v2.39.1+:
-   1. Create and `cd` to a temp directory.
-   2. Download Git v2.39.1 source code:
-      `wget https://www.kernel.org/pub/software/scm/git/git-2.39.1.tar.gz`.
-   3. Unpack the source code: `tar -xzf git-2.39.1.tar.gz`.
-   4. `cd` into the unpacked directory: `cd git-2.39.1`.
-   5. Install dependencies:
-      `sudo apt-get install libssl-dev libcurl4-openssl-dev gettext -y`.
-   6. Make and install to your home directory: `make && make install` (see
-      `INSTALL` for more options, or ensure `~/bin` is in your `PATH`).
-   7. Verify the installation: `git --version` (should be `2.39.1`).
+5. [VM] Install Git:
+   1. `sudo apt-get update && sudo apt-get install git -y`
+   2. Verify the installation: `git --version` (should be `2.34` or newer).
 6. [Host] If you want to be able to sign commits in macOS, configure Git commit
    signing from the info screen of the SSH key you just created (the header will
    prompt you).


### PR DESCRIPTION
Debian 12 ships with a new enough git, so we don't need to build it.