### PR TITLE
[i18n/Audio] Add react clients for UI String audio APIs

### DIFF
--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -55,6 +55,7 @@
     "@votingworks/logging": "workspace:*",
     "@votingworks/types": "workspace:*",
     "@votingworks/utils": "workspace:*",
+    "@yornaath/batshit": "^0.9.0",
     "base64-js": "1.5.1",
     "debug": "4.3.4",
     "deep-eql": "4.1.3",

--- a/libs/ui/src/hooks/ui_strings_api.test.tsx
+++ b/libs/ui/src/hooks/ui_strings_api.test.tsx
@@ -1,4 +1,4 @@
-import { LanguageCode } from '@votingworks/types';
+import { LanguageCode, UiStringAudioClips } from '@votingworks/types';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
@@ -92,4 +92,116 @@ test('getUiStrings', async () => {
   await waitFor(() => expect(result.current.isLoading).toEqual(false));
   expect(result.current.data).toEqual(null);
   expect(mockApiClient.getUiStrings).toHaveBeenLastCalledWith({ languageCode });
+});
+
+test('getAudioClip', async () => {
+  const { ENGLISH, SPANISH } = LanguageCode;
+
+  // Simulate initial machine state:
+  mockApiClient.getAudioClips.mockResolvedValue([]);
+
+  const { result } = renderHook(
+    () => ({
+      en1: api.getAudioClip.useQuery({ id: 'en1', languageCode: ENGLISH }),
+      es1: api.getAudioClip.useQuery({ id: 'es1', languageCode: SPANISH }),
+      es2: api.getAudioClip.useQuery({ id: 'es2', languageCode: SPANISH }),
+    }),
+    { wrapper: QueryWrapper }
+  );
+
+  // Expect a batch call for `ENGLISH` clips:
+  await waitFor(() => expect(result.current.en1.isSuccess).toEqual(true));
+  expect(result.current.en1.data).toBeNull();
+  expect(mockApiClient.getAudioClips).toHaveBeenCalledWith({
+    audioIds: ['en1'],
+    languageCode: ENGLISH,
+  });
+
+  // Expect another batch call for `SPANISH` clips:
+  await waitFor(() => expect(result.current.es1.isSuccess).toEqual(true));
+  expect(result.current.es1.data).toBeNull();
+  expect(result.current.es2.data).toBeNull();
+  expect(mockApiClient.getAudioClips).toHaveBeenCalledWith({
+    audioIds: ['es1', 'es2'],
+    languageCode: SPANISH,
+  });
+
+  expect(mockApiClient.getAudioClips).toHaveBeenCalledTimes(2);
+
+  // Simulate configuring an election:
+  const [clipEnglish1, clipSpanish1, clipSpanish2]: UiStringAudioClips = [
+    { dataBase64: 'ABC==', id: 'en1', languageCode: ENGLISH },
+    { dataBase64: 'DEF==', id: 'es1', languageCode: SPANISH },
+    { dataBase64: 'EDF==', id: 'es2', languageCode: SPANISH },
+  ];
+  await act(async () => {
+    mockApiClient.getAudioClips.mockImplementation((input) => {
+      if (input.languageCode === ENGLISH) {
+        return Promise.resolve([clipEnglish1]);
+      }
+
+      if (input.languageCode === SPANISH) {
+        return Promise.resolve([clipSpanish1, clipSpanish2]);
+      }
+
+      return Promise.resolve([]);
+    });
+    await api.onMachineConfigurationChange(queryClient);
+  });
+
+  await waitFor(() => expect(result.current.en1.isLoading).toEqual(false));
+  expect(result.current.en1.data).toEqual(clipEnglish1);
+
+  await waitFor(() => expect(result.current.es1.isLoading).toEqual(false));
+  expect(result.current.es1.data).toEqual(clipSpanish1);
+  expect(result.current.es2.data).toEqual(clipSpanish2);
+
+  // Simulate unconfiguring an election:
+  await act(async () => {
+    mockApiClient.getAudioClips.mockResolvedValue([]);
+    await api.onMachineConfigurationChange(queryClient);
+  });
+
+  await waitFor(() => expect(result.current.en1.isLoading).toEqual(false));
+  await waitFor(() => expect(result.current.es1.isLoading).toEqual(false));
+  expect(result.current.en1.data).toEqual(null);
+  expect(result.current.es1.data).toEqual(null);
+  expect(result.current.es2.data).toEqual(null);
+});
+
+test('getAudioIds', async () => {
+  const languageCode = LanguageCode.SPANISH;
+
+  // Simulate initial machine state:
+  mockApiClient.getUiStringAudioIds.mockResolvedValueOnce(null);
+
+  const { result } = renderHook(() => api.getAudioIds.useQuery(languageCode), {
+    wrapper: QueryWrapper,
+  });
+
+  await waitFor(() => expect(result.current.isSuccess).toEqual(true));
+  expect(result.current.data).toEqual(null);
+  expect(mockApiClient.getUiStringAudioIds).toHaveBeenCalledWith({
+    languageCode,
+  });
+
+  // Simulate configuring an election:
+  await act(async () => {
+    mockApiClient.getUiStringAudioIds.mockResolvedValueOnce({
+      foo: ['bar', 'baz'],
+    });
+    await api.onMachineConfigurationChange(queryClient);
+  });
+
+  await waitFor(() => expect(result.current.isLoading).toEqual(false));
+  expect(result.current.data).toEqual({ foo: ['bar', 'baz'] });
+
+  // Simulate unconfiguring an election:
+  await act(async () => {
+    mockApiClient.getUiStringAudioIds.mockResolvedValueOnce(null);
+    await api.onMachineConfigurationChange(queryClient);
+  });
+
+  await waitFor(() => expect(result.current.isLoading).toEqual(false));
+  expect(result.current.data).toEqual(null);
 });

