### PR TITLE
Better on-screen messaging when VxScan is not configured.

### DIFF
--- a/apps/central-scan/frontend/src/app.test.tsx
+++ b/apps/central-scan/frontend/src/app.test.tsx
@@ -309,7 +309,7 @@ test('configuring election from usb ballot package works end to end', async () =
   mockApiClient.ejectUsbDrive.expectCallWith().resolves();
   userEvent.click(screen.getByText('I am sure. Delete all election data.'));
   screen.getByText('Deleting election data');
-  await screen.findByText('Insert a USB drive containing a ballot package.');
+  await screen.findByText('Insert a USB drive containing a ballot package');
 });
 
 test('authentication works', async () => {

--- a/apps/mark/integration-testing/e2e/helpers.ts
+++ b/apps/mark/integration-testing/e2e/helpers.ts
@@ -51,5 +51,7 @@ export async function forceReset(page: Page): Promise<void> {
       .click();
   }
   mockCardRemoval();
-  await page.getByText('VxMark is Not Configured').waitFor();
+  await page
+    .getByText('Insert a USB drive containing a ballot package')
+    .waitFor();
 }

--- a/apps/mark/integration-testing/e2e/scroll_buttons.spec.ts
+++ b/apps/mark/integration-testing/e2e/scroll_buttons.spec.ts
@@ -35,7 +35,9 @@ test('configure, open polls, and test contest scroll buttons', async ({
     electionHash,
   });
   await enterPin(page);
-  await page.getByText('VxMark is Not Configured').waitFor();
+  await page
+    .getByText('Insert a USB drive containing a ballot package')
+    .waitFor();
 
   usbHandler.insert(
     await mockBallotPackageFileTree(electionGeneralJson.toBallotPackage())

--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -141,8 +141,7 @@ test('app can load and configure from a usb stick', async () => {
   apiMock.expectGetUsbDriveStatus('no_drive');
   apiMock.expectGetScannerStatus(statusNoPaper);
   renderApp();
-  await screen.findByText('VxScan is Not Configured');
-  await screen.findByText('Insert a USB drive containing a ballot package.');
+  await screen.findByText('Insert a USB drive containing a ballot package');
 
   // Insert a USB with no ballot package
   apiMock.expectGetUsbDriveStatus('mounted');
@@ -156,7 +155,7 @@ test('app can load and configure from a usb stick', async () => {
 
   // Remove the USB
   apiMock.expectGetUsbDriveStatus('no_drive');
-  await screen.findByText('Insert a USB drive containing a ballot package.');
+  await screen.findByText('Insert a USB drive containing a ballot package');
 
   // Insert a USB with a ballot package
   apiMock.expectGetUsbDriveStatus('mounted');
@@ -376,7 +375,7 @@ test('election manager and poll worker configuration', async () => {
   );
   userEvent.click(await screen.findByText('Yes, Delete All'));
   await screen.findByText('Loading');
-  await screen.findByText('VxScan is Not Configured');
+  await screen.findByText('Insert a USB drive containing a ballot package');
 });
 
 const statusBallotCounted = scannerStatus({

--- a/apps/scan/frontend/src/app_unhappy_paths.test.tsx
+++ b/apps/scan/frontend/src/app_unhappy_paths.test.tsx
@@ -102,7 +102,8 @@ test.each<{
       electionDefinition: undefined,
       precinctSelection: undefined,
     },
-    expectedHeadingWhenNoCard: 'VxScan is Not Configured',
+    expectedHeadingWhenNoCard:
+      'Insert Election Manager card to configure VxScan',
   },
 ])(
   'shows invalid card screen when invalid cards are inserted - $description',

--- a/apps/scan/frontend/src/screens/login_prompt_screen.tsx
+++ b/apps/scan/frontend/src/screens/login_prompt_screen.tsx
@@ -1,4 +1,4 @@
-import { Main, Screen, CenteredLargeProse, H1, P } from '@votingworks/ui';
+import { Main, Screen, CenteredLargeProse, H1 } from '@votingworks/ui';
 
 /**
  * LoginPromptScreen prompts the user to log in when the machine is unconfigured
@@ -9,8 +9,7 @@ export function LoginPromptScreen(): JSX.Element {
     <Screen>
       <Main centerChild>
         <CenteredLargeProse>
-          <H1>VxScan is Not Configured</H1>
-          <P>Insert Election Manager card to load an election definition.</P>
+          <H1>Insert Election Manager card to configure VxScan</H1>
         </CenteredLargeProse>
       </Main>
     </Screen>

--- a/libs/ui/src/unconfigured_election_screen.test.tsx
+++ b/libs/ui/src/unconfigured_election_screen.test.tsx
@@ -13,8 +13,7 @@ test('UnconfiguredElectionScreen shows an error message when no USB drive is ins
     />
   );
 
-  await screen.findByText('VxScan is Not Configured');
-  await screen.findByText('Insert a USB drive containing a ballot package.');
+  await screen.findByText('Insert a USB drive containing a ballot package');
 });
 
 test('UnconfiguredElectionScreen shows a loading screen when USB drive is mounted and no error message exists', async () => {

--- a/libs/ui/src/unconfigured_election_screen.tsx
+++ b/libs/ui/src/unconfigured_election_screen.tsx
@@ -18,41 +18,58 @@ export function UnconfiguredElectionScreen({
   backendConfigError,
   machineName,
 }: UnconfiguredElectionScreenProps): JSX.Element {
-  const errorMessage = (() => {
+  const [errorMessageBig, errorMessageSmall] = (() => {
     if (!isElectionManagerAuth) {
-      return `Only election managers can configure ${machineName}.`;
+      return [
+        'Use the Election Manager card instead',
+        `Only election managers can configure ${machineName}.`,
+      ];
     }
 
     if (usbDriveStatus.status !== 'mounted') {
-      return 'Insert a USB drive containing a ballot package.';
+      return ['Insert a USB drive containing a ballot package', ''];
     }
 
     if (!backendConfigError) {
-      return undefined;
+      return [undefined, undefined];
     }
+
+    const bigMessage = `${machineName} is Not Configured`;
 
     switch (backendConfigError) {
       case 'no_ballot_package_on_usb_drive':
-        return 'No ballot package found on the inserted USB drive.';
+        return [
+          bigMessage,
+          'No ballot package found on the inserted USB drive.',
+        ];
       // The frontend should prevent auth_required_before_ballot_package_load
       // but we enforce it for redundancy
       case 'auth_required_before_ballot_package_load':
-        return 'Please insert an election manager card before configuring.';
+        return [
+          bigMessage,
+          'Please insert an election manager card before configuring.',
+        ];
       case 'ballot_package_authentication_error':
-        return 'Error authenticating ballot package. Try exporting it from VxAdmin again.';
+        return [
+          bigMessage,
+          'Error authenticating ballot package. Try exporting it from VxAdmin again.',
+        ];
       case 'election_hash_mismatch':
-        return 'The most recent ballot package found is for a different election.';
+        return [
+          bigMessage,
+          'The most recent ballot package found is for a different election.',
+        ];
       /* istanbul ignore next - compile time check for completeness */
       default:
         throwIllegalValue(backendConfigError);
     }
   })();
 
-  if (errorMessage) {
+  if (errorMessageBig) {
     return (
       <CenteredLargeProse>
-        <H1>{machineName} is Not Configured</H1>
-        <P>{errorMessage}</P>
+        <H1>{errorMessageBig}</H1>
+        <P>{errorMessageSmall}</P>
       </CenteredLargeProse>
     );
   }


### PR DESCRIPTION
## Overview

When VxScan is unconfigured, only the small-font message tells the operator what to do. It's confusing, especially when the big message doesn't change after inserting the election manager card, only the small message does. 

This PR updates the language of an unconfigured machine to make the action clearer.

## Demo Video or Screenshot

Before:

<img width="1516" alt="Screenshot 2023-11-27 at 1 06 06 PM" src="https://github.com/votingworks/vxsuite/assets/18057/d7126cbe-d0d2-443e-a784-27fcde8c92f9">
<img width="1572" alt="Screenshot 2023-11-27 at 1 06 50 PM" src="https://github.com/votingworks/vxsuite/assets/18057/221390b9-c324-4ee5-b9cb-8f1366a19511">

After:

<img width="2346" alt="Screenshot 2023-11-27 at 1 08 37 PM" src="https://github.com/votingworks/vxsuite/assets/18057/b257d9fe-1b5b-4efb-bad2-de4e2a5318a7">
<img width="2327" alt="Screenshot 2023-11-27 at 1 08 52 PM" src="https://github.com/votingworks/vxsuite/assets/18057/3ae17d22-7623-4df8-ac8c-ca3ed2ce7098">

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
