### PR TITLE
[i18n] VxScan: <UiString>ify blank ballot warning screens

### DIFF
--- a/apps/scan/frontend/src/screens/scan_warning_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_warning_screen.tsx
@@ -210,16 +210,12 @@ function BlankBallotWarningScreen(): JSX.Element {
           </React.Fragment>
         }
       >
-        <P>No votes were found when scanning this ballot.</P>
-        <Caption>
-          Your votes will count, even if you leave some blank.
-          <br />
-          Ask a poll worker if you need help.
-        </Caption>
+        <P>{appStrings.warningScannerNoVotesFound()}</P>
+        <Caption>{appStrings.noteAskPollWorkerForHelp()}</Caption>
       </FullScreenPromptLayout>
       {confirmTabulate && (
         <ConfirmModal
-          content={<P>No votes will be counted from this ballot.</P>}
+          content={<P>{appStrings.warningScannerBlankBallotSubmission()}</P>}
           onConfirm={() => acceptBallotMutation.mutate()}
           onCancel={() => setConfirmTabulate(false)}
         />
@@ -235,7 +231,7 @@ function OtherReasonWarningScreen(): JSX.Element {
   return (
     <Screen centerContent>
       <FullScreenPromptLayout
-        title="Scanning Failed"
+        title={appStrings.titleScanningFailed()}
         image={
           <FullScreenIconWrapper>
             <Icons.Warning color="warning" />
@@ -255,12 +251,12 @@ function OtherReasonWarningScreen(): JSX.Element {
           </React.Fragment>
         }
       >
-        <P>There was a problem scanning this ballot.</P>
-        <Caption>Ask a poll worker if you need help.</Caption>
+        <P>{appStrings.warningProblemScanningBallot()}</P>
+        <Caption>{appStrings.noteAskPollWorkerForHelp()}</Caption>
       </FullScreenPromptLayout>
       {confirmTabulate && (
         <ConfirmModal
-          content={<P>No votes will be recorded for this ballot.</P>}
+          content={<P>{appStrings.warningScannerBlankBallotSubmission()}</P>}
           onConfirm={() => acceptBallotMutation.mutate()}
           onCancel={() => setConfirmTabulate(false)}
         />

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -583,6 +583,10 @@ export const appStrings = {
     </UiString>
   ),
 
+  titleScanningFailed: () => (
+    <UiString uiStringKey="titleScanningFailed">Scanning Failed</UiString>
+  ),
+
   warningBmdInactiveSession: () => (
     <UiString uiStringKey="warningBmdInactiveSession">
       This voting station has been inactive for more than 5 minutes.
@@ -612,6 +616,24 @@ export const appStrings = {
   warningNoVotesForContest: () => (
     <UiString uiStringKey="warningNoVotesForContest">
       You may still vote in this contest.
+    </UiString>
+  ),
+
+  warningProblemScanningBallot: () => (
+    <UiString uiStringKey="warningProblemScanningBallot">
+      There was a problem scanning this ballot.
+    </UiString>
+  ),
+
+  warningScannerBlankBallotSubmission: () => (
+    <UiString uiStringKey="warningScannerBlankBallotSubmission">
+      No votes will be counted from this ballot.
+    </UiString>
+  ),
+
+  warningScannerNoVotesFound: () => (
+    <UiString uiStringKey="warningScannerNoVotesFound">
+      No votes were found when scanning this ballot.
     </UiString>
   ),
 

--- a/libs/ui/src/ui_strings/app_strings_catalog/latest.json
+++ b/libs/ui/src/ui_strings/app_strings_catalog/latest.json
@@ -110,10 +110,14 @@
   "titleScannerNoVotesWarning": "No votes marked:",
   "titleScannerOvervoteWarning": "Too many votes marked:",
   "titleScannerUndervoteWarning": "You may add one or more votes:",
+  "titleScanningFailed": "Scanning Failed",
   "warningBmdInactiveSession": "This voting station has been inactive for more than 5 minutes.",
   "warningBmdInactiveTimeRemaining": "To protect your privacy, this ballot will be cleared when the timer runs out.",
   "warningNoPower": "<0>No Power Detected.</0> Please ask a poll worker to plug in the power cord.",
   "warningNoVotesForContest": "You may still vote in this contest.",
   "warningOvervoteCandidateContest": "To vote for another candidate, you must first deselect a previously selected candidate.",
-  "warningOvervoteYesNoContest": "To change your vote, first deselect your previous vote."
+  "warningOvervoteYesNoContest": "To change your vote, first deselect your previous vote.",
+  "warningProblemScanningBallot": "There was a problem scanning this ballot.",
+  "warningScannerBlankBallotSubmission": "No votes will be counted from this ballot.",
+  "warningScannerNoVotesFound": "No votes were found when scanning this ballot."
 }


### PR DESCRIPTION
## Overview

Converting text on the "blank ballot" `ScanWarningScreen` states in VxScan to language-aware `<UiString>`s.

Also removing the string, `"Your votes will count, even if you leave some blank."` from the `BlankBallotWarningScreen`, since it's not relevant for that state.

## Demo Video or Screenshot
<img width="500" alt="Screenshot 2023-11-15 at 12 20 19" src="https://github.com/votingworks/vxsuite/assets/264902/90d35b32-cce6-4791-8818-f4011b0238ed">
<img width="500" alt="Screenshot 2023-11-15 at 12 20 47" src="https://github.com/votingworks/vxsuite/assets/264902/0a564926-4a92-4f8d-8b69-128b1261dda7">
<img width="500" alt="Screenshot 2023-11-15 at 12 20 54" src="https://github.com/votingworks/vxsuite/assets/264902/32490784-e5da-43a9-8fa9-23065276af02">

## Testing Plan
- Manual + existing tests

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
