### PR TITLE
Move election package generation to VxDesign's background worker

### DIFF
--- a/apps/design/backend/jest.config.js
+++ b/apps/design/backend/jest.config.js
@@ -7,8 +7,8 @@ module.exports = {
   ...shared,
   coverageThreshold: {
     global: {
-      branches: -24,
-      lines: -86,
+      branches: -20,
+      lines: -74,
     },
   },
 };

--- a/apps/design/backend/jest.config.js
+++ b/apps/design/backend/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: -20,
-      lines: -74,
+      lines: -75,
     },
   },
 };

--- a/apps/design/backend/package.json
+++ b/apps/design/backend/package.json
@@ -75,6 +75,7 @@
     "@votingworks/ballot-interpreter": "workspace:*",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/image-utils": "workspace:*",
+    "@votingworks/test-utils": "workspace:*",
     "esbuild": "0.17.11",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",

--- a/apps/design/backend/schema.sql
+++ b/apps/design/backend/schema.sql
@@ -4,7 +4,11 @@ create table elections (
   system_settings_data text not null,
   precinct_data text not null,
   layout_options_data text not null,
-  created_at timestamp not null default current_timestamp
+  created_at timestamp not null default current_timestamp,
+  election_package_task_id text,
+  election_package_url text,
+  foreign key (election_package_task_id) references background_tasks(id)
+    on delete set null
 );
 
 create table background_tasks (

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -11,6 +11,7 @@ import {
   layOutAllBallotStyles,
   LayoutOptions,
 } from '@votingworks/hmpb-layout';
+import { suppressingConsoleOutput } from '@votingworks/test-utils';
 import {
   AdjudicationReason,
   AnyContest,
@@ -244,7 +245,9 @@ test('Election package management', async () => {
   );
 
   // Complete an export
-  await processNextBackgroundTaskIfAny({ log: jest.fn(), workspace });
+  await suppressingConsoleOutput(() =>
+    processNextBackgroundTaskIfAny(workspace)
+  );
   const electionPackageAfterExport = await apiClient.getElectionPackage({
     electionId,
   });
@@ -303,7 +306,9 @@ test('Election package export', async () => {
   const { election: appElection } = await apiClient.getElection({ electionId });
 
   await apiClient.exportElectionPackage({ electionId });
-  await processNextBackgroundTaskIfAny({ log: jest.fn(), workspace });
+  await suppressingConsoleOutput(() =>
+    processNextBackgroundTaskIfAny(workspace)
+  );
 
   const electionPackage = await apiClient.getElectionPackage({
     electionId,

--- a/apps/design/backend/src/index.ts
+++ b/apps/design/backend/src/index.ts
@@ -1,8 +1,7 @@
-import { join, resolve } from 'path';
-import { ensureDirSync } from 'fs-extra';
+import { resolve } from 'path';
 import { WORKSPACE } from './globals';
 import * as server from './server';
-import { Store } from './store';
+import { createWorkspace } from './workspace';
 
 export type {
   BallotStyle,
@@ -25,12 +24,9 @@ function main(): Promise<number> {
     );
   }
   const workspacePath = resolve(WORKSPACE);
-  ensureDirSync(workspacePath);
+  const workspace = createWorkspace(workspacePath);
 
-  const dbPath = join(workspacePath, 'design-backend.db');
-  const store = Store.fileStore(dbPath);
-
-  server.start({ store });
+  server.start({ workspace });
 
   return Promise.resolve(0);
 }

--- a/apps/design/backend/src/server.ts
+++ b/apps/design/backend/src/server.ts
@@ -1,12 +1,12 @@
 import { buildApp } from './app';
 import { PORT } from './globals';
-import { Store } from './store';
+import { Workspace } from './workspace';
 
 /**
  * Starts the server.
  */
-export function start({ store }: { store: Store }): void {
-  const app = buildApp({ store });
+export function start({ workspace }: { workspace: Workspace }): void {
+  const app = buildApp({ workspace });
 
   app.listen(PORT, () => {
     // eslint-disable-next-line no-console

--- a/apps/design/backend/src/store.test.ts
+++ b/apps/design/backend/src/store.test.ts
@@ -1,6 +1,6 @@
 import { LanguageCode } from '@votingworks/types';
 
-import { Store } from './store';
+import { Store, TaskName } from './store';
 
 test('Translation cache', () => {
   const store = Store.memoryStore();
@@ -92,7 +92,7 @@ test('Speech synthesis cache', () => {
 
 test('Background task processing - task creation and retrieval', () => {
   const store = Store.memoryStore();
-  const taskName = 'someTaskName';
+  const taskName = 'some_task_name' as TaskName;
 
   expect(store.getOldestQueuedBackgroundTask()).toEqual(undefined);
 
@@ -127,7 +127,7 @@ test('Background task processing - task creation and retrieval', () => {
 
 test('Background task processing - starting and completing tasks', () => {
   const store = Store.memoryStore();
-  const taskName = 'someTaskName';
+  const taskName = 'some_task_name' as TaskName;
 
   expect(store.getOldestQueuedBackgroundTask()).toEqual(undefined);
 

--- a/apps/design/backend/src/worker/index.ts
+++ b/apps/design/backend/src/worker/index.ts
@@ -1,17 +1,14 @@
-import { ensureDirSync } from 'fs-extra';
 import path from 'path';
 import { assertDefined } from '@votingworks/basics';
 
 import { WORKSPACE } from '../globals';
-import { Store } from '../store';
 import * as worker from './worker';
+import { createWorkspace } from '../workspace';
 
 async function main(): Promise<void> {
   const workspacePath = path.resolve(assertDefined(WORKSPACE));
-  ensureDirSync(workspacePath);
-  const dbPath = path.join(workspacePath, 'design-backend.db');
-  const store = Store.fileStore(dbPath);
-  worker.start({ store });
+  const workspace = createWorkspace(workspacePath);
+  worker.start({ workspace });
   return Promise.resolve();
 }
 

--- a/apps/design/backend/src/worker/tasks.ts
+++ b/apps/design/backend/src/worker/tasks.ts
@@ -1,0 +1,68 @@
+import fs from 'fs/promises';
+import JsZip from 'jszip';
+import path from 'path';
+import { z } from 'zod';
+import { throwIllegalValue } from '@votingworks/basics';
+import { layOutAllBallotStyles } from '@votingworks/hmpb-layout';
+import {
+  BallotType,
+  ElectionPackageFileName,
+  getDisplayElectionHash,
+  Id,
+  safeParseJson,
+} from '@votingworks/types';
+
+import { PORT } from '../globals';
+import { BackgroundTask } from '../store';
+import { Workspace } from '../workspace';
+
+async function generateElectionPackage(
+  { assetDirectoryPath, store }: Workspace,
+  { electionId }: { electionId: Id }
+): Promise<void> {
+  const { election, layoutOptions, systemSettings } =
+    store.getElection(electionId);
+  const { electionDefinition } = layOutAllBallotStyles({
+    election,
+    // Ballot type and ballot mode shouldn't change the election definition, so it doesn't matter
+    // what we pass here
+    ballotType: BallotType.Precinct,
+    ballotMode: 'test',
+    layoutOptions,
+  }).unsafeUnwrap();
+  const zip = new JsZip();
+  zip.file(ElectionPackageFileName.ELECTION, electionDefinition.electionData);
+  zip.file(
+    ElectionPackageFileName.SYSTEM_SETTINGS,
+    JSON.stringify(systemSettings, null, 2)
+  );
+
+  const displayElectionHash = getDisplayElectionHash(electionDefinition);
+  const fileName = `election-package-${displayElectionHash}.zip`;
+  const filePath = path.join(assetDirectoryPath, fileName);
+  await fs.writeFile(filePath, await zip.generateAsync({ type: 'nodebuffer' }));
+  store.setElectionPackageUrl({
+    electionId,
+    electionPackageUrl: `http://localhost:${PORT}/${fileName}`,
+  });
+}
+
+export async function processBackgroundTask(
+  workspace: Workspace,
+  { taskName, payload }: BackgroundTask
+): Promise<void> {
+  switch (taskName) {
+    case 'generate_election_package': {
+      const parsedPayload = safeParseJson(
+        payload,
+        z.object({ electionId: z.string() })
+      ).unsafeUnwrap();
+      await generateElectionPackage(workspace, parsedPayload);
+      break;
+    }
+    /* istanbul ignore next: Compile-time check for completeness */
+    default: {
+      throwIllegalValue(taskName);
+    }
+  }
+}

--- a/apps/design/backend/src/worker/worker.ts
+++ b/apps/design/backend/src/worker/worker.ts
@@ -1,45 +1,46 @@
 import { extractErrorMessage, sleep } from '@votingworks/basics';
 
-import { BackgroundTask, Store } from '../store';
+import { Workspace } from '../workspace';
+import { processBackgroundTask } from './tasks';
 
-async function processBackgroundTask(
-  _store: Store, // eslint-disable-line @typescript-eslint/no-unused-vars
-  _task: BackgroundTask // eslint-disable-line @typescript-eslint/no-unused-vars
-): Promise<void> {
-  // Simulate a long-running operation
-  // TODO(arsalan): Implement actual processing logic
-  await sleep(3000);
-}
+export async function processNextBackgroundTaskIfAny({
+  log = console.log, // eslint-disable-line no-console
+  workspace,
+}: {
+  log?: (text: string) => void;
+  workspace: Workspace;
+}): Promise<void> {
+  const { store } = workspace;
 
-async function processBackgroundTasks(store: Store): Promise<void> {
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const nextTask = store.getOldestQueuedBackgroundTask();
+  const nextTask = store.getOldestQueuedBackgroundTask();
 
-    if (!nextTask) {
-      await sleep(1000);
-      continue;
-    }
-
-    store.startBackgroundTask(nextTask.id);
-    process.stdout.write(`⏳ Processing background task ${nextTask.id}...\n`);
-    try {
-      await processBackgroundTask(store, nextTask);
-    } catch (error) {
-      const errorMessage = extractErrorMessage(error);
-      store.completeBackgroundTask(nextTask.id, errorMessage);
-      process.stdout.write(
-        `❌ Error processing background task ${nextTask.id}:\n${errorMessage}\n`
-      );
-      continue;
-    }
-    store.completeBackgroundTask(nextTask.id);
-    process.stdout.write(
-      `✅ Finished processing background task ${nextTask.id}\n`
-    );
+  if (!nextTask) {
+    await sleep(1000);
+    return;
   }
+
+  store.startBackgroundTask(nextTask.id);
+  log(`⏳ Processing background task ${nextTask.id}...`);
+  try {
+    await processBackgroundTask(workspace, nextTask);
+  } catch (error) {
+    const errorMessage = extractErrorMessage(error);
+    const errorStack = error instanceof Error ? error.stack : undefined;
+    store.completeBackgroundTask(nextTask.id, errorMessage);
+    log(
+      `❌ Error processing background task ${nextTask.id}:\n${errorMessage}\n${errorStack}`
+    );
+    return;
+  }
+  store.completeBackgroundTask(nextTask.id);
+  log(`✅ Finished processing background task ${nextTask.id}`);
 }
 
-export function start({ store }: { store: Store }): void {
-  setTimeout(() => processBackgroundTasks(store));
+export function start({ workspace }: { workspace: Workspace }): void {
+  setTimeout(async () => {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      await processNextBackgroundTaskIfAny({ workspace });
+    }
+  });
 }

--- a/apps/design/backend/src/worker/worker.ts
+++ b/apps/design/backend/src/worker/worker.ts
@@ -3,13 +3,9 @@ import { extractErrorMessage, sleep } from '@votingworks/basics';
 import { Workspace } from '../workspace';
 import { processBackgroundTask } from './tasks';
 
-export async function processNextBackgroundTaskIfAny({
-  log = console.log, // eslint-disable-line no-console
-  workspace,
-}: {
-  log?: (text: string) => void;
-  workspace: Workspace;
-}): Promise<void> {
+export async function processNextBackgroundTaskIfAny(
+  workspace: Workspace
+): Promise<void> {
   const { store } = workspace;
 
   const nextTask = store.getOldestQueuedBackgroundTask();
@@ -19,28 +15,30 @@ export async function processNextBackgroundTaskIfAny({
     return;
   }
 
+  /* eslint-disable no-console */
   store.startBackgroundTask(nextTask.id);
-  log(`⏳ Processing background task ${nextTask.id}...`);
+  console.log(`⏳ Processing background task ${nextTask.id}...`);
   try {
     await processBackgroundTask(workspace, nextTask);
   } catch (error) {
     const errorMessage = extractErrorMessage(error);
     const errorStack = error instanceof Error ? error.stack : undefined;
     store.completeBackgroundTask(nextTask.id, errorMessage);
-    log(
+    console.log(
       `❌ Error processing background task ${nextTask.id}:\n${errorMessage}\n${errorStack}`
     );
     return;
   }
   store.completeBackgroundTask(nextTask.id);
-  log(`✅ Finished processing background task ${nextTask.id}`);
+  console.log(`✅ Finished processing background task ${nextTask.id}`);
+  /* eslint-enable no-console */
 }
 
 export function start({ workspace }: { workspace: Workspace }): void {
   setTimeout(async () => {
     // eslint-disable-next-line no-constant-condition
     while (true) {
-      await processNextBackgroundTaskIfAny({ workspace });
+      await processNextBackgroundTaskIfAny(workspace);
     }
   });
 }

--- a/apps/design/backend/src/workspace.ts
+++ b/apps/design/backend/src/workspace.ts
@@ -1,0 +1,21 @@
+import { ensureDirSync } from 'fs-extra';
+import { join } from 'path';
+
+import { Store } from './store';
+
+export interface Workspace {
+  assetDirectoryPath: string;
+  store: Store;
+}
+
+export function createWorkspace(workspacePath: string): Workspace {
+  ensureDirSync(workspacePath);
+
+  const assetDirectoryPath = join(workspacePath, 'assets');
+  ensureDirSync(assetDirectoryPath);
+
+  const dbPath = join(workspacePath, 'design-backend.db');
+  const store = Store.fileStore(dbPath);
+
+  return { assetDirectoryPath, store };
+}

--- a/apps/design/backend/test/helpers.ts
+++ b/apps/design/backend/test/helpers.ts
@@ -8,6 +8,7 @@ import { Store } from '../src/store';
 import type { Api } from '../src/app';
 import { MinimalGoogleCloudTranslationClient } from '../src/language_and_audio/translator';
 import { MinimalGoogleCloudTextToSpeechClient } from '../src/language_and_audio/speech_synthesizer';
+import { Workspace } from '../src/workspace';
 
 tmp.setGracefulCleanup();
 
@@ -18,14 +19,16 @@ export function testSetupHelpers() {
   const servers: Server[] = [];
 
   function setupApp() {
+    const assetDirectoryPath = tmp.dirSync().name;
     const store = Store.fileStore(tmp.fileSync().name);
-    const app = buildApp({ store });
+    const workspace: Workspace = { assetDirectoryPath, store };
+    const app = buildApp({ workspace });
     const server = app.listen();
     servers.push(server);
     const { port } = server.address() as AddressInfo;
     const baseUrl = `http://localhost:${port}/api`;
     const apiClient = grout.createClient<Api>({ baseUrl });
-    return { apiClient };
+    return { apiClient, workspace };
   }
 
   function cleanup() {

--- a/apps/design/backend/test/helpers.ts
+++ b/apps/design/backend/test/helpers.ts
@@ -4,11 +4,10 @@ import { AddressInfo } from 'net';
 import * as tmp from 'tmp';
 import * as grout from '@votingworks/grout';
 import { buildApp } from '../src/app';
-import { Store } from '../src/store';
 import type { Api } from '../src/app';
 import { MinimalGoogleCloudTranslationClient } from '../src/language_and_audio/translator';
 import { MinimalGoogleCloudTextToSpeechClient } from '../src/language_and_audio/speech_synthesizer';
-import { Workspace } from '../src/workspace';
+import { createWorkspace } from '../src/workspace';
 
 tmp.setGracefulCleanup();
 
@@ -19,9 +18,7 @@ export function testSetupHelpers() {
   const servers: Server[] = [];
 
   function setupApp() {
-    const assetDirectoryPath = tmp.dirSync().name;
-    const store = Store.fileStore(tmp.fileSync().name);
-    const workspace: Workspace = { assetDirectoryPath, store };
+    const workspace = createWorkspace(tmp.dirSync().name);
     const app = buildApp({ workspace });
     const server = app.listen();
     servers.push(server);

--- a/apps/design/backend/test/helpers.ts
+++ b/apps/design/backend/test/helpers.ts
@@ -109,8 +109,10 @@ export async function exportElectionPackage({
     electionId,
   });
   const electionPackageFileName = assertDefined(
-    electionPackage.url?.match(/election-package-[0-9a-z]{10}\.zip$/)?.[0]
-  );
+    assertDefined(electionPackage.url).match(
+      /election-package-[0-9a-z]{10}\.zip$/
+    )
+  )[0];
   const electionPackageContents = fs.readFileSync(
     path.join(workspace.assetDirectoryPath, electionPackageFileName)
   );

--- a/apps/design/backend/tsconfig.build.json
+++ b/apps/design/backend/tsconfig.build.json
@@ -19,6 +19,7 @@
     { "path": "../../../libs/hmpb/layout/tsconfig.build.json" },
     { "path": "../../../libs/hmpb/render-backend/tsconfig.build.json" },
     { "path": "../../../libs/image-utils/tsconfig.build.json" },
+    { "path": "../../../libs/test-utils/tsconfig.build.json" },
     { "path": "../../../libs/types/tsconfig.build.json" },
     { "path": "../../../libs/utils/tsconfig.build.json" }
   ]

--- a/apps/design/backend/tsconfig.json
+++ b/apps/design/backend/tsconfig.json
@@ -27,6 +27,7 @@
     { "path": "../../../libs/hmpb/layout/tsconfig.build.json" },
     { "path": "../../../libs/hmpb/render-backend/tsconfig.build.json" },
     { "path": "../../../libs/image-utils/tsconfig.build.json" },
+    { "path": "../../../libs/test-utils/tsconfig.build.json" },
     { "path": "../../../libs/types/tsconfig.build.json" },
     { "path": "../../../libs/utils/tsconfig.build.json" }
   ]

--- a/apps/design/frontend/jest.config.js
+++ b/apps/design/frontend/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: -160,
-      lines: -362,
+      lines: -348,
     },
   },
   setupFiles: ['react-app-polyfill/jsdom'],

--- a/apps/design/frontend/package.json
+++ b/apps/design/frontend/package.json
@@ -93,6 +93,7 @@
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/grout-test-utils": "workspace:*",
     "@votingworks/monorepo-utils": "workspace:*",
+    "@votingworks/test-utils": "workspace:*",
     "eslint-plugin-vx": "workspace:*",
     "history": "4.10.1",
     "is-ci-cli": "2.2.0",

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -160,10 +160,35 @@ export const exportBallot = {
   },
 } as const;
 
+export const getElectionPackage = {
+  queryKey(electionId: Id): QueryKey {
+    return ['getElectionPackage', electionId];
+  },
+  useQuery(electionId: Id) {
+    const apiClient = useApiClient();
+    return useQuery(
+      this.queryKey(electionId),
+      () => apiClient.getElectionPackage({ electionId }),
+      {
+        // Poll if an export is in progress
+        refetchInterval: (result) =>
+          result?.task && !result.task.completedAt ? 1000 : 0,
+      }
+    );
+  },
+} as const;
+
 export const exportElectionPackage = {
   useMutation() {
     const apiClient = useApiClient();
-    return useMutation(apiClient.exportElectionPackage);
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.exportElectionPackage, {
+      async onSuccess(_, { electionId }) {
+        await queryClient.invalidateQueries(
+          getElectionPackage.queryKey(electionId)
+        );
+      },
+    });
   },
 } as const;
 

--- a/apps/design/frontend/src/export_screen.test.tsx
+++ b/apps/design/frontend/src/export_screen.test.tsx
@@ -1,5 +1,7 @@
 import { Buffer } from 'buffer';
 import fileDownload from 'js-file-download';
+import userEvent from '@testing-library/user-event';
+import { mockOf } from '@votingworks/test-utils';
 import {
   provideApi,
   createMockApiClient,
@@ -10,14 +12,21 @@ import { render, screen, waitFor } from '../test/react_testing_library';
 import { withRoute } from '../test/routing_helpers';
 import { ExportScreen } from './export_screen';
 import { routes } from './routes';
+import { downloadFile } from './utils';
 
 jest.mock('js-file-download');
 const fileDownloadMock = jest.mocked(fileDownload);
+
+jest.mock('./utils', (): typeof import('./utils') => ({
+  ...jest.requireActual('./utils'),
+  downloadFile: jest.fn(),
+}));
 
 let apiMock: MockApiClient;
 
 beforeEach(() => {
   apiMock = createMockApiClient();
+  apiMock.getElectionPackage.expectCallWith({ electionId }).resolves({});
 });
 
 afterEach(() => {
@@ -36,25 +45,6 @@ function renderScreen() {
   );
 }
 
-test('export election package', async () => {
-  renderScreen();
-  await screen.findByRole('heading', { name: 'Export' });
-
-  apiMock.exportElectionPackage.expectCallWith({ electionId }).resolves({
-    zipContents: Buffer.from('fake-zip-contents'),
-    electionHash: '1234567890abcdef',
-  });
-
-  screen.getButton('Export Election Package').click();
-
-  await waitFor(() => {
-    expect(fileDownloadMock).toHaveBeenCalledWith(
-      Buffer.from('fake-zip-contents'),
-      'election-package-1234567890.zip'
-    );
-  });
-});
-
 test('export all ballots', async () => {
   renderScreen();
   await screen.findByRole('heading', { name: 'Export' });
@@ -64,7 +54,7 @@ test('export all ballots', async () => {
     electionHash: '1234567890abcdef',
   });
 
-  screen.getButton('Export All Ballots').click();
+  userEvent.click(screen.getButton('Export All Ballots'));
 
   await waitFor(() => {
     expect(fileDownloadMock).toHaveBeenCalledWith(
@@ -83,7 +73,7 @@ test('export test decks', async () => {
     electionHash: '1234567890abcdef',
   });
 
-  screen.getButton('Export Test Decks').click();
+  userEvent.click(screen.getButton('Export Test Decks'));
 
   await waitFor(() => {
     expect(fileDownloadMock).toHaveBeenCalledWith(
@@ -91,4 +81,91 @@ test('export test decks', async () => {
       'test-decks-1234567890.zip'
     );
   });
+});
+
+test('export election package', async () => {
+  renderScreen();
+  await screen.findByRole('heading', { name: 'Export' });
+
+  const taskCreatedAt = new Date();
+  apiMock.exportElectionPackage.expectCallWith({ electionId }).resolves();
+  apiMock.getElectionPackage.expectRepeatedCallsWith({ electionId }).resolves({
+    task: {
+      createdAt: taskCreatedAt,
+      id: '1',
+      payload: JSON.stringify({ electionId }),
+      taskName: 'generate_election_package',
+    },
+  });
+  userEvent.click(screen.getButton('Export Election Package'));
+
+  await screen.findByText('Exporting Election Package...');
+  expect(screen.queryByText('Export Election Package')).not.toBeInTheDocument();
+
+  apiMock.getElectionPackage.expectCallWith({ electionId }).resolves({
+    task: {
+      completedAt: new Date(taskCreatedAt.getTime() + 2000),
+      createdAt: taskCreatedAt,
+      id: '1',
+      payload: JSON.stringify({ electionId }),
+      startedAt: new Date(taskCreatedAt.getTime() + 1000),
+      taskName: 'generate_election_package',
+    },
+    url: 'http://localhost:1234/election-package-1234567890.zip',
+  });
+
+  await screen.findByText('Export Election Package', undefined, {
+    timeout: 2000,
+  });
+  expect(
+    screen.queryByText('Exporting Election Package...')
+  ).not.toBeInTheDocument();
+
+  await waitFor(() => {
+    expect(mockOf(downloadFile)).toHaveBeenCalledWith(
+      'http://localhost:1234/election-package-1234567890.zip'
+    );
+  });
+});
+
+test('export election package error handling', async () => {
+  renderScreen();
+  await screen.findByRole('heading', { name: 'Export' });
+
+  const taskCreatedAt = new Date();
+  apiMock.exportElectionPackage.expectCallWith({ electionId }).resolves();
+  apiMock.getElectionPackage.expectRepeatedCallsWith({ electionId }).resolves({
+    task: {
+      createdAt: taskCreatedAt,
+      id: '1',
+      payload: JSON.stringify({ electionId }),
+      taskName: 'generate_election_package',
+    },
+  });
+  userEvent.click(screen.getButton('Export Election Package'));
+
+  await screen.findByText('Exporting Election Package...');
+  expect(screen.queryByText('Export Election Package')).not.toBeInTheDocument();
+
+  apiMock.getElectionPackage.expectCallWith({ electionId }).resolves({
+    task: {
+      completedAt: new Date(taskCreatedAt.getTime() + 2000),
+      createdAt: taskCreatedAt,
+      error: 'Whoa!',
+      id: '1',
+      payload: JSON.stringify({ electionId }),
+      startedAt: new Date(taskCreatedAt.getTime() + 1000),
+      taskName: 'generate_election_package',
+    },
+  });
+
+  await screen.findByText('Export Election Package', undefined, {
+    timeout: 2000,
+  });
+  expect(
+    screen.queryByText('Exporting Election Package...')
+  ).not.toBeInTheDocument();
+
+  await screen.findByText('An unexpected error occurred. Please try again.');
+  expect(mockOf(downloadFile)).not.toHaveBeenCalled();
 });

--- a/apps/design/frontend/src/export_screen.tsx
+++ b/apps/design/frontend/src/export_screen.tsx
@@ -31,7 +31,7 @@ export function ExportScreen(): JSX.Element | null {
   const exportElectionPackageMutation = exportElectionPackage.useMutation();
   const exportTestDecksMutation = exportTestDecks.useMutation();
 
-  const [exportError, setExportError] = useState<string | undefined>(undefined);
+  const [exportError, setExportError] = useState<string>();
 
   useQueryChangeListener(electionPackageQuery, {
     onChange: (currentElectionPackage, previousElectionPackage) => {

--- a/apps/design/frontend/src/utils.test.ts
+++ b/apps/design/frontend/src/utils.test.ts
@@ -1,5 +1,5 @@
 import { range } from '@votingworks/basics';
-import { nextId } from './utils';
+import { downloadFile, nextId } from './utils';
 
 test('nextId', () => {
   expect(nextId('prefix-')).toEqual('prefix-1');
@@ -15,4 +15,9 @@ test('nextId', () => {
   expect(
     nextId('prefix-', ['custom', 'prefix-2', 'id123', 'prefix-1'])
   ).toEqual('prefix-3');
+});
+
+test('downloadFile cleans up temporary anchor tag', () => {
+  downloadFile('http://localhost:1234/file.zip');
+  expect(document.getElementsByTagName('a')).toHaveLength(0);
 });

--- a/apps/design/frontend/src/utils.ts
+++ b/apps/design/frontend/src/utils.ts
@@ -39,3 +39,16 @@ export function replaceAtIndex<T>(
 ): T[] {
   return array.map((value, i) => (i === index ? newValue : value));
 }
+
+/**
+ * Downloads a file given a file path
+ */
+export function downloadFile(filePath: string): void {
+  const element = document.createElement('a');
+  element.setAttribute('href', filePath);
+  element.setAttribute('download', '');
+  element.style.display = 'none';
+  document.body.appendChild(element);
+  element.click();
+  document.body.removeChild(element);
+}

--- a/apps/design/frontend/tsconfig.json
+++ b/apps/design/frontend/tsconfig.json
@@ -22,6 +22,7 @@
     { "path": "../../../libs/fixtures/tsconfig.build.json" },
     { "path": "../../../libs/grout/tsconfig.build.json" },
     { "path": "../../../libs/grout/test-utils/tsconfig.build.json" },
+    { "path": "../../../libs/test-utils/tsconfig.build.json" },
     { "path": "../../../libs/types/tsconfig.build.json" },
     { "path": "../../../libs/ui/tsconfig.build.json" },
     { "path": "../../../libs/utils/tsconfig.build.json" }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1376,6 +1376,9 @@ importers:
       '@votingworks/monorepo-utils':
         specifier: workspace:*
         version: link:../../../libs/monorepo-utils
+      '@votingworks/test-utils':
+        specifier: workspace:*
+        version: link:../../../libs/test-utils
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../../../libs/eslint-plugin-vx
@@ -15509,7 +15512,7 @@ packages:
       semver: 7.3.2
       tapable: 1.1.3
       typescript: 5.2.2
-      webpack: 5.88.2(esbuild@0.17.11)
+      webpack: 5.88.2(esbuild@0.18.17)
 
   /form-data@2.5.1:
     resolution: {integrity: sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==}
@@ -19808,7 +19811,7 @@ packages:
       strip-ansi: 6.0.1
       text-table: 0.2.0
       typescript: 5.2.2
-      webpack: 5.88.2(esbuild@0.17.11)
+      webpack: 5.88.2(esbuild@0.18.17)
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -21588,7 +21591,7 @@ packages:
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
 
-  /terser-webpack-plugin@5.3.9(esbuild@0.17.11)(webpack@5.88.2):
+  /terser-webpack-plugin@5.3.9(esbuild@0.18.17)(webpack@5.88.2):
     resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -21605,12 +21608,12 @@ packages:
         optional: true
     dependencies:
       '@jridgewell/trace-mapping': 0.3.18
-      esbuild: 0.17.11
+      esbuild: 0.18.17
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.19.2
-      webpack: 5.88.2(esbuild@0.17.11)
+      webpack: 5.88.2(esbuild@0.18.17)
 
   /terser@4.8.1:
     resolution: {integrity: sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==}
@@ -22610,7 +22613,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /webpack@5.88.2(esbuild@0.17.11):
+  /webpack@5.88.2(esbuild@0.18.17):
     resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -22641,7 +22644,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(esbuild@0.17.11)(webpack@5.88.2)
+      terser-webpack-plugin: 5.3.9(esbuild@0.18.17)(webpack@5.88.2)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1207,6 +1207,9 @@ importers:
       '@votingworks/image-utils':
         specifier: workspace:*
         version: link:../../../libs/image-utils
+      '@votingworks/test-utils':
+        specifier: workspace:*
+        version: link:../../../libs/test-utils
       esbuild:
         specifier: 0.17.11
         version: 0.17.11


### PR DESCRIPTION
_Easiest reviewed by commit_

## Overview

This PR moves election package generation to VxDesign's background worker. Election package generation is likely to get much slower once we start translating and generating audio clips, so it'll no longer be reasonable to perform it synchronously. The patterns established in this PR can also be used to handle ballot and test deck generation asynchronously.

## Demo Video or Screenshot

The UX is still pretty bare bones. We can add progress bars and other optimizations in future PRs. We may also want to distinguish the act of generating the election package and downloading it. Note that I've artificially slowed down election package generation for this video 🐌

https://github.com/votingworks/vxsuite/assets/12616928/a30e6738-9033-48b2-80ac-a69dac53f372

_Error handling_

https://github.com/votingworks/vxsuite/assets/12616928/eaeba134-2cfb-4226-a59a-e681a8de2f51

## Testing Plan

- [x] Updated automated tests
- [x] Tested manually

## Checklist

- [x] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A