### PR TITLE
Allow election manager and system admin to save logs on central system

### DIFF
--- a/apps/admin/frontend/src/screens/settings_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/settings_screen.test.tsx
@@ -83,9 +83,13 @@ describe('as System Admin', () => {
     apiMock.apiClient.exportLogsToUsb.expectCallWith().resolves(ok());
 
     // Log saving is tested fully in src/components/export_logs_modal.test.tsx
-    userEvent.click(screen.getByText('Save Log File'));
+    userEvent.click(screen.getButton('Save Log File'));
     await screen.findByText('Save logs on the inserted USB drive?');
-    userEvent.click(screen.getByText('Save'));
+    userEvent.click(screen.getButton('Save'));
+    userEvent.click(await screen.findButton('Close'));
+    await waitFor(() =>
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    );
   });
 });
 
@@ -112,5 +116,24 @@ describe('as Election Manager', () => {
     expect(
       screen.queryByRole('heading', { name: 'USB Formatting' })
     ).not.toBeInTheDocument();
+  });
+
+  test('Exporting logs', async () => {
+    renderInAppContext(<SettingsScreen />, {
+      apiMock,
+      auth,
+      usbDriveStatus: mockUsbDriveStatus('mounted'),
+    });
+
+    apiMock.apiClient.exportLogsToUsb.expectCallWith().resolves(ok());
+
+    // Log saving is tested fully in src/components/export_logs_modal.test.tsx
+    userEvent.click(screen.getButton('Save Log File'));
+    await screen.findByText('Save logs on the inserted USB drive?');
+    userEvent.click(screen.getButton('Save'));
+    userEvent.click(await screen.findButton('Close'));
+    await waitFor(() =>
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    );
   });
 });

