### PR TITLE
Use PID file for controller connection status

### DIFF
--- a/apps/mark-scan/backend/src/app.diagnostics.test.ts
+++ b/apps/mark-scan/backend/src/app.diagnostics.test.ts
@@ -242,7 +242,7 @@ test('saving the readiness report', async () => {
   expect(pdfContents).toContain('Battery Level: 50%');
   expect(pdfContents).toContain('Power Source: External Power Supply');
   expect(pdfContents).toContain('Free Disk Space: 90% (9 GB / 10 GB)');
-  expect(pdfContents).toContain('Detected');
+  expect(pdfContents).toContain('Connected');
 
   mockUsbDrive.removeUsbDrive();
 });

--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -393,7 +393,7 @@ export function buildApi(
     },
 
     getIsAccessibleControllerInputDetected(): Promise<boolean> {
-      return isAccessibleControllerDaemonRunning();
+      return isAccessibleControllerDaemonRunning(workspace.path, logger);
     },
 
     saveReadinessReport(): Promise<ExportDataResult> {

--- a/apps/mark-scan/backend/src/readiness_report.ts
+++ b/apps/mark-scan/backend/src/readiness_report.ts
@@ -39,7 +39,10 @@ export async function saveReadinessReport({
       /* istanbul ignore next */ (await getBatteryInfo()) ?? undefined,
     diskSpaceSummary: await workspace.getDiskSpaceSummary(),
     accessibleControllerProps: {
-      isDeviceConnected: await isAccessibleControllerDaemonRunning(),
+      isDeviceConnected: await isAccessibleControllerDaemonRunning(
+        workspace.path,
+        logger
+      ),
       mostRecentDiagnosticRecord: store.getMostRecentDiagnosticRecord(
         'mark-scan-accessible-controller'
       ),

--- a/apps/mark-scan/backend/src/util/hardware.test.ts
+++ b/apps/mark-scan/backend/src/util/hardware.test.ts
@@ -1,5 +1,5 @@
 import { mockOf } from '@votingworks/test-utils';
-import { execFile } from '@votingworks/backend';
+import { exec } from '@votingworks/backend';
 import {
   BooleanEnvironmentVariableName,
   getFeatureFlagMock,
@@ -19,7 +19,7 @@ jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
   };
 });
 
-const execFileMock = mockOf(execFile);
+const execMock = mockOf(exec);
 
 afterEach(() => {
   featureFlagMock.resetFeatureFlags();
@@ -38,7 +38,7 @@ test('when bmd-150 flag is off', () => {
 });
 
 test('when virtual device detected', async () => {
-  execFileMock.mockResolvedValueOnce({
+  execMock.mockResolvedValueOnce({
     stdout: 'does not matter',
     stderr: '',
   });
@@ -47,7 +47,7 @@ test('when virtual device detected', async () => {
 });
 
 test('when virtual device not detected', async () => {
-  execFileMock.mockRejectedValueOnce({
+  execMock.mockRejectedValueOnce({
     stdout: 'does not matter',
     stderr: '',
   });

--- a/apps/mark-scan/backend/src/util/hardware.test.ts
+++ b/apps/mark-scan/backend/src/util/hardware.test.ts
@@ -1,12 +1,16 @@
-import { mockOf } from '@votingworks/test-utils';
-import { exec } from '@votingworks/backend';
 import {
   BooleanEnvironmentVariableName,
   getFeatureFlagMock,
 } from '@votingworks/utils';
+import tmp from 'tmp';
+import fs from 'fs';
+import { Buffer } from 'buffer';
+import { LogEventId, Logger, mockLogger } from '@votingworks/logging';
+import { join } from 'path';
 import {
   getMarkScanBmdModel,
   isAccessibleControllerDaemonRunning,
+  PID_FILENAME,
 } from './hardware';
 
 jest.mock('@votingworks/backend');
@@ -19,10 +23,32 @@ jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
   };
 });
 
-const execMock = mockOf(exec);
+let workspaceDir: tmp.DirResult;
+const MOCK_PID = 12345;
+let processKillSpy: jest.SpyInstance;
+let logger: Logger;
+let tmpFile: tmp.FileResult;
+
+beforeEach(() => {
+  workspaceDir = tmp.dirSync();
+  tmpFile = tmp.fileSync({ name: PID_FILENAME, dir: workspaceDir.name });
+  logger = mockLogger();
+
+  processKillSpy = jest.spyOn(process, 'kill').mockImplementation((pid) => {
+    if (pid === MOCK_PID) {
+      return true;
+    }
+
+    const err = new Error('No such process') as NodeJS.ErrnoException;
+    err.code = 'ESRCH';
+    throw err;
+  });
+});
 
 afterEach(() => {
   featureFlagMock.resetFeatureFlags();
+  processKillSpy.mockClear();
+  tmpFile.removeCallback();
 });
 
 test('when bmd-150 flag is on', () => {
@@ -37,20 +63,84 @@ test('when bmd-150 flag is off', () => {
   expect(getMarkScanBmdModel()).toEqual('bmd-155');
 });
 
-test('when virtual device detected', async () => {
-  execMock.mockResolvedValueOnce({
-    stdout: 'does not matter',
-    stderr: '',
-  });
-
-  expect(await isAccessibleControllerDaemonRunning()).toEqual(true);
+test('when daemon PID is running', async () => {
+  const pidStr = MOCK_PID.toString();
+  fs.writeSync(tmpFile.fd, Buffer.from(pidStr), 0, pidStr.length, 0);
+  expect(
+    await isAccessibleControllerDaemonRunning(workspaceDir.name, logger)
+  ).toEqual(true);
+  expect(logger.log).not.toHaveBeenCalled();
 });
 
-test('when virtual device not detected', async () => {
-  execMock.mockRejectedValueOnce({
-    stdout: 'does not matter',
-    stderr: '',
+test('when daemon PID is not running', async () => {
+  const wrongPidStr = '98765';
+  fs.writeSync(tmpFile.fd, Buffer.from(wrongPidStr), 0, wrongPidStr.length, 0);
+  expect(
+    await isAccessibleControllerDaemonRunning(workspaceDir.name, logger)
+  ).toEqual(false);
+  expect(logger.log).toHaveBeenCalledWith(LogEventId.NoPid, 'system', {
+    message: `Process with PID ${wrongPidStr} is not running`,
+  });
+});
+
+test('permission denied', async () => {
+  processKillSpy.mockClear();
+  processKillSpy = jest.spyOn(process, 'kill').mockImplementation(() => {
+    const err = new Error('Permission denied') as NodeJS.ErrnoException;
+    err.code = 'EPERM';
+    throw err;
   });
 
-  expect(await isAccessibleControllerDaemonRunning()).toEqual(false);
+  expect(
+    await isAccessibleControllerDaemonRunning(workspaceDir.name, logger)
+  ).toEqual(false);
+  expect(logger.log).toHaveBeenCalledWith(
+    LogEventId.PermissionDenied,
+    'system',
+    {
+      message: 'Permission denied to check PID',
+    }
+  );
+});
+
+test('unknown error', async () => {
+  processKillSpy.mockClear();
+  processKillSpy = jest.spyOn(process, 'kill').mockImplementation(() => {
+    const err = new Error('Other error') as NodeJS.ErrnoException;
+    err.code = 'something else';
+    throw err;
+  });
+
+  expect(
+    await isAccessibleControllerDaemonRunning(workspaceDir.name, logger)
+  ).toEqual(false);
+  expect(logger.log).toHaveBeenCalledWith(LogEventId.UnknownError, 'system', {
+    message: 'Unknown error when checking PID',
+    error: expect.anything(),
+  });
+});
+
+test('when PID file does not exist', async () => {
+  expect(
+    await isAccessibleControllerDaemonRunning(
+      join(__dirname, 'not-a-real-dir'),
+      logger
+    )
+  ).toEqual(false);
+  expect(logger.log).toHaveBeenCalledWith(LogEventId.NoPid, 'system', {
+    message: 'Unable to read accessible controller daemon PID file',
+    error: expect.anything(),
+  });
+});
+
+test('when reported PID is not a number', async () => {
+  const wrongPidStr = 'not a number';
+  fs.writeSync(tmpFile.fd, Buffer.from(wrongPidStr), 0, wrongPidStr.length, 0);
+
+  expect(
+    await isAccessibleControllerDaemonRunning(workspaceDir.name, logger)
+  ).toEqual(false);
+  expect(logger.log).toHaveBeenCalledWith(LogEventId.ParseError, 'system', {
+    message: `Unable to parse accessible controller daemon PID: ${wrongPidStr}`,
+  });
 });

--- a/apps/mark-scan/backend/src/util/hardware.ts
+++ b/apps/mark-scan/backend/src/util/hardware.ts
@@ -2,8 +2,14 @@ import {
   BooleanEnvironmentVariableName,
   isFeatureFlagEnabled,
 } from '@votingworks/utils';
-import { exec } from '@votingworks/backend';
+import { join } from 'path';
+import { readFile } from '@votingworks/fs';
+import { safeParseInt } from '@votingworks/types';
+import { LogEventId, Logger } from '@votingworks/logging';
 import { BmdModelNumber } from '../types';
+
+export const PID_FILENAME = 'vx_accessible_controller_daemon.pid';
+const MAX_FILE_SIZE_BYTES = 50 * 1024;
 
 export function getMarkScanBmdModel(): BmdModelNumber {
   return isFeatureFlagEnabled(
@@ -13,12 +19,56 @@ export function getMarkScanBmdModel(): BmdModelNumber {
     : 'bmd-155';
 }
 
-export async function isAccessibleControllerDaemonRunning(): Promise<boolean> {
-  try {
-    // Use exec instead of execFile because the latter doesn't support pipes
-    await exec('exec ps aux | grep controller[d]');
-    return true;
-  } catch {
+export async function isAccessibleControllerDaemonRunning(
+  workspacePath: string,
+  logger: Logger
+): Promise<boolean> {
+  const readResult = await readFile(join(workspacePath, PID_FILENAME), {
+    maxSize: MAX_FILE_SIZE_BYTES,
+    encoding: 'utf-8',
+  });
+
+  if (readResult.isErr()) {
+    await logger.log(LogEventId.NoPid, 'system', {
+      message: 'Unable to read accessible controller daemon PID file',
+      error: JSON.stringify(readResult.err()),
+    });
     return false;
+  }
+
+  const pidString = readResult.ok();
+  const pidResult = safeParseInt(pidString);
+  if (pidResult.isErr()) {
+    await logger.log(LogEventId.ParseError, 'system', {
+      message: `Unable to parse accessible controller daemon PID: ${pidString}`,
+    });
+    return false;
+  }
+
+  const pid = pidResult.ok();
+
+  try {
+    // Check if the process is running by sending signal 0
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    switch ((error as NodeJS.ErrnoException).code) {
+      case 'ESRCH':
+        await logger.log(LogEventId.NoPid, 'system', {
+          message: `Process with PID ${pid} is not running`,
+        });
+        return false;
+      case 'EPERM':
+        await logger.log(LogEventId.PermissionDenied, 'system', {
+          message: 'Permission denied to check PID',
+        });
+        return false;
+      default:
+        await logger.log(LogEventId.UnknownError, 'system', {
+          message: 'Unknown error when checking PID',
+          error: JSON.stringify(error),
+        });
+        return false;
+    }
   }
 }

--- a/apps/mark-scan/backend/src/util/hardware.ts
+++ b/apps/mark-scan/backend/src/util/hardware.ts
@@ -1,8 +1,8 @@
-import { execFile } from '@votingworks/backend';
 import {
   BooleanEnvironmentVariableName,
   isFeatureFlagEnabled,
 } from '@votingworks/utils';
+import { exec } from '@votingworks/backend';
 import { BmdModelNumber } from '../types';
 
 export function getMarkScanBmdModel(): BmdModelNumber {
@@ -15,7 +15,8 @@ export function getMarkScanBmdModel(): BmdModelNumber {
 
 export async function isAccessibleControllerDaemonRunning(): Promise<boolean> {
   try {
-    await execFile('exec ps aux | grep controller[d]');
+    // Use exec instead of execFile because the latter doesn't support pipes
+    await exec('exec ps aux | grep controller[d]');
     return true;
   } catch {
     return false;

--- a/apps/mark-scan/daemon-utils/src/lib.rs
+++ b/apps/mark-scan/daemon-utils/src/lib.rs
@@ -1,4 +1,8 @@
 use std::{
+    fs::OpenOptions,
+    io::{self, Write},
+    path::Path,
+    process,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -40,4 +44,19 @@ pub fn run_no_op_event_loop(running: &Arc<AtomicBool>) {
         // without spamming heartbeat logs
         sleep(NOOP_LOOP_INTERVAL);
     }
+}
+
+/// Writes a PID file containing the daemon's process ID to be checked by the mark-scan app.
+/// # Errors
+/// Bubbles up any `io::Error` resulting from opening or writing PID file.
+pub fn write_pid_file(workspace_path: &Path, pid_filename: &str) -> Result<(), io::Error> {
+    let pid = process::id();
+
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(workspace_path.join(pid_filename))?;
+
+    file.write_all(pid.to_string().as_bytes())
 }

--- a/apps/mark-scan/fai-100-controller/src/fai_100_controllerd.rs
+++ b/apps/mark-scan/fai-100-controller/src/fai_100_controllerd.rs
@@ -37,7 +37,7 @@ const APP_NAME: &str = "vx-mark-scan-fai-100-controller-daemon";
 const FAI_100_VID: u16 = 0x28cd;
 const FAI_100_PID: u16 = 0x4002;
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
-const EVENT_LOOP_LOG_INTERVAL: Duration = Duration::from_secs(1);
+const EVENT_LOOP_LOG_INTERVAL: Duration = Duration::from_secs(5 * 60); // 5 mins; from_mins is a nightly build feature
 const BUFFER_MAX_BYTES: usize = 64;
 const PAT_CONNECTION_STATUS_FILENAME: &str = "_pat_connection.status";
 use std::io::Write;

--- a/apps/mark-scan/fai-100-controller/src/fai_100_controllerd.rs
+++ b/apps/mark-scan/fai-100-controller/src/fai_100_controllerd.rs
@@ -11,10 +11,10 @@ use commands::{
     ButtonSignal, CommandError, NotificationStatusResponse, SipAndPuffDeviceStatus,
     SipAndPuffSignalStatus, VersionResponse, RESPONSE_BYTE_LENGTH,
 };
-use daemon_utils::run_no_op_event_loop;
+use daemon_utils::{run_no_op_event_loop, write_pid_file};
 use std::{
     fs::OpenOptions,
-    io::{self, Read},
+    io::{self, Read, Write},
     path::{Path, PathBuf},
     process::exit,
     sync::{
@@ -40,7 +40,7 @@ const POLL_INTERVAL: Duration = Duration::from_millis(100);
 const EVENT_LOOP_LOG_INTERVAL: Duration = Duration::from_secs(5 * 60); // 5 mins; from_mins is a nightly build feature
 const BUFFER_MAX_BYTES: usize = 64;
 const PAT_CONNECTION_STATUS_FILENAME: &str = "_pat_connection.status";
-use std::io::Write;
+const PID_FILENAME: &str = "vx_accessible_controller_daemon.pid";
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -115,6 +115,13 @@ fn main() -> color_eyre::Result<()> {
         EventType::SystemAction
     );
 
+    let workspace_path = &args.mark_scan_workspace;
+    if let Err(err) = write_pid_file(workspace_path, PID_FILENAME) {
+        // Graceful fallback; if PID file writing fails controller and PAT
+        // input may still work.
+        log!(EventId::Info, "Failed to write PID file: {}", err);
+    }
+
     if let Some(mut port) = get_usb_device() {
         log!(
             event_id: EventId::Info,
@@ -134,12 +141,8 @@ fn main() -> color_eyre::Result<()> {
             exit(1);
         }
 
-        run_event_loop(
-            &mut port,
-            &running,
-            &mut keyboard,
-            &args.mark_scan_workspace,
-        );
+        run_event_loop(&mut port, &running, &mut keyboard, workspace_path);
+
         exit(0);
     }
 

--- a/apps/mark-scan/frontend/src/pages/diagnostics/diagnostics_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/diagnostics/diagnostics_screen.test.tsx
@@ -2,7 +2,7 @@ import { MemoryRouter } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
 import {
   MARK_SCAN_CONTROLLER_ILLUSTRATION_HIGHLIGHT_CLASS_NAME,
-  expectDetected,
+  expectConnected,
   expectDiagnosticResult,
   mockUsbDriveStatus,
   DiagnosticSectionTitle,
@@ -98,9 +98,9 @@ test('data from API is passed to screen contents', async () => {
   screen.getByText('Power Source: Battery');
   screen.getByText('Free Disk Space: 50% (1 GB / 2 GB)');
 
-  expectDetected(screen, DiagnosticSectionTitle.PaperHandler, true);
-  expectDetected(screen, DiagnosticSectionTitle.AccessibleController, true);
-  expectDetected(screen, DiagnosticSectionTitle.PatInput, true);
+  expectConnected(screen, DiagnosticSectionTitle.PaperHandler, true);
+  expectConnected(screen, DiagnosticSectionTitle.AccessibleController, true);
+  expectConnected(screen, DiagnosticSectionTitle.PatInput, true);
   screen.getByText('Test passed, 3/23/2022, 11:15:00 AM');
   screen.getByText('Test passed, 3/23/2022, 11:10:00 AM');
   screen.getByText('Test passed, 3/23/2022, 11:05:00 AM');

--- a/libs/backend/src/exec.ts
+++ b/libs/backend/src/exec.ts
@@ -11,8 +11,3 @@ import { promisify } from 'util';
  * See `child_process.execFile` for details.
  */
 export const execFile = promisify(cp.execFile);
-
-/**
- * See `child_process.exec` for details.
- */
-export const exec = promisify(cp.exec);

--- a/libs/backend/src/exec.ts
+++ b/libs/backend/src/exec.ts
@@ -11,3 +11,8 @@ import { promisify } from 'util';
  * See `child_process.execFile` for details.
  */
 export const execFile = promisify(cp.execFile);
+
+/**
+ * See `child_process.exec` for details.
+ */
+export const exec = promisify(cp.exec);

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -510,3 +510,15 @@ IDs are logged with each log to identify the log being written.
 **Type:** [application-status](#application-status)  
 **Description:** Machine encountered an unknown error.  
 **Machines:** vx-admin-frontend, vx-central-scan-frontend, vx-mark-frontend, vx-mark-scan-frontend, vx-mark-scan-pat-daemon, vx-mark-scan-controller-daemon, vx-scan-frontend
+### permission-denied
+**Type:** [system-status](#system-status)  
+**Description:** Permission denied when performing a system action.  
+**Machines:** All
+### no-pid
+**Type:** [system-status](#system-status)  
+**Description:** No PID was readable from PID file, or PID file did not exist.  
+**Machines:** All
+### parse-error
+**Type:** [system-action](#system-action)  
+**Description:** A system action failed to parse data.  
+**Machines:** All

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -755,3 +755,19 @@ restrictInDocumentationToApps = [
   "vx-mark-scan-controller-daemon",
   "vx-scan-frontend",
 ]
+
+[PermissionDenied]
+eventId = "permission-denied"
+eventType = "system-status"
+documentationMessage = "Permission denied when performing a system action."
+
+[NoPid]
+eventId = "no-pid"
+eventType = "system-status"
+documentationMessage = "No PID was readable from PID file, or PID file did not exist."
+
+[ParseError]
+eventId = "parse-error"
+eventType = "system-action"
+documentationMessage = "A system action failed to parse data."
+

--- a/libs/logging/src/log_event_ids.ts
+++ b/libs/logging/src/log_event_ids.ts
@@ -136,6 +136,9 @@ export enum LogEventId {
   ReadinessReportSaved = 'readiness-report-saved',
   HeadphonesDetectionError = 'headphones-detection-errors',
   UnknownError = 'unknown-error',
+  PermissionDenied = 'permission-denied',
+  NoPid = 'no-pid',
+  ParseError = 'parse-error',
 }
 
 const ElectionConfigured: LogDetails = {
@@ -1148,6 +1151,25 @@ const UnknownError: LogDetails = {
   ],
 };
 
+const PermissionDenied: LogDetails = {
+  eventId: LogEventId.PermissionDenied,
+  eventType: LogEventType.SystemStatus,
+  documentationMessage: 'Permission denied when performing a system action.',
+};
+
+const NoPid: LogDetails = {
+  eventId: LogEventId.NoPid,
+  eventType: LogEventType.SystemStatus,
+  documentationMessage:
+    'No PID was readable from PID file, or PID file did not exist.',
+};
+
+const ParseError: LogDetails = {
+  eventId: LogEventId.ParseError,
+  eventType: LogEventType.SystemAction,
+  documentationMessage: 'A system action failed to parse data.',
+};
+
 export function getDetailsForEventId(eventId: LogEventId): LogDetails {
   switch (eventId) {
     case LogEventId.ElectionConfigured:
@@ -1398,6 +1420,12 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return HeadphonesDetectionError;
     case LogEventId.UnknownError:
       return UnknownError;
+    case LogEventId.PermissionDenied:
+      return PermissionDenied;
+    case LogEventId.NoPid:
+      return NoPid;
+    case LogEventId.ParseError:
+      return ParseError;
     /* istanbul ignore next - compile time check for completeness */
     default:
       throwIllegalValue(eventId);

--- a/libs/logging/types-rust/src/log_event_enums.rs
+++ b/libs/logging/types-rust/src/log_event_enums.rs
@@ -257,4 +257,10 @@ pub enum EventId {
     HeadphonesDetectionError,
     #[serde(rename = "unknown-error")]
     UnknownError,
+    #[serde(rename = "permission-denied")]
+    PermissionDenied,
+    #[serde(rename = "no-pid")]
+    NoPid,
+    #[serde(rename = "parse-error")]
+    ParseError,
 }

--- a/libs/ui/src/diagnostics/mark_scan_device_diagnostic_section.test.tsx
+++ b/libs/ui/src/diagnostics/mark_scan_device_diagnostic_section.test.tsx
@@ -32,12 +32,12 @@ function renderComponent(
 describe('input detection', () => {
   test('when detected', async () => {
     renderComponent();
-    await expectTextWithIcon('Detected', 'square-check');
+    await expectTextWithIcon('Connected', 'square-check');
   });
 
   test('when not detected', async () => {
     renderComponent({ isDeviceConnected: false });
-    await expectTextWithIcon('Not detected', 'triangle-exclamation');
+    await expectTextWithIcon('Not connected', 'triangle-exclamation');
   });
 });
 

--- a/libs/ui/src/diagnostics/mark_scan_device_diagnostic_section.tsx
+++ b/libs/ui/src/diagnostics/mark_scan_device_diagnostic_section.tsx
@@ -29,13 +29,13 @@ export function MarkScanDeviceDiagnosticSection({
     if (isDeviceConnected === true) {
       detectedText = (
         <P>
-          <SuccessIcon /> Detected
+          <SuccessIcon /> Connected
         </P>
       );
     } else {
       detectedText = (
         <P>
-          <WarningIcon /> Not detected
+          <WarningIcon /> Not connected
         </P>
       );
     }

--- a/libs/ui/src/diagnostics/mark_scan_readiness_report.test.tsx
+++ b/libs/ui/src/diagnostics/mark_scan_readiness_report.test.tsx
@@ -3,7 +3,7 @@ import { electionTwoPartyPrimaryDefinition } from '@votingworks/fixtures';
 import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 import { MarkScanReadinessReport } from './mark_scan_readiness_report';
 import { render, screen } from '../../test/react_testing_library';
-import { expectDetected, expectDiagnosticResult } from './test_utils';
+import { expectConnected, expectDiagnosticResult } from './test_utils';
 import { DiagnosticSectionTitle } from './types';
 
 test('MarkScanReadinessReport', () => {
@@ -72,9 +72,9 @@ test('MarkScanReadinessReport', () => {
   screen.getByText(/All Precincts/);
   screen.getByText('Battery Level: 50%');
   screen.getByText('Power Source: Battery');
-  expectDetected(screen, DiagnosticSectionTitle.PaperHandler, true);
-  expectDetected(screen, DiagnosticSectionTitle.AccessibleController, true);
-  expectDetected(screen, DiagnosticSectionTitle.PatInput, true);
+  expectConnected(screen, DiagnosticSectionTitle.PaperHandler, true);
+  expectConnected(screen, DiagnosticSectionTitle.AccessibleController, true);
+  expectConnected(screen, DiagnosticSectionTitle.PatInput, true);
   expectDiagnosticResult(screen, DiagnosticSectionTitle.PaperHandler, true);
   expectDiagnosticResult(screen, DiagnosticSectionTitle.PatInput, true);
   expectDiagnosticResult(screen, DiagnosticSectionTitle.HeadphoneInput, true);

--- a/libs/ui/src/diagnostics/test_utils.ts
+++ b/libs/ui/src/diagnostics/test_utils.ts
@@ -19,15 +19,15 @@ function expectTextInSection(
   ).toBeDefined();
 }
 
-export function expectDetected(
+export function expectConnected(
   screen: VxScreen,
   headerText: DiagnosticSectionTitle,
-  detectedExpected: boolean
+  connectedExpected: boolean
 ): void {
   expectTextInSection(
     screen,
     headerText,
-    detectedExpected ? 'Detected' : 'Not detected'
+    connectedExpected ? 'Connected' : 'Not connected'
   );
 }
 


### PR DESCRIPTION
## Overview

We currently check for controller connection by running `child_process.execFile('ps aux | grep controller[d])`. `execFile` doesn't support I/O redirect so this command will always fail and report no controller connection.

~`exec` behaves similarly but supports I/O redirect at the slight performance cost of starting (and ending) a shell session.~

Based on feedback, this PR changes controller daemons to write a PID file to be read by the mark-scan backend. The reported PID is checked with `kill` signal 0 to see if the daemon process is still running.



## Demo Video or Screenshot
![IMG_5468](https://github.com/user-attachments/assets/ee65d478-ee6b-4397-97ac-6ab4cc902df3)



## Testing Plan

Manual testing
- Ran daemon, confirmed backend can detect controller
- Killed daemon, confirmed backend can no longer detect controller
- Automated tests

## Checklist
N/A not user facing, no new actions

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
