### PR TITLE
chore(monorepo-utils): remove broken script

### DIFF
--- a/libs/monorepo-utils/package.json
+++ b/libs/monorepo-utils/package.json
@@ -10,7 +10,6 @@
   "scripts": {
     "type-check": "tsc --build",
     "build": "tsc --build tsconfig.build.json",
-    "build:resources": "bash build_resources.sh",
     "clean": "rm -rf build tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "lint": "pnpm type-check && eslint .",
     "lint:fix": "pnpm type-check && eslint . --fix",


### PR DESCRIPTION
This isn't used and references a shell script that doesn't exist. Presumably copied from `libs/fixtures/package.json`.