### PR TITLE
VxDesign: Fix bugs in contests form

### DIFF
--- a/apps/design/frontend/jest.config.js
+++ b/apps/design/frontend/jest.config.js
@@ -5,13 +5,15 @@ const shared = require('../../../jest.config.shared');
  */
 module.exports = {
   ...shared,
+  collectCoverageFrom: [
+    'src/**/*.{js,jsx,ts,tsx}',
+    '!src/**/*.d.ts',
+    '!src/index.tsx',
+  ],
   coverageThreshold: {
-    /* Experimental package, don't enforce coverage yet */
     global: {
-      statements: 0,
-      branches: 0,
-      functions: 0,
-      lines: 0,
+      branches: -152,
+      lines: -344,
     },
   },
   setupFiles: ['react-app-polyfill/jsdom'],

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -33,6 +33,9 @@ export function createQueryClient(): QueryClient {
     defaultOptions: {
       queries: {
         refetchOnWindowFocus: false,
+        // In test, we only want to refetch when we explicitly invalidate. In
+        // dev/prod, it's fine to refetch more aggressively.
+        refetchOnMount: process.env.NODE_ENV !== 'test',
       },
     },
   });

--- a/apps/design/frontend/src/ballots_screen.test.tsx
+++ b/apps/design/frontend/src/ballots_screen.test.tsx
@@ -125,9 +125,6 @@ test('Ballot layout tab', async () => {
   renderScreen();
   await screen.findByRole('heading', { name: 'Ballots' });
 
-  apiMock.getElection
-    .expectCallWith({ electionId })
-    .resolves(generalElectionRecord);
   userEvent.click(screen.getByRole('tab', { name: 'Ballot Layout' }));
 
   const paperSizeRadioGroup = screen.getByRole('radiogroup', {

--- a/apps/design/frontend/src/contests_screen.test.tsx
+++ b/apps/design/frontend/src/contests_screen.test.tsx
@@ -1,0 +1,580 @@
+import { createMemoryHistory } from 'history';
+import userEvent from '@testing-library/user-event';
+import type { ElectionRecord } from '@votingworks/design-backend';
+import { CandidateContest, YesNoContest } from '@votingworks/types';
+import { assert } from '@votingworks/basics';
+import {
+  MockApiClient,
+  createMockApiClient,
+  provideApi,
+} from '../test/api_helpers';
+import {
+  electionId,
+  generalElectionRecord,
+  primaryElectionRecord,
+} from '../test/fixtures';
+import { render, screen, waitFor, within } from '../test/react_testing_library';
+import { withRoute } from '../test/routing_helpers';
+import { ContestsScreen } from './contests_screen';
+import { routes } from './routes';
+
+let apiMock: MockApiClient;
+
+beforeEach(() => {
+  apiMock = createMockApiClient();
+});
+
+afterEach(() => {
+  apiMock.assertComplete();
+});
+
+function renderScreen() {
+  const { path } = routes.election(electionId).contests.root;
+  const history = createMemoryHistory({ initialEntries: [path] });
+  render(
+    provideApi(
+      apiMock,
+      withRoute(<ContestsScreen />, {
+        paramPath: routes.election(':electionId').contests.root.path,
+        path,
+      })
+    )
+  );
+  return history;
+}
+
+const electionWithNoContestsRecord: ElectionRecord = {
+  ...generalElectionRecord,
+  election: {
+    ...generalElectionRecord.election,
+    contests: [],
+  },
+};
+
+describe('Contests tab', () => {
+  test('adding a candidate contest (general election)', async () => {
+    const { election } = electionWithNoContestsRecord;
+    const newContest: CandidateContest = {
+      id: 'new-contest-id',
+      type: 'candidate',
+      title: 'New Contest',
+      districtId: election.districts[0].id,
+      seats: 2,
+      termDescription: '2 years',
+      allowWriteIns: false,
+      candidates: [
+        {
+          id: 'new-candidate-id-1',
+          name: 'New Candidate 1',
+          partyIds: [election.parties[0].id],
+        },
+        {
+          id: 'new-candidate-id-2',
+          name: 'New Candidate 2',
+          partyIds: [election.parties[1].id],
+        },
+        {
+          id: 'new-candidate-id-3',
+          name: 'New Candidate 3',
+        },
+      ],
+    };
+
+    apiMock.getElection
+      .expectCallWith({ electionId })
+      .resolves(electionWithNoContestsRecord);
+    renderScreen();
+
+    await screen.findByRole('heading', { name: 'Contests' });
+    screen.getByRole('tab', { name: 'Contests', selected: true });
+    screen.getByText("You haven't added any contests to this election yet.");
+
+    // Add contest
+    userEvent.click(screen.getByRole('button', { name: 'Add Contest' }));
+    await screen.findByRole('heading', { name: 'Add Contest' });
+
+    // Set title
+    userEvent.type(screen.getByLabelText('Title'), newContest.title);
+
+    // Set ID
+    const idInput = screen.getByLabelText('ID');
+    expect(idInput).toHaveValue('contest-1');
+    userEvent.clear(idInput);
+    userEvent.type(idInput, newContest.id);
+
+    // Set district
+    userEvent.click(screen.getByLabelText('District'));
+    userEvent.click(screen.getByText(election.districts[0].name));
+
+    // Default type is candidate contest
+    within(screen.getByLabelText('Type')).getByRole('option', {
+      name: 'Candidate Contest',
+      selected: true,
+    });
+
+    // Set seats
+    const seatsInput = screen.getByLabelText('Seats');
+    expect(seatsInput).toHaveValue(1);
+    userEvent.clear(seatsInput);
+    userEvent.type(seatsInput, '2');
+
+    // Set term
+    userEvent.type(screen.getByLabelText('Term'), newContest.termDescription!);
+
+    // Set write-ins allowed
+    const writeInsControl = screen.getByLabelText('Write-Ins Allowed?');
+    within(writeInsControl).getByRole('option', {
+      name: 'Yes',
+      selected: true,
+    });
+    userEvent.click(
+      within(writeInsControl).getByRole('option', { name: 'No' })
+    );
+
+    // Add candidates
+    screen.getByText("You haven't added any candidates to this contest yet.");
+    for (const [i, candidate] of newContest.candidates.entries()) {
+      userEvent.click(screen.getByRole('button', { name: 'Add Candidate' }));
+      screen.getByRole('columnheader', { name: 'Name' });
+      screen.getByRole('columnheader', { name: 'ID' });
+      screen.getByRole('columnheader', { name: 'Party' });
+      const row = screen.getAllByRole('row')[i + 1];
+
+      // Set name
+      userEvent.type(
+        within(row).getByLabelText(`Candidate ${i + 1} Name`),
+        candidate.name
+      );
+
+      // Set ID
+      const candidateIdInput = within(row).getByLabelText(
+        `Candidate ${i + 1} ID`
+      );
+      // Default ID will always end in 1 since we're changing the ID for each
+      // candidate as we go
+      expect(candidateIdInput).toHaveValue(`${newContest.id}-candidate-1`);
+      userEvent.clear(candidateIdInput);
+      userEvent.type(candidateIdInput, candidate.id);
+
+      // Set party
+      const partySelect = within(row).getByLabelText(
+        `Candidate ${i + 1} Party`
+      );
+      expect(partySelect).toHaveValue('');
+      userEvent.click(partySelect);
+      const party = election.parties.find(
+        (p) => p.id === candidate.partyIds?.[0]
+      );
+      if (party) {
+        userEvent.click(within(row).getByText(party.name));
+      }
+    }
+
+    // Save contest
+    const electionWithNewContestRecord: ElectionRecord = {
+      ...electionWithNoContestsRecord,
+      election: {
+        ...election,
+        contests: [newContest],
+      },
+    };
+    apiMock.updateElection
+      .expectCallWith({
+        electionId,
+        election: electionWithNewContestRecord.election,
+      })
+      .resolves();
+    apiMock.getElection
+      .expectCallWith({ electionId })
+      .resolves(electionWithNewContestRecord);
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+    userEvent.click(saveButton);
+
+    await screen.findByRole('heading', { name: 'Contests' });
+    screen.getByRole('tab', { name: 'Contests', selected: true });
+    screen.getByRole('columnheader', { name: 'Title' });
+    screen.getByRole('columnheader', { name: 'ID' });
+    screen.getByRole('columnheader', { name: 'District' });
+    const rows = screen.getAllByRole('row');
+    expect(screen.getAllByRole('row')).toHaveLength(2);
+    expect(
+      within(rows[1])
+        .getAllByRole('cell')
+        .map((cell) => cell.textContent)
+    ).toEqual([
+      newContest.title,
+      newContest.id,
+      election.districts[0].name,
+      'Edit',
+    ]);
+  });
+
+  test('editing a candidate contest (primary election)', async () => {
+    const { election } = primaryElectionRecord;
+    const savedContest = election.contests.find(
+      (contest): contest is CandidateContest => contest.type === 'candidate'
+    )!;
+    const savedDistrict = election.districts.find(
+      (district) => district.id === savedContest.districtId
+    )!;
+    const savedParty = election.parties.find(
+      (party) => party.id === savedContest.partyId
+    )!;
+    const changedDistrict = election.districts.find(
+      (district) => district.id !== savedContest.districtId
+    )!;
+    const changedParty = election.parties.find(
+      (party) => party.id !== savedContest.partyId
+    )!;
+
+    assert(savedContest.candidates.length > 2);
+    const changedContest: CandidateContest = {
+      ...savedContest,
+      title: 'Changed Contest Title',
+      id: 'changed-contest-id',
+      districtId: changedDistrict.id,
+      partyId: changedParty.id,
+      seats: savedContest.seats + 1,
+      allowWriteIns: !savedContest.allowWriteIns,
+      termDescription: 'Changed Term Description',
+      candidates: [
+        {
+          ...savedContest.candidates[1],
+          name: 'Changed Candidate Name',
+          id: 'changed-candidate-id',
+          partyIds: undefined,
+        },
+        ...savedContest.candidates.slice(2),
+      ],
+    };
+
+    apiMock.getElection
+      .expectCallWith({ electionId })
+      .resolves(primaryElectionRecord);
+    renderScreen();
+
+    await screen.findByRole('heading', { name: 'Contests' });
+    screen.getByRole('tab', { name: 'Contests', selected: true });
+    screen.getByRole('columnheader', { name: 'Title' });
+    screen.getByRole('columnheader', { name: 'ID' });
+    screen.getByRole('columnheader', { name: 'District' });
+    screen.getByRole('columnheader', { name: 'Party' });
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(election.contests.length + 1);
+
+    const savedContestRow = screen.getByText(savedContest.title).closest('tr')!;
+    within(savedContestRow).getByText(savedContest.id);
+    within(savedContestRow).getByText(savedDistrict.name);
+    within(savedContestRow).getByText(savedParty.name);
+    userEvent.click(
+      within(savedContestRow).getByRole('button', { name: 'Edit' })
+    );
+
+    await screen.findByRole('heading', { name: 'Edit Contest' });
+
+    // Change title
+    const titleInput = screen.getByLabelText('Title');
+    expect(titleInput).toHaveValue(savedContest.title);
+    userEvent.clear(titleInput);
+    userEvent.type(titleInput, changedContest.title);
+
+    // Change ID
+    const idInput = screen.getByLabelText('ID');
+    expect(idInput).toHaveValue(savedContest.id);
+    userEvent.clear(idInput);
+    userEvent.type(idInput, 'changed-contest-id');
+
+    // Change district
+    userEvent.click(screen.getByText(savedDistrict.name));
+    userEvent.click(screen.getByText(changedDistrict.name));
+
+    // Change party
+    userEvent.click(
+      within(
+        screen.getByLabelText('Party').parentElement!.parentElement!
+      ).getByText(savedParty.name)
+    );
+    userEvent.click(screen.getByText(changedParty.name));
+
+    // Change seats
+    const seatsInput = screen.getByLabelText('Seats');
+    expect(seatsInput).toHaveValue(savedContest.seats);
+    userEvent.clear(seatsInput);
+    userEvent.type(seatsInput, changedContest.seats.toString());
+
+    // Change term
+    const termInput = screen.getByLabelText('Term');
+    expect(termInput).toHaveValue(savedContest.termDescription ?? '');
+    userEvent.clear(termInput);
+    userEvent.type(termInput, changedContest.termDescription!);
+
+    // Change write-ins allowed
+    const writeInsControl = screen.getByLabelText('Write-Ins Allowed?');
+    within(writeInsControl).getByRole('option', {
+      name: 'No',
+      selected: true,
+    });
+    userEvent.click(
+      within(writeInsControl).getByRole('option', { name: 'Yes' })
+    );
+
+    // Confirm candidates
+    const candidateRows = screen.getAllByRole('row');
+    expect(candidateRows).toHaveLength(savedContest.candidates.length + 1);
+    for (const [i, candidate] of savedContest.candidates.entries()) {
+      const row = candidateRows[i + 1];
+      expect(within(row).getByLabelText(`Candidate ${i + 1} Name`)).toHaveValue(
+        candidate.name
+      );
+      expect(within(row).getByLabelText(`Candidate ${i + 1} ID`)).toHaveValue(
+        candidate.id
+      );
+      const party = election.parties.find(
+        (p) => p.id === candidate.partyIds?.[0]
+      )!;
+      within(row).getByText(party.name);
+    }
+
+    // Edit candidate 2
+    const candidateNameInput = within(candidateRows[2]).getByLabelText(
+      'Candidate 2 Name'
+    );
+    userEvent.clear(candidateNameInput);
+    userEvent.type(candidateNameInput, changedContest.candidates[0].name);
+    const candidateIdInput = within(candidateRows[2]).getByLabelText(
+      'Candidate 2 ID'
+    );
+    userEvent.clear(candidateIdInput);
+    userEvent.type(candidateIdInput, changedContest.candidates[0].id);
+    const partySelect = within(candidateRows[2]).getByLabelText(
+      'Candidate 2 Party'
+    );
+    userEvent.click(partySelect);
+    userEvent.click(within(candidateRows[2]).getByText('No Party Affiliation'));
+
+    // Remove candidate 1
+    userEvent.click(
+      within(candidateRows[1]).getByRole('button', { name: 'Remove' })
+    );
+    await waitFor(() => {
+      expect(screen.getAllByRole('row')).toHaveLength(
+        savedContest.candidates.length
+      );
+      expect(
+        screen.queryByText(savedContest.candidates[0].name)
+      ).not.toBeInTheDocument();
+    });
+
+    // Save contest
+    const electionWithChangedContestRecord: ElectionRecord = {
+      ...generalElectionRecord,
+      election: {
+        ...election,
+        contests: election.contests.map((contest) =>
+          contest.id === savedContest.id ? changedContest : contest
+        ),
+      },
+    };
+    apiMock.updateElection
+      .expectCallWith({
+        electionId,
+        election: electionWithChangedContestRecord.election,
+      })
+      .resolves();
+    apiMock.getElection
+      .expectCallWith({ electionId })
+      .resolves(electionWithChangedContestRecord);
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+    userEvent.click(saveButton);
+
+    await screen.findByRole('heading', { name: 'Contests' });
+    screen.getByRole('tab', { name: 'Contests', selected: true });
+
+    const changedContestRow = screen
+      .getByText(changedContest.title)
+      .closest('tr')!;
+    within(changedContestRow).getByText(changedContest.id);
+    within(changedContestRow).getByText(changedDistrict.name);
+    within(changedContestRow).getByText(changedParty.name);
+  });
+
+  test('adding a ballot measure', async () => {
+    const { election } = generalElectionRecord;
+    const newContest: YesNoContest = {
+      type: 'yesno',
+      title: 'New Ballot Measure',
+      id: 'new-ballot-measure',
+      districtId: election.districts[0].id,
+      description: 'New Ballot Measure Description',
+      yesOption: {
+        id: 'new-ballot-measure-option-yes',
+        label: 'Yes',
+      },
+      noOption: {
+        id: 'new-ballot-measure-option-no',
+        label: 'No',
+      },
+    };
+
+    apiMock.getElection
+      .expectCallWith({ electionId })
+      .resolves(generalElectionRecord);
+    renderScreen();
+
+    await screen.findByRole('heading', { name: 'Contests' });
+    userEvent.click(screen.getByRole('button', { name: 'Add Contest' }));
+
+    // Set title
+    userEvent.type(screen.getByLabelText('Title'), newContest.title);
+
+    // Set ID
+    const idInput = screen.getByLabelText('ID');
+    expect(idInput).toHaveValue('contest-1');
+    userEvent.clear(idInput);
+    userEvent.type(idInput, newContest.id);
+
+    // Set district
+    userEvent.click(screen.getByLabelText('District'));
+    userEvent.click(screen.getByText(election.districts[0].name));
+
+    // Change type to ballot measure
+    userEvent.click(screen.getByRole('option', { name: 'Ballot Measure' }));
+
+    // Set description
+    userEvent.type(
+      screen.getByLabelText('Description'),
+      newContest.description
+    );
+
+    // Save contest
+    const electionWithNewContestRecord: ElectionRecord = {
+      ...generalElectionRecord,
+      election: {
+        ...election,
+        contests: [...election.contests, newContest],
+      },
+    };
+    apiMock.updateElection
+      .expectCallWith({
+        electionId,
+        election: electionWithNewContestRecord.election,
+      })
+      .resolves();
+    apiMock.getElection
+      .expectCallWith({ electionId })
+      .resolves(electionWithNewContestRecord);
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+    userEvent.click(saveButton);
+
+    await screen.findByRole('heading', { name: 'Contests' });
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(
+      electionWithNewContestRecord.election.contests.length + 1
+    );
+    const lastRow = rows[rows.length - 1];
+    expect(
+      within(lastRow)
+        .getAllByRole('cell')
+        .map((cell) => cell.textContent)
+    ).toEqual([
+      newContest.title,
+      newContest.id,
+      election.districts[0].name,
+      'Edit',
+    ]);
+  });
+
+  test('editing a ballot measure', async () => {
+    const { election } = generalElectionRecord;
+    const savedContest = election.contests.find(
+      (contest): contest is YesNoContest => contest.type === 'yesno'
+    )!;
+    const savedDistrict = election.districts.find(
+      (district) => district.id === savedContest.districtId
+    )!;
+    const changedDistrict = election.districts.find(
+      (district) => district.id !== savedContest.districtId
+    )!;
+    const changedContest: YesNoContest = {
+      ...savedContest,
+      title: 'Changed Ballot Measure Title',
+      id: 'changed-ballot-measure-id',
+      districtId: changedDistrict.id,
+      description: 'Changed Ballot Measure Description',
+      yesOption: {
+        id: 'changed-ballot-measure-id-option-yes',
+        label: 'Yes',
+      },
+      noOption: {
+        id: 'changed-ballot-measure-id-option-no',
+        label: 'No',
+      },
+    };
+
+    apiMock.getElection
+      .expectCallWith({ electionId })
+      .resolves(generalElectionRecord);
+    renderScreen();
+
+    await screen.findByRole('heading', { name: 'Contests' });
+    const savedContestRow = screen.getByText(savedContest.title).closest('tr')!;
+    within(savedContestRow).getByText(savedContest.id);
+    within(savedContestRow).getByText(savedDistrict.name);
+    userEvent.click(
+      within(savedContestRow).getByRole('button', { name: 'Edit' })
+    );
+
+    await screen.findByRole('heading', { name: 'Edit Contest' });
+
+    // Change title
+    const titleInput = screen.getByLabelText('Title');
+    expect(titleInput).toHaveValue(savedContest.title);
+    userEvent.clear(titleInput);
+    userEvent.type(titleInput, changedContest.title);
+
+    // Change ID
+    const idInput = screen.getByLabelText('ID');
+    expect(idInput).toHaveValue(savedContest.id);
+    userEvent.clear(idInput);
+    userEvent.type(idInput, changedContest.id);
+
+    // Change district
+    userEvent.click(screen.getByText(savedDistrict.name));
+    userEvent.click(screen.getByText(changedDistrict.name));
+
+    // Change description
+    const descriptionInput = screen.getByLabelText('Description');
+    expect(descriptionInput).toHaveValue(savedContest.description);
+    userEvent.clear(descriptionInput);
+    userEvent.type(descriptionInput, changedContest.description);
+
+    // Save contest
+    const electionWithChangedContestRecord: ElectionRecord = {
+      ...generalElectionRecord,
+      election: {
+        ...election,
+        contests: election.contests.map((contest) =>
+          contest.id === savedContest.id ? changedContest : contest
+        ),
+      },
+    };
+    apiMock.updateElection
+      .expectCallWith({
+        electionId,
+        election: electionWithChangedContestRecord.election,
+      })
+      .resolves();
+    apiMock.getElection
+      .expectCallWith({ electionId })
+      .resolves(electionWithChangedContestRecord);
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+    userEvent.click(saveButton);
+
+    await screen.findByRole('heading', { name: 'Contests' });
+    const changedContestRow = screen
+      .getByText(changedContest.title)
+      .closest('tr')!;
+    within(changedContestRow).getByText(changedContest.id);
+    within(changedContestRow).getByText(changedDistrict.name);
+  });
+});

--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -45,7 +45,7 @@ import { ElectionNavScreen } from './nav_screen';
 import { ElectionIdParams, electionParamRoutes, routes } from './routes';
 import { TabPanel, TabBar } from './tabs';
 import { getElection, updateElection } from './api';
-import { nextId } from './utils';
+import { nextId, replaceAtIndex } from './utils';
 
 const FILTER_ALL = 'all';
 const FILTER_NONPARTISAN = 'nonpartisan';
@@ -413,10 +413,13 @@ function ContestForm({
                           onChange={(e) =>
                             setContest({
                               ...contest,
-                              candidates: contest.candidates.map((c) =>
-                                c.id === candidate.id
-                                  ? { ...candidate, name: e.target.value }
-                                  : c
+                              candidates: replaceAtIndex(
+                                contest.candidates,
+                                index,
+                                {
+                                  ...candidate,
+                                  name: e.target.value,
+                                }
                               ),
                             })
                           }
@@ -429,10 +432,10 @@ function ContestForm({
                           onChange={(e) =>
                             setContest({
                               ...contest,
-                              candidates: contest.candidates.map((c) =>
-                                c.id === candidate.id
-                                  ? { ...candidate, id: e.target.value }
-                                  : c
+                              candidates: replaceAtIndex(
+                                contest.candidates,
+                                index,
+                                { ...candidate, id: e.target.value }
                               ),
                             })
                           }
@@ -455,13 +458,13 @@ function ContestForm({
                           onChange={(value) =>
                             setContest({
                               ...contest,
-                              candidates: contest.candidates.map((c) =>
-                                c.id === candidate.id
-                                  ? {
-                                      ...candidate,
-                                      partyIds: value ? [value] : undefined,
-                                    }
-                                  : c
+                              candidates: replaceAtIndex(
+                                contest.candidates,
+                                index,
+                                {
+                                  ...candidate,
+                                  partyIds: value ? [value] : undefined,
+                                }
                               ),
                             })
                           }
@@ -474,7 +477,7 @@ function ContestForm({
                             setContest({
                               ...contest,
                               candidates: contest.candidates.filter(
-                                (c) => c.id !== candidate.id
+                                (_, i) => i !== index
                               ),
                             })
                           }

--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -38,12 +38,14 @@ import {
   Form,
   FormActionsRow,
   InputGroup,
+  Row,
   TableActionsRow,
 } from './layout';
 import { ElectionNavScreen } from './nav_screen';
 import { ElectionIdParams, electionParamRoutes, routes } from './routes';
 import { TabPanel, TabBar } from './tabs';
 import { getElection, updateElection } from './api';
+import { nextId } from './utils';
 
 const FILTER_ALL = 'all';
 const FILTER_NONPARTISAN = 'nonpartisan';
@@ -387,24 +389,6 @@ function ContestForm({
                 You haven&apos;t added any candidates to this contest yet.
               </P>
             )}
-            <TableActionsRow>
-              <Button
-                icon="Add"
-                onPress={() =>
-                  setContest({
-                    ...contest,
-                    candidates: [
-                      ...contest.candidates,
-                      createBlankCandidate(
-                        `candidate-${contest.candidates.length + 1}`
-                      ),
-                    ],
-                  })
-                }
-              >
-                Add Candidate
-              </Button>
-            </TableActionsRow>
             {contest.candidates.length > 0 && (
               <Table>
                 <thead>
@@ -503,6 +487,27 @@ function ContestForm({
                 </tbody>
               </Table>
             )}
+            <Row style={{ marginTop: '0.5rem' }}>
+              <Button
+                icon="Add"
+                onPress={() =>
+                  setContest({
+                    ...contest,
+                    candidates: [
+                      ...contest.candidates,
+                      createBlankCandidate(
+                        nextId(
+                          `${contest.id}-candidate-`,
+                          contest.candidates.map((c) => c.id)
+                        )
+                      ),
+                    ],
+                  })
+                }
+              >
+                Add Candidate
+              </Button>
+            </Row>
           </div>
         </React.Fragment>
       )}
@@ -682,7 +687,12 @@ function PartyForm({
   const savedParties = savedElection.parties;
   const savedParty = partyId
     ? find(savedParties, (p) => p.id === partyId)
-    : createBlankParty(`party-${savedParties.length + 1}`);
+    : createBlankParty(
+        nextId(
+          'party-',
+          savedParties.map((p) => p.id)
+        )
+      );
   const [party, setParty] = useState<Party>(savedParty);
   const updateElectionMutation = updateElection.useMutation();
   const history = useHistory();

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -43,7 +43,7 @@ import {
   FieldName,
 } from './layout';
 import { getElection, updateElection, updatePrecincts } from './api';
-import { hasSplits, nextId } from './utils';
+import { hasSplits, nextId, replaceAtIndex } from './utils';
 
 function DistrictsTab(): JSX.Element | null {
   const { electionId } = useParams<ElectionIdParams>();
@@ -494,10 +494,10 @@ function PrecinctForm({
     }
   }
 
-  function onRemoveSplitPress(id: PrecinctId) {
+  function onRemoveSplitPress(index: number) {
     assert(hasSplits(precinct));
     const { splits, ...rest } = precinct;
-    const newSplits = splits.filter((split) => split.id !== id);
+    const newSplits = splits.filter((_, i) => i !== index);
     if (newSplits.length > 1) {
       setPrecinct({
         ...rest,
@@ -560,11 +560,10 @@ function PrecinctForm({
                         onChange={(e) =>
                           setPrecinct({
                             ...precinct,
-                            splits: precinct.splits.map((s) =>
-                              s.id === split.id
-                                ? { ...s, name: e.target.value }
-                                : s
-                            ),
+                            splits: replaceAtIndex(precinct.splits, index, {
+                              ...split,
+                              name: e.target.value,
+                            }),
                           })
                         }
                       />
@@ -576,11 +575,10 @@ function PrecinctForm({
                         onChange={(e) =>
                           setPrecinct({
                             ...precinct,
-                            splits: precinct.splits.map((s) =>
-                              s.id === split.id
-                                ? { ...s, id: e.target.value }
-                                : s
-                            ),
+                            splits: replaceAtIndex(precinct.splits, index, {
+                              ...split,
+                              id: e.target.value,
+                            }),
                           })
                         }
                       />
@@ -595,18 +593,14 @@ function PrecinctForm({
                       onChange={(districtIds) =>
                         setPrecinct({
                           ...precinct,
-                          splits: precinct.splits.map((s) =>
-                            s.id === split.id
-                              ? {
-                                  ...s,
-                                  districtIds: districtIds as DistrictId[],
-                                }
-                              : s
-                          ),
+                          splits: replaceAtIndex(precinct.splits, index, {
+                            ...split,
+                            districtIds: districtIds as DistrictId[],
+                          }),
                         })
                       }
                     />
-                    <Button onPress={() => onRemoveSplitPress(split.id)}>
+                    <Button onPress={() => onRemoveSplitPress(index)}>
                       Remove Split
                     </Button>
                   </Column>

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -27,7 +27,7 @@ import {
   Id,
   PrecinctId,
 } from '@votingworks/types';
-import { assert, find } from '@votingworks/basics';
+import { assert, find, iter } from '@votingworks/basics';
 import type { Precinct } from '@votingworks/design-backend';
 import { ElectionNavScreen } from './nav_screen';
 import { ElectionIdParams, electionParamRoutes, routes } from './routes';
@@ -43,7 +43,7 @@ import {
   FieldName,
 } from './layout';
 import { getElection, updateElection, updatePrecincts } from './api';
-import { hasSplits } from './utils';
+import { hasSplits, nextId } from './utils';
 
 function DistrictsTab(): JSX.Element | null {
   const { electionId } = useParams<ElectionIdParams>();
@@ -124,7 +124,12 @@ function DistrictForm({
   const savedDistricts = savedElection.districts;
   const savedDistrict = districtId
     ? find(savedDistricts, (d) => d.id === districtId)
-    : createBlankDistrict(`district-${savedDistricts.length + 1}`);
+    : createBlankDistrict(
+        nextId(
+          'district-',
+          savedDistricts.map((d) => d.id)
+        )
+      );
   const [district, setDistrict] = useState<District>(savedDistrict);
   const updateElectionMutation = updateElection.useMutation();
   const updatePrecinctsMutation = updatePrecincts.useMutation();
@@ -420,7 +425,12 @@ function PrecinctForm({
 }): JSX.Element {
   const savedPrecinct = precinctId
     ? find(savedPrecincts, (p) => p.id === precinctId)
-    : createBlankPrecinct(`precinct-${savedPrecincts.length + 1}`);
+    : createBlankPrecinct(
+        nextId(
+          'precinct-',
+          savedPrecincts.map((p) => p.id)
+        )
+      );
   const [precinct, setPrecinct] = useState<Precinct>(savedPrecinct);
   const updatePrecinctsMutation = updatePrecincts.useMutation();
   const history = useHistory();
@@ -446,14 +456,19 @@ function PrecinctForm({
   function onAddSplitPress() {
     if (hasSplits(precinct)) {
       const { id, name, splits } = precinct;
+      const nextSplitId = nextId(
+        `${id}-split-`,
+        splits.map((split) => split.id)
+      );
+      const nextSplitNum = iter(nextSplitId.split('-')).last();
       setPrecinct({
         id,
         name,
         splits: [
           ...splits,
           {
-            id: `${id}-split-${splits.length + 1}`,
-            name: `${name} - Split ${splits.length + 1}`,
+            id: nextSplitId,
+            name: `${name} - Split ${nextSplitNum}`,
             districtIds: [],
           },
         ],

--- a/apps/design/frontend/src/nav_screen.tsx
+++ b/apps/design/frontend/src/nav_screen.tsx
@@ -22,7 +22,7 @@ export function NavScreen({
 }): JSX.Element {
   return (
     <Screen flexDirection="row">
-      <LeftNav>
+      <LeftNav style={{ width: '14rem' }}>
         <AppLogo appName="VxDesign" />
         {navContent}
       </LeftNav>

--- a/apps/design/frontend/src/utils.test.ts
+++ b/apps/design/frontend/src/utils.test.ts
@@ -1,0 +1,18 @@
+import { range } from '@votingworks/basics';
+import { nextId } from './utils';
+
+test('nextId', () => {
+  expect(nextId('prefix-')).toEqual('prefix-1');
+  expect(nextId('prefix-', ['prefix-1'])).toEqual('prefix-2');
+  expect(nextId('prefix-', ['prefix-1', 'prefix-2'])).toEqual('prefix-3');
+  expect(nextId('prefix-', ['prefix-1', 'prefix-3'])).toEqual('prefix-2');
+  expect(
+    nextId(
+      'prefix-',
+      range(1, 100).map((n) => `prefix-${n}`)
+    )
+  ).toEqual('prefix-100');
+  expect(
+    nextId('prefix-', ['custom', 'prefix-2', 'id123', 'prefix-1'])
+  ).toEqual('prefix-3');
+});

--- a/apps/design/frontend/src/utils.ts
+++ b/apps/design/frontend/src/utils.ts
@@ -8,7 +8,7 @@ export function hasSplits(precinct: Precinct): precinct is PrecinctWithSplits {
  * Given a prefix and a list of existing IDs, returns the next ID of the format
  * `${prefix}${n}` that does not already exist. Increments `n` starting at 1.
  */
-export function nextId(prefix: string, existingIds?: string[]): string {
+export function nextId(prefix: string, existingIds?: Iterable<string>): string {
   let n = 1;
   const existingIdsSet = new Set(existingIds);
   while (existingIdsSet.has(`${prefix}${n}`)) {

--- a/apps/design/frontend/src/utils.ts
+++ b/apps/design/frontend/src/utils.ts
@@ -3,3 +3,16 @@ import type { Precinct, PrecinctWithSplits } from '@votingworks/design-backend';
 export function hasSplits(precinct: Precinct): precinct is PrecinctWithSplits {
   return 'splits' in precinct && precinct.splits !== undefined;
 }
+
+/**
+ * Given a prefix and a list of existing IDs, returns the next ID of the format
+ * `${prefix}${n}` that does not already exist. Increments `n` starting at 1.
+ */
+export function nextId(prefix: string, existingIds?: string[]): string {
+  let n = 1;
+  const existingIdsSet = new Set(existingIds);
+  while (existingIdsSet.has(`${prefix}${n}`)) {
+    n += 1;
+  }
+  return `${prefix}${n}`;
+}

--- a/apps/design/frontend/src/utils.ts
+++ b/apps/design/frontend/src/utils.ts
@@ -16,3 +16,15 @@ export function nextId(prefix: string, existingIds?: string[]): string {
   }
   return `${prefix}${n}`;
 }
+
+/**
+ * Returns a copy of the given array with the value at the specified index
+ * replaced with the given value.
+ */
+export function replaceAtIndex<T>(
+  array: readonly T[],
+  index: number,
+  newValue: T
+): T[] {
+  return array.map((value, i) => (i === index ? newValue : value));
+}


### PR DESCRIPTION
## Overview

Fixes #4067, #4068

_Review by commits_

Fixes a few bugs with the contests form:
- Create globally unique contest/candidate IDs (ended up implementing a solution for all forms that create IDs)
- Use candidate index instead of candidate ID when making local state updates, since ID may be edited

Also adds tests for the contests form and cleans up some small bits of styling.

## Demo Video or Screenshot
N/A

## Testing Plan
Added tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
