### PR TITLE
apps/scan: Detect when scanner cover is open

### DIFF
--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -639,10 +639,23 @@ function buildMachine({
 
         disconnected: {
           id: 'disconnected',
-          after: {
-            DELAY_RECONNECT: {
-              actions: assign({ client: () => createPdiScannerClient() }),
-              target: 'connecting',
+          initial: 'waiting',
+          states: {
+            waiting: {
+              after: {
+                DELAY_RECONNECT: {
+                  actions: assign({ client: () => createPdiScannerClient() }),
+                  target: 'reconnecting',
+                },
+              },
+            },
+            reconnecting: {
+              invoke: {
+                src: async ({ client }) =>
+                  (await client.connect()).unsafeUnwrap(),
+                onDone: '#waitingForBallot',
+                onError: 'waiting',
+              },
             },
           },
         },

--- a/apps/scan/frontend/src/app_root.tsx
+++ b/apps/scan/frontend/src/app_root.tsx
@@ -36,6 +36,7 @@ import { VoterScreen } from './screens/voter_screen';
 import { LoginPromptScreen } from './screens/login_prompt_screen';
 import { CastVoteRecordSyncRequiredScreen } from './screens/cast_vote_record_sync_required_screen';
 import { SystemAdministratorScreen } from './screens/system_administrator_screen';
+import { ScannerCoverOpenScreen } from './screens/scanner_cover_open_screen';
 
 export function AppRoot(): JSX.Element | null {
   const authStatusQuery = getAuthStatus.useQuery();
@@ -146,6 +147,10 @@ export function AppRoot(): JSX.Element | null {
         scannedBallotCount={scannerStatus.ballotsCounted}
       />
     );
+  }
+
+  if (scannerStatus.state === 'cover_open') {
+    return <ScannerCoverOpenScreen />;
   }
 
   if (authStatus.status === 'checking_pin') {

--- a/apps/scan/frontend/src/app_unhappy_paths.test.tsx
+++ b/apps/scan/frontend/src/app_unhappy_paths.test.tsx
@@ -178,6 +178,19 @@ test('shows power cable message when there is no scanner and tablet is not plugg
   await screen.findByRole('heading', { name: 'Polls Closed' });
 });
 
+test('shows message when scanner cover is open', async () => {
+  apiMock.expectGetConfig();
+  apiMock.expectGetPollsInfo();
+  apiMock.setBatteryInfo();
+  apiMock.expectGetScannerStatus({
+    ...statusNoPaper,
+    state: 'cover_open',
+  });
+  renderApp();
+  await screen.findByRole('heading', { name: 'Scanner Cover is Open' });
+  screen.getByText('Please ask a poll worker for help.');
+});
+
 test('shows instructions to restart when the scanner client crashed', async () => {
   apiMock.expectGetConfig();
   apiMock.expectGetPollsInfo('polls_open');

--- a/apps/scan/frontend/src/screens/scanner_cover_open_screen.tsx
+++ b/apps/scan/frontend/src/screens/scanner_cover_open_screen.tsx
@@ -1,0 +1,13 @@
+import { CenteredLargeProse, H1, P, appStrings } from '@votingworks/ui';
+import { ScreenMainCenterChild } from '../components/layout';
+
+export function ScannerCoverOpenScreen(): JSX.Element {
+  return (
+    <ScreenMainCenterChild voterFacing>
+      <CenteredLargeProse>
+        <H1>{appStrings.titleScannerCoverIsOpen()}</H1>
+        <P>{appStrings.instructionsAskForHelp()}</P>
+      </CenteredLargeProse>
+    </ScreenMainCenterChild>
+  );
+}

--- a/apps/scan/frontend/src/screens/voter_screen.tsx
+++ b/apps/scan/frontend/src/screens/voter_screen.tsx
@@ -76,6 +76,7 @@ export function VoterScreen({
         // istanbul ignore next
         case 'connecting':
         case 'disconnected':
+        case 'cover_open':
         case 'no_paper':
         case 'hardware_ready_to_scan':
         case 'paused':
@@ -106,7 +107,12 @@ export function VoterScreen({
   const scannerStatus = scannerStatusQuery.data;
 
   switch (scannerStatus.state) {
+    // These states are handled in AppRoot, since they should show a message for
+    // all user types, not just voters.
     case 'disconnected':
+    case 'cover_open':
+      return null;
+    // This state should pass quickly, so we don't show a message
     case 'connecting':
       return null;
     // When a user (e.g. poll worker) removes their card, there may be a slight

--- a/libs/pdi-scanner/src/main.rs
+++ b/libs/pdi-scanner/src/main.rs
@@ -147,6 +147,9 @@ enum Event {
     ScanComplete {
         image_data: (String, String),
     },
+
+    CoverOpen,
+    CoverClosed,
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -401,6 +404,12 @@ fn main() -> color_eyre::Result<()> {
                         }
                     }
                     scan_in_progress = false;
+                }
+                Ok(Incoming::CoverOpenEvent) => {
+                    send_event(Event::CoverOpen)?;
+                }
+                Ok(Incoming::CoverClosedEvent) => {
+                    send_event(Event::CoverClosed)?;
                 }
                 Ok(event) => {
                     tracing::info!("unhandled event: {event:?}");

--- a/libs/pdi-scanner/src/protocol/packets.rs
+++ b/libs/pdi-scanner/src/protocol/packets.rs
@@ -78,7 +78,7 @@ pub enum Outgoing {
     /// - Bit 1 (0x02): Rear Right Sensor Covered = 1 (Omitted in Ultrascan)
     /// - Bit 2 (0x04): Brander Position Sensor Covered = 1
     /// - Bit 3 (0x08): Hi Speed Mode = 1
-    /// - Bit 4 (0x10): Download Needed = 1
+    /// - Bit 4 (0x10): Cover Open = 1
     /// - Bit 5 (0x20): Future Use (not defined) = 1
     /// - Bit 6 (0x40): Scanner Enabled = 1
     /// - Bit 7 (0x80): Always Set to 1
@@ -855,7 +855,7 @@ pub enum Incoming {
     /// - Bit 1 (0x02): Rear Right Sensor Covered = 1 (Omitted in Ultrascan)
     /// - Bit 2 (0x04): Brander Position Sensor Covered = 1
     /// - Bit 3 (0x08): Hi Speed Mode = 1
-    /// - Bit 4 (0x10): Download Needed = 1
+    /// - Bit 4 (0x10): Cover Open = 1
     /// - Bit 5 (0x20): Future Use (not defined) = 1
     /// - Bit 6 (0x40): Scanner Enabled = 1
     /// - Bit 7 (0x80): Always Set to 1

--- a/libs/pdi-scanner/src/protocol/types.rs
+++ b/libs/pdi-scanner/src/protocol/types.rs
@@ -148,7 +148,7 @@ pub struct Status {
     /// Byte 0, Bit 3 (0x08)
     pub hi_speed_mode: bool,
     /// Byte 0, Bit 4 (0x10)
-    pub download_needed: bool,
+    pub cover_open: bool,
     /// Byte 0, Bit 5 (0x20) – not defined
     /// future_use: bool,
     /// Byte 0, Bit 6 (0x40)
@@ -193,7 +193,7 @@ impl Status {
         rear_right_sensor_covered: bool,
         brander_position_sensor_covered: bool,
         hi_speed_mode: bool,
-        download_needed: bool,
+        cover_open: bool,
         scanner_enabled: bool,
         front_left_sensor_covered: bool,
         front_m1_sensor_covered: bool,
@@ -215,7 +215,7 @@ impl Status {
             rear_right_sensor_covered,
             brander_position_sensor_covered,
             hi_speed_mode,
-            download_needed,
+            cover_open,
             scanner_enabled,
             front_left_sensor_covered,
             front_m1_sensor_covered,

--- a/libs/pdi-scanner/ts/src/scanner_client.ts
+++ b/libs/pdi-scanner/ts/src/scanner_client.ts
@@ -32,7 +32,7 @@ export interface ScannerStatus {
   rearRightSensorCovered: boolean;
   branderPositionSensorCovered: boolean;
   hiSpeedMode: boolean;
-  downloadNeeded: boolean;
+  coverOpen: boolean;
   scannerEnabled: boolean;
   frontLeftSensorCovered: boolean;
   frontM1SensorCovered: boolean;

--- a/libs/pdi-scanner/ts/src/scanner_client.ts
+++ b/libs/pdi-scanner/ts/src/scanner_client.ts
@@ -74,7 +74,9 @@ export type ScannerError =
 export type ScannerEvent =
   | ({ event: 'error' } & ScannerError)
   | { event: 'scanStart' }
-  | { event: 'scanComplete'; images: SheetOf<ImageData> };
+  | { event: 'scanComplete'; images: SheetOf<ImageData> }
+  | { event: 'coverOpen' }
+  | { event: 'coverClosed' };
 
 /**
  * An event listener for any {@link ScannerEvent} emitted by the scanner.
@@ -117,7 +119,9 @@ type PdictlResponse =
 type PdictlEvent =
   | ({ event: 'error' } & ScannerError)
   | { event: 'scanStart' }
-  | { event: 'scanComplete'; imageData: [string, string] };
+  | { event: 'scanComplete'; imageData: [string, string] }
+  | { event: 'coverOpen' }
+  | { event: 'coverClosed' };
 
 type PdictlMessage = PdictlResponse | PdictlEvent;
 
@@ -205,7 +209,9 @@ export function createPdiScannerClient() {
         });
         break;
       }
-      case 'error': {
+      case 'error':
+      case 'coverOpen':
+      case 'coverClosed': {
         emit(message);
         break;
       }

--- a/libs/types/src/precinct_scanner.ts
+++ b/libs/types/src/precinct_scanner.ts
@@ -15,6 +15,7 @@ export const PRECINCT_SCANNER_STATES = [
   'rejecting',
   'rejected',
   'jammed',
+  'cover_open',
   'both_sides_have_paper',
   'recovering_from_error',
   'double_sheet_jammed',

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -1001,6 +1001,12 @@ export const appStrings = {
     </UiString>
   ),
 
+  titleScannerCoverIsOpen: () => (
+    <UiString uiStringKey="titleScannerCoverIsOpen">
+      Scanner Cover is Open
+    </UiString>
+  ),
+
   titleVoterSettings: () => (
     <UiString uiStringKey="titleVoterSettings">Settings:</UiString>
   ),

--- a/libs/ui/src/ui_strings/app_strings_catalog/latest.json
+++ b/libs/ui/src/ui_strings/app_strings_catalog/latest.json
@@ -258,6 +258,7 @@
   "titleRemoveYourBallot": "Remove Your Ballot",
   "titleScannerBallotNotCounted": "Ballot Not Counted",
   "titleScannerBallotWarningsScreen": "Review Your Ballot",
+  "titleScannerCoverIsOpen": "Scanner Cover is Open",
   "titleScannerInsertBallotScreen": "Insert Your Ballot",
   "titleScannerNoVotesWarning": "No votes marked:",
   "titleScannerOvervoteWarning": "Too many votes marked:",


### PR DESCRIPTION
## Overview

Show a blocking message when the scanner cover is open. Implemented for the PDI scanner only.

Context from @mattroe:
>I think we should populate a distinct message from the “internal connection error” screen that calls out the scanner cover is open and for a poll worker to ensure its closed.
>
> Realistically, this should only happen in the following cases:
> - cleaning (intentional)
> - not closing it all the way after cleaning (unintentional)
> - transport movement (unintentional and unlikely, but possible)

## Demo Video or Screenshot

https://github.com/votingworks/vxsuite/assets/530106/79679efa-e721-436f-a820-d9b4786dee2d



## Testing Plan
Manual testing. Added one frontend test for coverage. Will add backend/driver tests later.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
