### PR TITLE
Fix bug to autofocus okay button on overvote modal

### DIFF
--- a/libs/mark-flow-ui/src/components/candidate_contest.tsx
+++ b/libs/mark-flow-ui/src/components/candidate_contest.tsx
@@ -29,6 +29,7 @@ import {
   electionStrings,
   ReadOnLoad,
   AssistiveTechInstructions,
+  PageNavigationButtonId,
 } from '@votingworks/ui';
 import { assert } from '@votingworks/basics';
 
@@ -381,8 +382,8 @@ export function CandidateContest({
               {appStrings.warningOvervoteCandidateContest()}
               <AudioOnly>
                 <AssistiveTechInstructions
-                  controllerString={appStrings.instructionsBmdSelectToContinue()}
-                  patDeviceString={appStrings.instructionsBmdSelectToContinuePatDevice()}
+                  controllerString={appStrings.instructionsBmdNextToContinue()}
+                  patDeviceString={appStrings.instructionsBmdMoveToSelectToContinuePatDevice()}
                 />
               </AudioOnly>
             </P>
@@ -392,6 +393,7 @@ export function CandidateContest({
               variant="primary"
               autoFocus
               onPress={closeAttemptedVoteAlert}
+              id={PageNavigationButtonId.NEXT}
             >
               {appStrings.buttonOkay()}
               <AudioOnly>

--- a/libs/mark-flow-ui/src/components/yes_no_contest.tsx
+++ b/libs/mark-flow-ui/src/components/yes_no_contest.tsx
@@ -19,6 +19,7 @@ import {
   appStrings,
   AssistiveTechInstructions,
   Pre,
+  PageNavigationButtonId,
 } from '@votingworks/ui';
 
 import { getSingleYesNoVote } from '@votingworks/utils';
@@ -139,14 +140,19 @@ export function YesNoContest({
               {appStrings.warningOvervoteYesNoContest()}
               <AudioOnly>
                 <AssistiveTechInstructions
-                  controllerString={appStrings.instructionsBmdSelectToContinue()}
-                  patDeviceString={appStrings.instructionsBmdSelectToContinuePatDevice()}
+                  controllerString={appStrings.instructionsBmdNextToContinue()}
+                  patDeviceString={appStrings.instructionsBmdMoveToSelectToContinuePatDevice()}
                 />
               </AudioOnly>
             </P>
           }
           actions={
-            <Button variant="primary" autoFocus onPress={closeOvervoteAlert}>
+            <Button
+              variant="primary"
+              autoFocus
+              onPress={closeOvervoteAlert}
+              id={PageNavigationButtonId.NEXT}
+            >
               {appStrings.buttonOkay()}
               <AudioOnly>
                 <AssistiveTechInstructions

--- a/libs/ui/src/accessible_controllers/navigation.test.tsx
+++ b/libs/ui/src/accessible_controllers/navigation.test.tsx
@@ -111,3 +111,43 @@ test('triggerPageNavigationButton - is no-op for missing nav buttons', () => {
     triggerPageNavigationButton(PageNavigationButtonId.PREVIOUS)
   ).not.toThrow();
 });
+
+test('triggerPageNavigationButton - click visible button where there are both visible and hidden options', () => {
+  const onClickNextHidden = jest.fn();
+  const onClickNextVisible = jest.fn();
+
+  render(
+    <div>
+      <div aria-hidden>
+        <TestButton
+          id={PageNavigationButtonId.NEXT}
+          onClick={onClickNextHidden}
+        />
+      </div>
+      <div>
+        <TestButton
+          id={PageNavigationButtonId.NEXT}
+          onClick={onClickNextVisible}
+        />
+      </div>
+    </div>
+  );
+
+  act(() => triggerPageNavigationButton(PageNavigationButtonId.NEXT));
+  expect(onClickNextHidden).not.toHaveBeenCalled();
+  expect(onClickNextVisible).toHaveBeenCalled();
+});
+
+test('triggerPageNavigationButton - is a no op when there are multiple visible buttons', () => {
+  const onClickNext = jest.fn();
+
+  render(
+    <div>
+      <TestButton id={PageNavigationButtonId.NEXT} onClick={onClickNext} />
+      <TestButton id={PageNavigationButtonId.NEXT} onClick={onClickNext} />
+    </div>
+  );
+
+  act(() => triggerPageNavigationButton(PageNavigationButtonId.NEXT));
+  expect(onClickNext).not.toHaveBeenCalled();
+});

--- a/libs/ui/src/accessible_controllers/navigation.ts
+++ b/libs/ui/src/accessible_controllers/navigation.ts
@@ -57,11 +57,16 @@ export function advanceElementFocus(direction: 1 | -1): void {
  * to advance
  */
 export function triggerPageNavigationButton(id: PageNavigationButtonId): void {
-  const button = document.getElementById(id);
+  const possibleNextElements = document.querySelectorAll(`#${id}`);
+  const hiddenElements = getTabEnabledElementsInHiddenBlocks();
+  // create an array of elements in both possibleButtons and hiddenElements
+  const visibleButtons = Array.from(possibleNextElements).filter(
+    (e) => !hiddenElements.has(e) && e instanceof HTMLElement
+  );
 
-  if (!button || getTabEnabledElementsInHiddenBlocks().has(button)) {
+  if (visibleButtons.length !== 1) {
     return;
   }
 
-  button.click();
+  (visibleButtons[0] as HTMLElement).click();
 }

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -494,6 +494,13 @@ export const appStrings = {
     </UiString>
   ),
 
+  instructionsBmdMoveToSelectToContinuePatDevice: () => (
+    <UiString uiStringKey="instructionsBmdMoveToSelectToContinuePatDevice">
+      Use the move input to select the Okay button and then use the select input
+      to continue.
+    </UiString>
+  ),
+
   instructionsBmdWriteInFormNavigation: () => (
     <UiString uiStringKey="instructionsBmdWriteInFormNavigation">
       Use the up and down buttons to navigate between the letters of a standard

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -482,6 +482,12 @@ export const appStrings = {
     </UiString>
   ),
 
+  instructionsBmdNextToContinue: () => (
+    <UiString uiStringKey="instructionsBmdNextToContinue">
+      Press the right button to continue.
+    </UiString>
+  ),
+
   instructionsBmdSelectToContinuePatDevice: () => (
     <UiString uiStringKey="instructionsBmdSelectToContinuePatDevice">
       Use the select input to continue.

--- a/libs/ui/src/ui_strings/app_strings_catalog/latest.json
+++ b/libs/ui/src/ui_strings/app_strings_catalog/latest.json
@@ -71,6 +71,7 @@
   "instructionsBmdContestNavigationPatDevice": "To navigate through the contest choices, use the move input. To advance to the next contest, use the move input to navigate to the control labelled \"next\" and then use the select input to continue.",
   "instructionsBmdControllerSandboxMarkScan": "Press any button on the controller to learn what it is and how to use it. When you're done, press the question mark shaped “Help” button at the top left corner of the controller again to return to your ballot.",
   "instructionsBmdInvalidatedBallot": "You have indicated your ballot needs changes. Please alert a poll worker to invalidate the incorrect ballot sheet.",
+  "instructionsBmdNextToContinue": "Press the right button to continue.",
   "instructionsBmdPaperJam": "Please alert a poll worker to clear the jam.",
   "instructionsBmdPatCalibrationConfirmExitScreen": "You may continue with voting or go back to the previous screen.",
   "instructionsBmdPatCalibrationIntroStep": "Trigger any input to continue.",

--- a/libs/ui/src/ui_strings/app_strings_catalog/latest.json
+++ b/libs/ui/src/ui_strings/app_strings_catalog/latest.json
@@ -71,6 +71,7 @@
   "instructionsBmdContestNavigationPatDevice": "To navigate through the contest choices, use the move input. To advance to the next contest, use the move input to navigate to the control labelled \"next\" and then use the select input to continue.",
   "instructionsBmdControllerSandboxMarkScan": "Press any button on the controller to learn what it is and how to use it. When you're done, press the question mark shaped “Help” button at the top left corner of the controller again to return to your ballot.",
   "instructionsBmdInvalidatedBallot": "You have indicated your ballot needs changes. Please alert a poll worker to invalidate the incorrect ballot sheet.",
+  "instructionsBmdMoveToSelectToContinuePatDevice": "Use the move input to select the Okay button and then use the select input to continue.",
   "instructionsBmdNextToContinue": "Press the right button to continue.",
   "instructionsBmdPaperJam": "Please alert a poll worker to clear the jam.",
   "instructionsBmdPatCalibrationConfirmExitScreen": "You may continue with voting or go back to the previous screen.",


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/4927 
Because of the way React automatically handles focusing of Modals using the autofocus html5 attribute on a button inside a Modal does not work and the "Okay" to dismiss the overvote warning modal does not get properly autofocused. Instead we have to manually focus the button ref in order for it to autofocus as implemented here. Note the onAfterOpen was not triggering at the right time in the Modal component unless I passed through the isOpen parameter I know we don't otherwise use. 
<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot

## Testing Plan
Manually triggered overvotes saw "okay" focus 

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
