### PR TITLE
libs/types: Fix broken GeneratedDate in CDF conversion test fixture

### DIFF
--- a/libs/types/src/cdf/ballot-definition/fixtures.ts
+++ b/libs/types/src/cdf/ballot-definition/fixtures.ts
@@ -1088,10 +1088,7 @@ export const testCdfBallotDefinition: BallotDefinition = {
 
   vxSeal: '<svg>test seal</svg>',
 
-  GeneratedDate: new DateWithoutTime('2021-06-06')
-    .toMidnightDatetimeWithSystemTimezone()
-    .toISOString()
-    .replace(/.\d\d\dZ$/, 'Z'),
+  GeneratedDate: '2021-06-06T00:00:00Z',
   Issuer: 'VotingWorks',
   IssuerAbbreviation: 'VX',
   VendorApplicationId: 'VxSuite',


### PR DESCRIPTION

## Overview

This was working on CI where the timezone is always UTC, but failing locally.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
