### PR TITLE
comment on overflow when using exactly 8in width

### DIFF
--- a/libs/printing/src/render.tsx
+++ b/libs/printing/src/render.tsx
@@ -20,6 +20,8 @@ export interface PaperDimensions {
 }
 
 export const PAPER_DIMENSIONS = {
+  // Width of exactly 8in results in 1-3 dots of overflow. The overflowing dots print on a line of
+  // their own, followed by a mostly blank line. This causes stripes in the printed page.
   Bmd150: { width: 7.975, height: 13.25 },
   Letter: { width: 8.5, height: 11 },
   LetterRoll: { width: 8.5, height: Infinity },

--- a/libs/ui/src/bmd_paper_ballot.tsx
+++ b/libs/ui/src/bmd_paper_ballot.tsx
@@ -173,6 +173,8 @@ const Ballot = styled.div<BallotProps>`
       switch (props.sheetSize) {
         /* istanbul ignore next - hardware specs still in flux */
         case 'bmd150':
+          // Width of exactly 8in results in 1-3 dots of overflow. The overflowing dots print on a line of
+          // their own, followed by a mostly blank line. This causes stripes in the printed page.
           /* istanbul ignore next - hardware specs still in flux */
           return '7.975in 13.25in';
         case 'letter':


### PR DESCRIPTION
## Overview
Adds a comment explaining dot overflow when printing at exactly 8".

## Demo Video or Screenshot
N/A

## Testing Plan
N/A

## Checklist
N/A not user facing

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
