### PR TITLE
apps/scan/backend: Use isFeatureFlag for Fujitsu printer env var

### DIFF
--- a/apps/scan/backend/src/printing/printer.ts
+++ b/apps/scan/backend/src/printing/printer.ts
@@ -9,15 +9,11 @@ import {
 } from '@votingworks/fujitsu-thermal-printer';
 import {
   BooleanEnvironmentVariableName,
-  getEnvironmentVariable,
+  isFeatureFlagEnabled,
 } from '@votingworks/utils';
 import { BaseLogger } from '@votingworks/logging';
 import { assert, Result } from '@votingworks/basics';
 import { Buffer } from 'buffer';
-
-export const USE_FUJITSU_PRINTER = getEnvironmentVariable(
-  BooleanEnvironmentVariableName.SCAN_USE_FUJITSU_PRINTER
-);
 
 export type PrinterStatus =
   | ({
@@ -89,7 +85,7 @@ export function wrapFujitsuThermalPrinter(
 export async function getPrinter(logger: BaseLogger): Promise<Printer> {
   /* c8 ignore start */
   if (
-    getEnvironmentVariable(
+    isFeatureFlagEnabled(
       BooleanEnvironmentVariableName.SCAN_USE_FUJITSU_PRINTER
     )
   ) {

--- a/libs/utils/src/environment_variable.ts
+++ b/libs/utils/src/environment_variable.ts
@@ -72,6 +72,10 @@ export interface StringEnvironmentConfig {
   zodSchema?: ZodSchema;
 }
 
+/**
+ * @private Don't use this function directly, instead use isFeatureFlagEnabled,
+ * which will check the env var's config and convert it to a boolean.
+ */
 export function getEnvironmentVariable(
   name: BooleanEnvironmentVariableName | StringEnvironmentVariableName
 ): string | undefined {


### PR DESCRIPTION
## Overview

`getEnvironmentVariable` doesn't actually convert it to a boolean, so
the check was always true.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
