### PR TITLE
[MarkScan] Remove unused "Reset Accessible Controller" poll worker action

### DIFF
--- a/apps/mark-scan/frontend/src/apimachine_config.test.tsx
+++ b/apps/mark-scan/frontend/src/apimachine_config.test.tsx
@@ -27,7 +27,7 @@ test('machineConfig is fetched from api client by default', async () => {
   apiMock.expectGetElectionState({
     precinctSelection: ALL_PRECINCTS_SELECTION,
   });
-  render(<App reload={jest.fn()} apiClient={apiMock.mockApiClient} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
   await advanceTimersAndPromises();
   apiMock.setAuthStatusPollWorkerLoggedIn(
     electionFamousNames2021Fixtures.electionDefinition

--- a/apps/mark-scan/frontend/src/app.tsx
+++ b/apps/mark-scan/frontend/src/app.tsx
@@ -23,7 +23,6 @@ const DEFAULT_SCREEN_TYPE: ScreenType = 'elo15';
 const DEFAULT_SIZE_MODE: SizeMode = 'touchMedium';
 
 export interface Props {
-  reload?: VoidFunction;
   logger?: BaseLogger;
   apiClient?: ApiClient;
   queryClient?: QueryClient;
@@ -35,7 +34,6 @@ const RESTART_MESSAGE =
   'Ask a poll worker to restart the ballot marking device.';
 
 export function App({
-  reload = () => window.location.reload(),
   logger = new BaseLogger(LogSource.VxMarkScanFrontend, window.kiosk),
   /* istanbul ignore next */ apiClient = createApiClient(),
   queryClient = createQueryClient(),
@@ -62,7 +60,7 @@ export function App({
               logger={logger}
             >
               <VisualModeDisabledOverlay />
-              <AppRoot reload={reload} />
+              <AppRoot />
               <SessionTimeLimitTracker />
             </AppErrorBoundary>
           </ApiProvider>

--- a/apps/mark-scan/frontend/src/app_card_unhappy_paths.test.tsx
+++ b/apps/mark-scan/frontend/src/app_card_unhappy_paths.test.tsx
@@ -28,7 +28,7 @@ test('Shows card backwards screen when card connection error occurs', async () =
     pollsState: 'polls_open',
   });
 
-  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
   await screen.findByText('Insert Card');
 
   apiMock.setAuthStatus({

--- a/apps/mark-scan/frontend/src/app_cardless_voting.test.tsx
+++ b/apps/mark-scan/frontend/src/app_cardless_voting.test.tsx
@@ -71,7 +71,7 @@ test('Cardless Voting Flow', async () => {
     precinctSelection: CENTER_SPRINGFIELD_PRECINCT_SELECTION,
     pollsState: 'polls_open',
   });
-  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
   const findByTextWithMarkup = withMarkup(screen.findByText);
 
   await screen.findByText('Insert Card');
@@ -225,7 +225,7 @@ test('in "All Precincts" mode, poll worker must select a precinct first', async 
     precinctSelection: ALL_PRECINCTS_SELECTION,
     pollsState: 'polls_open',
   });
-  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
 
   await screen.findByText('Insert Card');
 

--- a/apps/mark-scan/frontend/src/app_contest_candidate_no_party.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_candidate_no_party.test.tsx
@@ -58,7 +58,7 @@ it('Single Seat Contest', async () => {
     pollsState: 'polls_open',
   });
 
-  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
   await advanceTimersAndPromises();
 
   // Start voter session

--- a/apps/mark-scan/frontend/src/app_contest_ms_either_neither.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_ms_either_neither.test.tsx
@@ -224,7 +224,7 @@ test('Can vote on a Mississippi Either Neither Contest', async () => {
     pollsState: 'polls_open',
   });
 
-  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
 
   // Start voter session
   apiMock.setAuthStatusCardlessVoterLoggedIn({

--- a/apps/mark-scan/frontend/src/app_contest_multi_seat.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_multi_seat.test.tsx
@@ -39,7 +39,7 @@ it('Single Seat Contest', async () => {
     pollsState: 'polls_open',
   });
 
-  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
   await advanceTimersAndPromises();
 
   // Start voter session

--- a/apps/mark-scan/frontend/src/app_contest_single_seat.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_single_seat.test.tsx
@@ -41,7 +41,7 @@ it('Single Seat Contest', async () => {
     pollsState: 'polls_open',
   });
 
-  render(<App reload={jest.fn()} apiClient={apiMock.mockApiClient} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
   await advanceTimersAndPromises();
 
   // Start voter session

--- a/apps/mark-scan/frontend/src/app_contest_write_in.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_write_in.test.tsx
@@ -98,7 +98,7 @@ it('Single Seat Contest with Write In', async () => {
   const { fireUpdateVoteEvent, getLatestVotes, goToReviewPage } =
     setUpMockContestPage();
 
-  const app = <App apiClient={apiMock.mockApiClient} reload={jest.fn()} />;
+  const app = <App apiClient={apiMock.mockApiClient} />;
   const { rerender } = render(app);
 
   // Start voter session

--- a/apps/mark-scan/frontend/src/app_contest_yes_no.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_yes_no.test.tsx
@@ -46,7 +46,7 @@ it('Single Seat Contest', async () => {
     pollsState: 'polls_open',
   });
 
-  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
   await advanceTimersAndPromises();
 
   // Start voter session

--- a/apps/mark-scan/frontend/src/app_election_package_config.test.tsx
+++ b/apps/mark-scan/frontend/src/app_election_package_config.test.tsx
@@ -25,7 +25,7 @@ test('renders an error if election package config endpoint returns an error', as
   apiMock.expectGetElectionState();
   apiMock.setAuthStatusElectionManagerLoggedIn(electionGeneralDefinition);
 
-  render(<App reload={jest.fn()} apiClient={apiMock.mockApiClient} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
 
   apiMock.expectConfigureElectionPackageFromUsbError('election_hash_mismatch');
   apiMock.expectGetSystemSettings();

--- a/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
@@ -60,11 +60,10 @@ test('MarkAndPrint end-to-end flow', async () => {
   });
   apiMock.setPaperHandlerState('not_accepting_paper');
   const expectedElectionHash = electionDefinition.electionHash.substring(0, 10);
-  const reload = jest.fn();
   apiMock.expectGetSystemSettings();
   apiMock.expectGetElectionDefinition(null);
   apiMock.expectGetElectionState();
-  render(<App reload={reload} apiClient={apiMock.mockApiClient} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
   const getByTextWithMarkup = withMarkup(screen.getByText);
   const findByTextWithMarkup = withMarkup(screen.findByText);
 
@@ -187,10 +186,9 @@ test('MarkAndPrint end-to-end flow', async () => {
     within(await screen.findByRole('alertdialog')).getByText('Open Polls')
   );
   await screen.findByText('Select Voter’s Ballot Style');
-  // Force refresh
+
+  // Close polls:
   userEvent.click(screen.getByText('View More Actions'));
-  userEvent.click(screen.getByText('Reset Accessible Controller'));
-  expect(reload).toHaveBeenCalledTimes(1);
   await screen.findByText('Close Polls');
 
   // Remove card

--- a/apps/mark-scan/frontend/src/app_quit_on_idle.test.tsx
+++ b/apps/mark-scan/frontend/src/app_quit_on_idle.test.tsx
@@ -46,7 +46,7 @@ test('Insert Card screen idle timeout to quit app', async () => {
     pollsState: 'polls_open',
   });
 
-  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
 
   // Ensure we're on the Insert Card screen
   await screen.findByText('Insert Card');

--- a/apps/mark-scan/frontend/src/app_replace_election.test.tsx
+++ b/apps/mark-scan/frontend/src/app_replace_election.test.tsx
@@ -39,7 +39,7 @@ test('app renders a notice when election hash on card does not match that of mac
     pollsState: 'polls_open',
   });
 
-  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
 
   // insert election manager card with different election
   apiMock.setAuthStatusElectionManagerLoggedIn(

--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -80,10 +80,6 @@ interface VotingState {
   votes?: VotesDict;
 }
 
-export interface Props {
-  reload: VoidFunction;
-}
-
 export const blankBallotVotes: VotesDict = {};
 
 export const initialElectionState: Readonly<ElectionState> = {
@@ -133,7 +129,7 @@ function votingStateReducer(
   }
 }
 
-export function AppRoot({ reload }: Props): JSX.Element | null {
+export function AppRoot(): JSX.Element | null {
   const [votingState, dispatchVotingState] = useReducer(
     votingStateReducer,
     initialVotingState
@@ -508,7 +504,6 @@ export function AppRoot({ reload }: Props): JSX.Element | null {
           ballotsPrintedCount={ballotsPrintedCount}
           machineConfig={machineConfig}
           hasVotes={!!votes}
-          reload={reload}
           precinctSelection={precinctSelection}
         />
       );

--- a/apps/mark-scan/frontend/src/app_setup_errors.test.tsx
+++ b/apps/mark-scan/frontend/src/app_setup_errors.test.tsx
@@ -43,7 +43,7 @@ describe('Displays setup warning messages and errors screens', () => {
       pollsState: 'polls_open',
     });
 
-    render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+    render(<App apiClient={apiMock.mockApiClient} />);
 
     // Start on Insert Card screen
     await screen.findByText(insertCardScreenText);
@@ -67,7 +67,7 @@ describe('Displays setup warning messages and errors screens', () => {
       pollsState: 'polls_open',
     });
 
-    render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+    render(<App apiClient={apiMock.mockApiClient} />);
 
     await screen.findByText('Insert Card');
 
@@ -94,7 +94,7 @@ describe('Displays setup warning messages and errors screens', () => {
       pollsState: 'polls_open',
     });
 
-    render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+    render(<App apiClient={apiMock.mockApiClient} />);
     const findByTextWithMarkup = withMarkup(screen.findByText);
 
     // Start on Insert Card screen
@@ -153,7 +153,7 @@ describe('Displays setup warning messages and errors screens', () => {
       pollsState: 'polls_open',
     });
 
-    render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+    render(<App apiClient={apiMock.mockApiClient} />);
 
     await screen.findByText('No Connection to Printer-Scanner');
   });

--- a/apps/mark-scan/frontend/src/app_states.test.tsx
+++ b/apps/mark-scan/frontend/src/app_states.test.tsx
@@ -34,7 +34,7 @@ jest.setTimeout(30000);
 test('`jammed` state renders jam page', async () => {
   apiMock.setPaperHandlerState('jammed');
 
-  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
 
   await screen.findByText('Paper is Jammed');
 });
@@ -43,7 +43,7 @@ test('`jam_cleared` state renders jam cleared page', async () => {
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
   apiMock.setPaperHandlerState('jam_cleared');
 
-  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
 
   await screen.findByText('Jam Cleared');
   screen.getByText(/The hardware is resetting/);
@@ -53,7 +53,7 @@ test('`resetting_state_machine_after_jam` state renders jam cleared page', async
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
   apiMock.setPaperHandlerState('resetting_state_machine_after_jam');
 
-  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
 
   await screen.findByText('Jam Cleared');
   screen.getByText(/The hardware has been reset/);
@@ -67,7 +67,7 @@ test('`waiting_for_invalidated_ballot_confirmation` state renders ballot invalid
     pollsState: 'polls_open',
   });
 
-  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
 
   apiMock.setPaperHandlerState(
     'waiting_for_invalidated_ballot_confirmation.paper_present'
@@ -84,7 +84,7 @@ test('`waiting_for_invalidated_ballot_confirmation` state renders ballot invalid
     pollsState: 'polls_open',
   });
 
-  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
 
   apiMock.setPaperHandlerState(
     'waiting_for_invalidated_ballot_confirmation.paper_present'
@@ -101,7 +101,7 @@ test('`waiting_for_invalidated_ballot_confirmation` state renders ballot invalid
 test('`blank_page_interpretation` state renders BlankPageInterpretationPage for cardless voter auth', async () => {
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
 
-  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
 
   apiMock.setPaperHandlerState('blank_page_interpretation');
   apiMock.setAuthStatusCardlessVoterLoggedInWithDefaults(electionDefinition);
@@ -112,7 +112,7 @@ test('`blank_page_interpretation` state renders BlankPageInterpretationPage for 
 test('`blank_page_interpretation` state renders BlankPageInterpretationPage for poll worker auth', async () => {
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
 
-  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
 
   apiMock.setPaperHandlerState('blank_page_interpretation');
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
@@ -127,7 +127,7 @@ test('`blank_page_interpretation` state renders BlankPageInterpretationPage for 
 test('`pat_device_connected` state renders PAT device calibration page', async () => {
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
 
-  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
 
   apiMock.setPaperHandlerState('pat_device_connected');
   apiMock.setAuthStatusCardlessVoterLoggedInWithDefaults(electionDefinition);
@@ -137,7 +137,7 @@ test('`pat_device_connected` state renders PAT device calibration page', async (
 test('`paper_reloaded` state renders PaperReloadedPage', async () => {
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
 
-  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
 
   apiMock.setPaperHandlerState('paper_reloaded');
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
@@ -154,7 +154,7 @@ test('`paper_reloaded` state renders PaperReloadedPage', async () => {
 test('`empty_ballot_box` state renders EmptyBallotBoxPage', async () => {
   apiMock.setAuthStatusCardlessVoterLoggedInWithDefaults(electionDefinition);
 
-  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
 
   apiMock.setPaperHandlerState('empty_ballot_box');
   await screen.findByText('Ballot Box Full');
@@ -169,7 +169,7 @@ test('`ballot_removed_during_presentation` state renders CastBallotPage', async 
     isTestMode: false,
   });
 
-  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
 
   apiMock.setPaperHandlerState('ballot_removed_during_presentation');
   await screen.findByText(
@@ -200,7 +200,7 @@ test.each(ballotCastPageTestSpecs)(
     apiMock.setAuthStatusCardlessVoterLoggedInWithDefaults(electionDefinition);
     apiMock.setPaperHandlerState(state);
 
-    render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+    render(<App apiClient={apiMock.mockApiClient} />);
 
     await screen.findByText('Your ballot was cast!');
     await screen.findByText('Thank you for voting.');
@@ -229,7 +229,7 @@ test.each(authEndedEarlyPageTestSpecs)(
       apiMock.setAuthStatusLoggedOut();
     }
 
-    render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+    render(<App apiClient={apiMock.mockApiClient} />);
 
     await screen.findByText(
       'The poll worker card was removed before paper loading completed. Please try again.'

--- a/apps/mark-scan/frontend/src/lib/assistive_technology.test.tsx
+++ b/apps/mark-scan/frontend/src/lib/assistive_technology.test.tsx
@@ -42,7 +42,7 @@ it('accessible controller handling works', async () => {
     precinctSelection: ALL_PRECINCTS_SELECTION,
     pollsState: 'polls_open',
   });
-  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
   await advanceTimersAndPromises();
   // Start voter session
   apiMock.setAuthStatusCardlessVoterLoggedIn({
@@ -120,7 +120,7 @@ it('auto-focuses "next" button on contest screen after voting', async () => {
   });
   mockOf(apiMock.mockApiClient.isPatDeviceConnected).mockResolvedValue(true);
 
-  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
   await advanceTimersAndPromises();
   // Start voter session
   apiMock.setAuthStatusCardlessVoterLoggedIn({

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.test.tsx
@@ -138,7 +138,7 @@ test('can toggle between vote activation and "other actions" during polls open',
 
   // switch to other actions pane
   userEvent.click(screen.getByText('View More Actions'));
-  screen.getByText('Reset Accessible Controller');
+  screen.getByRole('heading', { name: /poll worker actions/i });
 
   // switch back
   userEvent.click(screen.getByText('Back to Ballot Style Selection'));

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.test.tsx
@@ -71,7 +71,6 @@ function renderScreen(
         pollsState="polls_open"
         ballotsPrintedCount={0}
         machineConfig={mockMachineConfig()}
-        reload={jest.fn()}
         precinctSelection={singlePrecinctSelectionFor(
           electionDefinition.election.precincts[0].id
         )}

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
@@ -148,7 +148,6 @@ export interface PollworkerScreenProps {
   pollsState: PollsState;
   ballotsPrintedCount: number;
   machineConfig: MachineConfig;
-  reload: () => void;
   precinctSelection: PrecinctSelection;
 }
 
@@ -162,7 +161,6 @@ export function PollWorkerScreen({
   ballotsPrintedCount,
   machineConfig,
   hasVotes,
-  reload,
   precinctSelection,
 }: PollworkerScreenProps): JSX.Element | null {
   const { election } = electionDefinition;
@@ -420,9 +418,6 @@ export function PollWorkerScreen({
                     );
                   }
                 )}
-              </P>
-              <P>
-                <Button onPress={reload}>Reset Accessible Controller</Button>
               </P>
             </React.Fragment>
           )}

--- a/apps/mark-scan/frontend/test/helpers/build_app.tsx
+++ b/apps/mark-scan/frontend/test/helpers/build_app.tsx
@@ -11,9 +11,7 @@ export function buildApp(apiMock: ReturnType<typeof createApiMock>): {
   const logger = mockBaseLogger();
   const reload = jest.fn();
   function renderApp() {
-    return render(
-      <App reload={reload} logger={logger} apiClient={apiMock.mockApiClient} />
-    );
+    return render(<App logger={logger} apiClient={apiMock.mockApiClient} />);
   }
 
   return {


### PR DESCRIPTION
## Overview

Related to: https://github.com/votingworks/vxsuite/issues/4762

Removing the "Reset Accessible Controller" button (which formerly reloads the page) from the Poll Worker Actions screen, since has no effect on the state of VSAP controller connection.

## Demo Video or Screenshot

### Before -> After:

<img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/2dffa098-951f-45e9-8e71-7537a8a6ad88" /> <img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/8b438a73-3ee5-40ee-a0e6-aea4e31d4ed3" />

## Testing Plan
Manual

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
