### PR TITLE
feat(basics): rename `iter.toString` to `iter.join`

### DIFF
--- a/libs/basics/src/iterators/async_iterator_plus.test.ts
+++ b/libs/basics/src/iterators/async_iterator_plus.test.ts
@@ -339,15 +339,18 @@ test('toSet', async () => {
   expect(await iter([1, 2, 3]).async().toSet()).toEqual(new Set([1, 2, 3]));
 });
 
-test('toString', async () => {
-  expect(await iter([]).async().toString()).toEqual('');
-  expect(await iter([1, 2, 3]).async().toString()).toEqual('123');
-  expect(await iter([1, 2, 3]).async().toString(' ')).toEqual('1 2 3');
+test('join', async () => {
+  expect(await iter([]).async().join()).toEqual('');
+  expect(await iter([1, 2, 3]).async().join()).toEqual('123');
+  expect(await iter([1, 2, 3]).async().join(' ')).toEqual('1 2 3');
   expect(
     await iter([{ toString: (): string => 'hello' }, 'world'])
       .async()
-      .toString(', ')
+      .join(', ')
   ).toEqual('hello, world');
+
+  // `toString` is an alias for `join`
+  expect(await iter(['a', 'b', 'c']).async().toString()).toEqual('abc');
 });
 
 test('first', async () => {

--- a/libs/basics/src/iterators/async_iterator_plus.ts
+++ b/libs/basics/src/iterators/async_iterator_plus.ts
@@ -220,6 +220,10 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
     return (await this.iterable[Symbol.asyncIterator]().next()).done ?? true;
   }
 
+  async join(separator = ''): Promise<string> {
+    return (await this.toArray()).join(separator);
+  }
+
   async last(): Promise<T | undefined> {
     let lastElement: T | undefined;
     for await (const it of this.iterable) {
@@ -391,8 +395,8 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
     return set;
   }
 
-  async toString(separator = ''): Promise<string> {
-    return (await this.toArray()).join(separator);
+  toString(separator?: string): Promise<string> {
+    return this.join(separator);
   }
 
   windows(groupSize: 0): never;

--- a/libs/basics/src/iterators/iterator_plus.test.ts
+++ b/libs/basics/src/iterators/iterator_plus.test.ts
@@ -254,13 +254,16 @@ test('toSet', () => {
   expect(iter([1, 2, 3]).toSet()).toEqual(new Set([1, 2, 3]));
 });
 
-test('toString', () => {
-  expect(iter([]).toString()).toEqual('');
-  expect(iter([1, 2, 3]).toString()).toEqual('123');
-  expect(iter([1, 2, 3]).toString(' ')).toEqual('1 2 3');
+test('join', () => {
+  expect(iter([]).join()).toEqual('');
+  expect(iter([1, 2, 3]).join()).toEqual('123');
+  expect(iter([1, 2, 3]).join(' ')).toEqual('1 2 3');
   expect(
-    iter([{ toString: (): string => 'hello' }, 'world']).toString(', ')
+    iter([{ toString: (): string => 'hello' }, 'world']).join(', ')
   ).toEqual('hello, world');
+
+  // `toString` is an alias for `join`
+  expect(iter(['a', 'b', 'c']).toString()).toEqual('abc');
 });
 
 test('first', () => {

--- a/libs/basics/src/iterators/iterator_plus.ts
+++ b/libs/basics/src/iterators/iterator_plus.ts
@@ -222,6 +222,10 @@ export class IteratorPlusImpl<T> implements IteratorPlus<T>, AsyncIterable<T> {
     return this.iterable[Symbol.iterator]().next().done ?? true;
   }
 
+  join(separator = ''): string {
+    return this.toArray().join(separator);
+  }
+
   last(): T | undefined {
     let lastElement: T | undefined;
     for (const it of this.iterable) {
@@ -379,8 +383,8 @@ export class IteratorPlusImpl<T> implements IteratorPlus<T>, AsyncIterable<T> {
     return new Set(this.iterable);
   }
 
-  toString(separator = ''): string {
-    return this.toArray().join(separator);
+  toString(separator?: string): string {
+    return this.join(separator);
   }
 
   windows(groupSize: 0): never;

--- a/libs/basics/src/iterators/types.ts
+++ b/libs/basics/src/iterators/types.ts
@@ -250,6 +250,12 @@ export interface IteratorPlus<T> extends Iterable<T> {
   isEmpty(): boolean;
 
   /**
+   * Returns a string representation of `this` by joining elements with
+   * `separator`. Consumes the entire contained iterable.
+   */
+  join(separator?: string): string;
+
+  /**
    * Returns the last element of `this` or `undefined` if `this` is empty.
    * Consumes the entire contained iterable.
    *
@@ -497,8 +503,7 @@ export interface IteratorPlus<T> extends Iterable<T> {
   toSet(): Set<T>;
 
   /**
-   * Returns a string representation of `this` by joining elements with
-   * `separator`. Consumes the entire contained iterable.
+   * Alias for {@link join}.
    */
   toString(separator?: string): string;
 
@@ -936,6 +941,12 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
   isEmpty(): Promise<boolean>;
 
   /**
+   * Returns a string representation of `this` by joining elements with
+   * `separator`. Consumes the entire contained iterable.
+   */
+  join(separator?: string): Promise<string>;
+
+  /**
    * Returns the last element of `this` or `undefined` if `this` is empty.
    * Consumes the entire contained iterable.
    *
@@ -1128,8 +1139,7 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
   toSet(): Promise<Set<T>>;
 
   /**
-   * Returns a string representation of `this` by joining elements with
-   * `separator`. Consumes the entire contained iterable.
+   * Alias for {@link join}.
    */
   toString(separator?: string): Promise<string>;
 


### PR DESCRIPTION
## Overview
Per https://github.com/votingworks/vxsuite/pull/4489#discussion_r1446390035.

Keeps `iter.toString` as an alias for `iter.join` as it's semantically nicer when there's no separator.

## Demo Video or Screenshot
n/a

## Testing Plan
- Updated tests.
