### PR TITLE
chore(deps): upgrade `zod` to latest (v3.23.5)

### DIFF
--- a/apps/admin/backend/package.json
+++ b/apps/admin/backend/package.json
@@ -68,7 +68,7 @@
     "tmp": "^0.2.1",
     "uuid": "9.0.1",
     "zip-stream": "^4.1.0",
-    "zod": "3.14.4"
+    "zod": "3.23.5"
   },
   "devDependencies": {
     "@jest/types": "^29.6.1",

--- a/apps/admin/frontend/package.json
+++ b/apps/admin/frontend/package.json
@@ -101,7 +101,7 @@
     "use-interval": "1.4.0",
     "util": "^0.12.4",
     "uuid": "9.0.1",
-    "zod": "3.14.4"
+    "zod": "3.23.5"
   },
   "devDependencies": {
     "@jest/types": "^29.6.1",

--- a/apps/central-scan/backend/package.json
+++ b/apps/central-scan/backend/package.json
@@ -63,7 +63,7 @@
     "luxon": "^3.0.0",
     "tmp": "^0.2.1",
     "uuid": "9.0.1",
-    "zod": "3.14.4"
+    "zod": "3.23.5"
   },
   "devDependencies": {
     "@jest/types": "^29.6.1",

--- a/apps/central-scan/frontend/package.json
+++ b/apps/central-scan/frontend/package.json
@@ -75,7 +75,7 @@
     "styled-components": "^5.3.11",
     "use-interval": "1.4.0",
     "util": "^0.12.4",
-    "zod": "3.14.4"
+    "zod": "3.23.5"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.17.0",

--- a/apps/design/backend/package.json
+++ b/apps/design/backend/package.json
@@ -59,7 +59,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "uuid": "9.0.1",
-    "zod": "3.14.4"
+    "zod": "3.23.5"
   },
   "devDependencies": {
     "@jest/types": "^29.6.1",

--- a/apps/mark-scan/backend/package.json
+++ b/apps/mark-scan/backend/package.json
@@ -64,7 +64,7 @@
     "tmp": "^0.2.1",
     "uuid": "9.0.1",
     "xstate": "^4.33.0",
-    "zod": "3.14.4"
+    "zod": "3.23.5"
   },
   "devDependencies": {
     "@jest/types": "^29.6.1",

--- a/apps/mark/backend/package.json
+++ b/apps/mark/backend/package.json
@@ -51,7 +51,7 @@
     "js-sha256": "^0.9.0",
     "luxon": "^3.0.0",
     "tmp": "^0.2.1",
-    "zod": "3.14.4"
+    "zod": "3.23.5"
   },
   "devDependencies": {
     "@jest/types": "^29.6.1",

--- a/apps/scan/backend/package.json
+++ b/apps/scan/backend/package.json
@@ -71,7 +71,7 @@
     "tmp": "^0.2.1",
     "uuid": "9.0.1",
     "xstate": "^4.33.0",
-    "zod": "3.14.4"
+    "zod": "3.23.5"
   },
   "devDependencies": {
     "@jest/types": "^29.6.1",

--- a/apps/scan/frontend/package.json
+++ b/apps/scan/frontend/package.json
@@ -75,7 +75,7 @@
     "styled-components": "^5.3.11",
     "use-sound": "^4.0.1",
     "util": "^0.12.4",
-    "zod": "3.14.4"
+    "zod": "3.23.5"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.17.0",

--- a/libs/api/package.json
+++ b/libs/api/package.json
@@ -38,7 +38,7 @@
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/types": "workspace:*",
     "@votingworks/utils": "workspace:*",
-    "zod": "3.14.4"
+    "zod": "3.23.5"
   },
   "devDependencies": {
     "@types/jest": "^29.5.3",

--- a/libs/auth/package.json
+++ b/libs/auth/package.json
@@ -48,7 +48,7 @@
     "tmp": "^0.2.1",
     "uuid": "9.0.1",
     "yargs": "17.7.1",
-    "zod": "3.14.4"
+    "zod": "3.23.5"
   },
   "devDependencies": {
     "@types/combined-stream": "^1.0.3",

--- a/libs/backend/package.json
+++ b/libs/backend/package.json
@@ -61,7 +61,7 @@
     "tmp": "^0.2.1",
     "usb": "^2.6.0",
     "uuid": "9.0.1",
-    "zod": "3.14.4"
+    "zod": "3.23.5"
   },
   "devDependencies": {
     "@types/debug": "4.1.8",

--- a/libs/cdf-schema-builder/package.json
+++ b/libs/cdf-schema-builder/package.json
@@ -38,7 +38,7 @@
     "@votingworks/basics": "workspace:*",
     "jsdom": "20.0.1",
     "json-schema": "^0.4.0",
-    "zod": "3.14.4"
+    "zod": "3.23.5"
   },
   "devDependencies": {
     "@types/jest": "^29.5.3",

--- a/libs/converter-nh-accuvote/package.json
+++ b/libs/converter-nh-accuvote/package.json
@@ -35,7 +35,7 @@
     "jsdom": "20.0.1",
     "luxon": "^3.0.0",
     "tmp": "^0.2.1",
-    "zod": "3.14.4"
+    "zod": "3.23.5"
   },
   "devDependencies": {
     "@jest/types": "^29.6.1",

--- a/libs/cvr-fixture-generator/package.json
+++ b/libs/cvr-fixture-generator/package.json
@@ -51,7 +51,7 @@
     "jest-watch-typeahead": "^2.2.2",
     "tmp": "^0.2.1",
     "ts-jest": "29.1.1",
-    "zod": "3.14.4"
+    "zod": "3.23.5"
   },
   "packageManager": "pnpm@8.1.0"
 }

