### PR TITLE
Save voter session on ballot spoil

### DIFF
--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -34,7 +34,6 @@ import {
 } from '@votingworks/backend';
 import { LogEventId, Logger, LoggingUserRole } from '@votingworks/logging';
 import { useDevDockRouter } from '@votingworks/dev-dock-backend';
-import makeDebug from 'debug';
 import { UsbDrive, UsbDriveStatus } from '@votingworks/usb-drive';
 import { getMachineConfig } from './machine_config';
 import { Workspace, constructAuthMachineState } from './util/workspace';
@@ -43,8 +42,6 @@ import {
   SimpleServerStatus,
 } from './custom-paper-handler';
 import { ElectionState } from './types';
-
-const debug = makeDebug('mark-scan:app-backend');
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function buildApi(
@@ -257,14 +254,12 @@ export function buildApi(
     validateBallot(): void {
       assert(stateMachine);
 
-      debug('API validate');
       stateMachine.validateBallot();
     },
 
     invalidateBallot(): void {
       assert(stateMachine);
 
-      debug('API invalidate');
       stateMachine.invalidateBallot();
     },
 

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -591,10 +591,10 @@ export function buildMachine(
               paper_present: {
                 invoke: pollPaperStatus(),
                 on: {
-                  NO_PAPER_ANYWHERE: 'paper_nowhere',
+                  NO_PAPER_ANYWHERE: 'paper_absent',
                 },
               },
-              paper_nowhere: {
+              paper_absent: {
                 on: {
                   POLLWORKER_CONFIRMED_INVALIDATED_BALLOT: 'done',
                 },
@@ -834,9 +834,9 @@ export async function getPaperHandlerStateMachine({
         ):
           return 'waiting_for_invalidated_ballot_confirmation.paper_present';
         case state.matches(
-          'voting_flow.waiting_for_invalidated_ballot_confirmation.paper_nowhere'
+          'voting_flow.waiting_for_invalidated_ballot_confirmation.paper_absent'
         ):
-          return 'waiting_for_invalidated_ballot_confirmation.paper_nowhere';
+          return 'waiting_for_invalidated_ballot_confirmation.paper_absent';
         case state.matches('voting_flow.presenting_ballot'):
           return 'presenting_ballot';
         case state.matches('voting_flow.eject_to_front'):

--- a/apps/mark-scan/backend/src/custom-paper-handler/types.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/types.ts
@@ -20,7 +20,7 @@ export type SimpleStatus =
   | 'transition_interpretation'
   | 'waiting_for_ballot_data'
   | 'waiting_for_invalidated_ballot_confirmation.paper_present'
-  | 'waiting_for_invalidated_ballot_confirmation.paper_nowhere';
+  | 'waiting_for_invalidated_ballot_confirmation.paper_absent';
 
 export const SimpleStatusSchema: z.ZodSchema<SimpleStatus> = z.union([
   z.literal('accepting_paper'),
@@ -42,7 +42,7 @@ export const SimpleStatusSchema: z.ZodSchema<SimpleStatus> = z.union([
   z.literal('transition_interpretation'),
   z.literal('waiting_for_ballot_data'),
   z.literal('waiting_for_invalidated_ballot_confirmation.paper_present'),
-  z.literal('waiting_for_invalidated_ballot_confirmation.paper_nowhere'),
+  z.literal('waiting_for_invalidated_ballot_confirmation.paper_absent'),
 ]);
 
 export type SimpleServerStatus = SimpleStatus | 'no_hardware';

--- a/apps/mark-scan/backend/src/custom-paper-handler/types.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/types.ts
@@ -19,7 +19,8 @@ export type SimpleStatus =
   | 'scanning'
   | 'transition_interpretation'
   | 'waiting_for_ballot_data'
-  | 'waiting_for_invalidated_ballot_confirmation';
+  | 'waiting_for_invalidated_ballot_confirmation.paper_present'
+  | 'waiting_for_invalidated_ballot_confirmation.paper_nowhere';
 
 export const SimpleStatusSchema: z.ZodSchema<SimpleStatus> = z.union([
   z.literal('accepting_paper'),
@@ -40,7 +41,8 @@ export const SimpleStatusSchema: z.ZodSchema<SimpleStatus> = z.union([
   z.literal('scanning'),
   z.literal('transition_interpretation'),
   z.literal('waiting_for_ballot_data'),
-  z.literal('waiting_for_invalidated_ballot_confirmation'),
+  z.literal('waiting_for_invalidated_ballot_confirmation.paper_present'),
+  z.literal('waiting_for_invalidated_ballot_confirmation.paper_nowhere'),
 ]);
 
 export type SimpleServerStatus = SimpleStatus | 'no_hardware';

--- a/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
@@ -51,7 +51,7 @@ test('MarkAndPrint end-to-end flow', async () => {
   apiMock.expectGetMachineConfig({
     screenOrientation: 'portrait',
   });
-  apiMock.expectSetAcceptingPaperState();
+  apiMock.setPaperHandlerState('not_accepting_paper');
   const expectedElectionHash = electionDefinition.electionHash.substring(0, 10);
   const reload = jest.fn();
   apiMock.expectGetSystemSettings();
@@ -204,6 +204,7 @@ test('MarkAndPrint end-to-end flow', async () => {
   apiMock.mockApiClient.startCardlessVoterSession
     .expectCallWith({ ballotStyleId: '12', precinctId: '23' })
     .resolves();
+  apiMock.expectSetAcceptingPaperState();
   userEvent.click(await screen.findByText('12'));
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
     cardlessVoterUserParams: {
@@ -215,6 +216,7 @@ test('MarkAndPrint end-to-end flow', async () => {
     ballotStyleId: '12',
     precinctId: '23',
   });
+  apiMock.setPaperHandlerState('waiting_for_ballot_data');
 
   await findByTextWithMarkup('Number of contests on your ballot: 20');
   screen.getByText(/Center Springfield/);

--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -457,10 +457,24 @@ export function AppRoot({
     }
 
     if (
-      isPollWorkerAuth(authStatus) &&
-      // Ballot invalidation requires BallotContext, handled below
-      stateMachineState !== 'waiting_for_invalidated_ballot_confirmation'
+      (isPollWorkerAuth(authStatus) || isCardlessVoterAuth(authStatus)) &&
+      (stateMachineState ===
+        'waiting_for_invalidated_ballot_confirmation.paper_present' ||
+        stateMachineState ===
+          'waiting_for_invalidated_ballot_confirmation.paper_nowhere')
     ) {
+      return (
+        <BallotInvalidatedPage
+          authStatus={authStatus}
+          paperPresent={
+            stateMachineState ===
+            'waiting_for_invalidated_ballot_confirmation.paper_present'
+          }
+        />
+      );
+    }
+
+    if (isPollWorkerAuth(authStatus)) {
       if (stateMachineState === 'paper_reloaded') {
         return <PaperReloadedPage />;
       }
@@ -485,12 +499,7 @@ export function AppRoot({
     }
 
     if (pollsState === 'polls_open') {
-      if (
-        isCardlessVoterAuth(authStatus) ||
-        // Special case poll worker auth because both poll worker auth and BallotContext are needed to invalidate the ballot
-        (isPollWorkerAuth(authStatus) &&
-          stateMachineState === 'waiting_for_invalidated_ballot_confirmation')
-      ) {
+      if (isCardlessVoterAuth(authStatus)) {
         if (
           !isFeatureFlagEnabled(
             BooleanEnvironmentVariableName.SKIP_PAPER_HANDLER_HARDWARE_CHECK
@@ -508,16 +517,9 @@ export function AppRoot({
         let ballotContextProviderChild = <Ballot />;
         // Pages that condition on state machine state aren't nested under Ballot because Ballot uses
         // frontend browser routing for flow control and is completely independent of the state machine.
-        // We still want to nest pages that condition on the state machine under BallotContext so we render them here.
+        // We still want to nest some pages that condition on the state machine under BallotContext so we render them here.
         if (stateMachineState === 'presenting_ballot') {
           ballotContextProviderChild = <ValidateBallotPage />;
-        }
-        if (
-          stateMachineState === 'waiting_for_invalidated_ballot_confirmation'
-        ) {
-          ballotContextProviderChild = (
-            <BallotInvalidatedPage authStatus={authStatus} />
-          );
         }
 
         return (

--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -461,7 +461,7 @@ export function AppRoot({
       (stateMachineState ===
         'waiting_for_invalidated_ballot_confirmation.paper_present' ||
         stateMachineState ===
-          'waiting_for_invalidated_ballot_confirmation.paper_nowhere')
+          'waiting_for_invalidated_ballot_confirmation.paper_absent')
     ) {
       return (
         <BallotInvalidatedPage

--- a/apps/mark-scan/frontend/src/app_states.test.tsx
+++ b/apps/mark-scan/frontend/src/app_states.test.tsx
@@ -94,7 +94,9 @@ test('`waiting_for_invalidated_ballot_confirmation` state renders ballot invalid
     />
   );
 
-  apiMock.setPaperHandlerState('waiting_for_invalidated_ballot_confirmation');
+  apiMock.setPaperHandlerState(
+    'waiting_for_invalidated_ballot_confirmation.paper_present'
+  );
   apiMock.setAuthStatusCardlessVoterLoggedInWithDefaults(electionDefinition);
   await screen.findByText('Ask a Poll Worker for Help');
 });
@@ -115,7 +117,9 @@ test('`waiting_for_invalidated_ballot_confirmation` state renders ballot invalid
     />
   );
 
-  apiMock.setPaperHandlerState('waiting_for_invalidated_ballot_confirmation');
+  apiMock.setPaperHandlerState(
+    'waiting_for_invalidated_ballot_confirmation.paper_present'
+  );
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
     cardlessVoterUserParams: {
       ballotStyleId: electionDefinition.election.ballotStyles[0].id,

--- a/apps/mark-scan/frontend/src/pages/ballot_invalidated_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/ballot_invalidated_page.tsx
@@ -8,13 +8,19 @@ interface Props {
   authStatus:
     | InsertedSmartCardAuth.CardlessVoterLoggedIn
     | InsertedSmartCardAuth.PollWorkerLoggedIn;
+  paperPresent: boolean;
 }
 
-export function BallotInvalidatedPage({ authStatus }: Props): JSX.Element {
+export function BallotInvalidatedPage({
+  authStatus,
+  paperPresent,
+}: Props): JSX.Element {
   return (
     <AskPollWorkerPage
       authStatus={authStatus}
-      pollWorkerPage={<RemoveInvalidatedBallotPage />}
+      pollWorkerPage={
+        <RemoveInvalidatedBallotPage paperPresent={paperPresent} />
+      }
     >
       <P>{appStrings.instructionsBmdInvalidatedBallot()}</P>
     </AskPollWorkerPage>

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
@@ -252,7 +252,7 @@ export function PollWorkerScreen({
   ) {
     return (
       <Screen>
-        <Main centerChild>
+        <Main padded centerChild>
           <Text center>
             <H1
               aria-label={`Ballot style ${pollWorkerAuth.cardlessVoterUser.ballotStyleId} has been activated.`}

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
@@ -236,6 +236,13 @@ export function PollWorkerScreen({
   }
 
   if (
+    stateMachineState === 'accepting_paper' ||
+    stateMachineState === 'loading_paper'
+  ) {
+    return <LoadPaperPage />;
+  }
+
+  if (
     hasVotes &&
     pollWorkerAuth.cardlessVoterUser &&
     // It's expected there are votes in app state if the state machine reports a blank page after printing.
@@ -250,7 +257,7 @@ export function PollWorkerScreen({
             <H1
               aria-label={`Ballot style ${pollWorkerAuth.cardlessVoterUser.ballotStyleId} has been activated.`}
             >
-              Ballot Contains Votes
+              Voting Session in Progress
             </H1>
             <P>
               Remove card to allow voter to continue voting, or reset ballot.
@@ -279,13 +286,6 @@ export function PollWorkerScreen({
       return (
         <PaperHandlerHardwareCheckDisabledScreen message="Remove the poll worker card to continue." />
       );
-    }
-
-    if (
-      stateMachineState === 'accepting_paper' ||
-      stateMachineState === 'loading_paper'
-    ) {
-      return <LoadPaperPage />;
     }
 
     const { precinctId, ballotStyleId } = pollWorkerAuth.cardlessVoterUser;
@@ -379,11 +379,7 @@ export function PollWorkerScreen({
                           key={precinct.id}
                           aria-label={`Activate Voter Session for Precinct ${precinct.name}`}
                           onPress={() => {
-                            setAcceptingPaperStateMutation.mutate(undefined, {
-                              onSuccess() {
-                                setSelectedCardlessVoterPrecinctId(precinct.id);
-                              },
-                            });
+                            setSelectedCardlessVoterPrecinctId(precinct.id);
                           }}
                           variant={
                             selectedCardlessVoterPrecinctId === precinct.id

--- a/apps/mark-scan/frontend/src/pages/remove_invalidated_ballot_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/remove_invalidated_ballot_page.tsx
@@ -1,35 +1,44 @@
-import { useContext } from 'react';
-
 import { Button, P } from '@votingworks/ui';
+import { useHistory } from 'react-router-dom';
+import { useEffect } from 'react';
 import { confirmInvalidateBallot } from '../api';
-import { BallotContext } from '../contexts/ballot_context';
 import { CenteredPageLayout } from '../components/centered_page_layout';
 
-export function RemoveInvalidatedBallotPage(): JSX.Element {
-  const { resetBallot, endVoterSession } = useContext(BallotContext);
+interface Props {
+  paperPresent: boolean;
+}
+
+export function RemoveInvalidatedBallotPage(props: Props): JSX.Element {
+  const { paperPresent } = props;
 
   const confirmInvalidateBallotMutation = confirmInvalidateBallot.useMutation();
 
-  async function onPressContinue() {
-    // Reset session and ballot before changing the state machine state. If done
-    // in the reverse order the screen will flicker
-    await endVoterSession();
-    resetBallot();
+  const history = useHistory();
+  useEffect(() => {
+    history.push('/ready-to-review');
+  });
+
+  function onPressContinue() {
     confirmInvalidateBallotMutation.mutate(undefined);
   }
 
   return (
     <CenteredPageLayout
-      title="Remove Ballot"
+      title={paperPresent ? 'Remove Ballot' : 'Ballot Removed'}
       buttons={
-        <Button onPress={onPressContinue}>Start a New Voter Session</Button>
+        <Button disabled={paperPresent} onPress={onPressContinue}>
+          Continue
+        </Button>
       }
       voterFacing={false}
     >
-      <P>
-        Remove the ballot and press below to start a new voter session. Remember
-        to spoil the old ballot.
-      </P>
+      {paperPresent ? (
+        <P>Please remove the incorrect ballot.</P>
+      ) : (
+        <P>
+          The incorrect ballot has been removed. Remember to spoil the ballot.
+        </P>
+      )}
     </CenteredPageLayout>
   );
 }

--- a/apps/mark-scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/mark-scan/frontend/test/helpers/mock_api_client.tsx
@@ -227,7 +227,6 @@ export function createApiMock() {
     // Mocked version of a real method on the API client
     expectSetAcceptingPaperState(): void {
       mockApiClient.setAcceptingPaperState.expectCallWith().resolves();
-      setPaperHandlerState('accepting_paper');
     },
 
     // Helper on the mock API client; does not exist on real API client

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -5,6 +5,9 @@ import { UiString } from './ui_string';
 
 // TODO(kofi): Add lint rule to ensure object keys match uiStringKey props.
 
+// After updating this file, run `pnpm build[:app-strings-catalog]` from `libs/ui`
+// to generate libs/ui/src/ui_strings/app_strings_catalog/latest.json
+
 /* istanbul ignore next - mostly presentational, tested via apps where relevant */
 export const appStrings = {
   // TODO(kofi): Fill out.
@@ -148,7 +151,7 @@ export const appStrings = {
   instructionsBmdInvalidatedBallot: () => (
     <UiString uiStringKey="instructionsBmdInvalidatedBallot">
       You have indicated your ballot needs changes. Please alert a poll worker
-      to invalidate your incorrect ballot and restart your voting session.
+      to invalidate the incorrect ballot sheet.
     </UiString>
   ),
 

--- a/libs/ui/src/ui_strings/app_strings_catalog/latest.json
+++ b/libs/ui/src/ui_strings/app_strings_catalog/latest.json
@@ -32,7 +32,7 @@
   "instructionsBmdCastBallotStep1": "1. Verify your official ballot.",
   "instructionsBmdCastBallotStep2": "2. Scan your official ballot.",
   "instructionsBmdContestNavigation": "To navigate through the contest choices, use the down button. To move to the next contest, use the right button.",
-  "instructionsBmdInvalidatedBallot": "You have indicated your ballot needs changes. Please alert a poll worker to invalidate your incorrect ballot and restart your voting session.",
+  "instructionsBmdInvalidatedBallot": "You have indicated your ballot needs changes. Please alert a poll worker to invalidate the incorrect ballot sheet.",
   "instructionsBmdLoadPaper": "Please feed one sheet of paper into the front input tray. The printer will automatically grab the paper when positioned correctly.",
   "instructionsBmdPaperJam": "Please alert a poll worker to clear the jam, opening the printer cover or ballot box if necessary.",
   "instructionsBmdReviewPageChangingVotes": "To change your vote in any contest, use the select button to navigate to that contest. When you are finished making your ballot selections and ready to print your ballot, use the right button to print your ballot.",


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/3909

Improves the flow for spoiling a ballot in post-print ballot validation
* Rather than restarting the voter session, the session is saved. The voter is returned to the review screen after the poll worker removes the old ballot, loads a new sheet, and removes their card
* The ballot spoil flow now checks that the ballot is removed by the poll worker before allowing the poll worker to continue

## Demo Video or Screenshot

Happy path

https://github.com/votingworks/vxsuite/assets/1060688/75a28cb1-e35f-44ee-8213-bccd34d25a42

Lightly stress testing pulling paper early and repeated auth changes

https://github.com/votingworks/vxsuite/assets/1060688/a89d9fa6-8547-4c7f-9662-7bf8205a3abc




## Testing Plan
- updated component and e2e tests

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced. (no new actions or errors introduced)
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
