### PR TITLE
[BMD] Restrict "next" button autofocus to PAT voting sessions only

### DIFF
--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -350,6 +350,14 @@ export function buildApi(
         pollsState: store.getPollsState(),
       };
     },
+
+    isPatDeviceConnected(): boolean {
+      if (!stateMachine) {
+        return false;
+      }
+
+      return stateMachine.isPatDeviceConnected();
+    },
   });
 }
 

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -128,6 +128,7 @@ export interface PaperHandlerStateMachine {
   confirmBallotBoxEmptied(): void;
   setPatDeviceIsCalibrated(): void;
   setInterpretationFixture(): void;
+  isPatDeviceConnected(): boolean;
 }
 
 function paperHandlerStatusToEvent(
@@ -984,6 +985,10 @@ export async function getPaperHandlerStateMachine({
       machineService.send({
         type: 'POLL_WORKER_CONFIRMED_BALLOT_BOX_EMPTIED',
       });
+    },
+
+    isPatDeviceConnected(): boolean {
+      return machineService.state.context.isPatDeviceConnected;
     },
   };
 }

--- a/apps/mark-scan/frontend/src/api.ts
+++ b/apps/mark-scan/frontend/src/api.ts
@@ -393,4 +393,18 @@ export const setPatDeviceIsCalibrated = {
   },
 } as const;
 
+export const isPatDeviceConnected = {
+  queryKey(): QueryKey {
+    return ['isPatDeviceConnected'];
+  },
+
+  useQuery() {
+    const apiClient = useApiClient();
+
+    return useQuery(this.queryKey(), () => apiClient.isPatDeviceConnected(), {
+      refetchInterval: STATE_MACHINE_POLLING_INTERVAL_MS,
+    });
+  },
+} as const;
+
 export const systemCallApi = createSystemCallApi(useApiClient);

