### PR TITLE
docs: add exercises and docs for `iter`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -417,6 +417,29 @@ jobs:
       - store_test_results:
           path: apps/scan/frontend/reports/
 
+  # @votingworks/exercises
+  test-docs-exercises:
+    executor: nodejs
+    resource_class: xlarge
+    steps:
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            pnpm --dir docs/exercises build
+      - run:
+          name: Lint
+          command: |
+            pnpm --dir docs/exercises lint
+      - run:
+          name: Test
+          command: |
+            pnpm --dir docs/exercises test
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./reports/
+      - store_test_results:
+          path: docs/exercises/reports/
+
   # @votingworks/api
   test-libs-api:
     executor: nodejs
@@ -1186,6 +1209,7 @@ workflows:
       - test-apps-mark-integration-testing
       - test-apps-scan-backend
       - test-apps-scan-frontend
+      - test-docs-exercises
       - test-libs-api
       - test-libs-auth
       - test-libs-backend

--- a/docs/exercises/.eslintignore
+++ b/docs/exercises/.eslintignore
@@ -1,0 +1,3 @@
+build
+coverage
+jest.config.js

--- a/docs/exercises/.eslintrc.json
+++ b/docs/exercises/.eslintrc.json
@@ -1,0 +1,14 @@
+{
+  "extends": ["plugin:vx/recommended"],
+  "rules": {
+    "@typescript-eslint/no-unused-vars": "off",
+    "@typescript-eslint/no-use-before-define": "off",
+    "@typescript-eslint/require-await": "off",
+    "eqeqeq": "off",
+    "import/first": "off",
+    "import/order": "off",
+    "no-console": "off",
+    "vx/gts-jsdoc": "off",
+    "vx/gts-module-snake-case": "off"
+  }
+}

--- a/docs/exercises/01-iteration/01-toArray.exercise.ts
+++ b/docs/exercises/01-iteration/01-toArray.exercise.ts
@@ -1,0 +1,124 @@
+// 01-toArray.ts
+//
+// Task: Complete the `collect` function to use `iter` to collect the values
+// from the provided iterable into an array.
+//
+// Hint: look at the function signature for `iter` in @votingworks/basics.
+
+import { iter } from '@votingworks/basics';
+import { run } from '../src/example';
+import { TODO } from '../src/todo';
+
+function collect<T>(iterable: Iterable<T>): T[] {
+  TODO();
+}
+
+function collectReference<T>(iterable: Iterable<T>): T[] {
+  const values: T[] = [];
+
+  for (const value of iterable) {
+    values.push(value);
+  }
+
+  return values;
+}
+
+run({
+  makeInput: oneToTen,
+  referenceImplementation: collectReference,
+  exerciseImplementation: collect,
+  solutionImplementation: collectSolution,
+});
+
+function* oneToTen(): Generator<number> {
+  for (let i = 1; i <= 10; i += 1) {
+    yield i;
+  }
+}
+
+// Scroll down for solutions. ↓
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+// Solutions ↓
+
+// Use `iter` and the `toArray` method to collect the values. This is one of
+// several methods that consume the remaining values in an iterator.
+function collectSolution<T>(iterable: Iterable<T>): T[] {
+  return iter(iterable).toArray();
+}

--- a/docs/exercises/01-iteration/02-map.exercise.ts
+++ b/docs/exercises/01-iteration/02-map.exercise.ts
@@ -1,0 +1,125 @@
+// 02-map.ts
+//
+// Task: Complete the `convertAllCelsiusToFahrenheit` function using `iter` to convert
+// a list of celsius values to fahrenheit.
+//
+// Hint: what does `iter` return? What methods does it have?
+
+import { iter } from '@votingworks/basics';
+import { run } from '../src/example';
+import { TODO } from '../src/todo';
+import { collecting } from '../src/collecting';
+
+function convertCelsiusToFahrenheit(celsius: number): number {
+  return celsius * (9 / 5) + 32;
+}
+
+function convertAllCelsiusToFahrenheit(
+  celsiusValues: Iterable<number>
+): Iterable<number> {
+  TODO();
+}
+
+function convertAllCelsiusToFahrenheitReference(
+  celsiusValues: number[]
+): number[] {
+  return celsiusValues.map(convertCelsiusToFahrenheit);
+}
+
+const DAILY_MAXIMUM_CELSIUS_TEMPERATURES = [
+  20.0, 25.0, 18.0, 22.0, 27.0, 30.0, 28.0, 23.0, 19.0, 25.0,
+];
+
+run({
+  makeInput: () => DAILY_MAXIMUM_CELSIUS_TEMPERATURES,
+  referenceImplementation: convertAllCelsiusToFahrenheitReference,
+  exerciseImplementation: collecting(convertAllCelsiusToFahrenheit),
+  solutionImplementation: collecting(convertAllCelsiusToFahrenheitSolution),
+});
+
+// Scroll down for solutions. ↓
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+// Solutions ↓
+
+function convertAllCelsiusToFahrenheitSolution(
+  celsiusValues: Iterable<number>
+): Iterable<number> {
+  return iter(celsiusValues).map(convertCelsiusToFahrenheit);
+}

