### PR TITLE
don't log PAT device no status change event

### DIFF
--- a/apps/mark-scan/backend/src/custom-paper-handler/application_driver.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/application_driver.ts
@@ -77,15 +77,18 @@ export async function printBallotChunks(
 }
 
 export async function scanAndSave(driver: PaperHandlerDriver): Promise<string> {
+  debug('+scanAndSave');
   const pathOutFront = tmpNameSync({ postfix: '.jpeg' });
+  debug('saving scan to', pathOutFront);
   const status = await driver.getPaperHandlerStatus();
+  debug('status: %s', status);
   // Scan can happen from loaded or parked state. If the paper is not loaded or parked
   // it means the voter may have taken the paper out of the infeed
   if (!isPaperAnywhere(status)) {
     throw new Error('Paper has been removed');
   }
 
-  debug('Starting scanAndSave to', pathOutFront);
+  debug('Starting scanAndSave');
   await driver.scanAndSave(pathOutFront);
   debug('Completed scanAndSave');
 

--- a/apps/mark-scan/backend/src/custom-paper-handler/application_driver.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/application_driver.ts
@@ -85,7 +85,9 @@ export async function scanAndSave(driver: PaperHandlerDriver): Promise<string> {
     throw new Error('Paper has been removed');
   }
 
+  debug('Starting scanAndSave to', pathOutFront);
   await driver.scanAndSave(pathOutFront);
+  debug('Completed scanAndSave');
 
   // We can only print to one side from the thermal printer, but the interpret flow expects
   // a SheetOf 2 pages. Use an image of a blank sheet for the 2nd page.

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -521,6 +521,13 @@ export function buildMachine(
                       scannedBallotImagePath: (_, event) => event.data,
                     }),
                   },
