### PR TITLE
Requeue interrupted background tasks on VxDesign worker startup

### DIFF
--- a/apps/design/backend/jest.config.js
+++ b/apps/design/backend/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: -20,
-      lines: -77,
+      lines: -78,
     },
   },
   setupFilesAfterEnv: ['<rootDir>/test/setupTests.ts'],

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -654,4 +654,14 @@ export class Store {
       taskId
     );
   }
+
+  requeueInterruptedBackgroundTasks(): void {
+    this.client.run(
+      `
+      update background_tasks
+      set started_at = null
+      where started_at is not null and completed_at is null
+      `
+    );
+  }
 }

--- a/apps/design/backend/src/worker/worker.ts
+++ b/apps/design/backend/src/worker/worker.ts
@@ -34,7 +34,14 @@ export async function processNextBackgroundTaskIfAny(
   /* eslint-enable no-console */
 }
 
+/**
+ * Starts the VxDesign background worker. Note that, as currently implemented, it's only safe to
+ * run one instance of the worker.
+ */
 export function start(context: WorkerContext): void {
+  // Requeue any tasks that were previously interrupted, say, because the worker process crashed
+  context.workspace.store.requeueInterruptedBackgroundTasks();
+
   process.nextTick(async () => {
     // eslint-disable-next-line no-constant-condition
     while (true) {


### PR DESCRIPTION
## Overview

At some point during my testing of VxDesign, I ctrl-c'd the worker while a background task was being processed. On subsequent VxDesign startup, the UI was "locked," indicating that a background export operation was in progress when one was not.

This PR updates the VxDesign background worker to requeue interrupted tasks on startup.

Arlo uses a very similar cleanup mechanism.

## Testing Plan

- [x] Updated automated tests
- [x] Tested manually

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A