### PR TITLE
Refactor: Simplify test deck generation arguments

### DIFF
--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -315,7 +315,7 @@ function buildApi({ translator, workspace }: AppContext) {
 
       zip.file(
         FULL_TEST_DECK_TALLY_REPORT_FILE_NAME,
-        createTestDeckTallyReport({ electionDefinition, ballots })
+        createTestDeckTallyReport({ electionDefinition })
       );
 
       return {

--- a/apps/design/backend/src/test_decks.test.ts
+++ b/apps/design/backend/src/test_decks.test.ts
@@ -150,22 +150,17 @@ describe('createPrecinctTestDeck', () => {
 
 describe('getTallyReportResults', () => {
   test('general', async () => {
-    const { electionDefinition } = electionFamousNames2021Fixtures;
-    const { election } = electionDefinition;
-
-    const { ballots } = layOutAllBallotStyles({
-      election,
+    const { electionDefinition } = layOutAllBallotStyles({
+      election: electionFamousNames2021Fixtures.election,
       ballotType: BallotType.Precinct,
       ballotMode: 'test',
       layoutOptions: DEFAULT_LAYOUT_OPTIONS,
       nhCustomContent: {},
       translatedElectionStrings: {},
     }).unsafeUnwrap();
+    const { election } = electionDefinition;
 
-    const tallyReportResults = await getTallyReportResults({
-      election,
-      ballots,
-    });
+    const tallyReportResults = await getTallyReportResults({ election });
 
     expect(tallyReportResults.hasPartySplits).toEqual(false);
     expect(tallyReportResults.contestIds).toEqual(
@@ -203,22 +198,17 @@ describe('getTallyReportResults', () => {
   });
 
   test('primary', async () => {
-    const { electionDefinition } = electionTwoPartyPrimaryFixtures;
-    const { election } = electionDefinition;
-
-    const { ballots } = layOutAllBallotStyles({
-      election,
+    const { electionDefinition } = layOutAllBallotStyles({
+      election: electionTwoPartyPrimaryFixtures.election,
       ballotType: BallotType.Precinct,
       ballotMode: 'test',
       layoutOptions: DEFAULT_LAYOUT_OPTIONS,
       nhCustomContent: {},
       translatedElectionStrings: {},
     }).unsafeUnwrap();
+    const { election } = electionDefinition;
 
-    const tallyReportResults = await getTallyReportResults({
-      election,
-      ballots,
-    });
+    const tallyReportResults = await getTallyReportResults({ election });
 
     expect(tallyReportResults.hasPartySplits).toEqual(true);
     expect(tallyReportResults.contestIds).toEqual(
@@ -266,10 +256,8 @@ describe('getTallyReportResults', () => {
 });
 
 test('createTestDeckTallyReport', async () => {
-  const electionDefinition = electionGeneralDefinition;
-  const { election } = electionDefinition;
-  const { ballots } = layOutAllBallotStyles({
-    election,
+  const { electionDefinition } = layOutAllBallotStyles({
+    election: electionGeneralDefinition.election,
     ballotType: BallotType.Precinct,
     ballotMode: 'test',
     layoutOptions: DEFAULT_LAYOUT_OPTIONS,
@@ -279,7 +267,6 @@ test('createTestDeckTallyReport', async () => {
 
   const reportDocumentBuffer = await createTestDeckTallyReport({
     electionDefinition,
-    ballots,
     generatedAtTime: new Date('2021-01-01T00:00:00.000'),
   });
 

--- a/apps/design/backend/src/test_decks.test.ts
+++ b/apps/design/backend/src/test_decks.test.ts
@@ -160,7 +160,7 @@ describe('getTallyReportResults', () => {
     }).unsafeUnwrap();
     const { election } = electionDefinition;
 
-    const tallyReportResults = await getTallyReportResults({ election });
+    const tallyReportResults = await getTallyReportResults(election);
 
     expect(tallyReportResults.hasPartySplits).toEqual(false);
     expect(tallyReportResults.contestIds).toEqual(
@@ -208,7 +208,7 @@ describe('getTallyReportResults', () => {
     }).unsafeUnwrap();
     const { election } = electionDefinition;
 
-    const tallyReportResults = await getTallyReportResults({ election });
+    const tallyReportResults = await getTallyReportResults(election);
 
     expect(tallyReportResults.hasPartySplits).toEqual(true);
     expect(tallyReportResults.contestIds).toEqual(

--- a/apps/design/backend/src/test_decks.ts
+++ b/apps/design/backend/src/test_decks.ts
@@ -1,4 +1,4 @@
-import { assert, find, uniqueBy } from '@votingworks/basics';
+import { assert, assertDefined, find, uniqueBy } from '@votingworks/basics';
 import { BallotLayout, Document, markBallot } from '@votingworks/hmpb-layout';
 import {
   Admin,
@@ -113,11 +113,9 @@ function getBallotContestLayouts(
   });
 }
 
-function generateTestDeckCastVoteRecords({
-  election,
-}: {
-  election: Election;
-}): Tabulation.CastVoteRecord[] {
+function generateTestDeckCastVoteRecords(
+  election: Election
+): Tabulation.CastVoteRecord[] {
   const ballotSpecs: TestDeckBallotSpec[] = generateTestDeckBallots({
     election,
     markingMethod: 'hand',
@@ -125,9 +123,8 @@ function generateTestDeckCastVoteRecords({
     includeOvervotedBallots: false,
   });
 
-  assert(election.gridLayouts);
   const ballotContestLayouts: BallotContestLayout[] = getBallotContestLayouts(
-    election.gridLayouts
+    assertDefined(election.gridLayouts)
   );
 
   const ballotStyleIdPartyIdLookup = getBallotStyleIdPartyIdLookup(election);
@@ -170,14 +167,10 @@ function generateTestDeckCastVoteRecords({
   return cvrs;
 }
 
-export async function getTallyReportResults({
-  election,
-}: {
-  election: Election;
-}): Promise<Admin.TallyReportResults> {
-  const cvrs = generateTestDeckCastVoteRecords({
-    election,
-  });
+export async function getTallyReportResults(
+  election: Election
+): Promise<Admin.TallyReportResults> {
+  const cvrs = generateTestDeckCastVoteRecords(election);
 
   if (election.type === 'general') {
     const [electionResults] = groupMapToGroupList(
@@ -235,7 +228,7 @@ export async function createTestDeckTallyReport({
 }): Promise<Buffer> {
   const { election } = electionDefinition;
 
-  const tallyReportResults = await getTallyReportResults({ election });
+  const tallyReportResults = await getTallyReportResults(election);
 
   return await renderToPdf({
     document: AdminTallyReportByParty({


### PR DESCRIPTION
## Overview

We don't need to pass the ballot documents in just to get the grid layouts, since the grid layouts are already in the election definition. Also, we don't need a layout for each precinct, since layouts are the same across precincts that share a ballot style.

This makes life a little easier when integrating the upcoming new ballot rendering stack.

## Demo Video or Screenshot

## Testing Plan
Existing tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
