### PR TITLE
[libs/ui] Consolidate keybindings across apps into shared definition

### DIFF
--- a/apps/mark-scan/frontend/src/lib/assistive_technology.ts
+++ b/apps/mark-scan/frontend/src/lib/assistive_technology.ts
@@ -1,85 +1,36 @@
-import { mod } from '../utils/mod';
-
-const querySelector =
-  'button:not([aria-hidden="true"]):not([disabled]):not([tabindex="-1"]), [role="button"]:not([aria-hidden="true"]):not([disabled]):not([tabindex="-1"])';
-
-export function getActiveElement(): HTMLElement {
-  return document.activeElement as HTMLElement;
-}
-
-function getFocusableElements(): HTMLElement[] {
-  const tabbableElements = Array.from(document.querySelectorAll(querySelector));
-  const ariaHiddenTabbableElements = Array.from(
-    document.querySelectorAll('[aria-hidden="true"] button')
-  );
-  return tabbableElements.filter(
-    (element) => ariaHiddenTabbableElements.indexOf(element) === -1
-  ) as HTMLElement[];
-}
-
-function handleArrowUp() {
-  const focusable = getFocusableElements();
-  const currentIndex = focusable.indexOf(getActiveElement());
-  /* istanbul ignore else */
-  if (focusable.length) {
-    if (currentIndex > -1) {
-      focusable[mod(currentIndex - 1, focusable.length)].focus();
-    } else {
-      focusable[focusable.length - 1].focus();
-    }
-  }
-}
-
-function handleArrowDown() {
-  const focusable = getFocusableElements();
-  const currentIndex = focusable.indexOf(getActiveElement());
-  /* istanbul ignore else */
-  if (focusable.length) {
-    focusable[mod(currentIndex + 1, focusable.length)].focus();
-  }
-}
-
-function handleArrowLeft() {
-  const prevButton = document.getElementById('previous');
-  /* istanbul ignore else */
-  if (prevButton) {
-    prevButton.click();
-  }
-}
-
-function handleArrowRight() {
-  const nextButton = document.getElementById('next');
-  /* istanbul ignore else */
-  if (nextButton) {
-    nextButton.click();
-  }
-}
+import {
+  Keybinding,
+  PageNavigationButtonId,
+  advanceElementFocus,
+  triggerPageNavigationButton,
+} from '@votingworks/ui';
 
 function handleClick() {
-  const activeElement = getActiveElement();
-  activeElement.click();
+  if (document.activeElement instanceof HTMLElement) {
+    document.activeElement.click();
+  }
 }
 
 /* istanbul ignore next */
 export function handleKeyboardEvent(event: KeyboardEvent): void {
   switch (event.key) {
-    case 'ArrowLeft':
-      handleArrowLeft();
+    case Keybinding.PAGE_PREVIOUS:
+      triggerPageNavigationButton(PageNavigationButtonId.PREVIOUS);
       break;
-    case 'ArrowRight':
-      handleArrowRight();
+    case Keybinding.PAGE_NEXT:
+      triggerPageNavigationButton(PageNavigationButtonId.NEXT);
       break;
-    case 'ArrowUp':
-      handleArrowUp();
+    case Keybinding.FOCUS_PREVIOUS:
+      advanceElementFocus(-1);
       break;
-    case 'ArrowDown':
-    case '1':
-      handleArrowDown();
+    case Keybinding.FOCUS_NEXT:
+    case Keybinding.PAT_MOVE:
+      advanceElementFocus(1);
       break;
-    case '2':
+    case Keybinding.PAT_SELECT:
       handleClick();
       break;
-    case 'Enter':
+    case Keybinding.SELECT:
       // Enter already acts like a click
       // handleClick();
       break;

--- a/apps/mark-scan/frontend/src/pages/accessible_controller_diagnostic_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/accessible_controller_diagnostic_screen.tsx
@@ -6,9 +6,9 @@ import {
   Main,
   P,
   Screen,
-  ACCESSIBILITY_KEYBINDINGS,
   MarkScanControllerIllustration,
   MarkScanControllerButton,
+  Keybinding,
 } from '@votingworks/ui';
 import styled from 'styled-components';
 import { addDiagnosticRecord } from '../api';
@@ -30,66 +30,66 @@ const StepContainer = styled.div`
 `;
 
 interface DiagnosticStep {
-  button: MarkScanControllerButton;
+  button: string;
   label: string;
-  key: string;
+  key: MarkScanControllerButton;
 }
 
 export const DIAGNOSTIC_STEPS: DiagnosticStep[] = [
   {
     button: 'up',
     label: 'Up',
-    key: 'ArrowUp',
+    key: Keybinding.FOCUS_PREVIOUS,
   },
   {
     button: 'down',
     label: 'Down',
-    key: 'ArrowDown',
+    key: Keybinding.FOCUS_NEXT,
   },
   {
     button: 'left',
     label: 'Left',
-    key: 'ArrowLeft',
+    key: Keybinding.PAGE_PREVIOUS,
   },
   {
     button: 'right',
     label: 'Right',
-    key: 'ArrowRight',
+    key: Keybinding.PAGE_NEXT,
   },
   {
     button: 'select',
     label: 'Select',
-    key: 'Enter',
+    key: Keybinding.SELECT,
   },
   {
     button: 'help',
     label: 'Help',
-    key: ACCESSIBILITY_KEYBINDINGS.REPLAY,
+    key: Keybinding.TOGGLE_HELP,
   },
   {
     button: 'volume-down',
     label: 'Volume Down',
-    key: ACCESSIBILITY_KEYBINDINGS.DECREASE_VOLUME,
+    key: Keybinding.VOLUME_DOWN,
   },
   {
     button: 'volume-up',
     label: 'Volume Up',
-    key: ACCESSIBILITY_KEYBINDINGS.INCREASE_VOLUME,
+    key: Keybinding.VOLUME_UP,
   },
   {
     button: 'pause',
     label: 'Pause',
-    key: ACCESSIBILITY_KEYBINDINGS.TOGGLE_PAUSE,
+    key: Keybinding.TOGGLE_PAUSE,
   },
   {
     button: 'rate-down',
     label: 'Decrease Rate',
-    key: ACCESSIBILITY_KEYBINDINGS.DECREASE_PLAYBACK_RATE,
+    key: Keybinding.PLAYBACK_RATE_DOWN,
   },
   {
     button: 'rate-up',
     label: 'Increase Rate',
-    key: ACCESSIBILITY_KEYBINDINGS.INCREASE_PLAYBACK_RATE,
+    key: Keybinding.PLAYBACK_RATE_UP,
   },
 ];
 
@@ -123,7 +123,7 @@ function AccessibleControllerButtonDiagnostic({
       <H3>
         {stepIndex + 1}. Press the {step.label.toLowerCase()} button.
       </H3>
-      <MarkScanControllerIllustration highlight={step.button} />
+      <MarkScanControllerIllustration highlight={step.key} />
 
       <Button
         onPress={() =>
@@ -175,7 +175,7 @@ export function AccessibleControllerDiagnosticScreen({
   const steps = [
     ...DIAGNOSTIC_STEPS.map((curStep, index) => (
       <AccessibleControllerButtonDiagnostic
-        key={curStep.button}
+        key={curStep.key}
         step={curStep}
         stepIndex={index}
         onSuccess={index === DIAGNOSTIC_STEPS.length - 1 ? passTest : nextStep}

--- a/apps/mark-scan/frontend/src/pages/continue_to_review_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/continue_to_review_page.tsx
@@ -1,4 +1,10 @@
-import { LinkButton, appStrings, AudioOnly, P } from '@votingworks/ui';
+import {
+  LinkButton,
+  appStrings,
+  AudioOnly,
+  P,
+  PageNavigationButtonId,
+} from '@votingworks/ui';
 import { CenteredPageLayout } from '../components/centered_page_layout';
 
 // This page is rendered as part of the blank ballot interpretation flow immediately after
@@ -12,7 +18,7 @@ export function ContinueToReviewPage(): JSX.Element {
         <LinkButton
           autoFocus
           to="/review"
-          id="next"
+          id={PageNavigationButtonId.NEXT}
           variant="primary"
           icon="Done"
         >

--- a/apps/mark-scan/frontend/src/pages/diagnostics_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/diagnostics_screen.test.tsx
@@ -1,6 +1,6 @@
 import { MemoryRouter } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
-import { MARK_SCAN_CONTROLLER_ILLUSTRATION_HIGHLIGHT_FILL } from '@votingworks/ui';
+import { MARK_SCAN_CONTROLLER_ILLUSTRATION_HIGHLIGHT_CLASS_NAME } from '@votingworks/ui';
 import {
   fireEvent,
   render,
@@ -93,9 +93,8 @@ test('accessible controller diagnostic - pass', async () => {
       .getByTitle('Accessible Controller Illustration')
       .closest('svg') as unknown as HTMLElement;
     const element = within(illustration).getByTestId(step.button);
-    expect(element).toHaveAttribute(
-      'fill',
-      MARK_SCAN_CONTROLLER_ILLUSTRATION_HIGHLIGHT_FILL
+    expect(element).toHaveClass(
+      MARK_SCAN_CONTROLLER_ILLUSTRATION_HIGHLIGHT_CLASS_NAME
     );
     screen.getButton(`${step.label} Button is Not Working`);
     fireEvent.keyDown(illustration, { key: step.key });

--- a/apps/mark-scan/frontend/src/utils/mod.test.ts
+++ b/apps/mark-scan/frontend/src/utils/mod.test.ts
@@ -1,9 +1,0 @@
-import { mod } from './mod';
-
-test('calculates modulo for positive number', () => {
-  expect(mod(5, 2)).toEqual(1);
-});
-
-test('returns absolute value of modulo for negative number', () => {
-  expect(mod(-5, 2)).toEqual(1);
-});

--- a/apps/mark-scan/frontend/src/utils/mod.ts
+++ b/apps/mark-scan/frontend/src/utils/mod.ts
@@ -1,3 +1,0 @@
-export function mod(x: number, n: number): number {
-  return ((x % n) + n) % n;
-}

--- a/apps/mark/frontend/src/lib/gamepad.test.tsx
+++ b/apps/mark/frontend/src/lib/gamepad.test.tsx
@@ -19,16 +19,17 @@ import {
   contest1candidate0,
 } from '../../test/helpers/election';
 
-import {
-  getActiveElement,
-  handleGamepadButtonDown as unwrappedHandleGamepadButtonDown,
-} from './gamepad';
+import { handleGamepadButtonDown as unwrappedHandleGamepadButtonDown } from './gamepad';
 import { ApiMock, createApiMock } from '../../test/helpers/mock_api_client';
 
 function handleGamepadButtonDown(button: Button) {
   act(() => {
     unwrappedHandleGamepadButtonDown(button);
   });
+}
+
+function getActiveElement() {
+  return document.activeElement;
 }
 
 let apiMock: ApiMock;

--- a/apps/mark/frontend/src/lib/gamepad.ts
+++ b/apps/mark/frontend/src/lib/gamepad.ts
@@ -1,81 +1,31 @@
 import { Button } from 'react-gamepad';
-import { mod } from '../utils/mod';
-
-export function getActiveElement(): HTMLElement {
-  return document.activeElement as HTMLElement;
-}
-
-function getFocusableElements(): HTMLElement[] {
-  const tabbableElements = Array.from(
-    document.querySelectorAll(
-      'button:not([aria-hidden="true"]):not([disabled])'
-    )
-  );
-  const ariaHiddenTabbableElements = Array.from(
-    document.querySelectorAll('[aria-hidden="true"] button')
-  );
-  return tabbableElements.filter(
-    (element) => ariaHiddenTabbableElements.indexOf(element) === -1
-  ) as HTMLElement[];
-}
-
-function handleArrowUp() {
-  const focusable = getFocusableElements();
-  const currentIndex = focusable.indexOf(getActiveElement());
-  /* istanbul ignore else */
-  if (focusable.length) {
-    if (currentIndex > -1) {
-      focusable[mod(currentIndex - 1, focusable.length)].focus();
-    } else {
-      focusable[focusable.length - 1].focus();
-    }
-  }
-}
-
-function handleArrowDown() {
-  const focusable = getFocusableElements();
-  const currentIndex = focusable.indexOf(getActiveElement());
-  /* istanbul ignore else */
-  if (focusable.length) {
-    focusable[mod(currentIndex + 1, focusable.length)].focus();
-  }
-}
-
-function handleArrowLeft() {
-  const prevButton = document.getElementById('previous');
-  /* istanbul ignore else */
-  if (prevButton) {
-    prevButton.click();
-  }
-}
-
-function handleArrowRight() {
-  const nextButton = document.getElementById('next');
-  /* istanbul ignore else */
-  if (nextButton) {
-    nextButton.click();
-  }
-}
+import {
+  Keybinding,
+  PageNavigationButtonId,
+  advanceElementFocus,
+  triggerPageNavigationButton,
+} from '@votingworks/ui';
 
 function handleClick() {
-  const activeElement = getActiveElement();
-  activeElement.click();
+  if (document.activeElement instanceof HTMLElement) {
+    document.activeElement.click();
+  }
 }
 
 export function handleGamepadButtonDown(buttonName: Button): void {
   switch (buttonName) {
     case 'DPadUp':
-      handleArrowUp();
+      advanceElementFocus(-1);
       break;
     case 'B':
     case 'DPadDown':
-      handleArrowDown();
+      advanceElementFocus(1);
       break;
     case 'DPadLeft':
-      handleArrowLeft();
+      triggerPageNavigationButton(PageNavigationButtonId.PREVIOUS);
       break;
     case 'DPadRight':
-      handleArrowRight();
+      triggerPageNavigationButton(PageNavigationButtonId.NEXT);
       break;
     case 'A':
       handleClick();
@@ -88,23 +38,23 @@ export function handleGamepadButtonDown(buttonName: Button): void {
 /* istanbul ignore next - triggering keystrokes issue - https://github.com/votingworks/bmd/issues/62 */
 export function handleGamepadKeyboardEvent(event: KeyboardEvent): void {
   switch (event.key) {
-    case 'ArrowUp':
-      handleArrowUp();
+    case Keybinding.FOCUS_PREVIOUS:
+      advanceElementFocus(-1);
       break;
-    case '[':
-    case 'ArrowDown':
-      handleArrowDown();
+    case Keybinding.LEGACY_PAT_MOVE:
+    case Keybinding.FOCUS_NEXT:
+      advanceElementFocus(1);
       break;
-    case 'ArrowLeft':
-      handleArrowLeft();
+    case Keybinding.PAGE_PREVIOUS:
+      triggerPageNavigationButton(PageNavigationButtonId.PREVIOUS);
       break;
-    case 'ArrowRight':
-      handleArrowRight();
+    case Keybinding.PAGE_NEXT:
+      triggerPageNavigationButton(PageNavigationButtonId.NEXT);
       break;
-    case ']':
+    case Keybinding.LEGACY_PAT_SELECT:
       handleClick();
       break;
-    case 'Enter':
+    case Keybinding.SELECT:
       // Enter already acts like a click
       // handleClick()
       break;

--- a/apps/mark/frontend/src/lib/gamepad.ts
+++ b/apps/mark/frontend/src/lib/gamepad.ts
@@ -41,7 +41,6 @@ export function handleGamepadKeyboardEvent(event: KeyboardEvent): void {
     case Keybinding.FOCUS_PREVIOUS:
       advanceElementFocus(-1);
       break;
-    case Keybinding.LEGACY_PAT_MOVE:
     case Keybinding.FOCUS_NEXT:
       advanceElementFocus(1);
       break;
@@ -50,9 +49,6 @@ export function handleGamepadKeyboardEvent(event: KeyboardEvent): void {
       break;
     case Keybinding.PAGE_NEXT:
       triggerPageNavigationButton(PageNavigationButtonId.NEXT);
-      break;
-    case Keybinding.LEGACY_PAT_SELECT:
-      handleClick();
       break;
     case Keybinding.SELECT:
       // Enter already acts like a click

--- a/apps/mark/frontend/src/pages/accessible_controller_diagnostic_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/accessible_controller_diagnostic_screen.test.tsx
@@ -1,7 +1,7 @@
 import userEvent from '@testing-library/user-event';
 import { DateTime } from 'luxon';
 import { fakeUseAudioControls, mockOf } from '@votingworks/test-utils';
-import { ReadOnLoad } from '@votingworks/ui';
+import { Keybinding, ReadOnLoad } from '@votingworks/ui';
 import { render, screen, within } from '../../test/react_testing_library';
 import {
   AccessibleControllerDiagnosticScreen,
@@ -72,33 +72,33 @@ describe('Accessible Controller Diagnostic Screen', () => {
     expectToHaveIllustrationHighlight('up-button');
     // Try out pressing an incorrect button to make sure we actually detect the
     // right button.
-    userEvent.keyboard('{ArrowDown}');
+    userEvent.keyboard(`{${Keybinding.FOCUS_NEXT}}`);
     screen.getByText(/Step 1 of 6/);
     // Then press the up button.
     // We have to wrap key presses in act to avoid a warning. This may be due to
     // the fact that the keyDown listener is attached to the document instead of
     // a React component.
-    userEvent.keyboard('{ArrowUp}');
+    userEvent.keyboard(`{${Keybinding.FOCUS_PREVIOUS}}`);
 
     await screen.findByText(/Step 2 of 6/);
     screen.getByText('Press the down button.');
     expectToHaveIllustrationHighlight('down-button');
-    userEvent.keyboard('{ArrowDown}');
+    userEvent.keyboard(`{${Keybinding.FOCUS_NEXT}}`);
 
     await screen.findByText(/Step 3 of 6/);
     screen.getByText('Press the left button.');
     expectToHaveIllustrationHighlight('left-button');
-    userEvent.keyboard('{ArrowLeft}');
+    userEvent.keyboard(`{${Keybinding.PAGE_PREVIOUS}}`);
 
     await screen.findByText(/Step 4 of 6/);
     screen.getByText('Press the right button.');
     expectToHaveIllustrationHighlight('right-button');
-    userEvent.keyboard('{ArrowRight}');
+    userEvent.keyboard(`{${Keybinding.PAGE_NEXT}}`);
 
     await screen.findByText(/Step 5 of 6/);
     screen.getByText('Press the select button.');
     expectToHaveIllustrationHighlight('select-button');
-    userEvent.keyboard('{Enter}');
+    userEvent.keyboard(`{${Keybinding.SELECT}}`);
 
     await screen.findByText(/Step 6 of 6/);
     screen.getByText('Confirm sound is working.');
@@ -106,21 +106,21 @@ describe('Accessible Controller Diagnostic Screen', () => {
     expectToHaveIllustrationHighlight('headphones', true);
     // Try pressing the select button before playing sound to make sure it
     // doesn't work
-    userEvent.keyboard('{Enter}');
+    userEvent.keyboard(`{${Keybinding.SELECT}}`);
     expect(onComplete).not.toHaveBeenCalled();
     expect(
       screen.queryByTestId(MOCK_READ_ON_LOAD_TEST_ID)
     ).not.toBeInTheDocument();
 
     // Then play sound and confirm
-    userEvent.keyboard('{ArrowRight}');
+    userEvent.keyboard(`{${Keybinding.PAGE_NEXT}}`);
     expect(mockAudioControls.setIsEnabled).toHaveBeenCalledTimes(1);
     expect(mockAudioControls.setIsEnabled).toHaveBeenCalledWith(true);
     expect(screen.getByTestId(MOCK_READ_ON_LOAD_TEST_ID)).toHaveTextContent(
       'Press the select button to confirm sound is working.'
     );
 
-    userEvent.keyboard('{Enter}');
+    userEvent.keyboard(`{${Keybinding.SELECT}}`);
 
     expect(onComplete).toHaveBeenCalledWith({
       passed: true,
@@ -131,23 +131,23 @@ describe('Accessible Controller Diagnostic Screen', () => {
   async function passUntilStep(step: number) {
     if (step === 1) return;
     screen.getByText(/Step 1 of 6/);
-    userEvent.keyboard('{ArrowUp}');
+    userEvent.keyboard(`{${Keybinding.FOCUS_PREVIOUS}}`);
 
     if (step === 2) return;
     await screen.findByText(/Step 2 of 6/);
-    userEvent.keyboard('{ArrowDown}');
+    userEvent.keyboard(`{${Keybinding.FOCUS_NEXT}}`);
 
     if (step === 3) return;
     await screen.findByText(/Step 3 of 6/);
-    userEvent.keyboard('{ArrowLeft}');
+    userEvent.keyboard(`{${Keybinding.PAGE_PREVIOUS}}`);
 
     if (step === 4) return;
     await screen.findByText(/Step 4 of 6/);
-    userEvent.keyboard('{ArrowRight}');
+    userEvent.keyboard(`{${Keybinding.PAGE_NEXT}}`);
 
     if (step === 5) return;
     await screen.findByText(/Step 5 of 6/);
-    userEvent.keyboard('{Enter}');
+    userEvent.keyboard(`{${Keybinding.SELECT}}`);
 
     if (step === 6) return;
     throw new Error('Step must be between 1 and 6');

--- a/apps/mark/frontend/src/pages/accessible_controller_diagnostic_screen.tsx
+++ b/apps/mark/frontend/src/pages/accessible_controller_diagnostic_screen.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import {
+  Keybinding,
   AudioOnly,
   Button,
   Font,
@@ -62,8 +63,8 @@ const StepInnerContainer = styled.div`
 `;
 
 interface AccessibleControllerButtonDiagnosticProps {
-  buttonName: MarkControllerButton;
-  buttonKey: string;
+  buttonName: string;
+  buttonKey: MarkControllerButton;
   onSuccess: () => void;
   onFailure: (message: string) => void;
 }
@@ -96,7 +97,7 @@ function AccessibleControllerButtonDiagnostic({
           {buttonName} Button is Not Working
         </Button>
       </div>
-      <MarkControllerIllustration highlight={buttonName} />
+      <MarkControllerIllustration highlight={buttonKey} />
     </StepInnerContainer>
   );
 }
@@ -147,7 +148,10 @@ function AccessibleControllerSoundDiagnostic({
           Sound is Not Working
         </Button>
       </div>
-      <MarkControllerIllustration highlight="Headphones" />
+      <MarkControllerIllustration
+        highlight={Keybinding.PAGE_NEXT}
+        showHeadphones
+      />
     </StepInnerContainer>
   );
 }
@@ -185,12 +189,12 @@ export function AccessibleControllerDiagnosticScreen({
     setStep((previousStep) => previousStep + 1);
   }
 
-  const buttons: Array<[MarkControllerButton, string]> = [
-    ['Up', 'ArrowUp'],
-    ['Down', 'ArrowDown'],
-    ['Left', 'ArrowLeft'],
-    ['Right', 'ArrowRight'],
-    ['Select', 'Enter'],
+  const buttons: Array<[string, MarkControllerButton]> = [
+    ['Up', Keybinding.FOCUS_PREVIOUS],
+    ['Down', Keybinding.FOCUS_NEXT],
+    ['Left', Keybinding.PAGE_PREVIOUS],
+    ['Right', Keybinding.PAGE_NEXT],
+    ['Select', Keybinding.SELECT],
   ];
   const steps = [
     ...buttons.map(([buttonName, buttonKey]) => (

--- a/apps/mark/frontend/src/utils/mod.ts
+++ b/apps/mark/frontend/src/utils/mod.ts
@@ -1,3 +1,0 @@
-export function mod(x: number, n: number): number {
-  return ((x % n) + n) % n;
-}

--- a/libs/mark-flow-ui/src/pages/contest_page.tsx
+++ b/libs/mark-flow-ui/src/pages/contest_page.tsx
@@ -10,7 +10,12 @@ import {
   PrecinctId,
   VotesDict,
 } from '@votingworks/types';
-import { LinkButton, appStrings, Button } from '@votingworks/ui';
+import {
+  LinkButton,
+  appStrings,
+  Button,
+  PageNavigationButtonId,
+} from '@votingworks/ui';
 import { assert, throwIllegalValue } from '@votingworks/basics';
 
 import { Contest, ContestProps } from '../components/contest';
@@ -101,7 +106,7 @@ export function ContestPage(props: ContestPageProps): JSX.Element {
   const nextContestButton = (
     <LinkButton
       key={contest.id}
-      id="next"
+      id={PageNavigationButtonId.NEXT}
       rightIcon="Next"
       variant={isVoteComplete ? 'primary' : 'neutral'}
       to={nextContest ? getContestUrl(nextContestIndex) : getReviewPageUrl()}
@@ -117,7 +122,7 @@ export function ContestPage(props: ContestPageProps): JSX.Element {
       rightIcon="Next"
       variant={isVoteComplete ? 'primary' : 'neutral'}
       to={getReviewPageUrl(contest.id)}
-      id="next"
+      id={PageNavigationButtonId.NEXT}
       ref={reviewButtonRef}
     >
       {appStrings.buttonReview()}
@@ -144,7 +149,7 @@ export function ContestPage(props: ContestPageProps): JSX.Element {
   const previousContestButton = (
     <LinkButton
       icon="Previous"
-      id="previous"
+      id={PageNavigationButtonId.PREVIOUS}
       to={prevContest ? getContestUrl(prevContestIndex) : getStartPageUrl()}
     >
       {/* TODO(kofi): Maybe something like "Previous" would translate better in this context? */}

--- a/libs/mark-flow-ui/src/pages/review_page.tsx
+++ b/libs/mark-flow-ui/src/pages/review_page.tsx
@@ -7,6 +7,7 @@ import {
   appStrings,
   AudioOnly,
   ReadOnLoad,
+  PageNavigationButtonId,
 } from '@votingworks/ui';
 
 import { assert } from '@votingworks/basics';
@@ -49,7 +50,12 @@ export function ReviewPage(props: ReviewPageProps): JSX.Element {
   );
 
   const printMyBallotButton = (
-    <LinkButton to={printScreenUrl} id="next" variant="primary" icon="Done">
+    <LinkButton
+      to={printScreenUrl}
+      id={PageNavigationButtonId.NEXT}
+      variant="primary"
+      icon="Done"
+    >
       {appStrings.buttonPrintBallot()}
     </LinkButton>
   );

--- a/libs/mark-flow-ui/src/pages/start_page.tsx
+++ b/libs/mark-flow-ui/src/pages/start_page.tsx
@@ -7,6 +7,7 @@ import {
   AudioOnly,
   Wobble,
   ReadOnLoad,
+  PageNavigationButtonId,
 } from '@votingworks/ui';
 
 import { assert } from '@votingworks/basics';
@@ -66,7 +67,7 @@ export function StartPage(props: StartPageProps): JSX.Element {
       <StartVotingButton
         variant="primary"
         onPress={onStart}
-        id="next"
+        id={PageNavigationButtonId.NEXT}
         rightIcon="Next"
       >
         {appStrings.buttonStartVoting()}

--- a/libs/ui/src/accessible_controllers/index.ts
+++ b/libs/ui/src/accessible_controllers/index.ts
@@ -1,2 +1,4 @@
 export * from './mark_controller_illustration';
 export * from './mark_scan_controller_illustration';
+export * from './navigation';
+export * from './types';

--- a/libs/ui/src/accessible_controllers/mark_controller_illustration.tsx
+++ b/libs/ui/src/accessible_controllers/mark_controller_illustration.tsx
@@ -1,15 +1,23 @@
-export type MarkControllerButton = 'Up' | 'Down' | 'Left' | 'Right' | 'Select';
+import { Keybinding } from '../keybindings';
+import { MarkControllerButton } from './types';
 
 interface MarkControllerIllustrationProps {
-  highlight?: MarkControllerButton | 'Headphones';
+  highlight?: MarkControllerButton;
+  showHeadphones?: boolean;
 }
 
 /* istanbul ignore next - temporarily tested via apps/mark-scan */
 export function MarkControllerIllustration({
   highlight,
+  showHeadphones,
 }: MarkControllerIllustrationProps): JSX.Element {
   const defaultFill = '#fff';
   const highlightFill = '#985aa3';
+
+  function getButtonFill(button: MarkControllerButton) {
+    return highlight === button ? highlightFill : defaultFill;
+  }
+
   return (
     <svg
       version="1.1"
@@ -30,41 +38,37 @@ export function MarkControllerIllustration({
       <path d="m83.97 236.68-47.8-47.8c-4.07-4.07-6.31-9.48-6.31-15.25s2.24-11.18 6.31-15.25l47.8-47.8 30.02 30.02-1.64 3.23c-1.51 2.99-2.28 6.2-2.28 9.55v39.5c0 3.54.88 7.03 2.54 10.1l1.78 3.28-30.42 30.42z" />
       <path
         data-testid="left-button"
-        fill={highlight === 'Left' ? highlightFill : defaultFill}
+        fill={getButtonFill(Keybinding.PAGE_PREVIOUS)}
         d="m83.97 124.73-40.73 40.73c-4.51 4.51-4.51 11.85 0 16.36l40.73 40.73 18.25-18.25c-1.41-3.61-2.15-7.5-2.15-11.41v-39.5c0-3.69.63-7.26 1.88-10.67l-17.98-17.99z"
       />
       <path d="m184.2 136.45-3.28-1.78a21.278 21.278 0 0 0-10.09-2.54h-39.51c-3.35 0-6.56.77-9.55 2.28l-3.23 1.63-30.02-30.02 47.8-47.8c4.07-4.07 9.48-6.3 15.25-6.3s11.18 2.24 15.25 6.3l47.8 47.8-30.42 30.43z" />
       <path
         data-testid="up-button"
-        fill={highlight === 'Up' ? highlightFill : defaultFill}
+        fill={getButtonFill(Keybinding.FOCUS_PREVIOUS)}
         d="M131.32 122.14h39.51c3.91 0 7.79.74 11.4 2.15l18.25-18.25-40.73-40.74a11.48 11.48 0 0 0-8.18-3.38c-3.1 0-6 1.2-8.18 3.38l-40.73 40.73 17.98 17.98c3.42-1.24 7-1.87 10.68-1.87z"
       />
       <path d="M151.58 295.35c-5.77 0-11.19-2.24-15.25-6.31l-47.8-47.8 30.59-30.59 3.18 1.49c2.82 1.33 5.86 2 9.02 2h39.51c3.37 0 6.59-.76 9.56-2.27l3.23-1.63 31 31-47.8 47.8c-4.06 4.07-9.48 6.31-15.24 6.31z" />
       <path
         data-testid="down-button"
-        fill={highlight === 'Down' ? highlightFill : defaultFill}
+        fill={getButtonFill(Keybinding.FOCUS_NEXT)}
         d="m102.67 241.24 40.73 40.73a11.48 11.48 0 0 0 8.18 3.38c3.09 0 6-1.2 8.18-3.38l40.73-40.73-18.97-18.97c-3.4 1.24-6.98 1.87-10.68 1.87h-39.51c-3.43 0-6.76-.54-9.94-1.61l-18.72 18.71z"
       />
       <path d="m219.18 236.68-31-31.01 1.63-3.23a21.06 21.06 0 0 0 2.27-9.56v-39.51c0-3.17-.67-6.2-2-9.02l-1.49-3.18 30.6-30.6 47.8 47.8c4.07 4.07 6.3 9.48 6.3 15.25s-2.24 11.18-6.3 15.25l-47.81 47.81z" />
       <path
         data-testid="right-button"
-        fill={
-          highlight === 'Right' || highlight === 'Headphones'
-            ? highlightFill
-            : defaultFill
-        }
+        fill={getButtonFill(Keybinding.PAGE_NEXT)}
         d="m200.21 203.57 18.98 18.98 40.73-40.73a11.48 11.48 0 0 0 3.38-8.18c0-3.1-1.2-6-3.38-8.18l-40.73-40.73-18.71 18.71c1.07 3.18 1.61 6.51 1.61 9.94v39.51c-.02 3.7-.64 7.27-1.88 10.68z"
       />
       <path d="M169.52 209.42h-36.89c-4.76 0-9.24-1.85-12.61-5.22a17.715 17.715 0 0 1-5.22-12.61V154.7c0-9.83 8-17.83 17.83-17.83h36.89c4.76 0 9.24 1.85 12.61 5.22 3.37 3.37 5.22 7.85 5.22 12.61v36.89c0 4.76-1.85 9.24-5.22 12.61s-7.85 5.22-12.61 5.22z" />
       <path
         data-testid="select-button"
-        fill={highlight === 'Select' ? highlightFill : defaultFill}
+        fill={getButtonFill(Keybinding.SELECT)}
         d="M132.63 146.86c-4.32 0-7.83 3.51-7.83 7.83v36.89c0 2.09.81 4.06 2.29 5.54a7.783 7.783 0 0 0 5.54 2.29h36.89c2.09 0 4.06-.81 5.54-2.29s2.29-3.45 2.29-5.54v-36.89c0-2.09-.81-4.06-2.29-5.54a7.783 7.783 0 0 0-5.54-2.29h-36.89z"
       />
       <path d="M194.13 466.64h-3.26c-21.76 0-39.47-17.7-39.47-39.47v-86.08c0-21.76 17.7-39.47 39.47-39.47h3.26c21.76 0 39.47 17.7 39.47 39.47v86.08c-.01 21.76-17.71 39.47-39.47 39.47zm-3.27-155.01c-16.25 0-29.47 13.22-29.47 29.47v86.08c0 16.25 13.22 29.47 29.47 29.47h3.26c16.25 0 29.47-13.22 29.47-29.47V341.1c0-16.25-13.22-29.47-29.47-29.47h-3.26z" />
       <path d="M215.49 424.8c0-12.83-10.44-23.27-23.27-23.27s-23.27 10.44-23.27 23.27c0 6.79 2.93 12.9 7.58 17.16.48 2.61 2.78 4.61 5.52 4.61 3.09 0 5.62-2.53 5.62-5.62v-7.09c0-3.09-2.53-5.62-5.62-5.62-2.53 0-4.69 1.7-5.38 4.01a17.051 17.051 0 0 1-1.72-7.44c0-9.52 7.75-17.27 17.27-17.27s17.27 7.75 17.27 17.27c0 2.67-.62 5.2-1.71 7.46-.69-2.32-2.85-4.03-5.39-4.03-3.09 0-5.62 2.53-5.62 5.62v7.09c0 3.09 2.53 5.62 5.62 5.62 2.75 0 5.04-2 5.52-4.61 4.66-4.26 7.58-10.37 7.58-17.16zM119.87 373.03H87.29c-9.3 0-16.87-7.57-16.87-16.87v-32.57c0-9.3 7.57-16.87 16.87-16.87h32.57c9.3 0 16.87 7.57 16.87 16.87v32.57c.01 9.31-7.56 16.87-16.86 16.87zm-32.58-56.31c-3.79 0-6.87 3.08-6.87 6.87v32.57c0 3.79 3.08 6.87 6.87 6.87h32.57c3.79 0 6.87-3.08 6.87-6.87v-32.57c0-3.79-3.08-6.87-6.87-6.87H87.29z" />
       <path d="M90.81 357.38c-2.76 0-5-2.24-5-5v-3c0-2.76 2.24-5 5-5s5 2.24 5 5v3c0 2.76-2.24 5-5 5zM103.58 357.38c-2.76 0-5-2.24-5-5v-14c0-2.76 2.24-5 5-5s5 2.24 5 5v14c0 2.76-2.24 5-5 5zM116.35 357.38c-2.76 0-5-2.24-5-5v-25c0-2.76 2.24-5 5-5s5 2.24 5 5v25c0 2.76-2.24 5-5 5z" />
-      {highlight === 'Headphones' && (
+      {showHeadphones && (
         <g>
           <path
             data-testid="headphones"

--- a/libs/ui/src/accessible_controllers/mark_scan_controller_illustration.tsx
+++ b/libs/ui/src/accessible_controllers/mark_scan_controller_illustration.tsx
@@ -1,42 +1,69 @@
-export type MarkScanControllerButton =
-  | 'up'
-  | 'down'
-  | 'left'
-  | 'right'
-  | 'select'
-  | 'rate-up'
-  | 'rate-down'
-  | 'volume-up'
-  | 'volume-down'
-  | 'help'
-  | 'pause';
+import styled from 'styled-components';
+
+import { Keybinding } from '../keybindings';
+import { MarkScanControllerButton } from './types';
 
 interface MarkScanControllerIllustrationProps {
   highlight?: MarkScanControllerButton;
 }
 
-const HIGHLIGHT_FILL = '#885fce';
-export const MARK_SCAN_CONTROLLER_ILLUSTRATION_HIGHLIGHT_FILL = HIGHLIGHT_FILL;
+const BUTTON_CLASS_NAME = 'markScanControllerIllustration--Button';
+const BUTTON_CLASS_NAME_HIGHLIGHTED = `${BUTTON_CLASS_NAME}--highlighted`;
+const BUTTON_FOREGROUND_CLASS_NAME = `${BUTTON_CLASS_NAME}Foreground`;
+
+// Exported for Mark-Scan tests:
+export const MARK_SCAN_CONTROLLER_ILLUSTRATION_HIGHLIGHT_CLASS_NAME =
+  BUTTON_CLASS_NAME_HIGHLIGHTED;
+
+/* istanbul ignore next - tested via apps/mark-scan */
+const SvgContainer = styled.svg`
+  .${BUTTON_CLASS_NAME} {
+    fill: ${(p) => p.theme.colors.background};
+    stroke: ${(p) => p.theme.colors.onBackground};
+
+    .${BUTTON_FOREGROUND_CLASS_NAME} {
+      fill: ${(p) => p.theme.colors.onBackground};
+    }
+  }
+
+  .${BUTTON_CLASS_NAME_HIGHLIGHTED} {
+    fill: ${(p) => p.theme.colors.primary};
+    stroke: ${(p) => p.theme.colors.primary};
+
+    .${BUTTON_FOREGROUND_CLASS_NAME} {
+      fill: ${(p) => p.theme.colors.background};
+    }
+  }
+`;
 
 /* istanbul ignore next - temporarily tested via apps/mark-scan */
 export function MarkScanControllerIllustration({
   highlight,
 }: MarkScanControllerIllustrationProps): JSX.Element {
+  function getButtonClassNames(button: MarkScanControllerButton) {
+    const classNames = [BUTTON_CLASS_NAME];
+
+    if (highlight === button) {
+      classNames.push(BUTTON_CLASS_NAME_HIGHLIGHTED);
+    }
+
+    return classNames.join(' ');
+  }
+
   return (
-    <svg
+    <SvgContainer
       viewBox="25 40 160 160"
       version="1.1"
-      id="svg5"
       xmlSpace="preserve"
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>Accessible Controller Illustration</title>
-      <g id="layer1">
+      <g>
+        {/* Controller outline: */}
         <rect
           fill="none"
-          stroke="#000000"
+          stroke="currentColor"
           strokeWidth="2.465"
-          id="rect184"
           width="153.13997"
           height="153.13998"
           x="28.7325"
@@ -45,65 +72,54 @@ export function MarkScanControllerIllustration({
           ry="19.247101"
         />
         <g
-          id="g9197"
+          fill="none"
           transform="matrix(1.0474341,0,0,1.0474341,-5.2047137,-9.7350275)"
         >
           <path
             data-testid="left"
-            fill={highlight === 'left' ? HIGHLIGHT_FILL : 'none'}
-            stroke="#000000"
+            className={getButtonClassNames(Keybinding.PAGE_PREVIOUS)}
             strokeWidth="2.5"
             strokeLinejoin="round"
             d="m 63.21558,109.32741 v 32.712 L 46.405243,125.68342 Z"
-            id="path6813"
           />
           <path
             data-testid="up"
-            fill={highlight === 'up' ? HIGHLIGHT_FILL : 'none'}
-            stroke="#000000"
+            className={getButtonClassNames(Keybinding.FOCUS_PREVIOUS)}
             strokeWidth="2.5"
             strokeLinejoin="round"
             d="M 100.9252,104.77458 H 68.213198 L 84.569192,87.964243 Z"
-            id="path6813-2"
           />
           <path
             data-testid="down"
-            fill={highlight === 'down' ? HIGHLIGHT_FILL : 'none'}
-            stroke="#000000"
+            className={getButtonClassNames(Keybinding.FOCUS_NEXT)}
             strokeWidth="2.5"
             strokeLinejoin="round"
             d="M 68.213198,147.00378 H 100.9252 l -16.355997,16.80886 z"
-            id="path6813-2-5"
           />
           <path
             data-testid="right"
-            fill={highlight === 'right' ? HIGHLIGHT_FILL : 'none'}
-            stroke="#000000"
+            className={getButtonClassNames(Keybinding.PAGE_NEXT)}
             strokeWidth="2.5"
             strokeLinejoin="round"
             d="m 106.30715,142.03938 v -32.71199 l 16.81034,16.35599 z"
-            id="path6813-2-6"
           />
         </g>
         <circle
           data-testid="select"
-          fill={highlight === 'select' ? HIGHLIGHT_FILL : 'none'}
-          stroke="#000000"
+          className={getButtonClassNames(Keybinding.SELECT)}
           strokeWidth="2.5"
           strokeLinejoin="round"
-          id="path9191"
           cx="151.78627"
           cy="121.99416"
           r="12.847383"
         />
-        <g>
+        <g
+          className={getButtonClassNames(Keybinding.TOGGLE_HELP)}
+          data-testid="help"
+        >
           <rect
-            data-testid="help"
-            fill={highlight === 'help' ? HIGHLIGHT_FILL : 'none'}
-            stroke="#000000"
             strokeWidth="1.8"
             strokeLinejoin="round"
-            id="rect10678-77"
             width="16.343853"
             height="16.343853"
             x="42.200451"
@@ -112,79 +128,84 @@ export function MarkScanControllerIllustration({
             ry="3.9077237"
           />
           <path
+            className={BUTTON_FOREGROUND_CLASS_NAME}
             d="m 48.644064,63.596124 c 0,-0.76891 0.625151,-1.39407 1.394065,-1.39407 h 0.697032 c 0.768913,0 1.394064,0.62516 1.394064,1.39407 v 0.0784 c 0,0.47486 -0.241783,0.91704 -0.640398,1.17189 l -0.919211,0.5903 c -0.548913,0.35287 -0.880003,0.9606 -0.880003,1.61189 v 0.0327 c 0,0.38555 0.311486,0.69703 0.697032,0.69703 0.385545,0 0.697032,-0.31148 0.697032,-0.69703 v -0.0305 c 0,-0.17861 0.09148,-0.34415 0.239605,-0.44 l 0.919211,-0.5903 c 0.79723,-0.51406 1.280796,-1.39624 1.280796,-2.34595 v -0.0784 c 0,-1.54001 -1.248123,-2.78813 -2.788128,-2.78813 h -0.697032 c -1.540006,0 -2.788129,1.24812 -2.788129,2.78813 0,0.38554 0.311486,0.69703 0.697032,0.69703 0.385546,0 0.697032,-0.31149 0.697032,-0.69703 z m 1.742581,6.97032 a 0.8712903,0.8712903 0 1 0 0,-1.74258 0.8712903,0.8712903 0 1 0 0,1.74258 z"
-            id="path28013"
             strokeWidth="0.0217822"
           />
         </g>
-        <g id="g25380" transform="translate(3.1750001)">
+        <g
+          className={getButtonClassNames(Keybinding.PLAYBACK_RATE_DOWN)}
+          data-testid="rate-down"
+        >
           <path
-            id="rect10678-7"
-            data-testid="rate-down"
-            fill={highlight === 'rate-down' ? HIGHLIGHT_FILL : 'none'}
-            stroke="#000000"
             strokeWidth="1.8"
             strokeLinejoin="round"
+            transform="translate(3.1750001)"
             d="m 136.29567,167.70045 12.04536,0.0505 v 16.24294 c 0,0 -8.03015,0.0505 -12.04536,0.0505 -2.38136,0 -4.29849,-1.74284 -4.29849,-3.90772 v -8.5284 c 0,-2.16488 1.91713,-3.90773 4.29849,-3.90773 z"
           />
           <path
-            id="rect10678-7-6"
-            data-testid="rate-up"
-            fill={highlight === 'rate-up' ? HIGHLIGHT_FILL : 'none'}
-            stroke="#000000"
-            strokeWidth="1.8"
-            strokeLinejoin="round"
-            d="m 160.47841,167.70045 -12.04536,0.0505 v 16.24294 c 0,0 8.03015,0.0505 12.04536,0.0505 2.38136,0 4.29849,-1.74284 4.29849,-3.90772 v -8.5284 c 0,-2.16488 -1.91713,-3.90773 -4.29849,-3.90773 z"
+            className={BUTTON_FOREGROUND_CLASS_NAME}
+            d="m 142.85286,179.23155 c 0.35793,0.35793 0.93922,0.35793 1.29715,0 l 4.58153,-4.58154 c 0.35795,-0.35794 0.35795,-0.93922 0,-1.29715 -0.35793,-0.35794 -0.93921,-0.35794 -1.29714,0 l -3.9344,3.9344 -3.93441,-3.93154 c -0.35793,-0.35793 -0.93922,-0.35793 -1.29714,0 -0.35794,0.35793 -0.35794,0.93922 0,1.29715 l 4.58154,4.58154 z"
+            strokeWidth="0.0286346"
           />
         </g>
-        <g id="g25380-3" transform="translate(3.17527,-110)">
+        <g
+          className={getButtonClassNames(Keybinding.PLAYBACK_RATE_UP)}
+          data-testid="rate-up"
+        >
           <path
-            id="rect10678-7-4"
+            strokeWidth="1.8"
+            strokeLinejoin="round"
+            transform="translate(3.1750001)"
+            d="m 160.47841,167.70045 -12.04536,0.0505 v 16.24294 c 0,0 8.03015,0.0505 12.04536,0.0505 2.38136,0 4.29849,-1.74284 4.29849,-3.90772 v -8.5284 c 0,-2.16488 -1.91713,-3.90773 -4.29849,-3.90773 z"
+          />
+          <path
+            className={BUTTON_FOREGROUND_CLASS_NAME}
+            d="m 159.08993,172.85286 c 0.35793,-0.35793 0.9392,-0.35793 1.29713,0 l 4.58156,4.58154 c 0.35793,0.35793 0.35793,0.93921 0,1.29715 -0.35794,0.35793 -0.93922,0.35793 -1.29715,0 l -3.9344,-3.9344 -3.9344,3.93154 c -0.35794,0.35793 -0.93922,0.35793 -1.29715,0 -0.35793,-0.35794 -0.35793,-0.93922 0,-1.29715 l 4.58155,-4.58156 z"
+            strokeWidth="0.0286347"
+          />
+        </g>
+        <g>
+          <g
+            className={getButtonClassNames(Keybinding.VOLUME_DOWN)}
             data-testid="volume-down"
-            fill={highlight === 'volume-down' ? HIGHLIGHT_FILL : 'none'}
-            stroke="#000000"
-            strokeWidth="1.8"
-            strokeLinejoin="round"
-            d="m 136.29567,167.70045 12.04536,0.0505 v 16.24294 c 0,0 -8.03015,0.0505 -12.04536,0.0505 -2.38136,0 -4.29849,-1.74284 -4.29849,-3.90772 v -8.5284 c 0,-2.16488 1.91713,-3.90773 4.29849,-3.90773 z"
-          />
-          <path
-            id="rect10678-7-6-3"
+          >
+            <path
+              strokeWidth="1.8"
+              strokeLinejoin="round"
+              transform="translate(3.17527,-110)"
+              d="m 136.29567,167.70045 12.04536,0.0505 v 16.24294 c 0,0 -8.03015,0.0505 -12.04536,0.0505 -2.38136,0 -4.29849,-1.74284 -4.29849,-3.90772 v -8.5284 c 0,-2.16488 1.91713,-3.90773 4.29849,-3.90773 z"
+            />
+            <path
+              className={BUTTON_FOREGROUND_CLASS_NAME}
+              d="m 149.2,65.979017 c 0,0.498084 -0.40241,0.900492 -0.9005,0.900492 h -9.90541 c -0.49809,0 -0.90049,-0.402408 -0.90049,-0.900492 0,-0.498084 0.4024,-0.900492 0.90049,-0.900492 h 9.90541 c 0.49809,0 0.9005,0.402408 0.9005,0.900492 z"
+              strokeWidth="0.0281403"
+            />
+          </g>
+          <g
+            className={getButtonClassNames(Keybinding.VOLUME_UP)}
             data-testid="volume-up"
-            fill={highlight === 'volume-up' ? HIGHLIGHT_FILL : 'none'}
-            stroke="#000000"
-            strokeWidth="1.8"
-            strokeLinejoin="round"
-            d="m 160.47841,167.70045 -12.04536,0.0505 v 16.24294 c 0,0 8.03015,0.0505 12.04536,0.0505 2.38136,0 4.29849,-1.74284 4.29849,-3.90772 v -8.5284 c 0,-2.16488 -1.91713,-3.90773 -4.29849,-3.90773 z"
-          />
+          >
+            <path
+              strokeWidth="1.8"
+              strokeLinejoin="round"
+              transform="translate(3.17527,-110)"
+              d="m 160.47841,167.70045 -12.04536,0.0505 v 16.24294 c 0,0 8.03015,0.0505 12.04536,0.0505 2.38136,0 4.29849,-1.74284 4.29849,-3.90772 v -8.5284 c 0,-2.16488 -1.91713,-3.90773 -4.29849,-3.90773 z"
+            />
+            <path
+              className={BUTTON_FOREGROUND_CLASS_NAME}
+              d="m 160.5616,61.041143 c 0,-0.481673 -0.38915,-0.870821 -0.87082,-0.870821 -0.48167,0 -0.87082,0.389148 -0.87082,0.870821 v 3.918697 h -3.9187 c -0.48167,0 -0.87082,0.389149 -0.87082,0.870821 0,0.481674 0.38915,0.870822 0.87082,0.870822 h 3.9187 v 3.918697 c 0,0.481674 0.38915,0.870822 0.87082,0.870822 0.48167,0 0.87082,-0.389148 0.87082,-0.870822 v -3.918697 h 3.9187 c 0.48167,0 0.87082,-0.389148 0.87082,-0.870822 0,-0.481672 -0.38915,-0.870821 -0.87082,-0.870821 h -3.9187 z"
+              strokeWidth="0.0272132"
+            />
+          </g>
         </g>
-        <path
-          d="m 160.5616,61.041143 c 0,-0.481673 -0.38915,-0.870821 -0.87082,-0.870821 -0.48167,0 -0.87082,0.389148 -0.87082,0.870821 v 3.918697 h -3.9187 c -0.48167,0 -0.87082,0.389149 -0.87082,0.870821 0,0.481674 0.38915,0.870822 0.87082,0.870822 h 3.9187 v 3.918697 c 0,0.481674 0.38915,0.870822 0.87082,0.870822 0.48167,0 0.87082,-0.389148 0.87082,-0.870822 v -3.918697 h 3.9187 c 0.48167,0 0.87082,-0.389148 0.87082,-0.870822 0,-0.481672 -0.38915,-0.870821 -0.87082,-0.870821 h -3.9187 z"
-          id="path29547"
-          strokeWidth="0.0272132"
-        />
-        <path
-          d="m 149.2,65.979017 c 0,0.498084 -0.40241,0.900492 -0.9005,0.900492 h -9.90541 c -0.49809,0 -0.90049,-0.402408 -0.90049,-0.900492 0,-0.498084 0.4024,-0.900492 0.90049,-0.900492 h 9.90541 c 0.49809,0 0.9005,0.402408 0.9005,0.900492 z"
-          id="path30322"
-          strokeWidth="0.0281403"
-        />
-        <path
-          d="m 159.08993,172.85286 c 0.35793,-0.35793 0.9392,-0.35793 1.29713,0 l 4.58156,4.58154 c 0.35793,0.35793 0.35793,0.93921 0,1.29715 -0.35794,0.35793 -0.93922,0.35793 -1.29715,0 l -3.9344,-3.9344 -3.9344,3.93154 c -0.35794,0.35793 -0.93922,0.35793 -1.29715,0 -0.35793,-0.35794 -0.35793,-0.93922 0,-1.29715 l 4.58155,-4.58156 z"
-          id="path31089"
-          strokeWidth="0.0286347"
-        />
-        <path
-          d="m 142.85286,179.23155 c 0.35793,0.35793 0.93922,0.35793 1.29715,0 l 4.58153,-4.58154 c 0.35795,-0.35794 0.35795,-0.93922 0,-1.29715 -0.35793,-0.35794 -0.93921,-0.35794 -1.29714,0 l -3.9344,3.9344 -3.93441,-3.93154 c -0.35793,-0.35793 -0.93922,-0.35793 -1.29714,0 -0.35794,0.35793 -0.35794,0.93922 0,1.29715 l 4.58154,4.58154 z"
-          id="path31856"
-          strokeWidth="0.0286346"
-        />
-        <g id="g33812">
+        <g
+          className={getButtonClassNames(Keybinding.TOGGLE_PAUSE)}
+          data-testid="pause"
+        >
           <rect
-            data-testid="pause"
-            fill={highlight === 'pause' ? HIGHLIGHT_FILL : 'none'}
-            stroke="#000000"
             strokeWidth="1.8"
             strokeLinejoin="round"
-            id="rect10678"
             width="16.343853"
             height="16.343853"
             x="42.200451"
@@ -193,17 +214,17 @@ export function MarkScanControllerIllustration({
             ry="3.9077237"
           />
           <path
+            className={BUTTON_FOREGROUND_CLASS_NAME}
             d="m 48.30818,180.33017 c -0.60367,0 -1.091388,-0.3049 -1.091388,-0.68231 v -7.50534 c 0,-0.3774 0.487718,-0.6823 1.091388,-0.6823 0.60368,0 1.091398,0.3049 1.091398,0.6823 v 7.50534 c 0,0.37741 -0.487718,0.68231 -1.091398,0.68231 z"
-            id="path30322-1"
             strokeWidth="0.0269667"
           />
           <path
+            className={BUTTON_FOREGROUND_CLASS_NAME}
             d="m 52.508602,180.33017 c -0.60367,0 -1.091388,-0.3049 -1.091388,-0.68231 v -7.50534 c 0,-0.3774 0.487718,-0.6823 1.091388,-0.6823 0.60368,0 1.091398,0.3049 1.091398,0.6823 v 7.50534 c 0,0.37741 -0.487718,0.68231 -1.091398,0.68231 z"
-            id="path30322-1-2"
             strokeWidth="0.0269667"
           />
         </g>
       </g>
-    </svg>
+    </SvgContainer>
   );
 }

--- a/libs/ui/src/accessible_controllers/mark_scan_controller_illustration.tsx
+++ b/libs/ui/src/accessible_controllers/mark_scan_controller_illustration.tsx
@@ -7,7 +7,7 @@ interface MarkScanControllerIllustrationProps {
   highlight?: MarkScanControllerButton;
 }
 
-const BUTTON_CLASS_NAME = 'markScanControllerIllustration--Button';
+const BUTTON_CLASS_NAME = 'markScanControllerIllustrationButton';
 const BUTTON_CLASS_NAME_HIGHLIGHTED = `${BUTTON_CLASS_NAME}--highlighted`;
 const BUTTON_FOREGROUND_CLASS_NAME = `${BUTTON_CLASS_NAME}Foreground`;
 

--- a/libs/ui/src/accessible_controllers/navigation.test.tsx
+++ b/libs/ui/src/accessible_controllers/navigation.test.tsx
@@ -1,0 +1,113 @@
+import styled from 'styled-components';
+import { act, render, screen } from '../../test/react_testing_library';
+import {
+  PageNavigationButtonId,
+  advanceElementFocus,
+  triggerPageNavigationButton,
+} from './navigation';
+
+const TestButton = styled.button.attrs({ type: 'button' })`
+  /* stylelint-disable no-empty-source */
+`;
+
+test('advanceElementFocus', () => {
+  render(
+    <div>
+      <TestButton data-testid="focusableButton" />
+      <TestButton data-testid="disabledButton" disabled />
+      <TestButton data-testid="nonFocusableButton" tabIndex={-1} />
+      <TestButton data-testid="hiddenButton" aria-hidden />
+      <div data-testid="focusableButtonDiv" role="button" tabIndex={0} />
+      <div data-testid="nonFocusableButtonDiv" role="button" tabIndex={-1} />
+      <div data-testid="hiddenButtonDiv" role="button" aria-hidden />
+      <div aria-hidden>
+        <TestButton data-testid="focusableButtonInHiddenBlock" />
+        <div
+          data-testid="focusableButtonDivInHiddenBlock"
+          role="button"
+          tabIndex={0}
+        />
+      </div>
+    </div>
+  );
+
+  // Expect to move forwards and wrap to beginning:
+  act(() => advanceElementFocus(1));
+  expect(screen.getByTestId('focusableButton')).toHaveFocus();
+
+  act(() => advanceElementFocus(1));
+  expect(screen.getByTestId('focusableButtonDiv')).toHaveFocus();
+
+  act(() => advanceElementFocus(1));
+  expect(screen.getByTestId('focusableButton')).toHaveFocus();
+
+  // Expect to move backwards and wrap to end:
+  act(() => advanceElementFocus(-1));
+  expect(screen.getByTestId('focusableButtonDiv')).toHaveFocus();
+
+  act(() => advanceElementFocus(-1));
+  expect(screen.getByTestId('focusableButton')).toHaveFocus();
+
+  act(() => advanceElementFocus(-1));
+  expect(screen.getByTestId('focusableButtonDiv')).toHaveFocus();
+});
+
+test('advanceElementFocus - is no-op when no focusable elements present', () => {
+  render(
+    <div>
+      <div>foo</div>
+    </div>
+  );
+
+  expect(() => advanceElementFocus(1)).not.toThrow();
+  expect(() => advanceElementFocus(-1)).not.toThrow();
+});
+
+test('triggerPageNavigationButton - triggers nav buttons', () => {
+  const onClickPrev = jest.fn();
+  const onClickNext = jest.fn();
+
+  render(
+    <div>
+      <TestButton id={PageNavigationButtonId.PREVIOUS} onClick={onClickPrev} />
+      <TestButton id={PageNavigationButtonId.NEXT} onClick={onClickNext} />
+    </div>
+  );
+
+  act(() => triggerPageNavigationButton(PageNavigationButtonId.NEXT));
+  expect(onClickPrev).not.toHaveBeenCalled();
+  expect(onClickNext).toHaveBeenCalledTimes(1);
+
+  act(() => triggerPageNavigationButton(PageNavigationButtonId.PREVIOUS));
+  expect(onClickPrev).toHaveBeenCalledTimes(1);
+  expect(onClickNext).toHaveBeenCalledTimes(1);
+});
+
+test('triggerPageNavigationButton - is no-op for hidden nav buttons', () => {
+  const onClickPrev = jest.fn();
+  const onClickNext = jest.fn();
+
+  render(
+    <div aria-hidden>
+      <TestButton id={PageNavigationButtonId.PREVIOUS} onClick={onClickPrev} />
+      <TestButton id={PageNavigationButtonId.NEXT} onClick={onClickNext} />
+    </div>
+  );
+
+  act(() => triggerPageNavigationButton(PageNavigationButtonId.NEXT));
+  act(() => triggerPageNavigationButton(PageNavigationButtonId.PREVIOUS));
+  expect(onClickPrev).not.toHaveBeenCalled();
+  expect(onClickNext).not.toHaveBeenCalled();
+});
+
+test('triggerPageNavigationButton - is no-op for missing nav buttons', () => {
+  render(<div>Empty Page</div>);
+
+  expect(() =>
+    triggerPageNavigationButton(PageNavigationButtonId.NEXT)
+  ).not.toThrow();
+
+  expect(() =>
+    triggerPageNavigationButton(PageNavigationButtonId.PREVIOUS)
+  ).not.toThrow();
+});

--- a/libs/ui/src/accessible_controllers/navigation.ts
+++ b/libs/ui/src/accessible_controllers/navigation.ts
@@ -1,0 +1,60 @@
+export enum PageNavigationButtonId {
+  NEXT = 'next',
+  PREVIOUS = 'previous',
+}
+
+const FOCUSABLE_ELEMENT_SELECTORS = [
+  'button:not([aria-hidden="true"]):not([disabled]):not([tabindex="-1"])',
+  '[role="button"]:not([aria-hidden="true"]):not([disabled]):not([tabindex="-1"])',
+].join(', ');
+
+const HIDDEN_TAB_ENABLED_ELEMENT_SELECTORS = [
+  '[aria-hidden="true"] button',
+  '[aria-hidden="true"] [role="button"]',
+].join(', ');
+
+function getHiddenTabEnabledElements() {
+  return new Set(
+    document.querySelectorAll(HIDDEN_TAB_ENABLED_ELEMENT_SELECTORS)
+  );
+}
+
+/**
+ * Simulates browser `Tab`/`Shift+Tab` behavior by moving focus to the next
+ * focusable element in the document, in the specified {@link direction}.
+ */
+export function advanceElementFocus(direction: 1 | -1): void {
+  const hiddenTabEnabledElements = getHiddenTabEnabledElements();
+
+  const focusableElements = Array.from(
+    document.querySelectorAll<HTMLElement>(FOCUSABLE_ELEMENT_SELECTORS)
+  ).filter((e) => !hiddenTabEnabledElements.has(e));
+  if (focusableElements.length === 0) {
+    return;
+  }
+
+  if (direction === -1) {
+    focusableElements.reverse();
+  }
+
+  const { activeElement } = document;
+  const currentIndex = focusableElements.indexOf(activeElement as HTMLElement);
+  const nextIndex = (currentIndex + 1) % focusableElements.length;
+
+  focusableElements[nextIndex].focus();
+}
+
+/**
+ * Simulates a click on the page navigation button with the specified {@link id}
+ * to advance
+ */
+export function triggerPageNavigationButton(id: PageNavigationButtonId): void {
+  const hiddenTabEnabledElements = getHiddenTabEnabledElements();
+  const button = document.getElementById(id);
+
+  if (!button || hiddenTabEnabledElements.has(button)) {
+    return;
+  }
+
+  button.click();
+}

--- a/libs/ui/src/accessible_controllers/navigation.ts
+++ b/libs/ui/src/accessible_controllers/navigation.ts
@@ -3,19 +3,23 @@ export enum PageNavigationButtonId {
   PREVIOUS = 'previous',
 }
 
-const FOCUSABLE_ELEMENT_SELECTORS = [
+const TAB_ENABLED_ELEMENT_SELECTORS = [
   'button:not([aria-hidden="true"]):not([disabled]):not([tabindex="-1"])',
   '[role="button"]:not([aria-hidden="true"]):not([disabled]):not([tabindex="-1"])',
 ].join(', ');
 
-const HIDDEN_TAB_ENABLED_ELEMENT_SELECTORS = [
+/**
+ * Selectors for elements that may be tab-enabled, but not focusable as a result
+ * of being a descendant of an `aria-hidden` node.
+ */
+const TAB_ENABLED_ELEMENT_IN_HIDDEN_BLOCK_SELECTORS = [
   '[aria-hidden="true"] button',
   '[aria-hidden="true"] [role="button"]',
 ].join(', ');
 
-function getHiddenTabEnabledElements() {
+function getTabEnabledElementsInHiddenBlocks() {
   return new Set(
-    document.querySelectorAll(HIDDEN_TAB_ENABLED_ELEMENT_SELECTORS)
+    document.querySelectorAll(TAB_ENABLED_ELEMENT_IN_HIDDEN_BLOCK_SELECTORS)
   );
 }
 
@@ -24,11 +28,15 @@ function getHiddenTabEnabledElements() {
  * focusable element in the document, in the specified {@link direction}.
  */
 export function advanceElementFocus(direction: 1 | -1): void {
-  const hiddenTabEnabledElements = getHiddenTabEnabledElements();
+  const allTabEnabledElements = document.querySelectorAll<HTMLElement>(
+    TAB_ENABLED_ELEMENT_SELECTORS
+  );
+  const tabEnabledElementsInHiddenBlocks =
+    getTabEnabledElementsInHiddenBlocks();
 
-  const focusableElements = Array.from(
-    document.querySelectorAll<HTMLElement>(FOCUSABLE_ELEMENT_SELECTORS)
-  ).filter((e) => !hiddenTabEnabledElements.has(e));
+  const focusableElements = Array.from(allTabEnabledElements).filter(
+    (e) => !tabEnabledElementsInHiddenBlocks.has(e)
+  );
   if (focusableElements.length === 0) {
     return;
   }
@@ -49,10 +57,9 @@ export function advanceElementFocus(direction: 1 | -1): void {
  * to advance
  */
 export function triggerPageNavigationButton(id: PageNavigationButtonId): void {
-  const hiddenTabEnabledElements = getHiddenTabEnabledElements();
   const button = document.getElementById(id);
 
-  if (!button || hiddenTabEnabledElements.has(button)) {
+  if (!button || getTabEnabledElementsInHiddenBlocks().has(button)) {
     return;
   }
 

--- a/libs/ui/src/accessible_controllers/types.ts
+++ b/libs/ui/src/accessible_controllers/types.ts
@@ -1,0 +1,28 @@
+import { Keybinding } from '../keybindings';
+
+export const MARK_SCAN_CONTROLLER_KEYBINDINGS = [
+  Keybinding.PLAYBACK_RATE_DOWN,
+  Keybinding.VOLUME_DOWN,
+  Keybinding.FOCUS_NEXT,
+  Keybinding.FOCUS_PREVIOUS,
+  Keybinding.PLAYBACK_RATE_UP,
+  Keybinding.VOLUME_UP,
+  Keybinding.PAGE_NEXT,
+  Keybinding.PAGE_PREVIOUS,
+  Keybinding.SELECT,
+  Keybinding.TOGGLE_HELP,
+  Keybinding.TOGGLE_PAUSE,
+] satisfies Keybinding[];
+
+export type MarkScanControllerButton =
+  (typeof MARK_SCAN_CONTROLLER_KEYBINDINGS)[number];
+
+export const MARK_CONTROLLER_KEYBINDINGS = [
+  Keybinding.FOCUS_NEXT,
+  Keybinding.FOCUS_PREVIOUS,
+  Keybinding.PAGE_NEXT,
+  Keybinding.PAGE_PREVIOUS,
+  Keybinding.SELECT,
+] satisfies Keybinding[];
+
+export type MarkControllerButton = (typeof MARK_CONTROLLER_KEYBINDINGS)[number];

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -44,6 +44,7 @@ export * from './icons';
 export * from './input_group';
 export * from './insert_ballot_image';
 export * from './insert_card_image';
+export * from './keybindings';
 export * from './labelled_text';
 export * from './language_settings';
 export * from './left_nav';

--- a/libs/ui/src/keybindings.ts
+++ b/libs/ui/src/keybindings.ts
@@ -22,7 +22,4 @@ export enum Keybinding {
 
   PAT_MOVE = '1',
   PAT_SELECT = '2',
-
-  LEGACY_PAT_MOVE = '[',
-  LEGACY_PAT_SELECT = ']',
 }

--- a/libs/ui/src/keybindings.ts
+++ b/libs/ui/src/keybindings.ts
@@ -1,0 +1,28 @@
+/**
+ * Keyboard keybindings for VxSuite apps.
+ *
+ * These are mapped to features/behaviors in various apps (some triggered via
+ * accessible controllers) and are consolidated here to encourage consistency
+ * and avoid accidental collisions.
+ */
+export enum Keybinding {
+  FOCUS_NEXT = 'ArrowDown',
+  FOCUS_PREVIOUS = 'ArrowUp',
+  PAGE_NEXT = 'ArrowRight',
+  PAGE_PREVIOUS = 'ArrowLeft',
+  PLAYBACK_RATE_DOWN = ',',
+  PLAYBACK_RATE_UP = '.',
+  SELECT = 'Enter',
+  SWITCH_LANGUAGE = 'L',
+  TOGGLE_AUDIO = 'M',
+  TOGGLE_HELP = 'R',
+  TOGGLE_PAUSE = 'P',
+  VOLUME_DOWN = '-',
+  VOLUME_UP = '=',
+
+  PAT_MOVE = '1',
+  PAT_SELECT = '2',
+
+  LEGACY_PAT_MOVE = '[',
+  LEGACY_PAT_SELECT = ']',
+}

--- a/libs/ui/src/language_settings/language_settings_screen.tsx
+++ b/libs/ui/src/language_settings/language_settings_screen.tsx
@@ -19,6 +19,7 @@ import { RadioGroup } from '../radio_group';
 import { DEFAULT_LANGUAGE_CODE } from '../ui_strings/language_context';
 import { useScreenInfo } from '../hooks/use_screen_info';
 import { WithScrollButtons } from '../with_scroll_buttons';
+import { PageNavigationButtonId } from '../accessible_controllers';
 
 export interface LanguageSettingsScreenProps {
   onDone: () => void;
@@ -113,7 +114,7 @@ export function LanguageSettingsScreen(
       <Buttons>
         <Button
           icon="Done"
-          id="next" // Enables right arrow control on accessible controllers.
+          id={PageNavigationButtonId.NEXT}
           onPress={onDone}
           variant="primary"
         >

--- a/libs/ui/src/ui_strings/index.ts
+++ b/libs/ui/src/ui_strings/index.ts
@@ -2,7 +2,6 @@ export * from './app_strings';
 export * from './audio_only';
 export * from './date_string';
 export * from './election_strings';
-export { ACCESSIBILITY_KEYBINDINGS } from './keyboard_shortcut_handlers';
 export * from './language_override';
 export * from './number_string';
 export * from './read_on_load';

--- a/libs/ui/src/ui_strings/keyboard_shortcut_handlers.test.tsx
+++ b/libs/ui/src/ui_strings/keyboard_shortcut_handlers.test.tsx
@@ -5,6 +5,7 @@ import { newTestContext } from '../../test/test_context';
 import { KeyboardShortcutHandlers } from './keyboard_shortcut_handlers';
 import { act, render, screen, waitFor } from '../../test/react_testing_library';
 import { useCurrentLanguage } from '../hooks/use_current_language';
+import { Keybinding } from '..';
 
 const { CHINESE_SIMPLIFIED, ENGLISH, SPANISH } = LanguageCode;
 const audioControls: AudioControls = fakeUseAudioControls();
@@ -44,13 +45,13 @@ test('Shift+L switches display language', async () => {
 
   expect(currentLanguage).toEqual(ENGLISH);
 
-  await act(() => userEvent.keyboard('L'));
+  await act(() => userEvent.keyboard(Keybinding.SWITCH_LANGUAGE));
   expect(currentLanguage).toEqual(SPANISH);
 
-  await act(() => userEvent.keyboard('L'));
+  await act(() => userEvent.keyboard(Keybinding.SWITCH_LANGUAGE));
   expect(currentLanguage).toEqual(CHINESE_SIMPLIFIED);
 
-  await act(() => userEvent.keyboard('L'));
+  await act(() => userEvent.keyboard(Keybinding.SWITCH_LANGUAGE));
   expect(currentLanguage).toEqual(ENGLISH);
 
   // Should be a no-op without the `Shift` key modifier:
@@ -59,13 +60,18 @@ test('Shift+L switches display language', async () => {
 });
 
 test.each([
-  { key: 'M', expectedFnCall: audioControls.toggleEnabled },
-  { key: 'R', expectedFnCall: audioControls.replay },
-  { key: ',', expectedFnCall: audioControls.decreasePlaybackRate },
-  { key: '.', expectedFnCall: audioControls.increasePlaybackRate },
-  { key: 'P', expectedFnCall: audioControls.togglePause },
-  { key: '-', expectedFnCall: audioControls.decreaseVolume },
-  { key: '=', expectedFnCall: audioControls.increaseVolume },
+  { key: Keybinding.TOGGLE_AUDIO, expectedFnCall: audioControls.toggleEnabled },
+  {
+    key: Keybinding.PLAYBACK_RATE_DOWN,
+    expectedFnCall: audioControls.decreasePlaybackRate,
+  },
+  {
+    key: Keybinding.PLAYBACK_RATE_UP,
+    expectedFnCall: audioControls.increasePlaybackRate,
+  },
+  { key: Keybinding.TOGGLE_PAUSE, expectedFnCall: audioControls.togglePause },
+  { key: Keybinding.VOLUME_DOWN, expectedFnCall: audioControls.decreaseVolume },
+  { key: Keybinding.VOLUME_UP, expectedFnCall: audioControls.increaseVolume },
 ])(
   '"$key" key calls expected audioControls function',
   async ({ key, expectedFnCall }) => {

--- a/libs/ui/src/ui_strings/keyboard_shortcut_handlers.tsx
+++ b/libs/ui/src/ui_strings/keyboard_shortcut_handlers.tsx
@@ -3,20 +3,10 @@ import { useCurrentLanguage } from '../hooks/use_current_language';
 import { useAvailableLanguages } from '../hooks/use_available_languages';
 import { useLanguageControls } from '../hooks/use_language_controls';
 import { useAudioControls } from '../hooks/use_audio_controls';
-
-export enum ACCESSIBILITY_KEYBINDINGS {
-  TOGGLE_AUDIO = 'M',
-  REPLAY = 'R',
-  DECREASE_PLAYBACK_RATE = ',',
-  INCREASE_PLAYBACK_RATE = '.',
-  TOGGLE_PAUSE = 'P',
-  DECREASE_VOLUME = '-',
-  INCREASE_VOLUME = '=',
-}
+import { Keybinding } from '../keybindings';
 
 /**
  * Installs UI String keyboard shortcuts for dev convenience.
- *   - Shift+L: Switch to next available display/audio language.
  */
 export function KeyboardShortcutHandlers(): React.ReactNode {
   const currentLanguageCode = useCurrentLanguage();
@@ -27,7 +17,7 @@ export function KeyboardShortcutHandlers(): React.ReactNode {
   React.useEffect(() => {
     function onKeyPress(event: KeyboardEvent) {
       switch (event.key) {
-        case 'L': {
+        case Keybinding.SWITCH_LANGUAGE: {
           const currentLanguageIndex = availableLanguages.findIndex(
             (l) => l === currentLanguageCode
           );
@@ -37,25 +27,22 @@ export function KeyboardShortcutHandlers(): React.ReactNode {
           setLanguage(availableLanguages[nextIndex]);
           break;
         }
-        case ACCESSIBILITY_KEYBINDINGS.TOGGLE_AUDIO:
+        case Keybinding.TOGGLE_AUDIO:
           audioControls.toggleEnabled();
           break;
-        case ACCESSIBILITY_KEYBINDINGS.REPLAY:
-          audioControls.replay();
-          break;
-        case ACCESSIBILITY_KEYBINDINGS.DECREASE_PLAYBACK_RATE:
+        case Keybinding.PLAYBACK_RATE_DOWN:
           audioControls.decreasePlaybackRate();
           break;
-        case ACCESSIBILITY_KEYBINDINGS.INCREASE_PLAYBACK_RATE:
+        case Keybinding.PLAYBACK_RATE_UP:
           audioControls.increasePlaybackRate();
           break;
-        case ACCESSIBILITY_KEYBINDINGS.TOGGLE_PAUSE:
+        case Keybinding.TOGGLE_PAUSE:
           audioControls.togglePause();
           break;
-        case ACCESSIBILITY_KEYBINDINGS.DECREASE_VOLUME:
+        case Keybinding.VOLUME_DOWN:
           audioControls.decreaseVolume();
           break;
-        case ACCESSIBILITY_KEYBINDINGS.INCREASE_VOLUME:
+        case Keybinding.VOLUME_UP:
           audioControls.increaseVolume();
           break;
         default:


### PR DESCRIPTION
## Overview

Related to: https://github.com/votingworks/vxsuite/issues/4623

Moving navigation, language, and audio keybindings to a shared location in libs/ui in preparation for use in the BMD accessible controller help flow.

Also fixing a couple controller navigation bugs:
- Focus navigation on the VxMark "Review" screen was previously broken - this fixes the query selectors used to find focusable elements.
- Previously, voters could accidentally navigate to a different contest while an overvote modal or write-in modal was active - this fixes the page navigation logic to no-op when a modal is active.

## Demo Video or Screenshot
Also includes updates to the `MarkScanControllerIllustration` to use theme-aware styling for the interactive states - prototype of the help flow here:
https://drive.google.com/file/d/1nsAstb3RIabvBU6FgqhFOr2pH-Y4h1-K/view?usp=drive_link

## Testing Plan
- New tests for accessible navigation functions, updated relevant existing tests.

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
