### PR TITLE
add term description to tally reports

### DIFF
--- a/apps/admin/frontend/src/__snapshots__/app.test.tsx.snap
+++ b/apps/admin/frontend/src/__snapshots__/app.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
   font-size: 0.8em;
 }
 
-.c10 {
+.c13 {
   white-space: nowrap;
 }
 
@@ -76,50 +76,48 @@ exports[`L&A (logic and accuracy) flow 1`] = `
   font-weight: 400;
 }
 
+.c10 {
+  margin-bottom: 0;
+  font-size: 0.8em;
+}
+
+.c11 {
+  margin-top: 0;
+  margin-bottom: 0.2em;
+}
+
+.c12 {
+  margin-top: 0;
+  margin-bottom: 0.2em;
+  font-size: 0.8em;
+}
+
 .c9 {
   margin: 2.5em 0;
   page-break-inside: avoid;
 }
 
-.c9 h3 {
-  margin-top: 0;
-  margin-bottom: 0.5em;
-}
-
-.c9 h3 + p {
-  margin-top: -0.8em;
-  margin-bottom: 0.25em;
-}
-
-.c9 h3 + table {
-  margin-top: -0.5em;
-}
-
-.c9 p:first-child {
-  margin-bottom: 0;
-}
-
-.c11 {
+.c14 {
   width: 100%;
   height: 1px;
   border-collapse: collapse;
 }
 
-.c11 tr {
+.c14 tr {
   border-top: 1px solid rgb(194,200,203);
   border-bottom: 1px solid rgb(194,200,203);
   height: 100%;
 }
 
-.c11 tr.metadata {
+.c14 tr.metadata {
   font-size: 0.75em;
 }
 
-.c11 tr.metadata.last-metadata {
+.c14 tr.metadata.last-metadata {
   border-bottom: 1px solid #e6e6e6;
 }
 
-.c11 td {
+.c14 td {
   width: 1%;
   height: 100%;
   padding: 0.25em 0.625em;
@@ -128,23 +126,23 @@ exports[`L&A (logic and accuracy) flow 1`] = `
   white-space: no-wrap;
 }
 
