### PR TITLE
Fix bad assumption re signature length in .vxsig files

### DIFF
--- a/libs/auth/src/artifact_authentication.ts
+++ b/libs/auth/src/artifact_authentication.ts
@@ -151,8 +151,8 @@ function deserializeArtifactSignatureBundle(
   const signatureLength = buffer[0];
   assert(signatureLength !== undefined);
   assert(
-    signatureLength >= 70 && signatureLength <= 72,
-    `Signature length should be between 70 and 72, received ${signatureLength}`
+    signatureLength >= 60 && signatureLength <= 72,
+    `Signature length should be between 60 and 72, received ${signatureLength}`
   );
   const signature = buffer.subarray(1, signatureLength + 1);
   const signingMachineCert = buffer.subarray(signatureLength + 1);


### PR DESCRIPTION
## Overview

Just noticed this interesting failure in CI and realized that I've seen it before. It isn't a flaky test but a real issue!

![bad-assumption](https://github.com/votingworks/vxsuite/assets/12616928/12fdfcbe-7eb6-4656-85bf-d6fc3c7c3811)

Still wrapping my mind around what causes the signature length to vary, but the current theory is that it has something to do with truncation of leading 0s. So while 72 is the right upper bound, 70 and even 69 aren't ideal lower bounds. Landing on 60 as a super safe lower bound.

Will open an issue to revisit this and fully understand it. We can update the bounds accordingly, then.