### PR TITLE
Support controller and sip & puff on BMD 150 hardware

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1340,6 +1340,24 @@ jobs:
           command: |
             cargo test -p daemon-utils
 
+  test-crate-fai100-controllerd:
+    executor: 'nodejs'
+    resource_class: xlarge
+    steps:
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            cargo build -p fai100-controllerd
+      - run:
+          name: Lint
+          command: |
+            cargo clippy -p fai100-controllerd
+      - run:
+          name: Test
+          command: |
+            cargo test -p fai100-controllerd
+
   test-crate-patinputd:
     executor: 'nodejs'
     resource_class: xlarge
@@ -1485,6 +1503,7 @@ workflows:
       - test-crate-ballot-interpreter
       - test-crate-controllerd
       - test-crate-daemon-utils
+      - test-crate-fai100-controllerd
       - test-crate-patinputd
       - test-crate-pdi-scanner
       - test-crate-types-rs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,6 +721,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "fai100-controllerd"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "color-eyre",
+ "crc16",
+ "ctrlc",
+ "daemon-utils",
+ "hex",
+ "num_enum",
+ "rusb",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "uinput",
+ "vx-logging",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,7 +726,6 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "color-eyre",
- "crc16",
  "ctrlc",
  "daemon-utils",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
   "apps/mark-scan/accessible-controller",
+  "apps/mark-scan/fai-100-controller",
   "apps/mark-scan/daemon-utils",
   "apps/mark-scan/pat-device-input",
   "libs/ballot-interpreter",

--- a/apps/mark-scan/fai-100-controller/Cargo.toml
+++ b/apps/mark-scan/fai-100-controller/Cargo.toml
@@ -10,7 +10,6 @@ path = "src/fai_100_controllerd.rs"
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
 color-eyre = { workspace = true }
-crc16 = { workspace = true }
 ctrlc = { workspace = true }
 daemon-utils = { workspace = true }
 hex = { workspace = true }

--- a/apps/mark-scan/fai-100-controller/Cargo.toml
+++ b/apps/mark-scan/fai-100-controller/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "fai100-controllerd"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "fai100-controllerd"
+path = "src/fai_100_controllerd.rs"
+
+[dependencies]
+clap = { workspace = true, features = ["derive"] }
+color-eyre = { workspace = true }
+crc16 = { workspace = true }
+ctrlc = { workspace = true }
+daemon-utils = { workspace = true }
+hex = { workspace = true }
+num_enum = { workspace = true }
+rusb = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+vx-logging = { workspace = true }
+uinput = { workspace = true }
+
+[lints]
+workspace = true

--- a/apps/mark-scan/fai-100-controller/Makefile
+++ b/apps/mark-scan/fai-100-controller/Makefile
@@ -1,0 +1,9 @@
+# a phony dependency that can be used as a dependency to force builds
+FORCE:
+
+build: FORCE
+	mkdir -p target && cargo build --release --target-dir target/.
+
+run:
+	./target/release/fai100-controllerd
+

--- a/apps/mark-scan/fai-100-controller/README.md
+++ b/apps/mark-scan/fai-100-controller/README.md
@@ -6,25 +6,33 @@ keyboard keypress events to be consumed by the frontend.
 
 ## Usage in dev
 
