### PR TITLE
fix nesting warning

### DIFF
--- a/apps/central-scan/backend/src/app.diagnostics.test.ts
+++ b/apps/central-scan/backend/src/app.diagnostics.test.ts
@@ -9,6 +9,8 @@ import { LogEventId } from '@votingworks/logging';
 import { withApp } from '../test/helpers/setup_app';
 import { mockSystemAdministratorAuth } from '../test/helpers/auth';
 
+jest.setTimeout(20_000);
+
 jest.mock(
   '@votingworks/backend',
   (): typeof import('@votingworks/backend') => ({

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
@@ -280,7 +280,7 @@ export function PollWorkerScreen({
                 {`Voting Session Active: ${ballotStyleId} at ${precinct.name}`}
               </H2>
               <p>Paper has been loaded.</p>
-              <ol>
+              <ol style={{ marginBottom: '0' }}>
                 <li>
                   <P>
                     Instruct the voter to press the{' '}
@@ -294,9 +294,7 @@ export function PollWorkerScreen({
                   <P>Remove the poll worker card to continue.</P>
                 </li>
               </ol>
-              <P>
-                <HorizontalRule>or</HorizontalRule>
-              </P>
+              <HorizontalRule>or</HorizontalRule>
               <P align="center">Deactivate this voter session to start over.</P>
               <P align="center">
                 <Button onPress={resetCardlessVoterSession}>

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -240,7 +240,7 @@ export function PollWorkerScreen({
             <H2 as="h1" align="center">
               {`Voting Session Active: ${ballotStyleId} at ${precinct.name}`}
             </H2>
-            <ol>
+            <ol style={{ marginBottom: '0' }}>
               <li>
                 <P>
                   Instruct the voter to press the{' '}
@@ -254,9 +254,7 @@ export function PollWorkerScreen({
                 <P>Remove the poll worker card to continue.</P>
               </li>
             </ol>
-            <P>
-              <HorizontalRule>or</HorizontalRule>
-            </P>
+            <HorizontalRule>or</HorizontalRule>
             <P align="center">Deactivate this voter session to start over.</P>
             <P align="center">
               <Button onPress={resetCardlessVoterSession}>

--- a/libs/ui/src/__snapshots__/horizontal_rule.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/horizontal_rule.test.tsx.snap
@@ -1,53 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Renders HorizontalRule with custom green color 1`] = `
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin: -0.5rem 0;
-}
-
-.c0::after,
-.c0::before {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  border-top: 1px solid rgb(194,200,203);
-  content: '';
-}
-
-.c0::before {
-  margin-right: 0.5rem;
-}
-
-.c0::after {
-  margin-left: 0.5rem;
-}
-
-@media print {
-
-}
-
-@media print {
-
-}
-
-<p
-  class="c0"
-  color="#00FF00"
->
-  or
-</p>
-`;
-
 exports[`Renders HorizontalRule with defaults 1`] = `
 .c0 {
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0;
+  font-size: 1rem;
+  margin-bottom: 0.5em;
+}
+
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -56,11 +18,10 @@ exports[`Renders HorizontalRule with defaults 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin: -0.5rem 0;
 }
 
-.c0::after,
-.c0::before {
+.c1::after,
+.c1::before {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -68,11 +29,11 @@ exports[`Renders HorizontalRule with defaults 1`] = `
   content: '';
 }
 
-.c0::before {
+.c1::before {
   margin-right: 0.5rem;
 }
 
-.c0::after {
+.c1::after {
   margin-left: 0.5rem;
 }
 
@@ -85,7 +46,7 @@ exports[`Renders HorizontalRule with defaults 1`] = `
 }
 
 <p
-  class="c0"
+  class="c0 c1"
 >
   or
 </p>
@@ -93,6 +54,14 @@ exports[`Renders HorizontalRule with defaults 1`] = `
 
 exports[`Renders HorizontalRule without children 1`] = `
 .c0 {
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0;
+  font-size: 1rem;
+  margin-bottom: 0.5em;
+}
+
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -101,11 +70,10 @@ exports[`Renders HorizontalRule without children 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin: -0.5rem 0;
 }
 
-.c0::after,
-.c0::before {
+.c1::after,
+.c1::before {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -122,6 +90,6 @@ exports[`Renders HorizontalRule without children 1`] = `
 }
 
 <p
-  class="c0"
+  class="c0 c1"
 />
 `;

--- a/libs/ui/src/horizontal_rule.test.tsx
+++ b/libs/ui/src/horizontal_rule.test.tsx
@@ -8,13 +8,6 @@ describe('Renders HorizontalRule', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('with custom green color', () => {
-    const { container } = render(
-      <HorizontalRule color="#00FF00">or</HorizontalRule>
-    );
-    expect(container.firstChild).toMatchSnapshot();
-  });
-
   test('without children', () => {
     const { container } = render(<HorizontalRule />);
     expect(container.firstChild).toMatchSnapshot();

--- a/libs/ui/src/horizontal_rule.tsx
+++ b/libs/ui/src/horizontal_rule.tsx
@@ -1,20 +1,14 @@
 import styled from 'styled-components';
+import { P } from './typography';
 
-interface Props {
-  children?: string;
-  color?: string;
-}
-
-export const HorizontalRule = styled.p<Props>`
+export const HorizontalRule = styled(P)`
   display: flex;
   align-items: center;
-  margin: -0.5rem 0;
 
   &::after,
   &::before {
     flex: 1;
-    border-top: 1px solid
-      ${({ color }) => (color ? 'rgb(194, 200, 203)' : undefined)};
+    border-top: 1px solid;
     content: '';
   }
 


### PR DESCRIPTION
a lot of the test output for VxMark and VxMarkScan was made harder to read because of `<p>` within `<p>` warning. was also throwing console warnings. I fix that here, and give one of the elements a little more breathing room. I wasn't able to see this screen in dev on VxMarkScan (and didn't go through the code-editing effort to do so) because the screens are almost identical on both machines so the change should look good there too.

## Demo Video or Screenshot

VxMark Before:

<img width="1151" alt="Screen Shot 2024-03-07 at 10 29 39 AM" src="https://github.com/votingworks/vxsuite/assets/37960853/a18aa771-57ad-439d-b9db-07a922c9d6f6">


VxMark After: 

<img width="1155" alt="Screen Shot 2024-03-07 at 10 29 19 AM" src="https://github.com/votingworks/vxsuite/assets/37960853/4037323e-b66d-4712-810c-e47ffd9586c3">

