### PR TITLE
[i18n/audio] Add <UiStringsScreenReader> to trigger audio from focus/click events

### DIFF
--- a/libs/ui/src/hooks/use_audio_controls.ts
+++ b/libs/ui/src/hooks/use_audio_controls.ts
@@ -1,20 +1,8 @@
 import { AudioControls } from '@votingworks/types';
 import { useAudioContext } from '../ui_strings/audio_context';
+import { useUiStringScreenReaderContext } from '../ui_strings/ui_string_screen_reader';
 
 function noOp() {}
-
-/**
- * Replays the current or last-played audio by re-triggering a focus event on
- * the currently active element, if any.
- */
-function replay() {
-  const { activeElement } = window.document;
-
-  if (activeElement instanceof HTMLElement) {
-    activeElement.blur();
-    activeElement.focus();
-  }
-}
 
 /**
  * Provides an API for modifying UiString screen reader audio settings.
@@ -24,6 +12,7 @@ function replay() {
  */
 export function useAudioControls(): AudioControls {
   const audioContext = useAudioContext();
+  const screenReaderContext = useUiStringScreenReaderContext();
 
   return {
     decreasePlaybackRate: audioContext?.decreasePlaybackRate || noOp,
@@ -31,7 +20,7 @@ export function useAudioControls(): AudioControls {
     increasePlaybackRate: audioContext?.increasePlaybackRate || noOp,
     increaseVolume: audioContext?.increaseVolume || noOp,
     reset: audioContext?.reset || noOp,
-    replay,
+    replay: screenReaderContext?.replay || noOp,
     setIsEnabled: audioContext?.setIsEnabled || noOp,
     togglePause: audioContext?.togglePause || noOp,
   };

--- a/libs/ui/src/ui_strings/audio_context.test.tsx
+++ b/libs/ui/src/ui_strings/audio_context.test.tsx
@@ -209,6 +209,36 @@ test('enable/disable API', () => {
   expect(result.current?.playbackRate).toEqual(DEFAULT_PLAYBACK_RATE);
 });
 
+test('setIsPaused', () => {
+  const { result } = renderHook(useAudioContext, {
+    wrapper: TestContextWrapper,
+  });
+
+  act(() => result.current?.setIsEnabled(true));
+
+  jest.resetAllMocks();
+
+  // Changing from `false` to `true` should suspend the web audio context:
+  act(() => result.current?.setIsPaused(true));
+  expect(mockWebAudioContext.suspend).toHaveBeenCalled();
+  expect(mockWebAudioContext.resume).not.toHaveBeenCalled();
+  expect(mockWebAudioContext.destination.disconnect).not.toHaveBeenCalled();
+
+  jest.resetAllMocks();
+
+  // Changing from `true` to `true` should be a no-op:
+  act(() => result.current?.setIsPaused(true));
+  expect(mockWebAudioContext.resume).not.toHaveBeenCalled();
+  expect(mockWebAudioContext.suspend).not.toHaveBeenCalled();
+  expect(mockWebAudioContext.destination.disconnect).not.toHaveBeenCalled();
+
+  // Changing from `true` to `false` should resume the web audio context:
+  act(() => result.current?.setIsPaused(false));
+  expect(mockWebAudioContext.resume).toHaveBeenCalled();
+  expect(mockWebAudioContext.suspend).not.toHaveBeenCalled();
+  expect(mockWebAudioContext.destination.disconnect).not.toHaveBeenCalled();
+});
+
 test('togglePause', () => {
   const { result } = renderHook(useAudioContext, {
     wrapper: TestContextWrapper,

--- a/libs/ui/src/ui_strings/audio_context.tsx
+++ b/libs/ui/src/ui_strings/audio_context.tsx
@@ -24,9 +24,11 @@ export interface UiStringsAudioContextInterface {
   increasePlaybackRate: () => void;
   increaseVolume: () => void;
   isEnabled: boolean;
+  isPaused: boolean;
   playbackRate: number;
   reset: () => void;
   setIsEnabled: (enabled: boolean) => void;
+  setIsPaused: (paused: boolean) => void;
   togglePause: () => void;
   webAudioContext?: AudioContext;
 }
@@ -136,9 +138,11 @@ export function UiStringsAudioContextProvider(
         increasePlaybackRate,
         increaseVolume,
         isEnabled,
+        isPaused,
         playbackRate,
         reset,
         setIsEnabled,
+        setIsPaused,
         togglePause,
         webAudioContext: webAudioContextRef.current,
       }}

--- a/libs/ui/src/ui_strings/play_audio_clips.tsx
+++ b/libs/ui/src/ui_strings/play_audio_clips.tsx
@@ -1,0 +1,23 @@
+/* istanbul ignore file - pending implementation. */
+
+import React from 'react';
+
+import { LanguageCode } from '@votingworks/types';
+
+export interface ClipParams {
+  audioId: string;
+  languageCode: LanguageCode;
+}
+
+export interface PlayAudioClipsProps {
+  clips: ClipParams[];
+}
+
+export function PlayAudioClips(props: PlayAudioClipsProps): React.ReactNode {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { clips } = props;
+
+  // TODO(kofi): Flesh out.
+
+  return null;
+}

--- a/libs/ui/src/ui_strings/read_on_load.tsx
+++ b/libs/ui/src/ui_strings/read_on_load.tsx
@@ -41,7 +41,7 @@ export function ReadOnLoad(props: ReadOnLoadProps): JSX.Element {
   const currentUrl = location?.pathname;
 
   const audioContext = useAudioContext();
-  const isInAudioContext = !!audioContext;
+  const isInAudioContext = Boolean(audioContext);
 
   const containerRef = React.useRef<HTMLDivElement>(null);
 

--- a/libs/ui/src/ui_strings/read_on_load.tsx
+++ b/libs/ui/src/ui_strings/read_on_load.tsx
@@ -41,18 +41,18 @@ export function ReadOnLoad(props: ReadOnLoadProps): JSX.Element {
   const currentUrl = location?.pathname;
 
   const audioContext = useAudioContext();
-  const isAudioEnabled = audioContext?.isEnabled;
+  const isInAudioContext = !!audioContext;
 
   const containerRef = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
-    if (!containerRef.current || !isAudioEnabled) {
+    if (!containerRef.current || !isInAudioContext) {
       return;
     }
 
     containerRef.current.focus();
     containerRef.current.click();
-  }, [currentUrl, isAudioEnabled]);
+  }, [currentUrl, isInAudioContext]);
 
   return (
     <div className={className} ref={containerRef}>

--- a/libs/ui/src/ui_strings/ui_string_screen_reader.test.tsx
+++ b/libs/ui/src/ui_strings/ui_string_screen_reader.test.tsx
@@ -1,0 +1,243 @@
+import { advanceTimersAndPromises, mockOf } from '@votingworks/test-utils';
+import { LanguageCode } from '@votingworks/types';
+import userEvent from '@testing-library/user-event';
+import { act, screen, waitFor } from '../../test/react_testing_library';
+import { newTestContext } from '../../test/test_context';
+import { ClipParams, PlayAudioClips } from './play_audio_clips';
+import { appStrings } from './app_strings';
+import { AudioOnly } from './audio_only';
+import { LanguageOverride } from './language_override';
+import { Button } from '../button';
+
+jest.mock('./play_audio_clips', (): typeof import('./play_audio_clips') => ({
+  ...jest.requireActual('./play_audio_clips'),
+  PlayAudioClips: jest.fn(),
+}));
+
+const { CHINESE_SIMPLIFIED, ENGLISH, SPANISH } = LanguageCode;
+
+function getMockClipOutput(clip: ClipParams) {
+  return JSON.stringify(clip);
+}
+
+beforeAll(() => {
+  jest.useFakeTimers();
+});
+
+beforeEach(() => {
+  mockOf(PlayAudioClips).mockImplementation((props) => {
+    const { clips } = props;
+
+    return (
+      <div data-testid="mockClips">
+        {clips.map((clip) => (
+          <span data-testid="mockClipOutput" key={clip.audioId}>
+            {getMockClipOutput(clip)}
+          </span>
+        ))}
+      </div>
+    );
+  });
+});
+
+test('queues up audio for <UiString>s within focus/click event targets', async () => {
+  const { getAudioContext, mockApiClient, render } = newTestContext();
+
+  mockApiClient.getUiStringAudioIds.mockImplementation((input) => {
+    if (input.languageCode === ENGLISH) {
+      return Promise.resolve({
+        buttonDone: ['abc'],
+        titleBmdReviewScreen: ['cba'],
+      });
+    }
+
+    if (input.languageCode === SPANISH) {
+      return Promise.resolve({
+        instructionsBmdReviewPageNavigation: ['def', '123'],
+      });
+    }
+
+    return Promise.resolve({});
+  });
+
+  render(
+    <div>
+      <div data-testid="clickTarget">
+        <h1>{appStrings.titleBmdReviewScreen()}</h1>
+        <AudioOnly>
+          <LanguageOverride languageCode={SPANISH}>
+            {appStrings.instructionsBmdReviewPageNavigation()}
+          </LanguageOverride>
+        </AudioOnly>
+      </div>
+      <Button data-testid="focusTarget" onPress={() => undefined}>
+        {appStrings.buttonDone()}
+      </Button>
+    </div>
+  );
+
+  const clickTarget = await screen.findByTestId('clickTarget');
+  act(() => getAudioContext()?.setIsEnabled(true));
+
+  // Should trigger audio on click events:
+  act(() => userEvent.click(clickTarget));
+
+  const mockClipOutputs = await screen.findAllByTestId('mockClipOutput');
+  expect(mockClipOutputs).toHaveLength(3);
+  expect(mockClipOutputs[0]).toHaveTextContent(
+    getMockClipOutput({ audioId: 'cba', languageCode: ENGLISH })
+  );
+  expect(mockClipOutputs[1]).toHaveTextContent(
+    getMockClipOutput({ audioId: 'def', languageCode: SPANISH })
+  );
+  expect(mockClipOutputs[2]).toHaveTextContent(
+    getMockClipOutput({ audioId: '123', languageCode: SPANISH })
+  );
+
+  // Should trigger audio on focus events:
+  const focusTarget = screen.getByTestId('focusTarget');
+  act(() => {
+    focusTarget.dispatchEvent(new Event('focus', { bubbles: true }));
+  });
+  await waitFor(() =>
+    expect(screen.queryAllByTestId('mockClipOutput')).toHaveLength(1)
+  );
+  expect(screen.getByTestId('mockClipOutput')).toHaveTextContent(
+    getMockClipOutput({ audioId: 'abc', languageCode: ENGLISH })
+  );
+});
+
+test('resumes paused audio when user switches focus', async () => {
+  const { getAudioContext, mockApiClient, render } = newTestContext();
+
+  mockApiClient.getUiStringAudioIds.mockResolvedValue({
+    titleBmdReviewScreen: ['abc'],
+  });
+
+  render(
+    <div data-testid="clickTarget">{appStrings.titleBmdReviewScreen()}</div>
+  );
+
+  const clickTarget = await screen.findByTestId('clickTarget');
+
+  act(() => getAudioContext()?.setIsEnabled(true));
+  await advanceTimersAndPromises();
+
+  act(() => getAudioContext()?.setIsPaused(true));
+  expect(getAudioContext()?.isPaused).toEqual(true);
+
+  act(() => userEvent.click(clickTarget));
+  await advanceTimersAndPromises();
+
+  expect(getAudioContext()?.isPaused).toEqual(false);
+});
+
+test('clears audio queue on blur', async () => {
+  const { getAudioContext, mockApiClient, render } = newTestContext();
+
+  mockApiClient.getUiStringAudioIds.mockResolvedValue({
+    titleBmdReviewScreen: ['abc'],
+  });
+
+  render(
+    <div data-testid="clickTarget">{appStrings.titleBmdReviewScreen()}</div>
+  );
+
+  const clickTarget = await screen.findByTestId('clickTarget');
+  act(() => getAudioContext()?.setIsEnabled(true));
+  act(() => userEvent.click(clickTarget));
+
+  const mockClipOutput = await screen.findByTestId('mockClipOutput');
+  expect(mockClipOutput).toHaveTextContent(
+    getMockClipOutput({ audioId: 'abc', languageCode: ENGLISH })
+  );
+
+  act(() => {
+    clickTarget.dispatchEvent(new Event('blur', { bubbles: true }));
+  });
+
+  await waitFor(() =>
+    expect(screen.queryByTestId('mockClipOutput')).not.toBeInTheDocument()
+  );
+});
+
+test('triggers replay when user language is changed', async () => {
+  const { getAudioContext, getLanguageContext, mockApiClient, render } =
+    newTestContext();
+
+  mockApiClient.getUiStringAudioIds.mockImplementation((input) => {
+    if (input.languageCode === CHINESE_SIMPLIFIED) {
+      return Promise.resolve({
+        titleBmdReviewScreen: ['abc'],
+      });
+    }
+
+    if (input.languageCode === SPANISH) {
+      return Promise.resolve({
+        titleBmdReviewScreen: ['def'],
+      });
+    }
+
+    return Promise.resolve({});
+  });
+
+  render(
+    <div data-testid="clickTarget">{appStrings.titleBmdReviewScreen()}</div>
+  );
+
+  const clickTarget = await screen.findByTestId('clickTarget');
+  act(() => {
+    getAudioContext()?.setIsEnabled(true);
+    getLanguageContext()?.setLanguage(CHINESE_SIMPLIFIED);
+  });
+  act(() => userEvent.click(clickTarget));
+
+  const mockClipOutput = await screen.findByTestId('mockClipOutput');
+  expect(mockClipOutput).toHaveTextContent(
+    getMockClipOutput({ audioId: 'abc', languageCode: CHINESE_SIMPLIFIED })
+  );
+
+  act(() => getLanguageContext()?.setLanguage(SPANISH));
+
+  const updatedMockClipOutput = await screen.findByTestId('mockClipOutput');
+  expect(updatedMockClipOutput).toHaveTextContent(
+    getMockClipOutput({ audioId: 'def', languageCode: SPANISH })
+  );
+});
+
+test('is a no-op when audio is disabled', async () => {
+  const { getAudioContext, mockApiClient, render } = newTestContext();
+
+  mockApiClient.getUiStringAudioIds.mockResolvedValue({
+    titleBmdReviewScreen: ['abc'],
+  });
+
+  render(
+    <div data-testid="clickTarget">{appStrings.titleBmdReviewScreen()}</div>
+  );
+
+  const clickTarget = await screen.findByTestId('clickTarget');
+  act(() => getAudioContext()?.setIsEnabled(false));
+  act(() => userEvent.click(clickTarget));
+  await advanceTimersAndPromises();
+
+  expect(screen.queryByTestId('mockClips')).not.toBeInTheDocument();
+});
+
+test('handles missing audio ID data', async () => {
+  const { getAudioContext, mockApiClient, render } = newTestContext();
+
+  mockApiClient.getUiStringAudioIds.mockResolvedValue({});
+
+  render(
+    <div data-testid="clickTarget">{appStrings.titleBmdReviewScreen()}</div>
+  );
+
+  const clickTarget = await screen.findByTestId('clickTarget');
+  act(() => getAudioContext()?.setIsEnabled(true));
+  act(() => userEvent.click(clickTarget));
+  await advanceTimersAndPromises();
+
+  expect(screen.queryByTestId('mockClipOutput')).not.toBeInTheDocument();
+  screen.getByTestId('clickTarget');
+});

--- a/libs/ui/src/ui_strings/ui_string_screen_reader.tsx
+++ b/libs/ui/src/ui_strings/ui_string_screen_reader.tsx
@@ -1,0 +1,187 @@
+import React from 'react';
+import getDeepValue from 'lodash.get';
+
+import { Optional, assert, assertDefined } from '@votingworks/basics';
+import { LanguageCode, LanguageCodeSchema } from '@votingworks/types';
+import { useAudioContext } from './audio_context';
+import { ClipParams, PlayAudioClips } from './play_audio_clips';
+import { useCurrentLanguage } from '../hooks/use_current_language';
+import { UiStringAudioDataAttributeName } from './with_audio';
+
+const EMPTY_UI_STRING_QUEUE: UiStringParams[] = [];
+const EMPTY_CLIP_QUEUE: ClipParams[] = [];
+
+export interface UiStringScreenReaderProps {
+  children?: React.ReactNode;
+}
+
+interface UiStringParams {
+  i18nKey: string;
+  languageCode: LanguageCode;
+}
+
+export interface UiStringScreenReaderContextInterface {
+  /** Replays audio for any `UiString`s currently under focus. */
+  replay: () => void;
+}
+
+export const UiStringScreenReaderContext =
+  React.createContext<Optional<UiStringScreenReaderContextInterface>>(
+    undefined
+  );
+
+export function useUiStringScreenReaderContext(): Optional<UiStringScreenReaderContextInterface> {
+  return React.useContext(UiStringScreenReaderContext);
+}
+
+/**
+ * Monitors the DOM for click/focus user actions and plays back associated audio
+ * for all <UiString> elements within the event target.
+ */
+export function UiStringScreenReader(
+  props: UiStringScreenReaderProps
+): React.ReactNode {
+  const { children } = props;
+  const [activeEvent, setActiveEvent] = React.useState<Event>();
+  const [uiStringQueue, setUiStringQueue] = React.useState<UiStringParams[]>(
+    EMPTY_UI_STRING_QUEUE
+  );
+
+  const { api, isEnabled, setIsPaused } = assertDefined(useAudioContext());
+  const currentLanguageCode = useCurrentLanguage();
+
+  const activeLanguages = uiStringQueue.map((s) => s.languageCode);
+  const audioIdQueries = api.getAudioIds.useQueries(activeLanguages);
+
+  //
+  // Register click/focus handlers:
+  //
+  React.useEffect(() => {
+    function onFocusOrClick(event: Event) {
+      setActiveEvent(undefined);
+
+      // Run in the next tick to allow any UI updates related to the event to
+      // occur before "reading" the `UiString`s.
+      window.setTimeout(() => {
+        setActiveEvent(event);
+
+        // In case playback was paused for a previous event, unpause to ensure
+        // that the user receives audio feedback for this next event.
+        if (isEnabled) {
+          setIsPaused(false);
+        }
+      });
+    }
+
+    function onBlur() {
+      setActiveEvent(undefined);
+    }
+
+    document.addEventListener('click', onFocusOrClick, { capture: true });
+    document.addEventListener('focus', onFocusOrClick, { capture: true });
+    document.addEventListener('blur', onBlur, { capture: true });
+
+    return () => {
+      document.removeEventListener('click', onFocusOrClick, { capture: true });
+      document.removeEventListener('focus', onFocusOrClick, { capture: true });
+      document.removeEventListener('blur', onBlur, { capture: true });
+    };
+  }, [isEnabled, setIsPaused]);
+
+  //
+  // Extract and queue up i18n keys within the event target:
+  //
+  React.useEffect(() => {
+    // Clear the playback queue if the active event has been cleared:
+    if (!activeEvent) {
+      setUiStringQueue(EMPTY_UI_STRING_QUEUE);
+      return;
+    }
+
+    const { target } = activeEvent;
+    assert(target instanceof HTMLElement);
+
+    // Ignore event if the target element has since been removed from the DOM.
+    // (e.g. a button click event that triggers page navigation.)
+    /* istanbul ignore next */
+    if (!window.document.body.contains(target)) {
+      setUiStringQueue(EMPTY_UI_STRING_QUEUE);
+      return;
+    }
+
+    const { I18N_KEY, LANGUAGE_CODE } = UiStringAudioDataAttributeName;
+    const audioElements = target.querySelectorAll(`[${I18N_KEY}]`);
+    const newI18nKeys: UiStringParams[] = [];
+
+    for (const audioElement of audioElements.values()) {
+      const i18nKey = audioElement.getAttribute(I18N_KEY);
+      const languageCodeResult = LanguageCodeSchema.safeParse(
+        audioElement.getAttribute(LANGUAGE_CODE)
+      );
+
+      if (i18nKey && languageCodeResult.success) {
+        newI18nKeys.push({ i18nKey, languageCode: languageCodeResult.data });
+      }
+    }
+
+    setUiStringQueue(newI18nKeys);
+  }, [activeEvent]);
+
+  const replay = React.useCallback(() => {
+    if (activeEvent?.target) {
+      activeEvent.target.dispatchEvent(new Event('focus', { bubbles: true }));
+    }
+  }, [activeEvent]);
+
+  //
+  // When display language changes, stop playback and replay audio for focused
+  // element(s) in the new language:
+  //
+  const previousLanguageRef = React.useRef(currentLanguageCode);
+  React.useEffect(() => {
+    if (currentLanguageCode === previousLanguageRef.current) {
+      return;
+    }
+
+    // Replay audio for the active event, if any, in the new language:
+    replay();
+
+    previousLanguageRef.current = currentLanguageCode;
+  }, [currentLanguageCode, replay]);
+
+  let clipQueue = EMPTY_CLIP_QUEUE;
+
+  const isDataReady = Object.values(audioIdQueries).every((q) => q.isSuccess);
+  if (isDataReady) {
+    clipQueue = uiStringQueue.flatMap(({ i18nKey, languageCode }) => {
+      const audioIdMappings = assertDefined(audioIdQueries[languageCode]).data;
+      const matchingAudioIds = getDeepValue(audioIdMappings, i18nKey);
+
+      if (!Array.isArray(matchingAudioIds)) {
+        // TODO(kofi): start asserting that audio ID data is available once
+        // we're sure it won't break for dev fixtures.
+        return [];
+      }
+
+      return matchingAudioIds.map(
+        (audioId): ClipParams => ({ audioId, languageCode })
+      );
+    });
+  }
+
+  const memoizedClipQueue = React.useMemo(
+    () => clipQueue,
+    // Using a stringified audioId queue as a proxy for deep equality here to
+    // make sure the `PlayAudioClips.clips` prop value only changes when the
+    // queue is cleared/changed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [clipQueue.map((c) => c.audioId).join(',')]
+  );
+
+  return (
+    <UiStringScreenReaderContext.Provider value={{ replay }}>
+      {isEnabled && <PlayAudioClips clips={memoizedClipQueue} />}
+      {children}
+    </UiStringScreenReaderContext.Provider>
+  );
+}

--- a/libs/ui/src/ui_strings/ui_strings_context.tsx
+++ b/libs/ui/src/ui_strings/ui_strings_context.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { UiStringsReactQueryApi } from '../hooks/ui_strings_api';
 import { LanguageContextProvider } from './language_context';
 import { UiStringsAudioContextProvider } from './audio_context';
+import { UiStringScreenReader } from './ui_string_screen_reader';
 import { KeyboardShortcutHandlers } from './keyboard_shortcut_handlers';
 
 export interface UiStringsContextProviderProps {
@@ -34,7 +35,7 @@ export function UiStringsContextProvider(
         content
       ) : (
         <UiStringsAudioContextProvider api={api}>
-          {content}
+          <UiStringScreenReader>{content}</UiStringScreenReader>
         </UiStringsAudioContextProvider>
       )}
     </LanguageContextProvider>


### PR DESCRIPTION
## Overview

Adding a `<UiStringsScreenReader>`, installed via `<UiStringsContextProvider>`. 

Listens for `focus`/`click` events and queues up audio for any voter-facing strings contained in the event target (using recently added `data-i18n-key` and `data-language-code` attributes available on `<UiString>`s).

This doesn't yet include the actual audio player -- will be following up with additional PRs to flesh out that functionality.

## Demo Video or Screenshot [ 🔊 ]

https://github.com/votingworks/vxsuite/assets/264902/8f4a1c51-3d11-4e2c-b1c2-5f9ace44a8b1

## Testing Plan
- New & updated unit test cases.
- Manual verification with a prototype audio player & demo data.

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
