### PR TITLE
[i18n/audio] Fix repeated web AudioContext instantiations

### DIFF
--- a/libs/ui/src/ui_strings/audio_context.tsx
+++ b/libs/ui/src/ui_strings/audio_context.tsx
@@ -43,6 +43,19 @@ export interface UiStringsAudioContextProviderProps {
   children: React.ReactNode;
 }
 
+let webAudioContext: AudioContext | undefined;
+function getWebAudioContextInstance() {
+  if (!window.AudioContext) {
+    return undefined;
+  }
+
+  if (!webAudioContext) {
+    webAudioContext = new AudioContext();
+  }
+
+  return webAudioContext;
+}
+
 export function UiStringsAudioContextProvider(
   props: UiStringsAudioContextProviderProps
 ): JSX.Element {
@@ -54,9 +67,7 @@ export function UiStringsAudioContextProvider(
   );
   const [gainDb, setGainDb] = React.useState<number>(DEFAULT_GAIN_DB);
 
-  const webAudioContextRef = React.useRef(
-    window.AudioContext ? new AudioContext() : undefined
-  );
+  const webAudioContextRef = React.useRef(getWebAudioContextInstance());
 
   const reset = React.useCallback(() => {
     setGainDb(DEFAULT_GAIN_DB);


### PR DESCRIPTION
## Overview

Fixing an issue from https://github.com/votingworks/vxsuite/pull/4463 with unused `AudioContext` instances getting created on re-renders of the `UiStringsAudioContextProvider`. Ensuring that we only create an `AudioContext` once per app load.

## Testing Plan
- Existing automated tests + manual testing with debug logging

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
