### PR TITLE
VxDesign: Rename County -> Jurisdiction

### DIFF
--- a/apps/design/frontend/src/election_info_screen.test.tsx
+++ b/apps/design/frontend/src/election_info_screen.test.tsx
@@ -69,9 +69,9 @@ test('newly created election starts in edit mode', async () => {
   expect(stateInput).toHaveValue('');
   expect(stateInput).toBeEnabled();
 
-  const countyInput = screen.getByLabelText('County');
-  expect(countyInput).toHaveValue('');
-  expect(countyInput).toBeEnabled();
+  const jurisdictionInput = screen.getByLabelText('Jurisdiction');
+  expect(jurisdictionInput).toHaveValue('');
+  expect(jurisdictionInput).toBeEnabled();
 
   const sealInput = screen.getByText('Seal').parentElement!;
   expect(within(sealInput).queryByRole('img')).not.toBeInTheDocument();
@@ -110,9 +110,9 @@ test('edit and save election', async () => {
   expect(stateInput).toHaveValue(election.state);
   expect(stateInput).toBeDisabled();
 
-  const countyInput = screen.getByLabelText('County');
-  expect(countyInput).toHaveValue(election.county.name);
-  expect(countyInput).toBeDisabled();
+  const jurisdictionInput = screen.getByLabelText('Jurisdiction');
+  expect(jurisdictionInput).toHaveValue(election.county.name);
+  expect(jurisdictionInput).toBeDisabled();
 
   const sealInput = screen.getByText('Seal').parentElement!;
   expect(within(sealInput).getByRole('img')).toHaveAttribute(
@@ -141,9 +141,9 @@ test('edit and save election', async () => {
   userEvent.type(stateInput, 'New State');
   expect(stateInput).toHaveValue('New State');
 
-  userEvent.clear(countyInput);
-  userEvent.type(countyInput, 'New County');
-  expect(countyInput).toHaveValue('New County');
+  userEvent.clear(jurisdictionInput);
+  userEvent.type(jurisdictionInput, 'New County');
+  expect(jurisdictionInput).toHaveValue('New County');
 
   userEvent.upload(
     within(sealInput).getByLabelText('Upload Seal Image'),

--- a/apps/design/frontend/src/election_info_screen.tsx
+++ b/apps/design/frontend/src/election_info_screen.tsx
@@ -110,7 +110,7 @@ function ElectionInfoForm({
           disabled={!isEditing}
         />
       </InputGroup>
-      <InputGroup label="County">
+      <InputGroup label="Jurisdiction">
         <input
           type="text"
           value={electionInfo.county.name}


### PR DESCRIPTION
## Overview
This is a more flexible term that can encompass non-county entities like NH towns and cities.


## Demo Video or Screenshot
<img width="1424" alt="Screenshot 2023-12-14 at 9 40 32 AM" src="https://github.com/votingworks/vxsuite/assets/530106/e9c8da72-b20b-4dc5-b83b-dc5ec3346485">


## Testing Plan
Update automated test

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
