### PR TITLE
switch to pactl wrapper with sudo

### DIFF
--- a/libs/backend/src/system_call/get_audio_info.ts
+++ b/libs/backend/src/system_call/get_audio_info.ts
@@ -12,7 +12,8 @@ export async function getAudioInfo(logger: Logger): Promise<AudioInfo> {
   let commandOutput: string;
 
   try {
-    ({ stderr: errorOutput, stdout: commandOutput } = await execFile('pactl', [
+    ({ stderr: errorOutput, stdout: commandOutput } = await execFile('sudo', [
+      '/vx/code/app-scripts/pactl.sh',
       'list',
       'sinks',
     ]));


### PR DESCRIPTION
This PR uses a wrapper script for the `pactl` command with sudo permissions. This is necessary because `pulseaudio` runs unique instances per user. The `vx-ui` user is responsible for our production X session and accompanying audio configuration. To determine if headphones are present, the `vx-services` user needs to access the `vx-ui` session, and this approach makes that possible. 
