### PR TITLE
feat(basics): add `reduce` method to `iter`

### DIFF
--- a/libs/basics/src/iterators/iterator_plus.test.ts
+++ b/libs/basics/src/iterators/iterator_plus.test.ts
@@ -467,6 +467,44 @@ test('windows', () => {
   ]);
 });
 
+test('reduce', () => {
+  expect(
+    integers()
+      .take(0)
+      .reduce((a, b) => a + b)
+  ).toBeUndefined();
+  expect(
+    integers()
+      .take(5)
+      .reduce((a, b) => a + b)
+  ).toEqual(10);
+
+  const fn1 = jest.fn((a, b) => b);
+  iter(['a', 'b', 'c']).reduce(fn1);
+  expect(fn1).toHaveBeenCalledTimes(2);
+  expect(fn1).toHaveBeenNthCalledWith(1, 'a', 'b', 0);
+  expect(fn1).toHaveBeenNthCalledWith(2, 'b', 'c', 1);
+
+  const fn2 = jest.fn((a, b) => b);
+  iter(['a', 'b', 'c']).reduce(fn2, 'z');
+  expect(fn2).toHaveBeenCalledTimes(3);
+  expect(fn2).toHaveBeenNthCalledWith(1, 'z', 'a', 0);
+  expect(fn2).toHaveBeenNthCalledWith(2, 'a', 'b', 1);
+  expect(fn2).toHaveBeenNthCalledWith(3, 'b', 'c', 2);
+
+  fc.assert(
+    fc.property(
+      fc.array(fc.anything(), { minLength: 1 }),
+      fc.array(fc.anything()),
+      (arr, init) => {
+        expect(
+          iter(arr).reduce<unknown[]>((acc, value) => [...acc, value], init)
+        ).toEqual(arr.reduce<unknown[]>((acc, value) => [...acc, value], init));
+      }
+    )
+  );
+});
+
 test('single ownership', () => {
   const it = iter([1, 2, 3]);
   expect(it.toArray()).toEqual([1, 2, 3]);

--- a/libs/basics/src/iterators/iterator_plus.ts
+++ b/libs/basics/src/iterators/iterator_plus.ts
@@ -1,4 +1,5 @@
 import { assert } from '../assert';
+import { Optional } from '../types';
 import { AsyncIteratorPlusImpl } from './async_iterator_plus';
 import { AsyncIteratorPlus, IteratorPlus } from './types';
 
@@ -300,6 +301,29 @@ export class IteratorPlusImpl<T> implements IteratorPlus<T>, AsyncIterable<T> {
       }
     }
     return [left, right];
+  }
+
+  reduce(fn: (accumulator: T, value: T, index: number) => T): Optional<T>;
+  reduce<U>(
+    fn: (accumulator: U, value: T, index: number) => U,
+    initialValue: U
+  ): U;
+  reduce<U>(
+    fn: (accumulator: T | U, value: T, index: number) => T | U,
+    initialValue?: U
+  ): Optional<T> | U {
+    const iterable = this.intoInner();
+    const iterator = iterable[Symbol.iterator]();
+    let accumulator: Optional<T | U> =
+      initialValue === undefined ? iterator.next().value : initialValue;
+    for (
+      let index = 0, next = iterator.next();
+      !next.done;
+      index += 1, next = iterator.next()
+    ) {
+      accumulator = fn(accumulator as T | U, next.value, index);
+    }
+    return accumulator;
   }
 
   rev(): IteratorPlus<T> {

--- a/libs/basics/src/iterators/types.ts
+++ b/libs/basics/src/iterators/types.ts
@@ -1,4 +1,4 @@
-import { MaybePromise } from '../types';
+import { MaybePromise, Optional } from '../types';
 
 /**
  * An iterable with a number of convenience methods for chaining. Many methods are
@@ -381,6 +381,34 @@ export interface IteratorPlus<T> extends Iterable<T> {
    * ```
    */
   partition(predicate: (item: T) => unknown): [truthy: T[], falsy: T[]];
+
+  /**
+   * Reduces elements from `this` using `fn`. Consumes the entire contained
+   * iterable.
+   *
+   * @example
+   *
+   * ```ts
+   * expect(integers().take(0).reduce((a, b) => a + b)).toBeUndefined();
+   * expect(integers().take(10).reduce((a, b) => a + b)).toEqual(45);
+   * ```
+   */
+  reduce(fn: (accumulator: T, value: T, index: number) => T): Optional<T>;
+
+  /**
+   * Reduces elements from `this` using `fn` starting with a provided initial
+   * value. Consumes the entire contained iterable.
+   *
+   * @example
+   *
+   * ```ts
+   * expect(integers().take(10).reduce((a, b) => a + b, 0)).toEqual(45);
+   * ```
+   */
+  reduce<U>(
+    fn: (accumulator: U, value: T, index: number) => U,
+    initialValue: U
+  ): U;
 
   /**
    * Yields elements in reverse order. Consumes the entire contained iterable.
@@ -1034,6 +1062,37 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
   partition(
     predicate: (item: T) => unknown
   ): Promise<[truthy: T[], falsy: T[]]>;
+
+  /**
+   * Reduces elements from `this` using `fn`. Consumes the entire contained
+   * iterable.
+   *
+   * @example
+   *
+   * ```ts
+   * const input = fs.createReadStream('file.txt', { encoding: 'utf8' });
+   * const longestLine = await lines(input).reduce((a, b) => a.length > b.length ? a : b);
+   * ```
+   */
+  reduce(
+    fn: (accumulator: T, value: T, index: number) => MaybePromise<T>
+  ): Promise<Optional<T>>;
+
+  /**
+   * Reduces elements from `this` using `fn` starting with a provided initial
+   * value. Consumes the entire contained iterable.
+   *
+   * @example
+   *
+   * ```ts
+   * const input = fs.createReadStream('file.txt', { encoding: 'utf8' });
+   * const longestLine = await lines(input).reduce((a, b) => a.length > b.length ? a : b, '');
+   * ```
+   */
+  reduce<U>(
+    fn: (accumulator: U, value: T, index: number) => MaybePromise<U>,
+    initialValue: U
+  ): Promise<U>;
 
   /**
    * Yields elements in reverse order. Consumes the entire contained iterable.

--- a/libs/basics/src/iterators/types.ts
+++ b/libs/basics/src/iterators/types.ts
@@ -1085,8 +1085,10 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
    * @example
    *
    * ```ts
-   * const input = fs.createReadStream('file.txt', { encoding: 'utf8' });
-   * const longestLine = await lines(input).reduce((a, b) => a.length > b.length ? a : b, '');
+   * const input = fs.createReadStream('numbers.txt', { encoding: 'utf8' });
+   * const product = await lines(input)
+   *   .map(parseInt)
+   *   .reduce((acc, n) => acc * n, 1);
    * ```
    */
   reduce<U>(

--- a/libs/basics/src/iterators/types.ts
+++ b/libs/basics/src/iterators/types.ts
@@ -389,8 +389,8 @@ export interface IteratorPlus<T> extends Iterable<T> {
    * @example
    *
    * ```ts
-   * expect(integers().take(0).reduce((a, b) => a + b)).toBeUndefined();
-   * expect(integers().take(10).reduce((a, b) => a + b)).toEqual(45);
+   * expect(naturals().take(0).reduce((acc, n) => acc * n)).toBeUndefined();
+   * expect(naturals().take(10).reduce((acc, n) => acc * n)).toEqual(3_628_800);
    * ```
    */
   reduce(fn: (accumulator: T, value: T, index: number) => T): Optional<T>;
@@ -402,7 +402,7 @@ export interface IteratorPlus<T> extends Iterable<T> {
    * @example
    *
    * ```ts
-   * expect(integers().take(10).reduce((a, b) => a + b, 0)).toEqual(45);
+   * expect(naturals().take(10).reduce((acc, n) => acc * n, 1)).toEqual(3_628_800);
    * ```
    */
   reduce<U>(

--- a/libs/basics/src/iterators/types.ts
+++ b/libs/basics/src/iterators/types.ts
@@ -1070,8 +1070,10 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
    * @example
    *
    * ```ts
-   * const input = fs.createReadStream('file.txt', { encoding: 'utf8' });
-   * const longestLine = await lines(input).reduce((a, b) => a.length > b.length ? a : b);
+   * const input = fs.createReadStream('numbers.txt', { encoding: 'utf8' });
+   * const product = await lines(input)
+   *   .map(parseInt)
+   *   .reduce((acc, n) => acc * n);
    * ```
    */
   reduce(


### PR DESCRIPTION

## Overview

This was a bit of a glaring omission since it's a fairly common operation on `Array`.

## Demo Video or Screenshot

```ts
// without an explicit initial value
expect(integers().take(0).reduce((a, b) => a + b)).toBeUndefined();
expect(integers().take(10).reduce((a, b) => a + b)).toEqual(45);

// with an explicit initial value
expect(integers().take(0).reduce((a, b) => a + b, 0)).toEqual(0);
```

## Testing Plan
Updated automated tests.