### PR TITLE
Update Manual Tally Copy

### DIFF
--- a/apps/admin/frontend/src/app.test.tsx
+++ b/apps/admin/frontend/src/app.test.tsx
@@ -417,12 +417,8 @@ test('clearing results', async () => {
     (await screen.findByText('Load CVRs')).closest('button')
   ).toBeDisabled();
   expect(getByText('Remove CVRs').closest('button')).toBeDisabled();
-  expect(
-    getByText('Edit Manually Entered Results').closest('button')
-  ).toBeDisabled();
-  expect(
-    getByText('Remove Manually Entered Results').closest('button')
-  ).toBeDisabled();
+  expect(getByText('Edit Manual Tallies').closest('button')).toBeDisabled();
+  expect(getByText('Remove Manual Tallies').closest('button')).toBeDisabled();
 
   apiMock.expectDeleteAllManualResults();
 
@@ -433,7 +429,7 @@ test('clearing results', async () => {
   apiMock.expectGetManualResultsMetadata([]);
   fireEvent.click(getByText('Clear All Tallies and Results'));
   getByText(
-    'Do you want to remove the 1 loaded CVR export and the manually entered data?'
+    'Do you want to remove the 1 loaded CVR export and all manual tallies?'
   );
   fireEvent.click(getByText('Remove All Data'));
 
@@ -441,15 +437,11 @@ test('clearing results', async () => {
     expect(getByText('Load CVRs').closest('button')).toBeEnabled();
   });
   await waitFor(() => {
-    expect(
-      getByText('Add Manually Entered Results').closest('button')
-    ).toBeEnabled();
+    expect(getByText('Add Manual Tallies').closest('button')).toBeEnabled();
   });
 
   expect(getByText('Remove CVRs').closest('button')).toBeDisabled();
-  expect(
-    getByText('Remove Manually Entered Results').closest('button')
-  ).toBeDisabled();
+  expect(getByText('Remove Manual Tallies').closest('button')).toBeDisabled();
 
   expect(queryByText('Clear All Tallies and Results')).not.toBeInTheDocument();
 

--- a/apps/admin/frontend/src/components/confirm_removing_file_modal.tsx
+++ b/apps/admin/frontend/src/components/confirm_removing_file_modal.tsx
@@ -57,7 +57,7 @@ export function ConfirmRemovingFileModal({
           <P>
             Do you want to remove the {fileList.length} loaded CVR{' '}
             {pluralize('export', fileList.length)}
-            {hasManualData && ' and the manually entered data'}?
+            {hasManualData && ' and all manual tallies'}?
           </P>
           <P>All reports will be unavailable without CVR data.</P>
         </React.Fragment>

--- a/apps/admin/frontend/src/components/remove_all_manual_tallies_modal.tsx
+++ b/apps/admin/frontend/src/components/remove_all_manual_tallies_modal.tsx
@@ -18,17 +18,16 @@ export function RemoveAllManualTalliesModal({
   }
   return (
     <Modal
-      title="Remove Manually Entered Results"
+      title="Remove Manual Tallies"
       content={
         <P>
-          Do you want to remove <Font weight="bold">all</Font> manually entered
-          results?
+          Do you want to remove <Font weight="bold">all</Font> manual tallies?
         </P>
       }
       actions={
         <React.Fragment>
           <Button icon="Delete" variant="danger" onPress={onConfirm}>
-            Remove All Manually Entered Results
+            Remove All Manual Tallies
           </Button>
           <Button onPress={onClose}>Cancel</Button>
         </React.Fragment>

--- a/apps/admin/frontend/src/screens/manual_data_entry_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_entry_screen.test.tsx
@@ -154,20 +154,20 @@ test('can edit counts, receive validation messages, and save', async () => {
   // Initial validation shows that results are empty
   const bestAnimalTable = screen.getByTestId(testInputId).closest('table')!
     .parentElement!;
-  within(bestAnimalTable).getByText('No results entered');
-  screen.getByText('At least one contest above has no results entered');
+  within(bestAnimalTable).getByText('No tallies entered');
+  screen.getByText('At least one contest above has no tallies entered');
 
-  // while results are incomplete, we should get validation warning
+  // while tallies are incomplete, we should get validation warning
   userEvent.type(
     screen.getByTestId('best-animal-mammal-numBallots-input'),
     '10'
   );
   within(bestAnimalTable).getByText(
-    'Entered results do not match total ballots cast'
+    'Entered tallies do not match total ballots cast'
   );
-  screen.getByText('At least one contest above has invalid results entered');
+  screen.getByText('At least one contest above has invalid tallies entered');
 
-  // finish entering results for current contest
+  // finish entering tallies for current contest
   userEvent.type(screen.getByTestId('best-animal-mammal-overvotes-input'), '1');
   userEvent.type(
     screen.getByTestId('best-animal-mammal-undervotes-input'),
@@ -178,9 +178,9 @@ test('can edit counts, receive validation messages, and save', async () => {
   userEvent.type(screen.getByTestId('best-animal-mammal-fox-input'), '2');
 
   // validation should be successful
-  within(bestAnimalTable).getByText('Entered results are valid');
+  within(bestAnimalTable).getByText('Entered tallies are valid');
 
-  // fill out the rest of the form with valid results, covering yes no contests
+  // fill out the rest of the form with valid tallies, covering yes no contests
   const resultsToEnter: Array<[string, string, string]> = [
     ['zoo-council-mammal', 'numBallots', '10'],
     ['zoo-council-mammal', 'overvotes', '6'],
@@ -213,7 +213,7 @@ test('can edit counts, receive validation messages, and save', async () => {
     );
   }
 
-  await screen.findByText('All entered contest results are valid');
+  await screen.findByText('All entered contest tallies are valid');
 
   apiMock.expectSetManualResults({
     ballotStyleId: '1M',
@@ -221,7 +221,7 @@ test('can edit counts, receive validation messages, and save', async () => {
     votingMethod: 'absentee',
     manualResults: mockValidResults,
   });
-  userEvent.click(screen.getButton('Save Results'));
+  userEvent.click(screen.getButton('Save Tallies'));
 });
 
 test('loads pre-existing manual data to edit', async () => {
@@ -272,8 +272,8 @@ test('loads pre-existing manual data to edit', async () => {
   ).toEqual('2');
 
   // validation should be good
-  screen.getByText('All entered contest results are valid');
-  expect(screen.getAllByText('Entered results are valid')).toHaveLength(5);
+  screen.getByText('All entered contest tallies are valid');
+  expect(screen.getAllByText('Entered tallies are valid')).toHaveLength(5);
 });
 
 test('adding new write-in candidates', async () => {
@@ -343,13 +343,13 @@ test('adding new write-in candidates', async () => {
 
   // Write-in counts affect validation
   await within(zooCouncilMammal).findByText(
-    'Entered results do not match total ballots cast'
+    'Entered tallies do not match total ballots cast'
   );
   userEvent.type(
     screen.getByTestId('zoo-council-mammal-numBallots-input'),
     '10'
   );
-  await within(zooCouncilMammal).findByText('Entered results are valid');
+  await within(zooCouncilMammal).findByText('Entered tallies are valid');
 
   // Can remove our write-in
   userEvent.click(within(zooCouncilMammal).getByText('Remove'));
@@ -357,7 +357,7 @@ test('adding new write-in candidates', async () => {
     screen.queryByTestId('temp-write-in-(Mock Candidate)')
   ).not.toBeInTheDocument();
   await within(zooCouncilMammal).findByText(
-    'Entered results do not match total ballots cast'
+    'Entered tallies do not match total ballots cast'
   );
 
   // Add back the candidate and save
@@ -373,7 +373,7 @@ test('adding new write-in candidates', async () => {
     ),
     '30'
   );
-  await within(zooCouncilMammal).findByText('Entered results are valid');
+  await within(zooCouncilMammal).findByText('Entered tallies are valid');
 
   // saves temp write-in candidate to backend
   apiMock.expectSetManualResults({
@@ -399,7 +399,7 @@ test('adding new write-in candidates', async () => {
       },
     }),
   });
-  userEvent.click(screen.getButton('Save Results'));
+  userEvent.click(screen.getButton('Save Tallies'));
 });
 
 test('loads existing write-in candidates', async () => {

--- a/apps/admin/frontend/src/screens/manual_data_entry_screen.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_entry_screen.tsx
@@ -505,7 +505,7 @@ export function ManualDataEntryScreen(): JSX.Element {
     !getManualResultsQuery.isSuccess
   ) {
     return (
-      <NavigationScreen title="Manually Entered Results Form">
+      <NavigationScreen title="Manual Tally Form">
         <Loading isFullscreen />
       </NavigationScreen>
     );
@@ -527,7 +527,7 @@ export function ManualDataEntryScreen(): JSX.Element {
   );
 
   return (
-    <NavigationScreen title="Manually Entered Results Form">
+    <NavigationScreen title="Manual Tally Form">
       <P>
         <Font weight="bold">Ballot Style:</Font> {ballotStyleId} |{' '}
         <Font weight="bold">Precinct:</Font> {precinct.name} |{' '}
@@ -571,10 +571,10 @@ export function ManualDataEntryScreen(): JSX.Element {
                   <Icons.Checkbox color="success" />
                 )}{' '}
                 {contestValidationState === 'no-results'
-                  ? 'No results entered'
+                  ? 'No tallies entered'
                   : contestValidationState === 'invalid'
-                  ? 'Entered results do not match total ballots cast'
-                  : 'Entered results are valid'}
+                  ? 'Entered tallies do not match total ballots cast'
+                  : 'Entered tallies are valid'}
               </P>
               <Table condensed>
                 <tbody>
@@ -744,10 +744,10 @@ export function ManualDataEntryScreen(): JSX.Element {
             <Icons.Checkbox color="success" />
           )}{' '}
           {someContestHasInvalidResults
-            ? 'At least one contest above has invalid results entered'
+            ? 'At least one contest above has invalid tallies entered'
             : someContestHasNoResults
-            ? 'At least one contest above has no results entered'
-            : 'All entered contest results are valid'}
+            ? 'At least one contest above has no tallies entered'
+            : 'All entered contest tallies are valid'}
         </div>
         <div style={{ display: 'flex', gap: '0.5rem' }}>
           <LinkButton to={routerPaths.manualDataSummary}>Cancel</LinkButton>
@@ -759,7 +759,7 @@ export function ManualDataEntryScreen(): JSX.Element {
               tempManualResults === getManualResultsQuery.data?.manualResults
             }
           >
-            Save Results
+            Save Tallies
           </Button>
         </div>
       </Footer>

--- a/apps/admin/frontend/src/screens/manual_data_summary_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_summary_screen.test.tsx
@@ -59,31 +59,29 @@ test('initial table without manual tallies & adding a manual tally', async () =>
     }
   );
   await screen.findByText('Total Manual Ballot Count: 0');
-  expect(
-    screen.getButton('Remove All Manually Entered Results')
-  ).toBeDisabled();
+  expect(screen.getButton('Remove All Manual Tallies')).toBeDisabled();
 
   // adding a manual tally
-  expect(screen.getButton('Add Results')).toBeDisabled();
+  expect(screen.getButton('Add Tallies')).toBeDisabled();
   expect(screen.getByLabelText('Select Voting Method')).toBeDisabled();
   expect(screen.getByLabelText('Select Precinct')).toBeDisabled();
 
   userEvent.click(screen.getByLabelText('Select Ballot Style'));
   userEvent.click(screen.getByText('1M'));
 
-  expect(screen.getButton('Add Results')).toBeDisabled();
+  expect(screen.getButton('Add Tallies')).toBeDisabled();
   expect(screen.getByLabelText('Select Voting Method')).toBeDisabled();
 
   userEvent.click(screen.getByLabelText('Select Precinct'));
   userEvent.click(screen.getByText('Precinct 1'));
 
-  expect(screen.getButton('Add Results')).toBeDisabled();
+  expect(screen.getButton('Add Tallies')).toBeDisabled();
 
   userEvent.click(screen.getByLabelText('Select Voting Method'));
   const options = screen.getByText('Absentee').parentElement!;
   userEvent.click(within(options).getByText('Precinct'));
 
-  userEvent.click(screen.getButton('Add Results'));
+  userEvent.click(screen.getButton('Add Tallies'));
   expect(history.location.pathname).toEqual(
     '/tally/manual-data-entry/1M/precinct/precinct-1'
   );
@@ -112,11 +110,9 @@ test('link to edit an existing tally', async () => {
   );
 
   await screen.findByText('Total Manual Ballot Count: 10');
-  expect(
-    screen.getButton('Remove All Manually Entered Results')
-  ).not.toBeDisabled();
+  expect(screen.getButton('Remove All Manual Tallies')).not.toBeDisabled();
 
-  userEvent.click(screen.getButton('Edit Results'));
+  userEvent.click(screen.getButton('Edit Tallies'));
   expect(history.location.pathname).toEqual(
     '/tally/manual-data-entry/1M/precinct/precinct-1'
   );
@@ -138,11 +134,9 @@ test('delete an existing tally', async () => {
   });
 
   await screen.findByText('Total Manual Ballot Count: 10');
-  expect(
-    screen.getButton('Remove All Manually Entered Results')
-  ).not.toBeDisabled();
+  expect(screen.getButton('Remove All Manual Tallies')).not.toBeDisabled();
 
-  userEvent.click(screen.getButton('Remove Results'));
+  userEvent.click(screen.getButton('Remove Tallies'));
   const modal = await screen.findByRole('alertdialog');
   within(modal).getByText(hasTextAcrossElements(/Ballot Style: 1M/));
   within(modal).getByText(hasTextAcrossElements(/Precinct: Precinct 1/));
@@ -155,7 +149,7 @@ test('delete an existing tally', async () => {
     votingMethod: 'precinct',
   });
   apiMock.expectGetManualResultsMetadata([]);
-  userEvent.click(screen.getButton('Remove Manually Entered Results'));
+  userEvent.click(screen.getButton('Remove Manual Tallies'));
 });
 
 test('full table & clearing all data', async () => {
@@ -180,9 +174,7 @@ test('full table & clearing all data', async () => {
   });
 
   await screen.findByText('Total Manual Ballot Count: 80');
-  expect(
-    screen.getButton('Remove All Manually Entered Results')
-  ).not.toBeDisabled();
+  expect(screen.getButton('Remove All Manual Tallies')).not.toBeDisabled();
 
   // adding row should be gone
   expect(
@@ -192,23 +184,21 @@ test('full table & clearing all data', async () => {
   expect(
     screen.queryByLabelText('Select Voting Method')
   ).not.toBeInTheDocument();
-  expect(screen.queryByText('Add Results')).not.toBeInTheDocument();
+  expect(screen.queryByText('Add Tallies')).not.toBeInTheDocument();
 
   // existing entries
-  expect(screen.getAllButtons('Edit Results')).toHaveLength(8);
-  expect(screen.getAllButtons('Remove Results')).toHaveLength(8);
+  expect(screen.getAllButtons('Edit Tallies')).toHaveLength(8);
+  expect(screen.getAllButtons('Remove Tallies')).toHaveLength(8);
 
   // clearing all results
-  userEvent.click(screen.getButton('Remove All Manually Entered Results'));
+  userEvent.click(screen.getButton('Remove All Manual Tallies'));
   const modal = await screen.findByRole('alertdialog');
 
   apiMock.expectDeleteAllManualResults();
   apiMock.expectGetManualResultsMetadata([]);
-  userEvent.click(
-    within(modal).getButton('Remove All Manually Entered Results')
-  );
+  userEvent.click(within(modal).getButton('Remove All Manual Tallies'));
 
-  await screen.findByText('Add Results');
+  await screen.findByText('Add Tallies');
   screen.getByLabelText('Select Ballot Style');
   screen.getByLabelText('Select Precinct');
   screen.getByLabelText('Select Voting Method');

--- a/apps/admin/frontend/src/screens/manual_data_summary_screen.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_summary_screen.tsx
@@ -84,12 +84,12 @@ function RemoveManualTallyModal({
 
   return (
     <Modal
-      title="Remove Manually Entered Results"
+      title="Remove Manual Tallies"
       content={
         <React.Fragment>
           <P>
-            Do you want to remove the manually entered results for the following
-            type of ballots cast?
+            Do you want to remove the manual tallies for the following type of
+            ballots cast?
           </P>
           <P>
             <Font weight="bold">Ballot Style:</Font> {identifier.ballotStyleId}
@@ -103,7 +103,7 @@ function RemoveManualTallyModal({
       actions={
         <React.Fragment>
           <Button icon="Delete" variant="danger" onPress={onConfirm}>
-            Remove Manually Entered Results
+            Remove Manual Tallies
           </Button>
           <Button onPress={onClose}>Cancel</Button>
         </React.Fragment>
@@ -206,7 +206,7 @@ export function ManualDataSummaryScreen(): JSX.Element {
 
   if (!getManualTallyMetadataQuery.isSuccess) {
     return (
-      <NavigationScreen title="Manually Entered Results">
+      <NavigationScreen title="Manual Tally Summary">
         <Loading isFullscreen />
       </NavigationScreen>
     );
@@ -214,7 +214,7 @@ export function ManualDataSummaryScreen(): JSX.Element {
 
   return (
     <React.Fragment>
-      <NavigationScreen title="Manually Entered Results Summary">
+      <NavigationScreen title="Manual Tally Summary">
         <P>
           <Button onPress={() => history.push(routerPaths.tally)}>
             Back to Tally
@@ -265,12 +265,12 @@ export function ManualDataSummaryScreen(): JSX.Element {
                     <TD>{votingMethodTitle}</TD>
                     <TD nowrap>
                       <LinkButton to={routerPaths.manualDataEntry(metadata)}>
-                        Edit Results
+                        Edit Tallies
                       </LinkButton>
                     </TD>
                     <TD nowrap>
                       <Button onPress={() => setManualTallyToRemove(metadata)}>
-                        Remove Results
+                        Remove Tallies
                       </Button>
                     </TD>
                     <TD nowrap textAlign="center" data-testid="numBallots">
@@ -341,10 +341,10 @@ export function ManualDataSummaryScreen(): JSX.Element {
                           votingMethod: selectedVotingMethod,
                         })}
                       >
-                        Add Results
+                        Add Tallies
                       </LinkButton>
                     ) : (
-                      <LinkButton disabled>Add Results</LinkButton>
+                      <LinkButton disabled>Add Tallies</LinkButton>
                     )}
                   </TD>
                   <TD />
@@ -362,7 +362,7 @@ export function ManualDataSummaryScreen(): JSX.Element {
             disabled={!hasManualTally}
             onPress={() => setIsClearingAll(true)}
           >
-            Remove All Manually Entered Results
+            Remove All Manual Tallies
           </Button>
         </P>
       </NavigationScreen>

--- a/apps/admin/frontend/src/screens/tally_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/tally_screen.test.tsx
@@ -53,23 +53,23 @@ test('displays manual tally metadata & links to manual data summary page', async
       apiMock,
     }
   );
-  await screen.findByRole('heading', { name: 'Manually Entered Results' });
-  expect(screen.getButton('Edit Manually Entered Results')).toBeEnabled();
-  expect(screen.getButton('Remove Manually Entered Results')).toBeEnabled();
+  await screen.findByRole('heading', { name: 'Manual Tallies' });
+  expect(screen.getButton('Edit Manual Tallies')).toBeEnabled();
+  expect(screen.getButton('Remove Manual Tallies')).toBeEnabled();
 
   const fileTable = screen.getByTestId('loaded-file-table');
   const manualResultsRow = within(fileTable)
-    .getByText('Manually Entered Results')
+    .getByText('Manual Tallies')
     .closest('tr')!;
 
   within(manualResultsRow).getByText('07/01/2022 12:00:00 PM');
   within(manualResultsRow).getByText('100');
-  within(manualResultsRow).getByText('Manually Entered Results');
+  within(manualResultsRow).getByText('Manual Tallies');
   within(manualResultsRow).getByText('Precinct 1, Precinct 2');
 
   within(screen.getByTestId('total-cvr-count')).getByText('100');
 
-  userEvent.click(screen.getButton('Edit Manually Entered Results'));
+  userEvent.click(screen.getButton('Edit Manual Tallies'));
   expect(history.location.pathname).toEqual('/tally/manual-data-summary');
 });
 
@@ -102,8 +102,8 @@ test('can delete manual data', async () => {
       apiMock,
     }
   );
-  await screen.findByRole('heading', { name: 'Manually Entered Results' });
-  userEvent.click(screen.getButton('Remove Manually Entered Results'));
+  await screen.findByRole('heading', { name: 'Manual Tallies' });
+  userEvent.click(screen.getButton('Remove Manual Tallies'));
 
   // allows canceling the action
   let modal = await screen.findByRole('alertdialog');
@@ -111,13 +111,11 @@ test('can delete manual data', async () => {
   expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
 
   // confirming action causes mutation and refetch
-  userEvent.click(screen.getButton('Remove Manually Entered Results'));
+  userEvent.click(screen.getButton('Remove Manual Tallies'));
   modal = await screen.findByRole('alertdialog');
   apiMock.expectDeleteAllManualResults();
   apiMock.expectGetManualResultsMetadata([]);
-  userEvent.click(
-    within(modal).getButton('Remove All Manually Entered Results')
-  );
+  userEvent.click(within(modal).getButton('Remove All Manual Tallies'));
   expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
 });
 
@@ -135,6 +133,6 @@ test('with no data loaded', async () => {
   await screen.findByText('No CVRs loaded.');
   expect(screen.getButton('Load CVRs')).toBeEnabled();
   expect(screen.getButton('Remove CVRs')).toBeDisabled();
-  expect(screen.getButton('Add Manually Entered Results')).toBeEnabled();
-  expect(screen.getButton('Remove Manually Entered Results')).toBeDisabled();
+  expect(screen.getButton('Add Manual Tallies')).toBeEnabled();
+  expect(screen.getButton('Remove Manual Tallies')).toBeDisabled();
 });

--- a/apps/admin/frontend/src/screens/tally_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally_screen.tsx
@@ -207,7 +207,7 @@ export function TallyScreen(): JSX.Element | null {
                   </TD>
                   <TD narrow>{format.count(manualTallyTotalBallotCount)}</TD>
                   <TD narrow nowrap>
-                    Manually Entered Results
+                    Manual Tallies
                   </TD>
                   <TD>{getPrecinctNames(manualTallyPrecinctIds)}</TD>
                 </tr>
@@ -235,21 +235,19 @@ export function TallyScreen(): JSX.Element | null {
             <Icons.Info /> No CVRs loaded.
           </P>
         )}
-        <H2>Manually Entered Results</H2>
+        <H2>Manual Tallies</H2>
         <P>
           <LinkButton
             to={routerPaths.manualDataSummary}
             disabled={isOfficialResults}
           >
-            {hasManualTally
-              ? 'Edit Manually Entered Results'
-              : 'Add Manually Entered Results'}
+            {hasManualTally ? 'Edit Manual Tallies' : 'Add Manual Tallies'}
           </LinkButton>{' '}
           <Button
             disabled={!hasManualTally || isOfficialResults}
             onPress={() => setIsConfirmingRemoveAllManualTallies(true)}
           >
-            Remove Manually Entered Results
+            Remove Manual Tallies
           </Button>
         </P>
       </NavigationScreen>


### PR DESCRIPTION
## Overview

Closes #2837.

"Manually Entered Results" -> "Manual Tallies"

## Demo Video or Screenshot

#### Manual Tally Interface

https://github.com/votingworks/vxsuite/assets/37960853/25163b0a-00b2-4e3c-958a-b3492f2ed31b

#### Other - Remove All Results Model

<img width="1150" alt="Screen Shot 2023-11-21 at 7 55 01 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/b09e1323-e8f5-48e4-9535-3df1c11bf414">


## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
