### PR TITLE
Reset Audio-Only Mode properly

### DIFF
--- a/libs/mark-flow-ui/src/hooks/use_session_settings_manager.test.tsx
+++ b/libs/mark-flow-ui/src/hooks/use_session_settings_manager.test.tsx
@@ -42,6 +42,7 @@ const mockUseCurrentLanguage = mockOf(useCurrentLanguage);
 const DEFAULT_THEME: Partial<DefaultTheme> = {
   colorMode: 'contrastMedium',
   sizeMode: 'touchMedium',
+  isVisualModeDisabled: false,
 };
 const ACTIVE_VOTING_SESSION_VOTES: VotesDict = {};
 const NEW_VOTING_SESSION_VOTES = undefined;
@@ -104,11 +105,13 @@ test('Resets settings when election official logs in', () => {
   act(() => {
     voterSettingsManager.setColorMode('contrastLow');
     voterSettingsManager.setSizeMode('touchExtraLarge');
+    voterSettingsManager.setIsVisualModeDisabled(true);
   });
   expect(currentTheme).toEqual(
     expect.objectContaining<Partial<DefaultTheme>>({
       colorMode: 'contrastLow',
       sizeMode: 'touchExtraLarge',
+      isVisualModeDisabled: true,
     })
   );
   mockUseCurrentLanguage.mockReturnValue(SPANISH);
@@ -161,6 +164,7 @@ test('Resets settings when election official logs in', () => {
     expect.objectContaining<Partial<DefaultTheme>>({
       colorMode: 'contrastLow',
       sizeMode: 'touchExtraLarge',
+      isVisualModeDisabled: true,
     })
   );
   expect(mockLanguageControls.setLanguage).toHaveBeenCalledWith(SPANISH);
@@ -185,6 +189,7 @@ test('Resets theme to default if returning to a new voter session', () => {
   act(() => {
     voterSettingsManager.setColorMode('contrastLow');
     voterSettingsManager.setSizeMode('touchExtraLarge');
+    voterSettingsManager.setIsVisualModeDisabled(true);
   });
   mockUseCurrentLanguage.mockReturnValue(SPANISH);
   mockUseAudioEnabled.mockReturnValue(false);
@@ -193,6 +198,7 @@ test('Resets theme to default if returning to a new voter session', () => {
     expect.objectContaining<Partial<DefaultTheme>>({
       colorMode: 'contrastLow',
       sizeMode: 'touchExtraLarge',
+      isVisualModeDisabled: true,
     })
   );
 
@@ -216,6 +222,7 @@ test('Resets theme to default if returning to a new voter session', () => {
     expect.objectContaining<Partial<DefaultTheme>>({
       colorMode: 'contrastHighDark',
       sizeMode: 'touchSmall',
+      isVisualModeDisabled: false,
     })
   );
 

--- a/libs/mark-flow-ui/src/hooks/use_session_settings_manager.ts
+++ b/libs/mark-flow-ui/src/hooks/use_session_settings_manager.ts
@@ -76,6 +76,9 @@ export function useSessionSettingsManager(
         // when election official logs out:
         voterSettingsManager.setColorMode(voterSettings.theme.colorMode);
         voterSettingsManager.setSizeMode(voterSettings.theme.sizeMode);
+        voterSettingsManager.setIsVisualModeDisabled(
+          voterSettings.theme.isVisualModeDisabled
+        );
         setLanguage(voterSettings.language);
         setAudioEnabled(voterSettings.isAudioEnabled);
       } else {

--- a/libs/ui/src/app_base.tsx
+++ b/libs/ui/src/app_base.tsx
@@ -69,7 +69,8 @@ export function AppBase(props: AppBaseProps): JSX.Element {
   const resetThemes = useCallback(() => {
     setColorMode(defaultColorMode);
     setSizeMode(defaultSizeMode);
-  }, [defaultColorMode, defaultSizeMode]);
+    setIsVisualModeDisabled(defaultIsVisualModeDisabled);
+  }, [defaultColorMode, defaultSizeMode, defaultIsVisualModeDisabled]);
 
   if (!fontsLoaded) {
     // To avoid the possibility of font flicker before the fonts are loaded,


### PR DESCRIPTION
## Overview
Adds logic for resetting the audio-only mode flag when a voter session resets either after casting a ballot or when an election official authenticates. It is reset to its previous state when returning to a voter session. 

<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot

## Testing Plan
Started voter session , made a vote, Turned on audio-only mode, insertted pollworker card saw audio-only mode clear and pollworker text render, removed card, saw return to audio-only mode
Started voter session, turned on audio-only mode, finished casting a ballot, saw screen reset back to insert card 

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
