### PR TITLE
[VxScan] Decide when to scan on the backend

### DIFF
--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -365,11 +365,6 @@ export function buildApi(
       };
     },
 
-    scanBallot(): void {
-      assert(store.getPollsState() === 'polls_open');
-      machine.scan();
-    },
-
     acceptBallot(): void {
       machine.accept();
     },

--- a/apps/scan/backend/src/app_flow.test.ts
+++ b/apps/scan/backend/src/app_flow.test.ts
@@ -1,4 +1,3 @@
-import { typedAs } from '@votingworks/basics';
 import { buildMockInsertedSmartCardAuth } from '@votingworks/auth';
 import { createMockUsbDrive } from '@votingworks/usb-drive';
 import {
@@ -12,8 +11,7 @@ import { electionGeneralDefinition } from '@votingworks/fixtures';
 import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 import { PrecinctScannerState, TEST_JURISDICTION } from '@votingworks/types';
 import { doesUsbDriveRequireCastVoteRecordSync } from '@votingworks/backend';
-import { getCurrentAppFlowState } from './app_flow';
-import { AppFlowState } from '.';
+import { isReadyToScan } from './app_flow';
 import { Store } from './store';
 import { BALLOT_BAG_CAPACITY } from './globals';
 
@@ -37,13 +35,13 @@ test('setup_card_reader', async () => {
   });
 
   expect(
-    await getCurrentAppFlowState({
+    await isReadyToScan({
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
       precinctScannerState: 'no_paper',
     })
-  ).toEqual(typedAs<AppFlowState>('setup_card_reader'));
+  ).toEqual(false);
 });
 
 test('login_prompt', async () => {
@@ -52,13 +50,13 @@ test('login_prompt', async () => {
   const mockUsbDrive = createMockUsbDrive();
 
   expect(
-    await getCurrentAppFlowState({
+    await isReadyToScan({
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
       precinctScannerState: 'no_paper',
     })
-  ).toEqual(typedAs<AppFlowState>('login_prompt'));
+  ).toEqual(false);
 });
 
 test('card_error', async () => {
@@ -72,13 +70,13 @@ test('card_error', async () => {
   });
 
   expect(
-    await getCurrentAppFlowState({
+    await isReadyToScan({
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
       precinctScannerState: 'no_paper',
     })
-  ).toEqual(typedAs<AppFlowState>('card_error'));
+  ).toEqual(false);
 });
 
 test('unlock_machine (system_administrator)', async () => {
@@ -92,13 +90,13 @@ test('unlock_machine (system_administrator)', async () => {
   });
 
   expect(
-    await getCurrentAppFlowState({
+    await isReadyToScan({
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
       precinctScannerState: 'no_paper',
     })
-  ).toEqual(typedAs<AppFlowState>('unlock_machine'));
+  ).toEqual(false);
 });
 
 test('logged_in:system_administrator', async () => {
@@ -113,13 +111,13 @@ test('logged_in:system_administrator', async () => {
   });
 
   expect(
-    await getCurrentAppFlowState({
+    await isReadyToScan({
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
       precinctScannerState: 'no_paper',
     })
-  ).toEqual(typedAs<AppFlowState>('logged_in:system_administrator'));
+  ).toEqual(false);
 });
 
 test('setup_scanner', async () => {
@@ -133,13 +131,13 @@ test('setup_scanner', async () => {
   });
 
   expect(
-    await getCurrentAppFlowState({
+    await isReadyToScan({
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
       precinctScannerState: 'disconnected',
     })
-  ).toEqual(typedAs<AppFlowState>('setup_scanner'));
+  ).toEqual(false);
 });
 
 test('unlock_machine (election_manager)', async () => {
@@ -162,13 +160,13 @@ test('unlock_machine (election_manager)', async () => {
   });
 
   expect(
-    await getCurrentAppFlowState({
+    await isReadyToScan({
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
       precinctScannerState: 'no_paper',
     })
-  ).toEqual(typedAs<AppFlowState>('unlock_machine'));
+  ).toEqual(false);
 });
 
 test('unlock_machine (poll_worker)', async () => {
@@ -191,13 +189,13 @@ test('unlock_machine (poll_worker)', async () => {
   });
 
   expect(
-    await getCurrentAppFlowState({
+    await isReadyToScan({
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
       precinctScannerState: 'no_paper',
     })
-  ).toEqual(typedAs<AppFlowState>('unlock_machine'));
+  ).toEqual(false);
 });
 
 test('unconfigured:election (election_manager)', async () => {
@@ -216,13 +214,13 @@ test('unconfigured:election (election_manager)', async () => {
   });
 
   expect(
-    await getCurrentAppFlowState({
+    await isReadyToScan({
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
       precinctScannerState: 'no_paper',
     })
-  ).toEqual(typedAs<AppFlowState>('unconfigured:election'));
+  ).toEqual(false);
 });
 
 test('unconfigured:election (poll_worker)', async () => {
@@ -241,13 +239,13 @@ test('unconfigured:election (poll_worker)', async () => {
   });
 
   expect(
-    await getCurrentAppFlowState({
+    await isReadyToScan({
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
       precinctScannerState: 'no_paper',
     })
-  ).toEqual(typedAs<AppFlowState>('unconfigured:election'));
+  ).toEqual(false);
 });
 
 test('logged_in:election_manager', async () => {
@@ -270,13 +268,13 @@ test('logged_in:election_manager', async () => {
   });
 
   expect(
-    await getCurrentAppFlowState({
+    await isReadyToScan({
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
       precinctScannerState: 'no_paper',
     })
-  ).toEqual(typedAs<AppFlowState>('logged_in:election_manager'));
+  ).toEqual(false);
 });
 
 test('unconfigured:precinct', async () => {
@@ -299,13 +297,13 @@ test('unconfigured:precinct', async () => {
   });
 
   expect(
-    await getCurrentAppFlowState({
+    await isReadyToScan({
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
       precinctScannerState: 'no_paper',
     })
-  ).toEqual(typedAs<AppFlowState>('unconfigured:precinct'));
+  ).toEqual(false);
 });
 
 test('insert_usb_drive', async () => {
@@ -331,13 +329,13 @@ test('insert_usb_drive', async () => {
   mockUsbDrive.removeUsbDrive();
 
   expect(
-    await getCurrentAppFlowState({
+    await isReadyToScan({
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
       precinctScannerState: 'no_paper',
     })
-  ).toEqual(typedAs<AppFlowState>('insert_usb_drive'));
+  ).toEqual(false);
 });
 
 test('replace_ballot_bag', async () => {
@@ -365,13 +363,13 @@ test('replace_ballot_bag', async () => {
   jest.spyOn(store, 'getBallotsCounted').mockReturnValue(BALLOT_BAG_CAPACITY);
 
   expect(
-    await getCurrentAppFlowState({
+    await isReadyToScan({
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
       precinctScannerState: 'no_paper',
     })
-  ).toEqual(typedAs<AppFlowState>('replace_ballot_bag'));
+  ).toEqual(false);
 });
 
 test('logged_in:poll_worker', async () => {
@@ -397,13 +395,13 @@ test('logged_in:poll_worker', async () => {
   mockUsbDrive.insertUsbDrive({});
 
   expect(
-    await getCurrentAppFlowState({
+    await isReadyToScan({
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
       precinctScannerState: 'no_paper',
     })
-  ).toEqual(typedAs<AppFlowState>('logged_in:poll_worker'));
+  ).toEqual(false);
 });
 
 test('polls_not_open', async () => {
@@ -420,13 +418,13 @@ test('polls_not_open', async () => {
   mockUsbDrive.insertUsbDrive({});
 
   expect(
-    await getCurrentAppFlowState({
+    await isReadyToScan({
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
       precinctScannerState: 'no_paper',
     })
-  ).toEqual(typedAs<AppFlowState>('polls_not_open'));
+  ).toEqual(false);
 });
 
 test('cast_vote_record_sync_required', async () => {
@@ -446,13 +444,13 @@ test('cast_vote_record_sync_required', async () => {
   doesUsbDriveRequireCastVoteRecordSyncMock.mockResolvedValue(true);
 
   expect(
-    await getCurrentAppFlowState({
+    await isReadyToScan({
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
       precinctScannerState: 'no_paper',
     })
-  ).toEqual(typedAs<AppFlowState>('cast_vote_record_sync_required'));
+  ).toEqual(false);
 });
 
 test('ballot:accepted', async () => {
@@ -472,13 +470,13 @@ test('ballot:accepted', async () => {
   doesUsbDriveRequireCastVoteRecordSyncMock.mockResolvedValue(false);
 
   expect(
-    await getCurrentAppFlowState({
+    await isReadyToScan({
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
       precinctScannerState: 'accepted',
     })
-  ).toEqual(typedAs<AppFlowState>('ballot:accepted'));
+  ).toEqual(false);
 });
 
 test('ballot:accepting (no review)', async () => {
@@ -498,13 +496,13 @@ test('ballot:accepting (no review)', async () => {
   doesUsbDriveRequireCastVoteRecordSyncMock.mockResolvedValue(false);
 
   expect(
-    await getCurrentAppFlowState({
+    await isReadyToScan({
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
       precinctScannerState: 'accepting',
     })
-  ).toEqual(typedAs<AppFlowState>('ballot:accepting'));
+  ).toEqual(false);
 });
 
 test('ballot:accepting (with review)', async () => {
@@ -524,13 +522,13 @@ test('ballot:accepting (with review)', async () => {
   doesUsbDriveRequireCastVoteRecordSyncMock.mockResolvedValue(false);
 
   expect(
-    await getCurrentAppFlowState({
+    await isReadyToScan({
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
       precinctScannerState: 'accepting_after_review',
     })
-  ).toEqual(typedAs<AppFlowState>('ballot:accepting'));
+  ).toEqual(false);
 });
 
 test('ballot:scanning', async () => {
@@ -550,13 +548,13 @@ test('ballot:scanning', async () => {
   doesUsbDriveRequireCastVoteRecordSyncMock.mockResolvedValue(false);
 
   expect(
-    await getCurrentAppFlowState({
+    await isReadyToScan({
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
       precinctScannerState: 'scanning',
     })
-  ).toEqual(typedAs<AppFlowState>('ballot:scanning'));
+  ).toEqual(false);
 });
 
 test('ballot:waiting_to_accept', async () => {
@@ -576,13 +574,13 @@ test('ballot:waiting_to_accept', async () => {
   doesUsbDriveRequireCastVoteRecordSyncMock.mockResolvedValue(false);
 
   expect(
-    await getCurrentAppFlowState({
+    await isReadyToScan({
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
       precinctScannerState: 'ready_to_accept',
     })
-  ).toEqual(typedAs<AppFlowState>('ballot:waiting_to_accept'));
+  ).toEqual(false);
 });
 
 test('ballot:waiting_to_scan', async () => {
@@ -602,13 +600,13 @@ test('ballot:waiting_to_scan', async () => {
   doesUsbDriveRequireCastVoteRecordSyncMock.mockResolvedValue(false);
 
   expect(
-    await getCurrentAppFlowState({
+    await isReadyToScan({
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
       precinctScannerState: 'ready_to_scan',
     })
-  ).toEqual(typedAs<AppFlowState>('ballot:waiting_to_scan'));
+  ).toEqual(true);
 });
 
 test.each([
@@ -642,11 +640,11 @@ test.each([
   doesUsbDriveRequireCastVoteRecordSyncMock.mockResolvedValue(false);
 
   expect(
-    await getCurrentAppFlowState({
+    await isReadyToScan({
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
       precinctScannerState,
     })
-  ).toEqual(typedAs<AppFlowState>('unknown'));
+  ).toEqual(false);
 });

--- a/apps/scan/backend/src/app_flow.test.ts
+++ b/apps/scan/backend/src/app_flow.test.ts
@@ -9,7 +9,7 @@ import {
 } from '@votingworks/test-utils';
 import { electionGeneralDefinition } from '@votingworks/fixtures';
 import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
-import { PrecinctScannerState, TEST_JURISDICTION } from '@votingworks/types';
+import { TEST_JURISDICTION } from '@votingworks/types';
 import { doesUsbDriveRequireCastVoteRecordSync } from '@votingworks/backend';
 import { isReadyToScan } from './app_flow';
 import { Store } from './store';
@@ -39,7 +39,6 @@ test('setup_card_reader', async () => {
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
-      precinctScannerState: 'no_paper',
     })
   ).toEqual(false);
 });
@@ -54,7 +53,6 @@ test('login_prompt', async () => {
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
-      precinctScannerState: 'no_paper',
     })
   ).toEqual(false);
 });
@@ -74,7 +72,6 @@ test('card_error', async () => {
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
-      precinctScannerState: 'no_paper',
     })
   ).toEqual(false);
 });
@@ -94,7 +91,6 @@ test('unlock_machine (system_administrator)', async () => {
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
-      precinctScannerState: 'no_paper',
     })
   ).toEqual(false);
 });
@@ -115,27 +111,6 @@ test('logged_in:system_administrator', async () => {
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
-      precinctScannerState: 'no_paper',
-    })
-  ).toEqual(false);
-});
-
-test('setup_scanner', async () => {
-  const auth = buildMockInsertedSmartCardAuth();
-  const store = Store.memoryStore();
-  const mockUsbDrive = createMockUsbDrive();
-
-  store.setElectionAndJurisdiction({
-    electionData: electionGeneralDefinition.electionData,
-    jurisdiction: TEST_JURISDICTION,
-  });
-
-  expect(
-    await isReadyToScan({
-      auth,
-      store,
-      usbDrive: mockUsbDrive.usbDrive,
-      precinctScannerState: 'disconnected',
     })
   ).toEqual(false);
 });
@@ -164,7 +139,6 @@ test('unlock_machine (election_manager)', async () => {
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
-      precinctScannerState: 'no_paper',
     })
   ).toEqual(false);
 });
@@ -193,7 +167,6 @@ test('unlock_machine (poll_worker)', async () => {
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
-      precinctScannerState: 'no_paper',
     })
   ).toEqual(false);
 });
@@ -218,7 +191,6 @@ test('unconfigured:election (election_manager)', async () => {
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
-      precinctScannerState: 'no_paper',
     })
   ).toEqual(false);
 });
@@ -243,7 +215,6 @@ test('unconfigured:election (poll_worker)', async () => {
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
-      precinctScannerState: 'no_paper',
     })
   ).toEqual(false);
 });
@@ -272,7 +243,6 @@ test('logged_in:election_manager', async () => {
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
-      precinctScannerState: 'no_paper',
     })
   ).toEqual(false);
 });
@@ -301,7 +271,6 @@ test('unconfigured:precinct', async () => {
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
-      precinctScannerState: 'no_paper',
     })
   ).toEqual(false);
 });
@@ -333,7 +302,6 @@ test('insert_usb_drive', async () => {
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
-      precinctScannerState: 'no_paper',
     })
   ).toEqual(false);
 });
@@ -367,7 +335,6 @@ test('replace_ballot_bag', async () => {
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
-      precinctScannerState: 'no_paper',
     })
   ).toEqual(false);
 });
@@ -399,7 +366,6 @@ test('logged_in:poll_worker', async () => {
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
-      precinctScannerState: 'no_paper',
     })
   ).toEqual(false);
 });
@@ -422,7 +388,6 @@ test('polls_not_open', async () => {
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
-      precinctScannerState: 'no_paper',
     })
   ).toEqual(false);
 });
@@ -448,137 +413,6 @@ test('cast_vote_record_sync_required', async () => {
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
-      precinctScannerState: 'no_paper',
-    })
-  ).toEqual(false);
-});
-
-test('ballot:accepted', async () => {
-  const auth = buildMockInsertedSmartCardAuth();
-  const store = Store.memoryStore();
-  const mockUsbDrive = createMockUsbDrive();
-
-  store.setElectionAndJurisdiction({
-    electionData: electionGeneralDefinition.electionData,
-    jurisdiction: TEST_JURISDICTION,
-  });
-
-  store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
-  mockUsbDrive.insertUsbDrive({});
-  store.transitionPolls({ type: 'open_polls', time: Date.now() });
-
-  doesUsbDriveRequireCastVoteRecordSyncMock.mockResolvedValue(false);
-
-  expect(
-    await isReadyToScan({
-      auth,
-      store,
-      usbDrive: mockUsbDrive.usbDrive,
-      precinctScannerState: 'accepted',
-    })
-  ).toEqual(false);
-});
-
-test('ballot:accepting (no review)', async () => {
-  const auth = buildMockInsertedSmartCardAuth();
-  const store = Store.memoryStore();
-  const mockUsbDrive = createMockUsbDrive();
-
-  store.setElectionAndJurisdiction({
-    electionData: electionGeneralDefinition.electionData,
-    jurisdiction: TEST_JURISDICTION,
-  });
-
-  store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
-  mockUsbDrive.insertUsbDrive({});
-  store.transitionPolls({ type: 'open_polls', time: Date.now() });
-
-  doesUsbDriveRequireCastVoteRecordSyncMock.mockResolvedValue(false);
-
-  expect(
-    await isReadyToScan({
-      auth,
-      store,
-      usbDrive: mockUsbDrive.usbDrive,
-      precinctScannerState: 'accepting',
-    })
-  ).toEqual(false);
-});
-
-test('ballot:accepting (with review)', async () => {
-  const auth = buildMockInsertedSmartCardAuth();
-  const store = Store.memoryStore();
-  const mockUsbDrive = createMockUsbDrive();
-
-  store.setElectionAndJurisdiction({
-    electionData: electionGeneralDefinition.electionData,
-    jurisdiction: TEST_JURISDICTION,
-  });
-
-  store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
-  mockUsbDrive.insertUsbDrive({});
-  store.transitionPolls({ type: 'open_polls', time: Date.now() });
-
-  doesUsbDriveRequireCastVoteRecordSyncMock.mockResolvedValue(false);
-
-  expect(
-    await isReadyToScan({
-      auth,
-      store,
-      usbDrive: mockUsbDrive.usbDrive,
-      precinctScannerState: 'accepting_after_review',
-    })
-  ).toEqual(false);
-});
-
-test('ballot:scanning', async () => {
-  const auth = buildMockInsertedSmartCardAuth();
-  const store = Store.memoryStore();
-  const mockUsbDrive = createMockUsbDrive();
-
-  store.setElectionAndJurisdiction({
-    electionData: electionGeneralDefinition.electionData,
-    jurisdiction: TEST_JURISDICTION,
-  });
-
-  store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
-  mockUsbDrive.insertUsbDrive({});
-  store.transitionPolls({ type: 'open_polls', time: Date.now() });
-
-  doesUsbDriveRequireCastVoteRecordSyncMock.mockResolvedValue(false);
-
-  expect(
-    await isReadyToScan({
-      auth,
-      store,
-      usbDrive: mockUsbDrive.usbDrive,
-      precinctScannerState: 'scanning',
-    })
-  ).toEqual(false);
-});
-
-test('ballot:waiting_to_accept', async () => {
-  const auth = buildMockInsertedSmartCardAuth();
-  const store = Store.memoryStore();
-  const mockUsbDrive = createMockUsbDrive();
-
-  store.setElectionAndJurisdiction({
-    electionData: electionGeneralDefinition.electionData,
-    jurisdiction: TEST_JURISDICTION,
-  });
-
-  store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
-  mockUsbDrive.insertUsbDrive({});
-  store.transitionPolls({ type: 'open_polls', time: Date.now() });
-
-  doesUsbDriveRequireCastVoteRecordSyncMock.mockResolvedValue(false);
-
-  expect(
-    await isReadyToScan({
-      auth,
-      store,
-      usbDrive: mockUsbDrive.usbDrive,
-      precinctScannerState: 'ready_to_accept',
     })
   ).toEqual(false);
 });
@@ -604,47 +438,6 @@ test('ballot:waiting_to_scan', async () => {
       auth,
       store,
       usbDrive: mockUsbDrive.usbDrive,
-      precinctScannerState: 'ready_to_scan',
     })
   ).toEqual(true);
