### PR TITLE
libs/ballot-interpreter: Bugfix for binarized scanner images

### DIFF
--- a/libs/ballot-interpreter/src/hmpb-rust/timing_marks.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/timing_marks.rs
@@ -286,7 +286,7 @@ pub fn find_actual_bottom_marks(
             let rect_area = rect.width() * rect.height();
             if rect_sub_image
                 .pixels()
-                .filter(|(_, _, luma)| luma.0[0] < threshold)
+                .filter(|(_, _, luma)| luma.0[0] <= threshold)
                 .count()
                 > (rect_area / 2) as usize
             {


### PR DESCRIPTION


## Overview

If the image is binarized by the scanner before reaching the interpreter, the Otsu threshold will be computed as 0 (pure black). We were only accepting bottom timing marks whose luminance value was less than the threshold, which was impossible with a threshold of 0. To fix this, we allow matching the threshold exactly.
## Demo Video or Screenshot

## Testing Plan
Manual testing

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
