### PR TITLE
[mark-scan] Prod image hardware peripheral fixes

### DIFF
--- a/apps/mark-scan/accessible-controller/src/controllerd.rs
+++ b/apps/mark-scan/accessible-controller/src/controllerd.rs
@@ -15,6 +15,8 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
+    thread::sleep,
+    time::Duration,
 };
 use uinput::event::keyboard;
 use vx_logging::{log, set_app_name, Disposition, EventId, EventType};
@@ -32,6 +34,7 @@ mod port;
 const APP_NAME: &str = "vx-mark-scan-controller-daemon";
 const KPB_200_FW_VID: u16 = 0x28cd;
 const KPB_200_FW_PID: u16 = 0x4008;
+const STARTUP_SLEEP_DURATION: Duration = Duration::from_millis(1500);
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -43,6 +46,9 @@ struct Args {
 
 fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
+    // Give the controller device time to register with the OS. The echo command
+    // will sometimes fail without this pause.
+    sleep(STARTUP_SLEEP_DURATION);
 
     let args = Args::parse();
     set_app_name(APP_NAME);

--- a/apps/mark-scan/accessible-controller/src/controllerd.rs
+++ b/apps/mark-scan/accessible-controller/src/controllerd.rs
@@ -34,7 +34,7 @@ mod port;
 const APP_NAME: &str = "vx-mark-scan-controller-daemon";
 const KPB_200_FW_VID: u16 = 0x28cd;
 const KPB_200_FW_PID: u16 = 0x4008;
-const STARTUP_SLEEP_DURATION: Duration = Duration::from_millis(1500);
+const STARTUP_SLEEP_DURATION: Duration = Duration::from_millis(3000);
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -60,7 +60,7 @@ import {
   loadAndParkPaper,
   printBallotChunks,
 } from './application_driver';
-import { PatConnectionStatusReader } from '../pat-input/connection_status_reader';
+import { PatConnectionStatusReaderInterface } from '../pat-input/connection_status_reader';
 import {
   ORIGIN_SWIFTY_PRODUCT_ID,
   ORIGIN_VENDOR_ID,
@@ -71,7 +71,7 @@ interface Context {
   auth: InsertedSmartCardAuthApi;
   workspace: Workspace;
   driver: PaperHandlerDriverInterface;
-  patConnectionStatusReader: PatConnectionStatusReader;
+  patConnectionStatusReader: PatConnectionStatusReaderInterface;
   deviceTimeoutMs: number;
   devicePollingIntervalMs: number;
   authPollingIntervalMs: number;
@@ -930,7 +930,7 @@ export async function getPaperHandlerStateMachine({
   auth: InsertedSmartCardAuthApi;
   logger: BaseLogger;
   driver: PaperHandlerDriverInterface;
-  patConnectionStatusReader: PatConnectionStatusReader;
+  patConnectionStatusReader: PatConnectionStatusReaderInterface;
   deviceTimeoutMs?: number;
   devicePollingIntervalMs: number;
   authPollingIntervalMs: number;

--- a/apps/mark-scan/backend/src/pat-input/connection_status_reader.test.ts
+++ b/apps/mark-scan/backend/src/pat-input/connection_status_reader.test.ts
@@ -4,48 +4,74 @@ import * as fs from 'fs/promises';
 import { Buffer } from 'buffer';
 import { PatConnectionStatusReader } from './connection_status_reader';
 
+const ASCII_ZERO = 48;
+const ASCII_ONE = 49;
+
 let logger: BaseLogger;
+// Replaces /sys/class/gpio
+let mockGpioDir: tmp.DirResult;
+tmp.setGracefulCleanup();
 
 beforeEach(() => {
+  mockGpioDir = tmp.dirSync();
   logger = mockBaseLogger();
 });
 
 test('logs when it cannot access the gpio pin sysfs file', async () => {
-  const reader = new PatConnectionStatusReader(
-    logger,
-    '/sys/class/gpio/not-a-real-gpio-123/value'
-  );
+  const reader = new PatConnectionStatusReader(logger, mockGpioDir.name);
+
   const result = await reader.open();
-  expect(logger.log).toHaveBeenCalledWith(LogEventId.PatDeviceError, 'system', {
-    message: expect.stringMatching(/not accessible from VxMarkScan backend/),
-  });
+  expect(logger.log).toHaveBeenCalledWith(
+    LogEventId.ConnectToPatInputComplete,
+    'system',
+    {
+      disposition: 'failure',
+      message: expect.stringMatching(
+        /PatConnectionStatusReader failed to connect to PAT input. Attempted pins: [990,478]/
+      ),
+    }
+  );
 
   expect(result).toEqual(false);
   await reader.close();
 });
 
-test('isPatDeviceConnected can read "true" pin value from a file', async () => {
-  const file = tmp.fileSync();
-  const buf = Buffer.of(48); // ASCII char '0'
-  await fs.appendFile(file.name, buf);
+const pinAddresses = [
+  { address: 478, expectedConnectionStatus: true },
+  { address: 478, expectedConnectionStatus: false },
+  { address: 990, expectedConnectionStatus: true },
+  { address: 990, expectedConnectionStatus: false },
+];
 
-  const reader = new PatConnectionStatusReader(logger, file.name);
-  const result = await reader.open();
-  expect(result).toEqual(true);
-  const isConnected = await reader.isPatDeviceConnected();
-  expect(isConnected).toEqual(true);
-  await reader.close();
-});
+function expectedStatusToAsciiChar(expectedStatus: boolean) {
+  // Value file contains '0' when device is connected and '1' when not connected
+  return expectedStatus ? ASCII_ZERO : ASCII_ONE;
+}
 
-test('isPatDeviceConnected can read "false" pin value from a file', async () => {
-  const file = tmp.fileSync();
-  const buf = Buffer.of(49); // ASCII char '1'
-  await fs.appendFile(file.name, buf);
+test.each(pinAddresses)(
+  'isPatDeviceConnected can read "$expectedConnectionStatus" from pin $address value file',
+  async ({ address, expectedConnectionStatus }) => {
+    // Makes a directory for the pin. Analagous to /sys/class/gpio/gpio<n>
+    const pinDir = tmp.dirSync({
+      tmpdir: mockGpioDir.name,
+      name: `gpio${address}`,
+    });
 
-  const reader = new PatConnectionStatusReader(logger, file.name);
-  const result = await reader.open();
-  expect(result).toEqual(true);
-  const isConnected = await reader.isPatDeviceConnected();
-  expect(isConnected).toEqual(false);
-  await reader.close();
-});
+    // Makes a `value` file and writes one character to it. Analagous to
+    // /sys/class/gpio/gpio<n>/value
+    const valueFile = tmp.fileSync({
+      tmpdir: pinDir.name,
+      name: 'value',
+    });
+
+    const buf = Buffer.of(expectedStatusToAsciiChar(expectedConnectionStatus));
+    await fs.appendFile(valueFile.name, buf);
+
+    const reader = new PatConnectionStatusReader(logger, mockGpioDir.name);
+    const result = await reader.open();
+    expect(result).toEqual(true);
+    const isConnected = await reader.isPatDeviceConnected();
+    expect(isConnected).toEqual(expectedConnectionStatus);
+    await reader.close();
+  }
+);

--- a/apps/mark-scan/backend/src/pat-input/constants.ts
+++ b/apps/mark-scan/backend/src/pat-input/constants.ts
@@ -4,4 +4,8 @@ export const ORIGIN_SWIFTY_PRODUCT_ID = 0x0012;
 
 // Constants for built-in 3.5mm jack GPIO integration
 export const PAT_CONNECTION_STATUS_PIN = 478;
-export const PATH_TO_PAT_CONNECTION_STATUS_PIN = `/sys/class/gpio/gpio${PAT_CONNECTION_STATUS_PIN}/value`;
+// More recent versions of Debian offset the expected GPIO addresses
+// eg. the connection status pin is addressed at 478 + 512 = 990
+export const PAT_GPIO_OFFSET = 512;
+
+export const GPIO_PATH_PREFIX = '/sys/class/gpio';

--- a/apps/mark-scan/backend/src/pat-input/mock_connection_status_reader.ts
+++ b/apps/mark-scan/backend/src/pat-input/mock_connection_status_reader.ts
@@ -1,5 +1,7 @@
+/* eslint-disable vx/gts-no-public-class-fields */
 import { BaseLogger } from '@votingworks/logging';
 import { PatConnectionStatusReaderInterface } from './connection_status_reader';
+import { GPIO_PATH_PREFIX } from './constants';
 
 // This mock is intended for developing on PAT flows without PAT hardware.
 // It's also used to create a no-op mock for tests that just need
@@ -12,9 +14,8 @@ export class MockPatConnectionStatusReader
   private mockConnectedStatus: boolean = false;
 
   constructor(
-    // logger prop must be public to be defined in the interface
-    // eslint-disable-next-line vx/gts-no-public-class-fields
-    readonly logger: BaseLogger
+    readonly logger: BaseLogger,
+    readonly gpioPathPrefix: string = GPIO_PATH_PREFIX
   ) {}
 
   open(): Promise<boolean> {

--- a/apps/mark-scan/backend/src/server.ts
+++ b/apps/mark-scan/backend/src/server.ts
@@ -22,7 +22,10 @@ import {
   DEV_DEVICE_STATUS_POLLING_INTERVAL_MS,
   NOTIFICATION_DURATION_MS,
 } from './custom-paper-handler/constants';
-import { PatConnectionStatusReader } from './pat-input/connection_status_reader';
+import {
+  PatConnectionStatusReader,
+  PatConnectionStatusReaderInterface,
+} from './pat-input/connection_status_reader';
 import { MockPatConnectionStatusReader } from './pat-input/mock_connection_status_reader';
 
 export interface StartOptions {
@@ -74,7 +77,8 @@ export async function start({
     getUserRole(resolvedAuth, workspace)
   );
   const driver = await resolveDriver(logger);
-  let patConnectionStatusReader = new PatConnectionStatusReader(logger);
+  let patConnectionStatusReader: PatConnectionStatusReaderInterface =
+    new PatConnectionStatusReader(logger);
   const canReadPatConnectionStatus = await patConnectionStatusReader.open();
 
   if (!canReadPatConnectionStatus) {


### PR DESCRIPTION
## Overview

Fixes 2 bugs with hardware daemons in prod images.
*  `PatInputConnectionStatusReader` did not check for GPIO address offset present in Debian 12, resulting in the app being unable to trigger the PAT device calibration flow on Debian 12
* `controllerd` did not receive an echo response the majority of the time on startup, likely because the device was not ready yet

## Demo Video or Screenshot

No behavior change. We won't be able to QA on Debian 12 until we build a prod image, but here's a video of backwards compatibility of the PAT change on Debian 11.


https://github.com/votingworks/vxsuite/assets/1060688/c00071b7-9fd4-47e4-a3a4-f6ddc0f6f865



## Testing Plan

- updated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
