### PR TITLE
VxDesign: Add custom election title field to precinct split form

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -80,6 +80,7 @@ test('CRUD elections', async () => {
     ballotStyles: [],
     precincts: [],
     layoutOptions: DEFAULT_LAYOUT_OPTIONS,
+    nhCustomContent: {},
     createdAt: expect.any(String),
   });
 
@@ -124,6 +125,7 @@ test('CRUD elections', async () => {
       name: precinct.name,
       districtIds: ['district-1'],
     })),
+    nhCustomContent: {},
     createdAt: expect.any(String),
   });
 
@@ -467,6 +469,7 @@ test('Export all ballots', async () => {
       ballotType: expectedBallotType,
       ballotMode: expectedBallotMode,
       layoutOptions,
+      nhCustomContent: {},
     });
   }
 });
@@ -510,6 +513,7 @@ test('Export test decks', async () => {
     ballotType: BallotType.Precinct,
     ballotMode: 'test',
     layoutOptions: DEFAULT_LAYOUT_OPTIONS,
+    nhCustomContent: {},
   });
 });
 
@@ -711,23 +715,31 @@ describe('Ballot style generation', () => {
             id: 'precinct-2-split-1',
             name: 'Precinct 2 - Split 1',
             districtIds: [district1.id, district2.id],
+            nhCustomContent: {
+              electionTitle: 'Custom Election Title 1',
+            },
           },
           {
             id: 'precinct-2-split-2',
             name: 'Precinct 2 - Split 2',
             districtIds: [district1.id, district3.id],
+            nhCustomContent: {
+              electionTitle: 'Custom Election Title 2',
+            },
           },
           {
             id: 'precinct-2-split-3',
             name: 'Precinct 2 - Split 3',
             // Should share a ballot style with precinct-1, since same districts assigned
             districtIds: [district1.id],
+            nhCustomContent: {},
           },
           {
             id: 'precinct-2-split-4',
             name: 'Precinct 2 - Split 4',
             // Shouldn't get a ballot style, since no districts assigned
             districtIds: [],
+            nhCustomContent: {},
           },
         ],
       },
@@ -744,7 +756,9 @@ describe('Ballot style generation', () => {
       contests,
     });
 
-    const { ballotStyles } = await apiClient.getElection({ electionId });
+    const { ballotStyles, nhCustomContent } = await apiClient.getElection({
+      electionId,
+    });
     const [precinct1, precinct2] = precincts;
     assert(hasSplits(precinct2));
     const [split1, split2, split3] = precinct2.splits;
@@ -771,6 +785,14 @@ describe('Ballot style generation', () => {
         precinctsOrSplits: [{ precinctId: precinct2.id, splitId: split2.id }],
       },
     ]);
+    expect(nhCustomContent).toEqual({
+      'ballot-style-2': {
+        electionTitle: 'Custom Election Title 1',
+      },
+      'ballot-style-3': {
+        electionTitle: 'Custom Election Title 2',
+      },
+    });
   });
 
   test('Primary election, no splits', async () => {
@@ -872,23 +894,27 @@ describe('Ballot style generation', () => {
             id: 'precinct-1-split-1',
             name: 'Precinct 1 - Split 1',
             districtIds: [district1.id, district2.id],
+            nhCustomContent: {},
           },
           {
             id: 'precinct-1-split-2',
             name: 'Precinct 1 - Split 2',
             districtIds: [district1.id, district3.id],
+            nhCustomContent: {},
           },
           {
             id: 'precinct-1-split-3',
             name: 'Precinct 1 - Split 3',
             // Shouldn't get a ballot style, since no districts assigned
             districtIds: [],
+            nhCustomContent: {},
           },
           {
             id: 'precinct-1-split-4',
             name: 'Precinct 1 - Split 4',
             // Should share a ballot style with precinct-2, since same districts assigned
             districtIds: [district2.id],
+            nhCustomContent: {},
           },
         ],
       },

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -79,6 +79,7 @@ export function convertVxfPrecincts(election: Election): Precinct[] {
         id: `${precinct.id}-split-${index + 1}`,
         name: `${precinct.name} - Split ${index + 1}`,
         districtIds: ballotStyle.districts,
+        nhCustomContent: {},
       })),
     };
   });