--- a/libs/fs/package.json
+++ b/libs/fs/package.json
@@ -41,7 +41,7 @@
     "@votingworks/utils": "workspace:*",
     "buffer": "^6.0.3",
     "micromatch": "^4.0.5",
-    "zod": "3.14.4"
+    "zod": "3.23.5"
   },
   "devDependencies": {
     "@types/debug": "4.1.8",

--- a/libs/logging/package.json
+++ b/libs/logging/package.json
@@ -47,7 +47,7 @@
     "@votingworks/utils": "workspace:*",
     "debug": "4.3.4",
     "yargs": "17.7.1",
-    "zod": "3.14.4"
+    "zod": "3.23.5"
   },
   "devDependencies": {
     "@types/debug": "4.1.8",

--- a/libs/mark-flow-ui/package.json
+++ b/libs/mark-flow-ui/package.json
@@ -59,7 +59,7 @@
     "react-modal": "^3.16.1",
     "react-router-dom": "^5.3.4",
     "use-interval": "1.4.0",
-    "zod": "3.14.4"
+    "zod": "3.23.5"
   },
   "devDependencies": {
     "@storybook/cli": "^7.2.2",

--- a/libs/pdi-scanner/package.json
+++ b/libs/pdi-scanner/package.json
@@ -43,7 +43,7 @@
     "@votingworks/image-utils": "workspace:*",
     "@votingworks/types": "workspace:*",
     "debug": "4.3.4",
-    "zod": "3.14.4"
+    "zod": "3.23.5"
   },
   "devDependencies": {
     "@types/debug": "4.1.8",

--- a/libs/printing/package.json
+++ b/libs/printing/package.json
@@ -47,7 +47,7 @@
     "styled-components": "^5.3.11",
     "tmp": "^0.2.1",
     "tmp-promise": "^3.0.3",
-    "zod": "3.14.4"
+    "zod": "3.23.5"
   },
   "devDependencies": {
     "@types/debug": "4.1.8",

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -42,7 +42,7 @@
     "@votingworks/basics": "workspace:*",
     "js-sha256": "^0.9.0",
     "util": "^0.12.4",
-    "zod": "3.14.4"
+    "zod": "3.23.5"
   },
   "devDependencies": {
     "@types/jest": "^29.5.3",

--- a/libs/types/src/__snapshots__/election.test.ts.snap
+++ b/libs/types/src/__snapshots__/election.test.ts.snap
@@ -34,6 +34,7 @@ VXF error: [
   {
     "code": "custom",
     "message": "Input not instance of DateWithoutTime",
+    "fatal": true,
     "path": [
       "date"
     ]
@@ -194,14 +195,13 @@ CDF error: [
     "message": "Required"
   },
   {
-    "code": "invalid_enum_value",
-    "options": [
-      "1.0.0"
-    ],
+    "expected": "'1.0.0'",
+    "received": "undefined",
+    "code": "invalid_type",
     "path": [
       "Version"
     ],
-    "message": "Invalid enum value. Expected '1.0.0'"
+    "message": "Required"
   }
 ]]
 `;

--- a/libs/types/src/__snapshots__/schema.test.ts.snap
+++ b/libs/types/src/__snapshots__/schema.test.ts.snap
@@ -1,0 +1,325 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`contest IDs cannot start with an underscore 1`] = `
+[ZodError: [
+  {
+    "code": "custom",
+    "message": "IDs may not start with an underscore",
+    "path": [
+      "id"
+    ]
+  }
+]]
+`;
+
+exports[`ensures election date is YYYY-MM-DD 1`] = `
+[ZodError: [
+  {
+    "code": "custom",
+    "message": "Date must be in the format YYYY-MM-DD",
+    "path": [
+      "date"
+    ]
+  }
+]]
+`;
+
+exports[`parsing gives specific errors for nested objects 1`] = `
+[ZodError: [
+  {
+    "code": "invalid_union",
+    "unionErrors": [
+      {
+        "issues": [
+          {
+            "code": "invalid_type",
+            "expected": "string",
+            "received": "number",
+            "path": [
+              "contests",
+              1,
+              "title"
+            ],
+            "message": "Expected string, received number"
+          }
+        ],
+        "name": "ZodError"
+      },
+      {
+        "issues": [
+          {
+            "code": "invalid_type",
+            "expected": "string",
+            "received": "number",
+            "path": [
+              "contests",
+              1,
+              "title"
+            ],
+            "message": "Expected string, received number"
+          },
+          {
+            "received": "candidate",
+            "code": "invalid_literal",
+            "expected": "yesno",
+            "path": [
+              "contests",
+              1,
+              "type"
+            ],
+            "message": "Invalid literal value, expected \\"yesno\\""
+          },
+          {
+            "code": "invalid_type",
+            "expected": "string",
+            "received": "undefined",
+            "path": [
+              "contests",
+              1,
+              "description"
+            ],
+            "message": "Required"
+          },
+          {
+            "code": "invalid_type",
+            "expected": "object",
+            "received": "undefined",
+            "path": [
+              "contests",
+              1,
+              "yesOption"
+            ],
+            "message": "Required"
+          },
+          {
+            "code": "invalid_type",
+            "expected": "object",
+            "received": "undefined",
+            "path": [
+              "contests",
+              1,
+              "noOption"
+            ],
+            "message": "Required"
+          }
+        ],
+        "name": "ZodError"
+      }
+    ],
+    "path": [
+      "contests",
+      1
+    ],
+    "message": "Invalid input"
+  }
+]]
+`;
+
+exports[`parsing validates candidate party references 1`] = `
+[ZodError: [
+  {
+    "code": "custom",
+    "path": [
+      "contests",
+      0,
+      "candidates",
+      0,
+      "partyIds",
+      0
+    ],
+    "message": "Candidate 'C' in contest 'CC' has party 'not-a-party', but no such party is defined. Parties defined: [PARTY]."
+  }
+]]
+`;
+
+exports[`parsing validates contest party references 1`] = `
+[ZodError: [
+  {
+    "code": "custom",
+    "path": [
+      "contests",
+      0,
+      "partyId"
+    ],
+    "message": "Contest 'CC' has party 'not-a-party', but no such party is defined. Parties defined: [PARTY]."
+  }
+]]
+`;
+
+exports[`parsing validates district references 1`] = `
+[ZodError: [
+  {
+    "code": "custom",
+    "path": [
+      "ballotStyles",
+      0,
+      "districts",
+      0
+    ],
+    "message": "Ballot style '1' has district 'D', but no such district is defined. Districts defined: [DIS]."
+  }
+]]
+`;
+
+exports[`parsing validates precinct references 1`] = `
+[ZodError: [
+  {
+    "code": "custom",
+    "path": [
+      "ballotStyles",
+      0,
+      "precincts",
+      0
+    ],
+    "message": "Ballot style '1' has precinct 'P', but no such precinct is defined. Precincts defined: [PRE]."
+  }
+]]
+`;
+
+exports[`supports ballot layout paper size 1`] = `
+[ZodError: [
+  {
+    "received": "A4",
+    "code": "invalid_enum_value",
+    "options": [
+      "letter",
+      "legal",
+      "custom-8.5x17",
+      "custom-8.5x18",
+      "custom-8.5x21",
+      "custom-8.5x22"
+    ],
+    "path": [
+      "ballotLayout",
+      "paperSize"
+    ],
+    "message": "Invalid enum value. Expected 'letter' | 'legal' | 'custom-8.5x17' | 'custom-8.5x18' | 'custom-8.5x21' | 'custom-8.5x22', received 'A4'"
+  }
+]]
+`;
+
+exports[`supports ballot layout paper size 2`] = `
+[ZodError: [
+  {
+    "code": "invalid_type",
+    "expected": "object",
+    "received": "string",
+    "path": [
+      "ballotLayout"
+    ],
+    "message": "Expected object, received string"
+  }
+]]
+`;
+
+exports[`validates uniqueness of ballot style ids 1`] = `
+[ZodError: [
+  {
+    "code": "custom",
+    "path": [
+      1,
+      "id"
+    ],
+    "message": "Duplicate ballot style '1' found."
+  }
+]]
+`;
+
+exports[`validates uniqueness of candidate ids within a contest 1`] = `
+[ZodError: [
+  {
+    "code": "custom",
+    "path": [
+      "candidates",
+      1,
+      "id"
+    ],
+    "message": "Duplicate candidate 'C' found."
+  }
+]]
+`;
+
+exports[`validates uniqueness of contest ids 1`] = `
+[ZodError: [
+  {
+    "code": "custom",
+    "path": [
+      "contests",
+      2,
+      "id"
+    ],
+    "message": "Duplicate contest 'CC' found."
+  },
+  {
+    "code": "custom",
+    "path": [
+      "contests",
+      3,
+      "id"
+    ],
+    "message": "Duplicate contest 'YNC' found."
+  },
+  {
+    "code": "custom",
+    "path": [
+      "contests",
+      2,
+      "yes/noOption",
+      "id"
+    ],
+    "message": "Duplicate yes/no contest option 'YNC-option-yes' found."
+  },
+  {
+    "code": "custom",
+    "path": [
+      "contests",
+      3,
+      "yes/noOption",
+      "id"
+    ],
+    "message": "Duplicate yes/no contest option 'YNC-option-no' found."
+  }
+]]
+`;
+
+exports[`validates uniqueness of district ids 1`] = `
+[ZodError: [
+  {
+    "code": "custom",
+    "path": [
+      "districts",
+      1,
+      "id"
+    ],
+    "message": "Duplicate district 'D' found."
+  }
+]]
+`;
+
+exports[`validates uniqueness of party ids 1`] = `
+[ZodError: [
+  {
+    "code": "custom",
+    "path": [
+      "parties",
+      1,
+      "id"
+    ],
+    "message": "Duplicate party 'PARTY' found."
+  }
+]]
+`;
+
+exports[`validates uniqueness of precinct ids 1`] = `
+[ZodError: [
+  {
+    "code": "custom",
+    "path": [
+      "precincts",
+      1,
+      "id"
+    ],
+    "message": "Duplicate precinct 'P' found."
+  }
+]]
+`;

--- a/libs/types/src/__snapshots__/system_settings.test.ts.snap
+++ b/libs/types/src/__snapshots__/system_settings.test.ts.snap
@@ -1,0 +1,98 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`disallows invalid adjudication reasons 1`] = `
+[ZodError: [
+  {
+    "received": "abcdefg",
+    "code": "invalid_enum_value",
+    "options": [
+      "UninterpretableBallot",
+      "MarginalMark",
+      "Overvote",
+      "Undervote",
+      "BlankBallot",
+      "UnmarkedWriteIn"
+    ],
+    "path": [
+      "centralScanAdjudicationReasons",
+      0
+    ],
+    "message": "Invalid enum value. Expected 'UninterpretableBallot' | 'MarginalMark' | 'Overvote' | 'Undervote' | 'BlankBallot' | 'UnmarkedWriteIn', received 'abcdefg'"
+  },
+  {
+    "received": "abcdefg",
+    "code": "invalid_enum_value",
+    "options": [
+      "UninterpretableBallot",
+      "MarginalMark",
+      "Overvote",
+      "Undervote",
+      "BlankBallot",
+      "UnmarkedWriteIn"
+    ],
+    "path": [
+      "precinctScanAdjudicationReasons",
+      0
+    ],
+    "message": "Invalid enum value. Expected 'UninterpretableBallot' | 'MarginalMark' | 'Overvote' | 'Undervote' | 'BlankBallot' | 'UnmarkedWriteIn', received 'abcdefg'"
+  }
+]]
+`;
+
+exports[`disallows invalid adjudication reasons 2`] = `
+[ZodError: [
+  {
+    "code": "invalid_type",
+    "expected": "array",
+    "received": "string",
+    "path": [
+      "centralScanAdjudicationReasons"
+    ],
+    "message": "Expected array, received string"
+  }
+]]
+`;
+
+exports[`disallows invalid mark thresholds 1`] = `
+[ZodError: [
+  {
+    "code": "custom",
+    "message": "marginal mark threshold must be less than or equal to definite mark threshold",
+    "path": [
+      "markThresholds"
+    ]
+  }
+]]
+`;
+
+exports[`disallows invalid mark thresholds 2`] = `
+[ZodError: [
+  {
+    "code": "invalid_type",
+    "expected": "number",
+    "received": "undefined",
+    "path": [
+      "markThresholds",
+      "definite"
+    ],
+    "message": "Required"
+  }
+]]
+`;
+
+exports[`disallows invalid mark thresholds 3`] = `
+[ZodError: [
+  {
+    "code": "too_big",
+    "maximum": 1,
+    "type": "number",
+    "inclusive": true,
+    "exact": false,
+    "message": "Number must be less than or equal to 1",
+    "path": [
+      "markThresholds",
+      "definite"
+    ]
+  }
+]]
+`;

--- a/libs/types/src/cdf/ballot-definition/__snapshots__/convert.test.ts.snap
+++ b/libs/types/src/cdf/ballot-definition/__snapshots__/convert.test.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`safeParseCdfBallotDefinition 1`] = `
+Err {
+  "error": [Error: unable to find an element matching a predicate],
+}
+`;
+
+exports[`safeParseCdfBallotDefinition 2`] = `
+Err {
+  "error": [Error: Ballot definition contains duplicate @ids: same-id-0, same-id-1],
+}
+`;

--- a/libs/types/src/cdf/ballot-definition/convert.test.ts
+++ b/libs/types/src/cdf/ballot-definition/convert.test.ts
@@ -313,11 +313,7 @@ test('safeParseCdfBallotDefinition', () => {
         (unit) => unit.Type === 'state'
       ),
     })
-  ).toMatchInlineSnapshot(`
-    Err {
-      "error": [Error: unable to find an element matching a predicate],
-    }
-  `);
+  ).toMatchSnapshot();
 
   // Duplicate ids should be rejected
   expect(
@@ -332,11 +328,7 @@ test('safeParseCdfBallotDefinition', () => {
         '@id': `same-id-${i}`,
       })),
     })
-  ).toMatchInlineSnapshot(`
-    Err {
-      "error": [Error: Ballot definition contains duplicate @ids: same-id-0, same-id-1],
-    }
-  `);
+  ).toMatchSnapshot();
 
   expect(safeParseCdfBallotDefinition(testCdfBallotDefinition)).toEqual(
     ok({

--- a/libs/types/src/schema.test.ts
+++ b/libs/types/src/schema.test.ts
@@ -37,95 +37,7 @@ test('parsing gives specific errors for nested objects', () => {
         ],
       })
       .unsafeUnwrapErr()
-  ).toMatchInlineSnapshot(`
-    [ZodError: [
-      {
-        "code": "invalid_union",
-        "unionErrors": [
-          {
-            "issues": [
-              {
-                "code": "invalid_type",
-                "expected": "string",
-                "received": "number",
-                "path": [
-                  "contests",
-                  1,
-                  "title"
-                ],
-                "message": "Expected string, received number"
-              }
-            ],
-            "name": "ZodError"
-          },
-          {
-            "issues": [
-              {
-                "code": "invalid_type",
-                "expected": "string",
-                "received": "number",
-                "path": [
-                  "contests",
-                  1,
-                  "title"
-                ],
-                "message": "Expected string, received number"
-              },
-              {
-                "code": "invalid_literal",
-                "expected": "yesno",
-                "path": [
-                  "contests",
-                  1,
-                  "type"
-                ],
-                "message": "Invalid literal value, expected \\"yesno\\""
-              },
-              {
-                "code": "invalid_type",
-                "expected": "string",
-                "received": "undefined",
-                "path": [
-                  "contests",
-                  1,
-                  "description"
-                ],
-                "message": "Required"
-              },
-              {
-                "code": "invalid_type",
-                "expected": "object",
-                "received": "undefined",
-                "path": [
-                  "contests",
-                  1,
-                  "yesOption"
-                ],
-                "message": "Required"
-              },
-              {
-                "code": "invalid_type",
-                "expected": "object",
-                "received": "undefined",
-                "path": [
-                  "contests",
-                  1,
-                  "noOption"
-                ],
-                "message": "Required"
-              }
-            ],
-            "name": "ZodError"
-          }
-        ],
-        "path": [
-          "contests",
-          1
-        ],
-        "message": "Invalid input"
-      }
-    ]]
-  `);
+  ).toMatchSnapshot();
 });
 
 test('ensures election date is YYYY-MM-DD', () => {
@@ -136,17 +48,7 @@ test('ensures election date is YYYY-MM-DD', () => {
         date: 'not ISO',
       })
       .unsafeUnwrapErr()
-  ).toMatchInlineSnapshot(`
-    [ZodError: [
-      {
-        "code": "custom",
-        "message": "Date must be in the format YYYY-MM-DD",
-        "path": [
-          "date"
-        ]
-      }
-    ]]
-  `);
+  ).toMatchSnapshot();
 });
 
 test('parsing a valid election object succeeds', () => {
@@ -173,17 +75,7 @@ test('contest IDs cannot start with an underscore', () => {
       ...electionGeneral.contests[0],
       id: '_president',
     }).unsafeUnwrapErr()
-  ).toMatchInlineSnapshot(`
-    [ZodError: [
-      {
-        "code": "custom",
-        "message": "IDs may not start with an underscore",
-        "path": [
-          "id"
-        ]
-      }
-    ]]
-  `);
+  ).toMatchSnapshot();
 });
 
 test('allows valid adjudication reasons', () => {
@@ -209,26 +101,7 @@ test('supports ballot layout paper size', () => {
         },
       })
       .unsafeUnwrapErr()
-  ).toMatchInlineSnapshot(`
-    [ZodError: [
-      {
-        "code": "invalid_enum_value",
-        "options": [
-          "letter",
-          "legal",
-          "custom-8.5x17",
-          "custom-8.5x18",
-          "custom-8.5x21",
-          "custom-8.5x22"
-        ],
-        "path": [
-          "ballotLayout",
-          "paperSize"
-        ],
-        "message": "Invalid enum value. Expected 'letter' | 'legal' | 'custom-8.5x17' | 'custom-8.5x18' | 'custom-8.5x21' | 'custom-8.5x22'"
-      }
-    ]]
-  `);
+  ).toMatchSnapshot();
 
   expect(
     t
@@ -237,19 +110,7 @@ test('supports ballot layout paper size', () => {
         ballotLayout: 'letter',
       })
       .unsafeUnwrapErr()
-  ).toMatchInlineSnapshot(`
-    [ZodError: [
-      {
-        "code": "invalid_type",
-        "expected": "object",
-        "received": "string",
-        "path": [
-          "ballotLayout"
-        ],
-        "message": "Expected object, received string"
-      }
-    ]]
-  `);
+  ).toMatchSnapshot();
 });
 
 test('parsing validates district references', () => {
@@ -260,20 +121,7 @@ test('parsing validates district references', () => {
         districts: [{ id: 'DIS', name: 'DIS' }],
       })
       .unsafeUnwrapErr()
-  ).toMatchInlineSnapshot(`
-    [ZodError: [
-      {
-        "code": "custom",
-        "path": [
-          "ballotStyles",
-          0,
-          "districts",
-          0
-        ],
-        "message": "Ballot style '1' has district 'D', but no such district is defined. Districts defined: [DIS]."
-      }
-    ]]
-  `);
+  ).toMatchSnapshot();
 });
 
 test('parsing validates precinct references', () => {
@@ -284,20 +132,7 @@ test('parsing validates precinct references', () => {
         precincts: [{ id: 'PRE', name: 'PRE' }],
       })
       .unsafeUnwrapErr()
-  ).toMatchInlineSnapshot(`
-    [ZodError: [
-      {
-        "code": "custom",
-        "path": [
-          "ballotStyles",
-          0,
-          "precincts",
-          0
-        ],
-        "message": "Ballot style '1' has precinct 'P', but no such precinct is defined. Precincts defined: [PRE]."
-      }
-    ]]
-  `);
+  ).toMatchSnapshot();
 });
 
 test('parsing validates contest party references', () => {
@@ -322,19 +157,7 @@ test('parsing validates contest party references', () => {
         ],
       })
       .unsafeUnwrapErr()
-  ).toMatchInlineSnapshot(`
-    [ZodError: [
-      {
-        "code": "custom",
-        "path": [
-          "contests",
-          0,
-          "partyId"
-        ],
-        "message": "Contest 'CC' has party 'not-a-party', but no such party is defined. Parties defined: [PARTY]."
-      }
-    ]]
-  `);
+  ).toMatchSnapshot();
 });
 
 test('parsing validates candidate party references', () => {
@@ -365,22 +188,7 @@ test('parsing validates candidate party references', () => {
         ],
       })
       .unsafeUnwrapErr()
-  ).toMatchInlineSnapshot(`
-    [ZodError: [
-      {
-        "code": "custom",
-        "path": [
-          "contests",
-          0,
-          "candidates",
-          0,
-          "partyIds",
-          0
-        ],
-        "message": "Candidate 'C' in contest 'CC' has party 'not-a-party', but no such party is defined. Parties defined: [PARTY]."
-      }
-    ]]
-  `);
+  ).toMatchSnapshot();
 });
 
 test('validates uniqueness of district ids', () => {
@@ -391,19 +199,7 @@ test('validates uniqueness of district ids', () => {
         districts: [...electionGeneral.districts, ...electionGeneral.districts],
       })
       .unsafeUnwrapErr()
-  ).toMatchInlineSnapshot(`
-    [ZodError: [
-      {
-        "code": "custom",
-        "path": [
-          "districts",
-          1,
-          "id"
-        ],
-        "message": "Duplicate district 'D' found."
-      }
-    ]]
-  `);
+  ).toMatchSnapshot();
 });
 
 test('validates uniqueness of ballot style ids', () => {
@@ -412,18 +208,7 @@ test('validates uniqueness of ballot style ids', () => {
       ...electionGeneral.ballotStyles,
       ...electionGeneral.ballotStyles,
     ]).unsafeUnwrapErr()
-  ).toMatchInlineSnapshot(`
-    [ZodError: [
-      {
-        "code": "custom",
-        "path": [
-          1,
-          "id"
-        ],
-        "message": "Duplicate ballot style '1' found."
-      }
-    ]]
-  `);
+  ).toMatchSnapshot();
 });
 
 test('validates uniqueness of precinct ids', () => {
@@ -434,19 +219,7 @@ test('validates uniqueness of precinct ids', () => {
         precincts: [...electionGeneral.precincts, ...electionGeneral.precincts],
       })
       .unsafeUnwrapErr()
-  ).toMatchInlineSnapshot(`
-    [ZodError: [
-      {
-        "code": "custom",
-        "path": [
-          "precincts",
-          1,
-          "id"
-        ],
-        "message": "Duplicate precinct 'P' found."
-      }
-    ]]
-  `);
+  ).toMatchSnapshot();
 });
 
 test('validates uniqueness of contest ids', () => {
@@ -457,48 +230,7 @@ test('validates uniqueness of contest ids', () => {
         contests: [...electionGeneral.contests, ...electionGeneral.contests],
       })
       .unsafeUnwrapErr()
-  ).toMatchInlineSnapshot(`
-    [ZodError: [
-      {
-        "code": "custom",
-        "path": [
-          "contests",
-          2,
-          "id"
-        ],
-        "message": "Duplicate contest 'CC' found."
-      },
-      {
-        "code": "custom",
-        "path": [
-          "contests",
-          3,
-          "id"
-        ],
-        "message": "Duplicate contest 'YNC' found."
-      },
-      {
-        "code": "custom",
-        "path": [
-          "contests",
-          2,
-          "yes/noOption",
-          "id"
-        ],
-        "message": "Duplicate yes/no contest option 'YNC-option-yes' found."
-      },
-      {
-        "code": "custom",
-        "path": [
-          "contests",
-          3,
-          "yes/noOption",
-          "id"
-        ],
-        "message": "Duplicate yes/no contest option 'YNC-option-no' found."
-      }
-    ]]
-  `);
+  ).toMatchSnapshot();
 });
 
 test('validates uniqueness of party ids', () => {
@@ -509,19 +241,7 @@ test('validates uniqueness of party ids', () => {
         parties: [...electionGeneral.parties, ...electionGeneral.parties],
       })
       .unsafeUnwrapErr()
-  ).toMatchInlineSnapshot(`
-    [ZodError: [
-      {
-        "code": "custom",
-        "path": [
-          "parties",
-          1,
-          "id"
-        ],
-        "message": "Duplicate party 'PARTY' found."
-      }
-    ]]
-  `);
+  ).toMatchSnapshot();
 });
 
 test('validates uniqueness of candidate ids within a contest', () => {
@@ -532,19 +252,7 @@ test('validates uniqueness of candidate ids within a contest', () => {
       ...contest,
       candidates: [...contest.candidates, ...contest.candidates],
     }).unsafeUnwrapErr()
-  ).toMatchInlineSnapshot(`
-    [ZodError: [
-      {
-        "code": "custom",
-        "path": [
-          "candidates",
-          1,
-          "id"
-        ],
-        "message": "Duplicate candidate 'C' found."
-      }
-    ]]
-  `);
+  ).toMatchSnapshot();
 });
 
 test('safeParseVxfElectionDefinition computes the election hash', () => {

--- a/libs/types/src/system_settings.test.ts
+++ b/libs/types/src/system_settings.test.ts
@@ -26,17 +26,7 @@ test('disallows invalid mark thresholds', () => {
         markThresholds: { definite: 0.2, marginal: 0.3 },
       })
     ).unsafeUnwrapErr()
-  ).toMatchInlineSnapshot(`
-    [ZodError: [
-      {
-        "code": "custom",
-        "message": "marginal mark threshold must be less than or equal to definite mark threshold",
-        "path": [
-          "markThresholds"
-        ]
-      }
-    ]]
-  `);
+  ).toMatchSnapshot();
 
   expect(
     safeParseSystemSettings(
@@ -45,20 +35,7 @@ test('disallows invalid mark thresholds', () => {
         markThresholds: { marginal: 0.3 },
       })
     ).unsafeUnwrapErr()
-  ).toMatchInlineSnapshot(`
-    [ZodError: [
-      {
-        "code": "invalid_type",
-        "expected": "number",
-        "received": "undefined",
-        "path": [
-          "markThresholds",
-          "definite"
-        ],
-        "message": "Required"
-      }
-    ]]
-  `);
+  ).toMatchSnapshot();
 
   expect(
     safeParseSystemSettings(
@@ -67,21 +44,7 @@ test('disallows invalid mark thresholds', () => {
         markThresholds: { definite: 1.2, marginal: 0.3 },
       })
     ).unsafeUnwrapErr()
-  ).toMatchInlineSnapshot(`
-    [ZodError: [
-      {
-        "code": "too_big",
-        "maximum": 1,
-        "type": "number",
-        "inclusive": true,
-        "message": "Number must be less than or equal to 1",
-        "path": [
-          "markThresholds",
-          "definite"
-        ]
-      }
-    ]]
-  `);
+  ).toMatchSnapshot();
 });
 
 test('disallows invalid adjudication reasons', () => {
@@ -93,42 +56,7 @@ test('disallows invalid adjudication reasons', () => {
         centralScanAdjudicationReasons: ['abcdefg'],
       })
     ).unsafeUnwrapErr()
-  ).toMatchInlineSnapshot(`
-    [ZodError: [
-      {
-        "code": "invalid_enum_value",
-        "options": [
-          "UninterpretableBallot",
-          "MarginalMark",
-          "Overvote",
-          "Undervote",
-          "BlankBallot",
-          "UnmarkedWriteIn"
-        ],
-        "path": [
-          "centralScanAdjudicationReasons",
-          0
-        ],
-        "message": "Invalid enum value. Expected 'UninterpretableBallot' | 'MarginalMark' | 'Overvote' | 'Undervote' | 'BlankBallot' | 'UnmarkedWriteIn'"
-      },
-      {
-        "code": "invalid_enum_value",
-        "options": [
-          "UninterpretableBallot",
-          "MarginalMark",
-          "Overvote",
-          "Undervote",
-          "BlankBallot",
-          "UnmarkedWriteIn"
-        ],
-        "path": [
-          "precinctScanAdjudicationReasons",
-          0
-        ],
-        "message": "Invalid enum value. Expected 'UninterpretableBallot' | 'MarginalMark' | 'Overvote' | 'Undervote' | 'BlankBallot' | 'UnmarkedWriteIn'"
-      }
-    ]]
-  `);
+  ).toMatchSnapshot();
 
   expect(
     safeParseSystemSettings(
@@ -137,17 +65,5 @@ test('disallows invalid adjudication reasons', () => {
         centralScanAdjudicationReasons: 'foooo',
       })
     ).unsafeUnwrapErr()
-  ).toMatchInlineSnapshot(`
-    [ZodError: [
-      {
-        "code": "invalid_type",
-        "expected": "array",
-        "received": "string",
-        "path": [
-          "centralScanAdjudicationReasons"
-        ],
-        "message": "Expected array, received string"
-      }
-    ]]
-  `);
+  ).toMatchSnapshot();
 });

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -47,7 +47,7 @@
     "readline": "^1.3.0",
     "tmp": "^0.2.1",
     "yargs": "17.7.1",
-    "zod": "3.14.4"
+    "zod": "3.23.5"
   },
   "devDependencies": {
     "@types/debug": "4.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,8 +220,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       zod:
-        specifier: 3.14.4
-        version: 3.14.4
+        specifier: 3.23.5
+        version: 3.23.5
     devDependencies:
       '@jest/types':
         specifier: ^29.6.1
@@ -485,8 +485,8 @@ importers:
         specifier: 9.0.1
         version: 9.0.1
       zod:
-        specifier: 3.14.4
-        version: 3.14.4
+        specifier: 3.23.5
+        version: 3.23.5
     devDependencies:
       '@jest/types':
         specifier: ^29.6.1
@@ -775,8 +775,8 @@ importers:
         specifier: 9.0.1
         version: 9.0.1
       zod:
-        specifier: 3.14.4
-        version: 3.14.4
+        specifier: 3.23.5
+        version: 3.23.5
     devDependencies:
       '@jest/types':
         specifier: ^29.6.1
@@ -941,8 +941,8 @@ importers:
         specifier: ^0.12.4
         version: 0.12.4
       zod:
-        specifier: 3.14.4
-        version: 3.14.4
+        specifier: 3.23.5
+        version: 3.23.5
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^5.17.0
@@ -1078,7 +1078,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
       type-fest:
         specifier: ^0.18.0
         version: 0.18.1
@@ -1207,8 +1207,8 @@ importers:
         specifier: 9.0.1
         version: 9.0.1
       zod:
-        specifier: 3.14.4
-        version: 3.14.4
+        specifier: 3.23.5
+        version: 3.23.5
     devDependencies:
       '@jest/types':
         specifier: ^29.6.1
@@ -1480,7 +1480,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -1578,8 +1578,8 @@ importers:
         specifier: ^4.33.0
         version: 4.33.0
       zod:
-        specifier: 3.14.4
-        version: 3.14.4
+        specifier: 3.23.5
+        version: 3.23.5
     devDependencies:
       '@jest/types':
         specifier: ^29.6.1
@@ -1878,7 +1878,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -1983,8 +1983,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       zod:
-        specifier: 3.14.4
-        version: 3.14.4
+        specifier: 3.23.5
+        version: 3.23.5
     devDependencies:
       '@jest/types':
         specifier: ^29.6.1
@@ -2268,7 +2268,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -2430,8 +2430,8 @@ importers:
         specifier: ^4.33.0
         version: 4.33.0
       zod:
-        specifier: 3.14.4
-        version: 3.14.4
+        specifier: 3.23.5
+        version: 3.23.5
     devDependencies:
       '@jest/types':
         specifier: ^29.6.1
@@ -2602,8 +2602,8 @@ importers:
         specifier: ^0.12.4
         version: 0.12.4
       zod:
-        specifier: 3.14.4
-        version: 3.14.4
+        specifier: 3.23.5
+        version: 3.23.5
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^5.17.0
@@ -2721,7 +2721,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -2772,7 +2772,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/@types/compress-commons:
     dependencies:
@@ -2817,8 +2817,8 @@ importers:
         specifier: workspace:*
         version: link:../utils
       zod:
-        specifier: 3.14.4
-        version: 3.14.4
+        specifier: 3.23.5
+        version: 3.23.5
     devDependencies:
       '@types/jest':
         specifier: ^29.5.3
@@ -2846,7 +2846,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/auth:
     dependencies:
@@ -2902,8 +2902,8 @@ importers:
         specifier: 17.7.1
         version: 17.7.1
       zod:
-        specifier: 3.14.4
-        version: 3.14.4
+        specifier: 3.23.5
+        version: 3.23.5
     devDependencies:
       '@types/combined-stream':
         specifier: ^1.0.3
@@ -2961,7 +2961,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
       wait-for-expect:
         specifier: ^3.0.2
         version: 3.0.2
@@ -3050,8 +3050,8 @@ importers:
         specifier: 9.0.1
         version: 9.0.1
       zod:
-        specifier: 3.14.4
-        version: 3.14.4
+        specifier: 3.23.5
+        version: 3.23.5
     devDependencies:
       '@types/debug':
         specifier: 4.1.8
@@ -3127,7 +3127,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/ballot-encoder:
     dependencies:
@@ -3179,7 +3179,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/ballot-interpreter:
     dependencies:
@@ -3297,7 +3297,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/basics:
     dependencies:
@@ -3343,7 +3343,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/cdf-schema-builder:
     dependencies:
@@ -3357,8 +3357,8 @@ importers:
         specifier: ^0.4.0
         version: 0.4.0
       zod:
-        specifier: 3.14.4
-        version: 3.14.4
+        specifier: 3.23.5
+        version: 3.23.5
     devDependencies:
       '@types/jest':
         specifier: ^29.5.3
@@ -3395,7 +3395,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/converter-nh-accuvote:
     dependencies:
@@ -3445,8 +3445,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       zod:
-        specifier: 3.14.4
-        version: 3.14.4
+        specifier: 3.23.5
+        version: 3.23.5
     devDependencies:
       '@jest/types':
         specifier: ^29.6.1
@@ -3580,7 +3580,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/custom-scanner:
     dependencies:
@@ -3653,7 +3653,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -3741,10 +3741,10 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
       zod:
-        specifier: 3.14.4
-        version: 3.14.4
+        specifier: 3.23.5
+        version: 3.23.5
 
   libs/db:
     dependencies:
@@ -3869,7 +3869,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/dev-dock/frontend:
     dependencies:
@@ -3975,7 +3975,7 @@ importers:
         version: 5.3.11(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/eslint-plugin-vx:
     dependencies:
@@ -4054,7 +4054,7 @@ importers:
         version: 18.2.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/fixtures:
     dependencies:
@@ -4106,7 +4106,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/fs:
     dependencies:
@@ -4132,8 +4132,8 @@ importers:
         specifier: ^4.0.5
         version: 4.0.5
       zod:
-        specifier: 3.14.4
-        version: 3.14.4
+        specifier: 3.23.5
+        version: 3.23.5
     devDependencies:
       '@types/debug':
         specifier: 4.1.8
@@ -4185,7 +4185,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/fujitsu-thermal-printer:
     dependencies:
@@ -4246,7 +4246,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/grout:
     dependencies:
@@ -4307,7 +4307,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/grout/test-utils:
     dependencies:
@@ -4347,7 +4347,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/hmpb/layout:
     dependencies:
@@ -4432,7 +4432,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/hmpb/render-backend:
     dependencies:
@@ -4658,8 +4658,8 @@ importers:
         specifier: 17.7.1
         version: 17.7.1
       zod:
-        specifier: 3.14.4
-        version: 3.14.4
+        specifier: 3.23.5
+        version: 3.23.5
     devDependencies:
       '@types/debug':
         specifier: 4.1.8
@@ -4714,7 +4714,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/mark-flow-ui:
     dependencies:
@@ -4782,8 +4782,8 @@ importers:
         specifier: 1.4.0
         version: 1.4.0(react@18.2.0)
       zod:
-        specifier: 3.14.4
-        version: 3.14.4
+        specifier: 3.23.5
+        version: 3.23.5
     devDependencies:
       '@storybook/cli':
         specifier: ^7.2.2
@@ -4928,7 +4928,7 @@ importers:
         version: 5.3.11(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
       util:
         specifier: ^0.12.4
         version: 0.12.4
@@ -4968,7 +4968,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/monorepo-utils:
     dependencies:
@@ -5038,7 +5038,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -5058,8 +5058,8 @@ importers:
         specifier: 4.3.4
         version: 4.3.4(supports-color@5.5.0)
       zod:
-        specifier: 3.14.4
-        version: 3.14.4
+        specifier: 3.23.5
+        version: 3.23.5
     devDependencies:
       '@types/debug':
         specifier: 4.1.8
@@ -5093,7 +5093,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/printing:
     dependencies:
@@ -5143,8 +5143,8 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       zod:
-        specifier: 3.14.4
-        version: 3.14.4
+        specifier: 3.23.5
+        version: 3.23.5
     devDependencies:
       '@types/debug':
         specifier: 4.1.8
@@ -5205,7 +5205,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/res-to-ts:
     dependencies:
@@ -5260,7 +5260,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/test-utils:
     dependencies:
@@ -5345,7 +5345,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/types:
     dependencies:
@@ -5362,8 +5362,8 @@ importers:
         specifier: ^0.12.4
         version: 0.12.4
       zod:
-        specifier: 3.14.4
-        version: 3.14.4
+        specifier: 3.23.5
+        version: 3.23.5
     devDependencies:
       '@types/jest':
         specifier: ^29.5.3
@@ -5430,7 +5430,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/types-rs: {}
 
@@ -5706,7 +5706,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
       util:
         specifier: ^0.12.4
         version: 0.12.4
@@ -5779,7 +5779,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   libs/utils:
     dependencies:
@@ -5823,8 +5823,8 @@ importers:
         specifier: 17.7.1
         version: 17.7.1
       zod:
-        specifier: 3.14.4
-        version: 3.14.4
+        specifier: 3.23.5
+        version: 3.23.5
     devDependencies:
       '@types/debug':
         specifier: 4.1.8
@@ -5900,7 +5900,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.17.11)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
 
   script:
     dependencies:
@@ -21231,6 +21231,7 @@ packages:
       semver: 7.5.4
       typescript: 5.4.5
       yargs-parser: 21.1.1
+    dev: true
 
   /ts-jest@29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5):
     resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
@@ -21266,7 +21267,6 @@ packages:
       semver: 7.5.4
       typescript: 5.4.5
       yargs-parser: 21.1.1
-    dev: true
 
   /tsconfig-paths@3.14.1:
     resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}
@@ -22298,5 +22298,5 @@ packages:
       readable-stream: 3.6.0
     dev: false
 
-  /zod@3.14.4:
-    resolution: {integrity: sha512-U9BFLb2GO34Sfo9IUYp0w3wJLlmcyGoMd75qU9yf+DrdGA4kEx6e+l9KOkAlyUO0PSQzZCa3TR4qVlcmwqSDuw==}
+  /zod@3.23.5:
+    resolution: {integrity: sha512-fkwiq0VIQTksNNA131rDOsVJcns0pfVUjHzLrNBiF/O/Xxb5lQyEXkhZWcJ7npWsYlvs+h0jFWXXy4X46Em1JA==}


### PR DESCRIPTION
## Overview

It doesn't look like there's much in the way of new API that we'd want to use. It does add `util` and `objectUtil` namespaces to the API, but the functions they provide are already covered by existing tools.

Diff: https://github.com/colinhacks/zod/compare/v3.14.4...v3.23.5

## Demo Video or Screenshot
n/a

## Testing Plan
Automated testing.