### PR TITLE
admin(feat): battery status

### DIFF
--- a/apps/admin/frontend/src/app.test.tsx
+++ b/apps/admin/frontend/src/app.test.tsx
@@ -588,3 +588,22 @@ test('usb formatting flows', async () => {
   apiMock.expectGetUsbDriveStatus('no_drive');
   await screen.findByText('No USB Drive Detected');
 });
+
+test('battery display and alert', async () => {
+  const { renderApp } = buildApp(apiMock);
+  apiMock.expectGetCurrentElectionMetadata();
+  apiMock.expectListPotentialElectionPackagesOnUsbDrive();
+  renderApp();
+
+  await apiMock.authenticateAsSystemAdministrator();
+
+  // initial battery level in nav bar
+  await screen.findByText('100%');
+
+  apiMock.setBatteryInfo({ level: 0.15, discharging: true });
+  const warning = await screen.findByRole('alertdialog');
+  within(warning).getByText('Low Battery Warning');
+
+  // updated battery level in nav bar
+  await screen.findByText('15%');
+});

--- a/apps/admin/frontend/src/app.test.tsx
+++ b/apps/admin/frontend/src/app.test.tsx
@@ -600,10 +600,10 @@ test('battery display and alert', async () => {
   // initial battery level in nav bar
   await screen.findByText('100%');
 
-  apiMock.setBatteryInfo({ level: 0.15, discharging: true });
+  apiMock.setBatteryInfo({ level: 0.1, discharging: true });
   const warning = await screen.findByRole('alertdialog');
   within(warning).getByText('Low Battery Warning');
 
   // updated battery level in nav bar
-  await screen.findByText('15%');
+  await screen.findByText('10%');
 });

--- a/apps/admin/frontend/src/app.tsx
+++ b/apps/admin/frontend/src/app.tsx
@@ -2,6 +2,7 @@ import { getPrinter, getConverterClientType } from '@votingworks/utils';
 import { BrowserRouter } from 'react-router-dom';
 import './App.css';
 import { LogSource, Logger } from '@votingworks/logging';
+import { BatteryLowAlert } from '@votingworks/ui';
 import { AppRoot, Props as AppRootProps } from './app_root';
 import { SessionTimeLimitTracker } from './components/session_time_limit_tracker';
 
@@ -22,6 +23,7 @@ export function App({
         logger={logger}
       />
       <SessionTimeLimitTracker />
+      <BatteryLowAlert />
     </BrowserRouter>
   );
 }

--- a/apps/admin/frontend/src/components/app_routes.tsx
+++ b/apps/admin/frontend/src/components/app_routes.tsx
@@ -37,6 +37,7 @@ import { SinglePrecinctTallyReportScreen } from '../screens/reporting/single_pre
 import { PrecinctBallotCountReport } from '../screens/reporting/precinct_ballot_count_report_screen';
 import { VotingMethodBallotCountReport } from '../screens/reporting/voting_method_ballot_count_report_screen';
 import { FullElectionTallyReportScreen } from '../screens/reporting/full_election_tally_report_screen';
