### PR TITLE
fix(design): drop the definite article from "Green Party" translation

### DIFF
--- a/apps/design/backend/src/language_and_audio/translation_overrides.ts
+++ b/apps/design/backend/src/language_and_audio/translation_overrides.ts
@@ -12,6 +12,6 @@ export const GLOBAL_TRANSLATION_OVERRIDES: TranslationOverrides = {
   [LanguageCode.CHINESE_SIMPLIFIED]: {},
   [LanguageCode.CHINESE_TRADITIONAL]: {},
   [LanguageCode.SPANISH]: {
-    'Green Party': 'El Partido Verde',
+    'Green Party': 'Partido Verde',
   },
 };


### PR DESCRIPTION
The Spanish version of the name, like the English one, does not appear to contain the leading "El"/"The" definite article. This isn't really meant as the place to put all our translations and is really just an example of how to do overrides (replacing the obviously incorrect "Fiesta Verde"), but I'd still like it to be correct.

Context from Slack: https://votingworks.slack.com/archives/CEL6D3GAD/p1715015367963289
