### PR TITLE
Central system design polish

### DIFF
--- a/apps/admin/frontend/src/app.test.tsx
+++ b/apps/admin/frontend/src/app.test.tsx
@@ -440,9 +440,6 @@ test('clearing results', async () => {
     expect(getByText('Add Manual Tallies').closest('button')).toBeEnabled();
   });
 
-  expect(getByText('Remove CVRs').closest('button')).toBeDisabled();
-  expect(getByText('Remove Manual Tallies').closest('button')).toBeDisabled();
-
   expect(queryByText('Clear All Tallies and Results')).not.toBeInTheDocument();
 
   getByText('No CVRs loaded.');
@@ -478,19 +475,21 @@ test('election manager UI has expected nav', async () => {
   renderApp();
   await apiMock.authenticateAsElectionManager(eitherNeitherElectionDefinition);
 
+  userEvent.click(screen.getButton('Election'));
+  await screen.findByRole('heading', { name: 'Election' });
+
   userEvent.click(screen.getButton('L&A'));
   await screen.findByRole('heading', { name: 'L&A Testing Documents' });
 
   userEvent.click(screen.getButton('Tally'));
   await screen.findByRole('heading', {
-    name: 'Cast Vote Record (CVR) Management',
+    name: 'Cast Vote Records (CVRs)',
   });
 
   userEvent.click(screen.getByText('Reports'));
   await screen.findByRole('heading', { name: 'Election Reports' });
   screen.getByRole('button', { name: 'Lock Machine' });
 
-  expect(screen.queryByText('Election')).not.toBeInTheDocument();
   expect(screen.queryByText('Smartcards')).not.toBeInTheDocument();
   expect(screen.queryByText('Advanced')).not.toBeInTheDocument();
 });

--- a/apps/admin/frontend/src/app_root.tsx
+++ b/apps/admin/frontend/src/app_root.tsx
@@ -4,7 +4,7 @@ import { Hardware, randomBallotId } from '@votingworks/utils';
 import { useDevices } from '@votingworks/ui';
 
 import { AppContext } from './contexts/app_context';
-import { ElectionManager } from './components/election_manager';
+import { AppRoutes } from './components/app_routes';
 import {
   getAuthStatus,
   getCurrentElectionMetadata,
@@ -66,7 +66,7 @@ export function AppRoot({
         logger,
       }}
     >
-      <ElectionManager />
+      <AppRoutes />
     </AppContext.Provider>
   );
 }

