### PR TITLE
image-utils: Add toImageBuffer

### DIFF
--- a/libs/image-utils/src/image_data.ts
+++ b/libs/image-utils/src/image_data.ts
@@ -319,6 +319,22 @@ export async function writeImageData(
 }
 
 /**
+ * Converts an ImageData to an image Buffer.
+ */
+export function toImageBuffer(
+  imageData: ImageData,
+  mimeType: 'image/png' | 'image/jpeg' = 'image/png'
+): Buffer {
+  const canvas = createCanvas(imageData.width, imageData.height);
+  const context = canvas.getContext('2d');
+  context.putImageData(ensureImageData(imageData), 0, 0);
+  // Help TS match the union type branches to overloaded function signatures
+  return mimeType === 'image/png'
+    ? canvas.toBuffer(mimeType)
+    : canvas.toBuffer(mimeType);
+}
+
+/**
  * Extracts image data from an image.
  */
 export function toImageData(

--- a/libs/image-utils/src/jest_pdf_snapshot.ts
+++ b/libs/image-utils/src/jest_pdf_snapshot.ts
@@ -1,8 +1,7 @@
 import { readFile } from 'fs/promises';
-import { tmpNameSync } from 'tmp';
 import { Buffer } from 'buffer';
 import { pdfToImages } from './pdf_to_images';
-import { writeImageData } from './image_data';
+import { toImageBuffer } from './image_data';
 
 /**
  * Options for `toMatchPdfSnapshot`.
@@ -28,9 +27,7 @@ export async function toMatchPdfSnapshot(
     typeof received === 'string' ? await readFile(received) : received;
   const pdfPages = pdfToImages(pdfContents, { scale: 200 / 72 });
   for await (const { page, pageNumber } of pdfPages) {
-    const path = tmpNameSync({ postfix: '.png' });
-    await writeImageData(path, page);
-    const imageBuffer = await readFile(path);
+    const imageBuffer = toImageBuffer(page);
     expect(imageBuffer).toMatchImageSnapshot({
       customSnapshotIdentifier: options.customSnapshotIdentifier
         ? `${options.customSnapshotIdentifier}-${pageNumber}`


### PR DESCRIPTION
## Overview

Adds `toImageBuffer` to convert `ImageData` to a PNG or JPEG image `Buffer`. This enables easy usage with `toMatchImageSnapshot`, which expects a `Buffer`.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
