### PR TITLE
feat(ballot-interpreter): include more QR code debug metadata

### DIFF
--- a/libs/ballot-interpreter/src/hmpb-rust/debug.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/debug.rs
@@ -16,22 +16,57 @@ use crate::{
         BLUE, CYAN, DARK_BLUE, DARK_CYAN, DARK_GREEN, DARK_RED, GREEN, ORANGE, PINK, RAINBOW, RED,
         WHITE_RGB,
     },
+    qr_code::DetectedQrCode,
     scoring::{ScoredBubbleMark, ScoredPositionAreas},
     timing_marks::{Partial, TimingMarkGrid},
 };
 
 pub fn draw_qr_code_debug_image_mut(
     canvas: &mut RgbImage,
-    qr_code: Option<Rect>,
+    qr_code: Option<&DetectedQrCode>,
     detection_areas: &[Rect],
 ) {
-    for detecction_area in detection_areas {
-        draw_hollow_rect_mut(canvas, (*detecction_area).into(), ORANGE);
+    for detection_area in detection_areas {
+        draw_hollow_rect_mut(canvas, (*detection_area).into(), ORANGE);
     }
 
     match qr_code {
         Some(qr_code) => {
-            draw_hollow_rect_mut(canvas, qr_code.into(), DARK_GREEN);
+            let scale = Scale::uniform(20.0);
+            let font = monospace_font();
+            let fg = WHITE_RGB;
+            let bg = DARK_GREEN;
+            draw_hollow_rect_mut(canvas, qr_code.bounds().into(), DARK_GREEN);
+            draw_text_with_background_mut(
+                canvas,
+                &format!("QR code: {:x?}", qr_code.bytes()),
+                0,
+                0,
+                scale,
+                &font,
+                fg,
+                bg,
+            );
+            draw_text_with_background_mut(
+                canvas,
+                &format!("Detector: {:?}", qr_code.detector()),
+                0,
+                20,
+                scale,
+                &font,
+                fg,
+                bg
+            );
+            draw_text_with_background_mut(
+                canvas,
+                &format!("Orientation: {:?}", qr_code.orientation()),
+                0,
+                40,
+                scale,
+                &font,
+                fg,
+                bg
+            );
         }
         None => {
             draw_text_mut(

--- a/libs/ballot-interpreter/src/hmpb-rust/debug.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/debug.rs
@@ -20,7 +20,15 @@ use crate::{
     timing_marks::{Partial, TimingMarkGrid},
 };
 
-pub fn draw_qr_code_debug_image_mut(canvas: &mut RgbImage, qr_code: Option<Rect>) {
+pub fn draw_qr_code_debug_image_mut(
+    canvas: &mut RgbImage,
+    qr_code: Option<Rect>,
+    detection_areas: &[Rect],
+) {
+    for detecction_area in detection_areas {
+        draw_hollow_rect_mut(canvas, (*detecction_area).into(), ORANGE);
+    }
+
     match qr_code {
         Some(qr_code) => {
             draw_hollow_rect_mut(canvas, qr_code.into(), DARK_GREEN);

--- a/libs/ballot-interpreter/src/hmpb-rust/qr_code/detect.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/qr_code/detect.rs
@@ -43,6 +43,15 @@ impl DetectionArea {
         self.origin
     }
 
+    pub fn bounds(&self) -> Rect {
+        Rect::new(
+            self.origin.x as i32,
+            self.origin.y as i32,
+            self.image.width(),
+            self.image.height(),
+        )
+    }
+
     pub const fn orientation(&self) -> Orientation {
         self.orientation
     }
@@ -77,14 +86,21 @@ pub fn get_detection_areas(img: &GrayImage) -> Vec<DetectionArea> {
 /// Information about a QR code found in an image.
 #[derive(Debug, Clone)]
 pub struct DetectedQrCode {
+    detection_areas: Vec<Rect>,
     bytes: Vec<u8>,
     bounds: Rect,
     orientation: Orientation,
 }
 
 impl DetectedQrCode {
-    pub const fn new(bytes: Vec<u8>, bounds: Rect, orientation: Orientation) -> Self {
+    pub const fn new(
+        detection_areas: Vec<Rect>,
+        bytes: Vec<u8>,
+        bounds: Rect,
+        orientation: Orientation,
+    ) -> Self {
         Self {
+            detection_areas,
             bytes,
             bounds,
             orientation,
@@ -105,16 +121,41 @@ impl DetectedQrCode {
     pub const fn orientation(&self) -> Orientation {
         self.orientation
     }
+
+    /// The areas of the image that were searched for QR codes.
+    pub fn detection_areas(&self) -> &[Rect] {
+        &self.detection_areas
+    }
 }
 
 #[derive(Debug, Clone, Serialize, thiserror::Error)]
 pub enum Error {
-    #[error("failed to decode QR code: {0}")]
-    DecodeFailed(String),
-    #[error("failed to detect QR code: {0}")]
-    DetectFailed(String),
+    #[error("failed to decode QR code: {message}")]
+    DecodeFailed {
+        detection_areas: Vec<Rect>,
+        message: String,
+    },
+    #[error("failed to detect QR code: {message}")]
+    DetectFailed {
+        detection_areas: Vec<Rect>,
+        message: String,
+    },
     #[error("no QR code detected")]
-    NoQrCodeDetected,
+    NoQrCodeDetected { detection_areas: Vec<Rect> },
+}
+
+impl Error {
+    fn detection_areas(&self) -> &[Rect] {
+        match self {
+            Self::DecodeFailed {
+                detection_areas, ..
+            } => detection_areas,
+            Self::DetectFailed {
+                detection_areas, ..
+            } => detection_areas,
+            Self::NoQrCodeDetected { detection_areas } => detection_areas,
+        }
+    }
 }
 
 pub type Result = std::result::Result<DetectedQrCode, Error>;
@@ -128,11 +169,16 @@ pub type Result = std::result::Result<DetectedQrCode, Error>;
 pub fn detect(img: &GrayImage, debug: &ImageDebugWriter) -> Result {
     let rqrr_result = rqrr::detect(img);
     let detect_result = rqrr_result.or_else(|_| zbar::detect(img));
+    let detection_areas = match detect_result {
+        Ok(ref qr_code) => qr_code.detection_areas().to_vec(),
+        Err(ref e) => e.detection_areas().to_vec(),
+    };
 
     debug.write("qr_code", |canvas| {
         debug::draw_qr_code_debug_image_mut(
             canvas,
             detect_result.as_ref().ok().map(DetectedQrCode::bounds),
+            &detection_areas,
         );
     });
 
@@ -141,7 +187,12 @@ pub fn detect(img: &GrayImage, debug: &ImageDebugWriter) -> Result {
         let bytes = STANDARD
             .decode(qr_code.bytes())
             .unwrap_or_else(|_| qr_code.bytes().clone());
-        DetectedQrCode::new(bytes, qr_code.bounds(), qr_code.orientation())
+        DetectedQrCode::new(
+            qr_code.detection_areas().to_vec(),
+            bytes,
+            qr_code.bounds(),
+            qr_code.orientation(),
+        )
     })
 }
 

--- a/libs/ballot-interpreter/src/hmpb-rust/qr_code/mod.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/qr_code/mod.rs
@@ -2,4 +2,4 @@ mod detect;
 mod rqrr;
 mod zbar;
 
-pub use detect::{detect, Error, Result};
+pub use detect::{detect, DetectedQrCode, Error, Result};

--- a/libs/ballot-interpreter/src/hmpb-rust/qr_code/rqrr.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/qr_code/rqrr.rs
@@ -3,7 +3,7 @@ use rqrr::PreparedImage;
 
 use crate::geometry::{PixelUnit, Point, Rect};
 
-use super::detect::{get_detection_areas, DetectedQrCode, Error, Result};
+use super::detect::{get_detection_areas, DetectedQrCode, Detector, Error, Result};
 
 /// Uses the `rqrr` QR code library to detect a QR code in the given ballot
 /// image. Crops the image to improve performance.
@@ -16,6 +16,7 @@ pub fn detect(img: &GrayImage) -> Result {
             let mut bytes = Vec::new();
             return match grid.decode_to(&mut bytes) {
                 Ok(_) => Ok(DetectedQrCode::new(
+                    Detector::Rqrr,
                     detection_area_rects,
                     bytes,
                     get_original_bounds_rqrr(area.origin(), grid),

--- a/libs/ballot-interpreter/src/hmpb-rust/qr_code/rqrr.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/qr_code/rqrr.rs
@@ -8,21 +8,30 @@ use super::detect::{get_detection_areas, DetectedQrCode, Error, Result};
 /// Uses the `rqrr` QR code library to detect a QR code in the given ballot
 /// image. Crops the image to improve performance.
 pub fn detect(img: &GrayImage) -> Result {
-    for area in get_detection_areas(img) {
+    let detection_areas = get_detection_areas(img);
+    let detection_area_rects = detection_areas.iter().map(|a| a.bounds()).collect();
+    for area in detection_areas.iter() {
         let mut prepared_img = PreparedImage::prepare(area.image().clone());
         if let Some(grid) = prepared_img.detect_grids().first() {
             let mut bytes = Vec::new();
-            grid.decode_to(&mut bytes)
-                .map_err(|e| Error::DecodeFailed(e.to_string()))?;
-            return Ok(DetectedQrCode::new(
-                bytes,
-                get_original_bounds_rqrr(area.origin(), grid),
-                area.orientation(),
-            ));
+            return match grid.decode_to(&mut bytes) {
+                Ok(_) => Ok(DetectedQrCode::new(
+                    detection_area_rects,
+                    bytes,
+                    get_original_bounds_rqrr(area.origin(), grid),
+                    area.orientation(),
+                )),
+                Err(e) => Err(Error::DecodeFailed {
+                    detection_areas: detection_area_rects,
+                    message: e.to_string(),
+                }),
+            };
         }
     }
 
-    Err(Error::NoQrCodeDetected)
+    Err(Error::NoQrCodeDetected {
+        detection_areas: detection_area_rects,
+    })
 }
 
 const fn get_original_bounds_rqrr<G>(origin: Point<PixelUnit>, qr_code: &rqrr::Grid<G>) -> Rect {

--- a/libs/ballot-interpreter/src/hmpb-rust/qr_code/zbar.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/qr_code/zbar.rs
@@ -3,7 +3,7 @@ use zbar_rust::{ZBarImageScanResult, ZBarImageScanner, ZBarSymbolType};
 
 use crate::geometry::{PixelUnit, Point, Rect};
 
-use super::detect::{get_detection_areas, DetectedQrCode, DetectionArea, Error, Result};
+use super::detect::{get_detection_areas, DetectedQrCode, DetectionArea, Detector, Error, Result};
 
 /// Uses the `zbar` QR code library to detect a QR code in the given ballot
 /// image. Crops the image to improve performance.
@@ -17,6 +17,7 @@ pub fn detect(img: &GrayImage) -> Result {
                     if qr_code.symbol_type == ZBarSymbolType::ZBarQRCode {
                         let bounds = get_original_bounds(area.origin(), &qr_code);
                         return Ok(DetectedQrCode::new(
+                            Detector::Zbar,
                             detection_area_rects,
                             qr_code.data,
                             bounds,


### PR DESCRIPTION
## Overview
We previously only showed `No QR code found` when a QR code could not be detected. This wasn't very useful because it didn't really clarify why it wasn't detected. Now we include the search bounds in both `Ok` and `Err` variant QR code debug images to make it clearer.

## Demo Video or Screenshot
| Successful | Failed |
|-|-|
|![image](https://github.com/votingworks/vxsuite/assets/1938/5500fee4-02f5-42d5-b985-daead9b97344)|![20231100_182029-ballot-0001_debug_qr_code](https://github.com/votingworks/vxsuite/assets/1938/f936d12d-86b5-4c4b-9554-bd882c4ac2b4)|

## Testing Plan
Tested manually