### PR TITLE
[i18n/audio] Include ballot language display names and audio in election package

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -498,6 +498,8 @@ test('Election package export', async () => {
         expect(stringInLanguage).toEqual(stringInEnglish);
       } else if (stringKey === ElectionStringKey.ELECTION_DATE) {
         expect(stringInLanguage).toBeDefined();
+      } else if (stringKey === ElectionStringKey.BALLOT_LANGUAGE) {
+        expect(stringInLanguage).toBeDefined();
       } else {
         expect(stringInLanguage).toBeDefined();
         expect(stringInLanguage).toEqual(

--- a/apps/design/backend/src/language_and_audio/election_strings.ts
+++ b/apps/design/backend/src/language_and_audio/election_strings.ts
@@ -40,6 +40,14 @@ type ElectionStringConfig =
   | ElectionStringConfigTranslatable;
 
 const electionStringConfigs: Record<ElectionStringKey, ElectionStringConfig> = {
+  [ElectionStringKey.BALLOT_LANGUAGE]: {
+    translatable: true,
+    translationsCanBeStoredInCdf: false,
+    customTranslationMethod: (p) =>
+      format.languageDisplayName({
+        languageCode: p.languageCode,
+      }),
+  },
   [ElectionStringKey.BALLOT_STYLE_ID]: {
     translatable: false,
   },
@@ -101,6 +109,14 @@ const electionStringExtractorFns: Record<
   ElectionStringKey,
   (election: Election) => ElectionString[]
 > = {
+  [ElectionStringKey.BALLOT_LANGUAGE]() {
+    return [
+      {
+        stringKey: ElectionStringKey.BALLOT_LANGUAGE,
+        stringInEnglish: 'English',
+      },
+    ];
+  },
   [ElectionStringKey.BALLOT_STYLE_ID](election) {
     return election.ballotStyles.map((ballotStyle) => ({
       stringKey: [ElectionStringKey.BALLOT_STYLE_ID, ballotStyle.id],

--- a/libs/backend/src/election_package/election_package_io.test.ts
+++ b/libs/backend/src/election_package/election_package_io.test.ts
@@ -179,10 +179,12 @@ test('readElectionPackageFromFile loads available ui strings', async () => {
 test('readElectionPackageFromFile loads vx election strings', async () => {
   const vxElectionStrings: UiStringsPackage = {
     [LanguageCode.ENGLISH]: {
+      [ElectionStringKey.BALLOT_LANGUAGE]: 'English',
       [ElectionStringKey.ELECTION_DATE]: 'The Day The Earth Stood Still',
       [ElectionStringKey.ELECTION_TITLE]: 'Should be overridden by CDF string',
     },
     [LanguageCode.SPANISH]: {
+      [ElectionStringKey.BALLOT_LANGUAGE]: 'Español',
       [ElectionStringKey.ELECTION_DATE]: 'El día que la Tierra se detuvo',
     },
   };
@@ -198,10 +200,12 @@ test('readElectionPackageFromFile loads vx election strings', async () => {
   const expectedCdfStrings = extractCdfUiStrings(testCdfBallotDefinition);
   const expectedUiStrings: UiStringsPackage = {
     [LanguageCode.ENGLISH]: {
+      [ElectionStringKey.BALLOT_LANGUAGE]: 'English',
       [ElectionStringKey.ELECTION_DATE]: 'The Day The Earth Stood Still',
       ...assertDefined(expectedCdfStrings[LanguageCode.ENGLISH]),
     },
     [LanguageCode.SPANISH]: {
+      [ElectionStringKey.BALLOT_LANGUAGE]: 'Español',
       [ElectionStringKey.ELECTION_DATE]: 'El día que la Tierra se detuvo',
     },
   };

--- a/libs/types/src/ui_string_translations.ts
+++ b/libs/types/src/ui_string_translations.ts
@@ -7,6 +7,7 @@ import { LanguageCode } from './language_code';
  * spoken.
  */
 export enum ElectionStringKey {
+  BALLOT_LANGUAGE = 'ballotLanguage',
   BALLOT_STYLE_ID = 'ballotStyleId',
   CANDIDATE_NAME = 'candidateName',
   CONTEST_DESCRIPTION = 'contestDescription',

--- a/libs/ui/src/language_settings/language_settings_button.tsx
+++ b/libs/ui/src/language_settings/language_settings_button.tsx
@@ -6,6 +6,7 @@ import { useCurrentLanguage } from '../hooks/use_current_language';
 import { useAvailableLanguages } from '../hooks/use_available_languages';
 import { useLanguageControls } from '../hooks/use_language_controls';
 import { Button } from '../button';
+import { electionStrings } from '../ui_strings';
 
 export function LanguageModalButton(): React.ReactNode {
   const currentLanguageCode = useCurrentLanguage();
@@ -29,11 +30,7 @@ export function LanguageModalButton(): React.ReactNode {
 
   return (
     <Button icon="Language" onPress={onPress}>
-      {/* TODO(kofi): Use a UiString from the election package to enable audio */}
-      {new Intl.DisplayNames([currentLanguageCode], {
-        type: 'language',
-        style: 'narrow',
-      }).of(currentLanguageCode)}
+      {electionStrings.ballotLanguage(currentLanguageCode)}
     </Button>
   );
 }

--- a/libs/ui/src/ui_strings/election_strings.tsx
+++ b/libs/ui/src/ui_strings/election_strings.tsx
@@ -8,14 +8,17 @@ import {
   District,
   Election,
   ElectionStringKey as Key,
+  LanguageCode,
   Party,
   Precinct,
   YesNoOption,
 } from '@votingworks/types';
+import { format } from '@votingworks/utils';
 
 import { UiString } from './ui_string';
 import { Pre } from '../typography';
 import { DateString } from './date_string';
+import { LanguageOverride } from './language_override';
 
 type ContestWithDescription = ContestLike & {
   description: string;
@@ -26,7 +29,13 @@ type ContestWithDescription = ContestLike & {
  */
 /* istanbul ignore next - mostly presentational, tested via apps where relevant */
 export const electionStrings = {
-  // TODO(kofi): Fill out.
+  [Key.BALLOT_LANGUAGE]: (languageCode: LanguageCode) => (
+    <LanguageOverride languageCode={languageCode}>
+      <UiString uiStringKey={Key.BALLOT_LANGUAGE}>
+        {format.languageDisplayName({ languageCode })}
+      </UiString>
+    </LanguageOverride>
+  ),
 
   [Key.BALLOT_STYLE_ID]: (id: BallotStyleId) => (
     <UiString uiStringKey={Key.BALLOT_STYLE_ID} uiStringSubKey={id}>

--- a/libs/utils/src/extract_cdf_ui_strings.test.ts
+++ b/libs/utils/src/extract_cdf_ui_strings.test.ts
@@ -29,6 +29,14 @@ const ORIGINAL_ELECTION: Readonly<BallotDefinition.Election> = assertDefined(
  * key changes.
  */
 const tests: Record<ElectionStringKey, () => void> = {
+  [ElectionStringKey.BALLOT_LANGUAGE]() {
+    const uiStrings = extractCdfUiStrings(testCdfBallotDefinition);
+
+    expect(
+      uiStrings[LanguageCode.ENGLISH]?.[ElectionStringKey.BALLOT_LANGUAGE]
+    ).toBeUndefined();
+  },
+
   [ElectionStringKey.BALLOT_STYLE_ID]() {
     const uiStrings = extractCdfUiStrings({
       ...testCdfBallotDefinition,

--- a/libs/utils/src/extract_cdf_ui_strings.ts
+++ b/libs/utils/src/extract_cdf_ui_strings.ts
@@ -66,6 +66,11 @@ const extractorFns: Record<
     uiStrings: UiStringsPackage
   ) => void
 > = {
+  [ElectionStringKey.BALLOT_LANGUAGE]() {
+    // No-Op: This election string is not available via CDF.
+    // It is currently extracted directly from the
+    // `@votingworks/types/ElectionPackageFileName.VX_ELECTION_STRINGS` file.
+  },
   [ElectionStringKey.BALLOT_STYLE_ID](cdfElection, uiStrings) {
     for (const ballotStyle of assertDefined(cdfElection.Election[0])
       .BallotStyle) {
@@ -162,12 +167,10 @@ const extractorFns: Record<
     }
   },
 
-  [ElectionStringKey.ELECTION_DATE](_cdfElection, uiStrings) {
+  [ElectionStringKey.ELECTION_DATE]() {
     // No-Op: This election string is not available via CDF.
     // It is currently extracted directly from the
     // `@votingworks/types/ElectionPackageFileName.VX_ELECTION_STRINGS` file.
-
-    return uiStrings;
   },
 
   [ElectionStringKey.ELECTION_TITLE](cdfElection, uiStrings) {

--- a/libs/utils/src/format.test.ts
+++ b/libs/utils/src/format.test.ts
@@ -71,3 +71,42 @@ test('formats percentages properly', () => {
   expect(format.percent(0.591, { maximumFractionDigits: 2 })).toEqual('59.1%');
   expect(format.percent(0.5999, { maximumFractionDigits: 1 })).toEqual('60%');
 });
+
+describe('languageDisplayName()', () => {
+  const { ENGLISH, SPANISH } = LanguageCode;
+
+  test('happy paths', () => {
+    expect(format.languageDisplayName({ languageCode: SPANISH })).toMatch(
+      /^español \(ee\. uu\.\)/i
+    );
+
+    expect(
+      format.languageDisplayName({
+        displayLanguageCode: ENGLISH,
+        languageCode: SPANISH,
+      })
+    ).toMatch(/^spanish \(us\)/i);
+
+    expect(
+      format.languageDisplayName({
+        displayLanguageCode: ENGLISH,
+        languageCode: SPANISH,
+        style: 'long',
+      })
+    ).toMatch(/^spanish \(united states\)/i);
+  });
+
+  test('is compatible with all Vx languages', () => {
+    for (const languageCode of Object.values(LanguageCode) as LanguageCode[]) {
+      expect(() => format.languageDisplayName({ languageCode })).not.toThrow();
+    }
+  });
+
+  test('throws for unsupported languages', () => {
+    expect(() =>
+      format.languageDisplayName({
+        languageCode: 'not-a-language' as LanguageCode,
+      })
+    ).toThrow();
+  });
+});

--- a/libs/utils/src/format.ts
+++ b/libs/utils/src/format.ts
@@ -1,3 +1,4 @@
+import { assertDefined } from '@votingworks/basics';
 import { LanguageCode } from '@votingworks/types';
 
 export const DEFAULT_LOCALE: LanguageCode = LanguageCode.ENGLISH;
@@ -70,4 +71,34 @@ export function localeDate(time?: number | Date): string {
     day: 'numeric',
     year: 'numeric',
   }).format(time);
+}
+
+export function languageDisplayName(params: {
+  languageCode: LanguageCode;
+
+  /** @default {@link params.languageCode} */
+  displayLanguageCode?: LanguageCode;
+
+  /** @default 'narrow' */
+  style?: Intl.RelativeTimeFormatStyle;
+}): string {
+  const {
+    languageCode,
+    displayLanguageCode = languageCode,
+    style = 'narrow',
+  } = params;
+
+  return assertDefined(
+    // TODO(kofi): This util doesn't currently have a comprehensive list of
+    // native language names for all languages, so probably better to find a
+    // reliably sourced list and hardcode the mappings instead.
+    // This at least works for the top 10 spoken in the US and is sufficient for
+    // cert.
+    new Intl.DisplayNames([displayLanguageCode], {
+      style,
+      type: 'language',
+      fallback: 'none',
+    }).of(languageCode),
+    `unexpected missing language display name for ${languageCode} in ${displayLanguageCode}`
+  );
 }


### PR DESCRIPTION
## Overview

Adding a `ballotLanguage` UiString key to `electionStrings`, exported via/extracted from the `vxElectionStrings.json` file in the election package. For each configured language in the election, this will map to the display name text and audio of the language in its native form.

Currently using `Intl.DisplayNames` to map language codes to their appropriate display names, but may need to hardcode a mapping in the future, since language support is limited for that util.

## Demo Video or Screenshot [ 🔊 ]

https://github.com/votingworks/vxsuite/assets/264902/6a38e3cd-a9ac-4c2b-a438-0b56c5dec617

## Testing Plan
- Updated automated test cases
- Manual verification with test election package

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
