### PR TITLE
[MarkScan] Avoid repeating screen reader audio at the end of voter sessions

### DIFF
--- a/libs/mark-flow-ui/src/hooks/use_session_settings_manager.ts
+++ b/libs/mark-flow-ui/src/hooks/use_session_settings_manager.ts
@@ -5,6 +5,7 @@ import { isCardlessVoterAuth } from '@votingworks/utils';
 import {
   VoterSettingsManagerContext,
   useAudioControls,
+  useAudioEnabled,
   useCurrentLanguage,
   useCurrentTheme,
   useLanguageControls,
@@ -21,6 +22,7 @@ export interface UseSessionSettingsManagerParams {
 }
 
 interface VoterSettings {
+  isAudioEnabled: boolean;
   language: LanguageCode;
   theme: DefaultTheme;
 }
@@ -37,9 +39,11 @@ export function useSessionSettingsManager(
   const voterSettingsManager = React.useContext(VoterSettingsManagerContext);
   const currentTheme = useCurrentTheme();
 
-  const { reset: resetAudioSettings } = useAudioControls();
+  const { reset: resetAudioSettings, setIsEnabled: setAudioEnabled } =
+    useAudioControls();
   const { reset: resetLanguage, setLanguage } = useLanguageControls();
   const currentLanguage = useCurrentLanguage();
+  const isAudioEnabled = useAudioEnabled();
 
   const wasPreviouslyLoggedInAsVoter =
     previousAuthStatusRef.current &&
@@ -52,11 +56,13 @@ export function useSessionSettingsManager(
     // in during a voter session:
     if (wasPreviouslyLoggedInAsVoter && !isLoggedInAsVoter) {
       voterSettingsRef.current = {
+        isAudioEnabled,
         language: currentLanguage,
         theme: currentTheme,
       };
       voterSettingsManager.resetThemes();
       resetLanguage();
+      setAudioEnabled(false);
     }
 
     if (
@@ -71,6 +77,7 @@ export function useSessionSettingsManager(
         voterSettingsManager.setColorMode(voterSettings.theme.colorMode);
         voterSettingsManager.setSizeMode(voterSettings.theme.sizeMode);
         setLanguage(voterSettings.language);
+        setAudioEnabled(voterSettings.isAudioEnabled);
       } else {
         // [VVSG 2.0 7.1-A] Reset themes to default if this is a new voting
         // session:
@@ -86,10 +93,12 @@ export function useSessionSettingsManager(
     authStatus,
     currentLanguage,
     currentTheme,
+    isAudioEnabled,
     isLoggedInAsVoter,
     isVotingSessionActive,
     resetAudioSettings,
     resetLanguage,
+    setAudioEnabled,
     setLanguage,
     voterSettingsManager,
     wasPreviouslyLoggedInAsVoter,

--- a/libs/ui/src/hooks/use_audio_enabled.test.tsx
+++ b/libs/ui/src/hooks/use_audio_enabled.test.tsx
@@ -1,0 +1,24 @@
+import {
+  renderHook as renderHookWithoutContext,
+  waitFor,
+} from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
+import { useAudioEnabled } from './use_audio_enabled';
+import { newTestContext } from '../../test/test_context';
+
+test('returns false when audio context is absent', () => {
+  const { result } = renderHookWithoutContext(() => useAudioEnabled());
+
+  expect(result.current).toEqual(false);
+});
+
+test('returns audio state when rendered within audio context', async () => {
+  const { getAudioControls, renderHook } = newTestContext();
+
+  const { result } = renderHook(useAudioEnabled);
+
+  await waitFor(() => expect(result.current).toEqual(true));
+
+  act(() => getAudioControls()!.setIsEnabled(false));
+  expect(result.current).toEqual(false);
+});

--- a/libs/ui/src/hooks/use_audio_enabled.ts
+++ b/libs/ui/src/hooks/use_audio_enabled.ts
@@ -1,0 +1,5 @@
+import { useAudioContext } from '../ui_strings/audio_context';
+
+export function useAudioEnabled(): boolean {
+  return useAudioContext()?.isEnabled || false;
+}

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -25,6 +25,7 @@ export * from './globals';
 export * from './hand_marked_paper_ballot_prose';
 export * from './hooks/ui_strings_api';
 export * from './hooks/use_audio_controls';
+export * from './hooks/use_audio_enabled';
 export * from './hooks/use_autocomplete';
 export * from './hooks/use_available_languages';
 export * from './hooks/use_cancelable_promise';

--- a/libs/ui/test/test_context.tsx
+++ b/libs/ui/test/test_context.tsx
@@ -17,7 +17,7 @@ import {
   useAudioContext,
 } from '../src/ui_strings/audio_context';
 import { UiStringsContextProvider } from '../src/ui_strings/ui_strings_context';
-import { RenderResult, render } from './react_testing_library';
+import { RenderResult, render, renderHook } from './react_testing_library';
 import {
   QUERY_CLIENT_DEFAULT_OPTIONS,
   VxRenderOptions,
@@ -40,6 +40,7 @@ export interface TestContext {
     ui: React.ReactElement,
     renderOptions?: VxRenderOptions
   ) => RenderResult;
+  renderHook: typeof renderHook;
 }
 
 export function newTestContext(
@@ -142,6 +143,7 @@ export function newTestContext(
         rerender: (newUi) => result.rerender(<Wrapper>{newUi}</Wrapper>),
       };
     },
+    renderHook: (renderer) => renderHook(renderer, { wrapper: Wrapper }),
     getAudioContext: () => currentAudioContext,
     getAudioControls: () => currentAudioControls,
     getLanguageContext: () => currentLanguageContext,


### PR DESCRIPTION
## Overview

Related to: https://github.com/votingworks/vxsuite/issues/4762

Updating the voter session settings manager to disable audio whenever we're not in a cardless voter auth session and return to the previous state when the cardless voter auth session is resumed.

This avoids audio continuing to play whenever the voter is "logged out" in general. Motivated by an edge case at the end of the voter session when the underlying URL is updated while the `BallotSuccessfullyCastPage` page is still rendered, triggering the screen reader (which listens on page navigation) and causes the text on that page to be repeated.

## Demo Video or Screenshot

_(Volume's a little low, so you might have to turn it up a bit)_

Tough to repro the session-end repeated audio issue, since it relies on race condition, but this shows audio getting disabled whenever a voter session is interrupted/ended:

### Before [ 🔊 ]:

https://github.com/votingworks/vxsuite/assets/264902/7f43bcbf-c272-4324-9b39-66808f53a684

### After [ 🔊 ]:

https://github.com/votingworks/vxsuite/assets/264902/971ba316-c4fc-4006-a49c-d2451a68d015

## Testing Plan
- Updated unit tests, manually verified

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
