### PR TITLE
read FAI 100 PAT status

### DIFF
--- a/apps/mark-scan/backend/src/app.diagnostics.test.ts
+++ b/apps/mark-scan/backend/src/app.diagnostics.test.ts
@@ -7,6 +7,7 @@ import * as grout from '@votingworks/grout';
 import { Server } from 'http';
 import { LogEventId, Logger } from '@votingworks/logging';
 import { mockOf } from '@votingworks/test-utils';
+import tmp from 'tmp';
 import {
   BallotId,
   BallotType,
@@ -102,7 +103,13 @@ beforeEach(async () => {
     BooleanEnvironmentVariableName.SKIP_ELECTION_PACKAGE_AUTHENTICATION
   );
 
-  patConnectionStatusReader = new PatConnectionStatusReader(logger);
+  const mockWorkspaceDir = tmp.dirSync();
+
+  patConnectionStatusReader = new PatConnectionStatusReader(
+    logger,
+    'bmd-150',
+    mockWorkspaceDir.name
+  );
   mockOf(patConnectionStatusReader.isPatDeviceConnected).mockResolvedValue(
     false
   );
@@ -225,6 +232,7 @@ test('saving the readiness report', async () => {
   const exportPath = exportResult.ok()![0];
   await expect(exportPath).toMatchPdfSnapshot({
     customSnapshotIdentifier: 'readiness-report',
+    failureThreshold: 0.001,
   });
 
   const pdfContents = await pdfToText(exportPath);

--- a/apps/mark-scan/backend/src/app.test.ts
+++ b/apps/mark-scan/backend/src/app.test.ts
@@ -83,7 +83,12 @@ beforeEach(async () => {
     BooleanEnvironmentVariableName.MARK_SCAN_DISABLE_BALLOT_REINSERTION
   );
 
-  patConnectionStatusReader = new PatConnectionStatusReader(logger);
+  const mockWorkspaceDir = tmp.dirSync();
+  patConnectionStatusReader = new PatConnectionStatusReader(
+    logger,
+    'bmd-150',
+    mockWorkspaceDir.name
+  );
   mockOf(patConnectionStatusReader.isPatDeviceConnected).mockResolvedValue(
     false
   );

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -183,7 +183,11 @@ beforeEach(async () => {
   );
   driver = new MockPaperHandlerDriver();
 
-  patConnectionStatusReader = new PatConnectionStatusReader(logger);
+  patConnectionStatusReader = new PatConnectionStatusReader(
+    logger,
+    'bmd-150',
+    workspace.path
+  );
   mockOf(patConnectionStatusReader.open).mockResolvedValue(true);
   mockOf(patConnectionStatusReader.isPatDeviceConnected).mockResolvedValue(
     false

--- a/apps/mark-scan/backend/src/globals.ts
+++ b/apps/mark-scan/backend/src/globals.ts
@@ -24,7 +24,7 @@ export const NODE_ENV = unsafeParse(
 );
 
 /**
- * Where should the database and audio files go?
+ * Where should the database, audio, and hardware status files go?
  */
 export const MARK_SCAN_WORKSPACE =
   process.env.MARK_SCAN_WORKSPACE ??

--- a/apps/mark-scan/backend/src/pat-input/connection_status_reader.test.ts
+++ b/apps/mark-scan/backend/src/pat-input/connection_status_reader.test.ts
@@ -3,22 +3,35 @@ import tmp from 'tmp';
 import * as fs from 'fs/promises';
 import { Buffer } from 'buffer';
 import { PatConnectionStatusReader } from './connection_status_reader';
+import { FAI_100_STATUS_FILENAME } from './constants';
 
 const ASCII_ZERO = 48;
 const ASCII_ONE = 49;
 
 let logger: BaseLogger;
+let mockWorkspaceDir: tmp.DirResult;
 // Replaces /sys/class/gpio
 let mockGpioDir: tmp.DirResult;
 tmp.setGracefulCleanup();
 
+function expectedStatusToAsciiChar(expectedStatus: boolean) {
+  // Value file contains '0' when device is connected and '1' when not connected
+  return expectedStatus ? ASCII_ZERO : ASCII_ONE;
+}
+
 beforeEach(() => {
+  mockWorkspaceDir = tmp.dirSync();
   mockGpioDir = tmp.dirSync();
   logger = mockBaseLogger();
 });
 
 test('logs when it cannot access the gpio pin sysfs file', async () => {
-  const reader = new PatConnectionStatusReader(logger, mockGpioDir.name);
+  const reader = new PatConnectionStatusReader(
+    logger,
+    'bmd-155',
+    mockWorkspaceDir.name,
+    mockGpioDir.name
+  );
 
   const result = await reader.open();
   expect(logger.log).toHaveBeenCalledWith(
@@ -36,17 +49,34 @@ test('logs when it cannot access the gpio pin sysfs file', async () => {
   await reader.close();
 });
 
+test('bmd-150 implementation', async () => {
+  const statusFile = tmp.fileSync({
+    tmpdir: mockWorkspaceDir.name,
+    name: FAI_100_STATUS_FILENAME,
+  });
+
+  const expectedConnectionStatus = true;
+  const buf = Buffer.of(expectedStatusToAsciiChar(expectedConnectionStatus));
+  await fs.appendFile(statusFile.name, buf);
+
+  const reader = new PatConnectionStatusReader(
+    logger,
+    'bmd-150',
+    mockWorkspaceDir.name
+  );
+  const result = await reader.open();
+  expect(result).toEqual(true);
+  const isConnected = await reader.isPatDeviceConnected();
+  expect(isConnected).toEqual(expectedConnectionStatus);
+  await reader.close();
+});
+
 const pinAddresses = [
   { address: 478, expectedConnectionStatus: true },
   { address: 478, expectedConnectionStatus: false },
   { address: 990, expectedConnectionStatus: true },
   { address: 990, expectedConnectionStatus: false },
 ];
-
-function expectedStatusToAsciiChar(expectedStatus: boolean) {
-  // Value file contains '0' when device is connected and '1' when not connected
-  return expectedStatus ? ASCII_ZERO : ASCII_ONE;
-}
 
 test.each(pinAddresses)(
   'isPatDeviceConnected can read "$expectedConnectionStatus" from pin $address value file',
@@ -67,7 +97,12 @@ test.each(pinAddresses)(
     const buf = Buffer.of(expectedStatusToAsciiChar(expectedConnectionStatus));
     await fs.appendFile(valueFile.name, buf);
 
-    const reader = new PatConnectionStatusReader(logger, mockGpioDir.name);
+    const reader = new PatConnectionStatusReader(
+      logger,
+      'bmd-155',
+      mockWorkspaceDir.name,
+      mockGpioDir.name
+    );
     const result = await reader.open();
     expect(result).toEqual(true);
     const isConnected = await reader.isPatDeviceConnected();

--- a/apps/mark-scan/backend/src/pat-input/connection_status_reader.ts
+++ b/apps/mark-scan/backend/src/pat-input/connection_status_reader.ts
@@ -88,7 +88,7 @@ export class PatConnectionStatusReader
     const path = join(this.workspacePath, FAI_100_STATUS_FILENAME);
     const openResult = await fsOpen(path);
     if (openResult.isErr()) {
-      await this.logger.log(LogEventId.ConnectToGpioPinComplete, 'system', {
+      await this.logger.log(LogEventId.ConnectToPatInputComplete, 'system', {
         message: `Unexpected error trying to open ${path}. Is fai_100_controllerd running?`,
         disposition: 'failure',
       });
@@ -109,7 +109,9 @@ export class PatConnectionStatusReader
         return this.openBmd150();
       case 'bmd-155':
         return this.openBmd155();
+      // istanbul ignore next - unreachable because BmdModelNumber coverage is exhaustive
       default:
+        // istanbul ignore next
         throw new Error(`Unhandled BMD model ${this.bmdModelNumber}`);
     }
   }

--- a/apps/mark-scan/backend/src/pat-input/connection_status_reader.ts
+++ b/apps/mark-scan/backend/src/pat-input/connection_status_reader.ts
@@ -8,10 +8,12 @@ import { Buffer } from 'buffer';
 import { LogEventId, BaseLogger } from '@votingworks/logging';
 import { join } from 'path';
 import {
+  FAI_100_STATUS_FILENAME,
   GPIO_PATH_PREFIX,
   PAT_CONNECTION_STATUS_PIN,
   PAT_GPIO_OFFSET,
 } from './constants';
+import { BmdModelNumber } from '../types';
 
 export interface PatConnectionStatusReaderInterface {
   readonly logger: BaseLogger;
@@ -28,10 +30,12 @@ export class PatConnectionStatusReader
 
   constructor(
     readonly logger: BaseLogger,
+    readonly bmdModelNumber: BmdModelNumber,
+    readonly workspacePath: string,
     readonly gpioPathPrefix: string = GPIO_PATH_PREFIX
   ) {}
 
-  async open(): Promise<boolean> {
+  async openBmd155(): Promise<boolean> {
     await this.logger.log(LogEventId.ConnectToPatInputInit, 'system');
 
     const possiblePinAddresses = [
@@ -74,6 +78,40 @@ export class PatConnectionStatusReader
     });
     this.file = pinFileHandle;
     return true;
+  }
+
+  async openBmd150(): Promise<boolean> {
+    await this.logger.log(LogEventId.ConnectToPatInputInit, 'system');
+    await this.logger.log(LogEventId.ConnectToPatInputComplete, 'system', {
+      disposition: 'success',
+    });
+    const path = join(this.workspacePath, FAI_100_STATUS_FILENAME);
+    const openResult = await fsOpen(path);
+    if (openResult.isErr()) {
+      await this.logger.log(LogEventId.ConnectToGpioPinComplete, 'system', {
+        message: `Unexpected error trying to open ${path}. Is fai_100_controllerd running?`,
+        disposition: 'failure',
+      });
+
+      return false;
+    }
+
+    this.file = openResult.ok();
+    await this.logger.log(LogEventId.ConnectToPatInputComplete, 'system', {
+      disposition: 'success',
+    });
+    return true;
+  }
+
+  async open(): Promise<boolean> {
+    switch (this.bmdModelNumber) {
+      case 'bmd-150':
+        return this.openBmd150();
+      case 'bmd-155':
+        return this.openBmd155();
+      default:
+        throw new Error(`Unhandled BMD model ${this.bmdModelNumber}`);
+    }
   }
 
   async close(): Promise<void> {

--- a/apps/mark-scan/backend/src/pat-input/constants.ts
+++ b/apps/mark-scan/backend/src/pat-input/constants.ts
@@ -9,3 +9,4 @@ export const PAT_CONNECTION_STATUS_PIN = 478;
 export const PAT_GPIO_OFFSET = 512;
 
 export const GPIO_PATH_PREFIX = '/sys/class/gpio';
+export const FAI_100_STATUS_FILENAME = '_pat_connection.status';

--- a/apps/mark-scan/backend/src/server.ts
+++ b/apps/mark-scan/backend/src/server.ts
@@ -85,7 +85,11 @@ export async function start({
   );
   const driver = await resolveDriver(logger);
   let patConnectionStatusReader: PatConnectionStatusReaderInterface =
-    new PatConnectionStatusReader(logger);
+    new PatConnectionStatusReader(
+      logger,
+      getMarkScanBmdModel(),
+      workspace.path
+    );
   const canReadPatConnectionStatus = await patConnectionStatusReader.open();
 
   if (!canReadPatConnectionStatus) {


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/4961

Updates the mark-scan backend to read from the status file that the FAI 100 daemon writes to in [this change](https://github.com/votingworks/vxsuite/pull/4986/files#diff-c62233c817bd6e84b930c564731636d8f243fd9630683a4f112cfdcfeba53b6aR65).

The format of this file is the same as the BMD 155 implementation: a single ASCII character `0` or `1` indicating connection status of a PAT device. `0` means device is connected, `1` means no device is connected. This is the interface defined by the BMD 155 GPIO sysfiles so I kept it consistent despite the divergence from typical boolean values.

VxMarkScan uses this value to know whether a PAT device is connected and by extension when to launch the PAT calibration flow for voters or during the system diagnostic.

## Demo Video or Screenshot
N/A

## Testing Plan
- added tests
- manually verified PAT connection status works on BMD 150 hardware

## Checklist
N/A no user facing change

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
