### PR TITLE
Make sure pdictl binary is built in production

### DIFF
--- a/apps/scan/frontend/Makefile
+++ b/apps/scan/frontend/Makefile
@@ -5,7 +5,10 @@ FORCE:
 install:
 
 build: FORCE
-	pnpm install && pnpm --dir ../../../libs/ballot-interpreter build && pnpm build
+	pnpm install && \
+		pnpm --dir ../../../libs/ballot-interpreter build && \
+		pnpm --dir ../../../libs/pdi-scanner build && \
+		pnpm build
 
 bootstrap: install build
 


### PR DESCRIPTION
The first issue that I encountered while trying to run a production image on the VxScan v4 build0: The `pdictl` binary (our PDI driver) was missing. This PR makes sure that the binary is built in production.