--- a/apps/admin/frontend/src/screens/settings_screen.tsx
+++ b/apps/admin/frontend/src/screens/settings_screen.tsx
@@ -36,6 +36,13 @@ export function SettingsScreen(): JSX.Element {
 
   return (
     <NavigationScreen title="Settings">
+      <H2>Logs</H2>
+      <ExportLogsButton
+        usbDriveStatus={usbDriveStatus}
+        auth={auth}
+        logger={logger}
+        onExportLogs={doExportLogs}
+      />
       <H2>Date and Time</H2>
       <P>
         <CurrentDateAndTime />
@@ -45,13 +52,6 @@ export function SettingsScreen(): JSX.Element {
           Set Date and Time
         </SetClockButton>
       </P>
-      <H2>Logs</H2>
-      <ExportLogsButton
-        usbDriveStatus={usbDriveStatus}
-        auth={auth}
-        logger={logger}
-        onExportLogs={doExportLogs}
-      />
       {isSystemAdministratorAuth(auth) && (
         <React.Fragment>
           <H2>USB Formatting</H2>

--- a/apps/admin/frontend/src/screens/settings_screen.tsx
+++ b/apps/admin/frontend/src/screens/settings_screen.tsx
@@ -45,15 +45,15 @@ export function SettingsScreen(): JSX.Element {
           Set Date and Time
         </SetClockButton>
       </P>
+      <H2>Logs</H2>
+      <ExportLogsButton
+        usbDriveStatus={usbDriveStatus}
+        auth={auth}
+        logger={logger}
+        onExportLogs={doExportLogs}
+      />
       {isSystemAdministratorAuth(auth) && (
         <React.Fragment>
-          <H2>Logs</H2>
-          <ExportLogsButton
-            usbDriveStatus={usbDriveStatus}
-            auth={auth}
-            logger={logger}
-            onExportLogs={doExportLogs}
-          />
           <H2>USB Formatting</H2>
           <FormatUsbButton />
           <H2>Software Update</H2>

--- a/apps/central-scan/frontend/src/screens/settings_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/settings_screen.tsx
@@ -51,7 +51,6 @@ export function SettingsScreen({
   const ejectUsbDriveMutation = ejectUsbDrive.useMutation();
   const exportCastVoteRecordsToUsbDriveMutation =
     exportCastVoteRecordsToUsbDrive.useMutation();
-
   const exportLogsToUsbMutation = exportLogsToUsb.useMutation();
 
   async function doExportLogs(): Promise<LogsResultType> {

--- a/apps/central-scan/frontend/src/screens/system_administrator_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/system_administrator_screen.test.tsx
@@ -1,6 +1,8 @@
 import userEvent from '@testing-library/user-event';
+import { ok } from '@votingworks/basics';
+import { mockUsbDriveStatus } from '@votingworks/ui';
 import { MockApiClient, createMockApiClient } from '../../test/api';
-import { screen } from '../../test/react_testing_library';
+import { screen, waitFor } from '../../test/react_testing_library';
 import { renderInAppContext } from '../../test/render_in_app_context';
 import { SystemAdministratorScreen } from './system_administrator_screen';
 
@@ -25,13 +27,32 @@ test('System Admin screen', async () => {
   await screen.findByText('Delete all election data?');
   userEvent.click(screen.getButton('Cancel'));
 
-  screen.getByRole('heading', { name: 'Machine' });
-  screen.getButton('Power Down');
-
   screen.getByRole('heading', { name: 'Software Update' });
   screen.getButton('Reboot to BIOS');
+  screen.getButton('Power Down');
+
+  screen.getByRole('heading', { name: 'Logs' });
+  screen.getButton('Save Log File');
 
   screen.getByRole('heading', { name: 'Date and Time' });
   userEvent.click(screen.getButton('Set Date and Time'));
   await screen.findByRole('heading', { name: 'Set Date and Time' });
+});
+
+test('Exporting logs', async () => {
+  renderInAppContext(<SystemAdministratorScreen />, {
+    apiClient: mockApiClient,
+    usbDriveStatus: mockUsbDriveStatus('mounted'),
+  });
+
+  mockApiClient.exportLogsToUsb.expectCallWith().resolves(ok());
+
+  // Log saving is tested fully in src/components/export_logs_modal.test.tsx
+  userEvent.click(screen.getButton('Save Log File'));
+  await screen.findByText('Save logs on the inserted USB drive?');
+  userEvent.click(screen.getButton('Save'));
+  userEvent.click(await screen.findButton('Close'));
+  await waitFor(() =>
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  );
 });

--- a/apps/central-scan/frontend/src/screens/system_administrator_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/system_administrator_screen.tsx
@@ -51,9 +51,6 @@ export function SystemAdministratorScreen(): JSX.Element {
         }}
         isMachineConfigured={Boolean(electionDefinition)}
       />
-      <H2>Software Update</H2>
-      <RebootToBiosButton logger={logger} />{' '}
-      <PowerDownButton logger={logger} userRole="system_administrator" />
       <H2>Logs</H2>
       <ExportLogsButton
         usbDriveStatus={usbDriveStatus}
@@ -68,6 +65,9 @@ export function SystemAdministratorScreen(): JSX.Element {
       <SetClockButton logOut={() => logOutMutation.mutate()}>
         Set Date and Time
       </SetClockButton>
+      <H2>Software Update</H2>
+      <RebootToBiosButton logger={logger} />{' '}
+      <PowerDownButton logger={logger} userRole="system_administrator" />
     </NavigationScreen>
   );
 }

--- a/apps/central-scan/frontend/src/screens/system_administrator_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/system_administrator_screen.tsx
@@ -7,16 +7,30 @@ import {
   RebootToBiosButton,
   CurrentDateAndTime,
   SetClockButton,
+  ExportLogsButton,
 } from '@votingworks/ui';
 import { useContext } from 'react';
+import type { LogsResultType } from '@votingworks/backend';
+import { err } from '@votingworks/basics';
 import { NavigationScreen } from '../navigation_screen';
 import { AppContext } from '../contexts/app_context';
-import { logOut, unconfigure } from '../api';
+import { exportLogsToUsb, logOut, unconfigure } from '../api';
 
 export function SystemAdministratorScreen(): JSX.Element {
-  const { electionDefinition, logger } = useContext(AppContext);
+  const { auth, electionDefinition, logger, usbDriveStatus } =
+    useContext(AppContext);
   const unconfigureMutation = unconfigure.useMutation();
   const logOutMutation = logOut.useMutation();
+  const exportLogsToUsbMutation = exportLogsToUsb.useMutation();
+
+  async function doExportLogs(): Promise<LogsResultType> {
+    try {
+      return await exportLogsToUsbMutation.mutateAsync();
+    } catch (e) {
+      /* istanbul ignore next */
+      return err('copy-failed');
+    }
+  }
 
   return (
     <NavigationScreen title="System Administrator">
@@ -37,10 +51,16 @@ export function SystemAdministratorScreen(): JSX.Element {
         }}
         isMachineConfigured={Boolean(electionDefinition)}
       />
-      <H2>Machine</H2>
-      <PowerDownButton logger={logger} userRole="system_administrator" />
       <H2>Software Update</H2>
-      <RebootToBiosButton logger={logger} />
+      <RebootToBiosButton logger={logger} />{' '}
+      <PowerDownButton logger={logger} userRole="system_administrator" />
+      <H2>Logs</H2>
+      <ExportLogsButton
+        usbDriveStatus={usbDriveStatus}
+        auth={auth}
+        logger={logger}
+        onExportLogs={doExportLogs}
+      />
       <H2>Date and Time</H2>
       <P>
         <CurrentDateAndTime />


### PR DESCRIPTION
## Overview

Fixes #4347 

For parity, we want the election manager and system admin roles to be able to save logs on all machines. This PR updates VxAdmin and VxCentralScan to enable that. VxMark/MarkScan is being tracked by @kshen0 

_Review by commit_

## Demo Video or Screenshot

VxAdmin - election manager
<img width="961" alt="Screenshot 2023-12-11 at 3 50 32 PM" src="https://github.com/votingworks/vxsuite/assets/530106/318b6e7f-0909-4ebb-89f4-607026584099">

VxCentralScan - system admin
<img width="961" alt="Screenshot 2023-12-11 at 3 49 57 PM" src="https://github.com/votingworks/vxsuite/assets/530106/d2065e3e-d6b5-4a90-bc44-1bd40c18d29f">


## Testing Plan
Added new tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
