### PR TITLE
Protect against double-sheet w wind-up

### DIFF
--- a/apps/scan/backend/src/scanners/custom/state_machine.ts
+++ b/apps/scan/backend/src/scanners/custom/state_machine.ts
@@ -983,6 +983,8 @@ function buildMachine({
                 SCANNER_READY_TO_SCAN: doNothing,
                 SCANNER_BOTH_SIDES_HAVE_PAPER: doNothing,
                 SCANNER_JAM: doNothing,
+                SCANNER_JAM_DOUBLE_SHEET: doNothing,
+                SCANNER_JAM_CLEARED: doNothing,
                 SCANNER_READY_TO_EJECT: doNothing,
               },
               after: {

--- a/libs/custom-scanner/src/custom_a4_scanner.test.ts
+++ b/libs/custom-scanner/src/custom_a4_scanner.test.ts
@@ -808,6 +808,20 @@ test('move motor never retries on non-job errors', async () => {
   );
 });
 
+test('move motor with stop movement short-circuits', async () => {
+  const { onFormMovementRequest, onJobCreateRequest } = makeProtocolListeners();
+
+  onJobCreateRequest.mockReturnValueOnce(ok({ jobId: 0x01 }));
+
+  const scanner = await scannerWithListeners({
+    onFormMovementRequest,
+    onJobCreateRequest,
+  });
+
+  expect(await scanner.move(FormMovement.STOP)).toEqual(ok());
+  expect(onFormMovementRequest).not.toHaveBeenCalled();
+});
+
 test('resetHardware', async () => {
   const scanner = await scannerWithListeners({
     onHardwareResetRequest() {

--- a/libs/custom-scanner/src/custom_a4_scanner.ts
+++ b/libs/custom-scanner/src/custom_a4_scanner.ts
@@ -247,6 +247,13 @@ export class CustomA4Scanner implements CustomScanner {
         this.withRetries(async () => {
           (await this.createJobInternal()).okOrElse(fail);
 
+          // To stop the motors, the createJobInternal call above is sufficient, as it ends the
+          // current job, if any, before creating a new one. This in and of itself stops the
+          // motors.
+          if (movement === FormMovement.STOP) {
+            return ok();
+          }
+
           return await this.channelMutex.withLock((channel) =>
             formMove(channel, ONLY_VALID_JOB_ID, movement)
           );

--- a/libs/custom-scanner/src/types.ts
+++ b/libs/custom-scanner/src/types.ts
@@ -388,6 +388,11 @@ export enum JobStatus {
  */
 export enum FormMovement {
   /**
+   * Stop the motors
+   */
+  STOP = 0,
+
+  /**
    * Load paper
    */
   LOAD_PAPER = 1,


### PR DESCRIPTION
_Easiest reviewed by commit_

## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/4326

See **#issue-custom-scanner-state-machine-v3** in Slack for lots of additional context.

In our stress testing of the scanner state machine, we've identified edge cases that are unlikely to come up in real use but that we want to protect against regardless. One such issue we've dubbed "double-sheet w wind-up" (distinct from "[wind-up-less double sheet](https://github.com/votingworks/vxsuite/pull/4395)").

When a second ballot is inserted as a first ballot is being accepted, it's possible for the second ballot to be passed through the scanner without being counted. The timing has to be just right to escape the existing safeguards in the state machine. But there are other conditions that also have to be met that we don't quite understand. We've never repro'd with an NH test ballot, only with the (extremely dense) all-bubble ballot. And one can go long stretches of time without being able to repro and then all of a sudden be able to back-to-back. Though we've been suspicious of continuous export as the biggest diff between the m17b image (which we haven't been able to repro with) and current images, we've still been able to repro with continuous export operations commented out.

While we continue to investigate what changed to make this edge case more likely, we have a solid mitigation strategy. During ballot accept, we'll now stop the scanner rollers as soon as the ballot clears the scanner. The scanner rollers currently roll for ~1.3s on accept, which gives a second ballot plenty of time to pass through. Now, the rollers will only roll for as long as necessary, up to 1.3s. I haven't hardcoded a time; the rollers will stop dynamically, when the no-paper status is seen. I've also increased the paper status polling interval during ballot accept  to detect issues as quickly as possible.

## Testing Plan

- [x] Extensive manual testing