### PR TITLE
apps/scan: Fix pdictl process leak

### DIFF
--- a/apps/scan/backend/src/scanners/pdi/pdi_app_scan_disconnect.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_scan_disconnect.test.ts
@@ -94,6 +94,7 @@ test('scanner disconnected on startup', async () => {
     expect(precinctScannerMachine.status()).toEqual({ state: 'disconnected' });
   });
   precinctScannerMachine.stop();
+  expect(mockScanner.client.exit).toHaveBeenCalled(); // Previous client should have been cleaned up
 });
 
 test('scanner disconnected while waiting for ballots', async () => {
@@ -113,6 +114,7 @@ test('scanner disconnected while waiting for ballots', async () => {
       simulateReconnect(mockScanner);
       clock.increment(delays.DELAY_RECONNECT);
       await waitForStatus(apiClient, { state: 'no_paper' });
+      expect(mockScanner.client.exit).toHaveBeenCalled(); // Previous client should have been cleaned up
     }
   );
 });

--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -748,15 +748,20 @@ function buildMachine({
 
         error: {
           id: 'error',
-          initial: 'exiting',
-          always: {
-            cond: (context) =>
-              context.error !== undefined &&
-              'code' in context.error &&
-              context.error.code === 'disconnected',
-            target: 'disconnected',
-          },
+          initial: 'checkingErrorCode',
           states: {
+            checkingErrorCode: {
+              always: [
+                {
+                  cond: (context) =>
+                    context.error !== undefined &&
+                    'code' in context.error &&
+                    context.error.code === 'disconnected',
+                  target: '#disconnected',
+                },
+                { target: 'exiting' },
+              ],
+            },
             exiting: {
               invoke: {
                 src: async ({ client }) => {

--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -715,9 +715,18 @@ function buildMachine({
 
         disconnected: {
           id: 'disconnected',
-          initial: 'waiting',
+          initial: 'exiting',
           entry: assign({ interpretation: undefined }),
           states: {
+            exiting: {
+              invoke: {
+                src: async ({ client }) => {
+                  (await client.exit()).unsafeUnwrap();
+                },
+                onDone: 'waiting',
+                onError: '#error',
+              },
+            },
             waiting: {
               after: {
                 DELAY_RECONNECT: {
@@ -731,7 +740,7 @@ function buildMachine({
                 src: async ({ client }) =>
                   (await client.connect()).unsafeUnwrap(),
                 onDone: '#waitingForBallot',
-                onError: 'waiting',
+                onError: '#error',
               },
             },
           },

--- a/apps/scan/backend/test/helpers/pdi_helpers.ts
+++ b/apps/scan/backend/test/helpers/pdi_helpers.ts
@@ -167,7 +167,7 @@ export function createMockPdiScannerClient(): MockPdiScannerClient {
       disableScanning: jest.fn().mockResolvedValue(ok()),
       ejectDocument: jest.fn().mockResolvedValue(ok()),
       disconnect: jest.fn().mockResolvedValue(ok()),
-      exit: jest.fn(),
+      exit: jest.fn().mockResolvedValue(ok()),
     },
   };
 }


### PR DESCRIPTION
## Overview

When the scanner is disconnected, we create a new client each time we
reconnect, which spawns a new pdictl process. This process is not killed
when the previous client goes out of scope.

To fix the immediate problem, we exit the client explicitly before
creating a new one. There may be a cleaner design for the client that
will solve this in a better way, but I wanted to fix the immediate
problem as a starting point.

## Demo Video or Screenshot

## Testing Plan
Manually tested, updated automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
