### PR TITLE
[MarkScan] Only show PAT calibration on voter screens

### DIFF
--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -68,7 +68,6 @@ import { JamClearedPage } from './pages/jam_cleared_page';
 import { BallotInvalidatedPage } from './pages/ballot_invalidated_page';
 import { BlankPageInterpretationPage } from './pages/blank_page_interpretation_page';
 import { PaperReloadedPage } from './pages/paper_reloaded_page';
-import { PatDeviceCalibrationPage } from './pages/pat_device_identification/pat_device_calibration_page';
 import { CastingBallotPage } from './pages/casting_ballot_page';
 import { BallotSuccessfullyCastPage } from './pages/ballot_successfully_cast_page';
 import { EmptyBallotBoxPage } from './pages/empty_ballot_box_page';
@@ -464,10 +463,6 @@ export function AppRoot(): JSX.Element | null {
         // PollWorkerScreen will warn that votes exist in ballot state, but preserving
         // ballot state is the desired behavior when handling blank page interpretations.
         return <BlankPageInterpretationPage authStatus={authStatus} />;
-      }
-
-      if (stateMachineState === 'pat_device_connected') {
-        return <PatDeviceCalibrationPage />;
       }
 
       if (

--- a/apps/mark-scan/frontend/src/app_states.test.tsx
+++ b/apps/mark-scan/frontend/src/app_states.test.tsx
@@ -124,16 +124,6 @@ test('`blank_page_interpretation` state renders BlankPageInterpretationPage for 
   await screen.findByText('Load New Ballot Sheet');
 });
 
-test('`pat_device_connected` state renders PAT device calibration page', async () => {
-  apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
-
-  render(<App apiClient={apiMock.mockApiClient} />);
-
-  apiMock.setPaperHandlerState('pat_device_connected');
-  apiMock.setAuthStatusCardlessVoterLoggedInWithDefaults(electionDefinition);
-  await screen.findByText('Test Your Device');
-});
-
 test('`paper_reloaded` state renders PaperReloadedPage', async () => {
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
 

--- a/apps/mark-scan/frontend/src/voter_flow.tsx
+++ b/apps/mark-scan/frontend/src/voter_flow.tsx
@@ -21,6 +21,7 @@ import { Ballot } from './components/ballot';
 import { ValidateBallotPage } from './pages/validate_ballot_page';
 import { BallotContext } from './contexts/ballot_context';
 import { confirmSessionEnd } from './api';
+import { PatDeviceCalibrationPage } from './pages/pat_device_identification/pat_device_calibration_page';
 
 export interface VoterFlowProps {
   contests: ContestsWithMsEitherNeither;
@@ -42,6 +43,11 @@ export function VoterFlow(props: VoterFlowProps): React.ReactNode {
   const confirmSessionEndMutation = confirmSessionEnd.useMutation();
 
   const { shouldShowControllerSandbox } = useAccessibleControllerHelpTrigger();
+
+  if (stateMachineState === 'pat_device_connected') {
+    return <PatDeviceCalibrationPage />;
+  }
+
   if (shouldShowControllerSandbox) {
     return <MarkScanControllerSandbox />;
   }


### PR DESCRIPTION
## Overview

Related to: https://github.com/votingworks/vxsuite/issues/4762

Update the PAT device calibration step to only happen once a voter session has been started (previously could be triggered on Poll Worker screens whenever the PAT device was connected).

## Demo Video or Screenshot

https://github.com/votingworks/vxsuite/assets/264902/d75f1178-1b2b-439d-a509-30dbc262ff99

## Testing Plan
- New test case for `VoterFlow` component to assert PAT calibration screen takes precedence over ballot screens
- Manual verification with mock PAT connection status reader

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