--- a/apps/admin/frontend/src/components/app_routes.tsx
+++ b/apps/admin/frontend/src/components/app_routes.tsx
@@ -15,8 +15,7 @@ import {
 import type { ManualResultsVotingMethod } from '@votingworks/admin-backend';
 import { AppContext } from '../contexts/app_context';
 import { routerPaths } from '../router_paths';
-import { DefinitionScreen } from '../screens/election_screen';
-import { BallotListScreen } from '../screens/ballot_list_screen';
+import { ElectionScreen } from '../screens/election_screen';
 import { PrintTestDeckScreen } from '../screens/print_test_deck_screen';
 import { UnconfiguredScreen } from '../screens/unconfigured_screen';
 import { TallyScreen } from '../screens/tally_screen';
@@ -44,7 +43,7 @@ import { PrecinctBallotCountReport } from '../screens/reporting/precinct_ballot_
 import { VotingMethodBallotCountReport } from '../screens/reporting/voting_method_ballot_count_report_screen';
 import { FullElectionTallyReportScreen } from '../screens/reporting/full_election_tally_report_screen';
 
-export function ElectionManager(): JSX.Element {
+export function AppRoutes(): JSX.Element {
   const { electionDefinition, configuredAt, auth, hasCardReaderAttached } =
     useContext(AppContext);
   const election = electionDefinition?.election;
@@ -94,7 +93,7 @@ export function ElectionManager(): JSX.Element {
       return (
         <React.Fragment>
           <Switch>
-            <Route exact path={routerPaths.electionDefinition}>
+            <Route exact path={routerPaths.election}>
               <UnconfiguredScreen />
             </Route>
             <Route exact path={routerPaths.settings}>
@@ -103,7 +102,7 @@ export function ElectionManager(): JSX.Element {
             <Route exact path={routerPaths.logs}>
               <LogsScreen />
             </Route>
-            <Redirect to={routerPaths.electionDefinition} />
+            <Redirect to={routerPaths.election} />
           </Switch>
           <SmartcardModal />
         </React.Fragment>
@@ -113,8 +112,8 @@ export function ElectionManager(): JSX.Element {
     return (
       <React.Fragment>
         <Switch>
-          <Route exact path={routerPaths.electionDefinition}>
-            <DefinitionScreen />
+          <Route exact path={routerPaths.election}>
+            <ElectionScreen />
           </Route>
           <Route exact path={routerPaths.smartcards}>
             <Redirect
@@ -135,7 +134,7 @@ export function ElectionManager(): JSX.Element {
           <Route exact path={routerPaths.logs}>
             <LogsScreen />
           </Route>
-          <Redirect to={routerPaths.electionDefinition} />
+          <Redirect to={routerPaths.election} />
         </Switch>
         <SmartcardModal />
       </React.Fragment>
@@ -145,8 +144,8 @@ export function ElectionManager(): JSX.Element {
   // Election manager UI
   return (
     <Switch>
-      <Route exact path={routerPaths.ballotsList}>
-        <BallotListScreen />
+      <Route exact path={routerPaths.election}>
+        <ElectionScreen />
       </Route>
       <Route exact path={routerPaths.manualDataSummary}>
         <ManualDataSummaryScreen />
@@ -219,7 +218,7 @@ export function ElectionManager(): JSX.Element {
       <Route exact path={routerPaths.system}>
         <ElectionManagerSystemScreen />
       </Route>
-      <Redirect to={routerPaths.ballotsList} />
+      <Redirect to={routerPaths.election} />
     </Switch>
   );
 }

--- a/apps/admin/frontend/src/components/export_election_ballot_package_modal_button.tsx
+++ b/apps/admin/frontend/src/components/export_election_ballot_package_modal_button.tsx
@@ -82,7 +82,11 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
         case 'mounted': {
           actions = (
             <React.Fragment>
-              <Button onPress={saveBallotPackageToUsb} variant="primary">
+              <Button
+                icon="Export"
+                onPress={saveBallotPackageToUsb}
+                variant="primary"
+              >
                 Save
               </Button>
               <Button onPress={closeModal}>Cancel</Button>
@@ -157,7 +161,13 @@ export function ExportElectionBallotPackageModalButton(): JSX.Element {
 
   return (
     <React.Fragment>
-      <Button onPress={() => setIsModalOpen(true)}>Save Ballot Package</Button>
+      <Button
+        variant="primary"
+        icon="Export"
+        onPress={() => setIsModalOpen(true)}
+      >
+        Save Ballot Package
+      </Button>
       {isModalOpen && (
         <Modal
           title={title}

--- a/apps/admin/frontend/src/components/mark_official_button.tsx
+++ b/apps/admin/frontend/src/components/mark_official_button.tsx
@@ -33,7 +33,13 @@ export function MarkResultsOfficialButton(): JSX.Element {
 
   return (
     <React.Fragment>
-      <Button disabled={!canMarkResultsOfficial} onPress={openModal}>
+      <Button
+        icon="Done"
+        color="primary"
+        fill="outlined"
+        disabled={!canMarkResultsOfficial}
+        onPress={openModal}
+      >
         {MARK_RESULTS_OFFICIAL_BUTTON_TEXT}
       </Button>
       {isModalOpen && (
@@ -53,7 +59,7 @@ export function MarkResultsOfficialButton(): JSX.Element {
           }
           actions={
             <React.Fragment>
-              <Button variant="primary" onPress={markOfficial}>
+              <Button icon="Done" variant="primary" onPress={markOfficial}>
                 Mark Election Results as Official
               </Button>
               <Button onPress={closeModal}>Cancel</Button>

--- a/apps/admin/frontend/src/components/navigation_screen.tsx
+++ b/apps/admin/frontend/src/components/navigation_screen.tsx
@@ -32,20 +32,20 @@ interface Props {
 }
 
 const SYSTEM_ADMIN_NAV_ITEMS: readonly NavItem[] = [
-  { label: 'Election', routerPath: routerPaths.electionDefinition },
+  { label: 'Election', routerPath: routerPaths.election },
   { label: 'Smartcards', routerPath: routerPaths.smartcards },
   { label: 'Logs', routerPath: routerPaths.logs },
   { label: 'Settings', routerPath: routerPaths.settings },
 ];
 
 const SYSTEM_ADMIN_NAV_ITEMS_NO_ELECTION: readonly NavItem[] = [
-  { label: 'Election', routerPath: routerPaths.electionDefinition },
+  { label: 'Election', routerPath: routerPaths.election },
   { label: 'Logs', routerPath: routerPaths.logs },
   { label: 'Settings', routerPath: routerPaths.settings },
 ];
 
 const ELECTION_MANAGER_NAV_ITEMS: readonly NavItem[] = _.compact([
-  { label: 'Ballots', routerPath: routerPaths.ballotsList },
+  { label: 'Election', routerPath: routerPaths.election },
   { label: 'L&A', routerPath: routerPaths.logicAndAccuracy },
   { label: 'Tally', routerPath: routerPaths.tally },
   isFeatureFlagEnabled(

--- a/apps/admin/frontend/src/router_paths.ts
+++ b/apps/admin/frontend/src/router_paths.ts
@@ -7,11 +7,10 @@ import {
 export const routerPaths = {
   root: '/',
   advanced: '/advanced',
-  electionDefinition: '/definition',
+  election: '/election',
   smartcards: '/smartcards',
   smartcardsByType: ({ smartcardType }: SmartcardsScreenProps): string =>
     `/smartcards/smartcard-types/${smartcardType}`,
-  ballotsList: '/ballots',
   manualDataSummary: '/tally/manual-data-summary',
   manualDataEntry: ({
     precinctId,

--- a/apps/admin/frontend/src/screens/election_screen.tsx
+++ b/apps/admin/frontend/src/screens/election_screen.tsx
@@ -1,27 +1,33 @@
 import React, { useContext, useState } from 'react';
 import styled from 'styled-components';
 
-import { format } from '@votingworks/utils';
+import {
+  format,
+  isElectionManagerAuth,
+  isSystemAdministratorAuth,
+} from '@votingworks/utils';
 import { assert } from '@votingworks/basics';
 
-import { Button, Font, H2, P, Seal } from '@votingworks/ui';
+import { Button, Card, Font, H2, P, Seal } from '@votingworks/ui';
 import { AppContext } from '../contexts/app_context';
 
 import { NavigationScreen } from '../components/navigation_screen';
 import { RemoveElectionModal } from '../components/remove_election_modal';
+import { ExportElectionBallotPackageModalButton } from '../components/export_election_ballot_package_modal_button';
 
-const ElectionMetadataContainer = styled.div`
-  display: flex;
-  gap: 1rem;
+const ElectionCard = styled(Card).attrs({ color: 'neutral' })`
   margin: 1rem 0;
-  align-items: center;
-  padding: 1rem;
-  background: ${(p) => p.theme.colors.containerLow};
-  border-radius: ${(p) => p.theme.sizes.borderRadiusRem}rem;
+
+  > div {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    padding: 1rem;
+  }
 `;
 
-export function DefinitionScreen(): JSX.Element {
-  const { electionDefinition, configuredAt } = useContext(AppContext);
+export function ElectionScreen(): JSX.Element {
+  const { electionDefinition, configuredAt, auth } = useContext(AppContext);
   assert(electionDefinition && typeof configuredAt === 'string');
   const { election } = electionDefinition;
 
@@ -35,8 +41,9 @@ export function DefinitionScreen(): JSX.Element {
           <Font weight="bold">
             {format.localeLongDateAndTime(new Date(configuredAt))}
           </Font>
+          .
         </P>
-        <ElectionMetadataContainer>
+        <ElectionCard>
           <Seal seal={election.seal} maxWidth="7rem" />
           <div>
             <H2 as="h3">{election.title}</H2>
@@ -46,14 +53,27 @@ export function DefinitionScreen(): JSX.Element {
               {format.localeDate(new Date(election.date))}
             </P>
           </div>
-        </ElectionMetadataContainer>
-        <Button
-          variant="danger"
-          icon="Delete"
-          onPress={() => setIsRemovingElection(true)}
-        >
-          Remove Election
-        </Button>
+        </ElectionCard>
+        {isSystemAdministratorAuth(auth) && (
+          <Button
+            color="danger"
+            icon="Delete"
+            onPress={() => setIsRemovingElection(true)}
+          >
+            Remove Election
+          </Button>
+        )}
+        {isElectionManagerAuth(auth) && (
+          <React.Fragment>
+            <P>
+              Save the Ballot Package to USB to configure VxCentralScan or
+              VxScan.
+            </P>
+            <P>
+              <ExportElectionBallotPackageModalButton />
+            </P>
+          </React.Fragment>
+        )}
       </NavigationScreen>
       {isRemovingElection && (
         <RemoveElectionModal onClose={() => setIsRemovingElection(false)} />

--- a/apps/admin/frontend/src/screens/manual_data_entry_screen.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_entry_screen.tsx
@@ -753,6 +753,7 @@ export function ManualDataEntryScreen(): JSX.Element {
           <LinkButton to={routerPaths.manualDataSummary}>Cancel</LinkButton>
           <Button
             variant="primary"
+            icon="Done"
             onPress={saveResults}
             disabled={
               !getManualResultsQuery.isSuccess ||

--- a/apps/admin/frontend/src/screens/manual_data_summary_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_summary_screen.test.tsx
@@ -59,7 +59,9 @@ test('initial table without manual tallies & adding a manual tally', async () =>
     }
   );
   await screen.findByText('Total Manual Ballot Count: 0');
-  expect(screen.getButton('Remove All Manual Tallies')).toBeDisabled();
+  expect(
+    screen.queryByRole('button', { name: 'Remove All Manual Tallies' })
+  ).not.toBeInTheDocument();
 
   // adding a manual tally
   expect(screen.getButton('Add Tallies')).toBeDisabled();
@@ -112,7 +114,7 @@ test('link to edit an existing tally', async () => {
   await screen.findByText('Total Manual Ballot Count: 10');
   expect(screen.getButton('Remove All Manual Tallies')).not.toBeDisabled();
 
-  userEvent.click(screen.getButton('Edit Tallies'));
+  userEvent.click(screen.getButton('Edit'));
   expect(history.location.pathname).toEqual(
     '/tally/manual-data-entry/1M/precinct/precinct-1'
   );
@@ -134,9 +136,9 @@ test('delete an existing tally', async () => {
   });
 
   await screen.findByText('Total Manual Ballot Count: 10');
-  expect(screen.getButton('Remove All Manual Tallies')).not.toBeDisabled();
+  expect(screen.getButton('Remove All Manual Tallies')).toBeEnabled();
 
-  userEvent.click(screen.getButton('Remove Tallies'));
+  userEvent.click(screen.getButton('Remove'));
   const modal = await screen.findByRole('alertdialog');
   within(modal).getByText(hasTextAcrossElements(/Ballot Style: 1M/));
   within(modal).getByText(hasTextAcrossElements(/Precinct: Precinct 1/));
@@ -174,7 +176,7 @@ test('full table & clearing all data', async () => {
   });
 
   await screen.findByText('Total Manual Ballot Count: 80');
-  expect(screen.getButton('Remove All Manual Tallies')).not.toBeDisabled();
+  expect(screen.getButton('Remove All Manual Tallies')).toBeEnabled();
 
   // adding row should be gone
   expect(
@@ -187,8 +189,8 @@ test('full table & clearing all data', async () => {
   expect(screen.queryByText('Add Tallies')).not.toBeInTheDocument();
 
   // existing entries
-  expect(screen.getAllButtons('Edit Tallies')).toHaveLength(8);
-  expect(screen.getAllButtons('Remove Tallies')).toHaveLength(8);
+  expect(screen.getAllButtons('Edit')).toHaveLength(8);
+  expect(screen.getAllButtons('Remove')).toHaveLength(8);
 
   // clearing all results
   userEvent.click(screen.getButton('Remove All Manual Tallies'));

--- a/apps/admin/frontend/src/screens/manual_data_summary_screen.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_summary_screen.tsx
@@ -9,7 +9,6 @@ import {
   TD,
   LinkButton,
   P,
-  H4,
   Modal,
   Font,
   SearchSelect,
@@ -220,26 +219,41 @@ export function ManualDataSummaryScreen(): JSX.Element {
             Back to Tally
           </Button>
         </P>
-        <H4>
-          Total Manual Ballot Count:{' '}
-          {totalNumberBallotsEntered.toLocaleString()}
-        </H4>
-        <br />
+        <P
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'end',
+          }}
+        >
+          <Font weight="semiBold">
+            Total Manual Ballot Count:{' '}
+            {totalNumberBallotsEntered.toLocaleString()}
+          </Font>
+          {hasManualTally && (
+            <Button
+              icon="Delete"
+              color="danger"
+              onPress={() => setIsClearingAll(true)}
+            >
+              Remove All Manual Tallies
+            </Button>
+          )}
+        </P>
         <SummaryTableWrapper>
           <Table condensed data-testid="summary-data">
             <thead>
               <tr>
-                <TD as="th" style={{ width: '9rem' }}>
+                <TD as="th" style={{ width: '10rem' }}>
                   Ballot Style
                 </TD>
-                <TD as="th" style={{ width: '9rem' }}>
+                <TD as="th" style={{ width: '10rem' }}>
                   Precinct
                 </TD>
                 <TD as="th" style={{ width: '10rem' }}>
                   Voting Method
                 </TD>
-                <TD as="th" narrow />
-                <TD as="th" narrow />
+                <TD as="th" style={{ width: '10rem' }} />
                 <TD as="th" narrow nowrap>
                   Ballot Count
                 </TD>
@@ -264,13 +278,21 @@ export function ManualDataSummaryScreen(): JSX.Element {
 
                     <TD>{votingMethodTitle}</TD>
                     <TD nowrap>
-                      <LinkButton to={routerPaths.manualDataEntry(metadata)}>
-                        Edit Tallies
+                      <LinkButton
+                        icon="Edit"
+                        fill="transparent"
+                        to={routerPaths.manualDataEntry(metadata)}
+                        style={{ marginRight: '0.5rem' }}
+                      >
+                        Edit
                       </LinkButton>
-                    </TD>
-                    <TD nowrap>
-                      <Button onPress={() => setManualTallyToRemove(metadata)}>
-                        Remove Tallies
+                      <Button
+                        icon="Delete"
+                        color="danger"
+                        fill="transparent"
+                        onPress={() => setManualTallyToRemove(metadata)}
+                      >
+                        Remove
                       </Button>
                     </TD>
                     <TD nowrap textAlign="center" data-testid="numBallots">
@@ -334,6 +356,7 @@ export function ManualDataSummaryScreen(): JSX.Element {
                     selectedPrecinct &&
                     selectedVotingMethod ? (
                       <LinkButton
+                        icon="Add"
                         variant="primary"
                         to={routerPaths.manualDataEntry({
                           ballotStyleId: selectedBallotStyle.id,
@@ -344,27 +367,17 @@ export function ManualDataSummaryScreen(): JSX.Element {
                         Add Tallies
                       </LinkButton>
                     ) : (
-                      <LinkButton disabled>Add Tallies</LinkButton>
+                      <LinkButton icon="Add" disabled>
+                        Add Tallies
+                      </LinkButton>
                     )}
                   </TD>
-                  <TD />
                   <TD textAlign="center">-</TD>
                 </tr>
               </tfoot>
             )}
           </Table>
         </SummaryTableWrapper>
-        <br />
-        <P>
-          <Button
-            icon="Delete"
-            variant="danger"
-            disabled={!hasManualTally}
-            onPress={() => setIsClearingAll(true)}
-          >
-            Remove All Manual Tallies
-          </Button>
-        </P>
       </NavigationScreen>
       {isClearingAll && (
         <RemoveAllManualTalliesModal onClose={() => setIsClearingAll(false)} />

--- a/apps/admin/frontend/src/screens/print_test_deck_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/print_test_deck_screen.test.tsx
@@ -185,4 +185,4 @@ test('Printing L&A packages for all precincts', async () => {
   await waitFor(() => {
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
   });
-});
+}, 30_000);

--- a/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
@@ -6,15 +6,24 @@ import {
   isElectionManagerAuth,
   getBallotCount,
 } from '@votingworks/utils';
-import { LinkButton, H2, P, Font } from '@votingworks/ui';
+import { LinkButton, H2, P, Font, Card, H3, Icons } from '@votingworks/ui';
 
 import { assert } from '@votingworks/basics';
+import styled from 'styled-components';
 import { AppContext } from '../../contexts/app_context';
 
 import { NavigationScreen } from '../../components/navigation_screen';
 import { routerPaths } from '../../router_paths';
 import { getCardCounts, getCastVoteRecordFileMode } from '../../api';
 import { MarkResultsOfficialButton } from '../../components/mark_official_button';
+
+const OfficialResultsCard = styled(Card).attrs({ color: 'neutral' })`
+  > div {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+`;
 
 export function ReportsScreen(): JSX.Element {
   const { electionDefinition, isOfficialResults, configuredAt, auth } =
@@ -48,7 +57,24 @@ export function ReportsScreen(): JSX.Element {
   return (
     <NavigationScreen title="Election Reports">
       {ballotCountSummaryText}
-      <MarkResultsOfficialButton />
+      <OfficialResultsCard>
+        {isOfficialResults ? (
+          <div>
+            <H3>
+              <Icons.Done color="success" /> Results Marked as Official
+            </H3>
+            <div>Election results have been marked as official.</div>
+          </div>
+        ) : (
+          <div>
+            <H3>
+              <Icons.Info /> Results are Unofficial
+            </H3>
+            <div>Election results have not yet been marked as official.</div>
+          </div>
+        )}
+        <MarkResultsOfficialButton />
+      </OfficialResultsCard>
       <H2>{statusPrefix} Tally Reports</H2>
       <P>
         <LinkButton variant="primary" to={routerPaths.tallyFullReport}>

--- a/apps/admin/frontend/src/screens/tally_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/tally_screen.test.tsx
@@ -128,11 +128,15 @@ test('with no data loaded', async () => {
     apiMock,
   });
   await screen.findByRole('heading', {
-    name: 'Cast Vote Record (CVR) Management',
+    name: 'Cast Vote Records (CVRs)',
   });
   await screen.findByText('No CVRs loaded.');
   expect(screen.getButton('Load CVRs')).toBeEnabled();
-  expect(screen.getButton('Remove CVRs')).toBeDisabled();
+  expect(
+    screen.queryByRole('button', { name: 'Remove CVRs' })
+  ).not.toBeInTheDocument();
   expect(screen.getButton('Add Manual Tallies')).toBeEnabled();
-  expect(screen.getButton('Remove Manual Tallies')).toBeDisabled();
+  expect(
+    screen.queryByRole('button', { name: 'Remove Manual Tallies' })
+  ).not.toBeInTheDocument();
 });

--- a/apps/admin/frontend/src/screens/tally_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally_screen.tsx
@@ -13,6 +13,7 @@ import {
   Icons,
   Card,
   H3,
+  H4,
 } from '@votingworks/ui';
 import styled from 'styled-components';
 import { ResultsFileType } from '../config/types';
@@ -40,6 +41,12 @@ const OfficialResultsCard = styled(Card).attrs({ color: 'neutral' })`
     align-items: center;
     justify-content: space-between;
   }
+`;
+
+const Actions = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
 `;
 
 export function TallyScreen(): JSX.Element | null {
@@ -130,12 +137,6 @@ export function TallyScreen(): JSX.Element | null {
   const hasAnyFiles = castVoteRecordFileList.length > 0 || hasManualTally;
 
   const fileMode = castVoteRecordFileModeQuery.data;
-  const fileModeText =
-    fileMode === 'test'
-      ? 'Currently tallying test ballots. Once you have completed L&A testing and are ready to tally official ballots, remove the test ballot mode CVRs.'
-      : fileMode === 'official'
-      ? 'Currently tallying official ballots.'
-      : '';
 
   return (
     <React.Fragment>
@@ -162,10 +163,18 @@ export function TallyScreen(): JSX.Element | null {
           </OfficialResultsCard>
         )}
         <H2>Cast Vote Records (CVRs)</H2>
-        {!hasAnyFiles && <P>No CVRs loaded</P>}
-        {fileModeText && <P>{fileModeText}</P>}
+        {!hasAnyFiles && <P>No CVRs loaded.</P>}
+        {fileMode === 'test' && (
+          <Card color="warning" style={{ marginBottom: '0.5rem' }}>
+            <H4>
+              <Icons.Warning color="warning" /> Test Ballot Mode
+            </H4>
+            Once you have completed L&A testing and are ready to tally official
+            ballots, remove the test ballot CVRs.
+          </Card>
+        )}
 
-        <P style={{ display: 'flex', justifyContent: 'space-between' }}>
+        <Actions>
           <Button
             icon="Import"
             variant="primary"
@@ -186,7 +195,7 @@ export function TallyScreen(): JSX.Element | null {
               Remove CVRs
             </Button>
           )}
-        </P>
+        </Actions>
         {hasAnyFiles && (
           <Table data-testid="loaded-file-table">
             <tbody>

--- a/apps/admin/frontend/src/screens/tally_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally_screen.tsx
@@ -13,7 +13,6 @@ import {
   Icons,
   Card,
   H3,
-  H4,
 } from '@votingworks/ui';
 import styled from 'styled-components';
 import { ResultsFileType } from '../config/types';
@@ -36,6 +35,8 @@ import { Loading } from '../components/loading';
 import { RemoveAllManualTalliesModal } from '../components/remove_all_manual_tallies_modal';
 
 const OfficialResultsCard = styled(Card).attrs({ color: 'neutral' })`
+  margin-bottom: 1rem;
+
   > div {
     display: flex;
     align-items: center;
@@ -43,10 +44,18 @@ const OfficialResultsCard = styled(Card).attrs({ color: 'neutral' })`
   }
 `;
 
+const TestModeCard = styled(Card).attrs({ color: 'warning' })`
+  margin-bottom: 1rem;
+`;
+
 const Actions = styled.div`
   display: flex;
   justify-content: space-between;
   margin-bottom: 0.5rem;
+`;
+
+const Section = styled.section`
+  margin-bottom: 2rem;
 `;
 
 export function TallyScreen(): JSX.Element | null {
@@ -162,138 +171,146 @@ export function TallyScreen(): JSX.Element | null {
             </Button>
           </OfficialResultsCard>
         )}
-        <H2>Cast Vote Records (CVRs)</H2>
-        {!hasAnyFiles && <P>No CVRs loaded.</P>}
+
         {fileMode === 'test' && (
-          <Card color="warning" style={{ marginBottom: '0.5rem' }}>
-            <H4>
+          <TestModeCard>
+            <H3>
               <Icons.Warning color="warning" /> Test Ballot Mode
-            </H4>
+            </H3>
             Once you have completed L&A testing and are ready to tally official
             ballots, remove the test ballot CVRs.
-          </Card>
+          </TestModeCard>
         )}
 
-        <Actions>
-          <Button
-            icon="Import"
-            variant="primary"
-            disabled={isOfficialResults}
-            onPress={() => setIsImportCvrModalOpen(true)}
-          >
-            Load CVRs
-          </Button>
+        <Section>
+          <H2>Cast Vote Records (CVRs)</H2>
+          {!hasAnyFiles && <P>No CVRs loaded.</P>}
+          <Actions>
+            <Button
+              icon="Import"
+              variant="primary"
+              disabled={isOfficialResults}
+              onPress={() => setIsImportCvrModalOpen(true)}
+            >
+              Load CVRs
+            </Button>
+            {hasAnyFiles && (
+              <Button
+                icon="Delete"
+                color="danger"
+                disabled={isOfficialResults}
+                onPress={() =>
+                  beginConfirmRemoveFiles(ResultsFileType.CastVoteRecord)
+                }
+              >
+                Remove CVRs
+              </Button>
+            )}
+          </Actions>
           {hasAnyFiles && (
-            <Button
-              icon="Delete"
-              color="danger"
-              disabled={isOfficialResults}
-              onPress={() =>
-                beginConfirmRemoveFiles(ResultsFileType.CastVoteRecord)
-              }
-            >
-              Remove CVRs
-            </Button>
-          )}
-        </Actions>
-        {hasAnyFiles && (
-          <Table data-testid="loaded-file-table">
-            <tbody>
-              <tr>
-                <TD as="th" narrow nowrap textAlign="right">
-                  #
-                </TD>
-                <TD as="th" narrow nowrap>
-                  Created At
-                </TD>
-                <TD as="th" nowrap>
-                  CVR Count
-                </TD>
-                <TD as="th" narrow nowrap>
-                  Source
-                </TD>
-                <TD as="th" nowrap>
-                  Precinct
-                </TD>
-              </tr>
-              {castVoteRecordFileList.map(
-                (
-                  {
-                    filename,
-                    exportTimestamp,
-                    numCvrsImported,
-                    scannerIds,
-                    precinctIds,
-                  },
-                  cvrFileIndex
-                ) => (
-                  <tr key={filename}>
-                    <TD narrow nowrap textAlign="right">
-                      {cvrFileIndex + 1}.
-                    </TD>
-                    <TD narrow nowrap>
-                      {moment(exportTimestamp).format('MM/DD/YYYY hh:mm:ss A')}
-                    </TD>
-                    <TD nowrap>{format.count(numCvrsImported)} </TD>
-                    <TD narrow nowrap>
-                      {scannerIds.join(', ')}
-                    </TD>
-                    <TD>{getPrecinctNames(precinctIds)}</TD>
-                  </tr>
-                )
-              )}
-              {hasManualTally ? (
-                <tr key="manual-data">
-                  <TD />
-                  <TD narrow nowrap>
-                    {moment(manualTallyFirstAdded).format(TIME_FORMAT)}
+            <Table data-testid="loaded-file-table">
+              <tbody>
+                <tr>
+                  <TD as="th" narrow nowrap textAlign="right">
+                    #
                   </TD>
-                  <TD narrow>{format.count(manualTallyTotalBallotCount)}</TD>
-                  <TD narrow nowrap>
-                    Manual Tallies
+                  <TD as="th" narrow nowrap>
+                    Created At
                   </TD>
-                  <TD>{getPrecinctNames(manualTallyPrecinctIds)}</TD>
+                  <TD as="th" nowrap>
+                    CVR Count
+                  </TD>
+                  <TD as="th" narrow nowrap>
+                    Source
+                  </TD>
+                  <TD as="th" nowrap>
+                    Precinct
+                  </TD>
                 </tr>
-              ) : null}
-              <tr>
-                <TD />
-                <TD as="th" narrow nowrap>
-                  Total CVR Count
-                </TD>
-                <TD as="th" narrow data-testid="total-cvr-count">
-                  {format.count(
-                    castVoteRecordFileList.reduce(
-                      (prev, curr) => prev + curr.numCvrsImported,
-                      0
-                    ) + manualTallyTotalBallotCount
-                  )}
-                </TD>
-                <TD />
-                <TD as="th" />
-              </tr>
-            </tbody>
-          </Table>
-        )}
-        <H2>Manual Tallies</H2>
-        <P>
-          <LinkButton
-            icon={hasManualTally ? 'Edit' : 'Add'}
-            to={routerPaths.manualDataSummary}
-            disabled={isOfficialResults}
-          >
-            {hasManualTally ? 'Edit Manual Tallies' : 'Add Manual Tallies'}
-          </LinkButton>{' '}
-          {hasManualTally && (
-            <Button
-              icon="Delete"
-              color="danger"
-              disabled={isOfficialResults}
-              onPress={() => setIsConfirmingRemoveAllManualTallies(true)}
-            >
-              Remove Manual Tallies
-            </Button>
+                {castVoteRecordFileList.map(
+                  (
+                    {
+                      filename,
+                      exportTimestamp,
+                      numCvrsImported,
+                      scannerIds,
+                      precinctIds,
+                    },
+                    cvrFileIndex
+                  ) => (
+                    <tr key={filename}>
+                      <TD narrow nowrap textAlign="right">
+                        {cvrFileIndex + 1}.
+                      </TD>
+                      <TD narrow nowrap>
+                        {moment(exportTimestamp).format(
+                          'MM/DD/YYYY hh:mm:ss A'
+                        )}
+                      </TD>
+                      <TD nowrap>{format.count(numCvrsImported)} </TD>
+                      <TD narrow nowrap>
+                        {scannerIds.join(', ')}
+                      </TD>
+                      <TD>{getPrecinctNames(precinctIds)}</TD>
+                    </tr>
+                  )
+                )}
+                {hasManualTally ? (
+                  <tr key="manual-data">
+                    <TD />
+                    <TD narrow nowrap>
+                      {moment(manualTallyFirstAdded).format(TIME_FORMAT)}
+                    </TD>
+                    <TD narrow>{format.count(manualTallyTotalBallotCount)}</TD>
+                    <TD narrow nowrap>
+                      Manual Tallies
+                    </TD>
+                    <TD>{getPrecinctNames(manualTallyPrecinctIds)}</TD>
+                  </tr>
+                ) : null}
+                <tr>
+                  <TD />
+                  <TD as="th" narrow nowrap>
+                    Total CVR Count
+                  </TD>
+                  <TD as="th" narrow data-testid="total-cvr-count">
+                    {format.count(
+                      castVoteRecordFileList.reduce(
+                        (prev, curr) => prev + curr.numCvrsImported,
+                        0
+                      ) + manualTallyTotalBallotCount
+                    )}
+                  </TD>
+                  <TD />
+                  <TD as="th" />
+                </tr>
+              </tbody>
+            </Table>
           )}
-        </P>
+        </Section>
+
+        <Section>
+          <H2>Manual Tallies</H2>
+          <P>
+            <LinkButton
+              icon={hasManualTally ? 'Edit' : 'Add'}
+              to={routerPaths.manualDataSummary}
+              disabled={isOfficialResults}
+            >
+              {hasManualTally ? 'Edit Manual Tallies' : 'Add Manual Tallies'}
+            </LinkButton>{' '}
+            {hasManualTally && (
+              <Button
+                icon="Delete"
+                color="danger"
+                disabled={isOfficialResults}
+                onPress={() => setIsConfirmingRemoveAllManualTallies(true)}
+              >
+                Remove Manual Tallies
+              </Button>
+            )}
+          </P>
+        </Section>
       </NavigationScreen>
       {confirmingRemoveFileType && (
         <ConfirmRemovingFileModal

--- a/apps/admin/frontend/src/screens/tally_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally_screen.tsx
@@ -3,7 +3,18 @@ import moment from 'moment';
 
 import { format, isElectionManagerAuth } from '@votingworks/utils';
 import { assert, find, throwIllegalValue, unique } from '@votingworks/basics';
-import { Button, Table, TD, LinkButton, H2, P, Icons } from '@votingworks/ui';
+import {
+  Button,
+  Table,
+  TD,
+  LinkButton,
+  H2,
+  P,
+  Icons,
+  Card,
+  H3,
+} from '@votingworks/ui';
+import styled from 'styled-components';
 import { ResultsFileType } from '../config/types';
 
 import { AppContext } from '../contexts/app_context';
@@ -22,6 +33,14 @@ import {
 } from '../api';
 import { Loading } from '../components/loading';
 import { RemoveAllManualTalliesModal } from '../components/remove_all_manual_tallies_modal';
+
+const OfficialResultsCard = styled(Card).attrs({ color: 'neutral' })`
+  > div {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+`;
 
 export function TallyScreen(): JSX.Element | null {
   const { electionDefinition, isOfficialResults, auth } =
@@ -121,39 +140,54 @@ export function TallyScreen(): JSX.Element | null {
   return (
     <React.Fragment>
       <NavigationScreen title="Tally">
-        <H2>Cast Vote Record (CVR) Management</H2>
-        {fileModeText && <P>{fileModeText}</P>}
         {isOfficialResults && (
-          <P>
+          <OfficialResultsCard>
+            <div>
+              <H3>
+                <Icons.Done color="success" /> Results Marked as Official
+              </H3>
+              <div>
+                Election results have been marked as official and may no longer
+                be edited.
+              </div>
+            </div>
             <Button
               disabled={!hasAnyFiles}
               onPress={() => beginConfirmRemoveFiles(ResultsFileType.All)}
               icon="Delete"
-              variant="danger"
+              color="danger"
             >
               Clear All Tallies and Results
             </Button>
-          </P>
+          </OfficialResultsCard>
         )}
+        <H2>Cast Vote Records (CVRs)</H2>
+        {!hasAnyFiles && <P>No CVRs loaded</P>}
+        {fileModeText && <P>{fileModeText}</P>}
 
-        <P>
+        <P style={{ display: 'flex', justifyContent: 'space-between' }}>
           <Button
+            icon="Import"
             variant="primary"
             disabled={isOfficialResults}
             onPress={() => setIsImportCvrModalOpen(true)}
           >
             Load CVRs
-          </Button>{' '}
-          <Button
-            disabled={fileMode === 'unlocked' || isOfficialResults}
-            onPress={() =>
-              beginConfirmRemoveFiles(ResultsFileType.CastVoteRecord)
-            }
-          >
-            Remove CVRs
           </Button>
+          {hasAnyFiles && (
+            <Button
+              icon="Delete"
+              color="danger"
+              disabled={isOfficialResults}
+              onPress={() =>
+                beginConfirmRemoveFiles(ResultsFileType.CastVoteRecord)
+              }
+            >
+              Remove CVRs
+            </Button>
+          )}
         </P>
-        {hasAnyFiles ? (
+        {hasAnyFiles && (
           <Table data-testid="loaded-file-table">
             <tbody>
               <tr>
@@ -230,25 +264,26 @@ export function TallyScreen(): JSX.Element | null {
               </tr>
             </tbody>
           </Table>
-        ) : (
-          <P>
-            <Icons.Info /> No CVRs loaded.
-          </P>
         )}
         <H2>Manual Tallies</H2>
         <P>
           <LinkButton
+            icon={hasManualTally ? 'Edit' : 'Add'}
             to={routerPaths.manualDataSummary}
             disabled={isOfficialResults}
           >
             {hasManualTally ? 'Edit Manual Tallies' : 'Add Manual Tallies'}
           </LinkButton>{' '}
-          <Button
-            disabled={!hasManualTally || isOfficialResults}
-            onPress={() => setIsConfirmingRemoveAllManualTallies(true)}
-          >
-            Remove Manual Tallies
-          </Button>
+          {hasManualTally && (
+            <Button
+              icon="Delete"
+              color="danger"
+              disabled={isOfficialResults}
+              onPress={() => setIsConfirmingRemoveAllManualTallies(true)}
+            >
+              Remove Manual Tallies
+            </Button>
+          )}
         </P>
       </NavigationScreen>
       {confirmingRemoveFileType && (

--- a/apps/admin/frontend/src/screens/unconfigured_screen.tsx
+++ b/apps/admin/frontend/src/screens/unconfigured_screen.tsx
@@ -59,7 +59,7 @@ export function UnconfiguredScreen(): JSX.Element {
 
   async function loadDemoElection() {
     await configureFromElectionPackage(demoElection);
-    history.push(routerPaths.electionDefinition);
+    history.push(routerPaths.election);
   }
 
   const handleVxElectionFile: InputEventFunction = async (event) => {

--- a/apps/admin/integration-testing/e2e/reports.spec.ts
+++ b/apps/admin/integration-testing/e2e/reports.spec.ts
@@ -46,9 +46,7 @@ test('viewing and exporting reports', async ({ page }) => {
 
   await logInAsElectionManager(page, electionHash);
   await page.getByText('Tally').click();
-  await expect(
-    page.getByText('Cast Vote Record (CVR) Management')
-  ).toBeVisible();
+  await expect(page.getByText('Cast Vote Records (CVRs)')).toBeVisible();
 
   const electionDirectory = generateElectionBasedSubfolderName(
     election,

--- a/apps/central-scan/frontend/src/components/export_results_modal.tsx
+++ b/apps/central-scan/frontend/src/components/export_results_modal.tsx
@@ -152,7 +152,7 @@ export function ExportResultsModal({ onClose }: Props): JSX.Element {
           onOverlayClick={onClose}
           actions={
             <React.Fragment>
-              <Button variant="primary" onPress={exportResults}>
+              <Button icon="Export" variant="primary" onPress={exportResults}>
                 Save
               </Button>
               <Button onPress={onClose}>Cancel</Button>

--- a/apps/central-scan/frontend/src/navigation_screen.tsx
+++ b/apps/central-scan/frontend/src/navigation_screen.tsx
@@ -1,6 +1,7 @@
 import {
   AppLogo,
   Button,
+  Card,
   H1,
   Icons,
   LeftNav,
@@ -42,14 +43,13 @@ const HeaderActions = styled.div`
   align-items: center;
 `;
 
-const TestModeCallout = styled.div`
-  background: ${(p) => p.theme.colors.warningContainer};
-  border-radius: ${(p) => p.theme.sizes.borderRadiusRem}rem;
-  border: ${(p) => p.theme.sizes.bordersRem.hairline}rem solid
-    ${(p) => p.theme.colors.warningAccent};
+const TestModeCallout = styled(Card).attrs({ color: 'warning' })`
   font-size: ${(p) => p.theme.sizes.headingsRem.h3}rem;
   font-weight: ${(p) => p.theme.sizes.fontWeight.semiBold};
-  padding: 0.5rem 1rem;
+
+  > div {
+    padding: 0.5rem 1rem;
+  }
 `;
 
 export function NavigationScreen({ children, title }: Props): JSX.Element {

--- a/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
@@ -11,6 +11,7 @@ import { assert } from '@votingworks/basics';
 import {
   Button,
   H1,
+  H2,
   Icons,
   LabelledText,
   Main,
@@ -329,11 +330,12 @@ export function BallotEjectScreen({
     <Screen>
       <AdjudicationHeader>
         <H1>
-          <Icons.Warning /> {adjudicationTitle}
+          <Icons.Warning /> Ballot Not Counted
         </H1>
       </AdjudicationHeader>
       <Main flexRow>
         <AdjudicationExplanation>
+          <H2>{adjudicationTitle}</H2>
           {isOvervotedSheet ? (
             <P>
               The last scanned ballot was not tabulated because an overvote was

--- a/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
@@ -75,8 +75,8 @@ export function ScanBallotsScreen({
             status.adjudication.remaining > 0 || status.batches.length === 0
           }
           nonAccessibleTitle={exportButtonTitle}
-          icon="Done"
-          variant="secondary"
+          icon="Export"
+          color="primary"
         >
           Save CVRs
         </Button>

--- a/libs/ui/src/card.stories.tsx
+++ b/libs/ui/src/card.stories.tsx
@@ -25,9 +25,11 @@ export default meta;
 export function Card(props: Props): JSX.Element {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-      <Component {...props} />
-      <Component {...props} />
-      <Component {...props} />
+      <Component {...props} color={undefined} />
+      <Component {...props} color="neutral" />
+      <Component {...props} color="primary" />
+      <Component {...props} color="warning" />
+      <Component {...props} color="danger" />
     </div>
   );
 }

--- a/libs/ui/src/card.test.tsx
+++ b/libs/ui/src/card.test.tsx
@@ -25,14 +25,17 @@ test('renders with footer', () => {
   expect(screen.getByText('Footer content')).toBeDefined();
 });
 
-test('renders with desktop theme', () => {
+test('renders with desktop theme and color', () => {
   const theme = makeTheme({ colorMode: 'desktop', sizeMode: 'desktop' });
   render(
-    <Card>
+    <Card color="primary">
       <P>Card content</P>
     </Card>,
     { vxTheme: theme }
   );
   const cardContents = screen.getByText('Card content');
   expect(cardContents).toHaveStyleRule('padding: 1rem');
+  expect(cardContents.parentElement).toHaveStyleRule(
+    `background-color: ${theme.colors.primaryContainer}`
+  );
 });

--- a/libs/ui/src/card.tsx
+++ b/libs/ui/src/card.tsx
@@ -1,7 +1,10 @@
+import { UiTheme } from '@votingworks/types';
 import React from 'react';
 import styled from 'styled-components';
 
 export type CardFooterAlign = 'left' | 'center' | 'right';
+
+export type CardColor = 'neutral' | 'primary' | 'warning' | 'danger';
 
 export interface CardProps {
   children?: React.ReactNode;
@@ -9,14 +12,47 @@ export interface CardProps {
   footer?: React.ReactNode;
   footerAlign?: CardFooterAlign;
   style?: React.CSSProperties;
+  color?: CardColor;
 }
 
-const StyledContainer = styled.div`
+function cardColors(
+  theme: UiTheme,
+  color?: CardColor
+): { background: string; border: string } {
+  const { colors } = theme;
+  if (!color) {
+    return {
+      background: 'none',
+      border: colors.outline,
+    };
+  }
+  return {
+    neutral: {
+      background: colors.containerLow,
+      border: colors.outline,
+    },
+    primary: {
+      background: colors.primaryContainer,
+      border: colors.primary,
+    },
+    warning: {
+      background: colors.warningContainer,
+      border: colors.warningAccent,
+    },
+    danger: {
+      background: colors.dangerContainer,
+      border: colors.dangerAccent,
+    },
+  }[color ?? 'neutral'];
+}
+
+const StyledContainer = styled.div<{ color?: CardColor }>`
+  background-color: ${(p) => cardColors(p.theme, p.color).background};
   border: ${(p) =>
       p.theme.sizeMode === 'desktop'
         ? p.theme.sizes.bordersRem.thin
         : p.theme.sizes.bordersRem.hairline}rem
-    solid ${(p) => p.theme.colors.outline};
+    solid ${(p) => cardColors(p.theme, p.color).border};
   border-radius: ${(p) => p.theme.sizes.borderRadiusRem}rem;
   overflow: hidden;
 `;
@@ -47,10 +83,10 @@ const StyledFooter = styled.div<StyledFooterProps>`
  * components.
  */
 export function Card(props: CardProps): JSX.Element {
-  const { children, className, footer, footerAlign, style } = props;
+  const { children, className, color, footer, footerAlign, style } = props;
 
   return (
-    <StyledContainer className={className} style={style}>
+    <StyledContainer color={color} className={className} style={style}>
       <StyledContent>{children}</StyledContent>
       {footer && (
         <StyledFooter footerAlign={footerAlign || 'left'}>

--- a/libs/ui/src/card.tsx
+++ b/libs/ui/src/card.tsx
@@ -43,7 +43,7 @@ function cardColors(
       background: colors.dangerContainer,
       border: colors.dangerAccent,
     },
-  }[color ?? 'neutral'];
+  }[color];
 }
 
 const StyledContainer = styled.div<{ color?: CardColor }>`

--- a/libs/ui/src/election_info_bar.tsx
+++ b/libs/ui/src/election_info_bar.tsx
@@ -27,7 +27,7 @@ const Bar = styled.div<{ inverse?: boolean }>`
 const ElectionInfoContainer = styled.div`
   align-items: center;
   display: flex;
-  gap: 0.25rem;
+  gap: 0.5rem;
   justify-content: start;
 `;
 
@@ -155,28 +155,26 @@ export function VerticalElectionInfoBar({
 
   return (
     <VerticalBar inverse={inverse}>
-      <Caption>
-        <ElectionInfoContainer>
-          <Seal seal={seal} maxWidth="2.25rem" inverse={inverse} />
+      <ElectionInfoContainer>
+        <Seal seal={seal} maxWidth="3rem" inverse={inverse} />
+
+        <Caption weight="regular" align="left">
           <Font weight="bold">{electionStrings.electionTitle(election)}</Font>
-        </ElectionInfoContainer>
-      </Caption>
+          {precinctSelection && (
+            <PrecinctSelectionName
+              electionPrecincts={precincts}
+              precinctSelection={precinctSelection}
+            />
+          )}
 
-      <Caption weight="regular" align="left">
-        {precinctSelection && (
-          <PrecinctSelectionName
-            electionPrecincts={precincts}
-            precinctSelection={precinctSelection}
-          />
-        )}
+          <div>
+            {electionStrings.countyName(county)},{' '}
+            {electionStrings.stateName(election)}
+          </div>
 
-        <div>
-          {electionStrings.countyName(county)},{' '}
-          {electionStrings.stateName(election)}
-        </div>
-
-        <div>{electionStrings.electionDate(election)}</div>
-      </Caption>
+          <div>{electionStrings.electionDate(election)}</div>
+        </Caption>
+      </ElectionInfoContainer>
 
       <Caption>
         {mode !== 'voter' && codeVersion && (

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -32,6 +32,8 @@ import {
   faCircleQuestion,
   faLock,
   faEject,
+  faFileArrowUp,
+  faFileArrowDown,
 } from '@fortawesome/free-solid-svg-icons';
 import {
   faXmarkCircle,
@@ -196,8 +198,16 @@ export const Icons = {
     return <FaIcon {...props} type={faEject} />;
   },
 
+  Export(props) {
+    return <FaIcon {...props} type={faFileArrowDown} />;
+  },
+
   Info(props) {
     return <FaIcon {...props} type={faInfoCircle} />;
+  },
+
+  Import(props) {
+    return <FaIcon {...props} type={faFileArrowUp} />;
   },
 
   Loading(props) {


### PR DESCRIPTION
## Overview

Adds a variety of small tweaks to VxCentralSystem and VxAdmin to improve how they use the desktop theme.

## Demo Video or Screenshot
Central Scan - adjudication
<img width="966" alt="Screenshot 2023-11-22 at 11 24 31 AM" src="https://github.com/votingworks/vxsuite/assets/530106/761d2aec-0aa7-4d7f-8fe9-57985859af02">

Admin - Election Manager - Election screen (formerly Ballots screen)
<img width="960" alt="Screenshot 2023-11-22 at 1 04 58 PM" src="https://github.com/votingworks/vxsuite/assets/530106/6ae02856-a583-4cb6-a36e-be608ed77248">

Admin - Election Manager - tallies and marking as official
https://github.com/votingworks/vxsuite/assets/530106/54dd0dbd-f0c6-4028-9bc2-9bbc808b0148


## Testing Plan


## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
