### PR TITLE
Add metadata file to election packages exported by VxDesign

### DIFF
--- a/apps/admin/frontend/src/screens/unconfigured_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/unconfigured_screen.test.tsx
@@ -155,4 +155,15 @@ test('shows configuration error', async () => {
     );
   userEvent.click(screen.getByText('election-package.zip'));
   await screen.findByText('Invalid system settings file.');
+
+  apiMock.apiClient.configure
+    .expectCallWith({ electionFilePath: '/election-package.zip' })
+    .resolves(
+      err({
+        type: 'invalid-metadata',
+        message: 'Bad metatdata',
+      })
+    );
+  userEvent.click(screen.getByText('election-package.zip'));
+  await screen.findByText('Invalid metadata file.');
 });

--- a/apps/admin/frontend/src/screens/unconfigured_screen.tsx
+++ b/apps/admin/frontend/src/screens/unconfigured_screen.tsx
@@ -67,6 +67,8 @@ function SelectElectionPackage({
                     return 'Invalid election definition file.';
                   case 'invalid-system-settings':
                     return 'Invalid system settings file.';
+                  case 'invalid-metadata':
+                    return 'Invalid metadata file.';
                   default:
                     /* istanbul ignore next */
                     return throwIllegalValue(configureError.type);

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -391,6 +391,7 @@ test('Election package export', async () => {
 
   const {
     electionDefinition,
+    metadata,
     systemSettings,
     uiStringAudioClips,
     uiStringAudioIds,
@@ -398,10 +399,17 @@ test('Election package export', async () => {
   } = (
     await readElectionPackageFromFile(electionPackageFilePath)
   ).unsafeUnwrap();
+  assert(metadata !== undefined);
   assert(systemSettings !== undefined);
   assert(uiStringAudioClips !== undefined);
   assert(uiStringAudioIds !== undefined);
   assert(uiStrings !== undefined);
+
+  //
+  // Check metadata
+  //
+
+  expect(metadata.version).toEqual('latest');
 
   //
   // Check election definition

--- a/apps/design/backend/src/language_and_audio/app_strings.ts
+++ b/apps/design/backend/src/language_and_audio/app_strings.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { z } from 'zod';
 import {
   LanguageCode,
+  MachineVersion,
   safeParseJson,
   UiStringsPackage,
 } from '@votingworks/types';
@@ -15,7 +16,8 @@ import { GoogleCloudTranslator } from './translator';
 import { setUiString } from './utils';
 
 export async function translateAppStrings(
-  translator: GoogleCloudTranslator
+  translator: GoogleCloudTranslator,
+  machineVersion: MachineVersion
 ): Promise<UiStringsPackage> {
   /* istanbul ignore next */
   if (
@@ -29,8 +31,7 @@ export async function translateAppStrings(
   const appStringsCatalogFileContents = await fs.readFile(
     path.join(
       __dirname,
-      // TODO: Account for system version
-      '../../../../../libs/ui/src/ui_strings/app_strings_catalog/latest.json'
+      `../../../../../libs/ui/src/ui_strings/app_strings_catalog/${machineVersion}.json`
     ),
     'utf-8'
   );

--- a/apps/design/backend/src/worker/generate_election_package.ts
+++ b/apps/design/backend/src/worker/generate_election_package.ts
@@ -6,6 +6,7 @@ import { layOutAllBallotStyles } from '@votingworks/hmpb-layout';
 import {
   BallotType,
   ElectionPackageFileName,
+  ElectionPackageMetadata,
   getDisplayElectionHash,
   Id,
 } from '@votingworks/types';
@@ -29,7 +30,12 @@ export async function generateElectionPackage(
 
   const zip = new JsZip();
 
-  const appStrings = await translateAppStrings(translator);
+  const metadata: ElectionPackageMetadata = {
+    version: 'latest',
+  };
+  zip.file(ElectionPackageFileName.METADATA, JSON.stringify(metadata, null, 2));
+
+  const appStrings = await translateAppStrings(translator, metadata.version);
   zip.file(
     ElectionPackageFileName.APP_STRINGS,
     JSON.stringify(appStrings, null, 2)

--- a/libs/types/src/election_package_metadata.ts
+++ b/libs/types/src/election_package_metadata.ts
@@ -1,11 +1,13 @@
 /* istanbul ignore file - will eventually be tested via consumers. */
 import { z } from 'zod';
 
+export type MachineVersion = 'latest';
+
 export interface ElectionPackageMetadata {
-  version: string;
+  version: MachineVersion;
 }
 
 export const ElectionPackageMetadataSchema: z.ZodType<ElectionPackageMetadata> =
   z.object({
-    version: z.string(),
+    version: z.literal('latest'),
   });

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -1,6 +1,7 @@
 /* istanbul ignore file */
 export * as Admin from './admin';
 export * from './auth';
+export * from './election_package_metadata';
 export * from './election_package';
 export * from './byte';
 export * from './hmpb';


### PR DESCRIPTION
## Overview

This PR adds a metadata file to the election packages exported by VxDesign. The metadata file specifies the machine version, which for now can only be "latest". We use the machine version to determine which strings to include in `appStrings.json` and will use it for other delineations down the road as well, as we have different versions of software running in the field.

## Demo Video or Screenshot

https://github.com/votingworks/vxsuite/assets/12616928/d72c92fc-1dda-4035-a188-46575db54352

## Testing Plan

- [x] Updated automated tests
- [x] Tested VxDesign export manually
- [x] Tested VxAdmin import manually

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A