### PR TITLE
Modify pdfToImages to output an image Buffer instead of ImageData

### DIFF
--- a/libs/image-utils/src/image_data.test.ts
+++ b/libs/image-utils/src/image_data.test.ts
@@ -1,21 +1,19 @@
 import { Buffer } from 'buffer';
 import { ImageData, createImageData } from 'canvas';
 import fc from 'fast-check';
-import { writeFile } from 'fs/promises';
 import { fileSync } from 'tmp';
 import { arbitraryImageData } from '../test/arbitraries';
 import {
   RGBA_CHANNEL_COUNT,
-  ensureImageData,
   fromGrayScale,
   getImageChannelCount,
   isRgba,
   loadImage,
   loadImageData,
   toDataUrl,
-  toImageBuffer,
   toImageData,
   writeImageData,
+  ensureImageData,
 } from './image_data';
 
 test('channels', () => {
@@ -192,25 +190,4 @@ test('ensureImageData', () => {
   };
   expect(ensureImageData(imageDataLike) === imageDataLike).toBeFalsy();
   expect(ensureImageData(imageDataLike)).toBeInstanceOf(ImageData);
-});
-
-test('toImageBuffer', async () => {
-  await fc.assert(
-    fc.asyncProperty(
-      arbitraryImageData({ width: 5, height: 5 }),
-      fc.constantFrom<'png' | 'jpeg' | undefined>('png', 'jpeg', undefined),
-      async (imageData, format) => {
-        const buffer = toImageBuffer(imageData, format && `image/${format}`);
-        const filePath = fileSync({ template: `tmp-XXXXXX.${format}` }).name;
-        await writeFile(filePath, buffer);
-        const { width: decodedWidth, height: decodedHeight } = toImageData(
-          await loadImage(filePath)
-        );
-        expect({ width: decodedWidth, height: decodedHeight }).toStrictEqual({
-          width: imageData.width,
-          height: imageData.height,
-        });
-      }
-    )
-  );
 });

--- a/libs/image-utils/src/image_data.ts
+++ b/libs/image-utils/src/image_data.ts
@@ -131,22 +131,6 @@ export async function writeImageData(
 }
 
 /**
- * Converts an ImageData to an image Buffer.
- */
-export function toImageBuffer(
-  imageData: ImageData,
-  mimeType: 'image/png' | 'image/jpeg' = 'image/png'
-): Buffer {
-  const canvas = createCanvas(imageData.width, imageData.height);
-  const context = canvas.getContext('2d');
-  context.putImageData(ensureImageData(imageData), 0, 0);
-  // Help TS match the union type branches to overloaded function signatures
-  return mimeType === 'image/png'
-    ? canvas.toBuffer(mimeType)
-    : canvas.toBuffer(mimeType);
-}
-
-/**
  * Extracts image data from an image.
  */
 export function toImageData(

--- a/libs/image-utils/src/jest_pdf_snapshot.ts
+++ b/libs/image-utils/src/jest_pdf_snapshot.ts
@@ -1,7 +1,6 @@
 import { readFile } from 'fs/promises';
 import { Buffer } from 'buffer';
 import { pdfToImages } from './pdf_to_images';
-import { toImageBuffer } from './image_data';
 
 /**
  * Options for `toMatchPdfSnapshot`.
@@ -27,8 +26,7 @@ export async function toMatchPdfSnapshot(
     typeof received === 'string' ? await readFile(received) : received;
   const pdfPages = pdfToImages(pdfContents, { scale: 200 / 72 });
   for await (const { page, pageNumber } of pdfPages) {
-    const imageBuffer = toImageBuffer(page);
-    expect(imageBuffer).toMatchImageSnapshot({
+    expect(page).toMatchImageSnapshot({
       customSnapshotIdentifier: options.customSnapshotIdentifier
         ? `${options.customSnapshotIdentifier}-${pageNumber}`
         : undefined,


### PR DESCRIPTION


## Overview

Avoids an extra round trip from Canvas->Buffer->Canvas in all of the places we actually use pdfToImages. Also removes the toImageBuffer function that was being used to do this round trip, which is no longer needed.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
