### PR TITLE
[MarkScan] UI Screens for Invalid New Sheet Insertion

### DIFF
--- a/apps/mark-scan/frontend/src/pages/inserted_invalid_new_sheet_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/inserted_invalid_new_sheet_screen.test.tsx
@@ -1,0 +1,79 @@
+import {
+  BallotMetadata,
+  PageInterpretation,
+  PageInterpretationType,
+} from '@votingworks/types';
+import { mockOf, suppressingConsoleOutput } from '@votingworks/test-utils';
+import { TestErrorBoundary } from '@votingworks/ui';
+import { UseQueryResult } from '@tanstack/react-query';
+import { render, screen } from '../../test/react_testing_library';
+import { InsertedInvalidNewSheetScreen } from './inserted_invalid_new_sheet_screen';
+import * as api from '../api';
+
+jest.mock('../api');
+
+function setMockInterpretationQuery(params: {
+  isSuccess: boolean;
+  metadata?: Partial<BallotMetadata>;
+  type?: PageInterpretationType;
+}) {
+  const { isSuccess, metadata, type } = params;
+
+  mockOf(api.getInterpretation.useQuery).mockReturnValue({
+    data: {
+      metadata: metadata as unknown as BallotMetadata,
+      type,
+    } as unknown as PageInterpretation,
+    isSuccess,
+  } as unknown as UseQueryResult<PageInterpretation>);
+}
+
+function setMockInterpretation(type: PageInterpretationType) {
+  setMockInterpretationQuery({
+    isSuccess: true,
+    metadata: { isTestMode: true },
+    type,
+  });
+}
+
+const expectedScreenContents: Readonly<
+  Record<PageInterpretationType, string | RegExp>
+> = {
+  BlankPage: 'Test Error Boundary',
+  InterpretedBmdPage: 'Test Error Boundary',
+  InterpretedHmpbPage: /unable to read ballot/i,
+  InvalidElectionHashPage: /wrong election/i,
+  InvalidPrecinctPage: /wrong precinct/i,
+  InvalidTestModePage: /wrong ballot mode/i,
+  UnreadablePage: /unable to read ballot/i,
+};
+
+for (const [interpretationType, expectedString] of Object.entries(
+  expectedScreenContents
+) as Array<[PageInterpretationType, string]>) {
+  test(`'${interpretationType}' interpretation type`, () => {
+    suppressingConsoleOutput(() => {
+      setMockInterpretation(interpretationType);
+
+      render(
+        <TestErrorBoundary>
+          <InsertedInvalidNewSheetScreen />
+        </TestErrorBoundary>
+      );
+
+      screen.getByText(expectedString);
+    });
+  });
+}
+
+test('no contents while query is pending', () => {
+  setMockInterpretationQuery({ isSuccess: false });
+
+  const { container } = render(
+    <TestErrorBoundary>
+      <InsertedInvalidNewSheetScreen />
+    </TestErrorBoundary>
+  );
+
+  expect(container).toHaveTextContent('');
+});

--- a/apps/mark-scan/frontend/src/pages/inserted_invalid_new_sheet_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/inserted_invalid_new_sheet_screen.tsx
@@ -1,0 +1,40 @@
+import { assertDefined } from '@votingworks/basics';
+import { PageInterpretationType } from '@votingworks/types';
+
+import * as api from '../api';
+import { InsertedWrongElectionBallotScreen } from './inserted_wrong_election_ballot_screen';
+import { InsertedWrongPrecinctBallotScreen } from './inserted_wrong_precinct_ballot_screen';
+import { InsertedWrongTestModeBallotScreen } from './inserted_wrong_test_mode_ballot_screen';
+import { InsertedUnreadableBallotScreen } from './inserted_unreadable_ballot_screen';
+
+const SCREENS: Readonly<
+  Record<PageInterpretationType, JSX.Element | undefined>
+> = {
+  InterpretedBmdPage: undefined, // This page should be unreachable for this result.
+  BlankPage: undefined, // This page should be unreachable for this result.
+
+  // Not currently reachable in practice - HMPBs are interpreted as `BlankPage`s
+  // in VxMarkScan:
+  InterpretedHmpbPage: <InsertedUnreadableBallotScreen />,
+
+  InvalidElectionHashPage: <InsertedWrongElectionBallotScreen />,
+  InvalidTestModePage: <InsertedWrongTestModeBallotScreen />,
+  InvalidPrecinctPage: <InsertedWrongPrecinctBallotScreen />,
+  UnreadablePage: <InsertedUnreadableBallotScreen />,
+};
+
+export function InsertedInvalidNewSheetScreen(): React.ReactNode {
+  const interpretationQuery = api.getInterpretation.useQuery();
+
+  if (!interpretationQuery.isSuccess) {
+    return null;
+  }
+
+  const interpretationType = assertDefined(interpretationQuery.data).type;
+  const screen = assertDefined(
+    SCREENS[interpretationType],
+    `unexpected interpretation type: ${interpretationType}`
+  );
+
+  return screen;
+}