+import { HardwareDiagnosticsScreen } from '../screens/hardware_diagnostics_screen';
 
 export function AppRoutes(): JSX.Element {
   const { electionDefinition, configuredAt, auth, hasCardReaderAttached } =
@@ -94,6 +95,9 @@ export function AppRoutes(): JSX.Element {
             <Route exact path={routerPaths.settings}>
               <SettingsScreen />
             </Route>
+            <Route exact path={routerPaths.hardwareDiagnostics}>
+              <HardwareDiagnosticsScreen />
+            </Route>
             <Redirect to={routerPaths.election} />
           </Switch>
           <SmartcardModal />
@@ -122,6 +126,9 @@ export function AppRoutes(): JSX.Element {
           </Route>
           <Route exact path={routerPaths.settings}>
             <SettingsScreen />
+          </Route>
+          <Route exact path={routerPaths.hardwareDiagnostics}>
+            <HardwareDiagnosticsScreen />
           </Route>
           <Redirect to={routerPaths.election} />
         </Switch>

--- a/apps/admin/frontend/src/components/navigation_screen.tsx
+++ b/apps/admin/frontend/src/components/navigation_screen.tsx
@@ -11,6 +11,7 @@ import {
   H1,
   Route,
   Breadcrumbs,
+  BatteryDisplay,
 } from '@votingworks/ui';
 import {
   BooleanEnvironmentVariableName,
@@ -140,6 +141,7 @@ export function NavigationScreen({
                 <Button onPress={() => logOutMutation.mutate()} icon="Lock">
                   Lock Machine
                 </Button>
+                <BatteryDisplay />
               </React.Fragment>
             )}
           </HeaderActions>

--- a/apps/admin/frontend/src/components/navigation_screen.tsx
+++ b/apps/admin/frontend/src/components/navigation_screen.tsx
@@ -37,11 +37,13 @@ const SYSTEM_ADMIN_NAV_ITEMS: readonly NavItem[] = [
   { label: 'Election', routerPath: routerPaths.election },
   { label: 'Smartcards', routerPath: routerPaths.smartcards },
   { label: 'Settings', routerPath: routerPaths.settings },
+  { label: 'Diagnostics', routerPath: routerPaths.hardwareDiagnostics },
 ];
 
 const SYSTEM_ADMIN_NAV_ITEMS_NO_ELECTION: readonly NavItem[] = [
   { label: 'Election', routerPath: routerPaths.election },
   { label: 'Settings', routerPath: routerPaths.settings },
+  { label: 'Diagnostics', routerPath: routerPaths.hardwareDiagnostics },
 ];
 
 const ELECTION_MANAGER_NAV_ITEMS: readonly NavItem[] = [

--- a/apps/admin/frontend/src/router_paths.ts
+++ b/apps/admin/frontend/src/router_paths.ts
@@ -34,5 +34,6 @@ export const routerPaths = {
   }: WriteInsAdjudicationScreenProps): string =>
     `/write-ins/adjudication/${contestId}`,
   settings: '/settings',
+  hardwareDiagnostics: '/hardware-diagnostics',
   system: '/system',
 } as const;

--- a/apps/admin/frontend/src/screens/hardware_diagnostics_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/hardware_diagnostics_screen.test.tsx
@@ -1,0 +1,52 @@
+import { hasTextAcrossElements } from '@votingworks/test-utils';
+import { screen } from '../../test/react_testing_library';
+import { renderInAppContext } from '../../test/render_in_app_context';
+import { ApiMock, createApiMock } from '../../test/helpers/mock_api_client';
+import { HardwareDiagnosticsScreen } from './hardware_diagnostics_screen';
+
+let apiMock: ApiMock;
+
+beforeEach(() => {
+  jest.useFakeTimers().setSystemTime(new Date('2022-06-22T00:00:00.000Z'));
+  apiMock = createApiMock();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  apiMock.assertComplete();
+});
+
+test('displays battery state ', async () => {
+  apiMock.setPrinterStatus({ connected: false });
+  renderInAppContext(<HardwareDiagnosticsScreen />, {
+    apiMock,
+  });
+
+  await screen.findByText(
+    hasTextAcrossElements('Power Source: External Power Supply')
+  );
+  screen.getByText(hasTextAcrossElements('Battery Level: 100%'));
+
+  apiMock.setBatteryInfo({
+    level: 0.5,
+    discharging: true,
+  });
+
+  await screen.findByText(hasTextAcrossElements('Power Source: Battery'));
+  screen.getByText(hasTextAcrossElements('Battery Level: 50%'));
+});
+
+test('displays printer state ', async () => {
+  apiMock.setPrinterStatus({ connected: false });
+  renderInAppContext(<HardwareDiagnosticsScreen />, {
+    apiMock,
+  });
+
+  await screen.findByText('No compatible printer detected');
+
+  apiMock.setPrinterStatus({
+    connected: true,
+  });
+
+  await screen.findByText('Connected');
+});

--- a/apps/admin/frontend/src/screens/hardware_diagnostics_screen.tsx
+++ b/apps/admin/frontend/src/screens/hardware_diagnostics_screen.tsx
@@ -1,0 +1,50 @@
+import { Font, H2, Icons, P } from '@votingworks/ui';
+
+import { format } from '@votingworks/utils';
+import { NavigationScreen } from '../components/navigation_screen';
+import { getPrinterStatus, systemCallApi } from '../api';
+import { Loading } from '../components/loading';
+
+export function HardwareDiagnosticsScreen(): JSX.Element {
+  const batteryInfoQuery = systemCallApi.getBatteryInfo.useQuery();
+  const printerStatusQuery = getPrinterStatus.useQuery();
+
+  if (!batteryInfoQuery.isSuccess || !printerStatusQuery.isSuccess) {
+    return (
+      <NavigationScreen title="Hardware Diagnostics">
+        <Loading isFullscreen />
+      </NavigationScreen>
+    );
+  }
+
+  const batteryInfo = batteryInfoQuery.data;
+  const printerStatus = printerStatusQuery.data;
+
+  return (
+    <NavigationScreen title="Hardware Diagnostics">
+      <H2>Laptop</H2>
+      <P>
+        <Font weight="semiBold">Power Source:</Font>{' '}
+        {batteryInfo
+          ? batteryInfo.discharging
+            ? 'Battery'
+            : 'External Power Supply'
+          : '-'}
+      </P>
+      <P>
+        <Font weight="semiBold">Battery Level:</Font>{' '}
+        {batteryInfo ? format.percent(batteryInfo.level) : '--%'}
+      </P>
+      <H2>Printer</H2>
+      {printerStatus.connected ? (
+        <P>
+          <Icons.Done color="success" /> Connected
+        </P>
+      ) : (
+        <P>
+          <Icons.Info /> No compatible printer detected
+        </P>
+      )}
+    </NavigationScreen>
+  );
+}

--- a/libs/backend/src/system_call/get_battery_info.test.ts
+++ b/libs/backend/src/system_call/get_battery_info.test.ts
@@ -104,7 +104,7 @@ POWER_SUPPLY_STATUS=Discharging
   );
 });
 
