### PR TITLE
apps/scan: Use machines instead of observables in PDI state machine

### DIFF
--- a/apps/mark-scan/backend/package.json
+++ b/apps/mark-scan/backend/package.json
@@ -63,7 +63,7 @@
     "rxjs": "7.8.1",
     "tmp": "^0.2.1",
     "uuid": "9.0.1",
-    "xstate": "^4.32.1",
+    "xstate": "^4.33.0",
     "zod": "3.14.4"
   },
   "devDependencies": {

--- a/apps/scan/backend/package.json
+++ b/apps/scan/backend/package.json
@@ -70,7 +70,7 @@
     "rxjs": "7.8.1",
     "tmp": "^0.2.1",
     "uuid": "9.0.1",
-    "xstate": "^4.32.1",
+    "xstate": "^4.33.0",
     "zod": "3.14.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1590,8 +1590,8 @@ importers:
         specifier: 9.0.1
         version: 9.0.1
       xstate:
-        specifier: ^4.32.1
-        version: 4.32.1
+        specifier: ^4.33.0
+        version: 4.33.0
       zod:
         specifier: 3.14.4
         version: 3.14.4
@@ -2442,8 +2442,8 @@ importers:
         specifier: 9.0.1
         version: 9.0.1
       xstate:
-        specifier: ^4.32.1
-        version: 4.32.1
+        specifier: ^4.33.0
+        version: 4.33.0
       zod:
         specifier: 3.14.4
         version: 3.14.4
@@ -23604,8 +23604,8 @@ packages:
   /xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
-  /xstate@4.32.1:
-    resolution: {integrity: sha512-QYUd+3GkXZ8i6qdixnOn28bL3EvA++LONYL/EMWwKlFSh/hiLndJ8YTnz77FDs+JUXcwU7NZJg7qoezoRHc4GQ==}
+  /xstate@4.33.0:
+    resolution: {integrity: sha512-+oari/Nt2cBq79mklnGA9Tsb6kv7ln+cIMfrH6n642XpTEG6sMRHg4GkooAbGbcslG3Ff9uH2jmGRP+1uoZ/Xw==}
     dev: false
 
   /xtend@4.0.2:


### PR DESCRIPTION


## Overview

This will allow us to use xstate's simulated clock for testing, since all delays will use xstate machinery (rather than using rxjs for the polling delays).

## Demo Video or Screenshot
N/A
## Testing Plan
Manual test
## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
