### PR TITLE
feat(ballot-interpreter): add encoding for timing mark metadata

### DIFF
--- a/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
@@ -511,7 +511,7 @@ pub fn interpret_ballot_card(
                 ) => (
                     side_a,
                     side_b,
-                    BallotStyleId::from(format!("card-number-{}", front_metadata.card_number)),
+                    BallotStyleId::from(format!("card-number-{}", front_metadata.card)),
                 ),
                 (
                     BallotPageTimingMarkMetadata::Back(_),
@@ -519,7 +519,7 @@ pub fn interpret_ballot_card(
                 ) => (
                     side_b,
                     side_a,
-                    BallotStyleId::from(format!("card-number-{}", front_metadata.card_number)),
+                    BallotStyleId::from(format!("card-number-{}", front_metadata.card)),
                 ),
                 _ => {
                     return Err(Error::InvalidCardMetadata {

--- a/libs/ballot-interpreter/src/hmpb-rust/timing_mark_metadata.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/timing_mark_metadata.rs
@@ -1,7 +1,4 @@
-use std::{
-    convert::TryInto,
-    fmt::{Debug, Formatter},
-};
+use std::{convert::TryInto, fmt::Debug};
 
 use serde::Serialize;
 use types_rs::geometry::Rect;
@@ -11,140 +8,135 @@ use crate::ballot_card::Geometry;
 /// Expected number of metadata bits encoded in the bottom row of a ballot card.
 pub const METADATA_BITS: usize = 32;
 
+/// Metadata bits encoded in the bottom row of a ballot card, right-to-left.
+pub type MetadataBits = [bool; METADATA_BITS];
+
 /// Expected number of timing marks comprising the border of a ballot card that
 /// encodes the metadata.
 pub const METADATA_BORDER_MARK_COUNT: usize = METADATA_BITS + 2;
 
+pub type EnderCode = [bool; 11];
+
 /// Ending sequence of bits encoded on the back of a ballot card.
-pub const ENDER_CODE: [bool; 11] = [
+pub const ENDER_CODE: EnderCode = [
     false, true, true, true, true, false, true, true, true, true, false,
 ];
 
-fn print_boolean_slice_as_binary(slice: &[bool]) -> String {
-    slice
-        .iter()
-        .map(|b| if *b { "1" } else { "0" })
-        .collect::<Vec<_>>()
-        .join("")
-}
-
 /// Metadata encoded by the bottom row of the front of a ballot card.
-#[derive(Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub struct BallotPageTimingMarkMetadataFront {
-    /// Raw bits 0-31 in LSB-MSB order (right to left).
-    pub bits: [bool; METADATA_BITS],
-
-    /// Mod 4 check sum from bits 0-1 (2 bits).
-    ///
-    /// The mod 4 check sum bits are obtained by adding the number of 1’s in bits 2
-    /// through 31, then encoding the results of a mod 4 operation in bits 0 and 1.
-    /// For example, if bits 2 through 31 have 18 1’s, bits 0 and 1 will hold the
-    /// value 2 (18 mod 4 = 2).
-    pub mod_4_checksum: u8,
-
-    /// The mod 4 check sum computed from bits 2-31.
-    pub computed_mod_4_checksum: u8,
-
+pub struct BallotConfig {
     /// Batch or precinct number from bits 2-14 (13 bits).
-    pub batch_or_precinct_number: u16,
+    pub batch_or_precinct: u16,
 
     /// Card number (CardRotID) from bits 15-27 (13 bits).
-    pub card_number: u16,
+    pub card: u16,
 
     /// Sequence number (always 0) from bits 28-30 (3 bits).
-    pub sequence_number: u8,
-
-    /// Start bit (always 1) from bit 31-31 (1 bit).
-    pub start_bit: u8,
+    pub sequence: u8,
 }
 
-impl BallotPageTimingMarkMetadataFront {
-    /// Decodes the metadata bits assuming it's the front page of a ballot card.
-    pub fn decode(
-        bits_rtl: &[bool; METADATA_BITS],
-    ) -> Result<BallotPageTimingMarkMetadataFront, BallotPageTimingMarkMetadataError> {
-        let computed_mod_4_checksum =
-            bits_rtl[2..].iter().map(|&bit| u8::from(bit)).sum::<u8>() % 4;
+impl BallotConfig {
+    const MOD_4_CHECKSUM_OFFSET: usize = 0;
+    const BATCH_OR_PRECINCT_OFFSET: usize = 2;
+    const CARD_OFFSET: usize = 15;
+    const SEQUENCE_OFFSET: usize = 28;
+    const START_BIT_OFFSET: usize = 31;
 
-        let mod_4_checksum = bits_rtl[0..2]
-            .iter()
-            .rev()
-            .fold(0, |acc, &bit| (acc << 1) + u8::from(bit));
-
-        let batch_or_precinct_number = bits_rtl[2..15]
-            .iter()
-            .rev()
-            .fold(0, |acc, &bit| (acc << 1) + u16::from(bit));
-
-        let card_number = bits_rtl[15..28]
-            .iter()
-            .rev()
-            .fold(0, |acc, &bit| (acc << 1) + u16::from(bit));
-
-        let sequence_number = bits_rtl[28..31]
-            .iter()
-            .rev()
-            .fold(0, |acc, &bit| (acc << 1) + u8::from(bit));
-
-        let start_bit = u8::from(bits_rtl[31]);
-
-        let front_metadata = BallotPageTimingMarkMetadataFront {
-            bits: *bits_rtl,
-            mod_4_checksum,
-            computed_mod_4_checksum,
-            batch_or_precinct_number,
-            card_number,
-            sequence_number,
-            start_bit,
-        };
-
-        if computed_mod_4_checksum != mod_4_checksum {
-            return Err(BallotPageTimingMarkMetadataError::InvalidChecksum {
-                metadata: front_metadata,
-            });
+    pub const fn new(batch_or_precinct: u16, card: u16, sequence: u8) -> Self {
+        Self {
+            batch_or_precinct,
+            card,
+            sequence,
         }
+    }
+
+    /// Decodes the metadata bits assuming it's the front page of a ballot card.
+    pub fn decode_bits(bits_rtl: &MetadataBits) -> Result<Self, BallotPageTimingMarkMetadataError> {
+        let start_bit = u8::from(bits_rtl[Self::START_BIT_OFFSET]);
 
         if start_bit != 1 {
             return Err(BallotPageTimingMarkMetadataError::ValueOutOfRange {
-                field: "start_bit".to_string(),
+                field: "start_bit",
                 value: u32::from(start_bit),
                 min: 1,
                 max: 1,
-                metadata: BallotPageTimingMarkMetadata::Front(front_metadata),
             });
         }
 
-        Ok(front_metadata)
+        let computed_mod_4_checksum = compute_mod_4_checksum(bits_rtl);
+        let encoded_mod_4_checksum =
+            u8_from_bits(&bits_rtl[Self::MOD_4_CHECKSUM_OFFSET..Self::BATCH_OR_PRECINCT_OFFSET]);
+
+        if computed_mod_4_checksum != encoded_mod_4_checksum {
+            return Err(BallotPageTimingMarkMetadataError::InvalidChecksum {
+                expected: computed_mod_4_checksum,
+                actual: encoded_mod_4_checksum,
+            });
+        }
+
+        let batch_or_precinct =
+            u16_from_bits(&bits_rtl[Self::BATCH_OR_PRECINCT_OFFSET..Self::CARD_OFFSET]);
+        let card = u16_from_bits(&bits_rtl[Self::CARD_OFFSET..Self::SEQUENCE_OFFSET]);
+        let sequence = u8_from_bits(&bits_rtl[Self::SEQUENCE_OFFSET..Self::START_BIT_OFFSET]);
+
+        Ok(Self::new(batch_or_precinct, card, sequence))
+    }
+
+    /// Encodes the metadata as bits.
+    #[allow(dead_code)]
+    pub fn encode_bits(&self) -> MetadataBits {
+        let mut bits_rtl: MetadataBits = [false; METADATA_BITS];
+
+        // batch or precinct number
+        for i in 0..13 {
+            bits_rtl[2 + i] = (self.batch_or_precinct >> i) & 0b1 != 0;
+        }
+
+        // card number
+        for i in 0..13 {
+            bits_rtl[15 + i] = (self.card >> i) & 0b1 != 0;
+        }
+
+        // sequence number
+        for i in 0..3 {
+            bits_rtl[28 + i] = (self.sequence >> i) & 0b1 != 0;
+        }
+
+        // start bit
+        bits_rtl[31] = true;
+
+        // mod 4 checksum
+        let mod_4_checksum = compute_mod_4_checksum(&bits_rtl);
+        bits_rtl[0] = mod_4_checksum & 0b1 != 0;
+        bits_rtl[1] = (mod_4_checksum >> 1) & 0b1 != 0;
+
+        bits_rtl
     }
 }
 
-impl Debug for BallotPageTimingMarkMetadataFront {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("FrontMetadata")
-            .field("bits", &print_boolean_slice_as_binary(&self.bits))
-            .field("mod_4_checksum", &self.mod_4_checksum)
-            .field("computed_mod_4_checksum", &self.computed_mod_4_checksum)
-            .field("batch_or_precinct_number", &self.batch_or_precinct_number)
-            .field("card_number", &self.card_number)
-            .field("sequence_number", &self.sequence_number)
-            .field("start_bit", &self.start_bit)
-            .finish()
-    }
+fn compute_mod_4_checksum(bits_rtl: &MetadataBits) -> u8 {
+    bits_rtl[2..].iter().map(|&bit| u8::from(bit)).sum::<u8>() % 4
 }
 
 /// Represents a single capital letter from A-Z represented by a u8 index.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct IndexedCapitalLetter(u8);
 
-impl From<u8> for IndexedCapitalLetter {
-    fn from(value: u8) -> Self {
-        Self(value)
+impl TryFrom<u8> for IndexedCapitalLetter {
+    type Error = ();
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        if value < (b'Z' - b'A' + 1) {
+            Ok(Self(value))
+        } else {
+            Err(())
+        }
     }
 }
 
 impl IndexedCapitalLetter {
-    pub fn to_char(&self) -> char {
+    pub fn to_char(self) -> char {
         char::from(b'A' + self.0)
     }
 }
@@ -158,101 +150,172 @@ impl Serialize for IndexedCapitalLetter {
     }
 }
 
-/// Metadata encoded by the bottom row of the back of a ballot card.
-#[derive(Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct BallotPageTimingMarkMetadataBack {
-    /// Raw bits 0-31 in LSB-MSB order (right-to-left).
-    pub bits: [bool; METADATA_BITS],
-
-    /// Election day of month (1..31) from bits 0-4 (5 bits).
-    pub election_day: u8,
-
-    /// Election month (1..12) from bits 5-8 (4 bits).
-    pub election_month: u8,
-
-    /// Election year (2 digits) from bits 9-15 (7 bits).
-    pub election_year: u8,
-
-    /// Election type from bits 16-20 (5 bits).
-    ///
-    /// @example "G" for general election
-    pub election_type: IndexedCapitalLetter,
-
-    /// Ender code (binary 01111011110) from bits 21-31 (11 bits).
-    pub ender_code: [bool; 11],
-
-    /// Ender code (binary 01111011110) hardcoded to the expected value.
-    pub expected_ender_code: [bool; 11],
-}
-
-impl BallotPageTimingMarkMetadataBack {
-    /// Decodes the metadata bits assuming it's the back page of a ballot card.
-    pub fn decode(
-        bits_rtl: &[bool; METADATA_BITS],
-    ) -> Result<BallotPageTimingMarkMetadataBack, BallotPageTimingMarkMetadataError> {
-        let election_day = bits_rtl[0..5]
-            .iter()
-            .rev()
-            .fold(0, |acc, &bit| (acc << 1) + u8::from(bit));
-
-        let election_month = bits_rtl[5..9]
-            .iter()
-            .rev()
-            .fold(0, |acc, &bit| (acc << 1) + u8::from(bit));
-
-        let election_year = bits_rtl[9..16]
-            .iter()
-            .rev()
-            .fold(0, |acc, &bit| (acc << 1) + u8::from(bit));
-
-        let election_type: IndexedCapitalLetter = bits_rtl[16..21]
-            .iter()
-            .rev()
-            .fold(0, |acc, &bit| (acc << 1) + u8::from(bit))
-            .into();
-
-        let ender_code: [bool; 11] = bits_rtl[21..32]
-            .try_into()
-            .expect("slice with correct length");
-
-        let back_metadata = BallotPageTimingMarkMetadataBack {
-            bits: *bits_rtl,
-            election_day,
-            election_month,
-            election_year,
-            election_type,
-            ender_code,
-            expected_ender_code: ENDER_CODE,
-        };
-
-        if ender_code != ENDER_CODE {
-            return Err(BallotPageTimingMarkMetadataError::InvalidEnderCode {
-                metadata: back_metadata,
-            });
-        }
-
-        Ok(back_metadata)
+impl Debug for IndexedCapitalLetter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("IndexedCapitalLetter")
+            .field(&self.to_char())
+            .finish()
     }
 }
 
-impl Debug for BallotPageTimingMarkMetadataBack {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("BackMetadata")
-            .field("bits", &print_boolean_slice_as_binary(&self.bits))
-            .field("election_day", &self.election_day)
-            .field("election_month", &self.election_month)
-            .field("election_year", &self.election_year)
-            .field("election_type", &self.election_type)
-            .field(
-                "ender_code",
-                &print_boolean_slice_as_binary(&self.ender_code),
-            )
-            .field(
-                "expected_ender_code",
-                &print_boolean_slice_as_binary(&self.expected_ender_code),
-            )
-            .finish()
+/// Information encoded by the bottom row of the back of a ballot card.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ElectionInfo {
+    /// Election day of month (1..31) from bits 0-4 (5 bits).
+    pub day: u8,
+
+    /// Election month (1..12) from bits 5-8 (4 bits).
+    pub month: u8,
+
+    /// Election year (2 digits) from bits 9-15 (7 bits).
+    pub year: u8,
+
+    /// Election type from bits 16-20 (5 bits).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use ballot_interpreter::timing_mark_metadata::{ElectionMetadata, IndexedCapitalLetter};
+    /// // General Election
+    /// ElectionMetadata::new(1, 1, 24, IndexedCapitalLetter::try_from(b'G'));
+    /// ```
+    pub type_code: IndexedCapitalLetter,
+}
+
+impl ElectionInfo {
+    const DAY_OFFSET: usize = 0;
+    const MONTH_OFFSET: usize = 5;
+    const YEAR_OFFSET: usize = 9;
+    const TYPE_CODE_OFFSET: usize = 16;
+    const ENDER_CODE_OFFSET: usize = 21;
+
+    fn new(
+        day: u8,
+        month: u8,
+        year: u8,
+        type_code: IndexedCapitalLetter,
+    ) -> Result<Self, BallotPageTimingMarkMetadataError> {
+        if !(1..=31).contains(&day) {
+            return Err(BallotPageTimingMarkMetadataError::ValueOutOfRange {
+                field: "day",
+                value: u32::from(day),
+                min: 1,
+                max: 31,
+            });
+        }
+
+        if !(1..=12).contains(&month) {
+            return Err(BallotPageTimingMarkMetadataError::ValueOutOfRange {
+                field: "month",
+                value: u32::from(month),
+                min: 1,
+                max: 12,
+            });
+        }
+
+        if year > 99 {
+            return Err(BallotPageTimingMarkMetadataError::ValueOutOfRange {
+                field: "year",
+                value: u32::from(year),
+                min: 0,
+                max: 99,
+            });
+        }
+
+        Ok(Self {
+            day,
+            month,
+            year,
+            type_code,
+        })
+    }
+
+    /// Decodes the metadata bits assuming it's the back page of a ballot card.
+    pub fn decode_bits(bits_rtl: &MetadataBits) -> Result<Self, BallotPageTimingMarkMetadataError> {
+        let day = u8_from_bits(&bits_rtl[Self::DAY_OFFSET..Self::MONTH_OFFSET]);
+        let month = u8_from_bits(&bits_rtl[Self::MONTH_OFFSET..Self::YEAR_OFFSET]);
+        let year = u8_from_bits(&bits_rtl[Self::YEAR_OFFSET..Self::TYPE_CODE_OFFSET]);
+        let type_code = u8_from_bits(&bits_rtl[Self::TYPE_CODE_OFFSET..Self::ENDER_CODE_OFFSET]);
+
+        let type_code: IndexedCapitalLetter = type_code.try_into().map_err(|()| {
+            BallotPageTimingMarkMetadataError::ValueOutOfRange {
+                field: "type_code",
+                value: u32::from(type_code),
+                min: 0,
+                max: 25,
+            }
+        })?;
+
+        let ender_code: EnderCode = bits_rtl[Self::ENDER_CODE_OFFSET..]
+            .try_into()
+            .expect("slice with correct length");
+
+        if ender_code != ENDER_CODE {
+            return Err(BallotPageTimingMarkMetadataError::InvalidEnderCode {
+                actual: ender_code,
+                expected: ENDER_CODE,
+            });
+        }
+
+        Self::new(day, month, year, type_code)
+    }
+
+    /// Encodes the metadata as bits.
+    #[allow(dead_code)]
+    pub fn encode_bits(&self) -> MetadataBits {
+        let mut bits: MetadataBits = [false; METADATA_BITS];
+
+        // election day
+        copy_bits_from_u8(
+            &mut bits[Self::DAY_OFFSET..],
+            Self::MONTH_OFFSET - Self::DAY_OFFSET,
+            self.day,
+        );
+
+        // election month
+        copy_bits_from_u8(
+            &mut bits[Self::MONTH_OFFSET..],
+            Self::YEAR_OFFSET - Self::MONTH_OFFSET,
+            self.month,
+        );
+
+        // election year
+        copy_bits_from_u8(
+            &mut bits[Self::YEAR_OFFSET..],
+            Self::TYPE_CODE_OFFSET - Self::YEAR_OFFSET,
+            self.year,
+        );
+
+        // type code
+        copy_bits_from_u8(
+            &mut bits[Self::TYPE_CODE_OFFSET..],
+            Self::ENDER_CODE_OFFSET - Self::TYPE_CODE_OFFSET,
+            self.type_code.0,
+        );
+
+        // ender code
+        bits[Self::ENDER_CODE_OFFSET..].copy_from_slice(&ENDER_CODE);
+
+        bits
+    }
+}
+
+fn u8_from_bits(bits: &[bool]) -> u8 {
+    bits.iter()
+        .rev()
+        .fold(0, |acc, &bit| (acc << 1) + u8::from(bit))
+}
+
+fn u16_from_bits(bits: &[bool]) -> u16 {
+    bits.iter()
+        .rev()
+        .fold(0, |acc, &bit| (acc << 1) + u16::from(bit))
+}
+
+fn copy_bits_from_u8(bits: &mut [bool], count: usize, value: u8) {
+    for (i, bit) in bits.iter_mut().enumerate().take(count) {
+        *bit = (value >> i) & 0b1 != 0;
     }
 }
 
@@ -261,8 +324,8 @@ impl Debug for BallotPageTimingMarkMetadataBack {
 // Metadata encoded in the bottom row of timing marks on Accuvote-style ballots.
 #[allow(clippy::module_name_repetitions)]
 pub enum BallotPageTimingMarkMetadata {
-    Front(BallotPageTimingMarkMetadataFront),
-    Back(BallotPageTimingMarkMetadataBack),
+    Front(BallotConfig),
+    Back(ElectionInfo),
 }
 
 impl BallotPageTimingMarkMetadata {
@@ -272,12 +335,12 @@ impl BallotPageTimingMarkMetadata {
     pub fn decode_from_timing_marks(
         geometry: &Geometry,
         bottom_timing_marks: &[Option<Rect>],
-    ) -> Result<BallotPageTimingMarkMetadata, BallotPageTimingMarkMetadataError> {
+    ) -> Result<Self, BallotPageTimingMarkMetadataError> {
         {
             let bits = compute_bits_from_bottom_timing_marks(geometry, bottom_timing_marks)?;
 
-            let front_metadata_result = BallotPageTimingMarkMetadataFront::decode(&bits);
-            let back_metadata_result = BallotPageTimingMarkMetadataBack::decode(&bits);
+            let front_metadata_result = BallotConfig::decode_bits(&bits);
+            let back_metadata_result = ElectionInfo::decode_bits(&bits);
 
             match (front_metadata_result, back_metadata_result) {
                 (Ok(front_metadata), Ok(back_metadata)) => {
@@ -286,12 +349,8 @@ impl BallotPageTimingMarkMetadata {
                         back_metadata,
                     })
                 }
-                (Ok(front_metadata), Err(_)) => {
-                    Ok(BallotPageTimingMarkMetadata::Front(front_metadata))
-                }
-                (Err(_), Ok(back_metadata)) => {
-                    Ok(BallotPageTimingMarkMetadata::Back(back_metadata))
-                }
+                (Ok(front_metadata), Err(_)) => Ok(Self::Front(front_metadata)),
+                (Err(_), Ok(back_metadata)) => Ok(Self::Back(back_metadata)),
                 (Err(front_metadata_error), Err(_)) => Err(front_metadata_error),
             }
         }
@@ -303,26 +362,24 @@ impl BallotPageTimingMarkMetadata {
 pub enum BallotPageTimingMarkMetadataError {
     #[error("value {value} for field {field} is out of range [{min}, {max}]")]
     ValueOutOfRange {
-        field: String,
+        field: &'static str,
         value: u32,
         min: u32,
         max: u32,
-        metadata: BallotPageTimingMarkMetadata,
     },
-    #[error("invalid checksum: expected {}, got {}", metadata.mod_4_checksum, metadata.computed_mod_4_checksum)]
-    InvalidChecksum {
-        metadata: BallotPageTimingMarkMetadataFront,
-    },
-    #[error("invalid ender code: {:?}", metadata.ender_code)]
+    #[error("invalid checksum: expected {expected}, got {actual}")]
+    InvalidChecksum { expected: u8, actual: u8 },
+    #[error("invalid ender code: expected {expected:?}, got {actual:?}")]
     InvalidEnderCode {
-        metadata: BallotPageTimingMarkMetadataBack,
+        expected: EnderCode,
+        actual: EnderCode,
     },
     #[error("invalid number of timing marks: expected {expected}, got {actual}")]
     InvalidTimingMarkCount { expected: usize, actual: usize },
     #[error("ambiguous metadata: front={front_metadata:?}, back={back_metadata:?}")]
     AmbiguousMetadata {
-        front_metadata: BallotPageTimingMarkMetadataFront,
-        back_metadata: BallotPageTimingMarkMetadataBack,
+        front_metadata: BallotConfig,
+        back_metadata: ElectionInfo,
     },
 }
 
@@ -330,7 +387,7 @@ pub enum BallotPageTimingMarkMetadataError {
 pub fn compute_bits_from_bottom_timing_marks(
     geometry: &Geometry,
     bottom_timing_marks: &[Option<Rect>],
-) -> Result<[bool; METADATA_BITS], BallotPageTimingMarkMetadataError> {
+) -> Result<MetadataBits, BallotPageTimingMarkMetadataError> {
     // Validate the number of timing marks.
     if bottom_timing_marks.len() != geometry.grid_size.width as usize
         || geometry.grid_size.width as usize != METADATA_BORDER_MARK_COUNT
@@ -381,6 +438,7 @@ pub fn compute_bits_from_bottom_timing_marks(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod test {
     use proptest::{prop_compose, proptest};
 
@@ -388,114 +446,51 @@ mod test {
 
     proptest! {
         #[test]
-        fn test_decode_front_metadata_from_bits_does_not_panic(bits: [bool; METADATA_BITS]) {
-            let _ = BallotPageTimingMarkMetadataFront::decode(&bits);
+        fn test_decode_front_metadata_from_bits_does_not_panic(bits: MetadataBits) {
+            let _ = BallotConfig::decode_bits(&bits);
         }
 
         #[test]
-        fn test_decode_back_metadata_from_bits_does_not_panic(bits: [bool; METADATA_BITS]) {
-            let _ = BallotPageTimingMarkMetadataBack::decode(&bits);
+        fn test_decode_back_metadata_from_bits_does_not_panic(bits: MetadataBits) {
+            let _ = ElectionInfo::decode_bits(&bits);
         }
 
         #[test]
-        fn test_decode_front_metadata_from_bits(
-            batch_or_precinct_number in 0u16..=(1 << 13 - 1),
-            card_number in 0u16..=(1 << 13 - 1),
-            sequence_number in 0u8..=(1 << 3 - 1),
+        fn test_encode_decode_front_metadata(
+            batch_or_precinct in 0u16..(1 << 13),
+            card in 0u16..(1 << 13),
+            sequence in 0u8..(1 << 3),
         ) {
-            let mut bits: [bool; METADATA_BITS] = [
-                // placeholder for mod 4 checksum
-                false,
-                false,
+            let metadata = BallotConfig::new(
+                batch_or_precinct,
+                card,
+                sequence,
+            );
 
-                // batch or precinct number
-                (batch_or_precinct_number >> 0) & 0b1 != 0,
-                (batch_or_precinct_number >> 1) & 0b1 != 0,
-                (batch_or_precinct_number >> 2) & 0b1 != 0,
-                (batch_or_precinct_number >> 3) & 0b1 != 0,
-                (batch_or_precinct_number >> 4) & 0b1 != 0,
-                (batch_or_precinct_number >> 5) & 0b1 != 0,
-                (batch_or_precinct_number >> 6) & 0b1 != 0,
-                (batch_or_precinct_number >> 7) & 0b1 != 0,
-                (batch_or_precinct_number >> 8) & 0b1 != 0,
-                (batch_or_precinct_number >> 9) & 0b1 != 0,
-                (batch_or_precinct_number >> 10) & 0b1 != 0,
-                (batch_or_precinct_number >> 11) & 0b1 != 0,
-                (batch_or_precinct_number >> 12) & 0b1 != 0,
+            let bits = metadata.encode_bits();
+            let decoded_metadata = BallotConfig::decode_bits(&bits).unwrap();
 
-                // card number
-                (card_number >> 0) & 0b1 != 0,
-                (card_number >> 1) & 0b1 != 0,
-                (card_number >> 2) & 0b1 != 0,
-                (card_number >> 3) & 0b1 != 0,
-                (card_number >> 4) & 0b1 != 0,
-                (card_number >> 5) & 0b1 != 0,
-                (card_number >> 6) & 0b1 != 0,
-                (card_number >> 7) & 0b1 != 0,
-                (card_number >> 8) & 0b1 != 0,
-                (card_number >> 9) & 0b1 != 0,
-                (card_number >> 10) & 0b1 != 0,
-                (card_number >> 11) & 0b1 != 0,
-                (card_number >> 12) & 0b1 != 0,
-
-                // sequence number
-                (sequence_number >> 0) & 0b1 != 0,
-                (sequence_number >> 1) & 0b1 != 0,
-                (sequence_number >> 2) & 0b1 != 0,
-
-                // start bit
-                true,
-            ];
-
-            // compute mod 4 checksum
-            let computed_mod_4_checksum = bits[2..].iter().map(|&bit| u8::from(bit)).sum::<u8>() % 4;
-            bits[0] = (computed_mod_4_checksum >> 0) & 0b1 != 0;
-            bits[1] = (computed_mod_4_checksum >> 1) & 0b1 != 0;
-
-            let metadata = BallotPageTimingMarkMetadataFront::decode(&bits).unwrap();
-            assert_eq!(metadata.bits, bits);
-            assert_eq!(metadata.batch_or_precinct_number, batch_or_precinct_number);
-            assert_eq!(metadata.card_number, card_number);
-            assert_eq!(metadata.sequence_number, sequence_number);
+            assert_eq!(decoded_metadata, metadata);
         }
 
         #[test]
-        fn test_decode_back_metadata_from_bits(
-            election_day in 0u8..=31,
-            election_month in 0u8..=12,
-            election_year in 0u8..=100,
+        fn test_encode_decode_back_metadata(
+            election_day in 1u8..=31,
+            election_month in 1u8..=12,
+            election_year in 0u8..100,
             election_type in indexed_capital_letter(),
         ) {
-            let bits: [bool; METADATA_BITS] = [
-                (election_day >> 0) & 0b1 != 0,
-                (election_day >> 1) & 0b1 != 0,
-                (election_day >> 2) & 0b1 != 0,
-                (election_day >> 3) & 0b1 != 0,
-                (election_day >> 4) & 0b1 != 0,
-                (election_month >> 0) & 0b1 != 0,
-                (election_month >> 1) & 0b1 != 0,
-                (election_month >> 2) & 0b1 != 0,
-                (election_month >> 3) & 0b1 != 0,
-                (election_year >> 0) & 0b1 != 0,
-                (election_year >> 1) & 0b1 != 0,
-                (election_year >> 2) & 0b1 != 0,
-                (election_year >> 3) & 0b1 != 0,
-                (election_year >> 4) & 0b1 != 0,
-                (election_year >> 5) & 0b1 != 0,
-                (election_year >> 6) & 0b1 != 0,
-                (election_type.0 >> 0) & 0b1 != 0,
-                (election_type.0 >> 1) & 0b1 != 0,
-                (election_type.0 >> 2) & 0b1 != 0,
-                (election_type.0 >> 3) & 0b1 != 0,
-                (election_type.0 >> 4) & 0b1 != 0,
-                false, true, true, true, true, false, true, true, true, true, false,
-            ];
-            let metadata = BallotPageTimingMarkMetadataBack::decode(&bits).unwrap();
-            assert_eq!(metadata.bits, bits);
-            assert_eq!(metadata.election_day, election_day);
-            assert_eq!(metadata.election_month, election_month);
-            assert_eq!(metadata.election_year, election_year);
-            assert_eq!(metadata.election_type, election_type);
+            let original_metadata = ElectionInfo::new(
+                election_day,
+                election_month,
+                election_year,
+                election_type,
+            ).unwrap();
+
+            let bits = original_metadata.encode_bits();
+            let decoded_metadata = ElectionInfo::decode_bits(&bits).unwrap();
+
+            assert_eq!(decoded_metadata, original_metadata);
         }
     }
 
@@ -503,7 +498,7 @@ mod test {
         fn indexed_capital_letter()(
             value in b'A'..=b'Z'
         ) -> IndexedCapitalLetter {
-            IndexedCapitalLetter::from(value - b'A')
+            IndexedCapitalLetter::try_from(value - b'A').unwrap()
         }
     }
 }

--- a/libs/ballot-interpreter/src/hmpb-rust/timing_mark_metadata.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/timing_mark_metadata.rs
@@ -59,6 +59,66 @@ pub struct BallotPageTimingMarkMetadataFront {
     pub start_bit: u8,
 }
 
+impl BallotPageTimingMarkMetadataFront {
+    /// Decodes the metadata bits assuming it's the front page of a ballot card.
+    pub fn decode(
+        bits_rtl: &[bool; METADATA_BITS],
+    ) -> Result<BallotPageTimingMarkMetadataFront, BallotPageTimingMarkMetadataError> {
+        let computed_mod_4_checksum =
+            bits_rtl[2..].iter().map(|&bit| u8::from(bit)).sum::<u8>() % 4;
+
+        let mod_4_checksum = bits_rtl[0..2]
+            .iter()
+            .rev()
+            .fold(0, |acc, &bit| (acc << 1) + u8::from(bit));
+
+        let batch_or_precinct_number = bits_rtl[2..15]
+            .iter()
+            .rev()
+            .fold(0, |acc, &bit| (acc << 1) + u16::from(bit));
+
+        let card_number = bits_rtl[15..28]
+            .iter()
+            .rev()
+            .fold(0, |acc, &bit| (acc << 1) + u16::from(bit));
+
+        let sequence_number = bits_rtl[28..31]
+            .iter()
+            .rev()
+            .fold(0, |acc, &bit| (acc << 1) + u8::from(bit));
+
+        let start_bit = u8::from(bits_rtl[31]);
+
+        let front_metadata = BallotPageTimingMarkMetadataFront {
+            bits: *bits_rtl,
+            mod_4_checksum,
+            computed_mod_4_checksum,
+            batch_or_precinct_number,
+            card_number,
+            sequence_number,
+            start_bit,
+        };
+
+        if computed_mod_4_checksum != mod_4_checksum {
+            return Err(BallotPageTimingMarkMetadataError::InvalidChecksum {
+                metadata: front_metadata,
+            });
+        }
+
+        if start_bit != 1 {
+            return Err(BallotPageTimingMarkMetadataError::ValueOutOfRange {
+                field: "start_bit".to_string(),
+                value: u32::from(start_bit),
+                min: 1,
+                max: 1,
+                metadata: BallotPageTimingMarkMetadata::Front(front_metadata),
+            });
+        }
+
+        Ok(front_metadata)
+    }
+}
+
 impl Debug for BallotPageTimingMarkMetadataFront {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FrontMetadata")
@@ -74,7 +134,7 @@ impl Debug for BallotPageTimingMarkMetadataFront {
 }
 
 /// Represents a single capital letter from A-Z represented by a u8 index.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct IndexedCapitalLetter(u8);
 
 impl From<u8> for IndexedCapitalLetter {
@@ -126,6 +186,56 @@ pub struct BallotPageTimingMarkMetadataBack {
     pub expected_ender_code: [bool; 11],
 }
 
+impl BallotPageTimingMarkMetadataBack {
+    /// Decodes the metadata bits assuming it's the back page of a ballot card.
+    pub fn decode(
+        bits_rtl: &[bool; METADATA_BITS],
+    ) -> Result<BallotPageTimingMarkMetadataBack, BallotPageTimingMarkMetadataError> {
+        let election_day = bits_rtl[0..5]
+            .iter()
+            .rev()
+            .fold(0, |acc, &bit| (acc << 1) + u8::from(bit));
+
+        let election_month = bits_rtl[5..9]
+            .iter()
+            .rev()
+            .fold(0, |acc, &bit| (acc << 1) + u8::from(bit));
+
+        let election_year = bits_rtl[9..16]
+            .iter()
+            .rev()
+            .fold(0, |acc, &bit| (acc << 1) + u8::from(bit));
+
+        let election_type: IndexedCapitalLetter = bits_rtl[16..21]
+            .iter()
+            .rev()
+            .fold(0, |acc, &bit| (acc << 1) + u8::from(bit))
+            .into();
+
+        let ender_code: [bool; 11] = bits_rtl[21..32]
+            .try_into()
+            .expect("slice with correct length");
+
+        let back_metadata = BallotPageTimingMarkMetadataBack {
+            bits: *bits_rtl,
+            election_day,
+            election_month,
+            election_year,
+            election_type,
+            ender_code,
+            expected_ender_code: ENDER_CODE,
+        };
+
+        if ender_code != ENDER_CODE {
+            return Err(BallotPageTimingMarkMetadataError::InvalidEnderCode {
+                metadata: back_metadata,
+            });
+        }
+
+        Ok(back_metadata)
+    }
+}
+
 impl Debug for BallotPageTimingMarkMetadataBack {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("BackMetadata")
@@ -153,6 +263,39 @@ impl Debug for BallotPageTimingMarkMetadataBack {
 pub enum BallotPageTimingMarkMetadata {
     Front(BallotPageTimingMarkMetadataFront),
     Back(BallotPageTimingMarkMetadataBack),
+}
+
+impl BallotPageTimingMarkMetadata {
+    /// Decodes the ballot page metadata from the timing marks. Uses the difference
+    /// between the partial and complete timing marks to determine the metadata
+    /// bits.
+    pub fn decode_from_timing_marks(
+        geometry: &Geometry,
+        bottom_timing_marks: &[Option<Rect>],
+    ) -> Result<BallotPageTimingMarkMetadata, BallotPageTimingMarkMetadataError> {
+        {
+            let bits = compute_bits_from_bottom_timing_marks(geometry, bottom_timing_marks)?;
+
+            let front_metadata_result = BallotPageTimingMarkMetadataFront::decode(&bits);
+            let back_metadata_result = BallotPageTimingMarkMetadataBack::decode(&bits);
+
+            match (front_metadata_result, back_metadata_result) {
+                (Ok(front_metadata), Ok(back_metadata)) => {
+                    Err(BallotPageTimingMarkMetadataError::AmbiguousMetadata {
+                        front_metadata,
+                        back_metadata,
+                    })
+                }
+                (Ok(front_metadata), Err(_)) => {
+                    Ok(BallotPageTimingMarkMetadata::Front(front_metadata))
+                }
+                (Err(_), Ok(back_metadata)) => {
+                    Ok(BallotPageTimingMarkMetadata::Back(back_metadata))
+                }
+                (Err(front_metadata_error), Err(_)) => Err(front_metadata_error),
+            }
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Clone, thiserror::Error)]
@@ -237,132 +380,130 @@ pub fn compute_bits_from_bottom_timing_marks(
     )
 }
 
-/// Decodes the metadata bits assuming it's the front page of a ballot card.
-pub fn decode_front_metadata_from_bits(
-    bits_rtl: &[bool; METADATA_BITS],
-) -> Result<BallotPageTimingMarkMetadataFront, BallotPageTimingMarkMetadataError> {
-    let computed_mod_4_checksum = bits_rtl[2..].iter().map(|&bit| u8::from(bit)).sum::<u8>() % 4;
+#[cfg(test)]
+mod test {
+    use proptest::{prop_compose, proptest};
 
-    let mod_4_checksum = bits_rtl[0..2]
-        .iter()
-        .rev()
-        .fold(0, |acc, &bit| (acc << 1) + u8::from(bit));
+    use super::*;
 
-    let batch_or_precinct_number = bits_rtl[2..15]
-        .iter()
-        .rev()
-        .fold(0, |acc, &bit| (acc << 1) + u16::from(bit));
-
-    let card_number = bits_rtl[15..28]
-        .iter()
-        .rev()
-        .fold(0, |acc, &bit| (acc << 1) + u16::from(bit));
-
-    let sequence_number = bits_rtl[28..31]
-        .iter()
-        .rev()
-        .fold(0, |acc, &bit| (acc << 1) + u8::from(bit));
-
-    let start_bit = u8::from(bits_rtl[31]);
-
-    let front_metadata = BallotPageTimingMarkMetadataFront {
-        bits: *bits_rtl,
-        mod_4_checksum,
-        computed_mod_4_checksum,
-        batch_or_precinct_number,
-        card_number,
-        sequence_number,
-        start_bit,
-    };
-
-    if computed_mod_4_checksum != mod_4_checksum {
-        return Err(BallotPageTimingMarkMetadataError::InvalidChecksum {
-            metadata: front_metadata,
-        });
-    }
-
-    if start_bit != 1 {
-        return Err(BallotPageTimingMarkMetadataError::ValueOutOfRange {
-            field: "start_bit".to_string(),
-            value: u32::from(start_bit),
-            min: 1,
-            max: 1,
-            metadata: BallotPageTimingMarkMetadata::Front(front_metadata),
-        });
-    }
-
-    Ok(front_metadata)
-}
-
-/// Decodes the metadata bits assuming it's the back page of a ballot card.
-pub fn decode_back_metadata_from_bits(
-    bits_rtl: &[bool; METADATA_BITS],
-) -> Result<BallotPageTimingMarkMetadataBack, BallotPageTimingMarkMetadataError> {
-    let election_day = bits_rtl[0..5]
-        .iter()
-        .rev()
-        .fold(0, |acc, &bit| (acc << 1) + u8::from(bit));
-
-    let election_month = bits_rtl[5..9]
-        .iter()
-        .rev()
-        .fold(0, |acc, &bit| (acc << 1) + u8::from(bit));
-
-    let election_year = bits_rtl[9..16]
-        .iter()
-        .rev()
-        .fold(0, |acc, &bit| (acc << 1) + u8::from(bit));
-
-    let election_type: IndexedCapitalLetter = bits_rtl[16..21]
-        .iter()
-        .rev()
-        .fold(0, |acc, &bit| (acc << 1) + u8::from(bit))
-        .into();
-
-    let ender_code: [bool; 11] = bits_rtl[21..32]
-        .try_into()
-        .expect("slice with correct length");
-
-    let back_metadata = BallotPageTimingMarkMetadataBack {
-        bits: *bits_rtl,
-        election_day,
-        election_month,
-        election_year,
-        election_type,
-        ender_code,
-        expected_ender_code: ENDER_CODE,
-    };
-
-    if ender_code != ENDER_CODE {
-        return Err(BallotPageTimingMarkMetadataError::InvalidEnderCode {
-            metadata: back_metadata,
-        });
-    }
-
-    Ok(back_metadata)
-}
-
-/// Decodes the ballot page metadata from the timing marks. Uses the difference
-/// between the partial and complete timing marks to determine the metadata
-/// bits.
-pub fn decode_metadata_from_timing_marks(
-    geometry: &Geometry,
-    bottom_timing_marks: &[Option<Rect>],
-) -> Result<BallotPageTimingMarkMetadata, BallotPageTimingMarkMetadataError> {
-    let bits = compute_bits_from_bottom_timing_marks(geometry, bottom_timing_marks)?;
-
-    let front_metadata_result = decode_front_metadata_from_bits(&bits);
-    let back_metadata_result = decode_back_metadata_from_bits(&bits);
-
-    match (front_metadata_result, back_metadata_result) {
-        (Ok(front_metadata), Ok(back_metadata)) => {
-            Err(BallotPageTimingMarkMetadataError::AmbiguousMetadata {
-                front_metadata,
-                back_metadata,
-            })
+    proptest! {
+        #[test]
+        fn test_decode_front_metadata_from_bits_does_not_panic(bits: [bool; METADATA_BITS]) {
+            let _ = BallotPageTimingMarkMetadataFront::decode(&bits);
         }
-        (Ok(front_metadata), Err(_)) => Ok(BallotPageTimingMarkMetadata::Front(front_metadata)),
-        (Err(_), Ok(back_metadata)) => Ok(BallotPageTimingMarkMetadata::Back(back_metadata)),
-        (Err(front_metadata_error), Err(_)) => Err(front_metadata_error),
+
+        #[test]
+        fn test_decode_back_metadata_from_bits_does_not_panic(bits: [bool; METADATA_BITS]) {
+            let _ = BallotPageTimingMarkMetadataBack::decode(&bits);
+        }
+
+        #[test]
+        fn test_decode_front_metadata_from_bits(
+            batch_or_precinct_number in 0u16..=(1 << 13 - 1),
+            card_number in 0u16..=(1 << 13 - 1),
+            sequence_number in 0u8..=(1 << 3 - 1),
+        ) {
+            let mut bits: [bool; METADATA_BITS] = [
+                // placeholder for mod 4 checksum
+                false,
+                false,
+
+                // batch or precinct number
+                (batch_or_precinct_number >> 0) & 0b1 != 0,
+                (batch_or_precinct_number >> 1) & 0b1 != 0,
+                (batch_or_precinct_number >> 2) & 0b1 != 0,
+                (batch_or_precinct_number >> 3) & 0b1 != 0,
+                (batch_or_precinct_number >> 4) & 0b1 != 0,
+                (batch_or_precinct_number >> 5) & 0b1 != 0,
+                (batch_or_precinct_number >> 6) & 0b1 != 0,
+                (batch_or_precinct_number >> 7) & 0b1 != 0,
+                (batch_or_precinct_number >> 8) & 0b1 != 0,
+                (batch_or_precinct_number >> 9) & 0b1 != 0,
+                (batch_or_precinct_number >> 10) & 0b1 != 0,
+                (batch_or_precinct_number >> 11) & 0b1 != 0,
+                (batch_or_precinct_number >> 12) & 0b1 != 0,
+
+                // card number
+                (card_number >> 0) & 0b1 != 0,
+                (card_number >> 1) & 0b1 != 0,
+                (card_number >> 2) & 0b1 != 0,
+                (card_number >> 3) & 0b1 != 0,
+                (card_number >> 4) & 0b1 != 0,
+                (card_number >> 5) & 0b1 != 0,
+                (card_number >> 6) & 0b1 != 0,
+                (card_number >> 7) & 0b1 != 0,
+                (card_number >> 8) & 0b1 != 0,
+                (card_number >> 9) & 0b1 != 0,
+                (card_number >> 10) & 0b1 != 0,
+                (card_number >> 11) & 0b1 != 0,
+                (card_number >> 12) & 0b1 != 0,
+
+                // sequence number
+                (sequence_number >> 0) & 0b1 != 0,
+                (sequence_number >> 1) & 0b1 != 0,
+                (sequence_number >> 2) & 0b1 != 0,
+
+                // start bit
+                true,
+            ];
+
+            // compute mod 4 checksum
+            let computed_mod_4_checksum = bits[2..].iter().map(|&bit| u8::from(bit)).sum::<u8>() % 4;
+            bits[0] = (computed_mod_4_checksum >> 0) & 0b1 != 0;
+            bits[1] = (computed_mod_4_checksum >> 1) & 0b1 != 0;
+
+            let metadata = BallotPageTimingMarkMetadataFront::decode(&bits).unwrap();
+            assert_eq!(metadata.bits, bits);
+            assert_eq!(metadata.batch_or_precinct_number, batch_or_precinct_number);
+            assert_eq!(metadata.card_number, card_number);
+            assert_eq!(metadata.sequence_number, sequence_number);
+        }
+
+        #[test]
+        fn test_decode_back_metadata_from_bits(
+            election_day in 0u8..=31,
+            election_month in 0u8..=12,
+            election_year in 0u8..=100,
+            election_type in indexed_capital_letter(),
+        ) {
+            let bits: [bool; METADATA_BITS] = [
+                (election_day >> 0) & 0b1 != 0,
+                (election_day >> 1) & 0b1 != 0,
+                (election_day >> 2) & 0b1 != 0,
+                (election_day >> 3) & 0b1 != 0,
+                (election_day >> 4) & 0b1 != 0,
+                (election_month >> 0) & 0b1 != 0,
+                (election_month >> 1) & 0b1 != 0,
+                (election_month >> 2) & 0b1 != 0,
+                (election_month >> 3) & 0b1 != 0,
+                (election_year >> 0) & 0b1 != 0,
+                (election_year >> 1) & 0b1 != 0,
+                (election_year >> 2) & 0b1 != 0,
+                (election_year >> 3) & 0b1 != 0,
+                (election_year >> 4) & 0b1 != 0,
+                (election_year >> 5) & 0b1 != 0,
+                (election_year >> 6) & 0b1 != 0,
+                (election_type.0 >> 0) & 0b1 != 0,
+                (election_type.0 >> 1) & 0b1 != 0,
+                (election_type.0 >> 2) & 0b1 != 0,
+                (election_type.0 >> 3) & 0b1 != 0,
+                (election_type.0 >> 4) & 0b1 != 0,
+                false, true, true, true, true, false, true, true, true, true, false,
+            ];
+            let metadata = BallotPageTimingMarkMetadataBack::decode(&bits).unwrap();
+            assert_eq!(metadata.bits, bits);
+            assert_eq!(metadata.election_day, election_day);
+            assert_eq!(metadata.election_month, election_month);
+            assert_eq!(metadata.election_year, election_year);
+            assert_eq!(metadata.election_type, election_type);
+        }
+    }
+
+    prop_compose! {
+        fn indexed_capital_letter()(
+            value in b'A'..=b'Z'
+        ) -> IndexedCapitalLetter {
+            IndexedCapitalLetter::from(value - b'A')
+        }
     }
 }

--- a/libs/ballot-interpreter/src/hmpb-rust/timing_marks.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/timing_marks.rs
@@ -19,7 +19,7 @@ use crate::{
     image_utils::{expand_image, match_template, WHITE},
     interpret::{self, Error},
     qr_code_metadata::BallotPageQrCodeMetadata,
-    timing_mark_metadata::{decode_metadata_from_timing_marks, BallotPageTimingMarkMetadata},
+    timing_mark_metadata::BallotPageTimingMarkMetadata,
 };
 
 /// Represents partial timing marks found in a ballot card.
@@ -1003,7 +1003,7 @@ pub fn detect_metadata_and_normalize_orientation(
     let orientation = detect_orientation_from_grid(&grid);
     let (normalized_grid, normalized_image) =
         normalize_orientation(geometry, grid, image, orientation, debug);
-    let metadata = decode_metadata_from_timing_marks(
+    let metadata = BallotPageTimingMarkMetadata::decode_from_timing_marks(
         geometry,
         &find_actual_bottom_marks(
             &normalized_grid.complete_timing_marks,

--- a/libs/ballot-interpreter/src/hmpb-ts/types.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/types.ts
@@ -164,72 +164,43 @@ export interface BallotPageQrCodeMetadata extends HmpbBallotPageMetadata {
 }
 
 /** Metadata from the ballot card bottom timing marks. */
-export type BallotPageTimingMarkMetadata = (
-  | BallotPageTimingMarkMetadataFront
-  | BallotPageTimingMarkMetadataBack
-) & { source: 'timing-marks' };
+export type BallotPageTimingMarkMetadata = (BallotConfig | ElectionInfo) & {
+  source: 'timing-marks';
+};
 
 /** Metadata encoded on the front side of a ballot card. */
-export interface BallotPageTimingMarkMetadataFront {
+export interface BallotConfig {
   side: 'front';
 
-  /** Raw bits 0-31 in LSB-MSB order (right to left). */
-  bits: boolean[];
-
-  /**
-   * Mod 4 check sum from bits 0-1 (2 bits).
-   *
-   * The mod 4 check sum bits are obtained by adding the number of 1’s in bits 2
-   * through 31, then encoding the results of a mod 4 operation in bits 0 and 1.
-   * For example, if bits 2 through 31 have 18 1’s, bits 0 and 1 will hold the
-   * value 2 (18 mod 4 = 2).
-   */
-  mod4Checksum: u8;
-
-  /** The mod 4 check sum computed from bits 2-31. */
-  computedMod4Checksum: u8;
-
   /** Batch or precinct number from bits 2-14 (13 bits). */
-  batchOrPrecinctNumber: u16;
+  batchOrPrecinct: u16;
 
   /** Card number (CardRotID) from bits 15-27 (13 bits). */
-  cardNumber: u16;
+  card: u16;
 
   /** Sequence number (always 0) from bits 28-30 (3 bits). */
-  sequenceNumber: u8;
-
-  /** Start bit (always 1) from bit 31-31 (1 bit). */
-  startBit: u8;
+  sequence: u8;
 }
 
 /** Metadata encoded on the front side of a ballot card. */
-export interface BallotPageTimingMarkMetadataBack {
+export interface ElectionInfo {
   side: 'back';
 
-  /** Raw bits 0-31 in LSB-MSB order (right-to-left). */
-  bits: boolean[];
-
   /** Election day of month (1..31) from bits 0-4 (5 bits). */
-  electionDay: u8;
+  day: u8;
 
   /** Election month (1..12) from bits 5-8 (4 bits). */
-  electionMonth: u8;
+  month: u8;
 
   /** Election year (2 digits) from bits 9-15 (7 bits). */
-  electionYear: u8;
+  year: u8;
 
   /**
    * Election type from bits 16-20 (5 bits).
    *
    * @example "G" for general election
    */
-  electionType: IndexedCapitalLetter;
-
-  /** Ender code (binary 01111011110) from bits 21-31 (11 bits). */
-  enderCode: boolean[];
-
-  /** Ender code (binary 01111011110) hardcoded to the expected value. */
-  expectedEnderCode: boolean[];
+  typeCode: IndexedCapitalLetter;
 }
 
 /** Represents a single capital letter from A-Z. */
@@ -443,11 +414,11 @@ export type BallotPageMetadataError =
       max: u32;
       metadata: BallotPageTimingMarkMetadata;
     }
-  | { type: 'invalidChecksum'; metadata: BallotPageTimingMarkMetadataFront }
-  | { type: 'invalidEnderCode'; metadata: BallotPageTimingMarkMetadataBack }
+  | { type: 'invalidChecksum'; metadata: BallotConfig }
+  | { type: 'invalidEnderCode'; metadata: ElectionInfo }
   | { type: 'invalidTimingMarkCount'; expected: usize; actual: usize }
   | {
       type: 'ambiguousMetadata';
-      front_metadata: BallotPageTimingMarkMetadataFront;
-      back_metadata: BallotPageTimingMarkMetadataBack;
+      front_metadata: BallotConfig;
+      back_metadata: ElectionInfo;
     };

--- a/libs/ballot-interpreter/src/interpret.ts
+++ b/libs/ballot-interpreter/src/interpret.ts
@@ -52,7 +52,7 @@ import {
 import makeDebug from 'debug';
 import {
   interpret as interpretHmpbBallotSheetRust,
-  BallotPageTimingMarkMetadataFront,
+  BallotConfig,
   Geometry,
   InterpretedBallotCard,
   HmpbInterpretResult as NextInterpretResult,
@@ -309,19 +309,19 @@ export function determineAdjudicationInfoFromScoredContestOptions(
 function buildInterpretedHmpbPageMetadata(
   electionDefinition: ElectionDefinition,
   options: InterpreterOptions,
-  frontMetadata: BallotPageTimingMarkMetadataFront,
+  ballotConfig: BallotConfig,
   side: 'front' | 'back'
 ): HmpbBallotPageMetadata {
   const { election } = electionDefinition;
   const ballotStyle = getBallotStyle({
     election,
-    ballotStyleId: `card-number-${frontMetadata.cardNumber}`,
+    ballotStyleId: `card-number-${ballotConfig.card}`,
   });
-  assert(ballotStyle, `Ballot style ${frontMetadata.cardNumber} not found`);
+  assert(ballotStyle, `Ballot style ${ballotConfig.card} not found`);
   const precinctId = ballotStyle.precincts[0];
   assert(
     precinctId !== undefined,
-    `Precinct ${frontMetadata.batchOrPrecinctNumber} not found`
+    `Precinct ${ballotConfig.batchOrPrecinct} not found`
   );
 
   return {
@@ -407,8 +407,7 @@ function convertInterpretedBallotPage(
           options,
           // For timing mark metadata, always use the front, since it contains
           // the info we need
-          interpretedBallotCard.front
-            .metadata as BallotPageTimingMarkMetadataFront,
+          interpretedBallotCard.front.metadata as BallotConfig,
           side
         );
 

--- a/libs/converter-nh-accuvote/src/convert/convert_election_definition.ts
+++ b/libs/converter-nh-accuvote/src/convert/convert_election_definition.ts
@@ -1,5 +1,5 @@
 import {
-  BallotPageTimingMarkMetadataFront,
+  BallotConfig,
   findTemplateGridAndBubbles,
 } from '@votingworks/ballot-interpreter';
 import {
@@ -104,7 +104,6 @@ export function convertElectionDefinition(
         kind: ConvertIssueKind.InvalidTimingMarkMetadata,
         message: `front page timing mark metadata is invalid: side=${frontGridAndBubbles.metadata.side}`,
         side: 'front',
-        timingMarkBits: frontGridAndBubbles.metadata.bits,
         timingMarks: frontGridAndBubbles.grid.partialTimingMarks,
       });
     }
@@ -115,7 +114,6 @@ export function convertElectionDefinition(
         kind: ConvertIssueKind.InvalidTimingMarkMetadata,
         message: `back page timing mark metadata is invalid: side=${backGridAndBubbles.metadata.side}`,
         side: 'back',
-        timingMarkBits: backGridAndBubbles.metadata.bits,
         timingMarks: backGridAndBubbles.grid.partialTimingMarks,
       });
     }
@@ -127,9 +125,8 @@ export function convertElectionDefinition(
       });
     }
 
-    const frontMetadata =
-      frontGridAndBubbles.metadata as BallotPageTimingMarkMetadataFront;
-    const ballotStyleId = `card-number-${frontMetadata.cardNumber}`;
+    const frontMetadata = frontGridAndBubbles.metadata as BallotConfig;
+    const ballotStyleId = `card-number-${frontMetadata.card}`;
 
     const frontTemplateBubbles = frontGridAndBubbles.bubbles;
     const backTemplateBubbles = backGridAndBubbles.bubbles;

--- a/libs/converter-nh-accuvote/src/convert/types.ts
+++ b/libs/converter-nh-accuvote/src/convert/types.ts
@@ -162,7 +162,6 @@ export type ConvertIssue =
       message: string;
       side: 'front' | 'back';
       timingMarks: PartialTimingMarks;
-      timingMarkBits: readonly boolean[];
       validationError?: ZodError;
     }
   | {


### PR DESCRIPTION
## Overview
I mostly wanted to make this code more readable, tested, and idiomatic. In the process I found it easiest to improve the tests by making them round-trip encode/decode, so I added encoding functionality to the metadata structs. A summary of changes:
- Make the structs contain only the fields relevant to the running program; omit fields that are only related to encoding.
- Rename the structs after the information they contain rather than their position on a ballot card.
- Add property tests for encoding/decoding.
- Use `impl` methods for encode/decode rather than free functions.
- Make some helper functions for bitwise encode/decode.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated.