### PR TITLE
Manual tally entry polish

### DIFF
--- a/apps/admin/frontend/jest.config.js
+++ b/apps/admin/frontend/jest.config.js
@@ -15,8 +15,8 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: -116,
-      lines: -147,
+      branches: -113,
+      lines: -143,
     },
   },
   moduleFileExtensions: [

--- a/apps/admin/frontend/src/components/remove_all_manual_tallies_modal.tsx
+++ b/apps/admin/frontend/src/components/remove_all_manual_tallies_modal.tsx
@@ -13,8 +13,7 @@ export function RemoveAllManualTalliesModal({
   const deleteAllManualTalliesMutation = deleteAllManualResults.useMutation();
 
   function onConfirm() {
-    deleteAllManualTalliesMutation.mutate();
-    onClose();
+    deleteAllManualTalliesMutation.mutate(undefined, { onSuccess: onClose });
   }
   return (
     <Modal
@@ -26,7 +25,12 @@ export function RemoveAllManualTalliesModal({
       }
       actions={
         <React.Fragment>
-          <Button icon="Delete" variant="danger" onPress={onConfirm}>
+          <Button
+            icon="Delete"
+            variant="danger"
+            onPress={onConfirm}
+            disabled={deleteAllManualTalliesMutation.isLoading}
+          >
             Remove All Manual Tallies
           </Button>
           <Button onPress={onClose}>Cancel</Button>

--- a/apps/admin/frontend/src/screens/manual_data_entry_screen.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_entry_screen.tsx
@@ -95,21 +95,8 @@ const ContestData = styled(Card)`
   background: ${(p) => p.theme.colors.background};
 
   h3 {
-    margin-top: 0;
-    margin-bottom: 0.5em;
-
-    & + p {
-      margin-top: -0.8em;
-      margin-bottom: 0.25em;
-    }
-
-    & + table {
-      margin-top: -0.5em;
-    }
-  }
-
-  p:first-child {
-    margin-bottom: 0;
+    margin-top: 0 !important;
+    margin-bottom: 0.25rem;
   }
 `;
 
@@ -598,13 +585,8 @@ function ManualResultsDataEntryScreenForm({
 
             return (
               <ContestData key={contest.id}>
-                <P>
-                  <Caption>{getContestDistrictName(election, contest)}</Caption>
-                </P>
-
-                <div>
-                  <H3>{contest.title}</H3>
-                </div>
+                <Caption>{getContestDistrictName(election, contest)}</Caption>
+                <H3>{contest.title}</H3>
                 <P>
                   {contestValidationState === 'no-results' ? (
                     <Icons.Info />

--- a/apps/admin/frontend/src/screens/manual_data_entry_screen.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_entry_screen.tsx
@@ -17,8 +17,6 @@ import {
 } from '@votingworks/types';
 import {
   Button,
-  Table,
-  TD,
   LinkButton,
   Icons,
   P,
@@ -27,6 +25,7 @@ import {
   Caption,
   LabelledText,
   H1,
+  Font,
 } from '@votingworks/ui';
 import {
   isElectionManagerAuth,
@@ -108,16 +107,6 @@ const ContestData = styled(Card)`
   p:first-child {
     margin-bottom: 0;
   }
-
-  tbody tr:first-child {
-    border-top: ${(p) => p.theme.sizes.bordersRem.thin}rem solid
-      ${(p) => p.theme.colors.outline};
-  }
-
-  tfoot td {
-    border-bottom: unset;
-    padding-top: 0.5em;
-  }
 `;
 
 const TallyInput = styled.input`
@@ -125,27 +114,19 @@ const TallyInput = styled.input`
   text-align: center;
 `;
 
-function ContestDataRow({
-  label,
-  onRemove,
-  children,
-  testId,
-}: {
-  label: string | React.ReactNode;
-  onRemove?: VoidFunction;
-  children: React.ReactNode;
-  testId: string;
-}) {
-  return (
-    <tr data-testid={testId}>
-      <TD narrow>{children}</TD>
-      <TD>{label}</TD>
-      <TD textAlign="right">
-        {onRemove && <Button onPress={onRemove}>Remove</Button>}
-      </TD>
-    </tr>
-  );
-}
+const ContestDataRow = styled.div`
+  border-top: ${(p) => p.theme.sizes.bordersRem.thin}rem solid
+    ${(p) => p.theme.colors.outline};
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0;
+
+  &:last-child {
+    border-bottom: ${(p) => p.theme.sizes.bordersRem.thin}rem solid
+      ${(p) => p.theme.colors.outline};
+  }
+`;
 
 function AddWriteInRow({
   addWriteInCandidate,
@@ -166,51 +147,44 @@ function AddWriteInRow({
 
   if (isAddingWriteIn) {
     return (
-      <tr>
-        <TD narrow textAlign="center">
-          <Button
-            variant="primary"
-            onPress={onAdd}
-            disabled={
-              writeInName.length === 0 ||
-              disallowedCandidateNames.includes(
-                normalizeWriteInName(writeInName)
-              )
+      <ContestDataRow>
+        <input
+          // eslint-disable-next-line jsx-a11y/no-autofocus
+          autoFocus
+          defaultValue=""
+          data-testid={`${contestId}-write-in-input`}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setWriteInName(e.target.value)
+          }
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              onAdd();
             }
-          >
-            Add
-          </Button>
-        </TD>
-        <TD>
-          <div style={{ display: 'flex', gap: '0.5rem' }}>
-            <input
-              defaultValue=""
-              data-testid={`${contestId}-write-in-input`}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setWriteInName(e.target.value)
-              }
-              onKeyDown={(event) => {
-                if (event.key === 'Enter') {
-                  onAdd();
-                }
-              }}
-              style={{ flexGrow: 1 }}
-            />
-            <Button onPress={() => setIsAddingWriteIn(false)}>Cancel</Button>
-          </div>
-        </TD>
-      </tr>
+          }}
+          style={{ flexGrow: 1 }}
+        />
+        <Button
+          icon="Add"
+          variant="primary"
+          onPress={onAdd}
+          disabled={
+            writeInName.length === 0 ||
+            disallowedCandidateNames.includes(normalizeWriteInName(writeInName))
+          }
+        >
+          Add
+        </Button>
+        <Button onPress={() => setIsAddingWriteIn(false)}>Cancel</Button>
+      </ContestDataRow>
     );
   }
 
   return (
-    <tr>
-      <TD colSpan={3}>
-        <Button onPress={() => setIsAddingWriteIn(true)}>
-          Add Write-In Candidate
-        </Button>
-      </TD>
-    </tr>
+    <ContestDataRow>
+      <Button icon="Add" onPress={() => setIsAddingWriteIn(true)}>
+        Add Write-In Candidate
+      </Button>
+    </ContestDataRow>
   );
 }
 
@@ -611,7 +585,7 @@ export function ManualDataEntryScreen(): JSX.Element | null {
       </TaskControls>
       <TaskContent>
         <ContestsContainer>
-          {currentContests.map((contest) => {
+          {currentContests.map((contest, i) => {
             const contestWriteInCandidates = writeInCandidates.filter(
               ({ contestId }) => contestId === contest.id
             );
@@ -652,165 +626,172 @@ export function ManualDataEntryScreen(): JSX.Element | null {
                     ? 'Entered tallies do not match total ballots cast'
                     : 'Entered tallies are valid'}
                 </P>
-                <Table condensed>
-                  <tbody>
-                    <ContestDataRow
-                      label={<P weight="bold">Total Ballots Cast</P>}
-                      testId={`${contest.id}-numBallots`}
-                    >
-                      <TallyInput
-                        name={`${contest.id}-numBallots`}
-                        data-testid={`${contest.id}-numBallots-input`}
-                        value={getValueForInput(contest.id, 'numBallots')}
-                        onChange={(e) =>
-                          updateContestData(contest.id, 'numBallots', e)
-                        }
-                      />
-                    </ContestDataRow>
-                    <ContestDataRow
-                      label={<P>undervotes</P>}
-                      testId={`${contest.id}-undervotes`}
-                    >
-                      <TallyInput
-                        name={`${contest.id}-undervotes`}
-                        data-testid={`${contest.id}-undervotes-input`}
-                        value={getValueForInput(contest.id, 'undervotes')}
-                        onChange={(e) =>
-                          updateContestData(contest.id, 'undervotes', e)
-                        }
-                      />
-                    </ContestDataRow>
-                    <ContestDataRow
-                      label={<P>overvotes</P>}
-                      testId={`${contest.id}-overvotes`}
-                    >
-                      <TallyInput
-                        name={`${contest.id}-overvotes`}
-                        data-testid={`${contest.id}-overvotes-input`}
-                        value={getValueForInput(contest.id, 'overvotes')}
-                        onChange={(e) =>
-                          updateContestData(contest.id, 'overvotes', e)
-                        }
-                      />
-                    </ContestDataRow>
-                    {contest.type === 'candidate' && (
-                      <React.Fragment>
-                        {contest.candidates
-                          .filter((c) => !c.isWriteIn)
-                          .map((candidate) => (
-                            <ContestDataRow
-                              key={candidate.id}
-                              label={candidate.name}
-                              testId={`${contest.id}-${candidate.id}`}
-                            >
-                              <TallyInput
-                                name={`${contest.id}-${candidate.id}`}
-                                data-testid={`${contest.id}-${candidate.id}-input`}
-                                value={getValueForInput(
-                                  contest.id,
-                                  candidate.id
-                                )}
-                                onChange={(e) =>
-                                  updateContestData(contest.id, candidate.id, e)
-                                }
-                              />
-                            </ContestDataRow>
-                          ))}
-                        {contestWriteInCandidates.map((candidate) => (
-                          <ContestDataRow
-                            key={candidate.id}
-                            label={`${candidate.name} (write-in)`}
-                            testId={`${contest.id}-${candidate.id}`}
-                          >
-                            <TallyInput
-                              name={`${contest.id}-${candidate.id}`}
-                              data-testid={`${contest.id}-${candidate.id}-input`}
-                              value={getValueForInput(contest.id, candidate.id)}
-                              onChange={(e) =>
-                                updateContestData(
-                                  contest.id,
-                                  candidate.id,
-                                  e,
-                                  candidate.name
-                                )
-                              }
-                            />
-                          </ContestDataRow>
-                        ))}
-                        {contestTempWriteInCandidates.map((candidate) => (
-                          <ContestDataRow
-                            key={candidate.id}
-                            label={`${candidate.name} (write-in)`}
-                            testId={`${contest.id}-${candidate.id}`}
-                            onRemove={() => {
-                              removeTempWriteInCandidate(
-                                candidate.id,
-                                contest.id
-                              );
-                            }}
-                          >
-                            <TallyInput
-                              name={`${contest.id}-${candidate.id}`}
-                              data-testid={`${contest.id}-${candidate.id}-input`}
-                              value={getValueForInput(contest.id, candidate.id)}
-                              onChange={(e) =>
-                                updateContestData(
-                                  contest.id,
-                                  candidate.id,
-                                  e,
-                                  candidate.name
-                                )
-                              }
-                            />
-                          </ContestDataRow>
-                        ))}
-                      </React.Fragment>
-                    )}
-                    {contest.type === 'yesno' && (
-                      <React.Fragment>
+                <ContestDataRow data-testid={`${contest.id}-numBallots`}>
+                  <TallyInput
+                    autoFocus={i === 0}
+                    id={`${contest.id}-numBallots`}
+                    data-testid={`${contest.id}-numBallots-input`}
+                    value={getValueForInput(contest.id, 'numBallots')}
+                    onChange={(e) =>
+                      updateContestData(contest.id, 'numBallots', e)
+                    }
+                  />
+                  <label htmlFor={`${contest.id}-numBallots`}>
+                    <Font weight="bold">Total Ballots Cast</Font>
+                  </label>
+                </ContestDataRow>
+                <ContestDataRow data-testid={`${contest.id}-undervotes`}>
+                  <TallyInput
+                    id={`${contest.id}-undervotes`}
+                    data-testid={`${contest.id}-undervotes-input`}
+                    value={getValueForInput(contest.id, 'undervotes')}
+                    onChange={(e) =>
+                      updateContestData(contest.id, 'undervotes', e)
+                    }
+                  />
+                  <label htmlFor={`${contest.id}-undervotes`}>undervotes</label>
+                </ContestDataRow>
+                <ContestDataRow data-testid={`${contest.id}-overvotes`}>
+                  <TallyInput
+                    id={`${contest.id}-overvotes`}
+                    data-testid={`${contest.id}-overvotes-input`}
+                    value={getValueForInput(contest.id, 'overvotes')}
+                    onChange={(e) =>
+                      updateContestData(contest.id, 'overvotes', e)
+                    }
+                  />
+                  <label htmlFor={`${contest.id}-overvotes`}>overvotes</label>
+                </ContestDataRow>
+                {contest.type === 'candidate' && (
+                  <React.Fragment>
+                    {contest.candidates
+                      .filter((c) => !c.isWriteIn)
+                      .map((candidate) => (
                         <ContestDataRow
-                          label="Yes"
-                          testId={`${contest.id}-${contest.yesOption.id}`}
+                          key={candidate.id}
+                          data-testid={`${contest.id}-${candidate.id}`}
                         >
                           <TallyInput
-                            name={`${contest.id}-yes`}
-                            data-testid={`${contest.id}-${contest.yesOption.id}-input`}
-                            value={getValueForInput(contest.id, 'yesTally')}
+                            id={`${contest.id}-${candidate.id}`}
+                            data-testid={`${contest.id}-${candidate.id}-input`}
+                            value={getValueForInput(contest.id, candidate.id)}
                             onChange={(e) =>
-                              updateContestData(contest.id, 'yesTally', e)
+                              updateContestData(contest.id, candidate.id, e)
                             }
                           />
+                          <label htmlFor={`${contest.id}-${candidate.id}`}>
+                            {candidate.name}
+                          </label>
                         </ContestDataRow>
-                        <ContestDataRow
-                          label="No"
-                          testId={`${contest.id}-${contest.noOption.id}`}
+                      ))}
+                    {contestWriteInCandidates.map((candidate) => (
+                      <ContestDataRow
+                        key={candidate.id}
+                        data-testid={`${contest.id}-${candidate.id}`}
+                      >
+                        <TallyInput
+                          id={`${contest.id}-${candidate.id}`}
+                          data-testid={`${contest.id}-${candidate.id}-input`}
+                          value={getValueForInput(contest.id, candidate.id)}
+                          onChange={(e) =>
+                            updateContestData(
+                              contest.id,
+                              candidate.id,
+                              e,
+                              candidate.name
+                            )
+                          }
+                        />
+                        <label htmlFor={`${contest.id}-${candidate.id}`}>
+                          {candidate.name} (write-in)
+                        </label>
+                      </ContestDataRow>
+                    ))}
+                    {contestTempWriteInCandidates.map((candidate) => (
+                      <ContestDataRow
+                        key={candidate.id}
+                        data-testid={`${contest.id}-${candidate.id}`}
+                      >
+                        <TallyInput
+                          autoFocus
+                          id={`${contest.id}-${candidate.id}`}
+                          data-testid={`${contest.id}-${candidate.id}-input`}
+                          value={getValueForInput(contest.id, candidate.id)}
+                          onChange={(e) =>
+                            updateContestData(
+                              contest.id,
+                              candidate.id,
+                              e,
+                              candidate.name
+                            )
+                          }
+                        />
+                        <label htmlFor={`${contest.id}-${candidate.id}`}>
+                          {candidate.name} (write-in)
+                        </label>
+                        <Button
+                          icon="X"
+                          variant="danger"
+                          fill="transparent"
+                          onPress={() => {
+                            removeTempWriteInCandidate(
+                              candidate.id,
+                              contest.id
+                            );
+                          }}
+                          style={{ marginLeft: 'auto' }}
                         >
-                          <TallyInput
-                            name={`${contest.id}-no`}
-                            data-testid={`${contest.id}-${contest.noOption.id}-input`}
-                            value={getValueForInput(contest.id, 'noTally')}
-                            onChange={(e) =>
-                              updateContestData(contest.id, 'noTally', e)
-                            }
-                          />
-                        </ContestDataRow>
-                      </React.Fragment>
-                    )}
-                  </tbody>
-                  <tfoot>
-                    {contest.type === 'candidate' && contest.allowWriteIns && (
-                      <AddWriteInRow
-                        addWriteInCandidate={(name) =>
-                          addTempWriteInCandidate(name, contest.id)
-                        }
-                        contestId={contest.id}
-                        disallowedCandidateNames={
-                          disallowedNewWriteInCandidateNames
+                          Remove
+                        </Button>
+                      </ContestDataRow>
+                    ))}
+                  </React.Fragment>
+                )}
+                {contest.type === 'yesno' && (
+                  <React.Fragment>
+                    <ContestDataRow
+                      data-testid={`${contest.id}-${contest.yesOption.id}`}
+                    >
+                      <TallyInput
+                        name={`${contest.id}-yes`}
+                        data-testid={`${contest.id}-${contest.yesOption.id}-input`}
+                        value={getValueForInput(contest.id, 'yesTally')}
+                        onChange={(e) =>
+                          updateContestData(contest.id, 'yesTally', e)
                         }
                       />
-                    )}
-                  </tfoot>
-                </Table>
+                      <label htmlFor={`${contest.id}-yes`}>
+                        {contest.yesOption.label}
+                      </label>
+                    </ContestDataRow>
+                    <ContestDataRow
+                      data-testid={`${contest.id}-${contest.noOption.id}`}
+                    >
+                      <TallyInput
+                        id={`${contest.id}-no`}
+                        data-testid={`${contest.id}-${contest.noOption.id}-input`}
+                        value={getValueForInput(contest.id, 'noTally')}
+                        onChange={(e) =>
+                          updateContestData(contest.id, 'noTally', e)
+                        }
+                      />
+                      <label htmlFor={`${contest.id}-no`}>
+                        {contest.noOption.label}
+                      </label>
+                    </ContestDataRow>
+                  </React.Fragment>
+                )}
+                {contest.type === 'candidate' && contest.allowWriteIns && (
+                  <AddWriteInRow
+                    addWriteInCandidate={(name) =>
+                      addTempWriteInCandidate(name, contest.id)
+                    }
+                    contestId={contest.id}
+                    disallowedCandidateNames={
+                      disallowedNewWriteInCandidateNames
+                    }
+                  />
+                )}
               </ContestData>
             );
           })}

--- a/apps/admin/frontend/src/screens/manual_data_summary_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_summary_screen.test.tsx
@@ -4,7 +4,7 @@ import { createMemoryHistory } from 'history';
 import { Router } from 'react-router-dom';
 
 import userEvent from '@testing-library/user-event';
-import { screen, within } from '../../test/react_testing_library';
+import { screen, waitFor, within } from '../../test/react_testing_library';
 import {
   ALL_MANUAL_TALLY_BALLOT_TYPES,
   ManualDataSummaryScreen,
@@ -142,6 +142,9 @@ test('delete an existing tally', async () => {
   });
   apiMock.expectGetManualResultsMetadata([]);
   userEvent.click(screen.getButton('Remove Manual Tallies'));
+  await waitFor(() =>
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  );
 });
 
 test('full table & clearing all data', async () => {

--- a/apps/admin/frontend/src/screens/manual_data_summary_screen.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_summary_screen.tsx
@@ -78,12 +78,14 @@ function RemoveManualTallyModal({
   const deleteManualTallyMutation = deleteManualResults.useMutation();
 
   function onConfirm() {
-    deleteManualTallyMutation.mutate({
-      ballotStyleId: identifier.ballotStyleId,
-      precinctId: identifier.precinctId,
-      votingMethod: identifier.votingMethod,
-    });
-    onClose();
+    deleteManualTallyMutation.mutate(
+      {
+        ballotStyleId: identifier.ballotStyleId,
+        precinctId: identifier.precinctId,
+        votingMethod: identifier.votingMethod,
+      },
+      { onSuccess: onClose }
+    );
   }
   const precinct = find(
     election.precincts,
@@ -112,7 +114,12 @@ function RemoveManualTallyModal({
       }
       actions={
         <React.Fragment>
-          <Button icon="Delete" variant="danger" onPress={onConfirm}>
+          <Button
+            icon="Delete"
+            variant="danger"
+            onPress={onConfirm}
+            disabled={deleteManualTallyMutation.isLoading}
+          >
             Remove Manual Tallies
           </Button>
           <Button onPress={onClose}>Cancel</Button>

--- a/apps/admin/frontend/src/screens/tally_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/tally_screen.test.tsx
@@ -3,7 +3,7 @@ import { createMemoryHistory } from 'history';
 import { Router } from 'react-router-dom';
 
 import userEvent from '@testing-library/user-event';
-import { screen, within } from '../../test/react_testing_library';
+import { screen, waitFor, within } from '../../test/react_testing_library';
 import { TallyScreen } from './tally_screen';
 import { renderInAppContext } from '../../test/render_in_app_context';
 import { ApiMock, createApiMock } from '../../test/helpers/mock_api_client';
@@ -116,7 +116,9 @@ test('can delete manual data', async () => {
   apiMock.expectDeleteAllManualResults();
   apiMock.expectGetManualResultsMetadata([]);
   userEvent.click(within(modal).getButton('Remove All Manual Tallies'));
-  expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  await waitFor(() =>
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  );
 });
 
 test('with no data loaded', async () => {

--- a/apps/admin/frontend/src/screens/task_screen.tsx
+++ b/apps/admin/frontend/src/screens/task_screen.tsx
@@ -1,0 +1,48 @@
+import { Main, Screen } from '@votingworks/ui';
+import styled from 'styled-components';
+
+interface TaskScreenProps {
+  children: React.ReactNode;
+}
+
+export const MainWrapper = styled(Main)`
+  display: flex;
+  flex-direction: row-reverse;
+  overflow: hidden;
+  height: 100%;
+`;
+
+export const TaskContent = styled.div`
+  flex: 1;
+  overflow-y: auto;
+`;
+
+export const TaskControls = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const TaskHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  background: ${(p) => p.theme.colors.inverseBackground};
+  color: ${(p) => p.theme.colors.onInverse};
+
+  h1 {
+    margin: 0;
+  }
+
+  button {
+    padding: 0.5rem;
+  }
+`;
+
+export function TaskScreen({ children }: TaskScreenProps): JSX.Element {
+  return (
+    <Screen>
+      <MainWrapper>{children}</MainWrapper>
+    </Screen>
+  );
+}


### PR DESCRIPTION
## Overview

Fixes #4353 

- Restructures the Edit Tallies page layout to a "task mode" layout inspired by write-in adjudication
- Replaces the table-based implementation with simpler flexbox to fix some of the weird layout issues from the original bug report
- Adds selective auto-focus tags to ensure smooth keyboard nav

_Review by commits_

## Demo Video or Screenshot

https://github.com/votingworks/vxsuite/assets/530106/c99258b0-4b8d-408f-80f5-1b36c50337d2

(Note that in this video it appears there may be a bug where write-in candidates are not included in the validation of total ballots counted, but I'm going to look into that separately as a follow up if necessary)

## Testing Plan

Manual testing




## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
