### PR TITLE
apps/admin: Format election date with full month name

### DIFF
--- a/apps/admin/frontend/jest.config.js
+++ b/apps/admin/frontend/jest.config.js
@@ -16,7 +16,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: -103,
-      lines: -96,
+      lines: -95,
     },
   },
   moduleFileExtensions: [

--- a/apps/admin/frontend/src/screens/election_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/election_screen.test.tsx
@@ -1,0 +1,79 @@
+import { electionGeneralDefinition } from '@votingworks/fixtures';
+import {
+  mockSystemAdministratorUser,
+  mockSessionExpiresAt,
+  mockElectionManagerUser,
+} from '@votingworks/test-utils';
+import { constructElectionKey, DippedSmartCardAuth } from '@votingworks/types';
+import { ApiMock, createApiMock } from '../../test/helpers/mock_api_client';
+import { renderInAppContext } from '../../test/render_in_app_context';
+import { screen } from '../../test/react_testing_library';
+import { ElectionScreen } from './election_screen';
+
+const electionDefinition = electionGeneralDefinition;
+const { election } = electionDefinition;
+
+let apiMock: ApiMock;
+
+beforeEach(() => {
+  jest.useFakeTimers().setSystemTime(new Date('2022-06-22T00:00:00.000'));
+  apiMock = createApiMock();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  apiMock.assertComplete();
+});
+
+describe('as System Admin', () => {
+  const auth: DippedSmartCardAuth.SystemAdministratorLoggedIn = {
+    status: 'logged_in',
+    user: mockSystemAdministratorUser(),
+    sessionExpiresAt: mockSessionExpiresAt(),
+    programmableCard: { status: 'no_card' },
+  };
+
+  test('renders election details', () => {
+    renderInAppContext(<ElectionScreen />, {
+      apiMock,
+      auth,
+      electionDefinition,
+    });
+
+    screen.getByText(
+      'Configured with the current election at Wednesday, June 22, 2022 at 12:00:00 AM AKDT.'
+    );
+    screen.getByRole('heading', { name: election.title });
+    screen.getByText(new RegExp(`${election.county.name}, ${election.state}`));
+    screen.getByText('November 3, 2020');
+
+    screen.getButton('Unconfigure Machine');
+  });
+});
+
+describe('as Election Manager', () => {
+  const auth: DippedSmartCardAuth.ElectionManagerLoggedIn = {
+    status: 'logged_in',
+    user: mockElectionManagerUser({
+      electionKey: constructElectionKey(election),
+    }),
+    sessionExpiresAt: mockSessionExpiresAt(),
+  };
+
+  test('renders election details', () => {
+    renderInAppContext(<ElectionScreen />, {
+      apiMock,
+      auth,
+      electionDefinition,
+    });
+
+    screen.getByText(
+      'Configured with the current election at Wednesday, June 22, 2022 at 12:00:00 AM AKDT.'
+    );
+    screen.getByRole('heading', { name: election.title });
+    screen.getByText(new RegExp(`${election.county.name}, ${election.state}`));
+    screen.getByText('November 3, 2020');
+
+    screen.getButton('Save Election Package');
+  });
+});

--- a/apps/admin/frontend/src/screens/election_screen.tsx
+++ b/apps/admin/frontend/src/screens/election_screen.tsx
@@ -1,24 +1,14 @@
 import React, { useContext } from 'react';
 import styled from 'styled-components';
-
 import {
   format,
   isElectionManagerAuth,
   isSystemAdministratorAuth,
 } from '@votingworks/utils';
 import { assert } from '@votingworks/basics';
-
-import {
-  Card,
-  Font,
-  H2,
-  P,
-  Seal,
-  UnconfigureMachineButton,
-} from '@votingworks/ui';
+import { Card, H2, P, Seal, UnconfigureMachineButton } from '@votingworks/ui';
 import { useHistory } from 'react-router-dom';
 import { AppContext } from '../contexts/app_context';
-
 import { NavigationScreen } from '../components/navigation_screen';
 import { ExportElectionPackageModalButton } from '../components/export_election_package_modal_button';
 import { unconfigure } from '../api';
@@ -56,10 +46,7 @@ export function ElectionScreen(): JSX.Element {
     <NavigationScreen title="Election">
       <P>
         Configured with the current election at{' '}
-        <Font weight="bold">
-          {format.localeLongDateAndTime(new Date(configuredAt))}
-        </Font>
-        .
+        {format.localeLongDateAndTime(new Date(configuredAt))}.
       </P>
       <ElectionCard>
         <Seal seal={election.seal} maxWidth="7rem" />
@@ -68,7 +55,7 @@ export function ElectionScreen(): JSX.Element {
           <P>
             {election.county.name}, {election.state}
             <br />
-            {format.localeDate(
+            {format.localeLongDate(
               election.date.toMidnightDatetimeWithSystemTimezone()
             )}
           </P>


### PR DESCRIPTION


## Overview

I noticed that we were accidentally showing the abbreviated election date month name, which was unnecessary since there's plenty of space to show the full month name. Also deemphasized the configuration timestamp since it's not as important.

## Demo Video or Screenshot
Before
![Screenshot-VxAdmin-2024-07-25T20:38:39 469Z](https://github.com/user-attachments/assets/625854ac-ccd6-4a70-a294-6c73a32f981b)

After
![Screenshot-VxAdmin-2024-07-25T20:41:03 801Z](https://github.com/user-attachments/assets/1bf68a4f-666b-4f74-8fa5-19c3ee17d6ee)


## Testing Plan
Added new tests for election screen component

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
