### PR TITLE
Eject usb when unconfiguring as election manager

### DIFF
--- a/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
@@ -332,6 +332,7 @@ test('MarkAndPrint end-to-end flow', async () => {
   apiMock.expectGetSystemSettings();
   apiMock.expectGetElectionDefinition(null);
   apiMock.expectGetElectionState();
+  apiMock.expectEjectUsbDrive();
   userEvent.click(screen.getByText('Unconfigure Machine'));
   userEvent.click(screen.getButton('Yes, Delete Election Data'));
 

--- a/apps/mark-scan/frontend/src/pages/admin_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/admin_screen.test.tsx
@@ -130,3 +130,13 @@ test('USB button calls eject', async () => {
   apiMock.expectEjectUsbDrive();
   userEvent.click(ejectButton);
 });
+
+test('Unconfigure will eject usb', async () => {
+  renderScreen({
+    usbDriveStatus: mockUsbDriveStatus('mounted'),
+  });
+  const unconfigureButton = await screen.findByText('Unconfigure Machine');
+  apiMock.expectEjectUsbDrive();
+  userEvent.click(unconfigureButton);
+  userEvent.click(screen.getButton('Yes, Delete Election Data'));
+});

--- a/apps/mark-scan/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/admin_screen.tsx
@@ -63,6 +63,16 @@ export function AdminScreen({
   const setPrecinctSelectionMutation = setPrecinctSelection.useMutation();
   const setTestModeMutation = setTestMode.useMutation();
 
+  async function unconfigureMachineAndEjectUsb() {
+    try {
+      // If there is a mounted usb, eject it so that it doesn't auto reconfigure the machine.
+      await ejectUsbDriveMutation.mutateAsync();
+      await unconfigure();
+    } catch (error) {
+      // Handled by default query client error handling
+    }
+  }
+
   return (
     <Screen>
       {election && isTestMode && <TestMode />}
@@ -153,7 +163,7 @@ export function AdminScreen({
         <P>
           <UnconfigureMachineButton
             isMachineConfigured
-            unconfigureMachine={unconfigure}
+            unconfigureMachine={unconfigureMachineAndEjectUsb}
           />
         </P>
         <H6 as="h2">USB</H6>


### PR DESCRIPTION
## Overview
[
<!-- add a link to a GitHub Issue here -->](https://github.com/votingworks/vxsuite/issues/3510)

Copying how we do it in VxScan eject the usb when unconfiguring as an election manager so we don't automatically reconfigure. 

## Demo Video or Screenshot
https://github.com/votingworks/vxsuite/assets/14897017/87b8fc72-d82d-478c-8c85-cca87edb4ed5



## Testing Plan
Tested unconfiguring manually with and without usb mounted. 
Ran tests

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
