### PR TITLE
refactor: use `IteratorPlus` helper methods

### DIFF
--- a/apps/admin/backend/src/cast_vote_records.ts
+++ b/apps/admin/backend/src/cast_vote_records.ts
@@ -12,6 +12,7 @@ import {
   assert,
   assertDefined,
   err,
+  iter,
   ok,
   Result,
   throwIllegalValue,
@@ -160,9 +161,9 @@ export async function listCastVoteRecordExportsOnUsbDrive(
       }
       const metadata = metadataResult.ok();
       castVoteRecordExportSummaries.push({
-        cvrCount: metadata.castVoteRecordReportMetadata.vxBatch
+        cvrCount: iter(metadata.castVoteRecordReportMetadata.vxBatch)
           .map((batch) => batch.NumberSheets)
-          .reduce((sum, n) => sum + n, 0),
+          .sum(),
         exportTimestamp: new Date(
           metadata.castVoteRecordReportMetadata.GeneratedDate
         ),

--- a/apps/admin/frontend/src/screens/manual_data_entry_screen.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_entry_screen.tsx
@@ -1,4 +1,10 @@
-import { assert, assertDefined, find, mapObject } from '@votingworks/basics';
+import {
+  assert,
+  assertDefined,
+  find,
+  iter,
+  mapObject,
+} from '@votingworks/basics';
 import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import styled from 'styled-components';
@@ -310,10 +316,9 @@ function getContestValidationState(
     contestResults.undervotes +
     (contestResults.contestType === 'yesno'
       ? contestResults.yesTally + contestResults.noTally
-      : Object.values(contestResults.tallies).reduce(
-          (acc, cur) => acc + cur.tally,
-          0
-        ));
+      : iter(Object.values(contestResults.tallies))
+          .map(({ tally }) => tally)
+          .sum());
 
   if (expectedVotes === 0 && enteredVotes === 0) return 'no-results';
 

--- a/apps/admin/frontend/src/screens/manual_data_summary_screen.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_summary_screen.tsx
@@ -1,4 +1,4 @@
-import { assert, find } from '@votingworks/basics';
+import { assert, find, iter } from '@votingworks/basics';
 import React, { useContext, useMemo, useState } from 'react';
 import styled from 'styled-components';
 
@@ -145,9 +145,9 @@ export function ManualDataSummaryScreen(): JSX.Element {
     );
   }, [getManualTallyMetadataQuery.data]);
   const hasManualTally = manualTallyMetadataRecords.length > 0;
-  const totalNumberBallotsEntered = manualTallyMetadataRecords
+  const totalNumberBallotsEntered = iter(manualTallyMetadataRecords)
     .map(({ ballotCount }) => ballotCount)
-    .reduce((total, current) => total + current, 0);
+    .sum();
 
   const [isClearingAll, setIsClearingAll] = useState(false);
 

--- a/apps/central-scan/backend/src/index.ts
+++ b/apps/central-scan/backend/src/index.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import * as dotenv from 'dotenv';
 import * as dotenvExpand from 'dotenv-expand';
 import { isIntegrationTest } from '@votingworks/utils';
+import { iter } from '@votingworks/basics';
 import { MOCK_SCANNER_FILES, NODE_ENV } from './globals';
 import { LoopScanner, parseBatchesFromEnv } from './loop_scanner';
 import { BatchScanner } from './fujitsu_scanner';
@@ -43,10 +44,9 @@ function getScanner(): BatchScanner | undefined {
   const mockScannerFiles = parseBatchesFromEnv(MOCK_SCANNER_FILES);
   if (!mockScannerFiles) return undefined;
   process.stdout.write(
-    `Using mock scanner that scans ${mockScannerFiles.reduce(
-      (count, sheets) => count + sheets.length,
-      0
-    )} sheet(s) in ${mockScannerFiles.length} batch(es) repeatedly.\n`
+    `Using mock scanner that scans ${iter(mockScannerFiles)
+      .map((sheets) => sheets.length)
+      .sum()} sheet(s) in ${mockScannerFiles.length} batch(es) repeatedly.\n`
   );
   return new LoopScanner(mockScannerFiles);
 }

--- a/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
@@ -4,6 +4,7 @@ import { Scan } from '@votingworks/api';
 import { Button, Font, Icons, P, TD, Table } from '@votingworks/ui';
 import { BatchInfo } from '@votingworks/types';
 import styled from 'styled-components';
+import { iter } from '@votingworks/basics';
 import { DeleteBatchModal } from '../components/delete_batch_modal';
 import { NavigationScreen } from '../navigation_screen';
 import { ExportResultsModal } from '../components/export_results_modal';
@@ -49,7 +50,9 @@ export function ScanBallotsScreen({
 }: ScanBallotsScreenProps): JSX.Element {
   const { batches } = status;
   const batchCount = batches.length;
-  const ballotCount = batches.reduce((result, b) => result + b.count, 0);
+  const ballotCount = iter(batches)
+    .map((b) => b.count)
+    .sum();
 
   const [pendingDeleteBatch, setPendingDeleteBatch] = useState<BatchInfo>();
   let exportButtonTitle;

--- a/libs/backend/src/cast_vote_records/build_cast_vote_record.ts
+++ b/libs/backend/src/cast_vote_records/build_cast_vote_record.ts
@@ -225,10 +225,9 @@ function buildCVRCandidateContest({
     );
   }
 
-  const numWriteIns = vote.reduce(
-    (count, choice) => count + (choice.isWriteIn ? 1 : 0),
-    0
-  );
+  const numWriteIns = iter(vote)
+    .filter((choice) => choice.isWriteIn)
+    .count();
 
   // Write-ins on hand-marked paper ballots are have Id's indexed according to
   // their position on the ballot. For machine-marked ballots the Id's are not

--- a/libs/backend/src/cast_vote_records/build_report_metadata.test.ts
+++ b/libs/backend/src/cast_vote_records/build_report_metadata.test.ts
@@ -1,4 +1,4 @@
-import { assert, find } from '@votingworks/basics';
+import { assert, find, iter } from '@votingworks/basics';
 import { electionTwoPartyPrimaryDefinition } from '@votingworks/fixtures';
 import { CandidateContest, CVR, YesNoContest } from '@votingworks/types';
 import { buildCastVoteRecordReportMetadata } from './build_report_metadata';
@@ -110,9 +110,9 @@ test('builds well-formed cast vote record report', () => {
     (contest): contest is CandidateContest => contest.type === 'candidate'
   );
   expect(ReportElection.Candidate?.length).toEqual(
-    candidateContests
+    iter(candidateContests)
       .map((contest) => contest.candidates.length)
-      .reduce((prev, cur) => prev + cur, 0)
+      .sum()
   );
   for (const candidate of candidateContests.flatMap(
     (contest) => contest.candidates

--- a/libs/ballot-encoder/src/index.ts
+++ b/libs/ballot-encoder/src/index.ts
@@ -21,7 +21,7 @@ import {
   YesNoContest,
   YesNoVote,
 } from '@votingworks/types';
-import { assert } from '@votingworks/basics';
+import { assert, iter } from '@votingworks/basics';
 import {
   BitReader,
   BitWriter,
@@ -284,10 +284,9 @@ function encodeBallotVotesInto(
 
         if (contest.allowWriteIns) {
           // write write-in data
-          const writeInCount = choices.reduce(
-            (count, choice) => count + (choice.isWriteIn ? 1 : 0),
-            0
-          );
+          const writeInCount = iter(choices)
+            .filter((choice) => choice.isWriteIn)
+            .count();
           const nonWriteInCount = choices.length - writeInCount;
           const maximumWriteIns = Math.max(0, contest.seats - nonWriteInCount);
 

--- a/libs/basics/src/iterators/async_iterator_plus.test.ts
+++ b/libs/basics/src/iterators/async_iterator_plus.test.ts
@@ -453,6 +453,49 @@ test('min', async () => {
   );
 });
 
+test('minBy', async () => {
+  expect(
+    await iter([])
+      .async()
+      .minBy(() => 0)
+  ).toEqual(undefined);
+  expect(
+    await iter([1])
+      .async()
+      .minBy(() => 0)
+  ).toEqual(1);
+  expect(
+    await iter([1, 1, 1])
+      .async()
+      .minBy(() => 0)
+  ).toEqual(1);
+  expect(
+    await iter([1, 2, 3])
+      .async()
+      .minBy(() => 0)
+  ).toEqual(1);
+  expect(
+    await iter([{ t: 1 }, { t: 2 }])
+      .async()
+      .minBy((a) => a.t)
+  ).toEqual({ t: 1 });
+  expect(
+    await iter([{ t: 1 }, { t: 2 }])
+      .async()
+      .minBy((a) => -a.t)
+  ).toEqual({ t: 2 });
+
+  await fc.assert(
+    fc.asyncProperty(fc.array(fc.integer(), { minLength: 1 }), async (arr) => {
+      expect(
+        await iter(arr)
+          .async()
+          .minBy((a) => a)
+      ).toEqual(Math.min(...arr));
+    })
+  );
+});
+
 test('max', async () => {
   expect(await iter([]).async().max()).toEqual(undefined);
   expect(await iter([1]).async().max()).toEqual(1);
@@ -474,6 +517,34 @@ test('max', async () => {
       expect(await iter(arr).async().max()).toEqual(Math.max(...arr));
     })
   );
+});
+
+test('maxBy', async () => {
+  expect(
+    await iter([])
+      .async()
+      .maxBy(() => 0)
+  ).toEqual(undefined);
+  expect(
+    await iter([1])
+      .async()
+      .maxBy(() => 0)
+  ).toEqual(1);
+  expect(
+    await iter([1, 1, 1])
+      .async()
+      .maxBy(() => 0)
+  ).toEqual(1);
+  expect(
+    await iter([1, 2, 3])
+      .async()
+      .maxBy((a) => a)
+  ).toEqual(3);
+  expect(
+    await iter([{ t: 1 }, { t: 2 }])
+      .async()
+      .maxBy((a) => a.t)
+  ).toEqual({ t: 2 });
 });
 
 test('sum', async () => {

--- a/libs/basics/src/iterators/async_iterator_plus.ts
+++ b/libs/basics/src/iterators/async_iterator_plus.ts
@@ -203,6 +203,10 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
     return this.min((a, b) => compareFn(b, a));
   }
 
+  maxBy(fn: (item: T) => MaybePromise<number>): Promise<T | undefined> {
+    return this.minBy(async (item) => -(await fn(item)));
+  }
+
   min(): Promise<T extends number ? T | undefined : unknown>;
   min(compareFn: (a: T, b: T) => MaybePromise<number>): Promise<T | undefined>;
   async min(
@@ -216,6 +220,19 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
       }
     }
     return min;
+  }
+
+  async minBy(fn: (item: T) => MaybePromise<number>): Promise<T | undefined> {
+    let min: number | undefined;
+    let minItem: T | undefined;
+    for await (const it of this.iterable) {
+      const value = await fn(it);
+      if (min === undefined || value < min) {
+        min = value;
+        minItem = it;
+      }
+    }
+    return minItem;
   }
 
   async partition(predicate: (item: T) => unknown): Promise<[T[], T[]]> {

--- a/libs/basics/src/iterators/iterator_plus.test.ts
+++ b/libs/basics/src/iterators/iterator_plus.test.ts
@@ -302,6 +302,14 @@ test('min', () => {
   typedAs<number | undefined>(iter(['a']).min());
 });
 
+test('minBy', () => {
+  expect(iter([]).minBy(() => 0)).toEqual(undefined);
+  expect(iter([1]).minBy(() => 0)).toEqual(1);
+  expect(iter([1, 1, 1]).minBy(() => 0)).toEqual(1);
+  expect(iter([1, 2, 3]).minBy((a) => a)).toEqual(1);
+  expect(iter([{ t: 1 }, { t: 2 }]).minBy((a) => a.t)).toEqual({ t: 1 });
+});
+
 test('max', () => {
   expect(iter([]).max()).toEqual(undefined);
   expect(iter([1]).max()).toEqual(1);
@@ -316,6 +324,14 @@ test('max', () => {
       expect(iter(arr).max()).toEqual(Math.max(...arr));
     })
   );
+});
+
+test('maxBy', () => {
+  expect(iter([]).maxBy(() => 0)).toEqual(undefined);
+  expect(iter([1]).maxBy(() => 0)).toEqual(1);
+  expect(iter([1, 1, 1]).maxBy(() => 0)).toEqual(1);
+  expect(iter([1, 2, 3]).maxBy((a) => a)).toEqual(3);
+  expect(iter([{ t: 1 }, { t: 2 }]).maxBy((a) => a.t)).toEqual({ t: 2 });
 });
 
 test('sum', () => {

--- a/libs/basics/src/iterators/iterator_plus.ts
+++ b/libs/basics/src/iterators/iterator_plus.ts
@@ -204,6 +204,10 @@ export class IteratorPlusImpl<T> implements IteratorPlus<T>, AsyncIterable<T> {
     return this.min((a, b) => compareFn(b, a));
   }
 
+  maxBy(fn: (item: T) => number): T | undefined {
+    return this.minBy((item) => -fn(item));
+  }
+
   min(): T extends number ? T | undefined : unknown;
   min(compareFn?: (a: T, b: T) => number): T | undefined;
   min(
@@ -216,6 +220,19 @@ export class IteratorPlusImpl<T> implements IteratorPlus<T>, AsyncIterable<T> {
       }
     }
     return min;
+  }
+
+  minBy(fn: (item: T) => number): T | undefined {
+    let min: number | undefined;
+    let minItem: T | undefined;
+    for (const it of this.iterable) {
+      const value = fn(it);
+      if (min === undefined || value < min) {
+        min = value;
+        minItem = it;
+      }
+    }
+    return minItem;
   }
 
   partition(predicate: (item: T) => unknown): [T[], T[]] {

--- a/libs/basics/src/iterators/types.ts
+++ b/libs/basics/src/iterators/types.ts
@@ -109,6 +109,13 @@ export interface IteratorPlus<T> extends Iterable<T> {
   max(compareFn: (a: T, b: T) => number): T | undefined;
 
   /**
+   * Returns the element of `this` whose return value from `fn` is the maximum.
+   * Returns `undefined` if `this` is empty. Comparison happens using `>` on the
+   * return values of `fn`. Consumes the entire contained iterable.
+   */
+  maxBy(fn: (item: T) => number): T | undefined;
+
+  /**
    * Returns the minimum element of `this` or `undefined` if `this` is empty.
    * Consumes the entire contained iterable.
    */
@@ -120,6 +127,13 @@ export interface IteratorPlus<T> extends Iterable<T> {
    * iterable.
    */
   min(compareFn: (a: T, b: T) => number): T | undefined;
+
+  /**
+   * Returns the element of `this` whose return value from `fn` is the minimum.
+   * Returns `undefined` if `this` is empty. Comparison happens using `<` on the
+   * return values of `fn`. Consumes the entire contained iterable.
+   */
+  minBy(fn: (item: T) => number): T | undefined;
 
   /**
    * Partitions elements into two groups. Elements that satisfy `predicate` are
@@ -431,11 +445,25 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
   max(compareFn?: (a: T, b: T) => MaybePromise<number>): Promise<T | undefined>;
 
   /**
+   * Returns the element of `this` whose return value from `fn` is the maximum.
+   * Returns `undefined` if `this` is empty. Comparison happens using `>` on the
+   * return values of `fn`. Consumes the entire contained iterable.
+   */
+  maxBy(fn: (item: T) => MaybePromise<number>): Promise<T | undefined>;
+
+  /**
    * Returns the minimum element of `this` or `undefined` if `this` is empty.
    * Comparison happens using `compareFn` if provided, otherwise using `>` and
    * `<`. Consumes the entire contained iterable.
    */
   min(compareFn?: (a: T, b: T) => MaybePromise<number>): Promise<T | undefined>;
+
+  /**
+   * Returns the element of `this` whose return value from `fn` is the minimum.
+   * Returns `undefined` if `this` is empty. Comparison happens using `<` on the
+   * return values of `fn`. Consumes the entire contained iterable.
+   */
+  minBy(fn: (item: T) => MaybePromise<number>): Promise<T | undefined>;
 
   /**
    * Partitions elements into two groups. Elements that satisfy `predicate` are

--- a/libs/converter-nh-accuvote/jest.config.js
+++ b/libs/converter-nh-accuvote/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
   ...shared,
   coverageThreshold: {
     global: {
-      branches: -72,
+      branches: -74,
       lines: -35,
     },
   },

--- a/libs/converter-nh-accuvote/test/utils.ts
+++ b/libs/converter-nh-accuvote/test/utils.ts
@@ -1,3 +1,5 @@
+import { iter } from '@votingworks/basics';
+
 /**
  * Minimal information about a bubble position.
  */
@@ -11,14 +13,14 @@ export interface Bubble {
  */
 export function asciiBubbleGrid(bubbles: Iterable<Bubble>): string {
   const allBubbles = [...bubbles];
-  const maxColumn = allBubbles.reduce(
-    (max, bubble) => Math.max(max, bubble.column),
-    0
-  );
-  const maxRow = allBubbles.reduce(
-    (max, bubble) => Math.max(max, bubble.row),
-    0
-  );
+  const maxColumn =
+    iter(allBubbles)
+      .map((bubble) => bubble.column)
+      .max() ?? 0;
+  const maxRow =
+    iter(allBubbles)
+      .map((bubble) => bubble.row)
+      .max() ?? 0;
 
   let result = '';
   for (let row = 0; row <= maxRow; row += 1) {

--- a/libs/cvr-fixture-generator/src/generate_cvrs.ts
+++ b/libs/cvr-fixture-generator/src/generate_cvrs.ts
@@ -90,10 +90,10 @@ function getVoteConfigurations(
   optionsForEachContest: ReadonlyMap<ContestId, readonly Vote[]>
 ): VotesDict[] {
   // Find the contest with the most vote combinations generated to determine the number of vote combinations to generate.
-  const numOptionsToProduce = [...optionsForEachContest.values()].reduce(
-    (prev, options) => Math.max(prev, options.length),
-    0
-  );
+  const numOptionsToProduce =
+    iter(optionsForEachContest.values())
+      .map((options) => options.length)
+      .max() ?? 0;
   const voteOptions: VotesDict[] = [];
   for (let i = 0; i < numOptionsToProduce; i += 1) {
     const voteOption: VotesDict = {};

--- a/libs/test-utils/src/console.ts
+++ b/libs/test-utils/src/console.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { MaybePromise, Optional, assert } from '@votingworks/basics';
+import { MaybePromise, Optional, assert, iter } from '@votingworks/basics';
 
 const capturedCallCountsByTest = new Map<
   string,
@@ -25,10 +25,10 @@ function printLinesInBox(lines: string[], out: NodeJS.WritableStream) {
   const boxBottomLeft = '└';
   const boxBottomRight = '┘';
 
-  const longestLine = lines.reduce(
-    (longest, line) => Math.max(longest, stripAnsi(line).length),
-    0
-  );
+  const longestLine =
+    iter(lines)
+      .map((line) => stripAnsi(line).length)
+      .max() ?? 0;
 
   const boxTop = `${boxTopLeft}${boxTopAndBottom.repeat(
     longestLine + 2

--- a/libs/utils/src/tabulation/tabulation.ts
+++ b/libs/utils/src/tabulation/tabulation.ts
@@ -1,4 +1,9 @@
-import { assert, assertDefined, throwIllegalValue } from '@votingworks/basics';
+import {
+  assert,
+  assertDefined,
+  iter,
+  throwIllegalValue,
+} from '@votingworks/basics';
 import {
   AnyContest,
   BallotStyleId,
@@ -488,7 +493,9 @@ export function getScannedBallotCount(
 export function getSheetCount(cardCounts: Tabulation.CardCounts): number {
   return (
     cardCounts.bmd +
-    cardCounts.hmpb.reduce((acc: number, count) => acc + (count ?? 0), 0)
+    iter(cardCounts.hmpb)
+      .map((c) => c ?? 0)
+      .sum()
   );
 }
 
@@ -618,10 +625,9 @@ export function combineManualElectionResults({
   election: Election;
   allManualResults: Tabulation.ManualElectionResults[];
 }): Tabulation.ManualElectionResults {
-  const ballotCount = allManualResults.reduce(
-    (count, results) => count + results.ballotCount,
-    0
-  );
+  const ballotCount = iter(allManualResults)
+    .map((results) => results.ballotCount)
+    .sum();
 
   const electionContestResults = combineElectionContestResults({
     election,

--- a/libs/utils/src/tabulation/tally_reports.ts
+++ b/libs/utils/src/tabulation/tally_reports.ts
@@ -4,7 +4,7 @@ import {
   CandidateId,
   Tabulation,
 } from '@votingworks/types';
-import { assertDefined } from '@votingworks/basics';
+import { assertDefined, iter } from '@votingworks/basics';
 import { combineCandidateContestResults } from './tabulation';
 
 type TallyReportCandidateRow = Candidate & {
@@ -76,19 +76,15 @@ function getInsignificantWriteInCount({
   contestResults: Tabulation.CandidateContestResults;
   significantWriteInCandidateIds: CandidateId[];
 }): number {
-  return Object.values(contestResults.tallies).reduce(
-    (aggregateCount: number, candidateTally: Tabulation.CandidateTally) => {
-      if (
+  return iter(Object.values(contestResults.tallies))
+    .filter(
+      (candidateTally) =>
         candidateTally.isWriteIn &&
         !isNonCandidateWriteInTally(candidateTally) &&
         !significantWriteInCandidateIds.includes(candidateTally.id)
-      ) {
-        return aggregateCount + candidateTally.tally;
-      }
-      return aggregateCount;
-    },
-    0
-  );
+    )
+    .map((candidateTally) => candidateTally.tally)
+    .sum();
 }
 
 function getAggregatedWriteInRows({

--- a/libs/utils/src/tabulation/transformations.test.ts
+++ b/libs/utils/src/tabulation/transformations.test.ts
@@ -1,4 +1,5 @@
 import { Tabulation } from '@votingworks/types';
+import { iter } from '@votingworks/basics';
 import {
   coalesceGroupsAcrossParty,
   groupMapToGroupList,
@@ -105,10 +106,9 @@ test('coalesceGroupsAcrossParty', () => {
     { groupByPrecinct: true },
     (partyBallotCounts) => {
       return {
-        ballotCount: partyBallotCounts.reduce(
-          (sum, { ballotCount }) => sum + ballotCount,
-          0
-        ),
+        ballotCount: iter(partyBallotCounts)
+          .map(({ ballotCount }) => ballotCount)
+          .sum(),
       };
     }
   );


### PR DESCRIPTION
## Overview
Adds `maxBy` and `minBy` helper methods and updates some places to use them as well as the existing `sum` and `count` methods.

## Demo Video or Screenshot
```ts
async function getOldestFile(paths: string[]): Promise<Optional<string>> {
  return await iter(paths)
    .async()
    .minBy(async (path) =>
      (await fs.lstat(path)).ctime.getTime()
    );
}
```

## Testing Plan
- [x] New automated tests for new helpers.
- [x] Existing automated tests for updated code.
