### PR TITLE
[i18n/audio] Use <ReadOnLoad> component in BMD screens and modals

### DIFF
--- a/apps/mark-scan/frontend/src/components/centered_page_layout.tsx
+++ b/apps/mark-scan/frontend/src/components/centered_page_layout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Font, H1, Main, Screen } from '@votingworks/ui';
+import { Font, H1, Main, ReadOnLoad, Screen } from '@votingworks/ui';
 import { ButtonFooter } from '@votingworks/mark-flow-ui';
 
 export interface CenteredPageLayoutProps {
@@ -15,13 +15,17 @@ export function CenteredPageLayout(
 ): JSX.Element {
   const { buttons, children, title, voterFacing } = props;
 
+  const mainContent = (
+    <Font align="center">
+      {title && <H1>{title}</H1>}
+      {children}
+    </Font>
+  );
+
   return (
     <Screen>
       <Main padded centerChild>
-        <Font align="center" id={voterFacing ? 'audiofocus' : undefined}>
-          {title && <H1>{title}</H1>}
-          {children}
-        </Font>
+        {voterFacing ? <ReadOnLoad>{mainContent}</ReadOnLoad> : mainContent}
       </Main>
       {buttons && <ButtonFooter>{buttons}</ButtonFooter>}
     </Screen>

--- a/apps/mark-scan/frontend/src/pages/card_error_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/card_error_screen.tsx
@@ -1,17 +1,12 @@
-import { useEffect } from 'react';
-
 import { Main, Screen, Prose, RotateCardImage, H1, P } from '@votingworks/ui';
-import { triggerAudioFocus } from '../utils/trigger_audio_focus';
 
 export function CardErrorScreen(): JSX.Element {
-  useEffect(triggerAudioFocus, []);
-
   return (
     <Screen>
       <Main centerChild>
         <div>
           <RotateCardImage />
-          <Prose textCenter id="audiofocus">
+          <Prose textCenter>
             <H1>Card is Backwards</H1>
             <P>Remove the card, turn it around, and insert it again.</P>
           </Prose>

--- a/apps/mark-scan/frontend/src/pages/insert_card_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/insert_card_screen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import {
   ElectionDefinition,
   PollsState,
@@ -19,7 +19,6 @@ import {
 } from '@votingworks/ui';
 
 import { throwIllegalValue } from '@votingworks/basics';
-import { triggerAudioFocus } from '../utils/trigger_audio_focus';
 
 interface Props {
   appPrecinct: PrecinctSelection;
@@ -38,8 +37,6 @@ export function InsertCardScreen({
   pollsState,
   showNoAccessibleControllerWarning,
 }: Props): JSX.Element | null {
-  useEffect(triggerAudioFocus, []);
-
   const mainText = (() => {
     switch (pollsState) {
       case 'polls_closed_initial':
@@ -75,7 +72,7 @@ export function InsertCardScreen({
     <Screen>
       {!isLiveMode && <TestMode />}
       <Main centerChild>
-        <Prose textCenter id="audiofocus">
+        <Prose textCenter>
           {showNoChargerAttachedWarning && (
             <Caption>
               <Icons.Warning color="warning" />{' '}

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon';
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 
 import {
   BallotStyleId,
@@ -50,7 +50,6 @@ import type { MachineConfig } from '@votingworks/mark-scan-backend';
 import styled from 'styled-components';
 import { find, throwIllegalValue } from '@votingworks/basics';
 
-import { triggerAudioFocus } from '../utils/trigger_audio_focus';
 import { DiagnosticsScreen } from './diagnostics_screen';
 import { LoadPaperPage } from './load_paper_page';
 import {
@@ -124,11 +123,7 @@ function UpdatePollsButton({
       {isConfirmationModalOpen && (
         <Modal
           title={`Confirm ${action}`}
-          content={
-            <Prose id="modalaudiofocus">
-              <P>{explanationText}</P>
-            </Prose>
-          }
+          content={<P>{explanationText}</P>}
           actions={
             <React.Fragment>
               <Button variant="primary" onPress={confirmUpdate}>
@@ -203,9 +198,6 @@ export function PollWorkerScreen({
     : [];
   /*
    * Various state parameters to handle controlling when certain modals on the page are open or not.
-   * If you are adding a new modal make sure to add the new parameter to the triggerAudiofocus useEffect
-   * dependency. This will retrigger the audio to explain landing on the PollWorker homepage
-   * when the modal closes.
    */
   const [isConfirmingEnableLiveMode, setIsConfirmingEnableLiveMode] = useState(
     !isLiveMode && isElectionDay
@@ -214,17 +206,6 @@ export function PollWorkerScreen({
     return setIsConfirmingEnableLiveMode(false);
   }
   const [isDiagnosticsScreenOpen, setIsDiagnosticsScreenOpen] = useState(false);
-
-  /*
-   * Trigger audiofocus for the PollWorker screen landing page. This occurs when
-   * the component first renders, or any of the modals in the page are closed. If you
-   * add a new modal to this component add it's state parameter as a dependency here.
-   */
-  useEffect(() => {
-    if (!isConfirmingEnableLiveMode) {
-      triggerAudioFocus();
-    }
-  }, [isConfirmingEnableLiveMode]);
 
   const canSelectBallotStyle = pollsState === 'polls_open';
   const [isHidingSelectBallotStyle, setIsHidingSelectBallotStyle] =
@@ -295,7 +276,7 @@ export function PollWorkerScreen({
       return (
         <Screen>
           <Main centerChild padded>
-            <Prose id="audiofocus">
+            <Prose>
               <FullScreenIconWrapper align="center">
                 <Icons.Done color="success" />
               </FullScreenIconWrapper>
@@ -485,7 +466,7 @@ export function PollWorkerScreen({
           centerContent
           title="Switch to Official Ballot Mode and reset the Ballots Printed count?"
           content={
-            <Prose textCenter id="modalaudiofocus">
+            <Prose textCenter>
               <P>
                 Today is election day and this machine is in{' '}
                 <Font noWrap weight="bold">

--- a/apps/mark-scan/frontend/src/pages/replace_election_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/replace_election_screen.tsx
@@ -64,7 +64,7 @@ export function ReplaceElectionScreen({
   return (
     <Screen>
       <Main padded centerChild>
-        <Prose id="audiofocus">
+        <Prose>
           <H1>
             <Icons.Danger color="danger" /> This card is configured for a
             different election.

--- a/apps/mark-scan/frontend/src/pages/validate_ballot_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/validate_ballot_page.tsx
@@ -10,6 +10,7 @@ import {
   Button,
   appStrings,
   AudioOnly,
+  ReadOnLoad,
 } from '@votingworks/ui';
 
 import { assert } from '@votingworks/basics';
@@ -27,7 +28,7 @@ import {
 
 import { BallotContext } from '../contexts/ballot_context';
 
-const ContentHeader = styled.div`
+const ContentHeader = styled(ReadOnLoad)`
   padding: 0.5rem 0.75rem 0;
 `;
 
@@ -77,7 +78,7 @@ export function ValidateBallotPage(): JSX.Element | null {
   return (
     <Screen>
       <Main flexColumn>
-        <ContentHeader id="audiofocus">
+        <ContentHeader>
           <H1>{appStrings.titleBmdReviewScreen()}</H1>
           <AudioOnly>
             {appStrings.instructionsBmdReviewPageNavigation()}{' '}

--- a/apps/mark-scan/frontend/src/pages/wrong_election_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/wrong_election_screen.tsx
@@ -1,16 +1,10 @@
-import { useEffect } from 'react';
-
 import { Main, Screen, Prose, H1, P } from '@votingworks/ui';
 
-import { triggerAudioFocus } from '../utils/trigger_audio_focus';
-
 export function WrongElectionScreen(): JSX.Element {
-  useEffect(triggerAudioFocus, []);
-
   return (
     <Screen>
       <Main centerChild>
-        <Prose textCenter id="audiofocus">
+        <Prose textCenter>
           <H1>Invalid Card Data</H1>
           <P>Card is not configured for this election.</P>
           <P>Please ask admin for assistance.</P>

--- a/apps/mark-scan/frontend/src/utils/trigger_audio_focus.ts
+++ b/apps/mark-scan/frontend/src/utils/trigger_audio_focus.ts
@@ -1,7 +1,0 @@
-export function triggerAudioFocus(): void {
-  const element = document.getElementById('audiofocus');
-  if (element) {
-    element.focus();
-    element.click();
-  }
-}

--- a/apps/mark/frontend/src/pages/card_error_screen.tsx
+++ b/apps/mark/frontend/src/pages/card_error_screen.tsx
@@ -1,17 +1,12 @@
-import { useEffect } from 'react';
-
 import { Main, Screen, Prose, RotateCardImage, H1, P } from '@votingworks/ui';
-import { triggerAudioFocus } from '../utils/trigger_audio_focus';
 
 export function CardErrorScreen(): JSX.Element {
-  useEffect(triggerAudioFocus, []);
-
   return (
     <Screen>
       <Main centerChild>
         <div>
           <RotateCardImage />
-          <Prose textCenter id="audiofocus">
+          <Prose textCenter>
             <H1>Card is Backwards</H1>
             <P>Remove the card, turn it around, and insert it again.</P>
           </Prose>

--- a/apps/mark/frontend/src/pages/insert_card_screen.tsx
+++ b/apps/mark/frontend/src/pages/insert_card_screen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import {
   ElectionDefinition,
   PollsState,
@@ -19,7 +19,6 @@ import {
 } from '@votingworks/ui';
 
 import { throwIllegalValue } from '@votingworks/basics';
-import { triggerAudioFocus } from '../utils/trigger_audio_focus';
 
 interface Props {
   appPrecinct: PrecinctSelection;
@@ -38,8 +37,6 @@ export function InsertCardScreen({
   pollsState,
   showNoAccessibleControllerWarning,
 }: Props): JSX.Element {
-  useEffect(triggerAudioFocus, []);
-
   const mainText = (() => {
     switch (pollsState) {
       case 'polls_closed_initial':
@@ -75,7 +72,7 @@ export function InsertCardScreen({
     <Screen>
       {!isLiveMode && <TestMode />}
       <Main centerChild>
-        <Prose textCenter id="audiofocus">
+        <Prose textCenter>
           {showNoChargerAttachedWarning && (
             <Caption>
               <Icons.Warning color="warning" />{' '}

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon';
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 
 import {
   BallotStyleId,
@@ -47,7 +47,6 @@ import type { MachineConfig } from '@votingworks/mark-backend';
 import styled from 'styled-components';
 import { find, throwIllegalValue } from '@votingworks/basics';
 
-import { triggerAudioFocus } from '../utils/trigger_audio_focus';
 import { DiagnosticsScreen } from './diagnostics_screen';
 import { setPollsState, setTestMode } from '../api';
 
@@ -114,11 +113,7 @@ function UpdatePollsButton({
       {isConfirmationModalOpen && (
         <Modal
           title={`Confirm ${action}`}
-          content={
-            <Prose id="modalaudiofocus">
-              <P>{explanationText}</P>
-            </Prose>
-          }
+          content={<P>{explanationText}</P>}
           actions={
             <React.Fragment>
               <Button variant="primary" onPress={confirmUpdate}>
@@ -187,9 +182,6 @@ export function PollWorkerScreen({
     : [];
   /*
    * Various state parameters to handle controlling when certain modals on the page are open or not.
-   * If you are adding a new modal make sure to add the new parameter to the triggerAudiofocus useEffect
-   * dependency. This will retrigger the audio to explain landing on the PollWorker homepage
-   * when the modal closes.
    */
   const [isConfirmingEnableLiveMode, setIsConfirmingEnableLiveMode] = useState(
     !isLiveMode && isElectionDay
@@ -198,17 +190,6 @@ export function PollWorkerScreen({
     return setIsConfirmingEnableLiveMode(false);
   }
   const [isDiagnosticsScreenOpen, setIsDiagnosticsScreenOpen] = useState(false);
-
-  /*
-   * Trigger audiofocus for the PollWorker screen landing page. This occurs when
-   * the component first renders, or any of the modals in the page are closed. If you
-   * add a new modal to this component add it's state parameter as a dependency here.
-   */
-  useEffect(() => {
-    if (!isConfirmingEnableLiveMode) {
-      triggerAudioFocus();
-    }
-  }, [isConfirmingEnableLiveMode]);
 
   const canSelectBallotStyle = pollsState === 'polls_open';
   const [isHidingSelectBallotStyle, setIsHidingSelectBallotStyle] =
@@ -254,7 +235,7 @@ export function PollWorkerScreen({
     return (
       <Screen>
         <Main centerChild padded>
-          <Prose id="audiofocus">
+          <Prose>
             <FullScreenIconWrapper align="center">
               <Icons.Done color="success" />
             </FullScreenIconWrapper>
@@ -432,7 +413,7 @@ export function PollWorkerScreen({
           centerContent
           title="Switch to Official Ballot Mode and reset the Ballots Printed count?"
           content={
-            <Prose textCenter id="modalaudiofocus">
+            <Prose textCenter>
               <P>
                 Today is election day and this machine is in{' '}
                 <Font noWrap weight="bold">

--- a/apps/mark/frontend/src/pages/replace_election_screen.tsx
+++ b/apps/mark/frontend/src/pages/replace_election_screen.tsx
@@ -64,7 +64,7 @@ export function ReplaceElectionScreen({
   return (
     <Screen>
       <Main padded centerChild>
-        <Prose id="audiofocus">
+        <Prose>
           <H1>
             <Icons.Danger color="danger" /> This card is configured for a
             different election.

--- a/apps/mark/frontend/src/pages/wrong_election_screen.tsx
+++ b/apps/mark/frontend/src/pages/wrong_election_screen.tsx
@@ -1,16 +1,10 @@
-import { useEffect } from 'react';
-
 import { Main, Screen, Prose, H1, P } from '@votingworks/ui';
 
-import { triggerAudioFocus } from '../utils/trigger_audio_focus';
-
 export function WrongElectionScreen(): JSX.Element {
-  useEffect(triggerAudioFocus, []);
-
   return (
     <Screen>
       <Main centerChild>
-        <Prose textCenter id="audiofocus">
+        <Prose textCenter>
           <H1>Invalid Card Data</H1>
           <P>Card is not configured for this election.</P>
           <P>Please ask admin for assistance.</P>

--- a/apps/mark/frontend/src/utils/trigger_audio_focus.ts
+++ b/apps/mark/frontend/src/utils/trigger_audio_focus.ts
@@ -1,7 +1,0 @@
-export function triggerAudioFocus(): void {
-  const element = document.getElementById('audiofocus');
-  if (element) {
-    element.focus();
-    element.click();
-  }
-}

--- a/libs/mark-flow-ui/src/components/candidate_contest.tsx
+++ b/libs/mark-flow-ui/src/components/candidate_contest.tsx
@@ -28,6 +28,7 @@ import {
   AudioOnly,
   electionStrings,
   ButtonPressEvent,
+  ReadOnLoad,
 } from '@votingworks/ui';
 import { assert } from '@votingworks/basics';
 
@@ -214,6 +215,13 @@ export function CandidateContest({
 
   const hasReachedMaxSelections = contest.seats === vote.length;
 
+  const writeInModalTitle = (
+    <React.Fragment>
+      {appStrings.labelWriteInTitleCaseColon()}{' '}
+      {electionStrings.contestTitle(contest)}
+    </React.Fragment>
+  );
+
   const modalActions = (
     <React.Fragment>
       <Button
@@ -330,7 +338,7 @@ export function CandidateContest({
         <Modal
           centerContent
           content={
-            <P id="modalaudiofocus">
+            <P>
               {appStrings.warningOvervoteCandidateContest()}
               <AudioOnly>
                 {appStrings.instructionsBmdSelectToContinue()}
@@ -343,7 +351,7 @@ export function CandidateContest({
               autoFocus
               onPress={closeAttemptedVoteAlert}
             >
-              {appStrings.buttonOkay() /* TODO(kofi): Exclude from audio: */}
+              {appStrings.buttonOkay()}
               <AudioOnly>
                 {appStrings.instructionsBmdSelectToContinue()}
               </AudioOnly>
@@ -354,11 +362,7 @@ export function CandidateContest({
       {writeInPendingRemoval && (
         <Modal
           centerContent
-          content={
-            <P id="modalaudiofocus">
-              {appStrings.promptBmdConfirmRemoveWriteIn()}
-            </P>
-          }
+          content={<P>{appStrings.promptBmdConfirmRemoveWriteIn()}</P>}
           actions={
             <React.Fragment>
               <Button
@@ -379,36 +383,41 @@ export function CandidateContest({
       {writeInCandidateModalIsOpen && (
         <Modal
           modalWidth={ModalWidth.Wide}
-          title={
-            <React.Fragment>
-              {appStrings.labelWriteInTitleCaseColon()}{' '}
-              {electionStrings.contestTitle(contest)}
-            </React.Fragment>
-          }
+          disableAutoplayAudio
+          title={writeInModalTitle}
           content={
             <div>
-              <div id="modalaudiofocus">
+              <div>
                 <P>
                   <Caption>
                     <Icons.Info /> {appStrings.labelBmdWriteInForm()}
                   </Caption>
-                  <AudioOnly>
-                    {appStrings.instructionsBmdWriteInFormNavigation()}
-                  </AudioOnly>
                 </P>
               </div>
               <WriteInModalBody>
                 <WriteInForm>
                   <TouchTextInput value={writeInCandidateName} />
-                  <P align="right">
-                    <Caption>
-                      {writeInCharsRemaining === 0 && (
-                        <Icons.Warning color="warning" />
-                      )}{' '}
-                      {appStrings.labelCharactersRemaining()}{' '}
-                      {writeInCharsRemaining}
-                    </Caption>
-                  </P>
+                  <ReadOnLoad>
+                    {/*
+                     * Re-render the modal title and form label as hidden,
+                     * audio-only elements to enable grouping together content
+                     * that needs to be read on modal open:
+                     */}
+                    <AudioOnly>
+                      {writeInModalTitle}
+                      {appStrings.labelBmdWriteInForm()}
+                      {appStrings.instructionsBmdWriteInFormNavigation()}
+                    </AudioOnly>
+                    <P align="right">
+                      <Caption>
+                        {writeInCharsRemaining === 0 && (
+                          <Icons.Warning color="warning" />
+                        )}{' '}
+                        {appStrings.labelCharactersRemaining()}{' '}
+                        <NumberString value={writeInCharsRemaining} />
+                      </Caption>
+                    </P>
+                  </ReadOnLoad>
                   <VirtualKeyboard
                     onBackspace={onKeyboardBackspace}
                     onKeyPress={onKeyboardInput}

--- a/libs/mark-flow-ui/src/components/contest_header.tsx
+++ b/libs/mark-flow-ui/src/components/contest_header.tsx
@@ -3,8 +3,9 @@ import styled from 'styled-components';
 
 import {
   Caption,
-  Font,
   H2,
+  NumberString,
+  ReadOnLoad,
   appStrings,
   electionStrings,
 } from '@votingworks/ui';
@@ -29,6 +30,7 @@ const Container = styled.div`
 
 const ContestInfo = styled.div`
   display: flex;
+  flex-direction: row-reverse;
   gap: 0.5rem;
   justify-content: space-between;
 `;
@@ -39,9 +41,9 @@ function Breadcrumbs(props: BreadcrumbMetadata) {
   return (
     <Caption noWrap>
       {appStrings.labelContestNumber()}{' '}
-      <Font weight="bold">{contestNumber}</Font> |{' '}
+      <NumberString weight="bold" value={contestNumber} /> |{' '}
       {appStrings.labelTotalContests()}{' '}
-      <Font weight="bold">{ballotContestCount}</Font>{' '}
+      <NumberString weight="bold" value={ballotContestCount} />{' '}
     </Caption>
   );
 }
@@ -51,18 +53,18 @@ export function ContestHeader(props: ContestHeaderProps): JSX.Element {
 
   return (
     <Container id="contest-header">
-      <div id="audiofocus">
+      <ReadOnLoad>
         <ContestInfo>
+          {breadcrumbs && <Breadcrumbs {...breadcrumbs} />}
           <Caption weight="semiBold">
             {electionStrings.districtName(district)}
           </Caption>
-          {breadcrumbs && <Breadcrumbs {...breadcrumbs} />}
         </ContestInfo>
         <div>
           <H2 as="h1">{electionStrings.contestTitle(contest)}</H2>
         </div>
         {children}
-      </div>
+      </ReadOnLoad>
     </Container>
   );
 }

--- a/libs/mark-flow-ui/src/components/yes_no_contest.tsx
+++ b/libs/mark-flow-ui/src/components/yes_no_contest.tsx
@@ -134,7 +134,7 @@ export function YesNoContest({
         <Modal
           centerContent
           content={
-            <P id="modalaudiofocus">
+            <P>
               {appStrings.warningOvervoteYesNoContest()}
               <AudioOnly>
                 {appStrings.instructionsBmdSelectToContinue()}

--- a/libs/mark-flow-ui/src/pages/cast_ballot_page.tsx
+++ b/libs/mark-flow-ui/src/pages/cast_ballot_page.tsx
@@ -7,6 +7,7 @@ import {
   InsertBallotImage,
   Main,
   P,
+  ReadOnLoad,
   Screen,
   VerifyBallotImage,
   appStrings,
@@ -69,7 +70,7 @@ export function CastBallotPage({
   return (
     <Screen>
       <Main padded>
-        <div id="audiofocus">
+        <ReadOnLoad>
           <H1>{appStrings.titleBmdCastBallotScreen()}</H1>
           <P>{appStrings.instructionsBmdCastBallotPreamble()}</P>
           <Instructions>
@@ -89,7 +90,7 @@ export function CastBallotPage({
           <P>
             <Icons.Info /> {appStrings.noteAskPollWorkerForHelp()}
           </P>
-        </div>
+        </ReadOnLoad>
         <Done>
           <Button
             onPress={hidePostVotingInstructions}

--- a/libs/mark-flow-ui/src/pages/idle_page.tsx
+++ b/libs/mark-flow-ui/src/pages/idle_page.tsx
@@ -12,6 +12,7 @@ import {
   appStrings,
   AudioOnly,
   NumberString,
+  ReadOnLoad,
 } from '@votingworks/ui';
 
 import {
@@ -61,14 +62,7 @@ export function IdlePage({
           <Loading>{appStrings.noteBmdClearingBallot()}</Loading>
         ) : (
           <Font align="center">
-            {/*
-             * TODO(kofi): the old "audiofocus" pattern only works for one-time
-             * readouts of static text. Need to introduce configurable
-             * functionality for re-initiating speech when text gets
-             * added/replaced (e.g. when we move from this text to
-             * "Clearing ballot" above).
-             */}
-            <div id="audiofocus">
+            <ReadOnLoad>
               <H1>{appStrings.titleBmdIdleScreen()}</H1>
               <P>{idleTimeoutWarningStringFn()}</P>
               <AudioOnly>
@@ -84,7 +78,7 @@ export function IdlePage({
                   </P>
                 </React.Fragment>
               )}
-            </div>
+            </ReadOnLoad>
             <Button autoFocus variant="primary" onPress={onDismiss}>
               {appStrings.buttonStillVoting()}
             </Button>

--- a/libs/mark-flow-ui/src/pages/print_page.tsx
+++ b/libs/mark-flow-ui/src/pages/print_page.tsx
@@ -10,6 +10,7 @@ import {
   PrintingBallotImage,
   appStrings,
   Font,
+  ReadOnLoad,
 } from '@votingworks/ui';
 
 import {
@@ -86,11 +87,11 @@ export function PrintPage({
   return (
     <Screen>
       <Main centerChild padded>
-        <Font align="center" id="audiofocus">
+        <Font align="center">
           <PrintingBallotImage />
-          <div>
+          <ReadOnLoad>
             <H1>{appStrings.titleBmdPrintScreen()}</H1>
-          </div>
+          </ReadOnLoad>
         </Font>
       </Main>
     </Screen>

--- a/libs/mark-flow-ui/src/pages/review_page.tsx
+++ b/libs/mark-flow-ui/src/pages/review_page.tsx
@@ -9,6 +9,7 @@ import {
   useScreenInfo,
   appStrings,
   AudioOnly,
+  ReadOnLoad,
 } from '@votingworks/ui';
 
 import { assert } from '@votingworks/basics';
@@ -19,7 +20,7 @@ import { Review, ReviewProps } from '../components/review';
 import { ContestsWithMsEitherNeither } from '../utils/ms_either_neither_contests';
 import { DisplaySettingsButton } from '../components/display_settings_button';
 
-const ContentHeader = styled.div`
+const ContentHeader = styled(ReadOnLoad)`
   padding: 0.5rem 0.75rem 0;
 `;
 
@@ -64,7 +65,7 @@ export function ReviewPage(props: ReviewPageProps): JSX.Element {
   return (
     <Screen flexDirection={screenInfo.isPortrait ? 'column' : 'row'}>
       <Main flexColumn>
-        <ContentHeader id="audiofocus">
+        <ContentHeader>
           <H1>{appStrings.titleBmdReviewScreen()}</H1>
           <AudioOnly>
             {appStrings.instructionsBmdReviewPageNavigation()}{' '}

--- a/libs/ui/src/__snapshots__/modal.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/modal.test.tsx.snap
@@ -35,24 +35,6 @@ exports[`Modal can configure a wider max width 1`] = `
   padding: 1rem;
 }
 
-.c2 {
-  -webkit-align-items: inherit;
-  -webkit-box-align: inherit;
-  -ms-flex-align: inherit;
-  align-items: inherit;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: inherit;
-  -webkit-justify-content: inherit;
-  -ms-flex-pack: inherit;
-  justify-content: inherit;
-}
-
 @media (min-width:480px) {
   .c0 {
     position: static;
@@ -99,12 +81,7 @@ exports[`Modal can configure a wider max width 1`] = `
   <div
     class="c1"
   >
-    <div
-      class="c2"
-      data-testid="mockReadOnLoad"
-    >
-      Do you want to do the thing?
-    </div>
+    Do you want to do the thing?
   </div>
 </div>
 `;
@@ -141,24 +118,6 @@ exports[`Modal can configure fullscreen 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   overflow: auto;
-}
-
-.c2 {
-  -webkit-align-items: inherit;
-  -webkit-box-align: inherit;
-  -ms-flex-align: inherit;
-  align-items: inherit;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: inherit;
-  -webkit-justify-content: inherit;
-  -ms-flex-pack: inherit;
-  justify-content: inherit;
 }
 
 @media (min-width:480px) {
@@ -207,12 +166,7 @@ exports[`Modal can configure fullscreen 1`] = `
   <div
     class="c1"
   >
-    <div
-      class="c2"
-      data-testid="mockReadOnLoad"
-    >
-      Do you want to do the thing?
-    </div>
+    Do you want to do the thing?
   </div>
 </div>
 `;

--- a/libs/ui/src/__snapshots__/modal.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/modal.test.tsx.snap
@@ -35,6 +35,24 @@ exports[`Modal can configure a wider max width 1`] = `
   padding: 1rem;
 }
 
+.c2 {
+  -webkit-align-items: inherit;
+  -webkit-box-align: inherit;
+  -ms-flex-align: inherit;
+  align-items: inherit;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: inherit;
+  -webkit-justify-content: inherit;
+  -ms-flex-pack: inherit;
+  justify-content: inherit;
+}
+
 @media (min-width:480px) {
   .c0 {
     position: static;
@@ -81,7 +99,12 @@ exports[`Modal can configure a wider max width 1`] = `
   <div
     class="c1"
   >
-    Do you want to do the thing?
+    <div
+      class="c2"
+      data-testid="mockReadOnLoad"
+    >
+      Do you want to do the thing?
+    </div>
   </div>
 </div>
 `;
@@ -118,6 +141,24 @@ exports[`Modal can configure fullscreen 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   overflow: auto;
+}
+
+.c2 {
+  -webkit-align-items: inherit;
+  -webkit-box-align: inherit;
+  -ms-flex-align: inherit;
+  align-items: inherit;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: inherit;
+  -webkit-justify-content: inherit;
+  -ms-flex-pack: inherit;
+  justify-content: inherit;
 }
 
 @media (min-width:480px) {
@@ -166,7 +207,12 @@ exports[`Modal can configure fullscreen 1`] = `
   <div
     class="c1"
   >
-    Do you want to do the thing?
+    <div
+      class="c2"
+      data-testid="mockReadOnLoad"
+    >
+      Do you want to do the thing?
+    </div>
   </div>
 </div>
 `;

--- a/libs/ui/src/modal.tsx
+++ b/libs/ui/src/modal.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import ReactModal from 'react-modal';
 import styled from 'styled-components';
 import { rgba } from 'polished';
@@ -8,6 +8,7 @@ import { assert } from '@votingworks/basics';
 import { Theme } from './themes';
 import { ButtonBar } from './button_bar';
 import { H2 } from './typography';
+import { ReadOnLoad } from './ui_strings/read_on_load';
 
 /**
  * Controls the maximum width the modal can expand to.
@@ -85,6 +86,13 @@ const ModalContent = styled('div')<ModalContentInterface>`
   padding: ${({ fullscreen }) => !fullscreen && '1rem'};
 `;
 
+const ReadOnOpen = styled(ReadOnLoad)`
+  align-items: inherit;
+  display: flex;
+  flex-direction: column;
+  justify-content: inherit;
+`;
+
 /** Props for {@link Modal}. */
 export interface ModalProps {
   ariaLabel?: string;
@@ -94,6 +102,14 @@ export interface ModalProps {
   ariaHideApp?: boolean;
   content?: ReactNode;
   centerContent?: boolean;
+  /**
+   * Disables automatic audio readout of the modal title and content on open.
+   *
+   * Useful if only a portion of the modal content needs to be read out. Clients
+   * can manually mark the appropriate content with {@link ReadOnLoad} in that
+   * case.
+   */
+  disableAutoplayAudio?: boolean;
   /**
    * Modal actions go here, most likely buttons. The primary action (such as
    * "Save") should be first under a fragment, and the secondary actions (such
@@ -117,42 +133,28 @@ export interface ModalProps {
   title?: ReactNode;
 }
 
-/* istanbul ignore next - unclear why this isn't covered */
-function focusModalAudio() {
-  window.setTimeout(() => {
-    const element = document.getElementById('modalaudiofocus');
-    if (element) {
-      element.focus();
-      element.click();
-    }
-  }, 10);
-}
-
-/* istanbul ignore next - unclear why this isn't covered */
-function focusScreenAudio() {
-  window.setTimeout(() => {
-    const element = document.getElementById('audiofocus');
-    if (element) {
-      element.focus();
-      element.click();
-    }
-  }, 10);
-}
-
 export function Modal({
   actions,
   ariaLabel = 'Alert Modal',
   centerContent,
   content,
+  disableAutoplayAudio,
   fullscreen = false,
   ariaHideApp = true,
-  onAfterOpen = focusModalAudio,
-  onAfterClose = focusScreenAudio,
+  onAfterOpen,
+  onAfterClose,
   onOverlayClick,
   modalWidth,
   themeDeprecated,
   title,
 }: ModalProps): JSX.Element {
+  const modalContent = (
+    <React.Fragment>
+      {title && <H2 as="h1">{title}</H2>}
+      {content}
+    </React.Fragment>
+  );
+
   /* istanbul ignore next - can't get document.getElementById working in test */
   const appElement =
     document.getElementById('root') ??
@@ -193,8 +195,11 @@ export function Modal({
       overlayClassName="_"
     >
       <ModalContent centerContent={centerContent} fullscreen={fullscreen}>
-        {title && <H2 as="h1">{title}</H2>}
-        {content}
+        {disableAutoplayAudio ? (
+          modalContent
+        ) : (
+          <ReadOnOpen>{modalContent}</ReadOnOpen>
+        )}
       </ModalContent>
       {actions && <ButtonBar as="div">{actions}</ButtonBar>}
     </ReactModal>

--- a/libs/ui/src/modal.tsx
+++ b/libs/ui/src/modal.tsx
@@ -9,6 +9,7 @@ import { Theme } from './themes';
 import { ButtonBar } from './button_bar';
 import { H2 } from './typography';
 import { ReadOnLoad } from './ui_strings/read_on_load';
+import { useAudioContext } from './ui_strings/audio_context';
 
 /**
  * Controls the maximum width the modal can expand to.
@@ -148,6 +149,9 @@ export function Modal({
   themeDeprecated,
   title,
 }: ModalProps): JSX.Element {
+  const isInVoterAudioContext = !!useAudioContext();
+  const shouldPlayAudioOnOpen = isInVoterAudioContext && !disableAutoplayAudio;
+
   const modalContent = (
     <React.Fragment>
       {title && <H2 as="h1">{title}</H2>}
@@ -195,10 +199,10 @@ export function Modal({
       overlayClassName="_"
     >
       <ModalContent centerContent={centerContent} fullscreen={fullscreen}>
-        {disableAutoplayAudio ? (
-          modalContent
-        ) : (
+        {shouldPlayAudioOnOpen ? (
           <ReadOnOpen>{modalContent}</ReadOnOpen>
+        ) : (
+          modalContent
         )}
       </ModalContent>
       {actions && <ButtonBar as="div">{actions}</ButtonBar>}


### PR DESCRIPTION
## Overview

Using the `<ReadOnLoad>` component added in https://github.com/votingworks/vxsuite/pull/4483 on voter-facing screens and modals in the BMD apps. This replaces the previous `id="audiofocus"`/`id="modalaudiofocus"` tags and removes them altogether from non-voter-facing screens/modals.

Adding a default `<ReadOnLoad>` instance to the shared `<Modal>` component, which can be disabled for more complex modals (e.g. the write-in candidate modal, where we only want a portion of the modal content to be read on open). This is a no-op for apps with no audio and/or translations and also a no-op when there are no `<UiString>` instances in the modal. That being said, open to defaulting to autoplay disabled and having voter-facing modals explicitly enable it, if that feels more appropriate.

## Demo Video or Screenshot

### `<ReadOnLoad>` used on Contest Screen and autoplay in overvote modal:

https://github.com/votingworks/vxsuite/assets/264902/25cfce89-d6ca-4230-92e6-f8d6b4057209


### Write-in modal with autoplay disabled and custom `<ReadOnLoad>` setup:

https://github.com/votingworks/vxsuite/assets/264902/f90849e1-c563-4fef-bd19-b01273e5df3b

## Testing Plan
- Existing tests as regression checks
- New test cases for modal autoplay audio functionality

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
