### PR TITLE
chore(deps): update `canvas` to v2.11.2

### DIFF
--- a/apps/admin/frontend/package.json
+++ b/apps/admin/frontend/package.json
@@ -66,7 +66,6 @@
     "base64-js": "1.5.1",
     "browserify-zlib": "^0.2.0",
     "buffer": "^6.0.3",
-    "canvas": "2.11.2",
     "debug": "4.3.4",
     "dompurify": "^2.0.12",
     "dotenv": "16.3.1",

--- a/apps/admin/frontend/package.json
+++ b/apps/admin/frontend/package.json
@@ -66,7 +66,7 @@
     "base64-js": "1.5.1",
     "browserify-zlib": "^0.2.0",
     "buffer": "^6.0.3",
-    "canvas": "2.9.1",
+    "canvas": "2.11.2",
     "debug": "4.3.4",
     "dompurify": "^2.0.12",
     "dotenv": "16.3.1",

--- a/apps/central-scan/backend/package.json
+++ b/apps/central-scan/backend/package.json
@@ -55,7 +55,7 @@
     "@votingworks/usb-drive": "workspace:*",
     "@votingworks/utils": "workspace:*",
     "buffer": "^6.0.3",
-    "canvas": "2.9.1",
+    "canvas": "2.11.2",
     "debug": "4.3.4",
     "express": "4.18.2",
     "fs-extra": "11.1.1",

--- a/apps/mark-scan/backend/package.json
+++ b/apps/mark-scan/backend/package.json
@@ -53,7 +53,7 @@
     "@votingworks/ui": "workspace:*",
     "@votingworks/usb-drive": "workspace:*",
     "@votingworks/utils": "workspace:*",
-    "canvas": "2.9.1",
+    "canvas": "2.11.2",
     "debug": "4.3.4",
     "express": "4.18.2",
     "fs-extra": "11.1.1",

--- a/apps/mark-scan/frontend/package.json
+++ b/apps/mark-scan/frontend/package.json
@@ -62,7 +62,6 @@
     "@votingworks/utils": "workspace:*",
     "abortcontroller-polyfill": "^1.4.0",
     "buffer": "^6.0.3",
-    "canvas": "2.11.2",
     "debug": "4.3.4",
     "dotenv": "16.3.1",
     "dotenv-expand": "9.0.0",

--- a/apps/mark-scan/frontend/package.json
+++ b/apps/mark-scan/frontend/package.json
@@ -62,7 +62,7 @@
     "@votingworks/utils": "workspace:*",
     "abortcontroller-polyfill": "^1.4.0",
     "buffer": "^6.0.3",
-    "canvas": "2.9.1",
+    "canvas": "2.11.2",
     "debug": "4.3.4",
     "dotenv": "16.3.1",
     "dotenv-expand": "9.0.0",

--- a/apps/scan/backend/package.json
+++ b/apps/scan/backend/package.json
@@ -58,7 +58,7 @@
     "@votingworks/usb-drive": "workspace:*",
     "@votingworks/utils": "workspace:*",
     "buffer": "^6.0.3",
-    "canvas": "2.9.1",
+    "canvas": "2.11.2",
     "debug": "4.3.4",
     "express": "4.18.2",
     "fs-extra": "11.1.1",

--- a/apps/scan/backend/test/helpers/custom_helpers.ts
+++ b/apps/scan/backend/test/helpers/custom_helpers.ts
@@ -19,7 +19,11 @@ import {
   sampleBallotImages,
 } from '@votingworks/fixtures';
 import * as grout from '@votingworks/grout';
-import { RGBA_CHANNEL_COUNT, isRgba } from '@votingworks/image-utils';
+import {
+  ImageData,
+  RGBA_CHANNEL_COUNT,
+  isRgba,
+} from '@votingworks/image-utils';
 import { Logger } from '@votingworks/logging';
 import { SheetOf, mapSheet } from '@votingworks/types';
 import { Application } from 'express';

--- a/apps/scan/backend/test/helpers/pdi_helpers.ts
+++ b/apps/scan/backend/test/helpers/pdi_helpers.ts
@@ -1,3 +1,4 @@
+import { ImageData } from '@votingworks/image-utils';
 import * as grout from '@votingworks/grout';
 import * as tmp from 'tmp';
 import { Application } from 'express';

