### PR TITLE
libs/ui: Increase desktop modal spacing

### DIFF
--- a/libs/ui/src/modal.tsx
+++ b/libs/ui/src/modal.tsx
@@ -20,7 +20,7 @@ export enum ModalWidth {
 }
 
 const CONTENT_SPACING_VALUES_REM: Readonly<Record<SizeMode, number>> = {
-  desktop: 0.5,
+  desktop: 0.75,
   touchSmall: 0.5,
   touchMedium: 0.5,
   touchLarge: 0.25,


### PR DESCRIPTION
## Overview

In #4612, the spacing around the modal content accidentally got reduced. Originally, there were separate padding values specified for different parts of the modal (see below). In this new scheme, we use one spacing value throughout the design, so bumping that up to 0.75rem makes it look pretty balanced.

## Demo Video or Screenshot

Before #4612
<img width="573" alt="Screenshot 2024-03-11 at 11 38 13 AM" src="https://github.com/votingworks/vxsuite/assets/530106/81d35f7e-a1db-433a-ab8c-7010faf05a0c">


After #4612
<img width="574" alt="Screenshot 2024-03-11 at 11 36 40 AM" src="https://github.com/votingworks/vxsuite/assets/530106/14f867e3-b970-48c6-b04e-662c2cee1c7b">


After this PR
<img width="573" alt="Screenshot 2024-03-11 at 11 35 11 AM" src="https://github.com/votingworks/vxsuite/assets/530106/08ed600b-43a8-432c-bd4a-72c7a7098429">




## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
