### PR TITLE
Strict ballot definition CDF

### DIFF
--- a/libs/types/src/__snapshots__/election.test.ts.snap
+++ b/libs/types/src/__snapshots__/election.test.ts.snap
@@ -178,15 +178,6 @@ CDF error: [
   },
   {
     "code": "invalid_type",
-    "expected": "string",
-    "received": "undefined",
-    "path": [
-      "vxSeal"
-    ],
-    "message": "Required"
-  },
-  {
-    "code": "invalid_type",
     "expected": "number",
     "received": "undefined",
     "path": [

--- a/libs/types/src/cdf/ballot-definition/convert.test.ts
+++ b/libs/types/src/cdf/ballot-definition/convert.test.ts
@@ -1,6 +1,6 @@
 import cloneDeep from 'lodash.clonedeep';
 import set from 'lodash.set';
-import { mapObject, ok } from '@votingworks/basics';
+import { ok } from '@votingworks/basics';
 import {
   election,
   electionTwoPartyPrimary,
@@ -14,13 +14,13 @@ import {
 } from './convert';
 import { testCdfBallotDefinition, testVxfElection } from './fixtures';
 import {
-  Election,
   ElectionStringKey,
   LanguageCode,
   UiStringsPackage,
   mergeUiStrings,
 } from '../..';
 import * as Cdf from '.';
+import { normalizeVxfAfterCdfConversion } from '../../../test/cdf_conversion_helpers';
 
 function languageString(
   content: string,
@@ -282,26 +282,10 @@ test('convertVxfElectionToCdfBallotDefinition with translated election strings',
 test('convertCdfBallotDefinitionToVxfElection', () => {
   expect(
     convertCdfBallotDefinitionToVxfElection(testCdfBallotDefinition)
-  ).toEqual(testVxfElection);
+  ).toEqual(normalizeVxfAfterCdfConversion(testVxfElection));
 });
 
 const elections = [election, primaryElection, electionTwoPartyPrimary];
-
-function normalizeVxfAfterCdfConversion(vxfElection: Election): Election {
-  return {
-    ...vxfElection,
-    // CDF only has one field for party name, so we lose `party.name`
-    parties: vxfElection.parties.map((party) => ({
-      ...party,
-      name: party.fullName,
-    })),
-    ballotStrings: mapObject(vxfElection.ballotStrings, (strings) => ({
-      ...strings,
-      [ElectionStringKey.PARTY_NAME]:
-        strings[ElectionStringKey.PARTY_FULL_NAME],
-    })),
-  };
-}
 
 for (const vxf of elections) {
   test(`round trip conversion for election fixture: ${vxf.title}`, () => {
@@ -341,7 +325,7 @@ test('safeParseCdfBallotDefinition', () => {
 
   expect(safeParseCdfBallotDefinition(testCdfBallotDefinition)).toEqual(
     ok({
-      vxfElection: testVxfElection,
+      vxfElection: normalizeVxfAfterCdfConversion(testVxfElection),
       cdfElection: testCdfBallotDefinition,
     })
   );

--- a/libs/types/src/cdf/ballot-definition/convert.ts
+++ b/libs/types/src/cdf/ballot-definition/convert.ts
@@ -536,7 +536,6 @@ export function convertVxfElectionToCdfBallotDefinition(
           {
             '@type': 'BallotDefinition.PhysicalContest',
             BallotFormatId: 'ballot-format',
-            vxOptionBoundsFromTargetMark: gridLayout.optionBoundsFromTargetMark,
             PhysicalContestOption: gridLayout.gridPositions
               .filter((position) => position.contestId === contest.id)
               .map(
@@ -1097,11 +1096,16 @@ export function convertCdfBallotDefinitionToVxfElection(
         (ballotStyle) => ballotStyle.OrderedContent !== undefined
       ).map((ballotStyle): Vxf.GridLayout => {
         const orderedContests = assertDefined(ballotStyle.OrderedContent);
-        const optionBoundsFromTargetMark =
-          orderedContests[0].Physical[0].vxOptionBoundsFromTargetMark;
         return {
           ballotStyleId: ballotStyle.ExternalIdentifier[0].Value,
-          optionBoundsFromTargetMark,
+          // Since there's no CDF field for this, we set a default based on what
+          // generally works well for our HMPBs.
+          optionBoundsFromTargetMark: {
+            top: 1,
+            left: 1,
+            right: 9,
+            bottom: 1,
+          },
           gridPositions: orderedContests.flatMap(
             (orderedContest): Vxf.GridPosition[] =>
               orderedContest.Physical[0].PhysicalContestOption.map(

--- a/libs/types/src/cdf/ballot-definition/convert.ts
+++ b/libs/types/src/cdf/ballot-definition/convert.ts
@@ -843,8 +843,6 @@ export function convertVxfElectionToCdfBallotDefinition(
       },
     ],
 
-    vxSeal: vxfElection.seal,
-
     // Since we don't have a generated date in VXF, we use the election date. If
     // we were to use the current date, it would cause changes every time we
     // hash the object. We want hashes to be based on the content of the
@@ -946,7 +944,12 @@ export function convertCdfBallotDefinitionToVxfElection(
       name: englishText(county.Name),
     },
     date: new DateWithoutTime(election.StartDate),
-    seal: cdfBallotDefinition.vxSeal,
+    // CDF doesn't have a seal field, but VXF requires a seal, so we pass in an
+    // empty string (a hacky form of "no seal"). While we could change VXF to
+    // have an optional seal field, we actually want to require a seal for all
+    // elections - this is an edge case due to CDF limitations. This case is
+    // handled in the Seal ui component.
+    seal: '',
 
     parties: cdfBallotDefinition.Party.map((party) => {
       return {

--- a/libs/types/src/cdf/ballot-definition/convert.ts
+++ b/libs/types/src/cdf/ballot-definition/convert.ts
@@ -306,7 +306,7 @@ const extractorFns: Record<
       setInternationalizedUiStrings({
         stringKey: [ElectionStringKey.PARTY_NAME, party['@id']],
         uiStrings,
-        values: party.vxBallotLabel.Text,
+        values: party.Name.Text,
       });
     }
   },
@@ -761,7 +761,6 @@ export function convertVxfElectionToCdfBallotDefinition(
       '@id': party.id,
       Name: text(party.fullName, [ElectionStringKey.PARTY_FULL_NAME, party.id]),
       Abbreviation: text(party.abbrev, 'other'),
-      vxBallotLabel: text(party.name, [ElectionStringKey.PARTY_NAME, party.id]),
     })),
 
     GpUnit: [
@@ -953,7 +952,7 @@ export function convertCdfBallotDefinitionToVxfElection(
     parties: cdfBallotDefinition.Party.map((party) => {
       return {
         id: party['@id'] as Vxf.PartyId,
-        name: englishText(party.vxBallotLabel),
+        name: englishText(party.Name),
         fullName: englishText(party.Name),
         abbrev: englishText(party.Abbreviation),
       };

--- a/libs/types/src/cdf/ballot-definition/extract_cdf_ui_strings.test.ts
+++ b/libs/types/src/cdf/ballot-definition/extract_cdf_ui_strings.test.ts
@@ -489,7 +489,7 @@ const tests: Record<ElectionStringKey, () => void> = {
         {
           ...assertDefined(testCdfBallotDefinition.Party[0]),
           '@id': 'party1',
-          vxBallotLabel: buildInternationalizedText({
+          Name: buildInternationalizedText({
             [LanguageCode.ENGLISH]: 'Block Party',
             [LanguageCode.SPANISH]: 'Fiesta En La Calle',
             unsupported_lang: '🥳',
@@ -498,7 +498,7 @@ const tests: Record<ElectionStringKey, () => void> = {
         {
           ...assertDefined(testCdfBallotDefinition.Party[1]),
           '@id': 'party2',
-          vxBallotLabel: buildInternationalizedText({
+          Name: buildInternationalizedText({
             [LanguageCode.ENGLISH]: 'Pool Party',
             [LanguageCode.SPANISH]: 'Fiesta De Piscina',
             unsupported_lang: '🏖',

--- a/libs/types/src/cdf/ballot-definition/fixtures.ts
+++ b/libs/types/src/cdf/ballot-definition/fixtures.ts
@@ -1094,8 +1094,6 @@ export const testCdfBallotDefinition: BallotDefinition = {
     },
   ],
 
-  vxSeal: '<svg>test seal</svg>',
-
   GeneratedDate: '2021-06-06T00:00:00Z',
   Issuer: 'VotingWorks',
   IssuerAbbreviation: 'VX',

--- a/libs/types/src/cdf/ballot-definition/fixtures.ts
+++ b/libs/types/src/cdf/ballot-definition/fixtures.ts
@@ -575,12 +575,6 @@ export const testCdfBallotDefinition: BallotDefinition = {
                 {
                   '@type': 'BallotDefinition.PhysicalContest',
                   BallotFormatId: 'ballot-format',
-                  vxOptionBoundsFromTargetMark: {
-                    bottom: 1,
-                    left: 1,
-                    right: 9,
-                    top: 1,
-                  },
                   PhysicalContestOption: [
                     {
                       '@type': 'BallotDefinition.PhysicalContestOption',
@@ -652,12 +646,6 @@ export const testCdfBallotDefinition: BallotDefinition = {
                 {
                   '@type': 'BallotDefinition.PhysicalContest',
                   BallotFormatId: 'ballot-format',
-                  vxOptionBoundsFromTargetMark: {
-                    bottom: 1,
-                    left: 1,
-                    right: 9,
-                    top: 1,
-                  },
                   PhysicalContestOption: [
                     {
                       '@type': 'BallotDefinition.PhysicalContestOption',
@@ -716,12 +704,6 @@ export const testCdfBallotDefinition: BallotDefinition = {
                 {
                   '@type': 'BallotDefinition.PhysicalContest',
                   BallotFormatId: 'ballot-format',
-                  vxOptionBoundsFromTargetMark: {
-                    bottom: 1,
-                    left: 1,
-                    right: 9,
-                    top: 1,
-                  },
                   PhysicalContestOption: [
                     {
                       '@type': 'BallotDefinition.PhysicalContestOption',
@@ -764,12 +746,6 @@ export const testCdfBallotDefinition: BallotDefinition = {
                 {
                   '@type': 'BallotDefinition.PhysicalContest',
                   BallotFormatId: 'ballot-format',
-                  vxOptionBoundsFromTargetMark: {
-                    bottom: 1,
-                    left: 1,
-                    right: 9,
-                    top: 1,
-                  },
                   PhysicalContestOption: [
                     {
                       '@type': 'BallotDefinition.PhysicalContestOption',
@@ -841,12 +817,6 @@ export const testCdfBallotDefinition: BallotDefinition = {
                 {
                   '@type': 'BallotDefinition.PhysicalContest',
                   BallotFormatId: 'ballot-format',
-                  vxOptionBoundsFromTargetMark: {
-                    bottom: 1,
-                    left: 1,
-                    right: 9,
-                    top: 1,
-                  },
                   PhysicalContestOption: [
                     {
                       '@type': 'BallotDefinition.PhysicalContestOption',
@@ -891,12 +861,6 @@ export const testCdfBallotDefinition: BallotDefinition = {
                 {
                   '@type': 'BallotDefinition.PhysicalContest',
                   BallotFormatId: 'ballot-format',
-                  vxOptionBoundsFromTargetMark: {
-                    bottom: 1,
-                    left: 1,
-                    right: 9,
-                    top: 1,
-                  },
                   PhysicalContestOption: [
                     {
                       '@type': 'BallotDefinition.PhysicalContestOption',

--- a/libs/types/src/cdf/ballot-definition/fixtures.ts
+++ b/libs/types/src/cdf/ballot-definition/fixtures.ts
@@ -33,13 +33,13 @@ export const testVxfElection: Election = {
   parties: [
     {
       id: 'party-1' as PartyId,
-      name: 'Democrat',
+      name: 'Democratic Party',
       fullName: 'Democratic Party',
       abbrev: 'D',
     },
     {
       id: 'party-2' as PartyId,
-      name: 'Republican',
+      name: 'Republican Party',
       fullName: 'Republican Party',
       abbrev: 'R',
     },
@@ -336,8 +336,8 @@ export const testVxfElection: Election = {
         'party-2': 'Republican Party',
       },
       partyName: {
-        'party-1': 'Democrat',
-        'party-2': 'Republican',
+        'party-1': 'Democratic Party',
+        'party-2': 'Republican Party',
       },
       precinctName: {
         'precinct-1': 'North Lincoln',
@@ -956,16 +956,6 @@ export const testCdfBallotDefinition: BallotDefinition = {
           },
         ],
       },
-      vxBallotLabel: {
-        '@type': 'BallotDefinition.InternationalizedText',
-        Text: [
-          {
-            '@type': 'BallotDefinition.LanguageString',
-            Language: 'en',
-            Content: 'Democrat',
-          },
-        ],
-      },
     },
     {
       '@type': 'BallotDefinition.Party',
@@ -987,16 +977,6 @@ export const testCdfBallotDefinition: BallotDefinition = {
             '@type': 'BallotDefinition.LanguageString',
             Language: 'en',
             Content: 'R',
-          },
-        ],
-      },
-      vxBallotLabel: {
-        '@type': 'BallotDefinition.InternationalizedText',
-        Text: [
-          {
-            '@type': 'BallotDefinition.LanguageString',
-            Language: 'en',
-            Content: 'Republican',
           },
         ],
       },

--- a/libs/types/src/cdf/ballot-definition/index.ts
+++ b/libs/types/src/cdf/ballot-definition/index.ts
@@ -1199,26 +1199,6 @@ export const OrderedContestSchema: z.ZodSchema<OrderedContest> = z.object({
   Physical: z.array(z.lazy(/* istanbul ignore next */ () => PhysicalContestSchema)).min(1),
 });
 
-export interface vxOutset {
-  readonly top: number;
-
-  readonly bottom: number;
-
-  readonly left: number;
-
-  readonly right: number;
-}
-
-/**
- * Schema for {@link vxOutset}.
- */
-export const vxOutsetSchema: z.ZodSchema<vxOutset> = z.object({
-  top: z.number(),
-  bottom: z.number(),
-  left: z.number(),
-  right: z.number(),
-});
-
 /**
  * Used to describe a political party that can then be referenced in other elements. BallotDefinition includes Party. Candidate, PartyRegistration, and Person reference Party.
  * 
@@ -1277,8 +1257,6 @@ export interface PhysicalContest {
    * The contest options associated with the contest, including physical details.
    */
   readonly PhysicalContestOption: readonly PhysicalContestOption[];
-
-  readonly vxOptionBoundsFromTargetMark: vxOutset;
 }
 
 /**
@@ -1290,7 +1268,6 @@ export const PhysicalContestSchema: z.ZodSchema<PhysicalContest> = z.object({
   Extent: z.optional(z.array(z.union([z.lazy(/* istanbul ignore next */ () => BoundedObjectSchema), z.lazy(/* istanbul ignore next */ () => FiducialMarkSchema), z.lazy(/* istanbul ignore next */ () => OptionPositionSchema), z.lazy(/* istanbul ignore next */ () => WriteInPositionSchema), z.lazy(/* istanbul ignore next */ () => mCDFAreaSchema)]))),
   FiducialMark: z.optional(z.array(z.lazy(/* istanbul ignore next */ () => FiducialMarkSchema))),
   PhysicalContestOption: z.array(z.lazy(/* istanbul ignore next */ () => PhysicalContestOptionSchema)).min(1),
-  vxOptionBoundsFromTargetMark: z.lazy(/* istanbul ignore next */ () => vxOutsetSchema),
 });
 
 /**

--- a/libs/types/src/cdf/ballot-definition/index.ts
+++ b/libs/types/src/cdf/ballot-definition/index.ts
@@ -1240,11 +1240,6 @@ export interface Party {
    * Official full name of the party, e.g., “Republican”; can appear on the ballot.
    */
   readonly Name: InternationalizedText;
-
-  /**
-   * The label to describe candidates from this party on a ballot.
-   */
-  readonly vxBallotLabel: InternationalizedText;
 }
 
 /**
@@ -1255,7 +1250,6 @@ export const PartySchema: z.ZodSchema<Party> = z.object({
   '@type': z.literal('BallotDefinition.Party'),
   Abbreviation: z.lazy(/* istanbul ignore next */ () => InternationalizedTextSchema),
   Name: z.lazy(/* istanbul ignore next */ () => InternationalizedTextSchema),
-  vxBallotLabel: z.lazy(/* istanbul ignore next */ () => InternationalizedTextSchema),
 });
 
 /**

--- a/libs/types/src/cdf/ballot-definition/index.ts
+++ b/libs/types/src/cdf/ballot-definition/index.ts
@@ -355,11 +355,6 @@ export interface BallotDefinition {
   readonly Party: readonly Party[];
 
   /**
-   * SVG image content for the jurisdiction's seal in UTF8 text format
-   */
-  readonly vxSeal: string;
-
-  /**
    * The upper bound of the sequence; e.g., “1” if there is only 1 report, “2” if there are two reports in the sequence, etc.
    */
   readonly SequenceEnd: integer;
@@ -399,7 +394,6 @@ export const BallotDefinitionSchema: z.ZodSchema<BallotDefinition> = z.object({
   IssuerAbbreviation: z.string(),
   Office: z.optional(z.array(z.lazy(/* istanbul ignore next */ () => OfficeSchema))),
   Party: z.array(z.lazy(/* istanbul ignore next */ () => PartySchema)),
-  vxSeal: z.string(),
   SequenceEnd: integerSchema,
   SequenceStart: integerSchema,
   Shape: z.optional(z.array(z.lazy(/* istanbul ignore next */ () => ShapeSchema))),

--- a/libs/types/src/cdf/ballot-definition/vx-schema.json
+++ b/libs/types/src/cdf/ballot-definition/vx-schema.json
@@ -12,7 +12,6 @@
         "Issuer",
         "IssuerAbbreviation",
         "Party",
-        "vxSeal",
         "SequenceEnd",
         "SequenceStart",
         "VendorApplicationId",
@@ -80,10 +79,6 @@
           },
           "minItems": 0,
           "type": "array"
-        },
-        "vxSeal": {
-          "description": "SVG image content for the jurisdiction's seal in UTF8 text format",
-          "type": "string"
         },
         "SequenceEnd": {
           "type": "integer"

--- a/libs/types/src/cdf/ballot-definition/vx-schema.json
+++ b/libs/types/src/cdf/ballot-definition/vx-schema.json
@@ -758,7 +758,7 @@
       "additionalProperties": false
     },
     "BallotDefinition.Party": {
-      "required": ["@id", "@type", "Abbreviation", "Name", "vxBallotLabel"],
+      "required": ["@id", "@type", "Abbreviation", "Name"],
       "additionalProperties": false,
       "properties": {
         "@id": {
@@ -772,10 +772,6 @@
           "$ref": "#/definitions/BallotDefinition.InternationalizedText"
         },
         "Name": {
-          "$ref": "#/definitions/BallotDefinition.InternationalizedText"
-        },
-        "vxBallotLabel": {
-          "description": "The label to describe candidates from this party on a ballot.",
           "$ref": "#/definitions/BallotDefinition.InternationalizedText"
         }
       },

--- a/libs/types/src/cdf/ballot-definition/vx-schema.json
+++ b/libs/types/src/cdf/ballot-definition/vx-schema.json
@@ -746,17 +746,6 @@
       "enum": ["landscape", "portrait"],
       "type": "string"
     },
-    "BallotDefinition.vxOutset": {
-      "type": "object",
-      "properties": {
-        "top": { "type": "number" },
-        "bottom": { "type": "number" },
-        "left": { "type": "number" },
-        "right": { "type": "number" }
-      },
-      "required": ["top", "bottom", "left", "right"],
-      "additionalProperties": false
-    },
     "BallotDefinition.Party": {
       "required": ["@id", "@type", "Abbreviation", "Name"],
       "additionalProperties": false,
@@ -778,12 +767,7 @@
       "type": "object"
     },
     "BallotDefinition.PhysicalContest": {
-      "required": [
-        "@type",
-        "BallotFormatId",
-        "PhysicalContestOption",
-        "vxOptionBoundsFromTargetMark"
-      ],
+      "required": ["@type", "BallotFormatId", "PhysicalContestOption"],
       "additionalProperties": false,
       "properties": {
         "@type": {
@@ -830,9 +814,6 @@
           },
           "minItems": 1,
           "type": "array"
-        },
-        "vxOptionBoundsFromTargetMark": {
-          "$ref": "#/definitions/BallotDefinition.vxOutset"
         }
       },
       "type": "object"

--- a/libs/types/src/election.test.ts
+++ b/libs/types/src/election.test.ts
@@ -50,6 +50,7 @@ import {
   safeParseElectionDefinition,
 } from './election_parsing';
 import { LanguageCode } from '.';
+import { normalizeVxfAfterCdfConversion } from '../test/cdf_conversion_helpers';
 
 test('can build votes from a candidate ID', () => {
   const contests = election.contests.filter((c) => c.id === 'CC');
@@ -536,11 +537,11 @@ test('getDisplayBallotHash', () => {
 
 test('safeParseElection converts CDF to VXF', () => {
   expect(safeParseElection(testCdfBallotDefinition).unsafeUnwrap()).toEqual(
-    testVxfElection
+    normalizeVxfAfterCdfConversion(testVxfElection)
   );
   expect(
     safeParseElection(JSON.stringify(testCdfBallotDefinition)).unsafeUnwrap()
-  ).toEqual(testVxfElection);
+  ).toEqual(normalizeVxfAfterCdfConversion(testVxfElection));
 });
 
 test('safeParseElection shows VXF and CDF parsing errors', () => {

--- a/libs/types/test/cdf_conversion_helpers.ts
+++ b/libs/types/test/cdf_conversion_helpers.ts
@@ -1,0 +1,23 @@
+import { mapObject } from '@votingworks/basics';
+import { Election } from '../src/election';
+import { ElectionStringKey } from '../src/ui_string_translations';
+
+export function normalizeVxfAfterCdfConversion(
+  vxfElection: Election
+): Election {
+  return {
+    ...vxfElection,
+    // CDF only has one field for party name, so we lose `party.name`
+    parties: vxfElection.parties.map((party) => ({
+      ...party,
+      name: party.fullName,
+    })),
+    ballotStrings: mapObject(vxfElection.ballotStrings, (strings) => ({
+      ...strings,
+      [ElectionStringKey.PARTY_NAME]:
+        strings[ElectionStringKey.PARTY_FULL_NAME],
+    })),
+    // No field in CDF for seal
+    seal: '',
+  };
+}

--- a/libs/ui/src/seal.test.tsx
+++ b/libs/ui/src/seal.test.tsx
@@ -34,3 +34,8 @@ test('varies container styling based on UI theme', () => {
     window.getComputedStyle(darkThemeSeal.container.children[0])
   ).not.toEqual(window.getComputedStyle(lightThemeSeal.container.children[0]));
 });
+
+test('renders nothing if seal is empty string (special case for CDF)', () => {
+  render(<Seal seal="" maxWidth="7rem" />);
+  expect(screen.queryByAltText('Seal')).not.toBeInTheDocument();
+});

--- a/libs/ui/src/seal.tsx
+++ b/libs/ui/src/seal.tsx
@@ -38,7 +38,9 @@ export function Seal({
   maxWidth,
   style,
   inverse,
-}: SealProps): JSX.Element {
+}: SealProps): JSX.Element | null {
+  // Handle empty string case for CDF ballot definition, which has no seal field
+  if (!seal) return null;
   return (
     <SealImage
       aria-hidden


### PR DESCRIPTION
## Overview
Closes: #4953 

Updates our support for the ballot definition CDF to be strictly compatible with NIST's CDF by removing custom extension fields that we added. Instead, we either use a reasonable default or disable the behavior that was supported by each custom field (details in commits).

## Demo Video or Screenshot
VxAdmin and VxMarkScan with no seal
![Screenshot-VxAdmin-2024-07-30T20:07:39 211Z](https://github.com/user-attachments/assets/8f87c74b-0b0a-45d7-a4c7-ac42113df70e)
![Screenshot-VxMark-2024-07-30T20:09:23 087Z](https://github.com/user-attachments/assets/c2597e4f-8921-408e-a421-0ccd409d7f0f)

## Testing Plan
Updated existing tests, manually tested

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
