### PR TITLE
[MarkScan] Fix exit key sequence for the accessible controller sandbox

### DIFF
--- a/libs/ui/src/accessible_controllers/test_utils.tsx
+++ b/libs/ui/src/accessible_controllers/test_utils.tsx
@@ -1,5 +1,5 @@
 import userEvent from '@testing-library/user-event';
 
 export function simulateKeyPress(key: string): void {
-  userEvent.keyboard(key.length === 1 ? key : `[${key}]`);
+  userEvent.keyboard(key.length === 1 ? key : `{${key}}`);
 }

--- a/libs/ui/src/accessible_controllers/use_accessible_controller_help_trigger.test.tsx
+++ b/libs/ui/src/accessible_controllers/use_accessible_controller_help_trigger.test.tsx
@@ -25,6 +25,7 @@ test('toggles "on" to "off" for two consecutive keypresses', () => {
   expect(result.current.shouldShowControllerSandbox).toEqual(true);
 
   simulateKeyPress(Keybinding.TOGGLE_HELP);
+  simulateKeyPress('Shift'); // Should be ignored.
   simulateKeyPress(Keybinding.TOGGLE_HELP);
   expect(result.current.shouldShowControllerSandbox).toEqual(false);
 });

--- a/libs/ui/src/accessible_controllers/use_accessible_controller_help_trigger.tsx
+++ b/libs/ui/src/accessible_controllers/use_accessible_controller_help_trigger.tsx
@@ -5,6 +5,8 @@ export interface UseAccessibleControllerHelpTriggerResult {
   shouldShowControllerSandbox: boolean;
 }
 
+const IGNORED_MODIFIER_KEY_PRESSES = new Set(['Shift']);
+
 export function useAccessibleControllerHelpTrigger(): UseAccessibleControllerHelpTriggerResult {
   const [shouldShowHelp, setShouldShowHelp] = React.useState(false);
   const [lastKeyPress, setLastKeyPress] = React.useState<string>();
@@ -28,7 +30,11 @@ export function useAccessibleControllerHelpTrigger(): UseAccessibleControllerHel
         return;
       }
 
-      setLastKeyPress(event.key);
+      // Store the last recognized key press, ignoring modifier keys that are
+      // used in combination with character keys for some keybindings.
+      if (!IGNORED_MODIFIER_KEY_PRESSES.has(event.key)) {
+        setLastKeyPress(event.key);
+      }
     }
 
     document.addEventListener('keydown', onKeyDown);


### PR DESCRIPTION
## Overview

Related to: https://github.com/votingworks/vxsuite/issues/4762

The accessible controller sandbox requires two consecutive keypresses of the `TOGGLE_HELP` keybinding, but previously only worked if the `Shift` key was held across both key presses - whereas in real-world scenarios, the controller fires key press events `Shift`, `r`, `Shift`, `r` for a double press of the help button.
This change ignores the `Shift` key when determining what the last keypress was, to avoid having the `Shift` key break the exit sequence.

## Demo Video or Screenshot

### Before:

https://github.com/votingworks/vxsuite/assets/264902/d353ef0d-a440-41b9-8bb5-2522dd945419

### After:

https://github.com/votingworks/vxsuite/assets/264902/37e5dfd7-5f9b-483a-865d-44311398246e

## Testing Plan
- Updated unit tests to assert this behaviour

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
