### PR TITLE
[i18/audio] Expose toggleEnabled() audio control API method

### DIFF
--- a/apps/mark-scan/accessible-controller/src/controllerd.rs
+++ b/apps/mark-scan/accessible-controller/src/controllerd.rs
@@ -227,10 +227,10 @@ fn handle_command(device: &mut Device, data: &[u8]) -> Result<(), CommandError> 
             }
             Button::Help => key = keyboard::Key::R,
             Button::RateDown => {
-                key = keyboard::Key::LeftBrace;
+                key = keyboard::Key::Comma;
             }
             Button::RateUp => {
-                key = keyboard::Key::RightBrace;
+                key = keyboard::Key::Dot;
             }
             Button::VolumeDown => {
                 key = keyboard::Key::Minus;

--- a/libs/test-utils/src/fake_use_audio_controls.ts
+++ b/libs/test-utils/src/fake_use_audio_controls.ts
@@ -9,6 +9,7 @@ export function fakeUseAudioControls(): AudioControls {
     reset: jest.fn(),
     replay: jest.fn(),
     setIsEnabled: jest.fn(),
+    toggleEnabled: jest.fn(),
     togglePause: jest.fn(),
   };
 }

--- a/libs/types/src/ui_audio_controls.ts
+++ b/libs/types/src/ui_audio_controls.ts
@@ -6,5 +6,6 @@ export interface AudioControls {
   replay: () => void;
   reset: () => void;
   setIsEnabled: (enabled: boolean) => void;
+  toggleEnabled: () => void;
   togglePause: () => void;
 }

--- a/libs/ui/src/hooks/use_audio_controls.test.tsx
+++ b/libs/ui/src/hooks/use_audio_controls.test.tsx
@@ -20,6 +20,7 @@ test('returns external-facing audio context API', () => {
     increaseVolume: jest.fn(),
     reset: jest.fn(),
     setIsEnabled: jest.fn(),
+    toggleEnabled: jest.fn(),
     togglePause: jest.fn(),
   } as const;
 

--- a/libs/ui/src/hooks/use_audio_controls.ts
+++ b/libs/ui/src/hooks/use_audio_controls.ts
@@ -22,6 +22,7 @@ export function useAudioControls(): AudioControls {
     reset: audioContext?.reset || noOp,
     replay: screenReaderContext?.replay || noOp,
     setIsEnabled: audioContext?.setIsEnabled || noOp,
+    toggleEnabled: audioContext?.toggleEnabled || noOp,
     togglePause: audioContext?.togglePause || noOp,
   };
 }

--- a/libs/ui/src/ui_strings/audio_context.test.tsx
+++ b/libs/ui/src/ui_strings/audio_context.test.tsx
@@ -170,7 +170,7 @@ describe('playback rate API', () => {
   });
 });
 
-test('enable/disable API', () => {
+test('setIsEnabled', () => {
   const { result } = renderHook(useAudioContext, {
     wrapper: TestContextWrapper,
   });
@@ -207,6 +207,18 @@ test('enable/disable API', () => {
   expect(result.current?.isEnabled).toEqual(true);
   expect(result.current?.gainDb).toEqual(DEFAULT_GAIN_DB);
   expect(result.current?.playbackRate).toEqual(DEFAULT_PLAYBACK_RATE);
+});
+
+test('toggleEnabled', () => {
+  const { result } = renderHook(useAudioContext, {
+    wrapper: TestContextWrapper,
+  });
+
+  act(() => result.current?.toggleEnabled());
+  expect(result.current?.isEnabled).toEqual(true);
+
+  act(() => result.current?.toggleEnabled());
+  expect(result.current?.isEnabled).toEqual(false);
 });
 
 test('setIsPaused', () => {

--- a/libs/ui/src/ui_strings/audio_context.tsx
+++ b/libs/ui/src/ui_strings/audio_context.tsx
@@ -29,6 +29,7 @@ export interface UiStringsAudioContextInterface {
   reset: () => void;
   setIsEnabled: (enabled: boolean) => void;
   setIsPaused: (paused: boolean) => void;
+  toggleEnabled: () => void;
   togglePause: () => void;
   webAudioContext?: AudioContext;
 }
@@ -128,6 +129,11 @@ export function UiStringsAudioContextProvider(
     [isPaused]
   );
 
+  const toggleEnabled = React.useCallback(
+    () => setIsEnabled(!isEnabled),
+    [isEnabled]
+  );
+
   return (
     <UiStringsAudioContext.Provider
       value={{
@@ -143,6 +149,7 @@ export function UiStringsAudioContextProvider(
         reset,
         setIsEnabled,
         setIsPaused,
+        toggleEnabled,
         togglePause,
         webAudioContext: webAudioContextRef.current,
       }}

--- a/libs/ui/src/ui_strings/keyboard_shortcut_handlers.test.tsx
+++ b/libs/ui/src/ui_strings/keyboard_shortcut_handlers.test.tsx
@@ -59,9 +59,10 @@ test('Shift+L switches display language', async () => {
 });
 
 test.each([
+  { key: 'M', expectedFnCall: audioControls.toggleEnabled },
   { key: 'R', expectedFnCall: audioControls.replay },
-  { key: '[[', expectedFnCall: audioControls.decreasePlaybackRate },
-  { key: ']]', expectedFnCall: audioControls.increasePlaybackRate },
+  { key: ',', expectedFnCall: audioControls.decreasePlaybackRate },
+  { key: '.', expectedFnCall: audioControls.increasePlaybackRate },
   { key: 'P', expectedFnCall: audioControls.togglePause },
   { key: '-', expectedFnCall: audioControls.decreaseVolume },
   { key: '=', expectedFnCall: audioControls.increaseVolume },

--- a/libs/ui/src/ui_strings/keyboard_shortcut_handlers.tsx
+++ b/libs/ui/src/ui_strings/keyboard_shortcut_handlers.tsx
@@ -27,13 +27,16 @@ export function KeyboardShortcutHandlers(): React.ReactNode {
           setLanguage(availableLanguages[nextIndex]);
           break;
         }
+        case 'M':
+          audioControls.toggleEnabled();
+          break;
         case 'R':
           audioControls.replay();
           break;
-        case '[':
+        case ',':
           audioControls.decreasePlaybackRate();
           break;
-        case ']':
+        case '.':
           audioControls.increasePlaybackRate();
           break;
         case 'P':


### PR DESCRIPTION
## Overview

Adding a `toggleEnabled()` audio control method to the `useAudioControls()` hook result for dev convenience, along with a `Shift+M` keyboard shortcut.

Also modifying the shortcut keys for playback rate adjustment from `[` and `]` to `,` and `.`. The former pair collides with the VxMark shortcuts for the "scroll down" and "select" actions respectively (unsure if there's a VxMark peripheral that triggers those keys, but figured it's easier just to remap the VxMarkScan controller).

## Testing Plan
- Updated unit tests
- Manually tested with prototype audio player

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
