### PR TITLE
libs/pdi-scanner: Increase timeout so long ballots can eject

### DIFF
--- a/libs/pdi-scanner/src/rust/main.rs
+++ b/libs/pdi-scanner/src/rust/main.rs
@@ -275,7 +275,10 @@ fn main() -> color_eyre::Result<()> {
                         send_response(Response::Ok)?;
                     }
                     (Some(client), Command::GetScannerStatus) => {
-                        match client.get_scanner_status(Duration::from_secs(1)) {
+                        // We use a long-ish timeout here because the scanner
+                        // may sometimes be delayed in sending a response (e.g.
+                        // if its busy ejecting a long sheet of paper).
+                        match client.get_scanner_status(Duration::from_secs(2)) {
                             Ok(status) => send_response(Response::ScannerStatus { status })?,
                             Err(e) => send_error_response(&e)?,
                         }


### PR DESCRIPTION

## Overview

Previously, when trying to eject a long (22in) ballot from the back of the scanner to the front of the scanner, the subsequent scanner status command would time out. We bump this timeout from 1s to 2s since that seems to be reliably give the scanner enough time to finish ejecting a long ballot.

## Demo Video or Screenshot

## Testing Plan
Manual testing

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
