### PR TITLE
[i18n/audio] Implement <PlayAudioClips> utility component

### DIFF
--- a/libs/ui/src/ui_strings/audio_player.ts
+++ b/libs/ui/src/ui_strings/audio_player.ts
@@ -1,0 +1,30 @@
+/* istanbul ignore file - pending implementation. */
+
+import { UiStringAudioClip } from '@votingworks/types';
+
+export interface AudioPlayerParams {
+  clip: UiStringAudioClip;
+  gainDb: number;
+  playbackRate: number;
+  webAudioContext: AudioContext;
+}
+
+export interface AudioPlayer {
+  readonly play: () => Promise<void>;
+  readonly setPlaybackRate: (rate: number) => void;
+  readonly setVolume: (gainDb: number) => void;
+  readonly stop: () => void;
+}
+
+export async function newAudioPlayer(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _params: AudioPlayerParams
+): Promise<AudioPlayer> {
+  // TODO(kofi): Implement.
+  return Promise.resolve({
+    play: () => Promise.resolve(),
+    setPlaybackRate: () => {},
+    setVolume: () => {},
+    stop: () => {},
+  });
+}

--- a/libs/ui/src/ui_strings/play_audio_clips.test.tsx
+++ b/libs/ui/src/ui_strings/play_audio_clips.test.tsx
@@ -1,0 +1,244 @@
+import { LanguageCode } from '@votingworks/types';
+import { mockOf } from '@votingworks/test-utils';
+import { deferred } from '@votingworks/basics';
+
+import { newTestContext } from '../../test/test_context';
+import { PlayAudioClips } from './play_audio_clips';
+import { AudioPlayer, AudioPlayerParams, newAudioPlayer } from './audio_player';
+import { act, waitFor } from '../../test/react_testing_library';
+import { DEFAULT_GAIN_DB } from './audio_volume';
+import { DEFAULT_PLAYBACK_RATE } from './audio_playback_rate';
+
+jest.mock('./audio_player', (): typeof import('./audio_player') => ({
+  ...jest.requireActual('./audio_player'),
+  newAudioPlayer: jest.fn(),
+}));
+
+const { ENGLISH, SPANISH } = LanguageCode;
+
+function initMockPlayer() {
+  const mockPlayer: jest.Mocked<AudioPlayer> = {
+    play: jest.fn(),
+    setPlaybackRate: jest.fn(),
+    setVolume: jest.fn(),
+    stop: jest.fn(),
+  };
+
+  const mockOfNewAudioPlayer = mockOf(newAudioPlayer);
+  mockOf(mockOfNewAudioPlayer).mockResolvedValue(mockPlayer);
+
+  return { mockPlayer, mockOfNewAudioPlayer };
+}
+
+const originalWebAudioContext = window.AudioContext;
+const mockWebAudioContext = {
+  destination: {
+    disconnect: jest.fn(),
+  },
+  resume: jest.fn(),
+  suspend: jest.fn(),
+} as unknown as AudioContext;
+
+beforeEach(() => {
+  const mockAudioContextConstructor = jest.fn();
+  mockAudioContextConstructor.mockReturnValue(mockWebAudioContext);
+  window.AudioContext = mockAudioContextConstructor;
+});
+
+afterAll(() => {
+  window.AudioContext = originalWebAudioContext;
+});
+
+test('plays clips in order', async () => {
+  const { mockApiClient, render } = newTestContext();
+  mockApiClient.getAudioClips.mockResolvedValue([
+    { id: 'abc', dataBase64: 'data-for-abc', languageCode: ENGLISH },
+    { id: 'def', dataBase64: 'data-for-def', languageCode: SPANISH },
+  ]);
+
+  const { mockOfNewAudioPlayer, mockPlayer } = initMockPlayer();
+  const deferredPlayClip1 = deferred<void>();
+  mockPlayer.play.mockReturnValue(deferredPlayClip1.promise);
+
+  render(
+    <PlayAudioClips
+      clips={[
+        { audioId: 'abc', languageCode: ENGLISH },
+        { audioId: 'def', languageCode: SPANISH },
+      ]}
+    />
+  );
+
+  // Verify player instantiation and playback for the 1st clip:
+  await waitFor(() =>
+    expect(mockOfNewAudioPlayer).toHaveBeenCalledWith<[AudioPlayerParams]>({
+      clip: { id: 'abc', dataBase64: 'data-for-abc', languageCode: ENGLISH },
+      gainDb: DEFAULT_GAIN_DB,
+      playbackRate: DEFAULT_PLAYBACK_RATE,
+      webAudioContext: mockWebAudioContext,
+    })
+  );
+  expect(mockPlayer.play).toHaveBeenCalledTimes(1);
+  expect(mockOfNewAudioPlayer).toHaveBeenCalledTimes(1);
+
+  // Prep mock player for 2nd clip adn simulate first clip ending:
+  const deferredPlayClip2 = deferred<void>();
+  mockPlayer.play.mockReturnValue(deferredPlayClip2.promise);
+  act(() => deferredPlayClip1.resolve());
+
+  // Verify player instantiation and playback for the 2nd clip:
+  await waitFor(() =>
+    expect(mockOfNewAudioPlayer).toHaveBeenCalledWith<[AudioPlayerParams]>({
+      clip: { id: 'def', dataBase64: 'data-for-def', languageCode: SPANISH },
+      gainDb: DEFAULT_GAIN_DB,
+      playbackRate: DEFAULT_PLAYBACK_RATE,
+      webAudioContext: mockWebAudioContext,
+    })
+  );
+  expect(mockPlayer.play).toHaveBeenCalledTimes(2);
+  expect(mockOfNewAudioPlayer).toHaveBeenCalledTimes(2);
+
+  // Simulate end of the audio queue and expect a final `stop` call for cleanup:
+  mockPlayer.play.mockReset();
+  mockPlayer.stop.mockReset();
+  act(() => deferredPlayClip2.resolve());
+  await waitFor(() => expect(mockPlayer.stop).toHaveBeenCalled());
+  expect(mockPlayer.play).not.toHaveBeenCalled();
+
+  // Expect only 2 player instantiations over the course of the test.
+  expect(mockOfNewAudioPlayer).toHaveBeenCalledTimes(2);
+});
+
+test('playback rate follows user setting', async () => {
+  const { getAudioContext, mockApiClient, render } = newTestContext();
+  mockApiClient.getAudioClips.mockResolvedValue([
+    { id: 'abc', dataBase64: 'data-for-abc', languageCode: ENGLISH },
+  ]);
+
+  const { mockOfNewAudioPlayer, mockPlayer } = initMockPlayer();
+  mockPlayer.play.mockReturnValueOnce(deferred<void>().promise);
+
+  render(
+    <PlayAudioClips clips={[{ audioId: 'abc', languageCode: ENGLISH }]} />
+  );
+
+  await waitFor(() =>
+    expect(mockOfNewAudioPlayer).toHaveBeenCalledWith<[AudioPlayerParams]>(
+      expect.objectContaining({ playbackRate: DEFAULT_PLAYBACK_RATE })
+    )
+  );
+  expect(mockPlayer.setPlaybackRate).not.toHaveBeenCalled();
+
+  act(() => getAudioContext()?.decreasePlaybackRate());
+
+  const newPlaybackRate = getAudioContext()?.playbackRate;
+  await waitFor(() =>
+    expect(mockPlayer.setPlaybackRate).toHaveBeenLastCalledWith(newPlaybackRate)
+  );
+});
+
+test('volume follows user setting', async () => {
+  const { getAudioContext, mockApiClient, render } = newTestContext();
+  mockApiClient.getAudioClips.mockResolvedValue([
+    { id: 'abc', dataBase64: 'data-for-abc', languageCode: ENGLISH },
+  ]);
+
+  const { mockOfNewAudioPlayer, mockPlayer } = initMockPlayer();
+  mockPlayer.play.mockReturnValueOnce(deferred<void>().promise);
+
+  render(
+    <PlayAudioClips clips={[{ audioId: 'abc', languageCode: ENGLISH }]} />
+  );
+
+  await waitFor(() =>
+    expect(mockOfNewAudioPlayer).toHaveBeenCalledWith<[AudioPlayerParams]>(
+      expect.objectContaining({ gainDb: DEFAULT_GAIN_DB })
+    )
+  );
+  expect(mockPlayer.setPlaybackRate).not.toHaveBeenCalled();
+
+  act(() => getAudioContext()?.increaseVolume());
+
+  const newVolume = getAudioContext()?.gainDb;
+  await waitFor(() =>
+    expect(mockPlayer.setVolume).toHaveBeenLastCalledWith(newVolume)
+  );
+});
+
+test('stops playback and resets when clip queue is changed', async () => {
+  const { mockApiClient, render } = newTestContext();
+  mockApiClient.getAudioClips.mockResolvedValue([
+    { id: 'abc', dataBase64: 'data-for-abc', languageCode: ENGLISH },
+    { id: 'def', dataBase64: 'data-for-def', languageCode: ENGLISH },
+  ]);
+
+  const { mockOfNewAudioPlayer, mockPlayer } = initMockPlayer();
+  mockPlayer.play.mockReturnValue(deferred<void>().promise);
+
+  const { rerender } = render(
+    <PlayAudioClips clips={[{ audioId: 'abc', languageCode: ENGLISH }]} />
+  );
+
+  await waitFor(() =>
+    expect(mockOfNewAudioPlayer).toHaveBeenCalledWith<[AudioPlayerParams]>(
+      expect.objectContaining({
+        clip: { id: 'abc', dataBase64: 'data-for-abc', languageCode: ENGLISH },
+      })
+    )
+  );
+  expect(mockPlayer.stop).not.toHaveBeenCalled();
+  expect(mockPlayer.play).toHaveBeenCalledTimes(1);
+
+  rerender(
+    <PlayAudioClips clips={[{ audioId: 'def', languageCode: ENGLISH }]} />
+  );
+
+  expect(mockPlayer.stop).toHaveBeenCalled();
+  await waitFor(() =>
+    expect(mockOfNewAudioPlayer).toHaveBeenCalledWith<[AudioPlayerParams]>(
+      expect.objectContaining({
+        clip: { id: 'def', dataBase64: 'data-for-def', languageCode: ENGLISH },
+      })
+    )
+  );
+
+  expect(mockPlayer.play).toHaveBeenCalledTimes(2);
+});
+
+test('is no-op in environments with no web AudioContext support', () => {
+  window.AudioContext = originalWebAudioContext;
+  const { render } = newTestContext();
+  const { mockOfNewAudioPlayer } = initMockPlayer();
+
+  render(
+    <PlayAudioClips clips={[{ audioId: 'abc', languageCode: ENGLISH }]} />
+  );
+
+  expect(mockOfNewAudioPlayer).not.toHaveBeenCalled();
+});
+
+test('is no-op while loading clip data', () => {
+  const { mockApiClient, render } = newTestContext();
+  const { mockOfNewAudioPlayer } = initMockPlayer();
+
+  mockApiClient.getAudioClips.mockImplementation(() => new Promise(() => {}));
+
+  render(
+    <PlayAudioClips clips={[{ audioId: 'abc', languageCode: ENGLISH }]} />
+  );
+
+  expect(mockOfNewAudioPlayer).not.toHaveBeenCalled();
+});
+
+test('handles missing clip data', () => {
+  const { mockApiClient, render } = newTestContext();
+  const { mockOfNewAudioPlayer } = initMockPlayer();
+
+  mockApiClient.getAudioClips.mockResolvedValue([]);
+
+  render(
+    <PlayAudioClips clips={[{ audioId: 'abc', languageCode: ENGLISH }]} />
+  );
+
+  expect(mockOfNewAudioPlayer).not.toHaveBeenCalled();
+});

--- a/libs/ui/test/test_context.tsx
+++ b/libs/ui/test/test_context.tsx
@@ -125,7 +125,13 @@ export function newTestContext(
 
   return {
     mockApiClient,
-    render: (ui) => render(<Wrapper>{ui}</Wrapper>),
+    render: (ui) => {
+      const result = render(<Wrapper>{ui}</Wrapper>);
+      return {
+        ...result,
+        rerender: (newUi) => result.rerender(<Wrapper>{newUi}</Wrapper>),
+      };
+    },
     getAudioContext: () => currentAudioContext,
     getLanguageContext: () => currentLanguageContext,
   };


### PR DESCRIPTION
## Overview

Fleshing out `<PlayAudioClips>`, which takes in a list of audio IDs and plays their respective audio in order.

This implementation assumes that we're only ever playing audio for one section of the UI at a time -- whenever the audio ID queue changes, playback is stopped for the previous queue and started for the new queue.

Setting up a stubbed interface for the audio player for now - will implement in upcoming PR.

## Testing Plan
- Unit tests for audio queueing and playback rate/volume management.
- Manual verification with prototype audio player

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
