### PR TITLE
VxAdmin Diagnostics: Show Disk Space

### DIFF
--- a/apps/admin/backend/schema.sql
+++ b/apps/admin/backend/schema.sql
@@ -221,6 +221,7 @@ create table manual_result_write_in_candidate_references (
 create table settings (
   -- enforce singleton table
   id integer primary key check (id = 1),
+  maximum_workspace_disk_space integer not null default 1,
   current_election_id varchar(36),
   foreign key (current_election_id) references elections(id)
 );

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -45,6 +45,7 @@ import {
 } from '@votingworks/utils';
 import { dirSync } from 'tmp';
 import {
+  DiskSpaceSummary,
   ElectionPackageError,
   ElectionPackageWithFileContents,
   ExportDataError,
@@ -1073,6 +1074,10 @@ function buildApi({
         logger,
         userRole: assertDefined(await getUserRole()),
       });
+    },
+
+    async getApplicationDiskSpaceSummary(): Promise<DiskSpaceSummary> {
+      return workspace.getDiskSpaceSummary();
     },
 
     ...createSystemCallApi({

--- a/apps/admin/backend/src/store.test.ts
+++ b/apps/admin/backend/src/store.test.ts
@@ -584,3 +584,22 @@ describe('getFilteredContests', () => {
     );
   });
 });
+
+test('deleteElection reclaims disk space (vacuums the database)', async () => {
+  const tmpDir = tmpNameSync();
+  await fs.mkdir(tmpDir);
+  const tmpDbPath = join(tmpDir, 'data.db');
+  const store = Store.fileStore(tmpDbPath);
+
+  const electionId = store.addElection({
+    electionData:
+      electionTwoPartyPrimaryFixtures.electionDefinition.electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
+  });
+
+  const beforeSize = (await fs.stat(tmpDbPath)).size;
+  store.deleteElection(electionId);
+  const afterSize = (await fs.stat(tmpDbPath)).size;
+  expect(afterSize).toBeLessThan(beforeSize);
+});

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -289,6 +289,10 @@ export class Store {
       id
     );
     this.client.run('delete from elections where id = ?', id);
