### PR TITLE
Allow Unselecting WIA Adjudications

### DIFF
--- a/apps/admin/backend/src/adjudication.test.ts
+++ b/apps/admin/backend/src/adjudication.test.ts
@@ -238,4 +238,14 @@ test('adjudicateWriteIn', async () => {
       status: 'invalid',
     }
   );
+
+  await adjudicateWriteIn({ writeInId, type: 'reset' }, store, logger);
+  expectVotes({ 'zoo-council-mammal': ['write-in-0'] });
+  expectWriteInRecord({
+    status: 'pending',
+  });
+  expectLog(`User adjudicated a write-in from invalid to unadjudicated.`, {
+    previousStatus: 'invalid',
+    status: 'pending',
+  });
 });

--- a/apps/admin/backend/src/adjudication.ts
+++ b/apps/admin/backend/src/adjudication.ts
@@ -130,12 +130,19 @@ export async function adjudicateWriteIn(
 
   switch (adjudicationAction.type) {
     case 'official-candidate':
+      store.setWriteInRecordOfficialCandidate(adjudicationAction);
+      // ensure the vote does not appear as an undervote in tallies, which is
+      // only applicable to unmarked write-ins
+      adjudicateVote(
+        {
+          ...initialWriteInRecord,
+          isVote: true,
+        },
+        store
+      );
+      break;
     case 'write-in-candidate':
-      if (adjudicationAction.type === 'official-candidate') {
-        store.setWriteInRecordOfficialCandidate(adjudicationAction);
-      } else {
-        store.setWriteInRecordUnofficialCandidate(adjudicationAction);
-      }
+      store.setWriteInRecordUnofficialCandidate(adjudicationAction);
       // ensure the vote does not appear as an undervote in tallies, which is
       // only applicable to unmarked write-ins
       adjudicateVote(

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -2087,47 +2087,6 @@ export class Store {
     };
   }
 
-  getVoteAdjudication({
-    electionId,
-    cvrId,
-    contestId,
-    optionId,
-  }: Omit<VoteAdjudication, 'isVote'>): Optional<VoteAdjudication> {
-    const row = this.client.one(
-      `
-      select
-        election_id as electionId,
-        cvr_id as cvrId,
-        contest_id as contestId,
-        option_id as optionId,
-        is_vote as isVote
-      from vote_adjudications
-      where
-        election_id = ? and
-        cvr_id = ? and
-        contest_id = ? and
-        option_id = ?
-      `,
-      electionId,
-      cvrId,
-      contestId,
-      optionId
-    ) as Optional<{
-      electionId: Id;
-      cvrId: Id;
-      contestId: Id;
-      optionId: Id;
-      isVote: SqliteBool;
-    }>;
-
-    return row
-      ? {
-          ...row,
-          isVote: fromSqliteBool(row.isVote),
-        }
-      : undefined;
-  }
-
   deleteVoteAdjudication({
     electionId,
     cvrId,

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -76,6 +76,7 @@ import {
   WriteInAdjudicationActionInvalid,
   WriteInAdjudicationActionWriteInCandidate,
   CastVoteRecordAdjudicationFlags,
+  WriteInAdjudicationActionReset,
 } from './types';
 import { rootDebug } from './util/debug';
 
@@ -2220,6 +2221,23 @@ export class Store {
           official_candidate_id = null,
           write_in_candidate_id = null,
           adjudicated_at = current_timestamp
+        where id = ?
+      `,
+      writeInId
+    );
+  }
+
+  resetWriteInRecordToPending({
+    writeInId,
+  }: WriteInAdjudicationActionReset): void {
+    this.client.run(
+      `
+        update write_ins
+        set
+          is_invalid = 0,
+          official_candidate_id = null,
+          write_in_candidate_id = null,
+          adjudicated_at = null
         where id = ?
       `,
       writeInId

--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -321,12 +321,21 @@ export interface WriteInAdjudicationActionInvalid {
 }
 
 /**
+ * Information necessary to reset a write-in to pending.
+ */
+export interface WriteInAdjudicationActionReset {
+  writeInId: Id;
+  type: 'reset';
+}
+
+/**
  * Information necessary to adjudicate a write-in.
  */
 export type WriteInAdjudicationAction =
   | WriteInAdjudicationActionOfficialCandidate
   | WriteInAdjudicationActionWriteInCandidate
-  | WriteInAdjudicationActionInvalid;
+  | WriteInAdjudicationActionInvalid
+  | WriteInAdjudicationActionReset;
 
 /**
  * Information necessary to display a write-in on the frontend.

--- a/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
@@ -19,7 +19,6 @@ import {
   LinkButton,
   Loading,
   H1,
-  RadioGroup,
   H4,
 } from '@votingworks/ui';
 import { format } from '@votingworks/utils';
@@ -141,8 +140,74 @@ const WriteInActionButton = styled(Button)`
 
 const SectionLabel = styled.div`
   font-weight: ${(p) => p.theme.sizes.fontWeight.semiBold};
-  margin-top: 1rem;
   margin-bottom: 0.5rem;
+
+  :not(:first-child) {
+    margin-top: 1rem;
+  }
+`;
+
+// styles closely imitate our RadioGroup buttons, but we don't use RadioGroup
+// because we need to be able to deselect options by clicking them again
+const CandidateStyledButton = styled(Button)`
+  border-color: ${(p) => p.theme.colors.outline};
+  border-width: ${(p) =>
+    p.theme.sizeMode === 'desktop'
+      ? p.theme.sizes.bordersRem.thin
+      : p.theme.sizes.bordersRem.hairline}rem;
+  flex-wrap: nowrap;
+  font-weight: ${(p) => p.theme.sizes.fontWeight.regular};
+  justify-content: start;
+  padding-left: 0.5rem;
+  text-align: left;
+  width: 100%;
+
+  /* Increase contrast between selected/unselected options when disabled by
+   * removing the darkening filter for unselected options. */
+  &[disabled] {
+    ${(p) => p.color === 'neutral' && `filter: none;`}
+  }
+`;
+
+function CandidateButton({
+  candidate,
+  isSelected,
+  isSelectedStatusUpToDate,
+  onSelect,
+  onDeselect,
+}: {
+  candidate: Pick<Candidate, 'id' | 'name'>;
+  isSelected?: boolean;
+  isSelectedStatusUpToDate: boolean;
+  onSelect: () => void;
+  onDeselect: () => void;
+}) {
+  return (
+    <CandidateStyledButton
+      key={candidate.id}
+      onPress={() => {
+        if (!isSelectedStatusUpToDate) return;
+
+        if (!isSelected) {
+          onSelect();
+        } else {
+          onDeselect();
+        }
+      }}
+      color={isSelected ? 'primary' : 'neutral'}
+      fill={isSelected ? 'tinted' : 'outlined'}
+      icon={isSelected ? 'CircleDot' : 'Circle'}
+    >
+      {candidate.name}
+    </CandidateStyledButton>
+  );
+}
+
+const CandidateButtonList = styled.div`
+  display: grid;
+  align-items: stretch;
+  grid-gap: 0.5rem;
+  grid-template-columns: 1fr;
 `;
 
 export function WriteInsAdjudicationScreen(): JSX.Element {
@@ -392,6 +457,13 @@ export function WriteInsAdjudicationScreen(): JSX.Element {
     });
     focusNext();
   }
+  function resetAdjudication(): void {
+    assert(currentWriteInId !== undefined);
+    adjudicateWriteInMutation.mutate({
+      writeInId: currentWriteInId,
+      type: 'reset',
+    });
+  }
 
   async function onAddWriteInCandidate() {
     assert(currentWriteInId !== undefined);
@@ -466,55 +538,52 @@ export function WriteInsAdjudicationScreen(): JSX.Element {
             </ContestTitle>
           </ContestTitleContainer>
           <AdjudicationForm>
-            <RadioGroup
-              ref={firstAdjudicationControl}
-              label="Official Candidates"
-              options={officialCandidates.map((candidate) => ({
-                label: candidate.name,
-                value: candidate.id,
-              }))}
-              value={
-                currentWriteIn &&
-                currentWriteIn.status === 'adjudicated' &&
-                currentWriteIn.adjudicationType === 'official-candidate'
-                  ? currentWriteIn.candidateId
-                  : undefined
-              }
-              onChange={(candidateId) => {
-                if (isWriteInAdjudicationContextFresh) {
-                  adjudicateAsOfficialCandidate(
-                    find(officialCandidates, (c) => c.id === candidateId)
-                  );
-                }
-              }}
-            />
-
+            <SectionLabel>Official Candidates</SectionLabel>
+            <CandidateButtonList>
+              {officialCandidates.map((candidate) => {
+                return (
+                  <CandidateButton
+                    key={candidate.id}
+                    candidate={candidate}
+                    isSelected={
+                      currentWriteIn &&
+                      currentWriteIn.status === 'adjudicated' &&
+                      currentWriteIn.adjudicationType ===
+                        'official-candidate' &&
+                      currentWriteIn.candidateId === candidate.id
+                    }
+                    isSelectedStatusUpToDate={isWriteInAdjudicationContextFresh}
+                    onSelect={() => adjudicateAsOfficialCandidate(candidate)}
+                    onDeselect={resetAdjudication}
+                  />
+                );
+              })}
+            </CandidateButtonList>
             <SectionLabel>Write-In Candidates</SectionLabel>
             {writeInCandidates.length > 0 && (
-              <RadioGroup
-                label="Write-In Candidates"
-                hideLabel
-                options={writeInCandidates.map((candidate) => ({
-                  label: candidate.name,
-                  value: candidate.id,
-                }))}
-                value={
-                  currentWriteIn &&
-                  currentWriteIn.status === 'adjudicated' &&
-                  currentWriteIn.adjudicationType === 'write-in-candidate'
-                    ? currentWriteIn.candidateId
-                    : undefined
-                }
-                onChange={(candidateId) => {
-                  if (isWriteInAdjudicationContextFresh) {
-                    adjudicateAsWriteInCandidate(
-                      find(writeInCandidates, (c) => c.id === candidateId)
-                    );
-                  }
-                }}
-              />
+              <CandidateButtonList>
+                {writeInCandidates.map((candidate) => {
+                  return (
+                    <CandidateButton
+                      key={candidate.id}
+                      candidate={candidate}
+                      isSelected={
+                        currentWriteIn &&
+                        currentWriteIn.status === 'adjudicated' &&
+                        currentWriteIn.adjudicationType ===
+                          'write-in-candidate' &&
+                        currentWriteIn.candidateId === candidate.id
+                      }
+                      isSelectedStatusUpToDate={
+                        isWriteInAdjudicationContextFresh
+                      }
+                      onSelect={() => adjudicateAsWriteInCandidate(candidate)}
+                      onDeselect={resetAdjudication}
+                    />
+                  );
+                })}
+              </CandidateButtonList>
             )}
-
             <div style={{ margin: '0.5rem 0' }}>
               {showNewWriteInCandidateForm ? (
                 <div style={{ display: 'flex', gap: '0.5rem' }}>
@@ -561,14 +630,15 @@ export function WriteInsAdjudicationScreen(): JSX.Element {
               )}
             </div>
 
-            <div>
+            <div style={{ marginTop: '1rem' }}>
               <WriteInActionButton
                 onPress={() => {
-                  if (
-                    isWriteInAdjudicationContextFresh &&
-                    !currentWriteInMarkedInvalid
-                  ) {
+                  if (!isWriteInAdjudicationContextFresh) return;
+
+                  if (!currentWriteInMarkedInvalid) {
                     adjudicateAsInvalid();
+                  } else {
+                    resetAdjudication();
                   }
                 }}
                 variant={currentWriteInMarkedInvalid ? 'secondary' : 'neutral'}

--- a/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
@@ -151,10 +151,7 @@ const SectionLabel = styled.div`
 // because we need to be able to deselect options by clicking them again
 const CandidateStyledButton = styled(Button)`
   border-color: ${(p) => p.theme.colors.outline};
-  border-width: ${(p) =>
-    p.theme.sizeMode === 'desktop'
-      ? p.theme.sizes.bordersRem.thin
-      : p.theme.sizes.bordersRem.hairline}rem;
+  border-width: ${(p) => p.theme.sizes.bordersRem.thin}rem;
   flex-wrap: nowrap;
   font-weight: ${(p) => p.theme.sizes.fontWeight.regular};
   justify-content: start;
@@ -204,10 +201,10 @@ function CandidateButton({
 }
 
 const CandidateButtonList = styled.div`
-  display: grid;
+  display: flex;
+  flex-direction: column;
   align-items: stretch;
-  grid-gap: 0.5rem;
-  grid-template-columns: 1fr;
+  gap: 0.5rem;
 `;
 
 export function WriteInsAdjudicationScreen(): JSX.Element {
@@ -629,7 +626,6 @@ export function WriteInsAdjudicationScreen(): JSX.Element {
                 </WriteInActionButton>
               )}
             </div>
-
             <div style={{ marginTop: '1rem' }}>
               <WriteInActionButton
                 onPress={() => {


### PR DESCRIPTION
## Overview

Closes #4313. Allows you to unselect adjudications in WIA.

## Demo Video or Screenshot

#### WIA Screen Styling Before:

Laying out here because it is almost identical now, except that the candidate buttons are not `containerLow` (gray) and there is a little margin between the write-in candidate section and the mark as invalid button

<img width="1157" alt="Screen Shot 2023-11-30 at 3 29 35 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/9b4eb418-29e3-4c5f-892e-eab5b999bc55">

#### Unselect Demo

https://github.com/votingworks/vxsuite/assets/37960853/3f86651e-1010-44a0-915a-7208f5f838f5

## Testing Plan

Lots of automated testing changes, manual testing too.

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
