### PR TITLE
[i18n/Audio] Enable for pre-generated election date strings and audio

### DIFF
--- a/libs/mark-flow-ui/src/components/election_info.tsx
+++ b/libs/mark-flow-ui/src/components/election_info.tsx
@@ -6,7 +6,6 @@ import {
   ElectionDefinition,
   PrecinctSelection,
 } from '@votingworks/types';
-import { format, getPrecinctSelectionName } from '@votingworks/utils';
 
 import {
   NoWrap,
@@ -19,7 +18,6 @@ import {
   PrecinctSelectionName,
   PrimaryElectionTitlePrefix,
   NumberString,
-  DateString,
 } from '@votingworks/ui';
 
 const Container = styled.div`
@@ -46,11 +44,7 @@ export function ElectionInfo({
   contestCount,
 }: Props): JSX.Element {
   const { election } = electionDefinition;
-  const { state, county, date, seal } = election;
-
-  const precinctName =
-    precinctSelection &&
-    getPrecinctSelectionName(election.precincts, precinctSelection);
+  const { county, seal } = election;
 
   const partyPrimaryAdjective = (
     <React.Fragment>
@@ -70,17 +64,13 @@ export function ElectionInfo({
     </React.Fragment>
   );
 
-  const electionDate = format.localeLongDate(new Date(date));
-
   return (
     <Container>
       <Seal seal={seal} />
       <div>
         <H1>{title}</H1>
-        <P
-          aria-label={`${electionDate}. ${county.name}, ${state}. ${precinctName}.`}
-        >
-          <DateString value={new Date(date)} weight="bold" />
+        <P>
+          {electionStrings.electionDate(election)}
           <br />
           <Caption>
             {/* TODO(kofi): Use more language-agnostic delimiter (e.g. '|') or find way to translate commas. */}

--- a/libs/types/src/ballot_package.ts
+++ b/libs/types/src/ballot_package.ts
@@ -17,6 +17,7 @@ export enum BallotPackageFileName {
   METADATA = 'metadata.json',
   SYSTEM_SETTINGS = 'systemSettings.json',
   UI_STRING_AUDIO_IDS = 'uiStringAudioIds.json',
+  VX_ELECTION_STRINGS = 'vxElectionStrings.json',
 }
 
 export interface BallotPackage {

--- a/libs/types/src/cdf/ballot-definition/convert.ts
+++ b/libs/types/src/cdf/ballot-definition/convert.ts
@@ -17,6 +17,7 @@ import * as Vxf from '../../election';
 import { ballotPaperDimensions, getContests } from '../../election_utils';
 import { Id, safeParse } from '../../generic';
 import { safeParseInt } from '../../numeric';
+import { LanguageCode } from '../../language_code';
 
 function dateString(date: Date) {
   const isoString = date.toISOString();
@@ -38,7 +39,7 @@ export function convertVxfElectionToCdfBallotDefinition(
       Text: [
         {
           '@type': 'BallotDefinition.LanguageString',
-          Language: 'en',
+          Language: LanguageCode.ENGLISH,
           Content: content,
         },
       ],
@@ -511,7 +512,10 @@ export function convertCdfBallotDefinitionToVxfElection(
   }
 
   function englishText(text: Cdf.InternationalizedText): string {
-    const content = find(text.Text, (t) => t.Language === 'en').Content;
+    const content = find(
+      text.Text,
+      (t) => t.Language === LanguageCode.ENGLISH
+    ).Content;
     assert(content !== undefined, 'Could not find English text');
     return content;
   }

--- a/libs/types/src/ui_string_translations.ts
+++ b/libs/types/src/ui_string_translations.ts
@@ -14,6 +14,7 @@ export enum ElectionStringKey {
   CONTEST_TITLE = 'contestTitle',
   COUNTY_NAME = 'countyName',
   DISTRICT_NAME = 'districtName',
+  ELECTION_DATE = 'electionDate',
   ELECTION_TITLE = 'electionTitle',
   PARTY_FULL_NAME = 'partyFullName',
   PARTY_NAME = 'partyName',

--- a/libs/ui/src/ui_strings/election_strings.tsx
+++ b/libs/ui/src/ui_strings/election_strings.tsx
@@ -15,6 +15,7 @@ import {
 
 import { UiString } from './ui_string';
 import { Pre } from '../typography';
+import { DateString } from './date_string';
 
 type ContestWithDescription = ContestLike & {
   description: string;
@@ -70,6 +71,12 @@ export const electionStrings = {
   [Key.DISTRICT_NAME]: (district: District) => (
     <UiString uiStringKey={Key.DISTRICT_NAME} uiStringSubKey={district.id}>
       {district.name}
+    </UiString>
+  ),
+
+  [Key.ELECTION_DATE]: (election: Election) => (
+    <UiString uiStringKey={Key.ELECTION_DATE}>
+      <DateString value={new Date(election.date)} />
     </UiString>
   ),
 

--- a/libs/utils/src/ballot_package.test.ts
+++ b/libs/utils/src/ballot_package.test.ts
@@ -5,6 +5,7 @@ import {
   BallotPackage,
   BallotPackageFileName,
   DEFAULT_SYSTEM_SETTINGS,
+  ElectionStringKey,
   LanguageCode,
   SystemSettings,
   UiStringAudioIdsPackage,
@@ -85,6 +86,47 @@ test('readBallotPackageFromFile loads available ui strings', async () => {
     },
     [LanguageCode.CHINESE]: {
       ...assertDefined(appStrings[LanguageCode.CHINESE]),
+    },
+  };
+
+  expect(
+    await readBallotPackageFromFile(
+      new File([pkg], 'election-ballot-package.zip')
+    )
+  ).toEqual<BallotPackage>({
+    electionDefinition:
+      safeParseElectionDefinition(testCdfElectionData).unsafeUnwrap(),
+    systemSettings: DEFAULT_SYSTEM_SETTINGS,
+    uiStrings: expectedUiStrings,
+  });
+});
+
+test('readBallotPackageFromFile loads vx election strings', async () => {
+  const vxElectionStrings: UiStringsPackage = {
+    [LanguageCode.ENGLISH]: {
+      [ElectionStringKey.ELECTION_DATE]: 'The Day The Earth Stood Still',
+      [ElectionStringKey.ELECTION_TITLE]: 'Should be overridden by CDF string',
+    },
+    [LanguageCode.SPANISH]: {
+      [ElectionStringKey.ELECTION_DATE]: 'El día que la Tierra se detuvo',
+    },
+  };
+
+  const testCdfElectionData = JSON.stringify(testCdfBallotDefinition);
+  const pkg = await zipFile({
+    [BallotPackageFileName.ELECTION]: testCdfElectionData,
+    [BallotPackageFileName.VX_ELECTION_STRINGS]:
+      JSON.stringify(vxElectionStrings),
+  });
+
+  const expectedCdfStrings = extractCdfUiStrings(testCdfBallotDefinition);
+  const expectedUiStrings: UiStringsPackage = {
+    [LanguageCode.ENGLISH]: {
+      [ElectionStringKey.ELECTION_DATE]: 'The Day The Earth Stood Still',
+      ...assertDefined(expectedCdfStrings[LanguageCode.ENGLISH]),
+    },
+    [LanguageCode.SPANISH]: {
+      [ElectionStringKey.ELECTION_DATE]: 'El día que la Tierra se detuvo',
     },
   };
 

--- a/libs/utils/src/ballot_package.ts
+++ b/libs/utils/src/ballot_package.ts
@@ -69,6 +69,21 @@ export async function readBallotPackageFromBuffer(
 
     _.merge(uiStrings, appStrings);
   }
+
+  // Extract non-CDF election strings:
+  const vxElectionStringsEntry = maybeGetFileByName(
+    entries,
+    BallotPackageFileName.VX_ELECTION_STRINGS
+  );
+  if (vxElectionStringsEntry) {
+    const vxElectionStrings = safeParseJson(
+      await readTextEntry(vxElectionStringsEntry),
+      UiStringsPackageSchema
+    ).unsafeUnwrap();
+
+    _.merge(uiStrings, vxElectionStrings);
+  }
+
   if (cdfElection) {
     const electionStrings = extractCdfUiStrings(cdfElection);
     _.merge(uiStrings, electionStrings);

--- a/libs/utils/src/extract_cdf_ui_strings.test.ts
+++ b/libs/utils/src/extract_cdf_ui_strings.test.ts
@@ -394,6 +394,14 @@ const tests: Record<ElectionStringKey, () => void> = {
     });
   },
 
+  [ElectionStringKey.ELECTION_DATE]() {
+    const uiStrings = extractCdfUiStrings(testCdfBallotDefinition);
+
+    expect(
+      uiStrings[LanguageCode.ENGLISH]?.[ElectionStringKey.ELECTION_DATE]
+    ).toBeUndefined();
+  },
+
   [ElectionStringKey.ELECTION_TITLE]() {
     const uiStrings = extractCdfUiStrings({
       ...testCdfBallotDefinition,

--- a/libs/utils/src/extract_cdf_ui_strings.ts
+++ b/libs/utils/src/extract_cdf_ui_strings.ts
@@ -163,6 +163,14 @@ const extractorFns: Record<
     }
   },
 
+  [ElectionStringKey.ELECTION_DATE](_cdfElection, uiStrings) {
+    // No-Op: This election string is not available via CDF.
+    // It is currently extracted directly from the
+    // `@votingworks/types/BallotPackageFileName.VX_ELECTION_STRINGS` file.
+
+    return uiStrings;
+  },
+
   [ElectionStringKey.ELECTION_TITLE](cdfElection, uiStrings) {
     setInternationalizedUiStrings({
       stringKey: ElectionStringKey.ELECTION_TITLE,


### PR DESCRIPTION
## Overview

Noticed that the only date we need to translate and/or generate audio for, so far, is the election date -- to avoid having to piece together audio fragments to read out dates, this PR adds support for pre-generating language-specific date strings and audio for the election date.

The CDF doesn't currently provide support for `InternationalizedText` strings for the election date, so the approach here is to add a new `vxElectionStrings.json` file to the ballot package, which will contain non-CDF election-specific translations. 

Also adding an `ElectionStringKey.ELECTION_DATE` key and corresponding string extractor and renderer.

## Testing Plan
- New test cases for new ballot package file and string extraction logic
- Updated affected tests

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
