### PR TITLE
test: remove unnecessary `href = '/';`

### DIFF
--- a/apps/mark-scan/frontend/src/app_states.test.tsx
+++ b/apps/mark-scan/frontend/src/app_states.test.tsx
@@ -22,7 +22,6 @@ let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
-  window.location.href = '/';
   apiMock = createApiMock();
 
   apiMock.expectGetMachineConfig();

--- a/apps/mark/frontend/src/apimachine_config.test.tsx
+++ b/apps/mark/frontend/src/apimachine_config.test.tsx
@@ -8,7 +8,6 @@ let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
-  window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
 });

--- a/apps/mark/frontend/src/app_card_unhappy_paths.test.tsx
+++ b/apps/mark/frontend/src/app_card_unhappy_paths.test.tsx
@@ -10,7 +10,6 @@ let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
-  window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
 });

--- a/apps/mark/frontend/src/app_cardless_voting.test.tsx
+++ b/apps/mark/frontend/src/app_cardless_voting.test.tsx
@@ -18,7 +18,6 @@ let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
-  window.location.href = '/';
   apiMock = createApiMock();
 });
 

--- a/apps/mark/frontend/src/app_contest_candidate_no_party.test.tsx
+++ b/apps/mark/frontend/src/app_contest_candidate_no_party.test.tsx
@@ -36,7 +36,6 @@ const electionWithNoPartyCandidateContests: Election = {
 
 beforeEach(() => {
   jest.useFakeTimers();
-  window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
   apiMock.expectGetElectionDefinition(

--- a/apps/mark/frontend/src/app_contest_ms_either_neither.test.tsx
+++ b/apps/mark/frontend/src/app_contest_ms_either_neither.test.tsx
@@ -21,7 +21,6 @@ let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
-  window.location.href = '/';
   apiMock = createApiMock();
 });
 

--- a/apps/mark/frontend/src/app_contest_multi_seat.test.tsx
+++ b/apps/mark/frontend/src/app_contest_multi_seat.test.tsx
@@ -19,7 +19,6 @@ let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
-  window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
 });

--- a/apps/mark/frontend/src/app_contest_single_seat.test.tsx
+++ b/apps/mark/frontend/src/app_contest_single_seat.test.tsx
@@ -20,7 +20,6 @@ let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
-  window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
 });

--- a/apps/mark/frontend/src/app_contest_write_in.test.tsx
+++ b/apps/mark/frontend/src/app_contest_write_in.test.tsx
@@ -60,7 +60,6 @@ function setUpMockContestPage() {
 
 beforeEach(() => {
   jest.useFakeTimers();
-  window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
   setUpMockContestPage();

--- a/apps/mark/frontend/src/app_contest_yes_no.test.tsx
+++ b/apps/mark/frontend/src/app_contest_yes_no.test.tsx
@@ -26,7 +26,6 @@ let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
-  window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
 });

--- a/apps/mark/frontend/src/app_election_package_config.test.tsx
+++ b/apps/mark/frontend/src/app_election_package_config.test.tsx
@@ -9,7 +9,6 @@ let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
-  window.location.href = '/';
   apiMock = createApiMock();
 });
 

--- a/apps/mark/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark/frontend/src/app_end_to_end.test.tsx
@@ -29,7 +29,6 @@ let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
-  window.location.href = '/';
   apiMock = createApiMock();
 });
 

--- a/apps/mark/frontend/src/app_polls_flows.test.tsx
+++ b/apps/mark/frontend/src/app_polls_flows.test.tsx
@@ -10,7 +10,6 @@ let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
-  window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetSystemSettings();

