### PR TITLE
test: use `toEqual` type parameter

### DIFF
--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -1,4 +1,4 @@
-import { assert, err, ok, typedAs } from '@votingworks/basics';
+import { assert, err, ok } from '@votingworks/basics';
 import {
   electionTwoPartyPrimaryFixtures,
   electionGeneral,
@@ -373,25 +373,19 @@ test('usbDrive', async () => {
 test('printer status', async () => {
   const { mockPrinterHandler, apiClient } = buildTestEnvironment();
 
-  expect(await apiClient.getPrinterStatus()).toEqual(
-    typedAs<PrinterStatus>({
-      connected: false,
-    })
-  );
+  expect(await apiClient.getPrinterStatus()).toEqual<PrinterStatus>({
+    connected: false,
+  });
 
   mockPrinterHandler.connectPrinter(HP_LASER_PRINTER_CONFIG);
 
-  expect(await apiClient.getPrinterStatus()).toEqual(
-    typedAs<PrinterStatus>(
-      getMockConnectedPrinterStatus(HP_LASER_PRINTER_CONFIG)
-    )
+  expect(await apiClient.getPrinterStatus()).toEqual<PrinterStatus>(
+    getMockConnectedPrinterStatus(HP_LASER_PRINTER_CONFIG)
   );
 
   mockPrinterHandler.disconnectPrinter();
 
-  expect(await apiClient.getPrinterStatus()).toEqual(
-    typedAs<PrinterStatus>({
-      connected: false,
-    })
-  );
+  expect(await apiClient.getPrinterStatus()).toEqual<PrinterStatus>({
+    connected: false,
+  });
 });

--- a/apps/admin/backend/src/reports/warnings.test.ts
+++ b/apps/admin/backend/src/reports/warnings.test.ts
@@ -5,7 +5,6 @@ import {
   buildSimpleMockTallyReportResults,
   getEmptyCardCounts,
 } from '@votingworks/utils';
-import { typedAs } from '@votingworks/basics';
 import {
   electionFamousNames2021Fixtures,
   electionTwoPartyPrimary,
@@ -24,11 +23,9 @@ describe('getBallotCountReportWarning', () => {
       getBallotCountReportWarning({
         allCardCounts: [],
       })
-    ).toEqual(
-      typedAs<BallotCountReportWarning>({
-        type: 'no-reports-match-filter',
-      })
-    );
+    ).toEqual<BallotCountReportWarning>({
+      type: 'no-reports-match-filter',
+    });
   });
 
   test("doesn't give a warning on zero report", () => {
@@ -36,11 +33,9 @@ describe('getBallotCountReportWarning', () => {
       getBallotCountReportWarning({
         allCardCounts: [getEmptyCardCounts()],
       })
-    ).toEqual(
-      typedAs<BallotCountReportWarning>({
-        type: 'none',
-      })
-    );
+    ).toEqual<BallotCountReportWarning>({
+      type: 'none',
+    });
   });
 });
 
@@ -51,11 +46,9 @@ describe('getTallyReportWarning', () => {
         allTallyReports: [],
         election: electionTwoPartyPrimary,
       })
-    ).toEqual(
-      typedAs<TallyReportWarning>({
-        type: 'no-reports-match-filter',
-      })
-    );
+    ).toEqual<TallyReportWarning>({
+      type: 'no-reports-match-filter',
+    });
   });
 
   test("doesn't give a warning on zero report", () => {
@@ -70,11 +63,9 @@ describe('getTallyReportWarning', () => {
         ],
         election,
       })
-    ).toEqual(
-      typedAs<TallyReportWarning>({
-        type: 'none',
-      })
-    );
+    ).toEqual<TallyReportWarning>({
+      type: 'none',
+    });
   });
 
   test('does give warning when contest has votes all for one option', () => {
@@ -169,14 +160,12 @@ describe('getTallyReportWarning', () => {
 
       expect(
         getTallyReportWarning({ allTallyReports: [tallyReport], election })
-      ).toEqual(
-        typedAs<TallyReportWarning>({
-          type: 'privacy',
-          subType: 'contest-same-vote',
-          contestIds: expectedContestIds,
-          isOnlyOneReport: false,
-        })
-      );
+      ).toEqual<TallyReportWarning>({
+        type: 'privacy',
+        subType: 'contest-same-vote',
+        contestIds: expectedContestIds,
+        isOnlyOneReport: false,
+      });
     }
   });
 
@@ -205,13 +194,11 @@ describe('getTallyReportWarning', () => {
         allTallyReports: [tallyReport],
         election,
       })
-    ).toEqual(
-      typedAs<TallyReportWarning>({
-        type: 'privacy',
-        subType: 'low-ballot-count',
-        isOnlyOneReport: true,
-      })
-    );
+    ).toEqual<TallyReportWarning>({
+      type: 'privacy',
+      subType: 'low-ballot-count',
+      isOnlyOneReport: true,
+    });
   });
 
   test('includes manual results   assessing all-same-vote privacy risk', () => {
@@ -272,24 +259,20 @@ describe('getTallyReportWarning', () => {
         allTallyReports: [tallyReportWithoutManualResults],
         election,
       })
-    ).toEqual(
-      typedAs<TallyReportWarning>({
-        contestIds: ['fishing'],
-        isOnlyOneReport: false,
-        subType: 'contest-same-vote',
-        type: 'privacy',
-      })
-    );
+    ).toEqual<TallyReportWarning>({
+      contestIds: ['fishing'],
+      isOnlyOneReport: false,
+      subType: 'contest-same-vote',
+      type: 'privacy',
+    });
 
     expect(
       getTallyReportWarning({
         allTallyReports: [tallyReportWithManualResults],
         election,
       })
-    ).toEqual(
-      typedAs<TallyReportWarning>({
-        type: 'none',
-      })
-    );
+    ).toEqual<TallyReportWarning>({
+      type: 'none',
+    });
   });
 });

--- a/apps/admin/backend/src/util/cast_vote_records.test.ts
+++ b/apps/admin/backend/src/util/cast_vote_records.test.ts
@@ -1,5 +1,4 @@
 import { electionTwoPartyPrimaryFixtures } from '@votingworks/fixtures';
-import { typedAs } from '@votingworks/basics';
 import { Tabulation } from '@votingworks/types';
 import { getCastVoteRecordAdjudicationFlags } from './cast_vote_records';
 import { CastVoteRecordAdjudicationFlags } from '..';
@@ -33,27 +32,23 @@ test('blank ballot', () => {
       },
       electionDefinition
     )
-  ).toEqual(
-    typedAs<CastVoteRecordAdjudicationFlags>({
-      isBlank: true,
-      hasUndervote: true,
-      hasOvervote: false,
-      hasWriteIn: false,
-    })
-  );
+  ).toEqual<CastVoteRecordAdjudicationFlags>({
+    isBlank: true,
+    hasUndervote: true,
+    hasOvervote: false,
+    hasWriteIn: false,
+  });
 });
 
 test('no status ballot', () => {
   expect(
     getCastVoteRecordAdjudicationFlags(mockVotes(), electionDefinition)
-  ).toEqual(
-    typedAs<CastVoteRecordAdjudicationFlags>({
-      isBlank: false,
-      hasUndervote: false,
-      hasOvervote: false,
-      hasWriteIn: false,
-    })
-  );
+  ).toEqual<CastVoteRecordAdjudicationFlags>({
+    isBlank: false,
+    hasUndervote: false,
+    hasOvervote: false,
+    hasWriteIn: false,
+  });
 });
 
 test('undervote yes-no', () => {
@@ -62,14 +57,12 @@ test('undervote yes-no', () => {
       mockVotes({ fishing: [] }),
       electionDefinition
     )
-  ).toEqual(
-    typedAs<CastVoteRecordAdjudicationFlags>({
-      isBlank: false,
-      hasUndervote: true,
-      hasOvervote: false,
-      hasWriteIn: false,
-    })
-  );
+  ).toEqual<CastVoteRecordAdjudicationFlags>({
+    isBlank: false,
+    hasUndervote: true,
+    hasOvervote: false,
+    hasWriteIn: false,
+  });
 });
 
 test('undervote candidate', () => {
@@ -78,14 +71,12 @@ test('undervote candidate', () => {
       mockVotes({ 'best-animal-mammal': [] }),
       electionDefinition
     )
-  ).toEqual(
-    typedAs<CastVoteRecordAdjudicationFlags>({
-      isBlank: false,
-      hasUndervote: true,
-      hasOvervote: false,
-      hasWriteIn: false,
-    })
-  );
+  ).toEqual<CastVoteRecordAdjudicationFlags>({
+    isBlank: false,
+    hasUndervote: true,
+    hasOvervote: false,
+    hasWriteIn: false,
+  });
 });
 
 test('overvote yes-no', () => {
@@ -94,14 +85,12 @@ test('overvote yes-no', () => {
       mockVotes({ fishing: ['yes', 'no'] }),
       electionDefinition
     )
-  ).toEqual(
-    typedAs<CastVoteRecordAdjudicationFlags>({
-      isBlank: false,
-      hasUndervote: false,
-      hasOvervote: true,
-      hasWriteIn: false,
-    })
-  );
+  ).toEqual<CastVoteRecordAdjudicationFlags>({
+    isBlank: false,
+    hasUndervote: false,
+    hasOvervote: true,
+    hasWriteIn: false,
+  });
 });
 
 test('overvote candidate', () => {
@@ -112,14 +101,12 @@ test('overvote candidate', () => {
       }),
       electionDefinition
     )
-  ).toEqual(
-    typedAs<CastVoteRecordAdjudicationFlags>({
-      isBlank: false,
-      hasUndervote: false,
-      hasOvervote: true,
-      hasWriteIn: false,
-    })
-  );
+  ).toEqual<CastVoteRecordAdjudicationFlags>({
+    isBlank: false,
+    hasUndervote: false,
+    hasOvervote: true,
+    hasWriteIn: false,
+  });
 });
 
 test('write-in', () => {
@@ -130,14 +117,12 @@ test('write-in', () => {
       }),
       electionDefinition
     )
-  ).toEqual(
-    typedAs<CastVoteRecordAdjudicationFlags>({
-      isBlank: false,
-      hasUndervote: false,
-      hasOvervote: false,
-      hasWriteIn: true,
-    })
-  );
+  ).toEqual<CastVoteRecordAdjudicationFlags>({
+    isBlank: false,
+    hasUndervote: false,
+    hasOvervote: false,
+    hasWriteIn: true,
+  });
 });
 
 test('multiple flags', () => {
@@ -149,12 +134,10 @@ test('multiple flags', () => {
       }),
       electionDefinition
     )
-  ).toEqual(
-    typedAs<CastVoteRecordAdjudicationFlags>({
-      isBlank: false,
-      hasUndervote: true,
-      hasOvervote: true,
-      hasWriteIn: true,
-    })
-  );
+  ).toEqual<CastVoteRecordAdjudicationFlags>({
+    isBlank: false,
+    hasUndervote: true,
+    hasOvervote: true,
+    hasWriteIn: true,
+  });
 });

