### PR TITLE
refactor(mark-scan): get battery info from backend, not `kiosk-browser`

### DIFF
--- a/apps/mark-scan/backend/src/server.ts
+++ b/apps/mark-scan/backend/src/server.ts
@@ -12,6 +12,7 @@ import {
   isFeatureFlagEnabled,
 } from '@votingworks/utils';
 import { detectUsbDrive } from '@votingworks/usb-drive';
+import { detectDevices } from '@votingworks/backend';
 import { buildApp } from './app';
 import { Workspace } from './util/workspace';
 import { getPaperHandlerStateMachine } from './custom-paper-handler/state_machine';
@@ -67,6 +68,7 @@ export async function start({
   port,
   workspace,
 }: StartOptions): Promise<Server> {
+  detectDevices({ logger: baseLogger });
   const resolvedAuth = auth ?? getDefaultAuth(baseLogger);
   const logger = Logger.from(baseLogger, () =>
     getUserRole(resolvedAuth, workspace)

--- a/apps/mark-scan/frontend/package.json
+++ b/apps/mark-scan/frontend/package.json
@@ -104,6 +104,7 @@
     "@types/styled-components": "^5.1.26",
     "@types/testing-library__jest-dom": "^5.14.9",
     "@vitejs/plugin-react": "^1.3.2",
+    "@votingworks/backend": "workspace:*",
     "@votingworks/grout-test-utils": "workspace:*",
     "@votingworks/mark-scan-backend": "workspace:*",
     "@votingworks/monorepo-utils": "workspace:*",

--- a/apps/mark-scan/frontend/src/app.test.tsx
+++ b/apps/mark-scan/frontend/src/app.test.tsx
@@ -4,7 +4,7 @@ import {
   mockOf,
   suppressingConsoleOutput,
 } from '@votingworks/test-utils';
-import { ALL_PRECINCTS_SELECTION, MemoryHardware } from '@votingworks/utils';
+import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 
 import fetchMock from 'fetch-mock';
 import { electionGeneralDefinition } from '@votingworks/fixtures';
@@ -49,10 +49,9 @@ it('will throw an error when using default api', async () => {
       codeVersion: '3.14',
     },
   });
-  const hardware = MemoryHardware.buildStandard();
 
   await suppressingConsoleOutput(async () => {
-    render(<App hardware={hardware} />);
+    render(<App />);
     await screen.findByText('Something went wrong');
   });
 });
