### PR TITLE
libs/pdi-scanner: Bugfix for typo from eject pause feature PR

### DIFF
--- a/libs/pdi-scanner/src/rust/client.rs
+++ b/libs/pdi-scanner/src/rust/client.rs
@@ -90,7 +90,7 @@ impl<T> Client<T> {
             .iter()
             .filter(|packet| !packet.is_event())
             .collect::<Vec<_>>();
-        if unhandled_non_event_packets.is_empty() {
+        if !unhandled_non_event_packets.is_empty() {
             tracing::debug!("clearing unhandled packets: {unhandled_non_event_packets:?}");
             self.unhandled_packets.retain(Incoming::is_event);
         }


### PR DESCRIPTION

## Overview

I mistyped this condition when implementing the PR feedback from https://github.com/votingworks/vxsuite/pull/4843. Ideally, we'd have a test to make sure this doesn't happen, but I haven't figured out how to test the complex behavior of the Rust code yet. For now, I'd just like to fix this.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
