### PR TITLE
refactor(ballot-interpreter): improve code legibility

### DIFF
--- a/libs/ballot-interpreter/src/hmpb-rust/timing_mark_metadata.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/timing_mark_metadata.rs
@@ -29,7 +29,7 @@ pub struct BallotConfig {
     /// Batch or precinct number from bits 2-14 (13 bits).
     pub batch_or_precinct: u16,
 
-    /// Card number (CardRotID) from bits 15-27 (13 bits).
+    /// Card number (cardRotID) from bits 15-27 (13 bits).
     pub card: u16,
 
     /// Sequence number (always 0) from bits 28-30 (3 bits).

--- a/libs/ballot-interpreter/src/hmpb-rust/timing_marks.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/timing_marks.rs
@@ -7,11 +7,11 @@ use logging_timer::time;
 use rayon::iter::ParallelIterator;
 use rayon::prelude::IntoParallelRefIterator;
 use serde::Serialize;
-use types_rs::election::UnitIntervalValue;
 use types_rs::geometry::{
     find_largest_subset_intersecting_line, intersection_of_lines, GridUnit, PixelPosition,
     PixelUnit, Point, Rect, Segment, Size, SubGridUnit, SubPixelUnit,
 };
+use types_rs::{election::UnitIntervalValue, geometry::IntersectionBounds};
 
 use crate::{
     ballot_card::{Geometry, Orientation},
@@ -270,11 +270,8 @@ pub fn find_actual_bottom_marks(
         .bottom_rects
         .par_iter()
         .map(|rect| {
-            let Some(rect_within_image) =
-                rect.intersect(&Rect::new(0, 0, image.width(), image.height()))
-            else {
-                return None;
-            };
+            let rect_within_image =
+                rect.intersect(&Rect::new(0, 0, image.width(), image.height()))?;
 
             let rect_sub_image = GenericImageView::view(
                 image,
@@ -362,8 +359,7 @@ pub fn find_timing_mark_shapes(
     });
     let candidate_timing_marks = contours
         .iter()
-        .enumerate()
-        .filter_map(|(_i, contour)| {
+        .filter_map(|contour| {
             if contour.border_type == BorderType::Hole {
                 let contour_bounds = get_contour_bounding_rect(contour).offset(
                     -PixelPosition::from(BORDER_SIZE),
@@ -496,25 +492,25 @@ pub fn find_partial_timing_marks_from_candidate_rects(
     let top_left_intersection = intersection_of_lines(
         &Segment::new(top_start_rect_center, top_last_rect_center),
         &Segment::new(left_start_rect_center, left_last_rect_center),
-        false,
+        IntersectionBounds::Unbounded,
     )?;
 
     let top_right_intersection = intersection_of_lines(
         &Segment::new(top_start_rect_center, top_last_rect_center),
         &Segment::new(right_start_rect_center, right_last_rect_center),
-        false,
+        IntersectionBounds::Unbounded,
     )?;
 
     let bottom_left_intersection = intersection_of_lines(
         &Segment::new(bottom_start_rect_center, bottom_last_rect_center),
         &Segment::new(left_start_rect_center, left_last_rect_center),
-        false,
+        IntersectionBounds::Unbounded,
     )?;
 
     let bottom_right_intersection = intersection_of_lines(
         &Segment::new(bottom_start_rect_center, bottom_last_rect_center),
         &Segment::new(right_start_rect_center, right_last_rect_center),
-        false,
+        IntersectionBounds::Unbounded,
     )?;
 
     let partial_timing_marks = Partial {

--- a/libs/types-rs/src/geometry.rs
+++ b/libs/types-rs/src/geometry.rs
@@ -268,6 +268,12 @@ impl Segment {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum IntersectionBounds {
+    Unbounded,
+    Bounded,
+}
+
 /// Determines an intersection point of two line segments. If `bounded` is set
 /// to `true`, the intersection point must be within the bounds of both
 /// segments. If `bounded` is set to `false`, the intersection point may be
@@ -276,7 +282,7 @@ impl Segment {
 pub fn intersection_of_lines(
     segment1: &Segment,
     segment2: &Segment,
-    bounded: bool,
+    bounds: IntersectionBounds,
 ) -> Option<Point<SubPixelUnit>> {
     let p1 = segment1.start;
     let p2 = segment1.end;
@@ -288,7 +294,9 @@ pub fn intersection_of_lines(
     }
     let u_a = (p4.x - p3.x).mul_add(p1.y - p3.y, -(p4.y - p3.y) * (p1.x - p3.x)) / d;
     let u_b = (p2.x - p1.x).mul_add(p1.y - p3.y, -(p2.y - p1.y) * (p1.x - p3.x)) / d;
-    if !bounded || ((0.0..=1.0).contains(&u_a) && (0.0..=1.0).contains(&u_b)) {
+    if matches!(bounds, IntersectionBounds::Unbounded)
+        || ((0.0..=1.0).contains(&u_a) && (0.0..=1.0).contains(&u_b))
+    {
         return Some(Point::new(
             u_a.mul_add(p2.x - p1.x, p1.x),
             u_a.mul_add(p2.y - p1.y, p1.y),
@@ -300,7 +308,7 @@ pub fn intersection_of_lines(
 /// Determines whether the two line segments intersect.
 #[must_use]
 pub fn segments_intersect(line1: &Segment, line2: &Segment) -> bool {
-    intersection_of_lines(line1, line2, true).is_some()
+    intersection_of_lines(line1, line2, IntersectionBounds::Bounded).is_some()
 }
 
 /// Determines whether a line segment intersects a rectangle.


### PR DESCRIPTION
## Overview
- replace `let Some(_) = _ else { return None; }` with `let _ = _?;` (clippy lint)
- remove `enumerate()` since the index goes unused (clippy lint)
- improve legibility of `intersection_of_lines` call sites by using an enum

## Demo Video or Screenshot
n/a

## Testing Plan
Automated tests.