### PR TITLE
[BMDs] Use language-agnostic ballot style IDs on poll worker screen

### DIFF
--- a/apps/mark-scan/frontend/src/app_cardless_voting.test.tsx
+++ b/apps/mark-scan/frontend/src/app_cardless_voting.test.tsx
@@ -164,7 +164,8 @@ test('Cardless Voting Flow', async () => {
       precinctId: '23',
     },
   });
-  await screen.findByText('Voting Session Active: 12 at Center Springfield');
+  await screen.findByText('Voting Session Active:');
+  await screen.findByText('Ballot Style 12 at Center Springfield');
 
   // Poll Worker removes their card
   apiMock.setAuthStatusCardlessVoterLoggedIn({

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.test.tsx
@@ -10,6 +10,7 @@ import {
 
 import {
   BooleanEnvironmentVariableName,
+  extractBallotStyleGroupId,
   generateBallotStyleId,
   getFeatureFlagMock,
   singlePrecinctSelectionFor,
@@ -221,7 +222,7 @@ test('displays only default English ballot styles', async () => {
 
   await screen.findByText(hasTextAcrossElements('Select Voter’s Ballot Style'));
 
-  screen.getButton(ballotStyleEnglish.id);
+  screen.getButton(extractBallotStyleGroupId(ballotStyleEnglish.id));
   expect(
     screen.queryByRole('button', { name: ballotStyleSpanish.id })
   ).not.toBeInTheDocument();

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
@@ -276,7 +276,7 @@ export function PollWorkerScreen({
               {precinct.name}
             </Font>
           </H3>
-          <p>Paper has been loaded.</p>
+          <P>Paper has been loaded.</P>
           <ol style={{ marginBottom: '0' }}>
             <li>
               <P>

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
@@ -12,7 +12,6 @@ import {
 import {
   Button,
   ButtonList,
-  HorizontalRule,
   Main,
   Modal,
   Prose,
@@ -27,7 +26,6 @@ import {
   Font,
   H4,
   Icons,
-  FullScreenIconWrapper,
   H3,
   H6,
   Text,
@@ -41,6 +39,7 @@ import {
   isFeatureFlagEnabled,
   BooleanEnvironmentVariableName,
   getDefaultLanguageBallotStyles,
+  extractBallotStyleGroupId,
 } from '@votingworks/utils';
 
 import type { MachineConfig } from '@votingworks/mark-scan-backend';
@@ -55,6 +54,7 @@ import {
   setTestMode,
 } from '../api';
 import { PaperHandlerHardwareCheckDisabledScreen } from './paper_handler_hardware_check_disabled_screen';
+import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
 
 const VotingSession = styled.div`
   margin: 30px 0 60px;
@@ -260,40 +260,44 @@ export function PollWorkerScreen({
 
     if (stateMachineState === 'waiting_for_ballot_data') {
       return (
-        <Screen>
-          <Main centerChild padded>
-            <Prose>
-              <FullScreenIconWrapper align="center">
-                <Icons.Done color="success" />
-              </FullScreenIconWrapper>
-              <H2 as="h1" align="center">
-                {`Voting Session Active: ${ballotStyleId} at ${precinct.name}`}
-              </H2>
-              <p>Paper has been loaded.</p>
-              <ol style={{ marginBottom: '0' }}>
-                <li>
-                  <P>
-                    Instruct the voter to press the{' '}
-                    <Font weight="bold" noWrap>
-                      Start Voting
-                    </Font>{' '}
-                    button on the next screen.
-                  </P>
-                </li>
-                <li>
-                  <P>Remove the poll worker card to continue.</P>
-                </li>
-              </ol>
-              <HorizontalRule>or</HorizontalRule>
-              <P align="center">Deactivate this voter session to start over.</P>
-              <P align="center">
-                <Button onPress={resetCardlessVoterSession}>
-                  Deactivate Voting Session
-                </Button>
+        <CenteredCardPageLayout
+          buttons={
+            <Button onPress={resetCardlessVoterSession}>
+              Deactivate Voting Session
+            </Button>
+          }
+          icon={<Icons.Done color="success" />}
+          title="Voting Session Active:"
+          voterFacing={false}
+        >
+          <H3 as="h2">
+            <Font weight="regular">
+              Ballot Style {extractBallotStyleGroupId(ballotStyleId)} at{' '}
+              {precinct.name}
+            </Font>
+          </H3>
+          <p>Paper has been loaded.</p>
+          <ol style={{ marginBottom: '0' }}>
+            <li>
+              <P>
+                Instruct the voter to press the{' '}
+                <Font weight="bold" noWrap>
+                  Start Voting
+                </Font>{' '}
+                button on the next screen.
               </P>
-            </Prose>
-          </Main>
-        </Screen>
+            </li>
+            <li>
+              <P>Remove the poll worker card to continue.</P>
+            </li>
+          </ol>
+          <P>
+            <Caption>
+              <Icons.Info /> To start over, press the button below to deactivate
+              the voter session.
+            </Caption>
+          </P>
+        </CenteredCardPageLayout>
       );
     }
 
@@ -368,7 +372,7 @@ export function PollWorkerScreen({
                           });
                         }}
                       >
-                        {ballotStyle.id}
+                        {extractBallotStyleGroupId(ballotStyle.id)}
                       </Button>
                     ))}
                   </ButtonList>

--- a/apps/mark/frontend/src/app_cardless_voting.test.tsx
+++ b/apps/mark/frontend/src/app_cardless_voting.test.tsx
@@ -146,7 +146,8 @@ test('poll worker selects ballot style, voter votes', async () => {
       precinctId: '23',
     },
   });
-  await screen.findByText('Voting Session Active: 12 at Center Springfield');
+  await screen.findByText('Voting Session Active:');
+  await screen.findByText('Ballot Style 12 at Center Springfield');
 
   // Poll Worker removes their card
   apiMock.setAuthStatusCardlessVoterLoggedIn({
@@ -241,7 +242,8 @@ test('in "All Precincts" mode, poll worker must select a precinct first', async 
       precinctId: '23',
     },
   });
-  await screen.findByText('Voting Session Active: 12 at Center Springfield');
+  await screen.findByText('Voting Session Active:');
+  await screen.findByText('Ballot Style 12 at Center Springfield');
 
   // Poll Worker removes their card
   apiMock.setAuthStatusCardlessVoterLoggedIn({

--- a/apps/mark/frontend/src/pages/poll_worker_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.test.tsx
@@ -12,6 +12,7 @@ import {
   singlePrecinctSelectionFor,
   MemoryHardware,
   generateBallotStyleId,
+  extractBallotStyleGroupId,
 } from '@votingworks/utils';
 import {
   mockPollWorkerUser,
@@ -193,7 +194,7 @@ test('displays only default English ballot styles', async () => {
 
   await screen.findByText(hasTextAcrossElements('Select Voter’s Ballot Style'));
 
-  screen.getButton(ballotStyleEnglish.id);
+  screen.getButton(extractBallotStyleGroupId(ballotStyleEnglish.id));
   expect(
     screen.queryByRole('button', { name: ballotStyleSpanish.id })
   ).not.toBeInTheDocument();

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -40,6 +40,7 @@ import {
   getPollsTransitionAction,
   getPollTransitionsFromState,
   getDefaultLanguageBallotStyles,
+  extractBallotStyleGroupId,
 } from '@votingworks/utils';
 
 import type { MachineConfig } from '@votingworks/mark-backend';
@@ -238,8 +239,14 @@ export function PollWorkerScreen({
               <Icons.Done color="success" />
             </FullScreenIconWrapper>
             <H2 as="h1" align="center">
-              {`Voting Session Active: ${ballotStyleId} at ${precinct.name}`}
+              Voting Session Active:
             </H2>
+            <H3 as="h2" align="center">
+              <Font weight="regular">
+                Ballot Style {extractBallotStyleGroupId(ballotStyleId)} at{' '}
+                {precinct.name}
+              </Font>
+            </H3>
             <ol style={{ marginBottom: '0' }}>
               <li>
                 <P>
@@ -341,7 +348,7 @@ export function PollWorkerScreen({
                           )
                         }
                       >
-                        {ballotStyle.id}
+                        {extractBallotStyleGroupId(ballotStyle.id)}
                       </Button>
                     ))}
                   </ButtonList>

--- a/apps/mark/integration-testing/e2e/scroll_buttons.spec.ts
+++ b/apps/mark/integration-testing/e2e/scroll_buttons.spec.ts
@@ -64,9 +64,7 @@ test('configure, open polls, and test contest scroll buttons', async ({
   // Poll Worker: initiate voting session
   await page.getByText('Center Springfield').click();
   await page.getByText('12').click();
-  await page
-    .getByText('Voting Session Active: 12 at Center Springfield')
-    .waitFor();
+  await page.getByText('Voting Session Active:').waitFor();
   mockCardRemoval();
 
   await page

--- a/libs/utils/src/ballot_styles.ts
+++ b/libs/utils/src/ballot_styles.ts
@@ -39,7 +39,7 @@ export function generateBallotStyleId(params: {
   );
 }
 
-function extractBallotStyleGroupId(
+export function extractBallotStyleGroupId(
   ballotStyleId: BallotStyleId
 ): BallotStyleId {
   return ballotStyleId.split(ID_LANGUAGES_SEPARATOR)[0] || ballotStyleId;


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/4762

On the ballot style selection screen for poll workers, we filter ballot styles down to just the primary English ballots for simplicity (ballot styles are updated accordingly under the hood when the voter later updates their display language).

This change strips the `_en` suffixes from these ballot style IDs when displayed and just renders the root ballot style IDs instead.

## Demo Video or Screenshot
| Before | After |
| ------------- | ------------- |
| <img width="523" alt="Screenshot 2024-05-01 at 12 14 01" src="https://github.com/votingworks/vxsuite/assets/264902/d2189239-a111-41b2-9584-2c43f2ffc3ac"> | <img width="518" alt="Screenshot 2024-05-01 at 12 14 29" src="https://github.com/votingworks/vxsuite/assets/264902/dd1b5db4-aff2-4b16-ac5d-65600b58e831"> |
| <img width="514" alt="Screenshot 2024-05-01 at 15 04 21" src="https://github.com/votingworks/vxsuite/assets/264902/241d8a40-e85b-4b95-8d96-23211ebc4b91"> | <img width="514" alt="Screenshot 2024-05-01 at 15 03 11" src="https://github.com/votingworks/vxsuite/assets/264902/689ad094-355b-4acf-ac21-c19716389bc7"> |

## Testing Plan
- Updated unit tests + manual verification

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