+                  onError: {
+                    target: 'resetting_state_machine_after_jam',
+                    actions: (context, event) =>
+                      context.logger.log(LogEventId.UnknownError, 'system', {
+                        message: `Error in scan stage: ${event.data}`,
+                      }),
+                  },
                 },
                 pollPaperStatus(),
               ],

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -508,6 +508,7 @@ export function buildMachine(
               ],
             },
             scanning: {
+              entry: () => debug('+scanning'),
               invoke: [
                 {
                   id: 'scanAndSave',
@@ -525,6 +526,7 @@ export function buildMachine(
               ],
             },
             interpreting: {
+              entry: () => debug('+interpreting'),
               // Paper is in the paper handler for the duration of the interpreting stage and paper handler
               // motors are never moved, so we don't need to poll paper status or handle jams.
               invoke: {

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -851,13 +851,15 @@ function setUpLogging(
     .onEvent(async (event) => {
       // To protect voter privacy, we only log the event type (since some event
       // objects include ballot interpretations)
-      await logger.log(
-        LogEventId.MarkScanStateMachineEvent,
-        'system',
-        { message: `Event: ${event.type}` },
-        /* istanbul ignore next */
-        (logLine: LogLine) => debugEvents(logLine.message)
-      );
+      if (event.type !== 'PAT_DEVICE_NO_STATUS_CHANGE') {
+        await logger.log(
+          LogEventId.MarkScanStateMachineEvent,
+          'system',
+          { message: `Event: ${event.type}` },
+          /* istanbul ignore next */
+          (logLine: LogLine) => debugEvents(logLine.message)
+        );
+      }
     })
     .onChange(async (context, previousContext) => {
       if (!previousContext) return;

--- a/libs/custom-paper-handler/src/driver/driver.ts
+++ b/libs/custom-paper-handler/src/driver/driver.ts
@@ -372,6 +372,10 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
     const transferOutResult = await this.transferOutGeneric(coder, value);
     assert(transferOutResult.status === 'ok'); // TODO: Handling
 
+    return this.transferInAcknowledgement();
+  }
+
+  async transferInAcknowledgement(): Promise<boolean> {
     const transferInResult = await this.transferInGeneric();
     assert(transferInResult.status === 'ok'); // TODO: Handling
     this.genericLock.release();
@@ -392,8 +396,8 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
         debug('negative acknowledgement');
         return false;
       case ReturnCodes.UNKNOWN:
-        debug('unknown acknowledgement');
-        return true;
+        debug('unknown response code. retrying reading acknowledgement');
+        return this.transferInAcknowledgement();
       default:
         throw new Error(`uninterpretable acknowledgement: ${code}`);
     }

--- a/libs/custom-paper-handler/src/driver/driver.ts
+++ b/libs/custom-paper-handler/src/driver/driver.ts
@@ -194,7 +194,8 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
         sleep(1000).then(() => {
           return true;
         }),
-        this.transferInGeneric().then(() => {
+        this.transferInGeneric().then((data) => {
+          console.log('flushed transferInGeneric data', data);
           return false;
         }),
       ]);

--- a/libs/custom-paper-handler/src/driver/driver.ts
+++ b/libs/custom-paper-handler/src/driver/driver.ts
@@ -366,7 +366,8 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
     value: T
   ): Promise<boolean> {
     await this.genericLock.acquire();
-    console.log(`transferOutGeneric command buffer: ${value}`);
+    console.log(`transferOutGeneric coder command: ${JSON.stringify(coder)}`);
+    console.log(`transferOutGeneric command args: ${JSON.stringify(value)}`);
     const transferOutResult = await this.transferOutGeneric(coder, value);
     assert(transferOutResult.status === 'ok'); // TODO: Handling
 
@@ -458,6 +459,7 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
     // 2. Each data block can fit within a single `transferInGeneric` call
     while (scanStatus === OK_CONTINUE) {
       const rawResponse = await this.transferInGeneric();
+      debug(`rawResponse: ${JSON.stringify(rawResponse)}`);
       assert(rawResponse?.data);
 
       const responseBuffer = new Uint8Array(

--- a/libs/custom-paper-handler/src/driver/driver.ts
+++ b/libs/custom-paper-handler/src/driver/driver.ts
@@ -547,6 +547,7 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
    * attempt to pull paper in. if none is pulled in, command still returns positive.
    */
   async loadPaper(): Promise<boolean> {
+    debug('loadPaper');
     return this.handleGenericCommandWithAcknowledgement(
       LoadPaperCommand,
       undefined
@@ -558,6 +559,7 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
    * no paper to eject, handler will do nothing and return positive acknowledgement.
    */
   async ejectPaperToFront(): Promise<boolean> {
+    debug('ejectPaperToFront');
     return this.handleGenericCommandWithAcknowledgement(
       EjectPaperCommand,
       undefined
@@ -570,6 +572,7 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
    * positive acknowledgement. When parked, parkSensor should be true.
    */
   async parkPaper(): Promise<boolean> {
+    debug('parkPaper');
     return this.handleGenericCommandWithAcknowledgement(
       ParkPaperCommand,
       undefined
@@ -582,6 +585,7 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
    * state from the state where paper has not been picked up yet?
    */
   presentPaper(): Promise<boolean> {
+    debug('presentPaper');
     return this.handleGenericCommandWithAcknowledgement(
       PresentPaperAndHoldCommand,
       undefined
@@ -593,6 +597,7 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
    * no paper to eject, handler will do nothing and return positive acknowledgement.
    */
   async ejectBallotToRear(): Promise<boolean> {
+    debug('ejectBallotToRear');
     return this.handleGenericCommandWithAcknowledgement(
       EjectPaperToBallotCommand,
       undefined
@@ -600,6 +605,7 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
   }
 
   calibrate(): Promise<boolean> {
+    debug('calibrate');
     return this.handleGenericCommandWithAcknowledgement(
       ScannerCalibrationCommand,
       undefined
@@ -614,6 +620,7 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
    * a variety of positions.
    */
   enablePrint(): Promise<boolean> {
+    debug('enablePrint');
     return this.handleGenericCommandWithAcknowledgement(
       EnablePrintCommand,
       undefined
@@ -624,6 +631,7 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
    * Moves print head to UP position, does not move paper
    */
   disablePrint(): Promise<boolean> {
+    debug('disablePrint');
     return this.handleGenericCommandWithAcknowledgement(
       DisablePrintCommand,
       undefined

--- a/libs/custom-paper-handler/src/driver/driver.ts
+++ b/libs/custom-paper-handler/src/driver/driver.ts
@@ -374,6 +374,7 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
     this.genericLock.release();
     const { data } = transferInResult;
     assert(data);
+    console.log(data.buffer);
     const result = AcknowledgementResponse.decode(Buffer.from(data.buffer));
     if (result.isErr()) {
       debug(`Error decoding transferInGeneric response: ${result.err()}`);

--- a/libs/custom-paper-handler/src/driver/driver.ts
+++ b/libs/custom-paper-handler/src/driver/driver.ts
@@ -374,7 +374,7 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
     this.genericLock.release();
     const { data } = transferInResult;
     assert(data);
-    console.log(data.buffer);
+    console.log(Buffer.from(data.buffer));
     const result = AcknowledgementResponse.decode(Buffer.from(data.buffer));
     if (result.isErr()) {
       debug(`Error decoding transferInGeneric response: ${result.err()}`);

--- a/libs/custom-paper-handler/src/driver/driver.ts
+++ b/libs/custom-paper-handler/src/driver/driver.ts
@@ -366,6 +366,7 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
     value: T
   ): Promise<boolean> {
     await this.genericLock.acquire();
+    console.log(`transferOutGeneric command buffer: ${value}`);
     const transferOutResult = await this.transferOutGeneric(coder, value);
     assert(transferOutResult.status === 'ok'); // TODO: Handling
 
@@ -374,7 +375,7 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
     this.genericLock.release();
     const { data } = transferInResult;
     assert(data);
-    console.log(Buffer.from(data.buffer));
+    console.log('Transfer in data:', Buffer.from(data.buffer));
     const result = AcknowledgementResponse.decode(Buffer.from(data.buffer));
     if (result.isErr()) {
       debug(`Error decoding transferInGeneric response: ${result.err()}`);
@@ -506,6 +507,7 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
   }
 
   async scanAndSave(pathOut: string): Promise<ImageFromScanner> {
+    debug('setting scan direction');
     await this.setScanDirection('backward');
     const grayscaleResult = await this.scan();
     debug(

--- a/libs/custom-paper-handler/src/driver/driver.ts
+++ b/libs/custom-paper-handler/src/driver/driver.ts
@@ -471,6 +471,9 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
         rawResponse.data.byteOffset,
         rawResponse.data.byteLength
       );
+      serverDebug('buffer', rawResponse.data.buffer);
+      serverDebug('byteOffset', rawResponse.data.byteOffset);
+      serverDebug('byteLength', rawResponse.data.byteLength);
       debug(`Scan response buffer: ${responseBuffer}`);
       const header = responseBuffer.slice(0, SCAN_HEADER_LENGTH_BYTES);
       debug(`Scan response header: ${header}`);

--- a/libs/custom-paper-handler/src/driver/driver.ts
+++ b/libs/custom-paper-handler/src/driver/driver.ts
@@ -475,10 +475,8 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
         rawResponse.data.byteOffset,
         rawResponse.data.byteLength
       );
-      serverDebug('buffer', rawResponse.data.buffer);
-      serverDebug('byteOffset', rawResponse.data.byteOffset);
-      serverDebug('byteLength', rawResponse.data.byteLength);
-      debug(`Scan response buffer: ${responseBuffer}`);
+      serverDebug('Scan response byteOffset', rawResponse.data.byteOffset);
+      serverDebug('Scan response byteLength', rawResponse.data.byteLength);
       const header = responseBuffer.slice(0, SCAN_HEADER_LENGTH_BYTES);
       debug(`Scan response header: ${header}`);
       const responseResult = ScanResponse.decode(

--- a/libs/custom-paper-handler/src/driver/driver.ts
+++ b/libs/custom-paper-handler/src/driver/driver.ts
@@ -396,8 +396,9 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
         debug('negative acknowledgement');
         return false;
       case ReturnCodes.UNKNOWN:
-        debug('unknown response code. retrying reading acknowledgement');
-        return this.transferInAcknowledgement();
+        debug('unknown response code. throwing error.');
+        throw new Error(`Unhandled response code ${ReturnCodes.UNKNOWN}`)
+      // return this.transferInAcknowledgement();
       default:
         throw new Error(`uninterpretable acknowledgement: ${code}`);
     }

--- a/libs/custom-paper-handler/src/driver/driver.ts
+++ b/libs/custom-paper-handler/src/driver/driver.ts
@@ -115,6 +115,7 @@ export const PACKET_SIZE = 65536;
 export enum ReturnCodes {
   POSITIVE_ACKNOWLEDGEMENT = 0x06,
   NEGATIVE_ACKNOWLEDGEMENT = 0x15,
+  UNKNOWN = 0x12,
 }
 
 export async function getPaperHandlerWebDevice(): Promise<
@@ -390,6 +391,9 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
       case ReturnCodes.NEGATIVE_ACKNOWLEDGEMENT:
         debug('negative acknowledgement');
         return false;
+      case ReturnCodes.UNKNOWN:
+        debug('unknown acknowledgement');
+        return true;
       default:
         throw new Error(`uninterpretable acknowledgement: ${code}`);
     }

--- a/libs/custom-paper-handler/src/driver/driver_interface.ts
+++ b/libs/custom-paper-handler/src/driver/driver_interface.ts
@@ -34,6 +34,7 @@ export interface PaperHandlerDriverInterface {
   disconnect(): Promise<void>;
   getWebDevice(): MinimalWebUsbDevice;
   transferInGeneric(): Promise<USBInTransferResult>;
+  transferInAcknowledgement(): Promise<boolean>;
   clearGenericInBuffer(): Promise<void>;
   transferOutRealTime(requestId: Uint8): Promise<USBOutTransferResult>;
   transferInRealTime(): Promise<USBInTransferResult>;

--- a/libs/custom-paper-handler/src/driver/mock_driver.ts
+++ b/libs/custom-paper-handler/src/driver/mock_driver.ts
@@ -63,6 +63,9 @@ export class MockPaperHandlerDriver implements PaperHandlerDriverInterface {
   transferInGeneric(): Promise<USBInTransferResult> {
     throw new Error('Method not implemented.');
   }
+  transferInAcknowledgement(): Promise<boolean> {
+    throw new Error('Method not implemented.');
+  }
   clearGenericInBuffer(): Promise<void> {
     throw new Error('Method not implemented.');
   }
@@ -92,62 +95,62 @@ export class MockPaperHandlerDriver implements PaperHandlerDriverInterface {
     _expectedRequestId: RealTimeRequestIds,
     _response:
       | {
-          requestId: number;
-          returnCode: number;
-          parkSensor: boolean;
-          paperOutSensor: boolean;
-          paperPostCisSensor: boolean;
-          paperPreCisSensor: boolean;
-          paperInputLeftInnerSensor: boolean;
-          paperInputRightInnerSensor: boolean;
-          paperInputLeftOuterSensor: boolean;
-          paperInputRightOuterSensor: boolean;
-          printHeadInPosition: boolean;
-          scanTimeout: boolean;
-          motorMove: boolean;
-          scanInProgress: boolean;
-          jamEncoder: boolean;
-          paperJam: boolean;
-          coverOpen: boolean;
-          optoSensor: boolean;
-          ballotBoxDoorSensor: boolean;
-          ballotBoxAttachSensor: boolean;
-          preHeadSensor: boolean;
-          startOfPacket?: unknown;
-          token?: unknown;
-          optionalDataLength?: unknown;
-        }
+        requestId: number;
+        returnCode: number;
+        parkSensor: boolean;
+        paperOutSensor: boolean;
+        paperPostCisSensor: boolean;
+        paperPreCisSensor: boolean;
+        paperInputLeftInnerSensor: boolean;
+        paperInputRightInnerSensor: boolean;
+        paperInputLeftOuterSensor: boolean;
+        paperInputRightOuterSensor: boolean;
+        printHeadInPosition: boolean;
+        scanTimeout: boolean;
+        motorMove: boolean;
+        scanInProgress: boolean;
+        jamEncoder: boolean;
+        paperJam: boolean;
+        coverOpen: boolean;
+        optoSensor: boolean;
+        ballotBoxDoorSensor: boolean;
+        ballotBoxAttachSensor: boolean;
+        preHeadSensor: boolean;
+        startOfPacket?: unknown;
+        token?: unknown;
+        optionalDataLength?: unknown;
+      }
       | {
-          requestId: number;
-          returnCode: number;
-          coverOpen: boolean;
-          ticketPresentInOutput: boolean;
-          paperNotPresent: boolean;
-          dragPaperMotorOn: boolean;
-          spooling: boolean;
-          printingHeadUpError: boolean;
-          notAcknowledgeCommandError: boolean;
-          powerSupplyVoltageError: boolean;
-          headNotConnected: boolean;
-          comError: boolean;
-          headTemperatureError: boolean;
-          diverterError: boolean;
-          headErrorLocked: boolean;
-          printingHeadReadyToPrint: boolean;
-          eepromError: boolean;
-          ramError: boolean;
-          startOfPacket?: unknown;
-          token?: unknown;
-          optionalDataLength?: unknown;
-          dle?: unknown;
-          eot?: unknown;
-        }
+        requestId: number;
+        returnCode: number;
+        coverOpen: boolean;
+        ticketPresentInOutput: boolean;
+        paperNotPresent: boolean;
+        dragPaperMotorOn: boolean;
+        spooling: boolean;
+        printingHeadUpError: boolean;
+        notAcknowledgeCommandError: boolean;
+        powerSupplyVoltageError: boolean;
+        headNotConnected: boolean;
+        comError: boolean;
+        headTemperatureError: boolean;
+        diverterError: boolean;
+        headErrorLocked: boolean;
+        printingHeadReadyToPrint: boolean;
+        eepromError: boolean;
+        ramError: boolean;
+        startOfPacket?: unknown;
+        token?: unknown;
+        optionalDataLength?: unknown;
+        dle?: unknown;
+        eot?: unknown;
+      }
       | {
-          requestId: number;
-          returnCode: number;
-          startOfPacket?: unknown;
-          token?: unknown;
-        }
+        requestId: number;
+        returnCode: number;
+        startOfPacket?: unknown;
+        token?: unknown;
+      }
   ): void {
     throw new Error('Method not implemented.');
   }


### PR DESCRIPTION
## Overview
By default we log all events. This change skips logging for PAT_DEVICE_NO_STATUS_CHANGE, which is largely noise.

## Demo Video or Screenshot
N/A

## Testing Plan
Tested manually

## Checklist


- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
