### PR TITLE
Add script for programming a prod sys admin Java Card without a VxAdmin

### DIFF
--- a/libs/auth/README.md
+++ b/libs/auth/README.md
@@ -92,6 +92,18 @@ relevant env vars for local development and then calls the base script:
 The initial Java Card configuration script needs to be run before this script
 can be run. This script will remind you if you haven't done so.
 
+#### Programming a Production System Administrator Java Card without a VxAdmin
+
+A special variant of the above script exists for programming a production system
+administrator Java Card without a VxAdmin. This is useful for preparing backup
+cards after we've shipped a VxAdmin.
+
+```
+VX_MACHINE_JURISDICTION=<jurisdiction> \
+  VX_PRIVATE_KEY_PATH=/path/to/vx-private-key.pem \
+  ./scripts/program-production-system-administrator-java-card-without-vx-admin
+```
+
 ### Java Card Detail Reading Script
 
 This script reads Java Card details, namely environment, jurisdiction, user
@@ -176,7 +188,7 @@ development and testing.
 
 ```
 # With a card reader connected and a Common Access Card in the card reader
-./scripts/cac-get-cert
+./scripts/cac/cac-get-cert
 ```
 
 The script prints the certificate to stdout in PEM format by default. Use the

--- a/libs/auth/scripts/generate-dev-keys-and-certs
+++ b/libs/auth/scripts/generate-dev-keys-and-certs
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 
 require('esbuild-runner/register');
-require('./generate_dev_keys_and_certs').main();
+require('./generate_dev_keys_and_certs').main(process.argv.slice(2));

--- a/libs/auth/scripts/mock-card
+++ b/libs/auth/scripts/mock-card
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 
 require('esbuild-runner/register');
-require('./mock_card').main();
+require('./mock_card').main(process.argv.slice(2));

--- a/libs/auth/scripts/program-production-system-administrator-java-card-without-vx-admin
+++ b/libs/auth/scripts/program-production-system-administrator-java-card-without-vx-admin
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+require('esbuild-runner/register');
+require('./program_production_system_administrator_java_card_without_vx_admin').main();

--- a/libs/auth/scripts/program_production_system_administrator_java_card_without_vx_admin.ts
+++ b/libs/auth/scripts/program_production_system_administrator_java_card_without_vx_admin.ts
@@ -1,0 +1,83 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { DirResult, dirSync } from 'tmp';
+import { extractErrorMessage } from '@votingworks/basics';
+
+import { PROD_VX_CERT_AUTHORITY_CERT_PATH } from '../src';
+import { CERT_EXPIRY_IN_DAYS, constructMachineCertSubject } from '../src/certs';
+import { createCert } from '../src/cryptography';
+import { getRequiredEnvVar } from '../src/env_vars';
+import { JavaCard } from '../src/java_card';
+import {
+  generatePrivateKey,
+  programSystemAdministratorJavaCard,
+} from './utils';
+
+const jurisdiction = getRequiredEnvVar('VX_MACHINE_JURISDICTION');
+const vxPrivateKeyPath = getRequiredEnvVar('VX_PRIVATE_KEY_PATH');
+
+async function instantiateJavaCardWithOneOffVxAdminPrivateKeyAndCertAuthorityCert(
+  tempDirectoryPath: string
+): Promise<JavaCard> {
+  const vxAdminPrivateKey = await generatePrivateKey();
+  const vxAdminPrivateKeyPath = path.join(
+    tempDirectoryPath,
+    'vx-admin-private-key.pem'
+  );
+  await fs.writeFile(vxAdminPrivateKeyPath, vxAdminPrivateKey);
+
+  const vxAdminCertAuthorityCert = await createCert({
+    certKeyInput: {
+      type: 'private',
+      key: { source: 'file', path: vxAdminPrivateKeyPath },
+    },
+    certSubject: constructMachineCertSubject('admin', jurisdiction),
+    certType: 'cert_authority_cert',
+    expiryInDays: CERT_EXPIRY_IN_DAYS.MACHINE_VX_CERT,
+    signingCertAuthorityCertPath: PROD_VX_CERT_AUTHORITY_CERT_PATH,
+    signingPrivateKey: { source: 'file', path: vxPrivateKeyPath },
+  });
+  const vxAdminCertAuthorityCertPath = path.join(
+    tempDirectoryPath,
+    'vx-admin-cert-authority-cert.pem'
+  );
+  await fs.writeFile(vxAdminCertAuthorityCertPath, vxAdminCertAuthorityCert);
+
+  const card = new JavaCard({
+    cardProgrammingConfig: {
+      vxAdminCertAuthorityCertPath,
+      vxAdminPrivateKey: { source: 'file', path: vxAdminPrivateKeyPath },
+    },
+    vxCertAuthorityCertPath: PROD_VX_CERT_AUTHORITY_CERT_PATH,
+  });
+
+  return card;
+}
+
+/**
+ * A script for programming a production system administrator Java Card without a VxAdmin. This is
+ * useful for preparing backup cards after we've shipped a VxAdmin.
+ */
+export async function main(): Promise<void> {
+  let exitCode: number = 0;
+  let tempDirectory: DirResult | undefined;
+  try {
+    tempDirectory = dirSync({ unsafeCleanup: true });
+    const card =
+      await instantiateJavaCardWithOneOffVxAdminPrivateKeyAndCertAuthorityCert(
+        tempDirectory.name
+      );
+    await programSystemAdministratorJavaCard({
+      card,
+      jurisdiction,
+      isProduction: true,
+    });
+  } catch (error) {
+    console.error(`❌ ${extractErrorMessage(error)}`);
+    exitCode = 1;
+  } finally {
+    tempDirectory?.removeCallback();
+  }
+  // Smart card scripts require an explicit exit, even on success, or else they hang
+  process.exit(exitCode);
+}

