### PR TITLE
Move repeated dotenv logic to libs/backend and add dotenv logic to VxDesign backend

### DIFF
--- a/apps/admin/backend/package.json
+++ b/apps/admin/backend/package.json
@@ -51,8 +51,6 @@
     "compression": "^1.7.4",
     "csv-stringify": "^6.4.0",
     "debug": "4.3.4",
-    "dotenv": "16.3.1",
-    "dotenv-expand": "9.0.0",
     "express": "4.18.2",
     "fs-extra": "11.1.1",
     "js-sha256": "^0.9.0",

--- a/apps/admin/backend/src/index.ts
+++ b/apps/admin/backend/src/index.ts
@@ -1,42 +1,12 @@
 // Import the rest of our application.
-import fs from 'fs';
 import { Logger, LogSource, LogEventId } from '@votingworks/logging';
-import * as dotenv from 'dotenv';
-import * as dotenvExpand from 'dotenv-expand';
-
-import { isIntegrationTest } from '@votingworks/utils';
-import { NODE_ENV } from './globals';
+import { loadEnvVarsFromDotenvFiles } from '@votingworks/backend';
 import * as server from './server';
 
 export type { Api } from './app';
 export * from './types';
 
-const isTestEnvironment = NODE_ENV === 'test' || isIntegrationTest();
-
-// https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
-const dotenvPath = '.env';
-const dotenvFiles: string[] = [
-  `${dotenvPath}.${NODE_ENV}.local`,
-  // Don't include `.env.local` for `test` environment
-  // since normally you expect tests to produce the same
-  // results for everyone
-  !isTestEnvironment ? `${dotenvPath}.local` : '',
-  `${dotenvPath}.${NODE_ENV}`,
-  dotenvPath,
-  !isTestEnvironment ? `../../../${dotenvPath}.local` : '',
-  `../../../${dotenvPath}`,
-].filter(Boolean);
-
-// Load environment variables from .env* files. Suppress warnings using silent
-// if this file is missing. dotenv will never modify any environment variables
-// that have already been set.  Variable expansion is supported in .env files.
-// https://github.com/motdotla/dotenv
-// https://github.com/motdotla/dotenv-expand
-for (const dotenvFile of dotenvFiles) {
-  if (fs.existsSync(dotenvFile)) {
-    dotenvExpand.expand(dotenv.config({ path: dotenvFile }));
-  }
-}
+loadEnvVarsFromDotenvFiles();
 
 const logger = new Logger(LogSource.VxAdminService);
 

--- a/apps/central-scan/backend/package.json
+++ b/apps/central-scan/backend/package.json
@@ -57,8 +57,6 @@
     "buffer": "^6.0.3",
     "canvas": "2.9.1",
     "debug": "4.3.4",
-    "dotenv": "16.3.1",
-    "dotenv-expand": "9.0.0",
     "express": "4.18.2",
     "fs-extra": "11.1.1",
     "js-sha256": "^0.9.0",

--- a/apps/central-scan/backend/src/index.ts
+++ b/apps/central-scan/backend/src/index.ts
@@ -1,42 +1,14 @@
 import { Logger, LogSource, LogEventId } from '@votingworks/logging';
-import fs from 'fs';
-import * as dotenv from 'dotenv';
-import * as dotenvExpand from 'dotenv-expand';
-import { isIntegrationTest } from '@votingworks/utils';
 import { iter } from '@votingworks/basics';
-import { MOCK_SCANNER_FILES, NODE_ENV } from './globals';
+import { loadEnvVarsFromDotenvFiles } from '@votingworks/backend';
+import { MOCK_SCANNER_FILES } from './globals';
 import { LoopScanner, parseBatchesFromEnv } from './loop_scanner';
 import { BatchScanner } from './fujitsu_scanner';
 import * as server from './server';
 
 export type { Api } from './app';
 