--- a/docs/exercises/01-iteration/03-filter.exercise.ts
+++ b/docs/exercises/01-iteration/03-filter.exercise.ts
@@ -1,0 +1,128 @@
+// 03-filter.ts
+//
+// Task: Complete the `filterNullish` function using `iter` to filter nullish
+// values from the provided iterable into an array.
+//
+//   For example, if the iterable is `[1, 2, null, 3, undefined, 4]`, the result
+//   should be `[1, 2, 3, 4]`.
+//
+// Hint: what does `iter` return? What methods does it have?
+
+import { iter } from '@votingworks/basics';
+import { TODO } from '../src/todo';
+import { run } from '../src/example';
+import { collecting } from '../src/collecting';
+
+function filterNullish<T>(iterable: Iterable<T>): Iterable<NonNullable<T>> {
+  TODO();
+}
+
+function filterNullishReference<T>(
+  iterable: Iterable<T>
+): Array<NonNullable<T>> {
+  const values: Array<NonNullable<T>> = [];
+
+  for (const value of iterable) {
+    if (value != null) {
+      values.push(value);
+    }
+  }
+
+  return values;
+}
+
+run({
+  makeInput: () => [1, 2, null, 3, undefined, 4],
+  referenceImplementation: filterNullishReference,
+  exerciseImplementation: filterNullish,
+  solutionImplementation: collecting(filterNullishSolution),
+});
+
+// Scroll down for solutions. ↓
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+// Solutions ↓
+
+function filterNullishSolution<T>(
+  iterable: Iterable<T>
+): Array<NonNullable<T>> {
+  return iter(iterable)
+    .filter((value): value is NonNullable<T> => value != null)
+    .toArray();
+}

--- a/docs/exercises/01-iteration/04-take.exercise.ts
+++ b/docs/exercises/01-iteration/04-take.exercise.ts
@@ -1,0 +1,131 @@
+// 04-take.ts
+//
+// Task: Complete the `takeFirst10` function using `iter` to take the first 10
+// values from the provided iterable into an array.
+//
+// Hint: `fibonacci` is an infinite iterable. What happens if you try to make an
+// array from it and then slice the first ten elements?
+
+import { iter } from '@votingworks/basics';
+import { TODO } from '../src/todo';
+import { run } from '../src/example';
+
+function takeFirst10<T>(iterable: Iterable<T>): T[] {
+  TODO();
+}
+
+function takeFirst10Reference<T>(iterable: Iterable<T>): T[] {
+  const values: T[] = [];
+
+  for (const value of iterable) {
+    if (values.length >= 10) {
+      break;
+    }
+
+    values.push(value);
+  }
+
+  return values;
+}
+
+run({
+  makeInput: fibonacci,
+  referenceImplementation: takeFirst10Reference,
+  exerciseImplementation: takeFirst10,
+  solutionImplementation: takeFirst10Solution,
+});
+
+function* fibonacci(): IterableIterator<number> {
+  let a = 0;
+  let b = 1;
+
+  for (;;) {
+    yield a;
+    [a, b] = [b, a + b];
+  }
+}
+
+// Scroll down for solutions. ↓
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+// Solutions ↓
+
+function takeFirst10Solution<T>(iterable: Iterable<T>): T[] {
+  return iter(iterable).take(10).toArray();
+}

--- a/docs/exercises/01-iteration/05-async.exercise.ts
+++ b/docs/exercises/01-iteration/05-async.exercise.ts
@@ -1,0 +1,119 @@
+// 04-async.ts
+//
+// Task: Complete the `countNonBlankLines` function using `lines` to count the
+// number of non-blank lines in the the file at a given path.
+//
+// Note: `lines` returns an `AsyncIterablePlus<string>`, which is an async
+// iterable. You can use the same set of methods on the async version as with
+// the sync version, but they return and accept promises instead of values.
+
+import { lines } from '@votingworks/basics';
+import { readFile } from 'fs/promises';
+import { TODO } from '../src/todo';
+import { run } from '../src/example';
+
+async function countNonBlankLines(path: string): Promise<number> {
+  TODO();
+}
+
+async function countNonBlankLinesReference(path: string): Promise<number> {
+  return (await readFile(path, 'utf8'))
+    .split('\n')
+    .filter((line) => line.trim() !== '').length;
+}
+
+run({
+  makeInput: () => __filename,
+  referenceImplementation: countNonBlankLinesReference,
+  exerciseImplementation: countNonBlankLines,
+  solutionImplementation: countNonBlankLinesSolution,
+});
+
+// Scroll down for solutions. ↓
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+// Solutions ↓
+
+import { createReadStream } from 'fs';
+
+async function countNonBlankLinesSolution(path: string): Promise<number> {
+  return lines(createReadStream(path, 'utf8'))
+    .filter((line) => line.trim() !== '')
+    .count();
+}

