### PR TITLE
test: ensure stale caches get caught

### DIFF
--- a/apps/admin/backend/src/app.tally_reports.test.ts
+++ b/apps/admin/backend/src/app.tally_reports.test.ts
@@ -156,6 +156,11 @@ test('general, full election, write in adjudication', async () => {
       },
     },
   });
+
+  await apiClient.clearCastVoteRecordFiles();
+  expect(await apiClient.getResultsForTallyReports()).not.toEqual(
+    wiaFullElectionTallyReportList
+  );
 });
 
 test('general, reports by voting method, manual data', async () => {

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -146,14 +146,15 @@ function buildApi({
   workspace,
   logger,
   usbDrive,
+  tallyCache,
 }: {
   auth: DippedSmartCardAuthApi;
   workspace: Workspace;
   logger: Logger;
   usbDrive: UsbDrive;
+  tallyCache: TallyCache;
 }) {
   const { store } = workspace;
-  const tallyCache = new TallyCache();
 
   async function getUserRole() {
     const authStatus = await auth.getAuthStatus(
@@ -904,14 +905,16 @@ export function buildApp({
   workspace,
   logger,
   usbDrive,
+  tallyCache,
 }: {
   auth: DippedSmartCardAuthApi;
   workspace: Workspace;
   logger: Logger;
   usbDrive: UsbDrive;
+  tallyCache: TallyCache;
 }): Application {
   const app: Application = express();
-  const api = buildApi({ auth, workspace, logger, usbDrive });
+  const api = buildApi({ auth, workspace, logger, usbDrive, tallyCache });
   app.use('/api', grout.buildRouter(api, express));
   useDevDockRouter(app, express);
   return app;

--- a/apps/admin/backend/src/exports/csv_tally_report.test.ts
+++ b/apps/admin/backend/src/exports/csv_tally_report.test.ts
@@ -9,6 +9,7 @@ import {
 import { generateTallyReportCsv } from './csv_tally_report';
 import { iterableToString, parseCsv } from '../../test/csv';
 import { Store } from '../store';
+import { TestTallyCache } from '../../test/tally_cache';
 
 test('uses appropriate headers', async () => {
   const store = Store.memoryStore();
@@ -205,6 +206,7 @@ test('uses appropriate headers', async () => {
       store,
       filter: testCase.filter,
       groupBy: testCase.groupBy,
+      tallyCache: new TestTallyCache(),
     });
     const fileContents = await iterableToString(iterable);
     const { headers, rows } = parseCsv(fileContents);
@@ -239,6 +241,7 @@ test('includes rows for empty but known result groups', async () => {
     store,
     filter: {},
     groupBy: { groupByPrecinct: true },
+    tallyCache: new TestTallyCache(),
   });
   const fileContents = await iterableToString(iterable);
   const { rows } = parseCsv(fileContents);
@@ -261,6 +264,7 @@ test('included contests are specific to each results group', async () => {
     store,
     filter: {},
     groupBy: { groupByBallotStyle: true },
+    tallyCache: new TestTallyCache(),
   });
   const fileContents = await iterableToString(iterable);
   const { rows } = parseCsv(fileContents);
@@ -296,6 +300,7 @@ test('included contests are restricted by the overall export filter', async () =
   const iterable = generateTallyReportCsv({
     store,
     filter: { ballotStyleIds: ['1M'] },
+    tallyCache: new TestTallyCache(),
   });
   const fileContents = await iterableToString(iterable);
   const { rows } = parseCsv(fileContents);
@@ -324,6 +329,7 @@ test('does not include results groups when they are excluded by the filter', asy
   const byVotingMethodIterable = generateTallyReportCsv({
     store,
     groupBy: { groupByVotingMethod: true },
+    tallyCache: new TestTallyCache(),
   });
   const byVotingMethodFileContents = await iterableToString(
     byVotingMethodIterable
@@ -341,6 +347,7 @@ test('does not include results groups when they are excluded by the filter', asy
     store,
     groupBy: { groupByVotingMethod: true },
     filter: { votingMethods: ['precinct'] },
+    tallyCache: new TestTallyCache(),
   });
   const precinctFileContests = await iterableToString(precinctIterable);
   const { rows: precinctRows } = parseCsv(precinctFileContests);
@@ -413,6 +420,7 @@ test('incorporates manual data', async () => {
 
   const iterable = generateTallyReportCsv({
     store,
+    tallyCache: new TestTallyCache(),
   });
   const fileContents = await iterableToString(iterable);
   const { rows } = parseCsv(fileContents);
@@ -507,6 +515,7 @@ test('separate rows for manual data when grouping by an incompatible dimension',
     const iterable = generateTallyReportCsv({
       store,
       groupBy,
+      tallyCache: new TestTallyCache(),
     });
 
     const fileContents = await iterableToString(iterable);
@@ -544,6 +553,7 @@ test('separate rows for manual data when grouping by an incompatible dimension',
   const iterable = generateTallyReportCsv({
     store,
     groupBy: { groupByScanner: true },
+    tallyCache: new TestTallyCache(),
   });
 
   const fileContents = await iterableToString(iterable);

--- a/apps/admin/backend/src/exports/csv_tally_report.ts
+++ b/apps/admin/backend/src/exports/csv_tally_report.ts
@@ -227,7 +227,7 @@ export async function* generateTallyReportCsv({
   store: Store;
   filter?: Tabulation.Filter;
   groupBy?: Tabulation.GroupBy;
-  tallyCache?: TallyCache;
+  tallyCache: TallyCache;
 }): AsyncGenerator<string> {
   const electionId = store.getCurrentElectionId();
   assert(electionId !== undefined);

--- a/apps/admin/backend/src/server.test.ts
+++ b/apps/admin/backend/src/server.test.ts
@@ -9,6 +9,7 @@ import { start } from './server';
 import { createWorkspace } from './util/workspace';
 import { PORT } from './globals';
 import { buildApp } from './app';
+import { TestTallyCache } from '../test/tally_cache';
 
 beforeEach(() => {
   jest.restoreAllMocks();
@@ -19,7 +20,8 @@ test('starts with default logger and port', async () => {
   const workspace = createWorkspace(dirSync().name);
   const logger = fakeLogger();
   const { usbDrive } = createMockUsbDrive();
-  const app = buildApp({ auth, workspace, logger, usbDrive });
+  const tallyCache = new TestTallyCache();
+  const app = buildApp({ auth, workspace, logger, usbDrive, tallyCache });
 
   // don't actually listen
   jest.spyOn(app, 'listen').mockImplementationOnce((_port, onListening) => {
@@ -42,7 +44,8 @@ test('start with config options', async () => {
   const workspace = createWorkspace(dirSync().name);
   const logger = fakeLogger();
   const { usbDrive } = createMockUsbDrive();
-  const app = buildApp({ auth, workspace, logger, usbDrive });
+  const tallyCache = new TestTallyCache();
+  const app = buildApp({ auth, workspace, logger, usbDrive, tallyCache });
 
   // don't actually listen
   jest.spyOn(app, 'listen').mockImplementationOnce((_port, onListening) => {
@@ -63,7 +66,8 @@ test('errors on start with no workspace', async () => {
   const workspace = createWorkspace(dirSync().name);
   const logger = fakeLogger();
   const { usbDrive } = createMockUsbDrive();
-  const app = buildApp({ auth, workspace, logger, usbDrive });
+  const tallyCache = new TestTallyCache();
+  const app = buildApp({ auth, workspace, logger, usbDrive, tallyCache });
 
   // start up the server
   try {

--- a/apps/admin/backend/src/server.ts
+++ b/apps/admin/backend/src/server.ts
@@ -12,6 +12,7 @@ import { ADMIN_WORKSPACE, PORT } from './globals';
 import { createWorkspace, Workspace } from './util/workspace';
 import { buildApp } from './app';
 import { rootDebug } from './util/debug';
+import { RealTallyCache } from './tabulation/tally_cache';
 
 const debug = rootDebug.extend('server');
 
@@ -80,6 +81,7 @@ export async function start({
       logger,
       usbDrive: resolvedUsbDrive,
       workspace: resolvedWorkspace,
+      tallyCache: new RealTallyCache(),
     });
   }
   /* c8 ignore stop */

--- a/apps/admin/backend/src/tabulation/full_results.test.ts
+++ b/apps/admin/backend/src/tabulation/full_results.test.ts
@@ -23,6 +23,7 @@ import {
   addMockCvrFileToStore,
 } from '../../test/mock_cvr_file';
 import { adjudicateWriteIn } from '../adjudication';
+import { TestTallyCache } from '../../test/tally_cache';
 
 // mock SKIP_CVR_ELECTION_HASH_CHECK to allow us to use old cvr fixtures
 const featureFlagMock = getFeatureFlagMock();
@@ -246,6 +247,7 @@ test('tabulateCastVoteRecords', async () => {
       store,
       filter,
       groupBy,
+      tallyCache: new TestTallyCache(),
     });
 
     for (const [groupKey, tally] of expected) {
@@ -272,6 +274,7 @@ test('tabulateElectionResults - includes empty groups', async () => {
     electionId,
     store,
     groupBy: { groupByPrecinct: true, groupByVotingMethod: true },
+    tallyCache: new TestTallyCache(),
   });
   expect(Object.keys(groupedElectionResults)).toEqual([
     'root&precinctId=precinct-1&votingMethod=precinct',
@@ -312,6 +315,7 @@ test('tabulateElectionResults - write-in handling', async () => {
     await tabulateElectionResults({
       electionId,
       store,
+      tallyCache: new TestTallyCache(),
     })
   )[GROUP_KEY_ROOT];
   assert(overallResultsPreAdjudication);
@@ -431,6 +435,7 @@ test('tabulateElectionResults - write-in handling', async () => {
     await tabulateElectionResults({
       electionId,
       store,
+      tallyCache: new TestTallyCache(),
     })
   )[GROUP_KEY_ROOT];
   assert(overallResultsScreenWiaNoDetail);
@@ -475,6 +480,7 @@ test('tabulateElectionResults - write-in handling', async () => {
       electionId,
       store,
       includeWriteInAdjudicationResults: true,
+      tallyCache: new TestTallyCache(),
     })
   )[GROUP_KEY_ROOT];
   assert(overallResultsScreenWiaDetail);
@@ -574,6 +580,7 @@ test('tabulateElectionResults - write-in handling', async () => {
       store,
       includeWriteInAdjudicationResults: true,
       includeManualResults: true,
+      tallyCache: new TestTallyCache(),
     })
   )[GROUP_KEY_ROOT];
   assert(overallResultsScreenAndManualWiaDetail);
@@ -645,6 +652,7 @@ test('tabulateElectionResults - write-in handling', async () => {
       electionId,
       store,
       includeManualResults: true,
+      tallyCache: new TestTallyCache(),
     })
   )[GROUP_KEY_ROOT];
   assert(overallResultsScreenAndManualWiaNoDetail);
@@ -733,6 +741,7 @@ test('tabulateElectionResults - group and filter by voting method', async () => 
       store,
       filter: { votingMethods: ['absentee'] },
       includeWriteInAdjudicationResults: true,
+      tallyCache: new TestTallyCache(),
     })
   )[GROUP_KEY_ROOT];
   assert(absenteeResults);
@@ -776,6 +785,7 @@ test('tabulateElectionResults - group and filter by voting method', async () => 
       store,
       filter: { votingMethods: ['precinct'] },
       includeWriteInAdjudicationResults: true,
+      tallyCache: new TestTallyCache(),
     })
   )[GROUP_KEY_ROOT];
   assert(precinctResults);
@@ -791,6 +801,7 @@ test('tabulateElectionResults - group and filter by voting method', async () => 
     store,
     groupBy: { groupByVotingMethod: true },
     includeWriteInAdjudicationResults: true,
+    tallyCache: new TestTallyCache(),
   });
   const absenteeResultsGroup = groupedResults['root&votingMethod=absentee'];
   const precinctResultsGroup = groupedResults['root&votingMethod=precinct'];
@@ -841,6 +852,7 @@ test('tabulateElectionResults - group and filter by voting method', async () => 
       filter: { votingMethods: ['absentee'] },
       includeWriteInAdjudicationResults: true,
       includeManualResults: true,
+      tallyCache: new TestTallyCache(),
     })
   )[GROUP_KEY_ROOT];
   assert(absenteeResultsWithManual);
@@ -888,6 +900,7 @@ test('tabulateElectionResults - group and filter by voting method', async () => 
       filter: { votingMethods: ['precinct'] },
       includeWriteInAdjudicationResults: true,
       includeManualResults: true,
+      tallyCache: new TestTallyCache(),
     })
   )[GROUP_KEY_ROOT];
   assert(precinctResultsWithManual);

--- a/apps/admin/backend/src/tabulation/tally_reports.ts
+++ b/apps/admin/backend/src/tabulation/tally_reports.ts
@@ -57,7 +57,7 @@ export async function tabulateTallyReportResults({
   store: Store;
   filter?: Tabulation.Filter;
   groupBy?: Tabulation.GroupBy;
-  tallyCache?: TallyCache;
+  tallyCache: TallyCache;
 }): Promise<Tabulation.GroupList<Admin.TallyReportResults>> {
   const {
     electionDefinition: { election },

--- a/apps/admin/backend/test/app.ts
+++ b/apps/admin/backend/test/app.ts
@@ -31,6 +31,7 @@ import { Api } from '../src';
 import { createWorkspace } from '../src/util/workspace';
 import { buildApp } from '../src/app';
 import { deleteTmpFileAfterTestSuiteCompletes } from './cleanup';
+import { TestTallyCache } from './tally_cache';
 
 type ActualDirectory = string;
 type MockFileTree = MockFile | MockDirectory | ActualDirectory;
@@ -135,6 +136,7 @@ export function buildTestEnvironment(workspaceRoot?: string) {
     workspace,
     logger,
     usbDrive: mockUsbDrive.usbDrive,
+    tallyCache: new TestTallyCache(),
   });
   // port 0 will bind to a random, free port assigned by the OS
   const server = app.listen();

--- a/apps/admin/backend/test/tally_cache.ts
+++ b/apps/admin/backend/test/tally_cache.ts
@@ -1,0 +1,36 @@
+import { ElectionResultsGroupMap } from '@votingworks/types/src/tabulation';
+import {
+  RealTallyCache,
+  TallyCache,
+  TallyCacheKey,
+} from '../src/tabulation/tally_cache';
+
+/**
+ * A tally cache that uses the real tally cache, but also verifies that the
+ * value returned from the cache is the same as the value that was set. This
+ * is useful for testing that the cache is being cleared correctly.
+ *
+ * Note that the callback to `getOrSet` is always called, even if the value
+ * is already in the cache. This is because the callback is used to generate
+ * the expected value.
+ */
+export class TestTallyCache implements TallyCache {
+  private readonly inner = new RealTallyCache();
+
+  async getOrSet(
+    key: TallyCacheKey,
+    value: () => Promise<ElectionResultsGroupMap>
+  ): Promise<ElectionResultsGroupMap> {
+    const newValue = await value();
+    const existingValue = await this.inner.getOrSet(key, () =>
+      Promise.resolve(newValue)
+    );
+
+    expect(newValue).toEqual(existingValue);
+    return newValue;
+  }
+
+  clear(): void {
+    this.inner.clear();
+  }
+}


### PR DESCRIPTION
Possible changes to #4508

As long as a cached tally is used before it's cleared it'll be compared with the regenerated value, making sure that the value didn't change. This required an API change so that getting and setting the value happened in a single operation. As a result, it was simpler to always use a tally cache but make it an interface that could do whatever it needed, including not caching.