### PR TITLE
feat(basics): add `IteratorPlus::isEmpty`

### DIFF
--- a/libs/basics/src/iterators/async_iterator_plus.test.ts
+++ b/libs/basics/src/iterators/async_iterator_plus.test.ts
@@ -345,6 +345,14 @@ test('flatMap', async () => {
   ).toEqual([1, 1, 2, 2, 3, 3]);
 });
 
+test('isEmpty', async () => {
+  expect(await iter(null).async().isEmpty()).toEqual(true);
+  expect(await iter(undefined).async().isEmpty()).toEqual(true);
+  expect(await iter([]).async().isEmpty()).toEqual(true);
+  expect(await iter([1]).async().isEmpty()).toEqual(false);
+  expect(await iter([1, 2, 3]).async().isEmpty()).toEqual(false);
+});
+
 test('last', async () => {
   expect(await iter([]).async().last()).toEqual(undefined);
   expect(await iter([1]).async().last()).toEqual(1);

--- a/libs/basics/src/iterators/async_iterator_plus.ts
+++ b/libs/basics/src/iterators/async_iterator_plus.ts
@@ -171,6 +171,11 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
     ) as AsyncIteratorPlus<U>;
   }
 
+  async isEmpty(): Promise<boolean> {
+    /* istanbul ignore next - `done` is typed as `{ done?: false } | { done: true }`, but in practice is never undefined */
+    return (await this.iterable[Symbol.asyncIterator]().next()).done ?? true;
+  }
+
   async last(): Promise<T | undefined> {
     let lastElement: T | undefined;
     for await (const it of this.iterable) {

--- a/libs/basics/src/iterators/iter.test.ts
+++ b/libs/basics/src/iterators/iter.test.ts
@@ -50,6 +50,32 @@ test('iter with async iterable', async () => {
   ).toEqual([1, 2, 3]);
 });
 
+test('iter with null', async () => {
+  expect(iter(null).toArray()).toEqual([]);
+  expect(await iter(null).async().toArray()).toEqual([]);
+  expect(iter(null).count()).toEqual(0);
+
+  // get a maybe-null array in a way that TS can't tell is null
+  const maybeNull = ((): string[] | null => null)();
+
+  // explicit type annotation to ensure that the type is correct
+  const maybeStrings: string[] = iter(maybeNull).toArray();
+  expect(maybeStrings).toEqual([]);
+});
+
+test('iter with undefined', async () => {
+  expect(iter(undefined).toArray()).toEqual([]);
+  expect(await iter(undefined).async().toArray()).toEqual([]);
+  expect(iter(undefined).count()).toEqual(0);
+
+  // get a maybe-undefined array in a way that TS can't tell is undefined
+  const maybeUndefined = ((): string[] | undefined => undefined)();
+
+  // explicit type annotation to ensure that the type is correct
+  const maybeStrings: string[] = iter(maybeUndefined).toArray();
+  expect(maybeStrings).toEqual([]);
+});
+
 test('iter with non-iterable', () => {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-expect-error

--- a/libs/basics/src/iterators/iter.ts
+++ b/libs/basics/src/iterators/iter.ts
@@ -5,7 +5,9 @@ import { AsyncIteratorPlus, IteratorPlus } from './types';
 /**
  * Builds an {@link IteratorPlus} from an iterable.
  */
-export function iter<T>(iterable: Iterable<T>): IteratorPlus<T>;
+export function iter<T>(
+  iterable: Iterable<T> | undefined | null
+): IteratorPlus<T>;
 
 /**
  * Builds an {@link AsyncIteratorPlus} from an async iterable.
@@ -16,8 +18,12 @@ export function iter<T>(iterable: AsyncIterable<T>): AsyncIteratorPlus<T>;
  * Builds an {@link IteratorPlus} or {@link AsyncIteratorPlus} from an iterable.
  */
 export function iter<T>(
-  iterable: Iterable<T> | AsyncIterable<T>
+  iterable?: Iterable<T> | AsyncIterable<T> | null
 ): IteratorPlus<T> | AsyncIteratorPlus<T> {
+  if (iterable === null || iterable === undefined) {
+    return iter([] as T[]);
+  }
+
   if (typeof iterable === 'string' || Symbol.iterator in iterable) {
     return new IteratorPlusImpl(iterable);
   }

--- a/libs/basics/src/iterators/iterator_plus.test.ts
+++ b/libs/basics/src/iterators/iterator_plus.test.ts
@@ -254,6 +254,14 @@ test('flatMap', () => {
   ).toEqual([1, 1, 2, 2, 3, 3]);
 });
 
+test('isEmpty', () => {
+  expect(iter(null).isEmpty()).toEqual(true);
+  expect(iter(undefined).isEmpty()).toEqual(true);
+  expect(iter([]).isEmpty()).toEqual(true);
+  expect(iter([1]).isEmpty()).toEqual(false);
+  expect(iter([1, 2, 3]).isEmpty()).toEqual(false);
+});
+
 test('last', () => {
   expect(iter([]).last()).toEqual(undefined);
   expect(iter([1]).last()).toEqual(1);

--- a/libs/basics/src/iterators/iterator_plus.ts
+++ b/libs/basics/src/iterators/iterator_plus.ts
@@ -175,6 +175,11 @@ export class IteratorPlusImpl<T> implements IteratorPlus<T>, AsyncIterable<T> {
     );
   }
 
+  isEmpty(): boolean {
+    /* istanbul ignore next - `done` is typed as `{ done?: false } | { done: true }`, but in practice is never undefined */
+    return this.iterable[Symbol.iterator]().next().done ?? true;
+  }
+
   last(): T | undefined {
     let lastElement: T | undefined;
     for (const it of this.iterable) {

--- a/libs/basics/src/iterators/types.ts
+++ b/libs/basics/src/iterators/types.ts
@@ -54,7 +54,7 @@ export interface IteratorPlus<T> extends Iterable<T> {
 
   /**
    * Determines if all elements satisfy `predicate`. Consumes the contained
-   * iterable.
+   * iterable until a non-matching element is found.
    */
   every(predicate: (item: T) => unknown): boolean;
 
@@ -83,6 +83,11 @@ export interface IteratorPlus<T> extends Iterable<T> {
    * Maps elements to an iterable of `U` and flattens the result.
    */
   flatMap<U>(fn: (value: T, index: number) => Iterable<U>): IteratorPlus<U>;
+
+  /**
+   * Determines whether there are no elements in `this`.
+   */
+  isEmpty(): boolean;
 
   /**
    * Returns the last element of `this` or `undefined` if `this` is empty.
@@ -394,7 +399,7 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
 
   /**
    * Determines if all elements satisfy `predicate`. Consumes the contained
-   * iterable.
+   * iterable until a non-matching element is found.
    */
   every(predicate: (item: T) => MaybePromise<unknown>): Promise<boolean>;
 
@@ -423,6 +428,11 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
       index: number
     ) => MaybePromise<Iterable<U> | AsyncIterable<U>>
   ): AsyncIteratorPlus<U>;
+
+  /**
+   * Determines whether there are no elements in `this`.
+   */
+  isEmpty(): Promise<boolean>;
 
   /**
    * Returns the last element of `this` or `undefined` if `this` is empty.

--- a/libs/utils/src/ballot_styles.ts
+++ b/libs/utils/src/ballot_styles.ts
@@ -78,10 +78,7 @@ export function getRelatedBallotStyle(params: {
   }
 
   // For legacy language-agnostic ballot styles, return the same ballot style:
-  if (
-    !sourceBallotStyle.languages ||
-    sourceBallotStyle.languages.length === 0
-  ) {
+  if (iter(sourceBallotStyle.languages).isEmpty()) {
     return ok(sourceBallotStyle);
   }
 


### PR DESCRIPTION
Adds `IteratorPlus::isEmpty` and allows the argument to `iter` to be nullish, treating such values as an empty iterator. This allows for more succinctly checking whether e.g. a possibly-nullish array is empty:

```ts
iter(election.gridLayouts).isEmpty()
```

This changes one place where we were previously using `lodash.isempty` to use this pattern.