### PR TITLE
fix(design): omit empty place parts

### DIFF
--- a/libs/hmpb/layout/src/layout.ts
+++ b/libs/hmpb/layout/src/layout.ts
@@ -506,7 +506,9 @@ function HeaderAndInstructions({
             fontStyle: m.FontStyles.H3,
           },
           {
-            text: `${precinct.name}, ${election.county.name}, ${election.state}`,
+            text: [precinct.name, election.county.name, election.state]
+              .filter(Boolean)
+              .join(', '),
             fontStyle: m.FontStyles.BODY,
           },
         ],


### PR DESCRIPTION
## Overview

If someone wants to leave e.g. state blank we shouldn't put a trailing comma after the county name. I realize this is going to be replaced soonish. Consider it a request to preserve this fix in the new version.

## Demo Video or Screenshot
<img width="286" alt="image" src="https://github.com/votingworks/vxsuite/assets/1938/0ba1519e-f0e2-42da-96bb-8e94b98d6c89">

## Testing Plan
Generated some sample ballots.