### PR TITLE
Fix something went wrong printing test page

### DIFF
--- a/apps/scan/frontend/Makefile
+++ b/apps/scan/frontend/Makefile
@@ -8,6 +8,7 @@ build: FORCE
 	pnpm install && \
 		pnpm --dir ../../../libs/ballot-interpreter build && \
 		pnpm --dir ../../../libs/pdi-scanner build && \
+		pnpm --dir ../backend build && \
 		pnpm build
 
 bootstrap: install build


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/5004

Fixes the something went wrong screen when printing a test page in production. There is a custom step in the pnpm build for scan-backend that copies the printed pdf to the build directory. This ensures that the backend is build through that command and the pdf gets copied over, making sure it is there when printing needs to occur. 
<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot
N/A

## Testing Plan
Tested on VxDev 

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
