### PR TITLE
fix(ui): cache modal `appElement` to fix tests

### DIFF
--- a/apps/admin/frontend/src/components/smartcard_modal/smartcard_modal.test.tsx
+++ b/apps/admin/frontend/src/components/smartcard_modal/smartcard_modal.test.tsx
@@ -378,9 +378,7 @@ test('Programming election manager and poll worker smartcards', async () => {
     await waitFor(() =>
       expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
     );
-    // For some reason, we need to use the "hidden" option here, even though the
-    // heading is not hidden
-    await screen.findByRole('heading', { name: 'Election', hidden: true });
+    await screen.findByRole('heading', { name: 'Election' });
   }
 });
 
@@ -552,9 +550,7 @@ test('Resetting smartcard PINs', async () => {
     await waitFor(() =>
       expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
     );
-    // For some reason, we need to use the "hidden" option here, even though the
-    // heading is not hidden
-    await screen.findByRole('heading', { name: 'Election', hidden: true });
+    await screen.findByRole('heading', { name: 'Election' });
   }
 });
 
@@ -669,9 +665,7 @@ test('Unprogramming smartcards', async () => {
     await waitFor(() =>
       expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
     );
-    // For some reason, we need to use the "hidden" option here, even though the
-    // heading is not hidden
-    await screen.findByRole('heading', { name: 'Election', hidden: true });
+    await screen.findByRole('heading', { name: 'Election' });
   }
 });
 

--- a/apps/mark-scan/frontend/src/pages/diagnostics_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/diagnostics_screen.test.tsx
@@ -172,10 +172,6 @@ test('saving report', async () => {
   userEvent.click(await screen.findButton('Close'));
 
   // confirm modal resets after exiting
-  userEvent.click(
-    await screen.findButton('Save Readiness Report', {
-      useSparinglyIncludeHidden: true,
-    })
-  );
+  userEvent.click(await screen.findButton('Save Readiness Report'));
   await screen.findByRole('heading', { name: 'Save Readiness Report' });
 });

--- a/libs/ui/src/modal.test.tsx
+++ b/libs/ui/src/modal.test.tsx
@@ -185,3 +185,37 @@ describe('when in voter audio context', () => {
     screen.getByText('Content!');
   });
 });
+
+test('aria-hidden is set and cleared properly', () => {
+  // ensure there is a root element
+  render(<div id="test-root" />);
+
+  const root = document.body.firstElementChild;
+
+  const { unmount, rerender } = render(
+    <div>
+      <Modal
+        title={<span>TITLE</span>}
+        content={<span>Content!</span>}
+        actions={<span>Do not read this</span>}
+      />
+    </div>
+  );
+
+  expect(root).toHaveAttribute('aria-hidden', 'true');
+
+  // cause the `appElement` to change if it's not cached
+  rerender(
+    <div>
+      <Modal
+        title={<span>TITLE</span>}
+        content={<span>Content!</span>}
+        actions={<span>Do not read this</span>}
+      />
+    </div>
+  );
+
+  // unmount should clear the aria-hidden attribute
+  unmount();
+  expect(root).not.toHaveAttribute('aria-hidden');
+});

--- a/libs/ui/src/modal.tsx
+++ b/libs/ui/src/modal.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useMemo } from 'react';
 import ReactModal from 'react-modal';
 import styled, { DefaultTheme } from 'styled-components';
 import { rgba } from 'polished';
@@ -206,9 +206,12 @@ export function Modal({
   );
 
   /* istanbul ignore next - can't get document.getElementById working in test */
-  const appElement =
-    document.getElementById('root') ??
-    (document.body.firstElementChild as HTMLElement);
+  const appElement = useMemo(
+    () =>
+      document.getElementById('root') ??
+      (document.body.firstElementChild as HTMLElement | null),
+    []
+  );
   assert(appElement);
   return (
     <ReactModal

--- a/libs/ui/src/save_readiness_report_button.test.tsx
+++ b/libs/ui/src/save_readiness_report_button.test.tsx
@@ -123,10 +123,6 @@ test('mutation resets on close', async () => {
 
   userEvent.click(screen.getButton('Close'));
 
-  userEvent.click(
-    await screen.findButton('Save Readiness Report', {
-      useSparinglyIncludeHidden: true, // button hidden by react-modal's faulty cleanup
-    })
-  );
+  userEvent.click(await screen.findButton('Save Readiness Report'));
   await screen.findByRole('heading', { name: 'Save Readiness Report' });
 });


### PR DESCRIPTION

## Overview

In tests an element with id "root" typically does not exist, so `Modal` falls back to `document.body.firstElementChild`. However, `ReactModal` (under our `Modal`) adds an element with attribute `data-react-modal-body-trap` at the root. So if the `Modal` is ever re-rendered, it'll get a different `appElement` the next time around. This is important because when the modal first appears `ReactModal` adds `aria-hidden` to the `appElement`, and then when the modal goes away it removes the `aria-hidden` attribute. However, if the `appElement` changes between renders then you will end up with the `aria-hidden` attribute sticking around, which means all the `screen.findByRole` calls will fail because they ignore anything inside an element with `aria-hidden`.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated tests.