### PR TITLE
pull test mode from store when interpreting

### DIFF
--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -339,8 +339,6 @@ function loadMetadataAndInterpretBallot(
     'Expected precinctSelection to be defined in store'
   );
 
-  // Hardcoded until isLivemode is moved from frontend store to backend store
-  const testMode = true;
   const { markThresholds, precinctScanAdjudicationReasons } = assertDefined(
     store.getSystemSettings()
   );
@@ -349,7 +347,7 @@ function loadMetadataAndInterpretBallot(
     {
       electionDefinition,
       precinctSelection,
-      testMode,
+      testMode: store.getTestMode(),
       markThresholds,
       adjudicationReasons: precinctScanAdjudicationReasons,
     },


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/4470

Fixes a bug where test mode was hardcoded for interpretation

## Demo Video or Screenshot
N/A

## Testing Plan
Manually tested

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced. (no new actions)
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
