### PR TITLE
Add a more specific error message for jurisdiction mismatches between card and machine

### DIFF
--- a/apps/admin/frontend/src/app.test.tsx
+++ b/apps/admin/frontend/src/app.test.tsx
@@ -647,7 +647,8 @@ test('election manager cannot auth onto machine with different election hash', a
   );
   apiMock.setAuthStatus({
     status: 'logged_out',
-    reason: 'election_manager_wrong_election',
+    reason: 'wrong_election',
+    cardUserRole: 'election_manager',
   });
   await screen.findByText('Invalid Card');
   await screen.findByText(

--- a/apps/admin/frontend/src/components/election_manager.tsx
+++ b/apps/admin/frontend/src/components/election_manager.tsx
@@ -78,15 +78,16 @@ export function ElectionManager(): JSX.Element {
     if (auth.reason === 'machine_locked') {
       return <MachineLockedScreen />;
     }
-    if (auth.reason === 'machine_not_configured') {
-      return (
-        <InvalidCardScreen
-          reason={auth.reason}
-          recommendedAction="Please insert a System Administrator card."
-        />
-      );
-    }
-    return <InvalidCardScreen reason={auth.reason} />;
+    return (
+      <InvalidCardScreen
+        reasonAndContext={auth}
+        recommendedAction={
+          auth.reason === 'machine_not_configured'
+            ? 'Please insert a System Administrator card.'
+            : 'Please insert a valid Election Manager or System Administrator card.'
+        }
+      />
+    );
   }
 
   if (isSystemAdministratorAuth(auth)) {

--- a/apps/admin/frontend/src/components/smartcard_modal/smartcard_modal.tsx
+++ b/apps/admin/frontend/src/components/smartcard_modal/smartcard_modal.tsx
@@ -36,7 +36,12 @@ export function SmartcardModal(): JSX.Element | null {
     }
     case 'card_error': {
       return (
-        <Modal fullscreen content={<InvalidCardScreen reason="card_error" />} />
+        <Modal
+          fullscreen
+          content={
+            <InvalidCardScreen reasonAndContext={{ reason: 'card_error' }} />
+          }
+        />
       );
     }
     case 'ready': {

--- a/apps/central-scan/frontend/src/app.test.tsx
+++ b/apps/central-scan/frontend/src/app.test.tsx
@@ -454,7 +454,8 @@ test('election manager cannot auth onto machine with different election hash', a
   await screen.findByText('VxCentralScan is Locked');
   setAuthStatus(mockApiClient, {
     status: 'logged_out',
-    reason: 'election_manager_wrong_election',
+    reason: 'wrong_election',
+    cardUserRole: 'election_manager',
   });
   await screen.findByText(
     'The inserted Election Manager card is programmed for another election and cannot be used to unlock this machine. ' +

--- a/apps/central-scan/frontend/src/app_root.tsx
+++ b/apps/central-scan/frontend/src/app_root.tsx
@@ -338,15 +338,16 @@ export function AppRoot({
         </AppContext.Provider>
       );
     }
-    if (authStatus.reason === 'machine_not_configured') {
-      return (
-        <InvalidCardScreen
-          reason={authStatus.reason}
-          recommendedAction="Please insert an Election Manager card."
-        />
-      );
-    }
-    return <InvalidCardScreen reason={authStatus.reason} />;
+    return (
+      <InvalidCardScreen
+        reasonAndContext={authStatus}
+        recommendedAction={
+          authStatus.reason === 'machine_not_configured'
+            ? 'Please insert an Election Manager card.'
+            : 'Please insert a valid Election Manager or System Administrator card.'
+        }
+      />
+    );
   }
 
   if (authStatus.status === 'checking_pin') {

--- a/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
@@ -170,7 +170,8 @@ test('MarkAndPrint end-to-end flow', async () => {
   // Using an invalid Poll Worker Card shows an error
   apiMock.setAuthStatus({
     status: 'logged_out',
-    reason: 'poll_worker_wrong_election',
+    reason: 'wrong_election',
+    cardUserRole: 'poll_worker',
   });
   await screen.findByText('Invalid Card Data');
   screen.getByText('Card is not configured for this election.');

--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -668,7 +668,8 @@ export function AppRoot({
   if (optionalElectionDefinition && precinctSelection) {
     if (
       authStatus.status === 'logged_out' &&
-      authStatus.reason === 'poll_worker_wrong_election'
+      authStatus.reason === 'wrong_election' &&
+      authStatus.cardUserRole === 'poll_worker'
     ) {
       return <WrongElectionScreen />;
     }

--- a/apps/mark/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark/frontend/src/app_end_to_end.test.tsx
@@ -146,7 +146,8 @@ test('MarkAndPrint end-to-end flow', async () => {
   // Using an invalid Poll Worker Card shows an error
   apiMock.setAuthStatus({
     status: 'logged_out',
-    reason: 'poll_worker_wrong_election',
+    reason: 'wrong_election',
+    cardUserRole: 'poll_worker',
   });
   await screen.findByText('Invalid Card Data');
   screen.getByText('Card is not configured for this election.');

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -712,7 +712,8 @@ export function AppRoot({
     }
     if (
       authStatus.status === 'logged_out' &&
-      authStatus.reason === 'poll_worker_wrong_election'
+      authStatus.reason === 'wrong_election' &&
+      authStatus.cardUserRole === 'poll_worker'
     ) {
       return <WrongElectionScreen />;
     }

--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -923,7 +923,8 @@ test('election manager cannot auth onto machine with different election hash', a
 
   apiMock.setAuthStatus({
     status: 'logged_out',
-    reason: 'election_manager_wrong_election',
+    reason: 'wrong_election',
+    cardUserRole: 'election_manager',
   });
   await screen.findByText('Invalid Card');
 });

--- a/apps/scan/frontend/src/app_root.tsx
+++ b/apps/scan/frontend/src/app_root.tsx
@@ -128,7 +128,7 @@ export function AppRoot({
   }
 
   if (authStatus.status === 'logged_out' && authStatus.reason !== 'no_card') {
-    return <InvalidCardScreen />;
+    return <InvalidCardScreen authStatus={authStatus} />;
   }
 
   if (

--- a/apps/scan/frontend/src/app_unhappy_paths.test.tsx
+++ b/apps/scan/frontend/src/app_unhappy_paths.test.tsx
@@ -123,13 +123,15 @@ test.each<{
 
     apiMock.setAuthStatus({
       status: 'logged_out',
-      reason: 'election_manager_wrong_election',
+      reason: 'wrong_election',
+      cardUserRole: 'election_manager',
     });
     await screen.findByText('Invalid Card');
 
     apiMock.setAuthStatus({
       status: 'logged_out',
-      reason: 'poll_worker_wrong_election',
+      reason: 'wrong_election',
+      cardUserRole: 'poll_worker',
     });
     await screen.findByText('Invalid Card');
 

--- a/apps/scan/frontend/src/screens/invalid_card_screen.tsx
+++ b/apps/scan/frontend/src/screens/invalid_card_screen.tsx
@@ -1,11 +1,17 @@
+import { InsertedSmartCardAuth } from '@votingworks/types';
 import { InvalidCardScreen as SharedInvalidCardScreen } from '@votingworks/ui';
+
 import { ScreenMainCenterChild } from '../components/layout';
 
-export function InvalidCardScreen(): JSX.Element {
+export function InvalidCardScreen({
+  authStatus,
+}: {
+  authStatus: InsertedSmartCardAuth.LoggedOut;
+}): JSX.Element {
   return (
     <ScreenMainCenterChild infoBarMode="pollworker">
       <SharedInvalidCardScreen
-        reason="invalid_user_on_card"
+        reasonAndContext={authStatus}
         recommendedAction="Remove the card to continue."
       />
     </ScreenMainCenterChild>
@@ -14,5 +20,9 @@ export function InvalidCardScreen(): JSX.Element {
 
 /* istanbul ignore next */
 export function DefaultPreview(): JSX.Element {
-  return <InvalidCardScreen />;
+  return (
+    <InvalidCardScreen
+      authStatus={{ status: 'logged_out', reason: 'invalid_user_on_card' }}
+    />
+  );
 }

--- a/libs/auth/src/dipped_smart_card_auth.test.ts
+++ b/libs/auth/src/dipped_smart_card_auth.test.ts
@@ -519,6 +519,7 @@ test.each<{
     expectedAuthStatus: {
       status: 'logged_out',
       reason: 'invalid_user_on_card',
+      machineJurisdiction: jurisdiction,
     },
     expectedLog: [
       LogEventId.AuthLogin,
@@ -539,8 +540,10 @@ test.each<{
     },
     expectedAuthStatus: {
       status: 'logged_out',
-      reason: 'invalid_user_on_card',
+      reason: 'wrong_jurisdiction',
+      cardJurisdiction: otherJurisdiction,
       cardUserRole: 'system_administrator',
+      machineJurisdiction: jurisdiction,
     },
     expectedLog: [
       LogEventId.AuthLogin,
@@ -548,7 +551,7 @@ test.each<{
       {
         disposition: LogDispositionStandardTypes.Failure,
         message: 'User failed login.',
-        reason: 'invalid_user_on_card',
+        reason: 'wrong_jurisdiction',
       },
     ],
   },
@@ -575,7 +578,9 @@ test.each<{
     expectedAuthStatus: {
       status: 'logged_out',
       reason: 'user_role_not_allowed',
+      cardJurisdiction: jurisdiction,
       cardUserRole: 'poll_worker',
+      machineJurisdiction: jurisdiction,
     },
     expectedLog: [
       LogEventId.AuthLogin,
@@ -597,7 +602,9 @@ test.each<{
     expectedAuthStatus: {
       status: 'logged_out',
       reason: 'machine_not_configured',
+      cardJurisdiction: jurisdiction,
       cardUserRole: 'election_manager',
+      machineJurisdiction: jurisdiction,
     },
     expectedLog: [
       LogEventId.AuthLogin,
@@ -634,8 +641,10 @@ test.each<{
     },
     expectedAuthStatus: {
       status: 'logged_out',
-      reason: 'election_manager_wrong_election',
+      reason: 'wrong_election',
+      cardJurisdiction: jurisdiction,
       cardUserRole: 'election_manager',
+      machineJurisdiction: jurisdiction,
     },
     expectedLog: [
       LogEventId.AuthLogin,
@@ -643,7 +652,7 @@ test.each<{
       {
         disposition: LogDispositionStandardTypes.Failure,
         message: 'User failed login.',
-        reason: 'election_manager_wrong_election',
+        reason: 'wrong_election',
       },
     ],
   },

--- a/libs/auth/src/dipped_smart_card_auth.ts
+++ b/libs/auth/src/dipped_smart_card_auth.ts
@@ -479,7 +479,9 @@ export class DippedSmartCardAuth implements DippedSmartCardAuthApi {
                 return {
                   status: 'logged_out',
                   reason: validationResult.err(),
+                  cardJurisdiction: cardDetails?.user.jurisdiction,
                   cardUserRole: cardDetails?.user.role,
+                  machineJurisdiction: machineState.jurisdiction,
                 };
               }
               /* istanbul ignore next: Compile-time check for completeness */
@@ -607,7 +609,7 @@ export class DippedSmartCardAuth implements DippedSmartCardAuthApi {
       machineState.jurisdiction &&
       user.jurisdiction !== machineState.jurisdiction
     ) {
-      return err('invalid_user_on_card');
+      return err('wrong_jurisdiction');
     }
 
     if (!['system_administrator', 'election_manager'].includes(user.role)) {
@@ -621,7 +623,7 @@ export class DippedSmartCardAuth implements DippedSmartCardAuthApi {
           : err('machine_not_configured');
       }
       if (user.electionHash !== machineState.electionHash) {
-        return err('election_manager_wrong_election');
+        return err('wrong_election');
       }
     }
 

--- a/libs/auth/src/inserted_smart_card_auth.test.ts
+++ b/libs/auth/src/inserted_smart_card_auth.test.ts
@@ -570,6 +570,7 @@ test.each<{
     expectedAuthStatus: {
       status: 'logged_out',
       reason: 'invalid_user_on_card',
+      machineJurisdiction: jurisdiction,
     },
     expectedLog: [
       LogEventId.AuthLogin,
@@ -590,8 +591,10 @@ test.each<{
     },
     expectedAuthStatus: {
       status: 'logged_out',
-      reason: 'invalid_user_on_card',
+      reason: 'wrong_jurisdiction',
+      cardJurisdiction: otherJurisdiction,
       cardUserRole: 'system_administrator',
+      machineJurisdiction: jurisdiction,
     },
     expectedLog: [
       LogEventId.AuthLogin,
@@ -599,7 +602,7 @@ test.each<{
       {
         disposition: LogDispositionStandardTypes.Failure,
         message: 'User failed login.',
-        reason: 'invalid_user_on_card',
+        reason: 'wrong_jurisdiction',
       },
     ],
   },
@@ -638,7 +641,9 @@ test.each<{
     expectedAuthStatus: {
       status: 'logged_out',
       reason: 'machine_not_configured',
+      cardJurisdiction: jurisdiction,
       cardUserRole: 'poll_worker',
+      machineJurisdiction: jurisdiction,
     },
     expectedLog: [
       LogEventId.AuthLogin,
@@ -659,8 +664,10 @@ test.each<{
     },
     expectedAuthStatus: {
       status: 'logged_out',
-      reason: 'election_manager_wrong_election',
+      reason: 'wrong_election',
+      cardJurisdiction: jurisdiction,
       cardUserRole: 'election_manager',
+      machineJurisdiction: jurisdiction,
     },
     expectedLog: [
       LogEventId.AuthLogin,
@@ -668,7 +675,7 @@ test.each<{
       {
         disposition: LogDispositionStandardTypes.Failure,
         message: 'User failed login.',
-        reason: 'election_manager_wrong_election',
+        reason: 'wrong_election',
       },
     ],
   },
@@ -699,8 +706,10 @@ test.each<{
     },
     expectedAuthStatus: {
       status: 'logged_out',
-      reason: 'poll_worker_wrong_election',
+      reason: 'wrong_election',
+      cardJurisdiction: jurisdiction,
       cardUserRole: 'poll_worker',
+      machineJurisdiction: jurisdiction,
     },
     expectedLog: [
       LogEventId.AuthLogin,
@@ -708,7 +717,7 @@ test.each<{
       {
         disposition: LogDispositionStandardTypes.Failure,
         message: 'User failed login.',
-        reason: 'poll_worker_wrong_election',
+        reason: 'wrong_election',
       },
     ],
   },
@@ -727,7 +736,9 @@ test.each<{
     expectedAuthStatus: {
       status: 'logged_out',
       reason: 'invalid_user_on_card',
+      cardJurisdiction: jurisdiction,
       cardUserRole: 'poll_worker',
+      machineJurisdiction: jurisdiction,
     },
     expectedLog: [
       LogEventId.AuthLogin,
@@ -751,7 +762,9 @@ test.each<{
     expectedAuthStatus: {
       status: 'logged_out',
       reason: 'invalid_user_on_card',
+      cardJurisdiction: jurisdiction,
       cardUserRole: 'poll_worker',
+      machineJurisdiction: jurisdiction,
     },
     expectedLog: [
       LogEventId.AuthLogin,

--- a/libs/auth/src/inserted_smart_card_auth.ts
+++ b/libs/auth/src/inserted_smart_card_auth.ts
@@ -415,7 +415,9 @@ export class InsertedSmartCardAuth implements InsertedSmartCardAuthApi {
             return {
               status: 'logged_out',
               reason: validationResult.err(),
+              cardJurisdiction: cardDetails?.user.jurisdiction,
               cardUserRole: cardDetails?.user.role,
+              machineJurisdiction: machineState.jurisdiction,
             };
           }
           /* istanbul ignore next: Compile-time check for completeness */
@@ -508,7 +510,7 @@ export class InsertedSmartCardAuth implements InsertedSmartCardAuthApi {
       machineState.jurisdiction &&
       user.jurisdiction !== machineState.jurisdiction
     ) {
-      return err('invalid_user_on_card');
+      return err('wrong_jurisdiction');
     }
 
     if (user.role === 'election_manager') {
@@ -520,7 +522,7 @@ export class InsertedSmartCardAuth implements InsertedSmartCardAuthApi {
         !this.config
           .allowElectionManagersToAccessMachinesConfiguredForOtherElections
       ) {
-        return err('election_manager_wrong_election');
+        return err('wrong_election');
       }
     }
 
@@ -529,7 +531,7 @@ export class InsertedSmartCardAuth implements InsertedSmartCardAuthApi {
         return err('machine_not_configured');
       }
       if (user.electionHash !== machineState.electionHash) {
-        return err('poll_worker_wrong_election');
+        return err('wrong_election');
       }
       // If a poll worker card doesn't have a PIN but poll worker card PINs are enabled, treat the
       // card as unprogrammed. And vice versa. If a poll worker card does have a PIN but poll

--- a/libs/types/src/auth/dipped_smart_card_auth.ts
+++ b/libs/types/src/auth/dipped_smart_card_auth.ts
@@ -1,7 +1,6 @@
 import {
   ElectionManagerUser,
   SystemAdministratorUser,
-  UserRole,
   UserWithCard,
 } from './auth';
 
@@ -9,12 +8,15 @@ export interface LoggedOut {
   readonly status: 'logged_out';
   readonly reason:
     | 'card_error'
-    | 'election_manager_wrong_election'
     | 'invalid_user_on_card'
     | 'machine_locked'
     | 'machine_not_configured'
-    | 'user_role_not_allowed';
-  readonly cardUserRole?: UserRole;
+    | 'user_role_not_allowed'
+    | 'wrong_election'
+    | 'wrong_jurisdiction';
+  readonly cardJurisdiction?: string;
+  readonly cardUserRole?: UserWithCard['role'];
+  readonly machineJurisdiction?: string;
 }
 
 export interface CheckingPin {

--- a/libs/types/src/auth/inserted_smart_card_auth.ts
+++ b/libs/types/src/auth/inserted_smart_card_auth.ts
@@ -3,19 +3,21 @@ import {
   ElectionManagerUser,
   PollWorkerUser,
   SystemAdministratorUser,
-  UserRole,
+  UserWithCard,
 } from './auth';
 
 export interface LoggedOut {
   readonly status: 'logged_out';
   readonly reason:
     | 'card_error'
-    | 'election_manager_wrong_election'
     | 'invalid_user_on_card'
     | 'machine_not_configured'
     | 'no_card'
-    | 'poll_worker_wrong_election';
-  readonly cardUserRole?: UserRole;
+    | 'wrong_election'
+    | 'wrong_jurisdiction';
+  readonly cardJurisdiction?: string;
+  readonly cardUserRole?: UserWithCard['role'];
+  readonly machineJurisdiction?: string;
 }
 
 export interface CheckingPin {

--- a/libs/ui/src/invalid_card_screen.test.tsx
+++ b/libs/ui/src/invalid_card_screen.test.tsx
@@ -4,37 +4,48 @@ import { InvalidCardScreen, Props } from './invalid_card_screen';
 
 const testCases: Array<{
   description: string;
-  reason: Props['reason'];
+  reasonAndContext: Props['reasonAndContext'];
   recommendedAction?: string;
   expectedHeading: string;
   expectedText: string;
 }> = [
   {
     description: 'card is backwards',
-    reason: 'card_error',
+    reasonAndContext: {
+      reason: 'card_error',
+    },
     expectedHeading: 'Card is Backwards',
     expectedText: 'Remove the card, turn it around, and insert it again.',
   },
   {
     description:
       'election manager card election hash does not match machine election hash',
-    reason: 'election_manager_wrong_election',
+    reasonAndContext: {
+      reason: 'wrong_election',
+      cardUserRole: 'election_manager',
+    },
     expectedHeading: 'Invalid Card',
     expectedText:
       'The inserted Election Manager card is programmed for another election and cannot be used to unlock this machine. ' +
-      'Please insert a valid Election Manager or System Administrator card.',
+      'Please insert a valid card.',
+  },
+  {
+    description:
+      'poll worker card election hash does not match machine election hash',
+    reasonAndContext: {
+      reason: 'wrong_election',
+      cardUserRole: 'poll_worker',
+    },
+    expectedHeading: 'Invalid Card',
+    expectedText:
+      'The inserted Poll Worker card is programmed for another election and cannot be used to unlock this machine. ' +
+      'Please insert a valid card.',
   },
   {
     description: 'machine not configured',
-    reason: 'machine_not_configured',
-    expectedHeading: 'Invalid Card',
-    expectedText:
-      'This machine is unconfigured and cannot be unlocked with this card. ' +
-      'Please insert a valid Election Manager or System Administrator card.',
-  },
-  {
-    description: 'machine not configured, custom recommended action',
-    reason: 'machine_not_configured',
+    reasonAndContext: {
+      reason: 'machine_not_configured',
+    },
     recommendedAction: 'Please insert a System Administrator card.',
     expectedHeading: 'Invalid Card',
     expectedText:
@@ -42,20 +53,44 @@ const testCases: Array<{
       'Please insert a System Administrator card.',
   },
   {
-    description: 'other error',
-    reason: 'invalid_user_on_card',
+    description: 'machine not configured, custom recommended action',
+    reasonAndContext: {
+      reason: 'machine_not_configured',
+    },
+    recommendedAction: 'Please insert a System Administrator card.',
     expectedHeading: 'Invalid Card',
     expectedText:
-      'Please insert a valid Election Manager or System Administrator card.',
+      'This machine is unconfigured and cannot be unlocked with this card. ' +
+      'Please insert a System Administrator card.',
+  },
+  {
+    description: 'card jurisdiction does not match machine jurisdiction',
+    reasonAndContext: {
+      reason: 'wrong_jurisdiction',
+      cardJurisdiction: 'some-jurisdiction',
+      machineJurisdiction: 'another-jurisdiction',
+    },
+    expectedHeading: 'Invalid Card',
+    expectedText:
+      'The inserted card’s jurisdiction (some-jurisdiction) does not match this machine’s jurisdiction (another-jurisdiction). ' +
+      'Please insert a valid card.',
+  },
+  {
+    description: 'other error',
+    reasonAndContext: {
+      reason: 'invalid_user_on_card',
+    },
+    expectedHeading: 'Invalid Card',
+    expectedText: 'Please insert a valid card.',
   },
 ];
 
 test.each(testCases)(
   'InvalidCardScreen renders expected text ($description)',
-  ({ reason, recommendedAction, expectedHeading, expectedText }) => {
+  ({ reasonAndContext, recommendedAction, expectedHeading, expectedText }) => {
     render(
       <InvalidCardScreen
-        reason={reason}
+        reasonAndContext={reasonAndContext}
         recommendedAction={recommendedAction}
       />
     );

--- a/libs/ui/src/invalid_card_screen.tsx
+++ b/libs/ui/src/invalid_card_screen.tsx
@@ -1,47 +1,75 @@
 import { DippedSmartCardAuth, InsertedSmartCardAuth } from '@votingworks/types';
 
-import { fontSizeTheme } from './themes';
 import { Main } from './main';
 import { Prose } from './prose';
-import { Screen } from './screen';
 import { RotateCardImage } from './rotate_card_image';
+import { Screen } from './screen';
+import { fontSizeTheme } from './themes';
 import { H1, P } from './typography';
 
-type LoggedOutReason =
-  | DippedSmartCardAuth.LoggedOut['reason']
-  | InsertedSmartCardAuth.LoggedOut['reason'];
+type ReasonAndContext = Pick<
+  DippedSmartCardAuth.LoggedOut | InsertedSmartCardAuth.LoggedOut,
+  'reason' | 'cardJurisdiction' | 'cardUserRole' | 'machineJurisdiction'
+>;
 
 export interface Props {
-  reason: LoggedOutReason;
+  reasonAndContext: ReasonAndContext;
   recommendedAction?: string;
 }
 
 export function InvalidCardScreen({
-  reason,
+  reasonAndContext,
   recommendedAction: recommendedActionOverride,
 }: Props): JSX.Element {
+  const { cardJurisdiction, cardUserRole, machineJurisdiction, reason } =
+    reasonAndContext;
+
   let graphic: JSX.Element | null = null;
   let heading = 'Invalid Card';
   let errorDescription = '';
   let recommendedAction =
-    'Please insert a valid Election Manager or System Administrator card.';
+    recommendedActionOverride ?? 'Please insert a valid card.';
 
-  if (reason === 'card_error') {
-    graphic = <RotateCardImage />;
-    // The only cause we currently know of for a card error
-    heading = 'Card is Backwards';
-    recommendedAction = 'Remove the card, turn it around, and insert it again.';
-  }
-
-  if (reason === 'election_manager_wrong_election') {
-    errorDescription =
-      'The inserted Election Manager card is programmed for another election ' +
-      'and cannot be used to unlock this machine.';
-  }
-
-  if (reason === 'machine_not_configured') {
-    errorDescription =
-      'This machine is unconfigured and cannot be unlocked with this card.';
+  switch (reason) {
+    case 'card_error': {
+      graphic = <RotateCardImage />;
+      // The only cause we currently know of for a card error
+      heading = 'Card is Backwards';
+      recommendedAction =
+        'Remove the card, turn it around, and insert it again.';
+      break;
+    }
+    case 'machine_not_configured': {
+      errorDescription =
+        'This machine is unconfigured and cannot be unlocked with this card.';
+      break;
+    }
+    case 'wrong_election': {
+      const cardString = (() => {
+        switch (cardUserRole) {
+          case 'election_manager':
+            return 'Election Manager card';
+          case 'poll_worker':
+            return 'Poll Worker card';
+          /* istanbul ignore next */
+          default:
+            return 'card';
+        }
+      })();
+      errorDescription =
+        `The inserted ${cardString} is programmed for another election ` +
+        'and cannot be used to unlock this machine.';
+      break;
+    }
+    case 'wrong_jurisdiction': {
+      errorDescription =
+        `The inserted card’s jurisdiction (${cardJurisdiction}) does not match ` +
+        `this machine’s jurisdiction (${machineJurisdiction}).`;
+      break;
+    }
+    default: {
+      break;
+    }
   }
 
   return (
@@ -51,7 +79,7 @@ export function InvalidCardScreen({
         <Prose textCenter themeDeprecated={fontSizeTheme.medium}>
           <H1>{heading}</H1>
           <P>
-            {errorDescription} {recommendedActionOverride || recommendedAction}
+            {errorDescription} {recommendedAction}
           </P>
         </Prose>
       </Main>


### PR DESCRIPTION
_Easiest reviewed by commit_

## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/3615

TODO

## Demo Screenshots

TODO

## Testing Plan

- [x] Automated tests
- [x] Manually tested VxAdmin and VxScan

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced ➡️ Relying on existing logging pathways