### PR TITLE
dev-dock: Delay before screenshotting to ensure dev dock is hidden

### DIFF
--- a/libs/dev-dock/frontend/src/dev_dock.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.tsx
@@ -12,6 +12,7 @@ import * as grout from '@votingworks/grout';
 import {
   assert,
   assertDefined,
+  sleep,
   throwIllegalValue,
   uniqueBy,
 } from '@votingworks/basics';
@@ -426,6 +427,7 @@ function ScreenshotControls({
     assert(containerRef.current);
     // eslint-disable-next-line no-param-reassign
     containerRef.current.style.visibility = 'hidden';
+    await sleep(500);
 
     assert(window.kiosk);
     const screenshotData = await window.kiosk.captureScreenshot();


### PR DESCRIPTION
## Overview

I noticed that most of the time, the dev dock wasn't actually hidden fast enough to be excluded from the screenshot, so just added a little delay.

## Demo Video or Screenshot

## Testing Plan
Manually tested

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
