### PR TITLE
fix(auth): parse all TLV responses properly

### DIFF
--- a/libs/auth/src/apdu.ts
+++ b/libs/auth/src/apdu.ts
@@ -303,7 +303,7 @@ export interface Tlv {
 export function parseTlvPartial(
   tagAsByteOrBuffer: Byte | Buffer,
   tlv: Buffer
-): [remainder: Buffer, tlv: Tlv] {
+): [tlv: Tlv, remainder: Buffer] {
   const expectedTag = Buffer.isBuffer(tagAsByteOrBuffer)
     ? tagAsByteOrBuffer
     : Buffer.of(tagAsByteOrBuffer);
@@ -357,7 +357,7 @@ export function parseTlvPartial(
   );
   const remainder = tlv.subarray(tagLength + lengthBytesLength + valueLength);
 
-  return [remainder, { tag, length: lengthBytes, value }];
+  return [{ tag, length: lengthBytes, value }, remainder];
 }
 
 /**
@@ -366,7 +366,7 @@ export function parseTlvPartial(
  * thrown.
  */
 export function parseTlv(tagAsByteOrBuffer: Byte | Buffer, data: Buffer): Tlv {
-  const [remainder, tlv] = parseTlvPartial(tagAsByteOrBuffer, data);
+  const [tlv, remainder] = parseTlvPartial(tagAsByteOrBuffer, data);
   assert(
     remainder.length === 0,
     `TLV was not fully consumed: remainder=${remainder.toString('hex')}`

--- a/libs/auth/src/cac/common_access_card.test.ts
+++ b/libs/auth/src/cac/common_access_card.test.ts
@@ -105,7 +105,7 @@ function mockCardGetCertificateRequest(
   const certTlv = constructTlv(PUT_DATA.CERT_TAG, derFormatCert);
   const certTlvWithMetadata = Buffer.concat([
     certTlv,
-    Buffer.of(PUT_DATA.CERT_INFO_TAG, 0x01, PUT_DATA.CERT_INFO_UNCOMPRESSED),
+    Buffer.of(PUT_DATA.CERT_INFO_TAG, 0x01, 0x01),
     Buffer.of(PUT_DATA.ERROR_DETECTION_CODE_TAG, 0x00),
   ]);
   mockCardGetDataRequest(objectId, certTlvWithMetadata);

--- a/libs/auth/src/cac/common_access_card.test.ts
+++ b/libs/auth/src/cac/common_access_card.test.ts
@@ -105,7 +105,7 @@ function mockCardGetCertificateRequest(
   const certTlv = constructTlv(PUT_DATA.CERT_TAG, derFormatCert);
   const certTlvWithMetadata = Buffer.concat([
     certTlv,
-    Buffer.of(PUT_DATA.CERT_INFO_TAG, 0x01, 0x01),
+    Buffer.of(PUT_DATA.CERT_INFO_TAG, 0x01, PUT_DATA.CERT_INFO_UNCOMPRESSED),
     Buffer.of(PUT_DATA.ERROR_DETECTION_CODE_TAG, 0x00),
   ]);
   mockCardGetDataRequest(objectId, certTlvWithMetadata);

--- a/libs/auth/src/cac/common_access_card.ts
+++ b/libs/auth/src/cac/common_access_card.ts
@@ -421,7 +421,10 @@ export class CommonAccessCard implements CommonAccessCardCompatibleCard {
     );
     // NOTE: CACs seem to return 0x01 for this. I'm not sure what it means, but
     // it's not compressed.
-    assert(certInfo[0] === 0x01, 'Expected cert info to be uncompressed');
+    assert(
+      certInfo[0] === PUT_DATA.CERT_INFO_UNCOMPRESSED,
+      'Expected cert info to be uncompressed'
+    );
     const certErrorDetectionCode = parseTlv(
       PUT_DATA.ERROR_DETECTION_CODE_TAG,
       certInfoRemainder

--- a/libs/auth/src/cac/common_access_card.ts
+++ b/libs/auth/src/cac/common_access_card.ts
@@ -413,9 +413,9 @@ export class CommonAccessCard implements CommonAccessCardCompatibleCard {
       return Buffer.of();
     }
 
-    const [certInDerFormatRemainder, { value: certInDerFormat }] =
+    const [{ value: certInDerFormat }, certInDerFormatRemainder] =
       parseTlvPartial(PUT_DATA.CERT_TAG, data);
-    const [certInfoRemainder, { value: certInfo }] = parseTlvPartial(
+    const [{ value: certInfo }, certInfoRemainder] = parseTlvPartial(
       PUT_DATA.CERT_INFO_TAG,
       certInDerFormatRemainder
     );
@@ -503,7 +503,7 @@ export class CommonAccessCard implements CommonAccessCardCompatibleCard {
       GENERATE_ASYMMETRIC_KEY_PAIR.RESPONSE_TAG,
       generateKeyPairResponse
     );
-    const [rsaPublicKeyTlvRemainder, { value: modulusValue }] = parseTlvPartial(
+    const [{ value: modulusValue }, rsaPublicKeyTlvRemainder] = parseTlvPartial(
       GENERATE_ASYMMETRIC_KEY_PAIR.RESPONSE_RSA_MODULUS_TAG,
       rsaPublicKey
     );

--- a/libs/auth/src/java_card.ts
+++ b/libs/auth/src/java_card.ts
@@ -497,9 +497,9 @@ export class JavaCard implements Card {
    */
   private async retrieveCert(certObjectId: Buffer): Promise<Buffer> {
     const data = await this.getData(certObjectId);
-    const [certInDerFormatRemainder, { value: certInDerFormat }] =
+    const [{ value: certInDerFormat }, certInDerFormatRemainder] =
       parseTlvPartial(PUT_DATA.CERT_TAG, data);
-    const [certInfoRemainder, { value: certInfo }] = parseTlvPartial(
+    const [{ value: certInfo }, certInfoRemainder] = parseTlvPartial(
       PUT_DATA.CERT_INFO_TAG,
       certInDerFormatRemainder
     );


### PR DESCRIPTION

## Overview

Rather than trimming metadata by ignoring fixed-length prefixes and suffixes, we now properly parse the TLV structures. Additionally, this changes the `parseTlv` function to expect the data to be entirely consumed by the TLV structure. If it isn't, use `parseTlvPartial` instead, which returns a remainder.

## Demo Video or Screenshot
n/a

## Testing Plan
Updated tests for where we had the expected responses wrong (just getting certs for CAC's).