### PR TITLE
[Mark] Update settings screen 'reset' button to reset audio settings

### DIFF
--- a/libs/ui/src/voter_settings/index.tsx
+++ b/libs/ui/src/voter_settings/index.tsx
@@ -12,6 +12,7 @@ import { useScreenInfo } from '../hooks/use_screen_info';
 import { appStrings } from '../ui_strings';
 import { Header } from './header';
 import { AudioSettings } from './audio_settings';
+import { useAudioControls } from '../hooks/use_audio_controls';
 
 export interface VoterSettingsProps {
   /** @default ['contrastLow', 'contrastMedium', 'contrastHighLight', 'contrastHighDark'] */
@@ -55,6 +56,12 @@ export function VoterSettings(props: VoterSettingsProps): JSX.Element {
     React.useState<SettingsPaneId>('voterSettingsColor');
 
   const { resetThemes } = React.useContext(VoterSettingsManagerContext);
+  const { reset: resetAudioSettings } = useAudioControls();
+
+  const resetVoterSettings = React.useCallback(() => {
+    resetThemes();
+    resetAudioSettings();
+  }, [resetAudioSettings, resetThemes]);
 
   return (
     <Container>
@@ -79,7 +86,7 @@ export function VoterSettings(props: VoterSettingsProps): JSX.Element {
         )}
       </ActivePaneContainer>
       <Footer>
-        <Button onPress={resetThemes}>{appStrings.buttonReset()}</Button>
+        <Button onPress={resetVoterSettings}>{appStrings.buttonReset()}</Button>
         <Button onPress={onClose} variant="primary" icon="Done">
           {appStrings.buttonDone()}
         </Button>

--- a/libs/ui/src/voter_settings/voter_settings.test.tsx
+++ b/libs/ui/src/voter_settings/voter_settings.test.tsx
@@ -1,8 +1,19 @@
 import userEvent from '@testing-library/user-event';
 import { ThemeConsumer } from 'styled-components';
 import { UiTheme } from '@votingworks/types';
+import { mockUseAudioControls } from '@votingworks/test-utils';
 import { render, screen } from '../../test/react_testing_library';
 import { VoterSettings } from '.';
+
+const mockAudioControls = mockUseAudioControls();
+
+jest.mock(
+  '../hooks/use_audio_controls',
+  (): typeof import('../hooks/use_audio_controls') => ({
+    ...jest.requireActual('../hooks/use_audio_controls'),
+    useAudioControls: () => mockAudioControls,
+  })
+);
 
 test('renders expected subcomponents', () => {
   render(<VoterSettings onClose={jest.fn()} />);
@@ -38,7 +49,7 @@ test('does not render "Audio" tab when not enabled', () => {
   expect(screen.queryByText('Audio')).toBeNull();
 });
 
-test('resets button resets global theme', () => {
+test('resets button resets all voter settings', () => {
   let currentTheme: UiTheme | null = null;
 
   function TestComponent(): JSX.Element {
@@ -76,6 +87,8 @@ test('resets button resets global theme', () => {
     })
   );
 
+  expect(mockAudioControls.reset).not.toHaveBeenCalled();
+
   userEvent.click(screen.getButton('Reset'));
 
   expect(currentTheme).toEqual(
@@ -84,6 +97,8 @@ test('resets button resets global theme', () => {
       sizeMode: 'touchLarge',
     })
   );
+
+  expect(mockAudioControls.reset).toHaveBeenCalledTimes(1);
 });
 
 test('done button fires onClose event', () => {


### PR DESCRIPTION
## Overview

Fixes https://github.com/votingworks/vxsuite/issues/5055

Resetting screen reader audio settings when the "Reset" button on the voter settings screen is pressed.

## Testing Plan
- Updated unit tests
- Local run to verify
