### PR TITLE
Trigger configuration from usb properly on EM screen

### DIFF
--- a/apps/scan/frontend/src/screens/unconfigured_election_screen_wrapper.tsx
+++ b/apps/scan/frontend/src/screens/unconfigured_election_screen_wrapper.tsx
@@ -24,6 +24,7 @@ export function UnconfiguredElectionScreenWrapper(
   // TODO move watching for USB drive to configure to the backend
   useEffect(() => {
     if (
+      isElectionManagerAuth &&
       usbDriveStatusQuery.isSuccess &&
       usbDriveStatusQuery.data.status === 'mounted'
     ) {
@@ -34,6 +35,7 @@ export function UnconfiguredElectionScreenWrapper(
     configureMutation.mutate,
     usbDriveStatusQuery.isSuccess,
     usbDriveStatusQuery.data?.status,
+    isElectionManagerAuth,
   ]);
 
   const error = configureMutation.data?.err();

--- a/apps/scan/frontend/src/screens/unconfigured_election_screen_wrapper.tsx
+++ b/apps/scan/frontend/src/screens/unconfigured_election_screen_wrapper.tsx
@@ -1,9 +1,5 @@
-import {
-  UnconfiguredElectionScreen,
-  useQueryChangeListener,
-  Screen,
-  Main,
-} from '@votingworks/ui';
+import { UnconfiguredElectionScreen, Screen, Main } from '@votingworks/ui';
+import { useEffect } from 'react';
 import {
   configureFromElectionPackageOnUsbDrive,
   getUsbDriveStatus,
@@ -26,13 +22,20 @@ export function UnconfiguredElectionScreenWrapper(
   const configureMutation =
     configureFromElectionPackageOnUsbDrive.useMutation();
   // TODO move watching for USB drive to configure to the backend
-  useQueryChangeListener(usbDriveStatusQuery, {
-    onChange: (newUsbDriveStatus) => {
-      if (newUsbDriveStatus.status === 'mounted') {
-        configureMutation.mutate();
-      }
-    },
-  });
+  useEffect(() => {
+    if (
+      usbDriveStatusQuery.isSuccess &&
+      usbDriveStatusQuery.data.status === 'mounted'
+    ) {
+      configureMutation.mutate();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    configureMutation.mutate,
+    usbDriveStatusQuery.isSuccess,
+    usbDriveStatusQuery.data?.status,
+  ]);
+
   const error = configureMutation.data?.err();
 
   if (!usbDriveStatusQuery.isSuccess) return null;


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/4967

The issue was that the configureMutation call was never being made previously if the usb was mounted BEFORE the election manager card was inserted. Causing it to hang forever here and never show the failure screens when the usb didn't have the right election package for the election manager card. This makes it so that its triggered properly if the usb is mounted either before or after the EM card is authenticated. 

For some reason the happy path when there was an election package on the card always worked properly even if the usb was previously mounted which I don't totally understand. 

<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot

## Testing Plan
Manually Tested
- Mount usb and then insert EM card - in success case and in error cases saw correct behavior 
- Insert EM card then mount usb - in success case and in error cases saw correct behavior 

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
