### PR TITLE
chore: remove unused `Store.getSchemaDigest` method

### DIFF
--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -29,8 +29,6 @@ import {
 } from '@votingworks/types';
 import { assert, assertDefined, Optional } from '@votingworks/basics';
 import makeDebug from 'debug';
-import * as fs from 'fs-extra';
-import { sha256 } from 'js-sha256';
 import { DateTime } from 'luxon';
 import { dirname, join } from 'path';
 import { v4 as uuid } from 'uuid';
@@ -136,14 +134,6 @@ export class Store {
 
   getDbPath(): string {
     return this.client.getDatabasePath();
-  }
-
-  /**
-   * Gets the sha256 digest of the current schema file.
-   */
-  static getSchemaDigest(): string {
-    const schemaSql = fs.readFileSync(SchemaPath, 'utf-8');
-    return sha256(schemaSql);
   }
 
   /**

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -28,8 +28,6 @@ import {
   PollsTransitionType,
 } from '@votingworks/types';
 import { assert, assertDefined, Optional, typedAs } from '@votingworks/basics';
-import * as fs from 'fs-extra';
-import { sha256 } from 'js-sha256';
 import { DateTime } from 'luxon';
 import { join } from 'path';
 import { v4 as uuid } from 'uuid';
@@ -136,14 +134,6 @@ export class Store {
 
   getDbPath(): string {
     return this.client.getDatabasePath();
-  }
-
-  /**
-   * Gets the sha256 digest of the current schema file.
-   */
-  static getSchemaDigest(): string {
-    const schemaSql = fs.readFileSync(SchemaPath, 'utf-8');
-    return sha256(schemaSql);
   }
 
   /**


### PR DESCRIPTION
## Overview
This has been unused since #1456 when it became the responsibility of the `DbClient` class, but it was never removed from the `Store` classes.

## Demo Video or Screenshot
n/a

## Testing Plan
- [x] Existing automated tests.