### PR TITLE
Handle `realtime status transmission` response in `transferInGeneric`

### DIFF
--- a/libs/custom-paper-handler/src/driver/coders.ts
+++ b/libs/custom-paper-handler/src/driver/coders.ts
@@ -10,6 +10,8 @@ import {
 } from '@votingworks/message-coder';
 import { START_OF_PACKET, TOKEN } from './constants';
 
+export const INVALID_ARGUMENT_RESPONSE_CODE = 0x12;
+
 export interface PaperHandlerBitmap {
   data: Uint8Array;
   width: number;
@@ -139,6 +141,11 @@ export const RealTimeExchangeResponseWithoutData = message({
 });
 export type RealTimeExchangeResponseWithoutData = CoderType<
   typeof RealTimeExchangeResponseWithoutData
+>;
+
+export const InvalidArgumentErrorCode = literal(INVALID_ARGUMENT_RESPONSE_CODE);
+export type InvalidArgumentErrorCode = CoderType<
+  typeof InvalidArgumentErrorCode
 >;
 
 export const RealTimeStatusTransmission = message(printerStatusMessage);

--- a/libs/custom-paper-handler/src/driver/driver.ts
+++ b/libs/custom-paper-handler/src/driver/driver.ts
@@ -426,7 +426,7 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
     const { data } = transferInResult;
     assert(data);
 
-    const result = AcknowledgementResponse.decode(Buffer.from(data.buffer));
+    const result = AcknowledgementResponse.decode(bufferFromDataView(data));
     if (result.isErr()) {
       debug(`Error decoding transferInGeneric response: ${result.err()}`);
       return false;

--- a/libs/custom-scanner/src/mocks/web_usb_device.ts
+++ b/libs/custom-scanner/src/mocks/web_usb_device.ts
@@ -241,11 +241,15 @@ export class MockWebUsbDevice implements USBDevice {
     }
 
     const buffer = this.mockTransferInBuffer.get(endpointNumber);
+    const transferInLimit = this.mockNextTransferLimit
+      .get(endpointNumber)
+      ?.shift();
+    const numBytesToRead = transferInLimit ?? length;
     this.mockTransferInBuffer.set(
       endpointNumber,
-      buffer?.subarray(length) ?? Buffer.alloc(0)
+      buffer?.subarray(numBytesToRead) ?? Buffer.alloc(0)
     );
-    const readBuffer = buffer?.subarray(0, length) ?? Buffer.alloc(0);
+    const readBuffer = buffer?.subarray(0, numBytesToRead) ?? Buffer.alloc(0);
     const uint8Array = new Uint8Array(readBuffer);
     readBuffer.copy(uint8Array, 0, 0, readBuffer.byteLength);
     const data = new DataView(uint8Array.buffer, 0, uint8Array.byteLength);


### PR DESCRIPTION
## Overview
Issue https://github.com/votingworks/vxsuite/issues/5040

See explanation of issue in https://github.com/votingworks/vxsuite/pull/4846

We used to handle unexpected data sent from paper handler to host in `transferInAcknowledgement`. That function is called by most, but not all, commands. It has 2 jobs:
1. read data from generic in buffer
2. parse and handles a simple success/fail response code
 
This worked because printing was always followed by a call to `setScanDirection`, which does call `transferInAcknowlegdement`.

Recently we removed the call to `setScanDirection`, so the next call after printing that reads from the generic in buffer is `scan`. This call does not expect an acknowledgement. Rather, it expects a 16-byte header and a subsequent large block of scan data. Therefore `scan` does not call `transferInAcknowledgement`.

Since `transferInAcknowledgement` is no longer called, the generic in buffer is never cleared of unexpected data. This causes scan parsing to fail.

To fix this I moved handling of unexpected data to `transferInGeneric`. That function is the closest to the metal we can get and is eventually called by all driver functions that want to read the generic in buffer.

## Demo Video or Screenshot

N/A

## Testing Plan
* reproduced issue on hardware, installed fix, and verified it fixed the problem
* rewrote tests for `transferInGeneric`


## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