--- a/docs/exercises/01-iteration/06-json.exercise.ts
+++ b/docs/exercises/01-iteration/06-json.exercise.ts
@@ -1,0 +1,146 @@
+// 05-jsonStream.ts
+//
+// Task: Complete the `extractNamesFromContacts` function using `iter` to return
+// JSON with an array of names from a large list of contacts.
+//
+// Hint: A naive implementation using `iter` would still collect all of the
+// names in memory in order to JSON stringify them. Can you do better?
+
+import { iter } from '@votingworks/basics';
+import { TODO } from '../src/todo';
+import { run } from '../src/example';
+
+async function extractNamesFromContacts(): Promise<string> {
+  TODO();
+}
+
+async function extractNamesFromContactsReference(): Promise<string> {
+  const names: string[] = [];
+
+  for await (const { name } of getListOfContactsFromDatabase()) {
+    names.push(name);
+  }
+
+  return JSON.stringify(names);
+}
+
+interface Contact {
+  name: string;
+  email: string;
+}
+
+function* getListOfContactsFromDatabase(): Generator<Contact> {
+  for (let i = 0; i < 100_000; i += 1) {
+    yield {
+      name: `Person ${i}`,
+      email: `person${i}@example.com`,
+    };
+  }
+}
+
+run({
+  makeInput: () => undefined,
+  referenceImplementation: extractNamesFromContactsReference,
+  exerciseImplementation: extractNamesFromContacts,
+  solutionImplementation: extractNamesFromContactsSolution,
+});
+
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+
+import { jsonStream } from '@votingworks/utils';
+
+// This is the real solution, but we wrap it in the function below to make it
+// have the same signature as the other functions in this exercise.
+function extractNamesFromContactsSolutionInner(): AsyncGenerator<string> {
+  return jsonStream(
+    iter(getListOfContactsFromDatabase()).map(({ name }) => name)
+  );
+}
+
+// This wrapper just converts the AsyncGenerator<string> to a Promise<string>, but
+// in a real application you would want to use the AsyncGenerator directly. Otherwise
+// you would be building up a huge string in memory.
+async function extractNamesFromContactsSolution(): Promise<string> {
+  return (await iter(extractNamesFromContactsSolutionInner()).toArray()).join(
+    ''
+  );
+}

--- a/docs/exercises/01-iteration/07-math.exercise.ts
+++ b/docs/exercises/01-iteration/07-math.exercise.ts
@@ -1,0 +1,181 @@
+// 07-math.ts
+//
+// Task: Complete the `computeMin`, `computeMax`, and `computeAverage` functions
+// using `iter` to compute the minimum, maximum, and average of the provided
+// array.
+//
+//   For example, if the array is `[1, 2, 3, 4]`, the result should be
+//   `{ min: 1, max: 4, average: 2.5 }`.
+//
+// Hint: what does `iter` return? What methods does it have?
+
+import { Optional, iter } from '@votingworks/basics';
+import { TODO } from '../src/todo';
+import { run } from '../src/example';
+
+function computeMin(values: number[]): Optional<number> {
+  TODO();
+}
+
+function computeMax(values: number[]): Optional<number> {
+  TODO();
+}
+
+function computeAverage(values: number[]): Optional<number> {
+  TODO();
+}
+
+function computeMinReference(values: number[]): Optional<number> {
+  let min: Optional<number>;
+
+  for (const value of values) {
+    if (min === undefined || value < min) {
+      min = value;
+    }
+  }
+
+  return min;
+}
+
+function computeMaxReference(values: number[]): Optional<number> {
+  let max: Optional<number>;
+
+  for (const value of values) {
+    if (max === undefined || value > max) {
+      max = value;
+    }
+  }
+
+  return max;
+}
+
+function computeAverageReference(values: number[]): Optional<number> {
+  if (values.length === 0) {
+    return undefined;
+  }
+
+  let sum = 0;
+
+  for (const value of values) {
+    sum += value;
+  }
+
+  return sum / values.length;
+}
+
+run({
+  name: 'min',
+  makeInput: () => [1, 2, 3, 4],
+  referenceImplementation: computeMinReference,
+  exerciseImplementation: computeMin,
+  solutionImplementation: computeMinSolution,
+});
+
+run({
+  name: 'max',
+  makeInput: () => [1, 2, 3, 4],
+  referenceImplementation: computeMaxReference,
+  exerciseImplementation: computeMax,
+  solutionImplementation: computeMaxSolution,
+});
+
+run({
+  name: 'average',
+  makeInput: () => [1, 2, 3, 4],
+  referenceImplementation: computeAverageReference,
+  exerciseImplementation: computeAverage,
+  solutionImplementation: computeAverageSolution,
+});
+
+// Scroll down for solutions. ↓
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+// Solutions ↓
+
+function computeMinSolution(values: number[]): Optional<number> {
+  return iter(values).min();
+}
+
+function computeMaxSolution(values: number[]): Optional<number> {
+  return iter(values).max();
+}
+
+function computeAverageSolution(values: number[]): Optional<number> {
+  return iter(values).sum() / values.length;
+}

