### PR TITLE
[Mark] Persist audio settings when enabling & re-enabling audio

### DIFF
--- a/libs/ui/src/ui_strings/audio_context.test.tsx
+++ b/libs/ui/src/ui_strings/audio_context.test.tsx
@@ -158,7 +158,7 @@ test('setIsEnabled', () => {
   expect(result.current?.isEnabled).toEqual(DEFAULT_AUDIO_ENABLED_STATE);
   expect(result.current?.isPaused).toEqual(!result.current?.isEnabled);
 
-  // Re-enabling should reset all playback settings:
+  // Re-enabling should persist all playback settings:
 
   act(() => result.current?.setIsEnabled(false));
   act(() => result.current?.increasePlaybackRate());
@@ -170,8 +170,8 @@ test('setIsEnabled', () => {
 
   expect(result.current?.isEnabled).toEqual(true);
   expect(result.current?.isPaused).toEqual(false);
-  expect(result.current?.volume).toEqual(DEFAULT_AUDIO_VOLUME);
-  expect(result.current?.playbackRate).toEqual(DEFAULT_PLAYBACK_RATE);
+  expect(result.current?.volume).toEqual(AudioVolume.MINIMUM);
+  expect(result.current?.playbackRate).not.toEqual(DEFAULT_PLAYBACK_RATE);
 });
 
 test('toggleEnabled', () => {

--- a/libs/ui/src/ui_strings/audio_context.tsx
+++ b/libs/ui/src/ui_strings/audio_context.tsx
@@ -104,7 +104,7 @@ export function UiStringsAudioContextProvider(
 
   React.useEffect(() => {
     if (isEnabled) {
-      resetPlaybackSettings();
+      setIsPaused(false);
     } else {
       // Pausing here isn't strictly necessary, since we're disconnecting the
       // context destination node from any inputs, but this makes sure any


### PR DESCRIPTION
## Overview

Fixes https://github.com/votingworks/vxsuite/issues/5034

Updating audio context logic to leave audio settings intact when re-enabling audio after disabling.

## Testing Plan
- Updated unit test
- Manual verification

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
