### PR TITLE
Add sheet-copying scripts to facilitate scale testing

### DIFF
--- a/apps/central-scan/backend/.eslintrc.json
+++ b/apps/central-scan/backend/.eslintrc.json
@@ -5,6 +5,12 @@
     "vx/gts-jsdoc": "off"
   },
   "overrides": [
+    {
+      "files": ["scripts/**"],
+      "rules": {
+        "no-console": "off"
+      }
+    },
     // This file causes this rule to crash on private constructors.
     // Started happening after TypeScript upgrade to v4.6. I was not able to
     // find an issue on the GitHub repo for @typescript-eslint/eslint-plugin.

--- a/apps/central-scan/backend/scripts/copy-batch
+++ b/apps/central-scan/backend/scripts/copy-batch
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+require('esbuild-runner/register');
+require('./copy_batch').main(process.argv.slice(2));

--- a/apps/central-scan/backend/scripts/copy_batch.ts
+++ b/apps/central-scan/backend/scripts/copy_batch.ts
@@ -1,0 +1,121 @@
+import fs from 'fs';
+import path from 'path';
+import { v4 as uuid } from 'uuid';
+import { AcceptedSheet } from '@votingworks/backend';
+import {
+  assert,
+  assertDefined,
+  extractErrorMessage,
+} from '@votingworks/basics';
+import { Id, safeParseInt } from '@votingworks/types';
+
+import { SCAN_WORKSPACE } from '../src/globals';
+import { Store } from '../src/store';
+import { createWorkspace } from '../src/util/workspace';
+
+const usageMessage = `Usage: copy-batch '<batch-name>' <num-copies>
+
+Arguments:
+  <batch-name>\tThe name of the batch to copy
+  <num-copies>\tThe number of copies to create`;
+
+interface CopyBatchInput {
+  batchName: string;
+  numCopies: number;
+}
+
+function checkEnvironment(): void {
+  assert(process.env.NODE_ENV !== 'production', 'Cannot be run in production');
+}
+
+function parseCommandLineArgs(args: readonly string[]): CopyBatchInput {
+  const parseNumCopiesResult = safeParseInt(args[1]);
+  if (args.length !== 2 || !parseNumCopiesResult.isOk()) {
+    console.error(usageMessage);
+    process.exit(1);
+  }
+  const batchName = args[0];
+  const numCopies = parseNumCopiesResult.ok();
+  return { batchName, numCopies };
+}
+
+function copySheet(store: Store, sheet: AcceptedSheet, newBatchId: Id): void {
+  const newSheetId = uuid();
+  const newSheet: AcceptedSheet = {
+    ...sheet,
+    id: newSheetId,
+    batchId: newBatchId,
+    frontImagePath: path.join(
+      path.dirname(sheet.frontImagePath),
+      `${newSheetId}-front.jpg`
+    ),
+    backImagePath: path.join(
+      path.dirname(sheet.backImagePath),
+      `${newSheetId}-back.jpg`
+    ),
+  };
+
+  fs.copyFileSync(sheet.frontImagePath, newSheet.frontImagePath);
+  fs.copyFileSync(sheet.backImagePath, newSheet.backImagePath);
+
+  store.addSheet(newSheetId, newSheet.batchId, [
+    {
+      imagePath: newSheet.frontImagePath,
+      interpretation: newSheet.interpretation[0],
+    },
+    {
+      imagePath: newSheet.backImagePath,
+      interpretation: newSheet.interpretation[1],
+    },
+  ]);
+}
+
+function getAcceptedSheetsInBatch(
+  store: Store,
+  batchName: string
+): AcceptedSheet[] {
+  const batches = store.getBatches();
+  const batchId = assertDefined(
+    batches.find((batch) => batch.label === batchName),
+    `No batch named '${batchName}'`
+  ).id;
+
+  const sheetGenerator = store.forEachAcceptedSheet();
+  const sheets: AcceptedSheet[] = [];
+  for (const sheet of sheetGenerator) {
+    if (sheet.batchId === batchId) {
+      sheets.push(sheet);
+    }
+  }
+  return sheets;
+}
+
+function copyBatch({ batchName, numCopies }: CopyBatchInput): void {
+  const { store } = createWorkspace(assertDefined(SCAN_WORKSPACE));
+
+  const sheets = getAcceptedSheetsInBatch(store, batchName);
+
+  for (let i = 0; i < numCopies; i += 1) {
+    const newBatchId = store.addBatch();
+    for (const sheet of sheets) {
+      copySheet(store, sheet, newBatchId);
+    }
+    store.finishBatch({ batchId: newBatchId });
+  }
+
+  const copyOrCopies = numCopies === 1 ? 'copy' : 'copies';
+  console.log(`✅ Created ${numCopies} ${copyOrCopies} of '${batchName}'`);
+}
+
+/**
+ * A script for copying a scanner store's sheet records to facilitate scale testing
+ */
+export function main(args: readonly string[]): void {
+  try {
+    checkEnvironment();
+    copyBatch(parseCommandLineArgs(args));
+  } catch (error) {
+    console.error(`❌ ${extractErrorMessage(error)}`);
+    process.exit(1);
+  }
+}

--- a/apps/central-scan/backend/tsconfig.json
+++ b/apps/central-scan/backend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../../tsconfig.shared.json",
-  "include": ["src", "test"],
+  "include": ["scripts", "src", "test"],
   "exclude": [],
   "compilerOptions": {
     "allowJs": true,

--- a/apps/design/backend/.eslintrc.json
+++ b/apps/design/backend/.eslintrc.json
@@ -3,5 +3,13 @@
   "rules": {
     // Disable JSDOC rule as code is self-documenting.
     "vx/gts-jsdoc": "off"
-  }
+  },
+  "overrides": [
+    {
+      "files": ["scripts/**"],
+      "rules": {
+        "no-console": "off"
+      }
+    }
+  ]
 }

