### PR TITLE
VxDesign: Stable entity IDs

### DIFF
--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -123,7 +123,7 @@ function buildApi({ store }: { store: Store }) {
 
     updateElection(input: { electionId: Id; election: Election }): void {
       const { election } = store.getElection(input.electionId);
-      // TODO validate election
+      // TODO validate election, including global ID uniqueness
       store.updateElection(input.electionId, {
         ...election,
         ...input.election,

--- a/apps/design/frontend/package.json
+++ b/apps/design/frontend/package.json
@@ -64,6 +64,7 @@
     "esbuild-runner": "2.2.2",
     "js-file-download": "0.4.12",
     "luxon": "^3.0.0",
+    "nanoid": "^3.3.7",
     "normalize.css": "^8.0.1",
     "path": "^0.12.7",
     "react": "18.2.0",

--- a/apps/design/frontend/src/utils.ts
+++ b/apps/design/frontend/src/utils.ts
@@ -1,7 +1,18 @@
 import type { Precinct, PrecinctWithSplits } from '@votingworks/design-backend';
+import { customAlphabet } from 'nanoid';
 
 export function hasSplits(precinct: Precinct): precinct is PrecinctWithSplits {
   return 'splits' in precinct && precinct.splits !== undefined;
+}
+
+const idGenerator = customAlphabet('0123456789abcdefghijklmnopqrstuvwxyz', 12);
+
+/**
+ * Generates a URL-friendly and double-click-copy-friendly unique ID using a
+ * cryptographically secure RNG.
+ */
+export function generateId(): string {
+  return idGenerator();
 }
 
 /**

--- a/apps/design/frontend/test/id_helpers.tsx
+++ b/apps/design/frontend/test/id_helpers.tsx
@@ -1,0 +1,13 @@
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function makeIdFactory() {
+  let id = 0;
+  return {
+    next: () => {
+      id += 1;
+      return `test-random-id-${id}`;
+    },
+    reset: () => {
+      id = 0;
+    },
+  };
+}

--- a/apps/design/frontend/test/setupTests.ts
+++ b/apps/design/frontend/test/setupTests.ts
@@ -2,11 +2,27 @@ import '@testing-library/jest-dom/extend-expect';
 import 'jest-styled-components';
 
 import { TextEncoder } from 'node:util';
+import { makeIdFactory } from './id_helpers';
 
 // styled-components version 5.3.1 and above requires this remapping for jest
 // environments, reference: https://github.com/styled-components/styled-components/issues/3570
 jest.mock('styled-components', () =>
   jest.requireActual('styled-components/dist/styled-components.browser.cjs.js')
 );
+
+// Deterministic ID generation
+const idFactory = makeIdFactory();
+
+beforeEach(() => {
+  idFactory.reset();
+});
+
+jest.mock('nanoid', () => {
+  return {
+    customAlphabet: () => () => {
+      return idFactory.next();
+    },
+  };
+});
 
 global.TextEncoder = TextEncoder;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1300,6 +1300,9 @@ importers:
       luxon:
         specifier: ^3.0.0
         version: 3.3.0
+      nanoid:
+        specifier: ^3.3.7
+        version: 3.3.7
       normalize.css:
         specifier: ^8.0.1
         version: 8.0.1
@@ -7304,7 +7307,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-transform-react-jsx-source@7.18.6(@babel/core@7.20.12):
@@ -15516,7 +15519,7 @@ packages:
       semver: 7.3.2
       tapable: 1.1.3
       typescript: 5.2.2
-      webpack: 5.88.2(esbuild@0.18.17)
+      webpack: 5.88.2(esbuild@0.17.11)
 
   /form-data@2.5.1:
     resolution: {integrity: sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==}
@@ -18507,11 +18510,10 @@ packages:
     resolution: {integrity: sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==}
     requiresBuild: true
 
-  /nanoid@3.3.6:
-    resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
+  /nanoid@3.3.7:
+    resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-    dev: true
 
   /nanomatch@1.2.13:
     resolution: {integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==}
@@ -19373,7 +19375,7 @@ packages:
     resolution: {integrity: sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.3.6
+      nanoid: 3.3.7
       picocolors: 1.0.0
       source-map-js: 1.0.2
     dev: true
@@ -19816,7 +19818,7 @@ packages:
       strip-ansi: 6.0.1
       text-table: 0.2.0
       typescript: 5.2.2
-      webpack: 5.88.2(esbuild@0.18.17)
+      webpack: 5.88.2(esbuild@0.17.11)
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -21596,7 +21598,7 @@ packages:
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
 
-  /terser-webpack-plugin@5.3.9(esbuild@0.18.17)(webpack@5.88.2):
+  /terser-webpack-plugin@5.3.9(esbuild@0.17.11)(webpack@5.88.2):
     resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -21613,12 +21615,12 @@ packages:
         optional: true
     dependencies:
       '@jridgewell/trace-mapping': 0.3.18
-      esbuild: 0.18.17
+      esbuild: 0.17.11
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.19.2
-      webpack: 5.88.2(esbuild@0.18.17)
+      webpack: 5.88.2(esbuild@0.17.11)
 
   /terser@4.8.1:
     resolution: {integrity: sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==}
@@ -22618,7 +22620,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /webpack@5.88.2(esbuild@0.18.17):
+  /webpack@5.88.2(esbuild@0.17.11):
     resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -22649,7 +22651,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(esbuild@0.18.17)(webpack@5.88.2)
+      terser-webpack-plugin: 5.3.9(esbuild@0.17.11)(webpack@5.88.2)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION

## Overview

Closes #4423 

Instead of generating human-readable IDs for districts, precincts, contests and parties, generate random unique IDs. Also, remove the ability for users to edit those IDs.

This will help ensure global ID uniqueness in the election definition and make sure referential integrity is maintained (e.g. since a party's ID never changes, any references to that party will never need to change).


## Demo Video or Screenshot
Contests table now has "Type" column instead of "ID" column
<img width="1424" alt="Screenshot 2024-01-02 at 4 33 33 PM" src="https://github.com/votingworks/vxsuite/assets/530106/1379715a-6f44-43fe-b0df-6a2104a45b4e">


## Testing Plan
Updated automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
