### PR TITLE
chore: update vscode settings

### DIFF
--- a/apps/admin/frontend/.vscode/settings.json
+++ b/apps/admin/frontend/.vscode/settings.json
@@ -24,7 +24,7 @@
   "less.validate": false,
   "scss.validate": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "remote.SSH.defaultForwardedPorts": [
     {

--- a/apps/central-scan/frontend/.vscode/settings.json
+++ b/apps/central-scan/frontend/.vscode/settings.json
@@ -18,6 +18,6 @@
   "less.validate": false,
   "scss.validate": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   }
 }

--- a/apps/mark/frontend/.vscode/settings.json
+++ b/apps/mark/frontend/.vscode/settings.json
@@ -24,7 +24,7 @@
   "less.validate": false,
   "scss.validate": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "remote.SSH.defaultForwardedPorts": [
     {

--- a/libs/ui/.vscode/settings.json
+++ b/libs/ui/.vscode/settings.json
@@ -24,7 +24,7 @@
   "less.validate": false,
   "scss.validate": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "remote.SSH.defaultForwardedPorts": [
     {

--- a/vxsuite.code-workspace
+++ b/vxsuite.code-workspace
@@ -194,8 +194,8 @@
   "settings": {
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": true,
-      "source.fixAll.stylelint": true
+      "source.fixAll.eslint": "explicit",
+      "source.fixAll.stylelint": "explicit"
     },
     "cSpell.words": [
       "accuvote",


### PR DESCRIPTION
## Overview
VS Code 1.85.0 changed the `codeActionsOnSave` values. See https://code.visualstudio.com/updates/v1_85#_code-actions-on-save-and-auto.

## Demo Video or Screenshot
n/a

## Testing Plan
n/a
