### PR TITLE
Send Shift keypress event when sending alphabet key codes

### DIFF
--- a/apps/mark-scan/accessible-controller/src/controllerd.rs
+++ b/apps/mark-scan/accessible-controller/src/controllerd.rs
@@ -18,7 +18,7 @@ use std::{
     time::{Duration, Instant},
 };
 use uinput::{
-    event::{keyboard, Keyboard, Kind},
+    event::{keyboard, Keyboard},
     Device,
 };
 use vx_logging::{log, set_app_name, Disposition, EventId, EventType};

--- a/apps/mark-scan/accessible-controller/src/controllerd.rs
+++ b/apps/mark-scan/accessible-controller/src/controllerd.rs
@@ -501,8 +501,8 @@ mod tests {
             0x02,
             Button::Left as u8,
             Action::Pressed as u8,
-            0xc8,
-            0x37,
+            0xd8,
+            0x09,
         ];
         assert_eq!(
             handle_command(&data).unwrap().unwrap(),


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/4618

Sends a `Shift` key event along with `r` and `p` keypresses to correctly trigger keypress handlers in the apps. These keypress events map to `Pause` and `Replay` functionality.

## Demo Video or Screenshot


https://github.com/votingworks/vxsuite/assets/1060688/e7a3bffd-343f-4d60-8bb4-adf653c96b05



## Testing Plan
- updated test for `handle_command` in controller daemon

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
