### PR TITLE
support both possible thinkpad card readers

### DIFF
--- a/libs/utils/src/Hardware/utils.ts
+++ b/libs/utils/src/Hardware/utils.ts
@@ -16,8 +16,8 @@ export const OmniKeyCardReaderManufacturer = 'HID Global';
 export const OmniKeyCardReaderVendorId = 0x076b;
 export const OmniKeyCardReaderProductId = 0x3031;
 
-export const LenovoBuiltInCardReaderVendorId = 0x2ce3;
-export const LenovoBuiltInCardReaderProductId = 0x9563;
+export const LenovoBuiltInCardReaderVendorIds = [0x2ec3, 0x058f];
+export const LenovoBuiltInCardReaderProductIds = [0x9563, 0x9540];
 
 /**
  * Determines whether a device is the card reader.
@@ -29,8 +29,8 @@ export function isCardReader(device: KioskBrowser.Device): boolean {
     (device.vendorId === OmniKeyCardReaderVendorId &&
       device.productId === OmniKeyCardReaderProductId);
   const isBuiltInReader =
-    device.vendorId === LenovoBuiltInCardReaderVendorId &&
-    device.productId === LenovoBuiltInCardReaderProductId;
+    LenovoBuiltInCardReaderVendorIds.includes(device.vendorId) &&
+    LenovoBuiltInCardReaderProductIds.includes(device.productId);
   return isOmniKeyReader || isBuiltInReader;
 }
 


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/4164

The smartcard reader got swapped out when we ordered more thinkpads so supporting both the old and new <!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot

## Testing Plan
tested on real hardware

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
