### PR TITLE
fix: use `transform` mode for esbuild

### DIFF
--- a/apps/central-scan/backend/bin/read-qrcode
+++ b/apps/central-scan/backend/bin/read-qrcode
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 
 require('../src/cli/read-qrcode')
   .main(process.argv, {

--- a/apps/central-scan/backend/bin/render-pages
+++ b/apps/central-scan/backend/bin/render-pages
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 
 require('../src/cli/render_pages').main(process.argv.slice(2), {
   stdout: process.stdout,

--- a/apps/central-scan/backend/scripts/copy-batch
+++ b/apps/central-scan/backend/scripts/copy-batch
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 require('./copy_batch').main(process.argv.slice(2));

--- a/apps/design/backend/scripts/synthesize-speech
+++ b/apps/design/backend/scripts/synthesize-speech
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 require('./synthesize_speech.ts').main(process.argv.slice(2));

--- a/apps/design/backend/scripts/translate-text
+++ b/apps/design/backend/scripts/translate-text
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 require('./translate_text.ts').main(process.argv.slice(2));

--- a/apps/scan/backend/scripts/copy-sheets
+++ b/apps/scan/backend/scripts/copy-sheets
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 require('./copy_sheets').main(process.argv.slice(2));

--- a/libs/auth/scripts/cac/cac-get-cert
+++ b/libs/auth/scripts/cac/cac-get-cert
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 require('./src/cac_get_cert').main(process.argv.slice(2));

--- a/libs/auth/scripts/cac/configure-simulated-cac-card
+++ b/libs/auth/scripts/cac/configure-simulated-cac-card
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 require('./src/configure_simulated_cac_card').main();

--- a/libs/auth/scripts/check-pin
+++ b/libs/auth/scripts/check-pin
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 require('./src/check_pin').main(process.argv.slice(2));

--- a/libs/auth/scripts/configure-java-card
+++ b/libs/auth/scripts/configure-java-card
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 require('./src/configure_java_card').main();

--- a/libs/auth/scripts/create-production-machine-cert-signing-request
+++ b/libs/auth/scripts/create-production-machine-cert-signing-request
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 require('./src/create_production_machine_cert_signing_request').main();

--- a/libs/auth/scripts/generate-dev-keys-and-certs
+++ b/libs/auth/scripts/generate-dev-keys-and-certs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 require('./src/generate_dev_keys_and_certs').main(process.argv.slice(2));

--- a/libs/auth/scripts/mock-card
+++ b/libs/auth/scripts/mock-card
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 require('./src/mock_card').main(process.argv.slice(2));

--- a/libs/auth/scripts/program-production-system-administrator-java-card-without-vx-admin
+++ b/libs/auth/scripts/program-production-system-administrator-java-card-without-vx-admin
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 require('./src/program_production_system_administrator_java_card_without_vx_admin').main();

--- a/libs/auth/scripts/program-system-administrator-java-card
+++ b/libs/auth/scripts/program-system-administrator-java-card
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 require('./src/program_system_administrator_java_card').main();

--- a/libs/auth/scripts/program-vendor-java-card
+++ b/libs/auth/scripts/program-vendor-java-card
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 require('./src/program_vendor_java_card').main();

--- a/libs/auth/scripts/read-java-card-details
+++ b/libs/auth/scripts/read-java-card-details
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 require('./src/read_java_card_details').main();

--- a/libs/auth/src/intermediate-scripts/create-cert
+++ b/libs/auth/src/intermediate-scripts/create-cert
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 require('./create_cert').main();

--- a/libs/auth/src/intermediate-scripts/sign-message
+++ b/libs/auth/src/intermediate-scripts/sign-message
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 require('./sign_message').main();

--- a/libs/converter-nh-accuvote/bin/convert
+++ b/libs/converter-nh-accuvote/bin/convert
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 
 require('../src/cli/convert')
   .main(process.argv.slice(2))

--- a/libs/cvr-fixture-generator/bin/generate
+++ b/libs/cvr-fixture-generator/bin/generate
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 
 require('../src/cli/generate')
   .main(process.argv, {

--- a/libs/hmpb/bin/generate-fixtures
+++ b/libs/hmpb/bin/generate-fixtures
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 require('../src/generate_fixtures')
   .main()
   .catch((e) => {

--- a/libs/image-utils/bin/pdf-to-images
+++ b/libs/image-utils/bin/pdf-to-images
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 
 require('../src/pdf_to_images').main(process.argv.slice(2), {
   stdout: process.stdout,

--- a/libs/monorepo-utils/bin/generate-circleci-config
+++ b/libs/monorepo-utils/bin/generate-circleci-config
@@ -2,7 +2,9 @@
 
 // @ts-check
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 
 const { join } = require('path');
 const { generateConfig } = require('../src/circleci');

--- a/libs/monorepo-utils/bin/prune-unused
+++ b/libs/monorepo-utils/bin/prune-unused
@@ -2,7 +2,9 @@
 
 // @ts-check
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 
 const { rmSync } = require('fs');
 const { join } = require('path');
@@ -24,7 +26,7 @@ function pruneUnusedPackages({ dryRun = false } = {}) {
     for (const pkg of findUnusedPackages(pkgs)) {
       console.log(`${dryRun ? '[skip] ' : ''}Removing ${pkg.name}…`);
       if (!dryRun) {
-      rmSync(pkg.path, { recursive: true });
+        rmSync(pkg.path, { recursive: true });
       }
       count++;
     }
@@ -37,9 +39,9 @@ function pruneUnusedPackages({ dryRun = false } = {}) {
   doPrunePass();
 
   if (dryRun) {
-    console.log(`Would remove ${count} packages.`)
+    console.log(`Would remove ${count} packages.`);
   } else {
-    console.log(`Removed ${count} packages.`)
+    console.log(`Removed ${count} packages.`);
   }
 }
 

--- a/libs/monorepo-utils/bin/remove-package
+++ b/libs/monorepo-utils/bin/remove-package
@@ -2,7 +2,9 @@
 
 // @ts-check
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 
 const { join } = require('path');
 const { getWorkspacePackageInfo } = require('../src/pnpm');
@@ -26,14 +28,16 @@ function removePackages(names) {
       if (pkg !== pkgToRemove) {
         for (const dep of findAllMonorepoDependencies(pkgs, pkg)) {
           if (dep === pkgToRemove) {
-            console.error(`Package ${pkgToRemove.name} is depended on by ${pkg.name}!`);
+            console.error(
+              `Package ${pkgToRemove.name} is depended on by ${pkg.name}!`
+            );
             process.exit(1);
           }
         }
       }
     }
 
-    console.log(`Removing ${pkgToRemove.name}…`)
+    console.log(`Removing ${pkgToRemove.name}…`);
     rmSync(pkgToRemove.path, { recursive: true, force: true });
   }
 }

--- a/libs/pdi-scanner/src/ts/demo
+++ b/libs/pdi-scanner/src/ts/demo
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 require('./demo.ts')
   .main(process.argv.slice(2))
   .catch((e) => {

--- a/libs/printing/scripts/printer
+++ b/libs/printing/scripts/printer
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 
 require('../src/printer/cli')
   .main(process.argv)

--- a/libs/printing/scripts/render-tally-report
+++ b/libs/printing/scripts/render-tally-report
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 require('./render_tally_report.tsx').main(process.argv.slice(2));

--- a/libs/res-to-ts/bin/res-to-ts
+++ b/libs/res-to-ts/bin/res-to-ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 
 require('../src/cli')
   .main(process.argv, {

--- a/libs/types/bin/convert-vxf-election-to-cdf
+++ b/libs/types/bin/convert-vxf-election-to-cdf
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 
 require('../src/cdf/ballot-definition/cli.ts')
   .main(process.argv, {

--- a/libs/ui/scripts/finalize-app-strings-catalog
+++ b/libs/ui/scripts/finalize-app-strings-catalog
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 require('./finalize_app_strings_catalog.ts').main();

--- a/libs/ui/scripts/generate-font-awesome-styles
+++ b/libs/ui/scripts/generate-font-awesome-styles
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 require('./generate_font_awesome_styles.ts').main();

--- a/libs/usb-drive/bin/usb-drive
+++ b/libs/usb-drive/bin/usb-drive
@@ -2,7 +2,9 @@
 
 // @ts-check
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 
 require('../src/cli')
   .main(process.argv)

--- a/script/run-dev
+++ b/script/run-dev
@@ -2,7 +2,9 @@
 
 // @ts-check
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 
 require('./src/run-dev')
   .main(process.argv, {

--- a/script/validate-monorepo
+++ b/script/validate-monorepo
@@ -2,7 +2,9 @@
 
 // @ts-check
 
-require('esbuild-runner/register');
+require('esbuild-runner').install({
+  type: 'transform',
+});
 
 require('./src/validate-monorepo/cli')
   .main({


### PR DESCRIPTION
The default mode when using `esbuild-runner/register` is to bundle, which has problems with `__dirname` et al and also cannot load native extensions (`.node` files).
