### PR TITLE
apps/scan: Prevent hanging when second ballot inserted during accept

### DIFF
--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -346,8 +346,18 @@ function buildMachine({
               target: '#rejecting',
             },
             {
-              cond: (_, { status }) => !status.documentInScanner,
+              cond: (_, { status }) => !anyRearSensorCovered(status),
               target: '#accepted',
+            },
+            // If a second ballot is inserted before the first is fully ejected,
+            // go back to paperInFront. The first ballot will likely be fully
+            // ejected by the time the second ballot is removed. Attempting to
+            // eject the first ballot again will be a no-op (since it was
+            // already ejected), and we'll successfully transition to the
+            // accepted state.
+            {
+              cond: (_, { status }) => anyFrontSensorCovered(status),
+              target: 'paperInFront',
             },
           ],
         },


### PR DESCRIPTION

## Overview

Previously, we were waiting for the scanner to no longer have any document in the scanner to declare accepting complete. It's possible to trick the scanner by feeding a second ballot in while the motors are running to accept the first ballot, which results in either:
- The first ballot successfully ejected, while the second ballot is held in the front
- The first ballot successfully ejected, while the second ballot is held in the middle (covering front and rear sensors)
- The first ballot jammed, while the second ballot is held in the front

We handle this case with a few updates:
- Only declare accepting complete when the rear is cleared
- If the front is covered before the rear is cleared (very unlikely, but possible), go back to the warning to remove the second ballot before deciding whether the first ballot was successfully accepted

## Demo Video or Screenshot
Common case: The first ballot successfully ejected, while the second ballot is held in the front

https://github.com/votingworks/vxsuite/assets/530106/dd3642dc-97a3-4edf-9832-5b028a73c55d

Rare case: The first ballot successfully ejected, while the second ballot is held in the middle (covering front and rear sensors)

https://github.com/votingworks/vxsuite/assets/530106/be070149-079b-4791-b72c-62a96e4b04d5


I didn't have enough hands to actually create the third case (the first ballot jammed, while the second ballot is held in the front), but I've tested jams separately.

## Testing Plan
Manual testing + automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
