### PR TITLE
[i18n/audio] Generate a unique ballot style definitions/IDs for each language

### DIFF
--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -27,7 +27,8 @@ import {
 } from '@votingworks/hmpb-layout';
 import JsZip from 'jszip';
 import { renderDocumentToPdf } from '@votingworks/hmpb-render-backend';
-import { ElectionPackage, ElectionRecord, Precinct } from './store';
+import { ElectionPackage, ElectionRecord } from './store';
+import { Precinct } from './types';
 import {
   createPrecinctTestDeck,
   FULL_TEST_DECK_TALLY_REPORT_FILE_NAME,
@@ -174,9 +175,12 @@ function buildApi({ translator, workspace }: AppContext) {
     async exportAllBallots(input: {
       electionId: Id;
     }): Promise<{ zipContents: Buffer; electionHash: string }> {
-      const { election, layoutOptions, nhCustomContent } = store.getElection(
-        input.electionId
-      );
+      const {
+        ballotLanguageConfigs,
+        election,
+        layoutOptions,
+        nhCustomContent,
+      } = store.getElection(input.electionId);
 
       const zip = new JsZip();
 
@@ -192,7 +196,11 @@ function buildApi({ translator, workspace }: AppContext) {
             layoutOptions,
             nhCustomContent,
             translatedElectionStrings: (
-              await extractAndTranslateElectionStrings(translator, election)
+              await extractAndTranslateElectionStrings(
+                translator,
+                election,
+                ballotLanguageConfigs
+              )
             ).electionStrings,
           }).unsafeUnwrap();
 
@@ -266,9 +274,12 @@ function buildApi({ translator, workspace }: AppContext) {
     async exportTestDecks(input: {
       electionId: Id;
     }): Promise<{ zipContents: Buffer; electionHash: string }> {
-      const { election, layoutOptions, nhCustomContent } = store.getElection(
-        input.electionId
-      );
+      const {
+        ballotLanguageConfigs,
+        election,
+        layoutOptions,
+        nhCustomContent,
+      } = store.getElection(input.electionId);
       const { electionDefinition, ballots } = layOutAllBallotStyles({
         election,
         ballotType: BallotType.Precinct,
@@ -276,7 +287,11 @@ function buildApi({ translator, workspace }: AppContext) {
         layoutOptions,
         nhCustomContent,
         translatedElectionStrings: (
-          await extractAndTranslateElectionStrings(translator, election)
+          await extractAndTranslateElectionStrings(
+            translator,
+            election,
+            ballotLanguageConfigs
+          )
         ).electionStrings,
       }).unsafeUnwrap();
 

--- a/apps/design/backend/src/ballot_styles.test.ts
+++ b/apps/design/backend/src/ballot_styles.test.ts
@@ -1,0 +1,349 @@
+import { typedAs } from '@votingworks/basics';
+import {
+  AnyContest,
+  District,
+  DistrictId,
+  LanguageCode,
+  Party,
+  PartyId,
+} from '@votingworks/types';
+import { generateBallotStyleId } from '@votingworks/utils';
+
+import { generateBallotStyles } from './ballot_styles';
+import { BallotStyle, Precinct, PrecinctSplit } from './types';
+
+function makeContest(
+  id: string,
+  districtId: DistrictId,
+  partyId?: PartyId
+): AnyContest {
+  return {
+    id,
+    districtId,
+    type: 'candidate',
+    title: id,
+    candidates: [],
+    allowWriteIns: true,
+    seats: 1,
+    partyId,
+  };
+}
+
+describe('generateBallotStyles()', () => {
+  const { ENGLISH, SPANISH } = LanguageCode;
+
+  const district1: District = {
+    id: 'district-1' as DistrictId,
+    name: 'District 1',
+  };
+  const district2: District = {
+    id: 'district-2' as DistrictId,
+    name: 'District 2',
+  };
+
+  const partyA: Party = {
+    id: 'party-A' as PartyId,
+    name: 'Party A',
+    fullName: 'Party A',
+    abbrev: 'A',
+  };
+  const partyB: Party = {
+    id: 'party-B' as PartyId,
+    name: 'Party B',
+    fullName: 'Party B',
+    abbrev: 'B',
+  };
+  const partyC: Party = {
+    id: 'party-C' as PartyId,
+    name: 'Party C',
+    fullName: 'Party C',
+    abbrev: 'C',
+  };
+
+  const precinct1District1: Precinct = {
+    id: 'precinct-1',
+    name: 'Precinct 1',
+    districtIds: [district1.id],
+  };
+  const precinct2District2: Precinct = {
+    id: 'precinct-2',
+    name: 'Precinct 2',
+    districtIds: [district2.id],
+  };
+
+  const precinct3Splits = {
+    district1And2: typedAs<PrecinctSplit>({
+      id: 'precinct-3-split-1',
+      name: 'Precinct 2 - Split 1',
+      districtIds: [district1.id, district2.id],
+      nhCustomContent: {},
+    }),
+    district1Only: typedAs<PrecinctSplit>({
+      id: 'precinct-2-split-2',
+      name: 'Precinct 2 - Split 2',
+      // Should share a ballot style with precinct-1, since same districts assigned
+      districtIds: [district1.id],
+      nhCustomContent: {},
+    }),
+    noDistricts: typedAs<PrecinctSplit>({
+      id: 'precinct-2-split-4',
+      name: 'Precinct 2 - Split 3',
+      // Shouldn't get a ballot style, since no districts assigned
+      districtIds: [],
+      nhCustomContent: {},
+    }),
+  } as const;
+  const precinct3District1And2: Precinct = {
+    id: 'precinct-3-with-splits',
+    name: 'Precinct 3 - With Splits',
+    splits: Object.values(precinct3Splits),
+  };
+
+  const precinct4NoDistricts: Precinct = {
+    id: 'precinct-4',
+    name: 'Precinct 4',
+    // Shouldn't get a ballot style, since no districts assigned
+    districtIds: [],
+  };
+
+  const generalContest1 = makeContest('contest-1', district1.id);
+  const generalContest2 = makeContest('contest-2', district2.id);
+
+  /* eslint-disable vx/gts-identifiers */
+  const partyAContest1 = makeContest('contest-1A', district1.id, partyA.id);
+  const partyAContest2 = makeContest('contest-2A', district2.id, partyA.id);
+  const partyBContest1 = makeContest('contest-1B', district1.id, partyB.id);
+  const partyBContest2 = makeContest('contest-2B', district2.id, partyB.id);
+  /* eslint-enable vx/gts-identifiers */
+
+  test('general election, no splits', () => {
+    const ballotLanguageConfigs = [
+      { languages: [ENGLISH] },
+      { languages: [ENGLISH, SPANISH] },
+    ];
+    const ballotStyles = generateBallotStyles({
+      ballotLanguageConfigs,
+      contests: [generalContest1, generalContest2],
+      electionType: 'general',
+      parties: [],
+      precincts: [precinct1District1, precinct2District2, precinct4NoDistricts],
+    });
+
+    expect(ballotStyles).toEqual<BallotStyle[]>([
+      ...ballotLanguageConfigs.map<BallotStyle>(({ languages }) => ({
+        id: generateBallotStyleId({ ballotStyleIndex: 1, languages }),
+        districtIds: [district1.id],
+        languages,
+        precinctsOrSplits: [{ precinctId: precinct1District1.id }],
+      })),
+      ...ballotLanguageConfigs.map<BallotStyle>(({ languages }) => ({
+        id: generateBallotStyleId({ ballotStyleIndex: 2, languages }),
+        districtIds: [district2.id],
+        languages,
+        precinctsOrSplits: [{ precinctId: precinct2District2.id }],
+      })),
+    ]);
+  });
+
+  test('general election, split precincts', () => {
+    const ballotLanguageConfigs = [
+      { languages: [ENGLISH] },
+      { languages: [ENGLISH, SPANISH] },
+    ];
+    const ballotStyles = generateBallotStyles({
+      ballotLanguageConfigs,
+      contests: [generalContest1, generalContest2],
+      electionType: 'general',
+      parties: [],
+      precincts: [
+        precinct1District1,
+        precinct3District1And2,
+        precinct4NoDistricts,
+      ],
+    });
+
+    expect(ballotStyles).toEqual<BallotStyle[]>([
+      ...ballotLanguageConfigs.map<BallotStyle>(({ languages }) => ({
+        id: generateBallotStyleId({ ballotStyleIndex: 1, languages }),
+        districtIds: [district1.id],
+        languages,
+        precinctsOrSplits: [
+          { precinctId: precinct1District1.id },
+          {
+            precinctId: precinct3District1And2.id,
+            splitId: precinct3Splits.district1Only.id,
+          },
+        ],
+      })),
+      ...ballotLanguageConfigs.map<BallotStyle>(({ languages }) => ({
+        id: generateBallotStyleId({ ballotStyleIndex: 2, languages }),
+        districtIds: [district1.id, district2.id],
+        languages,
+        precinctsOrSplits: [
+          {
+            precinctId: precinct3District1And2.id,
+            splitId: precinct3Splits.district1And2.id,
+          },
+        ],
+      })),
+    ]);
+  });
+
+  test('primary election, no splits', () => {
+    const ballotLanguageConfigs = [
+      { languages: [ENGLISH] },
+      { languages: [ENGLISH, SPANISH] },
+    ];
+    const ballotStyles = generateBallotStyles({
+      ballotLanguageConfigs,
+      contests: [
+        partyAContest1,
+        partyAContest2,
+        partyBContest1,
+        partyBContest2,
+      ],
+      electionType: 'primary',
+      parties: [partyA, partyB, partyC],
+      precincts: [precinct1District1, precinct2District2, precinct4NoDistricts],
+    });
+
+    expect(ballotStyles).toEqual<BallotStyle[]>([
+      ...ballotLanguageConfigs.map<BallotStyle>(({ languages }) => ({
+        id: generateBallotStyleId({
+          ballotStyleIndex: 1,
+          languages,
+          party: partyA,
+        }),
+        districtIds: [district1.id],
+        languages,
+        partyId: partyA.id,
+        precinctsOrSplits: [{ precinctId: precinct1District1.id }],
+      })),
+      ...ballotLanguageConfigs.map<BallotStyle>(({ languages }) => ({
+        id: generateBallotStyleId({
+          ballotStyleIndex: 1,
+          languages,
+          party: partyB,
+        }),
+        districtIds: [district1.id],
+        languages,
+        partyId: partyB.id,
+        precinctsOrSplits: [{ precinctId: precinct1District1.id }],
+      })),
+      ...ballotLanguageConfigs.map<BallotStyle>(({ languages }) => ({
+        id: generateBallotStyleId({
+          ballotStyleIndex: 2,
+          languages,
+          party: partyA,
+        }),
+        districtIds: [district2.id],
+        languages,
+        partyId: partyA.id,
+        precinctsOrSplits: [{ precinctId: precinct2District2.id }],
+      })),
+      ...ballotLanguageConfigs.map<BallotStyle>(({ languages }) => ({
+        id: generateBallotStyleId({
+          ballotStyleIndex: 2,
+          languages,
+          party: partyB,
+        }),
+        districtIds: [district2.id],
+        languages,
+        partyId: partyB.id,
+        precinctsOrSplits: [{ precinctId: precinct2District2.id }],
+      })),
+    ]);
+  });
+
+  test('primary election, split precincts', () => {
+    const ballotLanguageConfigs = [
+      { languages: [ENGLISH] },
+      { languages: [ENGLISH, SPANISH] },
+    ];
+    const ballotStyles = generateBallotStyles({
+      ballotLanguageConfigs,
+      contests: [
+        partyAContest1,
+        partyAContest2,
+        partyBContest1,
+        partyBContest2,
+      ],
+      electionType: 'primary',
+      parties: [partyA, partyB, partyC],
+      precincts: [
+        precinct1District1,
+        precinct3District1And2,
+        precinct4NoDistricts,
+      ],
+    });
+
+    expect(ballotStyles).toEqual<BallotStyle[]>([
+      ...ballotLanguageConfigs.map<BallotStyle>(({ languages }) => ({
+        id: generateBallotStyleId({
+          ballotStyleIndex: 1,
+          languages,
+          party: partyA,
+        }),
+        districtIds: [district1.id],
+        languages,
+        partyId: partyA.id,
+        precinctsOrSplits: [
+          { precinctId: precinct1District1.id },
+          {
+            precinctId: precinct3District1And2.id,
+            splitId: precinct3Splits.district1Only.id,
+          },
+        ],
+      })),
+      ...ballotLanguageConfigs.map<BallotStyle>(({ languages }) => ({
+        id: generateBallotStyleId({
+          ballotStyleIndex: 1,
+          languages,
+          party: partyB,
+        }),
+        districtIds: [district1.id],
+        languages,
+        partyId: partyB.id,
+        precinctsOrSplits: [
+          { precinctId: precinct1District1.id },
+          {
+            precinctId: precinct3District1And2.id,
+            splitId: precinct3Splits.district1Only.id,
+          },
+        ],
+      })),
+      ...ballotLanguageConfigs.map<BallotStyle>(({ languages }) => ({
+        id: generateBallotStyleId({
+          ballotStyleIndex: 2,
+          languages,
+          party: partyA,
+        }),
+        districtIds: [district1.id, district2.id],
+        languages,
+        partyId: partyA.id,
+        precinctsOrSplits: [
+          {
+            precinctId: precinct3District1And2.id,
+            splitId: precinct3Splits.district1And2.id,
+          },
+        ],
+      })),
+      ...ballotLanguageConfigs.map<BallotStyle>(({ languages }) => ({
+        id: generateBallotStyleId({
+          ballotStyleIndex: 2,
+          languages,
+          party: partyB,
+        }),
+        districtIds: [district1.id, district2.id],
+        languages,
+        partyId: partyB.id,
+        precinctsOrSplits: [
+          {
+            precinctId: precinct3District1And2.id,
+            splitId: precinct3Splits.district1And2.id,
+          },
+        ],
+      })),
+    ]);
+  });
+});

--- a/apps/design/backend/src/ballot_styles.ts
+++ b/apps/design/backend/src/ballot_styles.ts
@@ -1,0 +1,118 @@
+import { groupBy, throwIllegalValue, unique } from '@votingworks/basics';
+import {
+  CandidateContest,
+  Contests,
+  DistrictId,
+  ElectionType,
+  Parties,
+} from '@votingworks/types';
+import { generateBallotStyleId } from '@votingworks/utils';
+
+import {
+  BallotLanguageConfigs,
+  BallotStyle,
+  Precinct,
+  PrecinctOrSplitId,
+  hasSplits,
+} from './types';
+
+/**
+ * Generates ballot styles for the election based on geography data (districts,
+ * precincts, and precinct splits) and ballot languages. For primary elections,
+ * generates distinct ballot styles for each party.
+ *
+ * Each ballot styles should have a unique set of contests. Contests are
+ * specified per district. We generate ballot styles by looking at the
+ * district list for each precinct/precinct split. If the district list is
+ * unique, it gets its own ballot style. Otherwise, we reuse another ballot
+ * style with the same district list.
+ */
+export function generateBallotStyles(params: {
+  contests: Contests;
+  ballotLanguageConfigs: BallotLanguageConfigs;
+  electionType: ElectionType;
+  parties: Parties;
+  precincts: Precinct[];
+}): BallotStyle[] {
+  const { ballotLanguageConfigs, contests, electionType, parties, precincts } =
+    params;
+
+  const allPrecinctsOrSplitsWithDistricts: Array<
+    PrecinctOrSplitId & { districtIds: readonly DistrictId[] }
+  > = precincts
+    .flatMap((precinct) => {
+      if (hasSplits(precinct)) {
+        return precinct.splits.map((split) => {
+          return {
+            precinctId: precinct.id,
+            splitId: split.id,
+            districtIds: split.districtIds,
+          };
+        });
+      }
+      return { precinctId: precinct.id, districtIds: precinct.districtIds };
+    })
+    .filter(({ districtIds }) => districtIds.length > 0);
+
+  const precinctsOrSplitsByDistricts: Array<
+    [readonly DistrictId[], PrecinctOrSplitId[]]
+  > = groupBy(
+    allPrecinctsOrSplitsWithDistricts,
+    ({ districtIds }) => districtIds
+  ).map(([districtIds, group]) => [
+    districtIds,
+    // Remove districtIds after grouping, we don't need them anymore
+    group.map(({ precinctId, splitId }) => ({ precinctId, splitId })),
+  ]);
+
+  switch (electionType) {
+    case 'general':
+      return precinctsOrSplitsByDistricts.flatMap(
+        ([districtIds, precinctsOrSplits], index) =>
+          ballotLanguageConfigs.map(({ languages }) => ({
+            id: generateBallotStyleId({
+              ballotStyleIndex: index + 1,
+              languages,
+            }),
+            precinctsOrSplits,
+            districtIds,
+            languages,
+          }))
+      );
+
+    case 'primary':
+      return precinctsOrSplitsByDistricts.flatMap(
+        ([districtIds, precinctsOrSplits], index) => {
+          const partyIds = unique(
+            contests
+              .filter(
+                (contest): contest is CandidateContest =>
+                  contest.type === 'candidate' &&
+                  contest.partyId !== undefined &&
+                  districtIds.includes(contest.districtId)
+              )
+              .map((contest) => contest.partyId)
+          );
+          const partiesWithContests = parties.filter((party) =>
+            partyIds.includes(party.id)
+          );
+          return partiesWithContests.flatMap((party) =>
+            ballotLanguageConfigs.map(({ languages }) => ({
+              id: generateBallotStyleId({
+                ballotStyleIndex: index + 1,
+                languages,
+                party,
+              }),
+              precinctsOrSplits,
+              districtIds,
+              partyId: party.id,
+              languages,
+            }))
+          );
+        }
+      );
+
+    default:
+      return throwIllegalValue(electionType);
+  }
+}

--- a/apps/design/backend/src/index.ts
+++ b/apps/design/backend/src/index.ts
@@ -8,18 +8,20 @@ import {
   GoogleCloudTranslator,
 } from './language_and_audio';
 
+export type { ElectionRecord } from './store';
 export type {
+  BallotLanguageConfig,
+  BallotLanguageConfigs,
   BallotStyle,
-  ElectionRecord,
   Precinct,
   PrecinctSplit,
   PrecinctWithSplits,
   PrecinctWithoutSplits,
-} from './store';
+} from './types';
 export type { Api } from './app';
 
 // Frontend tests import these for generating test data
-export { generateBallotStyles } from './store';
+export { generateBallotStyles } from './ballot_styles';
 export { createBlankElection, convertVxfPrecincts } from './app';
 
 loadEnvVarsFromDotenvFiles();

--- a/apps/design/backend/src/language_and_audio/app_strings.ts
+++ b/apps/design/backend/src/language_and_audio/app_strings.ts
@@ -7,26 +7,17 @@ import {
   safeParseJson,
   UiStringsPackage,
 } from '@votingworks/types';
-import {
-  BooleanEnvironmentVariableName,
-  isFeatureFlagEnabled,
-} from '@votingworks/utils';
 
 import { GoogleCloudTranslator } from './translator';
 import { setUiString } from './utils';
+import { BallotLanguageConfigs, getAllBallotLanguages } from '../types';
 
 export async function translateAppStrings(
   translator: GoogleCloudTranslator,
-  machineVersion: MachineVersion
+  machineVersion: MachineVersion,
+  ballotLanguageConfigs: BallotLanguageConfigs
 ): Promise<UiStringsPackage> {
-  /* istanbul ignore next */
-  if (
-    !isFeatureFlagEnabled(
-      BooleanEnvironmentVariableName.ENABLE_CLOUD_TRANSLATION_AND_SPEECH_SYNTHESIS
-    )
-  ) {
-    return {};
-  }
+  const languages = getAllBallotLanguages(ballotLanguageConfigs);
 
   const appStringsCatalogFileContents = await fs.readFile(
     path.join(
@@ -41,12 +32,12 @@ export async function translateAppStrings(
   ).unsafeUnwrap();
 
   const appStringKeys = Object.keys(appStringsCatalog).sort();
-  const appStringsInEnglish = appStringKeys.map(
+  const appStringsInEnglish = appStringKeys.map<string>(
     (key) => appStringsCatalog[key]
   );
 
   const appStrings: UiStringsPackage = {};
-  for (const languageCode of Object.values(LanguageCode)) {
+  for (const languageCode of languages) {
     const appStringsInLanguage =
       languageCode === LanguageCode.ENGLISH
         ? appStringsInEnglish

--- a/apps/design/backend/src/language_and_audio/audio.ts
+++ b/apps/design/backend/src/language_and_audio/audio.ts
@@ -6,6 +6,10 @@ import {
   UiStringsPackage,
 } from '@votingworks/types';
 
+import {
+  BooleanEnvironmentVariableName,
+  isFeatureFlagEnabled,
+} from '@votingworks/utils';
 import { GoogleCloudSpeechSynthesizer } from './speech_synthesizer';
 import {
   forEachUiString,
@@ -31,6 +35,15 @@ export function generateAudioIdsAndClips({
   uiStringAudioIds: UiStringAudioIdsPackage;
   uiStringAudioClips: NodeJS.ReadableStream;
 } {
+  /* istanbul ignore next */
+  if (
+    !isFeatureFlagEnabled(
+      BooleanEnvironmentVariableName.ENABLE_CLOUD_TRANSLATION_AND_SPEECH_SYNTHESIS
+    )
+  ) {
+    return { uiStringAudioClips: Readable.from([]), uiStringAudioIds: {} };
+  }
+
   const uiStringAudioIds: UiStringAudioIdsPackage = {};
   const textToSynthesizeSpeechFor: TextToSynthesizeSpeechFor[] = [];
 

--- a/apps/design/backend/src/types.test.ts
+++ b/apps/design/backend/src/types.test.ts
@@ -1,0 +1,49 @@
+import {
+  BallotStyle as VxfBallotStyle,
+  LanguageCode,
+  DistrictId,
+  PartyId,
+} from '@votingworks/types';
+import { convertToVxfBallotStyle } from './types';
+
+const { ENGLISH, SPANISH } = LanguageCode;
+
+test('convertToVxfBallotStyle()', () => {
+  const districtIds: DistrictId[] = [
+    'district1' as DistrictId,
+    'district2' as DistrictId,
+  ];
+
+  expect(
+    convertToVxfBallotStyle({
+      districtIds,
+      id: '1_A_en_es-US',
+      languages: [ENGLISH, SPANISH],
+      precinctsOrSplits: [
+        { precinctId: 'precinct1' },
+        { precinctId: 'precinct2', splitId: 'precinct2-split1' },
+      ],
+      partyId: 'partyA' as PartyId,
+    })
+  ).toEqual<VxfBallotStyle>({
+    districts: districtIds,
+    id: '1_A_en_es-US',
+    precincts: ['precinct1', 'precinct2'],
+    languages: [ENGLISH, SPANISH],
+    partyId: 'partyA' as PartyId,
+  });
+
+  expect(
+    convertToVxfBallotStyle({
+      districtIds,
+      id: '2_es-US',
+      languages: [SPANISH],
+      precinctsOrSplits: [{ precinctId: 'precinct1' }],
+    })
+  ).toEqual<VxfBallotStyle>({
+    districts: districtIds,
+    id: '2_es-US',
+    precincts: ['precinct1'],
+    languages: [SPANISH],
+  });
+});

--- a/apps/design/backend/src/types.ts
+++ b/apps/design/backend/src/types.ts
@@ -1,0 +1,81 @@
+// We create new types for precincts that can be split, since the existing
+// election types don't support this. We will likely want to extend the existing
+// types to support it in the future, but doing it separately for now allows us
+// to experiment and learn more first. We'll store these separately in the
+
+import { NhCustomContent } from '@votingworks/hmpb-layout';
+import {
+  BallotStyle as VxfBallotStyle,
+  BallotStyleId,
+  DistrictId,
+  Id,
+  LanguageCode,
+  PartyId,
+  PrecinctId,
+} from '@votingworks/types';
+
+export interface BallotLanguageConfig {
+  languages: LanguageCode[];
+}
+
+export type BallotLanguageConfigs = BallotLanguageConfig[];
+
+export function getAllBallotLanguages(
+  ballotLanguageConfigs: BallotLanguageConfigs
+): LanguageCode[] {
+  const uniqueLanguages = new Set(
+    ballotLanguageConfigs.flatMap((b) => b.languages)
+  );
+
+  return [...uniqueLanguages];
+}
+
+// database and ignore Election.precincts most of the app.
+export interface PrecinctWithoutSplits {
+  districtIds: readonly DistrictId[];
+  id: PrecinctId;
+  name: string;
+}
+export interface PrecinctWithSplits {
+  id: PrecinctId;
+  name: string;
+  splits: readonly PrecinctSplit[];
+}
+export interface PrecinctSplit {
+  districtIds: readonly DistrictId[];
+  id: Id;
+  name: string;
+  nhCustomContent: NhCustomContent;
+}
+export type Precinct = PrecinctWithoutSplits | PrecinctWithSplits;
+
+export function hasSplits(precinct: Precinct): precinct is PrecinctWithSplits {
+  return 'splits' in precinct && precinct.splits !== undefined;
+}
+
+export interface PrecinctOrSplitId {
+  precinctId: PrecinctId;
+  splitId?: Id;
+}
+
+// We also create a new type for a ballot style, that can reference precincts and
+// splits. We generate ballot styles on demand, so it won't be stored in the db.
+export interface BallotStyle {
+  districtIds: readonly DistrictId[];
+  id: BallotStyleId;
+  languages: LanguageCode[];
+  partyId?: PartyId;
+  precinctsOrSplits: readonly PrecinctOrSplitId[];
+}
+
+export function convertToVxfBallotStyle(
+  ballotStyle: BallotStyle
+): VxfBallotStyle {
+  return {
+    id: ballotStyle.id,
+    precincts: ballotStyle.precinctsOrSplits.map((p) => p.precinctId),
+    districts: ballotStyle.districtIds,
+    partyId: ballotStyle.partyId,
+    languages: ballotStyle.languages,
+  };
+}

--- a/apps/design/backend/src/worker/generate_election_package.ts
+++ b/apps/design/backend/src/worker/generate_election_package.ts
@@ -25,8 +25,13 @@ export async function generateElectionPackage(
 ): Promise<void> {
   const { assetDirectoryPath, store } = workspace;
 
-  const { election, layoutOptions, systemSettings, nhCustomContent } =
-    store.getElection(electionId);
+  const {
+    ballotLanguageConfigs,
+    election,
+    layoutOptions,
+    systemSettings,
+    nhCustomContent,
+  } = store.getElection(electionId);
 
   const zip = new JsZip();
 
@@ -35,14 +40,22 @@ export async function generateElectionPackage(
   };
   zip.file(ElectionPackageFileName.METADATA, JSON.stringify(metadata, null, 2));
 
-  const appStrings = await translateAppStrings(translator, metadata.version);
+  const appStrings = await translateAppStrings(
+    translator,
+    metadata.version,
+    ballotLanguageConfigs
+  );
   zip.file(
     ElectionPackageFileName.APP_STRINGS,
     JSON.stringify(appStrings, null, 2)
   );
 
   const { electionStrings, vxElectionStrings } =
-    await extractAndTranslateElectionStrings(translator, election);
+    await extractAndTranslateElectionStrings(
+      translator,
+      election,
+      ballotLanguageConfigs
+    );
   zip.file(
     ElectionPackageFileName.VX_ELECTION_STRINGS,
     JSON.stringify(vxElectionStrings, null, 2)

--- a/apps/design/frontend/src/ballots_screen.test.tsx
+++ b/apps/design/frontend/src/ballots_screen.test.tsx
@@ -67,10 +67,10 @@ describe('Ballot styles tab', () => {
             .map((cell) => cell.textContent)
         )
     ).toEqual([
-      ['Center Springfield', 'ballot-style-1', 'View Ballot'],
+      ['Center Springfield', '1_en', 'View Ballot'],
       ['North Springfield', '', ''],
-      ['North Springfield - Split 1', 'ballot-style-1', 'View Ballot'],
-      ['North Springfield - Split 2', 'ballot-style-2', 'View Ballot'],
+      ['North Springfield - Split 1', '1_en', 'View Ballot'],
+      ['North Springfield - Split 2', '2_en', 'View Ballot'],
     ]);
   });
 
@@ -101,17 +101,17 @@ describe('Ballot styles tab', () => {
             .map((cell) => cell.textContent)
         )
     ).toEqual([
-      ['Precinct 1', 'ballot-style-1-Ma', 'Mammal Party', 'View Ballot'],
-      ['Precinct 1', 'ballot-style-1-F', 'Fish Party', 'View Ballot'],
-      ['Precinct 2', 'ballot-style-1-Ma', 'Mammal Party', 'View Ballot'],
-      ['Precinct 2', 'ballot-style-1-F', 'Fish Party', 'View Ballot'],
-      ['Precinct 3', 'ballot-style-2-Ma', 'Mammal Party', 'View Ballot'],
-      ['Precinct 3', 'ballot-style-2-F', 'Fish Party', 'View Ballot'],
+      ['Precinct 1', '1-Ma_en', 'Mammal Party', 'View Ballot'],
+      ['Precinct 1', '1-F_en', 'Fish Party', 'View Ballot'],
+      ['Precinct 2', '1-Ma_en', 'Mammal Party', 'View Ballot'],
+      ['Precinct 2', '1-F_en', 'Fish Party', 'View Ballot'],
+      ['Precinct 3', '2-Ma_en', 'Mammal Party', 'View Ballot'],
+      ['Precinct 3', '2-F_en', 'Fish Party', 'View Ballot'],
       ['Precinct 4', '', '', ''],
-      ['Precinct 4 - Split 1', 'ballot-style-3-Ma', 'Mammal', 'View Ballot'],
-      ['Precinct 4 - Split 1', 'ballot-style-3-F', 'Fish', 'View Ballot'],
-      ['Precinct 4 - Split 2', 'ballot-style-4-Ma', 'Mammal', 'View Ballot'],
-      ['Precinct 4 - Split 2', 'ballot-style-4-F', 'Fish', 'View Ballot'],
+      ['Precinct 4 - Split 1', '3-Ma_en', 'Mammal', 'View Ballot'],
+      ['Precinct 4 - Split 1', '3-F_en', 'Fish', 'View Ballot'],
+      ['Precinct 4 - Split 2', '4-Ma_en', 'Mammal', 'View Ballot'],
+      ['Precinct 4 - Split 2', '4-F_en', 'Fish', 'View Ballot'],
     ]);
   });
 });

--- a/apps/design/frontend/test/fixtures.ts
+++ b/apps/design/frontend/test/fixtures.ts
@@ -3,19 +3,33 @@ import {
   createBlankElection,
   convertVxfPrecincts,
   generateBallotStyles,
+  BallotLanguageConfigs,
 } from '@votingworks/design-backend';
 import {
   electionPrimaryPrecinctSplitsFixtures,
   electionGeneral,
 } from '@votingworks/fixtures';
 import { DEFAULT_LAYOUT_OPTIONS } from '@votingworks/hmpb-layout';
-import { DEFAULT_SYSTEM_SETTINGS, Election } from '@votingworks/types';
+import {
+  DEFAULT_SYSTEM_SETTINGS,
+  Election,
+  LanguageCode,
+} from '@votingworks/types';
 
 export const electionId = 'election-id-1';
 
 export function makeElectionRecord(baseElection: Election): ElectionRecord {
+  const ballotLanguageConfigs: BallotLanguageConfigs = [
+    { languages: [LanguageCode.ENGLISH] },
+  ];
   const precincts = convertVxfPrecincts(baseElection);
-  const ballotStyles = generateBallotStyles(baseElection, precincts);
+  const ballotStyles = generateBallotStyles({
+    ballotLanguageConfigs,
+    contests: baseElection.contests,
+    electionType: baseElection.type,
+    parties: baseElection.parties,
+    precincts,
+  });
   const election: Election = {
     ...baseElection,
     ballotStyles: ballotStyles.map((ballotStyle) => ({
@@ -34,6 +48,7 @@ export function makeElectionRecord(baseElection: Election): ElectionRecord {
     layoutOptions: DEFAULT_LAYOUT_OPTIONS,
     createdAt: new Date().toISOString(),
     nhCustomContent: {},
+    ballotLanguageConfigs,
   };
 }
 


### PR DESCRIPTION
## Overview

Adding language codes to ballot styles generated in VxDesign to be matched up with BMD language selections (and eventually HMPB content as well).

Multi-language ballot style generation is currently hidden behind the `REACT_APP_VX_ENABLE_CLOUD_TRANSLATION_AND_SPEECH_SYNTHESIS` flag, since it needs to hand-in-hand with multi-language ballot content generation.

### TODO:
- Synthesised audio for the ballot style IDs sounds a little awkward and isn't useful for audio-only users in its current form. We may need to add a custom election string to use as alt audio text for this.

## Demo Video or Screenshot

### VxDesign:

<img width="972" alt="Screenshot 2024-03-07 at 14 29 50" src="https://github.com/votingworks/vxsuite/assets/264902/14edfdf0-e496-45b4-812d-9a6d9d5fc08f">

### BMD:

https://github.com/votingworks/vxsuite/assets/264902/5f8aca41-fa67-448e-9c0f-fdf5980472a5

## Testing Plan
- Updated ballot generation  test cases and related tests.
- Manually verified list of ballot styles in VxDesign screens and ballot exports.
- Manually verified BMD integration with voter language switcher.

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
