### PR TITLE
fix(utils): ensure `Mutex` internal async queue is cleared

### DIFF
--- a/libs/utils/src/mutex.test.ts
+++ b/libs/utils/src/mutex.test.ts
@@ -1,12 +1,11 @@
 import { Mutex } from './mutex';
 
 test('sync lock flow', () => {
-  const mutex = new Mutex(0);
+  const mutex = new Mutex();
   expect(mutex.isLocked()).toEqual(false);
   const locked = mutex.lock()!;
   expect(mutex.isLocked()).toEqual(true);
   expect(locked).toEqual({
-    value: 0,
     unlock: expect.any(Function),
   });
   locked.unlock();
@@ -14,13 +13,29 @@ test('sync lock flow', () => {
   expect(() => locked.unlock()).toThrow();
 });
 
+test('sync lock flow with a value', () => {
+  const mutex = new Mutex({ count: 123 });
+  expect(mutex.isLocked()).toEqual(false);
+  const locked = mutex.lock()!;
+  expect(mutex.isLocked()).toEqual(true);
+  expect(locked).toEqual({
+    value: { count: 123 },
+    unlock: expect.any(Function),
+  });
+  locked.value.count += 1;
+  locked.unlock();
+  expect(mutex.isLocked()).toEqual(false);
+  expect(() => locked.unlock()).toThrow();
+  expect(() => locked.value).toThrowError('value accessed after unlock');
+  expect(mutex.lock()?.value.count).toEqual(124);
+});
+
 test('async lock flow', async () => {
-  const mutex = new Mutex(0);
+  const mutex = new Mutex();
   expect(mutex.isLocked()).toEqual(false);
   const locked = await mutex.asyncLock();
   expect(mutex.isLocked()).toEqual(true);
   expect(locked).toEqual({
-    value: 0,
     unlock: expect.any(Function),
   });
   locked.unlock();
@@ -28,12 +43,33 @@ test('async lock flow', async () => {
   expect(() => locked.unlock()).toThrow();
 });
 
+test('async lock flow with a value', async () => {
+  const mutex = new Mutex({ count: 123 });
+  expect(mutex.isLocked()).toEqual(false);
+  const locked = await mutex.asyncLock();
+  expect(mutex.isLocked()).toEqual(true);
+  expect(locked).toEqual({
+    value: { count: 123 },
+    unlock: expect.any(Function),
+  });
+  locked.value.count += 1;
+  locked.unlock();
+  expect(mutex.isLocked()).toEqual(false);
+  expect(() => locked.unlock()).toThrow();
+  expect(() => locked.value).toThrowError('value accessed after unlock');
+  expect(mutex['asyncQueue']).toHaveLength(0);
+  expect((await mutex.asyncLock()).value.count).toEqual(124);
+});
+
 test('asyncLock waits for lock to be released', async () => {
-  const mutex = new Mutex(0);
+  const mutex = new Mutex();
   const locked1Promise = mutex.asyncLock();
   const locked2Promise = mutex.asyncLock();
   const locked1Resolved = jest.fn();
   const locked2Resolved = jest.fn();
+
+  // The first should be acquired immediately.
+  expect(mutex['asyncQueue']).toHaveLength(1);
 
   expect(mutex.isLocked()).toEqual(true);
   void locked1Promise.then(locked1Resolved);
@@ -41,15 +77,16 @@ test('asyncLock waits for lock to be released', async () => {
   expect(locked1Resolved).not.toHaveBeenCalled();
   expect(locked2Resolved).not.toHaveBeenCalled();
 
-  const { value: value1, unlock: unlock1 } = await locked1Promise;
-  expect(value1).toEqual(0);
+  const { unlock: unlock1 } = await locked1Promise;
   expect(mutex.isLocked()).toEqual(true);
   expect(locked1Resolved).toHaveBeenCalled();
   expect(locked2Resolved).not.toHaveBeenCalled();
   unlock1();
 
-  const { value: value2, unlock: unlock2 } = await locked2Promise;
-  expect(value2).toEqual(0);
+  // The second lock should be acquired immediately after the first is released.
+  expect(mutex['asyncQueue']).toHaveLength(0);
+
+  const { unlock: unlock2 } = await locked2Promise;
   expect(mutex.isLocked()).toEqual(true);
   expect(locked2Resolved).toHaveBeenCalled();
   unlock2();
@@ -58,11 +95,20 @@ test('asyncLock waits for lock to be released', async () => {
 });
 
 test('withLock', async () => {
-  const mutex = new Mutex(0);
-  const withLockReturnValue = await mutex.withLock(async (value) => {
+  const mutex = new Mutex();
+  const withLockReturnValue = await mutex.withLock(() => {
     expect(mutex.isLocked()).toEqual(true);
-    return Promise.resolve(value + 1);
+    return Promise.resolve('hello');
   });
-  expect(withLockReturnValue).toEqual(1);
+  expect(withLockReturnValue).toEqual('hello');
+  expect(mutex.isLocked()).toEqual(false);
+
+  await expect(
+    mutex.withLock(() => {
+      expect(mutex.isLocked()).toEqual(true);
+      throw new Error('this lock should still be released');
+    })
+  ).rejects.toThrowError('this lock should still be released');
+
   expect(mutex.isLocked()).toEqual(false);
 });


### PR DESCRIPTION
## Overview
@arsalansufi discovered that the private `asyncQueue` property of `Mutex` only ever grew and was never drained. This isn't great, and represents a memory leak. The only question is whether it's a fast or slow memory leak, which @arsalansufi is investigating.

While I was here I added some more testing, especially testing that covers the cases we care about: either with a value or without a value. For the case without a value I made it so you can do `new Mutex()` and just get one whose value is `void`. This avoids needing to give it a dummy value like `0`.

## Demo Video or Screenshot
n/a

## Testing Plan
- [x] New automated tests.
