### PR TITLE
apps/scan: Poll for PDI scanner cover closed status

### DIFF
--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -659,10 +659,10 @@ function buildMachine({
 
         coverOpen: {
           id: 'coverOpen',
-          invoke: listenForScannerEvents,
+          invoke: pollScannerStatus,
           on: {
-            SCANNER_EVENT: {
-              cond: (_, { event }) => event.event === 'coverClosed',
+            SCANNER_STATUS: {
+              cond: (_, { status }) => !status.coverOpen,
               target: 'waitingForBallot',
             },
           },


### PR DESCRIPTION

## Overview
I noticed that it was possible for the `coverClosed` event to be emitted before the state machine had transitioned to the `coverOpen` state (e.g. if you open the cover slightly, remove a jammed ballot, and then immediately close it), in which case we get stuck in the `coverOpen` state. Polling the scanner status seems like a more reliable way to exit this state.

Note that I'm not concerned about missing the `coverOpen` event since that listener is registered at the root of the state machine.

We could conceivably also register the `coverClosed` event handler at the root, but I am worried that it's a bit heavy handed to say that we should transition to `waitingForBallot` at any point if we receive a `coverClosed` event (rather than only when we're already in the `coverOpen` state).


## Demo Video or Screenshot

## Testing Plan
Manually tested

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
