### PR TITLE
VxAdmin: delete election on unconfigure rather than simply marking as 'deleted'

### DIFF
--- a/apps/admin/backend/schema.sql
+++ b/apps/admin/backend/schema.sql
@@ -3,8 +3,7 @@ create table elections (
   election_data text not null,
   system_settings_data text not null,
   is_official_results boolean not null default false,
-  created_at timestamp not null default current_timestamp,
-  deleted_at timestamp
+  created_at timestamp not null default current_timestamp
 );
 
 create table precincts(

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -354,7 +354,6 @@ function buildApi({
 
     async unconfigure(): Promise<void> {
       store.deleteElection(loadCurrentElectionIdOrThrow(workspace));
-      store.setCurrentElectionId();
       await logger.log(
         LogEventId.ElectionUnconfigured,
         assertDefined(await getUserRole()),

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -202,7 +202,6 @@ export class Store {
         datetime(created_at, 'localtime') as createdAt,
         is_official_results as isOfficialResults
       from elections
-      where deleted_at is null
     `) as Array<{
         id: Id;
         electionData: string;
@@ -231,7 +230,7 @@ export class Store {
         datetime(created_at, 'localtime') as createdAt,
         is_official_results as isOfficialResults
       from elections
-      where deleted_at is null AND id = ?
+      where id = ?
     `,
       electionId
     ) as
@@ -260,9 +259,10 @@ export class Store {
    */
   deleteElection(id: Id): void {
     this.client.run(
-      'update elections set deleted_at = current_timestamp where id = ?',
+      'update settings set current_election_id = null where current_election_id = ?',
       id
     );
+    this.client.run('delete from elections where id = ?', id);
   }
 
   /**
@@ -272,7 +272,7 @@ export class Store {
     const election = this.client.one(
       `
         select id from elections
-        where id = ? and deleted_at is null
+        where id = ?
       `,
       electionId
     ) as { id: Id } | undefined;


### PR DESCRIPTION
We haven't been deleting election data from the VxAdmin store on unconfigure, which could lead to the disk filling up over time.

https://votingworks.slack.com/archives/C060FEVB2L8/p1702320174466059

