### PR TITLE
clear controller in-buffer before echo command

### DIFF
--- a/apps/mark-scan/accessible-controller/src/port.rs
+++ b/apps/mark-scan/accessible-controller/src/port.rs
@@ -76,7 +76,7 @@ impl Port {
             Ok(0) => (),
             Ok(num_bytes) => {
                 match port.clear(serialport::ClearBuffer::Input) {
-                    Ok(_) => log!( event_id: EventId::Info,
+                    Ok(()) => log!( event_id: EventId::Info,
                         event_type: EventType::SystemStatus,
                         message: format!("Cleared {num_bytes} bytes from controller in-buffer")
                     ),

--- a/apps/mark-scan/accessible-controller/src/port.rs
+++ b/apps/mark-scan/accessible-controller/src/port.rs
@@ -76,7 +76,8 @@ impl Port {
             Ok(0) => (),
             Ok(num_bytes) => {
                 match port.clear(serialport::ClearBuffer::Input) {
-                    Ok(()) => log!( event_id: EventId::Info,
+                    Ok(()) => log!(
+                        event_id: EventId::Info,
                         event_type: EventType::SystemStatus,
                         message: format!("Cleared {num_bytes} bytes from controller in-buffer")
                     ),


### PR DESCRIPTION
## Overview

The controller daemon sends a health check command to the controller and expects a response back. If buttons on the controller have been pressed before the daemon has started up, the in-buffer will have data in it. That data is returned alongside the health check response. The concatenated response is unparsable by the daemon and crashes.

This PR clears the in-buffer before sending the health check command to avoid the problem.


## Demo Video or Screenshot

N/A

## Testing Plan

Manually tested both cases on hardware. No automated tests since this implementation is likely going away soon.

* starting daemon without any buttons pressed
* pressing buttons on controller and then starting daemon

