### PR TITLE
Reset session properly in mark

### DIFF
--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -330,7 +330,7 @@ export function AppRoot(): JSX.Element | null {
     };
   }, []);
 
-  useSessionSettingsManager({ authStatus, votes });
+  useSessionSettingsManager({ authStatus });
 
   useBallotStyleManager({
     currentBallotStyleId: ballotStyleId,

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -353,7 +353,7 @@ export function AppRoot({ reload }: Props): JSX.Element | null {
     };
   }, []);
 
-  useSessionSettingsManager({ authStatus, votes });
+  useSessionSettingsManager({ authStatus });
 
   useBallotStyleManager({
     currentBallotStyleId: ballotStyleId,

--- a/libs/auth/src/inserted_smart_card_auth.test.ts
+++ b/libs/auth/src/inserted_smart_card_auth.test.ts
@@ -862,7 +862,10 @@ test('Cardless voter sessions - ending preemptively', async () => {
     status: 'logged_in',
     user: pollWorkerUser,
     sessionExpiresAt: expect.any(Date),
-    cardlessVoterUser,
+    cardlessVoterUser: {
+      ...cardlessVoterUser,
+      sessionId: expect.any(String),
+    },
   });
   expect(mockLogger.log).toHaveBeenCalledTimes(1);
   expect(mockLogger.log).toHaveBeenNthCalledWith(
@@ -912,7 +915,10 @@ test('Cardless voter sessions - end-to-end', async () => {
     status: 'logged_in',
     user: pollWorkerUser,
     sessionExpiresAt: expect.any(Date),
-    cardlessVoterUser,
+    cardlessVoterUser: {
+      ...cardlessVoterUser,
+      sessionId: expect.any(String),
+    },
   });
   expect(mockLogger.log).toHaveBeenCalledTimes(1);
   expect(mockLogger.log).toHaveBeenNthCalledWith(
@@ -929,7 +935,10 @@ test('Cardless voter sessions - end-to-end', async () => {
   mockCardStatus({ status: 'no_card' });
   expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
     status: 'logged_in',
-    user: cardlessVoterUser,
+    user: {
+      ...cardlessVoterUser,
+      sessionId: expect.any(String),
+    },
     sessionExpiresAt: expect.any(Date),
   });
   expect(mockLogger.log).toHaveBeenCalledTimes(2);
@@ -955,7 +964,10 @@ test('Cardless voter sessions - end-to-end', async () => {
     status: 'logged_in',
     user: pollWorkerUser,
     sessionExpiresAt: expect.any(Date),
-    cardlessVoterUser,
+    cardlessVoterUser: {
+      ...cardlessVoterUser,
+      sessionId: expect.any(String),
+    },
   });
   expect(mockLogger.log).toHaveBeenCalledTimes(3);
   expect(mockLogger.log).toHaveBeenNthCalledWith(
@@ -972,7 +984,10 @@ test('Cardless voter sessions - end-to-end', async () => {
   mockCardStatus({ status: 'no_card' });
   expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
     status: 'logged_in',
-    user: cardlessVoterUser,
+    user: {
+      ...cardlessVoterUser,
+      sessionId: expect.any(String),
+    },
     sessionExpiresAt: expect.any(Date),
   });
   expect(mockLogger.log).toHaveBeenCalledTimes(4);

--- a/libs/auth/src/inserted_smart_card_auth.ts
+++ b/libs/auth/src/inserted_smart_card_auth.ts
@@ -1,4 +1,5 @@
 import { Buffer } from 'buffer';
+import { v4 as uuid } from 'uuid';
 import {
   assert,
   deepEqual,
@@ -252,7 +253,11 @@ export class InsertedSmartCardAuth implements InsertedSmartCardAuthApi {
       return;
     }
 
-    this.cardlessVoterUser = { ...input, role: 'cardless_voter' };
+    this.cardlessVoterUser = {
+      ...input,
+      sessionId: uuid(),
+      role: 'cardless_voter',
+    };
 
     await this.logger.log(LogEventId.AuthLogin, 'cardless_voter', {
       disposition: LogDispositionStandardTypes.Success,

--- a/libs/mark-flow-ui/src/hooks/use_session_settings_manager.test.tsx
+++ b/libs/mark-flow-ui/src/hooks/use_session_settings_manager.test.tsx
@@ -14,7 +14,7 @@ import {
   mockUseAudioControls,
   mockOf,
 } from '@votingworks/test-utils';
-import { AudioControls, LanguageCode, VotesDict } from '@votingworks/types';
+import { AudioControls, LanguageCode } from '@votingworks/types';
 import { act, render } from '../../test/react_testing_library';
 import {
   UseSessionSettingsManagerParams,
@@ -44,8 +44,6 @@ const DEFAULT_THEME: Partial<DefaultTheme> = {
   sizeMode: 'touchMedium',
   isVisualModeDisabled: false,
 };
-const ACTIVE_VOTING_SESSION_VOTES: VotesDict = {};
-const NEW_VOTING_SESSION_VOTES = undefined;
 const { CHINESE_SIMPLIFIED, SPANISH } = LanguageCode;
 
 let currentTheme: DefaultTheme;
@@ -85,7 +83,6 @@ test('Resets settings when election official logs in', () => {
         user: mockCardlessVoterUser(),
         sessionExpiresAt: mockSessionExpiresAt(),
       }}
-      votes={ACTIVE_VOTING_SESSION_VOTES}
     />,
     { vxTheme: DEFAULT_THEME }
   );
@@ -125,7 +122,6 @@ test('Resets settings when election official logs in', () => {
         user: mockElectionManagerUser(),
         sessionExpiresAt: mockSessionExpiresAt(),
       }}
-      votes={ACTIVE_VOTING_SESSION_VOTES}
     />
   );
   expect(currentTheme).toEqual(
@@ -157,7 +153,6 @@ test('Resets settings when election official logs in', () => {
         user: mockCardlessVoterUser(),
         sessionExpiresAt: mockSessionExpiresAt(),
       }}
-      votes={ACTIVE_VOTING_SESSION_VOTES}
     />
   );
   expect(currentTheme).toEqual(
@@ -180,7 +175,6 @@ test('Resets theme to default if returning to a new voter session', () => {
         user: mockCardlessVoterUser(),
         sessionExpiresAt: mockSessionExpiresAt(),
       }}
-      votes={ACTIVE_VOTING_SESSION_VOTES}
     />,
     { vxTheme: DEFAULT_THEME }
   );
@@ -210,7 +204,6 @@ test('Resets theme to default if returning to a new voter session', () => {
         user: mockElectionManagerUser(),
         sessionExpiresAt: mockSessionExpiresAt(),
       }}
-      votes={ACTIVE_VOTING_SESSION_VOTES}
     />
   );
   mockUseCurrentLanguage.mockReturnValue(CHINESE_SIMPLIFIED);
@@ -236,10 +229,12 @@ test('Resets theme to default if returning to a new voter session', () => {
     <TestHookWrapper
       authStatus={{
         status: 'logged_in',
-        user: mockCardlessVoterUser(),
+        user: {
+          ...mockCardlessVoterUser(),
+          sessionId: 'new_session',
+        },
         sessionExpiresAt: mockSessionExpiresAt(),
       }}
-      votes={NEW_VOTING_SESSION_VOTES}
     />
   );
   expect(currentTheme).toEqual(

--- a/libs/mark-flow-ui/src/hooks/use_session_settings_manager.ts
+++ b/libs/mark-flow-ui/src/hooks/use_session_settings_manager.ts
@@ -46,7 +46,7 @@ export function useSessionSettingsManager(
     previousAuthStatusRef.current &&
     isCardlessVoterAuth(previousAuthStatusRef.current);
   const isLoggedInAsVoter = isCardlessVoterAuth(authStatus);
-  // If the pollworker deactivated the voter session and initiated a new one, the session expires at timestamp will have changed.
+  // If the pollworker deactivated the voter session and initiated a new one, the sessionId have changed.
   const isNewVoterSession =
     isLoggedInAsVoter &&
     previousVoterAuthStatusRef.current &&

--- a/libs/test-utils/src/auth.ts
+++ b/libs/test-utils/src/auth.ts
@@ -64,6 +64,7 @@ export function mockCardlessVoterUser(
     role: 'cardless_voter',
     ballotStyleId: 'ballot-style-id',
     precinctId: 'precinct-id',
+    sessionId: 'session-id',
     ...props,
   };
 }

--- a/libs/types/src/auth/auth.ts
+++ b/libs/types/src/auth/auth.ts
@@ -53,6 +53,7 @@ export interface CardlessVoterUser {
   readonly role: 'cardless_voter';
   readonly ballotStyleId: BallotStyleId;
   readonly precinctId: PrecinctId;
+  readonly sessionId: string;
 }
 
 export type User =


### PR DESCRIPTION
## Overview
Updates the Mark session resetting logic to instead of checking for if there are selected votes to determine if the pollworker card had deactivated and started a new voter session instead keeping track of a unique id per session that is checked. 
<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot

## Testing Plan
Without Selecting Votes - Activate voter session, change language/display, Insert pollworker card - see temporary reset, remove pollworker card - see display/language are still what I changed to 
With Selecting Votes - Activate voter session, change language/display, Insert pollworker card - see temporary reset, remove pollworker card - see display/language are still what I changed to 
Without Selecting Votes - Activate voter session, change language/display, Insert pollworker card - see temporary reset, deactivate session, start new voting session, remove pollworker card - see display/language are now the defaults
With Selecting Votes - Activate voter session, change language/display, Insert pollworker card - see temporary reset, remove pollworker card -  see display/language are now the defaults


## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
