### PR TITLE
chore: update `pnpm` to 8.3.1

### DIFF
--- a/apps/admin/backend/package.json
+++ b/apps/admin/backend/package.json
@@ -110,5 +110,5 @@
   "engines": {
     "node": ">= 16"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/apps/admin/frontend/package.json
+++ b/apps/admin/frontend/package.json
@@ -150,7 +150,7 @@
     "ts-jest": "29.1.1",
     "vite": "4.5.0"
   },
-  "packageManager": "pnpm@8.1.0",
+  "packageManager": "pnpm@8.3.1",
   "vx": {
     "env": {
       "VX_MACHINE_TYPE": "admin"

--- a/apps/admin/frontend/prodserver/package.json
+++ b/apps/admin/frontend/prodserver/package.json
@@ -7,5 +7,5 @@
     "http-proxy-middleware": "1.0.6",
     "resolve": "1.18.1"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/apps/admin/integration-testing/package.json
+++ b/apps/admin/integration-testing/package.json
@@ -46,5 +46,5 @@
     "lint-staged": "11.0.0",
     "sort-package-json": "^1.50.0"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/apps/central-scan/backend/package.json
+++ b/apps/central-scan/backend/package.json
@@ -96,5 +96,5 @@
   "engines": {
     "node": ">= 12"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/apps/central-scan/frontend/package.json
+++ b/apps/central-scan/frontend/package.json
@@ -126,7 +126,7 @@
     "type-fest": "^0.18.0",
     "vite": "4.5.0"
   },
-  "packageManager": "pnpm@8.1.0",
+  "packageManager": "pnpm@8.3.1",
   "vx": {
     "env": {
       "VX_MACHINE_TYPE": "central-scan"

--- a/apps/central-scan/frontend/prodserver/package.json
+++ b/apps/central-scan/frontend/prodserver/package.json
@@ -6,5 +6,5 @@
     "express": "4.18.2",
     "http-proxy-middleware": "1.0.6"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/apps/central-scan/integration-testing/package.json
+++ b/apps/central-scan/integration-testing/package.json
@@ -41,5 +41,5 @@
     "lint-staged": "11.0.0",
     "sort-package-json": "^1.50.0"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/apps/design/backend/package.json
+++ b/apps/design/backend/package.json
@@ -94,5 +94,5 @@
   "engines": {
     "node": ">= 12"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/apps/design/frontend/package.json
+++ b/apps/design/frontend/package.json
@@ -109,7 +109,7 @@
     "ts-jest": "29.1.1",
     "vite": "4.5.0"
   },
-  "packageManager": "pnpm@8.1.0",
+  "packageManager": "pnpm@8.3.1",
   "vx": {
     "isBundled": true,
     "services": [

--- a/apps/mark-scan/backend/package.json
+++ b/apps/mark-scan/backend/package.json
@@ -98,5 +98,5 @@
   "engines": {
     "node": ">= 16"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/apps/mark-scan/frontend/package.json
+++ b/apps/mark-scan/frontend/package.json
@@ -130,7 +130,7 @@
   "engines": {
     "node": ">= 16"
   },
-  "packageManager": "pnpm@8.1.0",
+  "packageManager": "pnpm@8.3.1",
   "vx": {
     "env": {
       "VX_MACHINE_TYPE": "mark-scan"

--- a/apps/mark-scan/frontend/prodserver/package.json
+++ b/apps/mark-scan/frontend/prodserver/package.json
@@ -6,5 +6,5 @@
     "express": "4.18.2",
     "http-proxy-middleware": "1.0.6"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/apps/mark-scan/integration-testing/package.json
+++ b/apps/mark-scan/integration-testing/package.json
@@ -39,5 +39,5 @@
     "lint-staged": "11.0.0",
     "sort-package-json": "^1.50.0"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/apps/mark/backend/package.json
+++ b/apps/mark/backend/package.json
@@ -85,5 +85,5 @@
   "engines": {
     "node": ">= 16"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/apps/mark/frontend/package.json
+++ b/apps/mark/frontend/package.json
@@ -131,7 +131,7 @@
   "engines": {
     "node": ">= 16"
   },
-  "packageManager": "pnpm@8.1.0",
+  "packageManager": "pnpm@8.3.1",
   "vx": {
     "env": {
       "VX_MACHINE_TYPE": "mark"

--- a/apps/mark/frontend/prodserver/package.json
+++ b/apps/mark/frontend/prodserver/package.json
@@ -6,5 +6,5 @@
     "express": "4.18.2",
     "http-proxy-middleware": "1.0.6"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/apps/mark/integration-testing/package.json
+++ b/apps/mark/integration-testing/package.json
@@ -42,5 +42,5 @@
     "lint-staged": "11.0.0",
     "sort-package-json": "^1.50.0"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/apps/scan/backend/package.json
+++ b/apps/scan/backend/package.json
@@ -106,5 +106,5 @@
   "engines": {
     "node": ">= 12"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/apps/scan/frontend/package.json
+++ b/apps/scan/frontend/package.json
@@ -119,7 +119,7 @@
     "ts-jest": "29.1.1",
     "vite": "4.5.0"
   },
-  "packageManager": "pnpm@8.1.0",
+  "packageManager": "pnpm@8.3.1",
   "vx": {
     "env": {
       "VX_MACHINE_TYPE": "scan"

--- a/apps/scan/frontend/prodserver/package.json
+++ b/apps/scan/frontend/prodserver/package.json
@@ -6,5 +6,5 @@
     "express": "4.18.2",
     "http-proxy-middleware": "1.0.6"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/docs/exercises/package.json
+++ b/docs/exercises/package.json
@@ -42,5 +42,5 @@
     "sort-package-json": "^1.50.0",
     "ts-jest": "29.1.1"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/api/package.json
+++ b/libs/api/package.json
@@ -51,5 +51,5 @@
     "sort-package-json": "^1.50.0",
     "ts-jest": "29.1.1"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/auth/package.json
+++ b/libs/auth/package.json
@@ -72,5 +72,5 @@
     "ts-jest": "29.1.1",
     "wait-for-expect": "^3.0.2"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/backend/package.json
+++ b/libs/backend/package.json
@@ -90,5 +90,5 @@
     "sort-package-json": "^1.50.0",
     "ts-jest": "29.1.1"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/ballot-encoder/package.json
+++ b/libs/ballot-encoder/package.json
@@ -56,5 +56,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/ballot-interpreter/package.json
+++ b/libs/ballot-interpreter/package.json
@@ -80,5 +80,5 @@
     "sort-package-json": "^1.50.0",
     "ts-jest": "29.1.1"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/basics/package.json
+++ b/libs/basics/package.json
@@ -48,5 +48,5 @@
     "sort-package-json": "^1.50.0",
     "ts-jest": "29.1.1"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/cdf-schema-builder/package.json
+++ b/libs/cdf-schema-builder/package.json
@@ -60,5 +60,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/converter-nh-accuvote/package.json
+++ b/libs/converter-nh-accuvote/package.json
@@ -18,7 +18,7 @@
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch"
   },
-  "packageManager": "pnpm@8.1.0",
+  "packageManager": "pnpm@8.3.1",
   "dependencies": {
     "@votingworks/ballot-interpreter": "workspace:*",
     "@votingworks/basics": "workspace:*",

--- a/libs/custom-paper-handler/package.json
+++ b/libs/custom-paper-handler/package.json
@@ -47,5 +47,5 @@
     "jest-watch-typeahead": "^2.2.2",
     "ts-jest": "29.1.1"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/custom-scanner/package.json
+++ b/libs/custom-scanner/package.json
@@ -47,5 +47,5 @@
     "ts-jest": "29.1.1",
     "vite": "4.5.0"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/cvr-fixture-generator/package.json
+++ b/libs/cvr-fixture-generator/package.json
@@ -53,5 +53,5 @@
     "ts-jest": "29.1.1",
     "zod": "3.23.5"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/db/package.json
+++ b/libs/db/package.json
@@ -18,7 +18,7 @@
   },
   "author": "VotingWorks Eng <eng@voting.works>",
   "license": "GPL-3.0",
-  "packageManager": "pnpm@8.1.0",
+  "packageManager": "pnpm@8.3.1",
   "dependencies": {
     "@votingworks/basics": "workspace:*",
     "better-sqlite3": "8.2.0",

--- a/libs/dev-dock/backend/package.json
+++ b/libs/dev-dock/backend/package.json
@@ -57,5 +57,5 @@
     "sort-package-json": "^1.50.0",
     "ts-jest": "29.1.1"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/dev-dock/frontend/package.json
+++ b/libs/dev-dock/frontend/package.json
@@ -73,5 +73,5 @@
     "react": "18.3.1",
     "styled-components": "^5.3.11"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/eslint-plugin-vx/package.json
+++ b/libs/eslint-plugin-vx/package.json
@@ -23,7 +23,7 @@
     "test:coverage": "jest --coverage",
     "test:ci": "jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=6"
   },
-  "packageManager": "pnpm@8.1.0",
+  "packageManager": "pnpm@8.3.1",
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "6.7.0",
     "@typescript-eslint/utils": "6.7.0",

--- a/libs/fixtures/package.json
+++ b/libs/fixtures/package.json
@@ -55,5 +55,5 @@
     "sort-package-json": "^1.50.0",
     "ts-jest": "29.1.1"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/fs/package.json
+++ b/libs/fs/package.json
@@ -62,5 +62,5 @@
     "tmp": "^0.2.1",
     "ts-jest": "29.1.1"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/fujitsu-thermal-printer/package.json
+++ b/libs/fujitsu-thermal-printer/package.json
@@ -41,5 +41,5 @@
     "jest-watch-typeahead": "^2.2.2",
     "ts-jest": "29.1.1"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/grout/package.json
+++ b/libs/grout/package.json
@@ -53,5 +53,5 @@
     "sort-package-json": "^1.50.0",
     "ts-jest": "29.1.1"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/grout/test-utils/package.json
+++ b/libs/grout/test-utils/package.json
@@ -49,5 +49,5 @@
   "peerDependencies": {
     "@votingworks/grout": "workspace:*"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/hmpb/package.json
+++ b/libs/hmpb/package.json
@@ -80,5 +80,5 @@
   "engines": {
     "node": ">= 12"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/image-utils/package.json
+++ b/libs/image-utils/package.json
@@ -17,7 +17,7 @@
   },
   "author": "VotingWorks Eng <eng@voting.works>",
   "license": "GPL-3.0",
-  "packageManager": "pnpm@8.1.0",
+  "packageManager": "pnpm@8.3.1",
   "dependencies": {
     "@votingworks/basics": "workspace:*",
     "@votingworks/fixtures": "workspace:*",

--- a/libs/logging/package.json
+++ b/libs/logging/package.json
@@ -69,5 +69,5 @@
     "sort-package-json": "^1.50.0",
     "ts-jest": "29.1.1"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/mark-flow-ui/package.json
+++ b/libs/mark-flow-ui/package.json
@@ -118,5 +118,5 @@
     "react-dom": "18.3.1",
     "styled-components": "^5.3.11"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/message-coder/package.json
+++ b/libs/message-coder/package.json
@@ -32,5 +32,5 @@
     "jest-watch-typeahead": "^2.2.2",
     "ts-jest": "29.1.1"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/monorepo-utils/package.json
+++ b/libs/monorepo-utils/package.json
@@ -58,5 +58,5 @@
     "ts-jest": "29.1.1",
     "typescript": "5.4.5"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/pdi-scanner/package.json
+++ b/libs/pdi-scanner/package.json
@@ -58,5 +58,5 @@
     "jest-watch-typeahead": "^2.2.2",
     "ts-jest": "29.1.1"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/printing/package.json
+++ b/libs/printing/package.json
@@ -71,5 +71,5 @@
     "sort-package-json": "^1.50.0",
     "ts-jest": "29.1.1"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/res-to-ts/package.json
+++ b/libs/res-to-ts/package.json
@@ -21,7 +21,7 @@
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch"
   },
-  "packageManager": "pnpm@8.1.0",
+  "packageManager": "pnpm@8.3.1",
   "dependencies": {
     "globby": "11",
     "js-sha256": "^0.9.0",

--- a/libs/test-utils/package.json
+++ b/libs/test-utils/package.json
@@ -62,5 +62,5 @@
     "sort-package-json": "^1.50.0",
     "ts-jest": "29.1.1"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/types-rs/package.json
+++ b/libs/types-rs/package.json
@@ -10,5 +10,5 @@
     "lint": "cargo clippy",
     "test": "cargo test"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -68,5 +68,5 @@
     "sort-package-json": "^1.50.0",
     "ts-jest": "29.1.1"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -145,5 +145,5 @@
     "react-dom": "18.3.1",
     "styled-components": "^5.3.11"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/usb-drive/package.json
+++ b/libs/usb-drive/package.json
@@ -55,5 +55,5 @@
     "sort-package-json": "^1.50.0",
     "ts-jest": "29.1.1"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -76,5 +76,5 @@
     "sort-package-json": "^1.50.0",
     "ts-jest": "29.1.1"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "package.json": "sort-package-json",
     "*.ts,*.md,*.json": "prettier --write"
   },
-  "packageManager": "pnpm@8.1.0",
+  "packageManager": "pnpm@8.3.1",
   "devDependencies": {
     "@storybook/addon-a11y": "^7.2.2",
     "@storybook/addon-actions": "^7.2.2",

--- a/script/package.json
+++ b/script/package.json
@@ -23,5 +23,5 @@
     "prettier": "3.0.3",
     "typescript": "5.4.5"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.3.1"
 }


### PR DESCRIPTION
Versions prior to this were incompatible with more recent versions of NodeJS: https://github.com/pnpm/pnpm/issues/6424

Refs https://github.com/votingworks/vxsuite-complete-system/pull/374
Refs https://github.com/votingworks/vxsuite/issues/4163