### PR TITLE
Translate app strings and add to election packages

### DIFF
--- a/apps/design/backend/src/worker/context.ts
+++ b/apps/design/backend/src/worker/context.ts
@@ -1,0 +1,9 @@
+import { GoogleCloudSpeechSynthesizer } from '../language_and_audio/speech_synthesizer';
+import { GoogleCloudTranslator } from '../language_and_audio/translator';
+import { Workspace } from '../workspace';
+
+export interface WorkerContext {
+  speechSynthesizer: GoogleCloudSpeechSynthesizer;
+  translator: GoogleCloudTranslator;
+  workspace: Workspace;
+}

--- a/apps/design/backend/src/worker/generate_election_package.ts
+++ b/apps/design/backend/src/worker/generate_election_package.ts
@@ -1,0 +1,51 @@
+import { createWriteStream } from 'fs';
+import JsZip from 'jszip';
+import path from 'path';
+import { pipeline } from 'stream/promises';
+import { layOutAllBallotStyles } from '@votingworks/hmpb-layout';
+import {
+  BallotType,
+  ElectionPackageFileName,
+  getDisplayElectionHash,
+  Id,
+} from '@votingworks/types';
+
+import { PORT } from '../globals';
+import { WorkerContext } from './context';
+
+export async function generateElectionPackage(
+  { workspace }: WorkerContext,
+  { electionId }: { electionId: Id }
+): Promise<void> {
+  const { assetDirectoryPath, store } = workspace;
+
+  const { election, layoutOptions, systemSettings } =
+    store.getElection(electionId);
+
+  const { electionDefinition } = layOutAllBallotStyles({
+    election,
+    // Ballot type and ballot mode shouldn't change the election definition, so it doesn't matter
+    // what we pass here
+    ballotType: BallotType.Precinct,
+    ballotMode: 'test',
+    layoutOptions,
+  }).unsafeUnwrap();
+  const zip = new JsZip();
+  zip.file(ElectionPackageFileName.ELECTION, electionDefinition.electionData);
+  zip.file(
+    ElectionPackageFileName.SYSTEM_SETTINGS,
+    JSON.stringify(systemSettings, null, 2)
+  );
+
+  const displayElectionHash = getDisplayElectionHash(electionDefinition);
+  const fileName = `election-package-${displayElectionHash}.zip`;
+  const filePath = path.join(assetDirectoryPath, fileName);
+  await pipeline(
+    zip.generateNodeStream({ streamFiles: true }),
+    createWriteStream(filePath)
+  );
+  store.setElectionPackageUrl({
+    electionId,
+    electionPackageUrl: `http://localhost:${PORT}/${fileName}`,
+  });
+}

--- a/apps/design/backend/src/worker/generate_election_package.ts
+++ b/apps/design/backend/src/worker/generate_election_package.ts
@@ -1,26 +1,76 @@
 import { createWriteStream } from 'fs';
+import fs from 'fs/promises';
 import JsZip from 'jszip';
 import path from 'path';
 import { pipeline } from 'stream/promises';
+import { z } from 'zod';
+import { assertDefined } from '@votingworks/basics';
 import { layOutAllBallotStyles } from '@votingworks/hmpb-layout';
 import {
   BallotType,
   ElectionPackageFileName,
   getDisplayElectionHash,
   Id,
+  LanguageCode,
+  safeParseJson,
+  UiStringsPackage,
 } from '@votingworks/types';
 
 import { PORT } from '../globals';
+import { GoogleCloudTranslator } from '../language_and_audio/translator';
 import { WorkerContext } from './context';
 
