### PR TITLE
apps/scan: Enable double feed detection for PDI scanner

### DIFF
--- a/apps/scan/backend/jest.config.js
+++ b/apps/scan/backend/jest.config.js
@@ -23,10 +23,10 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      statements: -188,
-      branches: -46,
-      functions: -16,
-      lines: -188,
+      statements: -180,
+      branches: -47,
+      functions: -15,
+      lines: -180,
     },
   },
 };

--- a/apps/scan/backend/schema.sql
+++ b/apps/scan/backend/schema.sql
@@ -12,7 +12,7 @@ create table election (
   ballot_count_when_ballot_bag_last_replaced integer not null default 0,
   has_paper_been_loaded boolean not null default false,
   is_sound_muted boolean not null default false,
-  is_multi_sheet_detection_disabled boolean not null default false,
+  is_double_feed_detection_disabled boolean not null default false,
   created_at timestamp not null default current_timestamp
 );
 

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -176,7 +176,7 @@ export function buildApi({
         precinctSelection: store.getPrecinctSelection(),
         isSoundMuted: store.getIsSoundMuted(),
         isTestMode: store.getTestMode(),
-        isMultiSheetDetectionDisabled: store.getIsMultiSheetDetectionDisabled(),
+        isDoubleFeedDetectionDisabled: store.getIsDoubleFeedDetectionDisabled(),
         ballotCountWhenBallotBagLastReplaced:
           store.getBallotCountWhenBallotBagLastReplaced(),
         hasPaperBeenLoaded: store.getHasPaperBeenLoaded(),
@@ -225,11 +225,11 @@ export function buildApi({
       store.setIsSoundMuted(input.isSoundMuted);
     },
 
-    setIsMultiSheetDetectionDisabled(input: {
-      isMultiSheetDetectionDisabled: boolean;
+    setIsDoubleFeedDetectionDisabled(input: {
+      isDoubleFeedDetectionDisabled: boolean;
     }): void {
-      store.setIsMultiSheetDetectionDisabled(
-        input.isMultiSheetDetectionDisabled
+      store.setIsDoubleFeedDetectionDisabled(
+        input.isDoubleFeedDetectionDisabled
       );
     },
 

--- a/apps/scan/backend/src/scanners/custom/state_machine.ts
+++ b/apps/scan/backend/src/scanners/custom/state_machine.ts
@@ -294,14 +294,14 @@ async function reset({ client }: Context): Promise<void> {
 async function scan({ client, workspace }: Context): Promise<SheetOf<string>> {
   assert(client);
   debug('Scanning');
-  const isMultiSheetDetectionDisabled =
-    workspace.store.getIsMultiSheetDetectionDisabled();
+  const isDoubleSheetDetectionDisabled =
+    workspace.store.getIsDoubleFeedDetectionDisabled();
   const scanResult = await client.scan({
     wantedScanSide: ScanSide.A_AND_B,
     resolution: ImageResolution.RESOLUTION_200_DPI,
     imageColorDepth: ImageColorDepthType.Grey8bpp,
     formStandingAfterScan: FormStanding.HOLD_TICKET,
-    doubleSheetDetection: isMultiSheetDetectionDisabled
+    doubleSheetDetection: isDoubleSheetDetectionDisabled
       ? DoubleSheetDetectOpt.DetectOff
       : DoubleSheetDetectOpt.Level1,
   });

--- a/apps/scan/backend/src/scanners/pdi/pdi_app_scan_double_sheet.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_scan_double_sheet.test.ts
@@ -297,12 +297,12 @@ test('insert two sheets at once', async () => {
       // Scanner stops the scan immediately when multiple sheets are detected,
       // usually before the rear sensors are covered
       mockScanner.setScannerStatus(mockStatus.documentInFront);
-      mockScanner.emitEvent({ event: 'error', code: 'multipleSheetsDetected' });
+      mockScanner.emitEvent({ event: 'error', code: 'doubleFeedDetected' });
       mockScanner.emitEvent({ event: 'error', code: 'scanFailed' });
 
       await waitForStatus(apiClient, {
         state: 'rejected',
-        error: 'multiple_sheets_detected',
+        error: 'double_feed_detected',
       });
 
       mockScanner.setScannerStatus(mockStatus.idleScanningDisabled);
@@ -312,21 +312,21 @@ test('insert two sheets at once', async () => {
   );
 });
 
-test('disabling multi-sheet detection', async () => {
+test('disabling double feed detection', async () => {
   await withApp(
     async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
       await configureApp(apiClient, mockAuth, mockUsbDrive);
-      await apiClient.setIsMultiSheetDetectionDisabled({
-        isMultiSheetDetectionDisabled: true,
+      await apiClient.setIsDoubleFeedDetectionDisabled({
+        isDoubleFeedDetectionDisabled: true,
       });
 
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
       await waitForStatus(apiClient, { state: 'no_paper' });
       expect(mockScanner.client.enableScanning).toHaveBeenLastCalledWith({
-        multiSheetDetectionEnabled: false,
+        doubleFeedDetectionEnabled: false,
       });
 
-      // Simulate an election manager logging in to disable multi-sheet
+      // Simulate an election manager logging in to disable double feed
       // detection, since that's how it would happen in real-world usage. The
       // state machine only calls enableScanning when it transitions back into
       // the 'waitingForBallot' state, so we need to log out to trigger the
@@ -338,8 +338,8 @@ test('disabling multi-sheet detection', async () => {
       });
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
       await waitForStatus(apiClient, { state: 'paused' });
-      await apiClient.setIsMultiSheetDetectionDisabled({
-        isMultiSheetDetectionDisabled: false,
+      await apiClient.setIsDoubleFeedDetectionDisabled({
+        isDoubleFeedDetectionDisabled: false,
       });
       mockOf(mockAuth.getAuthStatus).mockResolvedValue({
         status: 'logged_out',
@@ -349,7 +349,7 @@ test('disabling multi-sheet detection', async () => {
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
       await waitForStatus(apiClient, { state: 'no_paper' });
       expect(mockScanner.client.enableScanning).toHaveBeenLastCalledWith({
-        multiSheetDetectionEnabled: true,
+        doubleFeedDetectionEnabled: true,
       });
     }
   );

--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -491,8 +491,8 @@ function buildMachine({
                   src: async ({ client }) => {
                     (
                       await client.enableScanning({
-                        multiSheetDetectionEnabled:
-                          !store.getIsMultiSheetDetectionDisabled(),
+                        doubleFeedDetectionEnabled:
+                          !store.getIsDoubleFeedDetectionDisabled(),
                       })
                     ).unsafeUnwrap();
                   },
@@ -546,18 +546,17 @@ function buildMachine({
                   },
                 ],
                 SCANNER_ERROR: [
-                  // A multipleSheetsDetected event will always be followed by a
+                  // A doubleFeedDetected event will always be followed by a
                   // scanFailed event (which indicates that the scan actually
                   // stopped), so we don't transition states yet, just record
                   // that it happened. Otherwise, we'd have a scanFailed event
                   // come in later and be unhandled.
                   {
-                    cond: (_, { error }) =>
-                      error.code === 'multipleSheetsDetected',
+                    cond: (_, { error }) => error.code === 'doubleFeedDetected',
                     actions: assign({
                       // eslint-disable-next-line @typescript-eslint/no-unused-vars
                       error: (_context) =>
-                        new PrecinctScannerError('multiple_sheets_detected'),
+                        new PrecinctScannerError('double_feed_detected'),
                     }),
                   },
                   {
@@ -565,10 +564,10 @@ function buildMachine({
                     target: '#rejecting',
                     actions: assign({
                       error: (context) =>
-                        // Don't overwrite the multiple_sheets_detected error if
+                        // Don't overwrite the double_feed_detected error if
                         // we already caught that
                         context.error instanceof PrecinctScannerError &&
-                        context.error.type === 'multiple_sheets_detected'
+                        context.error.type === 'double_feed_detected'
                           ? context.error
                           : new PrecinctScannerError('scanning_failed'),
                     }),

--- a/apps/scan/backend/src/store.test.ts
+++ b/apps/scan/backend/src/store.test.ts
@@ -191,12 +191,12 @@ test('get/set is sounds muted mode', () => {
   expect(store.getIsSoundMuted()).toEqual(false);
 });
 
-test('get/set is multi sheet detection disabled mode', () => {
+test('get/set is double feed detection disabled mode', () => {
   const store = Store.memoryStore();
 
   // Before setting an election
-  expect(store.getIsMultiSheetDetectionDisabled()).toEqual(false);
-  expect(() => store.setIsMultiSheetDetectionDisabled(true)).toThrowError();
+  expect(store.getIsDoubleFeedDetectionDisabled()).toEqual(false);
+  expect(() => store.setIsDoubleFeedDetectionDisabled(true)).toThrowError();
 
   store.setElectionAndJurisdiction({
     electionData:
@@ -206,13 +206,13 @@ test('get/set is multi sheet detection disabled mode', () => {
   });
 
   // After setting an election
-  expect(store.getIsMultiSheetDetectionDisabled()).toEqual(false);
+  expect(store.getIsDoubleFeedDetectionDisabled()).toEqual(false);
 
-  store.setIsMultiSheetDetectionDisabled(true);
-  expect(store.getIsMultiSheetDetectionDisabled()).toEqual(true);
+  store.setIsDoubleFeedDetectionDisabled(true);
+  expect(store.getIsDoubleFeedDetectionDisabled()).toEqual(true);
 
-  store.setIsMultiSheetDetectionDisabled(false);
-  expect(store.getIsMultiSheetDetectionDisabled()).toEqual(false);
+  store.setIsDoubleFeedDetectionDisabled(false);
+  expect(store.getIsDoubleFeedDetectionDisabled()).toEqual(false);
 });
 
 test('get/set ballot count when ballot bag last replaced', () => {

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -276,19 +276,19 @@ export class Store {
   }
 
   /**
-   * Gets whether multi sheet detection is disabled.
+   * Gets whether double feed detection is disabled.
    */
-  getIsMultiSheetDetectionDisabled(): boolean {
+  getIsDoubleFeedDetectionDisabled(): boolean {
     const electionRow = this.client.one(
-      'select is_multi_sheet_detection_disabled as isMultiSheetDetectionDisabled from election'
-    ) as { isMultiSheetDetectionDisabled: number } | undefined;
+      'select is_double_feed_detection_disabled as isDoubleFeedDetectionDisabled from election'
+    ) as { isDoubleFeedDetectionDisabled: number } | undefined;
 
     if (!electionRow) {
-      // we will not disable multi sheet detection by default once an election is defined
+      // we will not disable double feed detection by default once an election is defined
       return false;
     }
 
-    return Boolean(electionRow.isMultiSheetDetectionDisabled);
+    return Boolean(electionRow.isDoubleFeedDetectionDisabled);
   }
 
   /**
@@ -306,20 +306,20 @@ export class Store {
   }
 
   /**
-   * Sets whether or not to enable multi sheet detection, if supported.
+   * Sets whether or not to enable double feed detection.
    */
-  setIsMultiSheetDetectionDisabled(
-    isMultiSheetDetectionDisabled: boolean
+  setIsDoubleFeedDetectionDisabled(
+    isDoubleFeedDetectionDisabled: boolean
   ): void {
     if (!this.hasElection()) {
       throw new Error(
-        'Cannot toggle multi sheet detection without an election.'
+        'Cannot toggle double feed detection without an election.'
       );
     }
 
     this.client.run(
-      'update election set is_multi_sheet_detection_disabled = ?',
-      isMultiSheetDetectionDisabled ? 1 : 0
+      'update election set is_double_feed_detection_disabled = ?',
+      isDoubleFeedDetectionDisabled ? 1 : 0
     );
   }
 

--- a/apps/scan/backend/src/types.ts
+++ b/apps/scan/backend/src/types.ts
@@ -28,7 +28,7 @@ export type PrecinctScannerErrorType =
   | 'scanning_timed_out'
   | 'scanning_failed'
   | 'both_sides_have_paper'
-  | 'multiple_sheets_detected'
+  | 'double_feed_detected'
   | 'paper_in_back_after_accept'
   | 'paper_in_front_after_reconnect'
   | 'paper_in_back_after_reconnect'
@@ -67,7 +67,7 @@ export interface PrecinctScannerConfig {
   systemSettings: SystemSettings;
   precinctSelection?: PrecinctSelection;
   isSoundMuted: boolean;
-  isMultiSheetDetectionDisabled: boolean;
+  isDoubleFeedDetectionDisabled: boolean;
   hasPaperBeenLoaded: boolean;
   // "Config" that is specific to each election session
   isTestMode: boolean;

--- a/apps/scan/backend/src/types.ts
+++ b/apps/scan/backend/src/types.ts
@@ -28,6 +28,7 @@ export type PrecinctScannerErrorType =
   | 'scanning_timed_out'
   | 'scanning_failed'
   | 'both_sides_have_paper'
+  | 'multiple_sheets_detected'
   | 'paper_in_back_after_accept'
   | 'paper_in_front_after_reconnect'
   | 'paper_in_back_after_reconnect'

--- a/apps/scan/frontend/jest.config.js
+++ b/apps/scan/frontend/jest.config.js
@@ -13,10 +13,10 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      statements: 94,
-      branches: 86,
-      functions: 88,
-      lines: 95,
+      statements: -56,
+      branches: -58,
+      functions: -25,
+      lines: -54,
     },
   },
   resetMocks: true,

--- a/apps/scan/frontend/src/api.ts
+++ b/apps/scan/frontend/src/api.ts
@@ -234,11 +234,11 @@ export const setIsSoundMuted = {
   },
 } as const;
 
-export const setIsMultiSheetDetectionDisabled = {
+export const setIsDoubleFeedDetectionDisabled = {
   useMutation() {
     const apiClient = useApiClient();
     const queryClient = useQueryClient();
-    return useMutation(apiClient.setIsMultiSheetDetectionDisabled, {
+    return useMutation(apiClient.setIsDoubleFeedDetectionDisabled, {
       async onSuccess() {
         await queryClient.invalidateQueries(getConfig.queryKey());
       },

--- a/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
@@ -179,7 +179,7 @@ test('when sounds are muted, shows a button to unmute sounds', async () => {
   await screen.findByRole('button', { name: 'Mute Sounds' });
 });
 
-test('shows multi sheet detection toggle', async () => {
+test('shows double feed detection toggle', async () => {
   apiMock.expectGetConfig();
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
@@ -189,8 +189,8 @@ test('shows multi sheet detection toggle', async () => {
   await screen.findByText('Disable Double Sheet Detection');
 });
 
-test('prompts to enable multi sheet detection when disabled ', async () => {
-  apiMock.expectGetConfig({ isMultiSheetDetectionDisabled: true });
+test('prompts to enable double feed detection when disabled ', async () => {
+  apiMock.expectGetConfig({ isDoubleFeedDetectionDisabled: true });
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
 
@@ -199,17 +199,17 @@ test('prompts to enable multi sheet detection when disabled ', async () => {
   await screen.findByText('Enable Double Sheet Detection');
 });
 
-test('disables multi sheet detection properly', async () => {
+test('disables double feed detection properly', async () => {
   apiMock.expectGetConfig();
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
 
   userEvent.click(screen.getByRole('tab', { name: /system/i }));
 
-  apiMock.mockApiClient.setIsMultiSheetDetectionDisabled
-    .expectCallWith({ isMultiSheetDetectionDisabled: true })
+  apiMock.mockApiClient.setIsDoubleFeedDetectionDisabled
+    .expectCallWith({ isDoubleFeedDetectionDisabled: true })
     .resolves();
-  apiMock.expectGetConfig({ isMultiSheetDetectionDisabled: true });
+  apiMock.expectGetConfig({ isDoubleFeedDetectionDisabled: true });
   userEvent.click(await screen.findButton('Disable Double Sheet Detection'));
   await screen.findButton('Enable Double Sheet Detection');
   await screen.findByText('Enable Double Sheet Detection');

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -31,7 +31,7 @@ import {
   getUsbDriveStatus,
   logOut,
   setIsSoundMuted,
-  setIsMultiSheetDetectionDisabled,
+  setIsDoubleFeedDetectionDisabled,
   setPrecinctSelection,
   setTestMode,
   unconfigureElection,
@@ -64,8 +64,8 @@ export function ElectionManagerScreen({
   const setPrecinctSelectionMutation = setPrecinctSelection.useMutation();
   const setTestModeMutation = setTestMode.useMutation();
   const setIsSoundMutedMutation = setIsSoundMuted.useMutation();
-  const setIsMultiSheetDetectionDisabledMutation =
-    setIsMultiSheetDetectionDisabled.useMutation();
+  const setIsDoubleFeedDetectionDisabledMutation =
+    setIsDoubleFeedDetectionDisabled.useMutation();
   const unconfigureMutation = unconfigureElection.useMutation();
   const ejectUsbDriveMutation = ejectUsbDrive.useMutation();
   const logOutMutation = logOut.useMutation();
@@ -91,7 +91,7 @@ export function ElectionManagerScreen({
     precinctSelection,
     isTestMode,
     isSoundMuted,
-    isMultiSheetDetectionDisabled,
+    isDoubleFeedDetectionDisabled,
   } = configQuery.data;
   const { pollsState } = pollsInfoQuery.data;
   const printerStatus = printerStatusQuery.data;
@@ -193,12 +193,12 @@ export function ElectionManagerScreen({
     <P>
       <Button
         onPress={() =>
-          setIsMultiSheetDetectionDisabledMutation.mutate({
-            isMultiSheetDetectionDisabled: !isMultiSheetDetectionDisabled,
+          setIsDoubleFeedDetectionDisabledMutation.mutate({
+            isDoubleFeedDetectionDisabled: !isDoubleFeedDetectionDisabled,
           })
         }
       >
-        {isMultiSheetDetectionDisabled
+        {isDoubleFeedDetectionDisabled
           ? 'Enable Double Sheet Detection'
           : 'Disable Double Sheet Detection'}
       </Button>

--- a/apps/scan/frontend/src/screens/scan_error_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/scan_error_screen.test.tsx
@@ -101,12 +101,12 @@ test('render correct unreadable ballot screen', async () => {
   );
 });
 
-test('double sheet error screen', async () => {
+test('double feed error screen', async () => {
   render(
     provideApi(
       apiMock,
       <ScanErrorScreen
-        error="multiple_sheets_detected"
+        error="double_feed_detected"
         isTestMode
         scannedBallotCount={42}
       />

--- a/apps/scan/frontend/src/screens/scan_error_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/scan_error_screen.test.tsx
@@ -100,3 +100,18 @@ test('render correct unreadable ballot screen', async () => {
     'There was a problem scanning your ballot. Please scan it again.'
   );
 });
+
+test('double sheet error screen', async () => {
+  render(
+    provideApi(
+      apiMock,
+      <ScanErrorScreen
+        error="multiple_sheets_detected"
+        isTestMode
+        scannedBallotCount={42}
+      />
+    )
+  );
+  await screen.findByText('Ballot Not Counted');
+  await screen.findByText('Remove your ballot and insert one sheet at a time.');
+});

--- a/apps/scan/frontend/src/screens/scan_error_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_error_screen.tsx
@@ -47,6 +47,8 @@ export function ScanErrorScreen({
       case 'paper_in_back_after_accept':
       case 'paper_in_both_sides_after_reconnect':
         return appStrings.instructionsScannerRemoveBallotToContinue();
+      case 'multiple_sheets_detected':
+        return appStrings.instructionsScannerRemoveDoubleSheet();
       case 'paper_status_timed_out':
       case 'scanning_timed_out':
       case 'unexpected_paper_status':

--- a/apps/scan/frontend/src/screens/scan_error_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_error_screen.tsx
@@ -47,7 +47,7 @@ export function ScanErrorScreen({
       case 'paper_in_back_after_accept':
       case 'paper_in_both_sides_after_reconnect':
         return appStrings.instructionsScannerRemoveBallotToContinue();
-      case 'multiple_sheets_detected':
+      case 'double_feed_detected':
         return appStrings.instructionsScannerRemoveDoubleSheet();
       case 'paper_status_timed_out':
       case 'scanning_timed_out':

--- a/apps/scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/scan/frontend/test/helpers/mock_api_client.tsx
@@ -42,7 +42,7 @@ export const machineConfig: MachineConfig = {
 
 const defaultConfig: PrecinctScannerConfig = {
   isSoundMuted: false,
-  isMultiSheetDetectionDisabled: false,
+  isDoubleFeedDetectionDisabled: false,
   hasPaperBeenLoaded: false,
   isTestMode: true,
   ballotCountWhenBallotBagLastReplaced: 0,

--- a/libs/pdi-scanner/examples/scan_forever.rs
+++ b/libs/pdi-scanner/examples/scan_forever.rs
@@ -14,7 +14,7 @@ use pdi_scanner::{
     protocol::{
         image::{RawImageData, Sheet, DEFAULT_IMAGE_WIDTH},
         packets::Incoming,
-        types::{EjectMotion, FeederMode, ScanSideMode},
+        types::{DoubleFeedDetectionMode, EjectMotion, FeederMode, ScanSideMode},
     },
 };
 
@@ -64,7 +64,7 @@ fn main() -> color_eyre::Result<()> {
     let mut scan_index = 0;
 
     client.send_initial_commands_after_connect(Duration::from_secs(3))?;
-    client.send_enable_scan_commands()?;
+    client.send_enable_scan_commands(DoubleFeedDetectionMode::RejectDoubleFeeds)?;
     println!("waiting for sheet…");
 
     let running = Arc::new(AtomicBool::new(true));

--- a/libs/pdi-scanner/src/rust/main.rs
+++ b/libs/pdi-scanner/src/rust/main.rs
@@ -97,8 +97,9 @@ enum Command {
 enum ErrorCode {
     Disconnected,
     AlreadyConnected,
-    ScanFailed,
     ScanInProgress,
+    ScanFailed,
+    MultipleSheetsDetected,
     Other,
 }
 
@@ -407,6 +408,12 @@ fn main() -> color_eyre::Result<()> {
                 }
                 Ok(Incoming::CoverClosedEvent) => {
                     send_event(Event::CoverClosed)?;
+                }
+                Ok(Incoming::DoubleFeedEvent) => {
+                    send_event(Event::Error {
+                        code: ErrorCode::MultipleSheetsDetected,
+                        message: None,
+                    })?;
                 }
                 Ok(event) => {
                     tracing::info!("unhandled event: {event:?}");

--- a/libs/pdi-scanner/src/rust/main.rs
+++ b/libs/pdi-scanner/src/rust/main.rs
@@ -76,7 +76,7 @@ enum Command {
     GetScannerStatus,
 
     EnableScanning {
-        multi_sheet_detection_enabled: bool,
+        double_feed_detection_enabled: bool,
     },
 
     DisableScanning,
@@ -99,7 +99,7 @@ enum ErrorCode {
     AlreadyConnected,
     ScanInProgress,
     ScanFailed,
-    MultipleSheetsDetected,
+    DoubleFeedDetected,
     Other,
 }
 
@@ -283,10 +283,10 @@ fn main() -> color_eyre::Result<()> {
                     (
                         Some(client),
                         Command::EnableScanning {
-                            multi_sheet_detection_enabled,
+                            double_feed_detection_enabled,
                         },
                     ) => {
-                        let double_feed_detection_mode = if multi_sheet_detection_enabled {
+                        let double_feed_detection_mode = if double_feed_detection_enabled {
                             DoubleFeedDetectionMode::RejectDoubleFeeds
                         } else {
                             DoubleFeedDetectionMode::Disabled
@@ -411,7 +411,7 @@ fn main() -> color_eyre::Result<()> {
                 }
                 Ok(Incoming::DoubleFeedEvent) => {
                     send_event(Event::Error {
-                        code: ErrorCode::MultipleSheetsDetected,
+                        code: ErrorCode::DoubleFeedDetected,
                         message: None,
                     })?;
                 }

--- a/libs/pdi-scanner/src/rust/protocol/packets.rs
+++ b/libs/pdi-scanner/src/rust/protocol/packets.rs
@@ -555,14 +555,14 @@ pub enum Outgoing {
     GetDoubleFeedDetectionLedIntensityRequest,
 
     /// Requests the double feed detection calibration value for a single sheet
-    /// (`n3a30`).
+    /// (`n3a10`).
     GetDoubleFeedDetectionSingleSheetCalibrationValueRequest,
 
     /// Requests the double feed detection calibration value for a double sheet
     /// (`n3a20`).
     GetDoubleFeedDetectionDoubleSheetCalibrationValueRequest,
 
-    /// Requests the double feed detection threshold value (`n3a10`).
+    /// Requests the double feed detection threshold value (`n3a90`).
     GetDoubleFeedDetectionDoubleSheetThresholdValueRequest,
 
     RawPacket(Vec<u8>),

--- a/libs/pdi-scanner/src/ts/demo.ts
+++ b/libs/pdi-scanner/src/ts/demo.ts
@@ -8,7 +8,9 @@ export async function main(): Promise<void> {
   const scannerClient = createPdiScannerClient();
   (await scannerClient.connect()).unsafeUnwrap();
 
-  (await scannerClient.enableScanning()).unsafeUnwrap();
+  (
+    await scannerClient.enableScanning({ multiSheetDetectionEnabled: true })
+  ).unsafeUnwrap();
 
   let state = 'waitingForBallot';
   scannerClient.addListener((event) => {
@@ -27,7 +29,9 @@ export async function main(): Promise<void> {
   for (;;) {
     if (state === 'scanComplete') {
       (await scannerClient.ejectDocument('toRear')).unsafeUnwrap();
-      (await scannerClient.enableScanning()).unsafeUnwrap();
+      (
+        await scannerClient.enableScanning({ multiSheetDetectionEnabled: true })
+      ).unsafeUnwrap();
       state = 'waitingForBallot';
     }
     await sleep(1000);

--- a/libs/pdi-scanner/src/ts/demo.ts
+++ b/libs/pdi-scanner/src/ts/demo.ts
@@ -9,7 +9,7 @@ export async function main(): Promise<void> {
   (await scannerClient.connect()).unsafeUnwrap();
 
   (
-    await scannerClient.enableScanning({ multiSheetDetectionEnabled: true })
+    await scannerClient.enableScanning({ doubleFeedDetectionEnabled: true })
   ).unsafeUnwrap();
 
   let state = 'waitingForBallot';
@@ -30,7 +30,7 @@ export async function main(): Promise<void> {
     if (state === 'scanComplete') {
       (await scannerClient.ejectDocument('toRear')).unsafeUnwrap();
       (
-        await scannerClient.enableScanning({ multiSheetDetectionEnabled: true })
+        await scannerClient.enableScanning({ doubleFeedDetectionEnabled: true })
       ).unsafeUnwrap();
       state = 'waitingForBallot';
     }

--- a/libs/pdi-scanner/src/ts/scanner_client.test.ts
+++ b/libs/pdi-scanner/src/ts/scanner_client.test.ts
@@ -84,27 +84,27 @@ test('getScannerStatus', async () => {
   expectStdinCommand({ command: 'getScannerStatus' });
 });
 
-test('enableScanning({ multiSheetDetectionEnabled: true })', async () => {
+test('enableScanning({ doubleFeedDetectionEnabled: true })', async () => {
   const client = createPdiScannerClient();
   mockStdoutResponse({ response: 'ok' });
   expect(
-    await client.enableScanning({ multiSheetDetectionEnabled: true })
+    await client.enableScanning({ doubleFeedDetectionEnabled: true })
   ).toEqual(ok());
   expectStdinCommand({
     command: 'enableScanning',
-    multiSheetDetectionEnabled: true,
+    doubleFeedDetectionEnabled: true,
   });
 });
 
-test('enableScanning({ multiSheetDetectionEnabled: false })', async () => {
+test('enableScanning({ doubleFeedDetectionEnabled: false })', async () => {
   const client = createPdiScannerClient();
   mockStdoutResponse({ response: 'ok' });
   expect(
-    await client.enableScanning({ multiSheetDetectionEnabled: false })
+    await client.enableScanning({ doubleFeedDetectionEnabled: false })
   ).toEqual(ok());
   expectStdinCommand({
     command: 'enableScanning',
-    multiSheetDetectionEnabled: false,
+    doubleFeedDetectionEnabled: false,
   });
 });
 
@@ -240,11 +240,11 @@ test('queues overlapping commands', async () => {
   const client = createPdiScannerClient();
   const command1Promise = client.getScannerStatus();
   const command2Promise = client.enableScanning({
-    multiSheetDetectionEnabled: true,
+    doubleFeedDetectionEnabled: true,
   });
   expectStdinCommands([
     { command: 'getScannerStatus' },
-    { command: 'enableScanning', multiSheetDetectionEnabled: true },
+    { command: 'enableScanning', doubleFeedDetectionEnabled: true },
   ]);
   mockStdoutResponse({ response: 'scannerStatus', status: scannerStatus });
   mockStdoutResponse({ response: 'ok' });
@@ -286,7 +286,7 @@ test('simple commands handle unexpected response', async () => {
   const client = createPdiScannerClient();
   mockStdoutResponse({ response: 'scannerStatus', status: scannerStatus });
   expect(
-    await client.enableScanning({ multiSheetDetectionEnabled: true })
+    await client.enableScanning({ doubleFeedDetectionEnabled: true })
   ).toEqual(
     err({ code: 'other', message: 'Unexpected response: scannerStatus' })
   );
@@ -296,6 +296,6 @@ test('simple commands handle error response', async () => {
   const client = createPdiScannerClient();
   mockStdoutResponse({ response: 'error', code: 'scanInProgress' });
   expect(
-    await client.enableScanning({ multiSheetDetectionEnabled: true })
+    await client.enableScanning({ doubleFeedDetectionEnabled: true })
   ).toEqual(err({ response: 'error', code: 'scanInProgress' }));
 });

--- a/libs/pdi-scanner/src/ts/scanner_client.test.ts
+++ b/libs/pdi-scanner/src/ts/scanner_client.test.ts
@@ -84,11 +84,28 @@ test('getScannerStatus', async () => {
   expectStdinCommand({ command: 'getScannerStatus' });
 });
 
-test('enableScanning', async () => {
+test('enableScanning({ multiSheetDetectionEnabled: true })', async () => {
   const client = createPdiScannerClient();
   mockStdoutResponse({ response: 'ok' });
-  expect(await client.enableScanning()).toEqual(ok());
-  expectStdinCommand({ command: 'enableScanning' });
+  expect(
+    await client.enableScanning({ multiSheetDetectionEnabled: true })
+  ).toEqual(ok());
+  expectStdinCommand({
+    command: 'enableScanning',
+    multiSheetDetectionEnabled: true,
+  });
+});
+
+test('enableScanning({ multiSheetDetectionEnabled: false })', async () => {
+  const client = createPdiScannerClient();
+  mockStdoutResponse({ response: 'ok' });
+  expect(
+    await client.enableScanning({ multiSheetDetectionEnabled: false })
+  ).toEqual(ok());
+  expectStdinCommand({
+    command: 'enableScanning',
+    multiSheetDetectionEnabled: false,
+  });
 });
 
 test('disableScanning', async () => {
@@ -222,10 +239,12 @@ test('converts image data from scanComplete event', async () => {
 test('queues overlapping commands', async () => {
   const client = createPdiScannerClient();
   const command1Promise = client.getScannerStatus();
-  const command2Promise = client.enableScanning();
+  const command2Promise = client.enableScanning({
+    multiSheetDetectionEnabled: true,
+  });
   expectStdinCommands([
     { command: 'getScannerStatus' },
-    { command: 'enableScanning' },
+    { command: 'enableScanning', multiSheetDetectionEnabled: true },
   ]);
   mockStdoutResponse({ response: 'scannerStatus', status: scannerStatus });
   mockStdoutResponse({ response: 'ok' });
@@ -266,7 +285,9 @@ test('getScannerStatus handles unexpected response', async () => {
 test('simple commands handle unexpected response', async () => {
   const client = createPdiScannerClient();
   mockStdoutResponse({ response: 'scannerStatus', status: scannerStatus });
-  expect(await client.enableScanning()).toEqual(
+  expect(
+    await client.enableScanning({ multiSheetDetectionEnabled: true })
+  ).toEqual(
     err({ code: 'other', message: 'Unexpected response: scannerStatus' })
   );
 });
@@ -274,7 +295,7 @@ test('simple commands handle unexpected response', async () => {
 test('simple commands handle error response', async () => {
   const client = createPdiScannerClient();
   mockStdoutResponse({ response: 'error', code: 'scanInProgress' });
-  expect(await client.enableScanning()).toEqual(
-    err({ response: 'error', code: 'scanInProgress' })
-  );
+  expect(
+    await client.enableScanning({ multiSheetDetectionEnabled: true })
+  ).toEqual(err({ response: 'error', code: 'scanInProgress' }));
 });

--- a/libs/pdi-scanner/src/ts/scanner_client.ts
+++ b/libs/pdi-scanner/src/ts/scanner_client.ts
@@ -67,7 +67,7 @@ export type ScannerError =
   | { code: 'alreadyConnected' }
   | { code: 'scanInProgress' }
   | { code: 'scanFailed' }
-  | { code: 'multipleSheetsDetected' }
+  | { code: 'doubleFeedDetected' }
   | { code: 'other'; message: string };
 
 /**
@@ -99,7 +99,7 @@ type PdictlCommand =
   | { command: 'connect' }
   | { command: 'disconnect' }
   | { command: 'getScannerStatus' }
-  | { command: 'enableScanning'; multiSheetDetectionEnabled: boolean }
+  | { command: 'enableScanning'; doubleFeedDetectionEnabled: boolean }
   | { command: 'disableScanning' }
   | {
       command: 'ejectDocument';
@@ -315,13 +315,13 @@ export function createPdiScannerClient() {
      * automatically scan any document inserted into the scanner.
      */
     async enableScanning({
-      multiSheetDetectionEnabled,
+      doubleFeedDetectionEnabled,
     }: {
-      multiSheetDetectionEnabled: boolean;
+      doubleFeedDetectionEnabled: boolean;
     }): Promise<SimpleResult> {
       return sendSimpleCommand({
         command: 'enableScanning',
-        multiSheetDetectionEnabled,
+        doubleFeedDetectionEnabled,
       });
     },
 

--- a/libs/pdi-scanner/src/ts/scanner_client.ts
+++ b/libs/pdi-scanner/src/ts/scanner_client.ts
@@ -67,6 +67,7 @@ export type ScannerError =
   | { code: 'alreadyConnected' }
   | { code: 'scanInProgress' }
   | { code: 'scanFailed' }
+  | { code: 'multipleSheetsDetected' }
   | { code: 'other'; message: string };
 
 /**

--- a/libs/pdi-scanner/src/ts/scanner_client.ts
+++ b/libs/pdi-scanner/src/ts/scanner_client.ts
@@ -98,7 +98,7 @@ type PdictlCommand =
   | { command: 'connect' }
   | { command: 'disconnect' }
   | { command: 'getScannerStatus' }
-  | { command: 'enableScanning' }
+  | { command: 'enableScanning'; multiSheetDetectionEnabled: boolean }
   | { command: 'disableScanning' }
   | {
       command: 'ejectDocument';
@@ -313,8 +313,15 @@ export function createPdiScannerClient() {
      * Enables the scanner's feeder. Once enabled, the scanner will
      * automatically scan any document inserted into the scanner.
      */
-    async enableScanning(): Promise<SimpleResult> {
-      return sendSimpleCommand({ command: 'enableScanning' });
+    async enableScanning({
+      multiSheetDetectionEnabled,
+    }: {
+      multiSheetDetectionEnabled: boolean;
+    }): Promise<SimpleResult> {
+      return sendSimpleCommand({
+        command: 'enableScanning',
+        multiSheetDetectionEnabled,
+      });
     },
 
     /**


### PR DESCRIPTION
## Overview

Enables double feed detection (DFD) for the PDI scanner based on the flag stored in the VxScan db. See commits for details

Note that calibration of the DFD settings is not yet implemented and must be done with the PDI Diagnostics tool currently.

## Demo Video or Screenshot


https://github.com/votingworks/vxsuite/assets/530106/d458f1b5-3367-4a05-9634-430b016c0d61

![Screenshot-VxScan-2024-05-02T21:48:40 958Z](https://github.com/votingworks/vxsuite/assets/530106/85a6ba93-660c-4a52-a170-f2d50bae950f)



## Testing Plan
Manual testing, added automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
