### PR TITLE
[VxDesign] Fix broken-up comment in backend types file

### DIFF
--- a/apps/design/backend/src/types.ts
+++ b/apps/design/backend/src/types.ts
@@ -1,8 +1,3 @@
-// We create new types for precincts that can be split, since the existing
-// election types don't support this. We will likely want to extend the existing
-// types to support it in the future, but doing it separately for now allows us
-// to experiment and learn more first. We'll store these separately in the
-
 import { NhCustomContent } from '@votingworks/hmpb-layout';
 import {
   BallotStyle as VxfBallotStyle,
@@ -30,6 +25,10 @@ export function getAllBallotLanguages(
   return [...uniqueLanguages];
 }
 
+// We create new types for precincts that can be split, since the existing
+// election types don't support this. We will likely want to extend the existing
+// types to support it in the future, but doing it separately for now allows us
+// to experiment and learn more first. We'll store these separately in the
 // database and ignore Election.precincts most of the app.
 export interface PrecinctWithoutSplits {
   districtIds: readonly DistrictId[];


### PR DESCRIPTION
## Overview

Fixing comment block that got split up in https://github.com/votingworks/vxsuite/pull/4657 while moving types to a separate file.

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
