### PR TITLE
fix(auth): correct card interface APIs

### DIFF
--- a/libs/auth/scripts/cac_get_cert.ts
+++ b/libs/auth/scripts/cac_get_cert.ts
@@ -1,6 +1,10 @@
 import { createWriteStream } from 'fs';
 import { throwIllegalValue } from '@votingworks/basics';
-import { CARD_DOD_CERT, CommonAccessCard } from '../src/cac';
+import {
+  CARD_DOD_CERT,
+  CommonAccessCard,
+  CommonAccessCardCompatibleCard,
+} from '../src/cac';
 import { waitForReadyCardStatus } from './utils';
 
 /**
@@ -54,7 +58,7 @@ export async function main(args: readonly string[]): Promise<void> {
     }
   }
 
-  const card = new CommonAccessCard();
+  const card: CommonAccessCardCompatibleCard = new CommonAccessCard();
   await waitForReadyCardStatus(card);
 
   switch (format) {

--- a/libs/auth/src/cac/common_access_card_api.ts
+++ b/libs/auth/src/cac/common_access_card_api.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'buffer';
 import { Byte, Id } from '@votingworks/types';
-import { StatefulCard } from '../card';
+import { BaseCard, PinProtectedCard, StatefulCard } from '../card';
 
 /**
  * Details about a Common Access Card.
@@ -32,5 +32,8 @@ export interface CertificateProviderCard {
 /**
  * The API for a Common Access Card-compatible smart card.
  */
-export type CommonAccessCardCompatibleCard =
-  StatefulCard<CommonAccessCardDetails> & SigningCard & CertificateProviderCard;
+export type CommonAccessCardCompatibleCard = BaseCard &
+  StatefulCard<CommonAccessCardDetails> &
+  PinProtectedCard &
+  SigningCard &
+  CertificateProviderCard;

--- a/libs/auth/src/card.ts
+++ b/libs/auth/src/card.ts
@@ -100,6 +100,13 @@ export type CheckPinResponse =
   | CheckPinResponseIncorrect;
 
 /**
+ * The base API any card should support
+ */
+export interface BaseCard {
+  disconnect(): Promise<void>;
+}
+
+/**
  * The API for a card that can provide its status
  */
 export interface StatefulCard<T = CardDetails> {
@@ -138,7 +145,8 @@ export interface DataCard {
 /**
  * The API for a VxSuite-compatible card
  */
-export type Card = StatefulCard &
+export type Card = BaseCard &
+  StatefulCard &
   PinProtectedCard &
   ProgrammableCard &
   DataCard;

--- a/libs/auth/src/mock_file_card.test.ts
+++ b/libs/auth/src/mock_file_card.test.ts
@@ -281,3 +281,8 @@ test('MockFileCard resiliency to underlying file that cannot be parsed', async (
     status: 'no_card',
   });
 });
+
+test('MockFileCard disconnect does nothing', async () => {
+  const card = new MockFileCard();
+  await card.disconnect();
+});

--- a/libs/auth/src/mock_file_card.ts
+++ b/libs/auth/src/mock_file_card.ts
@@ -228,4 +228,8 @@ export class MockFileCard implements Card {
     });
     return Promise.resolve();
   }
+
+  disconnect(): Promise<void> {
+    return Promise.resolve();
+  }
 }

--- a/libs/auth/test/utils.ts
+++ b/libs/auth/test/utils.ts
@@ -44,6 +44,7 @@ export interface MockCard {
   writeData: MockFunction<Card['writeData']>;
   clearData: MockFunction<Card['clearData']>;
   unprogram: MockFunction<Card['unprogram']>;
+  disconnect: MockFunction<Card['disconnect']>;
 }
 
 /**
@@ -58,6 +59,7 @@ export function buildMockCard(): MockCard {
     writeData: mockFunction<Card['writeData']>('writeData'),
     clearData: mockFunction<Card['clearData']>('clearData'),
     unprogram: mockFunction<Card['unprogram']>('unprogram'),
+    disconnect: mockFunction<Card['disconnect']>('disconnect'),
   };
 }
 


### PR DESCRIPTION
## Overview

I noticed that the interfaces for `Card` and `CommonAccessCardCompatibleCard` didn't actually include all the methods that they should have. I added a `BaseCard` interface to capture the `disconnect` method, then fixed `CommonAccessCardCompatibleCard` to include `PinProtectedCard` to ensure it has `checkPin`.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated type checking.