--- a/docs/exercises/01-iteration/08-advanced.exercise.ts
+++ b/docs/exercises/01-iteration/08-advanced.exercise.ts
@@ -1,0 +1,223 @@
+// 08-advanced.ts
+//
+// Task: Complete the functions below to compute the relevant statistics for the
+// provided weather data.
+//
+
+import { Optional, assertDefined, iter, typedAs } from '@votingworks/basics';
+import { TODO } from '../src/todo';
+import { run } from '../src/example';
+import { collecting } from '../src/collecting';
+
+function consecutiveDayTemperatureDifferences(
+  celsiusValues: Iterable<number>
+): Iterable<number> {
+  TODO();
+}
+
+function* consecutiveDayTemperatureDifferencesReference(
+  celsiusValues: Iterable<number>
+): Iterable<number> {
+  let previousValue: Optional<number>;
+
+  for (const value of celsiusValues) {
+    if (previousValue !== undefined) {
+      yield value - previousValue;
+    }
+
+    previousValue = value;
+  }
+}
+
+interface IdentifyHeatWavesInput {
+  values: Iterable<number>;
+  threshold: number;
+  length: number;
+}
+
+function identifyHeatWaves({
+  values,
+  threshold,
+  length,
+}: IdentifyHeatWavesInput): Iterable<number> {
+  TODO();
+}
+
+function* identifyHeatWavesReference({
+  values,
+  threshold,
+  length,
+}: IdentifyHeatWavesInput): Iterable<number> {
+  let heatWaveStart: Optional<number>;
+  let currentIndex = 0;
+
+  for (const value of values) {
+    if (value >= threshold) {
+      heatWaveStart ??= currentIndex;
+    }
+
+    if (heatWaveStart !== undefined && currentIndex - heatWaveStart >= length) {
+      yield currentIndex - length;
+    }
+
+    if (value < threshold) {
+      heatWaveStart = undefined;
+    }
+
+    currentIndex += 1;
+  }
+
+  if (heatWaveStart !== undefined && currentIndex - heatWaveStart >= length) {
+    yield currentIndex - length;
+  }
+}
+
+const DAILY_MAXIMUM_CELSIUS_TEMPERATURES = [
+  20.0, 25.0, 18.0, 22.0, 27.0, 30.0, 28.0, 23.0, 19.0, 25.0,
+];
+const HIGH_TEMPERATURE_CELSIUS_THRESHOLD = 25;
+
+run({
+  name: 'consecutiveDayTemperatureDifferences',
+  makeInput: () => DAILY_MAXIMUM_CELSIUS_TEMPERATURES,
+  referenceImplementation: collecting(
+    consecutiveDayTemperatureDifferencesReference
+  ),
+  exerciseImplementation: collecting(consecutiveDayTemperatureDifferences),
+  solutionImplementation: collecting(
+    consecutiveDayTemperatureDifferencesSolution
+  ),
+});
+
+run({
+  name: 'identifyHeatWaves (length 3, min 25°C)',
+  makeInput: () =>
+    typedAs<IdentifyHeatWavesInput>({
+      values: DAILY_MAXIMUM_CELSIUS_TEMPERATURES,
+      threshold: HIGH_TEMPERATURE_CELSIUS_THRESHOLD,
+      length: 3,
+    }),
+  referenceImplementation: collecting(identifyHeatWavesReference),
+  exerciseImplementation: collecting(identifyHeatWaves),
+  solutionImplementation: collecting(identifyHeatWavesSolution),
+});
+
+run({
+  name: 'identifyHeatWaves (length 4, min 20°C)',
+  makeInput: () =>
+    typedAs<IdentifyHeatWavesInput>({
+      values: DAILY_MAXIMUM_CELSIUS_TEMPERATURES,
+      threshold: 20,
+      length: 4,
+    }),
+  referenceImplementation: collecting(identifyHeatWavesReference),
+  exerciseImplementation: collecting(identifyHeatWaves),
+  solutionImplementation: collecting(identifyHeatWavesSolution),
+});
+
+// Scroll down for solutions. ↓
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+// Solutions ↓
+
+// Use `windows` to get pairs of adjacent elements, then `map` to compute the
+// difference for each pair.
+function consecutiveDayTemperatureDifferencesSolution(
+  celsiusValues: Iterable<number>
+): Iterable<number> {
+  return iter(celsiusValues)
+    .windows(2)
+    .map(([previous, current]) => current - previous);
+}
+
+// Use `enumerate` to pair each value with its index, then look at each
+// consecutive window of the specified length and filter to only those windows
+// where every value is greater than or equal to the threshold. Finally, use
+// `map` to extract the index of the first value in each window.
+function identifyHeatWavesSolution({
+  values,
+  threshold,
+  length,
+}: IdentifyHeatWavesInput): Iterable<number> {
+  return iter(values)
+    .enumerate()
+    .windows(length)
+    .filter((window) => window.every(([, value]) => value >= threshold))
+    .map((window) => assertDefined(window[0])[0]);
+}

--- a/docs/exercises/README.md
+++ b/docs/exercises/README.md
@@ -1,0 +1,13 @@
+# Code Exercises for VxSuite
+
+This project contains a set of exercises to help you learn how to use the
+VxSuite libraries.
+
+## Running the Exercises
+
+To get started, set up the VxSuite repository as usual. Then, in this directory,
+run `pnpm test`. This will run the tests for all of the exercises. By default in
+watch mode, Jest will not run anything because no files have been changed. You
+can use the Jest CLI to run the tests for a specific exercise, e.g.
+`pnpm jest --watch 01-iteration/01-toArray.exercise.ts`. I recommend running
+with `--watch` so that you can see the tests update as you make changes.

--- a/docs/exercises/jest.config.js
+++ b/docs/exercises/jest.config.js
@@ -1,0 +1,9 @@
+const shared = require('../../jest.config.shared');
+
+/**
+ * @type {import('@jest/types').Config.InitialOptions}
+ */
+module.exports = {
+  ...shared,
+  testMatch: ['<rootDir>/**/*.exercise.ts'],
+};

