### PR TITLE
Support JCOP 4 Java Cards

### DIFF
--- a/libs/auth/scripts/cac/configure_simulated_cac_card.ts
+++ b/libs/auth/scripts/cac/configure_simulated_cac_card.ts
@@ -112,7 +112,7 @@ function configureKeySlotCommandApdu(
   accessMode: Byte
 ): CommandApdu {
   return new CommandApdu({
-    cla: { secure: true },
+    cla: { secureMessaging: true },
     ins: PUT_DATA_ADMIN.INS,
     p1: PUT_DATA_ADMIN.P1,
     p2: PUT_DATA_ADMIN.P2,
@@ -147,7 +147,7 @@ function configureKeySlotCommandApdu(
 
 function configureDataObjectSlotCommandApdu(objectId: Buffer): CommandApdu {
   return new CommandApdu({
-    cla: { secure: true },
+    cla: { secureMessaging: true },
     ins: PUT_DATA_ADMIN.INS,
     p1: PUT_DATA_ADMIN.P1,
     p2: PUT_DATA_ADMIN.P2,
@@ -178,7 +178,7 @@ async function runAppletConfigurationCommands(): Promise<void> {
   const apdus = [
     // Set PIN
     new CommandApdu({
-      cla: { secure: true },
+      cla: { secureMessaging: true },
       ins: CHANGE_REFERENCE_DATA_ADMIN.INS,
       p1: CHANGE_REFERENCE_DATA_ADMIN.P1,
       p2: CHANGE_REFERENCE_DATA_ADMIN.P2_PIN,
@@ -187,7 +187,7 @@ async function runAppletConfigurationCommands(): Promise<void> {
 
     // Set PUK
     new CommandApdu({
-      cla: { secure: true },
+      cla: { secureMessaging: true },
       ins: CHANGE_REFERENCE_DATA_ADMIN.INS,
       p1: CHANGE_REFERENCE_DATA_ADMIN.P1,
       p2: CHANGE_REFERENCE_DATA_ADMIN.P2_PUK,
@@ -196,7 +196,7 @@ async function runAppletConfigurationCommands(): Promise<void> {
 
     // Configure max incorrect PIN attempts
     new CommandApdu({
-      cla: { secure: true },
+      cla: { secureMessaging: true },
       ins: PUT_DATA_ADMIN.INS,
       p1: PUT_DATA_ADMIN.P1,
       p2: PUT_DATA_ADMIN.P2,

--- a/libs/auth/scripts/configure_java_card.ts
+++ b/libs/auth/scripts/configure_java_card.ts
@@ -113,7 +113,7 @@ function configureKeySlotCommandApdu(
   accessMode: Byte
 ): CommandApdu {
   return new CommandApdu({
-    cla: { secure: true },
+    cla: { secureMessaging: true },
     ins: PUT_DATA_ADMIN.INS,
     p1: PUT_DATA_ADMIN.P1,
     p2: PUT_DATA_ADMIN.P2,
@@ -148,7 +148,7 @@ function configureKeySlotCommandApdu(
 
 function configureDataObjectSlotCommandApdu(objectId: Buffer): CommandApdu {
   return new CommandApdu({
-    cla: { secure: true },
+    cla: { secureMessaging: true },
     ins: PUT_DATA_ADMIN.INS,
     p1: PUT_DATA_ADMIN.P1,
     p2: PUT_DATA_ADMIN.P2,
@@ -175,7 +175,7 @@ async function runAppletConfigurationCommands(): Promise<void> {
   const apdus = [
     // Set PIN
     new CommandApdu({
-      cla: { secure: true },
+      cla: { secureMessaging: true },
       ins: CHANGE_REFERENCE_DATA_ADMIN.INS,
       p1: CHANGE_REFERENCE_DATA_ADMIN.P1,
       p2: CHANGE_REFERENCE_DATA_ADMIN.P2_PIN,
@@ -184,7 +184,7 @@ async function runAppletConfigurationCommands(): Promise<void> {
 
     // Set PUK
     new CommandApdu({
-      cla: { secure: true },
+      cla: { secureMessaging: true },
       ins: CHANGE_REFERENCE_DATA_ADMIN.INS,
       p1: CHANGE_REFERENCE_DATA_ADMIN.P1,
       p2: CHANGE_REFERENCE_DATA_ADMIN.P2_PUK,
@@ -193,7 +193,7 @@ async function runAppletConfigurationCommands(): Promise<void> {
 
     // Configure max incorrect PIN attempts
     new CommandApdu({
-      cla: { secure: true },
+      cla: { secureMessaging: true },
       ins: PUT_DATA_ADMIN.INS,
       p1: PUT_DATA_ADMIN.P1,
       p2: PUT_DATA_ADMIN.P2,

--- a/libs/auth/src/apdu.test.ts
+++ b/libs/auth/src/apdu.test.ts
@@ -4,6 +4,7 @@ import { asHexString, Byte } from '@votingworks/types';
 
 import {
   CardCommand,
+  ClaParams,
   CommandApdu,
   constructTlv,
   parseTlv,
@@ -11,14 +12,14 @@ import {
 } from './apdu';
 
 test.each<{
-  cla?: { chained?: boolean; secure?: boolean };
+  cla?: ClaParams;
   expectedFirstByte: Byte;
 }>([
   { cla: undefined, expectedFirstByte: 0x00 },
   { cla: {}, expectedFirstByte: 0x00 },
   { cla: { chained: true }, expectedFirstByte: 0x10 },
-  { cla: { secure: true }, expectedFirstByte: 0x0c },
-  { cla: { chained: true, secure: true }, expectedFirstByte: 0x1c },
+  { cla: { secureMessaging: true }, expectedFirstByte: 0x04 },
+  { cla: { chained: true, secureMessaging: true }, expectedFirstByte: 0x14 },
 ])('CommandApdu CLA handling - $cla', ({ cla, expectedFirstByte }) => {
   const apdu = new CommandApdu({
     cla,


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/4184

This PR updates VxSuite to support our new JCOP 4 Java Card stock, while still maintaining support for our old JCOP 3 Java Card stock. The change ultimately didn't involve any machine code, just initial Java Card configuration script code, which means that we could even use JCOP 4 Java Cards on v3.1 machines that we're shipping to NH, should the need ever arise.

## Testing Plan

Tested manually with both JCOP 4 and JCOP 3 Java Cards