### PR TITLE
VxDesign: Add clerk signature image/caption custom content to ballots

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -731,7 +731,9 @@ describe('Ballot style generation', () => {
             name: 'Precinct 2 - Split 1',
             districtIds: [district1.id, district2.id],
             nhCustomContent: {
-              electionTitle: 'Custom Election Title 1',
+              electionTitle: 'Annual Town Election',
+              clerkSignatureImage: '<svg>town clerk signature image data</svg>',
+              clerkSignatureCaption: 'Town Clerk',
             },
           },
           {
@@ -739,7 +741,10 @@ describe('Ballot style generation', () => {
             name: 'Precinct 2 - Split 2',
             districtIds: [district1.id, district3.id],
             nhCustomContent: {
-              electionTitle: 'Custom Election Title 2',
+              electionTitle: 'Annual School District Election',
+              clerkSignatureImage:
+                '<svg>school district clerk signature image data</svg>',
+              clerkSignatureCaption: 'School District Clerk',
             },
           },
           {
@@ -802,10 +807,15 @@ describe('Ballot style generation', () => {
     ]);
     expect(nhCustomContent).toEqual({
       'ballot-style-2': {
-        electionTitle: 'Custom Election Title 1',
+        electionTitle: 'Annual Town Election',
+        clerkSignatureImage: '<svg>town clerk signature image data</svg>',
+        clerkSignatureCaption: 'Town Clerk',
       },
       'ballot-style-3': {
-        electionTitle: 'Custom Election Title 2',
+        electionTitle: 'Annual School District Election',
+        clerkSignatureImage:
+          '<svg>school district clerk signature image data</svg>',
+        clerkSignatureCaption: 'School District Clerk',
       },
     });
   });

--- a/apps/design/frontend/jest.config.js
+++ b/apps/design/frontend/jest.config.js
@@ -12,8 +12,8 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: -130,
-      lines: -217,
+      branches: -132,
+      lines: -224,
     },
   },
   setupFiles: ['react-app-polyfill/jsdom'],

--- a/apps/design/frontend/jest.config.js
+++ b/apps/design/frontend/jest.config.js
@@ -12,7 +12,7 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: -127,
+      branches: -130,
       lines: -217,
     },
   },

--- a/apps/design/frontend/src/ballot_screen.tsx
+++ b/apps/design/frontend/src/ballot_screen.tsx
@@ -30,7 +30,7 @@ export function BallotScreen(): JSX.Element | null {
         precinct={precinct}
         ballotStyle={ballotStyle}
         layoutOptions={layoutOptions}
-        nhCustomContent={nhCustomContent[ballotStyle.id]}
+        nhCustomContent={nhCustomContent[ballotStyle.id] ?? {}}
       />
     </Screen>
   );

