### PR TITLE
VxDesign 3.1: Support ballots without a seal

### DIFF
--- a/libs/hmpb/layout/src/layout.ts
+++ b/libs/hmpb/layout/src/layout.ts
@@ -36,6 +36,7 @@ import {
   AnyElement,
   Bubble,
   Document,
+  Image,
   Page,
   Rectangle,
   TextBox,
@@ -402,6 +403,21 @@ function HeaderAndInstructions({
   }
 
   const sealRowHeight = m.HEADER_ROW_HEIGHT - 0.5;
+  const sealBlock: Image | undefined = election.seal
+    ? {
+        type: 'Image',
+        ...gridPoint(
+          {
+            row: (m.HEADER_ROW_HEIGHT - 0.25 - sealRowHeight) / 2,
+            column: 0.5,
+          },
+          m
+        ),
+        width: gridWidth(sealRowHeight, m),
+        height: gridHeight(sealRowHeight, m),
+        contents: election.seal,
+      }
+    : undefined;
 
   const ballotModeLabel: Record<BallotMode, string> = {
     sample: 'Sample',
@@ -486,7 +502,10 @@ function HeaderAndInstructions({
     children: [
       TextBlock({
         ...gridPoint(
-          { row: m.HEADER_ROW_HEIGHT / 15, column: sealRowHeight + 1.5 },
+          {
+            row: m.HEADER_ROW_HEIGHT / 15,
+            column: sealBlock ? sealRowHeight + 1.5 : 0,
+          },
           m
         ),
         width: gridWidth(
@@ -511,19 +530,7 @@ function HeaderAndInstructions({
           },
         ],
       }),
-      {
-        type: 'Image',
-        ...gridPoint(
-          {
-            row: (m.HEADER_ROW_HEIGHT - 0.25 - sealRowHeight) / 2,
-            column: 0.5,
-          },
-          m
-        ),
-        width: gridWidth(sealRowHeight, m),
-        height: gridHeight(sealRowHeight, m),
-        contents: election.seal,
-      },
+      ...(sealBlock ? [sealBlock] : []),
       ...(clerkSignatureBlock ? [clerkSignatureBlock] : []),
     ],
   };


### PR DESCRIPTION
## Overview

Some customers don't want to show a seal.

## Demo Video or Screenshot
<img width="508" alt="Screenshot 2024-02-06 at 12 49 48 PM" src="https://github.com/votingworks/vxsuite/assets/530106/620d7c4a-9dbe-47b9-b43f-46a5b788bc88">


## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