--- a/libs/ui/src/hooks/ui_strings_api.ts
+++ b/libs/ui/src/hooks/ui_strings_api.ts
@@ -1,3 +1,5 @@
+import * as batcher from '@yornaath/batshit';
+
 import { QueryClient, QueryKey, useQuery } from '@tanstack/react-query';
 import { LanguageCode, UiStringsApi } from '@votingworks/types';
 import * as grout from '@votingworks/grout';
@@ -10,7 +12,56 @@ export type UiStringsApiClient = {
 };
 
 function createReactQueryApi(getApiClient: () => UiStringsApiClient) {
+  function createBatchAudioClipsClient(languageCode: LanguageCode) {
+    return batcher.create({
+      fetcher: (queries: Array<{ id: string }>) =>
+        getApiClient().getAudioClips({
+          audioIds: queries.map((q) => q.id),
+          languageCode,
+        }),
+
+      resolver: (clips, query) =>
+        clips.find((clip) => clip.id === query.id) || null,
+    });
+  }
+
+  const batchAudioClipsClients = new Map<
+    LanguageCode,
+    ReturnType<typeof createBatchAudioClipsClient>
+  >();
+
+  function getBatchAudioClipsClient(languageCode: LanguageCode) {
+    const existingBatchClient = batchAudioClipsClients.get(languageCode);
+    if (existingBatchClient) {
+      return existingBatchClient;
+    }
+
+    const newBatchClient = createBatchAudioClipsClient(languageCode);
+
+    batchAudioClipsClients.set(languageCode, newBatchClient);
+    return newBatchClient;
+  }
+
   return {
+    getAudioClip: {
+      queryKeyPrefix: 'getAudioClip',
+
+      getQueryKey(params: {
+        id: string;
+        languageCode: LanguageCode;
+      }): QueryKey {
+        return [this.queryKeyPrefix, params.languageCode, params.id];
+      },
+
+      useQuery(params: { id: string; languageCode: LanguageCode }) {
+        const batchClient = getBatchAudioClipsClient(params.languageCode);
+
+        return useQuery(this.getQueryKey(params), () =>
+          batchClient.fetch({ id: params.id })
+        );
+      },
+    },
+
     getAvailableLanguages: {
       getQueryKey(): QueryKey {
         return ['getAvailableLanguages'];
@@ -41,6 +92,22 @@ function createReactQueryApi(getApiClient: () => UiStringsApiClient) {
       },
     },
 
+    getAudioIds: {
+      queryKeyPrefix: 'getAudioIds',
+
+      getQueryKey(languageCode: LanguageCode): QueryKey {
+        return [this.queryKeyPrefix, languageCode];
+      },
+
+      useQuery(languageCode: LanguageCode) {
+        const apiClient = getApiClient();
+
+        return useQuery(this.getQueryKey(languageCode), () =>
+          apiClient.getUiStringAudioIds({ languageCode })
+        );
+      },
+    },
+
     async onMachineConfigurationChange(
       queryClient: QueryClient
     ): Promise<void> {
@@ -48,9 +115,9 @@ function createReactQueryApi(getApiClient: () => UiStringsApiClient) {
         this.getAvailableLanguages.getQueryKey()
       );
       await queryClient.invalidateQueries([this.getUiStrings.queryKeyPrefix]);
+      await queryClient.invalidateQueries([this.getAudioIds.queryKeyPrefix]);
+      await queryClient.invalidateQueries([this.getAudioClip.queryKeyPrefix]);
     },
-
-    // TODO(kofi): Fill out.
   };
 }
 

--- a/libs/ui/src/hooks/use_current_language.test.tsx
+++ b/libs/ui/src/hooks/use_current_language.test.tsx
@@ -18,7 +18,7 @@ test('returns default language when rendered without context', () => {
 
 test('returns current language when rendered within context', async () => {
   const api = createUiStringsApi(() => ({
-    getAudioClipsBase64: jest.fn(),
+    getAudioClips: jest.fn(),
     getAvailableLanguages: jest.fn().mockResolvedValue([]),
     getUiStringAudioIds: jest.fn(),
     getUiStrings: jest.fn().mockResolvedValue(null),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5036,6 +5036,9 @@ importers:
       '@votingworks/utils':
         specifier: workspace:*
         version: link:../utils
+      '@yornaath/batshit':
+        specifier: ^0.9.0
+        version: 0.9.0
       base64-js:
         specifier: 1.5.1
         version: 1.5.1
@@ -11781,6 +11784,16 @@ packages:
       '@types/emscripten': 1.39.7
       tslib: 1.14.1
     dev: true
+
+  /@yornaath/batshit-devtools@1.6.0:
+    resolution: {integrity: sha512-ckKxrdfuFSRFz54tYU+VkD1eZOOaxa92U4eKOPtlxc1itB12Cqb1Dmk8Rqv6mARxp8YvocVGKbccrXoCwH2Lew==}
+    dev: false
+
+  /@yornaath/batshit@0.9.0:
+    resolution: {integrity: sha512-QdI1hQUPlpFT+o1iKLi9fQEKCli8c3UG7q4Ih8MP4jn+pyAjbfC4xaK5PwqSsSZgT0YeAZ0GWbbO9+1xAtWXlQ==}
+    dependencies:
+      '@yornaath/batshit-devtools': 1.6.0
+    dev: false
 
   /abab@2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}


### PR DESCRIPTION
## Overview

Adding react-query clients for the `getUiStringAudioIds` and `getAudioClips`.

The plan is to lazy-load audio clips as `UiString` components get rendered -- the backend `getAudioClips()` endpoint is called via a batched client `getAudioClip()` method that combines all `getAudioClip()` queries within a default `10ms` window. Using the unfortunately named `@yornaath/batshit` library recommended in the `react-query` docs.

Once everything's wired up, will do some benchmarking to figure out if we need to optimise the audio clip fetching to make sure there's no significant latency in playing audio.

## Testing Plan
- New test cases for the react queries and batching logic.

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
