### PR TITLE
[MarkScan] Implement pre-printed ballot insertion in PollWorkerScreen

### DIFF
--- a/apps/mark-scan/frontend/src/api.ts
+++ b/apps/mark-scan/frontend/src/api.ts
@@ -522,13 +522,11 @@ export const startPaperHandlerDiagnostic = {
 
 export const systemCallApi = createSystemCallApi(useApiClient);
 
-// istanbul ignore next - will be tested via consumers later
 export const startSessionWithPreprintedBallot = {
   useMutation: () =>
     useMutation(useApiClient().startSessionWithPreprintedBallot),
 } as const;
 
-// istanbul ignore next - will be tested via consumers later
 export const returnPreprintedBallot = {
   useMutation: () => useMutation(useApiClient().returnPreprintedBallot),
 } as const;

--- a/apps/mark-scan/frontend/src/app_cardless_voting.test.tsx
+++ b/apps/mark-scan/frontend/src/app_cardless_voting.test.tsx
@@ -78,7 +78,7 @@ test('Cardless Voting Flow', async () => {
   });
   screen.getByText(/(12)/);
 
-  await screen.findByText('Load Blank Ballot Sheet');
+  await screen.findByText('Load Ballot Sheet');
   mockLoadPaper();
 
   // Poll Worker deactivates ballot style
@@ -243,5 +243,5 @@ test('in "All Precincts" mode, poll worker must select a precinct first', async 
   });
   screen.getByText(/(12)/);
 
-  await screen.findByText('Load Blank Ballot Sheet');
+  await screen.findByText('Load Ballot Sheet');
 });

--- a/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
@@ -303,6 +303,7 @@ test('MarkAndPrint end-to-end flow', async () => {
   userEvent.click(screen.getByText('My Ballot is Correct'));
 
   apiMock.setAuthStatusLoggedOut();
+  apiMock.setPaperHandlerState('not_accepting_paper');
 
   // ---------------
 

--- a/apps/mark-scan/frontend/src/app_root.test.tsx
+++ b/apps/mark-scan/frontend/src/app_root.test.tsx
@@ -1,0 +1,67 @@
+import { mockOf } from '@votingworks/test-utils';
+import { electionGeneralDefinition } from '@votingworks/fixtures';
+import { DEFAULT_SYSTEM_SETTINGS } from '@votingworks/types';
+import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
+
+import React from 'react';
+import { AUTH_STATUS_POLLING_INTERVAL_MS } from '@votingworks/ui';
+import { PollWorkerScreen } from './pages/poll_worker_screen';
+import { VoterFlow } from './voter_flow';
+import { AppRoot } from './app_root';
+import { render } from '../test/test_utils';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
+import {
+  mockCardlessVoterLoggedInAuth,
+  mockPollWorkerAuth,
+} from '../test/helpers/mock_auth';
+import { screen } from '../test/react_testing_library';
+
+jest.mock('./voter_flow');
+jest.mock('./pages/poll_worker_screen');
+
+let apiMock: ApiMock;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  apiMock = createApiMock();
+});
+
+test('setVotes action', async () => {
+  const electionDefinition = electionGeneralDefinition;
+  apiMock.expectGetElectionDefinition(electionDefinition);
+  apiMock.setAuthStatus(mockPollWorkerAuth(electionDefinition));
+  apiMock.expectGetMachineConfig();
+  apiMock.expectGetSystemSettings(DEFAULT_SYSTEM_SETTINGS);
+  apiMock.setPaperHandlerState('not_accepting_paper');
+  apiMock.expectGetElectionState({
+    precinctSelection: ALL_PRECINCTS_SELECTION,
+    pollsState: 'polls_open',
+  });
+
+  mockOf(PollWorkerScreen).mockImplementation((props) => {
+    const { setVotes } = props;
+    React.useEffect(() => setVotes({ contest2: ['yes'] }), [setVotes]);
+
+    return <div>MockPollWorkerScreen</div>;
+  });
+
+  render(<AppRoot />, {
+    apiMock,
+    electionDefinition,
+  });
+
+  await screen.findByText('MockPollWorkerScreen', undefined, { timeout: 200 });
+
+  mockOf(VoterFlow).mockImplementation((props) => {
+    const { votes } = props;
+    expect(votes).toEqual({ contest2: ['yes'] });
+
+    return <div>MockVoterFlow</div>;
+  });
+
+  apiMock.setAuthStatus(mockCardlessVoterLoggedInAuth(electionDefinition));
+  apiMock.setPaperHandlerState('waiting_for_ballot_data');
+
+  await jest.advanceTimersByTimeAsync(AUTH_STATUS_POLLING_INTERVAL_MS * 2);
+  await screen.findByText('MockVoterFlow');
+});

