### PR TITLE
remove `batchLabel`

### DIFF
--- a/apps/central-scan/backend/src/store.test.ts
+++ b/apps/central-scan/backend/src/store.test.ts
@@ -546,7 +546,6 @@ test('iterating over sheets', () => {
     type: 'accepted',
     id: sheet1Id,
     batchId,
-    batchLabel: 'Batch 1',
     interpretation: mapSheet(sheetWithFiles, (page) => page.interpretation),
     frontImagePath: '1-front.jpg',
     backImagePath: '1-back.jpg',
@@ -598,7 +597,6 @@ test('iterating over sheets', () => {
     type: 'accepted',
     id: sheet3Id,
     batchId,
-    batchLabel: 'Batch 1',
     interpretation: [
       interpretationRequiringAdjudication,
       sheetWithFiles[1].interpretation,

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -51,7 +51,6 @@ const getSheetsBaseQuery = `
   select
     sheets.id as id,
     batches.id as batchId,
-    batches.label as batchLabel,
     front_interpretation_json as frontInterpretationJson,
     back_interpretation_json as backInterpretationJson,
     front_image_path as frontImagePath,
@@ -67,7 +66,6 @@ const getSheetsBaseQuery = `
 interface SheetRow {
   id: string;
   batchId: string;
-  batchLabel: string | null;
   frontInterpretationJson: string;
   backInterpretationJson: string;
   frontImagePath: string;
@@ -84,7 +82,6 @@ function sheetRowToAcceptedSheet(row: SheetRow): AcceptedSheet {
     type: 'accepted',
     id: row.id,
     batchId: row.batchId,
-    batchLabel: row.batchLabel ?? undefined,
     interpretation: mapSheet(
       [row.frontInterpretationJson, row.backInterpretationJson],
       (json) => safeParseJson(json, PageInterpretationSchema).unsafeUnwrap()

--- a/apps/scan/backend/src/store.test.ts
+++ b/apps/scan/backend/src/store.test.ts
@@ -518,7 +518,6 @@ test('iterating over sheets', () => {
     type: 'accepted',
     id: sheet1Id,
     batchId,
-    batchLabel: 'Batch 1',
     interpretation: mapSheet(testSheetWithFiles, (page) => page.interpretation),
     frontImagePath: '1-front.jpg',
     backImagePath: '1-back.jpg',
@@ -568,7 +567,6 @@ test('iterating over sheets', () => {
     type: 'accepted',
     id: sheet3Id,
     batchId,
-    batchLabel: 'Batch 1',
     interpretation: [
       interpretationRequiringAdjudication,
       testSheetWithFiles[1].interpretation,
@@ -599,7 +597,6 @@ test('getSheet', () => {
     type: 'accepted',
     id: sheetId,
     batchId,
-    batchLabel: 'Batch 1',
     interpretation: mapSheet(testSheetWithFiles, (page) => page.interpretation),
     frontImagePath: '/front.png',
     backImagePath: '/back.png',

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -63,7 +63,6 @@ const getSheetsBaseQuery = `
   select
     sheets.id as id,
     batches.id as batchId,
-    batches.label as batchLabel,
     front_interpretation_json as frontInterpretationJson,
     back_interpretation_json as backInterpretationJson,
     front_image_path as frontImagePath,
@@ -78,7 +77,6 @@ const getSheetsBaseQuery = `
 interface SheetRow {
   id: string;
   batchId: string;
-  batchLabel: string | null;
   frontInterpretationJson: string;
   backInterpretationJson: string;
   frontImagePath: string;
@@ -94,7 +92,6 @@ function sheetRowToAcceptedSheet(row: SheetRow): AcceptedSheet {
     type: 'accepted',
     id: row.id,
     batchId: row.batchId,
-    batchLabel: row.batchLabel ?? undefined,
     interpretation: mapSheet(
       [row.frontInterpretationJson, row.backInterpretationJson],
       (json) => safeParseJson(json, PageInterpretationSchema).unsafeUnwrap()

--- a/libs/backend/src/cast_vote_records/export.ts
+++ b/libs/backend/src/cast_vote_records/export.ts
@@ -165,11 +165,6 @@ export interface AcceptedSheet {
    * this would compromise voter privacy.
    */
   readonly indexInBatch?: number;
-
-  /**
-   * TODO: Determine whether this field is still used and, if not, remove
-   */
-  readonly batchLabel?: string;
 }
 
 /**


### PR DESCRIPTION
Closes #4095. Removes unused `batchLabel` field.

