### PR TITLE
[i18n/Audio] Use stricter IETF language codes for better translations/audio

### DIFF
--- a/apps/design/backend/scripts/synthesize_speech.ts
+++ b/apps/design/backend/scripts/synthesize_speech.ts
@@ -6,11 +6,7 @@ import { LanguageCode } from '@votingworks/types';
 import { GoogleCloudSpeechSynthesizer } from '../src/language_and_audio/speech_synthesizer';
 import { Store } from '../src/store';
 
-const languageCodes: string[] = [
-  LanguageCode.CHINESE,
-  LanguageCode.ENGLISH,
-  LanguageCode.SPANISH,
-];
+const languageCodes: string[] = Object.values(LanguageCode);
 const usageMessage = `Usage: synthesize-speech 'Text to convert to speech' <language-code> <output-file-path>
 
 Arguments:

--- a/apps/design/backend/scripts/translate_text.ts
+++ b/apps/design/backend/scripts/translate_text.ts
@@ -4,7 +4,11 @@ import { LanguageCode } from '@votingworks/types';
 import { GoogleCloudTranslator } from '../src/language_and_audio/translator';
 import { Store } from '../src/store';
 
-const languageCodes: string[] = [LanguageCode.CHINESE, LanguageCode.SPANISH];
+const languageCodes: Set<string> = (() => {
+  const nonEnglishLanguageCodes = new Set<string>(Object.values(LanguageCode));
+  nonEnglishLanguageCodes.delete(LanguageCode.ENGLISH);
+  return nonEnglishLanguageCodes;
+})();
 const usageMessage = `Usage: translate-text 'Text to translate' <target-language-code>
 
 Arguments:
@@ -16,7 +20,7 @@ interface TranslateTextInput {
 }
 
 function parseCommandLineArgs(args: readonly string[]): TranslateTextInput {
-  if (args.length !== 2 || !languageCodes.includes(args[1])) {
+  if (args.length !== 2 || !languageCodes.has(args[1])) {
     console.log(usageMessage);
     process.exit(0);
   }

--- a/apps/design/backend/src/language_and_audio/speech_synthesizer.ts
+++ b/apps/design/backend/src/language_and_audio/speech_synthesizer.ts
@@ -18,7 +18,14 @@ export const GoogleCloudVoices: Record<
   LanguageCode,
   { languageCode: string; name: string }
 > = {
-  [LanguageCode.CHINESE]: { languageCode: 'cmn-CN', name: 'cmn-CN-Wavenet-B' },
+  [LanguageCode.CHINESE_SIMPLIFIED]: {
+    languageCode: 'cmn-CN',
+    name: 'cmn-CN-Wavenet-B',
+  },
+  [LanguageCode.CHINESE_TRADITIONAL]: {
+    languageCode: 'cmn-CN',
+    name: 'cmn-CN-Wavenet-B',
+  },
   [LanguageCode.ENGLISH]: { languageCode: 'en-US', name: 'en-US-Neural2-J' },
   [LanguageCode.SPANISH]: { languageCode: 'es-US', name: 'es-US-Neural2-B' },
 };

--- a/apps/design/backend/src/language_and_audio/translator.test.ts
+++ b/apps/design/backend/src/language_and_audio/translator.test.ts
@@ -14,8 +14,8 @@ test('GoogleCloudTranslator', async () => {
     LanguageCode.SPANISH
   );
   expect(translatedTextArray).toEqual([
-    'Do you like apples? (in es)',
-    'Do you like oranges? (in es)',
+    `Do you like apples? (in ${LanguageCode.SPANISH})`,
+    `Do you like oranges? (in ${LanguageCode.SPANISH})`,
   ]);
   expect(translationClient.translateText).toHaveBeenCalledTimes(1);
   expect(translationClient.translateText).toHaveBeenNthCalledWith(
@@ -33,9 +33,9 @@ test('GoogleCloudTranslator', async () => {
     LanguageCode.SPANISH
   );
   expect(translatedTextArray).toEqual([
-    'Do you like apples? (in es)',
-    'Do you like bananas? (in es)',
-    'Do you like oranges? (in es)',
+    `Do you like apples? (in ${LanguageCode.SPANISH})`,
+    `Do you like bananas? (in ${LanguageCode.SPANISH})`,
+    `Do you like oranges? (in ${LanguageCode.SPANISH})`,
   ]);
   expect(translationClient.translateText).toHaveBeenCalledTimes(1);
   expect(translationClient.translateText).toHaveBeenNthCalledWith(
@@ -53,9 +53,9 @@ test('GoogleCloudTranslator', async () => {
     LanguageCode.SPANISH
   );
   expect(translatedTextArray).toEqual([
-    'Do you like apples? (in es)',
-    'Do you like bananas? (in es)',
-    'Do you like oranges? (in es)',
+    `Do you like apples? (in ${LanguageCode.SPANISH})`,
+    `Do you like bananas? (in ${LanguageCode.SPANISH})`,
+    `Do you like oranges? (in ${LanguageCode.SPANISH})`,
   ]);
   expect(translationClient.translateText).not.toHaveBeenCalled();
 
@@ -66,9 +66,9 @@ test('GoogleCloudTranslator', async () => {
     LanguageCode.CHINESE_TRADITIONAL
   );
   expect(translatedTextArray).toEqual([
-    'Do you like apples? (in zh)',
-    'Do you like bananas? (in zh)',
-    'Do you like oranges? (in zh)',
+    `Do you like apples? (in ${LanguageCode.CHINESE_TRADITIONAL})`,
+    `Do you like bananas? (in ${LanguageCode.CHINESE_TRADITIONAL})`,
+    `Do you like oranges? (in ${LanguageCode.CHINESE_TRADITIONAL})`,
   ]);
   expect(translationClient.translateText).toHaveBeenCalledTimes(1);
   expect(translationClient.translateText).toHaveBeenNthCalledWith(

--- a/apps/design/backend/src/language_and_audio/translator.test.ts
+++ b/apps/design/backend/src/language_and_audio/translator.test.ts
@@ -63,7 +63,7 @@ test('GoogleCloudTranslator', async () => {
   // been translated to this specific language
   translatedTextArray = await translator.translateText(
     ['Do you like apples?', 'Do you like bananas?', 'Do you like oranges?'],
-    LanguageCode.CHINESE
+    LanguageCode.CHINESE_TRADITIONAL
   );
   expect(translatedTextArray).toEqual([
     'Do you like apples? (in zh)',
@@ -79,7 +79,7 @@ test('GoogleCloudTranslator', async () => {
         'Do you like bananas?',
         'Do you like oranges?',
       ],
-      targetLanguageCode: LanguageCode.CHINESE,
+      targetLanguageCode: LanguageCode.CHINESE_TRADITIONAL,
     })
   );
 });

--- a/apps/design/backend/src/store.test.ts
+++ b/apps/design/backend/src/store.test.ts
@@ -9,7 +9,10 @@ test('Translation cache', () => {
     store.getTranslatedTextFromCache('Happy birthday!', LanguageCode.SPANISH)
   ).toEqual(undefined);
   expect(
-    store.getTranslatedTextFromCache('Happy birthday!', LanguageCode.CHINESE)
+    store.getTranslatedTextFromCache(
+      'Happy birthday!',
+      LanguageCode.CHINESE_TRADITIONAL
+    )
   ).toEqual(undefined);
 
   // Add a Spanish translation
@@ -22,20 +25,26 @@ test('Translation cache', () => {
     store.getTranslatedTextFromCache('Happy birthday!', LanguageCode.SPANISH)
   ).toEqual('¡Feliz cumpleaños!');
   expect(
-    store.getTranslatedTextFromCache('Happy birthday!', LanguageCode.CHINESE)
+    store.getTranslatedTextFromCache(
+      'Happy birthday!',
+      LanguageCode.CHINESE_TRADITIONAL
+    )
   ).toEqual(undefined);
 
   // Add a Chinese translation
   store.addTranslationCacheEntry({
     text: 'Happy birthday!',
-    targetLanguageCode: LanguageCode.CHINESE,
+    targetLanguageCode: LanguageCode.CHINESE_TRADITIONAL,
     translatedText: '生日快乐！',
   });
   expect(
     store.getTranslatedTextFromCache('Happy birthday!', LanguageCode.SPANISH)
   ).toEqual('¡Feliz cumpleaños!');
   expect(
-    store.getTranslatedTextFromCache('Happy birthday!', LanguageCode.CHINESE)
+    store.getTranslatedTextFromCache(
+      'Happy birthday!',
+      LanguageCode.CHINESE_TRADITIONAL
+    )
   ).toEqual('生日快乐！');
 
   // Update the Spanish translation
@@ -48,7 +57,10 @@ test('Translation cache', () => {
     store.getTranslatedTextFromCache('Happy birthday!', LanguageCode.SPANISH)
   ).toEqual('¡Feliz cumpleaños! 🥳');
   expect(
-    store.getTranslatedTextFromCache('Happy birthday!', LanguageCode.CHINESE)
+    store.getTranslatedTextFromCache(
+      'Happy birthday!',
+      LanguageCode.CHINESE_TRADITIONAL
+    )
   ).toEqual('生日快乐！');
 });
 

--- a/libs/backend/src/ui_strings/ui_strings_api_test_runner.ts
+++ b/libs/backend/src/ui_strings/ui_strings_api_test_runner.ts
@@ -21,15 +21,17 @@ export function runUiStringApiTests(params: {
     store.addLanguage(LanguageCode.ENGLISH); // Should be a no-op.
     expect(api.getAvailableLanguages()).toEqual([LanguageCode.ENGLISH]);
 
-    store.addLanguage(LanguageCode.CHINESE);
+    store.addLanguage(LanguageCode.CHINESE_TRADITIONAL);
     expect([...api.getAvailableLanguages()].sort()).toEqual(
-      [LanguageCode.ENGLISH, LanguageCode.CHINESE].sort()
+      [LanguageCode.ENGLISH, LanguageCode.CHINESE_TRADITIONAL].sort()
     );
   });
 
   test('getUiStrings', () => {
     expect(api.getUiStrings({ languageCode: LanguageCode.ENGLISH })).toBeNull();
-    expect(api.getUiStrings({ languageCode: LanguageCode.CHINESE })).toBeNull();
+    expect(
+      api.getUiStrings({ languageCode: LanguageCode.CHINESE_TRADITIONAL })
+    ).toBeNull();
     expect(api.getUiStrings({ languageCode: LanguageCode.SPANISH })).toBeNull();
 
     store.setUiStrings({
@@ -37,14 +39,16 @@ export function runUiStringApiTests(params: {
       data: { foo: 'bar' },
     });
     store.setUiStrings({
-      languageCode: LanguageCode.CHINESE,
+      languageCode: LanguageCode.CHINESE_TRADITIONAL,
       data: { foo: 'bar_zh' },
     });
 
     expect(api.getUiStrings({ languageCode: LanguageCode.ENGLISH })).toEqual({
       foo: 'bar',
     });
-    expect(api.getUiStrings({ languageCode: LanguageCode.CHINESE })).toEqual({
+    expect(
+      api.getUiStrings({ languageCode: LanguageCode.CHINESE_TRADITIONAL })
+    ).toEqual({
       foo: 'bar_zh',
     });
     expect(api.getUiStrings({ languageCode: LanguageCode.SPANISH })).toBeNull();
@@ -71,9 +75,9 @@ export function runUiStringApiTests(params: {
       deeply: { nested: ['321', 'cba'] },
     });
 
-    store.addLanguage(LanguageCode.CHINESE);
+    store.addLanguage(LanguageCode.CHINESE_TRADITIONAL);
     store.setUiStringAudioIds({
-      languageCode: LanguageCode.CHINESE,
+      languageCode: LanguageCode.CHINESE_TRADITIONAL,
       data: {
         foo: ['456', 'def'],
         deeply: { nested: ['654', 'fed'] },
@@ -81,7 +85,9 @@ export function runUiStringApiTests(params: {
     });
 
     expect(
-      api.getUiStringAudioIds({ languageCode: LanguageCode.CHINESE })
+      api.getUiStringAudioIds({
+        languageCode: LanguageCode.CHINESE_TRADITIONAL,
+      })
     ).toEqual({
       foo: ['456', 'def'],
       deeply: { nested: ['654', 'fed'] },

--- a/libs/backend/src/ui_strings/ui_strings_machine_configuration_test_runner.ts
+++ b/libs/backend/src/ui_strings/ui_strings_machine_configuration_test_runner.ts
@@ -64,7 +64,7 @@ export function runUiStringMachineConfigurationTests(
     expect(store.getUiStrings(LanguageCode.SPANISH)).toEqual(
       appStrings[LanguageCode.SPANISH]
     );
-    expect(store.getUiStrings(LanguageCode.CHINESE)).toBeNull();
+    expect(store.getUiStrings(LanguageCode.CHINESE_TRADITIONAL)).toBeNull();
   });
 
   test('is a no-op for missing uiStrings package', async () => {
@@ -86,7 +86,7 @@ export function runUiStringMachineConfigurationTests(
     const uiStringAudioIds: UiStringAudioIdsPackage = {
       [LanguageCode.ENGLISH]: { foo: ['123', 'abc'] },
       [LanguageCode.SPANISH]: { foo: ['456', 'def'] },
-      [LanguageCode.CHINESE]: { foo: ['789', 'fff'] },
+      [LanguageCode.CHINESE_TRADITIONAL]: { foo: ['789', 'fff'] },
     };
 
     await doTestConfigure({ electionDefinition, uiStrings, uiStringAudioIds });
@@ -100,7 +100,9 @@ export function runUiStringMachineConfigurationTests(
     expect(store.getUiStringAudioIds(LanguageCode.SPANISH)).toEqual({
       ...assertDefined(uiStringAudioIds[LanguageCode.SPANISH]),
     });
-    expect(store.getUiStringAudioIds(LanguageCode.CHINESE)).toBeNull();
+    expect(
+      store.getUiStringAudioIds(LanguageCode.CHINESE_TRADITIONAL)
+    ).toBeNull();
   });
 
   test('is a no-op for missing uiStringAudioIds package', async () => {

--- a/libs/types/src/language_code.ts
+++ b/libs/types/src/language_code.ts
@@ -2,8 +2,8 @@ import { z } from 'zod';
 
 /* IETF language tags for supported VxSuite languages.  */
 export enum LanguageCode {
-  CHINESE_SIMPLIFIED = 'zh-HANS',
-  CHINESE_TRADITIONAL = 'zh-HANT',
+  CHINESE_SIMPLIFIED = 'zh-Hans',
+  CHINESE_TRADITIONAL = 'zh-Hant',
   ENGLISH = 'en',
   SPANISH = 'es-US',
 }

--- a/libs/types/src/language_code.ts
+++ b/libs/types/src/language_code.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
 
-/* ISO IETF language tags for supported VxSuite languages.  */
+/* IETF language tags for supported VxSuite languages.  */
 export enum LanguageCode {
   CHINESE_SIMPLIFIED = 'zh-HANS',
   CHINESE_TRADITIONAL = 'zh-HANT',
   ENGLISH = 'en',
-  SPANISH = 'es-419', // Default to Latin-American Spanish, since that's more common in the US.
+  SPANISH = 'es-US',
 }
 
 export const LanguageCodeSchema: z.ZodType<LanguageCode> =

--- a/libs/types/src/language_code.ts
+++ b/libs/types/src/language_code.ts
@@ -1,10 +1,11 @@
 import { z } from 'zod';
 
-/* ISO 639-1 codes for supported VxSuite languages.  */
+/* ISO IETF language tags for supported VxSuite languages.  */
 export enum LanguageCode {
-  CHINESE = 'zh',
+  CHINESE_SIMPLIFIED = 'zh-HANS',
+  CHINESE_TRADITIONAL = 'zh-HANT',
   ENGLISH = 'en',
-  SPANISH = 'es',
+  SPANISH = 'es-419', // Default to Latin-American Spanish, since that's more common in the US.
 }
 
 export const LanguageCodeSchema: z.ZodType<LanguageCode> =

--- a/libs/types/src/ui_string_audio_clips.test.ts
+++ b/libs/types/src/ui_string_audio_clips.test.ts
@@ -7,7 +7,7 @@ test('valid structure', () => {
     JSON.stringify({
       dataBase64: 'test data',
       id: 'testKey',
-      languageCode: LanguageCode.CHINESE,
+      languageCode: LanguageCode.CHINESE_TRADITIONAL,
     }),
     UiStringAudioClipSchema
   );
@@ -16,7 +16,7 @@ test('valid structure', () => {
   expect(result.ok()).toEqual({
     dataBase64: 'test data',
     id: 'testKey',
-    languageCode: LanguageCode.CHINESE,
+    languageCode: LanguageCode.CHINESE_TRADITIONAL,
   });
 });
 

--- a/libs/ui/src/hooks/ui_strings_api.test.tsx
+++ b/libs/ui/src/hooks/ui_strings_api.test.tsx
@@ -37,7 +37,7 @@ test('getAvailableLanguages', async () => {
   // Simulate configuring an election:
   await act(async () => {
     mockApiClient.getAvailableLanguages.mockResolvedValueOnce([
-      LanguageCode.CHINESE,
+      LanguageCode.CHINESE_TRADITIONAL,
       LanguageCode.SPANISH,
     ]);
     await api.onMachineConfigurationChange(queryClient);
@@ -45,7 +45,7 @@ test('getAvailableLanguages', async () => {
 
   await waitFor(() => expect(result.current.isLoading).toEqual(false));
   expect(result.current.data).toEqual([
-    LanguageCode.CHINESE,
+    LanguageCode.CHINESE_TRADITIONAL,
     LanguageCode.SPANISH,
   ]);
 

--- a/libs/ui/src/ui_strings/language_context.test.tsx
+++ b/libs/ui/src/ui_strings/language_context.test.tsx
@@ -15,7 +15,7 @@ beforeEach(() => {
 
   mockBackendApi.getAvailableLanguages.mockResolvedValueOnce([
     LanguageCode.ENGLISH,
-    LanguageCode.CHINESE,
+    LanguageCode.CHINESE_TRADITIONAL,
   ]);
 
   mockBackendApi.getUiStrings.mockImplementation(({ languageCode }) =>
@@ -29,7 +29,7 @@ test('availableLanguages', async () => {
   await waitFor(() => expect(getLanguageContext()).toBeDefined());
   expect(getLanguageContext()?.availableLanguages).toEqual([
     LanguageCode.ENGLISH,
-    LanguageCode.CHINESE,
+    LanguageCode.CHINESE_TRADITIONAL,
   ]);
 });
 
@@ -48,17 +48,19 @@ test('setLanguage', async () => {
     )
   ).toEqual(TEST_UI_STRING_TRANSLATIONS[DEFAULT_LANGUAGE_CODE]);
 
-  act(() => getLanguageContext()?.setLanguage(LanguageCode.CHINESE));
+  act(
+    () => getLanguageContext()?.setLanguage(LanguageCode.CHINESE_TRADITIONAL)
+  );
 
   await waitFor(() =>
     expect(getLanguageContext()?.currentLanguageCode).toEqual(
-      LanguageCode.CHINESE
+      LanguageCode.CHINESE_TRADITIONAL
     )
   );
   expect(
     getLanguageContext()?.i18next.getResourceBundle(
-      LanguageCode.CHINESE,
+      LanguageCode.CHINESE_TRADITIONAL,
       DEFAULT_I18NEXT_NAMESPACE
     )
-  ).toEqual(TEST_UI_STRING_TRANSLATIONS[LanguageCode.CHINESE]);
+  ).toEqual(TEST_UI_STRING_TRANSLATIONS[LanguageCode.CHINESE_TRADITIONAL]);
 });

--- a/libs/ui/src/ui_strings/number_string.test.tsx
+++ b/libs/ui/src/ui_strings/number_string.test.tsx
@@ -22,7 +22,8 @@ test('formats based on current language code', async () => {
 
   await screen.findByRole('heading', { name: '100,000' });
 
-  act(() => getLanguageContext()?.setLanguage(LanguageCode.SPANISH));
+  // Force-cast a non-Vx language to test locale-specific formatting:
+  act(() => getLanguageContext()?.setLanguage('es-ES' as LanguageCode));
 
   await screen.findByRole('heading', { name: '100.000' });
 });

--- a/libs/ui/src/ui_strings/ui_string.stories.tsx
+++ b/libs/ui/src/ui_strings/ui_string.stories.tsx
@@ -65,7 +65,7 @@ const uiStringsApi: UiStringsReactQueryApi = createUiStringsApi(() => ({
   getAvailableLanguages: () =>
     Promise.resolve([
       LanguageCode.ENGLISH,
-      LanguageCode.CHINESE,
+      LanguageCode.CHINESE_TRADITIONAL,
       LanguageCode.SPANISH,
     ]),
   getUiStringAudioIds: () => Promise.reject(new Error('not yet implemented')),

--- a/libs/ui/test/ui_strings/test_strings.tsx
+++ b/libs/ui/test/ui_strings/test_strings.tsx
@@ -18,7 +18,7 @@ export const TEST_UI_STRING_TRANSLATIONS: UiStringsPackage = {
       planet9: 'Pluto', // #NeverForget
     },
   },
-  [LanguageCode.CHINESE]: {
+  [LanguageCode.CHINESE_TRADITIONAL]: {
     [`numPlanets_one`]: '只有<2>{{count}}</2>個行星。',
     [`numPlanets_other`]: '有 <2>{{count}}</2> 個行星。',
     planetName: {

--- a/libs/utils/src/ballot_package.test.ts
+++ b/libs/utils/src/ballot_package.test.ts
@@ -65,7 +65,7 @@ test('readBallotPackageFromFile loads available ui strings', async () => {
       foo: 'bar',
       deeply: { nested: 'value' },
     },
-    [LanguageCode.CHINESE]: {
+    [LanguageCode.CHINESE_TRADITIONAL]: {
       foo: 'bar_zh',
       deeply: { nested: 'value_zh' },
     },
@@ -84,8 +84,8 @@ test('readBallotPackageFromFile loads available ui strings', async () => {
       ...assertDefined(appStrings[LanguageCode.ENGLISH]),
       ...assertDefined(expectedElectionStrings[LanguageCode.ENGLISH]),
     },
-    [LanguageCode.CHINESE]: {
-      ...assertDefined(appStrings[LanguageCode.CHINESE]),
+    [LanguageCode.CHINESE_TRADITIONAL]: {
+      ...assertDefined(appStrings[LanguageCode.CHINESE_TRADITIONAL]),
     },
   };
 
@@ -151,7 +151,7 @@ test('readBallotPackageFromFile loads UI string audio IDs', async () => {
       foo: ['123', 'abc'],
       deeply: { nested: ['321', 'cba'] },
     },
-    [LanguageCode.CHINESE]: {
+    [LanguageCode.CHINESE_TRADITIONAL]: {
       foo: ['456', 'def'],
       deeply: { nested: ['654', 'fed'] },
     },
@@ -166,8 +166,8 @@ test('readBallotPackageFromFile loads UI string audio IDs', async () => {
     [LanguageCode.ENGLISH]: {
       ...assertDefined(audioIds[LanguageCode.ENGLISH]),
     },
-    [LanguageCode.CHINESE]: {
-      ...assertDefined(audioIds[LanguageCode.CHINESE]),
+    [LanguageCode.CHINESE_TRADITIONAL]: {
+      ...assertDefined(audioIds[LanguageCode.CHINESE_TRADITIONAL]),
     },
   };
 

--- a/libs/utils/src/extract_cdf_ui_strings.test.ts
+++ b/libs/utils/src/extract_cdf_ui_strings.test.ts
@@ -132,7 +132,7 @@ const tests: Record<ElectionStringKey, () => void> = {
               '@type': 'BallotDefinition.BallotMeasureContest',
               FullText: buildInternationalizedText({
                 [LanguageCode.ENGLISH]: 'Would you like apples or oranges?',
-                [LanguageCode.CHINESE]: '你想要蘋果還是橘子？',
+                [LanguageCode.CHINESE_TRADITIONAL]: '你想要蘋果還是橘子？',
                 unsupported_lang: '🍎🍊',
               }),
               ContestOption: [],
@@ -143,7 +143,7 @@ const tests: Record<ElectionStringKey, () => void> = {
               '@type': 'BallotDefinition.BallotMeasureContest',
               FullText: buildInternationalizedText({
                 [LanguageCode.ENGLISH]: 'Would you like olives or pickles?',
-                [LanguageCode.CHINESE]: '您想要橄欖還是泡菜？',
+                [LanguageCode.CHINESE_TRADITIONAL]: '您想要橄欖還是泡菜？',
                 unsupported_lang: '🫒🥒',
               }),
               ContestOption: [],
@@ -160,7 +160,7 @@ const tests: Record<ElectionStringKey, () => void> = {
           contest2: 'Would you like olives or pickles?',
         },
       }),
-      [LanguageCode.CHINESE]: expect.objectContaining({
+      [LanguageCode.CHINESE_TRADITIONAL]: expect.objectContaining({
         [ElectionStringKey.CONTEST_DESCRIPTION]: {
           contest1: '你想要蘋果還是橘子？',
           contest2: '您想要橄欖還是泡菜？',
@@ -267,7 +267,7 @@ const tests: Record<ElectionStringKey, () => void> = {
               '@id': 'contest1',
               BallotTitle: buildInternationalizedText({
                 [LanguageCode.ENGLISH]: 'President',
-                [LanguageCode.CHINESE]: '總統',
+                [LanguageCode.CHINESE_TRADITIONAL]: '總統',
                 unsupported_lang: '🗳✅',
               }),
             },
@@ -276,7 +276,7 @@ const tests: Record<ElectionStringKey, () => void> = {
               '@id': 'contest2',
               BallotTitle: buildInternationalizedText({
                 [LanguageCode.ENGLISH]: 'Mayor',
-                [LanguageCode.CHINESE]: '市長',
+                [LanguageCode.CHINESE_TRADITIONAL]: '市長',
                 unsupported_lang: '🗳✅',
               }),
             },
@@ -292,7 +292,7 @@ const tests: Record<ElectionStringKey, () => void> = {
           contest2: 'Mayor',
         },
       }),
-      [LanguageCode.CHINESE]: expect.objectContaining({
+      [LanguageCode.CHINESE_TRADITIONAL]: expect.objectContaining({
         [ElectionStringKey.CONTEST_TITLE]: {
           contest1: '總統',
           contest2: '市長',

--- a/libs/utils/src/format.test.ts
+++ b/libs/utils/src/format.test.ts
@@ -16,7 +16,8 @@ test('formats counts properly', () => {
   expect(format.count(-1000000)).toEqual('-1,000,000');
   expect(format.count(-3141098210928)).toEqual('-3,141,098,210,928');
   expect(format.count(40240, LanguageCode.ENGLISH)).toEqual('40,240');
-  expect(format.count(40240, LanguageCode.SPANISH)).toEqual('40.240');
+  // Force-cast a non-Vx language to test locale-specific formatting:
+  expect(format.count(40240, 'es-ES' as LanguageCode)).toEqual('40.240');
 });
 
 test('formats locale long date and time properly', () => {
@@ -50,7 +51,7 @@ test('formats locale long date properly', () => {
   expect(
     format.localeLongDate(
       new Date(2020, 3, 14, 1, 15, 9, 26),
-      LanguageCode.CHINESE
+      LanguageCode.CHINESE_TRADITIONAL
     )
   ).toEqual('2020年4月14日');
 });

--- a/libs/utils/src/format.test.ts
+++ b/libs/utils/src/format.test.ts
@@ -16,6 +16,7 @@ test('formats counts properly', () => {
   expect(format.count(-1000000)).toEqual('-1,000,000');
   expect(format.count(-3141098210928)).toEqual('-3,141,098,210,928');
   expect(format.count(40240, LanguageCode.ENGLISH)).toEqual('40,240');
+  expect(format.count(40240, LanguageCode.SPANISH)).toEqual('40,240');
   // Force-cast a non-Vx language to test locale-specific formatting:
   expect(format.count(40240, 'es-ES' as LanguageCode)).toEqual('40.240');
 });


### PR DESCRIPTION
## Overview

Using more explicit `xx-YY...` language codes, where relevant, to enable better translations and formatting (noticed `'es'` defaults to `'es-ES'` when formatting numbers, for example, which means we end up with `4.096` instead of the more common `4,096` in the Americas).

Also adding both 'Simplified' and 'Traditional' variants of Chinese language codes.

## Testing Plan
- Updated existing tests

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
