### PR TITLE
VxAdmin: Scrollable CVR import table

### DIFF
--- a/apps/admin/frontend/src/components/import_cvrfiles_modal.tsx
+++ b/apps/admin/frontend/src/components/import_cvrfiles_modal.tsx
@@ -11,7 +11,6 @@ import {
   Button,
   ElectronFile,
   useExternalStateChangeListener,
-  WithScrollButtons,
   P,
   Font,
   Icons,
@@ -42,8 +41,25 @@ import {
   listCastVoteRecordFilesOnUsb,
 } from '../api';
 
-const CvrFileTable = styled(Table)`
-  margin-top: 20px;
+const CvrFileTableWrapper = styled.div`
+  background: ${(p) => p.theme.colors.containerLow};
+  position: relative;
+
+  /* Ensure that the last row is cut in half so it's clear you can scroll */
+  max-height: 22rem;
+  overflow-y: auto;
+
+  table {
+    border-collapse: separate;
+    border-spacing: 0;
+
+    thead tr {
+      position: sticky;
+      top: -1px; /* Cover up small gap */
+      z-index: 1;
+      background: ${(p) => p.theme.colors.containerHigh};
+    }
+  }
 `;
 
 const UsbImage = styled.img`
@@ -58,9 +74,6 @@ const LabelText = styled.span`
 `;
 
 const Content = styled.div`
-  display: flex;
-  flex-direction: column;
-  max-height: 100%;
   overflow: hidden;
 `;
 
@@ -464,8 +477,8 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element | null {
           <Content>
             <P>{instructionalText}</P>
             {fileTableRows.length > 0 && (
-              <WithScrollButtons>
-                <CvrFileTable>
+              <CvrFileTableWrapper>
+                <Table>
                   <thead>
                     <tr>
                       <th>Saved At</th>
@@ -476,8 +489,8 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element | null {
                     </tr>
                   </thead>
                   <tbody>{fileTableRows}</tbody>
-                </CvrFileTable>
-              </WithScrollButtons>
+                </Table>
+              </CvrFileTableWrapper>
             )}
           </Content>
         }


### PR DESCRIPTION

## Overview

Fixes: #4327 

Instead of using `WithScrollButtons` - a touch-screen scroll component - make a desktop-style scrollable table for the CVR import modal table.

## Demo Video or Screenshot


Scrolling
https://github.com/votingworks/vxsuite/assets/530106/67c6c918-81a8-4a59-a09e-91fbcd25d743

No scrolling needed
<img width="960" alt="Screenshot 2023-12-04 at 3 30 56 PM" src="https://github.com/votingworks/vxsuite/assets/530106/dbcffae1-10f2-45fd-bfa3-f191778bfa1d">


## Testing Plan
Manual testing.

Also did a search to ensure `WithScrollButtons` isn't getting used anywhere else in a desktop app.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
