### PR TITLE
fix tabulation for non-zero primary results

### DIFF
--- a/apps/scan/backend/src/util/results.ts
+++ b/apps/scan/backend/src/util/results.ts
@@ -8,6 +8,7 @@ import {
   VotesDict,
 } from '@votingworks/types';
 import {
+  getBallotStyleIdPartyIdLookup,
   groupMapToGroupList,
   tabulateCastVoteRecords,
 } from '@votingworks/utils';
@@ -72,6 +73,7 @@ export async function getScannerResults({
   const electionDefinition = store.getElectionDefinition();
   assert(electionDefinition);
   const { election } = electionDefinition;
+  const ballotStyleIdPartyIdLookup = getBallotStyleIdPartyIdLookup(election);
 
   const cvrs = iter(store.forEachAcceptedSheet()).map((resultSheet) => {
     const [frontInterpretation, backInterpretation] =
@@ -100,6 +102,10 @@ export async function getScannerResults({
         scannerId: VX_MACHINE_ID,
         precinctId: frontInterpretation.metadata.precinctId,
         ballotStyleId: frontInterpretation.metadata.ballotStyleId,
+        partyId:
+          ballotStyleIdPartyIdLookup[
+            frontInterpretation.metadata.ballotStyleId
+          ],
         votingMethod:
           BALLOT_TYPE_TO_VOTING_METHOD[frontInterpretation.metadata.ballotType],
       });
@@ -120,6 +126,8 @@ export async function getScannerResults({
       scannerId: VX_MACHINE_ID,
       precinctId: interpretation.metadata.precinctId,
       ballotStyleId: interpretation.metadata.ballotStyleId,
+      partyId:
+        ballotStyleIdPartyIdLookup[interpretation.metadata.ballotStyleId],
       votingMethod:
         BALLOT_TYPE_TO_VOTING_METHOD[interpretation.metadata.ballotType],
     });


### PR DESCRIPTION
## Overview

Closes #4084. Not sure how I or someone else didn't catch this before, as the bug appears to happen whenever you insert a poll worker card for a primary election on VxScan with more than one ballot scanned.

We need to add a regression test but it's a bit of a lift, so I created a ticket to circle back to: #4252.

## Testing Plan

I and @carolinemodic tested manually. For automated testing, need to circle back to #4252.
