### PR TITLE
Fix screen reader missing audio triggered immediately after unmute

### DIFF
--- a/libs/ui/src/ui_strings/ui_string_screen_reader.tsx
+++ b/libs/ui/src/ui_strings/ui_string_screen_reader.tsx
@@ -126,6 +126,19 @@ export function UiStringScreenReader(
   );
   const audioIdQueries = api.getAudioIds.useQueries([...activeLanguages]);
 
+  // Wrap `isEnabled` and `setIsPaused` in refs, so we can use it in the event
+  // listener effect without needing to unload and re-load the effect when the
+  // values change:
+  const isEnabledRef = React.useRef(isEnabled);
+  React.useEffect(() => {
+    isEnabledRef.current = isEnabled;
+  }, [isEnabled]);
+
+  const setIsPausedRef = React.useRef(setIsPaused);
+  React.useEffect(() => {
+    setIsPausedRef.current = setIsPaused;
+  }, [setIsPaused]);
+
   //
   // Register click/focus handlers:
   //
@@ -140,8 +153,8 @@ export function UiStringScreenReader(
 
         // In case playback was paused for a previous event, unpause to ensure
         // that the user receives audio feedback for this next event.
-        if (isEnabled) {
-          setIsPaused(false);
+        if (isEnabledRef.current) {
+          setIsPausedRef.current(false);
         }
       });
     }
@@ -159,7 +172,7 @@ export function UiStringScreenReader(
       document.removeEventListener('focus', onFocusOrClick, { capture: true });
       document.removeEventListener('blur', onBlur, { capture: true });
     };
-  }, [isEnabled, setIsPaused]);
+  }, []);
 
   //
   // Extract and queue up i18n keys within the event target:


### PR DESCRIPTION
## Overview

Fixes https://github.com/votingworks/vxsuite/issues/5087

When entering audio-only mode after muting audio, the screen reader is first unmuted, then the voter is returned to the ballot, but there was a race condition where the initial audio on the ballot screen was triggered before the screen reader's event handlers were re-registered after the mute change.

Updating the event listener registration to only happen once per app load - removing the React effect dependency on the audio mute state to avoid having the listeners removed and re-added every time we mute/unmute.

## Demo Video or Screenshot [ 🔊 ]

### Before:

https://github.com/user-attachments/assets/35fb3939-a0eb-4e34-a38e-8757615e5514

### After:

https://github.com/user-attachments/assets/276a2b87-dffd-4df6-a21c-c4a8909d7b6b

## Testing Plan
- Manual

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
