### PR TITLE
Fix broken build from previous cross-merge

### DIFF
--- a/libs/ui/src/hooks/use_current_language.test.tsx
+++ b/libs/ui/src/hooks/use_current_language.test.tsx
@@ -18,7 +18,7 @@ test('returns default language when rendered without context', () => {
 
 test('returns current language when rendered within context', async () => {
   const api = createUiStringsApi(() => ({
-    getAudioClipsBase64: jest.fn(),
+    getAudioClips: jest.fn(),
     getAvailableLanguages: jest.fn().mockResolvedValue([]),
     getUiStringAudioIds: jest.fn(),
     getUiStrings: jest.fn().mockResolvedValue(null),


### PR DESCRIPTION
## Overview

Had 2 separate PRs in flight that referenced the same API method and forgot to resolve before merge -- fixing to unbreak the build.