-test('returns undefined if the power_supply "files" are not present', async () => {
+test('returns null if the power_supply "files" are not present', async () => {
   createReadStreamMock
     .mockImplementationOnce(() => {
       throw new Error('ENOENT');
@@ -112,5 +112,5 @@ test('returns undefined if the power_supply "files" are not present', async () =
     .mockImplementationOnce(() => {
       throw new Error('ENOENT');
     });
-  expect(await getBatteryInfo()).toBeUndefined();
+  expect(await getBatteryInfo()).toBeNull();
 });

--- a/libs/backend/src/system_call/get_battery_info.ts
+++ b/libs/backend/src/system_call/get_battery_info.ts
@@ -1,4 +1,4 @@
-import { Optional, lines } from '@votingworks/basics';
+import { lines } from '@votingworks/basics';
 import { safeParseNumber } from '@votingworks/types';
 import { createReadStream } from 'fs';
 
@@ -46,9 +46,10 @@ export async function parseBatteryInfo(
 }
 
 /**
- * Get battery info for the main system battery.
+ * Get battery info for the main system battery. If no battery info is found,
+ * returns null (react-query doesn't accept `undefined`).
  */
-export async function getBatteryInfo(): Promise<Optional<BatteryInfo>> {
+export async function getBatteryInfo(): Promise<BatteryInfo | null> {
   for (const batteryPath of ['BAT0', 'BAT1']) {
     try {
       return await parseBatteryInfo(
@@ -61,5 +62,5 @@ export async function getBatteryInfo(): Promise<Optional<BatteryInfo>> {
       // ignore missing paths
     }
   }
-  return undefined;
+  return null;
 }

--- a/libs/ui/src/battery_display.test.tsx
+++ b/libs/ui/src/battery_display.test.tsx
@@ -1,0 +1,130 @@
+import type { BatteryInfo } from '@votingworks/backend';
+import { screen } from '../test/react_testing_library';
+
+import { newTestContext } from '../test/test_context';
+import { BatteryDisplay } from './battery_display';
+import { makeTheme } from './themes/make_theme';
+
+jest.useFakeTimers();
+
+const theme = makeTheme({ colorMode: 'desktop' });
+
+test.each<
+  BatteryInfo & {
+    expectedBatteryIcon: string;
+    expectRedBatteryIcon: boolean;
+    expectedPercentText: string;
+  }
+>([
+  {
+    level: 0.9,
+    discharging: true,
+    expectedBatteryIcon: 'battery-full',
+    expectRedBatteryIcon: false,
+    expectedPercentText: '90%',
+  },
+  {
+    level: 0.7,
+    discharging: true,
+    expectedBatteryIcon: 'battery-three-quarters',
+    expectRedBatteryIcon: false,
+    expectedPercentText: '70%',
+  },
+  {
+    level: 0.5,
+    discharging: true,
+    expectedBatteryIcon: 'battery-half',
+    expectRedBatteryIcon: false,
+    expectedPercentText: '50%',
+  },
+  {
+    level: 0.3,
+    discharging: true,
+    expectedBatteryIcon: 'battery-quarter',
+    expectRedBatteryIcon: true,
+    expectedPercentText: '30%',
+  },
+  {
+    level: 0.1,
+    discharging: true,
+    expectedBatteryIcon: 'battery-empty',
+    expectRedBatteryIcon: true,
+    expectedPercentText: '10%',
+  },
+  {
+    level: 0.1,
+    discharging: false,
+    expectedBatteryIcon: 'battery-empty',
+    expectRedBatteryIcon: false,
+    expectedPercentText: '10%',
+  },
+  {
+    level: 0.3,
+    discharging: false,
+    expectedBatteryIcon: 'battery-quarter',
+    expectRedBatteryIcon: false,
+    expectedPercentText: '30%',
+  },
+  {
+    level: 0.5,
+    discharging: false,
+    expectedBatteryIcon: 'battery-half',
+    expectRedBatteryIcon: false,
+    expectedPercentText: '50%',
+  },
+  {
+    level: 0.7,
+    discharging: false,
+    expectedBatteryIcon: 'battery-three-quarters',
+    expectRedBatteryIcon: false,
+    expectedPercentText: '70%',
+  },
+  {
+    level: 0.9,
+    discharging: false,
+    expectedBatteryIcon: 'battery-full',
+    expectRedBatteryIcon: false,
+    expectedPercentText: '90%',
+  },
+])(
+  'correct battery display for $expectedPercentText, discharging = $discharging',
+  async (t) => {
+    const { render, mockApiClient } = newTestContext({
+      skipUiStringsApi: true,
+    });
+    mockApiClient.getBatteryInfo.mockResolvedValueOnce(t);
+    render(<BatteryDisplay />, { vxTheme: theme });
+
+    await screen.findByText(t.expectedPercentText);
+    const icons = screen.getAllByRole('img', { hidden: true });
+    const [batteryIcon, boltIcon] = icons;
+    expect(batteryIcon).toHaveAttribute('data-icon', t.expectedBatteryIcon);
+    if (t.expectRedBatteryIcon) {
+      expect(batteryIcon).toHaveStyle(`color: ${theme.colors.dangerAccent};`);
+    } else {
+      expect(batteryIcon).not.toHaveStyle(
+        `color: ${theme.colors.onBackground};`
+      );
+    }
+
+    if (!t.discharging) {
+      expect(boltIcon).toHaveAttribute('data-icon', 'bolt');
+    }
+
+    expect(mockApiClient.getBatteryInfo).toHaveBeenCalledTimes(1);
+  }
+);
+
+test('displays placeholder when battery info is not available', async () => {
+  const { render, mockApiClient } = newTestContext({
+    skipUiStringsApi: true,
+  });
+  mockApiClient.getBatteryInfo.mockResolvedValueOnce(null);
+  render(<BatteryDisplay />, { vxTheme: theme });
+
+  await screen.findByText('—-%');
+  const icon = screen.getByRole('img', { hidden: true });
+  expect(icon).toHaveAttribute('data-icon', 'battery-full');
+
+  expect(mockApiClient.getBatteryInfo).toHaveBeenCalledTimes(1);
+});

--- a/libs/ui/src/battery_display.tsx
+++ b/libs/ui/src/battery_display.tsx
@@ -1,0 +1,71 @@
+import styled from 'styled-components';
+import type { BatteryInfo as BatteryInfoType } from '@votingworks/backend';
+import { format } from '@votingworks/utils';
+import { assert } from '@votingworks/basics';
+import { IconProps, Icons } from './icons';
+import { Font } from './typography';
+import { useSystemCallApi } from './system_call_api';
+
+const BatteryInfo = styled.div`
+  align-self: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.1rem;
+`;
+
+const IconContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+`;
+
+function getBatteryIcon(batteryInfo: BatteryInfoType): JSX.Element {
+  assert(
+    batteryInfo.level >= 0 && batteryInfo.level <= 1,
+    'Invalid battery level'
+  );
+  const quarters = Math.round(batteryInfo.level * 4);
+  const showDanger = quarters <= 1 && batteryInfo.discharging;
+  const iconProps: IconProps = {
+    color: showDanger ? 'danger' : undefined,
+    style: { fontSize: '1.2em' },
+  };
+
+  switch (quarters) {
+    case 0:
+      return <Icons.BatteryEmpty {...iconProps} />;
+    case 1:
+      return <Icons.BatteryQuarter {...iconProps} />;
+    case 2:
+      return <Icons.BatteryHalf {...iconProps} />;
+    case 3:
+      return <Icons.BatteryThreeQuarters {...iconProps} />;
+    case 4:
+      return <Icons.BatteryFull {...iconProps} />;
+    /* istanbul ignore next */
+    default:
+      throw new Error('Invalid battery level');
+  }
+}
+
+export function BatteryDisplay(): JSX.Element {
+  const systemCallApi = useSystemCallApi();
+  const batteryInfoQuery = systemCallApi.getBatteryInfo.useQuery();
+  const batteryInfo = batteryInfoQuery.data;
+
+  return (
+    <BatteryInfo>
+      <IconContainer>
+        {batteryInfo ? getBatteryIcon(batteryInfo) : <Icons.BatteryFull />}
+        {batteryInfo && !batteryInfo.discharging && (
+          <Icons.Bolt style={{ fontSize: '0.8em' }} />
+        )}
+      </IconContainer>
+      <Font weight="semiBold" style={{ fontSize: '0.8em', lineHeight: '0.9' }}>
+        {batteryInfo ? format.percent(batteryInfo.level) : '—-%'}
+      </Font>
+    </BatteryInfo>
+  );
+}

--- a/libs/ui/src/battery_display.tsx
+++ b/libs/ui/src/battery_display.tsx
@@ -21,6 +21,11 @@ const IconContainer = styled.div`
   gap: 4px;
 `;
 
+const BatteryPercentText = styled(Font)`
+  font-size: 0.8em;
+  line-height: 0.9;
+`;
+
 function getBatteryIcon(batteryInfo: BatteryInfoType): JSX.Element {
   assert(
     batteryInfo.level >= 0 && batteryInfo.level <= 1,
@@ -63,9 +68,9 @@ export function BatteryDisplay(): JSX.Element {
           <Icons.Bolt style={{ fontSize: '0.8em' }} />
         )}
       </IconContainer>
-      <Font weight="semiBold" style={{ fontSize: '0.8em', lineHeight: '0.9' }}>
+      <BatteryPercentText weight="semiBold">
         {batteryInfo ? format.percent(batteryInfo.level) : '—-%'}
-      </Font>
+      </BatteryPercentText>
     </BatteryInfo>
   );
 }

--- a/libs/ui/src/battery_low_alert.test.tsx
+++ b/libs/ui/src/battery_low_alert.test.tsx
@@ -1,0 +1,136 @@
+import userEvent from '@testing-library/user-event';
+import { advancePromises } from '@votingworks/test-utils';
+import {
+  screen,
+  waitForElementToBeRemoved,
+  within,
+} from '../test/react_testing_library';
+import { newTestContext } from '../test/test_context';
+import { BatteryLowAlert } from './battery_low_alert';
+
+jest.useFakeTimers();
+
+test.each<{
+  warningLevel: number;
+  warningPercent: string;
+  canDismiss: boolean;
+}>([
+  {
+    warningLevel: 0.15,
+    warningPercent: '15%',
+    canDismiss: true,
+  },
+  {
+    warningLevel: 0.1,
+    warningPercent: '10%',
+    canDismiss: true,
+  },
+  {
+    warningLevel: 0.05,
+    warningPercent: '5%',
+    canDismiss: true,
+  },
+  {
+    warningLevel: 0.01,
+    warningPercent: '1%',
+    canDismiss: false,
+  },
+])(`warning when battery drops to $warningPercent`, async (t) => {
+  const { render, mockApiClient } = newTestContext({
+    skipUiStringsApi: true,
+  });
+  mockApiClient.getBatteryInfo.mockResolvedValue({
+    // confirm we're rounding up and not considering this at the warning level
+    level: t.warningLevel + 0.007,
+    discharging: true,
+  });
+  render(<BatteryLowAlert />);
+  expect(screen.queryByRole('alertdialog')).toBeNull();
+
+  mockApiClient.getBatteryInfo.mockResolvedValue({
+    // confirm we're rounding down and considering this at the warning level
+    level: t.warningLevel + 0.003,
+    discharging: true,
+  });
+  const warning = await screen.findByRole('alertdialog');
+  within(warning).getByRole('heading', { name: 'Low Battery Warning' });
+  within(warning).getByText(
+    `The battery is at ${t.warningPercent} and is not charging. Please connect the power supply.`
+  );
+
+  if (!t.canDismiss) {
+    expect(within(warning).queryButton('Dismiss')).toBeNull();
+    return;
+  }
+
+  userEvent.click(within(warning).getButton('Dismiss'));
+  expect(screen.queryByRole('alertdialog')).toBeNull();
+
+  // confirm the modal doesn't reappear if the battery is still at the warning level
+  mockApiClient.getBatteryInfo.mockResolvedValue({
+    level: t.warningLevel - 0.003,
+    discharging: true,
+  });
+  jest.advanceTimersByTime(5000);
+  await advancePromises(); // to make sure a re-render happens (coverage enforces this)
+  expect(screen.queryByRole('alertdialog')).toBeNull();
+});
+
+test('connecting power supply dismisses warning', async () => {
+  const { render, mockApiClient } = newTestContext({
+    skipUiStringsApi: true,
+  });
+  mockApiClient.getBatteryInfo.mockResolvedValue({
+    level: 0.15,
+    discharging: true,
+  });
+  render(<BatteryLowAlert />);
+
+  const warning = await screen.findByRole('alertdialog');
+  within(warning).getByRole('heading', { name: 'Low Battery Warning' });
+  within(warning).getByText(
+    `The battery is at 15% and is not charging. Please connect the power supply.`
+  );
+
+  // connect power
+  mockApiClient.getBatteryInfo.mockResolvedValue({
+    level: 0.15,
+    discharging: false,
+  });
+  await waitForElementToBeRemoved(warning);
+});
+
+test('nothing appears if battery info is null', async () => {
+  const { render, mockApiClient } = newTestContext({
+    skipUiStringsApi: true,
+  });
+  mockApiClient.getBatteryInfo.mockResolvedValue(null);
+  render(<BatteryLowAlert />);
+
+  await advancePromises(); // to make sure a render happens (coverage enforces this)
+  expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+});
+
+test('unplugging power when at a warning level triggers warning', async () => {
+  const { render, mockApiClient } = newTestContext({
+    skipUiStringsApi: true,
+  });
+  mockApiClient.getBatteryInfo.mockResolvedValue({
+    level: 0.15,
+    discharging: false,
+  });
+  render(<BatteryLowAlert />);
+
+  await advancePromises();
+  expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+
+  mockApiClient.getBatteryInfo.mockResolvedValue({
+    level: 0.15,
+    discharging: true,
+  });
+  const warning = await screen.findByRole('alertdialog');
+  within(warning).getByRole('heading', { name: 'Low Battery Warning' });
+  within(warning).getByText(
+    `The battery is at 15% and is not charging. Please connect the power supply.`
+  );
+});

--- a/libs/ui/src/battery_low_alert.test.tsx
+++ b/libs/ui/src/battery_low_alert.test.tsx
@@ -1,103 +1,103 @@
 import userEvent from '@testing-library/user-event';
-import { advancePromises } from '@votingworks/test-utils';
 import {
   screen,
+  waitFor,
   waitForElementToBeRemoved,
   within,
 } from '../test/react_testing_library';
 import { newTestContext } from '../test/test_context';
 import { BatteryLowAlert } from './battery_low_alert';
+import { BATTERY_POLLING_INTERVAL_GROUT } from '.';
 
 jest.useFakeTimers();
 
-test.each<{
-  warningLevel: number;
-  warningPercent: string;
-  canDismiss: boolean;
-}>([
-  {
-    warningLevel: 0.15,
-    warningPercent: '15%',
-    canDismiss: true,
-  },
-  {
-    warningLevel: 0.1,
-    warningPercent: '10%',
-    canDismiss: true,
-  },
-  {
-    warningLevel: 0.05,
-    warningPercent: '5%',
-    canDismiss: true,
-  },
-  {
-    warningLevel: 0.01,
-    warningPercent: '1%',
-    canDismiss: false,
-  },
-])(`warning when battery drops to $warningPercent`, async (t) => {
+test(`warning when battery drops`, async () => {
   const { render, mockApiClient } = newTestContext({
     skipUiStringsApi: true,
   });
+
   mockApiClient.getBatteryInfo.mockResolvedValue({
-    // confirm we're rounding up and not considering this at the warning level
-    level: t.warningLevel + 0.007,
+    level: 0.11,
     discharging: true,
   });
   render(<BatteryLowAlert />);
+
+  // no warning initially, since we're above the threshold
+  await waitFor(() => {
+    // allow component to settle
+    expect(mockApiClient.getBatteryInfo).toHaveBeenCalledTimes(2);
+  });
   expect(screen.queryByRole('alertdialog')).toBeNull();
 
+  // warning at 10%
   mockApiClient.getBatteryInfo.mockResolvedValue({
-    // confirm we're rounding down and considering this at the warning level
-    level: t.warningLevel + 0.003,
+    level: 0.1,
     discharging: true,
   });
   const warning = await screen.findByRole('alertdialog');
   within(warning).getByRole('heading', { name: 'Low Battery Warning' });
   within(warning).getByText(
-    `The battery is at ${t.warningPercent} and is not charging. Please connect the power supply.`
+    `The battery is at 10% and is not charging. Please connect the power supply.`
   );
-
-  if (!t.canDismiss) {
-    expect(within(warning).queryButton('Dismiss')).toBeNull();
-    return;
-  }
-
   userEvent.click(within(warning).getButton('Dismiss'));
   expect(screen.queryByRole('alertdialog')).toBeNull();
 
-  // confirm the modal doesn't reappear if the battery is still at the warning level
+  // doesn't warn again if we haven't hit the next threshold
+  mockApiClient.getBatteryInfo.mockReset();
   mockApiClient.getBatteryInfo.mockResolvedValue({
-    level: t.warningLevel - 0.003,
+    level: 0.06,
     discharging: true,
   });
-  jest.advanceTimersByTime(5000);
-  await advancePromises(); // to make sure a re-render happens (coverage enforces this)
+  await waitFor(
+    // allow component to settle
+    () => {
+      expect(mockApiClient.getBatteryInfo).toHaveBeenCalledTimes(2);
+    },
+    {
+      timeout: BATTERY_POLLING_INTERVAL_GROUT * 3,
+    }
+  );
+  expect(screen.queryByRole('alertdialog')).toBeNull();
+
+  // warns again at 5%
+  mockApiClient.getBatteryInfo.mockResolvedValue({
+    level: 0.05,
+    discharging: true,
+  });
+  const secondWarning = await screen.findByRole('alertdialog');
+  within(secondWarning).getByRole('heading', { name: 'Low Battery Warning' });
+  within(secondWarning).getByText(
+    `The battery is at 5% and is not charging. Please connect the power supply.`
+  );
+  userEvent.click(within(secondWarning).getButton('Dismiss'));
   expect(screen.queryByRole('alertdialog')).toBeNull();
 });
 
-test('connecting power supply dismisses warning', async () => {
+test('connecting power supply dismisses warning, disconnecting brings warning back', async () => {
   const { render, mockApiClient } = newTestContext({
     skipUiStringsApi: true,
   });
   mockApiClient.getBatteryInfo.mockResolvedValue({
-    level: 0.15,
+    level: 0.08,
     discharging: true,
   });
   render(<BatteryLowAlert />);
 
-  const warning = await screen.findByRole('alertdialog');
-  within(warning).getByRole('heading', { name: 'Low Battery Warning' });
-  within(warning).getByText(
-    `The battery is at 15% and is not charging. Please connect the power supply.`
-  );
+  const modal = await screen.findByRole('alertdialog');
 
   // connect power
   mockApiClient.getBatteryInfo.mockResolvedValue({
-    level: 0.15,
+    level: 0.08,
     discharging: false,
   });
-  await waitForElementToBeRemoved(warning);
+  await waitForElementToBeRemoved(modal);
+
+  // disconnect power again
+  mockApiClient.getBatteryInfo.mockResolvedValue({
+    level: 0.08,
+    discharging: true,
+  });
+  await screen.findByRole('alertdialog');
 });
 
 test('nothing appears if battery info is null', async () => {
@@ -107,30 +107,9 @@ test('nothing appears if battery info is null', async () => {
   mockApiClient.getBatteryInfo.mockResolvedValue(null);
   render(<BatteryLowAlert />);
 
-  await advancePromises(); // to make sure a render happens (coverage enforces this)
+  await waitFor(() => {
+    // allow component to settle to avoid test warning
+    expect(mockApiClient.getBatteryInfo).toHaveBeenCalledTimes(2);
+  });
   expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
-});
-
-test('unplugging power when at a warning level triggers warning', async () => {
-  const { render, mockApiClient } = newTestContext({
-    skipUiStringsApi: true,
-  });
-  mockApiClient.getBatteryInfo.mockResolvedValue({
-    level: 0.15,
-    discharging: false,
-  });
-  render(<BatteryLowAlert />);
-
-  await advancePromises();
-  expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
-
-  mockApiClient.getBatteryInfo.mockResolvedValue({
-    level: 0.15,
-    discharging: true,
-  });
-  const warning = await screen.findByRole('alertdialog');
-  within(warning).getByRole('heading', { name: 'Low Battery Warning' });
-  within(warning).getByText(
-    `The battery is at 15% and is not charging. Please connect the power supply.`
-  );
 });

--- a/libs/ui/src/battery_low_alert.tsx
+++ b/libs/ui/src/battery_low_alert.tsx
@@ -1,0 +1,94 @@
+import React, { useState } from 'react';
+import { format } from '@votingworks/utils';
+import { Modal } from './modal';
+import { useQueryChangeListener } from './hooks/use_change_listener';
+import { useSystemCallApi } from './system_call_api';
+import { Button } from './button';
+import { H1, P } from './typography';
+import { Icons } from './icons';
+
+interface BatteryWarning {
+  level: number;
+  canDismiss: boolean;
+}
+
+const BATTERY_WARNINGS: BatteryWarning[] = [
+  { level: 0.15, canDismiss: true },
+  { level: 0.1, canDismiss: true },
+  { level: 0.05, canDismiss: true },
+  { level: 0.01, canDismiss: false },
+];
+
+function roundLevel(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/**
+ * A helper for SessionTimeLimitTracker
+ */
+export function BatteryLowAlert(): JSX.Element | null {
+  const systemCallApi = useSystemCallApi();
+  const batteryInfoQuery = systemCallApi.getBatteryInfo.useQuery();
+  const batteryInfo = batteryInfoQuery.data;
+  const [currentWarning, setCurrentWarning] = useState<BatteryWarning>();
+
+  useQueryChangeListener(batteryInfoQuery, {
+    onChange: (newBatteryInfo, previousBatteryInfo) => {
+      if (!newBatteryInfo) return;
+
+      // if the battery's charging, dismiss any existing warnings
+      if (!newBatteryInfo.discharging) {
+        setCurrentWarning(undefined);
+        return;
+      }
+
+      // if the rounded battery level hasn't changed, don't do anything
+      // unless the battery just started discharging
+      const newLevel = roundLevel(newBatteryInfo.level);
+      if (
+        previousBatteryInfo &&
+        newLevel === roundLevel(previousBatteryInfo.level) &&
+        previousBatteryInfo.discharging
+      ) {
+        return;
+      }
+
+      // if there is an applicable warning, show it
+      const applicableWarning = BATTERY_WARNINGS.find(
+        (w) => w.level === newLevel
+      );
+      if (applicableWarning) {
+        setCurrentWarning(applicableWarning);
+      }
+    },
+  });
+
+  if (!batteryInfo) {
+    return null;
+  }
+
+  if (!currentWarning) {
+    return null;
+  }
+
+  return (
+    <Modal
+      actions={
+        currentWarning.canDismiss ? (
+          <Button onPress={() => setCurrentWarning(undefined)}>Dismiss</Button>
+        ) : undefined
+      }
+      content={
+        <React.Fragment>
+          <H1>
+            <Icons.BatteryQuarter color="danger" /> Low Battery Warning
+          </H1>
+          <P>
+            The battery is at {format.percent(batteryInfo.level)} and is not
+            charging. Please connect the power supply.
+          </P>
+        </React.Fragment>
+      }
+    />
+  );
+}

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -37,6 +37,12 @@ import {
   faFileArrowDown,
   faChevronUp,
   faChevronDown,
+  faBatteryFull,
+  faBatteryThreeQuarters,
+  faBatteryHalf,
+  faBatteryQuarter,
+  faBatteryEmpty,
+  faBolt,
 } from '@fortawesome/free-solid-svg-icons';
 import {
   faXmarkCircle,
@@ -94,7 +100,7 @@ function iconColor(theme: UiTheme, color?: IconColor) {
   }[color];
 }
 
-function FaIcon(props: InnerProps): JSX.Element {
+export function FaIcon(props: InnerProps): JSX.Element {
   const { pulse, spin, type, color, style = {} } = props;
   const theme = useTheme();
 
@@ -123,6 +129,30 @@ export const Icons = {
 
   Backspace(props) {
     return <FaIcon {...props} type={faDeleteLeft} />;
+  },
+
+  BatteryFull(props) {
+    return <FaIcon {...props} type={faBatteryFull} />;
+  },
+
+  BatteryThreeQuarters(props) {
+    return <FaIcon {...props} type={faBatteryThreeQuarters} />;
+  },
+
+  BatteryHalf(props) {
+    return <FaIcon {...props} type={faBatteryHalf} />;
+  },
+
+  BatteryQuarter(props) {
+    return <FaIcon {...props} type={faBatteryQuarter} />;
+  },
+
+  BatteryEmpty(props) {
+    return <FaIcon {...props} type={faBatteryEmpty} />;
+  },
+
+  Bolt(props) {
+    return <FaIcon {...props} type={faBolt} />;
   },
 
   CaretDown(props) {

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -100,7 +100,7 @@ function iconColor(theme: UiTheme, color?: IconColor) {
   }[color];
 }
 
-export function FaIcon(props: InnerProps): JSX.Element {
+function FaIcon(props: InnerProps): JSX.Element {
   const { pulse, spin, type, color, style = {} } = props;
   const theme = useTheme();
 

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -112,3 +112,5 @@ export * from './checkbox';
 export * from './utils/pin_length';
 export * from './test-utils/mock_usb_drive';
 export * from './fonts/roboto';
+export * from './battery_display';
+export * from './battery_low_alert';

--- a/libs/ui/test/test_context.tsx
+++ b/libs/ui/test/test_context.tsx
@@ -17,8 +17,8 @@ import {
   useAudioContext,
 } from '../src/ui_strings/audio_context';
 import { UiStringsContextProvider } from '../src/ui_strings/ui_strings_context';
-import { render, RenderResult } from './react_testing_library';
-import { QUERY_CLIENT_DEFAULT_OPTIONS } from '../src';
+import { RenderResult, render } from './react_testing_library';
+import { QUERY_CLIENT_DEFAULT_OPTIONS, VxRenderOptions } from '../src';
 import {
   SystemCallReactQueryApi,
   createSystemCallApi,
@@ -31,7 +31,10 @@ export interface TestContext {
   getAudioContext: () => Optional<UiStringsAudioContextInterface>;
   getLanguageContext: () => Optional<LanguageContextInterface>;
   mockApiClient: jest.Mocked<ApiClient>;
-  render: (ui: React.ReactElement) => RenderResult;
+  render: (
+    ui: React.ReactElement,
+    renderOptions?: VxRenderOptions
+  ) => RenderResult;
 }
 
 export function newTestContext(
@@ -125,8 +128,8 @@ export function newTestContext(
 
   return {
     mockApiClient,
-    render: (ui) => {
-      const result = render(<Wrapper>{ui}</Wrapper>);
+    render: (ui, renderOptions) => {
+      const result = render(<Wrapper>{ui}</Wrapper>, renderOptions);
       return {
         ...result,
         rerender: (newUi) => result.rerender(<Wrapper>{newUi}</Wrapper>),


### PR DESCRIPTION
## Overview

Makes VxAdmin battery-aware, via three separate features:
1. Adds a battery display to the nav bar which indicates a variably filled battery icon, the percent, and a charge icon if the laptop is charging.
2. Creates a modal alert when the battery level drops to a warning level. Currently I have **dismissable** warnings at 15%, 10%, and 5%, and a non-dismissable warning at 1%.
3. Adds the same battery info the diagnostics screen.

## Demo Video or Screenshot

#### Battery Display

<img width="1209" alt="Screen Shot 2024-02-12 at 12 57 23 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/91b75841-ffbf-499c-bc66-6f3494a2daff">

<img width="1211" alt="Screen Shot 2024-02-12 at 12 56 58 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/c13b4ee4-8e7b-4eb1-8f42-4cb563bd51e4">

<img width="1210" alt="Screen Shot 2024-02-12 at 12 56 31 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/0e9f9ba2-23bb-475d-ad58-57be4922538b">

#### Battery Warning

<img width="1211" alt="Screen Shot 2024-02-13 at 11 00 30 AM" src="https://github.com/votingworks/vxsuite/assets/37960853/0d943a10-d2cd-4510-9572-a8c9ece5c295">

<img width="1208" alt="Screen Shot 2024-02-13 at 11 00 09 AM" src="https://github.com/votingworks/vxsuite/assets/37960853/451a05f8-b4a4-47d8-88ca-62f998b94a90">

#### Diagnostics Screen

<img width="1211" alt="Screen Shot 2024-02-13 at 11 41 23 AM" src="https://github.com/votingworks/vxsuite/assets/37960853/3422e82a-a929-4236-9d0d-1ff5afae82c1">

<img width="1211" alt="Screen Shot 2024-02-13 at 11 06 13 AM" src="https://github.com/votingworks/vxsuite/assets/37960853/23cb250d-7e31-4c30-9ee5-d3b844f45a67">

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
