### PR TITLE
mark-scan: Instructions for early ballot removal

### DIFF
--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -247,6 +247,12 @@ export function buildApi(
       return sheetInterpretation[0].interpretation;
     },
 
+    confirmSessionEnd(): void {
+      assert(stateMachine);
+
+      stateMachine.confirmSessionEnd();
+    },
+
     validateBallot(): void {
       assert(stateMachine);
 

--- a/apps/mark-scan/backend/src/custom-paper-handler/types.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/types.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 export type SimpleStatus =
   | 'accepting_paper'
   | 'ballot_accepted'
+  | 'ballot_removed_during_presentation'
   | 'blank_page_interpretation'
   | 'ejecting_to_front'
   | 'ejecting_to_rear'
@@ -29,6 +30,7 @@ export type SimpleStatus =
 export const SimpleStatusSchema: z.ZodSchema<SimpleStatus> = z.union([
   z.literal('accepting_paper'),
   z.literal('ballot_accepted'),
+  z.literal('ballot_removed_during_presentation'),
   z.literal('blank_page_interpretation'),
   z.literal('ejecting_to_front'),
   z.literal('ejecting_to_rear'),

--- a/apps/mark-scan/frontend/.codemod.bookmark
+++ b/apps/mark-scan/frontend/.codemod.bookmark
@@ -1,1 +1,0 @@
-./build/assets/index.c1222e2b.js:31135

--- a/apps/mark-scan/frontend/src/api.ts
+++ b/apps/mark-scan/frontend/src/api.ts
@@ -401,6 +401,19 @@ export const validateBallot = {
   },
 } as const;
 
+export const confirmSessionEnd = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.confirmSessionEnd, {
+      async onSuccess() {
+        await queryClient.invalidateQueries(getStateMachineState.queryKey());
+        await queryClient.invalidateQueries(getInterpretation.queryKey());
+      },
+    });
+  },
+} as const;
+
 export const invalidateBallot = {
   useMutation() {
     const apiClient = useApiClient();

--- a/apps/mark-scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/mark-scan/frontend/test/helpers/mock_api_client.tsx
@@ -225,6 +225,10 @@ export function createApiMock() {
       mockApiClient.getInterpretation.expectCallWith().resolves(interpretation);
     },
 
+    expectConfirmSessionEnd(): void {
+      mockApiClient.confirmSessionEnd.expectCallWith().resolves();
+    },
+
     expectValidateBallot(): void {
       mockApiClient.validateBallot.expectCallWith().resolves();
     },

--- a/libs/mark-flow-ui/src/pages/cast_ballot_page.tsx
+++ b/libs/mark-flow-ui/src/pages/cast_ballot_page.tsx
@@ -55,10 +55,12 @@ const InstructionImageContainer = styled.div`
 
 interface Props {
   hidePostVotingInstructions: () => void;
+  printingCompleted?: boolean;
 }
 
 export function CastBallotPage({
   hidePostVotingInstructions,
+  printingCompleted,
 }: Props): JSX.Element {
   return (
     <VoterScreen
@@ -75,7 +77,11 @@ export function CastBallotPage({
     >
       <ReadOnLoad>
         <H1>{appStrings.titleBmdCastBallotScreen()}</H1>
-        <P>{appStrings.instructionsBmdCastBallotPreamble()}</P>
+        <P>
+          {printingCompleted
+            ? appStrings.instructionsBmdCastBallotPreamblePostPrint()
+            : appStrings.instructionsBmdCastBallotPreamble()}
+        </P>
         <Instructions>
           <ListItem>
             <InstructionImageContainer>

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -214,6 +214,13 @@ export const appStrings = {
     </UiString>
   ),
 
+  instructionsBmdCastBallotPreamblePostPrint: () => (
+    <UiString uiStringKey="instructionsBmdCastBallotPreamblePostPrint">
+      Your official ballot has been removed from the printer. Complete the
+      following steps to finish voting:
+    </UiString>
+  ),
+
   instructionsBmdCastBallotStep1: () => (
     <UiString uiStringKey="instructionsBmdCastBallotStep1">
       1. Verify your official ballot.

--- a/libs/ui/src/ui_strings/app_strings_catalog/latest.json
+++ b/libs/ui/src/ui_strings/app_strings_catalog/latest.json
@@ -49,6 +49,7 @@
   "instructionsAudioMuteButton": "Press the select button to mute all audio.",
   "instructionsBmdBallotNavigation": "When voting with the text-to-speech audio, use the accessible controller to navigate your ballot. To navigate through the contests, use the left and right buttons. To navigate through contest choices, use the up and down buttons. To select or unselect a contest choice as your vote, use the select button. Press the right button now to advance to the first contest.",
   "instructionsBmdCastBallotPreamble": "Your official ballot is printing. Complete the following steps to finish voting:",
+  "instructionsBmdCastBallotPreamblePostPrint": "Your official ballot has been removed from the printer. Complete the following steps to finish voting:",
   "instructionsBmdCastBallotStep1": "1. Verify your official ballot.",
   "instructionsBmdCastBallotStep2": "2. Scan your official ballot.",
   "instructionsBmdContestNavigation": "To navigate through the contest choices, use the down button. To move to the next contest, use the right button.",


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/4542

Gives instructions to the voter when the ballot is removed during the presentation stage. On mark-scan the ideal path is for the voter to use the interface to confirm their ballot is correct, which causes the app to pull the paper back in and cast it to the rear box. But it's likely that some voters will remove the ballot during the presentation stage, especially if they realize other voters are casting their HMPBs at a precinct scanner.

In the case of early removal we should give instructions to cast at a precinct scanner rather than just ending the session.

## Demo Video or Screenshot
Changes start at 0:20

https://github.com/votingworks/vxsuite/assets/1060688/eaff182f-f523-4685-aed5-7eb6a0102dbc




## Testing Plan
- added tests

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced. (logging should be free with state machine state transition logging)
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
