### PR TITLE
mock paper handler driver: give mock ImageData height

### DIFF
--- a/libs/custom-paper-handler/src/driver/mock_driver.ts
+++ b/libs/custom-paper-handler/src/driver/mock_driver.ts
@@ -74,7 +74,8 @@ export type MockPaperHandlerStatus = keyof typeof MOCK_STATUSES_DEFINITIONS;
 
 const EMPTY_PAGE_CONTENTS = new ImageData(
   new Uint8ClampedArray([1, 2, 3, 4]),
-  2
+  1,
+  1
 );
 
 export class MockPaperHandlerDriver implements PaperHandlerDriverInterface {


### PR DESCRIPTION
## Overview

MarkScan run with a mock paper handler was crashing because the scan data returned had no height. The mock ImageData returned by the mock driver was given a width of 2 and no height; height is computed by dividing the length of pixel data by width, so we can either provide 4 total pixels' worth of data or explicitly set width (and height, while we're at it) to 1.

## Demo Video or Screenshot

No user facing change

## Testing Plan

Manually reproduced issue and verified fix.