### PR TITLE
remove irrelevant accessible controller connection warning

### DIFF
--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -155,7 +155,7 @@ export function AppRoot({
   const machineConfigQuery = getMachineConfig.useQuery();
 
   const devices = useDevices({ hardware, logger });
-  const { accessibleController, computer } = devices;
+  const { computer } = devices;
 
   const usbDriveStatusQuery = getUsbDriveStatus.useQuery();
   const authStatusQuery = getAuthStatus.useQuery();
@@ -551,7 +551,6 @@ export function AppRoot({
         <InsertCardScreen
           appPrecinct={precinctSelection}
           electionDefinition={optionalElectionDefinition}
-          showNoAccessibleControllerWarning={!accessibleController}
           showNoChargerAttachedWarning={!computer.batteryIsCharging}
           isLiveMode={!isTestMode}
           pollsState={pollsState}

--- a/apps/mark-scan/frontend/src/app_setup_errors.test.tsx
+++ b/apps/mark-scan/frontend/src/app_setup_errors.test.tsx
@@ -37,48 +37,6 @@ const lowBatteryErrorScreenText = 'No Power Detected and Battery is Low';
 const noPowerDetectedWarningText = 'No Power Detected.';
 
 describe('Displays setup warning messages and errors screens', () => {
-  it('Displays warning if Accessible Controller connection is lost', async () => {
-    apiMock.expectGetMachineConfig();
-    const hardware = MemoryHardware.buildStandard();
-    hardware.setAccessibleControllerConnected(true);
-
-    apiMock.expectGetElectionDefinition(electionGeneralDefinition);
-    apiMock.expectGetElectionState({
-      precinctSelection: ALL_PRECINCTS_SELECTION,
-      pollsState: 'polls_open',
-    });
-
-    render(
-      <App
-        hardware={hardware}
-        apiClient={apiMock.mockApiClient}
-        reload={jest.fn()}
-      />
-    );
-    const accessibleControllerWarningText =
-      'Voting with an accessible controller is not currently available.';
-
-    // Start on Insert Card screen
-    await screen.findByText(insertCardScreenText);
-    expect(screen.queryByText(accessibleControllerWarningText)).toBeFalsy();
-
-    // Disconnect Accessible Controller
-    act(() => {
-      hardware.setAccessibleControllerConnected(false);
-    });
-    await advanceTimersAndPromises();
-    screen.getByText(accessibleControllerWarningText);
-    screen.getByText(insertCardScreenText);
-
-    // Reconnect Accessible Controller
-    act(() => {
-      hardware.setAccessibleControllerConnected(true);
-    });
-    await advanceTimersAndPromises();
-    expect(screen.queryByText(accessibleControllerWarningText)).toBeFalsy();
-    screen.getByText(insertCardScreenText);
-  });
-
   it('Displays error screen if Card Reader connection is lost', async () => {
     apiMock.expectGetMachineConfig();
     const hardware = MemoryHardware.buildStandard();

--- a/apps/mark-scan/frontend/src/pages/insert_card_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/insert_card_screen.test.tsx
@@ -30,7 +30,6 @@ test('renders correctly', async () => {
           showNoChargerAttachedWarning={false}
           isLiveMode={false}
           pollsState="polls_closed_initial"
-          showNoAccessibleControllerWarning={false}
         />
       </QueryClientProvider>
     </ApiClientContext.Provider>

--- a/apps/mark-scan/frontend/src/pages/insert_card_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/insert_card_screen.tsx
@@ -27,7 +27,6 @@ interface Props {
   showNoChargerAttachedWarning: boolean;
   isLiveMode: boolean;
   pollsState: PollsState;
-  showNoAccessibleControllerWarning: boolean;
 }
 
 export function InsertCardScreen({
@@ -36,7 +35,6 @@ export function InsertCardScreen({
   showNoChargerAttachedWarning,
   isLiveMode,
   pollsState,
-  showNoAccessibleControllerWarning,
 }: Props): JSX.Element | null {
   useEffect(triggerAudioFocus, []);
 
@@ -87,11 +85,6 @@ export function InsertCardScreen({
             <InsertCardImage />
           </P>
           {mainText}
-          {showNoAccessibleControllerWarning && (
-            <Caption>
-              Voting with an accessible controller is not currently available.
-            </Caption>
-          )}
         </Prose>
       </Main>
       <ElectionInfoBar


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/4471

Removes a message that warns when an accessible controller is not connected. This is a leftover from VxMark's detachable controller. VxMarkScan's controller isn't detachable and so should always be connected.

There's an argument to be made that we should still check for the built-in controller's connection status. While a hardware failure is unlikely, it might be worth it to add this back in the future. However, continually reporting connection status to the frontend requires a little planning so for now we should remove this misleading error.

## Demo Video or Screenshot

Before

![Screenshot 2024-01-05 at 10 53 56 AM](https://github.com/votingworks/vxsuite/assets/1060688/8b0e3738-bbfa-40e8-9ac5-ba5e2c69c6fe)

After

![Screenshot 2024-01-05 at 10 43 37 AM](https://github.com/votingworks/vxsuite/assets/1060688/79df41f3-5b59-40dc-b800-958fd8a1e34f)


## Testing Plan

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced. (no new actions)
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
