### PR TITLE
Fix screen reader support for aria-labelled-by attribute

### DIFF
--- a/apps/mark-scan/frontend/src/utils/ScreenReader/aria_screen_reader.test.ts
+++ b/apps/mark-scan/frontend/src/utils/ScreenReader/aria_screen_reader.test.ts
@@ -121,13 +121,13 @@ it('speaks aria-label instead of text content if present', async () => {
   );
 });
 
-it('speaks a description of an aria-labeledby element if present', async () => {
+it('speaks a description of an aria-labelledby element if present', async () => {
   const tts = fakeTts();
   const asr = new AriaScreenReader(tts);
   const field = h(
     'span',
     h('label', { id: 'name-label' }, text('Name')),
-    h('input', { type: 'text', 'aria-labeledby': 'name-label' })
+    h('input', { type: 'text', 'aria-labelledby': 'name-label' })
   );
 
   document.body.append(field);
@@ -140,13 +140,13 @@ it('speaks a description of an aria-labeledby element if present', async () => {
   }
 });
 
-it('ignores an aria-labeledby attribute if the element exists but has no description', async () => {
+it('ignores an aria-labelledby attribute if the element exists but has no description', async () => {
   const tts = fakeTts();
   const asr = new AriaScreenReader(tts);
   const field = h(
     'span',
     h('label', { id: 'name-label' }, text('')),
-    h('input', { type: 'text', 'aria-labeledby': 'name-label' })
+    h('input', { type: 'text', 'aria-labelledby': 'name-label' })
   );
 
   document.body.append(field);
@@ -159,14 +159,14 @@ it('ignores an aria-labeledby attribute if the element exists but has no descrip
   }
 });
 
-it('ignores an aria-labeledby attribute if no such element exists', async () => {
+it('ignores an aria-labelledby attribute if no such element exists', async () => {
   const tts = fakeTts();
   const asr = new AriaScreenReader(tts);
 
   await asr.speakNode(
     h(
       'span',
-      { 'aria-labeledby': 'name-label' },
+      { 'aria-labelledby': 'name-label' },
       text('Read this since name-label does not exist')
     )
   );

--- a/apps/mark-scan/frontend/src/utils/ScreenReader/aria_screen_reader.ts
+++ b/apps/mark-scan/frontend/src/utils/ScreenReader/aria_screen_reader.ts
@@ -184,10 +184,10 @@ export class AriaScreenReader implements ScreenReader {
       return ariaLabel + terminator;
     }
 
-    const ariaLabeledBy = node.getAttribute('aria-labeledby');
+    const ariaLabelledBy = node.getAttribute('aria-labelledby');
 
-    if (ariaLabeledBy) {
-      const element = document.getElementById(ariaLabeledBy);
+    if (ariaLabelledBy) {
+      const element = document.getElementById(ariaLabelledBy);
 
       if (element) {
         const description = this.describeNode(element);

--- a/apps/mark/frontend/src/utils/ScreenReader/aria_screen_reader.test.ts
+++ b/apps/mark/frontend/src/utils/ScreenReader/aria_screen_reader.test.ts
@@ -121,13 +121,13 @@ it('speaks aria-label instead of text content if present', async () => {
   );
 });
 
-it('speaks a description of an aria-labeledby element if present', async () => {
+it('speaks a description of an aria-labelledby element if present', async () => {
   const tts = fakeTts();
   const asr = new AriaScreenReader(tts);
   const field = h(
     'span',
     h('label', { id: 'name-label' }, text('Name')),
-    h('input', { type: 'text', 'aria-labeledby': 'name-label' })
+    h('input', { type: 'text', 'aria-labelledby': 'name-label' })
   );
 
   document.body.append(field);
@@ -140,13 +140,13 @@ it('speaks a description of an aria-labeledby element if present', async () => {
   }
 });
 
-it('ignores an aria-labeledby attribute if the element exists but has no description', async () => {
+it('ignores an aria-labelledby attribute if the element exists but has no description', async () => {
   const tts = fakeTts();
   const asr = new AriaScreenReader(tts);
   const field = h(
     'span',
     h('label', { id: 'name-label' }, text('')),
-    h('input', { type: 'text', 'aria-labeledby': 'name-label' })
+    h('input', { type: 'text', 'aria-labelledby': 'name-label' })
   );
 
   document.body.append(field);
@@ -159,14 +159,14 @@ it('ignores an aria-labeledby attribute if the element exists but has no descrip
   }
 });
 
-it('ignores an aria-labeledby attribute if no such element exists', async () => {
+it('ignores an aria-labelledby attribute if no such element exists', async () => {
   const tts = fakeTts();
   const asr = new AriaScreenReader(tts);
 
   await asr.speakNode(
     h(
       'span',
-      { 'aria-labeledby': 'name-label' },
+      { 'aria-labelledby': 'name-label' },
       text('Read this since name-label does not exist')
     )
   );

--- a/apps/mark/frontend/src/utils/ScreenReader/aria_screen_reader.ts
+++ b/apps/mark/frontend/src/utils/ScreenReader/aria_screen_reader.ts
@@ -184,10 +184,10 @@ export class AriaScreenReader implements ScreenReader {
       return ariaLabel + terminator;
     }
 
-    const ariaLabeledBy = node.getAttribute('aria-labeledby');
+    const ariaLabelledBy = node.getAttribute('aria-labelledby');
 
-    if (ariaLabeledBy) {
-      const element = document.getElementById(ariaLabeledBy);
+    if (ariaLabelledBy) {
+      const element = document.getElementById(ariaLabelledBy);
 
       if (element) {
         const description = this.describeNode(element);


### PR DESCRIPTION

## Overview

It was misspelled.

## Demo Video or Screenshot

## Testing Plan
Manually tested and updated broken unit test.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
