### PR TITLE
feat(ui): add selector to `useQueryChangeListener`

### DIFF
--- a/apps/central-scan/frontend/src/screens/unconfigured_election_screen_wrapper.tsx
+++ b/apps/central-scan/frontend/src/screens/unconfigured_election_screen_wrapper.tsx
@@ -23,11 +23,15 @@ export function UnconfiguredElectionScreenWrapper({
 
   const configureMutation = configureFromBallotPackageOnUsbDrive.useMutation();
 
-  useQueryChangeListener(usbDriveStatusQuery, (newUsbDriveStatus) => {
-    if (newUsbDriveStatus.status === 'mounted') {
-      configureMutation.mutate();
+  useQueryChangeListener(
+    usbDriveStatusQuery,
+    ({ status }) => status,
+    (newUsbDriveStatus) => {
+      if (newUsbDriveStatus === 'mounted') {
+        configureMutation.mutate();
+      }
     }
-  });
+  );
 
   const error = configureMutation.data?.err();
 

--- a/apps/central-scan/frontend/src/screens/unconfigured_election_screen_wrapper.tsx
+++ b/apps/central-scan/frontend/src/screens/unconfigured_election_screen_wrapper.tsx
@@ -23,15 +23,13 @@ export function UnconfiguredElectionScreenWrapper({
 
   const configureMutation = configureFromBallotPackageOnUsbDrive.useMutation();
 
-  useQueryChangeListener(
-    usbDriveStatusQuery,
-    ({ status }) => status,
-    (newUsbDriveStatus) => {
-      if (newUsbDriveStatus === 'mounted') {
+  useQueryChangeListener(usbDriveStatusQuery, {
+    onChange: (newUsbDriveStatus) => {
+      if (newUsbDriveStatus.status === 'mounted') {
         configureMutation.mutate();
       }
-    }
-  );
+    },
+  });
 
   const error = configureMutation.data?.err();
 

--- a/apps/mark-scan/frontend/src/pages/unconfigured_election_screen_wrapper.tsx
+++ b/apps/mark-scan/frontend/src/pages/unconfigured_election_screen_wrapper.tsx
@@ -19,15 +19,13 @@ export function UnconfiguredElectionScreenWrapper(): JSX.Element {
 
   const configure = configureBallotPackageFromUsb.useMutation();
 
-  useQueryChangeListener(
-    usbDriveStatusQuery,
-    ({ status }) => status,
-    (newUsbDriveStatus) => {
-      if (newUsbDriveStatus === 'mounted') {
+  useQueryChangeListener(usbDriveStatusQuery, {
+    onChange: (newUsbDriveStatus) => {
+      if (newUsbDriveStatus.status === 'mounted') {
         configure.mutate();
       }
-    }
-  );
+    },
+  });
 
   const backendError = configure.data?.err();
   return (

--- a/apps/mark-scan/frontend/src/pages/unconfigured_election_screen_wrapper.tsx
+++ b/apps/mark-scan/frontend/src/pages/unconfigured_election_screen_wrapper.tsx
@@ -19,11 +19,15 @@ export function UnconfiguredElectionScreenWrapper(): JSX.Element {
 
   const configure = configureBallotPackageFromUsb.useMutation();
 
-  useQueryChangeListener(usbDriveStatusQuery, (newUsbDriveStatus) => {
-    if (newUsbDriveStatus.status === 'mounted') {
-      configure.mutate();
+  useQueryChangeListener(
+    usbDriveStatusQuery,
+    ({ status }) => status,
+    (newUsbDriveStatus) => {
+      if (newUsbDriveStatus === 'mounted') {
+        configure.mutate();
+      }
     }
-  });
+  );
 
   const backendError = configure.data?.err();
   return (

--- a/apps/mark/frontend/src/pages/unconfigured_election_screen_wrapper.tsx
+++ b/apps/mark/frontend/src/pages/unconfigured_election_screen_wrapper.tsx
@@ -18,15 +18,13 @@ export function UnconfiguredElectionScreenWrapper(): JSX.Element {
   assert(usbDriveStatusQuery.isSuccess);
   const configure = configureBallotPackageFromUsb.useMutation();
 
-  useQueryChangeListener(
-    usbDriveStatusQuery,
-    ({ status }) => status,
-    (newUsbDriveStatus) => {
-      if (newUsbDriveStatus === 'mounted') {
+  useQueryChangeListener(usbDriveStatusQuery, {
+    onChange: (newUsbDriveStatus) => {
+      if (newUsbDriveStatus.status === 'mounted') {
         configure.mutate();
       }
-    }
-  );
+    },
+  });
 
   const backendError = configure.data?.err();
   return (

--- a/apps/mark/frontend/src/pages/unconfigured_election_screen_wrapper.tsx
+++ b/apps/mark/frontend/src/pages/unconfigured_election_screen_wrapper.tsx
@@ -18,11 +18,15 @@ export function UnconfiguredElectionScreenWrapper(): JSX.Element {
   assert(usbDriveStatusQuery.isSuccess);
   const configure = configureBallotPackageFromUsb.useMutation();
 
-  useQueryChangeListener(usbDriveStatusQuery, (newUsbDriveStatus) => {
-    if (newUsbDriveStatus.status === 'mounted') {
-      configure.mutate();
+  useQueryChangeListener(
+    usbDriveStatusQuery,
+    ({ status }) => status,
+    (newUsbDriveStatus) => {
+      if (newUsbDriveStatus === 'mounted') {
+        configure.mutate();
+      }
     }
-  });
+  );
 
   const backendError = configure.data?.err();
   return (

--- a/apps/scan/frontend/src/components/cast_vote_record_sync_modal.tsx
+++ b/apps/scan/frontend/src/components/cast_vote_record_sync_modal.tsx
@@ -42,16 +42,11 @@ export function CastVoteRecordSyncModal(): JSX.Element | null {
 
   const [modalState, setModalState] = useState<ModalState>('closed');
 
-  useQueryChangeListener(
-    usbDriveStatusQuery,
-    ({ doesUsbDriveRequireCastVoteRecordSync }) =>
-      doesUsbDriveRequireCastVoteRecordSync,
-    (doesUsbDriveRequireCastVoteRecordSync) => {
-      if (doesUsbDriveRequireCastVoteRecordSync) {
-        setModalState('prompt');
-      }
+  useQueryChangeListener(usbDriveStatusQuery, (newUsbDriveStatus) => {
+    if (newUsbDriveStatus.doesUsbDriveRequireCastVoteRecordSync) {
+      setModalState('prompt');
     }
-  );
+  });
 
   function syncCastVoteRecords() {
     setModalState('syncing');

--- a/apps/scan/frontend/src/components/cast_vote_record_sync_modal.tsx
+++ b/apps/scan/frontend/src/components/cast_vote_record_sync_modal.tsx
@@ -42,10 +42,12 @@ export function CastVoteRecordSyncModal(): JSX.Element | null {
 
   const [modalState, setModalState] = useState<ModalState>('closed');
 
-  useQueryChangeListener(usbDriveStatusQuery, (newUsbDriveStatus) => {
-    if (newUsbDriveStatus.doesUsbDriveRequireCastVoteRecordSync) {
-      setModalState('prompt');
-    }
+  useQueryChangeListener(usbDriveStatusQuery, {
+    onChange: (newUsbDriveStatus) => {
+      if (newUsbDriveStatus.doesUsbDriveRequireCastVoteRecordSync) {
+        setModalState('prompt');
+      }
+    },
   });
 
   function syncCastVoteRecords() {

--- a/apps/scan/frontend/src/components/cast_vote_record_sync_modal.tsx
+++ b/apps/scan/frontend/src/components/cast_vote_record_sync_modal.tsx
@@ -42,11 +42,16 @@ export function CastVoteRecordSyncModal(): JSX.Element | null {
 
   const [modalState, setModalState] = useState<ModalState>('closed');
 
-  useQueryChangeListener(usbDriveStatusQuery, (newUsbDriveStatus) => {
-    if (newUsbDriveStatus.doesUsbDriveRequireCastVoteRecordSync) {
-      setModalState('prompt');
+  useQueryChangeListener(
+    usbDriveStatusQuery,
+    ({ doesUsbDriveRequireCastVoteRecordSync }) =>
+      doesUsbDriveRequireCastVoteRecordSync,
+    (doesUsbDriveRequireCastVoteRecordSync) => {
+      if (doesUsbDriveRequireCastVoteRecordSync) {
+        setModalState('prompt');
+      }
     }
-  });
+  );
 
   function syncCastVoteRecords() {
     setModalState('syncing');

--- a/apps/scan/frontend/src/components/display_settings_manager.tsx
+++ b/apps/scan/frontend/src/components/display_settings_manager.tsx
@@ -17,40 +17,37 @@ export function DisplaySettingsManager(): JSX.Element | null {
   const [voterSessionTheme, setVoterSessionTheme] =
     React.useState<DefaultTheme | null>(null);
 
-  useQueryChangeListener(authStatusQuery, (newStatus, previousStatus) => {
-    // Reset to default theme when election official logs in:
-    if (
-      previousStatus?.status === 'logged_out' &&
-      newStatus.status !== 'logged_out'
-    ) {
-      setVoterSessionTheme(currentTheme);
-      themeManager.resetThemes();
-    }
+  useQueryChangeListener(
+    authStatusQuery,
+    ({ status }) => status,
+    (newStatus, previousStatus) => {
+      // Reset to default theme when election official logs in:
+      if (previousStatus === 'logged_out') {
+        setVoterSessionTheme(currentTheme);
+        themeManager.resetThemes();
+      }
 
-    // Reset to previous voter settings when election official logs out:
-    if (
-      previousStatus?.status !== 'logged_out' &&
-      newStatus.status === 'logged_out' &&
-      voterSessionTheme
-    ) {
-      themeManager.setColorMode(voterSessionTheme.colorMode);
-      themeManager.setSizeMode(voterSessionTheme.sizeMode);
-      setVoterSessionTheme(null);
+      // Reset to previous voter settings when election official logs out:
+      if (newStatus === 'logged_out' && voterSessionTheme) {
+        themeManager.setColorMode(voterSessionTheme.colorMode);
+        themeManager.setSizeMode(voterSessionTheme.sizeMode);
+        setVoterSessionTheme(null);
+      }
     }
-  });
+  );
 
   // [VVSG 2.0 7.1-A] Reset to default theme when voter is done scanning. We
   // have chosen to interpret that as whenever paper leaves the scanner (either
   // into the ballot box, or retrieved by the user after a ballot rejection).
-  useQueryChangeListener(scannerStatusQuery, (newStatus, previousStatus) => {
-    if (
-      previousStatus &&
-      previousStatus.state !== 'no_paper' &&
-      newStatus.state === 'no_paper'
-    ) {
-      themeManager.resetThemes();
+  useQueryChangeListener(
+    scannerStatusQuery,
+    ({ state }) => state,
+    (newState, previousState) => {
+      if (previousState && newState === 'no_paper') {
+        themeManager.resetThemes();
+      }
     }
-  });
+  );
 
   return null;
 }

--- a/apps/scan/frontend/src/components/display_settings_manager.tsx
+++ b/apps/scan/frontend/src/components/display_settings_manager.tsx
@@ -17,10 +17,9 @@ export function DisplaySettingsManager(): JSX.Element | null {
   const [voterSessionTheme, setVoterSessionTheme] =
     React.useState<DefaultTheme | null>(null);
 
-  useQueryChangeListener(
-    authStatusQuery,
-    ({ status }) => status,
-    (newStatus, previousStatus) => {
+  useQueryChangeListener(authStatusQuery, {
+    select: ({ status }) => status,
+    onChange: (newStatus, previousStatus) => {
       // Reset to default theme when election official logs in:
       if (previousStatus === 'logged_out') {
         setVoterSessionTheme(currentTheme);
@@ -33,21 +32,20 @@ export function DisplaySettingsManager(): JSX.Element | null {
         themeManager.setSizeMode(voterSessionTheme.sizeMode);
         setVoterSessionTheme(null);
       }
-    }
-  );
+    },
+  });
 
   // [VVSG 2.0 7.1-A] Reset to default theme when voter is done scanning. We
   // have chosen to interpret that as whenever paper leaves the scanner (either
   // into the ballot box, or retrieved by the user after a ballot rejection).
-  useQueryChangeListener(
-    scannerStatusQuery,
-    ({ state }) => state,
-    (newState, previousState) => {
+  useQueryChangeListener(scannerStatusQuery, {
+    select: ({ state }) => state,
+    onChange: (newState, previousState) => {
       if (previousState && newState === 'no_paper') {
         themeManager.resetThemes();
       }
-    }
-  );
+    },
+  });
 
   return null;
 }

--- a/apps/scan/frontend/src/screens/unconfigured_election_screen_wrapper.tsx
+++ b/apps/scan/frontend/src/screens/unconfigured_election_screen_wrapper.tsx
@@ -24,11 +24,15 @@ export function UnconfiguredElectionScreenWrapper(
   const usbDriveStatusQuery = getUsbDriveStatus.useQuery();
   const configureMutation = configureFromBallotPackageOnUsbDrive.useMutation();
   // TODO move watching for USB drive to configure to the backend
-  useQueryChangeListener(usbDriveStatusQuery, (newUsbDriveStatus) => {
-    if (newUsbDriveStatus.status === 'mounted') {
-      configureMutation.mutate();
+  useQueryChangeListener(
+    usbDriveStatusQuery,
+    ({ status }) => status,
+    (newUsbDriveStatus) => {
+      if (newUsbDriveStatus === 'mounted') {
+        configureMutation.mutate();
+      }
     }
-  });
+  );
   const error = configureMutation.data?.err();
 
   if (!usbDriveStatusQuery.isSuccess) return null;

--- a/apps/scan/frontend/src/screens/unconfigured_election_screen_wrapper.tsx
+++ b/apps/scan/frontend/src/screens/unconfigured_election_screen_wrapper.tsx
@@ -24,15 +24,11 @@ export function UnconfiguredElectionScreenWrapper(
   const usbDriveStatusQuery = getUsbDriveStatus.useQuery();
   const configureMutation = configureFromBallotPackageOnUsbDrive.useMutation();
   // TODO move watching for USB drive to configure to the backend
-  useQueryChangeListener(
-    usbDriveStatusQuery,
-    ({ status }) => status,
-    (newUsbDriveStatus) => {
-      if (newUsbDriveStatus === 'mounted') {
-        configureMutation.mutate();
-      }
+  useQueryChangeListener(usbDriveStatusQuery, (newUsbDriveStatus) => {
+    if (newUsbDriveStatus.status === 'mounted') {
+      configureMutation.mutate();
     }
-  );
+  });
   const error = configureMutation.data?.err();
 
   if (!usbDriveStatusQuery.isSuccess) return null;

--- a/apps/scan/frontend/src/screens/unconfigured_election_screen_wrapper.tsx
+++ b/apps/scan/frontend/src/screens/unconfigured_election_screen_wrapper.tsx
@@ -24,10 +24,12 @@ export function UnconfiguredElectionScreenWrapper(
   const usbDriveStatusQuery = getUsbDriveStatus.useQuery();
   const configureMutation = configureFromBallotPackageOnUsbDrive.useMutation();
   // TODO move watching for USB drive to configure to the backend
-  useQueryChangeListener(usbDriveStatusQuery, (newUsbDriveStatus) => {
-    if (newUsbDriveStatus.status === 'mounted') {
-      configureMutation.mutate();
-    }
+  useQueryChangeListener(usbDriveStatusQuery, {
+    onChange: (newUsbDriveStatus) => {
+      if (newUsbDriveStatus.status === 'mounted') {
+        configureMutation.mutate();
+      }
+    },
   });
   const error = configureMutation.data?.err();
 

--- a/apps/scan/frontend/src/screens/voter_screen.tsx
+++ b/apps/scan/frontend/src/screens/voter_screen.tsx
@@ -38,23 +38,24 @@ export function VoterScreen({
   // we're in voter mode.
   const scanBallotMutation = scanBallot.useMutation();
   const acceptBallotMutation = acceptBallot.useMutation();
-  useQueryChangeListener(scannerStatusQuery, (newScannerStatus) => {
-    if (newScannerStatus.state === 'ready_to_scan') {
-      scanBallotMutation.mutate();
-    }
-    if (newScannerStatus.state === 'ready_to_accept') {
-      acceptBallotMutation.mutate();
-    }
+  useQueryChangeListener(scannerStatusQuery, {
+    onChange: (newScannerStatus) => {
+      if (newScannerStatus.state === 'ready_to_scan') {
+        scanBallotMutation.mutate();
+      }
+      if (newScannerStatus.state === 'ready_to_accept') {
+        acceptBallotMutation.mutate();
+      }
+    },
   });
 
   // Play sounds for scan result events
   const playSuccess = useSound('success');
   const playWarning = useSound('warning');
   const playError = useSound('error');
-  useQueryChangeListener(
-    scannerStatusQuery,
-    ({ state }) => state,
-    (newScannerState) => {
+  useQueryChangeListener(scannerStatusQuery, {
+    select: ({ state }) => state,
+    onChange: (newScannerState) => {
       if (isSoundMuted) return;
       switch (newScannerState) {
         case 'accepted': {
@@ -99,8 +100,8 @@ export function VoterScreen({
           throwIllegalValue(newScannerState);
         }
       }
-    }
-  );
+    },
+  });
 
   if (!scannerStatusQuery.isSuccess) {
     return null;

--- a/apps/scan/frontend/src/screens/voter_screen.tsx
+++ b/apps/scan/frontend/src/screens/voter_screen.tsx
@@ -38,18 +38,14 @@ export function VoterScreen({
   // we're in voter mode.
   const scanBallotMutation = scanBallot.useMutation();
   const acceptBallotMutation = acceptBallot.useMutation();
-  useQueryChangeListener(
-    scannerStatusQuery,
-    ({ state }) => state,
-    (newScannerState) => {
-      if (newScannerState === 'ready_to_scan') {
-        scanBallotMutation.mutate();
-      }
-      if (newScannerState === 'ready_to_accept') {
-        acceptBallotMutation.mutate();
-      }
+  useQueryChangeListener(scannerStatusQuery, (newScannerStatus) => {
+    if (newScannerStatus.state === 'ready_to_scan') {
+      scanBallotMutation.mutate();
     }
-  );
+    if (newScannerStatus.state === 'ready_to_accept') {
+      acceptBallotMutation.mutate();
+    }
+  });
 
   // Play sounds for scan result events
   const playSuccess = useSound('success');

--- a/apps/scan/frontend/src/screens/voter_screen.tsx
+++ b/apps/scan/frontend/src/screens/voter_screen.tsx
@@ -80,6 +80,7 @@ export function VoterScreen({
           break;
         }
 
+        // istanbul ignore next
         case 'connecting':
         case 'disconnected':
         case 'no_paper':
@@ -97,6 +98,7 @@ export function VoterScreen({
           break;
         }
 
+        // istanbul ignore next - compile time check for completeness
         default: {
           throwIllegalValue(newScannerState);
         }

--- a/libs/ui/src/hooks/use_change_listener.test.ts
+++ b/libs/ui/src/hooks/use_change_listener.test.ts
@@ -7,192 +7,198 @@ import {
 import { renderHook } from '../../test/react_testing_library';
 
 describe('useExternalStateChangeListener', () => {
-  test('calls the changeHandler function when the state changes', () => {
-    const changeHandler =
+  test('calls the onChange function when the state changes', () => {
+    const onChange =
       mockFunction<(newState: string, previousState?: string) => void>(
-        'changeHandler'
+        'onChange'
       );
 
-    changeHandler.expectCallWith('state 1', undefined).returns();
+    onChange.expectCallWith('state 1', undefined).returns();
     const { rerender } = renderHook(
-      (state) => useExternalStateChangeListener(state, changeHandler),
+      (state) => useExternalStateChangeListener(state, onChange),
       { initialProps: 'state 1' }
     );
 
-    changeHandler.expectCallWith('state 2', 'state 1').returns();
+    onChange.expectCallWith('state 2', 'state 1').returns();
     rerender('state 2');
 
-    // When state doesn't change, the changeHandler is not called
+    // When state doesn't change, the onChange is not called
     rerender('state 2');
 
-    changeHandler.expectCallWith('state 3', 'state 2').returns();
+    onChange.expectCallWith('state 3', 'state 2').returns();
     rerender('state 3');
 
-    changeHandler.assertComplete();
+    onChange.assertComplete();
   });
 
   test('works with objects using value equality', () => {
-    const changeHandler =
+    const onChange =
       mockFunction<
         (newState: { a: number }, previousState?: { a: number }) => void
-      >('changeHandler');
+      >('onChange');
 
-    changeHandler.expectCallWith({ a: 1 }, undefined).returns();
+    onChange.expectCallWith({ a: 1 }, undefined).returns();
     const { rerender } = renderHook(
-      (state) => useExternalStateChangeListener(state, changeHandler),
+      (state) => useExternalStateChangeListener(state, onChange),
       { initialProps: { a: 1 } }
     );
 
-    changeHandler.expectCallWith({ a: 2 }, { a: 1 }).returns();
+    onChange.expectCallWith({ a: 2 }, { a: 1 }).returns();
     rerender({ a: 2 });
 
-    // When object values don't change, even if object identity changes, the changeHandler is not called
+    // When object values don't change, even if object identity changes, the onChange is not called
     rerender({ a: 2 });
 
-    changeHandler.expectCallWith({ a: 3 }, { a: 2 }).returns();
+    onChange.expectCallWith({ a: 3 }, { a: 2 }).returns();
     rerender({ a: 3 });
 
-    changeHandler.assertComplete();
+    onChange.assertComplete();
   });
 
-  test('works with async changeHandler', () => {
-    const changeHandler =
+  test('works with async onChange', () => {
+    const onChange =
       mockFunction<(newState: string, previousState?: string) => Promise<void>>(
-        'changeHandler'
+        'onChange'
       );
 
-    changeHandler.expectCallWith('state 1', undefined).resolves();
+    onChange.expectCallWith('state 1', undefined).resolves();
     const { rerender } = renderHook(
-      (state) => useExternalStateChangeListener(state, changeHandler),
+      (state) => useExternalStateChangeListener(state, onChange),
       { initialProps: 'state 1' }
     );
 
-    changeHandler.expectCallWith('state 2', 'state 1').resolves();
+    onChange.expectCallWith('state 2', 'state 1').resolves();
     rerender('state 2');
 
-    changeHandler.assertComplete();
+    onChange.assertComplete();
   });
 });
 
 describe('useQueryChangeListener', () => {
-  test('calls the changeHandler function when the query data changes', () => {
-    const changeHandler =
+  test('calls the onChange function when the query data changes', () => {
+    const onChange =
       mockFunction<(newData: string, previousData?: string) => void>(
-        'changeHandler'
+        'onChange'
       );
 
-    changeHandler.expectCallWith('data 1', undefined).returns();
+    onChange.expectCallWith('data 1', undefined).returns();
     const { rerender } = renderHook(
       (data) => {
         const mockQuery = {
           isSuccess: true,
           data,
         } as unknown as UseQueryResult<string>;
-        return useQueryChangeListener(mockQuery, changeHandler);
+        return useQueryChangeListener(mockQuery, { onChange });
       },
       { initialProps: 'data 1' }
     );
 
-    changeHandler.expectCallWith('data 2', 'data 1').returns();
+    onChange.expectCallWith('data 2', 'data 1').returns();
     rerender('data 2');
 
-    // When data doesn't change, the changeHandler is not called
+    // When data doesn't change, the onChange is not called
     rerender('data 2');
 
-    changeHandler.expectCallWith('data 3', 'data 2').returns();
+    onChange.expectCallWith('data 3', 'data 2').returns();
     rerender('data 3');
 
-    changeHandler.assertComplete();
+    onChange.assertComplete();
   });
 
   test('works with objects using value equality', () => {
-    const changeHandler =
+    const onChange =
       mockFunction<
         (newData: { a: number }, previousData?: { a: number }) => void
-      >('changeHandler');
+      >('onChange');
 
-    changeHandler.expectCallWith({ a: 1 }, undefined).returns();
+    onChange.expectCallWith({ a: 1 }, undefined).returns();
     const { rerender } = renderHook(
       (data) => {
         const mockQuery = {
           isSuccess: true,
           data,
         } as unknown as UseQueryResult<{ a: number }>;
-        return useQueryChangeListener(mockQuery, changeHandler);
+        return useQueryChangeListener(mockQuery, { onChange });
       },
       { initialProps: { a: 1 } }
     );
 
-    changeHandler.expectCallWith({ a: 2 }, { a: 1 }).returns();
+    onChange.expectCallWith({ a: 2 }, { a: 1 }).returns();
     rerender({ a: 2 });
 
-    // When object values don't change, even if object identity changes, the changeHandler is not called
+    // When object values don't change, even if object identity changes, the onChange is not called
     rerender({ a: 2 });
 
-    changeHandler.expectCallWith({ a: 3 }, { a: 2 }).returns();
+    onChange.expectCallWith({ a: 3 }, { a: 2 }).returns();
     rerender({ a: 3 });
 
-    changeHandler.assertComplete();
+    onChange.assertComplete();
   });
 
   test('allows selecting a subset of the data', () => {
-    const changeHandler =
+    const onChange =
       mockFunction<(newData: number, previousData?: number) => void>(
-        'changeHandler'
+        'onChange'
       );
 
-    changeHandler.expectCallWith(1, undefined).returns();
+    onChange.expectCallWith(1, undefined).returns();
     const { rerender } = renderHook(
       (data) => {
         const mockQuery = {
           isSuccess: true,
           data,
         } as unknown as UseQueryResult<{ a: number; b: number }>;
-        return useQueryChangeListener(mockQuery, ({ a }) => a, changeHandler);
+        return useQueryChangeListener(mockQuery, {
+          select: ({ a }) => a,
+          onChange,
+        });
       },
       { initialProps: { a: 1, b: 2 } }
     );
 
-    changeHandler.expectCallWith(2, 1).returns();
+    onChange.expectCallWith(2, 1).returns();
     rerender({ a: 2, b: 2 });
 
-    // When selected values don't change, even if object identity changes, the changeHandler is not called
+    // When selected values don't change, even if object identity changes, the onChange is not called
     rerender({ a: 2, b: 2 });
 
-    changeHandler.expectCallWith(3, 2).returns();
+    onChange.expectCallWith(3, 2).returns();
     rerender({ a: 3, b: 2 });
 
-    changeHandler.assertComplete();
+    onChange.assertComplete();
+
+    // When another non-selected value changes, the onChange is not called
+    rerender({ a: 3, b: 3 });
   });
 
-  test('works with async changeHandler', () => {
-    const changeHandler =
+  test('works with async onChange', () => {
+    const onChange =
       mockFunction<(newData: string, previousData?: string) => Promise<void>>(
-        'changeHandler'
+        'onChange'
       );
 
-    changeHandler.expectCallWith('data 1', undefined).resolves();
+    onChange.expectCallWith('data 1', undefined).resolves();
     const { rerender } = renderHook(
       (data) => {
         const mockQuery = {
           isSuccess: true,
           data,
         } as unknown as UseQueryResult<string>;
-        return useQueryChangeListener(mockQuery, changeHandler);
+        return useQueryChangeListener(mockQuery, { onChange });
       },
       { initialProps: 'data 1' }
     );
 
-    changeHandler.expectCallWith('data 2', 'data 1').resolves();
+    onChange.expectCallWith('data 2', 'data 1').resolves();
     rerender('data 2');
 
-    changeHandler.assertComplete();
+    onChange.assertComplete();
   });
 
-  test("doesn't call the changeHandler function when the query is not successful", () => {
-    const changeHandler =
+  test("doesn't call the onChange function when the query is not successful", () => {
+    const onChange =
       mockFunction<(newData: string, previousData?: string) => void>(
-        'changeHandler'
+        'onChange'
       );
 
     const { rerender } = renderHook(
@@ -201,13 +207,13 @@ describe('useQueryChangeListener', () => {
           isSuccess: false,
           data,
         } as unknown as UseQueryResult<string>;
-        return useQueryChangeListener(mockQuery, changeHandler);
+        return useQueryChangeListener(mockQuery, { onChange });
       },
       { initialProps: undefined }
     );
 
     rerender();
 
-    changeHandler.assertComplete();
+    onChange.assertComplete();
   });
 });

--- a/libs/ui/src/hooks/use_change_listener.test.ts
+++ b/libs/ui/src/hooks/use_change_listener.test.ts
@@ -135,6 +135,36 @@ describe('useQueryChangeListener', () => {
     changeHandler.assertComplete();
   });
 
+  test('allows selecting a subset of the data', () => {
+    const changeHandler =
+      mockFunction<(newData: number, previousData?: number) => void>(
+        'changeHandler'
+      );
+
+    changeHandler.expectCallWith(1, undefined).returns();
+    const { rerender } = renderHook(
+      (data) => {
+        const mockQuery = {
+          isSuccess: true,
+          data,
+        } as unknown as UseQueryResult<{ a: number; b: number }>;
+        return useQueryChangeListener(mockQuery, ({ a }) => a, changeHandler);
+      },
+      { initialProps: { a: 1, b: 2 } }
+    );
+
+    changeHandler.expectCallWith(2, 1).returns();
+    rerender({ a: 2, b: 2 });
+
+    // When selected values don't change, even if object identity changes, the changeHandler is not called
+    rerender({ a: 2, b: 2 });
+
+    changeHandler.expectCallWith(3, 2).returns();
+    rerender({ a: 3, b: 2 });
+
+    changeHandler.assertComplete();
+  });
+
   test('works with async changeHandler', () => {
     const changeHandler =
       mockFunction<(newData: string, previousData?: string) => Promise<void>>(


### PR DESCRIPTION
## Overview

Allows selecting a subset of the data and only triggering the change handler when that subset changes.

## Demo Video or Screenshot
n/a

## Testing Plan
New automated test for the hook.
