### PR TITLE
Fix flaky property test for PickDateTimeModal

### DIFF
--- a/libs/ui/src/set_clock.test.tsx
+++ b/libs/ui/src/set_clock.test.tsx
@@ -180,7 +180,7 @@ describe('PickDateTimeModal', () => {
           userEvent.click(screen.getByText('Save'));
 
           // Expect a changed date
-          expect(onSave).toHaveBeenCalledWith(aDate.set(dateTime.toObject()));
+          expect(onSave).toHaveBeenCalledWith(dateTime);
         }
       ),
       { numRuns: 50 }


### PR DESCRIPTION


## Overview

Calling `aDate.set` with a time that is exactly the daylight savings time border changes the time zone offset, whereas the date returned from the modal retains the original offset.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
