### PR TITLE
feature(export-logs): export all historical logs at new location.

### DIFF
--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -41,7 +41,7 @@ import {
 } from '@votingworks/utils';
 import { dirSync } from 'tmp';
 import ZipStream from 'zip-stream';
-import { ExportDataError } from '@votingworks/backend';
+import { ExportDataError, createLogsApi } from '@votingworks/backend';
 import { UsbDrive, UsbDriveStatus } from '@votingworks/usb-drive';
 import {
   CastVoteRecordFileRecord,
@@ -778,6 +778,8 @@ function buildApi({
         store,
       });
     },
+
+    ...createLogsApi({ usbDrive, machineId: getMachineConfig().machineId }),
   });
 }
 

--- a/apps/admin/frontend/package.json
+++ b/apps/admin/frontend/package.json
@@ -54,6 +54,7 @@
   "dependencies": {
     "@tanstack/react-query": "4.32.1",
     "@tanstack/react-query-devtools": "4.32.1",
+    "@votingworks/backend": "workspace:*",
     "@votingworks/ballot-encoder": "workspace:*",
     "@votingworks/basics": "workspace:*",
     "@votingworks/dev-dock-frontend": "workspace:*",

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -672,3 +672,10 @@ export const saveBallotPackageToUsb = {
     return useMutation(apiClient.saveBallotPackageToUsb);
   },
 } as const;
+
+export const exportLogsToUsb = {
+  useMutation() {
+    const apiClient = useApiClient();
+    return useMutation(apiClient.exportLogsToUsb);
+  },
+} as const;

