### PR TITLE
[i18n/Audio] Expose audio controls via the UiStringsContextProvider

### DIFF
--- a/libs/ui/src/hooks/use_audio_controls.test.tsx
+++ b/libs/ui/src/hooks/use_audio_controls.test.tsx
@@ -1,0 +1,57 @@
+import { renderHook } from '@testing-library/react';
+import { UiStringsAudioContext } from '../ui_strings/audio_context';
+import { AudioControls, useAudioControls } from './use_audio_controls';
+import { UiStringsReactQueryApi, createUiStringsApi } from './ui_strings_api';
+
+test('returns external-facing audio context API', () => {
+  const mockUiStringsApi: UiStringsReactQueryApi = createUiStringsApi(() => ({
+    getAudioClips: jest.fn(),
+    getAvailableLanguages: jest.fn(),
+    getUiStringAudioIds: jest.fn(),
+    getUiStrings: jest.fn(),
+  }));
+
+  const mockAudioControls: AudioControls = {
+    decreasePlaybackRate: jest.fn(),
+    decreaseVolume: jest.fn(),
+    increasePlaybackRate: jest.fn(),
+    increaseVolume: jest.fn(),
+    reset: jest.fn(),
+    setIsEnabled: jest.fn(),
+    togglePause: jest.fn(),
+  };
+
+  function TestContextWrapper(props: { children: React.ReactNode }) {
+    const { children } = props;
+
+    return (
+      <UiStringsAudioContext.Provider
+        value={{
+          api: mockUiStringsApi,
+          gainDb: 0,
+          isEnabled: true,
+          playbackRate: 1,
+          ...mockAudioControls,
+        }}
+      >
+        {children}
+      </UiStringsAudioContext.Provider>
+    );
+  }
+
+  const { result } = renderHook(useAudioControls, {
+    wrapper: TestContextWrapper,
+  });
+
+  expect(result.current).toEqual(mockAudioControls);
+});
+
+test('returns no-op API when no audio context is present', () => {
+  const { result } = renderHook(useAudioControls);
+
+  expect(result.current).toBeDefined();
+
+  for (const method of Object.values(result.current)) {
+    expect(method).not.toThrow();
+  }
+});

--- a/libs/ui/src/hooks/use_audio_controls.test.tsx
+++ b/libs/ui/src/hooks/use_audio_controls.test.tsx
@@ -1,4 +1,5 @@
 import { renderHook } from '@testing-library/react';
+import { assert } from '@votingworks/basics';
 import { UiStringsAudioContext } from '../ui_strings/audio_context';
 import { AudioControls, useAudioControls } from './use_audio_controls';
 import { UiStringsReactQueryApi, createUiStringsApi } from './ui_strings_api';
@@ -11,7 +12,7 @@ test('returns external-facing audio context API', () => {
     getUiStrings: jest.fn(),
   }));
 
