### PR TITLE
[MarkScan] Handle ballot re-insertion flow edge cases

### DIFF
--- a/apps/mark-scan/frontend/src/app_root.test.tsx
+++ b/apps/mark-scan/frontend/src/app_root.test.tsx
@@ -1,4 +1,4 @@
-import { mockOf } from '@votingworks/test-utils';
+import { advancePromises, mockOf } from '@votingworks/test-utils';
 import { electionGeneralDefinition } from '@votingworks/fixtures';
 import { DEFAULT_SYSTEM_SETTINGS } from '@votingworks/types';
 import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
@@ -7,7 +7,7 @@ import React from 'react';
 import { AUTH_STATUS_POLLING_INTERVAL_MS } from '@votingworks/ui';
 import { PollWorkerScreen } from './pages/poll_worker_screen';
 import { VoterFlow } from './voter_flow';
-import { AppRoot } from './app_root';
+import { AppRoot, POLL_WORKER_AUTH_REQUIRED_STATES } from './app_root';
 import { render } from '../test/test_utils';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 import {
@@ -15,9 +15,11 @@ import {
   mockPollWorkerAuth,
 } from '../test/helpers/mock_auth';
 import { screen } from '../test/react_testing_library';
+import { PollWorkerAuthEndedUnexpectedlyPage } from './pages/poll_worker_auth_ended_unexpectedly_page';
 
 jest.mock('./voter_flow');
 jest.mock('./pages/poll_worker_screen');
+jest.mock('./pages/poll_worker_auth_ended_unexpectedly_page');
 
 let apiMock: ApiMock;
 
@@ -50,7 +52,7 @@ test('setVotes action', async () => {
     electionDefinition,
   });
 
-  await screen.findByText('MockPollWorkerScreen', undefined, { timeout: 200 });
+  await screen.findByText('MockPollWorkerScreen', undefined);
 
   mockOf(VoterFlow).mockImplementation((props) => {
     const { votes } = props;
@@ -64,4 +66,37 @@ test('setVotes action', async () => {
 
   await jest.advanceTimersByTimeAsync(AUTH_STATUS_POLLING_INTERVAL_MS * 2);
   await screen.findByText('MockVoterFlow');
+});
+
+describe('renders PollWorkerAuthEndedUnexpectedlyPage for relevant states:', () => {
+  const electionDefinition = electionGeneralDefinition;
+
+  beforeEach(() => {
+    apiMock.expectGetElectionDefinition(electionDefinition);
+    apiMock.expectGetMachineConfig();
+    apiMock.expectGetSystemSettings(DEFAULT_SYSTEM_SETTINGS);
+    apiMock.expectGetElectionState({
+      precinctSelection: ALL_PRECINCTS_SELECTION,
+      pollsState: 'polls_open',
+    });
+  });
+
+  for (const state of POLL_WORKER_AUTH_REQUIRED_STATES) {
+    test(state, async () => {
+      mockOf(PollWorkerAuthEndedUnexpectedlyPage).mockImplementation(() => (
+        <div>MockUnexpectedAuthScreen</div>
+      ));
+
+      apiMock.setAuthStatus(mockCardlessVoterLoggedInAuth(electionDefinition));
+      apiMock.setPaperHandlerState(state);
+
+      const { container } = render(<AppRoot />, {
+        apiMock,
+        electionDefinition,
+      });
+      await advancePromises();
+
+      expect(container).toHaveTextContent('MockUnexpectedAuthScreen');
+    });
+  }
 });

--- a/apps/mark-scan/frontend/src/ballot_reinsertion_flow.tsx
+++ b/apps/mark-scan/frontend/src/ballot_reinsertion_flow.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import type { SimpleServerStatus } from '@votingworks/mark-scan-backend';
+import { assert } from '@votingworks/basics';
+import { ReinsertedInvalidBallotScreen } from './pages/reinserted_invalid_ballot_screen';
+import { WaitingForBallotReinsertionBallotScreen } from './pages/waiting_for_ballot_reinsertion_screen';
+import { LoadingReinsertedBallotScreen } from './pages/loading_reinserted_ballot_screen';
+
+export const BALLOT_REINSERTION_SCREENS: Readonly<
+  Partial<Record<SimpleServerStatus, JSX.Element>>
+> = {
+  waiting_for_ballot_reinsertion: <WaitingForBallotReinsertionBallotScreen />,
+  loading_reinserted_ballot: <LoadingReinsertedBallotScreen />,
+  validating_reinserted_ballot: <LoadingReinsertedBallotScreen />,
+  reinserted_invalid_ballot: <ReinsertedInvalidBallotScreen />,
+};
+
+export function isBallotReinsertionState(
+  state?: SimpleServerStatus
+): state is
+  | 'waiting_for_ballot_reinsertion'
+  | 'loading_reinserted_ballot'
+  | 'validating_reinserted_ballot'
+  | 'reinserted_invalid_ballot' {
+  return !!state && !!BALLOT_REINSERTION_SCREENS[state];
+}
+
+export interface BallotReinsertionFlowProps {
+  stateMachineState: SimpleServerStatus;
+}
+
+export function BallotReinsertionFlow(
+  props: BallotReinsertionFlowProps
+): React.ReactNode {
+  const { stateMachineState } = props;
+
+  assert(isBallotReinsertionState(stateMachineState));
+
+  return BALLOT_REINSERTION_SCREENS[stateMachineState];
+}

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
@@ -61,6 +61,10 @@ import { InsertedInvalidNewSheetScreen } from './inserted_invalid_new_sheet_scre
 import { InsertedPreprintedBallotScreen } from './inserted_preprinted_ballot_screen';
 import { LoadingNewSheetScreen } from './loading_new_sheet_screen';
 import { BallotReadyForReviewScreen } from './ballot_ready_for_review_screen';
+import {
+  BallotReinsertionFlow,
+  isBallotReinsertionState,
+} from '../ballot_reinsertion_flow';
 
 function isBallotReinsertionEnabled() {
   return !isFeatureFlagEnabled(
@@ -234,6 +238,10 @@ export function PollWorkerScreen({
     }
   }, [setMockPaperHandlerStatus, stateMachineState]);
 
+  if (isBallotReinsertionState(stateMachineState)) {
+    return <BallotReinsertionFlow stateMachineState={stateMachineState} />;
+  }
+
   if (
     stateMachineState === 'accepting_paper' ||
     stateMachineState === 'loading_paper'
@@ -241,7 +249,10 @@ export function PollWorkerScreen({
     return <LoadPaperPage />;
   }
 
-  if (stateMachineState === 'validating_new_sheet') {
+  if (
+    stateMachineState === 'validating_new_sheet' ||
+    stateMachineState === 'loading_new_sheet'
+  ) {
     return <LoadingNewSheetScreen />;
   }
 

--- a/apps/mark-scan/frontend/src/voter_flow.tsx
+++ b/apps/mark-scan/frontend/src/voter_flow.tsx
@@ -23,9 +23,10 @@ import { ValidateBallotPage } from './pages/validate_ballot_page';
 import { BallotContext } from './contexts/ballot_context';
 import * as api from './api';
 import { PatDeviceCalibrationPage } from './pages/pat_device_identification/pat_device_calibration_page';
-import { ReinsertedInvalidBallotScreen } from './pages/reinserted_invalid_ballot_screen';
-import { WaitingForBallotReinsertionBallotScreen } from './pages/waiting_for_ballot_reinsertion_screen';
-import { LoadingReinsertedBallotScreen } from './pages/loading_reinserted_ballot_screen';
+import {
+  BallotReinsertionFlow,
+  isBallotReinsertionState,
+} from './ballot_reinsertion_flow';
 
 export interface VoterFlowProps {
   contests: ContestsWithMsEitherNeither;
@@ -79,19 +80,8 @@ export function VoterFlow(props: VoterFlowProps): React.ReactNode {
     );
   }
 
-  if (stateMachineState === 'waiting_for_ballot_reinsertion') {
-    return <WaitingForBallotReinsertionBallotScreen />;
-  }
-
-  if (
-    stateMachineState === 'loading_reinserted_ballot' ||
-    stateMachineState === 'validating_reinserted_ballot'
-  ) {
-    return <LoadingReinsertedBallotScreen />;
-  }
-
-  if (stateMachineState === 'reinserted_invalid_ballot') {
-    return <ReinsertedInvalidBallotScreen />;
+  if (isBallotReinsertionState(stateMachineState)) {
+    return <BallotReinsertionFlow stateMachineState={stateMachineState} />;
   }
 
   return (


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/4812

Last few loose ends on the ballot re-insertion flow:
1. Making sure we keep rendering the re-insertion screens when a Poll Worker logs in during the flow (we could further improve this by creating Poll-Worker-specific screens, but this seems fine for now).
2. Adding the new states for initial sheet insertion to the branched logic for resetting the session/state machine when the Poll Worker card is removed too early.

## Demo Video or Screenshot

### 1. Persistent Re-Insertion Flow Screens:
#### Before:

https://github.com/user-attachments/assets/c6ff4848-400a-4d4d-8112-d21cf33efe3c

#### After:

https://github.com/user-attachments/assets/742e7d87-71a2-4d93-9167-89b939dc8bf4

### 2. Unexpected Poll Worker Logout:

https://github.com/user-attachments/assets/eee3b01d-827f-4566-be02-9b27823d6700

## Testing Plan
- State machine + UI test cases
- Manual testing with mock paper handler

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