-});
-
-test.each([
-  'connecting',
-  'no_paper',
-  'returning_to_rescan',
-  'needs_review',
-  'returning',
-  'returned',
-  'rejecting',
-  'rejected',
-  'jammed',
-  'both_sides_have_paper',
-  'recovering_from_error',
-  'double_sheet_jammed',
-  'unrecoverable_error',
-] as PrecinctScannerState[])('unknown (%s)', async (precinctScannerState) => {
-  const auth = buildMockInsertedSmartCardAuth();
-  const store = Store.memoryStore();
-  const mockUsbDrive = createMockUsbDrive();
-
-  store.setElectionAndJurisdiction({
-    electionData: electionGeneralDefinition.electionData,
-    jurisdiction: TEST_JURISDICTION,
-  });
-
-  store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
-  mockUsbDrive.insertUsbDrive({});
-  store.transitionPolls({ type: 'open_polls', time: Date.now() });
-
-  doesUsbDriveRequireCastVoteRecordSyncMock.mockResolvedValue(false);
-
-  expect(
-    await isReadyToScan({
-      auth,
-      store,
-      usbDrive: mockUsbDrive.usbDrive,
-      precinctScannerState,
-    })
-  ).toEqual(false);
 });

--- a/apps/scan/backend/src/app_flow.test.ts
+++ b/apps/scan/backend/src/app_flow.test.ts
@@ -8,7 +8,7 @@ import {
   fakeSystemAdministratorUser,
   mockOf,
 } from '@votingworks/test-utils';
-import { electionGridLayoutNewHampshireAmherstFixtures } from '@votingworks/fixtures';
+import { electionGeneralDefinition } from '@votingworks/fixtures';
 import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 import { PrecinctScannerState, TEST_JURISDICTION } from '@votingworks/types';
 import { doesUsbDriveRequireCastVoteRecordSync } from '@votingworks/backend';
@@ -128,9 +128,7 @@ test('setup_scanner', async () => {
   const mockUsbDrive = createMockUsbDrive();
 
   store.setElectionAndJurisdiction({
-    electionData:
-      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
-        .electionData,
+    electionData: electionGeneralDefinition.electionData,
     jurisdiction: TEST_JURISDICTION,
   });
 
@@ -150,15 +148,11 @@ test('unlock_machine (election_manager)', async () => {
   const mockUsbDrive = createMockUsbDrive();
 
   const electionManagerUser = fakeElectionManagerUser({
-    electionHash:
-      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
-        .electionHash,
+    electionHash: electionGeneralDefinition.electionHash,
   });
 
   store.setElectionAndJurisdiction({
-    electionData:
-      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
-        .electionData,
+    electionData: electionGeneralDefinition.electionData,
     jurisdiction: TEST_JURISDICTION,
   });
 
@@ -183,15 +177,11 @@ test('unlock_machine (poll_worker)', async () => {
   const mockUsbDrive = createMockUsbDrive();
 
   const pollWorkerUser = fakePollWorkerUser({
-    electionHash:
-      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
-        .electionHash,
+    electionHash: electionGeneralDefinition.electionHash,
   });
 
   store.setElectionAndJurisdiction({
-    electionData:
-      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
-        .electionData,
+    electionData: electionGeneralDefinition.electionData,
     jurisdiction: TEST_JURISDICTION,
   });
 
@@ -216,9 +206,7 @@ test('unconfigured:election (election_manager)', async () => {
   const mockUsbDrive = createMockUsbDrive();
 
   const electionManagerUser = fakeElectionManagerUser({
-    electionHash:
-      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
-        .electionHash,
+    electionHash: electionGeneralDefinition.electionHash,
   });
 
   auth.getAuthStatus.mockResolvedValue({
@@ -243,9 +231,7 @@ test('unconfigured:election (poll_worker)', async () => {
   const mockUsbDrive = createMockUsbDrive();
 
   const pollWorkerUser = fakePollWorkerUser({
-    electionHash:
-      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
-        .electionHash,
+    electionHash: electionGeneralDefinition.electionHash,
   });
 
   auth.getAuthStatus.mockResolvedValue({
@@ -269,15 +255,11 @@ test('logged_in:election_manager', async () => {
   const store = Store.memoryStore();
   const mockUsbDrive = createMockUsbDrive();
   const electionManagerUser = fakeElectionManagerUser({
-    electionHash:
-      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
-        .electionHash,
+    electionHash: electionGeneralDefinition.electionHash,
   });
 
   store.setElectionAndJurisdiction({
-    electionData:
-      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
-        .electionData,
+    electionData: electionGeneralDefinition.electionData,
     jurisdiction: TEST_JURISDICTION,
   });
 
@@ -302,15 +284,11 @@ test('unconfigured:precinct', async () => {
   const store = Store.memoryStore();
   const mockUsbDrive = createMockUsbDrive();
   const pollWorkerUser = fakePollWorkerUser({
-    electionHash:
-      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
-        .electionHash,
+    electionHash: electionGeneralDefinition.electionHash,
   });
 
   store.setElectionAndJurisdiction({
-    electionData:
-      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
-        .electionData,
+    electionData: electionGeneralDefinition.electionData,
     jurisdiction: TEST_JURISDICTION,
   });
 
@@ -335,15 +313,11 @@ test('insert_usb_drive', async () => {
   const store = Store.memoryStore();
   const mockUsbDrive = createMockUsbDrive();
   const pollWorkerUser = fakePollWorkerUser({
-    electionHash:
-      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
-        .electionHash,
+    electionHash: electionGeneralDefinition.electionHash,
   });
 
   store.setElectionAndJurisdiction({
-    electionData:
-      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
-        .electionData,
+    electionData: electionGeneralDefinition.electionData,
     jurisdiction: TEST_JURISDICTION,
   });
 
@@ -371,15 +345,11 @@ test('replace_ballot_bag', async () => {
   const store = Store.memoryStore();
   const mockUsbDrive = createMockUsbDrive();
   const pollWorkerUser = fakePollWorkerUser({
-    electionHash:
-      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
-        .electionHash,
+    electionHash: electionGeneralDefinition.electionHash,
   });
 
   store.setElectionAndJurisdiction({
-    electionData:
-      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
-        .electionData,
+    electionData: electionGeneralDefinition.electionData,
     jurisdiction: TEST_JURISDICTION,
   });
 
@@ -409,15 +379,11 @@ test('logged_in:poll_worker', async () => {
   const store = Store.memoryStore();
   const mockUsbDrive = createMockUsbDrive();
   const pollWorkerUser = fakePollWorkerUser({
-    electionHash:
-      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
-        .electionHash,
+    electionHash: electionGeneralDefinition.electionHash,
   });
 
   store.setElectionAndJurisdiction({
-    electionData:
-      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
-        .electionData,
+    electionData: electionGeneralDefinition.electionData,
     jurisdiction: TEST_JURISDICTION,
   });
 
@@ -446,9 +412,7 @@ test('polls_not_open', async () => {
   const mockUsbDrive = createMockUsbDrive();
 
   store.setElectionAndJurisdiction({
-    electionData:
-      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
-        .electionData,
+    electionData: electionGeneralDefinition.electionData,
     jurisdiction: TEST_JURISDICTION,
   });
 
@@ -471,9 +435,7 @@ test('cast_vote_record_sync_required', async () => {
   const mockUsbDrive = createMockUsbDrive();
 
   store.setElectionAndJurisdiction({
-    electionData:
-      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
-        .electionData,
+    electionData: electionGeneralDefinition.electionData,
     jurisdiction: TEST_JURISDICTION,
   });
 
@@ -499,9 +461,7 @@ test('ballot:accepted', async () => {
   const mockUsbDrive = createMockUsbDrive();
 
   store.setElectionAndJurisdiction({
-    electionData:
-      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
-        .electionData,
+    electionData: electionGeneralDefinition.electionData,
     jurisdiction: TEST_JURISDICTION,
   });
 
@@ -527,9 +487,7 @@ test('ballot:accepting (no review)', async () => {
   const mockUsbDrive = createMockUsbDrive();
 
   store.setElectionAndJurisdiction({
-    electionData:
-      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
-        .electionData,
+    electionData: electionGeneralDefinition.electionData,
     jurisdiction: TEST_JURISDICTION,
   });
 
@@ -555,9 +513,7 @@ test('ballot:accepting (with review)', async () => {
   const mockUsbDrive = createMockUsbDrive();
 
   store.setElectionAndJurisdiction({
-    electionData:
-      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
-        .electionData,
+    electionData: electionGeneralDefinition.electionData,
     jurisdiction: TEST_JURISDICTION,
   });
 
@@ -583,9 +539,7 @@ test('ballot:scanning', async () => {
   const mockUsbDrive = createMockUsbDrive();
 
   store.setElectionAndJurisdiction({
-    electionData:
-      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
-        .electionData,
+    electionData: electionGeneralDefinition.electionData,
     jurisdiction: TEST_JURISDICTION,
   });
 
@@ -611,9 +565,7 @@ test('ballot:waiting_to_accept', async () => {
   const mockUsbDrive = createMockUsbDrive();
 
   store.setElectionAndJurisdiction({
-    electionData:
-      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
-        .electionData,
+    electionData: electionGeneralDefinition.electionData,
     jurisdiction: TEST_JURISDICTION,
   });
 
@@ -639,9 +591,7 @@ test('ballot:waiting_to_scan', async () => {
   const mockUsbDrive = createMockUsbDrive();
 
   store.setElectionAndJurisdiction({
-    electionData:
-      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
-        .electionData,
+    electionData: electionGeneralDefinition.electionData,
     jurisdiction: TEST_JURISDICTION,
   });
 
@@ -681,9 +631,7 @@ test.each([
   const mockUsbDrive = createMockUsbDrive();
 
   store.setElectionAndJurisdiction({
-    electionData:
-      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
-        .electionData,
+    electionData: electionGeneralDefinition.electionData,
     jurisdiction: TEST_JURISDICTION,
   });
 

--- a/apps/scan/backend/src/app_flow.test.ts
+++ b/apps/scan/backend/src/app_flow.test.ts
@@ -1,0 +1,704 @@
+import { typedAs } from '@votingworks/basics';
+import { buildMockInsertedSmartCardAuth } from '@votingworks/auth';
+import { createMockUsbDrive } from '@votingworks/usb-drive';
+import {
+  fakeElectionManagerUser,
+  fakePollWorkerUser,
+  fakeSessionExpiresAt,
+  fakeSystemAdministratorUser,
+  mockOf,
+} from '@votingworks/test-utils';
+import { electionGridLayoutNewHampshireAmherstFixtures } from '@votingworks/fixtures';
+import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
+import { PrecinctScannerState, TEST_JURISDICTION } from '@votingworks/types';
+import { doesUsbDriveRequireCastVoteRecordSync } from '@votingworks/backend';
+import { getCurrentAppFlowState } from './app_flow';
+import { AppFlowState } from '.';
+import { Store } from './store';
+import { BALLOT_BAG_CAPACITY } from './globals';
+
+jest.mock('@votingworks/backend', () => ({
+  ...jest.requireActual('@votingworks/backend'),
+  doesUsbDriveRequireCastVoteRecordSync: jest.fn(),
+}));
+
+const doesUsbDriveRequireCastVoteRecordSyncMock = mockOf(
+  doesUsbDriveRequireCastVoteRecordSync
+);
+
+test('setup_card_reader', async () => {
+  const auth = buildMockInsertedSmartCardAuth();
+  const store = Store.memoryStore();
+  const mockUsbDrive = createMockUsbDrive();
+
+  auth.getAuthStatus.mockResolvedValue({
+    status: 'logged_out',
+    reason: 'no_card_reader',
+  });
+
+  expect(
+    await getCurrentAppFlowState({
+      auth,
+      store,
+      usbDrive: mockUsbDrive.usbDrive,
+      precinctScannerState: 'no_paper',
+    })
+  ).toEqual(typedAs<AppFlowState>('setup_card_reader'));
+});
+
+test('login_prompt', async () => {
+  const auth = buildMockInsertedSmartCardAuth();
+  const store = Store.memoryStore();
+  const mockUsbDrive = createMockUsbDrive();
+
+  expect(
+    await getCurrentAppFlowState({
+      auth,
+      store,
+      usbDrive: mockUsbDrive.usbDrive,
+      precinctScannerState: 'no_paper',
+    })
+  ).toEqual(typedAs<AppFlowState>('login_prompt'));
+});
+
+test('card_error', async () => {
+  const auth = buildMockInsertedSmartCardAuth();
+  const store = Store.memoryStore();
+  const mockUsbDrive = createMockUsbDrive();
+
+  auth.getAuthStatus.mockResolvedValue({
+    status: 'logged_out',
+    reason: 'card_error',
+  });
+
+  expect(
+    await getCurrentAppFlowState({
+      auth,
+      store,
+      usbDrive: mockUsbDrive.usbDrive,
+      precinctScannerState: 'no_paper',
+    })
+  ).toEqual(typedAs<AppFlowState>('card_error'));
+});
+
+test('unlock_machine (system_administrator)', async () => {
+  const auth = buildMockInsertedSmartCardAuth();
+  const store = Store.memoryStore();
+  const mockUsbDrive = createMockUsbDrive();
+
+  auth.getAuthStatus.mockResolvedValue({
+    status: 'checking_pin',
+    user: fakeSystemAdministratorUser(),
+  });
+
+  expect(
+    await getCurrentAppFlowState({
+      auth,
+      store,
+      usbDrive: mockUsbDrive.usbDrive,
+      precinctScannerState: 'no_paper',
+    })
+  ).toEqual(typedAs<AppFlowState>('unlock_machine'));
+});
+
+test('logged_in:system_administrator', async () => {
+  const auth = buildMockInsertedSmartCardAuth();
+  const store = Store.memoryStore();
+  const mockUsbDrive = createMockUsbDrive();
+
+  auth.getAuthStatus.mockResolvedValue({
+    status: 'logged_in',
+    user: fakeSystemAdministratorUser(),
+    sessionExpiresAt: fakeSessionExpiresAt(),
+  });
+
+  expect(
+    await getCurrentAppFlowState({
+      auth,
+      store,
+      usbDrive: mockUsbDrive.usbDrive,
+      precinctScannerState: 'no_paper',
+    })
+  ).toEqual(typedAs<AppFlowState>('logged_in:system_administrator'));
+});
+
+test('setup_scanner', async () => {
+  const auth = buildMockInsertedSmartCardAuth();
+  const store = Store.memoryStore();
+  const mockUsbDrive = createMockUsbDrive();
+
+  store.setElectionAndJurisdiction({
+    electionData:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+        .electionData,
+    jurisdiction: TEST_JURISDICTION,
+  });
+
+  expect(
+    await getCurrentAppFlowState({
+      auth,
+      store,
+      usbDrive: mockUsbDrive.usbDrive,
+      precinctScannerState: 'disconnected',
+    })
+  ).toEqual(typedAs<AppFlowState>('setup_scanner'));
+});
+
+test('unlock_machine (election_manager)', async () => {
+  const auth = buildMockInsertedSmartCardAuth();
+  const store = Store.memoryStore();
+  const mockUsbDrive = createMockUsbDrive();
+
+  const electionManagerUser = fakeElectionManagerUser({
+    electionHash:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+        .electionHash,
+  });
+
+  store.setElectionAndJurisdiction({
+    electionData:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+        .electionData,
+    jurisdiction: TEST_JURISDICTION,
+  });
+
+  auth.getAuthStatus.mockResolvedValue({
+    status: 'checking_pin',
+    user: electionManagerUser,
+  });
+
+  expect(
+    await getCurrentAppFlowState({
+      auth,
+      store,
+      usbDrive: mockUsbDrive.usbDrive,
+      precinctScannerState: 'no_paper',
+    })
+  ).toEqual(typedAs<AppFlowState>('unlock_machine'));
+});
+
+test('unlock_machine (poll_worker)', async () => {
+  const auth = buildMockInsertedSmartCardAuth();
+  const store = Store.memoryStore();
+  const mockUsbDrive = createMockUsbDrive();
+
+  const pollWorkerUser = fakePollWorkerUser({
+    electionHash:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+        .electionHash,
+  });
+
+  store.setElectionAndJurisdiction({
+    electionData:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+        .electionData,
+    jurisdiction: TEST_JURISDICTION,
+  });
+
+  auth.getAuthStatus.mockResolvedValue({
+    status: 'checking_pin',
+    user: pollWorkerUser,
+  });
+
+  expect(
+    await getCurrentAppFlowState({
+      auth,
+      store,
+      usbDrive: mockUsbDrive.usbDrive,
+      precinctScannerState: 'no_paper',
+    })
+  ).toEqual(typedAs<AppFlowState>('unlock_machine'));
+});
+
+test('unconfigured:election (election_manager)', async () => {
+  const auth = buildMockInsertedSmartCardAuth();
+  const store = Store.memoryStore();
+  const mockUsbDrive = createMockUsbDrive();
+
+  const electionManagerUser = fakeElectionManagerUser({
+    electionHash:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+        .electionHash,
+  });
+
+  auth.getAuthStatus.mockResolvedValue({
+    status: 'logged_in',
+    user: electionManagerUser,
+    sessionExpiresAt: fakeSessionExpiresAt(),
+  });
+
+  expect(
+    await getCurrentAppFlowState({
+      auth,
+      store,
+      usbDrive: mockUsbDrive.usbDrive,
+      precinctScannerState: 'no_paper',
+    })
+  ).toEqual(typedAs<AppFlowState>('unconfigured:election'));
+});
+
+test('unconfigured:election (poll_worker)', async () => {
+  const auth = buildMockInsertedSmartCardAuth();
+  const store = Store.memoryStore();
+  const mockUsbDrive = createMockUsbDrive();
+
+  const pollWorkerUser = fakePollWorkerUser({
+    electionHash:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+        .electionHash,
+  });
+
+  auth.getAuthStatus.mockResolvedValue({
+    status: 'logged_in',
+    user: pollWorkerUser,
+    sessionExpiresAt: fakeSessionExpiresAt(),
+  });
+
+  expect(
+    await getCurrentAppFlowState({
+      auth,
+      store,
+      usbDrive: mockUsbDrive.usbDrive,
+      precinctScannerState: 'no_paper',
+    })
+  ).toEqual(typedAs<AppFlowState>('unconfigured:election'));
+});
+
+test('logged_in:election_manager', async () => {
+  const auth = buildMockInsertedSmartCardAuth();
+  const store = Store.memoryStore();
+  const mockUsbDrive = createMockUsbDrive();
+  const electionManagerUser = fakeElectionManagerUser({
+    electionHash:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+        .electionHash,
+  });
+
+  store.setElectionAndJurisdiction({
+    electionData:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+        .electionData,
+    jurisdiction: TEST_JURISDICTION,
+  });
+
+  auth.getAuthStatus.mockResolvedValue({
+    status: 'logged_in',
+    user: electionManagerUser,
+    sessionExpiresAt: fakeSessionExpiresAt(),
+  });
+
+  expect(
+    await getCurrentAppFlowState({
+      auth,
+      store,
+      usbDrive: mockUsbDrive.usbDrive,
+      precinctScannerState: 'no_paper',
+    })
+  ).toEqual(typedAs<AppFlowState>('logged_in:election_manager'));
+});
+
+test('unconfigured:precinct', async () => {
+  const auth = buildMockInsertedSmartCardAuth();
+  const store = Store.memoryStore();
+  const mockUsbDrive = createMockUsbDrive();
+  const pollWorkerUser = fakePollWorkerUser({
+    electionHash:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+        .electionHash,
+  });
+
+  store.setElectionAndJurisdiction({
+    electionData:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+        .electionData,
+    jurisdiction: TEST_JURISDICTION,
+  });
+
+  auth.getAuthStatus.mockResolvedValue({
+    status: 'logged_in',
+    user: pollWorkerUser,
+    sessionExpiresAt: fakeSessionExpiresAt(),
+  });
+
+  expect(
+    await getCurrentAppFlowState({
+      auth,
+      store,
+      usbDrive: mockUsbDrive.usbDrive,
+      precinctScannerState: 'no_paper',
+    })
+  ).toEqual(typedAs<AppFlowState>('unconfigured:precinct'));
+});
+
+test('insert_usb_drive', async () => {
+  const auth = buildMockInsertedSmartCardAuth();
+  const store = Store.memoryStore();
+  const mockUsbDrive = createMockUsbDrive();
+  const pollWorkerUser = fakePollWorkerUser({
+    electionHash:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+        .electionHash,
+  });
+
+  store.setElectionAndJurisdiction({
+    electionData:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+        .electionData,
+    jurisdiction: TEST_JURISDICTION,
+  });
+
+  auth.getAuthStatus.mockResolvedValue({
+    status: 'logged_in',
+    user: pollWorkerUser,
+    sessionExpiresAt: fakeSessionExpiresAt(),
+  });
+
+  store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
+  mockUsbDrive.removeUsbDrive();
+
+  expect(
+    await getCurrentAppFlowState({
+      auth,
+      store,
+      usbDrive: mockUsbDrive.usbDrive,
+      precinctScannerState: 'no_paper',
+    })
+  ).toEqual(typedAs<AppFlowState>('insert_usb_drive'));
+});
+
+test('replace_ballot_bag', async () => {
+  const auth = buildMockInsertedSmartCardAuth();
+  const store = Store.memoryStore();
+  const mockUsbDrive = createMockUsbDrive();
+  const pollWorkerUser = fakePollWorkerUser({
+    electionHash:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+        .electionHash,
+  });
+
+  store.setElectionAndJurisdiction({
+    electionData:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+        .electionData,
+    jurisdiction: TEST_JURISDICTION,
+  });
+
+  auth.getAuthStatus.mockResolvedValue({
+    status: 'logged_in',
+    user: pollWorkerUser,
+    sessionExpiresAt: fakeSessionExpiresAt(),
+  });
+
+  store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
+  mockUsbDrive.insertUsbDrive({});
+  store.setBallotCountWhenBallotBagLastReplaced(0);
+  jest.spyOn(store, 'getBallotsCounted').mockReturnValue(BALLOT_BAG_CAPACITY);
+
+  expect(
+    await getCurrentAppFlowState({
+      auth,
+      store,
+      usbDrive: mockUsbDrive.usbDrive,
+      precinctScannerState: 'no_paper',
+    })
+  ).toEqual(typedAs<AppFlowState>('replace_ballot_bag'));
+});
+
+test('logged_in:poll_worker', async () => {
+  const auth = buildMockInsertedSmartCardAuth();
+  const store = Store.memoryStore();
+  const mockUsbDrive = createMockUsbDrive();
+  const pollWorkerUser = fakePollWorkerUser({
+    electionHash:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+        .electionHash,
+  });
+
+  store.setElectionAndJurisdiction({
+    electionData:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+        .electionData,
+    jurisdiction: TEST_JURISDICTION,
+  });
+
+  auth.getAuthStatus.mockResolvedValue({
+    status: 'logged_in',
+    user: pollWorkerUser,
+    sessionExpiresAt: fakeSessionExpiresAt(),
+  });
+
+  store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
+  mockUsbDrive.insertUsbDrive({});
+
+  expect(
+    await getCurrentAppFlowState({
+      auth,
+      store,
+      usbDrive: mockUsbDrive.usbDrive,
+      precinctScannerState: 'no_paper',
+    })
+  ).toEqual(typedAs<AppFlowState>('logged_in:poll_worker'));
+});
+
+test('polls_not_open', async () => {
+  const auth = buildMockInsertedSmartCardAuth();
+  const store = Store.memoryStore();
+  const mockUsbDrive = createMockUsbDrive();
+
+  store.setElectionAndJurisdiction({
+    electionData:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+        .electionData,
+    jurisdiction: TEST_JURISDICTION,
+  });
+
+  store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
+  mockUsbDrive.insertUsbDrive({});
+
+  expect(
+    await getCurrentAppFlowState({
+      auth,
+      store,
+      usbDrive: mockUsbDrive.usbDrive,
+      precinctScannerState: 'no_paper',
+    })
+  ).toEqual(typedAs<AppFlowState>('polls_not_open'));
+});
+
+test('cast_vote_record_sync_required', async () => {
+  const auth = buildMockInsertedSmartCardAuth();
+  const store = Store.memoryStore();
+  const mockUsbDrive = createMockUsbDrive();
+
+  store.setElectionAndJurisdiction({
+    electionData:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+        .electionData,
+    jurisdiction: TEST_JURISDICTION,
+  });
+
+  store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
+  mockUsbDrive.insertUsbDrive({});
+  store.transitionPolls({ type: 'open_polls', time: Date.now() });
+
+  doesUsbDriveRequireCastVoteRecordSyncMock.mockResolvedValue(true);
+
+  expect(
+    await getCurrentAppFlowState({
+      auth,
+      store,
+      usbDrive: mockUsbDrive.usbDrive,
+      precinctScannerState: 'no_paper',
+    })
+  ).toEqual(typedAs<AppFlowState>('cast_vote_record_sync_required'));
+});
+
+test('ballot:accepted', async () => {
+  const auth = buildMockInsertedSmartCardAuth();
+  const store = Store.memoryStore();
+  const mockUsbDrive = createMockUsbDrive();
+
+  store.setElectionAndJurisdiction({
+    electionData:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+        .electionData,
+    jurisdiction: TEST_JURISDICTION,
+  });
+
+  store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
+  mockUsbDrive.insertUsbDrive({});
+  store.transitionPolls({ type: 'open_polls', time: Date.now() });
+
+  doesUsbDriveRequireCastVoteRecordSyncMock.mockResolvedValue(false);
+
+  expect(
+    await getCurrentAppFlowState({
+      auth,
+      store,
+      usbDrive: mockUsbDrive.usbDrive,
+      precinctScannerState: 'accepted',
+    })
+  ).toEqual(typedAs<AppFlowState>('ballot:accepted'));
+});
+
+test('ballot:accepting (no review)', async () => {
+  const auth = buildMockInsertedSmartCardAuth();
+  const store = Store.memoryStore();
+  const mockUsbDrive = createMockUsbDrive();
+
+  store.setElectionAndJurisdiction({
+    electionData:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+        .electionData,
+    jurisdiction: TEST_JURISDICTION,
+  });
+
+  store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
+  mockUsbDrive.insertUsbDrive({});
+  store.transitionPolls({ type: 'open_polls', time: Date.now() });
+
+  doesUsbDriveRequireCastVoteRecordSyncMock.mockResolvedValue(false);
+
+  expect(
+    await getCurrentAppFlowState({
+      auth,
+      store,
+      usbDrive: mockUsbDrive.usbDrive,
+      precinctScannerState: 'accepting',
+    })
+  ).toEqual(typedAs<AppFlowState>('ballot:accepting'));
+});
+
+test('ballot:accepting (with review)', async () => {
+  const auth = buildMockInsertedSmartCardAuth();
+  const store = Store.memoryStore();
+  const mockUsbDrive = createMockUsbDrive();
+
+  store.setElectionAndJurisdiction({
+    electionData:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+        .electionData,
+    jurisdiction: TEST_JURISDICTION,
+  });
+
+  store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
+  mockUsbDrive.insertUsbDrive({});
+  store.transitionPolls({ type: 'open_polls', time: Date.now() });
+
+  doesUsbDriveRequireCastVoteRecordSyncMock.mockResolvedValue(false);
+
+  expect(
+    await getCurrentAppFlowState({
+      auth,
+      store,
+      usbDrive: mockUsbDrive.usbDrive,
+      precinctScannerState: 'accepting_after_review',
+    })
+  ).toEqual(typedAs<AppFlowState>('ballot:accepting'));
+});
+
+test('ballot:scanning', async () => {
+  const auth = buildMockInsertedSmartCardAuth();
+  const store = Store.memoryStore();
+  const mockUsbDrive = createMockUsbDrive();
+
+  store.setElectionAndJurisdiction({
+    electionData:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+        .electionData,
+    jurisdiction: TEST_JURISDICTION,
+  });
+
+  store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
+  mockUsbDrive.insertUsbDrive({});
+  store.transitionPolls({ type: 'open_polls', time: Date.now() });
+
+  doesUsbDriveRequireCastVoteRecordSyncMock.mockResolvedValue(false);
+
+  expect(
+    await getCurrentAppFlowState({
+      auth,
+      store,
+      usbDrive: mockUsbDrive.usbDrive,
+      precinctScannerState: 'scanning',
+    })
+  ).toEqual(typedAs<AppFlowState>('ballot:scanning'));
+});
+
+test('ballot:waiting_to_accept', async () => {
+  const auth = buildMockInsertedSmartCardAuth();
+  const store = Store.memoryStore();
+  const mockUsbDrive = createMockUsbDrive();
+
+  store.setElectionAndJurisdiction({
+    electionData:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+        .electionData,
+    jurisdiction: TEST_JURISDICTION,
+  });
+
+  store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
+  mockUsbDrive.insertUsbDrive({});
+  store.transitionPolls({ type: 'open_polls', time: Date.now() });
+
+  doesUsbDriveRequireCastVoteRecordSyncMock.mockResolvedValue(false);
+
+  expect(
+    await getCurrentAppFlowState({
+      auth,
+      store,
+      usbDrive: mockUsbDrive.usbDrive,
+      precinctScannerState: 'ready_to_accept',
+    })
+  ).toEqual(typedAs<AppFlowState>('ballot:waiting_to_accept'));
+});
+
+test('ballot:waiting_to_scan', async () => {
+  const auth = buildMockInsertedSmartCardAuth();
+  const store = Store.memoryStore();
+  const mockUsbDrive = createMockUsbDrive();
+
+  store.setElectionAndJurisdiction({
+    electionData:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+        .electionData,
+    jurisdiction: TEST_JURISDICTION,
+  });
+
+  store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
+  mockUsbDrive.insertUsbDrive({});
+  store.transitionPolls({ type: 'open_polls', time: Date.now() });
+
+  doesUsbDriveRequireCastVoteRecordSyncMock.mockResolvedValue(false);
+
+  expect(
+    await getCurrentAppFlowState({
+      auth,
+      store,
+      usbDrive: mockUsbDrive.usbDrive,
+      precinctScannerState: 'ready_to_scan',
+    })
+  ).toEqual(typedAs<AppFlowState>('ballot:waiting_to_scan'));
+});
+
+test.each([
+  'connecting',
+  'no_paper',
+  'returning_to_rescan',
+  'needs_review',
+  'returning',
+  'returned',
+  'rejecting',
+  'rejected',
+  'jammed',
+  'both_sides_have_paper',
+  'recovering_from_error',
+  'double_sheet_jammed',
+  'unrecoverable_error',
+] as PrecinctScannerState[])('unknown (%s)', async (precinctScannerState) => {
+  const auth = buildMockInsertedSmartCardAuth();
+  const store = Store.memoryStore();
+  const mockUsbDrive = createMockUsbDrive();
+
+  store.setElectionAndJurisdiction({
+    electionData:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+        .electionData,
+    jurisdiction: TEST_JURISDICTION,
+  });
+
+  store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
+  mockUsbDrive.insertUsbDrive({});
+  store.transitionPolls({ type: 'open_polls', time: Date.now() });
+
+  doesUsbDriveRequireCastVoteRecordSyncMock.mockResolvedValue(false);
+
+  expect(
+    await getCurrentAppFlowState({
+      auth,
+      store,
+      usbDrive: mockUsbDrive.usbDrive,
+      precinctScannerState,
+    })
+  ).toEqual(typedAs<AppFlowState>('unknown'));
+});

--- a/apps/scan/backend/src/app_flow.ts
+++ b/apps/scan/backend/src/app_flow.ts
@@ -1,6 +1,6 @@
 import { InsertedSmartCardAuthApi } from '@votingworks/auth';
 import { doesUsbDriveRequireCastVoteRecordSync } from '@votingworks/backend';
-import { assert } from '@votingworks/basics';
+import { assert, throwIllegalValue } from '@votingworks/basics';
 import { PrecinctScannerState } from '@votingworks/types';
 import { UsbDrive } from '@votingworks/usb-drive';
 import {
@@ -131,7 +131,25 @@ export async function getCurrentAppFlowState({
     case 'ready_to_accept':
       return 'ballot:waiting_to_accept';
 
-    default:
+    case 'ready_to_scan':
       return 'ballot:waiting_to_scan';
+
+    case 'connecting':
+    case 'no_paper':
+    case 'returning_to_rescan':
+    case 'needs_review':
+    case 'returning':
+    case 'returned':
+    case 'rejecting':
+    case 'rejected':
+    case 'jammed':
+    case 'both_sides_have_paper':
+    case 'recovering_from_error':
+    case 'double_sheet_jammed':
+    case 'unrecoverable_error':
+      return 'unknown';
+
+    default:
+      throwIllegalValue(precinctScannerState);
   }
 }

--- a/apps/scan/backend/src/app_flow.ts
+++ b/apps/scan/backend/src/app_flow.ts
@@ -1,7 +1,6 @@
 import { InsertedSmartCardAuthApi } from '@votingworks/auth';
 import { doesUsbDriveRequireCastVoteRecordSync } from '@votingworks/backend';
 import { assert } from '@votingworks/basics';
-import { PrecinctScannerState } from '@votingworks/types';
 import { UsbDrive } from '@votingworks/usb-drive';
 import {
   isElectionManagerAuth,
@@ -22,12 +21,10 @@ export async function isReadyToScan({
   auth,
   store,
   usbDrive,
-  precinctScannerState,
 }: {
   auth: InsertedSmartCardAuthApi;
   store: Store;
   usbDrive: UsbDrive;
-  precinctScannerState: PrecinctScannerState;
 }): Promise<boolean> {
   const authStatus = await auth.getAuthStatus(constructAuthMachineState(store));
   if (
@@ -69,10 +66,6 @@ export async function isReadyToScan({
     return false;
   }
 
-  if (precinctScannerState === 'disconnected') {
-    return false;
-  }
-
   if (authStatus.status === 'checking_pin') {
     return false;
   }
@@ -102,7 +95,7 @@ export async function isReadyToScan({
   const needsToReplaceBallotBag =
     ballotsCounted >=
     ballotCountWhenBallotBagLastReplaced + BALLOT_BAG_CAPACITY;
-  if (needsToReplaceBallotBag && precinctScannerState !== 'accepted') {
+  if (needsToReplaceBallotBag) {
     return false;
   }
 
@@ -122,5 +115,5 @@ export async function isReadyToScan({
     return false;
   }
 
-  return precinctScannerState === 'ready_to_scan';
+  return true;
 }

--- a/apps/scan/backend/src/app_flow.ts
+++ b/apps/scan/backend/src/app_flow.ts
@@ -1,0 +1,137 @@
+import { InsertedSmartCardAuthApi } from '@votingworks/auth';
+import { doesUsbDriveRequireCastVoteRecordSync } from '@votingworks/backend';
+import { assert } from '@votingworks/basics';
+import { PrecinctScannerState } from '@votingworks/types';
+import { UsbDrive } from '@votingworks/usb-drive';
+import {
+  isElectionManagerAuth,
+  isPollWorkerAuth,
+  isSystemAdministratorAuth,
+} from '@votingworks/utils';
+import { BALLOT_BAG_CAPACITY } from './globals';
+import { Store } from './store';
+import { constructAuthMachineState } from './util/construct_auth_machine_state';
+import { AppFlowState } from './types';
+
+export async function getCurrentAppFlowState({
+  auth,
+  store,
+  usbDrive,
+  precinctScannerState,
+}: {
+  auth: InsertedSmartCardAuthApi;
+  store: Store;
+  usbDrive: UsbDrive;
+  precinctScannerState: PrecinctScannerState;
+}): Promise<AppFlowState> {
+  const authStatus = await auth.getAuthStatus(constructAuthMachineState(store));
+  if (
+    authStatus.status === 'logged_out' &&
+    authStatus.reason === 'no_card_reader'
+  ) {
+    return 'setup_card_reader';
+  }
+
+  const electionDefinition = store.getElectionDefinition();
+
+  if (
+    !electionDefinition &&
+    authStatus.status === 'logged_out' &&
+    authStatus.reason === 'no_card'
+  ) {
+    return 'login_prompt';
+  }
+
+  if (
+    authStatus.status === 'logged_out' &&
+    authStatus.reason === 'card_error'
+  ) {
+    return 'card_error';
+  }
+
+  if (authStatus.status === 'logged_out' && authStatus.reason !== 'no_card') {
+    return 'invalid_card';
+  }
+
+  if (
+    authStatus.status === 'checking_pin' &&
+    authStatus.user.role === 'system_administrator'
+  ) {
+    return 'unlock_machine';
+  }
+
+  if (isSystemAdministratorAuth(authStatus)) {
+    return 'logged_in:system_administrator';
+  }
+
+  if (precinctScannerState === 'disconnected') {
+    return 'setup_scanner';
+  }
+
+  if (authStatus.status === 'checking_pin') {
+    return 'unlock_machine';
+  }
+
+  if (!electionDefinition) {
+    return 'unconfigured:election';
+  }
+
+  if (isElectionManagerAuth(authStatus)) {
+    return 'logged_in:election_manager';
+  }
+
+  const precinctSelection = store.getPrecinctSelection();
+
+  if (!precinctSelection) {
+    return 'unconfigured:precinct';
+  }
+
+  const usbDriveStatus = await usbDrive.status();
+  if (usbDriveStatus.status !== 'mounted') {
+    return 'insert_usb_drive';
+  }
+
+  const ballotCountWhenBallotBagLastReplaced =
+    store.getBallotCountWhenBallotBagLastReplaced();
+  const ballotsCounted = store.getBallotsCounted();
+  const needsToReplaceBallotBag =
+    ballotsCounted >=
+    ballotCountWhenBallotBagLastReplaced + BALLOT_BAG_CAPACITY;
+  if (needsToReplaceBallotBag && precinctScannerState !== 'accepted') {
+    return 'replace_ballot_bag';
+  }
+
+  if (isPollWorkerAuth(authStatus)) {
+    return 'logged_in:poll_worker';
+  }
+
+  // When no card is inserted, we're in "voter" mode
+  assert(authStatus.status === 'logged_out' && authStatus.reason === 'no_card');
+
+  const pollsState = store.getPollsState();
+  if (pollsState !== 'polls_open') {
+    return 'polls_not_open';
+  }
+
+  if (await doesUsbDriveRequireCastVoteRecordSync(store, usbDriveStatus)) {
+    return 'cast_vote_record_sync_required';
+  }
+
+  switch (precinctScannerState) {
+    case 'accepted':
+      return 'ballot:accepted';
+
+    case 'accepting':
+    case 'accepting_after_review':
+      return 'ballot:accepting';
+
+    case 'scanning':
+      return 'ballot:scanning';
+
+    case 'ready_to_accept':
+      return 'ballot:waiting_to_accept';
+
+    default:
+      return 'ballot:waiting_to_scan';
+  }
+}

--- a/apps/scan/backend/src/globals.ts
+++ b/apps/scan/backend/src/globals.ts
@@ -30,3 +30,5 @@ export const SCAN_WORKSPACE =
   (NODE_ENV === 'development'
     ? join(__dirname, '../dev-workspace')
     : undefined);
+
+export const BALLOT_BAG_CAPACITY = 7000;

--- a/apps/scan/backend/src/index.ts
+++ b/apps/scan/backend/src/index.ts
@@ -80,6 +80,7 @@ async function main(): Promise<number> {
   const precinctScannerStateMachine =
     customStateMachine.createPrecinctScannerStateMachine({
       createCustomClient: customScanner.openScanner,
+      auth,
       workspace,
       logger,
       usbDrive,

--- a/apps/scan/backend/src/scanners/custom/app_scan.test.ts
+++ b/apps/scan/backend/src/scanners/custom/app_scan.test.ts
@@ -545,7 +545,7 @@ test('scanning paused when election manager card is inserted', async () => {
 
       // we don't scan because the election manager card is inserted
       await waitForStatus(apiClient, {
-        state: 'ready_to_scan',
+        state: 'hardware_ready_to_scan',
       });
 
       // remove the card
@@ -590,7 +590,7 @@ test('scanning paused when poll worker card is inserted', async () => {
 
       // we don't scan because the poll worker card is inserted
       await waitForStatus(apiClient, {
-        state: 'ready_to_scan',
+        state: 'hardware_ready_to_scan',
       });
 
       // remove the card
@@ -632,7 +632,7 @@ test('scanning paused when ballot bag needs replacement', async () => {
 
       // we don't scan because the ballot bag needs replacement
       await waitForStatus(apiClient, {
-        state: 'ready_to_scan',
+        state: 'hardware_ready_to_scan',
         ballotsCounted: BALLOT_BAG_CAPACITY,
       });
 

--- a/apps/scan/backend/src/scanners/custom/app_scan_power_off.test.ts
+++ b/apps/scan/backend/src/scanners/custom/app_scan_power_off.test.ts
@@ -63,11 +63,7 @@ test('scanner powered off while scanning', async () => {
     async ({ apiClient, mockScanner, mockUsbDrive, mockAuth }) => {
       await configureApp(apiClient, mockAuth, mockUsbDrive, { testMode: true });
 
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
-      await waitForStatus(apiClient, { state: 'ready_to_scan' });
-
       simulateScan(mockScanner, await ballotImages.completeBmd());
-      await apiClient.scanBallot();
       mockScanner.getStatus.mockResolvedValue(err(ErrorCode.ScannerOffline));
       await waitForStatus(apiClient, { state: 'disconnected' });
 
@@ -86,11 +82,7 @@ test('scanner powered off while accepting', async () => {
     async ({ apiClient, mockScanner, mockUsbDrive, mockAuth }) => {
       await configureApp(apiClient, mockAuth, mockUsbDrive, { testMode: true });
 
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
-      await waitForStatus(apiClient, { state: 'ready_to_scan' });
-
       simulateScan(mockScanner, await ballotImages.completeBmd());
-      await apiClient.scanBallot();
       await waitForStatus(apiClient, {
         state: 'ready_to_accept',
         interpretation,
@@ -122,11 +114,7 @@ test('scanner powered off after accepting', async () => {
     async ({ apiClient, mockScanner, mockUsbDrive, mockAuth }) => {
       await configureApp(apiClient, mockAuth, mockUsbDrive, { testMode: true });
 
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
-      await waitForStatus(apiClient, { state: 'ready_to_scan' });
-
       simulateScan(mockScanner, await ballotImages.completeBmd());
-      await apiClient.scanBallot();
       await waitForStatus(apiClient, {
         state: 'ready_to_accept',
         interpretation,
@@ -168,11 +156,7 @@ test('scanner powered off while rejecting', async () => {
     async ({ apiClient, mockScanner, mockUsbDrive, mockAuth }) => {
       await configureApp(apiClient, mockAuth, mockUsbDrive);
 
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
-      await waitForStatus(apiClient, { state: 'ready_to_scan' });
-
       simulateScan(mockScanner, await ballotImages.wrongElection());
-      await apiClient.scanBallot();
       await waitForStatus(apiClient, {
         state: 'rejecting',
         interpretation,
@@ -202,11 +186,7 @@ test('scanner powered off while returning', async () => {
           ),
       });
 
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
-      await waitForStatus(apiClient, { state: 'ready_to_scan' });
-
       simulateScan(mockScanner, await ballotImages.unmarkedHmpb());
-      await apiClient.scanBallot();
       await waitForStatus(apiClient, { state: 'needs_review', interpretation });
 
       await apiClient.returnBallot();
@@ -239,11 +219,7 @@ test('scanner powered off after returning', async () => {
           ),
       });
 
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
-      await waitForStatus(apiClient, { state: 'ready_to_scan' });
-
       simulateScan(mockScanner, await ballotImages.unmarkedHmpb());
-      await apiClient.scanBallot();
       await waitForStatus(apiClient, { state: 'needs_review', interpretation });
 
       await apiClient.returnBallot();

--- a/apps/scan/backend/src/scanners/custom/app_scan_precinct_config.test.ts
+++ b/apps/scan/backend/src/scanners/custom/app_scan_precinct_config.test.ts
@@ -43,16 +43,13 @@ test('bmd ballot is rejected when scanned for wrong precinct', async () => {
         testMode: true,
       });
 
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
-      await waitForStatus(apiClient, { state: 'ready_to_scan' });
-
       const interpretation: SheetInterpretation = {
         type: 'InvalidSheet',
         reason: 'invalid_precinct',
       };
 
       simulateScan(mockScanner, await ballotImages.completeBmd());
-      await apiClient.scanBallot();
+
       await waitForStatus(apiClient, {
         state: 'rejecting',
         interpretation,
@@ -83,11 +80,8 @@ test('bmd ballot is accepted if precinct is set for the right precinct', async (
         type: 'ValidSheet',
       };
 
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
-      await waitForStatus(apiClient, { state: 'ready_to_scan' });
-
       simulateScan(mockScanner, await ballotImages.completeBmd());
-      await apiClient.scanBallot();
+
       await waitForStatus(apiClient, {
         state: 'ready_to_accept',
         interpretation: validInterpretation,
@@ -107,16 +101,13 @@ test('hmpb ballot is rejected when scanned for wrong precinct', async () => {
         precinctId: '22',
       });
 
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
-      await waitForStatus(apiClient, { state: 'ready_to_scan' });
-
       const interpretation: SheetInterpretation = {
         type: 'InvalidSheet',
         reason: 'invalid_precinct',
       };
 
       simulateScan(mockScanner, await ballotImages.completeHmpb());
-      await apiClient.scanBallot();
+
       await waitForStatus(apiClient, {
         state: 'rejecting',
         interpretation,
@@ -148,11 +139,8 @@ test('hmpb ballot is accepted if precinct is set for the right precinct', async 
         type: 'ValidSheet',
       };
 
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
-      await waitForStatus(apiClient, { state: 'ready_to_scan' });
-
       simulateScan(mockScanner, await ballotImages.completeHmpb());
-      await apiClient.scanBallot();
+
       await waitForStatus(apiClient, {
         state: 'ready_to_accept',
         interpretation: validInterpretation,

--- a/apps/scan/backend/src/scanners/custom/state_machine.ts
+++ b/apps/scan/backend/src/scanners/custom/state_machine.ts
@@ -814,7 +814,7 @@ function buildMachine({
               target: 'returning_to_rescan',
             },
             // We can automatically start scanning the next ballot
-            SCANNER_READY_TO_SCAN: 'ready_to_scan',
+            SCANNER_READY_TO_SCAN: 'hardware_ready_to_scan',
           },
         },
         no_paper: {
@@ -823,21 +823,21 @@ function buildMachine({
           invoke: pollPaperStatus(),
           on: {
             SCANNER_NO_PAPER: doNothing,
-            SCANNER_READY_TO_SCAN: 'ready_to_scan',
+            SCANNER_READY_TO_SCAN: 'hardware_ready_to_scan',
             SCANNER_BOTH_SIDES_HAVE_PAPER: 'jam',
           },
         },
-        ready_to_scan: {
-          id: 'ready_to_scan',
+        hardware_ready_to_scan: {
+          id: 'hardware_ready_to_scan',
           entry: [clearError, clearLastScan],
           invoke: pollPaperStatus(),
           on: {
             SCAN: 'scanning',
             SCANNER_NO_PAPER: 'no_paper',
-            SCANNER_READY_TO_SCAN: 'check_ready_to_scan',
+            SCANNER_READY_TO_SCAN: 'check_app_ready_to_scan',
           },
         },
-        check_ready_to_scan: {
+        check_app_ready_to_scan: {
           invoke: {
             src: async () => isReadyToScan({ auth, store, usbDrive }),
             onDone: [
@@ -846,7 +846,7 @@ function buildMachine({
                 cond: (_context, event) => event.data,
               },
               {
-                target: 'ready_to_scan',
+                target: 'hardware_ready_to_scan',
               },
             ],
           },
@@ -1103,7 +1103,7 @@ function buildMachine({
                 SCANNER_NO_PAPER: '#no_paper',
                 SCANNER_BOTH_SIDES_HAVE_PAPER: doNothing,
                 SCANNER_JAM: doNothing,
-                SCANNER_READY_TO_SCAN: '#ready_to_scan',
+                SCANNER_READY_TO_SCAN: '#hardware_ready_to_scan',
               },
               after: {
                 DELAY_WAIT_FOR_JAM_CLEARED: '#internal_jam',
@@ -1333,8 +1333,8 @@ export function createPrecinctScannerStateMachine({
             return 'disconnected';
           case state.matches('no_paper'):
             return 'no_paper';
-          case state.matches('ready_to_scan'):
-            return 'ready_to_scan';
+          case state.matches('hardware_ready_to_scan'):
+            return 'hardware_ready_to_scan';
           case state.matches('scanning'):
             return 'scanning';
           case state.matches('interpreting'):

--- a/apps/scan/backend/src/scanners/custom/state_machine.ts
+++ b/apps/scan/backend/src/scanners/custom/state_machine.ts
@@ -54,7 +54,7 @@ import {
 } from '../../types';
 import { rootDebug } from '../../util/debug';
 import { Workspace } from '../../util/workspace';
-import { getCurrentAppFlowState } from '../../app_flow';
+import { isReadyToScan } from '../../app_flow';
 
 const debug = rootDebug.extend('state-machine');
 const debugPaperStatus = debug.extend('paper-status');
@@ -530,7 +530,7 @@ function buildMachine({
       )(context).pipe(
         switchMap(async (event) => {
           if (event.type === 'SCANNER_READY_TO_SCAN') {
-            const flowState = await getCurrentAppFlowState({
+            const readyToScan = await isReadyToScan({
               auth,
               store: workspace.store,
               usbDrive,
@@ -539,7 +539,7 @@ function buildMachine({
               // scan.
               precinctScannerState: 'ready_to_scan',
             });
-            if (flowState === 'ballot:waiting_to_scan') {
+            if (readyToScan) {
               return { type: 'SCAN' };
             }
           }

--- a/apps/scan/backend/src/types.ts
+++ b/apps/scan/backend/src/types.ts
@@ -9,29 +9,6 @@ import {
 } from '@votingworks/types';
 import { PrecinctScannerState } from '@votingworks/types/src/precinct_scanner';
 
-export type AppFlowState =
-  | 'ballot:accepted'
-  | 'ballot:accepting'
-  | 'ballot:scanning'
-  | 'ballot:waiting_to_accept'
-  | 'ballot:waiting_to_scan'
-  | 'card_error'
-  | 'cast_vote_record_sync_required'
-  | 'insert_usb_drive'
-  | 'invalid_card'
-  | 'login_prompt'
-  | 'logged_in:election_manager'
-  | 'logged_in:poll_worker'
-  | 'logged_in:system_administrator'
-  | 'polls_not_open'
-  | 'replace_ballot_bag'
-  | 'setup_card_reader'
-  | 'setup_scanner'
-  | 'unconfigured:election'
-  | 'unconfigured:precinct'
-  | 'unknown'
-  | 'unlock_machine';
-
 export interface MachineConfig {
   machineId: string;
   codeVersion: string;

--- a/apps/scan/backend/src/types.ts
+++ b/apps/scan/backend/src/types.ts
@@ -9,6 +9,29 @@ import {
 } from '@votingworks/types';
 import { PrecinctScannerState } from '@votingworks/types/src/precinct_scanner';
 
+export type AppFlowState =
+  | 'ballot:accepted'
+  | 'ballot:accepting'
+  | 'ballot:scanning'
+  | 'ballot:waiting_to_accept'
+  | 'ballot:waiting_to_scan'
+  | 'card_error'
+  | 'cast_vote_record_sync_required'
+  | 'insert_usb_drive'
+  | 'invalid_card'
+  | 'login_prompt'
+  | 'logged_in:election_manager'
+  | 'logged_in:poll_worker'
+  | 'logged_in:system_administrator'
+  | 'polls_not_open'
+  | 'replace_ballot_bag'
+  | 'setup_card_reader'
+  | 'setup_scanner'
+  | 'unconfigured:election'
+  | 'unconfigured:precinct'
+  | 'unknown'
+  | 'unlock_machine';
+
 export interface MachineConfig {
   machineId: string;
   codeVersion: string;
@@ -66,7 +89,6 @@ export interface PrecinctScannerStateMachine {
   // The commands are non-blocking and do not return a result. They just send an
   // event to the machine. The effects of the event (or any error) will show up
   // in the status.
-  scan: () => void;
   accept: () => void;
   return: () => void;
 

--- a/apps/scan/backend/src/util/construct_auth_machine_state.ts
+++ b/apps/scan/backend/src/util/construct_auth_machine_state.ts
@@ -1,0 +1,16 @@
+import { InsertedSmartCardAuthMachineState } from '@votingworks/auth';
+import { DEFAULT_SYSTEM_SETTINGS } from '@votingworks/types';
+import { Store } from '../store';
+
+export function constructAuthMachineState(
+  store: Store
+): InsertedSmartCardAuthMachineState {
+  const electionDefinition = store.getElectionDefinition();
+  const jurisdiction = store.getJurisdiction();
+  const systemSettings = store.getSystemSettings() ?? DEFAULT_SYSTEM_SETTINGS;
+  return {
+    ...systemSettings.auth,
+    electionHash: electionDefinition?.electionHash,
+    jurisdiction,
+  };
+}

--- a/apps/scan/backend/test/helpers/shared_helpers.ts
+++ b/apps/scan/backend/test/helpers/shared_helpers.ts
@@ -96,6 +96,13 @@ export async function configureApp(
     type: 'open_polls',
     time: Date.now(),
   });
+
+  mockOf(mockAuth.getAuthStatus).mockImplementation(() =>
+    Promise.resolve({
+      status: 'logged_out',
+      reason: 'no_card',
+    })
+  );
 }
 
 /**

--- a/apps/scan/frontend/src/api.ts
+++ b/apps/scan/frontend/src/api.ts
@@ -309,13 +309,6 @@ export const getScannerStatus = {
   },
 } as const;
 
-export const scanBallot = {
-  useMutation() {
-    const apiClient = useApiClient();
-    return useMutation(apiClient.scanBallot);
-  },
-} as const;
-
 export const acceptBallot = {
   useMutation() {
     const apiClient = useApiClient();

--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -378,7 +378,6 @@ const statusBallotCounted = scannerStatus({
 
 async function scanBallot() {
   apiMock.expectGetScannerStatus(scannerStatus({ state: 'ready_to_scan' }));
-  apiMock.mockApiClient.scanBallot.expectCallWith().resolves();
   jest.advanceTimersByTime(POLLING_INTERVAL_FOR_SCANNER_STATUS_MS);
   await screen.findByText(/Please wait/);
 
@@ -524,7 +523,6 @@ test('voter can cast a ballot that needs review and adjudicate as desired', asyn
     reasons: [{ type: AdjudicationReason.BlankBallot }],
   };
   apiMock.expectGetScannerStatus(scannerStatus({ state: 'ready_to_scan' }));
-  apiMock.mockApiClient.scanBallot.expectCallWith().resolves();
   jest.advanceTimersByTime(POLLING_INTERVAL_FOR_SCANNER_STATUS_MS);
   await screen.findByText(/Please wait/);
 
@@ -567,7 +565,6 @@ test('voter tries to cast ballot that is rejected', async () => {
   await screen.findByText(/Insert Your Ballot/i);
 
   apiMock.expectGetScannerStatus(scannerStatus({ state: 'ready_to_scan' }));
-  apiMock.mockApiClient.scanBallot.expectCallWith().resolves();
   jest.advanceTimersByTime(POLLING_INTERVAL_FOR_SCANNER_STATUS_MS);
   await screen.findByText(/Please wait/);
 
@@ -604,7 +601,6 @@ test('voter can cast another ballot while the success screen is showing', async 
   expect(screen.getByTestId('ballot-count').textContent).toEqual('1');
 
   apiMock.expectGetScannerStatus(scannerStatus({ state: 'ready_to_scan' }));
-  apiMock.mockApiClient.scanBallot.expectCallWith().resolves();
   jest.advanceTimersByTime(POLLING_INTERVAL_FOR_SCANNER_STATUS_MS);
   await screen.findByText(/Please wait/);
 
@@ -640,7 +636,6 @@ test('scanning is not triggered when polls closed or cards present', async () =>
   await screen.findByText('Polls are open.');
 
   // Once we remove the poll worker card, scanning should start
-  apiMock.mockApiClient.scanBallot.expectCallWith().resolves();
   apiMock.expectGetScannerStatus(scannerStatus({ state: 'ready_to_scan' }));
   apiMock.removeCard();
   jest.advanceTimersByTime(POLLING_INTERVAL_FOR_SCANNER_STATUS_MS);

--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -377,7 +377,9 @@ const statusBallotCounted = scannerStatus({
 });
 
 async function scanBallot() {
-  apiMock.expectGetScannerStatus(scannerStatus({ state: 'ready_to_scan' }));
+  apiMock.expectGetScannerStatus(
+    scannerStatus({ state: 'hardware_ready_to_scan' })
+  );
   jest.advanceTimersByTime(POLLING_INTERVAL_FOR_SCANNER_STATUS_MS);
   await screen.findByText(/Please wait/);
 
@@ -522,7 +524,9 @@ test('voter can cast a ballot that needs review and adjudicate as desired', asyn
     type: 'NeedsReviewSheet',
     reasons: [{ type: AdjudicationReason.BlankBallot }],
   };
-  apiMock.expectGetScannerStatus(scannerStatus({ state: 'ready_to_scan' }));
+  apiMock.expectGetScannerStatus(
+    scannerStatus({ state: 'hardware_ready_to_scan' })
+  );
   jest.advanceTimersByTime(POLLING_INTERVAL_FOR_SCANNER_STATUS_MS);
   await screen.findByText(/Please wait/);
 
@@ -564,7 +568,9 @@ test('voter tries to cast ballot that is rejected', async () => {
   renderApp();
   await screen.findByText(/Insert Your Ballot/i);
 
-  apiMock.expectGetScannerStatus(scannerStatus({ state: 'ready_to_scan' }));
+  apiMock.expectGetScannerStatus(
+    scannerStatus({ state: 'hardware_ready_to_scan' })
+  );
   jest.advanceTimersByTime(POLLING_INTERVAL_FOR_SCANNER_STATUS_MS);
   await screen.findByText(/Please wait/);
 
@@ -600,7 +606,9 @@ test('voter can cast another ballot while the success screen is showing', async 
   await screen.findByText('Your ballot was counted!');
   expect(screen.getByTestId('ballot-count').textContent).toEqual('1');
 
-  apiMock.expectGetScannerStatus(scannerStatus({ state: 'ready_to_scan' }));
+  apiMock.expectGetScannerStatus(
+    scannerStatus({ state: 'hardware_ready_to_scan' })
+  );
   jest.advanceTimersByTime(POLLING_INTERVAL_FOR_SCANNER_STATUS_MS);
   await screen.findByText(/Please wait/);
 
@@ -622,7 +630,9 @@ test('scanning is not triggered when polls closed or cards present', async () =>
   apiMock.expectGetConfig();
   apiMock.expectGetPollsInfo('polls_closed_initial');
   apiMock.expectGetUsbDriveStatus('mounted');
-  apiMock.expectGetScannerStatus(scannerStatus({ state: 'ready_to_scan' }));
+  apiMock.expectGetScannerStatus(
+    scannerStatus({ state: 'hardware_ready_to_scan' })
+  );
   renderApp();
   await screen.findByText('Polls Closed');
   apiMock.expectGetScannerResultsByParty([]);
@@ -636,7 +646,9 @@ test('scanning is not triggered when polls closed or cards present', async () =>
   await screen.findByText('Polls are open.');
 
   // Once we remove the poll worker card, scanning should start
-  apiMock.expectGetScannerStatus(scannerStatus({ state: 'ready_to_scan' }));
+  apiMock.expectGetScannerStatus(
+    scannerStatus({ state: 'hardware_ready_to_scan' })
+  );
   apiMock.removeCard();
   jest.advanceTimersByTime(POLLING_INTERVAL_FOR_SCANNER_STATUS_MS);
   await screen.findByText(/Please wait/);

--- a/apps/scan/frontend/src/screens/voter_screen.tsx
+++ b/apps/scan/frontend/src/screens/voter_screen.tsx
@@ -77,7 +77,7 @@ export function VoterScreen({
         case 'connecting':
         case 'disconnected':
         case 'no_paper':
-        case 'ready_to_scan':
+        case 'hardware_ready_to_scan':
         case 'scanning':
         case 'returning_to_rescan':
         case 'ready_to_accept':
@@ -116,7 +116,7 @@ export function VoterScreen({
           showNoChargerWarning={!batteryIsCharging}
         />
       );
-    case 'ready_to_scan':
+    case 'hardware_ready_to_scan':
     case 'scanning':
     case 'ready_to_accept':
     case 'accepting':

--- a/apps/scan/frontend/src/screens/voter_screen.tsx
+++ b/apps/scan/frontend/src/screens/voter_screen.tsx
@@ -1,7 +1,7 @@
 import { ElectionDefinition, SystemSettings } from '@votingworks/types';
 import { useQueryChangeListener } from '@votingworks/ui';
 import { assert, throwIllegalValue } from '@votingworks/basics';
-import { acceptBallot, getScannerStatus, scanBallot } from '../api';
+import { acceptBallot, getScannerStatus } from '../api';
 import { POLLING_INTERVAL_FOR_SCANNER_STATUS_MS } from '../config/globals';
 import { useSound } from '../utils/use_sound';
 import { InsertBallotScreen } from './insert_ballot_screen';
@@ -33,16 +33,12 @@ export function VoterScreen({
     refetchInterval: POLLING_INTERVAL_FOR_SCANNER_STATUS_MS,
   });
 
-  // The scan service waits to receive a command to scan or accept a ballot. The
-  // frontend controls when this happens so that ensure we're only scanning when
-  // we're in voter mode.
-  const scanBallotMutation = scanBallot.useMutation();
+  // The backend waits to receive a command accept a ballot. The frontend
+  // controls when this happens for now. In the future, we should move this to
+  // the backend.
   const acceptBallotMutation = acceptBallot.useMutation();
   useQueryChangeListener(scannerStatusQuery, {
     onChange: (newScannerStatus) => {
-      if (newScannerStatus.state === 'ready_to_scan') {
-        scanBallotMutation.mutate();
-      }
       if (newScannerStatus.state === 'ready_to_accept') {
         acceptBallotMutation.mutate();
       }

--- a/libs/types/src/precinct_scanner.ts
+++ b/libs/types/src/precinct_scanner.ts
@@ -2,7 +2,7 @@ export const PRECINCT_SCANNER_STATES = [
   'connecting',
   'disconnected',
   'no_paper',
-  'ready_to_scan',
+  'hardware_ready_to_scan',
   'scanning',
   'returning_to_rescan',
   'ready_to_accept',


### PR DESCRIPTION
## Overview
This change copies the logic from the frontend that controlled whether to trigger a scan into the backend. Most of that logic was in deciding which screen to render, with the last part on the `VoterScreen` itself. In the future it might make sense to render the screen based on the new backend status I'm calling "app flow state", but I wanted to make minimal changes to the frontend as part of this change.

## Demo Video or Screenshot

Note in this video that we never call the `scanBallot` endpoint (which no longer exists):

https://github.com/votingworks/vxsuite/assets/1938/e1615fe5-8162-41a4-a440-d03accb3c74c

## Testing Plan
- [x] Updated a bunch of existing backend tests.
- [x] Manual testing with the NH "Test Ballot" election.
- [x] Added some automated tests around "app flow state" and not triggering scans when we shouldn't (i.e. someone is logged in).
