### PR TITLE
apps/scan: Disable scanning while scanner cover is open

### DIFF
--- a/apps/scan/backend/src/scanners/pdi/pdi_app_scan_cover_open.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_scan_cover_open.test.ts
@@ -36,14 +36,18 @@ test('cover open while waiting for ballots', async () => {
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
       await waitForStatus(apiClient, { state: 'no_paper' });
 
+      mockScanner.client.disableScanning.mockClear();
+      mockScanner.client.enableScanning.mockClear();
       mockScanner.setScannerStatus(mockStatus.coverOpen);
       mockScanner.emitEvent({ event: 'coverOpen' });
       await waitForStatus(apiClient, { state: 'cover_open' });
+      expect(mockScanner.client.disableScanning).toHaveBeenCalled();
 
       mockScanner.setScannerStatus(mockStatus.idleScanningDisabled);
       mockScanner.emitEvent({ event: 'coverClosed' });
       clock.increment(delays.DELAY_SCANNER_STATUS_POLLING_INTERVAL);
       await waitForStatus(apiClient, { state: 'no_paper' });
+      expect(mockScanner.client.enableScanning).toHaveBeenCalled();
     }
   );
 });

--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -746,7 +746,16 @@ function buildMachine({
 
         coverOpen: {
           id: 'coverOpen',
-          invoke: pollScannerStatus,
+          invoke: [
+            // The scanner will try to scan ballots (unsuccessfully) while the
+            // cover is open - we have to explicitly disable scanning.
+            {
+              src: async ({ client }) => {
+                (await client.disableScanning()).unsafeUnwrap();
+              },
+            },
+            pollScannerStatus,
+          ],
           on: {
             SCANNER_STATUS: {
               cond: (_, { status }) => !status.coverOpen,


### PR DESCRIPTION


## Overview

If left to its own devices, the PDI scanner will continue trying to scan ballots while the cover is open. Of course, this doesn't actually work because the rollers can't grab the paper. This might actually be an issue if attempting to clean the scanner while the app is running. So we explicitly disable scanning while the cover is open.
## Demo Video or Screenshot
Skipping because there's not much to see
## Testing Plan
Manual test and automated test
## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
