### PR TITLE
Address two more continuous export edge cases

### DIFF
--- a/apps/scan/backend/schema.sql
+++ b/apps/scan/backend/schema.sql
@@ -59,16 +59,14 @@ create table system_settings (
   data text not null -- JSON blob
 );
 
-create table is_continuous_export_operation_in_progress (
-  -- Enforce singleton table
-  id integer primary key check (id = 1),
-  is_continuous_export_operation_in_progress boolean not null
-);
-
 create table export_directory_name (
   -- Enforce singleton table
   id integer primary key check (id = 1),
   export_directory_name text not null
+);
+
+create table pending_continuous_export_operations (
+  sheet_id text primary key check (length(sheet_id) = 36)
 );
 
 create table cvr_hashes (

--- a/apps/scan/backend/scripts/copy_sheets.ts
+++ b/apps/scan/backend/scripts/copy_sheets.ts
@@ -37,7 +37,7 @@ function parseCommandLineArgs(args: readonly string[]): CopySheetsInput {
   return { targetSheetCount };
 }
 
-function copySheet(store: Store, sheet: AcceptedSheet): void {
+function copySheet(store: Store, sheet: AcceptedSheet): string {
   const newSheetId = uuid();
   const newSheet: AcceptedSheet = {
     ...sheet,
@@ -65,6 +65,7 @@ function copySheet(store: Store, sheet: AcceptedSheet): void {
       interpretation: newSheet.interpretation[1],
     },
   ]);
+  return newSheetId;
 }
 
 function copySheets({ targetSheetCount }: CopySheetsInput): void {
@@ -89,9 +90,11 @@ function copySheets({ targetSheetCount }: CopySheetsInput): void {
     .take(maxNumSheetsToReadForCopying)
     .toArray();
 
+  const newSheetIds: string[] = [];
   for (let i = 0; i < numSheetsToCreate; i += 1) {
     const sheet = sheets[i % sheets.length];
-    copySheet(store, sheet);
+    const newSheetId = copySheet(store, sheet);
+    newSheetIds.push(newSheetId);
   }
 
   const sheetOrSheets = numSheetsToCreate === 1 ? 'sheet' : 'sheets';
@@ -101,7 +104,9 @@ function copySheets({ targetSheetCount }: CopySheetsInput): void {
   );
 
   // Ensure that we sync cast vote records to the now out-of-sync USB drive
-  store.setIsContinuousExportOperationInProgress(true);
+  for (const newSheetId of newSheetIds) {
+    store.addPendingContinuousExportOperation(newSheetId);
+  }
   console.log(
     '🟡 Restart VxScan if already running ' +
       'to surface the prompt to sync cast vote records to the now out-of-sync USB drive'

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -234,8 +234,12 @@ export function buildApi(
       store.setIsUltrasonicDisabled(input.isUltrasonicDisabled);
     },
 
-    setTestMode(input: { isTestMode: boolean }): void {
-      workspace.resetElectionSession();
+    async setTestMode(input: { isTestMode: boolean }): Promise<void> {
+      // Use the continuous export mutex to ensure that any pending continuous export operations
+      // finish first
+      await workspace.continuousExportMutex.withLock(() =>
+        workspace.resetElectionSession()
+      );
       store.setTestMode(input.isTestMode);
     },
 

--- a/apps/scan/backend/src/app_config.test.ts
+++ b/apps/scan/backend/src/app_config.test.ts
@@ -7,32 +7,18 @@ import waitForExpect from 'wait-for-expect';
 import { LogEventId } from '@votingworks/logging';
 import {
   BooleanEnvironmentVariableName,
-  convertCastVoteRecordVotesToTabulationVotes,
-  getCurrentSnapshot,
   getFeatureFlagMock,
   singlePrecinctSelectionFor,
 } from '@votingworks/utils';
-import {
-  assertDefined,
-  err,
-  find,
-  iter,
-  ok,
-  typedAs,
-  unique,
-} from '@votingworks/basics';
+import { err, find, iter, ok, typedAs, unique } from '@votingworks/basics';
 import {
   fakeElectionManagerUser,
   fakeSessionExpiresAt,
   mockOf,
 } from '@votingworks/test-utils';
-import {
-  getCastVoteRecordExportDirectoryPaths,
-  mockElectionPackageFileTree,
-  readCastVoteRecordExport,
-} from '@votingworks/backend';
+import { mockElectionPackageFileTree } from '@votingworks/backend';
 import { InsertedSmartCardAuthApi } from '@votingworks/auth';
-import { CVR, ElectionDefinition } from '@votingworks/types';
+import { ElectionDefinition } from '@votingworks/types';
 import { configureApp } from '../test/helpers/shared_helpers';
 import { scanBallot, withApp } from '../test/helpers/custom_helpers';
 import { PrecinctScannerPollsInfo } from '.';
@@ -161,159 +147,6 @@ test("if there's only one precinct in the election, it's selected automatically 
       precinctId: 'precinct-1',
     });
   });
-});
-
-test('continuous CVR export, including polls closing', async () => {
-  await withApp(
-    {},
-    async ({ apiClient, mockAuth, mockScanner, mockUsbDrive, workspace }) => {
-      await configureApp(apiClient, mockAuth, mockUsbDrive, { testMode: true });
-
-      // Don't wait for continuous export to USB drive in between scans and polls closing so that
-      // we can verify that the continuous export mutex prevents continuous export operations from
-      // interleaving
-      await scanBallot(mockScanner, apiClient, workspace.store, 0, {
-        waitForContinuousExportToUsbDrive: false,
-      });
-      await scanBallot(mockScanner, apiClient, workspace.store, 1, {
-        waitForContinuousExportToUsbDrive: false,
-      });
-      await scanBallot(mockScanner, apiClient, workspace.store, 2, {
-        waitForContinuousExportToUsbDrive: false,
-      });
-
-      expect(
-        await apiClient.exportCastVoteRecordsToUsbDrive({
-          mode: 'polls_closing',
-        })
-      ).toEqual(ok());
-
-      const exportDirectoryPaths = await getCastVoteRecordExportDirectoryPaths(
-        mockUsbDrive.usbDrive
-      );
-      expect(exportDirectoryPaths).toHaveLength(1);
-      const exportDirectoryPath = exportDirectoryPaths[0];
-      expect(exportDirectoryPath).toMatch(/TEST__machine_000__*/);
-
-      const { castVoteRecordExportMetadata, castVoteRecordIterator } = (
-        await readCastVoteRecordExport(exportDirectoryPath)
-      ).unsafeUnwrap();
-
-      expect(castVoteRecordExportMetadata.arePollsClosed).toEqual(true);
-      expect(
-        castVoteRecordExportMetadata.castVoteRecordReportMetadata.vxBatch[0]
-          .NumberSheets
-      ).toEqual(3);
-
-      const castVoteRecords: CVR.CVR[] = (
-        await castVoteRecordIterator.toArray()
-      ).map(
-        (castVoteRecordResult) =>
-          castVoteRecordResult.unsafeUnwrap().castVoteRecord
-      );
-      expect(castVoteRecords).toHaveLength(3);
-
-      for (const castVoteRecord of castVoteRecords) {
-        const tabulationVotes = convertCastVoteRecordVotesToTabulationVotes(
-          assertDefined(getCurrentSnapshot(castVoteRecord))
-        );
-        expect(tabulationVotes).toEqual({
-          attorney: ['john-snow'],
-          'board-of-alderman': [
-            'helen-keller',
-            'steve-jobs',
-            'nikola-tesla',
-            'vincent-van-gogh',
-          ],
-          'chief-of-police': ['natalie-portman'],
-          'city-council': [
-            'marie-curie',
-            'indiana-jones',
-            'mona-lisa',
-            'jackie-chan',
-          ],
-          controller: ['winston-churchill'],
-          mayor: ['sherlock-holmes'],
-          'parks-and-recreation-director': ['charles-darwin'],
-          'public-works-director': ['benjamin-franklin'],
-        });
-      }
-    }
-  );
-});
-
-test('continuous CVR export, including polls closing, followed by a full export', async () => {
-  await withApp(
-    {},
-    async ({ apiClient, mockAuth, mockScanner, mockUsbDrive, workspace }) => {
-      await configureApp(apiClient, mockAuth, mockUsbDrive, { testMode: true });
-
-      // Don't wait for continuous export to USB drive in between scans and polls closing so that
-      // we can verify that the continuous export mutex prevents continuous export operations from
-      // interleaving
-      await scanBallot(mockScanner, apiClient, workspace.store, 0, {
-        waitForContinuousExportToUsbDrive: false,
-      });
-      await scanBallot(mockScanner, apiClient, workspace.store, 1, {
-        waitForContinuousExportToUsbDrive: false,
-      });
-
-      expect(
-        await apiClient.exportCastVoteRecordsToUsbDrive({
-          mode: 'polls_closing',
-        })
-      ).toEqual(ok());
-
-      expect(
-        await apiClient.exportCastVoteRecordsToUsbDrive({
-          mode: 'full_export',
-        })
-      ).toEqual(ok());
-
-      // Expect two export directories, one from continuous export and one from the subsequent full
-      // export. Each should contain two CVRs.
-      const exportDirectoryPaths = await getCastVoteRecordExportDirectoryPaths(
-        mockUsbDrive.usbDrive
-      );
-      expect(exportDirectoryPaths).toHaveLength(2);
-
-      for (const exportDirectoryPath of exportDirectoryPaths) {
-        const { castVoteRecordIterator } = (
-          await readCastVoteRecordExport(exportDirectoryPath)
-        ).unsafeUnwrap();
-        const castVoteRecords: CVR.CVR[] = (
-          await castVoteRecordIterator.toArray()
-        ).map(
-          (castVoteRecordResult) =>
-            castVoteRecordResult.unsafeUnwrap().castVoteRecord
-        );
-        expect(castVoteRecords).toHaveLength(2);
-      }
-    }
-  );
-});
-
-test('CVR resync', async () => {
-  await withApp(
-    {},
-    async ({ apiClient, mockAuth, mockScanner, mockUsbDrive, workspace }) => {
-      await configureApp(apiClient, mockAuth, mockUsbDrive, { testMode: true });
-
-      await scanBallot(mockScanner, apiClient, workspace.store, 0);
-
-      // When a CVR resync is required, the CVR resync modal appears on the "insert your ballot"
-      // screen, i.e. the screen displayed when no card is inserted
-      mockOf(mockAuth.getAuthStatus).mockImplementation(() =>
-        Promise.resolve({ status: 'logged_out', reason: 'no_card' })
-      );
-
-      expect(
-        await apiClient.exportCastVoteRecordsToUsbDrive({
-          mode: 'full_export',
-        })
-      ).toEqual(ok());
-    }
-  );
 });
 
 test('setPrecinctSelection will reset polls to closed', async () => {

--- a/apps/scan/backend/src/app_export.test.ts
+++ b/apps/scan/backend/src/app_export.test.ts
@@ -1,0 +1,186 @@
+import {
+  getCastVoteRecordExportDirectoryPaths,
+  readCastVoteRecordExport,
+} from '@votingworks/backend';
+import { assertDefined, ok } from '@votingworks/basics';
+import { mockOf } from '@votingworks/test-utils';
+import { CVR } from '@votingworks/types';
+import {
+  BooleanEnvironmentVariableName,
+  convertCastVoteRecordVotesToTabulationVotes,
+  getCurrentSnapshot,
+  getFeatureFlagMock,
+} from '@votingworks/utils';
+
+import { scanBallot, withApp } from '../test/helpers/custom_helpers';
+import { configureApp } from '../test/helpers/shared_helpers';
+
+jest.setTimeout(30_000);
+
+const mockFeatureFlagger = getFeatureFlagMock();
+
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
+  return {
+    ...jest.requireActual('@votingworks/utils'),
+    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+  };
+});
+
+beforeEach(() => {
+  mockFeatureFlagger.resetFeatureFlags();
+  mockFeatureFlagger.enableFeatureFlag(
+    BooleanEnvironmentVariableName.SKIP_ELECTION_PACKAGE_AUTHENTICATION
+  );
+});
+
+test('continuous CVR export, including polls closing', async () => {
+  await withApp(
+    {},
+    async ({ apiClient, mockAuth, mockScanner, mockUsbDrive, workspace }) => {
+      await configureApp(apiClient, mockAuth, mockUsbDrive, { testMode: true });
+
+      // Don't wait for continuous export to USB drive in between scans and polls closing so that
+      // we can verify that the continuous export mutex prevents continuous export operations from
+      // interleaving
+      await scanBallot(mockScanner, apiClient, workspace.store, 0, {
+        waitForContinuousExportToUsbDrive: false,
+      });
+      await scanBallot(mockScanner, apiClient, workspace.store, 1, {
+        waitForContinuousExportToUsbDrive: false,
+      });
+      await scanBallot(mockScanner, apiClient, workspace.store, 2, {
+        waitForContinuousExportToUsbDrive: false,
+      });
+
+      expect(
+        await apiClient.exportCastVoteRecordsToUsbDrive({
+          mode: 'polls_closing',
+        })
+      ).toEqual(ok());
+
+      const exportDirectoryPaths = await getCastVoteRecordExportDirectoryPaths(
+        mockUsbDrive.usbDrive
+      );
+      expect(exportDirectoryPaths).toHaveLength(1);
+      expect(exportDirectoryPaths[0]).toMatch(/\/TEST__machine_000__*/);
+
+      const { castVoteRecordExportMetadata, castVoteRecordIterator } = (
+        await readCastVoteRecordExport(exportDirectoryPaths[0])
+      ).unsafeUnwrap();
+
+      expect(castVoteRecordExportMetadata.arePollsClosed).toEqual(true);
+      expect(
+        castVoteRecordExportMetadata.castVoteRecordReportMetadata.vxBatch[0]
+          .NumberSheets
+      ).toEqual(3);
+
+      const castVoteRecords: CVR.CVR[] = (
+        await castVoteRecordIterator.toArray()
+      ).map(
+        (castVoteRecordResult) =>
+          castVoteRecordResult.unsafeUnwrap().castVoteRecord
+      );
+      expect(castVoteRecords).toHaveLength(3);
+
+      for (const castVoteRecord of castVoteRecords) {
+        const tabulationVotes = convertCastVoteRecordVotesToTabulationVotes(
+          assertDefined(getCurrentSnapshot(castVoteRecord))
+        );
+        expect(tabulationVotes).toEqual({
+          attorney: ['john-snow'],
+          'board-of-alderman': [
+            'helen-keller',
+            'steve-jobs',
+            'nikola-tesla',
+            'vincent-van-gogh',
+          ],
+          'chief-of-police': ['natalie-portman'],
+          'city-council': [
+            'marie-curie',
+            'indiana-jones',
+            'mona-lisa',
+            'jackie-chan',
+          ],
+          controller: ['winston-churchill'],
+          mayor: ['sherlock-holmes'],
+          'parks-and-recreation-director': ['charles-darwin'],
+          'public-works-director': ['benjamin-franklin'],
+        });
+      }
+    }
+  );
+});
+
+test('continuous CVR export, including polls closing, followed by a full export', async () => {
+  await withApp(
+    {},
+    async ({ apiClient, mockAuth, mockScanner, mockUsbDrive, workspace }) => {
+      await configureApp(apiClient, mockAuth, mockUsbDrive, { testMode: true });
+
+      // Don't wait for continuous export to USB drive in between scans and polls closing so that
+      // we can verify that the continuous export mutex prevents continuous export operations from
+      // interleaving
+      await scanBallot(mockScanner, apiClient, workspace.store, 0, {
+        waitForContinuousExportToUsbDrive: false,
+      });
+      await scanBallot(mockScanner, apiClient, workspace.store, 1, {
+        waitForContinuousExportToUsbDrive: false,
+      });
+
+      expect(
+        await apiClient.exportCastVoteRecordsToUsbDrive({
+          mode: 'polls_closing',
+        })
+      ).toEqual(ok());
+
+      expect(
+        await apiClient.exportCastVoteRecordsToUsbDrive({
+          mode: 'full_export',
+        })
+      ).toEqual(ok());
+
+      // Expect two export directories, one from continuous export and one from the subsequent full
+      // export. Each should contain two CVRs.
+      const exportDirectoryPaths = await getCastVoteRecordExportDirectoryPaths(
+        mockUsbDrive.usbDrive
+      );
+      expect(exportDirectoryPaths).toHaveLength(2);
+
+      for (const exportDirectoryPath of exportDirectoryPaths) {
+        const { castVoteRecordIterator } = (
+          await readCastVoteRecordExport(exportDirectoryPath)
+        ).unsafeUnwrap();
+        const castVoteRecords: CVR.CVR[] = (
+          await castVoteRecordIterator.toArray()
+        ).map(
+          (castVoteRecordResult) =>
+            castVoteRecordResult.unsafeUnwrap().castVoteRecord
+        );
+        expect(castVoteRecords).toHaveLength(2);
+      }
+    }
+  );
+});
+
+test('CVR resync', async () => {
+  await withApp(
+    {},
+    async ({ apiClient, mockAuth, mockScanner, mockUsbDrive, workspace }) => {
+      await configureApp(apiClient, mockAuth, mockUsbDrive, { testMode: true });
+
+      await scanBallot(mockScanner, apiClient, workspace.store, 0);
+
+      // When a CVR resync is required, the CVR resync modal appears on the "insert your ballot"
+      // screen, i.e. the screen displayed when no card is inserted
+      mockOf(mockAuth.getAuthStatus).mockImplementation(() =>
+        Promise.resolve({ status: 'logged_out', reason: 'no_card' })
+      );
+
+      expect(
+        await apiClient.exportCastVoteRecordsToUsbDrive({
+          mode: 'full_export',
+        })
+      ).toEqual(ok());
+    }
+  );
+});

