### PR TITLE
chore: remove unused deps

### DIFF
--- a/libs/ballot-encoder/package.json
+++ b/libs/ballot-encoder/package.json
@@ -31,12 +31,9 @@
     ]
   },
   "dependencies": {
-    "@antongolub/iso8601": "^1.2.1",
     "@votingworks/basics": "workspace:*",
     "@votingworks/types": "workspace:*",
-    "@votingworks/utils": "workspace:*",
-    "js-sha256": "^0.9.0",
-    "zod": "3.14.4"
+    "js-sha256": "^0.9.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.3",

--- a/libs/ballot-encoder/tsconfig.build.json
+++ b/libs/ballot-encoder/tsconfig.build.json
@@ -12,7 +12,6 @@
     { "path": "../basics/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../fixtures/tsconfig.build.json" },
-    { "path": "../types/tsconfig.build.json" },
-    { "path": "../utils/tsconfig.build.json" }
+    { "path": "../types/tsconfig.build.json" }
   ]
 }

--- a/libs/ballot-encoder/tsconfig.json
+++ b/libs/ballot-encoder/tsconfig.json
@@ -17,7 +17,6 @@
     { "path": "../basics/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../fixtures/tsconfig.build.json" },
-    { "path": "../types/tsconfig.build.json" },
-    { "path": "../utils/tsconfig.build.json" }
+    { "path": "../types/tsconfig.build.json" }
   ]
 }

--- a/libs/custom-scanner/package.json
+++ b/libs/custom-scanner/package.json
@@ -27,8 +27,7 @@
     "buffer": "^6.0.3",
     "chalk": "4.1.2",
     "debug": "4.3.4",
-    "usb": "^2.6.0",
-    "zod": "3.14.4"
+    "usb": "^2.6.0"
   },
   "devDependencies": {
     "@types/debug": "4.1.8",

--- a/libs/fujitsu-thermal-printer/package.json
+++ b/libs/fujitsu-thermal-printer/package.json
@@ -23,27 +23,21 @@
     "@votingworks/image-utils": "workspace:*",
     "@votingworks/message-coder": "workspace:*",
     "@votingworks/types": "workspace:*",
-    "@votingworks/utils": "workspace:*",
     "buffer": "^6.0.3",
     "debug": "4.3.4",
-    "tmp": "^0.2.1",
     "tmp-promise": "^3.0.3",
-    "usb": "^2.6.0",
-    "wait-for-expect": "^3.0.2"
+    "usb": "^2.6.0"
   },
   "devDependencies": {
     "@types/debug": "4.1.8",
     "@types/jest": "^29.5.3",
     "@types/node": "16.18.23",
-    "@types/w3c-web-usb": "^1.0.6",
-    "@votingworks/test-utils": "workspace:*",
     "esbuild": "0.17.11",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "2.2.0",
     "jest": "^29.6.2",
     "jest-junit": "^16.0.0",
-    "jest-mock-extended": "^3.0.4",
     "jest-watch-typeahead": "^2.2.2",
     "ts-jest": "29.1.1"
   },

--- a/libs/fujitsu-thermal-printer/tsconfig.build.json
+++ b/libs/fujitsu-thermal-printer/tsconfig.build.json
@@ -14,7 +14,6 @@
     { "path": "../../libs/message-coder/tsconfig.build.json" },
     { "path": "../../libs/image-utils/tsconfig.build.json" },
     { "path": "../../libs/test-utils/tsconfig.build.json" },
-    { "path": "../../libs/types/tsconfig.build.json" },
-    { "path": "../../libs/utils/tsconfig.build.json" }
+    { "path": "../../libs/types/tsconfig.build.json" }
   ]
 }

--- a/libs/fujitsu-thermal-printer/tsconfig.json
+++ b/libs/fujitsu-thermal-printer/tsconfig.json
@@ -20,7 +20,6 @@
     { "path": "../../libs/message-coder/tsconfig.build.json" },
     { "path": "../../libs/image-utils/tsconfig.build.json" },
     { "path": "../../libs/test-utils/tsconfig.build.json" },
-    { "path": "../../libs/types/tsconfig.build.json" },
-    { "path": "../../libs/utils/tsconfig.build.json" }
+    { "path": "../../libs/types/tsconfig.build.json" }
   ]
 }