--- a/apps/design/frontend/src/election_info_screen.test.tsx
+++ b/apps/design/frontend/src/election_info_screen.test.tsx
@@ -119,9 +119,7 @@ test('edit and save election', async () => {
     'src',
     `data:image/svg+xml;base64,${Buffer.from(election.seal).toString('base64')}`
   );
-  expect(
-    within(sealInput).queryByLabelText('Upload Seal Image')
-  ).not.toBeInTheDocument();
+  expect(within(sealInput).getByLabelText('Upload Seal Image')).toBeDisabled();
 
   userEvent.click(screen.getByRole('button', { name: 'Edit' }));
 

--- a/apps/design/frontend/src/election_info_screen.tsx
+++ b/apps/design/frontend/src/election_info_screen.tsx
@@ -6,20 +6,25 @@ import {
   MainContent,
   MainHeader,
   SegmentedButton,
-  FileInputButton,
 } from '@votingworks/ui';
-import { Buffer } from 'buffer';
 import { useHistory, useParams } from 'react-router-dom';
-import DomPurify from 'dompurify';
+import styled from 'styled-components';
 import { deleteElection, getElection, updateElection } from './api';
 import { FieldName, Form, FormActionsRow, InputGroup } from './layout';
 import { ElectionNavScreen } from './nav_screen';
 import { routes } from './routes';
+import { ImageInput } from './image_input';
 
 type ElectionInfo = Pick<
   Election,
   'title' | 'date' | 'type' | 'state' | 'county' | 'seal'
 >;
+
+const SealImageInput = styled(ImageInput)`
+  img {
+    width: 10rem;
+  }
+`;
 
 function hasBlankElectionInfo(election: Election): boolean {
   return (
@@ -128,40 +133,12 @@ function ElectionInfoForm({
       </InputGroup>
       <div>
         <FieldName>Seal</FieldName>
-        {electionInfo.seal && (
-          <img
-            src={`data:image/svg+xml;base64,${Buffer.from(
-              electionInfo.seal
-            ).toString('base64')}`}
-            alt="Seal"
-            style={{ maxWidth: '10rem', marginBottom: '1rem' }}
-          />
-        )}
-        {(isEditing || !electionInfo.seal) && (
-          <FileInputButton
-            accept="image/svg+xml"
-            onChange={(e) => {
-              const file = e.target.files?.[0];
-              if (!file) {
-                return;
-              }
-              const reader = new FileReader();
-              reader.onload = (e2) => {
-                const svgContents = e2.target?.result;
-                if (typeof svgContents === 'string') {
-                  const seal = DomPurify.sanitize(svgContents, {
-                    USE_PROFILES: { svg: true },
-                  });
-                  setElectionInfo({ ...electionInfo, seal });
-                }
-              };
-              reader.readAsText(file);
-            }}
-            disabled={!isEditing}
-          >
-            Upload Seal Image
-          </FileInputButton>
-        )}
+        <SealImageInput
+          value={electionInfo.seal}
+          onChange={(seal) => setElectionInfo({ ...electionInfo, seal })}
+          disabled={!isEditing}
+          buttonLabel="Upload Seal Image"
+        />
       </div>
 
       {isEditing ? (

--- a/apps/design/frontend/src/image_input.tsx
+++ b/apps/design/frontend/src/image_input.tsx
@@ -1,0 +1,61 @@
+import { Buffer } from 'buffer';
+import DomPurify from 'dompurify';
+import { FileInputButton } from '@votingworks/ui';
+
+const MAX_SVG_UPLOAD_BYTES = 5 * 1_000 * 1_000; // 5 MB
+
+export function ImageInput({
+  value,
+  onChange,
+  buttonLabel,
+  disabled,
+  className,
+}: {
+  value?: string;
+  onChange: (value: string) => void;
+  buttonLabel: string;
+  disabled?: boolean;
+  className?: string;
+}): JSX.Element {
+  return (
+    <div className={className}>
+      {value && (
+        <img
+          src={`data:image/svg+xml;base64,${Buffer.from(value).toString(
+            'base64'
+          )}`}
+          alt="Upload preview"
+          style={{ marginBottom: '0.5rem' }}
+        />
+      )}
+      <FileInputButton
+        disabled={disabled}
+        accept="image/svg+xml"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (!file) return;
+          if (file.size > MAX_SVG_UPLOAD_BYTES) {
+            throw new Error(
+              `Image file size must be less than ${
+                MAX_SVG_UPLOAD_BYTES / 1_000 / 1_000
+              } MB`
+            );
+          }
+          const reader = new FileReader();
+          reader.onload = (e2) => {
+            const svgContents = e2.target?.result;
+            if (typeof svgContents === 'string') {
+              const image = DomPurify.sanitize(svgContents, {
+                USE_PROFILES: { svg: true },
+              });
+              onChange(image);
+            }
+          };
+          reader.readAsText(file);
+        }}
+      >
+        {buttonLabel}
+      </FileInputButton>
+    </div>
+  );
+}

--- a/libs/hmpb/layout/src/document_svg.tsx
+++ b/libs/hmpb/layout/src/document_svg.tsx
@@ -70,10 +70,22 @@ export function SvgTextBox({
           key={textLine + index}
           // Adjust x coordinate if textAnchor is 'end' so that the overall
           // content box location stays the same, since 'end' moves the text to
-          // the other side of the x coordinate.
-          x={align === 'left' ? 0 : width}
+          // the other side of the x coordinate. Similarly for 'middle'.
+          x={
+            {
+              left: 0,
+              center: width / 2,
+              right: width,
+            }[align]
+          }
           y={(index + 1) * lineHeight}
-          textAnchor={align === 'left' ? 'start' : 'end'}
+          textAnchor={
+            {
+              left: 'start',
+              center: 'middle',
+              right: 'end',
+            }[align]
+          }
           {...textProps}
         >
           {textLine}

--- a/libs/hmpb/layout/src/document_types.ts
+++ b/libs/hmpb/layout/src/document_types.ts
@@ -30,7 +30,7 @@ export interface TextBox extends ElementBase {
   fontSize: number;
   fontWeight: number;
   lineHeight: number;
-  align?: 'left' | 'right';
+  align?: 'left' | 'right' | 'center';
 }
 
 export interface Image extends ElementBase {

--- a/libs/hmpb/layout/src/layout.test.ts
+++ b/libs/hmpb/layout/src/layout.test.ts
@@ -213,7 +213,7 @@ test('gridForPaper', () => {
   });
 });
 
-test('NH school district election special case', () => {
+test('NH custom content', () => {
   const districts: District[] = [
     {
       id: 'district-1' as DistrictId,
@@ -254,9 +254,14 @@ test('NH school district election special case', () => {
   const nhCustomContent: NhCustomContentByBallotStyle = {
     [townBallotStyle.id]: {
       electionTitle: 'Annual Town Election',
+      clerkSignatureImage: '<svg>town clerk signature image data</svg>',
+      clerkSignatureCaption: 'Town Clerk',
     },
     [schoolBallotStyle.id]: {
       electionTitle: 'Annual School District Election',
+      clerkSignatureImage:
+        '<svg>school district clerk signature image data</svg>',
+      clerkSignatureCaption: 'School District Clerk',
     },
   };
   const { ballots } = layOutAllBallotStyles({
@@ -267,36 +272,38 @@ test('NH school district election special case', () => {
     nhCustomContent,
   }).unsafeUnwrap();
 
-  const townBallot = ballots.find(
-    (ballot) => ballot.gridLayout.ballotStyleId === townBallotStyle.id
+  const townBallot = JSON.stringify(
+    ballots.find(
+      (ballot) => ballot.gridLayout.ballotStyleId === townBallotStyle.id
+    )
   );
-  expect(JSON.stringify(townBallot)).toContain(
-    nhCustomContent[townBallotStyle.id].electionTitle
-  );
-  expect(JSON.stringify(townBallot)).not.toContain(
-    nhCustomContent[schoolBallotStyle.id].electionTitle
-  );
-  expect(JSON.stringify(townBallot)).not.toContain(election.title);
+  const townContent = nhCustomContent[townBallotStyle.id];
+  expect(townBallot).toContain(townContent.electionTitle);
+  expect(townBallot).toContain(townContent.clerkSignatureImage);
+  expect(townBallot).toContain(townContent.clerkSignatureCaption);
+  expect(townBallot).not.toContain(election.title);
 
-  const schoolBallot = ballots.find(
-    (ballot) => ballot.gridLayout.ballotStyleId === schoolBallotStyle.id
+  const schoolBallot = JSON.stringify(
+    ballots.find(
+      (ballot) => ballot.gridLayout.ballotStyleId === schoolBallotStyle.id
+    )
   );
-  expect(JSON.stringify(schoolBallot)).toContain(
-    nhCustomContent[schoolBallotStyle.id].electionTitle
-  );
-  expect(JSON.stringify(schoolBallot)).not.toContain(
-    nhCustomContent[townBallotStyle.id].electionTitle
-  );
+  const schoolContent = nhCustomContent[schoolBallotStyle.id];
+  expect(schoolBallot).toContain(schoolContent.electionTitle);
+  expect(schoolBallot).toContain(schoolContent.clerkSignatureImage);
+  expect(schoolBallot).toContain(schoolContent.clerkSignatureCaption);
   expect(JSON.stringify(schoolBallot)).not.toContain(election.title);
 
-  const combinedBallot = ballots.find(
-    (ballot) => ballot.gridLayout.ballotStyleId === combinedBallotStyle.id
+  const combinedBallot = JSON.stringify(
+    ballots.find(
+      (ballot) => ballot.gridLayout.ballotStyleId === combinedBallotStyle.id
+    )
   );
-  expect(JSON.stringify(combinedBallot)).toContain(election.title);
-  expect(JSON.stringify(combinedBallot)).not.toContain(
-    nhCustomContent[townBallotStyle.id].electionTitle
-  );
-  expect(JSON.stringify(combinedBallot)).not.toContain(
-    nhCustomContent[schoolBallotStyle.id].electionTitle
-  );
+  expect(combinedBallot).toContain(election.title);
+  expect(combinedBallot).not.toContain(townContent.electionTitle);
+  expect(combinedBallot).not.toContain(townContent.clerkSignatureImage);
+  expect(combinedBallot).not.toContain(townContent.clerkSignatureCaption);
+  expect(combinedBallot).not.toContain(schoolContent.electionTitle);
+  expect(combinedBallot).not.toContain(schoolContent.clerkSignatureImage);
+  expect(combinedBallot).not.toContain(schoolContent.clerkSignatureCaption);
 });

--- a/libs/hmpb/layout/src/layout.ts
+++ b/libs/hmpb/layout/src/layout.ts
@@ -55,6 +55,8 @@ const debug = makeDebug('layout');
  */
 export interface NhCustomContent {
   electionTitle?: string;
+  clerkSignatureImage?: string;
+  clerkSignatureCaption?: string;
 }
 export type NhCustomContentByBallotStyle = Record<
   BallotStyleId,
@@ -428,6 +430,53 @@ function HeaderAndInstructions({
     timeZone: 'UTC',
   }).format(new Date(election.date));
 
+  const clerkSignatureRowHeight = m.HEADER_ROW_HEIGHT - 1.5;
+  const clerkSignatureColumnWidth = nhCustomContent.clerkSignatureImage
+    ? 6.5
+    : 0;
+  const clerkSignatureBlock: Rectangle | undefined =
+    nhCustomContent.clerkSignatureImage
+      ? {
+          type: 'Rectangle',
+          ...gridPoint(
+            {
+              row: (m.HEADER_ROW_HEIGHT - 0.25 - clerkSignatureRowHeight) / 2,
+              column:
+                m.CONTENT_AREA_COLUMN_WIDTH - clerkSignatureColumnWidth - 0.5,
+            },
+            m
+          ),
+          width: gridWidth(clerkSignatureColumnWidth, m),
+          height: gridHeight(clerkSignatureRowHeight, m),
+          children: [
+            {
+              type: 'Image',
+              ...gridPoint({ row: 0, column: 0 }, m),
+              width: gridWidth(clerkSignatureColumnWidth, m),
+              height: gridHeight(clerkSignatureRowHeight - 0.5, m),
+              contents: nhCustomContent.clerkSignatureImage,
+            },
+            TextBlock({
+              ...gridPoint(
+                {
+                  row: clerkSignatureRowHeight - 0.5,
+                  column: 0,
+                },
+                m
+              ),
+              width: gridWidth(clerkSignatureColumnWidth, m),
+              textGroups: [
+                {
+                  text: nhCustomContent.clerkSignatureCaption ?? '',
+                  fontStyle: m.FontStyles.BODY,
+                },
+              ],
+              align: 'center',
+            }),
+          ],
+        }
+      : undefined;
+
   const header: Rectangle = {
     type: 'Rectangle',
     ...gridPoint({ row: 0, column: 0 }, m),
@@ -439,7 +488,10 @@ function HeaderAndInstructions({
           { row: m.HEADER_ROW_HEIGHT / 15, column: sealRowHeight + 1.5 },
           m
         ),
-        width: gridWidth(m.CONTENT_AREA_COLUMN_WIDTH - 1, m),
+        width: gridWidth(
+          m.CONTENT_AREA_COLUMN_WIDTH - 1 - clerkSignatureColumnWidth,
+          m
+        ),
         textGroups: [
           {
             text: `${ballotTitle}${party}`,
@@ -471,6 +523,7 @@ function HeaderAndInstructions({
         height: gridHeight(sealRowHeight, m),
         contents: election.seal,
       },
+      ...(clerkSignatureBlock ? [clerkSignatureBlock] : []),
     ],
   };
 

--- a/libs/ui/src/button.tsx
+++ b/libs/ui/src/button.tsx
@@ -518,11 +518,11 @@ export const LabelButton = styled.label`
   ${buttonStyles}
 
   &:hover {
-    ${(p) => css(hoverStyles(p))}
+    ${(p) => !p.disabled && css(hoverStyles(p))}
   }
 
-  &:active {
-    ${(p) => css(activeStyles(p))}
+  &:active:enabled {
+    ${(p) => !p.disabled && css(activeStyles(p))}
   }
 `;
 

--- a/libs/ui/src/card.tsx
+++ b/libs/ui/src/card.tsx
@@ -58,6 +58,7 @@ const StyledContainer = styled.div<{ color?: CardColor }>`
 
 const StyledContent = styled.div`
   padding: ${(p) => (p.theme.sizeMode === 'desktop' ? '1rem' : '0.5rem')};
+  height: 100%;
 
   /* Shrink padding if there's a footer: */
   &:not(:last-child) {

--- a/libs/ui/src/file_input_button.tsx
+++ b/libs/ui/src/file_input_button.tsx
@@ -51,7 +51,7 @@ export function FileInputButton({
     input?.blur();
   }
   return (
-    <LabelButtonContainer {...buttonProps}>
+    <LabelButtonContainer {...buttonProps} disabled={disabled}>
       <HiddenFileInput
         {...rest}
         accept={accept}


### PR DESCRIPTION
## Overview

Closes #4481 

Builds on #4495 to allow uploading a clerk signature image and caption for a precinct split. The image and caption are rendered in the ballot header.

## Demo Video or Screenshot

https://github.com/votingworks/vxsuite/assets/530106/fc39ba69-3b38-42e9-ba29-7a804da499f4



## Testing Plan
- Updated automated tests
- Manual test that layout works with signatures of varied length/image size (captured in video)

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