--- a/docs/exercises/package.json
+++ b/docs/exercises/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@votingworks/exercises",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Code exercises",
+  "license": "GPL-3.0-or-later",
+  "author": "VotingWorks Eng <eng@voting.works>",
+  "scripts": {
+    "build": "pnpm type-check",
+    "clean": "echo 'Nothing to clean'",
+    "lint": "pnpm type-check && eslint .",
+    "lint:fix": "pnpm type-check && eslint . --fix",
+    "pre-commit": "lint-staged",
+    "test": "is-ci test:ci test:watch",
+    "test:ci": "jest",
+    "test:coverage": "TZ=UTC jest --coverage",
+    "test:watch": "TZ=UTC jest --watch",
+    "type-check": "tsc --build"
+  },
+  "lint-staged": {
+    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
+      "prettier --write"
+    ],
+    "*.+(js|jsx|ts|tsx)": [
+      "eslint --quiet --fix"
+    ],
+    "package.json": [
+      "sort-package-json"
+    ]
+  },
+  "dependencies": {
+    "@types/jest": "^29.5.3",
+    "@types/node": "16.18.23",
+    "@votingworks/basics": "workspace:*",
+    "@votingworks/utils": "workspace:*",
+    "eslint-plugin-vx": "workspace:*",
+    "is-ci-cli": "2.2.0",
+    "jest": "^29.6.2",
+    "jest-junit": "^16.0.0",
+    "jest-watch-typeahead": "^2.2.2",
+    "lint-staged": "11.0.0",
+    "sort-package-json": "^1.50.0",
+    "ts-jest": "29.1.1"
+  }
+}

--- a/docs/exercises/package.json
+++ b/docs/exercises/package.json
@@ -41,5 +41,6 @@
     "lint-staged": "11.0.0",
     "sort-package-json": "^1.50.0",
     "ts-jest": "29.1.1"
-  }
+  },
+  "packageManager": "pnpm@8.1.0"
 }

--- a/docs/exercises/src/collecting.ts
+++ b/docs/exercises/src/collecting.ts
@@ -1,0 +1,5 @@
+export function collecting<I, T>(
+  fn: (input: I) => Iterable<T>
+): (input: I) => T[] {
+  return (input) => Array.from(fn(input));
+}

--- a/docs/exercises/src/example.ts
+++ b/docs/exercises/src/example.ts
@@ -1,0 +1,28 @@
+import { MaybePromise } from '@votingworks/basics';
+
+export function run<I, T extends (input: I) => MaybePromise<unknown>>({
+  name = 'example',
+  makeInput,
+  referenceImplementation,
+  exerciseImplementation,
+  solutionImplementation,
+}: {
+  name?: string;
+  makeInput: () => MaybePromise<I>;
+  referenceImplementation: T;
+  exerciseImplementation: T;
+  solutionImplementation: T;
+}): void {
+  test(name, async () => {
+    const referenceResult = await referenceImplementation(await makeInput());
+    const solutionResult = await solutionImplementation(await makeInput());
+    expect(referenceResult).toEqual(solutionResult);
+
+    if (process.env['CI']) {
+      return;
+    }
+
+    const exerciseResult = await exerciseImplementation(await makeInput());
+    expect(referenceResult).toEqual(exerciseResult);
+  });
+}

--- a/docs/exercises/src/todo.ts
+++ b/docs/exercises/src/todo.ts
@@ -1,0 +1,3 @@
+export function TODO(): never {
+  throw new Error('TODO: not implemented');
+}

--- a/docs/exercises/tsconfig.json
+++ b/docs/exercises/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.shared.json",
+  "include": ["**/*.ts"],
+  "exclude": [],
+  "compilerOptions": {
+    "module": "node16",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "composite": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noPropertyAccessFromIndexSignature": false
+  },
+  "references": [
+    { "path": "../../libs/basics/tsconfig.build.json" },
+    { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
+    { "path": "../../libs/utils/tsconfig.build.json" }
+  ]
+}

--- a/libs/utils/src/json_stream.ts
+++ b/libs/utils/src/json_stream.ts
@@ -43,17 +43,18 @@ export type JsonStreamInput<T> =
  * @example
  *
  * ```ts
+ * import { createWriteStream } from 'fs';
+ * import { Readable } from 'stream';
+ *
  * function* generateLargeArray() {
  *   for (let i = 0; i < 1_000_000_000; i++) {
  *     yield i;
  *   }
  * }
  *
- * const stream = jsonStream({ foo: [1, 2, 3], bar: generateLargeArray() });
- * const writer = createWriteStream('output.json');
- * for (const chunk of stream) {
- *  writer.write(chunk);
- * }
+ * Readable.from(jsonStream({ foo: [1, 2, 3], bar: generateLargeArray() })).pipe(
+ *   createWriteStream('output.json')
+ * );
  * ```
  */
 export async function* jsonStream<T>(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2660,6 +2660,45 @@ importers:
         specifier: 1.0.6
         version: 1.0.6(debug@4.3.4)
 
+  docs/exercises:
+    dependencies:
+      '@types/jest':
+        specifier: ^29.5.3
+        version: 29.5.3
+      '@types/node':
+        specifier: 16.18.23
+        version: 16.18.23
+      '@votingworks/basics':
+        specifier: workspace:*
+        version: link:../../libs/basics
+      '@votingworks/utils':
+        specifier: workspace:*
+        version: link:../../libs/utils
+      eslint-plugin-vx:
+        specifier: workspace:*
+        version: link:../../libs/eslint-plugin-vx
+      is-ci-cli:
+        specifier: 2.2.0
+        version: 2.2.0
+      jest:
+        specifier: ^29.6.2
+        version: 29.6.2(@types/node@16.18.23)
+      jest-junit:
+        specifier: ^16.0.0
+        version: 16.0.0
+      jest-watch-typeahead:
+        specifier: ^2.2.2
+        version: 2.2.2(jest@29.6.2)
+      lint-staged:
+        specifier: 11.0.0
+        version: 11.0.0
+      sort-package-json:
+        specifier: ^1.50.0
+        version: 1.50.0
+      ts-jest:
+        specifier: 29.1.1
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+
   libs/@types/compress-commons:
     dependencies:
       '@types/readable-stream':
@@ -6357,7 +6396,17 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.18.6
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
+
+  /@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.20.12):
+    resolution: {integrity: sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.20.12
+      '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
   /@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.22.9):
