### PR TITLE
apps/scan: Enable PDI scanner eject pause feature

### DIFF
--- a/libs/pdi-scanner/src/rust/client.rs
+++ b/libs/pdi-scanner/src/rust/client.rs
@@ -90,7 +90,7 @@ impl<T> Client<T> {
             .iter()
             .filter(|packet| !packet.is_event())
             .collect::<Vec<_>>();
-        if unhandled_non_event_packets.len() > 0 {
+        if unhandled_non_event_packets.is_empty() {
             tracing::debug!("clearing unhandled packets: {unhandled_non_event_packets:?}");
             self.unhandled_packets.retain(Incoming::is_event);
         }

--- a/libs/pdi-scanner/src/rust/main.rs
+++ b/libs/pdi-scanner/src/rust/main.rs
@@ -150,6 +150,8 @@ enum Event {
 
     CoverOpen,
     CoverClosed,
+    EjectPaused,
+    EjectResumed,
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -424,6 +426,12 @@ fn main() -> color_eyre::Result<()> {
                         code: ErrorCode::DoubleFeedDetected,
                         message: None,
                     })?;
+                }
+                Ok(Incoming::EjectPauseEvent) => {
+                    send_event(Event::EjectPaused)?;
+                }
+                Ok(Incoming::EjectResumeEvent) => {
+                    send_event(Event::EjectResumed)?;
                 }
                 Ok(event) => {
                     tracing::info!("unhandled event: {event:?}");

--- a/libs/pdi-scanner/src/rust/protocol/packets.rs
+++ b/libs/pdi-scanner/src/rust/protocol/packets.rs
@@ -1087,6 +1087,16 @@ pub enum Incoming {
     /// the same time.
     DoubleFeedEvent,
 
+    // An unsolicited message from the scanner indicating that the scanner has
+    // paused ejecting a document to the rear because the front sensors were
+    // covered (presumably due to another document being inserted).
+    EjectPauseEvent,
+
+    // An unsolicited message from the scanner indicating that the scanner has
+    // resumed ejecting after an EjectPause event since the front sensors are
+    // now clear.
+    EjectResumeEvent,
+
     /// An unsolicited message from the scanner indicating that the scanner has
     /// completed the double-feed detection calibration.
     DoubleFeedCalibrationCompleteEvent,
@@ -1129,6 +1139,8 @@ impl Incoming {
                 | Self::BeginScanEvent
                 | Self::EndScanEvent
                 | Self::DoubleFeedEvent
+                | Self::EjectPauseEvent
+                | Self::EjectResumeEvent
                 | Self::DoubleFeedCalibrationCompleteEvent
                 | Self::DoubleFeedCalibrationTimedOutEvent
         )

--- a/libs/pdi-scanner/src/rust/protocol/parsers.rs
+++ b/libs/pdi-scanner/src/rust/protocol/parsers.rs
@@ -429,6 +429,8 @@ fn any_event(input: &[u8]) -> IResult<&[u8], Incoming> {
             value(Incoming::BeginScanEvent, begin_scan_event),
             value(Incoming::EndScanEvent, end_scan_event),
             value(Incoming::DoubleFeedEvent, double_feed_event),
+            value(Incoming::EjectPauseEvent, eject_pause_event),
+            value(Incoming::EjectResumeEvent, eject_resume_event),
         )),
         alt((
             value(Incoming::CoverOpenEvent, cover_open_event_alternate),
@@ -1253,6 +1255,8 @@ simple_response!(calibration_speed_box_error, b"#1C");
 simple_response!(begin_scan_event, b"#30");
 simple_response!(end_scan_event, b"#31");
 simple_response!(double_feed_event, b"#33");
+simple_response!(eject_pause_event, b"#36");
+simple_response!(eject_resume_event, b"#37");
 
 // undocumented DFD-related events
 simple_response!(double_feed_calibration_complete_event, b"#90");

--- a/libs/pdi-scanner/src/ts/scanner_client.ts
+++ b/libs/pdi-scanner/src/ts/scanner_client.ts
@@ -89,7 +89,9 @@ export type ScannerEvent =
   | { event: 'scanStart' }
   | { event: 'scanComplete'; images: SheetOf<ImageData> }
   | { event: 'coverOpen' }
-  | { event: 'coverClosed' };
+  | { event: 'coverClosed' }
+  | { event: 'ejectPaused' }
+  | { event: 'ejectResumed' };
 
 /**
  * An event listener for any {@link ScannerEvent} emitted by the scanner.
@@ -134,7 +136,9 @@ export type PdictlEvent =
   | { event: 'scanStart' }
   | { event: 'scanComplete'; imageData: [string, string] }
   | { event: 'coverOpen' }
-  | { event: 'coverClosed' };
+  | { event: 'coverClosed' }
+  | { event: 'ejectPaused' }
+  | { event: 'ejectResumed' };
 
 type PdictlMessage = PdictlResponse | PdictlEvent;
 
@@ -227,7 +231,9 @@ export function createPdiScannerClient() {
       }
       case 'error':
       case 'coverOpen':
-      case 'coverClosed': {
+      case 'coverClosed':
+      case 'ejectPaused':
+      case 'ejectResumed': {
         emit(message);
         break;
       }


### PR DESCRIPTION
## Overview

When a ballot is being accepted and a second ballot is inserted, we don't want the second ballot to be mistakenly sucked through the scanner. Though we have guards in place, if there's enough resistance against the first ballot, it's still possible that this can occur.

Luckily, the PDI scanner has an internal "eject pause" feature that is designed to detect a second ballot in the front and pause the ejection. It's more effective than our previous approach since it has lower level control over the motors and can act quicker.

This PR enables the eject pause feature (only for rear ejections - i.e. ballot
accepts) and adds the corresponding events for eject pause/eject resume.

## Demo Video or Screenshot

https://github.com/votingworks/vxsuite/assets/530106/b7a54dc6-d990-40ef-b42e-7b3b5b5ed8fa

Note that in the 4th scan in this video, there's a 2s delay before the "remove your ballot" message pops up. This is the case where the scanner status request times out (detailed in one of the commits). We could potentially change the status request timeout in this context to make this faster, but given that it's an extreme edge case requiring precise timing to reproduce, I opted to let it be slow and keep things simpler.

## Testing Plan
Manual testing, updated automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
