### PR TITLE
VxAdmin Printer Status Alerts

### DIFF
--- a/apps/admin/frontend/src/app.test.tsx
+++ b/apps/admin/frontend/src/app.test.tsx
@@ -49,6 +49,7 @@ beforeEach(() => {
     status: 'logged_out',
     reason: 'machine_locked',
   });
+  apiMock.setPrinterStatus();
   apiMock.expectGetUsbDriveStatus('no_drive');
   apiMock.expectGetMachineConfig();
   apiMock.expectGetSystemSettings();

--- a/apps/admin/frontend/src/app.tsx
+++ b/apps/admin/frontend/src/app.tsx
@@ -3,6 +3,7 @@ import './App.css';
 import { BatteryLowAlert } from '@votingworks/ui';
 import { AppRoot } from './app_root';
 import { SessionTimeLimitTracker } from './components/session_time_limit_tracker';
+import { PrinterAlert } from './components/printer_alert';
 
 export function App(): JSX.Element {
   return (
@@ -10,6 +11,7 @@ export function App(): JSX.Element {
       <AppRoot />
       <SessionTimeLimitTracker />
       <BatteryLowAlert />
+      <PrinterAlert />
     </BrowserRouter>
   );
 }

--- a/apps/admin/frontend/src/components/printer_alert.test.tsx
+++ b/apps/admin/frontend/src/components/printer_alert.test.tsx
@@ -1,0 +1,138 @@
+import { PrinterRichStatus, PrinterStatus } from '@votingworks/types';
+import {
+  fakeElectionManagerUser,
+  fakeSessionExpiresAt,
+  fakeSystemAdministratorUser,
+} from '@votingworks/test-utils';
+import userEvent from '@testing-library/user-event';
+import {
+  ApiMock,
+  MOCK_PRINTER_CONFIG,
+  createApiMock,
+} from '../../test/helpers/mock_api_client';
+import { renderInAppContext } from '../../test/render_in_app_context';
+import { PrinterAlert } from './printer_alert';
+import {
+  screen,
+  waitForElementToBeRemoved,
+} from '../../test/react_testing_library';
+
+jest.useFakeTimers();
+
+let apiMock: ApiMock;
+
+beforeEach(() => {
+  apiMock = createApiMock();
+});
+
+afterEach(() => {
+  apiMock.assertComplete();
+});
+
+const ALERT_RICH_STATUS: PrinterRichStatus = {
+  state: 'stopped',
+  stateReasons: ['door-open-error'],
+  markerInfos: [],
+};
+
+const ALERT_STATUS: PrinterStatus = {
+  connected: true,
+  config: MOCK_PRINTER_CONFIG,
+  richStatus: ALERT_RICH_STATUS,
+};
+
+function setElectionManagerAuth() {
+  apiMock.setAuthStatus({
+    status: 'logged_in',
+    user: fakeElectionManagerUser(),
+    sessionExpiresAt: fakeSessionExpiresAt(),
+  });
+}
+
+function setSystemAdministratorAuth() {
+  apiMock.setAuthStatus({
+    status: 'logged_in',
+    user: fakeSystemAdministratorUser(),
+    sessionExpiresAt: fakeSessionExpiresAt(),
+    programmableCard: { status: 'no_card' },
+  });
+}
+
+test('shows alert with message which can be dismissed', async () => {
+  setElectionManagerAuth();
+  apiMock.setPrinterStatus(ALERT_STATUS);
+  renderInAppContext(<PrinterAlert />, { apiMock });
+  await screen.findByText('Printer Alert');
+  await screen.findByText(
+    "The printer's door is open. Close the printer's door."
+  );
+  userEvent.click(screen.getButton('Dismiss'));
+  expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+});
+
+test('shows alert only when printer is stopped', async () => {
+  setElectionManagerAuth();
+  apiMock.setPrinterStatus(ALERT_STATUS);
+  renderInAppContext(<PrinterAlert />, { apiMock });
+  await screen.findByText('Printer Alert');
+
+  // doesn't show when disconnected
+  apiMock.setPrinterStatus({ connected: false });
+  await waitForElementToBeRemoved(screen.getByText('Printer Alert'));
+
+  apiMock.setPrinterStatus(ALERT_STATUS);
+  await screen.findByText('Printer Alert');
+
+  // doesn't show when rich status is unavailable
+  apiMock.setPrinterStatus({ connected: true, config: MOCK_PRINTER_CONFIG });
+  await waitForElementToBeRemoved(screen.getByText('Printer Alert'));
+
+  apiMock.setPrinterStatus(ALERT_STATUS);
+  await screen.findByText('Printer Alert');
+
+  // doesn't show when printer not stopped
+  apiMock.setPrinterStatus({
+    connected: true,
+    config: MOCK_PRINTER_CONFIG,
+    richStatus: {
+      state: 'idle',
+      stateReasons: ['none'],
+      markerInfos: [],
+    },
+  });
+  await waitForElementToBeRemoved(screen.getByText('Printer Alert'));
+
+  apiMock.setPrinterStatus(ALERT_STATUS);
+  await screen.findByText('Printer Alert');
+
+  // doesn't show when printer when state reason is "other"
+  apiMock.setPrinterStatus({
+    connected: true,
+    config: MOCK_PRINTER_CONFIG,
+    richStatus: {
+      state: 'stopped',
+      stateReasons: ['other-error'],
+      markerInfos: [],
+    },
+  });
+  await waitForElementToBeRemoved(screen.getByText('Printer Alert'));
+});
+
+test('alert does not show for system administrators or when logged out', async () => {
+  setElectionManagerAuth();
+  apiMock.setPrinterStatus(ALERT_STATUS);
+  renderInAppContext(<PrinterAlert />, { apiMock });
+  await screen.findByText('Printer Alert');
+
+  // doesn't show for system administrators
+  setSystemAdministratorAuth();
+  await waitForElementToBeRemoved(screen.getByText('Printer Alert'));
+
+  setElectionManagerAuth();
+  apiMock.setPrinterStatus(ALERT_STATUS);
+  await screen.findByText('Printer Alert');
+
+  // doesn't show when logged out
+  apiMock.setAuthStatus({ status: 'logged_out', reason: 'machine_locked' });
+  await waitForElementToBeRemoved(screen.getByText('Printer Alert'));
+});

--- a/apps/admin/frontend/src/components/printer_alert.tsx
+++ b/apps/admin/frontend/src/components/printer_alert.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from 'react';
+import { PrinterRichStatus } from '@votingworks/types';
+import {
+  Button,
+  IPP_PRINTER_STATE_REASON_MESSAGES,
+  Icons,
+  Modal,
+  P,
+  parseHighestPriorityIppPrinterStateReason,
+} from '@votingworks/ui';
+import { isElectionManagerAuth } from '@votingworks/utils';
+import { getAuthStatus, getPrinterStatus } from '../api';
+
+export function PrinterAlert(): JSX.Element | null {
+  const printerStatusQuery = getPrinterStatus.useQuery();
+  const authStatusQuery = getAuthStatus.useQuery();
+  const [alertStatus, setAlertStatus] = useState<PrinterRichStatus>();
+
+  const printerStatus = printerStatusQuery.data;
+  useEffect(() => {
+    if (
+      printerStatus &&
+      printerStatus.connected === true &&
+      printerStatus.richStatus &&
+      printerStatus.richStatus.state === 'stopped'
+    ) {
+      setAlertStatus(printerStatus.richStatus);
+    } else {
+      setAlertStatus(undefined);
+    }
+  }, [printerStatus]);
+
+  // We only show alerts to election managers. We don't need to show alerts
+  // when not logged in and we don't want to show alerts to system
+  // administrators because they already see the same information on the
+  // diagnostics page.
+  if (
+    !authStatusQuery.isSuccess ||
+    !isElectionManagerAuth(authStatusQuery.data)
+  ) {
+    return null;
+  }
+
+  if (!alertStatus) {
+    return null;
+  }
+
+  const stoppedReason = parseHighestPriorityIppPrinterStateReason(
+    alertStatus.stateReasons
+  );
+
+  // There can be 'other-error' blips without a specific message, so it's not
+  // worth showing.
+  if (!stoppedReason || stoppedReason === 'other') {
+    return null;
+  }
+
+  return (
+    <Modal
+      title={
+        <React.Fragment>
+          <Icons.Warning color="warning" /> Printer Alert
+        </React.Fragment>
+      }
+      content={<P>{IPP_PRINTER_STATE_REASON_MESSAGES[stoppedReason]}</P>}
+      actions={
+        <Button onPress={() => setAlertStatus(undefined)}>Dismiss</Button>
+      }
+    />
+  );
+}

--- a/apps/admin/frontend/src/components/smartcard_modal/smartcard_modal.test.tsx
+++ b/apps/admin/frontend/src/components/smartcard_modal/smartcard_modal.test.tsx
@@ -34,6 +34,7 @@ beforeEach(() => {
     status: 'logged_out',
     reason: 'machine_locked',
   });
+  apiMock.setPrinterStatus();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetSystemSettings();
   apiMock.expectGetUsbDriveStatus('no_drive');

--- a/apps/admin/frontend/test/helpers/mock_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_api_client.ts
@@ -37,6 +37,7 @@ import {
   DippedSmartCardAuth,
   ElectionDefinition,
   Id,
+  PrinterConfig,
   PrinterStatus,
   Rect,
   SystemSettings,
@@ -50,6 +51,16 @@ const mockRect: Rect = {
   height: 1000,
   x: 0,
   y: 0,
+};
+
+// the below is copied from libs/printing to avoid importing a backend package
+export const MOCK_PRINTER_CONFIG: PrinterConfig = {
+  label: 'HP LaserJet Pro M404n',
+  vendorId: 1008,
+  productId: 49450,
+  baseDeviceUri: 'usb://HP/LaserJet%20Pro%20M404-M405',
+  ppd: 'generic-postscript-driver.ppd',
+  supportsIpp: true,
 };
 
 type MockApiClient = Omit<MockClient<Api>, 'getBatteryInfo'> & {
@@ -119,18 +130,10 @@ function createDeferredMock<T, U>(
 export function createApiMock(
   apiClient: MockApiClient = createMockApiClient()
 ) {
-  function setPrinterStatus(printerStatus: Partial<PrinterStatus>): void {
+  function setPrinterStatus(printerStatus: Partial<PrinterStatus> = {}): void {
     apiClient.getPrinterStatus.expectRepeatedCallsWith().resolves({
       connected: true,
-      // the below is copied from libs/printing to avoid importing a backend package
-      config: {
-        label: 'HP LaserJet Pro M404n',
-        vendorId: 1008,
-        productId: 49450,
-        baseDeviceUri: 'usb://HP/LaserJet%20Pro%20M404-M405',
-        ppd: 'generic-postscript-driver.ppd',
-        supportsIpp: true,
-      },
+      config: MOCK_PRINTER_CONFIG,
       ...printerStatus,
     });
   }

--- a/libs/ui/src/diagnostics/index.ts
+++ b/libs/ui/src/diagnostics/index.ts
@@ -1,2 +1,6 @@
+export {
+  parseHighestPriorityIppPrinterStateReason,
+  IPP_PRINTER_STATE_REASON_MESSAGES,
+} from './printer_section';
 export * from './admin_readiness_report';
 export * from './central_scan_readiness_report';

--- a/libs/ui/src/diagnostics/printer_section.tsx
+++ b/libs/ui/src/diagnostics/printer_section.tsx
@@ -39,7 +39,10 @@ export const IPP_PRINTER_STATE_REASON_MESSAGES: {
   'input-tray-missing':
     "The printer's input tray is missing. Connect the input tray.",
   'media-low': 'The printer is low on paper. Add paper to the printer.',
-  'media-empty': 'The printer is out of paper. Add paper to the printer.',
+  // HP printers use "media-empty" when the tray is simply open, so this message
+  // was changed to mention that possibility.
+  'media-empty':
+    'The printer does not detect any paper. Either the paper tray is open or the printer is out of paper.',
   'output-tray-missing':
     "The printer's output tray is missing. Connect the output tray.",
   'output-area-almost-full':


### PR DESCRIPTION
## Overview

Alert the user when something happens with the printer.

Because we can't distinguish between paper empty and tray open, it will alert anytime the tray is open. But will automatically close whenever the tray is closed (with paper).

https://github.com/votingworks/vxsuite/assets/37960853/9fa4de9f-a1b5-403d-8dbe-710a7d322a38

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
