### PR TITLE
Fix signing of large election packages in prod

### DIFF
--- a/libs/auth/src/cryptography.end_to_end.test.ts
+++ b/libs/auth/src/cryptography.end_to_end.test.ts
@@ -1,4 +1,3 @@
-import { Buffer } from 'buffer';
 import { Readable } from 'stream';
 import { TEST_JURISDICTION } from '@votingworks/types';
 
@@ -62,14 +61,13 @@ test('signMessage end-to-end', async () => {
     fileType: 'vx-scan-private-key.pem',
   });
 
-  const message = Buffer.from('abcd', 'utf-8');
   const messageSignature = await signMessage({
-    message: Readable.from(message),
+    message: Readable.from('abcd'),
     signingPrivateKey: { source: 'file', path: vxScanPrivateKeyPath },
   });
   const vxScanPublicKey = await extractPublicKeyFromCert(vxScanCertPath);
   await verifySignature({
-    message: Readable.from(message),
+    message: Readable.from('abcd'),
     messageSignature,
     publicKey: vxScanPublicKey,
   });

--- a/libs/auth/src/cryptography.test.ts
+++ b/libs/auth/src/cryptography.test.ts
@@ -550,9 +550,9 @@ test.each<{
     description: 'signing with private key file',
     signingPrivateKey: { source: 'file', path: '/path/to/private-key.pem' },
     expectedOpensslSignatureRequestParams: [
-      'dgst',
-      '-sha256',
+      'pkeyutl',
       '-sign',
+      '-inkey',
       '/path/to/private-key.pem',
     ],
   },
@@ -560,9 +560,9 @@ test.each<{
     description: 'signing with TPM private key',
     signingPrivateKey: { source: 'tpm' },
     expectedOpensslSignatureRequestParams: [
-      'dgst',
-      '-sha256',
+      'pkeyutl',
       '-sign',
+      '-inkey',
       'handle:0x81000001',
       '-provider',
       'tpm2',
@@ -575,13 +575,21 @@ test.each<{
   async ({ signingPrivateKey, expectedOpensslSignatureRequestParams }) => {
     setTimeout(() => {
       mockChildProcess.emit('close', successExitCode);
+      setTimeout(() => {
+        mockChildProcess.emit('close', successExitCode);
+      });
     });
 
     await signMessageHelper({ signingPrivateKey });
 
-    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(spawn).toHaveBeenNthCalledWith(1, 'openssl', [
+      'dgst',
+      '-sha256',
+      '-binary',
+    ]);
     expect(spawn).toHaveBeenNthCalledWith(
-      1,
+      2,
       'openssl',
       expectedOpensslSignatureRequestParams
     );

--- a/libs/auth/src/cryptography.test.ts
+++ b/libs/auth/src/cryptography.test.ts
@@ -575,9 +575,9 @@ test.each<{
   async ({ signingPrivateKey, expectedOpensslSignatureRequestParams }) => {
     setTimeout(() => {
       mockChildProcess.emit('close', successExitCode);
-      setTimeout(() => {
-        mockChildProcess.emit('close', successExitCode);
-      });
+    });
+    setTimeout(() => {
+      mockChildProcess.emit('close', successExitCode);
     });
 
     await signMessageHelper({ signingPrivateKey });

--- a/libs/auth/src/cryptography.ts
+++ b/libs/auth/src/cryptography.ts
@@ -475,8 +475,10 @@ export async function signMessageHelper({
   signingPrivateKey,
 }: SignMessageInputExcludingMessage): Promise<Buffer> {
   // While it's possible to hash and sign with a single OpenSSL command, we separate the two
-  // actions. Hashing large inputs with the TPM can be extremely slow. So in production, we hash
-  // using the main processor and only sign using the TPM.
+  // actions. Hashing large inputs with the TPM can be extremely slow, so in production, we hash
+  // using the main processor and only sign using the TPM. We perform the hashing with OpenSSL and
+  // not the Node crypto module because it's easier to make the former FIPS compliant than the
+  // latter.
   const hash = await openssl(['dgst', '-sha256', '-binary'], {
     stdin: process.stdin,
   });

--- a/libs/auth/src/tpm.ts
+++ b/libs/auth/src/tpm.ts
@@ -12,7 +12,7 @@ const TPM_OPENSSL_PROVIDER = 'tpm2';
  * Prepares the OpenSSL params necessary to use the TPM
  */
 export function tpmOpensslParams(
-  opensslParam: '-CAkey' | '-key' | '-sign'
+  opensslParam: '-CAkey' | '-inkey' | '-key'
 ): string[] {
   return [
     opensslParam,


### PR DESCRIPTION
## Overview

With the introduction of audio clips to election packages, election packages can now be substantially larger than in the past (e.g., 10+ MB instead of 50 KB). Testing with such an election package on a prod VxAdmin has surfaced an issue; digital signing of the election package hangs indefinitely. This issue is specific to prod and use of the TPM.

This PR fixes the issue by separating hashing and signing so that we can hash using the main processor and only sign using the TPM. Hashing large inputs with the TPM can be extremely slow as the TPM processor isn't particularly powerful. It's really only meant for small cryptographic operations.

## Testing Plan

- [x] Updated `cryptography.test.ts`
- [x] Updated `cryptography.end_to_end.test.ts`, which tests signing and verification commands end-to-end
- [x] Copied the updated code to my non-locked-down prod-imaged ThinkPad and verified that election package export was successful