### PR TITLE
VxAdmin: Breadcrumb nav for nested screens

### DIFF
--- a/apps/admin/frontend/prodserver/setupProxy.js
+++ b/apps/admin/frontend/prodserver/setupProxy.js
@@ -15,7 +15,6 @@ const { dirname, join } = require('path');
  * @param {import('connect').Server} app
  */
 module.exports = function (app) {
-  app.use(proxy('/convert', { target: 'http://localhost:3003/' }));
   app.use(proxy('/admin', { target: 'http://localhost:3004/' }));
   app.use(proxy('/api', { target: 'http://localhost:3004/' }));
   app.use(proxy('/dock', { target: 'http://localhost:3004/' }));

--- a/apps/admin/frontend/src/app.test.tsx
+++ b/apps/admin/frontend/src/app.test.tsx
@@ -272,7 +272,7 @@ test('L&A (logic and accuracy) flow', async () => {
   advanceTimers(30);
 
   // Test printing full test deck tally
-  userEvent.click(screen.getByText('L&A'));
+  userEvent.click(screen.getAllByText('L&A')[0]); // getByRole not working
   const fullTestDeckButton = screen
     .getByText('Print Full Test Deck Tally Report')
     .closest('button')!;

--- a/apps/admin/frontend/src/components/navigation_screen.tsx
+++ b/apps/admin/frontend/src/components/navigation_screen.tsx
@@ -10,6 +10,8 @@ import {
   UsbControllerButton,
   Main,
   H1,
+  Route,
+  Breadcrumbs,
 } from '@votingworks/ui';
 import {
   BooleanEnvironmentVariableName,
@@ -28,7 +30,8 @@ import { canViewAndPrintBallots } from '../utils/can_view_and_print_ballots';
 
 interface Props {
   children: React.ReactNode;
-  title?: React.ReactNode;
+  title?: string;
+  parentRoutes?: Route[];
 }
 
 const SYSTEM_ADMIN_NAV_ITEMS: readonly NavItem[] = [
@@ -108,6 +111,7 @@ export const Header = styled(MainHeader)`
   display: flex;
   align-items: center;
   justify-content: space-between;
+  padding-left: 0.75rem;
 `;
 
 export const HeaderActions = styled.div`
@@ -116,7 +120,11 @@ export const HeaderActions = styled.div`
   align-items: center;
 `;
 
-export function NavigationScreen({ children, title }: Props): JSX.Element {
+export function NavigationScreen({
+  children,
+  title,
+  parentRoutes,
+}: Props): JSX.Element {
   const { electionDefinition, usbDriveStatus, auth } = useContext(AppContext);
   const election = electionDefinition?.election;
   const logOutMutation = logOut.useMutation();
@@ -127,7 +135,19 @@ export function NavigationScreen({ children, title }: Props): JSX.Element {
       <Sidebar navItems={getNavItems(auth, election)} />
       <Main flexColumn>
         <Header>
-          <H1>{title}</H1>
+          <div>
+            {title && (
+              <React.Fragment>
+                {parentRoutes && (
+                  <Breadcrumbs
+                    currentTitle={title}
+                    parentRoutes={parentRoutes}
+                  />
+                )}
+                <H1>{title}</H1>
+              </React.Fragment>
+            )}
+          </div>
           <HeaderActions>
             <SessionTimeLimitTimer authStatus={auth} />
             {(isSystemAdministratorAuth(auth) ||

--- a/apps/admin/frontend/src/components/reporting/shared.tsx
+++ b/apps/admin/frontend/src/components/reporting/shared.tsx
@@ -1,10 +1,9 @@
-import { Card, H3, H5, Icons, Loading, P } from '@votingworks/ui';
+import { Card, H3, H5, Icons, Loading } from '@votingworks/ui';
 import styled from 'styled-components';
 import { routerPaths } from '../../router_paths';
 
 export const ExportActions = styled.div`
-  margin-top: 1rem;
-  margin-bottom: 0.5rem;
+  margin-bottom: 1rem;
   display: flex;
   justify-content: start;
   gap: 0.5rem;
@@ -13,7 +12,6 @@ export const ExportActions = styled.div`
 export const PreviewContainer = styled.div`
   position: relative;
   min-height: 11in;
-  margin-top: 0.5rem;
   padding: 0.5rem;
   background: ${(p) => p.theme.colors.container};
   display: flex;
@@ -83,24 +81,16 @@ export function PreviewLoading(): JSX.Element {
 }
 
 export const WarningContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  margin: 0.5rem 0;
-
-  p {
-    margin-bottom: 0;
-  }
+  margin: 1rem 0;
 `;
 
-export function ReportWarning({ text }: { text: string }): JSX.Element {
+export function ReportWarning({ text }: { text: string }): JSX.Element | null {
+  if (!text) {
+    return null;
+  }
   return (
     <WarningContainer>
-      {text && (
-        <P>
-          <Icons.Warning /> {text}
-        </P>
-      )}
+      <Icons.Warning color="warning" /> {text}
     </WarningContainer>
   );
 }

--- a/apps/admin/frontend/src/components/reporting/shared.tsx
+++ b/apps/admin/frontend/src/components/reporting/shared.tsx
@@ -1,4 +1,4 @@
-import { Card, H3, H5, Icons, LinkButton, Loading, P } from '@votingworks/ui';
+import { Card, H3, H5, Icons, Loading, P } from '@votingworks/ui';
 import styled from 'styled-components';
 import { routerPaths } from '../../router_paths';
 
@@ -82,14 +82,6 @@ export function PreviewLoading(): JSX.Element {
   );
 }
 
-export function ReportBackButton(): JSX.Element {
-  return (
-    <LinkButton icon="Previous" to={routerPaths.reports}>
-      Back
-    </LinkButton>
-  );
-}
-
 export const WarningContainer = styled.div`
   display: flex;
   flex-direction: column;
@@ -112,3 +104,7 @@ export function ReportWarning({ text }: { text: string }): JSX.Element {
     </WarningContainer>
   );
 }
+
+export const reportParentRoutes = [
+  { title: 'Reports', path: routerPaths.reports },
+];

--- a/apps/admin/frontend/src/screens/manual_data_entry_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_entry_screen.test.tsx
@@ -7,7 +7,7 @@ import { buildManualResultsFixture } from '@votingworks/utils';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
 import { screen, within } from '../../test/react_testing_library';
 import { renderInAppContext } from '../../test/render_in_app_context';
-import { ManualDataEntryScreen } from './manual_data_entry_screen';
+import { ManualDataEntryScreen, TITLE } from './manual_data_entry_screen';
 import { ApiMock, createApiMock } from '../../test/helpers/mock_api_client';
 
 let apiMock: ApiMock;
@@ -93,6 +93,16 @@ test('displays correct contests for ballot style', async () => {
       electionDefinition,
       apiMock,
     }
+  );
+
+  screen.getByRole('heading', { name: TITLE });
+  expect(screen.getByRole('link', { name: 'Manual Tallies' })).toHaveAttribute(
+    'href',
+    '/tally/manual-data-summary'
+  );
+  expect(screen.getByRole('link', { name: 'Tally' })).toHaveAttribute(
+    'href',
+    '/tally'
   );
 
   await screen.findByText('Enter the number of votes for each contest option.');

--- a/apps/admin/frontend/src/screens/manual_data_entry_screen.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_entry_screen.tsx
@@ -40,7 +40,11 @@ import {
 import { normalizeWriteInName } from '../utils/write_ins';
 import { Loading } from '../components/loading';
 
-const TITLE = 'Edit Tallies';
+export const TITLE = 'Edit Tallies';
+const PARENT_ROUTES = [
+  { title: 'Tally', path: routerPaths.tally },
+  { title: 'Manual Tallies', path: routerPaths.manualDataSummary },
+];
 
 const TallyInput = styled.input`
   width: 4em;
@@ -507,7 +511,7 @@ export function ManualDataEntryScreen(): JSX.Element {
     !getManualResultsQuery.isSuccess
   ) {
     return (
-      <NavigationScreen title={TITLE}>
+      <NavigationScreen title={TITLE} parentRoutes={PARENT_ROUTES}>
         <Loading isFullscreen />
       </NavigationScreen>
     );
@@ -529,13 +533,7 @@ export function ManualDataEntryScreen(): JSX.Element {
   );
 
   return (
-    <NavigationScreen
-      title={TITLE}
-      parentRoutes={[
-        { title: 'Tally', path: routerPaths.tally },
-        { title: 'Manual Tallies', path: routerPaths.manualDataSummary },
-      ]}
-    >
+    <NavigationScreen title={TITLE} parentRoutes={PARENT_ROUTES}>
       <P>
         <Font weight="bold">Ballot Style:</Font> {ballotStyleId} |{' '}
         <Font weight="bold">Precinct:</Font> {precinct.name} |{' '}

--- a/apps/admin/frontend/src/screens/manual_data_entry_screen.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_entry_screen.tsx
@@ -40,6 +40,8 @@ import {
 import { normalizeWriteInName } from '../utils/write_ins';
 import { Loading } from '../components/loading';
 
+const TITLE = 'Edit Tallies';
+
 const TallyInput = styled.input`
   width: 4em;
   text-align: center;
@@ -505,7 +507,7 @@ export function ManualDataEntryScreen(): JSX.Element {
     !getManualResultsQuery.isSuccess
   ) {
     return (
-      <NavigationScreen title="Manual Tally Form">
+      <NavigationScreen title={TITLE}>
         <Loading isFullscreen />
       </NavigationScreen>
     );
@@ -527,7 +529,13 @@ export function ManualDataEntryScreen(): JSX.Element {
   );
 
   return (
-    <NavigationScreen title="Manual Tally Form">
+    <NavigationScreen
+      title={TITLE}
+      parentRoutes={[
+        { title: 'Tally', path: routerPaths.tally },
+        { title: 'Manual Tallies', path: routerPaths.manualDataSummary },
+      ]}
+    >
       <P>
         <Font weight="bold">Ballot Style:</Font> {ballotStyleId} |{' '}
         <Font weight="bold">Precinct:</Font> {precinct.name} |{' '}

--- a/apps/admin/frontend/src/screens/manual_data_summary_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_summary_screen.test.tsx
@@ -8,6 +8,7 @@ import { screen, within } from '../../test/react_testing_library';
 import {
   ALL_MANUAL_TALLY_BALLOT_TYPES,
   ManualDataSummaryScreen,
+  TITLE,
 } from './manual_data_summary_screen';
 import { renderInAppContext } from '../../test/render_in_app_context';
 import { ApiMock, createApiMock } from '../../test/helpers/mock_api_client';
@@ -27,24 +28,6 @@ afterEach(() => {
 const electionDefinition = electionTwoPartyPrimaryDefinition;
 const { election } = electionDefinition;
 
-test('navigating back to tally page', async () => {
-  const history = createMemoryHistory();
-  apiMock.expectGetManualResultsMetadata([]);
-  renderInAppContext(
-    <Router history={history}>
-      <ManualDataSummaryScreen />
-    </Router>,
-    {
-      route: '/tally/manual-data-summary',
-      electionDefinition,
-      apiMock,
-    }
-  );
-  await screen.findByText('Total Manual Ballot Count: 0');
-  userEvent.click(screen.getButton('Back to Tally'));
-  expect(history.location.pathname).toEqual('/tally');
-});
-
 test('initial table without manual tallies & adding a manual tally', async () => {
   const history = createMemoryHistory();
   apiMock.expectGetManualResultsMetadata([]);
@@ -59,6 +42,13 @@ test('initial table without manual tallies & adding a manual tally', async () =>
     }
   );
   await screen.findByText('Total Manual Ballot Count: 0');
+
+  screen.getByRole('heading', { name: TITLE });
+  expect(screen.getByRole('link', { name: 'Tally' })).toHaveAttribute(
+    'href',
+    '/tally'
+  );
+
   expect(
     screen.queryByRole('button', { name: 'Remove All Manual Tallies' })
   ).not.toBeInTheDocument();

--- a/apps/admin/frontend/src/screens/manual_data_summary_screen.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_summary_screen.tsx
@@ -1,6 +1,5 @@
 import { assert, find } from '@votingworks/basics';
 import React, { useContext, useMemo, useState } from 'react';
-import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 
 import {
@@ -27,6 +26,8 @@ import { NavigationScreen } from '../components/navigation_screen';
 import { RemoveAllManualTalliesModal } from '../components/remove_all_manual_tallies_modal';
 import { deleteManualResults, getManualResultsMetadata } from '../api';
 import { Loading } from '../components/loading';
+
+const TITLE = 'Manual Tallies';
 
 export const ALL_MANUAL_TALLY_BALLOT_TYPES: ManualResultsVotingMethod[] = [
   'precinct',
@@ -127,7 +128,6 @@ export function ManualDataSummaryScreen(): JSX.Element {
   assert(electionDefinition);
   assert(isElectionManagerAuth(auth)); // TODO(auth) check permissions for adding manual tally data
   const { election } = electionDefinition;
-  const history = useHistory();
 
   const getManualTallyMetadataQuery = getManualResultsMetadata.useQuery();
 
@@ -215,7 +215,7 @@ export function ManualDataSummaryScreen(): JSX.Element {
 
   if (!getManualTallyMetadataQuery.isSuccess) {
     return (
-      <NavigationScreen title="Manual Tally Summary">
+      <NavigationScreen title={TITLE}>
         <Loading isFullscreen />
       </NavigationScreen>
     );
@@ -223,32 +223,15 @@ export function ManualDataSummaryScreen(): JSX.Element {
 
   return (
     <React.Fragment>
-      <NavigationScreen title="Manual Tally Summary">
+      <NavigationScreen
+        title={TITLE}
+        parentRoutes={[{ title: 'Tally', path: routerPaths.tally }]}
+      >
         <P>
-          <Button onPress={() => history.push(routerPaths.tally)}>
-            Back to Tally
-          </Button>
-        </P>
-        <P
-          style={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'end',
-          }}
-        >
           <Font weight="semiBold">
             Total Manual Ballot Count:{' '}
             {totalNumberBallotsEntered.toLocaleString()}
           </Font>
-          {hasManualTally && (
-            <Button
-              icon="Delete"
-              color="danger"
-              onPress={() => setIsClearingAll(true)}
-            >
-              Remove All Manual Tallies
-            </Button>
-          )}
         </P>
         {uncreatedManualTallyMetadata.length > 0 && (
           <AddTalliesCard color="neutral">
@@ -355,10 +338,10 @@ export function ManualDataSummaryScreen(): JSX.Element {
                   <TD as="th" narrow nowrap>
                     Voting Method
                   </TD>
-                  <TD as="th" narrow nowrap />
                   <TD as="th" narrow nowrap>
                     Ballot Count
                   </TD>
+                  <TD as="th" narrow nowrap />
                 </tr>
               </thead>
               <tbody>
@@ -379,6 +362,9 @@ export function ManualDataSummaryScreen(): JSX.Element {
                       <TD>{precinct.name}</TD>
 
                       <TD>{votingMethodTitle}</TD>
+                      <TD nowrap data-testid="numBallots">
+                        {metadata.ballotCount.toLocaleString()}
+                      </TD>
                       <TD nowrap>
                         <LinkButton
                           icon="Edit"
@@ -397,15 +383,29 @@ export function ManualDataSummaryScreen(): JSX.Element {
                           Remove
                         </Button>
                       </TD>
-                      <TD nowrap textAlign="center" data-testid="numBallots">
-                        {metadata.ballotCount.toLocaleString()}
-                      </TD>
                     </tr>
                   );
                 })}
               </tbody>
             </Table>
           </SummaryTableWrapper>
+        )}
+        {hasManualTally && (
+          <P
+            style={{
+              display: 'flex',
+              justifyContent: 'flex-end',
+              marginTop: '1rem',
+            }}
+          >
+            <Button
+              icon="Delete"
+              color="danger"
+              onPress={() => setIsClearingAll(true)}
+            >
+              Remove All Manual Tallies
+            </Button>
+          </P>
         )}
       </NavigationScreen>
       {isClearingAll && (

--- a/apps/admin/frontend/src/screens/manual_data_summary_screen.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_summary_screen.tsx
@@ -27,7 +27,7 @@ import { RemoveAllManualTalliesModal } from '../components/remove_all_manual_tal
 import { deleteManualResults, getManualResultsMetadata } from '../api';
 import { Loading } from '../components/loading';
 
-const TITLE = 'Manual Tallies';
+export const TITLE = 'Manual Tallies';
 
 export const ALL_MANUAL_TALLY_BALLOT_TYPES: ManualResultsVotingMethod[] = [
   'precinct',

--- a/apps/admin/frontend/src/screens/print_test_deck_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/print_test_deck_screen.test.tsx
@@ -16,6 +16,7 @@ import { screen, waitFor } from '../../test/react_testing_library';
 import {
   ONE_SIDED_PAGE_PRINT_TIME_MS,
   PrintTestDeckScreen,
+  TITLE,
 } from './print_test_deck_screen';
 import { renderInAppContext } from '../../test/render_in_app_context';
 import { ApiMock, createApiMock } from '../../test/helpers/mock_api_client';
@@ -55,6 +56,12 @@ test('Saving L&A package for one precinct', () => {
     usbDriveStatus,
     apiMock,
   });
+
+  screen.getByRole('heading', { name: TITLE });
+  expect(screen.getByRole('link', { name: 'L&A' })).toHaveAttribute(
+    'href',
+    '/logic-and-accuracy'
+  );
 
   userEvent.click(screen.getByText('Save Precinct 1 to PDF'));
   screen.getByText('Save Logic & Accuracy Package');

--- a/apps/admin/frontend/src/screens/print_test_deck_screen.tsx
+++ b/apps/admin/frontend/src/screens/print_test_deck_screen.tsx
@@ -40,6 +40,9 @@ import {
   FileType,
 } from '../components/save_frontend_file_modal';
 import { generateDefaultReportFilename } from '../utils/save_as_pdf';
+import { routerPaths } from '../router_paths';
+
+const TITLE = 'Precinct L&A Packages';
 
 export const ONE_SIDED_PAGE_PRINT_TIME_MS = 3000;
 export const TWO_SIDED_PAGE_PRINT_TIME_MS = 5000;
@@ -62,7 +65,6 @@ const ButtonRow = styled.div`
   grid-auto-rows: 1fr;
   grid-gap: max(${(p) => p.theme.sizes.minTouchAreaSeparationPx}px, 0.25rem);
   grid-template-columns: 1fr 1fr;
-  width: 80%;
 `;
 
 async function generateResultsForPrecinctTallyReport({
@@ -230,8 +232,6 @@ export function PrintTestDeckScreen(): JSX.Element {
     election,
     precinctId: precinctToSaveToPdf,
   });
-
-  const pageTitle = 'Precinct L&A Packages';
 
   const generatePrecinctIds = useCallback(
     (precinctId: PrecinctId) => {
@@ -421,7 +421,10 @@ export function PrintTestDeckScreen(): JSX.Element {
       {printIndex && (
         <PrintingModal election={election} printIndex={printIndex} />
       )}
-      <NavigationScreen title={pageTitle}>
+      <NavigationScreen
+        title={TITLE}
+        parentRoutes={[{ title: 'L&A', path: routerPaths.logicAndAccuracy }]}
+      >
         <P>
           Print the L&A Packages for all precincts, or for a specific precinct,
           by selecting a button below.

--- a/apps/admin/frontend/src/screens/print_test_deck_screen.tsx
+++ b/apps/admin/frontend/src/screens/print_test_deck_screen.tsx
@@ -42,7 +42,7 @@ import {
 import { generateDefaultReportFilename } from '../utils/save_as_pdf';
 import { routerPaths } from '../router_paths';
 
-const TITLE = 'Precinct L&A Packages';
+export const TITLE = 'Precinct L&A Packages';
 
 export const ONE_SIDED_PAGE_PRINT_TIME_MS = 3000;
 export const TWO_SIDED_PAGE_PRINT_TIME_MS = 5000;

--- a/apps/admin/frontend/src/screens/reporting/all_precincts_tally_report_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/all_precincts_tally_report_screen.test.tsx
@@ -101,7 +101,12 @@ test('displays report', async () => {
     },
   ];
 
-  screen.getByText(TITLE);
+  screen.getByRole('heading', { name: TITLE });
+  expect(screen.getByRole('link', { name: 'Reports' })).toHaveAttribute(
+    'href',
+    '/reports'
+  );
+
   const reports = await screen.findAllByTestId(/tally-report/);
   expect(reports).toHaveLength(expectedReports.length);
   for (const [i, report] of reports.entries()) {

--- a/apps/admin/frontend/src/screens/reporting/all_precincts_tally_report_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/all_precincts_tally_report_screen.test.tsx
@@ -6,7 +6,7 @@ import { renderInAppContext } from '../../../test/render_in_app_context';
 import { screen, within } from '../../../test/react_testing_library';
 import {
   AllPrecinctsTallyReportScreen,
-  SCREEN_TITLE,
+  TITLE,
 } from './all_precincts_tally_report_screen';
 
 let logger: Logger;
@@ -101,7 +101,7 @@ test('displays report', async () => {
     },
   ];
 
-  screen.getByText(SCREEN_TITLE);
+  screen.getByText(TITLE);
   const reports = await screen.findAllByTestId(/tally-report/);
   expect(reports).toHaveLength(expectedReports.length);
   for (const [i, report] of reports.entries()) {

--- a/apps/admin/frontend/src/screens/reporting/all_precincts_tally_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/all_precincts_tally_report_screen.tsx
@@ -1,13 +1,12 @@
-import { P } from '@votingworks/ui';
 import { useContext } from 'react';
 import { assert } from '@votingworks/basics';
 import { isElectionManagerAuth } from '@votingworks/utils';
 import { AppContext } from '../../contexts/app_context';
 import { NavigationScreen } from '../../components/navigation_screen';
 import { TallyReportViewer } from '../../components/reporting/tally_report_viewer';
-import { ReportBackButton } from '../../components/reporting/shared';
+import { reportParentRoutes } from '../../components/reporting/shared';
 
-export const SCREEN_TITLE = 'All Precincts Tally Report';
+export const TITLE = 'All Precincts Tally Report';
 
 export function AllPrecinctsTallyReportScreen(): JSX.Element {
   const { electionDefinition, auth } = useContext(AppContext);
@@ -15,10 +14,7 @@ export function AllPrecinctsTallyReportScreen(): JSX.Element {
   assert(isElectionManagerAuth(auth));
 
   return (
-    <NavigationScreen title={SCREEN_TITLE}>
-      <P>
-        <ReportBackButton />
-      </P>
+    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes}>
       <TallyReportViewer
         filter={{}}
         groupBy={{ groupByPrecinct: true }}

--- a/apps/admin/frontend/src/screens/reporting/ballot_count_report_builder.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/ballot_count_report_builder.test.tsx
@@ -10,7 +10,7 @@ import { renderInAppContext } from '../../../test/render_in_app_context';
 import { screen, waitFor, within } from '../../../test/react_testing_library';
 import { getMockCardCounts } from '../../../test/helpers/mock_results';
 import { canonicalizeFilter, canonicalizeGroupBy } from '../../utils/reporting';
-import { BallotCountReportBuilder } from './ballot_count_report_builder';
+import { BallotCountReportBuilder, TITLE } from './ballot_count_report_builder';
 
 let apiMock: ApiMock;
 
@@ -58,6 +58,12 @@ test('happy path', async () => {
     electionDefinition,
     apiMock,
   });
+
+  screen.getByRole('heading', { name: TITLE });
+  expect(screen.getByRole('link', { name: 'Reports' })).toHaveAttribute(
+    'href',
+    '/reports'
+  );
 
   expect(screen.queryByText('Load Preview')).not.toBeInTheDocument();
   expect(screen.getButton('Print Report')).toBeDisabled();

--- a/apps/admin/frontend/src/screens/reporting/ballot_count_report_builder.tsx
+++ b/apps/admin/frontend/src/screens/reporting/ballot_count_report_builder.tsx
@@ -25,7 +25,7 @@ import {
   reportParentRoutes,
 } from '../../components/reporting/shared';
 
-const TITLE = 'Ballot Count Report Builder';
+export const TITLE = 'Ballot Count Report Builder';
 
 export function BallotCountReportBuilder(): JSX.Element {
   const { electionDefinition, auth } = useContext(AppContext);

--- a/apps/admin/frontend/src/screens/reporting/ballot_count_report_builder.tsx
+++ b/apps/admin/frontend/src/screens/reporting/ballot_count_report_builder.tsx
@@ -21,11 +21,11 @@ import {
 import { BallotCountReportViewer } from '../../components/reporting/ballot_count_report_viewer';
 import {
   ControlLabel,
-  ReportBackButton,
   ReportBuilderControls,
+  reportParentRoutes,
 } from '../../components/reporting/shared';
 
-const SCREEN_TITLE = 'Ballot Count Report Builder';
+const TITLE = 'Ballot Count Report Builder';
 
 export function BallotCountReportBuilder(): JSX.Element {
   const { electionDefinition, auth } = useContext(AppContext);
@@ -66,10 +66,7 @@ export function BallotCountReportBuilder(): JSX.Element {
 
   const hasMadeSelections = !isFilterEmpty(filter) || !isGroupByEmpty(groupBy);
   return (
-    <NavigationScreen title={SCREEN_TITLE}>
-      <P style={{ marginBottom: '1rem' }}>
-        <ReportBackButton />
-      </P>
+    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes}>
       <ReportBuilderControls>
         <div style={{ marginBottom: '1.5rem' }}>
           <ControlLabel>Filters</ControlLabel>

--- a/apps/admin/frontend/src/screens/reporting/full_election_tally_report_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/full_election_tally_report_screen.test.tsx
@@ -2,7 +2,10 @@ import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 import { Logger, fakeLogger } from '@votingworks/logging';
 import { ApiMock, createApiMock } from '../../../test/helpers/mock_api_client';
 import { getSimpleMockTallyResults } from '../../../test/helpers/mock_results';
-import { FullElectionTallyReportScreen } from './full_election_tally_report_screen';
+import {
+  FullElectionTallyReportScreen,
+  TITLE,
+} from './full_election_tally_report_screen';
 import { renderInAppContext } from '../../../test/render_in_app_context';
 import { routerPaths } from '../../router_paths';
 import { screen } from '../../../test/react_testing_library';
@@ -39,6 +42,12 @@ test('displays report', async () => {
     route: routerPaths.tallyFullReport,
     isOfficialResults: true,
   });
+
+  screen.getByRole('heading', { name: TITLE });
+  expect(screen.getByRole('link', { name: 'Reports' })).toHaveAttribute(
+    'href',
+    '/reports'
+  );
 
   await screen.findByTestId('tally-report');
   screen.getByText('Official Lincoln Municipal General Election Tally Report');

--- a/apps/admin/frontend/src/screens/reporting/full_election_tally_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/full_election_tally_report_screen.tsx
@@ -6,7 +6,7 @@ import { NavigationScreen } from '../../components/navigation_screen';
 import { TallyReportViewer } from '../../components/reporting/tally_report_viewer';
 import { reportParentRoutes } from '../../components/reporting/shared';
 
-const TITLE = 'Full Election Tally Report';
+export const TITLE = 'Full Election Tally Report';
 
 export function FullElectionTallyReportScreen(): JSX.Element {
   const { electionDefinition, auth } = useContext(AppContext);

--- a/apps/admin/frontend/src/screens/reporting/full_election_tally_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/full_election_tally_report_screen.tsx
@@ -1,16 +1,12 @@
 import { useContext } from 'react';
 import { isElectionManagerAuth } from '@votingworks/utils';
 import { assert } from '@votingworks/basics';
-import { P } from '@votingworks/ui';
-
 import { AppContext } from '../../contexts/app_context';
-
 import { NavigationScreen } from '../../components/navigation_screen';
-
 import { TallyReportViewer } from '../../components/reporting/tally_report_viewer';
-import { ReportBackButton } from '../../components/reporting/shared';
+import { reportParentRoutes } from '../../components/reporting/shared';
 
-const SCREEN_TITLE = 'Full Election Tally Report';
+const TITLE = 'Full Election Tally Report';
 
 export function FullElectionTallyReportScreen(): JSX.Element {
   const { electionDefinition, auth } = useContext(AppContext);
@@ -18,10 +14,7 @@ export function FullElectionTallyReportScreen(): JSX.Element {
   assert(isElectionManagerAuth(auth));
 
   return (
-    <NavigationScreen title={SCREEN_TITLE}>
-      <P>
-        <ReportBackButton />
-      </P>
+    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes}>
       <TallyReportViewer
         filter={{}}
         groupBy={{}}

--- a/apps/admin/frontend/src/screens/reporting/precinct_ballot_count_report_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/precinct_ballot_count_report_screen.test.tsx
@@ -9,7 +9,7 @@ import { renderInAppContext } from '../../../test/render_in_app_context';
 import { screen, within } from '../../../test/react_testing_library';
 import {
   PrecinctBallotCountReport,
-  SCREEN_TITLE,
+  TITLE,
 } from './precinct_ballot_count_report_screen';
 
 let logger: Logger;
@@ -65,7 +65,7 @@ test('displays report (primary)', async () => {
     isOfficialResults: false,
   });
 
-  screen.getByText(SCREEN_TITLE);
+  screen.getByText(TITLE);
 
   const report = await screen.findByTestId('ballot-count-report');
   within(report).getByText('Unofficial Full Election Ballot Count Report');
@@ -120,7 +120,7 @@ test('displays report (general)', async () => {
     isOfficialResults: false,
   });
 
-  screen.getByText(SCREEN_TITLE);
+  screen.getByText(TITLE);
 
   const report = await screen.findByTestId('ballot-count-report');
   within(report).getByText('Unofficial Full Election Ballot Count Report');

--- a/apps/admin/frontend/src/screens/reporting/precinct_ballot_count_report_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/precinct_ballot_count_report_screen.test.tsx
@@ -65,7 +65,11 @@ test('displays report (primary)', async () => {
     isOfficialResults: false,
   });
 
-  screen.getByText(TITLE);
+  screen.getByRole('heading', { name: TITLE });
+  expect(screen.getByRole('link', { name: 'Reports' })).toHaveAttribute(
+    'href',
+    '/reports'
+  );
 
   const report = await screen.findByTestId('ballot-count-report');
   within(report).getByText('Unofficial Full Election Ballot Count Report');
@@ -120,7 +124,7 @@ test('displays report (general)', async () => {
     isOfficialResults: false,
   });
 
-  screen.getByText(TITLE);
+  screen.getByRole('heading', { name: TITLE });
 
   const report = await screen.findByTestId('ballot-count-report');
   within(report).getByText('Unofficial Full Election Ballot Count Report');

--- a/apps/admin/frontend/src/screens/reporting/precinct_ballot_count_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/precinct_ballot_count_report_screen.tsx
@@ -1,13 +1,12 @@
-import { P } from '@votingworks/ui';
 import { useContext } from 'react';
 import { assert } from '@votingworks/basics';
 import { isElectionManagerAuth } from '@votingworks/utils';
 import { AppContext } from '../../contexts/app_context';
 import { NavigationScreen } from '../../components/navigation_screen';
 import { BallotCountReportViewer } from '../../components/reporting/ballot_count_report_viewer';
-import { ReportBackButton } from '../../components/reporting/shared';
+import { reportParentRoutes } from '../../components/reporting/shared';
 
-export const SCREEN_TITLE = 'Precinct Ballot Count Report';
+export const TITLE = 'Precinct Ballot Count Report';
 
 export function PrecinctBallotCountReport(): JSX.Element {
   const { electionDefinition, auth } = useContext(AppContext);
@@ -15,10 +14,7 @@ export function PrecinctBallotCountReport(): JSX.Element {
   assert(isElectionManagerAuth(auth));
 
   return (
-    <NavigationScreen title={SCREEN_TITLE}>
-      <P>
-        <ReportBackButton />
-      </P>
+    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes}>
       <BallotCountReportViewer
         filter={{}}
         groupBy={{

--- a/apps/admin/frontend/src/screens/reporting/single_precinct_tally_report_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/single_precinct_tally_report_screen.test.tsx
@@ -6,7 +6,7 @@ import { getSimpleMockTallyResults } from '../../../test/helpers/mock_results';
 import { renderInAppContext } from '../../../test/render_in_app_context';
 import { screen, within } from '../../../test/react_testing_library';
 import {
-  SCREEN_TITLE,
+  TITLE,
   SinglePrecinctTallyReportScreen,
 } from './single_precinct_tally_report_screen';
 
@@ -35,7 +35,7 @@ test('select precinct and view report', async () => {
     isOfficialResults: false,
   });
 
-  screen.getByText(SCREEN_TITLE);
+  screen.getByText(TITLE);
 
   // display precinct 1 report
   apiMock.expectGetResultsForTallyReports(

--- a/apps/admin/frontend/src/screens/reporting/single_precinct_tally_report_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/single_precinct_tally_report_screen.test.tsx
@@ -35,7 +35,11 @@ test('select precinct and view report', async () => {
     isOfficialResults: false,
   });
 
-  screen.getByText(TITLE);
+  screen.getByRole('heading', { name: TITLE });
+  expect(screen.getByRole('link', { name: 'Reports' })).toHaveAttribute(
+    'href',
+    '/reports'
+  );
 
   // display precinct 1 report
   apiMock.expectGetResultsForTallyReports(

--- a/apps/admin/frontend/src/screens/reporting/single_precinct_tally_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/single_precinct_tally_report_screen.tsx
@@ -6,15 +6,16 @@ import styled from 'styled-components';
 import { AppContext } from '../../contexts/app_context';
 import { NavigationScreen } from '../../components/navigation_screen';
 import { TallyReportViewer } from '../../components/reporting/tally_report_viewer';
-import { ReportBackButton } from '../../components/reporting/shared';
+import { reportParentRoutes } from '../../components/reporting/shared';
 
-export const SCREEN_TITLE = 'Single Precinct Tally Report';
+export const TITLE = 'Single Precinct Tally Report';
 
 const SelectPrecinctContainer = styled.div`
   display: grid;
   grid-template-columns: min-content 30%;
   gap: 1rem;
   align-items: center;
+  margin-bottom: 1rem;
 
   p {
     white-space: nowrap;
@@ -31,10 +32,7 @@ export function SinglePrecinctTallyReportScreen(): JSX.Element {
   const [precinctId, setPrecinctId] = useState<string>();
 
   return (
-    <NavigationScreen title={SCREEN_TITLE}>
-      <P>
-        <ReportBackButton />
-      </P>
+    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes}>
       <SelectPrecinctContainer>
         <P>Select Precinct:</P>
         <SearchSelect

--- a/apps/admin/frontend/src/screens/reporting/tally_report_builder.tsx
+++ b/apps/admin/frontend/src/screens/reporting/tally_report_builder.tsx
@@ -14,12 +14,12 @@ import { GroupByEditor } from '../../components/reporting/group_by_editor';
 import { TallyReportViewer } from '../../components/reporting/tally_report_viewer';
 import { canonicalizeFilter, canonicalizeGroupBy } from '../../utils/reporting';
 import {
-  ReportBackButton,
   ReportBuilderControls,
   ControlLabel,
+  reportParentRoutes,
 } from '../../components/reporting/shared';
 
-const SCREEN_TITLE = 'Tally Report Builder';
+const TITLE = 'Tally Report Builder';
 
 export function TallyReportBuilder(): JSX.Element {
   const { electionDefinition, auth } = useContext(AppContext);
@@ -40,10 +40,7 @@ export function TallyReportBuilder(): JSX.Element {
 
   const hasMadeSelections = !isFilterEmpty(filter) || !isGroupByEmpty(groupBy);
   return (
-    <NavigationScreen title={SCREEN_TITLE}>
-      <P style={{ marginBottom: '1rem' }}>
-        <ReportBackButton />
-      </P>
+    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes}>
       <ReportBuilderControls>
         <div style={{ marginBottom: '1.5rem' }}>
           <ControlLabel>Filters</ControlLabel>

--- a/apps/admin/frontend/src/screens/reporting/voting_method_ballot_count_report_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/voting_method_ballot_count_report_screen.test.tsx
@@ -65,7 +65,11 @@ test('displays report (primary)', async () => {
     isOfficialResults: false,
   });
 
-  screen.getByText(TITLE);
+  screen.getByRole('heading', { name: TITLE });
+  expect(screen.getByRole('link', { name: 'Reports' })).toHaveAttribute(
+    'href',
+    '/reports'
+  );
 
   const report = await screen.findByTestId('ballot-count-report');
   within(report).getByText('Unofficial Full Election Ballot Count Report');
@@ -112,7 +116,7 @@ test('displays report (general)', async () => {
     isOfficialResults: false,
   });
 
-  screen.getByText(TITLE);
+  screen.getByRole('heading', { name: TITLE });
 
   const report = await screen.findByTestId('ballot-count-report');
   within(report).getByText('Unofficial Full Election Ballot Count Report');

--- a/apps/admin/frontend/src/screens/reporting/voting_method_ballot_count_report_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/voting_method_ballot_count_report_screen.test.tsx
@@ -8,7 +8,7 @@ import { getMockCardCounts } from '../../../test/helpers/mock_results';
 import { renderInAppContext } from '../../../test/render_in_app_context';
 import { screen, within } from '../../../test/react_testing_library';
 import {
-  SCREEN_TITLE,
+  TITLE,
   VotingMethodBallotCountReport,
 } from './voting_method_ballot_count_report_screen';
 
@@ -65,7 +65,7 @@ test('displays report (primary)', async () => {
     isOfficialResults: false,
   });
 
-  screen.getByText(SCREEN_TITLE);
+  screen.getByText(TITLE);
 
   const report = await screen.findByTestId('ballot-count-report');
   within(report).getByText('Unofficial Full Election Ballot Count Report');
@@ -112,7 +112,7 @@ test('displays report (general)', async () => {
     isOfficialResults: false,
   });
 
-  screen.getByText(SCREEN_TITLE);
+  screen.getByText(TITLE);
 
   const report = await screen.findByTestId('ballot-count-report');
   within(report).getByText('Unofficial Full Election Ballot Count Report');

--- a/apps/admin/frontend/src/screens/reporting/voting_method_ballot_count_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/voting_method_ballot_count_report_screen.tsx
@@ -1,13 +1,12 @@
-import { P } from '@votingworks/ui';
 import { useContext } from 'react';
 import { assert } from '@votingworks/basics';
 import { isElectionManagerAuth } from '@votingworks/utils';
 import { AppContext } from '../../contexts/app_context';
 import { NavigationScreen } from '../../components/navigation_screen';
 import { BallotCountReportViewer } from '../../components/reporting/ballot_count_report_viewer';
-import { ReportBackButton } from '../../components/reporting/shared';
+import { reportParentRoutes } from '../../components/reporting/shared';
 
-export const SCREEN_TITLE = 'Voting Method Ballot Count Report';
+export const TITLE = 'Voting Method Ballot Count Report';
 
 export function VotingMethodBallotCountReport(): JSX.Element {
   const { electionDefinition, auth } = useContext(AppContext);
@@ -15,10 +14,7 @@ export function VotingMethodBallotCountReport(): JSX.Element {
   assert(isElectionManagerAuth(auth));
 
   return (
-    <NavigationScreen title={SCREEN_TITLE}>
-      <P>
-        <ReportBackButton />
-      </P>
+    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes}>
       <BallotCountReportViewer
         filter={{}}
         groupBy={{

--- a/apps/admin/frontend/src/screens/reporting/write_in_adjudication_report_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/write_in_adjudication_report_screen.test.tsx
@@ -9,7 +9,10 @@ import { fakeLogger, Logger } from '@votingworks/logging';
 import userEvent from '@testing-library/user-event';
 import { renderInAppContext } from '../../../test/render_in_app_context';
 import { ApiMock, createApiMock } from '../../../test/helpers/mock_api_client';
-import { TallyWriteInReportScreen } from './write_in_adjudication_report_screen';
+import {
+  TITLE,
+  TallyWriteInReportScreen,
+} from './write_in_adjudication_report_screen';
 import {
   screen,
   waitForElementToBeRemoved,
@@ -68,6 +71,12 @@ test('renders provided data', async () => {
     apiMock,
   });
 
+  screen.getByRole('heading', { name: TITLE });
+  expect(screen.getByRole('link', { name: 'Reports' })).toHaveAttribute(
+    'href',
+    '/reports'
+  );
+
   const report = await screen.findByTestId('write-in-tally-report');
   within(report).getByText(
     'Unofficial General Election Write‑In Adjudication Report'
@@ -87,6 +96,5 @@ test('renders provided data', async () => {
   });
   await waitForElementToBeRemoved(screen.getByRole('alertdialog'));
 
-  expect(screen.getButton('Back')).toBeEnabled();
   expect(screen.getButton('Export Report PDF')).toBeEnabled();
 });

--- a/apps/admin/frontend/src/screens/reporting/write_in_adjudication_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/write_in_adjudication_report_screen.tsx
@@ -5,7 +5,6 @@ import { LogEventId } from '@votingworks/logging';
 import {
   printElement,
   printElementToPdf,
-  P,
   WriteInAdjudicationReport,
 } from '@votingworks/ui';
 import { AppContext } from '../../contexts/app_context';
@@ -21,10 +20,12 @@ import {
   PreviewContainer,
   PreviewLoading,
   PreviewReportPages,
-  ReportBackButton,
+  reportParentRoutes,
 } from '../../components/reporting/shared';
 import { ExportReportPdfButton } from '../../components/reporting/export_report_pdf_button';
 import { generateReportFilename } from '../../utils/reporting';
+
+const TITLE = 'Write-In Adjudication Report';
 
 export function TallyWriteInReportScreen(): JSX.Element {
   const { electionDefinition, isOfficialResults, auth, logger } =
@@ -91,10 +92,7 @@ export function TallyWriteInReportScreen(): JSX.Element {
   });
 
   return (
-    <NavigationScreen title="Write-In Adjudication Report">
-      <P>
-        <ReportBackButton />
-      </P>
+    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes}>
       <ExportActions>
         <PrintButton disabled={!report} print={printReport} variant="primary">
           Print Report

--- a/apps/admin/frontend/src/screens/reporting/write_in_adjudication_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/write_in_adjudication_report_screen.tsx
@@ -25,7 +25,7 @@ import {
 import { ExportReportPdfButton } from '../../components/reporting/export_report_pdf_button';
 import { generateReportFilename } from '../../utils/reporting';
 
-const TITLE = 'Write-In Adjudication Report';
+export const TITLE = 'Write-In Adjudication Report';
 
 export function TallyWriteInReportScreen(): JSX.Element {
   const { electionDefinition, isOfficialResults, auth, logger } =

--- a/apps/admin/frontend/src/screens/unconfigured_screen.tsx
+++ b/apps/admin/frontend/src/screens/unconfigured_screen.tsx
@@ -101,7 +101,6 @@ export function UnconfiguredScreen(): JSX.Element {
 
   return (
     <NavigationScreen title="Configure VxAdmin">
-      <P>How would you like to start?</P>
       {configureError && (
         <P>
           <Icons.Danger color="danger" />{' '}

--- a/apps/admin/integration-testing/e2e/reports.spec.ts
+++ b/apps/admin/integration-testing/e2e/reports.spec.ts
@@ -73,21 +73,26 @@ test('viewing and exporting reports', async ({ page }) => {
   await page.getByRole('button', { name: 'Close' }).click();
   await expect(page.getByTestId('total-cvr-count')).toHaveText('112');
 
-  await page.getByText('Reports', { exact: true }).click();
+  await page.getByRole('button', { name: 'Reports' }).click();
   await expect(page.getByText('Unofficial Tally Reports')).toBeVisible();
   await page.getByText('Full Election Tally Report').click();
 
   // Check Preview
   const reportTitles = [
-    'Unofficial Mammal Party Example Primary Election Tally Report',
-    'Unofficial Fish Party Example Primary Election Tally Report',
-    'Unofficial Example Primary Election Nonpartisan Contests Tally Report',
+    ['Unofficial Mammal Party Example Primary Election Tally Report', '56'],
+    ['Unofficial Fish Party Example Primary Election Tally Report', '56'],
+    [
+      'Unofficial Example Primary Election Nonpartisan Contests Tally Report',
+      '112',
+    ],
   ];
-  for (const title of reportTitles) {
-    await expect(page.getByText(title)).toBeVisible();
+  for (const [title, totalBallotCount] of reportTitles) {
+    const section = page.locator('section', { hasText: title });
+    await expect(section).toBeVisible();
+    await expect(section.getByTestId('total-ballot-count')).toHaveText(
+      totalBallotCount
+    );
   }
-  await expect(page.getByTestId('total-ballot-count').first()).toHaveText('56');
-  await expect(page.getByTestId('total-ballot-count').last()).toHaveText('112');
 
   // Check CSV Export
   await page.getByRole('button', { name: 'Export Report CSV' }).click();
@@ -107,7 +112,7 @@ test('viewing and exporting reports', async ({ page }) => {
   ).toMatchSnapshot();
 
   // Mark Official
-  await page.getByText('Reports', { exact: true }).click();
+  await page.getByRole('button', { name: 'Reports' }).click();
   await page
     .getByRole('button', { name: 'Mark Election Results as Official' })
     .click();

--- a/apps/design/frontend/src/ballot_viewer.tsx
+++ b/apps/design/frontend/src/ballot_viewer.tsx
@@ -10,7 +10,7 @@ import {
   Precinct,
 } from '@votingworks/types';
 import styled from 'styled-components';
-import { Button, H1, H3, P, RadioGroup } from '@votingworks/ui';
+import { Breadcrumbs, Button, H1, H3, P, RadioGroup } from '@votingworks/ui';
 import {
   AnyElement,
   Document,
@@ -29,7 +29,7 @@ import fileDownload from 'js-file-download';
 import { useParams } from 'react-router-dom';
 import { exportBallot } from './api';
 import { ElectionIdParams, routes } from './routes';
-import { Breadcrumbs, Column, FieldName as BaseFieldName } from './layout';
+import { Column, FieldName as BaseFieldName } from './layout';
 
 const FieldName = styled(BaseFieldName)`
   font-weight: ${(p) => p.theme.sizes.fontWeight.bold};
@@ -315,17 +315,17 @@ export function BallotViewer({
     );
   }
 
+  const { title } = ballotRoutes.viewBallot(ballotStyle.id, precinct.id);
+
   return (
     <div style={{ display: 'flex', height: '100%', width: '100%' }}>
       <Controls>
         <section>
           <Breadcrumbs
-            routes={[
-              ballotRoutes.root,
-              ballotRoutes.viewBallot(ballotStyle.id, precinct.id),
-            ]}
+            currentTitle={title}
+            parentRoutes={[ballotRoutes.root]}
           />
-          <H1 style={{ marginTop: 0 }}>View Ballot</H1>
+          <H1 style={{ marginTop: 0 }}>{title}</H1>
           <Column style={{ gap: '1rem' }}>
             <div>
               <FieldName>Ballot Style</FieldName>

--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -312,16 +312,7 @@ export function BallotsScreen(): JSX.Element | null {
           </MainHeader>
           <MainContent>
             <TabBar
-              tabs={[
-                {
-                  label: 'Ballot Styles',
-                  path: ballotsRoutes.ballotStyles.path,
-                },
-                {
-                  label: 'Ballot Layout',
-                  path: ballotsRoutes.ballotLayout.path,
-                },
-              ]}
+              tabs={[ballotsRoutes.ballotStyles, ballotsRoutes.ballotLayout]}
             />
             <Switch>
               <Route

--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -11,6 +11,7 @@ import {
   SearchSelect,
   MainContent,
   MainHeader,
+  Breadcrumbs,
 } from '@votingworks/ui';
 import {
   Redirect,
@@ -33,7 +34,6 @@ import {
 } from '@votingworks/types';
 import { assert, find } from '@votingworks/basics';
 import {
-  Breadcrumbs,
   FieldName,
   Form,
   FormActionsRow,
@@ -555,17 +555,16 @@ function AddContestForm(): JSX.Element | null {
   }
 
   const { election } = getElectionQuery.data;
+  const { title } = contestRoutes.contests.addContest;
 
   return (
     <React.Fragment>
       <MainHeader>
         <Breadcrumbs
-          routes={[
-            contestRoutes.contests.root,
-            contestRoutes.contests.addContest,
-          ]}
+          currentTitle={title}
+          parentRoutes={[contestRoutes.contests.root]}
         />
-        <H1>Add Contest</H1>
+        <H1>{title}</H1>
       </MainHeader>
       <MainContent>
         <ContestForm electionId={electionId} savedElection={election} />
@@ -586,17 +585,16 @@ function EditContestForm(): JSX.Element | null {
   }
 
   const { election } = getElectionQuery.data;
+  const { title } = contestRoutes.contests.editContest(contestId);
 
   return (
     <React.Fragment>
       <MainHeader>
         <Breadcrumbs
-          routes={[
-            contestRoutes.contests.root,
-            contestRoutes.contests.editContest(contestId),
-          ]}
+          currentTitle={title}
+          parentRoutes={[contestRoutes.contests.root]}
         />
-        <H1>Edit Contest</H1>
+        <H1>{title}</H1>
       </MainHeader>
       <MainContent>
         <ContestForm
@@ -819,12 +817,13 @@ function AddPartyForm(): JSX.Element | null {
   }
 
   const { election } = getElectionQuery.data;
+  const { title } = partyRoutes.addParty;
 
   return (
     <React.Fragment>
       <MainHeader>
-        <Breadcrumbs routes={[partyRoutes.root, partyRoutes.addParty]} />
-        <H1>Add Party</H1>
+        <Breadcrumbs currentTitle={title} parentRoutes={[partyRoutes.root]} />
+        <H1>{title}</H1>
       </MainHeader>
       <MainContent>
         <PartyForm electionId={electionId} savedElection={election} />
@@ -845,14 +844,13 @@ function EditPartyForm(): JSX.Element | null {
   }
 
   const { election } = getElectionQuery.data;
+  const { title } = partyRoutes.editParty(partyId);
 
   return (
     <React.Fragment>
       <MainHeader>
-        <Breadcrumbs
-          routes={[partyRoutes.root, partyRoutes.editParty(partyId)]}
-        />
-        <H1>Edit Party</H1>
+        <Breadcrumbs currentTitle={title} parentRoutes={[partyRoutes.root]} />
+        <H1>{title}</H1>
       </MainHeader>
       <MainContent>
         <PartyForm

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -11,6 +11,7 @@ import {
   CheckboxGroup,
   MainContent,
   MainHeader,
+  Breadcrumbs,
 } from '@votingworks/ui';
 import {
   Switch,
@@ -36,7 +37,6 @@ import {
   NestedTr,
   TableActionsRow,
   FormActionsRow,
-  Breadcrumbs,
   Row,
   Column,
   InputGroup,
@@ -258,17 +258,16 @@ function AddDistrictForm(): JSX.Element | null {
   }
 
   const { election } = getElectionQuery.data;
+  const { title } = geographyRoutes.districts.addDistrict;
 
   return (
     <React.Fragment>
       <MainHeader>
         <Breadcrumbs
-          routes={[
-            geographyRoutes.districts.root,
-            geographyRoutes.districts.addDistrict,
-          ]}
+          currentTitle={title}
+          parentRoutes={[geographyRoutes.districts.root]}
         />
-        <H1>Add District</H1>
+        <H1>{title}</H1>
       </MainHeader>
       <MainContent>
         <DistrictForm electionId={electionId} savedElection={election} />
@@ -289,17 +288,16 @@ function EditDistrictForm(): JSX.Element | null {
   }
 
   const { election, precincts } = getElectionQuery.data;
+  const { title } = geographyRoutes.districts.editDistrict(districtId);
 
   return (
     <React.Fragment>
       <MainHeader>
         <Breadcrumbs
-          routes={[
-            geographyRoutes.districts.root,
-            geographyRoutes.districts.editDistrict(districtId),
-          ]}
+          currentTitle={title}
+          parentRoutes={[geographyRoutes.districts.root]}
         />
-        <H1>Edit District</H1>
+        <H1>{title}</H1>
       </MainHeader>
       <MainContent>
         <DistrictForm
@@ -674,17 +672,16 @@ function AddPrecinctForm(): JSX.Element | null {
   }
 
   const { precincts, election } = getElectionQuery.data;
+  const { title } = geographyRoutes.precincts.addPrecinct;
 
   return (
     <React.Fragment>
       <MainHeader>
         <Breadcrumbs
-          routes={[
-            geographyRoutes.precincts.root,
-            geographyRoutes.precincts.addPrecinct,
-          ]}
+          currentTitle={title}
+          parentRoutes={[geographyRoutes.districts.root]}
         />
-        <H1>Add Precinct</H1>
+        <H1>{title}</H1>
       </MainHeader>
       <MainContent>
         <PrecinctForm
@@ -709,17 +706,16 @@ function EditPrecinctForm(): JSX.Element | null {
   }
 
   const { precincts, election } = getElectionQuery.data;
+  const { title } = geographyRoutes.precincts.editPrecinct(precinctId);
 
   return (
     <React.Fragment>
       <MainHeader>
         <Breadcrumbs
-          routes={[
-            geographyRoutes.precincts.root,
-            geographyRoutes.precincts.editPrecinct(precinctId),
-          ]}
+          currentTitle={title}
+          parentRoutes={[geographyRoutes.districts.root]}
         />
-        <H1>Edit Precinct</H1>
+        <H1>{title}</H1>
       </MainHeader>
       <MainContent>
         <PrecinctForm

--- a/apps/design/frontend/src/layout.tsx
+++ b/apps/design/frontend/src/layout.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { Icons, Table as UiTable } from '@votingworks/ui';
+import { Table as UiTable } from '@votingworks/ui';
 import styled from 'styled-components';
-import { Route } from './routes';
 
 export const Row = styled.div`
   display: flex;
@@ -73,21 +71,3 @@ export const NestedTr = styled.tr`
     padding-left: 3rem;
   }
 `;
-
-export function Breadcrumbs({ routes }: { routes: Route[] }): JSX.Element {
-  return (
-    <Row style={{ gap: '0.5rem', marginBottom: '0.75rem' }}>
-      {routes.map((route, index) => {
-        if (index === routes.length - 1) {
-          return route.label;
-        }
-        return (
-          <React.Fragment key={route.path}>
-            <Link to={route.path}>{route.label}</Link>
-            {index < routes.length - 1 && <Icons.RightChevron />}
-          </React.Fragment>
-        );
-      })}
-    </Row>
-  );
-}

--- a/apps/design/frontend/src/nav_screen.tsx
+++ b/apps/design/frontend/src/nav_screen.tsx
@@ -43,11 +43,11 @@ export function ElectionNavScreen({
     <NavScreen
       navContent={
         <NavList>
-          {electionNavRoutes(electionId).map(({ label, path }) => {
+          {electionNavRoutes(electionId).map(({ title, path }) => {
             return (
               <NavListItem key={path}>
                 <NavLink to={path} isActive={path === currentRoute.url}>
-                  {label}
+                  {title}
                 </NavLink>
               </NavListItem>
             );

--- a/apps/design/frontend/src/routes.ts
+++ b/apps/design/frontend/src/routes.ts
@@ -1,118 +1,114 @@
 import { Id } from '@votingworks/types';
-
-export interface Route {
-  readonly label: string;
-  readonly path: string;
-}
+import { Route } from '@votingworks/ui';
 
 export const routes = {
   root: {
-    label: 'Elections',
+    title: 'Elections',
     path: '/',
   },
   election: (id: string) => {
     const root = `/elections/${id}`;
     return {
       root: {
-        label: 'Election',
+        title: 'Election',
         path: root,
       },
       electionInfo: {
-        label: 'Election Info',
+        title: 'Election Info',
         path: `${root}/info`,
       },
       geography: {
         root: {
-          label: 'Geography',
+          title: 'Geography',
           path: `${root}/geography`,
         },
         districts: {
           root: {
-            label: 'Districts',
+            title: 'Districts',
             path: `${root}/geography/districts`,
           },
           addDistrict: {
-            label: 'Add District',
+            title: 'Add District',
             path: `${root}/geography/districts/add`,
           },
           editDistrict: (districtId: string) => ({
-            label: 'Edit District',
+            title: 'Edit District',
             path: `${root}/geography/districts/${districtId}`,
           }),
         },
         precincts: {
           root: {
-            label: 'Precincts',
+            title: 'Precincts',
             path: `${root}/geography/precincts`,
           },
           addPrecinct: {
-            label: 'Add Precinct',
+            title: 'Add Precinct',
             path: `${root}/geography/precincts/add`,
           },
           editPrecinct: (precinctId: string) => ({
-            label: 'Edit Precinct',
+            title: 'Edit Precinct',
             path: `${root}/geography/precincts/${precinctId}`,
           }),
         },
       },
       contests: {
         root: {
-          label: 'Contests',
+          title: 'Contests',
           path: `${root}/contests`,
         },
         contests: {
           root: {
-            label: 'Contests',
+            title: 'Contests',
             path: `${root}/contests/contests`,
           },
           addContest: {
-            label: 'Add Contest',
+            title: 'Add Contest',
             path: `${root}/contests/contests/add`,
           },
           editContest: (contestId: string) => ({
-            label: 'Edit Contest',
+            title: 'Edit Contest',
             path: `${root}/contests/contests/${contestId}`,
           }),
         },
         parties: {
           root: {
-            label: 'Parties',
+            title: 'Parties',
             path: `${root}/contests/parties`,
           },
           addParty: {
-            label: 'Add Party',
+            title: 'Add Party',
             path: `${root}/contests/parties/add`,
           },
           editParty: (partyId: string) => ({
-            label: 'Edit Party',
+            title: 'Edit Party',
             path: `${root}/contests/parties/${partyId}`,
           }),
         },
       },
       ballots: {
         root: {
-          label: 'Ballots',
+          title: 'Ballots',
           path: `${root}/ballots`,
         },
         ballotStyles: {
-          label: 'Ballot Styles',
+          title: 'Ballot Styles',
           path: `${root}/ballots/ballot-styles`,
         },
         ballotLayout: {
-          label: 'Ballot Layout',
+          title: 'Ballot Layout',
           path: `${root}/ballots/layout`,
         },
         viewBallot: (ballotStyleId: string, precinctId: string) => ({
-          label: 'View Ballot',
+          title: 'View Ballot',
           path: `${root}/ballots/${ballotStyleId}/${precinctId}`,
         }),
       },
       tabulation: {
-        label: 'Tabulation',
+        title: 'Tabulation',
         path: `${root}/tabulation`,
       },
       export: {
-        label: 'Export',
+        title: 'Export',
         path: `${root}/export`,
       },
     };

--- a/apps/design/frontend/src/tabs.tsx
+++ b/apps/design/frontend/src/tabs.tsx
@@ -1,12 +1,9 @@
-import { Button } from '@votingworks/ui';
+import { Button, Route } from '@votingworks/ui';
 import styled from 'styled-components';
 import { useHistory, useLocation } from 'react-router-dom';
 import { Row } from './layout';
 
-interface Tab {
-  label: string;
-  path: string;
-}
+interface Tab extends Route {}
 
 interface TabBarProps {
   tabs: Tab[];
@@ -40,7 +37,7 @@ export function TabBar({ tabs }: TabBarProps): JSX.Element {
             role="tab"
             aria-selected={isActive}
           >
-            {tab.label}
+            {tab.title}
           </TabButton>
         );
       })}

--- a/libs/ui/src/breadcrumbs.stories.tsx
+++ b/libs/ui/src/breadcrumbs.stories.tsx
@@ -1,0 +1,29 @@
+import { Meta } from '@storybook/react';
+import { MemoryRouter } from 'react-router-dom';
+import { BreadcrumbsProps, Breadcrumbs as Component } from './breadcrumbs';
+import { H1 } from './typography';
+
+const meta: Meta<typeof Component> = {
+  title: 'libs-ui/Breadcrumbs',
+  component: Component,
+  args: {
+    currentTitle: 'Child',
+    parentRoutes: [
+      { title: 'Grandparent', path: '/grandparent' },
+      { title: 'Parent', path: '/grandparent/parent' },
+    ],
+  },
+};
+
+export default meta;
+
+export function Breadcrumbs(props: BreadcrumbsProps): JSX.Element {
+  return (
+    <MemoryRouter>
+      <div>
+        <Component {...props} />
+        <H1 style={{ margin: 0 }}>Child</H1>
+      </div>
+    </MemoryRouter>
+  );
+}

--- a/libs/ui/src/breadcrumbs.test.tsx
+++ b/libs/ui/src/breadcrumbs.test.tsx
@@ -1,0 +1,31 @@
+import { MemoryRouter } from 'react-router-dom';
+import { Breadcrumbs } from './breadcrumbs';
+import { render, screen } from '../test/react_testing_library';
+
+describe('Breadcrumbs', () => {
+  test('shows a sequence of links to the parent routes, plus the current title', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <Breadcrumbs
+          currentTitle="Current Title"
+          parentRoutes={[
+            { title: 'Grandparent', path: '/grandparent' },
+            { title: 'Parent', path: '/grandparent/parent' },
+          ]}
+        />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('link', { name: 'Grandparent' })).toHaveAttribute(
+      'href',
+      '/grandparent'
+    );
+    expect(screen.getByRole('link', { name: 'Parent' })).toHaveAttribute(
+      'href',
+      '/grandparent/parent'
+    );
+    screen.getByText('Current Title');
+    expect(container.firstChild).toHaveTextContent(
+      'Grandparent / Parent / Current Title'
+    );
+  });
+});

--- a/libs/ui/src/breadcrumbs.tsx
+++ b/libs/ui/src/breadcrumbs.tsx
@@ -11,7 +11,7 @@ export interface Route {
   path: string;
 }
 
-interface BreadcrumbsProps {
+export interface BreadcrumbsProps {
   currentTitle: string;
   parentRoutes: Route[];
   className?: string;

--- a/libs/ui/src/breadcrumbs.tsx
+++ b/libs/ui/src/breadcrumbs.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+const Container = styled.div`
+  margin-bottom: 0.5rem;
+`;
+
+export interface Route {
+  title: string;
+  path: string;
+}
+
+interface BreadcrumbsProps {
+  currentTitle: string;
+  parentRoutes: Route[];
+  className?: string;
+}
+
+function joinElements(elements: JSX.Element[], separator: React.ReactNode) {
+  return elements.reduce((acc, element, index) => {
+    if (index === 0) {
+      return [element];
+    }
+
+    return [...acc, separator, element];
+  }, [] as React.ReactNode[]);
+}
+
+export function Breadcrumbs({
+  currentTitle,
+  parentRoutes,
+  className,
+}: BreadcrumbsProps): JSX.Element {
+  const parentLinks = parentRoutes.map((route) => (
+    <Link key={route.path} to={route.path}>
+      {route.title}
+    </Link>
+  ));
+  return (
+    <Container className={className}>
+      {joinElements(
+        [...parentLinks, <span key={currentTitle}>{currentTitle}</span>],
+        ' / '
+      )}
+    </Container>
+  );
+}

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -3,6 +3,7 @@ export * from './app_base';
 export * from './auth';
 export * from './big_metric';
 export * from './bmd_paper_ballot';
+export * from './breadcrumbs';
 export * from './button';
 export * from './button_bar';
 export * from './button_list';


### PR DESCRIPTION
## Overview

Adds breadcrumb navigation to the header for screens that are nested below the screens accessible from the top-level sidebar nav. This obviates the need for custom "back" buttons on these pages.

## Demo Video or Screenshot


https://github.com/votingworks/vxsuite/assets/530106/2a695fca-43f7-462f-a0d8-327fff9f6457






## Testing Plan
Manual testing and updated automated testing

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
