### PR TITLE
libs/ballot-interpreter: Create debug image for contest option layouts

### DIFF
--- a/libs/ballot-interpreter/src/hmpb-rust/debug.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/debug.rs
@@ -18,6 +18,7 @@ fn imageproc_rect_from_rect(rect: &Rect) -> imageproc::rect::Rect {
     imageproc::rect::Rect::at(rect.left(), rect.top()).of_size(rect.width(), rect.height())
 }
 
+use crate::layout::InterpretedContestLayout;
 use crate::{
     image_utils::{
         BLUE, CYAN, DARK_BLUE, DARK_CYAN, DARK_GREEN, DARK_RED, GREEN, ORANGE, PINK, RAINBOW, RED,
@@ -626,6 +627,40 @@ pub fn draw_scored_write_in_areas(
             imageproc_rect_from_rect(&scored_write_in_area.bounds),
             DARK_GREEN,
         );
+    }
+}
+
+pub fn draw_contest_layouts_debug_image_mut(
+    canvas: &mut RgbImage,
+    contest_layouts: &[InterpretedContestLayout],
+) {
+    let font = &monospace_font();
+    let font_scale = 20.0;
+    let scale = Scale::uniform(font_scale);
+
+    for contest_layout in contest_layouts {
+        for (option_layout, color) in contest_layout
+            .options
+            .iter()
+            .zip([DARK_BLUE, DARK_GREEN].into_iter().cycle())
+        {
+            let option_label = option_layout.option_id.to_string();
+            draw_text_with_background_mut(
+                canvas,
+                &option_label,
+                option_layout.bounds.left(),
+                option_layout.bounds.top(),
+                scale,
+                font,
+                WHITE_RGB,
+                color,
+            );
+            draw_hollow_rect_mut(
+                canvas,
+                imageproc_rect_from_rect(&option_layout.bounds),
+                color,
+            );
+        }
     }
 }
 

--- a/libs/ballot-interpreter/src/hmpb-rust/debug.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/debug.rs
@@ -636,7 +636,7 @@ pub fn draw_contest_layouts_debug_image_mut(
 ) {
     let font = &monospace_font();
     let font_scale = 20.0;
-    let scale = Scale::uniform(font_scale);
+    let scale = PxScale::from(font_scale);
 
     for contest_layout in contest_layouts {
         for (option_layout, color) in contest_layout

--- a/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
@@ -567,10 +567,10 @@ pub fn interpret_ballot_card(
     );
 
     let (front_contest_layouts, back_contest_layouts) = map_pair(
-        (&front_grid, BallotSide::Front),
-        (&back_grid, BallotSide::Back),
-        |(grid, side)| {
-            build_interpreted_page_layout(grid, grid_layout, sheet_number, side)
+        (&front_grid, BallotSide::Front, &front_debug),
+        (&back_grid, BallotSide::Back, &back_debug),
+        |(grid, side, debug)| {
+            build_interpreted_page_layout(grid, grid_layout, sheet_number, side, debug)
                 .ok_or(Error::CouldNotComputeLayout { side })
         },
     );

--- a/libs/ballot-interpreter/src/hmpb-rust/layout.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/layout.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 use types_rs::election::{ContestId, GridLayout, GridLocation, GridPosition, OptionId};
 use types_rs::geometry::{Point, Rect, SubGridUnit};
 
+use crate::debug::{self, ImageDebugWriter};
 use crate::{ballot_card::BallotSide, timing_marks::TimingMarkGrid};
 
 #[derive(Debug, Serialize)]
@@ -92,6 +93,7 @@ pub fn build_interpreted_page_layout(
     grid_layout: &GridLayout,
     sheet_number: u32,
     side: BallotSide,
+    debug: &ImageDebugWriter,
 ) -> Option<Vec<InterpretedContestLayout>> {
     let contest_ids_in_grid_layout_order = grid_layout
         .grid_positions
@@ -103,7 +105,7 @@ pub fn build_interpreted_page_layout(
         .unique()
         .collect::<Vec<_>>();
 
-    contest_ids_in_grid_layout_order
+    let layouts = contest_ids_in_grid_layout_order
         .iter()
         .map(|contest_id| {
             let grid_positions = grid_layout
@@ -130,5 +132,11 @@ pub fn build_interpreted_page_layout(
                 options,
             })
         })
-        .collect()
+        .collect::<Option<Vec<_>>>()?;
+
+    debug.write("contest_layouts", |canvas| {
+        debug::draw_contest_layouts_debug_image_mut(canvas, &layouts);
+    });
+
+    Some(layouts)
 }


### PR DESCRIPTION
## Overview

Cherry pick of #4872 onto `main`
## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
