### PR TITLE
feat(grout): add serialization support for `Map` and `Set`

### DIFF
--- a/libs/grout/src/serialization.test.ts
+++ b/libs/grout/src/serialization.test.ts
@@ -38,6 +38,21 @@ test('JSON serialization/deserialization', () => {
   expectToBePreservedExactly([]);
   expectToBePreservedExactly([1, 2, 3]);
   expectToBePreservedExactly([1, true, null, 'a']);
+  // Basic maps
+  expectToBePreservedExactly(new Map());
+  expectToBePreservedExactly(new Map([['a', 1]]));
+  expectToBePreservedExactly(
+    new Map([
+      ['a', 1],
+      ['b', 2],
+    ])
+  );
+  expectToBePreservedExactly(new Map([['a', new Map([['b', 2]])]]));
+  // Basic sets
+  expectToBePreservedExactly(new Set());
+  expectToBePreservedExactly(new Set([1]));
+  expectToBePreservedExactly(new Set([1, 2]));
+  expectToBePreservedExactly(new Set([new Set([1, 2])]));
   // Nested data
   expectToBePreservedExactly({
     name: 'John',

--- a/libs/grout/src/serialization.ts
+++ b/libs/grout/src/serialization.ts
@@ -5,9 +5,11 @@ import {
   isArray,
   isBoolean,
   isFunction,
+  isMap,
   isNumber,
   isObject,
   isPlainObject,
+  isSet,
   isString,
 } from './util';
 
@@ -121,6 +123,20 @@ const bufferTagger: Tagger<Buffer, string> = {
   deserialize: (value) => Buffer.from(value, 'base64'),
 };
 
+const mapTagger: Tagger<Map<unknown, unknown>, Array<[unknown, unknown]>> = {
+  tag: 'Map',
+  shouldTag: isMap,
+  serialize: (value) => Array.from(value.entries()),
+  deserialize: (value) => new Map(value),
+};
+
+const setTagger: Tagger<Set<unknown>, unknown[]> = {
+  tag: 'Set',
+  shouldTag: isSet,
+  serialize: (value) => Array.from(value.values()),
+  deserialize: (value) => new Set(value),
+};
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const taggers: Array<Tagger<any, any>> = [
   undefinedTagger,
@@ -129,6 +145,8 @@ const taggers: Array<Tagger<any, any>> = [
   errorTagger,
   resultTagger,
   bufferTagger,
+  mapTagger,
+  setTagger,
 ];
 
 function tagValueIfNeeded(value: unknown): TaggedValue | unknown {

--- a/libs/grout/src/util.ts
+++ b/libs/grout/src/util.ts
@@ -29,6 +29,14 @@ export function isPlainObject(
   );
 }
 
+export function isMap(value: unknown): value is Map<unknown, unknown> {
+  return value instanceof Map;
+}
+
+export function isSet(value: unknown): value is Set<unknown> {
+  return value instanceof Set;
+}
+
 export function isFunction(
   value: unknown
 ): value is (...args: unknown[]) => unknown {


### PR DESCRIPTION
## Overview
It'd be nice to be able to use these types, especially if we start using `Map` instead of `Record`.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated.