### PR TITLE
[VxScan] Optionally allow scanning official ballots in test mode

### DIFF
--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -75,6 +75,8 @@ async function interpretSheet(
       ballotImagesPath: workspace.ballotImagesPath,
       markThresholds: store.getMarkThresholds(),
       adjudicationReasons: store.getAdjudicationReasons(),
+      allowOfficialBallotsInTestMode:
+        store.getSystemSettings()?.allowOfficialBallotsInTestMode,
     })
   ).unsafeUnwrap();
   return {

--- a/libs/ballot-interpreter/package.json
+++ b/libs/ballot-interpreter/package.json
@@ -45,6 +45,7 @@
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/image-utils": "workspace:*",
     "@votingworks/qrdetect": "^1.0.1",
+    "@votingworks/test-utils": "workspace:*",
     "@votingworks/types": "workspace:*",
     "@votingworks/utils": "workspace:*",
     "better-sqlite3": "8.2.0",

--- a/libs/ballot-interpreter/src/index.ts
+++ b/libs/ballot-interpreter/src/index.ts
@@ -1,3 +1,4 @@
 /* istanbul ignore file */
 export * from './interpret';
 export * from './hmpb-ts';
+export * from './types';

--- a/libs/ballot-interpreter/src/interpret_vx_hmpb.test.ts
+++ b/libs/ballot-interpreter/src/interpret_vx_hmpb.test.ts
@@ -14,11 +14,13 @@ import {
   BallotType,
   DEFAULT_MARK_THRESHOLDS,
   ElectionDefinition,
+  PageInterpretation,
 } from '@votingworks/types';
 import { sliceElectionHash } from '@votingworks/ballot-encoder';
 import { loadImageData } from '@votingworks/image-utils';
 import { createCanvas } from 'canvas';
 import { readElection } from '@votingworks/fs';
+import { mockOf } from '@votingworks/test-utils';
 import {
   sortVotesDict,
   ballotPdfToPageImages,
@@ -27,6 +29,14 @@ import {
   unmarkedWriteInsForSheet,
 } from '../test/helpers/interpretation';
 import { interpretSheet } from './interpret';
+import { normalizeBallotMode } from './validation';
+import { InterpreterOptions } from './types';
+
+jest.mock('./validation');
+
+beforeEach(() => {
+  mockOf(normalizeBallotMode).mockImplementation((input) => input);
+});
 
 describe('HMPB - Famous Names', () => {
   const { electionPath, precinctId, votes, blankBallotPath, markedBallotPath } =
@@ -182,6 +192,39 @@ describe('HMPB - Famous Names', () => {
 
     expect(frontResult.interpretation.type).toEqual('InvalidTestModePage');
     expect(backResult.interpretation.type).toEqual('InvalidTestModePage');
+  });
+
+  test('normalizes ballot mode', async () => {
+    const ballotImagePaths = await ballotPdfToPageImages(blankBallotPath);
+    expect(ballotImagePaths.length).toEqual(2);
+
+    const options: InterpreterOptions = {
+      electionDefinition,
+      precinctSelection: singlePrecinctSelectionFor(assertDefined(precinctId)),
+      testMode: false,
+      markThresholds: DEFAULT_MARK_THRESHOLDS,
+      adjudicationReasons: [],
+    };
+
+    const blankPageInterpretation: PageInterpretation = { type: 'BlankPage' };
+    mockOf(normalizeBallotMode).mockImplementation(
+      (_input, interpreterOptions) => {
+        expect(interpreterOptions).toEqual(options);
+
+        return blankPageInterpretation;
+      }
+    );
+
+    const interpretationResult = await interpretSheet(
+      options,
+      ballotImagePaths as [string, string]
+    );
+    expect(interpretationResult[0].interpretation).toEqual(
+      blankPageInterpretation
+    );
+    expect(interpretationResult[1].interpretation).toEqual(
+      blankPageInterpretation
+    );
   });
 });
 

--- a/libs/ballot-interpreter/src/interpret_vx_hmpb.test.ts
+++ b/libs/ballot-interpreter/src/interpret_vx_hmpb.test.ts
@@ -49,7 +49,7 @@ describe('HMPB - Famous Names', () => {
   test('Blank ballot interpretation', async () => {
     const { election } = electionDefinition;
     const ballotImagePaths = await ballotPdfToPageImages(blankBallotPath);
-    expect(ballotImagePaths.length).toEqual(2);
+    expect(ballotImagePaths).toHaveLength(2);
 
     const [frontResult, backResult] = await interpretSheet(
       {
@@ -101,7 +101,7 @@ describe('HMPB - Famous Names', () => {
 
   test('Marked ballot interpretation', async () => {
     const ballotImagePaths = await ballotPdfToPageImages(markedBallotPath);
-    expect(ballotImagePaths.length).toEqual(2);
+    expect(ballotImagePaths).toHaveLength(2);
 
     const [frontResult, backResult] = await interpretSheet(
       {
@@ -128,7 +128,7 @@ describe('HMPB - Famous Names', () => {
 
   test('Wrong election', async () => {
     const ballotImagePaths = await ballotPdfToPageImages(blankBallotPath);
-    expect(ballotImagePaths.length).toEqual(2);
+    expect(ballotImagePaths).toHaveLength(2);
 
     const [frontResult, backResult] = await interpretSheet(
       {
@@ -153,7 +153,7 @@ describe('HMPB - Famous Names', () => {
   test('Wrong precinct', async () => {
     const { election } = electionDefinition;
     const ballotImagePaths = await ballotPdfToPageImages(blankBallotPath);
-    expect(ballotImagePaths.length).toEqual(2);
+    expect(ballotImagePaths).toHaveLength(2);
     assert(precinctId !== election.precincts[1]!.id);
 
     const [frontResult, backResult] = await interpretSheet(
@@ -175,7 +175,7 @@ describe('HMPB - Famous Names', () => {
 
   test('Wrong test mode', async () => {
     const ballotImagePaths = await ballotPdfToPageImages(blankBallotPath);
-    expect(ballotImagePaths.length).toEqual(2);
+    expect(ballotImagePaths).toHaveLength(2);
 
     const [frontResult, backResult] = await interpretSheet(
       {
@@ -196,7 +196,7 @@ describe('HMPB - Famous Names', () => {
 
   test('normalizes ballot mode', async () => {
     const ballotImagePaths = await ballotPdfToPageImages(blankBallotPath);
-    expect(ballotImagePaths.length).toEqual(2);
+    expect(ballotImagePaths).toHaveLength(2);
 
     const options: InterpreterOptions = {
       electionDefinition,
@@ -383,7 +383,7 @@ describe('HMPB - primary election', () => {
 
     test(`${partyLabel} - Blank ballot interpretation`, async () => {
       const ballotImagePaths = await ballotPdfToPageImages(blankBallotPath);
-      expect(ballotImagePaths.length).toEqual(2);
+      expect(ballotImagePaths).toHaveLength(2);
 
       const [frontResult, backResult] = await interpretSheet(
         {
@@ -429,7 +429,7 @@ describe('HMPB - primary election', () => {
 
     test(`${partyLabel} - Marked ballot interpretation`, async () => {
       const ballotImagePaths = await ballotPdfToPageImages(markedBallotPath);
-      expect(ballotImagePaths.length).toEqual(2);
+      expect(ballotImagePaths).toHaveLength(2);
 
       const [frontResult, backResult] = await interpretSheet(
         {
@@ -460,8 +460,8 @@ describe('HMPB - primary election', () => {
     const precinct2Paths = await ballotPdfToPageImages(
       mammalParty.otherPrecinctBlankBallotPath
     );
-    expect(precinct1Paths.length).toEqual(2);
-    expect(precinct2Paths.length).toEqual(2);
+    expect(precinct1Paths).toHaveLength(2);
+    expect(precinct2Paths).toHaveLength(2);
     const [frontPath] = precinct1Paths;
     const [, backPath] = precinct2Paths;
 
@@ -489,8 +489,8 @@ describe('HMPB - primary election', () => {
     const ballotStyle2Paths = await ballotPdfToPageImages(
       fishParty.blankBallotPath
     );
-    expect(ballotStyle1Paths.length).toEqual(2);
-    expect(ballotStyle2Paths.length).toEqual(2);
+    expect(ballotStyle1Paths).toHaveLength(2);
+    expect(ballotStyle2Paths).toHaveLength(2);
     const [frontPath] = ballotStyle1Paths;
     const [, backPath] = ballotStyle2Paths;
 

--- a/libs/ballot-interpreter/src/types.ts
+++ b/libs/ballot-interpreter/src/types.ts
@@ -1,0 +1,18 @@
+import {
+  AdjudicationReason,
+  ElectionDefinition,
+  MarkThresholds,
+  PrecinctSelection,
+} from '@votingworks/types';
+
+/**
+ * Options for interpreting a sheet of ballot images.
+ */
+export interface InterpreterOptions {
+  adjudicationReasons: readonly AdjudicationReason[];
+  electionDefinition: ElectionDefinition;
+  allowOfficialBallotsInTestMode?: boolean;
+  markThresholds: MarkThresholds;
+  precinctSelection: PrecinctSelection;
+  testMode: boolean;
+}

--- a/libs/ballot-interpreter/src/validation.test.ts
+++ b/libs/ballot-interpreter/src/validation.test.ts
@@ -1,0 +1,156 @@
+import { electionGeneralDefinition } from '@votingworks/fixtures';
+import {
+  BallotId,
+  BallotType,
+  DEFAULT_MARK_THRESHOLDS,
+  PageInterpretation,
+} from '@votingworks/types';
+import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
+import { normalizeBallotMode } from './validation';
+import { InterpreterOptions } from './types';
+
+const BLANK_INTERPRETATION: PageInterpretation = { type: 'BlankPage' };
+
+function createMockInterpretation(spec: {
+  isTestModeBallot: boolean;
+}): PageInterpretation {
+  return {
+    type: 'InterpretedBmdPage',
+    ballotId: 'abc' as BallotId,
+    metadata: {
+      electionHash: 'hash',
+      ballotType: BallotType.Precinct,
+      ballotStyleId: '5',
+      precinctId: '21',
+      isTestMode: spec.isTestModeBallot,
+    },
+    votes: {},
+  };
+}
+
+function createInterpreterOptions(spec: {
+  allowOfficialBallotsInTestMode: boolean;
+  isTestModeInterpreter: boolean;
+}) {
+  const options: InterpreterOptions = {
+    adjudicationReasons: [],
+    allowOfficialBallotsInTestMode: spec.allowOfficialBallotsInTestMode,
+    electionDefinition: electionGeneralDefinition,
+    markThresholds: DEFAULT_MARK_THRESHOLDS,
+    precinctSelection: ALL_PRECINCTS_SELECTION,
+    testMode: spec.isTestModeInterpreter,
+  };
+  return options;
+}
+
+describe('normalizeBallotMode', () => {
+  interface NormalizeBallotModeTestSpec {
+    allowOfficialBallotsInTestMode: boolean;
+    expectedOutputTestMode: boolean;
+    isTestModeInterpreter: boolean;
+    isTestModeBallot: boolean;
+  }
+
+  function testNormalization(spec: NormalizeBallotModeTestSpec) {
+    const input = createMockInterpretation({
+      isTestModeBallot: spec.isTestModeBallot,
+    });
+    const expectedOutput = createMockInterpretation({
+      isTestModeBallot: spec.expectedOutputTestMode,
+    });
+
+    expect(normalizeBallotMode(input, createInterpreterOptions(spec))).toEqual(
+      expectedOutput
+    );
+  }
+
+  test('official interpreter, test-mode ballot', () => {
+    const isTestModeInterpreter = false;
+    const isTestModeBallot = true;
+    const expectedOutputTestMode = true;
+
+    testNormalization({
+      allowOfficialBallotsInTestMode: false,
+      isTestModeInterpreter,
+      isTestModeBallot,
+      expectedOutputTestMode,
+    });
+
+    testNormalization({
+      allowOfficialBallotsInTestMode: true,
+      isTestModeInterpreter,
+      isTestModeBallot,
+      expectedOutputTestMode,
+    });
+  });
+
+  test('official interpreter, official ballot', () => {
+    const isTestModeInterpreter = false;
+    const isTestModeBallot = false;
+    const expectedOutputTestMode = false;
+
+    testNormalization({
+      allowOfficialBallotsInTestMode: false,
+      isTestModeInterpreter,
+      isTestModeBallot,
+      expectedOutputTestMode,
+    });
+
+    testNormalization({
+      allowOfficialBallotsInTestMode: true,
+      isTestModeInterpreter,
+      isTestModeBallot,
+      expectedOutputTestMode,
+    });
+  });
+
+  test('test-mode interpreter, test-mode ballot', () => {
+    const isTestModeInterpreter = true;
+    const isTestModeBallot = true;
+    const expectedOutputTestMode = true;
+
+    testNormalization({
+      allowOfficialBallotsInTestMode: false,
+      isTestModeInterpreter,
+      isTestModeBallot,
+      expectedOutputTestMode,
+    });
+
+    testNormalization({
+      allowOfficialBallotsInTestMode: true,
+      isTestModeInterpreter,
+      isTestModeBallot,
+      expectedOutputTestMode,
+    });
+  });
+
+  test('test-mode interpreter, official ballot, test-mode mismatches not allowed', () => {
+    testNormalization({
+      allowOfficialBallotsInTestMode: false,
+      isTestModeInterpreter: true,
+      isTestModeBallot: false,
+      expectedOutputTestMode: false,
+    });
+  });
+
+  test('test-mode interpreter, official ballot, test mode mismatches allowed', () => {
+    testNormalization({
+      allowOfficialBallotsInTestMode: true,
+      isTestModeInterpreter: true,
+      isTestModeBallot: false,
+      expectedOutputTestMode: true,
+    });
+  });
+
+  test('is no-op for interpretation with no metadata', () => {
+    expect(
+      normalizeBallotMode(
+        BLANK_INTERPRETATION,
+        createInterpreterOptions({
+          allowOfficialBallotsInTestMode: true,
+          isTestModeInterpreter: true,
+        })
+      )
+    ).toEqual(BLANK_INTERPRETATION);
+  });
+});

--- a/libs/ballot-interpreter/src/validation.ts
+++ b/libs/ballot-interpreter/src/validation.ts
@@ -1,0 +1,44 @@
+import {
+  InterpretedBmdPage,
+  InterpretedHmpbPage,
+  InvalidPrecinctPage,
+  InvalidTestModePage,
+  PageInterpretation,
+} from '@votingworks/types';
+
+import { InterpreterOptions } from './types';
+
+type PageInterpretationWithMetadata =
+  | InterpretedBmdPage
+  | InterpretedHmpbPage
+  | InvalidTestModePage
+  | InvalidPrecinctPage;
+
+function setTestMode<T extends PageInterpretationWithMetadata>(
+  interpretation: T,
+  isTestMode: boolean
+): T {
+  return {
+    // eslint-disable-next-line vx/gts-spread-like-types
+    ...interpretation,
+    metadata: {
+      ...interpretation.metadata,
+      isTestMode,
+    },
+  };
+}
+
+export function normalizeBallotMode(
+  interpretation: PageInterpretation,
+  options: InterpreterOptions
+): PageInterpretation {
+  if (
+    'metadata' in interpretation &&
+    options.testMode &&
+    options.allowOfficialBallotsInTestMode
+  ) {
+    return setTestMode(interpretation, true);
+  }
+
+  return interpretation;
+}

--- a/libs/types/src/system_settings.ts
+++ b/libs/types/src/system_settings.ts
@@ -57,6 +57,7 @@ export const MarkThresholdsSchema: z.ZodSchema<MarkThresholds> = z
  * (and therefore not needing to reprint ballots, for example).
  */
 export interface SystemSettings {
+  readonly allowOfficialBallotsInTestMode?: boolean;
   readonly auth: AuthSettings;
   readonly markThresholds: MarkThresholds;
   readonly centralScanAdjudicationReasons: readonly AdjudicationReason[];
@@ -65,6 +66,7 @@ export interface SystemSettings {
 }
 
 export const SystemSettingsSchema: z.ZodType<SystemSettings> = z.object({
+  allowOfficialBallotsInTestMode: z.boolean().optional(),
   auth: AuthSettingsSchema,
   markThresholds: MarkThresholdsSchema,
   centralScanAdjudicationReasons: z.array(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3210,6 +3210,9 @@ importers:
       '@votingworks/qrdetect':
         specifier: ^1.0.1
         version: 1.0.1
+      '@votingworks/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
       '@votingworks/types':
         specifier: workspace:*
         version: link:../types


### PR DESCRIPTION
## Overview

Related to https://github.com/votingworks/vxsuite/issues/4622

Adding an optional `allowOfficialBallotsInTestMode` system setting -- when enabled, always interpret official ballots as test-mode ballots when scanning in test mode.

## Testing Plan
- New unit tests for the `normalizeBallotMode` validation helper and test cases to verify it's getting used in each code path (BMD ballots, NH HMPBs, Vx HMPBs).
- Existing tests as regression guard

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
