### PR TITLE
Change election title on ballots for NH school districts

### DIFF
--- a/libs/hmpb/layout/package.json
+++ b/libs/hmpb/layout/package.json
@@ -49,6 +49,7 @@
     "@types/jest": "^29.5.3",
     "@types/react": "18.2.18",
     "@types/react-dom": "^18.2.7",
+    "@votingworks/fixtures": "workspace:*",
     "@votingworks/monorepo-utils": "workspace:*",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "2.2.0",

--- a/libs/hmpb/layout/src/layout.ts
+++ b/libs/hmpb/layout/src/layout.ts
@@ -368,7 +368,7 @@ export function TimingMarkGrid({ m }: { m: Measurements }): AnyElement {
 // school district, then change the election title. In the future, we might
 // support customization like this by allowing custom content for different
 // precinct splits or by using different ballot templates.
-function modifyElectionTitleForNhSchoolElections(
+function getElectionTitleOrNhSchoolElectionTitle(
   election: Election,
   ballotStyle: BallotStyle
 ): string {
@@ -430,7 +430,7 @@ function HeaderAndInstructions({
         }`
       : '';
 
-  const electionTitle = modifyElectionTitleForNhSchoolElections(
+  const electionTitle = getElectionTitleOrNhSchoolElectionTitle(
     election,
     ballotStyle
   );

--- a/libs/hmpb/layout/tsconfig.json
+++ b/libs/hmpb/layout/tsconfig.json
@@ -14,6 +14,7 @@
   "references": [
     { "path": "../../../libs/ballot-encoder/tsconfig.build.json" },
     { "path": "../../../libs/basics/tsconfig.build.json" },
+    { "path": "../../../libs/fixtures/tsconfig.build.json" },
     { "path": "../../../libs/types/tsconfig.build.json" }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4155,6 +4155,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.7
         version: 18.2.7
+      '@votingworks/fixtures':
+        specifier: workspace:*
+        version: link:../../fixtures
       '@votingworks/monorepo-utils':
         specifier: workspace:*
         version: link:../../monorepo-utils
@@ -15509,7 +15512,7 @@ packages:
       semver: 7.3.2
       tapable: 1.1.3
       typescript: 5.2.2
-      webpack: 5.88.2(esbuild@0.17.11)
+      webpack: 5.88.2(esbuild@0.18.17)
 
   /form-data@2.5.1:
     resolution: {integrity: sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==}
@@ -19808,7 +19811,7 @@ packages:
       strip-ansi: 6.0.1
       text-table: 0.2.0
       typescript: 5.2.2
-      webpack: 5.88.2(esbuild@0.17.11)
+      webpack: 5.88.2(esbuild@0.18.17)
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -21588,7 +21591,7 @@ packages:
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
 
-  /terser-webpack-plugin@5.3.9(esbuild@0.17.11)(webpack@5.88.2):
+  /terser-webpack-plugin@5.3.9(esbuild@0.18.17)(webpack@5.88.2):
     resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -21605,12 +21608,12 @@ packages:
         optional: true
     dependencies:
       '@jridgewell/trace-mapping': 0.3.18
-      esbuild: 0.17.11
+      esbuild: 0.18.17
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.19.2
-      webpack: 5.88.2(esbuild@0.17.11)
+      webpack: 5.88.2(esbuild@0.18.17)
 
   /terser@4.8.1:
     resolution: {integrity: sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==}
@@ -22610,7 +22613,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /webpack@5.88.2(esbuild@0.17.11):
+  /webpack@5.88.2(esbuild@0.18.17):
     resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -22641,7 +22644,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(esbuild@0.17.11)(webpack@5.88.2)
+      terser-webpack-plugin: 5.3.9(esbuild@0.18.17)(webpack@5.88.2)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Overview

Closes #4369 

NH runs simultaneous town and school district elections. The ballots for these two elections need to be scanned on the same scanner, meaning they must use the same election definition. However, they need to show a different election title on the ballot. For now, we add a special case in the ballot layout code to support this.

## Demo Video or Screenshot


https://github.com/votingworks/vxsuite/assets/530106/34818b5e-81e5-4c97-aa86-bd9185387314



## Testing Plan
- Added unit test
- Manual test in VxDesign

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
