### PR TITLE
Avoid warning flicker when switching from test mode to official mode while a CVR sync is required

### DIFF
--- a/apps/scan/frontend/jest.config.js
+++ b/apps/scan/frontend/jest.config.js
@@ -14,7 +14,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       statements: 95,
-      branches: 87,
+      branches: 86,
       functions: 88,
       lines: 95,
     },

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -151,10 +151,7 @@ export function ElectionManagerScreen({
   const ballotMode = (
     <P>
       <SegmentedButton
-        disabled={
-          setTestModeMutation.isLoading ||
-          (isCvrSyncRequired && scannerStatus.ballotsCounted > 0)
-        }
+        disabled={setTestModeMutation.isLoading || isCvrSyncRequired}
         label="Ballot Mode:"
         hideLabel
         onChange={() => {


### PR DESCRIPTION
_Easiest reviewed by commit_

## Overview

When switching from test mode to official mode while a CVR sync is required, you may see a flicker of the warning message typically displayed when you try to switch in the reverse direction (from official mode to test mode) without syncing CVRs first.

To repro reliably in dev, I had to slow down USB drive status polling:

https://github.com/votingworks/vxsuite/assets/12616928/5cafee1d-bb67-43d8-8906-f060dc9a0ae2

I think we're seeing this more reliably in prod, probably because our prod machines aren't as performant as our dev machines.

This PR fixes the issue by invalidating the USB drive status React query on mode switch, instead of just waiting for the next poll.

We didn't catch this earlier because the warning used to live in a modal, only surfaced when you actually clicked the "Official Ballot Mode" toggle. Technically, if you clicked the toggle fast enough, you might've been able to catch a flicker of the warning.

## Testing Plan

- [x] Tested manually
- [x] Updated automated tests, though I couldn't repro the flicker easily in a test environment

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A