### PR TITLE
Cleanup legacy colors

### DIFF
--- a/apps/scan/frontend/src/components/misvote_warnings/contest_list.tsx
+++ b/apps/scan/frontend/src/components/misvote_warnings/contest_list.tsx
@@ -20,7 +20,7 @@ export interface ContestListProps {
 
 const Container = styled.div`
   border: ${(p) => p.theme.sizes.bordersRem.hairline}rem solid
-    ${(p) => p.theme.colors.foreground};
+    ${(p) => p.theme.colors.outline};
   border-radius: 0.1rem;
   padding: 0.25rem 0.5rem 0.5rem;
 `;

--- a/libs/mark-flow-ui/src/components/button_footer.tsx
+++ b/libs/mark-flow-ui/src/components/button_footer.tsx
@@ -4,7 +4,7 @@ import styled, { css } from 'styled-components';
 const portraitStyles = css`
   align-items: stretch;
   border-top: ${(p) => p.theme.sizes.bordersRem.thick}rem solid
-    ${(p) => p.theme.colors.foreground};
+    ${(p) => p.theme.colors.outline};
   gap: 0.5rem;
   justify-content: right;
   min-height: 4.5rem;
@@ -19,7 +19,7 @@ const portraitStyles = css`
 
 const landscapeStyles = css`
   border-left: ${(p) => p.theme.sizes.bordersRem.thick}rem solid
-    ${(p) => p.theme.colors.foreground};
+    ${(p) => p.theme.colors.outline};
   flex-direction: column;
   gap: 1rem;
   justify-content: center;

--- a/libs/mark-flow-ui/src/components/ms_either_neither_contest.tsx
+++ b/libs/mark-flow-ui/src/components/ms_either_neither_contest.tsx
@@ -42,7 +42,7 @@ const Divider = styled.div`
   justify-content: center;
 
   &::before {
-    background: ${(p) => p.theme.colors.foreground};
+    background: ${(p) => p.theme.colors.onBackground};
     width: ${(p) => p.theme.sizes.bordersRem.medium}rem;
     content: '';
   }

--- a/libs/mark-flow-ui/src/pages/cast_ballot_page.tsx
+++ b/libs/mark-flow-ui/src/pages/cast_ballot_page.tsx
@@ -41,7 +41,7 @@ const ListItem = styled.li`
 
 const InstructionImageContainer = styled.div`
   border-right: ${(p) => p.theme.sizes.bordersRem.thick}rem solid
-    ${(p) => p.theme.colors.foreground};
+    ${(p) => p.theme.colors.outline};
   display: flex;
   justify-content: center;
   padding: 1rem 1rem 0 0;

--- a/libs/mark-flow-ui/src/pages/start_page.tsx
+++ b/libs/mark-flow-ui/src/pages/start_page.tsx
@@ -43,7 +43,7 @@ const StartVotingButton = styled(Button)`
 const Footer = styled.div`
   align-items: center;
   border-top: ${(p) => p.theme.sizes.bordersRem.thick}rem solid
-    ${(p) => p.theme.colors.foreground};
+    ${(p) => p.theme.colors.outline};
   display: flex;
   gap: 1rem;
   justify-content: center;

--- a/libs/types/src/ui_theme.ts
+++ b/libs/types/src/ui_theme.ts
@@ -38,59 +38,10 @@ export function isTouchSizeMode(sizeMode: SizeMode): sizeMode is TouchSizeMode {
   return TOUCH_SIZE_MODES.includes(sizeMode as any);
 }
 
-/** VX CSS color definitions. */
-export enum Color {
-  BLACK = '#000000',
-  DANGER_LOW_CONTRAST = '#ff3d3d',
-  DANGER_MEDIUM_CONTRAST = '#820b0b',
-  GRAY_DARK = '#222222',
-  GRAY_LIGHT = '#8a8a8a',
-  GRAY_MEDIUM = '#424242',
-  OFF_BLACK = '#080808',
-  OFF_WHITE = '#fafafa',
-  PRIMARY_BLUE_LOW_CONTRAST = '#5b8eb5',
-  PRIMARY_BLUE_MEDIUM_CONTRAST = '#00437d',
-  PRIMARY_GREEN_LOW_CONTRAST = '#509a52',
-  PRIMARY_GREEN_MEDIUM_CONTRAST = '#1c4c19',
-  VX_PURPLE_LOW_CONTRAST = '#a977b5',
-  VX_PURPLE_MEDIUM_CONTRAST = '#593460',
-  WARNING_LOW_CONTRAST = '#bc7c10',
-  WARNING_MEDIUM_CONTRAST = '#5c3600',
-  WHITE = '#ffffff',
-}
-
 export type ColorString = string;
 
-export interface LegacyColorTheme {
-  readonly background: ColorString;
-
-  /** @deprecated */
-  readonly accentDanger: ColorString;
-
-  /** @deprecated */
-  readonly accentPrimary: ColorString;
-
-  /** @deprecated */
-  readonly accentSecondary: ColorString;
-
-  /** @deprecated */
-  readonly accentSuccess: ColorString;
-
-  /** @deprecated */
-  readonly accentVxPurple: ColorString;
-
-  /** @deprecated */
-  readonly accentWarning: ColorString;
-
-  /** @deprecated use {@link ColorTheme.onBackground} */
-  readonly foreground: ColorString;
-
-  /** @deprecated use {@link ColorTheme.onBackgroundMuted} */
-  readonly foregroundDisabled: ColorString;
-}
-
 /** CSS color values for various UI features. */
-export interface ColorTheme extends LegacyColorTheme {
+export interface ColorTheme {
   readonly background: ColorString;
   readonly onBackground: ColorString;
   readonly onBackgroundMuted: ColorString;

--- a/libs/ui/src/bmd_paper_ballot.stories.tsx
+++ b/libs/ui/src/bmd_paper_ballot.stories.tsx
@@ -1,7 +1,6 @@
 import { Meta } from '@storybook/react';
 
 import {
-  Color,
   Election,
   ElectionStringKey,
   LanguageCode,
@@ -30,6 +29,7 @@ import {
   generateCandidateVotes,
   generateYesNoVote,
 } from './bmd_paper_ballot_test_utils';
+import { TouchscreenPalette } from './themes/make_theme';
 
 const ballotLanguages = [LanguageCode.ENGLISH, LanguageCode.CHINESE_SIMPLIFIED];
 const election: Election = {
@@ -176,7 +176,7 @@ const meta: Meta<typeof Component> = {
   parameters: {
     backgrounds: {
       default: 'gray',
-      values: [{ name: 'gray', value: Color.GRAY_LIGHT }],
+      values: [{ name: 'gray', value: TouchscreenPalette.Gray50 }],
     },
   },
 };

--- a/libs/ui/src/button.test.tsx
+++ b/libs/ui/src/button.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Color, ColorMode, SizeMode } from '@votingworks/types';
+import { ColorMode, SizeMode } from '@votingworks/types';
 import { assert } from '@votingworks/basics';
 import userEvent from '@testing-library/user-event';
 import { fireEvent, render, screen } from '../test/react_testing_library';
@@ -160,17 +160,19 @@ describe('Button', () => {
   });
 
   test('variant danger', () => {
+    const theme = makeTheme({
+      colorMode: 'contrastMedium',
+      sizeMode: 'touchMedium',
+    });
     render(
       <Button onPress={jest.fn()} variant="danger">
         I’m a dangerous button!
-      </Button>
+      </Button>,
+      { vxTheme: theme }
     );
     const button = screen.getButton('I’m a dangerous button!');
-    expect(button).toHaveStyleRule(
-      'background-color',
-      Color.DANGER_MEDIUM_CONTRAST
-    );
-    expect(button).toHaveStyleRule('color', Color.OFF_WHITE);
+    expect(button).toHaveStyleRule('background-color', theme.colors.danger);
+    expect(button).toHaveStyleRule('color', theme.colors.onDanger);
   });
 
   test('disabled button', () => {

--- a/libs/ui/src/themes/make_theme.ts
+++ b/libs/ui/src/themes/make_theme.ts
@@ -1,10 +1,8 @@
 import { assert } from '@votingworks/basics';
 import {
-  Color,
   ColorMode,
   ColorPalette,
   ColorTheme,
-  LegacyColorTheme,
   ScreenType,
   SizeMode,
   SizeTheme,
@@ -161,9 +159,7 @@ type TouchscreenColorTheme = Pick<
  * specified in this function.
  *
  */
-function expandToFullColorTheme(
-  theme: TouchscreenColorTheme
-): Omit<ColorTheme, keyof Omit<LegacyColorTheme, 'background'>> {
+function expandToFullColorTheme(theme: TouchscreenColorTheme): ColorTheme {
   return {
     background: theme.background,
     onBackground: theme.onBackground,
@@ -199,94 +195,43 @@ function expandToFullColorTheme(
 }
 
 export const colorThemes: Record<ColorMode, ColorTheme> = {
-  contrastHighLight: {
-    accentDanger: Color.BLACK,
-    accentPrimary: Color.BLACK,
-    accentSecondary: Color.BLACK,
-    accentSuccess: Color.BLACK,
-    accentVxPurple: Color.BLACK,
-    accentWarning: Color.BLACK,
-    foreground: Color.BLACK,
-    foregroundDisabled: Color.OFF_BLACK,
+  contrastHighLight: expandToFullColorTheme({
+    background: TouchscreenPalette.Gray0,
+    onBackground: TouchscreenPalette.Gray100,
+    primary: TouchscreenPalette.Gray100,
+    danger: TouchscreenPalette.Gray100,
+    warningAccent: TouchscreenPalette.Gray100,
+    successAccent: TouchscreenPalette.Gray100,
+  }),
 
-    ...expandToFullColorTheme({
-      background: TouchscreenPalette.Gray0,
-      onBackground: TouchscreenPalette.Gray100,
-      primary: TouchscreenPalette.Gray100,
-      danger: TouchscreenPalette.Gray100,
-      warningAccent: TouchscreenPalette.Gray100,
-      successAccent: TouchscreenPalette.Gray100,
-    }),
-  },
-  contrastHighDark: {
-    accentDanger: Color.WHITE,
-    accentPrimary: Color.WHITE,
-    accentSecondary: Color.WHITE,
-    accentSuccess: Color.WHITE,
-    accentVxPurple: Color.WHITE,
-    accentWarning: Color.WHITE,
-    foreground: Color.WHITE,
-    foregroundDisabled: Color.OFF_WHITE,
+  contrastHighDark: expandToFullColorTheme({
+    background: TouchscreenPalette.Gray100,
+    onBackground: TouchscreenPalette.Gray0,
+    primary: TouchscreenPalette.Gray0,
+    danger: TouchscreenPalette.Gray0,
+    warningAccent: TouchscreenPalette.Gray0,
+    successAccent: TouchscreenPalette.Gray0,
+  }),
 
-    ...expandToFullColorTheme({
-      background: TouchscreenPalette.Gray100,
-      onBackground: TouchscreenPalette.Gray0,
-      primary: TouchscreenPalette.Gray0,
-      danger: TouchscreenPalette.Gray0,
-      warningAccent: TouchscreenPalette.Gray0,
-      successAccent: TouchscreenPalette.Gray0,
-    }),
-  },
-  contrastMedium: {
-    accentDanger: Color.DANGER_MEDIUM_CONTRAST,
-    accentPrimary: Color.PRIMARY_BLUE_MEDIUM_CONTRAST,
-    accentSecondary: Color.PRIMARY_GREEN_MEDIUM_CONTRAST,
-    accentSuccess: Color.PRIMARY_GREEN_MEDIUM_CONTRAST,
-    accentVxPurple: Color.VX_PURPLE_MEDIUM_CONTRAST,
-    accentWarning: Color.GRAY_DARK,
-    foreground: Color.GRAY_DARK,
-    foregroundDisabled: Color.GRAY_DARK,
+  contrastMedium: expandToFullColorTheme({
+    background: TouchscreenPalette.Gray5,
+    onBackground: TouchscreenPalette.Gray90,
+    primary: TouchscreenPalette.Purple80,
+    danger: TouchscreenPalette.Red80,
+    warningAccent: TouchscreenPalette.Gray90,
+    successAccent: TouchscreenPalette.Green80,
+  }),
 
-    ...expandToFullColorTheme({
-      background: TouchscreenPalette.Gray5,
-      onBackground: TouchscreenPalette.Gray90,
-      primary: TouchscreenPalette.Purple80,
-      danger: TouchscreenPalette.Red80,
-      warningAccent: TouchscreenPalette.Gray90,
-      successAccent: TouchscreenPalette.Green80,
-    }),
-  },
-  contrastLow: {
-    accentDanger: Color.DANGER_LOW_CONTRAST,
-    accentPrimary: Color.PRIMARY_BLUE_LOW_CONTRAST,
-    accentSecondary: Color.PRIMARY_GREEN_LOW_CONTRAST,
-    accentSuccess: Color.PRIMARY_GREEN_LOW_CONTRAST,
-    accentVxPurple: Color.VX_PURPLE_LOW_CONTRAST,
-    accentWarning: Color.WARNING_LOW_CONTRAST,
-    foreground: Color.GRAY_LIGHT,
-    foregroundDisabled: Color.GRAY_LIGHT,
-
-    ...expandToFullColorTheme({
-      background: TouchscreenPalette.Gray90,
-      onBackground: TouchscreenPalette.Gray50,
-      primary: TouchscreenPalette.Purple50,
-      danger: TouchscreenPalette.Red50,
-      warningAccent: TouchscreenPalette.Orange50,
-      successAccent: TouchscreenPalette.Green50,
-    }),
-  },
+  contrastLow: expandToFullColorTheme({
+    background: TouchscreenPalette.Gray90,
+    onBackground: TouchscreenPalette.Gray50,
+    primary: TouchscreenPalette.Purple50,
+    danger: TouchscreenPalette.Red50,
+    warningAccent: TouchscreenPalette.Orange50,
+    successAccent: TouchscreenPalette.Green50,
+  }),
 
   desktop: {
-    accentDanger: Color.DANGER_LOW_CONTRAST,
-    accentPrimary: Color.PRIMARY_BLUE_LOW_CONTRAST,
-    accentSecondary: Color.PRIMARY_GREEN_LOW_CONTRAST,
-    accentSuccess: Color.PRIMARY_GREEN_LOW_CONTRAST,
-    accentVxPurple: Color.VX_PURPLE_LOW_CONTRAST,
-    accentWarning: Color.WARNING_LOW_CONTRAST,
-
-    foreground: DesktopPalette.Gray100,
-    foregroundDisabled: DesktopPalette.Gray70,
-
     background: DesktopPalette.Gray0,
     onBackground: DesktopPalette.Gray95,
     onBackgroundMuted: DesktopPalette.Gray70,


### PR DESCRIPTION
## Overview

Now that we've fully moved onto the expanded color roles, we can remove the deprecated legacy color roles and the corresponding color definitions (note that these colors have already been preserved in new definitions).

## Demo Video or Screenshot
N/A

## Testing Plan
Automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
