### PR TITLE
[i18n/Audio] Content bug fixes

### DIFF
--- a/apps/design/backend/src/language_and_audio/utils.test.ts
+++ b/apps/design/backend/src/language_and_audio/utils.test.ts
@@ -86,7 +86,28 @@ test.each<{ input: string; expectedOutput: Segment[] }>([
       { content: '{{count}}', isInterpolated: true },
     ],
   },
-])('splitInterpolatedText - $input', ({ input, expectedOutput }) => {
+  {
+    input: 'Vote for {{count}}...',
+    expectedOutput: [
+      { content: 'Vote for', isInterpolated: false },
+      { content: '{{count}}', isInterpolated: true },
+    ],
+  },
+  {
+    input: '0 {{unit}} remaining.',
+    expectedOutput: [
+      { content: '0', isInterpolated: false },
+      { content: '{{unit}}', isInterpolated: true },
+      { content: 'remaining.', isInterpolated: false },
+    ],
+  },
+  { input: ' ', expectedOutput: [] },
+  { input: "'", expectedOutput: [{ content: "'", isInterpolated: false }] },
+  { input: '"', expectedOutput: [{ content: '"', isInterpolated: false }] },
+  { input: ',', expectedOutput: [{ content: ',', isInterpolated: false }] },
+  { input: '.', expectedOutput: [{ content: '.', isInterpolated: false }] },
+  { input: '-', expectedOutput: [{ content: '-', isInterpolated: false }] },
+])('splitInterpolatedText - "$input"', ({ input, expectedOutput }) => {
   expect(splitInterpolatedText(input)).toEqual(expectedOutput);
 });
 

--- a/apps/design/backend/src/language_and_audio/utils.ts
+++ b/apps/design/backend/src/language_and_audio/utils.ts
@@ -36,20 +36,20 @@ export function splitInterpolatedText(text: string): Segment[] {
       segments.push({ content: interpolatedSegments[i], isInterpolated: true });
     }
   }
-  const segmentsCleaned = segments
-    .map(({ content, isInterpolated }) => ({
-      content: content.trim(),
-      isInterpolated,
-    }))
-    .filter(
-      ({ content }) =>
-        content !== '' &&
-        content !== '.' &&
-        content !== '!' &&
-        content !== '?' &&
-        content !== ':'
-    );
-  return segmentsCleaned;
+
+  const segmentsCleaned = segments.map(({ content, isInterpolated }) => ({
+    content: content.trim(),
+    isInterpolated,
+  }));
+
+  // Allow non-empty, single-segment strings (like punctuation) through without
+  // further cleaning:
+  if (segmentsCleaned.length === 1 && segmentsCleaned[0].content.length > 0) {
+    return segmentsCleaned;
+  }
+
+  // Remove extraneous non-word segments from multi-segment strings:
+  return segmentsCleaned.filter(({ content }) => /[a-z0-9]/i.test(content));
 }
 
 /**

--- a/libs/ui/src/bmd_paper_ballot.dual_language.test.tsx
+++ b/libs/ui/src/bmd_paper_ballot.dual_language.test.tsx
@@ -158,7 +158,6 @@ describe('non-English ballot style', () => {
     expectSingleLanguageString({
       key: ElectionStringKey.COUNTY_NAME,
       languageCode: LanguageCode.SPANISH,
-      subKey: election.county.id,
     });
     expectSingleLanguageString({
       key: ElectionStringKey.STATE_NAME,

--- a/libs/ui/src/bmd_paper_ballot.stories.tsx
+++ b/libs/ui/src/bmd_paper_ballot.stories.tsx
@@ -47,9 +47,7 @@ const election: Election = {
 
 const TEST_UI_STRINGS: UiStringsPackage = {
   [LanguageCode.CHINESE_SIMPLIFIED]: {
-    [ElectionStringKey.COUNTY_NAME]: {
-      franklin: '富兰克林县',
-    },
+    [ElectionStringKey.COUNTY_NAME]: '富兰克林县',
     [ElectionStringKey.CONTEST_OPTION_LABEL]: Object.fromEntries(
       election.contests
         .filter((contest): contest is YesNoContest => contest.type === 'yesno')

--- a/libs/ui/src/ui_strings/election_strings.tsx
+++ b/libs/ui/src/ui_strings/election_strings.tsx
@@ -76,9 +76,7 @@ export const electionStrings = {
   ),
 
   [Key.COUNTY_NAME]: (county: County) => (
-    <UiString uiStringKey={Key.COUNTY_NAME} uiStringSubKey={county.id}>
-      {county.name}
-    </UiString>
+    <UiString uiStringKey={Key.COUNTY_NAME}>{county.name}</UiString>
   ),
 
   [Key.DISTRICT_NAME]: (district: District) => (


### PR DESCRIPTION
## Overview

Addressing a couple of content issues:
- Fixing the election string key for county name to use a single-level key
- Allowing translation/speech synthesis to run for punctuation strings (specifically, period `.`) to support audio for the BMD virtual keyboard.

## Demo Video or Screenshot
### County Name Before/After:

| Before | After |
|--|--|
| <img width="514" alt="Screenshot 2024-03-12 at 09 49 24" src="https://github.com/votingworks/vxsuite/assets/264902/5f16b391-ef95-4d10-8054-18ff3cd0b22c"> | <img width="514" alt="Screenshot 2024-03-12 at 09 48 16" src="https://github.com/votingworks/vxsuite/assets/264902/e14acc2a-734a-492a-9eed-e54081a09f5f"> |

## Testing Plan
- Updated tests, manual verification

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
