### PR TITLE
[VxMark] Prevent first contest button's top outline getting cut off

### DIFF
--- a/apps/mark-scan/frontend/src/lib/assistive_technology.ts
+++ b/apps/mark-scan/frontend/src/lib/assistive_technology.ts
@@ -11,6 +11,17 @@ function handleClick() {
   }
 }
 
+/**
+ * Prevents the default browser scroll behavior for the arrow keys, since we're
+ * re-mapping them for focus navigation.
+ *
+ * This avoids the page constantly scrolling while focus is moved, which could
+ * be a little disorienting for some voters.
+ */
+function preventBrowserScroll(event: KeyboardEvent) {
+  event.preventDefault();
+}
+
 /* istanbul ignore next */
 export function handleKeyboardEvent(event: KeyboardEvent): void {
   switch (event.key) {
@@ -25,10 +36,12 @@ export function handleKeyboardEvent(event: KeyboardEvent): void {
       break;
     case Keybinding.FOCUS_PREVIOUS:
       advanceElementFocus(-1);
+      preventBrowserScroll(event);
       break;
     case Keybinding.FOCUS_NEXT:
     case Keybinding.PAT_MOVE:
       advanceElementFocus(1);
+      preventBrowserScroll(event);
       break;
     case Keybinding.PAT_SELECT:
       handleClick();

--- a/libs/mark-flow-ui/src/components/contest_screen_layout.tsx
+++ b/libs/mark-flow-ui/src/components/contest_screen_layout.tsx
@@ -12,4 +12,10 @@ export const ChoicesGrid = styled.div.attrs({
   display: grid;
   grid-auto-rows: minmax(auto, 1fr);
   grid-gap: 0.5rem;
+
+  /*
+   * Add a little vertical padding to account for focus outlines on the contest
+   * choice buttons, which would otherwise get cut off:
+   */
+  padding: ${(p) => p.theme.sizes.bordersRem.medium}rem 0;
 `;

--- a/libs/ui/src/with_scroll_buttons.tsx
+++ b/libs/ui/src/with_scroll_buttons.tsx
@@ -60,6 +60,13 @@ const Content = styled.div<ContentProps>`
   overflow: scroll;
   padding: 0 ${(p) => (p.noPadding ? 0 : getSpacingValueRem(p))}rem;
 
+  /*
+   * TODO: We should consider making this configurable via voter settings, since
+   * Some voters may prefer a reduced-motion mode without these smoothed-out
+  * transitions.
+  */
+  scroll-behavior: smooth;
+
   /* Always pad bottom when scroll enabled, to account for bottom shadow: */
   padding-bottom: ${(p) => (p.scrollEnabled ? getSpacingValueRem(p) : 0)}rem;
 `;
@@ -156,7 +163,6 @@ export function WithScrollButtons(props: WithScrollButtonsProps): JSX.Element {
         Math.round(offsetHeight * SCROLL_DISTANCE_TO_CONTENT_HEIGHT_RATIO);
 
       contentRef.current.scrollTo({
-        behavior: 'smooth',
         top: Math.max(targetScrollTop, 0),
       });
     }
@@ -172,7 +178,6 @@ export function WithScrollButtons(props: WithScrollButtonsProps): JSX.Element {
         Math.round(offsetHeight * SCROLL_DISTANCE_TO_CONTENT_HEIGHT_RATIO);
 
       contentRef.current.scrollTo({
-        behavior: 'smooth',
         top: Math.min(targetScrollTop, maxScrollTop),
       });
     }


### PR DESCRIPTION
## Overview

Fixes https://github.com/votingworks/vxsuite/issues/5000

Contest button UX fixes:
- Add a bit of padding to avoid the focus outline getting partially cut off
- Prevent the browser from scrolling in response to the up/down arrow keys, since we're using those to tab around.

## Demo Video or Screenshot

### Before:

https://github.com/user-attachments/assets/283a45a4-f91a-4cb6-838d-fdbd4e7d3467

### After:

https://github.com/user-attachments/assets/d4d6b08c-9298-446b-881a-1fdfbc970ce3

## Testing Plan
- Manual

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
