### PR TITLE
[MarkScan] Add the accessible controller help flow

### DIFF
--- a/apps/mark-scan/frontend/src/lib/assistive_technology.test.tsx
+++ b/apps/mark-scan/frontend/src/lib/assistive_technology.test.tsx
@@ -2,7 +2,7 @@ import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 import { electionGeneralDefinition } from '@votingworks/fixtures';
 import userEvent from '@testing-library/user-event';
 import { mockOf } from '@votingworks/test-utils';
-import { Keybinding } from '@votingworks/ui';
+import { Keybinding, simulateKeyPress } from '@votingworks/ui';
 import { render, screen, waitFor } from '../../test/react_testing_library';
 
 import { App } from '../app';
@@ -21,15 +21,6 @@ let apiMock: ApiMock;
 
 function getActiveElement() {
   return document.activeElement;
-}
-
-function simulateKeyPress(key: string) {
-  if (key.length === 1) {
-    userEvent.keyboard(key);
-    return;
-  }
-
-  userEvent.keyboard(`[${key}]`);
 }
 
 beforeEach(() => {

--- a/apps/mark-scan/frontend/src/voter_flow.test.tsx
+++ b/apps/mark-scan/frontend/src/voter_flow.test.tsx
@@ -1,0 +1,69 @@
+import { mockOf } from '@votingworks/test-utils';
+import { MarkScanControllerSandbox } from '@votingworks/ui';
+import React from 'react';
+import { electionGeneralDefinition } from '@votingworks/fixtures';
+import { act, render, screen } from '../test/react_testing_library';
+import { VoterFlow } from './voter_flow';
+import { fakeMachineConfig } from '../test/helpers/fake_machine_config';
+import { Ballot } from './components/ballot';
+
+let setMockControllerHelpTriggered:
+  | ((shouldShowHelp: boolean) => void)
+  | undefined;
+
+jest.mock('@votingworks/ui', (): typeof import('@votingworks/ui') => ({
+  ...jest.requireActual('@votingworks/ui'),
+
+  MarkScanControllerSandbox: jest.fn(),
+
+  useAccessibleControllerHelpTrigger: () => {
+    const [shouldShowControllerSandbox, setShouldShowControllerSandbox] =
+      React.useState(false);
+    setMockControllerHelpTriggered = setShouldShowControllerSandbox;
+
+    return { shouldShowControllerSandbox };
+  },
+}));
+
+jest.mock('./components/ballot', (): typeof import('./components/ballot') => ({
+  ...jest.requireActual('./components/ballot'),
+  Ballot: jest.fn(),
+}));
+
+jest.mock('./api', (): typeof import('./api') => ({
+  ...jest.requireActual('./api'),
+  confirmSessionEnd: { useMutation: jest.fn() },
+}));
+
+test('replaces screen with accessible controller sandbox when triggered', () => {
+  mockOf(Ballot).mockReturnValue(<div data-testid="mockBallotScreen" />);
+  mockOf(MarkScanControllerSandbox).mockReturnValue(
+    <div data-testid="mockControllerSandbox" />
+  );
+
+  const electionDefinition = electionGeneralDefinition;
+  const { contests } = electionDefinition.election;
+
+  render(
+    <VoterFlow
+      {...{
+        contests,
+        electionDefinition,
+        endVoterSession: jest.fn(),
+        isLiveMode: true,
+        machineConfig: fakeMachineConfig(),
+        resetBallot: jest.fn(),
+        stateMachineState: 'waiting_for_ballot_data',
+        updateVote: jest.fn(),
+        votes: {},
+      }}
+    />
+  );
+
+  screen.getByTestId('mockBallotScreen');
+  expect(screen.queryByTestId('mockControllerSandbox')).not.toBeInTheDocument();
+
+  act(() => setMockControllerHelpTriggered!(true));
+  screen.getByTestId('mockControllerSandbox');
+  expect(screen.queryByTestId('mockBallotScreen')).not.toBeInTheDocument();
+});

--- a/apps/mark-scan/frontend/src/voter_flow.tsx
+++ b/apps/mark-scan/frontend/src/voter_flow.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import {
+  CastBallotPage,
+  ContestsWithMsEitherNeither,
+  MachineConfig,
+  UpdateVoteFunction,
+} from '@votingworks/mark-flow-ui';
+import { randomBallotId } from '@votingworks/utils';
+import {
+  BallotStyleId,
+  ElectionDefinition,
+  PrecinctId,
+  VotesDict,
+} from '@votingworks/types';
+import type { SimpleServerStatus } from '@votingworks/mark-scan-backend';
+import {
+  MarkScanControllerSandbox,
+  useAccessibleControllerHelpTrigger,
+} from '@votingworks/ui';
+import { Ballot } from './components/ballot';
+import { ValidateBallotPage } from './pages/validate_ballot_page';
+import { BallotContext } from './contexts/ballot_context';
+import { confirmSessionEnd } from './api';
+
+export interface VoterFlowProps {
+  contests: ContestsWithMsEitherNeither;
+  electionDefinition: ElectionDefinition;
+  machineConfig: MachineConfig;
+  precinctId?: PrecinctId;
+  ballotStyleId?: BallotStyleId;
+  isLiveMode: boolean;
+  updateVote: UpdateVoteFunction;
+  resetBallot: (showPostVotingInstructions?: boolean) => void;
+  endVoterSession: () => Promise<void>;
+  stateMachineState: SimpleServerStatus;
+  votes: VotesDict;
+}
+
+export function VoterFlow(props: VoterFlowProps): React.ReactNode {
+  const { resetBallot, stateMachineState, ...rest } = props;
+
+  const confirmSessionEndMutation = confirmSessionEnd.useMutation();
+
+  const { shouldShowControllerSandbox } = useAccessibleControllerHelpTrigger();
+  if (shouldShowControllerSandbox) {
+    return <MarkScanControllerSandbox />;
+  }
+
+  let ballotContextProviderChild = <Ballot />;
+
+  // Pages that condition on state machine state aren't nested under Ballot because Ballot uses
+  // frontend browser routing for flow control and is completely independent of the state machine.
+  // We still want to nest some pages that condition on the state machine under BallotContext so we render them here.
+  if (stateMachineState === 'presenting_ballot') {
+    ballotContextProviderChild = <ValidateBallotPage />;
+  }
+
+  if (stateMachineState === 'ballot_removed_during_presentation') {
+    return (
+      <CastBallotPage
+        hidePostVotingInstructions={() => {
+          resetBallot();
+          confirmSessionEndMutation.mutate();
+        }}
+        printingCompleted
+      />
+    );
+  }
+
+  return (
+    <BallotContext.Provider
+      value={{
+        ...rest,
+        generateBallotId: randomBallotId,
+        isCardlessVoter: true,
+        resetBallot,
+      }}
+    >
+      {ballotContextProviderChild}
+    </BallotContext.Provider>
+  );
+}

--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -116,6 +116,8 @@ export = {
           'src/setupTests.tsx',
           '**/*.stories.ts',
           '**/*.stories.tsx',
+          '**/test_utils.ts',
+          '**/test_utils.tsx',
           '**/*.bench.ts',
         ],
       },

--- a/libs/test-utils/src/fake_use_audio_controls.ts
+++ b/libs/test-utils/src/fake_use_audio_controls.ts
@@ -8,6 +8,7 @@ export function fakeUseAudioControls(): jest.Mocked<AudioControls> {
     increaseVolume: jest.fn(),
     reset: jest.fn(),
     replay: jest.fn(),
+    setControlsEnabled: jest.fn(),
     setIsEnabled: jest.fn(),
     toggleEnabled: jest.fn(),
     togglePause: jest.fn(),

--- a/libs/types/src/ui_audio_controls.ts
+++ b/libs/types/src/ui_audio_controls.ts
@@ -5,6 +5,7 @@ export interface AudioControls {
   increaseVolume: () => void;
   replay: () => void;
   reset: () => void;
+  setControlsEnabled: (enabled: boolean) => void;
   setIsEnabled: (enabled: boolean) => void;
   toggleEnabled: () => void;
   togglePause: () => void;

--- a/libs/ui/src/accessible_controllers/accessible_controller_sandbox.test.tsx
+++ b/libs/ui/src/accessible_controllers/accessible_controller_sandbox.test.tsx
@@ -1,0 +1,156 @@
+import {
+  advanceTimers,
+  fakeUseAudioControls,
+  mockOf,
+} from '@votingworks/test-utils';
+import React from 'react';
+import { assert } from '@votingworks/basics';
+import userEvent from '@testing-library/user-event';
+import { UiString } from '../ui_strings/ui_string';
+import {
+  AccessibleControllerHelpStrings,
+  AccessibleControllerIllustrationProps,
+  AccessibleControllerSandbox,
+} from './accessible_controller_sandbox';
+import { act, screen } from '../../test/react_testing_library';
+import { Keybinding } from '../keybindings';
+import { newTestContext } from '../../test/test_context';
+
+const mockAudioControls = fakeUseAudioControls();
+
+jest.mock(
+  '../ui_strings/ui_string',
+  (): typeof import('../ui_strings/ui_string') => ({
+    ...jest.requireActual('../ui_strings/ui_string'),
+    UiString: jest.fn(),
+  })
+);
+
+jest.mock(
+  '../hooks/use_audio_controls',
+  (): typeof import('../hooks/use_audio_controls') => ({
+    ...jest.requireActual('../hooks/use_audio_controls'),
+    useAudioControls: () => mockAudioControls,
+  })
+);
+
+function newRenderer() {
+  let lastReadElement: HTMLElement;
+
+  const mockOnClick = jest.fn().mockImplementation((event: MouseEvent) => {
+    assert(event.target instanceof HTMLElement);
+    lastReadElement = event.target;
+  });
+
+  const { render } = newTestContext();
+
+  function renderWithMockScreenReader(ui: React.ReactNode) {
+    return render(<div onClickCapture={mockOnClick}>{ui}</div>);
+  }
+
+  return {
+    expectLastMockScreenReaderContent: (textContent: string) =>
+      expect(lastReadElement).toHaveTextContent(textContent),
+    renderWithMockScreenReader,
+  };
+}
+
+function simulateKeyPress(key: string) {
+  userEvent.keyboard(key.length === 1 ? key : `[${key}]`);
+  advanceTimers();
+}
+
+type MockIllustrationButton = Keybinding.PAGE_NEXT | Keybinding.PAGE_PREVIOUS;
+type MockIllustrationProps =
+  AccessibleControllerIllustrationProps<MockIllustrationButton>;
+
+function MockIllustration(props: MockIllustrationProps) {
+  const { highlight } = props;
+  return <div>MockIllustration - highlight:{highlight}</div>;
+}
+
+function expectMockIllustrationProps(highlight?: MockIllustrationButton) {
+  screen.getByText(`MockIllustration - highlight:${highlight || ''}`);
+}
+
+beforeAll(() => {
+  jest.useFakeTimers();
+});
+
+test('provides audio feedback for all relevant buttons', async () => {
+  mockOf(UiString).mockImplementation((p) => <span>{p.uiStringKey}</span>);
+
+  const { expectLastMockScreenReaderContent, renderWithMockScreenReader } =
+    newRenderer();
+
+  const helpStrings: AccessibleControllerHelpStrings<MockIllustrationButton> = {
+    [Keybinding.PAGE_NEXT]: 'helpBmdControllerButtonPageNext',
+    [Keybinding.PAGE_PREVIOUS]: 'helpBmdControllerButtonPagePrevious',
+  };
+
+  renderWithMockScreenReader(
+    <AccessibleControllerSandbox
+      feedbackStringKeys={helpStrings}
+      illustration={MockIllustration}
+      introAudioStringKey="instructionsBmdControllerSandboxMarkScan"
+    />
+  );
+
+  await screen.findByRole('heading', { name: /controller help/i });
+
+  expectLastMockScreenReaderContent('instructionsBmdControllerSandboxMarkScan');
+  expectMockIllustrationProps(undefined);
+
+  act(() => simulateKeyPress(Keybinding.PAGE_NEXT));
+  expectLastMockScreenReaderContent('helpBmdControllerButtonPageNext');
+  expectMockIllustrationProps(Keybinding.PAGE_NEXT);
+
+  act(() => simulateKeyPress(Keybinding.PAGE_PREVIOUS));
+  expectLastMockScreenReaderContent('helpBmdControllerButtonPagePrevious');
+  expectMockIllustrationProps(Keybinding.PAGE_PREVIOUS);
+
+  // Expect no screen reader events for unconfigured keybindings:
+  act(() => simulateKeyPress(Keybinding.FOCUS_NEXT));
+  act(() => simulateKeyPress(Keybinding.SELECT));
+  expectLastMockScreenReaderContent('helpBmdControllerButtonPagePrevious');
+  expectMockIllustrationProps(undefined);
+});
+
+test('force-enables audio and disables audio controls while active', async () => {
+  mockOf(UiString).mockImplementation((p) => <span>{p.uiStringKey}</span>);
+
+  const helpStrings: AccessibleControllerHelpStrings<MockIllustrationButton> = {
+    [Keybinding.PAGE_NEXT]: 'helpBmdControllerButtonPageNext',
+    [Keybinding.PAGE_PREVIOUS]: 'helpBmdControllerButtonPagePrevious',
+  };
+
+  const { render } = newTestContext();
+  const { rerender } = render(<div>Regular Voter Screen</div>);
+
+  await screen.findByText('Regular Voter Screen');
+  expect(mockAudioControls.setControlsEnabled).not.toHaveBeenCalled();
+  expect(mockAudioControls.setIsEnabled).not.toHaveBeenCalled();
+
+  rerender(
+    <AccessibleControllerSandbox
+      feedbackStringKeys={helpStrings}
+      illustration={MockIllustration}
+      introAudioStringKey="instructionsBmdControllerSandboxMarkScan"
+    />
+  );
+
+  await screen.findByRole('heading', { name: /controller help/i });
+  expect(mockAudioControls.setControlsEnabled).toHaveBeenLastCalledWith(false);
+  expect(mockAudioControls.setIsEnabled).toHaveBeenLastCalledWith(true);
+
+  // Reset audio control mocks so we can verify there are no further calls to
+  // `setIsEnabled`:
+  mockAudioControls.setIsEnabled.mockReset();
+  mockAudioControls.setControlsEnabled.mockReset();
+
+  rerender(<div>Regular Voter Screen</div>);
+
+  await screen.findByText('Regular Voter Screen');
+  expect(mockAudioControls.setControlsEnabled).toHaveBeenLastCalledWith(true);
+  expect(mockAudioControls.setIsEnabled).not.toHaveBeenCalled();
+});

--- a/libs/ui/src/accessible_controllers/accessible_controller_sandbox.test.tsx
+++ b/libs/ui/src/accessible_controllers/accessible_controller_sandbox.test.tsx
@@ -5,7 +5,7 @@ import {
 } from '@votingworks/test-utils';
 import React from 'react';
 import { assert } from '@votingworks/basics';
-import userEvent from '@testing-library/user-event';
+import { simulateKeyPress as baseSimulateKeyPress } from './test_utils';
 import { UiString } from '../ui_strings/ui_string';
 import {
   AccessibleControllerHelpStrings,
@@ -56,7 +56,7 @@ function newRenderer() {
 }
 
 function simulateKeyPress(key: string) {
-  userEvent.keyboard(key.length === 1 ? key : `[${key}]`);
+  baseSimulateKeyPress(key);
   advanceTimers();
 }
 

--- a/libs/ui/src/accessible_controllers/accessible_controller_sandbox.tsx
+++ b/libs/ui/src/accessible_controllers/accessible_controller_sandbox.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+
+import { AppStringKey, AudioOnly, ReadOnLoad, appStrings } from '../ui_strings';
+import { Keybinding } from '../keybindings';
+import { Screen } from '../screen';
+import { Main } from '../main';
+import { useAudioControls } from '../hooks/use_audio_controls';
+import { H1 } from '../typography';
+
+export type AccessibleControllerType = 'mark' | 'markScan';
+
+export interface AccessibleControllerIllustrationProps<T extends Keybinding> {
+  highlight?: T;
+}
+
+export type AccessibleControllerHelpStrings<T extends Keybinding> = Readonly<
+  Record<T, AppStringKey | null>
+>;
+
+export interface AccessibleControllerSandboxProps<T extends Keybinding> {
+  feedbackStringKeys: AccessibleControllerHelpStrings<T>;
+  illustration: (
+    props: AccessibleControllerIllustrationProps<T>
+  ) => JSX.Element;
+  introAudioStringKey: AppStringKey;
+}
+
+export function AccessibleControllerSandbox<T extends Keybinding>(
+  props: AccessibleControllerSandboxProps<T>
+): JSX.Element {
+  const { feedbackStringKeys, illustration, introAudioStringKey } = props;
+
+  const [pressedKey, setPressedKey] = React.useState<T>();
+  const [currentAudioStringKey, setCurrentAudioStringKey] =
+    React.useState<AppStringKey>();
+
+  const audioControls = useAudioControls();
+  const setAudioControlsEnabled = audioControls.setControlsEnabled;
+  const setAudioEnabled = audioControls.setIsEnabled;
+
+  React.useEffect(() => {
+    setAudioEnabled(true);
+    setAudioControlsEnabled(false);
+
+    return () => setAudioControlsEnabled(true);
+  }, [setAudioControlsEnabled, setAudioEnabled]);
+
+  React.useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      setPressedKey(undefined);
+      setCurrentAudioStringKey(undefined);
+
+      const key = event.key as T;
+      const audioStringKey = feedbackStringKeys[key];
+      if (!audioStringKey) {
+        return;
+      }
+
+      // Waiting to update the audio string key in the next tick allows the
+      // previous state to get cleared and for the screen reader to stop before
+      // triggering new audio. This enables repeated audio feedback on the
+      // repeated pressed of the same button.
+      window.setTimeout(() => {
+        setPressedKey(key);
+        setCurrentAudioStringKey(audioStringKey);
+      });
+    }
+
+    document.addEventListener('keydown', onKeyDown);
+
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [feedbackStringKeys]);
+
+  const Illustration = illustration;
+
+  return (
+    <Screen>
+      <Main centerChild padded>
+        <H1>Controller Help</H1>
+        <ReadOnLoad>
+          <AudioOnly>{appStrings[introAudioStringKey]()}</AudioOnly>
+        </ReadOnLoad>
+        <Illustration highlight={pressedKey} />
+        {currentAudioStringKey && (
+          <ReadOnLoad key={currentAudioStringKey}>
+            <AudioOnly>{appStrings[currentAudioStringKey]()}</AudioOnly>
+          </ReadOnLoad>
+        )}
+      </Main>
+    </Screen>
+  );
+}

--- a/libs/ui/src/accessible_controllers/accessible_controller_sandbox.tsx
+++ b/libs/ui/src/accessible_controllers/accessible_controller_sandbox.tsx
@@ -58,8 +58,8 @@ export function AccessibleControllerSandbox<T extends Keybinding>(
 
       // Waiting to update the audio string key in the next tick allows the
       // previous state to get cleared and for the screen reader to stop before
-      // triggering new audio. This enables repeated audio feedback on the
-      // repeated pressed of the same button.
+      // triggering new audio. This enables repeated audio feedback on repeated
+      // presses of the same button.
       window.setTimeout(() => {
         setPressedKey(key);
         setCurrentAudioStringKey(audioStringKey);

--- a/libs/ui/src/accessible_controllers/index.ts
+++ b/libs/ui/src/accessible_controllers/index.ts
@@ -3,5 +3,6 @@ export * from './mark_controller_illustration';
 export * from './mark_scan_controller_illustration';
 export * from './mark_scan_controller_sandbox';
 export * from './navigation';
+export * from './test_utils';
 export * from './types';
 export * from './use_accessible_controller_help_trigger';

--- a/libs/ui/src/accessible_controllers/index.ts
+++ b/libs/ui/src/accessible_controllers/index.ts
@@ -4,3 +4,4 @@ export * from './mark_scan_controller_illustration';
 export * from './mark_scan_controller_sandbox';
 export * from './navigation';
 export * from './types';
+export * from './use_accessible_controller_help_trigger';

--- a/libs/ui/src/accessible_controllers/index.ts
+++ b/libs/ui/src/accessible_controllers/index.ts
@@ -1,4 +1,6 @@
+export * from './accessible_controller_sandbox';
 export * from './mark_controller_illustration';
 export * from './mark_scan_controller_illustration';
+export * from './mark_scan_controller_sandbox';
 export * from './navigation';
 export * from './types';

--- a/libs/ui/src/accessible_controllers/mark_scan_controller_sandbox.test.tsx
+++ b/libs/ui/src/accessible_controllers/mark_scan_controller_sandbox.test.tsx
@@ -1,0 +1,47 @@
+import { mockOf } from '@votingworks/test-utils';
+import { MarkScanControllerSandbox } from './mark_scan_controller_sandbox';
+import { render, screen } from '../../test/react_testing_library';
+import { AccessibleControllerSandbox } from './accessible_controller_sandbox';
+import {
+  MARK_SCAN_CONTROLLER_KEYBINDINGS,
+  MarkScanControllerButton,
+} from './types';
+import { Keybinding } from '../keybindings';
+import { MARK_SCAN_CONTROLLER_ILLUSTRATION_HIGHLIGHT_CLASS_NAME } from '.';
+
+jest.mock(
+  './accessible_controller_sandbox',
+  (): typeof import('./accessible_controller_sandbox') => ({
+    ...jest.requireActual('./accessible_controller_sandbox'),
+    AccessibleControllerSandbox: jest.fn(),
+  })
+);
+
+test('all relevant buttons configured', () => {
+  mockOf(AccessibleControllerSandbox).mockImplementation((props) => {
+    const { feedbackStringKeys } = props;
+
+    expect(Object.keys(feedbackStringKeys).sort()).toEqual<
+      MarkScanControllerButton[]
+    >([...MARK_SCAN_CONTROLLER_KEYBINDINGS].sort());
+
+    return <div />;
+  });
+
+  render(<MarkScanControllerSandbox />);
+});
+
+test('highlights relevant portion of illustration', () => {
+  mockOf(AccessibleControllerSandbox).mockImplementation((props) => {
+    const { illustration } = props;
+    const Illustration = illustration;
+
+    return <Illustration highlight={Keybinding.TOGGLE_PAUSE} />;
+  });
+
+  render(<MarkScanControllerSandbox />);
+
+  expect(screen.getByTestId('pause')).toHaveClass(
+    MARK_SCAN_CONTROLLER_ILLUSTRATION_HIGHLIGHT_CLASS_NAME
+  );
+});

--- a/libs/ui/src/accessible_controllers/mark_scan_controller_sandbox.tsx
+++ b/libs/ui/src/accessible_controllers/mark_scan_controller_sandbox.tsx
@@ -1,0 +1,32 @@
+import { MarkScanControllerButton } from './types';
+import {
+  AccessibleControllerHelpStrings,
+  AccessibleControllerSandbox,
+} from './accessible_controller_sandbox';
+import { MarkScanControllerIllustration } from './mark_scan_controller_illustration';
+import { Keybinding } from '../keybindings';
+
+const FEEDBACK_STRING_KEYS: AccessibleControllerHelpStrings<MarkScanControllerButton> =
+  {
+    [Keybinding.FOCUS_NEXT]: 'helpBmdControllerButtonFocusNext',
+    [Keybinding.FOCUS_PREVIOUS]: 'helpBmdControllerButtonFocusPrevious',
+    [Keybinding.PAGE_NEXT]: 'helpBmdControllerButtonPageNext',
+    [Keybinding.PAGE_PREVIOUS]: 'helpBmdControllerButtonPagePrevious',
+    [Keybinding.PLAYBACK_RATE_DOWN]: 'helpBmdControllerButtonPlaybackRateDown',
+    [Keybinding.PLAYBACK_RATE_UP]: 'helpBmdControllerButtonPlaybackRateUp',
+    [Keybinding.SELECT]: 'helpBmdControllerButtonSelect',
+    [Keybinding.TOGGLE_HELP]: 'helpBmdControllerButtonToggleHelp',
+    [Keybinding.TOGGLE_PAUSE]: 'helpBmdControllerButtonTogglePause',
+    [Keybinding.VOLUME_DOWN]: 'helpBmdControllerButtonVolumeDown',
+    [Keybinding.VOLUME_UP]: 'helpBmdControllerButtonVolumeUp',
+  };
+
+export function MarkScanControllerSandbox(): JSX.Element {
+  return (
+    <AccessibleControllerSandbox
+      feedbackStringKeys={FEEDBACK_STRING_KEYS}
+      illustration={MarkScanControllerIllustration}
+      introAudioStringKey="instructionsBmdControllerSandboxMarkScan"
+    />
+  );
+}

--- a/libs/ui/src/accessible_controllers/test_utils.tsx
+++ b/libs/ui/src/accessible_controllers/test_utils.tsx
@@ -1,0 +1,5 @@
+import userEvent from '@testing-library/user-event';
+
+export function simulateKeyPress(key: string): void {
+  userEvent.keyboard(key.length === 1 ? key : `[${key}]`);
+}

--- a/libs/ui/src/accessible_controllers/use_accessible_controller_help_trigger.test.tsx
+++ b/libs/ui/src/accessible_controllers/use_accessible_controller_help_trigger.test.tsx
@@ -1,11 +1,6 @@
 import { renderHook } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { useAccessibleControllerHelpTrigger } from '.';
+import { simulateKeyPress, useAccessibleControllerHelpTrigger } from '.';
 import { KEYBINDINGS, Keybinding } from '../keybindings';
-
-function simulateKeyPress(key: string) {
-  userEvent.keyboard(key.length === 1 ? key : `[${key}]`);
-}
 
 test('toggles "off" to "on" for single keypress', () => {
   const { result } = renderHook(useAccessibleControllerHelpTrigger);

--- a/libs/ui/src/accessible_controllers/use_accessible_controller_help_trigger.test.tsx
+++ b/libs/ui/src/accessible_controllers/use_accessible_controller_help_trigger.test.tsx
@@ -1,0 +1,47 @@
+import { renderHook } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useAccessibleControllerHelpTrigger } from '.';
+import { KEYBINDINGS, Keybinding } from '../keybindings';
+
+function simulateKeyPress(key: string) {
+  userEvent.keyboard(key.length === 1 ? key : `[${key}]`);
+}
+
+test('toggles "off" to "on" for single keypress', () => {
+  const { result } = renderHook(useAccessibleControllerHelpTrigger);
+
+  expect(result.current.shouldShowControllerSandbox).toEqual(false);
+
+  for (const keybinding of KEYBINDINGS) {
+    if (keybinding !== Keybinding.TOGGLE_HELP) {
+      simulateKeyPress(keybinding);
+      expect(result.current.shouldShowControllerSandbox).toEqual(false);
+    }
+  }
+
+  simulateKeyPress(Keybinding.TOGGLE_HELP);
+  expect(result.current.shouldShowControllerSandbox).toEqual(true);
+});
+
+test('toggles "on" to "off" for two consecutive keypresses', () => {
+  const { result } = renderHook(useAccessibleControllerHelpTrigger);
+
+  simulateKeyPress(Keybinding.TOGGLE_HELP);
+  expect(result.current.shouldShowControllerSandbox).toEqual(true);
+
+  simulateKeyPress(Keybinding.TOGGLE_HELP);
+  simulateKeyPress(Keybinding.TOGGLE_HELP);
+  expect(result.current.shouldShowControllerSandbox).toEqual(false);
+});
+
+test('is no-op for non-consecutive keypresses while "on"', () => {
+  const { result } = renderHook(useAccessibleControllerHelpTrigger);
+
+  simulateKeyPress(Keybinding.TOGGLE_HELP);
+  expect(result.current.shouldShowControllerSandbox).toEqual(true);
+
+  simulateKeyPress(Keybinding.TOGGLE_HELP);
+  simulateKeyPress(Keybinding.SELECT);
+  simulateKeyPress(Keybinding.TOGGLE_HELP);
+  expect(result.current.shouldShowControllerSandbox).toEqual(true);
+});

--- a/libs/ui/src/accessible_controllers/use_accessible_controller_help_trigger.tsx
+++ b/libs/ui/src/accessible_controllers/use_accessible_controller_help_trigger.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Keybinding } from '../keybindings';
+
+export interface UseAccessibleControllerHelpTriggerResult {
+  shouldShowControllerSandbox: boolean;
+}
+
+export function useAccessibleControllerHelpTrigger(): UseAccessibleControllerHelpTriggerResult {
+  const [shouldShowHelp, setShouldShowHelp] = React.useState(false);
+  const [lastKeyPress, setLastKeyPress] = React.useState<string>();
+
+  // Toggles `shouldShowHelp` from `false` to `true` on a single
+  // `Keybinding.TOGGLE_HELP` event and toggles `true`` to `false` only after
+  // two consecutive `Keybinding.TOGGLE_HELP` events.
+  React.useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      const helpKeyPressed = event.key === Keybinding.TOGGLE_HELP;
+      const isSecondConsecutiveHelpKeyPress =
+        helpKeyPressed && lastKeyPress === Keybinding.TOGGLE_HELP;
+
+      const isSandboxActive = shouldShowHelp;
+      const shouldToggle =
+        (!isSandboxActive && helpKeyPressed) || isSecondConsecutiveHelpKeyPress;
+
+      if (shouldToggle) {
+        setShouldShowHelp(!isSandboxActive);
+        setLastKeyPress(undefined);
+        return;
+      }
+
+      setLastKeyPress(event.key);
+    }
+
+    document.addEventListener('keydown', onKeyDown);
+
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [lastKeyPress, shouldShowHelp]);
+
+  return { shouldShowControllerSandbox: shouldShowHelp };
+}

--- a/libs/ui/src/accessible_controllers/use_accessible_controller_help_trigger.tsx
+++ b/libs/ui/src/accessible_controllers/use_accessible_controller_help_trigger.tsx
@@ -10,7 +10,7 @@ export function useAccessibleControllerHelpTrigger(): UseAccessibleControllerHel
   const [lastKeyPress, setLastKeyPress] = React.useState<string>();
 
   // Toggles `shouldShowHelp` from `false` to `true` on a single
-  // `Keybinding.TOGGLE_HELP` event and toggles `true`` to `false` only after
+  // `Keybinding.TOGGLE_HELP` event and toggles `true` to `false` only after
   // two consecutive `Keybinding.TOGGLE_HELP` events.
   React.useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {

--- a/libs/ui/src/hooks/use_audio_controls.test.tsx
+++ b/libs/ui/src/hooks/use_audio_controls.test.tsx
@@ -17,6 +17,7 @@ test('returns external-facing audio context API', () => {
     decreasePlaybackRate: jest.fn(),
     increasePlaybackRate: jest.fn(),
     reset: jest.fn(),
+    setControlsEnabled: jest.fn(),
     setIsEnabled: jest.fn(),
     toggleEnabled: jest.fn(),
     togglePause: jest.fn(),

--- a/libs/ui/src/hooks/use_audio_controls.ts
+++ b/libs/ui/src/hooks/use_audio_controls.ts
@@ -21,6 +21,7 @@ export function useAudioControls(): AudioControls {
     increaseVolume: screenReaderContext?.increaseVolume || noOp,
     reset: audioContext?.reset || noOp,
     replay: screenReaderContext?.replay || noOp,
+    setControlsEnabled: audioContext?.setControlsEnabled || noOp,
     setIsEnabled: audioContext?.setIsEnabled || noOp,
     toggleEnabled: audioContext?.toggleEnabled || noOp,
     togglePause: audioContext?.togglePause || noOp,

--- a/libs/ui/src/keybindings.ts
+++ b/libs/ui/src/keybindings.ts
@@ -23,3 +23,7 @@ export enum Keybinding {
   PAT_MOVE = '1',
   PAT_SELECT = '2',
 }
+
+export const KEYBINDINGS: readonly Keybinding[] = Object.values(
+  Keybinding
+).filter((k) => typeof k === 'string');

--- a/libs/ui/src/ui_strings/audio_context.test.tsx
+++ b/libs/ui/src/ui_strings/audio_context.test.tsx
@@ -242,3 +242,30 @@ test('reset', () => {
   expect(result.current?.playbackRate).toEqual(DEFAULT_PLAYBACK_RATE);
   expect(result.current?.isPaused).toEqual(false);
 });
+
+test('setControlsEnabled', () => {
+  const { result } = renderHook(useAudioContext, {
+    wrapper: TestContextWrapper,
+  });
+
+  act(() => result.current?.setControlsEnabled(false));
+
+  //
+  // These should all be no-ops when controls are disabled:
+  //
+
+  act(() => result.current?.setIsEnabled(true));
+  expect(result.current?.isEnabled).toEqual(DEFAULT_AUDIO_ENABLED_STATE);
+
+  act(() => result.current?.increasePlaybackRate());
+  expect(result.current?.playbackRate).toEqual(DEFAULT_PLAYBACK_RATE);
+
+  act(() => result.current?.decreasePlaybackRate());
+  expect(result.current?.playbackRate).toEqual(DEFAULT_PLAYBACK_RATE);
+
+  act(() => result.current?.setVolume(AudioVolume.MINIMUM));
+  expect(result.current?.volume).toEqual(DEFAULT_AUDIO_VOLUME);
+
+  act(() => result.current?.setIsPaused(true));
+  expect(result.current?.isPaused).toEqual(false);
+});

--- a/libs/ui/src/ui_strings/audio_context.tsx
+++ b/libs/ui/src/ui_strings/audio_context.tsx
@@ -13,6 +13,8 @@ import { AudioVolume, DEFAULT_AUDIO_VOLUME } from './audio_volume';
 
 export const DEFAULT_AUDIO_ENABLED_STATE = true;
 
+function noOp() {}
+
 export interface UiStringsAudioContextInterface {
   api: UiStringsReactQueryApi;
   decreasePlaybackRate: () => void;
@@ -21,6 +23,7 @@ export interface UiStringsAudioContextInterface {
   isPaused: boolean;
   playbackRate: number;
   reset: () => void;
+  setControlsEnabled: (enabled: boolean) => void;
   setIsEnabled: (enabled: boolean) => void;
   setIsPaused: (paused: boolean) => void;
   setVolume: (volume: AudioVolume) => void;
@@ -60,6 +63,7 @@ export function UiStringsAudioContextProvider(
 ): JSX.Element {
   const { api, children } = props;
   const [isEnabled, setIsEnabled] = React.useState(DEFAULT_AUDIO_ENABLED_STATE);
+  const [controlsEnabled, setControlsEnabled] = React.useState(true);
   const [isPaused, setIsPaused] = React.useState(true);
   const [playbackRate, setPlaybackRate] = React.useState<number>(
     DEFAULT_PLAYBACK_RATE
@@ -77,6 +81,7 @@ export function UiStringsAudioContextProvider(
   const reset = React.useCallback(() => {
     resetPlaybackSettings();
     setIsEnabled(DEFAULT_AUDIO_ENABLED_STATE);
+    setControlsEnabled(true);
   }, [resetPlaybackSettings]);
 
   React.useEffect(() => {
@@ -129,17 +134,18 @@ export function UiStringsAudioContextProvider(
     <UiStringsAudioContext.Provider
       value={{
         api,
-        decreasePlaybackRate,
-        increasePlaybackRate,
+        decreasePlaybackRate: controlsEnabled ? decreasePlaybackRate : noOp,
+        increasePlaybackRate: controlsEnabled ? increasePlaybackRate : noOp,
         isEnabled,
         isPaused,
         playbackRate,
         reset,
-        setIsEnabled,
-        setIsPaused,
-        setVolume,
-        toggleEnabled,
-        togglePause,
+        setControlsEnabled,
+        setIsEnabled: controlsEnabled ? setIsEnabled : noOp,
+        setIsPaused: controlsEnabled ? setIsPaused : noOp,
+        setVolume: controlsEnabled ? setVolume : noOp,
+        toggleEnabled: controlsEnabled ? toggleEnabled : noOp,
+        togglePause: controlsEnabled ? togglePause : noOp,
         volume,
         webAudioContext: webAudioContextRef.current,
       }}


### PR DESCRIPTION
## Overview

Resolves https://github.com/votingworks/vxsuite/issues/4623

Adding an accessible controller sandbox screen that allows the user to try out the various buttons without triggering the default behaviour - instead, they'll receive audio feedback on what each button does.

The sandbox will be triggered by the "help" button (currently mapped to the old "replay" keybinding, `Shift+R` -- we can clean that up later) and can be exited with another two successive presses on the "help" button (the first press describes the button and tells the voter they can press it again to exit).

## Demo Video or Screenshot [ 🔊 ]

A little long, so recorded with increased speech rate to speed things up a bit:

https://github.com/votingworks/vxsuite/assets/264902/cc3ffc23-c8a5-4d7d-8bad-2cf38cdf0395

## Testing Plan
- New unit tests for the sandbox component and trigger hook
- Broke out a `VoterFlow` component from `app_root` to make testing easier and make it easier to scope the trigger to just voter sessions 

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
