### PR TITLE
VxScan: Center single action button on scan warning screen

### DIFF
--- a/apps/scan/frontend/src/components/full_screen_prompt_layout.tsx
+++ b/apps/scan/frontend/src/components/full_screen_prompt_layout.tsx
@@ -50,12 +50,15 @@ const Text = styled.div`
 `;
 
 const Footer = styled.div`
-  display: grid;
-  grid-gap: ${HORIZONTAL_PADDING_REM}rem;
-  grid-template-columns: 1fr 1fr;
-  justify-content: end;
+  display: flex;
+  gap: ${HORIZONTAL_PADDING_REM}rem;
+  justify-content: center;
   padding: 0 7.5vw 0.25rem;
   width: 100%;
+
+  > * {
+    flex-basis: 20rem;
+  }
 `;
 
 export function FullScreenPromptLayout(


### PR DESCRIPTION

## Overview

Fixes: #4288

The scan warning screen generally has two action buttons, one to return the ballot and one to cast the ballot. In some cases (e.g. if casting overvoted ballots is disallowed), there may only be one button. This PR ensures we center the lone button in those cases.

## Demo Video or Screenshot
Single button
https://github.com/votingworks/vxsuite/assets/530106/9e69d105-2d7e-48e9-b2d1-c72339d6763e

Double button (no regression)

https://github.com/votingworks/vxsuite/assets/530106/e29c67f3-3eeb-48da-a9ab-130c0cfc59c1



## Testing Plan
Manual test

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