-To build:
+### Set up groups and udev rules
+
+First ensure you have two udev rules granting group permission to `uinput` and
+the `FAI-100` device. Edit or create relevant files in `/etc/udev/rules.d` eg.
+[`/etc/udev/rules.d/50-uinput.rules`](https://github.com/votingworks/vxsuite-complete-system/blob/main/config/50-uinput.rules)
+and
+[`/etc/udev/rules.d/55-fai100.rules`](https://github.com/votingworks/vxsuite-complete-system/blob/main/config/55-fai100.rules).
+
+Ensure those groups exist and then add your user to the groups.
+
+```
+getent group uinput || groupadd uinput
+getent group fai100 || groupadd fai100
+sudo usermod -aG uinput,fai100 vx
+```
+
+`vxdev` images will already have the necessary groups and udev rules but you
+will still need to run `usermod`.
+
+### Building
 
 ```
 cd apps/mark-scan/fai-100-controller
 make build
 ```
 
-To run:
-
-First ensure you have a udev rule granting `uinput` permission
-([example](https://github.com/votingworks/vxsuite-complete-system/pull/367/files#diff-50733779da0c9503b7a83caae7825d6c540b10d4ca6f62c53789d2bb25c52752R1)),
-then add your user to the group.
-
-```
-sudo usermod -aG uinput vx
-```
-
-`vxdev` will already have this udev rule defined but will still need to run the
-`usermod` command.
+### Running
 
 ```
 // From apps/mark-scan/fai-100-controller

--- a/apps/mark-scan/fai-100-controller/README.md
+++ b/apps/mark-scan/fai-100-controller/README.md
@@ -1,0 +1,32 @@
+# Accessible controller daemon
+
+The accessible controller daemon listens for incoming signal from the VSAP 150
+accessible controller. It receives button press and sip & puff events and emits
+keyboard keypress events to be consumed by the frontend.
+
+## Usage in dev
+
+To build:
+
+```
+cd apps/mark-scan/fai-100-controller
+make build
+```
+
+To run:
+
+First ensure you have a udev rule granting `uinput` permission
+([example](https://github.com/votingworks/vxsuite-complete-system/pull/367/files#diff-50733779da0c9503b7a83caae7825d6c540b10d4ca6f62c53789d2bb25c52752R1)),
+then add your user to the group.
+
+```
+sudo usermod -aG uinput vx
+```
+
+`vxdev` will already have this udev rule defined but will still need to run the
+`usermod` command.
+
+```
+// From apps/mark-scan/fai-100-controller
+MARK_SCAN_WORKSPACE=/path/to/dev-workspace ./target/release/fai-100-controllerd
+```

--- a/apps/mark-scan/fai-100-controller/src/commands.rs
+++ b/apps/mark-scan/fai-100-controller/src/commands.rs
@@ -11,10 +11,8 @@ pub enum CommandError {
     FailedSliceConversion,
     #[error("Unexpected data length: {0}")]
     UnexpectedDataLength(usize),
-    #[error("Unexpected command ID received: {0}")]
+    #[error("Unexpected command ID received: {0:x}")]
     UnexpectedCommandId(u8),
-    #[error("Unknown command received: {0}")]
-    UnknownCommand(u8),
     #[error("Error occurred when sending keypress event")]
     KeypressError(#[from] uinput::Error),
     #[error("Error occurred when converting button value from raw response")]
@@ -222,7 +220,7 @@ impl TryFrom<&[u8]> for VersionResponse {
 
         // Validate correct command ID was returned
         if response[0] != CommandId::GetFirmwareVersion as u8 {
-            return Err(CommandError::UnknownCommand(bytes[25]));
+            return Err(CommandError::UnexpectedCommandId(response[0]));
         }
 
         // Version is the only chunk of data that is big endian according to docs.

--- a/apps/mark-scan/fai-100-controller/src/commands.rs
+++ b/apps/mark-scan/fai-100-controller/src/commands.rs
@@ -1,0 +1,346 @@
+use num_enum::TryFromPrimitiveError;
+use std::io;
+
+#[derive(Debug, thiserror::Error)]
+pub enum CommandError {
+    #[error("Unexpected command data length: {0}")]
+    UnexpectedPacketSize(usize),
+    #[error("Unknown sender ID: {0}")]
+    UnknownSenderId(u32),
+    #[error("Failed to convert slice to unsigned int type")]
+    FailedSliceConversion(),
+    #[error("Unexpected data length: {0}")]
+    UnexpectedDataLength(usize),
+    #[error("Unexpected command ID received: {0}")]
+    UnexpectedCommandId(u8),
+    #[error("Unknown command received: {0}")]
+    UnknownCommand(u8),
+    #[error("Error occurred when sending keypress event")]
+    KeypressError(#[from] uinput::Error),
+    #[error("Error occurred when converting button value from raw response")]
+    InvalidButton(TryFromPrimitiveError<ButtonSignal>),
+    #[error("Error occurred when converting sip/puff signal status value from raw response")]
+    InvalidSipPuffSignalStatus(TryFromPrimitiveError<SipAndPuffSignalStatus>),
+    #[error("Error occurred when converting sip/puff connection status value from raw response")]
+    InvalidSipPuffDeviceStatus(TryFromPrimitiveError<SipAndPuffDeviceStatus>),
+    #[error("I/O error when parsing command response")]
+    IOError(#[from] io::Error),
+}
+
+impl From<TryFromPrimitiveError<ButtonSignal>> for CommandError {
+    fn from(err: TryFromPrimitiveError<ButtonSignal>) -> Self {
+        Self::InvalidButton(err)
+    }
+}
+
+impl From<TryFromPrimitiveError<SipAndPuffSignalStatus>> for CommandError {
+    fn from(err: TryFromPrimitiveError<SipAndPuffSignalStatus>) -> Self {
+        Self::InvalidSipPuffSignalStatus(err)
+    }
+}
+
+impl From<TryFromPrimitiveError<SipAndPuffDeviceStatus>> for CommandError {
+    fn from(err: TryFromPrimitiveError<SipAndPuffDeviceStatus>) -> Self {
+        Self::InvalidSipPuffDeviceStatus(err)
+    }
+}
+
+const SENDER_ID: u32 = 0xD0BB_55AA;
+
+#[derive(Debug, num_enum::TryFromPrimitive, Clone, Copy)]
+#[repr(u8)]
+pub enum CommandId {
+    GetFirmwareVersion = 0x50,
+    GetNotificationValues = 0xc1,
+}
+
+/// An outgoing command sent from host to device.
+#[derive(Debug)]
+pub struct Command {
+    pub command_id: CommandId,
+}
+
+#[macro_export]
+macro_rules! create_command {
+    ($id:ident) => {
+        $crate::commands::Command {
+            command_id: $crate::commands::CommandId::$id,
+        }
+    };
+}
+
+impl From<Command> for Vec<u8> {
+    fn from(command: Command) -> Self {
+        const EXPECTED_LENGTH: usize = 27;
+        let mut bytes = Self::with_capacity(EXPECTED_LENGTH);
+        // All commands start with device sender ID
+        bytes.extend_from_slice(&u32::to_le_bytes(SENDER_ID));
+        // Unused padding
+        bytes.append(&mut vec![0; 16]);
+        // LE u32 size of upcoming noise + data = 3 bytes
+        bytes.push(0x03);
+        bytes.append(&mut vec![0; 3]);
+        // 2 bytes of noise
+        bytes.append(&mut vec![0xff; 2]);
+        // 1 byte of data (just the command ID)
+        bytes.push(command.command_id as u8);
+
+        bytes
+    }
+}
+
+#[derive(Debug, num_enum::TryFromPrimitive, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum ButtonSignal {
+    Help = 0x30,
+    VolumeDown = 0x31,
+    Down = 0x32,
+    RateDown = 0x33,
+    Left = 0x34,
+    Select = 0x35,
+    Right = 0x36,
+    VolumeUp = 0x37,
+    Up = 0x38,
+    RateUp = 0x39,
+    Play = 0x3a,
+    Pause = 0x3b,
+    NoButton = 0xff,
+}
+
+#[derive(Debug, num_enum::TryFromPrimitive, PartialEq, Eq)]
+#[repr(u8)]
+pub enum SipAndPuffSignalStatus {
+    // Documented as Active = 0x01, Idle = 0x00, but based on experimentation the signals are flipped
+    // when a PAT device is plugged in. TODO handle this in event loop
+    Active = 0x00,
+    Idle = 0x01,
+}
+
+#[derive(Debug, num_enum::TryFromPrimitive, PartialEq, Eq)]
+#[repr(u8)]
+pub enum SipAndPuffDeviceStatus {
+    Connected = 0x01,
+    Disconnected = 0x00,
+}
+
+#[derive(Debug)]
+pub struct NotificationStatusResponse {
+    pub button_pressed: ButtonSignal,
+    pub sip_status: SipAndPuffSignalStatus,
+    pub puff_status: SipAndPuffSignalStatus,
+    pub sip_puff_device_connection_status: SipAndPuffDeviceStatus,
+}
+
+pub const NOTIFICATION_STATUS_RESPONSE_BYTE_LENGTH: usize = 31;
+
+impl TryFrom<&[u8]> for NotificationStatusResponse {
+    type Error = CommandError;
+
+    // All data segments are little endian.
+    // The expected format of a data packet for input status command is 31 bytes
+    // Bytes 0-3 (4 bytes) sender ID 0xD0BB55AA
+    // Bytes 4-19 (16 bytes) unused padding
+    // Bytes 20-23 (4 bytes) `n=7`, describing length of incoming noise + data
+    // Bytes 24-25 (2 bytes) random noise, unused
+    // Byte 26 command ID
+    // Bytes 27-30 (4 bytes) button status, sip status, puff status, sip/puff device detection status
+    // eg. AA55BBD00000000000000000000000000000000007000000FFFFC134000000
+    // Sender ID 0xAA55BBD
+    // Padding 0x0000000000000000000000000000000000
+    // Data length 0x7000000
+    // Noise 0xFFFF
+    // Command ID 0xC1
+    // Button status 0x34000000 = "Left" button is pressed
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        if bytes.len() != NOTIFICATION_STATUS_RESPONSE_BYTE_LENGTH {
+            return Err(CommandError::UnexpectedPacketSize(bytes.len()));
+        }
+
+        let sender_id: u32 = u32::from_le_bytes(
+            bytes[..4]
+                .try_into()
+                .map_err(|_| CommandError::FailedSliceConversion())?,
+        );
+
+        if sender_id != SENDER_ID {
+            return Err(CommandError::UnknownSenderId(sender_id));
+        }
+
+        match CommandId::try_from(bytes[26]) {
+            Ok(CommandId::GetNotificationValues) => (),
+            _ => return Err(CommandError::UnexpectedCommandId(bytes[26])),
+        }
+
+        let payload: &[u8] = &bytes[27..];
+
+        let button_pressed = ButtonSignal::try_from(payload[0])?;
+        let sip_status = SipAndPuffSignalStatus::try_from(payload[1])?;
+        let puff_status = SipAndPuffSignalStatus::try_from(payload[2])?;
+        let sip_puff_device_connection_status = SipAndPuffDeviceStatus::try_from(payload[3])?;
+
+        Ok(Self {
+            button_pressed,
+            sip_status,
+            puff_status,
+            sip_puff_device_connection_status,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct VersionResponse {
+    pub version: u32,
+}
+
+impl TryFrom<&[u8]> for VersionResponse {
+    type Error = CommandError;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        const EXPECTED_LENGTH: usize = 31;
+        if bytes.len() != EXPECTED_LENGTH {
+            return Err(CommandError::UnexpectedPacketSize(bytes.len()));
+        }
+
+        let sender_id: u32 = u32::from_le_bytes(
+            bytes[..4]
+                .try_into()
+                .map_err(|_| CommandError::FailedSliceConversion())?,
+        );
+        if sender_id != SENDER_ID {
+            return Err(CommandError::UnknownSenderId(sender_id));
+        }
+
+        let data_length: u32 = u32::from_le_bytes(
+            bytes[20..24]
+                .try_into()
+                .map_err(|_| CommandError::FailedSliceConversion())?,
+        );
+
+        // Length including 2 bytes of noise we don't need to read
+        let response_length: usize =
+            usize::try_from(data_length - 2).expect("Failed to parse data length");
+        if response_length != 5 {
+            return Err(CommandError::UnexpectedDataLength(response_length));
+        }
+        let response: &[u8] = &bytes[26..26 + response_length];
+
+        // Validate correct command ID was returned
+        if response[0] != CommandId::GetFirmwareVersion as u8 {
+            return Err(CommandError::UnknownCommand(bytes[25]));
+        }
+
+        // Version is the only chunk of data that is big endian according to docs.
+        // However, version reported by device does not match that of docs, regardless
+        // of endianness so we can't confirm.
+        let version: u32 = u32::from_be_bytes(
+            response[1..]
+                .try_into()
+                .map_err(|_| CommandError::FailedSliceConversion())?,
+        );
+        Ok(Self { version })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    const BUTTON_SIGNAL_INDEX: usize = 27;
+    const SIP_SIGNAL_INDEX: usize = 28;
+    const PUFF_SIGNAL_INDEX: usize = 29;
+    const DEVICE_CONNECTION_STATUS_INDEX: usize = 30;
+
+    use super::*;
+
+    #[test]
+    fn test_notification_status_command() {
+        let mut expected = vec![0xAA, 0x55, 0xBB, 0xD0];
+        expected.extend(vec![0x00; 16]); // Padding
+        expected.extend(vec![0x03, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xC1]);
+
+        let cmd = create_command!(GetNotificationValues);
+        let cmd: Vec<u8> = cmd.into();
+
+        assert_eq!(cmd, expected);
+    }
+
+    fn create_notification_status_test_data() -> Vec<u8> {
+        let mut data = vec![0xAA, 0x55, 0xBB, 0xD0];
+        data.extend(vec![0x00; 16]); // Padding
+        data.extend(vec![
+            0x07, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xC1, 0xff, 0x00, 0x00, 0x00,
+        ]);
+
+        data
+    }
+
+    #[test]
+    fn test_notification_status_response_button_signal() {
+        let button_byte_values = vec![
+            0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0xff,
+        ];
+
+        for &value in &button_byte_values {
+            let mut data = create_notification_status_test_data();
+            data[BUTTON_SIGNAL_INDEX] = value;
+
+            let notification = NotificationStatusResponse::try_from(&data[..]).unwrap();
+            let expected_button_signal = ButtonSignal::try_from(value).unwrap();
+            assert_eq!(notification.button_pressed, expected_button_signal);
+        }
+    }
+
+    #[test]
+    fn test_notification_status_response_sip_and_puff_signal() {
+        for i in SIP_SIGNAL_INDEX..=PUFF_SIGNAL_INDEX {
+            for status in 0x00..=0x01 {
+                let mut data = create_notification_status_test_data();
+                let status_value = SipAndPuffSignalStatus::try_from(status).unwrap();
+                data[i] = status;
+                let notification = NotificationStatusResponse::try_from(&data[..]).unwrap();
+                assert_eq!(
+                    if i == SIP_SIGNAL_INDEX {
+                        notification.sip_status
+                    } else {
+                        notification.puff_status
+                    },
+                    status_value
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_notification_status_response_device_connection_status() {
+        for status in 0x00..=0x01 {
+            let mut data = create_notification_status_test_data();
+            let status_value = SipAndPuffDeviceStatus::try_from(status).unwrap();
+            data[DEVICE_CONNECTION_STATUS_INDEX] = status;
+            let notification = NotificationStatusResponse::try_from(&data[..]).unwrap();
+            assert_eq!(notification.sip_puff_device_connection_status, status_value);
+        }
+    }
+
+    #[test]
+    fn test_version_command() {
+        let mut expected = vec![0xAA, 0x55, 0xBB, 0xD0];
+        expected.extend(vec![0x00; 16]); // Padding
+        expected.extend(vec![0x03, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0x50]);
+
+        let cmd = create_command!(GetFirmwareVersion);
+        let cmd: Vec<u8> = cmd.into();
+
+        assert_eq!(cmd, expected);
+    }
+
+    #[test]
+    fn test_version_response() {
+        let mut data = vec![0xAA, 0x55, 0xBB, 0xD0];
+        data.extend(vec![0x00; 16]); // Padding
+        data.extend(vec![
+            0x07, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0x50, 0x01, 0x02, 0x03, 0x04,
+        ]);
+
+        let version_response = VersionResponse::try_from(&data[..]).unwrap();
+        assert_eq!(version_response.version, 0x0102_0304);
+    }
+}

--- a/apps/mark-scan/fai-100-controller/src/commands.rs
+++ b/apps/mark-scan/fai-100-controller/src/commands.rs
@@ -126,7 +126,7 @@ pub struct NotificationStatusResponse {
     pub sip_puff_device_connection_status: SipAndPuffDeviceStatus,
 }
 
-// Not all possibleresponses are 31 bytes, but all the ones we use are
+// Not all possible responses are 31 bytes, but all the ones we use are
 pub const RESPONSE_BYTE_LENGTH: usize = 31;
 
 impl TryFrom<&[u8]> for NotificationStatusResponse {

--- a/apps/mark-scan/fai-100-controller/src/commands.rs
+++ b/apps/mark-scan/fai-100-controller/src/commands.rs
@@ -226,8 +226,8 @@ impl TryFrom<&[u8]> for VersionResponse {
         }
 
         // Version is the only chunk of data that is big endian according to docs.
-        // However, version reported by device does not match that of docs, regardless
-        // of endianness so we can't confirm.
+        // However, we can't confirm because version reported by device does not
+        // match that of docs regardless of endianness.
         let version = u32::from_be_bytes(
             response[1..]
                 .try_into()

--- a/apps/mark-scan/fai-100-controller/src/commands.rs
+++ b/apps/mark-scan/fai-100-controller/src/commands.rs
@@ -111,7 +111,7 @@ pub enum ButtonSignal {
 #[repr(u8)]
 pub enum SipAndPuffSignalStatus {
     // Documented as Active = 0x01, Idle = 0x00, but based on experimentation the signals are flipped
-    // when a PAT device is plugged in. TODO handle this in event loop
+    // when a PAT device is plugged in.
     Active = 0x00,
     Idle = 0x01,
 }

--- a/apps/mark-scan/fai-100-controller/src/commands.rs
+++ b/apps/mark-scan/fai-100-controller/src/commands.rs
@@ -128,7 +128,8 @@ pub struct NotificationStatusResponse {
     pub sip_puff_device_connection_status: SipAndPuffDeviceStatus,
 }
 
-pub const NOTIFICATION_STATUS_RESPONSE_BYTE_LENGTH: usize = 31;
+// Not all possibleresponses are 31 bytes, but all the ones we use are
+pub const RESPONSE_BYTE_LENGTH: usize = 31;
 
 impl TryFrom<&[u8]> for NotificationStatusResponse {
     type Error = CommandError;
@@ -149,7 +150,7 @@ impl TryFrom<&[u8]> for NotificationStatusResponse {
     // Command ID 0xC1
     // Button status 0x34000000 = "Left" button is pressed
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        if bytes.len() != NOTIFICATION_STATUS_RESPONSE_BYTE_LENGTH {
+        if bytes.len() != RESPONSE_BYTE_LENGTH {
             return Err(CommandError::UnexpectedPacketSize(bytes.len()));
         }
 
@@ -192,8 +193,7 @@ impl TryFrom<&[u8]> for VersionResponse {
     type Error = CommandError;
 
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        const EXPECTED_LENGTH: usize = 31;
-        if bytes.len() != EXPECTED_LENGTH {
+        if bytes.len() != RESPONSE_BYTE_LENGTH {
             return Err(CommandError::UnexpectedPacketSize(bytes.len()));
         }
 

--- a/apps/mark-scan/fai-100-controller/src/commands.rs
+++ b/apps/mark-scan/fai-100-controller/src/commands.rs
@@ -156,7 +156,7 @@ impl TryFrom<&[u8]> for NotificationStatusResponse {
         let sender_id: u32 = u32::from_le_bytes(
             bytes[..4]
                 .try_into()
-                .map_err(|_| CommandError::FailedSliceConversion())?,
+                .map_err(|_| CommandError::FailedSliceConversion)?,
         );
 
         if sender_id != SENDER_ID {
@@ -200,7 +200,7 @@ impl TryFrom<&[u8]> for VersionResponse {
         let sender_id = u32::from_le_bytes(
             bytes[..4]
                 .try_into()
-                .map_err(|_| CommandError::FailedSliceConversion())?,
+                .map_err(|_| CommandError::FailedSliceConversion)?,
         );
         if sender_id != SENDER_ID {
             return Err(CommandError::UnknownSenderId(sender_id));
@@ -209,7 +209,7 @@ impl TryFrom<&[u8]> for VersionResponse {
         let data_length = u32::from_le_bytes(
             bytes[20..24]
                 .try_into()
-                .map_err(|_| CommandError::FailedSliceConversion())?,
+                .map_err(|_| CommandError::FailedSliceConversion)?,
         );
 
         // Length including 2 bytes of noise we don't need to read
@@ -231,7 +231,7 @@ impl TryFrom<&[u8]> for VersionResponse {
         let version = u32::from_be_bytes(
             response[1..]
                 .try_into()
-                .map_err(|_| CommandError::FailedSliceConversion())?,
+                .map_err(|_| CommandError::FailedSliceConversion)?,
         );
         Ok(Self { version })
     }

--- a/apps/mark-scan/fai-100-controller/src/commands.rs
+++ b/apps/mark-scan/fai-100-controller/src/commands.rs
@@ -116,7 +116,7 @@ pub enum SipAndPuffSignalStatus {
     Idle = 0x01,
 }
 
-#[derive(Debug, num_enum::TryFromPrimitive, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, num_enum::TryFromPrimitive, PartialEq, Eq)]
 #[repr(u8)]
 pub enum SipAndPuffDeviceStatus {
     Connected = 0x01,

--- a/apps/mark-scan/fai-100-controller/src/fai_100_controllerd.rs
+++ b/apps/mark-scan/fai-100-controller/src/fai_100_controllerd.rs
@@ -349,7 +349,7 @@ fn handle_status_response(
         // Write device connection status to system file so mark-scan app is aware
         write_pat_connection_status(new_connection_status, workspace_path)?;
 
-        sleep(2 * POLL_INTERVAL);
+        sleep(3 * POLL_INTERVAL);
         return Ok(());
     }
 

--- a/apps/mark-scan/fai-100-controller/src/fai_100_controllerd.rs
+++ b/apps/mark-scan/fai-100-controller/src/fai_100_controllerd.rs
@@ -15,7 +15,7 @@ use daemon_utils::run_no_op_event_loop;
 use std::{
     fs::OpenOptions,
     io::{self, Read},
-    path::PathBuf,
+    path::{Path, PathBuf},
     process::exit,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -56,7 +56,7 @@ struct Args {
 
 fn write_pat_connection_status(
     status: SipAndPuffDeviceStatus,
-    workspace_path: &PathBuf,
+    workspace_path: &Path,
 ) -> Result<(), io::Error> {
     let mut file = OpenOptions::new()
         .write(true)
@@ -322,7 +322,7 @@ fn handle_status_response(
     new_status: NotificationStatusResponse,
     current_status: &mut CurrentStatus,
     keyboard: &mut impl VirtualKeyboard,
-    workspace_path: &PathBuf,
+    workspace_path: &Path,
 ) -> Result<(), CommandError> {
     let new_button = new_status.button_pressed;
     let new_sip_status = new_status.sip_status;
@@ -406,7 +406,7 @@ fn run_event_loop(
     usb_device: &mut UsbDevice,
     running: &Arc<AtomicBool>,
     keyboard: &mut impl VirtualKeyboard,
-    workspace_path: &PathBuf,
+    workspace_path: &Path,
 ) {
     let mut buf: [u8; BUFFER_MAX_BYTES] = [0; BUFFER_MAX_BYTES];
 

--- a/apps/mark-scan/fai-100-controller/src/fai_100_controllerd.rs
+++ b/apps/mark-scan/fai-100-controller/src/fai_100_controllerd.rs
@@ -36,7 +36,7 @@ mod virtual_keyboard;
 const APP_NAME: &str = "vx-mark-scan-fai-100-controller-daemon";
 const FAI_100_VID: u16 = 0x28cd;
 const FAI_100_PID: u16 = 0x4002;
-const POLL_INTERVAL: Duration = Duration::from_millis(1);
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
 const EVENT_LOOP_LOG_INTERVAL: Duration = Duration::from_secs(1);
 const BUFFER_MAX_BYTES: usize = 64;
 const PAT_CONNECTION_STATUS_FILENAME: &str = "_pat_connection.status";

--- a/apps/mark-scan/fai-100-controller/src/fai_100_controllerd.rs
+++ b/apps/mark-scan/fai-100-controller/src/fai_100_controllerd.rs
@@ -9,7 +9,7 @@
 use clap::Parser;
 use commands::{
     ButtonSignal, CommandError, NotificationStatusResponse, SipAndPuffDeviceStatus,
-    SipAndPuffSignalStatus, VersionResponse, NOTIFICATION_STATUS_RESPONSE_BYTE_LENGTH,
+    SipAndPuffSignalStatus, VersionResponse, RESPONSE_BYTE_LENGTH,
 };
 use daemon_utils::run_no_op_event_loop;
 use std::{
@@ -452,7 +452,7 @@ fn run_event_loop(
 
         match usb_device.read(&mut buf) {
             Ok(_) => {
-                let data = &buf[..NOTIFICATION_STATUS_RESPONSE_BYTE_LENGTH];
+                let data = &buf[..RESPONSE_BYTE_LENGTH];
                 match NotificationStatusResponse::try_from(data) {
                     Ok(response) => {
                         if let Err(e) = handle_status_response(

--- a/apps/mark-scan/fai-100-controller/src/fai_100_controllerd.rs
+++ b/apps/mark-scan/fai-100-controller/src/fai_100_controllerd.rs
@@ -202,7 +202,7 @@ fn validate_connection(usb_device: &mut UsbDevice) -> Result<(), io::Error> {
         ),
     }
 
-    let mut buf: [u8; BUFFER_MAX_BYTES] = [0; BUFFER_MAX_BYTES];
+    let mut buf = [0; BUFFER_MAX_BYTES];
     match usb_device.read(&mut buf) {
         Ok(size) => match VersionResponse::try_from(&buf[..size]) {
             Ok(response) => {

--- a/apps/mark-scan/fai-100-controller/src/fai_100_controllerd.rs
+++ b/apps/mark-scan/fai-100-controller/src/fai_100_controllerd.rs
@@ -1,0 +1,555 @@
+//! Daemon whose purpose is to expose signal from VSAP's FAI-100 accessible controller
+//! to the mark-scan application.
+//!
+//! Signal from the accessible controller is available in userspace over
+//! the serialport protocol. The daemon connects to the controller and polls
+//! for change in signal value. When a button press is detected, it sends
+//! a keypress event for consumption by the mark-scan application.
+
+use clap::Parser;
+use commands::{
+    ButtonSignal, CommandError, NotificationStatusResponse, SipAndPuffDeviceStatus,
+    SipAndPuffSignalStatus, VersionResponse, NOTIFICATION_STATUS_RESPONSE_BYTE_LENGTH,
+};
+use daemon_utils::run_no_op_event_loop;
+use std::{
+    env,
+    fs::OpenOptions,
+    io::{self, Read},
+    path::Path,
+    process::exit,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    thread,
+    time::{Duration, Instant},
+};
+use uinput::event::keyboard;
+use usb_device::UsbDevice;
+use virtual_keyboard::{create_keyboard, VirtualKeyboard};
+use vx_logging::{log, set_app_name, Disposition, EventId, EventType};
+
+mod commands;
+mod usb_device;
+mod virtual_keyboard;
+
+const APP_NAME: &str = "vx-mark-scan-fai-100-controller-daemon";
+const FAI_100_VID: u16 = 0x28cd;
+const FAI_100_PID: u16 = 0x4002;
+const POLL_INTERVAL: Duration = Duration::from_millis(1);
+const EVENT_LOOP_LOG_INTERVAL: Duration = Duration::from_secs(1);
+const BUFFER_MAX_BYTES: usize = 64;
+const PAT_CONNECTION_STATUS_FILENAME: &str = "_pat_connection.status";
+use std::io::Write;
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Args {
+    /// Allow the daemon to run if no hardware is found.
+    #[arg(short, long)]
+    skip_hardware_check: bool,
+}
+
+fn write_pat_connection_status(is_connected: bool) -> Result<(), io::Error> {
+    match env::var("MARK_SCAN_WORKSPACE") {
+        Ok(workspace_path) => {
+            let mut file = OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(Path::new(&workspace_path).join(PAT_CONNECTION_STATUS_FILENAME))?;
+            // For consistency with the BMD 155 integration, "0" means a PAT device is connected and "1" means no device is connected
+            let value: &str = if is_connected { "0" } else { "1" };
+            file.write_all(value.as_bytes())?;
+        }
+        Err(e) => {
+            log!(
+            event_id: EventId::UnknownError,
+            message: format!("Unable to read workspace path from environment variable: {e:?}"),
+            event_type: EventType::SystemStatus
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn main() -> color_eyre::Result<()> {
+    color_eyre::install()?;
+
+    let args = Args::parse();
+    set_app_name(APP_NAME);
+    log!(
+        EventId::ProcessStarted;
+        EventType::SystemAction
+    );
+
+    let running = Arc::new(AtomicBool::new(true));
+
+    if let Err(e) = ctrlc::set_handler({
+        let running = running.clone();
+        move || {
+            running.store(false, Ordering::SeqCst);
+        }
+    }) {
+        log!(
+            event_id: EventId::ErrorSettingSigintHandler,
+            message: e.to_string(),
+            event_type: EventType::SystemStatus
+        );
+    }
+
+    // Create virtual device for keypress events
+    log!(
+        EventId::CreateVirtualUinputDeviceInit;
+        EventType::SystemAction
+    );
+    let mut keyboard = create_keyboard("FAI 100 Accessible Controller Daemon Virtual Device")?;
+    log!(
+        event_id: EventId::CreateVirtualUinputDeviceComplete,
+        disposition: Disposition::Success,
+        event_type: EventType::SystemAction
+    );
+
+    log!(
+        EventId::ControllerConnectionInit;
+        EventType::SystemAction
+    );
+
+    if let Some(mut port) = get_usb_device() {
+        log!(
+            event_id: EventId::Info,
+            disposition: Disposition::Success,
+            event_type: EventType::SystemStatus,
+            message: ("Connected to port successfully").to_string()
+        );
+
+        if let Err(err) = validate_connection(&mut port) {
+            log!(
+                event_id: EventId::ControllerHandshakeComplete,
+                message: err.to_string(),
+                event_type: EventType::SystemAction,
+                disposition: Disposition::Failure
+            );
+
+            exit(1);
+        }
+
+        run_event_loop(&mut port, &running, &mut keyboard);
+        exit(0);
+    }
+
+    if args.skip_hardware_check {
+        run_no_op_event_loop(&running);
+        exit(0);
+    }
+
+    log!(
+        event_id: EventId::ProcessTerminated,
+        event_type: EventType::SystemStatus,
+        message: "Could not connect to ATI controller".to_string()
+    );
+    exit(1);
+}
+
+fn get_usb_device() -> Option<UsbDevice> {
+    match UsbDevice::open_by_ids(FAI_100_VID, FAI_100_PID) {
+        Ok(port) => {
+            log!(
+                event_id: EventId::ControllerConnectionComplete,
+                event_type: EventType::SystemAction,
+                disposition: Disposition::Success
+            );
+
+            return Some(port);
+        }
+        Err(e) => {
+            log!(
+                event_id: EventId::ControllerConnectionComplete,
+                message: format!("Failed to open controller device. Error: {e}"),
+                event_type: EventType::SystemAction,
+                disposition: Disposition::Failure
+            );
+        }
+    }
+
+    None
+}
+
+fn validate_connection(usb_device: &mut UsbDevice) -> Result<(), io::Error> {
+    log!(
+        event_id: EventId::ControllerHandshakeInit,
+        event_type: EventType::SystemAction
+    );
+
+    let version_cmd = create_command!(GetFirmwareVersion);
+    let version_cmd: Vec<u8> = version_cmd.into();
+
+    match usb_device.write_bulk(&version_cmd) {
+        Ok(num_bytes) => log!(
+            event_id: EventId::Info,
+            message: format!("validate_connection: {num_bytes} bytes written"),
+            event_type: EventType::SystemAction
+        ),
+        Err(e) => log!(
+            event_id: EventId::UnknownError,
+            message: format!("validate_connection unexpected error when writing command: {e:?}"),
+            event_type: EventType::SystemStatus
+        ),
+    }
+
+    let mut buf: [u8; BUFFER_MAX_BYTES] = [0; BUFFER_MAX_BYTES];
+    match usb_device.read(&mut buf) {
+        Ok(size) => match VersionResponse::try_from(&buf[..size]) {
+            Ok(response) => {
+                log!(
+                    event_id: EventId::ControllerHandshakeComplete,
+                    event_type: EventType::SystemAction,
+                    disposition: Disposition::Success,
+                    message: format!("Version: {:x}", response.version)
+                );
+                return Ok(());
+            }
+            Err(error) => {
+                log!(
+                    event_id: EventId::ControllerHandshakeComplete,
+                    event_type: EventType::SystemAction,
+                    disposition: Disposition::Failure,
+                    message: format!("Error reading GetFirmwareVersion response: {error}")
+                );
+            }
+        },
+        Err(ref e) if e.kind() == io::ErrorKind::TimedOut => {
+            println!("No data received from IN ENDPOINT");
+        }
+        Err(e) => {
+            log!(
+                event_id: EventId::ControllerHandshakeComplete,
+                message: format!("Error reading echo response: {e:?}"),
+                event_type: EventType::SystemAction,
+                disposition: Disposition::Failure
+            );
+        }
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::TimedOut,
+        "No echo response received",
+    ))
+}
+
+#[derive(Debug)]
+struct CurrentStatus {
+    button_pressed: ButtonSignal,
+    sip: SipAndPuffSignalStatus,
+    puff: SipAndPuffSignalStatus,
+    sip_puff_device_connected: SipAndPuffDeviceStatus,
+}
+
+struct KeypressSpec {
+    key: keyboard::Key,
+    send_shift: bool,
+}
+
+const fn get_key_for_button_signal(signal: &ButtonSignal) -> Option<KeypressSpec> {
+    let key: keyboard::Key;
+    let mut send_shift: bool = false;
+
+    match signal {
+        ButtonSignal::Select => {
+            key = keyboard::Key::Enter;
+        }
+        ButtonSignal::Left => {
+            key = keyboard::Key::Left;
+        }
+        ButtonSignal::Right => {
+            key = keyboard::Key::Right;
+        }
+        ButtonSignal::Up => {
+            key = keyboard::Key::Up;
+        }
+        ButtonSignal::Down => {
+            key = keyboard::Key::Down;
+        }
+        ButtonSignal::Help => {
+            send_shift = true;
+            key = keyboard::Key::R;
+        }
+        ButtonSignal::RateDown => {
+            key = keyboard::Key::Comma;
+        }
+        ButtonSignal::RateUp => {
+            key = keyboard::Key::Dot;
+        }
+        ButtonSignal::VolumeDown => {
+            key = keyboard::Key::Minus;
+        }
+        ButtonSignal::VolumeUp => {
+            key = keyboard::Key::Equal;
+        }
+        ButtonSignal::Pause | ButtonSignal::Play => {
+            send_shift = true;
+            key = keyboard::Key::P;
+        }
+        ButtonSignal::NoButton => return None,
+    }
+
+    Some(KeypressSpec { key, send_shift })
+}
+
+fn send_keystroke(keypress: &KeypressSpec, keyboard: &mut impl VirtualKeyboard) {
+    if let Err(err) = keyboard.send_keystroke(
+        keypress.key,
+        if keypress.send_shift {
+            &[keyboard::Key::LeftShift]
+        } else {
+            &[]
+        },
+    ) {
+        log!(EventId::UnknownError, "Error sending key: {err}");
+    }
+}
+
+/// Checks new status for changed statuses in button press, sip, puff, and sip & puff device connection.
+/// If changing from inactive to active, sends the appropriate event (keypress or system file update).
+/// If changing from active to inactive or no status change, does nothing.
+fn handle_status_response(
+    new_status: NotificationStatusResponse,
+    current_status: &mut CurrentStatus,
+    keyboard: &mut impl VirtualKeyboard,
+) -> Result<(), CommandError> {
+    let new_button = new_status.button_pressed;
+    let new_sip_status = new_status.sip_status;
+    let new_puff_status = new_status.puff_status;
+    let new_connection_status = new_status.sip_puff_device_connection_status;
+
+    // If the new button isn't currently being pressed (ie. this is a keydown event), send a keypress
+    if new_button != current_status.button_pressed {
+        // Only sends keypress when a new button is pressed.
+        // This will no-op when a button is released because new_button == ButtonSignal::NoButton
+        // get_key_for_button_signal(ButtonSignal::NoButton) returns None
+        if let Some(keypress_spec) = get_key_for_button_signal(&new_button) {
+            send_keystroke(&keypress_spec, keyboard);
+        }
+    }
+    // Update the currently pressed button so subsequent identical status reports won't trigger a second keypress
+    current_status.button_pressed = new_button;
+
+    // Write device connection status to system file so mark-scan app is aware
+    if new_connection_status != current_status.sip_puff_device_connected {
+        write_pat_connection_status(new_connection_status == SipAndPuffDeviceStatus::Connected)?;
+
+        // Explicitly reset sip and puff signals if device was just disconnected because signals are
+        // ignored once device is disconnected. See comment below.
+        let just_disconnected = new_connection_status == SipAndPuffDeviceStatus::Disconnected
+            && current_status.sip_puff_device_connected == SipAndPuffDeviceStatus::Connected;
+        if just_disconnected {
+            current_status.sip = SipAndPuffSignalStatus::Idle;
+            current_status.puff = SipAndPuffSignalStatus::Idle;
+        }
+    }
+    current_status.sip_puff_device_connected = new_connection_status;
+
+    // Only check for sip & puff actions when the device is connected. When the device is not connected
+    // the values switch meaning.
+    // ie. When a sip & puff is connected, 0x01 is sent to host when a sip
+    // is happening and 0x00 is sent when no sip is happening.
+    // When no sip & puff is connected, 0x00 is sent when no sip is happening.
+    // Therefore we must ignore all sip & puff signals unless we know the sip & puff is connected.
+    if current_status.sip_puff_device_connected == SipAndPuffDeviceStatus::Connected {
+        // Send keypress for new sip event
+        if new_sip_status == SipAndPuffSignalStatus::Active
+            && current_status.sip == SipAndPuffSignalStatus::Idle
+        {
+            send_keystroke(
+                &KeypressSpec {
+                    key: keyboard::Key::_1,
+                    send_shift: false,
+                },
+                keyboard,
+            );
+        }
+        current_status.sip = new_sip_status;
+
+        // Send keypress for new puff event
+        if new_puff_status == SipAndPuffSignalStatus::Active
+            && current_status.puff == SipAndPuffSignalStatus::Idle
+        {
+            send_keystroke(
+                &KeypressSpec {
+                    key: keyboard::Key::_2,
+                    send_shift: false,
+                },
+                keyboard,
+            );
+        }
+        current_status.puff = new_puff_status;
+    }
+
+    Ok(())
+}
+
+fn run_event_loop(
+    port: &mut UsbDevice,
+    running: &Arc<AtomicBool>,
+    keyboard: &mut impl VirtualKeyboard,
+) {
+    let mut buf: [u8; BUFFER_MAX_BYTES] = [0; BUFFER_MAX_BYTES];
+
+    log!(
+        event_id: EventId::Info,
+        message: "Starting event loop".to_string(),
+        event_type: EventType::SystemAction
+    );
+
+    let mut last_log_time = Instant::now();
+    let mut current_status = CurrentStatus {
+        button_pressed: ButtonSignal::NoButton,
+        sip: SipAndPuffSignalStatus::Idle,
+        puff: SipAndPuffSignalStatus::Idle,
+        sip_puff_device_connected: SipAndPuffDeviceStatus::Connected,
+    };
+
+    loop {
+        if !running.load(Ordering::SeqCst) {
+            log!(
+                EventId::ProcessTerminated;
+                EventType::SystemAction
+            );
+            break;
+        }
+
+        if last_log_time.elapsed() > EVENT_LOOP_LOG_INTERVAL {
+            log!(EventId::Info, "Polling for status");
+            last_log_time = Instant::now();
+        }
+
+        let get_notifications_command = create_command!(GetNotificationValues);
+        let get_notifications_command: Vec<u8> = get_notifications_command.into();
+        match port.write_bulk(&get_notifications_command) {
+            Ok(_) => (),
+            Err(e) => log!(
+                event_id: EventId::UnknownError,
+                message: format!("Unexpected error when writing get_notifications_command: {e:?}"),
+                event_type: EventType::SystemStatus
+            ),
+        }
+
+        match port.read(&mut buf) {
+            Ok(_) => {
+                let data = &buf[..NOTIFICATION_STATUS_RESPONSE_BYTE_LENGTH];
+                match NotificationStatusResponse::try_from(data) {
+                    Ok(response) => {
+                        if let Err(e) =
+                            handle_status_response(response, &mut current_status, keyboard)
+                        {
+                            log!(
+                                event_id: EventId::UnknownError,
+                                message: format!("Unexpected error when handling status response: {e:?}"),
+                                event_type: EventType::SystemStatus
+                            );
+                        }
+                    }
+                    Err(e) => log!(
+                        event_id: EventId::UnknownError,
+                        message: format!("Unexpected error when parsing status response from raw data: {e:?}"),
+                        event_type: EventType::SystemStatus
+                    ),
+                }
+            }
+            // Timeout error just means no event was sent in the current polling period
+            Err(ref e) if e.kind() == io::ErrorKind::TimedOut => (),
+            Err(e) => {
+                log!(
+                    event_id: EventId::UnknownError,
+                    message: format!("Unexpected error when reading from bulk endpoint: {e:?}"),
+                    event_type: EventType::SystemStatus
+                );
+            }
+        }
+
+        thread::sleep(POLL_INTERVAL);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    struct MockKeyboard {
+        pub keystrokes: Vec<(keyboard::Key, Vec<keyboard::Key>)>,
+    }
+
+    impl MockKeyboard {
+        pub const fn new() -> Self {
+            Self {
+                keystrokes: Vec::new(),
+            }
+        }
+    }
+
+    impl VirtualKeyboard for MockKeyboard {
+        fn send_keystroke(
+            &mut self,
+            key: keyboard::Key,
+            modifiers: &[keyboard::Key],
+        ) -> Result<(), uinput::Error> {
+            self.keystrokes.push((key, modifiers.to_vec()));
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_press_help() {
+        set_app_name("test");
+        let mut mock_keyboard = MockKeyboard::new();
+
+        let current_status = &mut CurrentStatus {
+            button_pressed: ButtonSignal::NoButton,
+            sip: SipAndPuffSignalStatus::Idle,
+            puff: SipAndPuffSignalStatus::Idle,
+            sip_puff_device_connected: SipAndPuffDeviceStatus::Disconnected,
+        };
+        let new_status = NotificationStatusResponse {
+            button_pressed: ButtonSignal::Help,
+            sip_status: SipAndPuffSignalStatus::Idle,
+            puff_status: SipAndPuffSignalStatus::Idle,
+            sip_puff_device_connection_status: SipAndPuffDeviceStatus::Disconnected,
+        };
+
+        handle_status_response(new_status, current_status, &mut mock_keyboard).unwrap();
+
+        assert_eq!(
+            mock_keyboard.keystrokes,
+            vec![(keyboard::Key::R, vec![keyboard::Key::LeftShift])]
+        );
+    }
+
+    #[test]
+    fn test_press_left() {
+        set_app_name("test");
+        let mut mock_keyboard = MockKeyboard::new();
+
+        let current_status = &mut CurrentStatus {
+            button_pressed: ButtonSignal::NoButton,
+            sip: SipAndPuffSignalStatus::Idle,
+            puff: SipAndPuffSignalStatus::Idle,
+            sip_puff_device_connected: SipAndPuffDeviceStatus::Disconnected,
+        };
+        let new_status = NotificationStatusResponse {
+            button_pressed: ButtonSignal::Left,
+            sip_status: SipAndPuffSignalStatus::Idle,
+            puff_status: SipAndPuffSignalStatus::Idle,
+            sip_puff_device_connection_status: SipAndPuffDeviceStatus::Disconnected,
+        };
+
+        handle_status_response(new_status, current_status, &mut mock_keyboard).unwrap();
+
+        assert_eq!(
+            mock_keyboard.keystrokes,
+            vec![(keyboard::Key::Left, vec![])]
+        );
+    }
+}

--- a/apps/mark-scan/fai-100-controller/src/usb_device.rs
+++ b/apps/mark-scan/fai-100-controller/src/usb_device.rs
@@ -1,6 +1,6 @@
 use std::{io, time::Duration};
 
-use color_eyre::eyre::{bail, ErrReport, Result};
+use color_eyre::eyre::{bail, eyre, ErrReport, Result};
 use rusb::{Context, DeviceHandle, UsbContext};
 
 const INTERFACE_NUMBER: u8 = 0x00;
@@ -39,10 +39,9 @@ impl UsbDevice {
             };
 
             if device_desc.vendor_id() == vendor_id && device_desc.product_id() == product_id {
-                match device.open() {
-                    Ok(handle) => return Ok(handle),
-                    Err(e) => bail!("Device found but failed to open: {e}"),
-                }
+                return device
+                    .open()
+                    .map_err(|e| eyre!("Device found but failed to open: {e}"));
             }
         }
 

--- a/apps/mark-scan/fai-100-controller/src/usb_device.rs
+++ b/apps/mark-scan/fai-100-controller/src/usb_device.rs
@@ -72,7 +72,7 @@ impl UsbDevice {
             .write_bulk(self.endpoint_out.address, buf, WRITE_TIMEOUT)
     }
 
-    pub fn open_by_ids(vendor_id: u16, product_id: u16) -> color_eyre::Result<Self> {
+    pub fn open_by_ids(vendor_id: u16, product_id: u16) -> Result<Self> {
         let usb_context = Context::new().expect("Failed to create new USB context");
 
         match Self::open_device(&usb_context, vendor_id, product_id) {

--- a/apps/mark-scan/fai-100-controller/src/usb_device.rs
+++ b/apps/mark-scan/fai-100-controller/src/usb_device.rs
@@ -1,0 +1,115 @@
+use std::{io, time::Duration};
+
+use color_eyre::eyre::Result;
+use rusb::{Context, DeviceHandle, UsbContext};
+
+const INTERFACE_NUMBER: u8 = 0x00;
+const CONFIG_NUMBER: u8 = 0x01;
+const SETTING_NUMBER: u8 = 0x00;
+const ENDPOINT_ADDRESS_IN: u8 = 0x81;
+const ENDPOINT_ADDRESS_OUT: u8 = 0x01;
+const WRITE_TIMEOUT: Duration = Duration::from_secs(1);
+const READ_TIMEOUT: Duration = Duration::from_millis(50);
+
+#[derive(Debug)]
+struct Endpoint {
+    address: u8,
+}
+
+pub struct UsbDevice {
+    endpoint_in: Endpoint,
+    endpoint_out: Endpoint,
+    handle: DeviceHandle<Context>,
+}
+
+impl UsbDevice {
+    fn open_device<T: UsbContext>(
+        context: &T,
+        vendor_id: u16,
+        product_id: u16,
+    ) -> Option<DeviceHandle<T>> {
+        let Ok(devices) = context.devices() else {
+            return None;
+        };
+
+        for device in devices.iter() {
+            let Ok(device_desc) = device.device_descriptor() else {
+                continue;
+            };
+
+            if device_desc.vendor_id() == vendor_id && device_desc.product_id() == product_id {
+                match device.open() {
+                    Ok(handle) => return Some(handle),
+                    Err(e) => panic!("Device found but failed to open: {e}"),
+                }
+            }
+        }
+
+        None
+    }
+
+    fn claim_interface<T: UsbContext>(handle: &mut DeviceHandle<T>) -> Result<()> {
+        let has_kernel_driver = match handle.kernel_driver_active(INTERFACE_NUMBER) {
+            Ok(true) => {
+                handle.detach_kernel_driver(INTERFACE_NUMBER).ok();
+                true
+            }
+            _ => false,
+        };
+
+        handle.set_active_configuration(CONFIG_NUMBER)?;
+        handle.claim_interface(INTERFACE_NUMBER)?;
+        handle.set_alternate_setting(INTERFACE_NUMBER, SETTING_NUMBER)?;
+
+        if has_kernel_driver {
+            handle.attach_kernel_driver(INTERFACE_NUMBER).ok();
+        }
+        Ok(())
+    }
+
+    pub fn write_bulk(&mut self, buf: &[u8]) -> Result<usize, rusb::Error> {
+        self.handle
+            .write_bulk(self.endpoint_out.address, buf, WRITE_TIMEOUT)
+    }
+
+    pub fn open_by_ids(vendor_id: u16, product_id: u16) -> color_eyre::Result<Self> {
+        let usb_context = Context::new().expect("Failed to create new USB context");
+
+        match Self::open_device(&usb_context, vendor_id, product_id) {
+            Some(mut handle) => {
+                Self::claim_interface(&mut handle)?;
+
+                let endpoint_in = Endpoint {
+                    address: ENDPOINT_ADDRESS_IN,
+                };
+
+                let endpoint_out = Endpoint {
+                    address: ENDPOINT_ADDRESS_OUT,
+                };
+
+                Ok(Self {
+                    endpoint_in,
+                    endpoint_out,
+                    handle,
+                })
+            }
+            // TODO real error handling
+            None => panic!("could not find device {vendor_id:04x}:{product_id:04x}"),
+        }
+    }
+}
+
+impl io::Read for UsbDevice {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self
+            .handle
+            .read_bulk(self.endpoint_in.address, buf, READ_TIMEOUT)
+        {
+            Ok(len) => Ok(len),
+            Err(rusb::Error::Timeout) => {
+                Err(io::Error::new(io::ErrorKind::TimedOut, "Read timed out"))
+            }
+            Err(err) => Err(io::Error::new(io::ErrorKind::Other, format!("{err:?}"))),
+        }
+    }
+}

--- a/apps/mark-scan/fai-100-controller/src/usb_device.rs
+++ b/apps/mark-scan/fai-100-controller/src/usb_device.rs
@@ -52,7 +52,7 @@ impl UsbDevice {
     fn claim_interface<T: UsbContext>(handle: &mut DeviceHandle<T>) -> Result<()> {
         let has_kernel_driver = match handle.kernel_driver_active(INTERFACE_NUMBER) {
             Ok(true) => {
-                let _ = handle.detach_kernel_driver(INTERFACE_NUMBER)?;
+                handle.detach_kernel_driver(INTERFACE_NUMBER)?;
                 true
             }
             _ => false,
@@ -63,7 +63,7 @@ impl UsbDevice {
         handle.set_alternate_setting(INTERFACE_NUMBER, SETTING_NUMBER)?;
 
         if has_kernel_driver {
-            let _ = handle.attach_kernel_driver(INTERFACE_NUMBER)?;
+            handle.attach_kernel_driver(INTERFACE_NUMBER)?;
         }
         Ok(())
     }

--- a/apps/mark-scan/fai-100-controller/src/usb_device.rs
+++ b/apps/mark-scan/fai-100-controller/src/usb_device.rs
@@ -101,6 +101,7 @@ impl io::Write for UsbDevice {
         let _ = self
             .handle
             .write_bulk(self.endpoint_out.address, &self.buffer, WRITE_TIMEOUT);
+        self.buffer.clear();
         Ok(())
     }
 }

--- a/apps/mark-scan/fai-100-controller/src/usb_device.rs
+++ b/apps/mark-scan/fai-100-controller/src/usb_device.rs
@@ -93,7 +93,6 @@ impl UsbDevice {
                     handle,
                 })
             }
-            // TODO real error handling
             None => panic!("could not find device {vendor_id:04x}:{product_id:04x}"),
         }
     }

--- a/apps/mark-scan/fai-100-controller/src/virtual_keyboard.rs
+++ b/apps/mark-scan/fai-100-controller/src/virtual_keyboard.rs
@@ -1,0 +1,44 @@
+use std::{thread, time::Duration};
+
+use uinput::{
+    event::{keyboard, Keyboard},
+    Device,
+};
+
+const UINPUT_PATH: &str = "/dev/uinput";
+
+pub trait VirtualKeyboard {
+    fn send_keystroke(
+        &mut self,
+        key: keyboard::Key,
+        modifiers: &[keyboard::Key],
+    ) -> Result<(), uinput::Error>;
+}
+
+impl VirtualKeyboard for Device {
+    fn send_keystroke(
+        &mut self,
+        key: keyboard::Key,
+        modifiers: &[keyboard::Key],
+    ) -> Result<(), uinput::Error> {
+        for modifier in modifiers {
+            self.press(modifier)?;
+        }
+        self.click(&key)?;
+        for modifier in modifiers {
+            self.release(modifier)?;
+        }
+        self.synchronize()?;
+        Ok(())
+    }
+}
+
+pub fn create_keyboard(name: &str) -> color_eyre::Result<impl VirtualKeyboard> {
+    let keyboard = uinput::open(UINPUT_PATH)?
+        .name(name)?
+        .event(Keyboard::All)?
+        .create()?;
+    // Wait for virtual device to register
+    thread::sleep(Duration::from_secs(1));
+    Ok(keyboard)
+}

--- a/vxsuite.code-workspace
+++ b/vxsuite.code-workspace
@@ -61,6 +61,10 @@
       "path": "apps/mark-scan/daemon-utils"
     },
     {
+      "name": "apps/mark-scan/fai-100-controller",
+      "path": "apps/mark-scan/fai-100-controller"
+    },
+    {
       "name": "apps/mark-scan/accessible-controller",
       "path": "apps/mark-scan/accessible-controller"
     },


### PR DESCRIPTION
## Overview
Solves https://github.com/votingworks/vxsuite/issues/4960 and https://github.com/votingworks/vxsuite/issues/4961

Adds support for the FAI-100 USB device which encompasses both ATI controller and sip & puff input on the BMD 150. The implementation is forked from the BMD 155 controller daemon.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/6c7447cb-fd44-487b-8f04-4afdb8d663f8



https://github.com/user-attachments/assets/24df0b63-03bf-4256-bd06-59fc4c8bc5fe



## Testing Plan
- rewrote existing tests for BMD 155 controller
- added sip and puff tests

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
