### PR TITLE
apps/scan: Scan ballot inserted during accepted state

### DIFF
--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -443,11 +443,47 @@ function buildMachine({
           entry: listenForScannerEventsAtRoot,
           invoke: {
             src: async ({ client }) => (await client.connect()).unsafeUnwrap(),
-            onDone: 'waitingForBallot',
+            onDone: 'checkingInitialStatus',
             onError: {
               target: 'error',
               actions: assign({ error: (_, event) => event.data }),
             },
+          },
+        },
+
+        checkingInitialStatus: {
+          id: 'checkingInitialStatus',
+          invoke: pollScannerStatus,
+          on: {
+            SCANNER_STATUS: [
+              // We need to check for coverOpen on connect, since we won't get
+              // an event (since the cover is already open).
+              {
+                cond: (_, { status }) => status.coverOpen,
+                target: '#coverOpen',
+              },
+              {
+                cond: (_, { status }) => anyRearSensorCovered(status),
+                target: '#rejecting',
+                actions: [
+                  assign({
+                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                    error: (_context) =>
+                      new PrecinctScannerError('paper_in_back_after_reconnect'),
+                  }),
+                ],
+              },
+              {
+                cond: (_, { status }) => anyFrontSensorCovered(status),
+                target: '#rejected',
+                actions: assign({
+                  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                  error: (_context) =>
+                    new PrecinctScannerError('paper_in_front_after_reconnect'),
+                }),
+              },
+              { target: 'waitingForBallot' },
+            ],
           },
         },
 
@@ -458,7 +494,8 @@ function buildMachine({
         // scanning. When that occurs, the scan is interrupted.
         //
         // Since we don't poll scanner status, we have an initial check when
-        // entering this state to ensure the scanner is clear of ballots.
+        // entering this state to ensure the scanner doesn't have a ballot in
+        // the rear. (A ballot in the front is ok - we can scan it.)
         waitingForBallot: {
           id: 'waitingForBallot',
           entry: assign({
@@ -474,12 +511,7 @@ function buildMachine({
               on: {
                 SCANNER_STATUS: [
                   {
-                    cond: (_, { status }) => status.coverOpen,
-                    target: '#coverOpen',
-                  },
-                  {
-                    cond: (_, { status }) =>
-                      status.documentInScanner && anyRearSensorCovered(status),
+                    cond: (_, { status }) => anyRearSensorCovered(status),
                     target: '#rejecting',
                     actions: [
                       assign({
@@ -490,17 +522,6 @@ function buildMachine({
                           ),
                       }),
                     ],
-                  },
-                  {
-                    cond: (_, { status }) => status.documentInScanner,
-                    target: '#rejected',
-                    actions: assign({
-                      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                      error: (_context) =>
-                        new PrecinctScannerError(
-                          'paper_in_front_after_reconnect'
-                        ),
-                    }),
                   },
                   { target: 'waiting' },
                 ],
@@ -769,7 +790,7 @@ function buildMachine({
               invoke: {
                 src: async ({ client }) =>
                   (await client.connect()).unsafeUnwrap(),
-                onDone: '#waitingForBallot',
+                onDone: '#checkingInitialStatus',
                 onError: {
                   target: '#error',
                   actions: assign({ error: (_, event) => event.data }),
@@ -810,7 +831,7 @@ function buildMachine({
               invoke: {
                 src: async ({ client }) =>
                   (await client.connect()).unsafeUnwrap(),
-                onDone: '#waitingForBallot',
+                onDone: '#checkingInitialStatus',
                 onError: '#unrecoverableError',
               },
             },
@@ -952,6 +973,7 @@ export function createPrecinctScannerStateMachine({
         // us to add new substates to a state without breaking this switch.
         switch (true) {
           case state.matches('connecting'):
+          case state.matches('checkingInitialStatus'):
             return 'connecting';
           case state.matches('disconnected'):
             return 'disconnected';


### PR DESCRIPTION
## Overview

Previously, we would reject a ballot inserted during the accepted state. Instead, we still wait until the accepted state is done, but then scan the next ballot. This is especially important for testing use cases where we want to feed many ballots in a row.

## Demo Video or Screenshot


https://github.com/votingworks/vxsuite/assets/530106/aea505fc-7b45-4eb5-884b-c78aa53bf2e7






## Testing Plan
Manual testing, updated automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
