### PR TITLE
fix(basics): improve types of conditional `iter` methods

### DIFF
--- a/libs/basics/src/iterators/async_iterator_plus.test.ts
+++ b/libs/basics/src/iterators/async_iterator_plus.test.ts
@@ -555,6 +555,9 @@ test('min', async () => {
       expect(await iter(arr).async().min()).toEqual(Math.min(...arr));
     })
   );
+
+  // @ts-expect-error - should be an array of numbers
+  await iter(['a']).async().min();
 });
 
 test('minBy', async () => {
@@ -621,6 +624,9 @@ test('max', async () => {
       expect(await iter(arr).async().max()).toEqual(Math.max(...arr));
     })
   );
+
+  // @ts-expect-error - should be an array of numbers
+  await iter(['a']).async().max();
 });
 
 test('maxBy', async () => {
@@ -669,6 +675,9 @@ test('sum', async () => {
       );
     })
   );
+
+  // @ts-expect-error - should be an array of numbers
+  await iter(['a']).async().sum();
 });
 
 test('partition', async () => {

--- a/libs/basics/src/iterators/async_iterator_plus.ts
+++ b/libs/basics/src/iterators/async_iterator_plus.ts
@@ -273,7 +273,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
     );
   }
 
-  max(): Promise<T | undefined>;
+  max(this: AsyncIteratorPlus<number>): Promise<T | undefined>;
   max(compareFn: (a: T, b: T) => MaybePromise<number>): Promise<T | undefined>;
   max(
     compareFn: (a: T, b: T) => MaybePromise<number> = (a, b) =>
@@ -286,7 +286,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
     return this.minBy(async (item) => -(await fn(item)));
   }
 
-  min(): Promise<T | undefined>;
+  min(this: AsyncIteratorPlus<number>): Promise<T | undefined>;
   min(compareFn: (a: T, b: T) => MaybePromise<number>): Promise<T | undefined>;
   async min(
     compareFn: (a: T, b: T) => MaybePromise<number> = (a, b) =>
@@ -373,9 +373,9 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
     return false;
   }
 