@@ -7261,7 +7310,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
   /@babel/plugin-transform-react-jsx-source@7.18.6(@babel/core@7.20.12):
@@ -7308,7 +7357,7 @@ packages:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-module-imports': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.20.12)
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.20.12)
       '@babel/types': 7.22.10
     dev: true
 
@@ -8736,7 +8785,7 @@ packages:
       chalk: 4.1.2
       ci-info: 3.8.0
       exit: 0.1.2
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       jest-changed-files: 29.5.0
       jest-config: 29.6.2(@types/node@16.18.23)
       jest-haste-map: 29.6.2
@@ -10842,7 +10891,6 @@ packages:
     dependencies:
       '@types/minimatch': 5.1.2
       '@types/node': 16.18.23
-    dev: true
 
   /@types/graceful-fs@4.1.6:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
@@ -10906,7 +10954,6 @@ packages:
     dependencies:
       expect: 29.6.2
       pretty-format: 29.6.2
-    dev: true
 
   /@types/jsdom@20.0.0:
     resolution: {integrity: sha512-YfAchFs0yM1QPDrLm2VHe+WHGtqms3NXnXAMolrgrVP6fgBHHXy1ozAbo/dFtPNtZC/m66bPiCTWYmqp1F14gA==}
@@ -11017,7 +11064,6 @@ packages:
 
   /@types/minimatch@5.1.2:
     resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
-    dev: true
 
   /@types/minimist@1.2.2:
     resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
@@ -11898,7 +11944,6 @@ packages:
     dependencies:
       clean-stack: 2.2.0
       indent-string: 4.0.0
-    dev: true
 
   /ajv-draft-04@1.0.0(ajv@8.12.0):
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
@@ -11945,7 +11990,6 @@ packages:
   /ansi-colors@4.1.1:
     resolution: {integrity: sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==}
     engines: {node: '>=6'}
-    dev: true
 
   /ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
@@ -11958,7 +12002,6 @@ packages:
     engines: {node: '>=14.16'}
     dependencies:
       type-fest: 3.13.1
-    dev: true
 
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -11967,7 +12010,6 @@ packages:
   /ansi-regex@6.0.1:
     resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
     engines: {node: '>=12'}
-    dev: true
 
   /ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
@@ -12233,7 +12275,6 @@ packages:
   /astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /async-each@1.0.6:
     resolution: {integrity: sha512-c646jH1avxr+aVpndVMeAfYw7wAa6idufrlN3LPA4PmKS0QEGp6PIC9nwz0WQkkvBGAMEki3pFdtxaF39J9vvg==}
@@ -12712,7 +12753,6 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       fast-json-stable-stringify: 2.1.0
-    dev: true
 
   /bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
@@ -12934,7 +12974,6 @@ packages:
   /chalk@5.3.0:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-    dev: true
 
   /char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
@@ -12943,7 +12982,6 @@ packages:
   /char-regex@2.0.1:
     resolution: {integrity: sha512-oSvEeo6ZUD7NepqAat3RqoucZ5SeqLJgOvVIwkafu6IP3V0pO38s/ypdVUmDDK6qIIHNlYHJAKX9E7R7HoKElw==}
     engines: {node: '>=12.20'}
-    dev: true
 
   /cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
@@ -13017,7 +13055,6 @@ packages:
 
   /ci-info@2.0.0:
     resolution: {integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==}
-    dev: true
 
   /ci-info@3.8.0:
     resolution: {integrity: sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==}
@@ -13044,7 +13081,6 @@ packages:
   /clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
-    dev: true
 
   /clear-cut@2.0.2:
     resolution: {integrity: sha512-WVgn/gSejQ+0aoR8ucbKIdo6icduPZW6AbWwyUmAUgxy63rUYjwa5rj/HeoNPhf0/XPrl82X8bO/hwBkSmsFtg==}
@@ -13055,7 +13091,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       restore-cursor: 3.1.0
-    dev: true
 
   /cli-spinners@2.5.0:
     resolution: {integrity: sha512-PC+AmIuK04E6aeSs/pUccSujsTzBhu4HzC2dL+CfJB/Jcc2qTRbEwZQDfIUpt2Xl8BodYBEq8w4fc0kU2I9DjQ==}
@@ -13077,7 +13112,6 @@ packages:
     dependencies:
       slice-ansi: 3.0.0
       string-width: 4.2.3
-    dev: true
 
   /cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
@@ -13177,7 +13211,6 @@ packages:
 
   /colorette@2.0.19:
     resolution: {integrity: sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==}
-    dev: true
 
   /colors@1.4.0:
     resolution: {integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==}
@@ -13206,7 +13239,6 @@ packages:
   /commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
