### PR TITLE
Fix libs/backend system calls in prod

### DIFF
--- a/libs/backend/src/intermediate-scripts/power-down
+++ b/libs/backend/src/intermediate-scripts/power-down
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# -i prevents blocking the power-down on other logged-in users
+systemctl poweroff -i

--- a/libs/backend/src/intermediate-scripts/reboot
+++ b/libs/backend/src/intermediate-scripts/reboot
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# -i prevents blocking the reboot on other logged-in users
+systemctl reboot -i

--- a/libs/backend/src/intermediate-scripts/reboot-to-bios
+++ b/libs/backend/src/intermediate-scripts/reboot-to-bios
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# -i prevents blocking the reboot on other logged-in users
+systemctl reboot --firmware-setup -i

--- a/libs/backend/src/intermediate-scripts/set-clock
+++ b/libs/backend/src/intermediate-scripts/set-clock
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage () {
+    echo 'Usage: set-clock <iana-zone> <datetime-string>'
+    exit 1
+}
+
+if ! [[ "${#}" -eq 2 ]]; then
+    usage
+fi
+
+LOCALTIME_SYMLINK=`readlink /etc/localtime`
+TIMEZONE_DIRECTORY=/usr/share/zoneinfo
+
+# timedatectl sets timezone by symlinking /etc/localtime to a file in /usr/share/zoneinfo, but
+# because /etc is read-only on locked-down images, the setup-machine.sh script sets up a level
+# of indirection:
+#
+# /etc/localtime (read-only symlink) -->
+# /vx/config/localtime (writable symlink) -->
+# /usr/share/zoneinfo/...
+#
+# We account for that indirection, if relevant, here.
+#
+if [[ ! "${LOCALTIME_SYMLINK}" =~ "${TIMEZONE_DIRECTORY}".* ]]; then
+    ln -sf "${TIMEZONE_DIRECTORY}/${1}" "${LOCALTIME_SYMLINK}"
+else
+    timedatectl set-timezone "${1}"
+fi
+
+timedatectl set-time "${2}"

--- a/libs/backend/src/intermediate_scripts.ts
+++ b/libs/backend/src/intermediate_scripts.ts
@@ -1,0 +1,13 @@
+import path from 'node:path';
+
+/**
+ * For shell commands that require sudo privileges, we create intermediate scripts and allow them
+ * to be run without having to provide the sudo password by explicitly adding them to the sudoers
+ * file (defined in vxsuite-complete-system).
+ */
+export function intermediateScript(
+  script: 'power-down' | 'reboot' | 'reboot-to-bios' | 'set-clock'
+): string {
+  // Prefix with ../src since we're actually in ../build at runtime
+  return path.join(__dirname, '../src/intermediate-scripts', script);
+}

--- a/libs/backend/src/system_call/api.test.ts
+++ b/libs/backend/src/system_call/api.test.ts
@@ -1,4 +1,5 @@
 /* istanbul ignore file - test util */
+/* eslint-disable prefer-regex-literals */
 
 import { MockUsbDrive, createMockUsbDrive } from '@votingworks/usb-drive';
 import { mockOf } from '@votingworks/test-utils';
