### PR TITLE
perf(fs): use `opendir` instead of `readdir`

### DIFF
--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -392,23 +392,30 @@ function buildApi({
     async listPotentialElectionPackagesOnUsbDrive(): Promise<
       Result<FileSystemEntry[], ListDirectoryOnUsbDriveError>
     > {
-      const usbDriveEntriesResult = await listDirectoryOnUsbDrive(usbDrive, '');
-      if (usbDriveEntriesResult.isErr()) {
-        return usbDriveEntriesResult;
+      const potentialElectionPackages: FileSystemEntry[] = [];
+
+      for await (const result of listDirectoryOnUsbDrive(usbDrive, '')) {
+        if (result.isErr()) {
+          return result;
+        }
+
+        const entry = result.ok();
+
+        if (
+          entry.type === FileSystemEntryType.File &&
+          entry.name.endsWith('.zip') &&
+          !entry.name.startsWith('.') &&
+          !entry.name.startsWith('_')
+        ) {
+          potentialElectionPackages.push(entry);
+        }
       }
 
       return ok(
-        usbDriveEntriesResult
-          .ok()
-          .filter(
-            (entry) =>
-              entry.type === FileSystemEntryType.File &&
-              entry.name.endsWith('.zip') &&
-              !entry.name.startsWith('.') &&
-              !entry.name.startsWith('_')
-          )
-          // Most recent first
-          .sort((a, b) => b.ctime.getTime() - a.ctime.getTime())
+        // Most recent first
+        [...potentialElectionPackages].sort(
+          (a, b) => b.ctime.getTime() - a.ctime.getTime()
+        )
       );
     },
 

--- a/libs/usb-drive/src/list_directory_on_usb_drive.ts
+++ b/libs/usb-drive/src/list_directory_on_usb_drive.ts
@@ -18,20 +18,26 @@ export type ListDirectoryOnUsbDriveError =
  * Lists entities in a directory specified by a relative path within a USB
  * drive's filesystem. Looks at only the first found USB drive.
  */
-export async function listDirectoryOnUsbDrive(
+export async function* listDirectoryOnUsbDrive(
   usbDrive: UsbDrive,
   relativePath: string
-): Promise<Result<FileSystemEntry[], ListDirectoryOnUsbDriveError>> {
+): AsyncGenerator<Result<FileSystemEntry, ListDirectoryOnUsbDriveError>> {
   const usbDriveStatus = await usbDrive.status();
 
   switch (usbDriveStatus.status) {
     case 'no_drive':
-      return err({ type: 'no-usb-drive' });
+      yield err({ type: 'no-usb-drive' });
+      break;
+
     case 'ejected':
     case 'error':
-      return err({ type: 'usb-drive-not-mounted' });
+      yield err({ type: 'usb-drive-not-mounted' });
+      break;
+
     case 'mounted':
-      return await listDirectory(join(usbDriveStatus.mountPoint, relativePath));
+      yield* listDirectory(join(usbDriveStatus.mountPoint, relativePath));
+      break;
+
     // istanbul ignore next
     default:
       throwIllegalValue(usbDriveStatus);


### PR DESCRIPTION
## Overview
If we don't need to list all of the contents of a directory we shouldn't be forced to.

## Demo Video or Screenshot
n/a

## Testing Plan
Updated automated tests.