### PR TITLE
libs/hmpb: Rework fix to wait for HTML to load during rendering

### DIFF
--- a/libs/hmpb/src/renderer.tsx
+++ b/libs/hmpb/src/renderer.tsx
@@ -43,13 +43,17 @@ export function createDocument(page: Page) {
             throw new Error(`No element found with selector: ${selector}`);
           }
 
+          node.innerHTML = content;
           // After we set the innerHTML, we wait for the DOM to finish updating
-          // with the new content, which will be picked up by the
-          // MutationObserver registered on the node.
+          // with the new content. requestAnimationFrame will call the supplied
+          // callback before the next repaint, so we call it twice to wait for
+          // exactly one repaint to occur.
           return new Promise<void>((resolve) => {
-            const observer = new MutationObserver(() => resolve());
-            observer.observe(node, { childList: true });
-            node.innerHTML = content;
+            requestAnimationFrame(() => {
+              requestAnimationFrame(() => {
+                resolve();
+              });
+            });
           });
         },
         [selector, htmlContent]


### PR DESCRIPTION


## Overview

I had tried out using a MutationObserver to wait for DOM content to load after being inserted (https://github.com/votingworks/vxsuite/pull/4957). However, the same issue occurred again, where some content was still changing after the observer fired. I think it only appeared to work by delaying things slightly without actually solving the problem.

Here is a new approach where we use requestAnimationFrame to wait for the next browser repaint. This seems to work, though similarly to last time I can't be 100% confident that it's solving the problem, so we'll need to wait and see.
## Demo Video or Screenshot
N/A

## Testing Plan
Manual testing with an example that was buggy before, and now works.
## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
