### PR TITLE
[MarkScan] Post-testing updates to ValidateBallotPage

### DIFF
--- a/apps/mark-scan/frontend/src/app_contest_ms_either_neither.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_ms_either_neither.test.tsx
@@ -116,7 +116,7 @@ test('Renders Ballot with EitherNeither: blank', async () => {
     expect(
       printedElement.getAllByText(
         hasTextAcrossElements(
-          new RegExp(`${eitherNeitherContest.title}.?[no selection]`)
+          new RegExp(`${eitherNeitherContest.title}.?[No Selection]`)
         )
       )
     ).toHaveLength(2);
@@ -148,7 +148,7 @@ test('Renders Ballot with EitherNeither: Either & blank', async () => {
   await expectPrintToPdf((printedElement) => {
     expectPrintedVotes(printedElement, {
       eitherNeither: assertDefined(eitherNeitherContest.yesOption).label,
-      pickOne: '[no selection]',
+      pickOne: '[No Selection]',
     });
   });
 });
@@ -207,7 +207,7 @@ test('Renders Ballot with EitherNeither: blank & secondOption', async () => {
   });
   await expectPrintToPdf((printedElement) => {
     expectPrintedVotes(printedElement, {
-      eitherNeither: '[no selection]',
+      eitherNeither: '[No Selection]',
       pickOne: assertDefined(pickOneContest.noOption).label,
     });
   });

--- a/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
@@ -286,9 +286,7 @@ test('MarkAndPrint end-to-end flow', async () => {
   await screen.findByText('Review Your Votes');
   screen.getByText(countyCommissionersContest.candidates[0].name);
   screen.getByText(countyCommissionersContest.candidates[1].name);
-  screen.getByText(
-    hasTextAcrossElements(/Votes remaining in this contest: 2/i)
-  );
+  screen.getByText(hasTextAcrossElements(/number of unused votes: 2/i));
 
   // Print Screen
   apiMock.expectPrintBallot();

--- a/apps/mark-scan/frontend/src/config/types.ts
+++ b/apps/mark-scan/frontend/src/config/types.ts
@@ -1,27 +1,16 @@
 import {
   BallotStyleId,
-  CandidateContest,
-  CandidateVote,
-  ContestId,
-  Election,
   ElectionDefinition,
-  OptionalVote,
-  OptionalYesNoVote,
   PrecinctId,
   VotesDict,
-  YesNoContest,
 } from '@votingworks/types';
 import type { MachineConfig } from '@votingworks/mark-scan-backend';
 import {
   ContestsWithMsEitherNeither,
-  MsEitherNeitherContest,
+  UpdateVoteFunction,
 } from '@votingworks/mark-flow-ui';
 
 // Ballot
-export type UpdateVoteFunction = (
-  contestId: ContestId,
-  vote: OptionalVote
-) => void;
 export interface BallotContextInterface {
   machineConfig: MachineConfig;
   ballotStyleId?: BallotStyleId;
@@ -35,37 +24,4 @@ export interface BallotContextInterface {
   resetBallot: (showPostVotingInstructions?: boolean) => void;
   updateVote: UpdateVoteFunction;
   votes: VotesDict;
-}
-
-// Review and Printed Ballot
-export interface CandidateContestResultInterface {
-  contest: CandidateContest;
-  election: Election;
-  precinctId: PrecinctId;
-  vote: CandidateVote;
-}
-export interface YesNoContestResultInterface {
-  contest: YesNoContest;
-  election: Election;
-  vote: OptionalYesNoVote;
-}
-export interface MsEitherNeitherContestResultInterface {
-  contest: MsEitherNeitherContest;
-  election: Election;
-  eitherNeitherContestVote: OptionalYesNoVote;
-  pickOneContestVote: OptionalYesNoVote;
-}
-
-export interface PrintOptions extends KioskBrowser.PrintOptions {
-  sides: KioskBrowser.PrintSides;
-}
-
-// User Interface
-export type ScrollDirections = 'up' | 'down';
-export interface ScrollShadows {
-  showBottomShadow: boolean;
-  showTopShadow: boolean;
-}
-export interface Scrollable {
-  isScrollable: boolean;
 }

--- a/apps/mark-scan/frontend/src/pages/validate_ballot_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/validate_ballot_page.tsx
@@ -75,7 +75,6 @@ export function ValidateBallotPage(): JSX.Element | null {
           <Button
             id={PageNavigationButtonId.PREVIOUS}
             variant="danger"
-            icon="Danger"
             onPress={invalidateBallotCallback}
           >
             {appStrings.buttonBallotIsIncorrect()}

--- a/apps/mark-scan/frontend/src/pages/validate_ballot_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/validate_ballot_page.tsx
@@ -102,7 +102,6 @@ export function ValidateBallotPage(): JSX.Element | null {
           precinctId={precinctId}
           votes={votes}
           selectionsAreEditable={false}
-          isInterpretationResult
         />
       </WithScrollButtons>
     </VoterScreen>

--- a/apps/mark-scan/frontend/src/pages/validate_ballot_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/validate_ballot_page.tsx
@@ -102,6 +102,7 @@ export function ValidateBallotPage(): JSX.Element | null {
           precinctId={precinctId}
           votes={votes}
           selectionsAreEditable={false}
+          isInterpretationResult
         />
       </WithScrollButtons>
     </VoterScreen>

--- a/apps/mark/frontend/src/app_contest_ms_either_neither.test.tsx
+++ b/apps/mark/frontend/src/app_contest_ms_either_neither.test.tsx
@@ -110,7 +110,7 @@ test('Renders Ballot with EitherNeither: blank', async () => {
     expect(
       printedElement.getAllByText(
         hasTextAcrossElements(
-          new RegExp(`${eitherNeitherContest.title}.?[no selection]`)
+          new RegExp(`${eitherNeitherContest.title}.?[No Selection]`)
         )
       )
     ).toHaveLength(2);
@@ -140,7 +140,7 @@ test('Renders Ballot with EitherNeither: Either & blank', async () => {
   await expectPrint((printedElement) => {
     expectPrintedVotes(printedElement, {
       eitherNeither: assertDefined(eitherNeitherContest.yesOption).label,
-      pickOne: '[no selection]',
+      pickOne: '[No Selection]',
     });
   });
 });
@@ -195,7 +195,7 @@ test('Renders Ballot with EitherNeither: blank & secondOption', async () => {
   });
   await expectPrint((printedElement) => {
     expectPrintedVotes(printedElement, {
-      eitherNeither: '[no selection]',
+      eitherNeither: '[No selection]',
       pickOne: assertDefined(pickOneContest.noOption).label,
     });
   });

--- a/apps/mark/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark/frontend/src/app_end_to_end.test.tsx
@@ -287,9 +287,7 @@ test('MarkAndPrint end-to-end flow', async () => {
   await screen.findByText('Review Your Votes');
   screen.getByText(countyCommissionersContest.candidates[0].name);
   screen.getByText(countyCommissionersContest.candidates[1].name);
-  screen.getByText(
-    hasTextAcrossElements(/Votes remaining in this contest: 2/i)
-  );
+  screen.getByText(hasTextAcrossElements(/number of unused votes: 2/i));
 
   // Print Screen
   apiMock.expectIncrementBallotsPrintedCount();

--- a/apps/mark/frontend/src/config/types.ts
+++ b/apps/mark/frontend/src/config/types.ts
@@ -1,27 +1,16 @@
 import {
   BallotStyleId,
-  CandidateContest,
-  CandidateVote,
-  ContestId,
-  Election,
   ElectionDefinition,
-  OptionalVote,
-  OptionalYesNoVote,
   PrecinctId,
   VotesDict,
-  YesNoContest,
 } from '@votingworks/types';
 import type { MachineConfig } from '@votingworks/mark-backend';
 import {
   ContestsWithMsEitherNeither,
-  MsEitherNeitherContest,
+  UpdateVoteFunction,
 } from '@votingworks/mark-flow-ui';
 
 // Ballot
-export type UpdateVoteFunction = (
-  contestId: ContestId,
-  vote: OptionalVote
-) => void;
 export interface BallotContextInterface {
   machineConfig: MachineConfig;
   ballotStyleId?: BallotStyleId;
@@ -36,37 +25,4 @@ export interface BallotContextInterface {
   updateTally: () => void;
   updateVote: UpdateVoteFunction;
   votes: VotesDict;
-}
-
-// Review and Printed Ballot
-export interface CandidateContestResultInterface {
-  contest: CandidateContest;
-  election: Election;
-  precinctId: PrecinctId;
-  vote: CandidateVote;
-}
-export interface YesNoContestResultInterface {
-  contest: YesNoContest;
-  election: Election;
-  vote: OptionalYesNoVote;
-}
-export interface MsEitherNeitherContestResultInterface {
-  contest: MsEitherNeitherContest;
-  election: Election;
-  eitherNeitherContestVote: OptionalYesNoVote;
-  pickOneContestVote: OptionalYesNoVote;
-}
-
-export interface PrintOptions extends KioskBrowser.PrintOptions {
-  sides: KioskBrowser.PrintSides;
-}
-
-// User Interface
-export type ScrollDirections = 'up' | 'down';
-export interface ScrollShadows {
-  showBottomShadow: boolean;
-  showTopShadow: boolean;
-}
-export interface Scrollable {
-  isScrollable: boolean;
 }

--- a/libs/mark-flow-ui/src/components/review.test.tsx
+++ b/libs/mark-flow-ui/src/components/review.test.tsx
@@ -56,7 +56,7 @@ test('candidate contest interpretation result with no votes', () => {
     <Review
       contests={[contest]}
       election={electionGeneral}
-      isInterpretationResult
+      selectionsAreEditable={false}
       precinctId={electionGeneral.precincts[0].id}
       returnToContest={jest.fn()}
       votes={{}}
@@ -157,7 +157,7 @@ describe('yesno contest', () => {
       <Review
         election={electionGeneral}
         contests={[contest]}
-        isInterpretationResult
+        selectionsAreEditable={false}
         precinctId={electionGeneral.precincts[0].id}
         returnToContest={jest.fn()}
         votes={{}}
@@ -238,7 +238,7 @@ describe('ms-either-neither contest', () => {
       <Review
         contests={[mergedContest]}
         election={electionDefinition.election}
-        isInterpretationResult
+        selectionsAreEditable={false}
         precinctId={electionDefinition.election.precincts[0].id}
         returnToContest={jest.fn()}
         votes={{}}

--- a/libs/mark-flow-ui/src/components/review.test.tsx
+++ b/libs/mark-flow-ui/src/components/review.test.tsx
@@ -46,6 +46,28 @@ test('candidate contest with no votes', () => {
   expect(screen.getByText('You may still vote in this contest.')).toBeTruthy();
 });
 
+test('candidate contest interpretation result with no votes', () => {
+  const contest = find(
+    electionGeneral.contests,
+    (c): c is CandidateContest => c.type === 'candidate'
+  );
+
+  render(
+    <Review
+      contests={[contest]}
+      election={electionGeneral}
+      isInterpretationResult
+      precinctId={electionGeneral.precincts[0].id}
+      returnToContest={jest.fn()}
+      votes={{}}
+    />
+  );
+
+  within(screen.getByTestId(`contest-wrapper-${contest.id}`)).getByText(
+    'no selection'
+  );
+});
+
 test('candidate contest with votes but still undervoted', () => {
   const contest: CandidateContest = {
     ...find(
@@ -68,9 +90,7 @@ test('candidate contest with votes but still undervoted', () => {
     />
   );
 
-  screen.getByText(
-    hasTextAcrossElements(/votes remaining in this contest: 2/i)
-  );
+  screen.getByText(hasTextAcrossElements(/number of unused votes: 2/i));
 });
 
 test('candidate contest fully voted', () => {
@@ -131,6 +151,23 @@ describe('yesno contest', () => {
       expect(returnToContest).toHaveBeenCalledWith(contest.id);
     }
   );
+
+  test('empty vote interpretation result', () => {
+    render(
+      <Review
+        election={electionGeneral}
+        contests={[contest]}
+        isInterpretationResult
+        precinctId={electionGeneral.precincts[0].id}
+        returnToContest={jest.fn()}
+        votes={{}}
+      />
+    );
+
+    within(screen.getByTestId(`contest-wrapper-${contest.id}`)).getByText(
+      'no selection'
+    );
+  });
 });
 
 describe('ms-either-neither contest', () => {
@@ -149,6 +186,7 @@ describe('ms-either-neither contest', () => {
   const contests = mergeMsEitherNeitherContests(
     electionDefinition.election.contests
   );
+  const mergedContest = find(contests, (c) => c.type === 'ms-either-neither');
 
   test.each([
     [eitherNeitherContest.yesOption.id, pickOneContest.yesOption.id],
@@ -171,7 +209,6 @@ describe('ms-either-neither contest', () => {
       />
     );
 
-    const mergedContest = find(contests, (c) => c.type === 'ms-either-neither');
     const contestVoteSummary = within(
       screen.getByTestId(`contest-${mergedContest.id}`)
     );
@@ -194,6 +231,23 @@ describe('ms-either-neither contest', () => {
     if (!eitherNeitherVote || !pickOneVote) {
       contestVoteSummary.getByText('You may still vote in this contest.');
     }
+  });
+
+  test('empty vote in interpretation result', () => {
+    render(
+      <Review
+        contests={[mergedContest]}
+        election={electionDefinition.election}
+        isInterpretationResult
+        precinctId={electionDefinition.election.precincts[0].id}
+        returnToContest={jest.fn()}
+        votes={{}}
+      />
+    );
+
+    within(screen.getByTestId(`contest-${mergedContest.id}`)).getByText(
+      'no selection'
+    );
   });
 });
 

--- a/libs/mark-flow-ui/src/components/review.test.tsx
+++ b/libs/mark-flow-ui/src/components/review.test.tsx
@@ -64,7 +64,7 @@ test('candidate contest interpretation result with no votes', () => {
   );
 
   within(screen.getByTestId(`contest-wrapper-${contest.id}`)).getByText(
-    'no selection'
+    /no selection/i
   );
 });
 
@@ -165,7 +165,7 @@ describe('yesno contest', () => {
     );
 
     within(screen.getByTestId(`contest-wrapper-${contest.id}`)).getByText(
-      'no selection'
+      /no selection/i
     );
   });
 });
@@ -246,7 +246,7 @@ describe('ms-either-neither contest', () => {
     );
 
     within(screen.getByTestId(`contest-${mergedContest.id}`)).getByText(
-      'no selection'
+      /no selection/i
     );
   });
 });

--- a/libs/mark-flow-ui/src/components/review.tsx
+++ b/libs/mark-flow-ui/src/components/review.tsx
@@ -53,9 +53,14 @@ function CandidateContestResult({
   contest,
   vote = [],
   election,
+  isInterpretationResult,
 }: CandidateContestResultInterface): JSX.Element {
   const district = getContestDistrict(election, contest);
   const remainingChoices = contest.seats - vote.length;
+
+  const noVotesString = isInterpretationResult
+    ? appStrings.noteBallotContestNoSelection()
+    : appStrings.warningNoVotesForContest();
 
   return (
     <VoterContestSummary
@@ -65,10 +70,10 @@ function CandidateContestResult({
       undervoteWarning={
         remainingChoices > 0 ? (
           vote.length === 0 ? (
-            appStrings.warningNoVotesForContest()
+            noVotesString
           ) : (
             <React.Fragment>
-              {appStrings.labelNumVotesRemaining()}{' '}
+              {appStrings.labelNumVotesUnused()}{' '}
               <NumberString value={remainingChoices} />
             </React.Fragment>
           )
@@ -96,6 +101,7 @@ function YesNoContestResult({
   vote,
   contest,
   election,
+  isInterpretationResult,
 }: YesNoContestResultInterface): JSX.Element {
   const district = getContestDistrict(election, contest);
   const yesNo = getSingleYesNoVote(vote);
@@ -111,14 +117,16 @@ function YesNoContestResult({
       ]
     : [];
 
+  const noVotesString = isInterpretationResult
+    ? appStrings.noteBallotContestNoSelection()
+    : appStrings.warningNoVotesForContest();
+
   return (
     <VoterContestSummary
       districtName={electionStrings.districtName(district)}
       title={electionStrings.contestTitle(contest)}
       titleType="h2"
-      undervoteWarning={
-        !yesNo ? appStrings.warningNoVotesForContest() : undefined
-      }
+      undervoteWarning={!yesNo ? noVotesString : undefined}
       votes={votes}
     />
   );
@@ -129,6 +137,7 @@ function MsEitherNeitherContestResult({
   election,
   eitherNeitherContestVote,
   pickOneContestVote,
+  isInterpretationResult,
 }: MsEitherNeitherContestResultInterface): JSX.Element {
   const district = getContestDistrict(election, contest);
   /* istanbul ignore next */
@@ -158,15 +167,17 @@ function MsEitherNeitherContestResult({
     });
   }
 
+  const noVotesString = isInterpretationResult
+    ? appStrings.noteBallotContestNoSelection()
+    : appStrings.warningNoVotesForContest();
+
   return (
     <VoterContestSummary
       data-testid={`contest-${contest.id}`}
       districtName={electionStrings.districtName(district)}
       title={electionStrings.contestTitle(contest)}
       titleType="h2"
-      undervoteWarning={
-        votes.length < 2 ? appStrings.warningNoVotesForContest() : undefined
-      }
+      undervoteWarning={votes.length < 2 ? noVotesString : undefined}
       votes={votes}
     />
   );
@@ -179,6 +190,7 @@ export interface ReviewProps {
   votes: VotesDict;
   returnToContest?: (contestId: string) => void;
   selectionsAreEditable?: boolean;
+  isInterpretationResult?: boolean;
 }
 
 export function Review({
@@ -188,6 +200,7 @@ export function Review({
   votes,
   returnToContest,
   selectionsAreEditable = true,
+  isInterpretationResult,
 }: ReviewProps): JSX.Element {
   function onChangeClick(contestId: ContestId) {
     if (!returnToContest) {
@@ -235,6 +248,7 @@ export function Review({
               <CandidateContestResult
                 contest={contest}
                 election={election}
+                isInterpretationResult={isInterpretationResult}
                 precinctId={precinctId}
                 vote={votes[contest.id] as CandidateVote}
               />
@@ -244,6 +258,7 @@ export function Review({
                 vote={votes[contest.id] as YesNoVote}
                 contest={contest}
                 election={election}
+                isInterpretationResult={isInterpretationResult}
               />
             )}
             {contest.type === 'ms-either-neither' && (
@@ -253,6 +268,7 @@ export function Review({
                 eitherNeitherContestVote={
                   votes[contest.eitherNeitherContestId] as OptionalYesNoVote
                 }
+                isInterpretationResult={isInterpretationResult}
                 pickOneContestVote={
                   votes[contest.pickOneContestId] as OptionalYesNoVote
                 }

--- a/libs/mark-flow-ui/src/components/review.tsx
+++ b/libs/mark-flow-ui/src/components/review.tsx
@@ -53,14 +53,14 @@ function CandidateContestResult({
   contest,
   vote = [],
   election,
-  isInterpretationResult,
+  selectionsAreEditable,
 }: CandidateContestResultInterface): JSX.Element {
   const district = getContestDistrict(election, contest);
   const remainingChoices = contest.seats - vote.length;
 
-  const noVotesString = isInterpretationResult
-    ? appStrings.noteBallotContestNoSelection()
-    : appStrings.warningNoVotesForContest();
+  const noVotesString = selectionsAreEditable
+    ? appStrings.warningNoVotesForContest()
+    : appStrings.noteBallotContestNoSelection();
 
   return (
     <VoterContestSummary
@@ -101,7 +101,7 @@ function YesNoContestResult({
   vote,
   contest,
   election,
-  isInterpretationResult,
+  selectionsAreEditable,
 }: YesNoContestResultInterface): JSX.Element {
   const district = getContestDistrict(election, contest);
   const yesNo = getSingleYesNoVote(vote);
@@ -117,9 +117,9 @@ function YesNoContestResult({
       ]
     : [];
 
-  const noVotesString = isInterpretationResult
-    ? appStrings.noteBallotContestNoSelection()
-    : appStrings.warningNoVotesForContest();
+  const noVotesString = selectionsAreEditable
+    ? appStrings.warningNoVotesForContest()
+    : appStrings.noteBallotContestNoSelection();
 
   return (
     <VoterContestSummary
@@ -137,7 +137,7 @@ function MsEitherNeitherContestResult({
   election,
   eitherNeitherContestVote,
   pickOneContestVote,
-  isInterpretationResult,
+  selectionsAreEditable,
 }: MsEitherNeitherContestResultInterface): JSX.Element {
   const district = getContestDistrict(election, contest);
   /* istanbul ignore next */
@@ -167,9 +167,9 @@ function MsEitherNeitherContestResult({
     });
   }
 
-  const noVotesString = isInterpretationResult
-    ? appStrings.noteBallotContestNoSelection()
-    : appStrings.warningNoVotesForContest();
+  const noVotesString = selectionsAreEditable
+    ? appStrings.warningNoVotesForContest()
+    : appStrings.noteBallotContestNoSelection();
 
   return (
     <VoterContestSummary
@@ -190,7 +190,6 @@ export interface ReviewProps {
   votes: VotesDict;
   returnToContest?: (contestId: string) => void;
   selectionsAreEditable?: boolean;
-  isInterpretationResult?: boolean;
 }
 
 export function Review({
@@ -200,7 +199,6 @@ export function Review({
   votes,
   returnToContest,
   selectionsAreEditable = true,
-  isInterpretationResult,
 }: ReviewProps): JSX.Element {
   function onChangeClick(contestId: ContestId) {
     if (!returnToContest) {
@@ -248,7 +246,7 @@ export function Review({
               <CandidateContestResult
                 contest={contest}
                 election={election}
-                isInterpretationResult={isInterpretationResult}
+                selectionsAreEditable={selectionsAreEditable}
                 precinctId={precinctId}
                 vote={votes[contest.id] as CandidateVote}
               />
@@ -258,7 +256,7 @@ export function Review({
                 vote={votes[contest.id] as YesNoVote}
                 contest={contest}
                 election={election}
-                isInterpretationResult={isInterpretationResult}
+                selectionsAreEditable={selectionsAreEditable}
               />
             )}
             {contest.type === 'ms-either-neither' && (
@@ -268,7 +266,7 @@ export function Review({
                 eitherNeitherContestVote={
                   votes[contest.eitherNeitherContestId] as OptionalYesNoVote
                 }
-                isInterpretationResult={isInterpretationResult}
+                selectionsAreEditable={selectionsAreEditable}
                 pickOneContestVote={
                   votes[contest.pickOneContestId] as OptionalYesNoVote
                 }

--- a/libs/mark-flow-ui/src/config/types.ts
+++ b/libs/mark-flow-ui/src/config/types.ts
@@ -42,18 +42,21 @@ export interface BallotContextInterface {
 export interface CandidateContestResultInterface {
   contest: CandidateContest;
   election: Election;
+  isInterpretationResult?: boolean;
   precinctId: PrecinctId;
   vote: CandidateVote;
 }
 export interface YesNoContestResultInterface {
   contest: YesNoContest;
   election: Election;
+  isInterpretationResult?: boolean;
   vote: OptionalYesNoVote;
 }
 export interface MsEitherNeitherContestResultInterface {
   contest: MsEitherNeitherContest;
   election: Election;
   eitherNeitherContestVote: OptionalYesNoVote;
+  isInterpretationResult?: boolean;
   pickOneContestVote: OptionalYesNoVote;
 }
 

--- a/libs/mark-flow-ui/src/config/types.ts
+++ b/libs/mark-flow-ui/src/config/types.ts
@@ -42,22 +42,22 @@ export interface BallotContextInterface {
 export interface CandidateContestResultInterface {
   contest: CandidateContest;
   election: Election;
-  isInterpretationResult?: boolean;
   precinctId: PrecinctId;
+  selectionsAreEditable?: boolean;
   vote: CandidateVote;
 }
 export interface YesNoContestResultInterface {
   contest: YesNoContest;
   election: Election;
-  isInterpretationResult?: boolean;
   vote: OptionalYesNoVote;
+  selectionsAreEditable?: boolean;
 }
 export interface MsEitherNeitherContestResultInterface {
   contest: MsEitherNeitherContest;
   election: Election;
   eitherNeitherContestVote: OptionalYesNoVote;
-  isInterpretationResult?: boolean;
   pickOneContestVote: OptionalYesNoVote;
+  selectionsAreEditable?: boolean;
 }
 
 // Machine Config

--- a/libs/mark-flow-ui/src/pages/__snapshots__/print_page.test.tsx.snap
+++ b/libs/mark-flow-ui/src/pages/__snapshots__/print_page.test.tsx.snap
@@ -388,7 +388,7 @@ exports[`no votes 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -416,7 +416,7 @@ exports[`no votes 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -444,7 +444,7 @@ exports[`no votes 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -472,7 +472,7 @@ exports[`no votes 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -500,7 +500,7 @@ exports[`no votes 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -528,7 +528,7 @@ exports[`no votes 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -556,7 +556,7 @@ exports[`no votes 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -584,7 +584,7 @@ exports[`no votes 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -612,7 +612,7 @@ exports[`no votes 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -640,7 +640,7 @@ exports[`no votes 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -668,7 +668,7 @@ exports[`no votes 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -1105,7 +1105,7 @@ exports[`with votes 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -1163,7 +1163,7 @@ exports[`with votes 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -1191,7 +1191,7 @@ exports[`with votes 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -1219,7 +1219,7 @@ exports[`with votes 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -1247,7 +1247,7 @@ exports[`with votes 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -1327,7 +1327,7 @@ exports[`with votes 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -1355,7 +1355,7 @@ exports[`with votes 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -1755,7 +1755,7 @@ exports[`without votes and inline seal 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -1783,7 +1783,7 @@ exports[`without votes and inline seal 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -1811,7 +1811,7 @@ exports[`without votes and inline seal 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -1839,7 +1839,7 @@ exports[`without votes and inline seal 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -1867,7 +1867,7 @@ exports[`without votes and inline seal 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -1895,7 +1895,7 @@ exports[`without votes and inline seal 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -1923,7 +1923,7 @@ exports[`without votes and inline seal 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -1951,7 +1951,7 @@ exports[`without votes and inline seal 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -1979,7 +1979,7 @@ exports[`without votes and inline seal 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -2007,7 +2007,7 @@ exports[`without votes and inline seal 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -2035,7 +2035,7 @@ exports[`without votes and inline seal 1`] = `
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>

--- a/libs/ui/src/__snapshots__/bmd_paper_ballot.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/bmd_paper_ballot.test.tsx.snap
@@ -420,7 +420,7 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -478,7 +478,7 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -506,7 +506,7 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -534,7 +534,7 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -562,7 +562,7 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -642,7 +642,7 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>
@@ -670,7 +670,7 @@ exports[`BmdPaperBallot renders votes for candidate contests and yes-no contests
             >
               [
               <span>
-                no selection
+                No Selection
               </span>
               ]
             </span>

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -738,7 +738,7 @@ export const appStrings = {
   ),
 
   noteBallotContestNoSelection: () => (
-    <UiString uiStringKey="noteBallotContestNoSelection">no selection</UiString>
+    <UiString uiStringKey="noteBallotContestNoSelection">No Selection</UiString>
   ),
 
   noteBmdBallotSheetLoaded: () => (

--- a/libs/ui/src/ui_strings/app_strings_catalog/latest.json
+++ b/libs/ui/src/ui_strings/app_strings_catalog/latest.json
@@ -153,7 +153,7 @@
   "letterY": "Y",
   "letterZ": "Z",
   "noteAskPollWorkerForHelp": "Ask a poll worker if you need help.",
-  "noteBallotContestNoSelection": "no selection",
+  "noteBallotContestNoSelection": "No Selection",
   "noteBmdBallotBoxIsFull": "A poll worker must empty the full ballot box.",
   "noteBmdBallotSheetLoaded": "The ballot sheet has been loaded. You will have a chance to review your selections before reprinting your ballot.",
   "noteBmdCastingBallot": "Casting Ballot...",


### PR DESCRIPTION
## Overview

Related to: https://github.com/votingworks/vxsuite/issues/4762

Addressing a couple issues found on the `ValidateBallotPage` during testing:
- Removing the icon from the `My Ballot is Incorrect` button to avoid wrapping in the default size mode.
- Updating the wording of the undervote warnings to match the strings used on the printed paper ballot, for consistency.
  - Leaving the `You may still vote in this contest` wording intact for the pre-print review screen, but updating `Votes remaining in this contest:` to `Number of unused votes:` there as well, since it's semantically similar and avoids unnecessary branching in the code.

## Demo Video or Screenshot

| Before  | After |
| ------------- | ------------- |
| <img width="512" alt="Screenshot 2024-04-18 at 13 32 12" src="https://github.com/votingworks/vxsuite/assets/264902/49e6945e-46d7-41d0-a3a5-e80d8f323155"> | <img width="511" alt="Screenshot 2024-04-18 at 13 45 47" src="https://github.com/votingworks/vxsuite/assets/264902/378c05eb-4c18-481c-b173-81761a0de4cf"> |
| <img width="512" alt="Screenshot 2024-04-18 at 13 46 57" src="https://github.com/votingworks/vxsuite/assets/264902/48465eaa-a337-419a-9c93-05c0760c1f21"> | <img width="510" alt="Screenshot 2024-04-18 at 13 47 52" src="https://github.com/votingworks/vxsuite/assets/264902/dae10016-364e-49e9-a7f3-a23137a9640e"> |

## Testing Plan
- New and updated unit tests
- Manual test to verify strings and audio

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
