### PR TITLE
Fujitsu Printer Reconnect & Power Settings

### DIFF
--- a/apps/scan/backend/src/index.ts
+++ b/apps/scan/backend/src/index.ts
@@ -69,7 +69,7 @@ async function main(): Promise<number> {
   const workspace = await resolveWorkspace();
   const logger = Logger.from(baseLogger, () => getUserRole(auth, workspace));
   const usbDrive = detectUsbDrive(logger);
-  const printer = await getPrinter(logger);
+  const printer = getPrinter(logger);
 
   const precinctScannerStateMachine = isFeatureFlagEnabled(
     BooleanEnvironmentVariableName.USE_CUSTOM_SCANNER
@@ -89,7 +89,7 @@ async function main(): Promise<number> {
         logger,
       });
 
-  await server.start({
+  server.start({
     auth,
     precinctScannerStateMachine,
     workspace,

--- a/apps/scan/backend/src/printing/printer.ts
+++ b/apps/scan/backend/src/printing/printer.ts
@@ -4,8 +4,8 @@ import {
   PrinterStatus as FujitsuPrinterStatus,
   PrinterState as FujitsuPrinterState,
   PrintResult as FujitsuPrintResult,
-  getFujitsuThermalPrinter,
   FujitsuThermalPrinterInterface,
+  FujitsuThermalPrinter,
 } from '@votingworks/fujitsu-thermal-printer';
 import {
   BooleanEnvironmentVariableName,
@@ -82,14 +82,14 @@ export function wrapFujitsuThermalPrinter(
   };
 }
 
-export async function getPrinter(logger: BaseLogger): Promise<Printer> {
+export function getPrinter(logger: BaseLogger): Printer {
   /* c8 ignore start */
   if (
     isFeatureFlagEnabled(
       BooleanEnvironmentVariableName.SCAN_USE_FUJITSU_PRINTER
     )
   ) {
-    const printer = await getFujitsuThermalPrinter();
+    const printer = new FujitsuThermalPrinter();
     assert(printer); // TODO: build mock and/or reconnection instead of asserting
     return wrapFujitsuThermalPrinter(printer);
   }

--- a/apps/scan/backend/src/server.test.ts
+++ b/apps/scan/backend/src/server.test.ts
@@ -33,7 +33,7 @@ test('start passes the state machine and workspace to `buildApp`', async () => {
   const logger = buildMockLogger(auth, workspace);
   buildAppMock.mockReturnValueOnce({ listen } as unknown as Application);
 
-  await start({
+  start({
     auth: buildMockInsertedSmartCardAuth(),
     workspace,
     logger,
@@ -67,14 +67,14 @@ test('start passes the state machine and workspace to `buildApp`', async () => {
   );
 });
 
-test('logs device attach/unattach events', async () => {
+test('logs device attach/unattach events', () => {
   const precinctScannerStateMachine = createPrecinctScannerStateMachineMock();
   const listen = jest.fn();
   const auth = buildMockInsertedSmartCardAuth();
   const logger = buildMockLogger(auth, workspace);
   buildAppMock.mockReturnValueOnce({ listen } as unknown as Application);
 
-  await start({
+  start({
     auth: buildMockInsertedSmartCardAuth(),
     workspace,
     logger,

--- a/apps/scan/backend/src/server.ts
+++ b/apps/scan/backend/src/server.ts
@@ -21,17 +21,17 @@ export interface StartOptions {
 /**
  * Starts the server.
  */
-export async function start({
+export function start({
   auth,
   workspace,
   logger,
   precinctScannerStateMachine,
   usbDrive,
   printer,
-}: StartOptions): Promise<void> {
+}: StartOptions): void {
   detectDevices({ logger });
   const resolvedUsbDrive = usbDrive ?? detectUsbDrive(logger);
-  const resolvedPrinter = printer ?? (await getPrinter(logger));
+  const resolvedPrinter = printer ?? getPrinter(logger);
 
   // Clear any cached data
   workspace.clearUploads();

--- a/libs/fujitsu-thermal-printer/src/driver/coders.ts
+++ b/libs/fujitsu-thermal-printer/src/driver/coders.ts
@@ -61,20 +61,29 @@ export const FeedForwardCommand = message({
   dots: uint8(),
 });
 
-export enum SpeedSetting {
-  Type1Mode1 = 0x60,
-  Type1Mode2 = 0x61,
-  Type1Mode3 = 0x62,
-  Type1Mode4 = 0x63,
-  Type1Mode5 = 0x64,
-  Type2Mode1 = 0xc0,
-  Type2Mode2 = 0xc1,
-  Type2Mode3 = 0xc2,
-  Type2Mode4 = 0xc3,
-  Type2Mode5 = 0xc4,
+export interface PrintQuality {
+  // long term storage is the printer default
+  paperQuality: 'long-term-storage' | 'standard';
+  automaticDivision: boolean;
 }
 
-export const SetSpeedSettingCommand = message({
-  command: literal(0x1b, 0x73),
-  speed: uint8(),
+export const SetPrintQuality = message({
+  command: literal(0x1d, 0x45),
+  automaticDivision: uint1(),
+  unused: padding(4),
+  qualityBit2: uint1(),
+  qualityBit1: uint1(),
+  qualityBit0: uint1(),
 });
+
+export function convertPrintQualityToCoderValue(
+  details: PrintQuality
+): CoderType<typeof SetPrintQuality> {
+  const isLongTermStorageQuality = details.paperQuality === 'long-term-storage';
+  return {
+    qualityBit2: !isLongTermStorageQuality,
+    qualityBit1: isLongTermStorageQuality,
+    qualityBit0: isLongTermStorageQuality,
+    automaticDivision: details.automaticDivision,
+  };
+}

--- a/libs/fujitsu-thermal-printer/src/driver/driver.ts
+++ b/libs/fujitsu-thermal-printer/src/driver/driver.ts
@@ -11,8 +11,9 @@ import {
   PrinterStatusResponse,
   SetReplyParameterCommand,
   FeedForwardCommand,
-  SpeedSetting,
-  SetSpeedSettingCommand,
+  PrintQuality,
+  SetPrintQuality,
+  convertPrintQualityToCoderValue,
 } from './coders';
 import { Uint16toUint8, Uint8 } from '../bits';
 import { CompressedBitImage } from './types';
@@ -52,11 +53,11 @@ export interface FujitsuThermalPrinterDriverInterface {
   connect(): Promise<void>;
   disconnect(): Promise<void>;
   resetPrinter(): Promise<void>;
+  setPrintQuality(printQuality: PrintQuality): Promise<void>;
   getStatus(): Promise<RawPrinterStatus>;
   setReplyParameter(parameter: Uint8): Promise<void>;
   printBitImage(bitImage: CompressedBitImage): void;
   feedForward(dots: number): Promise<void>;
-  setSpeed(speed: SpeedSetting): Promise<void>;
 }
 
 export class FujitsuThermalPrinterDriver
@@ -189,8 +190,17 @@ export class FujitsuThermalPrinterDriver
     await this.transferOut(FeedForwardCommand, { dots });
   }
 
-  async setSpeed(speed: SpeedSetting): Promise<void> {
-    debug(`setting speed to ${SpeedSetting[speed]}...`);
-    await this.transferOut(SetSpeedSettingCommand, { speed });
+  async setPrintQuality(printQuality: PrintQuality): Promise<void> {
+    debug(
+      `setting print quality to "${
+        printQuality.paperQuality
+      }" and turning auto-division ${
+        printQuality.automaticDivision ? 'on' : 'off'
+      }...`
+    );
+    await this.transferOut(
+      SetPrintQuality,
+      convertPrintQualityToCoderValue(printQuality)
+    );
   }
 }

--- a/libs/fujitsu-thermal-printer/src/driver/driver.ts
+++ b/libs/fujitsu-thermal-printer/src/driver/driver.ts
@@ -194,22 +194,3 @@ export class FujitsuThermalPrinterDriver
     await this.transferOut(SetSpeedSettingCommand, { speed });
   }
 }
-
-/**
- * Class constructors cannot be async, so we need a factory function to
- * asynchronously create a FujitsuThermalPrinterDriver.
- */
-export async function getFujitsuThermalPrinterDriver(): Promise<
-  Optional<FujitsuThermalPrinterDriver>
-> {
-  const thermalPrinterWebDevice = await getDevice();
-  if (!thermalPrinterWebDevice) {
-    return;
-  }
-
-  const thermalPrinterDriver = new FujitsuThermalPrinterDriver(
-    thermalPrinterWebDevice
-  );
-  await thermalPrinterDriver.connect();
-  return thermalPrinterDriver;
-}

--- a/libs/fujitsu-thermal-printer/src/mock_printer.ts
+++ b/libs/fujitsu-thermal-printer/src/mock_printer.ts
@@ -47,7 +47,6 @@ export function createMockFujitsuPrinterHandler(): MemoryFujitsuPrinterHandler {
   }
 
   const printer: FujitsuThermalPrinterInterface = {
-    initialize: async () => {},
     getStatus: () => Promise.resolve(mockPrinterState.status),
     print: mockPrint,
     advancePaper: () => Promise.resolve(ok()),

--- a/libs/fujitsu-thermal-printer/src/printer.ts
+++ b/libs/fujitsu-thermal-printer/src/printer.ts
@@ -1,10 +1,10 @@
-import { Optional, Result, err, ok } from '@votingworks/basics';
+import { Optional, Result, assert, err, ok } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import { print } from './printing';
 import {
+  FujitsuThermalPrinterDriver,
   FujitsuThermalPrinterDriverInterface,
-  SpeedSetting,
-  getFujitsuThermalPrinterDriver,
+  getDevice,
 } from './driver';
 import { rootDebug } from './debug';
 import { IDLE_REPLY_PARAMETER, LINE_FEED_REPLY_PARAMETER } from './globals';
@@ -22,33 +22,67 @@ const WAIT_FOR_ADVANCE_APPEAR_PER_CM_MS = 250;
 export type PrintResult = Result<void, PrinterStatus>;
 
 export interface FujitsuThermalPrinterInterface {
-  initialize(): Promise<void>;
   getStatus(): Promise<PrinterStatus>;
   print(data: Uint8Array): Promise<PrintResult>;
   advancePaper(lineFeedCount: number): Promise<PrintResult>;
 }
 
 export class FujitsuThermalPrinter implements FujitsuThermalPrinterInterface {
-  private readonly driver: FujitsuThermalPrinterDriverInterface;
+  private driver?: FujitsuThermalPrinterDriverInterface;
 
-  constructor(_driver: FujitsuThermalPrinterDriverInterface) {
-    this.driver = _driver;
+  private async getDriver(): Promise<
+    Optional<FujitsuThermalPrinterDriverInterface>
+  > {
+    if (this.driver) return this.driver;
+
+    const device = await getDevice();
+    if (!device) {
+      // the device is not attached or there is an access issue
+      return;
+    }
+
+    const driver = new FujitsuThermalPrinterDriver(device);
+    await driver.connect();
+
+    // standardize the printer config state
+    await driver.resetPrinter();
+    await driver.setReplyParameter(IDLE_REPLY_PARAMETER);
+
+    return driver;
   }
 
-  async initialize(): Promise<void> {
-    await this.driver.connect();
-    await this.driver.resetPrinter();
-    await this.driver.setReplyParameter(IDLE_REPLY_PARAMETER);
-  }
-
+  /**
+   * Gets a the status of the printer. Handles device connection and
+   * disconnection. All other printer methods should check status via this
+   * method to ensure the printer is connected.
+   */
   async getStatus(): Promise<PrinterStatus> {
-    const status = await this.driver.getStatus();
-    return summarizeRawStatus(status);
+    this.driver = await this.getDriver();
+    if (!this.driver) {
+      return { state: 'error', type: 'disconnected' };
+    }
+
+    try {
+      const status = await this.driver.getStatus();
+      return summarizeRawStatus(status);
+    } catch {
+      // when a previously responsive driver fails to return a response, it is
+      // most likely that the device was disconnected
+      this.driver = undefined;
+      return { state: 'error', type: 'disconnected' };
+    }
   }
 
   async advancePaper(
     millimeters: number
   ): Promise<Result<void, PrinterStatus>> {
+    const initialStatus = await this.getStatus();
+    if (initialStatus.state !== 'idle') {
+      debug(`advance paper command ignored because printer is not idle`);
+      return err(initialStatus);
+    }
+    assert(this.driver);
+
     await this.driver.setReplyParameter(LINE_FEED_REPLY_PARAMETER);
     let dotLinesRemaining = millimeters * 8;
     while (dotLinesRemaining > 0) {
@@ -73,6 +107,13 @@ export class FujitsuThermalPrinter implements FujitsuThermalPrinterInterface {
   }
 
   async print(data: Buffer): Promise<Result<void, PrinterStatus>> {
+    const initialStatus = await this.getStatus();
+    if (initialStatus.state !== 'idle') {
+      debug(`print command ignored because printer is not idle`);
+      return err(initialStatus);
+    }
+    assert(this.driver);
+
     const printResult = await print(this.driver, data);
     if (printResult.isErr()) {
       debug(`print failed on status: ${JSON.stringify(printResult.err())}`);
@@ -81,22 +122,4 @@ export class FujitsuThermalPrinter implements FujitsuThermalPrinterInterface {
     debug(`finished printing document of ${data.length} bytes`);
     return ok();
   }
-
-  async setSpeed(speed: SpeedSetting): Promise<void> {
-    await this.driver.setSpeed(speed);
-    debug(`set speed to ${speed}`);
-  }
-}
-
-export async function getFujitsuThermalPrinter(): Promise<
-  Optional<FujitsuThermalPrinter>
-> {
-  const driver = await getFujitsuThermalPrinterDriver();
-  if (!driver) {
-    return;
-  }
-
-  const printer = new FujitsuThermalPrinter(driver);
-  await printer.initialize();
-  return printer;
 }

--- a/libs/fujitsu-thermal-printer/src/printer.ts
+++ b/libs/fujitsu-thermal-printer/src/printer.ts
@@ -44,8 +44,12 @@ export class FujitsuThermalPrinter implements FujitsuThermalPrinterInterface {
     const driver = new FujitsuThermalPrinterDriver(device);
     await driver.connect();
 
-    // standardize the printer config state
+    // standardize the printer's configuration
     await driver.resetPrinter();
+    await driver.setPrintQuality({
+      paperQuality: 'long-term-storage',
+      automaticDivision: true,
+    });
     await driver.setReplyParameter(IDLE_REPLY_PARAMETER);
 
     return driver;

--- a/libs/fujitsu-thermal-printer/src/status.ts
+++ b/libs/fujitsu-thermal-printer/src/status.ts
@@ -13,7 +13,8 @@ export type ErrorType =
   | 'hardware'
   | 'supply-voltage'
   | 'receive-data'
-  | 'temperature';
+  | 'temperature'
+  | 'disconnected';
 
 export function getErrorType(status: RawPrinterStatus): ErrorType {
   if (status.temperatureError) {


### PR DESCRIPTION
Commit 1: Currently VxScan just crashes if the printer is not attached on startup, and it cannot handle disconnects and reconnects. While this was OK for the happy path, it's not OK for the sad path and development. Changing the layers so that we are just checking for the device on every status call.

Commit 2: Finishes removing the speed setting (started in commit 1) and also specifies the print quality setting on printer connect. This is to set "Auto-Division" which we've found that we need to set to prevent spikes in power draw that go beyond our v4 PSU capabilities.