### PR TITLE
[MarkScan] Update audio instructions for ValidateBallotPage

### DIFF
--- a/apps/mark-scan/frontend/src/pages/validate_ballot_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/validate_ballot_page.tsx
@@ -9,6 +9,7 @@ import {
   appStrings,
   AudioOnly,
   ReadOnLoad,
+  PageNavigationButtonId,
 } from '@votingworks/ui';
 
 import { assert } from '@votingworks/basics';
@@ -72,13 +73,17 @@ export function ValidateBallotPage(): JSX.Element | null {
       actionButtons={
         <React.Fragment>
           <Button
+            id={PageNavigationButtonId.PREVIOUS}
             variant="danger"
             icon="Danger"
             onPress={invalidateBallotCallback}
           >
             {appStrings.buttonBallotIsIncorrect()}
           </Button>
-          <Button onPress={validateBallotCallback}>
+          <Button
+            id={PageNavigationButtonId.PREVIOUS}
+            onPress={validateBallotCallback}
+          >
             {appStrings.buttonBallotIsCorrect()}
           </Button>
         </React.Fragment>

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -415,13 +415,11 @@ export const appStrings = {
     </UiString>
   ),
 
-  // TODO(kofi): I think these instructions could be improved a bit. Not sure
-  // it's obvious to a vision-impaired voter that they have to navigate down to
-  // the confirm/reject buttons at the bottom of the screen.
   instructionsBmdScanReviewConfirmation: () => (
     <UiString uiStringKey="instructionsBmdScanReviewConfirmation">
-      If your selections are correct, press "My Ballot is Correct”. If there is
-      an error, press "My Ballot is Incorrect” and alert a poll worker.
+      If your selections are correct, press the Right button to confirm your
+      choices and cast your ballot. If there is an error, press the Left button
+      to mark this ballot as incorrect and alert a poll worker.
     </UiString>
   ),
 

--- a/libs/ui/src/ui_strings/app_strings_catalog/latest.json
+++ b/libs/ui/src/ui_strings/app_strings_catalog/latest.json
@@ -76,7 +76,7 @@
   "instructionsBmdPatCalibrationTryOtherInput": "Try the other input.",
   "instructionsBmdReviewPageChangingVotes": "To change your vote in any contest, use the select button to navigate to that contest. When you are finished making your ballot selections and ready to print your ballot, use the right button to print your ballot.",
   "instructionsBmdReviewPageNavigation": "To review your votes, advance through the ballot contests using the up and down buttons.",
-  "instructionsBmdScanReviewConfirmation": "If your selections are correct, press \"My Ballot is Correct”. If there is an error, press \"My Ballot is Incorrect” and alert a poll worker.",
+  "instructionsBmdScanReviewConfirmation": "If your selections are correct, press the Right button to confirm your choices and cast your ballot. If there is an error, press the Left button to mark this ballot as incorrect and alert a poll worker.",
   "instructionsBmdSelectToContinue": "Press the select button to continue.",
   "instructionsBmdWriteInFormNavigation": "Use the up and down buttons to navigate between the letters of a standard keyboard. Use the select button to select the current letter.",
   "instructionsLanguageSettingsScreen": "Use the up and down buttons to navigate through the available ballot languages. To select a language, use the select button. When you're done, use the right button to continue voting.",


### PR DESCRIPTION
## Overview

Related to: https://github.com/votingworks/vxsuite/issues/4743

Updating navigation on the `ValidateBallotPage` in MarkScan for consistency with other voter screens ("right" button to advance and cast the ballot, "left" button to reject the ballot and return) and updating the initial audio instructions to reflect that.

## Testing Plan
- Manual 

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
