### PR TITLE
refactor: use `Array::at` to access last element

### DIFF
--- a/apps/design/backend/src/candidate_rotation.ts
+++ b/apps/design/backend/src/candidate_rotation.ts
@@ -1,4 +1,4 @@
-import { assertDefined, iter } from '@votingworks/basics';
+import { assertDefined } from '@votingworks/basics';
 import { AnyContest } from '@votingworks/types';
 
 // Maps the number of candidates in a contest to the index at which to rotate
@@ -40,7 +40,7 @@ export function rotateCandidates(contest: AnyContest): AnyContest {
 
   // Lacking structured name data, we approximate last name by using the last word
   function lastName(name: string): string {
-    return assertDefined(iter(name.split(' ')).last());
+    return assertDefined(name.split(' ').at(-1));
   }
 
   const orderedCandidates = [...contest.candidates].sort((a, b) =>

--- a/apps/design/frontend/src/contests_screen.test.tsx
+++ b/apps/design/frontend/src/contests_screen.test.tsx
@@ -568,7 +568,7 @@ describe('Contests tab', () => {
     userEvent.click(screen.getByRole('button', { name: 'Reorder Contests' }));
 
     const [contest1Title, contest2Title, contest3Title] = originalOrder;
-    const contest1Row = screen.getByText(contest1Title).closest('tr')!;
+    const contest1Row = screen.getByText(contest1Title!).closest('tr')!;
     expect(
       within(contest1Row).getByRole('button', { name: 'Move Up' })
     ).toBeDisabled();
@@ -576,7 +576,7 @@ describe('Contests tab', () => {
       within(contest1Row).getByRole('button', { name: 'Move Down' })
     );
 
-    const contest3Row = screen.getByText(contest3Title).closest('tr')!;
+    const contest3Row = screen.getByText(contest3Title!).closest('tr')!;
     userEvent.click(
       within(contest3Row).getByRole('button', { name: 'Move Up' })
     );

--- a/apps/design/frontend/src/contests_screen.test.tsx
+++ b/apps/design/frontend/src/contests_screen.test.tsx
@@ -2,7 +2,7 @@ import { createMemoryHistory } from 'history';
 import userEvent from '@testing-library/user-event';
 import type { ElectionRecord } from '@votingworks/design-backend';
 import { CandidateContest, YesNoContest } from '@votingworks/types';
-import { assert, iter } from '@votingworks/basics';
+import { assert } from '@votingworks/basics';
 import {
   MockApiClient,
   createMockApiClient,
@@ -436,7 +436,7 @@ describe('Contests tab', () => {
     expect(rows).toHaveLength(
       electionWithNewContestRecord.election.contests.length + 1
     );
-    const lastRow = rows[rows.length - 1];
+    const lastRow = rows.at(-1)!;
     expect(
       within(lastRow)
         .getAllByRole('cell')
@@ -568,7 +568,7 @@ describe('Contests tab', () => {
     userEvent.click(screen.getByRole('button', { name: 'Reorder Contests' }));
 
     const [contest1Title, contest2Title, contest3Title] = originalOrder;
-    const contest1Row = screen.getByText(contest1Title!).closest('tr')!;
+    const contest1Row = screen.getByText(contest1Title).closest('tr')!;
     expect(
       within(contest1Row).getByRole('button', { name: 'Move Up' })
     ).toBeDisabled();
@@ -576,12 +576,12 @@ describe('Contests tab', () => {
       within(contest1Row).getByRole('button', { name: 'Move Down' })
     );
 
-    const contest3Row = screen.getByText(contest3Title!).closest('tr')!;
+    const contest3Row = screen.getByText(contest3Title).closest('tr')!;
     userEvent.click(
       within(contest3Row).getByRole('button', { name: 'Move Up' })
     );
 
-    const lastContestRow = iter(screen.getAllByRole('row')).last()!;
+    const lastContestRow = screen.getAllByRole('row').at(-1)!;
     expect(
       within(lastContestRow).getByRole('button', { name: 'Move Down' })
     ).toBeDisabled();

--- a/libs/eslint-plugin-vx/src/rules/gts_func_style.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_func_style.ts
@@ -73,7 +73,7 @@ const rule: TSESLint.RuleModule<'useFunctionDeclaration', readonly unknown[]> =
         },
 
         ThisExpression(): void {
-          const pendingReport = pendingReports[pendingReports.length - 1];
+          const pendingReport = pendingReports.at(-1);
 
           if (pendingReport?.functionLevel === functionLevel) {
             pendingReport.usesThis = true;
@@ -91,7 +91,7 @@ const rule: TSESLint.RuleModule<'useFunctionDeclaration', readonly unknown[]> =
         'VariableDeclarator:exit': (
           node: TSESTree.VariableDeclarator
         ): void => {
-          if (pendingReports[pendingReports.length - 1]?.declarator === node) {
+          if (pendingReports.at(-1)?.declarator === node) {
             const { declaration, id, init, usesThis } =
               pendingReports.pop() as PendingReport;
 

--- a/libs/eslint-plugin-vx/src/rules/gts_no_foreach.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_no_foreach.ts
@@ -220,7 +220,7 @@ const rule: TSESLint.RuleModule<'noForEach', readonly unknown[]> = createRule({
        * `continue`s.
        */
       ReturnStatement(node: TSESTree.ReturnStatement): void {
-        const currentForEach = forEachStack[forEachStack.length - 1];
+        const currentForEach = forEachStack.at(-1);
 
         if (currentForEach?.functionLevel !== functionLevel - 1) {
           return;
@@ -251,7 +251,7 @@ const rule: TSESLint.RuleModule<'noForEach', readonly unknown[]> = createRule({
           return;
         }
 
-        const currentForEach = forEachStack[forEachStack.length - 1];
+        const currentForEach = forEachStack.at(-1);
         if (currentForEach?.forEachCall !== node) {
           return;
         }

--- a/libs/hmpb/src/render_ballot.tsx
+++ b/libs/hmpb/src/render_ballot.tsx
@@ -100,8 +100,7 @@ async function paginateBallotContent<P extends object>(
       `.${CONTENT_SLOT_CLASS}`
     );
     const currentPageProps: P =
-      pagedContentResults[pagedContentResults.length - 1]?.nextPageProps ??
-      props;
+      pagedContentResults.at(-1)?.nextPageProps ?? props;
 
     if (
       deepEqual(
@@ -129,7 +128,7 @@ async function paginateBallotContent<P extends object>(
       scratchpad
     );
     pagedContentResults.push(pagedContentResult);
-  } while (pagedContentResults[pagedContentResults.length - 1].nextPageProps);
+  } while (pagedContentResults.at(-1)?.nextPageProps);
 
   if (pagedContentResults.length % 2 === 1) {
     pagedContentResults.push(await contentComponent(undefined, scratchpad));

--- a/libs/printing/src/printer/mocks/memory_printer.ts
+++ b/libs/printing/src/printer/mocks/memory_printer.ts
@@ -78,7 +78,7 @@ export function createMockPrinterHandler(): MemoryPrinterHandler {
 
     getLastPrintPath() {
       const { printJobHistory } = mockPrinterState;
-      return printJobHistory[printJobHistory.length - 1]?.filename;
+      return printJobHistory.at(-1)?.filename;
     },
 
     cleanup() {

--- a/libs/ui/src/set_clock.tsx
+++ b/libs/ui/src/set_clock.tsx
@@ -9,7 +9,7 @@ import {
   MONTHS_SHORT,
 } from '@votingworks/utils';
 import { SelectChangeEventFunction } from '@votingworks/types';
-import { integers } from '@votingworks/basics';
+import { assertDefined, integers } from '@votingworks/basics';
 import styled from 'styled-components';
 import { Select } from './select';
 import { Modal } from './modal';
@@ -125,7 +125,7 @@ export function PickDateTimeModal({
     const year = name === 'year' ? partValue : newValue.year;
     const month = name === 'month' ? partValue : newValue.month;
     const daysInMonth = getDaysInMonth(year, month);
-    const lastDayOfMonth = daysInMonth.at(-1)?.day;
+    const lastDayOfMonth = assertDefined(daysInMonth.at(-1)).day;
     const day = name === 'day' ? partValue : newValue.day;
     setNewValue(
       DateTime.fromObject(

--- a/libs/ui/src/set_clock.tsx
+++ b/libs/ui/src/set_clock.tsx
@@ -125,7 +125,7 @@ export function PickDateTimeModal({
     const year = name === 'year' ? partValue : newValue.year;
     const month = name === 'month' ? partValue : newValue.month;
     const daysInMonth = getDaysInMonth(year, month);
-    const lastDayOfMonth = daysInMonth[daysInMonth.length - 1].day;
+    const lastDayOfMonth = daysInMonth.at(-1)?.day;
     const day = name === 'day' ? partValue : newValue.day;
     setNewValue(
       DateTime.fromObject(


### PR DESCRIPTION
`a.at(-1)` is nicer than `a[a.length - 1]`. Maybe less self-documenting than `iter(a).last()`, but more platform-native.
