### PR TITLE
refactor(mark): remove election definition from local storage

### DIFF
--- a/apps/mark/frontend/src/apimachine_config.test.tsx
+++ b/apps/mark/frontend/src/apimachine_config.test.tsx
@@ -4,10 +4,7 @@ import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 import { render, screen } from '../test/react_testing_library';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 import { App } from './app';
-import {
-  setElectionInStorage,
-  setStateInStorage,
-} from '../test/helpers/election';
+import { setStateInStorage } from '../test/helpers/election';
 
 let apiMock: ApiMock;
 
@@ -16,7 +13,6 @@ beforeEach(() => {
   window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {
@@ -28,8 +24,7 @@ test('machineConfig is fetched from api client by default', async () => {
     codeVersion: 'fake-code-version',
   });
   const storage = new MemoryStorage();
-  await setElectionInStorage(
-    storage,
+  apiMock.expectGetElectionDefinition(
     electionFamousNames2021Fixtures.electionDefinition
   );
   await setStateInStorage(storage);

--- a/apps/mark/frontend/src/app.test.tsx
+++ b/apps/mark/frontend/src/app.test.tsx
@@ -14,10 +14,7 @@ import { electionGeneralDefinition } from '@votingworks/fixtures';
 import { useDisplaySettingsManager } from '@votingworks/mark-flow-ui';
 import userEvent from '@testing-library/user-event';
 import { fireEvent, screen, waitFor } from '../test/react_testing_library';
-import {
-  setElectionInStorage,
-  setStateInStorage,
-} from '../test/helpers/election';
+import { setStateInStorage } from '../test/helpers/election';
 import { fakeTts } from '../test/helpers/fake_tts';
 import { advanceTimersAndPromises } from '../test/helpers/timers';
 import { render } from '../test/test_utils';
@@ -147,10 +144,9 @@ it('uses display settings management hook', async () => {
   // window.location.href = '/';
   apiMock.expectGetMachineConfig();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
+  apiMock.expectGetElectionDefinition(electionGeneralDefinition);
 
   const { storage, renderApp } = buildApp(apiMock);
-  await setElectionInStorage(storage);
   await setStateInStorage(storage);
   renderApp();
 
@@ -167,7 +163,6 @@ it('uses window.location.reload by default', async () => {
   const reload = jest.fn();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
   jest.spyOn(window, 'location', 'get').mockReturnValue({
     ...window.location,
     reload,
@@ -178,7 +173,7 @@ it('uses window.location.reload by default', async () => {
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
 
-  await setElectionInStorage(storage, electionDefinition);
+  apiMock.expectGetElectionDefinition(electionDefinition);
   await setStateInStorage(storage, {
     appPrecinct: ALL_PRECINCTS_SELECTION,
     pollsState: 'polls_closed_initial',

--- a/apps/mark/frontend/src/app_card_unhappy_paths.test.tsx
+++ b/apps/mark/frontend/src/app_card_unhappy_paths.test.tsx
@@ -1,12 +1,10 @@
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
+import { electionGeneralDefinition } from '@votingworks/fixtures';
 import { render, screen } from '../test/react_testing_library';
 
 import { App } from './app';
 
-import {
-  setElectionInStorage,
-  setStateInStorage,
-} from '../test/helpers/election';
+import { setStateInStorage } from '../test/helpers/election';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
 let apiMock: ApiMock;
@@ -16,7 +14,6 @@ beforeEach(() => {
   window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {
@@ -28,7 +25,7 @@ test('Shows card backwards screen when card connection error occurs', async () =
   const storage = new MemoryStorage();
   apiMock.expectGetMachineConfig();
 
-  await setElectionInStorage(storage);
+  apiMock.expectGetElectionDefinition(electionGeneralDefinition);
   await setStateInStorage(storage);
 
   render(

--- a/apps/mark/frontend/src/app_cardless_voting.test.tsx
+++ b/apps/mark/frontend/src/app_cardless_voting.test.tsx
@@ -14,7 +14,6 @@ import { App } from './app';
 
 import {
   presidentContest,
-  setElectionInStorage,
   setStateInStorage,
   voterContests,
 } from '../test/helpers/election';
@@ -248,9 +247,8 @@ test('Another Voter submits blank ballot and clicks Done', async () => {
   const storage = new MemoryStorage();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
+  apiMock.expectGetElectionDefinition(electionGeneralDefinition);
 
-  await setElectionInStorage(storage, electionGeneralDefinition);
   await setStateInStorage(storage);
 
   render(

--- a/apps/mark/frontend/src/app_contest_candidate_no_party.test.tsx
+++ b/apps/mark/frontend/src/app_contest_candidate_no_party.test.tsx
@@ -12,7 +12,6 @@ import { App } from './app';
 import { advanceTimersAndPromises } from '../test/helpers/timers';
 
 import { setStateInStorage } from '../test/helpers/election';
-import { electionStorageKey } from './app_root';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
 let apiMock: ApiMock;
@@ -41,7 +40,9 @@ beforeEach(() => {
   window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
+  apiMock.expectGetElectionDefinition(
+    asElectionDefinition(electionWithNoPartyCandidateContests)
+  );
 });
 
 afterEach(() => {
@@ -55,10 +56,6 @@ it('Single Seat Contest', async () => {
   const storage = new MemoryStorage();
   apiMock.expectGetMachineConfig();
 
-  await storage.set(
-    electionStorageKey,
-    asElectionDefinition(electionWithNoPartyCandidateContests)
-  );
   await setStateInStorage(storage);
 
   render(

--- a/apps/mark/frontend/src/app_contest_ms_either_neither.test.tsx
+++ b/apps/mark/frontend/src/app_contest_ms_either_neither.test.tsx
@@ -28,10 +28,7 @@ import { render as renderWithBallotContext } from '../test/test_utils';
 import { withMarkup } from '../test/helpers/with_markup';
 import { advanceTimersAndPromises } from '../test/helpers/timers';
 
-import {
-  setElectionInStorage,
-  setStateInStorage,
-} from '../test/helpers/election';
+import { setStateInStorage } from '../test/helpers/election';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
 let apiMock: ApiMock;
@@ -207,9 +204,8 @@ test('Can vote on a Mississippi Either Neither Contest', async () => {
   const storage = new MemoryStorage();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
+  apiMock.expectGetElectionDefinition(electionDefinition);
 
-  await setElectionInStorage(storage, electionDefinition);
   await setStateInStorage(storage, {
     appPrecinct: singlePrecinctSelectionFor(precinctId),
   });

--- a/apps/mark/frontend/src/app_contest_multi_seat.test.tsx
+++ b/apps/mark/frontend/src/app_contest_multi_seat.test.tsx
@@ -1,6 +1,7 @@
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 
 import userEvent from '@testing-library/user-event';
+import { electionGeneralDefinition } from '@votingworks/fixtures';
 import {
   fireEvent,
   render,
@@ -13,7 +14,6 @@ import { advanceTimersAndPromises } from '../test/helpers/timers';
 
 import {
   countyCommissionersContest,
-  setElectionInStorage,
   setStateInStorage,
 } from '../test/helpers/election';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
@@ -25,7 +25,6 @@ beforeEach(() => {
   window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {
@@ -38,8 +37,8 @@ it('Single Seat Contest', async () => {
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
   apiMock.expectGetMachineConfig();
+  apiMock.expectGetElectionDefinition(electionGeneralDefinition);
 
-  await setElectionInStorage(storage);
   await setStateInStorage(storage);
 
   render(

--- a/apps/mark/frontend/src/app_contest_single_seat.test.tsx
+++ b/apps/mark/frontend/src/app_contest_single_seat.test.tsx
@@ -1,6 +1,7 @@
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 
 import userEvent from '@testing-library/user-event';
+import { electionGeneralDefinition } from '@votingworks/fixtures';
 import {
   fireEvent,
   render,
@@ -12,11 +13,7 @@ import { App } from './app';
 
 import { advanceTimersAndPromises } from '../test/helpers/timers';
 
-import {
-  presidentContest,
-  setElectionInStorage,
-  setStateInStorage,
-} from '../test/helpers/election';
+import { presidentContest, setStateInStorage } from '../test/helpers/election';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
 let apiMock: ApiMock;
@@ -26,7 +23,6 @@ beforeEach(() => {
   window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {
@@ -40,7 +36,7 @@ it('Single Seat Contest', async () => {
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
 
-  await setElectionInStorage(storage);
+  apiMock.expectGetElectionDefinition(electionGeneralDefinition);
   await setStateInStorage(storage);
 
   render(

--- a/apps/mark/frontend/src/app_contest_write_in.test.tsx
+++ b/apps/mark/frontend/src/app_contest_write_in.test.tsx
@@ -1,6 +1,7 @@
 import { expectPrint } from '@votingworks/test-utils';
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 import userEvent from '@testing-library/user-event';
+import { electionGeneralDefinition } from '@votingworks/fixtures';
 import {
   fireEvent,
   render,
@@ -17,7 +18,6 @@ import {
 
 import {
   singleSeatContestWithWriteIn,
-  setElectionInStorage,
   setStateInStorage,
 } from '../test/helpers/election';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
@@ -45,7 +45,6 @@ beforeEach(() => {
   window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {
@@ -58,8 +57,8 @@ it('Single Seat Contest with Write In', async () => {
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
   apiMock.expectGetMachineConfig();
+  apiMock.expectGetElectionDefinition(electionGeneralDefinition);
 
-  await setElectionInStorage(storage);
   await setStateInStorage(storage);
 
   render(

--- a/apps/mark/frontend/src/app_contest_yes_no.test.tsx
+++ b/apps/mark/frontend/src/app_contest_yes_no.test.tsx
@@ -1,4 +1,7 @@
-import { electionGeneral } from '@votingworks/fixtures';
+import {
+  electionGeneral,
+  electionGeneralDefinition,
+} from '@votingworks/fixtures';
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 
 import { getContestDistrictName } from '@votingworks/types';
@@ -16,11 +19,7 @@ import { withMarkup } from '../test/helpers/with_markup';
 
 import { advanceTimersAndPromises } from '../test/helpers/timers';
 
-import {
-  measure102Contest,
-  setElectionInStorage,
-  setStateInStorage,
-} from '../test/helpers/election';
+import { measure102Contest, setStateInStorage } from '../test/helpers/election';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
 let apiMock: ApiMock;
@@ -30,7 +29,6 @@ beforeEach(() => {
   window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {
@@ -43,9 +41,9 @@ it('Single Seat Contest', async () => {
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
 
-  await setElectionInStorage(storage);
   await setStateInStorage(storage);
   apiMock.expectGetMachineConfig();
+  apiMock.expectGetElectionDefinition(electionGeneralDefinition);
 
   render(
     <App

--- a/apps/mark/frontend/src/app_data.test.tsx
+++ b/apps/mark/frontend/src/app_data.test.tsx
@@ -1,10 +1,8 @@
 import { screen } from '../test/react_testing_library';
 
-import { electionStorageKey } from './app_root';
-
 import {
   election,
-  setElectionInStorage,
+  electionDefinition,
   setStateInStorage,
 } from '../test/helpers/election';
 import { advanceTimersAndPromises } from '../test/helpers/timers';
@@ -19,7 +17,6 @@ beforeEach(() => {
   apiMock = createApiMock();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {
@@ -29,6 +26,7 @@ afterEach(() => {
 describe('loads election', () => {
   it('Machine is not configured by default', async () => {
     const { renderApp } = buildApp(apiMock);
+    apiMock.expectGetElectionDefinition(null);
     renderApp();
 
     // Let the initial hardware detection run.
@@ -37,13 +35,12 @@ describe('loads election', () => {
     screen.getByText('VxMark is Not Configured');
   });
 
-  it('from storage', async () => {
+  it('from backend', async () => {
     const { storage, renderApp } = buildApp(apiMock);
-    await setElectionInStorage(storage);
+    apiMock.expectGetElectionDefinition(electionDefinition);
     await setStateInStorage(storage);
     renderApp();
 
     await screen.findByText(election.title);
-    expect(storage.get(electionStorageKey)).toBeTruthy();
   });
 });

--- a/apps/mark/frontend/src/app_polls_flows.test.tsx
+++ b/apps/mark/frontend/src/app_polls_flows.test.tsx
@@ -3,10 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { electionGeneralDefinition } from '@votingworks/fixtures';
 import { LogEventId } from '@votingworks/logging';
 import { screen, waitFor, within } from '../test/react_testing_library';
-import {
-  setElectionInStorage,
-  setStateInStorage,
-} from '../test/helpers/election';
+import { setStateInStorage } from '../test/helpers/election';
 import { buildApp } from '../test/helpers/build_app';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
@@ -18,7 +15,6 @@ beforeEach(() => {
   apiMock = createApiMock();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {
@@ -31,9 +27,8 @@ test('full polls flow', async () => {
   apiMock = createApiMock();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
+  apiMock.expectGetElectionDefinition(electionGeneralDefinition);
   const { renderApp, storage, logger } = buildApp(apiMock);
-  await setElectionInStorage(storage, electionGeneralDefinition);
   await setStateInStorage(storage, { pollsState: 'polls_closed_initial' });
   renderApp();
   await screen.findByText('Polls Closed');
@@ -105,7 +100,7 @@ test('full polls flow', async () => {
 
 test('can close polls from paused', async () => {
   const { renderApp, storage } = buildApp(apiMock);
-  await setElectionInStorage(storage, electionGeneralDefinition);
+  apiMock.expectGetElectionDefinition(electionGeneralDefinition);
   await setStateInStorage(storage, { pollsState: 'polls_paused' });
   renderApp();
   await screen.findByText('Voting Paused');
@@ -125,7 +120,7 @@ test('can close polls from paused', async () => {
 
 test('no buttons to change polls from closed final', async () => {
   const { renderApp, storage } = buildApp(apiMock);
-  await setElectionInStorage(storage, electionGeneralDefinition);
+  apiMock.expectGetElectionDefinition(electionGeneralDefinition);
   await setStateInStorage(storage, { pollsState: 'polls_closed_final' });
   renderApp();
   await screen.findByText('Polls Closed');
@@ -146,7 +141,7 @@ test('no buttons to change polls from closed final', async () => {
 
 test('can reset polls to paused with system administrator card', async () => {
   const { renderApp, storage } = buildApp(apiMock);
-  await setElectionInStorage(storage, electionGeneralDefinition);
+  apiMock.expectGetElectionDefinition(electionGeneralDefinition);
   await setStateInStorage(storage, { pollsState: 'polls_closed_final' });
   renderApp();
   await screen.findByText('Polls Closed');

--- a/apps/mark/frontend/src/app_quit_on_idle.test.tsx
+++ b/apps/mark/frontend/src/app_quit_on_idle.test.tsx
@@ -13,10 +13,7 @@ import { App } from './app';
 
 import { advanceTimersAndPromises } from '../test/helpers/timers';
 
-import {
-  setElectionInStorage,
-  setStateInStorage,
-} from '../test/helpers/election';
+import { setStateInStorage } from '../test/helpers/election';
 
 import { QUIT_KIOSK_IDLE_SECONDS } from './config/globals';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
@@ -30,7 +27,6 @@ beforeEach(() => {
   window.kiosk = fakeKiosk();
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {
@@ -47,7 +43,7 @@ test('Insert Card screen idle timeout to quit app', async () => {
     machineId: '0000',
   });
 
-  await setElectionInStorage(storage);
+  apiMock.expectGetElectionDefinition(electionGeneralDefinition);
   await setStateInStorage(storage);
 
   render(
@@ -72,11 +68,10 @@ test('Insert Card screen idle timeout to quit app', async () => {
 });
 
 test('Voter idle timeout', async () => {
-  const electionDefinition = electionGeneralDefinition;
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
   apiMock.expectGetMachineConfig();
-  await setElectionInStorage(storage, electionDefinition);
+  apiMock.expectGetElectionDefinition(electionGeneralDefinition);
   await setStateInStorage(storage);
   render(
     <App

--- a/apps/mark/frontend/src/app_replace_election.test.tsx
+++ b/apps/mark/frontend/src/app_replace_election.test.tsx
@@ -6,10 +6,7 @@ import {
 import { FakeKiosk, fakeKiosk } from '@votingworks/test-utils';
 import { DEFAULT_SYSTEM_SETTINGS } from '@votingworks/types';
 import { screen } from '../test/react_testing_library';
-import {
-  setElectionInStorage,
-  setStateInStorage,
-} from '../test/helpers/election';
+import { setStateInStorage } from '../test/helpers/election';
 import { render } from '../test/test_utils';
 import { App } from './app';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
@@ -40,7 +37,6 @@ test('app renders a notice when election hash on card does not match that of mac
   apiMock.expectGetElectionDefinition(electionGeneralDefinition);
 
   // setup with typical election
-  await setElectionInStorage(storage);
   await setStateInStorage(storage);
 
   render(

--- a/apps/mark/frontend/src/app_setup_errors.test.tsx
+++ b/apps/mark/frontend/src/app_setup_errors.test.tsx
@@ -13,11 +13,7 @@ import { App } from './app';
 
 import { advanceTimersAndPromises } from '../test/helpers/timers';
 
-import {
-  electionDefinition,
-  setElectionInStorage,
-  setStateInStorage,
-} from '../test/helpers/election';
+import { setStateInStorage } from '../test/helpers/election';
 import { withMarkup } from '../test/helpers/with_markup';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
@@ -28,7 +24,6 @@ beforeEach(() => {
   window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {
@@ -46,7 +41,7 @@ describe('Displays setup warning messages and errors screens', () => {
     const hardware = MemoryHardware.buildStandard();
     hardware.setAccessibleControllerConnected(true);
 
-    await setElectionInStorage(storage);
+    apiMock.expectGetElectionDefinition(electionGeneralDefinition);
     await setStateInStorage(storage);
 
     render(
@@ -85,7 +80,7 @@ describe('Displays setup warning messages and errors screens', () => {
     apiMock.expectGetMachineConfig();
     const storage = new MemoryStorage();
     const hardware = MemoryHardware.buildStandard();
-    await setElectionInStorage(storage);
+    apiMock.expectGetElectionDefinition(electionGeneralDefinition);
     await setStateInStorage(storage);
 
     render(
@@ -119,7 +114,7 @@ describe('Displays setup warning messages and errors screens', () => {
     apiMock.expectGetMachineConfig();
     const storage = new MemoryStorage();
     const hardware = MemoryHardware.buildStandard();
-    await setElectionInStorage(storage);
+    apiMock.expectGetElectionDefinition(electionGeneralDefinition);
     await setStateInStorage(storage);
     render(
       <App
@@ -151,7 +146,7 @@ describe('Displays setup warning messages and errors screens', () => {
     apiMock.expectGetMachineConfig();
     const storage = new MemoryStorage();
     const hardware = MemoryHardware.buildStandard();
-    await setElectionInStorage(storage, electionDefinition);
+    apiMock.expectGetElectionDefinition(electionGeneralDefinition);
     await setStateInStorage(storage);
     render(
       <App
@@ -182,7 +177,7 @@ describe('Displays setup warning messages and errors screens', () => {
     apiMock.expectGetMachineConfig();
     const storage = new MemoryStorage();
     const hardware = MemoryHardware.buildStandard();
-    await setElectionInStorage(storage);
+    apiMock.expectGetElectionDefinition(electionGeneralDefinition);
     await setStateInStorage(storage);
     render(
       <App

--- a/apps/mark/frontend/src/app_test_mode.test.tsx
+++ b/apps/mark/frontend/src/app_test_mode.test.tsx
@@ -6,10 +6,7 @@ import {
 import { MemoryHardware, MemoryStorage } from '@votingworks/utils';
 import { render, screen, waitFor } from '../test/react_testing_library';
 
-import {
-  setElectionInStorage,
-  setStateInStorage,
-} from '../test/helpers/election';
+import { setStateInStorage } from '../test/helpers/election';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 import { App } from './app';
 
@@ -20,7 +17,6 @@ beforeEach(() => {
   window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {
@@ -35,7 +31,7 @@ it('Prompts to change from test mode to live mode on election day', async () => 
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
   apiMock.expectGetMachineConfig();
-  await setElectionInStorage(storage, electionDefinition);
+  apiMock.expectGetElectionDefinition(electionDefinition);
   await setStateInStorage(storage, {
     isLiveMode: false,
   });

--- a/apps/mark/frontend/src/lib/gamepad.test.tsx
+++ b/apps/mark/frontend/src/lib/gamepad.test.tsx
@@ -1,5 +1,6 @@
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 import { Button } from 'react-gamepad';
+import { electionGeneralDefinition } from '@votingworks/fixtures';
 import {
   act,
   fireEvent,
@@ -15,7 +16,6 @@ import {
   contest0candidate0,
   contest0candidate1,
   contest1candidate0,
-  setElectionInStorage,
   setStateInStorage,
 } from '../../test/helpers/election';
 
@@ -38,7 +38,6 @@ beforeEach(() => {
   window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {
@@ -50,7 +49,7 @@ it('gamepad controls work', async () => {
   const storage = new MemoryStorage();
   apiMock.expectGetMachineConfig();
 
-  await setElectionInStorage(storage);
+  apiMock.expectGetElectionDefinition(electionGeneralDefinition);
   await setStateInStorage(storage);
 
   render(

--- a/apps/mark/frontend/test/helpers/election.ts
+++ b/apps/mark/frontend/test/helpers/election.ts
@@ -7,7 +7,7 @@ import {
 } from '@votingworks/types';
 import { singlePrecinctSelectionFor, Storage } from '@votingworks/utils';
 import { electionGeneralDefinition } from '@votingworks/fixtures';
-import { electionStorageKey, State, stateStorageKey } from '../../src/app_root';
+import { State, stateStorageKey } from '../../src/app_root';
 
 export const electionDefinition = electionGeneralDefinition;
 export const { election } = electionDefinition;
@@ -56,13 +56,6 @@ export const voterContests = getContests({
   ballotStyle,
   election,
 });
-
-export async function setElectionInStorage(
-  storage: Storage,
-  newElectionDefinition = electionDefinition
-): Promise<void> {
-  await storage.set(electionStorageKey, newElectionDefinition);
-}
 
 export async function setStateInStorage(
   storage: Storage,


### PR DESCRIPTION

## Overview

We store this in the backend and should not be storing it locally. This is a step in the direction of removing `kiosk`-based API uses.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated test changes. Manually configured, unconfigured, opened and closed polls, and voted.
