### PR TITLE
[MarkScan] Add server/client API for pre-printed ballot insertion

### DIFF
--- a/apps/mark-scan/backend/src/app.preprinted_ballot_insertion.test.ts
+++ b/apps/mark-scan/backend/src/app.preprinted_ballot_insertion.test.ts
@@ -1,0 +1,49 @@
+import tmp from 'tmp';
+
+import { buildMockInsertedSmartCardAuth } from '@votingworks/auth';
+import { createMockUsbDrive } from '@votingworks/usb-drive';
+import { typedAs } from '@votingworks/basics';
+
+import { Store } from './store';
+import { createWorkspace } from './util/workspace';
+import { buildApi } from './app';
+import { buildMockLogger } from '../test/app_helpers';
+import { PaperHandlerStateMachine } from './custom-paper-handler';
+
+function getMockStateMachine() {
+  return typedAs<Partial<PaperHandlerStateMachine>>({
+    startSessionWithPreprintedBallot: jest.fn(),
+    returnPreprintedBallot: jest.fn(),
+  }) as unknown as jest.Mocked<PaperHandlerStateMachine>;
+}
+
+function buildTestApi() {
+  const store = Store.memoryStore();
+  const workspace = createWorkspace(tmp.dirSync().name, { store });
+  const mockAuth = buildMockInsertedSmartCardAuth();
+  const mockStateMachine = getMockStateMachine();
+
+  const api = buildApi(
+    mockAuth,
+    createMockUsbDrive().usbDrive,
+    buildMockLogger(mockAuth, workspace),
+    workspace,
+    mockStateMachine
+  );
+
+  return { api, mockStateMachine };
+}
+
+test('startSessionWithPreprintedBallot', () => {
+  const { api, mockStateMachine } = buildTestApi();
+
+  api.startSessionWithPreprintedBallot();
+  expect(mockStateMachine.startSessionWithPreprintedBallot).toHaveBeenCalled();
+});
+
+test('returnPreprintedBallot', () => {
+  const { api, mockStateMachine } = buildTestApi();
+
+  api.returnPreprintedBallot();
+  expect(mockStateMachine.returnPreprintedBallot).toHaveBeenCalled();
+});

--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -266,6 +266,14 @@ export function buildApi(
       stateMachine.invalidateBallot();
     },
 
+    startSessionWithPreprintedBallot(): void {
+      assertDefined(stateMachine).startSessionWithPreprintedBallot();
+    },
+
+    returnPreprintedBallot(): void {
+      assertDefined(stateMachine).returnPreprintedBallot();
+    },
+
     async confirmInvalidateBallot(): Promise<void> {
       assert(stateMachine);
 

--- a/apps/mark-scan/frontend/src/api.ts
+++ b/apps/mark-scan/frontend/src/api.ts
@@ -522,6 +522,17 @@ export const startPaperHandlerDiagnostic = {
 
 export const systemCallApi = createSystemCallApi(useApiClient);
 
+// istanbul ignore next - will be tested via consumers later
+export const startSessionWithPreprintedBallot = {
+  useMutation: () =>
+    useMutation(useApiClient().startSessionWithPreprintedBallot),
+} as const;
+
+// istanbul ignore next - will be tested via consumers later
+export const returnPreprintedBallot = {
+  useMutation: () => useMutation(useApiClient().returnPreprintedBallot),
+} as const;
+
 // istanbul ignore next
 export const getMockPaperHandlerStatus = {
   queryKey: ['getMockPaperHandlerStatus'] as QueryKey,


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/4812

Adding API methods related to the pre-printed ballot insertion flow (poll-worker-facing). These are used when a poll worker inserts a valid, pre-printed BMD ballot while setting up a new voter session:
- `startSessionWithPreprintedBallot`: moves the state machine into a `presenting_paper` state, corresponding to the ballot review and validation step in the voter flow, after which the voter can confirm and cast the ballot.
- `returnPreprintedBallot`: ejects the sheet to the front and moves the state machine back into an `accepting_paper` state, after which the poll worker can insert another sheet.

## Demo Video or Screenshot

Related to this section of the UX flow:

![Screenshot 2024-07-10 at 16 29 39](https://github.com/votingworks/vxsuite/assets/264902/9c41bd54-71e5-4bc7-ab2e-b41bcfaa3d1c)

## Testing Plan
- Glue tests for server API -> state machine calls
- Manual testing locally

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
