### PR TITLE
apps/scan/backend: Increase maxWorkers to match other tests

### DIFF
--- a/apps/scan/backend/package.json
+++ b/apps/scan/backend/package.json
@@ -19,7 +19,7 @@
     "pre-commit": "lint-staged",
     "start": "node ./build/index.js",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "TZ=America/Anchorage jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=2 # VxScan backend tests (which involve lots of polling and I/O operations) get flaky when we set --maxWorkers higher",
+    "test:ci": "TZ=America/Anchorage jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:coverage": "TZ=America/Anchorage jest --coverage",
     "test:debug": "TZ=America/Anchorage node --inspect-brk $(which jest) --runInBand --no-cache",
     "test:watch": "TZ=America/Anchorage jest --watch",


### PR DESCRIPTION
## Overview

We had previously limited `maxWorkers` to 2 to prevent flakiness, but I think now it may actually be causing flakiness. I don't have a good understanding of why, but there are a lot of tests that seem to be timing out on CI, which makes me think that maybe they are running much more slowly than we expect. I wouldn't necessarily expect increasing the number of workers to help with that, but maybe the machine is somehow getting bogged down by not leveraging all of its cores?

## Demo Video or Screenshot
N/A

## Testing Plan
I reran the tests in CI on this branch 10 times and the apps/scan/backend tests passed every time (and executed faster than they used to)

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
