### PR TITLE
fix(logs): create intermediate diretories for log exports

### DIFF
--- a/libs/backend/src/logs/logs_api.test.ts
+++ b/libs/backend/src/logs/logs_api.test.ts
@@ -96,6 +96,11 @@ test('exportLogsToUsb works when all conditions are met', async () => {
   expect((await api.exportLogsToUsb()).isOk()).toBeTruthy();
   expect(mockOf(fs.stat)).toHaveBeenCalledWith('/var/log/votingworks');
 
+  expect(execFileMock).toHaveBeenCalledWith('mkdir', [
+    '-p',
+    '/media/usb-drive/logs/machine_TEST-MACHINE-ID',
+  ]);
+
   expect(execFileMock).toHaveBeenCalledWith('cp', [
     '-r',
     '/var/log/votingworks',

--- a/libs/backend/src/logs/logs_api.ts
+++ b/libs/backend/src/logs/logs_api.ts
@@ -40,12 +40,16 @@ function buildApi({
         return err('no-usb-drive');
       }
 
-      const mountpoint = status.mountPoint;
+      const machineNamePath = join(
+        status.mountPoint,
+        `/logs/machine_${machineId}`
+      );
+
       const dateString = new Date().toISOString().replaceAll(':', '-');
-      const dirPath = `/logs/machine_${machineId}/${dateString}`;
-      const destinationDirectory = join(mountpoint, dirPath);
+      const destinationDirectory = join(machineNamePath, dateString);
 
       try {
+        await execFile('mkdir', ['-p', machineNamePath]);
         await execFile('cp', ['-r', LOG_DIR, destinationDirectory]);
       } catch {
         return err('copy-failed');


### PR DESCRIPTION

Once we moved to `cp`, we also have to create intermediate directories.