### PR TITLE
always interpret bmd ballots in mark-scan

### DIFF
--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -15,6 +15,7 @@ import { backendWaitFor, mockOf } from '@votingworks/test-utils';
 import { sleep } from '@votingworks/basics';
 import {
   electionGeneralDefinition,
+  electionGridLayoutNewHampshireHudsonFixtures,
   systemSettings,
 } from '@votingworks/fixtures';
 import {
@@ -309,6 +310,25 @@ test('ballot box empty flow', async () => {
 
   machine.confirmBallotBoxEmptied();
   await waitForStatus('not_accepting_paper');
+});
+
+test('elections with grid layouts still try to interpret BMD ballots', async () => {
+  const { electionDefinition } = electionGridLayoutNewHampshireHudsonFixtures;
+
+  workspace.store.setElectionAndJurisdiction({
+    electionData: electionDefinition.electionData,
+    jurisdiction: TEST_JURISDICTION,
+  });
+  workspace.store.setPrecinctSelection(
+    singlePrecinctSelectionFor(electionDefinition.election.precincts[0].id)
+  );
+
+  const ballotPdfData = await readBallotFixture();
+  const scannedBallotFixtureFilepaths = getSampleBallotFilepaths();
+  await executePrintBallotAndAssert(
+    ballotPdfData,
+    scannedBallotFixtureFilepaths
+  );
 });
 
 test('blank page interpretation', async () => {

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -24,7 +24,7 @@ import { Optional, assert, assertDefined } from '@votingworks/basics';
 import { SheetOf } from '@votingworks/types';
 import {
   InterpretFileResult,
-  interpretSheet,
+  interpretBmdBallot,
 } from '@votingworks/ballot-interpreter';
 import { LogEventId, LogLine, BaseLogger } from '@votingworks/logging';
 import { InsertedSmartCardAuthApi } from '@votingworks/auth';
@@ -380,16 +380,13 @@ function loadMetadataAndInterpretBallot(
     store.getSystemSettings()
   );
 
-  return interpretSheet(
-    {
-      electionDefinition,
-      precinctSelection,
-      testMode: store.getTestMode(),
-      markThresholds,
-      adjudicationReasons: precinctScanAdjudicationReasons,
-    },
-    scannedImagePaths
-  );
+  return interpretBmdBallot(scannedImagePaths, {
+    electionDefinition,
+    precinctSelection,
+    testMode: store.getTestMode(),
+    markThresholds,
+    adjudicationReasons: precinctScanAdjudicationReasons,
+  });
 }
 
 export function buildMachine(

--- a/libs/ballot-interpreter/src/interpret.ts
+++ b/libs/ballot-interpreter/src/interpret.ts
@@ -590,7 +590,7 @@ async function interpretHmpb(
  * Interpret a BMD ballot sheet and convert the result into the result format
  * used by the rest of VxSuite.
  */
-async function interpretBmdBallot(
+export async function interpretBmdBallot(
   sheet: SheetOf<string>,
   options: InterpreterOptions
 ): Promise<SheetOf<InterpretFileResult>> {


### PR DESCRIPTION
## Overview
Hotfixes a bug in VxMarkScan where elections with `gridLayouts` (ie. all elections exported from VxDesign) would always try to interpret ballots as HMPBs.

Note that this does not fix the underlying bug, so users of VxMark + VxScan will still have this problem. A long term solution is tracked in https://github.com/votingworks/vxsuite/issues/4659.

## Demo Video or Screenshot
N/A

## Testing Plan
Added test for interpreting a BMD ballot using a `gridLayouts` election

## Checklist

N/A
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
