### PR TITLE
VxDesign: Rotate contest candidates on save

### DIFF
--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -27,6 +27,7 @@ import {
 } from './test_decks';
 import { AppContext } from './context';
 import { extractAndTranslateElectionStrings } from './language_and_audio';
+import { rotateCandidates } from './candidate_rotation';
 
 export function createBlankElection(): Election {
   return {
@@ -136,6 +137,7 @@ function buildApi({ translator, workspace }: AppContext) {
       store.updateElection(input.electionId, {
         ...election,
         ...input.election,
+        contests: input.election.contests.map(rotateCandidates),
       });
     },
 

--- a/apps/design/backend/src/candidate_rotation.test.ts
+++ b/apps/design/backend/src/candidate_rotation.test.ts
@@ -1,0 +1,150 @@
+import { electionGeneral } from '@votingworks/fixtures';
+import { CandidateContest } from '@votingworks/types';
+import { rotateCandidates } from './candidate_rotation';
+
+describe('rotateCandidates', () => {
+  const candidateContest = electionGeneral.contests.find(
+    (c): c is CandidateContest => c.type === 'candidate'
+  )!;
+
+  test('skips non-candidate contests', () => {
+    const contest = electionGeneral.contests.find(
+      (c) => c.type !== 'candidate'
+    )!;
+    expect(rotateCandidates(contest)).toEqual(contest);
+  });
+
+  test('skips contests with fewer than 2 candidates', () => {
+    const contest: CandidateContest = {
+      ...candidateContest,
+      candidates: candidateContest.candidates.slice(0, 1),
+    };
+    expect(rotateCandidates(contest)).toEqual(contest);
+  });
+
+  // Examples drawn from NH-provided documentation
+  test('rotates candidates according to NH rules for 3-candidate contest', () => {
+    const contest: CandidateContest = {
+      ...candidateContest,
+      candidates: [
+        {
+          id: '1',
+          name: 'Martha Jones',
+        },
+        {
+          id: '2',
+          name: 'John Zorro',
+        },
+        {
+          id: '3',
+          name: 'Larry Smith',
+        },
+      ],
+    };
+    expect((rotateCandidates(contest) as CandidateContest).candidates).toEqual([
+      {
+        id: '1',
+        name: 'Martha Jones',
+      },
+      {
+        id: '3',
+        name: 'Larry Smith',
+      },
+      {
+        id: '2',
+        name: 'John Zorro',
+      },
+    ]);
+  });
+
+  test('rotates candidates according to NH rules for 10-candidate contest', () => {
+    const contest: CandidateContest = {
+      ...candidateContest,
+      candidates: [
+        {
+          id: '1',
+          name: 'Jane Adams',
+        },
+        {
+          id: '3',
+          name: 'John Curtis',
+        },
+        {
+          id: '2',
+          name: 'Bruce Brown',
+        },
+        {
+          id: '4',
+          name: 'Adam Dean',
+        },
+        {
+          id: '5',
+          name: 'Frank French',
+        },
+        {
+          id: '7',
+          name: 'Susan North',
+        },
+        {
+          id: '8',
+          name: 'Joseph Smith',
+        },
+        {
+          id: '9',
+          name: 'Jean Thompson',
+        },
+        {
+          id: '10',
+          name: 'John Zorro',
+        },
+        {
+          id: '6',
+          name: 'Candy Lozenge',
+        },
+      ],
+    };
+
+    expect((rotateCandidates(contest) as CandidateContest).candidates).toEqual([
+      {
+        id: '6',
+        name: 'Candy Lozenge',
+      },
+      {
+        id: '7',
+        name: 'Susan North',
+      },
+      {
+        id: '8',
+        name: 'Joseph Smith',
+      },
+      {
+        id: '9',
+        name: 'Jean Thompson',
+      },
+      {
+        id: '10',
+        name: 'John Zorro',
+      },
+      {
+        id: '1',
+        name: 'Jane Adams',
+      },
+      {
+        id: '2',
+        name: 'Bruce Brown',
+      },
+      {
+        id: '3',
+        name: 'John Curtis',
+      },
+      {
+        id: '4',
+        name: 'Adam Dean',
+      },
+      {
+        id: '5',
+        name: 'Frank French',
+      },
+    ]);
+  });
+});

--- a/apps/design/backend/src/candidate_rotation.ts
+++ b/apps/design/backend/src/candidate_rotation.ts
@@ -1,0 +1,65 @@
+import { assertDefined, iter } from '@votingworks/basics';
+import { AnyContest } from '@votingworks/types';
+
+// Maps the number of candidates in a contest to the index at which to rotate
+// the candidates. These indexes are randomly selected by the state every 2
+// years. Note that these use 1-based indexing.
+const NH_ROTATION_INDICES: Record<number, number> = {
+  2: 2,
+  3: 1,
+  4: 2,
+  5: 1,
+  6: 1,
+  7: 7,
+  8: 7,
+  9: 2,
+  10: 6,
+  11: 3,
+  12: 3,
+  13: 8,
+  14: 11,
+  15: 4,
+  16: 5,
+  17: 7,
+  18: 18,
+  19: 19,
+  20: 18,
+};
+
+/**
+ * Rotate a contest's candidates according to the governing statutes. Currently
+ * only supports NH rules.
+ *
+ * The NH rotation algorithm is as follows:
+ * 1. Order the candidates alphabetically by last name.
+ * 2. Cut the "deck" at a randomly selected index (see NH_ROTATION_INDICES).
+ */
+export function rotateCandidates(contest: AnyContest): AnyContest {
+  if (contest.type !== 'candidate') return contest;
+  if (contest.candidates.length < 2) return contest;
+
+  // Lacking structured name data, we approximate last name by using the last word
+  function lastName(name: string): string {
+    return assertDefined(iter(name.split(' ')).last());
+  }
+
+  const orderedCandidates = [...contest.candidates].sort((a, b) =>
+    lastName(a.name).localeCompare(lastName(b.name))
+  );
+
+  const rotationIndex =
+    assertDefined(
+      NH_ROTATION_INDICES[contest.candidates.length],
+      `No rotation index defined for contest with ${contest.candidates.length} candidates`
+    ) - 1;
+
+  const rotatedCandidates = [
+    ...orderedCandidates.slice(rotationIndex),
+    ...orderedCandidates.slice(0, rotationIndex),
+  ];
+
+  return {
+    ...contest,
+    candidates: rotatedCandidates,
+  };
+}


### PR DESCRIPTION
## Overview

Closes #4514 

Automatically re-orders the candidates of all contests whenever the election is saved. This ensures that the candidate order on the ballot follows the NH statutes.

## Demo Video or Screenshot

https://github.com/votingworks/vxsuite/assets/530106/1c16a2c2-2594-415c-9858-7dc8366b11d4

## Testing Plan
- Updated automated tests
- Some basic manual testing

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
