### PR TITLE
refactor: replace `Object.fromEntries` with `Map`

### DIFF
--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -74,12 +74,10 @@ function ContestsTab(): JSX.Element | null {
     return matchesDistrict && matchesParty;
   });
 
-  const districtIdToName = Object.fromEntries(
+  const districtIdToName = new Map(
     districts.map((district) => [district.id, district.name])
   );
-  const partyIdToName = Object.fromEntries(
-    parties.map((party) => [party.id, party.name])
-  );
+  const partyIdToName = new Map(parties.map((party) => [party.id, party.name]));
 
   return (
     <TabPanel>
@@ -160,12 +158,12 @@ function ContestsTab(): JSX.Element | null {
                 <tr key={contest.id}>
                   <TD>{contest.title}</TD>
                   <TD>{contest.id}</TD>
-                  <TD nowrap>{districtIdToName[contest.districtId]}</TD>
+                  <TD nowrap>{districtIdToName.get(contest.districtId)}</TD>
                   {election.type === 'primary' && (
                     <TD nowrap>
                       {contest.type === 'candidate' &&
                         contest.partyId !== undefined &&
-                        partyIdToName[contest.partyId]}
+                        partyIdToName.get(contest.partyId)}
                     </TD>
                   )}
                   <TD nowrap>

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -322,7 +322,7 @@ function PrecinctsTab(): JSX.Element | null {
 
   const { precincts, election } = getElectionQuery.data;
 
-  const districtIdToName = Object.fromEntries(
+  const districtIdToName = new Map(
     election.districts.map((district) => [district.id, district.name])
   );
 
@@ -359,7 +359,7 @@ function PrecinctsTab(): JSX.Element | null {
                   <TD>
                     {'districtIds' in precinct &&
                       precinct.districtIds
-                        .map((districtId) => districtIdToName[districtId])
+                        .map((districtId) => districtIdToName.get(districtId))
                         .join(', ')}
                   </TD>
                   <TD>
@@ -384,7 +384,7 @@ function PrecinctsTab(): JSX.Element | null {
                   <TD>{split.id}</TD>
                   <TD>
                     {split.districtIds
-                      .map((districtId) => districtIdToName[districtId])
+                      .map((districtId) => districtIdToName.get(districtId))
                       .join(', ')}
                   </TD>
                   <TD />

--- a/libs/eslint-plugin-vx/src/rules/gts_no_unnecessary_has_own_property_check.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_no_unnecessary_has_own_property_check.ts
@@ -32,25 +32,23 @@ const rule: TSESLint.RuleModule<
       '[type=CallExpression] > MemberExpression.callee > MemberExpression.object[object.object.name="Object"][object.property.name="prototype"]' +
       ' > Identifier.property[name=hasOwnProperty]';
 
-    return Object.fromEntries(
-      [
-        `${forOfBlockIf}${hasOwnPropertyCall}`,
-        `${forOfIf}${hasOwnPropertyCall}`,
-        `${forOfBlockIf}${unaryNegation}${hasOwnPropertyCall}`,
-        `${forOfIf}${unaryNegation}${hasOwnPropertyCall}`,
-        `${forOfBlockIf}${hasOwnPropertyPrototypeCall}`,
-        `${forOfIf}${hasOwnPropertyPrototypeCall}`,
-        `${forOfBlockIf}${unaryNegation}${hasOwnPropertyPrototypeCall}`,
-        `${forOfIf}${unaryNegation}${hasOwnPropertyPrototypeCall}`,
-      ].map((pattern) => [
-        pattern,
-        (node: TSESTree.Node) =>
-          context.report({
-            node,
-            messageId: 'noUnnecessaryHasOwnPropertyCheck',
-          }),
-      ])
-    );
+    function report(node: TSESTree.Node) {
+      context.report({
+        node,
+        messageId: 'noUnnecessaryHasOwnPropertyCheck',
+      });
+    }
+
+    return {
+      [`${forOfBlockIf}${hasOwnPropertyCall}`]: report,
+      [`${forOfIf}${hasOwnPropertyCall}`]: report,
+      [`${forOfBlockIf}${unaryNegation}${hasOwnPropertyCall}`]: report,
+      [`${forOfIf}${unaryNegation}${hasOwnPropertyCall}`]: report,
+      [`${forOfBlockIf}${hasOwnPropertyPrototypeCall}`]: report,
+      [`${forOfIf}${hasOwnPropertyPrototypeCall}`]: report,
+      [`${forOfBlockIf}${unaryNegation}${hasOwnPropertyPrototypeCall}`]: report,
+      [`${forOfIf}${unaryNegation}${hasOwnPropertyPrototypeCall}`]: report,
+    };
   },
 });
 


### PR DESCRIPTION
## Overview
There are still a few instances of `Object.fromEntries` left, but these ones were the easy ones to convert. This is part of my exploration into how difficult it would be to convert uses of `Record` into `Map`.

## Demo Video or Screenshot
n/a

## Testing Plan
Existing automated tests.