### PR TITLE
Allow daemons to run without hardware; make more robust for different device configs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1258,6 +1258,24 @@ jobs:
           command: |
             cargo test -p controllerd
 
+  test-crate-daemon-utils:
+    executor: 'nodejs'
+    resource_class: xlarge
+    steps:
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            cargo build -p daemon-utils
+      - run:
+          name: Lint
+          command: |
+            cargo clippy -p daemon-utils
+      - run:
+          name: Test
+          command: |
+            cargo test -p daemon-utils
+
   test-crate-types-rs:
     executor: 'nodejs'
     resource_class: xlarge
@@ -1364,6 +1382,7 @@ workflows:
       - test-libs-utils
       - test-crate-ballot-interpreter
       - test-crate-controllerd
+      - test-crate-daemon-utils
       - test-crate-types-rs
       - test-crate-vx-logging
       - validate-monorepo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfaff671f6b22ca62406885ece523383b9b64022e341e53e009a62ebc47a45f2"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -264,6 +265,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -315,9 +328,11 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 name = "controllerd"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "color-eyre",
  "crc16",
  "ctrlc",
+ "daemon-utils",
  "num_enum",
  "serde",
  "serde_json",
@@ -410,6 +425,13 @@ name = "custom_derive"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
+
+[[package]]
+name = "daemon-utils"
+version = "0.1.0"
+dependencies = [
+ "vx-logging",
+]
 
 [[package]]
 name = "either"
@@ -626,6 +648,12 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -1144,7 +1172,9 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 name = "patinputd"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "ctrlc",
+ "daemon-utils",
  "uinput",
  "vx-logging",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "libs/types-rs",
   "apps/mark-scan/accessible-controller",
   "apps/mark-scan/pat-device-input",
+  "apps/mark-scan/daemon-utils",
 ]
 
 [workspace.dependencies]
@@ -21,6 +22,7 @@ imageproc = "0.23.0"
 itertools = "0.10.5"
 log = "0.4.17"
 vx-logging = { path = "libs/logging" }
+daemon-utils = { path = "apps/mark-scan/daemon-utils" }
 logging_timer = "1.1.0"
 neon = { version = "0.10", default-features = false, features = ["napi-6"] }
 num_enum = "0.7.1"

--- a/apps/mark-scan/accessible-controller/Cargo.toml
+++ b/apps/mark-scan/accessible-controller/Cargo.toml
@@ -8,9 +8,11 @@ name = "controllerd"
 path = "src/controllerd.rs"
 
 [dependencies]
+clap = { workspace = true, features = ["derive"] }
 color-eyre = { workspace = true }
 crc16 = { workspace = true }
 ctrlc = { workspace = true }
+daemon-utils = { workspace = true }
 num_enum = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/apps/mark-scan/accessible-controller/src/controllerd.rs
+++ b/apps/mark-scan/accessible-controller/src/controllerd.rs
@@ -36,7 +36,7 @@ const KPB_200_FW_PID: u16 = 16392;
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
-    // Whether to allow the daemon to run if no hardware is found.
+    /// Allow the daemon to run if no hardware is found.
     #[arg(short, long)]
     skip_hardware_check: bool,
 }
