### PR TITLE
feat(basics): add `iter::cycle` and use it in a few places

### DIFF
--- a/apps/scan/backend/scripts/copy_sheets.ts
+++ b/apps/scan/backend/scripts/copy_sheets.ts
@@ -86,16 +86,13 @@ function copySheets({ targetSheetCount }: CopySheetsInput): void {
     numSheetsToCreate,
     500 // A cap to limit how much data the script loads
   );
-  const sheets = iter(store.forEachAcceptedSheet())
-    .take(maxNumSheetsToReadForCopying)
-    .toArray();
 
-  const newSheetIds: string[] = [];
-  for (let i = 0; i < numSheetsToCreate; i += 1) {
-    const sheet = sheets[i % sheets.length];
-    const newSheetId = copySheet(store, sheet);
-    newSheetIds.push(newSheetId);
-  }
+  const newSheetIds = iter(store.forEachAcceptedSheet())
+    .take(maxNumSheetsToReadForCopying)
+    .cycle()
+    .take(numSheetsToCreate)
+    .map((sheet) => copySheet(store, sheet))
+    .toArray();
 
   const sheetOrSheets = numSheetsToCreate === 1 ? 'sheet' : 'sheets';
   console.log(

--- a/libs/basics/src/iterators/async_iterator_plus.test.ts
+++ b/libs/basics/src/iterators/async_iterator_plus.test.ts
@@ -775,3 +775,33 @@ test('single ownership', async () => {
     'inner iterable has already been taken'
   );
 });
+
+test('cycle', async () => {
+  expect(await iter([]).async().cycle().take(3).toArray()).toEqual([]);
+  expect(await iter([1, 2]).async().cycle().take(3).toArray()).toEqual([
+    1, 2, 1,
+  ]);
+  expect(await iter([1, 2]).async().cycle().take(5).toArray()).toEqual([
+    1, 2, 1, 2, 1,
+  ]);
+
+  await fc.assert(
+    fc.asyncProperty(fc.array(fc.anything()), async (arr) => {
+      expect(await iter(arr).async().cycle().take(0).toArray()).toEqual([]);
+    })
+  );
+
+  await fc.assert(
+    fc.asyncProperty(
+      fc.record({
+        arr: fc.array(fc.anything(), { minLength: 1 }),
+        n: fc.integer({ min: 1, max: 100 }),
+      }),
+      async ({ arr, n }) => {
+        expect(await iter(arr).async().cycle().take(n).toArray()).toHaveLength(
+          n
+        );
+      }
+    )
+  );
+});

--- a/libs/basics/src/iterators/async_iterator_plus.ts
+++ b/libs/basics/src/iterators/async_iterator_plus.ts
@@ -107,6 +107,27 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
     return count;
   }
 
