### PR TITLE
Various `iter` improvements

### DIFF
--- a/libs/basics/src/iterators/async_iterator_plus.test.ts
+++ b/libs/basics/src/iterators/async_iterator_plus.test.ts
@@ -137,13 +137,14 @@ test('zip', async () => {
     [3, 6],
   ]);
 
-  const numbers = iter(naturals()).async();
-  expect(await numbers.zip(numbers).take(5).toArray()).toEqual([
-    [1, 2],
-    [3, 4],
-    [5, 6],
-    [7, 8],
-    [9, 10],
+  expect(
+    await naturals().async().zip(naturals().async()).take(5).toArray()
+  ).toEqual([
+    [1, 1],
+    [2, 2],
+    [3, 3],
+    [4, 4],
+    [5, 5],
   ]);
 });
 
@@ -716,4 +717,12 @@ test('windows', async () => {
     ['u', 's'],
     ['s', 't'],
   ]);
+});
+
+test('single ownership', async () => {
+  const it = iter([1, 2, 3]).async();
+  expect(await it.toArray()).toEqual([1, 2, 3]);
+  await expect(it.toArray()).rejects.toThrowError(
+    'inner iterable has already been taken'
+  );
 });

--- a/libs/basics/src/iterators/async_iterator_plus.ts
+++ b/libs/basics/src/iterators/async_iterator_plus.ts
@@ -51,15 +51,11 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   chain<U>(other: AsyncIterable<U>): AsyncIteratorPlus<T | U> {
     const iterable = this.intoInner();
     return new AsyncIteratorPlusImpl(
-      (async function* gen() {
-        for await (const value of iterable) {
-          yield value;
-        }
-        for await (const value of other) {
-          yield value;
-        }
+      (async function* gen(): AsyncIterableIterator<T | U> {
+        yield* iterable;
+        yield* other;
       })()
-    ) as AsyncIteratorPlus<T | U>;
+    );
   }
 
   chunks(groupSize: 1): AsyncIteratorPlus<[T]>;
@@ -114,14 +110,14 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   enumerate(): AsyncIteratorPlus<[number, T]> {
     const iterable = this.intoInner();
     return new AsyncIteratorPlusImpl(
-      (async function* gen(): AsyncGenerator<[number, T]> {
+      (async function* gen(): AsyncIterableIterator<[number, T]> {
         let index = 0;
         for await (const value of iterable) {
           yield [index, value];
           index += 1;
         }
       })()
-    ) as AsyncIteratorPlus<[number, T]>;
+    );
   }
 
   async every(predicate: (item: T) => MaybePromise<unknown>): Promise<boolean> {
@@ -136,14 +132,14 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   filter(fn: (value: T) => MaybePromise<unknown>): AsyncIteratorPlus<T> {
     const iterable = this.intoInner();
     return new AsyncIteratorPlusImpl(
-      (async function* gen(): AsyncGenerator<T> {
+      (async function* gen(): AsyncIterableIterator<T> {
         for await (const value of iterable) {
           if (await fn(value)) {
             yield value;
           }
         }
       })()
-    ) as AsyncIteratorPlus<T>;
+    );
   }
 
   filterMap<U extends NonNullable<unknown>>(
@@ -151,7 +147,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   ): AsyncIteratorPlus<U> {
     const iterable = this.intoInner();
     return new AsyncIteratorPlusImpl(
-      (async function* gen(): AsyncGenerator<U> {
+      (async function* gen(): AsyncIterableIterator<U> {
         let index = 0;
         for await (const value of iterable) {
           const mapped = await fn(value, index);
@@ -161,7 +157,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
           index += 1;
         }
       })()
-    ) as AsyncIteratorPlus<U>;
+    );
   }
 
   async find(
@@ -188,14 +184,14 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   ): AsyncIteratorPlus<U> {
     const iterable = this.intoInner();
     return new AsyncIteratorPlusImpl(
-      (async function* gen() {
+      (async function* gen(): AsyncIterableIterator<U> {
         let index = 0;
         for await (const value of iterable) {
           yield* await fn(value, index);
           index += 1;
         }
       })()
-    ) as AsyncIteratorPlus<U>;
+    );
   }
 
   groupBy(
@@ -203,7 +199,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   ): AsyncIteratorPlus<T[]> {
     const iterable = this.intoInner();
     return new AsyncIteratorPlusImpl(
-      (async function* gen() {
+      (async function* gen(): AsyncIterableIterator<T[]> {
         let group: T[] = [];
         let previous: T | undefined;
         let isFirst = true;
@@ -221,7 +217,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
           yield group;
         }
       })()
-    ) as AsyncIteratorPlus<T[]>;
+    );
   }
 
   async isEmpty(): Promise<boolean> {
@@ -246,17 +242,17 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   ): AsyncIteratorPlus<U> {
     const iterable = this.intoInner();
     return new AsyncIteratorPlusImpl(
-      (async function* gen() {
+      (async function* gen(): AsyncIterableIterator<U> {
         let index = 0;
         for await (const value of iterable) {
           yield await fn(value, index);
           index += 1;
         }
       })()
-    ) as AsyncIteratorPlus<U>;
+    );
   }
 
-  max(): Promise<T extends number ? T | undefined : unknown>;
+  max(): Promise<T | undefined>;
   max(compareFn: (a: T, b: T) => MaybePromise<number>): Promise<T | undefined>;
   max(
     compareFn: (a: T, b: T) => MaybePromise<number> = (a, b) =>
@@ -269,7 +265,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
     return this.minBy(async (item) => -(await fn(item)));
   }
 
-  min(): Promise<T extends number ? T | undefined : unknown>;
+  min(): Promise<T | undefined>;
   min(compareFn: (a: T, b: T) => MaybePromise<number>): Promise<T | undefined>;
   async min(
     compareFn: (a: T, b: T) => MaybePromise<number> = (a, b) =>
@@ -313,13 +309,13 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   rev(): AsyncIteratorPlus<T> {
     const toArrayPromise = this.toArray();
     return new AsyncIteratorPlusImpl(
-      (async function* gen() {
+      (async function* gen(): AsyncIterableIterator<T> {
         const array = await toArrayPromise;
         for (let i = array.length - 1; i >= 0; i -= 1) {
           yield array[i] as T;
         }
       })()
-    ) as AsyncIteratorPlus<T>;
+    );
   }
 
   async some(predicate: (item: T) => MaybePromise<unknown>): Promise<boolean> {
@@ -344,7 +340,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   skip(count: number): AsyncIteratorPlus<T> {
     const iterable = this.intoInner();
     return new AsyncIteratorPlusImpl(
-      (async function* gen() {
+      (async function* gen(): AsyncIterableIterator<T> {
         let remaining = count;
         for await (const value of iterable) {
           if (remaining <= 0) {
@@ -354,13 +350,13 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
           }
         }
       })()
-    ) as AsyncIteratorPlus<T>;
+    );
   }
 
   take(count: number): AsyncIteratorPlus<T> {
     const iterable = this.intoInner();
     return new AsyncIteratorPlusImpl(
-      (async function* gen() {
+      (async function* gen(): AsyncIterableIterator<T> {
         let remaining = count;
         for await (const value of iterable) {
           if (remaining <= 0) {
@@ -371,7 +367,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
           }
         }
       })()
-    ) as AsyncIteratorPlus<T>;
+    );
   }
 
   async toArray(): Promise<T[]> {
@@ -422,7 +418,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
 
     const iterable = this.intoInner();
     return new AsyncIteratorPlusImpl(
-      (async function* gen() {
+      (async function* gen(): AsyncIterableIterator<T[]> {
         const window: T[] = [];
         for await (const value of iterable) {
           window.push(value);
@@ -464,7 +460,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   ): AsyncIteratorPlus<unknown[]> {
     const iterable = this.intoInner();
     return new AsyncIteratorPlusImpl(
-      (async function* gen() {
+      (async function* gen(): AsyncIterableIterator<unknown[]> {
         const iterators = [iterable, ...others].map(
           (it) =>
             /* istanbul ignore next */
@@ -520,7 +516,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   ): AsyncIteratorPlus<unknown[]> {
     const iterable = this.intoInner();
     return new AsyncIteratorPlusImpl(
-      (async function* gen() {
+      (async function* gen(): AsyncIterableIterator<unknown[]> {
         const iterators = [iterable, ...others].map((it) =>
           it[Symbol.asyncIterator]()
         );

--- a/libs/basics/src/iterators/async_iterator_plus.ts
+++ b/libs/basics/src/iterators/async_iterator_plus.ts
@@ -4,12 +4,44 @@ import { AsyncIteratorPlus } from './types';
 
 /**
  * A wrapper around {@link AsyncIterable} that provides additional methods.
+ *
+ * This is modeled after Rust's `Iterator` trait and follows similar semantics.
+ * See https://doc.rust-lang.org/std/iter/trait.Iterator.html for more. In
+ * particular, note {@link AsyncIteratorPlus} is a *consumable* iterator,
+ * meaning that it can only be iterated over once. This is to prevent bugs where
+ * the same iterator is used multiple times, which can lead to unexpected
+ * behavior. Methods either create a new {@link AsyncIteratorPlus} (transforms)
+ * or return a value that is not an iterator (consumers).
+ *
+ * Note that {@link AsyncIteratorPlus} is lazy, meaning that it does not perform
+ * any work until it is iterated over. This means that methods like {@link map}
+ * and {@link filter} are transforms and do not actually perform any work until
+ * a consumer method is called. This is in contrast to {@link Array} methods
+ * like `map` and `filter`, which perform work immediately.
  */
 export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
-  constructor(private readonly iterable: AsyncIterable<T>) {}
+  /**
+   * Retrieves the inner iterable, or throws an error if it has already been
+   * taken. This ensures that the inner iterable can only be used once.
+   */
+  private readonly intoInner: () => AsyncIterable<T>;
+
+  constructor(iterable: AsyncIterable<T>) {
+    let innerIterable: AsyncIterable<T> | undefined = iterable;
+
+    this.intoInner = () => {
+      if (!innerIterable) {
+        throw new Error('inner iterable has already been taken');
+      }
+
+      const result = innerIterable;
+      innerIterable = undefined;
+      return result;
+    };
+  }
 
   [Symbol.asyncIterator](): AsyncIterator<T> {
-    return this.iterable[Symbol.asyncIterator]();
+    return this.intoInner()[Symbol.asyncIterator]();
   }
 
   async(): AsyncIteratorPlus<T> {
@@ -17,7 +49,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   }
 
   chain<U>(other: AsyncIterable<U>): AsyncIteratorPlus<T | U> {
-    const { iterable } = this;
+    const iterable = this.intoInner();
     return new AsyncIteratorPlusImpl(
       (async function* gen() {
         for await (const value of iterable) {
@@ -30,42 +62,19 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
     ) as AsyncIteratorPlus<T | U>;
   }
 
-  /**
-   * Yields tuples of one element at a time from {@link iterable}.
-   */
   chunks(groupSize: 1): AsyncIteratorPlus<[T]>;
-
-  /**
-   * Yields tuples of one or two elements at a time from {@link iterable}.
-   */
   chunks(groupSize: 2): AsyncIteratorPlus<[T] | [T, T]>;
-
-  /**
-   * Yields tuples of 1-3 elements from {@link iterable}.
-   */
   chunks(groupSize: 3): AsyncIteratorPlus<[T] | [T, T] | [T, T, T]>;
-
-  /**
-   * Yields tuples of 1-4 elements from {@link iterable}.
-   */
   chunks(
     groupSize: 4
   ): AsyncIteratorPlus<[T] | [T, T] | [T, T, T] | [T, T, T, T]>;
-
-  /**
-   * Yields arrays of {@link groupSize} or fewer elements from {@link iterable}.
-   */
   chunks(groupSize: number): AsyncIteratorPlus<T[]>;
-
-  /**
-   * Yields arrays of {@link groupSize} or fewer elements from {@link iterable}.
-   */
   chunks(groupSize: number): AsyncIteratorPlus<T[]> {
     assert(
       groupSize > 0 && Math.floor(groupSize) === groupSize,
       'groupSize must be an integer greater than 0'
     );
-    const { iterable } = this;
+    const iterable = this.intoInner();
     const iterator = iterable[Symbol.asyncIterator]();
     let group: T[] = [];
 
@@ -96,16 +105,16 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   async count(): Promise<number> {
     let count = 0;
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    for await (const it of this.iterable) {
+    for await (const it of this.intoInner()) {
       count += 1;
     }
     return count;
   }
 
   enumerate(): AsyncIteratorPlus<[number, T]> {
-    const { iterable } = this;
+    const iterable = this.intoInner();
     return new AsyncIteratorPlusImpl(
-      (async function* gen() {
+      (async function* gen(): AsyncGenerator<[number, T]> {
         let index = 0;
         for await (const value of iterable) {
           yield [index, value];
@@ -116,7 +125,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   }
 
   async every(predicate: (item: T) => MaybePromise<unknown>): Promise<boolean> {
-    for await (const it of this.iterable) {
+    for await (const it of this.intoInner()) {
       if (!(await predicate(it))) {
         return false;
       }
@@ -125,9 +134,9 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   }
 
   filter(fn: (value: T) => MaybePromise<unknown>): AsyncIteratorPlus<T> {
-    const { iterable } = this;
+    const iterable = this.intoInner();
     return new AsyncIteratorPlusImpl(
-      (async function* gen() {
+      (async function* gen(): AsyncGenerator<T> {
         for await (const value of iterable) {
           if (await fn(value)) {
             yield value;
@@ -140,9 +149,9 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   filterMap<U extends NonNullable<unknown>>(
     fn: (value: T, index: number) => MaybePromise<U | null | undefined>
   ): AsyncIteratorPlus<U> {
-    const { iterable } = this;
+    const iterable = this.intoInner();
     return new AsyncIteratorPlusImpl(
-      (async function* gen() {
+      (async function* gen(): AsyncGenerator<U> {
         let index = 0;
         for await (const value of iterable) {
           const mapped = await fn(value, index);
@@ -158,7 +167,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   async find(
     predicate: (item: T) => MaybePromise<unknown>
   ): Promise<T | undefined> {
-    for await (const it of this.iterable) {
+    for await (const it of this.intoInner()) {
       if (await predicate(it)) {
         return it;
       }
@@ -167,7 +176,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   }
 
   async first(): Promise<T | undefined> {
-    const { iterable } = this;
+    const iterable = this.intoInner();
     return (await iterable[Symbol.asyncIterator]().next()).value;
   }
 
@@ -177,7 +186,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
       index: number
     ) => MaybePromise<Iterable<U> | AsyncIterable<U>>
   ): AsyncIteratorPlus<U> {
-    const { iterable } = this;
+    const iterable = this.intoInner();
     return new AsyncIteratorPlusImpl(
       (async function* gen() {
         let index = 0;
@@ -192,7 +201,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   groupBy(
     predicate: (a: T, b: T) => MaybePromise<boolean>
   ): AsyncIteratorPlus<T[]> {
-    const { iterable } = this;
+    const iterable = this.intoInner();
     return new AsyncIteratorPlusImpl(
       (async function* gen() {
         let group: T[] = [];
@@ -217,7 +226,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
 
   async isEmpty(): Promise<boolean> {
     /* istanbul ignore next - `done` is typed as `{ done?: false } | { done: true }`, but in practice is never undefined */
-    return (await this.iterable[Symbol.asyncIterator]().next()).done ?? true;
+    return (await this.intoInner()[Symbol.asyncIterator]().next()).done ?? true;
   }
 
   async join(separator = ''): Promise<string> {
@@ -226,7 +235,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
 
   async last(): Promise<T | undefined> {
     let lastElement: T | undefined;
-    for await (const it of this.iterable) {
+    for await (const it of this.intoInner()) {
       lastElement = it;
     }
     return lastElement;
@@ -235,7 +244,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   map<U>(
     fn: (value: T, index: number) => MaybePromise<U>
   ): AsyncIteratorPlus<U> {
-    const { iterable } = this;
+    const iterable = this.intoInner();
     return new AsyncIteratorPlusImpl(
       (async function* gen() {
         let index = 0;
@@ -267,7 +276,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
       a < b ? -1 : a > b ? 1 : 0
   ): Promise<T | undefined | unknown> {
     let min: T | undefined;
-    for await (const it of this.iterable) {
+    for await (const it of this.intoInner()) {
       if (min === undefined || (await compareFn(it, min)) < 0) {
         min = it;
       }
@@ -278,7 +287,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   async minBy(fn: (item: T) => MaybePromise<number>): Promise<T | undefined> {
     let min: number | undefined;
     let minItem: T | undefined;
-    for await (const it of this.iterable) {
+    for await (const it of this.intoInner()) {
       const value = await fn(it);
       if (min === undefined || value < min) {
         min = value;
@@ -291,7 +300,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   async partition(predicate: (item: T) => unknown): Promise<[T[], T[]]> {
     const left = [];
     const right = [];
-    for await (const it of this.iterable) {
+    for await (const it of this.intoInner()) {
       if (predicate(it)) {
         left.push(it);
       } else {
@@ -314,7 +323,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   }
 
   async some(predicate: (item: T) => MaybePromise<unknown>): Promise<boolean> {
-    for await (const it of this.iterable) {
+    for await (const it of this.intoInner()) {
       if (await predicate(it)) {
         return true;
       }
@@ -326,14 +335,14 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   sum(fn: (item: T) => MaybePromise<number>): Promise<number>;
   async sum(fn?: (item: T) => MaybePromise<number>): Promise<number | unknown> {
     let sum = 0;
-    for await (const it of this.iterable) {
+    for await (const it of this.intoInner()) {
       sum += await (fn ? fn(it) : (it as unknown as number));
     }
     return sum;
   }
 
   skip(count: number): AsyncIteratorPlus<T> {
-    const { iterable } = this;
+    const iterable = this.intoInner();
     return new AsyncIteratorPlusImpl(
       (async function* gen() {
         let remaining = count;
@@ -349,7 +358,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   }
 
   take(count: number): AsyncIteratorPlus<T> {
-    const { iterable } = this;
+    const iterable = this.intoInner();
     return new AsyncIteratorPlusImpl(
       (async function* gen() {
         let remaining = count;
@@ -367,7 +376,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
 
   async toArray(): Promise<T[]> {
     const array = [];
-    for await (const item of this.iterable) {
+    for await (const item of this.intoInner()) {
       array.push(item);
     }
     return array;
@@ -376,7 +385,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   async toMap<K>(
     keySelector: (item: T) => MaybePromise<K>
   ): Promise<Map<K, Set<T>>> {
-    const { iterable } = this;
+    const iterable = this.intoInner();
     const result = new Map<K, Set<T>>();
     for await (const item of iterable) {
       const key = await keySelector(item);
@@ -389,7 +398,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
 
   async toSet(): Promise<Set<T>> {
     const set = new Set<T>();
-    for await (const item of this.iterable) {
+    for await (const item of this.intoInner()) {
       set.add(item);
     }
     return set;
@@ -411,7 +420,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
       throw new Error('groupSize must be greater than 0');
     }
 
-    const { iterable } = this;
+    const iterable = this.intoInner();
     return new AsyncIteratorPlusImpl(
       (async function* gen() {
         const window: T[] = [];
@@ -453,7 +462,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   zip(
     ...others: Array<Iterable<unknown> | AsyncIterable<unknown>>
   ): AsyncIteratorPlus<unknown[]> {
-    const { iterable } = this;
+    const iterable = this.intoInner();
     return new AsyncIteratorPlusImpl(
       (async function* gen() {
         const iterators = [iterable, ...others].map(
@@ -509,7 +518,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
   zipMin(
     ...others: Array<AsyncIterable<unknown>>
   ): AsyncIteratorPlus<unknown[]> {
-    const { iterable } = this;
+    const iterable = this.intoInner();
     return new AsyncIteratorPlusImpl(
       (async function* gen() {
         const iterators = [iterable, ...others].map((it) =>

--- a/libs/basics/src/iterators/iter.ts
+++ b/libs/basics/src/iterators/iter.ts
@@ -3,19 +3,22 @@ import { IteratorPlusImpl } from './iterator_plus';
 import { AsyncIteratorPlus, IteratorPlus } from './types';
 
 /**
- * Builds an {@link IteratorPlus} from an iterable.
+ * Wraps iterables to make working with them easier. See {@link IteratorPlus}
+ * and {@link AsyncIteratorPlus} for more information.
  */
 export function iter<T>(
   iterable: Iterable<T> | undefined | null
 ): IteratorPlus<T>;
 
 /**
- * Builds an {@link AsyncIteratorPlus} from an async iterable.
+ * Wraps iterables to make working with them easier. See {@link IteratorPlus}
+ * and {@link AsyncIteratorPlus} for more information.
  */
 export function iter<T>(iterable: AsyncIterable<T>): AsyncIteratorPlus<T>;
 
 /**
- * Builds an {@link IteratorPlus} or {@link AsyncIteratorPlus} from an iterable.
+ * Wraps iterables to make working with them easier. See {@link IteratorPlus}
+ * and {@link AsyncIteratorPlus} for more information.
  */
 export function iter<T>(
   iterable?: Iterable<T> | AsyncIterable<T> | null

--- a/libs/basics/src/iterators/iterator_plus.test.ts
+++ b/libs/basics/src/iterators/iterator_plus.test.ts
@@ -109,13 +109,12 @@ test('zip', () => {
     [3, 6],
   ]);
 
-  const numbers = naturals();
-  expect(numbers.zip(numbers).take(5).toArray()).toEqual([
-    [1, 2],
-    [3, 4],
-    [5, 6],
-    [7, 8],
-    [9, 10],
+  expect(naturals().zip(naturals()).take(5).toArray()).toEqual([
+    [1, 1],
+    [2, 2],
+    [3, 3],
+    [4, 4],
+    [5, 5],
   ]);
 });
 
@@ -466,4 +465,12 @@ test('windows', () => {
     ['u', 's'],
     ['s', 't'],
   ]);
+});
+
+test('single ownership', () => {
+  const it = iter([1, 2, 3]);
+  expect(it.toArray()).toEqual([1, 2, 3]);
+  expect(() => it.toArray()).toThrowError(
+    'inner iterable has already been taken'
+  );
 });

--- a/libs/basics/src/iterators/types.ts
+++ b/libs/basics/src/iterators/types.ts
@@ -292,7 +292,7 @@ export interface IteratorPlus<T> extends Iterable<T> {
    * expect(iter([]).max()).toBeUndefined();
    * ```
    */
-  max(): T extends number ? T | undefined : unknown;
+  max(): T | undefined;
 
   /**
    * Returns the maximum element of `this` or `undefined` if `this` is empty.
@@ -334,7 +334,7 @@ export interface IteratorPlus<T> extends Iterable<T> {
    * expect(iter([]).min()).toBeUndefined();
    * ```
    */
-  min(): T extends number ? T | undefined : unknown;
+  min(): T | undefined;
 
   /**
    * Returns the minimum element of `this` or `undefined` if `this` is empty.
@@ -979,10 +979,31 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
 
   /**
    * Returns the maximum element of `this` or `undefined` if `this` is empty.
-   * Comparison happens using `compareFn` if provided, otherwise using `>` and
-   * `<`. Consumes the entire contained iterable.
+   * Consumes the entire contained iterable.
+   *
+   * @example
+   *
+   * ```ts
+   * const maximumLineLength = await lines(process.stdin)
+   *   .map((line) => line.length)
+   *   .max();
+   * ```
    */
-  max(compareFn?: (a: T, b: T) => MaybePromise<number>): Promise<T | undefined>;
+  max(): Promise<T | undefined>;
+
+  /**
+   * Returns the maximum element of `this` or `undefined` if `this` is empty.
+   * Comparison happens using `compareFn`. Consumes the entire contained
+   * iterable.
+   *
+   * @example
+   *
+   * ```ts
+   * const maximumLineLength = await lines(process.stdin)
+   *   .max((line1, line2) => line1.length - line2.length);
+   * ```
+   */
+  max(compareFn: (a: T, b: T) => MaybePromise<number>): Promise<T | undefined>;
 
   /**
    * Returns the element of `this` whose return value from `fn` is the maximum.


### PR DESCRIPTION
## Overview
Mainly this changes the `iter` classes to enforce that there is only ever one owner of the inner iterable. This reinforces the expected usage patterns and should prevent some potentially surprising behavior of trying to reuse iterables. The rest of the changes are just small cleanups.

## Demo Video or Screenshot
For example, this would have previously produced the wrong values:

```ts
const options = iter(
  allContestOptions(electionFamousNames2021Fixtures.election.contests[0])
);

const names = options.map((o) => o.name).toArray();
const ids = options.map((o) => o.id).toArray();

console.log({ names, ids });
// { names: [ 'Write-In' ], ids: [] }
```

Now it will properly throw an exception: `Error: inner iterable has already been taken`

## Testing Plan
- [x] Updated automated tests.