-.c11 th {
+.c14 th {
   padding: 0 0.5em;
   text-align: right;
   font-weight: 400;
 }
 
-.c11 th.option-label {
+.c14 th.option-label {
   padding: 0.25em 0.5em;
   line-height: 1;
 }
 
-.c11 th:first-child {
+.c14 th:first-child {
   padding-left: 0.25em;
   text-align: left;
 }
 
-.c11 th:not(:first-child) {
+.c14 th:not(:first-child) {
   padding-right: 0;
 }
 
@@ -297,18 +295,20 @@ exports[`L&A (logic and accuracy) flow 1`] = `
           data-testid="results-table-775020876"
         >
           <p
-            class="c3"
+            class="c10"
           >
             United States
           </p>
-          <h3>
+          <h3
+            class="c11"
+          >
             President
           </h3>
           <p
-            class="c3"
+            class="c12"
           >
             <span
-              class="c10"
+              class="c13"
             >
               8 ballots
                
@@ -316,7 +316,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
             </span>
              
             <span
-              class="c10"
+              class="c13"
             >
                
               0 overvotes
@@ -325,14 +325,14 @@ exports[`L&A (logic and accuracy) flow 1`] = `
             </span>
              
             <span
-              class="c10"
+              class="c13"
             >
                
               0 undervotes
             </span>
           </p>
           <table
-            class="c11"
+            class="c14"
           >
             <tbody>
               <tr
@@ -391,18 +391,20 @@ exports[`L&A (logic and accuracy) flow 1`] = `
           data-testid="results-table-775020877"
         >
           <p
-            class="c3"
+            class="c10"
           >
             United States
           </p>
-          <h3>
+          <h3
+            class="c11"
+          >
             Senate 
           </h3>
           <p
-            class="c3"
+            class="c12"
           >
             <span
-              class="c10"
+              class="c13"
             >
               8 ballots
                
@@ -410,7 +412,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
             </span>
              
             <span
-              class="c10"
+              class="c13"
             >
                
               0 overvotes
@@ -419,14 +421,14 @@ exports[`L&A (logic and accuracy) flow 1`] = `
             </span>
              
             <span
-              class="c10"
+              class="c13"
             >
                
               0 undervotes
             </span>
           </p>
           <table
-            class="c11"
+            class="c14"
           >
             <tbody>
               <tr
@@ -485,18 +487,20 @@ exports[`L&A (logic and accuracy) flow 1`] = `
           data-testid="results-table-775020872"
         >
           <p
-            class="c3"
+            class="c10"
           >
             US House Of Representatives
           </p>
-          <h3>
+          <h3
+            class="c11"
+          >
             1st Congressional District
           </h3>
           <p
-            class="c3"
+            class="c12"
           >
             <span
-              class="c10"
+              class="c13"
             >
               8 ballots
                
@@ -504,7 +508,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
             </span>
              
             <span
-              class="c10"
+              class="c13"
             >
                
               0 overvotes
@@ -513,14 +517,14 @@ exports[`L&A (logic and accuracy) flow 1`] = `
             </span>
              
             <span
-              class="c10"
+              class="c13"
             >
                
               0 undervotes
             </span>
           </p>
           <table
-            class="c11"
+            class="c14"
           >
             <tbody>
               <tr
@@ -567,18 +571,20 @@ exports[`L&A (logic and accuracy) flow 1`] = `
           data-testid="results-table-775020870"
         >
           <p
-            class="c3"
+            class="c10"
           >
             Northern District
           </p>
-          <h3>
+          <h3
+            class="c11"
+          >
             Supreme Court District 3(Northern) Position 3
           </h3>
           <p
-            class="c3"
+            class="c12"
           >
             <span
-              class="c10"
+              class="c13"
             >
               8 ballots
                
@@ -586,7 +592,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
             </span>
              
             <span
-              class="c10"
+              class="c13"
             >
                
               0 overvotes
@@ -595,14 +601,14 @@ exports[`L&A (logic and accuracy) flow 1`] = `
             </span>
              
             <span
-              class="c10"
+              class="c13"
             >
                
               0 undervotes
             </span>
           </p>
           <table
-            class="c11"
+            class="c14"
           >
             <tbody>
               <tr
@@ -649,18 +655,20 @@ exports[`L&A (logic and accuracy) flow 1`] = `
           data-testid="results-table-775020903"
         >
           <p
-            class="c3"
+            class="c10"
           >
             Election Commissioner 05
           </p>
-          <h3>
+          <h3
+            class="c11"
+          >
             Election Commissioner 05
           </h3>
           <p
-            class="c3"
+            class="c12"
           >
             <span
-              class="c10"
+              class="c13"
             >
               8 ballots
                
@@ -668,7 +676,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
             </span>
              
             <span
-              class="c10"
+              class="c13"
             >
                
               0 overvotes
@@ -677,14 +685,14 @@ exports[`L&A (logic and accuracy) flow 1`] = `
             </span>
              
             <span
-              class="c10"
+              class="c13"
             >
                
               0 undervotes
             </span>
           </p>
           <table
-            class="c11"
+            class="c14"
           >
             <tbody>
               <tr
@@ -731,18 +739,20 @@ exports[`L&A (logic and accuracy) flow 1`] = `
           data-testid="results-table-775020904"
         >
           <p
-            class="c3"
+            class="c10"
           >
             School Board District 5
           </p>
-          <h3>
+          <h3
+            class="c11"
+          >
             School Board 05
           </h3>
           <p
-            class="c3"
+            class="c12"
           >
             <span
-              class="c10"
+              class="c13"
             >
               8 ballots
                
@@ -750,7 +760,7 @@ exports[`L&A (logic and accuracy) flow 1`] = `
             </span>
              
             <span
-              class="c10"
+              class="c13"
             >
                
               0 overvotes
@@ -759,14 +769,14 @@ exports[`L&A (logic and accuracy) flow 1`] = `
             </span>
              
             <span
-              class="c10"
+              class="c13"
             >
                
               0 undervotes
             </span>
           </p>
           <table
-            class="c11"
+            class="c14"
           >
             <tbody>
               <tr
@@ -801,19 +811,21 @@ exports[`L&A (logic and accuracy) flow 1`] = `
           data-testid="results-table-750000017"
         >
           <p
-            class="c3"
+            class="c10"
           >
             State Of Mississippi
           </p>
-          <h3>
+          <h3
+            class="c11"
+          >
             Ballot Measure 2
 House Concurrent Resolution No. 47
           </h3>
           <p
-            class="c3"
+            class="c12"
           >
             <span
-              class="c10"
+              class="c13"
             >
               8 ballots
                
@@ -821,7 +833,7 @@ House Concurrent Resolution No. 47
             </span>
              
             <span
-              class="c10"
+              class="c13"
             >
                
               0 overvotes
@@ -830,14 +842,14 @@ House Concurrent Resolution No. 47
             </span>
              
             <span
-              class="c10"
+              class="c13"
             >
                
               0 undervotes
             </span>
           </p>
           <table
-            class="c11"
+            class="c14"
           >
             <tbody>
               <tr
@@ -872,19 +884,21 @@ House Concurrent Resolution No. 47
           data-testid="results-table-750000018"
         >
           <p
-            class="c3"
+            class="c10"
           >
             State Of Mississippi
           </p>
-          <h3>
+          <h3
+            class="c11"
+          >
             Ballot Measure 3
 House Bill 1796 - Flag Referendum
           </h3>
           <p
-            class="c3"
+            class="c12"
           >
             <span
-              class="c10"
+              class="c13"
             >
               8 ballots
                
@@ -892,7 +906,7 @@ House Bill 1796 - Flag Referendum
             </span>
              
             <span
-              class="c10"
+              class="c13"
             >
                
               0 overvotes
@@ -901,14 +915,14 @@ House Bill 1796 - Flag Referendum
             </span>
              
             <span
-              class="c10"
+              class="c13"
             >
                
               0 undervotes
             </span>
           </p>
           <table
-            class="c11"
+            class="c14"
           >
             <tbody>
               <tr
@@ -943,18 +957,20 @@ House Bill 1796 - Flag Referendum
           data-testid="results-table-750000015"
         >
           <p
-            class="c3"
+            class="c10"
           >
             State Of Mississippi
           </p>
-          <h3>
+          <h3
+            class="c11"
+          >
             Ballot Measure 1
           </h3>
           <p
-            class="c3"
+            class="c12"
           >
             <span
-              class="c10"
+              class="c13"
             >
               8 ballots
                
@@ -962,7 +978,7 @@ House Bill 1796 - Flag Referendum
             </span>
              
             <span
-              class="c10"
+              class="c13"
             >
                
               0 overvotes
@@ -971,14 +987,14 @@ House Bill 1796 - Flag Referendum
             </span>
              
             <span
-              class="c10"
+              class="c13"
             >
                
               0 undervotes
             </span>
           </p>
           <table
-            class="c11"
+            class="c14"
           >
             <tbody>
               <tr
@@ -1013,18 +1029,20 @@ House Bill 1796 - Flag Referendum
           data-testid="results-table-750000016"
         >
           <p
-            class="c3"
+            class="c10"
           >
             State Of Mississippi
           </p>
-          <h3>
+          <h3
+            class="c11"
+          >
             Ballot Measure 1
           </h3>
           <p
-            class="c3"
+            class="c12"
           >
             <span
-              class="c10"
+              class="c13"
             >
               8 ballots
                
@@ -1032,7 +1050,7 @@ House Bill 1796 - Flag Referendum
             </span>
              
             <span
-              class="c10"
+              class="c13"
             >
                
               0 overvotes
@@ -1041,14 +1059,14 @@ House Bill 1796 - Flag Referendum
             </span>
              
             <span
-              class="c10"
+              class="c13"
             >
                
               0 undervotes
             </span>
           </p>
           <table
-            class="c11"
+            class="c14"
           >
             <tbody>
               <tr

--- a/libs/ui/src/reports/admin_tally_report.stories.tsx
+++ b/libs/ui/src/reports/admin_tally_report.stories.tsx
@@ -4,7 +4,12 @@ import {
   buildElectionResultsFixture,
   buildManualResultsFixture,
 } from '@votingworks/utils';
-import { Tabulation, getBallotStyle, getContests } from '@votingworks/types';
+import {
+  ElectionDefinition,
+  Tabulation,
+  getBallotStyle,
+  getContests,
+} from '@votingworks/types';
 import { assertDefined } from '@votingworks/basics';
 import { AdminTallyReportProps, AdminTallyReport } from './admin_tally_report';
 import { TallyReportPreview } from './tally_report';
@@ -128,14 +133,30 @@ export const BallotStyleManualReport: Story = {
   args: ballotStyleManualReportArgs,
 };
 
+const electionDefinitionWithTermDescription: ElectionDefinition = {
+  ...electionTwoPartyPrimaryDefinition,
+  election: {
+    ...electionTwoPartyPrimaryDefinition.election,
+    contests: electionTwoPartyPrimaryDefinition.election.contests.map((c) => {
+      if (c.type === 'candidate') {
+        return {
+          ...c,
+          termDescription: 'For three years',
+        };
+      }
+      return c;
+    }),
+  },
+};
+
 const fullElectionWriteInReportArgs: AdminTallyReportProps = {
   title: 'Full Election Tally Report',
   isTest: true,
   isOfficial: false,
   subtitle: election.title,
   testId: 'tally-report',
-  electionDefinition,
-  contests: election.contests,
+  electionDefinition: electionDefinitionWithTermDescription,
+  contests: electionDefinitionWithTermDescription.election.contests,
   scannedElectionResults: buildElectionResultsFixture({
     election,
     cardCounts: {

--- a/libs/ui/src/reports/contest_results_table.test.tsx
+++ b/libs/ui/src/reports/contest_results_table.test.tsx
@@ -240,3 +240,15 @@ test('uses write-in adjudication aggregation', () => {
   within(fishing).getByText(hasTextAcrossElements('Giraffe (Write-In)40'));
   within(fishing).getByText(hasTextAcrossElements('Other Write-In20'));
 });
+
+test('shows term description if it exists', () => {
+  render(
+    <ContestResultsTable
+      election={election}
+      contest={{ ...candidateContest, termDescription: 'For three years' }}
+      scannedContestResults={candidateContestScannedResults}
+    />
+  );
+  const bestAnimalFish = screen.getByTestId('results-table-best-animal-fish');
+  within(bestAnimalFish).getByText('For three years');
+});

--- a/libs/ui/src/reports/contest_results_table.tsx
+++ b/libs/ui/src/reports/contest_results_table.tsx
@@ -15,27 +15,32 @@ import { Text, NoWrap } from '../text';
 
 const tableBorderColor = 'rgb(194, 200, 203)';
 
+const DistrictName = styled.p`
+  margin-bottom: 0;
+  font-size: 0.8em;
+`;
+
+const ContestTitle = styled.h3`
+  margin-top: 0;
+  margin-bottom: 0.2em;
+`;
+
+const TermDescription = styled.p`
+  margin-top: -0.2em;
+  margin-bottom: 0.2em;
+  font-weight: 500;
+  font-size: 0.8em;
+`;
+
+const MetadataLabel = styled.p`
+  margin-top: 0;
+  margin-bottom: 0.2em;
+  font-size: 0.8em;
+`;
+
 const Contest = styled.div`
   margin: 2.5em 0;
   page-break-inside: avoid;
-
-  h3 {
-    margin-top: 0;
-    margin-bottom: 0.5em;
-
-    & + p {
-      margin-top: -0.8em;
-      margin-bottom: 0.25em;
-    }
-
-    & + table {
-      margin-top: -0.5em;
-    }
-  }
-
-  p:first-child {
-    margin-bottom: 0;
-  }
 `;
 
 const ContestTable = styled.table`
@@ -277,8 +282,8 @@ export function ContestResultsTable({
 
   return (
     <Contest data-testid={`results-table-${contest.id}`}>
-      <Text small>{getContestDistrictName(election, contest)}</Text>
-      <h3>
+      <DistrictName>{getContestDistrictName(election, contest)}</DistrictName>
+      <ContestTitle>
         {contest.title}
         {contest.type === 'candidate' && contest.seats > 1 && (
           <React.Fragment>
@@ -288,9 +293,12 @@ export function ContestResultsTable({
             </Text>
           </React.Fragment>
         )}
-      </h3>
+      </ContestTitle>
+      {contest.type === 'candidate' && contest.termDescription && (
+        <TermDescription>{contest.termDescription}</TermDescription>
+      )}
       {!hasManualResults && (
-        <Text small>
+        <MetadataLabel>
           <NoWrap>
             {`${format.count(scannedContestResults.ballots)} ${pluralize(
               'ballots',
@@ -313,7 +321,7 @@ export function ContestResultsTable({
               scannedContestResults.undervotes
             )}`}
           </NoWrap>
-        </Text>
+        </MetadataLabel>
       )}
       <ContestTable>
         <tbody>{contestTableRows}</tbody>

--- a/libs/ui/src/reports/precinct_scanner_tally_reports.stories.tsx
+++ b/libs/ui/src/reports/precinct_scanner_tally_reports.stories.tsx
@@ -4,6 +4,7 @@ import {
   ALL_PRECINCTS_SELECTION,
   buildElectionResultsFixture,
 } from '@votingworks/utils';
+import { ElectionDefinition } from '@votingworks/types';
 import { TallyReportPreview } from './tally_report';
 import {
   PrecinctScannerTallyReports,
@@ -72,8 +73,24 @@ const electionResultsByParty = [
   },
 ];
 
+const electionDefinitionWithTermDescription: ElectionDefinition = {
+  ...electionTwoPartyPrimaryDefinition,
+  election: {
+    ...electionTwoPartyPrimaryDefinition.election,
+    contests: electionTwoPartyPrimaryDefinition.election.contests.map((c) => {
+      if (c.type === 'candidate') {
+        return {
+          ...c,
+          termDescription: 'For three years',
+        };
+      }
+      return c;
+    }),
+  },
+};
+
 const reportArgs: PrecinctScannerTallyReportsProps = {
-  electionDefinition: electionTwoPartyPrimaryDefinition,
+  electionDefinition: electionDefinitionWithTermDescription,
   electionResultsByParty,
   precinctSelection: ALL_PRECINCTS_SELECTION,
   pollsTransition: 'close_polls',


### PR DESCRIPTION
## Overview

Closes #4024. Adds term description, the same string which appears on the ballot, to tally reports. Also modifies the styling in the case where there is no term description to be slightly less cramped.

## Demo Video or Screenshot

|  Type  | Scanned Only  | Manual Too |
| ------------- | ------------- | --------- |
| Before | <img width="248" alt="Screen Shot 2023-11-17 at 1 09 39 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/e1c1ad42-ec3c-4c61-92ff-8ca5573b3394"> | <img width="243" alt="Screen Shot 2023-11-17 at 1 09 31 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/e601a307-4317-48a1-bf55-c8fbce0fe6c4"> |
| After, no term  | <img width="239" alt="Screen Shot 2023-11-17 at 1 02 43 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/c76abfc9-76cb-4732-a5a3-d8ad77c29d0f"> | <img width="243" alt="Screen Shot 2023-11-17 at 1 02 36 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/a383dffc-de66-43d9-ba38-b24f7fcefd71"> |
| After, term | <img width="237" alt="Screen Shot 2023-11-17 at 1 02 14 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/1c031a78-c56e-4357-831d-ddf855688d48"> | <img width="245" alt="Screen Shot 2023-11-17 at 1 01 52 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/015a68c4-6e74-4b56-89c0-90553cad326c"> |

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