--- a/apps/mark-scan/frontend/src/pages/inserted_unreadable_ballot_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/inserted_unreadable_ballot_screen.tsx
@@ -1,0 +1,25 @@
+import { Caption, Icons, P } from '@votingworks/ui';
+
+import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+
+export function InsertedUnreadableBallotScreen(): JSX.Element {
+  return (
+    <CenteredCardPageLayout
+      icon={<Icons.Warning color="warning" />}
+      title="Unable to Read Ballot"
+      voterFacing={false}
+    >
+      <P>
+        There was a problem while reading the ballot information on the inserted
+        sheet.
+      </P>
+      <P>
+        Please remove the sheet and insert a valid BMD ballot for the configured
+        election.
+      </P>
+      <Caption>
+        <Icons.Info /> Insert a blank sheet to start a new voting session.
+      </Caption>
+    </CenteredCardPageLayout>
+  );
+}

--- a/apps/mark-scan/frontend/src/pages/inserted_wrong_election_ballot_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/inserted_wrong_election_ballot_screen.tsx
@@ -1,0 +1,21 @@
+import { Caption, Icons, P } from '@votingworks/ui';
+
+import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+
+export function InsertedWrongElectionBallotScreen(): JSX.Element {
+  return (
+    <CenteredCardPageLayout
+      icon={<Icons.Warning color="warning" />}
+      title="Wrong Election"
+      voterFacing={false}
+    >
+      <P>
+        The inserted sheet contains a ballot from a different election. Please
+        remove the sheet and insert a ballot for the current election.
+      </P>
+      <Caption>
+        <Icons.Info /> Insert a blank sheet to start a new voting session.
+      </Caption>
+    </CenteredCardPageLayout>
+  );
+}

--- a/apps/mark-scan/frontend/src/pages/inserted_wrong_precinct_ballot_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/inserted_wrong_precinct_ballot_screen.tsx
@@ -1,0 +1,22 @@
+import { Caption, Icons, P } from '@votingworks/ui';
+
+import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+
+export function InsertedWrongPrecinctBallotScreen(): JSX.Element {
+  return (
+    <CenteredCardPageLayout
+      icon={<Icons.Warning color="warning" />}
+      title="Wrong Precinct"
+      voterFacing={false}
+    >
+      <P>The inserted sheet contains a ballot for a different precinct.</P>
+      <P>
+        Please remove the sheet and insert a ballot for the currently configured
+        precinct.
+      </P>
+      <Caption>
+        <Icons.Info /> Insert a blank sheet to start a new voting session.
+      </Caption>
+    </CenteredCardPageLayout>
+  );
+}

