### PR TITLE
libs/pdi-scanner: Add commands and improved error handling 

### DIFF
--- a/libs/pdi-scanner/examples/scan_forever.rs
+++ b/libs/pdi-scanner/examples/scan_forever.rs
@@ -63,7 +63,7 @@ fn main() -> color_eyre::Result<()> {
     let mut raw_image_data = RawImageData::new();
     let mut scan_index = 0;
 
-    client.send_connect()?;
+    client.send_initial_commands_after_connect(Duration::from_secs(3))?;
     client.send_enable_scan_commands()?;
     println!("waiting for sheet…");
 

--- a/libs/pdi-scanner/src/client.rs
+++ b/libs/pdi-scanner/src/client.rs
@@ -748,8 +748,7 @@ impl<T> Client<T> {
     ///
     /// This function will return an error if any of the commands fail to
     /// validate or if the response is not received within the timeout.
-    pub fn send_connect(&mut self) -> Result<()> {
-        let timeout = Duration::from_secs(5);
+    pub fn send_initial_commands_after_connect(&mut self, timeout: Duration) -> Result<()> {
         let deadline = Instant::now() + timeout;
 
         // OUT DisableFeederRequest

--- a/libs/pdi-scanner/src/lib.rs
+++ b/libs/pdi-scanner/src/lib.rs
@@ -6,11 +6,11 @@ mod types;
 
 use client::Client;
 use scanner::Scanner;
-pub use types::{Error, Result};
+pub use types::{Error, Result, UsbError};
 
 /// Connect to the scanner and return the scanner and client. When you're done,
 /// you should call [`Scanner::stop`] to properly close the connection.
-pub fn connect() -> color_eyre::Result<Client<Scanner>> {
+pub fn connect() -> color_eyre::Result<Client<Scanner>, Error> {
     let mut scanner = Scanner::open()?;
     let (tx, ack_rx, rx) = scanner.start();
     let client = Client::new(tx, ack_rx, rx, Some(scanner));

--- a/libs/pdi-scanner/src/main.rs
+++ b/libs/pdi-scanner/src/main.rs
@@ -15,8 +15,8 @@ use pdi_scanner::{
         image::{RawImageData, Sheet, DEFAULT_IMAGE_WIDTH},
         packets::Incoming,
         types::{
-            DoubleFeedDetectionCalibrationType, DoubleFeedDetectionMode, EjectMotion, ScanSideMode,
-            Status,
+            DoubleFeedDetectionCalibrationType, DoubleFeedDetectionMode, EjectMotion, FeederMode,
+            ScanSideMode, Status,
         },
     },
     scanner::Scanner,
@@ -74,6 +74,8 @@ enum Command {
     GetScannerStatus,
 
     EnableScanning,
+
+    DisableScanning,
 
     EjectDocument {
         eject_motion: EjectMotion,
@@ -204,6 +206,18 @@ fn main() -> color_eyre::Result<()> {
                 }
                 (Some(client), Command::EnableScanning) => {
                     match client.send_enable_scan_commands() {
+                        Ok(()) => {
+                            send_response(&Response::Ok)?;
+                        }
+                        Err(e) => {
+                            send_response(&Response::Error {
+                                message: e.to_string(),
+                            })?;
+                        }
+                    }
+                }
+                (Some(client), Command::DisableScanning) => {
+                    match client.set_feeder_mode(FeederMode::Disabled) {
                         Ok(()) => {
                             send_response(&Response::Ok)?;
                         }

--- a/libs/pdi-scanner/src/main.rs
+++ b/libs/pdi-scanner/src/main.rs
@@ -2,7 +2,6 @@ use clap::Parser;
 use image::EncodableLayout;
 use std::{
     io::{self, Write},
-    process::exit,
     time::Duration,
 };
 use tracing_subscriber::prelude::*;
@@ -161,7 +160,7 @@ fn main() -> color_eyre::Result<()> {
             Ok(command) => match (&mut client, command) {
                 (_, Command::Exit) => {
                     serde_json::to_writer(io::stdout(), &Response::Ok)?;
-                    exit(0)
+                    return color_eyre::Result::Ok(());
                 }
                 (Some(_), Command::Connect) => {
                     send_response(&Response::Error {
@@ -296,7 +295,9 @@ fn main() -> color_eyre::Result<()> {
             Err(std::sync::mpsc::TryRecvError::Empty) => {}
             Err(std::sync::mpsc::TryRecvError::Disconnected) => {
                 tracing::error!("stdin channel disconnected");
-                exit(-1);
+                return color_eyre::Result::Err(color_eyre::Report::msg(
+                    "stdin channel disconnected",
+                ));
             }
         }
 

--- a/libs/pdi-scanner/src/main.rs
+++ b/libs/pdi-scanner/src/main.rs
@@ -304,10 +304,10 @@ fn main() -> color_eyre::Result<()> {
         if let Some(client) = &mut client {
             if let Ok(event) = client.try_recv_matching(Incoming::is_event) {
                 eprintln!("event: {:?}", event);
-                // TODO: pass the event as JSON via stdout
                 match event {
                     Incoming::BeginScanEvent => {
                         raw_image_data = RawImageData::new();
+                        send_response(&Response::ScanStart)?;
                     }
                     Incoming::EndScanEvent => {
                         match raw_image_data

--- a/libs/pdi-scanner/src/main.rs
+++ b/libs/pdi-scanner/src/main.rs
@@ -59,66 +59,66 @@ fn setup_logging(config: &Config) -> color_eyre::Result<()> {
 }
 
 #[derive(Debug, serde::Deserialize)]
-#[serde(tag = "type")]
-#[serde(rename_all = "camelCase")]
+#[serde(
+    tag = "type",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
 enum Command {
-    #[serde(rename = "exit")]
     Exit,
 
-    #[serde(rename = "connect")]
     Connect,
 
-    #[serde(rename = "disconnect")]
     Disconnect,
 
-    #[serde(rename = "get_scanner_status")]
     GetScannerStatus,
 
-    #[serde(rename = "enable_scanning")]
     EnableScanning,
 
-    #[serde(rename = "eject")]
-    #[serde(rename_all = "camelCase")]
-    EjectDocument { eject_motion: EjectMotion },
+    EjectDocument {
+        eject_motion: EjectMotion,
+    },
 
-    #[serde(rename = "enable_msd")]
-    EnableMsd { enable: bool },
+    EnableMsd {
+        enable: bool,
+    },
 
-    #[serde(rename = "calibrate_msd")]
-    #[serde(rename_all = "camelCase")]
     CalibrateMsd {
         calibration_type: DoubleFeedDetectionCalibrationType,
     },
 
-    #[serde(rename = "get_msd_calibration_config")]
     GetMsdCalibrationConfig,
 }
 
 #[derive(Debug, serde::Serialize)]
-#[serde(tag = "type")]
+#[serde(
+    tag = "type",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
 enum Response {
-    #[serde(rename = "ok")]
     Ok,
 
-    #[serde(rename = "error")]
-    Err { message: String },
+    Error {
+        message: String,
+    },
 
-    #[serde(rename = "scan_complete")]
-    #[serde(rename_all = "camelCase")]
-    ScanComplete { image_data: (String, String) },
+    ScannerStatus {
+        status: Status,
+    },
 
-    #[serde(rename = "msd_calibration_config")]
-    #[serde(rename_all = "camelCase")]
+    ScanStart,
+
+    ScanComplete {
+        image_data: (String, String),
+    },
+
     MsdCalibrationConfig {
         led_intensity: u16,
         single_sheet_calibration_value: u16,
         double_sheet_calibration_value: u16,
         threshold_value: u16,
     },
-
-    #[serde(rename = "scanner_status")]
-    #[serde(rename_all = "camelCase")]
-    ScannerStatus { status: Status },
 }
 
 fn send_response(response: &Response) -> color_eyre::Result<()> {
@@ -162,7 +162,7 @@ fn main() -> color_eyre::Result<()> {
                     exit(0)
                 }
                 (Some(_), Command::Connect) => {
-                    send_response(&Response::Err {
+                    send_response(&Response::Error {
                         message: "already connected".to_string(),
                     })?;
                 }
@@ -173,7 +173,7 @@ fn main() -> color_eyre::Result<()> {
                                 send_response(&Response::Ok)?;
                             }
                             Err(e) => {
-                                send_response(&Response::Err {
+                                send_response(&Response::Error {
                                     message: e.to_string(),
                                 })?;
                             }
@@ -181,7 +181,7 @@ fn main() -> color_eyre::Result<()> {
                         client = Some(c);
                     }
                     Err(e) => {
-                        send_response(&Response::Err {
+                        send_response(&Response::Error {
                             message: e.to_string(),
                         })?;
                     }
@@ -196,7 +196,7 @@ fn main() -> color_eyre::Result<()> {
                             send_response(&Response::ScannerStatus { status })?;
                         }
                         Err(e) => {
-                            send_response(&Response::Err {
+                            send_response(&Response::Error {
                                 message: e.to_string(),
                             })?;
                         }
@@ -208,7 +208,7 @@ fn main() -> color_eyre::Result<()> {
                             send_response(&Response::Ok)?;
                         }
                         Err(e) => {
-                            send_response(&Response::Err {
+                            send_response(&Response::Error {
                                 message: e.to_string(),
                             })?;
                         }
@@ -220,7 +220,7 @@ fn main() -> color_eyre::Result<()> {
                             send_response(&Response::Ok)?;
                         }
                         Err(e) => {
-                            send_response(&Response::Err {
+                            send_response(&Response::Error {
                                 message: e.to_string(),
                             })?;
                         }
@@ -236,7 +236,7 @@ fn main() -> color_eyre::Result<()> {
                             send_response(&Response::Ok)?;
                         }
                         Err(e) => {
-                            send_response(&Response::Err {
+                            send_response(&Response::Error {
                                 message: e.to_string(),
                             })?;
                         }
@@ -248,7 +248,7 @@ fn main() -> color_eyre::Result<()> {
                             send_response(&Response::Ok)?;
                         }
                         Err(e) => {
-                            send_response(&Response::Err {
+                            send_response(&Response::Error {
                                 message: e.to_string(),
                             })?;
                         }
@@ -267,14 +267,14 @@ fn main() -> color_eyre::Result<()> {
                             })?;
                         }
                         Err(e) => {
-                            send_response(&Response::Err {
+                            send_response(&Response::Error {
                                 message: e.to_string(),
                             })?;
                         }
                     }
                 }
                 (None, _) => {
-                    send_response(&Response::Err {
+                    send_response(&Response::Error {
                         message: "scanner not connected".to_string(),
                     })?;
                 }
@@ -324,7 +324,7 @@ fn main() -> color_eyre::Result<()> {
                                 ScanSideMode::Duplex
                             ),
                             Err(e) => {
-                                send_response(&Response::Err {
+                                send_response(&Response::Error {
                                     message: format!(
                                         "failed to decode the scanned image data: {e}"
                                     ),

--- a/libs/pdi-scanner/src/main.rs
+++ b/libs/pdi-scanner/src/main.rs
@@ -58,7 +58,7 @@ fn setup_logging(config: &Config) -> color_eyre::Result<()> {
     Ok(())
 }
 
-#[derive(Debug, serde::Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize)]
 #[serde(
     tag = "type",
     rename_all = "camelCase",
@@ -187,7 +187,7 @@ fn main() -> color_eyre::Result<()> {
     loop {
         match stdin_rx.try_recv() {
             Ok(command) => {
-                if command == Command::Exit {
+                if matches!(command, Command::Exit) {
                     serde_json::to_writer(io::stdout(), &Response::Ok)?;
                     return color_eyre::Result::Ok(());
                 }

--- a/libs/pdi-scanner/src/protocol/types.rs
+++ b/libs/pdi-scanner/src/protocol/types.rs
@@ -100,7 +100,7 @@ impl ScanSideMode {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum EjectMotion {
     ToRear,
@@ -289,7 +289,7 @@ impl TryFrom<u16> for CalibrationStatus {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum DoubleFeedDetectionCalibrationType {
     #[serde(rename = "single")]
     SingleSheet,

--- a/libs/pdi-scanner/src/protocol/types.rs
+++ b/libs/pdi-scanner/src/protocol/types.rs
@@ -100,7 +100,7 @@ impl ScanSideMode {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum EjectMotion {
     ToRear,
@@ -289,7 +289,7 @@ impl TryFrom<u16> for CalibrationStatus {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum DoubleFeedDetectionCalibrationType {
     #[serde(rename = "single")]
     SingleSheet,


### PR DESCRIPTION
## Overview

A variety of improvements to libs/pdi-scanner based on the needs of the apps/scan state machine. Details in commits.

## Demo Video or Screenshot
N/A

## Testing Plan
Manual testing with the scanner

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