@@ -41,7 +42,11 @@ test('exportLogsToUsb', async () => {
 
 test('reboot', () => {
   api.reboot();
-  expect(execMock).toHaveBeenCalledWith('systemctl', ['reboot', '-i']);
+  expect(execMock).toHaveBeenCalledWith('sudo', [
+    expect.stringMatching(
+      new RegExp('^/.*/libs/backend/src/intermediate-scripts/reboot$')
+    ),
+  ]);
 });
 
 test('rebootToBios', async () => {
@@ -52,10 +57,10 @@ test('rebootToBios', async () => {
       message: 'User trigged a reboot of the machine to BIOS screen…',
     }
   );
-  expect(execMock).toHaveBeenCalledWith('systemctl', [
-    'reboot',
-    '--firmware-setup',
-    '-i',
+  expect(execMock).toHaveBeenCalledWith('sudo', [
+    expect.stringMatching(
+      new RegExp('^/.*/libs/backend/src/intermediate-scripts/reboot-to-bios$')
+    ),
   ]);
 });
 
@@ -64,7 +69,11 @@ test('powerDown', async () => {
   expect(logger.logAsCurrentRole).toHaveBeenCalledWith(LogEventId.PowerDown, {
     message: 'User triggered the machine to power down.',
   });
-  expect(execMock).toHaveBeenCalledWith('systemctl', ['poweroff', '-i']);
+  expect(execMock).toHaveBeenCalledWith('sudo', [
+    expect.stringMatching(
+      new RegExp('^/.*/libs/backend/src/intermediate-scripts/power-down$')
+    ),
+  ]);
 });
 
 test('setClock', async () => {
@@ -74,16 +83,10 @@ test('setClock', async () => {
   });
 
   expect(execMock).toHaveBeenNthCalledWith(1, 'sudo', [
-    '-n',
-    'timedatectl',
-    'set-timezone',
+    expect.stringMatching(
+      new RegExp('^/.*/libs/backend/src/intermediate-scripts/set-clock$')
+    ),
     'America/Chicago',
-  ]);
-
-  expect(execMock).toHaveBeenNthCalledWith(2, 'sudo', [
-    '-n',
-    'timedatectl',
-    'set-time',
     '2020-11-03 09:00:00',
   ]);
 });

--- a/libs/backend/src/system_call/power_down.ts
+++ b/libs/backend/src/system_call/power_down.ts
@@ -1,5 +1,6 @@
 import { LogEventId, Logger } from '@votingworks/logging';
 import { execFile } from '../exec';
+import { intermediateScript } from '../intermediate_scripts';
 
 /**
  * Reboots the machine.
@@ -10,5 +11,5 @@ export async function powerDown(logger: Logger): Promise<void> {
   });
 
   // -i prevents blocking the reboot on other logged in users
-  void execFile('systemctl', ['poweroff', '-i']);
+  void execFile('sudo', [intermediateScript('power-down')]);
 }

--- a/libs/backend/src/system_call/reboot.ts
+++ b/libs/backend/src/system_call/reboot.ts
@@ -1,9 +1,9 @@
 import { execFile } from '../exec';
+import { intermediateScript } from '../intermediate_scripts';
 
 /**
  * Reboots the machine.
  */
 export function reboot(): void {
-  // -i prevents blocking the reboot on other logged in users
-  void execFile('systemctl', ['reboot', '-i']);
+  void execFile('sudo', [intermediateScript('reboot')]);
 }

--- a/libs/backend/src/system_call/reboot_to_bios.ts
+++ b/libs/backend/src/system_call/reboot_to_bios.ts
@@ -1,5 +1,6 @@
 import { LogEventId, Logger } from '@votingworks/logging';
 import { execFile } from '../exec';
+import { intermediateScript } from '../intermediate_scripts';
 
 /**
  * Reboots the machine into the BIOS.
@@ -9,6 +10,5 @@ export async function rebootToBios(logger: Logger): Promise<void> {
     message: 'User trigged a reboot of the machine to BIOS screen…',
   });
 
-  // -i prevents blocking the reboot on other logged in users
-  void execFile('systemctl', ['reboot', '--firmware-setup', '-i']);
+  void execFile('sudo', [intermediateScript('reboot-to-bios')]);
 }

--- a/libs/backend/src/system_call/set_clock.test.ts
+++ b/libs/backend/src/system_call/set_clock.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable prefer-regex-literals */
+
 import { mockOf } from '@votingworks/test-utils';
 import { setClock } from './set_clock';
 import { execFile } from '../exec';
@@ -16,16 +18,10 @@ test('setClock works in daylights savings', async () => {
   });
 
   expect(execMock).toHaveBeenNthCalledWith(1, 'sudo', [
-    '-n',
-    'timedatectl',
-    'set-timezone',
+    expect.stringMatching(
+      new RegExp('^/.*/libs/backend/src/intermediate-scripts/set-clock$')
+    ),
     'America/Chicago',
-  ]);
-
-  expect(execMock).toHaveBeenNthCalledWith(2, 'sudo', [
-    '-n',
-    'timedatectl',
-    'set-time',
     '2020-10-03 10:00:00',
   ]);
 });
@@ -37,16 +33,10 @@ test('setClock works in non-daylights savings', async () => {
   });
 
   expect(execMock).toHaveBeenNthCalledWith(1, 'sudo', [
-    '-n',
-    'timedatectl',
-    'set-timezone',
+    expect.stringMatching(
+      new RegExp('^/.*/libs/backend/src/intermediate-scripts/set-clock$')
+    ),
     'America/Chicago',
-  ]);
-
-  expect(execMock).toHaveBeenNthCalledWith(2, 'sudo', [
-    '-n',
-    'timedatectl',
-    'set-time',
     '2020-11-03 09:00:00',
   ]);
 });

--- a/libs/backend/src/system_call/set_clock.ts
+++ b/libs/backend/src/system_call/set_clock.ts
@@ -1,5 +1,6 @@
 import { DateTime } from 'luxon';
 import { execFile } from '../exec';
+import { intermediateScript } from '../intermediate_scripts';
 
 /**
  * Parameters for the `setClock` function.
@@ -20,8 +21,11 @@ export async function setClock({
     const datetimeString = DateTime.fromISO(isoDatetime, {
       zone: ianaZone,
     }).toFormat('yyyy-LL-dd TT');
-    await execFile('sudo', ['-n', 'timedatectl', 'set-timezone', ianaZone]);
-    await execFile('sudo', ['-n', 'timedatectl', 'set-time', datetimeString]);
+    await execFile('sudo', [
+      intermediateScript('set-clock'),
+      ianaZone,
+      datetimeString,
+    ]);
   } catch (err) {
     const error = err as Error;
     if ('stderr' in error) {


### PR DESCRIPTION
## Overview

Issue links: https://github.com/votingworks/vxsuite/issues/4904 + https://github.com/votingworks/vxsuite/issues/5003 + https://github.com/votingworks/vxsuite/issues/4899

When we moved the system-call API from `kiosk-browser` to `libs/backend`, we missed a few pieces of configuration for production, namely some `sudo` calls and the relevant `sudoers` file update to allow those `sudo` calls to be made without having to provide the `sudo` password.

The result has been that setting the clock and interacting with reboot buttons cause VxSuite apps to crash in production.

This PR, paired with https://github.com/votingworks/vxsuite-complete-system/pull/384, remedies this.

## Testing Plan

Reproduced the crashes on a production-imaged non-locked-down VxAdmin, then copied updated source code over, rebuilt, and verified that the errors were no more.

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A