### PR TITLE
VxAdmin: Add District Filtering

### DIFF
--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -85,7 +85,7 @@ import {
 } from './cast_vote_records';
 import { generateBallotCountReportCsv } from './exports/csv_ballot_count_report';
 import { adjudicateWriteIn } from './adjudication';
-import { convertFrontendFilter as convertFrontendFileUtil } from './util/filters';
+import { convertFrontendFilter as convertFrontendFilterUtil } from './util/filters';
 
 const debug = rootDebug.extend('app');
 
@@ -162,7 +162,7 @@ function buildApi({
     const {
       electionDefinition: { election },
     } = assertDefined(store.getElection(electionId));
-    return convertFrontendFileUtil(filter, election);
+    return convertFrontendFilterUtil(filter, election);
   }
 
   return grout.createApi({

--- a/apps/admin/backend/src/tabulation/card_counts.ts
+++ b/apps/admin/backend/src/tabulation/card_counts.ts
@@ -11,6 +11,7 @@ import { CardTally } from '../types';
 import { Store } from '../store';
 import { tabulateManualBallotCounts } from './manual_results';
 import { rootDebug } from '../util/debug';
+import { assertIsBackendFilter } from '../util/filters';
 
 const debug = rootDebug.extend('card-counts');
 
@@ -53,6 +54,7 @@ export function tabulateScannedCardCounts({
   filter?: Admin.ReportingFilter;
   groupBy?: Tabulation.GroupBy;
 }): Tabulation.GroupMap<Tabulation.CardCounts> {
+  assertIsBackendFilter(filter);
   debug('querying scanned card tallies');
   const cardTallies = store.getCardTallies({
     electionId,

--- a/apps/admin/backend/src/tabulation/full_results.ts
+++ b/apps/admin/backend/src/tabulation/full_results.ts
@@ -15,6 +15,7 @@ import {
 } from './write_ins';
 import { tabulateManualResults } from './manual_results';
 import { rootDebug } from '../util/debug';
+import { assertIsBackendFilter } from '../util/filters';
 
 const debug = rootDebug.extend('tabulation');
 
@@ -32,6 +33,7 @@ export function tabulateCastVoteRecords({
   filter?: Tabulation.Filter;
   groupBy?: Tabulation.GroupBy;
 }): Promise<Tabulation.ElectionResultsGroupMap> {
+  assertIsBackendFilter(filter);
   const {
     electionDefinition: { election },
   } = assertDefined(store.getElection(electionId));

--- a/apps/admin/backend/src/util/filters.test.ts
+++ b/apps/admin/backend/src/util/filters.test.ts
@@ -1,0 +1,89 @@
+import { electionGeneral } from '@votingworks/fixtures';
+import { Admin } from '@votingworks/types';
+import { assertIsBackendFilter, convertFrontendFilter } from './filters';
+
+test('convertFrontendFilter', () => {
+  expect(
+    convertFrontendFilter(
+      {
+        districtIds: ['district-1'],
+      },
+      electionGeneral
+    )
+  ).toEqual({
+    ballotStyleIds: ['12', '5'],
+  });
+
+  expect(
+    convertFrontendFilter(
+      {
+        districtIds: ['district-2'],
+      },
+      electionGeneral
+    )
+  ).toEqual({
+    ballotStyleIds: ['12'],
+  });
+
+  expect(
+    convertFrontendFilter(
+      {
+        districtIds: ['district-1', 'district-2'],
+      },
+      electionGeneral
+    )
+  ).toEqual({
+    ballotStyleIds: ['12', '5'],
+  });
+
+  expect(
+    convertFrontendFilter(
+      {
+        votingMethods: ['absentee'],
+        ballotStyleIds: ['12'],
+      },
+      electionGeneral
+    )
+  ).toEqual({
+    votingMethods: ['absentee'],
+    ballotStyleIds: ['12'],
+  });
+
+  expect(
+    convertFrontendFilter(
+      {
+        districtIds: ['district-2'],
+        ballotStyleIds: ['12'],
+      },
+      electionGeneral
+    )
+  ).toEqual({
+    ballotStyleIds: ['12'],
+  });
+
+  // should exclude all ballots, because there is no intersection between district and ballot styles
+  expect(
+    convertFrontendFilter(
+      {
+        districtIds: ['district-2'],
+        ballotStyleIds: ['5'],
+      },
+      electionGeneral
+    )
+  ).toEqual({
+    ballotStyleIds: [],
+  });
+});
+
+test('assertIsBackendFilter', () => {
+  const filter: Admin.FrontendReportingFilter = {
+    districtIds: ['12'],
+  };
+  expect(() => {
+    assertIsBackendFilter(filter);
+  }).toThrowError();
+
+  expect(() => {
+    assertIsBackendFilter({ precinctIds: ['precinct-1'] });
+  }).not.toThrowError();
+});

--- a/apps/admin/backend/src/util/filters.ts
+++ b/apps/admin/backend/src/util/filters.ts
@@ -1,0 +1,42 @@
+import { Admin, Election } from '@votingworks/types';
+
+/**
+ * The frontend filter interface allows filtering on geographical district,
+ * which has a many-to-many relationship with ballot styles. In this helper,
+ * we reduce the district filters into ballot style filters.
+ */
+export function convertFrontendFilter(
+  frontendFilter: Admin.FrontendReportingFilter,
+  election: Election
+): Admin.ReportingFilter {
+  const { districtIds, ...rest } = frontendFilter;
+  if (!districtIds) return rest;
+
+  const districtBallotStyleIds = election.ballotStyles
+    .filter((bs) =>
+      bs.districts.some((districtId) => districtIds.includes(districtId))
+    )
+    .map((bs) => bs.id);
+
+  // the new filter should be the intersection of the district-based ballot styles
+  // and the pre-existing list of ballot styles, if one exists
+  const ballotStyleIds = rest.ballotStyleIds
+    ? rest.ballotStyleIds.filter((id) => districtBallotStyleIds.includes(id))
+    : districtBallotStyleIds;
+
+  return {
+    ...rest,
+    ballotStyleIds,
+  };
+}
+
+/**
+ * Confirm that filter doesn't contain dimensions which should have been pre-processed.
+ */
+export function assertIsBackendFilter(filter?: Admin.ReportingFilter): void {
+  if (filter && 'districtIds' in filter) {
+    throw new Error(
+      'filter contains unused dimension "districtIds" - does that need to be converted to ballotStyleIds?'
+    );
+  }
+}

--- a/apps/admin/frontend/src/components/admin_tally_report_by_party.tsx
+++ b/apps/admin/frontend/src/components/admin_tally_report_by_party.tsx
@@ -1,4 +1,4 @@
-import { ElectionDefinition, Tabulation } from '@votingworks/types';
+import { Admin, ElectionDefinition } from '@votingworks/types';
 import React from 'react';
 
 import { find, unique } from '@votingworks/basics';
@@ -37,7 +37,7 @@ export function AdminTallyReportByParty({
   isForLogicAndAccuracyTesting?: boolean;
   testId: string;
   generatedAtTime: Date;
-  customFilter?: Tabulation.Filter;
+  customFilter?: Admin.FrontendReportingFilter;
   includeSignatureLines?: boolean;
 }): JSX.Element {
   const { election } = electionDefinition;

--- a/apps/admin/frontend/src/components/reporting/ballot_count_report_viewer.test.tsx
+++ b/apps/admin/frontend/src/components/reporting/ballot_count_report_viewer.test.tsx
@@ -13,7 +13,7 @@ import {
 } from '@votingworks/test-utils';
 import { waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 import { LogEventId, fakeLogger } from '@votingworks/logging';
-import { Tabulation } from '@votingworks/types';
+import { Admin, Tabulation } from '@votingworks/types';
 import { act } from 'react-dom/test-utils';
 import { mockUsbDriveStatus } from '@votingworks/ui';
 import { ApiMock, createApiMock } from '../../../test/helpers/mock_api_client';
@@ -274,7 +274,7 @@ test('print failure logging', async () => {
 
 test('displays custom filter rather than specific title when necessary', async () => {
   const { electionDefinition } = electionFamousNames2021Fixtures;
-  const filter: Tabulation.Filter = {
+  const filter: Admin.FrontendReportingFilter = {
     ballotStyleIds: ['1'],
     precinctIds: ['23'],
     votingMethods: ['absentee'],

--- a/apps/admin/frontend/src/components/reporting/ballot_count_report_viewer.tsx
+++ b/apps/admin/frontend/src/components/reporting/ballot_count_report_viewer.tsx
@@ -57,7 +57,7 @@ function Report({
   isOfficialResults: boolean;
   isTestMode: boolean;
   cardCountsList: Tabulation.GroupList<Tabulation.CardCounts>;
-  filter: Admin.ReportingFilter;
+  filter: Admin.FrontendReportingFilter;
   groupBy: Tabulation.GroupBy;
   includeSheetCounts: boolean;
   generatedAtTime: Date;
@@ -91,7 +91,7 @@ function Report({
 }
 
 export interface BallotCountReportViewerProps {
-  filter: Admin.ReportingFilter;
+  filter: Admin.FrontendReportingFilter;
   groupBy: Tabulation.GroupBy;
   includeSheetCounts: boolean;
   disabled: boolean;

--- a/apps/admin/frontend/src/components/reporting/export_ballot_count_report_csv_button.test.tsx
+++ b/apps/admin/frontend/src/components/reporting/export_ballot_count_report_csv_button.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from '@testing-library/user-event';
-import { Tabulation } from '@votingworks/types';
+import { Admin, Tabulation } from '@votingworks/types';
 import { mockUsbDriveStatus } from '@votingworks/ui';
 import { renderInAppContext } from '../../../test/render_in_app_context';
 import { screen, within } from '../../../test/react_testing_library';
@@ -21,7 +21,7 @@ test('calls mutation in happy path', async () => {
   jest.useFakeTimers();
   jest.setSystemTime(new Date('2021-01-01T00:00:00Z'));
 
-  const filter: Tabulation.Filter = {
+  const filter: Admin.FrontendReportingFilter = {
     votingMethods: ['absentee'],
   };
   const groupBy: Tabulation.GroupBy = {

--- a/apps/admin/frontend/src/components/reporting/export_ballot_count_report_csv_button.tsx
+++ b/apps/admin/frontend/src/components/reporting/export_ballot_count_report_csv_button.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from 'react';
 import { Button } from '@votingworks/ui';
 import { assert } from '@votingworks/basics';
-import { Tabulation } from '@votingworks/types';
+import { Admin, Tabulation } from '@votingworks/types';
 import path from 'path';
 import { generateElectionBasedSubfolderName } from '@votingworks/utils';
 import { AppContext } from '../../contexts/app_context';
@@ -21,7 +21,7 @@ export function ExportBallotCountReportCsvButton({
   includeSheetCounts,
   disabled,
 }: {
-  filter: Tabulation.Filter;
+  filter: Admin.FrontendReportingFilter;
   groupBy: Tabulation.GroupBy;
   includeSheetCounts: boolean;
   disabled?: boolean;

--- a/apps/admin/frontend/src/components/reporting/export_tally_report_csv_button.test.tsx
+++ b/apps/admin/frontend/src/components/reporting/export_tally_report_csv_button.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from '@testing-library/user-event';
-import { Tabulation } from '@votingworks/types';
+import { Admin, Tabulation } from '@votingworks/types';
 import { mockUsbDriveStatus } from '@votingworks/ui';
 import { renderInAppContext } from '../../../test/render_in_app_context';
 import { screen, within } from '../../../test/react_testing_library';
@@ -21,7 +21,7 @@ test('calls mutation in happy path', async () => {
   jest.useFakeTimers();
   jest.setSystemTime(new Date('2021-01-01T00:00:00Z'));
 
-  const filter: Tabulation.Filter = {
+  const filter: Admin.FrontendReportingFilter = {
     votingMethods: ['absentee'],
   };
   const groupBy: Tabulation.GroupBy = {

--- a/apps/admin/frontend/src/components/reporting/export_tally_report_csv_button.tsx
+++ b/apps/admin/frontend/src/components/reporting/export_tally_report_csv_button.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from 'react';
 import { Button } from '@votingworks/ui';
 import { assert } from '@votingworks/basics';
-import { Tabulation } from '@votingworks/types';
+import { Admin, Tabulation } from '@votingworks/types';
 import path from 'path';
 import { generateElectionBasedSubfolderName } from '@votingworks/utils';
 import { AppContext } from '../../contexts/app_context';
@@ -17,7 +17,7 @@ export function ExportTallyReportCsvButton({
   groupBy,
   disabled,
 }: {
-  filter: Tabulation.Filter;
+  filter: Admin.FrontendReportingFilter;
   groupBy: Tabulation.GroupBy;
   disabled?: boolean;
 }): JSX.Element {

--- a/apps/admin/frontend/src/components/reporting/filter_editor.test.tsx
+++ b/apps/admin/frontend/src/components/reporting/filter_editor.test.tsx
@@ -221,6 +221,34 @@ test('adjudication status selection', () => {
   });
 });
 
+test('district filter', () => {
+  const { election } = electionTwoPartyPrimaryDefinition;
+  const onChange = jest.fn();
+
+  apiMock.expectGetScannerBatches([]);
+  renderInAppContext(
+    <FilterEditor
+      election={election}
+      onChange={onChange}
+      allowedFilters={['district']}
+    />,
+    {
+      apiMock,
+    }
+  );
+
+  // add adjudication status filter
+  userEvent.click(screen.getButton('Add Filter'));
+  userEvent.click(screen.getByLabelText('Select New Filter Type'));
+  userEvent.click(screen.getByText('District'));
+  expect(onChange).toHaveBeenNthCalledWith(1, { districtIds: [] });
+  userEvent.click(screen.getByLabelText('Select Filter Values'));
+  userEvent.click(screen.getByText('District 1'));
+  expect(onChange).toHaveBeenNthCalledWith(2, {
+    districtIds: ['district-1'],
+  });
+});
+
 test('can cancel adding a filter', () => {
   const { election } = electionTwoPartyPrimaryDefinition;
   const onChange = jest.fn();

--- a/apps/admin/frontend/src/components/reporting/tally_report_viewer.test.tsx
+++ b/apps/admin/frontend/src/components/reporting/tally_report_viewer.test.tsx
@@ -13,7 +13,7 @@ import {
 } from '@votingworks/test-utils';
 import { waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 import { LogEventId, fakeLogger } from '@votingworks/logging';
-import { Tabulation } from '@votingworks/types';
+import { Admin } from '@votingworks/types';
 import { act } from 'react-dom/test-utils';
 import { mockUsbDriveStatus } from '@votingworks/ui';
 import { ApiMock, createApiMock } from '../../../test/helpers/mock_api_client';
@@ -285,7 +285,7 @@ test('print failure logging', async () => {
 test('displays custom filter rather than specific title when necessary', async () => {
   const { electionDefinition } = electionFamousNames2021Fixtures;
   const { election } = electionDefinition;
-  const filter: Tabulation.Filter = {
+  const filter: Admin.FrontendReportingFilter = {
     ballotStyleIds: ['1'],
     precinctIds: ['23'],
     votingMethods: ['absentee'],

--- a/apps/admin/frontend/src/components/reporting/tally_report_viewer.tsx
+++ b/apps/admin/frontend/src/components/reporting/tally_report_viewer.tsx
@@ -1,4 +1,4 @@
-import { ElectionDefinition, Tabulation } from '@votingworks/types';
+import { Admin, ElectionDefinition, Tabulation } from '@votingworks/types';
 import {
   Button,
   H6,
@@ -63,7 +63,7 @@ function Reports({
   isOfficialResults: boolean;
   isTestMode: boolean;
   allTallyReportResults: Tabulation.GroupList<TallyReportResults>;
-  filterUsed: Tabulation.Filter;
+  filterUsed: Admin.FrontendReportingFilter;
   generatedAtTime: Date;
   scannerBatches: ScannerBatch[];
   includeSignatureLines?: boolean;
@@ -105,7 +105,7 @@ function Reports({
 }
 
 export interface TallyReportViewerProps {
-  filter: Tabulation.Filter;
+  filter: Admin.FrontendReportingFilter;
   groupBy: Tabulation.GroupBy;
   disabled: boolean;
   autoGenerateReport: boolean;

--- a/apps/admin/frontend/src/screens/reporting/ballot_count_report_builder.tsx
+++ b/apps/admin/frontend/src/screens/reporting/ballot_count_report_builder.tsx
@@ -37,11 +37,11 @@ export function BallotCountReportBuilder(): JSX.Element {
   assert(isElectionManagerAuth(auth));
   const { election } = electionDefinition;
 
-  const [filter, setFilter] = useState<Admin.ReportingFilter>({});
+  const [filter, setFilter] = useState<Admin.FrontendReportingFilter>({});
   const [groupBy, setGroupBy] = useState<Tabulation.GroupBy>({});
   const [includeSheetCounts, setIncludeSheetCounts] = useState<boolean>(false);
 
-  function updateFilter(newFilter: Admin.ReportingFilter) {
+  function updateFilter(newFilter: Admin.FrontendReportingFilter) {
     setFilter(canonicalizeFilter(newFilter));
   }
 
@@ -56,6 +56,7 @@ export function BallotCountReportBuilder(): JSX.Element {
     'scanner',
     'voting-method',
     'adjudication-status',
+    'district',
   ];
   const allowedGroupBys: GroupByEditorOption[] = [
     'groupByBallotStyle',

--- a/apps/admin/frontend/src/screens/reporting/tally_report_builder.tsx
+++ b/apps/admin/frontend/src/screens/reporting/tally_report_builder.tsx
@@ -6,7 +6,7 @@ import {
   isFilterEmpty,
   isGroupByEmpty,
 } from '@votingworks/utils';
-import { Tabulation } from '@votingworks/types';
+import { Admin, Tabulation } from '@votingworks/types';
 import { AppContext } from '../../contexts/app_context';
 import { NavigationScreen } from '../../components/navigation_screen';
 import { FilterEditor } from '../../components/reporting/filter_editor';
@@ -27,10 +27,10 @@ export function TallyReportBuilder(): JSX.Element {
   assert(isElectionManagerAuth(auth));
   const { election } = electionDefinition;
 
-  const [filter, setFilter] = useState<Tabulation.Filter>({});
+  const [filter, setFilter] = useState<Admin.FrontendReportingFilter>({});
   const [groupBy, setGroupBy] = useState<Tabulation.GroupBy>({});
 
-  function updateFilter(newFilter: Tabulation.Filter) {
+  function updateFilter(newFilter: Admin.FrontendReportingFilter) {
     setFilter(canonicalizeFilter(newFilter));
   }
 
@@ -54,6 +54,7 @@ export function TallyReportBuilder(): JSX.Element {
               'precinct',
               'scanner',
               'voting-method',
+              'district',
             ]} // omits party
           />
         </div>

--- a/apps/admin/frontend/src/utils/election.ts
+++ b/apps/admin/frontend/src/utils/election.ts
@@ -14,8 +14,9 @@ import {
   Tabulation,
   CandidateVote,
   ElectionDefinition,
+  District,
 } from '@votingworks/types';
-import { assert, find } from '@votingworks/basics';
+import { assert, find, unique } from '@votingworks/basics';
 import type {
   CardCountsByParty,
   TallyReportResults,
@@ -221,4 +222,14 @@ export async function generateResultsFromTestDeckBallots({
     hasPartySplits: true,
     cardCountsByParty,
   };
+}
+
+/**
+ * Returns all districts that have some ballot style associated with them.
+ */
+export function getValidDistricts(election: Election): District[] {
+  const ids = unique(election.ballotStyles.flatMap((bs) => bs.districts));
+  return ids.map((id) =>
+    find(election.districts, (district) => district.id === id)
+  );
 }

--- a/apps/admin/frontend/src/utils/reporting.test.ts
+++ b/apps/admin/frontend/src/utils/reporting.test.ts
@@ -34,7 +34,7 @@ const scannerBatches: ScannerBatch[] = [
 
 test('generateTitleForReport', () => {
   const electionDefinition = electionTwoPartyPrimaryDefinition;
-  const unsupportedFilters: Admin.ReportingFilter[] = [
+  const unsupportedFilters: Admin.FrontendReportingFilter[] = [
     {
       precinctIds: ['precinct-1', 'precinct-2'],
     },
@@ -76,7 +76,7 @@ test('generateTitleForReport', () => {
   }
 
   const supportedFilters: Array<
-    [filter: Admin.ReportingFilter, title: string]
+    [filter: Admin.FrontendReportingFilter, title: string]
   > = [
     [
       {
@@ -198,7 +198,7 @@ test('generateTitleForReport', () => {
   }
 
   const ballotCountFilters: Array<
-    [filter: Admin.ReportingFilter, title: string]
+    [filter: Admin.FrontendReportingFilter, title: string]
   > = [
     [
       {
@@ -296,7 +296,7 @@ test('canonicalizeGroupBy', () => {
 test('generateBallotCountReportPdfFilename', () => {
   const { election } = electionTwoPartyPrimaryDefinition;
   const testCases: Array<{
-    filter?: Admin.ReportingFilter;
+    filter?: Admin.FrontendReportingFilter;
     groupBy?: Tabulation.GroupBy;
     expectedFilename: string;
     isTestMode?: boolean;
@@ -357,7 +357,7 @@ test('generateBallotCountReportPdfFilename', () => {
 test('generateTallyReportPdfFilename', () => {
   const { election } = electionTwoPartyPrimaryDefinition;
   const testCases: Array<{
-    filter?: Admin.ReportingFilter;
+    filter?: Admin.FrontendReportingFilter;
     groupBy?: Tabulation.GroupBy;
     expectedFilename: string;
     isTestMode?: boolean;

--- a/apps/admin/frontend/src/utils/reporting.test.ts
+++ b/apps/admin/frontend/src/utils/reporting.test.ts
@@ -172,6 +172,19 @@ test('generateTitleForReport', () => {
     ],
     [
       {
+        districtIds: ['district-1'],
+      },
+      'District 1 Tally Report',
+    ],
+    [
+      {
+        districtIds: ['district-1'],
+        votingMethods: ['absentee'],
+      },
+      'District 1 Absentee Ballot Tally Report',
+    ],
+    [
+      {
         batchIds: [Tabulation.MANUAL_BATCH_ID],
       },
       'Manual Batch Tally Report',
@@ -249,6 +262,7 @@ test('canonicalizeFilter', () => {
       votingMethods: [],
       partyIds: [],
       adjudicationFlags: [],
+      districtIds: [],
     })
   ).toEqual({});
   expect(
@@ -260,6 +274,7 @@ test('canonicalizeFilter', () => {
       votingMethods: ['precinct', 'absentee'],
       partyIds: ['b', 'a'],
       adjudicationFlags: ['isBlank', 'hasOvervote'],
+      districtIds: ['district-2', 'district-1'],
     })
   ).toEqual({
     precinctIds: ['a', 'b'],
@@ -269,6 +284,7 @@ test('canonicalizeFilter', () => {
     votingMethods: ['absentee', 'precinct'],
     partyIds: ['a', 'b'],
     adjudicationFlags: ['hasOvervote', 'isBlank'],
+    districtIds: ['district-1', 'district-2'],
   });
 });
 
@@ -475,6 +491,15 @@ test('generateTallyReportPdfFilename', () => {
       expectedFilename:
         'TEST-unofficial-absentee-ballots-tally-report__2023-12-09_15-59-32.pdf',
     },
+    {
+      filter: {
+        districtIds: ['district-1'],
+        votingMethods: ['absentee'],
+      },
+      isTestMode: true,
+      expectedFilename:
+        'TEST-unofficial-district-1-absentee-ballots-tally-report__2023-12-09_15-59-32.pdf',
+    },
   ];
 
   for (const testCase of testCases) {
@@ -522,4 +547,5 @@ test('isFilterEmpty', () => {
   expect(isFilterEmpty({})).toEqual(true);
   expect(isFilterEmpty({ batchIds: [] })).toEqual(false);
   expect(isFilterEmpty({ adjudicationFlags: [] })).toEqual(false);
+  expect(isFilterEmpty({ districtIds: [] })).toEqual(false);
 });

--- a/apps/admin/frontend/src/utils/reporting.ts
+++ b/apps/admin/frontend/src/utils/reporting.ts
@@ -30,14 +30,14 @@ const VOTING_METHOD_LABELS: Record<Tabulation.VotingMethod, string> = {
 
 const FAT_FILENAME_CHAR_LIMIT = 255;
 
-export function isFilterEmpty(filter: Admin.ReportingFilter): boolean {
+export function isFilterEmpty(filter: Admin.FrontendReportingFilter): boolean {
   return isTabulationFilterEmpty(filter) && !filter.adjudicationFlags;
 }
 
 /**
  * Checks whether the report has any filters which have multiple values selected.
  */
-function isCompoundFilter(filter: Admin.ReportingFilter): boolean {
+function isCompoundFilter(filter: Admin.FrontendReportingFilter): boolean {
   return Boolean(
     (filter.partyIds && filter.partyIds.length > 1) ||
       (filter.ballotStyleIds && filter.ballotStyleIds.length > 1) ||
@@ -52,7 +52,7 @@ function isCompoundFilter(filter: Admin.ReportingFilter): boolean {
 /**
  * Returns the number of dimensions being filtered on.
  */
-function getFilterRank(filter: Admin.ReportingFilter): number {
+function getFilterRank(filter: Admin.FrontendReportingFilter): number {
   return (
     (filter.ballotStyleIds?.[0] ? 1 : 0) +
     (filter.precinctIds?.[0] ? 1 : 0) +
@@ -79,7 +79,7 @@ export function generateTitleForReport({
   scannerBatches,
   reportType = 'Tally',
 }: {
-  filter: Admin.ReportingFilter;
+  filter: Admin.FrontendReportingFilter;
   electionDefinition: ElectionDefinition;
   scannerBatches: ScannerBatch[];
   reportType?: 'Tally' | 'Ballot Count';
@@ -256,8 +256,8 @@ export function generateTitleForReport({
  * - sorts filter values alphabetically
  */
 export function canonicalizeFilter(
-  filter: Admin.ReportingFilter
-): Admin.ReportingFilter {
+  filter: Admin.FrontendReportingFilter
+): Admin.FrontendReportingFilter {
   return {
     ballotStyleIds:
       filter.ballotStyleIds && filter.ballotStyleIds.length > 0
@@ -313,7 +313,7 @@ function generateReportFilenameFilterPrefix({
   filter,
 }: {
   election: Election;
-  filter: Admin.ReportingFilter;
+  filter: Admin.FrontendReportingFilter;
 }): string {
   if (isCompoundFilter(filter)) {
     return 'custom';
@@ -438,7 +438,7 @@ export function generateReportFilename({
   time,
 }: {
   election: Election;
-  filter: Admin.ReportingFilter;
+  filter: Admin.FrontendReportingFilter;
   groupBy: Tabulation.GroupBy;
   isTestMode: boolean;
   isOfficialResults: boolean;
@@ -515,7 +515,7 @@ export function generateTallyReportPdfFilename({
   time = new Date(),
 }: {
   election: Election;
-  filter: Admin.ReportingFilter;
+  filter: Admin.FrontendReportingFilter;
   groupBy: Tabulation.GroupBy;
   isTestMode: boolean;
   isOfficialResults: boolean;
@@ -543,7 +543,7 @@ export function generateTallyReportCsvFilename({
   time = new Date(),
 }: {
   election: Election;
-  filter: Admin.ReportingFilter;
+  filter: Admin.FrontendReportingFilter;
   groupBy: Tabulation.GroupBy;
   isTestMode: boolean;
   isOfficialResults: boolean;
@@ -570,7 +570,7 @@ export function generateBallotCountReportPdfFilename({
   time = new Date(),
 }: {
   election: Election;
-  filter: Admin.ReportingFilter;
+  filter: Admin.FrontendReportingFilter;
   groupBy: Tabulation.GroupBy;
   isTestMode: boolean;
   isOfficialResults: boolean;
@@ -597,7 +597,7 @@ export function generateBallotCountReportCsvFilename({
   time = new Date(),
 }: {
   election: Election;
-  filter: Admin.ReportingFilter;
+  filter: Admin.FrontendReportingFilter;
   groupBy: Tabulation.GroupBy;
   isTestMode: boolean;
   isOfficialResults: boolean;

--- a/apps/admin/frontend/test/helpers/mock_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_api_client.ts
@@ -23,6 +23,7 @@ import {
   fakeSystemAdministratorUser,
 } from '@votingworks/test-utils';
 import {
+  Admin,
   ContestId,
   DEFAULT_SYSTEM_SETTINGS,
   DippedSmartCardAuth,
@@ -350,7 +351,7 @@ export function createApiMock(
       groupBy,
     }: {
       path: string;
-      filter?: Tabulation.Filter;
+      filter?: Admin.FrontendReportingFilter;
       groupBy?: Tabulation.GroupBy;
     }) {
       apiClient.exportTallyReportCsv
@@ -365,7 +366,7 @@ export function createApiMock(
       includeSheetCounts,
     }: {
       path: string;
-      filter?: Tabulation.Filter;
+      filter?: Admin.FrontendReportingFilter;
       groupBy?: Tabulation.GroupBy;
       includeSheetCounts?: boolean;
     }) {
@@ -388,7 +389,7 @@ export function createApiMock(
 
     expectGetCardCounts(
       input: {
-        filter?: Tabulation.Filter;
+        filter?: Admin.FrontendReportingFilter;
         groupBy?: Tabulation.GroupBy;
       },
       results: Array<Tabulation.GroupOf<Tabulation.CardCounts>>,
@@ -416,7 +417,7 @@ export function createApiMock(
 
     expectGetResultsForTallyReports(
       input: {
-        filter?: Tabulation.Filter;
+        filter?: Admin.FrontendReportingFilter;
         groupBy?: Tabulation.GroupBy;
       },
       results: Tabulation.GroupList<TallyReportResults>,

--- a/libs/types/src/admin/reporting.ts
+++ b/libs/types/src/admin/reporting.ts
@@ -21,9 +21,18 @@ export const ADJUDICATION_FLAG_LABELS: Record<
 };
 
 /**
- * Filter options in the reporting interfaces, which extends beyond core
- * filters on CVR properties to include adjudication status.
+ * Features of cast vote records that VxAdmin can filter on, which extends beyond
+ * features that the tabulation code can group on, e.g. adjudication flags.
  */
 export type ReportingFilter = Tabulation.Filter & {
   adjudicationFlags?: CastVoteRecordAdjudicationFlag[];
+};
+
+/**
+ * Features of cast vote records that the VxAdmin allows filtering on, which
+ * includes features that converted to other, lower-level filters on the
+ * backend, e.g. district.
+ */
+export type FrontendReportingFilter = ReportingFilter & {
+  districtIds?: string[];
 };

--- a/libs/ui/src/reports/admin_tally_report.tsx
+++ b/libs/ui/src/reports/admin_tally_report.tsx
@@ -1,4 +1,9 @@
-import { Contests, ElectionDefinition, Tabulation } from '@votingworks/types';
+import {
+  Admin,
+  Contests,
+  ElectionDefinition,
+  Tabulation,
+} from '@votingworks/types';
 import { assert } from '@votingworks/basics';
 import { ThemeProvider } from 'styled-components';
 import {
@@ -28,7 +33,7 @@ export interface AdminTallyReportProps {
   manualElectionResults?: Tabulation.ManualElectionResults;
   cardCountsOverride?: Tabulation.CardCounts;
   generatedAtTime?: Date;
-  customFilter?: Tabulation.Filter;
+  customFilter?: Admin.FrontendReportingFilter;
   includeSignatureLines?: boolean;
 }
 

--- a/libs/ui/src/reports/ballot_count_report.tsx
+++ b/libs/ui/src/reports/ballot_count_report.tsx
@@ -586,7 +586,7 @@ export interface BallotCountReportProps {
   cardCountsList: Tabulation.GroupList<Tabulation.CardCounts>;
   groupBy: Tabulation.GroupBy;
   includeSheetCounts?: boolean;
-  customFilter?: Admin.ReportingFilter;
+  customFilter?: Admin.FrontendReportingFilter;
   generatedAtTime?: Date;
 }
 

--- a/libs/ui/src/reports/custom_filter_summary.test.tsx
+++ b/libs/ui/src/reports/custom_filter_summary.test.tsx
@@ -92,6 +92,19 @@ test('adjudication status filter', () => {
   );
 });
 
+test('district filter', () => {
+  const { electionDefinition } = electionFamousNames2021Fixtures;
+  render(
+    <CustomFilterSummary
+      electionDefinition={electionDefinition}
+      filter={{ districtIds: ['district-1'] }}
+    />
+  );
+  expect(screen.getByTestId('custom-filter-summary').textContent).toEqual(
+    'District: City of Lincoln'
+  );
+});
+
 test('complex filter', () => {
   const { electionDefinition } = electionFamousNames2021Fixtures;
   render(

--- a/libs/ui/src/reports/custom_filter_summary.tsx
+++ b/libs/ui/src/reports/custom_filter_summary.tsx
@@ -1,6 +1,6 @@
 import { Admin, ElectionDefinition, Tabulation } from '@votingworks/types';
 
-import { getPrecinctById } from '@votingworks/utils';
+import { getDistrictById, getPrecinctById } from '@votingworks/utils';
 
 import pluralize from 'pluralize';
 import styled from 'styled-components';
@@ -9,7 +9,7 @@ import { getBatchLabel, getScannerLabel } from './utils';
 
 interface Props {
   electionDefinition: ElectionDefinition;
-  filter: Admin.ReportingFilter;
+  filter: Admin.FrontendReportingFilter;
 }
 
 const FilterDisplayRow = styled.p`
@@ -78,6 +78,19 @@ export function CustomFilterSummary({
           </Font>{' '}
           {filter.adjudicationFlags
             .map((flag) => Admin.ADJUDICATION_FLAG_LABELS[flag])
+            .join(', ')}
+        </FilterDisplayRow>
+      )}
+      {filter.districtIds && (
+        <FilterDisplayRow>
+          <Font weight="semiBold">
+            {pluralize('District', filter.districtIds.length)}:
+          </Font>{' '}
+          {filter.districtIds
+            .map(
+              (districtId) =>
+                getDistrictById(electionDefinition, districtId).name
+            )
             .join(', ')}
         </FilterDisplayRow>
       )}

--- a/libs/utils/src/tabulation/lookups.ts
+++ b/libs/utils/src/tabulation/lookups.ts
@@ -3,6 +3,7 @@ import {
   AnyContest,
   BallotStyle,
   BallotStyleId,
+  District,
   Election,
   ElectionDefinition,
   Party,
@@ -41,6 +42,17 @@ export const getPrecinctById = createElectionMetadataLookupFunction(
       precinctLookup[precinct.id] = precinct;
     }
     return precinctLookup;
+  }
+);
+
+export const getDistrictById = createElectionMetadataLookupFunction(
+  (election) => {
+    const { districts } = election;
+    const districtLookup: Record<string, District> = {};
+    for (const district of districts) {
+      districtLookup[district.id] = district;
+    }
+    return districtLookup;
   }
 );
 


### PR DESCRIPTION
## Overview

Closes #4275.  Adds ability to filter by "District" to the report builders. This could include things like wards, cities, sub-jurisdictions, etc.

Under the hood, it just converts a list of districts to a list of ballot styles. We don't have districts arranged in the election definition in such a way that we can do groupings by them, just filtering.

## Demo Video or Screenshot

https://github.com/votingworks/vxsuite/assets/37960853/d7062f5d-91ad-4beb-88cb-04afed43c278

## Testing Plan

I had trouble thinking of a good way to write resilient tests for this. At each endpoint in `app.ts` on the backend, we convert from the frontend filter format, which contains district IDs, to a the more basic version. Ideally testing would ensure this always happens, but it's laborious because there's four endpoints to test and no existing fixtures. I chose to use assertions so that manual testing would reveal any issues, but didn't do the work to write four extensive automated tests.

Ideally the conversion could happen at some middle layer, like logging, but that middle layer would have to be aware of the election definition.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
