### PR TITLE
[i18n/audio] Implement screen reader audio playback

### DIFF
--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -73,6 +73,7 @@
     "react-modal": "^3.16.1",
     "react-router-dom": "^5.3.4",
     "react-select": "^5.7.4",
+    "tone": "^14.7.77",
     "use-interval": "1.4.0",
     "zod": "3.14.4"
   },

--- a/libs/ui/src/ui_strings/audio_player.test.ts
+++ b/libs/ui/src/ui_strings/audio_player.test.ts
@@ -18,7 +18,6 @@ import {
   DEFAULT_PLAYBACK_RATE,
   MAX_PLAYBACK_RATE,
   MIN_PLAYBACK_RATE,
-  PLAYBACK_RATE_INCREMENT_AMOUNT,
 } from './audio_playback_rate';
 
 const SILENT_SAMPLE_VALUE = SILENT_SAMPLE_ABSOLUTE_VALUE_THRESHOLD;
@@ -328,10 +327,8 @@ test('setPlaybackRate()', async () => {
   const minPlaybackRateGrainSize = mockGrainPlayer.grainSize;
   const minPlaybackRateGrainOverlap = mockGrainPlayer.overlap;
 
-  const slowishPlaybackRate =
-    DEFAULT_PLAYBACK_RATE - PLAYBACK_RATE_INCREMENT_AMOUNT;
-  player.setPlaybackRate(slowishPlaybackRate);
-  expect(mockGrainPlayer.playbackRate).toEqual(slowishPlaybackRate);
+  player.setPlaybackRate(DEFAULT_PLAYBACK_RATE);
+  expect(mockGrainPlayer.playbackRate).toEqual(DEFAULT_PLAYBACK_RATE);
   expect(mockGrainPlayer.grainSize).not.toEqual(minPlaybackRateGrainSize);
   expect(mockGrainPlayer.overlap).not.toEqual(minPlaybackRateGrainOverlap);
 

--- a/libs/ui/src/ui_strings/audio_player.test.ts
+++ b/libs/ui/src/ui_strings/audio_player.test.ts
@@ -1,0 +1,342 @@
+import { Buffer } from 'buffer';
+import type {
+  BasicPlaybackState,
+  GrainPlayer,
+  Param,
+  ToneAudioBuffer,
+} from 'tone';
+
+import { LanguageCode, UiStringAudioClip } from '@votingworks/types';
+
+import { waitFor } from '../../test/react_testing_library';
+import {
+  SILENT_SAMPLE_ABSOLUTE_VALUE_THRESHOLD,
+  newAudioPlayer,
+} from './audio_player';
+import { MAX_GAIN_DB, MIN_GAIN_DB } from './audio_volume';
+import {
+  DEFAULT_PLAYBACK_RATE,
+  MAX_PLAYBACK_RATE,
+  MIN_PLAYBACK_RATE,
+  PLAYBACK_RATE_INCREMENT_AMOUNT,
+} from './audio_playback_rate';
+
+const SILENT_SAMPLE_VALUE = SILENT_SAMPLE_ABSOLUTE_VALUE_THRESHOLD;
+const NON_SILENT_SAMPLE_VALUE = SILENT_SAMPLE_ABSOLUTE_VALUE_THRESHOLD + 0.01;
+const FIRST_AUDIO_CHANNEL_INDEX = 0;
+
+const mockToneJsGetContext = jest.fn();
+const mockToneJsSetContext = jest.fn();
+const mockToneJsGrainPlayerConstructor = jest.fn();
+
+jest.mock('tone', () => ({
+  getContext: mockToneJsGetContext,
+  GrainPlayer: mockToneJsGrainPlayerConstructor,
+  setContext: mockToneJsSetContext,
+}));
+
+const { ENGLISH } = LanguageCode;
+
+function newMockWebAudioContext() {
+  return {
+    createBuffer: jest.fn(),
+    decodeAudioData: jest.fn(),
+    destination: { fake: 'web audio destination' },
+  } as unknown as jest.Mocked<AudioContext>;
+}
+
+function newFakeAudioBuffer(samples: number[]) {
+  return {
+    getChannelData: (channelIndex: number) => {
+      expect(channelIndex).toEqual(FIRST_AUDIO_CHANNEL_INDEX);
+      return samples;
+    },
+    length: samples.length,
+    numberOfChannels: 1,
+    sampleRate: 44100,
+  } as unknown as AudioBuffer;
+}
+
+function newMockGrainPlayer() {
+  let bufferDisposed = false;
+
+  const mockBuffer: jest.Mocked<Partial<ToneAudioBuffer>> = {
+    dispose: jest.fn().mockImplementation(() => {
+      bufferDisposed = true;
+    }),
+
+    get disposed() {
+      return bufferDisposed;
+    },
+  };
+
+  const mockVolume: Partial<Param<'decibels'>> = {
+    value: undefined,
+  };
+
+  let playerDisposed = false;
+  let playerState: BasicPlaybackState = 'stopped';
+
+  const mockPlayer: jest.Mocked<Partial<GrainPlayer>> = {
+    buffer: mockBuffer as unknown as jest.Mocked<ToneAudioBuffer>,
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+    dispose: jest.fn().mockImplementation(() => {
+      playerDisposed = true;
+    }),
+    onstop: undefined,
+    start: jest.fn().mockImplementation(() => {
+      playerState = 'started';
+    }),
+    stop: jest.fn().mockImplementation(() => {
+      playerState = 'stopped';
+    }),
+    volume: mockVolume as unknown as Param<'decibels'>,
+
+    get disposed() {
+      return playerDisposed;
+    },
+
+    get state() {
+      return playerState;
+    },
+  };
+
+  return mockPlayer as unknown as jest.Mocked<GrainPlayer>;
+}
+
+test('lazy-initializes ToneJS only once', async () => {
+  const mockWebAudioContext = newMockWebAudioContext();
+  mockWebAudioContext.decodeAudioData.mockResolvedValue(
+    newFakeAudioBuffer([1, 1, 0])
+  );
+  mockWebAudioContext.createBuffer.mockReturnValue({
+    copyToChannel: jest.fn(),
+  } as unknown as AudioBuffer);
+
+  //
+  // Expect ToneJS web audio context to be disposed and replaced with Vx web
+  // audio context.
+  //
+
+  const mockToneJsContext = {
+    dispose: jest.fn(),
+    rawContext: { foo: 'bar' },
+  } as const;
+  mockToneJsGetContext.mockReturnValue(mockToneJsContext);
+
+  await newAudioPlayer({
+    clip: { dataBase64: '', id: 'clip-1', languageCode: ENGLISH },
+    webAudioContext: mockWebAudioContext,
+  });
+
+  expect(mockToneJsContext.dispose).toHaveBeenCalledTimes(1);
+  expect(mockToneJsSetContext).toHaveBeenCalledWith(mockWebAudioContext);
+
+  //
+  // Expect subsequent initializations to be no-ops:
+  //
+
+  const updatedMockToneJsContext = {
+    dispose: jest.fn(),
+    rawContext: mockWebAudioContext,
+  } as const;
+  mockToneJsGetContext.mockReturnValue(updatedMockToneJsContext);
+  mockToneJsSetContext.mockReset();
+
+  await newAudioPlayer({
+    clip: { dataBase64: '', id: 'clip-2', languageCode: ENGLISH },
+    webAudioContext: mockWebAudioContext,
+  });
+
+  expect(updatedMockToneJsContext.dispose).not.toHaveBeenCalled();
+  expect(mockToneJsSetContext).not.toHaveBeenCalled();
+});
+
+test('trims beginning silence', async () => {
+  const testClip: UiStringAudioClip = {
+    dataBase64: 'AAAB',
+    id: 'clip-1',
+    languageCode: ENGLISH,
+  };
+
+  const mockWebAudioContext = newMockWebAudioContext();
+  mockWebAudioContext.decodeAudioData.mockImplementation((buffer) => {
+    expect(buffer).toEqual(Buffer.from(testClip.dataBase64, 'base64').buffer);
+
+    return Promise.resolve(
+      newFakeAudioBuffer([
+        0,
+        0,
+        -SILENT_SAMPLE_VALUE,
+        SILENT_SAMPLE_VALUE,
+        -NON_SILENT_SAMPLE_VALUE,
+        NON_SILENT_SAMPLE_VALUE,
+        1,
+        1,
+        0,
+      ])
+    );
+  });
+
+  const mockTrimmedAudioBuffer = {
+    copyToChannel: jest.fn(),
+  } as unknown as jest.Mocked<AudioBuffer>;
+  mockWebAudioContext.createBuffer.mockReturnValue(mockTrimmedAudioBuffer);
+
+  mockToneJsGetContext.mockReturnValue({ rawContext: mockWebAudioContext });
+
+  await newAudioPlayer({
+    clip: testClip,
+    webAudioContext: mockWebAudioContext,
+  });
+
+  expect(mockToneJsGrainPlayerConstructor).toHaveBeenCalledWith(
+    mockTrimmedAudioBuffer
+  );
+  expect(mockTrimmedAudioBuffer.copyToChannel).toHaveBeenCalledWith(
+    [-NON_SILENT_SAMPLE_VALUE, NON_SILENT_SAMPLE_VALUE, 1, 1, 0],
+    FIRST_AUDIO_CHANNEL_INDEX
+  );
+});
+
+test('play()', async () => {
+  const mockWebAudioContext = newMockWebAudioContext();
+  mockWebAudioContext.decodeAudioData.mockResolvedValue(
+    newFakeAudioBuffer([1, 1, 0])
+  );
+  mockWebAudioContext.createBuffer.mockReturnValue({
+    copyToChannel: jest.fn(),
+  } as unknown as AudioBuffer);
+
+  mockToneJsGetContext.mockReturnValue({ rawContext: mockWebAudioContext });
+
+  const mockGrainPlayer = newMockGrainPlayer();
+  mockToneJsGrainPlayerConstructor.mockReturnValue(mockGrainPlayer);
+
+  const player = await newAudioPlayer({
+    clip: { dataBase64: 'AAAB', id: 'clip-1', languageCode: ENGLISH },
+    webAudioContext: mockWebAudioContext,
+  });
+
+  //
+  // Simulate playing twice and assert that the second call is a no-op:
+  //
+
+  const onDone1 = jest.fn();
+  player.play().then(onDone1, (error) => fail(error));
+
+  const onDone2 = jest.fn();
+  player.play().then(onDone2, (error) => fail(error));
+
+  expect(mockGrainPlayer.connect).toHaveBeenCalledTimes(1);
+  expect(mockGrainPlayer.connect).toHaveBeenCalledWith(
+    mockWebAudioContext.destination
+  );
+  expect(mockGrainPlayer.start).toHaveBeenCalledTimes(1);
+
+  expect(onDone1).not.toHaveBeenCalled();
+  expect(onDone2).not.toHaveBeenCalled();
+
+  mockGrainPlayer.onstop(null as never);
+
+  await waitFor(() => expect(onDone1).toHaveBeenCalledTimes(1));
+  expect(onDone2).toHaveBeenCalledTimes(1);
+});
+
+test('stop()', async () => {
+  const mockWebAudioContext = newMockWebAudioContext();
+  mockWebAudioContext.decodeAudioData.mockResolvedValue(
+    newFakeAudioBuffer([1, 1, 0])
+  );
+  mockWebAudioContext.createBuffer.mockReturnValue({
+    copyToChannel: jest.fn(),
+  } as unknown as AudioBuffer);
+
+  mockToneJsGetContext.mockReturnValue({ rawContext: mockWebAudioContext });
+
+  const mockGrainPlayer = newMockGrainPlayer();
+  mockToneJsGrainPlayerConstructor.mockReturnValue(mockGrainPlayer);
+
+  const player = await newAudioPlayer({
+    clip: { dataBase64: 'AAAB', id: 'clip-1', languageCode: ENGLISH },
+    webAudioContext: mockWebAudioContext,
+  });
+
+  void player.play();
+
+  expect(mockGrainPlayer.disconnect).not.toHaveBeenCalled();
+  expect(mockGrainPlayer.dispose).not.toHaveBeenCalled();
+  expect(mockGrainPlayer.buffer.dispose).not.toHaveBeenCalled();
+
+  player.stop();
+  player.stop();
+
+  expect(mockGrainPlayer.disconnect).toHaveBeenCalled();
+  expect(mockGrainPlayer.dispose).toHaveBeenCalledTimes(1);
+  expect(mockGrainPlayer.buffer.dispose).toHaveBeenCalledTimes(1);
+});
+
+test('setVolume()', async () => {
+  const mockWebAudioContext = newMockWebAudioContext();
+  mockWebAudioContext.decodeAudioData.mockResolvedValue(
+    newFakeAudioBuffer([1, 1, 0])
+  );
+  mockWebAudioContext.createBuffer.mockReturnValue({
+    copyToChannel: jest.fn(),
+  } as unknown as AudioBuffer);
+
+  mockToneJsGetContext.mockReturnValue({ rawContext: mockWebAudioContext });
+
+  const mockGrainPlayer = newMockGrainPlayer();
+  mockToneJsGrainPlayerConstructor.mockReturnValue(mockGrainPlayer);
+
+  const player = await newAudioPlayer({
+    clip: { dataBase64: 'AAAB', id: 'clip-1', languageCode: ENGLISH },
+    webAudioContext: mockWebAudioContext,
+  });
+
+  player.setVolume(MAX_GAIN_DB);
+  expect(mockGrainPlayer.volume.value).toEqual(MAX_GAIN_DB);
+
+  player.setVolume(MIN_GAIN_DB);
+  expect(mockGrainPlayer.volume.value).toEqual(MIN_GAIN_DB);
+});
+
+test('setPlaybackRate()', async () => {
+  const mockWebAudioContext = newMockWebAudioContext();
+  mockWebAudioContext.decodeAudioData.mockResolvedValue(
+    newFakeAudioBuffer([1, 1, 0])
+  );
+  mockWebAudioContext.createBuffer.mockReturnValue({
+    copyToChannel: jest.fn(),
+  } as unknown as AudioBuffer);
+
+  mockToneJsGetContext.mockReturnValue({ rawContext: mockWebAudioContext });
+
+  const mockGrainPlayer = newMockGrainPlayer();
+  mockToneJsGrainPlayerConstructor.mockReturnValue(mockGrainPlayer);
+
+  const player = await newAudioPlayer({
+    clip: { dataBase64: 'AAAB', id: 'clip-1', languageCode: ENGLISH },
+    webAudioContext: mockWebAudioContext,
+  });
+
+  player.setPlaybackRate(MIN_PLAYBACK_RATE);
+  expect(mockGrainPlayer.playbackRate).toEqual(MIN_PLAYBACK_RATE);
+
+  const minPlaybackRateGrainSize = mockGrainPlayer.grainSize;
+  const minPlaybackRateGrainOverlap = mockGrainPlayer.overlap;
+
+  const slowishPlaybackRate =
+    DEFAULT_PLAYBACK_RATE - PLAYBACK_RATE_INCREMENT_AMOUNT;
+  player.setPlaybackRate(slowishPlaybackRate);
+  expect(mockGrainPlayer.playbackRate).toEqual(slowishPlaybackRate);
+  expect(mockGrainPlayer.grainSize).not.toEqual(minPlaybackRateGrainSize);
+  expect(mockGrainPlayer.overlap).not.toEqual(minPlaybackRateGrainOverlap);
+
+  player.setPlaybackRate(MAX_PLAYBACK_RATE);
+  expect(mockGrainPlayer.playbackRate).toEqual(MAX_PLAYBACK_RATE);
+  expect(mockGrainPlayer.grainSize).not.toEqual(minPlaybackRateGrainSize);
+  expect(mockGrainPlayer.overlap).not.toEqual(minPlaybackRateGrainOverlap);
+});

--- a/libs/ui/src/ui_strings/audio_player.ts
+++ b/libs/ui/src/ui_strings/audio_player.ts
@@ -46,11 +46,6 @@ const RATE_CONFIG_VERY_SLOW: RateBasedConfig = {
   grainSizeSeconds: 0.02,
 };
 
-const RATE_CONFIG_SLOW: RateBasedConfig = {
-  grainOverlapSeconds: 0.05,
-  grainSizeSeconds: 0.1,
-};
-
 const RATE_CONFIG_DEFAULT: RateBasedConfig = {
   grainOverlapSeconds: 0.05,
   grainSizeSeconds: 0.1,
@@ -125,8 +120,6 @@ export async function newAudioPlayer(
     let config = RATE_CONFIG_DEFAULT;
     if (playbackRate < 0.75) {
       config = RATE_CONFIG_VERY_SLOW;
-    } else if (playbackRate < 1) {
-      config = RATE_CONFIG_SLOW;
     }
 
     player.playbackRate = playbackRate;

--- a/libs/ui/src/ui_strings/audio_player.ts
+++ b/libs/ui/src/ui_strings/audio_player.ts
@@ -1,6 +1,16 @@
-/* istanbul ignore file - pending implementation. */
+import { Buffer } from 'buffer';
 
 import { UiStringAudioClip } from '@votingworks/types';
+import { deferred } from '@votingworks/basics';
+
+/**
+ * Lowest absolute audio sample value, between 0 and 1, considered to be
+ * non-silence.
+ *
+ * TODO(kofi): Optimise further upstream instead - we could add an audio cleanup
+ * step in VxDesign, which would be particularly useful for user-recorded audio.
+ */
+export const SILENT_SAMPLE_ABSOLUTE_VALUE_THRESHOLD = 0.0025;
 
 export interface AudioPlayerParams {
   clip: UiStringAudioClip;
@@ -14,15 +24,154 @@ export interface AudioPlayer {
   readonly stop: () => void;
 }
 
+/**
+ * ToneJS GrainPlayer configuration used for a particular playback rate.
+ *
+ * Audio grain configuration needs to be varied for slower playback rates to
+ * minimize phasing and echo artefacts. The values below have been tuned
+ * manually, but may need tweaking after some testing with a wider variety of
+ * clips.
+ *
+ * See https://en.wikipedia.org/wiki/Granular_synthesis for more background info
+ * on granular synthesis as a method of varying audio speed and pitch
+ * independently.
+ */
+interface RateBasedConfig {
+  grainSizeSeconds: number;
+  grainOverlapSeconds: number;
+}
+
+const RATE_CONFIG_VERY_SLOW: RateBasedConfig = {
+  grainOverlapSeconds: 0.025,
+  grainSizeSeconds: 0.02,
+};
+
+const RATE_CONFIG_SLOW: RateBasedConfig = {
+  grainOverlapSeconds: 0.05,
+  grainSizeSeconds: 0.1,
+};
+
+const RATE_CONFIG_DEFAULT: RateBasedConfig = {
+  grainOverlapSeconds: 0.05,
+  grainSizeSeconds: 0.1,
+};
+
+/**
+ * Lazily import and instantiate the ToneJS library to avoid the creation of the
+ * audio worker thread for apps that don't need audio (and until playback is
+ * actually needed).
+ *
+ * ToneJS also automatically creates a global web AudioContext on import, so we
+ * replace the context reference here with the one passed down from the Vx app.
+ */
+async function initializeToneJs(webAudioContext: AudioContext) {
+  const { getContext, GrainPlayer, setContext } = await import('tone');
+
+  if (getContext().rawContext !== webAudioContext) {
+    getContext().dispose();
+    setContext(webAudioContext);
+  }
+
+  return { GrainPlayer };
+}
+
+async function newToneJsGrainPlayer(params: AudioPlayerParams) {
+  const { clip, webAudioContext } = params;
+
+  const toneJsLib = initializeToneJs(webAudioContext);
+
+  const audioBuffer = await webAudioContext.decodeAudioData(
+    Buffer.from(clip.dataBase64, 'base64').buffer
+  );
+
+  //
+  // Trim silence at the beginning of clips to minimize the latency between user
+  // actions and audio feedback.
+  //
+  // [7.2-N – System response time: The system initially responds to a voter
+  // action in no more than 0.5 seconds for an audio response.]
+  //
+
+  let firstNonSilentSampleIndex = 0;
+  const audioSamples = audioBuffer.getChannelData(0);
+  for (let i = 0; i < audioBuffer.length; i += 1) {
+    if (Math.abs(audioSamples[i]) > SILENT_SAMPLE_ABSOLUTE_VALUE_THRESHOLD) {
+      firstNonSilentSampleIndex = i;
+      break;
+    }
+  }
+
+  const trimmedAudioBuffer = webAudioContext.createBuffer(
+    audioBuffer.numberOfChannels,
+    audioBuffer.length - firstNonSilentSampleIndex,
+    audioBuffer.sampleRate
+  );
+  trimmedAudioBuffer.copyToChannel(
+    audioSamples.slice(firstNonSilentSampleIndex),
+    0
+  );
+
+  const { GrainPlayer } = await toneJsLib;
+  return new GrainPlayer(trimmedAudioBuffer);
+}
+
 export async function newAudioPlayer(
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _params: AudioPlayerParams
+  params: AudioPlayerParams
 ): Promise<AudioPlayer> {
-  // TODO(kofi): Implement.
-  return Promise.resolve({
-    play: () => Promise.resolve(),
-    setPlaybackRate: () => {},
-    setVolume: () => {},
-    stop: () => {},
-  });
+  const player = await newToneJsGrainPlayer(params);
+  const deferredEnd = deferred<void>();
+
+  function setPlaybackRate(playbackRate: number) {
+    let config = RATE_CONFIG_DEFAULT;
+    if (playbackRate < 0.75) {
+      config = RATE_CONFIG_VERY_SLOW;
+    } else if (playbackRate < 1) {
+      config = RATE_CONFIG_SLOW;
+    }
+
+    player.playbackRate = playbackRate;
+    player.grainSize = config.grainSizeSeconds;
+    player.overlap = config.grainOverlapSeconds;
+  }
+
+  function setVolume(gainDb: number) {
+    player.volume.value = gainDb;
+  }
+
+  function dispose() {
+    player.disconnect();
+
+    if (!player.buffer.disposed) {
+      player.buffer.dispose();
+    }
+
+    if (!player.disposed) {
+      player.dispose();
+    }
+  }
+
+  async function play() {
+    if (player.state === 'stopped') {
+      player.onstop = () => {
+        deferredEnd.resolve();
+        dispose();
+      };
+      player.connect(params.webAudioContext.destination);
+      player.start();
+    }
+
+    await deferredEnd.promise;
+  }
+
+  function stop() {
+    player.stop();
+    dispose();
+  }
+
+  return {
+    play,
+    setPlaybackRate,
+    setVolume,
+    stop,
+  };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1024,7 +1024,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
       type-fest:
         specifier: ^0.18.0
         version: 0.18.1
@@ -1438,7 +1438,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -1821,7 +1821,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -2214,7 +2214,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -2661,7 +2661,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -2712,7 +2712,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
 
   libs/@types/compress-commons:
     dependencies:
@@ -2786,7 +2786,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
 
   libs/auth:
     dependencies:
@@ -2898,7 +2898,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
       wait-for-expect:
         specifier: ^3.0.2
         version: 3.0.2
@@ -3061,7 +3061,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
 
   libs/ballot-encoder:
     dependencies:
@@ -3122,7 +3122,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
 
   libs/ballot-interpreter:
     dependencies:
@@ -3237,7 +3237,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
 
   libs/basics:
     dependencies:
@@ -3283,7 +3283,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
 
   libs/cdf-schema-builder:
     dependencies:
@@ -3335,7 +3335,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
 
   libs/converter-nh-accuvote:
     dependencies:
@@ -3520,7 +3520,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
 
   libs/custom-scanner:
     dependencies:
@@ -3596,7 +3596,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -3681,7 +3681,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
       zod:
         specifier: 3.14.4
         version: 3.14.4
@@ -3803,7 +3803,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
 
   libs/dev-dock/frontend:
     dependencies:
@@ -3909,7 +3909,7 @@ importers:
         version: 5.3.11(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
 
   libs/eslint-plugin-vx:
     dependencies:
@@ -3988,7 +3988,7 @@ importers:
         version: 18.2.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
 
   libs/fixtures:
     dependencies:
@@ -4040,7 +4040,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
 
   libs/grout:
     dependencies:
@@ -4101,7 +4101,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
 
   libs/grout/test-utils:
     dependencies:
@@ -4141,7 +4141,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
 
   libs/hmpb/layout:
     dependencies:
@@ -4226,7 +4226,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
 
   libs/hmpb/render-backend:
     dependencies:
@@ -4481,7 +4481,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
 
   libs/mark-flow-ui:
     dependencies:
@@ -4704,7 +4704,7 @@ importers:
         version: 5.3.11(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
       util:
         specifier: ^0.12.4
         version: 0.12.4
@@ -4744,7 +4744,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
 
   libs/monorepo-utils:
     dependencies:
@@ -4814,7 +4814,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
       typescript:
         specifier: 5.2.2
         version: 5.2.2
@@ -4929,7 +4929,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
 
   libs/res-to-ts:
     dependencies:
@@ -4984,7 +4984,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
 
   libs/test-utils:
     dependencies:
@@ -5069,7 +5069,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
 
   libs/types:
     dependencies:
@@ -5160,7 +5160,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
 
   libs/types-rs: {}
 
@@ -5256,6 +5256,9 @@ importers:
       react-select:
         specifier: ^5.7.4
         version: 5.7.4(@types/react@18.2.18)(react-dom@18.2.0)(react@18.2.0)
+      tone:
+        specifier: ^14.7.77
+        version: 14.7.77
       use-interval:
         specifier: 1.4.0
         version: 1.4.0(react@18.2.0)
@@ -5424,7 +5427,7 @@ importers:
         version: 5.3.11(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
       util:
         specifier: ^0.12.4
         version: 0.12.4
@@ -5494,7 +5497,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
 
   libs/utils:
     dependencies:
@@ -5618,7 +5621,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
 
   script:
     dependencies:
@@ -8031,6 +8034,12 @@ packages:
     dependencies:
       regenerator-runtime: 0.13.11
 
+  /@babel/runtime@7.23.9:
+    resolution: {integrity: sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.14.1
+
   /@babel/template@7.22.5:
     resolution: {integrity: sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==}
     engines: {node: '>=6.9.0'}
@@ -8207,7 +8216,7 @@ packages:
     resolution: {integrity: sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==}
     dependencies:
       '@babel/helper-module-imports': 7.22.5
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
       '@emotion/hash': 0.9.1
       '@emotion/memoize': 0.8.1
       '@emotion/serialize': 1.1.2
@@ -9305,13 +9314,13 @@ packages:
   /@radix-ui/number@1.0.1:
     resolution: {integrity: sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==}
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
     dev: true
 
   /@radix-ui/primitive@1.0.1:
     resolution: {integrity: sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==}
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
     dev: true
 
   /@radix-ui/react-arrow@1.0.3(react-dom@18.2.0)(react@18.2.0):
@@ -9327,7 +9336,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
       '@radix-ui/react-primitive': 1.0.3(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -9346,7 +9355,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
       '@radix-ui/react-compose-refs': 1.0.1(react@18.2.0)
       '@radix-ui/react-context': 1.0.1(react@18.2.0)
       '@radix-ui/react-primitive': 1.0.3(react-dom@18.2.0)(react@18.2.0)
@@ -9364,7 +9373,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
       react: 18.2.0
     dev: true
 
@@ -9377,7 +9386,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
       react: 18.2.0
     dev: true
 
@@ -9390,7 +9399,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
       react: 18.2.0
     dev: true
 
@@ -9407,7 +9416,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-compose-refs': 1.0.1(react@18.2.0)
       '@radix-ui/react-primitive': 1.0.3(react-dom@18.2.0)(react@18.2.0)
@@ -9426,7 +9435,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
       react: 18.2.0
     dev: true
 
@@ -9443,7 +9452,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
       '@radix-ui/react-compose-refs': 1.0.1(react@18.2.0)
       '@radix-ui/react-primitive': 1.0.3(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-use-callback-ref': 1.0.1(react@18.2.0)
@@ -9460,7 +9469,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
       '@radix-ui/react-use-layout-effect': 1.0.1(react@18.2.0)
       react: 18.2.0
     dev: true
@@ -9478,7 +9487,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
       '@floating-ui/react-dom': 2.0.1(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-arrow': 1.0.3(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-compose-refs': 1.0.1(react@18.2.0)
@@ -9506,7 +9515,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
       '@radix-ui/react-primitive': 1.0.3(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -9525,7 +9534,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
       '@radix-ui/react-slot': 1.0.2(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -9544,7 +9553,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
       '@radix-ui/number': 1.0.1
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-collection': 1.0.3(react-dom@18.2.0)(react@18.2.0)
@@ -9579,7 +9588,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
       '@radix-ui/react-compose-refs': 1.0.1(react@18.2.0)
       react: 18.2.0
     dev: true
@@ -9593,7 +9602,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
       react: 18.2.0
     dev: true
 
@@ -9606,7 +9615,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
       '@radix-ui/react-use-callback-ref': 1.0.1(react@18.2.0)
       react: 18.2.0
     dev: true
@@ -9620,7 +9629,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
       '@radix-ui/react-use-callback-ref': 1.0.1(react@18.2.0)
       react: 18.2.0
     dev: true
@@ -9634,7 +9643,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
       react: 18.2.0
     dev: true
 
@@ -9647,7 +9656,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
       react: 18.2.0
     dev: true
 
@@ -9660,7 +9669,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
       '@radix-ui/rect': 1.0.1
       react: 18.2.0
     dev: true
@@ -9674,7 +9683,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
       '@radix-ui/react-use-layout-effect': 1.0.1(react@18.2.0)
       react: 18.2.0
     dev: true
@@ -9692,7 +9701,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
       '@radix-ui/react-primitive': 1.0.3(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -9701,7 +9710,7 @@ packages:
   /@radix-ui/rect@1.0.1:
     resolution: {integrity: sha512-fyrgCaedtvMg9NK3en0pnOYJdtfwxUcNolezkNPUsoX57X8oQk+NkqcvzHXD2uKNij6GXmWU9NDru2IWjrO4BQ==}
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
     dev: true
 
   /@rollup/pluginutils@4.2.1:
@@ -12470,6 +12479,14 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
+  /automation-events@6.0.14:
+    resolution: {integrity: sha512-CoxZlKaVDGfjdfOULxd6ws8gQ/WLCw7JXub4qb0LM55otKQL9j2BnlN07lT/0V75SGzLMOElfXpTvWqzzIHx0w==}
+    engines: {node: '>=16.1.0'}
+    dependencies:
+      '@babel/runtime': 7.23.9
+      tslib: 2.6.2
+    dev: false
+
   /available-typed-arrays@1.0.5:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
     engines: {node: '>= 0.4'}
@@ -12532,7 +12549,7 @@ packages:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
       cosmiconfig: 7.0.1
       resolve: 1.22.4
     dev: false
@@ -14148,7 +14165,7 @@ packages:
   /dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
       csstype: 3.1.2
     dev: false
 
@@ -20524,10 +20541,13 @@ packages:
     resolution: {integrity: sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==}
     dev: true
 
+  /regenerator-runtime@0.14.1:
+    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
+
   /regenerator-transform@0.15.2:
     resolution: {integrity: sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==}
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.9
     dev: true
 
   /regex-not@1.0.2:
@@ -21289,6 +21309,14 @@ packages:
     dependencies:
       escape-string-regexp: 2.0.0
 
+  /standardized-audio-context@25.3.63:
+    resolution: {integrity: sha512-6hB0GbZOx3Q0npxg1QMZTN/jioom3jMkVcr3EqZbwywytqykevtuCgZuaUJqntTzv7q2mEW9KsCUtFCpbWpCkw==}
+    dependencies:
+      '@babel/runtime': 7.23.9
+      automation-events: 6.0.14
+      tslib: 2.6.2
+    dev: false
+
   /static-extend@0.1.2:
     resolution: {integrity: sha512-72E9+uLc27Mt718pMHt9VMNiAL4LMsmDbBva8mxWUCkT07fSzEGMYUCk0XWY6lp0j6RBAG4cJ3mWuZv2OE3s0g==}
     engines: {node: '>=0.10.0'}
@@ -22008,6 +22036,13 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  /tone@14.7.77:
+    resolution: {integrity: sha512-tCfK73IkLHyzoKUvGq47gyDyxiKLFvKiVCOobynGgBB9Dl0NkxTM2p+eRJXyCYrjJwy9Y0XCMqD3uOYsYt2Fdg==}
+    dependencies:
+      standardized-audio-context: 25.3.63
+      tslib: 2.6.2
+    dev: false
+
   /touch@3.1.0:
     resolution: {integrity: sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==}
     hasBin: true
@@ -22102,7 +22137,6 @@ packages:
       semver: 7.5.4
       typescript: 5.2.2
       yargs-parser: 21.1.1
-    dev: true
 
   /ts-jest@29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2):
     resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
@@ -22138,6 +22172,7 @@ packages:
       semver: 7.5.4
       typescript: 5.2.2
       yargs-parser: 21.1.1
+    dev: true
 
   /tsconfig-paths@3.14.1:
     resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}


### PR DESCRIPTION
## Overview

Adding an `AudioPlayer` implementation for the `UiStringsScreenReader`.

Currently using the `GrainPlayer` from [`Tone.js`](https://tonejs.github.io/), which is primarily intended for music applications, but provided the least glitchy implementation of pitch-invariant playback rate control that I found. It's working well as a v1 -- we could choose to write our own implementation later down the line if we find functional or performance issues once we've tested on prod hardware.

## Limitations/TODOs:
- After some idle time with no audio playing, the next clip played stutters a for a fraction of a second, so we may need to play some quiet warmup audio at regular intervals during moments of silence to smooth that out.
- Switching up from slower playback rates causes some audio to be lost, due to way data is buffered to handle rate changes.

## Demo Video or Screenshot [ 🔊 ]

https://github.com/votingworks/vxsuite/assets/264902/c51a9a57-b4d6-4f13-b45c-d68988f46042

## Testing Plan
- Unit tests with Tone.js mocked/stubbed out
- Manual tests with audio data from VxDesign

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