--- a/apps/central-scan/backend/src/app.deprecated_api.test.ts
+++ b/apps/central-scan/backend/src/app.deprecated_api.test.ts
@@ -277,27 +277,25 @@ test('get next sheet layouts', async () => {
     .get(`/central-scanner/scan/hmpb/review/next-sheet`)
     .expect(200);
 
-  expect(response.body).toEqual(
-    typedAs<Scan.GetNextReviewSheetResponse>({
-      interpreted: {
-        id: 'mock-review-sheet',
-        front: {
-          image: { url: '/url/front' },
-          interpretation: frontInterpretation,
-        },
-        back: {
-          image: { url: '/url/back' },
-          interpretation: backInterpretation,
-        },
+  expect(response.body).toEqual<Scan.GetNextReviewSheetResponse>({
+    interpreted: {
+      id: 'mock-review-sheet',
+      front: {
+        image: { url: '/url/front' },
+        interpretation: frontInterpretation,
       },
-      layouts: {
-        front: frontInterpretation.layout,
-        back: backInterpretation.layout,
+      back: {
+        image: { url: '/url/back' },
+        interpretation: backInterpretation,
       },
-      definitions: {
-        front: { contestIds: expect.any(Array) },
-        back: { contestIds: expect.any(Array) },
-      },
-    })
-  );
+    },
+    layouts: {
+      front: frontInterpretation.layout,
+      back: backInterpretation.layout,
+    },
+    definitions: {
+      front: { contestIds: expect.any(Array) },
+      back: { contestIds: expect.any(Array) },
+    },
+  });
 });

--- a/apps/central-scan/backend/src/app.diagnostics.test.ts
+++ b/apps/central-scan/backend/src/app.diagnostics.test.ts
@@ -7,7 +7,6 @@ import {
 } from '@votingworks/backend';
 import { LogEventId } from '@votingworks/logging';
 import { join } from 'path';
-import { typedAs } from '@votingworks/basics';
 import { DiagnosticRecord, TEST_JURISDICTION } from '@votingworks/types';
 import { electionTwoPartyPrimaryDefinition } from '@votingworks/fixtures';
 import { mockSystemAdministratorAuth } from '../test/helpers/auth';
@@ -128,13 +127,13 @@ describe('scan diagnostic', () => {
 
       await apiClient.performScanDiagnostic();
 
-      expect(await apiClient.getMostRecentScannerDiagnostic()).toEqual(
-        typedAs<DiagnosticRecord>({
-          type: 'blank-sheet-scan',
-          outcome: 'pass',
-          timestamp: 0,
-        })
-      );
+      expect(
+        await apiClient.getMostRecentScannerDiagnostic()
+      ).toEqual<DiagnosticRecord>({
+        type: 'blank-sheet-scan',
+        outcome: 'pass',
+        timestamp: 0,
+      });
 
       expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
         LogEventId.DiagnosticInit,
@@ -166,13 +165,13 @@ describe('scan diagnostic', () => {
         .end();
       await apiClient.performScanDiagnostic();
 
-      expect(await apiClient.getMostRecentScannerDiagnostic()).toEqual(
-        typedAs<DiagnosticRecord>({
-          type: 'blank-sheet-scan',
-          outcome: 'fail',
-          timestamp: 0,
-        })
-      );
+      expect(
+        await apiClient.getMostRecentScannerDiagnostic()
+      ).toEqual<DiagnosticRecord>({
+        type: 'blank-sheet-scan',
+        outcome: 'fail',
+        timestamp: 0,
+      });
       expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
         LogEventId.DiagnosticComplete,
         {
@@ -197,13 +196,13 @@ describe('scan diagnostic', () => {
         .end();
       await apiClient.performScanDiagnostic();
 
-      expect(await apiClient.getMostRecentScannerDiagnostic()).toEqual(
-        typedAs<DiagnosticRecord>({
-          type: 'blank-sheet-scan',
-          outcome: 'fail',
-          timestamp: 0,
-        })
-      );
+      expect(
+        await apiClient.getMostRecentScannerDiagnostic()
+      ).toEqual<DiagnosticRecord>({
+        type: 'blank-sheet-scan',
+        outcome: 'fail',
+        timestamp: 0,
+      });
       expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
         LogEventId.DiagnosticComplete,
         {
@@ -222,13 +221,13 @@ describe('scan diagnostic', () => {
       scanner.withNextScannerSession().end();
       await apiClient.performScanDiagnostic();
 
-      expect(await apiClient.getMostRecentScannerDiagnostic()).toEqual(
-        typedAs<DiagnosticRecord>({
-          type: 'blank-sheet-scan',
-          outcome: 'fail',
-          timestamp: 0,
-        })
-      );
+      expect(
+        await apiClient.getMostRecentScannerDiagnostic()
+      ).toEqual<DiagnosticRecord>({
+        type: 'blank-sheet-scan',
+        outcome: 'fail',
+        timestamp: 0,
+      });
       expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
         LogEventId.DiagnosticComplete,
         {

--- a/apps/central-scan/backend/src/app.scanning.test.ts
+++ b/apps/central-scan/backend/src/app.scanning.test.ts
@@ -4,7 +4,6 @@ import {
   DEFAULT_SYSTEM_SETTINGS,
   TEST_JURISDICTION,
 } from '@votingworks/types';
-import { typedAs } from '@votingworks/basics';
 import { withApp } from '../test/helpers/setup_app';
 import { mockElectionManagerAuth } from '../test/helpers/auth';
 
@@ -41,16 +40,14 @@ test('scanBatch with multiple sheets', async () => {
     expect(status.adjudicationsRemaining).toEqual(0);
     expect(status.canUnconfigure).toEqual(true);
     expect(status.batches.length).toEqual(1);
-    expect(status.batches[0]).toEqual(
-      typedAs<BatchInfo>({
-        id: expect.any(String),
-        batchNumber: 1,
-        label: 'Batch 1',
-        count: 3,
-        startedAt: expect.any(String),
-        endedAt: expect.any(String),
-      })
-    );
+    expect(status.batches[0]).toEqual<BatchInfo>({
+      id: expect.any(String),
+      batchNumber: 1,
+      label: 'Batch 1',
+      count: 3,
+      startedAt: expect.any(String),
+      endedAt: expect.any(String),
+    });
   });
 });
 
@@ -85,16 +82,14 @@ test('continueScanning after invalid ballot', async () => {
       expect(status.adjudicationsRemaining).toEqual(1);
       expect(status.canUnconfigure).toEqual(true);
       expect(status.batches.length).toEqual(1);
-      expect(status.batches[0]).toEqual(
-        typedAs<BatchInfo>({
-          id: expect.any(String),
-          batchNumber: 1,
-          label: 'Batch 1',
-          count: 2,
-          startedAt: expect.any(String),
-          endedAt: undefined, // not ended
-        })
-      );
+      expect(status.batches[0]).toEqual<BatchInfo>({
+        id: expect.any(String),
+        batchNumber: 1,
+        label: 'Batch 1',
+        count: 2,
+        startedAt: expect.any(String),
+        endedAt: undefined, // not ended
+      });
     }
     await apiClient.continueScanning({ forceAccept: false });
     await importer.waitForEndOfBatchOrScanningPause();
@@ -103,16 +98,14 @@ test('continueScanning after invalid ballot', async () => {
       expect(status.adjudicationsRemaining).toEqual(0);
       expect(status.canUnconfigure).toEqual(true);
       expect(status.batches.length).toEqual(1);
-      expect(status.batches[0]).toEqual(
-        typedAs<BatchInfo>({
-          id: expect.any(String),
-          batchNumber: 1,
-          label: 'Batch 1',
-          count: 2, // bad ballot removed
-          startedAt: expect.any(String),
-          endedAt: expect.any(String),
-        })
-      );
+      expect(status.batches[0]).toEqual<BatchInfo>({
+        id: expect.any(String),
+        batchNumber: 1,
+        label: 'Batch 1',
+        count: 2, // bad ballot removed
+        startedAt: expect.any(String),
+        endedAt: expect.any(String),
+      });
     }
   });
 });

--- a/apps/central-scan/backend/src/validation.test.ts
+++ b/apps/central-scan/backend/src/validation.test.ts
@@ -5,7 +5,6 @@ import {
   InterpretedBmdPage,
   InterpretedHmpbPage,
 } from '@votingworks/types';
-import { typedAs } from '@votingworks/basics';
 import {
   describeValidationError,
   validateSheetInterpretation,
@@ -94,12 +93,10 @@ test('BMD ballot with two BMD sides', () => {
     BmdPage,
     BmdPage,
   ]).unsafeUnwrapErr();
-  expect(error).toEqual(
-    typedAs<ValidationError>({
-      type: ValidationErrorType.InvalidFrontBackPageTypes,
-      types: ['InterpretedBmdPage', 'InterpretedBmdPage'],
-    })
-  );
+  expect(error).toEqual<ValidationError>({
+    type: ValidationErrorType.InvalidFrontBackPageTypes,
+    types: ['InterpretedBmdPage', 'InterpretedBmdPage'],
+  });
   expect(describeValidationError(error)).toEqual(
     `expected the back of a BMD page to be blank, but got 'InterpretedBmdPage'`
   );
@@ -110,12 +107,10 @@ test('HMPB ballot with non-consecutive pages', () => {
     HmpbPage1,
     HmpbPage1,
   ]).unsafeUnwrapErr();
-  expect(error).toEqual(
-    typedAs<ValidationError>({
-      type: ValidationErrorType.NonConsecutivePages,
-      pageNumbers: [1, 1],
-    })
-  );
+  expect(error).toEqual<ValidationError>({
+    type: ValidationErrorType.NonConsecutivePages,
+    pageNumbers: [1, 1],
+  });
   expect(describeValidationError(error)).toEqual(
     `expected a sheet to have consecutive page numbers, but got front=1 back=1`
   );
@@ -129,12 +124,10 @@ test('HMPB ballot with mismatched ballot style', () => {
       metadata: { ...HmpbPage2.metadata, ballotStyleId: '34' },
     },
   ]).unsafeUnwrapErr();
-  expect(error).toEqual(
-    typedAs<ValidationError>({
-      type: ValidationErrorType.MismatchedBallotStyle,
-      ballotStyleIds: ['12', '34'],
-    })
-  );
+  expect(error).toEqual<ValidationError>({
+    type: ValidationErrorType.MismatchedBallotStyle,
+    ballotStyleIds: ['12', '34'],
+  });
   expect(describeValidationError(error)).toEqual(
     `expected a sheet to have the same ballot style, but got front=12 back=34`
   );
@@ -149,12 +142,10 @@ test('HMPB ballot with mismatched precinct', () => {
     },
   ]).unsafeUnwrapErr();
 
-  expect(error).toEqual(
-    typedAs<ValidationError>({
-      type: ValidationErrorType.MismatchedPrecinct,
-      precinctIds: ['23', '34'],
-    })
-  );
+  expect(error).toEqual<ValidationError>({
+    type: ValidationErrorType.MismatchedPrecinct,
+    precinctIds: ['23', '34'],
+  });
   expect(describeValidationError(error)).toEqual(
     `expected a sheet to have the same precinct, but got front=23 back=34`
   );
@@ -169,12 +160,10 @@ test('HMPB ballot with mismatched election', () => {
     },
   ]).unsafeUnwrapErr();
 
-  expect(error).toEqual(
-    typedAs<ValidationError>({
-      type: ValidationErrorType.MismatchedElectionHash,
-      electionHashes: ['abc', 'def'],
-    })
-  );
+  expect(error).toEqual<ValidationError>({
+    type: ValidationErrorType.MismatchedElectionHash,
+    electionHashes: ['abc', 'def'],
+  });
   expect(describeValidationError(error)).toEqual(
     `expected a sheet to have the same election hash, but got front=abc back=def`
   );
@@ -189,12 +178,10 @@ test('HMPB ballot with mismatched ballot type', () => {
     },
   ]).unsafeUnwrapErr();
 
-  expect(error).toEqual(
-    typedAs<ValidationError>({
-      type: ValidationErrorType.MismatchedBallotType,
-      ballotTypes: [BallotType.Absentee, BallotType.Precinct],
-    })
-  );
+  expect(error).toEqual<ValidationError>({
+    type: ValidationErrorType.MismatchedBallotType,
+    ballotTypes: [BallotType.Absentee, BallotType.Precinct],
+  });
   expect(describeValidationError(error)).toEqual(
     `expected a sheet to have the same ballot type, but got front=absentee back=precinct`
   );
@@ -205,12 +192,10 @@ test('sheet with HMPB and BMD pages', () => {
     HmpbPage1,
     BmdPage,
   ]).unsafeUnwrapErr();
-  expect(error).toEqual(
-    typedAs<ValidationError>({
-      type: ValidationErrorType.InvalidFrontBackPageTypes,
-      types: ['InterpretedHmpbPage', 'InterpretedBmdPage'],
-    })
-  );
+  expect(error).toEqual<ValidationError>({
+    type: ValidationErrorType.InvalidFrontBackPageTypes,
+    types: ['InterpretedHmpbPage', 'InterpretedBmdPage'],
+  });
   expect(describeValidationError(error)).toEqual(
     `expected the a HMPB page to be another HMPB page, but got 'InterpretedBmdPage'`
   );
@@ -221,12 +206,10 @@ test('sheet with BMD and HMPB pages', () => {
     BmdPage,
     HmpbPage1,
   ]).unsafeUnwrapErr();
-  expect(error).toEqual(
-    typedAs<ValidationError>({
-      type: ValidationErrorType.InvalidFrontBackPageTypes,
-      types: ['InterpretedBmdPage', 'InterpretedHmpbPage'],
-    })
-  );
+  expect(error).toEqual<ValidationError>({
+    type: ValidationErrorType.InvalidFrontBackPageTypes,
+    types: ['InterpretedBmdPage', 'InterpretedHmpbPage'],
+  });
   expect(describeValidationError(error)).toEqual(
     `expected the back of a BMD page to be blank, but got 'InterpretedHmpbPage'`
   );

--- a/apps/scan/backend/src/app_config.test.ts
+++ b/apps/scan/backend/src/app_config.test.ts
@@ -9,7 +9,7 @@ import {
   getFeatureFlagMock,
   singlePrecinctSelectionFor,
 } from '@votingworks/utils';
-import { err, ok, typedAs } from '@votingworks/basics';
+import { err, ok } from '@votingworks/basics';
 import {
   mockElectionManagerUser,
   mockSessionExpiresAt,
@@ -152,25 +152,21 @@ test('setPrecinctSelection will reset polls to closed', async () => {
   await withApp(async ({ apiClient, mockUsbDrive, mockAuth, logger }) => {
     await configureApp(apiClient, mockAuth, mockUsbDrive);
 
-    expect(await apiClient.getPollsInfo()).toEqual(
-      typedAs<PrecinctScannerPollsInfo>({
-        pollsState: 'polls_open',
-        lastPollsTransition: {
-          type: 'open_polls',
-          time: expect.anything(),
-          ballotCount: 0,
-        },
-      })
-    );
+    expect(await apiClient.getPollsInfo()).toEqual<PrecinctScannerPollsInfo>({
+      pollsState: 'polls_open',
+      lastPollsTransition: {
+        type: 'open_polls',
+        time: expect.anything(),
+        ballotCount: 0,
+      },
+    });
 
     await apiClient.setPrecinctSelection({
       precinctSelection: singlePrecinctSelectionFor('21'),
     });
-    expect(await apiClient.getPollsInfo()).toEqual(
-      typedAs<PrecinctScannerPollsInfo>({
-        pollsState: 'polls_closed_initial',
-      })
-    );
+    expect(await apiClient.getPollsInfo()).toEqual<PrecinctScannerPollsInfo>({
+      pollsState: 'polls_closed_initial',
+    });
     expect(logger.logAsCurrentRole).toHaveBeenLastCalledWith(
       LogEventId.PrecinctConfigurationChanged,
       {

--- a/libs/auth/src/cac/common_access_card.test.ts
+++ b/libs/auth/src/cac/common_access_card.test.ts
@@ -1,4 +1,4 @@
-import { assertDefined, err, ok, typedAs } from '@votingworks/basics';
+import { assertDefined, err, ok } from '@votingworks/basics';
 import { mockOf } from '@votingworks/test-utils';
 import { Byte } from '@votingworks/types';
 import { Buffer } from 'buffer';
@@ -256,11 +256,9 @@ test('checkPin: success', async () => {
       'hex'
     ),
   });
-  expect(await cac.checkPin('1234')).toEqual(
-    typedAs<CheckPinResponse>({
-      response: 'correct',
-    })
-  );
+  expect(await cac.checkPin('1234')).toEqual<CheckPinResponse>({
+    response: 'correct',
+  });
 });
 
 test('checkPin: failure', async () => {
@@ -272,12 +270,10 @@ test('checkPin: failure', async () => {
     await certPemToDer(DEV_CERT_PEM)
   );
   mockCardPinVerificationRequest('1234', new ResponseApduError([0x69, 0x82]));
-  expect(await cac.checkPin('1234')).toEqual(
-    typedAs<CheckPinResponse>({
-      response: 'incorrect',
-      numIncorrectPinAttempts: -1,
-    })
-  );
+  expect(await cac.checkPin('1234')).toEqual<CheckPinResponse>({
+    response: 'incorrect',
+    numIncorrectPinAttempts: -1,
+  });
 });
 
 test('checkPin: failure with incorrect pin status word', async () => {
@@ -289,12 +285,10 @@ test('checkPin: failure with incorrect pin status word', async () => {
     await certPemToDer(DEV_CERT_PEM)
   );
   mockCardPinVerificationRequest('1234', new ResponseApduError([0x63, 0xc1]));
-  expect(await cac.checkPin('1234')).toEqual(
-    typedAs<CheckPinResponse>({
-      response: 'incorrect',
-      numIncorrectPinAttempts: -1,
-    })
-  );
+  expect(await cac.checkPin('1234')).toEqual<CheckPinResponse>({
+    response: 'incorrect',
+    numIncorrectPinAttempts: -1,
+  });
 });
 
 test('checkPin: failure with card error', async () => {
@@ -306,12 +300,10 @@ test('checkPin: failure with card error', async () => {
     await certPemToDer(DEV_CERT_PEM)
   );
   mockCardPinVerificationRequest('1234', new ResponseApduError([0x6f, 0x00]));
-  expect(await cac.checkPin('1234')).toEqual(
-    typedAs<CheckPinResponse>({
-      response: 'error',
-      error: new ResponseApduError([0x6f, 0x00]),
-    })
-  );
+  expect(await cac.checkPin('1234')).toEqual<CheckPinResponse>({
+    response: 'error',
+    error: new ResponseApduError([0x6f, 0x00]),
+  });
 });
 
 test('checkPin: unexpected error', async () => {

--- a/libs/backend/src/cast_vote_records/build_cast_vote_record.test.ts
+++ b/libs/backend/src/cast_vote_records/build_cast_vote_record.test.ts
@@ -1,4 +1,4 @@
-import { assert, find, typedAs } from '@votingworks/basics';
+import { assert, find } from '@votingworks/basics';
 import { electionTwoPartyPrimaryDefinition } from '@votingworks/fixtures';
 import {
   BallotIdSchema,
@@ -729,28 +729,26 @@ test('buildCastVoteRecord - HMPB ballot with unmarked write-in', () => {
     (cs) => cs.ContestSelectionId === 'write-in-1'
   );
 
-  expect(unmarkedWriteInSelection).toEqual(
-    typedAs<CVR.CVRContestSelection>({
-      '@type': 'CVR.CVRContestSelection',
-      ContestSelectionId: 'write-in-1',
-      OptionPosition: 5,
-      Status: [CVR.ContestSelectionStatus.NeedsAdjudication],
-      SelectionPosition: [
-        {
-          '@type': 'CVR.SelectionPosition',
-          HasIndication: CVR.IndicationStatus.No,
-          NumberVotes: 1,
-          IsAllocable: CVR.AllocationStatus.Unknown,
-          Status: [CVR.PositionStatus.Other],
-          OtherStatus: 'unmarked-write-in',
-          CVRWriteIn: {
-            '@type': 'CVR.CVRWriteIn',
-            WriteInImage: expectedFrontImageData,
-          },
+  expect(unmarkedWriteInSelection).toEqual<CVR.CVRContestSelection>({
+    '@type': 'CVR.CVRContestSelection',
+    ContestSelectionId: 'write-in-1',
+    OptionPosition: 5,
+    Status: [CVR.ContestSelectionStatus.NeedsAdjudication],
+    SelectionPosition: [
+      {
+        '@type': 'CVR.SelectionPosition',
+        HasIndication: CVR.IndicationStatus.No,
+        NumberVotes: 1,
+        IsAllocable: CVR.AllocationStatus.Unknown,
+        Status: [CVR.PositionStatus.Other],
+        OtherStatus: 'unmarked-write-in',
+        CVRWriteIn: {
+          '@type': 'CVR.CVRWriteIn',
+          WriteInImage: expectedFrontImageData,
         },
-      ],
-    })
-  );
+      },
+    ],
+  });
 });
 
 describe('hash manipulation', () => {

--- a/libs/backend/src/cast_vote_records/canonicalize.test.ts
+++ b/libs/backend/src/cast_vote_records/canonicalize.test.ts
@@ -4,7 +4,6 @@ import {
   SheetOf,
   SheetValidationError,
 } from '@votingworks/types';
-import { typedAs } from '@votingworks/basics';
 import { canonicalizeSheet } from './canonicalize';
 import {
   interpretedBmdPage,
@@ -70,13 +69,11 @@ test('BMD ballot with two BMD sides', () => {
     [interpretedBmdPage, interpretedBmdPage],
     filenames
   ).unsafeUnwrapErr();
-  expect(error).toEqual(
-    typedAs<SheetValidationError>({
-      type: 'invalid-sheet',
-      subType: 'incompatible-interpretation-types',
-      interpretationTypes: ['InterpretedBmdPage', 'InterpretedBmdPage'],
-    })
-  );
+  expect(error).toEqual<SheetValidationError>({
+    type: 'invalid-sheet',
+    subType: 'incompatible-interpretation-types',
+    interpretationTypes: ['InterpretedBmdPage', 'InterpretedBmdPage'],
+  });
 });
 
 test('HMPB ballot with non-consecutive pages', () => {
@@ -84,13 +81,11 @@ test('HMPB ballot with non-consecutive pages', () => {
     [interpretedHmpbPage1, interpretedHmpbPage1],
     filenames
   ).unsafeUnwrapErr();
-  expect(error).toEqual(
-    typedAs<SheetValidationError>({
-      type: 'invalid-sheet',
-      subType: 'non-consecutive-page-numbers',
-      pageNumbers: [1, 1],
-    })
-  );
+  expect(error).toEqual<SheetValidationError>({
+    type: 'invalid-sheet',
+    subType: 'non-consecutive-page-numbers',
+    pageNumbers: [1, 1],
+  });
 });
 
 test('HMPB ballot with mismatched ballot style', () => {
@@ -104,13 +99,11 @@ test('HMPB ballot with mismatched ballot style', () => {
     ],
     filenames
   ).unsafeUnwrapErr();
-  expect(error).toEqual(
-    typedAs<SheetValidationError>({
-      type: 'invalid-sheet',
-      subType: 'mismatched-ballot-style-ids',
-      ballotStyleIds: ['2F', '1M'],
-    })
-  );
+  expect(error).toEqual<SheetValidationError>({
+    type: 'invalid-sheet',
+    subType: 'mismatched-ballot-style-ids',
+    ballotStyleIds: ['2F', '1M'],
+  });
 });
 
 test('HMPB ballot with mismatched precinct', () => {
@@ -128,13 +121,11 @@ test('HMPB ballot with mismatched precinct', () => {
     filenames
   ).unsafeUnwrapErr();
 
-  expect(error).toEqual(
-    typedAs<SheetValidationError>({
-      type: 'invalid-sheet',
-      subType: 'mismatched-precinct-ids',
-      precinctIds: ['precinct-1', 'precinct-2'],
-    })
-  );
+  expect(error).toEqual<SheetValidationError>({
+    type: 'invalid-sheet',
+    subType: 'mismatched-precinct-ids',
+    precinctIds: ['precinct-1', 'precinct-2'],
+  });
 });
 
 test('HMPB ballot with mismatched election', () => {
@@ -152,13 +143,11 @@ test('HMPB ballot with mismatched election', () => {
     filenames
   ).unsafeUnwrapErr();
 
-  expect(error).toEqual(
-    typedAs<SheetValidationError>({
-      type: 'invalid-sheet',
-      subType: 'mismatched-election-hashes',
-      electionHashes: ['abc', 'def'],
-    })
-  );
+  expect(error).toEqual<SheetValidationError>({
+    type: 'invalid-sheet',
+    subType: 'mismatched-election-hashes',
+    electionHashes: ['abc', 'def'],
+  });
 });
 
 test('HMPB ballot with mismatched ballot type', () => {
@@ -176,13 +165,11 @@ test('HMPB ballot with mismatched ballot type', () => {
     filenames
   ).unsafeUnwrapErr();
 
-  expect(error).toEqual(
-    typedAs<SheetValidationError>({
-      type: 'invalid-sheet',
-      subType: 'mismatched-ballot-types',
-      ballotTypes: [BallotType.Precinct, BallotType.Absentee],
-    })
-  );
+  expect(error).toEqual<SheetValidationError>({
+    type: 'invalid-sheet',
+    subType: 'mismatched-ballot-types',
+    ballotTypes: [BallotType.Precinct, BallotType.Absentee],
+  });
 });
 
 test('sheet with HMPB and BMD pages', () => {
@@ -190,13 +177,11 @@ test('sheet with HMPB and BMD pages', () => {
     [interpretedHmpbPage1, interpretedBmdPage],
     filenames
   ).unsafeUnwrapErr();
-  expect(error).toEqual(
-    typedAs<SheetValidationError>({
-      type: 'invalid-sheet',
-      subType: 'incompatible-interpretation-types',
-      interpretationTypes: ['InterpretedHmpbPage', 'InterpretedBmdPage'],
-    })
-  );
+  expect(error).toEqual<SheetValidationError>({
+    type: 'invalid-sheet',
+    subType: 'incompatible-interpretation-types',
+    interpretationTypes: ['InterpretedHmpbPage', 'InterpretedBmdPage'],
+  });
 });
 
 test('sheet with BMD and HMPB pages', () => {
@@ -204,11 +189,9 @@ test('sheet with BMD and HMPB pages', () => {
     [interpretedBmdPage, interpretedHmpbPage1],
     filenames
   ).unsafeUnwrapErr();
-  expect(error).toEqual(
-    typedAs<SheetValidationError>({
-      type: 'invalid-sheet',
-      subType: 'incompatible-interpretation-types',
-      interpretationTypes: ['InterpretedBmdPage', 'InterpretedHmpbPage'],
-    })
-  );
+  expect(error).toEqual<SheetValidationError>({
+    type: 'invalid-sheet',
+    subType: 'incompatible-interpretation-types',
+    interpretationTypes: ['InterpretedBmdPage', 'InterpretedHmpbPage'],
+  });
 });

--- a/libs/backend/src/election_package/election_package_io.test.ts
+++ b/libs/backend/src/election_package/election_package_io.test.ts
@@ -99,16 +99,16 @@ test('readElectionPackageFromFile reads an election package without system setti
         .electionData,
   });
   const file = saveTmpFile(pkg);
-  expect((await readElectionPackageFromFile(file)).unsafeUnwrap()).toEqual(
-    typedAs<ElectionPackageWithFileContents>({
-      electionDefinition:
-        electionGridLayoutNewHampshireTestBallotFixtures.electionDefinition,
-      systemSettings: DEFAULT_SYSTEM_SETTINGS,
-      uiStrings: {},
-      uiStringAudioClips: [],
-      fileContents: expect.any(Buffer),
-    })
-  );
+  expect(
+    (await readElectionPackageFromFile(file)).unsafeUnwrap()
+  ).toEqual<ElectionPackageWithFileContents>({
+    electionDefinition:
+      electionGridLayoutNewHampshireTestBallotFixtures.electionDefinition,
+    systemSettings: DEFAULT_SYSTEM_SETTINGS,
+    uiStrings: {},
+    uiStringAudioClips: [],
+    fileContents: expect.any(Buffer),
+  });
 });
 
 test('readElectionPackageFromFile reads an election package with system settings from a file', async () => {
@@ -121,16 +121,16 @@ test('readElectionPackageFromFile reads an election package with system settings
     ),
   });
   const file = saveTmpFile(pkg);
-  expect((await readElectionPackageFromFile(file)).unsafeUnwrap()).toEqual(
-    typedAs<ElectionPackageWithFileContents>({
-      electionDefinition:
-        electionGridLayoutNewHampshireTestBallotFixtures.electionDefinition,
-      systemSettings: DEFAULT_SYSTEM_SETTINGS,
-      uiStrings: {},
-      uiStringAudioClips: [],
-      fileContents: expect.any(Buffer),
-    })
-  );
+  expect(
+    (await readElectionPackageFromFile(file)).unsafeUnwrap()
+  ).toEqual<ElectionPackageWithFileContents>({
+    electionDefinition:
+      electionGridLayoutNewHampshireTestBallotFixtures.electionDefinition,
+    systemSettings: DEFAULT_SYSTEM_SETTINGS,
+    uiStrings: {},
+    uiStringAudioClips: [],
+    fileContents: expect.any(Buffer),
+  });
 });
 
 test('readElectionPackageFromFile loads available ui strings', async () => {

--- a/libs/ballot-interpreter/src/adjudication_reasons.test.ts
+++ b/libs/ballot-interpreter/src/adjudication_reasons.test.ts
@@ -9,7 +9,7 @@ import {
   YesNoContest,
 } from '@votingworks/types';
 import { electionTwoPartyPrimaryDefinition } from '@votingworks/fixtures';
-import { assert, typedAs } from '@votingworks/basics';
+import { assert } from '@votingworks/basics';
 import { allContestOptions } from '@votingworks/utils';
 import {
   getAllPossibleAdjudicationReasons,
@@ -78,16 +78,14 @@ test('a ballot with marginal marks', () => {
     })
   );
 
-  expect(reasons).toEqual(
-    typedAs<AdjudicationReasonInfo[]>([
-      {
-        type: AdjudicationReason.MarginalMark,
-        contestId: bestAnimalMammal.id,
-        optionId: bestAnimalMammalCandidate2.id,
-        optionIndex: 1,
-      },
-    ])
-  );
+  expect(reasons).toEqual<AdjudicationReasonInfo[]>([
+    {
+      type: AdjudicationReason.MarginalMark,
+      contestId: bestAnimalMammal.id,
+      optionId: bestAnimalMammalCandidate2.id,
+      optionIndex: 1,
+    },
+  ]);
 
   expect(reasons.map(adjudicationReasonDescription)).toEqual([
     "Contest 'best-animal-mammal' has a marginal mark for option 'otter'.",
@@ -100,20 +98,18 @@ test('a ballot with no marks', () => {
     generateMockContestOptionScores(bestAnimalMammal, {})
   );
 
-  expect(reasons).toEqual(
-    typedAs<AdjudicationReasonInfo[]>([
-      {
-        type: AdjudicationReason.Undervote,
-        contestId: bestAnimalMammal.id,
-        optionIds: [],
-        optionIndexes: [],
-        expected: 1,
-      },
-      {
-        type: AdjudicationReason.BlankBallot,
-      },
-    ])
-  );
+  expect(reasons).toEqual<AdjudicationReasonInfo[]>([
+    {
+      type: AdjudicationReason.Undervote,
+      contestId: bestAnimalMammal.id,
+      optionIds: [],
+      optionIndexes: [],
+      expected: 1,
+    },
+    {
+      type: AdjudicationReason.BlankBallot,
+    },
+  ]);
 
   expect(reasons.map(adjudicationReasonDescription)).toEqual([
     "Contest 'best-animal-mammal' is undervoted, expected 1 but got none.",
@@ -137,20 +133,15 @@ test('a ballot with too many marks', () => {
     })
   );
 
-  expect(reasons).toEqual(
-    typedAs<AdjudicationReasonInfo[]>([
-      {
-        type: AdjudicationReason.Overvote,
-        contestId: bestAnimalMammal.id,
-        optionIds: [
-          bestAnimalMammalCandidate1.id,
-          bestAnimalMammalCandidate2.id,
-        ],
-        optionIndexes: [0, 1],
-        expected: 1,
-      },
-    ])
-  );
+  expect(reasons).toEqual<AdjudicationReasonInfo[]>([
+    {
+      type: AdjudicationReason.Overvote,
+      contestId: bestAnimalMammal.id,
+      optionIds: [bestAnimalMammalCandidate1.id, bestAnimalMammalCandidate2.id],
+      optionIndexes: [0, 1],
+      expected: 1,
+    },
+  ]);
 
   expect(reasons.map(adjudicationReasonDescription)).toEqual([
     "Contest 'best-animal-mammal' is overvoted, expected 1 but got 2: 'horse', 'otter'.",
@@ -173,35 +164,33 @@ test('multiple contests with issues', () => {
     ]
   );
 
-  expect(reasons).toEqual(
-    typedAs<AdjudicationReasonInfo[]>([
-      {
-        type: AdjudicationReason.MarginalMark,
-        contestId: bestAnimalMammal.id,
-        optionId: bestAnimalMammalCandidate1.id,
-        optionIndex: 0,
-      },
-      {
-        type: AdjudicationReason.Undervote,
-        contestId: bestAnimalMammal.id,
-        optionIds: [],
-        expected: 1,
-        optionIndexes: [],
-      },
-      {
-        type: AdjudicationReason.Overvote,
-        contestId: zooCouncilMammal.id,
-        optionIds: [
-          zooCouncilMammalCandidate1.id,
-          zooCouncilMammalCandidate2.id,
-          zooCouncilMammalCandidate3.id,
-          zooCouncilMammalCandidate4.id,
-        ],
-        optionIndexes: [0, 1, 2, 3],
-        expected: 3,
-      },
-    ])
-  );
+  expect(reasons).toEqual<AdjudicationReasonInfo[]>([
+    {
+      type: AdjudicationReason.MarginalMark,
+      contestId: bestAnimalMammal.id,
+      optionId: bestAnimalMammalCandidate1.id,
+      optionIndex: 0,
+    },
+    {
+      type: AdjudicationReason.Undervote,
+      contestId: bestAnimalMammal.id,
+      optionIds: [],
+      expected: 1,
+      optionIndexes: [],
+    },
+    {
+      type: AdjudicationReason.Overvote,
+      contestId: zooCouncilMammal.id,
+      optionIds: [
+        zooCouncilMammalCandidate1.id,
+        zooCouncilMammalCandidate2.id,
+        zooCouncilMammalCandidate3.id,
+        zooCouncilMammalCandidate4.id,
+      ],
+      optionIndexes: [0, 1, 2, 3],
+      expected: 3,
+    },
+  ]);
 
   expect(reasons.map(adjudicationReasonDescription)).toEqual([
     "Contest 'best-animal-mammal' has a marginal mark for option 'horse'.",
@@ -219,17 +208,15 @@ test('yesno contest overvotes', () => {
     })
   );
 
-  expect(reasons).toEqual(
-    typedAs<AdjudicationReasonInfo[]>([
-      {
-        type: AdjudicationReason.Overvote,
-        contestId: ballotMeasure3.id,
-        optionIds: [ballotMeasure3.yesOption.id, ballotMeasure3.noOption.id],
-        optionIndexes: [0, 1],
-        expected: 1,
-      },
-    ])
-  );
+  expect(reasons).toEqual<AdjudicationReasonInfo[]>([
+    {
+      type: AdjudicationReason.Overvote,
+      contestId: ballotMeasure3.id,
+      optionIds: [ballotMeasure3.yesOption.id, ballotMeasure3.noOption.id],
+      optionIndexes: [0, 1],
+      expected: 1,
+    },
+  ]);
 
   expect(reasons.map(adjudicationReasonDescription)).toEqual([
     "Contest 'fishing' is overvoted, expected 1 but got 2: 'ban-fishing', 'allow-fishing'.",

--- a/libs/ballot-interpreter/src/bmd/interpret.test.ts
+++ b/libs/ballot-interpreter/src/bmd/interpret.test.ts
@@ -4,10 +4,10 @@ import {
   electionGridLayoutNewHampshireTestBallotFixtures,
   sampleBallotImages,
 } from '@votingworks/fixtures';
-import { assert, err, typedAs } from '@votingworks/basics';
+import { assert, err } from '@votingworks/basics';
 import { SheetOf } from '@votingworks/types';
 import { sliceElectionHash } from '@votingworks/ballot-encoder';
-import { InterpretError, interpret } from './interpret';
+import { InterpretResult, interpret } from './interpret';
 
 test.each([
   [
@@ -52,13 +52,11 @@ test('votes not found', async () => {
     electionFamousNames2021Fixtures.electionDefinition,
     card
   );
-  expect(result).toEqual(
-    err(
-      typedAs<InterpretError>({
-        type: 'votes-not-found',
-        source: [{ type: 'blank-page' }, { type: 'blank-page' }],
-      })
-    )
+  expect(result).toEqual<InterpretResult>(
+    err({
+      type: 'votes-not-found',
+      source: [{ type: 'blank-page' }, { type: 'blank-page' }],
+    })
   );
 });
 
@@ -71,13 +69,11 @@ test('multiple QR codes', async () => {
     electionFamousNames2021Fixtures.electionDefinition,
     card
   );
-  expect(result).toEqual(
-    err(
-      typedAs<InterpretError>({
-        type: 'multiple-qr-codes',
-        source: expect.anything(),
-      })
-    )
+  expect(result).toEqual<InterpretResult>(
+    err({
+      type: 'multiple-qr-codes',
+      source: expect.anything(),
+    })
   );
 });
 
@@ -90,18 +86,16 @@ test('mismatched election', async () => {
     electionGridLayoutNewHampshireTestBallotFixtures.electionDefinition,
     card
   );
-  expect(result).toEqual(
-    err(
-      typedAs<InterpretError>({
-        type: 'mismatched-election',
-        expectedElectionHash: sliceElectionHash(
-          electionGridLayoutNewHampshireTestBallotFixtures.electionDefinition
-            .electionHash
-        ),
-        actualElectionHash: sliceElectionHash(
-          electionFamousNames2021Fixtures.electionDefinition.electionHash
-        ),
-      })
-    )
+  expect(result).toEqual<InterpretResult>(
+    err({
+      type: 'mismatched-election',
+      expectedElectionHash: sliceElectionHash(
+        electionGridLayoutNewHampshireTestBallotFixtures.electionDefinition
+          .electionHash
+      ),
+      actualElectionHash: sliceElectionHash(
+        electionFamousNames2021Fixtures.electionDefinition.electionHash
+      ),
+    })
   );
 });

--- a/libs/ballot-interpreter/src/bmd/utils/qrcode.test.ts
+++ b/libs/ballot-interpreter/src/bmd/utils/qrcode.test.ts
@@ -1,5 +1,5 @@
 import { Buffer } from 'buffer';
-import { err, ok, typedAs } from '@votingworks/basics';
+import { err, ok } from '@votingworks/basics';
 import {
   electionFamousNames2021Fixtures,
   sampleBallotImages,
@@ -10,23 +10,19 @@ test('does not find QR codes when there are none to find', async () => {
   const detectResult = await detectInBallot(
     await sampleBallotImages.notBallot.asImageData()
   );
-  expect(detectResult).toEqual(
-    typedAs<QrCodePageResult>(err({ type: 'no-qr-code' }))
-  );
+  expect(detectResult).toEqual<QrCodePageResult>(err({ type: 'no-qr-code' }));
 });
 
 test('can read metadata encoded in a QR code with base64', async () => {
   const detectResult = await detectInBallot(
     await electionFamousNames2021Fixtures.machineMarkedBallotPage1.asImageData()
   );
-  expect(detectResult).toEqual(
-    typedAs<QrCodePageResult>(
-      ok({
-        data: expect.any(Buffer),
-        position: 'top',
-        detector: 'qrdetect',
-      })
-    )
+  expect(detectResult).toEqual<QrCodePageResult>(
+    ok({
+      data: expect.any(Buffer),
+      position: 'top',
+      detector: 'qrdetect',
+    })
   );
 });
 

--- a/libs/ballot-interpreter/src/hmpb-ts/find_template_grid_and_bubbles.test.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/find_template_grid_and_bubbles.test.ts
@@ -1,5 +1,5 @@
 import { ImageData } from 'canvas';
-import { err, typedAs } from '@votingworks/basics';
+import { err } from '@votingworks/basics';
 import {
   electionGridLayoutNewHampshireTestBallotFixtures,
   sampleBallotImages,
@@ -17,9 +17,10 @@ test('find layout from template images', async () => {
   const [front, back] = findTemplateGridAndBubbles(ballotImages).unsafeUnwrap();
 
   // the particulars of the grid are tested in template.rs
-  expect([front, back]).toEqual(
-    typedAs<SheetOf<TimingMarkGrid>>([expect.any(Object), expect.any(Object)])
-  );
+  expect([front, back]).toEqual<SheetOf<TimingMarkGrid>>([
+    expect.any(Object),
+    expect.any(Object),
+  ]);
   expect(front.metadata.side).toEqual('front');
   expect(back.metadata.side).toEqual('back');
   expect(front.bubbles).toBeDefined();

--- a/libs/ballot-interpreter/src/interpret_bmd_ballots.test.ts
+++ b/libs/ballot-interpreter/src/interpret_bmd_ballots.test.ts
@@ -13,7 +13,6 @@ import {
   ALL_PRECINCTS_SELECTION,
   singlePrecinctSelectionFor,
 } from '@votingworks/utils';
-import { typedAs } from '@votingworks/basics';
 import { sliceElectionHash } from '@votingworks/ballot-encoder';
 import { mockOf } from '@votingworks/test-utils';
 import {
@@ -253,13 +252,13 @@ describe('VX BMD interpretation', () => {
       validBmdSheet
     );
 
-    expect(interpretationResult[0].interpretation).toEqual(
-      typedAs<InvalidElectionHashPage>({
-        type: 'InvalidElectionHashPage',
-        actualElectionHash: sliceElectionHash(electionDefinition.electionHash),
-        expectedElectionHash: 'd34db33f',
-      })
-    );
+    expect(
+      interpretationResult[0].interpretation
+    ).toEqual<InvalidElectionHashPage>({
+      type: 'InvalidElectionHashPage',
+      actualElectionHash: sliceElectionHash(electionDefinition.electionHash),
+      expectedElectionHash: 'd34db33f',
+    });
   });
 
   test('properly identifies blank sheets', async () => {

--- a/libs/cdf-schema-builder/src/json_schema.test.ts
+++ b/libs/cdf-schema-builder/src/json_schema.test.ts
@@ -23,53 +23,49 @@ test('createEnumFromDefinition', () => {
   expect(createEnumFromDefinition('foo', {})).toBeUndefined();
   expect(
     createEnumFromDefinition('foo', { type: 'string', enum: ['a', 'b'] })
-  ).toEqual(
-    typedAs<Enum>({
-      name: 'foo',
-      values: [
-        {
-          name: 'A',
-          value: 'a',
-        },
-        {
-          name: 'B',
-          value: 'b',
-        },
-      ],
-    })
-  );
+  ).toEqual<Enum>({
+    name: 'foo',
+    values: [
+      {
+        name: 'A',
+        value: 'a',
+      },
+      {
+        name: 'B',
+        value: 'b',
+      },
+    ],
+  });
 });
 
 test('convertToGenericType', () => {
-  expect(convertToGenericType({ type: 'string' })).toEqual(
-    typedAs<Type>({ kind: 'string' })
-  );
-  expect(convertToGenericType({ type: 'string', enum: ['a', 'b'] })).toEqual(
-    typedAs<Type>({
-      kind: 'union',
-      types: [
-        { kind: 'literal', value: 'a' },
-        { kind: 'literal', value: 'b' },
-      ],
-    })
-  );
-  expect(convertToGenericType({ type: 'boolean' })).toEqual(
-    typedAs<Type>({ kind: 'boolean' })
-  );
-  expect(convertToGenericType({ type: 'integer' })).toEqual(
-    typedAs<Type>({ kind: 'integer' })
-  );
-  expect(convertToGenericType({ type: 'number' })).toEqual(
-    typedAs<Type>({ kind: 'number' })
-  );
+  expect(convertToGenericType({ type: 'string' })).toEqual<Type>({
+    kind: 'string',
+  });
+  expect(
+    convertToGenericType({ type: 'string', enum: ['a', 'b'] })
+  ).toEqual<Type>({
+    kind: 'union',
+    types: [
+      { kind: 'literal', value: 'a' },
+      { kind: 'literal', value: 'b' },
+    ],
+  });
+  expect(convertToGenericType({ type: 'boolean' })).toEqual<Type>({
+    kind: 'boolean',
+  });
+  expect(convertToGenericType({ type: 'integer' })).toEqual<Type>({
+    kind: 'integer',
+  });
+  expect(convertToGenericType({ type: 'number' })).toEqual<Type>({
+    kind: 'number',
+  });
   expect(
     convertToGenericType({ type: 'array', items: { type: 'string' } })
-  ).toEqual(
-    typedAs<Type>({
-      kind: 'array',
-      items: { kind: 'string' },
-    })
-  );
+  ).toEqual<Type>({
+    kind: 'array',
+    items: { kind: 'string' },
+  });
   expect(convertToGenericType({ $ref: '#/definitions/foo' })).toEqual({
     kind: 'reference',
     name: 'foo',
@@ -90,12 +86,10 @@ test('createInterfaceFromDefinition', () => {
       type: 'object',
       additionalProperties: false,
     })
-  ).toEqual(
-    typedAs<Interface>({
-      name: 'Person',
-      properties: [],
-    })
-  );
+  ).toEqual<Interface>({
+    name: 'Person',
+    properties: [],
+  });
   expect(
     createInterfaceFromDefinition('Person', {
       type: 'object',
@@ -106,13 +100,11 @@ test('createInterfaceFromDefinition', () => {
         age: { type: 'integer' },
       },
     })
-  ).toEqual(
-    typedAs<Interface>({
-      name: 'Person',
-      properties: [
-        { name: 'name', type: { kind: 'string' }, required: true },
-        { name: 'age', type: { kind: 'integer' }, required: false },
-      ],
-    })
-  );
+  ).toEqual<Interface>({
+    name: 'Person',
+    properties: [
+      { name: 'name', type: { kind: 'string' }, required: true },
+      { name: 'age', type: { kind: 'integer' }, required: false },
+    ],
+  });
 });

--- a/libs/cdf-schema-builder/src/xsd.test.ts
+++ b/libs/cdf-schema-builder/src/xsd.test.ts
@@ -1,4 +1,3 @@
-import { typedAs } from '@votingworks/basics';
 import { DocumentedEntity } from './types';
 import {
   extractDocumentation,
@@ -108,73 +107,71 @@ test('extractDocumentationForSchema', () => {
     []
   );
 
-  expect(extractDocumentationForSchema(schema)).toEqual(
-    typedAs<DocumentedEntity[]>([
-      {
-        kind: 'DocumentedType',
-        type: 'DayOfWeek',
-        documentation: 'A day of the week.',
-      },
-      {
-        kind: 'DocumentedProperty',
-        type: 'DayOfWeek',
-        name: 'Monday',
-        documentation: 'The first day of the week.',
-      },
-      {
-        kind: 'DocumentedProperty',
-        type: 'DayOfWeek',
-        name: 'Tuesday',
-        documentation: '',
-      },
-      {
-        kind: 'DocumentedProperty',
-        type: 'DayOfWeek',
-        name: 'Wednesday',
-      },
-      {
-        kind: 'DocumentedProperty',
-        type: 'DayOfWeek',
-        name: 'Thursday',
-      },
-      {
-        kind: 'DocumentedProperty',
-        type: 'DayOfWeek',
-        name: 'Friday',
-      },
-      {
-        kind: 'DocumentedProperty',
-        type: 'DayOfWeek',
-        name: 'Saturday',
-      },
-      {
-        kind: 'DocumentedProperty',
-        type: 'DayOfWeek',
-        name: 'Sunday',
-      },
-      {
-        kind: 'DocumentedType',
-        type: 'Person',
-        documentation: 'A person.',
-      },
-      {
-        kind: 'DocumentedProperty',
-        type: 'Person',
-        name: 'birthday',
-        documentation: `The person's birthday.`,
-      },
-      {
-        kind: 'DocumentedType',
-        type: 'PersonWithAddress',
-        extends: 'Person',
-      },
-      {
-        kind: 'DocumentedType',
-        type: 'Employee',
-        extends: 'PersonWithAddress',
-      },
-    ])
-  );
+  expect(extractDocumentationForSchema(schema)).toEqual<DocumentedEntity[]>([
+    {
+      kind: 'DocumentedType',
+      type: 'DayOfWeek',
+      documentation: 'A day of the week.',
+    },
+    {
+      kind: 'DocumentedProperty',
+      type: 'DayOfWeek',
+      name: 'Monday',
+      documentation: 'The first day of the week.',
+    },
+    {
+      kind: 'DocumentedProperty',
+      type: 'DayOfWeek',
+      name: 'Tuesday',
+      documentation: '',
+    },
+    {
+      kind: 'DocumentedProperty',
+      type: 'DayOfWeek',
+      name: 'Wednesday',
+    },
+    {
+      kind: 'DocumentedProperty',
+      type: 'DayOfWeek',
+      name: 'Thursday',
+    },
+    {
+      kind: 'DocumentedProperty',
+      type: 'DayOfWeek',
+      name: 'Friday',
+    },
+    {
+      kind: 'DocumentedProperty',
+      type: 'DayOfWeek',
+      name: 'Saturday',
+    },
+    {
+      kind: 'DocumentedProperty',
+      type: 'DayOfWeek',
+      name: 'Sunday',
+    },
+    {
+      kind: 'DocumentedType',
+      type: 'Person',
+      documentation: 'A person.',
+    },
+    {
+      kind: 'DocumentedProperty',
+      type: 'Person',
+      name: 'birthday',
+      documentation: `The person's birthday.`,
+    },
+    {
+      kind: 'DocumentedType',
+      type: 'PersonWithAddress',
+      extends: 'Person',
+    },
+    {
+      kind: 'DocumentedType',
+      type: 'Employee',
+      extends: 'PersonWithAddress',
+    },
+  ]);
 
   getChildOfType(
     getChildOfType(schema, 'xsd:simpleType')!,
@@ -188,13 +185,11 @@ test('extractDocumentationForSchema', () => {
     complexTypeElement.remove();
   }
 
-  expect(extractDocumentationForSchema(schema)).toEqual(
-    typedAs<DocumentedEntity[]>([
-      {
-        kind: 'DocumentedType',
-        type: 'DayOfWeek',
-        documentation: 'A day of the week.',
-      },
-    ])
-  );
+  expect(extractDocumentationForSchema(schema)).toEqual<DocumentedEntity[]>([
+    {
+      kind: 'DocumentedType',
+      type: 'DayOfWeek',
+      documentation: 'A day of the week.',
+    },
+  ]);
 });

--- a/libs/converter-nh-accuvote/src/convert/convert_election_definition.test.ts
+++ b/libs/converter-nh-accuvote/src/convert/convert_election_definition.test.ts
@@ -89,64 +89,64 @@ test('constitutional question ovals get placed on the grid correctly', async () 
   //   'utf8'
   // );
 
-  expect(converted).toEqual(
-    typedAs<ConvertResult extends Result<infer T, unknown> ? T : never>({
-      issues: expect.any(Array),
-      election: expect.objectContaining({
-        contests: expect.arrayContaining([
-          {
-            type: 'yesno',
-            id: 'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc',
-            title: 'Constitutional Amendment Question #1',
-            description:
-              'Shall there be a convention to amend or revise the constitution?',
-            districtId: unsafeParse(
-              DistrictIdSchema,
-              'town-id-00701-precinct-id-'
-            ),
-            yesOption: {
-              id: 'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-yes',
-              label: 'Yes',
-            },
-            noOption: {
-              id: 'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-no',
-              label: 'No',
-            },
+  expect(converted).toEqual<
+    ConvertResult extends Result<infer T, unknown> ? T : never
+  >({
+    issues: expect.any(Array),
+    election: expect.objectContaining({
+      contests: expect.arrayContaining([
+        {
+          type: 'yesno',
+          id: 'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc',
+          title: 'Constitutional Amendment Question #1',
+          description:
+            'Shall there be a convention to amend or revise the constitution?',
+          districtId: unsafeParse(
+            DistrictIdSchema,
+            'town-id-00701-precinct-id-'
+          ),
+          yesOption: {
+            id: 'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-yes',
+            label: 'Yes',
           },
-        ]),
-        gridLayouts: [
-          expect.objectContaining({
-            gridPositions: expect.arrayContaining(
-              typedAs<GridPosition[]>([
-                {
-                  type: 'option',
-                  contestId:
-                    'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc',
-                  optionId:
-                    'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-yes',
-                  sheetNumber: 1,
-                  side: 'back',
-                  column: 26,
-                  row: 24,
-                },
-                {
-                  type: 'option',
-                  contestId:
-                    'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc',
-                  optionId:
-                    'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-no',
-                  sheetNumber: 1,
-                  side: 'back',
-                  column: 32,
-                  row: 24,
-                },
-              ])
-            ),
-          }),
-        ],
-      }),
-    })
-  );
+          noOption: {
+            id: 'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-no',
+            label: 'No',
+          },
+        },
+      ]),
+      gridLayouts: [
+        expect.objectContaining({
+          gridPositions: expect.arrayContaining(
+            typedAs<GridPosition[]>([
+              {
+                type: 'option',
+                contestId:
+                  'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc',
+                optionId:
+                  'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-yes',
+                sheetNumber: 1,
+                side: 'back',
+                column: 26,
+                row: 24,
+              },
+              {
+                type: 'option',
+                contestId:
+                  'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc',
+                optionId:
+                  'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-no',
+                sheetNumber: 1,
+                side: 'back',
+                column: 32,
+                row: 24,
+              },
+            ])
+          ),
+        }),
+      ],
+    }),
+  });
 
   for (const issue of converted.issues) {
     expect(issue).not.toMatchObject({

--- a/libs/converter-nh-accuvote/src/convert/convert_election_definition_header.test.ts
+++ b/libs/converter-nh-accuvote/src/convert/convert_election_definition_header.test.ts
@@ -246,25 +246,25 @@ test('constitutional questions become yesno contests', async () => {
     nhTestBallotCardDefinition.definition
   ).unsafeUnwrap();
 
-  expect(converted.election.contests.filter((c) => c.type === 'yesno')).toEqual(
-    typedAs<YesNoContest[]>([
-      {
-        type: 'yesno',
-        id: 'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc',
-        title: 'Constitutional Amendment Question #1',
-        description:
-          'Shall there be a convention to amend or revise the constitution?',
-        districtId: unsafeParse(DistrictIdSchema, 'town-id-00701-precinct-id-'),
-        yesOption: {
-          id: 'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-yes',
-          label: 'Yes',
-        },
-        noOption: {
-          id: 'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-no',
-
-          label: 'No',
-        },
+  expect(converted.election.contests.filter((c) => c.type === 'yesno')).toEqual<
+    YesNoContest[]
+  >([
+    {
+      type: 'yesno',
+      id: 'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc',
+      title: 'Constitutional Amendment Question #1',
+      description:
+        'Shall there be a convention to amend or revise the constitution?',
+      districtId: unsafeParse(DistrictIdSchema, 'town-id-00701-precinct-id-'),
+      yesOption: {
+        id: 'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-yes',
+        label: 'Yes',
       },
-    ])
-  );
+      noOption: {
+        id: 'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-no',
+
+        label: 'No',
+      },
+    },
+  ]);
 });

--- a/libs/converter-nh-accuvote/src/convert/parse_constitutional_questions.test.ts
+++ b/libs/converter-nh-accuvote/src/convert/parse_constitutional_questions.test.ts
@@ -1,4 +1,3 @@
-import { typedAs } from '@votingworks/basics';
 import {
   parseConstitutionalQuestions,
   ParsedConstitutionalQuestions,
@@ -9,23 +8,21 @@ test('single simple question', () => {
     `<![CDATA[<div>CONSTITUTIONAL AMENDMENT QUESTION </div><div>Constitutional Amendment Proposed by the General Court</div><div>Question Proposed pursuant to Part II, Article 100 of the New Hampshire Constitution.</div><div>&nbsp;</div><div>"Shall there be a convention to amend or revise the constitution? &nbsp; &nbsp; YES&nbsp;&nbsp;<FONT face=Arial>&nbsp;<IMG src="http://ertuat.sos.nh.gov/ballotpaper/assets/images/oval.png""></FONT> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;NO&nbsp;&nbsp;<FONT face=Arial>&nbsp;<IMG src="http://ertuat.sos.nh.gov/ballotpaper/assets/images/oval.png""></FONT></div> `
   ).unsafeUnwrap();
 
-  expect(questions).toEqual(
-    typedAs<ParsedConstitutionalQuestions>({
-      title: 'CONSTITUTIONAL AMENDMENT QUESTION',
-      questions: [
-        {
-          number: undefined,
-          header: [
-            'Constitutional Amendment Proposed by the General Court',
-            '',
-            'Question Proposed pursuant to Part II, Article 100 of the New Hampshire Constitution.',
-          ].join('\n'),
-          title:
-            'Shall there be a convention to amend or revise the constitution?',
-        },
-      ],
-    })
-  );
+  expect(questions).toEqual<ParsedConstitutionalQuestions>({
+    title: 'CONSTITUTIONAL AMENDMENT QUESTION',
+    questions: [
+      {
+        number: undefined,
+        header: [
+          'Constitutional Amendment Proposed by the General Court',
+          '',
+          'Question Proposed pursuant to Part II, Article 100 of the New Hampshire Constitution.',
+        ].join('\n'),
+        title:
+          'Shall there be a convention to amend or revise the constitution?',
+      },
+    ],
+  });
 });
 
 test('multiple constitutional questions with long text', () => {
@@ -34,29 +31,27 @@ test('multiple constitutional questions with long text', () => {
     `<![CDATA[<div>2022 CONSTITUTIONAL AMENDMENT QUESTIONS</div><div>Constitutional Amendment Proposed by the 2022 General Court</div><div> </div><div>1.  "Are you in favor of amending articles 71 and 81 of the second part of the constitution to read as follows:</div><div>[Art.] 71. [County Treasurers, County Attorneys, Sheriffs, and Registers of Deeds Elected.] The county treasurers, county attorneys, sheriffs and registers of deeds, shall be elected by the inhabitants of the several towns, in the several counties in the State, according to the method now practiced, and the laws of the state, provided nevertheless the legislature shall have authority to alter the manner of certifying the votes, and the mode of electing those officers; but not so as to deprive the people of the right they now have of electing them. [Art.] 81. [Judges Not to Act as Counsel.] No judge shall be of counsel, act as advocate, or receive any fees as advocate or counsel, in any probate business which is pending, or may be brought into any court of probate in the county of which he or she is judge." </div><div>(Passed by the N.H. House 294 Yes 43 No; Passed by Senate 21 Yes 3 No.) CACR 21</div><div> </div><div>                                              YES   <FONT face=Arial> <IMG src="http://ertuat.sos.nh.gov/ballotpaper/assets/images/oval.png""></FONT>                                  NO  <FONT face=Arial> <IMG src="http://ertuat.sos.nh.gov/ballotpaper/assets/images/oval.png""></FONT></div><div> </div><div>Question Proposed pursuant to Part II, Article 100 of the New Hampshire Constitution</div><div> </div><div>2. "Shall there be a convention to amend or revise the constitution?"</div>                                YES  <FONT face=Arial> <IMG src="http://ertuat.sos.nh.gov/ballotpaper/assets/images/oval.png""></FONT>                                  NO  <FONT face=Arial> <IMG src="http://ertuat.sos.nh.gov/ballotpaper/assets/images/oval.png""></FONT></div><div> </div>]]>`
   ).unsafeUnwrap();
 
-  expect(questions).toEqual(
-    typedAs<ParsedConstitutionalQuestions>({
-      title: '2022 CONSTITUTIONAL AMENDMENT QUESTIONS',
-      questions: [
-        {
-          number: 1,
-          header: 'Constitutional Amendment Proposed by the 2022 General Court',
-          title: [
-            'Are you in favor of amending articles 71 and 81 of the second part of the constitution to read as follows:',
-            '',
-            '[Art.] 71. [County Treasurers, County Attorneys, Sheriffs, and Registers of Deeds Elected.] The county treasurers, county attorneys, sheriffs and registers of deeds, shall be elected by the inhabitants of the several towns, in the several counties in the State, according to the method now practiced, and the laws of the state, provided nevertheless the legislature shall have authority to alter the manner of certifying the votes, and the mode of electing those officers; but not so as to deprive the people of the right they now have of electing them. [Art.] 81. [Judges Not to Act as Counsel.] No judge shall be of counsel, act as advocate, or receive any fees as advocate or counsel, in any probate business which is pending, or may be brought into any court of probate in the county of which he or she is judge.',
-            '',
-            '(Passed by the N.H. House 294 Yes 43 No; Passed by Senate 21 Yes 3 No.) CACR 21',
-          ].join('\n'),
-        },
-        {
-          number: 2,
-          header:
-            'Question Proposed pursuant to Part II, Article 100 of the New Hampshire Constitution',
-          title:
-            'Shall there be a convention to amend or revise the constitution?',
-        },
-      ],
-    })
-  );
+  expect(questions).toEqual<ParsedConstitutionalQuestions>({
+    title: '2022 CONSTITUTIONAL AMENDMENT QUESTIONS',
+    questions: [
+      {
+        number: 1,
+        header: 'Constitutional Amendment Proposed by the 2022 General Court',
+        title: [
+          'Are you in favor of amending articles 71 and 81 of the second part of the constitution to read as follows:',
+          '',
+          '[Art.] 71. [County Treasurers, County Attorneys, Sheriffs, and Registers of Deeds Elected.] The county treasurers, county attorneys, sheriffs and registers of deeds, shall be elected by the inhabitants of the several towns, in the several counties in the State, according to the method now practiced, and the laws of the state, provided nevertheless the legislature shall have authority to alter the manner of certifying the votes, and the mode of electing those officers; but not so as to deprive the people of the right they now have of electing them. [Art.] 81. [Judges Not to Act as Counsel.] No judge shall be of counsel, act as advocate, or receive any fees as advocate or counsel, in any probate business which is pending, or may be brought into any court of probate in the county of which he or she is judge.',
+          '',
+          '(Passed by the N.H. House 294 Yes 43 No; Passed by Senate 21 Yes 3 No.) CACR 21',
+        ].join('\n'),
+      },
+      {
+        number: 2,
+        header:
+          'Question Proposed pursuant to Part II, Article 100 of the New Hampshire Constitution',
+        title:
+          'Shall there be a convention to amend or revise the constitution?',
+      },
+    ],
+  });
 });

--- a/libs/custom-scanner/src/mocks/web_usb_device.test.ts
+++ b/libs/custom-scanner/src/mocks/web_usb_device.test.ts
@@ -1,4 +1,3 @@
-import { typedAs } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import { mockWebUsbDevice } from './web_usb_device';
 
@@ -150,11 +149,9 @@ test('read/write with halts', async () => {
   await device.clearHalt('in', 8);
 
   await device.mockStallEndpoint(8);
-  expect(await device.transferIn(8, 1)).toEqual(
-    typedAs<USBInTransferResult>({
-      status: 'stall',
-    })
-  );
+  expect(await device.transferIn(8, 1)).toEqual<USBInTransferResult>({
+    status: 'stall',
+  });
   await device.clearHalt('in', 8);
   await expect(
     device.mockAddTransferInData(10, Buffer.of(1, 2, 3))
@@ -163,40 +160,38 @@ test('read/write with halts', async () => {
   const arrayBuffer = new ArrayBuffer(3);
   const uint8Array = new Uint8Array(arrayBuffer);
   uint8Array.set([1, 2, 3]);
-  expect(await device.transferIn(8, 1)).toEqual(
-    typedAs<USBInTransferResult>({
-      status: 'ok',
-      data: new DataView(arrayBuffer, 0, 3),
-    })
-  );
+  expect(await device.transferIn(8, 1)).toEqual<USBInTransferResult>({
+    status: 'ok',
+    data: new DataView(arrayBuffer, 0, 3),
+  });
   await expect(device.transferIn(10, 1)).rejects.toThrow(
     'endpoint direction is out'
   );
 
   await device.mockStallEndpoint(10);
-  expect(await device.transferOut(10, Buffer.of(1, 2, 3))).toEqual(
-    typedAs<USBOutTransferResult>({
-      status: 'stall',
-      bytesWritten: 0,
-    })
-  );
+  expect(
+    await device.transferOut(10, Buffer.of(1, 2, 3))
+  ).toEqual<USBOutTransferResult>({
+    status: 'stall',
+    bytesWritten: 0,
+  });
   await expect(device.clearHalt('in', 10)).rejects.toThrow(
     'endpoint direction does not match'
   );
   await device.clearHalt('out', 10);
   expect(await device.mockGetTransferOutData(10)).toHaveLength(0);
-  expect(await device.transferOut(10, Buffer.of(1, 2, 3))).toEqual(
-    typedAs<USBOutTransferResult>({
-      status: 'ok',
-      bytesWritten: 3,
-    })
-  );
-  expect(await device.transferOut(10, arrayBuffer)).toEqual(
-    typedAs<USBOutTransferResult>({
-      status: 'ok',
-      bytesWritten: 3,
-    })
-  );
+  expect(
+    await device.transferOut(10, Buffer.of(1, 2, 3))
+  ).toEqual<USBOutTransferResult>({
+    status: 'ok',
+    bytesWritten: 3,
+  });
+  expect(
+    await device.transferOut(10, arrayBuffer)
+  ).toEqual<USBOutTransferResult>({
+    status: 'ok',
+    bytesWritten: 3,
+  });
   expect(await device.mockGetTransferOutData(10)).toHaveLength(2);
   await expect(device.transferOut(8, Buffer.of(1, 2, 3))).rejects.toThrow(
     'endpoint direction is in'
@@ -206,16 +201,12 @@ test('read/write with halts', async () => {
   await device.mockLimitNextTransferInSize(8, 2);
   await device.mockLimitNextTransferInSize(8, 1);
   await device.mockAddTransferInData(8, Buffer.of(1, 2, 3));
-  expect(await device.transferIn(8, 3)).toEqual(
-    typedAs<USBInTransferResult>({
-      status: 'ok',
-      data: new DataView(arrayBuffer, 0, 2),
-    })
-  );
-  expect(await device.transferIn(8, 3)).toEqual(
-    typedAs<USBInTransferResult>({
-      status: 'ok',
-      data: new DataView(arrayBuffer, 2, 1),
-    })
-  );
+  expect(await device.transferIn(8, 3)).toEqual<USBInTransferResult>({
+    status: 'ok',
+    data: new DataView(arrayBuffer, 0, 2),
+  });
+  expect(await device.transferIn(8, 3)).toEqual<USBInTransferResult>({
+    status: 'ok',
+    data: new DataView(arrayBuffer, 2, 1),
+  });
 });

--- a/libs/custom-scanner/src/protocol.test.ts
+++ b/libs/custom-scanner/src/protocol.test.ts
@@ -150,56 +150,47 @@ test('checkAnswer', () => {
   const ackAnswer = AckResponseMessage.encode({
     jobId: 0x01,
   }).assertOk('should encode');
-  expect(checkAnswer(ackAnswer)).toEqual(
-    typedAs<CheckAnswerResult>({ type: 'ack', jobId: 0x01 })
-  );
+  expect(checkAnswer(ackAnswer)).toEqual<CheckAnswerResult>({
+    type: 'ack',
+    jobId: 0x01,
+  });
 
   const formatErrorAnswer = ErrorResponseMessage.encode({
     errorCode: ResponseErrorCode.FORMAT_ERROR,
   }).assertOk('should encode');
-  expect(checkAnswer(formatErrorAnswer)).toEqual(
-    typedAs<CheckAnswerResult>({
-      type: 'error',
-      errorCode: ErrorCode.CommunicationUnknownError,
-    })
-  );
+  expect(checkAnswer(formatErrorAnswer)).toEqual<CheckAnswerResult>({
+    type: 'error',
+    errorCode: ErrorCode.CommunicationUnknownError,
+  });
 
   const invalidCommandErrorAnswer = ErrorResponseMessage.encode({
     errorCode: ResponseErrorCode.INVALID_COMMAND,
   }).assertOk('should encode');
-  expect(checkAnswer(invalidCommandErrorAnswer)).toEqual(
-    typedAs<CheckAnswerResult>({
-      type: 'error',
-      errorCode: ErrorCode.InvalidCommand,
-    })
-  );
+  expect(checkAnswer(invalidCommandErrorAnswer)).toEqual<CheckAnswerResult>({
+    type: 'error',
+    errorCode: ErrorCode.InvalidCommand,
+  });
 
   const jobNotValidErrorAnswer = ErrorResponseMessage.encode({
     errorCode: ResponseErrorCode.INVALID_JOB_ID,
   }).assertOk('should encode');
-  expect(checkAnswer(jobNotValidErrorAnswer)).toEqual(
-    typedAs<CheckAnswerResult>({
-      type: 'error',
-      errorCode: ErrorCode.JobNotValid,
-    })
-  );
+  expect(checkAnswer(jobNotValidErrorAnswer)).toEqual<CheckAnswerResult>({
+    type: 'error',
+    errorCode: ErrorCode.JobNotValid,
+  });
 
   const dataAnswer = DataResponseMessage.encode({
     data: 'hello',
   }).assertOk('should encode');
-  expect(checkAnswer(dataAnswer)).toEqual(
-    typedAs<CheckAnswerResult>({
-      type: 'data',
-      data: 'hello',
-    })
-  );
+  expect(checkAnswer(dataAnswer)).toEqual<CheckAnswerResult>({
+    type: 'data',
+    data: 'hello',
+  });
 
-  expect(checkAnswer(Buffer.alloc(0))).toEqual(
-    typedAs<CheckAnswerResult>({
-      type: 'other',
-      buffer: Buffer.alloc(0),
-    })
-  );
+  expect(checkAnswer(Buffer.alloc(0))).toEqual<CheckAnswerResult>({
+    type: 'other',
+    buffer: Buffer.alloc(0),
+  });
 });
 
 test('sendRequest (experiment)', async () => {

--- a/libs/custom-scanner/test/arbitraries.ts
+++ b/libs/custom-scanner/test/arbitraries.ts
@@ -327,7 +327,7 @@ export function arbitraryRequest(): fc.Arbitrary<AnyRequest> {
           type: 'JobCreateRequest',
           coder: JobCreateRequest,
           value,
-        }) as const
+        } as const)
     ),
     arbitraryJobEndRequest().map(
       (value) =>
@@ -335,7 +335,7 @@ export function arbitraryRequest(): fc.Arbitrary<AnyRequest> {
           type: 'JobEndRequest',
           coder: JobEndRequest,
           value,
-        }) as const
+        } as const)
     ),
     arbitraryGetImageDataRequest().map(
       (value) =>
@@ -343,7 +343,7 @@ export function arbitraryRequest(): fc.Arbitrary<AnyRequest> {
           type: 'GetImageDataRequest',
           coder: GetImageDataRequest,
           value,
-        }) as const
+        } as const)
     ),
     arbitrarySetScanParametersRequest().map(
       (value) =>
@@ -351,7 +351,7 @@ export function arbitraryRequest(): fc.Arbitrary<AnyRequest> {
           type: 'SetScanParametersRequest',
           coder: SetScanParametersRequest,
           value,
-        }) as const
+        } as const)
     ),
     arbitrarySetScanParametersRequestData().map(
       (value) =>
@@ -359,7 +359,7 @@ export function arbitraryRequest(): fc.Arbitrary<AnyRequest> {
           type: 'SetScanParametersRequestData',
           coder: SetScanParametersRequestData,
           value,
-        }) as const
+        } as const)
     ),
     arbitraryStartScanRequest().map(
       (value) =>
@@ -367,7 +367,7 @@ export function arbitraryRequest(): fc.Arbitrary<AnyRequest> {
           type: 'StartScanRequest',
           coder: StartScanRequest,
           value,
-        }) as const
+        } as const)
     ),
     arbitraryStopScanRequest().map(
       (value) =>
@@ -375,7 +375,7 @@ export function arbitraryRequest(): fc.Arbitrary<AnyRequest> {
           type: 'StopScanRequest',
           coder: StopScanRequest,
           value,
-        }) as const
+        } as const)
     ),
     arbitraryHardwareResetRequest().map(
       (value) =>
@@ -383,7 +383,7 @@ export function arbitraryRequest(): fc.Arbitrary<AnyRequest> {
           type: 'HardwareResetRequest',
           coder: HardwareResetRequest,
           value,
-        }) as const
+        } as const)
     ),
     arbitraryFormMovementRequest().map(
       (value) =>
@@ -391,7 +391,7 @@ export function arbitraryRequest(): fc.Arbitrary<AnyRequest> {
           type: 'FormMovementRequest',
           coder: FormMovementRequest,
           value,
-        }) as const
+        } as const)
     ),
     arbitraryStatusInternalRequest().map(
       (value) =>
@@ -399,7 +399,7 @@ export function arbitraryRequest(): fc.Arbitrary<AnyRequest> {
           type: 'StatusInternalRequest',
           coder: StatusInternalRequest,
           value,
-        }) as const
+        } as const)
     ),
     arbitraryReleaseVersionRequest().map(
       (value) =>
@@ -407,7 +407,7 @@ export function arbitraryRequest(): fc.Arbitrary<AnyRequest> {
           type: 'ReleaseVersionRequest',
           coder: ReleaseVersionRequest,
           value,
-        }) as const
+        } as const)
     ),
     arbitraryMapParametersRequest().map(
       (value) =>
@@ -415,7 +415,7 @@ export function arbitraryRequest(): fc.Arbitrary<AnyRequest> {
           type: 'MapParametersRequest',
           coder: MapParametersRequest,
           value,
-        }) as const
+        } as const)
     ),
     arbitraryMapParametersRequestData().map(
       (value) =>
@@ -423,7 +423,7 @@ export function arbitraryRequest(): fc.Arbitrary<AnyRequest> {
           type: 'MapParametersRequestData',
           coder: MapParametersRequestData,
           value,
-        }) as const
+        } as const)
     )
   );
 }
@@ -499,7 +499,7 @@ export function arbitraryResponse(): fc.Arbitrary<AnyResponse> {
           type: 'AckResponseMessage',
           coder: AckResponseMessage,
           value,
-        }) as const
+        } as const)
     ),
     arbitraryErrorResponseMessage().map(
       (value) =>
@@ -507,7 +507,7 @@ export function arbitraryResponse(): fc.Arbitrary<AnyResponse> {
           type: 'ErrorResponseMessage',
           coder: ErrorResponseMessage,
           value,
-        }) as const
+        } as const)
     ),
     arbitraryDataResponseMessage().map(
       (value) =>
@@ -515,7 +515,7 @@ export function arbitraryResponse(): fc.Arbitrary<AnyResponse> {
           type: 'DataResponseMessage',
           coder: DataResponseMessage,
           value,
-        }) as const
+        } as const)
     ),
     arbitraryStatusInternalMessage().map(
       (value) =>
@@ -523,7 +523,7 @@ export function arbitraryResponse(): fc.Arbitrary<AnyResponse> {
           type: 'StatusInternalMessage',
           coder: StatusInternalMessage,
           value,
-        }) as const
+        } as const)
     )
   );
 }

