### PR TITLE
Ignore Pat Connection on Pollworker Screen

### DIFF
--- a/apps/mark-scan/backend/src/app.auth.test.ts
+++ b/apps/mark-scan/backend/src/app.auth.test.ts
@@ -155,7 +155,7 @@ test('endCardlessVoterSession', async () => {
 
 test('getAuthStatus before election definition has been configured', async () => {
   await apiClient.getAuthStatus();
-  expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(2);
+  expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(1);
   expect(mockAuth.getAuthStatus).toHaveBeenNthCalledWith(
     1,
     DEFAULT_SYSTEM_SETTINGS.auth

--- a/apps/mark-scan/backend/src/app.auth.test.ts
+++ b/apps/mark-scan/backend/src/app.auth.test.ts
@@ -155,7 +155,7 @@ test('endCardlessVoterSession', async () => {
 
 test('getAuthStatus before election definition has been configured', async () => {
   await apiClient.getAuthStatus();
-  expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(1);
+  expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(2);
   expect(mockAuth.getAuthStatus).toHaveBeenNthCalledWith(
     1,
     DEFAULT_SYSTEM_SETTINGS.auth

--- a/apps/mark-scan/backend/src/app.diagnostics.test.ts
+++ b/apps/mark-scan/backend/src/app.diagnostics.test.ts
@@ -225,6 +225,7 @@ test('saving the readiness report', async () => {
   const exportPath = exportResult.ok()![0];
   await expect(exportPath).toMatchPdfSnapshot({
     customSnapshotIdentifier: 'readiness-report',
+    failureThreshold: 0.001,
   });
 
   const pdfContents = await pdfToText(exportPath);

--- a/apps/mark-scan/backend/src/app.test.ts
+++ b/apps/mark-scan/backend/src/app.test.ts
@@ -50,7 +50,7 @@ import {
 import { PatConnectionStatusReader } from './pat-input/connection_status_reader';
 import { createWorkspace } from './util/workspace';
 
-const TEST_POLLING_INTERVAL_MS = 5;
+const TEST_POLLING_INTERVAL_MS = 15;
 
 jest.mock('./pat-input/connection_status_reader');
 

--- a/apps/mark-scan/backend/src/app.test.ts
+++ b/apps/mark-scan/backend/src/app.test.ts
@@ -45,7 +45,6 @@ import { ElectionState } from './types';
 import {
   mockElectionManagerAuth,
   mockPollWorkerAuth,
-  mockCardlessVoterAuth,
 } from '../test/auth_helpers';
 import { PatConnectionStatusReader } from './pat-input/connection_status_reader';
 import { createWorkspace } from './util/workspace';
@@ -465,15 +464,18 @@ test('removing ballot during presentation', async () => {
 });
 
 test('setPatDeviceIsCalibrated', async () => {
-  mockCardlessVoterAuth(mockAuth);
-  expect(await apiClient.getPaperHandlerState()).toEqual('not_accepting_paper');
+  await configureForTestElection(electionGeneralDefinition);
+  await mockLoadFlow(apiClient, driver);
+  expect(await apiClient.getPaperHandlerState()).toEqual(
+    'waiting_for_ballot_data'
+  );
   mockOf(patConnectionStatusReader.isPatDeviceConnected).mockResolvedValue(
     true
   );
   await waitForStatus('pat_device_connected');
 
   await apiClient.setPatDeviceIsCalibrated();
-  await waitForStatus('not_accepting_paper');
+  await waitForStatus('waiting_for_ballot_data');
 });
 
 function sortVotes(votes: VotesDict): VotesDict {

--- a/apps/mark-scan/backend/src/app.test.ts
+++ b/apps/mark-scan/backend/src/app.test.ts
@@ -43,6 +43,7 @@ import { Api, buildApp } from './app';
 import { PaperHandlerStateMachine } from './custom-paper-handler';
 import { ElectionState } from './types';
 import {
+  mockCardlessVoterAuth,
   mockElectionManagerAuth,
   mockPollWorkerAuth,
 } from '../test/auth_helpers';
@@ -408,6 +409,7 @@ async function mockLoadFlow(
 ) {
   await testApiClient.setAcceptingPaperState();
   testDriver.setMockStatus('paperInserted');
+  mockCardlessVoterAuth(mockAuth);
   await waitForStatus('waiting_for_ballot_data');
 }
 
@@ -429,6 +431,7 @@ test('ballot invalidation flow', async () => {
   await configureForTestElection(electionGeneralDefinition);
   await mockLoadAndPrint(apiClient, driver);
   await apiClient.invalidateBallot();
+  mockPollWorkerAuth(mockAuth, electionGeneralDefinition);
   await waitForStatus(
     'waiting_for_invalidated_ballot_confirmation.paper_present'
   );
@@ -542,6 +545,7 @@ test('printing ballots', async () => {
   deferredEjection.resolve(true);
   driver.setMockStatus('noPaper');
   await waitForStatus('not_accepting_paper');
+  mockPollWorkerAuth(mockAuth, electionDefinition);
 
   // vote a ballot in Chinese
   await mockLoadFlow(apiClient, driver);

--- a/apps/mark-scan/backend/src/app.test.ts
+++ b/apps/mark-scan/backend/src/app.test.ts
@@ -45,6 +45,7 @@ import { ElectionState } from './types';
 import {
   mockElectionManagerAuth,
   mockPollWorkerAuth,
+  mockCardlessVoterAuth,
 } from '../test/auth_helpers';
 import { PatConnectionStatusReader } from './pat-input/connection_status_reader';
 import { createWorkspace } from './util/workspace';
@@ -464,6 +465,7 @@ test('removing ballot during presentation', async () => {
 });
 
 test('setPatDeviceIsCalibrated', async () => {
+  mockCardlessVoterAuth(mockAuth);
   expect(await apiClient.getPaperHandlerState()).toEqual('not_accepting_paper');
   mockOf(patConnectionStatusReader.isPatDeviceConnected).mockResolvedValue(
     true

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -274,6 +274,8 @@ describe('loading_paper', () => {
 
     driver.setMockStatus('paperInserted');
     await expectStatusTransitionTo('loading_paper');
+    await expectStatusTransitionTo('waiting_for_voter_auth');
+    mockCardlessVoterAuth(auth);
     await expectStatusTransitionTo('waiting_for_ballot_data');
   });
 });
@@ -391,6 +393,8 @@ async function executePrintBallotAndAssert(
   machine.setAcceptingPaper();
   driver.setMockStatus('paperInserted');
   await expectStatusTransitionTo('loading_paper');
+  await expectStatusTransitionTo('waiting_for_voter_auth');
+  mockCardlessVoterAuth(auth);
   await expectStatusTransitionTo('waiting_for_ballot_data');
 
   void machine.printBallot(ballotPdfData);
@@ -597,8 +601,9 @@ describe('PAT device', () => {
     );
 
     await expectStatusTransitionTo('loading_paper');
-    await expectStatusTransitionTo('waiting_for_ballot_data');
+    await expectStatusTransitionTo('waiting_for_voter_auth');
     mockCardlessVoterAuth(auth);
+    await expectStatusTransitionTo('waiting_for_ballot_data');
   }
   // Get into the state at the start of a voter session.
   test('HID adapter support', async () => {
@@ -661,10 +666,11 @@ describe('PAT device', () => {
       jest.requireActual('./application_driver').loadAndParkPaper
     );
     await expectStatusTransitionTo('loading_paper');
-    await expectStatusTransitionTo('waiting_for_ballot_data');
+    await expectStatusTransitionTo('waiting_for_voter_auth');
 
     // Change to voter auth to see state change to pat_device_connected
     mockCardlessVoterAuth(auth);
+    await expectStatusTransitionTo('waiting_for_ballot_data');
     await expectStatusTransitionTo('pat_device_connected');
     expect(machine.isPatDeviceConnected()).toEqual(true);
   });
@@ -870,6 +876,9 @@ test('insert and validate new blank sheet', async () => {
   await expectStatusTransitionTo('validating_new_sheet');
 
   mockInterpretResult.resolve(BLANK_PAGE_INTERPRETATION_MOCK);
+
+  await expectStatusTransitionTo('waiting_for_voter_auth');
+  mockCardlessVoterAuth(auth);
   await expectStatusTransitionTo('waiting_for_ballot_data');
   expect(
     mockOf(interpretSimplexBmdBallotFromFilepath)

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -783,7 +783,7 @@ export function buildMachine(
             paper_reloaded: {
               invoke: pollAuthStatus(),
               on: {
-                AUTH_STATUS_CARDLESS_VOTER: 'waiting_for_voter_auth',
+                AUTH_STATUS_CARDLESS_VOTER: 'waiting_for_ballot_data',
                 AUTH_STATUS_LOGGED_OUT: 'not_accepting_paper',
                 AUTH_STATUS_UNHANDLED: 'not_accepting_paper',
               },
@@ -1413,6 +1413,7 @@ export async function getPaperHandlerStateMachine({
         case state.matches('voting_flow.loading_new_sheet'):
           return 'loading_new_sheet';
         case state.matches('voting_flow.waiting_for_voter_auth'):
+          return 'waiting_for_voter_auth';
         case state.matches('voting_flow.waiting_for_ballot_data'):
           return 'waiting_for_ballot_data';
         case state.matches('voting_flow.printing_ballot'):

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -367,6 +367,8 @@ function buildPatDeviceConnectionStatusObservable() {
             constructAuthMachineState(workspace)
           );
 
+          // We only present the option to calibrate the PAT device when a cardless voter is authenticated.
+          // Otherwise, we don't care about the PAT device status.
           if (!isCardlessVoterAuth(authStatus)) {
             return { type: 'PAT_DEVICE_NO_STATUS_CHANGE' };
           }
@@ -1187,10 +1189,12 @@ export function buildMachine(
           always: 'voting_flow.history',
         },
         pat_device_connected: {
+          invoke: pollAuthStatus(),
           on: {
             VOTER_CONFIRMED_PAT_DEVICE_CALIBRATION: 'voting_flow.history',
             PAT_DEVICE_DISCONNECTED: 'pat_device_disconnected',
             PAT_DEVICE_CONNECTED: undefined,
+            AUTH_STATUS_POLL_WORKER: 'voting_flow.history',
           },
         },
       },

--- a/apps/mark-scan/backend/src/custom-paper-handler/types.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/types.ts
@@ -45,6 +45,7 @@ export const SimpleStatusSchema = z.union([
   z.literal('waiting_for_ballot_reinsertion'),
   z.literal('waiting_for_invalidated_ballot_confirmation.paper_absent'),
   z.literal('waiting_for_invalidated_ballot_confirmation.paper_present'),
+  z.literal('waiting_for_voter_auth'),
 ]);
 
 export type SimpleStatus = z.infer<typeof SimpleStatusSchema>;

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
@@ -316,7 +316,10 @@ export function PollWorkerScreen({
     const { precinctId, ballotStyleId } = pollWorkerAuth.cardlessVoterUser;
     const precinct = find(election.precincts, (p) => p.id === precinctId);
 
-    if (stateMachineState === 'waiting_for_ballot_data') {
+    if (
+      stateMachineState === 'waiting_for_ballot_data' ||
+      stateMachineState === 'waiting_for_voter_auth'
+    ) {
       return (
         <CenteredCardPageLayout
           buttons={


### PR DESCRIPTION
## Overview
Currently if you insert the pat device while on the pollworker screen, or insert a PW card with a pat device connected you end up on a white screen. This PR fixes that and handles those cases to just go to the pollworker screen as expected. 
<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot

## Testing Plan
Connected/Disconnected PAT at various moments in PW screen flows and saw no impact, saw PAT test flow come up once voter session started (if still plugged in) as expected
Inserted PW card again once in PAT connection flow and saw PW screen display as expected. 

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