--- a/apps/mark-scan/frontend/src/pages/ballot_ready_for_review_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/ballot_ready_for_review_screen.test.tsx
@@ -1,0 +1,19 @@
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '../../test/react_testing_library';
+import { BallotReadyForReviewScreen } from './ballot_ready_for_review_screen';
+
+test('renders instructions', () => {
+  render(<BallotReadyForReviewScreen resetCardlessVoterSession={jest.fn()} />);
+  screen.getByText(/remove the poll worker card/i);
+});
+
+test('allows voter session deactivation', () => {
+  const mockReset = jest.fn();
+
+  render(<BallotReadyForReviewScreen resetCardlessVoterSession={mockReset} />);
+
+  expect(mockReset).not.toHaveBeenCalled();
+
+  userEvent.click(screen.getButton(/deactivate/i));
+  expect(mockReset).toHaveBeenCalled();
+});

--- a/apps/mark-scan/frontend/src/pages/ballot_ready_for_review_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/ballot_ready_for_review_screen.tsx
@@ -1,0 +1,32 @@
+import { Button, Icons, P } from '@votingworks/ui';
+
+import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+
+export interface BallotReadyForReviewScreenProps {
+  resetCardlessVoterSession: () => void;
+}
+
+export function BallotReadyForReviewScreen(
+  props: BallotReadyForReviewScreenProps
+): JSX.Element {
+  const { resetCardlessVoterSession } = props;
+
+  return (
+    <CenteredCardPageLayout
+      buttons={
+        <Button onPress={resetCardlessVoterSession} variant="danger">
+          Deactivate Voting Session
+        </Button>
+      }
+      icon={<Icons.Done color="success" />}
+      title="Remove Poll Worker Card"
+      voterFacing={false}
+    >
+      <P>The ballot is ready for review.</P>
+      <P>
+        Remove the poll worker card to allow the voter to review and cast their
+        ballot.
+      </P>
+    </CenteredCardPageLayout>
+  );
+}