@@ -44,6 +44,7 @@ struct Args {
 fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
 
+    let args = Args::parse();
     set_app_name(APP_NAME);
     log!(
         EventId::ProcessStarted;
@@ -87,7 +88,6 @@ fn main() -> color_eyre::Result<()> {
         exit(0);
     }
 
-    let args = Args::parse();
     if args.skip_hardware_check {
         run_no_op_event_loop(&running);
         exit(0);

--- a/apps/mark-scan/accessible-controller/src/controllerd.rs
+++ b/apps/mark-scan/accessible-controller/src/controllerd.rs
@@ -30,6 +30,8 @@ mod device;
 mod port;
 
 const APP_NAME: &str = "vx-mark-scan-controller-daemon";
+const KPB_200_FW_VID: u16 = 10445;
+const KPB_200_FW_PID: u16 = 16392;
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -80,7 +82,27 @@ fn main() -> color_eyre::Result<()> {
         EventType::SystemAction
     );
 
-    match Port::open() {
+    if let Some(port) = get_port() {
+        run_event_loop(keyboard, port, &running);
+        exit(0);
+    }
+
+    let args = Args::parse();
+    if args.skip_hardware_check {
+        run_no_op_event_loop(&running);
+        exit(0);
+    }
+
+    log!(
+        event_id: EventId::ProcessTerminated,
+        event_type: EventType::SystemStatus,
+        message: "Could not connect to ATI controller".to_string()
+    );
+    exit(1);
+}
+
+fn get_port() -> Option<Port> {
+    match Port::open_by_ids(KPB_200_FW_VID, KPB_200_FW_PID) {
         Ok(port) => {
             log!(
                 event_id: EventId::ControllerConnectionComplete,
@@ -89,26 +111,19 @@ fn main() -> color_eyre::Result<()> {
                 disposition: Disposition::Success
             );
 
-            run_event_loop(keyboard, port, &running);
+            return Some(port);
         }
         Err(e) => {
             log!(
                 event_id: EventId::ControllerConnectionComplete,
-                message: format!("Failed to open port. Error: {e}"),
+                message: format!("Failed to open controller port. Error: {e}"),
                 event_type: EventType::SystemAction,
                 disposition: Disposition::Failure
             );
-            let args = Args::parse();
-            if args.skip_hardware_check {
-                run_no_op_event_loop(&running);
-                exit(0);
-            }
-
-            exit(1);
         }
     }
 
-    Ok(())
+    None
 }
 
 fn run_event_loop(mut keyboard: impl VirtualKeyboard, mut port: Port, running: &Arc<AtomicBool>) {
@@ -128,7 +143,7 @@ fn run_event_loop(mut keyboard: impl VirtualKeyboard, mut port: Port, running: &
             Err(e) => {
                 log!(
                     event_id: EventId::UnknownError,
-                    message: format!("Unexpected error when opening serial port: {e}"),
+                    message: format!("Unexpected error when reading from serial port: {e:?}"),
                     event_type: EventType::SystemStatus
                 );
             }

--- a/apps/mark-scan/accessible-controller/src/controllerd.rs
+++ b/apps/mark-scan/accessible-controller/src/controllerd.rs
@@ -6,6 +6,8 @@
 //! for change in signal value. When a button press is detected, it sends
 //! a keypress event for consumption by the mark-scan application.
 
+use clap::Parser;
+use daemon_utils::run_no_op_event_loop;
 use std::{
     io::{self, Read},
     process::exit,
@@ -28,6 +30,14 @@ mod device;
 mod port;
 
 const APP_NAME: &str = "vx-mark-scan-controller-daemon";
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Args {
+    // Whether to allow the daemon to run if no hardware is found.
+    #[arg(short, long)]
+    skip_hardware_check: bool,
+}
 
 fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
@@ -88,6 +98,12 @@ fn main() -> color_eyre::Result<()> {
                 event_type: EventType::SystemAction,
                 disposition: Disposition::Failure
             );
+            let args = Args::parse();
+            if args.skip_hardware_check {
+                run_no_op_event_loop(&running);
+                exit(0);
+            }
+
             exit(1);
         }
     }

--- a/apps/mark-scan/accessible-controller/src/controllerd.rs
+++ b/apps/mark-scan/accessible-controller/src/controllerd.rs
@@ -30,8 +30,8 @@ mod device;
 mod port;
 
 const APP_NAME: &str = "vx-mark-scan-controller-daemon";
-const KPB_200_FW_VID: u16 = 10445;
-const KPB_200_FW_PID: u16 = 16392;
+const KPB_200_FW_VID: u16 = 0x28cd;
+const KPB_200_FW_PID: u16 = 0x4008;
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]

--- a/apps/mark-scan/daemon-utils/Cargo.toml
+++ b/apps/mark-scan/daemon-utils/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "daemon-utils"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+vx-logging = { workspace = true }
+
+[lints]
+workspace = true

--- a/apps/mark-scan/daemon-utils/src/lib.rs
+++ b/apps/mark-scan/daemon-utils/src/lib.rs
@@ -8,8 +8,8 @@ use std::{
 };
 use vx_logging::{log, EventId, EventType};
 
-const HEARTBEAT_INTERVAL: Duration = Duration::new(5, 0);
-const NOOP_LOOP_INTERVAL: Duration = Duration::new(1, 0);
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+const NOOP_LOOP_INTERVAL: Duration = Duration::from_secs(1);
 
 pub fn run_no_op_event_loop(running: &Arc<AtomicBool>) {
     log!(

--- a/apps/mark-scan/daemon-utils/src/lib.rs
+++ b/apps/mark-scan/daemon-utils/src/lib.rs
@@ -1,0 +1,44 @@
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    thread::sleep,
+    time::{Duration, Instant},
+};
+use vx_logging::{log, EventId, EventType};
+
+const HEARTBEAT_INTERVAL: Duration = Duration::new(5, 0);
+const NOOP_LOOP_INTERVAL: Duration = Duration::new(1, 0);
+
+pub fn run_no_op_event_loop(running: &Arc<AtomicBool>) {
+    log!(
+        event_id: EventId::Info,
+        event_type: EventType::SystemStatus,
+        message: format!("Connection will not be reattempted. Running a no-op loop, ctrl+c to exit.")
+    );
+
+    let mut last_heartbeat_log_time = Instant::now();
+    loop {
+        if !running.load(Ordering::SeqCst) {
+            log!(
+                EventId::ProcessTerminated;
+                EventType::SystemAction
+            );
+            break;
+        }
+
+        if last_heartbeat_log_time.elapsed() > HEARTBEAT_INTERVAL {
+            log!(
+                EventId::Heartbeat;
+                EventType::SystemStatus
+            );
+
+            last_heartbeat_log_time = Instant::now();
+        }
+
+        // Separate loop and heartbeat intervals allow for faster response to kill signal
+        // without spamming heartbeat logs
+        sleep(NOOP_LOOP_INTERVAL);
+    }
+}

--- a/apps/mark-scan/daemon-utils/src/lib.rs
+++ b/apps/mark-scan/daemon-utils/src/lib.rs
@@ -13,9 +13,8 @@ const NOOP_LOOP_INTERVAL: Duration = Duration::new(1, 0);
 
 pub fn run_no_op_event_loop(running: &Arc<AtomicBool>) {
     log!(
-        event_id: EventId::Info,
-        event_type: EventType::SystemStatus,
-        message: format!("Connection will not be reattempted. Running a no-op loop, ctrl+c to exit.")
+        EventId::Info,
+        "Connection will not be reattempted. Running a no-op loop, ctrl+c to exit."
     );
 
     let mut last_heartbeat_log_time = Instant::now();

--- a/apps/mark-scan/pat-device-input/Cargo.toml
+++ b/apps/mark-scan/pat-device-input/Cargo.toml
@@ -11,5 +11,7 @@ path = "src/patinputd.rs"
 
 [dependencies]
 ctrlc = { workspace = true }
-vx-logging = { workspace = true }
+daemon-utils = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
 uinput = { workspace = true }
+vx-logging = { workspace = true }

--- a/apps/mark-scan/pat-device-input/Cargo.toml
+++ b/apps/mark-scan/pat-device-input/Cargo.toml
@@ -10,8 +10,8 @@ path = "src/patinputd.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { workspace = true, features = ["derive"] }
 ctrlc = { workspace = true }
 daemon-utils = { workspace = true }
-clap = { workspace = true, features = ["derive"] }
 uinput = { workspace = true }
 vx-logging = { workspace = true }

--- a/apps/mark-scan/pat-device-input/src/patinputd.rs
+++ b/apps/mark-scan/pat-device-input/src/patinputd.rs
@@ -17,7 +17,7 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
-    thread::{self},
+    thread,
     time::Duration,
 };
 use uinput::{

--- a/apps/mark-scan/pat-device-input/src/patinputd.rs
+++ b/apps/mark-scan/pat-device-input/src/patinputd.rs
@@ -39,7 +39,7 @@ const SIGNAL_B_PIN: Pin = Pin::new(476);
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
-    // Whether to allow the daemon to run if no hardware is found.
+    /// Allow the daemon to run if no hardware is found.
     #[arg(short, long)]
     skip_hardware_check: bool,
 }
@@ -69,6 +69,8 @@ fn set_up_pins() -> io::Result<()> {
 }
 
 fn main() {
+    let args = Args::parse();
+
     set_app_name(APP_NAME);
     log!(EventId::ProcessStarted; EventType::SystemAction);
 
@@ -108,7 +110,6 @@ fn main() {
             message: format!("An error occurred during GPIO pin connection: {err}")
         );
 
-        let args = Args::parse();
         if args.skip_hardware_check {
             run_no_op_event_loop(&running);
             exit(0);

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -42,6 +42,14 @@ IDs are logged with each log to identify the log being written.
 **Type:** [system-status](#system-status)  
 **Description:** A message from the machine kernel about an externally-connected USB device, usually when a new device is connected or disconnected.  
 **Machines:** All
+### info
+**Type:** [system-status](#system-status)  
+**Description:** The process is reporting general status.  
+**Machines:** vx-mark-scan-controller-daemon, vx-mark-scan-pat-daemon
+### heartbeat
+**Type:** [system-status](#system-status)  
+**Description:** The process sent a heartbeat  
+**Machines:** vx-mark-scan-controller-daemon, vx-mark-scan-pat-daemon
 ### process-started
 **Type:** [system-action](#system-action)  
 **Description:** A VotingWorks-authored process (eg. hardware daemon) has been started.  

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -39,6 +39,24 @@ eventId = "usb-device-change-detected"
 eventType = "system-status"
 documentationMessage = "A message from the machine kernel about an externally-connected USB device, usually when a new device is connected or disconnected."
 
+[Info]
+eventId = "info"
+eventType = "system-status"
+documentationMessage = "The process is reporting general status."
+restrictInDocumentationToApps = [
+  "vx-mark-scan-controller-daemon",
+  "vx-mark-scan-pat-daemon",
+]
+
+[Heartbeat]
+eventId = "heartbeat"
+eventType = "system-status"
+documentationMessage = "The process sent a heartbeat"
+restrictInDocumentationToApps = [
+  "vx-mark-scan-controller-daemon",
+  "vx-mark-scan-pat-daemon",
+]
+
 [ProcessStarted]
 eventId = "process-started"
 eventType = "system-action"

--- a/libs/logging/src/log_event_ids.ts
+++ b/libs/logging/src/log_event_ids.ts
@@ -19,6 +19,8 @@ export enum LogEventId {
   MachineShutdownInit = 'machine-shutdown-init',
   MachineShutdownComplete = 'machine-shutdown-complete',
   UsbDeviceChangeDetected = 'usb-device-change-detected',
+  Info = 'info',
+  Heartbeat = 'heartbeat',
   ProcessStarted = 'process-started',
   ProcessTerminated = 'process-terminated',
   AuthPinEntry = 'auth-pin-entry',
@@ -180,6 +182,26 @@ const UsbDeviceChangeDetected: LogDetails = {
   eventType: LogEventType.SystemStatus,
   documentationMessage:
     'A message from the machine kernel about an externally-connected USB device, usually when a new device is connected or disconnected.',
+};
+
+const Info: LogDetails = {
+  eventId: LogEventId.Info,
+  eventType: LogEventType.SystemStatus,
+  documentationMessage: 'The process is reporting general status.',
+  restrictInDocumentationToApps: [
+    LogSource.VxMarkScanControllerDaemon,
+    LogSource.VxMarkScanPatDaemon,
+  ],
+};
+
+const Heartbeat: LogDetails = {
+  eventId: LogEventId.Heartbeat,
+  eventType: LogEventType.SystemStatus,
+  documentationMessage: 'The process sent a heartbeat',
+  restrictInDocumentationToApps: [
+    LogSource.VxMarkScanControllerDaemon,
+    LogSource.VxMarkScanPatDaemon,
+  ],
 };
 
 const ProcessStarted: LogDetails = {
@@ -1110,6 +1132,10 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return MachineShutdownComplete;
     case LogEventId.UsbDeviceChangeDetected:
       return UsbDeviceChangeDetected;
+    case LogEventId.Info:
+      return Info;
+    case LogEventId.Heartbeat:
+      return Heartbeat;
     case LogEventId.ProcessStarted:
       return ProcessStarted;
     case LogEventId.ProcessTerminated:

--- a/libs/logging/types-rust/src/log_event_enums.rs
+++ b/libs/logging/types-rust/src/log_event_enums.rs
@@ -23,6 +23,10 @@ pub enum EventId {
     MachineShutdownComplete,
     #[serde(rename = "usb-device-change-detected")]
     UsbDeviceChangeDetected,
+    #[serde(rename = "info")]
+    Info,
+    #[serde(rename = "heartbeat")]
+    Heartbeat,
     #[serde(rename = "process-started")]
     ProcessStarted,
     #[serde(rename = "process-terminated")]

--- a/vxsuite.code-workspace
+++ b/vxsuite.code-workspace
@@ -57,6 +57,10 @@
       "path": "apps/mark-scan/integration-testing"
     },
     {
+      "name": "apps/mark-scan/daemon-utils",
+      "path": "apps/mark-scan/daemon-utils"
+    },
+    {
       "name": "apps/mark-scan/accessible-controller",
       "path": "apps/mark-scan/accessible-controller"
     },


### PR DESCRIPTION
## Overview
Allows `controllerd` and `patinputd` to run when no hardware is found. The daemons will report failure to connect then run in a no-op loop with a heartbeat logged every 5s.

## Demo Video or Screenshot

PAT input running with no hardware

![Screenshot 2024-03-22 at 6 30 48 PM](https://github.com/votingworks/vxsuite/assets/1060688/d44ddade-a3b5-41b2-8705-fb9e5e704dbb)

Controller daemon running with no hardware

![Screenshot 2024-04-01 at 3 36 41 PM](https://github.com/votingworks/vxsuite/assets/1060688/ec9b7fed-1909-4b6d-953d-5bd1d20a40f3)

Controller daemon successfully connecting

<img width="1510" alt="Screenshot 2024-04-01 at 3 35 21 PM" src="https://github.com/votingworks/vxsuite/assets/1060688/b78a1f85-8d9f-4b65-9041-d66802ff4ab2">



## Testing Plan
* Manually tested both daemons run on VM
* Manually tested both hardware devices work on real hardware

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
