### PR TITLE
fix: `sync` after exporting logs

### DIFF
--- a/libs/backend/src/system_call/export_logs_to_usb.test.ts
+++ b/libs/backend/src/system_call/export_logs_to_usb.test.ts
@@ -143,6 +143,8 @@ test('exportLogsToUsb works when all conditions are met', async () => {
     expect.stringMatching('^/media/usb-drive/logs/machine_TEST-MACHINE-ID/'),
   ]);
 
+  expect(execFileMock).toHaveBeenCalledWith('sync', ['/media/usb-drive']);
+
   expect(logger.log).toHaveBeenCalledWith(
     LogEventId.FileSaved,
     'unknown',

--- a/libs/backend/src/system_call/export_logs_to_usb.test.ts
+++ b/libs/backend/src/system_call/export_logs_to_usb.test.ts
@@ -143,7 +143,7 @@ test('exportLogsToUsb works when all conditions are met', async () => {
     expect.stringMatching('^/media/usb-drive/logs/machine_TEST-MACHINE-ID/'),
   ]);
 
-  expect(execFileMock).toHaveBeenCalledWith('sync', ['/media/usb-drive']);
+  expect(execFileMock).toHaveBeenCalledWith('sync', ['-f', '/media/usb-drive']);
 
   expect(logger.log).toHaveBeenCalledWith(
     LogEventId.FileSaved,

--- a/libs/backend/src/system_call/export_logs_to_usb.ts
+++ b/libs/backend/src/system_call/export_logs_to_usb.ts
@@ -49,7 +49,7 @@ async function exportLogsToUsbHelper({
   try {
     await execFile('mkdir', ['-p', machineNamePath]);
     await execFile('cp', ['-r', LOG_DIR, destinationDirectory]);
-    await execFile('sync', [status.mountPoint]);
+    await execFile('sync', ['-f', status.mountPoint]);
   } catch {
     return err('copy-failed');
   }

--- a/libs/backend/src/system_call/export_logs_to_usb.ts
+++ b/libs/backend/src/system_call/export_logs_to_usb.ts
@@ -49,6 +49,7 @@ async function exportLogsToUsbHelper({
   try {
     await execFile('mkdir', ['-p', machineNamePath]);
     await execFile('cp', ['-r', LOG_DIR, destinationDirectory]);
+    await execFile('sync', [status.mountPoint]);
   } catch {
     return err('copy-failed');
   }


### PR DESCRIPTION
## Overview

Closes #4685. I have also seen the same issue described in the same ticket when saving logs from `tty2`. I'm not sure what about saving logs is more prone to delays than other things, but in any case we can just run `sync` on the mount point to ensure the save completes before freeing up the modal / indicating the save is complete to the user.

## Testing Plan
- Automated testing confirms we are running `sync`
- I manually confirmed that the export still works after this change, although I'm not able to reproduce the original issue on my dev hardware, so I can't be 100% sure it fixes the issue, just 99% sure

