### PR TITLE
[BMD] Update voter-facing screen layouts to make room for language picker

### DIFF
--- a/apps/mark-scan/frontend/src/components/centered_page_layout.tsx
+++ b/apps/mark-scan/frontend/src/components/centered_page_layout.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Font, H1, Main, ReadOnLoad, Screen } from '@votingworks/ui';
-import { ButtonFooter } from '@votingworks/mark-flow-ui';
+import { VoterScreen, ButtonFooter } from '@votingworks/mark-flow-ui';
 
 export interface CenteredPageLayoutProps {
   buttons?: React.ReactNode;
@@ -22,10 +22,18 @@ export function CenteredPageLayout(
     </Font>
   );
 
+  if (voterFacing) {
+    return (
+      <VoterScreen actionButtons={buttons} centerContent padded>
+        <ReadOnLoad>{mainContent}</ReadOnLoad>
+      </VoterScreen>
+    );
+  }
+
   return (
     <Screen>
       <Main padded centerChild>
-        {voterFacing ? <ReadOnLoad>{mainContent}</ReadOnLoad> : mainContent}
+        {mainContent}
       </Main>
       {buttons && <ButtonFooter>{buttons}</ButtonFooter>}
     </Screen>

--- a/apps/mark-scan/frontend/src/lib/assistive_technology.test.tsx
+++ b/apps/mark-scan/frontend/src/lib/assistive_technology.test.tsx
@@ -1,7 +1,7 @@
 import { MemoryHardware, ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 import { electionGeneralDefinition } from '@votingworks/fixtures';
 import userEvent from '@testing-library/user-event';
-import { render, screen } from '../../test/react_testing_library';
+import { render, screen, waitFor } from '../../test/react_testing_library';
 
 import { App } from '../app';
 import { advanceTimersAndPromises } from '../../test/helpers/timers';
@@ -66,11 +66,16 @@ it('accessible controller handling works', async () => {
   expect(getActiveElement()).toHaveTextContent(contest0candidate1.name);
   userEvent.keyboard('[ArrowUp]');
   expect(getActiveElement()).toHaveTextContent(contest0candidate0.name);
+
   // test the edge case of rolling over
-  userEvent.keyboard('[ArrowUp]');
-  expect(document.activeElement!.textContent).toEqual('Next');
-  userEvent.keyboard('[ArrowDown]');
-  expect(getActiveElement()).toHaveTextContent(contest0candidate0.name);
+  await waitFor(() => {
+    userEvent.keyboard('[ArrowUp]');
+    expect(getActiveElement()).toHaveTextContent(contest0candidate1.name);
+  });
+  await waitFor(() => {
+    userEvent.keyboard('[ArrowDown]');
+    expect(getActiveElement()).toHaveTextContent(contest0candidate0.name);
+  });
 
   userEvent.keyboard('[ArrowRight]');
   await advanceTimersAndPromises();

--- a/apps/mark-scan/frontend/src/pages/ballot_successfully_cast_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/ballot_successfully_cast_page.tsx
@@ -5,13 +5,11 @@ import {
   P,
   appStrings,
 } from '@votingworks/ui';
-import { DisplaySettingsButton } from '@votingworks/mark-flow-ui';
 import { CenteredPageLayout } from '../components/centered_page_layout';
 
 export function BallotSuccessfullyCastPage(): JSX.Element {
-  const settingsButton = <DisplaySettingsButton />;
   return (
-    <CenteredPageLayout voterFacing buttons={settingsButton}>
+    <CenteredPageLayout voterFacing>
       <FullScreenIconWrapper>
         <Icons.Done color="success" />
       </FullScreenIconWrapper>

--- a/apps/mark-scan/frontend/src/pages/pat_device_identification/confirm_exit_pat_device_identification_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/pat_device_identification/confirm_exit_pat_device_identification_page.tsx
@@ -1,14 +1,6 @@
-import {
-  Main,
-  Screen,
-  H1,
-  P,
-  Button,
-  Icons,
-  ReadOnLoad,
-  appStrings,
-} from '@votingworks/ui';
-import { ButtonFooter } from '@votingworks/mark-flow-ui';
+import React from 'react';
+import { H1, P, Button, Icons, ReadOnLoad, appStrings } from '@votingworks/ui';
+import { VoterScreen } from '@votingworks/mark-flow-ui';
 import { PortraitStepInnerContainer } from './portrait_step_inner_container';
 
 interface Props {
@@ -21,24 +13,26 @@ export function ConfirmExitPatDeviceIdentificationPage({
   onPressContinue,
 }: Props): JSX.Element {
   return (
-    <Screen>
-      <Main centerChild>
-        <PortraitStepInnerContainer>
-          <ReadOnLoad>
-            <Icons.Done color="success" />
-            <H1>{appStrings.titleBmdPatCalibrationConfirmExitScreen()}</H1>
-            <P>{appStrings.instructionsBmdPatCalibrationConfirmExitScreen()}</P>
-          </ReadOnLoad>
-        </PortraitStepInnerContainer>
-      </Main>
-      <ButtonFooter>
-        <Button icon="Previous" onPress={onPressBack}>
-          {appStrings.buttonBack()}
-        </Button>
-        <Button variant="primary" rightIcon="Next" onPress={onPressContinue}>
-          {appStrings.buttonContinueVoting()}
-        </Button>
-      </ButtonFooter>
-    </Screen>
+    <VoterScreen
+      centerContent
+      actionButtons={
+        <React.Fragment>
+          <Button icon="Previous" onPress={onPressBack}>
+            {appStrings.buttonBack()}
+          </Button>
+          <Button variant="primary" rightIcon="Next" onPress={onPressContinue}>
+            {appStrings.buttonContinueVoting()}
+          </Button>
+        </React.Fragment>
+      }
+    >
+      <PortraitStepInnerContainer>
+        <ReadOnLoad>
+          <Icons.Done color="success" />
+          <H1>{appStrings.titleBmdPatCalibrationConfirmExitScreen()}</H1>
+          <P>{appStrings.instructionsBmdPatCalibrationConfirmExitScreen()}</P>
+        </ReadOnLoad>
+      </PortraitStepInnerContainer>
+    </VoterScreen>
   );
 }

--- a/apps/mark-scan/frontend/src/pages/pat_device_identification/pat_device_identification_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/pat_device_identification/pat_device_identification_page.tsx
@@ -1,6 +1,4 @@
 import {
-  Main,
-  Screen,
   P,
   Font,
   Button,
@@ -8,7 +6,7 @@ import {
   appStrings,
 } from '@votingworks/ui';
 import { useCallback, useState, useEffect } from 'react';
-import { ButtonFooter } from '@votingworks/mark-flow-ui';
+import { VoterScreen } from '@votingworks/mark-flow-ui';
 import styled from 'styled-components';
 import {
   DiagnosticScreenHeader,
@@ -78,26 +76,26 @@ export function PatDeviceIdentificationPage({
   };
 
   return (
-    <Screen>
-      <Main centerChild>
-        <ReadOnLoad>
-          <DiagnosticScreenHeader>
-            <P>
-              <Font weight="bold">
-                {appStrings.titleBmdPatCalibrationIdentificationPage()}
-              </Font>
-              <br />
-              {statusStrings[currentStepId]}
-            </P>
-          </DiagnosticScreenHeader>
-          <StepContainer fullWidth>{steps[currentStepId]}</StepContainer>
-        </ReadOnLoad>
-      </Main>
-      <ButtonFooter>
+    <VoterScreen
+      actionButtons={
         <Button onPress={onExitCalibration}>
           {appStrings.buttonBmdSkipPatCalibration()}
         </Button>
-      </ButtonFooter>
-    </Screen>
+      }
+      centerContent
+    >
+      <ReadOnLoad>
+        <DiagnosticScreenHeader>
+          <P>
+            <Font weight="bold">
+              {appStrings.titleBmdPatCalibrationIdentificationPage()}
+            </Font>
+            <br />
+            {statusStrings[currentStepId]}
+          </P>
+        </DiagnosticScreenHeader>
+        <StepContainer fullWidth>{steps[currentStepId]}</StepContainer>
+      </ReadOnLoad>
+    </VoterScreen>
   );
 }

--- a/apps/mark-scan/frontend/src/pages/validate_ballot_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/validate_ballot_page.tsx
@@ -1,12 +1,10 @@
 /* istanbul ignore file - placeholder component that will change */
-import { useContext } from 'react';
+import React from 'react';
 
 import styled from 'styled-components';
 import {
-  Screen,
   H1,
   WithScrollButtons,
-  Main,
   Button,
   appStrings,
   AudioOnly,
@@ -14,11 +12,7 @@ import {
 } from '@votingworks/ui';
 
 import { assert } from '@votingworks/basics';
-import {
-  ButtonFooter,
-  DisplaySettingsButton,
-  Review,
-} from '@votingworks/mark-flow-ui';
+import { VoterScreen, Review } from '@votingworks/mark-flow-ui';
 import {
   getElectionDefinition,
   getInterpretation,
@@ -36,14 +30,12 @@ export function ValidateBallotPage(): JSX.Element | null {
   const getInterpretationQuery = getInterpretation.useQuery();
   const getElectionDefinitionQuery = getElectionDefinition.useQuery();
   // We use the contest data stored in BallotContext but vote data from the interpreted ballot
-  const { contests, precinctId, resetBallot } = useContext(BallotContext);
+  const { contests, precinctId, resetBallot } = React.useContext(BallotContext);
 
   assert(
     typeof precinctId !== 'undefined',
     'precinctId is required to render ValidateBallotPage'
   );
-
-  const settingsButton = <DisplaySettingsButton />;
 
   const invalidateBallotMutation = invalidateBallot.useMutation();
   const validateBallotMutation = validateBallot.useMutation();
@@ -76,38 +68,38 @@ export function ValidateBallotPage(): JSX.Element | null {
   const { votes } = interpretation;
 
   return (
-    <Screen>
-      <Main flexColumn>
-        <ContentHeader>
-          <H1>{appStrings.titleBmdReviewScreen()}</H1>
-          <AudioOnly>
-            {appStrings.instructionsBmdReviewPageNavigation()}{' '}
-            {appStrings.instructionsBmdScanReviewConfirmation()}
-          </AudioOnly>
-        </ContentHeader>
-        <WithScrollButtons>
-          <Review
-            election={electionDefinition.election}
-            contests={contests}
-            precinctId={precinctId}
-            votes={votes}
-            selectionsAreEditable={false}
-          />
-        </WithScrollButtons>
-      </Main>
-      <ButtonFooter>
-        {settingsButton}
-        <Button
-          variant="danger"
-          icon="Danger"
-          onPress={invalidateBallotCallback}
-        >
-          {appStrings.buttonBallotIsIncorrect()}
-        </Button>
-        <Button onPress={validateBallotCallback}>
-          {appStrings.buttonBallotIsCorrect()}
-        </Button>
-      </ButtonFooter>
-    </Screen>
+    <VoterScreen
+      actionButtons={
+        <React.Fragment>
+          <Button
+            variant="danger"
+            icon="Danger"
+            onPress={invalidateBallotCallback}
+          >
+            {appStrings.buttonBallotIsIncorrect()}
+          </Button>
+          <Button onPress={validateBallotCallback}>
+            {appStrings.buttonBallotIsCorrect()}
+          </Button>
+        </React.Fragment>
+      }
+    >
+      <ContentHeader>
+        <H1>{appStrings.titleBmdReviewScreen()}</H1>
+        <AudioOnly>
+          {appStrings.instructionsBmdReviewPageNavigation()}{' '}
+          {appStrings.instructionsBmdScanReviewConfirmation()}
+        </AudioOnly>
+      </ContentHeader>
+      <WithScrollButtons>
+        <Review
+          election={electionDefinition.election}
+          contests={contests}
+          precinctId={precinctId}
+          votes={votes}
+          selectionsAreEditable={false}
+        />
+      </WithScrollButtons>
+    </VoterScreen>
   );
 }

--- a/apps/mark/frontend/src/lib/gamepad.test.tsx
+++ b/apps/mark/frontend/src/lib/gamepad.test.tsx
@@ -6,6 +6,7 @@ import {
   fireEvent,
   render,
   screen,
+  waitFor,
 } from '../../test/react_testing_library';
 import { App } from '../app';
 
@@ -87,10 +88,16 @@ it('gamepad controls work', async () => {
   expect(getActiveElement()).toHaveTextContent(contest0candidate0.name);
 
   // test the edge case of rolling over
-  handleGamepadButtonDown('DPadUp');
-  expect(document.activeElement!.textContent).toEqual('Next');
-  handleGamepadButtonDown('DPadDown');
-  expect(getActiveElement()).toHaveTextContent(contest0candidate0.name);
+
+  await waitFor(() => {
+    handleGamepadButtonDown('DPadUp');
+    expect(getActiveElement()).toHaveTextContent(contest0candidate1.name);
+  });
+
+  await waitFor(() => {
+    handleGamepadButtonDown('DPadDown');
+    expect(getActiveElement()).toHaveTextContent(contest0candidate0.name);
+  });
 
   handleGamepadButtonDown('DPadRight');
   await advanceTimersAndPromises();

--- a/apps/mark/integration-testing/e2e/scroll_buttons.spec.ts
+++ b/apps/mark/integration-testing/e2e/scroll_buttons.spec.ts
@@ -75,18 +75,18 @@ test('configure, open polls, and test contest scroll buttons', async ({
     })
     .click();
 
-  await page.getByText(/contest number: 1/i).waitFor();
+  await page
+    .getByText(/contest number: 1/i)
+    .first() // Rendered multiple times as visible and audio-only elements.
+    .waitFor();
   await page.getByRole('button', { name: /next/i }).click();
-  await page.getByText(/contest number: 2/i).waitFor();
   await page.getByRole('button', { name: /next/i }).click();
-  await page.getByText(/contest number: 3/i).waitFor();
 
   await expect(page.getByText('Brad Plunkard')).toBeInViewport();
 
   expect(await findMoreButtons(page)).toHaveLength(0);
 
   await page.getByRole('button', { name: /next/i }).click();
-  await page.getByText(/contest number: 4/i).waitFor();
 
   // first candidate in the list should be visible
   await expect(page.getByText('Charlene Franz')).toBeInViewport();

--- a/libs/mark-flow-ui/src/components/contest_header.tsx
+++ b/libs/mark-flow-ui/src/components/contest_header.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import {
+  AudioOnly,
   Caption,
   H2,
   NumberString,
@@ -28,22 +29,20 @@ const Container = styled.div`
   padding: 0.25rem 0.5rem 0.5rem;
 `;
 
-const ContestInfo = styled.div`
-  display: flex;
-  flex-direction: row-reverse;
-  gap: 0.5rem;
-  justify-content: space-between;
-`;
-
-function Breadcrumbs(props: BreadcrumbMetadata) {
+export function Breadcrumbs(props: BreadcrumbMetadata): React.ReactNode {
   const { ballotContestCount, contestNumber } = props;
 
   return (
     <Caption noWrap>
       {appStrings.labelContestNumber()}{' '}
-      <NumberString weight="bold" value={contestNumber} /> |{' '}
-      {appStrings.labelTotalContests()}{' '}
-      <NumberString weight="bold" value={ballotContestCount} />{' '}
+      <NumberString weight="bold" value={contestNumber} />
+      {ballotContestCount && (
+        <React.Fragment>
+          {' '}
+          | {appStrings.labelTotalContests()}{' '}
+          <NumberString weight="bold" value={ballotContestCount} />{' '}
+        </React.Fragment>
+      )}
     </Caption>
   );
 }
@@ -54,12 +53,21 @@ export function ContestHeader(props: ContestHeaderProps): JSX.Element {
   return (
     <Container id="contest-header">
       <ReadOnLoad>
-        <ContestInfo>
-          {breadcrumbs && <Breadcrumbs {...breadcrumbs} />}
+        {/*
+         * NOTE: This is visually rendered elsewhere in the screen footer, but
+         * needs to be spoken on contest navigation for the benefit of
+         * vision-impaired voters:
+         */}
+        {breadcrumbs && (
+          <AudioOnly>
+            <Breadcrumbs {...breadcrumbs} />
+          </AudioOnly>
+        )}
+        <div>
           <Caption weight="semiBold">
             {electionStrings.districtName(district)}
           </Caption>
-        </ContestInfo>
+        </div>
         <div>
           <H2 as="h1">{electionStrings.contestTitle(contest)}</H2>
         </div>

--- a/libs/mark-flow-ui/src/components/display_settings_button.tsx
+++ b/libs/mark-flow-ui/src/components/display_settings_button.tsx
@@ -1,29 +1,18 @@
-import { Button, Icons, appStrings } from '@votingworks/ui';
+import { Button, appStrings } from '@votingworks/ui';
 import { useHistory } from 'react-router-dom';
-import styled from 'styled-components';
 import { Paths } from '../config/globals';
-
-const LabelContainer = styled.span`
-  align-items: center;
-  display: flex;
-  flex-wrap: nowrap;
-  justify-content: center;
-  gap: 0.5rem;
-  text-align: left;
-`;
 
 export function DisplaySettingsButton(): JSX.Element | null {
   const history = useHistory();
 
   return (
     <Button
+      icon="Display"
       onPress={(target: string) => history.push(target)}
       value={Paths.DISPLAY_SETTINGS}
     >
-      <LabelContainer>
-        <Icons.Display />
-        {appStrings.buttonDisplaySettings()}
-      </LabelContainer>
+      {/* TODO(kofi): Update app string to "Settings". */}
+      {appStrings.buttonDisplaySettings()}
     </Button>
   );
 }

--- a/libs/mark-flow-ui/src/components/voter_screen.tsx
+++ b/libs/mark-flow-ui/src/components/voter_screen.tsx
@@ -1,0 +1,153 @@
+/* istanbul ignore file - presentational component */
+
+import React from 'react';
+import styled, { DefaultTheme } from 'styled-components';
+
+import {
+  LanguageModalButton,
+  Main,
+  Screen,
+  useScreenInfo,
+} from '@votingworks/ui';
+import { SizeMode } from '@votingworks/types';
+
+import { DisplaySettingsButton } from './display_settings_button';
+
+export interface VoterScreenProps {
+  actionButtons?: React.ReactNode;
+  breadcrumbs?: React.ReactNode;
+  children: React.ReactNode;
+  centerContent?: boolean;
+  padded?: boolean;
+}
+
+const COMPACT_SIZE_MODES = new Set<SizeMode>(['touchLarge', 'touchExtraLarge']);
+
+function isCompactMode(p: { theme: DefaultTheme }) {
+  return COMPACT_SIZE_MODES.has(p.theme.sizeMode);
+}
+
+function getButtonBarSpacingRem(p: { theme: DefaultTheme }) {
+  return isCompactMode(p) ? 0.3 : 0.5;
+}
+
+const ButtonBar = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${(p) => getButtonBarSpacingRem(p)}rem;
+  padding: ${(p) => getButtonBarSpacingRem(p)}rem;
+`;
+
+const Header = styled(ButtonBar)`
+  border-bottom: ${(p) => p.theme.sizes.bordersRem.thick}rem solid
+    ${(p) => p.theme.colors.outline};
+  order: 1;
+`;
+
+const Body = styled(Main)`
+  order: 2;
+`;
+
+const Footer = styled(ButtonBar)`
+  border-top: ${(p) => p.theme.sizes.bordersRem.thick}rem solid
+    ${(p) => p.theme.colors.outline};
+  order: 3;
+`;
+
+const SideBar = styled(ButtonBar)`
+  border-left: ${(p) => p.theme.sizes.bordersRem.thick}rem solid
+    ${(p) => p.theme.colors.outline};
+  justify-content: center;
+  max-width: 35%;
+  order: 3;
+`;
+
+const ButtonGrid = styled.div`
+  align-items: center;
+  display: grid;
+  grid-gap: ${(p) => getButtonBarSpacingRem(p)}rem;
+
+  & > * {
+    height: 100%;
+    width: 100%;
+  }
+`;
+
+const PortraitButtonGrid = styled(ButtonGrid)`
+  grid-template-columns: 1fr 1fr;
+
+  /*
+   * For single-button grids, expand the button to fill out the whole row.
+   * Particularly useful for avoiding unnecessary button text wrapping at larger
+   * display size settings.
+   */
+  & > *:first-child:last-child {
+    grid-column: 1 / span 2;
+  }
+`;
+
+const LandscapeButtonGrid = styled(ButtonGrid)`
+  grid-template-columns: 1fr;
+`;
+
+const BreadcrumbsContainer = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
+/**
+ * Base screen layout for voter-facing screens, rendered with persistent voter
+ * settings menu buttons, along with optional context-specific action buttons.
+ */
+export function VoterScreen(props: VoterScreenProps): JSX.Element {
+  const { actionButtons, breadcrumbs, centerContent, children, padded } = props;
+
+  const screenInfo = useScreenInfo();
+
+  const optionalBreadcrumbs = breadcrumbs && (
+    <BreadcrumbsContainer>{breadcrumbs}</BreadcrumbsContainer>
+  );
+
+  const menuButtons = (
+    <React.Fragment>
+      <LanguageModalButton />
+      <DisplaySettingsButton />
+    </React.Fragment>
+  );
+
+  if (screenInfo.isPortrait) {
+    return (
+      // NOTE: Elements are rendered in accessible focus order and visually
+      // re-ordered using flex ordering (see styles above).
+      <Screen flexDirection="column">
+        <Body centerChild={centerContent} flexColumn padded={padded}>
+          {children}
+        </Body>
+        {actionButtons && (
+          <Footer>
+            {optionalBreadcrumbs}
+            <PortraitButtonGrid>{actionButtons}</PortraitButtonGrid>
+          </Footer>
+        )}
+        <Header>
+          <PortraitButtonGrid>{menuButtons}</PortraitButtonGrid>
+        </Header>
+      </Screen>
+    );
+  }
+
+  return (
+    <Screen flexDirection="row">
+      <Body centerChild={centerContent} flexColumn padded={padded}>
+        {children}
+      </Body>
+      <SideBar>
+        <LandscapeButtonGrid>
+          {menuButtons}
+          {actionButtons}
+        </LandscapeButtonGrid>
+        {optionalBreadcrumbs}
+      </SideBar>
+    </Screen>
+  );
+}

--- a/libs/mark-flow-ui/src/index.ts
+++ b/libs/mark-flow-ui/src/index.ts
@@ -3,6 +3,7 @@ export * from './components/button_footer';
 export * from './components/contest';
 export * from './components/display_settings_button';
 export * from './components/review';
+export * from './components/voter_screen';
 export * from './config/globals';
 export * from './config/types';
 export * from './hooks/use_ballot_style_manager';

--- a/libs/mark-flow-ui/src/pages/cast_ballot_page.tsx
+++ b/libs/mark-flow-ui/src/pages/cast_ballot_page.tsx
@@ -5,13 +5,12 @@ import {
   H1,
   Icons,
   InsertBallotImage,
-  Main,
   P,
   ReadOnLoad,
-  Screen,
   VerifyBallotImage,
   appStrings,
 } from '@votingworks/ui';
+import { VoterScreen } from '../components/voter_screen';
 
 const Instructions = styled.ol`
   display: flex;
@@ -54,12 +53,6 @@ const InstructionImageContainer = styled.div`
   }
 `;
 
-const Done = styled.div`
-  position: absolute;
-  right: 1rem;
-  bottom: 1rem;
-`;
-
 interface Props {
   hidePostVotingInstructions: () => void;
 }
@@ -68,39 +61,39 @@ export function CastBallotPage({
   hidePostVotingInstructions,
 }: Props): JSX.Element {
   return (
-    <Screen>
-      <Main padded>
-        <ReadOnLoad>
-          <H1>{appStrings.titleBmdCastBallotScreen()}</H1>
-          <P>{appStrings.instructionsBmdCastBallotPreamble()}</P>
-          <Instructions>
-            <ListItem>
-              <InstructionImageContainer>
-                <VerifyBallotImage />
-              </InstructionImageContainer>
-              <span>{appStrings.instructionsBmdCastBallotStep1()}</span>
-            </ListItem>
-            <ListItem>
-              <InstructionImageContainer>
-                <InsertBallotImage disableAnimation />
-              </InstructionImageContainer>
-              <span>{appStrings.instructionsBmdCastBallotStep2()}</span>
-            </ListItem>
-          </Instructions>
-          <P>
-            <Icons.Info /> {appStrings.noteAskPollWorkerForHelp()}
-          </P>
-        </ReadOnLoad>
-        <Done>
-          <Button
-            onPress={hidePostVotingInstructions}
-            variant="primary"
-            icon="Done"
-          >
-            {appStrings.buttonDone()}
-          </Button>
-        </Done>
-      </Main>
-    </Screen>
+    <VoterScreen
+      actionButtons={
+        <Button
+          onPress={hidePostVotingInstructions}
+          variant="primary"
+          icon="Done"
+        >
+          {appStrings.buttonDone()}
+        </Button>
+      }
+      padded
+    >
+      <ReadOnLoad>
+        <H1>{appStrings.titleBmdCastBallotScreen()}</H1>
+        <P>{appStrings.instructionsBmdCastBallotPreamble()}</P>
+        <Instructions>
+          <ListItem>
+            <InstructionImageContainer>
+              <VerifyBallotImage />
+            </InstructionImageContainer>
+            <span>{appStrings.instructionsBmdCastBallotStep1()}</span>
+          </ListItem>
+          <ListItem>
+            <InstructionImageContainer>
+              <InsertBallotImage disableAnimation />
+            </InstructionImageContainer>
+            <span>{appStrings.instructionsBmdCastBallotStep2()}</span>
+          </ListItem>
+        </Instructions>
+        <P>
+          <Icons.Info /> {appStrings.noteAskPollWorkerForHelp()}
+        </P>
+      </ReadOnLoad>
+    </VoterScreen>
   );
 }

--- a/libs/mark-flow-ui/src/pages/contest_page.tsx
+++ b/libs/mark-flow-ui/src/pages/contest_page.tsx
@@ -10,20 +10,14 @@ import {
   PrecinctId,
   VotesDict,
 } from '@votingworks/types';
-import {
-  Screen,
-  LinkButton,
-  useScreenInfo,
-  appStrings,
-  Button,
-} from '@votingworks/ui';
+import { LinkButton, appStrings, Button } from '@votingworks/ui';
 import { assert, throwIllegalValue } from '@votingworks/basics';
 
 import { Contest, ContestProps } from '../components/contest';
-import { ButtonFooter } from '../components/button_footer';
-import { DisplaySettingsButton } from '../components/display_settings_button';
 import { ContestsWithMsEitherNeither } from '../utils/ms_either_neither_contests';
 import { VoteUpdateInteractionMethod } from '../config/types';
+import { BreadcrumbMetadata, Breadcrumbs } from '../components/contest_header';
+import { VoterScreen } from '../components/voter_screen';
 
 export interface ContestPageProps {
   contests: ContestsWithMsEitherNeither;
@@ -56,8 +50,6 @@ export function ContestPage(props: ContestPageProps): JSX.Element {
     votes,
   } = props;
 
-  const screenInfo = useScreenInfo();
-
   // eslint-disable-next-line vx/gts-safe-number-parse
   const currentContestIndex = parseInt(contestNumber, 10);
   const contest = contests[currentContestIndex];
@@ -79,8 +71,12 @@ export function ContestPage(props: ContestPageProps): JSX.Element {
 
   const vote = votes[contest.id];
 
-  const ballotContestNumber = currentContestIndex + 1;
-  const ballotContestsLength = contests.length;
+  const breadcrumbsMetadata: BreadcrumbMetadata | undefined = isReviewMode
+    ? undefined
+    : {
+        contestNumber: currentContestIndex + 1,
+        ballotContestCount: contests.length,
+      };
 
   const isVoteComplete = (() => {
     switch (contest.type) {
@@ -163,34 +159,31 @@ export function ContestPage(props: ContestPageProps): JSX.Element {
     </LinkButton>
   );
 
-  const settingsButton = <DisplaySettingsButton />;
-
   return (
-    <Screen flexDirection={screenInfo.isPortrait ? 'column' : 'row'}>
+    <VoterScreen
+      actionButtons={
+        <React.Fragment>
+          {isReviewMode ? (
+            reviewScreenButton
+          ) : (
+            <React.Fragment>
+              {previousContestButton}
+              {nextContestButton}
+            </React.Fragment>
+          )}
+        </React.Fragment>
+      }
+      breadcrumbs={
+        breadcrumbsMetadata && <Breadcrumbs {...breadcrumbsMetadata} />
+      }
+    >
       <Contest
-        breadcrumbs={{
-          ballotContestCount: ballotContestsLength,
-          contestNumber: ballotContestNumber,
-        }}
         election={electionDefinition.election}
+        breadcrumbs={breadcrumbsMetadata}
         contest={contest}
         votes={votes}
         updateVote={handleUpdateVote}
       />
-      <ButtonFooter>
-        {isReviewMode ? (
-          <React.Fragment>
-            {settingsButton}
-            {reviewScreenButton}
-          </React.Fragment>
-        ) : (
-          <React.Fragment>
-            {previousContestButton}
-            {settingsButton}
-            {nextContestButton}
-          </React.Fragment>
-        )}
-      </ButtonFooter>
-    </Screen>
+    </VoterScreen>
   );
 }

--- a/libs/mark-flow-ui/src/pages/review_page.tsx
+++ b/libs/mark-flow-ui/src/pages/review_page.tsx
@@ -2,11 +2,8 @@
 import styled from 'styled-components';
 import {
   LinkButton,
-  Main,
-  Screen,
   H1,
   WithScrollButtons,
-  useScreenInfo,
   appStrings,
   AudioOnly,
   ReadOnLoad,
@@ -15,10 +12,9 @@ import {
 import { assert } from '@votingworks/basics';
 
 import { ElectionDefinition, PrecinctId, VotesDict } from '@votingworks/types';
-import { ButtonFooter } from '../components/button_footer';
 import { Review, ReviewProps } from '../components/review';
 import { ContestsWithMsEitherNeither } from '../utils/ms_either_neither_contests';
-import { DisplaySettingsButton } from '../components/display_settings_button';
+import { VoterScreen } from '../components/voter_screen';
 
 const ContentHeader = styled(ReadOnLoad)`
   padding: 0.5rem 0.75rem 0;
@@ -43,8 +39,6 @@ export function ReviewPage(props: ReviewPageProps): JSX.Element {
     votes,
   } = props;
 
-  const screenInfo = useScreenInfo();
-
   assert(
     electionDefinition,
     'electionDefinition is required to render ReviewPage'
@@ -60,32 +54,24 @@ export function ReviewPage(props: ReviewPageProps): JSX.Element {
     </LinkButton>
   );
 
-  const settingsButton = <DisplaySettingsButton />;
-
   return (
-    <Screen flexDirection={screenInfo.isPortrait ? 'column' : 'row'}>
-      <Main flexColumn>
-        <ContentHeader>
-          <H1>{appStrings.titleBmdReviewScreen()}</H1>
-          <AudioOnly>
-            {appStrings.instructionsBmdReviewPageNavigation()}{' '}
-            {appStrings.instructionsBmdReviewPageChangingVotes()}
-          </AudioOnly>
-        </ContentHeader>
-        <WithScrollButtons>
-          <Review
-            election={electionDefinition.election}
-            contests={contests}
-            precinctId={precinctId}
-            votes={votes}
-            returnToContest={returnToContest}
-          />
-        </WithScrollButtons>
-      </Main>
-      <ButtonFooter>
-        {settingsButton}
-        {printMyBallotButton}
-      </ButtonFooter>
-    </Screen>
+    <VoterScreen actionButtons={printMyBallotButton}>
+      <ContentHeader>
+        <H1>{appStrings.titleBmdReviewScreen()}</H1>
+        <AudioOnly>
+          {appStrings.instructionsBmdReviewPageNavigation()}{' '}
+          {appStrings.instructionsBmdReviewPageChangingVotes()}
+        </AudioOnly>
+      </ContentHeader>
+      <WithScrollButtons>
+        <Review
+          election={electionDefinition.election}
+          contests={contests}
+          precinctId={precinctId}
+          votes={votes}
+          returnToContest={returnToContest}
+        />
+      </WithScrollButtons>
+    </VoterScreen>
   );
 }

--- a/libs/mark-flow-ui/src/pages/start_page.tsx
+++ b/libs/mark-flow-ui/src/pages/start_page.tsx
@@ -2,7 +2,6 @@
 import { singlePrecinctSelectionFor } from '@votingworks/utils';
 import styled from 'styled-components';
 import {
-  Screen,
   Button,
   appStrings,
   AudioOnly,
@@ -18,18 +17,8 @@ import {
   PrecinctId,
 } from '@votingworks/types';
 import { ElectionInfo } from '../components/election_info';
-import { DisplaySettingsButton } from '../components/display_settings_button';
 import { ContestsWithMsEitherNeither } from '../utils/ms_either_neither_contests';
-
-const Body = styled.div`
-  align-items: center;
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
-  gap: 1rem;
-  justify-content: center;
-  padding: 0.5rem;
-`;
+import { VoterScreen } from '../components/voter_screen';
 
 const ElectionInfoContainer = styled.div`
   @media (orientation: portrait) {
@@ -45,16 +34,6 @@ const StartVotingButtonContainer = styled.div`
 const StartVotingButton = styled(Button)`
   font-size: 1.2rem;
   line-height: 2rem;
-`;
-
-const Footer = styled.div`
-  align-items: center;
-  border-top: ${(p) => p.theme.sizes.bordersRem.thick}rem solid
-    ${(p) => p.theme.colors.outline};
-  display: flex;
-  gap: 1rem;
-  justify-content: center;
-  padding: 0.5rem;
 `;
 
 export interface StartPageProps {
@@ -96,26 +75,21 @@ export function StartPage(props: StartPageProps): JSX.Element {
   );
 
   return (
-    <Screen>
-      <Body>
-        <ReadOnLoad>
-          <ElectionInfoContainer>
-            <ElectionInfo
-              electionDefinition={electionDefinition}
-              ballotStyleId={ballotStyleId}
-              precinctSelection={singlePrecinctSelectionFor(precinctId)}
-              contestCount={contests.length}
-            />
-          </ElectionInfoContainer>
-          <AudioOnly>{appStrings.instructionsBmdBallotNavigation()}</AudioOnly>
-        </ReadOnLoad>
-        <StartVotingButtonContainer>
-          {startVotingButton}
-        </StartVotingButtonContainer>
-      </Body>
-      <Footer>
-        <DisplaySettingsButton />
-      </Footer>
-    </Screen>
+    <VoterScreen centerContent padded>
+      <ReadOnLoad>
+        <ElectionInfoContainer>
+          <ElectionInfo
+            electionDefinition={electionDefinition}
+            ballotStyleId={ballotStyleId}
+            precinctSelection={singlePrecinctSelectionFor(precinctId)}
+            contestCount={contests.length}
+          />
+        </ElectionInfoContainer>
+        <AudioOnly>{appStrings.instructionsBmdBallotNavigation()}</AudioOnly>
+      </ReadOnLoad>
+      <StartVotingButtonContainer>
+        {startVotingButton}
+      </StartVotingButtonContainer>
+    </VoterScreen>
   );
 }

--- a/libs/ui/src/contest_choice_button.tsx
+++ b/libs/ui/src/contest_choice_button.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
-import styled, { css } from 'styled-components';
+import styled, { DefaultTheme, css } from 'styled-components';
 
+import { SizeMode } from '@votingworks/types';
 import { Button, ButtonPressEvent, ButtonVariant } from './button';
 import { Checkbox } from './checkbox';
 import { Caption, P } from './typography';
@@ -27,17 +28,24 @@ interface StyleProps {
   variant?: ButtonVariant;
 }
 
+const COMPACT_SIZE_MODES = new Set<SizeMode>(['touchLarge', 'touchExtraLarge']);
+
+function isCompactMode(p: { theme: DefaultTheme }) {
+  return COMPACT_SIZE_MODES.has(p.theme.sizeMode);
+}
+
 const selectedChoiceStyles = css<StyleProps>`
   border: ${(p) => p.theme.sizes.bordersRem.hairline}rem solid
     ${(p) => p.theme.colors.primary};
 `;
 
+/* istanbul ignore next */
 const OuterContainer = styled(Button)<StyleProps>`
   border: ${(p) => p.theme.sizes.bordersRem.hairline}rem solid currentColor;
   grid-area: ${(p) => p.gridArea};
   justify-content: start;
   min-width: min-content;
-  padding: 0.5rem;
+  padding: ${(p) => (isCompactMode(p) ? '0.25rem 0.3rem' : '0.5rem')};
   text-align: left;
   width: 100%;
 
@@ -48,11 +56,12 @@ const OuterContainer = styled(Button)<StyleProps>`
   }
 `;
 
+/* istanbul ignore next */
 const Content = styled.span`
   align-items: center;
   display: flex;
   flex-wrap: nowrap;
-  gap: 0.5rem;
+  gap: ${(p) => (isCompactMode(p) ? 0.25 : 0.5)}rem;
 `;
 
 const CheckboxContainer = styled.span`

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -15,6 +15,7 @@ import {
   faInfoCircle,
   faMinusCircle,
   faPencil,
+  faLanguage,
   faXmark,
   faMagnifyingGlassPlus,
   faMagnifyingGlassMinus,
@@ -206,6 +207,10 @@ export const Icons = {
 
   Import(props) {
     return <FaIcon {...props} type={faFileArrowUp} />;
+  },
+
+  Language(props) {
+    return <FaIcon {...props} type={faLanguage} />;
   },
 
   Loading(props) {

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -44,6 +44,7 @@ export * from './input_group';
 export * from './insert_ballot_image';
 export * from './insert_card_image';
 export * from './labelled_text';
+export * from './language_settings';
 export * from './left_nav';
 export * from './link_button';
 export * from './list';

--- a/libs/ui/src/language_settings/index.ts
+++ b/libs/ui/src/language_settings/index.ts
@@ -1,0 +1,1 @@
+export * from './language_settings_button';

--- a/libs/ui/src/language_settings/language_settings_button.tsx
+++ b/libs/ui/src/language_settings/language_settings_button.tsx
@@ -1,0 +1,39 @@
+/* istanbul ignore file - stub implementation */
+
+import React from 'react';
+
+import { useCurrentLanguage } from '../hooks/use_current_language';
+import { useAvailableLanguages } from '../hooks/use_available_languages';
+import { useLanguageControls } from '../hooks/use_language_controls';
+import { Button } from '../button';
+
+export function LanguageModalButton(): React.ReactNode {
+  const currentLanguageCode = useCurrentLanguage();
+  const availableLanguages = useAvailableLanguages();
+  const { setLanguage } = useLanguageControls();
+
+  // TODO(kofi): Let clients trigger navigation to a language settings screen
+  // instead:
+  const onPress = React.useCallback(() => {
+    const currentLanguageIndex = availableLanguages.findIndex(
+      (l) => l === currentLanguageCode
+    );
+    const nextIndex = (currentLanguageIndex + 1) % availableLanguages.length;
+
+    setLanguage(availableLanguages[nextIndex]);
+  }, [availableLanguages, currentLanguageCode, setLanguage]);
+
+  if (availableLanguages.length < 2) {
+    return null;
+  }
+
+  return (
+    <Button icon="Language" onPress={onPress}>
+      {/* TODO(kofi): Use a UiString from the election package to enable audio */}
+      {new Intl.DisplayNames([currentLanguageCode], {
+        type: 'language',
+        style: 'narrow',
+      }).of(currentLanguageCode)}
+    </Button>
+  );
+}

--- a/libs/ui/src/ui_strings/read_on_load.test.tsx
+++ b/libs/ui/src/ui_strings/read_on_load.test.tsx
@@ -99,3 +99,28 @@ test('triggers click event on URL change', () => {
   screen.getByText('Mayor');
   expect(mockOnClick).toHaveBeenCalled();
 });
+
+test('clears any pre-existing focus first', () => {
+  const { mockOnClick, renderWithClickListener } = newRenderer();
+
+  mockOnClick.mockImplementation((event: MouseEvent) => {
+    assert(event.target instanceof HTMLElement);
+    expect(event.target.textContent).toEqual('Akwaaba!');
+  });
+
+  const previouslyFocusedElement = document.createElement('button');
+  document.body.appendChild(previouslyFocusedElement);
+  previouslyFocusedElement.focus();
+
+  const activeElementBlurSpy = jest.spyOn(previouslyFocusedElement, 'blur');
+
+  renderWithClickListener(
+    <UiStringsAudioContextProvider api={mockUiStringsApi}>
+      <ReadOnLoad>Akwaaba!</ReadOnLoad>
+    </UiStringsAudioContextProvider>
+  );
+
+  screen.getByText('Akwaaba!');
+  expect(activeElementBlurSpy).toHaveBeenCalled();
+  expect(mockOnClick).toHaveBeenCalled();
+});

--- a/libs/ui/src/ui_strings/read_on_load.tsx
+++ b/libs/ui/src/ui_strings/read_on_load.tsx
@@ -50,6 +50,19 @@ export function ReadOnLoad(props: ReadOnLoadProps): JSX.Element {
       return;
     }
 
+    // Clear pre-existing active focus first, if any.
+    // Avoids any controls that trigger the render of a `ReadOnLoad` component
+    // holding focus and preventing the following `focus`/`click` events from
+    // working (e.g. persistent page navigation buttons).
+    const { activeElement } = document;
+    if (
+      activeElement instanceof HTMLElement ||
+      /* istanbul ignore next */
+      activeElement instanceof SVGElement
+    ) {
+      activeElement.blur();
+    }
+
     containerRef.current.focus();
     containerRef.current.click();
   }, [currentUrl, isInAudioContext]);


### PR DESCRIPTION
## Overview

- Consolidating voter-facing BMD screens into a shared `<VoterScreen>` layout component to keep things visually consistent.
- Moving the "Display Settings" button out of the bottom bar into a new to bar and adding a stand-in language picker alongside it.
  - For the landscape BMD, all buttons stay in the right side bar as before.
  - The language settings button will be omitted for elections containing only one ballot language.
 - Moving the contest number/progress indicator into the bottom/side bars to co-locate with the navigation buttons.

### TODO for later
- Build out a language settings screen
- Start exporting a non-CDF `ballotLanguageName` election string text/audio for use in the language picker
- Update the "Display Settings" button to "Settings", since it now exposes audio settings as well.

## Demo Video or Screenshot

### Portrait:

https://github.com/votingworks/vxsuite/assets/264902/1a148e60-c481-4e1b-be84-330dc64f5d8d

### Landscape:

https://github.com/votingworks/vxsuite/assets/264902/f1be8e9f-5411-4c1e-b866-3677108dfd3a

### Single-Language Election:
<img width="454" alt="Screenshot 2024-02-08 at 13 55 08" src="https://github.com/votingworks/vxsuite/assets/264902/9b73d7e7-b856-4fda-ad9e-e48ddefaf507">


## Testing Plan
- New/updated test cases
- Manual click through for voter-facing pages in both orientations

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
