### PR TITLE
Kevin/paper handler cli set scan dir

### DIFF
--- a/apps/mark-scan/backend/src/custom-paper-handler/application_driver.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/application_driver.ts
@@ -10,6 +10,7 @@ import {
   imageDataToBinaryBitmap,
   isPaperAnywhere,
   isMockPaperHandler,
+  ScanDirection,
 } from '@votingworks/custom-paper-handler';
 import { pdfToImages } from '@votingworks/image-utils';
 import { tmpNameSync } from 'tmp';
@@ -36,6 +37,10 @@ export async function setDefaults(
   debug('set line spacing to 0');
   await driver.setPrintingSpeed('slow');
   debug('set printing speed to slow');
+
+  const scanDirection: ScanDirection = 'backward';
+  await driver.setScanDirection(scanDirection);
+  debug('set scan direction to', scanDirection);
 }
 
 export async function printBallotChunks(

--- a/libs/custom-paper-handler/src/cli/driver_cli.ts
+++ b/libs/custom-paper-handler/src/cli/driver_cli.ts
@@ -134,6 +134,7 @@ async function setScanDirection(
         scanDirections
       )}`
     );
+    return;
   }
 
   const direction = assertDefined(args[0]) as ScanDirection;

--- a/libs/custom-paper-handler/src/cli/driver_cli.ts
+++ b/libs/custom-paper-handler/src/cli/driver_cli.ts
@@ -64,6 +64,7 @@ async function outputSampleBallotPdfWidth() {
 async function scan(driver: PaperHandlerDriverInterface): Promise<void> {
   const dateString = new Date().toISOString();
   const pathOut = join(tmpdir(), `ballot-driver-cli-${dateString}.jpg`);
+  console.log('Writing scan to', pathOut);
   await driver.scanAndSave(pathOut);
 }
 

--- a/libs/custom-paper-handler/src/driver/coders.ts
+++ b/libs/custom-paper-handler/src/driver/coders.ts
@@ -207,7 +207,7 @@ export enum ConfigureScannerOptionSensorConfig {
 export enum ConfigureScannerFlags {
   NONE = 0x00,
   SCAN_BACKWARDS = 0x01,
-  SCAN_IN_PARK = 0x02,
+  SCAN_IN_PARK = 0x03,
 }
 export const ConfigureScannerCommand = message({
   command: literal(0x1c, 'SPC'),

--- a/libs/custom-paper-handler/src/driver/driver.ts
+++ b/libs/custom-paper-handler/src/driver/driver.ts
@@ -537,8 +537,6 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
   }
 
   async scanAndSave(pathOut: string): Promise<void> {
-    debug('setting scan direction');
-    await this.setScanDirection('backward');
     const grayscaleResult = await this.scan();
     debug(
       `Received imageData with specs:\nHeight=${grayscaleResult.height}, Width=${grayscaleResult.width}, data byte length=${grayscaleResult.data.byteLength}`

--- a/libs/custom-paper-handler/src/driver/index.ts
+++ b/libs/custom-paper-handler/src/driver/index.ts
@@ -8,3 +8,7 @@ export * from './helpers';
 export * from './minimal_web_usb_device';
 export * from './test_utils';
 export * from './scanner_status';
+// scanner_config is mostly internal but some types are useful to callers.
+// Scanner config types can be separated to a different file if this export
+// becomes unwieldy.
+export type { PaperMovementAfterScan, ScanDirection } from './scanner_config';

--- a/libs/custom-paper-handler/src/driver/scanner_config.ts
+++ b/libs/custom-paper-handler/src/driver/scanner_config.ts
@@ -9,7 +9,8 @@ export type PaperMovementAfterScan =
 export type ScanLight = 'red' | 'green' | 'blue' | 'white';
 export type ScanDataFormat = 'BW' | 'grayscale';
 export type Resolution = 100 | 150 | 200 | 250 | 300;
-export type ScanDirection = 'forward' | 'backward' | 'in_park';
+export const scanDirections = ['forward', 'backward', 'in_park'] as const;
+export type ScanDirection = (typeof scanDirections)[number];
 
 export interface ScannerConfig {
   scanLight: ScanLight;

--- a/libs/custom-paper-handler/src/driver/scanner_config.ts
+++ b/libs/custom-paper-handler/src/driver/scanner_config.ts
@@ -10,6 +10,31 @@ export type ScanLight = 'red' | 'green' | 'blue' | 'white';
 export type ScanDataFormat = 'BW' | 'grayscale';
 export type Resolution = 100 | 150 | 200 | 250 | 300;
 export const scanDirections = ['forward', 'backward', 'in_park'] as const;
+/**
+ * ScanDirection refers to the physical direction in which the page is scanned.
+ * This setting impacts the orientation of the resulting image and in some ways
+ * the placement of the page after the scan is complete.
+ *
+ * The simplified guidance is to use `forward` when scanning a page that is in the
+ * scanner input, such as when paper has just been inserted and loaded via `loadPaper()`,
+ * or `presentPaper()` has been called. Use `backward` when the page is parked.
+ *
+ * `forward` moves the paper from scanner front to scanner rear ie. away from the voter.
+ * When combined with the `hold_ticket` PaperMovementAfterScan option, the page will remain
+ * in the scanner.
+ * `backward` moves the paper from scanner rear to scanner front ie. toward the voter.
+ * When combined with the `hold_ticket` PaperMovementAfterScan option, the page will remain
+ * displayed in front of the scanner. The result is similar to calling `presentPaper()`.
+ * `in_park` sets the direction to `backward` and presumably is intended to optimize
+ * scanning a page from the parked position.
+ *
+ * During testing, scanning a page from parked position with the `in_park` or `forward`
+ * setting results in early truncation of the scanned image.
+ *
+ * Page orientation:
+ * `forward` produces a rightside-up image.
+ * `backward` produces an upside-down image.
+ */
 export type ScanDirection = (typeof scanDirections)[number];
 
 export interface ScannerConfig {


### PR DESCRIPTION
## Overview

* Adds support for `setScanDirection` to the driver CLI for manual testing.
* Moves the call to set default scan direction out of `driver.scanAndSave` and into the application layer. Always setting scan direction to `backward` in `scanAndSave` doesn't make a lot of sense because any previous call to `setScanDirection` would be overwritten right before the scan actually happens.
* Fixes a typo where the `in_park` scan direction was encoded with `0x02` instead of `0x03`

## Demo Video or Screenshot

N/A

## Testing Plan

* Ran CLI and confirmed the setting works

## Checklist

- [ ] (No new actions) I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.