### PR TITLE
Shrink padding in radio group when size mode is extra-large

### DIFF
--- a/libs/ui/src/radio_group.tsx
+++ b/libs/ui/src/radio_group.tsx
@@ -61,7 +61,9 @@ const StyledButton = styled(Button)`
   flex-wrap: nowrap;
   font-weight: ${(p) => p.theme.sizes.fontWeight.regular};
   justify-content: start;
-  padding-left: 0.5rem;
+  padding-left: ${(p) =>
+    /* istanbul ignore next */
+    p.theme.sizeMode === 'touchExtraLarge' && '0.25rem'};
   text-align: left;
   width: 100%;
 
@@ -96,7 +98,9 @@ interface OptionsContainerProps {
 const OptionsContainer = styled.span<OptionsContainerProps>`
   align-items: stretch;
   display: grid;
-  grid-gap: 0.5rem;
+  grid-gap: ${(p) =>
+    /* istanbul ignore next */
+    p.theme.sizeMode === 'touchExtraLarge' ? '0.25rem' : '0.5rem'};
   grid-template-columns: ${(p) =>
     Array.from({ length: p.numColumns }).fill('1fr').join(' ')};
   height: 100%;


### PR DESCRIPTION


## Overview

We currently use this specifically in the display settings, which looks weird in extra-large without an adjustment. This probably won't address every case (e.g. if we are supporting languages that take up more space) but it works for now.

## Demo Video or Screenshot
Before
<img width="961" alt="Screenshot 2023-12-06 at 5 22 53 PM" src="https://github.com/votingworks/vxsuite/assets/530106/fb9c4a85-ef73-4a5e-9fc0-ee483c1b2078">


After
<img width="961" alt="Screenshot 2023-12-06 at 5 16 56 PM" src="https://github.com/votingworks/vxsuite/assets/530106/389a123a-8bdc-4b84-8d06-ed020ae6f45f">


## Testing Plan
Manual test

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
