### PR TITLE
Rebrand Live Check --> (Signed) Hash Validation and add Hash Validation button to VxMarkScan

### DIFF
--- a/apps/admin/frontend/src/components/live_check_button.tsx
+++ b/apps/admin/frontend/src/components/live_check_button.tsx
@@ -37,7 +37,7 @@ export function LiveCheckButton(): JSX.Element {
 
   return (
     <React.Fragment>
-      <Button onPress={openLiveCheckModal}>Live Check</Button>
+      <Button onPress={openLiveCheckModal}>Hash Validation</Button>
       {isLiveCheckModalOpen && <LiveCheckModal onClose={closeLiveCheckModal} />}
     </React.Fragment>
   );

--- a/apps/admin/frontend/src/screens/settings_screen.tsx
+++ b/apps/admin/frontend/src/screens/settings_screen.tsx
@@ -46,7 +46,7 @@ export function SettingsScreen(): JSX.Element {
       )}
       {isFeatureFlagEnabled(BooleanEnvironmentVariableName.LIVECHECK) && (
         <React.Fragment>
-          <H2>Live Check</H2>
+          <H2>Hash Validation</H2>
           <P>
             <LiveCheckButton />
           </P>

--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -1,5 +1,5 @@
 import express, { Application } from 'express';
-import { InsertedSmartCardAuthApi } from '@votingworks/auth';
+import { InsertedSmartCardAuthApi, LiveCheck } from '@votingworks/auth';
 import { assert, ok, Result, throwIllegalValue } from '@votingworks/basics';
 import * as grout from '@votingworks/grout';
 import {
@@ -376,6 +376,16 @@ export function buildApi(
         workspace,
         usbDrive,
         logger,
+      });
+    },
+
+    /* istanbul ignore next */
+    generateLiveCheckQrCodeValue() {
+      const { machineId } = getMachineConfig();
+      const electionDefinition = workspace.store.getElectionDefinition();
+      return new LiveCheck().generateQrCodeValue({
+        machineId,
+        electionHash: electionDefinition?.electionHash,
       });
     },
   });

--- a/apps/mark-scan/frontend/src/api.ts
+++ b/apps/mark-scan/frontend/src/api.ts
@@ -486,4 +486,19 @@ export const isPatDeviceConnected = {
   },
 } as const;
 
+/* istanbul ignore next */
+export const generateLiveCheckQrCodeValue = {
+  queryKey(): QueryKey {
+    return ['generateLiveCheckQrCodeValue'];
+  },
+  useQuery() {
+    const apiClient = useApiClient();
+    return useQuery(
+      this.queryKey(),
+      () => apiClient.generateLiveCheckQrCodeValue(),
+      { cacheTime: 0 } // Always generate a fresh QR code value
+    );
+  },
+} as const;
+
 export const systemCallApi = createSystemCallApi(useApiClient);

--- a/apps/mark-scan/frontend/src/components/live_check_button.tsx
+++ b/apps/mark-scan/frontend/src/components/live_check_button.tsx
@@ -1,0 +1,45 @@
+/* istanbul ignore file */
+import React, { useState } from 'react';
+import { Button, LiveCheckModal as LiveCheckModalBase } from '@votingworks/ui';
+
+import { generateLiveCheckQrCodeValue } from '../api';
+
+interface LiveCheckModalProps {
+  onClose: () => void;
+}
+
+function LiveCheckModal({ onClose }: LiveCheckModalProps): JSX.Element | null {
+  const liveCheckQrCodeValueQuery = generateLiveCheckQrCodeValue.useQuery();
+
+  if (!liveCheckQrCodeValueQuery.isSuccess) {
+    return null;
+  }
+  const { qrCodeValue, signatureInputs } = liveCheckQrCodeValueQuery.data;
+
+  return (
+    <LiveCheckModalBase
+      onClose={onClose}
+      qrCodeValue={qrCodeValue}
+      signatureInputs={signatureInputs}
+    />
+  );
+}
+
+export function LiveCheckButton(): JSX.Element {
+  const [isLiveCheckModalOpen, setIsLiveCheckModalOpen] = useState(false);
+
+  function openLiveCheckModal() {
+    return setIsLiveCheckModalOpen(true);
+  }
+
+  function closeLiveCheckModal() {
+    return setIsLiveCheckModalOpen(false);
+  }
+
+  return (
+    <React.Fragment>
+      <Button onPress={openLiveCheckModal}>Hash Validation</Button>
+      {isLiveCheckModalOpen && <LiveCheckModal onClose={closeLiveCheckModal} />}
+    </React.Fragment>
+  );
+}