-    dev: true
 
   /commander@9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
@@ -13715,7 +13747,6 @@ packages:
 
   /dedent@0.7.0:
     resolution: {integrity: sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==}
-    dev: true
 
   /dedent@1.3.0:
     resolution: {integrity: sha512-7glNLfvdsMzZm3FpRY1CHuI2lbYDR+71YmrhmTZjYFD5pfT0ACgnGRdrrC9Mk2uICnzkcdelCx5at787UDGOvg==}
@@ -13873,7 +13904,6 @@ packages:
   /detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
-    dev: true
 
   /detect-libc@2.0.1:
     resolution: {integrity: sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==}
@@ -14114,7 +14144,6 @@ packages:
     engines: {node: '>=8.6'}
     dependencies:
       ansi-colors: 4.1.1
-    dev: true
 
   /ensure-posix-path@1.1.1:
     resolution: {integrity: sha512-VWU0/zXzVbeJNXvME/5EmLuEj2TauvoaTz6aFYK1Z92JCBlDlZ3Gu0tuGR42kpW1754ywTs+QB0g5TP0oj9Zaw==}
@@ -15738,7 +15767,6 @@ packages:
 
   /get-own-enumerable-property-symbols@3.0.2:
     resolution: {integrity: sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==}
-    dev: true
 
   /get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
@@ -15797,7 +15825,6 @@ packages:
 
   /git-hooks-list@1.0.3:
     resolution: {integrity: sha512-Y7wLWcrLUXwk2noSka166byGCvhMtDRpgHdzCno1UQv/n/Hegp++a2xBWJL1lJarnKD3SWaljD+0z1ztqxuKyQ==}
-    dev: true
 
   /github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
@@ -15929,7 +15956,6 @@ packages:
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
-    dev: true
 
   /globby@11.0.4:
     resolution: {integrity: sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==}
@@ -16488,7 +16514,6 @@ packages:
   /indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
-    dev: true
 
   /indent-string@5.0.0:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
@@ -16626,14 +16651,12 @@ packages:
     dependencies:
       cross-spawn: 7.0.3
       is-ci: 2.0.0
-    dev: true
 
   /is-ci@2.0.0:
     resolution: {integrity: sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==}
     hasBin: true
     dependencies:
       ci-info: 2.0.0
-    dev: true
 
   /is-core-module@2.10.0:
     resolution: {integrity: sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==}
