### PR TITLE
Fix DateWithoutTime test that was dependent on current date

### DIFF
--- a/libs/basics/src/date_without_time.test.ts
+++ b/libs/basics/src/date_without_time.test.ts
@@ -31,7 +31,13 @@ describe('DateWithoutTime', () => {
     // actually test it.
     const expectedDate = new Date();
     expectedDate.setFullYear(2024);
-    expectedDate.setMonth(1); // Months are weirdly 0-indexed
+    // Set date to 1 before setting month, since setMonth depends on the date
+    // value. According to MDN docs: "Conceptually it will add the number of
+    // days given by the current day of the month to the 1st day of the new
+    // month specified as the parameter, to return the new date."
+    expectedDate.setDate(1);
+    // Months are weirdly 0-indexed
+    expectedDate.setMonth(1);
     expectedDate.setDate(26);
     expectedDate.setHours(0);
     expectedDate.setMinutes(0);


### PR DESCRIPTION
## Overview

This test was failing today due to the high day of the month (30), which was overflowing the date to the next month when we set the month to February (since there are more than 30 days in Feb). See code comment for details

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
