### PR TITLE
Update BMD paper ballot single-page layout to fit more contests

### DIFF
--- a/apps/mark-scan/frontend/src/pages/print_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/print_page.tsx
@@ -41,7 +41,7 @@ export function PrintPage(): JSX.Element | null {
       votes={votes}
       generateBallotId={generateBallotId}
       printElement={printElementToCustomPaperHandler}
-      printType="vsap"
+      machineType="markScan"
     />
   );
 }

--- a/apps/mark-scan/frontend/src/pages/print_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/print_page.tsx
@@ -41,7 +41,7 @@ export function PrintPage(): JSX.Element | null {
       votes={votes}
       generateBallotId={generateBallotId}
       printElement={printElementToCustomPaperHandler}
-      largeTopMargin
+      printType="vsap"
     />
   );
 }

--- a/apps/mark/frontend/src/pages/print_page.tsx
+++ b/apps/mark/frontend/src/pages/print_page.tsx
@@ -44,6 +44,7 @@ export function PrintPage(): JSX.Element {
       votes={votes}
       generateBallotId={generateBallotId}
       onPrintStarted={onPrintStarted}
+      printType="vxMark"
     />
   );
 }

--- a/apps/mark/frontend/src/pages/print_page.tsx
+++ b/apps/mark/frontend/src/pages/print_page.tsx
@@ -44,7 +44,7 @@ export function PrintPage(): JSX.Element {
       votes={votes}
       generateBallotId={generateBallotId}
       onPrintStarted={onPrintStarted}
-      printType="vxMark"
+      machineType="mark"
     />
   );
 }

--- a/libs/mark-flow-ui/src/pages/__snapshots__/print_page.test.tsx.snap
+++ b/libs/mark-flow-ui/src/pages/__snapshots__/print_page.test.tsx.snap
@@ -68,31 +68,6 @@ exports[`no votes 1`] = `
   margin-top: 0 !important;
 }
 
-.c13 {
-  font-size: 1em;
-  line-height: 1.3;
-  margin: 0;
-  font-weight: 500;
-  line-height: 1.1700000000000002;
-  margin-bottom: 0.3em;
-  font-size: 1rem;
-  line-height: 1.105;
-  font-weight: 600;
-}
-
-.c13:not(:first-child) {
-  margin-top: 1.25em;
-}
-
-.c13 + h1,
-.c13 + h2,
-.c13 + h3,
-.c13 + h4,
-.c13 + h5,
-.c13 + h6 {
-  margin-top: 0 !important;
-}
-
 .c9 {
   white-space: nowrap;
 }
@@ -116,7 +91,7 @@ exports[`no votes 1`] = `
   color: #000;
   line-height: 1;
   font-family: 'Vx Roboto','Noto Emoji',sans-serif;
-  font-size: 16px;
+  font-size: 10pt !important;
   page-break-after: always;
 }
 
@@ -133,14 +108,7 @@ exports[`no votes 1`] = `
   -ms-flex-align: center;
   align-items: center;
   border-bottom: 0.2em solid #000;
-}
-
-.c1 h2 {
-  margin-bottom: 0;
-}
-
-.c1 h3 {
-  margin-top: 0;
+  margin-top: 1.75in;
 }
 
 .c1 > .ballot-header-content {
@@ -225,8 +193,8 @@ exports[`no votes 1`] = `
 .c11 {
   -webkit-columns: 2;
   columns: 2;
-  -webkit-column-gap: 2em;
-  column-gap: 2em;
+  -webkit-column-gap: 1em;
+  column-gap: 1em;
 }
 
 .c12 {
@@ -237,8 +205,11 @@ exports[`no votes 1`] = `
   page-break-inside: avoid;
 }
 
-.c14 {
+.c13 {
+  font-size: 1.125em;
   font-weight: normal;
+  margin: 0;
+  margin-bottom: 0.25em;
 }
 
 .c15 {
@@ -247,6 +218,10 @@ exports[`no votes 1`] = `
 
 .c15:not(:last-child) {
   margin-bottom: 0.125em;
+}
+
+.c14 {
+  display: inline-block;
 }
 
 @media print {
@@ -394,13 +369,17 @@ exports[`no votes 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              President and Vice-President
+            <span
+              class="c14"
+            >
+              <span>
+                President and Vice-President
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -418,13 +397,17 @@ exports[`no votes 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Representative, District 6
+            <span
+              class="c14"
+            >
+              <span>
+                Representative, District 6
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -442,13 +425,17 @@ exports[`no votes 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Lieutenant Governor
+            <span
+              class="c14"
+            >
+              <span>
+                Lieutenant Governor
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -466,13 +453,17 @@ exports[`no votes 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Senator, District 31
+            <span
+              class="c14"
+            >
+              <span>
+                Senator, District 31
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -490,13 +481,17 @@ exports[`no votes 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Assembly Member, District 54
+            <span
+              class="c14"
+            >
+              <span>
+                Assembly Member, District 54
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -514,13 +509,17 @@ exports[`no votes 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Registrar of Wills
+            <span
+              class="c14"
+            >
+              <span>
+                Registrar of Wills
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -538,13 +537,17 @@ exports[`no votes 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Retain Robert Demergue as Chief Justice?
+            <span
+              class="c14"
+            >
+              <span>
+                Retain Robert Demergue as Chief Justice?
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -562,13 +565,17 @@ exports[`no votes 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Question A: Recovery of Property Damages
+            <span
+              class="c14"
+            >
+              <span>
+                Question A: Recovery of Property Damages
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -586,13 +593,17 @@ exports[`no votes 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Question B: Separation of Powers
+            <span
+              class="c14"
+            >
+              <span>
+                Question B: Separation of Powers
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -610,13 +621,17 @@ exports[`no votes 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Proposition 1: Gambling in Franklin and Fromwit Counties
+            <span
+              class="c14"
+            >
+              <span>
+                Proposition 1: Gambling in Franklin and Fromwit Counties
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -634,13 +649,17 @@ exports[`no votes 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Measure 102: Vehicle Abatement Program
+            <span
+              class="c14"
+            >
+              <span>
+                Measure 102: Vehicle Abatement Program
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -736,31 +755,6 @@ exports[`with votes 1`] = `
   margin-top: 0 !important;
 }
 
-.c13 {
-  font-size: 1em;
-  line-height: 1.3;
-  margin: 0;
-  font-weight: 500;
-  line-height: 1.1700000000000002;
-  margin-bottom: 0.3em;
-  font-size: 1rem;
-  line-height: 1.105;
-  font-weight: 600;
-}
-
-.c13:not(:first-child) {
-  margin-top: 1.25em;
-}
-
-.c13 + h1,
-.c13 + h2,
-.c13 + h3,
-.c13 + h4,
-.c13 + h5,
-.c13 + h6 {
-  margin-top: 0 !important;
-}
-
 .c9 {
   white-space: nowrap;
 }
@@ -784,7 +778,7 @@ exports[`with votes 1`] = `
   color: #000;
   line-height: 1;
   font-family: 'Vx Roboto','Noto Emoji',sans-serif;
-  font-size: 16px;
+  font-size: 10pt !important;
   page-break-after: always;
 }
 
@@ -801,14 +795,7 @@ exports[`with votes 1`] = `
   -ms-flex-align: center;
   align-items: center;
   border-bottom: 0.2em solid #000;
-}
-
-.c1 h2 {
-  margin-bottom: 0;
-}
-
-.c1 h3 {
-  margin-top: 0;
+  margin-top: 1.75in;
 }
 
 .c1 > .ballot-header-content {
@@ -893,8 +880,8 @@ exports[`with votes 1`] = `
 .c11 {
   -webkit-columns: 2;
   columns: 2;
-  -webkit-column-gap: 2em;
-  column-gap: 2em;
+  -webkit-column-gap: 1em;
+  column-gap: 1em;
 }
 
 .c12 {
@@ -905,8 +892,11 @@ exports[`with votes 1`] = `
   page-break-inside: avoid;
 }
 
-.c14 {
+.c13 {
+  font-size: 1.125em;
   font-weight: normal;
+  margin: 0;
+  margin-bottom: 0.25em;
 }
 
 .c15 {
@@ -915,6 +905,10 @@ exports[`with votes 1`] = `
 
 .c15:not(:last-child) {
   margin-bottom: 0.125em;
+}
+
+.c14 {
+  display: inline-block;
 }
 
 @media print {
@@ -1062,13 +1056,17 @@ exports[`with votes 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              President and Vice-President
+            <span
+              class="c14"
+            >
+              <span>
+                President and Vice-President
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -1080,23 +1078,25 @@ exports[`with votes 1`] = `
               </span>
             </span>
              
-            (
             <span>
               Federalist
             </span>
-            )
           </span>
         </div>
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Representative, District 6
+            <span
+              class="c14"
+            >
+              <span>
+                Representative, District 6
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -1114,13 +1114,17 @@ exports[`with votes 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Lieutenant Governor
+            <span
+              class="c14"
+            >
+              <span>
+                Lieutenant Governor
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -1132,23 +1136,25 @@ exports[`with votes 1`] = `
               </span>
             </span>
              
-            (
             <span>
               Federalist
             </span>
-            )
           </span>
         </div>
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Senator, District 31
+            <span
+              class="c14"
+            >
+              <span>
+                Senator, District 31
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -1166,13 +1172,17 @@ exports[`with votes 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Assembly Member, District 54
+            <span
+              class="c14"
+            >
+              <span>
+                Assembly Member, District 54
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -1190,13 +1200,17 @@ exports[`with votes 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Registrar of Wills
+            <span
+              class="c14"
+            >
+              <span>
+                Registrar of Wills
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -1214,13 +1228,17 @@ exports[`with votes 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Retain Robert Demergue as Chief Justice?
+            <span
+              class="c14"
+            >
+              <span>
+                Retain Robert Demergue as Chief Justice?
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -1238,13 +1256,17 @@ exports[`with votes 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Question A: Recovery of Property Damages
+            <span
+              class="c14"
+            >
+              <span>
+                Question A: Recovery of Property Damages
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -1260,13 +1282,17 @@ exports[`with votes 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Question B: Separation of Powers
+            <span
+              class="c14"
+            >
+              <span>
+                Question B: Separation of Powers
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -1282,13 +1308,17 @@ exports[`with votes 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Proposition 1: Gambling in Franklin and Fromwit Counties
+            <span
+              class="c14"
+            >
+              <span>
+                Proposition 1: Gambling in Franklin and Fromwit Counties
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -1306,13 +1336,17 @@ exports[`with votes 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Measure 102: Vehicle Abatement Program
+            <span
+              class="c14"
+            >
+              <span>
+                Measure 102: Vehicle Abatement Program
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -1401,31 +1435,6 @@ exports[`without votes and inline seal 1`] = `
   margin-top: 0 !important;
 }
 
-.c13 {
-  font-size: 1em;
-  line-height: 1.3;
-  margin: 0;
-  font-weight: 500;
-  line-height: 1.1700000000000002;
-  margin-bottom: 0.3em;
-  font-size: 1rem;
-  line-height: 1.105;
-  font-weight: 600;
-}
-
-.c13:not(:first-child) {
-  margin-top: 1.25em;
-}
-
-.c13 + h1,
-.c13 + h2,
-.c13 + h3,
-.c13 + h4,
-.c13 + h5,
-.c13 + h6 {
-  margin-top: 0 !important;
-}
-
 .c9 {
   white-space: nowrap;
 }
@@ -1449,7 +1458,7 @@ exports[`without votes and inline seal 1`] = `
   color: #000;
   line-height: 1;
   font-family: 'Vx Roboto','Noto Emoji',sans-serif;
-  font-size: 16px;
+  font-size: 10pt !important;
   page-break-after: always;
 }
 
@@ -1466,14 +1475,7 @@ exports[`without votes and inline seal 1`] = `
   -ms-flex-align: center;
   align-items: center;
   border-bottom: 0.2em solid #000;
-}
-
-.c1 h2 {
-  margin-bottom: 0;
-}
-
-.c1 h3 {
-  margin-top: 0;
+  margin-top: 1.75in;
 }
 
 .c1 > .ballot-header-content {
@@ -1558,8 +1560,8 @@ exports[`without votes and inline seal 1`] = `
 .c11 {
   -webkit-columns: 2;
   columns: 2;
-  -webkit-column-gap: 2em;
-  column-gap: 2em;
+  -webkit-column-gap: 1em;
+  column-gap: 1em;
 }
 
 .c12 {
@@ -1570,8 +1572,11 @@ exports[`without votes and inline seal 1`] = `
   page-break-inside: avoid;
 }
 
-.c14 {
+.c13 {
+  font-size: 1.125em;
   font-weight: normal;
+  margin: 0;
+  margin-bottom: 0.25em;
 }
 
 .c15 {
@@ -1580,6 +1585,10 @@ exports[`without votes and inline seal 1`] = `
 
 .c15:not(:last-child) {
   margin-bottom: 0.125em;
+}
+
+.c14 {
+  display: inline-block;
 }
 
 @media print {
@@ -1727,13 +1736,17 @@ exports[`without votes and inline seal 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              President and Vice-President
+            <span
+              class="c14"
+            >
+              <span>
+                President and Vice-President
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -1751,13 +1764,17 @@ exports[`without votes and inline seal 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Representative, District 6
+            <span
+              class="c14"
+            >
+              <span>
+                Representative, District 6
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -1775,13 +1792,17 @@ exports[`without votes and inline seal 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Lieutenant Governor
+            <span
+              class="c14"
+            >
+              <span>
+                Lieutenant Governor
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -1799,13 +1820,17 @@ exports[`without votes and inline seal 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Senator, District 31
+            <span
+              class="c14"
+            >
+              <span>
+                Senator, District 31
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -1823,13 +1848,17 @@ exports[`without votes and inline seal 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Assembly Member, District 54
+            <span
+              class="c14"
+            >
+              <span>
+                Assembly Member, District 54
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -1847,13 +1876,17 @@ exports[`without votes and inline seal 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Registrar of Wills
+            <span
+              class="c14"
+            >
+              <span>
+                Registrar of Wills
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -1871,13 +1904,17 @@ exports[`without votes and inline seal 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Retain Robert Demergue as Chief Justice?
+            <span
+              class="c14"
+            >
+              <span>
+                Retain Robert Demergue as Chief Justice?
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -1895,13 +1932,17 @@ exports[`without votes and inline seal 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Question A: Recovery of Property Damages
+            <span
+              class="c14"
+            >
+              <span>
+                Question A: Recovery of Property Damages
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -1919,13 +1960,17 @@ exports[`without votes and inline seal 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Question B: Separation of Powers
+            <span
+              class="c14"
+            >
+              <span>
+                Question B: Separation of Powers
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -1943,13 +1988,17 @@ exports[`without votes and inline seal 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Proposition 1: Gambling in Franklin and Fromwit Counties
+            <span
+              class="c14"
+            >
+              <span>
+                Proposition 1: Gambling in Franklin and Fromwit Counties
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -1967,13 +2016,17 @@ exports[`without votes and inline seal 1`] = `
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Measure 102: Vehicle Abatement Program
+            <span
+              class="c14"
+            >
+              <span>
+                Measure 102: Vehicle Abatement Program
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >

--- a/libs/mark-flow-ui/src/pages/print_page.test.tsx
+++ b/libs/mark-flow-ui/src/pages/print_page.test.tsx
@@ -17,7 +17,7 @@ test('no votes', async () => {
       isLiveMode={false}
       votes={{}}
       onPrintStarted={jest.fn()}
-      printType="vsap"
+      machineType="markScan"
     />
   );
   await expectPrintToMatchSnapshot();
@@ -47,7 +47,7 @@ test('with votes', async () => {
       )}
       isLiveMode={false}
       onPrintStarted={jest.fn()}
-      printType="vsap"
+      machineType="markScan"
     />
   );
   await expectPrintToMatchSnapshot();
@@ -64,7 +64,7 @@ test('without votes and inline seal', async () => {
       isLiveMode={false}
       votes={{}}
       onPrintStarted={jest.fn()}
-      printType="vsap"
+      machineType="markScan"
     />
   );
   await expectPrintToMatchSnapshot();

--- a/libs/mark-flow-ui/src/pages/print_page.test.tsx
+++ b/libs/mark-flow-ui/src/pages/print_page.test.tsx
@@ -17,6 +17,7 @@ test('no votes', async () => {
       isLiveMode={false}
       votes={{}}
       onPrintStarted={jest.fn()}
+      printType="vsap"
     />
   );
   await expectPrintToMatchSnapshot();
@@ -46,6 +47,7 @@ test('with votes', async () => {
       )}
       isLiveMode={false}
       onPrintStarted={jest.fn()}
+      printType="vsap"
     />
   );
   await expectPrintToMatchSnapshot();
@@ -62,6 +64,7 @@ test('without votes and inline seal', async () => {
       isLiveMode={false}
       votes={{}}
       onPrintStarted={jest.fn()}
+      printType="vsap"
     />
   );
   await expectPrintToMatchSnapshot();

--- a/libs/mark-flow-ui/src/pages/print_page.tsx
+++ b/libs/mark-flow-ui/src/pages/print_page.tsx
@@ -11,6 +11,7 @@ import {
   appStrings,
   Font,
   ReadOnLoad,
+  BmdBallotPrintType,
 } from '@votingworks/ui';
 
 import {
@@ -35,7 +36,7 @@ export interface PrintPageProps {
     element: JSX.Element,
     printOptions: PrintOptions
   ) => Promise<void>;
-  largeTopMargin?: boolean;
+  printType: BmdBallotPrintType;
 }
 
 export function PrintPage({
@@ -47,7 +48,7 @@ export function PrintPage({
   generateBallotId,
   onPrintStarted,
   printElement = DefaultPrintElement,
-  largeTopMargin,
+  printType,
 }: PrintPageProps): JSX.Element {
   const printLock = useLock();
 
@@ -62,7 +63,7 @@ export function PrintPage({
         isLiveMode={isLiveMode}
         precinctId={precinctId}
         votes={votes}
-        largeTopMargin={largeTopMargin}
+        printType={printType}
       />,
       { sides: 'one-sided' }
     );
@@ -77,7 +78,7 @@ export function PrintPage({
     votes,
     onPrintStarted,
     printElement,
-    largeTopMargin,
+    printType,
   ]);
 
   useEffect(() => {

--- a/libs/mark-flow-ui/src/pages/print_page.tsx
+++ b/libs/mark-flow-ui/src/pages/print_page.tsx
@@ -11,7 +11,7 @@ import {
   appStrings,
   Font,
   ReadOnLoad,
-  BmdBallotPrintType,
+  MachineType,
 } from '@votingworks/ui';
 
 import {
@@ -36,7 +36,7 @@ export interface PrintPageProps {
     element: JSX.Element,
     printOptions: PrintOptions
   ) => Promise<void>;
-  printType: BmdBallotPrintType;
+  machineType: MachineType;
 }
 
 export function PrintPage({
@@ -48,7 +48,7 @@ export function PrintPage({
   generateBallotId,
   onPrintStarted,
   printElement = DefaultPrintElement,
-  printType,
+  machineType,
 }: PrintPageProps): JSX.Element {
   const printLock = useLock();
 
@@ -63,7 +63,7 @@ export function PrintPage({
         isLiveMode={isLiveMode}
         precinctId={precinctId}
         votes={votes}
-        printType={printType}
+        machineType={machineType}
       />,
       { sides: 'one-sided' }
     );
@@ -78,7 +78,7 @@ export function PrintPage({
     votes,
     onPrintStarted,
     printElement,
-    printType,
+    machineType,
   ]);
 
   useEffect(() => {

--- a/libs/ui/src/__snapshots__/bmd_paper_ballot.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/bmd_paper_ballot.test.tsx.snap
@@ -85,31 +85,6 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
   margin-top: 0 !important;
 }
 
-.c13 {
-  font-size: 1em;
-  line-height: 1.3;
-  margin: 0;
-  font-weight: 500;
-  line-height: 1.1700000000000002;
-  margin-bottom: 0.3em;
-  font-size: 1rem;
-  line-height: 1.105;
-  font-weight: 600;
-}
-
-.c13:not(:first-child) {
-  margin-top: 1.25em;
-}
-
-.c13 + h1,
-.c13 + h2,
-.c13 + h3,
-.c13 + h4,
-.c13 + h5,
-.c13 + h6 {
-  margin-top: 0 !important;
-}
-
 .c2 {
   height: 100%;
   width: 100%;
@@ -123,7 +98,7 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
   color: #000;
   line-height: 1;
   font-family: 'Vx Roboto','Noto Emoji',sans-serif;
-  font-size: 16px;
+  font-size: 10pt !important;
   page-break-after: always;
 }
 
@@ -140,14 +115,6 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
   -ms-flex-align: center;
   align-items: center;
   border-bottom: 0.2em solid #000;
-}
-
-.c1 h2 {
-  margin-bottom: 0;
-}
-
-.c1 h3 {
-  margin-top: 0;
 }
 
 .c1 > .ballot-header-content {
@@ -230,10 +197,10 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
 }
 
 .c11 {
-  -webkit-columns: 2;
-  columns: 2;
-  -webkit-column-gap: 2em;
-  column-gap: 2em;
+  -webkit-columns: 1;
+  columns: 1;
+  -webkit-column-gap: 1em;
+  column-gap: 1em;
 }
 
 .c12 {
@@ -244,8 +211,11 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
   page-break-inside: avoid;
 }
 
-.c14 {
+.c13 {
+  font-size: 1.125em;
   font-weight: normal;
+  margin: 0;
+  margin-bottom: 0.25em;
 }
 
 .c15 {
@@ -254,6 +224,10 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
 
 .c15:not(:last-child) {
   margin-bottom: 0.125em;
+}
+
+.c14 {
+  display: inline-block;
 }
 
 @media print {
@@ -397,13 +371,17 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              President and Vice-President
+            <span
+              class="c14"
+            >
+              <span>
+                President and Vice-President
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -415,23 +393,25 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
               </span>
             </span>
              
-            (
             <span>
               Federalist
             </span>
-            )
           </span>
         </div>
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Representative, District 6
+            <span
+              class="c14"
+            >
+              <span>
+                Representative, District 6
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -449,13 +429,17 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Lieutenant Governor
+            <span
+              class="c14"
+            >
+              <span>
+                Lieutenant Governor
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -467,23 +451,25 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
               </span>
             </span>
              
-            (
             <span>
               Federalist
             </span>
-            )
           </span>
         </div>
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Senator, District 31
+            <span
+              class="c14"
+            >
+              <span>
+                Senator, District 31
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -501,13 +487,17 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Assembly Member, District 54
+            <span
+              class="c14"
+            >
+              <span>
+                Assembly Member, District 54
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -525,13 +515,17 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Registrar of Wills
+            <span
+              class="c14"
+            >
+              <span>
+                Registrar of Wills
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -549,13 +543,17 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Retain Robert Demergue as Chief Justice?
+            <span
+              class="c14"
+            >
+              <span>
+                Retain Robert Demergue as Chief Justice?
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -573,13 +571,17 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Question A: Recovery of Property Damages
+            <span
+              class="c14"
+            >
+              <span>
+                Question A: Recovery of Property Damages
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -595,13 +597,17 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Question B: Separation of Powers
+            <span
+              class="c14"
+            >
+              <span>
+                Question B: Separation of Powers
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -617,13 +623,17 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Proposition 1: Gambling in Franklin and Fromwit Counties
+            <span
+              class="c14"
+            >
+              <span>
+                Proposition 1: Gambling in Franklin and Fromwit Counties
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >
@@ -641,13 +651,17 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
         <div
           class="c12"
         >
-          <h6
-            class="c13 c14"
+          <div
+            class="c13"
           >
-            <span>
-              Measure 102: Vehicle Abatement Program
+            <span
+              class="c14"
+            >
+              <span>
+                Measure 102: Vehicle Abatement Program
+              </span>
             </span>
-          </h6>
+          </div>
           <span
             class="c15"
           >

--- a/libs/ui/src/bmd_paper_ballot.dual_language.test.tsx
+++ b/libs/ui/src/bmd_paper_ballot.dual_language.test.tsx
@@ -143,7 +143,7 @@ describe('non-English ballot style', () => {
         precinctId={spanishBallotStyle.precincts[0]}
         votes={{}}
         onRendered={() => {}}
-        printType="vsap"
+        machineType="markScan"
       />
     );
 
@@ -189,7 +189,7 @@ describe('non-English ballot style', () => {
           ],
         }}
         onRendered={() => {}}
-        printType="vsap"
+        machineType="markScan"
       />
     );
 
@@ -241,7 +241,7 @@ describe('non-English ballot style', () => {
         precinctId={spanishBallotStyle.precincts[0]}
         votes={{}}
         onRendered={() => {}}
-        printType="vsap"
+        machineType="markScan"
       />
     );
 
@@ -270,7 +270,7 @@ describe('non-English ballot style', () => {
         precinctId={spanishBallotStyle.precincts[0]}
         votes={{ [contest.id]: [contest.yesOption.id] }}
         onRendered={() => {}}
-        printType="vsap"
+        machineType="markScan"
       />
     );
 
@@ -308,7 +308,7 @@ describe('non-English ballot style', () => {
         precinctId={spanishBallotStyle.precincts[0]}
         votes={{}}
         onRendered={() => {}}
-        printType="vsap"
+        machineType="markScan"
       />
     );
 
@@ -351,7 +351,7 @@ describe('English ballot style', () => {
         precinctId={englishBallotStyle.precincts[0]}
         votes={votes}
         onRendered={() => {}}
-        printType="vsap"
+        machineType="markScan"
       />
     );
 
@@ -380,7 +380,7 @@ describe('English ballot style', () => {
         precinctId={englishBallotStyle.precincts[0]}
         votes={{}}
         onRendered={() => {}}
-        printType="vsap"
+        machineType="markScan"
       />
     );
 

--- a/libs/ui/src/bmd_paper_ballot.dual_language.test.tsx
+++ b/libs/ui/src/bmd_paper_ballot.dual_language.test.tsx
@@ -143,6 +143,7 @@ describe('non-English ballot style', () => {
         precinctId={spanishBallotStyle.precincts[0]}
         votes={{}}
         onRendered={() => {}}
+        printType="vsap"
       />
     );
 
@@ -188,6 +189,7 @@ describe('non-English ballot style', () => {
           ],
         }}
         onRendered={() => {}}
+        printType="vsap"
       />
     );
 
@@ -209,8 +211,9 @@ describe('non-English ballot style', () => {
     });
 
     for (const partyId of candidate.partyIds!) {
-      expectDualLanguageString({
+      expectSingleLanguageString({
         key: ElectionStringKey.PARTY_NAME,
+        languageCode: LanguageCode.SPANISH,
         subKey: partyId,
       });
     }
@@ -238,6 +241,7 @@ describe('non-English ballot style', () => {
         precinctId={spanishBallotStyle.precincts[0]}
         votes={{}}
         onRendered={() => {}}
+        printType="vsap"
       />
     );
 
@@ -266,6 +270,7 @@ describe('non-English ballot style', () => {
         precinctId={spanishBallotStyle.precincts[0]}
         votes={{ [contest.id]: [contest.yesOption.id] }}
         onRendered={() => {}}
+        printType="vsap"
       />
     );
 
@@ -303,6 +308,7 @@ describe('non-English ballot style', () => {
         precinctId={spanishBallotStyle.precincts[0]}
         votes={{}}
         onRendered={() => {}}
+        printType="vsap"
       />
     );
 
@@ -345,6 +351,7 @@ describe('English ballot style', () => {
         precinctId={englishBallotStyle.precincts[0]}
         votes={votes}
         onRendered={() => {}}
+        printType="vsap"
       />
     );
 
@@ -373,6 +380,7 @@ describe('English ballot style', () => {
         precinctId={englishBallotStyle.precincts[0]}
         votes={{}}
         onRendered={() => {}}
+        printType="vsap"
       />
     );
 

--- a/libs/ui/src/bmd_paper_ballot.stories.tsx
+++ b/libs/ui/src/bmd_paper_ballot.stories.tsx
@@ -155,7 +155,7 @@ const initialArgs: BmdPaperBallotProps = {
     JSON.stringify(election)
   ).unsafeUnwrap(),
   isLiveMode: true,
-  printType: 'vsap',
+  machineType: 'markScan',
   onRendered: () => undefined,
   precinctId: election.precincts[0].id,
   votes: Object.fromEntries(

--- a/libs/ui/src/bmd_paper_ballot.test.tsx
+++ b/libs/ui/src/bmd_paper_ballot.test.tsx
@@ -21,10 +21,10 @@ import { fromByteArray } from 'base64-js';
 import { assertDefined, find } from '@votingworks/basics';
 import { render, screen } from '../test/react_testing_library';
 import {
-  BMD_BALLOT_LAYOUTS,
-  BmdBallotPrintType,
+  ORDERED_BMD_BALLOT_LAYOUTS,
+  MachineType,
   BmdPaperBallot,
-  MAX_VSAP_TOP_MARGIN,
+  MAX_MARK_SCAN_TOP_MARGIN,
 } from './bmd_paper_ballot';
 import * as QrCodeModule from './qrcode';
 
@@ -64,7 +64,7 @@ function renderBmdPaperBallot({
   votes,
   isLiveMode = false,
   onRendered,
-  printType = 'vxMark',
+  machineType = 'mark',
 }: {
   electionDefinition: ElectionDefinition;
   ballotStyleId: BallotStyleId;
@@ -72,7 +72,7 @@ function renderBmdPaperBallot({
   votes: { [key: string]: string | string[] | Candidate };
   isLiveMode?: boolean;
   onRendered?: () => void;
-  printType?: BmdBallotPrintType;
+  machineType?: MachineType;
 }) {
   return render(
     <BmdPaperBallot
@@ -91,7 +91,7 @@ function renderBmdPaperBallot({
         votes
       )}
       onRendered={onRendered}
-      printType={printType}
+      machineType={machineType}
     />
   );
 }
@@ -162,7 +162,7 @@ test('BmdPaperBallot treats missing entries in the votes dict as undervotes', ()
       precinctId="6525"
       isLiveMode
       votes={{}}
-      printType="vsap"
+      machineType="markScan"
     />
   );
 
@@ -292,17 +292,17 @@ describe('BmdPaperBallot calls onRendered', () => {
   });
 });
 
-test('BmdPaperBallot renders a large top margin for VSAP prints', () => {
+test('BmdPaperBallot renders a large top margin for VxMarkScan prints', () => {
   renderBmdPaperBallot({
     electionDefinition: electionWithMsEitherNeitherDefinition,
     ballotStyleId: '1',
     precinctId: '6525',
     votes: {},
-    printType: 'vsap',
+    machineType: 'markScan',
   });
 
   const header = screen.getByTestId('header');
-  expect(header).toHaveStyle(`margin-top: ${MAX_VSAP_TOP_MARGIN}`);
+  expect(header).toHaveStyle(`margin-top: ${MAX_MARK_SCAN_TOP_MARGIN}`);
 });
 
 test('BmdPaperBallot does not render a large top margin for VxMark prints', () => {
@@ -320,30 +320,34 @@ test('BmdPaperBallot does not render a large top margin for VxMark prints', () =
 test('BMD_BALLOT_LAYOUTS is properly defined', () => {
   // Expect no repeated contest thresholds:
   expect([
-    ...new Set(BMD_BALLOT_LAYOUTS.vsap.map((l) => l.minContests)),
-  ]).toHaveLength(BMD_BALLOT_LAYOUTS.vsap.length);
+    ...new Set(ORDERED_BMD_BALLOT_LAYOUTS.markScan.map((l) => l.minContests)),
+  ]).toHaveLength(ORDERED_BMD_BALLOT_LAYOUTS.markScan.length);
   expect([
-    ...new Set(BMD_BALLOT_LAYOUTS.vxMark.map((l) => l.minContests)),
-  ]).toHaveLength(BMD_BALLOT_LAYOUTS.vxMark.length);
+    ...new Set(ORDERED_BMD_BALLOT_LAYOUTS.mark.map((l) => l.minContests)),
+  ]).toHaveLength(ORDERED_BMD_BALLOT_LAYOUTS.mark.length);
 
   // Should be defined in order of increasing contest thresholds:
-  expect(BMD_BALLOT_LAYOUTS.vsap).toEqual(
-    [...BMD_BALLOT_LAYOUTS.vsap].sort((a, b) => a.minContests - b.minContests)
+  expect(ORDERED_BMD_BALLOT_LAYOUTS.markScan).toEqual(
+    [...ORDERED_BMD_BALLOT_LAYOUTS.markScan].sort(
+      (a, b) => a.minContests - b.minContests
+    )
   );
-  expect(BMD_BALLOT_LAYOUTS.vxMark).toEqual(
-    [...BMD_BALLOT_LAYOUTS.vxMark].sort((a, b) => a.minContests - b.minContests)
+  expect(ORDERED_BMD_BALLOT_LAYOUTS.mark).toEqual(
+    [...ORDERED_BMD_BALLOT_LAYOUTS.mark].sort(
+      (a, b) => a.minContests - b.minContests
+    )
   );
 
   // Should an entry with a threshold of 0 contests for each print type:
-  expect(BMD_BALLOT_LAYOUTS.vsap[0].minContests).toEqual(0);
-  expect(BMD_BALLOT_LAYOUTS.vxMark[0].minContests).toEqual(0);
+  expect(ORDERED_BMD_BALLOT_LAYOUTS.markScan[0].minContests).toEqual(0);
+  expect(ORDERED_BMD_BALLOT_LAYOUTS.mark[0].minContests).toEqual(0);
 
-  // Expect top margins only for VSAP prints:
+  // Expect top margins only for MarkScan prints:
   expect(
-    BMD_BALLOT_LAYOUTS.vsap.every((l) => l.topMargin !== undefined)
+    ORDERED_BMD_BALLOT_LAYOUTS.markScan.every((l) => l.topMargin !== undefined)
   ).toEqual(true);
   expect(
-    BMD_BALLOT_LAYOUTS.vxMark.every((l) => l.topMargin === undefined)
+    ORDERED_BMD_BALLOT_LAYOUTS.mark.every((l) => l.topMargin === undefined)
   ).toEqual(true);
 });
 

--- a/libs/ui/src/bmd_paper_ballot.tsx
+++ b/libs/ui/src/bmd_paper_ballot.tsx
@@ -22,10 +22,10 @@ import {
 } from '@votingworks/types';
 import { getSingleYesNoVote, randomBallotId } from '@votingworks/utils';
 
-import { assert } from '@votingworks/basics';
+import { assert, find } from '@votingworks/basics';
 import { NoWrap } from './text';
 import { QrCode } from './qrcode';
-import { Font, H4, H5, H6, P } from './typography';
+import { Font, H4, H5, P } from './typography';
 import { VxThemeProvider } from './themes/vx_theme_provider';
 import { VX_DEFAULT_FONT_FAMILY_DECLARATION } from './fonts/font_family';
 import { Seal } from './seal';
@@ -39,12 +39,50 @@ import {
   NumberString,
 } from './ui_strings';
 
-const Ballot = styled.div`
+export type BmdBallotPrintType = 'vxMark' | 'vsap';
+
+/**
+ * Max margin required to keep the ballot header visible when the page is
+ * partially covered by the VSAP infeed hood.
+ */
+export const MAX_VSAP_TOP_MARGIN = '1.75in';
+
+/**
+ * Min margin required to keep the first row of contests visible when the page
+ * is partially covered by the VSAP infeed hood.
+ */
+export const MIN_VSAP_TOP_MARGIN = '0.5625in';
+
+interface Layout {
+  hideParties: boolean;
+  maxRows: number;
+  minContests: number;
+  topMargin?: typeof MAX_VSAP_TOP_MARGIN | typeof MIN_VSAP_TOP_MARGIN;
+}
+
+export const BMD_BALLOT_LAYOUTS: Record<BmdBallotPrintType, Layout[]> = {
+  vsap: [
+    { minContests: 0, maxRows: 10, hideParties: false, topMargin: '1.75in' },
+    { minContests: 21, maxRows: 10, hideParties: true, topMargin: '0.5625in' },
+    { minContests: 31, maxRows: 9, hideParties: true, topMargin: '0.5625in' },
+    { minContests: 37, maxRows: 8, hideParties: true, topMargin: '0.5625in' },
+    { minContests: 49, maxRows: 7, hideParties: true, topMargin: '0.5625in' },
+  ],
+  vxMark: [
+    { minContests: 0, maxRows: 12, hideParties: false },
+    { minContests: 25, maxRows: 11, hideParties: true },
+    { minContests: 37, maxRows: 11, hideParties: true },
+    { minContests: 45, maxRows: 10, hideParties: true },
+    { minContests: 55, maxRows: 8, hideParties: true },
+  ],
+};
+
+const Ballot = styled.div<{ layout: Layout }>`
   background: #fff;
   color: #000;
   line-height: 1;
   font-family: ${VX_DEFAULT_FONT_FAMILY_DECLARATION};
-  font-size: 16px;
+  font-size: 10pt !important;
   page-break-after: always;
 
   @media screen {
@@ -58,22 +96,14 @@ const Ballot = styled.div`
 `;
 
 interface StyledHeaderProps {
-  largeTopMargin?: boolean;
+  layout: Layout;
 }
 const Header = styled.div<StyledHeaderProps>`
   display: flex;
   flex-direction: row;
   align-items: center;
   border-bottom: 0.2em solid #000;
-  margin-top: ${(p) => (p.largeTopMargin ? '1.75in' : undefined)};
-
-  & h2 {
-    margin-bottom: 0;
-  }
-
-  & h3 {
-    margin-top: 0;
-  }
+  margin-top: ${(p) => p.layout.topMargin};
 
   & > .ballot-header-content {
     flex: 4;
@@ -125,9 +155,9 @@ const QrCodeContainer = styled.div`
 const Content = styled.div`
   flex: 1;
 `;
-const BallotSelections = styled.div`
-  columns: 2;
-  column-gap: 2em;
+const BallotSelections = styled.div<{ numColumns: number }>`
+  columns: ${(p) => p.numColumns};
+  column-gap: 1em;
 `;
 const Contest = styled.div`
   border-bottom: 0.01em solid #000;
@@ -136,9 +166,12 @@ const Contest = styled.div`
   page-break-inside: avoid;
 `;
 
-const ContestTitle = styled(H6)`
+const ContestTitle = styled.div`
+  font-size: 1.125em;
   /* stylelint-disable-next-line font-weight-notation */
   font-weight: normal;
+  margin: 0;
+  margin-bottom: 0.25em;
 `;
 
 const VoteLine = styled.span`
@@ -150,7 +183,11 @@ const VoteLine = styled.span`
 `;
 
 const SecondaryLanguageText = styled.span`
-  font-size: 0.75em;
+  font-size: 0.6em;
+`;
+
+const InlineBlockSpan = styled.span`
+  display: inline-block;
 `;
 
 function DualLanguageText(props: {
@@ -194,17 +231,6 @@ function AdjacentTextWithSeparator(props: { children: JSX.Element }) {
   return <React.Fragment> | {children}</React.Fragment>;
 }
 
-function NewlineText(props: { children: JSX.Element }) {
-  const { children } = props;
-
-  return (
-    <React.Fragment>
-      <br />
-      {children}
-    </React.Fragment>
-  );
-}
-
 function ParenthesizedText(props: { children: JSX.Element }) {
   const { children } = props;
 
@@ -233,6 +259,7 @@ function NoSelection(props: {
 interface CandidateContestResultProps {
   contest: CandidateContest;
   election: Election;
+  layout: Layout;
   primaryBallotLanguage: LanguageCode;
   vote?: CandidateVote;
 }
@@ -240,6 +267,7 @@ interface CandidateContestResultProps {
 function CandidateContestResult({
   contest,
   election,
+  layout,
   primaryBallotLanguage,
   vote = [],
 }: CandidateContestResultProps): JSX.Element {
@@ -258,19 +286,14 @@ function CandidateContestResult({
               <InEnglish>{electionStrings.candidateName(candidate)}</InEnglish>
             )}
           </Font>{' '}
-          {candidate.partyIds && candidate.partyIds.length > 0 && (
-            <DualLanguageText
-              primaryLanguage={primaryBallotLanguage}
-              englishTextWrapper={AdjacentText}
-            >
-              (
-              <CandidatePartyList
-                candidate={candidate}
-                electionParties={election.parties}
-              />
-              )
-            </DualLanguageText>
-          )}
+          {layout.hideParties
+            ? undefined
+            : candidate.partyIds && (
+                <CandidatePartyList
+                  candidate={candidate}
+                  electionParties={election.parties}
+                />
+              )}
           {candidate.isWriteIn && (
             <DualLanguageText
               primaryLanguage={primaryBallotLanguage}
@@ -286,10 +309,12 @@ function CandidateContestResult({
           <Font weight="light">
             <DualLanguageText
               primaryLanguage={primaryBallotLanguage}
-              englishTextWrapper={NewlineText}
+              englishTextWrapper={AdjacentText}
             >
-              [{appStrings.labelNumVotesUnused()}{' '}
-              <NumberString value={remainingChoices} />]
+              <InlineBlockSpan>
+                [{appStrings.labelNumVotesUnused()}{' '}
+                <NumberString value={remainingChoices} />]
+              </InlineBlockSpan>
             </DualLanguageText>
           </Font>
         </VoteLine>
@@ -337,7 +362,7 @@ export interface BmdPaperBallotProps {
   precinctId: PrecinctId;
   votes: VotesDict;
   onRendered?: () => void;
-  largeTopMargin?: boolean;
+  printType: BmdBallotPrintType;
 }
 
 /**
@@ -363,7 +388,7 @@ export function BmdPaperBallot({
   precinctId,
   votes,
   onRendered,
-  largeTopMargin,
+  printType,
 }: BmdPaperBallotProps): JSX.Element {
   const ballotId = generateBallotId();
   const {
@@ -393,10 +418,17 @@ export function BmdPaperBallot({
     }
   }, [onRendered]);
 
+  const layout = find(
+    [...BMD_BALLOT_LAYOUTS[printType]].reverse(),
+    (l) => contests.length >= l.minContests
+  );
+
+  const numColumns = Math.ceil(contests.length / layout.maxRows);
+
   return withPrintTheme(
     <LanguageOverride languageCode={primaryBallotLanguage}>
-      <Ballot aria-hidden>
-        <Header largeTopMargin={largeTopMargin} data-testid="header">
+      <Ballot aria-hidden layout={layout}>
+        <Header layout={layout} data-testid="header">
           <Seal seal={seal} maxWidth="1in" style={{ margin: '0.25em 0' }} />
           <div className="ballot-header-content">
             <H4>
@@ -464,21 +496,24 @@ export function BmdPaperBallot({
           </QrCodeContainer>
         </Header>
         <Content>
-          <BallotSelections>
+          <BallotSelections numColumns={numColumns}>
             {contests.map((contest) => (
               <Contest key={contest.id}>
                 <ContestTitle>
                   <DualLanguageText
                     primaryLanguage={primaryBallotLanguage}
-                    englishTextWrapper={NewlineText}
+                    englishTextWrapper={AdjacentText}
                   >
-                    {electionStrings.contestTitle(contest)}
+                    <InlineBlockSpan>
+                      {electionStrings.contestTitle(contest)}
+                    </InlineBlockSpan>
                   </DualLanguageText>
                 </ContestTitle>
                 {contest.type === 'candidate' && (
                   <CandidateContestResult
                     contest={contest}
                     election={election}
+                    layout={layout}
                     primaryBallotLanguage={primaryBallotLanguage}
                     vote={votes[contest.id] as CandidateVote}
                   />


### PR DESCRIPTION
## Overview

Resolves https://github.com/votingworks/vxsuite/issues/4474

Applying the following changes to increase the number of contests we can fit on a single page of the BMD paper ballot:
- Decrease font size to the VVSG 2.0 minimum: `10pt`
- For VSAP prints, decrease the size of the top margin, so that the ballot header is covered by the VSAP in-feed hood, while keeping the first row of contests visible.
- Increase the number of contest columns as the number of columns increases.
- Drop party names from candidate selections when rendering 3+ columns.
- Shrink contest titles.
- Shrink English text on multi-language ballots further (75% -> 60%).
- Inline English text whenever possible on multi-language ballots (we were previously rendering on a new line in some cases).
- Reduce spacing where possible.

We don't yet put a cap on how many contests this will attempt to render on a single page - we'll be addressing how split contests across multiple sheets later in https://github.com/votingworks/vxsuite/issues/4473.

## Demo Video or Screenshot

https://github.com/votingworks/vxsuite/assets/264902/87926a3e-2213-4158-84d7-3996767bcad4

## Testing Plan
- Added/updated unit test cases.
- Manual testing and tuning for layout change thresholds.

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
