### PR TITLE
VxDesign: Support bitmap image uploads (PNG and JPEG)

### DIFF
--- a/apps/design/frontend/jest.config.js
+++ b/apps/design/frontend/jest.config.js
@@ -12,8 +12,8 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: -132,
-      lines: -224,
+      branches: -128,
+      lines: -216,
     },
   },
   setupFiles: ['react-app-polyfill/jsdom'],

--- a/apps/design/frontend/src/election_info_screen.test.tsx
+++ b/apps/design/frontend/src/election_info_screen.test.tsx
@@ -145,7 +145,9 @@ test('edit and save election', async () => {
 
   userEvent.upload(
     within(sealInput).getByLabelText('Upload Seal Image'),
-    new File(['<svg>updated seal</svg>'], 'new_seal.svg')
+    new File(['<svg>updated seal</svg>'], 'new_seal.svg', {
+      type: 'image/svg+xml',
+    })
   );
   await waitFor(() =>
     expect(within(sealInput).getByRole('img')).toHaveAttribute(

--- a/apps/design/frontend/src/geography_screen.test.tsx
+++ b/apps/design/frontend/src/geography_screen.test.tsx
@@ -438,7 +438,8 @@ describe('Precincts tab', () => {
       within(split1ClerkSignatureField).getByLabelText('Upload Image'),
       new File(
         [changedPrecinct.splits[0].nhCustomContent.clerkSignatureImage!],
-        'signature.svg'
+        'signature.svg',
+        { type: 'image/svg+xml' }
       )
     );
     await waitFor(() =>

--- a/apps/design/frontend/src/image_input.test.tsx
+++ b/apps/design/frontend/src/image_input.test.tsx
@@ -42,21 +42,17 @@ describe('ImageInput', () => {
   });
 
   test.each(['png', 'jpeg'])('converts %s images to SVG', async (imageType) => {
-    // Mock Image so we can test getting the dimensions of the uploaded PNG
-    window.Image = class Image extends window.Image {
-      constructor() {
-        super();
-        // @ts-expect-error we're not using the event arg in onload
-        setTimeout(() => this.onload(), 0);
-        Object.defineProperties(this, {
-          naturalWidth: { value: 1 },
-          naturalHeight: { value: 2 },
-        });
-      }
+    // Mock Image so we can test getting the dimensions of the uploaded image
+    HTMLImageElement.prototype.decode = function decode() {
+      Object.defineProperties(this, {
+        naturalWidth: { value: 1 },
+        naturalHeight: { value: 2 },
+      });
+      return Promise.resolve();
     };
     const onChange = jest.fn();
-    const imageContents = 'test png contents';
-    const pngFile = new File([imageContents], `image.${imageType}`, {
+    const imageContents = 'test image contents';
+    const imageFile = new File([imageContents], `image.${imageType}`, {
       type: `image/${imageType}`,
     });
     const svgContents = `<svg viewBox="0 0 1 2" height="2" width="1" xmlns="http://www.w3.org/2000/svg">
@@ -68,7 +64,7 @@ describe('ImageInput', () => {
       <ImageInput value={undefined} onChange={onChange} buttonLabel="Upload" />
     );
     const input = screen.getByLabelText('Upload');
-    userEvent.upload(input, pngFile);
+    userEvent.upload(input, imageFile);
     await waitFor(() => expect(onChange).toHaveBeenCalledWith(svgContents));
   });
 

--- a/apps/design/frontend/src/image_input.test.tsx
+++ b/apps/design/frontend/src/image_input.test.tsx
@@ -1,0 +1,90 @@
+import userEvent from '@testing-library/user-event';
+import { Buffer } from 'buffer';
+import { render, screen, waitFor } from '../test/react_testing_library';
+import { ImageInput } from './image_input';
+
+describe('ImageInput', () => {
+  test('accepts and sanitizes SVGs', async () => {
+    const onChange = jest.fn();
+    const unsafeContents = '<svg><script>alert("unsafe")</script></svg>';
+    const sanitizedContents = '<svg></svg>';
+    const svgFile = new File([unsafeContents], 'image.svg', {
+      type: 'image/svg+xml',
+    });
+    render(
+      <ImageInput value={undefined} onChange={onChange} buttonLabel="Upload" />
+    );
+    const input = screen.getByLabelText('Upload');
+    userEvent.upload(input, svgFile);
+    await waitFor(() =>
+      expect(onChange).toHaveBeenCalledWith(sanitizedContents)
+    );
+  });
+
+  test('shows a preview image', async () => {
+    const imageContents = '<svg><circle r="1" fill="black" /></svg>';
+    render(
+      <ImageInput
+        value={imageContents}
+        onChange={jest.fn()}
+        buttonLabel="Upload"
+      />
+    );
+    const previewImage = await screen.findByRole('img', {
+      name: 'Upload preview',
+    });
+    expect(previewImage).toHaveAttribute(
+      'src',
+      `data:image/svg+xml;base64,${Buffer.from(imageContents).toString(
+        'base64'
+      )}`
+    );
+  });
+
+  test.each(['png', 'jpeg'])('converts %s images to SVG', async (imageType) => {
+    // Mock Image so we can test getting the dimensions of the uploaded PNG
+    window.Image = class Image extends window.Image {
+      constructor() {
+        super();
+        // @ts-expect-error we're not using the event arg in onload
+        setTimeout(() => this.onload(), 0);
+        Object.defineProperties(this, {
+          naturalWidth: { value: 1 },
+          naturalHeight: { value: 2 },
+        });
+      }
+    };
+    const onChange = jest.fn();
+    const imageContents = 'test png contents';
+    const pngFile = new File([imageContents], `image.${imageType}`, {
+      type: `image/${imageType}`,
+    });
+    const svgContents = `<svg viewBox="0 0 1 2" height="2" width="1" xmlns="http://www.w3.org/2000/svg">
+    <image height="2" width="1" href="data:image/${imageType};base64,${Buffer.from(
+      imageContents
+    ).toString('base64')}"></image>
+  </svg>`;
+    render(
+      <ImageInput value={undefined} onChange={onChange} buttonLabel="Upload" />
+    );
+    const input = screen.getByLabelText('Upload');
+    userEvent.upload(input, pngFile);
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(svgContents));
+  });
+
+  test('rejects images that are too large', async () => {
+    const tooLargeFile = new File([''], 'image.png', { type: 'image/png' });
+    jest.spyOn(tooLargeFile, 'size', 'get').mockReturnValue(6 * 1_000 * 1_000);
+    const consoleErrorMock = jest.spyOn(console, 'error').mockImplementation();
+    render(
+      <ImageInput value={undefined} onChange={jest.fn()} buttonLabel="Upload" />
+    );
+
+    const input = screen.getByLabelText('Upload');
+    userEvent.upload(input, tooLargeFile);
+    await waitFor(() => expect(consoleErrorMock).toHaveBeenCalled());
+    expect(consoleErrorMock.mock.calls[0][0]['message']).toEqual(
+      'Image file size must be less than 5 MB'
+    );
+  });
+});

--- a/apps/design/frontend/src/image_input.tsx
+++ b/apps/design/frontend/src/image_input.tsx
@@ -1,8 +1,61 @@
 import { Buffer } from 'buffer';
 import DomPurify from 'dompurify';
 import { FileInputButton } from '@votingworks/ui';
+import { assert, assertDefined } from '@votingworks/basics';
 
-const MAX_SVG_UPLOAD_BYTES = 5 * 1_000 * 1_000; // 5 MB
+const MAX_IMAGE_UPLOAD_BYTES = 5 * 1_000 * 1_000; // 5 MB
+
+const ALLOWED_IMAGE_TYPES = ['image/svg+xml', 'image/png', 'image/jpeg'];
+
+async function loadSvgImage(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      /* istanbul ignore next */
+      const contents = e.target?.result;
+      if (typeof contents === 'string') {
+        resolve(contents);
+      }
+      reject(new Error('Could not read file contents'));
+    };
+    reader.readAsText(file);
+  });
+}
+
+async function getBitmapImageDimensions(
+  imageDataUrl: string
+): Promise<{ width: number; height: number }> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => {
+      resolve({ width: img.naturalWidth, height: img.naturalHeight });
+    };
+    img.src = imageDataUrl;
+  });
+}
+
+async function bitmapImageToSvg(imageDataUrl: string) {
+  const { width, height } = await getBitmapImageDimensions(imageDataUrl);
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+    <image href="${imageDataUrl}" width="${width}" height="${height}" />
+  </svg>`;
+}
+
+async function loadBitmapImageAndConvertToSvg(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = async (e) => {
+      /* istanbul ignore next */
+      const imageDataUrl = e.target?.result;
+      if (typeof imageDataUrl === 'string') {
+        const svgContents = await bitmapImageToSvg(imageDataUrl);
+        resolve(svgContents);
+      }
+      reject(new Error('Could not read file contents'));
+    };
+    reader.readAsDataURL(file);
+  });
+}
 
 export function ImageInput({
   value,
@@ -30,28 +83,32 @@ export function ImageInput({
       )}
       <FileInputButton
         disabled={disabled}
-        accept="image/svg+xml"
-        onChange={(e) => {
-          const file = e.target.files?.[0];
-          if (!file) return;
-          if (file.size > MAX_SVG_UPLOAD_BYTES) {
-            throw new Error(
-              `Image file size must be less than ${
-                MAX_SVG_UPLOAD_BYTES / 1_000 / 1_000
-              } MB`
-            );
-          }
-          const reader = new FileReader();
-          reader.onload = (e2) => {
-            const svgContents = e2.target?.result;
-            if (typeof svgContents === 'string') {
-              const image = DomPurify.sanitize(svgContents, {
-                USE_PROFILES: { svg: true },
-              });
-              onChange(image);
+        accept={ALLOWED_IMAGE_TYPES.join(',')}
+        onChange={async (e) => {
+          try {
+            /* istanbul ignore next */
+            const file = assertDefined(e.target.files?.[0]);
+            if (file.size > MAX_IMAGE_UPLOAD_BYTES) {
+              throw new Error(
+                `Image file size must be less than ${
+                  MAX_IMAGE_UPLOAD_BYTES / 1_000 / 1_000
+                } MB`
+              );
             }
-          };
-          reader.readAsText(file);
+            assert(ALLOWED_IMAGE_TYPES.includes(file.type));
+            const svgImage =
+              file.type === 'image/svg+xml'
+                ? await loadSvgImage(file)
+                : await loadBitmapImageAndConvertToSvg(file);
+            const sanitizedSvg = DomPurify.sanitize(svgImage, {
+              USE_PROFILES: { svg: true },
+            });
+            onChange(sanitizedSvg);
+          } catch (error) {
+            // TODO handle errors and show to user when we do form validation
+            // eslint-disable-next-line no-console
+            console.error(error);
+          }
         }}
       >
         {buttonLabel}

--- a/apps/design/frontend/src/image_input.tsx
+++ b/apps/design/frontend/src/image_input.tsx
@@ -8,15 +8,13 @@ const MAX_IMAGE_UPLOAD_BYTES = 5 * 1_000 * 1_000; // 5 MB
 const ALLOWED_IMAGE_TYPES = ['image/svg+xml', 'image/png', 'image/jpeg'];
 
 async function loadSvgImage(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     const reader = new FileReader();
     reader.onload = (e) => {
       /* istanbul ignore next */
       const contents = e.target?.result;
-      if (typeof contents === 'string') {
-        resolve(contents);
-      }
-      reject(new Error('Could not read file contents'));
+      assert(typeof contents === 'string');
+      resolve(contents);
     };
     reader.readAsText(file);
   });
@@ -25,13 +23,10 @@ async function loadSvgImage(file: File): Promise<string> {
 async function getBitmapImageDimensions(
   imageDataUrl: string
 ): Promise<{ width: number; height: number }> {
-  return new Promise((resolve) => {
-    const img = new Image();
-    img.onload = () => {
-      resolve({ width: img.naturalWidth, height: img.naturalHeight });
-    };
-    img.src = imageDataUrl;
-  });
+  const img = new Image();
+  img.src = imageDataUrl;
+  await img.decode();
+  return { width: img.naturalWidth, height: img.naturalHeight };
 }
 
 async function bitmapImageToSvg(imageDataUrl: string) {


### PR DESCRIPTION
## Overview

Closes #4500 

Adds support for PNG/JPEG images for seals and clerk signatures by embedding them within an SVG using the `<image>` tag.

## Demo Video or Screenshot

## Testing Plan
- Added unit tests for `ImageInput`
- Manually tested uploading a PNG seal and rendering ballots/configuring VxAdmin

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
