### PR TITLE
VxCentralScan: Disable "Delete Batch" buttons while scanning

### DIFF
--- a/apps/central-scan/frontend/src/screens/scan_ballots_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/scan_ballots_screen.test.tsx
@@ -95,4 +95,7 @@ test('shows whether a batch is scanning', () => {
   };
   renderScreen({ isScanning: true, status });
   screen.getByText('Scanning…');
+  for (const deleteButton of screen.getAllButtons('Delete')) {
+    expect(deleteButton).toBeDisabled();
+  }
 });

--- a/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
@@ -124,6 +124,7 @@ export function ScanBallotsScreen({
                         color="danger"
                         onPress={() => setPendingDeleteBatch(batch)}
                         style={{ flexWrap: 'nowrap' }}
+                        disabled={isScanning}
                       >
                         Delete
                       </Button>


### PR DESCRIPTION


## Overview
It's not currently clear what is supposed to happen if you try to delete a batch while scanning is in progress. We've seen the scanner device keep scanning even though the batch is deleted, which is weird. Quick fix: disable the buttons.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