--- a/libs/message-coder/src/fixed_string.test.ts
+++ b/libs/message-coder/src/fixed_string.test.ts
@@ -1,4 +1,4 @@
-import { err, ok, typedAs } from '@votingworks/basics';
+import { err, ok } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import fc from 'fast-check';
 import { toBitOffset } from './bits';
@@ -21,8 +21,8 @@ test('fixed string', () => {
   expect(coder.encodeInto('abc', buffer, 0)).toEqual(ok(40));
   // 0x01 is the fill value
   expect(buffer).toEqual(Buffer.from('abc\0\0\x01\x01\x01\x01\x01'));
-  expect(coder.decodeFrom(buffer, 0)).toEqual(
-    typedAs<DecodeResult<coder>>(ok({ value: 'abc', bitOffset: 40 }))
+  expect(coder.decodeFrom(buffer, 0)).toEqual<DecodeResult<coder>>(
+    ok({ value: 'abc', bitOffset: 40 })
   );
 });
 
@@ -33,8 +33,8 @@ test('fixed string with trailing nulls', () => {
 
   expect(coder.default()).toEqual('\0\0\0\0\0');
   expect(coder.encodeInto('abc', buffer, 0)).toEqual(ok(40));
-  expect(coder.decodeFrom(buffer, 0)).toEqual(
-    typedAs<DecodeResult<coder>>(ok({ value: 'abc\0\0', bitOffset: 40 }))
+  expect(coder.decodeFrom(buffer, 0)).toEqual<DecodeResult<coder>>(
+    ok({ value: 'abc\0\0', bitOffset: 40 })
   );
   expect(coder.decode(buffer)).toEqual(ok('abc\0\0'));
 });
@@ -74,11 +74,9 @@ test('fixed string random', () => {
           ok(bitOffset + coder.bitLength(s).unsafeUnwrap())
         );
         expect(buffer.slice(byteOffset).toString('utf8')).toEqual(s);
-        expect(coder.decodeFrom(buffer, toBitOffset(byteOffset))).toEqual(
-          typedAs<DecodeResult<coder>>(
-            ok({ value: s, bitOffset: toBitOffset(byteOffset + byteLength) })
-          )
-        );
+        expect(coder.decodeFrom(buffer, toBitOffset(byteOffset))).toEqual<
+          DecodeResult<coder>
+        >(ok({ value: s, bitOffset: toBitOffset(byteOffset + byteLength) }));
       }
     )
   );

