### PR TITLE
Update to TypeScript v5.4.5

### DIFF
--- a/apps/central-scan/backend/src/validation.test.ts
+++ b/apps/central-scan/backend/src/validation.test.ts
@@ -25,7 +25,7 @@ const BmdPage: InterpretedBmdPage = {
   votes: {},
 };
 
-const BlankPage: BlankPage = {
+const BlankPageInstance: BlankPage = {
   type: 'BlankPage',
 };
 
@@ -79,13 +79,13 @@ const HmpbPage2: InterpretedHmpbPage = {
 
 test('BMD ballot', () => {
   expect(
-    validateSheetInterpretation([BmdPage, BlankPage]).err()
+    validateSheetInterpretation([BmdPage, BlankPageInstance]).err()
   ).toBeUndefined();
 });
 
 test('BMD ballot reversed', () => {
   expect(
-    validateSheetInterpretation([BmdPage, BlankPage]).err()
+    validateSheetInterpretation([BmdPage, BlankPageInstance]).err()
   ).toBeUndefined();
 });
 

--- a/libs/eslint-plugin-vx/package.json
+++ b/libs/eslint-plugin-vx/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-jsx-a11y": "^6.6.1",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-react": "^7.31.8",
-    "typescript": "5.2.2"
+    "typescript": "5.4.5"
   },
   "devDependencies": {
     "@types/jest": "^29.5.3",

--- a/libs/hmpb/render-backend/src/next/vx_default_ballot_template.tsx
+++ b/libs/hmpb/render-backend/src/next/vx_default_ballot_template.tsx
@@ -10,7 +10,7 @@ import styled from 'styled-components';
 import {
   AnyContest,
   BallotType,
-  CandidateContest,
+  CandidateContest as CandidateContestStruct,
   Election,
   YesNoContest,
   ballotPaperDimensions,
@@ -306,7 +306,7 @@ function CandidateContest({
   contest,
 }: {
   election: Election;
-  contest: CandidateContest;
+  contest: CandidateContestStruct;
 }) {
   return (
     <Box

--- a/libs/message-coder/src/message_coder.ts
+++ b/libs/message-coder/src/message_coder.ts
@@ -104,7 +104,7 @@ class MessageCoder<P extends MessageCoderParts<object>>
         continue;
       }
 
-      if (!coder.canEncode((value as ObjectFromParts<P>)[k])) {
+      if (!coder.canEncode((value as ObjectFromParts<P>)[k as keyof P])) {
         return false;
       }
     }
@@ -129,7 +129,7 @@ class MessageCoder<P extends MessageCoderParts<object>>
       let length = 0;
       for (const [k, v] of Object.entries(this.parts)) {
         const coder = v as Coder<ObjectFromParts<P>[keyof ObjectFromParts<P>]>;
-        length += coder.bitLength(value[k]).okOrElse(fail);
+        length += coder.bitLength(value[k as keyof P]).okOrElse(fail);
       }
       return length;
     });
@@ -148,7 +148,7 @@ class MessageCoder<P extends MessageCoderParts<object>>
         bitOffset = (
           coder instanceof PaddingCoder
             ? coder.encodeInto(undefined, buffer, bitOffset)
-            : coder.encodeInto(value[k], buffer, bitOffset)
+            : coder.encodeInto(value[k as keyof P], buffer, bitOffset)
         ).okOrElse(fail);
       }
 

--- a/libs/monorepo-utils/package.json
+++ b/libs/monorepo-utils/package.json
@@ -56,7 +56,7 @@
     "prettier": "3.0.3",
     "sort-package-json": "^1.50.0",
     "ts-jest": "29.1.1",
-    "typescript": "5.2.2"
+    "typescript": "5.4.5"
   },
   "packageManager": "pnpm@8.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -52,12 +52,12 @@
     "storybook": "^7.2.2",
     "stylelint": "^15.10.2",
     "stylelint-config-standard": "^34.0.0",
