### PR TITLE
refactor: use `IteratorPlus` in a few more places

### DIFF
--- a/libs/auth/src/cast_vote_record_hashes.test.ts
+++ b/libs/auth/src/cast_vote_record_hashes.test.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import { sha256 } from 'js-sha256';
 import path from 'path';
 import { dirSync } from 'tmp';
+import { iter } from '@votingworks/basics';
 import { Client } from '@votingworks/db';
 import { CastVoteRecordExportFileName } from '@votingworks/types';
 
@@ -88,11 +89,7 @@ const expectedCastVoteRecordRootHash =
 test('readableFileFromData', async () => {
   const readableFile = readableFileFromData('1', 'a');
   expect(readableFile.fileName).toEqual('1');
-  const chunks = [];
-  for await (const chunk of readableFile.open()) {
-    chunks.push(chunk);
-  }
-  expect(chunks.join('')).toEqual('a');
+  expect((await iter(readableFile.open()).toArray()).join('')).toEqual('a');
   expect(await readableFile.computeSha256Hash()).toEqual(sha256('a'));
 });
 
@@ -100,11 +97,7 @@ test('readableFileFromDisk', async () => {
   fs.writeFileSync(path.join(tempDirectoryPath, '1'), 'a');
   const readableFile = readableFileFromDisk(path.join(tempDirectoryPath, '1'));
   expect(readableFile.fileName).toEqual('1');
-  const chunks = [];
-  for await (const chunk of readableFile.open()) {
-    chunks.push(chunk);
-  }
-  expect(chunks.join('')).toEqual('a');
+  expect((await iter(readableFile.open()).toArray()).join('')).toEqual('a');
   expect(await readableFile.computeSha256Hash()).toEqual(sha256('a'));
 });
 

