### PR TITLE
fix keyboard nav on review screen

### DIFF
--- a/libs/mark-flow-ui/src/components/review.test.tsx
+++ b/libs/mark-flow-ui/src/components/review.test.tsx
@@ -197,25 +197,32 @@ describe('ms-either-neither contest', () => {
   });
 });
 
-test('keyboard navigation', async () => {
-  const contest = electionGeneral.contests.find(
-    (c): c is CandidateContest => c.type === 'candidate'
-  );
-  assert(contest);
-  const contests = [contest];
-  const returnToContestStub = jest.fn();
-  render(
-    <Review
-      election={electionGeneral}
-      contests={contests}
-      precinctId={electionGeneral.precincts[0].id}
-      votes={{}}
-      returnToContest={returnToContestStub}
-    />
-  );
+describe('keyboard navigation', () => {
+  test.each([['[Enter]'], ['[Space]']] as const)(
+    '%s key activates contest review button',
+    async (key) => {
+      const contest = electionGeneral.contests.find(
+        (c): c is CandidateContest => c.type === 'candidate'
+      );
+      assert(contest);
+      const contests = [contest];
+      const returnToContestStub = jest.fn();
+      render(
+        <Review
+          election={electionGeneral}
+          contests={contests}
+          precinctId={electionGeneral.precincts[0].id}
+          votes={{}}
+          returnToContest={returnToContestStub}
+        />
+      );
 
-  userEvent.tab();
-  expect(await screen.findByTestId(`contest-${contests[0].id}`)).toHaveFocus();
-  userEvent.keyboard('[Enter]');
-  expect(returnToContestStub).toHaveBeenCalledTimes(1);
+      userEvent.tab();
+      expect(
+        await screen.findByTestId(`contest-wrapper-${contests[0].id}`)
+      ).toHaveFocus();
+      userEvent.keyboard(key);
+      expect(returnToContestStub).toHaveBeenCalledTimes(1);
+    }
+  );
 });

--- a/libs/mark-flow-ui/src/components/review.test.tsx
+++ b/libs/mark-flow-ui/src/components/review.test.tsx
@@ -196,3 +196,26 @@ describe('ms-either-neither contest', () => {
     }
   });
 });
+
+test('keyboard navigation', async () => {
+  const contest = electionGeneral.contests.find(
+    (c): c is CandidateContest => c.type === 'candidate'
+  );
+  assert(contest);
+  const contests = [contest];
+  const returnToContestStub = jest.fn();
+  render(
+    <Review
+      election={electionGeneral}
+      contests={contests}
+      precinctId={electionGeneral.precincts[0].id}
+      votes={{}}
+      returnToContest={returnToContestStub}
+    />
+  );
+
+  userEvent.tab();
+  expect(await screen.findByTestId(`contest-${contests[0].id}`)).toHaveFocus();
+  userEvent.keyboard('[Enter]');
+  expect(returnToContestStub).toHaveBeenCalledTimes(1);
+});

--- a/libs/mark-flow-ui/src/components/review.tsx
+++ b/libs/mark-flow-ui/src/components/review.tsx
@@ -203,7 +203,11 @@ export function Review({
           tabIndex={0}
           role="button"
           id={`contest-${contest.id}`}
+          data-testid={`contest-${contest.id}`}
           key={contest.id}
+          onKeyDown={(event) =>
+            event.key === 'Enter' && onChangeClick(contest.id)
+          }
           onClick={() => onChangeClick(contest.id)}
         >
           <Card

--- a/libs/mark-flow-ui/src/components/review.tsx
+++ b/libs/mark-flow-ui/src/components/review.tsx
@@ -205,9 +205,14 @@ export function Review({
           id={`contest-${contest.id}`}
           data-testid={`contest-${contest.id}`}
           key={contest.id}
-          onKeyDown={(event) =>
-            event.key === 'Enter' && onChangeClick(contest.id)
-          }
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              // Default behavior for Space key is to scroll and should be prevented.
+              // See code example at https://www.w3.org/WAI/ARIA/apg/patterns/button/examples/button/
+              event.preventDefault();
+              onChangeClick(contest.id);
+            }
+          }}
           onClick={() => onChangeClick(contest.id)}
         >
           <Card

--- a/libs/mark-flow-ui/src/components/review.tsx
+++ b/libs/mark-flow-ui/src/components/review.tsx
@@ -203,7 +203,7 @@ export function Review({
           tabIndex={0}
           role="button"
           id={`contest-${contest.id}`}
-          data-testid={`contest-${contest.id}`}
+          data-testid={`contest-wrapper-${contest.id}`}
           key={contest.id}
           onKeyDown={(event) => {
             if (event.key === 'Enter' || event.key === ' ') {


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/4509

This fixes the issue where selecting a button by keyboard `Enter` (or device that depends on keyboard events ie. PAT or accessibility controller) does not activate the contest review button.

I want to be sure we're avoiding a band-aid fix. Do we actually expect `onClick` to be called when an `Enter` keypress event is received and a deeper issue is causing the no-op behavior? But from [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role) the current no-op behavior is expected for a `div` with `role="button"`:

> The button role is for clickable elements that trigger a response when activated by the user. Adding role="button" tells the screen reader the element is a button, but provides no button functionality.

And further down in [Required event handlers](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role#required_javascript_features):

> Buttons can be operated by mouse, touch, and keyboard users. For native HTML <button> elements, the button's onclick event fires for mouse clicks and when the user presses Space or Enter while the button has focus. But if another tag is used to create a button, the onclick event only fires when clicked by the mouse cursor, even if role="button" is used. Because of this, separate key event handlers must be added to the element so that the button is be triggered when the Space or Enter key is pressed.

Finally, outside the scope of this PR, we might consider making `Card` a `<button>`, or if `Card` is used in non-button contexts, make a `CardButton` wrapper. It seems like bad practice to have a button nested under a button like we do with the "Change" `<Button>` nested under the `<Card role="button">`. In practice, a touchscreen user pressing anywhere on the `Card` will navigate to the contest, so the smaller "Change" `<Button>` doesn't seem like it's adding value.

## Demo Video or Screenshot

https://github.com/votingworks/vxsuite/assets/1060688/5d01c9f1-a0b4-453e-b4d2-6c6cb90ba18e



## Testing Plan
- added tests

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
