### PR TITLE
Fix env var quirk with VxAdmin-less prod sys admin card script

### DIFF
--- a/libs/auth/README.md
+++ b/libs/auth/README.md
@@ -57,8 +57,8 @@ For production, you can use the following command:
 
 ```
 NODE_ENV=production \
-  VX_PRIVATE_KEY_PATH=/path/to/vx-private-key.pem \
-  ./scripts/configure-java-card
+    VX_PRIVATE_KEY_PATH=/path/to/vx-private-key.pem \
+    ./scripts/configure-java-card
 ```
 
 For development, you can use the following wrapper command, which sets the
@@ -146,7 +146,7 @@ NODE_ENV=production \
 ```
 
 If you want the card to be a universal vendor card granting vendor access to
-machines regardless of their jurisdiction, specify \* for the jurisdiction.
+machines regardless of their jurisdiction, specify `*` for the jurisdiction.
 
 For development, you can use the following wrapper command, which sets the
 relevant env vars for development and then calls the base script:
@@ -190,7 +190,7 @@ The script works not only with VxSuite cards but also with Common Access Cards:
 This script creates a production machine cert signing request, using the
 machine's TPM key, given which the VotingWorks certification terminal will
 create a machine cert. Because the script requires a TPM, it can only be run on
-real hardware.
+production hardware.
 
 ```
 # With the relevant env vars set

--- a/libs/auth/scripts/src/program_production_system_administrator_java_card_without_vx_admin.ts
+++ b/libs/auth/scripts/src/program_production_system_administrator_java_card_without_vx_admin.ts
@@ -81,6 +81,7 @@ export async function main(): Promise<void> {
       );
     await programJavaCard({
       card,
+      isProduction: true,
       user: {
         role: 'system_administrator',
         jurisdiction: scriptEnv.jurisdiction,

--- a/libs/auth/scripts/src/program_system_administrator_java_card.ts
+++ b/libs/auth/scripts/src/program_system_administrator_java_card.ts
@@ -7,16 +7,18 @@ import { DEV_JURISDICTION } from '../../src/jurisdictions';
 import { programJavaCard } from './utils';
 
 interface ScriptEnv {
+  isProduction: boolean;
   javaCardConfig: JavaCardConfig;
   jurisdiction: string;
 }
 
 function readScriptEnvVars(): ScriptEnv {
+  const isProduction = isNodeEnvProduction();
   const javaCardConfig = constructJavaCardConfig(); // Uses env vars
-  const jurisdiction = isNodeEnvProduction()
+  const jurisdiction = isProduction
     ? getRequiredEnvVar('VX_MACHINE_JURISDICTION')
     : DEV_JURISDICTION;
-  return { javaCardConfig, jurisdiction };
+  return { isProduction, javaCardConfig, jurisdiction };
 }
 
 /**
@@ -27,10 +29,11 @@ function readScriptEnvVars(): ScriptEnv {
  */
 export async function main(): Promise<void> {
   try {
-    const { javaCardConfig, jurisdiction } = readScriptEnvVars();
+    const { isProduction, javaCardConfig, jurisdiction } = readScriptEnvVars();
     const card = new JavaCard(javaCardConfig);
     await programJavaCard({
       card,
+      isProduction,
       user: { role: 'system_administrator', jurisdiction },
     });
     process.exit(0); // Smart card scripts require an explicit exit or else they hang

--- a/libs/auth/scripts/src/program_vendor_java_card.ts
+++ b/libs/auth/scripts/src/program_vendor_java_card.ts
@@ -10,16 +10,18 @@ import { DEV_JURISDICTION } from '../../src/jurisdictions';
 import { programJavaCard } from './utils';
 
 interface ScriptEnv {
+  isProduction: boolean;
   javaCardConfig: JavaCardConfig;
   jurisdiction: string;
 }
 
 function readScriptEnvVars(): ScriptEnv {
+  const isProduction = isNodeEnvProduction();
   const javaCardConfig = constructJavaCardConfigForVxProgramming(); // Uses env vars
-  const jurisdiction = isNodeEnvProduction()
+  const jurisdiction = isProduction
     ? getRequiredEnvVar('VX_MACHINE_JURISDICTION')
     : DEV_JURISDICTION;
-  return { javaCardConfig, jurisdiction };
+  return { isProduction, javaCardConfig, jurisdiction };
 }
 
 /**
@@ -28,10 +30,11 @@ function readScriptEnvVars(): ScriptEnv {
  */
 export async function main(): Promise<void> {
   try {
-    const { javaCardConfig, jurisdiction } = readScriptEnvVars();
+    const { isProduction, javaCardConfig, jurisdiction } = readScriptEnvVars();
     const card = new JavaCard(javaCardConfig);
     await programJavaCard({
       card,
+      isProduction,
       user: { role: 'vendor', jurisdiction },
     });
     process.exit(0); // Smart card scripts require an explicit exit or else they hang

--- a/libs/auth/scripts/src/utils.ts
+++ b/libs/auth/scripts/src/utils.ts
@@ -6,7 +6,6 @@ import { generatePin, hyphenatePin } from '@votingworks/utils';
 import { ResponseApduError } from '../../src/apdu';
 import { CardStatusReady, StatefulCard } from '../../src/card';
 import { openssl } from '../../src/cryptography';
-import { isNodeEnvProduction } from '../../src/env_vars';
 import { JavaCard } from '../../src/java_card';
 
 /**
@@ -38,18 +37,20 @@ export async function waitForReadyCardStatus<T>(
 }
 
 /**
- * Programs a system administrator Java Card
+ * Programs a vendor or system administrator Java Card
  */
 export async function programJavaCard({
   card,
+  isProduction,
   user,
 }: {
   card: JavaCard;
+  isProduction: boolean;
   user: VendorUser | SystemAdministratorUser;
 }): Promise<void> {
   const initialJavaCardConfigurationScriptReminder = `
 ${
-  isNodeEnvProduction()
+  isProduction
     ? 'Have you run this card through the configure-java-card script yet?'
     : 'Have you run this card through the configure-dev-java-card script yet?'
 }
@@ -59,7 +60,7 @@ Run that and then retry.
 
   await waitForReadyCardStatus(card);
 
-  const pin = isNodeEnvProduction() ? generatePin() : '000000';
+  const pin = isProduction ? generatePin() : '000000';
   try {
     switch (user.role) {
       case 'vendor': {


### PR DESCRIPTION
## Overview

Right as I merged https://github.com/votingworks/vxsuite/pull/4827, I realized that I'd made a tiny mistake with the `program-production-system-administrator-java-card-without-vxadmin` script. The libs/auth README says that you can use the script as follows:

```
VX_MACHINE_JURISDICTION=<jurisdiction> \
    VX_PRIVATE_KEY_PATH=/path/to/vx-private-key.pem \
    ./scripts/program-production-system-administrator-java-card-without-vx-admin
```

But doing so will yield the error:

```
❌ Missing required NODE_ENV env var
```

This PR makes it such that the README is once again correct (by updating the script, not the README).

## Testing Plan

- [x] Tested relevant libs/auth scripts manually