### PR TITLE
Fix bug in SearchSelect component to ensure falsy options are selectable

### DIFF
--- a/libs/ui/src/search_select.test.tsx
+++ b/libs/ui/src/search_select.test.tsx
@@ -255,3 +255,19 @@ test('multi disabled', () => {
   screen.getByText('Apple');
   screen.getByText('Pear');
 });
+
+test('empty option', () => {
+  render(
+    <ControlledSingleSelect
+      options={[{ value: '', label: 'None' }, ...options]}
+      ariaLabel="Choose Fruit"
+      value="apple"
+    />
+  );
+
+  screen.getByText('Apple');
+  userEvent.click(screen.getByText('Apple'));
+  userEvent.click(screen.getByText('None'));
+  expect(screen.queryByText('Apple')).not.toBeInTheDocument();
+  screen.getByText('None');
+});

--- a/libs/ui/src/search_select.tsx
+++ b/libs/ui/src/search_select.tsx
@@ -125,7 +125,7 @@ export function SearchSelect<T extends string = string>({
       value={
         Array.isArray(value)
           ? value.map((v) => findOption(options, v))
-          : value
+          : value !== undefined
           ? findOption(options, value)
           : null
       }


### PR DESCRIPTION


## Overview

Fixes: #4499 

Previously, if an option was falsy, we would set the selected value to `null`. This prevented the corresponding option label from being displayed.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
