### PR TITLE
increase chromium spin up timeout

### DIFF
--- a/apps/mark-scan/backend/src/app.diagnostics.test.ts
+++ b/apps/mark-scan/backend/src/app.diagnostics.test.ts
@@ -323,8 +323,8 @@ describe('paper handler diagnostic', () => {
 
     mockDriverStatus(getPaperParkedStatus());
     await waitForStatus('paper_handler_diagnostic.print_ballot_fixture');
-    // Chromium, used by print_ballot_fixture, needs ~150ms to spin up
-    await waitForStatus('paper_handler_diagnostic.scan_ballot', 150);
+    // Chromium, used by print_ballot_fixture, needs some time to spin up
+    await waitForStatus('paper_handler_diagnostic.scan_ballot', 300);
 
     mockScanResult.resolve(scannedPath);
     await waitForStatus('paper_handler_diagnostic.interpret_ballot');


### PR DESCRIPTION
## Overview
Increases the time to wait for chromium to spin up when rendering a ballot for the paper handler diagnostic. Hopefully addresses flaky tests.

## Demo Video or Screenshot
N/A

## Testing Plan
N/A

