### PR TITLE
add scripts and capabilities for building a simulated CAC card out of a JavaCard

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1208,6 +1208,7 @@ commands:
       # Edit this comment somehow in order to invalidate the CircleCI cache.
       # Since the contents of this file affect the cache key, editing only a
       # comment will invalidate the cache without changing the behavior.
+      # last edited by Ben 2023-11-17
       - restore_cache:
           key:
             dotcache-cache-{{checksum ".circleci/config.yml" }}-{{ checksum

--- a/libs/auth/package.json
+++ b/libs/auth/package.json
@@ -39,6 +39,7 @@
     "@votingworks/utils": "workspace:*",
     "base64-js": "1.5.1",
     "combined-stream": "^1.0.8",
+    "debug": "4.3.4",
     "js-sha256": "^0.9.0",
     "luxon": "^3.0.0",
     "node-fetch": "^2.6.0",
@@ -50,6 +51,7 @@
   },
   "devDependencies": {
     "@types/combined-stream": "^1.0.3",
+    "@types/debug": "4.1.8",
     "@types/jest": "^29.5.3",
     "@types/luxon": "^3.0.0",
     "@types/node-fetch": "^2.6.0",

--- a/libs/auth/scripts/configure-dev-simulated-cac-card
+++ b/libs/auth/scripts/configure-dev-simulated-cac-card
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPTS_DIRECTORY="$(dirname "${BASH_SOURCE[0]}")"
+
+VX_CERT_AUTHORITY_CERT_PATH="${SCRIPTS_DIRECTORY}/../certs/dev/vx-cert-authority-cert.pem" \
+    VX_PRIVATE_KEY_PATH="${SCRIPTS_DIRECTORY}/../certs/dev/vx-private-key.pem" \
+    "${SCRIPTS_DIRECTORY}/configure-simulated-cac-card"

--- a/libs/auth/scripts/configure-simulated-cac-card
+++ b/libs/auth/scripts/configure-simulated-cac-card
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+require('esbuild-runner/register');
+require('./configure_simulated_cac_card').main();

--- a/libs/auth/scripts/configure_simulated_cac_card.ts
+++ b/libs/auth/scripts/configure_simulated_cac_card.ts
@@ -1,0 +1,292 @@
+import { Buffer } from 'buffer';
+import { existsSync } from 'fs';
+import path from 'path';
+import { extractErrorMessage } from '@votingworks/basics';
+import { Byte } from '@votingworks/types';
+
+import { CommandApdu, constructTlv } from '../src/apdu';
+import { getRequiredEnvVar } from '../src/env_vars';
+import {
+  MAX_NUM_INCORRECT_PIN_ATTEMPTS,
+  OPEN_FIPS_201_AID,
+  PUK,
+} from '../src/java_card';
+import {
+  construct8BytePinBuffer,
+  CRYPTOGRAPHIC_ALGORITHM_IDENTIFIER,
+} from '../src/piv';
+import { runCommand } from '../src/shell';
+import { waitForReadyCardStatus } from './utils';
+
+import { CARD_DOD_CERT, CommonAccessCard, DEFAULT_PIN } from '../src/cac';
+
+const APPLET_PATH = path.join(
+  __dirname,
+  '../applets/OpenFIPS201-v1.10.2-with-vx-mods.cap'
+);
+const GLOBAL_PLATFORM_JAR_FILE_PATH = path.join(__dirname, '../scripts/gp.jar');
+
+/**
+ * CHANGE REFERENCE DATA ADMIN is an OpenFIPS201-specific extension of the PIV-standard CHANGE
+ * REFERENCE DATA command. It allows setting PINs and PUKs without the current value. APDUs must be
+ * sent over a GlobalPlatform Secure Channel.
+ */
+const CHANGE_REFERENCE_DATA_ADMIN = {
+  INS: 0x24,
+  P1: 0xff,
+  P2_PIN: 0x80,
+  P2_PUK: 0x81,
+} as const;
+
+/**
+ * PUT DATA ADMIN is an OpenFIPS201-specific extension of the PIV-standard PUT DATA command, meant
+ * for initial card configuration. APDUs must be sent over a GlobalPlatform Secure Channel.
+ */
+const PUT_DATA_ADMIN = {
+  INS: 0xdb,
+  P1: 0x3f,
+  P2: 0x00,
+
+  UPDATE_CONFIG_TAG: 0x68,
+  PIN_POLICY_TAG: 0xa0,
+  MAX_INCORRECT_PIN_ATTEMPTS_OVER_CONTACT_INTERFACE_TAG: 0x86,
+
+  CREATE_KEY_TAG: 0x66,
+  CREATE_OBJECT_TAG: 0x64,
+  ID_TAG: 0x8b,
+  ACCESS_MODE_OVER_CONTACT_INTERFACE_TAG: 0x8c,
+  ACCESS_MODE_OVER_CONTACTLESS_INTERFACE_TAG: 0x8d,
+  ACCESS_MODE_NEVER: 0x00,
+  ACCESS_MODE_PIN_GATED: 0x12,
+  ACCESS_MODE_ALWAYS: 0x7f,
+  KEY_MECHANISM_TAG: 0x8e,
+  KEY_ROLE_TAG: 0x8f,
+  KEY_ROLE_SIGN: 0x04,
+  KEY_ATTRIBUTE_TAG: 0x90,
+  KEY_ATTRIBUTE_NONE: 0x00,
+} as const;
+
+const vxCertAuthorityCertPath = getRequiredEnvVar(
+  'VX_CERT_AUTHORITY_CERT_PATH'
+);
+const vxPrivateKeyPath = getRequiredEnvVar('VX_PRIVATE_KEY_PATH');
+
+function sectionLog(symbol: string, message: string): void {
+  console.log('-'.repeat(3 + message.length));
+  console.log(`${symbol} ${message}`);
+  console.log('-'.repeat(3 + message.length));
+}
+
+function globalPlatformCommand(command: string[]): string[] {
+  return ['java', '-jar', GLOBAL_PLATFORM_JAR_FILE_PATH, ...command];
+}
+
+function checkForScriptDependencies(): void {
+  if (!existsSync(GLOBAL_PLATFORM_JAR_FILE_PATH)) {
+    throw new Error(
+      'Missing script dependencies; install using `make install-script-dependencies` in libs/auth'
+    );
+  }
+}
+
+async function installApplet(): Promise<void> {
+  sectionLog('🧹', 'Uninstalling applet if already installed...');
+  try {
+    await runCommand(globalPlatformCommand(['--uninstall', APPLET_PATH]));
+  } catch (error) {
+    // Don't err if the applet was never installed to begin with
+    if (!extractErrorMessage(error).includes('is not present on card!')) {
+      throw error;
+    }
+  }
+
+  sectionLog('💿', 'Installing applet...');
+  await runCommand(globalPlatformCommand(['--install', APPLET_PATH]));
+}
+
+function configureKeySlotCommandApdu(
+  keyId: Byte,
+  accessMode: Byte
+): CommandApdu {
+  return new CommandApdu({
+    cla: { secure: true },
+    ins: PUT_DATA_ADMIN.INS,
+    p1: PUT_DATA_ADMIN.P1,
+    p2: PUT_DATA_ADMIN.P2,
+    data: constructTlv(
+      PUT_DATA_ADMIN.CREATE_KEY_TAG,
+      Buffer.concat([
+        constructTlv(PUT_DATA_ADMIN.ID_TAG, Buffer.of(keyId)),
+        constructTlv(
+          PUT_DATA_ADMIN.ACCESS_MODE_OVER_CONTACT_INTERFACE_TAG,
+          Buffer.of(accessMode)
+        ),
+        constructTlv(
+          PUT_DATA_ADMIN.ACCESS_MODE_OVER_CONTACTLESS_INTERFACE_TAG,
+          Buffer.of(PUT_DATA_ADMIN.ACCESS_MODE_NEVER)
+        ),
+        constructTlv(
+          PUT_DATA_ADMIN.KEY_MECHANISM_TAG,
+          Buffer.of(CRYPTOGRAPHIC_ALGORITHM_IDENTIFIER.RSA2048)
+        ),
+        constructTlv(
+          PUT_DATA_ADMIN.KEY_ROLE_TAG,
+          Buffer.of(PUT_DATA_ADMIN.KEY_ROLE_SIGN)
+        ),
+        constructTlv(
+          PUT_DATA_ADMIN.KEY_ATTRIBUTE_TAG,
+          Buffer.of(PUT_DATA_ADMIN.KEY_ATTRIBUTE_NONE)
+        ),
+      ])
+    ),
+  });
+}
+
+function configureDataObjectSlotCommandApdu(objectId: Buffer): CommandApdu {
+  return new CommandApdu({
+    cla: { secure: true },
+    ins: PUT_DATA_ADMIN.INS,
+    p1: PUT_DATA_ADMIN.P1,
+    p2: PUT_DATA_ADMIN.P2,
+    data: constructTlv(
+      PUT_DATA_ADMIN.CREATE_OBJECT_TAG,
+      Buffer.concat([
+        constructTlv(PUT_DATA_ADMIN.ID_TAG, objectId),
+        constructTlv(
+          PUT_DATA_ADMIN.ACCESS_MODE_OVER_CONTACT_INTERFACE_TAG,
+          Buffer.of(PUT_DATA_ADMIN.ACCESS_MODE_ALWAYS)
+        ),
+        constructTlv(
+          PUT_DATA_ADMIN.ACCESS_MODE_OVER_CONTACTLESS_INTERFACE_TAG,
+          Buffer.of(PUT_DATA_ADMIN.ACCESS_MODE_NEVER)
+        ),
+      ])
+    ),
+  });
+}
+
+async function runAppletConfigurationCommands(): Promise<void> {
+  const cardPin = process.env['CARD_PIN'] || DEFAULT_PIN;
+  sectionLog(
+    '🔧',
+    `Running applet configuration commands, with PIN ${cardPin}...`
+  );
+
+  const apdus = [
+    // Set PIN
+    new CommandApdu({
+      cla: { secure: true },
+      ins: CHANGE_REFERENCE_DATA_ADMIN.INS,
+      p1: CHANGE_REFERENCE_DATA_ADMIN.P1,
+      p2: CHANGE_REFERENCE_DATA_ADMIN.P2_PIN,
+      data: construct8BytePinBuffer(cardPin),
+    }),
+
+    // Set PUK
+    new CommandApdu({
+      cla: { secure: true },
+      ins: CHANGE_REFERENCE_DATA_ADMIN.INS,
+      p1: CHANGE_REFERENCE_DATA_ADMIN.P1,
+      p2: CHANGE_REFERENCE_DATA_ADMIN.P2_PUK,
+      data: PUK,
+    }),
+
+    // Configure max incorrect PIN attempts
+    new CommandApdu({
+      cla: { secure: true },
+      ins: PUT_DATA_ADMIN.INS,
+      p1: PUT_DATA_ADMIN.P1,
+      p2: PUT_DATA_ADMIN.P2,
+      data: constructTlv(
+        PUT_DATA_ADMIN.UPDATE_CONFIG_TAG,
+        constructTlv(
+          PUT_DATA_ADMIN.PIN_POLICY_TAG,
+          constructTlv(
+            PUT_DATA_ADMIN.MAX_INCORRECT_PIN_ATTEMPTS_OVER_CONTACT_INTERFACE_TAG,
+            Buffer.of(MAX_NUM_INCORRECT_PIN_ATTEMPTS)
+          )
+        )
+      ),
+    }),
+
+    // Configure key slots
+    configureKeySlotCommandApdu(
+      CARD_DOD_CERT.PRIVATE_KEY_ID,
+      // This doesn't mean that the private key itself can be accessed, just that it can always be
+      // used for signing operations, without a PIN
+      PUT_DATA_ADMIN.ACCESS_MODE_ALWAYS
+    ),
+
+    // Configure data object slots
+    configureDataObjectSlotCommandApdu(CARD_DOD_CERT.OBJECT_ID), // configureDataObjectSlotCommandApdu(CARD_VX_CERT.OBJECT_ID),
+  ];
+
+  const apduStrings = apdus.map((apdu) => apdu.asHexString(':'));
+  console.log(
+    'Sending the following APDUs over a GlobalPlatform Secure Channel:'
+  );
+  for (const apduString of apduStrings) {
+    console.log(`> ${apduString}`);
+  }
+  const output = await runCommand(
+    // -d --> Output command and response APDUs
+    // -c <applet-id> + --mode enc + -s <apdu> --> Use a GlobalPlatform Secure Channel
+    globalPlatformCommand([
+      '-d',
+      '-c',
+      OPEN_FIPS_201_AID,
+      '--mode',
+      'enc',
+      ...apduStrings.map((apduString) => ['-s', apduString]).flat(),
+    ])
+  );
+  const apduLines = output
+    .toString('utf-8')
+    .split('\n')
+    .filter((line) => line.startsWith('A>>') || line.startsWith('A<<'));
+  const successCount = apduLines.filter(
+    (line) => line.startsWith('A<<') && line.endsWith('9000')
+  ).length;
+  // Applet selection and establishment of GlobalPlatform Secure Channel
+  const baselineApduCount = 3;
+  if (successCount !== baselineApduCount + apdus.length) {
+    console.error(apduLines.join('\n'));
+    throw new Error(
+      'Not all applet configuration commands returned 90 00 success status word'
+    );
+  }
+}
+
+async function createAndStoreCardVxCert(commonName: string): Promise<void> {
+  sectionLog(
+    '🔏',
+    `Creating and storing simulated CAC cert for ${commonName} ...`
+  );
+  const card = new CommonAccessCard({ certPath: vxCertAuthorityCertPath });
+  await waitForReadyCardStatus(card);
+  await card.createAndStoreCert(
+    {
+      source: 'file',
+      path: vxPrivateKeyPath,
+    },
+    commonName
+  );
+}
+
+/**
+ * Create a mock Common Access Card for use with RAVE.
+ */
+export async function main(): Promise<void> {
+  try {
+    const commonName = getRequiredEnvVar('CERT_COMMON_NAME');
+    checkForScriptDependencies();
+    await installApplet();
+    await runAppletConfigurationCommands();
+    await createAndStoreCardVxCert(commonName);
+    sectionLog('✅', 'Done!');
+    process.exit(0);
+  } catch (error) {
+    console.error(`❌ ${extractErrorMessage(error)}`);
+    process.exit(1);
+  }
+}

--- a/libs/auth/src/piv.ts
+++ b/libs/auth/src/piv.ts
@@ -10,6 +10,14 @@ import { STATUS_WORD } from './apdu';
  */
 
 /**
+ * standard tags for PIV TLVs
+ */
+export const GENERATE_RSA_PUBLIC_KEY_RESPONSE_TAG = Buffer.of(0x7f, 0x49); // eslint-disable-next-line vx/gts-jsdoc
+export const RSA_PUBLIC_KEY_MODULUS_TAG = 0x81; // eslint-disable-next-line vx/gts-jsdoc
+export const RSA_PUBLIC_KEY_EXPONENT_TAG = 0x82; // eslint-disable-next-line vx/gts-jsdoc
+export const SEQUENCE_TAG = 0x30;
+
+/**
  * PIV IDs for different cryptographic algorithms, e.g. elliptic curve cryptography, RSA, etc.
  */
 export const CRYPTOGRAPHIC_ALGORITHM_IDENTIFIER = {

--- a/libs/monorepo-utils/src/circleci.ts
+++ b/libs/monorepo-utils/src/circleci.ts
@@ -153,6 +153,7 @@ commands:
       # Edit this comment somehow in order to invalidate the CircleCI cache.
       # Since the contents of this file affect the cache key, editing only a
       # comment will invalidate the cache without changing the behavior.
+      # last edited by Ben 2023-11-17
       - restore_cache:
           key:
             dotcache-cache-{{checksum ".circleci/config.yml" }}-{{ checksum

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2822,6 +2822,9 @@ importers:
       combined-stream:
         specifier: ^1.0.8
         version: 1.0.8
+      debug:
+        specifier: 4.3.4
+        version: 4.3.4(supports-color@5.5.0)
       js-sha256:
         specifier: ^0.9.0
         version: 0.9.0
@@ -2850,6 +2853,9 @@ importers:
       '@types/combined-stream':
         specifier: ^1.0.3
         version: 1.0.3
+      '@types/debug':
+        specifier: 4.1.8
+        version: 4.1.8
       '@types/jest':
         specifier: ^29.5.3
         version: 29.5.3


### PR DESCRIPTION
Allow us to program a JavaCard to mimick a CAC card as best as possible. Important changes:
- use the same key slots as the CAC card
- use RSA2048 instead of ECC

all the changes are downstream from those two requirements.