### PR TITLE
hide WIA report when no write-in contests

### DIFF
--- a/apps/admin/frontend/src/screens/reporting/reports_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/reports_screen.test.tsx
@@ -1,5 +1,6 @@
 import { electionTwoPartyPrimaryDefinition } from '@votingworks/fixtures';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
+import { ElectionDefinition } from '@votingworks/types';
 import { ReportsScreen } from './reports_screen';
 import { renderInAppContext } from '../../../test/render_in_app_context';
 import { ApiMock, createApiMock } from '../../../test/helpers/mock_api_client';
@@ -68,5 +69,51 @@ describe('ballot count summary text', () => {
         '3,000 test ballots have been counted for Example Primary Election.'
       )
     );
+  });
+});
+
+describe('showing WIA report link', () => {
+  const BUTTON_TEXT = 'Unofficial Write-In Adjudication Report';
+
+  test('shown when election has write-in contests', async () => {
+    apiMock.expectGetCastVoteRecordFileMode('test');
+    apiMock.expectGetCardCounts({}, [getMockCardCounts(3000)]);
+
+    renderInAppContext(<ReportsScreen />, {
+      electionDefinition,
+      apiMock,
+    });
+
+    await screen.findButton(BUTTON_TEXT);
+  });
+
+  test('not shown when election does not write-in contests', async () => {
+    apiMock.expectGetCastVoteRecordFileMode('test');
+    apiMock.expectGetCardCounts({}, [getMockCardCounts(3000)]);
+
+    const electionDefinitionWithoutWriteIns: ElectionDefinition = {
+      ...electionDefinition,
+      election: {
+        ...electionDefinition.election,
+        contests: electionDefinition.election.contests.map((contest) => {
+          if (contest.type === 'candidate') {
+            return {
+              ...contest,
+              allowWriteIns: false,
+            };
+          }
+
+          return contest;
+        }),
+      },
+    };
+
+    renderInAppContext(<ReportsScreen />, {
+      electionDefinition: electionDefinitionWithoutWriteIns,
+      apiMock,
+    });
+
+    await screen.findButton('Full Election Tally Report');
+    expect(screen.queryByText(BUTTON_TEXT)).not.toBeInTheDocument();
   });
 });

--- a/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
@@ -37,6 +37,10 @@ export function ReportsScreen(): JSX.Element {
     ? getBallotCount(cardCountsQuery.data[0])
     : 0;
 
+  const electionHasWriteInContest = electionDefinition.election.contests.some(
+    (c) => c.type === 'candidate' && c.allowWriteIns
+  );
+
   const ballotCountSummaryText = cardCountsQuery.isSuccess ? (
     <P>
       <Font weight="bold">
@@ -104,15 +108,16 @@ export function ReportsScreen(): JSX.Element {
           </LinkButton>
         </P>
       </Section>
-
-      <Section>
-        <H2>Other Reports</H2>
-        <P>
-          <LinkButton to={routerPaths.tallyWriteInReport}>
-            {statusPrefix} Write-In Adjudication Report
-          </LinkButton>
-        </P>
-      </Section>
+      {electionHasWriteInContest && (
+        <Section>
+          <H2>Other Reports</H2>
+          <P>
+            <LinkButton to={routerPaths.tallyWriteInReport}>
+              {statusPrefix} Write-In Adjudication Report
+            </LinkButton>
+          </P>
+        </Section>
+      )}
     </NavigationScreen>
   );
 }


### PR DESCRIPTION
## Overview

Hides WIA report section and link button when there are no WIA contests. Closes #4414. 

## Demo Video or Screenshot

w/ write-ins:
<img width="1150" alt="Screen Shot 2023-12-14 at 9 43 37 AM" src="https://github.com/votingworks/vxsuite/assets/37960853/00d94bf7-b37a-418a-b6b9-2ee79c59a705">

w/o write-ins:
<img width="1153" alt="Screen Shot 2023-12-14 at 9 43 10 AM" src="https://github.com/votingworks/vxsuite/assets/37960853/fd857e77-67c9-442b-b2fa-474c15a19697">


## Testing Plan
- automated coverage
- manual check

