### PR TITLE
Add mechanism for global Vx-managed translation overrides

### DIFF
--- a/apps/design/backend/scripts/synthesize_speech.ts
+++ b/apps/design/backend/scripts/synthesize_speech.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import { extractErrorMessage } from '@votingworks/basics';
 import { LanguageCode } from '@votingworks/types';
 
-import { GoogleCloudSpeechSynthesizer } from '../src/language_and_audio/speech_synthesizer';
+import { GoogleCloudSpeechSynthesizer } from '../src/language_and_audio';
 import { Store } from '../src/store';
 
 const languageCodes: string[] = Object.values(LanguageCode);

--- a/apps/design/backend/scripts/translate_text.ts
+++ b/apps/design/backend/scripts/translate_text.ts
@@ -1,30 +1,30 @@
 import { extractErrorMessage } from '@votingworks/basics';
-import { LanguageCode } from '@votingworks/types';
+import { LanguageCode, NonEnglishLanguageCode } from '@votingworks/types';
 
-import { GoogleCloudTranslator } from '../src/language_and_audio/translator';
+import { GoogleCloudTranslator } from '../src/language_and_audio';
 import { Store } from '../src/store';
 
-const languageCodes: Set<string> = (() => {
-  const nonEnglishLanguageCodes = new Set<string>(Object.values(LanguageCode));
-  nonEnglishLanguageCodes.delete(LanguageCode.ENGLISH);
-  return nonEnglishLanguageCodes;
+const nonEnglishLanguageCodes: Set<string> = (() => {
+  const set = new Set<string>(Object.values(LanguageCode));
+  set.delete(LanguageCode.ENGLISH);
+  return set;
 })();
 const usageMessage = `Usage: translate-text 'Text to translate' <target-language-code>
 
 Arguments:
-  <target-language-code>\t${[...languageCodes].sort().join(' | ')}`;
+  <target-language-code>\t${[...nonEnglishLanguageCodes].sort().join(' | ')}`;
 
 interface TranslateTextInput {
-  targetLanguageCode: LanguageCode;
+  targetLanguageCode: NonEnglishLanguageCode;
   text: string;
 }
 
 function parseCommandLineArgs(args: readonly string[]): TranslateTextInput {
-  if (args.length !== 2 || !languageCodes.has(args[1])) {
+  if (args.length !== 2 || !nonEnglishLanguageCodes.has(args[1])) {
     console.error(usageMessage);
     process.exit(1);
   }
-  const [text, targetLanguageCode] = args as [string, LanguageCode];
+  const [text, targetLanguageCode] = args as [string, NonEnglishLanguageCode];
   return { targetLanguageCode, text };
 }
 

--- a/apps/design/backend/src/language_and_audio/index.ts
+++ b/apps/design/backend/src/language_and_audio/index.ts
@@ -2,5 +2,6 @@ export * from './app_strings';
 export * from './audio';
 export * from './election_strings';
 export * from './speech_synthesizer';
+export * from './translation_overrides';
 export * from './translator';
 export * from './utils';

--- a/apps/design/backend/src/language_and_audio/translation_overrides.ts
+++ b/apps/design/backend/src/language_and_audio/translation_overrides.ts
@@ -1,0 +1,17 @@
+import { LanguageCode, NonEnglishLanguageCode } from '@votingworks/types';
+
+export type TranslationOverrides = Record<
+  NonEnglishLanguageCode,
+  { [englishText: string]: string | undefined }
+>;
+
+/**
+ * Cloud translations are sometimes incorrect and need to be globally overridden.
+ */
+export const GLOBAL_TRANSLATION_OVERRIDES: TranslationOverrides = {
+  [LanguageCode.CHINESE_SIMPLIFIED]: {},
+  [LanguageCode.CHINESE_TRADITIONAL]: {},
+  [LanguageCode.SPANISH]: {
+    'Green Party': 'El Partido Verde',
+  },
+};

--- a/apps/design/backend/test/helpers.ts
+++ b/apps/design/backend/test/helpers.ts
@@ -6,16 +6,16 @@ import * as tmp from 'tmp';
 import * as grout from '@votingworks/grout';
 import { suppressingConsoleOutput } from '@votingworks/test-utils';
 import { assertDefined } from '@votingworks/basics';
+import { LanguageCode } from '@votingworks/types';
 import { buildApp } from '../src/app';
 import type { Api } from '../src/app';
 import {
-  GoogleCloudTranslator,
-  MinimalGoogleCloudTranslationClient,
-} from '../src/language_and_audio/translator';
-import {
   GoogleCloudSpeechSynthesizer,
+  GoogleCloudTranslator,
   MinimalGoogleCloudTextToSpeechClient,
-} from '../src/language_and_audio/speech_synthesizer';
+  MinimalGoogleCloudTranslationClient,
+  TranslationOverrides,
+} from '../src/language_and_audio';
 import { Workspace, createWorkspace } from '../src/workspace';
 import * as worker from '../src/worker/worker';
 
@@ -86,6 +86,12 @@ export class MockGoogleCloudTextToSpeechClient
   );
 }
 
+const globalTranslationOverrides: TranslationOverrides = {
+  [LanguageCode.CHINESE_SIMPLIFIED]: {},
+  [LanguageCode.CHINESE_TRADITIONAL]: {},
+  [LanguageCode.SPANISH]: {},
+};
+
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function testSetupHelpers() {
   const servers: Server[] = [];
@@ -98,6 +104,7 @@ export function testSetupHelpers() {
       textToSpeechClient: new MockGoogleCloudTextToSpeechClient(),
     });
     const translator = new GoogleCloudTranslator({
+      globalTranslationOverrides,
       store,
       translationClient: new MockGoogleCloudTranslationClient(),
     });
@@ -131,6 +138,7 @@ export async function processNextBackgroundTaskIfAny(
     textToSpeechClient: new MockGoogleCloudTextToSpeechClient(),
   });
   const translator = new GoogleCloudTranslator({
+    globalTranslationOverrides,
     store,
     translationClient: new MockGoogleCloudTranslationClient(),
   });

--- a/libs/types/src/language_code.ts
+++ b/libs/types/src/language_code.ts
@@ -11,6 +11,11 @@ export enum LanguageCode {
 export const LanguageCodeSchema: z.ZodType<LanguageCode> =
   z.nativeEnum(LanguageCode);
 
+export type NonEnglishLanguageCode = Exclude<
+  LanguageCode,
+  LanguageCode.ENGLISH
+>;
+
 export function isLanguageCode(value: string): value is LanguageCode {
   return Object.values(LanguageCode).includes(value as LanguageCode);
 }


### PR DESCRIPTION
## Overview

Cloud speech synthesis is great! Cloud translation is... good, but sometimes off. My favorite example is the Spanish translation of "Green Party" to "Fiesta Verde" 🟢 🎉 😆

We expect that election officials will proof translations and add their own overrides. But before we implement election-level overrides (which we will before cert), we should also have global Vx-managed overrides, to make the default translations as good as possible. This PR introduces a very rudimentary mechanism for that. We can build upon this rudimentary mechanism (e.g. with a UI and proper `Store` persistence) down the road.

## Testing Plan

- [x] Updated automated tests
- [x] Tested manually

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A