### PR TITLE
feat(basics): add `lines` iterator helper

### DIFF
--- a/libs/auth/scripts/configure_java_card.ts
+++ b/libs/auth/scripts/configure_java_card.ts
@@ -1,7 +1,7 @@
 import { Buffer } from 'buffer';
 import { existsSync } from 'fs';
 import path from 'path';
-import { extractErrorMessage } from '@votingworks/basics';
+import { extractErrorMessage, lines } from '@votingworks/basics';
 import { Byte } from '@votingworks/types';
 
 import { CommandApdu, constructTlv } from '../src/apdu';
@@ -246,20 +246,16 @@ async function runAppletConfigurationCommands(): Promise<void> {
       OPEN_FIPS_201_AID,
       '--mode',
       'enc',
-      ...apduStrings.map((apduString) => ['-s', apduString]).flat(),
+      ...apduStrings.flatMap((apduString) => ['-s', apduString]),
     ])
   );
-  const apduLines = output
-    .toString('utf-8')
-    .split('\n')
-    .filter((line) => line.startsWith('A>>') || line.startsWith('A<<'));
-  const successCount = apduLines.filter(
-    (line) => line.startsWith('A<<') && line.endsWith('9000')
-  ).length;
+  const successCount = lines(output.toString('utf-8'))
+    .filter((line) => line.startsWith('A<<') && line.endsWith('9000'))
+    .count();
   // Applet selection and establishment of GlobalPlatform Secure Channel
   const baselineApduCount = 3;
   if (successCount !== baselineApduCount + apdus.length) {
-    console.error(apduLines.join('\n'));
+    console.error(output.toString('utf-8'));
     throw new Error(
       'Not all applet configuration commands returned 90 00 success status word'
     );

--- a/libs/basics/src/iterators/index.ts
+++ b/libs/basics/src/iterators/index.ts
@@ -2,5 +2,6 @@
 export * from './integers';
 export * from './iter';
 export * from './iterator_plus';
+export * from './lines';
 export * from './naturals';
 export * from './types';

--- a/libs/basics/src/iterators/lines.test.ts
+++ b/libs/basics/src/iterators/lines.test.ts
@@ -1,5 +1,7 @@
 import { Buffer } from 'buffer';
 import fc from 'fast-check';
+import { createReadStream } from 'fs';
+import { readFile } from 'fs/promises';
 import { iter } from './iter';
 import { lines } from './lines';
 
@@ -8,7 +10,7 @@ test('lines (sync)', () => {
   expect(lines('a').toArray()).toEqual(['a']);
   expect(lines('a\nb').toArray()).toEqual(['a', 'b']);
   expect(lines(Buffer.from('a\nb')).toArray()).toEqual(['a', 'b']);
-  expect(lines({ toString: () => 'a\nb' }).toArray()).toEqual(['a', 'b']);
+  expect(lines([{ toString: () => 'a\nb' }]).toArray()).toEqual(['a', 'b']);
   expect(lines(iter([])).toArray()).toEqual([]);
   expect(lines(iter([''])).toArray()).toEqual(['']);
   expect(lines(iter(['\n'])).toArray()).toEqual(['', '']);
@@ -108,6 +110,11 @@ test('lines (async)', async () => {
       })()
     ).toArray()
   ).toEqual(['abc', 'de']);
+
+  const input = createReadStream(__filename);
+  expect((await lines(input).toArray()).join('\n')).toEqual(
+    await readFile(__filename, 'utf8')
+  );
 
   // check that the lines are the same as joining then splitting
   await fc.assert(

--- a/libs/basics/src/iterators/lines.test.ts
+++ b/libs/basics/src/iterators/lines.test.ts
@@ -1,0 +1,132 @@
+import { Buffer } from 'buffer';
+import fc from 'fast-check';
+import { iter } from './iter';
+import { lines } from './lines';
+
+test('lines (sync)', () => {
+  expect(lines('').toArray()).toEqual(['']);
+  expect(lines('a').toArray()).toEqual(['a']);
+  expect(lines('a\nb').toArray()).toEqual(['a', 'b']);
+  expect(lines(Buffer.from('a\nb')).toArray()).toEqual(['a', 'b']);
+  expect(lines({ toString: () => 'a\nb' }).toArray()).toEqual(['a', 'b']);
+  expect(lines(iter([])).toArray()).toEqual([]);
+  expect(lines(iter([''])).toArray()).toEqual(['']);
+  expect(lines(iter(['\n'])).toArray()).toEqual(['', '']);
+  expect(lines(iter(['a'])).toArray()).toEqual(['a']);
+  expect(lines(iter(['a', 'b'])).toArray()).toEqual(['ab']);
+  expect(lines(iter(['a\nb'])).toArray()).toEqual(['a', 'b']);
+  expect(lines(iter(['a\nb\r\nc'])).toArray()).toEqual(['a', 'b', 'c']);
+  expect(lines(iter(['a\nb', 'c\n'])).toArray()).toEqual(['a', 'bc', '']);
+  expect(lines(iter(['a\nb\r\nc\n\n'])).toArray()).toEqual([
+    'a',
+    'b',
+    'c',
+    '',
+    '',
+  ]);
+
+  expect(lines(iter([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])).toArray()).toEqual([
+    '0123456789',
+  ]);
+
+  expect(lines(iter(['a\nb', 'c\r'])).toArray()).toEqual(['a', 'bc\r']);
+
+  expect(
+    lines(
+      (function* gen() {
+        yield 'a';
+        yield 'b';
+        yield Buffer.from('c\n');
+        yield 'd';
+        yield 'e';
+      })()
+    ).toArray()
+  ).toEqual(['abc', 'de']);
+
+  // check that the lines are the same as joining then splitting
+  fc.assert(
+    fc.property(
+      fc
+        .array(
+          fc.oneof(
+            fc.string(),
+            fc.integer(),
+            fc.boolean(),
+            fc.constantFrom('\n', '\r\n')
+          )
+        )
+        .filter((arr) => arr.length > 0),
+      (arr) => {
+        expect(lines(iter(arr)).toArray()).toEqual(arr.join('').split(/\r?\n/));
+      }
+    )
+  );
+});
+
+test('lines (async)', async () => {
+  expect(await lines(iter([]).async()).toArray()).toEqual([]);
+  expect(await lines(iter(['']).async()).toArray()).toEqual(['']);
+  expect(await lines(iter(['\n']).async()).toArray()).toEqual(['', '']);
+  expect(await lines(iter(['a']).async()).toArray()).toEqual(['a']);
+  expect(await lines(iter(['a', 'b']).async()).toArray()).toEqual(['ab']);
+  expect(await lines(iter(['a\nb']).async()).toArray()).toEqual(['a', 'b']);
+  expect(await lines(iter(['a\nb\r\nc']).async()).toArray()).toEqual([
+    'a',
+    'b',
+    'c',
+  ]);
+  expect(await lines(iter(['a\nb', 'c\n']).async()).toArray()).toEqual([
+    'a',
+    'bc',
+    '',
+  ]);
+  expect(await lines(iter(['a\nb\r\nc\n\n']).async()).toArray()).toEqual([
+    'a',
+    'b',
+    'c',
+    '',
+    '',
+  ]);
+
+  expect(
+    await lines(iter([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).async()).toArray()
+  ).toEqual(['0123456789']);
+
+  expect(await lines(iter(['a\nb', 'c\r']).async()).toArray()).toEqual([
+    'a',
+    'bc\r',
+  ]);
+
+  expect(
+    await lines(
+      (async function* gen() {
+        yield 'a';
+        yield 'b';
+        yield Buffer.from('c\n');
+        yield await Promise.resolve('d');
+        yield 'e';
+      })()
+    ).toArray()
+  ).toEqual(['abc', 'de']);
+
+  // check that the lines are the same as joining then splitting
+  await fc.assert(
+    fc.asyncProperty(
+      fc
+        .array(
+          fc.oneof(
+            fc.string(),
+            fc.integer(),
+            fc.boolean(),
+            fc.constantFrom('\n', '\r\n')
+          )
+        )
+        .filter((arr) => arr.length > 0),
+      async (arr) => {
+        expect(await lines(iter(arr).async()).toArray()).toEqual(
+          arr.join('').split(/\r?\n/)
+        );
+      }
+    )
+  );
+});

--- a/libs/basics/src/iterators/lines.ts
+++ b/libs/basics/src/iterators/lines.ts
@@ -1,0 +1,136 @@
+import { Buffer } from 'buffer';
+import { AsyncIteratorPlusImpl } from './async_iterator_plus';
+import { IteratorPlusImpl } from './iterator_plus';
+import { AsyncIteratorPlus, IteratorPlus } from './types';
+
+interface ToString {
+  toString(): string;
+}
+
+function matchAllNewlines(str: string): Iterable<RegExpMatchArray> {
+  return str.matchAll(/\r?\n/g);
+}
+
+function linesSync(iterable: Iterable<ToString>): IteratorPlus<string> {
+  let buffer = '';
+  return new IteratorPlusImpl(
+    (function* gen() {
+      let hasSeenAnyChunks = false;
+
+      for (const element of iterable) {
+        const chunk = element.toString();
+        let offset = 0;
+        for (const newlineMatch of matchAllNewlines(chunk)) {
+          /* istanbul ignore next */
+          if (typeof newlineMatch.index !== 'number') {
+            throw new Error('expected index');
+          }
+
+          const line = buffer + chunk.slice(offset, newlineMatch.index);
+          buffer = '';
+          offset = newlineMatch.index + newlineMatch[0].length;
+          yield line;
+        }
+
+        buffer += chunk.slice(offset);
+        hasSeenAnyChunks = true;
+      }
+
+      if (hasSeenAnyChunks) {
+        yield buffer;
+      }
+    })()
+  );
+}
+
+function linesAsync(
+  iterable: AsyncIterable<ToString>
+): AsyncIteratorPlus<string> {
+  let buffer = '';
+  return new AsyncIteratorPlusImpl(
+    (async function* gen() {
+      let hasSeenAnyChunks = false;
+
+      for await (const element of iterable) {
+        const chunk = element.toString();
+        let offset = 0;
+        for (const newlineMatch of matchAllNewlines(chunk)) {
+          /* istanbul ignore next */
+          if (typeof newlineMatch.index !== 'number') {
+            throw new Error('expected index');
+          }
+
+          const line = buffer + chunk.slice(offset, newlineMatch.index);
+          buffer = '';
+          offset = newlineMatch.index + newlineMatch[0].length;
+          yield line;
+        }
+
+        buffer += chunk.slice(offset);
+        hasSeenAnyChunks = true;
+      }
+
+      if (hasSeenAnyChunks) {
+        yield buffer;
+      }
+    })()
+  );
+}
+
+/**
+ * Pipes elements from `iterable` by collecting them together into a string
+ * until a full line is formed, then yielding that line. The final line may or
+ * may not include a newline.
+ *
+ * @example
+ *
+ * ```ts
+ * const file = fs.createReadStream('file.txt', { encoding: 'utf8' });
+ *
+ * expect(await iter(file).lines().toArray()).toEqual([
+ *   'line 1\n',
+ *   'line 2\n',
+ *   …
+ * ]);
+ * ```
+ */
+export function lines(
+  iterable: AsyncIterable<ToString>
+): AsyncIteratorPlus<string>;
+
+/**
+ * Pipes elements from `iterable` by collecting them together into a string
+ * until a full line is formed, then yielding that line. The final line may or
+ * may not include a newline.
+ *
+ * @example
+ *
+ * ```ts
+ * const input = ['hello', ' world', '!', '\n', 'goodbye', 'world'];
+ *
+ * expect(lines(input).toArray()).toEqual([
+ *   'hello world!\n',
+ *   'goodbye world'
+ * ]);
+ * ```
+ */
+export function lines(
+  iterable: ToString | Iterable<ToString>
+): IteratorPlus<string>;
+
+/**
+ * Pipes elements from `iterable` by collecting them together into a string
+ * until a full line is formed, then yielding that line. The final line may or
+ * may not include a newline.
+ */
+export function lines(
+  iterable: ToString | Iterable<ToString> | AsyncIterable<ToString>
+): IteratorPlus<string> | AsyncIteratorPlus<string> {
+  return typeof iterable === 'string' || Buffer.isBuffer(iterable)
+    ? linesSync([iterable.toString()])
+    : Symbol.iterator in iterable
+    ? linesSync(iterable)
+    : Symbol.asyncIterator in iterable
+    ? linesAsync(iterable)
+    : linesSync([iterable.toString()]);
+}

--- a/libs/basics/src/iterators/lines.ts
+++ b/libs/basics/src/iterators/lines.ts
@@ -115,7 +115,7 @@ export function lines(
  * ```
  */
 export function lines(
-  iterable: ToString | Iterable<ToString>
+  iterable: string | Buffer | Iterable<ToString>
 ): IteratorPlus<string>;
 
 /**
@@ -124,13 +124,11 @@ export function lines(
  * may not include a newline.
  */
 export function lines(
-  iterable: ToString | Iterable<ToString> | AsyncIterable<ToString>
+  iterable: string | Buffer | Iterable<ToString> | AsyncIterable<ToString>
 ): IteratorPlus<string> | AsyncIteratorPlus<string> {
   return typeof iterable === 'string' || Buffer.isBuffer(iterable)
     ? linesSync([iterable.toString()])
     : Symbol.iterator in iterable
     ? linesSync(iterable)
-    : Symbol.asyncIterator in iterable
-    ? linesAsync(iterable)
-    : linesSync([iterable.toString()]);
+    : linesAsync(iterable);
 }

--- a/libs/hmpb/layout/src/layout.ts
+++ b/libs/hmpb/layout/src/layout.ts
@@ -2,6 +2,7 @@ import {
   assert,
   assertDefined,
   iter,
+  lines,
   ok,
   range,
   Result,
@@ -73,7 +74,7 @@ function textWidth(text: string, fontStyle: FontStyle): number {
 
 function wrapLine(line: string, fontStyle: FontStyle, width: number): string[] {
   const words = line.split(' ');
-  const lines: string[] = [];
+  const results: string[] = [];
   let currentLine = '';
   for (const word of words) {
     const extendedLine =
@@ -81,16 +82,18 @@ function wrapLine(line: string, fontStyle: FontStyle, width: number): string[] {
     if (textWidth(extendedLine, fontStyle) <= width) {
       currentLine = extendedLine;
     } else {
-      lines.push(currentLine);
+      results.push(currentLine);
       currentLine = word;
     }
   }
-  lines.push(currentLine);
-  return lines;
+  results.push(currentLine);
+  return results;
 }
 
 function textWrap(text: string, fontStyle: FontStyle, width: number): string[] {
-  return text.split('\n').flatMap((line) => wrapLine(line, fontStyle, width));
+  return lines(text)
+    .flatMap((line) => wrapLine(line, fontStyle, width))
+    .toArray();
 }
 
 function textHeight(textLines: string[], fontStyle: FontStyle): number {
@@ -117,18 +120,18 @@ function TextBlock({
   let heightUsed = 0;
 
   for (const { text, fontStyle } of textGroups) {
-    const lines = textWrap(text, fontStyle, width);
+    const wrappedText = textWrap(text, fontStyle, width);
     textBoxes.push({
       type: 'TextBox',
       x: 0,
       y: heightUsed,
       width,
-      height: textHeight(lines, fontStyle) + fontStyle.lineHeight / 4,
-      textLines: lines,
+      height: textHeight(wrappedText, fontStyle) + fontStyle.lineHeight / 4,
+      textLines: wrappedText,
       ...fontStyle,
       align,
     });
-    heightUsed += textHeight(lines, fontStyle) + fontStyle.lineHeight / 4;
+    heightUsed += textHeight(wrappedText, fontStyle) + fontStyle.lineHeight / 4;
   }
 
   return {

--- a/libs/image-utils/test/utils.ts
+++ b/libs/image-utils/test/utils.ts
@@ -1,5 +1,6 @@
 import { Rect } from '@votingworks/types';
 import { createImageData } from 'canvas';
+import { lines } from '@votingworks/basics';
 import { int } from '../src';
 import { getImageChannelCount } from '../src/image_data';
 
@@ -87,11 +88,11 @@ export function makeImageData(
   decodePixel: (char: string, x: int, y: int) => number,
   channelCount: 1 | 4
 ): ImageData {
-  const rows = description
-    .split('\n')
+  const rows = lines(description)
     .map((row) => row.trim())
     .filter(Boolean)
-    .map((row) => row.split(''));
+    .map((row) => row.split(''))
+    .toArray();
   const height = rows.length;
   let width = 0;
   for (const row of rows) {

--- a/libs/monorepo-utils/src/pnpm.ts
+++ b/libs/monorepo-utils/src/pnpm.ts
@@ -1,4 +1,4 @@
-import { assert } from '@votingworks/basics';
+import { assert, lines } from '@votingworks/basics';
 import { execFileSync } from 'child_process';
 import { readFileSync } from 'fs';
 import { isAbsolute, join, relative } from 'path';
@@ -105,10 +105,10 @@ export function getWorkspacePackagePaths(root: string): string[] {
     ['recursive', 'list', '--depth=-1', '--porcelain'],
     { cwd: absoluteRootPath, encoding: 'utf-8' }
   );
-  return stdout
-    .split('\n')
+  return lines(stdout)
     .map((line) => relative(absoluteRootPath, line))
-    .filter((line) => line.length > 0);
+    .filter((line) => line.length > 0)
+    .toArray();
 }
 
 /**


### PR DESCRIPTION
## Overview
The changes made as part of this PR are fairly trivial examples where we're working on relatively small strings, so at best this is a minor improvement in semantic clarity and in correctness (splits on `\r\n` and `\n`). However, the real benefit comes when working on large files where we would previously read the whole file because it's easier. See below for an example.

Helps us avoid running afoul of the problem described in #4443.

## Demo Video or Screenshot
```ts
// old
const contents = fs.readFileSync(path, { encoding: 'utf8' });
const lines = contents.split('\n');
for (const line of lines) {
  …
}

// new
const input = fs.createReadStream(path, { encoding: 'utf8' });
for await (const line of lines(input)) {
  …
}
```

## Testing Plan
- [x] New automated tests for the feature.
- [x] Existing tests covering the refactor.
