### PR TITLE
ci: update docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,13 +9,13 @@ orbs:
 executors:
   nodejs-browsers:
     docker:
-      - image: votingworks/cimg-debian12-browsers:3.0.1
+      - image: votingworks/cimg-debian12-browsers:3.0.2
         auth:
           username: $VX_DOCKER_USERNAME
           password: $VX_DOCKER_PASSWORD
   nodejs:
     docker:
-      - image: votingworks/cimg-debian12:3.0.1
+      - image: votingworks/cimg-debian12:3.0.2
         auth:
           username: $VX_DOCKER_USERNAME
           password: $VX_DOCKER_PASSWORD

--- a/libs/monorepo-utils/src/circleci.ts
+++ b/libs/monorepo-utils/src/circleci.ts
@@ -136,13 +136,13 @@ orbs:
 executors:
   nodejs-browsers:
     docker:
-      - image: votingworks/cimg-debian12-browsers:3.0.1
+      - image: votingworks/cimg-debian12-browsers:3.0.2
         auth:
           username: $VX_DOCKER_USERNAME
           password: $VX_DOCKER_PASSWORD
   nodejs:
     docker:
-      - image: votingworks/cimg-debian12:3.0.1
+      - image: votingworks/cimg-debian12:3.0.2
         auth:
           username: $VX_DOCKER_USERNAME
           password: $VX_DOCKER_PASSWORD


### PR DESCRIPTION
## Overview
The main change is to update Rust from 1.72.0 to 1.76.0.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated