### PR TITLE
[MarkScan] Stop redirecting to review screen after session-start jam

### DIFF
--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -488,7 +488,7 @@ export function AppRoot(): JSX.Element | null {
 
     if (isPollWorkerAuth(authStatus)) {
       if (stateMachineState === 'paper_reloaded') {
-        return <PaperReloadedPage />;
+        return <PaperReloadedPage votesSelected={!!votes} />;
       }
 
       return (

--- a/apps/mark-scan/frontend/src/pages/paper_reloaded_page.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/paper_reloaded_page.test.tsx
@@ -1,0 +1,50 @@
+import { mockOf } from '@votingworks/test-utils';
+import { createMemoryHistory } from 'history';
+import { Router } from 'react-router-dom';
+import { createApiMock, ApiMock } from '../../test/helpers/mock_api_client';
+import { render, screen } from '../../test/react_testing_library';
+import { PaperReloadedPage } from './paper_reloaded_page';
+import { RemoveJammedSheetScreen } from './remove_jammed_sheet_screen';
+
+jest.mock('./remove_jammed_sheet_screen');
+
+let apiMock: ApiMock;
+beforeEach(() => {
+  apiMock = createApiMock();
+});
+
+afterEach(() => {
+  apiMock.mockApiClient.assertComplete();
+});
+
+beforeEach(() => {
+  mockOf(RemoveJammedSheetScreen).mockImplementation(() => (
+    <div>mockRemoveJammedSheetScreen</div>
+  ));
+});
+
+test('redirects to /ready-to-review if session already in progress', () => {
+  const mockHistory = createMemoryHistory({ initialEntries: ['/contest/0'] });
+
+  render(
+    <Router history={mockHistory}>
+      <PaperReloadedPage votesSelected />
+    </Router>
+  );
+
+  screen.getByText('Remove Poll Worker Card');
+  expect(mockHistory.location.pathname).toEqual('/ready-to-review');
+});
+
+test("no URL change if voting session hasn't started", () => {
+  const mockHistory = createMemoryHistory({ initialEntries: ['/contest/0'] });
+
+  render(
+    <Router history={mockHistory}>
+      <PaperReloadedPage votesSelected={false} />
+    </Router>
+  );
+
+  screen.getByText('Remove Poll Worker Card');
+  expect(mockHistory.location.pathname).toEqual('/');
+});

--- a/apps/mark-scan/frontend/src/pages/paper_reloaded_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/paper_reloaded_page.tsx
@@ -3,14 +3,20 @@ import { useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
 
-export function PaperReloadedPage(): JSX.Element {
+export interface PaperReloadedPageProps {
+  votesSelected: boolean;
+}
+
+export function PaperReloadedPage(props: PaperReloadedPageProps): JSX.Element {
+  const { votesSelected } = props;
+
   // Messy, but this flow eventually ends up in BallotContext. By setting path now
   // we ensure we render the correct page once poll worker auth is ended. If we don't
   // set the path now, we'll incorrectly render PrintPage (the last ballot screen rendered).
-  const history = useHistory();
+  const goToUrl = useHistory().push;
   useEffect(() => {
-    history.push('/ready-to-review');
-  });
+    goToUrl(votesSelected ? '/ready-to-review' : '/');
+  }, [goToUrl, votesSelected]);
 
   return (
     <CenteredCardPageLayout


### PR DESCRIPTION
## Overview

Fixing an issue noticed in user testing and internal testing at VxAustin where a paper jam while loading a new sheet at the start of the voting session causes the voter to get dropped into the review screen first, with no votes selected.

This updates the post-paper-jam URL redirect logic to only go to the review page if the jam occured after the voter had made contest selections.

## Demo Video or Screenshot

### Before:

https://github.com/votingworks/vxsuite/assets/264902/11c678eb-e81a-4af4-956c-d4fc04820580

### After:

https://github.com/votingworks/vxsuite/assets/264902/d97ed0a0-8e08-4c83-91e5-aa34cd73df8a

## Testing Plan
- Reproduced locally with mock paper handler and verified this change fixes the issue.
- Added new unit tests for the relevant screen

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