-const isTestEnvironment = NODE_ENV === 'test' || isIntegrationTest();
-
-// https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
-const dotenvPath = '.env';
-const dotenvFiles: string[] = [
-  `${dotenvPath}.${NODE_ENV}.local`,
-  // Don't include `.env.local` for `test` environment
-  // since normally you expect tests to produce the same
-  // results for everyone
-  !isTestEnvironment ? `${dotenvPath}.local` : '',
-  `${dotenvPath}.${NODE_ENV}`,
-  dotenvPath,
-  !isTestEnvironment ? `../../../${dotenvPath}.local` : '',
-  `../../../${dotenvPath}`,
-].filter(Boolean);
-
-// Load environment variables from .env* files. Suppress warnings using silent
-// if this file is missing. dotenv will never modify any environment variables
-// that have already been set.  Variable expansion is supported in .env files.
-// https://github.com/motdotla/dotenv
-// https://github.com/motdotla/dotenv-expand
-for (const dotenvFile of dotenvFiles) {
-  if (fs.existsSync(dotenvFile)) {
-    dotenvExpand.expand(dotenv.config({ path: dotenvFile }));
-  }
-}
+loadEnvVarsFromDotenvFiles();
 
 const logger = new Logger(LogSource.VxCentralScanService);
 

--- a/apps/design/backend/package.json
+++ b/apps/design/backend/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@google-cloud/text-to-speech": "^5.0.1",
     "@google-cloud/translate": "^8.0.2",
+    "@votingworks/backend": "workspace:*",
     "@votingworks/basics": "workspace:*",
     "@votingworks/db": "workspace:*",
     "@votingworks/grout": "workspace:*",

--- a/apps/design/backend/src/index.ts
+++ b/apps/design/backend/src/index.ts
@@ -1,4 +1,5 @@
 import { resolve } from 'path';
+import { loadEnvVarsFromDotenvFiles } from '@votingworks/backend';
 import { WORKSPACE } from './globals';
 import * as server from './server';
 import { createWorkspace } from './workspace';
@@ -16,6 +17,8 @@ export type { Api } from './app';
 // Frontend tests import these for generating test data
 export { generateBallotStyles } from './store';
 export { createBlankElection, convertVxfPrecincts } from './app';
