### PR TITLE
VxAdmin: Loading state for "Save Election Package"

### DIFF
--- a/apps/admin/frontend/src/components/export_election_package_modal_button.tsx
+++ b/apps/admin/frontend/src/components/export_election_package_modal_button.tsx
@@ -5,7 +5,13 @@ import {
   isSystemAdministratorAuth,
 } from '@votingworks/utils';
 import { assert, throwIllegalValue } from '@votingworks/basics';
-import { Button, Modal, P, UsbControllerButton } from '@votingworks/ui';
+import {
+  Button,
+  LoadingButton,
+  Modal,
+  P,
+  UsbControllerButton,
+} from '@votingworks/ui';
 import type { ExportDataError } from '@votingworks/admin-backend';
 
 import { ejectUsbDrive, saveElectionPackageToUsb } from '../api';
@@ -42,6 +48,7 @@ export function ExportElectionPackageModalButton(): JSX.Element {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   function closeModal() {
+    if (saveElectionPackageToUsbMutation.isLoading) return;
     setIsModalOpen(false);
     setSaveState({ state: 'unsaved' });
   }
@@ -80,15 +87,23 @@ export function ExportElectionPackageModalButton(): JSX.Element {
         case 'mounted': {
           actions = (
             <React.Fragment>
+              {saveElectionPackageToUsbMutation.isLoading ? (
+                <LoadingButton variant="primary">Saving...</LoadingButton>
+              ) : (
+                <Button
+                  icon="Export"
+                  onPress={saveElectionPackage}
+                  variant="primary"
+                >
+                  Save
+                </Button>
+              )}
               <Button
-                icon="Export"
-                onPress={saveElectionPackage}
-                variant="primary"
-                loading={saveElectionPackageToUsbMutation.isLoading}
+                onPress={closeModal}
+                disabled={saveElectionPackageToUsbMutation.isLoading}
               >
-                Save
+                Cancel
               </Button>
-              <Button onPress={closeModal}>Cancel</Button>
             </React.Fragment>
           );
           title = 'Save Election Package';

--- a/libs/ui/src/button.test.tsx
+++ b/libs/ui/src/button.test.tsx
@@ -9,6 +9,7 @@ import {
   ButtonColor,
   ButtonFill,
   LabelButton,
+  LoadingButton,
 } from './button';
 import { makeTheme } from './themes/make_theme';
 import { Icons } from './icons';
@@ -237,7 +238,11 @@ describe('Button', () => {
       </Button>
     );
     const button = screen.getButton('Add');
-    expect(button.getElementsByTagName('svg')).toHaveLength(1);
+    const icons = button.getElementsByTagName('svg');
+    expect(icons).toHaveLength(1);
+    const [icon] = icons;
+    expect(icon).toHaveAttribute('data-icon', 'circle-plus');
+    expect(button.firstChild).toEqual(icon);
   });
 
   test('with icon name', () => {
@@ -247,7 +252,11 @@ describe('Button', () => {
       </Button>
     );
     const button = screen.getButton('Add');
-    expect(button.getElementsByTagName('svg')).toHaveLength(1);
+    const icons = button.getElementsByTagName('svg');
+    expect(icons).toHaveLength(1);
+    const [icon] = icons;
+    expect(icon).toHaveAttribute('data-icon', 'circle-plus');
+    expect(button.firstChild).toEqual(icon);
   });
 
   test('with rightIcon component', () => {
@@ -257,7 +266,11 @@ describe('Button', () => {
       </Button>
     );
     const button = screen.getButton('Add');
-    expect(button.getElementsByTagName('svg')).toHaveLength(1);
+    const icons = button.getElementsByTagName('svg');
+    expect(icons).toHaveLength(1);
+    const [icon] = icons;
+    expect(icon).toHaveAttribute('data-icon', 'circle-plus');
+    expect(button.lastChild).toEqual(icon);
   });
 
   test('with rightIcon name', () => {
@@ -267,7 +280,11 @@ describe('Button', () => {
       </Button>
     );
     const button = screen.getButton('Add');
-    expect(button.getElementsByTagName('svg')).toHaveLength(1);
+    const icons = button.getElementsByTagName('svg');
+    expect(icons).toHaveLength(1);
+    const [icon] = icons;
+    expect(icon).toHaveAttribute('data-icon', 'circle-plus');
+    expect(button.lastChild).toEqual(icon);
   });
 
   test('focus()/blur() API', () => {
@@ -335,5 +352,18 @@ describe('Button', () => {
     expect(screen.getByText('I am a label').tagName.toLowerCase()).toEqual(
       'label'
     );
+  });
+});
+
+describe('LoadingButton', () => {
+  test('is disabled and shows spinner', () => {
+    render(<LoadingButton>Saving...</LoadingButton>);
+    const button = screen.getButton('Saving...');
+    expect(button).toBeDisabled();
+    const icons = button.getElementsByTagName('svg');
+    expect(icons).toHaveLength(1);
+    const [icon] = icons;
+    expect(icon).toHaveAttribute('data-icon', 'spinner');
+    expect(button.firstChild).toEqual(icon);
   });
 });

--- a/libs/ui/src/button.tsx
+++ b/libs/ui/src/button.tsx
@@ -519,3 +519,21 @@ export const LabelButton = styled.label`
     ${(p) => css(activeStyles(p))}
   }
 `;
+
+/**
+ * A disabled button that shows a loading spinner. Swap this button out for a
+ * submit button while a form or async action is submitting. Don't forget to add
+ * the variant or other styles from the original button.
+ *
+ * Example usage:
+ *  {someMutation.isLoading ? (
+ *    <LoadingButton variant="primary">Saving...</LoadingButton>
+ *  ) : (
+ *    <Button variant="primary" onPress={someMutation.mutate}>Save</Button>
+ *  )}
+ */
+export function LoadingButton(
+  props: Omit<ButtonProps, 'disabled' | 'onPress' | 'icon'>
+): JSX.Element {
+  return <Button {...props} onPress={() => {}} disabled icon="Loading" />;
+}


### PR DESCRIPTION
## Overview

_Review by commit_

Fixes #4043 

- Adds a new `loading` prop to `Button` that disables the button and shows a loading spinner.
- Uses this prop to add a loading state to the Save Election Package modal.

## Demo Video or Screenshot

https://github.com/votingworks/vxsuite/assets/530106/78f61728-92ee-480f-b926-260cbdbbda39




## Testing Plan
Manual and automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