-    "typescript": "5.2.2"
+    "typescript": "5.4.5"
   },
   "pnpm": {
     "overrides": {
       "@types/eslint": "8.4.1",
-      "typescript": "5.2.2",
+      "typescript": "5.4.5",
       "graceful-fs": "^4.2.9"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,7 +2,7 @@ lockfileVersion: '6.0'
 
 overrides:
   '@types/eslint': 8.4.1
-  typescript: 5.2.2
+  typescript: 5.4.5
   graceful-fs: ^4.2.9
 
 importers:
@@ -47,7 +47,7 @@ importers:
         version: 7.2.2(react-dom@18.2.0)(react@18.2.0)
       '@storybook/builder-vite':
         specifier: ^7.2.2
-        version: 7.2.2(typescript@5.2.2)(vite@4.5.0)
+        version: 7.2.2(typescript@5.4.5)(vite@4.5.0)
       '@storybook/channel-postmessage':
         specifier: ^7.2.2
         version: 7.2.2
@@ -74,10 +74,10 @@ importers:
         version: 7.2.2
       '@storybook/react':
         specifier: ^7.2.2
-        version: 7.2.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
+        version: 7.2.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
       '@storybook/react-vite':
         specifier: ^7.2.2
-        version: 7.2.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(vite@4.5.0)
+        version: 7.2.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)(vite@4.5.0)
       '@storybook/theming':
         specifier: ^7.2.2
         version: 7.2.2(react-dom@18.2.0)(react@18.2.0)
@@ -89,7 +89,7 @@ importers:
         version: 8.4.1
       '@typescript-eslint/parser':
         specifier: 6.7.0
-        version: 6.7.0(eslint@8.49.0)(typescript@5.2.2)
+        version: 6.7.0(eslint@8.49.0)(typescript@5.4.5)
       eslint:
         specifier: 8.49.0
         version: 8.49.0
@@ -104,7 +104,7 @@ importers:
         version: 5.2.0
       postcss-styled-syntax:
         specifier: ^0.4.0
-        version: 0.4.0(postcss@8.4.27)(typescript@5.2.2)
+        version: 0.4.0(postcss@8.4.27)(typescript@5.4.5)
       prettier:
         specifier: ^3.0.3
         version: 3.0.3
@@ -121,8 +121,8 @@ importers:
         specifier: ^34.0.0
         version: 34.0.0(stylelint@15.10.2)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.4.5
+        version: 5.4.5
 
   apps/admin/backend:
     dependencies:
@@ -336,7 +336,7 @@ importers:
         version: 6.1.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
 
   apps/admin/frontend:
     dependencies:
@@ -453,7 +453,7 @@ importers:
         version: 3.0.0
       react-dev-utils:
         specifier: 12.0.1
-        version: 12.0.1(eslint@8.49.0)(typescript@5.2.2)(webpack@5.88.2)
+        version: 12.0.1(eslint@8.49.0)(typescript@5.4.5)(webpack@5.88.2)
       react-dom:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
@@ -622,7 +622,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -858,7 +858,7 @@ importers:
         version: 6.1.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
 
   apps/central-scan/frontend:
     dependencies:
@@ -1072,7 +1072,7 @@ importers:
         version: 3.0.0
       react-dev-utils:
         specifier: 12.0.1
-        version: 12.0.1(eslint@8.49.0)(typescript@5.2.2)(webpack@5.88.2)
+        version: 12.0.1(eslint@8.49.0)(typescript@5.4.5)(webpack@5.88.2)
       react-refresh:
         specifier: ^0.9.0
         version: 0.9.0
@@ -1081,7 +1081,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
       type-fest:
         specifier: ^0.18.0
         version: 0.18.1
@@ -1317,7 +1317,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
 
   apps/design/frontend:
     dependencies:
@@ -1486,7 +1486,7 @@ importers:
         version: 3.0.0
       react-dev-utils:
         specifier: 12.0.1
-        version: 12.0.1(eslint@8.49.0)(typescript@5.2.2)(webpack@5.88.2)
+        version: 12.0.1(eslint@8.49.0)(typescript@5.4.5)(webpack@5.88.2)
       sort-package-json:
         specifier: ^1.50.0
         version: 1.53.1
@@ -1495,7 +1495,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -1670,7 +1670,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
 
   apps/mark-scan/frontend:
     dependencies:
@@ -1751,7 +1751,7 @@ importers:
         version: 3.0.0
       react-dev-utils:
         specifier: 12.0.1
-        version: 12.0.1(eslint@8.49.0)(typescript@5.2.2)(webpack@5.88.2)
+        version: 12.0.1(eslint@8.49.0)(typescript@5.4.5)(webpack@5.88.2)
       react-dom:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
@@ -1893,7 +1893,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -2060,7 +2060,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
 
   apps/mark/frontend:
     dependencies:
@@ -2138,7 +2138,7 @@ importers:
         version: 3.0.0
       react-dev-utils:
         specifier: 12.0.1
-        version: 12.0.1(eslint@8.49.0)(typescript@5.2.2)(webpack@5.88.2)
+        version: 12.0.1(eslint@8.49.0)(typescript@5.4.5)(webpack@5.88.2)
       react-dom:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
@@ -2283,7 +2283,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -2531,7 +2531,7 @@ importers:
         version: 6.1.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
       wait-for-expect:
         specifier: ^3.0.2
         version: 3.0.2
@@ -2730,13 +2730,13 @@ importers:
         version: 3.0.0
       react-dev-utils:
         specifier: 12.0.1
-        version: 12.0.1(eslint@8.49.0)(typescript@5.2.2)(webpack@4.46.0)
+        version: 12.0.1(eslint@8.49.0)(typescript@5.4.5)(webpack@4.46.0)
       sort-package-json:
         specifier: ^1.50.0
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -2787,7 +2787,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/@types/compress-commons:
     dependencies:
@@ -2861,7 +2861,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/auth:
     dependencies:
@@ -2976,7 +2976,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
       wait-for-expect:
         specifier: ^3.0.2
         version: 3.0.2
@@ -3142,7 +3142,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/ballot-encoder:
     dependencies:
@@ -3194,7 +3194,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/ballot-interpreter:
     dependencies:
@@ -3312,7 +3312,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/basics:
     dependencies:
@@ -3358,7 +3358,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/cdf-schema-builder:
     dependencies:
@@ -3410,7 +3410,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/converter-nh-accuvote:
     dependencies:
@@ -3516,7 +3516,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
 
   libs/custom-paper-handler:
     dependencies:
@@ -3589,13 +3589,13 @@ importers:
         version: 16.0.0
       jest-mock-extended:
         specifier: ^3.0.4
-        version: 3.0.4(jest@29.6.2)(typescript@5.2.2)
+        version: 3.0.4(jest@29.6.2)(typescript@5.4.5)
       jest-watch-typeahead:
         specifier: ^2.2.2
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/custom-scanner:
     dependencies:
@@ -3662,13 +3662,13 @@ importers:
         version: 16.0.0
       jest-mock-extended:
         specifier: ^3.0.4
-        version: 3.0.4(jest@29.6.2)(typescript@5.2.2)
+        version: 3.0.4(jest@29.6.2)(typescript@5.4.5)
       jest-watch-typeahead:
         specifier: ^2.2.2
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -3756,7 +3756,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
       zod:
         specifier: 3.14.4
         version: 3.14.4
@@ -3811,7 +3811,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/dev-dock/backend:
     dependencies:
@@ -3884,7 +3884,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/dev-dock/frontend:
     dependencies:
@@ -3990,16 +3990,16 @@ importers:
         version: 5.3.11(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/eslint-plugin-vx:
     dependencies:
       '@typescript-eslint/eslint-plugin':
         specifier: 6.7.0
-        version: 6.7.0(@typescript-eslint/parser@6.7.0)(eslint@8.49.0)(typescript@5.2.2)
+        version: 6.7.0(@typescript-eslint/parser@6.7.0)(eslint@8.49.0)(typescript@5.4.5)
       '@typescript-eslint/utils':
         specifier: 6.7.0
-        version: 6.7.0(eslint@8.49.0)(typescript@5.2.2)
+        version: 6.7.0(eslint@8.49.0)(typescript@5.4.5)
       comment-parser:
         specifier: ^1.4.0
         version: 1.4.0
@@ -4023,7 +4023,7 @@ importers:
         version: 2.26.0(@typescript-eslint/parser@6.7.0)(eslint-import-resolver-typescript@3.6.0)(eslint@8.49.0)
       eslint-plugin-jest:
         specifier: ^27.2.3
-        version: 27.2.3(@typescript-eslint/eslint-plugin@6.7.0)(eslint@8.49.0)(jest@29.6.2)(typescript@5.2.2)
+        version: 27.2.3(@typescript-eslint/eslint-plugin@6.7.0)(eslint@8.49.0)(jest@29.6.2)(typescript@5.4.5)
       eslint-plugin-jsx-a11y:
         specifier: ^6.6.1
         version: 6.6.1(eslint@8.49.0)
@@ -4034,8 +4034,8 @@ importers:
         specifier: ^7.31.8
         version: 7.31.8(eslint@8.49.0)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.4.5
+        version: 5.4.5
     devDependencies:
       '@types/jest':
         specifier: ^29.5.3
@@ -4048,7 +4048,7 @@ importers:
         version: 18.2.18
       '@typescript-eslint/rule-tester':
         specifier: ^6.7.0
-        version: 6.7.0(@eslint/eslintrc@2.1.2)(eslint@8.49.0)(typescript@5.2.2)
+        version: 6.7.0(@eslint/eslintrc@2.1.2)(eslint@8.49.0)(typescript@5.4.5)
       eslint-plugin-vx:
         specifier: workspace:*
         version: 'link:'
@@ -4069,7 +4069,7 @@ importers:
         version: 18.2.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/fixtures:
     dependencies:
@@ -4121,7 +4121,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/fs:
     dependencies:
@@ -4200,7 +4200,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/fujitsu-thermal-printer:
     dependencies:
@@ -4261,7 +4261,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/grout:
     dependencies:
@@ -4322,7 +4322,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/grout/test-utils:
     dependencies:
@@ -4362,7 +4362,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/hmpb/layout:
     dependencies:
@@ -4447,7 +4447,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/hmpb/render-backend:
     dependencies:
@@ -4580,7 +4580,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -4665,7 +4665,7 @@ importers:
         version: 11.0.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
 
   libs/logging:
     dependencies:
@@ -4744,7 +4744,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/mark-flow-ui:
     dependencies:
@@ -4820,7 +4820,7 @@ importers:
         version: 7.2.2
       '@storybook/react':
         specifier: ^7.2.2
-        version: 7.2.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
+        version: 7.2.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
       '@tanstack/react-query':
         specifier: 4.32.1
         version: 4.32.1(react-dom@18.2.0)(react@18.2.0)
@@ -4898,7 +4898,7 @@ importers:
         version: 6.0.3
       eslint-plugin-storybook:
         specifier: ^0.6.10
-        version: 0.6.10(eslint@8.49.0)(typescript@5.2.2)
+        version: 0.6.10(eslint@8.49.0)(typescript@5.4.5)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
@@ -4958,7 +4958,7 @@ importers:
         version: 5.3.11(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
       util:
         specifier: ^0.12.4
         version: 0.12.4
@@ -4998,7 +4998,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/monorepo-utils:
     dependencies:
@@ -5014,10 +5014,10 @@ importers:
         version: 16.18.23
       '@typescript-eslint/eslint-plugin':
         specifier: 6.7.0
-        version: 6.7.0(@typescript-eslint/parser@6.7.0)(eslint@8.49.0)(typescript@5.2.2)
+        version: 6.7.0(@typescript-eslint/parser@6.7.0)(eslint@8.49.0)(typescript@5.4.5)
       '@typescript-eslint/parser':
         specifier: 6.7.0
-        version: 6.7.0(eslint@8.49.0)(typescript@5.2.2)
+        version: 6.7.0(eslint@8.49.0)(typescript@5.4.5)
       esbuild-runner:
         specifier: 2.2.2
         version: 2.2.2(esbuild@0.17.11)
@@ -5038,7 +5038,7 @@ importers:
         version: 2.27.5(@typescript-eslint/parser@6.7.0)(eslint-import-resolver-typescript@3.6.0)(eslint@8.49.0)
       eslint-plugin-jest:
         specifier: ^27.2.3
-        version: 27.2.3(@typescript-eslint/eslint-plugin@6.7.0)(eslint@8.49.0)(jest@29.6.2)(typescript@5.2.2)
+        version: 27.2.3(@typescript-eslint/eslint-plugin@6.7.0)(eslint@8.49.0)(jest@29.6.2)(typescript@5.4.5)
       eslint-plugin-prettier:
         specifier: ^5.0.0
         version: 5.0.0(@types/eslint@8.4.1)(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.0.3)
@@ -5068,10 +5068,10 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.4.5
+        version: 5.4.5
 
   libs/pdi-scanner:
     dependencies:
@@ -5123,7 +5123,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/printing:
     dependencies:
@@ -5235,7 +5235,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/res-to-ts:
     dependencies:
@@ -5290,7 +5290,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/test-utils:
     dependencies:
@@ -5375,7 +5375,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/types:
     dependencies:
@@ -5460,7 +5460,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/types-rs: {}
 
@@ -5568,7 +5568,7 @@ importers:
         version: 7.2.2
       '@storybook/react':
         specifier: ^7.2.2
-        version: 7.2.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
+        version: 7.2.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
       '@tanstack/react-query':
         specifier: 4.32.1
         version: 4.32.1(react-dom@18.2.0)(react@18.2.0)
@@ -5670,7 +5670,7 @@ importers:
         version: 2.2.2(esbuild@0.17.11)
       eslint-plugin-storybook:
         specifier: ^0.6.10
-        version: 0.6.10(eslint@8.49.0)(typescript@5.2.2)
+        version: 0.6.10(eslint@8.49.0)(typescript@5.4.5)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
@@ -5736,7 +5736,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
       util:
         specifier: ^0.12.4
         version: 0.12.4
@@ -5809,7 +5809,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/utils:
     dependencies:
@@ -5930,7 +5930,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   script:
     dependencies:
@@ -5966,8 +5966,8 @@ importers:
         specifier: 3.0.3
         version: 3.0.3
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.4.5
+        version: 5.4.5
 
 packages:
 
@@ -9465,7 +9465,7 @@ packages:
       '@types/yargs': 17.0.24
       chalk: 4.1.2
 
-  /@joshwooding/vite-plugin-react-docgen-typescript@0.2.1(typescript@5.2.2)(vite@4.5.0):
+  /@joshwooding/vite-plugin-react-docgen-typescript@0.2.1(typescript@5.4.5)(vite@4.5.0):
     resolution: {integrity: sha512-ou4ZJSXMMWHqGS4g8uNRbC5TiTWxAgQZiVucoUrOCWuPrTbkpJbmVyIi9jU72SBry7gQtuMEDp4YR8EEXAg7VQ==}
     peerDependencies:
       typescript: '>= 4.3.x'
@@ -9477,8 +9477,8 @@ packages:
       glob: 7.2.3
       glob-promise: 4.2.2(glob@7.2.3)
       magic-string: 0.27.0
-      react-docgen-typescript: 2.2.2(typescript@5.2.2)
-      typescript: 5.2.2
+      react-docgen-typescript: 2.2.2(typescript@5.4.5)
+      typescript: 5.4.5
       vite: 4.5.0(@types/node@16.18.23)
     dev: true
 
@@ -10543,7 +10543,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/builder-vite@7.2.2(typescript@5.2.2)(vite@4.5.0):
+  /@storybook/builder-vite@7.2.2(typescript@5.4.5)(vite@4.5.0):
     resolution: {integrity: sha512-3YDxZPJsHOsRQob/85X2Xf6pYfwbQilJBsEcuwmEV0JEO4p3JijOlO8xV58uCjkZSpuJ0ARl6t5oCMBo89DKCQ==}
     peerDependencies:
       '@preact/preset-vite': '*'
@@ -10577,7 +10577,7 @@ packages:
       remark-external-links: 8.0.0
       remark-slug: 6.1.0
       rollup: 3.27.2
-      typescript: 5.2.2
+      typescript: 5.4.5
       vite: 4.5.0(@types/node@16.18.23)
     transitivePeerDependencies:
       - encoding
@@ -10971,7 +10971,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
-  /@storybook/react-vite@7.2.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(vite@4.5.0):
+  /@storybook/react-vite@7.2.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)(vite@4.5.0):
     resolution: {integrity: sha512-j77ckWdQaVVHLXFUkDCkZRqFcYkwi3usBdg60goe+NRAdX56WKPScwL2VMKpj3hR38E9jZwNgjjB2EGp0tam8w==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -10979,10 +10979,10 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
       vite: ^3.0.0 || ^4.0.0
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.2.1(typescript@5.2.2)(vite@4.5.0)
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.2.1(typescript@5.4.5)(vite@4.5.0)
       '@rollup/pluginutils': 5.0.3
-      '@storybook/builder-vite': 7.2.2(typescript@5.2.2)(vite@4.5.0)
-      '@storybook/react': 7.2.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
+      '@storybook/builder-vite': 7.2.2(typescript@5.4.5)(vite@4.5.0)
+      '@storybook/react': 7.2.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
       '@vitejs/plugin-react': 3.0.1(vite@4.5.0)
       ast-types: 0.14.2
       magic-string: 0.30.2
@@ -10999,7 +10999,7 @@ packages:
       - vite-plugin-glimmerx
     dev: true
 
-  /@storybook/react@7.2.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2):
+  /@storybook/react@7.2.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5):
     resolution: {integrity: sha512-41vOR9mCPGeO4YBVfej+X+Fge+igelqSFCJF/koZDdYxOVehsz3bK++TNrKo2utF69evhwSmIU1iEMEjesmbNg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -11032,7 +11032,7 @@ packages:
       react-element-to-jsx-string: 15.0.0(react-dom@18.2.0)(react@18.2.0)
       ts-dedent: 2.2.0
       type-fest: 2.19.0
-      typescript: 5.2.2
+      typescript: 5.4.5
       util-deprecate: 1.0.2
     transitivePeerDependencies:
       - encoding
@@ -11875,7 +11875,7 @@ packages:
     dependencies:
       '@types/yargs-parser': 21.0.0
 
-  /@typescript-eslint/eslint-plugin@6.7.0(@typescript-eslint/parser@6.7.0)(eslint@8.49.0)(typescript@5.2.2):
+  /@typescript-eslint/eslint-plugin@6.7.0(@typescript-eslint/parser@6.7.0)(eslint@8.49.0)(typescript@5.4.5):
     resolution: {integrity: sha512-gUqtknHm0TDs1LhY12K2NA3Rmlmp88jK9Tx8vGZMfHeNMLE3GH2e9TRub+y+SOjuYgtOmok+wt1AyDPZqxbNag==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -11887,10 +11887,10 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.8.1
-      '@typescript-eslint/parser': 6.7.0(eslint@8.49.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.7.0(eslint@8.49.0)(typescript@5.4.5)
       '@typescript-eslint/scope-manager': 6.7.0
-      '@typescript-eslint/type-utils': 6.7.0(eslint@8.49.0)(typescript@5.2.2)
-      '@typescript-eslint/utils': 6.7.0(eslint@8.49.0)(typescript@5.2.2)
+      '@typescript-eslint/type-utils': 6.7.0(eslint@8.49.0)(typescript@5.4.5)
+      '@typescript-eslint/utils': 6.7.0(eslint@8.49.0)(typescript@5.4.5)
       '@typescript-eslint/visitor-keys': 6.7.0
       debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.49.0
@@ -11898,12 +11898,12 @@ packages:
       ignore: 5.2.4
       natural-compare: 1.4.0
       semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.2.2)
-      typescript: 5.2.2
+      ts-api-utils: 1.0.3(typescript@5.4.5)
+      typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/parser@6.7.0(eslint@8.49.0)(typescript@5.2.2):
+  /@typescript-eslint/parser@6.7.0(eslint@8.49.0)(typescript@5.4.5):
     resolution: {integrity: sha512-jZKYwqNpNm5kzPVP5z1JXAuxjtl2uG+5NpaMocFPTNC2EdYIgbXIPImObOkhbONxtFTTdoZstLZefbaK+wXZng==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -11915,15 +11915,15 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 6.7.0
       '@typescript-eslint/types': 6.7.0
-      '@typescript-eslint/typescript-estree': 6.7.0(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 6.7.0(typescript@5.4.5)
       '@typescript-eslint/visitor-keys': 6.7.0
       debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.49.0
-      typescript: 5.2.2
+      typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/rule-tester@6.7.0(@eslint/eslintrc@2.1.2)(eslint@8.49.0)(typescript@5.2.2):
+  /@typescript-eslint/rule-tester@6.7.0(@eslint/eslintrc@2.1.2)(eslint@8.49.0)(typescript@5.4.5):
     resolution: {integrity: sha512-xOsCbazwq/78/KiJUm2VLVbeoP6XwZtc/gWx8Tz+ajZSv+I9VyX1OnMU0uOj8PY4WHCKUmy8EOyREElAj+2l4w==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -11931,8 +11931,8 @@ packages:
       eslint: '>=8'
     dependencies:
       '@eslint/eslintrc': 2.1.2
-      '@typescript-eslint/typescript-estree': 6.7.0(typescript@5.2.2)
-      '@typescript-eslint/utils': 6.7.0(eslint@8.49.0)(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 6.7.0(typescript@5.4.5)
+      '@typescript-eslint/utils': 6.7.0(eslint@8.49.0)(typescript@5.4.5)
       ajv: 6.12.6
       eslint: 8.49.0
       lodash.merge: 4.6.2
@@ -11956,7 +11956,7 @@ packages:
       '@typescript-eslint/types': 6.7.0
       '@typescript-eslint/visitor-keys': 6.7.0
 
-  /@typescript-eslint/type-utils@6.7.0(eslint@8.49.0)(typescript@5.2.2):
+  /@typescript-eslint/type-utils@6.7.0(eslint@8.49.0)(typescript@5.4.5):
     resolution: {integrity: sha512-f/QabJgDAlpSz3qduCyQT0Fw7hHpmhOzY/Rv6zO3yO+HVIdPfIWhrQoAyG+uZVtWAIS85zAyzgAFfyEr+MgBpg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -11966,12 +11966,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.7.0(typescript@5.2.2)
-      '@typescript-eslint/utils': 6.7.0(eslint@8.49.0)(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 6.7.0(typescript@5.4.5)
+      '@typescript-eslint/utils': 6.7.0(eslint@8.49.0)(typescript@5.4.5)
       debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.49.0
-      ts-api-utils: 1.0.3(typescript@5.2.2)
-      typescript: 5.2.2
+      ts-api-utils: 1.0.3(typescript@5.4.5)
+      typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
@@ -11983,7 +11983,7 @@ packages:
     resolution: {integrity: sha512-ihPfvOp7pOcN/ysoj0RpBPOx3HQTJTrIN8UZK+WFd3/iDeFHHqeyYxa4hQk4rMhsz9H9mXpR61IzwlBVGXtl9Q==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
-  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.2.2):
+  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.4.5):
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -11998,12 +11998,12 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.2.2)
-      typescript: 5.2.2
+      tsutils: 3.21.0(typescript@5.4.5)
+      typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/typescript-estree@6.7.0(typescript@5.2.2):
+  /@typescript-eslint/typescript-estree@6.7.0(typescript@5.4.5):
     resolution: {integrity: sha512-dPvkXj3n6e9yd/0LfojNU8VMUGHWiLuBZvbM6V6QYD+2qxqInE7J+J/ieY2iGwR9ivf/R/haWGkIj04WVUeiSQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -12018,12 +12018,12 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.2.2)
-      typescript: 5.2.2
+      ts-api-utils: 1.0.3(typescript@5.4.5)
+      typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/utils@5.62.0(eslint@8.49.0)(typescript@5.2.2):
+  /@typescript-eslint/utils@5.62.0(eslint@8.49.0)(typescript@5.4.5):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -12032,10 +12032,10 @@ packages:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.49.0)
       '@types/json-schema': 7.0.12
       '@types/semver': 7.5.0
-      '@typescript-eslint/parser': 6.7.0(eslint@8.49.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.7.0(eslint@8.49.0)(typescript@5.4.5)
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.4.5)
       eslint: 8.49.0
       eslint-scope: 5.1.1
       semver: 7.5.4
@@ -12043,7 +12043,7 @@ packages:
       - supports-color
       - typescript
 
-  /@typescript-eslint/utils@6.7.0(eslint@8.49.0)(typescript@5.2.2):
+  /@typescript-eslint/utils@6.7.0(eslint@8.49.0)(typescript@5.4.5):
     resolution: {integrity: sha512-MfCq3cM0vh2slSikQYqK2Gq52gvOhe57vD2RM3V4gQRZYX4rDPnKLu5p6cm89+LJiGlwEXU8hkYxhqqEC/V3qA==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -12052,10 +12052,10 @@ packages:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.49.0)
       '@types/json-schema': 7.0.12
       '@types/semver': 7.5.0
-      '@typescript-eslint/parser': 6.7.0(eslint@8.49.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.7.0(eslint@8.49.0)(typescript@5.4.5)
       '@typescript-eslint/scope-manager': 6.7.0
       '@typescript-eslint/types': 6.7.0
-      '@typescript-eslint/typescript-estree': 6.7.0(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 6.7.0(typescript@5.4.5)
       eslint: 8.49.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -15260,7 +15260,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.7.0(eslint@8.49.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.7.0(eslint@8.49.0)(typescript@5.4.5)
       debug: 3.2.7(supports-color@5.5.0)
       eslint: 8.49.0
       eslint-import-resolver-node: 0.3.9
@@ -15278,7 +15278,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.7.0(eslint@8.49.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.7.0(eslint@8.49.0)(typescript@5.4.5)
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
@@ -15308,7 +15308,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.7.0(eslint@8.49.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.7.0(eslint@8.49.0)(typescript@5.4.5)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
@@ -15331,7 +15331,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-jest@27.2.3(@typescript-eslint/eslint-plugin@6.7.0)(eslint@8.49.0)(jest@29.6.2)(typescript@5.2.2):
+  /eslint-plugin-jest@27.2.3(@typescript-eslint/eslint-plugin@6.7.0)(eslint@8.49.0)(jest@29.6.2)(typescript@5.4.5):
     resolution: {integrity: sha512-sRLlSCpICzWuje66Gl9zvdF6mwD5X86I4u55hJyFBsxYOsBCmT5+kSUjf+fkFWVMMgpzNEupjW8WzUqi83hJAQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -15344,8 +15344,8 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 6.7.0(@typescript-eslint/parser@6.7.0)(eslint@8.49.0)(typescript@5.2.2)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.49.0)(typescript@5.2.2)
+      '@typescript-eslint/eslint-plugin': 6.7.0(@typescript-eslint/parser@6.7.0)(eslint@8.49.0)(typescript@5.4.5)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.49.0)(typescript@5.4.5)
       eslint: 8.49.0
       jest: 29.6.2(@types/node@16.18.23)
     transitivePeerDependencies:
@@ -15427,14 +15427,14 @@ packages:
       string.prototype.matchall: 4.0.7
     dev: false
 
-  /eslint-plugin-storybook@0.6.10(eslint@8.49.0)(typescript@5.2.2):
+  /eslint-plugin-storybook@0.6.10(eslint@8.49.0)(typescript@5.4.5):
     resolution: {integrity: sha512-3DKXRey06EhwnTKaG6fgMqGTy4C3z6Ikyv6VVixO5BvaExWQe3yGWIAufrC2Et0OaAMIaMwx9KWjqb/Wq+JxPg==}
     engines: {node: 12.x || 14.x || >= 16}
     peerDependencies:
       eslint: '>=6'
     dependencies:
       '@storybook/csf': 0.0.1
-      '@typescript-eslint/utils': 5.62.0(eslint@8.49.0)(typescript@5.2.2)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.49.0)(typescript@5.4.5)
       eslint: 8.49.0
       requireindex: 1.2.0
       ts-dedent: 2.2.0
@@ -16046,7 +16046,7 @@ packages:
       signal-exit: 4.1.0
     dev: true
 
-  /fork-ts-checker-webpack-plugin@6.5.2(eslint@8.49.0)(typescript@5.2.2)(webpack@4.46.0):
+  /fork-ts-checker-webpack-plugin@6.5.2(eslint@8.49.0)(typescript@5.4.5)(webpack@4.46.0):
     resolution: {integrity: sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -16074,11 +16074,11 @@ packages:
       schema-utils: 2.7.0
       semver: 7.3.2
       tapable: 1.1.3
-      typescript: 5.2.2
+      typescript: 5.4.5
       webpack: 4.46.0
     dev: true
 
-  /fork-ts-checker-webpack-plugin@6.5.2(eslint@8.49.0)(typescript@5.2.2)(webpack@5.88.2):
+  /fork-ts-checker-webpack-plugin@6.5.2(eslint@8.49.0)(typescript@5.4.5)(webpack@5.88.2):
     resolution: {integrity: sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -16106,7 +16106,7 @@ packages:
       schema-utils: 2.7.0
       semver: 7.3.2
       tapable: 1.1.3
-      typescript: 5.2.2
+      typescript: 5.4.5
       webpack: 5.88.2(esbuild@0.18.17)
 
   /form-data@2.5.1:
@@ -17018,7 +17018,7 @@ packages:
       rsvp: 4.8.5
       sort-keys: 5.0.0
       through2: 4.0.2
-      typescript: 5.2.2
+      typescript: 5.4.5
       vinyl: 3.0.0
       vinyl-fs: 3.0.3
       vue-template-compiler: 2.7.15
@@ -17933,15 +17933,15 @@ packages:
       slash: 3.0.0
       stack-utils: 2.0.6
 
-  /jest-mock-extended@3.0.4(jest@29.6.2)(typescript@5.2.2):
+  /jest-mock-extended@3.0.4(jest@29.6.2)(typescript@5.4.5):
     resolution: {integrity: sha512-2ynEZ7IEJNrhrgshklDMhrOdnmW4Nt+PhkyRqZxRgpwMo7JjmFWMzyp0+eSyk+H9KK1QjXI5xTZIw6x7cVDcRg==}
     peerDependencies:
       jest: ^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0
       typescript: ^3.0.0 || ^4.0.0 || ^5.0.0
     dependencies:
       jest: 29.6.2(@types/node@16.18.23)
-      ts-essentials: 7.0.3(typescript@5.2.2)
-      typescript: 5.2.2
+      ts-essentials: 7.0.3(typescript@5.4.5)
+      typescript: 5.4.5
     dev: true
 
   /jest-mock@27.5.1:
@@ -20041,12 +20041,12 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /postcss-styled-syntax@0.4.0(postcss@8.4.27)(typescript@5.2.2):
+  /postcss-styled-syntax@0.4.0(postcss@8.4.27)(typescript@5.4.5):
     resolution: {integrity: sha512-LvG++K8LtIyX1Q1mNuZVQYmBo+SCwn90cEkMigo4/I0QwXrEiYt8nPeJ5rrI5Uuh+5w7hRfPyJKlvQdhVZBhUg==}
     peerDependencies:
       postcss: ^8.4.21
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.4.5)
       estree-walker: 2.0.2
       postcss: 8.4.27
     transitivePeerDependencies:
@@ -20428,7 +20428,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
-  /react-dev-utils@12.0.1(eslint@8.49.0)(typescript@5.2.2)(webpack@4.46.0):
+  /react-dev-utils@12.0.1(eslint@8.49.0)(typescript@5.4.5)(webpack@4.46.0):
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -20447,7 +20447,7 @@ packages:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.2(eslint@8.49.0)(typescript@5.2.2)(webpack@4.46.0)
+      fork-ts-checker-webpack-plugin: 6.5.2(eslint@8.49.0)(typescript@5.4.5)(webpack@4.46.0)
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -20462,7 +20462,7 @@ packages:
       shell-quote: 1.7.3
       strip-ansi: 6.0.1
       text-table: 0.2.0
-      typescript: 5.2.2
+      typescript: 5.4.5
       webpack: 4.46.0
     transitivePeerDependencies:
       - eslint
@@ -20470,7 +20470,7 @@ packages:
       - vue-template-compiler
     dev: true
 
-  /react-dev-utils@12.0.1(eslint@8.49.0)(typescript@5.2.2)(webpack@5.88.2):
+  /react-dev-utils@12.0.1(eslint@8.49.0)(typescript@5.4.5)(webpack@5.88.2):
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -20489,7 +20489,7 @@ packages:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.2(eslint@8.49.0)(typescript@5.2.2)(webpack@5.88.2)
+      fork-ts-checker-webpack-plugin: 6.5.2(eslint@8.49.0)(typescript@5.4.5)(webpack@5.88.2)
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -20504,19 +20504,19 @@ packages:
       shell-quote: 1.7.3
       strip-ansi: 6.0.1
       text-table: 0.2.0
-      typescript: 5.2.2
+      typescript: 5.4.5
       webpack: 5.88.2(esbuild@0.18.17)
     transitivePeerDependencies:
       - eslint
       - supports-color
       - vue-template-compiler
 
-  /react-docgen-typescript@2.2.2(typescript@5.2.2):
+  /react-docgen-typescript@2.2.2(typescript@5.4.5):
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
       typescript: '>= 4.3.x'
     dependencies:
-      typescript: 5.2.2
+      typescript: 5.4.5
     dev: true
 
   /react-docgen@6.0.0-alpha.3:
@@ -22565,28 +22565,28 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /ts-api-utils@1.0.3(typescript@5.2.2):
+  /ts-api-utils@1.0.3(typescript@5.4.5):
     resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
     engines: {node: '>=16.13.0'}
     peerDependencies:
       typescript: '>=4.2.0'
     dependencies:
-      typescript: 5.2.2
+      typescript: 5.4.5
 
   /ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
     dev: true
 
-  /ts-essentials@7.0.3(typescript@5.2.2):
+  /ts-essentials@7.0.3(typescript@5.4.5):
     resolution: {integrity: sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==}
     peerDependencies:
       typescript: '>=3.7.0'
     dependencies:
-      typescript: 5.2.2
+      typescript: 5.4.5
     dev: true
 
-  /ts-jest@29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.2.2):
+  /ts-jest@29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5):
     resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -22618,11 +22618,11 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.5.4
-      typescript: 5.2.2
+      typescript: 5.4.5
       yargs-parser: 21.1.1
     dev: true
 
-  /ts-jest@29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.2.2):
+  /ts-jest@29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5):
     resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -22654,7 +22654,7 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.5.4
-      typescript: 5.2.2
+      typescript: 5.4.5
       yargs-parser: 21.1.1
 
   /tsconfig-paths@3.14.1:
@@ -22674,14 +22674,14 @@ packages:
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
-  /tsutils@3.21.0(typescript@5.2.2):
+  /tsutils@3.21.0(typescript@5.4.5):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.2.2
+      typescript: 5.4.5
 
   /tty-browserify@0.0.0:
     resolution: {integrity: sha512-JVa5ijo+j/sOoHGjw0sxw734b1LhBkQ3bvUGNdxnVXDCX81Yx7TFgnZygxrIIWn23hbfTaMYLwRmAxFyDuFmIw==}
@@ -22781,8 +22781,8 @@ packages:
   /typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  /typescript@5.2.2:
-    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
+  /typescript@5.4.5:
+    resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 

--- a/script/package.json
+++ b/script/package.json
@@ -21,7 +21,7 @@
     "esbuild": "0.17.11",
     "esbuild-runner": "2.2.2",
     "prettier": "3.0.3",
-    "typescript": "5.2.2"
+    "typescript": "5.4.5"
   },
   "packageManager": "pnpm@8.1.0"
 }


### PR DESCRIPTION
## Overview
Updates to TypeScript v5.4.5 (current latest).

- [What's new in TypeScript 5.3](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-3.html)
  - Import Attributes
  - `resolution-mode` in Import Types
  - `switch (true)` Narrowing
  - Narrowing on Comparison to Booleans
  - `instanceof` Narrowing Through `Symbol.hasInstance`
  - Checks for `super` Property Accesses on Instance Fields
  - Interactive Inlay Hints for Types (yay!)
  - Setting to Prefer `type` Auto-Imports
  - Optimizations by Skipping JSDoc Parsing
  - Optimizations by Comparing Non-Normalized Intersections
  - Consolidation Between `tsserverlibrary.js` and `typescript.js` (20.5% reduction in `typescript` package size)
- [What's new in TypeScript 5.4](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-4.html)
  - Preserved Narrowing in Closures Following Last Assignments
  - The `NoInfer` Utility Type
  - `Object.groupBy` and `Map.groupBy`
  - Support for `require()` calls in `--moduleResolution bundler` and `--module preserve`
  - Checked Import Attributes and Assertions
  - Quick Fix for Adding Missing Parameters

## Demo Video or Screenshot
n/a

## Testing Plan
Automated.