--- a/libs/logging/package.json
+++ b/libs/logging/package.json
@@ -51,7 +51,6 @@
   },
   "devDependencies": {
     "@types/debug": "4.1.8",
-    "@types/fs-extra": "11.0.1",
     "@types/jest": "^29.5.3",
     "@types/kiosk-browser": "workspace:*",
     "@types/node": "16.18.23",
@@ -62,7 +61,6 @@
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",
     "fast-check": "2.23.2",
-    "fs-extra": "11.1.1",
     "is-ci-cli": "2.2.0",
     "jest": "^29.6.2",
     "jest-junit": "^16.0.0",

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -74,8 +74,7 @@
     "react-router-dom": "^5.3.4",
     "react-select": "^5.7.4",
     "tone": "^14.7.77",
-    "use-interval": "1.4.0",
-    "zod": "3.14.4"
+    "use-interval": "1.4.0"
   },
   "devDependencies": {
     "@storybook/cli": "^7.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3143,24 +3143,15 @@ importers:
 
   libs/ballot-encoder:
     dependencies:
-      '@antongolub/iso8601':
-        specifier: ^1.2.1
-        version: 1.2.1
       '@votingworks/basics':
         specifier: workspace:*
         version: link:../basics
       '@votingworks/types':
         specifier: workspace:*
         version: link:../types
-      '@votingworks/utils':
-        specifier: workspace:*
-        version: link:../utils
       js-sha256:
         specifier: ^0.9.0
         version: 0.9.0
-      zod:
-        specifier: 3.14.4
-        version: 3.14.4
     devDependencies:
       '@types/jest':
         specifier: ^29.5.3
@@ -3629,9 +3620,6 @@ importers:
       usb:
         specifier: ^2.6.0
         version: 2.8.3
-      zod:
-        specifier: 3.14.4
-        version: 3.14.4
     devDependencies:
       '@types/debug':
         specifier: 4.1.8
@@ -4225,27 +4213,18 @@ importers:
       '@votingworks/types':
         specifier: workspace:*
         version: link:../types
-      '@votingworks/utils':
-        specifier: workspace:*
-        version: link:../utils
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
       debug:
         specifier: 4.3.4
         version: 4.3.4(supports-color@5.5.0)
-      tmp:
-        specifier: ^0.2.1
-        version: 0.2.1
       tmp-promise:
         specifier: ^3.0.3
         version: 3.0.3
       usb:
         specifier: ^2.6.0
         version: 2.8.3
-      wait-for-expect:
-        specifier: ^3.0.2
-        version: 3.0.2
     devDependencies:
       '@types/debug':
         specifier: 4.1.8
@@ -4256,12 +4235,6 @@ importers:
       '@types/node':
         specifier: 16.18.23
         version: 16.18.23
-      '@types/w3c-web-usb':
-        specifier: ^1.0.6
-        version: 1.0.6
-      '@votingworks/test-utils':
-        specifier: workspace:*
-        version: link:../test-utils
       esbuild:
         specifier: 0.17.11
         version: 0.17.11
@@ -4280,9 +4253,6 @@ importers:
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
-      jest-mock-extended:
-        specifier: ^3.0.4
-        version: 3.0.4(jest@29.6.2)(typescript@5.2.2)
       jest-watch-typeahead:
         specifier: ^2.2.2
         version: 2.2.2(jest@29.6.2)
@@ -4721,9 +4691,6 @@ importers:
       '@types/debug':
         specifier: 4.1.8
         version: 4.1.8
-      '@types/fs-extra':
-        specifier: 11.0.1
-        version: 11.0.1
       '@types/jest':
         specifier: ^29.5.3
         version: 29.5.3
@@ -4754,9 +4721,6 @@ importers:
       fast-check:
         specifier: 2.23.2
         version: 2.23.2
-      fs-extra:
-        specifier: 11.1.1
-        version: 11.1.1
       is-ci-cli:
         specifier: 2.2.0
         version: 2.2.0
@@ -5583,9 +5547,6 @@ importers:
       use-interval:
         specifier: 1.4.0
         version: 1.4.0(react@18.2.0)
-      zod:
-        specifier: 3.14.4
-        version: 3.14.4
     devDependencies:
       '@storybook/cli':
         specifier: ^7.2.2


### PR DESCRIPTION
## Overview
Mostly removes `zod` from a number of packages, but also a couple others plus some intra-monorepo deps.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated tests.