### PR TITLE
pdi-scanner: Detect disconnect and send event

### DIFF
--- a/libs/pdi-scanner/src/lib.rs
+++ b/libs/pdi-scanner/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod client;
 pub mod protocol;
-mod rusb_async;
+pub mod rusb_async;
 pub mod scanner;
 mod types;
 

--- a/libs/pdi-scanner/src/scanner.rs
+++ b/libs/pdi-scanner/src/scanner.rs
@@ -9,11 +9,7 @@ use std::{
 
 use rusb::UsbContext;
 
-use crate::{
-    protocol::parsers,
-    rusb_async::{self, Error},
-    Result,
-};
+use crate::{protocol::parsers, rusb_async, Result};
 
 use super::protocol::packets::{self, Incoming};
 
@@ -64,7 +60,7 @@ impl Scanner {
     ) -> (
         Sender<(usize, packets::Outgoing)>,
         Receiver<usize>,
-        Receiver<packets::Incoming>,
+        Receiver<Result<packets::Incoming>>,
     ) {
         /// The endpoint for sending commands to the scanner.
         const ENDPOINT_OUT: u8 = 0x05;
@@ -143,7 +139,7 @@ impl Scanner {
                             match parsers::any_incoming(&data) {
                                 Ok(([], packet)) => {
                                     tracing::debug!("Received incoming packet: {packet:?}");
-                                    scanner_to_host_tx.send(packet).unwrap();
+                                    scanner_to_host_tx.send(Ok(packet)).unwrap();
                                 }
                                 Ok((remaining, packet)) => {
                                     tracing::warn!(
@@ -152,7 +148,7 @@ impl Scanner {
                                         remaining = String::from_utf8_lossy(remaining)
                                     );
                                     scanner_to_host_tx
-                                        .send(Incoming::Unknown(data.to_vec()))
+                                        .send(Ok(Incoming::Unknown(data.to_vec())))
                                         .unwrap();
                                 }
                                 Err(err) => {
@@ -161,7 +157,7 @@ impl Scanner {
                                         data = String::from_utf8_lossy(&data)
                                     );
                                     scanner_to_host_tx
-                                        .send(Incoming::Unknown(data.to_vec()))
+                                        .send(Ok(Incoming::Unknown(data.to_vec())))
                                         .unwrap();
                                 }
                             }
@@ -174,9 +170,8 @@ impl Scanner {
                         }
                         Err(rusb_async::Error::PollTimeout) => {}
                         Err(err) => {
-                            if !matches!(err, Error::Cancelled) {
-                                tracing::error!("Error while polling primary IN endpoint: {err}");
-                            }
+                            tracing::error!("Error while polling primary IN endpoint: {err}");
+                            scanner_to_host_tx.send(Err(err.into())).unwrap();
                             break;
                         }
                     }
@@ -187,7 +182,7 @@ impl Scanner {
                         Ok(data) => {
                             tracing::debug!("Received image data: {len} bytes", len = data.len());
                             scanner_to_host_tx
-                                .send(packets::Incoming::ImageData(data.clone()))
+                                .send(Ok(packets::Incoming::ImageData(data.clone())))
                                 .unwrap();
 
                             // resubmit the transfer to receive more data
@@ -197,9 +192,8 @@ impl Scanner {
                         }
                         Err(rusb_async::Error::PollTimeout) => {}
                         Err(err) => {
-                            if !matches!(err, Error::Cancelled) {
-                                tracing::error!("Error while polling image data endpoint: {err}");
-                            }
+                            tracing::error!("Error while polling image data endpoint: {err}");
+                            scanner_to_host_tx.send(Err(err.into())).unwrap();
                             break;
                         }
                     }
@@ -219,7 +213,10 @@ impl Scanner {
     /// dropped.
     pub fn stop(&mut self) {
         if let Some(stop_tx) = self.stop_tx.take() {
-            stop_tx.send(()).unwrap();
+            // send will only error if its receiver has been dropped, which
+            // means the scanner is already cleaned up, so it's safe to ignore
+            // the error here.
+            stop_tx.send(()).ok();
         }
 
         if let Some(thread_handle) = self.thread_handle.take() {

--- a/libs/pdi-scanner/src/scanner.rs
+++ b/libs/pdi-scanner/src/scanner.rs
@@ -216,7 +216,7 @@ impl Scanner {
             // send will only error if its receiver has been dropped, which
             // means the scanner is already cleaned up, so it's safe to ignore
             // the error here.
-            stop_tx.send(()).ok();
+            let _ = stop_tx.send(());
         }
 
         if let Some(thread_handle) = self.thread_handle.take() {


### PR DESCRIPTION


## Overview

Detect when the scanner is disconnected (e.g. unplugged) while polling the scanner for incoming events. This manifests as `rusb_async::Error:Stall`. Propagate this error back up to the main thread and send a disconnect error event to stdout.

We also break from the loop that is detecting events when we receive an error, which causes the scanner_to_host channel to close, so we handle that case in the main thread by dropping the client (allowing the user to reconnect if desired).
## Demo Video or Screenshot
```sh
$ pdictl
# Start with scanner plugged in
{"type":"connect"} # command
{"type":"ok"} # response
# Unplug scanner
{"type":"error","code":"disconnected","message":null} # event
{"type":"connect"} # command
{"type":"error","code":"disconnected","message":null} # response
# Plug scanner back in
{"type":"connect"} # command
{"type":"ok"} # response
```

## Testing Plan
Manual tested `pdictl` as outlined above, testing with state machine


## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
