### PR TITLE
refactor(fai-100-controller): let `clap` handle MarkScan workspace

### DIFF
--- a/apps/mark-scan/fai-100-controller/src/commands.rs
+++ b/apps/mark-scan/fai-100-controller/src/commands.rs
@@ -116,7 +116,7 @@ pub enum SipAndPuffSignalStatus {
     Idle = 0x01,
 }
 
-#[derive(Debug, num_enum::TryFromPrimitive, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, num_enum::TryFromPrimitive, PartialEq, Eq)]
 #[repr(u8)]
 pub enum SipAndPuffDeviceStatus {
     Connected = 0x01,


### PR DESCRIPTION
Rather than accessing the `MARK_SCAN_WORKSPACE` env var when we need it, read it upfront using `clap`. This has the additional effect of allowing it to be passed as a CLI arg instead: `--mark-scan-workspace /path/to/workspace`.

Also, changes `write_pat_connection_status` to improve readability by accepting the status directly rather than passing a boolean.