### PR TITLE
Fix various VxScan mode-switching bugs

### DIFF
--- a/apps/central-scan/backend/src/store.test.ts
+++ b/apps/central-scan/backend/src/store.test.ts
@@ -700,10 +700,12 @@ test('resetElectionSession', () => {
   store.setScannerBackedUp();
 
   store.resetElectionSession();
+
   // resetElectionSession should reset election session state
   expect(store.getPollsState()).toEqual('polls_closed_initial');
   expect(store.getBallotCountWhenBallotBagLastReplaced()).toEqual(0);
   expect(store.getScannerBackupTimestamp()).toBeFalsy();
+
   // resetElectionSession should clear all batches
   expect(store.getBatches()).toEqual([]);
 

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -672,13 +672,15 @@ export class Store {
       this.client.transaction(() => {
         this.setPollsState('polls_closed_initial');
         this.setBallotCountWhenBallotBagLastReplaced(0);
+
+        // Delete batches, which will cascade delete sheets
+        this.client.run('delete from batches');
+        // Reset auto-incrementing key on "batches" table
+        this.client.run("delete from sqlite_sequence where name = 'batches'");
+
         this.setScannerBackedUp(false);
       });
     }
-    // delete batches, which will cascade delete sheets
-    this.client.run('delete from batches');
-    // reset autoincrementing key on "batches" table
-    this.client.run("delete from sqlite_sequence where name = 'batches'");
   }
 
   getBallotImagePath(sheetId: string, side: Side): Optional<string> {

--- a/apps/scan/backend/src/store.test.ts
+++ b/apps/scan/backend/src/store.test.ts
@@ -625,6 +625,7 @@ test('resetElectionSession', () => {
 
   store.transitionPolls({ type: 'open_polls', time: Date.now() });
   store.setBallotCountWhenBallotBagLastReplaced(1500);
+  store.setExportDirectoryName('export-directory-name');
 
   store.addBatch();
   store.addBatch();
@@ -636,9 +637,12 @@ test('resetElectionSession', () => {
   ).toEqual(['Batch 1', 'Batch 2']);
 
   store.resetElectionSession();
+
   // resetElectionSession should reset election session state
   expect(store.getPollsState()).toEqual('polls_closed_initial');
   expect(store.getBallotCountWhenBallotBagLastReplaced()).toEqual(0);
+  expect(store.getExportDirectoryName()).toEqual(undefined);
+
   // resetElectionSession should clear all batches
   expect(store.getBatches()).toEqual([]);
 
@@ -730,8 +734,10 @@ test('isContinuousExportOperationInProgress and setIsContinuousExportOperationIn
   const store = Store.memoryStore();
 
   expect(store.isContinuousExportOperationInProgress()).toEqual(false);
+
   store.setIsContinuousExportOperationInProgress(true);
   expect(store.isContinuousExportOperationInProgress()).toEqual(true);
+
   store.setIsContinuousExportOperationInProgress(false);
   expect(store.isContinuousExportOperationInProgress()).toEqual(false);
 });
@@ -743,10 +749,15 @@ test('getExportDirectoryName and setExportDirectoryName', () => {
   const exportDirectoryName2 = 'TEST__machine_SCAN-0001__2023-08-16_23-10-01';
 
   expect(store.getExportDirectoryName()).toEqual(undefined);
+
   store.setExportDirectoryName(exportDirectoryName1);
   expect(store.getExportDirectoryName()).toEqual(exportDirectoryName1);
+
   store.setExportDirectoryName(exportDirectoryName2);
   expect(store.getExportDirectoryName()).toEqual(exportDirectoryName2);
+
+  store.setExportDirectoryName(undefined);
+  expect(store.getExportDirectoryName()).toEqual(undefined);
 });
 
 test('getCastVoteRecordRootHash, updateCastVoteRecordHashes, and clearCastVoteRecordHashes', () => {

--- a/apps/scan/backend/src/store.test.ts
+++ b/apps/scan/backend/src/store.test.ts
@@ -626,6 +626,11 @@ test('resetElectionSession', () => {
   store.transitionPolls({ type: 'open_polls', time: Date.now() });
   store.setBallotCountWhenBallotBagLastReplaced(1500);
   store.setExportDirectoryName('export-directory-name');
+  store.updateCastVoteRecordHashes(
+    '00000000-0000-0000-0000-000000000000',
+    sha256('')
+  );
+  store.setIsContinuousExportOperationInProgress(true);
 
   store.addBatch();
   store.addBatch();
@@ -641,7 +646,11 @@ test('resetElectionSession', () => {
   // resetElectionSession should reset election session state
   expect(store.getPollsState()).toEqual('polls_closed_initial');
   expect(store.getBallotCountWhenBallotBagLastReplaced()).toEqual(0);
+
+  // resetElectionSession should reset all export-related metadata
   expect(store.getExportDirectoryName()).toEqual(undefined);
+  expect(store.getCastVoteRecordRootHash()).toEqual('');
+  expect(store.isContinuousExportOperationInProgress()).toEqual(false);
 
   // resetElectionSession should clear all batches
   expect(store.getBatches()).toEqual([]);

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -657,6 +657,7 @@ export class Store {
       this.client.transaction(() => {
         this.resetPollsState();
         this.setBallotCountWhenBallotBagLastReplaced(0);
+        this.setExportDirectoryName(undefined);
       });
     }
     // delete batches, which will cascade delete sheets
@@ -941,16 +942,18 @@ export class Store {
   /**
    * Stores the name of the directory that we'll be continuously exporting to
    */
-  setExportDirectoryName(exportDirectoryName: string): void {
+  setExportDirectoryName(exportDirectoryName?: string): void {
     this.client.run('delete from export_directory_name');
-    this.client.run(
-      `
+    if (exportDirectoryName !== undefined) {
+      this.client.run(
+        `
       insert into export_directory_name (
         export_directory_name
       ) values (?)
       `,
-      exportDirectoryName
-    );
+        exportDirectoryName
+      );
+    }
   }
 
   getCastVoteRecordRootHash(): string {

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -38,6 +38,7 @@ import {
   RejectedSheet,
   Sheet,
   UiStringsStore,
+  clearDoesUsbDriveRequireCastVoteRecordSyncCachedResult,
   createUiStringStore,
 } from '@votingworks/backend';
 import {
@@ -657,9 +658,15 @@ export class Store {
       this.client.transaction(() => {
         this.resetPollsState();
         this.setBallotCountWhenBallotBagLastReplaced(0);
+
+        // Reset all export-related metadata
         this.setExportDirectoryName(undefined);
+        this.clearCastVoteRecordHashes();
+        this.setIsContinuousExportOperationInProgress(false);
+        clearDoesUsbDriveRequireCastVoteRecordSyncCachedResult();
       });
     }
+
     // delete batches, which will cascade delete sheets
     this.client.run('delete from batches');
     // reset autoincrementing key on "batches" table

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -659,6 +659,11 @@ export class Store {
         this.resetPollsState();
         this.setBallotCountWhenBallotBagLastReplaced(0);
 
+        // Delete batches, which will cascade delete sheets
+        this.client.run('delete from batches');
+        // Reset auto-incrementing key on "batches" table
+        this.client.run("delete from sqlite_sequence where name = 'batches'");
+
         // Reset all export-related metadata
         this.setExportDirectoryName(undefined);
         this.clearCastVoteRecordHashes();
@@ -666,11 +671,6 @@ export class Store {
         clearDoesUsbDriveRequireCastVoteRecordSyncCachedResult();
       });
     }
-
-    // delete batches, which will cascade delete sheets
-    this.client.run('delete from batches');
-    // reset autoincrementing key on "batches" table
-    this.client.run("delete from sqlite_sequence where name = 'batches'");
   }
 
   getNextAdjudicationSheet(): BallotSheetInfo | undefined {

--- a/apps/scan/frontend/src/api.ts
+++ b/apps/scan/frontend/src/api.ts
@@ -196,7 +196,7 @@ export const setPrecinctSelection = {
     return useMutation(apiClient.setPrecinctSelection, {
       async onSuccess() {
         await queryClient.invalidateQueries(getConfig.queryKey());
-        // changing the precinct selection after polls open will reset polls to closed
+        // Changing the precinct selection after polls open resets polls to closed
         await queryClient.invalidateQueries(getPollsInfo.queryKey());
       },
     });
@@ -234,6 +234,8 @@ export const setTestMode = {
     return useMutation(apiClient.setTestMode, {
       async onSuccess() {
         await queryClient.invalidateQueries(getConfig.queryKey());
+        // Changing the mode after polls open resets polls to closed
+        await queryClient.invalidateQueries(getPollsInfo.queryKey());
       },
     });
   },

--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -239,6 +239,7 @@ test('election manager and poll worker configuration', async () => {
   apiMock.expectSetTestMode(false);
   config = { ...config, isTestMode: false };
   apiMock.expectGetConfig(config);
+  apiMock.expectGetPollsInfo('polls_closed_initial');
 
   await hackActuallyCleanUpReactModal();
 
@@ -1058,7 +1059,23 @@ test('requires CVR sync if necessary', async () => {
   await waitFor(() =>
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
   );
-  screen.getByText('Insert Your Ballot');
+  await screen.findByText('Insert Your Ballot');
+});
 
-  await waitFor(() => apiMock.mockApiClient.assertComplete());
+test('clears CVR sync required screen if no longer required', async () => {
+  apiMock.expectGetConfig();
+  apiMock.expectGetPollsInfo('polls_open');
+  apiMock.expectGetScannerStatus(statusNoPaper);
+  apiMock.expectGetUsbDriveStatus('mounted', {
+    doesUsbDriveRequireCastVoteRecordSync: true,
+  });
+  renderApp();
+
+  await screen.findByText(
+    'The inserted USB drive does not contain up-to-date records of the votes cast at this scanner. ' +
+      'Cast vote records (CVRs) need to be synced to the USB drive.'
+  );
+
+  apiMock.expectGetUsbDriveStatus('mounted');
+  await screen.findByText('Insert Your Ballot');
 });

--- a/apps/scan/frontend/src/app_root.tsx
+++ b/apps/scan/frontend/src/app_root.tsx
@@ -6,7 +6,6 @@ import {
   UnlockMachineScreen,
   SystemAdministratorScreenContents,
   ExportLogsButtonGroup,
-  useQueryChangeListener,
 } from '@votingworks/ui';
 import {
   Hardware,
@@ -97,16 +96,9 @@ export function AppRoot({
   });
 
   const [
-    isCastVoteRecordSyncRequiredScreenUp,
-    setIsCastVoteRecordSyncRequiredScreenUp,
+    shouldStayOnCastVoteRecordSyncRequiredScreen,
+    setShouldStayOnCastVoteRecordSyncRequiredScreen,
   ] = useState(false);
-  useQueryChangeListener(usbDriveStatusQuery, {
-    onChange: (newUsbDriveStatus) => {
-      if (newUsbDriveStatus.doesUsbDriveRequireCastVoteRecordSync) {
-        setIsCastVoteRecordSyncRequiredScreenUp(true);
-      }
-    },
-  });
 
   if (
     !(
@@ -316,11 +308,17 @@ export function AppRoot({
     );
   }
 
-  if (isCastVoteRecordSyncRequiredScreenUp) {
+  if (
+    usbDrive.doesUsbDriveRequireCastVoteRecordSync ||
+    // This ensures that we don't immediately transition away from the CVR sync success message.
+    // We can't rely on doesUsbDriveRequireCastVoteRecordSync because it becomes false as soon as
+    // the sync completes.
+    shouldStayOnCastVoteRecordSyncRequiredScreen
+  ) {
     return (
       <CastVoteRecordSyncRequiredScreen
-        returnToVoterScreen={() =>
-          setIsCastVoteRecordSyncRequiredScreenUp(false)
+        setShouldStayOnCastVoteRecordSyncRequiredScreen={
+          setShouldStayOnCastVoteRecordSyncRequiredScreen
         }
       />
     );

--- a/apps/scan/frontend/src/screens/cast_vote_record_sync_required_screen.tsx
+++ b/apps/scan/frontend/src/screens/cast_vote_record_sync_required_screen.tsx
@@ -39,11 +39,13 @@ const CAST_VOTE_RECORD_SYNC_REQUIRED_PROMPTS: Record<
 type ModalState = 'closed' | 'syncing' | 'success' | 'error';
 
 interface Props {
-  returnToVoterScreen: () => void;
+  setShouldStayOnCastVoteRecordSyncRequiredScreen: (
+    shouldStayOnCastVoteRecordSyncRequiredScreen: boolean
+  ) => void;
 }
 
 export function CastVoteRecordSyncRequiredScreen({
-  returnToVoterScreen,
+  setShouldStayOnCastVoteRecordSyncRequiredScreen,
 }: Props): JSX.Element {
   const exportCastVoteRecordsToUsbDriveMutation =
     exportCastVoteRecordsToUsbDrive.useMutation();
@@ -51,6 +53,7 @@ export function CastVoteRecordSyncRequiredScreen({
   const [modalState, setModalState] = useState<ModalState>('closed');
 
   function syncCastVoteRecords() {
+    setShouldStayOnCastVoteRecordSyncRequiredScreen(true);
     setModalState('syncing');
     exportCastVoteRecordsToUsbDriveMutation.mutate(
       { mode: 'full_export' },
@@ -68,6 +71,7 @@ export function CastVoteRecordSyncRequiredScreen({
 
   function closeModal() {
     setModalState('closed');
+    setShouldStayOnCastVoteRecordSyncRequiredScreen(false);
   }
 
   const modal = (() => {
@@ -93,8 +97,8 @@ export function CastVoteRecordSyncRequiredScreen({
           <Modal
             title="CVR Sync Complete"
             content={<P>Voters may continue casting ballots.</P>}
-            actions={<Button onPress={returnToVoterScreen}>Close</Button>}
-            onOverlayClick={returnToVoterScreen}
+            actions={<Button onPress={closeModal}>Close</Button>}
+            onOverlayClick={closeModal}
           />
         );
       }

--- a/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
@@ -274,6 +274,7 @@ test('switching mode when no ballots have been counted', async () => {
   // Switch from test mode to official mode
   apiMock.expectSetTestMode(false);
   apiMock.expectGetConfig({ isTestMode: false });
+  apiMock.expectGetPollsInfo();
   userEvent.click(officialBallotModeButton);
   const testBallotModeButton = await screen.findByRole('option', {
     name: 'Test Ballot Mode',
@@ -287,6 +288,7 @@ test('switching mode when no ballots have been counted', async () => {
   // Switch from official mode to test mode
   apiMock.expectSetTestMode(true);
   apiMock.expectGetConfig({ isTestMode: true });
+  apiMock.expectGetPollsInfo();
   userEvent.click(testBallotModeButton);
   await screen.findByRole('option', {
     name: 'Test Ballot Mode',
@@ -316,6 +318,7 @@ test('switching to official mode when ballots have been counted', async () => {
 
   apiMock.expectSetTestMode(false);
   apiMock.expectGetConfig({ isTestMode: false });
+  apiMock.expectGetPollsInfo();
   userEvent.click(officialBallotModeButton);
   await screen.findByRole('option', {
     name: 'Test Ballot Mode',
@@ -370,6 +373,7 @@ test('switching to test mode when ballots have been counted', async () => {
   );
   apiMock.expectSetTestMode(true);
   apiMock.expectGetConfig({ isTestMode: true });
+  apiMock.expectGetPollsInfo();
   userEvent.click(within(modal).getByRole('button', { name: 'Yes, Switch' }));
   await waitFor(() =>
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
@@ -445,6 +449,7 @@ test('machine *can* be switched to test mode if CVR sync is required but no ball
 
   apiMock.expectSetTestMode(true);
   apiMock.expectGetConfig({ isTestMode: true });
+  apiMock.expectGetPollsInfo();
   userEvent.click(testBallotModeButton);
   await screen.findByRole('option', {
     name: 'Test Ballot Mode',


### PR DESCRIPTION
_Easiest reviewed by commit_

## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/4285

This PR fixes various VxScan bugs around mode switching (i.e. switching between test and official mode). The bugs include the following:

1. Switching mode after polls have been opened (and even subsequently closed) is supposed to return the polls to their initial closed state. But VxScan is currently only "half" switching - the backend is updating but the frontend is not.
2. Switching mode does not result in the creation of a new export directory for continuous export, when it should.
3. The only way to currently clear the CVR sync required screen is to click the screen's sync button. But other actions can also render a sync to USB drive unnecessary. One such action is switching from test mode to official mode, since switching mode clears scanned ballots. These other actions should also clear the CVR sync required screen.

This PR fixes all of the above.

## Testing Plan

- [x] Updated automated tests
- [x] Tested manually