### PR TITLE
style: fix some minor lints

### DIFF
--- a/apps/scan/frontend/src/screens/poll_worker_screen.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.tsx
@@ -154,7 +154,6 @@ export function PollWorkerScreen({
   const lastPollsTransition: Optional<PollsTransition> =
     transitionPollsMutation.variables
       ? {
-          // eslint-disable-next-line vx/gts-spread-like-types
           ...transitionPollsMutation.variables,
           ballotCount: scannedBallotCount,
         }

--- a/libs/backend/src/logs/logs_api.ts
+++ b/libs/backend/src/logs/logs_api.ts
@@ -1,10 +1,9 @@
+import { err, ok, Result } from '@votingworks/basics';
 import * as grout from '@votingworks/grout';
 import { UsbDrive } from '@votingworks/usb-drive';
 import * as fs from 'fs/promises';
 import { join } from 'path';
-import { err, ok } from '@votingworks/basics';
 
-import { Result } from '@votingworks/basics';
 import { execFile } from '../exec';
 
 /** type of return value from exporting logs */
@@ -29,7 +28,7 @@ function buildApi({
         const sourceStatus = await fs.stat(LOG_DIR);
         logDirPathExistsAndIsDirectory = sourceStatus.isDirectory();
       } catch (e) {
-        // eslint-disable-line no-empty
+        // ignore
       }
 
       if (!logDirPathExistsAndIsDirectory) {


### PR DESCRIPTION
## Overview
- Combine imports from the same source.
- remove `eslint-disable` directives that weren't doing anything (though the `no-empty` did fix the issue because the block was no longer empty, but then the directive doesn't suppress any lints so eslint warns; just replace it with a comment saying that we're ignoring exceptions)

## Demo Video or Screenshot
n/a

## Testing Plan
Automated tests.
