### PR TITLE
apps/scan: Set PDI scanner paper length to prevent back-to-back ballots

### DIFF
--- a/apps/scan/backend/src/scanners/pdi/pdi_app_scan.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_scan.test.ts
@@ -59,7 +59,10 @@ test('configure and scan hmpb', async () => {
 
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
       await waitForStatus(apiClient, { state: 'no_paper' });
-      expect(mockScanner.client.enableScanning).toHaveBeenCalled();
+      expect(mockScanner.client.enableScanning).toHaveBeenCalledWith({
+        doubleFeedDetectionEnabled: true,
+        paperLengthInches: 11,
+      });
 
       await simulateScan(
         apiClient,
@@ -136,7 +139,10 @@ test('configure and scan bmd ballot', async () => {
 
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
       await waitForStatus(apiClient, { state: 'no_paper' });
-      expect(mockScanner.client.enableScanning).toHaveBeenCalled();
+      expect(mockScanner.client.enableScanning).toHaveBeenCalledWith({
+        doubleFeedDetectionEnabled: true,
+        paperLengthInches: 11,
+      });
 
       await simulateScan(
         apiClient,

--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -20,7 +20,12 @@ import {
   spawn,
 } from 'xstate';
 import { v4 as uuid } from 'uuid';
-import { SheetInterpretation, SheetOf, mapSheet } from '@votingworks/types';
+import {
+  SheetInterpretation,
+  SheetOf,
+  ballotPaperDimensions,
+  mapSheet,
+} from '@votingworks/types';
 import { join } from 'path';
 import { writeImageData } from '@votingworks/image-utils';
 import { BaseLogger, LogEventId, LogLine } from '@votingworks/logging';
@@ -505,10 +510,17 @@ function buildMachine({
                 pollScanningEnabled,
                 {
                   src: async ({ client }) => {
+                    const electionDefinition = store.getElectionDefinition();
+                    if (!electionDefinition) return;
+                    const paperLengthInches = ballotPaperDimensions(
+                      electionDefinition.election.ballotLayout.paperSize
+                    ).height;
+                    const doubleFeedDetectionEnabled =
+                      !store.getIsDoubleFeedDetectionDisabled();
                     (
                       await client.enableScanning({
-                        doubleFeedDetectionEnabled:
-                          !store.getIsDoubleFeedDetectionDisabled(),
+                        doubleFeedDetectionEnabled,
+                        paperLengthInches,
                       })
                     ).unsafeUnwrap();
                   },

--- a/libs/pdi-scanner/examples/scan_forever.rs
+++ b/libs/pdi-scanner/examples/scan_forever.rs
@@ -64,7 +64,7 @@ fn main() -> color_eyre::Result<()> {
     let mut scan_index = 0;
 
     client.send_initial_commands_after_connect(Duration::from_secs(3))?;
-    client.send_enable_scan_commands(DoubleFeedDetectionMode::RejectDoubleFeeds)?;
+    client.send_enable_scan_commands(DoubleFeedDetectionMode::RejectDoubleFeeds, 11.0)?;
     println!("waiting for sheet…");
 
     let running = Arc::new(AtomicBool::new(true));

--- a/libs/pdi-scanner/src/rust/client.rs
+++ b/libs/pdi-scanner/src/rust/client.rs
@@ -810,7 +810,7 @@ impl<T> Client<T> {
         // OUT SetRequiredInputSensorsRequest { sensors: 2 }
         self.set_required_input_sensors(2)?;
 
-        // Set the max lenght of the document to scan to 0.5" less than the
+        // Set the max length of the document to scan to 0.5" less than the
         // paper length. Experimentally, this seems to result in the scanner
         // successfully scanning paper of the given length but rejecting two
         // pieces of paper inserted back to back. Crucially, it stops the motors

--- a/libs/pdi-scanner/src/rust/main.rs
+++ b/libs/pdi-scanner/src/rust/main.rs
@@ -78,6 +78,7 @@ enum Command {
 
     EnableScanning {
         double_feed_detection_enabled: bool,
+        paper_length_inches: f32,
     },
 
     DisableScanning,
@@ -298,6 +299,7 @@ fn main() -> color_eyre::Result<()> {
                         Some(client),
                         Command::EnableScanning {
                             double_feed_detection_enabled,
+                            paper_length_inches,
                         },
                     ) => {
                         let double_feed_detection_mode = if double_feed_detection_enabled {
@@ -305,7 +307,10 @@ fn main() -> color_eyre::Result<()> {
                         } else {
                             DoubleFeedDetectionMode::Disabled
                         };
-                        match client.send_enable_scan_commands(double_feed_detection_mode) {
+                        match client.send_enable_scan_commands(
+                            double_feed_detection_mode,
+                            paper_length_inches,
+                        ) {
                             Ok(()) => send_response(Response::Ok)?,
                             Err(e) => send_error_response(&e)?,
                         }

--- a/libs/pdi-scanner/src/ts/demo.ts
+++ b/libs/pdi-scanner/src/ts/demo.ts
@@ -8,9 +8,12 @@ export async function main(): Promise<void> {
   const scannerClient = createPdiScannerClient();
   (await scannerClient.connect()).unsafeUnwrap();
 
-  (
-    await scannerClient.enableScanning({ doubleFeedDetectionEnabled: true })
-  ).unsafeUnwrap();
+  const scanningOptions = {
+    doubleFeedDetectionEnabled: true,
+    paperLengthInches: 11,
+  } as const;
+
+  (await scannerClient.enableScanning(scanningOptions)).unsafeUnwrap();
 
   let state = 'waitingForBallot';
   scannerClient.addListener((event) => {
@@ -29,9 +32,7 @@ export async function main(): Promise<void> {
   for (;;) {
     if (state === 'scanComplete') {
       (await scannerClient.ejectDocument('toRear')).unsafeUnwrap();
-      (
-        await scannerClient.enableScanning({ doubleFeedDetectionEnabled: true })
-      ).unsafeUnwrap();
+      (await scannerClient.enableScanning(scanningOptions)).unsafeUnwrap();
       state = 'waitingForBallot';
     }
     await sleep(1000);

--- a/libs/pdi-scanner/src/ts/scanner_client.test.ts
+++ b/libs/pdi-scanner/src/ts/scanner_client.test.ts
@@ -84,27 +84,35 @@ test('getScannerStatus', async () => {
   expectStdinCommand({ command: 'getScannerStatus' });
 });
 
-test('enableScanning({ doubleFeedDetectionEnabled: true })', async () => {
+test('enableScanning({ doubleFeedDetectionEnabled: true, paperLengthInches: 11 })', async () => {
   const client = createPdiScannerClient();
   mockStdoutResponse({ response: 'ok' });
   expect(
-    await client.enableScanning({ doubleFeedDetectionEnabled: true })
+    await client.enableScanning({
+      doubleFeedDetectionEnabled: true,
+      paperLengthInches: 11,
+    })
   ).toEqual(ok());
   expectStdinCommand({
     command: 'enableScanning',
     doubleFeedDetectionEnabled: true,
+    paperLengthInches: 11,
   });
 });
 
-test('enableScanning({ doubleFeedDetectionEnabled: false })', async () => {
+test('enableScanning({ doubleFeedDetectionEnabled: false, paperLengthInches: 14 })', async () => {
   const client = createPdiScannerClient();
   mockStdoutResponse({ response: 'ok' });
   expect(
-    await client.enableScanning({ doubleFeedDetectionEnabled: false })
+    await client.enableScanning({
+      doubleFeedDetectionEnabled: false,
+      paperLengthInches: 14,
+    })
   ).toEqual(ok());
   expectStdinCommand({
     command: 'enableScanning',
     doubleFeedDetectionEnabled: false,
+    paperLengthInches: 14,
   });
 });
 
@@ -241,10 +249,15 @@ test('queues overlapping commands', async () => {
   const command1Promise = client.getScannerStatus();
   const command2Promise = client.enableScanning({
     doubleFeedDetectionEnabled: true,
+    paperLengthInches: 11,
   });
   expectStdinCommands([
     { command: 'getScannerStatus' },
-    { command: 'enableScanning', doubleFeedDetectionEnabled: true },
+    {
+      command: 'enableScanning',
+      doubleFeedDetectionEnabled: true,
+      paperLengthInches: 11,
+    },
   ]);
   mockStdoutResponse({ response: 'scannerStatus', status: scannerStatus });
   mockStdoutResponse({ response: 'ok' });
@@ -286,7 +299,10 @@ test('simple commands handle unexpected response', async () => {
   const client = createPdiScannerClient();
   mockStdoutResponse({ response: 'scannerStatus', status: scannerStatus });
   expect(
-    await client.enableScanning({ doubleFeedDetectionEnabled: true })
+    await client.enableScanning({
+      doubleFeedDetectionEnabled: true,
+      paperLengthInches: 11,
+    })
   ).toEqual(
     err({ code: 'other', message: 'Unexpected response: scannerStatus' })
   );
@@ -296,6 +312,9 @@ test('simple commands handle error response', async () => {
   const client = createPdiScannerClient();
   mockStdoutResponse({ response: 'error', code: 'scanInProgress' });
   expect(
-    await client.enableScanning({ doubleFeedDetectionEnabled: true })
+    await client.enableScanning({
+      doubleFeedDetectionEnabled: true,
+      paperLengthInches: 11,
+    })
   ).toEqual(err({ response: 'error', code: 'scanInProgress' }));
 });

--- a/libs/pdi-scanner/src/ts/scanner_client.ts
+++ b/libs/pdi-scanner/src/ts/scanner_client.ts
@@ -115,7 +115,11 @@ type PdictlCommand =
   | { command: 'connect' }
   | { command: 'disconnect' }
   | { command: 'getScannerStatus' }
-  | { command: 'enableScanning'; doubleFeedDetectionEnabled: boolean }
+  | {
+      command: 'enableScanning';
+      doubleFeedDetectionEnabled: boolean;
+      paperLengthInches: number;
+    }
   | { command: 'disableScanning' }
   | {
       command: 'ejectDocument';
@@ -336,12 +340,15 @@ export function createPdiScannerClient() {
      */
     async enableScanning({
       doubleFeedDetectionEnabled,
+      paperLengthInches,
     }: {
       doubleFeedDetectionEnabled: boolean;
+      paperLengthInches: number;
     }): Promise<SimpleResult> {
       return sendSimpleCommand({
         command: 'enableScanning',
         doubleFeedDetectionEnabled,
+        paperLengthInches,
       });
     },
 


### PR DESCRIPTION

## Overview
Task: #4825 

Previously, if you timed it just right, it was possible to trick the PDI scanner into thinking it was scanning one long ballot by inserting two ballots in quick succession back to back. In this case, the first ballot would be ejected out of the rear of the scanner into the ballot box before the issue would be detected by the interpreter.

To prevent this, we set the max paper length setting provided by the PDI scanner. After scanning (approximately) this length, the PDI scanner declares a jam and stops the motors. I found that the optimal length for stopping the motors soon enough to prevent the first ballot from being ejected was 0.5in shorter than the actual length of the ballot.
## Demo Video or Screenshot
Before

https://github.com/votingworks/vxsuite/assets/530106/e41ee457-4bd1-4639-850d-a9c52efefa36



After

https://github.com/votingworks/vxsuite/assets/530106/4b64265e-269c-4c1b-b47c-e1a0969198c1


## Testing Plan
- Updated automated tests
- Manual test with letter and legal ballots

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