+  cycle(): AsyncIteratorPlus<T> {
+    const iterable = this.intoInner();
+    return new AsyncIteratorPlusImpl(
+      (async function* gen(): AsyncIterableIterator<T> {
+        const array = Array.of<T>();
+        for await (const value of iterable) {
+          array.push(value);
+          yield value;
+        }
+
+        if (array.length === 0) {
+          return;
+        }
+
+        while (true) {
+          yield* array;
+        }
+      })()
+    );
+  }
+
   enumerate(): AsyncIteratorPlus<[number, T]> {
     const iterable = this.intoInner();
     return new AsyncIteratorPlusImpl(

--- a/libs/basics/src/iterators/iterator_plus.test.ts
+++ b/libs/basics/src/iterators/iterator_plus.test.ts
@@ -512,3 +512,27 @@ test('single ownership', () => {
     'inner iterable has already been taken'
   );
 });
+
+test('cycle', () => {
+  expect(iter([]).cycle().take(5).toArray()).toEqual([]);
+  expect(iter([1]).cycle().take(5).toArray()).toEqual([1, 1, 1, 1, 1]);
+  expect(iter([1, 2, 3]).cycle().take(5).toArray()).toEqual([1, 2, 3, 1, 2]);
+
+  fc.assert(
+    fc.property(fc.array(fc.anything()), (arr) => {
+      expect(iter(arr).cycle().take(0).toArray()).toEqual([]);
+    })
+  );
+
+  fc.assert(
+    fc.property(
+      fc.record({
+        arr: fc.array(fc.anything(), { minLength: 1 }),
+        n: fc.integer({ min: 1, max: 100 }),
+      }),
+      ({ arr, n }) => {
+        expect(iter(arr).cycle().take(n).toArray()).toHaveLength(n);
+      }
+    )
+  );
+});

--- a/libs/basics/src/iterators/iterator_plus.ts
+++ b/libs/basics/src/iterators/iterator_plus.ts
@@ -115,6 +115,28 @@ export class IteratorPlusImpl<T> implements IteratorPlus<T>, AsyncIterable<T> {
     return count;
   }
 
+  cycle(): IteratorPlus<T> {
+    const iterable = this.intoInner();
+    return new IteratorPlusImpl(
+      (function* gen(): IterableIterator<T> {
+        const array = Array.of<T>();
+
+        for (const value of iterable) {
+          array.push(value);
+          yield value;
+        }
+
+        if (array.length === 0) {
+          return;
+        }
+
+        while (true) {
+          yield* array;
+        }
+      })()
+    );
+  }
+
   enumerate(): IteratorPlus<[number, T]> {
     const iterable = this.intoInner();
     return new IteratorPlusImpl(

--- a/libs/basics/src/iterators/types.ts
+++ b/libs/basics/src/iterators/types.ts
@@ -99,6 +99,17 @@ export interface IteratorPlus<T> extends Iterable<T> {
   count(): number;
 
   /**
+   * Cycles elements from `this` indefinitely.
+   *
+   * @example
+   *
+   * ```ts
+   * expect(iter([1, 2, 3]).cycle().take(7).toArray()).toEqual([1, 2, 3, 1, 2, 3, 1]);
+   * ```
+   */
+  cycle(): IteratorPlus<T>;
+
+  /**
    * Enumerates elements along with their index.
    *
    * @example
@@ -812,6 +823,20 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
    * ```
    */
   count(): Promise<number>;
+
+  /**
+   * Cycles elements from `this` indefinitely.
+   *
+   * @example
+   *
+   * ```ts
+   * const input = fs.createReadStream('file.txt', { encoding: 'utf8' });
+   * for await (const line of lines(input).cycle().take(100)) {
+   *   …
+   * }
+   * ```
+   */
+  cycle(): AsyncIteratorPlus<T>;
 
   /**
    * Enumerates elements along with their index.

--- a/libs/hmpb/src/ballot_fixtures.ts
+++ b/libs/hmpb/src/ballot_fixtures.ts
@@ -1,4 +1,4 @@
-import { assert, assertDefined, iter, range } from '@votingworks/basics';
+import { assert, assertDefined, iter } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import {
   electionGeneral,
@@ -61,8 +61,11 @@ export const famousNamesFixtures = (() => {
   const votes: VotesDict = Object.fromEntries(
     contests.map((contest, i) => {
       assert(contest.type === 'candidate');
-      const candidates = range(0, contest.seats)
-        .map((j) => contest.candidates[(i + j) % contest.candidates.length])
+      const candidates = iter(contest.candidates)
+        .cycle()
+        .skip(i)
+        .take(contest.seats)
+        .toArray()
         // list candidates in the order they appear on the ballot
         .sort(
           (a, b) =>
@@ -149,9 +152,11 @@ export const generalElectionFixtures = (() => {
     const votes: VotesDict = Object.fromEntries(
       contests.map((contest, i) => {
         if (contest.type === 'candidate') {
-          const candidates = range(0, contest.seats - (i % 2)).map(
-            (j) => contest.candidates[(i + j) % contest.candidates.length]
-          );
+          const candidates = iter(contest.candidates)
+            .cycle()
+            .skip(i)
+            .take(contest.seats - (i % 2))
+            .toArray();
           if (contest.allowWriteIns && i % 2 === 0) {
             const writeInIndex = i % contest.seats;
             candidates.push({
@@ -326,9 +331,11 @@ export const primaryElectionFixtures = (() => {
     const votes: VotesDict = Object.fromEntries(
       contests.map((contest, i) => {
         if (contest.type === 'candidate') {
-          const candidates = range(0, contest.seats).map(
-            (j) => contest.candidates[(i + j) % contest.candidates.length]
-          );
+          const candidates = iter(contest.candidates)
+            .cycle()
+            .skip(i)
+            .take(contest.seats)
+            .toArray();
           return [contest.id, candidates];
         }
         return [

--- a/libs/hmpb/src/preview/browser_preview.ts
+++ b/libs/hmpb/src/preview/browser_preview.ts
@@ -11,7 +11,7 @@ import {
   electionGeneral,
   electionGeneralFixtures,
 } from '@votingworks/fixtures';
-import { assertDefined, range } from '@votingworks/basics';
+import { assertDefined, iter } from '@votingworks/basics';
 import { vxDefaultBallotTemplate } from '../vx_default_ballot_template';
 import {
   BaseBallotProps,
@@ -62,9 +62,11 @@ export async function main(): Promise<void> {
   const votes: VotesDict = Object.fromEntries(
     contests.map((contest, i) => {
       if (contest.type === 'candidate') {
-        const candidates = range(0, contest.seats - (i % 2)).map(
-          (j) => contest.candidates[(i + j) % contest.candidates.length]
-        );
+        const candidates = iter(contest.candidates)
+          .cycle()
+          .skip(i)
+          .take(contest.seats - (i % 2))
+          .toArray();
         if (contest.allowWriteIns && i % 2 === 0) {
           const writeInIndex = i % contest.seats;
           candidates.push({

--- a/libs/pdi-scanner/src/ts/scanner_client.test.ts
+++ b/libs/pdi-scanner/src/ts/scanner_client.test.ts
@@ -5,7 +5,7 @@ import {
   MockChildProcess,
   mockOf,
 } from '@votingworks/test-utils';
-import { err, ok, range, sleep } from '@votingworks/basics';
+import { err, iter, ok, sleep } from '@votingworks/basics';
 import { fromGrayScale } from '@votingworks/image-utils';
 import { Buffer } from 'buffer';
 import {
@@ -273,7 +273,10 @@ test('converts image data from scanComplete event', async () => {
   client.addListener(listener);
   const imageHeight = 10;
   const rawImageGrayscalePixels = Buffer.from(
-    range(0, SCAN_IMAGE_WIDTH * imageHeight).map((i) => i % 2)
+    iter([0, 1])
+      .cycle()
+      .take(SCAN_IMAGE_WIDTH * imageHeight)
+      .toArray()
   );
   const scanCompleteEvent: PdictlEvent = {
     event: 'scanComplete',

--- a/libs/utils/src/bmd_votes_mock.ts
+++ b/libs/utils/src/bmd_votes_mock.ts
@@ -1,6 +1,5 @@
-import { assert } from '@votingworks/basics';
+import { iter } from '@votingworks/basics';
 import {
-  Candidate,
   CandidateContest,
   Election,
   Vote,
@@ -9,16 +8,11 @@ import {
 } from '@votingworks/types';
 
 function generateMockCandidateVote(contest: CandidateContest, seed = 0): Vote {
-  const votes: Candidate[] = [];
-
-  for (let i = 0; i < contest.seats && i < contest.candidates.length; i += 1) {
-    const candidate =
-      contest.candidates[(i + seed) % contest.candidates.length];
-    assert(candidate);
-    votes.push(candidate);
-  }
-
-  return votes;
+  return iter(contest.candidates)
+    .cycle()
+    .skip(seed)
+    .take(Math.min(contest.seats, contest.candidates.length))
+    .toArray();
 }
 
 function generateMockYesNoVote(c: YesNoContest, seed = 0): Vote {


### PR DESCRIPTION

## Overview

In a bunch of places where we would map from another list starting at some offset it's nicer to use `iter::cycle` than managing the machinery manually with `list[i % list.length]` or similar.

## Demo Video or Screenshot

```ts
expect(iter([1, 2, 3]).cycle().take(7).toArray()).toEqual([1, 2, 3, 1, 2, 3, 1]);
```

## Testing Plan
- [x] Added automated tests for `iter::cycle` itself.
- [x] Tested the script to generate HMPB fixtures manually, verified that the results were equivalent.
