### PR TITLE
various improvements & PR feedback for #4502

### DIFF
--- a/libs/printing/package.json
+++ b/libs/printing/package.json
@@ -53,7 +53,6 @@
     "@types/debug": "4.1.8",
     "@types/jest": "^29.5.3",
     "@types/jest-image-snapshot": "^6.4.0",
-    "@types/memorystream": "^0.3.4",
     "@types/node": "16.18.23",
     "@types/react": "18.2.18",
     "@types/react-dom": "^18.2.7",
@@ -69,7 +68,6 @@
     "jest-junit": "^16.0.0",
     "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "11.0.0",
-    "memorystream": "^0.3.1",
     "sort-package-json": "^1.50.0",
     "ts-jest": "29.1.1"
   },

--- a/libs/printing/src/printer/cli.ts
+++ b/libs/printing/src/printer/cli.ts
@@ -17,7 +17,7 @@ async function printStatus(printer: Printer, stdout: NodeJS.WriteStream) {
   }
 }
 
-async function watchPrinter(printer: Printer): Promise<void> {
+async function watchPrinter(printer: Printer): Promise<never> {
   const { stdout } = process;
   for (;;) {
     await printStatus(printer, stdout);

--- a/libs/printing/src/printer/configure.test.ts
+++ b/libs/printing/src/printer/configure.test.ts
@@ -1,7 +1,8 @@
+import { ok } from '@votingworks/basics';
 import { mockOf } from '@votingworks/test-utils';
+import { BROTHER_THERMAL_PRINTER_CONFIG, getPpdPath } from '.';
 import { exec } from '../utils/exec';
 import { DEFAULT_MANAGED_PRINTER_NAME, configurePrinter } from './configure';
-import { BROTHER_THERMAL_PRINTER_CONFIG, getPpdPath } from '.';
 
 jest.mock('../utils/exec');
 
@@ -14,10 +15,12 @@ beforeEach(() => {
 });
 
 test('calls lpadmin with expected args', async () => {
-  execMock.mockResolvedValueOnce({
-    stdout: '',
-    stderr: '',
-  });
+  execMock.mockResolvedValueOnce(
+    ok({
+      stdout: '',
+      stderr: '',
+    })
+  );
 
   const uri = 'usb://Make/Model';
   const config = BROTHER_THERMAL_PRINTER_CONFIG;

--- a/libs/printing/src/printer/configure.ts
+++ b/libs/printing/src/printer/configure.ts
@@ -28,5 +28,5 @@ export async function configurePrinter({
   ];
 
   debug('configuring printer with lpadmin: args=%o', lpadminConfigureArgs);
-  await exec('lpadmin', lpadminConfigureArgs);
+  (await exec('lpadmin', lpadminConfigureArgs)).unsafeUnwrap();
 }

--- a/libs/printing/src/printer/device_uri.ts
+++ b/libs/printing/src/printer/device_uri.ts
@@ -1,3 +1,4 @@
+import { lines } from '@votingworks/basics';
 import { rootDebug } from '../utils/debug';
 import { exec } from '../utils/exec';
 
@@ -5,12 +6,13 @@ const debug = rootDebug.extend('device-uri');
 
 export async function getConnectedDeviceUris(): Promise<string[]> {
   debug('getting connected device URIs from lpinfo...');
-  const { stdout } = await exec('lpinfo', ['--include-schemes', 'usb', '-v']);
+  const { stdout } = (
+    await exec('lpinfo', ['--include-schemes', 'usb', '-v'])
+  ).unsafeUnwrap();
 
-  const deviceUris = stdout
-    .split('\n')
-    .map((line) => line.split(/\s+/, 2)[1])
-    .filter(Boolean);
+  const deviceUris = lines(stdout)
+    .filterMap((line) => line.split(/\s+/, 2)[1])
+    .toArray();
   debug('connected device URIs: %O', deviceUris);
   return deviceUris;
 }

--- a/libs/printing/src/printer/print.test.ts
+++ b/libs/printing/src/printer/print.test.ts
@@ -1,8 +1,9 @@
+import { ok } from '@votingworks/basics';
 import { mockOf } from '@votingworks/test-utils';
 import { Buffer } from 'buffer';
 import { exec } from '../utils/exec';
-import { print } from './print';
 import { DEFAULT_MANAGED_PRINTER_NAME } from './configure';
+import { print } from './print';
 import { PrintSides } from './types';
 
 jest.mock('../utils/exec');
@@ -16,7 +17,7 @@ beforeEach(() => {
 });
 
 test('prints with defaults', async () => {
-  execMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+  execMock.mockResolvedValueOnce(ok({ stdout: '', stderr: '' }));
 
   await print({ data: Buffer.of() });
 
@@ -28,7 +29,7 @@ test('prints with defaults', async () => {
 });
 
 test('allows specifying other sided-ness', async () => {
-  execMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+  execMock.mockResolvedValueOnce(ok({ stdout: '', stderr: '' }));
 
   await print({ data: Buffer.of(), sides: PrintSides.OneSided });
 
@@ -40,7 +41,7 @@ test('allows specifying other sided-ness', async () => {
 });
 
 test('prints a specified number of copies', async () => {
-  execMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+  execMock.mockResolvedValueOnce(ok({ stdout: '', stderr: '' }));
 
   await print({ data: Buffer.of(), copies: 3 });
 
@@ -59,7 +60,7 @@ test('prints a specified number of copies', async () => {
 });
 
 test('passes through raw options', async () => {
-  execMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+  execMock.mockResolvedValueOnce(ok({ stdout: '', stderr: '' }));
 
   await print({ data: Buffer.of(), raw: { 'fit-to-page': 'true' } });
 
@@ -78,7 +79,7 @@ test('passes through raw options', async () => {
 });
 
 test('rejects invalid raw options', async () => {
-  execMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+  execMock.mockResolvedValueOnce(ok({ stdout: '', stderr: '' }));
 
   await expect(
     print({ data: Buffer.of(), raw: { 'fit to page': 'true' } })

--- a/libs/printing/src/printer/print.ts
+++ b/libs/printing/src/printer/print.ts
@@ -32,7 +32,8 @@ export async function print({
   }
 
   debug('printing via lpr with args=%o', lprOptions);
-  debug('data length is %d', data.length);
-  const { stdout, stderr } = await exec('lpr', lprOptions, data);
+  const { stdout, stderr } = (
+    await exec('lpr', lprOptions, data)
+  ).unsafeUnwrap();
   debug('`lpr` succeeded with stdout=%s stderr=%s', stdout, stderr);
 }

--- a/libs/printing/src/printer/types.ts
+++ b/libs/printing/src/printer/types.ts
@@ -44,7 +44,13 @@ export interface PrintOptions {
   raw?: { [key: string]: string };
 }
 
-export type PrintProps = PrintOptions & { data: Buffer };
+export type PrintProps = PrintOptions & {
+  data:
+    | Buffer
+    | NodeJS.ReadableStream
+    | Iterable<Buffer>
+    | AsyncIterable<Buffer>;
+};
 
 export type PrintFunction = (props: PrintProps) => Promise<void>;
 

--- a/libs/printing/src/utils/exec.test.ts
+++ b/libs/printing/src/utils/exec.test.ts
@@ -8,10 +8,10 @@ const argsWorkerPath = join(__dirname, '../../test/args_worker.js');
 const echoWorkerPath = join(__dirname, '../../test/echo_worker.js');
 
 test('command with no args', async () => {
-  const execPromise = exec('whoami');
+  const execPromise = exec('date');
   expect(await execPromise).toEqual(
     ok({
-      stdout: expect.stringContaining(process.env['USER']!),
+      stdout: expect.stringMatching(/\d+/),
       stderr: '',
     })
   );

--- a/libs/printing/test/args_worker.js
+++ b/libs/printing/test/args_worker.js
@@ -1,0 +1,3 @@
+// Prints out JSON of the arguments passed to this process.
+
+process.stdout.write(JSON.stringify(process.argv.slice(2)));

--- a/libs/printing/test/echo_worker.js
+++ b/libs/printing/test/echo_worker.js
@@ -1,0 +1,6 @@
+// Echos stdin to stdout
+
+process.stdin.resume();
+process.stdin.on('data', (chunk) => {
+  process.stdout.write(chunk);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4858,9 +4858,6 @@ importers:
       '@types/jest-image-snapshot':
         specifier: ^6.4.0
         version: 6.4.0
-      '@types/memorystream':
-        specifier: ^0.3.4
-        version: 0.3.4
       '@types/node':
         specifier: 16.18.23
         version: 16.18.23
@@ -4906,9 +4903,6 @@ importers:
       lint-staged:
         specifier: 11.0.0
         version: 11.0.0
-      memorystream:
-        specifier: ^0.3.1
-        version: 0.3.1
       sort-package-json:
         specifier: ^1.50.0
         version: 1.50.0
@@ -11161,12 +11155,6 @@ packages:
 
   /@types/mdx@2.0.3:
     resolution: {integrity: sha512-IgHxcT3RC8LzFLhKwP3gbMPeaK7BM9eBH46OdapPA7yvuIUJ8H6zHZV53J8hGZcTSnt95jANt+rTBNUUc22ACQ==}
-    dev: true
-
-  /@types/memorystream@0.3.4:
-    resolution: {integrity: sha512-AVVe8unTnhTecg9GmRVddQFvi5K7+QcvLTfUstT+5dhQ633+JX4bK/sKaHTj8Z5RUOoVNS6u1gfby29ArDj4Gw==}
-    dependencies:
-      '@types/node': 16.18.23
     dev: true
 
   /@types/micromatch@4.0.2:
@@ -18371,11 +18359,6 @@ packages:
     resolution: {integrity: sha512-qVQ/CjkMyMInPaaRMrwWNDvf6boRZXaT/DbQeMYcCWuXPEBf1v8qChOc9OlEVQp2uOvRXa1Qu30fLmKhY6NipA==}
     dependencies:
       readable-stream: 1.0.34
-    dev: true
-
-  /memorystream@0.3.1:
-    resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
-    engines: {node: '>= 0.10.0'}
     dev: true
 
   /meow@10.1.5:


### PR DESCRIPTION
- use `test.each` rather than reimplementing it
- allow printing from a stream of data
- make `exec` return `Result`
- test `exec` using real `child_process.spawn`
- use `iter` for processing `lpinfo` stdout
- use `never` return type for never-returning function