--- a/apps/mark-scan/frontend/src/pages/inserted_wrong_test_mode_ballot_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/inserted_wrong_test_mode_ballot_screen.test.tsx
@@ -1,0 +1,90 @@
+import { BallotMetadata, PageInterpretation } from '@votingworks/types';
+import { mockOf, suppressingConsoleOutput } from '@votingworks/test-utils';
+import { TestErrorBoundary } from '@votingworks/ui';
+import { UseQueryResult } from '@tanstack/react-query';
+import { render } from '../../test/react_testing_library';
+import * as api from '../api';
+import { InsertedWrongTestModeBallotScreen } from './inserted_wrong_test_mode_ballot_screen';
+
+jest.mock('../api');
+
+function setMockInterpretationQuery(params: {
+  data?: Partial<PageInterpretation>;
+  isSuccess: boolean;
+}) {
+  const { data, isSuccess } = params;
+
+  mockOf(api.getInterpretation.useQuery).mockReturnValue({
+    data: data as unknown as PageInterpretation,
+    isSuccess,
+  } as unknown as UseQueryResult<PageInterpretation>);
+}
+
+function setMockInterpretation(options: { isTestMode: boolean }) {
+  const metadata: Partial<BallotMetadata> = { isTestMode: options.isTestMode };
+
+  setMockInterpretationQuery({
+    data: {
+      metadata: metadata as unknown as BallotMetadata,
+      type: 'InvalidTestModePage',
+    },
+    isSuccess: true,
+  });
+}
+
+function setUnsupportedMockInterpretation() {
+  setMockInterpretationQuery({
+    data: { type: 'InvalidElectionHashPage' },
+    isSuccess: true,
+  });
+}
+
+test('test ballot in live mode', () => {
+  setMockInterpretation({ isTestMode: true });
+
+  const { container } = render(
+    <TestErrorBoundary>
+      <InsertedWrongTestModeBallotScreen />
+    </TestErrorBoundary>
+  );
+
+  expect(container).toHaveTextContent(/sheet contains a test ballot/i);
+});
+
+test('live ballot in test mode', () => {
+  setMockInterpretation({ isTestMode: false });
+
+  const { container } = render(
+    <TestErrorBoundary>
+      <InsertedWrongTestModeBallotScreen />
+    </TestErrorBoundary>
+  );
+
+  expect(container).toHaveTextContent(/sheet contains an official ballot/i);
+});
+
+test('no contents while query is pending', () => {
+  setMockInterpretationQuery({ isSuccess: false });
+
+  const { container } = render(
+    <TestErrorBoundary>
+      <InsertedWrongTestModeBallotScreen />
+    </TestErrorBoundary>
+  );
+
+  expect(container).toHaveTextContent('');
+});
+
+test('throws if rendered for the wrong interpretation type', () => {
+  suppressingConsoleOutput(() => {
+    setUnsupportedMockInterpretation();
+
+    const { container } = render(
+      <TestErrorBoundary>
+        <InsertedWrongTestModeBallotScreen />
+      </TestErrorBoundary>
+    );
+
+    expect(container).toHaveTextContent('Test Error Boundary');
+  });
+});

--- a/apps/mark-scan/frontend/src/pages/inserted_wrong_test_mode_ballot_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/inserted_wrong_test_mode_ballot_screen.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import { Caption, Font, Icons, P } from '@votingworks/ui';
+import { assert, assertDefined } from '@votingworks/basics';
+
+import * as api from '../api';
+import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+
+export function InsertedWrongTestModeBallotScreen(): React.ReactNode {
+  const interpretationQuery = api.getInterpretation.useQuery();
+
+  if (!interpretationQuery.isSuccess) {
+    return null;
+  }
+
+  const interpretation = assertDefined(interpretationQuery.data);
+  assert(interpretation.type === 'InvalidTestModePage');
+
+  return (
+    <CenteredCardPageLayout
+      icon={<Icons.Warning color="warning" />}
+      title="Wrong Ballot Mode"
+      voterFacing={false}
+    >
+      {interpretation.metadata.isTestMode ? (
+        <React.Fragment>
+          <P>
+            The inserted sheet contains a <Font weight="bold">test</Font>{' '}
+            ballot.
+          </P>
+          <P>
+            Please remove the sheet and insert an{' '}
+            <Font weight="bold">official</Font> ballot.
+          </P>
+        </React.Fragment>
+      ) : (
+        <React.Fragment>
+          <P>
+            The inserted sheet contains an <Font weight="bold">official</Font>{' '}
+            ballot.
+          </P>
+          <P>
+            Please remove the sheet and insert a <Font weight="bold">test</Font>{' '}
+            ballot.
+          </P>
+        </React.Fragment>
+      )}
+      <Caption>
+        <Icons.Info /> Insert a blank sheet to start a new voting session.
+      </Caption>
+    </CenteredCardPageLayout>
+  );
+}


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/4812

Adding error screens for the upcoming changes to scan new sheets at the start of the session.
These are shown if a newly inserted sheet contains a valid BMD ballot for a different election/precinct/ballot mode, or contains a BMD ballot with an unreadable QR code.

## Demo Video or Screenshot

![Screenshot 2024-07-10 at 17 11 35](https://github.com/votingworks/vxsuite/assets/264902/48b3424b-0e04-487b-a658-745a43600226)

## Testing Plan
- Tests cases for UI branching logic 
- Manual verification locally

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
