### PR TITLE
Integrate built-in PAT input

### DIFF
--- a/apps/mark-scan/backend/README.md
+++ b/apps/mark-scan/backend/README.md
@@ -9,6 +9,13 @@ Follow the instructions in the [VxSuite README](../../../README.md)
 You generally should not need to run the backend directly. Instead, run the
 frontend, which will automatically run the backend.
 
+```sh
+cd apps/mark-scan/frontend
+pnpm start
+```
+
+## PAT Inputs
+
 For the backend to recognize the USB PAT switch you may need to extend your udev
 rules. Create or edit `/etc/udev/rules.d/50-usb-hid.rules` with:
 
@@ -24,10 +31,10 @@ then run
 sudo udevadm control --reload-rules && sudo udevadm trigger
 ```
 
-```sh
-cd apps/mark/frontend
-pnpm start
-```
+To work on production hardware with the built-in 3.5mm PAT input, you'll need to
+run `./backend/build/patinputd` in the background or a separate terminal. There
+are no build steps for this tool besides
+`cd apps/mark-scan/backend && pnpm build`.
 
 ## Testing
 

--- a/apps/mark-scan/backend/build-patinputd.sh
+++ b/apps/mark-scan/backend/build-patinputd.sh
@@ -1,0 +1,1 @@
+gcc src/pat-input/vsapgpio.c src/pat-input/patinputd.c -o build/patinputd

--- a/apps/mark-scan/backend/package.json
+++ b/apps/mark-scan/backend/package.json
@@ -8,7 +8,7 @@
     "build"
   ],
   "scripts": {
-    "build": "tsc --build tsconfig.build.json && copyfiles -u 3 src/custom-paper-handler/fixtures/*.jpg build/custom-paper-handler/fixtures",
+    "build": "tsc --build tsconfig.build.json && copyfiles -u 3 src/custom-paper-handler/fixtures/*.jpg build/custom-paper-handler/fixtures && ./build-patinputd.sh",
     "clean": "rm -rf build tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
     "lint": "pnpm type-check && eslint .",

--- a/apps/mark-scan/backend/src/custom-paper-handler/cli/state_machine_cli.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/cli/state_machine_cli.ts
@@ -17,6 +17,7 @@ import {
   getPaperHandlerStateMachine,
 } from '../state_machine';
 import { getDefaultAuth } from '../../util/auth';
+import { MockPatConnectionStatusReader } from '../../pat-input/mock_connection_status_reader';
 
 // We could add a LogSource for this CLI tool but that's unnecessary because
 // these logs will never reach production
@@ -82,11 +83,14 @@ export async function main(): Promise<number> {
     'Could not get paper handler driver. Is a paper handler device connected?'
   );
 
+  const patConnectionStatusReader = new MockPatConnectionStatusReader(logger);
+
   const stateMachine = await getPaperHandlerStateMachine({
     workspace,
     auth,
     logger,
     driver,
+    patConnectionStatusReader,
     devicePollingIntervalMs: DEV_DEVICE_STATUS_POLLING_INTERVAL_MS,
     authPollingIntervalMs: AUTH_STATUS_POLLING_INTERVAL_MS,
   });

--- a/apps/mark-scan/backend/src/custom-paper-handler/constants.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/constants.ts
@@ -16,6 +16,3 @@ export const DELAY_BEFORE_DECLARING_REAR_JAM_MS = 7_000;
 
 export const SCAN_DPI = 72;
 export const PRINT_DPI = 200;
-
-export const ORIGIN_VENDOR_ID = 0x0a95;
-export const ORIGIN_SWIFTY_PRODUCT_ID = 0x0012;

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -13,6 +13,8 @@ import {
   getPaperHandlerStateMachine,
 } from './state_machine';
 import { Workspace, createWorkspace } from '../util/workspace';
+import { PatConnectionStatusReaderInterface } from '../pat-input/connection_status_reader';
+import { MockPatConnectionStatusReader } from '../pat-input/mock_connection_status_reader';
 
 // Use shorter polling interval in tests to reduce run times
 const TEST_POLLING_INTERVAL_MS = 10;
@@ -23,6 +25,7 @@ let driver: PaperHandlerDriver;
 let workspace: Workspace;
 let machine: PaperHandlerStateMachine;
 let logger: Logger;
+let patConnectionStatusReader: PatConnectionStatusReaderInterface;
 
 beforeEach(async () => {
   logger = fakeLogger();
@@ -37,6 +40,7 @@ beforeEach(async () => {
     selectConfiguration: jest.fn(),
   };
   driver = new PaperHandlerDriver(webDevice);
+  patConnectionStatusReader = new MockPatConnectionStatusReader(logger);
   jest
     .spyOn(driver, 'syncScannerConfig')
     .mockImplementation(() => Promise.resolve(false));
@@ -49,6 +53,7 @@ beforeEach(async () => {
     auth,
     logger,
     driver,
+    patConnectionStatusReader,
     devicePollingIntervalMs: TEST_POLLING_INTERVAL_MS,
     authPollingIntervalMs: TEST_POLLING_INTERVAL_MS,
   })) as PaperHandlerStateMachine;

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -96,8 +96,8 @@ type PaperHandlerStatusEvent =
   | { type: 'AUTH_STATUS_CARDLESS_VOTER' }
   | { type: 'AUTH_STATUS_POLL_WORKER' }
   | { type: 'AUTH_STATUS_UNHANDLED' }
-  | { type: 'PAT_DEVICE_CONNECTED'; isPatDeviceConnected: boolean }
-  | { type: 'PAT_DEVICE_DISCONNECTED'; isPatDeviceConnected: boolean }
+  | { type: 'PAT_DEVICE_CONNECTED' }
+  | { type: 'PAT_DEVICE_DISCONNECTED' }
   | { type: 'VOTER_CONFIRMED_PAT_DEVICE_CALIBRATION' }
   | { type: 'PAT_DEVICE_NO_STATUS_CHANGE' }
   | { type: 'PAT_DEVICE_STATUS_UNHANDLED' };

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -38,8 +38,6 @@ import {
   DELAY_BEFORE_DECLARING_REAR_JAM_MS,
   DEVICE_STATUS_POLLING_INTERVAL_MS,
   DEVICE_STATUS_POLLING_TIMEOUT_MS,
-  ORIGIN_SWIFTY_PRODUCT_ID,
-  ORIGIN_VENDOR_ID,
   RESET_AFTER_JAM_DELAY_MS,
 } from './constants';
 import {
@@ -55,16 +53,22 @@ import {
   resetAndReconnect,
   loadAndParkPaper,
 } from './application_driver';
+import { PatConnectionStatusReader } from '../pat-input/connection_status_reader';
+import {
+  ORIGIN_SWIFTY_PRODUCT_ID,
+  ORIGIN_VENDOR_ID,
+} from '../pat-input/constants';
 
 interface Context {
   auth: InsertedSmartCardAuthApi;
   workspace: Workspace;
   driver: PaperHandlerDriver;
+  patConnectionStatusReader: PatConnectionStatusReader;
   devicePollingIntervalMs: number;
   authPollingIntervalMs: number;
   scannedImagePaths?: SheetOf<string>;
   interpretation?: SheetOf<InterpretFileResult>;
-  patDevice?: HID.HID;
+  isPatDeviceConnected: boolean;
 }
 
 function assign(arg: Assigner<Context, any> | PropertyAssigner<Context, any>) {
@@ -92,11 +96,11 @@ type PaperHandlerStatusEvent =
   | { type: 'AUTH_STATUS_CARDLESS_VOTER' }
   | { type: 'AUTH_STATUS_POLL_WORKER' }
   | { type: 'AUTH_STATUS_UNHANDLED' }
-  | { type: 'PAT_DEVICE_CONNECTED'; patDevice: HID.HID }
-  | { type: 'PAT_DEVICE_DISCONNECTED' }
+  | { type: 'PAT_DEVICE_CONNECTED'; isPatDeviceConnected: boolean }
+  | { type: 'PAT_DEVICE_DISCONNECTED'; isPatDeviceConnected: boolean }
   | { type: 'VOTER_CONFIRMED_PAT_DEVICE_CALIBRATION' }
   | { type: 'PAT_DEVICE_NO_STATUS_CHANGE' }
-  | { type: 'PAT_DEVICE_STATUS_UNHANDLED'; patDevice?: HID.HID };
+  | { type: 'PAT_DEVICE_STATUS_UNHANDLED' };
 
 const debug = makeDebug('mark-scan:state-machine');
 const debugEvents = debug.extend('events');
@@ -242,7 +246,7 @@ function pollAuthStatus(): InvokeConfig<Context, PaperHandlerStatusEvent> {
 
 // Finds the Origin Swifty PAT input converter or returns an empty Promise.
 // This is a Promise because Observable's switchMap gives a type error if it's not.
-function findPatDevice(): Promise<HID.HID | void> {
+function findUsbPatDevice(): Promise<HID.HID | void> {
   // `new HID.HID(vendorId, productId)` throws if device is not found.
   // Listing devices first avoids hard failure.
   const devices = HID.devices();
@@ -262,22 +266,30 @@ function findPatDevice(): Promise<HID.HID | void> {
 function buildPatDeviceConnectionStatusObservable() {
   return ({
     devicePollingIntervalMs,
-    patDevice: existingPatDevice,
+    isPatDeviceConnected: oldConnectionStatus,
+    patConnectionStatusReader,
   }: Context) => {
     return timer(0, devicePollingIntervalMs).pipe(
       switchMap(async () => {
         try {
-          const currentPatDevice = await findPatDevice();
+          // Checks for a PAT device connected to the built-in PAT jack first. If no device found,
+          // checks for a device connected through the Origin Swifty USB switch. We support the Swifty
+          // for development only and should be open to deprecating support if the cost of maintaining
+          // Swifty support is too high.
+          let newConnectionStatus =
+            await patConnectionStatusReader.isPatDeviceConnected();
 
-          if (existingPatDevice && !currentPatDevice) {
+          if (!newConnectionStatus) {
+            const currentPatDevice = await findUsbPatDevice();
+            newConnectionStatus = !!currentPatDevice;
+          }
+
+          if (oldConnectionStatus && !newConnectionStatus) {
             return { type: 'PAT_DEVICE_DISCONNECTED' };
           }
 
-          if (!existingPatDevice && currentPatDevice) {
-            return {
-              type: 'PAT_DEVICE_CONNECTED',
-              patDevice: currentPatDevice,
-            };
+          if (!oldConnectionStatus && newConnectionStatus) {
+            return { type: 'PAT_DEVICE_CONNECTED' };
           }
 
           return { type: 'PAT_DEVICE_NO_STATUS_CHANGE' };
@@ -368,13 +380,13 @@ export function buildMachine(
       JAMMED_STATUS_NO_PAPER: 'voting_flow.jam_physically_cleared',
       PAT_DEVICE_CONNECTED: {
         actions: assign({
-          patDevice: (_, event) => event.patDevice,
+          isPatDeviceConnected: true,
         }),
         target: 'pat_device_connected',
       },
       PAT_DEVICE_DISCONNECTED: {
         actions: assign({
-          patDevice: () => undefined,
+          isPatDeviceConnected: false,
         }),
         // Without this target, the PAT device observable won't have an updated value
         // for context.patDevice
@@ -628,7 +640,7 @@ export function buildMachine(
               assign({
                 interpretation: undefined,
                 scannedImagePaths: undefined,
-                patDevice: undefined,
+                isPatDeviceConnected: false,
               });
             },
             after: {
@@ -645,7 +657,7 @@ export function buildMachine(
               assign({
                 interpretation: undefined,
                 scannedImagePaths: undefined,
-                patDevice: undefined,
+                isPatDeviceConnected: false,
               });
             },
             always: 'not_accepting_paper',
@@ -657,7 +669,7 @@ export function buildMachine(
           VOTER_CONFIRMED_PAT_DEVICE_CALIBRATION: 'voting_flow.history',
           PAT_DEVICE_DISCONNECTED: {
             actions: assign({
-              patDevice: () => undefined,
+              isPatDeviceConnected: false,
             }),
             target: 'voting_flow.history',
           },
@@ -741,6 +753,7 @@ export async function getPaperHandlerStateMachine({
   auth,
   logger,
   driver,
+  patConnectionStatusReader,
   devicePollingIntervalMs = DEVICE_STATUS_POLLING_INTERVAL_MS,
   authPollingIntervalMs = AUTH_STATUS_POLLING_INTERVAL_MS,
 }: {
@@ -748,6 +761,7 @@ export async function getPaperHandlerStateMachine({
   auth: InsertedSmartCardAuthApi;
   logger: Logger;
   driver: PaperHandlerDriverInterface;
+  patConnectionStatusReader: PatConnectionStatusReader;
   devicePollingIntervalMs: number;
   authPollingIntervalMs: number;
 }): Promise<Optional<PaperHandlerStateMachine>> {
@@ -755,8 +769,10 @@ export async function getPaperHandlerStateMachine({
     auth,
     workspace,
     driver,
+    patConnectionStatusReader,
     devicePollingIntervalMs,
     authPollingIntervalMs,
+    isPatDeviceConnected: false,
   };
 
   const machine = buildMachine(initialContext, auth);

--- a/apps/mark-scan/backend/src/pat-input/README.md
+++ b/apps/mark-scan/backend/src/pat-input/README.md
@@ -30,7 +30,7 @@ Three status bits can be read from the 3.5mm jack:
 2. "A" signal - is the user currently triggering their "A" input?
 3. "B" signal - is the user currently triggering their "B" input?
 
-These bits are read communicated through
+These bits are communicated through
 [GPIO](https://en.wikipedia.org/wiki/General-purpose_input/output). From the
 software perspective, GPIO pins may be thought of as shared registers for the
 3.5mm jack to communicate with the OS.

--- a/apps/mark-scan/backend/src/pat-input/README.md
+++ b/apps/mark-scan/backend/src/pat-input/README.md
@@ -1,0 +1,86 @@
+# PAT Input
+
+Personal Assistive Technology (PAT) devices are used by people to send 2 or more
+signals to computers. A PAT device may be used on the hardware by plugging the
+PAT device into the front right 3.5mm jack.
+
+VxMarkScan hardware supports only 2-signal devices. As this integration is
+device-agnostic, we call these signals "A" and "B". The signals commonly map to
+user actions of "sip" and "puff" on a
+[sip and puff device](https://accessibleweb.com/assistive-technologies/assistive-technology-focus-sip-and-puff-devices/).
+
+# Building and running the daemon
+
+To get the PAT input working, run:
+
+```
+cd /apps/mark-scan/backend
+pnpm build
+sudo ./bin/patinputd
+```
+
+udev rule configuration to allow running the daemon without `sudo` is on the
+backlog.
+
+## Data Format and Protocol
+
+Three status bits can be read from the 3.5mm jack:
+
+1. Device connection status - is a PAT device plugged in?
+2. "A" signal - is the user currently triggering their "A" input?
+3. "B" signal - is the user currently triggering their "B" input?
+
+These bits are read communicated through
+[GPIO](https://en.wikipedia.org/wiki/General-purpose_input/output). From the
+software perspective, GPIO pins may be thought of as shared registers for the
+3.5mm jack to communicate with the OS.
+
+There are several ways for software to read GPIO values. This integration uses
+the [sysfs](https://www.ics.com/blog/gpio-programming-using-sysfs-interface)
+interface.
+
+## Implementation Overview
+
+This integration has 2 responsibilities:
+
+1. Communicate with the OS to read GPIO pins that contain PAT device data
+2. Send that data to VxMarkScan
+
+### Structure
+
+`patinputd.c` is a daemon that reads "A" and "B" signal and sends keypresses for
+mark-scan frontend to handle. More specifically, it
+
+- Sets itself up to read GPIO pins and send keypress events
+- Polls GPIO pin data in a loop
+- When "A" or "B" signal is received, sends a "1" or "2" keypress event
+- Cleans up on exit
+
+`connection_status_reader.ts` is a small node helper that reads PAT device
+connection status. It's used by the VxMarkScan backend.
+
+### Reading PAT device data
+
+The aforementioned `sysfs` interface makes GPIO pin data available to userspace
+via the filesystem at `/sys/class/gpio`. The pattern for querying this data is
+below. Each step involves writing to or reading from the filesystem.
+
+1. `Export` the desired pin. The pin's value can't be read until it's exported.
+2. Set the pin direction. In our case we set it to `input` because data is going
+   from pin to software.
+3. Read the pin value.
+4. When done with all reading, `unexport` the pin. The pin is no longer
+   readable.
+
+### Sending data to VxMarkScan frontend
+
+Once `patinputd` has "A" or "B" signal, it sends a keypress event with
+[uinput](https://kernel.org/doc/html/v4.12/input/uinput.html). VxMarkScan
+listens for keypresses "1" or "2" and handles them as DOM navigation and DOM
+element selection, respectively.
+
+### connection_status_reader
+
+`connection_status_reader` reads the GPIO pin for PAT device connection status.
+The daemon must be running or `connection_status_reader` will fail because the
+pin will be exported.

--- a/apps/mark-scan/backend/src/pat-input/README.md
+++ b/apps/mark-scan/backend/src/pat-input/README.md
@@ -22,6 +22,9 @@ sudo ./bin/patinputd
 udev rule configuration to allow running the daemon without `sudo` is on the
 backlog.
 
+The daemon must be running for `connection_status_reader` to work. Otherwise it
+will fail because the pin will be unexported.
+
 ## Data Format and Protocol
 
 Three status bits can be read from the 3.5mm jack:
@@ -53,7 +56,7 @@ mark-scan frontend to handle. More specifically, it
 
 - Sets itself up to read GPIO pins and send keypress events
 - Polls GPIO pin data in a loop
-- When "A" or "B" signal is received, sends a "1" or "2" keypress event
+- When "A" or "B" signal is received, emits a keypress event
 - Cleans up on exit
 
 `connection_status_reader.ts` is a small node helper that reads PAT device
@@ -78,9 +81,3 @@ Once `patinputd` has "A" or "B" signal, it sends a keypress event with
 [uinput](https://kernel.org/doc/html/v4.12/input/uinput.html). VxMarkScan
 listens for keypresses "1" or "2" and handles them as DOM navigation and DOM
 element selection, respectively.
-
-### connection_status_reader
-
-`connection_status_reader` reads the GPIO pin for PAT device connection status.
-The daemon must be running or `connection_status_reader` will fail because the
-pin will be exported.

--- a/apps/mark-scan/backend/src/pat-input/connection_status_reader.test.ts
+++ b/apps/mark-scan/backend/src/pat-input/connection_status_reader.test.ts
@@ -25,7 +25,7 @@ test('logs when it cannot access the gpio pin sysfs file', async () => {
 
 test('isPatDeviceConnected can read "true" pin value from a file', async () => {
   const file = tmp.fileSync();
-  const buf = Buffer.of(0);
+  const buf = Buffer.of(48); // ASCII char '0'
   await fs.appendFile(file.name, buf);
 
   const reader = new PatConnectionStatusReader(logger, file.name);
@@ -37,7 +37,7 @@ test('isPatDeviceConnected can read "true" pin value from a file', async () => {
 
 test('isPatDeviceConnected can read "false" pin value from a file', async () => {
   const file = tmp.fileSync();
-  const buf = Buffer.of(1);
+  const buf = Buffer.of(49); // ASCII char '1'
   await fs.appendFile(file.name, buf);
 
   const reader = new PatConnectionStatusReader(logger, file.name);

--- a/apps/mark-scan/backend/src/pat-input/connection_status_reader.test.ts
+++ b/apps/mark-scan/backend/src/pat-input/connection_status_reader.test.ts
@@ -1,0 +1,48 @@
+import { LogEventId, Logger, fakeLogger } from '@votingworks/logging';
+import tmp from 'tmp';
+import * as fs from 'fs/promises';
+import { Buffer } from 'buffer';
+import { PatConnectionStatusReader } from './connection_status_reader';
+
+let logger: Logger;
+
+beforeEach(() => {
+  logger = fakeLogger();
+});
+
+test('logs when it cannot access the gpio pin sysfs file', async () => {
+  const reader = new PatConnectionStatusReader(
+    logger,
+    '/sys/class/gpio/not-a-real-gpio-123/value'
+  );
+  const result = await reader.open();
+  expect(logger.log).toHaveBeenCalledWith(LogEventId.PatDeviceError, 'system', {
+    message: expect.stringMatching(/not accessible from VxMarkScan backend/),
+  });
+
+  expect(result).toEqual(false);
+});
+
+test('isPatDeviceConnected can read "true" pin value from a file', async () => {
+  const file = tmp.fileSync();
+  const buf = Buffer.of(0);
+  await fs.appendFile(file.name, buf);
+
+  const reader = new PatConnectionStatusReader(logger, file.name);
+  const result = await reader.open();
+  expect(result).toEqual(true);
+  const isConnected = await reader.isPatDeviceConnected();
+  expect(isConnected).toEqual(true);
+});
+
+test('isPatDeviceConnected can read "false" pin value from a file', async () => {
+  const file = tmp.fileSync();
+  const buf = Buffer.of(1);
+  await fs.appendFile(file.name, buf);
+
+  const reader = new PatConnectionStatusReader(logger, file.name);
+  const result = await reader.open();
+  expect(result).toEqual(true);
+  const isConnected = await reader.isPatDeviceConnected();
+  expect(isConnected).toEqual(false);
+});

--- a/apps/mark-scan/backend/src/pat-input/connection_status_reader.ts
+++ b/apps/mark-scan/backend/src/pat-input/connection_status_reader.ts
@@ -1,0 +1,76 @@
+import * as fs from 'fs/promises';
+import { assert } from '@votingworks/basics';
+import { Buffer } from 'buffer';
+import { LogEventId, Logger } from '@votingworks/logging';
+import makeDebug from 'debug';
+import { PATH_TO_PAT_CONNECTION_STATUS_PIN } from './constants';
+
+const debug = makeDebug('mark-scan:pat-status-reader');
+
+export interface PatConnectionStatusReaderInterface {
+  readonly logger: Logger;
+  open(): Promise<boolean>;
+  isPatDeviceConnected(): Promise<boolean>;
+}
+
+export class PatConnectionStatusReader
+  implements PatConnectionStatusReaderInterface
+{
+  private file?: fs.FileHandle;
+
+  constructor(
+    // logger prop must be public to be defined in the interface
+    // eslint-disable-next-line vx/gts-no-public-class-fields
+    readonly logger: Logger,
+    private readonly filePath?: string
+  ) {
+    // We don't use the default initializer syntax because then we'd have to
+    // also make filePath a no-op constructor argument in the mock
+    if (!filePath) {
+      this.filePath = PATH_TO_PAT_CONNECTION_STATUS_PIN;
+    }
+  }
+
+  async open(): Promise<boolean> {
+    assert(this.filePath !== undefined);
+    try {
+      debug('Checking access to sysfs file %s', this.filePath);
+      await fs.access(this.filePath, fs.constants.R_OK);
+    } catch (err) {
+      debug('Err checking access to syfs file: %O', err);
+      await this.logger.log(LogEventId.PatDeviceError, 'system', {
+        message: `${this.filePath} is not accessible from VxMarkScan backend. It may be unexported or the backend may be running on development hardware.`,
+      });
+
+      return false;
+    }
+
+    debug('Opening sysfs file');
+    this.file = await fs.open(this.filePath);
+    debug('Successfully opened sysfs file');
+    return true;
+  }
+
+  async isPatDeviceConnected(): Promise<boolean> {
+    assert(
+      this.file,
+      'No FileHandle for PAT connection status pin. Did you call `PatConnectionStatusReader.open()`?'
+    );
+    // The value file will always contain a single byte (0 or 1)
+    const buf = Buffer.alloc(1);
+    debug('Attempting to read PAT connection status from file');
+    await this.file.read(buf, 0, 1, 0);
+
+    // We need to convert from raw value to char value
+    // ie. raw value 48 for char '0' or raw value 49 for char '1'
+    const raw = buf.at(0);
+    assert(raw !== undefined);
+    const charValue = String.fromCharCode(raw);
+    debug('Read raw value: %d', raw);
+    debug('Read char value: %d', charValue);
+
+    // Contrary to boolean conventions, the value is 0 when a PAT device
+    // is connected and 1 when no PAT device is connected
+    return charValue === '0';
+  }
+}

--- a/apps/mark-scan/backend/src/pat-input/connection_status_reader.ts
+++ b/apps/mark-scan/backend/src/pat-input/connection_status_reader.ts
@@ -2,10 +2,7 @@ import * as fs from 'fs/promises';
 import { assert } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import { LogEventId, Logger } from '@votingworks/logging';
-import makeDebug from 'debug';
 import { PATH_TO_PAT_CONNECTION_STATUS_PIN } from './constants';
-
-const debug = makeDebug('mark-scan:pat-status-reader');
 
 export interface PatConnectionStatusReaderInterface {
   readonly logger: Logger;
@@ -34,10 +31,8 @@ export class PatConnectionStatusReader
   async open(): Promise<boolean> {
     assert(this.filePath !== undefined);
     try {
-      debug('Checking access to sysfs file %s', this.filePath);
       await fs.access(this.filePath, fs.constants.R_OK);
     } catch (err) {
-      debug('Err checking access to syfs file: %O', err);
       await this.logger.log(LogEventId.PatDeviceError, 'system', {
         message: `${this.filePath} is not accessible from VxMarkScan backend. It may be unexported or the backend may be running on development hardware.`,
       });
@@ -45,9 +40,7 @@ export class PatConnectionStatusReader
       return false;
     }
 
-    debug('Opening sysfs file');
     this.file = await fs.open(this.filePath);
-    debug('Successfully opened sysfs file');
     return true;
   }
 
@@ -58,7 +51,6 @@ export class PatConnectionStatusReader
     );
     // The value file will always contain a single byte (0 or 1)
     const buf = Buffer.alloc(1);
-    debug('Attempting to read PAT connection status from file');
     await this.file.read(buf, 0, 1, 0);
 
     // We need to convert from raw value to char value
@@ -66,8 +58,6 @@ export class PatConnectionStatusReader
     const raw = buf.at(0);
     assert(raw !== undefined);
     const charValue = String.fromCharCode(raw);
-    debug('Read raw value: %d', raw);
-    debug('Read char value: %d', charValue);
 
     // Contrary to boolean conventions, the value is 0 when a PAT device
     // is connected and 1 when no PAT device is connected

--- a/apps/mark-scan/backend/src/pat-input/constants.ts
+++ b/apps/mark-scan/backend/src/pat-input/constants.ts
@@ -1,0 +1,7 @@
+// Constants for Origin Swifty USB switch integration
+export const ORIGIN_VENDOR_ID = 0x0a95;
+export const ORIGIN_SWIFTY_PRODUCT_ID = 0x0012;
+
+// Constants for built-in 3.5mm jack GPIO integration
+export const PAT_CONNECTION_STATUS_PIN = 478;
+export const PATH_TO_PAT_CONNECTION_STATUS_PIN = `/sys/class/gpio/gpio${PAT_CONNECTION_STATUS_PIN}/value`;

--- a/apps/mark-scan/backend/src/pat-input/mock_connection_status_reader.ts
+++ b/apps/mark-scan/backend/src/pat-input/mock_connection_status_reader.ts
@@ -1,0 +1,26 @@
+import { Logger } from '@votingworks/logging';
+import { PatConnectionStatusReaderInterface } from './connection_status_reader';
+
+export class MockPatConnectionStatusReader
+  implements PatConnectionStatusReaderInterface
+{
+  private mockConnectedStatus: boolean = false;
+
+  constructor(
+    // logger prop must be public to be defined in the interface
+    // eslint-disable-next-line vx/gts-no-public-class-fields
+    readonly logger: Logger
+  ) {}
+
+  open(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+
+  setConnectionStatus(isConnected: boolean): void {
+    this.mockConnectedStatus = isConnected;
+  }
+
+  async isPatDeviceConnected(): Promise<boolean> {
+    return Promise.resolve(this.mockConnectedStatus);
+  }
+}

--- a/apps/mark-scan/backend/src/pat-input/patinputd.c
+++ b/apps/mark-scan/backend/src/pat-input/patinputd.c
@@ -58,8 +58,10 @@ int main(void)
 
   memset(&usetup, 0, sizeof(usetup));
   usetup.id.bustype = BUS_USB;
-  usetup.id.vendor = 0x1234;  /* sample vendor */
-  usetup.id.product = 0x5678; /* sample product */
+  // Vendor and product ID are required but their values are never read,
+  // so we use dummy values.
+  usetup.id.vendor = 0x1234;
+  usetup.id.product = 0x5678;
   strcpy(usetup.name, "PAT Input daemon virtual device");
 
   ioctl(uinput_fd, UI_DEV_SETUP, &usetup);

--- a/apps/mark-scan/backend/src/pat-input/patinputd.c
+++ b/apps/mark-scan/backend/src/pat-input/patinputd.c
@@ -1,0 +1,171 @@
+#include <fcntl.h>
+#include <linux/uinput.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <string.h>
+
+#include "vsapgpio.h"
+
+bool should_exit_cleanly = false;
+char *pat_is_connected_gpio_number = "478";
+char *pat_a_signal_gpio_number = "481";
+char *pat_b_signal_gpio_number = "476";
+
+const long INTERVAL_MS = 100;
+struct timespec interval_timespec = {
+    0,
+    (INTERVAL_MS % 1000) * 1000000,
+};
+struct timespec rem;
+
+void emit(int fd, int type, int code, int val)
+{
+  struct input_event ie;
+
+  ie.type = type;
+  ie.code = code;
+  ie.value = val;
+  /* timestamp values below are ignored */
+  ie.time.tv_sec = 0;
+  ie.time.tv_usec = 0;
+
+  write(fd, &ie, sizeof(ie));
+}
+
+void interrupt(int signal)
+{
+  // TODO handle error signals
+  printf("Got signal %d\n", signal);
+  should_exit_cleanly = true;
+}
+
+int main(void)
+{
+  struct uinput_setup usetup;
+
+  int uinput_fd = open("/dev/uinput", O_WRONLY | O_NONBLOCK);
+
+  /*
+   * The ioctls below will enable the device that is about to be
+   * created, to pass key events.
+   */
+  ioctl(uinput_fd, UI_SET_EVBIT, EV_KEY);
+  ioctl(uinput_fd, UI_SET_KEYBIT, KEY_1);
+  ioctl(uinput_fd, UI_SET_KEYBIT, KEY_2);
+
+  memset(&usetup, 0, sizeof(usetup));
+  usetup.id.bustype = BUS_USB;
+  usetup.id.vendor = 0x1234;  /* sample vendor */
+  usetup.id.product = 0x5678; /* sample product */
+  strcpy(usetup.name, "PAT Input daemon virtual device");
+
+  ioctl(uinput_fd, UI_DEV_SETUP, &usetup);
+  ioctl(uinput_fd, UI_DEV_CREATE);
+
+  /*
+   * On UI_DEV_CREATE the kernel will create the device node for this
+   * device. We are inserting a pause here so that userspace has time
+   * to detect, initialize the new device, and can start listening to
+   * the event, otherwise it will not notice the event we are about
+   * to send. This pause is only needed in our example code!
+   */
+  sleep(1);
+
+  // TODO handle already-exported pins
+  export_pin(pat_is_connected_gpio_number);
+  export_pin(pat_a_signal_gpio_number);
+  export_pin(pat_b_signal_gpio_number);
+
+  set_pin_direction_in(pat_is_connected_gpio_number);
+  set_pin_direction_in(pat_a_signal_gpio_number);
+  set_pin_direction_in(pat_b_signal_gpio_number);
+
+  int is_connected_value_fd = get_pin_value_fd(pat_is_connected_gpio_number);
+  bool is_connected = get_bool_pin_value(is_connected_value_fd);
+
+  printf("Initial PAT device is connected: %s\n", is_connected ? "true" : "false");
+
+  int a_signal_fd = get_pin_value_fd(pat_a_signal_gpio_number);
+  bool a_signal = get_bool_pin_value(a_signal_fd);
+  printf("Initial A value: %s\n", a_signal ? "true" : "false");
+
+  int b_signal_fd = get_pin_value_fd(pat_b_signal_gpio_number);
+  bool b_signal = get_bool_pin_value(b_signal_fd);
+  printf("Initial B value: %s\n", b_signal ? "true" : "false");
+
+  signal(SIGINT, interrupt);
+
+  while (!should_exit_cleanly)
+  {
+    // Need to get file descriptor each time we read or the value will be stale
+    a_signal_fd = get_pin_value_fd(pat_a_signal_gpio_number);
+    bool new_a_signal = get_bool_pin_value(a_signal_fd);
+
+    b_signal_fd = get_pin_value_fd(pat_b_signal_gpio_number);
+    bool new_b_signal = get_bool_pin_value(b_signal_fd);
+
+    // Only emit keyboard event when signal changes
+    if (new_a_signal && !a_signal)
+    {
+      printf("'A' signal triggered\n");
+      /* Key press, report the event, send key release, and report again */
+      emit(uinput_fd, EV_KEY, KEY_1, 1);
+      emit(uinput_fd, EV_SYN, SYN_REPORT, 0);
+      emit(uinput_fd, EV_KEY, KEY_1, 0);
+      emit(uinput_fd, EV_SYN, SYN_REPORT, 0);
+    }
+
+    if (new_b_signal && !b_signal)
+    {
+      printf("'B' signal triggered\n");
+      /* Key press, report the event, send key release, and report again */
+      emit(uinput_fd, EV_KEY, KEY_2, 1);
+      emit(uinput_fd, EV_SYN, SYN_REPORT, 0);
+      emit(uinput_fd, EV_KEY, KEY_2, 0);
+      emit(uinput_fd, EV_SYN, SYN_REPORT, 0);
+    }
+
+    a_signal = new_a_signal;
+    b_signal = new_b_signal;
+    int close_result = close(a_signal_fd);
+    if (close_result != 0)
+    {
+      perror("Failed to close A signal file descriptor\n");
+    }
+    close_result = close(b_signal_fd);
+    if (close_result != 0)
+    {
+      perror("Failed to close B signal file descriptor\n");
+    }
+    // Sleep accepts integer seconds only and we want to poll more frequently
+    nanosleep(&interval_timespec, &rem);
+  }
+
+  printf("Unexporting pins\n");
+  unexport_pin(pat_is_connected_gpio_number);
+  unexport_pin(pat_a_signal_gpio_number);
+  unexport_pin(pat_b_signal_gpio_number);
+
+  printf("Closing GPIO sysfs file descriptors\n");
+  close(a_signal);
+  close(b_signal);
+  close(is_connected_value_fd);
+
+  /*
+   * Events are unlikely to have been sent recently, but we still
+   * give userspace some time to read the events before we clean up by
+   * closing GPIO connections and destroying the virtual device with
+   * UI_DEV_DESTOY.
+   */
+  sleep(1);
+
+  printf("Cleaning up virtual device\n");
+  ioctl(uinput_fd, UI_DEV_DESTROY);
+  close(uinput_fd);
+
+  return 0;
+}

--- a/apps/mark-scan/backend/src/pat-input/patinputd.c
+++ b/apps/mark-scan/backend/src/pat-input/patinputd.c
@@ -65,16 +65,6 @@ int main(void)
   ioctl(uinput_fd, UI_DEV_SETUP, &usetup);
   ioctl(uinput_fd, UI_DEV_CREATE);
 
-  /*
-   * On UI_DEV_CREATE the kernel will create the device node for this
-   * device. We are inserting a pause here so that userspace has time
-   * to detect, initialize the new device, and can start listening to
-   * the event, otherwise it will not notice the event we are about
-   * to send. This pause is only needed in our example code!
-   */
-  sleep(1);
-
-  // TODO handle already-exported pins
   export_pin(pat_is_connected_gpio_number);
   export_pin(pat_a_signal_gpio_number);
   export_pin(pat_b_signal_gpio_number);
@@ -130,16 +120,17 @@ int main(void)
 
     a_signal = new_a_signal;
     b_signal = new_b_signal;
-    int close_result = close(a_signal_fd);
-    if (close_result != 0)
+
+    if (close(a_signal_fd) != 0)
     {
       perror("Failed to close A signal file descriptor\n");
     }
-    close_result = close(b_signal_fd);
-    if (close_result != 0)
+
+    if (close(b_signal_fd) != 0)
     {
       perror("Failed to close B signal file descriptor\n");
     }
+
     // Sleep accepts integer seconds only and we want to poll more frequently
     nanosleep(&interval_timespec, &rem);
   }

--- a/apps/mark-scan/backend/src/pat-input/patinputd.c
+++ b/apps/mark-scan/backend/src/pat-input/patinputd.c
@@ -38,8 +38,7 @@ void emit(int fd, int type, int code, int val)
 
 void interrupt(int signal)
 {
-  // TODO handle error signals
-  printf("Got signal %d\n", signal);
+  printf("Got exit signal %d\n", signal);
   should_exit_cleanly = true;
 }
 

--- a/apps/mark-scan/backend/src/pat-input/vsapgpio.c
+++ b/apps/mark-scan/backend/src/pat-input/vsapgpio.c
@@ -1,0 +1,117 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
+const int MAX_PIN_NUMBER_DIGITS = 3;
+
+int ascii_to_int(int ascii_char)
+{
+  return ascii_char - '0';
+}
+
+void unexport_pin(char *pin)
+{
+  // Unexport the pin by writing to /sys/class/gpio/unexport
+  int fd = open("/sys/class/gpio/unexport", O_WRONLY);
+  if (fd == -1)
+  {
+    perror("Unable to open /sys/class/gpio/unexport");
+    exit(1);
+  }
+
+  if (write(fd, pin, MAX_PIN_NUMBER_DIGITS) != MAX_PIN_NUMBER_DIGITS)
+  {
+    perror("Error writing to /sys/class/gpio/unexport");
+    exit(1);
+  }
+
+  close(fd);
+}
+
+void export_pin(char *pin)
+{
+  // Export the desired pin by writing to /sys/class/gpio/export
+  int fd = open("/sys/class/gpio/export", O_WRONLY);
+  if (fd == -1)
+  {
+    perror("Unable to open /sys/class/gpio/export");
+    exit(1);
+  }
+
+  if (write(fd, pin, MAX_PIN_NUMBER_DIGITS) != MAX_PIN_NUMBER_DIGITS)
+  {
+    perror("Error writing to /sys/class/gpio/export");
+    exit(1);
+  }
+
+  close(fd);
+}
+
+void set_pin_direction_in(char *pin)
+{
+  char path[strlen("/sys/class/gpio/gpio/direction") + MAX_PIN_NUMBER_DIGITS];
+  sprintf(path, "/sys/class/gpio/gpio%s/direction", pin);
+  printf("Attempting to open fd to path: %s\n", path);
+  int fd = open(path, O_WRONLY);
+  if (fd == -1)
+  {
+    perror("Unable to open pin direction fd");
+    exit(1);
+  }
+
+  if (write(fd, "in", 3) != 3)
+  {
+    perror("Error writing to pin direction file");
+    exit(1);
+  }
+
+  close(fd);
+}
+
+// Gets a file descriptor for a pin's value file at /sys/class/gpio/gpio<pin_number>/value
+int get_pin_value_fd(char *pin)
+{
+  char value_path[strlen("/sys/class/gpio/gpio/value") + MAX_PIN_NUMBER_DIGITS];
+  sprintf(value_path,
+          "/sys/class/gpio/gpio%s/value",
+          pin);
+  int fd = open(value_path, O_RDONLY);
+  if (fd == -1)
+  {
+    perror("Unable to open value pin");
+    exit(1);
+  }
+
+  return fd;
+}
+
+// Reads and return the value of a GPIO pin given a file descriptor
+// from get_pin_value_fd. Assumes the pin has already been exported.
+int read_pin_value_from_fd(int fd)
+{
+  // Pin value should be exactly 1 ASCII char == 1 byte
+  char pin_value_ascii;
+  read(fd, &pin_value_ascii, 1);
+
+  return ascii_to_int(pin_value_ascii);
+}
+
+// Convenience function that returns value of a pin that follows typical boolean conventions.
+// The pin that is read is specified by the given file descriptor.
+bool get_bool_pin_value(int fd)
+{
+  // 1 is the default state, 0 is actioned state
+  // connection status: 1 when PAT device is not plugged in, 0 when plugged in
+  // A/B signal: 1 when no signal is sent from device, 0 when signal is sent
+  int value = read_pin_value_from_fd(fd);
+
+  if (value == 0)
+  {
+    return true;
+  }
+
+  return false;
+}

--- a/apps/mark-scan/backend/src/pat-input/vsapgpio.h
+++ b/apps/mark-scan/backend/src/pat-input/vsapgpio.h
@@ -1,0 +1,7 @@
+int ascii_to_int(int ascii_char);
+void unexport_pin(char *pin);
+void export_pin(char *pin);
+void set_pin_direction_in(char *pin);
+int get_pin_value_fd(char *pin);
+int read_pin_value_from_fd(int fd);
+bool get_bool_pin_value(int fd);

--- a/apps/mark-scan/backend/test/app_helpers.ts
+++ b/apps/mark-scan/backend/test/app_helpers.ts
@@ -37,6 +37,7 @@ import {
   DEV_AUTH_STATUS_POLLING_INTERVAL_MS,
   DEV_DEVICE_STATUS_POLLING_INTERVAL_MS,
 } from '../src/custom-paper-handler/constants';
+import { MockPatConnectionStatusReader } from '../src/pat-input/mock_connection_status_reader';
 
 jest.mock('@votingworks/custom-paper-handler');
 
@@ -55,6 +56,9 @@ export async function getMockStateMachine(
   };
   const driver = new PaperHandlerDriver(webDevice);
   const auth = buildMockInsertedSmartCardAuth();
+  const mockPatConnectionStatusReader = new MockPatConnectionStatusReader(
+    logger
+  );
   jest
     .spyOn(driver, 'getPaperHandlerStatus')
     .mockImplementation(() => Promise.resolve(defaultPaperHandlerStatus()));
@@ -63,6 +67,7 @@ export async function getMockStateMachine(
     auth,
     logger,
     driver,
+    patConnectionStatusReader: mockPatConnectionStatusReader,
     devicePollingIntervalMs: DEV_DEVICE_STATUS_POLLING_INTERVAL_MS,
     authPollingIntervalMs: DEV_AUTH_STATUS_POLLING_INTERVAL_MS,
   });

--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -477,11 +477,16 @@ export function AppRoot({
       'data-useragent',
       navigator.userAgent
     );
-    document.addEventListener('keydown', handleGamepadKeyboardEvent);
+    // During PAT calibration the voter triggers PAT inputs to identify them. We don't
+    // want PAT input to actually navigate focus or select elements as random navigate +
+    // select events could accidentally exit PAT calibration early.
+    if (stateMachineState !== 'pat_device_connected') {
+      document.addEventListener('keydown', handleGamepadKeyboardEvent);
+    }
     return () => {
       document.removeEventListener('keydown', handleGamepadKeyboardEvent);
     };
-  }, []);
+  }, [stateMachineState]);
 
   // Bootstraps the AppRoot Component
   useEffect(() => {

--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -477,16 +477,13 @@ export function AppRoot({
       'data-useragent',
       navigator.userAgent
     );
-    // During PAT calibration the voter triggers PAT inputs to identify them. We don't
-    // want PAT input to actually navigate focus or select elements as random navigate +
-    // select events could accidentally exit PAT calibration early.
-    if (stateMachineState !== 'pat_device_connected') {
-      document.addEventListener('keydown', handleGamepadKeyboardEvent);
-    }
+
+    document.addEventListener('keydown', handleGamepadKeyboardEvent);
+
     return () => {
       document.removeEventListener('keydown', handleGamepadKeyboardEvent);
     };
-  }, [stateMachineState]);
+  }, []);
 
   // Bootstraps the AppRoot Component
   useEffect(() => {

--- a/apps/mark-scan/frontend/src/pages/pat_device_identification/pat_device_identification_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/pat_device_identification/pat_device_identification_page.tsx
@@ -1,5 +1,5 @@
 import { Main, Screen, P, Font, Button } from '@votingworks/ui';
-import { useCallback, useState } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 import { ButtonFooter } from '@votingworks/mark-flow-ui';
 import {
   DiagnosticScreenHeader,
@@ -7,6 +7,7 @@ import {
 } from '../diagnostic_screen_components';
 import { PatIntroductionStep } from './pat_introduction_step';
 import { IdentifyInputStep } from './identify_input_step';
+import { handleGamepadKeyboardEvent } from '../../lib/gamepad';
 
 interface Props {
   onAllInputsIdentified: () => void;
@@ -18,6 +19,19 @@ export function PatDeviceIdentificationPage({
   onExitCalibration,
 }: Props): JSX.Element {
   const [step, setStep] = useState(0);
+
+  useEffect(() => {
+    // During PAT identification the voter triggers PAT inputs to identify them. We don't
+    // want PAT input to actually navigate focus or select elements as random navigate +
+    // select events could accidentally exit PAT calibration early.
+    document.removeEventListener('keydown', handleGamepadKeyboardEvent);
+
+    // On cleanup, re-enable the listener once devices are identified and the user is prompted
+    // to select the "Continue with Voting" button
+    return () => {
+      document.addEventListener('keydown', handleGamepadKeyboardEvent);
+    };
+  }, []);
 
   const nextStep = useCallback(() => {
     setStep(step + 1);

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -422,3 +422,7 @@ IDs are logged with each log to identify the log being written.
 **Type:** [application-status](#application-status)  
 **Description:** Precinct print/scan BMD state machine transitioned states.  
 **Machines:** vx-mark-scan-backend
+### pat-device-error
+**Type:** [system-status](#system-status)  
+**Description:** VxMarkScan encountered an error with the built-in PAT device port or the device itself  
+**Machines:** vx-mark-scan-backend

--- a/libs/logging/src/log_event_ids.ts
+++ b/libs/logging/src/log_event_ids.ts
@@ -3,11 +3,10 @@ import { LogEventType } from './log_event_types';
 import { LogSource } from './log_source';
 
 /**
- * In order to add a new log event you must do four things:
+ * In order to add a new log event you must:
  * 1. Add the new event to the enum LogEventId
  * 2. Define a LogDetails object representing the information about that log event.
  * 3. Add a case statement to the switch in getDetailsForEventId returning your new LogDetails object when you see your new LogEventId.
- * 4. Update the test expectation for number of EventIdDescriptions in libs/logging/src/log_documentation.test.ts
  * You will then be ready to use the log event from your code!
  */
 
@@ -135,6 +134,9 @@ export enum LogEventId {
   ScannerEvent = 'scanner-state-machine-event',
   ScannerStateChanged = 'scanner-state-machine-transition',
   PaperHandlerStateChanged = 'paper-handler-state-machine-transition',
+
+  // VxMarkScan logs
+  PatDeviceError = 'pat-device-error',
 }
 
 export interface LogDetails {
@@ -927,6 +929,13 @@ const SystemSettingsRetrieved: LogDetails = {
   documentationMessage: 'VxAdmin System Settings read from db',
   restrictInDocumentationToApps: [LogSource.VxAdminService],
 };
+const PatDeviceError: LogDetails = {
+  eventId: LogEventId.PatDeviceError,
+  eventType: LogEventType.SystemStatus,
+  documentationMessage:
+    'VxMarkScan encountered an error with the built-in PAT device port or the device itself',
+  restrictInDocumentationToApps: [LogSource.VxMarkScanBackend],
+};
 
 const WriteInAdjudicated: LogDetails = {
   eventId: LogEventId.WriteInAdjudicated,
@@ -1141,6 +1150,8 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return SystemSettingsRetrieved;
     case LogEventId.WriteInAdjudicated:
       return WriteInAdjudicated;
+    case LogEventId.PatDeviceError:
+      return PatDeviceError;
 
     /* istanbul ignore next - compile time check for completeness */
     default:

--- a/libs/logging/src/log_event_ids.ts
+++ b/libs/logging/src/log_event_ids.ts
@@ -929,19 +929,20 @@ const SystemSettingsRetrieved: LogDetails = {
   documentationMessage: 'VxAdmin System Settings read from db',
   restrictInDocumentationToApps: [LogSource.VxAdminService],
 };
-const PatDeviceError: LogDetails = {
-  eventId: LogEventId.PatDeviceError,
-  eventType: LogEventType.SystemStatus,
-  documentationMessage:
-    'VxMarkScan encountered an error with the built-in PAT device port or the device itself',
-  restrictInDocumentationToApps: [LogSource.VxMarkScanBackend],
-};
 
 const WriteInAdjudicated: LogDetails = {
   eventId: LogEventId.WriteInAdjudicated,
   eventType: LogEventType.UserAction,
   documentationMessage: 'User adjudicated a write-in.',
   restrictInDocumentationToApps: [LogSource.VxAdminService],
+};
+
+const PatDeviceError: LogDetails = {
+  eventId: LogEventId.PatDeviceError,
+  eventType: LogEventType.SystemStatus,
+  documentationMessage:
+    'VxMarkScan encountered an error with the built-in PAT device port or the device itself',
+  restrictInDocumentationToApps: [LogSource.VxMarkScanBackend],
 };
 
 export function getDetailsForEventId(eventId: LogEventId): LogDetails {


### PR DESCRIPTION
## Overview

* Adds support for the hardware's built-in PAT input
* Does not affect support for the Swifty USB switch (useful for development)

**Architecture**
* The hardware sends 3 signals over GPIO: connection status, A signal, and B signal. A and B signal are generic terms for what is most commonly "sip" and "puff" (not necessarily in that order)
* GPIO values are available by writing to and reading from the filesystem. See: [sysfs interface](https://www.ics.com/blog/gpio-programming-using-sysfs-interface)
* A daemon `patinputd.c` polls the `sysfs` interface and emits keypress events when A or B signal is detected
* The frontend's existing `gamepad` + USB switch integration already handles these keypress events
* The backend has been updated to read connection status from the `sysfs` interface

## Demo Video or Screenshot

https://github.com/votingworks/vxsuite/assets/1060688/2bdcb826-aa94-4e44-9c9d-c55d74a66d7d


## Testing Plan
* Added tests for backend status reader
* Manually verified USB switch and 3.5mm input both work

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
