### PR TITLE
VxDesign 3.1: Account for timezone bug in election date input

### DIFF
--- a/apps/design/frontend/src/election_info_screen.test.tsx
+++ b/apps/design/frontend/src/election_info_screen.test.tsx
@@ -2,6 +2,7 @@ import userEvent from '@testing-library/user-event';
 import { Election } from '@votingworks/types';
 import { Buffer } from 'buffer';
 import { createMemoryHistory } from 'history';
+import { assert } from '@votingworks/basics';
 import {
   MockApiClient,
   createMockApiClient,
@@ -97,7 +98,9 @@ test('edit and save election', async () => {
   expect(titleInput).toBeDisabled();
 
   const dateInput = screen.getByLabelText('Date');
-  expect(dateInput).toHaveValue(election.date);
+  // Date input should account for timezone bug
+  assert(election.date === '2020-11-03');
+  expect(dateInput).toHaveValue('2020-11-02');
   expect(dateInput).toBeDisabled();
 
   const typeInput = screen.getByRole('listbox', { name: 'Type' });
@@ -161,7 +164,8 @@ test('edit and save election', async () => {
   const updatedElection: Election = {
     ...election,
     title: 'New Title',
-    date: '2023-09-06',
+    // Date input should account for timezone bug
+    date: '2023-09-07',
     type: 'primary',
     state: 'New State',
     county: {

--- a/apps/design/frontend/src/election_info_screen.tsx
+++ b/apps/design/frontend/src/election_info_screen.tsx
@@ -89,11 +89,26 @@ function ElectionInfoForm({
       <InputGroup label="Date">
         <input
           type="date"
-          value={
-            electionInfo.date &&
-            new Date(electionInfo.date).toISOString().slice(0, 10)
-          }
-          onChange={onInputChange('date')}
+          value={(() => {
+            if (!electionInfo.date) return '';
+            const date = new Date(electionInfo.date);
+            // Subtract one day to account for timezone bug in the rest of VxSuite 3.1
+            date.setDate(date.getDate() - 1);
+            return date.toISOString().split('T')[0];
+          })()}
+          onChange={(e) => {
+            if (!e.target.value) {
+              setElectionInfo({ ...electionInfo, date: '' });
+              return;
+            }
+            const date = new Date(e.target.value);
+            // Add one day to the date to account for timezone bug in the rest of VxSuite 3.1
+            date.setDate(date.getDate() + 1);
+            setElectionInfo({
+              ...electionInfo,
+              date: date.toISOString().split('T')[0],
+            });
+          }}
           disabled={!isEditing}
         />
       </InputGroup>

--- a/apps/design/frontend/src/elections_screen.tsx
+++ b/apps/design/frontend/src/elections_screen.tsx
@@ -97,9 +97,7 @@ export function ElectionsScreen(): JSX.Element | null {
                     <td>{election.title || 'Untitled Election'}</td>
                     <td>
                       {election.date &&
-                        new Date(election.date).toLocaleDateString(undefined, {
-                          timeZone: 'UTC',
-                        })}
+                        new Date(election.date).toLocaleDateString()}
                     </td>
                     <td>{election.county.name}</td>
                     <td>{election.state}</td>


### PR DESCRIPTION


## Overview

Since the rest of VxSuite 3.1 has a timezone bug that displays the election date one day earlier, modify the election date input in VxDesign to automatically set the election date one day later than entered by the user. This means we won't have to remember to manually offset the date by one day moving forward.
## Demo Video or Screenshot
N/A
## Testing Plan
Updated existing automated tests, manually tested and verified the ballots and election definition have the correct dates

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
