### PR TITLE
transition from eject_to_front when paper is in input

### DIFF
--- a/apps/mark-scan/backend/src/custom-paper-handler/scanner_status.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/scanner_status.ts
@@ -28,7 +28,7 @@ export function isPaperInScanner(
   );
 }
 
-export function isPaperInInput(
+export function isPaperPartiallyInInput(
   paperHandlerStatus: PaperHandlerStatus
 ): boolean {
   return (
@@ -53,7 +53,7 @@ export function isPaperAnywhere(
   paperHandlerStatus: PaperHandlerStatus
 ): boolean {
   return (
-    isPaperInInput(paperHandlerStatus) ||
+    isPaperPartiallyInInput(paperHandlerStatus) ||
     isPaperInOutput(paperHandlerStatus) ||
     isPaperInScanner(paperHandlerStatus)
   );

--- a/apps/mark-scan/backend/src/custom-paper-handler/scanner_status.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/scanner_status.ts
@@ -28,7 +28,7 @@ export function isPaperInScanner(
   );
 }
 
-export function isPaperPartiallyInInput(
+export function isPaperInInput(
   paperHandlerStatus: PaperHandlerStatus
 ): boolean {
   return (
@@ -53,7 +53,7 @@ export function isPaperAnywhere(
   paperHandlerStatus: PaperHandlerStatus
 ): boolean {
   return (
-    isPaperPartiallyInInput(paperHandlerStatus) ||
+    isPaperInInput(paperHandlerStatus) ||
     isPaperInOutput(paperHandlerStatus) ||
     isPaperInScanner(paperHandlerStatus)
   );

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -249,6 +249,25 @@ describe('not_accepting_paper', () => {
   });
 });
 
+describe('eject_to_front', () => {
+  test.each([
+    {
+      description: 'paper is absent',
+      setStatus: () => setMockDeviceStatus(getDefaultPaperHandlerStatus()),
+    },
+    {
+      description: 'paper is in front input',
+      setStatus: () => setMockDeviceStatus(getPaperInFrontStatus()),
+    },
+  ])('transitions when $description', async ({ setStatus }) => {
+    expect(machine.getSimpleStatus()).toEqual('not_accepting_paper');
+    setMockDeviceStatus(getPaperParkedStatus());
+    await expectStatusTransitionTo('ejecting_to_front');
+    setStatus();
+    await expectStatusTransitionTo('not_accepting_paper');
+  });
+});
+
 describe('accepting_paper', () => {
   it('transitions to loading_paper state when front sensors are triggered', async () => {
     machine.setAcceptingPaper();

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -256,9 +256,22 @@ describe('eject_to_front', () => {
       setStatus: () => setMockDeviceStatus(getDefaultPaperHandlerStatus()),
     },
     {
-      description: 'paper is in front input',
+      description: 'paper triggers all front sensors',
       setStatus: () => setMockDeviceStatus(getPaperInFrontStatus()),
     },
+    ...[
+      'paperInputLeftInnerSensor',
+      'paperInputLeftOuterSensor',
+      'paperInputRightInnerSensor',
+      'paperInputRightOuterSensor',
+    ].map((sensor) => ({
+      description: `paper triggers only ${sensor} sensor`,
+      setStatus: () =>
+        setMockDeviceStatus({
+          ...getDefaultPaperHandlerStatus(),
+          [sensor]: true,
+        }),
+    })),
   ])('transitions when $description', async ({ setStatus }) => {
     expect(machine.getSimpleStatus()).toEqual('not_accepting_paper');
     setMockDeviceStatus(getPaperParkedStatus());

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -53,7 +53,7 @@ import {
   isPaperInOutput,
   isPaperAnywhere,
   isPaperJammed,
-  isPaperInInput,
+  isPaperPartiallyInInput,
 } from './scanner_status';
 import {
   scanAndSave,
@@ -167,7 +167,7 @@ export function paperHandlerStatusToEvent(
   }
 
   /* istanbul ignore next */
-  if (isPaperInInput(paperHandlerStatus)) {
+  if (isPaperPartiallyInInput(paperHandlerStatus)) {
     return { type: 'PAPER_IN_INPUT' };
   }
 
@@ -705,6 +705,11 @@ export function buildMachine(
               entry: ['ejectPaperToFront'],
               on: {
                 NO_PAPER_ANYWHERE: 'resetting_state_machine_after_success',
+                // Sometimes paper ejected to front is not held by the motors but
+                // will still trigger input sensors.
+                // In this case we still want to allow the machine to progress.
+                PAPER_READY_TO_LOAD: 'resetting_state_machine_after_success',
+                PAPER_IN_INPUT: 'resetting_state_machine_after_success',
               },
             },
             jammed: {

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -53,7 +53,7 @@ import {
   isPaperInOutput,
   isPaperAnywhere,
   isPaperJammed,
-  isPaperPartiallyInInput,
+  isPaperInInput,
 } from './scanner_status';
 import {
   scanAndSave,
@@ -167,7 +167,7 @@ export function paperHandlerStatusToEvent(
   }
 
   /* istanbul ignore next */
-  if (isPaperPartiallyInInput(paperHandlerStatus)) {
+  if (isPaperInInput(paperHandlerStatus)) {
     return { type: 'PAPER_IN_INPUT' };
   }
 


### PR DESCRIPTION
## Overview
Fixes an issue where ejecting to front may sometimes result in the paper being held in the front by friction with the paper tray. In this case, the input sensors are tripped and the state machine gets stuck in `eject_to_front` state because we currently only check for complete absence of paper. 

This PR adds transitions for when paper triggers some or all input sensors, allowing the state machine to exit `eject_to_front` state.


## Demo Video or Screenshot

Note in these videos I have to manually stop the paper because the paper tray of the dev unit has less friction than the paper tray of the prod unit. On the dev unit, the paper will slide all the way out of the input and avoid tripping input sensors.

Before: when paper trips input sensors, state machine is stuck in `ejecting_to_front` state.


https://github.com/votingworks/vxsuite/assets/1060688/da1b4036-7540-41ab-b3c5-36ff84b205b7

After: when paper trips input sensors but not internal sensors, state machine transitions to reset the session and then back to initial `not_accepting_paper` state. 

https://github.com/votingworks/vxsuite/assets/1060688/be1f9eb9-8ef6-4c64-b8e1-7a467851c887

## Testing Plan
- added test for state transition
- tested manually

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.