### PR TITLE
Improve PDI scanner error handling

### DIFF
--- a/apps/scan/backend/src/scanners/pdi/pdi_app_scan_disconnect.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_scan_disconnect.test.ts
@@ -91,7 +91,6 @@ test('scanner disconnected on startup', async () => {
     expect(precinctScannerMachine.status()).toEqual({ state: 'disconnected' });
   });
   precinctScannerMachine.stop();
-  expect(mockScanner.client.exit).toHaveBeenCalled(); // Previous client should have been cleaned up
 });
 
 test('scanner disconnected while waiting for ballots', async () => {
@@ -111,7 +110,6 @@ test('scanner disconnected while waiting for ballots', async () => {
       simulateReconnect(mockScanner);
       clock.increment(delays.DELAY_RECONNECT);
       await waitForStatus(apiClient, { state: 'no_paper' });
-      expect(mockScanner.client.exit).toHaveBeenCalled(); // Previous client should have been cleaned up
     }
   );
 });

--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -735,24 +735,12 @@ function buildMachine({
 
         disconnected: {
           id: 'disconnected',
-          initial: 'exiting',
+          initial: 'waiting',
           entry: assign({ interpretation: undefined }),
           states: {
-            exiting: {
-              invoke: {
-                src: async ({ client }) => {
-                  (await client.exit()).unsafeUnwrap();
-                },
-                onDone: 'waiting',
-                onError: '#error',
-              },
-            },
             waiting: {
               after: {
-                DELAY_RECONNECT: {
-                  actions: assign({ client: () => createScannerClient() }),
-                  target: 'reconnecting',
-                },
+                DELAY_RECONNECT: 'reconnecting',
               },
             },
             reconnecting: {

--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -8,14 +8,17 @@ import {
 } from '@votingworks/pdi-scanner';
 import assert from 'assert';
 import {
+  ActorRef,
   BaseActionObject,
   Interpreter,
   InvokeConfig,
+  Sender,
   StateNodeConfig,
   assign,
   createMachine,
   interpret as interpretStateMachine,
   sendParent,
+  spawn,
 } from 'xstate';
 import { v4 as uuid } from 'uuid';
 import { SheetInterpretation, SheetOf, mapSheet } from '@votingworks/types';
@@ -93,6 +96,7 @@ interface Context {
   scanImages?: SheetOf<ImageData>;
   interpretation?: InterpretationResult;
   error?: ScannerError | PrecinctScannerError | Error;
+  rootListenerRef?: ActorRef<Event>;
 }
 
 type Event =
@@ -226,17 +230,33 @@ function buildMachine({
     data: (context) => ({ client: context.client }),
   };
 
+  function addEventListener(client: ScannerClient, callback: Sender<Event>) {
+    return client.addListener((event) => {
+      callback(
+        event.event === 'error'
+          ? { type: 'SCANNER_ERROR', error: event }
+          : { type: 'SCANNER_EVENT', event }
+      );
+    });
+  }
+
+  // To ensure we catch scanner events no matter what state the machine is in,
+  // we spawn a long-lived actor that is referenced in the context (rather than
+  // invoking it in a specific state). These events will be caught in the root
+  // `on` handlers.
+  const listenForScannerEventsAtRoot = assign({
+    rootListenerRef: ({ client }) =>
+      spawn((callback) => {
+        const listener = addEventListener(client, callback);
+        return () => client.removeListener(listener);
+      }),
+  });
+
   const listenForScannerEvents: InvokeConfig<Context, Event> = {
     src:
       ({ client }) =>
       (callback) => {
-        const listener = client.addListener((event) => {
-          callback(
-            event.event === 'error'
-              ? { type: 'SCANNER_ERROR', error: event }
-              : { type: 'SCANNER_EVENT', event }
-          );
-        });
+        const listener = addEventListener(client, callback);
         return () => client.removeListener(listener);
       },
   };
@@ -382,7 +402,8 @@ function buildMachine({
 
       context: { client: initialClient },
 
-      invoke: listenForScannerEvents,
+      // Listen for scanner events at the root level (see rootListenerRef to see
+      // how the listener is created).
       on: {
         SCANNER_EVENT: [
           {
@@ -419,6 +440,7 @@ function buildMachine({
       initial: 'connecting',
       states: {
         connecting: {
+          entry: listenForScannerEventsAtRoot,
           invoke: {
             src: async ({ client }) => (await client.connect()).unsafeUnwrap(),
             onDone: 'waitingForBallot',
@@ -781,9 +803,10 @@ function buildMachine({
                 onDone: 'reconnecting',
                 onError: 'reconnecting',
               },
+              exit: assign({ client: () => createScannerClient() }),
             },
             reconnecting: {
-              entry: assign({ client: () => createScannerClient() }),
+              entry: listenForScannerEventsAtRoot,
               invoke: {
                 src: async ({ client }) =>
                   (await client.connect()).unsafeUnwrap(),
@@ -831,6 +854,7 @@ function setupLogging(
         // Hide large values
         'layout',
         'client',
+        'rootListenerRef',
       ].includes(key)
     ) {
       return '[hidden]';

--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -748,7 +748,10 @@ function buildMachine({
                 src: async ({ client }) =>
                   (await client.connect()).unsafeUnwrap(),
                 onDone: '#waitingForBallot',
-                onError: '#error',
+                onError: {
+                  target: '#error',
+                  actions: assign({ error: (_, event) => event.data }),
+                },
               },
             },
           },

--- a/libs/logging/src/test_utils.test.ts
+++ b/libs/logging/src/test_utils.test.ts
@@ -1,4 +1,5 @@
-import { LogSource } from '.';
+import { typedAs } from '@votingworks/basics';
+import { LogEventType, LogLine, LogSource } from '.';
 import { LogEventId } from './log_event_ids';
 import { mockBaseLogger, mockLogger } from './test_utils';
 
@@ -6,6 +7,22 @@ test('mockBaseLogger returns a logger with a spy on logger.log', async () => {
   const logger = mockBaseLogger();
   await logger.log(LogEventId.MachineBootInit, 'system');
   expect(logger.log).toHaveBeenCalledWith(LogEventId.MachineBootInit, 'system');
+});
+
+test('mockLogger returns a logger that can print debug logs', async () => {
+  const logger = mockLogger(LogSource.System);
+  const debug = jest.fn();
+  await logger.log(LogEventId.MachineBootInit, 'system', undefined, debug);
+  expect(debug).toHaveBeenCalledWith(
+    typedAs<LogLine>({
+      source: LogSource.System,
+      eventId: LogEventId.MachineBootInit,
+      eventType: LogEventType.SystemAction,
+      user: 'system',
+      disposition: 'na',
+      details: undefined,
+    })
+  );
 });
 
 test('mockLogger', async () => {

--- a/libs/pdi-scanner/src/ts/scanner_client.test.ts
+++ b/libs/pdi-scanner/src/ts/scanner_client.test.ts
@@ -156,7 +156,7 @@ test('exit', async () => {
   expect(await client.getScannerStatus()).toEqual(
     err({
       response: 'error',
-      code: 'disconnected',
+      code: 'exited',
     })
   );
 });
@@ -258,7 +258,7 @@ test('handles unexpected pdictl exit', async () => {
   expect(await client.getScannerStatus()).toEqual(
     err({
       response: 'error',
-      code: 'disconnected',
+      code: 'exited',
     })
   );
 });

--- a/libs/pdi-scanner/src/ts/scanner_client.ts
+++ b/libs/pdi-scanner/src/ts/scanner_client.ts
@@ -63,11 +63,21 @@ export interface ScannerStatus {
  * Coded error responses from the scanner client.
  */
 export type ScannerError =
+  /** The pdictl process has exited and a new client should be created */
+  | { code: 'exited' }
+  /** The scanner is disconnected */
   | { code: 'disconnected' }
+  /** The scanner is already connected, can't connect again */
   | { code: 'alreadyConnected' }
+  /** A scan is in progress and can't be interrupted with other commands */
   | { code: 'scanInProgress' }
+  /** Scanning failed */
   | { code: 'scanFailed' }
+  /** More than one sheet was detected during scanning. Always followed by a
+   * `scanFailed` event.
+   */
   | { code: 'doubleFeedDetected' }
+  /** Another error occurred. See `message` for details. */
   | { code: 'other'; message: string };
 
 /**
@@ -242,7 +252,7 @@ export function createPdiScannerClient() {
     if (pdictlIsClosed) {
       return {
         response: 'error',
-        code: 'disconnected',
+        code: 'exited',
       };
     }
     const pendingResponse = pendingResponseQueue.get();


### PR DESCRIPTION
## Overview

Makes a variety of changes to libs/pdi-scanner and apps/scan-backend to improve the behavior in edge case error scenarios. The main improvements:
- Improved reliability of recovering from unexpected errors
- Better discernment of when the scanner is in a borked state (so we can show the message to restart)

Details in the commits.

## Demo Video or Screenshot

## Testing Plan
Added tests to cover each piece of new behavior, and manually tested.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
