### PR TITLE
[BMD] Reset scroll state on contest navigation

### DIFF
--- a/libs/mark-flow-ui/src/pages/contest_page.tsx
+++ b/libs/mark-flow-ui/src/pages/contest_page.tsx
@@ -176,6 +176,7 @@ export function ContestPage(props: ContestPageProps): JSX.Element {
       }
     >
       <Contest
+        key={contest.id} // Force a re-mount for every contest to reset scroll state.
         election={electionDefinition.election}
         breadcrumbs={breadcrumbsMetadata}
         contest={contest}


### PR DESCRIPTION
## Overview

Forcing a component re-mount every time we render a new contest page to make sure the scroll state is reset when navigating between contests.

## Demo Video or Screenshot

### Before:

https://github.com/votingworks/vxsuite/assets/264902/74c9a636-01c0-45d0-b5bc-b3c7704fa355

### After:

https://github.com/votingworks/vxsuite/assets/264902/cdc18133-c31e-401b-80e9-b0f37ca702d4


## Testing Plan
- Manual

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
