### PR TITLE
[mark-scan] Handle status transmission command

### DIFF
--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -845,13 +845,15 @@ function setUpLogging(
     .onEvent(async (event) => {
       // To protect voter privacy, we only log the event type (since some event
       // objects include ballot interpretations)
-      await logger.log(
-        LogEventId.MarkScanStateMachineEvent,
-        'system',
-        { message: `Event: ${event.type}` },
-        /* istanbul ignore next */
-        (logLine: LogLine) => debugEvents(logLine.message)
-      );
+      if (event.type !== 'PAT_DEVICE_NO_STATUS_CHANGE') {
+        await logger.log(
+          LogEventId.MarkScanStateMachineEvent,
+          'system',
+          { message: `Event: ${event.type}` },
+          /* istanbul ignore next */
+          (logLine: LogLine) => debugEvents(logLine.message)
+        );
+      }
     })
     .onChange(async (context, previousContext) => {
       if (!previousContext) return;

--- a/libs/custom-paper-handler/src/driver/coders.ts
+++ b/libs/custom-paper-handler/src/driver/coders.ts
@@ -84,12 +84,7 @@ export type SensorStatusRealTimeExchangeResponse = CoderType<
   typeof SensorStatusRealTimeExchangeResponse
 >;
 
-export const PrinterStatusRealTimeExchangeResponse = message({
-  startOfPacket: literal(0x82),
-  requestId: uint8(),
-  token: literal(TOKEN),
-  returnCode: uint8(),
-  optionalDataLength: literal(6),
+const printerStatusMessage = {
   // Byte 0 fixed
   dle: literal(0x10),
   // Byte 1 fixed
@@ -121,6 +116,15 @@ export const PrinterStatusRealTimeExchangeResponse = message({
   eepromError: uint1(),
   ramError: uint1(),
   byte3Padding1: padding(2),
+} as const;
+
+export const PrinterStatusRealTimeExchangeResponse = message({
+  startOfPacket: literal(0x82),
+  requestId: uint8(),
+  token: literal(TOKEN),
+  returnCode: uint8(),
+  optionalDataLength: literal(6),
+  ...printerStatusMessage,
 });
 export type PrinterStatusRealTimeExchangeResponse = CoderType<
   typeof PrinterStatusRealTimeExchangeResponse
@@ -137,37 +141,7 @@ export type RealTimeExchangeResponseWithoutData = CoderType<
   typeof RealTimeExchangeResponseWithoutData
 >;
 
-export const RealTimeStatusTransmission = message({
-  // Bytes 1 and 2 response signature
-  startOfPacket: literal(0x10, 0x0f),
-  // Byte 3 paper status
-  reserved1: padding(2),
-  ticketPresentInOutput: uint1(),
-  reserved2: padding(4),
-  paperPresent: uint1(),
-  // Byte 4 user status
-  reserved3: padding(4),
-  coverOpened: uint1(),
-  spooling: uint1(),
-  dragPaperMotorOn: uint1(),
-  printingHeadUpError: uint1(),
-  // Byte 5 recoverable error status
-  reserved4: padding(2),
-  notAcknowledgeCommandError: uint1(),
-  reserved5: padding(1),
-  powerSupplyVoltageError: uint1(),
-  headNotConnected: uint1(),
-  comError: uint1(),
-  headTemperatureError: uint1(),
-  // Byte 6 unrecoverable error status
-  diverterError: uint1(),
-  headErrorLocked: uint1(),
-  printingHeadReadyToPrint: uint1(),
-  byte3Padding0: padding(1),
-  eepromError: uint1(),
-  ramError: uint1(),
-  reserved6: padding(2),
-});
+export const RealTimeStatusTransmission = message(printerStatusMessage);
 export type RealTimeStatusTransmission = CoderType<
   typeof RealTimeStatusTransmission
 >;

--- a/libs/custom-paper-handler/src/driver/coders.ts
+++ b/libs/custom-paper-handler/src/driver/coders.ts
@@ -137,6 +137,41 @@ export type RealTimeExchangeResponseWithoutData = CoderType<
   typeof RealTimeExchangeResponseWithoutData
 >;
 
+export const RealTimeStatusTransmission = message({
+  // Bytes 1 and 2 response signature
+  startOfPacket: literal(0x10, 0x0f),
+  // Byte 3 paper status
+  reserved1: padding(2),
+  ticketPresentInOutput: uint1(),
+  reserved2: padding(4),
+  paperPresent: uint1(),
+  // Byte 4 user status
+  reserved3: padding(4),
+  coverOpened: uint1(),
+  spooling: uint1(),
+  dragPaperMotorOn: uint1(),
+  printingHeadUpError: uint1(),
+  // Byte 5 recoverable error status
+  reserved4: padding(2),
+  notAcknowledgeCommandError: uint1(),
+  reserved5: padding(1),
+  powerSupplyVoltageError: uint1(),
+  headNotConnected: uint1(),
+  comError: uint1(),
+  headTemperatureError: uint1(),
+  // Byte 6 unrecoverable error status
+  diverterError: uint1(),
+  headErrorLocked: uint1(),
+  printingHeadReadyToPrint: uint1(),
+  byte3Padding0: padding(1),
+  eepromError: uint1(),
+  ramError: uint1(),
+  reserved6: padding(2),
+});
+export type RealTimeStatusTransmission = CoderType<
+  typeof RealTimeStatusTransmission
+>;
+
 export const AcknowledgementResponse = uint8();
 export type AcknowledgementResponse = CoderType<typeof AcknowledgementResponse>;
 

--- a/libs/custom-paper-handler/src/driver/driver.ts
+++ b/libs/custom-paper-handler/src/driver/driver.ts
@@ -11,6 +11,7 @@ import {
   CoderError,
   literal,
   message,
+  oneOf,
 } from '@votingworks/message-coder';
 import { createImageData, writeImageData } from '@votingworks/image-utils';
 import {
@@ -76,6 +77,7 @@ import {
   PrintAndFeedPaperCommand,
   PrinterStatusRealTimeExchangeResponse,
   RealTimeExchangeResponseWithoutData,
+  RealTimeStatusTransmission,
   ScanCommand,
   ScannerCalibrationCommand,
   ScanResponse,
@@ -115,6 +117,10 @@ export const PACKET_SIZE = 65536;
 export enum ReturnCodes {
   POSITIVE_ACKNOWLEDGEMENT = 0x06,
   NEGATIVE_ACKNOWLEDGEMENT = 0x15,
+  // Return code when the `Real-time status transmission` command is invoked
+  // when buffered data coincidentally contains a byte sequence matching
+  // that command's hex code
+  INVALID_STATUS_TRANSMISSION_ARGUMENT = 0x12,
 }
 
 export async function getPaperHandlerWebDevice(): Promise<
@@ -369,27 +375,65 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
     const transferOutResult = await this.transferOutGeneric(coder, value);
     assert(transferOutResult.status === 'ok'); // TODO: Handling
 
+    return this.transferInAcknowledgement();
+  }
+
+  async transferInAcknowledgement(): Promise<boolean> {
     const transferInResult = await this.transferInGeneric();
     assert(transferInResult.status === 'ok'); // TODO: Handling
     this.genericLock.release();
     const { data } = transferInResult;
     assert(data);
-    const result = AcknowledgementResponse.decode(Buffer.from(data.buffer));
+
+    // If data buffered to the `generic transfer-out buffer` contains the command code
+    // for `Real-time status transmission` (0x10 0x04 n), that command will be executed.
+    // It is executed regardless of whether the buffered data is received as part of a
+    // different command and ignores convention that `Real-time status transmission` is
+    // expected to use the real-time channels.
+    //
+    // eg. `bufferChunk()` uses `Select image print mode` to buffer PDF data to the
+    // generic out buffer. If the PDF data contains the byte sequence `0x10 0x04 0x12`,
+    // the device will execute `Real-time status transmission` and return a 6 byte response
+    // on the generic transfer-in buffer.
+    //
+    // If the PDF data contains byte sequence `0x10 0x04 0x03`, where 0x03 is an invalid
+    // argument for `Real-time status transmission`, the printer will return 1 byte 0x12
+    // on the generic transfer-in buffer. 0x12 is an undocumented response code but
+    // presumably means "Invalid argument" or similar.
+
+    const TransferInData = oneOf(
+      RealTimeStatusTransmission,
+      AcknowledgementResponse
+    );
+    const result = TransferInData.decode(Buffer.from(data.buffer));
     if (result.isErr()) {
       debug(`Error decoding transferInGeneric response: ${result.err()}`);
       return false;
     }
+
     const code = result.ok();
-    switch (code) {
-      case ReturnCodes.POSITIVE_ACKNOWLEDGEMENT:
-        debug('positive acknowledgement');
-        return true;
-      case ReturnCodes.NEGATIVE_ACKNOWLEDGEMENT:
-        debug('negative acknowledgement');
-        return false;
-      default:
-        throw new Error(`uninterpretable acknowledgement: ${code}`);
+    if (typeof code === 'number') {
+      switch (code) {
+        case ReturnCodes.POSITIVE_ACKNOWLEDGEMENT:
+          debug('positive acknowledgement');
+          return true;
+        case ReturnCodes.NEGATIVE_ACKNOWLEDGEMENT:
+          debug('negative acknowledgement');
+          return false;
+        case ReturnCodes.INVALID_STATUS_TRANSMISSION_ARGUMENT:
+          debug(
+            'Handled unrestricted malformed execution of "Real-time status transmission" command. Retrying transferInAcknowledgement.'
+          );
+          return this.transferInAcknowledgement();
+        default:
+          throw new Error(`Uninterpretable acknowledgement code: ${code}`);
+      }
     }
+
+    debug(
+      'Handled unrestricted execution of "Real-time status transmission" command. Retrying transferInAcknowledgement.'
+    );
+    return this.transferInAcknowledgement();
   }
 
   async getScannerCapability(): Promise<ScannerCapability> {
@@ -505,6 +549,7 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
   }
 
   async scanAndSave(pathOut: string): Promise<ImageFromScanner> {
+    debug('setting scan direction');
     await this.setScanDirection('backward');
     const grayscaleResult = await this.scan();
     debug(
@@ -547,6 +592,7 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
    * attempt to pull paper in. if none is pulled in, command still returns positive.
    */
   async loadPaper(): Promise<boolean> {
+    debug('loadPaper');
     return this.handleGenericCommandWithAcknowledgement(
       LoadPaperCommand,
       undefined
@@ -558,6 +604,7 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
    * no paper to eject, handler will do nothing and return positive acknowledgement.
    */
   async ejectPaperToFront(): Promise<boolean> {
+    debug('ejectPaperToFront');
     return this.handleGenericCommandWithAcknowledgement(
       EjectPaperCommand,
       undefined
@@ -570,6 +617,7 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
    * positive acknowledgement. When parked, parkSensor should be true.
    */
   async parkPaper(): Promise<boolean> {
+    debug('parkPaper');
     return this.handleGenericCommandWithAcknowledgement(
       ParkPaperCommand,
       undefined
@@ -582,6 +630,7 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
    * state from the state where paper has not been picked up yet?
    */
   presentPaper(): Promise<boolean> {
+    debug('presentPaper');
     return this.handleGenericCommandWithAcknowledgement(
       PresentPaperAndHoldCommand,
       undefined
@@ -593,6 +642,7 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
    * no paper to eject, handler will do nothing and return positive acknowledgement.
    */
   async ejectBallotToRear(): Promise<boolean> {
+    debug('ejectBallotToRear');
     return this.handleGenericCommandWithAcknowledgement(
       EjectPaperToBallotCommand,
       undefined
@@ -600,6 +650,7 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
   }
 
   calibrate(): Promise<boolean> {
+    debug('calibrate');
     return this.handleGenericCommandWithAcknowledgement(
       ScannerCalibrationCommand,
       undefined
@@ -614,6 +665,7 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
    * a variety of positions.
    */
   enablePrint(): Promise<boolean> {
+    debug('enablePrint');
     return this.handleGenericCommandWithAcknowledgement(
       EnablePrintCommand,
       undefined
@@ -624,6 +676,7 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
    * Moves print head to UP position, does not move paper
    */
   disablePrint(): Promise<boolean> {
+    debug('disablePrint');
     return this.handleGenericCommandWithAcknowledgement(
       DisablePrintCommand,
       undefined

--- a/libs/custom-paper-handler/src/driver/driver.ts
+++ b/libs/custom-paper-handler/src/driver/driver.ts
@@ -375,13 +375,14 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
     const transferOutResult = await this.transferOutGeneric(coder, value);
     assert(transferOutResult.status === 'ok'); // TODO: Handling
 
-    return this.transferInAcknowledgement();
+    const isAckSuccessful = this.transferInAcknowledgement();
+    this.genericLock.release();
+    return isAckSuccessful;
   }
 
   async transferInAcknowledgement(): Promise<boolean> {
     const transferInResult = await this.transferInGeneric();
     assert(transferInResult.status === 'ok'); // TODO: Handling
-    this.genericLock.release();
     const { data } = transferInResult;
     assert(data);
 

--- a/libs/custom-paper-handler/src/driver/driver_interface.ts
+++ b/libs/custom-paper-handler/src/driver/driver_interface.ts
@@ -34,6 +34,7 @@ export interface PaperHandlerDriverInterface {
   disconnect(): Promise<void>;
   getWebDevice(): MinimalWebUsbDevice;
   transferInGeneric(): Promise<USBInTransferResult>;
+  transferInAcknowledgement(): Promise<boolean>;
   clearGenericInBuffer(): Promise<void>;
   transferOutRealTime(requestId: Uint8): Promise<USBOutTransferResult>;
   transferInRealTime(): Promise<USBInTransferResult>;

--- a/libs/custom-paper-handler/src/driver/mock_driver.ts
+++ b/libs/custom-paper-handler/src/driver/mock_driver.ts
@@ -63,6 +63,9 @@ export class MockPaperHandlerDriver implements PaperHandlerDriverInterface {
   transferInGeneric(): Promise<USBInTransferResult> {
     throw new Error('Method not implemented.');
   }
+  transferInAcknowledgement(): Promise<boolean> {
+    throw new Error('Method not implemented.');
+  }
   clearGenericInBuffer(): Promise<void> {
     throw new Error('Method not implemented.');
   }


### PR DESCRIPTION
## Overview
Buffering print data (or any data) to the generic transfer-out buffer may invoke the `real-time status transmission` command if the buffered data contains a byte sequence matching that command (`0x10 0x04`). This causes unsolicited data to be passed to the generic transfer-in buffer, which breaks parsing the next time the driver issues a command that responds over the generic transfer-in buffer.

See comment here: https://github.com/votingworks/vxsuite/pull/4846/files#diff-6d4416eebc285362e1f02d2f6252d35972e5c0db67a2db365540cb87a2bea431R388 and [Slack](https://votingworks.slack.com/archives/C03Q42V9MJ5/p1715296095534459) for more.

## Demo Video or Screenshot

Successful print of ballot with problematic byte sequence

https://github.com/votingworks/vxsuite/assets/1060688/7a52b519-e07a-4bba-b86c-ecf444566709



## Testing Plan

- added tests
- manually verified ballot with problematic byte sequence can be printed

## Checklist

- [ ] (N/A) I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
