### PR TITLE
Prevent accidental ballot casting with accessible controller 

### DIFF
--- a/apps/mark-scan/frontend/src/lib/assistive_technology.ts
+++ b/apps/mark-scan/frontend/src/lib/assistive_technology.ts
@@ -18,7 +18,10 @@ export function handleKeyboardEvent(event: KeyboardEvent): void {
       triggerPageNavigationButton(PageNavigationButtonId.PREVIOUS);
       break;
     case Keybinding.PAGE_NEXT:
-      triggerPageNavigationButton(PageNavigationButtonId.NEXT);
+      triggerPageNavigationButton(
+        PageNavigationButtonId.NEXT,
+        PageNavigationButtonId.NEXT_AFTER_CONFIRM
+      );
       break;
     case Keybinding.FOCUS_PREVIOUS:
       advanceElementFocus(-1);

--- a/apps/mark-scan/frontend/src/pages/validate_ballot_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/validate_ballot_page.tsx
@@ -81,10 +81,16 @@ export function ValidateBallotPage(): JSX.Element | null {
             {appStrings.buttonBallotIsIncorrect()}
           </Button>
           <Button
-            id={PageNavigationButtonId.NEXT}
+            id={PageNavigationButtonId.NEXT_AFTER_CONFIRM}
             onPress={validateBallotCallback}
           >
             {appStrings.buttonBallotIsCorrect()}
+            <AudioOnly>
+              <AssistiveTechInstructions
+                controllerString={appStrings.instructionsBmdConfirmCastingBallot()}
+                patDeviceString={appStrings.instructionsBmdConfirmCastingBallotPatDevice()}
+              />
+            </AudioOnly>
           </Button>
         </React.Fragment>
       }

--- a/apps/mark/frontend/src/lib/gamepad.ts
+++ b/apps/mark/frontend/src/lib/gamepad.ts
@@ -25,7 +25,10 @@ export function handleGamepadButtonDown(buttonName: Button): void {
       triggerPageNavigationButton(PageNavigationButtonId.PREVIOUS);
       break;
     case 'DPadRight':
-      triggerPageNavigationButton(PageNavigationButtonId.NEXT);
+      triggerPageNavigationButton(
+        PageNavigationButtonId.NEXT,
+        PageNavigationButtonId.NEXT_AFTER_CONFIRM
+      );
       break;
     case 'A':
       handleClick();
@@ -48,7 +51,10 @@ export function handleGamepadKeyboardEvent(event: KeyboardEvent): void {
       triggerPageNavigationButton(PageNavigationButtonId.PREVIOUS);
       break;
     case Keybinding.PAGE_NEXT:
-      triggerPageNavigationButton(PageNavigationButtonId.NEXT);
+      triggerPageNavigationButton(
+        PageNavigationButtonId.NEXT,
+        PageNavigationButtonId.NEXT_AFTER_CONFIRM
+      );
       break;
     case Keybinding.SELECT:
       // Enter already acts like a click

--- a/libs/mark-flow-ui/src/pages/review_page.tsx
+++ b/libs/mark-flow-ui/src/pages/review_page.tsx
@@ -53,11 +53,17 @@ export function ReviewPage(props: ReviewPageProps): JSX.Element {
   const printMyBallotButton = (
     <LinkButton
       to={printScreenUrl}
-      id={PageNavigationButtonId.NEXT}
+      id={PageNavigationButtonId.NEXT_AFTER_CONFIRM}
       variant="primary"
       icon="Done"
     >
       {appStrings.buttonPrintBallot()}
+      <AudioOnly>
+        <AssistiveTechInstructions
+          controllerString={appStrings.instructionsBmdConfirmPrintingBallot()}
+          patDeviceString={appStrings.instructionsBmdConfirmPrintingBallotPatDevice()}
+        />
+      </AudioOnly>
     </LinkButton>
   );
 

--- a/libs/ui/src/accessible_controllers/navigation.test.tsx
+++ b/libs/ui/src/accessible_controllers/navigation.test.tsx
@@ -108,6 +108,13 @@ test('triggerPageNavigationButton - is no-op for missing nav buttons', () => {
   ).not.toThrow();
 
   expect(() =>
+    triggerPageNavigationButton(
+      PageNavigationButtonId.NEXT,
+      PageNavigationButtonId.NEXT_AFTER_CONFIRM
+    )
+  ).not.toThrow();
+
+  expect(() =>
     triggerPageNavigationButton(PageNavigationButtonId.PREVIOUS)
   ).not.toThrow();
 });
@@ -138,16 +145,88 @@ test('triggerPageNavigationButton - click visible button where there are both vi
   expect(onClickNextVisible).toHaveBeenCalled();
 });
 
-test('triggerPageNavigationButton - is a no op when there are multiple visible buttons', () => {
-  const onClickNext = jest.fn();
+test('triggerPageNavigationButton - selects the first when there are multiple visible buttons', () => {
+  const onClickNext1 = jest.fn();
+  const onClickNext2 = jest.fn();
 
   render(
     <div>
-      <TestButton id={PageNavigationButtonId.NEXT} onClick={onClickNext} />
-      <TestButton id={PageNavigationButtonId.NEXT} onClick={onClickNext} />
+      <TestButton id={PageNavigationButtonId.NEXT} onClick={onClickNext1} />
+      <TestButton id={PageNavigationButtonId.NEXT} onClick={onClickNext2} />
     </div>
   );
 
   act(() => triggerPageNavigationButton(PageNavigationButtonId.NEXT));
+  expect(onClickNext1).toHaveBeenCalled();
+  expect(onClickNext2).not.toHaveBeenCalled();
+});
+
+test('triggerPageNavigationButton - focuses on navigationOnConfirm element when no visible nav buttons', () => {
+  const onClickNext = jest.fn();
+
+  render(
+    <div>
+      <TestButton
+        data-testid="button"
+        id={PageNavigationButtonId.NEXT_AFTER_CONFIRM}
+        onClick={onClickNext}
+      />
+    </div>
+  );
+
+  act(() =>
+    triggerPageNavigationButton(
+      PageNavigationButtonId.NEXT,
+      PageNavigationButtonId.NEXT_AFTER_CONFIRM
+    )
+  );
+  // Check that we have focused but not clicked the button
   expect(onClickNext).not.toHaveBeenCalled();
+  expect(screen.getByTestId('button')).toHaveFocus();
+});
+
+test('triggerPageNavigationButton - does not focus on navigationOnConfirm element id not provided', () => {
+  const onClickNext = jest.fn();
+
+  render(
+    <div>
+      <TestButton
+        data-testid="button"
+        id={PageNavigationButtonId.NEXT_AFTER_CONFIRM}
+        onClick={onClickNext}
+      />
+    </div>
+  );
+
+  act(() => triggerPageNavigationButton(PageNavigationButtonId.NEXT));
+  // Check that we have focused but not clicked the button
+  expect(onClickNext).not.toHaveBeenCalled();
+  expect(screen.getByTestId('button')).not.toHaveFocus();
+});
+
+test('triggerPageNavigationButton - clicking on a button takes precendence over focus when there are buttons matching both options', () => {
+  const onClickNext1 = jest.fn();
+  const onClickNext2 = jest.fn();
+
+  render(
+    <div>
+      <TestButton
+        data-testid="button"
+        id={PageNavigationButtonId.NEXT_AFTER_CONFIRM}
+        onClick={onClickNext1}
+      />
+      <TestButton id={PageNavigationButtonId.NEXT} onClick={onClickNext2} />
+    </div>
+  );
+
+  act(() =>
+    triggerPageNavigationButton(
+      PageNavigationButtonId.NEXT,
+      PageNavigationButtonId.NEXT_AFTER_CONFIRM
+    )
+  );
+  // Check that we have focused but not clicked the button
+  expect(onClickNext1).not.toHaveBeenCalled();
+  expect(screen.getByTestId('button')).not.toHaveFocus();
+  expect(onClickNext2).toHaveBeenCalled();
 });

--- a/libs/ui/src/accessible_controllers/navigation.ts
+++ b/libs/ui/src/accessible_controllers/navigation.ts
@@ -76,7 +76,6 @@ export function triggerPageNavigationButton(
   ).filter((e) => !hiddenElements.has(e) && e instanceof HTMLElement);
 
   if (navigationOnConfirmButtons.length >= 1) {
-    console.log('we are focusing');
     (navigationOnConfirmButtons[0] as HTMLElement).focus();
   }
 }

--- a/libs/ui/src/accessible_controllers/navigation.ts
+++ b/libs/ui/src/accessible_controllers/navigation.ts
@@ -71,6 +71,9 @@ export function triggerPageNavigationButton(
     (navigationButtons[0] as HTMLElement).click();
     return;
   }
+  if (!navigationOnConfirmId) {
+    return;
+  }
   const navigationOnConfirmButtons = Array.from(
     document.querySelectorAll(`#${navigationOnConfirmId}`)
   ).filter((e) => !hiddenElements.has(e) && e instanceof HTMLElement);

--- a/libs/ui/src/accessible_controllers/navigation.ts
+++ b/libs/ui/src/accessible_controllers/navigation.ts
@@ -1,5 +1,6 @@
 export enum PageNavigationButtonId {
   NEXT = 'next',
+  NEXT_AFTER_CONFIRM = 'next_after_confirm',
   PREVIOUS = 'previous',
 }
 
@@ -53,20 +54,29 @@ export function advanceElementFocus(direction: 1 | -1): void {
 }
 
 /**
- * Simulates a click on the page navigation button with the specified {@link id}
- * to advance
+ * Looks for all page navigation elements with the specified {@link navigationId} or
+ * {@link nagivationOnConfirmId} (if provided). If a visible {@link navigationId} is found, the first element is clicked.
+ * Otherwise if a visible {@link navigationOnConfirmId} is found, the first element is focused.
  */
-export function triggerPageNavigationButton(id: PageNavigationButtonId): void {
-  const possibleNextElements = document.querySelectorAll(`#${id}`);
+export function triggerPageNavigationButton(
+  navigationId: PageNavigationButtonId,
+  navigationOnConfirmId?: PageNavigationButtonId
+): void {
   const hiddenElements = getTabEnabledElementsInHiddenBlocks();
-  // create an array of elements in both possibleButtons and hiddenElements
-  const visibleButtons = Array.from(possibleNextElements).filter(
-    (e) => !hiddenElements.has(e) && e instanceof HTMLElement
-  );
+  const navigationButtons = Array.from(
+    document.querySelectorAll(`#${navigationId}`)
+  ).filter((e) => !hiddenElements.has(e) && e instanceof HTMLElement);
 
-  if (visibleButtons.length !== 1) {
+  if (navigationButtons.length >= 1) {
+    (navigationButtons[0] as HTMLElement).click();
     return;
   }
+  const navigationOnConfirmButtons = Array.from(
+    document.querySelectorAll(`#${navigationOnConfirmId}`)
+  ).filter((e) => !hiddenElements.has(e) && e instanceof HTMLElement);
 
-  (visibleButtons[0] as HTMLElement).click();
+  if (navigationOnConfirmButtons.length >= 1) {
+    console.log('we are focusing');
+    (navigationOnConfirmButtons[0] as HTMLElement).focus();
+  }
 }

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -476,6 +476,20 @@ export const appStrings = {
     </UiString>
   ),
 
+  instructionsBmdConfirmCastingBallot: () => (
+    <UiString uiStringKey="instructionsBmdConfirmCastingBallot">
+      Press the select button to confirm your selections are correct and cast
+      your ballot.
+    </UiString>
+  ),
+
+  instructionsBmdConfirmCastingBallotPatDevice: () => (
+    <UiString uiStringKey="instructionsBmdConfirmCastingBallotPatDevice">
+      Use the select input to confirm your selections are correct and cast your
+      ballot.
+    </UiString>
+  ),
+
   instructionsBmdScanReviewConfirmation: () => (
     <UiString uiStringKey="instructionsBmdScanReviewConfirmation">
       If your selections are correct, press the Right button to confirm your

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -464,6 +464,18 @@ export const appStrings = {
     </UiString>
   ),
 
+  instructionsBmdConfirmPrintingBallot: () => (
+    <UiString uiStringKey="instructionsBmdConfirmPrintingBallot">
+      Press the select button to confirm your selections and print your ballot.
+    </UiString>
+  ),
+
+  instructionsBmdConfirmPrintingBallotPatDevice: () => (
+    <UiString uiStringKey="instructionsBmdConfirmPrintingBallotPatDevice">
+      Use the select input to confirm your selections and print your ballot.
+    </UiString>
+  ),
+
   instructionsBmdScanReviewConfirmation: () => (
     <UiString uiStringKey="instructionsBmdScanReviewConfirmation">
       If your selections are correct, press the Right button to confirm your

--- a/libs/ui/src/ui_strings/app_strings_catalog/latest.json
+++ b/libs/ui/src/ui_strings/app_strings_catalog/latest.json
@@ -67,6 +67,8 @@
   "instructionsBmdCastBallotPreamblePostPrint": "Your official ballot has been removed from the printer. Complete the following steps to finish voting:",
   "instructionsBmdCastBallotStep1": "1. Verify your official ballot.",
   "instructionsBmdCastBallotStep2": "2. Scan your official ballot.",
+  "instructionsBmdConfirmCastingBallot": "Press the select button to confirm your selections are correct and cast your ballot.",
+  "instructionsBmdConfirmCastingBallotPatDevice": "Use the select input to confirm your selections are correct and cast your ballot.",
   "instructionsBmdConfirmPrintingBallot": "Press the select button to confirm your selections and print your ballot.",
   "instructionsBmdConfirmPrintingBallotPatDevice": "Use the select input to confirm your selections and print your ballot.",
   "instructionsBmdContestNavigation": "To navigate through the contest choices, use the down button. To move to the next contest, use the right button.",

--- a/libs/ui/src/ui_strings/app_strings_catalog/latest.json
+++ b/libs/ui/src/ui_strings/app_strings_catalog/latest.json
@@ -67,6 +67,8 @@
   "instructionsBmdCastBallotPreamblePostPrint": "Your official ballot has been removed from the printer. Complete the following steps to finish voting:",
   "instructionsBmdCastBallotStep1": "1. Verify your official ballot.",
   "instructionsBmdCastBallotStep2": "2. Scan your official ballot.",
+  "instructionsBmdConfirmPrintingBallot": "Press the select button to confirm your selections and print your ballot.",
+  "instructionsBmdConfirmPrintingBallotPatDevice": "Use the select input to confirm your selections and print your ballot.",
   "instructionsBmdContestNavigation": "To navigate through the contest choices, use the down button. To move to the next contest, use the right button.",
   "instructionsBmdContestNavigationPatDevice": "To navigate through the contest choices, use the move input. To advance to the next contest, use the move input to navigate to the control labelled \"next\" and then use the select input to continue.",
   "instructionsBmdControllerSandboxMarkScan": "Press any button on the controller to learn what it is and how to use it. When you're done, press the question mark shaped “Help” button at the top left corner of the controller again to return to your ballot.",


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/4930

In order to prevent pressing the right arrow too quickly and accidental casting ballots this PR makes the right arrow on the review screen simply focus on the "Print my Ballot" button rather then clicking the button. So the user will now need to press the right button and the select button, unless they are using the touch screen and just press the button. I added an additional audio instruction to confirm your selections and print to the Print My Ballot when focused as well. 

## Demo Video or Screenshot

## Testing Plan
Manually Tested with keyboard. Ran tests for navigation helper function changes. 

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
