### PR TITLE
Ensure that continuous export operations do not interleave and avoid spurious "CVR Sync Required" screens

### DIFF
--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -195,6 +195,7 @@ export class Store {
    */
   reset(): void {
     this.client.reset();
+    clearDoesUsbDriveRequireCastVoteRecordSyncCachedResult();
   }
 
   /**

--- a/apps/scan/backend/src/util/workspace.ts
+++ b/apps/scan/backend/src/util/workspace.ts
@@ -1,5 +1,6 @@
 import { emptyDirSync, ensureDirSync } from 'fs-extra';
 import { join, resolve } from 'path';
+import { Mutex } from '@votingworks/utils';
 import { Store } from '../store';
 
 export interface Workspace {
@@ -27,6 +28,11 @@ export interface Workspace {
    * The store associated with the workspace.
    */
   readonly store: Store;
+
+  /**
+   * A mutex to ensure that continuous export operations happen sequentially and do not interleave.
+   */
+  readonly continuousExportMutex: Mutex;
 
   /**
    * Zero out the data in the workspace, but leave the configuration.
@@ -65,6 +71,7 @@ export function createWorkspace(
     scannedImagesPath,
     uploadsPath,
     store,
+    continuousExportMutex: new Mutex(),
     resetElectionSession() {
       store.resetElectionSession();
       emptyDirSync(ballotImagesPath);

--- a/apps/scan/backend/test/helpers/custom_helpers.ts
+++ b/apps/scan/backend/test/helpers/custom_helpers.ts
@@ -219,7 +219,8 @@ export async function scanBallot(
   mockScanner: jest.Mocked<CustomScanner>,
   apiClient: grout.Client<Api>,
   store: Store,
-  initialBallotsCounted: number
+  initialBallotsCounted: number,
+  options: { waitForContinuousExportToUsbDrive?: boolean } = {}
 ): Promise<void> {
   mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
   await waitForStatus(apiClient, {
@@ -243,5 +244,7 @@ export async function scanBallot(
     ballotsCounted: initialBallotsCounted + 1,
   });
 
-  await waitForContinuousExportToUsbDrive(store);
+  if (options.waitForContinuousExportToUsbDrive ?? true) {
+    await waitForContinuousExportToUsbDrive(store);
+  }
 }

--- a/libs/backend/src/cast_vote_records/export.test.ts
+++ b/libs/backend/src/cast_vote_records/export.test.ts
@@ -984,7 +984,7 @@ test('change in USB drive status clears doesUsbDriveRequireCastVoteRecordSync ca
   expect(getElectionDefinitionSpy).toHaveBeenCalledTimes(1);
 });
 
-test('cast vote record export clears doesUsbDriveRequireCastVoteRecordSync cache', async () => {
+test('full cast vote record export on precinct scanner clears doesUsbDriveRequireCastVoteRecordSync cache', async () => {
   mockUsbDrive.insertUsbDrive({});
   let usbDriveStatus = await mockUsbDrive.usbDrive.status();
   mockPrecinctScannerStore.setElectionDefinition(electionDefinition);
@@ -1034,6 +1034,22 @@ test('cast vote record export clears doesUsbDriveRequireCastVoteRecordSync cache
       mockUsbDrive.usbDrive,
       [sheet],
       { scannerType: 'precinct' }
+    )
+  ).toEqual(ok());
+
+  expect(
+    await doesUsbDriveRequireCastVoteRecordSync(
+      mockPrecinctScannerStore,
+      usbDriveStatus
+    )
+  ).toEqual(true);
+
+  expect(
+    await exportCastVoteRecordsToUsbDrive(
+      mockPrecinctScannerStore,
+      mockUsbDrive.usbDrive,
+      [sheet],
+      { scannerType: 'precinct', isFullExport: true }
     )
   ).toEqual(ok());
 

--- a/libs/backend/src/cast_vote_records/export.ts
+++ b/libs/backend/src/cast_vote_records/export.ts
@@ -790,8 +790,13 @@ export async function exportCastVoteRecordsToUsbDrive(
    */
   if (scannerStore.scannerType === 'precinct') {
     scannerStore.setIsContinuousExportOperationInProgress(false);
+    if (
+      exportOptions.scannerType === 'precinct' &&
+      exportOptions.isFullExport
+    ) {
+      clearDoesUsbDriveRequireCastVoteRecordSyncCachedResult();
+    }
   }
-  clearDoesUsbDriveRequireCastVoteRecordSyncCachedResult();
 
   return ok();
 }

--- a/libs/backend/src/cast_vote_records/file_system_utils.ts
+++ b/libs/backend/src/cast_vote_records/file_system_utils.ts
@@ -29,11 +29,14 @@ export async function updateCreationTimestampOfDirectoryAndChildrenFiles(
     return entry.name;
   });
   for (const fileName of fileNames) {
+    // Use execFile instead of fs.copyFile because fs.copyFile has issues in prod when the source
+    // and destination paths are both on a USB drive
     await execFile('cp', [
       path.join(directoryPath, fileName),
       path.join(`${directoryPath}-temp`, fileName),
     ]);
   }
+
   // In case the system loses power while deleting the original directory, mark the copied
   // directory as complete to facilitate recovery on reboot. On reboot, if we see a *-temp
   // directory, we can safely delete it, and if we see a *-temp-complete directory, we can safely


### PR DESCRIPTION
_Easiest reviewed by commit_

## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/4322

This PR addresses various continuous export edge cases, that I think explain some of the odd behaviors that we've seen in prod. Unfortunately, the issues that we've seen, like unexpected crashes and spurious "CVR Sync Required" screens, have been hard to repro with consistency in dev (VxDev or VM). So I'm partly hypothesizing. There may be other sources of problems out there.

More on the specific fixes in GitHub comments.

## Testing Plan

- [x] Lots of manual testing
- [x] Updated automated tests

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A