### PR TITLE
VxDesign: Add form to reorder contests

### DIFF
--- a/apps/design/frontend/jest.config.js
+++ b/apps/design/frontend/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: -128,
-      lines: -216,
+      lines: -217,
     },
   },
   setupFiles: ['react-app-polyfill/jsdom'],

--- a/apps/design/frontend/package.json
+++ b/apps/design/frontend/package.json
@@ -69,6 +69,7 @@
     "path": "^0.12.7",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-flip-toolkit": "^7.1.0",
     "react-router-dom": "^5.3.4",
     "styled-components": "^5.3.11",
     "util": "^0.12.4"

--- a/apps/design/frontend/src/contests_screen.test.tsx
+++ b/apps/design/frontend/src/contests_screen.test.tsx
@@ -538,7 +538,10 @@ describe('Contests tab', () => {
 
   test('reordering contests', async () => {
     const { election } = generalElectionRecord;
-    Element.prototype.scrollIntoView = jest.fn();
+    // Mock needed for react-flip-toolkit
+    window.matchMedia = jest.fn().mockImplementation(() => ({
+      matches: false,
+    }));
 
     apiMock.getElection
       .expectCallWith({ electionId })

--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -33,7 +33,7 @@ import {
   PartyId,
   YesNoContest,
 } from '@votingworks/types';
-import { assert, assertDefined, find } from '@votingworks/basics';
+import { assert, find } from '@votingworks/basics';
 import styled from 'styled-components';
 import {
   FieldName,
@@ -64,9 +64,7 @@ function ContestsTab(): JSX.Element | null {
   const updateElectionMutation = updateElection.useMutation();
   const [filterDistrictId, setFilterDistrictId] = useState(FILTER_ALL);
   const [filterPartyId, setFilterPartyId] = useState(FILTER_ALL);
-  const [reorderedContests, setReorderedContests] = useState<
-    Contests | undefined
-  >();
+  const [reorderedContests, setReorderedContests] = useState<Contests>();
 
   if (!getElectionQuery.isSuccess) {
     return null;
@@ -101,13 +99,13 @@ function ContestsTab(): JSX.Element | null {
   );
   const partyIdToName = new Map(parties.map((party) => [party.id, party.name]));
 
-  function onSaveReorderedContests() {
+  function onSaveReorderedContests(updatedContests: Contests) {
     updateElectionMutation.mutate(
       {
         electionId,
         election: {
           ...election,
-          contests: assertDefined(reorderedContests),
+          contests: updatedContests,
         },
       },
       {
@@ -172,7 +170,7 @@ function ContestsTab(): JSX.Element | null {
                 Cancel
               </Button>
               <Button
-                onPress={onSaveReorderedContests}
+                onPress={() => onSaveReorderedContests(reorderedContests)}
                 variant="primary"
                 icon="Done"
                 disabled={updateElectionMutation.isLoading}
@@ -346,11 +344,10 @@ function ContestForm({
   const history = useHistory();
   const contestRoutes = routes.election(electionId).contests;
 
-  function onSavePress() {
-    assert(contest !== undefined);
+  function onSavePress(updatedContest: AnyContest) {
     const newContests = contestId
-      ? savedContests.map((c) => (c.id === contestId ? contest : c))
-      : [...savedContests, contest];
+      ? savedContests.map((c) => (c.id === contestId ? updatedContest : c))
+      : [...savedContests, updatedContest];
     updateElectionMutation.mutate(
       {
         electionId,
@@ -367,9 +364,8 @@ function ContestForm({
     );
   }
 
-  function onDeletePress() {
-    assert(contestId !== undefined);
-    const newContests = savedContests.filter((c) => c.id !== contestId);
+  function onDeletePress(id: ContestId) {
+    const newContests = savedContests.filter((c) => c.id !== id);
     updateElectionMutation.mutate(
       {
         electionId,
@@ -613,7 +609,7 @@ function ContestForm({
         <FormActionsRow>
           <LinkButton to={contestRoutes.root.path}>Cancel</LinkButton>
           <Button
-            onPress={onSavePress}
+            onPress={() => onSavePress(contest)}
             variant="primary"
             icon="Done"
             disabled={updateElectionMutation.isLoading}
@@ -623,7 +619,11 @@ function ContestForm({
         </FormActionsRow>
         {contestId && (
           <FormActionsRow style={{ marginTop: '1rem' }}>
-            <Button variant="danger" icon="Delete" onPress={onDeletePress}>
+            <Button
+              variant="danger"
+              icon="Delete"
+              onPress={() => onDeletePress(contestId)}
+            >
               Delete Contest
             </Button>
           </FormActionsRow>
@@ -779,10 +779,10 @@ function PartyForm({
   const history = useHistory();
   const partyRoutes = routes.election(electionId).contests.parties;
 
-  function onSavePress() {
+  function onSavePress(updatedParty: Party) {
     const newParties = partyId
-      ? savedParties.map((p) => (p.id === partyId ? party : p))
-      : [...savedParties, party];
+      ? savedParties.map((p) => (p.id === partyId ? updatedParty : p))
+      : [...savedParties, updatedParty];
     updateElectionMutation.mutate(
       {
         electionId,
@@ -799,9 +799,8 @@ function PartyForm({
     );
   }
 
-  function onDeletePress() {
-    assert(partyId !== undefined);
-    const newParties = savedParties.filter((p) => p.id !== partyId);
+  function onDeletePress(id: PartyId) {
+    const newParties = savedParties.filter((p) => p.id !== id);
     // When deleting a party, we need to remove it from any contests/candidates
     // that reference it
     updateElectionMutation.mutate(
@@ -867,7 +866,7 @@ function PartyForm({
         <FormActionsRow>
           <LinkButton to={partyRoutes.root.path}>Cancel</LinkButton>
           <Button
-            onPress={onSavePress}
+            onPress={() => onSavePress(party)}
             variant="primary"
             icon="Done"
             disabled={updateElectionMutation.isLoading}
@@ -877,7 +876,11 @@ function PartyForm({
         </FormActionsRow>
         {partyId && (
           <FormActionsRow style={{ marginTop: '1rem' }}>
-            <Button variant="danger" icon="Delete" onPress={onDeletePress}>
+            <Button
+              variant="danger"
+              icon="Delete"
+              onPress={() => onDeletePress(partyId)}
+            >
               Delete Party
             </Button>
           </FormActionsRow>

--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -35,6 +35,7 @@ import {
 } from '@votingworks/types';
 import { assert, find } from '@votingworks/basics';
 import styled from 'styled-components';
+import { Flipper, Flipped } from 'react-flip-toolkit';
 import {
   FieldName,
   Form,
@@ -207,80 +208,93 @@ function ContestsTab(): JSX.Element | null {
             </P>
           </React.Fragment>
         ) : (
-          <Table>
-            <thead>
-              <tr>
-                <TH>Title</TH>
-                <TH>Type</TH>
-                <TH>District</TH>
-                {election.type === 'primary' && <TH>Party</TH>}
-                <TH />
-              </tr>
-            </thead>
-            <tbody>
-              {contestsToShow.map((contest, index) => (
-                <ReorderableTr key={contest.id} isReordering={isReordering}>
-                  <TD>{contest.title}</TD>
-                  <TD>
-                    {contest.type === 'candidate'
-                      ? 'Candidate Contest'
-                      : 'Ballot Measure'}
-                  </TD>
-                  <TD nowrap>{districtIdToName.get(contest.districtId)}</TD>
-                  {election.type === 'primary' && (
-                    <TD nowrap>
-                      {contest.type === 'candidate' &&
-                        contest.partyId !== undefined &&
-                        partyIdToName.get(contest.partyId)}
-                    </TD>
-                  )}
-                  <TD nowrap style={{ height: '3rem' }}>
-                    <Row style={{ gap: '0.5rem', justifyContent: 'flex-end' }}>
-                      {isReordering ? (
-                        <React.Fragment>
-                          <Button
-                            aria-label="Move Up"
-                            icon="ChevronUp"
-                            disabled={index === 0}
-                            onPress={() =>
-                              setReorderedContests(
-                                reorderElement(
-                                  reorderedContests,
-                                  index,
-                                  index - 1
-                                )
-                              )
-                            }
-                          />
-                          <Button
-                            aria-label="Move Down"
-                            icon="ChevronDown"
-                            disabled={index === contestsToShow.length - 1}
-                            onPress={() =>
-                              setReorderedContests(
-                                reorderElement(
-                                  reorderedContests,
-                                  index,
-                                  index + 1
-                                )
-                              )
-                            }
-                          />
-                        </React.Fragment>
-                      ) : (
-                        <LinkButton
-                          icon="Edit"
-                          to={contestRoutes.editContest(contest.id).path}
-                        >
-                          Edit
-                        </LinkButton>
+          // Flipper/Flip are used to animate the reordering of contest rows
+          /* @ts-expect-error: TS doesn't think Flipper is a valid component */
+          <Flipper
+            flipKey={contestsToShow.map((contest) => contest.id).join(',')}
+            // Custom spring parameters to speed up the duration of the animation
+            // See https://github.com/aholachek/react-flip-toolkit/issues/100#issuecomment-551056183
+            spring={{ stiffness: 439, damping: 42 }}
+          >
+            <Table>
+              <thead>
+                <tr>
+                  <TH>Title</TH>
+                  <TH>Type</TH>
+                  <TH>District</TH>
+                  {election.type === 'primary' && <TH>Party</TH>}
+                  <TH />
+                </tr>
+              </thead>
+              <tbody>
+                {contestsToShow.map((contest, index) => (
+                  <Flipped key={contest.id} flipId={contest.id}>
+                    <ReorderableTr key={contest.id} isReordering={isReordering}>
+                      <TD>{contest.title}</TD>
+                      <TD>
+                        {contest.type === 'candidate'
+                          ? 'Candidate Contest'
+                          : 'Ballot Measure'}
+                      </TD>
+                      <TD nowrap>{districtIdToName.get(contest.districtId)}</TD>
+                      {election.type === 'primary' && (
+                        <TD nowrap>
+                          {contest.type === 'candidate' &&
+                            contest.partyId !== undefined &&
+                            partyIdToName.get(contest.partyId)}
+                        </TD>
                       )}
-                    </Row>
-                  </TD>
-                </ReorderableTr>
-              ))}
-            </tbody>
-          </Table>
+                      <TD nowrap style={{ height: '3rem' }}>
+                        <Row
+                          style={{ gap: '0.5rem', justifyContent: 'flex-end' }}
+                        >
+                          {isReordering ? (
+                            <React.Fragment>
+                              <Button
+                                aria-label="Move Up"
+                                icon="ChevronUp"
+                                disabled={index === 0}
+                                onPress={() =>
+                                  setReorderedContests(
+                                    reorderElement(
+                                      reorderedContests,
+                                      index,
+                                      index - 1
+                                    )
+                                  )
+                                }
+                              />
+                              <Button
+                                aria-label="Move Down"
+                                icon="ChevronDown"
+                                disabled={index === contestsToShow.length - 1}
+                                onPress={() =>
+                                  setReorderedContests(
+                                    reorderElement(
+                                      reorderedContests,
+                                      index,
+                                      index + 1
+                                    )
+                                  )
+                                }
+                              />
+                            </React.Fragment>
+                          ) : (
+                            <LinkButton
+                              icon="Edit"
+                              to={contestRoutes.editContest(contest.id).path}
+                            >
+                              Edit
+                            </LinkButton>
+                          )}
+                        </Row>
+                      </TD>
+                    </ReorderableTr>
+                  </Flipped>
+                ))}
+              </tbody>
+            </Table>
+          </Flipper>
         ))}
     </TabPanel>
   );

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -141,11 +141,12 @@ function DistrictForm({
     return null;
   }
 
-  function onSavePress() {
-    assert(district);
+  function onSavePress(updatedDistrict: District) {
     const newDistricts = districtId
-      ? savedElection.districts.map((d) => (d.id === districtId ? district : d))
-      : [...savedDistricts, district];
+      ? savedElection.districts.map((d) =>
+          d.id === districtId ? updatedDistrict : d
+        )
+      : [...savedDistricts, updatedDistrict];
     updateElectionMutation.mutate(
       {
         electionId,
@@ -162,10 +163,11 @@ function DistrictForm({
     );
   }
 
-  function onDeletePress() {
-    assert(districtId !== undefined);
+  function onDeletePress(districtIdToRemove: DistrictId) {
     assert(savedPrecincts !== undefined);
-    const newDistricts = savedDistricts.filter((d) => d.id !== districtId);
+    const newDistricts = savedDistricts.filter(
+      (d) => d.id !== districtIdToRemove
+    );
     // When deleting a district, we need to remove it from any precincts that
     // reference it
     updatePrecinctsMutation.mutate(
@@ -178,14 +180,16 @@ function DistrictForm({
               splits: precinct.splits.map((split) => ({
                 ...split,
                 districtIds: split.districtIds.filter(
-                  (id) => id !== districtId
+                  (id) => id !== districtIdToRemove
                 ),
               })),
             };
           }
           return {
             ...precinct,
-            districtIds: precinct.districtIds.filter((id) => id !== districtId),
+            districtIds: precinct.districtIds.filter(
+              (id) => id !== districtIdToRemove
+            ),
           };
         }),
       },
@@ -227,7 +231,7 @@ function DistrictForm({
           <Button
             variant="primary"
             icon="Done"
-            onPress={onSavePress}
+            onPress={() => onSavePress(district)}
             disabled={updateElectionMutation.isLoading}
           >
             Save
@@ -238,7 +242,7 @@ function DistrictForm({
             <Button
               variant="danger"
               icon="Delete"
-              onPress={onDeletePress}
+              onPress={() => onDeletePress(districtId as DistrictId)}
               disabled={updateElectionMutation.isLoading}
             >
               Delete District
@@ -441,11 +445,10 @@ function PrecinctForm({
     return null;
   }
 
-  function onSavePress() {
-    assert(precinct);
+  function onSavePress(updatedPrecinct: Precinct) {
     const newPrecincts = precinctId
-      ? savedPrecincts.map((p) => (p.id === precinctId ? precinct : p))
-      : [...savedPrecincts, precinct];
+      ? savedPrecincts.map((p) => (p.id === precinctId ? updatedPrecinct : p))
+      : [...savedPrecincts, updatedPrecinct];
     updatePrecinctsMutation.mutate(
       {
         electionId,
@@ -520,9 +523,8 @@ function PrecinctForm({
     }
   }
 
-  function onDeletePress() {
-    assert(precinctId !== undefined);
-    const newPrecincts = savedPrecincts.filter((p) => p.id !== precinctId);
+  function onDeletePress(id: PrecinctId) {
+    const newPrecincts = savedPrecincts.filter((p) => p.id !== id);
     updatePrecinctsMutation.mutate(
       {
         electionId,
@@ -678,7 +680,7 @@ function PrecinctForm({
           <Button
             variant="primary"
             icon="Done"
-            onPress={onSavePress}
+            onPress={() => onSavePress(precinct)}
             disabled={updatePrecinctsMutation.isLoading}
           >
             Save
@@ -689,7 +691,7 @@ function PrecinctForm({
             <Button
               variant="danger"
               icon="Delete"
-              onPress={onDeletePress}
+              onPress={() => onDeletePress(precinctId)}
               disabled={updatePrecinctsMutation.isLoading}
             >
               Delete Precinct

--- a/apps/design/frontend/src/nav_screen.tsx
+++ b/apps/design/frontend/src/nav_screen.tsx
@@ -58,7 +58,7 @@ export function ElectionNavScreen({
               to="/"
               fill="transparent"
               color="inverseNeutral"
-              icon="LeftChevron"
+              icon="ChevronLeft"
             >
               All Elections
             </LinkButton>

--- a/apps/design/frontend/src/utils.test.ts
+++ b/apps/design/frontend/src/utils.test.ts
@@ -1,6 +1,21 @@
-import { downloadFile } from './utils';
+import { downloadFile, reorderElement } from './utils';
 
 test('downloadFile cleans up temporary anchor tag', () => {
   downloadFile('http://localhost:1234/file.zip');
   expect(document.getElementsByTagName('a')).toHaveLength(0);
+});
+
+test('reorderElement', () => {
+  expect(reorderElement([1], 0, 0)).toEqual([1]);
+  expect(reorderElement([1, 2, 3], 0, 0)).toEqual([1, 2, 3]);
+  expect(reorderElement([1, 2, 3], 0, 1)).toEqual([2, 1, 3]);
+  expect(reorderElement([1, 2, 3], 0, 2)).toEqual([2, 3, 1]);
+  expect(reorderElement([1, 2, 3], 2, 0)).toEqual([3, 1, 2]);
+  expect(reorderElement([1, 2, 3], 2, 1)).toEqual([1, 3, 2]);
+  expect(reorderElement([1, 2, 3], 2, 2)).toEqual([1, 2, 3]);
+  expect(() => reorderElement([], 0, 0)).toThrow();
+  expect(() => reorderElement([1, 2, 3], 0, 3)).toThrow();
+  expect(() => reorderElement([1, 2, 3], 3, 0)).toThrow();
+  expect(() => reorderElement([1, 2, 3], -1, 0)).toThrow();
+  expect(() => reorderElement([1, 2, 3], 0, -1)).toThrow();
 });

--- a/apps/design/frontend/src/utils.ts
+++ b/apps/design/frontend/src/utils.ts
@@ -1,3 +1,4 @@
+import { assert } from '@votingworks/basics';
 import type { Precinct, PrecinctWithSplits } from '@votingworks/design-backend';
 import { customAlphabet } from 'nanoid';
 
@@ -38,4 +39,21 @@ export function downloadFile(filePath: string): void {
   document.body.appendChild(element);
   element.click();
   document.body.removeChild(element);
+}
+
+/**
+ * Returns a copy of the given array with the element at fromIndex
+ * moved to toIndex.
+ */
+export function reorderElement<T>(
+  array: readonly T[],
+  fromIndex: number,
+  toIndex: number
+): T[] {
+  assert(fromIndex >= 0 && fromIndex < array.length);
+  assert(toIndex >= 0 && toIndex < array.length);
+  const result = [...array];
+  const [removed] = result.splice(fromIndex, 1);
+  result.splice(toIndex, 0, removed);
+  return result;
 }

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -34,6 +34,8 @@ import {
   faEject,
   faFileArrowUp,
   faFileArrowDown,
+  faChevronUp,
+  faChevronDown,
 } from '@fortawesome/free-solid-svg-icons';
 import {
   faXmarkCircle,
@@ -186,10 +188,6 @@ export const Icons = {
     return <FaIcon {...props} type={faCheckCircle} />;
   },
 
-  DownChevron(props) {
-    return <FaIcon {...props} type={faChevronCircleDown} />;
-  },
-
   Edit(props) {
     return <FaIcon {...props} type={faPencil} />;
   },
@@ -234,11 +232,27 @@ export const Icons = {
     return <FaIcon {...props} type={faCircleQuestion} />;
   },
 
-  RightChevron(props) {
+  ChevronCircleDown(props) {
+    return <FaIcon {...props} type={faChevronCircleDown} />;
+  },
+
+  ChevronCircleUp(props) {
+    return <FaIcon {...props} type={faChevronCircleUp} />;
+  },
+
+  ChevronDown(props) {
+    return <FaIcon {...props} type={faChevronDown} />;
+  },
+
+  ChevronUp(props) {
+    return <FaIcon {...props} type={faChevronUp} />;
+  },
+
+  ChevronRight(props) {
     return <FaIcon {...props} type={faChevronRight} />;
   },
 
-  LeftChevron(props) {
+  ChevronLeft(props) {
     return <FaIcon {...props} type={faChevronLeft} />;
   },
 
@@ -260,10 +274,6 @@ export const Icons = {
 
   TextSize(props) {
     return <FaIcon {...props} type={faTextHeight} />;
-  },
-
-  UpChevron(props) {
-    return <FaIcon {...props} type={faChevronCircleUp} />;
   },
 
   Warning(props) {

--- a/libs/ui/src/left_nav.tsx
+++ b/libs/ui/src/left_nav.tsx
@@ -53,7 +53,7 @@ export function NavLink({
       color="inverseNeutral"
       rightIcon={
         isActive ? (
-          <Icons.RightChevron style={{ marginLeft: 'auto' }} />
+          <Icons.ChevronRight style={{ marginLeft: 'auto' }} />
         ) : undefined
       }
       {...linkButtonProps}

--- a/libs/ui/src/tabbed_section/tab_bar.tsx
+++ b/libs/ui/src/tabbed_section/tab_bar.tsx
@@ -57,7 +57,7 @@ export function TabBar<Id extends string = string>(
           onPress={() => onChange(paneId)}
           role="tab"
           variant={activePaneId === paneId ? 'primary' : 'neutral'}
-          rightIcon="RightChevron"
+          rightIcon="ChevronRight"
           active={activePaneId === paneId}
         >
           {label}

--- a/libs/ui/src/with_scroll_buttons.tsx
+++ b/libs/ui/src/with_scroll_buttons.tsx
@@ -182,7 +182,7 @@ export function WithScrollButtons(props: WithScrollButtonsProps): JSX.Element {
             {canScrollUp && (
               <Control onPress={onScrollUp} variant="primary">
                 <ControlLabel>
-                  <Icons.UpChevron />
+                  <Icons.ChevronCircleUp />
                   {appStrings.buttonMore()}
                 </ControlLabel>
               </Control>
@@ -192,7 +192,7 @@ export function WithScrollButtons(props: WithScrollButtonsProps): JSX.Element {
               <Control onPress={onScrollDown} variant="primary">
                 <ControlLabel>
                   {appStrings.buttonMore()}
-                  <Icons.DownChevron />
+                  <Icons.ChevronCircleDown />
                 </ControlLabel>
               </Control>
             )}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1324,6 +1324,9 @@ importers:
       react-dom:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
+      react-flip-toolkit:
+        specifier: ^7.1.0
+        version: 7.1.0(react-dom@18.2.0)(react@18.2.0)
       react-router-dom:
         specifier: ^5.3.4
         version: 5.3.4(react@18.2.0)
@@ -15538,6 +15541,13 @@ packages:
   /flatted@3.2.7:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
 
+  /flip-toolkit@7.1.0:
+    resolution: {integrity: sha512-tvids+uibr8gVFUp1xHMkNSIFvM4++Xr4jAJouUVsId2hv3YvhvC4Ht2FJzdxBZHhI4AeULPFAF6z9fhc20XWQ==}
+    engines: {node: '>=8', npm: '>=5'}
+    dependencies:
+      rematrix: 0.2.2
+    dev: false
+
   /flow-parser@0.198.2:
     resolution: {integrity: sha512-tCQzqXbRAz0ZadIhAXGwdp/xsusADo8IK9idgc/2qCK5RmazbKDGedyykfRtzWgy7Klt4f4NZxq0o/wFUg6plQ==}
     engines: {node: '>=0.4.0'}
@@ -16718,12 +16728,14 @@ packages:
   /is-accessor-descriptor@0.1.6:
     resolution: {integrity: sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==}
     engines: {node: '>=0.10.0'}
+    deprecated: Please upgrade to v0.1.7
     dependencies:
       kind-of: 3.2.2
 
   /is-accessor-descriptor@1.0.0:
     resolution: {integrity: sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==}
     engines: {node: '>=0.10.0'}
+    deprecated: Please upgrade to v1.0.1
     dependencies:
       kind-of: 6.0.3
 
@@ -16816,12 +16828,14 @@ packages:
   /is-data-descriptor@0.1.4:
     resolution: {integrity: sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==}
     engines: {node: '>=0.10.0'}
+    deprecated: Please upgrade to v0.1.5
     dependencies:
       kind-of: 3.2.2
 
   /is-data-descriptor@1.0.0:
     resolution: {integrity: sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==}
     engines: {node: '>=0.10.0'}
+    deprecated: Please upgrade to v1.0.1
     dependencies:
       kind-of: 6.0.3
 
@@ -20057,6 +20071,19 @@ packages:
   /react-error-overlay@6.0.11:
     resolution: {integrity: sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==}
 
+  /react-flip-toolkit@7.1.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-KJ2IecKpYOJWgtXY9myyJzzC96FJaE9/8pFSAKgIoG54tiUAZ64ksDpmB+QmMofqFTa06RK7xWb9Rfavf8qz4Q==}
+    engines: {node: '>=8', npm: '>=5'}
+    peerDependencies:
+      react: '>= 16.x'
+      react-dom: '>= 16.x'
+    dependencies:
+      flip-toolkit: 7.1.0
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
   /react-gamepad@1.0.3(react@18.2.0):
     resolution: {integrity: sha512-gMwITmfoHtCaMFpDaEshcjeibHAgynXD28NnS2pa+dG+stwNoN66YDVizN7GfyIrYiW5Ft1ubRxs6/2xW9sRhQ==}
     peerDependencies:
@@ -20541,6 +20568,10 @@ packages:
       mdast-util-to-string: 1.1.0
       unist-util-visit: 2.0.3
     dev: true
+
+  /rematrix@0.2.2:
+    resolution: {integrity: sha512-agFFS3RzrLXJl5LY5xg/xYyXvUuVAnkhgKO7RaO9J1Ssth6yvbO+PIiV67V59MB5NCdAK2flvGvNT4mdKVniFA==}
+    dev: false
 
   /remove-accents@0.4.2:
     resolution: {integrity: sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==}


### PR DESCRIPTION
## Overview

Closes #4419 

Adds a button to reorder contests to the contests screen. When clicked, the screen enters reordering mode and the user can click up/down buttons to move contests around in the order. The user can then save or cancel changes.

I originally experimented with a drag-and-drop UX, but decided to go with the simpler up/down buttons as a starting point since it's easier to implement and easier to test. I suspect we may change this feature to support contest sections and state-specific rules, so I didn't want to invest too heavily in it yet.

## Demo Video or Screenshot

https://github.com/votingworks/vxsuite/assets/530106/95f485cc-b9e8-4d0e-b7d0-9edcd302d8d5


## Testing Plan
Updated automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