+
+    // there are many cascading deletes from elections, so there may be lots of
+    // disk space to reclaim
+    this.client.vacuum();
   }
 
   /**

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -2548,6 +2548,27 @@ export class Store {
     ) as DiagnosticsRecord[];
   }
 
+  getMaximumWorkspaceDiskSpace(): number {
+    const row = this.client.one(
+      `
+        select maximum_workspace_disk_space as maximumWorkspaceDiskSpace
+        from settings
+      `
+    ) as { maximumWorkspaceDiskSpace: number };
+
+    return row.maximumWorkspaceDiskSpace;
+  }
+
+  updateMaximumWorkspaceDiskSpace(space: number): void {
+    this.client.run(
+      `
+        update settings
+        set maximum_workspace_disk_space = ?
+      `,
+      space
+    );
+  }
+
   /* c8 ignore start */
   getDebugSummary(): Map<string, number> {
     const tableNameRows = this.client.all(

--- a/apps/admin/backend/src/util/workspace.test.ts
+++ b/apps/admin/backend/src/util/workspace.test.ts
@@ -1,10 +1,75 @@
 import * as tmp from 'tmp';
+import { backendWaitFor, mockFunction } from '@votingworks/test-utils';
+import { DiskSpaceSummary, getDiskSpaceSummary } from '@votingworks/backend';
 import { createWorkspace } from './workspace';
 import { Store } from '../store';
 
+const mockDiskSpaceSummary: DiskSpaceSummary = {
+  total: 100,
+  used: 50,
+  available: 50,
+};
+const getDiskSpaceSummaryMock = mockFunction<typeof getDiskSpaceSummary>(
+  'getDiskSpaceSummary'
+);
+
+jest.mock(
+  '@votingworks/backend',
+  (): typeof import('@votingworks/backend') => ({
+    ...jest.requireActual('@votingworks/backend'),
+    getDiskSpaceSummary: (paths: string[]) => getDiskSpaceSummaryMock(paths),
+  })
+);
+
+beforeEach(() => {
+  getDiskSpaceSummaryMock.reset();
+});
+
+afterEach(() => {
+  getDiskSpaceSummaryMock.assertComplete();
+});
+
 test('createWorkspace', () => {
   const dir = tmp.dirSync();
+  getDiskSpaceSummaryMock
+    .expectCallWith([dir.name])
+    .resolves(mockDiskSpaceSummary);
   const workspace = createWorkspace(dir.name);
   expect(workspace.path).toEqual(dir.name);
   expect(workspace.store).toBeInstanceOf(Store);
+});
+
+test('disk space tracking', async () => {
+  const dir = tmp.dirSync();
+  getDiskSpaceSummaryMock.expectCallWith([dir.name]).resolves({
+    total: 10000,
+    used: 1000,
+    available: 9000,
+  });
+  const workspace = createWorkspace(dir.name);
+  await backendWaitFor(() => {
+    expect(workspace.store.getMaximumWorkspaceDiskSpace()).toEqual(9000);
+  });
+
+  getDiskSpaceSummaryMock.expectCallWith([dir.name]).resolves({
+    total: 10000,
+    used: 2000,
+    available: 8000,
+  });
+  expect(await workspace.getDiskSpaceSummary()).toEqual({
+    total: 9000,
+    used: 1000,
+    available: 8000,
+  });
+
+  getDiskSpaceSummaryMock.expectCallWith([dir.name]).resolves({
+    total: 10000,
+    used: 500,
+    available: 9500,
+  });
+  expect(await workspace.getDiskSpaceSummary()).toEqual({
+    total: 9500,
+    used: 0,
+    available: 9500,
+  });
 });

--- a/apps/admin/backend/src/util/workspace.ts
+++ b/apps/admin/backend/src/util/workspace.ts
@@ -1,5 +1,6 @@
 import { ensureDirSync } from 'fs-extra';
 import { join, resolve } from 'path';
+import { DiskSpaceSummary, getDiskSpaceSummary } from '@votingworks/backend';
 import { Store } from '../store';
 
 /**
@@ -8,6 +9,41 @@ import { Store } from '../store';
 export interface Workspace {
   readonly path: string;
   readonly store: Store;
+  getDiskSpaceSummary: () => Promise<DiskSpaceSummary>;
+}
+
+/**
+ * Returns the disk space summary for the workspace - the total, used, and
+ * available. Rather than rely on the volume's disk space summary, we track the
+ * maximum available disk space over time and use that as the total. As such,
+ * we're not counting fixed disk space (code, config, etc.) as unavailable and
+ * have a more accurate picture of the disk space available to the application.
+ *
+ * While checking, this method will also update the store with a new maximum
+ * disk space if the current available disk space is greater than the
+ * previous maximum.
+ */
+async function getWorkspaceDiskSpaceSummary(
+  store: Store,
+  workspacePath: string
+): Promise<DiskSpaceSummary> {
+  const previousMaximumDiskSpace = store.getMaximumWorkspaceDiskSpace();
+  const currentDiskSpaceSummary = await getDiskSpaceSummary([workspacePath]);
+
+  const maximumDiskSpace = Math.max(
+    previousMaximumDiskSpace,
+    currentDiskSpaceSummary.available
+  );
+
+  if (maximumDiskSpace > previousMaximumDiskSpace) {
+    store.updateMaximumWorkspaceDiskSpace(maximumDiskSpace);
+  }
+
+  return {
+    total: maximumDiskSpace,
+    available: currentDiskSpaceSummary.available,
+    used: maximumDiskSpace - currentDiskSpaceSummary.available,
+  };
 }
 
 /**
@@ -15,12 +51,18 @@ export interface Workspace {
  */
 export function createWorkspace(root: string): Workspace {
   const resolvedRoot = resolve(root);
-  const dbPath = join(resolvedRoot, 'data.db');
-
   ensureDirSync(resolvedRoot);
+
+  const dbPath = join(resolvedRoot, 'data.db');
+  const store = Store.fileStore(dbPath);
+
+  // check disk space on summary to detect a new maximum available disk space
+  void getWorkspaceDiskSpaceSummary(store, resolvedRoot);
 
   return {
     path: resolvedRoot,
-    store: Store.fileStore(dbPath),
+    store,
+    getDiskSpaceSummary: () =>
+      getWorkspaceDiskSpaceSummary(store, resolvedRoot),
   };
 }

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -528,6 +528,22 @@ export const getDiagnosticRecords = {
   },
 } as const;
 
+export const getApplicationDiskSpaceSummary = {
+  queryKey(): QueryKey {
+    return ['getApplicationDiskSpaceSummary'];
+  },
+  useQuery() {
+    const apiClient = useApiClient();
+    return useQuery(
+      this.queryKey(),
+      () => apiClient.getApplicationDiskSpaceSummary(),
+      {
+        refetchOnMount: true,
+      }
+    );
+  },
+} as const;
+
 // Grouped Invalidations
 
 function invalidateCastVoteRecordQueries(queryClient: QueryClient) {

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -538,7 +538,9 @@ export const getApplicationDiskSpaceSummary = {
       this.queryKey(),
       () => apiClient.getApplicationDiskSpaceSummary(),
       {
-        refetchOnMount: true,
+        // disk space availability could change between queries for a variety
+        // reasons, so always treat it as stale
+        staleTime: 0,
       }
     );
   },

--- a/apps/admin/frontend/src/screens/hardware_diagnostics_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/hardware_diagnostics_screen.test.tsx
@@ -32,6 +32,7 @@ async function expectTextWithIcon(text: string, icon: string) {
 
 test('battery state ', async () => {
   apiMock.setPrinterStatus({ connected: false });
+  apiMock.expectGetApplicationDiskSpaceSummary();
   apiMock.expectGetDiagnosticsRecords([]);
   renderInAppContext(<HardwareDiagnosticsScreen />, {
     apiMock,
@@ -71,6 +72,7 @@ const mockPrinterConfig: PrinterConfig = {
 
 test('displays printer state and allows diagnostic', async () => {
   apiMock.setPrinterStatus({ connected: false });
+  apiMock.expectGetApplicationDiskSpaceSummary();
   apiMock.expectGetDiagnosticsRecords([]);
   renderInAppContext(<HardwareDiagnosticsScreen />, {
     apiMock,
@@ -170,4 +172,43 @@ test('displays printer state and allows diagnostic', async () => {
     'Test print successful, 6/22/2022, 12:01:00 PM',
     'circle-check'
   );
+});
+
+describe('disk space summary', () => {
+  beforeEach(() => {
+    apiMock.setPrinterStatus({ connected: false });
+    apiMock.expectGetDiagnosticsRecords([]);
+  });
+
+  test('normal disk space', async () => {
+    apiMock.expectGetApplicationDiskSpaceSummary({
+      available: 99.2 * 1_000_000,
+      used: 0.08 * 1_000_000,
+      total: 100 * 1_000_000,
+    });
+    renderInAppContext(<HardwareDiagnosticsScreen />, {
+      apiMock,
+    });
+
+    await expectTextWithIcon(
+      'Free Disk Space: 99% (99.2 GB / 100 GB)',
+      'circle-check'
+    );
+  });
+
+  test('low disk space', async () => {
+    apiMock.expectGetApplicationDiskSpaceSummary({
+      available: 2.4 * 1_000_000,
+      used: 97.6 * 1_000_000,
+      total: 100 * 1_000_000,
+    });
+    renderInAppContext(<HardwareDiagnosticsScreen />, {
+      apiMock,
+    });
+
+    await expectTextWithIcon(
+      'Free Disk Space: 2% (2.4 GB / 100 GB)',
+      'triangle-exclamation'
+    );
+  });
 });

--- a/apps/admin/frontend/src/screens/hardware_diagnostics_screen.tsx
+++ b/apps/admin/frontend/src/screens/hardware_diagnostics_screen.tsx
@@ -84,7 +84,7 @@ export function HardwareDiagnosticsScreen(): JSX.Element {
             : 'External Power Supply'
           : '-'}
       </P>
-      <H6 as="h3">Memory</H6>
+      <H6 as="h3">Storage</H6>
       <P>
         {storageAvailableLevel < DISK_SPACE_WARN_LEVEL ? (
           <Icons.Warning color="warning" />

--- a/apps/admin/frontend/src/screens/hardware_diagnostics_screen.tsx
+++ b/apps/admin/frontend/src/screens/hardware_diagnostics_screen.tsx
@@ -17,7 +17,7 @@ function roundToGigabytes(kilobytes: number): number {
   return Math.round(kilobytes / 100_000) / 10;
 }
 
-const DISK_SPACE_WARN_LEVEL = 0.05;
+const FREE_DISK_SPACE_RATIO_WARN_THRESHOLD = 0.05;
 
 function BatteryStatusIcon({ discharging, level }: BatteryInfo): JSX.Element {
   if (discharging && level < 0.1) {
@@ -86,7 +86,7 @@ export function HardwareDiagnosticsScreen(): JSX.Element {
       </P>
       <H6 as="h3">Storage</H6>
       <P>
-        {storageAvailableLevel < DISK_SPACE_WARN_LEVEL ? (
+        {storageAvailableLevel < FREE_DISK_SPACE_RATIO_WARN_THRESHOLD ? (
           <Icons.Warning color="warning" />
         ) : (
           <Icons.Done color="success" />

--- a/apps/admin/frontend/src/screens/hardware_diagnostics_screen.tsx
+++ b/apps/admin/frontend/src/screens/hardware_diagnostics_screen.tsx
@@ -1,12 +1,23 @@
-import { H2, Icons, P, PrinterStatusDisplay } from '@votingworks/ui';
+import { H2, H6, Icons, P, PrinterStatusDisplay } from '@votingworks/ui';
 
 import { format } from '@votingworks/utils';
 import type { DiagnosticsRecord } from '@votingworks/admin-backend';
 import type { BatteryInfo } from '@votingworks/backend';
 import { NavigationScreen } from '../components/navigation_screen';
-import { getDiagnosticRecords, getPrinterStatus, systemCallApi } from '../api';
+import {
+  getDiagnosticRecords,
+  getPrinterStatus,
+  getApplicationDiskSpaceSummary,
+  systemCallApi,
+} from '../api';
 import { Loading } from '../components/loading';
 import { PrintTestPageButton } from '../components/print_diagnostic_button';
+
+function roundToGigabytes(kilobytes: number): number {
+  return Math.round(kilobytes / 100_000) / 10;
+}
+
+const DISK_SPACE_WARN_LEVEL = 0.05;
 
 function BatteryStatusIcon({ discharging, level }: BatteryInfo): JSX.Element {
   if (discharging && level < 0.1) {
@@ -19,12 +30,14 @@ function BatteryStatusIcon({ discharging, level }: BatteryInfo): JSX.Element {
 export function HardwareDiagnosticsScreen(): JSX.Element {
   const batteryInfoQuery = systemCallApi.getBatteryInfo.useQuery();
   const printerStatusQuery = getPrinterStatus.useQuery();
+  const diskSpaceQuery = getApplicationDiskSpaceSummary.useQuery();
   const diagnosticRecordsQuery = getDiagnosticRecords.useQuery();
 
   if (
     !batteryInfoQuery.isSuccess ||
     !printerStatusQuery.isSuccess ||
-    !diagnosticRecordsQuery.isSuccess
+    !diagnosticRecordsQuery.isSuccess ||
+    !diskSpaceQuery.isSuccess
   ) {
     return (
       <NavigationScreen title="Hardware Diagnostics">
@@ -35,6 +48,9 @@ export function HardwareDiagnosticsScreen(): JSX.Element {
 
   const batteryInfo = batteryInfoQuery.data;
   const printerStatus = printerStatusQuery.data;
+  const diskSpaceSummary = diskSpaceQuery.data;
+  const storageAvailableLevel =
+    diskSpaceSummary.available / diskSpaceSummary.total;
   const mostRecentPrinterDiagnostic = diagnosticRecordsQuery.data
     .filter(({ hardware }) => hardware === 'printer')
     .sort((a, b) => b.timestamp - a.timestamp)[0] as
@@ -44,6 +60,7 @@ export function HardwareDiagnosticsScreen(): JSX.Element {
   return (
     <NavigationScreen title="Hardware Diagnostics">
       <H2>Laptop</H2>
+      <H6 as="h3">Power</H6>
       {batteryInfo ? (
         <P>
           <BatteryStatusIcon {...batteryInfo} /> Battery Level:{' '}
@@ -66,6 +83,17 @@ export function HardwareDiagnosticsScreen(): JSX.Element {
             ? 'Battery'
             : 'External Power Supply'
           : '-'}
+      </P>
+      <H6 as="h3">Memory</H6>
+      <P>
+        {storageAvailableLevel < DISK_SPACE_WARN_LEVEL ? (
+          <Icons.Warning color="warning" />
+        ) : (
+          <Icons.Done color="success" />
+        )}{' '}
+        Free Disk Space: {format.percent(storageAvailableLevel)} (
+        {roundToGigabytes(diskSpaceSummary.available)} GB /{' '}
+        {roundToGigabytes(diskSpaceSummary.total)} GB)
       </P>
       <H2>Printer</H2>
       <PrinterStatusDisplay printerStatus={printerStatus} />

--- a/apps/admin/frontend/test/helpers/mock_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_api_client.ts
@@ -19,7 +19,7 @@ import type {
   TallyReportWarning,
   DiagnosticsRecord,
 } from '@votingworks/admin-backend';
-import { BatteryInfo } from '@votingworks/backend';
+import type { BatteryInfo, DiskSpaceSummary } from '@votingworks/backend';
 import { FileSystemEntry, FileSystemEntryType } from '@votingworks/fs';
 import { Result, deferred, ok } from '@votingworks/basics';
 import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
@@ -477,6 +477,16 @@ export function createApiMock(
 
     expectAddDiagnosticRecord(record: Omit<DiagnosticsRecord, 'timestamp'>) {
       apiClient.addDiagnosticRecord.expectCallWith(record).resolves();
+    },
+
+    expectGetApplicationDiskSpaceSummary(summary?: DiskSpaceSummary) {
+      apiClient.getApplicationDiskSpaceSummary.expectCallWith().resolves(
+        summary ?? {
+          available: 1,
+          used: 1,
+          total: 2,
+        }
+      );
     },
 
     expectGetResultsForTallyReports(

--- a/libs/backend/src/disk_space_summary.test.ts
+++ b/libs/backend/src/disk_space_summary.test.ts
@@ -1,0 +1,29 @@
+import { mockOf } from '@votingworks/test-utils';
+import { execFile } from './exec';
+import { getDiskSpaceSummary } from './disk_space_summary';
+
+jest.mock('./exec', (): typeof import('./exec') => ({
+  ...jest.requireActual('./exec'),
+  execFile: jest.fn(),
+}));
+
+const execFileMock = mockOf(execFile);
+
+const EXAMPLE_STDOUT = `Filesystem             1K-blocks    Used Available Use% Mounted on
+/dev/mapper/Vx--vx-tmp    940768      40    875604   1% /tmp
+/dev/mapper/Vx--vg-var  91997880 4424092  82854584   6% /var
+total                   92938648 4424132  83730188   6% -
+`;
+
+test('getDiskSpaceSummary', async () => {
+  execFileMock.mockResolvedValue({
+    stdout: EXAMPLE_STDOUT,
+    stderr: '',
+  });
+
+  expect(await getDiskSpaceSummary(['/tmp', '/var'])).toEqual({
+    total: 92938648,
+    used: 4424132,
+    available: 83730188,
+  });
+});

--- a/libs/backend/src/disk_space_summary.ts
+++ b/libs/backend/src/disk_space_summary.ts
@@ -1,0 +1,38 @@
+import { assert, lines } from '@votingworks/basics';
+import { safeParseInt } from '@votingworks/types';
+import { execFile } from './exec';
+
+/**
+ * Summary of disk space usage, in kilobytes.
+ */
+export interface DiskSpaceSummary {
+  total: number;
+  used: number;
+  available: number;
+}
+
+/**
+ * Returns the amount of free disk space available at the specified paths in
+ * kilobytes. Output:
+ * @example
+ *
+ * df /tmp --total
+ * Filesystem                 1K-blocks     Used Available Use% Mounted on
+ * /dev/mapper/deb12--vg-root 129524860 53099284  69799888  44% /
+ * total                      129524860 53099284  69799888  44% -
+ */
+export async function getDiskSpaceSummary(
+  paths: string[]
+): Promise<DiskSpaceSummary> {
+  const { stdout } = await execFile('df', [...paths, '--total']);
+  const totalLine = lines(stdout)
+    .filter((line) => line)
+    .last();
+  assert(totalLine !== undefined, 'no output from df');
+  const [total, used, available] = totalLine
+    .split(/\s+/)
+    .slice(1, 4)
+    .map((s) => safeParseInt(s).unsafeUnwrap());
+  assert(total !== undefined && used !== undefined && available !== undefined);
+  return { total, used, available };
+}

--- a/libs/backend/src/index.ts
+++ b/libs/backend/src/index.ts
@@ -4,6 +4,7 @@ export * from './detect_devices';
 export * from './dotenv';
 export * from './election_package';
 export * from './exporter';
+export * from './disk_space_summary';
 export * from './system_call';
 export * from './scan_globals';
 export * from './split';

--- a/libs/db/src/client.ts
+++ b/libs/db/src/client.ts
@@ -312,4 +312,11 @@ export class Client {
 
     this.create();
   }
+
+  /**
+   * Runs a full vacuum of the database.
+   */
+  vacuum(): void {
+    this.run('vacuum');
+  }
 }


### PR DESCRIPTION
## Overview

Shows available disk space on the VxAdmin Diagnostics page.

We only want to show users diagnostic information that is meaningful to them and would make sense to include in a "readiness report." So most standard computer diagnostics do not make the cut - you don't need to see the RAM performance because there's nothing the user (or us) can do about. Used disk space is technically actionable, although users normally will not want to delete election data to free up space. I think it will be a somewhat useful indicator to see how much disk space we actually use in production, and to catch serious memory leaks. If VxAdmin goes to a multi-election format, disk space _could_ be a regular concern.

I made a few choices in how to define "disk space" here:
- I'm not simply taking the operating system's report of the disk space availability at the given paths. Because that will count a lot of system and other application files, e.g. our code, against the "used" disk space. If we did that, the user would never see disk space be 100% available - a new VxAdmin might be at 93% available or 98% available. This is not abnormal - it's the same with how 128GB phones come with less than 128GB free space. But I thought that approximating _application_ disk space would give a better sense of the status, and be at or near 100% after unconfiguring. The downside is that it adds some state complexity, and it's theoretically possible that due to some OS or frontend events, the application discovers _more_ available space over time, so one day it's 71GB / 71.9GB and the next day it's 71GB / 72.1GB. But I am assuming that the emptiest the file system will be is at first boot up, and this actually isn't a possible event.
- I'm not including `/tmp` storage. I don't want to lump it in, because it would introduce volatility to an otherwise stable metric. And I don't want to show it separately - if it were just for me, I might, to catch `/tmp` memory leaks, but for users it doesn't mean anything (although we could prompt them to restart the computer?) Could add this in if we wanted.
This PR also makes VxAdmin run a database vacuum after deleting an election, so disk space is actually reclaimed from SQLite. It may make unconfiguring a little slower.

## Demo Video or Screenshot

<img width="1152" alt="Screen Shot 2024-02-20 at 3 32 35 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/a3b5f9c4-58c8-4e1c-bdfa-5dad8d42401d">

## Testing Plan
Automated testing + manually checked that disk space results reflect actions on my filesystem.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
