### PR TITLE
fix(basics): make `IteratorPlus` predicates like `Array` predicates

### DIFF
--- a/libs/basics/src/iterators/async_iterator_plus.test.ts
+++ b/libs/basics/src/iterators/async_iterator_plus.test.ts
@@ -33,6 +33,13 @@ test('filter', async () => {
       .filter((n) => n % 2 === 0)
       .toArray()
   ).toEqual([2, 4]);
+  expect(
+    await iter(naturals())
+      .async()
+      .take(5)
+      .filter((n) => n % 2)
+      .toArray()
+  ).toEqual([1, 3, 5]);
 });
 
 test('count', async () => {
@@ -360,6 +367,11 @@ test('find', async () => {
       .async()
       .find((a) => a === 2)
   ).toEqual(2);
+  expect(
+    await iter([0, 1, 2])
+      .async()
+      .find((a) => a)
+  ).toEqual(1);
 });
 
 test('some', async () => {
@@ -377,6 +389,16 @@ test('some', async () => {
     await iter([1, 2, 3])
       .async()
       .some((a) => a === 2)
+  ).toEqual(true);
+  expect(
+    await iter([0])
+      .async()
+      .some((a) => a)
+  ).toEqual(false);
+  expect(
+    await iter([1])
+      .async()
+      .some((a) => a)
   ).toEqual(true);
 });
 
@@ -396,6 +418,16 @@ test('every', async () => {
       .async()
       .every((a) => a === 2)
   ).toEqual(false);
+  expect(
+    await iter([0, 1, 2])
+      .async()
+      .every((a) => a)
+  ).toEqual(false);
+  expect(
+    await iter([1, 2, 3])
+      .async()
+      .every((a) => a)
+  ).toEqual(true);
 });
 
 test('min', async () => {
@@ -485,6 +517,11 @@ test('partition', async () => {
       .async()
       .partition((a) => a % 2 === 0)
   ).toEqual([[2], [1, 3]]);
+  expect(
+    await iter([1, 2, 3])
+      .async()
+      .partition((a) => a % 2)
+  ).toEqual([[1, 3], [2]]);
 });
 
 test('windows', async () => {

--- a/libs/basics/src/iterators/async_iterator_plus.ts
+++ b/libs/basics/src/iterators/async_iterator_plus.ts
@@ -115,7 +115,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
     ) as AsyncIteratorPlus<[number, T]>;
   }
 
-  async every(predicate: (item: T) => MaybePromise<boolean>): Promise<boolean> {
+  async every(predicate: (item: T) => MaybePromise<unknown>): Promise<boolean> {
     for await (const it of this.iterable) {
       if (!(await predicate(it))) {
         return false;
@@ -124,7 +124,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
     return true;
   }
 
-  filter(fn: (value: T) => MaybePromise<boolean>): AsyncIteratorPlus<T> {
+  filter(fn: (value: T) => MaybePromise<unknown>): AsyncIteratorPlus<T> {
     const { iterable } = this;
     return new AsyncIteratorPlusImpl(
       (async function* gen() {
@@ -138,7 +138,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   }
 
   async find(
-    predicate: (item: T) => MaybePromise<boolean>
+    predicate: (item: T) => MaybePromise<unknown>
   ): Promise<T | undefined> {
     for await (const it of this.iterable) {
       if (await predicate(it)) {
@@ -218,7 +218,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
     return min;
   }
 
-  async partition(predicate: (item: T) => boolean): Promise<[T[], T[]]> {
+  async partition(predicate: (item: T) => unknown): Promise<[T[], T[]]> {
     const left = [];
     const right = [];
     for await (const it of this.iterable) {
@@ -243,7 +243,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
     ) as AsyncIteratorPlus<T>;
   }
 
-  async some(predicate: (item: T) => MaybePromise<boolean>): Promise<boolean> {
+  async some(predicate: (item: T) => MaybePromise<unknown>): Promise<boolean> {
     for await (const it of this.iterable) {
       if (await predicate(it)) {
         return true;

--- a/libs/basics/src/iterators/iterator_plus.test.ts
+++ b/libs/basics/src/iterators/iterator_plus.test.ts
@@ -24,6 +24,12 @@ test('filter', () => {
       .filter((n) => n % 2 === 0)
       .toArray()
   ).toEqual([2, 4]);
+  expect(
+    naturals()
+      .take(5)
+      .filter((n) => n % 2)
+      .toArray()
+  ).toEqual([1, 3, 5]);
 });
 
 test('count', () => {
@@ -258,18 +264,23 @@ test('find', () => {
   expect(iter([]).find(() => true)).toEqual(undefined);
   expect(iter([1]).find(() => true)).toEqual(1);
   expect(iter([1, 2, 3]).find((a) => a === 2)).toEqual(2);
+  expect(iter([0, 1, 2]).find((a) => a)).toEqual(1);
 });
 
 test('some', () => {
   expect(iter([]).some(() => true)).toEqual(false);
   expect(iter([1]).some(() => true)).toEqual(true);
   expect(iter([1, 2, 3]).some((a) => a === 2)).toEqual(true);
+  expect(iter([0]).some((a) => a)).toEqual(false);
+  expect(iter([1]).some((a) => a)).toEqual(true);
 });
 
 test('every', () => {
   expect(iter([]).every(() => true)).toEqual(true);
   expect(iter([1]).every(() => true)).toEqual(true);
   expect(iter([1, 2, 3]).every((a) => a === 2)).toEqual(false);
+  expect(iter([0, 1, 2]).every((a) => a)).toEqual(false);
+  expect(iter([1, 2, 3]).every((a) => a)).toEqual(true);
 });
 
 test('min', () => {
@@ -326,6 +337,7 @@ test('partition', () => {
   expect(iter([1]).partition(() => true)).toEqual([[1], []]);
   expect(iter([1, 2, 3]).partition(() => true)).toEqual([[1, 2, 3], []]);
   expect(iter([1, 2, 3]).partition((a) => a % 2 === 0)).toEqual([[2], [1, 3]]);
+  expect(iter([1, 2, 3]).partition((a) => a % 2)).toEqual([[1, 3], [2]]);
 });
 
 test('windows', () => {

--- a/libs/basics/src/iterators/iterator_plus.ts
+++ b/libs/basics/src/iterators/iterator_plus.ts
@@ -124,7 +124,7 @@ export class IteratorPlusImpl<T> implements IteratorPlus<T>, AsyncIterable<T> {
     );
   }
 
-  every(predicate: (item: T) => boolean): boolean {
+  every(predicate: (item: T) => unknown): boolean {
     for (const it of this.iterable) {
       if (!predicate(it)) {
         return false;
@@ -134,8 +134,8 @@ export class IteratorPlusImpl<T> implements IteratorPlus<T>, AsyncIterable<T> {
   }
 
   filter<U extends T>(fn: (value: T) => value is U): IteratorPlus<U>;
-  filter(fn: (value: T) => boolean): IteratorPlus<T>;
-  filter(fn: (value: T) => boolean): IteratorPlus<T> {
+  filter(fn: (value: T) => unknown): IteratorPlus<T>;
+  filter(fn: (value: T) => unknown): IteratorPlus<T> {
     const { iterable } = this;
     return new IteratorPlusImpl(
       (function* gen() {
@@ -148,7 +148,7 @@ export class IteratorPlusImpl<T> implements IteratorPlus<T>, AsyncIterable<T> {
     );
   }
 
-  find(predicate: (item: T) => boolean): T | undefined {
+  find(predicate: (item: T) => unknown): T | undefined {
     for (const it of this.iterable) {
       if (predicate(it)) {
         return it;
@@ -218,7 +218,7 @@ export class IteratorPlusImpl<T> implements IteratorPlus<T>, AsyncIterable<T> {
     return min;
   }
 
-  partition(predicate: (item: T) => boolean): [T[], T[]] {
+  partition(predicate: (item: T) => unknown): [T[], T[]] {
     const left = Array.of<T>();
     const right = Array.of<T>();
     for (const value of this.iterable) {
@@ -259,7 +259,7 @@ export class IteratorPlusImpl<T> implements IteratorPlus<T>, AsyncIterable<T> {
     );
   }
 
-  some(predicate: (item: T) => boolean): boolean {
+  some(predicate: (item: T) => unknown): boolean {
     for (const it of this.iterable) {
       if (predicate(it)) {
         return true;

--- a/libs/basics/src/iterators/types.ts
+++ b/libs/basics/src/iterators/types.ts
@@ -56,7 +56,7 @@ export interface IteratorPlus<T> extends Iterable<T> {
    * Determines if all elements satisfy `predicate`. Consumes the contained
    * iterable.
    */
-  every(predicate: (item: T) => boolean): boolean;
+  every(predicate: (item: T) => unknown): boolean;
 
   /**
    * Filters elements by applying `predicate` to each element.
@@ -66,13 +66,13 @@ export interface IteratorPlus<T> extends Iterable<T> {
   /**
    * Filters elements by applying `predicate` to each element.
    */
-  filter(fn: (value: T) => boolean): IteratorPlus<T>;
+  filter(fn: (value: T) => unknown): IteratorPlus<T>;
 
   /**
    * Finds an element that satisfies `predicate`. Consumes the contained
    * iterable until a matching element is found.
    */
-  find(predicate: (item: T) => boolean): T | undefined;
+  find(predicate: (item: T) => unknown): T | undefined;
 
   /**
    * Returns the first element of `this` or `undefined` if `this` is empty.
@@ -126,7 +126,7 @@ export interface IteratorPlus<T> extends Iterable<T> {
    * placed in the first group, and the rest are placed in the second group.
    * Consumes the entire contained iterable. Element order is preserved.
    */
-  partition(predicate: (item: T) => boolean): [T[], T[]];
+  partition(predicate: (item: T) => unknown): [T[], T[]];
 
   /**
    * Yields elements in reverse order. Consumes the entire contained iterable.
@@ -142,7 +142,7 @@ export interface IteratorPlus<T> extends Iterable<T> {
    * Determines whether any element satisfies `predicate`. Consumes the
    * contained iterable until a matching element is found.
    */
-  some(predicate: (item: T) => boolean): boolean;
+  some(predicate: (item: T) => unknown): boolean;
 
   /**
    * Sums elements from `this`. Consumes the entire contained iterable.
@@ -382,18 +382,18 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
    * Determines if all elements satisfy `predicate`. Consumes the contained
    * iterable.
    */
-  every(predicate: (item: T) => MaybePromise<boolean>): Promise<boolean>;
+  every(predicate: (item: T) => MaybePromise<unknown>): Promise<boolean>;
 
   /**
    * Filters elements from `iterable` by applying `predicate` to each element.
    */
-  filter(fn: (value: T) => MaybePromise<boolean>): AsyncIteratorPlus<T>;
+  filter(fn: (value: T) => MaybePromise<unknown>): AsyncIteratorPlus<T>;
 
   /**
    * Finds an element that satisfies `predicate`. Consumes the contained
    * iterable until a matching element is found.
    */
-  find(predicate: (item: T) => MaybePromise<boolean>): Promise<T | undefined>;
+  find(predicate: (item: T) => MaybePromise<unknown>): Promise<T | undefined>;
 
   /**
    * Returns the first element of `this` or `undefined` if `this` is empty.
@@ -442,7 +442,7 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
    * placed in the first group, and the rest are placed in the second group.
    * Consumes the entire contained iterable. Element order is preserved.
    */
-  partition(predicate: (item: T) => boolean): Promise<[T[], T[]]>;
+  partition(predicate: (item: T) => unknown): Promise<[T[], T[]]>;
 
   /**
    * Yields elements in reverse order. Consumes the entire contained iterable.
@@ -458,7 +458,7 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
    * Determines whether any element satisfies `predicate`. Consumes the
    * contained iterable until a matching element is found.
    */
-  some(predicate: (item: T) => MaybePromise<boolean>): Promise<boolean>;
+  some(predicate: (item: T) => MaybePromise<unknown>): Promise<boolean>;
 
   /**
    * Sums elements from `this`. Consumes the entire contained iterable.


### PR DESCRIPTION
## Overview
Predicates passed to e.g. `Array::filter` don't have to return `boolean`. They can return anything, and the truthiness of the value determines matches. This change brings the `IteratorPlus` predicates in line with that precedent.

## Demo Video or Screenshot
```ts
const candidates = [
  { name: 'Bob' },
  { name: 'MICKEY', isWriteIn: true },
] as const;

// previously, `c.isWriteIn === true` would be required since `isWriteIn` is `boolean | undefined`
console.log('Write-in candidate count:', iter(candidates).filter((c) => c.isWriteIn).count());
```

## Testing Plan
Additional unit tests.