### PR TITLE
apps/scan: Remove ultrasonic flag

### DIFF
--- a/apps/scan/backend/schema.sql
+++ b/apps/scan/backend/schema.sql
@@ -12,7 +12,7 @@ create table election (
   ballot_count_when_ballot_bag_last_replaced integer not null default 0,
   has_paper_been_loaded boolean not null default false,
   is_sound_muted boolean not null default false,
-  is_ultrasonic_disabled boolean not null default false,
+  is_multi_sheet_detection_disabled boolean not null default false,
   created_at timestamp not null default current_timestamp
 );
 

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -176,7 +176,7 @@ export function buildApi({
         precinctSelection: store.getPrecinctSelection(),
         isSoundMuted: store.getIsSoundMuted(),
         isTestMode: store.getTestMode(),
-        isUltrasonicDisabled: store.getIsUltrasonicDisabled(),
+        isMultiSheetDetectionDisabled: store.getIsMultiSheetDetectionDisabled(),
         ballotCountWhenBallotBagLastReplaced:
           store.getBallotCountWhenBallotBagLastReplaced(),
         hasPaperBeenLoaded: store.getHasPaperBeenLoaded(),
@@ -225,8 +225,12 @@ export function buildApi({
       store.setIsSoundMuted(input.isSoundMuted);
     },
 
-    setIsUltrasonicDisabled(input: { isUltrasonicDisabled: boolean }): void {
-      store.setIsUltrasonicDisabled(input.isUltrasonicDisabled);
+    setIsMultiSheetDetectionDisabled(input: {
+      isMultiSheetDetectionDisabled: boolean;
+    }): void {
+      store.setIsMultiSheetDetectionDisabled(
+        input.isMultiSheetDetectionDisabled
+      );
     },
 
     async setTestMode(input: { isTestMode: boolean }): Promise<void> {

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -176,8 +176,7 @@ export function buildApi({
         precinctSelection: store.getPrecinctSelection(),
         isSoundMuted: store.getIsSoundMuted(),
         isTestMode: store.getTestMode(),
-        isUltrasonicDisabled:
-          !machine.supportsUltrasonic() || store.getIsUltrasonicDisabled(),
+        isUltrasonicDisabled: store.getIsUltrasonicDisabled(),
         ballotCountWhenBallotBagLastReplaced:
           store.getBallotCountWhenBallotBagLastReplaced(),
         hasPaperBeenLoaded: store.getHasPaperBeenLoaded(),
@@ -357,10 +356,6 @@ export function buildApi({
 
     printTestPage(): Promise<FujitsuPrintResult> {
       return printTestPage({ printer });
-    },
-
-    supportsUltrasonic(): boolean {
-      return machine.supportsUltrasonic();
     },
 
     ...createUiStringsApi({

--- a/apps/scan/backend/src/scanners/custom/state_machine.ts
+++ b/apps/scan/backend/src/scanners/custom/state_machine.ts
@@ -1423,10 +1423,6 @@ export function createPrecinctScannerStateMachine({
       machineService.send('RETURN');
     },
 
-    supportsUltrasonic: () => {
-      return true;
-    },
-
     stop: () => {
       machineService.stop();
     },

--- a/apps/scan/backend/src/scanners/custom/state_machine.ts
+++ b/apps/scan/backend/src/scanners/custom/state_machine.ts
@@ -312,13 +312,14 @@ async function reset({ client }: Context): Promise<void> {
 async function scan({ client, workspace }: Context): Promise<SheetOf<string>> {
   assert(client);
   debug('Scanning');
-  const isUltrasonicDisabled = workspace.store.getIsUltrasonicDisabled();
+  const isMultiSheetDetectionDisabled =
+    workspace.store.getIsMultiSheetDetectionDisabled();
   const scanResult = await client.scan({
     wantedScanSide: ScanSide.A_AND_B,
     resolution: ImageResolution.RESOLUTION_200_DPI,
     imageColorDepth: ImageColorDepthType.Grey8bpp,
     formStandingAfterScan: FormStanding.HOLD_TICKET,
-    doubleSheetDetection: isUltrasonicDisabled
+    doubleSheetDetection: isMultiSheetDetectionDisabled
       ? DoubleSheetDetectOpt.DetectOff
       : DoubleSheetDetectOpt.Level1,
   });

--- a/apps/scan/backend/src/store.test.ts
+++ b/apps/scan/backend/src/store.test.ts
@@ -191,12 +191,12 @@ test('get/set is sounds muted mode', () => {
   expect(store.getIsSoundMuted()).toEqual(false);
 });
 
-test('get/set is ultrasonic disabled mode', () => {
+test('get/set is multi sheet detection disabled mode', () => {
   const store = Store.memoryStore();
 
   // Before setting an election
-  expect(store.getIsUltrasonicDisabled()).toEqual(false);
-  expect(() => store.setIsUltrasonicDisabled(true)).toThrowError();
+  expect(store.getIsMultiSheetDetectionDisabled()).toEqual(false);
+  expect(() => store.setIsMultiSheetDetectionDisabled(true)).toThrowError();
 
   store.setElectionAndJurisdiction({
     electionData:
@@ -206,13 +206,13 @@ test('get/set is ultrasonic disabled mode', () => {
   });
 
   // After setting an election
-  expect(store.getIsUltrasonicDisabled()).toEqual(false);
+  expect(store.getIsMultiSheetDetectionDisabled()).toEqual(false);
 
-  store.setIsUltrasonicDisabled(true);
-  expect(store.getIsUltrasonicDisabled()).toEqual(true);
+  store.setIsMultiSheetDetectionDisabled(true);
+  expect(store.getIsMultiSheetDetectionDisabled()).toEqual(true);
 
-  store.setIsUltrasonicDisabled(false);
-  expect(store.getIsUltrasonicDisabled()).toEqual(false);
+  store.setIsMultiSheetDetectionDisabled(false);
+  expect(store.getIsMultiSheetDetectionDisabled()).toEqual(false);
 });
 
 test('get/set ballot count when ballot bag last replaced', () => {

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -276,19 +276,19 @@ export class Store {
   }
 
   /**
-   * Gets whether ultrasonic is disabled.
+   * Gets whether multi sheet detection is disabled.
    */
-  getIsUltrasonicDisabled(): boolean {
+  getIsMultiSheetDetectionDisabled(): boolean {
     const electionRow = this.client.one(
-      'select is_ultrasonic_disabled as isUltrasonicDisabled from election'
-    ) as { isUltrasonicDisabled: number } | undefined;
+      'select is_multi_sheet_detection_disabled as isMultiSheetDetectionDisabled from election'
+    ) as { isMultiSheetDetectionDisabled: number } | undefined;
 
     if (!electionRow) {
-      // we will not disable ultrasonic by default once an election is defined
+      // we will not disable multi sheet detection by default once an election is defined
       return false;
     }
 
-    return Boolean(electionRow.isUltrasonicDisabled);
+    return Boolean(electionRow.isMultiSheetDetectionDisabled);
   }
 
   /**
@@ -306,16 +306,20 @@ export class Store {
   }
 
   /**
-   * Sets whether or not to enable ultrasonic, if supported.
+   * Sets whether or not to enable multi sheet detection, if supported.
    */
-  setIsUltrasonicDisabled(isUltrasonicDisabled: boolean): void {
+  setIsMultiSheetDetectionDisabled(
+    isMultiSheetDetectionDisabled: boolean
+  ): void {
     if (!this.hasElection()) {
-      throw new Error('Cannot toggle ultrasonic without an election.');
+      throw new Error(
+        'Cannot toggle multi sheet detection without an election.'
+      );
     }
 
     this.client.run(
-      'update election set is_ultrasonic_disabled = ?',
-      isUltrasonicDisabled ? 1 : 0
+      'update election set is_multi_sheet_detection_disabled = ?',
+      isMultiSheetDetectionDisabled ? 1 : 0
     );
   }
 

--- a/apps/scan/backend/src/types.ts
+++ b/apps/scan/backend/src/types.ts
@@ -63,7 +63,6 @@ export interface PrecinctScannerConfig {
  */
 export interface PrecinctScannerStateMachine {
   status: () => PrecinctScannerMachineStatus;
-  supportsUltrasonic: () => boolean;
   // The commands are non-blocking and do not return a result. They just send an
   // event to the machine. The effects of the event (or any error) will show up
   // in the status.

--- a/apps/scan/backend/src/types.ts
+++ b/apps/scan/backend/src/types.ts
@@ -49,7 +49,7 @@ export interface PrecinctScannerConfig {
   systemSettings: SystemSettings;
   precinctSelection?: PrecinctSelection;
   isSoundMuted: boolean;
-  isUltrasonicDisabled: boolean;
+  isMultiSheetDetectionDisabled: boolean;
   hasPaperBeenLoaded: boolean;
   // "Config" that is specific to each election session
   isTestMode: boolean;

--- a/apps/scan/backend/test/helpers/custom_helpers.ts
+++ b/apps/scan/backend/test/helpers/custom_helpers.ts
@@ -297,7 +297,6 @@ export function createPrecinctScannerStateMachineMock(): jest.Mocked<PrecinctSca
     status: jest.fn(),
     accept: jest.fn(),
     return: jest.fn(),
-    supportsUltrasonic: jest.fn(),
     stop: jest.fn(),
   };
 }

--- a/apps/scan/frontend/src/api.ts
+++ b/apps/scan/frontend/src/api.ts
@@ -381,16 +381,6 @@ export const returnBallot = {
   },
 } as const;
 
-export const supportsUltrasonic = {
-  queryKey(): QueryKey {
-    return ['supportsUltrasonic'];
-  },
-  useQuery() {
-    const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () => apiClient.supportsUltrasonic());
-  },
-} as const;
-
 export const setHasPaperBeenLoaded = {
   useMutation() {
     const apiClient = useApiClient();

--- a/apps/scan/frontend/src/api.ts
+++ b/apps/scan/frontend/src/api.ts
@@ -234,11 +234,11 @@ export const setIsSoundMuted = {
   },
 } as const;
 
-export const setIsUltrasonicDisabled = {
+export const setIsMultiSheetDetectionDisabled = {
   useMutation() {
     const apiClient = useApiClient();
     const queryClient = useQueryClient();
-    return useMutation(apiClient.setIsUltrasonicDisabled, {
+    return useMutation(apiClient.setIsMultiSheetDetectionDisabled, {
       async onSuccess() {
         await queryClient.invalidateQueries(getConfig.queryKey());
       },

--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -105,7 +105,6 @@ test('shows insert USB Drive screen when there is no USB drive', async () => {
 
 test('app can load and configure from a usb stick', async () => {
   apiMock.authenticateAsElectionManager(electionGeneralDefinition);
-  apiMock.expectCheckUltrasonicSupported(false);
   apiMock.expectGetConfig({
     electionDefinition: undefined,
   });
@@ -161,7 +160,6 @@ test('app can load and configure from a usb stick', async () => {
 });
 
 test('election manager must set precinct', async () => {
-  apiMock.expectCheckUltrasonicSupported(false);
   apiMock.expectGetConfig({
     precinctSelection: undefined,
   });
@@ -201,7 +199,6 @@ test('election manager must set precinct', async () => {
 test('election manager and poll worker configuration', async () => {
   const electionDefinition = electionGeneralDefinition;
   let config: Partial<PrecinctScannerConfig> = { electionDefinition };
-  apiMock.expectCheckUltrasonicSupported(false);
   apiMock.expectGetConfig(config);
   apiMock.expectGetPollsInfo('polls_closed_initial');
   apiMock.expectGetScannerStatus(statusNoPaper);
@@ -352,7 +349,6 @@ async function scanBallot() {
 
 test('voter can cast a ballot that scans successfully ', async () => {
   const electionDefinition = electionTwoPartyPrimaryDefinition;
-  apiMock.expectCheckUltrasonicSupported(false);
   apiMock.expectGetConfig({
     electionDefinition,
   });

--- a/apps/scan/frontend/src/app_unhappy_paths.test.tsx
+++ b/apps/scan/frontend/src/app_unhappy_paths.test.tsx
@@ -49,7 +49,6 @@ test('when backend does not respond shows error screen', async () => {
 });
 
 test('backend fails to unconfigure', async () => {
-  apiMock.expectCheckUltrasonicSupported(false);
   apiMock.expectGetConfig();
   apiMock.expectGetPollsInfo();
   apiMock.setBatteryInfo();

--- a/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
@@ -179,7 +179,7 @@ test('when sounds are muted, shows a button to unmute sounds', async () => {
   await screen.findByRole('button', { name: 'Mute Sounds' });
 });
 
-test('shows ultrasonic toggle', async () => {
+test('shows multi sheet detection toggle', async () => {
   apiMock.expectGetConfig();
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
@@ -189,8 +189,8 @@ test('shows ultrasonic toggle', async () => {
   await screen.findByText('Disable Double Sheet Detection');
 });
 
-test('prompts to enable ultrasonic when disabled ', async () => {
-  apiMock.expectGetConfig({ isUltrasonicDisabled: true });
+test('prompts to enable multi sheet detection when disabled ', async () => {
+  apiMock.expectGetConfig({ isMultiSheetDetectionDisabled: true });
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
 
@@ -199,17 +199,17 @@ test('prompts to enable ultrasonic when disabled ', async () => {
   await screen.findByText('Enable Double Sheet Detection');
 });
 
-test('disables ultrasonic properly', async () => {
+test('disables multi sheet detection properly', async () => {
   apiMock.expectGetConfig();
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
 
   userEvent.click(screen.getByRole('tab', { name: /system/i }));
 
-  apiMock.mockApiClient.setIsUltrasonicDisabled
-    .expectCallWith({ isUltrasonicDisabled: true })
+  apiMock.mockApiClient.setIsMultiSheetDetectionDisabled
+    .expectCallWith({ isMultiSheetDetectionDisabled: true })
     .resolves();
-  apiMock.expectGetConfig({ isUltrasonicDisabled: true });
+  apiMock.expectGetConfig({ isMultiSheetDetectionDisabled: true });
   userEvent.click(await screen.findButton('Disable Double Sheet Detection'));
   await screen.findButton('Enable Double Sheet Detection');
   await screen.findByText('Enable Double Sheet Detection');

--- a/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
@@ -35,7 +35,6 @@ beforeEach(() => {
   window.kiosk = fakeKiosk();
   apiMock = createApiMock();
   apiMock.expectGetPollsInfo();
-  apiMock.expectCheckUltrasonicSupported(true);
   apiMock.expectGetMachineConfig();
   apiMock.expectGetScannerStatus(statusNoPaper);
   apiMock.expectGetUsbDriveStatus('mounted');
@@ -180,19 +179,7 @@ test('when sounds are muted, shows a button to unmute sounds', async () => {
   await screen.findByRole('button', { name: 'Mute Sounds' });
 });
 
-test('does not show ultrasonic button if not supported', async () => {
-  apiMock.mockApiClient.supportsUltrasonic.reset();
-  apiMock.expectCheckUltrasonicSupported(false);
-  apiMock.expectGetConfig();
-  renderScreen();
-  await screen.findByRole('heading', { name: 'Election Manager Settings' });
-
-  userEvent.click(screen.getByRole('tab', { name: /system/i }));
-
-  expect(screen.queryByText('Disable Double Sheet Detection')).toBeNull();
-});
-
-test('shows ultrasonic toggle when supported', async () => {
+test('shows ultrasonic toggle', async () => {
   apiMock.expectGetConfig();
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -34,7 +34,6 @@ import {
   setIsUltrasonicDisabled,
   setPrecinctSelection,
   setTestMode,
-  supportsUltrasonic,
   unconfigureElection,
 } from '../api';
 import { usePreviewContext } from '../preview_dashboard';
@@ -56,7 +55,6 @@ export function ElectionManagerScreen({
   scannerStatus,
   usbDrive,
 }: ElectionManagerScreenProps): JSX.Element | null {
-  const supportsUltrasonicQuery = supportsUltrasonic.useQuery();
   const configQuery = getConfig.useQuery();
   const pollsInfoQuery = getPollsInfo.useQuery();
   const usbDriveStatusQuery = getUsbDriveStatus.useQuery();
@@ -188,19 +186,17 @@ export function ElectionManagerScreen({
 
   const doubleSheetDetectionToggle = (
     <P>
-      {supportsUltrasonicQuery.data === true && (
-        <Button
-          onPress={() =>
-            setIsUltrasonicDisabledMutation.mutate({
-              isUltrasonicDisabled: !isUltrasonicDisabled,
-            })
-          }
-        >
-          {isUltrasonicDisabled
-            ? 'Enable Double Sheet Detection'
-            : 'Disable Double Sheet Detection'}
-        </Button>
-      )}
+      <Button
+        onPress={() =>
+          setIsUltrasonicDisabledMutation.mutate({
+            isUltrasonicDisabled: !isUltrasonicDisabled,
+          })
+        }
+      >
+        {isUltrasonicDisabled
+          ? 'Enable Double Sheet Detection'
+          : 'Disable Double Sheet Detection'}
+      </Button>
     </P>
   );
 

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -31,7 +31,7 @@ import {
   getUsbDriveStatus,
   logOut,
   setIsSoundMuted,
-  setIsUltrasonicDisabled,
+  setIsMultiSheetDetectionDisabled,
   setPrecinctSelection,
   setTestMode,
   unconfigureElection,
@@ -64,7 +64,8 @@ export function ElectionManagerScreen({
   const setPrecinctSelectionMutation = setPrecinctSelection.useMutation();
   const setTestModeMutation = setTestMode.useMutation();
   const setIsSoundMutedMutation = setIsSoundMuted.useMutation();
-  const setIsUltrasonicDisabledMutation = setIsUltrasonicDisabled.useMutation();
+  const setIsMultiSheetDetectionDisabledMutation =
+    setIsMultiSheetDetectionDisabled.useMutation();
   const unconfigureMutation = unconfigureElection.useMutation();
   const ejectUsbDriveMutation = ejectUsbDrive.useMutation();
   const logOutMutation = logOut.useMutation();
@@ -86,8 +87,12 @@ export function ElectionManagerScreen({
   }
 
   const { election } = electionDefinition;
-  const { precinctSelection, isTestMode, isSoundMuted, isUltrasonicDisabled } =
-    configQuery.data;
+  const {
+    precinctSelection,
+    isTestMode,
+    isSoundMuted,
+    isMultiSheetDetectionDisabled,
+  } = configQuery.data;
   const { pollsState } = pollsInfoQuery.data;
   const printerStatus = printerStatusQuery.data;
 
@@ -188,12 +193,12 @@ export function ElectionManagerScreen({
     <P>
       <Button
         onPress={() =>
-          setIsUltrasonicDisabledMutation.mutate({
-            isUltrasonicDisabled: !isUltrasonicDisabled,
+          setIsMultiSheetDetectionDisabledMutation.mutate({
+            isMultiSheetDetectionDisabled: !isMultiSheetDetectionDisabled,
           })
         }
       >
-        {isUltrasonicDisabled
+        {isMultiSheetDetectionDisabled
           ? 'Enable Double Sheet Detection'
           : 'Disable Double Sheet Detection'}
       </Button>

--- a/apps/scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/scan/frontend/test/helpers/mock_api_client.tsx
@@ -215,12 +215,6 @@ export function createApiMock() {
         .resolves(ok());
     },
 
-    expectCheckUltrasonicSupported(supportsUltrasonic: boolean): void {
-      mockApiClient.supportsUltrasonic
-        .expectCallWith()
-        .resolves(supportsUltrasonic);
-    },
-
     expectLogOut() {
       mockApiClient.logOut.expectCallWith().resolves();
     },

--- a/apps/scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/scan/frontend/test/helpers/mock_api_client.tsx
@@ -42,7 +42,7 @@ export const machineConfig: MachineConfig = {
 
 const defaultConfig: PrecinctScannerConfig = {
   isSoundMuted: false,
-  isUltrasonicDisabled: false,
+  isMultiSheetDetectionDisabled: false,
   hasPaperBeenLoaded: false,
   isTestMode: true,
   ballotCountWhenBallotBagLastReplaced: 0,

--- a/libs/custom-scanner/src/parameters.ts
+++ b/libs/custom-scanner/src/parameters.ts
@@ -4,7 +4,7 @@ import {
   DoubleSheetDetectOpt,
   ImageResolution,
   ScanParameters,
-  UltrasonicSensorLevelInternal,
+  MultiSheetDetectionSensorLevelInternal,
 } from './types';
 
 type ResolutionProps = Pick<
@@ -37,21 +37,21 @@ const resolutionPropsMap: Record<number, ResolutionProps> = {
 };
 
 /**
- * Converts the high-level double sheet detection parameter to the specific internal ultrasonic level desired
+ * Converts the high-level double sheet detection parameter to the specific internal multi sheet detection level desired
  */
-function convertToUltrasonicSensorLevelInternal(
+function convertToMultiSheetDetectionSensorLevelInternal(
   option: DoubleSheetDetectOpt
-): UltrasonicSensorLevelInternal {
+): MultiSheetDetectionSensorLevelInternal {
   switch (option) {
     case DoubleSheetDetectOpt.Level1:
     case DoubleSheetDetectOpt.DetectOff:
-      return UltrasonicSensorLevelInternal.Level1;
+      return MultiSheetDetectionSensorLevelInternal.Level1;
     case DoubleSheetDetectOpt.Level2:
-      return UltrasonicSensorLevelInternal.Level2;
+      return MultiSheetDetectionSensorLevelInternal.Level2;
     case DoubleSheetDetectOpt.Level3:
-      return UltrasonicSensorLevelInternal.Level3;
+      return MultiSheetDetectionSensorLevelInternal.Level3;
     case DoubleSheetDetectOpt.Level4:
-      return UltrasonicSensorLevelInternal.Level4;
+      return MultiSheetDetectionSensorLevelInternal.Level4;
     /* c8 ignore next 2 */
     default:
       throwIllegalValue(option);
@@ -87,10 +87,11 @@ export function convertToInternalScanParameters(
     acquireLampOff: false,
     acquireNoPaperSensor: true,
     acquireMotorOff: false,
-    ultrasonicSensorLevel: convertToUltrasonicSensorLevelInternal(
-      scanParameters.doubleSheetDetection
-    ),
-    disableUltrasonicSensor:
+    multiSheetDetectionSensorLevel:
+      convertToMultiSheetDetectionSensorLevelInternal(
+        scanParameters.doubleSheetDetection
+      ),
+    disableMultiSheetDetectionSensor:
       scanParameters.doubleSheetDetection === DoubleSheetDetectOpt.DetectOff,
     disableHardwareDeskew: true,
     formStandingAfterScan: scanParameters.formStandingAfterScan,

--- a/libs/custom-scanner/src/protocol.ts
+++ b/libs/custom-scanner/src/protocol.ts
@@ -44,7 +44,7 @@ import {
   ReleaseType,
   ResponseErrorCode,
   ScanSide,
-  UltrasonicSensorLevelInternal,
+  MultiSheetDetectionSensorLevelInternal,
 } from './types';
 
 const debug = baseDebug.extend('protocol');
@@ -194,9 +194,9 @@ export const StatusInternalMessage = message({
   endScanB: uint8(),
 
   /**
-   * Byte 28. Ultrasonic status.
+   * Byte 28. MultiSheetDetection status.
    */
-  ultrasonic: uint8(),
+  multiSheetDetection: uint8(),
 
   /**
    * Byte 29. 'J' if there is a paper jam, but which kind of jam depends on bit
@@ -440,12 +440,12 @@ export const SetScanParametersRequestData = message({
   byte7Unused: padding(8),
 
   /** Byte 8.6 (0x40) and 8.7 (0x80) */
-  ultrasonicSensorLevel: uint2<UltrasonicSensorLevelInternal>(
-    UltrasonicSensorLevelInternal
+  multiSheetDetectionSensorLevel: uint2<MultiSheetDetectionSensorLevelInternal>(
+    MultiSheetDetectionSensorLevelInternal
   ),
 
   /** Byte 8.5 (0x20) */
-  disableUltrasonicSensor: uint1(),
+  disableMultiSheetDetectionSensor: uint1(),
 
   /** Byte 8.4 (0x10) */
   disableHardwareDeskew: uint1(),

--- a/libs/custom-scanner/src/types.ts
+++ b/libs/custom-scanner/src/types.ts
@@ -369,7 +369,7 @@ export enum CustomSensorsBitmask {
 export enum JobStatus {
   SCAN = 0x00000001,
   CALIBRATION = 0x00000002,
-  ULTRASONIC = 0x00000004,
+  MULTI_SHEET_DETECTION = 0x00000004,
   FLASH_ACCESS = 0x00000008,
   ADF_LOAD_PAPER = 0x00010000, // (1 << 16)
   ADF_EJECT_PAPER = 0x00020000, // (2 << 16)
@@ -539,7 +539,7 @@ export enum FormStanding {
 }
 
 /**
- * Ultrasonic sensor settings for double/multiple sheet loaded detection.
+ * MultiSheetDetection sensor settings for double/multiple sheet loaded detection.
  */
 export enum DoubleSheetDetectOpt {
   /** Turn OFF the double/multiple sheet detection */
@@ -559,9 +559,9 @@ export enum DoubleSheetDetectOpt {
 }
 
 /**
- * Internal enum for ultrasonic sensor level.
+ * Internal enum for multi sheet detection sensor level.
  */
-export enum UltrasonicSensorLevelInternal {
+export enum MultiSheetDetectionSensorLevelInternal {
   Level1 = 0b00,
   Level2 = 0b01,
   Level3 = 0b10,

--- a/libs/custom-scanner/test/arbitraries.ts
+++ b/libs/custom-scanner/test/arbitraries.ts
@@ -40,7 +40,7 @@ import {
   ResponseErrorCode,
   ScanParameters,
   ScanSide,
-  UltrasonicSensorLevelInternal,
+  MultiSheetDetectionSensorLevelInternal,
 } from '../src/types';
 
 /**
@@ -90,10 +90,10 @@ export function arbitraryFormMovement(): fc.Arbitrary<FormMovement> {
 }
 
 /**
- * Builds an arbitrary `UltraSonicSensorLevelInternal` value.
+ * Builds an arbitrary `MultiSheetDetectionSensorLevelInternal` value.
  */
-export function arbitraryUltrasonicSensorLevelInternal(): fc.Arbitrary<UltrasonicSensorLevelInternal> {
-  return arbitraryNumericEnumValue(UltrasonicSensorLevelInternal);
+export function arbitraryMultiSheetDetectionSensorLevelInternal(): fc.Arbitrary<MultiSheetDetectionSensorLevelInternal> {
+  return arbitraryNumericEnumValue(MultiSheetDetectionSensorLevelInternal);
 }
 
 /**
@@ -214,8 +214,9 @@ export function arbitrarySetScanParametersRequestData(): fc.Arbitrary<SetScanPar
     acquireLampOff: fc.boolean(),
     acquireNoPaperSensor: fc.boolean(),
     acquireMotorOff: fc.boolean(),
-    ultrasonicSensorLevel: arbitraryUltrasonicSensorLevelInternal(),
-    disableUltrasonicSensor: fc.boolean(),
+    multiSheetDetectionSensorLevel:
+      arbitraryMultiSheetDetectionSensorLevelInternal(),
+    disableMultiSheetDetectionSensor: fc.boolean(),
     disableHardwareDeskew: fc.boolean(),
     formStandingAfterScan: arbitraryFormStanding(),
     wantedScanSide: arbitraryScanSide(),
@@ -471,7 +472,7 @@ export function arbitraryStatusInternalMessage(): fc.Arbitrary<StatusInternalMes
     endPageB: arbitraryUint8(),
     endScanA: arbitraryUint8(),
     endScanB: arbitraryUint8(),
-    ultrasonic: arbitraryUint8(),
+    multiSheetDetection: arbitraryUint8(),
     paperJam: arbitraryUint8(),
     coverOpen: arbitraryUint8(),
     cancel: arbitraryUint8(),


### PR DESCRIPTION
## Overview

Removes the `supportsUltrasonic` flag, since all of our scanners (Custom and PDI) support multiple sheet detection, so this is an unnecessary flag. Also changes the language used in the code to refer to this feature from "ultrasonic" to "multi sheet detection" in order to better describe what the feature does, not how it works.

## Demo Video or Screenshot
N/A

## Testing Plan
Existing tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
