### PR TITLE
[fix/4691] [VxMarkScan] Disable query caching for scan interpretations

### DIFF
--- a/apps/mark-scan/frontend/src/api.ts
+++ b/apps/mark-scan/frontend/src/api.ts
@@ -102,7 +102,11 @@ export const getInterpretation = {
   },
   useQuery() {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () => apiClient.getInterpretation());
+    return useQuery(this.queryKey(), () => apiClient.getInterpretation(), {
+      // Avoid caching interpretation results to avoid any potential flicker
+      // between re-renders on interpretation results:
+      cacheTime: 0,
+    });
   },
 } as const;
 


### PR DESCRIPTION
## Overview

Fixes https://github.com/votingworks/vxsuite/issues/4691

Disabling the react-query cache for the `getInterpretation` API call, to avoid UI flicker when rendering the `ValidateBallotPage`. This will ensure that we're always loading fresh data when re-rendering the page. We were already invalidating the cache for that call whenever the ballot got accepted or rejected, but since that happens in the same component that fetches the interpretation data, it was getting re-fetched and cached again immediately.

## Testing Plan
- Repro'd locally and verified the change prevents the flicker

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
