### PR TITLE
FIX(ui): remove accidental commit of shortened test timeouts

### DIFF
--- a/libs/ui/src/hooks/use_available_languages.test.tsx
+++ b/libs/ui/src/hooks/use_available_languages.test.tsx
@@ -30,9 +30,7 @@ test('returns available languages from backend', async () => {
     wrapper: TestHookWrapper,
   });
 
-  await waitFor(() => expect(result.current).toEqual([ENGLISH, SPANISH]), {
-    timeout: 100,
-  });
+  await waitFor(() => expect(result.current).toEqual([ENGLISH, SPANISH]));
 });
 
 test('returns only default language when rendered without context', () => {

--- a/libs/ui/src/hooks/use_current_language.test.tsx
+++ b/libs/ui/src/hooks/use_current_language.test.tsx
@@ -41,12 +41,8 @@ test('returns current language when rendered within context', async () => {
     { wrapper: TestHookWrapper }
   );
 
-  await waitFor(() => expect(result.current).toEqual(DEFAULT_LANGUAGE_CODE), {
-    timeout: 100,
-  });
+  await waitFor(() => expect(result.current).toEqual(DEFAULT_LANGUAGE_CODE));
 
   act(() => setLanguage(LanguageCode.SPANISH));
-  await waitFor(() => expect(result.current).toEqual(LanguageCode.SPANISH), {
-    timeout: 100,
-  });
+  await waitFor(() => expect(result.current).toEqual(LanguageCode.SPANISH));
 });


### PR DESCRIPTION
## Overview

Had these shortened assertion timeouts for local debugging and accidentally committed in a previous PR. Removing to fix the [flakes](https://votingworks.slack.com/archives/CEL6D3GAD/p1713485245450899) they're causing in circleci.
