### PR TITLE
[i18n/audio] Reset language and audio settings before every new voting session

### DIFF
--- a/apps/mark-scan/frontend/src/app.test.tsx
+++ b/apps/mark-scan/frontend/src/app.test.tsx
@@ -10,7 +10,7 @@ import fetchMock from 'fetch-mock';
 import { electionGeneralDefinition } from '@votingworks/fixtures';
 import {
   useBallotStyleManager,
-  useDisplaySettingsManager,
+  useSessionSettingsManager,
 } from '@votingworks/mark-flow-ui';
 import userEvent from '@testing-library/user-event';
 import { screen } from '../test/react_testing_library';
@@ -25,7 +25,7 @@ jest.mock(
   (): typeof import('@votingworks/mark-flow-ui') => ({
     ...jest.requireActual('@votingworks/mark-flow-ui'),
     useBallotStyleManager: jest.fn(),
-    useDisplaySettingsManager: jest.fn(),
+    useSessionSettingsManager: jest.fn(),
   })
 );
 
@@ -39,7 +39,7 @@ beforeEach(() => {
 
 afterEach(() => {
   apiMock.mockApiClient.assertComplete();
-  mockOf(useDisplaySettingsManager).mockReset();
+  mockOf(useSessionSettingsManager).mockReset();
 });
 
 it('will throw an error when using default api', async () => {
@@ -110,7 +110,7 @@ it('uses display settings management hook', async () => {
 
   await advanceTimersAndPromises();
 
-  expect(mockOf(useDisplaySettingsManager)).toBeCalled();
+  expect(mockOf(useSessionSettingsManager)).toBeCalled();
 });
 
 it('uses ballot style management hook', async () => {

--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -30,6 +30,8 @@ import {
   useDevices,
   UnlockMachineScreen,
   DisplaySettingsManagerContext,
+  useAudioControls,
+  useLanguageControls,
 } from '@votingworks/ui';
 
 import { assert, throwIllegalValue } from '@votingworks/basics';
@@ -154,6 +156,8 @@ export function AppRoot({
   const displaySettingsManager = React.useContext(
     DisplaySettingsManagerContext
   );
+  const { reset: resetAudioSettings } = useAudioControls();
+  const { reset: resetLanguage } = useLanguageControls();
 
   const machineConfigQuery = getMachineConfig.useQuery();
 
@@ -225,12 +229,14 @@ export function AppRoot({
       history.push('/');
 
       if (!newShowPostVotingInstructions) {
-        // [VVSG 2.0 7.1-A] Reset to default theme when voter is done marking
+        // [VVSG 2.0 7.1-A] Reset to default settings when voter is done marking
         // their ballot:
         displaySettingsManager.resetThemes();
+        resetAudioSettings();
+        resetLanguage();
       }
     },
-    [history, displaySettingsManager]
+    [history, displaySettingsManager, resetAudioSettings, resetLanguage]
   );
 
   const unconfigure = useCallback(async () => {

--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -36,7 +36,7 @@ import { assert, throwIllegalValue } from '@votingworks/basics';
 import {
   mergeMsEitherNeitherContests,
   useBallotStyleManager,
-  useDisplaySettingsManager,
+  useSessionSettingsManager,
 } from '@votingworks/mark-flow-ui';
 import type { ElectionState } from '@votingworks/mark-scan-backend';
 import {
@@ -315,7 +315,7 @@ export function AppRoot({
     };
   }, []);
 
-  useDisplaySettingsManager({ authStatus, votes });
+  useSessionSettingsManager({ authStatus, votes });
 
   useBallotStyleManager({
     currentBallotStyleId: ballotStyleId,

--- a/apps/mark/frontend/src/app.test.tsx
+++ b/apps/mark/frontend/src/app.test.tsx
@@ -10,7 +10,7 @@ import fetchMock from 'fetch-mock';
 import { electionGeneralDefinition } from '@votingworks/fixtures';
 import {
   useBallotStyleManager,
-  useDisplaySettingsManager,
+  useSessionSettingsManager,
 } from '@votingworks/mark-flow-ui';
 import userEvent from '@testing-library/user-event';
 import { screen } from '../test/react_testing_library';
@@ -25,7 +25,7 @@ jest.mock(
   (): typeof import('@votingworks/mark-flow-ui') => ({
     ...jest.requireActual('@votingworks/mark-flow-ui'),
     useBallotStyleManager: jest.fn(),
-    useDisplaySettingsManager: jest.fn(),
+    useSessionSettingsManager: jest.fn(),
   })
 );
 
@@ -39,7 +39,7 @@ beforeEach(() => {
 
 afterEach(() => {
   apiMock.mockApiClient.assertComplete();
-  mockOf(useDisplaySettingsManager).mockReset();
+  mockOf(useSessionSettingsManager).mockReset();
 });
 
 it('will throw an error when using default api', async () => {
@@ -110,7 +110,7 @@ it('uses display settings management hook', async () => {
 
   await advanceTimersAndPromises();
 
-  expect(mockOf(useDisplaySettingsManager)).toBeCalled();
+  expect(mockOf(useSessionSettingsManager)).toBeCalled();
 });
 
 it('uses ballot style management hook', async () => {

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -36,7 +36,7 @@ import { assert, throwIllegalValue } from '@votingworks/basics';
 import {
   mergeMsEitherNeitherContests,
   CastBallotPage,
-  useDisplaySettingsManager,
+  useSessionSettingsManager,
   useBallotStyleManager,
 } from '@votingworks/mark-flow-ui';
 import type { ElectionState } from '@votingworks/mark-backend';
@@ -360,7 +360,7 @@ export function AppRoot({
     };
   }, []);
 
-  useDisplaySettingsManager({ authStatus, votes });
+  useSessionSettingsManager({ authStatus, votes });
 
   useBallotStyleManager({
     currentBallotStyleId: ballotStyleId,

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -30,6 +30,8 @@ import {
   usePrevious,
   UnlockMachineScreen,
   DisplaySettingsManagerContext,
+  useAudioControls,
+  useLanguageControls,
 } from '@votingworks/ui';
 
 import { assert, throwIllegalValue } from '@votingworks/basics';
@@ -154,6 +156,8 @@ export function AppRoot({
   const displaySettingsManager = React.useContext(
     DisplaySettingsManagerContext
   );
+  const { reset: resetAudioSettings } = useAudioControls();
+  const { reset: resetLanguage } = useLanguageControls();
 
   const machineConfigQuery = getMachineConfig.useQuery();
 
@@ -231,12 +235,14 @@ export function AppRoot({
       history.push('/');
 
       if (!newShowPostVotingInstructions) {
-        // [VVSG 2.0 7.1-A] Reset to default theme when voter is done marking
+        // [VVSG 2.0 7.1-A] Reset to default settings when voter is done marking
         // their ballot:
         displaySettingsManager.resetThemes();
+        resetAudioSettings();
+        resetLanguage();
       }
     },
-    [history, displaySettingsManager]
+    [history, displaySettingsManager, resetAudioSettings, resetLanguage]
   );
 
   const hidePostVotingInstructions = useCallback(() => {

--- a/libs/mark-flow-ui/src/hooks/use_session_settings_manager.test.tsx
+++ b/libs/mark-flow-ui/src/hooks/use_session_settings_manager.test.tsx
@@ -12,9 +12,9 @@ import {
 import { VotesDict } from '@votingworks/types';
 import { act, render } from '../../test/react_testing_library';
 import {
-  UseDisplaySettingsManagerParams,
-  useDisplaySettingsManager,
-} from './use_display_settings_manager';
+  UseSessionSettingsManagerParams,
+  useSessionSettingsManager,
+} from './use_session_settings_manager';
 
 const DEFAULT_THEME: Partial<DefaultTheme> = {
   colorMode: 'contrastMedium',
@@ -26,11 +26,11 @@ const NEW_VOTING_SESSION_VOTES = undefined;
 let currentTheme: DefaultTheme;
 let displaySettingsManager: DisplaySettingsManagerContextInterface;
 
-function TestHookWrapper(props: UseDisplaySettingsManagerParams): null {
+function TestHookWrapper(props: UseSessionSettingsManagerParams): null {
   currentTheme = React.useContext(ThemeContext);
   displaySettingsManager = React.useContext(DisplaySettingsManagerContext);
 
-  useDisplaySettingsManager(props);
+  useSessionSettingsManager(props);
 
   return null;
 }

--- a/libs/mark-flow-ui/src/hooks/use_session_settings_manager.ts
+++ b/libs/mark-flow-ui/src/hooks/use_session_settings_manager.ts
@@ -10,7 +10,7 @@ export interface UseDisplaySettingsManagerParams {
   votes?: VotesDict;
 }
 
-export function useDisplaySettingsManager(
+export function useSessionSettingsManager(
   params: UseDisplaySettingsManagerParams
 ): void {
   const { authStatus, votes } = params;

--- a/libs/mark-flow-ui/src/index.ts
+++ b/libs/mark-flow-ui/src/index.ts
@@ -6,7 +6,7 @@ export * from './components/review';
 export * from './config/globals';
 export * from './config/types';
 export * from './hooks/use_ballot_style_manager';
-export * from './hooks/use_display_settings_manager';
+export * from './hooks/use_session_settings_manager';
 export * from './pages/cast_ballot_page';
 export * from './pages/contest_page';
 export * from './pages/idle_page';

--- a/libs/ui/src/ui_strings/audio_context.test.tsx
+++ b/libs/ui/src/ui_strings/audio_context.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import {
+  DEFAULT_AUDIO_ENABLED_STATE,
   UiStringsAudioContextProvider,
   useAudioContext,
 } from './audio_context';
@@ -175,36 +176,28 @@ test('setIsEnabled', () => {
     wrapper: TestContextWrapper,
   });
 
-  expect(result.current?.isEnabled).toEqual(false);
+  expect(result.current?.isEnabled).toEqual(DEFAULT_AUDIO_ENABLED_STATE);
 
-  jest.resetAllMocks();
+  act(() => result.current?.setIsEnabled(!DEFAULT_AUDIO_ENABLED_STATE));
+  expect(result.current?.isEnabled).toEqual(!DEFAULT_AUDIO_ENABLED_STATE);
+  expect(result.current?.isPaused).toEqual(!result.current?.isEnabled);
 
-  act(() => result.current?.setIsEnabled(true));
+  act(() => result.current?.setIsEnabled(DEFAULT_AUDIO_ENABLED_STATE));
+  expect(result.current?.isEnabled).toEqual(DEFAULT_AUDIO_ENABLED_STATE);
+  expect(result.current?.isPaused).toEqual(!result.current?.isEnabled);
 
-  expect(result.current?.isEnabled).toEqual(true);
-  expect(mockWebAudioContext.resume).toHaveBeenCalled();
-  expect(mockWebAudioContext.suspend).not.toHaveBeenCalled();
-  expect(mockWebAudioContext.destination.disconnect).not.toHaveBeenCalled();
-
-  jest.resetAllMocks();
+  // Re-enabling should reset all playback settings:
 
   act(() => result.current?.setIsEnabled(false));
-
-  expect(result.current?.isEnabled).toEqual(false);
-  expect(mockWebAudioContext.suspend).toHaveBeenCalled();
-  expect(mockWebAudioContext.resume).not.toHaveBeenCalled();
-  expect(mockWebAudioContext.destination.disconnect).toHaveBeenCalled();
-
-  jest.resetAllMocks();
-
-  // Re-enabling should reset all settings:
-
   act(() => result.current?.increasePlaybackRate());
   act(() => result.current?.decreaseVolume());
 
+  expect(result.current?.isPaused).toEqual(true);
+
   act(() => result.current?.setIsEnabled(true));
 
   expect(result.current?.isEnabled).toEqual(true);
+  expect(result.current?.isPaused).toEqual(false);
   expect(result.current?.gainDb).toEqual(DEFAULT_GAIN_DB);
   expect(result.current?.playbackRate).toEqual(DEFAULT_PLAYBACK_RATE);
 });
@@ -215,10 +208,10 @@ test('toggleEnabled', () => {
   });
 
   act(() => result.current?.toggleEnabled());
-  expect(result.current?.isEnabled).toEqual(true);
+  expect(result.current?.isEnabled).toEqual(!DEFAULT_AUDIO_ENABLED_STATE);
 
   act(() => result.current?.toggleEnabled());
-  expect(result.current?.isEnabled).toEqual(false);
+  expect(result.current?.isEnabled).toEqual(DEFAULT_AUDIO_ENABLED_STATE);
 });
 
 test('setIsPaused', () => {
@@ -283,15 +276,12 @@ test('reset', () => {
   act(() => result.current?.setIsEnabled(true));
   act(() => result.current?.increasePlaybackRate());
   act(() => result.current?.decreaseVolume());
-  act(() => result.current?.togglePause());
-
-  jest.resetAllMocks();
+  act(() => result.current?.setIsPaused(false));
 
   act(() => result.current?.reset());
 
+  expect(result.current?.isEnabled).toEqual(DEFAULT_AUDIO_ENABLED_STATE);
   expect(result.current?.gainDb).toEqual(DEFAULT_GAIN_DB);
   expect(result.current?.playbackRate).toEqual(DEFAULT_PLAYBACK_RATE);
-  expect(mockWebAudioContext.resume).toHaveBeenCalled();
-  expect(mockWebAudioContext.suspend).not.toHaveBeenCalled();
-  expect(mockWebAudioContext.destination.disconnect).not.toHaveBeenCalled();
+  expect(result.current?.isPaused).toEqual(false);
 });

--- a/libs/ui/src/ui_strings/audio_context.tsx
+++ b/libs/ui/src/ui_strings/audio_context.tsx
@@ -16,6 +16,8 @@ import {
   MIN_GAIN_DB,
 } from './audio_volume';
 
+export const DEFAULT_AUDIO_ENABLED_STATE = true;
+
 export interface UiStringsAudioContextInterface {
   api: UiStringsReactQueryApi;
   decreasePlaybackRate: () => void;
@@ -63,7 +65,7 @@ export function UiStringsAudioContextProvider(
   props: UiStringsAudioContextProviderProps
 ): JSX.Element {
   const { api, children } = props;
-  const [isEnabled, setIsEnabled] = React.useState(false);
+  const [isEnabled, setIsEnabled] = React.useState(DEFAULT_AUDIO_ENABLED_STATE);
   const [isPaused, setIsPaused] = React.useState(true);
   const [playbackRate, setPlaybackRate] = React.useState<number>(
     DEFAULT_PLAYBACK_RATE
@@ -72,15 +74,20 @@ export function UiStringsAudioContextProvider(
 
   const webAudioContextRef = React.useRef(getWebAudioContextInstance());
 
-  const reset = React.useCallback(() => {
+  const resetPlaybackSettings = React.useCallback(() => {
     setGainDb(DEFAULT_GAIN_DB);
     setPlaybackRate(DEFAULT_PLAYBACK_RATE);
     setIsPaused(false);
   }, []);
 
+  const reset = React.useCallback(() => {
+    resetPlaybackSettings();
+    setIsEnabled(DEFAULT_AUDIO_ENABLED_STATE);
+  }, [resetPlaybackSettings]);
+
   React.useEffect(() => {
     if (isEnabled) {
-      reset();
+      resetPlaybackSettings();
     } else {
       // Pausing here isn't strictly necessary, since we're disconnecting the
       // context destination node from any inputs, but this makes sure any
@@ -88,7 +95,7 @@ export function UiStringsAudioContextProvider(
       setIsPaused(true);
       webAudioContextRef.current?.destination.disconnect();
     }
-  }, [isEnabled, reset]);
+  }, [isEnabled, resetPlaybackSettings]);
 
   React.useEffect(() => {
     if (!webAudioContextRef.current) {


### PR DESCRIPTION
## Overview

Resetting language and audio settings every time a new voter session is started -- hooking into the same points as the existing display settings reset logic.

Also resetting to the default language whenever a non-voter login happens during a voting session -- some translated visual elements are shared between voter and non-voter screens, like the election info bar, so this ensures that non-voters are always presented with a fully English UI.

## Testing Plan
- Additional test cases for language and audio resets
- Manual verification

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
