### PR TITLE
unmount phantom drives before mounting drive

### DIFF
--- a/libs/usb-drive/scripts/mount.sh
+++ b/libs/usb-drive/scripts/mount.sh
@@ -22,6 +22,17 @@ fi
 DEVICE=$1
 MOUNTPOINT=/media/vx/usb-drive
 
+# If a drive was previously removed without being ejected first, it may leave a
+# "phantom" mounted drive - a mount entry for an inaccessible file system. Although
+# "phantom" drives do not cause problems for our application code, the system's 
+# file picker will confusingly show multiple drives with the same name. Thus,
+# before mounting, we check for a (probably "phantom") mounted drive and
+# unmount it if it exists.
+if [[  $(findmnt) =~ "$MOUNTPOINT" ]]; then
+    SCRIPTS_DIRECTORY="$(dirname "${BASH_SOURCE[0]}")"
+    "${SCRIPTS_DIRECTORY}/unmount.sh" "$MOUNTPOINT"
+fi
+
 # The mount point will already exist in production but possibly not in development
 if ! [[ -e $MOUNTPOINT ]]; then
     mkdir -p $MOUNTPOINT 


### PR DESCRIPTION
## Overview

Closes #4286. Now, phantom drive entries are removed on each mount, so the user will only ever see one in the file menu.

## Testing Plan

Tested on a prod image - because the changes are confined to a script, it's possible to just change the script and test in prod.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
