### PR TITLE
Protect against wind-up-less double-sheet

### DIFF
--- a/apps/scan/backend/package.json
+++ b/apps/scan/backend/package.json
@@ -85,6 +85,7 @@
     "esbuild": "0.17.11",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",
+    "fast-check": "2.23.2",
     "is-ci-cli": "2.2.0",
     "jest": "^29.6.2",
     "jest-junit": "^16.0.0",

--- a/apps/scan/backend/src/scanners/custom/app_scan.test.ts
+++ b/apps/scan/backend/src/scanners/custom/app_scan.test.ts
@@ -516,7 +516,7 @@ test("scannerStatusToEvent's cases are exhaustive and can all be reached", () =>
           sensorVoidPrintHead: 0xff,
         };
 
-        // First, ensure that scannerStatusToEvent's cases are exhaustive. We'll now that they are
+        // First, ensure that scannerStatusToEvent's cases are exhaustive. We'll know that they are
         // if this line never throws.
         const event = scannerStatusToEvent(scannerStatus);
 

--- a/apps/scan/backend/src/scanners/custom/state_machine.ts
+++ b/apps/scan/backend/src/scanners/custom/state_machine.ts
@@ -181,45 +181,62 @@ async function closeCustomClient({ client }: Context) {
 function scannerStatusToEvent(
   scannerStatus: ScannerStatus
 ): ScannerStatusEvent {
-  const frontHasPaper =
+  const allFrontSensorsDetectPaper =
     scannerStatus.sensorInputLeftLeft === SensorStatus.PaperPresent &&
     scannerStatus.sensorInputCenterLeft === SensorStatus.PaperPresent &&
     scannerStatus.sensorInputCenterRight === SensorStatus.PaperPresent &&
     scannerStatus.sensorInputRightRight === SensorStatus.PaperPresent;
-  const backHasPaper =
-    scannerStatus.sensorOutputLeftLeft === SensorStatus.PaperPresent &&
-    scannerStatus.sensorOutputCenterLeft === SensorStatus.PaperPresent &&
-    scannerStatus.sensorOutputCenterRight === SensorStatus.PaperPresent &&
+  const someFrontSensorsDetectPaper =
+    scannerStatus.sensorInputLeftLeft === SensorStatus.PaperPresent ||
+    scannerStatus.sensorInputCenterLeft === SensorStatus.PaperPresent ||
+    scannerStatus.sensorInputCenterRight === SensorStatus.PaperPresent ||
+    scannerStatus.sensorInputRightRight === SensorStatus.PaperPresent;
+
+  const someBackSensorsUnderRollersDetectPaper =
+    scannerStatus.sensorOutputCenterLeft === SensorStatus.PaperPresent ||
+    scannerStatus.sensorOutputCenterRight === SensorStatus.PaperPresent;
+  const someBackSensorsPastRollersDetectPaper =
+    scannerStatus.sensorOutputLeftLeft === SensorStatus.PaperPresent ||
     scannerStatus.sensorOutputRightRight === SensorStatus.PaperPresent;
+  const someBackSensorsDetectPaper =
+    someBackSensorsUnderRollersDetectPaper ||
+    someBackSensorsPastRollersDetectPaper;
 
   if (scannerStatus.isScannerCoverOpen) {
     return { type: 'SCANNER_DISCONNECTED' };
   }
 
   if (scannerStatus.isPaperJam || scannerStatus.isJamPaperHeldBack) {
-    if (!frontHasPaper && !backHasPaper) {
+    if (!someFrontSensorsDetectPaper && !someBackSensorsDetectPaper) {
       return { type: 'SCANNER_JAM_CLEARED' };
     }
 
     if (scannerStatus.isDoubleSheet) {
       return { type: 'SCANNER_JAM_DOUBLE_SHEET' };
     }
+
     return { type: 'SCANNER_JAM' };
   }
 
-  if (!frontHasPaper && !backHasPaper) {
+  // Paper past the back rollers but caught on, say, the emergency ballot bag should not be
+  // considered still in the scanner. Continuing to spin the rollers won't clear the paper. Rather,
+  // scanning the next ballot will.
+  if (!allFrontSensorsDetectPaper && !someBackSensorsUnderRollersDetectPaper) {
     return { type: 'SCANNER_NO_PAPER' };
   }
 
-  if (frontHasPaper && !backHasPaper) {
+  // Wait for all and not just some of the front sensors to detect paper before scanning to ensure
+  // proper alignment
+  if (allFrontSensorsDetectPaper && !someBackSensorsUnderRollersDetectPaper) {
     return { type: 'SCANNER_READY_TO_SCAN' };
   }
 
-  if (!frontHasPaper && backHasPaper) {
+  if (!someFrontSensorsDetectPaper && someBackSensorsUnderRollersDetectPaper) {
     return { type: 'SCANNER_READY_TO_EJECT' };
   }
 
-  // If we get here frontHasPaper and backHasPaper are true
+  // The above conditions make it such that this condition is equivalent to:
+  // someFrontSensorsDetectPaper && someBackSensorsUnderRollersDetectPaper
   return { type: 'SCANNER_BOTH_SIDES_HAVE_PAPER' };
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2436,6 +2436,9 @@ importers:
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../../../libs/eslint-plugin-vx
+      fast-check:
+        specifier: 2.23.2
+        version: 2.23.2
       is-ci-cli:
         specifier: 2.2.0
         version: 2.2.0
@@ -8158,7 +8161,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-arm@0.17.11:
@@ -8175,7 +8177,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-x64@0.17.11:
@@ -8192,7 +8193,6 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-arm64@0.17.11:
@@ -8209,7 +8209,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-x64@0.17.11:
@@ -8226,7 +8225,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-arm64@0.17.11:
@@ -8243,7 +8241,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-x64@0.17.11:
@@ -8260,7 +8257,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-arm64@0.17.11:
@@ -8277,7 +8273,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-arm@0.17.11:
@@ -8294,7 +8289,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ia32@0.17.11:
@@ -8311,7 +8305,6 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-loong64@0.17.11:
@@ -8328,7 +8321,6 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-mips64el@0.17.11:
@@ -8345,7 +8337,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ppc64@0.17.11:
@@ -8362,7 +8353,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-riscv64@0.17.11:
@@ -8379,7 +8369,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-s390x@0.17.11:
@@ -8396,7 +8385,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-x64@0.17.11:
@@ -8413,7 +8401,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/netbsd-x64@0.17.11:
@@ -8430,7 +8417,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/openbsd-x64@0.17.11:
@@ -8447,7 +8433,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/sunos-x64@0.17.11:
@@ -8464,7 +8449,6 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-arm64@0.17.11:
@@ -8481,7 +8465,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-ia32@0.17.11:
@@ -8498,7 +8481,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-x64@0.17.11:
@@ -8515,7 +8497,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@eslint-community/eslint-utils@4.4.0(eslint@8.49.0):
@@ -14538,7 +14519,6 @@ packages:
       '@esbuild/win32-arm64': 0.18.17
       '@esbuild/win32-ia32': 0.18.17
       '@esbuild/win32-x64': 0.18.17
-    dev: true
 
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -15524,7 +15504,7 @@ packages:
       semver: 7.3.2
       tapable: 1.1.3
       typescript: 5.2.2
-      webpack: 5.88.2(esbuild@0.17.11)
+      webpack: 5.88.2(esbuild@0.18.17)
 
   /form-data@2.5.1:
     resolution: {integrity: sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==}
@@ -19789,7 +19769,7 @@ packages:
       strip-ansi: 6.0.1
       text-table: 0.2.0
       typescript: 5.2.2
-      webpack: 5.88.2(esbuild@0.17.11)
+      webpack: 5.88.2(esbuild@0.18.17)
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -21577,7 +21557,7 @@ packages:
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
 
-  /terser-webpack-plugin@5.3.9(esbuild@0.17.11)(webpack@5.88.2):
+  /terser-webpack-plugin@5.3.9(esbuild@0.18.17)(webpack@5.88.2):
     resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -21594,12 +21574,12 @@ packages:
         optional: true
     dependencies:
       '@jridgewell/trace-mapping': 0.3.18
-      esbuild: 0.17.11
+      esbuild: 0.18.17
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.19.2
-      webpack: 5.88.2(esbuild@0.17.11)
+      webpack: 5.88.2(esbuild@0.18.17)
 
   /terser@4.8.1:
     resolution: {integrity: sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==}
@@ -22603,7 +22583,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /webpack@5.88.2(esbuild@0.17.11):
+  /webpack@5.88.2(esbuild@0.18.17):
     resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -22634,7 +22614,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(esbuild@0.17.11)(webpack@5.88.2)
+      terser-webpack-plugin: 5.3.9(esbuild@0.18.17)(webpack@5.88.2)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/4326

See **#issue-custom-scanner-state-machine-v3** in Slack for lots of additional context.

In our stress testing of the scanner state machine, we've identified edge cases that are unlikely to come up in real use but that we want to protect against regardless. One such issue we've dubbed "wind-up-less double-sheet".

When we prep a second ballot just in front of the scanner before accept of a first ballot, and the second ballot isn't close enough to trigger the sensors for the "remove your ballot" notice, the first ballot is ejected without the typical backwards wind-up. The second ballot can then be passed through the scanner without being counted.

Because we only consider the front of the scanner to have paper if all of the front sensors detect paper, the scanner state machine doesn't recognize the second ballot in the scanner if it only triggers a subset of the front sensors. But the scanner itself does see the paper and, on accept, doesn't wind-up first so as not to bump into it.

This PR mitigates the issue by tweaking the use of ANDs and ORs in paper status conditions.

## Testing Plan

- [x] Extensive manual testing