### PR TITLE
Translate election date and add to election packages

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -18,6 +18,7 @@ import {
   District,
   DistrictId,
   Election,
+  ElectionStringKey,
   ElectionType,
   LanguageCode,
   Parties,
@@ -317,10 +318,11 @@ test('Election package export', async () => {
   // Check overall structure of zip file
 
   const zip = await JsZip.loadAsync(electionPackageContents);
-  expect(Object.keys(zip.files)).toEqual([
+  expect(Object.keys(zip.files).sort()).toEqual([
     'appStrings.json',
     'election.json',
     'systemSettings.json',
+    'vxElectionStrings.json',
   ]);
 
   // Check appStrings.json
@@ -358,6 +360,19 @@ test('Election package export', async () => {
         `${appStringInEnglish} (in ${languageCode})`
       );
     }
+  }
+
+  // Check vxElectionStrings.json
+
+  const vxElectionStrings = safeParseJson(
+    await assertDefined(zip.file('vxElectionStrings.json')).async('text'),
+    UiStringsPackageSchema
+  ).unsafeUnwrap();
+
+  for (const languageCode of Object.values(LanguageCode)) {
+    expect(
+      vxElectionStrings[languageCode]?.[ElectionStringKey.ELECTION_DATE]
+    ).toBeDefined();
   }
 
   // Check election.json


### PR DESCRIPTION
## Overview

We want to translate election date, but there isn't an `InternationalizedText` field in the CDF schema for it. This PR accordingly translates election date and adds it to election packages via the `vxElectionStrings.json` file that @kofi-q introduced in https://github.com/votingworks/vxsuite/pull/4202.

_Sample `vxElectionStrings.json` file_

```json
{
  "zh-Hans": {
    "electionDate": "2024年1月1日"
  },
  "zh-Hant": {
    "electionDate": "2024年1月1日"
  },
  "en": {
    "electionDate": "January 1, 2024"
  },
  "es-US": {
    "electionDate": "1 de enero de 2024"
  }
}
```

## Testing Plan

- [x] Updated automated tests
- [x] Tested VxDesign export manually
- [x] Tested VxAdmin import manually

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A