--- a/apps/mark-scan/frontend/src/pages/inserted_preprinted_ballot_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/inserted_preprinted_ballot_screen.test.tsx
@@ -1,0 +1,111 @@
+import {
+  BallotMetadata,
+  InterpretedBmdPage,
+  VotesDict,
+} from '@votingworks/types';
+import { QueryClientProvider } from '@tanstack/react-query';
+import userEvent from '@testing-library/user-event';
+import { deferred, typedAs } from '@votingworks/basics';
+
+import { advancePromises } from '@votingworks/test-utils';
+import { render, screen } from '../../test/react_testing_library';
+import * as api from '../api';
+import { InsertedPreprintedBallotScreen } from './inserted_preprinted_ballot_screen';
+
+const mockApiClient = typedAs<Partial<api.ApiClient>>({
+  getInterpretation: jest.fn(),
+  returnPreprintedBallot: jest.fn(),
+  startSessionWithPreprintedBallot: jest.fn(),
+}) as unknown as jest.Mocked<api.ApiClient>;
+
+const ballotStyleId = '2_en';
+const precinctId = 'abc123';
+const votes: VotesDict = { contest1: ['yes'], contest2: ['no'] };
+const metadata: Partial<BallotMetadata> = { ballotStyleId, precinctId };
+
+const mockInterpretation = typedAs<Partial<InterpretedBmdPage>>({
+  metadata: metadata as unknown as BallotMetadata,
+  type: 'InterpretedBmdPage',
+  votes,
+}) as unknown as InterpretedBmdPage;
+
+function renderScreen() {
+  const mockActivateCardlessVoter = jest.fn();
+  const mockSetVotes = jest.fn();
+
+  return {
+    mockActivateCardlessVoter,
+    mockSetVotes,
+    renderResult: render(
+      <api.ApiClientContext.Provider value={mockApiClient}>
+        <QueryClientProvider client={api.createQueryClient()}>
+          <InsertedPreprintedBallotScreen
+            activateCardlessVoterSession={mockActivateCardlessVoter}
+            setVotes={mockSetVotes}
+          />
+        </QueryClientProvider>
+      </api.ApiClientContext.Provider>
+    ),
+  };
+}
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('with valid interpretation loaded', () => {
+  test('start a new session with interpreted votes', async () => {
+    mockApiClient.getInterpretation.mockResolvedValue(mockInterpretation);
+
+    const { mockActivateCardlessVoter, mockSetVotes } = renderScreen();
+    await advancePromises();
+
+    screen.getByText(/ballot detected/i);
+    expect(mockSetVotes).not.toHaveBeenCalled();
+    expect(mockActivateCardlessVoter).not.toHaveBeenCalled();
+
+    userEvent.click(screen.getButton(/yes/i));
+    await advancePromises();
+
+    expect(mockApiClient.returnPreprintedBallot).not.toHaveBeenCalled();
+    expect(mockApiClient.startSessionWithPreprintedBallot).toHaveBeenCalled();
+    expect(mockSetVotes).toHaveBeenCalledWith(mockInterpretation.votes);
+    expect(mockActivateCardlessVoter).toHaveBeenCalledWith(
+      precinctId,
+      ballotStyleId
+    );
+  });
+
+  test('return ballot', async () => {
+    mockApiClient.getInterpretation.mockResolvedValue(mockInterpretation);
+
+    const { mockActivateCardlessVoter, mockSetVotes } = renderScreen();
+    await advancePromises();
+
+    screen.getByText(/ballot detected/i);
+    expect(mockSetVotes).not.toHaveBeenCalled();
+    expect(mockActivateCardlessVoter).not.toHaveBeenCalled();
+
+    userEvent.click(screen.getButton(/no/i));
+    await advancePromises();
+
+    expect(
+      mockApiClient.startSessionWithPreprintedBallot
+    ).not.toHaveBeenCalled();
+    expect(mockApiClient.returnPreprintedBallot).toHaveBeenCalled();
+    expect(mockSetVotes).not.toHaveBeenCalled();
+    expect(mockActivateCardlessVoter).not.toHaveBeenCalled();
+  });
+});
+
+test('no contents while query is pending', () => {
+  const deferredInterpretation = deferred<InterpretedBmdPage>();
+  mockApiClient.getInterpretation.mockReturnValue(
+    deferredInterpretation.promise
+  );
+
+  const { renderResult } = renderScreen();
+
+  expect(renderResult.container).toHaveTextContent('');
+  deferredInterpretation.resolve(mockInterpretation);
+});

