### PR TITLE
test(scan): stop state machine on test end

### DIFF
--- a/apps/scan/backend/src/app_ui_strings.test.ts
+++ b/apps/scan/backend/src/app_ui_strings.test.ts
@@ -24,6 +24,7 @@ import {
 import { Store } from './store';
 import { buildApi } from './app';
 import { createWorkspace } from './util/workspace';
+import { createPrecinctScannerStateMachineMock } from '../test/helpers/custom_helpers';
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
@@ -49,13 +50,7 @@ afterEach(() => {
 runUiStringApiTests({
   api: buildApi(
     mockAuth,
-    {
-      accept: jest.fn(),
-      return: jest.fn(),
-      scan: jest.fn(),
-      status: jest.fn(),
-      supportsUltrasonic: jest.fn(),
-    },
+    createPrecinctScannerStateMachineMock(),
     workspace,
     mockUsbDrive.usbDrive,
     fakeLogger()
@@ -81,13 +76,7 @@ describe('configureFromElectionPackageOnUsbDrive', () => {
 
   const api = buildApi(
     mockAuth,
-    {
-      accept: jest.fn(),
-      return: jest.fn(),
-      scan: jest.fn(),
-      status: jest.fn(),
-      supportsUltrasonic: jest.fn(),
-    },
+    createPrecinctScannerStateMachineMock(),
     workspace,
     mockUsbDrive.usbDrive,
     fakeLogger()
@@ -104,13 +93,7 @@ describe('configureFromElectionPackageOnUsbDrive', () => {
 describe('unconfigureElection', () => {
   const api = buildApi(
     mockAuth,
-    {
-      accept: jest.fn(),
-      return: jest.fn(),
-      scan: jest.fn(),
-      status: jest.fn(),
-      supportsUltrasonic: jest.fn(),
-    },
+    createPrecinctScannerStateMachineMock(),
     workspace,
     mockUsbDrive.usbDrive,
     fakeLogger()

--- a/apps/scan/backend/src/scanners/custom/state_machine.ts
+++ b/apps/scan/backend/src/scanners/custom/state_machine.ts
@@ -1353,5 +1353,9 @@ export function createPrecinctScannerStateMachine({
     supportsUltrasonic: () => {
       return true;
     },
+
+    stop: () => {
+      machineService.stop();
+    },
   };
 }

--- a/apps/scan/backend/src/server.test.ts
+++ b/apps/scan/backend/src/server.test.ts
@@ -5,8 +5,8 @@ import { buildMockInsertedSmartCardAuth } from '@votingworks/auth';
 import { buildApp } from './app';
 import { PORT } from './globals';
 import { start } from './server';
-import { PrecinctScannerStateMachine } from './types';
 import { createWorkspace, Workspace } from './util/workspace';
+import { createPrecinctScannerStateMachineMock } from '../test/helpers/custom_helpers';
 
 jest.mock('./app');
 jest.mock('@votingworks/logging');
@@ -23,16 +23,6 @@ beforeEach(() => {
 afterEach(() => {
   workspace.reset();
 });
-
-function createPrecinctScannerStateMachineMock(): jest.Mocked<PrecinctScannerStateMachine> {
-  return {
-    status: jest.fn(),
-    scan: jest.fn(),
-    accept: jest.fn(),
-    return: jest.fn(),
-    supportsUltrasonic: jest.fn(),
-  };
-}
 
 test('start passes the state machine and workspace to `buildApp`', async () => {
   const precinctScannerStateMachine = createPrecinctScannerStateMachineMock();

--- a/apps/scan/backend/src/types.ts
+++ b/apps/scan/backend/src/types.ts
@@ -69,6 +69,9 @@ export interface PrecinctScannerStateMachine {
   scan: () => void;
   accept: () => void;
   return: () => void;
+
+  // Stop the state machine and release any resources it is using.
+  stop: () => void;
 }
 
 export interface PollsTransition {

--- a/apps/scan/backend/test/helpers/custom_helpers.ts
+++ b/apps/scan/backend/test/helpers/custom_helpers.ts
@@ -40,6 +40,7 @@ import {
   waitForStatus,
 } from './shared_helpers';
 import { Store } from '../../src/store';
+import { PrecinctScannerStateMachine } from '../../src';
 
 export async function withApp(
   {
@@ -128,6 +129,7 @@ export async function withApp(
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
     });
+    precinctScannerMachine.stop();
     workspace.reset();
   }
 }
@@ -247,4 +249,15 @@ export async function scanBallot(
   if (options.waitForContinuousExportToUsbDrive ?? true) {
     await waitForContinuousExportToUsbDrive(store);
   }
+}
+
+export function createPrecinctScannerStateMachineMock(): jest.Mocked<PrecinctScannerStateMachine> {
+  return {
+    status: jest.fn(),
+    scan: jest.fn(),
+    accept: jest.fn(),
+    return: jest.fn(),
+    supportsUltrasonic: jest.fn(),
+    stop: jest.fn(),
+  };
 }


### PR DESCRIPTION
## Overview

Before this change, the tests would print warnings that there were resources being held that were preventing NodeJS from exiting within 1s of the tests ending. The state machine's paper status polling was why. This change stops the state machine when the tests are over to prevent that from happening.

## Demo Video or Screenshot
n/a

## Testing Plan
- [x] Existing automated tests.
