### PR TITLE
[i18n/audio] Explcitly render non-translatable strings in English

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -494,8 +494,7 @@ test('Election package export', async () => {
         Array.isArray(stringKey) &&
         stringKey[0] === ElectionStringKey.CANDIDATE_NAME
       ) {
-        expect(stringInLanguage).toBeDefined();
-        expect(stringInLanguage).toEqual(stringInEnglish);
+        expect(stringInLanguage).not.toBeDefined();
       } else if (stringKey === ElectionStringKey.ELECTION_DATE) {
         expect(stringInLanguage).toBeDefined();
       } else if (stringKey === ElectionStringKey.BALLOT_LANGUAGE) {

--- a/apps/design/backend/src/language_and_audio/election_strings.ts
+++ b/apps/design/backend/src/language_and_audio/election_strings.ts
@@ -52,10 +52,7 @@ const electionStringConfigs: Record<ElectionStringKey, ElectionStringConfig> = {
     translatable: false,
   },
   [ElectionStringKey.CANDIDATE_NAME]: {
-    translatable: true,
-    translationsCanBeStoredInCdf: true,
-    // Don't attempt to cloud translate candidate names
-    customTranslationMethod: ({ stringInEnglish }) => stringInEnglish,
+    translatable: false,
   },
   [ElectionStringKey.CONTEST_DESCRIPTION]: {
     translatable: true,

--- a/libs/ui/src/ui_strings/election_strings.tsx
+++ b/libs/ui/src/ui_strings/election_strings.tsx
@@ -18,7 +18,7 @@ import { format } from '@votingworks/utils';
 import { UiString } from './ui_string';
 import { Pre } from '../typography';
 import { DateString } from './date_string';
-import { LanguageOverride } from './language_override';
+import { InEnglish, LanguageOverride } from './language_override';
 
 type ContestWithDescription = ContestLike & {
   description: string;
@@ -38,15 +38,19 @@ export const electionStrings = {
   ),
 
   [Key.BALLOT_STYLE_ID]: (id: BallotStyleId) => (
-    <UiString uiStringKey={Key.BALLOT_STYLE_ID} uiStringSubKey={id}>
-      {id}
-    </UiString>
+    <InEnglish>
+      <UiString uiStringKey={Key.BALLOT_STYLE_ID} uiStringSubKey={id}>
+        {id}
+      </UiString>
+    </InEnglish>
   ),
 
   [Key.CANDIDATE_NAME]: (candidate: Candidate) => (
-    <UiString uiStringKey={Key.CANDIDATE_NAME} uiStringSubKey={candidate.id}>
-      {candidate.name}
-    </UiString>
+    <InEnglish>
+      <UiString uiStringKey={Key.CANDIDATE_NAME} uiStringSubKey={candidate.id}>
+        {candidate.name}
+      </UiString>
+    </InEnglish>
   ),
 
   [Key.CONTEST_DESCRIPTION]: (contest: ContestWithDescription) => (


### PR DESCRIPTION
## Overview

Follow-up from https://github.com/votingworks/vxsuite/pull/4599, which caused us to start generating audio for candidate names in all ballot languages instead of reusing the English audio as before.

For now, forcing English strings and audio for candidate names and ballot style ID in the UI code to avoid this. Might revisit later to see if it's worth updating the election package to map these strings to the same audio IDs in all languages for completeness, but this approach should prevent any accidental references to non-English audio for the strings in the meantime. 

## Testing Plan
- Updated existing tests, verified manually via VxMark

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