--- a/apps/design/backend/scripts/.eslintrc.json
+++ b/apps/design/backend/scripts/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "no-console": "off"
-  }
-}

--- a/apps/design/backend/scripts/synthesize_speech.ts
+++ b/apps/design/backend/scripts/synthesize_speech.ts
@@ -52,7 +52,6 @@ async function synthesizeSpeech({
 export async function main(args: readonly string[]): Promise<void> {
   try {
     await synthesizeSpeech(parseCommandLineArgs(args));
-    process.exit(0);
   } catch (error) {
     console.error(`❌ ${extractErrorMessage(error)}`);
     process.exit(1);

--- a/apps/design/backend/scripts/synthesize_speech.ts
+++ b/apps/design/backend/scripts/synthesize_speech.ts
@@ -21,8 +21,8 @@ interface SynthesizeSpeechInput {
 
 function parseCommandLineArgs(args: readonly string[]): SynthesizeSpeechInput {
   if (args.length !== 3 || !languageCodes.includes(args[1])) {
-    console.log(usageMessage);
-    process.exit(0);
+    console.error(usageMessage);
+    process.exit(1);
   }
   const [text, languageCode, outputFilePath] = args as [
     string,

--- a/apps/design/backend/scripts/translate_text.ts
+++ b/apps/design/backend/scripts/translate_text.ts
@@ -21,8 +21,8 @@ interface TranslateTextInput {
 
 function parseCommandLineArgs(args: readonly string[]): TranslateTextInput {
   if (args.length !== 2 || !languageCodes.has(args[1])) {
-    console.log(usageMessage);
-    process.exit(0);
+    console.error(usageMessage);
+    process.exit(1);
   }
   const [text, targetLanguageCode] = args as [string, LanguageCode];
   return { targetLanguageCode, text };

--- a/apps/design/backend/scripts/translate_text.ts
+++ b/apps/design/backend/scripts/translate_text.ts
@@ -47,7 +47,6 @@ async function translateText({
 export async function main(args: readonly string[]): Promise<void> {
   try {
     await translateText(parseCommandLineArgs(args));
-    process.exit(0);
   } catch (error) {
     console.error(`❌ ${extractErrorMessage(error)}`);
     process.exit(1);

--- a/apps/scan/backend/.eslintrc.json
+++ b/apps/scan/backend/.eslintrc.json
@@ -5,6 +5,12 @@
     "vx/gts-jsdoc": "off"
   },
   "overrides": [
+    {
+      "files": ["scripts/**"],
+      "rules": {
+        "no-console": "off"
+      }
+    },
     // This file causes this rule to crash on private constructors.
     // Started happening after TypeScript upgrade to v4.6. I was not able to
     // find an issue on the GitHub repo for @typescript-eslint/eslint-plugin.

--- a/apps/scan/backend/scripts/.eslintrc.json
+++ b/apps/scan/backend/scripts/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-console": "off"
+  }
+}

--- a/apps/scan/backend/scripts/.eslintrc.json
+++ b/apps/scan/backend/scripts/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "no-console": "off"
-  }
-}

--- a/apps/scan/backend/scripts/copy-sheets
+++ b/apps/scan/backend/scripts/copy-sheets
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+require('esbuild-runner/register');
+require('./copy_sheets').main(process.argv.slice(2));

--- a/apps/scan/backend/scripts/copy_sheets.ts
+++ b/apps/scan/backend/scripts/copy_sheets.ts
@@ -91,7 +91,6 @@ export function main(args: readonly string[]): void {
   try {
     checkEnvironment();
     copySheets(parseCommandLineArgs(args));
-    process.exit(0);
   } catch (error) {
     console.error(`❌ ${extractErrorMessage(error)}`);
     process.exit(1);

--- a/apps/scan/backend/scripts/copy_sheets.ts
+++ b/apps/scan/backend/scripts/copy_sheets.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 import { v4 as uuid } from 'uuid';
 import { AcceptedSheet } from '@votingworks/backend';
 import {
@@ -40,8 +41,14 @@ function copySheet(store: Store, sheet: AcceptedSheet): void {
   const newSheet: AcceptedSheet = {
     ...sheet,
     id: newSheetId,
-    frontImagePath: sheet.frontImagePath.replace(sheet.id, newSheetId),
-    backImagePath: sheet.backImagePath.replace(sheet.id, newSheetId),
+    frontImagePath: path.join(
+      path.dirname(sheet.frontImagePath),
+      `${newSheetId}-front.jpg`
+    ),
+    backImagePath: path.join(
+      path.dirname(sheet.backImagePath),
+      `${newSheetId}-back.jpg`
+    ),
   };
 
   fs.copyFileSync(sheet.frontImagePath, newSheet.frontImagePath);
@@ -93,8 +100,9 @@ function copySheets({ targetSheetCount }: CopySheetsInput): void {
     copySheet(store, sheet);
   }
 
+  const sheetOrSheets = numSheetsToCreate === 1 ? 'sheet' : 'sheets';
   console.log(
-    `✅ Created ${numSheetsToCreate} new sheets by copying existing sheets, ` +
+    `✅ Created ${numSheetsToCreate} new ${sheetOrSheets} by copying existing sheets, ` +
       `bringing total sheet count to ${targetSheetCount}`
   );
 }

--- a/apps/scan/backend/scripts/copy_sheets.ts
+++ b/apps/scan/backend/scripts/copy_sheets.ts
@@ -6,7 +6,7 @@ import {
   assertDefined,
   extractErrorMessage,
 } from '@votingworks/basics';
-import { safeParseNumber } from '@votingworks/types';
+import { safeParseInt } from '@votingworks/types';
 
 import { SCAN_WORKSPACE } from '../src/globals';
 import { Store } from '../src/store';
@@ -26,11 +26,12 @@ function checkEnvironment(): void {
 }
 
 function parseCommandLineArgs(args: readonly string[]): CopySheetsInput {
-  if (args.length !== 1 || !safeParseNumber(args[0]).isOk()) {
-    console.log(usageMessage);
-    process.exit(0);
+  const parseTargetSheetCountResult = safeParseInt(args[0]);
+  if (args.length !== 1 || !parseTargetSheetCountResult.isOk()) {
+    console.error(usageMessage);
+    process.exit(1);
   }
-  const targetSheetCount = safeParseNumber(args[0]).unsafeUnwrap();
+  const targetSheetCount = parseTargetSheetCountResult.ok();
   return { targetSheetCount };
 }
 

--- a/apps/scan/backend/scripts/copy_sheets.ts
+++ b/apps/scan/backend/scripts/copy_sheets.ts
@@ -1,7 +1,10 @@
 import fs from 'fs';
 import path from 'path';
 import { v4 as uuid } from 'uuid';
-import { AcceptedSheet } from '@votingworks/backend';
+import {
+  AcceptedSheet,
+  clearDoesUsbDriveRequireCastVoteRecordSyncCachedResult,
+} from '@votingworks/backend';
 import {
   assert,
   assertDefined,
@@ -66,6 +69,11 @@ function copySheet(store: Store, sheet: AcceptedSheet): void {
   ]);
 }
 
+function surfaceCastVoteRecordSyncModal(store: Store): void {
+  store.setIsContinuousExportOperationInProgress(true);
+  clearDoesUsbDriveRequireCastVoteRecordSyncCachedResult();
+}
+
 function copySheets({ targetSheetCount }: CopySheetsInput): void {
   const { store } = createWorkspace(assertDefined(SCAN_WORKSPACE));
 
@@ -99,6 +107,9 @@ function copySheets({ targetSheetCount }: CopySheetsInput): void {
     const sheet = sheets[i % sheets.length];
     copySheet(store, sheet);
   }
+
+  // Ensure that the user is forced to sync cast vote records to the now out-of-sync USB drive
+  surfaceCastVoteRecordSyncModal(store);
 
   const sheetOrSheets = numSheetsToCreate === 1 ? 'sheet' : 'sheets';
   console.log(

--- a/apps/scan/backend/scripts/copy_sheets.ts
+++ b/apps/scan/backend/scripts/copy_sheets.ts
@@ -73,7 +73,7 @@ function copySheets({ targetSheetCount }: CopySheetsInput): void {
     `Target sheet count should be greater than current sheet count (${sheets.length})`
   );
 
-  const numSheetsToCreate = Math.max(targetSheetCount - sheets.length, 0);
+  const numSheetsToCreate = targetSheetCount - sheets.length;
   for (let i = 0; i < numSheetsToCreate; i += 1) {
     const sheet = sheets[i % sheets.length];
     copySheet(store, sheet);

--- a/apps/scan/backend/scripts/copy_sheets.ts
+++ b/apps/scan/backend/scripts/copy_sheets.ts
@@ -21,6 +21,10 @@ interface CopySheetsInput {
   targetSheetCount: number;
 }
 
+function checkEnvironment(): void {
+  assert(process.env.NODE_ENV !== 'production', 'Cannot be run in production');
+}
+
 function parseCommandLineArgs(args: readonly string[]): CopySheetsInput {
   if (args.length !== 1 || !safeParseNumber(args[0]).isOk()) {
     console.log(usageMessage);
@@ -85,6 +89,7 @@ function copySheets({ targetSheetCount }: CopySheetsInput): void {
  */
 export function main(args: readonly string[]): void {
   try {
+    checkEnvironment();
     copySheets(parseCommandLineArgs(args));
     process.exit(0);
   } catch (error) {

--- a/apps/scan/backend/scripts/copy_sheets.ts
+++ b/apps/scan/backend/scripts/copy_sheets.ts
@@ -1,0 +1,94 @@
+import fs from 'fs';
+import path from 'path';
+import { v4 as uuid } from 'uuid';
+import { AcceptedSheet } from '@votingworks/backend';
+import {
+  assert,
+  assertDefined,
+  extractErrorMessage,
+} from '@votingworks/basics';
+import { safeParseNumber } from '@votingworks/types';
+
+import { SCAN_WORKSPACE } from '../src/globals';
+import { Store } from '../src/store';
+
+const usageMessage = `Usage: copy-sheets <target-sheet-count>
+
+Arguments:
+  <target-sheet-count>\tThe target total sheet count after copying`;
+
+interface CopySheetsInput {
+  targetSheetCount: number;
+}
+
+function parseCommandLineArgs(args: readonly string[]): CopySheetsInput {
+  if (args.length !== 1 || !safeParseNumber(args[0]).isOk()) {
+    console.log(usageMessage);
+    process.exit(0);
+  }
+  const targetSheetCount = safeParseNumber(args[0]).unsafeUnwrap();
+  return { targetSheetCount };
+}
+
+function copySheet(store: Store, sheet: AcceptedSheet): void {
+  const newSheetId = uuid();
+  const newSheet: AcceptedSheet = {
+    ...sheet,
+    id: newSheetId,
+    frontImagePath: sheet.frontImagePath.replace(sheet.id, newSheetId),
+    backImagePath: sheet.backImagePath.replace(sheet.id, newSheetId),
+  };
+
+  fs.copyFileSync(sheet.frontImagePath, newSheet.frontImagePath);
+  fs.copyFileSync(sheet.backImagePath, newSheet.backImagePath);
+
+  store.addSheet(newSheetId, newSheet.batchId, [
+    {
+      imagePath: newSheet.frontImagePath,
+      interpretation: newSheet.interpretation[0],
+    },
+    {
+      imagePath: newSheet.backImagePath,
+      interpretation: newSheet.interpretation[1],
+    },
+  ]);
+}
+
+function copySheets({ targetSheetCount }: CopySheetsInput): void {
+  const store = Store.fileStore(
+    path.join(assertDefined(SCAN_WORKSPACE), 'ballots.db')
+  );
+  const sheets = Array.from(store.forEachAcceptedSheet());
+
+  assert(
+    sheets.length > 0,
+    'Scanner store should contain at least one sheet to copy'
+  );
+  assert(
+    targetSheetCount > sheets.length,
+    `Target sheet count should be greater than current sheet count (${sheets.length})`
+  );
+
+  const numSheetsToCreate = Math.max(targetSheetCount - sheets.length, 0);
+  for (let i = 0; i < numSheetsToCreate; i += 1) {
+    const sheet = sheets[i % sheets.length];
+    copySheet(store, sheet);
+  }
+  console.log(
+    `✅ Created ${numSheetsToCreate} new sheets by copying existing sheets, ` +
+      `bringing total sheet count to ${targetSheetCount}`
+  );
+}
+
+/**
+ * A script for copying a scanner store's sheet records to facilitate scale testing
+ */
+export function main(args: readonly string[]): void {
+  try {
+    copySheets(parseCommandLineArgs(args));
+    process.exit(0);
+  } catch (error) {
+    console.error(`❌ ${extractErrorMessage(error)}`);
+    process.exit(1);
+  }
+}

--- a/apps/scan/backend/tsconfig.json
+++ b/apps/scan/backend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../../tsconfig.shared.json",
-  "include": ["src", "test"],
+  "include": ["scripts", "src", "test"],
   "exclude": [],
   "compilerOptions": {
     "allowJs": true,

--- a/libs/auth/.eslintrc.json
+++ b/libs/auth/.eslintrc.json
@@ -1,3 +1,11 @@
 {
-  "extends": ["plugin:vx/recommended"]
+  "extends": ["plugin:vx/recommended"],
+  "overrides": [
+    {
+      "files": ["scripts/**"],
+      "rules": {
+        "no-console": "off"
+      }
+    }
+  ]
 }

--- a/libs/auth/scripts/.eslintrc.json
+++ b/libs/auth/scripts/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "no-console": "off"
-  }
-}

--- a/libs/auth/scripts/check_pin.ts
+++ b/libs/auth/scripts/check_pin.ts
@@ -56,7 +56,6 @@ async function checkPin({ cardType }: CheckPinInput): Promise<void> {
 export async function main(args: readonly string[]): Promise<void> {
   try {
     await checkPin(parseCommandLineArgs(args));
-    process.exit(0);
   } catch (error) {
     console.error(`❌ ${extractErrorMessage(error)}`);
     process.exit(1);

--- a/libs/auth/scripts/check_pin.ts
+++ b/libs/auth/scripts/check_pin.ts
@@ -14,8 +14,8 @@ interface CheckPinInput {
 
 function parseCommandLineArgs(args: readonly string[]): CheckPinInput {
   if (args.length > 1 || ![undefined, '--cac', '--vxsuite'].includes(args[0])) {
-    console.log(usageMessage);
-    process.exit(0);
+    console.error(usageMessage);
+    process.exit(1);
   }
   return { cardType: args[0] === '--cac' ? 'cac' : 'vxsuite' };
 }

--- a/libs/auth/scripts/configure_java_card.ts
+++ b/libs/auth/scripts/configure_java_card.ts
@@ -286,7 +286,6 @@ export async function main(): Promise<void> {
     await runAppletConfigurationCommands();
     await createAndStoreCardVxCert();
     sectionLog('✅', 'Done!');
-    process.exit(0);
   } catch (error) {
     console.error(`❌ ${extractErrorMessage(error)}`);
     process.exit(1);

--- a/libs/auth/scripts/create_production_machine_cert_signing_request.ts
+++ b/libs/auth/scripts/create_production_machine_cert_signing_request.ts
@@ -24,7 +24,6 @@ async function createProductionMachineCertSigningRequest(): Promise<void> {
 export async function main(): Promise<void> {
   try {
     await createProductionMachineCertSigningRequest();
-    process.exit(0);
   } catch (error) {
     console.error(`❌ ${extractErrorMessage(error)}`);
     process.exit(1);

--- a/libs/auth/scripts/generate_dev_keys_and_certs.ts
+++ b/libs/auth/scripts/generate_dev_keys_and_certs.ts
@@ -301,7 +301,6 @@ async function generateDevKeysAndCerts({
 export async function main(): Promise<void> {
   try {
     await generateDevKeysAndCerts(await parseCommandLineArgs());
-    process.exit(0);
   } catch (error) {
     console.error(`❌ ${extractErrorMessage(error)}`);
     process.exit(1);

--- a/libs/auth/scripts/mock_card.ts
+++ b/libs/auth/scripts/mock_card.ts
@@ -205,7 +205,6 @@ function mockCardWrapper({ cardType, electionHash }: MockCardInput) {
 export async function main(): Promise<void> {
   try {
     mockCardWrapper(await parseCommandLineArgs());
-    process.exit(0);
   } catch (error) {
     console.error(`❌ ${extractErrorMessage(error)}`);
     process.exit(1);

--- a/libs/auth/scripts/program_system_administrator_java_card.ts
+++ b/libs/auth/scripts/program_system_administrator_java_card.ts
@@ -58,7 +58,6 @@ async function programSystemAdministratorJavaCard(): Promise<void> {
 export async function main(): Promise<void> {
   try {
     await programSystemAdministratorJavaCard();
-    process.exit(0);
   } catch (error) {
     console.error(`❌ ${extractErrorMessage(error)}`);
     process.exit(1);

--- a/libs/auth/scripts/read_java_card_details.ts
+++ b/libs/auth/scripts/read_java_card_details.ts
@@ -75,7 +75,6 @@ Election hash: ${electionHash ?? '-'}
 export async function main(): Promise<void> {
   try {
     printCardDetails(await readJavaCardDetails());
-    process.exit(0);
   } catch (error) {
     console.error(`❌ ${extractErrorMessage(error)}`);
     process.exit(1);


### PR DESCRIPTION
## Overview

In preparation for upcoming QA, I'm committing a script that I've been using to facilitate my own scale testing. The script copies a scanner store's sheet records to quickly bump the sheet count up without having to physically scan ballots.

### Gotchas

Because the script is copying sheets rather than creating them from scratch, a first sheet does have to be physically scanned before the script can be used. The script reminds you of this, if relevant:

```
$ ./copy-sheets 10
❌ Scanner store should contain at least one sheet to copy
```

-----

For safety, I added a check to ensure that the script cannot be run in production:

```
$ NODE_ENV=production ./copy-sheets 
❌ Cannot be run in production
```

-----

And finally, the script does not cover continuous export to the USB drive, but it does surface the CVR re-sync modal on completion.

### Update 11/20

I've also added a script to facilitate scale testing on VxCentralScan. This script copies a specified batch and all its sheets. Here's the usage message for both scripts.

_VxScan script_

```
Usage: copy-sheets <target-sheet-count>

Arguments:
  <target-sheet-count>	The target total sheet count after copying
```

_VxCentralScan script_

```
Usage: copy-batch '<batch-name>' <num-copies>

Arguments:
  <batch-name>	The name of the batch to copy
  <num-copies>	The number of copies to create
```

## Demo Video

https://github.com/votingworks/vxsuite/assets/12616928/608a9175-2e2a-4e22-837a-b1bb38b713c4

## Testing Plan

- [x] Tested manually