### PR TITLE
Introduce getSystemTimezone helper that can be mocked in tests

### DIFF
--- a/apps/admin/backend/src/app.tally_report_pdf.test.ts
+++ b/apps/admin/backend/src/app.tally_report_pdf.test.ts
@@ -35,6 +35,7 @@ const featureFlagMock = getFeatureFlagMock();
 jest.mock('@votingworks/utils', () => {
   return {
     ...jest.requireActual('@votingworks/utils'),
+    getSystemTimezone: () => 'UTC',
     isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
       featureFlagMock.isEnabled(flag),
   };

--- a/libs/ui/src/reports/tally_report_metadata.tsx
+++ b/libs/ui/src/reports/tally_report_metadata.tsx
@@ -1,6 +1,6 @@
 import { Election } from '@votingworks/types';
 
-import { format } from '@votingworks/utils';
+import { format, getSystemTimezone } from '@votingworks/utils';
 
 import { Text } from '../text';
 
@@ -16,7 +16,10 @@ export function TallyReportMetadata({
   const electionDate = format.localeWeekdayAndDate(
     election.date.toMidnightDatetimeWithSystemTimezone()
   );
-  const generatedAt = format.localeLongDateAndTime(generatedAtTime);
+  const generatedAt = format.localeLongDateAndTime(
+    generatedAtTime,
+    getSystemTimezone()
+  );
 
   return (
     <p>

--- a/libs/utils/src/format.ts
+++ b/libs/utils/src/format.ts
@@ -32,7 +32,12 @@ export function percent(
   return percentFormatter.format(value);
 }
 
-export function localeLongDateAndTime(time?: number | Date): string {
+export function localeLongDateAndTime(
+  time?: number | Date,
+  // Since this function displays the timezone, allow it to be overridden to
+  // make tests deterministic.
+  timeZone?: string
+): string {
   return new Intl.DateTimeFormat(DEFAULT_LOCALE, {
     weekday: 'long',
     month: 'long',
@@ -42,6 +47,7 @@ export function localeLongDateAndTime(time?: number | Date): string {
     minute: 'numeric',
     second: 'numeric',
     timeZoneName: 'short',
+    timeZone,
   }).format(time);
 }
 

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -5,6 +5,7 @@ export * from './pins';
 export * from './cast_vote_records';
 export * from './compressed_tallies';
 export * from './date';
+export * from './get_system_timezone';
 export * from './elections';
 export * from './environment_variable';
 export * from './extract_cdf_ui_strings';


### PR DESCRIPTION
## Overview

<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
