### PR TITLE
VxDesign: Fix bug for primary elections

### DIFF
--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -189,10 +189,6 @@ export function generateBallotStyles(
               )
               .map((contest) => contest.partyId)
           );
-          assert(
-            partyIds.length > 0,
-            'Primary elections cannot have ballot styles with no partisan contests'
-          );
           const parties = election.parties.filter((party) =>
             partyIds.includes(party.id)
           );


### PR DESCRIPTION

## Overview

Fixes: #4063 

There was a well-intentioned assertion guarding against an edge case in primary elections where there were no partisan contests (which would result in no ballot styles being generated). The intention was to explain to the user why there were no ballot styles in that case. However, crashing the app until partisan contests are added prevents the user from being able to address the issue, so it was not a good solution.

## Demo Video or Screenshot
N/A

## Testing Plan
Manual test

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
