### PR TITLE
refactor: remove `lodash.find`

### DIFF
--- a/libs/utils/src/ballot_styles.ts
+++ b/libs/utils/src/ballot_styles.ts
@@ -70,8 +70,7 @@ export function getRelatedBallotStyle(params: {
   const { ballotStyles, sourceBallotStyleId, targetBallotStyleLanguage } =
     params;
 
-  const sourceBallotStyle = _.find(
-    ballotStyles,
+  const sourceBallotStyle = ballotStyles.find(
     (b) => b.id === sourceBallotStyleId
   );
   if (!sourceBallotStyle) {
@@ -87,7 +86,7 @@ export function getRelatedBallotStyle(params: {
   const groupId = extractBallotStyleGroupId(sourceBallotStyleId);
   const matchingGroup = assertDefined(ballotStyleGroups[groupId]);
 
-  const destinationBallotStyle = _.find(matchingGroup, (b) =>
+  const destinationBallotStyle = matchingGroup.find((b) =>
     _.isEqual(b.languages, [targetBallotStyleLanguage])
   );
   if (!destinationBallotStyle) {

--- a/libs/utils/src/extract_cdf_ui_strings.ts
+++ b/libs/utils/src/extract_cdf_ui_strings.ts
@@ -135,8 +135,7 @@ const extractorFns: Record<
   },
 
   [ElectionStringKey.COUNTY_NAME](cdfElection, uiStrings) {
-    const county = _.find(
-      cdfElection.GpUnit,
+    const county = cdfElection.GpUnit.find(
       (gpUnit) => gpUnit.Type === BallotDefinition.ReportingUnitType.County
     );
 
@@ -214,8 +213,7 @@ const extractorFns: Record<
   },
 
   [ElectionStringKey.STATE_NAME](cdfElection, uiStrings) {
-    const state = _.find(
-      cdfElection.GpUnit,
+    const state = cdfElection.GpUnit.find(
       (gpUnit) => gpUnit.Type === BallotDefinition.ReportingUnitType.State
     );
 


### PR DESCRIPTION
## Overview

We're planning to just use the built-in methods and `iter` from `@votingworks/basics` for operating on lists. This change just removes the most trivial use of `lodash`.

## Demo Video or Screenshot
n/a

## Testing Plan
- [x] Existing automated tests.