--- a/apps/mark-scan/frontend/src/app_contest_write_in.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_write_in.test.tsx
@@ -9,11 +9,7 @@ import {
 import { ALL_PRECINCTS_SELECTION, MemoryHardware } from '@votingworks/utils';
 import userEvent from '@testing-library/user-event';
 import { electionGeneralDefinition } from '@votingworks/fixtures';
-import {
-  ContestPage,
-  ContestPageProps,
-  VoteUpdateInteractionMethod,
-} from '@votingworks/mark-flow-ui';
+import { ContestPage, ContestPageProps } from '@votingworks/mark-flow-ui';
 import { ContestId, OptionalVote, VotesDict } from '@votingworks/types';
 import { useHistory } from 'react-router-dom';
 import { act, fireEvent, render, screen } from '../test/react_testing_library';
@@ -69,9 +65,7 @@ function setUpMockContestPage() {
 
   return {
     fireUpdateVoteEvent: (contestId: ContestId, vote: OptionalVote) =>
-      act(() =>
-        fireUpdateVoteEvent(contestId, vote, VoteUpdateInteractionMethod.Touch)
-      ),
+      act(() => fireUpdateVoteEvent(contestId, vote)),
     getLatestVotes: () => latestVotes,
     goToReviewPage: () => {
       routerHistory.location.pathname = '/review';

--- a/apps/mark-scan/frontend/src/lib/assistive_technology.test.tsx
+++ b/apps/mark-scan/frontend/src/lib/assistive_technology.test.tsx
@@ -145,7 +145,7 @@ it('auto-focuses "next" button on contest screen after voting', async () => {
   // Confirm first contest only has 1 seat
   expect(contest0.seats).toEqual(1);
 
-  // Test navigation by accessible controller keyboard event interface
+  // Test navigation by PAT input keyboard event interface
   userEvent.keyboard('1');
   expect(getActiveElement()).toHaveTextContent(contest0candidate0.name);
   userEvent.keyboard('1');
@@ -158,6 +158,6 @@ it('auto-focuses "next" button on contest screen after voting', async () => {
     selected: true,
   });
 
-  // Focus should have jumped to the "Next" button because we're using keyboard nav
+  // Focus should have jumped to the "Next" button because we're using PAT nav
   expect(await screen.findByRole('button', { name: 'Next' })).toHaveFocus();
 });

--- a/apps/mark-scan/frontend/src/pages/contest_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/contest_screen.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
 import { ContestPage } from '@votingworks/mark-flow-ui';
-
 import { ContestId } from '@votingworks/types';
+
+import * as api from '../api';
 import { BallotContext } from '../contexts/ballot_context';
 
 function getContestUrl(contestIndex: number) {
@@ -25,6 +26,10 @@ export function ContestScreen(): JSX.Element {
   const { contests, electionDefinition, precinctId, updateVote, votes } =
     React.useContext(BallotContext);
 
+  const isPathDeviceConnected = Boolean(
+    api.isPatDeviceConnected.useQuery().data
+  );
+
   return (
     <ContestPage
       contests={contests}
@@ -32,6 +37,7 @@ export function ContestScreen(): JSX.Element {
       getContestUrl={getContestUrl}
       getReviewPageUrl={getReviewPageUrl}
       getStartPageUrl={getStartPageUrl}
+      isPatDeviceConnected={isPathDeviceConnected}
       precinctId={precinctId}
       updateVote={updateVote}
       votes={votes}

--- a/apps/mark-scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/mark-scan/frontend/test/helpers/mock_api_client.tsx
@@ -59,6 +59,9 @@ function createMockApiClient(): MockApiClient {
   (mockApiClient.getUsbDriveStatus as unknown as jest.Mock) = jest.fn(() =>
     Promise.resolve({ status: 'no_drive' })
   );
+  (mockApiClient.isPatDeviceConnected as unknown as jest.Mock) = jest.fn(() =>
+    Promise.resolve(false)
+  );
 
   return mockApiClient as unknown as MockApiClient;
 }

--- a/apps/mark/frontend/src/app_contest_write_in.test.tsx
+++ b/apps/mark/frontend/src/app_contest_write_in.test.tsx
@@ -7,11 +7,7 @@ import {
 import { ALL_PRECINCTS_SELECTION, MemoryHardware } from '@votingworks/utils';
 import userEvent from '@testing-library/user-event';
 import { electionGeneralDefinition } from '@votingworks/fixtures';
-import {
-  ContestPage,
-  ContestPageProps,
-  VoteUpdateInteractionMethod,
-} from '@votingworks/mark-flow-ui';
+import { ContestPage, ContestPageProps } from '@votingworks/mark-flow-ui';
 import { ContestId, OptionalVote, VotesDict } from '@votingworks/types';
 import { useHistory } from 'react-router-dom';
 import { act, fireEvent, render, screen } from '../test/react_testing_library';
@@ -65,9 +61,7 @@ function setUpMockContestPage() {
 
   return {
     fireUpdateVoteEvent: (contestId: ContestId, vote: OptionalVote) =>
-      act(() =>
-        fireUpdateVoteEvent(contestId, vote, VoteUpdateInteractionMethod.Touch)
-      ),
+      act(() => fireUpdateVoteEvent(contestId, vote)),
     getLatestVotes: () => latestVotes,
     goToReviewPage: () => {
       routerHistory.location.pathname = '/review';

--- a/apps/mark/frontend/src/lib/gamepad.test.tsx
+++ b/apps/mark/frontend/src/lib/gamepad.test.tsx
@@ -114,16 +114,11 @@ it('gamepad controls work', async () => {
 
   // select candidate
   handleGamepadButtonDown('A');
-  const candidate0Option = await screen.findByRole('option', {
+  await screen.findByRole('option', {
     name: new RegExp(contest0candidate0.name),
     selected: true,
   });
 
-  // Focus should have jumped to the "Next" button because we're using keyboard nav
-  expect(await screen.findByRole('button', { name: 'Next' })).toHaveFocus();
-
-  // Return focus to candidate so we can test unselect
-  candidate0Option.focus();
   handleGamepadButtonDown('A');
   await screen.findByRole('option', {
     name: new RegExp(contest0candidate0.name),

--- a/libs/mark-flow-ui/src/components/candidate_contest.test.tsx
+++ b/libs/mark-flow-ui/src/components/candidate_contest.test.tsx
@@ -15,7 +15,6 @@ import {
 import { VirtualKeyboard, VirtualKeyboardProps } from '@votingworks/ui';
 import { screen, within, render } from '../../test/react_testing_library';
 import { CandidateContest } from './candidate_contest';
-import { VoteUpdateInteractionMethod } from '../config/types';
 
 jest.mock('@votingworks/ui', (): typeof import('@votingworks/ui') => ({
   ...jest.requireActual('@votingworks/ui'),
@@ -185,17 +184,13 @@ describe('supports single-seat contest', () => {
     expect(candidateButton).toHaveFocus();
     userEvent.keyboard('[Enter]');
     expect(updateVote).toHaveBeenCalledTimes(1);
-    expect(updateVote).toHaveBeenCalledWith(
-      candidateContest.id,
-      [
-        {
-          id: candidateContest.candidates[0].id,
-          name: candidateContest.candidates[0].name,
-          partyIds: candidateContest.candidates[0].partyIds,
-        },
-      ],
-      VoteUpdateInteractionMethod.AssistiveTechnologyDevice
-    );
+    expect(updateVote).toHaveBeenCalledWith(candidateContest.id, [
+      {
+        id: candidateContest.candidates[0].id,
+        name: candidateContest.candidates[0].name,
+        partyIds: candidateContest.candidates[0].partyIds,
+      },
+    ]);
     act(() => {
       jest.runOnlyPendingTimers();
     });
@@ -325,11 +320,9 @@ describe('supports write-in candidates', () => {
     userEvent.click(modal.getByText('Accept'));
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
 
-    expect(updateVote).toHaveBeenCalledWith(
-      candidateContestWithWriteIns.id,
-      [{ id: 'write-in-lizardPeople', isWriteIn: true, name: 'LIZARD PEOPLE' }],
-      VoteUpdateInteractionMethod.Mouse
-    );
+    expect(updateVote).toHaveBeenCalledWith(candidateContestWithWriteIns.id, [
+      { id: 'write-in-lizardPeople', isWriteIn: true, name: 'LIZARD PEOPLE' },
+    ]);
 
     act(() => {
       jest.runOnlyPendingTimers();
@@ -360,8 +353,7 @@ describe('supports write-in candidates', () => {
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
     expect(updateVote).toHaveBeenCalledWith(
       candidateContestWithWriteIns.id,
-      [],
-      VoteUpdateInteractionMethod.Mouse
+      []
     );
   });
 
@@ -453,17 +445,13 @@ describe('supports write-in candidates', () => {
     userEvent.click(modal.getByText('Accept'));
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
 
-    expect(updateVote).toHaveBeenCalledWith(
-      candidateContestWithWriteIns.id,
-      [
-        {
-          id: 'write-in-jacobJohansonJingleheimmerSchmidttT',
-          isWriteIn: true,
-          name: 'JACOB JOHANSON JINGLEHEIMMER SCHMIDTT, T',
-        },
-      ],
-      VoteUpdateInteractionMethod.Mouse
-    );
+    expect(updateVote).toHaveBeenCalledWith(candidateContestWithWriteIns.id, [
+      {
+        id: 'write-in-jacobJohansonJingleheimmerSchmidttT',
+        isWriteIn: true,
+        name: 'JACOB JOHANSON JINGLEHEIMMER SCHMIDTT, T',
+      },
+    ]);
 
     act(() => {
       jest.runOnlyPendingTimers();

--- a/libs/mark-flow-ui/src/components/candidate_contest.tsx
+++ b/libs/mark-flow-ui/src/components/candidate_contest.tsx
@@ -27,12 +27,11 @@ import {
   NumberString,
   AudioOnly,
   electionStrings,
-  ButtonPressEvent,
   ReadOnLoad,
 } from '@votingworks/ui';
 import { assert } from '@votingworks/basics';
 
-import { UpdateVoteFunction, getInteractionMethod } from '../config/types';
+import { UpdateVoteFunction } from '../config/types';
 
 import { WRITE_IN_CANDIDATE_MAX_LENGTH } from '../config/globals';
 import { ChoicesGrid } from './contest_screen_layout';
@@ -117,21 +116,21 @@ export function CandidateContest({
     }
   }, [recentlySelectedCandidate]);
 
-  function addCandidateToVote(id: string, event: ButtonPressEvent) {
+  function addCandidateToVote(id: string) {
     const { candidates } = contest;
     const candidate = findCandidateById(candidates, id);
     assert(candidate);
-    updateVote(contest.id, [...vote, candidate], getInteractionMethod(event));
+    updateVote(contest.id, [...vote, candidate]);
     setRecentlySelectedCandidate(id);
   }
 
-  function removeCandidateFromVote(id: string, event: ButtonPressEvent) {
+  function removeCandidateFromVote(id: string) {
     const newVote = vote.filter((c) => c.id !== id);
-    updateVote(contest.id, newVote, getInteractionMethod(event));
+    updateVote(contest.id, newVote);
     setRecentlyDeselectedCandidate(id);
   }
 
-  function handleUpdateSelection(event: ButtonPressEvent, candidateId: string) {
+  function handleUpdateSelection(candidateId: string) {
     /* istanbul ignore else */
     if (candidateId) {
       const candidate = findCandidateById(vote, candidateId);
@@ -139,10 +138,10 @@ export function CandidateContest({
         if (candidate.isWriteIn) {
           setWriteInPendingRemoval(candidate);
         } else {
-          removeCandidateFromVote(candidateId, event);
+          removeCandidateFromVote(candidateId);
         }
       } else {
-        addCandidateToVote(candidateId, event);
+        addCandidateToVote(candidateId);
       }
     }
   }
@@ -159,9 +158,9 @@ export function CandidateContest({
     setWriteInPendingRemoval(undefined);
   }
 
-  function confirmRemovePendingWriteInCandidate(event: ButtonPressEvent) {
+  function confirmRemovePendingWriteInCandidate() {
     assert(writeInPendingRemoval);
-    removeCandidateFromVote(writeInPendingRemoval.id, event);
+    removeCandidateFromVote(writeInPendingRemoval.id);
     clearWriteInPendingRemoval();
   }
 
@@ -173,21 +172,17 @@ export function CandidateContest({
     toggleWriteInCandidateModal(true);
   }
 
-  function addWriteInCandidate(event: ButtonPressEvent) {
+  function addWriteInCandidate() {
     const normalizedCandidateName =
       normalizeCandidateName(writeInCandidateName);
-    updateVote(
-      contest.id,
-      [
-        ...vote,
-        {
-          id: `write-in-${camelCase(normalizedCandidateName)}`,
-          isWriteIn: true,
-          name: normalizedCandidateName,
-        },
-      ],
-      getInteractionMethod(event)
-    );
+    updateVote(contest.id, [
+      ...vote,
+      {
+        id: `write-in-${camelCase(normalizedCandidateName)}`,
+        isWriteIn: true,
+        name: normalizedCandidateName,
+      },
+    ]);
     setWriteInCandidateName('');
     toggleWriteInCandidateModal(false);
   }

--- a/libs/mark-flow-ui/src/components/contest.test.tsx
+++ b/libs/mark-flow-ui/src/components/contest.test.tsx
@@ -13,7 +13,6 @@ import {
   MsEitherNeitherContest,
   mergeMsEitherNeitherContests,
 } from '../utils/ms_either_neither_contests';
-import { VoteUpdateInteractionMethod } from '../config/types';
 
 const electionGeneral = electionGeneralDefinition.election;
 
@@ -81,17 +80,13 @@ test('renders ms-either-neither contests', () => {
   userEvent.click(
     screen.getByRole('option', { name: /for approval of either/i })
   );
-  expect(updateVote).toHaveBeenCalledWith(
-    '750000015',
-    [msEitherNeitherContest.eitherOption.id],
-    VoteUpdateInteractionMethod.Mouse
-  );
+  expect(updateVote).toHaveBeenCalledWith('750000015', [
+    msEitherNeitherContest.eitherOption.id,
+  ]);
   userEvent.click(screen.getByRole('option', { name: /for alternative/i }));
-  expect(updateVote).toHaveBeenCalledWith(
-    '750000016',
-    [msEitherNeitherContest.secondOption.id],
-    VoteUpdateInteractionMethod.Mouse
-  );
+  expect(updateVote).toHaveBeenCalledWith('750000016', [
+    msEitherNeitherContest.secondOption.id,
+  ]);
   // Tested further in ms_either_neither_contest.test.tsx
 });
 

--- a/libs/mark-flow-ui/src/components/ms_either_neither_contest.test.tsx
+++ b/libs/mark-flow-ui/src/components/ms_either_neither_contest.test.tsx
@@ -8,7 +8,6 @@ import {
 } from '../utils/ms_either_neither_contests';
 import { MsEitherNeitherContest } from './ms_either_neither_contest';
 import { render, screen, within } from '../../test/react_testing_library';
-import { VoteUpdateInteractionMethod } from '../config/types';
 
 const contests = mergeMsEitherNeitherContests(
   electionWithMsEitherNeither.contests
@@ -76,18 +75,14 @@ test('voting for either/neither', () => {
     .closest('button')!;
 
   userEvent.click(eitherButton);
-  expect(updateVote).toHaveBeenCalledWith(
-    contest.eitherNeitherContestId,
-    [contest.eitherOption.id],
-    VoteUpdateInteractionMethod.Mouse
-  );
+  expect(updateVote).toHaveBeenCalledWith(contest.eitherNeitherContestId, [
+    contest.eitherOption.id,
+  ]);
 
   userEvent.click(neitherButton);
-  expect(updateVote).toHaveBeenCalledWith(
-    contest.eitherNeitherContestId,
-    [contest.neitherOption.id],
-    VoteUpdateInteractionMethod.Mouse
-  );
+  expect(updateVote).toHaveBeenCalledWith(contest.eitherNeitherContestId, [
+    contest.neitherOption.id,
+  ]);
 });
 
 test.each([
@@ -135,8 +130,7 @@ test.each([
       contest.eitherNeitherContestId,
       eitherNeitherContestVote === contest.eitherOption.id
         ? []
-        : [contest.eitherOption.id],
-      VoteUpdateInteractionMethod.Mouse
+        : [contest.eitherOption.id]
     );
 
     userEvent.click(neitherButton);
@@ -144,8 +138,7 @@ test.each([
       contest.eitherNeitherContestId,
       eitherNeitherContestVote === contest.neitherOption.id
         ? []
-        : [contest.neitherOption.id],
-      VoteUpdateInteractionMethod.Mouse
+        : [contest.neitherOption.id]
     );
 
     userEvent.click(pickFirstButton);
@@ -153,8 +146,7 @@ test.each([
       contest.pickOneContestId,
       pickOneContestVote === contest.firstOption.id
         ? []
-        : [contest.firstOption.id],
-      VoteUpdateInteractionMethod.Mouse
+        : [contest.firstOption.id]
     );
 
     userEvent.click(pickSecondButton);
@@ -162,8 +154,7 @@ test.each([
       contest.pickOneContestId,
       pickOneContestVote === contest.secondOption.id
         ? []
-        : [contest.secondOption.id],
-      VoteUpdateInteractionMethod.Mouse
+        : [contest.secondOption.id]
     );
   }
 );

--- a/libs/mark-flow-ui/src/components/ms_either_neither_contest.tsx
+++ b/libs/mark-flow-ui/src/components/ms_either_neither_contest.tsx
@@ -8,7 +8,6 @@ import {
   appStrings,
   AudioOnly,
   electionStrings,
-  ButtonPressEvent,
 } from '@votingworks/ui';
 
 import {
@@ -18,7 +17,7 @@ import {
   YesNoOption,
 } from '@votingworks/types';
 
-import { UpdateVoteFunction, getInteractionMethod } from '../config/types';
+import { UpdateVoteFunction } from '../config/types';
 import { MsEitherNeitherContest as MsEitherNeitherContestInterface } from '../utils/ms_either_neither_contests';
 import { BreadcrumbMetadata, ContestHeader } from './contest_header';
 
@@ -94,10 +93,7 @@ export function MsEitherNeitherContest({
 }: Props): JSX.Element {
   const [deselectedOptionId, setDeselectedOptionId] = useState<string>();
 
-  function handleUpdateEitherNeither(
-    event: ButtonPressEvent,
-    targetVote: string
-  ) {
+  function handleUpdateEitherNeither(targetVote: string) {
     const currentVote = eitherNeitherContestVote?.[0];
     const newVote = currentVote === targetVote ? [] : [targetVote];
 
@@ -105,13 +101,9 @@ export function MsEitherNeitherContest({
       setDeselectedOptionId(targetVote);
     }
 
-    updateVote(
-      contest.eitherNeitherContestId,
-      newVote,
-      getInteractionMethod(event)
-    );
+    updateVote(contest.eitherNeitherContestId, newVote);
   }
-  function handleUpdatePickOne(event: ButtonPressEvent, targetVote: string) {
+  function handleUpdatePickOne(targetVote: string) {
     const currentVote = pickOneContestVote?.[0];
     const newVote =
       currentVote === targetVote ? ([] as YesNoVote) : [targetVote];
@@ -120,7 +112,7 @@ export function MsEitherNeitherContest({
       setDeselectedOptionId(targetVote);
     }
 
-    updateVote(contest.pickOneContestId, newVote, getInteractionMethod(event));
+    updateVote(contest.pickOneContestId, newVote);
   }
 
   const district = getContestDistrict(election, contest);

--- a/libs/mark-flow-ui/src/components/yes_no_contest.tsx
+++ b/libs/mark-flow-ui/src/components/yes_no_contest.tsx
@@ -17,7 +17,6 @@ import {
   AudioOnly,
   electionStrings,
   appStrings,
-  ButtonPressEvent,
 } from '@votingworks/ui';
 
 import { getSingleYesNoVote } from '@votingworks/utils';
@@ -25,7 +24,7 @@ import { Optional } from '@votingworks/basics';
 
 import { ContestFooter, ChoicesGrid } from './contest_screen_layout';
 import { BreadcrumbMetadata, ContestHeader } from './contest_header';
-import { UpdateVoteFunction, getInteractionMethod } from '../config/types';
+import { UpdateVoteFunction } from '../config/types';
 
 interface Props {
   breadcrumbs?: BreadcrumbMetadata;
@@ -55,15 +54,12 @@ export function YesNoContest({
     }
   }, [deselectedVote]);
 
-  function handleUpdateSelection(
-    event: ButtonPressEvent,
-    newVote: YesNoContestOptionId
-  ) {
+  function handleUpdateSelection(newVote: YesNoContestOptionId) {
     if ((vote as string[] | undefined)?.includes(newVote)) {
-      updateVote(contest.id, undefined, getInteractionMethod(event));
+      updateVote(contest.id, undefined);
       setDeselectedVote(newVote);
     } else {
-      updateVote(contest.id, [newVote], getInteractionMethod(event));
+      updateVote(contest.id, [newVote]);
     }
   }
 

--- a/libs/mark-flow-ui/src/config/types.ts
+++ b/libs/mark-flow-ui/src/config/types.ts
@@ -11,38 +11,15 @@ import {
   VotesDict,
   YesNoContest,
 } from '@votingworks/types';
-import { ButtonPressEvent } from '@votingworks/ui';
 import {
   ContestsWithMsEitherNeither,
   MsEitherNeitherContest,
 } from '../utils/ms_either_neither_contests';
 
-export enum VoteUpdateInteractionMethod {
-  Touch = 'touch',
-  AssistiveTechnologyDevice = 'assistive_technology_device',
-  Mouse = 'mouse',
-}
-
-export function getInteractionMethod(
-  event: ButtonPressEvent
-): VoteUpdateInteractionMethod {
-  if (event.detail === 0) {
-    /* istanbul ignore next - react-testing-library/userEvent pointer API was added in 14.0.0; we are on 13.x.x */
-    if ((event as React.TouchEvent<HTMLButtonElement>).touches) {
-      return VoteUpdateInteractionMethod.Touch;
-    }
-
-    return VoteUpdateInteractionMethod.AssistiveTechnologyDevice;
-  }
-
-  return VoteUpdateInteractionMethod.Mouse;
-}
-
 // Ballot
 export type UpdateVoteFunction = (
   contestId: ContestId,
-  vote: OptionalVote,
-  interactionMethod: VoteUpdateInteractionMethod
+  vote: OptionalVote
 ) => void;
 
 export interface BallotContextInterface {

--- a/libs/mark-flow-ui/src/pages/contest_page.tsx
+++ b/libs/mark-flow-ui/src/pages/contest_page.tsx
@@ -15,7 +15,6 @@ import { assert, throwIllegalValue } from '@votingworks/basics';
 
 import { Contest, ContestProps } from '../components/contest';
 import { ContestsWithMsEitherNeither } from '../utils/ms_either_neither_contests';
-import { VoteUpdateInteractionMethod } from '../config/types';
 import { BreadcrumbMetadata, Breadcrumbs } from '../components/contest_header';
 import { VoterScreen } from '../components/voter_screen';
 
@@ -25,6 +24,7 @@ export interface ContestPageProps {
   getContestUrl: (contestIndex: number) => string;
   getStartPageUrl: () => string;
   getReviewPageUrl: (contestId?: ContestId) => string;
+  isPatDeviceConnected?: boolean;
   precinctId?: PrecinctId;
   updateVote: ContestProps['updateVote'];
   votes: VotesDict;
@@ -45,6 +45,7 @@ export function ContestPage(props: ContestPageProps): JSX.Element {
     getContestUrl,
     getStartPageUrl,
     getReviewPageUrl,
+    isPatDeviceConnected,
     precinctId,
     updateVote,
     votes,
@@ -124,18 +125,10 @@ export function ContestPage(props: ContestPageProps): JSX.Element {
   );
 
   const handleUpdateVote: ContestProps['updateVote'] = useCallback(
-    (
-      contestIdProp: ContestId,
-      voteProp: OptionalVote,
-      interactionMethod: VoteUpdateInteractionMethod
-    ) => {
+    (contestIdProp: ContestId, voteProp: OptionalVote) => {
       const maxNumSelections = contest.type === 'candidate' ? contest.seats : 1;
 
-      if (
-        interactionMethod ===
-          VoteUpdateInteractionMethod.AssistiveTechnologyDevice &&
-        voteProp?.length === maxNumSelections
-      ) {
+      if (isPatDeviceConnected && voteProp?.length === maxNumSelections) {
         if (isReviewMode) {
           reviewButtonRef?.current?.focus();
         } else {
@@ -143,9 +136,9 @@ export function ContestPage(props: ContestPageProps): JSX.Element {
         }
       }
 
-      updateVote(contestIdProp, voteProp, interactionMethod);
+      updateVote(contestIdProp, voteProp);
     },
-    [updateVote, isReviewMode, contest]
+    [updateVote, isReviewMode, contest, isPatDeviceConnected]
   );
 
   const previousContestButton = (

--- a/libs/test-utils/src/index.ts
+++ b/libs/test-utils/src/index.ts
@@ -11,7 +11,6 @@ export * from './fake_kiosk';
 export * from './fake_printer';
 export * from './fake_use_audio_controls';
 export * from './has_text_across_elements';
-export * from './matchers';
 export * from './mock_function';
 export * from './mock_of';
 export * from './objects';

--- a/libs/test-utils/src/matchers.ts
+++ b/libs/test-utils/src/matchers.ts
@@ -1,5 +1,0 @@
-export function buttonPressEventMatcher():
-  | React.TouchEvent<HTMLButtonElement>
-  | React.MouseEvent<HTMLButtonElement> {
-  return expect.objectContaining({ detail: expect.any(Number) });
-}

--- a/libs/ui/src/button.test.tsx
+++ b/libs/ui/src/button.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { ColorMode, SizeMode } from '@votingworks/types';
 import { assert } from '@votingworks/basics';
 import userEvent from '@testing-library/user-event';
-import { buttonPressEventMatcher } from '@votingworks/test-utils';
 import { fireEvent, render, screen } from '../test/react_testing_library';
 import {
   BUTTON_VARIANTS,
@@ -160,10 +159,7 @@ describe('Button', () => {
 
     userEvent.click(screen.getButton('Click me'));
 
-    expect(onPress).toHaveBeenCalledWith(
-      ['foo', 'bar'],
-      buttonPressEventMatcher()
-    );
+    expect(onPress).toHaveBeenCalledWith(['foo', 'bar']);
   });
 
   test('variant danger', () => {

--- a/libs/ui/src/button.tsx
+++ b/libs/ui/src/button.tsx
@@ -43,12 +43,8 @@ const buttonVariants = {
 export type ButtonVariant = keyof typeof buttonVariants;
 export const BUTTON_VARIANTS = Object.keys(buttonVariants) as ButtonVariant[];
 
-export type ButtonPressEvent =
-  | React.TouchEvent<HTMLButtonElement>
-  | React.MouseEvent<HTMLButtonElement>;
-
-export type ClickHandler = (event: ButtonPressEvent) => void;
-export type TypedClickHandler<T> = (value: T, event: ButtonPressEvent) => void;
+export type ClickHandler = () => void;
+export type TypedClickHandler<T> = (value: T) => void;
 
 export interface StyledButtonProps {
   autoFocus?: boolean;
@@ -430,18 +426,18 @@ export class Button<T = undefined> extends PureComponent<
       Math.abs(startCoordinates[0] - clientX) < maxMove &&
       Math.abs(startCoordinates[1] - clientY) < maxMove
     ) {
-      this.onPress(event);
+      this.onPress();
       event.preventDefault();
     }
   };
 
-  private readonly onPress = (event: ButtonPressEvent): void => {
+  private readonly onPress = (): void => {
     const { onPress, value } = this.props;
 
     if (value === undefined) {
-      (onPress as ClickHandler)(event);
+      (onPress as ClickHandler)();
     } else {
-      (onPress as TypedClickHandler<T>)(value, event);
+      (onPress as TypedClickHandler<T>)(value);
     }
   };
 

--- a/libs/ui/src/contest_choice_button.test.tsx
+++ b/libs/ui/src/contest_choice_button.test.tsx
@@ -1,5 +1,4 @@
 import userEvent from '@testing-library/user-event';
-import { buttonPressEventMatcher } from '@votingworks/test-utils';
 import { render, screen } from '../test/react_testing_library';
 import { ContestChoiceButton } from './contest_choice_button';
 
@@ -40,7 +39,7 @@ test('fires press event with choice value', () => {
 
   userEvent.click(screen.getByRole('option'));
 
-  expect(onPress).toBeCalledWith(buttonPressEventMatcher(), 'cleo');
+  expect(onPress).toBeCalledWith('cleo');
 });
 
 test('has accessible "selected" state', () => {

--- a/libs/ui/src/contest_choice_button.tsx
+++ b/libs/ui/src/contest_choice_button.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from 'react';
 import styled, { DefaultTheme, css } from 'styled-components';
 
 import { SizeMode } from '@votingworks/types';
-import { Button, ButtonPressEvent, ButtonVariant } from './button';
+import { Button, ButtonVariant } from './button';
 import { Checkbox } from './checkbox';
 import { Caption, P } from './typography';
 
@@ -12,7 +12,7 @@ export interface ContestChoiceButtonProps<T extends string = string> {
   choice: T;
   isSelected?: boolean;
   label: React.ReactNode;
-  onPress: (event: ButtonPressEvent, value: T) => void;
+  onPress: (value: T) => void;
 
   /**
    * @deprecated Added to support pre-existing behaviour WRT the VxMark
@@ -85,10 +85,7 @@ export function ContestChoiceButton<T extends string>(
   const { ariaLabel, caption, choice, gridArea, isSelected, label, onPress } =
     props;
 
-  const handlePress = useCallback(
-    (event: ButtonPressEvent) => onPress(event, choice),
-    [onPress, choice]
-  );
+  const handlePress = useCallback(() => onPress(choice), [onPress, choice]);
 
   return (
     <OuterContainer

--- a/libs/ui/src/number_pad.test.tsx
+++ b/libs/ui/src/number_pad.test.tsx
@@ -1,5 +1,4 @@
 import userEvent from '@testing-library/user-event';
-import { buttonPressEventMatcher } from '@votingworks/test-utils';
 import { fireEvent, render, screen } from '../test/react_testing_library';
 
 import { NumberPad } from './number_pad';
@@ -17,7 +16,7 @@ test('click all pad buttons', () => {
   );
   for (let digit = 0; digit <= 9; digit += 1) {
     userEvent.click(screen.getButton(`${digit}`));
-    expect(onPress).toHaveBeenCalledWith(digit, buttonPressEventMatcher());
+    expect(onPress).toHaveBeenCalledWith(digit);
   }
   expect(onPress).toHaveBeenCalledTimes(10);
 

--- a/libs/ui/src/segmented_button.test.tsx
+++ b/libs/ui/src/segmented_button.test.tsx
@@ -1,6 +1,4 @@
-import { SyntheticEvent } from 'react';
 import userEvent from '@testing-library/user-event';
-import { buttonPressEventMatcher } from '@votingworks/test-utils';
 import { render, screen } from '../test/react_testing_library';
 import { SegmentedButton, SegmentedButtonOption } from './segmented_button';
 import { makeTheme } from './themes/make_theme';
@@ -39,26 +37,17 @@ test('renders all provided options ', () => {
   userEvent.click(
     screen.getByRole('option', { name: 'Option A', selected: false })
   );
-  expect(onChange).toHaveBeenCalledWith<[TestOptionId, SyntheticEvent]>(
-    'a',
-    buttonPressEventMatcher()
-  );
+  expect(onChange).toHaveBeenCalledWith<[TestOptionId]>('a');
 
   userEvent.click(
     screen.getByRole('option', { name: 'Option B', selected: true })
   );
-  expect(onChange).toHaveBeenCalledWith<[TestOptionId, SyntheticEvent]>(
-    'b',
-    buttonPressEventMatcher()
-  );
+  expect(onChange).toHaveBeenCalledWith<[TestOptionId]>('b');
 
   userEvent.click(
     screen.getByRole('option', { name: 'Enable Option C', selected: false })
   );
-  expect(onChange).toHaveBeenCalledWith<[TestOptionId, SyntheticEvent]>(
-    'c',
-    buttonPressEventMatcher()
-  );
+  expect(onChange).toHaveBeenCalledWith<[TestOptionId]>('c');
 });
 
 test('optionally hides label', () => {

--- a/libs/ui/src/virtual_keyboard.test.tsx
+++ b/libs/ui/src/virtual_keyboard.test.tsx
@@ -1,10 +1,6 @@
 import userEvent from '@testing-library/user-event';
 
-import {
-  buttonPressEventMatcher,
-  hasTextAcrossElements,
-  mockOf,
-} from '@votingworks/test-utils';
+import { hasTextAcrossElements, mockOf } from '@votingworks/test-utils';
 import { assertDefined } from '@votingworks/basics';
 import { LanguageCode } from '@votingworks/types';
 
@@ -80,7 +76,7 @@ test('fires key events', async () => {
       userEvent.click(
         screen.getByText(hasTextAcrossElements(expectedButtonContent))
       );
-      expect(onKeyPress).lastCalledWith(key.value, buttonPressEventMatcher());
+      expect(onKeyPress).lastCalledWith(key.value);
     }
   }
 
@@ -88,7 +84,7 @@ test('fires key events', async () => {
     `space ${getMockAudioOnlyTextPrefix(SPANISH)} space`
   );
   userEvent.click(spaceBar);
-  expect(onKeyPress).lastCalledWith(' ', buttonPressEventMatcher());
+  expect(onKeyPress).lastCalledWith(' ');
 
   expect(onBackspace).not.toHaveBeenCalled();
 
@@ -139,10 +135,10 @@ test('custom keymap', () => {
   userEvent.click(
     screen.getButton(`😂 ${getMockAudioOnlyTextPrefix(ENGLISH)} lol`)
   );
-  expect(onKeyPress).lastCalledWith('😂', buttonPressEventMatcher());
+  expect(onKeyPress).lastCalledWith('😂');
 
   userEvent.click(
     screen.getButton(`magic ${getMockAudioOnlyTextPrefix(ENGLISH)} magic`)
   );
-  expect(onKeyPress).lastCalledWith('✨', buttonPressEventMatcher());
+  expect(onKeyPress).lastCalledWith('✨');
 });

--- a/libs/ui/src/voter_settings/tab_bar.test.tsx
+++ b/libs/ui/src/voter_settings/tab_bar.test.tsx
@@ -1,6 +1,4 @@
 import userEvent from '@testing-library/user-event';
-import { SyntheticEvent } from 'react';
-import { buttonPressEventMatcher } from '@votingworks/test-utils';
 import { render, screen, within } from '../../test/react_testing_library';
 import { TabBar } from './tab_bar';
 import { SettingsPaneId } from './types';
@@ -27,17 +25,13 @@ test('fires change event with settings pane id', () => {
 
   userEvent.click(screen.getByRole('tab', { name: 'Color', selected: false }));
 
-  expect(onChange).toHaveBeenCalledWith<[SettingsPaneId, SyntheticEvent]>(
-    'voterSettingsColor',
-    buttonPressEventMatcher()
-  );
+  expect(onChange).toHaveBeenCalledWith<[SettingsPaneId]>('voterSettingsColor');
 
   userEvent.click(
     screen.getByRole('tab', { name: 'Audio/Video Only', selected: false })
   );
 
-  expect(onChange).toHaveBeenCalledWith<[SettingsPaneId, SyntheticEvent]>(
-    'voterSettingsAudioVideoOnly',
-    buttonPressEventMatcher()
+  expect(onChange).toHaveBeenCalledWith<[SettingsPaneId]>(
+    'voterSettingsAudioVideoOnly'
   );
 });


### PR DESCRIPTION
## Overview

Fixes https://github.com/votingworks/vxsuite/issues/4576

On BMD contest screens, we were previously automatically moving focus to the "next" button whenever the user makes the final available selection in the current contest -- this makes it easier for sip-and-puff voters to move to the next contest without having to scroll through the remaining contest options, but also prevented the screen reader from providing selection feedback for audio-only voters using the accessible button controller.

This limits that behaviour to only when a PAT device is connected to try to provide both PAT voters and audio-only-button-controller voters with an optimal experience.

## Demo Video or Screenshot

### Before - Non-PAT Voter [ 🔊 ]:

https://github.com/votingworks/vxsuite/assets/264902/0bdbd308-b88b-4ee6-8bcd-016874353727

### After - Non-PAT Voter [ 🔊 ]:

https://github.com/votingworks/vxsuite/assets/264902/08f5699e-3084-464d-a0cf-127a304fa9df

## Testing Plan
- Updated existing tests, added PAT-specific test case
- Manual verification

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
