### PR TITLE
Change medium contrast warning color

### DIFF
--- a/libs/ui/src/themes/make_theme.ts
+++ b/libs/ui/src/themes/make_theme.ts
@@ -243,7 +243,7 @@ export const colorThemes: Record<ColorMode, ColorTheme> = {
     accentSecondary: Color.PRIMARY_GREEN_MEDIUM_CONTRAST,
     accentSuccess: Color.PRIMARY_GREEN_MEDIUM_CONTRAST,
     accentVxPurple: Color.VX_PURPLE_MEDIUM_CONTRAST,
-    accentWarning: Color.DANGER_MEDIUM_CONTRAST,
+    accentWarning: Color.GRAY_DARK,
     foreground: Color.GRAY_DARK,
     foregroundDisabled: Color.GRAY_DARK,
 
@@ -252,7 +252,7 @@ export const colorThemes: Record<ColorMode, ColorTheme> = {
       onBackground: TouchscreenPalette.Gray90,
       primary: TouchscreenPalette.Purple80,
       danger: TouchscreenPalette.Red80,
-      warningAccent: TouchscreenPalette.Orange80,
+      warningAccent: TouchscreenPalette.Gray90,
       successAccent: TouchscreenPalette.Green80,
     }),
   },


### PR DESCRIPTION


## Overview

Due to the 10:1 contrast ratio, it's impossible to find a warning color that actually looks orange/yellow, it just comes out brown. Due to this constraint, we had originally decided to just use the main text color for warning accents. I accidentally changed that somewhere along the way. This PR resets it.

## Demo Video or Screenshot


<img width="960" alt="Screenshot 2023-11-27 at 2 49 55 PM" src="https://github.com/votingworks/vxsuite/assets/530106/e041739a-0aa8-4e51-904d-2db3badba762">

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
