### PR TITLE
chore(deps): update to `typescript` v5.5.3

### DIFF
--- a/apps/scan/frontend/src/screens/scan_warning_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/scan_warning_screen.test.tsx
@@ -277,7 +277,7 @@ test('undervote by 1', async () => {
 test('multiple undervotes', async () => {
   apiMock.mockApiClient.acceptBallot.expectCallWith().resolves();
   const contests = electionGeneralDefinition.election.contests
-    .filter((c): c is CandidateContest => c.type === 'candidate')
+    .filter((c) => c.type === 'candidate')
     .slice(0, 2);
 
   renderScreen({

--- a/libs/backend/src/cast_vote_records/build_report_metadata.ts
+++ b/libs/backend/src/cast_vote_records/build_report_metadata.ts
@@ -101,7 +101,7 @@ function buildElection({
   electionScopeId: string;
 }): CVR.Election {
   const allCandidates = election.contests
-    .filter((c): c is CandidateContest => c.type === 'candidate')
+    .filter((c) => c.type === 'candidate')
     .flatMap((c) => c.candidates);
 
   // The VotingWorks election format nests candidate definitions under

--- a/libs/ballot-encoder/tsconfig.json
+++ b/libs/ballot-encoder/tsconfig.json
@@ -4,6 +4,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "lib": ["dom", "dom.iterable", "esnext"],
+    "skipLibCheck": true,
     "module": "node16",
     "moduleResolution": "node16",
     "noUnusedParameters": true,

--- a/libs/eslint-plugin-vx/package.json
+++ b/libs/eslint-plugin-vx/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-jsx-a11y": "^6.6.1",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-react": "^7.31.8",
-    "typescript": "5.4.5"
+    "typescript": "5.5.3"
   },
   "devDependencies": {
     "@types/jest": "^29.5.3",

--- a/libs/mark-flow-ui/src/components/candidate_contest.test.tsx
+++ b/libs/mark-flow-ui/src/components/candidate_contest.test.tsx
@@ -54,7 +54,7 @@ const electionDefinition = electionGeneralDefinition;
 
 const candidateContest = electionDefinition.election.contests.find(
   (c) => c.type === 'candidate'
-)! as CandidateContestInterface;
+)!;
 
 const candidateContestWithMultipleSeats: CandidateContestInterface = {
   ...electionDefinition.election.contests.find(

--- a/libs/monorepo-utils/package.json
+++ b/libs/monorepo-utils/package.json
@@ -56,7 +56,7 @@
     "prettier": "3.0.3",
     "sort-package-json": "^1.50.0",
     "ts-jest": "29.1.1",
-    "typescript": "5.4.5"
+    "typescript": "5.5.3"
   },
   "packageManager": "pnpm@8.3.1"
 }

--- a/libs/ui/src/modal.test.tsx
+++ b/libs/ui/src/modal.test.tsx
@@ -115,10 +115,12 @@ describe('Modal', () => {
 
   it('handles after open', () => {
     // Work around a react-modal bug: https://github.com/reactjs/react-modal/issues/903
-    jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
-      cb(1);
-      return 1;
-    });
+    jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((cb: FrameRequestCallback) => {
+        cb(1);
+        return 1;
+      });
     const onAfterOpen = jest.fn();
     render(<Modal content="Content" onAfterOpen={onAfterOpen} />);
     expect(onAfterOpen).toHaveBeenCalledTimes(1);

--- a/package.json
+++ b/package.json
@@ -51,12 +51,12 @@
     "storybook": "^7.2.2",
     "stylelint": "^15.10.2",
     "stylelint-config-standard": "^34.0.0",
-    "typescript": "5.4.5"
+    "typescript": "5.5.3"
   },
   "pnpm": {
     "overrides": {
       "@types/eslint": "8.4.1",
-      "typescript": "5.4.5",
+      "typescript": "5.5.3",
       "graceful-fs": "^4.2.9"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,7 +2,7 @@ lockfileVersion: '6.0'
 
 overrides:
   '@types/eslint': 8.4.1
-  typescript: 5.4.5
+  typescript: 5.5.3
   graceful-fs: ^4.2.9
 
 importers:
@@ -44,7 +44,7 @@ importers:
         version: 7.2.2(react-dom@18.3.1)(react@18.3.1)
       '@storybook/builder-vite':
         specifier: ^7.2.2
-        version: 7.2.2(typescript@5.4.5)(vite@4.5.0)
+        version: 7.2.2(typescript@5.5.3)(vite@4.5.0)
       '@storybook/channel-postmessage':
         specifier: ^7.2.2
         version: 7.2.2
@@ -71,10 +71,10 @@ importers:
         version: 7.2.2
       '@storybook/react':
         specifier: ^7.2.2
-        version: 7.2.2(react-dom@18.3.1)(react@18.3.1)(typescript@5.4.5)
+        version: 7.2.2(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3)
       '@storybook/react-vite':
         specifier: ^7.2.2
-        version: 7.2.2(react-dom@18.3.1)(react@18.3.1)(typescript@5.4.5)(vite@4.5.0)
+        version: 7.2.2(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3)(vite@4.5.0)
       '@storybook/theming':
         specifier: ^7.2.2
         version: 7.2.2(react-dom@18.3.1)(react@18.3.1)
@@ -86,7 +86,7 @@ importers:
         version: 8.4.1
       '@typescript-eslint/parser':
         specifier: 6.7.0
-        version: 6.7.0(eslint@8.49.0)(typescript@5.4.5)
+        version: 6.7.0(eslint@8.49.0)(typescript@5.5.3)
       eslint:
         specifier: 8.49.0
         version: 8.49.0
@@ -101,7 +101,7 @@ importers:
         version: 5.2.0
       postcss-styled-syntax:
         specifier: ^0.4.0
-        version: 0.4.0(postcss@8.4.38)(typescript@5.4.5)
+        version: 0.4.0(postcss@8.4.38)(typescript@5.5.3)
       prettier:
         specifier: ^3.0.3
         version: 3.0.3
@@ -118,8 +118,8 @@ importers:
         specifier: ^34.0.0
         version: 34.0.0(stylelint@15.10.2)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.5.3
+        version: 5.5.3
 
   apps/admin/backend:
     dependencies:
@@ -327,7 +327,7 @@ importers:
         version: 6.1.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
 
   apps/admin/frontend:
     dependencies:
@@ -441,7 +441,7 @@ importers:
         version: 3.0.0
       react-dev-utils:
         specifier: 12.0.1
-        version: 12.0.1(eslint@8.49.0)(typescript@5.4.5)(webpack@5.88.2)
+        version: 12.0.1(eslint@8.49.0)(typescript@5.5.3)(webpack@5.88.2)
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
@@ -610,7 +610,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -849,7 +849,7 @@ importers:
         version: 6.1.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
 
   apps/central-scan/frontend:
     dependencies:
@@ -1063,7 +1063,7 @@ importers:
         version: 3.0.0
       react-dev-utils:
         specifier: 12.0.1
-        version: 12.0.1(eslint@8.49.0)(typescript@5.4.5)(webpack@5.88.2)
+        version: 12.0.1(eslint@8.49.0)(typescript@5.5.3)(webpack@5.88.2)
       react-refresh:
         specifier: ^0.9.0
         version: 0.9.0
@@ -1072,7 +1072,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       type-fest:
         specifier: ^0.18.0
         version: 0.18.1
@@ -1287,7 +1287,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
 
   apps/design/frontend:
     dependencies:
@@ -1453,7 +1453,7 @@ importers:
         version: 3.0.0
       react-dev-utils:
         specifier: 12.0.1
-        version: 12.0.1(eslint@8.49.0)(typescript@5.4.5)(webpack@5.88.2)
+        version: 12.0.1(eslint@8.49.0)(typescript@5.5.3)(webpack@5.88.2)
       sort-package-json:
         specifier: ^1.50.0
         version: 1.53.1
@@ -1462,7 +1462,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -1643,7 +1643,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
 
   apps/mark-scan/frontend:
     dependencies:
@@ -1724,7 +1724,7 @@ importers:
         version: 3.0.0
       react-dev-utils:
         specifier: 12.0.1
-        version: 12.0.1(eslint@8.49.0)(typescript@5.4.5)(webpack@5.88.2)
+        version: 12.0.1(eslint@8.49.0)(typescript@5.5.3)(webpack@5.88.2)
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
@@ -1863,7 +1863,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -2051,7 +2051,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
 
   apps/mark/frontend:
     dependencies:
@@ -2132,7 +2132,7 @@ importers:
         version: 3.0.0
       react-dev-utils:
         specifier: 12.0.1
-        version: 12.0.1(eslint@8.49.0)(typescript@5.4.5)(webpack@5.88.2)
+        version: 12.0.1(eslint@8.49.0)(typescript@5.5.3)(webpack@5.88.2)
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
@@ -2277,7 +2277,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -2531,7 +2531,7 @@ importers:
         version: 6.1.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
       wait-for-expect:
         specifier: ^3.0.2
         version: 3.0.2
@@ -2730,13 +2730,13 @@ importers:
         version: 3.0.0
       react-dev-utils:
         specifier: 12.0.1
-        version: 12.0.1(eslint@8.49.0)(typescript@5.4.5)(webpack@4.46.0)
+        version: 12.0.1(eslint@8.49.0)(typescript@5.5.3)(webpack@4.46.0)
       sort-package-json:
         specifier: ^1.50.0
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -2787,7 +2787,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/@types/compress-commons:
     dependencies:
@@ -2861,7 +2861,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/auth:
     dependencies:
@@ -2976,7 +2976,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       wait-for-expect:
         specifier: ^3.0.2
         version: 3.0.2
@@ -3136,7 +3136,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/ballot-encoder:
     dependencies:
@@ -3188,7 +3188,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/ballot-interpreter:
     dependencies:
@@ -3309,7 +3309,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/basics:
     dependencies:
@@ -3355,7 +3355,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/bmd-ballot-fixtures:
     dependencies:
@@ -3419,7 +3419,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       util:
         specifier: ^0.12.4
         version: 0.12.4
@@ -3474,7 +3474,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/converter-nh-accuvote:
     dependencies:
@@ -3580,7 +3580,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
 
   libs/custom-paper-handler:
     dependencies:
@@ -3653,13 +3653,13 @@ importers:
         version: 16.0.0
       jest-mock-extended:
         specifier: ^3.0.4
-        version: 3.0.4(jest@29.6.2)(typescript@5.4.5)
+        version: 3.0.4(jest@29.6.2)(typescript@5.5.3)
       jest-watch-typeahead:
         specifier: ^2.2.2
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/custom-scanner:
     dependencies:
@@ -3726,13 +3726,13 @@ importers:
         version: 16.0.0
       jest-mock-extended:
         specifier: ^3.0.4
-        version: 3.0.4(jest@29.6.2)(typescript@5.4.5)
+        version: 3.0.4(jest@29.6.2)(typescript@5.5.3)
       jest-watch-typeahead:
         specifier: ^2.2.2
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -3820,7 +3820,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       zod:
         specifier: 3.23.5
         version: 3.23.5
@@ -3875,7 +3875,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/dev-dock/backend:
     dependencies:
@@ -3948,7 +3948,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/dev-dock/frontend:
     dependencies:
@@ -4054,16 +4054,16 @@ importers:
         version: 5.3.11(react-dom@18.3.1)(react-is@18.2.0)(react@18.3.1)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/eslint-plugin-vx:
     dependencies:
       '@typescript-eslint/eslint-plugin':
         specifier: 6.7.0
-        version: 6.7.0(@typescript-eslint/parser@6.7.0)(eslint@8.49.0)(typescript@5.4.5)
+        version: 6.7.0(@typescript-eslint/parser@6.7.0)(eslint@8.49.0)(typescript@5.5.3)
       '@typescript-eslint/utils':
         specifier: 6.7.0
-        version: 6.7.0(eslint@8.49.0)(typescript@5.4.5)
+        version: 6.7.0(eslint@8.49.0)(typescript@5.5.3)
       comment-parser:
         specifier: ^1.4.0
         version: 1.4.0
@@ -4087,7 +4087,7 @@ importers:
         version: 2.26.0(@typescript-eslint/parser@6.7.0)(eslint-import-resolver-typescript@3.6.0)(eslint@8.49.0)
       eslint-plugin-jest:
         specifier: ^27.2.3
-        version: 27.2.3(@typescript-eslint/eslint-plugin@6.7.0)(eslint@8.49.0)(jest@29.6.2)(typescript@5.4.5)
+        version: 27.2.3(@typescript-eslint/eslint-plugin@6.7.0)(eslint@8.49.0)(jest@29.6.2)(typescript@5.5.3)
       eslint-plugin-jsx-a11y:
         specifier: ^6.6.1
         version: 6.6.1(eslint@8.49.0)
@@ -4098,8 +4098,8 @@ importers:
         specifier: ^7.31.8
         version: 7.31.8(eslint@8.49.0)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.5.3
+        version: 5.5.3
     devDependencies:
       '@types/jest':
         specifier: ^29.5.3
@@ -4112,7 +4112,7 @@ importers:
         version: 18.3.3
       '@typescript-eslint/rule-tester':
         specifier: ^6.7.0
-        version: 6.7.0(@eslint/eslintrc@2.1.2)(eslint@8.49.0)(typescript@5.4.5)
+        version: 6.7.0(@eslint/eslintrc@2.1.2)(eslint@8.49.0)(typescript@5.5.3)
       eslint-plugin-vx:
         specifier: workspace:*
         version: 'link:'
@@ -4133,7 +4133,7 @@ importers:
         version: 18.3.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/fixtures:
     dependencies:
@@ -4185,7 +4185,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/fs:
     dependencies:
@@ -4264,7 +4264,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/fujitsu-thermal-printer:
     dependencies:
@@ -4325,7 +4325,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/grout:
     dependencies:
@@ -4386,7 +4386,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/grout/test-utils:
     dependencies:
@@ -4426,7 +4426,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/hmpb:
     dependencies:
@@ -4544,7 +4544,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -4629,7 +4629,7 @@ importers:
         version: 11.0.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
 
   libs/logging:
     dependencies:
@@ -4708,7 +4708,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/mark-flow-ui:
     dependencies:
@@ -4784,7 +4784,7 @@ importers:
         version: 7.2.2
       '@storybook/react':
         specifier: ^7.2.2
-        version: 7.2.2(react-dom@18.3.1)(react@18.3.1)(typescript@5.4.5)
+        version: 7.2.2(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3)
       '@tanstack/react-query':
         specifier: 4.32.1
         version: 4.32.1(react-dom@18.3.1)(react@18.3.1)
@@ -4862,7 +4862,7 @@ importers:
         version: 6.0.3
       eslint-plugin-storybook:
         specifier: ^0.6.10
-        version: 0.6.10(eslint@8.49.0)(typescript@5.4.5)
+        version: 0.6.10(eslint@8.49.0)(typescript@5.5.3)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
@@ -4922,7 +4922,7 @@ importers:
         version: 5.3.11(react-dom@18.3.1)(react-is@18.2.0)(react@18.3.1)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       util:
         specifier: ^0.12.4
         version: 0.12.4
@@ -4962,7 +4962,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/monorepo-utils:
     dependencies:
@@ -4978,10 +4978,10 @@ importers:
         version: 16.18.23
       '@typescript-eslint/eslint-plugin':
         specifier: 6.7.0
-        version: 6.7.0(@typescript-eslint/parser@6.7.0)(eslint@8.49.0)(typescript@5.4.5)
+        version: 6.7.0(@typescript-eslint/parser@6.7.0)(eslint@8.49.0)(typescript@5.5.3)
       '@typescript-eslint/parser':
         specifier: 6.7.0
-        version: 6.7.0(eslint@8.49.0)(typescript@5.4.5)
+        version: 6.7.0(eslint@8.49.0)(typescript@5.5.3)
       esbuild-runner:
         specifier: 2.2.2
         version: 2.2.2(esbuild@0.21.2)
@@ -5002,7 +5002,7 @@ importers:
         version: 2.27.5(@typescript-eslint/parser@6.7.0)(eslint-import-resolver-typescript@3.6.0)(eslint@8.49.0)
       eslint-plugin-jest:
         specifier: ^27.2.3
-        version: 27.2.3(@typescript-eslint/eslint-plugin@6.7.0)(eslint@8.49.0)(jest@29.6.2)(typescript@5.4.5)
+        version: 27.2.3(@typescript-eslint/eslint-plugin@6.7.0)(eslint@8.49.0)(jest@29.6.2)(typescript@5.5.3)
       eslint-plugin-prettier:
         specifier: ^5.0.0
         version: 5.0.0(@types/eslint@8.4.1)(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.0.3)
@@ -5032,10 +5032,10 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.5.3
+        version: 5.5.3
 
   libs/pdi-scanner:
     dependencies:
@@ -5087,7 +5087,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/printing:
     dependencies:
@@ -5199,7 +5199,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/res-to-ts:
     dependencies:
@@ -5254,7 +5254,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/test-utils:
     dependencies:
@@ -5336,7 +5336,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/types:
     dependencies:
@@ -5427,7 +5427,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/types-rs: {}
 
@@ -5538,7 +5538,7 @@ importers:
         version: 7.2.2
       '@storybook/react':
         specifier: ^7.2.2
-        version: 7.2.2(react-dom@18.3.1)(react@18.3.1)(typescript@5.4.5)
+        version: 7.2.2(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3)
       '@tanstack/react-query':
         specifier: 4.32.1
         version: 4.32.1(react-dom@18.3.1)(react@18.3.1)
@@ -5637,7 +5637,7 @@ importers:
         version: 2.2.2(esbuild@0.21.2)
       eslint-plugin-storybook:
         specifier: ^0.6.10
-        version: 0.6.10(eslint@8.49.0)(typescript@5.4.5)
+        version: 0.6.10(eslint@8.49.0)(typescript@5.5.3)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
@@ -5703,7 +5703,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       util:
         specifier: ^0.12.4
         version: 0.12.4
@@ -5776,7 +5776,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/utils:
     dependencies:
@@ -5891,7 +5891,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   script:
     dependencies:
@@ -5927,8 +5927,8 @@ importers:
         specifier: 3.0.3
         version: 3.0.3
       typescript:
-        specifier: 5.4.5
-        version: 5.4.5
+        specifier: 5.5.3
+        version: 5.5.3
 
 packages:
 
@@ -8650,7 +8650,7 @@ packages:
       '@types/yargs': 17.0.24
       chalk: 4.1.2
 
-  /@joshwooding/vite-plugin-react-docgen-typescript@0.2.1(typescript@5.4.5)(vite@4.5.0):
+  /@joshwooding/vite-plugin-react-docgen-typescript@0.2.1(typescript@5.5.3)(vite@4.5.0):
     resolution: {integrity: sha512-ou4ZJSXMMWHqGS4g8uNRbC5TiTWxAgQZiVucoUrOCWuPrTbkpJbmVyIi9jU72SBry7gQtuMEDp4YR8EEXAg7VQ==}
     peerDependencies:
       typescript: '>= 4.3.x'
@@ -8662,8 +8662,8 @@ packages:
       glob: 7.2.3
       glob-promise: 4.2.2(glob@7.2.3)
       magic-string: 0.27.0
-      react-docgen-typescript: 2.2.2(typescript@5.4.5)
-      typescript: 5.4.5
+      react-docgen-typescript: 2.2.2(typescript@5.5.3)
+      typescript: 5.5.3
       vite: 4.5.0(@types/node@16.18.23)
     dev: true
 
@@ -9723,7 +9723,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/builder-vite@7.2.2(typescript@5.4.5)(vite@4.5.0):
+  /@storybook/builder-vite@7.2.2(typescript@5.5.3)(vite@4.5.0):
     resolution: {integrity: sha512-3YDxZPJsHOsRQob/85X2Xf6pYfwbQilJBsEcuwmEV0JEO4p3JijOlO8xV58uCjkZSpuJ0ARl6t5oCMBo89DKCQ==}
     peerDependencies:
       '@preact/preset-vite': '*'
@@ -9757,7 +9757,7 @@ packages:
       remark-external-links: 8.0.0
       remark-slug: 6.1.0
       rollup: 3.27.2
-      typescript: 5.4.5
+      typescript: 5.5.3
       vite: 4.5.0(@types/node@16.18.23)
     transitivePeerDependencies:
       - encoding
@@ -10151,7 +10151,7 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
     dev: true
 
-  /@storybook/react-vite@7.2.2(react-dom@18.3.1)(react@18.3.1)(typescript@5.4.5)(vite@4.5.0):
+  /@storybook/react-vite@7.2.2(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3)(vite@4.5.0):
     resolution: {integrity: sha512-j77ckWdQaVVHLXFUkDCkZRqFcYkwi3usBdg60goe+NRAdX56WKPScwL2VMKpj3hR38E9jZwNgjjB2EGp0tam8w==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -10159,10 +10159,10 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
       vite: ^3.0.0 || ^4.0.0
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.2.1(typescript@5.4.5)(vite@4.5.0)
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.2.1(typescript@5.5.3)(vite@4.5.0)
       '@rollup/pluginutils': 5.0.3
-      '@storybook/builder-vite': 7.2.2(typescript@5.4.5)(vite@4.5.0)
-      '@storybook/react': 7.2.2(react-dom@18.3.1)(react@18.3.1)(typescript@5.4.5)
+      '@storybook/builder-vite': 7.2.2(typescript@5.5.3)(vite@4.5.0)
+      '@storybook/react': 7.2.2(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3)
       '@vitejs/plugin-react': 3.0.1(vite@4.5.0)
       ast-types: 0.14.2
       magic-string: 0.30.2
@@ -10179,7 +10179,7 @@ packages:
       - vite-plugin-glimmerx
     dev: true
 
-  /@storybook/react@7.2.2(react-dom@18.3.1)(react@18.3.1)(typescript@5.4.5):
+  /@storybook/react@7.2.2(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3):
     resolution: {integrity: sha512-41vOR9mCPGeO4YBVfej+X+Fge+igelqSFCJF/koZDdYxOVehsz3bK++TNrKo2utF69evhwSmIU1iEMEjesmbNg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -10212,7 +10212,7 @@ packages:
       react-element-to-jsx-string: 15.0.0(react-dom@18.3.1)(react@18.3.1)
       ts-dedent: 2.2.0
       type-fest: 2.19.0
-      typescript: 5.4.5
+      typescript: 5.5.3
       util-deprecate: 1.0.2
     transitivePeerDependencies:
       - encoding
@@ -11040,7 +11040,7 @@ packages:
     dependencies:
       '@types/yargs-parser': 21.0.0
 
-  /@typescript-eslint/eslint-plugin@6.7.0(@typescript-eslint/parser@6.7.0)(eslint@8.49.0)(typescript@5.4.5):
+  /@typescript-eslint/eslint-plugin@6.7.0(@typescript-eslint/parser@6.7.0)(eslint@8.49.0)(typescript@5.5.3):
     resolution: {integrity: sha512-gUqtknHm0TDs1LhY12K2NA3Rmlmp88jK9Tx8vGZMfHeNMLE3GH2e9TRub+y+SOjuYgtOmok+wt1AyDPZqxbNag==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -11052,10 +11052,10 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.8.1
-      '@typescript-eslint/parser': 6.7.0(eslint@8.49.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 6.7.0(eslint@8.49.0)(typescript@5.5.3)
       '@typescript-eslint/scope-manager': 6.7.0
-      '@typescript-eslint/type-utils': 6.7.0(eslint@8.49.0)(typescript@5.4.5)
-      '@typescript-eslint/utils': 6.7.0(eslint@8.49.0)(typescript@5.4.5)
+      '@typescript-eslint/type-utils': 6.7.0(eslint@8.49.0)(typescript@5.5.3)
+      '@typescript-eslint/utils': 6.7.0(eslint@8.49.0)(typescript@5.5.3)
       '@typescript-eslint/visitor-keys': 6.7.0
       debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.49.0
@@ -11063,12 +11063,12 @@ packages:
       ignore: 5.2.4
       natural-compare: 1.4.0
       semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.4.5)
-      typescript: 5.4.5
+      ts-api-utils: 1.0.3(typescript@5.5.3)
+      typescript: 5.5.3
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/parser@6.7.0(eslint@8.49.0)(typescript@5.4.5):
+  /@typescript-eslint/parser@6.7.0(eslint@8.49.0)(typescript@5.5.3):
     resolution: {integrity: sha512-jZKYwqNpNm5kzPVP5z1JXAuxjtl2uG+5NpaMocFPTNC2EdYIgbXIPImObOkhbONxtFTTdoZstLZefbaK+wXZng==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -11080,15 +11080,15 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 6.7.0
       '@typescript-eslint/types': 6.7.0
-      '@typescript-eslint/typescript-estree': 6.7.0(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 6.7.0(typescript@5.5.3)
       '@typescript-eslint/visitor-keys': 6.7.0
       debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.49.0
-      typescript: 5.4.5
+      typescript: 5.5.3
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/rule-tester@6.7.0(@eslint/eslintrc@2.1.2)(eslint@8.49.0)(typescript@5.4.5):
+  /@typescript-eslint/rule-tester@6.7.0(@eslint/eslintrc@2.1.2)(eslint@8.49.0)(typescript@5.5.3):
     resolution: {integrity: sha512-xOsCbazwq/78/KiJUm2VLVbeoP6XwZtc/gWx8Tz+ajZSv+I9VyX1OnMU0uOj8PY4WHCKUmy8EOyREElAj+2l4w==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -11096,8 +11096,8 @@ packages:
       eslint: '>=8'
     dependencies:
       '@eslint/eslintrc': 2.1.2
-      '@typescript-eslint/typescript-estree': 6.7.0(typescript@5.4.5)
-      '@typescript-eslint/utils': 6.7.0(eslint@8.49.0)(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 6.7.0(typescript@5.5.3)
+      '@typescript-eslint/utils': 6.7.0(eslint@8.49.0)(typescript@5.5.3)
       ajv: 6.12.6
       eslint: 8.49.0
       lodash.merge: 4.6.2
@@ -11121,7 +11121,7 @@ packages:
       '@typescript-eslint/types': 6.7.0
       '@typescript-eslint/visitor-keys': 6.7.0
 
-  /@typescript-eslint/type-utils@6.7.0(eslint@8.49.0)(typescript@5.4.5):
+  /@typescript-eslint/type-utils@6.7.0(eslint@8.49.0)(typescript@5.5.3):
     resolution: {integrity: sha512-f/QabJgDAlpSz3qduCyQT0Fw7hHpmhOzY/Rv6zO3yO+HVIdPfIWhrQoAyG+uZVtWAIS85zAyzgAFfyEr+MgBpg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -11131,12 +11131,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.7.0(typescript@5.4.5)
-      '@typescript-eslint/utils': 6.7.0(eslint@8.49.0)(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 6.7.0(typescript@5.5.3)
+      '@typescript-eslint/utils': 6.7.0(eslint@8.49.0)(typescript@5.5.3)
       debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.49.0
-      ts-api-utils: 1.0.3(typescript@5.4.5)
-      typescript: 5.4.5
+      ts-api-utils: 1.0.3(typescript@5.5.3)
+      typescript: 5.5.3
     transitivePeerDependencies:
       - supports-color
 
@@ -11148,7 +11148,7 @@ packages:
     resolution: {integrity: sha512-ihPfvOp7pOcN/ysoj0RpBPOx3HQTJTrIN8UZK+WFd3/iDeFHHqeyYxa4hQk4rMhsz9H9mXpR61IzwlBVGXtl9Q==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
-  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.4.5):
+  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.5.3):
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -11163,12 +11163,12 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.4.5)
-      typescript: 5.4.5
+      tsutils: 3.21.0(typescript@5.5.3)
+      typescript: 5.5.3
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/typescript-estree@6.7.0(typescript@5.4.5):
+  /@typescript-eslint/typescript-estree@6.7.0(typescript@5.5.3):
     resolution: {integrity: sha512-dPvkXj3n6e9yd/0LfojNU8VMUGHWiLuBZvbM6V6QYD+2qxqInE7J+J/ieY2iGwR9ivf/R/haWGkIj04WVUeiSQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -11183,12 +11183,12 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.4.5)
-      typescript: 5.4.5
+      ts-api-utils: 1.0.3(typescript@5.5.3)
+      typescript: 5.5.3
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/utils@5.62.0(eslint@8.49.0)(typescript@5.4.5):
+  /@typescript-eslint/utils@5.62.0(eslint@8.49.0)(typescript@5.5.3):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -11197,10 +11197,10 @@ packages:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.49.0)
       '@types/json-schema': 7.0.12
       '@types/semver': 7.5.0
-      '@typescript-eslint/parser': 6.7.0(eslint@8.49.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 6.7.0(eslint@8.49.0)(typescript@5.5.3)
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.3)
       eslint: 8.49.0
       eslint-scope: 5.1.1
       semver: 7.5.4
@@ -11208,7 +11208,7 @@ packages:
       - supports-color
       - typescript
 
-  /@typescript-eslint/utils@6.7.0(eslint@8.49.0)(typescript@5.4.5):
+  /@typescript-eslint/utils@6.7.0(eslint@8.49.0)(typescript@5.5.3):
     resolution: {integrity: sha512-MfCq3cM0vh2slSikQYqK2Gq52gvOhe57vD2RM3V4gQRZYX4rDPnKLu5p6cm89+LJiGlwEXU8hkYxhqqEC/V3qA==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -11217,10 +11217,10 @@ packages:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.49.0)
       '@types/json-schema': 7.0.12
       '@types/semver': 7.5.0
-      '@typescript-eslint/parser': 6.7.0(eslint@8.49.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 6.7.0(eslint@8.49.0)(typescript@5.5.3)
       '@typescript-eslint/scope-manager': 6.7.0
       '@typescript-eslint/types': 6.7.0
-      '@typescript-eslint/typescript-estree': 6.7.0(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 6.7.0(typescript@5.5.3)
       eslint: 8.49.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -14143,7 +14143,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.7.0(eslint@8.49.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 6.7.0(eslint@8.49.0)(typescript@5.5.3)
       debug: 3.2.7(supports-color@5.5.0)
       eslint: 8.49.0
       eslint-import-resolver-node: 0.3.9
@@ -14161,7 +14161,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.7.0(eslint@8.49.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 6.7.0(eslint@8.49.0)(typescript@5.5.3)
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
@@ -14191,7 +14191,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.7.0(eslint@8.49.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 6.7.0(eslint@8.49.0)(typescript@5.5.3)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
@@ -14214,7 +14214,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-jest@27.2.3(@typescript-eslint/eslint-plugin@6.7.0)(eslint@8.49.0)(jest@29.6.2)(typescript@5.4.5):
+  /eslint-plugin-jest@27.2.3(@typescript-eslint/eslint-plugin@6.7.0)(eslint@8.49.0)(jest@29.6.2)(typescript@5.5.3):
     resolution: {integrity: sha512-sRLlSCpICzWuje66Gl9zvdF6mwD5X86I4u55hJyFBsxYOsBCmT5+kSUjf+fkFWVMMgpzNEupjW8WzUqi83hJAQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -14227,8 +14227,8 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 6.7.0(@typescript-eslint/parser@6.7.0)(eslint@8.49.0)(typescript@5.4.5)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.49.0)(typescript@5.4.5)
+      '@typescript-eslint/eslint-plugin': 6.7.0(@typescript-eslint/parser@6.7.0)(eslint@8.49.0)(typescript@5.5.3)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.49.0)(typescript@5.5.3)
       eslint: 8.49.0
       jest: 29.6.2(@types/node@16.18.23)
     transitivePeerDependencies:
@@ -14310,14 +14310,14 @@ packages:
       string.prototype.matchall: 4.0.7
     dev: false
 
-  /eslint-plugin-storybook@0.6.10(eslint@8.49.0)(typescript@5.4.5):
+  /eslint-plugin-storybook@0.6.10(eslint@8.49.0)(typescript@5.5.3):
     resolution: {integrity: sha512-3DKXRey06EhwnTKaG6fgMqGTy4C3z6Ikyv6VVixO5BvaExWQe3yGWIAufrC2Et0OaAMIaMwx9KWjqb/Wq+JxPg==}
     engines: {node: 12.x || 14.x || >= 16}
     peerDependencies:
       eslint: '>=6'
     dependencies:
       '@storybook/csf': 0.0.1
-      '@typescript-eslint/utils': 5.62.0(eslint@8.49.0)(typescript@5.4.5)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.49.0)(typescript@5.5.3)
       eslint: 8.49.0
       requireindex: 1.2.0
       ts-dedent: 2.2.0
@@ -14915,7 +14915,7 @@ packages:
       signal-exit: 4.1.0
     dev: true
 
-  /fork-ts-checker-webpack-plugin@6.5.2(eslint@8.49.0)(typescript@5.4.5)(webpack@4.46.0):
+  /fork-ts-checker-webpack-plugin@6.5.2(eslint@8.49.0)(typescript@5.5.3)(webpack@4.46.0):
     resolution: {integrity: sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -14943,11 +14943,11 @@ packages:
       schema-utils: 2.7.0
       semver: 7.3.2
       tapable: 1.1.3
-      typescript: 5.4.5
+      typescript: 5.5.3
       webpack: 4.46.0
     dev: true
 
-  /fork-ts-checker-webpack-plugin@6.5.2(eslint@8.49.0)(typescript@5.4.5)(webpack@5.88.2):
+  /fork-ts-checker-webpack-plugin@6.5.2(eslint@8.49.0)(typescript@5.5.3)(webpack@5.88.2):
     resolution: {integrity: sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -14975,7 +14975,7 @@ packages:
       schema-utils: 2.7.0
       semver: 7.3.2
       tapable: 1.1.3
-      typescript: 5.4.5
+      typescript: 5.5.3
       webpack: 5.88.2(esbuild@0.18.17)
 
   /form-data@2.5.1:
@@ -15878,7 +15878,7 @@ packages:
       rsvp: 4.8.5
       sort-keys: 5.0.0
       through2: 4.0.2
-      typescript: 5.4.5
+      typescript: 5.5.3
       vinyl: 3.0.0
       vinyl-fs: 3.0.3
       vue-template-compiler: 2.7.15
@@ -16776,15 +16776,15 @@ packages:
       slash: 3.0.0
       stack-utils: 2.0.6
 
-  /jest-mock-extended@3.0.4(jest@29.6.2)(typescript@5.4.5):
+  /jest-mock-extended@3.0.4(jest@29.6.2)(typescript@5.5.3):
     resolution: {integrity: sha512-2ynEZ7IEJNrhrgshklDMhrOdnmW4Nt+PhkyRqZxRgpwMo7JjmFWMzyp0+eSyk+H9KK1QjXI5xTZIw6x7cVDcRg==}
     peerDependencies:
       jest: ^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0
       typescript: ^3.0.0 || ^4.0.0 || ^5.0.0
     dependencies:
       jest: 29.6.2(@types/node@16.18.23)
-      ts-essentials: 7.0.3(typescript@5.4.5)
-      typescript: 5.4.5
+      ts-essentials: 7.0.3(typescript@5.5.3)
+      typescript: 5.5.3
     dev: true
 
   /jest-mock@27.5.1:
@@ -18848,12 +18848,12 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /postcss-styled-syntax@0.4.0(postcss@8.4.38)(typescript@5.4.5):
+  /postcss-styled-syntax@0.4.0(postcss@8.4.38)(typescript@5.5.3):
     resolution: {integrity: sha512-LvG++K8LtIyX1Q1mNuZVQYmBo+SCwn90cEkMigo4/I0QwXrEiYt8nPeJ5rrI5Uuh+5w7hRfPyJKlvQdhVZBhUg==}
     peerDependencies:
       postcss: ^8.4.21
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.3)
       estree-walker: 2.0.2
       postcss: 8.4.38
     transitivePeerDependencies:
@@ -19239,7 +19239,7 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
     dev: true
 
-  /react-dev-utils@12.0.1(eslint@8.49.0)(typescript@5.4.5)(webpack@4.46.0):
+  /react-dev-utils@12.0.1(eslint@8.49.0)(typescript@5.5.3)(webpack@4.46.0):
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -19258,7 +19258,7 @@ packages:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.2(eslint@8.49.0)(typescript@5.4.5)(webpack@4.46.0)
+      fork-ts-checker-webpack-plugin: 6.5.2(eslint@8.49.0)(typescript@5.5.3)(webpack@4.46.0)
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -19273,7 +19273,7 @@ packages:
       shell-quote: 1.7.3
       strip-ansi: 6.0.1
       text-table: 0.2.0
-      typescript: 5.4.5
+      typescript: 5.5.3
       webpack: 4.46.0
     transitivePeerDependencies:
       - eslint
@@ -19281,7 +19281,7 @@ packages:
       - vue-template-compiler
     dev: true
 
-  /react-dev-utils@12.0.1(eslint@8.49.0)(typescript@5.4.5)(webpack@5.88.2):
+  /react-dev-utils@12.0.1(eslint@8.49.0)(typescript@5.5.3)(webpack@5.88.2):
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -19300,7 +19300,7 @@ packages:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.2(eslint@8.49.0)(typescript@5.4.5)(webpack@5.88.2)
+      fork-ts-checker-webpack-plugin: 6.5.2(eslint@8.49.0)(typescript@5.5.3)(webpack@5.88.2)
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -19315,19 +19315,19 @@ packages:
       shell-quote: 1.7.3
       strip-ansi: 6.0.1
       text-table: 0.2.0
-      typescript: 5.4.5
+      typescript: 5.5.3
       webpack: 5.88.2(esbuild@0.18.17)
     transitivePeerDependencies:
       - eslint
       - supports-color
       - vue-template-compiler
 
-  /react-docgen-typescript@2.2.2(typescript@5.4.5):
+  /react-docgen-typescript@2.2.2(typescript@5.5.3):
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
       typescript: '>= 4.3.x'
     dependencies:
-      typescript: 5.4.5
+      typescript: 5.5.3
     dev: true
 
   /react-docgen@6.0.0-alpha.3:
@@ -21338,28 +21338,28 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /ts-api-utils@1.0.3(typescript@5.4.5):
+  /ts-api-utils@1.0.3(typescript@5.5.3):
     resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
     engines: {node: '>=16.13.0'}
     peerDependencies:
       typescript: '>=4.2.0'
     dependencies:
-      typescript: 5.4.5
+      typescript: 5.5.3
 
   /ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
     dev: true
 
-  /ts-essentials@7.0.3(typescript@5.4.5):
+  /ts-essentials@7.0.3(typescript@5.5.3):
     resolution: {integrity: sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==}
     peerDependencies:
       typescript: '>=3.7.0'
     dependencies:
-      typescript: 5.4.5
+      typescript: 5.5.3
     dev: true
 
-  /ts-jest@29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.4.5):
+  /ts-jest@29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3):
     resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -21391,10 +21391,10 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.5.4
-      typescript: 5.4.5
+      typescript: 5.5.3
       yargs-parser: 21.1.1
 
-  /ts-jest@29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.4.5):
+  /ts-jest@29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3):
     resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -21426,7 +21426,7 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.5.4
-      typescript: 5.4.5
+      typescript: 5.5.3
       yargs-parser: 21.1.1
     dev: true
 
@@ -21447,14 +21447,14 @@ packages:
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
-  /tsutils@3.21.0(typescript@5.4.5):
+  /tsutils@3.21.0(typescript@5.5.3):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.4.5
+      typescript: 5.5.3
 
   /tty-browserify@0.0.0:
     resolution: {integrity: sha512-JVa5ijo+j/sOoHGjw0sxw734b1LhBkQ3bvUGNdxnVXDCX81Yx7TFgnZygxrIIWn23hbfTaMYLwRmAxFyDuFmIw==}
@@ -21549,8 +21549,8 @@ packages:
   /typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  /typescript@5.4.5:
-    resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
+  /typescript@5.5.3:
+    resolution: {integrity: sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 

--- a/script/package.json
+++ b/script/package.json
@@ -21,7 +21,7 @@
     "esbuild": "0.21.2",
     "esbuild-runner": "2.2.2",
     "prettier": "3.0.3",
-    "typescript": "5.4.5"
+    "typescript": "5.5.3"
   },
   "packageManager": "pnpm@8.3.1"
 }


### PR DESCRIPTION
See the release notes here: https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/

I updated the few places I could easily find where we can benefit from TS v5.5's new ability to automatically infer type narrowing functions (e.g. better `filter` type narrowing). We also may benefit from a tooling perspective in the future if we turn on `isolatedDeclarations`, but this isn't straightforward to do right now.