--- a/apps/admin/frontend/src/app.test.tsx
+++ b/apps/admin/frontend/src/app.test.tsx
@@ -118,13 +118,12 @@ test('configuring with a demo election definition', async () => {
 
   await screen.findByText('Election Definition');
 
-  // You can view the Logs screen and save log files when there is an election.
+  // You can view the Logs screen and save log files
   fireEvent.click(screen.getByText('Logs'));
   fireEvent.click(screen.getByText('Save Log File'));
-  await screen.findByText('No Log File Present');
-  fireEvent.click(screen.getByText('Close'));
-  fireEvent.click(screen.getByText('Save CDF Log File'));
-  await screen.findByText('No Log File Present');
+  await screen.findByText('No USB Drive Detected');
+  apiMock.expectGetUsbDriveStatus('mounted');
+  await screen.findByText('Save logs on the inserted USB drive?');
 
   fireEvent.click(getByText('Definition'));
 
@@ -142,12 +141,9 @@ test('configuring with a demo election definition', async () => {
 
   // You can view the Logs screen and save log files when there is no election.
   fireEvent.click(screen.getByText('Logs'));
+  await screen.findByText('Save Log File');
   fireEvent.click(screen.getByText('Save Log File'));
-  await screen.findByText('No Log File Present');
-  fireEvent.click(screen.getByText('Close'));
-  fireEvent.click(screen.getByText('Save CDF Log File'));
-  // You can not save as CDF when there is no election.
-  expect(screen.queryAllByText('No Log File Present')).toHaveLength(0);
+  await screen.findByText('Save logs on the inserted USB drive?');
 
   userEvent.click(screen.getByText('Definition'));
   await screen.findByText('Load Demo Election Definition');

--- a/apps/admin/frontend/src/screens/logs_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/logs_screen.test.tsx
@@ -1,7 +1,8 @@
-import userEvent from '@testing-library/user-event';
 import { fakeKiosk } from '@votingworks/test-utils';
+import { ok } from '@votingworks/basics';
+import { mockUsbDriveStatus } from '@votingworks/ui';
+import userEvent from '@testing-library/user-event';
 import { screen } from '../../test/react_testing_library';
-
 import { LogsScreen } from './logs_screen';
 import { renderInAppContext } from '../../test/render_in_app_context';
 import { ApiMock, createApiMock } from '../../test/helpers/mock_api_client';
@@ -20,28 +21,15 @@ afterEach(() => {
 });
 
 test('Exporting logs', async () => {
-  renderInAppContext(<LogsScreen />, { apiMock });
+  renderInAppContext(<LogsScreen />, {
+    apiMock,
+    usbDriveStatus: mockUsbDriveStatus('mounted'),
+  });
+
+  apiMock.apiClient.exportLogsToUsb.expectCallWith().resolves(ok());
 
   // Log saving is tested fully in src/components/export_logs_modal.test.tsx
   userEvent.click(screen.getByText('Save Log File'));
-  await screen.findByText('No Log File Present');
-  userEvent.click(screen.getByText('Close'));
-
-  // Log saving is tested fully in src/components/export_logs_modal.test.tsx
-  userEvent.click(screen.getByText('Save CDF Log File'));
-  await screen.findByText('No Log File Present');
-  userEvent.click(screen.getByText('Close'));
-});
-
-test('Exporting logs when no election definition', async () => {
-  renderInAppContext(<LogsScreen />, { electionDefinition: 'NONE', apiMock });
-
-  // Log saving is tested fully in src/components/export_logs_modal.test.tsx
-  userEvent.click(screen.getByText('Save Log File'));
-  await screen.findByText('No Log File Present');
-  userEvent.click(screen.getByText('Close'));
-
-  expect(
-    screen.getByText('Save CDF Log File').closest('button')
-  ).toHaveAttribute('disabled');
+  await screen.findByText('Save logs on the inserted USB drive?');
+  userEvent.click(screen.getByText('Save'));
 });

--- a/apps/admin/frontend/src/screens/logs_screen.tsx
+++ b/apps/admin/frontend/src/screens/logs_screen.tsx
@@ -1,21 +1,32 @@
 import { useContext } from 'react';
 import { ExportLogsButtonRow } from '@votingworks/ui';
+import { err } from '@votingworks/basics';
+import { LogsResultType } from '@votingworks/backend';
+import { exportLogsToUsb } from '../api';
 
 import { AppContext } from '../contexts/app_context';
 import { NavigationScreen } from '../components/navigation_screen';
 
 export function LogsScreen(): JSX.Element {
-  const { electionDefinition, usbDriveStatus, auth, logger, machineConfig } =
-    useContext(AppContext);
+  const { usbDriveStatus, auth, logger } = useContext(AppContext);
+
+  const exportLogsToUsbMutation = exportLogsToUsb.useMutation();
+
+  async function doExportLogs(): Promise<LogsResultType> {
+    try {
+      return await exportLogsToUsbMutation.mutateAsync();
+    } catch (e) {
+      return err('copy-failed');
+    }
+  }
 
   return (
     <NavigationScreen title="Logs">
       <ExportLogsButtonRow
-        electionDefinition={electionDefinition}
         usbDriveStatus={usbDriveStatus}
         auth={auth}
         logger={logger}
-        machineConfig={machineConfig}
+        onExportLogs={doExportLogs}
       />
     </NavigationScreen>
   );

--- a/apps/central-scan/backend/src/app.ts
+++ b/apps/central-scan/backend/src/app.ts
@@ -5,6 +5,7 @@ import {
 } from '@votingworks/auth';
 import { Result, assert, assertDefined, ok } from '@votingworks/basics';
 import {
+  createLogsApi,
   readBallotPackageFromUsb,
   exportCastVoteRecordsToUsbDrive,
 } from '@votingworks/backend';
@@ -25,6 +26,7 @@ import { useDevDockRouter } from '@votingworks/dev-dock-backend';
 import { UsbDrive, UsbDriveStatus } from '@votingworks/usb-drive';
 import { Importer } from './importer';
 import { Workspace } from './util/workspace';
+import { getMachineConfig } from './machine_config';
 
 type NoParams = never;
 
@@ -256,6 +258,8 @@ function buildApi({
       }
       return exportResult;
     },
+
+    ...createLogsApi({ usbDrive, machineId: getMachineConfig().machineId }),
   });
 }
 

--- a/apps/central-scan/backend/src/env.d.ts
+++ b/apps/central-scan/backend/src/env.d.ts
@@ -4,5 +4,7 @@ declare namespace NodeJS {
     readonly NODE_ENV: 'development' | 'production' | 'test';
     readonly PORT?: string;
     readonly SCAN_WORKSPACE?: string;
+    readonly VX_MACHINE_ID?: string;
+    readonly VX_CODE_VERSION?: string;
   }
 }

--- a/apps/central-scan/backend/src/machine_config.ts
+++ b/apps/central-scan/backend/src/machine_config.ts
@@ -1,0 +1,8 @@
+import { MachineConfig } from './types';
+
+export function getMachineConfig(): MachineConfig {
+  return {
+    machineId: process.env.VX_MACHINE_ID || '0000',
+    codeVersion: process.env.VX_CODE_VERSION || 'dev',
+  };
+}

--- a/apps/central-scan/backend/src/types.ts
+++ b/apps/central-scan/backend/src/types.ts
@@ -1,0 +1,4 @@
+export interface MachineConfig {
+  machineId: string;
+  codeVersion: string;
+}

--- a/apps/central-scan/frontend/package.json
+++ b/apps/central-scan/frontend/package.json
@@ -50,6 +50,7 @@
   "dependencies": {
     "@tanstack/react-query": "4.32.1",
     "@votingworks/api": "workspace:*",
+    "@votingworks/backend": "workspace:*",
     "@votingworks/basics": "workspace:*",
     "@votingworks/dev-dock-frontend": "workspace:*",
     "@votingworks/grout": "workspace:*",

--- a/apps/central-scan/frontend/src/api.ts
+++ b/apps/central-scan/frontend/src/api.ts
@@ -212,3 +212,10 @@ export const exportCastVoteRecordsToUsbDrive = {
     return useMutation(apiClient.exportCastVoteRecordsToUsbDrive);
   },
 } as const;
+
+export const exportLogsToUsb = {
+  useMutation() {
+    const apiClient = useApiClient();
+    return useMutation(apiClient.exportLogsToUsb);
+  },
+} as const;

--- a/apps/central-scan/frontend/src/app_root.tsx
+++ b/apps/central-scan/frontend/src/app_root.tsx
@@ -440,7 +440,6 @@ export function AppRoot({
           <AdminActionsScreen
             isTestMode={isTestMode}
             canUnconfigure={status.canUnconfigure}
-            electionDefinition={electionDefinition}
           />
         </Route>
         <Route path="/">

--- a/apps/central-scan/frontend/src/screens/admin_actions_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/admin_actions_screen.test.tsx
@@ -41,12 +41,7 @@ function renderScreen(
   history = createMemoryHistory()
 ) {
   return renderInAppContext(
-    <AdminActionsScreen
-      canUnconfigure={false}
-      isTestMode={false}
-      electionDefinition={testElectionDefinition}
-      {...props}
-    />,
+    <AdminActionsScreen canUnconfigure={false} isTestMode={false} {...props} />,
     { apiClient: mockApiClient, history }
   );
 }

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -17,6 +17,7 @@ import {
 import express, { Application } from 'express';
 import {
   createUiStringsApi,
+  createLogsApi,
   readBallotPackageFromUsb,
   exportCastVoteRecordsToUsbDrive,
   doesUsbDriveRequireCastVoteRecordSync as doesUsbDriveRequireCastVoteRecordSyncFn,
@@ -392,6 +393,8 @@ export function buildApi(
       logger,
       store: workspace.store.getUiStringsStore(),
     }),
+
+    ...createLogsApi({ usbDrive, machineId: getMachineConfig().machineId }),
   });
 }
 

--- a/apps/scan/frontend/package.json
+++ b/apps/scan/frontend/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "4.32.1",
+    "@votingworks/backend": "workspace:*",
     "@votingworks/basics": "workspace:*",
     "@votingworks/dev-dock-frontend": "workspace:*",
     "@votingworks/fixtures": "workspace:*",

--- a/apps/scan/frontend/src/api.ts
+++ b/apps/scan/frontend/src/api.ts
@@ -333,3 +333,10 @@ export const supportsUltrasonic = {
     return useQuery(this.queryKey(), () => apiClient.supportsUltrasonic());
   },
 } as const;
+
+export const exportLogsToUsb = {
+  useMutation() {
+    const apiClient = useApiClient();
+    return useMutation(apiClient.exportLogsToUsb);
+  },
+} as const;

--- a/apps/scan/frontend/src/app_root.tsx
+++ b/apps/scan/frontend/src/app_root.tsx
@@ -17,7 +17,8 @@ import {
 } from '@votingworks/utils';
 import { Logger } from '@votingworks/logging';
 
-import { assert } from '@votingworks/basics';
+import { assert, err } from '@votingworks/basics';
+import { LogsResultType } from '@votingworks/backend';
 import { PrecinctReportDestination } from '@votingworks/types';
 import { LoadingConfigurationScreen } from './screens/loading_configuration_screen';
 import { ElectionManagerScreen } from './screens/election_manager_screen';
@@ -45,6 +46,7 @@ import {
   getUsbDriveStatus,
   transitionPolls,
   unconfigureElection,
+  exportLogsToUsb,
 } from './api';
 import { VoterScreen } from './screens/voter_screen';
 import { LoginPromptScreen } from './screens/login_prompt_screen';
