### PR TITLE
Add imprinting to the central scanner 

### DIFF
--- a/apps/central-scan/backend/schema.sql
+++ b/apps/central-scan/backend/schema.sql
@@ -25,6 +25,7 @@ create table batches (
 create table sheets (
   id varchar(36) primary key,
   batch_id varchar(36),
+  ballot_audit_id varchar(41), -- <batch_id>_<4-digit-sequence>
 
   -- Paths for the sheet images.
   front_image_path text unique,

--- a/apps/central-scan/backend/src/app.diagnostics.test.ts
+++ b/apps/central-scan/backend/src/app.diagnostics.test.ts
@@ -66,10 +66,10 @@ test('save readiness report', async () => {
       jest.setSystemTime(reportPrintedTime.getTime());
       scanner
         .withNextScannerSession()
-        .sheet([
-          join(__dirname, '../test/fixtures/blank-sheet-front.jpg'),
-          join(__dirname, '../test/fixtures/blank-sheet-back.jpg'),
-        ])
+        .sheet({
+          frontPath: join(__dirname, '../test/fixtures/blank-sheet-front.jpg'),
+          backPath: join(__dirname, '../test/fixtures/blank-sheet-back.jpg'),
+        })
         .end();
       await apiClient.performScanDiagnostic();
       jest.useRealTimers();
@@ -119,10 +119,10 @@ describe('scan diagnostic', () => {
 
       scanner
         .withNextScannerSession()
-        .sheet([
-          join(__dirname, '../test/fixtures/blank-sheet-front.jpg'),
-          join(__dirname, '../test/fixtures/blank-sheet-back.jpg'),
-        ])
+        .sheet({
+          frontPath: join(__dirname, '../test/fixtures/blank-sheet-front.jpg'),
+          backPath: join(__dirname, '../test/fixtures/blank-sheet-back.jpg'),
+        })
         .end();
 
       await apiClient.performScanDiagnostic();
@@ -158,10 +158,10 @@ describe('scan diagnostic', () => {
 
       scanner
         .withNextScannerSession()
-        .sheet([
-          join(__dirname, '../test/fixtures/streaked-page.jpg'),
-          join(__dirname, '../test/fixtures/blank-sheet-back.jpg'),
-        ])
+        .sheet({
+          frontPath: join(__dirname, '../test/fixtures/streaked-page.jpg'),
+          backPath: join(__dirname, '../test/fixtures/blank-sheet-back.jpg'),
+        })
         .end();
       await apiClient.performScanDiagnostic();
 
@@ -189,10 +189,10 @@ describe('scan diagnostic', () => {
 
       scanner
         .withNextScannerSession()
-        .sheet([
-          join(__dirname, '../test/fixtures/blank-sheet-front.jpg'),
-          join(__dirname, '../test/fixtures/streaked-page.jpg'),
-        ])
+        .sheet({
+          frontPath: join(__dirname, '../test/fixtures/blank-sheet-front.jpg'),
+          backPath: join(__dirname, '../test/fixtures/streaked-page.jpg'),
+        })
         .end();
       await apiClient.performScanDiagnostic();
 

--- a/apps/central-scan/backend/src/app.scanning.test.ts
+++ b/apps/central-scan/backend/src/app.scanning.test.ts
@@ -7,12 +7,17 @@ import {
 import { mockElectionManagerAuth } from '../test/helpers/auth';
 import { withApp } from '../test/helpers/setup_app';
 import { generateBmdBallotFixture } from '../test/helpers/ballots';
+import { ScannedSheetInfo } from './fujitsu_scanner';
 
 const jurisdiction = TEST_JURISDICTION;
 
 test('scanBatch with multiple sheets', async () => {
   const { electionDefinition } = electionFamousNames2021Fixtures;
   const ballot = await generateBmdBallotFixture();
+  const scannedBallot: ScannedSheetInfo = {
+    frontPath: ballot[0],
+    backPath: ballot[1],
+  };
   await withApp(async ({ auth, apiClient, scanner, importer, workspace }) => {
     mockElectionManagerAuth(auth, electionDefinition);
     importer.configure(electionDefinition, jurisdiction);
@@ -21,9 +26,9 @@ test('scanBatch with multiple sheets', async () => {
 
     scanner
       .withNextScannerSession()
-      .sheet(ballot)
-      .sheet(ballot)
-      .sheet(ballot)
+      .sheet(scannedBallot)
+      .sheet(scannedBallot)
+      .sheet(scannedBallot)
       .end();
 
     await apiClient.scanBatch();
@@ -55,10 +60,13 @@ test('continueScanning after invalid ballot', async () => {
 
     scanner
       .withNextScannerSession()
-      .sheet(ballot)
+      .sheet({
+        frontPath: ballot[0],
+        backPath: ballot[1],
+      })
       // Invalid BMD ballot
-      .sheet([ballot[1], ballot[1]])
-      .sheet(ballot)
+      .sheet({ frontPath: ballot[1], backPath: ballot[1] })
+      .sheet({ frontPath: ballot[0], backPath: ballot[1] })
       .end();
 
     await apiClient.scanBatch();

--- a/apps/central-scan/backend/src/diagnostic.ts
+++ b/apps/central-scan/backend/src/diagnostic.ts
@@ -1,7 +1,6 @@
 import { LogEventId, Logger } from '@votingworks/logging';
 import { runBlankPaperDiagnostic } from '@votingworks/ballot-interpreter';
-import { SheetOf } from '@votingworks/types';
-import { BatchScanner } from './fujitsu_scanner';
+import { BatchScanner, ScannedSheetInfo } from './fujitsu_scanner';
 import { Store } from './store';
 
 export type ScanDiagnosticOutcome = 'no-paper' | 'pass' | 'fail';
@@ -17,7 +16,7 @@ export async function performScanDiagnostic(
   });
 
   const batchControl = scanner.scanSheets();
-  let sheets: SheetOf<string> | undefined;
+  let sheets: ScannedSheetInfo | undefined;
   try {
     sheets = await batchControl.scanSheet();
   } catch {
@@ -37,7 +36,8 @@ export async function performScanDiagnostic(
     return 'no-paper';
   }
 
-  const [pathA, pathB] = sheets;
+  const pathA = sheets.frontPath;
+  const pathB = sheets.backPath;
 
   const didPass =
     runBlankPaperDiagnostic(pathA) && runBlankPaperDiagnostic(pathB);

--- a/apps/central-scan/backend/src/end_to_end_bmd.test.ts
+++ b/apps/central-scan/backend/src/end_to_end_bmd.test.ts
@@ -14,6 +14,7 @@ import { ok, sleep } from '@votingworks/basics';
 import { withApp } from '../test/helpers/setup_app';
 import { mockElectionManagerAuth } from '../test/helpers/auth';
 import { generateBmdBallotFixture } from '../test/helpers/ballots';
+import { ScannedSheetInfo } from './fujitsu_scanner';
 
 // we need more time for ballot interpretation
 jest.setTimeout(20000);
@@ -51,9 +52,13 @@ test('going through the whole process works - BMD', async () => {
       await apiClient.setTestMode({ testMode: true });
 
       const ballot = await generateBmdBallotFixture();
+      const scannedBallot: ScannedSheetInfo = {
+        frontPath: ballot[0],
+        backPath: ballot[1],
+      };
       {
         // define the next scanner session & scan some sample ballots
-        scanner.withNextScannerSession().sheet(ballot).end();
+        scanner.withNextScannerSession().sheet(scannedBallot).end();
         await apiClient.scanBatch();
 
         await importer.waitForEndOfBatchOrScanningPause();

--- a/apps/central-scan/backend/src/end_to_end_hmpb.test.ts
+++ b/apps/central-scan/backend/src/end_to_end_hmpb.test.ts
@@ -71,10 +71,13 @@ test('going through the whole process works - HMPB', async () => {
         const nextSession = scanner.withNextScannerSession();
 
         // scan some sample ballots
-        nextSession.sheet([
-          electionGridLayoutNewHampshireTestBallotFixtures.scanMarkedFront.asFilePath(),
-          electionGridLayoutNewHampshireTestBallotFixtures.scanMarkedBack.asFilePath(),
-        ]);
+        nextSession.sheet({
+          frontPath:
+            electionGridLayoutNewHampshireTestBallotFixtures.scanMarkedFront.asFilePath(),
+          backPath:
+            electionGridLayoutNewHampshireTestBallotFixtures.scanMarkedBack.asFilePath(),
+          ballotAuditId: 'fake-ballot-audit-id',
+        });
 
         nextSession.end();
 
@@ -119,6 +122,7 @@ test('going through the whole process works - HMPB', async () => {
         expect(cvr.BallotStyleUnitId).toEqual('town-id-00701-precinct-id-');
         expect(cvr.CreatingDeviceId).toEqual('000');
         expect(cvr.BallotSheetId).toEqual('1');
+        expect(cvr.BallotAuditId).toEqual('fake-ballot-audit-id');
         expect(getCastVoteRecordBallotType(cvr)).toEqual(BallotType.Precinct);
         expect(convertCastVoteRecordVotesToTabulationVotes(cvr.CVRSnapshot[0]))
           .toMatchInlineSnapshot(`

--- a/apps/central-scan/backend/src/fujitsu_scanner.test.ts
+++ b/apps/central-scan/backend/src/fujitsu_scanner.test.ts
@@ -28,8 +28,6 @@ const exec = streamExecFile as unknown as jest.MockedFunction<
   (file: string, args: readonly string[]) => ChildProcess
 >;
 
-// TODO(CARO) - test with imprint prefix defined and undefined
-
 test('fujitsu scanner calls scanimage with fujitsu device type', async () => {
   const scanimage = makeMockChildProcess();
   const scanner = new FujitsuScanner({
@@ -55,10 +53,43 @@ test('fujitsu scanner calls scanimage with fujitsu device type', async () => {
   );
 
   scanimage.emit('exit', 0, null);
-  await expect(sheets.scanSheet()).resolves.toEqual([
-    '/tmp/image-0001.png',
-    '/tmp/image-0002.png',
-  ]);
+  await expect(sheets.scanSheet()).resolves.toEqual({
+    frontPath: '/tmp/image-0001.png',
+    backPath: '/tmp/image-0002.png',
+  });
+  await expect(sheets.scanSheet()).resolves.toBeUndefined();
+});
+
+test('fujitsu scanner returns ballot audit id on scans when imprinting', async () => {
+  const scanimage = makeMockChildProcess();
+  const scanner = new FujitsuScanner({
+    logger: new BaseLogger(LogSource.VxScanService),
+  });
+
+  exec.mockReturnValueOnce(scanimage);
+  const sheets = scanner.scanSheets({ imprintIdPrefix: 'test-batch' });
+
+  scanimage.stderr.append(
+    [
+      'Scanning infinity pages, incrementing by 1, numbering from 1\n',
+      'Place document no. 1 on the scanner.\n',
+      'Press <RETURN> to continue.\n',
+      'Press Ctrl + D to terminate.\n',
+    ].join('')
+  );
+  scanimage.stdout.append('/tmp/image-0001.png\n');
+  scanimage.stdout.append('/tmp/image-0002.png\n');
+  expect(exec).toHaveBeenCalledWith(
+    'scanimage',
+    expect.arrayContaining(['-d', 'fujitsu'])
+  );
+
+  scanimage.emit('exit', 0, null);
+  await expect(sheets.scanSheet()).resolves.toEqual({
+    frontPath: '/tmp/image-0001.png',
+    backPath: '/tmp/image-0002.png',
+    ballotAuditId: 'test-batch_0000',
+  });
   await expect(sheets.scanSheet()).resolves.toBeUndefined();
 });
 
@@ -194,7 +225,7 @@ test('fujitsu scanner does imprint as expected when given an imprint ID prefix',
 
   expect(exec).toHaveBeenCalledWith(
     'scanimage',
-    expect.arrayContaining(['--endorser-string', 'TEST-BATCH-ID_%04d'])
+    expect.arrayContaining(['--endorser-string', 'TEST-BATCH-ID_%04ud'])
   );
 });
 
@@ -300,10 +331,10 @@ test('fujitsu scanner requests two images at a time from scanimage', async () =>
 
   scanimage.stdout.append('/tmp/front.png\n');
   scanimage.stdout.append('/tmp/back.png\n');
-  await expect(sheetPromise).resolves.toEqual([
-    '/tmp/front.png',
-    '/tmp/back.png',
-  ]);
+  await expect(sheetPromise).resolves.toEqual({
+    frontPath: '/tmp/front.png',
+    backPath: '/tmp/back.png',
+  });
 });
 
 test('fujitsu scanner ends the scanimage process on generator return', async () => {

--- a/apps/central-scan/backend/src/fujitsu_scanner.ts
+++ b/apps/central-scan/backend/src/fujitsu_scanner.ts
@@ -136,7 +136,7 @@ export class FujitsuScanner implements BatchScanner {
     if (imprintIdPrefix !== undefined) {
       args.push('--endorser=yes');
       // Imprint the prefix followed by a sequential index for each page in the batch
-      args.push('--endorser-string', `${imprintIdPrefix}_%04d`);
+      args.push('--endorser-string', `${imprintIdPrefix}_%04ud`);
     }
 
     const MM_PER_INCH = 25.3967;
@@ -201,9 +201,15 @@ export class FujitsuScanner implements BatchScanner {
             frontPath,
             backPath,
             ballotAuditId:
+              // Because we pass `${imprintIdPrefix}_%04ud` to --endorser-string the scanner
+              // will imprint the prefix followed by a sequential index for each page in the batch,
+              // starting with 0000 for the first page, then 0001 and so on.
               imprintIdPrefix !== undefined
-                ? `${imprintIdPrefix}_${zeroPad(scannedFiles.length / 2)}`
-                : undefined, // TODO(CARO) figure out what this should actually be
+                ? `${imprintIdPrefix}_${zeroPad(
+                    scannedFiles.length / 2 - 1,
+                    4
+                  )}`
+                : undefined,
           })
         );
       }

--- a/apps/central-scan/backend/src/fujitsu_scanner.ts
+++ b/apps/central-scan/backend/src/fujitsu_scanner.ts
@@ -29,6 +29,7 @@ export interface BatchControl {
 export interface ScanOptions {
   directory?: string;
   pageSize?: BallotPaperSize;
+  imprintIdPrefix?: string; // Prefix for the audit ID to imprint on the ballot, an undefined value means no imprinting
 }
 
 export interface BatchScanner {
@@ -114,6 +115,7 @@ export class FujitsuScanner implements BatchScanner {
   scanSheets({
     directory = dirSync().name,
     pageSize = BallotPaperSize.Letter,
+    imprintIdPrefix,
   }: ScanOptions = {}): BatchControl {
     const args: string[] = [
       '-d',
@@ -128,6 +130,12 @@ export class FujitsuScanner implements BatchScanner {
       `--batch-print`,
       `--batch-prompt`,
     ];
+
+    if (imprintIdPrefix !== undefined) {
+      args.push('--endorser=yes');
+      // Imprint the prefix followed by a sequential index for each page in the batch
+      args.push('--endorser-string', `${imprintIdPrefix}_%04d`);
+    }
 
     const MM_PER_INCH = 25.3967;
     function toMillimeters(inches: number): string {

--- a/apps/central-scan/backend/src/fujitsu_scanner.ts
+++ b/apps/central-scan/backend/src/fujitsu_scanner.ts
@@ -96,7 +96,7 @@ export class FujitsuScanner implements BatchScanner {
         'fujitsu',
         '--endorser=yes',
         '--format=jpeg',
-        '-n',
+        '--dont-scan',
       ]);
 
       assert(process.stderr);

--- a/apps/central-scan/backend/src/importer.ts
+++ b/apps/central-scan/backend/src/importer.ts
@@ -12,7 +12,11 @@ import { join } from 'path';
 import { v4 as uuid } from 'uuid';
 import { interpretSheetAndSaveImages } from '@votingworks/ballot-interpreter';
 import { Logger } from '@votingworks/logging';
-import { BatchControl, BatchScanner } from './fujitsu_scanner';
+import {
+  BatchControl,
+  BatchScanner,
+  ScannedSheetInfo,
+} from './fujitsu_scanner';
 import { Workspace } from './util/workspace';
 import {
   describeValidationError,
@@ -67,18 +71,29 @@ export class Importer {
   }
 
   private async sheetAdded(
-    paths: SheetOf<string>,
+    sheetInfo: ScannedSheetInfo,
     batchId: string
   ): Promise<string> {
     const start = Date.now();
     try {
-      debug('sheetAdded %o batchId=%s STARTING', paths, batchId);
-      return await this.importSheet(batchId, paths[0], paths[1]);
+      debug(
+        'sheetAdded %s %s batchId=%s STARTING',
+        sheetInfo.frontPath,
+        sheetInfo.backPath,
+        batchId
+      );
+      return await this.importSheet(
+        batchId,
+        sheetInfo.frontPath,
+        sheetInfo.backPath,
+        sheetInfo.ballotAuditId
+      );
     } finally {
       const end = Date.now();
       debug(
-        'sheetAdded %o batchId=%s FINISHED in %dms',
-        paths,
+        'sheetAdded %s %s batchId=%s FINISHED in %dms',
+        sheetInfo.frontPath,
+        sheetInfo.backPath,
         batchId,
         Math.round(end - start)
       );
@@ -88,7 +103,8 @@ export class Importer {
   async importSheet(
     batchId: string,
     frontInputImagePath: string,
-    backInputImagePath: string
+    backInputImagePath: string,
+    ballotAuditId?: string
   ): Promise<string> {
     let sheetId = uuid();
     const interpretResult = await this.interpretSheet(sheetId, [
@@ -148,7 +164,8 @@ export class Importer {
       frontImagePath,
       frontInterpretation,
       backImagePath,
-      backInterpretation
+      backInterpretation,
+      ballotAuditId
     );
 
     const batch = this.workspace.store.getBatch(batchId);
@@ -188,7 +205,8 @@ export class Importer {
     frontImagePath: string,
     frontInterpretation: PageInterpretation,
     backImagePath: string,
-    backInterpretation: PageInterpretation
+    backInterpretation: PageInterpretation,
+    ballotAuditId?: string
   ): Promise<string> {
     if ('metadata' in frontInterpretation && 'metadata' in backInterpretation) {
       if (
@@ -204,22 +222,28 @@ export class Importer {
             backImagePath,
             backInterpretation,
             frontImagePath,
-            frontInterpretation
+            frontInterpretation,
+            ballotAuditId
           );
         }
       }
     }
 
-    const ballotId = this.workspace.store.addSheet(uuid(), batchId, [
-      {
-        imagePath: frontImagePath,
-        interpretation: frontInterpretation,
-      },
-      {
-        imagePath: backImagePath,
-        interpretation: backInterpretation,
-      },
-    ]);
+    const ballotId = this.workspace.store.addSheet(
+      uuid(),
+      batchId,
+      [
+        {
+          imagePath: frontImagePath,
+          interpretation: frontInterpretation,
+        },
+        {
+          imagePath: backImagePath,
+          interpretation: backInterpretation,
+        },
+      ],
+      ballotAuditId
+    );
 
     return ballotId;
   }

--- a/apps/central-scan/backend/src/importer.ts
+++ b/apps/central-scan/backend/src/importer.ts
@@ -268,7 +268,7 @@ export class Importer {
    */
   async startImport(): Promise<string> {
     this.getElectionDefinition(); // ensure election definition is loaded
-    //  TODO(#4939) const hasImprinter = await this.scanner.isImprinterAttached();
+    const hasImprinter = await this.scanner.isImprinterAttached();
 
     if (this.sheetGenerator) {
       throw new Error('scanning already in progress');
@@ -290,6 +290,8 @@ export class Importer {
     this.sheetGenerator = this.scanner.scanSheets({
       directory: batchScanDirectory,
       pageSize: ballotPaperSize,
+      // If the imprinter is attached automatically imprint an ID prefixed by the batchID
+      imprintIdPrefix: hasImprinter ? `${this.batchId}` : undefined,
     });
 
     this.continueImport({ forceAccept: false });

--- a/apps/central-scan/backend/src/importer.ts
+++ b/apps/central-scan/backend/src/importer.ts
@@ -268,6 +268,7 @@ export class Importer {
    */
   async startImport(): Promise<string> {
     this.getElectionDefinition(); // ensure election definition is loaded
+    //  TODO(#4939) const hasImprinter = await this.scanner.isImprinterAttached();
 
     if (this.sheetGenerator) {
       throw new Error('scanning already in progress');

--- a/apps/central-scan/backend/src/loop_scanner.ts
+++ b/apps/central-scan/backend/src/loop_scanner.ts
@@ -86,6 +86,10 @@ export class LoopScanner implements BatchScanner {
     return true;
   }
 
+  isImprinterAttached(): Promise<boolean> {
+    return Promise.resolve(false);
+  }
+
   /**
    * "Scans" the next sheet by returning the paths for the next two images.
    */

--- a/apps/central-scan/backend/src/store.test.ts
+++ b/apps/central-scan/backend/src/store.test.ts
@@ -560,6 +560,7 @@ test('iterating over sheets', () => {
     type: 'accepted',
     id: sheet1Id,
     batchId,
+    ballotAuditId: undefined,
     interpretation: mapSheet(sheetWithFiles, (page) => page.interpretation),
     frontImagePath: '1-front.jpg',
     backImagePath: '1-back.jpg',
@@ -570,14 +571,20 @@ test('iterating over sheets', () => {
 
   // Add and retrieve a rejected sheet
   const sheet2Id = uuid();
-  store.addSheet(sheet2Id, batchId, [
-    { ...sheetWithFiles[0], imagePath: '2-front.jpg' },
-    { ...sheetWithFiles[1], imagePath: '2-back.jpg' },
-  ]);
+  store.addSheet(
+    sheet2Id,
+    batchId,
+    [
+      { ...sheetWithFiles[0], imagePath: '2-front.jpg' },
+      { ...sheetWithFiles[1], imagePath: '2-back.jpg' },
+    ],
+    `${batchId}_0002`
+  );
   store.deleteSheet(sheet2Id);
   const expectedSheet2: RejectedSheet = {
     type: 'rejected',
     id: sheet2Id,
+    ballotAuditId: `${batchId}_0002`,
     frontImagePath: '2-front.jpg',
     backImagePath: '2-back.jpg',
   };

--- a/apps/central-scan/backend/test/util/mocks.ts
+++ b/apps/central-scan/backend/test/util/mocks.ts
@@ -98,6 +98,10 @@ export function makeMockScanner(): MockScanner {
       return true;
     },
 
+    async isImprinterAttached(): Promise<boolean> {
+      return Promise.resolve(false);
+    },
+
     scanSheets(): BatchControl {
       const session = nextScannerSession;
       nextScannerSession = undefined;

--- a/apps/central-scan/backend/test/util/mocks.ts
+++ b/apps/central-scan/backend/test/util/mocks.ts
@@ -5,12 +5,15 @@ import {
   MockWritable,
   mockWritable,
 } from '@votingworks/test-utils';
-import { SheetOf } from '@votingworks/types';
 import { Optional, throwIllegalValue } from '@votingworks/basics';
 import { ChildProcess } from 'child_process';
 import { EventEmitter } from 'events';
 import { fileSync } from 'tmp';
-import { BatchControl, BatchScanner } from '../../src/fujitsu_scanner';
+import {
+  BatchControl,
+  BatchScanner,
+  ScannedSheetInfo,
+} from '../../src/fujitsu_scanner';
 
 export function makeMock<T>(Cls: new (...args: never[]) => T): jest.Mocked<T> {
   if (!jest.isMockFunction(Cls)) {
@@ -22,7 +25,7 @@ export function makeMock<T>(Cls: new (...args: never[]) => T): jest.Mocked<T> {
 }
 
 type ScanSessionStep =
-  | { type: 'sheet'; sheet: SheetOf<string> }
+  | { type: 'sheet'; sheet: ScannedSheetInfo }
   | { type: 'error'; error: Error };
 
 /**
@@ -39,7 +42,7 @@ class ScannerSessionPlan {
   /**
    * Adds a scanning step to the session.
    */
-  sheet(sheet: SheetOf<string>): this {
+  sheet(sheet: ScannedSheetInfo): this {
     if (this.ended) {
       throw new Error('cannot add a sheet scan step to an ended session');
     }
@@ -115,7 +118,7 @@ export function makeMockScanner(): MockScanner {
 
       return {
         // eslint-disable-next-line @typescript-eslint/require-await
-        scanSheet: async (): Promise<SheetOf<string> | undefined> => {
+        scanSheet: async (): Promise<ScannedSheetInfo | undefined> => {
           const step = session.getStep(stepIndex);
           stepIndex += 1;
 

--- a/libs/backend/src/cast_vote_records/build_cast_vote_record.test.ts
+++ b/libs/backend/src/cast_vote_records/build_cast_vote_record.test.ts
@@ -432,6 +432,7 @@ const electionId = '0000000000'; // fixed for resiliency to hash change
 const scannerId = 'SC-00-000';
 const batchId = 'batch-1';
 const indexInBatch = 19;
+const ballotAuditId = `${batchId}_0023`;
 const castVoteRecordId = unsafeParse(BallotIdSchema, '1234');
 const definiteMarkThreshold = 0.15;
 
@@ -442,6 +443,7 @@ test('buildCastVoteRecord - BMD ballot', () => {
     castVoteRecordId,
     scannerId,
     batchId,
+    ballotAuditId,
     ballotMarkingMode: 'machine',
     interpretation: interpretedBmdPage,
   });
@@ -454,6 +456,7 @@ test('buildCastVoteRecord - BMD ballot', () => {
     CreatingDeviceId: scannerId,
     ElectionId: electionId,
     BatchId: batchId,
+    BallotAuditId: ballotAuditId,
     BatchSequenceId: undefined,
     UniqueId: castVoteRecordId,
   });
@@ -500,6 +503,7 @@ test('buildCastVoteRecord - BMD ballot images', () => {
       },
     ],
   });
+  expect(castVoteRecordWithImageReferences.BallotAuditId).toBeUndefined();
   expect(castVoteRecordWithImageReferences.BallotImage).toEqual([
     {
       '@type': 'CVR.ImageData',
@@ -529,6 +533,7 @@ describe('buildCastVoteRecord - HMPB Ballot', () => {
     castVoteRecordId,
     scannerId,
     batchId,
+    ballotAuditId,
     indexInBatch,
     ballotMarkingMode: 'hand',
     interpretations: [interpretedHmpbPage1, interpretedHmpbPage2],
@@ -546,6 +551,7 @@ describe('buildCastVoteRecord - HMPB Ballot', () => {
       BatchSequenceId: indexInBatch,
       UniqueId: castVoteRecordId,
       BallotSheetId: '1',
+      BallotAuditId: ballotAuditId,
     });
     expect(getCastVoteRecordBallotType(castVoteRecord)).toEqual(
       BallotType.Precinct

--- a/libs/backend/src/cast_vote_records/build_cast_vote_record.ts
+++ b/libs/backend/src/cast_vote_records/build_cast_vote_record.ts
@@ -518,6 +518,7 @@ type BuildCastVoteRecordParams = {
   batchId: string;
   electionOptionPositionMap?: ElectionOptionPositionMap;
   indexInBatch?: number;
+  ballotAuditId?: string;
 } & (
   | {
       ballotMarkingMode: 'machine';
@@ -543,6 +544,7 @@ export function buildCastVoteRecord({
   castVoteRecordId,
   batchId,
   indexInBatch,
+  ballotAuditId,
   electionOptionPositionMap,
   ...rest
 }: BuildCastVoteRecordParams): CVR.CVR {
@@ -566,6 +568,7 @@ export function buildCastVoteRecord({
     ElectionId: electionId,
     BatchId: batchId, // VVSG 2.0 1.1.5-G.6
     BatchSequenceId: indexInBatch, // VVSG 2.0 1.1.5-G.7
+    BallotAuditId: ballotAuditId,
     UniqueId: castVoteRecordId,
   };
 

--- a/libs/backend/src/cast_vote_records/export.ts
+++ b/libs/backend/src/cast_vote_records/export.ts
@@ -158,6 +158,7 @@ export interface AcceptedSheet {
   readonly type: 'accepted';
   readonly id: Id;
   readonly batchId: Id;
+  readonly ballotAuditId?: Id;
   readonly interpretation: SheetOf<PageInterpretation>;
   readonly frontImagePath: string;
   readonly backImagePath: string;
@@ -175,6 +176,7 @@ export interface AcceptedSheet {
 export interface RejectedSheet {
   readonly type: 'rejected';
   readonly id: Id;
+  readonly ballotAuditId?: Id;
   readonly frontImagePath: string;
   readonly backImagePath: string;
 }
@@ -314,7 +316,7 @@ async function buildCastVoteRecord(
   const electionOptionPositionMap = buildElectionOptionPositionMap(election);
   const scannerId = VX_MACHINE_ID;
 
-  const { id, batchId, indexInBatch } = sheet;
+  const { id, batchId, indexInBatch, ballotAuditId } = sheet;
   const castVoteRecordId =
     (canonicalizedSheet.type === 'bmd' &&
       canonicalizedSheet.interpretation.ballotId) ||
@@ -336,6 +338,7 @@ async function buildCastVoteRecord(
     return baseBuildCastVoteRecord({
       ballotMarkingMode: 'machine',
       batchId,
+      ballotAuditId,
       castVoteRecordId,
       electionDefinition,
       electionId,
@@ -352,6 +355,7 @@ async function buildCastVoteRecord(
   return baseBuildCastVoteRecord({
     ballotMarkingMode: 'hand',
     batchId,
+    ballotAuditId,
     castVoteRecordId,
     definiteMarkThreshold: markThresholds.definite,
     electionDefinition,


### PR DESCRIPTION
## Overview

When an imprinter module is attached to the scanner and you scan a batch, a new BallotAuditID in the form <Batch_ID>_<Sequence> will be imprinted on each sheet and exported in the CVR, where <Sequence> is a sequential ID starting with 0000, then 0001, etc. The largest scanner we use in the central system scans in max batches of 300 so 4 digit should be plenty for this ID. The ID gets reset on each subsequent batch, and is notably different from the BallotSequenceIdx currently included in the exported CVR in that it increments on rejected sheets, and all sheets, rejected ballots, unreadables, etc. are imprinted. 

BallotAuditId is an existing CDF field we are not currently using.

When an imprinter module is not attached to the scanner everything behaves identically to how to does today. Nothing is imprinted, and the CVR does not include a BallotAuditId. 


## Demo Video or Screenshot
The UI doesn't look any different then today, but here are photos of two sample ballots scanned with the imprinter module attached along with the associated CVRs. 
![IMG_1391](https://github.com/votingworks/vxsuite/assets/14897017/f1a58ce2-065b-44ec-8b7c-5738c5edb371)
[cast-vote-record-report.json](https://github.com/user-attachments/files/15976098/cast-vote-record-report.json)

![IMG_1392](https://github.com/votingworks/vxsuite/assets/14897017/c7c5e28f-513c-417e-a750-25b635a872db)
[cast-vote-record-report.json](https://github.com/user-attachments/files/15976100/cast-vote-record-report.json)



## Testing Plan

- Manually tested behavior with imprinter attached, scanning multiple batches, batches with unreadbles, etc. to verify all expected behavior
- Manually tested behavior without imprinter attached, verified it matches existing behavior
- Ran tests 

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