--- a/apps/mark/frontend/src/app_quit_on_idle.test.tsx
+++ b/apps/mark/frontend/src/app_quit_on_idle.test.tsx
@@ -21,7 +21,6 @@ let apiMock: ApiMock;
 jest.useFakeTimers();
 beforeEach(() => {
   createReactIdleTimerMocks();
-  window.location.href = '/';
   window.kiosk = mockKiosk();
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();

--- a/apps/mark/frontend/src/app_replace_election.test.tsx
+++ b/apps/mark/frontend/src/app_replace_election.test.tsx
@@ -13,7 +13,6 @@ let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
-  window.location.href = '/';
   apiMock = createApiMock();
 });
 

--- a/apps/mark/frontend/src/app_setup_errors.test.tsx
+++ b/apps/mark/frontend/src/app_setup_errors.test.tsx
@@ -21,7 +21,6 @@ let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
-  window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
 });

--- a/apps/mark/frontend/src/app_test_mode.test.tsx
+++ b/apps/mark/frontend/src/app_test_mode.test.tsx
@@ -14,7 +14,6 @@ let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
-  window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
 });

--- a/apps/mark/frontend/src/lib/gamepad.test.tsx
+++ b/apps/mark/frontend/src/lib/gamepad.test.tsx
@@ -36,7 +36,6 @@ let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers();
-  window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
 });

--- a/apps/mark/frontend/src/pages/admin_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.test.tsx
@@ -26,7 +26,6 @@ let apiMock: ApiMock;
 
 beforeEach(() => {
   jest.useFakeTimers().setSystemTime(new Date('2020-10-31T00:00:00.000'));
-  window.location.href = '/';
   apiMock = createApiMock();
 });
 

