### PR TITLE
feat(basics): allow promise in `flatMap`return value

### DIFF
--- a/libs/basics/src/iterators/async_iterator_plus.test.ts
+++ b/libs/basics/src/iterators/async_iterator_plus.test.ts
@@ -330,6 +330,12 @@ test('flatMap', async () => {
       })
       .toArray()
   ).toEqual([1, 1, 2, 2, 3, 3]);
+  expect(
+    await iter([1, 2, 3])
+      .async()
+      .flatMap((a) => Promise.resolve([a, a]))
+      .toArray()
+  ).toEqual([1, 1, 2, 2, 3, 3]);
 });
 
 test('last', async () => {

--- a/libs/basics/src/iterators/async_iterator_plus.ts
+++ b/libs/basics/src/iterators/async_iterator_plus.ts
@@ -154,14 +154,17 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   }
 
   flatMap<U>(
-    fn: (value: T, index: number) => Iterable<U> | AsyncIterable<U>
+    fn: (
+      value: T,
+      index: number
+    ) => MaybePromise<Iterable<U> | AsyncIterable<U>>
   ): AsyncIteratorPlus<U> {
     const { iterable } = this;
     return new AsyncIteratorPlusImpl(
       (async function* gen() {
         let index = 0;
         for await (const value of iterable) {
-          yield* fn(value, index);
+          yield* await fn(value, index);
           index += 1;
         }
       })()

--- a/libs/basics/src/iterators/types.ts
+++ b/libs/basics/src/iterators/types.ts
@@ -404,7 +404,10 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
    * Maps elements to an async iterable of `U` and flattens the result.
    */
   flatMap<U>(
-    fn: (value: T, index: number) => Iterable<U> | AsyncIterable<U>
+    fn: (
+      value: T,
+      index: number
+    ) => MaybePromise<Iterable<U> | AsyncIterable<U>>
   ): AsyncIteratorPlus<U>;
 
   /**


### PR DESCRIPTION
## Overview
For `AsyncIteratorPlus` it can be convenient for the callback passed to `flatMap` to be an async function. This makes that possible.

## Demo Video or Screenshot
| Before | After |
|-|-|
|<img width="839" alt="image" src="https://github.com/votingworks/vxsuite/assets/1938/00219a9b-0049-4fe8-9651-04020deb60e6">|<img width="770" alt="image" src="https://github.com/votingworks/vxsuite/assets/1938/a00600f7-da65-42f9-96f8-ad2d7dd5f3d9">|

## Testing Plan
- [x] New automated test