### PR TITLE
[BMD] Update screen reader volume level, based on calibration

### DIFF
--- a/libs/ui/src/ui_strings/audio_volume.ts
+++ b/libs/ui/src/ui_strings/audio_volume.ts
@@ -44,10 +44,13 @@ export enum AudioVolume {
  * in roughly an output level of {@link MIN_VOLUME_DB_SPL} when the OS volume is
  * set to its maximum output level.
  *
- * TODO(kofi): Re-calibrate this value on prod hardware once we've settled on a
- * model of headphones.
+ * Last Calibration: 2024-05-14 on VSAP with JLAB Studio On-Ear Headphones.
+ *
+ * TODO: Might be worth defining different offsets for different machines
+ * (VxMark vs VxMarkScan), since audio hardware and output levels will likely
+ * differ between the two.
  */
-const GOOGLE_CLOUD_TTS_GAIN_OFFSET_FOR_MIN_VOLUME = -80;
+const GOOGLE_CLOUD_TTS_GAIN_OFFSET_FOR_MIN_VOLUME = -68;
 
 export function getAudioGainAmountDb(volume: AudioVolume): number {
   // eslint-disable-next-line vx/gts-safe-number-parse


### PR DESCRIPTION
## Overview

Updating the volume offset for screen reader audio based on calibration on VSAP hardware with our [chosen set of headphones](https://www.jlab.com/products/studio-on-ear-headphones?variant=28207115731016&currency=USD&utm_medium=product_sync&utm_source=google&utm_content=sag_organic&utm_campaign=sag_organic&srsltid=AfmBOopcrsnM5iD6c6jpM_MCXk_V30ljmh1hGxGpMNhuNX4wFOUlyARQb4c).

Based on rough measurements, applying a gain of `-68 dB` to audio from Google Cloud TTS when OS volume is set to `100%` results in a real-world output level between `63 dB SPL` and `67 dB SPL`, which falls within the VVSG 2.0 range of `60-70 dB SPL` (VVSG 2.0 7.1-K – Audio settings).

Our volume increments result in jumps of between `5 dB SPL` and `8 dB SPL`, which puts them under the `10 dB` VVSG limit.

## Testing Plan
- Highly scientific test with an SPL meter on VSAP hardware with the JLAB studio headphones
- <img width="350" src="https://github.com/votingworks/vxsuite/assets/264902/954aa43e-5c13-4403-8d9d-fb3b50c761b3" />

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
