### PR TITLE
Fix PIN entry numpad button sizing

### DIFF
--- a/libs/ui/src/number_pad.tsx
+++ b/libs/ui/src/number_pad.tsx
@@ -11,7 +11,7 @@ export const NumberPadContainer = styled.div`
   > button {
     display: flex;
     justify-content: center;
-    margin: 2px;
+    margin: 0.125rem;
     width: 26%;
   }
 `;

--- a/libs/ui/src/unlock_machine_screen.tsx
+++ b/libs/ui/src/unlock_machine_screen.tsx
@@ -22,7 +22,7 @@ const NumberPadWrapper = styled.div`
   font-size: 1em;
 
   > div {
-    width: 400px;
+    width: 12rem;
   }
 
   *:focus {


### PR DESCRIPTION
## Overview

@mattroe noticed that the buttons in the PIN entry were hard to press on VxScan, so this PR makes them a bit bigger.

## Demo Video or Screenshot

Before
<img width="960" alt="Screenshot 2023-12-04 at 11 39 05 AM" src="https://github.com/votingworks/vxsuite/assets/530106/90229691-2acd-43f2-8e4f-23e3ddbb5aef">

After
<img width="960" alt="Screenshot 2023-12-04 at 11 38 55 AM" src="https://github.com/votingworks/vxsuite/assets/530106/1ca72a98-bfad-431a-9fb6-cec99204bf1c">


## Testing Plan
Manual test

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
