### PR TITLE
perf(scan): optimize writing of scanned images to disk

### DIFF
--- a/apps/central-scan/backend/src/importer.test.ts
+++ b/apps/central-scan/backend/src/importer.test.ts
@@ -1,5 +1,6 @@
 import { dirSync } from 'tmp';
 import { mockLogger } from '@votingworks/logging';
+import { createImageData } from 'canvas';
 import { Importer } from './importer';
 import { createWorkspace } from './util/workspace';
 import { makeMockScanner } from '../test/util/mocks';
@@ -18,6 +19,10 @@ test('no election is configured', async () => {
   );
 
   await expect(
-    importer.importSheet('batch-1', '/tmp/front.jpeg', '/tmp/back.jpeg')
+    importer.importSheet(
+      'batch-1',
+      createImageData(1, 1),
+      createImageData(1, 1)
+    )
   ).rejects.toThrowError('no election configuration');
 });

--- a/apps/mark-scan/backend/src/app.diagnostics.test.ts
+++ b/apps/mark-scan/backend/src/app.diagnostics.test.ts
@@ -26,7 +26,7 @@ import { MockPaperHandlerDriver } from '@votingworks/custom-paper-handler';
 import { assertDefined, deferred, ok } from '@votingworks/basics';
 import {
   InterpretFileResult,
-  interpretSimplexBmdBallotFromFilepath,
+  interpretSimplexBmdBallot,
 } from '@votingworks/ballot-interpreter';
 import { readElection } from '@votingworks/fs';
 import { Api } from './app';
