### PR TITLE
Iter exercises tweak and addition

### DIFF
--- a/docs/exercises/01-iteration/03-filter.exercise.ts
+++ b/docs/exercises/01-iteration/03-filter.exercise.ts
@@ -13,7 +13,7 @@ import { TODO } from '../src/todo';
 import { run } from '../src/example';
 import { collecting } from '../src/collecting';
 
-function filterNullish<T>(iterable: Iterable<T>): Iterable<NonNullable<T>> {
+function filterNullish<T>(iterable: Iterable<T>): Array<NonNullable<T>> {
   TODO();
 }
 
@@ -33,8 +33,8 @@ function filterNullishReference<T>(
 
 run({
   makeInput: () => [1, 2, null, 3, undefined, 4],
-  referenceImplementation: filterNullishReference,
-  exerciseImplementation: filterNullish,
+  referenceImplementation: collecting(filterNullishReference),
+  exerciseImplementation: collecting(filterNullish),
   solutionImplementation: collecting(filterNullishSolution),
 });
 
@@ -121,8 +121,8 @@ run({
 
 function filterNullishSolution<T>(
   iterable: Iterable<T>
-): Array<NonNullable<T>> {
-  return iter(iterable)
-    .filter((value): value is NonNullable<T> => value != null)
-    .toArray();
+): Iterable<NonNullable<T>> {
+  return iter(iterable).filter(
+    (value): value is NonNullable<T> => value != null
+  );
 }

--- a/docs/exercises/01-iteration/09-image-diff.exercise.ts
+++ b/docs/exercises/01-iteration/09-image-diff.exercise.ts
@@ -1,0 +1,177 @@
+// 09-image-diff.ts
+//
+// Task: Given streaming pixel data from two images, produce an image matrix (2d
+// array) that identifies pixels that don't match. The images are guaranteed to
+// have the same dimensions.
+//
+
+import { iter, typedAs } from '@votingworks/basics';
+import { TODO } from '../src/todo';
+import { run } from '../src/example';
+import { collecting } from '../src/collecting';
+
+type Pixel = number; // Value from 0 to 255, representing a shade of gray
+
+type ImageStream = Iterable<Pixel>;
+
+interface Dimensions {
+  width: number;
+  height: number;
+}
+
+type Diff = Array<boolean[]>; // True means the pixels match, false means they don't
+
+interface DiffImagesInput {
+  dimensions: Dimensions;
+  image1: ImageStream;
+  image2: ImageStream;
+}
+
+function diffImages({ dimensions, image1, image2 }: DiffImagesInput): Diff {
+  TODO();
+}
+
+function diffImagesReference({
+  dimensions,
+  image1,
+  image2,
+}: DiffImagesInput): Diff {
+  const diff: Diff = [];
+  const image1Iterator = image1[Symbol.iterator]();
+  const image2Iterator = image2[Symbol.iterator]();
+
+  for (let y = 0; y < dimensions.height; y += 1) {
+    const row = [];
+
+    for (let x = 0; x < dimensions.width; x += 1) {
+      const pixel1 = image1Iterator.next().value;
+      const pixel2 = image2Iterator.next().value;
+
+      row.push(pixel1 === pixel2);
+    }
+
+    diff.push(row);
+  }
+
+  return diff;
+}
+
+const DIMENSIONS: Dimensions = {
+  width: 2,
+  height: 4,
+};
+const IMAGE_1 = [0, 255, 255, 0, 100, 150, 0, 255];
+const IMAGE_2 = [0, 255, 0, 0, 100, 255, 255, 0];
+
+// Expected diff: [
+//   [true, true],
+//   [false, true],
+//   [true, false],
+//   [false, false],
+// ]
+
+run({
+  name: 'diffImages',
+  makeInput: () =>
+    typedAs<DiffImagesInput>({
+      dimensions: DIMENSIONS,
+      image1: IMAGE_1,
+      image2: IMAGE_2,
+    }),
+  referenceImplementation: collecting(diffImagesReference),
+  exerciseImplementation: collecting(diffImages),
+  solutionImplementation: collecting(diffImagesSolution),
+});
+
+// Scroll down for solutions. ↓
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+// Solutions ↓
+
+function diffImagesSolution({
+  dimensions,
+  image1,
+  image2,
+}: DiffImagesInput): Diff {
+  return iter(image1)
+    .zip(image2)
+    .map(([pixel1, pixel2]) => pixel1 === pixel2)
+    .chunks(dimensions.width)
+    .toArray();
+}


### PR DESCRIPTION
## Overview

- Fixes a type issue on the 03-filter exercise
- Adds a new 09-image-diff exercise

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