--- a/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
@@ -31,7 +31,6 @@ let apiMock: ApiMock;
 jest.useFakeTimers();
 
 beforeEach(() => {
-  window.location.href = '/';
   window.kiosk = mockKiosk();
   apiMock = createApiMock();
   apiMock.expectGetPollsInfo();

--- a/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
@@ -33,7 +33,6 @@ jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
 
 beforeEach(() => {
   featureFlagMock.resetFeatureFlags();
-  window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetConfig();


### PR DESCRIPTION
Most of our apps don't use URL routing (except `admin`), so this is useless and produces JSDOM warnings:

```
  console.error
    Error: Not implemented: navigation (except hash changes)
        at module.exports (/home/parallels/code/vxsuite/node_modules/.pnpm/jsdom@20.0.1_canvas@2.11.2/node_modules/jsdom/lib/jsdom/browser/not-implemented.js:9:17)
        at navigateFetch (/home/parallels/code/vxsuite/node_modules/.pnpm/jsdom@20.0.1_canvas@2.11.2/node_modules/jsdom/lib/jsdom/living/window/navigation.js:77:3)
        at exports.navigate (/home/parallels/code/vxsuite/node_modules/.pnpm/jsdom@20.0.1_canvas@2.11.2/node_modules/jsdom/lib/jsdom/living/window/navigation.js:55:3)
        at LocationImpl._locationObjectNavigate (/home/parallels/code/vxsuite/node_modules/.pnpm/jsdom@20.0.1_canvas@2.11.2/node_modules/jsdom/lib/jsdom/living/window/Location-impl.js:31:5)
        at LocationImpl._locationObjectSetterNavigate (/home/parallels/code/vxsuite/node_modules/.pnpm/jsdom@20.0.1_canvas@2.11.2/node_modules/jsdom/lib/jsdom/living/window/Location-impl.js:25:17)
        at LocationImpl.set href [as href] (/home/parallels/code/vxsuite/node_modules/.pnpm/jsdom@20.0.1_canvas@2.11.2/node_modules/jsdom/lib/jsdom/living/window/Location-impl.js:47:10)
        at Location.set href [as href] (/home/parallels/code/vxsuite/node_modules/.pnpm/jsdom@20.0.1_canvas@2.11.2/node_modules/jsdom/lib/jsdom/living/generated/Location.js:125:37)
        at Object.<anonymous> (/home/parallels/code/vxsuite/apps/mark-scan/frontend/src/app_states.test.tsx:25:23)
        at Promise.then.completed (/home/parallels/code/vxsuite/node_modules/.pnpm/jest-circus@29.6.2/node_modules/jest-circus/build/utils.js:300:28)
        at new Promise (<anonymous>)
        at callAsyncCircusFn (/home/parallels/code/vxsuite/node_modules/.pnpm/jest-circus@29.6.2/node_modules/jest-circus/build/utils.js:233:10)
        at _callCircusHook (/home/parallels/code/vxsuite/node_modules/.pnpm/jest-circus@29.6.2/node_modules/jest-circus/build/run.js:280:40)
        at _runTest (/home/parallels/code/vxsuite/node_modules/.pnpm/jest-circus@29.6.2/node_modules/jest-circus/build/run.js:245:5)
        at _runTestsForDescribeBlock (/home/parallels/code/vxsuite/node_modules/.pnpm/jest-circus@29.6.2/node_modules/jest-circus/build/run.js:125:9)
        at run (/home/parallels/code/vxsuite/node_modules/.pnpm/jest-circus@29.6.2/node_modules/jest-circus/build/run.js:70:3)
        at runAndTransformResultsToJestFormat (/home/parallels/code/vxsuite/node_modules/.pnpm/jest-circus@29.6.2/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)
        at jestAdapter (/home/parallels/code/vxsuite/node_modules/.pnpm/jest-circus@29.6.2/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)
        at runTestInternal (/home/parallels/code/vxsuite/node_modules/.pnpm/jest-runner@29.6.2/node_modules/jest-runner/build/runTest.js:367:16)
        at runTest (/home/parallels/code/vxsuite/node_modules/.pnpm/jest-runner@29.6.2/node_modules/jest-runner/build/runTest.js:444:34)
        at Object.worker (/home/parallels/code/vxsuite/node_modules/.pnpm/jest-runner@29.6.2/node_modules/jest-runner/build/testWorker.js:106:12) {
      type: 'not implemented'
    }

      23 | beforeEach(() => {
      24 |   jest.useFakeTimers();
    > 25 |   window.location.href = '/';
         |                       ^
      26 |   apiMock = createApiMock();
      27 |
      28 |   apiMock.expectGetMachineConfig();

      at VirtualConsole.<anonymous> (../../../node_modules/.pnpm/jest-environment-jsdom@29.6.2/node_modules/jest-environment-jsdom/build/index.js:63:23)
      at module.exports (../../../node_modules/.pnpm/jsdom@20.0.1_canvas@2.11.2/node_modules/jsdom/lib/jsdom/browser/not-implemented.js:12:26)
      at navigateFetch (../../../node_modules/.pnpm/jsdom@20.0.1_canvas@2.11.2/node_modules/jsdom/lib/jsdom/living/window/navigation.js:77:3)
      at exports.navigate (../../../node_modules/.pnpm/jsdom@20.0.1_canvas@2.11.2/node_modules/jsdom/lib/jsdom/living/window/navigation.js:55:3)
      at LocationImpl._locationObjectNavigate (../../../node_modules/.pnpm/jsdom@20.0.1_canvas@2.11.2/node_modules/jsdom/lib/jsdom/living/window/Location-impl.js:31:5)
      at LocationImpl._locationObjectSetterNavigate (../../../node_modules/.pnpm/jsdom@20.0.1_canvas@2.11.2/node_modules/jsdom/lib/jsdom/living/window/Location-impl.js:25:17)
      at LocationImpl.set href [as href] (../../../node_modules/.pnpm/jsdom@20.0.1_canvas@2.11.2/node_modules/jsdom/lib/jsdom/living/window/Location-impl.js:47:10)
      at Location.set href [as href] (../../../node_modules/.pnpm/jsdom@20.0.1_canvas@2.11.2/node_modules/jsdom/lib/jsdom/living/generated/Location.js:125:37)
      at Object.<anonymous> (src/app_states.test.tsx:25:23)
```
