### PR TITLE
Fix unconfiguring VxAdmin in integration test

### DIFF
--- a/apps/admin/integration-testing/e2e/support/auth.ts
+++ b/apps/admin/integration-testing/e2e/support/auth.ts
@@ -74,14 +74,16 @@ export async function forceLogOutAndResetElectionDefinition(
   await logInAsSystemAdministrator(page);
   await page.getByRole('button', { name: 'Election', exact: true }).click();
 
-  const removeElectionButton = page.getByRole('button', {
-    name: 'Remove Election',
+  const unconfigureMachineButton = page.getByRole('button', {
+    name: 'Unconfigure Machine',
   });
 
-  if (await removeElectionButton.isVisible()) {
-    await removeElectionButton.click();
+  if (await unconfigureMachineButton.isVisible()) {
+    await unconfigureMachineButton.click();
     const modal = page.getByRole('alertdialog');
-    await modal.getByRole('button', { name: 'Remove Election' }).click();
+    await modal
+      .getByRole('button', { name: 'Yes, Delete Election Data' })
+      .click();
   }
 
   await forceLogOut(page);


### PR DESCRIPTION
## Overview

Missed this in #4349 

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