--- a/libs/message-coder/src/literal_coder.test.ts
+++ b/libs/message-coder/src/literal_coder.test.ts
@@ -1,4 +1,4 @@
-import { err, ok, typedAs } from '@votingworks/basics';
+import { err, ok } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import * as fc from 'fast-check';
 import { literal } from './literal_coder';
@@ -39,13 +39,11 @@ test('literal', () => {
         expect(buffer.subarray(byteOffset, byteOffset + bytes.length)).toEqual(
           Buffer.from(bytes)
         );
-        expect(lit.decodeFrom(buffer, bitOffset)).toEqual(
-          typedAs<DecodeResult<lit>>(
-            ok({
-              value: undefined,
-              bitOffset: bitOffset + bytes.length * 8,
-            })
-          )
+        expect(lit.decodeFrom(buffer, bitOffset)).toEqual<DecodeResult<lit>>(
+          ok({
+            value: undefined,
+            bitOffset: bitOffset + bytes.length * 8,
+          })
         );
       }
     )

--- a/libs/message-coder/src/message_coder.test.ts
+++ b/libs/message-coder/src/message_coder.test.ts
@@ -17,12 +17,12 @@ test('empty message', () => {
   expect(m.default()).toEqual({});
   expect(m.bitLength({})).toEqual(ok(0));
   expect(m.encode({})).toEqual(ok(Buffer.alloc(0)));
-  expect(m.decode(Buffer.alloc(0))).toEqual(typedAs<m>(ok({})));
+  expect(m.decode(Buffer.alloc(0))).toEqual<m>(ok({}));
 
   const buffer = Buffer.alloc(100);
   expect(m.encodeInto({}, buffer, 0)).toEqual(ok(0));
-  expect(m.decodeFrom(buffer, 0)).toEqual(
-    typedAs<DecodeResult<m>>(ok({ value: {}, bitOffset: 0 }))
+  expect(m.decodeFrom(buffer, 0)).toEqual<DecodeResult<m>>(
+    ok({ value: {}, bitOffset: 0 })
   );
 });
 

--- a/libs/message-coder/src/uint16_coder.test.ts
+++ b/libs/message-coder/src/uint16_coder.test.ts
@@ -1,4 +1,4 @@
-import { err, ok, typedAs } from '@votingworks/basics';
+import { err, ok } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import * as fc from 'fast-check';
 import { MAX_UINT16 } from './constants';
@@ -21,9 +21,9 @@ test('uint16', () => {
           ok(bitOffset + 16)
         );
         expect(buffer.readUInt16LE(byteOffset)).toEqual(value);
-        expect(field.decodeFrom(buffer, bitOffset)).toEqual(
-          typedAs<DecodeResult<field>>(ok({ value, bitOffset: bitOffset + 16 }))
-        );
+        expect(field.decodeFrom(buffer, bitOffset)).toEqual<
+          DecodeResult<field>
+        >(ok({ value, bitOffset: bitOffset + 16 }));
       }
     )
   );