@@ -304,7 +304,7 @@ describe('paper handler diagnostic', () => {
       BLANK_PAGE_MOCK,
     ];
     const mockInterpretResult = deferred<SheetOf<InterpretFileResult>>();
-    mockOf(interpretSimplexBmdBallotFromFilepath).mockResolvedValue(
+    mockOf(interpretSimplexBmdBallot).mockResolvedValue(
       mockInterpretResult.promise
     );
 

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -12,7 +12,7 @@ import {
   buildMockInsertedSmartCardAuth,
 } from '@votingworks/auth';
 import { advanceTimers, mockOf } from '@votingworks/test-utils';
-import { assert, deferred } from '@votingworks/basics';
+import { assert, deferred, iter } from '@votingworks/basics';
 import {
   electionGeneralDefinition,
   electionGridLayoutNewHampshireHudsonFixtures,
@@ -35,7 +35,12 @@ import {
   InterpretFileResult,
   interpretSimplexBmdBallot,
 } from '@votingworks/ballot-interpreter';
-import { fromGrayScale, writeImageData } from '@votingworks/image-utils';
+import {
+  fromGrayScale,
+  ImageData,
+  loadImageData,
+  writeImageData,
+} from '@votingworks/image-utils';
 import { join } from 'path';
 import {
   PaperHandlerStateMachine,
@@ -373,6 +378,23 @@ describe('paper jam', () => {
   });
 });
 
+function assertImageDatasEqual(
+  imageData1: ImageData,
+  imageData2: ImageData
+): void {
+  expect({
+    width: imageData1.width,
+    height: imageData1.height,
+  }).toEqual({
+    width: imageData2.width,
+    height: imageData2.height,
+  });
+  assert(
+    Buffer.from(imageData1.data).equals(Buffer.from(imageData2.data)),
+    'Image data does not match'
+  );
+}
+
 // Sets up print and scan mocks. Executes the state machine from 'not_accepting_paper' to 'presenting_ballot'.
 async function executePrintBallotAndAssert(
   ballotPdfData: Buffer,
@@ -413,10 +435,15 @@ async function executePrintBallotAndAssert(
   await expectStatusTransitionTo('interpreting');
 
   mockInterpretResult.resolve(interpretationResult);
-  expect(mockOf(interpretSimplexBmdBallot)).toHaveBeenCalledWith(
-    scanFixtureFilepath,
-    expect.objectContaining({})
-  );
+
+  const scanFixtureImageData = await loadImageData(scanFixtureFilepath);
+  expect(interpretSimplexBmdBallot).toHaveBeenCalledTimes(1);
+  const {
+    calls: [[frontImage]],
+  } = mockOf(interpretSimplexBmdBallot).mock;
+
+  assert(frontImage, 'No front image was passed to interpretSimplexBmdBallot');
+  assertImageDatasEqual(frontImage, scanFixtureImageData);
 }
 
 test('voting flow happy path', async () => {
@@ -513,10 +540,11 @@ test('elections with grid layouts still try to interpret BMD ballots', async () 
   );
 });
 
+const BLANK_IMAGE = fromGrayScale(new Uint8ClampedArray([0]), 1, 1);
+
 async function writeTmpBlankImage(): Promise<string> {
-  const blankImage = fromGrayScale(new Uint8ClampedArray([0]), 1, 1);
   const path = join(dirSync().name, 'blank-image.jpg');
-  await writeImageData(path, blankImage);
+  await writeImageData(path, BLANK_IMAGE);
   return path;
 }
 
@@ -779,7 +807,7 @@ describe('poll_worker_auth_ended_unexpectedly', () => {
     await expectStatusTransitionTo('poll_worker_auth_ended_unexpectedly');
 
     // Clean up hanging promise:
-    deferredScan.resolve('mock-scan.jpg');
+    deferredScan.resolve(await writeTmpBlankImage());
   });
 
   test('inserted_invalid_new_sheet state', async () => {
@@ -790,7 +818,7 @@ describe('poll_worker_auth_ended_unexpectedly', () => {
     machine.setAcceptingPaper();
     await expectStatusTransitionTo('accepting_paper');
 
-    mockOf(scanAndSave).mockResolvedValue('mock-scan.jpg');
+    mockOf(scanAndSave).mockResolvedValue(await writeTmpBlankImage());
 
     const interpretationType: PageInterpretationType = 'InvalidBallotHashPage';
     mockOf(interpretSimplexBmdBallot).mockResolvedValue([
@@ -816,7 +844,7 @@ describe('poll_worker_auth_ended_unexpectedly', () => {
     machine.setAcceptingPaper();
     await expectStatusTransitionTo('accepting_paper');
 
-    mockOf(scanAndSave).mockResolvedValue('mock-scan.jpg');
+    mockOf(scanAndSave).mockResolvedValue(await writeTmpBlankImage());
     mockOf(interpretSimplexBmdBallot).mockResolvedValue(
       SUCCESSFUL_INTERPRETATION_MOCK
     );
@@ -875,7 +903,7 @@ test('insert and validate new blank sheet', async () => {
   mockOf(interpretSimplexBmdBallot).mockReturnValue(
     mockInterpretResult.promise
   );
-  mockOf(scanAndSave).mockResolvedValue('mock-scan.jpg');
+  mockOf(scanAndSave).mockResolvedValue(await writeTmpBlankImage());
 
   driver.setMockStatus('paperInserted');
   await expectStatusTransitionTo('loading_new_sheet');
@@ -886,10 +914,13 @@ test('insert and validate new blank sheet', async () => {
   await expectStatusTransitionTo('waiting_for_voter_auth');
   mockCardlessVoterAuth(auth);
   await expectStatusTransitionTo('waiting_for_ballot_data');
-  expect(mockOf(interpretSimplexBmdBallot)).toHaveBeenLastCalledWith(
-    'mock-scan.jpg',
-    expect.anything()
-  );
+
+  const {
+    calls: [[frontImage]],
+  } = mockOf(interpretSimplexBmdBallot).mock;
+  assert(frontImage, 'No front image was passed to interpretSimplexBmdBallot');
+
+  assertImageDatasEqual(frontImage, BLANK_IMAGE);
 });
 
 describe('insert pre-printed ballot', () => {
@@ -902,7 +933,7 @@ describe('insert pre-printed ballot', () => {
   test('start session with valid pre-printed ballot', async () => {
     machine.setAcceptingPaper();
 
-    mockOf(scanAndSave).mockResolvedValue('mock-scan.jpg');
+    mockOf(scanAndSave).mockResolvedValue(await writeTmpBlankImage());
     mockOf(interpretSimplexBmdBallot).mockResolvedValue(
       SUCCESSFUL_INTERPRETATION_MOCK
     );
@@ -918,7 +949,7 @@ describe('insert pre-printed ballot', () => {
   test('return valid pre-printed ballot', async () => {
     machine.setAcceptingPaper();
 
-    mockOf(scanAndSave).mockResolvedValue('mock-scan.jpg');
+    mockOf(scanAndSave).mockResolvedValue(await writeTmpBlankImage());
     mockOf(interpretSimplexBmdBallot).mockResolvedValue(
       SUCCESSFUL_INTERPRETATION_MOCK
     );
@@ -946,42 +977,38 @@ describe('insert pre-printed ballot', () => {
     UnreadablePage: true,
   };
 
-  for (const interpretationType of Object.keys(
-    invalidInterpretationTypes
-  ) as PageInterpretationType[]) {
-    if (!invalidInterpretationTypes[interpretationType]) {
-      continue;
-    }
+  test.each(
+    iter(Object.entries(invalidInterpretationTypes))
+      .filterMap(([type, enabled]) => (enabled ? type : undefined))
+      .toArray()
+  )('insert invalid sheet: %s', async (interpretationType) => {
+    machine.setAcceptingPaper();
+    expect(machine.getSimpleStatus()).toEqual('accepting_paper');
 
-    test(`insert invalid sheet: ${interpretationType}`, async () => {
-      machine.setAcceptingPaper();
-      expect(machine.getSimpleStatus()).toEqual('accepting_paper');
+    mockOf(scanAndSave).mockResolvedValue(await writeTmpBlankImage());
 
-      mockOf(scanAndSave).mockResolvedValue('mock-scan.jpg');
+    const mockInterpretResult = deferred<SheetOf<InterpretFileResult>>();
+    mockOf(interpretSimplexBmdBallot).mockReturnValue(
+      mockInterpretResult.promise
+    );
 
-      const mockInterpretResult = deferred<SheetOf<InterpretFileResult>>();
-      mockOf(interpretSimplexBmdBallot).mockReturnValue(
-        mockInterpretResult.promise
-      );
+    driver.setMockStatus('paperInserted');
+    await expectStatusTransitionTo('loading_new_sheet');
+    await expectStatusTransitionTo('validating_new_sheet');
 
-      driver.setMockStatus('paperInserted');
-      await expectStatusTransitionTo('loading_new_sheet');
-      await expectStatusTransitionTo('validating_new_sheet');
+    mockInterpretResult.resolve([
+      {
+        interpretation: { type: interpretationType },
+      } as unknown as InterpretFileResult,
+      BLANK_PAGE_MOCK,
+    ]);
+    await expectStatusTransitionTo('inserted_invalid_new_sheet');
+    expectMockPaperHandlerStatus(driver, 'presentingPaper');
 
-      mockInterpretResult.resolve([
-        {
-          interpretation: { type: interpretationType },
-        } as unknown as InterpretFileResult,
-        BLANK_PAGE_MOCK,
-      ]);
-      await expectStatusTransitionTo('inserted_invalid_new_sheet');
-      expectMockPaperHandlerStatus(driver, 'presentingPaper');
-
-      // Simulate removing the rejected sheet:
-      driver.setMockStatus('noPaper');
-      await expectStatusTransitionTo('accepting_paper');
-    });
-  }
+    // Simulate removing the rejected sheet:
+    driver.setMockStatus('noPaper');
+    await expectStatusTransitionTo('accepting_paper');
+  });
 });
 
 describe('re-insert removed ballot', () => {
@@ -998,7 +1025,7 @@ describe('re-insert removed ballot', () => {
 
     machine.setAcceptingPaper();
 
-    mockOf(scanAndSave).mockResolvedValue('mock-scan.jpg');
+    mockOf(scanAndSave).mockResolvedValue(await writeTmpBlankImage());
     mockOf(interpretSimplexBmdBallot).mockResolvedValue(
       SUCCESSFUL_INTERPRETATION_MOCK
     );
@@ -1025,7 +1052,8 @@ describe('re-insert removed ballot', () => {
     mockOf(interpretSimplexBmdBallot).mockReturnValue(
       mockInterpretResult.promise
     );
-    mockOf(scanAndSave).mockResolvedValue('mock-reinsertion-scan.jpg');
+    const ballotImagePath = await writeTmpBlankImage();
+    mockOf(scanAndSave).mockResolvedValue(ballotImagePath);
 
     driver.setMockStatus('paperInserted');
     await expectStatusTransitionTo('loading_reinserted_ballot');
@@ -1033,10 +1061,11 @@ describe('re-insert removed ballot', () => {
 
     mockInterpretResult.resolve(SUCCESSFUL_INTERPRETATION_MOCK);
     await expectStatusTransitionTo('presenting_ballot');
-    expect(mockOf(interpretSimplexBmdBallot)).toHaveBeenLastCalledWith(
-      'mock-reinsertion-scan.jpg',
-      expect.anything()
-    );
+    const {
+      calls: [[frontImage]],
+    } = mockOf(interpretSimplexBmdBallot).mock;
+
+    assertImageDatasEqual(frontImage, BLANK_IMAGE);
   });
 
   const invalidInterpretationTypes: Record<PageInterpretationType, boolean> = {
@@ -1050,67 +1079,63 @@ describe('re-insert removed ballot', () => {
     UnreadablePage: true,
   };
 
-  for (const interpretationType of Object.keys(
-    invalidInterpretationTypes
-  ) as PageInterpretationType[]) {
-    if (!invalidInterpretationTypes[interpretationType]) {
-      continue;
-    }
+  test.each(
+    iter(Object.entries(invalidInterpretationTypes))
+      .filterMap(([type, enabled]) => (enabled ? type : undefined))
+      .toArray()
+  )(`reinsert invalid ballot: %s`, async (interpretationType) => {
+    //
+    // 1. [Setup] Seed voting session with pre-printed ballot:
+    //
 
-    test(`reinsert invalid ballot: ${interpretationType}`, async () => {
-      //
-      // 1. [Setup] Seed voting session with pre-printed ballot:
-      //
+    machine.setAcceptingPaper();
 
-      machine.setAcceptingPaper();
+    mockOf(scanAndSave).mockResolvedValue(await writeTmpBlankImage());
+    mockOf(interpretSimplexBmdBallot).mockResolvedValue(
+      SUCCESSFUL_INTERPRETATION_MOCK
+    );
 
-      mockOf(scanAndSave).mockResolvedValue('mock-scan.jpg');
-      mockOf(interpretSimplexBmdBallot).mockResolvedValue(
-        SUCCESSFUL_INTERPRETATION_MOCK
-      );
+    driver.setMockStatus('paperInserted');
+    await expectStatusTransitionTo('loading_new_sheet');
+    await expectStatusTransitionTo('inserted_preprinted_ballot');
 
-      driver.setMockStatus('paperInserted');
-      await expectStatusTransitionTo('loading_new_sheet');
-      await expectStatusTransitionTo('inserted_preprinted_ballot');
+    machine.startSessionWithPreprintedBallot();
+    await expectStatusTransitionTo('presenting_ballot');
 
-      machine.startSessionWithPreprintedBallot();
-      await expectStatusTransitionTo('presenting_ballot');
+    //
+    // 2. Remove ballot during presentation/review:
+    //
 
-      //
-      // 2. Remove ballot during presentation/review:
-      //
+    driver.setMockStatus('noPaper');
+    await expectStatusTransitionTo('waiting_for_ballot_reinsertion');
 
-      driver.setMockStatus('noPaper');
-      await expectStatusTransitionTo('waiting_for_ballot_reinsertion');
+    //
+    // 3. Re-insert invalid ballot:
+    //
 
-      //
-      // 3. Re-insert invalid ballot:
-      //
+    const mockInterpretResult = deferred<SheetOf<InterpretFileResult>>();
+    mockOf(interpretSimplexBmdBallot).mockReturnValue(
+      mockInterpretResult.promise
+    );
 
-      const mockInterpretResult = deferred<SheetOf<InterpretFileResult>>();
-      mockOf(interpretSimplexBmdBallot).mockReturnValue(
-        mockInterpretResult.promise
-      );
+    driver.setMockStatus('paperInserted');
+    await expectStatusTransitionTo('loading_reinserted_ballot');
+    await expectStatusTransitionTo('validating_reinserted_ballot');
 
-      driver.setMockStatus('paperInserted');
-      await expectStatusTransitionTo('loading_reinserted_ballot');
-      await expectStatusTransitionTo('validating_reinserted_ballot');
+    mockInterpretResult.resolve([
+      {
+        interpretation: { type: interpretationType },
+      } as unknown as InterpretFileResult,
+      BLANK_PAGE_MOCK,
+    ]);
+    await expectStatusTransitionTo('reinserted_invalid_ballot');
+    expectMockPaperHandlerStatus(driver, 'presentingPaper');
 
-      mockInterpretResult.resolve([
-        {
-          interpretation: { type: interpretationType },
-        } as unknown as InterpretFileResult,
-        BLANK_PAGE_MOCK,
-      ]);
-      await expectStatusTransitionTo('reinserted_invalid_ballot');
-      expectMockPaperHandlerStatus(driver, 'presentingPaper');
+    //
+    // 4. Remove invalid ballot:
+    //
 
-      //
-      // 4. Remove invalid ballot:
-      //
-
-      driver.setMockStatus('noPaper');
-      await expectStatusTransitionTo('waiting_for_ballot_reinsertion');
-    });
-  }
+    driver.setMockStatus('noPaper');
+    await expectStatusTransitionTo('waiting_for_ballot_reinsertion');
+  });
 });

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -33,7 +33,7 @@ import {
 } from '@votingworks/utils';
 import {
   InterpretFileResult,
-  interpretSimplexBmdBallotFromFilepath,
+  interpretSimplexBmdBallot,
 } from '@votingworks/ballot-interpreter';
 import { fromGrayScale, writeImageData } from '@votingworks/image-utils';
 import { join } from 'path';
@@ -385,7 +385,7 @@ async function executePrintBallotAndAssert(
   mockOf(scanAndSave).mockResolvedValue(mockScanResult.promise);
 
   const mockInterpretResult = deferred<SheetOf<InterpretFileResult>>();
-  mockOf(interpretSimplexBmdBallotFromFilepath).mockResolvedValue(
+  mockOf(interpretSimplexBmdBallot).mockResolvedValue(
     mockInterpretResult.promise
   );
 
@@ -413,7 +413,7 @@ async function executePrintBallotAndAssert(
   await expectStatusTransitionTo('interpreting');
 
   mockInterpretResult.resolve(interpretationResult);
-  expect(mockOf(interpretSimplexBmdBallotFromFilepath)).toHaveBeenCalledWith(
+  expect(mockOf(interpretSimplexBmdBallot)).toHaveBeenCalledWith(
     scanFixtureFilepath,
     expect.objectContaining({})
   );
@@ -793,7 +793,7 @@ describe('poll_worker_auth_ended_unexpectedly', () => {
     mockOf(scanAndSave).mockResolvedValue('mock-scan.jpg');
 
     const interpretationType: PageInterpretationType = 'InvalidBallotHashPage';
-    mockOf(interpretSimplexBmdBallotFromFilepath).mockResolvedValue([
+    mockOf(interpretSimplexBmdBallot).mockResolvedValue([
       {
         interpretation: { type: interpretationType },
       } as unknown as InterpretFileResult,
@@ -817,7 +817,7 @@ describe('poll_worker_auth_ended_unexpectedly', () => {
     await expectStatusTransitionTo('accepting_paper');
 
     mockOf(scanAndSave).mockResolvedValue('mock-scan.jpg');
-    mockOf(interpretSimplexBmdBallotFromFilepath).mockResolvedValue(
+    mockOf(interpretSimplexBmdBallot).mockResolvedValue(
       SUCCESSFUL_INTERPRETATION_MOCK
     );
 
@@ -872,7 +872,7 @@ test('insert and validate new blank sheet', async () => {
   expect(machine.getSimpleStatus()).toEqual('accepting_paper');
 
   const mockInterpretResult = deferred<SheetOf<InterpretFileResult>>();
-  mockOf(interpretSimplexBmdBallotFromFilepath).mockReturnValue(
+  mockOf(interpretSimplexBmdBallot).mockReturnValue(
     mockInterpretResult.promise
   );
   mockOf(scanAndSave).mockResolvedValue('mock-scan.jpg');
@@ -886,9 +886,10 @@ test('insert and validate new blank sheet', async () => {
   await expectStatusTransitionTo('waiting_for_voter_auth');
   mockCardlessVoterAuth(auth);
   await expectStatusTransitionTo('waiting_for_ballot_data');
-  expect(
-    mockOf(interpretSimplexBmdBallotFromFilepath)
-  ).toHaveBeenLastCalledWith('mock-scan.jpg', expect.anything());
+  expect(mockOf(interpretSimplexBmdBallot)).toHaveBeenLastCalledWith(
+    'mock-scan.jpg',
+    expect.anything()
+  );
 });
 
 describe('insert pre-printed ballot', () => {
@@ -902,7 +903,7 @@ describe('insert pre-printed ballot', () => {
     machine.setAcceptingPaper();
 
     mockOf(scanAndSave).mockResolvedValue('mock-scan.jpg');
-    mockOf(interpretSimplexBmdBallotFromFilepath).mockResolvedValue(
+    mockOf(interpretSimplexBmdBallot).mockResolvedValue(
       SUCCESSFUL_INTERPRETATION_MOCK
     );
 
@@ -918,7 +919,7 @@ describe('insert pre-printed ballot', () => {
     machine.setAcceptingPaper();
 
     mockOf(scanAndSave).mockResolvedValue('mock-scan.jpg');
-    mockOf(interpretSimplexBmdBallotFromFilepath).mockResolvedValue(
+    mockOf(interpretSimplexBmdBallot).mockResolvedValue(
       SUCCESSFUL_INTERPRETATION_MOCK
     );
 
@@ -959,7 +960,7 @@ describe('insert pre-printed ballot', () => {
       mockOf(scanAndSave).mockResolvedValue('mock-scan.jpg');
 
       const mockInterpretResult = deferred<SheetOf<InterpretFileResult>>();
-      mockOf(interpretSimplexBmdBallotFromFilepath).mockReturnValue(
+      mockOf(interpretSimplexBmdBallot).mockReturnValue(
         mockInterpretResult.promise
       );
 
@@ -998,7 +999,7 @@ describe('re-insert removed ballot', () => {
     machine.setAcceptingPaper();
 
     mockOf(scanAndSave).mockResolvedValue('mock-scan.jpg');
-    mockOf(interpretSimplexBmdBallotFromFilepath).mockResolvedValue(
+    mockOf(interpretSimplexBmdBallot).mockResolvedValue(
       SUCCESSFUL_INTERPRETATION_MOCK
     );
 
@@ -1021,7 +1022,7 @@ describe('re-insert removed ballot', () => {
     //
 
     const mockInterpretResult = deferred<SheetOf<InterpretFileResult>>();
-    mockOf(interpretSimplexBmdBallotFromFilepath).mockReturnValue(
+    mockOf(interpretSimplexBmdBallot).mockReturnValue(
       mockInterpretResult.promise
     );
     mockOf(scanAndSave).mockResolvedValue('mock-reinsertion-scan.jpg');
@@ -1032,9 +1033,10 @@ describe('re-insert removed ballot', () => {
 
     mockInterpretResult.resolve(SUCCESSFUL_INTERPRETATION_MOCK);
     await expectStatusTransitionTo('presenting_ballot');
-    expect(
-      mockOf(interpretSimplexBmdBallotFromFilepath)
-    ).toHaveBeenLastCalledWith('mock-reinsertion-scan.jpg', expect.anything());
+    expect(mockOf(interpretSimplexBmdBallot)).toHaveBeenLastCalledWith(
+      'mock-reinsertion-scan.jpg',
+      expect.anything()
+    );
   });
 
   const invalidInterpretationTypes: Record<PageInterpretationType, boolean> = {
@@ -1063,7 +1065,7 @@ describe('re-insert removed ballot', () => {
       machine.setAcceptingPaper();
 
       mockOf(scanAndSave).mockResolvedValue('mock-scan.jpg');
-      mockOf(interpretSimplexBmdBallotFromFilepath).mockResolvedValue(
+      mockOf(interpretSimplexBmdBallot).mockResolvedValue(
         SUCCESSFUL_INTERPRETATION_MOCK
       );
 
@@ -1086,7 +1088,7 @@ describe('re-insert removed ballot', () => {
       //
 
       const mockInterpretResult = deferred<SheetOf<InterpretFileResult>>();
-      mockOf(interpretSimplexBmdBallotFromFilepath).mockReturnValue(
+      mockOf(interpretSimplexBmdBallot).mockReturnValue(
         mockInterpretResult.promise
       );
 

--- a/apps/mark-scan/backend/test/ballot_helpers.ts
+++ b/apps/mark-scan/backend/test/ballot_helpers.ts
@@ -1,12 +1,8 @@
 import { InterpretFileResult } from '@votingworks/ballot-interpreter';
 import { SheetOf } from '@votingworks/types';
+import { createImageData } from 'canvas';
 
-export const MOCK_IMAGE: ImageData = {
-  colorSpace: 'srgb',
-  data: new Uint8ClampedArray(),
-  height: 0,
-  width: 0,
-} as const;
+export const MOCK_IMAGE = createImageData(1, 1);
 
 export const BLANK_PAGE_MOCK: InterpretFileResult = {
   interpretation: { type: 'BlankPage' },

--- a/apps/mark-scan/backend/test/setup_custom_matchers.ts
+++ b/apps/mark-scan/backend/test/setup_custom_matchers.ts
@@ -3,6 +3,10 @@ import {
   toMatchPdfSnapshot,
 } from '@votingworks/image-utils';
 import { toMatchImageSnapshot } from 'jest-image-snapshot';
+import { setGracefulCleanup } from 'tmp';
+
+// ensure tmp files are cleaned up
+setGracefulCleanup();
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/apps/scan/backend/jest.config.js
+++ b/apps/scan/backend/jest.config.js
@@ -24,7 +24,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       statements: -180,
-      branches: -48,
+      branches: -60,
       functions: -15,
       lines: -180,
     },

--- a/apps/scan/backend/src/interpret.ts
+++ b/apps/scan/backend/src/interpret.ts
@@ -1,4 +1,9 @@
 import {
+  InterpreterOptions,
+  interpretSheetAndSaveImages,
+} from '@votingworks/ballot-interpreter';
+import { ok, Result } from '@votingworks/basics';
+import {
   AdjudicationReason,
   AdjudicationReasonInfo,
   PageInterpretationWithFiles,
@@ -7,11 +12,7 @@ import {
   SheetOf,
 } from '@votingworks/types';
 import { time } from '@votingworks/utils';
-import { ok, Result } from '@votingworks/basics';
-import {
-  interpretSheetAndSaveImages,
-  InterpreterOptions,
-} from '@votingworks/ballot-interpreter';
+import { ImageData } from 'canvas';
 import { rootDebug } from './util/debug';
 
 export function combinePageInterpretationsForSheet(
@@ -123,7 +124,7 @@ export function combinePageInterpretationsForSheet(
 
 export async function interpret(
   sheetId: string,
-  sheet: SheetOf<string>,
+  sheet: SheetOf<ImageData>,
   options: InterpreterOptions & { ballotImagesPath: string }
 ): Promise<Result<SheetInterpretationWithPages, Error>> {
   const timer = time(rootDebug, `vxInterpret: ${sheetId}`);

--- a/apps/scan/backend/src/scanners/custom/custom_app_scan_double_sheets.test.ts
+++ b/apps/scan/backend/src/scanners/custom/custom_app_scan_double_sheets.test.ts
@@ -1,25 +1,30 @@
+import { deferred, err, ok, Result } from '@votingworks/basics';
+import {
+  ErrorCode,
+  ImageFromScanner,
+  mocks,
+} from '@votingworks/custom-scanner';
+import { electionGridLayoutNewHampshireTestBallotFixtures } from '@votingworks/fixtures';
 import {
   AdjudicationReason,
   AdjudicationReasonInfo,
   DEFAULT_SYSTEM_SETTINGS,
   SheetInterpretation,
+  SheetOf,
 } from '@votingworks/types';
-import { err, ok, typedAs } from '@votingworks/basics';
-import { ErrorCode, mocks } from '@votingworks/custom-scanner';
 import {
   BooleanEnvironmentVariableName,
   getFeatureFlagMock,
 } from '@votingworks/utils';
-import { electionGridLayoutNewHampshireTestBallotFixtures } from '@votingworks/fixtures';
-import {
-  configureApp,
-  waitForStatus,
-} from '../../../test/helpers/shared_helpers';
 import {
   ballotImages,
   simulateScan,
   withApp,
 } from '../../../test/helpers/custom_helpers';
+import {
+  configureApp,
+  waitForStatus,
+} from '../../../test/helpers/shared_helpers';
 import { delays } from './state_machine';
 
 jest.setTimeout(20_000);
@@ -48,9 +53,13 @@ test('insert second ballot before first ballot accept', async () => {
       await configureApp(apiClient, mockAuth, mockUsbDrive, { testMode: true });
 
       mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
-      mockScanner.scan.mockResolvedValue(ok(await ballotImages.completeBmd()));
+
+      const scanDeferred =
+        deferred<Result<SheetOf<ImageFromScanner>, ErrorCode>>();
+      mockScanner.scan.mockResolvedValue(scanDeferred.promise);
       clock.increment(delays.DELAY_PAPER_STATUS_POLLING_INTERVAL);
       await waitForStatus(apiClient, { state: 'scanning' });
+      scanDeferred.resolve(ok(await ballotImages.completeBmd()));
 
       mockScanner.getStatus.mockResolvedValue(
         ok(mocks.MOCK_BOTH_SIDES_HAVE_PAPER)
@@ -129,11 +138,9 @@ test('insert second ballot while first ballot needs review', async () => {
   const interpretation: SheetInterpretation = {
     type: 'NeedsReviewSheet',
     reasons: [
-      expect.objectContaining(
-        typedAs<Partial<AdjudicationReasonInfo>>({
-          type: AdjudicationReason.Overvote,
-        })
-      ),
+      expect.objectContaining<Partial<AdjudicationReasonInfo>>({
+        type: AdjudicationReason.Overvote,
+      }),
     ],
   };
   await withApp(
@@ -148,24 +155,46 @@ test('insert second ballot while first ballot needs review', async () => {
           ),
       });
 
-      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
-      simulateScan(mockScanner, await ballotImages.overvoteHmpb(), clock);
+      // set up deferred scan result
+      const scanDeferred =
+        deferred<Result<SheetOf<ImageFromScanner>, ErrorCode>>();
+      mockScanner.scan.mockResolvedValue(scanDeferred.promise);
 
+      // mark as ready and trigger the scan
+      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
+      clock.increment(delays.DELAY_PAPER_STATUS_POLLING_INTERVAL);
+
+      // ensure we're scanning before we release the deferred scan result
+      await waitForStatus(apiClient, { state: 'scanning' });
+
+      // switch to being ready to eject with the scan result
+      mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
+      scanDeferred.resolve(ok(await ballotImages.overvoteHmpb()));
+      clock.increment(delays.DELAY_PAPER_STATUS_POLLING_INTERVAL);
+
+      // now we're in review
       await waitForStatus(apiClient, { state: 'needs_review', interpretation });
 
+      // simulate another sheet of paper being inserted in front
       mockScanner.getStatus.mockResolvedValue(
         ok(mocks.MOCK_BOTH_SIDES_HAVE_PAPER)
       );
       clock.increment(delays.DELAY_PAPER_STATUS_POLLING_INTERVAL);
+
+      // we can't accept the in-review ballot
       await waitForStatus(apiClient, {
         state: 'both_sides_have_paper',
         interpretation,
       });
 
+      // simulate removing the paper from the front
       mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
       clock.increment(delays.DELAY_PAPER_STATUS_POLLING_INTERVAL);
+
+      // now we're back to review
       await waitForStatus(apiClient, { state: 'needs_review', interpretation });
 
+      // trigger accepting the ballot
       await apiClient.acceptBallot();
       await waitForStatus(apiClient, {
         state: 'accepting_after_review',

--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -40,7 +40,11 @@ import {
 } from '../../types';
 import { rootDebug } from '../../util/debug';
 import { Workspace } from '../../util/workspace';
-import { recordAcceptedSheet, recordRejectedSheet } from '../shared';
+import {
+  cleanLogData,
+  recordAcceptedSheet,
+  recordRejectedSheet,
+} from '../shared';
 
 const debug = rootDebug.extend('state-machine');
 
@@ -978,39 +982,6 @@ function setupLogging(
   machineService: Interpreter<Context, any, Event, any, any>,
   logger: BaseLogger
 ) {
-  function cleanLogData(key: string, value: unknown): unknown {
-    if (value === undefined) {
-      return 'undefined';
-    }
-    if (value instanceof ImageData) {
-      return {
-        width: value.width,
-        height: value.height,
-        data: value.data.length,
-      };
-    }
-    if (value instanceof Error) {
-      return { ...value, message: value.message, stack: value.stack };
-    }
-    if (
-      [
-        // Protect voter privacy
-        'markInfo',
-        'votes',
-        'unmarkedWriteIns',
-        'adjudicationInfo',
-        'reasons',
-        // Hide large values
-        'layout',
-        'client',
-        'rootListenerRef',
-      ].includes(key)
-    ) {
-      return '[hidden]';
-    }
-    return value;
-  }
-
   machineService
     .onEvent(async (event) => {
       const eventString = JSON.stringify(event, cleanLogData);

--- a/apps/scan/backend/src/scanners/shared.ts
+++ b/apps/scan/backend/src/scanners/shared.ts
@@ -2,6 +2,7 @@ import { assert, assertDefined } from '@votingworks/basics';
 import { Id, SheetInterpretationWithPages } from '@votingworks/types';
 import { UsbDrive } from '@votingworks/usb-drive';
 import { exportCastVoteRecordsToUsbDrive } from '@votingworks/backend';
+import { ImageData } from 'canvas';
 import { Store } from '../store';
 import { rootDebug } from '../util/debug';
 import { Workspace } from '../util/workspace';
@@ -86,4 +87,37 @@ export async function recordRejectedSheet(
   exportResult.unsafeUnwrap();
 
   debug('Stored rejected sheet: %s', sheetId);
+}
+
+export function cleanLogData(key: string, value: unknown): unknown {
+  if (value === undefined) {
+    return 'undefined';
+  }
+  if (value instanceof ImageData) {
+    return {
+      width: value.width,
+      height: value.height,
+      data: value.data.length,
+    };
+  }
+  if (value instanceof Error) {
+    return { ...value, message: value.message, stack: value.stack };
+  }
+  if (
+    [
+      // Protect voter privacy
+      'markInfo',
+      'votes',
+      'unmarkedWriteIns',
+      'adjudicationInfo',
+      'reasons',
+      // Hide large values
+      'layout',
+      'client',
+      'rootListenerRef',
+    ].includes(key)
+  ) {
+    return '[hidden]';
+  }
+  return value;
 }

--- a/libs/ballot-interpreter/benchmarks/interpret_hmpb.bench.ts
+++ b/libs/ballot-interpreter/benchmarks/interpret_hmpb.bench.ts
@@ -1,14 +1,15 @@
-import { assert, assertDefined } from '@votingworks/basics';
+import { assertDefined } from '@votingworks/basics';
 import { readElection } from '@votingworks/fs';
 import { famousNamesFixtures } from '@votingworks/hmpb';
 import {
+  asSheet,
   DEFAULT_MARK_THRESHOLDS,
   ElectionDefinition,
 } from '@votingworks/types';
 import { singlePrecinctSelectionFor } from '@votingworks/utils';
 import { interpretSheet } from '../src';
+import { pdfToPageImages } from '../test/helpers/interpretation';
 import { benchmarkRegressionTest } from './benchmarking';
-import { pdfToPageImagePaths } from '../test/helpers/interpretation';
 
 jest.setTimeout(60_000);
 
@@ -21,8 +22,9 @@ describe('Interpretation benchmark', () => {
   });
 
   test('Blank HMPB', async () => {
-    const ballotImagePaths = await pdfToPageImagePaths(blankBallotPath);
-    assert(ballotImagePaths.length === 2);
+    const ballotImages = asSheet(
+      await pdfToPageImages(blankBallotPath).toArray()
+    );
 
     await benchmarkRegressionTest({
       label: 'Blank HMPB interpretation',
@@ -37,7 +39,7 @@ describe('Interpretation benchmark', () => {
             markThresholds: DEFAULT_MARK_THRESHOLDS,
             adjudicationReasons: [],
           },
-          ballotImagePaths as [string, string]
+          ballotImages
         );
       },
       runs: 50,
@@ -45,8 +47,9 @@ describe('Interpretation benchmark', () => {
   });
 
   test('Marked HMPB', async () => {
-    const ballotImagePaths = await pdfToPageImagePaths(markedBallotPath);
-    assert(ballotImagePaths.length === 2);
+    const ballotImages = asSheet(
+      await pdfToPageImages(markedBallotPath).toArray()
+    );
 
     await benchmarkRegressionTest({
       label: 'Marked HMPB interpretation',
@@ -61,7 +64,7 @@ describe('Interpretation benchmark', () => {
             markThresholds: DEFAULT_MARK_THRESHOLDS,
             adjudicationReasons: [],
           },
-          ballotImagePaths as [string, string]
+          ballotImages
         );
       },
       runs: 50,

--- a/libs/ballot-interpreter/src/__snapshots__/interpret_bmd_ballots.test.ts.snap
+++ b/libs/ballot-interpreter/src/__snapshots__/interpret_bmd_ballots.test.ts.snap
@@ -135,7 +135,7 @@ exports[`VX BMD interpretation extracts votes encoded in a QR code 1`] = `
 ]
 `;
 
-exports[`VX BMD interpretation interpretSimplexBmdBallotFromFilepath 1`] = `
+exports[`VX BMD interpretation interpretSimplexBmdBallot 1`] = `
 [
   {
     "ballotId": undefined,

--- a/libs/ballot-interpreter/src/__snapshots__/interpret_nh_hmpb.test.ts.snap
+++ b/libs/ballot-interpreter/src/__snapshots__/interpret_nh_hmpb.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 1`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=04e81bd0-1cb6-4030-bc35-2ac549b25437 1`] = `
 {
   "04e81bd0-1cb6-4030-bc35-2ac549b25437": [
     {
@@ -62,7 +62,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 1`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 2`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=05b4f778-4a9c-477f-bb7d-40ca98c280e9 1`] = `
 {
   "05b4f778-4a9c-477f-bb7d-40ca98c280e9": [
     {
@@ -172,88 +172,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 2`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 3`] = `
-{
-  "0603e8df-6aa4-413c-b5cc-f2dadad9c441": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [
-          {
-            "id": "Anne-Waldron-ee0cbc85",
-            "name": "Anne Waldron",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Governor-061a401b": [
-          {
-            "id": "Hannah-Dustin-ab4ef7c8",
-            "name": "Hannah Dustin",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Representative-in-Congress-24683b44": [
-          {
-            "id": "Nicholas-Gilman-1791aed7",
-            "name": "Nicholas Gilman",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "State-Representative-Hillsborough-District-37-f3bde894": [],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [],
-        "State-Senator-391381f8": [],
-        "United-States-Senator-d3f1c75b": [
-          {
-            "id": "John-Langdon-5951c8e1",
-            "name": "John Langdon",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [],
-        "County-Commissioner-d6feed25": [],
-        "County-Treasurer-87d25a31": [],
-        "Register-of-Deeds-a1278df2": [],
-        "Register-of-Probate-a4117da8": [],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
-        "Sheriff-4243fe0b": [],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 4`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=060d4aba-9b70-43c3-80e0-1ac38dc129a6 1`] = `
 {
   "060d4aba-9b70-43c3-80e0-1ac38dc129a6": [
     {
@@ -348,7 +267,88 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 4`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 5`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=0603e8df-6aa4-413c-b5cc-f2dadad9c441 1`] = `
+{
+  "0603e8df-6aa4-413c-b5cc-f2dadad9c441": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [
+          {
+            "id": "Anne-Waldron-ee0cbc85",
+            "name": "Anne Waldron",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Governor-061a401b": [
+          {
+            "id": "Hannah-Dustin-ab4ef7c8",
+            "name": "Hannah Dustin",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Representative-in-Congress-24683b44": [
+          {
+            "id": "Nicholas-Gilman-1791aed7",
+            "name": "Nicholas Gilman",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "State-Representative-Hillsborough-District-37-f3bde894": [],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [],
+        "State-Senator-391381f8": [],
+        "United-States-Senator-d3f1c75b": [
+          {
+            "id": "John-Langdon-5951c8e1",
+            "name": "John Langdon",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [],
+        "County-Commissioner-d6feed25": [],
+        "County-Treasurer-87d25a31": [],
+        "Register-of-Deeds-a1278df2": [],
+        "Register-of-Probate-a4117da8": [],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
+        "Sheriff-4243fe0b": [],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=0c802ae3-06f5-431b-8953-6368f93e71b1 1`] = `
 {
   "0c802ae3-06f5-431b-8953-6368f93e71b1": [
     {
@@ -499,121 +499,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 5`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 6`] = `
-{
-  "12ee4c7c-fe40-4492-94ca-75bcf6db9f18": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [],
-        "Governor-061a401b": [
-          {
-            "id": "Josiah-Bartlett-1bb99985",
-            "name": "Josiah Bartlett",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Representative-in-Congress-24683b44": [],
-        "State-Representative-Hillsborough-District-37-f3bde894": [],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [],
-        "State-Senator-391381f8": [],
-        "United-States-Senator-d3f1c75b": [
-          {
-            "id": "William-Preston-3778fcd5",
-            "name": "William Preston",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [],
-        "County-Commissioner-d6feed25": [],
-        "County-Treasurer-87d25a31": [],
-        "Register-of-Deeds-a1278df2": [],
-        "Register-of-Probate-a4117da8": [],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
-        "Sheriff-4243fe0b": [],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 7`] = `
-{
-  "12effe84-6be5-481b-b70d-5a5df4b049e7": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [],
-        "Governor-061a401b": [],
-        "Representative-in-Congress-24683b44": [],
-        "State-Representative-Hillsborough-District-37-f3bde894": [],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [],
-        "State-Senator-391381f8": [],
-        "United-States-Senator-d3f1c75b": [],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [],
-        "County-Commissioner-d6feed25": [],
-        "County-Treasurer-87d25a31": [],
-        "Register-of-Deeds-a1278df2": [],
-        "Register-of-Probate-a4117da8": [],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
-        "Sheriff-4243fe0b": [],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 8`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=1d8eb82c-43bb-454d-a85b-1ffaf65c2b72 1`] = `
 {
   "1d8eb82c-43bb-454d-a85b-1ffaf65c2b72": [
     {
@@ -725,7 +611,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 8`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 9`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=1e44bb3a-dfb3-4f70-9ed5-7da7548af1bd 1`] = `
 {
   "1e44bb3a-dfb3-4f70-9ed5-7da7548af1bd": [
     {
@@ -804,721 +690,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 9`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 10`] = `
-{
-  "21e0d2db-0f44-4a23-ac08-2eec70851df5": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [],
-        "Governor-061a401b": [
-          {
-            "id": "write-in-0",
-            "isWriteIn": true,
-            "name": "Write-In #1",
-            "writeInIndex": 0,
-          },
-        ],
-        "Representative-in-Congress-24683b44": [],
-        "State-Representative-Hillsborough-District-37-f3bde894": [
-          {
-            "id": "William-Lovejoy-fde3c2df",
-            "name": "William Lovejoy",
-            "partyIds": [
-              "OC-3a386d2b",
-            ],
-          },
-        ],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [
-          {
-            "id": "Obadiah-Carrigan-5c95145a",
-            "name": "Obadiah Carrigan",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-          {
-            "id": "Mary-Baker-Eddy-350785d5",
-            "name": "Mary Baker Eddy",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-          {
-            "id": "Samuel-Bell-17973275",
-            "name": "Samuel Bell",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-          {
-            "id": "Elijah-Miller-a52e6988",
-            "name": "Elijah Miller",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "State-Senator-391381f8": [],
-        "United-States-Senator-d3f1c75b": [
-          {
-            "id": "write-in-0",
-            "isWriteIn": true,
-            "name": "Write-In #1",
-            "writeInIndex": 0,
-          },
-        ],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [
-          {
-            "id": "Ezra-Bartlett-8f95223c",
-            "name": "Ezra Bartlett",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "County-Commissioner-d6feed25": [
-          {
-            "id": "Ichabod-Goodwin-55e8de1f",
-            "name": "Ichabod Goodwin",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "County-Treasurer-87d25a31": [
-          {
-            "id": "John-Smith-ef61a579",
-            "name": "John Smith",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Register-of-Deeds-a1278df2": [
-          {
-            "id": "John-Mann-b56bbdd3",
-            "name": "John Mann",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Register-of-Probate-a4117da8": [
-          {
-            "id": "Nathaniel-Parker-56a06c29",
-            "name": "Nathaniel Parker",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [
-          "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-yes",
-        ],
-        "Sheriff-4243fe0b": [
-          {
-            "id": "Edward-Randolph-bf4c848a",
-            "name": "Edward Randolph",
-            "partyIds": [
-              "Democratic-aea20adb",
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 11`] = `
-{
-  "227e070a-53e5-4409-a89d-cec7e8c45c7d": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [],
-        "Governor-061a401b": [],
-        "Representative-in-Congress-24683b44": [],
-        "State-Representative-Hillsborough-District-37-f3bde894": [],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [
-          {
-            "id": "Samuel-Bell-17973275",
-            "name": "Samuel Bell",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-          {
-            "id": "Isaac-Hill-d6c9deeb",
-            "name": "Isaac Hill",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-          {
-            "id": "Abigail-Bartlett-4e46c9d4",
-            "name": "Abigail Bartlett",
-            "partyIds": [
-              "OC-3a386d2b",
-            ],
-          },
-          {
-            "id": "Jacob-Freese-b5146505",
-            "name": "Jacob Freese",
-            "partyIds": [
-              "OC-3a386d2b",
-            ],
-          },
-        ],
-        "State-Senator-391381f8": [],
-        "United-States-Senator-d3f1c75b": [],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [],
-        "County-Commissioner-d6feed25": [],
-        "County-Treasurer-87d25a31": [],
-        "Register-of-Deeds-a1278df2": [],
-        "Register-of-Probate-a4117da8": [],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
-        "Sheriff-4243fe0b": [],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 12`] = `
-{
-  "22c0ab78-020b-4535-b231-5b5177581265": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [
-          {
-            "id": "Anne-Waldron-ee0cbc85",
-            "name": "Anne Waldron",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Governor-061a401b": [],
-        "Representative-in-Congress-24683b44": [
-          {
-            "id": "Jeremiah-Smith-469560c9",
-            "name": "Jeremiah Smith",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "State-Representative-Hillsborough-District-37-f3bde894": [],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [
-          {
-            "id": "Abigail-Bartlett-4e46c9d4",
-            "name": "Abigail Bartlett",
-            "partyIds": [
-              "OC-3a386d2b",
-            ],
-          },
-        ],
-        "State-Senator-391381f8": [],
-        "United-States-Senator-d3f1c75b": [],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [],
-        "County-Commissioner-d6feed25": [],
-        "County-Treasurer-87d25a31": [],
-        "Register-of-Deeds-a1278df2": [],
-        "Register-of-Probate-a4117da8": [],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
-        "Sheriff-4243fe0b": [],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 13`] = `
-{
-  "30950612-8e0b-4934-a7b9-5e2190724afe": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [],
-        "Governor-061a401b": [
-          {
-            "id": "John-Spencer-9ffb5970",
-            "name": "John Spencer",
-            "partyIds": [
-              "OC-3a386d2b",
-            ],
-          },
-        ],
-        "Representative-in-Congress-24683b44": [
-          {
-            "id": "Nicholas-Gilman-1791aed7",
-            "name": "Nicholas Gilman",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "State-Representative-Hillsborough-District-37-f3bde894": [],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [],
-        "State-Senator-391381f8": [
-          {
-            "id": "write-in-0",
-            "isWriteIn": true,
-            "name": "Write-In #1",
-            "writeInIndex": 0,
-          },
-        ],
-        "United-States-Senator-d3f1c75b": [],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [],
-        "County-Commissioner-d6feed25": [
-          {
-            "id": "write-in-0",
-            "isWriteIn": true,
-            "name": "Write-In #1",
-            "writeInIndex": 0,
-          },
-        ],
-        "County-Treasurer-87d25a31": [],
-        "Register-of-Deeds-a1278df2": [
-          {
-            "id": "John-Mann-b56bbdd3",
-            "name": "John Mann",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Register-of-Probate-a4117da8": [],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
-        "Sheriff-4243fe0b": [],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 14`] = `
-{
-  "32e0764e-e0b1-4275-b5bd-e6e9f1b504fc": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [
-          {
-            "id": "Daniel-Webster-13f77b2d",
-            "name": "Daniel Webster",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Governor-061a401b": [
-          {
-            "id": "Hannah-Dustin-ab4ef7c8",
-            "name": "Hannah Dustin",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Representative-in-Congress-24683b44": [
-          {
-            "id": "Nicholas-Gilman-1791aed7",
-            "name": "Nicholas Gilman",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "State-Representative-Hillsborough-District-37-f3bde894": [
-          {
-            "id": "Charles-H-Hersey-096286a4",
-            "name": "Charles H. Hersey",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [
-          {
-            "id": "Elijah-Miller-a52e6988",
-            "name": "Elijah Miller",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "State-Senator-391381f8": [
-          {
-            "id": "Matthew-Thornton-f66fec5e",
-            "name": "Matthew Thornton",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "United-States-Senator-d3f1c75b": [
-          {
-            "id": "William-Preston-3778fcd5",
-            "name": "William Preston",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [
-          {
-            "id": "Mary-Woolson-dc0b854a",
-            "name": "Mary Woolson",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "County-Commissioner-d6feed25": [
-          {
-            "id": "Valbe-Cady-ba3af3af",
-            "name": "Valbe Cady",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "County-Treasurer-87d25a31": [
-          {
-            "id": "Jane-Jones-9caa141f",
-            "name": "Jane Jones",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Register-of-Deeds-a1278df2": [
-          {
-            "id": "Ellen-A-Stileman-14408737",
-            "name": "Ellen A. Stileman",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Register-of-Probate-a4117da8": [
-          {
-            "id": "Claire-Cutts-07a436e7",
-            "name": "Claire Cutts",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [
-          "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-yes",
-        ],
-        "Sheriff-4243fe0b": [
-          {
-            "id": "Edward-Randolph-bf4c848a",
-            "name": "Edward Randolph",
-            "partyIds": [
-              "Democratic-aea20adb",
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 15`] = `
-{
-  "346698d4-e4fa-4f9f-956d-2e86a0150673": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [],
-        "Governor-061a401b": [],
-        "Representative-in-Congress-24683b44": [],
-        "State-Representative-Hillsborough-District-37-f3bde894": [
-          {
-            "id": "write-in-0",
-            "isWriteIn": true,
-            "name": "Write-In #1",
-            "writeInIndex": 0,
-          },
-        ],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [
-          {
-            "id": "Obadiah-Carrigan-5c95145a",
-            "name": "Obadiah Carrigan",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-          {
-            "id": "Mary-Baker-Eddy-350785d5",
-            "name": "Mary Baker Eddy",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-          {
-            "id": "Elijah-Miller-a52e6988",
-            "name": "Elijah Miller",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "State-Senator-391381f8": [],
-        "United-States-Senator-d3f1c75b": [],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [],
-        "County-Commissioner-d6feed25": [],
-        "County-Treasurer-87d25a31": [
-          {
-            "id": "Jane-Jones-9caa141f",
-            "name": "Jane Jones",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Register-of-Deeds-a1278df2": [
-          {
-            "id": "Ellen-A-Stileman-14408737",
-            "name": "Ellen A. Stileman",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Register-of-Probate-a4117da8": [],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [
-          "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-no",
-        ],
-        "Sheriff-4243fe0b": [],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 16`] = `
-{
-  "381da8b3-cb46-4f1e-8511-814d892a05f3": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [],
-        "Governor-061a401b": [
-          {
-            "id": "Hannah-Dustin-ab4ef7c8",
-            "name": "Hannah Dustin",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Representative-in-Congress-24683b44": [
-          {
-            "id": "Nicholas-Gilman-1791aed7",
-            "name": "Nicholas Gilman",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "State-Representative-Hillsborough-District-37-f3bde894": [],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [],
-        "State-Senator-391381f8": [],
-        "United-States-Senator-d3f1c75b": [
-          {
-            "id": "William-Preston-3778fcd5",
-            "name": "William Preston",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [],
-        "County-Commissioner-d6feed25": [],
-        "County-Treasurer-87d25a31": [],
-        "Register-of-Deeds-a1278df2": [],
-        "Register-of-Probate-a4117da8": [],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
-        "Sheriff-4243fe0b": [],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 17`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=3cb39cd0-6357-42ca-841a-b7c750d327b9 1`] = `
 {
   "3cb39cd0-6357-42ca-841a-b7c750d327b9": [
     {
@@ -1589,600 +761,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 17`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 18`] = `
-{
-  "40ce9cdc-42c3-4932-bb2d-46aa782629e8": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [
-          {
-            "id": "Daniel-Webster-13f77b2d",
-            "name": "Daniel Webster",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Governor-061a401b": [
-          {
-            "id": "John-Spencer-9ffb5970",
-            "name": "John Spencer",
-            "partyIds": [
-              "OC-3a386d2b",
-            ],
-          },
-        ],
-        "Representative-in-Congress-24683b44": [
-          {
-            "id": "Richard-Coote-b9095636",
-            "name": "Richard Coote",
-            "partyIds": [
-              "OC-3a386d2b",
-            ],
-          },
-        ],
-        "State-Representative-Hillsborough-District-37-f3bde894": [
-          {
-            "id": "William-Lovejoy-fde3c2df",
-            "name": "William Lovejoy",
-            "partyIds": [
-              "OC-3a386d2b",
-            ],
-          },
-        ],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [
-          {
-            "id": "Samuel-Livermore-f927fef1",
-            "name": "Samuel Livermore",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "State-Senator-391381f8": [],
-        "United-States-Senator-d3f1c75b": [
-          {
-            "id": "William-Preston-3778fcd5",
-            "name": "William Preston",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [],
-        "County-Commissioner-d6feed25": [],
-        "County-Treasurer-87d25a31": [],
-        "Register-of-Deeds-a1278df2": [],
-        "Register-of-Probate-a4117da8": [],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
-        "Sheriff-4243fe0b": [],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 19`] = `
-{
-  "4483d72e-ea62-4698-b8f7-e24911a72a5b": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [
-          {
-            "id": "Daniel-Webster-13f77b2d",
-            "name": "Daniel Webster",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Governor-061a401b": [
-          {
-            "id": "Josiah-Bartlett-1bb99985",
-            "name": "Josiah Bartlett",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Representative-in-Congress-24683b44": [
-          {
-            "id": "Jeremiah-Smith-469560c9",
-            "name": "Jeremiah Smith",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "State-Representative-Hillsborough-District-37-f3bde894": [
-          {
-            "id": "William-Lovejoy-fde3c2df",
-            "name": "William Lovejoy",
-            "partyIds": [
-              "OC-3a386d2b",
-            ],
-          },
-        ],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [
-          {
-            "id": "Samuel-Livermore-f927fef1",
-            "name": "Samuel Livermore",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-          {
-            "id": "Elijah-Miller-a52e6988",
-            "name": "Elijah Miller",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-          {
-            "id": "Isaac-Hill-d6c9deeb",
-            "name": "Isaac Hill",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "State-Senator-391381f8": [
-          {
-            "id": "Matthew-Thornton-f66fec5e",
-            "name": "Matthew Thornton",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "United-States-Senator-d3f1c75b": [
-          {
-            "id": "William-Preston-3778fcd5",
-            "name": "William Preston",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [
-          {
-            "id": "Mary-Woolson-dc0b854a",
-            "name": "Mary Woolson",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "County-Commissioner-d6feed25": [
-          {
-            "id": "Valbe-Cady-ba3af3af",
-            "name": "Valbe Cady",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "County-Treasurer-87d25a31": [
-          {
-            "id": "John-Smith-ef61a579",
-            "name": "John Smith",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Register-of-Deeds-a1278df2": [
-          {
-            "id": "Ellen-A-Stileman-14408737",
-            "name": "Ellen A. Stileman",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Register-of-Probate-a4117da8": [
-          {
-            "id": "Nathaniel-Parker-56a06c29",
-            "name": "Nathaniel Parker",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
-        "Sheriff-4243fe0b": [
-          {
-            "id": "Edward-Randolph-bf4c848a",
-            "name": "Edward Randolph",
-            "partyIds": [
-              "Democratic-aea20adb",
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 20`] = `
-{
-  "4653ca16-0f5c-4968-8390-f6297f2c278c": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [],
-        "Governor-061a401b": [],
-        "Representative-in-Congress-24683b44": [
-          {
-            "id": "Jeremiah-Smith-469560c9",
-            "name": "Jeremiah Smith",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "State-Representative-Hillsborough-District-37-f3bde894": [],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [
-          {
-            "id": "write-in-0",
-            "isWriteIn": true,
-            "name": "Write-In #1",
-            "writeInIndex": 0,
-          },
-          {
-            "id": "write-in-1",
-            "isWriteIn": true,
-            "name": "Write-In #2",
-            "writeInIndex": 1,
-          },
-          {
-            "id": "write-in-2",
-            "isWriteIn": true,
-            "name": "Write-In #3",
-            "writeInIndex": 2,
-          },
-        ],
-        "State-Senator-391381f8": [],
-        "United-States-Senator-d3f1c75b": [],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [],
-        "County-Commissioner-d6feed25": [],
-        "County-Treasurer-87d25a31": [],
-        "Register-of-Deeds-a1278df2": [],
-        "Register-of-Probate-a4117da8": [],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
-        "Sheriff-4243fe0b": [],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 21`] = `
-{
-  "46f9490e-5717-4c56-92e5-37c1f1a971c2": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [
-        {
-          "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
-          "optionId": "write-in-0",
-        },
-      ],
-      "votes": {
-        "Executive-Councilor-bb22557f": [
-          {
-            "id": "Anne-Waldron-ee0cbc85",
-            "name": "Anne Waldron",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Governor-061a401b": [
-          {
-            "id": "Josiah-Bartlett-1bb99985",
-            "name": "Josiah Bartlett",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Representative-in-Congress-24683b44": [
-          {
-            "id": "Jeremiah-Smith-469560c9",
-            "name": "Jeremiah Smith",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "State-Representative-Hillsborough-District-37-f3bde894": [],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [
-          {
-            "id": "Samuel-Bell-17973275",
-            "name": "Samuel Bell",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-          {
-            "id": "Abigail-Bartlett-4e46c9d4",
-            "name": "Abigail Bartlett",
-            "partyIds": [
-              "OC-3a386d2b",
-            ],
-          },
-        ],
-        "State-Senator-391381f8": [
-          {
-            "id": "write-in-0",
-            "isWriteIn": true,
-            "name": "Write-In #1",
-            "writeInIndex": 0,
-          },
-        ],
-        "United-States-Senator-d3f1c75b": [
-          {
-            "id": "William-Preston-3778fcd5",
-            "name": "William Preston",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [
-          {
-            "id": "Mary-Woolson-dc0b854a",
-            "name": "Mary Woolson",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "County-Commissioner-d6feed25": [
-          {
-            "id": "Valbe-Cady-ba3af3af",
-            "name": "Valbe Cady",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "County-Treasurer-87d25a31": [],
-        "Register-of-Deeds-a1278df2": [
-          {
-            "id": "Ellen-A-Stileman-14408737",
-            "name": "Ellen A. Stileman",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Register-of-Probate-a4117da8": [],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [
-          "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-yes",
-        ],
-        "Sheriff-4243fe0b": [
-          {
-            "id": "Edward-Randolph-bf4c848a",
-            "name": "Edward Randolph",
-            "partyIds": [
-              "Democratic-aea20adb",
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 22`] = `
-{
-  "47cda523-a05a-439d-8519-ce077cf781f3": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [],
-        "Governor-061a401b": [],
-        "Representative-in-Congress-24683b44": [
-          {
-            "id": "Jeremiah-Smith-469560c9",
-            "name": "Jeremiah Smith",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-          {
-            "id": "Nicholas-Gilman-1791aed7",
-            "name": "Nicholas Gilman",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "State-Representative-Hillsborough-District-37-f3bde894": [
-          {
-            "id": "Charles-H-Hersey-096286a4",
-            "name": "Charles H. Hersey",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [
-          {
-            "id": "Mary-Baker-Eddy-350785d5",
-            "name": "Mary Baker Eddy",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-          {
-            "id": "Samuel-Livermore-f927fef1",
-            "name": "Samuel Livermore",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-          {
-            "id": "write-in-0",
-            "isWriteIn": true,
-            "name": "Write-In #1",
-            "writeInIndex": 0,
-          },
-        ],
-        "State-Senator-391381f8": [
-          {
-            "id": "Matthew-Thornton-f66fec5e",
-            "name": "Matthew Thornton",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "United-States-Senator-d3f1c75b": [
-          {
-            "id": "William-Preston-3778fcd5",
-            "name": "William Preston",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [],
-        "County-Commissioner-d6feed25": [],
-        "County-Treasurer-87d25a31": [],
-        "Register-of-Deeds-a1278df2": [],
-        "Register-of-Probate-a4117da8": [],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
-        "Sheriff-4243fe0b": [],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 23`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=4b12014e-60c5-447c-bfde-98855d1feaea 1`] = `
 {
   "4b12014e-60c5-447c-bfde-98855d1feaea": [
     {
@@ -2327,7 +906,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 23`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 24`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=4c7a63dc-3f16-434d-87bf-7ac31bd6caa0 1`] = `
 {
   "4c7a63dc-3f16-434d-87bf-7ac31bd6caa0": [
     {
@@ -2392,7 +971,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 24`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 25`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=4f054d5a-f890-4717-ae1e-5ddadf32a16b 1`] = `
 {
   "4f054d5a-f890-4717-ae1e-5ddadf32a16b": [
     {
@@ -2495,349 +1074,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 25`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 26`] = `
-{
-  "50d8aa5e-2a3b-47e3-813d-075be04ebb6e": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [],
-        "Governor-061a401b": [
-          {
-            "id": "Josiah-Bartlett-1bb99985",
-            "name": "Josiah Bartlett",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-          {
-            "id": "Hannah-Dustin-ab4ef7c8",
-            "name": "Hannah Dustin",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Representative-in-Congress-24683b44": [],
-        "State-Representative-Hillsborough-District-37-f3bde894": [],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [],
-        "State-Senator-391381f8": [],
-        "United-States-Senator-d3f1c75b": [],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [],
-        "County-Commissioner-d6feed25": [],
-        "County-Treasurer-87d25a31": [],
-        "Register-of-Deeds-a1278df2": [],
-        "Register-of-Probate-a4117da8": [],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
-        "Sheriff-4243fe0b": [],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 27`] = `
-{
-  "524a09ad-b366-4d3f-8399-763ea31bf357": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [
-          {
-            "id": "Daniel-Webster-13f77b2d",
-            "name": "Daniel Webster",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Governor-061a401b": [
-          {
-            "id": "Hannah-Dustin-ab4ef7c8",
-            "name": "Hannah Dustin",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Representative-in-Congress-24683b44": [],
-        "State-Representative-Hillsborough-District-37-f3bde894": [],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [],
-        "State-Senator-391381f8": [],
-        "United-States-Senator-d3f1c75b": [],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [],
-        "County-Commissioner-d6feed25": [],
-        "County-Treasurer-87d25a31": [],
-        "Register-of-Deeds-a1278df2": [],
-        "Register-of-Probate-a4117da8": [],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
-        "Sheriff-4243fe0b": [],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 28`] = `
-{
-  "53884725-3c74-49ba-86b9-932e1177ec10": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [
-          {
-            "id": "Daniel-Webster-13f77b2d",
-            "name": "Daniel Webster",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Governor-061a401b": [
-          {
-            "id": "Josiah-Bartlett-1bb99985",
-            "name": "Josiah Bartlett",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Representative-in-Congress-24683b44": [
-          {
-            "id": "Richard-Coote-b9095636",
-            "name": "Richard Coote",
-            "partyIds": [
-              "OC-3a386d2b",
-            ],
-          },
-        ],
-        "State-Representative-Hillsborough-District-37-f3bde894": [
-          {
-            "id": "Charles-H-Hersey-096286a4",
-            "name": "Charles H. Hersey",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [
-          {
-            "id": "Obadiah-Carrigan-5c95145a",
-            "name": "Obadiah Carrigan",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "State-Senator-391381f8": [],
-        "United-States-Senator-d3f1c75b": [
-          {
-            "id": "William-Preston-3778fcd5",
-            "name": "William Preston",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [
-          {
-            "id": "Mary-Woolson-dc0b854a",
-            "name": "Mary Woolson",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "County-Commissioner-d6feed25": [],
-        "County-Treasurer-87d25a31": [
-          {
-            "id": "Jane-Jones-9caa141f",
-            "name": "Jane Jones",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Register-of-Deeds-a1278df2": [],
-        "Register-of-Probate-a4117da8": [],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [
-          "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-yes",
-        ],
-        "Sheriff-4243fe0b": [
-          {
-            "id": "Edward-Randolph-bf4c848a",
-            "name": "Edward Randolph",
-            "partyIds": [
-              "Democratic-aea20adb",
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 29`] = `
-{
-  "55a65b48-69ce-4b44-a582-736b492bb10c": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [
-          {
-            "id": "Anne-Waldron-ee0cbc85",
-            "name": "Anne Waldron",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Governor-061a401b": [
-          {
-            "id": "Josiah-Bartlett-1bb99985",
-            "name": "Josiah Bartlett",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Representative-in-Congress-24683b44": [
-          {
-            "id": "Jeremiah-Smith-469560c9",
-            "name": "Jeremiah Smith",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "State-Representative-Hillsborough-District-37-f3bde894": [],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [],
-        "State-Senator-391381f8": [
-          {
-            "id": "James-Poole-db5ef4bd",
-            "name": "James Poole",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "United-States-Senator-d3f1c75b": [
-          {
-            "id": "John-Langdon-5951c8e1",
-            "name": "John Langdon",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [],
-        "County-Commissioner-d6feed25": [],
-        "County-Treasurer-87d25a31": [],
-        "Register-of-Deeds-a1278df2": [],
-        "Register-of-Probate-a4117da8": [],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
-        "Sheriff-4243fe0b": [],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 30`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=5dc43750-a2aa-4d46-ad1c-7a0e2cb4e2c1 1`] = `
 {
   "5dc43750-a2aa-4d46-ad1c-7a0e2cb4e2c1": [
     {
@@ -3007,250 +1244,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 30`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 31`] = `
-{
-  "62385dba-db90-442a-b089-fb41d1f42eea": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [
-          {
-            "id": "Anne-Waldron-ee0cbc85",
-            "name": "Anne Waldron",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Governor-061a401b": [
-          {
-            "id": "Josiah-Bartlett-1bb99985",
-            "name": "Josiah Bartlett",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Representative-in-Congress-24683b44": [],
-        "State-Representative-Hillsborough-District-37-f3bde894": [
-          {
-            "id": "Abeil-Foster-ded38e36",
-            "name": "Abeil Foster",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [
-          {
-            "id": "Mary-Baker-Eddy-350785d5",
-            "name": "Mary Baker Eddy",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-          {
-            "id": "Samuel-Livermore-f927fef1",
-            "name": "Samuel Livermore",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-          {
-            "id": "Isaac-Hill-d6c9deeb",
-            "name": "Isaac Hill",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "State-Senator-391381f8": [
-          {
-            "id": "Matthew-Thornton-f66fec5e",
-            "name": "Matthew Thornton",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "United-States-Senator-d3f1c75b": [
-          {
-            "id": "William-Preston-3778fcd5",
-            "name": "William Preston",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [
-          {
-            "id": "Ezra-Bartlett-8f95223c",
-            "name": "Ezra Bartlett",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "County-Commissioner-d6feed25": [],
-        "County-Treasurer-87d25a31": [
-          {
-            "id": "Jane-Jones-9caa141f",
-            "name": "Jane Jones",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Register-of-Deeds-a1278df2": [
-          {
-            "id": "John-Mann-b56bbdd3",
-            "name": "John Mann",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Register-of-Probate-a4117da8": [
-          {
-            "id": "Claire-Cutts-07a436e7",
-            "name": "Claire Cutts",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [
-          "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-no",
-        ],
-        "Sheriff-4243fe0b": [
-          {
-            "id": "Edward-Randolph-bf4c848a",
-            "name": "Edward Randolph",
-            "partyIds": [
-              "Democratic-aea20adb",
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 32`] = `
-{
-  "672353df-27cb-4e5a-8b6a-de0b90f8a28d": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [
-          {
-            "id": "Daniel-Webster-13f77b2d",
-            "name": "Daniel Webster",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Governor-061a401b": [
-          {
-            "id": "Hannah-Dustin-ab4ef7c8",
-            "name": "Hannah Dustin",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Representative-in-Congress-24683b44": [
-          {
-            "id": "Nicholas-Gilman-1791aed7",
-            "name": "Nicholas Gilman",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "State-Representative-Hillsborough-District-37-f3bde894": [],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [],
-        "State-Senator-391381f8": [
-          {
-            "id": "Matthew-Thornton-f66fec5e",
-            "name": "Matthew Thornton",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "United-States-Senator-d3f1c75b": [
-          {
-            "id": "William-Preston-3778fcd5",
-            "name": "William Preston",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [],
-        "County-Commissioner-d6feed25": [],
-        "County-Treasurer-87d25a31": [],
-        "Register-of-Deeds-a1278df2": [],
-        "Register-of-Probate-a4117da8": [],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
-        "Sheriff-4243fe0b": [],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 33`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=6e229f1d-676e-4ced-bb8f-523793391001 1`] = `
 {
   "6e229f1d-676e-4ced-bb8f-523793391001": [
     {
@@ -3339,487 +1333,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 33`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 34`] = `
-{
-  "72547548-e08e-48fa-a8f9-d36560c43125": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [
-          {
-            "id": "Daniel-Webster-13f77b2d",
-            "name": "Daniel Webster",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Governor-061a401b": [],
-        "Representative-in-Congress-24683b44": [
-          {
-            "id": "Richard-Coote-b9095636",
-            "name": "Richard Coote",
-            "partyIds": [
-              "OC-3a386d2b",
-            ],
-          },
-        ],
-        "State-Representative-Hillsborough-District-37-f3bde894": [
-          {
-            "id": "William-Lovejoy-fde3c2df",
-            "name": "William Lovejoy",
-            "partyIds": [
-              "OC-3a386d2b",
-            ],
-          },
-        ],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [
-          {
-            "id": "Obadiah-Carrigan-5c95145a",
-            "name": "Obadiah Carrigan",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-          {
-            "id": "Isaac-Hill-d6c9deeb",
-            "name": "Isaac Hill",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-          {
-            "id": "Jacob-Freese-b5146505",
-            "name": "Jacob Freese",
-            "partyIds": [
-              "OC-3a386d2b",
-            ],
-          },
-        ],
-        "State-Senator-391381f8": [
-          {
-            "id": "James-Poole-db5ef4bd",
-            "name": "James Poole",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "United-States-Senator-d3f1c75b": [
-          {
-            "id": "John-Langdon-5951c8e1",
-            "name": "John Langdon",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-          {
-            "id": "William-Preston-3778fcd5",
-            "name": "William Preston",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [
-          {
-            "id": "Mary-Woolson-dc0b854a",
-            "name": "Mary Woolson",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "County-Commissioner-d6feed25": [
-          {
-            "id": "Valbe-Cady-ba3af3af",
-            "name": "Valbe Cady",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "County-Treasurer-87d25a31": [
-          {
-            "id": "John-Smith-ef61a579",
-            "name": "John Smith",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Register-of-Deeds-a1278df2": [
-          {
-            "id": "write-in-0",
-            "isWriteIn": true,
-            "name": "Write-In #1",
-            "writeInIndex": 0,
-          },
-        ],
-        "Register-of-Probate-a4117da8": [
-          {
-            "id": "write-in-0",
-            "isWriteIn": true,
-            "name": "Write-In #1",
-            "writeInIndex": 0,
-          },
-        ],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [
-          "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-no",
-        ],
-        "Sheriff-4243fe0b": [
-          {
-            "id": "Edward-Randolph-bf4c848a",
-            "name": "Edward Randolph",
-            "partyIds": [
-              "Democratic-aea20adb",
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 35`] = `
-{
-  "7527d2a4-1cde-4f8f-ae08-7f95de165192": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [
-          {
-            "id": "Anne-Waldron-ee0cbc85",
-            "name": "Anne Waldron",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Governor-061a401b": [
-          {
-            "id": "Josiah-Bartlett-1bb99985",
-            "name": "Josiah Bartlett",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Representative-in-Congress-24683b44": [
-          {
-            "id": "Jeremiah-Smith-469560c9",
-            "name": "Jeremiah Smith",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "State-Representative-Hillsborough-District-37-f3bde894": [
-          {
-            "id": "Abeil-Foster-ded38e36",
-            "name": "Abeil Foster",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [
-          {
-            "id": "Obadiah-Carrigan-5c95145a",
-            "name": "Obadiah Carrigan",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-          {
-            "id": "Mary-Baker-Eddy-350785d5",
-            "name": "Mary Baker Eddy",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-          {
-            "id": "Samuel-Bell-17973275",
-            "name": "Samuel Bell",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "State-Senator-391381f8": [
-          {
-            "id": "James-Poole-db5ef4bd",
-            "name": "James Poole",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "United-States-Senator-d3f1c75b": [
-          {
-            "id": "John-Langdon-5951c8e1",
-            "name": "John Langdon",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [
-          {
-            "id": "Ezra-Bartlett-8f95223c",
-            "name": "Ezra Bartlett",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "County-Commissioner-d6feed25": [
-          {
-            "id": "Ichabod-Goodwin-55e8de1f",
-            "name": "Ichabod Goodwin",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "County-Treasurer-87d25a31": [
-          {
-            "id": "John-Smith-ef61a579",
-            "name": "John Smith",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Register-of-Deeds-a1278df2": [
-          {
-            "id": "John-Mann-b56bbdd3",
-            "name": "John Mann",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Register-of-Probate-a4117da8": [
-          {
-            "id": "Nathaniel-Parker-56a06c29",
-            "name": "Nathaniel Parker",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [
-          "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-no",
-        ],
-        "Sheriff-4243fe0b": [
-          {
-            "id": "Edward-Randolph-bf4c848a",
-            "name": "Edward Randolph",
-            "partyIds": [
-              "Democratic-aea20adb",
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 36`] = `
-{
-  "759fee43-9f63-4550-ba2d-eec22fa6fb0d": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [],
-        "Governor-061a401b": [
-          {
-            "id": "John-Spencer-9ffb5970",
-            "name": "John Spencer",
-            "partyIds": [
-              "OC-3a386d2b",
-            ],
-          },
-        ],
-        "Representative-in-Congress-24683b44": [],
-        "State-Representative-Hillsborough-District-37-f3bde894": [
-          {
-            "id": "Charles-H-Hersey-096286a4",
-            "name": "Charles H. Hersey",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [],
-        "State-Senator-391381f8": [
-          {
-            "id": "Matthew-Thornton-f66fec5e",
-            "name": "Matthew Thornton",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "United-States-Senator-d3f1c75b": [],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [],
-        "County-Commissioner-d6feed25": [],
-        "County-Treasurer-87d25a31": [],
-        "Register-of-Deeds-a1278df2": [],
-        "Register-of-Probate-a4117da8": [],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
-        "Sheriff-4243fe0b": [],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 37`] = `
-{
-  "786f4868-0d0a-45cd-b193-42a9c3553d30": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [
-        {
-          "contestId": "Governor-061a401b",
-          "optionId": "write-in-0",
-        },
-      ],
-      "votes": {
-        "Executive-Councilor-bb22557f": [],
-        "Governor-061a401b": [
-          {
-            "id": "Josiah-Bartlett-1bb99985",
-            "name": "Josiah Bartlett",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Representative-in-Congress-24683b44": [
-          {
-            "id": "Nicholas-Gilman-1791aed7",
-            "name": "Nicholas Gilman",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "State-Representative-Hillsborough-District-37-f3bde894": [],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [],
-        "State-Senator-391381f8": [],
-        "United-States-Senator-d3f1c75b": [],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [],
-        "County-Commissioner-d6feed25": [],
-        "County-Treasurer-87d25a31": [],
-        "Register-of-Deeds-a1278df2": [],
-        "Register-of-Probate-a4117da8": [],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
-        "Sheriff-4243fe0b": [],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 38`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=7a5f1429-a94b-44a8-80fc-c290b217e632 1`] = `
 {
   "7a5f1429-a94b-44a8-80fc-c290b217e632": [
     {
@@ -3979,7 +1493,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 38`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 39`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=7c29afa2-8b91-49c6-8292-db47d2d8a34c 1`] = `
 {
   "7c29afa2-8b91-49c6-8292-db47d2d8a34c": [
     {
@@ -4103,7 +1617,78 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 39`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 40`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=7cd316f5-9775-49a2-a8ac-3da46c30add3 1`] = `
+{
+  "7cd316f5-9775-49a2-a8ac-3da46c30add3": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [],
+        "Governor-061a401b": [],
+        "Representative-in-Congress-24683b44": [],
+        "State-Representative-Hillsborough-District-37-f3bde894": [],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [
+          {
+            "id": "Obadiah-Carrigan-5c95145a",
+            "name": "Obadiah Carrigan",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+          {
+            "id": "write-in-2",
+            "isWriteIn": true,
+            "name": "Write-In #3",
+            "writeInIndex": 2,
+          },
+        ],
+        "State-Senator-391381f8": [],
+        "United-States-Senator-d3f1c75b": [
+          {
+            "id": "William-Preston-3778fcd5",
+            "name": "William Preston",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [],
+        "County-Commissioner-d6feed25": [],
+        "County-Treasurer-87d25a31": [],
+        "Register-of-Deeds-a1278df2": [],
+        "Register-of-Probate-a4117da8": [],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
+        "Sheriff-4243fe0b": [],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=7cd12878-7c65-4d81-8cc6-45a4238df0a8 1`] = `
 {
   "7cd12878-7c65-4d81-8cc6-45a4238df0a8": [
     {
@@ -4192,78 +1777,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 40`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 41`] = `
-{
-  "7cd316f5-9775-49a2-a8ac-3da46c30add3": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [],
-        "Governor-061a401b": [],
-        "Representative-in-Congress-24683b44": [],
-        "State-Representative-Hillsborough-District-37-f3bde894": [],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [
-          {
-            "id": "Obadiah-Carrigan-5c95145a",
-            "name": "Obadiah Carrigan",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-          {
-            "id": "write-in-2",
-            "isWriteIn": true,
-            "name": "Write-In #3",
-            "writeInIndex": 2,
-          },
-        ],
-        "State-Senator-391381f8": [],
-        "United-States-Senator-d3f1c75b": [
-          {
-            "id": "William-Preston-3778fcd5",
-            "name": "William Preston",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [],
-        "County-Commissioner-d6feed25": [],
-        "County-Treasurer-87d25a31": [],
-        "Register-of-Deeds-a1278df2": [],
-        "Register-of-Probate-a4117da8": [],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
-        "Sheriff-4243fe0b": [],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 42`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=7dfff758-2f99-467e-b1d9-b590d871ae0b 1`] = `
 {
   "7dfff758-2f99-467e-b1d9-b590d871ae0b": [
     {
@@ -4358,135 +1872,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 42`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 43`] = `
-{
-  "85cde9ce-edc4-41eb-b1cd-280c63a46474": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [],
-        "Governor-061a401b": [
-          {
-            "id": "Josiah-Bartlett-1bb99985",
-            "name": "Josiah Bartlett",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-          {
-            "id": "Hannah-Dustin-ab4ef7c8",
-            "name": "Hannah Dustin",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-          {
-            "id": "John-Spencer-9ffb5970",
-            "name": "John Spencer",
-            "partyIds": [
-              "OC-3a386d2b",
-            ],
-          },
-        ],
-        "Representative-in-Congress-24683b44": [],
-        "State-Representative-Hillsborough-District-37-f3bde894": [],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [],
-        "State-Senator-391381f8": [],
-        "United-States-Senator-d3f1c75b": [],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [],
-        "County-Commissioner-d6feed25": [],
-        "County-Treasurer-87d25a31": [],
-        "Register-of-Deeds-a1278df2": [],
-        "Register-of-Probate-a4117da8": [],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
-        "Sheriff-4243fe0b": [],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 44`] = `
-{
-  "8978016e-2585-49bc-9bfb-2852a473a11d": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [
-          {
-            "id": "Anne-Waldron-ee0cbc85",
-            "name": "Anne Waldron",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Governor-061a401b": [],
-        "Representative-in-Congress-24683b44": [],
-        "State-Representative-Hillsborough-District-37-f3bde894": [],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [],
-        "State-Senator-391381f8": [],
-        "United-States-Senator-d3f1c75b": [],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [],
-        "County-Commissioner-d6feed25": [],
-        "County-Treasurer-87d25a31": [],
-        "Register-of-Deeds-a1278df2": [],
-        "Register-of-Probate-a4117da8": [],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
-        "Sheriff-4243fe0b": [],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 45`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=8a7625a3-950f-4346-aad2-e904b1a9cba2 1`] = `
 {
   "8a7625a3-950f-4346-aad2-e904b1a9cba2": [
     {
@@ -4605,7 +1991,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 45`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 46`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=8c5ea5a3-9d17-4895-96b4-ab803d39bd3f 1`] = `
 {
   "8c5ea5a3-9d17-4895-96b4-ab803d39bd3f": [
     {
@@ -4729,7 +2115,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 46`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 47`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=8d50bac9-d511-48b3-9e1f-af9c7d85b7a8 1`] = `
 {
   "8d50bac9-d511-48b3-9e1f-af9c7d85b7a8": [
     {
@@ -4802,7 +2188,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 47`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 48`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=8e6a152e-7986-4ff1-b52d-a89d52d240f6 1`] = `
 {
   "8e6a152e-7986-4ff1-b52d-a89d52d240f6": [
     {
@@ -4972,479 +2358,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 48`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 49`] = `
-{
-  "913c814b-f170-4427-8049-76d322b3eee3": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [
-          {
-            "id": "Daniel-Webster-13f77b2d",
-            "name": "Daniel Webster",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Governor-061a401b": [
-          {
-            "id": "Hannah-Dustin-ab4ef7c8",
-            "name": "Hannah Dustin",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Representative-in-Congress-24683b44": [
-          {
-            "id": "Richard-Coote-b9095636",
-            "name": "Richard Coote",
-            "partyIds": [
-              "OC-3a386d2b",
-            ],
-          },
-        ],
-        "State-Representative-Hillsborough-District-37-f3bde894": [
-          {
-            "id": "Abeil-Foster-ded38e36",
-            "name": "Abeil Foster",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [
-          {
-            "id": "Samuel-Livermore-f927fef1",
-            "name": "Samuel Livermore",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-          {
-            "id": "Elijah-Miller-a52e6988",
-            "name": "Elijah Miller",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-          {
-            "id": "Isaac-Hill-d6c9deeb",
-            "name": "Isaac Hill",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "State-Senator-391381f8": [
-          {
-            "id": "Matthew-Thornton-f66fec5e",
-            "name": "Matthew Thornton",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "United-States-Senator-d3f1c75b": [
-          {
-            "id": "John-Langdon-5951c8e1",
-            "name": "John Langdon",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [
-          {
-            "id": "Ezra-Bartlett-8f95223c",
-            "name": "Ezra Bartlett",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "County-Commissioner-d6feed25": [
-          {
-            "id": "Ichabod-Goodwin-55e8de1f",
-            "name": "Ichabod Goodwin",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "County-Treasurer-87d25a31": [
-          {
-            "id": "Jane-Jones-9caa141f",
-            "name": "Jane Jones",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Register-of-Deeds-a1278df2": [
-          {
-            "id": "John-Mann-b56bbdd3",
-            "name": "John Mann",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Register-of-Probate-a4117da8": [
-          {
-            "id": "Claire-Cutts-07a436e7",
-            "name": "Claire Cutts",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
-        "Sheriff-4243fe0b": [
-          {
-            "id": "Edward-Randolph-bf4c848a",
-            "name": "Edward Randolph",
-            "partyIds": [
-              "Democratic-aea20adb",
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 50`] = `
-{
-  "97af3ccb-dd18-406f-aea2-e0a7af30c11c": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [],
-        "Governor-061a401b": [
-          {
-            "id": "Josiah-Bartlett-1bb99985",
-            "name": "Josiah Bartlett",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Representative-in-Congress-24683b44": [
-          {
-            "id": "Jeremiah-Smith-469560c9",
-            "name": "Jeremiah Smith",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-          {
-            "id": "Nicholas-Gilman-1791aed7",
-            "name": "Nicholas Gilman",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "State-Representative-Hillsborough-District-37-f3bde894": [],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [
-          {
-            "id": "Samuel-Livermore-f927fef1",
-            "name": "Samuel Livermore",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-          {
-            "id": "Elijah-Miller-a52e6988",
-            "name": "Elijah Miller",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-          {
-            "id": "Isaac-Hill-d6c9deeb",
-            "name": "Isaac Hill",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-          {
-            "id": "Abigail-Bartlett-4e46c9d4",
-            "name": "Abigail Bartlett",
-            "partyIds": [
-              "OC-3a386d2b",
-            ],
-          },
-        ],
-        "State-Senator-391381f8": [],
-        "United-States-Senator-d3f1c75b": [
-          {
-            "id": "write-in-0",
-            "isWriteIn": true,
-            "name": "Write-In #1",
-            "writeInIndex": 0,
-          },
-        ],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [],
-        "County-Commissioner-d6feed25": [],
-        "County-Treasurer-87d25a31": [],
-        "Register-of-Deeds-a1278df2": [],
-        "Register-of-Probate-a4117da8": [],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
-        "Sheriff-4243fe0b": [],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 51`] = `
-{
-  "97c8dd4a-52ec-4d16-a843-5a5bdf22d6f3": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [],
-        "Governor-061a401b": [],
-        "Representative-in-Congress-24683b44": [],
-        "State-Representative-Hillsborough-District-37-f3bde894": [],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [
-          {
-            "id": "write-in-1",
-            "isWriteIn": true,
-            "name": "Write-In #2",
-            "writeInIndex": 1,
-          },
-        ],
-        "State-Senator-391381f8": [],
-        "United-States-Senator-d3f1c75b": [],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [],
-        "County-Commissioner-d6feed25": [],
-        "County-Treasurer-87d25a31": [],
-        "Register-of-Deeds-a1278df2": [],
-        "Register-of-Probate-a4117da8": [],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
-        "Sheriff-4243fe0b": [],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 52`] = `
-{
-  "99b486dd-9507-4c82-87c8-67bba43b4e1b": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [
-          {
-            "id": "Daniel-Webster-13f77b2d",
-            "name": "Daniel Webster",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Governor-061a401b": [],
-        "Representative-in-Congress-24683b44": [],
-        "State-Representative-Hillsborough-District-37-f3bde894": [
-          {
-            "id": "Charles-H-Hersey-096286a4",
-            "name": "Charles H. Hersey",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [
-          {
-            "id": "Elijah-Miller-a52e6988",
-            "name": "Elijah Miller",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "State-Senator-391381f8": [
-          {
-            "id": "Matthew-Thornton-f66fec5e",
-            "name": "Matthew Thornton",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "United-States-Senator-d3f1c75b": [
-          {
-            "id": "William-Preston-3778fcd5",
-            "name": "William Preston",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [
-          {
-            "id": "Mary-Woolson-dc0b854a",
-            "name": "Mary Woolson",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "County-Commissioner-d6feed25": [
-          {
-            "id": "Valbe-Cady-ba3af3af",
-            "name": "Valbe Cady",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "County-Treasurer-87d25a31": [
-          {
-            "id": "Jane-Jones-9caa141f",
-            "name": "Jane Jones",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Register-of-Deeds-a1278df2": [
-          {
-            "id": "Ellen-A-Stileman-14408737",
-            "name": "Ellen A. Stileman",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Register-of-Probate-a4117da8": [
-          {
-            "id": "Claire-Cutts-07a436e7",
-            "name": "Claire Cutts",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [
-          "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-yes",
-        ],
-        "Sheriff-4243fe0b": [
-          {
-            "id": "Edward-Randolph-bf4c848a",
-            "name": "Edward Randolph",
-            "partyIds": [
-              "Democratic-aea20adb",
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 53`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=9f5ee84a-5da0-4a80-bc1e-5ea0e2cf4e34 1`] = `
 {
   "9f5ee84a-5da0-4a80-bc1e-5ea0e2cf4e34": [
     {
@@ -5618,7 +2532,3093 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 53`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 54`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=12ee4c7c-fe40-4492-94ca-75bcf6db9f18 1`] = `
+{
+  "12ee4c7c-fe40-4492-94ca-75bcf6db9f18": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [],
+        "Governor-061a401b": [
+          {
+            "id": "Josiah-Bartlett-1bb99985",
+            "name": "Josiah Bartlett",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Representative-in-Congress-24683b44": [],
+        "State-Representative-Hillsborough-District-37-f3bde894": [],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [],
+        "State-Senator-391381f8": [],
+        "United-States-Senator-d3f1c75b": [
+          {
+            "id": "William-Preston-3778fcd5",
+            "name": "William Preston",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [],
+        "County-Commissioner-d6feed25": [],
+        "County-Treasurer-87d25a31": [],
+        "Register-of-Deeds-a1278df2": [],
+        "Register-of-Probate-a4117da8": [],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
+        "Sheriff-4243fe0b": [],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=12effe84-6be5-481b-b70d-5a5df4b049e7 1`] = `
+{
+  "12effe84-6be5-481b-b70d-5a5df4b049e7": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [],
+        "Governor-061a401b": [],
+        "Representative-in-Congress-24683b44": [],
+        "State-Representative-Hillsborough-District-37-f3bde894": [],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [],
+        "State-Senator-391381f8": [],
+        "United-States-Senator-d3f1c75b": [],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [],
+        "County-Commissioner-d6feed25": [],
+        "County-Treasurer-87d25a31": [],
+        "Register-of-Deeds-a1278df2": [],
+        "Register-of-Probate-a4117da8": [],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
+        "Sheriff-4243fe0b": [],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=21e0d2db-0f44-4a23-ac08-2eec70851df5 1`] = `
+{
+  "21e0d2db-0f44-4a23-ac08-2eec70851df5": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [],
+        "Governor-061a401b": [
+          {
+            "id": "write-in-0",
+            "isWriteIn": true,
+            "name": "Write-In #1",
+            "writeInIndex": 0,
+          },
+        ],
+        "Representative-in-Congress-24683b44": [],
+        "State-Representative-Hillsborough-District-37-f3bde894": [
+          {
+            "id": "William-Lovejoy-fde3c2df",
+            "name": "William Lovejoy",
+            "partyIds": [
+              "OC-3a386d2b",
+            ],
+          },
+        ],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [
+          {
+            "id": "Obadiah-Carrigan-5c95145a",
+            "name": "Obadiah Carrigan",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+          {
+            "id": "Mary-Baker-Eddy-350785d5",
+            "name": "Mary Baker Eddy",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+          {
+            "id": "Samuel-Bell-17973275",
+            "name": "Samuel Bell",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+          {
+            "id": "Elijah-Miller-a52e6988",
+            "name": "Elijah Miller",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "State-Senator-391381f8": [],
+        "United-States-Senator-d3f1c75b": [
+          {
+            "id": "write-in-0",
+            "isWriteIn": true,
+            "name": "Write-In #1",
+            "writeInIndex": 0,
+          },
+        ],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [
+          {
+            "id": "Ezra-Bartlett-8f95223c",
+            "name": "Ezra Bartlett",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "County-Commissioner-d6feed25": [
+          {
+            "id": "Ichabod-Goodwin-55e8de1f",
+            "name": "Ichabod Goodwin",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "County-Treasurer-87d25a31": [
+          {
+            "id": "John-Smith-ef61a579",
+            "name": "John Smith",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Register-of-Deeds-a1278df2": [
+          {
+            "id": "John-Mann-b56bbdd3",
+            "name": "John Mann",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Register-of-Probate-a4117da8": [
+          {
+            "id": "Nathaniel-Parker-56a06c29",
+            "name": "Nathaniel Parker",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [
+          "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-yes",
+        ],
+        "Sheriff-4243fe0b": [
+          {
+            "id": "Edward-Randolph-bf4c848a",
+            "name": "Edward Randolph",
+            "partyIds": [
+              "Democratic-aea20adb",
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=22c0ab78-020b-4535-b231-5b5177581265 1`] = `
+{
+  "22c0ab78-020b-4535-b231-5b5177581265": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [
+          {
+            "id": "Anne-Waldron-ee0cbc85",
+            "name": "Anne Waldron",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Governor-061a401b": [],
+        "Representative-in-Congress-24683b44": [
+          {
+            "id": "Jeremiah-Smith-469560c9",
+            "name": "Jeremiah Smith",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "State-Representative-Hillsborough-District-37-f3bde894": [],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [
+          {
+            "id": "Abigail-Bartlett-4e46c9d4",
+            "name": "Abigail Bartlett",
+            "partyIds": [
+              "OC-3a386d2b",
+            ],
+          },
+        ],
+        "State-Senator-391381f8": [],
+        "United-States-Senator-d3f1c75b": [],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [],
+        "County-Commissioner-d6feed25": [],
+        "County-Treasurer-87d25a31": [],
+        "Register-of-Deeds-a1278df2": [],
+        "Register-of-Probate-a4117da8": [],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
+        "Sheriff-4243fe0b": [],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=32e0764e-e0b1-4275-b5bd-e6e9f1b504fc 1`] = `
+{
+  "32e0764e-e0b1-4275-b5bd-e6e9f1b504fc": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [
+          {
+            "id": "Daniel-Webster-13f77b2d",
+            "name": "Daniel Webster",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Governor-061a401b": [
+          {
+            "id": "Hannah-Dustin-ab4ef7c8",
+            "name": "Hannah Dustin",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Representative-in-Congress-24683b44": [
+          {
+            "id": "Nicholas-Gilman-1791aed7",
+            "name": "Nicholas Gilman",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "State-Representative-Hillsborough-District-37-f3bde894": [
+          {
+            "id": "Charles-H-Hersey-096286a4",
+            "name": "Charles H. Hersey",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [
+          {
+            "id": "Elijah-Miller-a52e6988",
+            "name": "Elijah Miller",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "State-Senator-391381f8": [
+          {
+            "id": "Matthew-Thornton-f66fec5e",
+            "name": "Matthew Thornton",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "United-States-Senator-d3f1c75b": [
+          {
+            "id": "William-Preston-3778fcd5",
+            "name": "William Preston",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [
+          {
+            "id": "Mary-Woolson-dc0b854a",
+            "name": "Mary Woolson",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "County-Commissioner-d6feed25": [
+          {
+            "id": "Valbe-Cady-ba3af3af",
+            "name": "Valbe Cady",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "County-Treasurer-87d25a31": [
+          {
+            "id": "Jane-Jones-9caa141f",
+            "name": "Jane Jones",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Register-of-Deeds-a1278df2": [
+          {
+            "id": "Ellen-A-Stileman-14408737",
+            "name": "Ellen A. Stileman",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Register-of-Probate-a4117da8": [
+          {
+            "id": "Claire-Cutts-07a436e7",
+            "name": "Claire Cutts",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [
+          "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-yes",
+        ],
+        "Sheriff-4243fe0b": [
+          {
+            "id": "Edward-Randolph-bf4c848a",
+            "name": "Edward Randolph",
+            "partyIds": [
+              "Democratic-aea20adb",
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=40ce9cdc-42c3-4932-bb2d-46aa782629e8 1`] = `
+{
+  "40ce9cdc-42c3-4932-bb2d-46aa782629e8": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [
+          {
+            "id": "Daniel-Webster-13f77b2d",
+            "name": "Daniel Webster",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Governor-061a401b": [
+          {
+            "id": "John-Spencer-9ffb5970",
+            "name": "John Spencer",
+            "partyIds": [
+              "OC-3a386d2b",
+            ],
+          },
+        ],
+        "Representative-in-Congress-24683b44": [
+          {
+            "id": "Richard-Coote-b9095636",
+            "name": "Richard Coote",
+            "partyIds": [
+              "OC-3a386d2b",
+            ],
+          },
+        ],
+        "State-Representative-Hillsborough-District-37-f3bde894": [
+          {
+            "id": "William-Lovejoy-fde3c2df",
+            "name": "William Lovejoy",
+            "partyIds": [
+              "OC-3a386d2b",
+            ],
+          },
+        ],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [
+          {
+            "id": "Samuel-Livermore-f927fef1",
+            "name": "Samuel Livermore",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "State-Senator-391381f8": [],
+        "United-States-Senator-d3f1c75b": [
+          {
+            "id": "William-Preston-3778fcd5",
+            "name": "William Preston",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [],
+        "County-Commissioner-d6feed25": [],
+        "County-Treasurer-87d25a31": [],
+        "Register-of-Deeds-a1278df2": [],
+        "Register-of-Probate-a4117da8": [],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
+        "Sheriff-4243fe0b": [],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=46f9490e-5717-4c56-92e5-37c1f1a971c2 1`] = `
+{
+  "46f9490e-5717-4c56-92e5-37c1f1a971c2": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [
+        {
+          "contestId": "State-Representative-Hillsborough-District-37-f3bde894",
+          "optionId": "write-in-0",
+        },
+      ],
+      "votes": {
+        "Executive-Councilor-bb22557f": [
+          {
+            "id": "Anne-Waldron-ee0cbc85",
+            "name": "Anne Waldron",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Governor-061a401b": [
+          {
+            "id": "Josiah-Bartlett-1bb99985",
+            "name": "Josiah Bartlett",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Representative-in-Congress-24683b44": [
+          {
+            "id": "Jeremiah-Smith-469560c9",
+            "name": "Jeremiah Smith",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "State-Representative-Hillsborough-District-37-f3bde894": [],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [
+          {
+            "id": "Samuel-Bell-17973275",
+            "name": "Samuel Bell",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+          {
+            "id": "Abigail-Bartlett-4e46c9d4",
+            "name": "Abigail Bartlett",
+            "partyIds": [
+              "OC-3a386d2b",
+            ],
+          },
+        ],
+        "State-Senator-391381f8": [
+          {
+            "id": "write-in-0",
+            "isWriteIn": true,
+            "name": "Write-In #1",
+            "writeInIndex": 0,
+          },
+        ],
+        "United-States-Senator-d3f1c75b": [
+          {
+            "id": "William-Preston-3778fcd5",
+            "name": "William Preston",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [
+          {
+            "id": "Mary-Woolson-dc0b854a",
+            "name": "Mary Woolson",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "County-Commissioner-d6feed25": [
+          {
+            "id": "Valbe-Cady-ba3af3af",
+            "name": "Valbe Cady",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "County-Treasurer-87d25a31": [],
+        "Register-of-Deeds-a1278df2": [
+          {
+            "id": "Ellen-A-Stileman-14408737",
+            "name": "Ellen A. Stileman",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Register-of-Probate-a4117da8": [],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [
+          "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-yes",
+        ],
+        "Sheriff-4243fe0b": [
+          {
+            "id": "Edward-Randolph-bf4c848a",
+            "name": "Edward Randolph",
+            "partyIds": [
+              "Democratic-aea20adb",
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=47cda523-a05a-439d-8519-ce077cf781f3 1`] = `
+{
+  "47cda523-a05a-439d-8519-ce077cf781f3": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [],
+        "Governor-061a401b": [],
+        "Representative-in-Congress-24683b44": [
+          {
+            "id": "Jeremiah-Smith-469560c9",
+            "name": "Jeremiah Smith",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+          {
+            "id": "Nicholas-Gilman-1791aed7",
+            "name": "Nicholas Gilman",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "State-Representative-Hillsborough-District-37-f3bde894": [
+          {
+            "id": "Charles-H-Hersey-096286a4",
+            "name": "Charles H. Hersey",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [
+          {
+            "id": "Mary-Baker-Eddy-350785d5",
+            "name": "Mary Baker Eddy",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+          {
+            "id": "Samuel-Livermore-f927fef1",
+            "name": "Samuel Livermore",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+          {
+            "id": "write-in-0",
+            "isWriteIn": true,
+            "name": "Write-In #1",
+            "writeInIndex": 0,
+          },
+        ],
+        "State-Senator-391381f8": [
+          {
+            "id": "Matthew-Thornton-f66fec5e",
+            "name": "Matthew Thornton",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "United-States-Senator-d3f1c75b": [
+          {
+            "id": "William-Preston-3778fcd5",
+            "name": "William Preston",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [],
+        "County-Commissioner-d6feed25": [],
+        "County-Treasurer-87d25a31": [],
+        "Register-of-Deeds-a1278df2": [],
+        "Register-of-Probate-a4117da8": [],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
+        "Sheriff-4243fe0b": [],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=50d8aa5e-2a3b-47e3-813d-075be04ebb6e 1`] = `
+{
+  "50d8aa5e-2a3b-47e3-813d-075be04ebb6e": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [],
+        "Governor-061a401b": [
+          {
+            "id": "Josiah-Bartlett-1bb99985",
+            "name": "Josiah Bartlett",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+          {
+            "id": "Hannah-Dustin-ab4ef7c8",
+            "name": "Hannah Dustin",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Representative-in-Congress-24683b44": [],
+        "State-Representative-Hillsborough-District-37-f3bde894": [],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [],
+        "State-Senator-391381f8": [],
+        "United-States-Senator-d3f1c75b": [],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [],
+        "County-Commissioner-d6feed25": [],
+        "County-Treasurer-87d25a31": [],
+        "Register-of-Deeds-a1278df2": [],
+        "Register-of-Probate-a4117da8": [],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
+        "Sheriff-4243fe0b": [],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=55a65b48-69ce-4b44-a582-736b492bb10c 1`] = `
+{
+  "55a65b48-69ce-4b44-a582-736b492bb10c": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [
+          {
+            "id": "Anne-Waldron-ee0cbc85",
+            "name": "Anne Waldron",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Governor-061a401b": [
+          {
+            "id": "Josiah-Bartlett-1bb99985",
+            "name": "Josiah Bartlett",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Representative-in-Congress-24683b44": [
+          {
+            "id": "Jeremiah-Smith-469560c9",
+            "name": "Jeremiah Smith",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "State-Representative-Hillsborough-District-37-f3bde894": [],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [],
+        "State-Senator-391381f8": [
+          {
+            "id": "James-Poole-db5ef4bd",
+            "name": "James Poole",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "United-States-Senator-d3f1c75b": [
+          {
+            "id": "John-Langdon-5951c8e1",
+            "name": "John Langdon",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [],
+        "County-Commissioner-d6feed25": [],
+        "County-Treasurer-87d25a31": [],
+        "Register-of-Deeds-a1278df2": [],
+        "Register-of-Probate-a4117da8": [],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
+        "Sheriff-4243fe0b": [],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=85cde9ce-edc4-41eb-b1cd-280c63a46474 1`] = `
+{
+  "85cde9ce-edc4-41eb-b1cd-280c63a46474": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [],
+        "Governor-061a401b": [
+          {
+            "id": "Josiah-Bartlett-1bb99985",
+            "name": "Josiah Bartlett",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+          {
+            "id": "Hannah-Dustin-ab4ef7c8",
+            "name": "Hannah Dustin",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+          {
+            "id": "John-Spencer-9ffb5970",
+            "name": "John Spencer",
+            "partyIds": [
+              "OC-3a386d2b",
+            ],
+          },
+        ],
+        "Representative-in-Congress-24683b44": [],
+        "State-Representative-Hillsborough-District-37-f3bde894": [],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [],
+        "State-Senator-391381f8": [],
+        "United-States-Senator-d3f1c75b": [],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [],
+        "County-Commissioner-d6feed25": [],
+        "County-Treasurer-87d25a31": [],
+        "Register-of-Deeds-a1278df2": [],
+        "Register-of-Probate-a4117da8": [],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
+        "Sheriff-4243fe0b": [],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=97af3ccb-dd18-406f-aea2-e0a7af30c11c 1`] = `
+{
+  "97af3ccb-dd18-406f-aea2-e0a7af30c11c": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [],
+        "Governor-061a401b": [
+          {
+            "id": "Josiah-Bartlett-1bb99985",
+            "name": "Josiah Bartlett",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Representative-in-Congress-24683b44": [
+          {
+            "id": "Jeremiah-Smith-469560c9",
+            "name": "Jeremiah Smith",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+          {
+            "id": "Nicholas-Gilman-1791aed7",
+            "name": "Nicholas Gilman",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "State-Representative-Hillsborough-District-37-f3bde894": [],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [
+          {
+            "id": "Samuel-Livermore-f927fef1",
+            "name": "Samuel Livermore",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+          {
+            "id": "Elijah-Miller-a52e6988",
+            "name": "Elijah Miller",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+          {
+            "id": "Isaac-Hill-d6c9deeb",
+            "name": "Isaac Hill",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+          {
+            "id": "Abigail-Bartlett-4e46c9d4",
+            "name": "Abigail Bartlett",
+            "partyIds": [
+              "OC-3a386d2b",
+            ],
+          },
+        ],
+        "State-Senator-391381f8": [],
+        "United-States-Senator-d3f1c75b": [
+          {
+            "id": "write-in-0",
+            "isWriteIn": true,
+            "name": "Write-In #1",
+            "writeInIndex": 0,
+          },
+        ],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [],
+        "County-Commissioner-d6feed25": [],
+        "County-Treasurer-87d25a31": [],
+        "Register-of-Deeds-a1278df2": [],
+        "Register-of-Probate-a4117da8": [],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
+        "Sheriff-4243fe0b": [],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=97c8dd4a-52ec-4d16-a843-5a5bdf22d6f3 1`] = `
+{
+  "97c8dd4a-52ec-4d16-a843-5a5bdf22d6f3": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [],
+        "Governor-061a401b": [],
+        "Representative-in-Congress-24683b44": [],
+        "State-Representative-Hillsborough-District-37-f3bde894": [],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [
+          {
+            "id": "write-in-1",
+            "isWriteIn": true,
+            "name": "Write-In #2",
+            "writeInIndex": 1,
+          },
+        ],
+        "State-Senator-391381f8": [],
+        "United-States-Senator-d3f1c75b": [],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [],
+        "County-Commissioner-d6feed25": [],
+        "County-Treasurer-87d25a31": [],
+        "Register-of-Deeds-a1278df2": [],
+        "Register-of-Probate-a4117da8": [],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
+        "Sheriff-4243fe0b": [],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=99b486dd-9507-4c82-87c8-67bba43b4e1b 1`] = `
+{
+  "99b486dd-9507-4c82-87c8-67bba43b4e1b": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [
+          {
+            "id": "Daniel-Webster-13f77b2d",
+            "name": "Daniel Webster",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Governor-061a401b": [],
+        "Representative-in-Congress-24683b44": [],
+        "State-Representative-Hillsborough-District-37-f3bde894": [
+          {
+            "id": "Charles-H-Hersey-096286a4",
+            "name": "Charles H. Hersey",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [
+          {
+            "id": "Elijah-Miller-a52e6988",
+            "name": "Elijah Miller",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "State-Senator-391381f8": [
+          {
+            "id": "Matthew-Thornton-f66fec5e",
+            "name": "Matthew Thornton",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "United-States-Senator-d3f1c75b": [
+          {
+            "id": "William-Preston-3778fcd5",
+            "name": "William Preston",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [
+          {
+            "id": "Mary-Woolson-dc0b854a",
+            "name": "Mary Woolson",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "County-Commissioner-d6feed25": [
+          {
+            "id": "Valbe-Cady-ba3af3af",
+            "name": "Valbe Cady",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "County-Treasurer-87d25a31": [
+          {
+            "id": "Jane-Jones-9caa141f",
+            "name": "Jane Jones",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Register-of-Deeds-a1278df2": [
+          {
+            "id": "Ellen-A-Stileman-14408737",
+            "name": "Ellen A. Stileman",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Register-of-Probate-a4117da8": [
+          {
+            "id": "Claire-Cutts-07a436e7",
+            "name": "Claire Cutts",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [
+          "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-yes",
+        ],
+        "Sheriff-4243fe0b": [
+          {
+            "id": "Edward-Randolph-bf4c848a",
+            "name": "Edward Randolph",
+            "partyIds": [
+              "Democratic-aea20adb",
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=227e070a-53e5-4409-a89d-cec7e8c45c7d 1`] = `
+{
+  "227e070a-53e5-4409-a89d-cec7e8c45c7d": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [],
+        "Governor-061a401b": [],
+        "Representative-in-Congress-24683b44": [],
+        "State-Representative-Hillsborough-District-37-f3bde894": [],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [
+          {
+            "id": "Samuel-Bell-17973275",
+            "name": "Samuel Bell",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+          {
+            "id": "Isaac-Hill-d6c9deeb",
+            "name": "Isaac Hill",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+          {
+            "id": "Abigail-Bartlett-4e46c9d4",
+            "name": "Abigail Bartlett",
+            "partyIds": [
+              "OC-3a386d2b",
+            ],
+          },
+          {
+            "id": "Jacob-Freese-b5146505",
+            "name": "Jacob Freese",
+            "partyIds": [
+              "OC-3a386d2b",
+            ],
+          },
+        ],
+        "State-Senator-391381f8": [],
+        "United-States-Senator-d3f1c75b": [],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [],
+        "County-Commissioner-d6feed25": [],
+        "County-Treasurer-87d25a31": [],
+        "Register-of-Deeds-a1278df2": [],
+        "Register-of-Probate-a4117da8": [],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
+        "Sheriff-4243fe0b": [],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=381da8b3-cb46-4f1e-8511-814d892a05f3 1`] = `
+{
+  "381da8b3-cb46-4f1e-8511-814d892a05f3": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [],
+        "Governor-061a401b": [
+          {
+            "id": "Hannah-Dustin-ab4ef7c8",
+            "name": "Hannah Dustin",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Representative-in-Congress-24683b44": [
+          {
+            "id": "Nicholas-Gilman-1791aed7",
+            "name": "Nicholas Gilman",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "State-Representative-Hillsborough-District-37-f3bde894": [],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [],
+        "State-Senator-391381f8": [],
+        "United-States-Senator-d3f1c75b": [
+          {
+            "id": "William-Preston-3778fcd5",
+            "name": "William Preston",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [],
+        "County-Commissioner-d6feed25": [],
+        "County-Treasurer-87d25a31": [],
+        "Register-of-Deeds-a1278df2": [],
+        "Register-of-Probate-a4117da8": [],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
+        "Sheriff-4243fe0b": [],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=524a09ad-b366-4d3f-8399-763ea31bf357 1`] = `
+{
+  "524a09ad-b366-4d3f-8399-763ea31bf357": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [
+          {
+            "id": "Daniel-Webster-13f77b2d",
+            "name": "Daniel Webster",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Governor-061a401b": [
+          {
+            "id": "Hannah-Dustin-ab4ef7c8",
+            "name": "Hannah Dustin",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Representative-in-Congress-24683b44": [],
+        "State-Representative-Hillsborough-District-37-f3bde894": [],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [],
+        "State-Senator-391381f8": [],
+        "United-States-Senator-d3f1c75b": [],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [],
+        "County-Commissioner-d6feed25": [],
+        "County-Treasurer-87d25a31": [],
+        "Register-of-Deeds-a1278df2": [],
+        "Register-of-Probate-a4117da8": [],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
+        "Sheriff-4243fe0b": [],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=759fee43-9f63-4550-ba2d-eec22fa6fb0d 1`] = `
+{
+  "759fee43-9f63-4550-ba2d-eec22fa6fb0d": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [],
+        "Governor-061a401b": [
+          {
+            "id": "John-Spencer-9ffb5970",
+            "name": "John Spencer",
+            "partyIds": [
+              "OC-3a386d2b",
+            ],
+          },
+        ],
+        "Representative-in-Congress-24683b44": [],
+        "State-Representative-Hillsborough-District-37-f3bde894": [
+          {
+            "id": "Charles-H-Hersey-096286a4",
+            "name": "Charles H. Hersey",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [],
+        "State-Senator-391381f8": [
+          {
+            "id": "Matthew-Thornton-f66fec5e",
+            "name": "Matthew Thornton",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "United-States-Senator-d3f1c75b": [],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [],
+        "County-Commissioner-d6feed25": [],
+        "County-Treasurer-87d25a31": [],
+        "Register-of-Deeds-a1278df2": [],
+        "Register-of-Probate-a4117da8": [],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
+        "Sheriff-4243fe0b": [],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=786f4868-0d0a-45cd-b193-42a9c3553d30 1`] = `
+{
+  "786f4868-0d0a-45cd-b193-42a9c3553d30": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [
+        {
+          "contestId": "Governor-061a401b",
+          "optionId": "write-in-0",
+        },
+      ],
+      "votes": {
+        "Executive-Councilor-bb22557f": [],
+        "Governor-061a401b": [
+          {
+            "id": "Josiah-Bartlett-1bb99985",
+            "name": "Josiah Bartlett",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Representative-in-Congress-24683b44": [
+          {
+            "id": "Nicholas-Gilman-1791aed7",
+            "name": "Nicholas Gilman",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "State-Representative-Hillsborough-District-37-f3bde894": [],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [],
+        "State-Senator-391381f8": [],
+        "United-States-Senator-d3f1c75b": [],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [],
+        "County-Commissioner-d6feed25": [],
+        "County-Treasurer-87d25a31": [],
+        "Register-of-Deeds-a1278df2": [],
+        "Register-of-Probate-a4117da8": [],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
+        "Sheriff-4243fe0b": [],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=913c814b-f170-4427-8049-76d322b3eee3 1`] = `
+{
+  "913c814b-f170-4427-8049-76d322b3eee3": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [
+          {
+            "id": "Daniel-Webster-13f77b2d",
+            "name": "Daniel Webster",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Governor-061a401b": [
+          {
+            "id": "Hannah-Dustin-ab4ef7c8",
+            "name": "Hannah Dustin",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Representative-in-Congress-24683b44": [
+          {
+            "id": "Richard-Coote-b9095636",
+            "name": "Richard Coote",
+            "partyIds": [
+              "OC-3a386d2b",
+            ],
+          },
+        ],
+        "State-Representative-Hillsborough-District-37-f3bde894": [
+          {
+            "id": "Abeil-Foster-ded38e36",
+            "name": "Abeil Foster",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [
+          {
+            "id": "Samuel-Livermore-f927fef1",
+            "name": "Samuel Livermore",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+          {
+            "id": "Elijah-Miller-a52e6988",
+            "name": "Elijah Miller",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+          {
+            "id": "Isaac-Hill-d6c9deeb",
+            "name": "Isaac Hill",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "State-Senator-391381f8": [
+          {
+            "id": "Matthew-Thornton-f66fec5e",
+            "name": "Matthew Thornton",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "United-States-Senator-d3f1c75b": [
+          {
+            "id": "John-Langdon-5951c8e1",
+            "name": "John Langdon",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [
+          {
+            "id": "Ezra-Bartlett-8f95223c",
+            "name": "Ezra Bartlett",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "County-Commissioner-d6feed25": [
+          {
+            "id": "Ichabod-Goodwin-55e8de1f",
+            "name": "Ichabod Goodwin",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "County-Treasurer-87d25a31": [
+          {
+            "id": "Jane-Jones-9caa141f",
+            "name": "Jane Jones",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Register-of-Deeds-a1278df2": [
+          {
+            "id": "John-Mann-b56bbdd3",
+            "name": "John Mann",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Register-of-Probate-a4117da8": [
+          {
+            "id": "Claire-Cutts-07a436e7",
+            "name": "Claire Cutts",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
+        "Sheriff-4243fe0b": [
+          {
+            "id": "Edward-Randolph-bf4c848a",
+            "name": "Edward Randolph",
+            "partyIds": [
+              "Democratic-aea20adb",
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=4483d72e-ea62-4698-b8f7-e24911a72a5b 1`] = `
+{
+  "4483d72e-ea62-4698-b8f7-e24911a72a5b": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [
+          {
+            "id": "Daniel-Webster-13f77b2d",
+            "name": "Daniel Webster",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Governor-061a401b": [
+          {
+            "id": "Josiah-Bartlett-1bb99985",
+            "name": "Josiah Bartlett",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Representative-in-Congress-24683b44": [
+          {
+            "id": "Jeremiah-Smith-469560c9",
+            "name": "Jeremiah Smith",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "State-Representative-Hillsborough-District-37-f3bde894": [
+          {
+            "id": "William-Lovejoy-fde3c2df",
+            "name": "William Lovejoy",
+            "partyIds": [
+              "OC-3a386d2b",
+            ],
+          },
+        ],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [
+          {
+            "id": "Samuel-Livermore-f927fef1",
+            "name": "Samuel Livermore",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+          {
+            "id": "Elijah-Miller-a52e6988",
+            "name": "Elijah Miller",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+          {
+            "id": "Isaac-Hill-d6c9deeb",
+            "name": "Isaac Hill",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "State-Senator-391381f8": [
+          {
+            "id": "Matthew-Thornton-f66fec5e",
+            "name": "Matthew Thornton",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "United-States-Senator-d3f1c75b": [
+          {
+            "id": "William-Preston-3778fcd5",
+            "name": "William Preston",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [
+          {
+            "id": "Mary-Woolson-dc0b854a",
+            "name": "Mary Woolson",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "County-Commissioner-d6feed25": [
+          {
+            "id": "Valbe-Cady-ba3af3af",
+            "name": "Valbe Cady",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "County-Treasurer-87d25a31": [
+          {
+            "id": "John-Smith-ef61a579",
+            "name": "John Smith",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Register-of-Deeds-a1278df2": [
+          {
+            "id": "Ellen-A-Stileman-14408737",
+            "name": "Ellen A. Stileman",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Register-of-Probate-a4117da8": [
+          {
+            "id": "Nathaniel-Parker-56a06c29",
+            "name": "Nathaniel Parker",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
+        "Sheriff-4243fe0b": [
+          {
+            "id": "Edward-Randolph-bf4c848a",
+            "name": "Edward Randolph",
+            "partyIds": [
+              "Democratic-aea20adb",
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=4653ca16-0f5c-4968-8390-f6297f2c278c 1`] = `
+{
+  "4653ca16-0f5c-4968-8390-f6297f2c278c": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [],
+        "Governor-061a401b": [],
+        "Representative-in-Congress-24683b44": [
+          {
+            "id": "Jeremiah-Smith-469560c9",
+            "name": "Jeremiah Smith",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "State-Representative-Hillsborough-District-37-f3bde894": [],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [
+          {
+            "id": "write-in-0",
+            "isWriteIn": true,
+            "name": "Write-In #1",
+            "writeInIndex": 0,
+          },
+          {
+            "id": "write-in-1",
+            "isWriteIn": true,
+            "name": "Write-In #2",
+            "writeInIndex": 1,
+          },
+          {
+            "id": "write-in-2",
+            "isWriteIn": true,
+            "name": "Write-In #3",
+            "writeInIndex": 2,
+          },
+        ],
+        "State-Senator-391381f8": [],
+        "United-States-Senator-d3f1c75b": [],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [],
+        "County-Commissioner-d6feed25": [],
+        "County-Treasurer-87d25a31": [],
+        "Register-of-Deeds-a1278df2": [],
+        "Register-of-Probate-a4117da8": [],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
+        "Sheriff-4243fe0b": [],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=7527d2a4-1cde-4f8f-ae08-7f95de165192 1`] = `
+{
+  "7527d2a4-1cde-4f8f-ae08-7f95de165192": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [
+          {
+            "id": "Anne-Waldron-ee0cbc85",
+            "name": "Anne Waldron",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Governor-061a401b": [
+          {
+            "id": "Josiah-Bartlett-1bb99985",
+            "name": "Josiah Bartlett",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Representative-in-Congress-24683b44": [
+          {
+            "id": "Jeremiah-Smith-469560c9",
+            "name": "Jeremiah Smith",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "State-Representative-Hillsborough-District-37-f3bde894": [
+          {
+            "id": "Abeil-Foster-ded38e36",
+            "name": "Abeil Foster",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [
+          {
+            "id": "Obadiah-Carrigan-5c95145a",
+            "name": "Obadiah Carrigan",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+          {
+            "id": "Mary-Baker-Eddy-350785d5",
+            "name": "Mary Baker Eddy",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+          {
+            "id": "Samuel-Bell-17973275",
+            "name": "Samuel Bell",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "State-Senator-391381f8": [
+          {
+            "id": "James-Poole-db5ef4bd",
+            "name": "James Poole",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "United-States-Senator-d3f1c75b": [
+          {
+            "id": "John-Langdon-5951c8e1",
+            "name": "John Langdon",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [
+          {
+            "id": "Ezra-Bartlett-8f95223c",
+            "name": "Ezra Bartlett",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "County-Commissioner-d6feed25": [
+          {
+            "id": "Ichabod-Goodwin-55e8de1f",
+            "name": "Ichabod Goodwin",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "County-Treasurer-87d25a31": [
+          {
+            "id": "John-Smith-ef61a579",
+            "name": "John Smith",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Register-of-Deeds-a1278df2": [
+          {
+            "id": "John-Mann-b56bbdd3",
+            "name": "John Mann",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Register-of-Probate-a4117da8": [
+          {
+            "id": "Nathaniel-Parker-56a06c29",
+            "name": "Nathaniel Parker",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [
+          "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-no",
+        ],
+        "Sheriff-4243fe0b": [
+          {
+            "id": "Edward-Randolph-bf4c848a",
+            "name": "Edward Randolph",
+            "partyIds": [
+              "Democratic-aea20adb",
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=62385dba-db90-442a-b089-fb41d1f42eea 1`] = `
+{
+  "62385dba-db90-442a-b089-fb41d1f42eea": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [
+          {
+            "id": "Anne-Waldron-ee0cbc85",
+            "name": "Anne Waldron",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Governor-061a401b": [
+          {
+            "id": "Josiah-Bartlett-1bb99985",
+            "name": "Josiah Bartlett",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Representative-in-Congress-24683b44": [],
+        "State-Representative-Hillsborough-District-37-f3bde894": [
+          {
+            "id": "Abeil-Foster-ded38e36",
+            "name": "Abeil Foster",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [
+          {
+            "id": "Mary-Baker-Eddy-350785d5",
+            "name": "Mary Baker Eddy",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+          {
+            "id": "Samuel-Livermore-f927fef1",
+            "name": "Samuel Livermore",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+          {
+            "id": "Isaac-Hill-d6c9deeb",
+            "name": "Isaac Hill",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "State-Senator-391381f8": [
+          {
+            "id": "Matthew-Thornton-f66fec5e",
+            "name": "Matthew Thornton",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "United-States-Senator-d3f1c75b": [
+          {
+            "id": "William-Preston-3778fcd5",
+            "name": "William Preston",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [
+          {
+            "id": "Ezra-Bartlett-8f95223c",
+            "name": "Ezra Bartlett",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "County-Commissioner-d6feed25": [],
+        "County-Treasurer-87d25a31": [
+          {
+            "id": "Jane-Jones-9caa141f",
+            "name": "Jane Jones",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Register-of-Deeds-a1278df2": [
+          {
+            "id": "John-Mann-b56bbdd3",
+            "name": "John Mann",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Register-of-Probate-a4117da8": [
+          {
+            "id": "Claire-Cutts-07a436e7",
+            "name": "Claire Cutts",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [
+          "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-no",
+        ],
+        "Sheriff-4243fe0b": [
+          {
+            "id": "Edward-Randolph-bf4c848a",
+            "name": "Edward Randolph",
+            "partyIds": [
+              "Democratic-aea20adb",
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=346698d4-e4fa-4f9f-956d-2e86a0150673 1`] = `
+{
+  "346698d4-e4fa-4f9f-956d-2e86a0150673": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [],
+        "Governor-061a401b": [],
+        "Representative-in-Congress-24683b44": [],
+        "State-Representative-Hillsborough-District-37-f3bde894": [
+          {
+            "id": "write-in-0",
+            "isWriteIn": true,
+            "name": "Write-In #1",
+            "writeInIndex": 0,
+          },
+        ],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [
+          {
+            "id": "Obadiah-Carrigan-5c95145a",
+            "name": "Obadiah Carrigan",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+          {
+            "id": "Mary-Baker-Eddy-350785d5",
+            "name": "Mary Baker Eddy",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+          {
+            "id": "Elijah-Miller-a52e6988",
+            "name": "Elijah Miller",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "State-Senator-391381f8": [],
+        "United-States-Senator-d3f1c75b": [],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [],
+        "County-Commissioner-d6feed25": [],
+        "County-Treasurer-87d25a31": [
+          {
+            "id": "Jane-Jones-9caa141f",
+            "name": "Jane Jones",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Register-of-Deeds-a1278df2": [
+          {
+            "id": "Ellen-A-Stileman-14408737",
+            "name": "Ellen A. Stileman",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Register-of-Probate-a4117da8": [],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [
+          "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-no",
+        ],
+        "Sheriff-4243fe0b": [],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=672353df-27cb-4e5a-8b6a-de0b90f8a28d 1`] = `
+{
+  "672353df-27cb-4e5a-8b6a-de0b90f8a28d": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [
+          {
+            "id": "Daniel-Webster-13f77b2d",
+            "name": "Daniel Webster",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Governor-061a401b": [
+          {
+            "id": "Hannah-Dustin-ab4ef7c8",
+            "name": "Hannah Dustin",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Representative-in-Congress-24683b44": [
+          {
+            "id": "Nicholas-Gilman-1791aed7",
+            "name": "Nicholas Gilman",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "State-Representative-Hillsborough-District-37-f3bde894": [],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [],
+        "State-Senator-391381f8": [
+          {
+            "id": "Matthew-Thornton-f66fec5e",
+            "name": "Matthew Thornton",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "United-States-Senator-d3f1c75b": [
+          {
+            "id": "William-Preston-3778fcd5",
+            "name": "William Preston",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [],
+        "County-Commissioner-d6feed25": [],
+        "County-Treasurer-87d25a31": [],
+        "Register-of-Deeds-a1278df2": [],
+        "Register-of-Probate-a4117da8": [],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
+        "Sheriff-4243fe0b": [],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=8978016e-2585-49bc-9bfb-2852a473a11d 1`] = `
+{
+  "8978016e-2585-49bc-9bfb-2852a473a11d": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [
+          {
+            "id": "Anne-Waldron-ee0cbc85",
+            "name": "Anne Waldron",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Governor-061a401b": [],
+        "Representative-in-Congress-24683b44": [],
+        "State-Representative-Hillsborough-District-37-f3bde894": [],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [],
+        "State-Senator-391381f8": [],
+        "United-States-Senator-d3f1c75b": [],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [],
+        "County-Commissioner-d6feed25": [],
+        "County-Treasurer-87d25a31": [],
+        "Register-of-Deeds-a1278df2": [],
+        "Register-of-Probate-a4117da8": [],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
+        "Sheriff-4243fe0b": [],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=30950612-8e0b-4934-a7b9-5e2190724afe 1`] = `
+{
+  "30950612-8e0b-4934-a7b9-5e2190724afe": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [],
+        "Governor-061a401b": [
+          {
+            "id": "John-Spencer-9ffb5970",
+            "name": "John Spencer",
+            "partyIds": [
+              "OC-3a386d2b",
+            ],
+          },
+        ],
+        "Representative-in-Congress-24683b44": [
+          {
+            "id": "Nicholas-Gilman-1791aed7",
+            "name": "Nicholas Gilman",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "State-Representative-Hillsborough-District-37-f3bde894": [],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [],
+        "State-Senator-391381f8": [
+          {
+            "id": "write-in-0",
+            "isWriteIn": true,
+            "name": "Write-In #1",
+            "writeInIndex": 0,
+          },
+        ],
+        "United-States-Senator-d3f1c75b": [],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [],
+        "County-Commissioner-d6feed25": [
+          {
+            "id": "write-in-0",
+            "isWriteIn": true,
+            "name": "Write-In #1",
+            "writeInIndex": 0,
+          },
+        ],
+        "County-Treasurer-87d25a31": [],
+        "Register-of-Deeds-a1278df2": [
+          {
+            "id": "John-Mann-b56bbdd3",
+            "name": "John Mann",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Register-of-Probate-a4117da8": [],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
+        "Sheriff-4243fe0b": [],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=53884725-3c74-49ba-86b9-932e1177ec10 1`] = `
+{
+  "53884725-3c74-49ba-86b9-932e1177ec10": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [
+          {
+            "id": "Daniel-Webster-13f77b2d",
+            "name": "Daniel Webster",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Governor-061a401b": [
+          {
+            "id": "Josiah-Bartlett-1bb99985",
+            "name": "Josiah Bartlett",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Representative-in-Congress-24683b44": [
+          {
+            "id": "Richard-Coote-b9095636",
+            "name": "Richard Coote",
+            "partyIds": [
+              "OC-3a386d2b",
+            ],
+          },
+        ],
+        "State-Representative-Hillsborough-District-37-f3bde894": [
+          {
+            "id": "Charles-H-Hersey-096286a4",
+            "name": "Charles H. Hersey",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [
+          {
+            "id": "Obadiah-Carrigan-5c95145a",
+            "name": "Obadiah Carrigan",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "State-Senator-391381f8": [],
+        "United-States-Senator-d3f1c75b": [
+          {
+            "id": "William-Preston-3778fcd5",
+            "name": "William Preston",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [
+          {
+            "id": "Mary-Woolson-dc0b854a",
+            "name": "Mary Woolson",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "County-Commissioner-d6feed25": [],
+        "County-Treasurer-87d25a31": [
+          {
+            "id": "Jane-Jones-9caa141f",
+            "name": "Jane Jones",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Register-of-Deeds-a1278df2": [],
+        "Register-of-Probate-a4117da8": [],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [
+          "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-yes",
+        ],
+        "Sheriff-4243fe0b": [
+          {
+            "id": "Edward-Randolph-bf4c848a",
+            "name": "Edward Randolph",
+            "partyIds": [
+              "Democratic-aea20adb",
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=72547548-e08e-48fa-a8f9-d36560c43125 1`] = `
+{
+  "72547548-e08e-48fa-a8f9-d36560c43125": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [
+          {
+            "id": "Daniel-Webster-13f77b2d",
+            "name": "Daniel Webster",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Governor-061a401b": [],
+        "Representative-in-Congress-24683b44": [
+          {
+            "id": "Richard-Coote-b9095636",
+            "name": "Richard Coote",
+            "partyIds": [
+              "OC-3a386d2b",
+            ],
+          },
+        ],
+        "State-Representative-Hillsborough-District-37-f3bde894": [
+          {
+            "id": "William-Lovejoy-fde3c2df",
+            "name": "William Lovejoy",
+            "partyIds": [
+              "OC-3a386d2b",
+            ],
+          },
+        ],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [
+          {
+            "id": "Obadiah-Carrigan-5c95145a",
+            "name": "Obadiah Carrigan",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+          {
+            "id": "Isaac-Hill-d6c9deeb",
+            "name": "Isaac Hill",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+          {
+            "id": "Jacob-Freese-b5146505",
+            "name": "Jacob Freese",
+            "partyIds": [
+              "OC-3a386d2b",
+            ],
+          },
+        ],
+        "State-Senator-391381f8": [
+          {
+            "id": "James-Poole-db5ef4bd",
+            "name": "James Poole",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "United-States-Senator-d3f1c75b": [
+          {
+            "id": "John-Langdon-5951c8e1",
+            "name": "John Langdon",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+          {
+            "id": "William-Preston-3778fcd5",
+            "name": "William Preston",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [
+          {
+            "id": "Mary-Woolson-dc0b854a",
+            "name": "Mary Woolson",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "County-Commissioner-d6feed25": [
+          {
+            "id": "Valbe-Cady-ba3af3af",
+            "name": "Valbe Cady",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "County-Treasurer-87d25a31": [
+          {
+            "id": "John-Smith-ef61a579",
+            "name": "John Smith",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Register-of-Deeds-a1278df2": [
+          {
+            "id": "write-in-0",
+            "isWriteIn": true,
+            "name": "Write-In #1",
+            "writeInIndex": 0,
+          },
+        ],
+        "Register-of-Probate-a4117da8": [
+          {
+            "id": "write-in-0",
+            "isWriteIn": true,
+            "name": "Write-In #1",
+            "writeInIndex": 0,
+          },
+        ],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [
+          "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-no",
+        ],
+        "Sheriff-4243fe0b": [
+          {
+            "id": "Edward-Randolph-bf4c848a",
+            "name": "Edward Randolph",
+            "partyIds": [
+              "Democratic-aea20adb",
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=a7cbd4bb-9ca8-4001-ab5e-f0f5eb30d360 1`] = `
 {
   "a7cbd4bb-9ca8-4001-ab5e-f0f5eb30d360": [
     {
@@ -5778,7 +5778,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 54`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 55`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=adb431f9-4fd9-41f2-8f13-14d198a92dfe 1`] = `
 {
   "adb431f9-4fd9-41f2-8f13-14d198a92dfe": [
     {
@@ -5872,7 +5872,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 55`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 56`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=af6d30a5-958c-4c08-884a-30c1d1a52416 1`] = `
 {
   "af6d30a5-958c-4c08-884a-30c1d1a52416": [
     {
@@ -6039,7 +6039,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 56`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 57`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=b2e14c74-c514-4c3a-bd92-22d29210648b 1`] = `
 {
   "b2e14c74-c514-4c3a-bd92-22d29210648b": [
     {
@@ -6088,7 +6088,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 57`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 58`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=b36f2116-5290-4509-b53c-015895333e1a 1`] = `
 {
   "b36f2116-5290-4509-b53c-015895333e1a": [
     {
@@ -6152,7 +6152,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 58`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 59`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=b57e8748-f761-46c6-9da5-acd4cafd654e 1`] = `
 {
   "b57e8748-f761-46c6-9da5-acd4cafd654e": [
     {
@@ -6319,7 +6319,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 59`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 60`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=bc1c384d-23ec-4358-b5ba-83ed457feabe 1`] = `
 {
   "bc1c384d-23ec-4358-b5ba-83ed457feabe": [
     {
@@ -6397,7 +6397,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 60`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 61`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=bf365d83-4e7a-4708-92c8-e3b092a4f26a 1`] = `
 {
   "bf365d83-4e7a-4708-92c8-e3b092a4f26a": [
     {
@@ -6461,9 +6461,9 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 61`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 62`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=c8b3565d-d8e2-4b13-9ada-10aba6e25327 1`] = `
 {
-  "c336275b-921b-4d25-9463-ddaf6b1f2210": [
+  "c8b3565d-d8e2-4b13-9ada-10aba6e25327": [
     {
       "metadata": {
         "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
@@ -6478,20 +6478,44 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 62`] = `
       "votes": {
         "Executive-Councilor-bb22557f": [
           {
-            "id": "Daniel-Webster-13f77b2d",
-            "name": "Daniel Webster",
+            "id": "Anne-Waldron-ee0cbc85",
+            "name": "Anne Waldron",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Governor-061a401b": [
+          {
+            "id": "Josiah-Bartlett-1bb99985",
+            "name": "Josiah Bartlett",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
+        "Representative-in-Congress-24683b44": [
+          {
+            "id": "Nicholas-Gilman-1791aed7",
+            "name": "Nicholas Gilman",
             "partyIds": [
               "Republican-f0167ce7",
             ],
           },
         ],
-        "Governor-061a401b": [],
-        "Representative-in-Congress-24683b44": [],
-        "State-Representative-Hillsborough-District-37-f3bde894": [],
+        "State-Representative-Hillsborough-District-37-f3bde894": [
+          {
+            "id": "Abeil-Foster-ded38e36",
+            "name": "Abeil Foster",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+        ],
         "State-Representatives-Hillsborough-District-34-b1012d38": [
           {
-            "id": "Samuel-Livermore-f927fef1",
-            "name": "Samuel Livermore",
+            "id": "Elijah-Miller-a52e6988",
+            "name": "Elijah Miller",
             "partyIds": [
               "Republican-f0167ce7",
             ],
@@ -6499,10 +6523,10 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 62`] = `
         ],
         "State-Senator-391381f8": [
           {
-            "id": "Matthew-Thornton-f66fec5e",
-            "name": "Matthew Thornton",
+            "id": "James-Poole-db5ef4bd",
+            "name": "James Poole",
             "partyIds": [
-              "Republican-f0167ce7",
+              "Democratic-aea20adb",
             ],
           },
         ],
@@ -6542,7 +6566,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 62`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 63`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=c59ef524-893f-4cf8-8678-14103f1286de 1`] = `
 {
   "c59ef524-893f-4cf8-8678-14103f1286de": [
     {
@@ -6704,9 +6728,9 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 63`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 64`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=c336275b-921b-4d25-9463-ddaf6b1f2210 1`] = `
 {
-  "c8b3565d-d8e2-4b13-9ada-10aba6e25327": [
+  "c336275b-921b-4d25-9463-ddaf6b1f2210": [
     {
       "metadata": {
         "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
@@ -6721,44 +6745,20 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 64`] = `
       "votes": {
         "Executive-Councilor-bb22557f": [
           {
-            "id": "Anne-Waldron-ee0cbc85",
-            "name": "Anne Waldron",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Governor-061a401b": [
-          {
-            "id": "Josiah-Bartlett-1bb99985",
-            "name": "Josiah Bartlett",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
-        "Representative-in-Congress-24683b44": [
-          {
-            "id": "Nicholas-Gilman-1791aed7",
-            "name": "Nicholas Gilman",
+            "id": "Daniel-Webster-13f77b2d",
+            "name": "Daniel Webster",
             "partyIds": [
               "Republican-f0167ce7",
             ],
           },
         ],
-        "State-Representative-Hillsborough-District-37-f3bde894": [
-          {
-            "id": "Abeil-Foster-ded38e36",
-            "name": "Abeil Foster",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-        ],
+        "Governor-061a401b": [],
+        "Representative-in-Congress-24683b44": [],
+        "State-Representative-Hillsborough-District-37-f3bde894": [],
         "State-Representatives-Hillsborough-District-34-b1012d38": [
           {
-            "id": "Elijah-Miller-a52e6988",
-            "name": "Elijah Miller",
+            "id": "Samuel-Livermore-f927fef1",
+            "name": "Samuel Livermore",
             "partyIds": [
               "Republican-f0167ce7",
             ],
@@ -6766,10 +6766,10 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 64`] = `
         ],
         "State-Senator-391381f8": [
           {
-            "id": "James-Poole-db5ef4bd",
-            "name": "James Poole",
+            "id": "Matthew-Thornton-f66fec5e",
+            "name": "Matthew Thornton",
             "partyIds": [
-              "Democratic-aea20adb",
+              "Republican-f0167ce7",
             ],
           },
         ],
@@ -6809,7 +6809,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 64`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 65`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=ccdad2d3-ef7c-402d-8b9a-593988722583 1`] = `
 {
   "ccdad2d3-ef7c-402d-8b9a-593988722583": [
     {
@@ -6872,7 +6872,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 65`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 66`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=cd113cfc-2393-4cf1-889d-7bfca2b17cad 1`] = `
 {
   "cd113cfc-2393-4cf1-889d-7bfca2b17cad": [
     {
@@ -6984,7 +6984,137 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 66`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 67`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=d5be8dd6-46d1-4ce4-b906-3bfc61bcfad6 1`] = `
+{
+  "d5be8dd6-46d1-4ce4-b906-3bfc61bcfad6": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [
+          {
+            "id": "Daniel-Webster-13f77b2d",
+            "name": "Daniel Webster",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Governor-061a401b": [
+          {
+            "id": "Josiah-Bartlett-1bb99985",
+            "name": "Josiah Bartlett",
+            "partyIds": [
+              "Democratic-aea20adb",
+            ],
+          },
+          {
+            "id": "Hannah-Dustin-ab4ef7c8",
+            "name": "Hannah Dustin",
+            "partyIds": [
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+        "Representative-in-Congress-24683b44": [],
+        "State-Representative-Hillsborough-District-37-f3bde894": [],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [],
+        "State-Senator-391381f8": [],
+        "United-States-Senator-d3f1c75b": [],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [],
+        "County-Commissioner-d6feed25": [],
+        "County-Treasurer-87d25a31": [],
+        "Register-of-Deeds-a1278df2": [],
+        "Register-of-Probate-a4117da8": [],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
+        "Sheriff-4243fe0b": [
+          {
+            "id": "Edward-Randolph-bf4c848a",
+            "name": "Edward Randolph",
+            "partyIds": [
+              "Democratic-aea20adb",
+              "Republican-f0167ce7",
+            ],
+          },
+        ],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=d9c7eaae-79f8-4c8a-b2d2-f47b5768fd3a 1`] = `
+{
+  "d9c7eaae-79f8-4c8a-b2d2-f47b5768fd3a": [
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 1,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "Executive-Councilor-bb22557f": [],
+        "Governor-061a401b": [],
+        "Representative-in-Congress-24683b44": [],
+        "State-Representative-Hillsborough-District-37-f3bde894": [],
+        "State-Representatives-Hillsborough-District-34-b1012d38": [],
+        "State-Senator-391381f8": [],
+        "United-States-Senator-d3f1c75b": [],
+      },
+    },
+    {
+      "metadata": {
+        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
+        "ballotStyleId": "card-number-3",
+        "ballotType": "precinct",
+        "isTestMode": false,
+        "pageNumber": 2,
+        "precinctId": "town-id-00701-precinct-id-default",
+      },
+      "type": "InterpretedHmpbPage",
+      "unmarkedWriteIns": [],
+      "votes": {
+        "County-Attorney-133f910f": [],
+        "County-Commissioner-d6feed25": [],
+        "County-Treasurer-87d25a31": [],
+        "Register-of-Deeds-a1278df2": [],
+        "Register-of-Probate-a4117da8": [],
+        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
+        "Sheriff-4243fe0b": [],
+      },
+    },
+  ],
+}
+`;
+
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=d24bf705-40ef-4da3-a9b0-4d2f21924db6 1`] = `
 {
   "d24bf705-40ef-4da3-a9b0-4d2f21924db6": [
     {
@@ -7109,137 +7239,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 67`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 68`] = `
-{
-  "d5be8dd6-46d1-4ce4-b906-3bfc61bcfad6": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [
-          {
-            "id": "Daniel-Webster-13f77b2d",
-            "name": "Daniel Webster",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Governor-061a401b": [
-          {
-            "id": "Josiah-Bartlett-1bb99985",
-            "name": "Josiah Bartlett",
-            "partyIds": [
-              "Democratic-aea20adb",
-            ],
-          },
-          {
-            "id": "Hannah-Dustin-ab4ef7c8",
-            "name": "Hannah Dustin",
-            "partyIds": [
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-        "Representative-in-Congress-24683b44": [],
-        "State-Representative-Hillsborough-District-37-f3bde894": [],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [],
-        "State-Senator-391381f8": [],
-        "United-States-Senator-d3f1c75b": [],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [],
-        "County-Commissioner-d6feed25": [],
-        "County-Treasurer-87d25a31": [],
-        "Register-of-Deeds-a1278df2": [],
-        "Register-of-Probate-a4117da8": [],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
-        "Sheriff-4243fe0b": [
-          {
-            "id": "Edward-Randolph-bf4c848a",
-            "name": "Edward Randolph",
-            "partyIds": [
-              "Democratic-aea20adb",
-              "Republican-f0167ce7",
-            ],
-          },
-        ],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 69`] = `
-{
-  "d9c7eaae-79f8-4c8a-b2d2-f47b5768fd3a": [
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 1,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "Executive-Councilor-bb22557f": [],
-        "Governor-061a401b": [],
-        "Representative-in-Congress-24683b44": [],
-        "State-Representative-Hillsborough-District-37-f3bde894": [],
-        "State-Representatives-Hillsborough-District-34-b1012d38": [],
-        "State-Senator-391381f8": [],
-        "United-States-Senator-d3f1c75b": [],
-      },
-    },
-    {
-      "metadata": {
-        "ballotHash": "13cfe19cc2452f18ac565ef188b5df1673227546e28c7e1b4f8be3548e12f373",
-        "ballotStyleId": "card-number-3",
-        "ballotType": "precinct",
-        "isTestMode": false,
-        "pageNumber": 2,
-        "precinctId": "town-id-00701-precinct-id-default",
-      },
-      "type": "InterpretedHmpbPage",
-      "unmarkedWriteIns": [],
-      "votes": {
-        "County-Attorney-133f910f": [],
-        "County-Commissioner-d6feed25": [],
-        "County-Treasurer-87d25a31": [],
-        "Register-of-Deeds-a1278df2": [],
-        "Register-of-Probate-a4117da8": [],
-        "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc": [],
-        "Sheriff-4243fe0b": [],
-      },
-    },
-  ],
-}
-`;
-
-exports[`HMPB - m17 backup Interprets all ballots correctly 70`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=e61e3d7a-a060-41a2-b14e-c7bffd0a6960 1`] = `
 {
   "e61e3d7a-a060-41a2-b14e-c7bffd0a6960": [
     {
@@ -7357,7 +7357,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 70`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 71`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=ed1dd8cb-257e-48de-b4bf-95e293fbf57f 1`] = `
 {
   "ed1dd8cb-257e-48de-b4bf-95e293fbf57f": [
     {
@@ -7450,7 +7450,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 71`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 72`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=edd42fb9-83b6-4df0-96d5-7b193f11e970 1`] = `
 {
   "edd42fb9-83b6-4df0-96d5-7b193f11e970": [
     {
@@ -7514,7 +7514,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 72`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 73`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=ee64f4eb-9ea3-48a3-a50d-6ef5f91251da 1`] = `
 {
   "ee64f4eb-9ea3-48a3-a50d-6ef5f91251da": [
     {
@@ -7563,7 +7563,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 73`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 74`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=f1a1a561-52ee-4750-82f7-88cef012b451 1`] = `
 {
   "f1a1a561-52ee-4750-82f7-88cef012b451": [
     {
@@ -7620,7 +7620,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 74`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 75`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=f55cca96-7b2f-47b2-8457-092db1e17e20 1`] = `
 {
   "f55cca96-7b2f-47b2-8457-092db1e17e20": [
     {
@@ -7789,7 +7789,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 75`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 76`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=fa5d9338-fd91-4936-88e7-a16b294caa12 1`] = `
 {
   "fa5d9338-fd91-4936-88e7-a16b294caa12": [
     {
@@ -7905,7 +7905,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 76`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 77`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=fc7db095-ce91-4d6c-8a05-53b2930ec583 1`] = `
 {
   "fc7db095-ce91-4d6c-8a05-53b2930ec583": [
     {
@@ -7982,7 +7982,7 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 77`] = `
 }
 `;
 
-exports[`HMPB - m17 backup Interprets all ballots correctly 78`] = `
+exports[`HMPB - m17 backup Interprets all ballots correctly: ballotId=fda1aa08-52b4-4364-b537-990666219558 1`] = `
 {
   "fda1aa08-52b4-4364-b537-990666219558": [
     {

--- a/libs/ballot-interpreter/src/interpret.ts
+++ b/libs/ballot-interpreter/src/interpret.ts
@@ -818,7 +818,7 @@ export async function interpretSheetAndSaveImages(
     const imagePaths = await saveSheetImages({
       sheetId,
       ballotImagesPath,
-      images: sheet,
+      images: mapSheet(interpreted, ({ normalizedImage }) => normalizedImage),
     });
 
     return asSheet(

--- a/libs/ballot-interpreter/src/interpret.ts
+++ b/libs/ballot-interpreter/src/interpret.ts
@@ -752,6 +752,7 @@ function scoreInterpretFileResult(
     return -60;
   }
 
+  /* istanbul ignore next - should be unreachable */
   throw new Error(`Unexpected result types: ${frontType}, ${backType}`);
 }
 

--- a/libs/ballot-interpreter/src/interpret_and_save_files.test.ts
+++ b/libs/ballot-interpreter/src/interpret_and_save_files.test.ts
@@ -1,29 +1,29 @@
-import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
-import { loadImageData } from '@votingworks/image-utils';
-import { DEFAULT_MARK_THRESHOLDS, asSheet } from '@votingworks/types';
-import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 import {
   DEFAULT_FAMOUS_NAMES_BALLOT_STYLE_ID,
   DEFAULT_FAMOUS_NAMES_PRECINCT_ID,
   DEFAULT_FAMOUS_NAMES_VOTES,
   renderBmdBallotFixture,
 } from '@votingworks/bmd-ballot-fixtures';
+import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import { loadImageData } from '@votingworks/image-utils';
+import { DEFAULT_MARK_THRESHOLDS, asSheet } from '@votingworks/types';
+import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
+import { pdfToPageImages } from '../test/helpers/interpretation';
 import { tmpDir } from '../test/helpers/tmp';
 import { interpretSheetAndSaveImages } from './interpret';
-import { pdfToPageImagePaths } from '../test/helpers/interpretation';
 
 test('interprets ballot images and saves images for storage', async () => {
   const fixtures = electionFamousNames2021Fixtures;
   const { electionDefinition } = fixtures;
   const testBallot = asSheet(
-    await pdfToPageImagePaths(
+    await pdfToPageImages(
       await renderBmdBallotFixture({
         electionDefinition,
         precinctId: DEFAULT_FAMOUS_NAMES_PRECINCT_ID,
         ballotStyleId: DEFAULT_FAMOUS_NAMES_BALLOT_STYLE_ID,
         votes: DEFAULT_FAMOUS_NAMES_VOTES,
       })
-    )
+    ).toArray()
   );
 
   const ballotImagesPath = tmpDir();

--- a/libs/ballot-interpreter/src/interpret_bmd_and_hmp_ballots.test.ts
+++ b/libs/ballot-interpreter/src/interpret_bmd_and_hmp_ballots.test.ts
@@ -1,29 +1,29 @@
+import { renderBmdBallotFixture } from '@votingworks/bmd-ballot-fixtures';
+import { readElection } from '@votingworks/fs';
 import { famousNamesFixtures } from '@votingworks/hmpb';
-import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 import {
   DEFAULT_MARK_THRESHOLDS,
   InterpretedHmpbPage,
   PageInterpretation,
   asSheet,
 } from '@votingworks/types';
-import { readElection } from '@votingworks/fs';
-import { renderBmdBallotFixture } from '@votingworks/bmd-ballot-fixtures';
+import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
+import { pdfToPageImages } from '../test/helpers/interpretation';
 import { interpretSheet } from './interpret';
-import { pdfToPageImagePaths } from '../test/helpers/interpretation';
 
 test('interpret BMD ballot for an election supporting hand-marked paper ballots', async () => {
   const electionDefinition = (
     await readElection(famousNamesFixtures.electionPath)
   ).unsafeUnwrap();
   const bmdBallot = asSheet(
-    await pdfToPageImagePaths(
+    await pdfToPageImages(
       await renderBmdBallotFixture({
         electionDefinition,
         precinctId: famousNamesFixtures.precinctId,
         ballotStyleId: famousNamesFixtures.ballotStyleId,
         votes: famousNamesFixtures.votes,
       })
-    )
+    ).toArray()
   );
 
   const [bmdPage1Result, bmdPage2Result] = await interpretSheet(
@@ -48,7 +48,7 @@ test('interpret BMD ballot for an election supporting hand-marked paper ballots'
   });
 
   const hmpbBallot = asSheet(
-    await pdfToPageImagePaths(famousNamesFixtures.markedBallotPath)
+    await pdfToPageImages(famousNamesFixtures.markedBallotPath).toArray()
   );
 
   const [hmpbPage1Result, hmpbPage2Result] = await interpretSheet(

--- a/libs/ballot-interpreter/src/save_images.test.ts
+++ b/libs/ballot-interpreter/src/save_images.test.ts
@@ -1,31 +1,25 @@
-import { createImageData, writeImageData } from '@votingworks/image-utils';
+import { createImageData, ImageData } from '@votingworks/image-utils';
+import { SheetOf } from '@votingworks/types';
 import { join } from 'path';
 import { tmpDir } from '../test/helpers/tmp';
-import { saveSheetImage } from './save_images';
+import { saveSheetImages } from './save_images';
 
-test.each([
-  ['.jpg', 'front'],
-  ['.jpg', 'back'],
-  ['.png', 'front'],
-  ['.png', 'back'],
-] as const)('saveSheetImages: %s extension', async (ext, side) => {
+test('saveSheetImages', async () => {
   const sheetId = 'sheetId';
-  const scannedImagesPath = tmpDir();
   const ballotImagesPath = tmpDir();
-  const sourceImagePath = join(scannedImagesPath, `ballot-image${ext}`);
-  const normalizedImage = createImageData(1, 1);
+  const images: SheetOf<ImageData> = [
+    createImageData(1, 1),
+    createImageData(1, 1),
+  ];
 
-  await writeImageData(sourceImagePath, normalizedImage);
-
-  const destinationImagePath = await saveSheetImage({
+  const destinationImagePaths = await saveSheetImages({
     sheetId,
-    side,
     ballotImagesPath,
-    sourceImagePath,
-    normalizedImage,
+    images,
   });
 
-  expect(destinationImagePath).toEqual(
-    join(ballotImagesPath, `sheetId-${side}${ext}`)
-  );
+  expect(destinationImagePaths).toEqual([
+    join(ballotImagesPath, `sheetId-front.png`),
+    join(ballotImagesPath, `sheetId-back.png`),
+  ]);
 });

--- a/libs/ballot-interpreter/test/helpers/interpretation.ts
+++ b/libs/ballot-interpreter/test/helpers/interpretation.ts
@@ -5,11 +5,7 @@ import {
   unique,
 } from '@votingworks/basics';
 import { voteToOptionId } from '@votingworks/hmpb';
-import {
-  pdfToImages,
-  writeImageData,
-  ImageData,
-} from '@votingworks/image-utils';
+import { ImageData, pdfToImages } from '@votingworks/image-utils';
 import {
   ContestId,
   GridLayout,
@@ -17,7 +13,6 @@ import {
   Vote,
   VotesDict,
 } from '@votingworks/types';
-import { tmpNameSync } from 'tmp';
 import { Buffer } from 'buffer';
 import { readFileSync } from 'fs';
 
@@ -28,16 +23,6 @@ export function pdfToPageImages(
   return iter(pdfToImages(pdfData, { scale: 200 / 72 })).map(
     ({ page }) => page
   );
-}
-
-export function pdfToPageImagePaths(pdf: Buffer | string): Promise<string[]> {
-  return pdfToPageImages(pdf)
-    .map(async (page) => {
-      const path = tmpNameSync({ postfix: '.png' });
-      await writeImageData(path, page);
-      return path;
-    })
-    .toArray();
 }
 
 function isContestOnSheet(

--- a/libs/image-utils/src/image_data.ts
+++ b/libs/image-utils/src/image_data.ts
@@ -123,8 +123,6 @@ export function toDataUrl(
 
 /**
  * Writes an image to a file.
- *
- * @param buffer - Whether to buffer the image before writing it to disk.
  */
 export async function writeImageData(
   path: string,


### PR DESCRIPTION
## Overview

Previously we were writing both front & back images to disk twice: once before interpretation (as a kind of staging area, I guess?) and once after. This removes the first write (and the subsequent read+decode). In addition, this ensures that the PNG encoding (which is the slowest part of saving the images) happens in parallel.

## Demo Video or Screenshot
Testing on my Core i5, I'm seeing the time spend just encoding images and writing to disk going from ~450ms down to 250-300ms. Here's a chart of the total time for _all of intake, transfer, interpret, write and record_ before and after:

<img width="583" alt="image" src="https://github.com/user-attachments/assets/df8304b6-bb62-4a84-b5a2-b2e63910e284">

The median scan time went from 3.47s to 2.865s, a decrease of about 23%.

## Testing Plan
Manual testing, new automated testing to prevent regression of the PNG encoding parallelism.