### PR TITLE
fix(eslint-plugin-vx): support `Result` type aliasing

### DIFF
--- a/libs/eslint-plugin-vx/src/rules/no_floating_results.ts
+++ b/libs/eslint-plugin-vx/src/rules/no_floating_results.ts
@@ -6,21 +6,10 @@ import {
   TSESTree,
 } from '@typescript-eslint/utils';
 import * as ts from 'typescript';
-import { createRule } from '../util';
+import { containsNamedType, createRule } from '../util';
 
 interface Options {
   ignoreVoid?: boolean;
-}
-
-function isResultType(checker: ts.TypeChecker, node: ts.Node): boolean {
-  // TODO: consider the actual declaration location?
-  const type = checker.getTypeAtLocation(node);
-  const typeName =
-    // this seems to be for when the type is declared in the same file
-    type.getSymbol()?.getName() ??
-    // and this is for when it's imported
-    type.aliasSymbol?.getName();
-  return typeName === 'Result';
 }
 
 function isUnhandledResult(
@@ -53,7 +42,10 @@ function isUnhandledResult(
   }
 
   // Check the type. At this point it can't be unhandled if it isn't a Result
-  return isResultType(checker, parserServices.esTreeNodeToTSNodeMap.get(node));
+  const type = checker.getTypeAtLocation(
+    parserServices.esTreeNodeToTSNodeMap.get(node)
+  );
+  return containsNamedType(checker, 'Result', type);
 }
 
 const rule: TSESLint.RuleModule<

--- a/libs/eslint-plugin-vx/tests/rules/no_floating_results.test.ts
+++ b/libs/eslint-plugin-vx/tests/rules/no_floating_results.test.ts
@@ -84,5 +84,20 @@ void rand()
       options: [{ ignoreVoid: false }],
       errors: [{ line: 9, messageId: 'floating' }],
     },
+    {
+      code: `
+declare module '@votingworks/types' {
+  export interface Result<T, E> {}
+}
+
+import { Result } from '@votingworks/types';
+
+type CustomResult<T> = Result<T, CustomError>;
+
+declare function rand(): CustomResult<number>;
+rand();
+        `,
+      errors: [{ line: 11, messageId: 'floatingVoid' }],
+    },
   ],
 });


### PR DESCRIPTION
## Overview
Previously we only checked if the type as literally `Result`, but it didn't support type aliases like `type CustomResult = Result<T, E>;`. This fixes that.

## Demo Video or Screenshot
Function returns `Promise<ExportDataResult>`:
<img width="293" alt="image" src="https://github.com/votingworks/vxsuite/assets/1938/40569e6f-2127-4bec-bd01-fc4773209bc6">

| Before (no error) | After (ESLint error) |
|-|-|
|<img width="397" alt="image" src="https://github.com/votingworks/vxsuite/assets/1938/d9010af3-becd-4025-8dce-2b24c3fc49c3">|<img width="851" alt="image" src="https://github.com/votingworks/vxsuite/assets/1938/2e7d84c7-ded3-47b6-abc4-00a0c8e5dd88">|

## Testing Plan
- [x] New automated tests
- [x] Manual testing in VS Code