@@ -16811,7 +16834,6 @@ packages:
   /is-obj@1.0.1:
     resolution: {integrity: sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /is-path-cwd@2.2.0:
     resolution: {integrity: sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==}
@@ -16830,7 +16852,6 @@ packages:
   /is-plain-obj@2.1.0:
     resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
     engines: {node: '>=8'}
-    dev: true
 
   /is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
@@ -16861,7 +16882,6 @@ packages:
   /is-regexp@1.0.0:
     resolution: {integrity: sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /is-relative@1.0.0:
     resolution: {integrity: sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==}
@@ -16921,7 +16941,6 @@ packages:
   /is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
-    dev: true
 
   /is-utf8@0.2.1:
     resolution: {integrity: sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==}
@@ -17275,7 +17294,6 @@ packages:
       strip-ansi: 6.0.1
       uuid: 8.3.2
       xml: 1.0.1
-    dev: true
 
   /jest-leak-detector@29.6.2:
     resolution: {integrity: sha512-aNqYhfp5uYEO3tdWMb2bfWv6f0b4I0LOxVRpnRLAeque2uqOVVMLh6khnTcE2qJ5wAKop0HcreM1btoysD6bPQ==}
@@ -17502,7 +17520,6 @@ packages:
       slash: 5.1.0
       string-length: 5.0.1
       strip-ansi: 7.1.0
-    dev: true
 
   /jest-watcher@29.6.2:
     resolution: {integrity: sha512-GZitlqkMkhkefjfN/p3SJjrDaxPflqxEAv3/ik10OirZqJGYH5rPiIsgVcfof0Tdqg3shQGdEIxDBx+B4tuLzA==}
@@ -17874,7 +17891,6 @@ packages:
       stringify-object: 3.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /listr2@3.14.0(enquirer@2.3.6):
     resolution: {integrity: sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==}
@@ -17894,7 +17910,6 @@ packages:
       rxjs: 7.8.1
       through: 2.3.8
       wrap-ansi: 7.0.0
-    dev: true
 
   /loader-runner@2.4.0:
     resolution: {integrity: sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==}
@@ -17964,7 +17979,6 @@ packages:
 
   /lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
-    dev: true
 
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -18005,7 +18019,6 @@ packages:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
-    dev: true
 
   /log-update@4.0.0:
     resolution: {integrity: sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==}
@@ -18015,7 +18028,6 @@ packages:
       cli-cursor: 3.1.0
       slice-ansi: 4.0.0
       wrap-ansi: 6.2.0
-    dev: true
 
   /long@5.2.3:
     resolution: {integrity: sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==}
@@ -18099,7 +18111,6 @@ packages:
 
   /make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
-    dev: true
 
   /makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
@@ -19029,7 +19040,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       aggregate-error: 3.1.0
-    dev: true
 
   /p-timeout@3.2.0:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
@@ -19298,7 +19308,6 @@ packages:
     resolution: {integrity: sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==}
     dependencies:
       semver-compare: 1.0.0
-    dev: true
 
   /pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -20507,7 +20516,6 @@ packages:
     dependencies:
       onetime: 5.1.2
       signal-exit: 3.0.7
-    dev: true
 
   /restructure@2.0.1:
     resolution: {integrity: sha512-e0dOpjm5DseomnXx2M5lpdZ5zoHqF1+bqdMJUohoYVVQa7cBdnk7fdmeI6byNWP/kiME72EeTiSypTCVnpLiDg==}
@@ -20536,7 +20544,6 @@ packages:
 
   /rfdc@1.3.0:
     resolution: {integrity: sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==}
-    dev: true
 
   /rgb@0.1.0:
     resolution: {integrity: sha512-F49dXX73a92N09uQkfCp2QjwXpmJcn9/i9PvjmwsSIXUGqRLCf/yx5Q9gRxuLQTq248kakqQuc8GX/U/CxSqlA==}
@@ -20676,7 +20683,6 @@ packages:
 
   /semver-compare@1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
-    dev: true
 
   /semver@5.7.1:
     resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
@@ -20874,7 +20880,6 @@ packages:
   /slash@5.1.0:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
     engines: {node: '>=14.16'}
-    dev: true
 
   /slice-ansi@3.0.0:
     resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
@@ -20883,7 +20888,6 @@ packages:
       ansi-styles: 4.3.0
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
-    dev: true
 
   /slice-ansi@4.0.0:
     resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
@@ -20892,7 +20896,6 @@ packages:
       ansi-styles: 4.3.0
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
-    dev: true
 
   /snapdragon-node@2.1.1:
     resolution: {integrity: sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==}
@@ -20932,7 +20935,6 @@ packages:
 
   /sort-object-keys@1.1.3:
     resolution: {integrity: sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==}
-    dev: true
 
   /sort-package-json@1.50.0:
     resolution: {integrity: sha512-qZpqhMU9XTntebgAgc4hv/D6Fzhh7kFnwvV6a7+q8y8J5JoaDqPYQnvXPf7BBqG95tdE8X6JVNo7/jDzcbdfUg==}
@@ -20944,7 +20946,6 @@ packages:
       globby: 10.0.0
       is-plain-obj: 2.1.0
       sort-object-keys: 1.1.3
-    dev: true
 
   /sort-package-json@1.53.1:
     resolution: {integrity: sha512-ltLORrQuuPMpy23YkWCA8fO7zBOxM4P1j9LcGxci4K2Fk8jmSyCA/ATU6CFyy8qR2HQRx4RBYWzoi78FU/Anuw==}
@@ -21157,7 +21158,6 @@ packages:
   /string-argv@0.3.1:
     resolution: {integrity: sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==}
     engines: {node: '>=0.6.19'}
-    dev: true
 
   /string-length@4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
@@ -21172,7 +21172,6 @@ packages:
     dependencies:
       char-regex: 2.0.1
       strip-ansi: 7.1.0
-    dev: true
 
   /string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -21239,7 +21238,6 @@ packages:
       get-own-enumerable-property-symbols: 3.0.2
       is-obj: 1.0.1
       is-regexp: 1.0.0
-    dev: true
 
   /strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -21252,7 +21250,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       ansi-regex: 6.0.1
-    dev: true
 
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -21681,7 +21678,6 @@ packages:
 
   /through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
-    dev: true
 
   /timers-browserify@2.0.12:
     resolution: {integrity: sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==}
@@ -21905,7 +21901,6 @@ packages:
       semver: 7.5.4
       typescript: 5.2.2
       yargs-parser: 21.1.1
-    dev: true
 
   /tsconfig-paths@3.14.1:
     resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}
@@ -22004,7 +21999,6 @@ packages:
   /type-fest@3.13.1:
     resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
     engines: {node: '>=14.16'}
-    dev: true
 
   /type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -22357,7 +22351,6 @@ packages:
   /uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
-    dev: true
 
   /uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
@@ -22779,7 +22772,6 @@ packages:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-    dev: true
 
   /wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -22856,7 +22848,6 @@ packages:
 
   /xml@1.0.1:
     resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
-    dev: true
 
   /xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,3 +16,6 @@ packages:
   # include top-level development project
   - 'codemods'
   - 'script'
+
+  # code exercises
+  - 'docs/exercises'


### PR DESCRIPTION
## Overview
Adds some interactive exercises to teach the basics of using `iter`. Also updates the best practices doc with some specific reasons to use the iteration helpers.

## Demo Video or Screenshot
One of the intermediate `iter` exercises:

```ts
// 04-async.ts
//
// Task: Complete the `countNonBlankLines` function using `lines` to count the
// number of non-blank lines in the the file at a given path.
//
// Note: `lines` returns an `AsyncIterablePlus<string>`, which is an async
// iterable. You can use the same set of methods on the async version as with
// the sync version, but they return and accept promises instead of values.

import { lines } from '@votingworks/basics';
import { readFile } from 'fs/promises';
import { TODO } from '../src/todo';
import { run } from '../src/example';

async function countNonBlankLines(path: string): Promise<number> {
  TODO();
}

async function countNonBlankLinesReference(path: string): Promise<number> {
  return (await readFile(path, 'utf8'))
    .split('\n')
    .filter((line) => line.trim() !== '').length;
}
```

## Testing Plan
- [x] Added new automated tests that validates that the exercises compile and produces the expected values.