### PR TITLE
VxScan: Shoeshine mode for Custom scanner

### DIFF
--- a/apps/scan/backend/src/scanners/custom/custom_app_scan_shoeshine_mode.test.ts
+++ b/apps/scan/backend/src/scanners/custom/custom_app_scan_shoeshine_mode.test.ts
@@ -1,0 +1,95 @@
+import { ok } from '@votingworks/basics';
+import { mocks } from '@votingworks/custom-scanner';
+import { electionGridLayoutNewHampshireTestBallotFixtures } from '@votingworks/fixtures';
+import { SheetInterpretation } from '@votingworks/types';
+import {
+  getFeatureFlagMock,
+  BooleanEnvironmentVariableName,
+} from '@votingworks/utils';
+import {
+  configureApp,
+  waitForStatus,
+  expectStatus,
+} from '../../../test/helpers/shared_helpers';
+import {
+  ballotImages,
+  simulateScan,
+  withApp,
+} from '../../../test/helpers/custom_helpers';
+
+jest.setTimeout(20_000);
+
+const mockFeatureFlagger = getFeatureFlagMock();
+
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
+  return {
+    ...jest.requireActual('@votingworks/utils'),
+    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+  };
+});
+beforeEach(() => {
+  mockFeatureFlagger.enableFeatureFlag(
+    BooleanEnvironmentVariableName.SKIP_ELECTION_PACKAGE_AUTHENTICATION
+  );
+  mockFeatureFlagger.enableFeatureFlag(
+    BooleanEnvironmentVariableName.USE_CUSTOM_SCANNER
+  );
+  mockFeatureFlagger.enableFeatureFlag(
+    BooleanEnvironmentVariableName.ENABLE_SCAN_SHOESHINE_MODE
+  );
+});
+
+test('shoeshine mode scans the same ballot repeatedly', async () => {
+  await withApp(
+    {
+      delays: { DELAY_ACCEPTED_RESET_TO_NO_PAPER: 500 },
+    },
+    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth }) => {
+      await configureApp(apiClient, mockAuth, mockUsbDrive, {
+        electionPackage:
+          electionGridLayoutNewHampshireTestBallotFixtures.electionJson.toElectionPackage(),
+      });
+
+      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
+
+      const interpretation: SheetInterpretation = {
+        type: 'ValidSheet',
+      };
+
+      simulateScan(mockScanner, await ballotImages.completeHmpb());
+      await waitForStatus(apiClient, { state: 'scanning' });
+      await waitForStatus(apiClient, {
+        state: 'ready_to_accept',
+        interpretation,
+      });
+
+      await apiClient.acceptBallot();
+      const ballotsCounted = 1;
+      await expectStatus(apiClient, {
+        state: 'accepted',
+        interpretation,
+        ballotsCounted,
+      });
+      await waitForStatus(apiClient, {
+        state: 'returning_to_rescan',
+        ballotsCounted,
+      });
+
+      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
+      simulateScan(mockScanner, await ballotImages.completeHmpb());
+      await waitForStatus(apiClient, { state: 'scanning', ballotsCounted });
+      await waitForStatus(apiClient, {
+        state: 'ready_to_accept',
+        interpretation,
+        ballotsCounted,
+      });
+
+      await apiClient.acceptBallot();
+      await expectStatus(apiClient, {
+        state: 'accepted',
+        interpretation,
+        ballotsCounted: 2,
+      });
+    }
+  );
+});

--- a/apps/scan/backend/src/scanners/custom/state_machine.ts
+++ b/apps/scan/backend/src/scanners/custom/state_machine.ts
@@ -37,6 +37,10 @@ import {
 } from 'xstate';
 import { UsbDrive } from '@votingworks/usb-drive';
 import { InsertedSmartCardAuthApi } from '@votingworks/auth';
+import {
+  BooleanEnvironmentVariableName,
+  isFeatureFlagEnabled,
+} from '@votingworks/utils';
 import { interpret as defaultInterpret, InterpretFn } from '../../interpret';
 import {
   InterpretationResult,
@@ -407,6 +411,9 @@ function buildMachine({
 }) {
   const delays: Delays = { ...defaultDelays, ...delayOverrides };
   const { store } = workspace;
+  const isShoeshineModeEnabled = isFeatureFlagEnabled(
+    BooleanEnvironmentVariableName.ENABLE_SCAN_SHOESHINE_MODE
+  );
 
   function pollPaperStatus(
     pollingInterval: number = delays.DELAY_PAPER_STATUS_POLLING_INTERVAL
@@ -892,7 +899,7 @@ function buildMachine({
           id: 'ready_to_accept',
           invoke: pollPaperStatus(),
           on: {
-            ACCEPT: 'accepting',
+            ACCEPT: isShoeshineModeEnabled ? 'accepted' : 'accepting',
             SCANNER_READY_TO_EJECT: doNothing,
           },
         },


### PR DESCRIPTION
## Overview

Uses the feature flag added in #4870 (`REACT_APP_VX_ENABLE_SCAN_SHOESHINE_MODE`) to enable shoeshine mode for the Custom scanner.

## Demo Video or Screenshot

https://github.com/votingworks/vxsuite/assets/530106/14d65768-0b13-4ba0-9f37-97abf0d93b16



## Testing Plan
Manual and automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