--- a/libs/ballot-interpreter/package.json
+++ b/libs/ballot-interpreter/package.json
@@ -49,7 +49,7 @@
     "@votingworks/types": "workspace:*",
     "@votingworks/utils": "workspace:*",
     "better-sqlite3": "8.2.0",
-    "canvas": "2.9.1",
+    "canvas": "2.11.2",
     "chalk": "4.1.2",
     "debug": "4.3.4",
     "node-quirc": "^2.2.1",

--- a/libs/ballot-interpreter/src/bmd/interpret.test.ts
+++ b/libs/ballot-interpreter/src/bmd/interpret.test.ts
@@ -1,3 +1,4 @@
+import { ImageData } from 'canvas';
 import {
   electionFamousNames2021Fixtures,
   electionGridLayoutNewHampshireTestBallotFixtures,

--- a/libs/ballot-interpreter/src/bmd/interpret.ts
+++ b/libs/ballot-interpreter/src/bmd/interpret.ts
@@ -1,3 +1,4 @@
+import { ImageData } from 'canvas';
 import { Result, err, ok } from '@votingworks/basics';
 import {
   CompletedBallot,

--- a/libs/ballot-interpreter/src/bmd/utils/luminosity.ts
+++ b/libs/ballot-interpreter/src/bmd/utils/luminosity.ts
@@ -1,3 +1,4 @@
+import { ImageData } from 'canvas';
 import { assertDefined } from '@votingworks/basics';
 import { Rect } from '@votingworks/types';
 import makeDebug from 'debug';

--- a/libs/ballot-interpreter/src/bmd/utils/qrcode.ts
+++ b/libs/ballot-interpreter/src/bmd/utils/qrcode.ts
@@ -4,7 +4,7 @@ import {
   detectRawBytesBmdBallot as detectMetadata,
   isVxBallot,
 } from '@votingworks/ballot-encoder';
-import { crop } from '@votingworks/image-utils';
+import { ImageData, crop } from '@votingworks/image-utils';
 import { Rect, Size } from '@votingworks/types';
 import { Buffer } from 'buffer';
 import makeDebug from 'debug';
@@ -178,7 +178,7 @@ export async function detect(
     {
       name: 'quirc',
       detect: async (croppedImage: ImageData): Promise<Buffer[]> => {
-        const results = await quircDecode(croppedImage);
+        const results = await quircDecode(croppedImage as globalThis.ImageData);
         return results
           .filter((result): result is QRCode => !('err' in result))
           .map((result) => result.data);

--- a/libs/ballot-interpreter/src/hmpb-ts/debug.test.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/debug.test.ts
@@ -1,3 +1,4 @@
+import { ImageData } from 'canvas';
 import { electionGridLayoutNewHampshireTestBallotFixtures } from '@votingworks/fixtures';
 import { interpret as interpretImpl } from './rust_addon';
 import { interpret } from './interpret';

--- a/libs/ballot-interpreter/src/hmpb-ts/find_template_grid_and_bubbles.test.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/find_template_grid_and_bubbles.test.ts
@@ -1,3 +1,4 @@
+import { ImageData } from 'canvas';
 import { err, typedAs } from '@votingworks/basics';
 import {
   electionGridLayoutNewHampshireTestBallotFixtures,

--- a/libs/ballot-interpreter/src/hmpb-ts/find_template_grid_and_bubbles.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/find_template_grid_and_bubbles.ts
@@ -1,3 +1,4 @@
+import { ImageData } from 'canvas';
 import { Result, err, ok } from '@votingworks/basics';
 import { SheetOf } from '@votingworks/types';
 import { findTemplateGridAndBubbles as findTemplateGridAndBubblesImpl } from './rust_addon';

--- a/libs/ballot-interpreter/src/hmpb-ts/interpret.test.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/interpret.test.ts
@@ -1,4 +1,5 @@
 import { assertDefined, iter, ok, unique } from '@votingworks/basics';
+import { ImageData } from 'canvas';
 import { electionGridLayoutNewHampshireTestBallotFixtures } from '@votingworks/fixtures';
 import { Election, ElectionDefinition, SheetOf } from '@votingworks/types';
 import { interpret } from './interpret';

--- a/libs/ballot-interpreter/src/hmpb-ts/interpret.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/interpret.ts
@@ -1,4 +1,5 @@
 import { assert, err, ok } from '@votingworks/basics';
+import { ImageData } from 'canvas';
 import { ElectionDefinition, safeParseJson, SheetOf } from '@votingworks/types';
 import { interpret as interpretImpl } from './rust_addon';
 import {

--- a/libs/ballot-interpreter/src/hmpb-ts/rust_addon.d.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/rust_addon.d.ts
@@ -1,4 +1,5 @@
 import { Election } from '@votingworks/types';
+import { ImageData } from 'canvas';
 import { type TemplateGridAndBubbles } from './find_template_grid_and_bubbles';
 
 /**

--- a/libs/ballot-interpreter/src/hmpb-ts/scoring_report.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/scoring_report.ts
@@ -6,9 +6,9 @@ import {
   safeParseElectionDefinition,
 } from '@votingworks/types';
 import { mkdir, readFile, readdir } from 'fs/promises';
-import { writeImageData } from '@votingworks/image-utils';
+import { ImageData, writeImageData } from '@votingworks/image-utils';
 import { basename, join } from 'path';
-import { createCanvas } from 'canvas';
+import { CanvasRenderingContext2D, createCanvas } from 'canvas';
 import { interpret } from './interpret';
 import { InterpretedBallotPage } from './types';
 

--- a/libs/ballot-interpreter/src/hmpb-ts/types.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/types.ts
@@ -1,3 +1,4 @@
+import { ImageData } from 'canvas';
 import {
   BallotPaperSize,
   GridPosition,

--- a/libs/ballot-interpreter/src/save_images.ts
+++ b/libs/ballot-interpreter/src/save_images.ts
@@ -1,4 +1,4 @@
-import { writeImageData } from '@votingworks/image-utils';
+import { ImageData, writeImageData } from '@votingworks/image-utils';
 import { Side } from '@votingworks/types';
 import { join, parse } from 'path';
 

--- a/libs/converter-nh-accuvote/package.json
+++ b/libs/converter-nh-accuvote/package.json
@@ -27,7 +27,7 @@
     "@votingworks/utils": "workspace:*",
     "@xmldom/xmldom": "^0.8.4",
     "buffer": "^6.0.3",
-    "canvas": "2.9.1",
+    "canvas": "2.11.2",
     "chalk": "4.1.2",
     "debug": "4.3.4",
     "he": "^1.2.0",

--- a/libs/converter-nh-accuvote/src/convert/types.ts
+++ b/libs/converter-nh-accuvote/src/convert/types.ts
@@ -1,3 +1,4 @@
+import { ImageData } from 'canvas';
 import { Result } from '@votingworks/basics';
 import {
   BallotPaperSize,

--- a/libs/converter-nh-accuvote/test/fixtures/index.ts
+++ b/libs/converter-nh-accuvote/test/fixtures/index.ts
@@ -1,3 +1,4 @@
+import { ImageData } from 'canvas';
 import { DOMParser } from '@xmldom/xmldom';
 import { NewHampshireBallotCardDefinition } from '../../src/convert/types';
 

--- a/libs/custom-paper-handler/src/cli/driver_cli.ts
+++ b/libs/custom-paper-handler/src/cli/driver_cli.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 import { createInterface } from 'readline';
-import { pdfToImages } from '@votingworks/image-utils';
+import { ImageData, pdfToImages } from '@votingworks/image-utils';
 import { Buffer } from 'buffer';
 import { assert, iter, sleep } from '@votingworks/basics';
 import { exit } from 'process';

--- a/libs/custom-paper-handler/src/driver/driver.ts
+++ b/libs/custom-paper-handler/src/driver/driver.ts
@@ -13,7 +13,11 @@ import {
   message,
   oneOf,
 } from '@votingworks/message-coder';
-import { createImageData, writeImageData } from '@votingworks/image-utils';
+import {
+  createImageData,
+  ImageData,
+  writeImageData,
+} from '@votingworks/image-utils';
 import {
   ImageColorDepthType,
   ImageFileFormat,

--- a/libs/custom-paper-handler/src/driver/driver_interface.ts
+++ b/libs/custom-paper-handler/src/driver/driver_interface.ts
@@ -1,6 +1,7 @@
 import { Coder, CoderError, Uint16, Uint8 } from '@votingworks/message-coder';
 import { Result } from '@votingworks/basics';
 import { ImageFromScanner } from '@votingworks/custom-scanner';
+import { ImageData } from '@votingworks/image-utils';
 import { MinimalWebUsbDevice } from './minimal_web_usb_device';
 import { Lock } from './lock';
 import {

--- a/libs/custom-paper-handler/src/printing.ts
+++ b/libs/custom-paper-handler/src/printing.ts
@@ -1,5 +1,6 @@
 import { assert, iter } from '@votingworks/basics';
 import { BITS_PER_BYTE } from '@votingworks/message-coder';
+import { ImageData } from '@votingworks/image-utils';
 import { BitArray, bitArrayToByte, Uint8Max } from './bits';
 import { DEVICE_MAX_WIDTH_DOTS } from './driver/constants';
 import { PaperHandlerBitmap } from './driver/coders';

--- a/libs/fixtures/package.json
+++ b/libs/fixtures/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@votingworks/types": "workspace:*",
     "buffer": "^6.0.3",
-    "canvas": "2.9.1",
+    "canvas": "2.11.2",
     "csv-writer": "^1.6.0",
     "js-sha256": "^0.9.0"
   },

--- a/libs/fujitsu-thermal-printer/src/printing.ts
+++ b/libs/fujitsu-thermal-printer/src/printing.ts
@@ -1,5 +1,5 @@
 import { IteratorPlus, Result, assert, iter, ok } from '@votingworks/basics';
-import { pdfToImages } from '@votingworks/image-utils';
+import { ImageData, pdfToImages } from '@votingworks/image-utils';
 import { BITS_PER_BYTE } from '@votingworks/message-coder';
 import { readFileSync } from 'fs';
 import { Buffer } from 'buffer';
@@ -176,11 +176,11 @@ export function imageDataToBinaryBitmap(
   const data: boolean[] = [];
 
   for (let i = 0; i < imageData.data.length; i += 4) {
-    const r = imageData.data[i];
-    const g = imageData.data[i + 1];
-    const b = imageData.data[i + 2];
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    data.push(rgbToBinary(r!, g!, b!, options));
+    const r = imageData.data[i] as number;
+    const g = imageData.data[i + 1] as number;
+    const b = imageData.data[i + 2] as number;
+
+    data.push(rgbToBinary(r, g, b, options));
   }
 
   return {

--- a/libs/hmpb/tsconfig.json
+++ b/libs/hmpb/tsconfig.json
@@ -8,7 +8,7 @@
     "composite": true,
     "jsx": "react-jsx",
     "esModuleInterop": true,
-    "lib": ["esnext"],
+    "lib": ["esnext", "dom"],
     "module": "node16",
     "moduleResolution": "node16",
     "noEmit": true,

--- a/libs/image-utils/package.json
+++ b/libs/image-utils/package.json
@@ -23,7 +23,7 @@
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/types": "workspace:*",
     "@votingworks/utils": "workspace:*",
-    "canvas": "2.9.1",
+    "canvas": "2.11.2",
     "debug": "4.3.4",
     "pdfjs-dist": "2.3.200",
     "tmp": "^0.2.1"

--- a/libs/image-utils/src/image_data.test.ts
+++ b/libs/image-utils/src/image_data.test.ts
@@ -188,7 +188,6 @@ test('ensureImageData', () => {
     width: 1,
     height: 1,
     data: Uint8ClampedArray.of(0),
-    colorSpace: 'srgb',
   };
   expect(ensureImageData(imageDataLike) === imageDataLike).toBeFalsy();
   expect(ensureImageData(imageDataLike)).toBeInstanceOf(ImageData);

--- a/libs/image-utils/src/index.ts
+++ b/libs/image-utils/src/index.ts
@@ -4,4 +4,4 @@ export * from './image_data';
 export * from './pdf_to_images';
 export * from './jest_pdf_snapshot';
 export * from './types';
-export { createImageData } from 'canvas';
+export { createImageData, ImageData } from 'canvas';

--- a/libs/image-utils/src/pdf_to_images.ts
+++ b/libs/image-utils/src/pdf_to_images.ts
@@ -1,6 +1,11 @@
 import { assert, assertDefined } from '@votingworks/basics';
 import { Buffer } from 'buffer';
-import { Canvas, createCanvas, ImageData } from 'canvas';
+import {
+  Canvas,
+  createCanvas,
+  ImageData,
+  CanvasRenderingContext2D,
+} from 'canvas';
 import { promises as fs } from 'fs';
 import { basename, dirname, extname, join } from 'path';
 import {
@@ -101,7 +106,7 @@ export async function* pdfToImages(
     canvas.height = viewport.height;
 
     await page.render({
-      canvasContext: context,
+      canvasContext: context as unknown as globalThis.CanvasRenderingContext2D,
       viewport,
       canvasFactory: buildCanvasFactory(),
     }).promise;

--- a/libs/pdi-scanner/src/ts/scanner_client.ts
+++ b/libs/pdi-scanner/src/ts/scanner_client.ts
@@ -10,7 +10,11 @@ import {
   ok,
   throwIllegalValue,
 } from '@votingworks/basics';
-import { createImageData, fromGrayScale } from '@votingworks/image-utils';
+import {
+  ImageData,
+  createImageData,
+  fromGrayScale,
+} from '@votingworks/image-utils';
 import { Buffer } from 'buffer';
 import { SheetOf, mapSheet } from '@votingworks/types';
 import makeDebug from 'debug';
@@ -87,7 +91,10 @@ export type ScannerError =
 export type ScannerEvent =
   | ({ event: 'error' } & ScannerError)
   | { event: 'scanStart' }
-  | { event: 'scanComplete'; images: SheetOf<ImageData> }
+  | {
+      event: 'scanComplete';
+      images: SheetOf<ImageData>;
+    }
   | { event: 'coverOpen' }
   | { event: 'coverClosed' }
   | { event: 'ejectPaused' }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -374,8 +374,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       canvas:
-        specifier: 2.9.1
-        version: 2.9.1
+        specifier: 2.11.2
+        version: 2.11.2
       debug:
         specifier: 4.3.4
         version: 4.3.4(supports-color@5.5.0)
@@ -414,7 +414,7 @@ importers:
         version: 0.9.0
       jsdom:
         specifier: 20.0.1
-        version: 20.0.1(canvas@2.9.1)
+        version: 20.0.1(canvas@2.11.2)
       luxon:
         specifier: ^3.0.0
         version: 3.3.0
@@ -595,7 +595,7 @@ importers:
         version: 29.6.2(@types/node@16.18.23)
       jest-environment-jsdom:
         specifier: ^29.6.2
-        version: 29.6.2(canvas@2.9.1)
+        version: 29.6.2(canvas@2.11.2)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -745,8 +745,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       canvas:
-        specifier: 2.9.1
-        version: 2.9.1
+        specifier: 2.11.2
+        version: 2.11.2
       debug:
         specifier: 4.3.4
         version: 4.3.4(supports-color@5.5.0)
@@ -1039,7 +1039,7 @@ importers:
         version: 29.6.2(@types/node@16.18.23)
       jest-environment-jsdom:
         specifier: ^29.6.2
-        version: 29.6.2(canvas@2.9.1)
+        version: 29.6.2(canvas@2.11.2)
       jest-fetch-mock:
         specifier: ^3.0.3
         version: 3.0.3
@@ -1435,7 +1435,7 @@ importers:
         version: 29.6.2(@types/node@16.18.23)
       jest-environment-jsdom:
         specifier: ^29.6.2
-        version: 29.6.2(canvas@2.9.1)
+        version: 29.6.2(canvas@2.11.2)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -1527,8 +1527,8 @@ importers:
         specifier: workspace:*
         version: link:../../../libs/utils
       canvas:
-        specifier: 2.9.1
-        version: 2.9.1
+        specifier: 2.11.2
+        version: 2.11.2
       debug:
         specifier: 4.3.4
         version: 4.3.4(supports-color@5.5.0)
@@ -1687,8 +1687,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       canvas:
-        specifier: 2.9.1
-        version: 2.9.1
+        specifier: 2.11.2
+        version: 2.11.2
       debug:
         specifier: 4.3.4
         version: 4.3.4(supports-color@5.5.0)
@@ -1842,7 +1842,7 @@ importers:
         version: 29.6.2(@types/node@16.18.23)
       jest-environment-jsdom:
         specifier: ^29.6.2
-        version: 29.6.2(canvas@2.9.1)
+        version: 29.6.2(canvas@2.11.2)
       jest-fetch-mock:
         specifier: ^3.0.3
         version: 3.0.3
@@ -2256,7 +2256,7 @@ importers:
         version: 29.6.2(@types/node@16.18.23)
       jest-environment-jsdom:
         specifier: ^29.6.2
-        version: 29.6.2(canvas@2.9.1)
+        version: 29.6.2(canvas@2.11.2)
       jest-fetch-mock:
         specifier: ^3.0.3
         version: 3.0.3
@@ -2406,8 +2406,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       canvas:
-        specifier: 2.9.1
-        version: 2.9.1
+        specifier: 2.11.2
+        version: 2.11.2
       debug:
         specifier: 4.3.4
         version: 4.3.4(supports-color@5.5.0)
@@ -2706,7 +2706,7 @@ importers:
         version: 29.6.2(@types/node@16.18.23)
       jest-environment-jsdom:
         specifier: ^29.6.2
-        version: 29.6.2(canvas@2.9.1)
+        version: 29.6.2(canvas@2.11.2)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -3217,8 +3217,8 @@ importers:
         specifier: 8.2.0
         version: 8.2.0
       canvas:
-        specifier: 2.9.1
-        version: 2.9.1
+        specifier: 2.11.2
+        version: 2.11.2
       chalk:
         specifier: 4.1.2
         version: 4.1.2
@@ -3358,7 +3358,7 @@ importers:
         version: link:../basics
       jsdom:
         specifier: 20.0.1
-        version: 20.0.1(canvas@2.9.1)
+        version: 20.0.1(canvas@2.11.2)
       json-schema:
         specifier: ^0.4.0
         version: 0.4.0
@@ -3427,8 +3427,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       canvas:
-        specifier: 2.9.1
-        version: 2.9.1
+        specifier: 2.11.2
+        version: 2.11.2
       chalk:
         specifier: 4.1.2
         version: 4.1.2
@@ -3443,7 +3443,7 @@ importers:
         version: 0.9.0
       jsdom:
         specifier: 20.0.1
-        version: 20.0.1(canvas@2.9.1)
+        version: 20.0.1(canvas@2.11.2)
       luxon:
         specifier: ^3.0.0
         version: 3.3.0
@@ -3960,7 +3960,7 @@ importers:
         version: 29.6.2(@types/node@16.18.23)
       jest-environment-jsdom:
         specifier: ^29.6.2
-        version: 29.6.2(canvas@2.9.1)
+        version: 29.6.2(canvas@2.11.2)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -4071,8 +4071,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       canvas:
-        specifier: 2.9.1
-        version: 2.9.1
+        specifier: 2.11.2
+        version: 2.11.2
       csv-writer:
         specifier: ^1.6.0
         version: 1.6.0
@@ -4491,8 +4491,8 @@ importers:
         specifier: workspace:*
         version: link:../utils
       canvas:
-        specifier: 2.9.1
-        version: 2.9.1
+        specifier: 2.11.2
+        version: 2.11.2
       debug:
         specifier: 4.3.4
         version: 4.3.4(supports-color@5.5.0)
@@ -4810,7 +4810,7 @@ importers:
         version: 29.6.2(@types/node@16.18.23)
       jest-environment-jsdom:
         specifier: ^29.6.2
-        version: 29.6.2(canvas@2.9.1)
+        version: 29.6.2(canvas@2.11.2)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -5248,7 +5248,7 @@ importers:
         version: 29.6.2(@types/node@16.18.23)
       jest-environment-jsdom:
         specifier: ^29.6.2
-        version: 29.6.2(canvas@2.9.1)
+        version: 29.6.2(canvas@2.11.2)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -5582,7 +5582,7 @@ importers:
         version: 29.6.2(@types/node@16.18.23)
       jest-environment-jsdom:
         specifier: ^29.6.2
-        version: 29.6.2(canvas@2.9.1)
+        version: 29.6.2(canvas@2.11.2)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -5797,7 +5797,7 @@ importers:
         version: 29.6.2(@types/node@16.18.23)
       jest-environment-jsdom:
         specifier: ^29.6.2
-        version: 29.6.2(canvas@2.9.1)
+        version: 29.6.2(canvas@2.11.2)
       jest-fetch-mock:
         specifier: ^3.0.3
         version: 3.0.3
@@ -11710,6 +11710,7 @@ packages:
   /are-we-there-yet@2.0.0:
     resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==}
     engines: {node: '>=10'}
+    deprecated: This package is no longer supported.
     dependencies:
       delegates: 1.0.0
       readable-stream: 3.6.2
@@ -12496,20 +12497,6 @@ packages:
 
   /canvas@2.11.2:
     resolution: {integrity: sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==}
-    engines: {node: '>=6'}
-    requiresBuild: true
-    dependencies:
-      '@mapbox/node-pre-gyp': 1.0.9
-      nan: 2.17.0
-      simple-get: 3.1.1
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-    optional: true
-
-  /canvas@2.9.1:
-    resolution: {integrity: sha512-vSQti1uG/2gjv3x6QLOZw7TctfufaerTWbVe+NSduHxxLGB+qf3kFgQ6n66DSnuoINtVUjrLLIK2R+lxrBG07A==}
     engines: {node: '>=6'}
     requiresBuild: true
     dependencies:
@@ -15107,6 +15094,7 @@ packages:
   /gauge@3.0.2:
     resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==}
     engines: {node: '>=10'}
+    deprecated: This package is no longer supported.
     dependencies:
       aproba: 2.0.0
       color-support: 1.1.3
@@ -15310,6 +15298,7 @@ packages:
 
   /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -16581,7 +16570,7 @@ packages:
       jest-util: 29.6.2
       pretty-format: 29.6.2
 
-  /jest-environment-jsdom@29.6.2(canvas@2.9.1):
+  /jest-environment-jsdom@29.6.2(canvas@2.11.2):
     resolution: {integrity: sha512-7oa/+266AAEgkzae8i1awNEfTfjwawWKLpiw2XesZmaoVVj9u9t8JOYx18cG29rbPNtkUlZ8V4b5Jb36y/VxoQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -16595,10 +16584,10 @@ packages:
       '@jest/types': 29.6.1
       '@types/jsdom': 20.0.1
       '@types/node': 16.18.23
-      canvas: 2.9.1
+      canvas: 2.11.2
       jest-mock: 29.6.2
       jest-util: 29.6.2
-      jsdom: 20.0.1(canvas@2.9.1)
+      jsdom: 20.0.1(canvas@2.11.2)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -17016,7 +17005,7 @@ packages:
       - supports-color
     dev: true
 
-  /jsdom@20.0.1(canvas@2.9.1):
+  /jsdom@20.0.1(canvas@2.11.2):
     resolution: {integrity: sha512-pksjj7Rqoa+wdpkKcLzQRHhJCEE42qQhl/xLMUKHgoSejaKOdaXEAnqs6uDNwMl/fciHTzKeR8Wm8cw7N+g98A==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -17028,7 +17017,7 @@ packages:
       abab: 2.0.6
       acorn: 8.10.0
       acorn-globals: 7.0.1
-      canvas: 2.9.1
+      canvas: 2.11.2
       cssom: 0.5.0
       cssstyle: 2.3.0
       data-urls: 3.0.2
@@ -18193,6 +18182,7 @@ packages:
 
   /npmlog@5.0.1:
     resolution: {integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==}
+    deprecated: This package is no longer supported.
     dependencies:
       are-we-there-yet: 2.0.0
       console-control-strings: 1.1.0
@@ -20016,6 +20006,7 @@ packages:
 
   /rimraf@2.6.3:
     resolution: {integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
     dependencies:
       glob: 7.2.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -373,9 +373,6 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
-      canvas:
-        specifier: 2.11.2
-        version: 2.11.2
       debug:
         specifier: 4.3.4
         version: 4.3.4(supports-color@5.5.0)
@@ -595,7 +592,7 @@ importers:
         version: 29.6.2(@types/node@16.18.23)
       jest-environment-jsdom:
         specifier: ^29.6.2
-        version: 29.6.2(canvas@2.11.2)
+        version: 29.6.2
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -1039,7 +1036,7 @@ importers:
         version: 29.6.2(@types/node@16.18.23)
       jest-environment-jsdom:
         specifier: ^29.6.2
-        version: 29.6.2(canvas@2.11.2)
+        version: 29.6.2
       jest-fetch-mock:
         specifier: ^3.0.3
         version: 3.0.3
@@ -1435,7 +1432,7 @@ importers:
         version: 29.6.2(@types/node@16.18.23)
       jest-environment-jsdom:
         specifier: ^29.6.2
-        version: 29.6.2(canvas@2.11.2)
+        version: 29.6.2
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -1686,9 +1683,6 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
-      canvas:
-        specifier: 2.11.2
-        version: 2.11.2
       debug:
         specifier: 4.3.4
         version: 4.3.4(supports-color@5.5.0)
@@ -1842,7 +1836,7 @@ importers:
         version: 29.6.2(@types/node@16.18.23)
       jest-environment-jsdom:
         specifier: ^29.6.2
-        version: 29.6.2(canvas@2.11.2)
+        version: 29.6.2
       jest-fetch-mock:
         specifier: ^3.0.3
         version: 3.0.3
@@ -2256,7 +2250,7 @@ importers:
         version: 29.6.2(@types/node@16.18.23)
       jest-environment-jsdom:
         specifier: ^29.6.2
-        version: 29.6.2(canvas@2.11.2)
+        version: 29.6.2
       jest-fetch-mock:
         specifier: ^3.0.3
         version: 3.0.3
@@ -2706,7 +2700,7 @@ importers:
         version: 29.6.2(@types/node@16.18.23)
       jest-environment-jsdom:
         specifier: ^29.6.2
-        version: 29.6.2(canvas@2.11.2)
+        version: 29.6.2
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -3960,7 +3954,7 @@ importers:
         version: 29.6.2(@types/node@16.18.23)
       jest-environment-jsdom:
         specifier: ^29.6.2
-        version: 29.6.2(canvas@2.11.2)
+        version: 29.6.2
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -4810,7 +4804,7 @@ importers:
         version: 29.6.2(@types/node@16.18.23)
       jest-environment-jsdom:
         specifier: ^29.6.2
-        version: 29.6.2(canvas@2.11.2)
+        version: 29.6.2
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -5248,7 +5242,7 @@ importers:
         version: 29.6.2(@types/node@16.18.23)
       jest-environment-jsdom:
         specifier: ^29.6.2
-        version: 29.6.2(canvas@2.11.2)
+        version: 29.6.2
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -5582,7 +5576,7 @@ importers:
         version: 29.6.2(@types/node@16.18.23)
       jest-environment-jsdom:
         specifier: ^29.6.2
-        version: 29.6.2(canvas@2.11.2)
+        version: 29.6.2
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -5797,7 +5791,7 @@ importers:
         version: 29.6.2(@types/node@16.18.23)
       jest-environment-jsdom:
         specifier: ^29.6.2
-        version: 29.6.2(canvas@2.11.2)
+        version: 29.6.2
       jest-fetch-mock:
         specifier: ^3.0.3
         version: 3.0.3
@@ -16570,7 +16564,7 @@ packages:
       jest-util: 29.6.2
       pretty-format: 29.6.2
 
-  /jest-environment-jsdom@29.6.2(canvas@2.11.2):
+  /jest-environment-jsdom@29.6.2:
     resolution: {integrity: sha512-7oa/+266AAEgkzae8i1awNEfTfjwawWKLpiw2XesZmaoVVj9u9t8JOYx18cG29rbPNtkUlZ8V4b5Jb36y/VxoQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -16584,7 +16578,6 @@ packages:
       '@jest/types': 29.6.1
       '@types/jsdom': 20.0.1
       '@types/node': 16.18.23
-      canvas: 2.11.2
       jest-mock: 29.6.2
       jest-util: 29.6.2
       jsdom: 20.0.1(canvas@2.11.2)


### PR DESCRIPTION
## Overview

Refs https://github.com/votingworks/vxsuite/issues/4163

v2.9.1 is incompatible with NodeJS v20. Also, v2.11.2 is incompatible with NodeJS v22, but that's a problem for future us.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated tests, plus I tested manually building an image using `createCanvas` and it worked:

![test](https://github.com/votingworks/vxsuite/assets/1938/7a0a8db3-71e1-40a4-b211-7baf9c545c67)

```js
const canvas = require("canvas").createCanvas(100, 100);
const ctx = canvas.getContext("2d");
ctx.fillStyle = "red";
ctx.fillRect(20, 20, 40, 40);
const png = canvas.toBuffer("image/png");
fs.writeFileSync("test.png", png);
```