-  const mockAudioControls: AudioControls = {
+  const mockAudioContextControls = {
     decreasePlaybackRate: jest.fn(),
     decreaseVolume: jest.fn(),
     increasePlaybackRate: jest.fn(),
@@ -19,7 +20,7 @@ test('returns external-facing audio context API', () => {
     reset: jest.fn(),
     setIsEnabled: jest.fn(),
     togglePause: jest.fn(),
-  };
+  } as const;
 
   function TestContextWrapper(props: { children: React.ReactNode }) {
     const { children } = props;
@@ -31,7 +32,7 @@ test('returns external-facing audio context API', () => {
           gainDb: 0,
           isEnabled: true,
           playbackRate: 1,
-          ...mockAudioControls,
+          ...mockAudioContextControls,
         }}
       >
         {children}
@@ -43,7 +44,21 @@ test('returns external-facing audio context API', () => {
     wrapper: TestContextWrapper,
   });
 
-  expect(result.current).toEqual(mockAudioControls);
+  expect(result.current).toEqual<AudioControls>(
+    expect.objectContaining(mockAudioContextControls)
+  );
+
+  window.document.body.focus();
+  const testActiveElement = window.document.activeElement;
+  assert(testActiveElement instanceof HTMLElement);
+
+  const blurSpy = jest.spyOn(testActiveElement, 'blur');
+  const focusSpy = jest.spyOn(testActiveElement, 'focus');
+
+  result.current.replay();
+
+  expect(blurSpy).toHaveBeenCalled();
+  expect(focusSpy).toHaveBeenCalled();
 });
 
 test('returns no-op API when no audio context is present', () => {

--- a/libs/ui/src/hooks/use_audio_controls.ts
+++ b/libs/ui/src/hooks/use_audio_controls.ts
@@ -1,0 +1,33 @@
+import { useAudioContext } from '../ui_strings/audio_context';
+
+export interface AudioControls {
+  decreasePlaybackRate: () => void;
+  decreaseVolume: () => void;
+  increasePlaybackRate: () => void;
+  increaseVolume: () => void;
+  reset: () => void;
+  setIsEnabled: (enabled: boolean) => void;
+  togglePause: () => void;
+}
+
+function noOp() {}
+
+/**
+ * Provides an API for modifying UiString screen reader audio settings.
+ *
+ * Returns a stubbed-out no-op API for convenience/ease-of-testing, when used
+ * without a parent `UiStringsAudioContext`.
+ */
+export function useAudioControls(): AudioControls {
+  const audioContext = useAudioContext();
+
+  return {
+    decreasePlaybackRate: audioContext?.decreasePlaybackRate || noOp,
+    decreaseVolume: audioContext?.decreaseVolume || noOp,
+    increasePlaybackRate: audioContext?.increasePlaybackRate || noOp,
+    increaseVolume: audioContext?.increaseVolume || noOp,
+    reset: audioContext?.reset || noOp,
+    setIsEnabled: audioContext?.setIsEnabled || noOp,
+    togglePause: audioContext?.togglePause || noOp,
+  };
+}

--- a/libs/ui/src/hooks/use_audio_controls.ts
+++ b/libs/ui/src/hooks/use_audio_controls.ts
@@ -5,12 +5,26 @@ export interface AudioControls {
   decreaseVolume: () => void;
   increasePlaybackRate: () => void;
   increaseVolume: () => void;
+  replay: () => void;
   reset: () => void;
   setIsEnabled: (enabled: boolean) => void;
   togglePause: () => void;
 }
 
 function noOp() {}
+
+/**
+ * Replays the current or last-played audio by re-triggering a focus event on
+ * the currently active element, if any.
+ */
+function replay() {
+  const { activeElement } = window.document;
+
+  if (activeElement instanceof HTMLElement) {
+    activeElement.blur();
+    activeElement.focus();
+  }
+}
 
 /**
  * Provides an API for modifying UiString screen reader audio settings.
@@ -27,6 +41,7 @@ export function useAudioControls(): AudioControls {
     increasePlaybackRate: audioContext?.increasePlaybackRate || noOp,
     increaseVolume: audioContext?.increaseVolume || noOp,
     reset: audioContext?.reset || noOp,
+    replay,
     setIsEnabled: audioContext?.setIsEnabled || noOp,
     togglePause: audioContext?.togglePause || noOp,
   };

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -22,6 +22,7 @@ export * from './global_styles';
 export * from './globals';
 export * from './hand_marked_paper_ballot_prose';
 export * from './hooks/ui_strings_api';
+export * from './hooks/use_audio_controls';
 export * from './hooks/use_autocomplete';
 export * from './hooks/use_cancelable_promise';
 export * from './hooks/use_change_listener';

--- a/libs/ui/src/ui_strings/audio_context.test.tsx
+++ b/libs/ui/src/ui_strings/audio_context.test.tsx
@@ -1,0 +1,255 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import {
+  UiStringsAudioContextProvider,
+  useAudioContext,
+} from './audio_context';
+import {
+  UiStringsReactQueryApi,
+  createUiStringsApi,
+} from '../hooks/ui_strings_api';
+import { renderHook } from '../../test/react_testing_library';
+import {
+  DEFAULT_GAIN_DB,
+  GAIN_INCREMENT_AMOUNT_DB,
+  MAX_GAIN_DB,
+  MIN_GAIN_DB,
+} from './audio_volume';
+import {
+  DEFAULT_PLAYBACK_RATE,
+  MAX_PLAYBACK_RATE,
+  MIN_PLAYBACK_RATE,
+  PLAYBACK_RATE_INCREMENT_AMOUNT,
+} from './audio_playback_rate';
+
+const mockUiStringsApi: UiStringsReactQueryApi = createUiStringsApi(() => ({
+  getAudioClips: jest.fn(),
+  getAvailableLanguages: jest.fn(),
+  getUiStringAudioIds: jest.fn(),
+  getUiStrings: jest.fn(),
+}));
+
+function TestContextWrapper(props: { children: React.ReactNode }) {
+  const { children } = props;
+
+  return (
+    <UiStringsAudioContextProvider api={mockUiStringsApi}>
+      {children}
+    </UiStringsAudioContextProvider>
+  );
+}
+
+const mockWebAudioContext = {
+  resume: jest.fn(),
+  suspend: jest.fn(),
+  destination: {
+    disconnect: jest.fn(),
+  },
+} as const;
+
+beforeEach(() => {
+  const mockAudioContextConstructor = jest.fn();
+  mockAudioContextConstructor.mockReturnValue(mockWebAudioContext);
+
+  window.AudioContext = mockAudioContextConstructor;
+});
+
+const originalWebAudioContext = window.AudioContext;
+
+afterAll(() => {
+  window.AudioContext = originalWebAudioContext;
+});
+
+test('exposes UiStrings API', () => {
+  const { result } = renderHook(useAudioContext, {
+    wrapper: TestContextWrapper,
+  });
+
+  expect(result.current?.api).toEqual(mockUiStringsApi);
+});
+
+test('exposes web AudioContext', () => {
+  const { result } = renderHook(useAudioContext, {
+    wrapper: TestContextWrapper,
+  });
+
+  expect(result.current?.webAudioContext).toEqual(mockWebAudioContext);
+});
+
+describe('volume API', () => {
+  test('increaseVolume', () => {
+    const { result } = renderHook(useAudioContext, {
+      wrapper: TestContextWrapper,
+    });
+
+    expect(result.current?.gainDb).toEqual(DEFAULT_GAIN_DB);
+
+    act(() => result.current?.increaseVolume());
+    act(() => result.current?.increaseVolume());
+    expect(result.current?.gainDb).toEqual(
+      DEFAULT_GAIN_DB + GAIN_INCREMENT_AMOUNT_DB * 2
+    );
+
+    // Try increasing the volume well past the maximum:
+    const maxIncrementSteps = Math.ceil(MAX_GAIN_DB / GAIN_INCREMENT_AMOUNT_DB);
+    for (let i = 0; i < maxIncrementSteps + 2; i += 1) {
+      act(() => result.current?.increaseVolume());
+    }
+    expect(result.current?.gainDb).toEqual(MAX_GAIN_DB);
+  });
+
+  test('decreaseVolume', () => {
+    const { result } = renderHook(useAudioContext, {
+      wrapper: TestContextWrapper,
+    });
+
+    expect(result.current?.gainDb).toEqual(DEFAULT_GAIN_DB);
+
+    act(() => result.current?.decreaseVolume());
+    act(() => result.current?.decreaseVolume());
+    expect(result.current?.gainDb).toEqual(
+      DEFAULT_GAIN_DB - GAIN_INCREMENT_AMOUNT_DB * 2
+    );
+
+    // Try decreasing the volume well past the minimum:
+    const maxDecrementSteps = Math.abs(
+      Math.ceil(MIN_GAIN_DB / GAIN_INCREMENT_AMOUNT_DB)
+    );
+    for (let i = 0; i < maxDecrementSteps + 2; i += 1) {
+      act(() => result.current?.decreaseVolume());
+    }
+    expect(result.current?.gainDb).toEqual(MIN_GAIN_DB);
+  });
+});
+
+describe('playback rate API', () => {
+  test('increasePlaybackRate', () => {
+    const { result } = renderHook(useAudioContext, {
+      wrapper: TestContextWrapper,
+    });
+
+    expect(result.current?.playbackRate).toEqual(DEFAULT_PLAYBACK_RATE);
+
+    act(() => result.current?.increasePlaybackRate());
+    act(() => result.current?.increasePlaybackRate());
+    expect(result.current?.playbackRate).toEqual(
+      DEFAULT_PLAYBACK_RATE + PLAYBACK_RATE_INCREMENT_AMOUNT * 2
+    );
+
+    // Try increasing the rate well past the maximum:
+    const maxIncrementSteps = Math.ceil(
+      MAX_PLAYBACK_RATE / PLAYBACK_RATE_INCREMENT_AMOUNT
+    );
+    for (let i = 0; i < maxIncrementSteps + 2; i += 1) {
+      act(() => result.current?.increasePlaybackRate());
+    }
+    expect(result.current?.playbackRate).toEqual(MAX_PLAYBACK_RATE);
+  });
+
+  test('decreasePlaybackRate', () => {
+    const { result } = renderHook(useAudioContext, {
+      wrapper: TestContextWrapper,
+    });
+
+    expect(result.current?.playbackRate).toEqual(DEFAULT_PLAYBACK_RATE);
+
+    act(() => result.current?.decreasePlaybackRate());
+    act(() => result.current?.decreasePlaybackRate());
+    expect(result.current?.playbackRate).toEqual(
+      DEFAULT_PLAYBACK_RATE - PLAYBACK_RATE_INCREMENT_AMOUNT * 2
+    );
+
+    // Try decreasing the rate well past the minimum:
+    const maxDecrementSteps = Math.abs(
+      Math.ceil(MIN_PLAYBACK_RATE / PLAYBACK_RATE_INCREMENT_AMOUNT)
+    );
+    for (let i = 0; i < maxDecrementSteps + 2; i += 1) {
+      act(() => result.current?.decreasePlaybackRate());
+    }
+    expect(result.current?.playbackRate).toEqual(MIN_PLAYBACK_RATE);
+  });
+});
+
+test('enable/disable API', () => {
+  const { result } = renderHook(useAudioContext, {
+    wrapper: TestContextWrapper,
+  });
+
+  expect(result.current?.isEnabled).toEqual(false);
+
+  jest.resetAllMocks();
+
+  act(() => result.current?.setIsEnabled(true));
+
+  expect(result.current?.isEnabled).toEqual(true);
+  expect(mockWebAudioContext.resume).toHaveBeenCalled();
+  expect(mockWebAudioContext.suspend).not.toHaveBeenCalled();
+  expect(mockWebAudioContext.destination.disconnect).not.toHaveBeenCalled();
+
+  jest.resetAllMocks();
+
+  act(() => result.current?.setIsEnabled(false));
+
+  expect(result.current?.isEnabled).toEqual(false);
+  expect(mockWebAudioContext.suspend).toHaveBeenCalled();
+  expect(mockWebAudioContext.resume).not.toHaveBeenCalled();
+  expect(mockWebAudioContext.destination.disconnect).toHaveBeenCalled();
+
+  jest.resetAllMocks();
+
+  // Re-enabling should reset all settings:
+
+  act(() => result.current?.increasePlaybackRate());
+  act(() => result.current?.decreaseVolume());
+
+  act(() => result.current?.setIsEnabled(true));
+
+  expect(result.current?.isEnabled).toEqual(true);
+  expect(result.current?.gainDb).toEqual(DEFAULT_GAIN_DB);
+  expect(result.current?.playbackRate).toEqual(DEFAULT_PLAYBACK_RATE);
+});
+
+test('togglePause', () => {
+  const { result } = renderHook(useAudioContext, {
+    wrapper: TestContextWrapper,
+  });
+
+  act(() => result.current?.setIsEnabled(true));
+
+  jest.resetAllMocks();
+
+  act(() => result.current?.togglePause());
+
+  expect(mockWebAudioContext.suspend).toHaveBeenCalled();
+  expect(mockWebAudioContext.resume).not.toHaveBeenCalled();
+  expect(mockWebAudioContext.destination.disconnect).not.toHaveBeenCalled();
+
+  jest.resetAllMocks();
+
+  act(() => result.current?.togglePause());
+
+  expect(mockWebAudioContext.resume).toHaveBeenCalled();
+  expect(mockWebAudioContext.suspend).not.toHaveBeenCalled();
+  expect(mockWebAudioContext.destination.disconnect).not.toHaveBeenCalled();
+});
+
+test('reset', () => {
+  const { result } = renderHook(useAudioContext, {
+    wrapper: TestContextWrapper,
+  });
+
+  act(() => result.current?.setIsEnabled(true));
+  act(() => result.current?.increasePlaybackRate());
+  act(() => result.current?.decreaseVolume());
+  act(() => result.current?.togglePause());
+
+  jest.resetAllMocks();
+
+  act(() => result.current?.reset());
+
+  expect(result.current?.gainDb).toEqual(DEFAULT_GAIN_DB);
+  expect(result.current?.playbackRate).toEqual(DEFAULT_PLAYBACK_RATE);
+  expect(mockWebAudioContext.resume).toHaveBeenCalled();
+  expect(mockWebAudioContext.suspend).not.toHaveBeenCalled();
+  expect(mockWebAudioContext.destination.disconnect).not.toHaveBeenCalled();
+});

--- a/libs/ui/src/ui_strings/audio_context.tsx
+++ b/libs/ui/src/ui_strings/audio_context.tsx
@@ -68,6 +68,9 @@ export function UiStringsAudioContextProvider(
     if (isEnabled) {
       reset();
     } else {
+      // Pausing here isn't strictly necessary, since we're disconnecting the
+      // context destination node from any inputs, but this makes sure any
+      // active audio streams don't continue to "play" in the background.
       setIsPaused(true);
       webAudioContextRef.current?.destination.disconnect();
     }

--- a/libs/ui/src/ui_strings/audio_context.tsx
+++ b/libs/ui/src/ui_strings/audio_context.tsx
@@ -3,28 +3,133 @@ import React from 'react';
 import { Optional } from '@votingworks/basics';
 
 import { UiStringsReactQueryApi } from '../hooks/ui_strings_api';
+import {
+  DEFAULT_PLAYBACK_RATE,
+  MAX_PLAYBACK_RATE,
+  MIN_PLAYBACK_RATE,
+  PLAYBACK_RATE_INCREMENT_AMOUNT,
+} from './audio_playback_rate';
+import {
+  GAIN_INCREMENT_AMOUNT_DB,
+  DEFAULT_GAIN_DB,
+  MAX_GAIN_DB,
+  MIN_GAIN_DB,
+} from './audio_volume';
 
-export interface AudioContextInterface {
-  // TODO(kofi): Flesh out.
+export interface UiStringsAudioContextInterface {
+  api: UiStringsReactQueryApi;
+  decreasePlaybackRate: () => void;
+  decreaseVolume: () => void;
+  gainDb: number;
+  increasePlaybackRate: () => void;
+  increaseVolume: () => void;
+  isEnabled: boolean;
+  playbackRate: number;
+  reset: () => void;
+  setIsEnabled: (enabled: boolean) => void;
+  togglePause: () => void;
+  webAudioContext?: AudioContext;
 }
 
-const AudioContext =
-  React.createContext<Optional<AudioContextInterface>>(undefined);
+export const UiStringsAudioContext =
+  React.createContext<Optional<UiStringsAudioContextInterface>>(undefined);
 
-export function useAudioContext(): Optional<AudioContextInterface> {
-  return React.useContext(AudioContext);
+export function useAudioContext(): Optional<UiStringsAudioContextInterface> {
+  return React.useContext(UiStringsAudioContext);
 }
 
-export interface AudioContextProviderProps {
-  // eslint-disable-next-line react/no-unused-prop-types
+export interface UiStringsAudioContextProviderProps {
   api: UiStringsReactQueryApi;
   children: React.ReactNode;
 }
 
-export function AudioContextProvider(
-  props: AudioContextProviderProps
+export function UiStringsAudioContextProvider(
+  props: UiStringsAudioContextProviderProps
 ): JSX.Element {
-  const { children } = props;
+  const { api, children } = props;
+  const [isEnabled, setIsEnabled] = React.useState(false);
+  const [isPaused, setIsPaused] = React.useState(true);
+  const [playbackRate, setPlaybackRate] = React.useState<number>(
+    DEFAULT_PLAYBACK_RATE
+  );
+  const [gainDb, setGainDb] = React.useState<number>(DEFAULT_GAIN_DB);
 
-  return <AudioContext.Provider value={{}}>{children}</AudioContext.Provider>;
+  const webAudioContextRef = React.useRef(
+    window.AudioContext ? new AudioContext() : undefined
+  );
+
+  const reset = React.useCallback(() => {
+    setGainDb(DEFAULT_GAIN_DB);
+    setPlaybackRate(DEFAULT_PLAYBACK_RATE);
+    setIsPaused(false);
+  }, []);
+
+  React.useEffect(() => {
+    if (isEnabled) {
+      reset();
+    } else {
+      setIsPaused(true);
+      webAudioContextRef.current?.destination.disconnect();
+    }
+  }, [isEnabled, reset]);
+
+  React.useEffect(() => {
+    if (!webAudioContextRef.current) {
+      return;
+    }
+
+    if (isPaused) {
+      void webAudioContextRef.current.suspend();
+    } else {
+      void webAudioContextRef.current.resume();
+    }
+  }, [isPaused]);
+
+  const increasePlaybackRate = React.useCallback(() => {
+    setPlaybackRate(
+      Math.min(MAX_PLAYBACK_RATE, playbackRate + PLAYBACK_RATE_INCREMENT_AMOUNT)
+    );
+  }, [playbackRate]);
+
+  const decreasePlaybackRate = React.useCallback(() => {
+    setPlaybackRate(
+      Math.max(MIN_PLAYBACK_RATE, playbackRate - PLAYBACK_RATE_INCREMENT_AMOUNT)
+    );
+  }, [playbackRate]);
+
+  const increaseVolume = React.useCallback(
+    () => setGainDb(Math.min(MAX_GAIN_DB, gainDb + GAIN_INCREMENT_AMOUNT_DB)),
+    [gainDb]
+  );
+
+  const decreaseVolume = React.useCallback(
+    () => setGainDb(Math.max(MIN_GAIN_DB, gainDb - GAIN_INCREMENT_AMOUNT_DB)),
+    [gainDb]
+  );
+
+  const togglePause = React.useCallback(
+    () => setIsPaused(!isPaused),
+    [isPaused]
+  );
+
+  return (
+    <UiStringsAudioContext.Provider
+      value={{
+        api,
+        decreasePlaybackRate,
+        decreaseVolume,
+        gainDb,
+        increasePlaybackRate,
+        increaseVolume,
+        isEnabled,
+        playbackRate,
+        reset,
+        setIsEnabled,
+        togglePause,
+        webAudioContext: webAudioContextRef.current,
+      }}
+    >
+      {children}
+    </UiStringsAudioContext.Provider>
+  );
 }

--- a/libs/ui/src/ui_strings/audio_playback_rate.ts
+++ b/libs/ui/src/ui_strings/audio_playback_rate.ts
@@ -1,0 +1,31 @@
+/*
+ * [VVSG 2.0 7.1-K – Audio settings]
+ *
+ * 4. The rate of speech is adjustable throughout the voting session while
+ *    preserving the current votes, with 6 to 8 discrete steps in the rate.
+ *
+ * 5. The default rate of speech is 120 to 125 words per minute (wpm).
+ *
+ * 6. The range of speech rates supported is from 60-70 wpm to 240-250 wpm (or
+ *    50% to 200% of the default rate), with no distortion.
+ *
+ * 7. Adjusting the rate of speech does not affect the pitch of the voice.
+ */
+
+/** Minimum allowed playback rate (50%), as prescribed in VVSG 2.0 7.1-K. */
+export const MIN_PLAYBACK_RATE = 0.5;
+
+/**
+ * Default playback rate, assuming a synthesized speech rate of 120-125 wpm, as
+ * prescribed in VVSG 2.0 7.1-K.
+ */
+export const DEFAULT_PLAYBACK_RATE = 1;
+
+/** Maximum allowed playback rate (200%), as prescribed in VVSG 2.0 7.1-K. */
+export const MAX_PLAYBACK_RATE = 2;
+
+/**
+ * Amount by which the rate is changed when increasing/decreasing playback rate.
+ * This should be assigned a value that allows for 6-8 rate settings, per VVSG.
+ */
+export const PLAYBACK_RATE_INCREMENT_AMOUNT = 0.25;

--- a/libs/ui/src/ui_strings/audio_volume.ts
+++ b/libs/ui/src/ui_strings/audio_volume.ts
@@ -13,6 +13,10 @@
  *    100 dB SPL, in increments no greater than 10 dB
  */
 
+const DEFAULT_VOLUME_DB_SPL = 65;
+const MIN_VOLUME_DB_SPL = 20;
+const MAX_VOLUME_DB_SPL = 100;
+
 /**
  * Minimum allowed gain to achieve a minimum SPL of 20 dB, as prescribed in
  * VVSG 2.0, section 7.1-K,
@@ -20,7 +24,7 @@
  * Assumes a 0 dB gain represents the 65 dB SPL midpoint of the default 60-70
  * dB range prescribed in the VVSG spec.
  */
-export const MIN_GAIN_DB = -45;
+export const MIN_GAIN_DB = MIN_VOLUME_DB_SPL - DEFAULT_VOLUME_DB_SPL;
 
 /**
  * Default gain applied, assuming a 0 dB gain represents the 65 dB midpoint of
@@ -35,7 +39,7 @@ export const DEFAULT_GAIN_DB = 0;
  * Assumes a 0 dB gain represents the 65 dB SPL midpoint of the default 60-70
  * dB range prescribed in the VVSG spec.
  */
-export const MAX_GAIN_DB = 35;
+export const MAX_GAIN_DB = MAX_VOLUME_DB_SPL - DEFAULT_VOLUME_DB_SPL;
 
 /**
  * Amount of gain to add/subtract at a time when increasing/decreasing audio

--- a/libs/ui/src/ui_strings/audio_volume.ts
+++ b/libs/ui/src/ui_strings/audio_volume.ts
@@ -1,0 +1,44 @@
+/*
+ * Gain values in this file represent the amount of amplification (in decibels)
+ * added to the audio output to increase/decrease its volume.
+ *
+ * [VVSG 2.0, 7.1-K – Audio settings]
+ *
+ * 1. The settings for volume and rate of speech are followed regardless of the
+ *    technical means of producing audio output.
+ *
+ * 2. The default volume for each voting session is set between 60 and 70 dB SPL.
+ *
+ * 3. The volume is adjustable from a minimum of 20 dB SPL up to a maximum of
+ *    100 dB SPL, in increments no greater than 10 dB
+ */
+
+/**
+ * Minimum allowed gain to achieve a minimum SPL of 20 dB, as prescribed in
+ * VVSG 2.0, section 7.1-K,
+ *
+ * Assumes a 0 dB gain represents the 65 dB SPL midpoint of the default 60-70
+ * dB range prescribed in the VVSG spec.
+ */
+export const MIN_GAIN_DB = -45;
+
+/**
+ * Default gain applied, assuming a 0 dB gain represents the 65 dB midpoint of
+ * the 60-70 dB range prescribed in VVSG 2.0 7.1-K.
+ */
+export const DEFAULT_GAIN_DB = 0;
+
+/**
+ * Maximum allowed gain to achieve a maximum SPL of 100 dB, as prescribed in
+ * VVSG 2.0, section 7.1-K,
+ *
+ * Assumes a 0 dB gain represents the 65 dB SPL midpoint of the default 60-70
+ * dB range prescribed in the VVSG spec.
+ */
+export const MAX_GAIN_DB = 35;
+
+/**
+ * Amount of gain to add/subtract at a time when increasing/decreasing audio
+ * volume.
+ */
+export const GAIN_INCREMENT_AMOUNT_DB = 5;

--- a/libs/ui/src/ui_strings/ui_strings_context.tsx
+++ b/libs/ui/src/ui_strings/ui_strings_context.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { UiStringsReactQueryApi } from '../hooks/ui_strings_api';
 import { LanguageContextProvider } from './language_context';
-import { AudioContextProvider } from './audio_context';
+import { UiStringsAudioContextProvider } from './audio_context';
 
 export interface UiStringsContextProviderProps {
   api: UiStringsReactQueryApi;
@@ -25,7 +25,9 @@ export function UiStringsContextProvider(
       {noAudio ? (
         children
       ) : (
-        <AudioContextProvider api={api}>{children}</AudioContextProvider>
+        <UiStringsAudioContextProvider api={api}>
+          {children}
+        </UiStringsAudioContextProvider>
       )}
     </LanguageContextProvider>
   );

--- a/libs/ui/test/ui_strings/test_utils.tsx
+++ b/libs/ui/test/ui_strings/test_utils.tsx
@@ -11,7 +11,7 @@ import {
   useLanguageContext,
 } from '../../src/ui_strings/language_context';
 import {
-  AudioContextInterface,
+  UiStringsAudioContextInterface,
   useAudioContext,
 } from '../../src/ui_strings/audio_context';
 import { UiStringsContextProvider } from '../../src/ui_strings/ui_strings_context';
@@ -19,7 +19,7 @@ import { render, RenderResult } from '../react_testing_library';
 import { QUERY_CLIENT_DEFAULT_OPTIONS } from '../../src';
 
 export interface UiStringsTestContext {
-  getAudioContext: () => Optional<AudioContextInterface>;
+  getAudioContext: () => Optional<UiStringsAudioContextInterface>;
   getLanguageContext: () => Optional<LanguageContextInterface>;
   mockBackendApi: jest.Mocked<UiStringsApiClient>;
   render: (ui: React.ReactElement) => RenderResult;
@@ -32,7 +32,7 @@ export function newTestContext(
   } = {}
 ): UiStringsTestContext {
   let currentLanguageContext: Optional<LanguageContextInterface>;
-  let currentAudioContext: Optional<AudioContextInterface>;
+  let currentAudioContext: Optional<UiStringsAudioContextInterface>;
 
   function ContextConsumer() {
     currentLanguageContext = useLanguageContext();


### PR DESCRIPTION
## Overview

Fleshing out the `UiStringsAudioContext` (renamed from `AudioContext` to avoid the name collision with the native web audio API) to manage global audio settings and expose controls for modifying them.

Adding a `useAudioControls` hook to externally expose the parts of the `UiStringsAudioContext` that need to be available outside of `libs/ui`. Future PRs will add the internal audio playback utilities that make use of the remaining context values.

## Testing Plan
- Unit tests for the context API and external hook
- Some manual testing with a local prototype 

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
