### PR TITLE
Allow exporting from iterables

### DIFF
--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -761,7 +761,7 @@ function buildApi({
       debug('exporting tally report CSV file: %o', input);
       const exportFileResult = await exportFile({
         path: input.path,
-        data: await generateTallyReportCsv({
+        data: generateTallyReportCsv({
           store,
           filter: convertFrontendFilter(input.filter),
           groupBy: input.groupBy,

--- a/apps/admin/backend/src/util/export_file.ts
+++ b/apps/admin/backend/src/util/export_file.ts
@@ -1,4 +1,8 @@
-import { ExportDataResult, Exporter } from '@votingworks/backend';
+import {
+  ExportDataResult,
+  ExportableData,
+  Exporter,
+} from '@votingworks/backend';
 import { ADMIN_ALLOWED_EXPORT_PATTERNS } from '../globals';
 import { rootDebug } from './debug';
 
@@ -12,7 +16,7 @@ export function exportFile({
   data,
 }: {
   path: string;
-  data: string | NodeJS.ReadableStream;
+  data: ExportableData;
 }): Promise<ExportDataResult> {
   const exporter = new Exporter({
     allowedExportPatterns: ADMIN_ALLOWED_EXPORT_PATTERNS,

--- a/apps/admin/backend/test/csv.ts
+++ b/apps/admin/backend/test/csv.ts
@@ -10,11 +10,12 @@ export function parseCsv(fileContents: string): {
   };
 }
 
-export function streamToString(stream: NodeJS.ReadableStream): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const chunks: string[] = [];
-    stream.on('data', (chunk: string) => chunks.push(chunk));
-    stream.on('end', () => resolve(chunks.join('')));
-    stream.on('error', reject);
-  });
+export async function iterableToString(
+  iterable: Iterable<string> | AsyncIterable<string>
+): Promise<string> {
+  let result = '';
+  for await (const chunk of iterable) {
+    result += chunk;
+  }
+  return result;
 }

--- a/libs/backend/src/exporter.test.ts
+++ b/libs/backend/src/exporter.test.ts
@@ -1,5 +1,5 @@
 import { mockOf } from '@votingworks/test-utils';
-import { err, ok } from '@votingworks/basics';
+import { err, iter, ok } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import { readFile, symlink, writeFile } from 'fs/promises';
 import { join } from 'path';
@@ -56,6 +56,22 @@ test('exportData disallowed path', async () => {
   expect(
     (await exporter.exportData('/etc/passwd', 'bar')).err()?.message
   ).toMatch(/Path is not allowed/);
+});
+
+test('exportData with iterable', async () => {
+  const tmpDir = createTmpDir();
+  const path = join(tmpDir, 'test.txt');
+  const result = await exporter.exportData(path, ['foo', 'bar']);
+  expect(result).toEqual(ok([path]));
+  expect(await readFile(path, 'utf-8')).toEqual('foobar');
+});
+
+test('exportData with async iterable', async () => {
+  const tmpDir = createTmpDir();
+  const path = join(tmpDir, 'test.txt');
+  const result = await exporter.exportData(path, iter(['foo', 'bar']).async());
+  expect(result).toEqual(ok([path]));
+  expect(await readFile(path, 'utf-8')).toEqual('foobar');
 });
 
 test('exportData with stream', async () => {

--- a/libs/backend/src/exporter.ts
+++ b/libs/backend/src/exporter.ts
@@ -18,6 +18,11 @@ import { execFile } from './exec';
 const MAXIMUM_FAT32_FILE_SIZE = 2 ** 32 - 1;
 
 /**
+ * Types that may be exported.
+ */
+export type ExportableData = string | Buffer | NodeJS.ReadableStream;
+
+/**
  * Possible export errors.
  */
 export interface ExportDataError {
@@ -60,7 +65,7 @@ export class Exporter {
    */
   async exportData(
     path: string,
-    data: string | Buffer | NodeJS.ReadableStream,
+    data: ExportableData,
     {
       maximumFileSize,
     }: {
@@ -117,7 +122,7 @@ export class Exporter {
   async exportDataToUsbDrive(
     bucket: string,
     name: string,
-    data: string | Buffer | NodeJS.ReadableStream,
+    data: ExportableData,
     {
       machineDirectoryToWriteToFirst,
       maximumFileSize = MAXIMUM_FAT32_FILE_SIZE,


### PR DESCRIPTION
## Overview
Allows export functions to accept iterables, which are generally easier to create than streams. Converts a couple simple cases that exposed streams but were already using iterables internally to just expose the iterables directly.

## Demo Video or Screenshot
n/a

## Testing Plan
- [x] Existing automated tests.