@@ -44,9 +44,9 @@ test('uint16 with littleEndian=false', () => {
           ok(bitOffset + 16)
         );
         expect(buffer.readUInt16BE(byteOffset)).toEqual(value);
-        expect(field.decodeFrom(buffer, bitOffset)).toEqual(
-          typedAs<DecodeResult<field>>(ok({ value, bitOffset: bitOffset + 16 }))
-        );
+        expect(field.decodeFrom(buffer, bitOffset)).toEqual<
+          DecodeResult<field>
+        >(ok({ value, bitOffset: bitOffset + 16 }));
       }
     )
   );

--- a/libs/message-coder/src/uint24_coder.test.ts
+++ b/libs/message-coder/src/uint24_coder.test.ts
@@ -1,4 +1,4 @@
-import { err, ok, typedAs } from '@votingworks/basics';
+import { err, ok } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import * as fc from 'fast-check';
 import { MAX_UINT24 } from './constants';
@@ -21,9 +21,9 @@ test('uint24', () => {
           ok(bitOffset + 24)
         );
         expect(buffer.readUInt32LE(byteOffset) & 0x00ffffff).toEqual(value);
-        expect(field.decodeFrom(buffer, bitOffset)).toEqual(
-          typedAs<DecodeResult<field>>(ok({ value, bitOffset: bitOffset + 24 }))
-        );
+        expect(field.decodeFrom(buffer, bitOffset)).toEqual<
+          DecodeResult<field>
+        >(ok({ value, bitOffset: bitOffset + 24 }));
       }
     )
   );