+
+loadEnvVarsFromDotenvFiles();
 
 function main(): Promise<number> {
   if (!WORKSPACE) {

--- a/apps/design/backend/src/worker/index.ts
+++ b/apps/design/backend/src/worker/index.ts
@@ -1,9 +1,12 @@
 import path from 'path';
+import { loadEnvVarsFromDotenvFiles } from '@votingworks/backend';
 import { assertDefined } from '@votingworks/basics';
 
 import { WORKSPACE } from '../globals';
-import * as worker from './worker';
 import { createWorkspace } from '../workspace';
+import * as worker from './worker';
+
+loadEnvVarsFromDotenvFiles();
 
 async function main(): Promise<void> {
   const workspacePath = path.resolve(assertDefined(WORKSPACE));

--- a/apps/design/backend/tsconfig.build.json
+++ b/apps/design/backend/tsconfig.build.json
@@ -10,6 +10,7 @@
     "declarationMap": true
   },
   "references": [
+    { "path": "../../../libs/backend/tsconfig.build.json" },
     { "path": "../../../libs/basics/tsconfig.build.json" },
     { "path": "../../../libs/ballot-interpreter/tsconfig.build.json" },
     { "path": "../../../libs/db/tsconfig.build.json" },

--- a/apps/design/backend/tsconfig.json
+++ b/apps/design/backend/tsconfig.json
@@ -18,6 +18,7 @@
     "noUncheckedIndexedAccess": false
   },
   "references": [
+    { "path": "../../../libs/backend/tsconfig.build.json" },
     { "path": "../../../libs/basics/tsconfig.build.json" },
     { "path": "../../../libs/ballot-interpreter/tsconfig.build.json" },
     { "path": "../../../libs/db/tsconfig.build.json" },

--- a/apps/mark-scan/backend/package.json
+++ b/apps/mark-scan/backend/package.json
@@ -52,8 +52,6 @@
     "@votingworks/utils": "workspace:*",
     "canvas": "2.9.1",
     "debug": "4.3.4",
-    "dotenv": "16.3.1",
-    "dotenv-expand": "9.0.0",
     "express": "4.18.2",
     "fs-extra": "11.1.1",
     "js-sha256": "^0.9.0",

--- a/apps/mark-scan/backend/src/index.ts
+++ b/apps/mark-scan/backend/src/index.ts
@@ -1,42 +1,14 @@
 import { Logger, LogSource, LogEventId } from '@votingworks/logging';
-import fs from 'fs';
-import * as dotenv from 'dotenv';
-import * as dotenvExpand from 'dotenv-expand';
-import { isIntegrationTest } from '@votingworks/utils';
+import { loadEnvVarsFromDotenvFiles } from '@votingworks/backend';
 import * as server from './server';
-import { MARK_SCAN_WORKSPACE, NODE_ENV, PORT } from './globals';
+import { MARK_SCAN_WORKSPACE, PORT } from './globals';
 import { createWorkspace, Workspace } from './util/workspace';
 
 export type { Api } from './app';
 export * from './types';
 export * from './custom-paper-handler';
 
-const isTestEnvironment = NODE_ENV === 'test' || isIntegrationTest();
-
-// https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
-const dotEnvPath = '.env';
-const dotenvFiles: string[] = [
-  `${dotEnvPath}.${NODE_ENV}.local`,
-  // Don't include `.env.local` for `test` environment
-  // since normally you expect tests to produce the same
-  // results for everyone
-  !isTestEnvironment ? `${dotEnvPath}.local` : '',
-  `${dotEnvPath}.${NODE_ENV}`,
-  dotEnvPath,
-  !isTestEnvironment ? `../../../${dotEnvPath}.local` : '',
-  `../../../${dotEnvPath}`,
-].filter(Boolean);
-
-// Load environment variables from .env* files. Suppress warnings using silent
-// if this file is missing. dotenv will never modify any environment variables
-// that have already been set.  Variable expansion is supported in .env files.
-// https://github.com/motdotla/dotenv
-// https://github.com/motdotla/dotenv-expand
-for (const dotenvFile of dotenvFiles) {
-  if (fs.existsSync(dotenvFile)) {
-    dotenvExpand.expand(dotenv.config({ path: dotenvFile }));
-  }
-}
+loadEnvVarsFromDotenvFiles();
 
 const logger = new Logger(LogSource.VxMarkScanBackend);
 

--- a/apps/mark/backend/package.json
+++ b/apps/mark/backend/package.json
@@ -46,8 +46,6 @@
     "@votingworks/usb-drive": "workspace:*",
     "@votingworks/utils": "workspace:*",
     "debug": "4.3.4",
-    "dotenv": "16.3.1",
-    "dotenv-expand": "9.0.0",
     "express": "4.18.2",
     "fs-extra": "11.1.1",
     "js-sha256": "^0.9.0",

--- a/apps/mark/backend/src/index.ts
+++ b/apps/mark/backend/src/index.ts
@@ -1,41 +1,13 @@
 import { Logger, LogSource, LogEventId } from '@votingworks/logging';
-import fs from 'fs';
-import * as dotenv from 'dotenv';
-import * as dotenvExpand from 'dotenv-expand';
-import { isIntegrationTest } from '@votingworks/utils';
+import { loadEnvVarsFromDotenvFiles } from '@votingworks/backend';
 import * as server from './server';
-import { MARK_WORKSPACE, NODE_ENV, PORT } from './globals';
+import { MARK_WORKSPACE, PORT } from './globals';
 import { createWorkspace, Workspace } from './util/workspace';
 
 export type { Api } from './app';
 export * from './types';
 
-const isTestEnvironment = NODE_ENV === 'test' || isIntegrationTest();
-
-// https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
-const dotEnvPath = '.env';
-const dotenvFiles: string[] = [
-  `${dotEnvPath}.${NODE_ENV}.local`,
-  // Don't include `.env.local` for `test` environment
-  // since normally you expect tests to produce the same
-  // results for everyone
-  !isTestEnvironment ? `${dotEnvPath}.local` : '',
-  `${dotEnvPath}.${NODE_ENV}`,
-  dotEnvPath,
-  !isTestEnvironment ? `../../../${dotEnvPath}.local` : '',
-  `../../../${dotEnvPath}`,
-].filter(Boolean);
-
-// Load environment variables from .env* files. Suppress warnings using silent
-// if this file is missing. dotenv will never modify any environment variables
-// that have already been set.  Variable expansion is supported in .env files.
-// https://github.com/motdotla/dotenv
-// https://github.com/motdotla/dotenv-expand
-for (const dotenvFile of dotenvFiles) {
-  if (fs.existsSync(dotenvFile)) {
-    dotenvExpand.expand(dotenv.config({ path: dotenvFile }));
-  }
-}
+loadEnvVarsFromDotenvFiles();
 
 const logger = new Logger(LogSource.VxMarkBackend);
 

--- a/apps/scan/backend/package.json
+++ b/apps/scan/backend/package.json
@@ -57,8 +57,6 @@
     "buffer": "^6.0.3",
     "canvas": "2.9.1",
     "debug": "4.3.4",
-    "dotenv": "16.3.1",
-    "dotenv-expand": "9.0.0",
     "express": "4.18.2",
     "fs-extra": "11.1.1",
     "got": "^11.8.2",

--- a/apps/scan/backend/src/index.ts
+++ b/apps/scan/backend/src/index.ts
@@ -1,8 +1,5 @@
 import * as customScanner from '@votingworks/custom-scanner';
 import { LogEventId, Logger, LogSource } from '@votingworks/logging';
-import * as dotenv from 'dotenv';
-import * as dotenvExpand from 'dotenv-expand';
-import fs from 'fs';
 import { detectUsbDrive } from '@votingworks/usb-drive';
 import {
   InsertedSmartCardAuth,
@@ -14,7 +11,8 @@ import {
   isFeatureFlagEnabled,
   isIntegrationTest,
 } from '@votingworks/utils';
-import { NODE_ENV, SCAN_WORKSPACE } from './globals';
+import { loadEnvVarsFromDotenvFiles } from '@votingworks/backend';
+import { SCAN_WORKSPACE } from './globals';
 import * as customStateMachine from './scanners/custom/state_machine';
 import * as server from './server';
 import { createWorkspace, Workspace } from './util/workspace';
@@ -22,30 +20,7 @@ import { createWorkspace, Workspace } from './util/workspace';
 export type { Api } from './app';
 export * from './types';
 
-// https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
-const dotenvPath = '.env';
-const dotenvFiles: string[] = [
-  `${dotenvPath}.${NODE_ENV}.local`,
-  // Don't include `.env.local` for `test` environment
-  // since normally you expect tests to produce the same
-  // results for everyone
-  NODE_ENV !== 'test' ? `${dotenvPath}.local` : '',
-  `${dotenvPath}.${NODE_ENV}`,
-  dotenvPath,
-  NODE_ENV !== 'test' ? `../../../${dotenvPath}.local` : '',
-  `../../../${dotenvPath}`,
-].filter(Boolean);
-
-// Load environment variables from .env* files. Suppress warnings using silent
-// if this file is missing. dotenv will never modify any environment variables
-// that have already been set.  Variable expansion is supported in .env files.
-// https://github.com/motdotla/dotenv
-// https://github.com/motdotla/dotenv-expand
-for (const dotenvFile of dotenvFiles) {
-  if (fs.existsSync(dotenvFile)) {
-    dotenvExpand.expand(dotenv.config({ path: dotenvFile }));
-  }
-}
+loadEnvVarsFromDotenvFiles();
 
 const logger = new Logger(LogSource.VxScanBackend);
 

--- a/libs/backend/package.json
+++ b/libs/backend/package.json
@@ -46,6 +46,8 @@
     "@votingworks/utils": "workspace:*",
     "buffer": "^6.0.3",
     "debug": "4.3.4",
+    "dotenv": "16.3.1",
+    "dotenv-expand": "9.0.0",
     "fs-extra": "11.1.1",
     "js-sha256": "^0.9.0",
     "jszip": "^3.9.1",

--- a/libs/backend/src/dotenv.ts
+++ b/libs/backend/src/dotenv.ts
@@ -1,0 +1,37 @@
+/* istanbul ignore file */
+
+import * as dotenv from 'dotenv';
+import * as dotenvExpand from 'dotenv-expand';
+import fs from 'fs';
+import { isIntegrationTest } from '@votingworks/utils';
+
+/**
+ * Loads environment variables from .env* files. dotenv will never modify environment variables
+ * that have already been set.
+ *
+ * https://github.com/motdotla/dotenv
+ * https://github.com/motdotla/dotenv-expand
+ */
+export function loadEnvVarsFromDotenvFiles(): void {
+  const nodeEnv = process.env.NODE_ENV;
+  const isTestEnvironment = nodeEnv === 'test' || isIntegrationTest();
+
+  // https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
+  const dotenvPath = '.env';
+  const dotenvFiles: string[] = [
+    `${dotenvPath}.${nodeEnv}.local`,
+    // Don't include `.env.local` in test environments since we expect tests to produce the same
+    // results for everyone
+    !isTestEnvironment ? `${dotenvPath}.local` : '',
+    `${dotenvPath}.${nodeEnv}`,
+    dotenvPath,
+    !isTestEnvironment ? `../../../${dotenvPath}.local` : '',
+    `../../../${dotenvPath}`,
+  ].filter(Boolean);
+
+  for (const dotenvFile of dotenvFiles) {
+    if (fs.existsSync(dotenvFile)) {
+      dotenvExpand.expand(dotenv.config({ path: dotenvFile }));
+    }
+  }
+}

--- a/libs/backend/src/index.ts
+++ b/libs/backend/src/index.ts
@@ -1,9 +1,10 @@
 /* istanbul ignore file */
-export * from './election_package';
 export * from './cast_vote_records';
+export * from './dotenv';
+export * from './election_package';
 export * from './exporter';
 export * from './list_directory';
+export * from './logs';
 export * from './scan_globals';
 export * from './split';
 export * from './ui_strings';
-export * from './logs';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,12 +171,6 @@ importers:
       debug:
         specifier: 4.3.4
         version: 4.3.4(supports-color@5.5.0)
-      dotenv:
-        specifier: 16.3.1
-        version: 16.3.1
-      dotenv-expand:
-        specifier: 9.0.0
-        version: 9.0.0
       express:
         specifier: 4.18.2
         version: 4.18.2
@@ -708,12 +702,6 @@ importers:
       debug:
         specifier: 4.3.4
         version: 4.3.4(supports-color@5.5.0)
-      dotenv:
-        specifier: 16.3.1
-        version: 16.3.1
-      dotenv-expand:
-        specifier: 9.0.0
-        version: 9.0.0
       express:
         specifier: 4.18.2
         version: 4.18.2
@@ -1104,6 +1092,9 @@ importers:
       '@google-cloud/translate':
         specifier: ^8.0.2
         version: 8.0.2
+      '@votingworks/backend':
+        specifier: workspace:*
+        version: link:../../../libs/backend
       '@votingworks/basics':
         specifier: workspace:*
         version: link:../../../libs/basics
@@ -1496,12 +1487,6 @@ importers:
       debug:
         specifier: 4.3.4
         version: 4.3.4(supports-color@5.5.0)
-      dotenv:
-        specifier: 16.3.1
-        version: 16.3.1
-      dotenv-expand:
-        specifier: 9.0.0
-        version: 9.0.0
       express:
         specifier: 4.18.2
         version: 4.18.2
@@ -1913,12 +1898,6 @@ importers:
       debug:
         specifier: 4.3.4
         version: 4.3.4(supports-color@5.5.0)
-      dotenv:
-        specifier: 16.3.1
-        version: 16.3.1
-      dotenv-expand:
-        specifier: 9.0.0
-        version: 9.0.0
       express:
         specifier: 4.18.2
         version: 4.18.2
@@ -2342,12 +2321,6 @@ importers:
       debug:
         specifier: 4.3.4
         version: 4.3.4(supports-color@5.5.0)
-      dotenv:
-        specifier: 16.3.1
-        version: 16.3.1
-      dotenv-expand:
-        specifier: 9.0.0
-        version: 9.0.0
       express:
         specifier: 4.18.2
         version: 4.18.2
@@ -2935,6 +2908,12 @@ importers:
       debug:
         specifier: 4.3.4
         version: 4.3.4(supports-color@5.5.0)
+      dotenv:
+        specifier: 16.3.1
+        version: 16.3.1
+      dotenv-expand:
+        specifier: 9.0.0
+        version: 9.0.0
       fs-extra:
         specifier: 11.1.1
         version: 11.1.1


### PR DESCRIPTION
## Overview

This PR moves repeated dotenv logic to `libs/backend` and adds dotenv logic to the VxDesign backend. This logic is necessary for our `.env*` file based feature flagging to work in app backends.

Doing this as a pre-req before I add a feature flag for skipping cloud translation and speech synthesis in VxDesign.

## Testing Plan

Manually tested that env vars in `.env` files are still properly recognized in app backends