--- a/apps/mark-scan/frontend/src/pages/inserted_preprinted_ballot_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/inserted_preprinted_ballot_screen.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+
+import { Button, Icons, P } from '@votingworks/ui';
+import { BallotStyleId, PrecinctId, VotesDict } from '@votingworks/types';
+import { assert } from '@votingworks/basics';
+
+import * as api from '../api';
+import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+
+export interface InsertedPreprintedBallotScreenProps {
+  activateCardlessVoterSession: (
+    precinctId: PrecinctId,
+    ballotStyleId: BallotStyleId
+  ) => void;
+  setVotes: (votes: VotesDict) => void;
+}
+
+export function InsertedPreprintedBallotScreen(
+  props: InsertedPreprintedBallotScreenProps
+): React.ReactNode {
+  const { activateCardlessVoterSession, setVotes } = props;
+
+  const startSessionWithPreprintedBallot =
+    api.startSessionWithPreprintedBallot.useMutation().mutate;
+
+  const returnPreprintedBallot =
+    api.returnPreprintedBallot.useMutation().mutate;
+
+  const interpretationQuery = api.getInterpretation.useQuery();
+  const interpretation = interpretationQuery.data;
+
+  const onPressReview = React.useCallback(() => {
+    assert(interpretation);
+    assert(interpretation.type === 'InterpretedBmdPage');
+
+    const { ballotStyleId, precinctId } = interpretation.metadata;
+
+    activateCardlessVoterSession(precinctId, ballotStyleId);
+    startSessionWithPreprintedBallot();
+    setVotes(interpretation.votes);
+  }, [
+    activateCardlessVoterSession,
+    startSessionWithPreprintedBallot,
+    interpretation,
+    setVotes,
+  ]);
+
+  if (!interpretationQuery.isSuccess) {
+    return null;
+  }
+
+  return (
+    <CenteredCardPageLayout
+      buttons={
+        <React.Fragment>
+          <Button onPress={returnPreprintedBallot}>
+            No, Return the Ballot
+          </Button>
+          <Button onPress={onPressReview} variant="primary">
+            Yes, Review Ballot
+          </Button>
+        </React.Fragment>
+      }
+      icon={<Icons.Info />}
+      title="Ballot Detected"
+      voterFacing={false}
+    >
+      <P>The inserted sheet already has a ballot printed on it.</P>
+      <P>Would you like to let the voter review and cast this ballot?</P>
+    </CenteredCardPageLayout>
+  );
+}

--- a/apps/mark-scan/frontend/src/pages/loading_new_sheet_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/loading_new_sheet_screen.tsx
@@ -1,14 +1,17 @@
 import { Icons, P } from '@votingworks/ui';
+
 import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
 
-export function LoadPaperPage(): JSX.Element {
+export function LoadingNewSheetScreen(): JSX.Element {
   return (
     <CenteredCardPageLayout
       icon={<Icons.Info />}
-      title="Load Ballot Sheet"
+      title="Loading Sheet"
       voterFacing={false}
     >
-      <P>Please feed one sheet of paper into the front input tray.</P>
+      <P>
+        <Icons.Loading /> Please wait while the sheet is loaded...
+      </P>
     </CenteredCardPageLayout>
   );
 }


### PR DESCRIPTION
## Overview

Related to https://github.com/votingworks/vxsuite/issues/4812

Enabling support (currently behind the `MARK_SCAN_ENABLE_BALLOT_REINSERTION` feature flag) for re-inserting a printed ballot after a voter session has ended or timed out.

- Adding a new  Poll Worker screen section to bypass ballot style selection (pre-printed ballots will still be accepted after ballot style selection, though).
- Hooking up the new state machine states to poll-worker-facing screens.
- Updating load paper prompt

## Demo Video or Screenshot

(Full flow [here](https://www.figma.com/design/hvboQDWXqE1PbpGbWfb9iU/%5BVxMarkScan%5D-Printed-Ballot-Scan%2FRe-Scan-Flows?node-id=2-78&t=l4h4NmR73jzOW8Zz-1)):

### New Poll Worker Option:
<img width="350" src="https://github.com/user-attachments/assets/3868f36c-bc4c-49d9-a14e-8159c1ee83b6" />

### Ballot Insertion Flow:
![Screenshot 2024-07-16 at 13 13 49](https://github.com/user-attachments/assets/99f2bd18-c8d7-41fc-840d-0de82f4e3b5e)

## Testing Plan
- New unit test cases
- Manual testing with mock paper handler (will need to verify fully on real VSAP later)

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
