### PR TITLE
Add ballot cast confirmation screen to mark-scan

### DIFF
--- a/apps/mark-scan/backend/src/custom-paper-handler/constants.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/constants.ts
@@ -13,6 +13,7 @@ export const RESET_AFTER_JAM_DELAY_MS = 3_000;
 // declaring a jam state during rear ejection. Expected time for a successful
 // ballot cast is is about 3.5 seconds.
 export const DELAY_BEFORE_DECLARING_REAR_JAM_MS = 7_000;
+export const SUCCESS_NOTIFICATION_DURATION_MS = 5_000;
 
 export const SCAN_DPI = 72;
 export const PRINT_DPI = 200;

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -39,6 +39,7 @@ import {
   DEVICE_STATUS_POLLING_INTERVAL_MS,
   DEVICE_STATUS_POLLING_TIMEOUT_MS,
   RESET_AFTER_JAM_DELAY_MS,
+  SUCCESS_NOTIFICATION_DURATION_MS,
 } from './constants';
 import {
   isPaperInScanner,
@@ -614,11 +615,17 @@ export function buildMachine(
               await context.driver.ejectBallotToRear();
             },
             on: {
-              NO_PAPER_ANYWHERE: 'resetting_state_machine_after_success',
+              NO_PAPER_ANYWHERE: 'ballot_accepted',
               PAPER_JAM: 'jammed',
             },
             after: {
               [DELAY_BEFORE_DECLARING_REAR_JAM_MS]: 'jammed',
+            },
+          },
+          ballot_accepted: {
+            after: {
+              [SUCCESS_NOTIFICATION_DURATION_MS]:
+                'resetting_state_machine_after_success',
             },
           },
           eject_to_front: {
@@ -847,6 +854,8 @@ export async function getPaperHandlerStateMachine({
           return 'jam_cleared';
         case state.matches('voting_flow.resetting_state_machine_after_jam'):
           return 'resetting_state_machine_after_jam';
+        case state.matches('voting_flow.ballot_accepted'):
+          return 'ballot_accepted';
         case state.matches('voting_flow.resetting_state_machine_after_success'):
           return 'resetting_state_machine_after_success';
         case state.matches('voting_flow.transition_interpretation'):

--- a/apps/mark-scan/backend/src/custom-paper-handler/types.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/types.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 export type SimpleStatus =
   | 'accepting_paper'
+  | 'ballot_accepted'
   | 'blank_page_interpretation'
   | 'ejecting_to_front'
   | 'ejecting_to_rear'
@@ -24,6 +25,7 @@ export type SimpleStatus =
 
 export const SimpleStatusSchema: z.ZodSchema<SimpleStatus> = z.union([
   z.literal('accepting_paper'),
+  z.literal('ballot_accepted'),
   z.literal('blank_page_interpretation'),
   z.literal('ejecting_to_front'),
   z.literal('ejecting_to_rear'),

--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -77,6 +77,7 @@ import { BlankPageInterpretationPage } from './pages/blank_page_interpretation_p
 import { PaperReloadedPage } from './pages/paper_reloaded_page';
 import { PatDeviceCalibrationPage } from './pages/pat_device_identification/pat_device_calibration_page';
 import { CastingBallotPage } from './pages/casting_ballot_page';
+import { BallotSuccessfullyCastPage } from './pages/ballot_successfully_cast_page';
 
 interface VotingState {
   votes?: VotesDict;
@@ -505,15 +506,23 @@ export function AppRoot({
         if (
           !isFeatureFlagEnabled(
             BooleanEnvironmentVariableName.SKIP_PAPER_HANDLER_HARDWARE_CHECK
-          ) &&
-          (stateMachineState === 'ejecting_to_rear' ||
-            stateMachineState === 'resetting_state_machine_after_success' ||
+          )
+        ) {
+          if (
+            stateMachineState === 'ejecting_to_rear' ||
             // Cardless voter auth is ended in the backend when the voting session ends but the frontend
             // may have a stale value. Cardless voter auth + 'not_accepting_paper' state means the frontend
             // is stale, so we want to render the previous loading screen until the frontend auth status updates.
-            stateMachineState === 'not_accepting_paper')
-        ) {
-          return <CastingBallotPage />;
+            stateMachineState === 'not_accepting_paper'
+          ) {
+            return <CastingBallotPage />;
+          }
+          if (
+            stateMachineState === 'ballot_accepted' ||
+            stateMachineState === 'resetting_state_machine_after_success'
+          ) {
+            return <BallotSuccessfullyCastPage />;
+          }
         }
 
         let ballotContextProviderChild = <Ballot />;

--- a/apps/mark-scan/frontend/src/pages/ballot_successfully_cast_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/ballot_successfully_cast_page.tsx
@@ -1,0 +1,40 @@
+import {
+  FullScreenIconWrapper,
+  H1,
+  Icons,
+  P,
+  appStrings,
+} from '@votingworks/ui';
+import styled from 'styled-components';
+import { DisplaySettingsButton } from '@votingworks/mark-flow-ui';
+import { CenteredPageLayout } from '../components/centered_page_layout';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+
+const TextContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+  margin-left: 1rem;
+`;
+
+export function BallotSuccessfullyCastPage(): JSX.Element {
+  const settingsButton = <DisplaySettingsButton />;
+  return (
+    <CenteredPageLayout voterFacing buttons={settingsButton}>
+      <Container>
+        <FullScreenIconWrapper>
+          <Icons.Done color="success" />
+        </FullScreenIconWrapper>
+        <TextContainer>
+          <H1>{appStrings.titleBallotSuccessfullyCastPage()}</H1>
+          <P>{appStrings.noteThankYouForVoting()}</P>
+        </TextContainer>
+      </Container>
+    </CenteredPageLayout>
+  );
+}

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -787,6 +787,12 @@ export const appStrings = {
     <UiString uiStringKey="titleScannerProcessingScreen">Please wait…</UiString>
   ),
 
+  titleBallotSuccessfullyCastPage: () => (
+    <UiString uiStringKey="titleBallotSuccessfullyCastPage">
+      Your ballot was cast!
+    </UiString>
+  ),
+
   titleScannerSuccessScreen: () => (
     <UiString uiStringKey="titleScannerSuccessScreen">
       Your ballot was counted!

--- a/libs/ui/src/ui_strings/app_strings_catalog/latest.json
+++ b/libs/ui/src/ui_strings/app_strings_catalog/latest.json
@@ -141,6 +141,7 @@
   "titleBallotBagFull": "Ballot Bag Full",
   "titleBallotId": "Ballot ID",
   "titleBallotStyle": "Ballot Style",
+  "titleBallotSuccessfullyCastPage": "Your ballot was cast!",
   "titleBmdAskForHelpScreen": "Ask a Poll Worker for Help",
   "titleBmdCastBallotScreen": "You’re Almost Done",
   "titleBmdIdleScreen": "Are you still voting?",


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/4475

Adds a screen to confirm a ballot was successfully cast. The screen borrows from [scan_success_screen](https://github.com/votingworks/vxsuite/blob/main/apps/scan/frontend/src/screens/scan_success_screen.tsx) in VxScan.

## Demo Video or Screenshot
![Screenshot 2024-01-25 at 9 26 49 AM](https://github.com/votingworks/vxsuite/assets/1060688/e3bd5867-1722-46ca-9528-3e9083d79b12)


## Testing Plan

- [x] manually tested
- [x] automated tests

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