--- a/libs/backend/src/cast_vote_records/build_report_metadata.ts
+++ b/libs/backend/src/cast_vote_records/build_report_metadata.ts
@@ -1,3 +1,4 @@
+import { integers } from '@votingworks/basics';
 import {
   AnyContest,
   BatchInfo,
@@ -21,23 +22,20 @@ export type CastVoteRecordReportMetadata = Omit<
   'CVR'
 >;
 
-function buildWriteInCandidateSelections(
+function* buildWriteInCandidateSelections(
   contest: CandidateContest
-): CVR.CandidateSelection[] {
+): Generator<CVR.CandidateSelection> {
   if (!contest.allowWriteIns) {
-    return [];
+    return;
   }
 
-  const writeInSelections: CVR.CandidateSelection[] = [];
-  for (let i = 0; i < contest.seats; i += 1) {
-    writeInSelections.push({
+  for (const i of integers().take(contest.seats)) {
+    yield {
       '@type': 'CVR.CandidateSelection',
       '@id': `write-in-${i}`,
       IsWriteIn: true,
-    });
+    };
   }
-
-  return writeInSelections;
 }
 
 function buildCandidateContest(

--- a/libs/backend/src/split.test.ts
+++ b/libs/backend/src/split.test.ts
@@ -250,7 +250,6 @@ test('split works like POSIX split', async () => {
       async ({ size, data }) => {
         // run split and collect outputs
         const streamOutputs: WritableStream[] = [];
-        const fileOutputs: string[] = [];
 
         await split(Readable.from(data), {
           size,
@@ -269,14 +268,12 @@ test('split works like POSIX split', async () => {
           { input: data.join('') }
         );
 
-        for (const file of readdirSync(tmpDir.name).sort()) {
-          fileOutputs.push(readFileSync(join(tmpDir.name, file), 'utf-8'));
-        }
+        const fileOutputs = iter(readdirSync(tmpDir.name).sort()).map((file) =>
+          readFileSync(join(tmpDir.name, file), 'utf-8')
+        );
 
         // compare outputs
-        for (const [fileOutput, output] of iter(fileOutputs).zip(
-          streamOutputs
-        )) {
+        for (const [fileOutput, output] of fileOutputs.zip(streamOutputs)) {
           expect(fileOutput).toEqual(output.toString());
         }
       }

--- a/libs/ballot-encoder/src/bits/utils.ts
+++ b/libs/ballot-encoder/src/bits/utils.ts
@@ -61,16 +61,3 @@ export function sizeof(number: number): number {
 
   return maxBits;
 }
-
-/**
- * Groups `array` into arrays of size `count`.
- */
-export function inGroupsOf<T>(count: number, array: T[]): Array<T[]> {
-  const result: Array<T[]> = [];
-
-  for (let i = 0; i < array.length; i += count) {
-    result.push(array.slice(i, i + count));
-  }
-
-  return result;
-}

--- a/libs/custom-paper-handler/src/driver/scanner_capability.ts
+++ b/libs/custom-paper-handler/src/driver/scanner_capability.ts
@@ -1,3 +1,4 @@
+import { integers } from '@votingworks/basics';
 import {
   PaperMovementAfterScan,
   Resolution,
@@ -135,12 +136,11 @@ export function parseScannerCapability(data: DataView): ScannerCapability {
 
   // Parses capability block starting at the current byte
   function parseOptions<T>(decoder: Decoder<T>): T[] {
-    const options: T[] = [];
     const numOptions = data.getUint8(byteIndex + 1);
-    for (let i = 0; i < numOptions; i += 1) {
-      options.push(decode(data.getUint8(byteIndex + 2 + i), decoder));
-    }
-    return options;
+    return integers()
+      .take(numOptions)
+      .map((i) => decode(data.getUint8(byteIndex + 2 + i), decoder))
+      .toArray();
   }
 
   while (byteIndex < data.byteLength) {

--- a/libs/custom-paper-handler/src/printing.ts
+++ b/libs/custom-paper-handler/src/printing.ts
@@ -1,4 +1,5 @@
-import { assert } from '@votingworks/basics';
+import { assert, iter } from '@votingworks/basics';
+import { BITS_PER_BYTE } from '@votingworks/message-coder';
 import { BitArray, bitArrayToByte, Uint8Max } from './bits';
 import { DEVICE_MAX_WIDTH_DOTS } from './driver/constants';
 import { PaperHandlerBitmap } from './driver/coders';
@@ -188,13 +189,11 @@ export function chunkBinaryBitmap(
       continue;
     }
 
-    const chunks: number[] = [];
+    const chunks = iter(chunkOrderBits)
+      .chunks(BITS_PER_BYTE)
+      .map((bits) => bits as BitArray)
+      .map(bitArrayToByte);
 
-    for (let i = 0; i < chunkOrderBits.length / 8; i += 1) {
-      chunks.push(
-        bitArrayToByte(chunkOrderBits.slice(i * 8, i * 8 + 8) as BitArray)
-      );
-    }
     paperHandlerBitmaps.push({
       data: new Uint8Array(chunks),
       width: binaryBitmap.width,
@@ -207,15 +206,13 @@ export function chunkBinaryBitmap(
 export function getBlackChunk(width: number): PaperHandlerBitmapExt {
   return {
     width,
-    // eslint-disable-next-line vx/gts-no-array-constructor
-    data: new Uint8Array(Array(width * 3).fill(Uint8Max)),
+    data: new Uint8Array(width * 3).fill(Uint8Max),
   };
 }
 
 export function getWhiteChunk(width: number): PaperHandlerBitmapExt {
   return {
     width,
-    // eslint-disable-next-line vx/gts-no-array-constructor
-    data: new Uint8Array(Array(width * 3).fill(0)),
+    data: new Uint8Array(width * 3).fill(0),
   };
 }

--- a/libs/cvr-fixture-generator/src/cli/generate/main.test.ts
+++ b/libs/cvr-fixture-generator/src/cli/generate/main.test.ts
@@ -50,12 +50,9 @@ async function readAndValidateCastVoteRecordExport(
   assert(readResult.isOk());
   const { castVoteRecordExportMetadata, castVoteRecordIterator } =
     readResult.ok();
-  const castVoteRecords: CVR.CVR[] = [];
-  for await (const castVoteRecordResult of castVoteRecordIterator) {
-    assert(castVoteRecordResult.isOk());
-    const { castVoteRecord } = castVoteRecordResult.ok();
-    castVoteRecords.push(castVoteRecord);
-  }
+  const castVoteRecords = await castVoteRecordIterator
+    .map((cvrResult) => cvrResult.unsafeUnwrap().castVoteRecord)
+    .toArray();
   return {
     castVoteRecordReportMetadata:
       castVoteRecordExportMetadata.castVoteRecordReportMetadata,

--- a/libs/cvr-fixture-generator/src/generate_cvrs.ts
+++ b/libs/cvr-fixture-generator/src/generate_cvrs.ts
@@ -307,7 +307,7 @@ export function* generateCvrs({
               for (const [
                 sheetIndex,
                 sheetContests,
-              ] of contestsBySheet.entries()) {
+              ] of contestsBySheet.enumerate()) {
                 const [frontContests, backContests] = sheetContests;
                 const frontVotes = filterVotesByContests(votes, frontContests);
                 const backVotes = filterVotesByContests(votes, backContests);

--- a/libs/cvr-fixture-generator/src/utils.ts
+++ b/libs/cvr-fixture-generator/src/utils.ts
@@ -1,4 +1,4 @@
-import { assert, assertDefined } from '@votingworks/basics';
+import { IteratorPlus, assert, iter } from '@votingworks/basics';
 import { sha256 } from 'js-sha256';
 import {
   BallotPageLayout,
@@ -100,19 +100,11 @@ export function splitContestsByPage({
  * as from [[...A], [...B], [...C], [...D]] to [[[...A], [...B]], [[...C],[...D]]]
  */
 export function arrangeContestsBySheet(
-  contestsByPage: Contests[]
-): Array<SheetOf<Contests>> {
-  const contestsBySheet: Array<SheetOf<Contests>> = [];
-  const numSheets = Math.ceil(contestsByPage.length / 2);
-
-  for (let i = 0; i < numSheets; i += 1) {
-    contestsBySheet.push([
-      assertDefined(contestsByPage[i * 2]),
-      contestsByPage[i * 2 + 1] ?? [],
-    ]);
-  }
-
-  return contestsBySheet;
+  contestsByPage: Iterable<Contests>
+): IteratorPlus<SheetOf<Contests>> {
+  return iter(contestsByPage)
+    .chunks(2)
+    .map<SheetOf<Contests>>(([front, back = []]) => [front, back]);
 }
 
 /**

--- a/libs/utils/src/json_stream.test.ts
+++ b/libs/utils/src/json_stream.test.ts
@@ -1,4 +1,4 @@
-import { integers } from '@votingworks/basics';
+import { integers, iter } from '@votingworks/basics';
 import * as fc from 'fast-check';
 import { jsonStream, JsonStreamInput, JsonStreamOptions } from './json_stream';
 
@@ -6,11 +6,7 @@ async function asString<T>(
   input: JsonStreamInput<T>,
   options?: JsonStreamOptions
 ) {
-  const output = [];
-  for await (const chunk of jsonStream<T>(input, options)) {
-    output.push(chunk);
-  }
-  return output.join('');
+  return (await iter(jsonStream<T>(input, options)).toArray()).join('');
 }
 
 test('number', async () => {


### PR DESCRIPTION
## Overview
I looked for places where we were building an array using `.push` inside a `for` loop and found some that I thought could be improved using `IteratorPlus`, either with `iter` directly or one of the helpers like `integers`. There are more, but this seemed like a good starting point of the ones that I felt were fairly clearly better this way.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated tests.