@@ -63,15 +62,8 @@ it('Displays error boundary if the api returns an unexpected error', async () =>
   apiMock.expectGetElectionState();
   apiMock.expectGetMachineConfigToError();
   apiMock.mockApiClient.reboot.expectRepeatedCallsWith().resolves();
-  const hardware = MemoryHardware.buildStandard();
   await suppressingConsoleOutput(async () => {
-    render(
-      <App
-        hardware={hardware}
-        apiClient={apiMock.mockApiClient}
-        reload={jest.fn()}
-      />
-    );
+    render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
     await advanceTimersAndPromises();
     screen.getByText('Something went wrong');
     userEvent.click(await screen.findButton('Restart'));
@@ -167,9 +159,7 @@ it('uses window.location.reload by default', async () => {
   });
 
   // Set up in an already-configured state.
-  const hardware = MemoryHardware.buildStandard();
-
-  render(<App hardware={hardware} apiClient={apiMock.mockApiClient} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
 
   await advanceTimersAndPromises();
 

--- a/apps/mark-scan/frontend/src/app.tsx
+++ b/apps/mark-scan/frontend/src/app.tsx
@@ -1,6 +1,5 @@
 import { BrowserRouter } from 'react-router-dom';
 
-import { getHardware } from '@votingworks/utils';
 import { BaseLogger, LogSource } from '@votingworks/logging';
 import { QueryClient } from '@tanstack/react-query';
 import {
@@ -10,7 +9,7 @@ import {
 } from '@votingworks/ui';
 import { ColorMode, ScreenType, SizeMode } from '@votingworks/types';
 
-import { AppRoot, Props as AppRootProps } from './app_root';
+import { AppRoot } from './app_root';
 import { ApiClient, createApiClient, createQueryClient } from './api';
 import { SessionTimeLimitTracker } from './components/session_time_limit_tracker';
 import { ApiProvider } from './api_provider';
@@ -24,9 +23,8 @@ const DEFAULT_SCREEN_TYPE: ScreenType = 'elo15';
 const DEFAULT_SIZE_MODE: SizeMode = 'touchMedium';
 
 export interface Props {
-  hardware?: AppRootProps['hardware'];
   reload?: VoidFunction;
-  logger?: AppRootProps['logger'];
+  logger?: BaseLogger;
   apiClient?: ApiClient;
   queryClient?: QueryClient;
   enableStringTranslation?: boolean;
@@ -37,7 +35,6 @@ const RESTART_MESSAGE =
   'Ask a poll worker to restart the ballot marking device.';
 
 export function App({
-  hardware = getHardware(),
   reload = () => window.location.reload(),
   logger = new BaseLogger(LogSource.VxMarkScanFrontend, window.kiosk),
   /* istanbul ignore next */ apiClient = createApiClient(),
@@ -65,7 +62,7 @@ export function App({
               logger={logger}
             >
               <VisualModeDisabledOverlay />
-              <AppRoot hardware={hardware} reload={reload} logger={logger} />
+              <AppRoot reload={reload} />
               <SessionTimeLimitTracker />
             </AppErrorBoundary>
           </ApiProvider>

--- a/apps/mark-scan/frontend/src/app_card_unhappy_paths.test.tsx
+++ b/apps/mark-scan/frontend/src/app_card_unhappy_paths.test.tsx
@@ -1,4 +1,4 @@
-import { MemoryHardware, ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
+import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 import { electionGeneralDefinition } from '@votingworks/fixtures';
 import { render, screen } from '../test/react_testing_library';
 
@@ -20,7 +20,6 @@ afterEach(() => {
 });
 
 test('Shows card backwards screen when card connection error occurs', async () => {
-  const hardware = MemoryHardware.buildStandard();
   apiMock.expectGetMachineConfig();
 
   apiMock.expectGetElectionDefinition(electionGeneralDefinition);
@@ -29,13 +28,7 @@ test('Shows card backwards screen when card connection error occurs', async () =
     pollsState: 'polls_open',
   });
 
-  render(
-    <App
-      hardware={hardware}
-      apiClient={apiMock.mockApiClient}
-      reload={jest.fn()}
-    />
-  );
+  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
   await screen.findByText('Insert Card');
 
   apiMock.setAuthStatus({

--- a/apps/mark-scan/frontend/src/app_cardless_voting.test.tsx
+++ b/apps/mark-scan/frontend/src/app_cardless_voting.test.tsx
@@ -1,5 +1,4 @@
 import {
-  MemoryHardware,
   singlePrecinctSelectionFor,
   ALL_PRECINCTS_SELECTION,
 } from '@votingworks/utils';
@@ -65,7 +64,6 @@ const CENTER_SPRINGFIELD_PRECINCT_SELECTION = singlePrecinctSelectionFor('23');
 
 test('Cardless Voting Flow', async () => {
   const electionDefinition = electionGeneralDefinition;
-  const hardware = MemoryHardware.buildStandard();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetSystemSettings();
   apiMock.expectGetElectionDefinition(electionGeneralDefinition);
@@ -73,13 +71,7 @@ test('Cardless Voting Flow', async () => {
     precinctSelection: CENTER_SPRINGFIELD_PRECINCT_SELECTION,
     pollsState: 'polls_open',
   });
-  render(
-    <App
-      hardware={hardware}
-      apiClient={apiMock.mockApiClient}
-      reload={jest.fn()}
-    />
-  );
+  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
   const findByTextWithMarkup = withMarkup(screen.findByText);
 
   await screen.findByText('Insert Card');
@@ -226,7 +218,6 @@ test('Cardless Voting Flow', async () => {
 
 test('in "All Precincts" mode, poll worker must select a precinct first', async () => {
   const electionDefinition = electionGeneralDefinition;
-  const hardware = MemoryHardware.buildStandard();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetSystemSettings();
   apiMock.expectGetElectionDefinition(electionGeneralDefinition);
@@ -234,13 +225,7 @@ test('in "All Precincts" mode, poll worker must select a precinct first', async 
     precinctSelection: ALL_PRECINCTS_SELECTION,
     pollsState: 'polls_open',
   });
-  render(
-    <App
-      hardware={hardware}
-      apiClient={apiMock.mockApiClient}
-      reload={jest.fn()}
-    />
-  );
+  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
 
   await screen.findByText('Insert Card');
 

--- a/apps/mark-scan/frontend/src/app_contest_candidate_no_party.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_candidate_no_party.test.tsx
@@ -1,4 +1,4 @@
-import { MemoryHardware, ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
+import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 
 import { CandidateContest, Election } from '@votingworks/types';
 import {
@@ -52,20 +52,13 @@ afterEach(() => {
 it('Single Seat Contest', async () => {
   // ====================== BEGIN CONTEST SETUP ====================== //
 
-  const hardware = MemoryHardware.buildStandard();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetElectionState({
     precinctSelection: ALL_PRECINCTS_SELECTION,
     pollsState: 'polls_open',
   });
 
-  render(
-    <App
-      hardware={hardware}
-      apiClient={apiMock.mockApiClient}
-      reload={jest.fn()}
-    />
-  );
+  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
   await advanceTimersAndPromises();
 
   // Start voter session

--- a/apps/mark-scan/frontend/src/app_contest_ms_either_neither.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_ms_either_neither.test.tsx
@@ -1,4 +1,4 @@
-import { MemoryHardware, singlePrecinctSelectionFor } from '@votingworks/utils';
+import { singlePrecinctSelectionFor } from '@votingworks/utils';
 import { Route } from 'react-router-dom';
 import {
   getBallotStyle,
@@ -215,7 +215,6 @@ test('Renders Ballot with EitherNeither: blank & secondOption', async () => {
 
 test('Can vote on a Mississippi Either Neither Contest', async () => {
   // ====================== BEGIN CONTEST SETUP ====================== //
-  const hardware = MemoryHardware.buildStandard();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetSystemSettings();
   apiMock.expectGetElectionDefinition(electionDefinition);
@@ -225,13 +224,7 @@ test('Can vote on a Mississippi Either Neither Contest', async () => {
     pollsState: 'polls_open',
   });
 
-  render(
-    <App
-      hardware={hardware}
-      apiClient={apiMock.mockApiClient}
-      reload={jest.fn()}
-    />
-  );
+  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
 
   // Start voter session
   apiMock.setAuthStatusCardlessVoterLoggedIn({

--- a/apps/mark-scan/frontend/src/app_contest_multi_seat.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_multi_seat.test.tsx
@@ -1,4 +1,4 @@
-import { MemoryHardware, ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
+import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 
 import userEvent from '@testing-library/user-event';
 import { electionGeneralDefinition } from '@votingworks/fixtures';
@@ -32,7 +32,6 @@ afterEach(() => {
 it('Single Seat Contest', async () => {
   // ====================== BEGIN CONTEST SETUP ====================== //
 
-  const hardware = MemoryHardware.buildStandard();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetElectionDefinition(electionGeneralDefinition);
   apiMock.expectGetElectionState({
@@ -40,13 +39,7 @@ it('Single Seat Contest', async () => {
     pollsState: 'polls_open',
   });
 
-  render(
-    <App
-      hardware={hardware}
-      apiClient={apiMock.mockApiClient}
-      reload={jest.fn()}
-    />
-  );
+  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
   await advanceTimersAndPromises();
 
   // Start voter session

--- a/apps/mark-scan/frontend/src/app_contest_single_seat.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_single_seat.test.tsx
@@ -1,4 +1,4 @@
-import { MemoryHardware, ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
+import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 
 import userEvent from '@testing-library/user-event';
 import { electionGeneralDefinition } from '@votingworks/fixtures';
@@ -34,7 +34,6 @@ it('Single Seat Contest', async () => {
   // ====================== BEGIN CONTEST SETUP ====================== //
 
   apiMock.expectGetMachineConfig();
-  const hardware = MemoryHardware.buildStandard();
 
   apiMock.expectGetElectionDefinition(electionGeneralDefinition);
   apiMock.expectGetElectionState({
@@ -42,13 +41,7 @@ it('Single Seat Contest', async () => {
     pollsState: 'polls_open',
   });
 
-  render(
-    <App
-      hardware={hardware}
-      reload={jest.fn()}
-      apiClient={apiMock.mockApiClient}
-    />
-  );
+  render(<App reload={jest.fn()} apiClient={apiMock.mockApiClient} />);
   await advanceTimersAndPromises();
 
   // Start voter session

--- a/apps/mark-scan/frontend/src/app_contest_write_in.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_write_in.test.tsx
@@ -6,7 +6,7 @@ import {
   fakePrintElementWhenReady,
   fakePrintElementToPdf,
 } from '@votingworks/test-utils';
-import { ALL_PRECINCTS_SELECTION, MemoryHardware } from '@votingworks/utils';
+import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 import userEvent from '@testing-library/user-event';
 import { electionGeneralDefinition } from '@votingworks/fixtures';
 import { ContestPage, ContestPageProps } from '@votingworks/mark-flow-ui';
@@ -14,11 +14,7 @@ import { ContestId, OptionalVote, VotesDict } from '@votingworks/types';
 import { useHistory } from 'react-router-dom';
 import { act, fireEvent, render, screen } from '../test/react_testing_library';
 import { App } from './app';
-
-import {
-  advanceTimers,
-  advanceTimersAndPromises,
-} from '../test/helpers/timers';
+import { advanceTimers } from '../test/helpers/timers';
 
 import { singleSeatContestWithWriteIn } from '../test/helpers/election';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
@@ -91,7 +87,6 @@ afterEach(() => {
 it('Single Seat Contest with Write In', async () => {
   // ====================== BEGIN CONTEST SETUP ====================== //
 
-  const hardware = MemoryHardware.buildStandard();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetElectionDefinition(electionGeneralDefinition);
   apiMock.expectGetElectionState({
@@ -103,14 +98,8 @@ it('Single Seat Contest with Write In', async () => {
   const { fireUpdateVoteEvent, getLatestVotes, goToReviewPage } =
     setUpMockContestPage();
 
-  render(
-    <App
-      hardware={hardware}
-      apiClient={apiMock.mockApiClient}
-      reload={jest.fn()}
-    />
-  );
-  await advanceTimersAndPromises();
+  const app = <App apiClient={apiMock.mockApiClient} reload={jest.fn()} />;
+  const { rerender } = render(app);
 
   // Start voter session
   apiMock.setAuthStatusCardlessVoterLoggedIn({
@@ -148,6 +137,7 @@ it('Single Seat Contest with Write In', async () => {
 
   // Go to review page and confirm write in exists
   act(() => goToReviewPage());
+  rerender(app); // no component change so we need to force a rerender
 
   // Review Screen
   await screen.findByText('Review Your Votes');

--- a/apps/mark-scan/frontend/src/app_contest_yes_no.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_yes_no.test.tsx
@@ -2,7 +2,7 @@ import {
   electionGeneral,
   electionGeneralDefinition,
 } from '@votingworks/fixtures';
-import { MemoryHardware, ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
+import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 
 import { getContestDistrictName } from '@votingworks/types';
 import userEvent from '@testing-library/user-event';
@@ -39,8 +39,6 @@ afterEach(() => {
 it('Single Seat Contest', async () => {
   // ====================== BEGIN CONTEST SETUP ====================== //
 
-  const hardware = MemoryHardware.buildStandard();
-
   apiMock.expectGetMachineConfig();
   apiMock.expectGetElectionDefinition(electionGeneralDefinition);
   apiMock.expectGetElectionState({
@@ -48,13 +46,7 @@ it('Single Seat Contest', async () => {
     pollsState: 'polls_open',
   });
 
-  render(
-    <App
-      apiClient={apiMock.mockApiClient}
-      hardware={hardware}
-      reload={jest.fn()}
-    />
-  );
+  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
   await advanceTimersAndPromises();
 
   // Start voter session

--- a/apps/mark-scan/frontend/src/app_election_package_config.test.tsx
+++ b/apps/mark-scan/frontend/src/app_election_package_config.test.tsx
@@ -1,6 +1,5 @@
 import { mockBaseLogger } from '@votingworks/logging';
 import { electionGeneralDefinition } from '@votingworks/fixtures';
-import { MemoryHardware } from '@votingworks/utils';
 import { mockUsbDriveStatus } from '@votingworks/ui';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 import { render, screen } from '../test/react_testing_library';
@@ -29,7 +28,6 @@ test('renders an error if election package config endpoint returns an error', as
 
   render(
     <App
-      hardware={MemoryHardware.buildStandard()}
       reload={jest.fn()}
       logger={mockBaseLogger()}
       apiClient={apiMock.mockApiClient}

--- a/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
@@ -8,7 +8,7 @@ import {
   fakePrintElementWhenReady,
   fakePrintElementToPdf,
 } from '@votingworks/test-utils';
-import { MemoryHardware, singlePrecinctSelectionFor } from '@votingworks/utils';
+import { singlePrecinctSelectionFor } from '@votingworks/utils';
 import { mockBaseLogger } from '@votingworks/logging';
 import { getContestDistrictName } from '@votingworks/types';
 import { electionGeneralDefinition } from '@votingworks/fixtures';
@@ -57,7 +57,6 @@ test('MarkAndPrint end-to-end flow', async () => {
   const logger = mockBaseLogger();
   const electionDefinition = electionGeneralDefinition;
   const { electionHash } = electionDefinition;
-  const hardware = MemoryHardware.buildStandard();
   apiMock.expectGetMachineConfig({
     screenOrientation: 'portrait',
   });
@@ -68,12 +67,7 @@ test('MarkAndPrint end-to-end flow', async () => {
   apiMock.expectGetElectionDefinition(null);
   apiMock.expectGetElectionState();
   render(
-    <App
-      hardware={hardware}
-      reload={reload}
-      logger={logger}
-      apiClient={apiMock.mockApiClient}
-    />
+    <App reload={reload} logger={logger} apiClient={apiMock.mockApiClient} />
   );
   const getByTextWithMarkup = withMarkup(screen.getByText);
   const findByTextWithMarkup = withMarkup(screen.findByText);

--- a/apps/mark-scan/frontend/src/app_quit_on_idle.test.tsx
+++ b/apps/mark-scan/frontend/src/app_quit_on_idle.test.tsx
@@ -1,5 +1,5 @@
 import { fakeKiosk } from '@votingworks/test-utils';
-import { MemoryHardware, ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
+import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 
 import userEvent from '@testing-library/user-event';
 import { createMocks as createReactIdleTimerMocks } from 'react-idle-timer';
@@ -34,7 +34,6 @@ afterEach(() => {
 });
 
 test('Insert Card screen idle timeout to quit app', async () => {
-  const hardware = MemoryHardware.buildStandard();
   apiMock.expectGetMachineConfig({
     // machineId used to determine whether we quit. Now they all do.
     // making sure a machineId that ends in 0 still triggers.
@@ -47,13 +46,7 @@ test('Insert Card screen idle timeout to quit app', async () => {
     pollsState: 'polls_open',
   });
 
-  render(
-    <App
-      hardware={hardware}
-      apiClient={apiMock.mockApiClient}
-      reload={jest.fn()}
-    />
-  );
+  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
 
   // Ensure we're on the Insert Card screen
   await screen.findByText('Insert Card');
@@ -68,7 +61,6 @@ test('Insert Card screen idle timeout to quit app', async () => {
 });
 
 test('Voter idle timeout', async () => {
-  const hardware = MemoryHardware.buildStandard();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetElectionDefinition(electionGeneralDefinition);
   apiMock.expectGetElectionState({
@@ -76,7 +68,7 @@ test('Voter idle timeout', async () => {
     pollsState: 'polls_open',
   });
 
-  render(<App apiClient={apiMock.mockApiClient} hardware={hardware} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
 
   // Start voter session
   apiMock.setAuthStatusCardlessVoterLoggedIn({

--- a/apps/mark-scan/frontend/src/app_replace_election.test.tsx
+++ b/apps/mark-scan/frontend/src/app_replace_election.test.tsx
@@ -1,4 +1,4 @@
-import { ALL_PRECINCTS_SELECTION, MemoryHardware } from '@votingworks/utils';
+import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 import {
   electionTwoPartyPrimaryDefinition,
   electionGeneralDefinition,
@@ -28,7 +28,6 @@ afterEach(() => {
 jest.setTimeout(2000);
 
 test('app renders a notice when election hash on card does not match that of machine config', async () => {
-  const hardware = MemoryHardware.buildStandard();
   apiMock.expectGetMachineConfig();
   // Set up an already-configured election
   apiMock.expectGetSystemSettings(DEFAULT_SYSTEM_SETTINGS);
@@ -40,13 +39,7 @@ test('app renders a notice when election hash on card does not match that of mac
     pollsState: 'polls_open',
   });
 
-  render(
-    <App
-      hardware={hardware}
-      apiClient={apiMock.mockApiClient}
-      reload={jest.fn()}
-    />
-  );
+  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
 
   // insert election manager card with different election
   apiMock.setAuthStatusElectionManagerLoggedIn(

--- a/apps/mark-scan/frontend/src/app_states.test.tsx
+++ b/apps/mark-scan/frontend/src/app_states.test.tsx
@@ -1,4 +1,4 @@
-import { ALL_PRECINCTS_SELECTION, MemoryHardware } from '@votingworks/utils';
+import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 import { fakeKiosk } from '@votingworks/test-utils';
 import { SimpleServerStatus } from '@votingworks/mark-scan-backend';
 import { electionDefinition } from '../test/helpers/election';
@@ -8,7 +8,6 @@ import { createApiMock, ApiMock } from '../test/helpers/mock_api_client';
 
 let apiMock: ApiMock;
 let kiosk = fakeKiosk();
-let hardware: MemoryHardware;
 
 beforeEach(() => {
   jest.useFakeTimers();
@@ -16,8 +15,6 @@ beforeEach(() => {
   apiMock = createApiMock();
   kiosk = fakeKiosk();
   window.kiosk = kiosk;
-
-  hardware = MemoryHardware.buildStandard();
 
   apiMock.expectGetMachineConfig();
   apiMock.expectGetElectionDefinition(electionDefinition);
@@ -36,13 +33,7 @@ jest.setTimeout(30000);
 test('`jammed` state renders jam page', async () => {
   apiMock.setPaperHandlerState('jammed');
 
-  render(
-    <App
-      hardware={hardware}
-      apiClient={apiMock.mockApiClient}
-      reload={jest.fn()}
-    />
-  );
+  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
 
   await screen.findByText('Paper is Jammed');
 });
@@ -51,13 +42,7 @@ test('`jam_cleared` state renders jam cleared page', async () => {
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
   apiMock.setPaperHandlerState('jam_cleared');
 
-  render(
-    <App
-      hardware={hardware}
-      apiClient={apiMock.mockApiClient}
-      reload={jest.fn()}
-    />
-  );
+  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
 
   await screen.findByText('Jam Cleared');
   screen.getByText(/The hardware is resetting/);
@@ -67,13 +52,7 @@ test('`resetting_state_machine_after_jam` state renders jam cleared page', async
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
   apiMock.setPaperHandlerState('resetting_state_machine_after_jam');
 
-  render(
-    <App
-      hardware={hardware}
-      apiClient={apiMock.mockApiClient}
-      reload={jest.fn()}
-    />
-  );
+  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
 
   await screen.findByText('Jam Cleared');
   screen.getByText(/The hardware has been reset/);
@@ -87,13 +66,7 @@ test('`waiting_for_invalidated_ballot_confirmation` state renders ballot invalid
     pollsState: 'polls_open',
   });
 
-  render(
-    <App
-      hardware={hardware}
-      apiClient={apiMock.mockApiClient}
-      reload={jest.fn()}
-    />
-  );
+  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
 
   apiMock.setPaperHandlerState(
     'waiting_for_invalidated_ballot_confirmation.paper_present'
@@ -110,13 +83,7 @@ test('`waiting_for_invalidated_ballot_confirmation` state renders ballot invalid
     pollsState: 'polls_open',
   });
 
-  render(
-    <App
-      hardware={hardware}
-      apiClient={apiMock.mockApiClient}
-      reload={jest.fn()}
-    />
-  );
+  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
 
   apiMock.setPaperHandlerState(
     'waiting_for_invalidated_ballot_confirmation.paper_present'
@@ -133,13 +100,7 @@ test('`waiting_for_invalidated_ballot_confirmation` state renders ballot invalid
 test('`blank_page_interpretation` state renders BlankPageInterpretationPage for cardless voter auth', async () => {
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
 
-  render(
-    <App
-      hardware={hardware}
-      apiClient={apiMock.mockApiClient}
-      reload={jest.fn()}
-    />
-  );
+  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
 
   apiMock.setPaperHandlerState('blank_page_interpretation');
   apiMock.setAuthStatusCardlessVoterLoggedInWithDefaults(electionDefinition);
@@ -150,13 +111,7 @@ test('`blank_page_interpretation` state renders BlankPageInterpretationPage for 
 test('`blank_page_interpretation` state renders BlankPageInterpretationPage for poll worker auth', async () => {
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
 
-  render(
-    <App
-      hardware={hardware}
-      apiClient={apiMock.mockApiClient}
-      reload={jest.fn()}
-    />
-  );
+  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
 
   apiMock.setPaperHandlerState('blank_page_interpretation');
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
@@ -171,13 +126,7 @@ test('`blank_page_interpretation` state renders BlankPageInterpretationPage for 
 test('`pat_device_connected` state renders PAT device calibration page', async () => {
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
 
-  render(
-    <App
-      hardware={hardware}
-      apiClient={apiMock.mockApiClient}
-      reload={jest.fn()}
-    />
-  );
+  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
 
   apiMock.setPaperHandlerState('pat_device_connected');
   apiMock.setAuthStatusCardlessVoterLoggedInWithDefaults(electionDefinition);
@@ -187,13 +136,7 @@ test('`pat_device_connected` state renders PAT device calibration page', async (
 test('`paper_reloaded` state renders PaperReloadedPage', async () => {
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
 
-  render(
-    <App
-      hardware={hardware}
-      apiClient={apiMock.mockApiClient}
-      reload={jest.fn()}
-    />
-  );
+  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
 
   apiMock.setPaperHandlerState('paper_reloaded');
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
@@ -210,13 +153,7 @@ test('`paper_reloaded` state renders PaperReloadedPage', async () => {
 test('`empty_ballot_box` state renders EmptyBallotBoxPage', async () => {
   apiMock.setAuthStatusCardlessVoterLoggedInWithDefaults(electionDefinition);
 
-  render(
-    <App
-      hardware={hardware}
-      apiClient={apiMock.mockApiClient}
-      reload={jest.fn()}
-    />
-  );
+  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
 
   apiMock.setPaperHandlerState('empty_ballot_box');
   await screen.findByText('Ballot Box Full');
@@ -241,13 +178,7 @@ test.each(testSpecs)(
     apiMock.setAuthStatusCardlessVoterLoggedInWithDefaults(electionDefinition);
     apiMock.setPaperHandlerState(state);
 
-    render(
-      <App
-        hardware={hardware}
-        apiClient={apiMock.mockApiClient}
-        reload={jest.fn()}
-      />
-    );
+    render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
 
     await screen.findByText('Your ballot was cast!');
     await screen.findByText('Thank you for voting.');

--- a/apps/mark-scan/frontend/src/app_test_mode.test.tsx
+++ b/apps/mark-scan/frontend/src/app_test_mode.test.tsx
@@ -3,7 +3,7 @@ import {
   asElectionDefinition,
   electionGeneralDefinition,
 } from '@votingworks/fixtures';
-import { ALL_PRECINCTS_SELECTION, MemoryHardware } from '@votingworks/utils';
+import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 import { DateWithoutTime } from '@votingworks/basics';
 import { render, screen, waitFor } from '../test/react_testing_library';
 
@@ -28,14 +28,13 @@ it('Prompts to change from test mode to live mode on election day', async () => 
     ...electionGeneralDefinition.election,
     date: DateWithoutTime.today(),
   });
-  const hardware = MemoryHardware.buildStandard();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetElectionDefinition(electionDefinition);
   apiMock.expectGetElectionState({
     isTestMode: true,
     precinctSelection: ALL_PRECINCTS_SELECTION,
   });
-  render(<App apiClient={apiMock.mockApiClient} hardware={hardware} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
 
   await screen.findByText('Test Ballot Mode');
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);

--- a/apps/mark-scan/frontend/src/app_visual_mode_disabled.test.tsx
+++ b/apps/mark-scan/frontend/src/app_visual_mode_disabled.test.tsx
@@ -1,15 +1,9 @@
-import { Hardware, MemoryHardware } from '@votingworks/utils';
 import userEvent from '@testing-library/user-event';
 import { App } from './app';
 import { render, screen } from '../test/react_testing_library';
 
-let hardware: Hardware;
-beforeEach(() => {
-  hardware = MemoryHardware.buildStandard();
-});
-
 test('renders overlay when audio-only mode is enabled', () => {
-  render(<App hardware={hardware} />, {
+  render(<App />, {
     vxTheme: { isVisualModeDisabled: true },
   });
 

--- a/apps/mark-scan/frontend/src/constants.ts
+++ b/apps/mark-scan/frontend/src/constants.ts
@@ -2,3 +2,5 @@
 export const STATE_MACHINE_POLLING_INTERVAL_MS = 300;
 // Overrides shorter libs/ui polling interval
 export const AUTH_STATUS_POLLING_INTERVAL_MS_OVERRIDE = 300;
+
+export const LOW_BATTERY_THRESHOLD = 0.25;

--- a/apps/mark-scan/frontend/src/lib/assistive_technology.test.tsx
+++ b/apps/mark-scan/frontend/src/lib/assistive_technology.test.tsx
@@ -1,4 +1,4 @@
-import { MemoryHardware, ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
+import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 import { electionGeneralDefinition } from '@votingworks/fixtures';
 import userEvent from '@testing-library/user-event';
 import { mockOf } from '@votingworks/test-utils';
@@ -32,20 +32,13 @@ afterEach(() => {
 });
 
 it('accessible controller handling works', async () => {
-  const hardware = MemoryHardware.buildStandard();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetElectionDefinition(electionGeneralDefinition);
   apiMock.expectGetElectionState({
     precinctSelection: ALL_PRECINCTS_SELECTION,
     pollsState: 'polls_open',
   });
-  render(
-    <App
-      hardware={hardware}
-      apiClient={apiMock.mockApiClient}
-      reload={jest.fn()}
-    />
-  );
+  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
   await advanceTimersAndPromises();
   // Start voter session
   apiMock.setAuthStatusCardlessVoterLoggedIn({
@@ -115,7 +108,6 @@ it('accessible controller handling works', async () => {
 });
 
 it('auto-focuses "next" button on contest screen after voting', async () => {
-  const hardware = MemoryHardware.buildStandard();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetElectionDefinition(electionGeneralDefinition);
   apiMock.expectGetElectionState({
@@ -124,13 +116,7 @@ it('auto-focuses "next" button on contest screen after voting', async () => {
   });
   mockOf(apiMock.mockApiClient.isPatDeviceConnected).mockResolvedValue(true);
 
-  render(
-    <App
-      hardware={hardware}
-      apiClient={apiMock.mockApiClient}
-      reload={jest.fn()}
-    />
-  );
+  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
   await advanceTimersAndPromises();
   // Start voter session
   apiMock.setAuthStatusCardlessVoterLoggedIn({

--- a/apps/mark-scan/frontend/src/pages/diagnostics_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/diagnostics_screen.tsx
@@ -1,28 +1,25 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import {
   Button,
-  ComputerStatus as ComputerStatusType,
-  Devices,
   H1,
   H4,
   LinkButton,
   Main,
   Prose,
   Screen,
-  useCancelablePromise,
   P,
   Caption,
   Icons,
 } from '@votingworks/ui';
-import { formatTime, Hardware } from '@votingworks/utils';
-import { DateTime } from 'luxon';
+import { formatTime } from '@votingworks/utils';
 import { useHistory, Switch, Route } from 'react-router-dom';
 import styled from 'styled-components';
-import { assert, Optional } from '@votingworks/basics';
+import type { BatteryInfo } from '@votingworks/backend';
 import {
   AccessibleControllerDiagnosticScreen,
   AccessibleControllerDiagnosticResults,
 } from './accessible_controller_diagnostic_screen';
+import { systemCallApi } from '../api';
 
 const ButtonAndTimestamp = styled.div`
   display: flex;
@@ -39,17 +36,19 @@ const CHECKBOX_ICON = <Icons.Checkbox color="success" />;
 const WARNING_ICON = <Icons.Warning color="warning" />;
 
 interface ComputerStatusProps {
-  computer: ComputerStatusType;
+  battery?: BatteryInfo;
 }
 
-function ComputerStatus({ computer }: ComputerStatusProps) {
+function ComputerStatus({ battery }: ComputerStatusProps) {
+  const level = battery ? battery.level : 1;
+  const discharging = battery ? battery.discharging : false;
+
   return (
     <React.Fragment>
       <P>
-        {CHECKBOX_ICON} Battery:{' '}
-        {computer.batteryLevel && `${Math.round(computer.batteryLevel * 100)}%`}
+        {CHECKBOX_ICON} Battery: {`${Math.round(level * 100)}%`}
       </P>
-      {computer.batteryIsCharging ? (
+      {!discharging ? (
         <P>{CHECKBOX_ICON} Power cord connected.</P>
       ) : (
         <P>{WARNING_ICON} No power cord connected. Connect power cord.</P>
@@ -58,179 +57,13 @@ function ComputerStatus({ computer }: ComputerStatusProps) {
   );
 }
 
-/**
- * IPP printer-state-reasons explain what's going on with a printer in detail.
- * Here, we map them to a human-readable explanation, both for user-friendliness
- * and developer documentation.
- * Spec: https://datatracker.ietf.org/doc/html/rfc2911#section-4.4.12
- * There are more possible reasons than covered in the spec, so this list is not
- * exhaustive.
- *
- * Note that the actual printer-state-reasons sent by the printer may have a
- * suffix of either: "-report", "-warning", or "-error" (e.g. "media-jam-error").
- */
-const IppPrinterStateReasonMessage: { [reason: string]: string } = {
-  'sleep-mode':
-    'The printer is in sleep mode. Press any button on the printer to wake it, then refresh printer status.', // Custom reason added by us
-  'media-needed': 'The printer is out of paper. Add paper to the printer.',
-  'media-jam': 'The printer has a paper jam. Open cover and remove paper.',
-  'moving-to-paused': 'The printer is pausing. Restart the printer.',
-  paused: 'The printer is paused. Restart the printer.',
-  shutdown: 'The printer is turned off or disconnected. Restart the printer.',
-  'timed-out': 'The printer is not responding. Restart the printer.',
-  stopping: 'The printer is stopping. Restart the printer.',
-  'stopped-partly': 'The printer is stopped. Restart the printer.',
-  'toner-low': 'The printer is low on toner. Replace toner cartridge.',
-  'toner-empty': 'The printer is low on toner. Replace toner cartridge.',
-  'spool-area-full': 'The spool area is full. Restart the printer.',
-  'cover-open': "The printer's cover is open. Close the printer's cover.",
-  'interlock-open': "The printer's door is open. Close the printer's door.",
-  'door-open': "The printer's door is open. Close the printer's door.",
-  'input-tray-missing':
-    "The printer's input tray is missing. Connect the input tray.",
-  'media-low': 'The printer is low on paper. Add paper to the printer.',
-  'media-empty': 'The printer is out of paper. Add paper to the printer.',
-  'output-tray-missing':
-    "The printer's output tray is missing. Connect the output tray.",
-  'output-area-almost-full':
-    "The printer's output tray is almost full. Remove printed documents.",
-  'output-area-full':
-    "The printer's output tray is full. Remove printed documents.",
-  'marker-supply-low': 'The printer is low on toner. Replace toner cartridge.',
-  'marker-supply-empty':
-    'The printer is out of toner. Replace toner cartridge.',
-  'marker-waste-almost-full':
-    "The printer's toner waste cartridge is almost full. Empty the toner waste cartridge.",
-  'marker-waste-full':
-    "The printer's toner waste receptacle is full. Empty the toner waste cartridge.",
-  'fuser-over-temp':
-    "The printer's fuser temperature is above normal. Restart the printer.",
-  'fuser-under-temp':
-    "The printer's fuser temperature is below normal. Restart the printer.",
-  'opc-near-eol':
-    "The printer's optical photo conductor is near end of life. Replace this printer.",
-  'opc-life-over':
-    "The printer's optical photo conductor is no longer functioning. Replace this printer.",
-};
-
-function parseHighestPriorityReason(
-  printerStateReasons: string[]
-): Optional<string> {
-  return printerStateReasons
-    .map((printerStateReason) => {
-      const [, reason, level] = Array.from(
-        /^([a-z-]+?)(?:-(report|warning|error))?$/.exec(printerStateReason) ||
-          []
-      );
-      return [reason, level];
-    })
-    .filter(([reason]) => reason)
-    .sort(([, level1], [, level2]) => {
-      function levelRank(level?: string) {
-        return level === 'error' ? 0 : level === 'warning' ? 1 : 2;
-      }
-      return levelRank(level1) - levelRank(level2);
-    })
-    .map(([reason]) => reason)[0];
-}
-
-interface PrinterStatusProps {
-  hardware: Hardware;
-}
-
-type PrinterStatusState =
-  | { isLoading: true }
-  | {
-      isLoading: false;
-      printer?: KioskBrowser.PrinterInfo;
-      loadedAt: DateTime;
-    };
-
-function PrinterStatus({ hardware }: PrinterStatusProps) {
-  const makeCancelable = useCancelablePromise();
-  const [printerStatus, setPrinterStatus] = useState<PrinterStatusState>({
-    isLoading: true,
-  });
-
-  // devices.printer only updates when the printer connects/disconnects. We want
-  // to load its current status, since it may have changed (e.g. if it ran out
-  // of paper).
-  const loadPrinterStatus = useCallback(async () => {
-    setPrinterStatus({ isLoading: true });
-    const printer = await makeCancelable(hardware.readPrinterStatus());
-    setPrinterStatus({ isLoading: false, printer, loadedAt: DateTime.now() });
-  }, [hardware, makeCancelable]);
-
-  useEffect(() => {
-    void loadPrinterStatus();
-  }, [loadPrinterStatus]);
-
-  if (printerStatus.isLoading) {
-    return <P>Loading printer status…</P>;
-  }
-  const { printer, loadedAt } = printerStatus;
-
-  const refreshButton = (
-    <ButtonAndTimestamp>
-      <Button onPress={loadPrinterStatus}>Refresh Printer Status</Button>
-      {loadedAt && <Caption>Last updated at {formatTime(loadedAt)}</Caption>}
-    </ButtonAndTimestamp>
-  );
-
-  if (!printer || printer.state === 'unknown') {
-    return (
-      <React.Fragment>
-        <P>{WARNING_ICON} Could not get printer status.</P>
-        {refreshButton}
-      </React.Fragment>
-    );
-  }
-
-  const bestReason = parseHighestPriorityReason(printer.stateReasons);
-  const marker = printer.markerInfos[0];
-  const markerLow = marker.level <= marker.lowLevel;
-
-  return (
-    <React.Fragment>
-      <P>
-        {printer.state === 'stopped' ? WARNING_ICON : CHECKBOX_ICON} Printer
-        status:{' '}
-        {
-          {
-            idle: 'Ready',
-            processing: 'Processing',
-            stopped: 'Stopped',
-          }[printer.state]
-        }
-      </P>
-      {bestReason && bestReason !== 'none' && (
-        <P>
-          {WARNING_ICON} Warning:{' '}
-          {IppPrinterStateReasonMessage[bestReason] ?? bestReason}
-        </P>
-      )}
-      <P>
-        {markerLow ? WARNING_ICON : CHECKBOX_ICON} Toner level:{' '}
-        {marker && marker.level >= 0 ? `${marker.level}%` : 'Unknown'}
-      </P>
-      {refreshButton}
-    </React.Fragment>
-  );
-}
-
 interface AccessibleControllerStatusProps {
-  accessibleController?: KioskBrowser.Device;
   diagnosticResults?: AccessibleControllerDiagnosticResults;
 }
 
 function AccessibleControllerStatus({
-  accessibleController,
   diagnosticResults,
 }: AccessibleControllerStatusProps) {
-  if (!accessibleController) {
-    return <P>{WARNING_ICON} No accessible controller connected.</P>;
-  }
-
   return (
     <React.Fragment>
       <P>{CHECKBOX_ICON} Accessible controller connected.</P>
@@ -257,22 +90,14 @@ function AccessibleControllerStatus({
 }
 
 export interface DiagnosticsScreenProps {
-  hardware: Hardware;
-  devices: Devices;
   onBackButtonPress: () => void;
 }
 
 export function DiagnosticsScreen({
-  hardware,
-  devices,
   onBackButtonPress,
 }: DiagnosticsScreenProps): JSX.Element {
-  // Since we show full-screen alerts for specific hardware states, there are
-  // certain cases that we will never see in this screen
-  assert(devices.printer);
-  assert(
-    !(devices.computer.batteryIsLow && !devices.computer.batteryIsCharging)
-  );
+  const batteryQuery = systemCallApi.getBatteryInfo.useQuery();
+  const battery = batteryQuery.data ?? undefined;
 
   const [
     accessibleControllerDiagnosticResults,
@@ -300,12 +125,9 @@ export function DiagnosticsScreen({
                 To navigate through the available actions, use the down arrow.
               </span>
               <H4 as="h2">Computer</H4>
-              <ComputerStatus computer={devices.computer} />
-              <H4 as="h2">Printer</H4>
-              <PrinterStatus hardware={hardware} />
+              <ComputerStatus battery={battery} />
               <H4 as="h2">Accessible Controller</H4>
               <AccessibleControllerStatus
-                accessibleController={devices.accessibleController}
                 diagnosticResults={accessibleControllerDiagnosticResults}
               />
             </Prose>

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.test.tsx
@@ -10,7 +10,6 @@ import {
 
 import {
   BooleanEnvironmentVariableName,
-  MemoryHardware,
   generateBallotStyleId,
   getFeatureFlagMock,
   singlePrecinctSelectionFor,
@@ -25,7 +24,6 @@ import { render } from '../../test/test_utils';
 
 import { PollWorkerScreen, PollworkerScreenProps } from './poll_worker_screen';
 import { fakeMachineConfig } from '../../test/helpers/fake_machine_config';
-import { fakeDevices } from '../../test/helpers/fake_devices';
 import { ApiMock, createApiMock } from '../../test/helpers/mock_api_client';
 import {
   fakeCardlessVoterAuth,
@@ -73,8 +71,6 @@ function renderScreen(
         pollsState="polls_open"
         ballotsPrintedCount={0}
         machineConfig={fakeMachineConfig()}
-        hardware={MemoryHardware.buildStandard()}
-        devices={fakeDevices()}
         reload={jest.fn()}
         precinctSelection={singlePrecinctSelectionFor(
           electionDefinition.election.precincts[0].id

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
@@ -12,7 +12,6 @@ import {
 import {
   Button,
   ButtonList,
-  Devices,
   HorizontalRule,
   Main,
   Modal,
@@ -35,7 +34,6 @@ import {
 } from '@votingworks/ui';
 
 import {
-  Hardware,
   getPollsTransitionDestinationState,
   getPollsStateName,
   getPollsTransitionAction,
@@ -151,8 +149,6 @@ export interface PollworkerScreenProps {
   pollsState: PollsState;
   ballotsPrintedCount: number;
   machineConfig: MachineConfig;
-  hardware: Hardware;
-  devices: Devices;
   reload: () => void;
   precinctSelection: PrecinctSelection;
 }
@@ -166,8 +162,6 @@ export function PollWorkerScreen({
   pollsState,
   ballotsPrintedCount,
   machineConfig,
-  hardware,
-  devices,
   hasVotes,
   reload,
   precinctSelection,
@@ -313,8 +307,6 @@ export function PollWorkerScreen({
   if (isDiagnosticsScreenOpen) {
     return (
       <DiagnosticsScreen
-        hardware={hardware}
-        devices={devices}
         onBackButtonPress={() => setIsDiagnosticsScreenOpen(false)}
       />
     );

--- a/apps/mark-scan/frontend/test/helpers/build_app.tsx
+++ b/apps/mark-scan/frontend/test/helpers/build_app.tsx
@@ -1,35 +1,23 @@
 import { mockBaseLogger, BaseLogger } from '@votingworks/logging';
-import { MemoryHardware } from '@votingworks/utils';
 import { render, RenderResult } from '../react_testing_library';
 import { App } from '../../src/app';
 import { createApiMock } from './mock_api_client';
 
 export function buildApp(apiMock: ReturnType<typeof createApiMock>): {
   logger: BaseLogger;
-  hardware: MemoryHardware;
   reload: () => void;
   renderApp: () => RenderResult;
 } {
   const logger = mockBaseLogger();
-  const hardware = MemoryHardware.build({
-    connectPrinter: true,
-    connectAccessibleController: true,
-  });
   const reload = jest.fn();
   function renderApp() {
     return render(
-      <App
-        hardware={hardware}
-        reload={reload}
-        logger={logger}
-        apiClient={apiMock.mockApiClient}
-      />
+      <App reload={reload} logger={logger} apiClient={apiMock.mockApiClient} />
     );
   }
 
   return {
     logger,
-    hardware,
     reload,
     renderApp,
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,7 +456,7 @@ importers:
         version: 3.0.0
       react-dev-utils:
         specifier: 12.0.1
-        version: 12.0.1(typescript@5.2.2)(webpack@5.88.2)
+        version: 12.0.1(eslint@8.49.0)(typescript@5.2.2)(webpack@5.88.2)
       react-dom:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
@@ -625,7 +625,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -909,7 +909,7 @@ importers:
         version: 1.0.3
       http-proxy-middleware:
         specifier: 1.0.6
-        version: 1.0.6
+        version: 1.0.6(debug@4.3.4)
       js-file-download:
         specifier: 0.4.12
         version: 0.4.12
@@ -1054,7 +1054,7 @@ importers:
         version: 29.6.2(@types/node@16.18.23)
       jest-environment-jsdom:
         specifier: ^29.6.2
-        version: 29.6.2
+        version: 29.6.2(canvas@2.9.1)
       jest-fetch-mock:
         specifier: ^3.0.3
         version: 3.0.3
@@ -1078,7 +1078,7 @@ importers:
         version: 3.0.0
       react-dev-utils:
         specifier: 12.0.1
-        version: 12.0.1(typescript@5.2.2)(webpack@5.88.2)
+        version: 12.0.1(eslint@8.49.0)(typescript@5.2.2)(webpack@5.88.2)
       react-refresh:
         specifier: ^0.9.0
         version: 0.9.0
@@ -1087,7 +1087,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
       type-fest:
         specifier: ^0.18.0
         version: 0.18.1
@@ -1498,7 +1498,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -1825,6 +1825,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^1.3.2
         version: 1.3.2
+      '@votingworks/backend':
+        specifier: workspace:*
+        version: link:../../../libs/backend
       '@votingworks/grout-test-utils':
         specifier: workspace:*
         version: link:../../../libs/grout/test-utils
@@ -1884,7 +1887,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -2277,7 +2280,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -2724,7 +2727,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -2775,7 +2778,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
 
   libs/@types/compress-commons:
     dependencies:
@@ -2849,7 +2852,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
 
   libs/auth:
     dependencies:
@@ -2964,7 +2967,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
       wait-for-expect:
         specifier: ^3.0.2
         version: 3.0.2
@@ -3130,7 +3133,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
 
   libs/ballot-encoder:
     dependencies:
@@ -3191,7 +3194,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
 
   libs/ballot-interpreter:
     dependencies:
@@ -3306,7 +3309,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
 
   libs/basics:
     dependencies:
@@ -3352,7 +3355,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
 
   libs/cdf-schema-builder:
     dependencies:
@@ -3404,7 +3407,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
 
   libs/converter-nh-accuvote:
     dependencies:
@@ -3589,7 +3592,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
 
   libs/custom-scanner:
     dependencies:
@@ -3665,7 +3668,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -3753,7 +3756,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
       zod:
         specifier: 3.14.4
         version: 3.14.4
@@ -3881,7 +3884,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
 
   libs/dev-dock/frontend:
     dependencies:
@@ -3987,7 +3990,7 @@ importers:
         version: 5.3.11(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
 
   libs/eslint-plugin-vx:
     dependencies:
@@ -4066,7 +4069,7 @@ importers:
         version: 18.2.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
 
   libs/fixtures:
     dependencies:
@@ -4118,7 +4121,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
 
   libs/fs:
     dependencies:
@@ -4197,7 +4200,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
 
   libs/grout:
     dependencies:
@@ -4258,7 +4261,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
 
   libs/grout/test-utils:
     dependencies:
@@ -4298,7 +4301,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
 
   libs/hmpb/layout:
     dependencies:
@@ -4383,7 +4386,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
 
   libs/hmpb/render-backend:
     dependencies:
@@ -4641,7 +4644,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
 
   libs/mark-flow-ui:
     dependencies:
@@ -4858,7 +4861,7 @@ importers:
         version: 5.3.11(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
       util:
         specifier: ^0.12.4
         version: 0.12.4
@@ -4898,7 +4901,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
 
   libs/monorepo-utils:
     dependencies:
@@ -4968,7 +4971,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
       typescript:
         specifier: 5.2.2
         version: 5.2.2
@@ -5083,7 +5086,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
 
   libs/res-to-ts:
     dependencies:
@@ -5138,7 +5141,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
 
   libs/test-utils:
     dependencies:
@@ -5223,7 +5226,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
 
   libs/types:
     dependencies:
@@ -5308,7 +5311,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
 
   libs/types-rs: {}
 
@@ -5587,7 +5590,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
       util:
         specifier: ^0.12.4
         version: 0.12.4
@@ -5660,7 +5663,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
 
   libs/utils:
     dependencies:
@@ -5781,7 +5784,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
 
   script:
     dependencies:
@@ -15804,16 +15807,6 @@ packages:
       inherits: 2.0.4
       readable-stream: 2.3.8
 
-  /follow-redirects@1.14.1:
-    resolution: {integrity: sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dev: false
-
   /follow-redirects@1.14.1(debug@4.3.4):
     resolution: {integrity: sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==}
     engines: {node: '>=4.0'}
@@ -15927,36 +15920,6 @@ packages:
       tapable: 1.1.3
       typescript: 5.2.2
       webpack: 5.88.2(esbuild@0.18.17)
-
-  /fork-ts-checker-webpack-plugin@6.5.2(typescript@5.2.2)(webpack@5.88.2):
-    resolution: {integrity: sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==}
-    engines: {node: '>=10', yarn: '>=1.0.0'}
-    peerDependencies:
-      eslint: '>= 6'
-      typescript: '>= 2.7'
-      vue-template-compiler: '*'
-      webpack: '>= 4'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-      vue-template-compiler:
-        optional: true
-    dependencies:
-      '@babel/code-frame': 7.22.5
-      '@types/json-schema': 7.0.12
-      chalk: 4.1.2
-      chokidar: 3.5.3
-      cosmiconfig: 6.0.0
-      deepmerge: 4.3.1
-      fs-extra: 9.1.0
-      glob: 7.2.3
-      memfs: 3.4.7
-      minimatch: 3.1.2
-      schema-utils: 2.7.0
-      semver: 7.3.2
-      tapable: 1.1.3
-      typescript: 5.2.2
-      webpack: 5.88.2(esbuild@0.17.11)
 
   /form-data@2.5.1:
     resolution: {integrity: sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==}
@@ -16759,19 +16722,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /http-proxy-middleware@1.0.6:
-    resolution: {integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==}
-    engines: {node: '>=8.0.0'}
-    dependencies:
-      '@types/http-proxy': 1.17.6
-      http-proxy: 1.18.1
-      is-glob: 4.0.3
-      lodash: 4.17.21
-      micromatch: 4.0.5
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
   /http-proxy-middleware@1.0.6(debug@4.3.4):
     resolution: {integrity: sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==}
     engines: {node: '>=8.0.0'}
@@ -16781,17 +16731,6 @@ packages:
       is-glob: 4.0.3
       lodash: 4.17.21
       micromatch: 4.0.5
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
-  /http-proxy@1.18.1:
-    resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
-    engines: {node: '>=8.0.0'}
-    dependencies:
-      eventemitter3: 4.0.7
-      follow-redirects: 1.14.1
-      requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
     dev: false
@@ -17662,29 +17601,6 @@ packages:
       jest-util: 29.6.2
       pretty-format: 29.6.2
 
-  /jest-environment-jsdom@29.6.2:
-    resolution: {integrity: sha512-7oa/+266AAEgkzae8i1awNEfTfjwawWKLpiw2XesZmaoVVj9u9t8JOYx18cG29rbPNtkUlZ8V4b5Jb36y/VxoQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    peerDependencies:
-      canvas: ^2.5.0
-    peerDependenciesMeta:
-      canvas:
-        optional: true
-    dependencies:
-      '@jest/environment': 29.6.2
-      '@jest/fake-timers': 29.6.2
-      '@jest/types': 29.6.1
-      '@types/jsdom': 20.0.1
-      '@types/node': 16.18.23
-      jest-mock: 29.6.2
-      jest-util: 29.6.2
-      jsdom: 20.0.1
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: true
-
   /jest-environment-jsdom@29.6.2(canvas@2.9.1):
     resolution: {integrity: sha512-7oa/+266AAEgkzae8i1awNEfTfjwawWKLpiw2XesZmaoVVj9u9t8JOYx18cG29rbPNtkUlZ8V4b5Jb36y/VxoQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -18108,47 +18024,6 @@ packages:
       write-file-atomic: 2.4.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /jsdom@20.0.1:
-    resolution: {integrity: sha512-pksjj7Rqoa+wdpkKcLzQRHhJCEE42qQhl/xLMUKHgoSejaKOdaXEAnqs6uDNwMl/fciHTzKeR8Wm8cw7N+g98A==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      canvas: ^2.5.0
-    peerDependenciesMeta:
-      canvas:
-        optional: true
-    dependencies:
-      abab: 2.0.6
-      acorn: 8.10.0
-      acorn-globals: 7.0.1
-      cssom: 0.5.0
-      cssstyle: 2.3.0
-      data-urls: 3.0.2
-      decimal.js: 10.4.1
-      domexception: 4.0.0
-      escodegen: 2.1.0
-      form-data: 4.0.0
-      html-encoding-sniffer: 3.0.0
-      http-proxy-agent: 5.0.0
-      https-proxy-agent: 5.0.1
-      is-potential-custom-element-name: 1.0.1
-      nwsapi: 2.2.2
-      parse5: 7.1.2
-      saxes: 6.0.0
-      symbol-tree: 3.2.4
-      tough-cookie: 4.1.2
-      w3c-xmlserializer: 3.0.0
-      webidl-conversions: 7.0.0
-      whatwg-encoding: 2.0.0
-      whatwg-mimetype: 3.0.0
-      whatwg-url: 11.0.0
-      ws: 8.15.1
-      xml-name-validator: 4.0.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
     dev: true
 
   /jsdom@20.0.1(canvas@2.9.1):
@@ -20416,47 +20291,6 @@ packages:
       - supports-color
       - vue-template-compiler
 
-  /react-dev-utils@12.0.1(typescript@5.2.2)(webpack@5.88.2):
-    resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      typescript: '>=2.7'
-      webpack: '>=4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@babel/code-frame': 7.22.5
-      address: 1.1.2
-      browserslist: 4.21.10
-      chalk: 4.1.2
-      cross-spawn: 7.0.3
-      detect-port-alt: 1.1.6
-      escape-string-regexp: 4.0.0
-      filesize: 8.0.7
-      find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.2(typescript@5.2.2)(webpack@5.88.2)
-      global-modules: 2.0.0
-      globby: 11.1.0
-      gzip-size: 6.0.0
-      immer: 9.0.15
-      is-root: 2.1.0
-      loader-utils: 3.2.0
-      open: 8.4.0
-      pkg-up: 3.1.0
-      prompts: 2.4.2
-      react-error-overlay: 6.0.11
-      recursive-readdir: 2.2.2
-      shell-quote: 1.7.3
-      strip-ansi: 6.0.1
-      text-table: 0.2.0
-      typescript: 5.2.2
-      webpack: 5.88.2(esbuild@0.17.11)
-    transitivePeerDependencies:
-      - eslint
-      - supports-color
-      - vue-template-compiler
-
   /react-docgen-typescript@2.2.2(typescript@5.2.2):
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
@@ -22286,30 +22120,6 @@ packages:
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
 
-  /terser-webpack-plugin@5.3.9(esbuild@0.17.11)(webpack@5.88.2):
-    resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      '@swc/core': '*'
-      esbuild: '*'
-      uglify-js: '*'
-      webpack: ^5.1.0
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      esbuild:
-        optional: true
-      uglify-js:
-        optional: true
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.18
-      esbuild: 0.17.11
-      jest-worker: 27.5.1
-      schema-utils: 3.3.0
-      serialize-javascript: 6.0.1
-      terser: 5.19.2
-      webpack: 5.88.2(esbuild@0.17.11)
-
   /terser-webpack-plugin@5.3.9(esbuild@0.18.17)(webpack@5.88.2):
     resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
     engines: {node: '>= 10.13.0'}
@@ -22586,6 +22396,7 @@ packages:
       semver: 7.5.4
       typescript: 5.2.2
       yargs-parser: 21.1.1
+    dev: true
 
   /ts-jest@29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2):
     resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
@@ -22621,77 +22432,6 @@ packages:
       semver: 7.5.4
       typescript: 5.2.2
       yargs-parser: 21.1.1
-    dev: true
-
-  /ts-jest@29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(jest@29.6.2)(typescript@5.2.2):
-    resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@jest/types': ^29.0.0
-      babel-jest: ^29.0.0
-      esbuild: '*'
-      jest: ^29.0.0
-      typescript: '>=4.3 <6'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@jest/types':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      '@babel/core': 7.22.9
-      '@jest/types': 29.6.1
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.6.2(@types/node@16.18.23)
-      jest-util: 29.6.2
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.5.4
-      typescript: 5.2.2
-      yargs-parser: 21.1.1
-    dev: true
-
-  /ts-jest@29.1.1(@babel/core@7.22.9)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2):
-    resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@jest/types': ^29.0.0
-      babel-jest: ^29.0.0
-      esbuild: '*'
-      jest: ^29.0.0
-      typescript: '>=4.3 <6'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@jest/types':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      '@babel/core': 7.22.9
-      bs-logger: 0.2.6
-      esbuild: 0.17.11
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.6.2(@types/node@16.18.23)
-      jest-util: 29.6.2
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.5.4
-      typescript: 5.2.2
-      yargs-parser: 21.1.1
-    dev: true
 
   /tsconfig-paths@3.14.1:
     resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}
@@ -23415,45 +23155,6 @@ packages:
       webpack-sources: 1.4.3
     transitivePeerDependencies:
       - supports-color
-
-  /webpack@5.88.2(esbuild@0.17.11):
-    resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    peerDependencies:
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack-cli:
-        optional: true
-    dependencies:
-      '@types/eslint-scope': 3.7.4
-      '@types/estree': 1.0.1
-      '@webassemblyjs/ast': 1.11.6
-      '@webassemblyjs/wasm-edit': 1.11.6
-      '@webassemblyjs/wasm-parser': 1.11.6
-      acorn: 8.10.0
-      acorn-import-assertions: 1.9.0(acorn@8.10.0)
-      browserslist: 4.21.10
-      chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.15.0
-      es-module-lexer: 1.3.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(esbuild@0.17.11)(webpack@5.88.2)
-      watchpack: 2.4.0
-      webpack-sources: 3.2.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
 
   /webpack@5.88.2(esbuild@0.18.17):
     resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}


### PR DESCRIPTION
## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
