### PR TITLE
fix(auth): handle mock CAC card bad PIN responses

### DIFF
--- a/libs/auth/src/cac/common_access_card.test.ts
+++ b/libs/auth/src/cac/common_access_card.test.ts
@@ -203,6 +203,23 @@ test('checkPin: failure', async () => {
   );
 });
 
+test('checkPin: failure with incorrect pin status word', async () => {
+  const cac = new CommonAccessCard();
+
+  mockCardAppletSelectionRequest();
+  mockCardGetCertificateRequest(
+    CARD_DOD_CERT.OBJECT_ID,
+    await certPemToDer(DEV_CERT_PEM)
+  );
+  mockCardPinVerificationRequest('1234', new ResponseApduError([0x63, 0xc1]));
+  expect(await cac.checkPin('1234')).toEqual(
+    typedAs<CheckPinResponse>({
+      response: 'incorrect',
+      numIncorrectPinAttempts: -1,
+    })
+  );
+});
+
 test('checkPin: unexpected error', async () => {
   const cac = new CommonAccessCard();
 

--- a/libs/auth/src/cac/common_access_card.ts
+++ b/libs/auth/src/cac/common_access_card.ts
@@ -24,6 +24,7 @@ import {
   CRYPTOGRAPHIC_ALGORITHM_IDENTIFIER,
   GENERAL_AUTHENTICATE,
   GET_DATA,
+  isIncorrectPinStatusWord,
   isSecurityConditionNotSatisfiedStatusWord,
   pivDataObjectId,
   PUT_DATA,
@@ -171,7 +172,10 @@ export class CommonAccessCard implements CommonAccessCardCompatibleCard {
     } catch (error) {
       if (
         error instanceof ResponseApduError &&
-        isSecurityConditionNotSatisfiedStatusWord(error.statusWord())
+        // real CAC cards return 0x6982 for an incorrect PIN
+        (isSecurityConditionNotSatisfiedStatusWord(error.statusWord()) ||
+          // our mock CAC cards return 0x63c? for an incorrect PIN
+          isIncorrectPinStatusWord(error.statusWord()))
       ) {
         return { response: 'incorrect', numIncorrectPinAttempts: -1 };
       }


### PR DESCRIPTION
## Overview

Our mock CAC cards act the same as our VxSuite cards when receiving an invalid PIN. Instead of responding with a "security condition not satisfied" code, they respond with "counter has reached the value X".

## Demo Video or Screenshot
n/a

## Testing Plan
Automated tests. @benadida to put up a parallel PR that will enable me to manually test this (or he can).
