### PR TITLE
fix(backend): remove `console.log`

### DIFF
--- a/libs/backend/src/cast_vote_records/referenced_files.ts
+++ b/libs/backend/src/cast_vote_records/referenced_files.ts
@@ -55,14 +55,6 @@ function referencedFile(input: {
       }
 
       if (sha256(fileContents) !== input.expectedFileHash) {
-        console.log(
-          'filePath',
-          input.filePath,
-          'sha256(fileContents)',
-          sha256(fileContents),
-          'input.expectedFileHash',
-          input.expectedFileHash
-        );
         return err({
           type: 'invalid-cast-vote-record',
           subType: `incorrect-${input.fileType}-hash`,


### PR DESCRIPTION
This was accidentally added in https://github.com/votingworks/vxsuite/pull/5065.