### PR TITLE
apps/scan: Only listen for scanner events at root

### DIFF
--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -232,7 +232,7 @@ function buildMachine({
   // To ensure we catch scanner events no matter what state the machine is in,
   // we spawn a long-lived actor that is referenced in the context (rather than
   // invoking it in a specific state).
-  const listenForScannerEventsAtRoot = assign({
+  const listenForScannerEventsAtRoot = assign<Context>({
     rootListenerRef: ({ client }) =>
       spawn((callback) => {
         const listener = client.addListener((event) => {

--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -12,7 +12,6 @@ import {
   BaseActionObject,
   Interpreter,
   InvokeConfig,
-  Sender,
   StateNodeConfig,
   assign,
   createMachine,
@@ -230,36 +229,22 @@ function buildMachine({
     data: (context) => ({ client: context.client }),
   };
 
-  function addEventListener(client: ScannerClient, callback: Sender<Event>) {
-    return client.addListener((event) => {
-      callback(
-        event.event === 'error'
-          ? { type: 'SCANNER_ERROR', error: event }
-          : { type: 'SCANNER_EVENT', event }
-      );
-    });
-  }
-
   // To ensure we catch scanner events no matter what state the machine is in,
   // we spawn a long-lived actor that is referenced in the context (rather than
-  // invoking it in a specific state). These events will be caught in the root
-  // `on` handlers.
+  // invoking it in a specific state).
   const listenForScannerEventsAtRoot = assign({
     rootListenerRef: ({ client }) =>
       spawn((callback) => {
-        const listener = addEventListener(client, callback);
+        const listener = client.addListener((event) => {
+          callback(
+            event.event === 'error'
+              ? { type: 'SCANNER_ERROR', error: event }
+              : { type: 'SCANNER_EVENT', event }
+          );
+        });
         return () => client.removeListener(listener);
       }),
   });
-
-  const listenForScannerEvents: InvokeConfig<Context, Event> = {
-    src:
-      ({ client }) =>
-      (callback) => {
-        const listener = addEventListener(client, callback);
-        return () => client.removeListener(listener);
-      },
-  };
 
   const rejectingState: StateNodeConfig<
     Context,
@@ -521,7 +506,6 @@ function buildMachine({
                     ).unsafeUnwrap();
                   },
                 },
-                listenForScannerEvents,
               ],
               on: {
                 SCANNING_DISABLED: '#paused',
@@ -555,7 +539,6 @@ function buildMachine({
           initial: 'waitingForScanComplete',
           states: {
             waitingForScanComplete: {
-              invoke: listenForScannerEvents,
               on: {
                 SCANNER_EVENT: [
                   {


### PR DESCRIPTION

## Overview

We don't actually want to have multiple active listeners at a time for scanner events. The listener at the root will send a state machine event that can be caught in any state. Registering an additional listener within a state will just create a duplicate state machine event. This hasn't been causing problems because we've been transitioning away from the states with listeners before that happens, but it still presents a risk and is unnecessary.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