--- a/libs/message-coder/src/uint32_coder.test.ts
+++ b/libs/message-coder/src/uint32_coder.test.ts
@@ -1,4 +1,4 @@
-import { err, ok, typedAs } from '@votingworks/basics';
+import { err, ok } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import * as fc from 'fast-check';
 import { MAX_UINT32 } from './constants';
@@ -21,9 +21,9 @@ test('uint32', () => {
           ok(bitOffset + 32)
         );
         expect(buffer.readUInt32LE(byteOffset)).toEqual(value);
-        expect(field.decodeFrom(buffer, bitOffset)).toEqual(
-          typedAs<DecodeResult<field>>(ok({ value, bitOffset: bitOffset + 32 }))
-        );
+        expect(field.decodeFrom(buffer, bitOffset)).toEqual<
+          DecodeResult<field>
+        >(ok({ value, bitOffset: bitOffset + 32 }));
       }
     )
   );
@@ -44,9 +44,9 @@ test('uint32 with little-endian=false', () => {
           ok(bitOffset + 32)
         );
         expect(buffer.readUInt32BE(byteOffset)).toEqual(value);
-        expect(field.decodeFrom(buffer, bitOffset)).toEqual(
-          typedAs<DecodeResult<field>>(ok({ value, bitOffset: bitOffset + 32 }))
-        );
+        expect(field.decodeFrom(buffer, bitOffset)).toEqual<
+          DecodeResult<field>
+        >(ok({ value, bitOffset: bitOffset + 32 }));
       }
     )
   );

--- a/libs/message-coder/src/uint4_coder.test.ts
+++ b/libs/message-coder/src/uint4_coder.test.ts
@@ -1,4 +1,4 @@
-import { err, ok, typedAs } from '@votingworks/basics';
+import { err, ok } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import * as fc from 'fast-check';
 import { MAX_UINT4 } from './constants';
@@ -22,21 +22,21 @@ test('uint4', () => {
           ok(bitOffset + 4)
         );
         expect(buffer.readUInt8(byteOffset) & 0xf0).toEqual(value << 4);
-        expect(field.decodeFrom(buffer, bitOffset)).toEqual(
-          typedAs<DecodeResult<field>>(ok({ value, bitOffset: bitOffset + 4 }))
-        );
+        expect(field.decodeFrom(buffer, bitOffset)).toEqual<
+          DecodeResult<field>
+        >(ok({ value, bitOffset: bitOffset + 4 }));
 
         expect(field.encodeInto(value, buffer, bitOffset + 4)).toEqual(
           ok(bitOffset + 8)
         );
         expect(buffer.readUInt8(byteOffset) & 0x0f).toEqual(value);
-        expect(field.decodeFrom(buffer, bitOffset + 4)).toEqual(
-          typedAs<DecodeResult<field>>(
-            ok({
-              value,
-              bitOffset: bitOffset + 8,
-            })
-          )
+        expect(field.decodeFrom(buffer, bitOffset + 4)).toEqual<
+          DecodeResult<field>
+        >(
+          ok({
+            value,
+            bitOffset: bitOffset + 8,
+          })
         );
       }
     )

--- a/libs/message-coder/src/uint8_coder.test.ts
+++ b/libs/message-coder/src/uint8_coder.test.ts
@@ -1,4 +1,4 @@
-import { err, ok, typedAs } from '@votingworks/basics';
+import { err, ok } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import * as fc from 'fast-check';
 import { MAX_UINT8 } from './constants';
@@ -21,9 +21,9 @@ test('uint8', () => {
           ok(bitOffset + 8)
         );
         expect(buffer.readUInt8(byteOffset)).toEqual(value);
-        expect(field.decodeFrom(buffer, bitOffset)).toEqual(
-          typedAs<DecodeResult<field>>(ok({ value, bitOffset: bitOffset + 8 }))
-        );
+        expect(field.decodeFrom(buffer, bitOffset)).toEqual<
+          DecodeResult<field>
+        >(ok({ value, bitOffset: bitOffset + 8 }));
       }
     )
   );

--- a/libs/printing/src/printer/mocks/file_printer.test.ts
+++ b/libs/printing/src/printer/mocks/file_printer.test.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'buffer';
 import { existsSync, readFileSync, readdirSync } from 'fs';
-import { sleep, typedAs } from '@votingworks/basics';
+import { sleep } from '@votingworks/basics';
 import { PrinterStatus } from '@votingworks/types';
 import {
   DEFAULT_MOCK_USB_DRIVE_DIR,
@@ -20,9 +20,9 @@ test('mock file printer', async () => {
   const filePrinter = new MockFilePrinter();
   const filePrinterHandler = getMockFilePrinterHandler();
 
-  expect(await filePrinter.status()).toEqual(
-    typedAs<PrinterStatus>({ connected: false })
-  );
+  expect(await filePrinter.status()).toEqual<PrinterStatus>({
+    connected: false,
+  });
   expect(filePrinterHandler.getPrinterStatus()).toEqual(
     await filePrinter.status()
   );
@@ -31,13 +31,11 @@ test('mock file printer', async () => {
   ).rejects.toThrow();
 
   filePrinterHandler.connectPrinter(HP_LASER_PRINTER_CONFIG);
-  expect(await filePrinter.status()).toEqual(
-    typedAs<PrinterStatus>({
-      connected: true,
-      config: HP_LASER_PRINTER_CONFIG,
-      richStatus: MOCK_PRINTER_RICH_STATUS,
-    })
-  );
+  expect(await filePrinter.status()).toEqual<PrinterStatus>({
+    connected: true,
+    config: HP_LASER_PRINTER_CONFIG,
+    richStatus: MOCK_PRINTER_RICH_STATUS,
+  });
   expect(filePrinterHandler.getPrinterStatus()).toEqual(
     await filePrinter.status()
   );
@@ -66,9 +64,9 @@ test('mock file printer', async () => {
   );
 
   filePrinterHandler.disconnectPrinter();
-  expect(await filePrinter.status()).toEqual(
-    typedAs<PrinterStatus>({ connected: false })
-  );
+  expect(await filePrinter.status()).toEqual<PrinterStatus>({
+    connected: false,
+  });
   expect(filePrinterHandler.getPrinterStatus()).toEqual(
     await filePrinter.status()
   );

--- a/libs/utils/src/hmpb/all_contest_options.test.ts
+++ b/libs/utils/src/hmpb/all_contest_options.test.ts
@@ -5,7 +5,7 @@ import {
 } from '@votingworks/test-utils';
 import { ContestOption } from '@votingworks/types';
 import fc from 'fast-check';
-import { assert, typedAs } from '@votingworks/basics';
+import { assert } from '@votingworks/basics';
 import { allContestOptions } from './all_contest_options';
 
 test('candidate contest with no write-ins', () => {
@@ -108,24 +108,22 @@ test('candidate contest with provided write-in IDs', () => {
 test('yesno contest', () => {
   fc.assert(
     fc.property(arbitraryYesNoContest(), (contest) => {
-      expect(Array.from(allContestOptions(contest))).toEqual(
-        typedAs<ContestOption[]>([
-          {
-            type: 'yesno',
-            id: contest.yesOption.id,
-            contestId: contest.id,
-            name: contest.yesOption.label,
-            optionIndex: 0,
-          },
-          {
-            type: 'yesno',
-            id: contest.noOption.id,
-            contestId: contest.id,
-            name: contest.noOption.label,
-            optionIndex: 1,
-          },
-        ])
-      );
+      expect(Array.from(allContestOptions(contest))).toEqual<ContestOption[]>([
+        {
+          type: 'yesno',
+          id: contest.yesOption.id,
+          contestId: contest.id,
+          name: contest.yesOption.label,
+          optionIndex: 0,
+        },
+        {
+          type: 'yesno',
+          id: contest.noOption.id,
+          contestId: contest.id,
+          name: contest.noOption.label,
+          optionIndex: 1,
+        },
+      ]);
     })
   );
 });

--- a/libs/utils/src/json_stream.test.ts
+++ b/libs/utils/src/json_stream.test.ts
@@ -1,4 +1,4 @@
-import { integers, iter, typedAs } from '@votingworks/basics';
+import { integers, iter } from '@votingworks/basics';
 import * as fc from 'fast-check';
 import { jsonStream, JsonStreamInput, JsonStreamOptions } from './json_stream';
 
@@ -116,27 +116,25 @@ test('allows iterables instead of arrays at any nesting level', async () => {
         },
       ])
     )
-  ).toEqual(
-    typedAs<Movie[]>([
-      {
-        title: 'The Matrix',
-        actors: [
-          {
-            name: 'Keanu Reeves',
-            awards: ['MTV Movie & TV Award for Best Male Performance'],
-          },
-          {
-            name: 'Laurence Fishburne',
-            awards: ['MTV Movie & TV Award for Best Fight'],
-          },
-          {
-            name: 'Carrie-Anne Moss',
-            awards: ['Empire Award for Best Newcomer'],
-          },
-        ],
-      },
-    ])
-  );
+  ).toEqual<Movie[]>([
+    {
+      title: 'The Matrix',
+      actors: [
+        {
+          name: 'Keanu Reeves',
+          awards: ['MTV Movie & TV Award for Best Male Performance'],
+        },
+        {
+          name: 'Laurence Fishburne',
+          awards: ['MTV Movie & TV Award for Best Fight'],
+        },
+        {
+          name: 'Carrie-Anne Moss',
+          awards: ['Empire Award for Best Newcomer'],
+        },
+      ],
+    },
+  ]);
 });
 
 test('fails with circular references', async () => {

--- a/libs/utils/src/tabulation/tabulation.test.ts
+++ b/libs/utils/src/tabulation/tabulation.test.ts
@@ -1186,16 +1186,14 @@ test('convertManualElectionResults', () => {
       ballotCount: 5,
       contestResults: {},
     })
-  ).toEqual(
-    typedAs<Tabulation.ElectionResults>({
-      cardCounts: {
-        bmd: 0,
-        hmpb: [],
-        manual: 5,
-      },
-      contestResults: {},
-    })
-  );
+  ).toEqual<Tabulation.ElectionResults>({
+    cardCounts: {
+      bmd: 0,
+      hmpb: [],
+      manual: 5,
+    },
+    contestResults: {},
+  });
 });
 
 test('mergeManualWriteInTallies', () => {


### PR DESCRIPTION
## Overview
Replaces `expect(…).toEqual(typedAs<T>(…))` with `expect(…).toEqual<T>(…)`.

## Demo Video or Screenshot

Here's the codemod I used:

```ts
export default function (): babel.PluginItem {
  return {
    visitor: {
      ExpressionStatement(path) {
        const expression = path.get('expression');
        if (!expression.isCallExpression()) {
          return;
        }

        const callee = expression.get('callee');
        if (!callee.isMemberExpression()) {
          return;
        }

        const object = callee.get('object');
        if (
          !object.isCallExpression() ||
          !object.get('callee').isIdentifier({ name: 'expect' })
        ) {
          return;
        }

        const property = callee.get('property');

        if (
          !property.isIdentifier({ name: 'toEqual' }) &&
          !property.isIdentifier({ name: 'toStrictEqual' })
        ) {
          return;
        }

        const args = expression.get('arguments');
        if (args.length !== 1) {
          return;
        }

        const arg = args[0];
        if (!arg.isCallExpression()) {
          return;
        }

        const argCallee = arg.get('callee');
        if (!argCallee.isIdentifier({ name: 'typedAs' })) {
          return;
        }

        if (!arg.node.typeParameters) {
          return;
        }

        // replace `expect(foo).toEqual(typedAs<Baz>(baz))` with `expect(foo).toEqual<Baz>(baz)`
        const innerArg = arg.get('arguments')[0];
        const typeParameters = arg.get('typeParameters');

        expression.node.arguments = [innerArg.node];
        expression.node.typeParameters = typeParameters.node;
      },
    },
  };
}
```