--- a/libs/auth/scripts/program_production_system_administrator_java_card_without_vx_admin.ts
+++ b/libs/auth/scripts/program_production_system_administrator_java_card_without_vx_admin.ts
@@ -76,6 +76,7 @@ export async function main(): Promise<void> {
     console.error(`❌ ${extractErrorMessage(error)}`);
     exitCode = 1;
   } finally {
+    // Delete temp directory and contained files
     tempDirectory?.removeCallback();
   }
   // Smart card scripts require an explicit exit, even on success, or else they hang

--- a/libs/auth/scripts/program_production_system_administrator_java_card_without_vx_admin.ts
+++ b/libs/auth/scripts/program_production_system_administrator_java_card_without_vx_admin.ts
@@ -1,6 +1,6 @@
 import fs from 'fs/promises';
 import path from 'path';
-import { DirResult, dirSync } from 'tmp';
+import tmp from 'tmp';
 import { extractErrorMessage } from '@votingworks/basics';
 
 import { PROD_VX_CERT_AUTHORITY_CERT_PATH } from '../src';
@@ -60,9 +60,9 @@ async function instantiateJavaCardWithOneOffVxAdminPrivateKeyAndCertAuthorityCer
  */
 export async function main(): Promise<void> {
   let exitCode: number = 0;
-  let tempDirectory: DirResult | undefined;
+  let tempDirectory: tmp.DirResult | undefined;
   try {
-    tempDirectory = dirSync({ unsafeCleanup: true });
+    tempDirectory = tmp.dirSync({ unsafeCleanup: true });
     const card =
       await instantiateJavaCardWithOneOffVxAdminPrivateKeyAndCertAuthorityCert(
         tempDirectory.name

--- a/libs/auth/scripts/program_system_administrator_java_card.ts
+++ b/libs/auth/scripts/program_system_administrator_java_card.ts
@@ -1,11 +1,9 @@
 import { assert, extractErrorMessage } from '@votingworks/basics';
-import { generatePin, hyphenatePin } from '@votingworks/utils';
 
-import { ResponseApduError } from '../src/apdu';
 import { getRequiredEnvVar } from '../src/env_vars';
 import { JavaCard } from '../src/java_card';
 import { DEV_JURISDICTION } from '../src/jurisdictions';
-import { waitForReadyCardStatus } from './utils';
+import { programSystemAdministratorJavaCard } from './utils';
 
 const nodeEnv = getRequiredEnvVar('NODE_ENV');
 assert(
@@ -17,37 +15,6 @@ const jurisdiction = isProduction
   ? getRequiredEnvVar('VX_MACHINE_JURISDICTION')
   : DEV_JURISDICTION;
 
-const initialJavaCardConfigurationScriptReminder = `
-${
-  isProduction
-    ? 'Have you run this card through the configure-java-card yet?'
-    : 'Have you run this card through the configure-dev-java-card script yet?'
-}
-If not, that's likely the cause of this error.
-Run that and then retry.
-`;
-
-async function programSystemAdministratorJavaCard(): Promise<void> {
-  const card = new JavaCard(); // Uses NODE_ENV to determine which config to use
-  await waitForReadyCardStatus(card);
-
-  const pin = isProduction ? generatePin() : '000000';
-  try {
-    await card.program({
-      user: { role: 'system_administrator', jurisdiction },
-      pin,
-    });
-  } catch (error) {
-    if (error instanceof ResponseApduError) {
-      throw new Error(
-        `${error.message}\n${initialJavaCardConfigurationScriptReminder}`
-      );
-    }
-    throw error;
-  }
-  console.log(`✅ Done! Card PIN is ${hyphenatePin(pin)}.`);
-}
-
 /**
  * A script for programming a first system administrator Java Card to bootstrap both production
  * machine usage and local development.
@@ -57,7 +24,12 @@ async function programSystemAdministratorJavaCard(): Promise<void> {
  */
 export async function main(): Promise<void> {
   try {
-    await programSystemAdministratorJavaCard();
+    const card = new JavaCard(); // Uses NODE_ENV to determine which config to use
+    await programSystemAdministratorJavaCard({
+      card,
+      isProduction,
+      jurisdiction,
+    });
     process.exit(0); // Smart card scripts require an explicit exit or else they hang
   } catch (error) {
     console.error(`❌ ${extractErrorMessage(error)}`);

--- a/libs/auth/scripts/utils.ts
+++ b/libs/auth/scripts/utils.ts
@@ -1,6 +1,19 @@
+import { Buffer } from 'buffer';
 import { sleep } from '@votingworks/basics';
+import { generatePin, hyphenatePin } from '@votingworks/utils';
 
+import { ResponseApduError } from '../src/apdu';
 import { CardStatusReady, StatefulCard } from '../src/card';
+import { openssl } from '../src/cryptography';
+import { JavaCard } from '../src/java_card';
+
+/**
+ * Generates an ECC private key and returns the private key contents in a buffer. The key is not
+ * stored in a TPM.
+ */
+export async function generatePrivateKey(): Promise<Buffer> {
+  return await openssl(['ecparam', '-genkey', '-name', 'prime256v1', '-noout']);
+}
 
 /**
  * Waits for a card to have a ready status
@@ -20,4 +33,45 @@ export async function waitForReadyCardStatus<T>(
     throw new Error(`Card status not "ready" after ${waitTimeSeconds} seconds`);
   }
   return cardStatus;
+}
+
+/**
+ * Programs a system administrator Java Card
+ */
+export async function programSystemAdministratorJavaCard({
+  card,
+  isProduction,
+  jurisdiction,
+}: {
+  card: JavaCard;
+  isProduction: boolean;
+  jurisdiction: string;
+}): Promise<void> {
+  const initialJavaCardConfigurationScriptReminder = `
+${
+  isProduction
+    ? 'Have you run this card through the configure-java-card script yet?'
+    : 'Have you run this card through the configure-dev-java-card script yet?'
+}
+If not, that's likely the cause of this error.
+Run that and then retry.
+`;
+
+  await waitForReadyCardStatus(card);
+
+  const pin = isProduction ? generatePin() : '000000';
+  try {
+    await card.program({
+      user: { role: 'system_administrator', jurisdiction },
+      pin,
+    });
+  } catch (error) {
+    if (error instanceof ResponseApduError) {
+      throw new Error(
+        `${error.message}\n${initialJavaCardConfigurationScriptReminder}`
+      );
+    }
+    throw error;
+  }
+  console.log(`✅ Done! Card PIN is ${hyphenatePin(pin)}.`);
 }

--- a/libs/auth/src/certs.ts
+++ b/libs/auth/src/certs.ts
@@ -166,6 +166,7 @@ const CustomCertFieldsSchema: z.ZodSchema<CustomCertFields> = z.union([
  * Cert expiries in days. Must be integers.
  */
 export const CERT_EXPIRY_IN_DAYS = {
+  MACHINE_VX_CERT: 365 * 100, // 100 years
   CARD_VX_CERT: 365 * 100, // 100 years
   SYSTEM_ADMINISTRATOR_CARD_VX_ADMIN_CERT: 365 * 5, // 5 years
   ELECTION_CARD_VX_ADMIN_CERT: Math.round(365 * 0.5), // 6 months


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/3762

This PR adds a script for programming a prod sys admin Java Card without a VxAdmin. This is useful for preparing backup
cards after we've shipped a VxAdmin.

This is possible because the VxAdmin cert on a card does not have to exactly match the cert on the VxAdmin; it just needs to have the same jurisdiction (and be signed by VotingWorks, of course).

## Testing Plan

- [x] Tested manually