### PR TITLE
Export images with write-ins on central scanner

### DIFF
--- a/libs/backend/src/cast_vote_records/export.test.ts
+++ b/libs/backend/src/cast_vote_records/export.test.ts
@@ -19,6 +19,7 @@ import {
 
 import {
   interpretedBmdBallot,
+  interpretedBmdBallotWithWriteIn,
   interpretedBmdPage,
   interpretedHmpb,
   interpretedHmpbPage1,
@@ -368,6 +369,31 @@ test.each<{
     ],
   },
   {
+    description:
+      'accepted BMD ballot with write in on central scanner, non-minimal export',
+    sheetGenerator: () =>
+      newAcceptedSheet(interpretedBmdBallotWithWriteIn, sheet1Id),
+    exportOptions: { scannerType: 'central', isMinimalExport: false },
+    expectedDirectoryContents: [
+      CastVoteRecordExportFileName.METADATA,
+      `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+      `${sheet1Id}/${sheet1Id}-front.jpg`,
+      `${sheet1Id}/${sheet1Id}-back.jpg`,
+    ],
+    expectedBallotImageField: [
+      {
+        '@type': 'CVR.ImageData',
+        Hash: anyCastVoteRecordHash,
+        Location: `file:${sheet1Id}-front.jpg`,
+      },
+      {
+        '@type': 'CVR.ImageData',
+        Hash: anyCastVoteRecordHash,
+        Location: `file:${sheet1Id}-back.jpg`,
+      },
+    ],
+  },
+  {
     description: 'accepted BMD ballot on central scanner, minimal export',
     sheetGenerator: () => newAcceptedSheet(interpretedBmdBallot, sheet1Id),
     exportOptions: { scannerType: 'central', isMinimalExport: true },
@@ -376,6 +402,31 @@ test.each<{
       `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
     ],
     expectedBallotImageField: undefined,
+  },
+  {
+    description:
+      'accepted BMD ballot with write in on central scanner, minimal export',
+    sheetGenerator: () =>
+      newAcceptedSheet(interpretedBmdBallotWithWriteIn, sheet1Id),
+    exportOptions: { scannerType: 'central', isMinimalExport: true },
+    expectedDirectoryContents: [
+      CastVoteRecordExportFileName.METADATA,
+      `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+      `${sheet1Id}/${sheet1Id}-front.jpg`,
+      `${sheet1Id}/${sheet1Id}-back.jpg`,
+    ],
+    expectedBallotImageField: [
+      {
+        '@type': 'CVR.ImageData',
+        Hash: anyCastVoteRecordHash,
+        Location: `file:${sheet1Id}-front.jpg`,
+      },
+      {
+        '@type': 'CVR.ImageData',
+        Hash: anyCastVoteRecordHash,
+        Location: `file:${sheet1Id}-back.jpg`,
+      },
+    ],
   },
   {
     description: 'rejected sheet on precinct scanner',

--- a/libs/backend/src/cast_vote_records/export.ts
+++ b/libs/backend/src/cast_vote_records/export.ts
@@ -215,11 +215,14 @@ function shouldIncludeImagesInMinimalExport(
   canonicalizedSheet: CanonicalizedSheet
 ): boolean {
   return (
-    canonicalizedSheet.type === 'hmpb' &&
-    canonicalizedSheet.interpretation.some(
-      ({ votes, unmarkedWriteIns }) =>
-        hasWriteIns(votes) || (unmarkedWriteIns && unmarkedWriteIns.length > 0)
-    )
+    (canonicalizedSheet.type === 'hmpb' &&
+      canonicalizedSheet.interpretation.some(
+        ({ votes, unmarkedWriteIns }) =>
+          hasWriteIns(votes) ||
+          (unmarkedWriteIns && unmarkedWriteIns.length > 0)
+      )) ||
+    (canonicalizedSheet.type === 'bmd' &&
+      hasWriteIns(canonicalizedSheet.interpretation.votes))
   );
 }
 

--- a/libs/backend/test/fixtures/interpretations.ts
+++ b/libs/backend/test/fixtures/interpretations.ts
@@ -184,6 +184,17 @@ export const interpretedBmdPage: InterpretedBmdPage = {
   },
 };
 
+export const interpretedBmdPageWithWriteIn: InterpretedBmdPage = {
+  type: 'InterpretedBmdPage',
+  metadata: mockBallotMetadata,
+  votes: {
+    [fishingContest.id]: [fishingContest.noOption.id],
+    [fishCouncilContest.id]: [
+      { id: 'write-in-1', name: 'Write In #1', isWriteIn: true },
+    ],
+  },
+};
+
 export const interpretedHmpbPage1WithWriteIn: InterpretedHmpbPage = {
   ...interpretedHmpbPage1,
   votes: {
@@ -217,6 +228,11 @@ export const interpretedHmpb: SheetOf<PageInterpretation> = [
 
 export const interpretedBmdBallot: SheetOf<PageInterpretation> = [
   interpretedBmdPage,
+  blankPage,
+];
+
+export const interpretedBmdBallotWithWriteIn: SheetOf<PageInterpretation> = [
+  interpretedBmdPageWithWriteIn,
   blankPage,
 ];
 


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/5100
Includes images for BMD ballots with write in when exporting from a central scan minimal export (i.e. a regular cvr save, non-minimal is when you save backup) 

<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot

## Testing Plan
Ran tests
Tested on VxDev through central scan and admin import and viewed images in WIA 

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