@@ -162,7 +163,9 @@ function buildApi({ workspace }: { workspace: Workspace }) {
     async exportAllBallots(input: {
       electionId: Id;
     }): Promise<{ zipContents: Buffer; electionHash: string }> {
-      const { election, layoutOptions } = store.getElection(input.electionId);
+      const { election, layoutOptions, nhCustomContent } = store.getElection(
+        input.electionId
+      );
 
       const zip = new JsZip();
 
@@ -176,6 +179,7 @@ function buildApi({ workspace }: { workspace: Workspace }) {
             ballotType,
             ballotMode,
             layoutOptions,
+            nhCustomContent,
           }).unsafeUnwrap();
 
           // Election definition doesn't change across ballot types/modes
@@ -210,12 +214,15 @@ function buildApi({ workspace }: { workspace: Workspace }) {
       ballotType: BallotType;
       ballotMode: BallotMode;
     }): Promise<Buffer> {
-      const { election, layoutOptions } = store.getElection(input.electionId);
+      const { election, layoutOptions, nhCustomContent } = store.getElection(
+        input.electionId
+      );
       const { ballots } = layOutAllBallotStyles({
         election,
         ballotType: input.ballotType,
         ballotMode: input.ballotMode,
         layoutOptions,
+        nhCustomContent,
       }).unsafeUnwrap();
       const { document } = find(
         ballots,
@@ -239,12 +246,15 @@ function buildApi({ workspace }: { workspace: Workspace }) {
     async exportTestDecks(input: {
       electionId: Id;
     }): Promise<{ zipContents: Buffer; electionHash: string }> {
-      const { election, layoutOptions } = store.getElection(input.electionId);
+      const { election, layoutOptions, nhCustomContent } = store.getElection(
+        input.electionId
+      );
       const { electionDefinition, ballots } = layOutAllBallotStyles({
         election,
         ballotType: BallotType.Precinct,
         ballotMode: 'test',
         layoutOptions,
+        nhCustomContent,
       }).unsafeUnwrap();
 
       const zip = new JsZip();

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -1,7 +1,9 @@
 import {
   Optional,
   assert,
+  find,
   groupBy,
+  iter,
   throwIllegalValue,
   unique,
 } from '@votingworks/basics';
@@ -9,6 +11,8 @@ import { Client as DbClient } from '@votingworks/db';
 import {
   DEFAULT_LAYOUT_OPTIONS,
   LayoutOptions,
+  NhCustomContent,
+  NhCustomContentByBallotStyle,
 } from '@votingworks/hmpb-layout';
 import {
   Id,
@@ -35,6 +39,7 @@ export interface ElectionRecord {
   systemSettings: SystemSettings;
   layoutOptions: LayoutOptions;
   createdAt: Iso8601Timestamp;
+  nhCustomContent: NhCustomContentByBallotStyle;
 }
 
 // We create new types for precincts that can be split, since the existing
@@ -56,6 +61,7 @@ export interface PrecinctSplit {
   id: Id;
   name: string;
   districtIds: readonly DistrictId[];
+  nhCustomContent: NhCustomContent;
 }
 export type Precinct = PrecinctWithoutSplits | PrecinctWithSplits;
 
@@ -213,6 +219,42 @@ export function generateBallotStyles(
   }
 }
 
+export function assignCustomContentToBallotStyles(
+  precincts: Precinct[],
+  ballotStyles: BallotStyle[]
+): NhCustomContentByBallotStyle {
+  return Object.fromEntries(
+    ballotStyles.map((ballotStyle) => {
+      const splitsWithCustomContent = iter(ballotStyle.precinctsOrSplits)
+        .filterMap((precinctOrSplit) => {
+          if (precinctOrSplit.splitId) {
+            const precinct = find(
+              precincts,
+              (p) => p.id === precinctOrSplit.precinctId
+            );
+            assert(hasSplits(precinct));
+            const split = find(
+              precinct.splits,
+              (s) => s.id === precinctOrSplit.splitId
+            );
+            if (Object.keys(split.nhCustomContent).length > 0) {
+              return split;
+            }
+          }
+          return undefined;
+        })
+        .toArray();
+      assert(
+        splitsWithCustomContent.length <= 1,
+        `Cannot apply NH custom content to multiple precinct splits that have the same ballot style. Splits with same ballot style: ${splitsWithCustomContent
+          .map((s) => s.name)
+          .join(', ')}`
+      );
+      return [ballotStyle.id, splitsWithCustomContent[0]?.nhCustomContent];
+    })
+  );
+}
+
 function convertSqliteTimestampToIso8601(
   sqliteTimestamp: string
 ): Iso8601Timestamp {
@@ -231,6 +273,10 @@ function hydrateElection(row: {
   const precincts: Precinct[] = JSON.parse(row.precinctData);
   const layoutOptions = JSON.parse(row.layoutOptionsData);
   const ballotStyles = generateBallotStyles(rawElection, precincts);
+  const nhCustomContent = assignCustomContentToBallotStyles(
+    precincts,
+    ballotStyles
+  );
   // Fill in our precinct/ballot style overrides in the VXF election format.
   // This is important for pieces of the code that rely on the VXF election
   // (e.g. rendering ballots)
@@ -259,6 +305,7 @@ function hydrateElection(row: {
     ballotStyles,
     systemSettings,
     layoutOptions,
+    nhCustomContent,
     createdAt: convertSqliteTimestampToIso8601(row.createdAt),
   };
 }

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -219,7 +219,7 @@ export function generateBallotStyles(
   }
 }
 
-export function assignCustomContentToBallotStyles(
+export function getNhCustomContentByBallotStyle(
   precincts: Precinct[],
   ballotStyles: BallotStyle[]
 ): NhCustomContentByBallotStyle {
@@ -273,7 +273,7 @@ function hydrateElection(row: {
   const precincts: Precinct[] = JSON.parse(row.precinctData);
   const layoutOptions = JSON.parse(row.layoutOptionsData);
   const ballotStyles = generateBallotStyles(rawElection, precincts);
-  const nhCustomContent = assignCustomContentToBallotStyles(
+  const nhCustomContent = getNhCustomContentByBallotStyle(
     precincts,
     ballotStyles
   );

--- a/apps/design/backend/src/test_decks.test.ts
+++ b/apps/design/backend/src/test_decks.test.ts
@@ -78,6 +78,7 @@ describe('createPrecinctTestDeck', () => {
       ballotType: BallotType.Precinct,
       ballotMode: 'test',
       layoutOptions: DEFAULT_LAYOUT_OPTIONS,
+      nhCustomContent: {},
     }).unsafeUnwrap();
     const testDeckDocument = createPrecinctTestDeck({
       election,
@@ -108,6 +109,7 @@ describe('createPrecinctTestDeck', () => {
       ballotType: BallotType.Precinct,
       ballotMode: 'test',
       layoutOptions: DEFAULT_LAYOUT_OPTIONS,
+      nhCustomContent: {},
     }).unsafeUnwrap();
     const testDeckDocument = createPrecinctTestDeck({
       election,
@@ -154,6 +156,7 @@ describe('getTallyReportResults', () => {
       ballotType: BallotType.Precinct,
       ballotMode: 'test',
       layoutOptions: DEFAULT_LAYOUT_OPTIONS,
+      nhCustomContent: {},
     }).unsafeUnwrap();
 
     const tallyReportResults = await getTallyReportResults({
@@ -205,6 +208,7 @@ describe('getTallyReportResults', () => {
       ballotType: BallotType.Precinct,
       ballotMode: 'test',
       layoutOptions: DEFAULT_LAYOUT_OPTIONS,
+      nhCustomContent: {},
     }).unsafeUnwrap();
 
     const tallyReportResults = await getTallyReportResults({
@@ -265,6 +269,7 @@ test('createTestDeckTallyReport', async () => {
     ballotType: BallotType.Precinct,
     ballotMode: 'test',
     layoutOptions: DEFAULT_LAYOUT_OPTIONS,
+    nhCustomContent: {},
   }).unsafeUnwrap();
 
   const reportDocumentBuffer = await createTestDeckTallyReport({

--- a/apps/design/backend/src/worker/generate_election_package.ts
+++ b/apps/design/backend/src/worker/generate_election_package.ts
@@ -61,7 +61,7 @@ export async function generateElectionPackage(
 ): Promise<void> {
   const { assetDirectoryPath, store } = workspace;
 
-  const { election, layoutOptions, systemSettings } =
+  const { election, layoutOptions, systemSettings, nhCustomContent } =
     store.getElection(electionId);
 
   const zip = new JsZip();
@@ -79,6 +79,7 @@ export async function generateElectionPackage(
     ballotType: BallotType.Precinct,
     ballotMode: 'test',
     layoutOptions,
+    nhCustomContent,
   }).unsafeUnwrap();
   zip.file(ElectionPackageFileName.ELECTION, electionDefinition.electionData);
 

--- a/apps/design/frontend/jest.config.js
+++ b/apps/design/frontend/jest.config.js
@@ -12,8 +12,8 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: -160,
-      lines: -348,
+      branches: -127,
+      lines: -217,
     },
   },
   setupFiles: ['react-app-polyfill/jsdom'],

--- a/apps/design/frontend/src/ballot_screen.tsx
+++ b/apps/design/frontend/src/ballot_screen.tsx
@@ -17,17 +17,20 @@ export function BallotScreen(): JSX.Element | null {
     return null; // Initial loading state
   }
 
-  const { election, layoutOptions } = getElectionQuery.data;
-  const precinct = getPrecinctById({ election, precinctId });
-  const ballotStyle = getBallotStyle({ election, ballotStyleId });
+  const { election, layoutOptions, nhCustomContent } = getElectionQuery.data;
+  const precinct = assertDefined(getPrecinctById({ election, precinctId }));
+  const ballotStyle = assertDefined(
+    getBallotStyle({ election, ballotStyleId })
+  );
 
   return (
     <Screen>
       <BallotViewer
         election={election}
-        precinct={assertDefined(precinct)}
-        ballotStyle={assertDefined(ballotStyle)}
+        precinct={precinct}
+        ballotStyle={ballotStyle}
         layoutOptions={layoutOptions}
+        nhCustomContent={nhCustomContent[ballotStyle.id]}
       />
     </Screen>
   );

--- a/apps/design/frontend/src/ballot_viewer.tsx
+++ b/apps/design/frontend/src/ballot_viewer.tsx
@@ -27,6 +27,7 @@ import {
   LayoutOptions,
   BallotMode,
   SvgBubble,
+  NhCustomContent,
 } from '@votingworks/hmpb-layout';
 import fileDownload from 'js-file-download';
 import { useParams } from 'react-router-dom';
@@ -411,11 +412,13 @@ export function BallotViewer({
   precinct,
   ballotStyle,
   layoutOptions,
+  nhCustomContent,
 }: {
   election: Election;
   precinct: Precinct;
   ballotStyle: BallotStyle;
   layoutOptions: LayoutOptions;
+  nhCustomContent: NhCustomContent;
 }): JSX.Element | null {
   const { electionId } = useParams<ElectionIdParams>();
   const ballotRoutes = routes.election(electionId).ballots;
@@ -448,6 +451,7 @@ export function BallotViewer({
     ballotType,
     ballotMode,
     layoutOptions,
+    nhCustomContent,
   });
 
   if (ballotResult.isErr()) {

--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -240,7 +240,7 @@ function ContestForm({
     contestId
       ? find(savedContests, (c) => c.id === contestId)
       : // To make mocked IDs predictable in tests, we pass a function here
-        // so it will only be called on intial render.
+        // so it will only be called on initial render.
         createBlankCandidateContest
   );
   const updateElectionMutation = updateElection.useMutation();
@@ -673,7 +673,7 @@ function PartyForm({
     partyId
       ? find(savedParties, (p) => p.id === partyId)
       : // To make mocked IDs predictable in tests, we pass a function here
-        // so it will only be called on intial render.
+        // so it will only be called on initial render.
         createBlankParty
   );
   const updateElectionMutation = updateElection.useMutation();

--- a/apps/design/frontend/src/geography_screen.test.tsx
+++ b/apps/design/frontend/src/geography_screen.test.tsx
@@ -1,0 +1,624 @@
+import {
+  ElectionRecord,
+  Precinct,
+  PrecinctWithSplits,
+  PrecinctWithoutSplits,
+} from '@votingworks/design-backend';
+import { createMemoryHistory } from 'history';
+import { District, DistrictId } from '@votingworks/types';
+import userEvent from '@testing-library/user-event';
+import { assert } from '@votingworks/basics';
+import { electionGeneral } from '@votingworks/fixtures';
+import {
+  MockApiClient,
+  createMockApiClient,
+  provideApi,
+} from '../test/api_helpers';
+import {
+  electionId,
+  generalElectionRecord,
+  makeElectionRecord,
+} from '../test/fixtures';
+import { makeIdFactory } from '../test/id_helpers';
+import { withRoute } from '../test/routing_helpers';
+import { routes } from './routes';
+import { render, screen, within } from '../test/react_testing_library';
+import { GeographyScreen } from './geography_screen';
+import { hasSplits } from './utils';
+
+let apiMock: MockApiClient;
+
+const idFactory = makeIdFactory();
+
+beforeEach(() => {
+  apiMock = createMockApiClient();
+  idFactory.reset();
+});
+
+afterEach(() => {
+  apiMock.assertComplete();
+});
+
+function renderScreen() {
+  const { path } = routes.election(electionId).geography.root;
+  const history = createMemoryHistory({ initialEntries: [path] });
+  render(
+    provideApi(
+      apiMock,
+      withRoute(<GeographyScreen />, {
+        paramPath: routes.election(':electionId').geography.root.path,
+        path,
+      })
+    )
+  );
+  return history;
+}
+
+const electionWithNoGeographyRecord: ElectionRecord = makeElectionRecord({
+  ...electionGeneral,
+  districts: [],
+  precincts: [],
+});
+
+const electionWithNoPrecinctsRecord: ElectionRecord = makeElectionRecord({
+  ...electionGeneral,
+  precincts: [],
+});
+
+describe('Districts tab', () => {
+  test('adding a district', async () => {
+    const { election } = electionWithNoGeographyRecord;
+    const newDistrict: District = {
+      id: idFactory.next() as DistrictId,
+      name: 'New District',
+    };
+
+    apiMock.getElection
+      .expectCallWith({ electionId })
+      .resolves(electionWithNoGeographyRecord);
+    renderScreen();
+
+    await screen.findByRole('heading', { name: 'Geography' });
+    screen.getByRole('tab', { name: 'Districts', selected: true });
+    screen.getByText("You haven't added any districts to this election yet.");
+
+    userEvent.click(screen.getByRole('button', { name: 'Add District' }));
+    await screen.findByRole('heading', { name: 'Add District' });
+
+    userEvent.type(screen.getByLabelText('Name'), newDistrict.name);
+
+    const electionWithNewDistrictRecord: ElectionRecord = {
+      ...electionWithNoGeographyRecord,
+      election: { ...election, districts: [newDistrict] },
+    };
+    apiMock.updateElection
+      .expectCallWith({
+        electionId,
+        election: electionWithNewDistrictRecord.election,
+      })
+      .resolves();
+    apiMock.getElection
+      .expectCallWith({ electionId })
+      .resolves(electionWithNewDistrictRecord);
+    userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await screen.findByRole('heading', { name: 'Geography' });
+    screen.getByRole('tab', { name: 'Districts', selected: true });
+    expect(
+      screen.getAllByRole('columnheader').map((th) => th.textContent)
+    ).toEqual(['Name', '']);
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(2);
+    expect(
+      within(rows[1])
+        .getAllByRole('cell')
+        .map((td) => td.textContent)
+    ).toEqual([newDistrict.name, 'Edit']);
+  });
+
+  test('editing a district', async () => {
+    const { election } = generalElectionRecord;
+    const savedDistrict = election.districts[0];
+    const changedDistrict: District = {
+      ...savedDistrict,
+      name: 'Changed District',
+    };
+
+    apiMock.getElection
+      .expectCallWith({ electionId })
+      .resolves(generalElectionRecord);
+    renderScreen();
+
+    await screen.findByRole('heading', { name: 'Geography' });
+    screen.getByRole('tab', { name: 'Districts', selected: true });
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(election.districts.length + 1);
+
+    const savedContestRow = screen.getByText(savedDistrict.name).closest('tr')!;
+    const contestRowIndex = rows.indexOf(savedContestRow);
+    userEvent.click(
+      within(savedContestRow).getByRole('button', { name: 'Edit' })
+    );
+
+    await screen.findByRole('heading', { name: 'Edit District' });
+
+    const nameInput = screen.getByLabelText('Name');
+    expect(nameInput).toHaveValue(savedDistrict.name);
+    userEvent.clear(nameInput);
+    userEvent.type(nameInput, changedDistrict.name);
+
+    const electionWithChangedDistrictRecord: ElectionRecord = {
+      ...generalElectionRecord,
+      election: {
+        ...election,
+        districts: [changedDistrict, ...election.districts.slice(1)],
+      },
+    };
+    apiMock.updateElection
+      .expectCallWith({
+        electionId,
+        election: electionWithChangedDistrictRecord.election,
+      })
+      .resolves();
+    apiMock.getElection
+      .expectCallWith({ electionId })
+      .resolves(electionWithChangedDistrictRecord);
+    userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await screen.findByRole('heading', { name: 'Geography' });
+    screen.getByRole('tab', { name: 'Districts', selected: true });
+
+    const changedContestRow = screen.getAllByRole('row')[contestRowIndex];
+    within(changedContestRow).getByText(changedDistrict.name);
+  });
+
+  test('deleting a district', async () => {
+    const { election } = generalElectionRecord;
+    assert(election.districts.length === 3);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [savedDistrict, remainingDistrict, unusedDistrict] =
+      election.districts;
+
+    apiMock.getElection
+      .expectCallWith({ electionId })
+      .resolves(generalElectionRecord);
+    renderScreen();
+
+    await screen.findByRole('heading', { name: 'Geography' });
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(election.districts.length + 1);
+    const savedDistrictRow = screen
+      .getByText(savedDistrict.name)
+      .closest('tr')!;
+    userEvent.click(
+      within(savedDistrictRow).getByRole('button', { name: 'Edit' })
+    );
+
+    await screen.findByRole('heading', { name: 'Edit District' });
+
+    // Writing out by hand the expected precincts after deleting the district to
+    // avoid replicating the logic we're trying to test (which removes the
+    // deleted district from any precincts/splits that reference it)
+    assert(generalElectionRecord.precincts.length === 3);
+    assert(hasSplits(generalElectionRecord.precincts[1]));
+    const precinctsWithDeletedDistrict: Precinct[] = [
+      {
+        ...generalElectionRecord.precincts[0],
+        districtIds: [remainingDistrict.id],
+      },
+      {
+        ...generalElectionRecord.precincts[1],
+        splits: [
+          {
+            ...generalElectionRecord.precincts[1].splits[0],
+            districtIds: [remainingDistrict.id],
+          },
+          {
+            ...generalElectionRecord.precincts[1].splits[1],
+            districtIds: [],
+          },
+        ],
+      },
+      {
+        ...generalElectionRecord.precincts[2],
+        districtIds: [],
+      },
+    ];
+    const electionWithDeletedDistrictRecord: ElectionRecord = {
+      ...generalElectionRecord,
+      election: {
+        ...election,
+        districts: election.districts.filter(
+          (district) => district.id !== savedDistrict.id
+        ),
+      },
+      precincts: precinctsWithDeletedDistrict,
+    };
+    apiMock.updateElection
+      .expectCallWith({
+        electionId,
+        election: electionWithDeletedDistrictRecord.election,
+      })
+      .resolves();
+    apiMock.updatePrecincts
+      .expectCallWith({
+        electionId,
+        precincts: precinctsWithDeletedDistrict,
+      })
+      .resolves();
+    apiMock.getElection
+      .expectCallWith({ electionId })
+      .resolves(electionWithDeletedDistrictRecord);
+    // Two mutations cause two refetches
+    apiMock.getElection
+      .expectCallWith({ electionId })
+      .resolves(electionWithDeletedDistrictRecord);
+    userEvent.click(screen.getByRole('button', { name: 'Delete District' }));
+
+    await screen.findByRole('heading', { name: 'Geography' });
+    expect(screen.getAllByRole('row')).toHaveLength(
+      electionWithDeletedDistrictRecord.election.districts.length + 1
+    );
+    expect(screen.queryByText(savedDistrict.name)).not.toBeInTheDocument();
+  });
+});
+
+describe('Precincts tab', () => {
+  test('adding a precinct', async () => {
+    const { election } = electionWithNoPrecinctsRecord;
+    const newPrecinct: Precinct = {
+      id: idFactory.next(),
+      name: 'New Precinct',
+      districtIds: [election.districts[0].id, election.districts[1].id],
+    };
+
+    apiMock.getElection
+      .expectCallWith({ electionId })
+      .resolves(electionWithNoPrecinctsRecord);
+    renderScreen();
+
+    await screen.findByRole('heading', { name: 'Geography' });
+    userEvent.click(screen.getByRole('tab', { name: 'Precincts' }));
+    screen.getByText("You haven't added any precincts to this election yet.");
+
+    userEvent.click(screen.getByRole('button', { name: 'Add Precinct' }));
+    await screen.findByRole('heading', { name: 'Add Precinct' });
+
+    userEvent.type(screen.getByLabelText('Name'), newPrecinct.name);
+
+    for (const districtId of newPrecinct.districtIds) {
+      userEvent.click(
+        screen.getByRole('checkbox', {
+          name: election.districts.find((d) => d.id === districtId)!.name,
+        })
+      );
+    }
+
+    const electionWithNewPrecinctRecord: ElectionRecord = {
+      ...electionWithNoPrecinctsRecord,
+      election, // Don't update the election, since it's not used here and it's hard to update ballot styles correctly
+      precincts: [newPrecinct],
+    };
+    apiMock.updatePrecincts
+      .expectCallWith({
+        electionId,
+        precincts: [newPrecinct],
+      })
+      .resolves();
+    apiMock.getElection
+      .expectCallWith({ electionId })
+      .resolves(electionWithNewPrecinctRecord);
+    userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await screen.findByRole('heading', { name: 'Geography' });
+    screen.getByRole('tab', { name: 'Precincts', selected: true });
+    expect(
+      screen.getAllByRole('columnheader').map((th) => th.textContent)
+    ).toEqual(['Name', 'Districts', '']);
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(2);
+    expect(
+      within(rows[1])
+        .getAllByRole('cell')
+        .map((td) => td.textContent)
+    ).toEqual([
+      newPrecinct.name,
+      `${election.districts[0].name}, ${election.districts[1].name}`,
+      'Edit',
+    ]);
+  });
+
+  test('editing a precinct - adding splits', async () => {
+    const { election, precincts } = generalElectionRecord;
+    const savedPrecinct = precincts[0];
+    assert(!hasSplits(savedPrecinct));
+
+    const changedPrecinct: PrecinctWithSplits = {
+      id: savedPrecinct.id,
+      name: 'Changed Precinct',
+      splits: [
+        {
+          id: idFactory.next(),
+          name: 'Split 1',
+          districtIds: [election.districts[0].id],
+          nhCustomContent: {
+            electionTitle: 'Custom Election Title',
+          },
+        },
+        {
+          id: (() => {
+            // Burn one ID since we're gonna delete a split
+            idFactory.next();
+            return idFactory.next();
+          })(),
+          name: 'Split 2',
+          districtIds: [election.districts[1].id],
+          nhCustomContent: {},
+        },
+      ],
+    };
+
+    apiMock.getElection
+      .expectCallWith({ electionId })
+      .resolves(generalElectionRecord);
+    renderScreen();
+
+    await screen.findByRole('heading', { name: 'Geography' });
+    userEvent.click(screen.getByRole('tab', { name: 'Precincts' }));
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(precincts.length + 2 /* precinct splits */ + 1);
+
+    const savedPrecinctRow = screen
+      .getByText(savedPrecinct.name)
+      .closest('tr')!;
+    expect(
+      within(savedPrecinctRow)
+        .getAllByRole('cell')
+        .map((td) => td.textContent)
+    ).toEqual([
+      savedPrecinct.name,
+      `${election.districts[0].name}, ${election.districts[1].name}`,
+      'Edit',
+    ]);
+    userEvent.click(
+      within(savedPrecinctRow).getByRole('button', { name: 'Edit' })
+    );
+    await screen.findByRole('heading', { name: 'Edit Precinct' });
+
+    const nameInput = screen.getByLabelText('Name');
+    expect(nameInput).toHaveValue(savedPrecinct.name);
+    userEvent.clear(nameInput);
+    userEvent.type(nameInput, changedPrecinct.name);
+
+    userEvent.click(screen.getByRole('button', { name: 'Add Split' }));
+    userEvent.click(screen.getByRole('button', { name: 'Add Split' }));
+
+    const splitCards = screen
+      .getAllByRole('button', { name: 'Remove Split' })
+      .map((button) => button.closest('div')!);
+    expect(splitCards).toHaveLength(3);
+    const [split1Card, split2Card, split3Card] = splitCards;
+
+    const split1NameInput = within(split1Card).getByLabelText('Name');
+    expect(split1NameInput).toHaveValue('');
+    userEvent.type(split1NameInput, changedPrecinct.splits[0].name);
+    // Selected districts carry over to first precinct split
+    within(split1Card).getByRole('checkbox', {
+      name: election.districts[0].name,
+      checked: true,
+    });
+    userEvent.click(
+      within(split1Card).getByRole('checkbox', {
+        name: election.districts[1].name,
+        checked: true,
+      })
+    );
+    within(split1Card).getByRole('checkbox', {
+      name: election.districts[2].name,
+      checked: false,
+    });
+    const split1ElectionTitleInput = within(split1Card).getByLabelText(
+      'Election Title Override'
+    );
+    expect(split1ElectionTitleInput).toHaveValue('');
+    userEvent.type(
+      split1ElectionTitleInput,
+      changedPrecinct.splits[0].nhCustomContent.electionTitle!
+    );
+
+    for (const district of election.districts) {
+      within(split2Card).getByRole('checkbox', {
+        name: district.name,
+        checked: false,
+      });
+    }
+    userEvent.click(
+      within(split2Card).getByRole('button', { name: 'Remove Split' })
+    );
+
+    const split3NameInput = within(split3Card).getByLabelText('Name');
+    expect(split3NameInput).toHaveValue('');
+    userEvent.type(split3NameInput, changedPrecinct.splits[1].name);
+    for (const district of election.districts) {
+      within(split3Card).getByRole('checkbox', {
+        name: district.name,
+        checked: false,
+      });
+    }
+    userEvent.click(
+      within(split3Card).getByRole('checkbox', {
+        name: election.districts[1].name,
+      })
+    );
+
+    const electionWithChangedPrecinctRecord: ElectionRecord = {
+      ...generalElectionRecord,
+      election, // Don't update the election, since it's not used here and it's hard to update ballot styles correctly
+      precincts: precincts.map((precinct) =>
+        precinct.id === changedPrecinct.id ? changedPrecinct : precinct
+      ),
+    };
+    apiMock.updatePrecincts
+      .expectCallWith({
+        electionId,
+        precincts: electionWithChangedPrecinctRecord.precincts,
+      })
+      .resolves();
+    apiMock.getElection
+      .expectCallWith({ electionId })
+      .resolves(electionWithChangedPrecinctRecord);
+    userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await screen.findByRole('heading', { name: 'Geography' });
+    expect(screen.getAllByRole('row')).toHaveLength(
+      precincts.length + 4 /* precinct splits */ + 1
+    );
+    const changedPrecinctRow = screen
+      .getByText(changedPrecinct.name)
+      .closest('tr')!;
+    expect(
+      within(changedPrecinctRow)
+        .getAllByRole('cell')
+        .map((td) => td.textContent)
+    ).toEqual([changedPrecinct.name, '', 'Edit']);
+    expect(
+      within(changedPrecinctRow.nextSibling as HTMLTableRowElement)
+        .getAllByRole('cell')
+        .map((td) => td.textContent)
+    ).toEqual([changedPrecinct.splits[0].name, election.districts[0].name, '']);
+    expect(
+      within(changedPrecinctRow.nextSibling!.nextSibling as HTMLTableRowElement)
+        .getAllByRole('cell')
+        .map((td) => td.textContent)
+    ).toEqual([changedPrecinct.splits[1].name, election.districts[1].name, '']);
+  });
+
+  test('editing a precinct - removing splits', async () => {
+    const { election, precincts } = generalElectionRecord;
+    const savedPrecinct = precincts.find(hasSplits)!;
+    assert(savedPrecinct.splits.length === 2);
+
+    const changedPrecinct: PrecinctWithoutSplits = {
+      id: savedPrecinct.id,
+      name: savedPrecinct.name,
+      districtIds: savedPrecinct.splits[1].districtIds,
+    };
+
+    apiMock.getElection
+      .expectCallWith({ electionId })
+      .resolves(generalElectionRecord);
+    renderScreen();
+
+    await screen.findByRole('heading', { name: 'Geography' });
+    userEvent.click(screen.getByRole('tab', { name: 'Precincts' }));
+    const savedPrecinctRow = screen
+      .getByText(savedPrecinct.name)
+      .closest('tr')!;
+    userEvent.click(
+      within(savedPrecinctRow).getByRole('button', { name: 'Edit' })
+    );
+    await screen.findByRole('heading', { name: 'Edit Precinct' });
+
+    const splitCards = screen
+      .getAllByRole('button', { name: 'Remove Split' })
+      .map((button) => button.closest('div')!);
+    const [split1Card] = splitCards;
+    userEvent.click(
+      within(split1Card).getByRole('button', { name: 'Remove Split' })
+    );
+    expect(
+      screen.queryByRole('button', { name: 'Remove Split' })
+    ).not.toBeInTheDocument();
+
+    // Districts from last remaining split should be selected for the whole precinct
+    screen.getByRole('checkbox', {
+      name: election.districts[0].name,
+      checked: true,
+    });
+    screen.getByRole('checkbox', {
+      name: election.districts[1].name,
+      checked: false,
+    });
+    screen.getByRole('checkbox', {
+      name: election.districts[2].name,
+      checked: false,
+    });
+
+    const electionWithChangedPrecinctRecord: ElectionRecord = {
+      ...generalElectionRecord,
+      election, // Don't update the election, since it's not used here and it's hard to update ballot styles correctly
+      precincts: precincts.map((precinct) =>
+        precinct.id === changedPrecinct.id ? changedPrecinct : precinct
+      ),
+    };
+    apiMock.updatePrecincts
+      .expectCallWith({
+        electionId,
+        precincts: electionWithChangedPrecinctRecord.precincts,
+      })
+      .resolves();
+    apiMock.getElection
+      .expectCallWith({ electionId })
+      .resolves(electionWithChangedPrecinctRecord);
+    userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await screen.findByRole('heading', { name: 'Geography' });
+    expect(screen.getAllByRole('row')).toHaveLength(precincts.length + 1);
+    const changedPrecinctRow = screen
+      .getByText(changedPrecinct.name)
+      .closest('tr')!;
+    expect(
+      within(changedPrecinctRow)
+        .getAllByRole('cell')
+        .map((td) => td.textContent)
+    ).toEqual([changedPrecinct.name, election.districts[0].name, 'Edit']);
+  });
+
+  test('deleting a precinct', async () => {
+    const { election, precincts } = generalElectionRecord;
+    assert(precincts.length === 3);
+    const [savedPrecinct] = precincts;
+
+    apiMock.getElection
+      .expectCallWith({ electionId })
+      .resolves(generalElectionRecord);
+    renderScreen();
+
+    await screen.findByRole('heading', { name: 'Geography' });
+    userEvent.click(screen.getByRole('tab', { name: 'Precincts' }));
+    const savedPrecinctRow = screen
+      .getByText(savedPrecinct.name)
+      .closest('tr')!;
+    userEvent.click(
+      within(savedPrecinctRow).getByRole('button', { name: 'Edit' })
+    );
+
+    await screen.findByRole('heading', { name: 'Edit Precinct' });
+
+    const electionWithDeletedPrecinctRecord: ElectionRecord = {
+      ...generalElectionRecord,
+      election, // Don't update the election, since it's not used here and it's hard to update ballot styles correctly
+      precincts: precincts.filter(
+        (precinct) => precinct.id !== savedPrecinct.id
+      ),
+    };
+    apiMock.updatePrecincts
+      .expectCallWith({
+        electionId,
+        precincts: electionWithDeletedPrecinctRecord.precincts,
+      })
+      .resolves();
+    apiMock.getElection
+      .expectCallWith({ electionId })
+      .resolves(electionWithDeletedPrecinctRecord);
+    userEvent.click(screen.getByRole('button', { name: 'Delete Precinct' }));
+
+    await screen.findByRole('heading', { name: 'Geography' });
+    expect(screen.getAllByRole('row')).toHaveLength(
+      electionWithDeletedPrecinctRecord.precincts.length +
+        2 /* precinct splits */ +
+        1
+    );
+    expect(screen.queryByText(savedPrecinct.name)).not.toBeInTheDocument();
+  });
+});

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -447,6 +447,7 @@ function PrecinctForm({
             id: generateId(),
             name: nextId(`${name} - Split `),
             districtIds: [],
+            nhCustomContent: {},
           },
         ],
       });
@@ -460,11 +461,13 @@ function PrecinctForm({
             id: `${id}-split-1`,
             name: `${name} - Split 1`,
             districtIds,
+            nhCustomContent: {},
           },
           {
             id: `${id}-split-2`,
             name: `${name} - Split 2`,
             districtIds: [],
+            nhCustomContent: {},
           },
         ],
       });
@@ -553,6 +556,25 @@ function PrecinctForm({
                         })
                       }
                     />
+                    <InputGroup label="Election Title Override">
+                      <input
+                        type="text"
+                        value={split.nhCustomContent.electionTitle ?? ''}
+                        onChange={(e) =>
+                          setPrecinct({
+                            ...precinct,
+                            splits: replaceAtIndex(precinct.splits, index, {
+                              ...split,
+                              nhCustomContent: {
+                                ...split.nhCustomContent,
+                                electionTitle: e.target.value,
+                              },
+                            }),
+                          })
+                        }
+                      />
+                    </InputGroup>
+
                     <Button onPress={() => onRemoveSplitPress(index)}>
                       Remove Split
                     </Button>

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -118,11 +118,11 @@ function DistrictForm({
   districtId?: string;
   savedElection: Election;
   savedPrecincts?: Precinct[];
-}): JSX.Element {
+}): JSX.Element | null {
   const savedDistricts = savedElection.districts;
-  const [district, setDistrict] = useState<District>(
+  const [district, setDistrict] = useState<District | undefined>(
     districtId
-      ? find(savedDistricts, (d) => d.id === districtId)
+      ? savedDistricts.find((d) => d.id === districtId)
       : // To make mocked IDs predictable in tests, we pass a function here
         // so it will only be called on intial render.
         createBlankDistrict
@@ -132,7 +132,15 @@ function DistrictForm({
   const history = useHistory();
   const geographyRoutes = routes.election(electionId).geography;
 
+  // After deleting a district, this component may re-render briefly with no
+  // district before redirecting to the districts list. We can just render
+  // nothing in that case.
+  if (!district) {
+    return null;
+  }
+
   function onSavePress() {
+    assert(district);
     const newDistricts = districtId
       ? savedElection.districts.map((d) => (d.id === districtId ? district : d))
       : [...savedDistricts, district];

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -124,7 +124,7 @@ function DistrictForm({
     districtId
       ? savedDistricts.find((d) => d.id === districtId)
       : // To make mocked IDs predictable in tests, we pass a function here
-        // so it will only be called on intial render.
+        // so it will only be called on initial render.
         createBlankDistrict
   );
   const updateElectionMutation = updateElection.useMutation();
@@ -419,7 +419,7 @@ function PrecinctForm({
     precinctId
       ? savedPrecincts.find((p) => p.id === precinctId)
       : // To make mocked IDs predictable in tests, we pass a function here
-        // so it will only be called on intial render.
+        // so it will only be called on initial render.
         createBlankPrecinct
   );
   const updatePrecinctsMutation = updatePrecincts.useMutation();

--- a/apps/design/frontend/src/utils.test.ts
+++ b/apps/design/frontend/src/utils.test.ts
@@ -1,21 +1,4 @@
-import { range } from '@votingworks/basics';
-import { downloadFile, nextId } from './utils';
-
-test('nextId', () => {
-  expect(nextId('prefix-')).toEqual('prefix-1');
-  expect(nextId('prefix-', ['prefix-1'])).toEqual('prefix-2');
-  expect(nextId('prefix-', ['prefix-1', 'prefix-2'])).toEqual('prefix-3');
-  expect(nextId('prefix-', ['prefix-1', 'prefix-3'])).toEqual('prefix-2');
-  expect(
-    nextId(
-      'prefix-',
-      range(1, 100).map((n) => `prefix-${n}`)
-    )
-  ).toEqual('prefix-100');
-  expect(
-    nextId('prefix-', ['custom', 'prefix-2', 'id123', 'prefix-1'])
-  ).toEqual('prefix-3');
-});
+import { downloadFile } from './utils';
 
 test('downloadFile cleans up temporary anchor tag', () => {
   downloadFile('http://localhost:1234/file.zip');

--- a/apps/design/frontend/src/utils.ts
+++ b/apps/design/frontend/src/utils.ts
@@ -16,19 +16,6 @@ export function generateId(): string {
 }
 
 /**
- * Given a prefix and a list of existing IDs, returns the next ID of the format
- * `${prefix}${n}` that does not already exist. Increments `n` starting at 1.
- */
-export function nextId(prefix: string, existingIds?: Iterable<string>): string {
-  let n = 1;
-  const existingIdsSet = new Set(existingIds);
-  while (existingIdsSet.has(`${prefix}${n}`)) {
-    n += 1;
-  }
-  return `${prefix}${n}`;
-}
-
-/**
  * Returns a copy of the given array with the value at the specified index
  * replaced with the given value.
  */

--- a/apps/design/frontend/test/fixtures.ts
+++ b/apps/design/frontend/test/fixtures.ts
@@ -13,7 +13,7 @@ import { DEFAULT_SYSTEM_SETTINGS, Election } from '@votingworks/types';
 
 export const electionId = 'election-id-1';
 
-function makeElectionRecord(baseElection: Election): ElectionRecord {
+export function makeElectionRecord(baseElection: Election): ElectionRecord {
   const precincts = convertVxfPrecincts(baseElection);
   const ballotStyles = generateBallotStyles(baseElection, precincts);
   const election: Election = {
@@ -33,6 +33,7 @@ function makeElectionRecord(baseElection: Election): ElectionRecord {
     ballotStyles,
     layoutOptions: DEFAULT_LAYOUT_OPTIONS,
     createdAt: new Date().toISOString(),
+    nhCustomContent: {},
   };
 }
 

--- a/libs/hmpb/render-backend/src/ballot_fixtures.ts
+++ b/libs/hmpb/render-backend/src/ballot_fixtures.ts
@@ -34,6 +34,7 @@ export const famousNamesFixtures = (() => {
     ballotType: BallotType.Precinct,
     ballotMode: 'test',
     layoutOptions: DEFAULT_LAYOUT_OPTIONS,
+    nhCustomContent: {},
   }).unsafeUnwrap();
 
   const { precinctId, document: ballot, gridLayout } = ballots[0];
@@ -88,6 +89,7 @@ export const generalElectionFixtures = (() => {
             bubblePosition,
             layoutDensity,
           },
+          nhCustomContent: {},
         }).unsafeUnwrap();
 
         // Has ballot measures
@@ -191,6 +193,7 @@ export const primaryElectionFixtures = (() => {
     ballotType: BallotType.Precinct,
     ballotMode: 'test',
     layoutOptions: DEFAULT_LAYOUT_OPTIONS,
+    nhCustomContent: {},
   }).unsafeUnwrap();
 
   function makePartyFixtures(partyLabel: string, ballotStyle: BallotStyle) {


### PR DESCRIPTION
## Overview

Changing the solution for #4369. In #4482, we hardcoded an election title override for NH school district elections. However, we have more customizations needed for school district elections (e.g. adding a clerk signature: #4481). So we'll need a way to attach custom content to precinct splits (which is how we'll model the town and school elections - each will have its own precinct split).

This PR removes the election title override hardcoding and instead adds a field for a custom election title override to the precinct split form.

## Demo Video or Screenshot


https://github.com/votingworks/vxsuite/assets/530106/285f9b46-c4e0-49a5-9860-330d6870ccfa



## Testing Plan
- Updated existing tests
- Added new tests to cover the geography screen
- Some basic manual testing

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
