### PR TITLE
Update VxAdmin election package exports to include everything from VxDesign

### DIFF
--- a/apps/admin/backend/schema.sql
+++ b/apps/admin/backend/schema.sql
@@ -2,6 +2,7 @@ create table elections (
   id serial primary key,
   election_data text not null,
   system_settings_data text not null,
+  election_package_file_contents blob not null,
   is_official_results boolean not null default false,
   created_at timestamp not null default current_timestamp
 );

--- a/apps/admin/backend/src/adjudication.test.ts
+++ b/apps/admin/backend/src/adjudication.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import {
   ContestOptionId,
   DEFAULT_SYSTEM_SETTINGS,
@@ -23,6 +24,7 @@ test('adjudicateVote', () => {
   const electionId = store.addElection({
     electionData,
     systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
   });
   store.setCurrentElectionId(electionId);
 
@@ -109,6 +111,7 @@ test('adjudicateWriteIn', async () => {
   const electionId = store.addElection({
     electionData,
     systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
   });
   store.setCurrentElectionId(electionId);
 

--- a/apps/admin/backend/src/exports/csv_ballot_count_report.test.ts
+++ b/apps/admin/backend/src/exports/csv_ballot_count_report.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import {
   electionFamousNames2021Fixtures,
   electionTwoPartyPrimaryFixtures,
@@ -20,6 +21,7 @@ test('uses appropriate headers', async () => {
   const electionId = store.addElection({
     electionData,
     systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
   });
   store.setCurrentElectionId(electionId);
 
@@ -162,6 +164,7 @@ test('includes rows for empty but known result groups', async () => {
   const electionId = store.addElection({
     electionData,
     systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
   });
   store.setCurrentElectionId(electionId);
 
@@ -186,6 +189,7 @@ test('does not include results groups when they are excluded by the filter', asy
   const electionId = store.addElection({
     electionData,
     systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
   });
   store.setCurrentElectionId(electionId);
 
@@ -230,6 +234,7 @@ test('excludes Manual column if no manual data exists', async () => {
   const electionId = store.addElection({
     electionData,
     systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
   });
   store.setCurrentElectionId(electionId);
 
@@ -254,6 +259,7 @@ test('can include sheet counts', async () => {
   const electionId = store.addElection({
     electionData,
     systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
   });
   store.setCurrentElectionId(electionId);
 

--- a/apps/admin/backend/src/exports/csv_tally_report.test.ts
+++ b/apps/admin/backend/src/exports/csv_tally_report.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import { electionTwoPartyPrimaryFixtures } from '@votingworks/fixtures';
 import { DEFAULT_SYSTEM_SETTINGS, Tabulation } from '@votingworks/types';
 import { find } from '@votingworks/basics';
@@ -17,6 +18,7 @@ test('uses appropriate headers', async () => {
   const electionId = store.addElection({
     electionData,
     systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
   });
   store.setCurrentElectionId(electionId);
 
@@ -231,6 +233,7 @@ test('includes rows for empty but known result groups', async () => {
   const electionId = store.addElection({
     electionData,
     systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
   });
   store.setCurrentElectionId(electionId);
 
@@ -254,6 +257,7 @@ test('included contests are specific to each results group', async () => {
   const electionId = store.addElection({
     electionData,
     systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
   });
   store.setCurrentElectionId(electionId);
 
@@ -290,6 +294,7 @@ test('included contests are restricted by the overall export filter', async () =
   const electionId = store.addElection({
     electionData,
     systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
   });
   store.setCurrentElectionId(electionId);
 
@@ -317,6 +322,7 @@ test('does not include results groups when they are excluded by the filter', asy
   const electionId = store.addElection({
     electionData,
     systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
   });
   store.setCurrentElectionId(electionId);
 
@@ -359,6 +365,7 @@ test('incorporates manual data', async () => {
   const electionId = store.addElection({
     electionData,
     systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
   });
   store.setCurrentElectionId(electionId);
 
@@ -458,6 +465,7 @@ test('separate rows for manual data when grouping by an incompatible dimension',
   const electionId = store.addElection({
     electionData,
     systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
   });
   store.setCurrentElectionId(electionId);
 

--- a/apps/admin/backend/src/tabulation/card_counts.test.ts
+++ b/apps/admin/backend/src/tabulation/card_counts.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import { electionTwoPartyPrimaryFixtures } from '@votingworks/fixtures';
 import { Admin, DEFAULT_SYSTEM_SETTINGS, Tabulation } from '@votingworks/types';
 import {
@@ -22,6 +23,7 @@ test('tabulateScannedCardCounts - grouping', () => {
   const electionId = store.addElection({
     electionData,
     systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
   });
   store.setCurrentElectionId(electionId);
 
@@ -172,6 +174,7 @@ test('tabulateScannedCardCounts - merging card tallies', () => {
   const electionId = store.addElection({
     electionData,
     systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
   });
   store.setCurrentElectionId(electionId);
 
@@ -239,6 +242,7 @@ test('tabulateFullCardCounts - manual results', () => {
   const electionId = store.addElection({
     electionData,
     systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
   });
   store.setCurrentElectionId(electionId);
 
@@ -376,6 +380,7 @@ test('tabulateFullCardCounts - blankBallots', () => {
   const electionId = store.addElection({
     electionData,
     systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
   });
   store.setCurrentElectionId(electionId);
 

--- a/apps/admin/backend/src/tabulation/full_results.test.ts
+++ b/apps/admin/backend/src/tabulation/full_results.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import {
   electionGridLayoutNewHampshireTestBallotFixtures,
   electionTwoPartyPrimaryFixtures,
@@ -55,6 +56,7 @@ test('tabulateCastVoteRecords', async () => {
   const electionId = store.addElection({
     electionData,
     systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
   });
   store.setCurrentElectionId(electionId);
 
@@ -265,6 +267,7 @@ test('tabulateElectionResults - includes empty groups', async () => {
   const electionId = store.addElection({
     electionData,
     systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
   });
   store.setCurrentElectionId(electionId);
 
@@ -294,6 +297,7 @@ test('tabulateElectionResults - write-in handling', async () => {
   const electionId = store.addElection({
     electionData: electionDefinition.electionData,
     systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
   });
   store.setCurrentElectionId(electionId);
 
@@ -700,6 +704,7 @@ test('tabulateElectionResults - group and filter by voting method', async () => 
   const electionId = store.addElection({
     electionData,
     systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
   });
   store.setCurrentElectionId(electionId);
   const importResult = await importCastVoteRecords(

--- a/apps/admin/backend/src/tabulation/manual_results.test.ts
+++ b/apps/admin/backend/src/tabulation/manual_results.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import { electionTwoPartyPrimaryFixtures } from '@votingworks/fixtures';
 import { buildManualResultsFixture } from '@votingworks/utils';
 import { assert } from '@votingworks/basics';
@@ -51,6 +52,7 @@ describe('tabulateManualResults & tabulateManualBallotCounts', () => {
       electionData:
         electionTwoPartyPrimaryFixtures.electionDefinition.electionData,
       systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+      electionPackageFileContents: Buffer.of(),
     });
     store.setCurrentElectionId(electionId);
 
@@ -77,6 +79,7 @@ describe('tabulateManualResults & tabulateManualBallotCounts', () => {
     const electionId = store.addElection({
       electionData,
       systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+      electionPackageFileContents: Buffer.of(),
     });
     store.setCurrentElectionId(electionId);
 

--- a/apps/admin/backend/src/tabulation/write_ins.test.ts
+++ b/apps/admin/backend/src/tabulation/write_ins.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import {
   electionFamousNames2021Fixtures,
   electionTwoPartyPrimaryDefinition,
@@ -151,6 +152,7 @@ test('tabulateWriteInTallies', () => {
   const electionId = store.addElection({
     electionData,
     systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
   });
   store.setCurrentElectionId(electionId);
 

--- a/libs/backend/src/election_package/election_package_io.test.ts
+++ b/libs/backend/src/election_package/election_package_io.test.ts
@@ -1,7 +1,6 @@
 import { fakeLogger } from '@votingworks/logging';
 import {
   DEFAULT_SYSTEM_SETTINGS,
-  ElectionPackage,
   ElectionPackageFileName,
   ElectionPackageMetadata,
   ElectionStringKey,
@@ -47,6 +46,7 @@ import {
   mockElectionPackageFileTree,
 } from './test_utils';
 import {
+  ElectionPackageWithFileContents,
   readElectionPackageFromFile,
   readSignedElectionPackageFromUsb,
 } from './election_package_io';
@@ -100,12 +100,13 @@ test('readElectionPackageFromFile reads an election package without system setti
   });
   const file = saveTmpFile(pkg);
   expect((await readElectionPackageFromFile(file)).unsafeUnwrap()).toEqual(
-    typedAs<ElectionPackage>({
+    typedAs<ElectionPackageWithFileContents>({
       electionDefinition:
         electionGridLayoutNewHampshireTestBallotFixtures.electionDefinition,
       systemSettings: DEFAULT_SYSTEM_SETTINGS,
       uiStrings: {},
       uiStringAudioClips: [],
+      fileContents: expect.any(Buffer),
     })
   );
 });
@@ -121,12 +122,13 @@ test('readElectionPackageFromFile reads an election package with system settings
   });
   const file = saveTmpFile(pkg);
   expect((await readElectionPackageFromFile(file)).unsafeUnwrap()).toEqual(
-    typedAs<ElectionPackage>({
+    typedAs<ElectionPackageWithFileContents>({
       electionDefinition:
         electionGridLayoutNewHampshireTestBallotFixtures.electionDefinition,
       systemSettings: DEFAULT_SYSTEM_SETTINGS,
       uiStrings: {},
       uiStringAudioClips: [],
+      fileContents: expect.any(Buffer),
     })
   );
 });
@@ -164,12 +166,13 @@ test('readElectionPackageFromFile loads available ui strings', async () => {
 
   expect(
     (await readElectionPackageFromFile(file)).unsafeUnwrap()
-  ).toEqual<ElectionPackage>({
+  ).toEqual<ElectionPackageWithFileContents>({
     electionDefinition:
       safeParseElectionDefinition(testCdfElectionData).unsafeUnwrap(),
     systemSettings: DEFAULT_SYSTEM_SETTINGS,
     uiStrings: expectedUiStrings,
     uiStringAudioClips: [],
+    fileContents: expect.any(Buffer),
   });
 });
 
@@ -205,12 +208,13 @@ test('readElectionPackageFromFile loads vx election strings', async () => {
 
   expect(
     (await readElectionPackageFromFile(file)).unsafeUnwrap()
-  ).toEqual<ElectionPackage>({
+  ).toEqual<ElectionPackageWithFileContents>({
     electionDefinition:
       safeParseElectionDefinition(testCdfElectionData).unsafeUnwrap(),
     systemSettings: DEFAULT_SYSTEM_SETTINGS,
     uiStrings: expectedUiStrings,
     uiStringAudioClips: [],
+    fileContents: expect.any(Buffer),
   });
 });
 
@@ -247,12 +251,13 @@ test('readElectionPackageFromFile loads UI string audio IDs', async () => {
 
   expect(
     (await readElectionPackageFromFile(file)).unsafeUnwrap()
-  ).toEqual<ElectionPackage>({
+  ).toEqual<ElectionPackageWithFileContents>({
     electionDefinition,
     systemSettings: DEFAULT_SYSTEM_SETTINGS,
     uiStrings: {},
     uiStringAudioIds: expectedAudioIds,
     uiStringAudioClips: [],
+    fileContents: expect.any(Buffer),
   });
 });
 
@@ -276,11 +281,12 @@ test('readElectionPackageFromFile loads UI string audio clips', async () => {
 
   expect(
     (await readElectionPackageFromFile(file)).unsafeUnwrap()
-  ).toEqual<ElectionPackage>({
+  ).toEqual<ElectionPackageWithFileContents>({
     electionDefinition,
     systemSettings: DEFAULT_SYSTEM_SETTINGS,
     uiStrings: {},
     uiStringAudioClips: audioClips,
+    fileContents: expect.any(Buffer),
   });
 });
 
@@ -298,12 +304,13 @@ test('readElectionPackageFromFile reads metadata', async () => {
 
   expect(
     (await readElectionPackageFromFile(file)).unsafeUnwrap()
-  ).toEqual<ElectionPackage>({
+  ).toEqual<ElectionPackageWithFileContents>({
     electionDefinition,
     metadata,
     systemSettings: DEFAULT_SYSTEM_SETTINGS,
     uiStringAudioClips: [],
     uiStrings: {},
+    fileContents: expect.any(Buffer),
   });
 });
 

--- a/libs/backend/src/election_package/election_package_io.ts
+++ b/libs/backend/src/election_package/election_package_io.ts
@@ -59,12 +59,12 @@ export interface ElectionPackageError {
 }
 
 async function readElectionPackageFromBuffer(
-  source: Buffer
+  fileContents: Buffer
 ): Promise<Result<ElectionPackage, ElectionPackageError>> {
   try {
-    const zipfile = await openZip(source);
+    const zipFile = await openZip(fileContents);
     const zipName = 'election package';
-    const entries = getEntries(zipfile);
+    const entries = getEntries(zipFile);
     const electionEntry = getFileByName(
       entries,
       ElectionPackageFileName.ELECTION,
@@ -212,13 +212,21 @@ async function readElectionPackageFromBuffer(
 }
 
 /**
+ * An {@link ElectionPackage} object, with the raw contents of the zip file included
+ */
+export type ElectionPackageWithFileContents = ElectionPackage & {
+  fileContents: Buffer;
+};
+
+/**
  * Attempts to read an election package from the given filepath and parse the contents.
  */
 export async function readElectionPackageFromFile(
   path: string
-): Promise<Result<ElectionPackage, ElectionPackageError>> {
+): Promise<Result<ElectionPackageWithFileContents, ElectionPackageError>> {
   const fileContents = await fs.readFile(path);
-  return readElectionPackageFromBuffer(fileContents);
+  const result = await readElectionPackageFromBuffer(fileContents);
+  return result.isErr() ? result : ok({ ...result.ok(), fileContents });
 }
 
 async function getMostRecentElectionPackageFilepath(


### PR DESCRIPTION
## Overview

The workflow for election packages involves the following steps:

1. Export an election package from VxDesign
2. Import the election package onto VxAdmin
3. Re-export the election package from VxAdmin, this time signed
4. Import the signed election package onto the other machines

This PR updates step 3 to include all the contents generated in step 1, specifically adding language and audio files. It does so by storing the entire election package zip file in the VxAdmin DB in step 2.

## Demo Video or Screenshot

https://github.com/votingworks/vxsuite/assets/12616928/76b19c5d-dc69-4f66-80d4-b485f4424bb6

## Testing Plan

- [x] Updated automated tests
- [x] Manually tested VxAdmin export and VxScan import

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A