### PR TITLE
feat(ballot-interpreter): add more debug information for partial timing marks

### DIFF
--- a/libs/ballot-interpreter/package.json
+++ b/libs/ballot-interpreter/package.json
@@ -68,7 +68,7 @@
     "@votingworks/bmd-ballot-fixtures": "workspace:*",
     "@votingworks/fs": "workspace:*",
     "@votingworks/hmpb": "workspace:*",
-    "cargo-cp-artifact": "^0.1",
+    "cargo-cp-artifact": "^0.1.9",
     "esbuild": "0.21.2",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",

--- a/libs/ballot-interpreter/src/hmpb-rust/debug.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/debug.rs
@@ -18,11 +18,11 @@ fn imageproc_rect_from_rect(rect: &Rect) -> imageproc::rect::Rect {
     imageproc::rect::Rect::at(rect.left(), rect.top()).of_size(rect.width(), rect.height())
 }
 
+use crate::image_utils::rainbow;
 use crate::layout::InterpretedContestLayout;
 use crate::{
     image_utils::{
-        BLUE, CYAN, DARK_BLUE, DARK_CYAN, DARK_GREEN, DARK_RED, GREEN, ORANGE, PINK, RAINBOW, RED,
-        WHITE_RGB,
+        BLUE, CYAN, DARK_BLUE, DARK_CYAN, DARK_GREEN, DARK_RED, GREEN, ORANGE, PINK, RED, WHITE_RGB,
     },
     qr_code::Detected,
     scoring::{ScoredBubbleMark, ScoredPositionAreas},
@@ -95,12 +95,8 @@ pub fn draw_qr_code_debug_image_mut(
 }
 
 pub fn draw_contours_debug_image_mut(canvas: &mut RgbImage, contour_rects: &[Rect]) {
-    for (i, rect) in contour_rects.iter().enumerate() {
-        draw_hollow_rect_mut(
-            canvas,
-            imageproc_rect_from_rect(rect),
-            RAINBOW[i % RAINBOW.len()],
-        );
+    for (rect, color) in contour_rects.iter().zip(rainbow()) {
+        draw_hollow_rect_mut(canvas, imageproc_rect_from_rect(rect), color);
     }
 }
 
@@ -110,20 +106,12 @@ pub fn draw_candidate_timing_marks_debug_image_mut(
     contour_rects: &[Rect],
     candidate_timing_marks: &[Rect],
 ) {
-    for (i, rect) in contour_rects.iter().enumerate() {
-        draw_hollow_rect_mut(
-            canvas,
-            imageproc_rect_from_rect(rect),
-            RAINBOW[i % RAINBOW.len()],
-        );
+    for (rect, color) in contour_rects.iter().zip(rainbow()) {
+        draw_hollow_rect_mut(canvas, imageproc_rect_from_rect(rect), color);
     }
 
-    for (i, rect) in candidate_timing_marks.iter().enumerate() {
-        draw_filled_rect_mut(
-            canvas,
-            imageproc_rect_from_rect(rect),
-            RAINBOW[i % RAINBOW.len()],
-        );
+    for (rect, color) in candidate_timing_marks.iter().zip(rainbow()) {
+        draw_filled_rect_mut(canvas, imageproc_rect_from_rect(rect), color);
     }
 }
 

--- a/libs/ballot-interpreter/src/hmpb-rust/debug.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/debug.rs
@@ -123,7 +123,7 @@ pub fn draw_timing_mark_debug_image_mut(
 ) {
     draw_legend(
         canvas,
-        &vec![
+        &[
             (
                 GREEN,
                 format!("Top ({})", partial_timing_marks.top_rects.len()).as_str(),
@@ -443,7 +443,7 @@ pub fn draw_scored_bubble_marks_debug_image_mut(
 
     draw_legend(
         canvas,
-        &vec![
+        &[
             (original_bubble_color, "Expected Bubble Bounds"),
             (matched_bubble_color, "Matched Bubble Bounds"),
             (
@@ -569,7 +569,7 @@ pub fn draw_scored_write_in_areas(
 
     draw_legend(
         canvas,
-        &vec![
+        &[
             (DARK_GREEN, "Write-In Area Bounds"),
             (ORANGE, "Write-In Area Score (100% = completely filled)"),
         ],
@@ -673,7 +673,7 @@ fn draw_text_with_background_mut(
     draw_text_mut(canvas, text_color, x, y, scale, font, text);
 }
 
-fn draw_legend(canvas: &mut RgbImage, colored_labels: &Vec<(Rgb<u8>, &str)>) {
+fn draw_legend(canvas: &mut RgbImage, colored_labels: &[(Rgb<u8>, &str)]) {
     let font = &monospace_font();
     let font_scale = 12.0;
     let scale = PxScale::from(font_scale);

--- a/libs/ballot-interpreter/src/hmpb-rust/debug.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/debug.rs
@@ -126,21 +126,55 @@ pub fn draw_timing_mark_debug_image_mut(
         &[
             (
                 GREEN,
-                format!("Top ({})", partial_timing_marks.top_rects.len()).as_str(),
+                format!(
+                    "Top ({}/{} found, rotation {})",
+                    partial_timing_marks.top_rects.len(),
+                    geometry.grid_size.width,
+                    partial_timing_marks.top_side_rotation().to_degrees(),
+                )
+                .as_str(),
             ),
             (
                 BLUE,
-                format!("Bottom ({})", partial_timing_marks.bottom_rects.len()).as_str(),
+                format!(
+                    "Bottom ({}/{} found, rotation {})",
+                    partial_timing_marks.bottom_rects.len(),
+                    geometry.grid_size.width,
+                    partial_timing_marks.bottom_side_rotation().to_degrees(),
+                )
+                .as_str(),
             ),
             (
                 RED,
-                format!("Left ({})", partial_timing_marks.left_rects.len()).as_str(),
+                format!(
+                    "Left ({}/{} found, rotation {})",
+                    partial_timing_marks.left_rects.len(),
+                    geometry.grid_size.height,
+                    partial_timing_marks.left_side_rotation().to_degrees(),
+                )
+                .as_str(),
             ),
             (
                 CYAN,
-                format!("Right ({})", partial_timing_marks.right_rects.len()).as_str(),
+                format!(
+                    "Right ({}/{} found, rotation {})",
+                    partial_timing_marks.right_rects.len(),
+                    geometry.grid_size.height,
+                    partial_timing_marks.right_side_rotation().to_degrees(),
+                )
+                .as_str(),
             ),
-            (PINK, format!("Corners ({})", 4).as_str()),
+            (
+                PINK,
+                format!(
+                    "Corners ({}/4)",
+                    u32::from(partial_timing_marks.top_left_rect.is_some())
+                        + u32::from(partial_timing_marks.top_right_rect.is_some())
+                        + u32::from(partial_timing_marks.bottom_left_rect.is_some())
+                        + u32::from(partial_timing_marks.bottom_right_rect.is_some()),
+                )
+                .as_str(),
+            ),
         ],
     );
 

--- a/libs/ballot-interpreter/src/hmpb-rust/image_utils.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/image_utils.rs
@@ -25,6 +25,10 @@ pub const DARK_CYAN: Rgb<u8> = Rgb([0, 127, 127]);
 pub const PINK: Rgb<u8> = Rgb([255, 0, 255]);
 pub const RAINBOW: [Rgb<u8>; 7] = [RED, ORANGE, YELLOW, GREEN, BLUE, INDIGO, VIOLET];
 
+pub fn rainbow() -> impl Iterator<Item = Rgb<u8>> {
+    RAINBOW.iter().copied().cycle()
+}
+
 /// An inset is a set of pixel offsets from the edges of an image.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub struct Inset {

--- a/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
@@ -144,8 +144,8 @@ pub enum Error {
         front: BallotPageMetadata,
         back: BallotPageMetadata,
     },
-    #[error("missing timing marks: {rects:?}")]
-    MissingTimingMarks { rects: Vec<Rect> },
+    #[error("missing timing marks: {rects:?}, reason: {reason}")]
+    MissingTimingMarks { rects: Vec<Rect>, reason: String },
     #[error("unexpected dimensions for {label}: {dimensions:?}")]
     UnexpectedDimensions {
         label: String,

--- a/libs/ballot-interpreter/src/hmpb-rust/timing_marks.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/timing_marks.rs
@@ -1,3 +1,5 @@
+use std::f32::consts::PI;
+
 use image::{imageops::rotate180, GenericImageView, GrayImage};
 use imageproc::{
     contours::{find_contours_with_threshold, BorderType, Contour},
@@ -9,7 +11,7 @@ use rayon::prelude::IntoParallelRefIterator;
 use serde::Serialize;
 use types_rs::geometry::{
     find_largest_subset_intersecting_line, intersection_of_lines, GridUnit, PixelPosition,
-    PixelUnit, Point, Rect, Segment, Size, SubGridUnit, SubPixelUnit,
+    PixelUnit, Point, Radians, Rect, Segment, Size, SubGridUnit, SubPixelUnit,
 };
 use types_rs::{election::UnitIntervalValue, geometry::IntersectionBounds};
 
@@ -39,6 +41,36 @@ pub struct Partial {
     pub top_right_rect: Option<Rect>,
     pub bottom_left_rect: Option<Rect>,
     pub bottom_right_rect: Option<Rect>,
+}
+
+impl Partial {
+    pub fn left_side_rotation(&self) -> Radians {
+        let left_angle = Segment::new(self.top_left_corner, self.bottom_left_corner).angle();
+        // expected angle is 90 degrees and not 270 degrees because the Y axis
+        // is inverted in the image coordinate system
+        let expected_angle = PI / 2.0;
+        (left_angle - expected_angle).abs()
+    }
+
+    pub fn right_side_rotation(&self) -> Radians {
+        let right_angle = Segment::new(self.top_right_corner, self.bottom_right_corner).angle();
+        // expected angle is 90 degrees and not 270 degrees because the Y axis
+        // is inverted in the image coordinate system
+        let expected_angle = PI / 2.0;
+        (right_angle - expected_angle).abs()
+    }
+
+    pub fn top_side_rotation(&self) -> Radians {
+        let top_angle = Segment::new(self.top_left_corner, self.top_right_corner).angle();
+        let expected_angle = 0.0;
+        (top_angle - expected_angle).abs()
+    }
+
+    pub fn bottom_side_rotation(&self) -> Radians {
+        let bottom_angle = Segment::new(self.bottom_left_corner, self.bottom_right_corner).angle();
+        let expected_angle = 0.0;
+        (bottom_angle - expected_angle).abs()
+    }
 }
 
 impl From<Complete> for Partial {

--- a/libs/ballot-interpreter/src/hmpb-ts/types.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/types.ts
@@ -391,7 +391,7 @@ export type InterpretError =
       front: BallotPageTimingMarkMetadata;
       back: BallotPageTimingMarkMetadata;
     }
-  | { type: 'missingTimingMarks'; rects: Rect[] }
+  | { type: 'missingTimingMarks'; rects: Rect[]; reason: string }
   | { type: 'unexpectedDimensions'; path: string; dimensions: Size<PixelUnit> }
   | { type: 'unknown'; message: string };
 

--- a/libs/types-rs/src/f32_newtype.rs
+++ b/libs/types-rs/src/f32_newtype.rs
@@ -1,0 +1,137 @@
+/// Creates a newtype for `f32` that can act like it, but is distinct from it.
+macro_rules! f32_newtype {
+    ($name:ident) => {
+        #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+        #[must_use]
+        pub struct $name(f32);
+
+        impl $name {
+            pub const INFINITY: Self = Self(f32::INFINITY);
+            pub const NEG_INFINITY: Self = Self(f32::NEG_INFINITY);
+            pub const NAN: Self = Self(f32::NAN);
+
+            pub const fn new(value: f32) -> Self {
+                Self(value)
+            }
+
+            #[must_use]
+            pub const fn get(&self) -> f32 {
+                self.0
+            }
+
+            #[must_use]
+            pub fn is_infinite(&self) -> bool {
+                self.0.is_infinite()
+            }
+
+            #[must_use]
+            pub fn is_nan(&self) -> bool {
+                self.0.is_nan()
+            }
+
+            pub fn abs(&self) -> Self {
+                Self(self.0.abs())
+            }
+        }
+
+        impl ::std::default::Default for $name {
+            fn default() -> Self {
+                Self(Default::default())
+            }
+        }
+
+        impl ::std::ops::Add for $name {
+            type Output = Self;
+
+            fn add(self, rhs: Self) -> Self::Output {
+                Self(self.0 + rhs.0)
+            }
+        }
+
+        impl ::std::ops::AddAssign for $name {
+            fn add_assign(&mut self, rhs: Self) {
+                self.0 += rhs.0;
+            }
+        }
+
+        impl ::std::ops::Sub for $name {
+            type Output = Self;
+
+            fn sub(self, rhs: Self) -> Self::Output {
+                Self(self.0 - rhs.0)
+            }
+        }
+
+        impl ::std::ops::SubAssign for $name {
+            fn sub_assign(&mut self, rhs: Self) {
+                self.0 -= rhs.0;
+            }
+        }
+
+        impl ::std::ops::Neg for $name {
+            type Output = Self;
+
+            fn neg(self) -> Self::Output {
+                Self(-self.0)
+            }
+        }
+
+        impl ::std::ops::Mul<f32> for $name {
+            type Output = Self;
+
+            fn mul(self, rhs: f32) -> Self::Output {
+                Self(self.0 * rhs)
+            }
+        }
+
+        impl ::std::ops::Mul<$name> for f32 {
+            type Output = $name;
+
+            fn mul(self, rhs: $name) -> Self::Output {
+                $name(self * rhs.0)
+            }
+        }
+
+        impl ::std::ops::Div<f32> for $name {
+            type Output = Self;
+
+            fn div(self, rhs: f32) -> Self::Output {
+                Self(self.0 / rhs)
+            }
+        }
+
+        impl ::std::ops::Div<$name> for f32 {
+            type Output = $name;
+
+            fn div(self, rhs: $name) -> Self::Output {
+                $name(self / rhs.0)
+            }
+        }
+
+        impl ::std::ops::Rem for $name {
+            type Output = Self;
+
+            fn rem(self, rhs: Self) -> Self::Output {
+                Self(self.0 % rhs.0)
+            }
+        }
+
+        impl ::std::cmp::Eq for $name {}
+
+        impl ::std::cmp::PartialOrd for $name {
+            fn partial_cmp(&self, other: &Self) -> Option<::std::cmp::Ordering> {
+                Some(self.cmp(other))
+            }
+        }
+
+        impl ::std::cmp::Ord for $name {
+            fn cmp(&self, other: &Self) -> ::std::cmp::Ordering {
+                self.0
+                    .partial_cmp(&other.0)
+                    .unwrap_or(::std::cmp::Ordering::Equal)
+            }
+        }
+    };
+}
+
+pub(crate) use f32_newtype;

--- a/libs/types-rs/src/geometry.rs
+++ b/libs/types-rs/src/geometry.rs
@@ -5,6 +5,8 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
+use crate::f32_newtype::f32_newtype;
+
 /// A unit of length in timing mark grid, i.e. 1 `GridUnit` is the logical
 /// distance from one timing mark to the next. This does not map directly to
 /// pixels.
@@ -46,11 +48,67 @@ pub type PixelUnit = u32;
 /// with the same underlying representation is not used.
 pub type SubPixelUnit = f32;
 
-/// Angle in radians.
-///
-/// Because this is just a type alias it does not enforce that another type
-/// with the same underlying representation is not used.
-pub type Radians = f32;
+macro_rules! impl_angle {
+    ($name:ident, $pi:expr, $display:expr) => {
+        impl $name {
+            pub const PI: Self = Self($pi);
+
+            /// Normalize angle to [0, PI). This means that two angles that are
+            /// equivalent modulo PI will be equal, e.g. 90° and 270°, even though
+            /// they are not equal in the mathematical sense.
+            pub fn normalize(self) -> Self {
+                if self.is_infinite() || self.is_nan() {
+                    return self;
+                }
+
+                let mut angle = self % (Self::PI * 2.0);
+                while self < Self(0.0) {
+                    angle += Self::PI;
+                }
+                while self >= Self::PI {
+                    angle -= Self::PI;
+                }
+                self
+            }
+        }
+
+        impl ::std::fmt::Display for $name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                write!(f, $display, self.0)
+            }
+        }
+    };
+}
+
+f32_newtype!(Radians);
+impl_angle!(Radians, std::f32::consts::PI, "{:.2}rad");
+
+impl Radians {
+    pub fn to_degrees(self) -> Degrees {
+        Degrees::new(self.0.to_degrees())
+    }
+}
+
+impl From<Degrees> for Radians {
+    fn from(degrees: Degrees) -> Self {
+        degrees.to_radians()
+    }
+}
+
+f32_newtype!(Degrees);
+impl_angle!(Degrees, 180.0, "{:.2}°");
+
+impl Degrees {
+    pub fn to_radians(self) -> Radians {
+        Radians::new(self.0.to_radians())
+    }
+}
+
+impl From<Radians> for Degrees {
+    fn from(radians: Radians) -> Self {
+        radians.to_degrees()
+    }
+}
 
 /// Fractional number of inches.
 ///
@@ -214,6 +272,24 @@ impl Rect {
             (bottom - top + 1) as PixelUnit,
         )
     }
+
+    /// Determines whether a line segment intersects a rectangle.
+    #[must_use]
+    pub fn intersects_line(&self, line: &Segment) -> bool {
+        let top_left = Point::new(self.left() as SubPixelUnit, self.top() as SubPixelUnit);
+        let top_right = Point::new(self.right() as SubPixelUnit, self.top() as SubPixelUnit);
+        let bottom_left = Point::new(self.left() as SubPixelUnit, self.bottom() as SubPixelUnit);
+        let bottom_right = Point::new(self.right() as SubPixelUnit, self.bottom() as SubPixelUnit);
+        let top_line = Segment::new(top_left, top_right);
+        let right_line = Segment::new(top_right, bottom_right);
+        let bottom_line = Segment::new(bottom_left, bottom_right);
+        let left_line = Segment::new(top_left, bottom_left);
+
+        top_line.intersects(line)
+            || bottom_line.intersects(line)
+            || left_line.intersects(line)
+            || right_line.intersects(line)
+    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize)]
@@ -270,7 +346,45 @@ impl Segment {
     pub fn angle(&self) -> Radians {
         let dx = self.end.x - self.start.x;
         let dy = self.end.y - self.start.y;
-        dy.atan2(dx)
+        Radians::new(dy.atan2(dx))
+    }
+
+    /// Determines whether the two line segments intersect.
+    #[must_use]
+    pub fn intersects(&self, other: &Self) -> bool {
+        self.intersection_point(other, IntersectionBounds::Bounded)
+            .is_some()
+    }
+
+    /// Determines an intersection point of two line segments. If `bounded` is set
+    /// to `true`, the intersection point must be within the bounds of both
+    /// segments. If `bounded` is set to `false`, the intersection point may be
+    /// outside the bounds of either segment.
+    #[must_use]
+    pub fn intersection_point(
+        &self,
+        other: &Self,
+        bounds: IntersectionBounds,
+    ) -> Option<Point<SubPixelUnit>> {
+        let p1 = self.start;
+        let p2 = self.end;
+        let p3 = other.start;
+        let p4 = other.end;
+        let d = (p4.y - p3.y).mul_add(p2.x - p1.x, -(p4.x - p3.x) * (p2.y - p1.y));
+        if d == 0.0 {
+            return None;
+        }
+        let u_a = (p4.x - p3.x).mul_add(p1.y - p3.y, -(p4.y - p3.y) * (p1.x - p3.x)) / d;
+        let u_b = (p2.x - p1.x).mul_add(p1.y - p3.y, -(p2.y - p1.y) * (p1.x - p3.x)) / d;
+        if matches!(bounds, IntersectionBounds::Unbounded)
+            || ((0.0..=1.0).contains(&u_a) && (0.0..=1.0).contains(&u_b))
+        {
+            return Some(Point::new(
+                u_a.mul_add(p2.x - p1.x, p1.x),
+                u_a.mul_add(p2.y - p1.y, p1.y),
+            ));
+        }
+        None
     }
 }
 
@@ -280,66 +394,11 @@ pub enum IntersectionBounds {
     Bounded,
 }
 
-/// Determines an intersection point of two line segments. If `bounded` is set
-/// to `true`, the intersection point must be within the bounds of both
-/// segments. If `bounded` is set to `false`, the intersection point may be
-/// outside the bounds of either segment.
-#[must_use]
-pub fn intersection_of_lines(
-    segment1: &Segment,
-    segment2: &Segment,
-    bounds: IntersectionBounds,
-) -> Option<Point<SubPixelUnit>> {
-    let p1 = segment1.start;
-    let p2 = segment1.end;
-    let p3 = segment2.start;
-    let p4 = segment2.end;
-    let d = (p4.y - p3.y).mul_add(p2.x - p1.x, -(p4.x - p3.x) * (p2.y - p1.y));
-    if d == 0.0 {
-        return None;
-    }
-    let u_a = (p4.x - p3.x).mul_add(p1.y - p3.y, -(p4.y - p3.y) * (p1.x - p3.x)) / d;
-    let u_b = (p2.x - p1.x).mul_add(p1.y - p3.y, -(p2.y - p1.y) * (p1.x - p3.x)) / d;
-    if matches!(bounds, IntersectionBounds::Unbounded)
-        || ((0.0..=1.0).contains(&u_a) && (0.0..=1.0).contains(&u_b))
-    {
-        return Some(Point::new(
-            u_a.mul_add(p2.x - p1.x, p1.x),
-            u_a.mul_add(p2.y - p1.y, p1.y),
-        ));
-    }
-    None
-}
-
-/// Determines whether the two line segments intersect.
-#[must_use]
-pub fn segments_intersect(line1: &Segment, line2: &Segment) -> bool {
-    intersection_of_lines(line1, line2, IntersectionBounds::Bounded).is_some()
-}
-
-/// Determines whether a line segment intersects a rectangle.
-#[must_use]
-pub fn rect_intersects_line(rect: &Rect, line: &Segment) -> bool {
-    let top_left = Point::new(rect.left() as SubPixelUnit, rect.top() as SubPixelUnit);
-    let top_right = Point::new(rect.right() as SubPixelUnit, rect.top() as SubPixelUnit);
-    let bottom_left = Point::new(rect.left() as SubPixelUnit, rect.bottom() as SubPixelUnit);
-    let bottom_right = Point::new(rect.right() as SubPixelUnit, rect.bottom() as SubPixelUnit);
-    let top_line = Segment::new(top_left, top_right);
-    let right_line = Segment::new(top_right, bottom_right);
-    let bottom_line = Segment::new(bottom_left, bottom_right);
-    let left_line = Segment::new(top_left, bottom_left);
-
-    segments_intersect(&top_line, line)
-        || segments_intersect(&bottom_line, line)
-        || segments_intersect(&left_line, line)
-        || segments_intersect(&right_line, line)
-}
-
 /// Returns the angle between two angles in radians.
 #[must_use]
 pub fn angle_diff(a: Radians, b: Radians) -> Radians {
-    let diff = normalize_angle(a - b);
-    diff.min(PI - diff)
+    let diff = normalize_angle(Radians::new(a.0 - b.0));
+    Radians::new(f32::min(diff.0, PI - diff.0))
 }
 
 /// Normalize angle to [0, PI). This means that two angles that are
@@ -347,18 +406,18 @@ pub fn angle_diff(a: Radians, b: Radians) -> Radians {
 /// they are not equal in the mathematical sense.
 #[must_use]
 pub fn normalize_angle(angle: Radians) -> Radians {
-    if angle.is_infinite() || angle.is_nan() {
+    if angle.0.is_infinite() || angle.0.is_nan() {
         return angle;
     }
 
-    let mut angle = angle % (2.0 * PI);
+    let mut angle = angle.0 % (2.0 * PI);
     while angle < 0.0 {
         angle += PI;
     }
     while angle >= PI {
         angle -= PI;
     }
-    angle
+    Radians::new(angle)
 }
 
 /// Finds the largest subset of rectangles such that a line can be drawn through
@@ -366,9 +425,11 @@ pub fn normalize_angle(angle: Radians) -> Radians {
 #[must_use]
 pub fn find_largest_subset_intersecting_line(
     rects: &[Rect],
-    angle: Radians,
-    tolerance: Radians,
+    angle: impl Into<Radians>,
+    tolerance: impl Into<Radians>,
 ) -> Vec<Rect> {
+    let angle = angle.into();
+    let tolerance = tolerance.into();
     rects
         .iter()
         // Get all pairs of rectangles.
@@ -377,7 +438,7 @@ pub fn find_largest_subset_intersecting_line(
         .filter_map(|(rect, other_rect)| {
             let line_angle = (other_rect.center().y - rect.center().y)
                 .atan2(other_rect.center().x - rect.center().x);
-            if angle_diff(line_angle, angle) > tolerance {
+            if angle_diff(Radians::new(line_angle), angle).0 > tolerance.0 {
                 // The line between the two rectangles is not within the
                 // tolerance of the desired angle, so skip this pair.
                 return None;
@@ -388,7 +449,7 @@ pub fn find_largest_subset_intersecting_line(
             Some(
                 rects
                     .iter()
-                    .filter(|r| rect_intersects_line(r, &segment))
+                    .filter(|r| r.intersects_line(&segment))
                     .collect::<Vec<_>>(),
             )
         })
@@ -409,14 +470,14 @@ mod normalize_angle_tests {
 
     use super::Radians;
 
-    const ANGLE_RANGE: Range<Radians> = -(10.0 * PI)..(10.0 * PI);
+    const ANGLE_RANGE: Range<f32> = -(10.0 * PI)..(10.0 * PI);
 
     macro_rules! assert_nearly_eq {
         ($a:expr, $b:expr) => {
             #[allow(clippy::suboptimal_flops)]
             {
                 assert!(
-                    ($a - $b).abs() < 0.0001,
+                    ($a.0 - $b.0).abs() < 0.0001,
                     "assertion failed: `({} - {}) < 0.0001`",
                     $a,
                     $b
@@ -427,10 +488,16 @@ mod normalize_angle_tests {
 
     #[test]
     fn test_normalize_angle() {
-        assert_nearly_eq!(super::normalize_angle(0.0), 0.0);
-        assert_nearly_eq!(super::normalize_angle(PI), 0.0);
-        assert_nearly_eq!(super::normalize_angle(2.0 * PI), 0.0);
-        assert_nearly_eq!(super::normalize_angle(1.5 * PI), 0.5 * PI);
+        assert_nearly_eq!(super::normalize_angle(Radians::new(0.0)), Radians::new(0.0));
+        assert_nearly_eq!(super::normalize_angle(Radians::new(PI)), Radians::new(0.0));
+        assert_nearly_eq!(
+            super::normalize_angle(Radians::new(2.0 * PI)),
+            Radians::new(0.0)
+        );
+        assert_nearly_eq!(
+            super::normalize_angle(Radians::new(1.5 * PI)),
+            Radians::new(0.5 * PI)
+        );
     }
 
     #[test]
@@ -445,21 +512,21 @@ mod normalize_angle_tests {
     proptest! {
         #[test]
         fn prop_normalize_angle(angle in ANGLE_RANGE) {
-            let normalized = super::normalize_angle(angle);
-            assert!((0.0..PI).contains(&normalized));
+            let normalized = super::normalize_angle(Radians::new(angle));
+            assert!((0.0..PI).contains(&normalized.0));
         }
 
         #[test]
         fn prop_normalize_angle_is_idempotent(angle in ANGLE_RANGE) {
-            let normalized = super::normalize_angle(angle);
+            let normalized = super::normalize_angle(Radians::new(angle));
             let normalized_again = super::normalize_angle(normalized);
             assert_nearly_eq!(normalized, normalized_again);
         }
 
         #[test]
         fn prop_normalize_angle_is_equivalent(angle in ANGLE_RANGE) {
-            let normalized = super::normalize_angle(angle);
-            let equivalent = super::normalize_angle(angle + PI);
+            let normalized = super::normalize_angle(Radians::new(angle));
+            let equivalent = super::normalize_angle(Radians::new(angle + PI));
             assert_nearly_eq!(normalized, equivalent);
         }
     }

--- a/libs/types-rs/src/geometry.rs
+++ b/libs/types-rs/src/geometry.rs
@@ -266,6 +266,12 @@ impl Segment {
         let dy = self.end.y - self.start.y;
         Point::new(dx, dy)
     }
+    /// Computes the angle of the segment in radians.
+    pub fn angle(&self) -> Radians {
+        let dx = self.end.x - self.start.x;
+        let dy = self.end.y - self.start.y;
+        dy.atan2(dx)
+    }
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/libs/types-rs/src/lib.rs
+++ b/libs/types-rs/src/lib.rs
@@ -5,5 +5,6 @@
 
 pub mod ballot_card;
 pub mod election;
+mod f32_newtype;
 pub mod geometry;
 pub mod idtype;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3272,8 +3272,8 @@ importers:
         specifier: workspace:*
         version: link:../hmpb
       cargo-cp-artifact:
-        specifier: ^0.1
-        version: 0.1.7
+        specifier: ^0.1.9
+        version: 0.1.9
       esbuild:
         specifier: 0.21.2
         version: 0.21.2
@@ -3419,7 +3419,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.4.5)
       util:
         specifier: ^0.12.4
         version: 0.12.4
@@ -12580,8 +12580,8 @@ packages:
       - encoding
       - supports-color
 
-  /cargo-cp-artifact@0.1.7:
-    resolution: {integrity: sha512-pxEV9p1on8vu3BOKstVisF9TwMyGKCBRvzaVpQHuU2sLULCKrn3MJWx/4XlNzmG6xNCTPf78DJ7WCGgr2mOzjg==}
+  /cargo-cp-artifact@0.1.9:
+    resolution: {integrity: sha512-6F+UYzTaGB+awsTXg0uSJA1/b/B3DDJzpKVRu0UmyI7DmNeaAl2RFHuTGIN6fEgpadRxoXGb7gbC1xo4C3IdyA==}
     hasBin: true
     dev: true
 


### PR DESCRIPTION
## Overview

Adds more debug information to the partial timing mark debug image and includes more specific reasons why the timing marks could not be found. This should not change the behavior of interpretation at all, just output more debug info along with some minor refactors.

Refs #4578 

## Demo Video or Screenshot
<img width="566" alt="image" src="https://github.com/votingworks/vxsuite/assets/1938/ac855a1a-964e-4076-9831-2975e150bd40">

## Testing Plan
- [x] Existing automated tests