--- a/apps/mark-scan/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/admin_screen.tsx
@@ -25,11 +25,16 @@ import {
 import type { MachineConfig } from '@votingworks/mark-scan-backend';
 import type { UsbDriveStatus } from '@votingworks/usb-drive';
 import {
+  BooleanEnvironmentVariableName,
+  isFeatureFlagEnabled,
+} from '@votingworks/utils';
+import {
   ejectUsbDrive,
   logOut,
   setPrecinctSelection,
   setTestMode,
 } from '../api';
+import { LiveCheckButton } from '../components/live_check_button';
 
 export interface AdminScreenProps {
   appPrecinct?: PrecinctSelection;
@@ -145,17 +150,29 @@ export function AdminScreen({
         <P>
           <Icons.Checkbox color="success" /> Election Definition is loaded.
         </P>
-        <UnconfigureMachineButton
-          isMachineConfigured
-          unconfigureMachine={unconfigure}
-        />
+        <P>
+          <UnconfigureMachineButton
+            isMachineConfigured
+            unconfigureMachine={unconfigure}
+          />
+        </P>
         <H6 as="h2">USB</H6>
-        <UsbControllerButton
-          primary
-          usbDriveStatus={usbDriveStatus}
-          usbDriveEject={() => ejectUsbDriveMutation.mutate()}
-          usbDriveIsEjecting={ejectUsbDriveMutation.isLoading}
-        />
+        <P>
+          <UsbControllerButton
+            primary
+            usbDriveStatus={usbDriveStatus}
+            usbDriveEject={() => ejectUsbDriveMutation.mutate()}
+            usbDriveIsEjecting={ejectUsbDriveMutation.isLoading}
+          />
+        </P>
+        {isFeatureFlagEnabled(BooleanEnvironmentVariableName.LIVECHECK) && (
+          /* istanbul ignore next */ <React.Fragment>
+            <H6 as="h2">Security</H6>
+            <P>
+              <LiveCheckButton />
+            </P>
+          </React.Fragment>
+        )}
       </Main>
       {election && (
         <ElectionInfoBar

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
@@ -55,6 +55,7 @@ import {
 } from '../api';
 import { PaperHandlerHardwareCheckDisabledScreen } from './paper_handler_hardware_check_disabled_screen';
 import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { LiveCheckButton } from '../components/live_check_button';
 
 const VotingSession = styled.div`
   margin: 30px 0 60px;
@@ -423,6 +424,13 @@ export function PollWorkerScreen({
                   }
                 )}
               </P>
+              {isFeatureFlagEnabled(
+                BooleanEnvironmentVariableName.LIVECHECK
+              ) && (
+                /* istanbul ignore next */ <P>
+                  <LiveCheckButton />
+                </P>
+              )}
             </React.Fragment>
           )}
         </Prose>

--- a/apps/scan/frontend/src/components/live_check_button.tsx
+++ b/apps/scan/frontend/src/components/live_check_button.tsx
@@ -37,7 +37,7 @@ export function LiveCheckButton(): JSX.Element {
 
   return (
     <React.Fragment>
-      <Button onPress={openLiveCheckModal}>Live Check</Button>
+      <Button onPress={openLiveCheckModal}>Hash Validation</Button>
       {isLiveCheckModalOpen && <LiveCheckModal onClose={closeLiveCheckModal} />}
     </React.Fragment>
   );

--- a/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
@@ -79,10 +79,10 @@ describe('shows Livecheck button only when enabled', () => {
     });
 
     userEvent.click(await screen.findByText('No'));
-    expect(screen.queryByText('Live Check')).toBeTruthy();
+    expect(screen.queryByText('Hash Validation')).toBeTruthy();
 
     apiMock.expectGenerateLiveCheckQrCodeValue();
-    userEvent.click(screen.getByText('Live Check'));
+    userEvent.click(screen.getByText('Hash Validation'));
     await screen.findByText('Done');
   });
 
@@ -97,7 +97,7 @@ describe('shows Livecheck button only when enabled', () => {
     });
 
     userEvent.click(await screen.findByText('No'));
-    expect(screen.queryByText('Live Check')).toBeFalsy();
+    expect(screen.queryByText('Hash Validation')).toBeFalsy();
   });
 });
 

--- a/libs/ui/src/live_check_modal.tsx
+++ b/libs/ui/src/live_check_modal.tsx
@@ -38,7 +38,7 @@ export function LiveCheckModal({
 }: Props): JSX.Element | null {
   return (
     <Modal
-      title="Live Check"
+      title="Hash Validation"
       content={
         <React.Fragment>
           <P>Scan this QR code at https://check.voting.works</P>


### PR DESCRIPTION
## Overview

This PR rebrands Live Check ➡️ (Signed) Hash Validation and adds a Hash Validation button to VxMarkScan.

Note that I prepped this very quickly, adding istanbul ignores and only updating user-facing references to Live Check. Variable names and comments still refer to the feature as Live Check and not (Signed) Hash Validation. In a time crunch for the upcoming demo, but will be revisiting all this code soon when I complete the implementation of Signed Hash Validation.

## Demo Video or Screenshot

### Election Manager UI

https://github.com/votingworks/vxsuite/assets/12616928/3dd7f110-7f06-4cc4-94da-81b34248d471

### Poll Worker UI

_While polls are open_

https://github.com/votingworks/vxsuite/assets/12616928/6c762830-821c-4f35-91dd-426166d256cd

_Before polls open / After polls close_

<img width="300" alt="pw-before-polls-open" src="https://github.com/votingworks/vxsuite/assets/12616928/3830b2cf-ae0e-4d5f-b3a6-6c555a899c0a"> <img width="300" alt="pw-after-polls-close" src="https://github.com/votingworks/vxsuite/assets/12616928/fb224ec7-6263-4b99-a60d-18aed5f038b0">

## Testing Plan

- [x] Tested manually in dev
- [ ] Will test manually on a prod-imaged VxMarkScan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced ➡️ Will be handling in a future PR for all instances of Signed Hash Validation
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates