### PR TITLE
fix(mark-scan): `clap` usage fixes

### DIFF
--- a/apps/mark-scan/accessible-controller/src/controllerd.rs
+++ b/apps/mark-scan/accessible-controller/src/controllerd.rs
@@ -36,7 +36,7 @@ const KPB_200_FW_PID: u16 = 16392;
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
-    // Whether to allow the daemon to run if no hardware is found.
+    /// Allow the daemon to run if no hardware is found.
     #[arg(short, long)]
     skip_hardware_check: bool,
 }
@@ -44,6 +44,7 @@ struct Args {
 fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
 
+    let args = Args::parse();
     set_app_name(APP_NAME);
     log!(
         EventId::ProcessStarted;
@@ -87,7 +88,6 @@ fn main() -> color_eyre::Result<()> {
         exit(0);
     }
 
-    let args = Args::parse();
     if args.skip_hardware_check {
         run_no_op_event_loop(&running);
         exit(0);

--- a/apps/mark-scan/pat-device-input/src/patinputd.rs
+++ b/apps/mark-scan/pat-device-input/src/patinputd.rs
@@ -39,7 +39,7 @@ const SIGNAL_B_PIN: Pin = Pin::new(476);
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
-    // Whether to allow the daemon to run if no hardware is found.
+    /// Allow the daemon to run if no hardware is found.
     #[arg(short, long)]
     skip_hardware_check: bool,
 }
@@ -69,6 +69,8 @@ fn set_up_pins() -> io::Result<()> {
 }
 
 fn main() {
+    let args = Args::parse();
+
     set_app_name(APP_NAME);
     log!(EventId::ProcessStarted; EventType::SystemAction);
 
@@ -108,7 +110,6 @@ fn main() {
             message: format!("An error occurred during GPIO pin connection: {err}")
         );
 
-        let args = Args::parse();
         if args.skip_hardware_check {
             run_no_op_event_loop(&running);
             exit(0);


### PR DESCRIPTION
- use doc comments (triple-slash) on `clap::Parser` struct fields to have them show up both in intellisense and in `--help` output
- unconditionally run `Args::parse()` early to allow handling of `--help` and `--version` flags

```
Usage: patinputd [OPTIONS]

Options:
  -s, --skip-hardware-check  Allow the daemon to run if no hardware is found
  -h, --help                 Print help
  -V, --version              Print version
```