### PR TITLE
Polish on WIA Screen

### DIFF
--- a/apps/admin/frontend/src/screens/write_ins_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/write_ins_adjudication_screen.test.tsx
@@ -600,7 +600,7 @@ describe('making adjudications', () => {
     apiMock.expectGetWriteInCandidates([mockWriteInCandidate], contestId);
     expectGetQueueMetadata({ total: 2, pending: 1, contestId });
 
-    userEvent.click(screen.getButton('Mark write-in invalid'));
+    userEvent.click(screen.getButton('Mark write-in as undervote'));
     await waitFor(async () =>
       expect(await screen.findButton('Next')).toHaveFocus()
     );
@@ -622,7 +622,7 @@ describe('making adjudications', () => {
     apiMock.expectGetWriteInCandidates([mockWriteInCandidate], contestId);
     expectGetQueueMetadata({ total: 2, pending: 2, contestId });
 
-    userEvent.click(screen.getButton('Mark write-in invalid'));
+    userEvent.click(screen.getButton('Mark write-in as undervote'));
   });
 });
 

--- a/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
@@ -100,16 +100,22 @@ const WriteInText = styled.span`
   color: ${(p) => p.theme.colors.primary};
 `;
 
-const AdjudicationNav = styled.div`
-  align-items: center;
-  background: ${(p) => p.theme.colors.containerLow};
-  border-top: ${(p) => p.theme.sizes.bordersRem.hairline}rem solid
-    ${(p) => p.theme.colors.outline};
+const AdjudicationStickyFooter = styled.div`
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   gap: 0.5rem;
   margin-top: auto;
   padding: 0.5rem;
+  background: ${(p) => p.theme.colors.containerLow};
+  border-top: ${(p) => p.theme.sizes.bordersRem.hairline}rem solid
+    ${(p) => p.theme.colors.outline};
+`;
+
+const AdjudicationNav = styled.div`
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+  flex-direction: row;
 
   button {
     flex: 1;
@@ -649,78 +655,79 @@ export function WriteInsAdjudicationScreen(): JSX.Element {
                     Add
                   </Button>
                 </div>
-              ) : (
-                <WriteInActionButton
-                  icon="Add"
-                  onPress={() => {
-                    if (isBmdWriteIn) {
-                      setNewWriteInCandidateName(
-                        writeInImageView.machineMarkedText
-                      );
-                    }
-                    setShowNewWriteInCandidateForm(true);
-                  }}
-                >
-                  Add new write-in candidate
-                </WriteInActionButton>
-              )}
-            </div>
-            <div style={{ marginTop: '1rem' }}>
-              <WriteInActionButton
-                onPress={() => {
-                  if (!isWriteInAdjudicationContextFresh) return;
-
-                  if (!currentWriteInMarkedInvalid) {
-                    adjudicateAsInvalid();
-                  } else {
-                    resetAdjudication();
-                  }
-                }}
-                variant={currentWriteInMarkedInvalid ? 'secondary' : 'neutral'}
-                icon="Disabled"
-              >
-                Mark write-in invalid
-              </WriteInActionButton>
+              ) : null}
             </div>
           </AdjudicationForm>
-          <AdjudicationNav>
-            <Button
-              disabled={offset === 0}
-              onPress={goPrevious}
-              icon="Previous"
+          <AdjudicationStickyFooter>
+            <WriteInActionButton
+              icon="Add"
+              onPress={() => {
+                if (isBmdWriteIn) {
+                  setNewWriteInCandidateName(
+                    writeInImageView.machineMarkedText
+                  );
+                }
+                setShowNewWriteInCandidateForm(true);
+              }}
             >
-              Previous
-            </Button>
-            <Caption weight="semiBold" style={{ whiteSpace: 'nowrap' }}>
-              {format.count(offset + 1)} of {format.count(totalWriteIns)}
-            </Caption>
-            {isLastAdjudication ? (
-              <LinkButton
-                variant={
-                  currentWriteIn?.status === 'adjudicated'
-                    ? 'primary'
-                    : 'neutral'
+              Add new write-in candidate
+            </WriteInActionButton>
+
+            <WriteInActionButton
+              onPress={() => {
+                if (!isWriteInAdjudicationContextFresh) return;
+
+                if (!currentWriteInMarkedInvalid) {
+                  adjudicateAsInvalid();
+                } else {
+                  resetAdjudication();
                 }
-                to={routerPaths.writeIns}
-                icon="Done"
-              >
-                Finish
-              </LinkButton>
-            ) : (
+              }}
+              variant={currentWriteInMarkedInvalid ? 'secondary' : 'neutral'}
+              icon="Disabled"
+            >
+              Mark write-in as undervote
+            </WriteInActionButton>
+
+            <AdjudicationNav>
               <Button
-                ref={nextButton}
-                variant={
-                  currentWriteIn?.status === 'adjudicated'
-                    ? 'primary'
-                    : 'neutral'
-                }
-                rightIcon="Next"
-                onPress={goNext}
+                disabled={offset === 0}
+                onPress={goPrevious}
+                icon="Previous"
               >
-                Next
+                Previous
               </Button>
-            )}
-          </AdjudicationNav>
+              <Caption weight="semiBold" style={{ whiteSpace: 'nowrap' }}>
+                {format.count(offset + 1)} of {format.count(totalWriteIns)}
+              </Caption>
+              {isLastAdjudication ? (
+                <LinkButton
+                  variant={
+                    currentWriteIn?.status === 'adjudicated'
+                      ? 'primary'
+                      : 'neutral'
+                  }
+                  to={routerPaths.writeIns}
+                  icon="Done"
+                >
+                  Finish
+                </LinkButton>
+              ) : (
+                <Button
+                  ref={nextButton}
+                  variant={
+                    currentWriteIn?.status === 'adjudicated'
+                      ? 'primary'
+                      : 'neutral'
+                  }
+                  rightIcon="Next"
+                  onPress={goNext}
+                >
+                  Next
+                </Button>
+              )}
+            </AdjudicationNav>
+          </AdjudicationStickyFooter>
         </AdjudicationControls>
         {doubleVoteAlert && (
           <DoubleVoteAlertModal

--- a/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
@@ -572,7 +572,9 @@ export function WriteInsAdjudicationScreen(): JSX.Element {
             )}
           </ContestTitleContainer>
           <AdjudicationForm>
-            <SectionLabel>Official Candidates</SectionLabel>
+            {officialCandidates.length > 0 ? (
+              <SectionLabel>Official Candidates</SectionLabel>
+            ) : null}
             <CandidateButtonList>
               {officialCandidates.map((candidate) => {
                 return (

--- a/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
@@ -593,7 +593,9 @@ export function WriteInsAdjudicationScreen(): JSX.Element {
                 );
               })}
             </CandidateButtonList>
-            <SectionLabel>Write-In Candidates</SectionLabel>
+            {showNewWriteInCandidateForm || writeInCandidates.length > 0 ? (
+              <SectionLabel>Write-In Candidates</SectionLabel>
+            ) : null}
             {writeInCandidates.length > 0 && (
               <CandidateButtonList>
                 {writeInCandidates.map((candidate) => {


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/4714

Pins the "Mark write in as undervote" (renamed from invalid) and "add new candidate" buttons on the WIA screen when there are enough custom candidates that it is scrolling. Based on feedback from the spring town elections.

<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot

https://github.com/votingworks/vxsuite/assets/14897017/a9440a24-70c2-434d-83db-ba28ad11a1ff



## Testing Plan
Manually used WIA flow when there were enough options to create scroll. 

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
