### PR TITLE
chore(auth): remove unnecessary `async` in tmpfile cleanup

### DIFF
--- a/libs/auth/src/cryptography.test.ts
+++ b/libs/auth/src/cryptography.test.ts
@@ -146,7 +146,9 @@ test('openssl - error writing temp file', async () => {
 test('openssl - error cleaning up temp files', async () => {
   setTimeout(() => {
     for (const tempFileRemoveCallback of tempFileRemoveCallbacks) {
-      tempFileRemoveCallback.mockRejectedValueOnce(new Error('Whoa!'));
+      tempFileRemoveCallback.mockImplementationOnce(() => {
+        throw new Error('Whoa!');
+      });
     }
     mockChildProcess.emit('close', successExitCode);
   });

--- a/libs/auth/src/cryptography.ts
+++ b/libs/auth/src/cryptography.ts
@@ -105,9 +105,9 @@ export async function openssl(
   try {
     stdout = await runCommand(['openssl', ...processedParams], { stdin });
   } finally {
-    await Promise.all(
-      tempFileResults.map((tempFile) => tempFile.removeCallback())
-    );
+    for (const tempFile of tempFileResults) {
+      tempFile.removeCallback();
+    }
   }
   return stdout;
 }


### PR DESCRIPTION

## Overview

`FileResult::removeCallback` doesn't return a `Promise`, so there's no sense in `await`ing the result. See the value of `removeCallback` here: https://github.com/raszi/node-tmp/blob/7ae22ed2d56c10d425a66e99fe8bc10c925442e6/lib/tmp.js#L181.

## Demo Video or Screenshot
n/a

## Testing Plan
Updated automated test that incorrectly mocked using a `Promise`.