### PR TITLE
Decrease VxSuite test flakiness

### DIFF
--- a/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
@@ -41,7 +41,7 @@ afterEach(() => {
   apiMock.mockApiClient.assertComplete();
 });
 
-jest.setTimeout(40_000);
+jest.setTimeout(60_000);
 
 test('MarkAndPrint end-to-end flow', async () => {
   const logger = fakeLogger();

--- a/apps/mark/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark/frontend/src/app_end_to_end.test.tsx
@@ -42,7 +42,7 @@ afterEach(() => {
   apiMock.mockApiClient.assertComplete();
 });
 
-jest.setTimeout(30000);
+jest.setTimeout(60_000);
 
 test('MarkAndPrint end-to-end flow', async () => {
   const logger = fakeLogger();

--- a/apps/scan/backend/package.json
+++ b/apps/scan/backend/package.json
@@ -19,7 +19,7 @@
     "pre-commit": "lint-staged",
     "start": "node ./build/index.js",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
+    "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=2 # VxScan backend tests (which involve lots of polling and I/O operations) get flaky when we set --maxWorkers higher",
     "test:coverage": "jest --coverage",
     "test:debug": "node --inspect-brk $(which jest) --runInBand --no-cache",
     "test:watch": "jest --watch",

--- a/apps/scan/backend/src/app_usb_drive.test.ts
+++ b/apps/scan/backend/src/app_usb_drive.test.ts
@@ -76,4 +76,4 @@ test('doesUsbDriveRequireCastVoteRecordSync is properly populated', async () => 
       });
     }
   );
-});
+}, 30_000);

--- a/libs/auth/src/live_check.test.ts
+++ b/libs/auth/src/live_check.test.ts
@@ -64,6 +64,12 @@ test.each<{
       machineId,
       electionHash: isMachineConfiguredForAnElection ? electionHash : undefined,
     });
-    expect(qrCodeValue).toHaveLength(expectedQrCodeValueLength);
+    expect([
+      expectedQrCodeValueLength,
+      // There's a slight chance that the base64-encoded signature within the QR code value is 92
+      // characters long instead of 96. (The length of a base64-encoded string is always a multiple
+      // of 4.)
+      expectedQrCodeValueLength - 4,
+    ]).toContain(qrCodeValue.length);
   }
 );

--- a/libs/backend/src/cast_vote_records/export.test.ts
+++ b/libs/backend/src/cast_vote_records/export.test.ts
@@ -48,7 +48,7 @@ import {
   readCastVoteRecord,
 } from './test_utils';
 
-jest.setTimeout(10_000);
+jest.setTimeout(30_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 


### PR DESCRIPTION
## Overview

VxSuite tests have gotten quite flaky lately. Using the list of flaky tests on the (super helpful) [CI insights page](https://app.circleci.com/insights/github/votingworks/vxsuite/workflows/test/tests?branch=main) as a guide, I've made a number of small tweaks to decrease flakiness. More on the specifics of the fixes in GitHub comments.

## Testing Plan

- [x] Tested some of the fixes by SSH-ing onto a CI machine for a more representative environment