### PR TITLE
[fix/5033] Fix inconsistent audio feedback on touch events

### DIFF
--- a/libs/ui/src/button.tsx
+++ b/libs/ui/src/button.tsx
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import styled, { css, CSSObject, DefaultTheme } from 'styled-components';
 import { SizeMode, SizeTheme, UiTheme } from '@votingworks/types';
 
-import { throwIllegalValue } from '@votingworks/basics';
+import { assertDefined, throwIllegalValue } from '@votingworks/basics';
 import { rgba } from 'polished';
 import { IconName, Icons } from './icons';
 
@@ -429,8 +429,10 @@ export class Button<T = undefined> extends PureComponent<
       Math.abs(startCoordinates[0] - clientX) < maxMove &&
       Math.abs(startCoordinates[1] - clientY) < maxMove
     ) {
-      this.onPress();
       event.preventDefault();
+      event.stopPropagation();
+
+      assertDefined(this.buttonRef.current).click();
     }
   };
 


### PR DESCRIPTION
## Overview

Related to https://github.com/votingworks/vxsuite/issues/5033

We noticed in manual tests that touch-based "click" events don't trigger audio in the same way that "click" events with the accessible controller do.

This change fixes our handling of touch events in the `<Button>` component by triggering an actual `click` event on the button when we detect a touch-based button press. This allows the click/focus-based screen reader to properly detect button presses.

__Context:__ 
Our `<Button>` component overrides the default browser handling of touch taps by intercepting `touchStart` and `touchEnd` and treating the pair as a button press even if the user's finger moved slightly in-between. It then triggers the `onPress` callback directly and blocks the default browser handling, which prevents any downstream `click` listeners from being triggered. Not entirely sure if the custom touch detection logic is necessary, but leaving it intact, assuming it was added to solve a specific issue.

## Demo Video or Screenshot [ 🔊 ]

### Before:

https://github.com/user-attachments/assets/bbd9a1a7-636f-41a8-9a89-27dd91ffac18

### After:

https://github.com/user-attachments/assets/3c95abdf-9361-4b62-9867-e9617e167e50

## Testing Plan
- Manual (+ existing tests as regression checks)

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
