### PR TITLE
[MarkScan] Reset state machine when ending voter session

### DIFF
--- a/apps/mark-scan/backend/src/app.auth.test.ts
+++ b/apps/mark-scan/backend/src/app.auth.test.ts
@@ -138,6 +138,8 @@ test('startCardlessVoterSession', async () => {
 });
 
 test('endCardlessVoterSession', async () => {
+  jest.spyOn(stateMachine, 'reset');
+
   await configureApp(apiClient, mockAuth, mockUsbDrive, systemSettings);
 
   await apiClient.endCardlessVoterSession();
@@ -147,6 +149,7 @@ test('endCardlessVoterSession', async () => {
     electionHash,
     jurisdiction,
   });
+  expect(stateMachine.reset).toHaveBeenCalled();
 });
 
 test('getAuthStatus before election definition has been configured', async () => {

--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -125,6 +125,7 @@ export function buildApi(
     },
 
     endCardlessVoterSession() {
+      stateMachine?.reset();
       return auth.endCardlessVoterSession(constructAuthMachineState(workspace));
     },
 

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -686,3 +686,22 @@ describe('paper handler diagnostic', () => {
     await expectStatusTransitionTo('accepting_paper');
   });
 });
+
+test('reset() API', async () => {
+  const ballotPdfData = await readBallotFixture();
+  const scannedBallotFixtureFilepaths = getSampleBallotFilepath();
+
+  await executePrintBallotAndAssert(
+    ballotPdfData,
+    scannedBallotFixtureFilepaths,
+    SUCCESSFUL_INTERPRETATION_MOCK
+  );
+
+  await expectStatusTransitionTo('presenting_ballot');
+  expect(machine.getInterpretation()).toEqual(SUCCESSFUL_INTERPRETATION_MOCK);
+
+  machine.reset();
+
+  expectCurrentStatus('not_accepting_paper');
+  expect(machine.getInterpretation()).toBeUndefined();
+});


### PR DESCRIPTION
## Overview

(Tangentially) related to https://github.com/votingworks/vxsuite/issues/4812

Noticed while working on the ballot re-insertion flow that we're not yet cleaning up the state machine when a poll worker resets the ballot/voter session. Adding a state machine `reset()` API method that gets called when ending a voter session - resets the state machine context and moves to `not_accepting_paper` to make sure any existing paper is ejected.

## Testing Plan
- Updated unit tests
- Tested locally with mock paper handler

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
