### PR TITLE
refactor(mark): remove unused `forceSaveVoteFlag`

### DIFF
--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -99,7 +99,6 @@ interface SharedState {
 interface OtherState {
   lastVoteUpdateAt: number;
   lastVoteSaveToCardAt: number;
-  forceSaveVoteFlag: boolean;
   writingVoteToCard: boolean;
   initializedFromStorage: boolean;
 }
@@ -138,7 +137,6 @@ const initialSharedState: Readonly<SharedState> = {
 const initialOtherState: Readonly<OtherState> = {
   lastVoteUpdateAt: 0,
   lastVoteSaveToCardAt: 0,
-  forceSaveVoteFlag: false,
   writingVoteToCard: false,
   initializedFromStorage: false,
 };
@@ -158,7 +156,6 @@ type AppAction =
   | { type: 'updateLastVoteUpdateAt'; date: number }
   | { type: 'unconfigure' }
   | { type: 'updateVote'; contestId: ContestId; vote: OptionalVote }
-  | { type: 'forceSaveVote' }
   | { type: 'resetBallot' }
   | { type: 'enableLiveMode' }
   | { type: 'toggleLiveMode' }
@@ -191,11 +188,6 @@ function appReducer(state: State, action: AppAction): State {
         },
       };
     }
-    case 'forceSaveVote':
-      return {
-        ...state,
-        forceSaveVoteFlag: true,
-      };
     case 'resetBallot':
       return {
         ...state,
@@ -383,10 +375,6 @@ export function AppRoot({
 
   const updateVote = useCallback((contestId: ContestId, vote: OptionalVote) => {
     dispatchAppState({ type: 'updateVote', contestId, vote });
-  }, []);
-
-  const forceSaveVote = useCallback(() => {
-    dispatchAppState({ type: 'forceSaveVote' });
   }, []);
 
   const enableLiveMode = useCallback(() => {
@@ -767,7 +755,6 @@ export function AppRoot({
                 endVoterSession,
                 resetBallot,
                 updateVote,
-                forceSaveVote,
                 votes: votes ?? blankBallotVotes,
               }}
             >

--- a/apps/mark-scan/frontend/src/config/types.ts
+++ b/apps/mark-scan/frontend/src/config/types.ts
@@ -35,7 +35,6 @@ export interface BallotContextInterface {
   resetBallot: (showPostVotingInstructions?: boolean) => void;
   updateTally: () => void;
   updateVote: UpdateVoteFunction;
-  forceSaveVote: () => void;
   votes: VotesDict;
 }
 

--- a/apps/mark-scan/frontend/src/contexts/ballot_context.ts
+++ b/apps/mark-scan/frontend/src/contexts/ballot_context.ts
@@ -16,7 +16,6 @@ const ballot: BallotContextInterface = {
   resetBallot: () => undefined,
   updateTally: () => undefined,
   updateVote: () => undefined,
-  forceSaveVote: () => undefined,
   votes: {},
 };
 

--- a/apps/mark-scan/frontend/src/pages/start_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/start_screen.tsx
@@ -6,16 +6,10 @@ import { BallotContext } from '../contexts/ballot_context';
 
 export function StartScreen(): JSX.Element {
   const history = useHistory();
-  const {
-    ballotStyleId,
-    contests,
-    electionDefinition,
-    precinctId,
-    forceSaveVote,
-  } = useContext(BallotContext);
+  const { ballotStyleId, contests, electionDefinition, precinctId } =
+    useContext(BallotContext);
 
   function onStart() {
-    forceSaveVote();
     history.push('/contests/0');
   }
 

--- a/apps/mark-scan/frontend/test/test_utils.tsx
+++ b/apps/mark-scan/frontend/test/test_utils.tsx
@@ -37,7 +37,6 @@ export function render(
     resetBallot = jest.fn(),
     updateTally = jest.fn(),
     updateVote = jest.fn(),
-    forceSaveVote = jest.fn(),
     votes = {},
     apiMock = createApiMock(),
   }: {
@@ -56,7 +55,6 @@ export function render(
     setUserSettings?(): void;
     updateTally?(): void;
     updateVote?(): void;
-    forceSaveVote?(): void;
     votes?: VotesDict;
     apiMock?: ApiMock;
   } = {}
@@ -79,7 +77,6 @@ export function render(
               resetBallot,
               updateTally,
               updateVote,
-              forceSaveVote,
               votes,
             }}
           >

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -93,7 +93,6 @@ interface SharedState {
 interface OtherState {
   lastVoteUpdateAt: number;
   lastVoteSaveToCardAt: number;
-  forceSaveVoteFlag: boolean;
   writingVoteToCard: boolean;
   initializedFromStorage: boolean;
 }
@@ -134,7 +133,6 @@ const initialSharedState: Readonly<SharedState> = {
 const initialOtherState: Readonly<OtherState> = {
   lastVoteUpdateAt: 0,
   lastVoteSaveToCardAt: 0,
-  forceSaveVoteFlag: false,
   writingVoteToCard: false,
   initializedFromStorage: false,
 };
@@ -154,7 +152,6 @@ type AppAction =
   | { type: 'updateLastVoteUpdateAt'; date: number }
   | { type: 'unconfigure' }
   | { type: 'updateVote'; contestId: ContestId; vote: OptionalVote }
-  | { type: 'forceSaveVote' }
   | { type: 'resetBallot'; showPostVotingInstructions?: boolean }
   | { type: 'updateAppPrecinct'; appPrecinct: PrecinctSelection }
   | { type: 'enableLiveMode' }
@@ -188,11 +185,6 @@ function appReducer(state: State, action: AppAction): State {
         },
       };
     }
-    case 'forceSaveVote':
-      return {
-        ...state,
-        forceSaveVoteFlag: true,
-      };
     case 'resetBallot':
       return {
         ...state,
@@ -424,10 +416,6 @@ export function AppRoot({
 
   const updateVote = useCallback((contestId: ContestId, vote: OptionalVote) => {
     dispatchAppState({ type: 'updateVote', contestId, vote });
-  }, []);
-
-  const forceSaveVote = useCallback(() => {
-    dispatchAppState({ type: 'forceSaveVote' });
   }, []);
 
   const updateAppPrecinct = useCallback((newAppPrecinct: PrecinctSelection) => {
@@ -764,7 +752,6 @@ export function AppRoot({
                 endVoterSession,
                 resetBallot,
                 updateVote,
-                forceSaveVote,
                 votes: votes ?? blankBallotVotes,
               }}
             >

--- a/apps/mark/frontend/src/config/types.ts
+++ b/apps/mark/frontend/src/config/types.ts
@@ -35,7 +35,6 @@ export interface BallotContextInterface {
   resetBallot: (showPostVotingInstructions?: boolean) => void;
   updateTally: () => void;
   updateVote: UpdateVoteFunction;
-  forceSaveVote: () => void;
   votes: VotesDict;
 }
 

--- a/apps/mark/frontend/src/contexts/ballot_context.ts
+++ b/apps/mark/frontend/src/contexts/ballot_context.ts
@@ -16,7 +16,6 @@ const ballot: BallotContextInterface = {
   resetBallot: () => undefined,
   updateTally: () => undefined,
   updateVote: () => undefined,
-  forceSaveVote: () => undefined,
   votes: {},
 };
 

--- a/apps/mark/frontend/src/pages/start_screen.tsx
+++ b/apps/mark/frontend/src/pages/start_screen.tsx
@@ -5,16 +5,10 @@ import { BallotContext } from '../contexts/ballot_context';
 
 export function StartScreen(): JSX.Element {
   const history = useHistory();
-  const {
-    ballotStyleId,
-    contests,
-    electionDefinition,
-    precinctId,
-    forceSaveVote,
-  } = React.useContext(BallotContext);
+  const { ballotStyleId, contests, electionDefinition, precinctId } =
+    React.useContext(BallotContext);
 
   function onStart() {
-    forceSaveVote();
     history.push('/contests/0');
   }
 

--- a/apps/mark/frontend/test/test_utils.tsx
+++ b/apps/mark/frontend/test/test_utils.tsx
@@ -33,7 +33,6 @@ export function render(
     resetBallot = jest.fn(),
     updateTally = jest.fn(),
     updateVote = jest.fn(),
-    forceSaveVote = jest.fn(),
     votes = {},
   }: {
     route?: string;
@@ -51,7 +50,6 @@ export function render(
     setUserSettings?(): void;
     updateTally?(): void;
     updateVote?(): void;
-    forceSaveVote?(): void;
     votes?: VotesDict;
   } = {}
 ): ReturnType<typeof testRender> {
@@ -71,7 +69,6 @@ export function render(
           resetBallot,
           updateTally,
           updateVote,
-          forceSaveVote,
           votes,
         }}
       >

--- a/libs/mark-flow-ui/src/config/types.ts
+++ b/libs/mark-flow-ui/src/config/types.ts
@@ -34,7 +34,6 @@ export interface BallotContextInterface {
   resetBallot: (showPostVotingInstructions?: boolean) => void;
   updateTally: () => void;
   updateVote: UpdateVoteFunction;
-  forceSaveVote: () => void;
   votes: VotesDict;
 }
 


### PR DESCRIPTION
## Overview

This was added in 5c46e9cbc2eeb26cd25772fabe7948c7566e7272 and only makes sense in a world where we store votes on a voter card. Since we no longer do that, there's no need to keep this flag around.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated, plus some manual clicking around.