+async function translateAppStrings(
+  translator: GoogleCloudTranslator
+): Promise<UiStringsPackage> {
+  const appStringsCatalogFileContents = await fs.readFile(
+    path.join(
+      __dirname,
+      // TODO: Account for system version
+      '../../../../../libs/ui/src/ui_strings/app_strings_catalog/latest.json'
+    ),
+    'utf-8'
+  );
+  const appStringsCatalog = safeParseJson(
+    appStringsCatalogFileContents,
+    z.record(z.string())
+  ).unsafeUnwrap();
+
+  const appStringKeys = Object.keys(appStringsCatalog).sort();
+  const appStringsInEnglish = appStringKeys.map(
+    (key) => appStringsCatalog[key]
+  );
+
+  const appStrings: UiStringsPackage = {};
+  for (const languageCode of Object.values(LanguageCode)) {
+    appStrings[languageCode] = {};
+    const appStringsInLanguage =
+      languageCode === LanguageCode.ENGLISH
+        ? appStringsInEnglish
+        : await translator.translateText(appStringsInEnglish, languageCode);
+    for (const [i, key] of appStringKeys.entries()) {
+      assertDefined(appStrings[languageCode])[key] = appStringsInLanguage[i];
+    }
+  }
+  return appStrings;
+}
+
 export async function generateElectionPackage(
-  { workspace }: WorkerContext,
+  { translator, workspace }: WorkerContext,
   { electionId }: { electionId: Id }
 ): Promise<void> {
   const { assetDirectoryPath, store } = workspace;
 
   const { election, layoutOptions, systemSettings } =
     store.getElection(electionId);
+
+  const zip = new JsZip();
+
+  const appStrings = await translateAppStrings(translator);
+  zip.file(
+    ElectionPackageFileName.APP_STRINGS,
+    JSON.stringify(appStrings, null, 2)
+  );
 
   const { electionDefinition } = layOutAllBallotStyles({
     election,
@@ -30,8 +80,8 @@ export async function generateElectionPackage(
     ballotMode: 'test',
     layoutOptions,
   }).unsafeUnwrap();
-  const zip = new JsZip();
   zip.file(ElectionPackageFileName.ELECTION, electionDefinition.electionData);
+
   zip.file(
     ElectionPackageFileName.SYSTEM_SETTINGS,
     JSON.stringify(systemSettings, null, 2)

--- a/apps/design/backend/src/worker/tasks.ts
+++ b/apps/design/backend/src/worker/tasks.ts
@@ -15,14 +15,17 @@ import {
 
 import { PORT } from '../globals';
 import { BackgroundTask } from '../store';
-import { Workspace } from '../workspace';
+import { WorkerContext } from './context';
 
 async function generateElectionPackage(
-  { assetDirectoryPath, store }: Workspace,
+  { workspace }: WorkerContext,
   { electionId }: { electionId: Id }
 ): Promise<void> {
+  const { assetDirectoryPath, store } = workspace;
+
   const { election, layoutOptions, systemSettings } =
     store.getElection(electionId);
+
   const { electionDefinition } = layOutAllBallotStyles({
     election,
     // Ballot type and ballot mode shouldn't change the election definition, so it doesn't matter
@@ -52,7 +55,7 @@ async function generateElectionPackage(
 }
 
 export async function processBackgroundTask(
-  workspace: Workspace,
+  context: WorkerContext,
   { taskName, payload }: BackgroundTask
 ): Promise<void> {
   switch (taskName) {
@@ -61,7 +64,7 @@ export async function processBackgroundTask(
         payload,
         z.object({ electionId: z.string() })
       ).unsafeUnwrap();
-      await generateElectionPackage(workspace, parsedPayload);
+      await generateElectionPackage(context, parsedPayload);
       break;
     }
     /* istanbul ignore next: Compile-time check for completeness */

--- a/apps/design/backend/src/worker/tasks.ts
+++ b/apps/design/backend/src/worker/tasks.ts
@@ -1,58 +1,10 @@
-import { createWriteStream } from 'fs';
-import JsZip from 'jszip';
-import path from 'path';
-import { pipeline } from 'stream/promises';
 import { z } from 'zod';
 import { throwIllegalValue } from '@votingworks/basics';
-import { layOutAllBallotStyles } from '@votingworks/hmpb-layout';
-import {
-  BallotType,
-  ElectionPackageFileName,
-  getDisplayElectionHash,
-  Id,
-  safeParseJson,
-} from '@votingworks/types';
+import { safeParseJson } from '@votingworks/types';
 
-import { PORT } from '../globals';
 import { BackgroundTask } from '../store';
 import { WorkerContext } from './context';
-
-async function generateElectionPackage(
-  { workspace }: WorkerContext,
-  { electionId }: { electionId: Id }
-): Promise<void> {
-  const { assetDirectoryPath, store } = workspace;
-
-  const { election, layoutOptions, systemSettings } =
-    store.getElection(electionId);
-
-  const { electionDefinition } = layOutAllBallotStyles({
-    election,
-    // Ballot type and ballot mode shouldn't change the election definition, so it doesn't matter
-    // what we pass here
-    ballotType: BallotType.Precinct,
-    ballotMode: 'test',
-    layoutOptions,
-  }).unsafeUnwrap();
-  const zip = new JsZip();
-  zip.file(ElectionPackageFileName.ELECTION, electionDefinition.electionData);
-  zip.file(
-    ElectionPackageFileName.SYSTEM_SETTINGS,
-    JSON.stringify(systemSettings, null, 2)
-  );
-
-  const displayElectionHash = getDisplayElectionHash(electionDefinition);
-  const fileName = `election-package-${displayElectionHash}.zip`;
-  const filePath = path.join(assetDirectoryPath, fileName);
-  await pipeline(
-    zip.generateNodeStream({ streamFiles: true }),
-    createWriteStream(filePath)
-  );
-  store.setElectionPackageUrl({
-    electionId,
-    electionPackageUrl: `http://localhost:${PORT}/${fileName}`,
-  });
-}
+import { generateElectionPackage } from './generate_election_package';
 
 export async function processBackgroundTask(
   context: WorkerContext,


### PR DESCRIPTION
## Overview

This PR translates app strings and adds them to election packages exported by VxDesign, in the format expected by VxSuite machines. The first translation run, before the VxDesign translation cache was populated, was actually quite fast! (The slowest part of language and audio file generation is going to be speech synthesis.)

## Demo Video or Screenshot

https://github.com/votingworks/vxsuite/assets/12616928/d39e032a-ebe7-4974-81d3-b816bc0a5e28

## Testing Plan

- [x] Tested VxDesign export manually
- [x] Tested VxAdmin import manually
- [x] Updated automated tests

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A