### PR TITLE
Update hex code vendor ID for Alcor Link AK9563 card reader

### DIFF
--- a/libs/utils/src/Hardware/utils.ts
+++ b/libs/utils/src/Hardware/utils.ts
@@ -16,7 +16,7 @@ export const OmniKeyCardReaderManufacturer = 'HID Global';
 export const OmniKeyCardReaderVendorId = 0x076b;
 export const OmniKeyCardReaderProductId = 0x3031;
 
-export const LenovoBuiltInCardReaderVendorIds = [0x2ec3, 0x058f];
+export const LenovoBuiltInCardReaderVendorIds = [0x2ce3, 0x058f];
 export const LenovoBuiltInCardReaderProductIds = [0x9563, 0x9540];
 
 /**


### PR DESCRIPTION
Hex code value had two letters transposed. This correctly identifies the vendor id. 