### PR TITLE
Address Two `nh-march` VxCentralScan Bugs

### DIFF
--- a/libs/backend/src/cast_vote_records/export.test.ts
+++ b/libs/backend/src/cast_vote_records/export.test.ts
@@ -22,6 +22,7 @@ import {
   interpretedBmdPage,
   interpretedHmpb,
   interpretedHmpbPage1,
+  interpretedHmpbWithUnmarkedWriteIn,
   interpretedHmpbWithWriteIn,
 } from '../../test/fixtures/interpretations';
 import {
@@ -277,6 +278,35 @@ test.each<{
       'accepted HMPB with write-in on central scanner, minimal export',
     sheetGenerator: () =>
       newAcceptedSheet(interpretedHmpbWithWriteIn, sheet1Id),
+    exportOptions: { scannerType: 'central', isMinimalExport: true },
+    expectedDirectoryContents: [
+      CastVoteRecordExportFileName.METADATA,
+      `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+      `${sheet1Id}/${sheet1Id}-front.jpg`,
+      `${sheet1Id}/${sheet1Id}-back.jpg`,
+      `${sheet1Id}/${sheet1Id}-front.layout.json`,
+      `${sheet1Id}/${sheet1Id}-back.layout.json`,
+    ],
+    expectedBallotImageField: [
+      {
+        '@type': 'CVR.ImageData',
+        Hash: anyCastVoteRecordHash,
+        Location: `file:${sheet1Id}-front.jpg`,
+        vxLayoutFileHash: expect.any(String),
+      },
+      {
+        '@type': 'CVR.ImageData',
+        Hash: anyCastVoteRecordHash,
+        Location: `file:${sheet1Id}-back.jpg`,
+        vxLayoutFileHash: expect.any(String),
+      },
+    ],
+  },
+  {
+    description:
+      'accepted HMPB with unmarked write-in on central scanner, minimal export',
+    sheetGenerator: () =>
+      newAcceptedSheet(interpretedHmpbWithUnmarkedWriteIn, sheet1Id),
     exportOptions: { scannerType: 'central', isMinimalExport: true },
     expectedDirectoryContents: [
       CastVoteRecordExportFileName.METADATA,

--- a/libs/backend/src/cast_vote_records/export.ts
+++ b/libs/backend/src/cast_vote_records/export.ts
@@ -207,6 +207,18 @@ function isMinimalExport(exportOptions: ExportOptions): boolean {
   );
 }
 
+function shouldIncludeImagesInMinimalExport(
+  canonicalizedSheet: CanonicalizedSheet
+): boolean {
+  return (
+    canonicalizedSheet.type === 'hmpb' &&
+    canonicalizedSheet.interpretation.some(
+      ({ votes, unmarkedWriteIns }) =>
+        hasWriteIns(votes) || (unmarkedWriteIns && unmarkedWriteIns.length > 0)
+    )
+  );
+}
+
 /**
  * Returns the export directory path relative to the USB mount point. Creates a new export
  * directory if one hasn't been created yet or if we're performing a full export.
@@ -383,8 +395,7 @@ async function exportCastVoteRecordFilesToUsbDrive(
   const canonicalizedSheet = canonicalizeSheetResult.ok();
 
   const shouldIncludeImages = isMinimalExport(exportOptions)
-    ? canonicalizedSheet.type === 'hmpb' &&
-      canonicalizedSheet.interpretation.some(({ votes }) => hasWriteIns(votes))
+    ? shouldIncludeImagesInMinimalExport(canonicalizedSheet)
     : true;
 
   const castVoteRecordFilesToExport: ReadableFile[] = [];


### PR DESCRIPTION
## Overview

Addresses bug where VxCentralScan will crash on exporting CVRs sometimes if there is an unmarked write-in. We were making the assumption that the image exists for the page with the UWI, but not ensuring it for VxCentralScan's minimal export's. Bug fixed in first commit.

Second commit prevents "Tabulate as is" for overvote ballots if `precinctScanDisallowCastingOvervotes` is set.

## Demo Video or Screenshot

#### Overvote UI Before, NH Settings:

<img width="1157" alt="Screen Shot 2023-11-30 at 10 37 29 AM" src="https://github.com/votingworks/vxsuite/assets/37960853/b5268d67-6a95-4334-b1a3-3411129a4197">

#### Overvote UI After, NH Settings:

<img width="1157" alt="Screen Shot 2023-11-30 at 10 36 41 AM" src="https://github.com/votingworks/vxsuite/assets/37960853/d0a55008-2b90-4afe-8e4c-8198ba084e36">


## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
