### PR TITLE
VxCentralScan: determine whether the scanner's attached on the backend and add to Diagnostic screen

### DIFF
--- a/apps/admin/backend/src/server.ts
+++ b/apps/admin/backend/src/server.ts
@@ -15,6 +15,7 @@ import {
 import { detectUsbDrive, UsbDrive } from '@votingworks/usb-drive';
 import { Printer, detectPrinter } from '@votingworks/printing';
 import { assertDefined } from '@votingworks/basics';
+import { detectDevices } from '@votingworks/backend';
 import { ADMIN_WORKSPACE, PORT } from './globals';
 import { createWorkspace, Workspace } from './util/workspace';
 import { buildApp } from './app';
@@ -47,6 +48,7 @@ export async function start({
   printer,
 }: Partial<StartOptions>): Promise<Server> {
   debug('starting server...');
+  detectDevices({ logger: baseLogger });
   let resolvedWorkspace = workspace;
   /* c8 ignore start */
   if (!resolvedWorkspace) {

--- a/apps/central-scan/backend/src/fujitsu_scanner.ts
+++ b/apps/central-scan/backend/src/fujitsu_scanner.ts
@@ -8,10 +8,15 @@ import {
   ballotPaperDimensions,
 } from '@votingworks/types';
 import { LogEventId, BaseLogger } from '@votingworks/logging';
+import { isDeviceAttached } from '@votingworks/backend';
 import { streamExecFile } from './exec';
 import { StreamLines } from './util/stream_lines';
 
 const debug = makeDebug('scan:scanner');
+
+export const FUJITSU_VENDOR_ID = 0x4c5;
+export const FUJITSU_FI_7160_PRODUCT_ID = 0x132e;
+export const FUJITSU_FI_8170_PRODUCT_ID = 0x15ff;
 
 export interface BatchControl {
   scanSheet(): Promise<SheetOf<string> | undefined>;
@@ -24,6 +29,7 @@ export interface ScanOptions {
 }
 
 export interface BatchScanner {
+  isAttached(): boolean;
   scanSheets(options?: ScanOptions): BatchControl;
 }
 
@@ -68,6 +74,12 @@ export class FujitsuScanner implements BatchScanner {
     this.format = format;
     this.mode = mode;
     this.logger = logger;
+  }
+
+  isAttached(): boolean {
+    return isDeviceAttached(
+      (device) => device.deviceDescriptor.idVendor === FUJITSU_VENDOR_ID
+    );
   }
 
   scanSheets({

--- a/apps/central-scan/backend/src/importer.ts
+++ b/apps/central-scan/backend/src/importer.ts
@@ -349,6 +349,7 @@ export class Importer {
    */
   getStatus(): ScanStatus {
     return {
+      isScannerAttached: this.scanner.isAttached(),
       ongoingBatchId: this.batchId,
       adjudicationsRemaining:
         this.workspace.store.adjudicationStatus().remaining,

--- a/apps/central-scan/backend/src/loop_scanner.test.ts
+++ b/apps/central-scan/backend/src/loop_scanner.test.ts
@@ -72,3 +72,7 @@ test('ignores comments', () => {
     [['01.png', '02.png']],
   ]);
 });
+
+test('always attached', () => {
+  expect(new LoopScanner([]).isAttached()).toEqual(true);
+});

--- a/apps/central-scan/backend/src/loop_scanner.ts
+++ b/apps/central-scan/backend/src/loop_scanner.ts
@@ -82,6 +82,10 @@ export class LoopScanner implements BatchScanner {
    */
   constructor(private readonly batches: readonly Batch[]) {}
 
+  isAttached(): boolean {
+    return true;
+  }
+
   /**
    * "Scans" the next sheet by returning the paths for the next two images.
    */

--- a/apps/central-scan/backend/src/server.test.ts
+++ b/apps/central-scan/backend/src/server.test.ts
@@ -1,0 +1,39 @@
+import { buildMockDippedSmartCardAuth } from '@votingworks/auth';
+import { dirSync } from 'tmp';
+import { createMockUsbDrive } from '@votingworks/usb-drive';
+import { testDetectDevices } from '@votingworks/backend';
+import { Server } from 'http';
+import { createWorkspace } from './util/workspace';
+import { buildMockLogger } from '../test/helpers/setup_app';
+import { makeMockScanner } from '../test/util/mocks';
+import { Importer } from './importer';
+import { buildCentralScannerApp } from './app';
+import { start } from './server';
+
+test('logs device attach/un-attach events', async () => {
+  const auth = buildMockDippedSmartCardAuth();
+  const workspace = createWorkspace(dirSync().name);
+  const logger = buildMockLogger(auth, workspace);
+  const { usbDrive } = createMockUsbDrive();
+  const scanner = makeMockScanner();
+  const importer = new Importer({ workspace, logger, scanner });
+  const app = buildCentralScannerApp({
+    auth,
+    workspace,
+    logger,
+    usbDrive,
+    importer,
+  });
+
+  // don't actually listen
+  jest.spyOn(app, 'listen').mockImplementationOnce((_port, onListening) => {
+    onListening?.();
+    return undefined as unknown as Server;
+  });
+  jest.spyOn(console, 'log').mockImplementation();
+
+  // start up the server
+  await start({ app, workspace, port: 3005, logger });
+
+  testDetectDevices(logger);
+});

--- a/apps/central-scan/backend/src/server.ts
+++ b/apps/central-scan/backend/src/server.ts
@@ -14,6 +14,7 @@ import {
 } from '@votingworks/utils';
 import { UsbDrive, detectUsbDrive } from '@votingworks/usb-drive';
 import { assertDefined } from '@votingworks/basics';
+import { detectDevices } from '@votingworks/backend';
 import { PORT, SCAN_WORKSPACE } from './globals';
 import { Importer } from './importer';
 import { FujitsuScanner, BatchScanner, ScannerMode } from './fujitsu_scanner';
@@ -43,6 +44,7 @@ export async function start({
   logger: baseLogger = new BaseLogger(LogSource.VxCentralScanService),
   workspace,
 }: Partial<StartOptions> = {}): Promise<Server> {
+  detectDevices({ logger: baseLogger });
   let resolvedWorkspace = workspace;
   /* c8 ignore start */
   if (!resolvedWorkspace) {

--- a/apps/central-scan/backend/src/types.ts
+++ b/apps/central-scan/backend/src/types.ts
@@ -8,6 +8,7 @@ export interface MachineConfig {
 export type ScanState = 'idle' | 'scanning' | 'adjudication';
 
 export interface ScanStatus {
+  isScannerAttached: boolean;
   ongoingBatchId?: BatchInfo['id'];
   adjudicationsRemaining: number;
   batches: BatchInfo[];

--- a/apps/central-scan/backend/test/util/mocks.ts
+++ b/apps/central-scan/backend/test/util/mocks.ts
@@ -94,6 +94,10 @@ export function makeMockScanner(): MockScanner {
   let nextScannerSession: ScannerSessionPlan | undefined;
 
   return {
+    isAttached(): boolean {
+      return true;
+    },
+
     scanSheets(): BatchControl {
       const session = nextScannerSession;
       nextScannerSession = undefined;

--- a/apps/central-scan/frontend/src/app.tsx
+++ b/apps/central-scan/frontend/src/app.tsx
@@ -1,4 +1,3 @@
-import { getHardware } from '@votingworks/utils';
 import { BrowserRouter } from 'react-router-dom';
 import { BaseLogger, LogSource } from '@votingworks/logging';
 import {
@@ -19,14 +18,12 @@ import {
 import { SessionTimeLimitTracker } from './components/session_time_limit_tracker';
 
 export interface Props {
-  hardware?: AppRootProps['hardware'];
   logger?: AppRootProps['logger'];
   apiClient?: ApiClient;
   queryClient?: QueryClient;
 }
 
 export function App({
-  hardware = getHardware(),
   logger = new BaseLogger(LogSource.VxCentralScanFrontend, window.kiosk),
   apiClient = createApiClient(),
   queryClient = createQueryClient(),
@@ -45,7 +42,7 @@ export function App({
           <ApiClientContext.Provider value={apiClient}>
             <QueryClientProvider client={queryClient}>
               <SystemCallContextProvider api={systemCallApi}>
-                <AppRoot hardware={hardware} logger={logger} />
+                <AppRoot logger={logger} />
                 <SessionTimeLimitTracker />
                 <BatteryLowAlert />
               </SystemCallContextProvider>

--- a/apps/central-scan/frontend/src/app_root.tsx
+++ b/apps/central-scan/frontend/src/app_root.tsx
@@ -1,7 +1,6 @@
 import { Redirect, Route, Switch } from 'react-router-dom';
 
 import {
-  Hardware,
   isElectionManagerAuth,
   isSystemAdministratorAuth,
 } from '@votingworks/utils';
@@ -12,7 +11,6 @@ import {
   RemoveCardScreen,
   Screen,
   SetupCardReaderPage,
-  useDevices,
   H1,
 } from '@votingworks/ui';
 import { BaseLogger } from '@votingworks/logging';
@@ -37,19 +35,10 @@ import { SystemAdministratorSettingsScreen } from './screens/system_administrato
 import { HardwareDiagnosticsScreen } from './screens/hardware_diagnostics_screen';
 
 export interface AppRootProps {
-  hardware: Hardware;
   logger: BaseLogger;
 }
 
-export function AppRoot({
-  hardware,
-  logger,
-}: AppRootProps): JSX.Element | null {
-  const { batchScanner } = useDevices({
-    hardware,
-    logger,
-  });
-
+export function AppRoot({ logger }: AppRootProps): JSX.Element | null {
   const machineConfigQuery = getMachineConfig.useQuery();
   const usbDriveStatusQuery = getUsbDriveStatus.useQuery();
   const authStatusQuery = getAuthStatus.useQuery();
@@ -177,7 +166,6 @@ export function AppRoot({
       <Switch>
         <Route path="/scan">
           <ScanBallotsScreen
-            isScannerAttached={batchScanner !== undefined}
             status={status}
             statusIsStale={statusQuery.isStale}
           />

--- a/apps/central-scan/frontend/src/app_root.tsx
+++ b/apps/central-scan/frontend/src/app_root.tsx
@@ -135,7 +135,7 @@ export function AppRoot({ logger }: AppRootProps): JSX.Element | null {
             <SystemAdministratorSettingsScreen />
           </Route>
           <Route path="/hardware-diagnostics">
-            <HardwareDiagnosticsScreen />
+            <HardwareDiagnosticsScreen scanStatus={status} />
           </Route>
           <Redirect to="/system-administrator-settings" />
         </Switch>

--- a/apps/central-scan/frontend/src/screens/hardware_diagnostics_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/hardware_diagnostics_screen.test.tsx
@@ -2,6 +2,7 @@ import { screen } from '../../test/react_testing_library';
 import { renderInAppContext } from '../../test/render_in_app_context';
 import { createApiMock, ApiMock } from '../../test/api';
 import { HardwareDiagnosticsScreen } from './hardware_diagnostics_screen';
+import { mockStatus } from '../../test/fixtures';
 
 let apiMock: ApiMock;
 
@@ -23,10 +24,11 @@ test('hardware diagnostics screen', async () => {
     available: 500_000_000,
     used: 500_000_000,
   });
-  renderInAppContext(<HardwareDiagnosticsScreen />, {
+  renderInAppContext(<HardwareDiagnosticsScreen scanStatus={mockStatus()} />, {
     apiMock,
   });
 
   await screen.findByText('Battery Level: 50%');
   screen.getByText('Free Disk Space: 50% (500 GB / 1000 GB)');
+  screen.getByText('Connected');
 });

--- a/apps/central-scan/frontend/src/screens/hardware_diagnostics_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/hardware_diagnostics_screen.tsx
@@ -1,8 +1,15 @@
 import { CentralScanReadinessReportContents } from '@votingworks/ui';
+import type { ScanStatus } from '@votingworks/central-scan-backend';
 import { NavigationScreen } from '../navigation_screen';
 import { getApplicationDiskSpaceSummary, systemCallApi } from '../api';
 
-export function HardwareDiagnosticsScreen(): JSX.Element {
+export interface HardwareDiagnosticsScreenProps {
+  scanStatus: ScanStatus;
+}
+
+export function HardwareDiagnosticsScreen({
+  scanStatus,
+}: HardwareDiagnosticsScreenProps): JSX.Element {
   const batteryInfoQuery = systemCallApi.getBatteryInfo.useQuery();
   const diskSpaceQuery = getApplicationDiskSpaceSummary.useQuery();
 
@@ -20,6 +27,7 @@ export function HardwareDiagnosticsScreen(): JSX.Element {
       <CentralScanReadinessReportContents
         batteryInfo={batteryInfo ?? undefined}
         diskSpaceSummary={diskSpaceSummary}
+        isScannerAttached={scanStatus.isScannerAttached}
       />
     </NavigationScreen>
   );

--- a/apps/central-scan/frontend/src/screens/scan_ballots_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/scan_ballots_screen.test.tsx
@@ -8,6 +8,7 @@ import {
 } from './scan_ballots_screen';
 import { renderInAppContext } from '../../test/render_in_app_context';
 import { ApiMock, createApiMock } from '../../test/api';
+import { mockBatch, mockStatus } from '../../test/fixtures';
 
 let apiMock: ApiMock;
 
@@ -22,13 +23,7 @@ afterEach(() => {
 function renderScreen(props?: Partial<ScanBallotsScreenProps>) {
   return renderInAppContext(
     <ScanBallotsScreen
-      isScannerAttached
-      status={{
-        ongoingBatchId: undefined,
-        adjudicationsRemaining: 0,
-        canUnconfigure: true,
-        batches: [],
-      }}
+      status={mockStatus()}
       statusIsStale={false}
       {...props}
     />,
@@ -42,29 +37,18 @@ test('null state', () => {
 });
 
 test('shows scanned ballot count', () => {
-  const status: ScanStatus = {
-    ongoingBatchId: undefined,
-    adjudicationsRemaining: 0,
-    canUnconfigure: false,
+  const status: ScanStatus = mockStatus({
     batches: [
-      {
+      mockBatch({
         id: 'a',
-        batchNumber: 1,
         count: 1,
-        label: 'Batch 1',
-        startedAt: new Date(0).toISOString(),
-        endedAt: new Date(0).toISOString(),
-      },
-      {
+      }),
+      mockBatch({
         id: 'b',
-        batchNumber: 2,
         count: 3,
-        label: 'Batch 2',
-        startedAt: new Date(0).toISOString(),
-        endedAt: new Date(0).toISOString(),
-      },
+      }),
     ],
-  };
+  });
   renderScreen({ status });
   screen.getByText(
     hasTextAcrossElements(
@@ -74,20 +58,14 @@ test('shows scanned ballot count', () => {
 });
 
 test('shows whether a batch is scanning', () => {
-  const status: ScanStatus = {
+  const status: ScanStatus = mockStatus({
     ongoingBatchId: 'a',
-    adjudicationsRemaining: 0,
-    canUnconfigure: false,
     batches: [
-      {
-        id: 'a',
-        batchNumber: 1,
-        label: 'Batch 1',
-        count: 3,
-        startedAt: new Date(0).toISOString(),
-      },
+      mockBatch({
+        endedAt: undefined,
+      }),
     ],
-  };
+  });
   renderScreen({ status });
   screen.getByText('Scanning…');
   for (const deleteButton of screen.getAllButtons('Delete')) {
@@ -97,21 +75,10 @@ test('shows whether a batch is scanning', () => {
 });
 
 test('Delete All Batches is not allowed when canUnconfigure is false', () => {
-  const status: ScanStatus = {
-    ongoingBatchId: undefined,
-    adjudicationsRemaining: 0,
+  const status: ScanStatus = mockStatus({
     canUnconfigure: false,
-    batches: [
-      {
-        id: 'a',
-        batchNumber: 1,
-        label: 'Batch 1',
-        count: 3,
-        startedAt: new Date(0).toISOString(),
-        endedAt: new Date(0).toISOString(),
-      },
-    ],
-  };
+    batches: [mockBatch()],
+  });
   renderScreen({ status });
 
   userEvent.click(screen.getButton('Delete All Batches'));
@@ -121,21 +88,9 @@ test('Delete All Batches is not allowed when canUnconfigure is false', () => {
 });
 
 test('Delete All Batches button', async () => {
-  const status: ScanStatus = {
-    ongoingBatchId: undefined,
-    adjudicationsRemaining: 0,
-    canUnconfigure: true,
-    batches: [
-      {
-        id: 'a',
-        batchNumber: 1,
-        label: 'Batch 1',
-        count: 3,
-        startedAt: new Date(0).toISOString(),
-        endedAt: new Date(0).toISOString(),
-      },
-    ],
-  };
+  const status: ScanStatus = mockStatus({
+    batches: [mockBatch()],
+  });
   renderScreen({ status });
 
   // initial button
@@ -155,18 +110,15 @@ test('Delete All Batches button', async () => {
 
 describe('Scan Ballots Button', () => {
   test('disabled when no scanner is attached', () => {
-    renderScreen({ isScannerAttached: false });
+    renderScreen({ status: mockStatus({ isScannerAttached: false }) });
     expect(screen.getButton('No Scanner')).toBeDisabled();
   });
 
   test('disabled when there is an ongoing batch', () => {
     renderScreen({
-      status: {
+      status: mockStatus({
         ongoingBatchId: 'a',
-        canUnconfigure: true,
-        adjudicationsRemaining: 0,
-        batches: [],
-      },
+      }),
     });
     expect(screen.getButton('Scan New Batch')).toBeDisabled();
   });

--- a/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
@@ -52,13 +52,11 @@ const DeleteAllWrapper = styled.div`
 `;
 
 export interface ScanBallotsScreenProps {
-  isScannerAttached: boolean;
   status: ScanStatus;
   statusIsStale: boolean;
 }
 
 export function ScanBallotsScreen({
-  isScannerAttached,
   status,
   statusIsStale,
 }: ScanBallotsScreenProps): JSX.Element {
@@ -102,7 +100,7 @@ export function ScanBallotsScreen({
           <ScanButton
             /* disable scan button while status query is refetching to avoid double clicks */
             disabled={isScanning || statusIsStale}
-            isScannerAttached={isScannerAttached}
+            isScannerAttached={status.isScannerAttached}
           />
           <Button
             onPress={() => setIsExportingCvrs(true)}

--- a/apps/central-scan/frontend/test/api.tsx
+++ b/apps/central-scan/frontend/test/api.tsx
@@ -17,13 +17,7 @@ import type { BatteryInfo, DiskSpaceSummary } from '@votingworks/backend';
 import type { UsbDriveStatus } from '@votingworks/usb-drive';
 import { ok } from '@votingworks/basics';
 import { ApiClientContext, createQueryClient, systemCallApi } from '../src/api';
-
-const DEFAULT_STATUS: ScanStatus = {
-  ongoingBatchId: undefined,
-  adjudicationsRemaining: 0,
-  canUnconfigure: true,
-  batches: [],
-};
+import { DEFAULT_STATUS } from './fixtures';
 
 export type MockApiClient = Omit<MockClient<Api>, 'getBatteryInfo'> & {
   // Because this is polled so frequently, we opt for a standard jest mock instead of a

--- a/apps/central-scan/frontend/test/fixtures.ts
+++ b/apps/central-scan/frontend/test/fixtures.ts
@@ -1,0 +1,33 @@
+import { ScanStatus } from '@votingworks/central-scan-backend';
+import { BatchInfo } from '@votingworks/types';
+
+export const DEFAULT_STATUS: ScanStatus = {
+  isScannerAttached: true,
+  ongoingBatchId: undefined,
+  adjudicationsRemaining: 0,
+  canUnconfigure: true,
+  batches: [],
+};
+
+export function mockStatus(status: Partial<ScanStatus> = {}): ScanStatus {
+  return {
+    ...DEFAULT_STATUS,
+    ...status,
+  };
+}
+
+export const MOCK_BATCH: BatchInfo = {
+  id: 'id',
+  batchNumber: 1,
+  count: 1,
+  label: 'Batch 1',
+  startedAt: new Date(0).toISOString(),
+  endedAt: new Date(0).toISOString(),
+};
+
+export function mockBatch(batch: Partial<BatchInfo> = {}): BatchInfo {
+  return {
+    ...MOCK_BATCH,
+    ...batch,
+  };
+}

--- a/apps/scan/backend/src/server.test.ts
+++ b/apps/scan/backend/src/server.test.ts
@@ -2,6 +2,7 @@ import { LogEventId } from '@votingworks/logging';
 import { Application } from 'express';
 import { dirSync } from 'tmp';
 import { buildMockInsertedSmartCardAuth } from '@votingworks/auth';
+import { testDetectDevices } from '@votingworks/backend';
 import { buildApp } from './app';
 import { PORT } from './globals';
 import { start } from './server';
@@ -64,4 +65,21 @@ test('start passes the state machine and workspace to `buildApp`', async () => {
     expect.anything(),
     expect.anything()
   );
+});
+
+test('logs device attach/unattach events', () => {
+  const precinctScannerStateMachine = createPrecinctScannerStateMachineMock();
+  const listen = jest.fn();
+  const auth = buildMockInsertedSmartCardAuth();
+  const logger = buildMockLogger(auth, workspace);
+  buildAppMock.mockReturnValueOnce({ listen } as unknown as Application);
+
+  start({
+    auth: buildMockInsertedSmartCardAuth(),
+    workspace,
+    logger,
+    precinctScannerStateMachine,
+  });
+
+  testDetectDevices(logger);
 });

--- a/libs/backend/src/detect_devices.test.ts
+++ b/libs/backend/src/detect_devices.test.ts
@@ -1,40 +1,9 @@
-import { LogEventId, mockBaseLogger } from '@votingworks/logging';
-import { usb } from 'usb';
+import { mockBaseLogger } from '@votingworks/logging';
 import { detectDevices } from './detect_devices';
+import { testDetectDevices } from './test_detect_devices';
 
 test('detectDevices', () => {
   const logger = mockBaseLogger();
-
   detectDevices({ logger });
-
-  const device = {
-    deviceDescriptor: {
-      idVendor: 1,
-      idProduct: 2,
-    },
-  } as unknown as usb.Device;
-
-  usb.emit('attach', device);
-  expect(logger.log).toHaveBeenCalledTimes(1);
-  expect(logger.log).toHaveBeenLastCalledWith(
-    LogEventId.DeviceAttached,
-    'system',
-    {
-      message: 'Device attached. Vendor ID: 1, Product ID: 2',
-      productId: 2,
-      vendorId: 1,
-    }
-  );
-
-  usb.emit('detach', device);
-  expect(logger.log).toHaveBeenCalledTimes(2);
-  expect(logger.log).toHaveBeenLastCalledWith(
-    LogEventId.DeviceUnattached,
-    'system',
-    {
-      message: 'Device unattached. Vendor ID: 1, Product ID: 2',
-      productId: 2,
-      vendorId: 1,
-    }
-  );
+  testDetectDevices(logger);
 });

--- a/libs/backend/src/index.ts
+++ b/libs/backend/src/index.ts
@@ -1,6 +1,7 @@
 /* istanbul ignore file */
 export * from './cast_vote_records';
 export * from './detect_devices';
+export * from './test_detect_devices';
 export * from './dotenv';
 export * from './election_package';
 export * from './exporter';

--- a/libs/backend/src/index.ts
+++ b/libs/backend/src/index.ts
@@ -11,3 +11,5 @@ export * from './system_call';
 export * from './scan_globals';
 export * from './split';
 export * from './ui_strings';
+
+export type { Device } from 'usb';

--- a/libs/backend/src/index.ts
+++ b/libs/backend/src/index.ts
@@ -5,6 +5,7 @@ export * from './dotenv';
 export * from './election_package';
 export * from './exporter';
 export * from './disk_space_summary';
+export * from './is_device_attached';
 export * from './pdf_to_text';
 export * from './system_call';
 export * from './scan_globals';

--- a/libs/backend/src/is_device_attached.test.ts
+++ b/libs/backend/src/is_device_attached.test.ts
@@ -1,0 +1,68 @@
+import { mockOf } from '@votingworks/test-utils';
+import { usb } from 'usb';
+import { isDeviceAttached } from './is_device_attached';
+
+jest.mock('usb', (): typeof import('usb') => {
+  const actual = jest.requireActual('usb');
+  return {
+    ...actual,
+    usb: {
+      ...actual.usb,
+      getDeviceList: jest.fn(),
+    },
+  };
+});
+
+test('isDeviceAttached', () => {
+  const getDeviceListMock = mockOf(usb.getDeviceList);
+  const devices = [
+    {
+      deviceDescriptor: {
+        idVendor: 1,
+        idProduct: 2,
+      },
+    },
+    {
+      deviceDescriptor: {
+        idVendor: 1,
+        idProduct: 3,
+      },
+    },
+    {
+      deviceDescriptor: {
+        idVendor: 3,
+        idProduct: 4,
+      },
+    },
+  ] as unknown as usb.Device[];
+
+  getDeviceListMock.mockReturnValue(devices);
+
+  expect(
+    isDeviceAttached(
+      (device) =>
+        device.deviceDescriptor.idVendor === 1 &&
+        device.deviceDescriptor.idProduct === 2
+    )
+  ).toEqual(true);
+
+  expect(
+    isDeviceAttached(
+      (device) =>
+        device.deviceDescriptor.idVendor === 3 &&
+        device.deviceDescriptor.idProduct === 4
+    )
+  ).toEqual(true);
+
+  expect(
+    isDeviceAttached((device) => device.deviceDescriptor.idVendor === 1)
+  ).toEqual(true);
+
+  expect(
+    isDeviceAttached(
+      (device) =>
+        device.deviceDescriptor.idVendor === 1 &&
+        device.deviceDescriptor.idProduct === 4
+    )
+  ).toEqual(false);
+});

--- a/libs/backend/src/is_device_attached.ts
+++ b/libs/backend/src/is_device_attached.ts
@@ -1,0 +1,10 @@
+import { usb } from 'usb';
+
+/**
+ * Checks whether a device is attached or not.
+ */
+export function isDeviceAttached(
+  isDevice: (device: usb.Device) => boolean
+): boolean {
+  return usb.getDeviceList().some(isDevice);
+}

--- a/libs/backend/src/test_detect_devices.ts
+++ b/libs/backend/src/test_detect_devices.ts
@@ -1,0 +1,37 @@
+import { BaseLogger, LogEventId } from '@votingworks/logging';
+import { usb } from 'usb';
+
+/**
+ * Test harness for app that uses `detectDevices`, to confirm it logs device
+ * events.
+ */
+export function testDetectDevices(logger: BaseLogger): void {
+  const device = {
+    deviceDescriptor: {
+      idVendor: 1,
+      idProduct: 2,
+    },
+  } as unknown as usb.Device;
+
+  usb.emit('attach', device);
+  expect(logger.log).toHaveBeenLastCalledWith(
+    LogEventId.DeviceAttached,
+    'system',
+    {
+      message: 'Device attached. Vendor ID: 1, Product ID: 2',
+      productId: 2,
+      vendorId: 1,
+    }
+  );
+
+  usb.emit('detach', device);
+  expect(logger.log).toHaveBeenLastCalledWith(
+    LogEventId.DeviceUnattached,
+    'system',
+    {
+      message: 'Device unattached. Vendor ID: 1, Product ID: 2',
+      productId: 2,
+      vendorId: 1,
+    }
+  );
+}

--- a/libs/ui/src/diagnostics/central_scan_readiness_report.test.tsx
+++ b/libs/ui/src/diagnostics/central_scan_readiness_report.test.tsx
@@ -13,6 +13,7 @@ test('CentralScanReadinessReportContents', () => {
         available: 500_000_000,
         used: 500_000_000,
       }}
+      isScannerAttached
     />
   );
 
@@ -21,4 +22,6 @@ test('CentralScanReadinessReportContents', () => {
   expect(
     screen.getByText('Free Disk Space: 50% (500 GB / 1000 GB)')
   ).toBeInTheDocument();
+  expect(screen.getByText('Scanner')).toBeInTheDocument();
+  expect(screen.getByText('Connected')).toBeInTheDocument();
 });

--- a/libs/ui/src/diagnostics/central_scan_readiness_report.tsx
+++ b/libs/ui/src/diagnostics/central_scan_readiness_report.tsx
@@ -1,12 +1,15 @@
 import type { BatteryInfo, DiskSpaceSummary } from '@votingworks/backend';
 import { LaptopSection } from './laptop_section';
+import { CentralScannerSection } from './central_scanner_section';
 
 export function CentralScanReadinessReportContents({
   batteryInfo,
   diskSpaceSummary,
+  isScannerAttached,
 }: {
   batteryInfo?: BatteryInfo;
   diskSpaceSummary: DiskSpaceSummary;
+  isScannerAttached: boolean;
 }): JSX.Element {
   return (
     <div>
@@ -14,6 +17,7 @@ export function CentralScanReadinessReportContents({
         batteryInfo={batteryInfo}
         diskSpaceSummary={diskSpaceSummary}
       />
+      <CentralScannerSection isScannerAttached={isScannerAttached} />
     </div>
   );
 }

--- a/libs/ui/src/diagnostics/central_scanner_section.test.tsx
+++ b/libs/ui/src/diagnostics/central_scanner_section.test.tsx
@@ -1,0 +1,15 @@
+import { expectTextWithIcon } from '../../test/expect_text_with_icon';
+import { render } from '../../test/react_testing_library';
+import { CentralScannerSection } from './central_scanner_section';
+
+test('connected', async () => {
+  render(<CentralScannerSection isScannerAttached />);
+
+  await expectTextWithIcon('Connected', 'square-check');
+});
+
+test('not connected', async () => {
+  render(<CentralScannerSection isScannerAttached={false} />);
+
+  await expectTextWithIcon('No scanner detected', 'circle-info');
+});

--- a/libs/ui/src/diagnostics/central_scanner_section.tsx
+++ b/libs/ui/src/diagnostics/central_scanner_section.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { H2, P } from '../typography';
+import { InfoIcon, SuccessIcon } from './icons';
+
+export function CentralScannerSection({
+  isScannerAttached,
+}: {
+  isScannerAttached: boolean;
+}): JSX.Element {
+  return (
+    <React.Fragment>
+      <H2>Scanner</H2>
+      {isScannerAttached ? (
+        <P>
+          <SuccessIcon /> Connected
+        </P>
+      ) : (
+        <P>
+          <InfoIcon /> No scanner detected
+        </P>
+      )}
+    </React.Fragment>
+  );
+}


### PR DESCRIPTION
## Overview

Precursor to VxCentralScan scanner diagnostic.

## Demo Video or Screenshot

<img width="1151" alt="Screen Shot 2024-02-29 at 4 21 14 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/4eb51c01-34f0-4e6e-9d90-c74d598a1557">
<img width="1152" alt="Screen Shot 2024-02-29 at 4 20 53 PM" src="https://github.com/votingworks/vxsuite/assets/37960853/66c28fbb-6a45-4579-bce9-d7c635ee49dd">
