### PR TITLE
Reset language with voter display settings on vxscan

### DIFF
--- a/apps/scan/frontend/src/components/voter_settings_manager.tsx
+++ b/apps/scan/frontend/src/components/voter_settings_manager.tsx
@@ -1,14 +1,17 @@
 import React from 'react';
 import {
   VoterSettingsManagerContext,
+  useCurrentLanguage,
+  useLanguageControls,
   useQueryChangeListener,
 } from '@votingworks/ui';
 import { DefaultTheme, ThemeContext } from 'styled-components';
+import { LanguageCode } from '@votingworks/types';
 import { getAuthStatus, getScannerStatus } from '../api';
 
 /**
  * Side-effect component for monitoring for auth and voter session changes and
- * resetting/restoring voter voter settings as needed.
+ * resetting/restoring voter display settings and language choice as needed.
  */
 export function VoterSettingsManager(): JSX.Element | null {
   const voterSettingsManager = React.useContext(VoterSettingsManagerContext);
@@ -17,8 +20,15 @@ export function VoterSettingsManager(): JSX.Element | null {
   const authStatusQuery = getAuthStatus.useQuery();
   const scannerStatusQuery = getScannerStatus.useQuery();
 
+  const { reset: resetLanguage, setLanguage } = useLanguageControls();
+  const currentLanguage = useCurrentLanguage();
+
   const [voterSessionTheme, setVoterSessionTheme] =
     React.useState<DefaultTheme | null>(null);
+
+  const [voterLanguage, setVoterLanguage] = React.useState<LanguageCode | null>(
+    null
+  );
 
   useQueryChangeListener(authStatusQuery, {
     select: ({ status }) => status,
@@ -26,26 +36,39 @@ export function VoterSettingsManager(): JSX.Element | null {
       // Reset to default theme when election official logs in:
       if (previousStatus === 'logged_out') {
         setVoterSessionTheme(currentTheme);
+        setVoterLanguage(currentLanguage);
         voterSettingsManager.resetThemes();
+        resetLanguage();
       }
 
       // Reset to previous voter settings when election official logs out:
       if (newStatus === 'logged_out' && voterSessionTheme) {
         voterSettingsManager.setColorMode(voterSessionTheme.colorMode);
         voterSettingsManager.setSizeMode(voterSessionTheme.sizeMode);
+        if (voterLanguage) {
+          setLanguage(voterLanguage);
+        }
         setVoterSessionTheme(null);
+        setVoterLanguage(null);
       }
     },
   });
 
-  // [VVSG 2.0 7.1-A] Reset to default theme when voter is done scanning. We
+  // [VVSG 2.0 7.1-A] Reset to default theme and language when voter is done scanning. We
   // have chosen to interpret that as whenever paper leaves the scanner (either
   // into the ballot box, or retrieved by the user after a ballot rejection).
   useQueryChangeListener(scannerStatusQuery, {
     select: ({ state }) => state,
     onChange: (newState, previousState) => {
-      if (previousState && newState === 'no_paper') {
+      // If we transition from paused to no_paper we are just returning from an election official screen
+      if (
+        previousState &&
+        previousState !== 'no_paper' &&
+        previousState !== 'paused' &&
+        newState === 'no_paper'
+      ) {
         voterSettingsManager.resetThemes();
+        resetLanguage();
       }
     },
   });


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/5069

Adds language reset logic alongside display settings reset logic for VxScan, now matching how Mark works.
<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot

## Testing Plan
Changed voter display/language - inserted pollworker card - saw both reset
Changed voter display/language - inserted rejected ballot - saw both reset
Changed voter display/language - inserted succesfull ballot - saw both reset 

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
