### PR TITLE
VxDesign: List elections using table

### DIFF
--- a/apps/design/frontend/jest.config.js
+++ b/apps/design/frontend/jest.config.js
@@ -12,8 +12,8 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: -126,
-      lines: -179,
+      branches: -119,
+      lines: -173,
     },
   },
   setupFiles: ['react-app-polyfill/jsdom'],

--- a/apps/design/frontend/src/elections_screen.test.tsx
+++ b/apps/design/frontend/src/elections_screen.test.tsx
@@ -1,0 +1,114 @@
+import { ok } from '@votingworks/basics';
+import userEvent from '@testing-library/user-event';
+import { createMemoryHistory } from 'history';
+import {
+  MockApiClient,
+  createMockApiClient,
+  provideApi,
+} from '../test/api_helpers';
+import {
+  blankElectionRecord,
+  generalElectionRecord,
+  primaryElectionRecord,
+} from '../test/fixtures';
+import { render, screen, waitFor, within } from '../test/react_testing_library';
+import { withRoute } from '../test/routing_helpers';
+import { ElectionsScreen } from './elections_screen';
+import { routes } from './routes';
+
+let apiMock: MockApiClient;
+
+beforeEach(() => {
+  apiMock = createMockApiClient();
+});
+
+afterEach(() => {
+  apiMock.assertComplete();
+});
+
+function renderScreen() {
+  const history = createMemoryHistory();
+  const result = render(
+    provideApi(
+      apiMock,
+      withRoute(<ElectionsScreen />, {
+        paramPath: routes.root.path,
+        path: routes.root.path,
+        history,
+      })
+    )
+  );
+  return {
+    ...result,
+    history,
+  };
+}
+
+test('with no elections, creating a new election', async () => {
+  apiMock.listElections.expectCallWith().resolves([]);
+  const { history } = renderScreen();
+  await screen.findByRole('heading', { name: 'Elections' });
+  screen.getByText("You haven't created any elections yet.");
+
+  apiMock.createElection
+    .expectCallWith({ electionData: undefined })
+    .resolves(ok(blankElectionRecord.id));
+  apiMock.listElections.expectCallWith().resolves([blankElectionRecord]);
+  const createElectionButton = screen.getByRole('button', {
+    name: 'Create Election',
+  });
+  userEvent.click(createElectionButton);
+  await waitFor(() => {
+    expect(history.location.pathname).toEqual(
+      `/elections/${blankElectionRecord.id}`
+    );
+  });
+});
+
+test('with elections', async () => {
+  apiMock.listElections
+    .expectCallWith()
+    .resolves([
+      generalElectionRecord,
+      { ...primaryElectionRecord, id: 'election-id-2' },
+    ]);
+  const { history } = renderScreen();
+  await screen.findByRole('heading', { name: 'Elections' });
+
+  const table = screen.getByRole('table');
+  const headers = within(table).getAllByRole('columnheader');
+  expect(headers.map((header) => header.textContent)).toEqual([
+    'Title',
+    'Date',
+    'Jurisdiction',
+    'State',
+  ]);
+  const rows = within(table).getAllByRole('row').slice(1);
+  expect(
+    rows.map((row) =>
+      within(row)
+        .getAllByRole('cell')
+        .map((cell) => cell.textContent)
+    )
+  ).toEqual([
+    [
+      generalElectionRecord.election.title,
+      '11/3/2020',
+      generalElectionRecord.election.county.name,
+      generalElectionRecord.election.state,
+    ],
+    [
+      primaryElectionRecord.election.title,
+      '9/8/2021',
+      primaryElectionRecord.election.county.name,
+      primaryElectionRecord.election.state,
+    ],
+  ]);
+
+  userEvent.click(rows[0]);
+  await waitFor(() => {
+    expect(history.location.pathname).toEqual(
+      `/elections/${generalElectionRecord.id}`
+    );
+  });
+});

--- a/apps/design/frontend/src/elections_screen.tsx
+++ b/apps/design/frontend/src/elections_screen.tsx
@@ -4,11 +4,11 @@ import {
   H1,
   P,
   Icons,
-  LinkButton,
   Button,
   MainContent,
   MainHeader,
   FileInputButton,
+  Table,
 } from '@votingworks/ui';
 import { FormEvent } from 'react';
 import { useHistory } from 'react-router-dom';
@@ -17,19 +17,15 @@ import { listElections, createElection } from './api';
 import { Column, Row } from './layout';
 import { NavScreen } from './nav_screen';
 
-const ElectionList = styled.ul`
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+const ButtonRow = styled.tr`
+  cursor: pointer;
 
-  li {
-    button {
-      width: 100%;
-      text-align: left;
-    }
+  & td {
+    padding: 0.75rem 0.5rem;
+  }
+
+  &:hover {
+    background-color: ${(p) => p.theme.colors.containerLow};
   }
 `;
 
@@ -77,26 +73,38 @@ export function ElectionsScreen(): JSX.Element | null {
         <H1>Elections</H1>
       </MainHeader>
       <MainContent>
-        <Column style={{ gap: '1rem', width: '25rem' }}>
+        <Column style={{ gap: '1rem' }}>
           {elections.length === 0 ? (
             <P>
               <Icons.Info /> You haven&apos;t created any elections yet.
             </P>
           ) : (
-            <ElectionList>
-              {elections.map(({ id, election }) => (
-                <li key={id}>
-                  <LinkButton to={`/elections/${id}`}>
-                    {election.title
-                      ? election.title +
-                        (election.date
-                          ? ` - ${new Date(election.date).toLocaleDateString()}`
-                          : '')
-                      : 'Untitled Election'}
-                  </LinkButton>
-                </li>
-              ))}
-            </ElectionList>
+            <Table>
+              <thead>
+                <tr>
+                  <th>Title</th>
+                  <th>Date</th>
+                  <th>Jurisdiction</th>
+                  <th>State</th>
+                </tr>
+              </thead>
+              <tbody>
+                {elections.map(({ id, election }) => (
+                  <ButtonRow
+                    key={id}
+                    onClick={() => history.push(`/elections/${id}`)}
+                  >
+                    <td>{election.title || 'Untitled Election'}</td>
+                    <td>
+                      {election.date &&
+                        new Date(election.date).toLocaleDateString()}
+                    </td>
+                    <td>{election.county.name}</td>
+                    <td>{election.state}</td>
+                  </ButtonRow>
+                ))}
+              </tbody>
+            </Table>
           )}
           <Row style={{ gap: '0.5rem' }}>
             <Button


### PR DESCRIPTION
## Overview

To help differentiate elections, convert the election list from a list of buttons to a table that shows title, date, jurisdiction, and state.

## Demo Video or Screenshot

https://github.com/votingworks/vxsuite/assets/530106/7123be9d-8343-4943-9517-6dbdcbe69880



## Testing Plan
Added new unit tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