@@ -70,6 +72,15 @@ export function AppRoot({
   const checkPinMutation = checkPin.useMutation();
   const transitionPollsMutation = transitionPolls.useMutation();
   const unconfigureMutation = unconfigureElection.useMutation();
+  const exportLogsToUsbMutation = exportLogsToUsb.useMutation();
+
+  async function doExportLogs(): Promise<LogsResultType> {
+    try {
+      return await exportLogsToUsbMutation.mutateAsync();
+    } catch (e) {
+      return err('copy-failed');
+    }
+  }
 
   const {
     cardReader,
@@ -160,11 +171,10 @@ export function AppRoot({
           <LiveCheckButton />
         ) : undefined}
         <ExportLogsButtonGroup
-          electionDefinition={electionDefinition}
           usbDriveStatus={usbDrive}
           auth={authStatus}
           logger={logger}
-          machineConfig={machineConfig}
+          onExportLogs={doExportLogs}
         />
       </React.Fragment>
     );
@@ -238,6 +248,7 @@ export function AppRoot({
         scannerStatus={scannerStatus}
         usbDrive={usbDrive}
         logger={logger}
+        doExportLogs={doExportLogs}
       />
     );
   }

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -1,3 +1,5 @@
+import { ok } from '@votingworks/basics';
+import { LogsResultType } from '@votingworks/backend';
 import { ElectionDefinition } from '@votingworks/types';
 import {
   Button,
@@ -19,6 +21,7 @@ import type { UsbDriveStatus } from '@votingworks/usb-drive';
 import {
   BooleanEnvironmentVariableName,
   isFeatureFlagEnabled,
+  LogFileType,
 } from '@votingworks/utils';
 import { ExportResultsModal } from '../components/export_results_modal';
 import { Screen } from '../components/layout';
@@ -50,6 +53,7 @@ export interface ElectionManagerScreenProps {
   scannerStatus: PrecinctScannerStatus;
   usbDrive: UsbDriveStatus;
   logger: Logger;
+  doExportLogs: (lft: LogFileType) => Promise<LogsResultType>;
 }
 
 export function ElectionManagerScreen({
@@ -57,6 +61,7 @@ export function ElectionManagerScreen({
   scannerStatus,
   usbDrive,
   logger,
+  doExportLogs,
 }: ElectionManagerScreenProps): JSX.Element | null {
   const supportsUltrasonicQuery = supportsUltrasonic.useQuery();
   const configQuery = getConfig.useQuery();
@@ -95,7 +100,6 @@ export function ElectionManagerScreen({
     configQuery.data;
   const { pollsState } = pollsInfoQuery.data;
   const authStatus = authStatusQuery.data;
-  const machineConfig = machineConfigQuery.data;
 
   const doesUsbDriveRequireCastVoteRecordSync = Boolean(
     usbDriveStatusQuery.data.doesUsbDriveRequireCastVoteRecordSync
@@ -193,11 +197,10 @@ export function ElectionManagerScreen({
         <Button onPress={() => setIsExportingResults(true)}>Save CVRs</Button>{' '}
       </P>
       <ExportLogsButtonRow
-        electionDefinition={electionDefinition}
         usbDriveStatus={usbDrive}
         auth={authStatus}
         logger={logger}
-        machineConfig={machineConfig}
+        onExportLogs={doExportLogs}
       />
     </React.Fragment>
   );
@@ -376,6 +379,10 @@ export function ElectionManagerScreen({
 /* istanbul ignore next */
 export function DefaultPreview(): JSX.Element {
   const { electionDefinition } = usePreviewContext();
+  // eslint-disable-next-line @typescript-eslint/require-await
+  const doExportLogs: () => Promise<LogsResultType> = async () => {
+    return ok();
+  };
   return (
     <ElectionManagerScreen
       electionDefinition={electionDefinition}
@@ -385,6 +392,7 @@ export function DefaultPreview(): JSX.Element {
       }}
       usbDrive={{ status: 'no_drive' }}
       logger={new Logger(LogSource.VxScanFrontend)}
+      doExportLogs={doExportLogs}
     />
   );
 }

--- a/libs/backend/package.json
+++ b/libs/backend/package.json
@@ -39,6 +39,7 @@
     "@votingworks/basics": "workspace:*",
     "@votingworks/db": "workspace:*",
     "@votingworks/fixtures": "workspace:*",
+    "@votingworks/grout": "workspace:*",
     "@votingworks/logging": "workspace:*",
     "@votingworks/types": "workspace:*",
     "@votingworks/usb-drive": "workspace:*",

--- a/libs/backend/src/index.ts
+++ b/libs/backend/src/index.ts
@@ -6,3 +6,4 @@ export * from './list_directory';
 export * from './scan_globals';
 export * from './split';
 export * from './ui_strings';
+export * from './logs';

--- a/libs/backend/src/logs/index.ts
+++ b/libs/backend/src/logs/index.ts
@@ -1,0 +1,2 @@
+/* istanbul ignore file */
+export * from './logs_api';

--- a/libs/backend/src/logs/logs_api.test.ts
+++ b/libs/backend/src/logs/logs_api.test.ts
@@ -1,0 +1,98 @@
+/* istanbul ignore file - test util */
+
+import { createMockUsbDrive } from '@votingworks/usb-drive';
+import * as fs from 'fs/promises';
+import { copy as copyDirectory } from 'fs-extra';
+import { Stats } from 'fs';
+import { mockOf } from '@votingworks/test-utils';
+import { createLogsApi } from './logs_api';
+
+jest.mock('fs/promises', () => ({
+  ...jest.requireActual('fs/promises'),
+  stat: jest.fn().mockRejectedValue(new Error('not mocked yet')),
+}));
+
+jest.mock('fs-extra');
+
+test('exportLogsToUsb without logs directory', async () => {
+  const mockUsbDrive = createMockUsbDrive();
+  mockUsbDrive.insertUsbDrive({});
+
+  const api = createLogsApi({
+    usbDrive: mockUsbDrive.usbDrive,
+    machineId: 'TEST-MACHINE-ID',
+  });
+
+  expect((await api.exportLogsToUsb()).err()).toEqual('no-logs-directory');
+
+  // now we have the filesystem entry, but it's a file not a directory
+  const mockStats = new Stats();
+  mockStats.isDirectory = jest.fn().mockReturnValue(false);
+  mockOf(fs.stat).mockResolvedValue(mockStats);
+
+  expect((await api.exportLogsToUsb()).err()).toEqual('no-logs-directory');
+});
+
+test('exportLogsToUsb without USB', async () => {
+  const mockUsbDrive = createMockUsbDrive();
+  mockUsbDrive.removeUsbDrive();
+
+  const api = createLogsApi({
+    usbDrive: mockUsbDrive.usbDrive,
+    machineId: 'TEST-MACHINE-ID',
+  });
+
+  const mockStats = new Stats();
+  mockStats.isDirectory = jest.fn().mockReturnValue(true);
+  mockOf(fs.stat).mockResolvedValue(mockStats);
+
+  expect((await api.exportLogsToUsb()).err()).toEqual('no-usb-drive');
+});
+
+test('exportLogsToUsb with unknown failure', async () => {
+  const mockUsbDrive = createMockUsbDrive();
+  mockUsbDrive.insertUsbDrive({});
+
+  const api = createLogsApi({
+    usbDrive: mockUsbDrive.usbDrive,
+    machineId: 'TEST-MACHINE-ID',
+  });
+
+  const mockStats = new Stats();
+  mockStats.isDirectory = jest.fn().mockReturnValue(true);
+  mockOf(fs.stat).mockResolvedValueOnce(mockStats);
+
+  mockOf(copyDirectory).mockImplementation(() => {
+    throw new Error('boo');
+  });
+
+  expect((await api.exportLogsToUsb()).err()).toEqual('copy-failed');
+});
+
+test('exportLogsToUsb works when all conditions are met', async () => {
+  const mockUsbDrive = createMockUsbDrive();
+  mockUsbDrive.usbDrive.status.reset();
+  mockUsbDrive.usbDrive.status.expectRepeatedCallsWith().resolves({
+    status: 'mounted',
+    mountPoint: '/media/usb-drive',
+  });
+
+  const api = createLogsApi({
+    usbDrive: mockUsbDrive.usbDrive,
+    machineId: 'TEST-MACHINE-ID',
+  });
+
+  const mockStats = new Stats();
+  mockStats.isDirectory = jest.fn().mockReturnValue(true);
+  mockOf(fs.stat).mockResolvedValueOnce(mockStats);
+
+  mockOf(copyDirectory).mockReturnValue();
+
+  expect((await api.exportLogsToUsb()).isOk()).toBeTruthy();
+  expect(mockOf(fs.stat)).toHaveBeenCalledWith('/var/log/votingworks');
+
+  expect(mockOf(copyDirectory)).toHaveBeenCalledWith(
+    '/var/log/votingworks',
+    expect.stringMatching('^/media/usb-drive/logs/machine_TEST-MACHINE-ID/')
+  );
+});

--- a/libs/backend/src/logs/logs_api.ts
+++ b/libs/backend/src/logs/logs_api.ts
@@ -1,0 +1,72 @@
+import * as grout from '@votingworks/grout';
+import { UsbDrive } from '@votingworks/usb-drive';
+import * as fs from 'fs/promises';
+import { copy as copyDirectory } from 'fs-extra';
+import { join } from 'path';
+import { err, ok } from '@votingworks/basics';
+
+import { Result } from '@votingworks/basics';
+
+/** type of return value from exporting logs */
+export type LogsResultType = Result<
+  void,
+  'no-logs-directory' | 'no-usb-drive' | 'copy-failed'
+>;
+
+const LOG_DIR = '/var/log/votingworks';
+
+function buildApi({
+  usbDrive,
+  machineId,
+}: {
+  usbDrive: UsbDrive;
+  machineId: string;
+}) {
+  return grout.createApi({
+    async exportLogsToUsb(): Promise<LogsResultType> {
+      let logDirPathExistsAndIsDirectory = false;
+      try {
+        const sourceStatus = await fs.stat(LOG_DIR);
+        logDirPathExistsAndIsDirectory = sourceStatus.isDirectory();
+      } catch (e) {
+        // eslint-disable-line no-empty
+      }
+
+      if (!logDirPathExistsAndIsDirectory) {
+        return err('no-logs-directory');
+      }
+
+      const status = await usbDrive.status();
+      if (status.status !== 'mounted') {
+        return err('no-usb-drive');
+      }
+
+      const mountpoint = status.mountPoint;
+      const dateString = new Date().toISOString().replaceAll(':', '-');
+      const dirPath = `/logs/machine_${machineId}/${dateString}`;
+      const destinationDirectory = join(mountpoint, dirPath);
+
+      try {
+        await copyDirectory(LOG_DIR, destinationDirectory);
+      } catch {
+        return err('copy-failed');
+      }
+
+      return ok();
+    },
+  });
+}
+
+/** Grout API definition for UI string functions */
+export type LogsApi = ReturnType<typeof buildApi>;
+
+/** Creates a shareable implementation of {@link LogsApi}. */
+export function createLogsApi({
+  usbDrive,
+  machineId,
+}: {
+  usbDrive: UsbDrive;
+  machineId: string;
+}): LogsApi {
+  return buildApi({ usbDrive, machineId });
+}

--- a/libs/backend/tsconfig.build.json
+++ b/libs/backend/tsconfig.build.json
@@ -13,6 +13,7 @@
     { "path": "../../libs/basics/tsconfig.build.json" },
     { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../../libs/fixtures/tsconfig.build.json" },
+    { "path": "../../libs/grout/tsconfig.build.json" },
     { "path": "../../libs/logging/tsconfig.build.json" },
     { "path": "../../libs/test-utils/tsconfig.build.json" },
     { "path": "../../libs/types/tsconfig.build.json" },

--- a/libs/backend/tsconfig.json
+++ b/libs/backend/tsconfig.json
@@ -19,6 +19,7 @@
     { "path": "../../libs/basics/tsconfig.build.json" },
     { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../../libs/fixtures/tsconfig.build.json" },
+    { "path": "../../libs/grout/tsconfig.build.json" },
     { "path": "../../libs/logging/tsconfig.build.json" },
     { "path": "../../libs/test-utils/tsconfig.build.json" },
     { "path": "../../libs/types/tsconfig.build.json" },

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -48,6 +48,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.2.1",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@testing-library/react": "^14.0.0",
+    "@votingworks/backend": "workspace:*",
     "@votingworks/ballot-encoder": "workspace:*",
     "@votingworks/basics": "workspace:*",
     "@votingworks/grout": "workspace:*",

--- a/libs/ui/src/export_logs_modal.test.tsx
+++ b/libs/ui/src/export_logs_modal.test.tsx
@@ -1,39 +1,22 @@
 import {
-  fakeKiosk,
-  fakeFileWriter,
   fakeSystemAdministratorUser,
   fakeElectionManagerUser,
   fakeSessionExpiresAt,
 } from '@votingworks/test-utils';
 import { LogFileType } from '@votingworks/utils';
 
+import { err, ok } from '@votingworks/basics';
 import { fakeLogger, LogEventId } from '@votingworks/logging';
 import userEvent from '@testing-library/user-event';
-import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 import { DippedSmartCardAuth } from '@votingworks/types';
 import type { UsbDriveStatus } from '@votingworks/usb-drive';
-import { act, render, screen, waitFor } from '../test/react_testing_library';
+import { act, render, screen } from '../test/react_testing_library';
 import {
   ExportLogsButton,
   ExportLogsButtonGroup,
   ExportLogsButtonRow,
 } from './export_logs_modal';
 import { mockUsbDriveStatus } from './test-utils/mock_usb_drive';
-
-const machineConfig = {
-  codeVersion: 'TEST',
-  machineId: '0000',
-} as const;
-
-const fileSystemEntry: KioskBrowser.FileSystemEntry = {
-  name: 'file',
-  path: 'path',
-  type: 1,
-  size: 1,
-  atime: new Date(),
-  ctime: new Date(2021, 0, 1),
-  mtime: new Date(),
-};
 
 const systemAdministratorAuthStatus: DippedSmartCardAuth.SystemAdministratorLoggedIn =
   {
@@ -52,13 +35,9 @@ const electionManagerAuthStatus: DippedSmartCardAuth.ElectionManagerLoggedIn = {
 jest.useFakeTimers();
 
 test('renders no log file found when usb is mounted but no log file on machine', async () => {
-  const mockKiosk = fakeKiosk();
-  mockKiosk.getFileSystemEntries.mockResolvedValueOnce([
-    { ...fileSystemEntry, name: 'not-the-right-file.log' },
-  ]);
-  window.kiosk = mockKiosk;
-
   const logger = fakeLogger();
+
+  const onExportLogs = jest.fn().mockResolvedValue(err('no-log-directory'));
 
   render(
     <ExportLogsButton
@@ -66,25 +45,21 @@ test('renders no log file found when usb is mounted but no log file on machine',
       usbDriveStatus={mockUsbDriveStatus('mounted')}
       logger={logger}
       auth={electionManagerAuthStatus}
-      machineConfig={machineConfig}
+      onExportLogs={onExportLogs}
     />
   );
   userEvent.click(screen.getByText('Save Log File'));
-  await screen.findByText('Loading');
-  await screen.findByText('No Log File Present');
+  userEvent.click(screen.getByText('Save'));
+  await screen.findByText('Failed to save log file. no-log-directory');
   expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.SaveLogFileFound,
+    LogEventId.FileSaved,
     'election_manager',
     expect.objectContaining({ disposition: 'failure' })
   );
 });
 
 test('render no usb found screen when there is not a mounted usb drive', async () => {
-  const mockKiosk = fakeKiosk();
-  mockKiosk.getFileSystemEntries.mockResolvedValue([
-    { ...fileSystemEntry, name: 'vx-logs.log' },
-  ]);
-  window.kiosk = mockKiosk;
+  const onExportLogs = jest.fn();
 
   const usbStatuses: UsbDriveStatus[] = [
     { status: 'no_drive' },
@@ -95,13 +70,12 @@ test('render no usb found screen when there is not a mounted usb drive', async (
       <ExportLogsButton
         logFileType={LogFileType.Raw}
         usbDriveStatus={status}
-        machineConfig={machineConfig}
         logger={fakeLogger()}
+        onExportLogs={onExportLogs}
         auth={systemAdministratorAuthStatus}
       />
     );
     userEvent.click(screen.getByText('Save Log File'));
-    await screen.findByText('Loading');
     await screen.findByText('No USB Drive Detected');
     screen.getByText(
       'Please insert a USB drive where you would like the save the log file.'
@@ -115,18 +89,10 @@ test('render no usb found screen when there is not a mounted usb drive', async (
   }
 });
 
-test('successful save raw log flow', async () => {
-  const mockKiosk = fakeKiosk();
-  mockKiosk.getFileSystemEntries.mockResolvedValueOnce([
-    { ...fileSystemEntry, name: 'vx-logs.log' },
-  ]);
-  mockKiosk.readFile.mockResolvedValue('this-is-my-file-content');
-  window.kiosk = mockKiosk;
-
+test('successful save raw logs flow', async () => {
   const logger = fakeLogger();
-  const logCdfSpy = jest
-    .spyOn(logger, 'buildCDFLog')
-    .mockReturnValue('this-is-the-cdf-content');
+
+  const onExportLogs = jest.fn().mockResolvedValue(ok());
 
   render(
     <ExportLogsButton
@@ -134,257 +100,59 @@ test('successful save raw log flow', async () => {
       usbDriveStatus={mockUsbDriveStatus('mounted')}
       logger={logger}
       auth={electionManagerAuthStatus}
-      machineConfig={machineConfig}
+      onExportLogs={onExportLogs}
     />
   );
   userEvent.click(screen.getByText('Save Log File'));
-  await screen.findByText('Loading');
   await screen.findByText('Save Logs');
-  expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.SaveLogFileFound,
-    'election_manager',
-    expect.objectContaining({ disposition: 'success' })
-  );
-
   userEvent.click(screen.getByText('Save'));
   await screen.findByText(/Saving Logs/);
-  expect(mockKiosk.readFile).toHaveBeenCalled();
   act(() => {
     jest.advanceTimersByTime(2001);
   });
   await screen.findByText(/Logs Saved/);
-  await waitFor(() => {
-    expect(mockKiosk.writeFile).toHaveBeenCalledTimes(1);
-    expect(mockKiosk.writeFile).toHaveBeenNthCalledWith(
-      1,
-      expect.stringContaining('test-mount-point/vx-log'),
-      'this-is-my-file-content'
-    );
-  });
-  expect(logCdfSpy).toHaveBeenCalledTimes(0);
 
   userEvent.click(screen.getByText('Close'));
   expect(screen.queryByRole('alertdialog')).toBeFalsy();
 
+  expect(onExportLogs).toHaveBeenCalledWith(LogFileType.Raw);
   expect(logger.log).toHaveBeenCalledWith(
     LogEventId.FileSaved,
     'election_manager',
     expect.objectContaining({
       disposition: 'success',
-      filename: expect.stringContaining('vx-log'),
-      fileType: 'logs',
-    })
-  );
-});
-
-test('successful save cdf log file flow', async () => {
-  const mockKiosk = fakeKiosk();
-  mockKiosk.getFileSystemEntries.mockResolvedValueOnce([
-    { ...fileSystemEntry, name: 'vx-logs.log' },
-  ]);
-  mockKiosk.readFile.mockResolvedValue('this-is-my-raw-file-content');
-  window.kiosk = mockKiosk;
-
-  const logger = fakeLogger();
-  logger.buildCDFLog = jest.fn().mockReturnValue('this-is-the-cdf-content');
-
-  render(
-    <ExportLogsButton
-      logFileType={LogFileType.Cdf}
-      usbDriveStatus={mockUsbDriveStatus('mounted')}
-      logger={logger}
-      auth={electionManagerAuthStatus}
-      machineConfig={machineConfig}
-      electionDefinition={electionFamousNames2021Fixtures.electionDefinition}
-    />
-  );
-  userEvent.click(screen.getByText('Save CDF Log File'));
-  await screen.findByText('Loading');
-  await screen.findByText('Save Logs');
-  expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.SaveLogFileFound,
-    'election_manager',
-    expect.objectContaining({ disposition: 'success' })
-  );
-
-  userEvent.click(screen.getByText('Save'));
-  await screen.findByText(/Saving Logs/);
-  expect(mockKiosk.readFile).toHaveBeenCalled();
-  act(() => {
-    jest.advanceTimersByTime(2001);
-  });
-  await screen.findByText(/Logs Saved/);
-  await waitFor(() => {
-    expect(mockKiosk.writeFile).toHaveBeenCalledTimes(1);
-    expect(mockKiosk.writeFile).toHaveBeenNthCalledWith(
-      1,
-      expect.stringContaining('test-mount-point/vx-log'),
-      'this-is-the-cdf-content'
-    );
-  });
-  expect(logger.buildCDFLog).toHaveBeenCalledTimes(1);
-
-  userEvent.click(screen.getByText('Close'));
-  expect(screen.queryByRole('alertdialog')).toBeFalsy();
-
-  expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.FileSaved,
-    'election_manager',
-    expect.objectContaining({
-      disposition: 'success',
-      filename: expect.stringContaining('vx-log'),
-      fileType: 'logs',
-    })
-  );
-});
-
-test('failed export flow', async () => {
-  const mockKiosk = fakeKiosk();
-  window.kiosk = mockKiosk;
-  mockKiosk.getFileSystemEntries.mockResolvedValueOnce([
-    { ...fileSystemEntry, name: 'vx-logs.log' },
-  ]);
-  const logger = fakeLogger();
-
-  mockKiosk.readFile.mockRejectedValueOnce(new Error('this-is-an-error'));
-
-  render(
-    <ExportLogsButton
-      logFileType={LogFileType.Raw}
-      usbDriveStatus={mockUsbDriveStatus('mounted')}
-      logger={logger}
-      auth={electionManagerAuthStatus}
-      machineConfig={machineConfig}
-    />
-  );
-  userEvent.click(screen.getByText('Save Log File'));
-  await screen.findByText('Loading');
-  await screen.findByText('Save Logs');
-
-  userEvent.click(screen.getByText('Save'));
-  await screen.findByText(/Saving Logs/);
-  await screen.findByText(/Failed to Save Logs/);
-  screen.getByText(/Failed to save log file./);
-  screen.getByText(/this-is-an-error/);
-
-  userEvent.click(screen.getByText('Close'));
-  expect(screen.queryByRole('alertdialog')).toBeFalsy();
-  expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.FileSaved,
-    'election_manager',
-    expect.objectContaining({
-      disposition: 'failure',
-      fileType: 'logs',
-      message: 'Error saving log file: this-is-an-error',
-    })
-  );
-});
-
-test('successful save to custom location', async () => {
-  const mockKiosk = fakeKiosk();
-  mockKiosk.getFileSystemEntries.mockResolvedValueOnce([
-    { ...fileSystemEntry, name: 'vx-logs.log' },
-  ]);
-  mockKiosk.readFile.mockResolvedValue('this-is-my-file-content');
-  const fileWriter = fakeFileWriter();
-  mockKiosk.saveAs.mockResolvedValueOnce(fileWriter);
-  window.kiosk = mockKiosk;
-
-  const logger = fakeLogger();
-
-  render(
-    <ExportLogsButton
-      logFileType={LogFileType.Raw}
-      usbDriveStatus={mockUsbDriveStatus('mounted')}
-      logger={logger}
-      auth={electionManagerAuthStatus}
-      machineConfig={machineConfig}
-    />
-  );
-  userEvent.click(screen.getByText('Save Log File'));
-  userEvent.click(await screen.findByText(/Save As/));
-  await screen.findByText(/Saving Logs/);
-  jest.advanceTimersByTime(2001);
-  await screen.findByText(/Logs Saved/);
-  await waitFor(() => {
-    expect(fileWriter.write).toHaveBeenCalled();
-    expect(fileWriter.end).toHaveBeenCalled();
-  });
-
-  userEvent.click(screen.getByText('Close'));
-  expect(screen.queryByRole('alertdialog')).toBeFalsy();
-
-  expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.FileSaved,
-    'election_manager',
-    expect.objectContaining({
-      disposition: 'success',
-      fileType: 'logs',
-    })
-  );
-});
-
-test('failed save to custom location', async () => {
-  const mockKiosk = fakeKiosk();
-  mockKiosk.getFileSystemEntries.mockResolvedValueOnce([
-    { ...fileSystemEntry, name: 'vx-logs.log' },
-  ]);
-  mockKiosk.readFile.mockResolvedValue('this-is-my-file-content');
-  mockKiosk.saveAs.mockResolvedValueOnce(undefined);
-  window.kiosk = mockKiosk;
-
-  const logger = fakeLogger();
-
-  render(
-    <ExportLogsButton
-      logFileType={LogFileType.Raw}
-      usbDriveStatus={mockUsbDriveStatus('mounted')}
-      logger={logger}
-      auth={electionManagerAuthStatus}
-      machineConfig={machineConfig}
-    />
-  );
-  userEvent.click(screen.getByText('Save Log File'));
-  userEvent.click(await screen.findByText(/Save As/));
-  await screen.findByText(/Saving Logs/);
-  jest.advanceTimersByTime(2001);
-  await screen.findByText(/Failed to Save Logs/);
-  userEvent.click(screen.getByText('Close'));
-  expect(screen.queryByRole('alertdialog')).toBeFalsy();
-
-  expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.FileSaved,
-    'election_manager',
-    expect.objectContaining({
-      disposition: 'failure',
       fileType: 'logs',
     })
   );
 });
 
 test('button row renders both buttons', () => {
+  const onExportLogs = jest.fn().mockResolvedValue(err('no-log-directory'));
+
   render(
     <ExportLogsButtonRow
       usbDriveStatus={mockUsbDriveStatus('mounted')}
       logger={fakeLogger()}
       auth={electionManagerAuthStatus}
-      machineConfig={machineConfig}
+      onExportLogs={onExportLogs}
     />
   );
 
   expect(screen.getButton('Save Log File')).toBeEnabled();
 
-  // without an election definition, CDF button should be disabled
+  // CDF button is disabled for now
   expect(screen.getButton('Save CDF Log File')).toBeDisabled();
 });
 
 test('button group renders both buttons', () => {
+  const onExportLogs = jest.fn().mockResolvedValue(err('no-log-directory'));
+
   render(
     <ExportLogsButtonGroup
       usbDriveStatus={mockUsbDriveStatus('mounted')}
       logger={fakeLogger()}
       auth={electionManagerAuthStatus}
-      machineConfig={machineConfig}
+      onExportLogs={onExportLogs}
     />
   );
 

--- a/libs/ui/src/export_logs_modal.tsx
+++ b/libs/ui/src/export_logs_modal.tsx
@@ -1,44 +1,29 @@
-import React, { useEffect, useState } from 'react';
-import { join } from 'path';
+import React, { useState } from 'react';
 import {
-  generateLogFilename,
   LogFileType,
   isElectionManagerAuth,
   isSystemAdministratorAuth,
 } from '@votingworks/utils';
 
-import {
-  LogEventId,
-  LOGS_ROOT_LOCATION,
-  LOG_NAME,
-  FULL_LOG_PATH,
-  Logger,
-} from '@votingworks/logging';
+import { LogEventId, Logger } from '@votingworks/logging';
 
-import {
-  DippedSmartCardAuth,
-  ElectionDefinition,
-  InsertedSmartCardAuth,
-} from '@votingworks/types';
-import { assert, sleep, throwIllegalValue } from '@votingworks/basics';
+import { DippedSmartCardAuth, InsertedSmartCardAuth } from '@votingworks/types';
+import { LogsResultType } from '@votingworks/backend';
+import { assert, throwIllegalValue } from '@votingworks/basics';
 import type { UsbDriveStatus } from '@votingworks/usb-drive';
 import { Button } from './button';
 import { Modal } from './modal';
 
 import { Loading } from './loading';
 import { UsbImage } from './graphics';
-import { Font, P } from './typography';
+import { P } from './typography';
 
 export interface ExportLogsModalProps {
   usbDriveStatus: UsbDriveStatus;
   auth: DippedSmartCardAuth.AuthStatus | InsertedSmartCardAuth.AuthStatus;
   logFileType: LogFileType;
   logger: Logger;
-  electionDefinition?: ElectionDefinition;
-  machineConfig: {
-    machineId: string;
-    codeVersion: string;
-  };
+  onExportLogs: (lft: LogFileType) => Promise<LogsResultType>;
   onClose: () => void;
 }
 
@@ -54,9 +39,8 @@ export function ExportLogsModal({
   auth,
   logFileType,
   logger,
-  electionDefinition,
-  machineConfig,
   onClose,
+  onExportLogs,
 }: ExportLogsModalProps): JSX.Element {
   assert(isSystemAdministratorAuth(auth) || isElectionManagerAuth(auth)); // TODO(auth) should this check for a specific user type
   const userRole = auth.user.role;
@@ -64,104 +48,25 @@ export function ExportLogsModal({
   const [currentState, setCurrentState] = useState(ModalState.Init);
   const [errorMessage, setErrorMessage] = useState('');
 
-  const [savedFilename, setSavedFilename] = useState('');
-  const [foundLogFile, setFoundLogFile] = useState(false);
-  const [isLocatingLogFile, setIsLocatingLogFile] = useState(true);
-
-  useEffect(() => {
-    async function checkLogFile() {
-      if (window.kiosk) {
-        const allLogs =
-          await window.kiosk.getFileSystemEntries(LOGS_ROOT_LOCATION);
-        const vxLogFile = allLogs.filter((f) => f.name === `${LOG_NAME}.log`);
-        if (vxLogFile.length > 0) {
-          setFoundLogFile(true);
-          await logger.log(LogEventId.SaveLogFileFound, userRole, {
-            disposition: 'success',
-            message:
-              'Successfully located vx-logs.log file on machine to save.',
-          });
-        } else {
-          setFoundLogFile(false);
-          await logger.log(LogEventId.SaveLogFileFound, userRole, {
-            disposition: 'failure',
-            message:
-              'Could not locate vx-logs.log file on machine. Machine is not configured for production use.',
-            result: 'Logs are not saveable.',
-          });
-        }
-        setIsLocatingLogFile(false);
-      }
-    }
-    void checkLogFile();
-  }, [userRole, logger]);
-  const defaultFilename = generateLogFilename('vx-logs', logFileType);
-
-  async function exportLogs(openFileDialog: boolean) {
-    assert(window.kiosk);
+  async function exportLogs() {
     setCurrentState(ModalState.Saving);
 
-    try {
-      const rawLogFile = await window.kiosk.readFile(FULL_LOG_PATH, 'utf8');
-      let results = '';
-      switch (logFileType) {
-        case LogFileType.Raw:
-          results = rawLogFile;
-          break;
-        case LogFileType.Cdf: {
-          assert(electionDefinition);
-          results = logger.buildCDFLog(
-            electionDefinition,
-            rawLogFile,
-            machineConfig.machineId,
-            machineConfig.codeVersion,
-            userRole
-          );
-          break;
-        }
-        /* istanbul ignore next - compile time check for completeness */
-        default:
-          throwIllegalValue(logFileType);
-      }
-      let filenameLocation = '';
-      if (openFileDialog) {
-        const fileWriter = await window.kiosk.saveAs({
-          defaultPath: defaultFilename,
-        });
+    if (logFileType === LogFileType.Raw) {
+      const result = await onExportLogs(logFileType);
+      await logger.log(LogEventId.FileSaved, userRole, {
+        disposition: result.isOk() ? 'success' : 'failure',
+        message: result.isOk()
+          ? 'Sucessfully saved logs on the usb drive.'
+          : `Failed to save logs to usb drive: ${result.err()}`,
+        fileType: 'logs',
+      });
 
-        if (!fileWriter) {
-          throw new Error('could not save; no file was chosen');
-        }
-        await fileWriter.write(results);
-
-        filenameLocation = fileWriter.filename;
-        await fileWriter.end();
+      if (result.isErr()) {
+        setErrorMessage(result.err());
+        setCurrentState(ModalState.Error);
       } else {
-        assert(usbDriveStatus.status === 'mounted');
-        const pathToFile = join(usbDriveStatus.mountPoint, defaultFilename);
-        await window.kiosk.writeFile(pathToFile, results);
-        filenameLocation = defaultFilename;
+        setCurrentState(ModalState.Done);
       }
-
-      setSavedFilename(filenameLocation);
-      await sleep(2000);
-      await logger.log(LogEventId.FileSaved, userRole, {
-        disposition: 'success',
-        message: `Successfully saved log file to ${filenameLocation} on the usb drive.`,
-        fileType: 'logs',
-        filename: filenameLocation,
-      });
-      setCurrentState(ModalState.Done);
-    } catch (error) {
-      assert(error instanceof Error);
-      setErrorMessage(error.message);
-      await logger.log(LogEventId.FileSaved, userRole, {
-        disposition: 'failure',
-        message: `Error saving log file: ${error.message}`,
-        result: 'File not saved, error message shown to user.',
-        fileType: 'logs',
-      });
-      setCurrentState(ModalState.Error);
     }
   }
 
@@ -180,17 +85,7 @@ export function ExportLogsModal({
     return (
       <Modal
         title="Logs Saved"
-        content={
-          <P>
-            Log file successfully saved{' '}
-            {savedFilename !== '' && (
-              <span>
-                as <Font weight="bold">{savedFilename}</Font>
-              </span>
-            )}{' '}
-            on the inserted USB drive.
-          </P>
-        }
+        content={<P>Log files successfully saved on the inserted USB drive.</P>}
         onOverlayClick={onClose}
         actions={<Button onPress={onClose}>Close</Button>}
       />
@@ -206,33 +101,10 @@ export function ExportLogsModal({
     throwIllegalValue(currentState);
   }
 
-  if (isLocatingLogFile) {
-    return (
-      <Modal
-        content={<Loading />}
-        onOverlayClick={onClose}
-        actions={<Button onPress={onClose}>Close</Button>}
-      />
-    );
-  }
-
-  if (!window.kiosk || !foundLogFile) {
-    return (
-      <Modal
-        title="No Log File Present"
-        content={<P>No log file detected on device.</P>}
-        onOverlayClick={onClose}
-        actions={<Button onPress={onClose}>Close</Button>}
-      />
-    );
-  }
-
   switch (usbDriveStatus.status) {
     case 'no_drive':
     case 'ejected':
     case 'error':
-      // When run not through kiosk mode let the user save the file
-      // on the machine for internal debugging use
       return (
         <Modal
           title="No USB Drive Detected"
@@ -249,7 +121,7 @@ export function ExportLogsModal({
               {
                 /* istanbul ignore next */ process.env.NODE_ENV ===
                   'development' && (
-                  <Button onPress={() => exportLogs(true)}>Save</Button>
+                  <Button onPress={() => exportLogs()}>Save</Button>
                 )
               }
               <Button onPress={onClose}>Cancel</Button>
@@ -261,20 +133,14 @@ export function ExportLogsModal({
       return (
         <Modal
           title="Save Logs"
-          content={
-            <P>
-              Save the log file as <Font weight="bold">{defaultFilename}</Font>{' '}
-              directly on the inserted USB drive?
-            </P>
-          }
+          content={<P>Save logs on the inserted USB drive?</P>}
           onOverlayClick={onClose}
           actions={
             <React.Fragment>
-              <Button variant="primary" onPress={() => exportLogs(false)}>
+              <Button variant="primary" onPress={() => exportLogs()}>
                 Save
               </Button>
               <Button onPress={onClose}>Cancel</Button>
-              <Button onPress={() => exportLogs(true)}>Save As…</Button>
             </React.Fragment>
           }
         />
@@ -290,7 +156,6 @@ export type ExportLogsButtonProps = Omit<ExportLogsModalProps, 'onClose'>;
 
 export function ExportLogsButton({
   logFileType,
-  electionDefinition,
   ...rest
 }: ExportLogsButtonProps): JSX.Element {
   const [isShowingModal, setIsShowingModal] = useState(false);
@@ -299,14 +164,13 @@ export function ExportLogsButton({
     <React.Fragment>
       <Button
         onPress={() => setIsShowingModal(true)}
-        disabled={logFileType === 'cdf' && !electionDefinition}
+        disabled={logFileType === 'cdf'}
       >
         {logFileType === 'raw' ? 'Save Log File' : 'Save CDF Log File'}
       </Button>
       {isShowingModal && (
         <ExportLogsModal
           logFileType={logFileType}
-          electionDefinition={electionDefinition}
           {...rest}
           onClose={() => setIsShowingModal(false)}
         />

--- a/libs/ui/tsconfig.build.json
+++ b/libs/ui/tsconfig.build.json
@@ -15,6 +15,7 @@
   },
   "references": [
     { "path": "../ballot-encoder/tsconfig.build.json" },
+    { "path": "../backend/tsconfig.build.json" },
     { "path": "../basics/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../fixtures/tsconfig.build.json" },

--- a/libs/ui/tsconfig.json
+++ b/libs/ui/tsconfig.json
@@ -14,6 +14,7 @@
   "exclude": [],
   "references": [
     { "path": "../ballot-encoder/tsconfig.build.json" },
+    { "path": "../backend/tsconfig.build.json" },
     { "path": "../basics/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../fixtures/tsconfig.build.json" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,6 +310,9 @@ importers:
       '@tanstack/react-query-devtools':
         specifier: 4.32.1
         version: 4.32.1(@tanstack/react-query@4.32.1)(react-dom@18.2.0)(react@18.2.0)
+      '@votingworks/backend':
+        specifier: workspace:*
+        version: link:../../../libs/backend
       '@votingworks/ballot-encoder':
         specifier: workspace:*
         version: link:../../../libs/ballot-encoder
@@ -853,6 +856,9 @@ importers:
       '@votingworks/api':
         specifier: workspace:*
         version: link:../../../libs/api
+      '@votingworks/backend':
+        specifier: workspace:*
+        version: link:../../../libs/backend
       '@votingworks/basics':
         specifier: workspace:*
         version: link:../../../libs/basics
@@ -2511,6 +2517,9 @@ importers:
       '@tanstack/react-query':
         specifier: 4.32.1
         version: 4.32.1(react-dom@18.2.0)(react@18.2.0)
+      '@votingworks/backend':
+        specifier: workspace:*
+        version: link:../../../libs/backend
       '@votingworks/basics':
         specifier: workspace:*
         version: link:../../../libs/basics
@@ -2913,6 +2922,9 @@ importers:
       '@votingworks/fixtures':
         specifier: workspace:*
         version: link:../fixtures
+      '@votingworks/grout':
+        specifier: workspace:*
+        version: link:../grout
       '@votingworks/logging':
         specifier: workspace:*
         version: link:../logging
@@ -5033,6 +5045,9 @@ importers:
       '@testing-library/react':
         specifier: ^14.0.0
         version: 14.0.0(react-dom@18.2.0)(react@18.2.0)
+      '@votingworks/backend':
+        specifier: workspace:*
+        version: link:../backend
       '@votingworks/ballot-encoder':
         specifier: workspace:*
         version: link:../ballot-encoder


### PR DESCRIPTION
A revamp of log export. Moved to the backend. This now includes all historical logs, everything in `/var/log/votingworks`. For the moment, CDF export is disabled.