--- a/apps/scan/backend/src/scanners/custom/state_machine.ts
+++ b/apps/scan/backend/src/scanners/custom/state_machine.ts
@@ -391,8 +391,8 @@ async function recordAcceptedSheet(
       store.adjudicateSheet(sheetId);
     }
 
-    // Gets reset to false within exportCastVoteRecordsToUsbDrive
-    store.setIsContinuousExportOperationInProgress(true);
+    // Marked as complete within exportCastVoteRecordsToUsbDrive
+    store.addPendingContinuousExportOperation(sheetId);
   });
 
   const exportResult = await continuousExportMutex.withLock(() =>
@@ -423,8 +423,8 @@ async function recordRejectedSheet(
     // ballot wasn't counted.
     store.deleteSheet(sheetId);
 
-    // Gets reset to false within exportCastVoteRecordsToUsbDrive
-    store.setIsContinuousExportOperationInProgress(true);
+    // Marked as complete within exportCastVoteRecordsToUsbDrive
+    store.addPendingContinuousExportOperation(sheetId);
   });
 
   const exportResult = await continuousExportMutex.withLock(() =>

--- a/apps/scan/backend/test/helpers/shared_helpers.ts
+++ b/apps/scan/backend/test/helpers/shared_helpers.ts
@@ -107,7 +107,7 @@ export async function waitForContinuousExportToUsbDrive(
   store: Store
 ): Promise<void> {
   await waitForExpect(
-    () => expect(store.isContinuousExportOperationInProgress()).toEqual(false),
+    () => expect(store.getPendingContinuousExportOperations()).toEqual([]),
     10000,
     250
   );

--- a/libs/backend/src/cast_vote_records/export.test.ts
+++ b/libs/backend/src/cast_vote_records/export.test.ts
@@ -822,7 +822,9 @@ test.each<{
       mockPrecinctScannerStore.setBallotsCounted(1);
       const usbDriveStatus = await mockUsbDrive.usbDrive.status();
       assert(usbDriveStatus.status === 'mounted');
-      mockPrecinctScannerStore.setIsContinuousExportOperationInProgress(true);
+      mockPrecinctScannerStore.addPendingContinuousExportOperation(
+        'abcd1234-0000-0000-0000-000000000000'
+      );
     },
     shouldUsbDriveRequireCastVoteRecordSync: true,
   },

--- a/libs/backend/test/utils.ts
+++ b/libs/backend/test/utils.ts
@@ -114,15 +114,26 @@ export class MockPrecinctScannerStore
 
   private ballotsCounted: number;
   private exportDirectoryName?: string;
-  private isContinuousExportOperationInProgressValue: boolean;
+  private pendingContinuousExportOperations: string[];
   private pollsState: PollsState;
 
   constructor() {
     super();
     this.ballotsCounted = 0;
     this.exportDirectoryName = undefined;
-    this.isContinuousExportOperationInProgressValue = false;
+    this.pendingContinuousExportOperations = [];
     this.pollsState = 'polls_closed_initial';
+  }
+
+  deleteAllPendingContinuousExportOperations(): void {
+    this.pendingContinuousExportOperations = [];
+  }
+
+  deletePendingContinuousExportOperation(sheetIdToDelete: string): void {
+    this.pendingContinuousExportOperations =
+      this.pendingContinuousExportOperations.filter(
+        (sheetId) => sheetId !== sheetIdToDelete
+      );
   }
 
   getBallotsCounted(): number {
@@ -133,28 +144,25 @@ export class MockPrecinctScannerStore
     return this.exportDirectoryName;
   }
 
-  getPollsState(): PollsState {
-    return this.pollsState;
+  getPendingContinuousExportOperations(): string[] {
+    return this.pendingContinuousExportOperations;
   }
 
-  isContinuousExportOperationInProgress(): boolean {
-    return this.isContinuousExportOperationInProgressValue;
+  getPollsState(): PollsState {
+    return this.pollsState;
   }
 
   setExportDirectoryName(exportDirectoryName: string): void {
     this.exportDirectoryName = exportDirectoryName;
   }
 
-  setIsContinuousExportOperationInProgress(
-    isContinuousExportOperationInProgress: boolean
-  ): void {
-    this.isContinuousExportOperationInProgressValue =
-      isContinuousExportOperationInProgress;
-  }
-
   //
   // Methods to facilitate testing, beyond the ScannerStore interface
   //
+
+  addPendingContinuousExportOperation(sheetId: string): void {
+    this.pendingContinuousExportOperations.push(sheetId);
+  }
 
   setBallotsCounted(ballotsCounted: number): void {
     this.ballotsCounted = ballotsCounted;

--- a/libs/utils/src/mutex.ts
+++ b/libs/utils/src/mutex.ts
@@ -81,7 +81,7 @@ export class Mutex<T = void> {
    * Acquires the lock or waits until it is available, then runs the given
    * function and releases the lock automatically.
    */
-  async withLock<U>(fn: (value: T) => Promise<U>): Promise<U> {
+  async withLock<U>(fn: (value: T) => U | Promise<U>): Promise<U> {
     const { value, unlock } = await this.asyncLock();
     try {
       return await fn(value);


### PR DESCRIPTION
_Easiest reviewed by commit_

## Overview

After merging https://github.com/votingworks/vxsuite/pull/4365, I thought of two more continuous export edge cases worth addressing.

### Edge case 1

In that previous PR, I was focused on avoiding spurious "CVR Sync Required" screens. But a specific race condition could also cause us to miss a case where we _should_ display the screen. Consider the following sequence:

1. Ballot 1 is accepted, and we set `isContinuousExportOperationInProgress` to true
2. Export operation 1 (for ballot 1) starts
3. Ballot 2 is accepted, and we set `isContinuousExportOperationInProgress` to true
4. Export operation 1 completes and sets `isContinuousExportOperationInProgress` to false
5. Export operation 2 (for ballot 2) starts
6. Export operation 2 fails

We'd fail to display the "CVR Sync Required" screen on reboot because `isContinuousExportOperationInProgress` is false. The issue is that we're using a single boolean to track the status of all of the continuous export operations. What we really want is a list of all running operations. On reboot, we can check if this list is empty or not.

Side note: This change will make it much easier to implement https://github.com/votingworks/vxsuite/issues/4216.

### Edge case 2

In https://github.com/votingworks/vxsuite/pull/4365, I updated a number of operations (polls close, full export, etc.) to first wait for any pending continuous export operations. I forgot to cover mode-switching in that update.

## Testing Plan

- [x] Updated automated tests
- [x] Tested manually with a slow USB 2.0 drive, which makes all of these edge cases more likely

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A