### PR TITLE
feat(backend): add `readFile` and `readElection` helpers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -808,6 +808,29 @@ jobs:
       - store_test_results:
           path: libs/fixtures/reports/
 
+  # @votingworks/fs
+  test-libs-fs:
+    executor: nodejs
+    resource_class: xlarge
+    steps:
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            pnpm --dir libs/fs build
+      - run:
+          name: Lint
+          command: |
+            pnpm --dir libs/fs lint
+      - run:
+          name: Test
+          command: |
+            pnpm --dir libs/fs test
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./reports/
+      - store_test_results:
+          path: libs/fs/reports/
+
   # @votingworks/grout
   test-libs-grout:
     executor: nodejs
@@ -1249,6 +1272,7 @@ workflows:
       - test-libs-dev-dock-frontend
       - test-libs-eslint-plugin-vx
       - test-libs-fixtures
+      - test-libs-fs
       - test-libs-grout
       - test-libs-grout-test-utils
       - test-libs-hmpb-layout

--- a/apps/admin/backend/package.json
+++ b/apps/admin/backend/package.json
@@ -42,6 +42,7 @@
     "@votingworks/db": "workspace:*",
     "@votingworks/dev-dock-backend": "workspace:*",
     "@votingworks/fixtures": "workspace:*",
+    "@votingworks/fs": "workspace:*",
     "@votingworks/grout": "workspace:*",
     "@votingworks/image-utils": "workspace:*",
     "@votingworks/logging": "workspace:*",

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -8,7 +8,6 @@ import {
   ContestId,
   DEFAULT_SYSTEM_SETTINGS,
   Id,
-  safeParseElectionDefinition,
   SystemSettings,
   Tabulation,
   TEST_JURISDICTION,
@@ -48,14 +47,20 @@ import {
   ElectionPackageError,
   ElectionPackageWithFileContents,
   ExportDataError,
-  FileSystemEntry,
-  FileSystemEntryType,
-  ListDirectoryOnUsbDriveError,
   createSystemCallApi,
-  listDirectoryOnUsbDrive,
   readElectionPackageFromFile,
 } from '@votingworks/backend';
-import { UsbDrive, UsbDriveStatus } from '@votingworks/usb-drive';
+import {
+  FileSystemEntry,
+  FileSystemEntryType,
+  readElection,
+} from '@votingworks/fs';
+import {
+  ListDirectoryOnUsbDriveError,
+  listDirectoryOnUsbDrive,
+  UsbDrive,
+  UsbDriveStatus,
+} from '@votingworks/usb-drive';
 import ZipStream from 'zip-stream';
 import {
   CastVoteRecordFileRecord,
@@ -415,8 +420,8 @@ function buildApi({
 
       let electionPackage: ElectionPackageWithFileContents;
       if (input.electionFilePath.endsWith('.json')) {
-        const electionDefinitionResult = safeParseElectionDefinition(
-          await fs.readFile(input.electionFilePath, 'utf8')
+        const electionDefinitionResult = await readElection(
+          input.electionFilePath
         );
         if (electionDefinitionResult.isErr()) {
           return err({

--- a/apps/admin/backend/src/cast_vote_records.ts
+++ b/apps/admin/backend/src/cast_vote_records.ts
@@ -2,9 +2,7 @@ import { sha256 } from 'js-sha256';
 import path from 'path';
 import { v4 as uuid } from 'uuid';
 import {
-  FileSystemEntryType,
   isTestReport,
-  listDirectoryOnUsbDrive,
   readCastVoteRecordExport,
   readCastVoteRecordExportMetadata,
 } from '@votingworks/backend';
@@ -17,6 +15,7 @@ import {
   Result,
   throwIllegalValue,
 } from '@votingworks/basics';
+import { FileSystemEntryType } from '@votingworks/fs';
 import {
   BallotId,
   CVR,
@@ -25,7 +24,7 @@ import {
   getContests,
   getPrecinctById,
 } from '@votingworks/types';
-import { UsbDrive } from '@votingworks/usb-drive';
+import { listDirectoryOnUsbDrive, UsbDrive } from '@votingworks/usb-drive';
 import {
   BooleanEnvironmentVariableName,
   castVoteRecordHasValidContestReferences,

--- a/apps/admin/frontend/package.json
+++ b/apps/admin/frontend/package.json
@@ -130,6 +130,7 @@
     "@vitejs/plugin-react": "^1.3.2",
     "@votingworks/admin-backend": "workspace:*",
     "@votingworks/backend": "workspace:*",
+    "@votingworks/fs": "workspace:*",
     "@votingworks/grout-test-utils": "workspace:*",
     "@votingworks/monorepo-utils": "workspace:*",
     "@votingworks/printing": "workspace:*",

--- a/apps/admin/frontend/src/screens/unconfigured_screen.tsx
+++ b/apps/admin/frontend/src/screens/unconfigured_screen.tsx
@@ -10,7 +10,7 @@ import {
   Table,
   UsbDriveImage,
 } from '@votingworks/ui';
-import type { FileSystemEntry } from '@votingworks/backend';
+import type { FileSystemEntry } from '@votingworks/fs';
 import { assertDefined, throwIllegalValue } from '@votingworks/basics';
 import { Loading } from '../components/loading';
 import { NavigationScreen } from '../components/navigation_screen';

--- a/apps/admin/frontend/test/helpers/mock_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_api_client.ts
@@ -18,11 +18,8 @@ import type {
   TallyReportSpec,
   TallyReportWarning,
 } from '@votingworks/admin-backend';
-import {
-  BatteryInfo,
-  FileSystemEntry,
-  FileSystemEntryType,
-} from '@votingworks/backend';
+import { BatteryInfo } from '@votingworks/backend';
+import { FileSystemEntry, FileSystemEntryType } from '@votingworks/fs';
 import { Result, deferred, ok } from '@votingworks/basics';
 import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
 import { Buffer } from 'buffer';

--- a/apps/admin/frontend/tsconfig.json
+++ b/apps/admin/frontend/tsconfig.json
@@ -23,6 +23,7 @@
     { "path": "../../../libs/dev-dock/frontend/tsconfig.build.json" },
     { "path": "../../../libs/eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../../../libs/fixtures/tsconfig.build.json" },
+    { "path": "../../../libs/fs/tsconfig.build.json" },
     { "path": "../../../libs/grout/test-utils/tsconfig.build.json" },
     { "path": "../../../libs/grout/tsconfig.build.json" },
     { "path": "../../../libs/image-utils/tsconfig.build.json" },

--- a/libs/auth/package.json
+++ b/libs/auth/package.json
@@ -34,6 +34,7 @@
     "@votingworks/basics": "workspace:*",
     "@votingworks/db": "workspace:*",
     "@votingworks/fixtures": "workspace:*",
+    "@votingworks/fs": "workspace:*",
     "@votingworks/logging": "workspace:*",
     "@votingworks/types": "workspace:*",
     "@votingworks/utils": "workspace:*",

--- a/libs/auth/scripts/mock_card.ts
+++ b/libs/auth/scripts/mock_card.ts
@@ -1,13 +1,11 @@
-import * as fs from 'fs';
-import { sha256 } from 'js-sha256';
 import yargs from 'yargs/yargs';
+import { readElection } from '@votingworks/fs';
 import {
   assert,
   extractErrorMessage,
   Optional,
   throwIllegalValue,
 } from '@votingworks/basics';
-import { safeParseElection } from '@votingworks/types';
 
 import { DEV_JURISDICTION } from '../src/jurisdictions';
 import { mockCard } from '../src/mock_file_card';
@@ -91,13 +89,13 @@ async function parseCommandLineArgs(): Promise<MockCardInput> {
         `Must specify election definition for election manager and poll worker cards\n\n${helpMessage}`
       );
     }
-    const electionData = fs.readFileSync(args.electionDefinition, 'utf-8');
-    if (!safeParseElection(electionData).isOk()) {
+    const readElectionResult = await readElection(args.electionDefinition);
+    if (readElectionResult.isErr()) {
       throw new Error(
         `${args.electionDefinition} isn't a valid election definition`
       );
     }
-    electionHash = sha256(electionData);
+    electionHash = readElectionResult.ok().electionHash;
   }
 
   return {

--- a/libs/auth/tsconfig.build.json
+++ b/libs/auth/tsconfig.build.json
@@ -14,6 +14,7 @@
     { "path": "../db/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../fixtures/tsconfig.build.json" },
+    { "path": "../fs/tsconfig.build.json" },
     { "path": "../logging/tsconfig.build.json" },
     { "path": "../test-utils/tsconfig.build.json" },
     { "path": "../types/tsconfig.build.json" },

--- a/libs/auth/tsconfig.json
+++ b/libs/auth/tsconfig.json
@@ -15,6 +15,7 @@
     { "path": "../db/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../fixtures/tsconfig.build.json" },
+    { "path": "../fs/tsconfig.build.json" },
     { "path": "../logging/tsconfig.build.json" },
     { "path": "../test-utils/tsconfig.build.json" },
     { "path": "../types/tsconfig.build.json" },

--- a/libs/backend/package.json
+++ b/libs/backend/package.json
@@ -76,6 +76,7 @@
     "@types/stream-chopper": "workspace:*",
     "@types/stream-json": "^1.7.3",
     "@types/tmp": "0.2.4",
+    "@votingworks/fs": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
     "eslint-plugin-vx": "workspace:*",
     "fast-check": "2.23.2",

--- a/libs/backend/src/index.ts
+++ b/libs/backend/src/index.ts
@@ -4,7 +4,6 @@ export * from './detect_devices';
 export * from './dotenv';
 export * from './election_package';
 export * from './exporter';
-export * from './list_directory';
 export * from './system_call';
 export * from './scan_globals';
 export * from './split';

--- a/libs/backend/test/utils.ts
+++ b/libs/backend/test/utils.ts
@@ -13,16 +13,12 @@ import {
   MarkThresholds,
   PollsState,
 } from '@votingworks/types';
-
+import { FileSystemEntryType, listDirectoryRecursive } from '@votingworks/fs';
 import {
   CentralScannerStore,
   PrecinctScannerStore,
   ScannerStoreBase,
 } from '../src/cast_vote_records/export';
-import {
-  FileSystemEntryType,
-  listDirectoryRecursive,
-} from '../src/list_directory';
 
 class MockScannerStoreBase implements ScannerStoreBase {
   private batches: BatchInfo[];

--- a/libs/backend/tsconfig.json
+++ b/libs/backend/tsconfig.json
@@ -19,6 +19,7 @@
     { "path": "../../libs/basics/tsconfig.build.json" },
     { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../../libs/fixtures/tsconfig.build.json" },
+    { "path": "../../libs/fs/tsconfig.build.json" },
     { "path": "../../libs/grout/tsconfig.build.json" },
     { "path": "../../libs/logging/tsconfig.build.json" },
     { "path": "../../libs/test-utils/tsconfig.build.json" },

--- a/libs/cvr-fixture-generator/package.json
+++ b/libs/cvr-fixture-generator/package.json
@@ -27,6 +27,7 @@
     "@votingworks/basics": "workspace:*",
     "@votingworks/converter-nh-accuvote": "workspace:*",
     "@votingworks/fixtures": "workspace:*",
+    "@votingworks/fs": "workspace:*",
     "@votingworks/image-utils": "workspace:*",
     "@votingworks/types": "workspace:*",
     "@votingworks/utils": "workspace:*",

--- a/libs/cvr-fixture-generator/src/cli/generate/main.ts
+++ b/libs/cvr-fixture-generator/src/cli/generate/main.ts
@@ -5,13 +5,13 @@ import {
   CastVoteRecordExportFileName,
   CastVoteRecordExportMetadata,
   ballotPaperDimensions,
-  safeParseElectionDefinition,
 } from '@votingworks/types';
 import { assert, assertDefined, iter } from '@votingworks/basics';
 import {
   buildCastVoteRecordReportMetadata,
   buildBatchManifest,
 } from '@votingworks/backend';
+import { readElection } from '@votingworks/fs';
 import * as fs from 'fs';
 import yargs from 'yargs/yargs';
 import { writeImageData, createImageData } from '@votingworks/image-utils';
@@ -153,8 +153,8 @@ export async function main(
     (s) => `${s}`
   );
 
-  const electionDefinition = safeParseElectionDefinition(
-    fs.readFileSync(electionDefinitionPath).toString()
+  const electionDefinition = (
+    await readElection(electionDefinitionPath)
   ).unsafeUnwrap();
 
   const castVoteRecords = iter(

--- a/libs/cvr-fixture-generator/tsconfig.build.json
+++ b/libs/cvr-fixture-generator/tsconfig.build.json
@@ -14,6 +14,7 @@
     { "path": "../converter-nh-accuvote/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../fixtures/tsconfig.build.json" },
+    { "path": "../fs/tsconfig.build.json" },
     { "path": "../image-utils/tsconfig.build.json" },
     { "path": "../types/tsconfig.build.json" },
     { "path": "../utils/tsconfig.build.json" },

--- a/libs/cvr-fixture-generator/tsconfig.json
+++ b/libs/cvr-fixture-generator/tsconfig.json
@@ -16,6 +16,7 @@
     { "path": "../converter-nh-accuvote/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../fixtures/tsconfig.build.json" },
+    { "path": "../fs/tsconfig.build.json" },
     { "path": "../image-utils/tsconfig.build.json" },
     { "path": "../types/tsconfig.build.json" },
     { "path": "../utils/tsconfig.build.json" },

--- a/libs/dev-dock/backend/package.json
+++ b/libs/dev-dock/backend/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@votingworks/auth": "workspace:*",
     "@votingworks/basics": "workspace:*",
+    "@votingworks/fs": "workspace:*",
     "@votingworks/grout": "workspace:*",
     "@votingworks/printing": "workspace:*",
     "@votingworks/types": "workspace:*",

--- a/libs/dev-dock/backend/tsconfig.build.json
+++ b/libs/dev-dock/backend/tsconfig.build.json
@@ -14,6 +14,7 @@
     { "path": "../../basics/tsconfig.build.json" },
     { "path": "../../eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../../fixtures/tsconfig.build.json" },
+    { "path": "../../fs/tsconfig.build.json" },
     { "path": "../../grout/tsconfig.build.json" },
     { "path": "../../printing/tsconfig.build.json" },
     { "path": "../../test-utils/tsconfig.build.json" },

--- a/libs/dev-dock/backend/tsconfig.json
+++ b/libs/dev-dock/backend/tsconfig.json
@@ -15,6 +15,7 @@
     { "path": "../../basics/tsconfig.build.json" },
     { "path": "../../eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../../fixtures/tsconfig.build.json" },
+    { "path": "../../fs/tsconfig.build.json" },
     { "path": "../../grout/tsconfig.build.json" },
     { "path": "../../printing/tsconfig.build.json" },
     { "path": "../../test-utils/tsconfig.build.json" },

--- a/libs/fs/.eslintignore
+++ b/libs/fs/.eslintignore
@@ -1,0 +1,3 @@
+build
+coverage
+jest.config.js

--- a/libs/fs/.eslintrc.json
+++ b/libs/fs/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["plugin:vx/recommended"]
+}

--- a/libs/fs/README.md
+++ b/libs/fs/README.md
@@ -1,0 +1,14 @@
+# @votingworks/fs
+
+File system utilities for NodeJS in the vxsuite monorepo. This package is
+intended to be used _only_ in NodeJS, not in the browser. Do not use this
+package in any frontends.
+
+The functions exported by this package may duplicate functionality provided by
+NodeJS's built-in `fs` module, but they are intended to be either more
+convenient or safer to use. For example, `readFile` has a mandatory `maxSize`
+parameter to prevent reading large files into memory.
+
+## License
+
+GPLv3

--- a/libs/fs/jest.config.js
+++ b/libs/fs/jest.config.js
@@ -1,0 +1,17 @@
+const shared = require('../../jest.config.shared');
+
+/**
+ * @type {import('@jest/types').Config.InitialOptions}
+ */
+module.exports = {
+  ...shared,
+  coveragePathIgnorePatterns: ['test'],
+  coverageThreshold: {
+    global: {
+      statements: 100,
+      branches: 100,
+      functions: 100,
+      lines: 100,
+    },
+  },
+};

--- a/libs/fs/package.json
+++ b/libs/fs/package.json
@@ -1,15 +1,18 @@
 {
-  "name": "@votingworks/usb-drive",
+  "name": "@votingworks/fs",
   "version": "1.0.0",
   "private": true,
-  "description": "Library for interacting with a USB drive",
+  "description": "File system utilities for VotingWorks projects",
   "license": "GPL-3.0",
   "author": "VotingWorks Eng <eng@voting.works>",
   "main": "build/index.js",
   "types": "build/index.d.js",
+  "files": [
+    "build"
+  ],
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
-    "clean": "rm -rf build *.tsbuildinfo",
+    "clean": "rm -rf build tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "pnpm type-check && eslint .",
     "lint:fix": "pnpm type-check && eslint . --fix",
     "pre-commit": "lint-staged",
@@ -32,27 +35,31 @@
   },
   "dependencies": {
     "@votingworks/basics": "workspace:*",
-    "@votingworks/fs": "workspace:*",
+    "@votingworks/grout": "workspace:*",
     "@votingworks/logging": "workspace:*",
-    "@votingworks/test-utils": "workspace:*",
+    "@votingworks/types": "workspace:*",
     "@votingworks/utils": "workspace:*",
-    "debug": "4.3.4",
-    "tmp": "^0.2.1"
+    "buffer": "^6.0.3",
+    "micromatch": "^4.0.5",
+    "zod": "3.14.4"
   },
   "devDependencies": {
     "@types/debug": "4.1.8",
     "@types/jest": "^29.5.3",
     "@types/node": "16.18.23",
     "@types/tmp": "0.2.4",
-    "esbuild": "0.17.11",
-    "esbuild-runner": "2.2.2",
+    "@votingworks/fixtures": "workspace:*",
+    "@votingworks/test-utils": "workspace:*",
     "eslint-plugin-vx": "workspace:*",
+    "fast-check": "2.23.2",
     "is-ci-cli": "2.2.0",
     "jest": "^29.6.2",
     "jest-junit": "^16.0.0",
     "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "11.0.0",
+    "memory-streams": "^0.1.3",
     "sort-package-json": "^1.50.0",
+    "tmp": "^0.2.1",
     "ts-jest": "29.1.1"
   },
   "packageManager": "pnpm@8.1.0"

--- a/libs/fs/src/election.test.ts
+++ b/libs/fs/src/election.test.ts
@@ -1,0 +1,72 @@
+import { err, ok, typedAs } from '@votingworks/basics';
+import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import { writeFileSync } from 'fs';
+import { makeTmpFile } from '../test/utils';
+import { ReadElectionError, readElection } from './election';
+
+test('syntax error', async () => {
+  const path = makeTmpFile();
+  writeFileSync(path, 'invalid json');
+  expect(await readElection(path)).toEqual(
+    err(
+      typedAs<ReadElectionError>({
+        type: 'ParseError',
+        error: expect.any(SyntaxError),
+      })
+    )
+  );
+});
+
+test('parse error', async () => {
+  const path = makeTmpFile();
+  writeFileSync(path, '{"invalid": "election"}');
+  expect(await readElection(path)).toEqual(
+    err(
+      typedAs<ReadElectionError>({
+        type: 'ParseError',
+        error: expect.any(Error),
+      })
+    )
+  );
+});
+
+test('file system error: no such file', async () => {
+  const path = makeTmpFile();
+  expect(await readElection(path)).toEqual(
+    err(
+      typedAs<ReadElectionError>({
+        type: 'ReadFileError',
+        error: {
+          type: 'OpenFileError',
+          error: expect.objectContaining({ code: 'ENOENT' }),
+        },
+      })
+    )
+  );
+});
+
+test('file system error: file exceeds max size', async () => {
+  const path = makeTmpFile();
+  writeFileSync(path, 'a'.repeat(10 * 1024 * 1024 + 1));
+  expect(await readElection(path)).toEqual(
+    err(
+      typedAs<ReadElectionError>({
+        type: 'ReadFileError',
+        error: {
+          type: 'FileExceedsMaxSize',
+          maxSize: 10 * 1024 * 1024,
+          fileSize: 10 * 1024 * 1024 + 1,
+        },
+      })
+    )
+  );
+});
+
+test('success', async () => {
+  const path = makeTmpFile();
+  const contents = electionFamousNames2021Fixtures.electionJson.asText();
+  writeFileSync(path, contents);
+  expect(await readElection(path)).toEqual(
+    ok(electionFamousNames2021Fixtures.electionDefinition)
+  );
+});

--- a/libs/fs/src/election.ts
+++ b/libs/fs/src/election.ts
@@ -1,0 +1,43 @@
+import { Result, err } from '@votingworks/basics';
+import {
+  ElectionDefinition,
+  safeParseElectionDefinition,
+} from '@votingworks/types';
+import { ZodError } from 'zod';
+import { ReadFileError, readFile } from './read_file';
+
+/**
+ * Possible errors that can occur when reading an election.
+ */
+export type ReadElectionError =
+  | { type: 'ReadFileError'; error: ReadFileError }
+  | { type: 'ParseError'; error: ZodError | SyntaxError };
+
+/**
+ * Maximum size of an election file (10 MB).
+ */
+const MAX_ELECTION_SIZE = 10 * 1024 * 1024;
+
+/**
+ * Reads an election from a file path.
+ */
+export async function readElection(
+  electionPath: string
+): Promise<Result<ElectionDefinition, ReadElectionError>> {
+  const readFileResult = await readFile(electionPath, {
+    maxSize: MAX_ELECTION_SIZE,
+    encoding: 'utf-8',
+  });
+
+  if (readFileResult.isErr()) {
+    return err({ type: 'ReadFileError', error: readFileResult.err() });
+  }
+
+  const parseResult = safeParseElectionDefinition(readFileResult.ok());
+
+  if (parseResult.isErr()) {
+    return err({ type: 'ParseError', error: parseResult.err() });
+  }
+
+  return parseResult;
+}

--- a/libs/fs/src/index.ts
+++ b/libs/fs/src/index.ts
@@ -1,0 +1,5 @@
+/* istanbul ignore file */
+export * from './election';
+export * from './list_directory';
+export * from './open_file';
+export * from './read_file';

--- a/libs/fs/src/list_directory.test.ts
+++ b/libs/fs/src/list_directory.test.ts
@@ -1,14 +1,12 @@
 import { iter } from '@votingworks/basics';
 import tmp from 'tmp';
-import { UsbDriveStatus, createMockUsbDrive } from '@votingworks/usb-drive';
 import {
   FileSystemEntryType,
   listDirectory,
-  listDirectoryOnUsbDrive,
   listDirectoryRecursive,
 } from './list_directory';
 
-describe('listDirectory', () => {
+describe(listDirectory, () => {
   test('happy path', async () => {
     const directory = tmp.dirSync();
     tmp.fileSync({ name: 'file-1', dir: directory.name });
@@ -93,80 +91,5 @@ describe(listDirectoryRecursive, () => {
   test('bubbles up root errors', () => {
     const results = iter(listDirectoryRecursive('/tmp/no-entity'));
     expect(results.some((result) => result.isErr())).toBeTruthy();
-  });
-});
-
-describe('listDirectoryOnUsbDrive', () => {
-  test('happy path', async () => {
-    const mockMountPoint = tmp.dirSync();
-    const { usbDrive } = createMockUsbDrive();
-    usbDrive.status.expectCallWith().resolves({
-      status: 'mounted',
-      mountPoint: mockMountPoint.name,
-    });
-
-    const directory = tmp.dirSync({
-      name: 'directory',
-      dir: mockMountPoint.name,
-    });
-    tmp.fileSync({ name: 'file-1', dir: directory.name });
-    tmp.fileSync({ name: 'file-2', dir: directory.name });
-    tmp.dirSync({
-      name: 'subdirectory',
-      dir: directory.name,
-    });
-
-    const listDirectoryResult = await listDirectoryOnUsbDrive(
-      usbDrive,
-      './directory'
-    );
-    expect(listDirectoryResult.isOk()).toBeTruthy();
-
-    expect(listDirectoryResult.ok()).toMatchObject([
-      expect.objectContaining({
-        name: 'file-1',
-        type: FileSystemEntryType.File,
-      }),
-      expect.objectContaining({
-        name: 'file-2',
-        type: FileSystemEntryType.File,
-      }),
-      expect.objectContaining({
-        name: 'subdirectory',
-        type: FileSystemEntryType.Directory,
-      }),
-    ]);
-  });
-
-  test('error on no usb drive', async () => {
-    const { usbDrive } = createMockUsbDrive();
-    usbDrive.status.expectCallWith().resolves({
-      status: 'no_drive',
-    });
-    const listDirectoryResult = await listDirectoryOnUsbDrive(
-      usbDrive,
-      './directory'
-    );
-    expect(listDirectoryResult.isErr()).toBeTruthy();
-    expect(listDirectoryResult.err()).toMatchObject({ type: 'no-usb-drive' });
-  });
-
-  test('error on unmounted usb drive', async () => {
-    const unmountedStatuses: UsbDriveStatus[] = [
-      { status: 'ejected' },
-      { status: 'error', reason: 'bad_format' },
-    ];
-    for (const status of unmountedStatuses) {
-      const { usbDrive } = createMockUsbDrive();
-      usbDrive.status.expectCallWith().resolves(status);
-      const listDirectoryResult = await listDirectoryOnUsbDrive(
-        usbDrive,
-        './directory'
-      );
-      expect(listDirectoryResult.isErr()).toBeTruthy();
-      expect(listDirectoryResult.err()).toMatchObject({
-        type: 'usb-drive-not-mounted',
-      });
-    }
   });
 });

--- a/libs/fs/src/open_file.test.ts
+++ b/libs/fs/src/open_file.test.ts
@@ -1,0 +1,10 @@
+import { err } from '@votingworks/basics';
+import { makeTmpFile } from '../test/utils';
+import { open } from './open_file';
+
+test('file open error', async () => {
+  const path = makeTmpFile();
+  expect(await open(path)).toEqual(
+    err(expect.objectContaining({ code: 'ENOENT' }))
+  );
+});

--- a/libs/fs/src/open_file.ts
+++ b/libs/fs/src/open_file.ts
@@ -1,0 +1,20 @@
+import { Result, err, ok } from '@votingworks/basics';
+import { Mode } from 'fs';
+import { FileHandle, open as fsOpen } from 'fs/promises';
+
+/**
+ * Opens a file and returns a file descriptor. You are responsible for closing
+ * the file descriptor when you are done with it. Use `readFile` instead if you
+ * need to read the entire file into memory.
+ */
+export async function open(
+  path: string,
+  flags?: string | number,
+  mode?: Mode
+): Promise<Result<FileHandle, Error>> {
+  try {
+    return ok(await fsOpen(path, flags, mode));
+  } catch (error) {
+    return err(error as Error);
+  }
+}

--- a/libs/fs/src/read_file.test.ts
+++ b/libs/fs/src/read_file.test.ts
@@ -1,0 +1,71 @@
+import { Buffer } from 'buffer';
+import { writeFileSync } from 'fs';
+import { err, ok, typedAs } from '@votingworks/basics';
+import fc from 'fast-check';
+import { ReadFileError, readFile } from './read_file';
+import { makeTmpFile } from '../test/utils';
+
+test('file open error', async () => {
+  const path = makeTmpFile();
+  expect(await readFile(path, { maxSize: 1024 })).toEqual(
+    err(
+      typedAs<ReadFileError>({
+        type: 'OpenFileError',
+        error: expect.objectContaining({ code: 'ENOENT' }),
+      })
+    )
+  );
+});
+
+test('file exceeds max size', async () => {
+  await fc.assert(
+    fc.asyncProperty(fc.nat(1024 * 1024 * 10), async (maxSize) => {
+      const path = makeTmpFile();
+      writeFileSync(path, 'a'.repeat(maxSize + 1));
+      expect(await readFile(path, { maxSize })).toEqual(
+        err(
+          typedAs<ReadFileError>({
+            type: 'FileExceedsMaxSize',
+            maxSize,
+            fileSize: maxSize + 1,
+          })
+        )
+      );
+    })
+  );
+});
+
+test('invalid maxSize', async () => {
+  await expect(readFile('path', { maxSize: -1 })).rejects.toThrow(
+    'maxSize must be non-negative'
+  );
+});
+
+test('success', async () => {
+  {
+    const path = makeTmpFile();
+    const contents = 'file contents';
+
+    writeFileSync(path, contents);
+
+    const buffer = (await readFile(path, { maxSize: 1024 })).unsafeUnwrap();
+    expect(buffer).toBeInstanceOf(Buffer);
+    expect(buffer.toString('utf-8')).toEqual(contents);
+
+    expect(await readFile(path, { maxSize: 1024, encoding: 'utf-8' })).toEqual(
+      ok(contents)
+    );
+  }
+
+  await fc.assert(
+    fc.asyncProperty(fc.uint8Array(), async (contents) => {
+      const path = makeTmpFile();
+      writeFileSync(path, contents);
+      expect(
+        await readFile(path, {
+          maxSize: contents.byteLength,
+        })
+      ).toEqual(ok(Buffer.from(contents)));
+    })
+  );
+});

--- a/libs/fs/src/read_file.ts
+++ b/libs/fs/src/read_file.ts
@@ -1,0 +1,84 @@
+import { Result, err, ok } from '@votingworks/basics';
+import { Buffer } from 'buffer';
+import { open } from './open_file';
+
+/**
+ * Possible errors that can occur when reading a file.
+ */
+export type ReadFileError =
+  | { type: 'OpenFileError'; error: globalThis.Error }
+  | { type: 'FileExceedsMaxSize'; maxSize: number; fileSize: number }
+  | { type: 'ReadFileError'; error: globalThis.Error };
+
+/**
+ * Reads the entire contents of a file. If the file is larger than `maxSize`
+ * then an error is returned without reading the file.
+ *
+ * @param path The path to the file to read.
+ * @param maxSize The maximum size of the file to read in bytes.
+ */
+export async function readFile(
+  path: string,
+  { maxSize }: { maxSize: number }
+): Promise<Result<Buffer, ReadFileError>>;
+/**
+ * Reads the entire contents of a file. If the file is larger than `maxSize`
+ * then an error is returned without reading the file.
+ *
+ * @param path The path to the file to read.
+ * @param maxSize The maximum size of the file to read in bytes.
+ */
+export async function readFile(
+  path: string,
+  { maxSize, encoding }: { maxSize: number; encoding: BufferEncoding }
+): Promise<Result<string, ReadFileError>>;
+/**
+ * Reads the entire contents of a file. If the file is larger than `maxSize`
+ * then an error is returned without reading the file.
+ *
+ * @param path The path to the file to read.
+ * @param maxSize The maximum size of the file to read in bytes.
+ */
+export async function readFile(
+  path: string,
+  { maxSize, encoding }: { maxSize: number; encoding?: BufferEncoding }
+): Promise<Result<Buffer | string, ReadFileError>> {
+  if (maxSize < 0) {
+    throw new Error('maxSize must be non-negative');
+  }
+
+  const openResult = await open(path);
+
+  if (openResult.isErr()) {
+    return err({ type: 'OpenFileError', error: openResult.err() });
+  }
+
+  const fd = openResult.ok();
+  const stat = await fd.stat();
+
+  if (stat.size > maxSize) {
+    await fd.close();
+    return err({
+      type: 'FileExceedsMaxSize',
+      maxSize,
+      fileSize: stat.size,
+    });
+  }
+
+  const buffer = Buffer.allocUnsafe(stat.size);
+  const readResult = await fd.read(buffer, 0, stat.size, 0);
+
+  /* istanbul ignore next */
+  if (readResult.bytesRead !== stat.size) {
+    await fd.close();
+    return err({
+      type: 'ReadFileError',
+      error: new Error(
+        `unexpected number of bytes read: ${readResult.bytesRead} instead of ${stat.size}`
+      ),
+    });
+  }
+
+  await fd.close();
+  return ok(encoding ? buffer.toString(encoding) : buffer);
+}

--- a/libs/fs/test/utils.ts
+++ b/libs/fs/test/utils.ts
@@ -1,0 +1,26 @@
+import { unlinkSync } from 'fs';
+import { tmpNameSync } from 'tmp';
+
+const tmpFilePaths: string[] = [];
+
+function cleanupTmpFiles() {
+  for (const path of tmpFilePaths) {
+    try {
+      unlinkSync(path);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+/**
+ * Creates a temporary file and returns its path. The file will be deleted when
+ * the test suite is finished.
+ */
+export function makeTmpFile(): string {
+  const path = tmpNameSync();
+  tmpFilePaths.push(path);
+  return path;
+}
+
+afterEach(cleanupTmpFiles);

--- a/libs/fs/tsconfig.build.json
+++ b/libs/fs/tsconfig.build.json
@@ -9,16 +9,12 @@
     "declaration": true
   },
   "references": [
-    { "path": "../../libs/auth/tsconfig.build.json" },
     { "path": "../../libs/basics/tsconfig.build.json" },
     { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../../libs/fixtures/tsconfig.build.json" },
-    { "path": "../../libs/fs/tsconfig.build.json" },
-    { "path": "../../libs/grout/tsconfig.build.json" },
     { "path": "../../libs/logging/tsconfig.build.json" },
     { "path": "../../libs/test-utils/tsconfig.build.json" },
     { "path": "../../libs/types/tsconfig.build.json" },
-    { "path": "../../libs/usb-drive/tsconfig.build.json" },
     { "path": "../../libs/utils/tsconfig.build.json" }
   ]
 }

--- a/libs/fs/tsconfig.json
+++ b/libs/fs/tsconfig.json
@@ -1,24 +1,26 @@
 {
-  "extends": "./tsconfig.json",
-  "include": ["src", "src/data/*.json"],
-  "exclude": ["**/*.test.ts", "**/*.test.tsx"],
+  "extends": "../../tsconfig.shared.json",
+  "include": ["src", "src/data/*.json", "test"],
+  "exclude": [],
   "compilerOptions": {
-    "noEmit": false,
-    "rootDir": "src",
-    "outDir": "build",
-    "declaration": true
+    "module": "node16",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "composite": true,
+    "noEmit": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
   },
   "references": [
-    { "path": "../../libs/auth/tsconfig.build.json" },
     { "path": "../../libs/basics/tsconfig.build.json" },
     { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../../libs/fixtures/tsconfig.build.json" },
-    { "path": "../../libs/fs/tsconfig.build.json" },
-    { "path": "../../libs/grout/tsconfig.build.json" },
     { "path": "../../libs/logging/tsconfig.build.json" },
     { "path": "../../libs/test-utils/tsconfig.build.json" },
     { "path": "../../libs/types/tsconfig.build.json" },
-    { "path": "../../libs/usb-drive/tsconfig.build.json" },
     { "path": "../../libs/utils/tsconfig.build.json" }
   ]
 }

--- a/libs/printing/package.json
+++ b/libs/printing/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@votingworks/basics": "workspace:*",
     "@votingworks/fixtures": "workspace:*",
+    "@votingworks/fs": "workspace:*",
     "@votingworks/logging": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
     "@votingworks/types": "workspace:*",

--- a/libs/printing/scripts/render_tally_report.tsx
+++ b/libs/printing/scripts/render_tally_report.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { safeParseElectionDefinition } from '@votingworks/types';
-import { readFileSync } from 'fs';
+import { readElection } from '@votingworks/fs';
 import { AdminTallyReportByParty } from '@votingworks/ui';
 import { buildSimpleMockTallyReportResults } from '@votingworks/utils';
 import { renderToPdf } from '../src';
@@ -13,9 +12,7 @@ export async function main(args: readonly string[]): Promise<void> {
 
   const electionPath = args[0];
   const outputPath = args[1];
-  const electionDefinition = safeParseElectionDefinition(
-    readFileSync(electionPath, 'utf8')
-  ).unsafeUnwrap();
+  const electionDefinition = (await readElection(electionPath)).unsafeUnwrap();
   const { election } = electionDefinition;
 
   await renderToPdf(

--- a/libs/printing/tsconfig.build.json
+++ b/libs/printing/tsconfig.build.json
@@ -13,6 +13,7 @@
     { "path": "../basics/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../fixtures/tsconfig.build.json" },
+    { "path": "../fs/tsconfig.build.json" },
     { "path": "../image-utils/tsconfig.build.json" },
     { "path": "../logging/tsconfig.build.json" },
     { "path": "../test-utils/tsconfig.build.json" },

--- a/libs/printing/tsconfig.json
+++ b/libs/printing/tsconfig.json
@@ -21,6 +21,7 @@
     { "path": "../basics/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../fixtures/tsconfig.build.json" },
+    { "path": "../fs/tsconfig.build.json" },
     { "path": "../image-utils/tsconfig.build.json" },
     { "path": "../logging/tsconfig.build.json" },
     { "path": "../test-utils/tsconfig.build.json" },

--- a/libs/usb-drive/src/index.ts
+++ b/libs/usb-drive/src/index.ts
@@ -1,4 +1,5 @@
 /* istanbul ignore file */
+export * from './list_directory_on_usb_drive';
 export * from './mocks/memory_usb_drive';
 export * from './mocks/file_usb_drive';
 export * from './types';

--- a/libs/usb-drive/src/list_directory_on_usb_drive.test.ts
+++ b/libs/usb-drive/src/list_directory_on_usb_drive.test.ts
@@ -1,0 +1,80 @@
+import { FileSystemEntryType } from '@votingworks/fs';
+import tmp from 'tmp';
+import { listDirectoryOnUsbDrive } from './list_directory_on_usb_drive';
+import { createMockUsbDrive } from './mocks/memory_usb_drive';
+import { UsbDriveStatus } from './types';
+
+describe('listDirectoryOnUsbDrive', () => {
+  test('happy path', async () => {
+    const mockMountPoint = tmp.dirSync();
+    const { usbDrive } = createMockUsbDrive();
+    usbDrive.status.expectCallWith().resolves({
+      status: 'mounted',
+      mountPoint: mockMountPoint.name,
+    });
+
+    const directory = tmp.dirSync({
+      name: 'directory',
+      dir: mockMountPoint.name,
+    });
+    tmp.fileSync({ name: 'file-1', dir: directory.name });
+    tmp.fileSync({ name: 'file-2', dir: directory.name });
+    tmp.dirSync({
+      name: 'subdirectory',
+      dir: directory.name,
+    });
+
+    const listDirectoryResult = await listDirectoryOnUsbDrive(
+      usbDrive,
+      './directory'
+    );
+    expect(listDirectoryResult.isOk()).toBeTruthy();
+
+    expect(listDirectoryResult.ok()).toMatchObject([
+      expect.objectContaining({
+        name: 'file-1',
+        type: FileSystemEntryType.File,
+      }),
+      expect.objectContaining({
+        name: 'file-2',
+        type: FileSystemEntryType.File,
+      }),
+      expect.objectContaining({
+        name: 'subdirectory',
+        type: FileSystemEntryType.Directory,
+      }),
+    ]);
+  });
+
+  test('error on no usb drive', async () => {
+    const { usbDrive } = createMockUsbDrive();
+    usbDrive.status.expectCallWith().resolves({
+      status: 'no_drive',
+    });
+    const listDirectoryResult = await listDirectoryOnUsbDrive(
+      usbDrive,
+      './directory'
+    );
+    expect(listDirectoryResult.isErr()).toBeTruthy();
+    expect(listDirectoryResult.err()).toMatchObject({ type: 'no-usb-drive' });
+  });
+
+  test('error on unmounted usb drive', async () => {
+    const unmountedStatuses: UsbDriveStatus[] = [
+      { status: 'ejected' },
+      { status: 'error', reason: 'bad_format' },
+    ];
+    for (const status of unmountedStatuses) {
+      const { usbDrive } = createMockUsbDrive();
+      usbDrive.status.expectCallWith().resolves(status);
+      const listDirectoryResult = await listDirectoryOnUsbDrive(
+        usbDrive,
+        './directory'
+      );
+      expect(listDirectoryResult.isErr()).toBeTruthy();
+      expect(listDirectoryResult.err()).toMatchObject({
+        type: 'usb-drive-not-mounted',
+      });
+    }
+  });
+});

--- a/libs/usb-drive/src/list_directory_on_usb_drive.ts
+++ b/libs/usb-drive/src/list_directory_on_usb_drive.ts
@@ -1,0 +1,39 @@
+import { Result, err, throwIllegalValue } from '@votingworks/basics';
+import {
+  FileSystemEntry,
+  ListDirectoryError,
+  listDirectory,
+} from '@votingworks/fs';
+import { join } from 'path';
+import { UsbDrive } from './types';
+
+/**
+ * Expected errors that can occur when trying to list directories on a USB drive.
+ */
+export type ListDirectoryOnUsbDriveError =
+  | ListDirectoryError
+  | { type: 'no-usb-drive' }
+  | { type: 'usb-drive-not-mounted' };
+/**
+ * Lists entities in a directory specified by a relative path within a USB
+ * drive's filesystem. Looks at only the first found USB drive.
+ */
+export async function listDirectoryOnUsbDrive(
+  usbDrive: UsbDrive,
+  relativePath: string
+): Promise<Result<FileSystemEntry[], ListDirectoryOnUsbDriveError>> {
+  const usbDriveStatus = await usbDrive.status();
+
+  switch (usbDriveStatus.status) {
+    case 'no_drive':
+      return err({ type: 'no-usb-drive' });
+    case 'ejected':
+    case 'error':
+      return err({ type: 'usb-drive-not-mounted' });
+    case 'mounted':
+      return await listDirectory(join(usbDriveStatus.mountPoint, relativePath));
+    // istanbul ignore next
+    default:
+      throwIllegalValue(usbDriveStatus);
+  }
+}

--- a/libs/usb-drive/tsconfig.build.json
+++ b/libs/usb-drive/tsconfig.build.json
@@ -12,6 +12,7 @@
   "references": [
     { "path": "../basics/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
+    { "path": "../fs/tsconfig.build.json" },
     { "path": "../logging/tsconfig.build.json" },
     { "path": "../test-utils/tsconfig.build.json" }
   ]

--- a/libs/usb-drive/tsconfig.json
+++ b/libs/usb-drive/tsconfig.json
@@ -13,6 +13,7 @@
   "references": [
     { "path": "../basics/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
+    { "path": "../fs/tsconfig.build.json" },
     { "path": "../logging/tsconfig.build.json" },
     { "path": "../test-utils/tsconfig.build.json" }
   ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       '@votingworks/fixtures':
         specifier: workspace:*
         version: link:../../../libs/fixtures
+      '@votingworks/fs':
+        specifier: workspace:*
+        version: link:../../../libs/fs
       '@votingworks/grout':
         specifier: workspace:*
         version: link:../../../libs/grout
@@ -566,6 +569,9 @@ importers:
       '@votingworks/backend':
         specifier: workspace:*
         version: link:../../../libs/backend
+      '@votingworks/fs':
+        specifier: workspace:*
+        version: link:../../../libs/fs
       '@votingworks/grout-test-utils':
         specifier: workspace:*
         version: link:../../../libs/grout/test-utils
@@ -2853,6 +2859,9 @@ importers:
       '@votingworks/fixtures':
         specifier: workspace:*
         version: link:../fixtures
+      '@votingworks/fs':
+        specifier: workspace:*
+        version: link:../fs
       '@votingworks/logging':
         specifier: workspace:*
         version: link:../logging
@@ -3080,6 +3089,9 @@ importers:
       '@types/tmp':
         specifier: 0.2.4
         version: 0.2.4
+      '@votingworks/fs':
+        specifier: workspace:*
+        version: link:../fs
       '@votingworks/test-utils':
         specifier: workspace:*
         version: link:../test-utils
@@ -3672,6 +3684,9 @@ importers:
       '@votingworks/fixtures':
         specifier: workspace:*
         version: link:../fixtures
+      '@votingworks/fs':
+        specifier: workspace:*
+        version: link:../fs
       '@votingworks/image-utils':
         specifier: workspace:*
         version: link:../image-utils
@@ -3800,6 +3815,9 @@ importers:
       '@votingworks/basics':
         specifier: workspace:*
         version: link:../../basics
+      '@votingworks/fs':
+        specifier: workspace:*
+        version: link:../../fs
       '@votingworks/grout':
         specifier: workspace:*
         version: link:../../grout
@@ -4095,6 +4113,85 @@ importers:
       sort-package-json:
         specifier: ^1.50.0
         version: 1.50.0
+      ts-jest:
+        specifier: 29.1.1
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+
+  libs/fs:
+    dependencies:
+      '@votingworks/basics':
+        specifier: workspace:*
+        version: link:../basics
+      '@votingworks/grout':
+        specifier: workspace:*
+        version: link:../grout
+      '@votingworks/logging':
+        specifier: workspace:*
+        version: link:../logging
+      '@votingworks/types':
+        specifier: workspace:*
+        version: link:../types
+      '@votingworks/utils':
+        specifier: workspace:*
+        version: link:../utils
+      buffer:
+        specifier: ^6.0.3
+        version: 6.0.3
+      micromatch:
+        specifier: ^4.0.5
+        version: 4.0.5
+      zod:
+        specifier: 3.14.4
+        version: 3.14.4
+    devDependencies:
+      '@types/debug':
+        specifier: 4.1.8
+        version: 4.1.8
+      '@types/jest':
+        specifier: ^29.5.3
+        version: 29.5.3
+      '@types/node':
+        specifier: 16.18.23
+        version: 16.18.23
+      '@types/tmp':
+        specifier: 0.2.4
+        version: 0.2.4
+      '@votingworks/fixtures':
+        specifier: workspace:*
+        version: link:../fixtures
+      '@votingworks/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      eslint-plugin-vx:
+        specifier: workspace:*
+        version: link:../eslint-plugin-vx
+      fast-check:
+        specifier: 2.23.2
+        version: 2.23.2
+      is-ci-cli:
+        specifier: 2.2.0
+        version: 2.2.0
+      jest:
+        specifier: ^29.6.2
+        version: 29.6.2(@types/node@16.18.23)
+      jest-junit:
+        specifier: ^16.0.0
+        version: 16.0.0
+      jest-watch-typeahead:
+        specifier: ^2.2.2
+        version: 2.2.2(jest@29.6.2)
+      lint-staged:
+        specifier: 11.0.0
+        version: 11.0.0
+      memory-streams:
+        specifier: ^0.1.3
+        version: 0.1.3
+      sort-package-json:
+        specifier: ^1.50.0
+        version: 1.50.0
+      tmp:
+        specifier: ^0.2.1
+        version: 0.2.1
       ts-jest:
         specifier: 29.1.1
         version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
@@ -4887,6 +4984,9 @@ importers:
       '@votingworks/fixtures':
         specifier: workspace:*
         version: link:../fixtures
+      '@votingworks/fs':
+        specifier: workspace:*
+        version: link:../fs
       '@votingworks/logging':
         specifier: workspace:*
         version: link:../logging
@@ -5506,6 +5606,9 @@ importers:
       '@votingworks/basics':
         specifier: workspace:*
         version: link:../basics
+      '@votingworks/fs':
+        specifier: workspace:*
+        version: link:../fs
       '@votingworks/logging':
         specifier: workspace:*
         version: link:../logging

--- a/vxsuite.code-workspace
+++ b/vxsuite.code-workspace
@@ -121,6 +121,10 @@
       "path": "libs/fixtures"
     },
     {
+      "name": "libs/fs",
+      "path": "libs/fs"
+    },
+    {
       "name": "libs/grout",
       "path": "libs/grout"
     },


### PR DESCRIPTION
## Overview
Introduces a `readFile` helper that gets us moving toward #4443. The idea is that if you _have_ to read the file all at once, then we should cap the size. I opted to start by using this for a new `readElection` helper, which is a fairly common operation. This introduces a limit of 10MB for election definitions. In our election-definitions repo the biggest ones I found (using `find . -name election.json`) were 208KB, so this should give us plenty of room.

## Demo Video or Screenshot
```ts
import { readElection, readFile } from '@votingworks/fs';

// read an election from a path
const electionDefinition = (await readElection(path)).unsafeUnwrap();

// read the whole file as long as it's ≤ 1 MB
const readFileResult = readFile(path, { maxSize: 1024 * 1024 });
```

## Testing Plan
Updated automated tests.