-  sum(): Promise<T extends number ? number : unknown>;
-  sum(fn: (item: T) => MaybePromise<number>): Promise<number>;
-  async sum(fn?: (item: T) => MaybePromise<number>): Promise<number | unknown> {
+  sum(this: AsyncIteratorPlus<number>): Promise<T>;
+  sum(fn: (item: T) => MaybePromise<number>): Promise<T>;
+  async sum(fn?: (item: T) => MaybePromise<number>): Promise<T | unknown> {
     let sum = 0;
     for await (const it of this.intoInner()) {
       sum += await (fn ? fn(it) : (it as unknown as number));

--- a/libs/basics/src/iterators/iterator_plus.test.ts
+++ b/libs/basics/src/iterators/iterator_plus.test.ts
@@ -1,5 +1,4 @@
 import * as fc from 'fast-check';
-import { typedAs } from '../typed_as';
 import { integers } from './integers';
 import { iter } from './iter';
 import { naturals } from './naturals';
@@ -390,9 +389,8 @@ test('min', () => {
     })
   );
 
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-expect-error
-  typedAs<number | undefined>(iter(['a']).min());
+  // @ts-expect-error - should be an array of numbers
+  iter(['a']).min();
 });
 
 test('minBy', () => {
@@ -417,6 +415,9 @@ test('max', () => {
       expect(iter(arr).max()).toEqual(Math.max(...arr));
     })
   );
+
+  // @ts-expect-error - should be an array of numbers
+  iter(['a']).max();
 });
 
 test('maxBy', () => {
@@ -439,6 +440,9 @@ test('sum', () => {
       expect(iter(arr).sum()).toEqual(arr.reduce((a, b) => a + b));
     })
   );
+
+  // @ts-expect-error - should be an array of numbers
+  iter(['a']).sum();
 });
 
 test('partition', () => {

--- a/libs/basics/src/iterators/iterator_plus.ts
+++ b/libs/basics/src/iterators/iterator_plus.ts
@@ -273,7 +273,7 @@ export class IteratorPlusImpl<T> implements IteratorPlus<T>, AsyncIterable<T> {
     );
   }
 
-  max(): T | undefined;
+  max(this: IteratorPlus<number>): T;
   max(compareFn: (a: T, b: T) => number): T | undefined;
   max(
     compareFn: (a: T, b: T) => number = (a, b) => (a < b ? -1 : a > b ? 1 : 0)
@@ -285,7 +285,7 @@ export class IteratorPlusImpl<T> implements IteratorPlus<T>, AsyncIterable<T> {
     return this.minBy((item) => -fn(item));
   }
 
-  min(): T extends number ? T | undefined : unknown;
+  min(this: IteratorPlus<number>): T;
   min(compareFn?: (a: T, b: T) => number): T | undefined;
   min(
     compareFn: (a: T, b: T) => number = (a, b) => (a < b ? -1 : a > b ? 1 : 0)
@@ -385,7 +385,7 @@ export class IteratorPlusImpl<T> implements IteratorPlus<T>, AsyncIterable<T> {
     return false;
   }
 
-  sum(): T extends number ? number : unknown;
+  sum(this: IteratorPlus<number>): T;
   sum(fn: (item: T) => number): number;
   sum(fn?: (item: T) => number): number | unknown {
     let sum = 0;

--- a/libs/basics/src/iterators/types.ts
+++ b/libs/basics/src/iterators/types.ts
@@ -303,7 +303,7 @@ export interface IteratorPlus<T> extends Iterable<T> {
    * expect(iter([]).max()).toBeUndefined();
    * ```
    */
-  max(): T | undefined;
+  max(this: IteratorPlus<number>): T | undefined;
 
   /**
    * Returns the maximum element of `this` or `undefined` if `this` is empty.
@@ -345,7 +345,7 @@ export interface IteratorPlus<T> extends Iterable<T> {
    * expect(iter([]).min()).toBeUndefined();
    * ```
    */
-  min(): T | undefined;
+  min(this: IteratorPlus<number>): T | undefined;
 
   /**
    * Returns the minimum element of `this` or `undefined` if `this` is empty.
@@ -468,7 +468,7 @@ export interface IteratorPlus<T> extends Iterable<T> {
    * expect(iter([1, 2, 3, 4, 5]).sum()).toEqual(15);
    * ```
    */
-  sum(): T extends number ? number : unknown;
+  sum(this: IteratorPlus<number>): T;
 
   /**
    * Sums elements from `this` using `fn` to transform each element. Consumes
@@ -1042,7 +1042,7 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
    *   .max();
    * ```
    */
-  max(): Promise<T | undefined>;
+  max(this: AsyncIteratorPlus<number>): Promise<T | undefined>;
 
   /**
    * Returns the maximum element of `this` or `undefined` if `this` is empty.
@@ -1067,10 +1067,22 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
 
   /**
    * Returns the minimum element of `this` or `undefined` if `this` is empty.
-   * Comparison happens using `compareFn` if provided, otherwise using `>` and
-   * `<`. Consumes the entire contained iterable.
+   * Consumes the entire contained iterable.
+   *
+   * @example
+   *
+   * ```ts
+   * expect(await iter([10, 40, 30]).async().min()).toEqual(10);
+   * expect(await iter([]).async().min()).toBeUndefined();
+   * ```
    */
-  min(compareFn?: (a: T, b: T) => MaybePromise<number>): Promise<T | undefined>;
+  min(this: AsyncIteratorPlus<number>): Promise<T | undefined>;
+
+  /**
+   * Returns the minimum element of `this` or `undefined` if `this` is empty.
+   * Comparison happens using `compareFn`. Consumes the entire contained iterable.
+   */
+  min(compareFn: (a: T, b: T) => MaybePromise<number>): Promise<T | undefined>;
 
   /**
    * Returns the element of `this` whose return value from `fn` is the minimum.
@@ -1178,7 +1190,7 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
    * ).sum();
    * ```
    */
-  sum(): Promise<T extends number ? number : unknown>;
+  sum(this: AsyncIteratorPlus<number>): Promise<T>;
 
   /**
    * Sums elements from `this` using `fn` to transform each element. Consumes
@@ -1192,7 +1204,7 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
    * const sum = await input.sum((line) => safeParseInt(line).ok() ?? 0);
    * ```
    */
-  sum(fn: (item: T) => MaybePromise<number>): Promise<number>;
+  sum(fn: (item: T) => MaybePromise<number>): Promise<T>;
 
   /**
    * Takes up to the first `count` elements from `iterable`.


### PR DESCRIPTION
## Overview
When it only makes sense to call certain `iter` methods based on the contained type `T`, the better approach is to use an explicit type for `this` in the method definition rather than a ternary type resulting in `unknown` when the type doesn't match. This way actually gives us TypeScript errors and is clearer.

## Demo Video or Screenshot
<img width="740" alt="image" src="https://github.com/user-attachments/assets/a8a6db20-aac6-4c92-b478-d1dbbe729bb4">

## Testing Plan
Automated testing, including new tests to ensure the error is triggered appropriately.