### PR TITLE
fix(utils): correct `jsonStream` cycle false positive

### DIFF
--- a/libs/utils/.eslintrc.json
+++ b/libs/utils/.eslintrc.json
@@ -6,7 +6,7 @@
     // Allow for variable naming with "CVR"
     "vx/gts-identifiers": [
       "error",
-      { "allowedNames": ["/CVR.*/", "/buildCVR.*/"] }
+      { "allowedNames": ["/CVR.*/", "/buildCVR.*/", "toJSON"] }
     ]
   }
 }


### PR DESCRIPTION
## Overview
Since I was keeping track of _all_ objects that had been serialized as part of the initial `jsonStream` call, this would fail to serialize:

```ts
const o = {};
jsonStream([o, o]);
```

That's not a cycle, so it should be fine. This change updates the cycle tracking to only look at the ancestors of the current object being serialized.

While I was making this change I remembered that `JSON.stringify` respects `toJSON` being defined on objects, so I added that feature.

## Testing Plan
- [x] New automated tests.
