### PR TITLE
fix(basics): ensure `take` doesn't take beyond

### DIFF
--- a/libs/basics/src/iterators/async_iterator_plus.test.ts
+++ b/libs/basics/src/iterators/async_iterator_plus.test.ts
@@ -251,6 +251,19 @@ test('take', async () => {
     0, 1, 2, 3, 4,
   ]);
   expect(await iter([]).async().take(-1).toArray()).toEqual([]);
+
+  let count = 0;
+  await iter({
+    [Symbol.asyncIterator]: () => ({
+      next: () => {
+        count += 1;
+        return Promise.resolve({ value: count, done: false });
+      },
+    }),
+  })
+    .take(2)
+    .toArray();
+  expect(count).toEqual(2);
 });
 
 test('skip', async () => {

--- a/libs/basics/src/iterators/async_iterator_plus.ts
+++ b/libs/basics/src/iterators/async_iterator_plus.ts
@@ -401,16 +401,15 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
 
   take(count: number): AsyncIteratorPlus<T> {
     const iterable = this.intoInner();
+    const iterator = iterable[Symbol.asyncIterator]();
     return new AsyncIteratorPlusImpl(
       (async function* gen(): AsyncIterableIterator<T> {
-        let remaining = count;
-        for await (const value of iterable) {
-          if (remaining <= 0) {
+        for (let remaining = count; remaining > 0; remaining -= 1) {
+          const next = await iterator.next();
+          if (next.done) {
             break;
-          } else {
-            yield value;
-            remaining -= 1;
           }
+          yield next.value;
         }
       })()
     );

--- a/libs/basics/src/iterators/iterator_plus.test.ts
+++ b/libs/basics/src/iterators/iterator_plus.test.ts
@@ -188,6 +188,19 @@ test('take', () => {
   expect(iter(integers()).take(1).toArray()).toEqual([0]);
   expect(iter(integers()).take(5).toArray()).toEqual([0, 1, 2, 3, 4]);
   expect(iter([]).take(-1).toArray()).toEqual([]);
+
+  let count = 0;
+  iter({
+    [Symbol.iterator]: () => ({
+      next: () => {
+        count += 1;
+        return { value: count, done: false };
+      },
+    }),
+  })
+    .take(2)
+    .toArray();
+  expect(count).toEqual(2);
 });
 
 test('skip', () => {

--- a/libs/basics/src/iterators/iterator_plus.ts
+++ b/libs/basics/src/iterators/iterator_plus.ts
@@ -397,16 +397,15 @@ export class IteratorPlusImpl<T> implements IteratorPlus<T>, AsyncIterable<T> {
 
   take(count: number): IteratorPlus<T> {
     const iterable = this.intoInner();
+    const iterator = iterable[Symbol.iterator]();
     return new IteratorPlusImpl(
       (function* gen(): IterableIterator<T> {
-        let remaining = count;
-        for (const value of iterable) {
-          if (remaining <= 0) {
+        for (let remaining = count; remaining > 0; remaining -= 1) {
+          const next = iterator.next();
+          if (next.done) {
             break;
-          } else {
-            yield value;
-            remaining -= 1;
           }
+          yield next.value;
         }
       })()
     );


### PR DESCRIPTION
The old approach took the value on the last iteration but discarded it if there weren't any more requested. This version fixes that.
