### PR TITLE
[Mark] Tighten up voter settings save/restore logic

### DIFF
--- a/apps/mark-scan/frontend/src/app.test.tsx
+++ b/apps/mark-scan/frontend/src/app.test.tsx
@@ -29,6 +29,10 @@ let apiMock: ApiMock;
 beforeEach(() => {
   jest.useFakeTimers();
   apiMock = createApiMock();
+
+  mockOf(useSessionSettingsManager).mockReturnValue({
+    onSessionEnd: jest.fn(),
+  });
 });
 
 afterEach(() => {

--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -231,6 +231,8 @@ export function AppRoot(): JSX.Element | null {
         )
       : [];
 
+  const { onSessionEnd } = useSessionSettingsManager({ authStatus });
+
   const resetBallot = useCallback(
     (newShowPostVotingInstructions?: boolean) => {
       dispatchVotingState({
@@ -245,8 +247,16 @@ export function AppRoot(): JSX.Element | null {
         resetAudioSettings();
         resetLanguage();
       }
+
+      onSessionEnd();
     },
-    [history, voterSettingsManager, resetAudioSettings, resetLanguage]
+    [
+      history,
+      voterSettingsManager,
+      resetAudioSettings,
+      resetLanguage,
+      onSessionEnd,
+    ]
   );
 
   const unconfigure = useCallback(async () => {
@@ -330,8 +340,6 @@ export function AppRoot(): JSX.Element | null {
       document.removeEventListener('keydown', handleKeyboardEvent);
     };
   }, []);
-
-  useSessionSettingsManager({ authStatus });
 
   useBallotStyleManager({
     currentBallotStyleId: ballotStyleId,

--- a/apps/mark/frontend/src/app.test.tsx
+++ b/apps/mark/frontend/src/app.test.tsx
@@ -30,6 +30,10 @@ let apiMock: ApiMock;
 beforeEach(() => {
   jest.useFakeTimers();
   apiMock = createApiMock();
+
+  mockOf(useSessionSettingsManager).mockReturnValue({
+    onSessionEnd: jest.fn(),
+  });
 });
 
 afterEach(() => {

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -219,6 +219,8 @@ export function AppRoot({ reload }: Props): JSX.Element | null {
         )
       : [];
 
+  const { onSessionEnd } = useSessionSettingsManager({ authStatus });
+
   const resetBallot = useCallback(
     (newShowPostVotingInstructions?: boolean) => {
       dispatchVotingState({
@@ -234,8 +236,16 @@ export function AppRoot({ reload }: Props): JSX.Element | null {
         resetAudioSettings();
         resetLanguage();
       }
+
+      onSessionEnd();
     },
-    [history, voterSettingsManager, resetAudioSettings, resetLanguage]
+    [
+      history,
+      voterSettingsManager,
+      resetAudioSettings,
+      resetLanguage,
+      onSessionEnd,
+    ]
   );
 
   const hidePostVotingInstructions = useCallback(() => {
@@ -353,8 +363,6 @@ export function AppRoot({ reload }: Props): JSX.Element | null {
       document.removeEventListener('keydown', handleGamepadKeyboardEvent);
     };
   }, []);
-
-  useSessionSettingsManager({ authStatus });
 
   useBallotStyleManager({
     currentBallotStyleId: ballotStyleId,

--- a/libs/mark-flow-ui/src/hooks/use_session_settings_manager.test.tsx
+++ b/libs/mark-flow-ui/src/hooks/use_session_settings_manager.test.tsx
@@ -2,10 +2,10 @@ import { DefaultTheme, ThemeContext } from 'styled-components';
 import React from 'react';
 import {
   VoterSettingsManagerContext,
-  VoterSettingsManagerContextInterface,
   LanguageControls,
   useCurrentLanguage,
   useAudioEnabled,
+  AppBase,
 } from '@votingworks/ui';
 import {
   mockCardlessVoterUser,
@@ -14,12 +14,13 @@ import {
   mockUseAudioControls,
   mockOf,
 } from '@votingworks/test-utils';
-import { AudioControls, LanguageCode } from '@votingworks/types';
-import { act, render } from '../../test/react_testing_library';
 import {
-  UseSessionSettingsManagerParams,
-  useSessionSettingsManager,
-} from './use_session_settings_manager';
+  AudioControls,
+  InsertedSmartCardAuth,
+  LanguageCode,
+} from '@votingworks/types';
+import { act, renderHook } from '../../test/react_testing_library';
+import { useSessionSettingsManager } from './use_session_settings_manager';
 
 const mockAudioControls = mockUseAudioControls();
 const mockLanguageControls: jest.Mocked<LanguageControls> = {
@@ -29,7 +30,6 @@ const mockLanguageControls: jest.Mocked<LanguageControls> = {
 
 jest.mock('@votingworks/ui', (): typeof import('@votingworks/ui') => ({
   ...jest.requireActual('@votingworks/ui'),
-  ReadOnLoad: jest.fn(),
   useAudioControls: () => mockAudioControls,
   useAudioEnabled: jest.fn(),
   useCurrentLanguage: jest.fn(),
@@ -39,28 +39,64 @@ jest.mock('@votingworks/ui', (): typeof import('@votingworks/ui') => ({
 const mockUseAudioEnabled = mockOf(useAudioEnabled);
 const mockUseCurrentLanguage = mockOf(useCurrentLanguage);
 
-const DEFAULT_THEME: Partial<DefaultTheme> = {
+const DEFAULT_THEME = {
   colorMode: 'contrastMedium',
   sizeMode: 'touchMedium',
   isVisualModeDisabled: false,
+} as const satisfies Partial<DefaultTheme>;
+const { CHINESE_SIMPLIFIED, ENGLISH, SPANISH } = LanguageCode;
+
+const VOTER_AUTH: InsertedSmartCardAuth.AuthStatus = {
+  status: 'logged_in',
+  user: mockCardlessVoterUser(),
+  sessionExpiresAt: mockSessionExpiresAt(),
 };
-const { CHINESE_SIMPLIFIED, SPANISH } = LanguageCode;
 
-let currentTheme: DefaultTheme;
-let voterSettingsManager: VoterSettingsManagerContextInterface;
+const ELECTION_MANAGER_AUTH: InsertedSmartCardAuth.AuthStatus = {
+  status: 'logged_in',
+  user: mockElectionManagerUser(),
+  cardlessVoterUser: mockCardlessVoterUser(),
+  sessionExpiresAt: mockSessionExpiresAt(),
+};
 
-function TestHookWrapper(props: UseSessionSettingsManagerParams): null {
-  currentTheme = React.useContext(ThemeContext);
-  voterSettingsManager = React.useContext(VoterSettingsManagerContext);
+function TestHookWrapper(props: { children: React.ReactNode }) {
+  return (
+    <AppBase
+      {...props}
+      defaultColorMode={DEFAULT_THEME.colorMode}
+      defaultSizeMode={DEFAULT_THEME.sizeMode}
+      defaultIsVisualModeDisabled={DEFAULT_THEME.isVisualModeDisabled ?? false}
+      disableFontsForTests
+    />
+  );
+}
 
-  useSessionSettingsManager(props);
+function useTestHook() {
+  const [authStatus, setMockAuth] = React.useState(VOTER_AUTH);
+  const [mockLanguage, setMockLanguage] = React.useState(ENGLISH);
+  const [mockAudioEnabled, setMockAudioEnabled] = React.useState(true);
 
-  return null;
+  mockUseCurrentLanguage.mockReturnValue(mockLanguage);
+  mockUseAudioEnabled.mockReturnValue(mockAudioEnabled);
+
+  const theme = React.useContext(ThemeContext);
+  const voterSettingsManager = React.useContext(VoterSettingsManagerContext);
+
+  const { onSessionEnd } = useSessionSettingsManager({ authStatus });
+
+  return {
+    theme,
+    onSessionEnd,
+    setMockAudioEnabled,
+    setMockAuth,
+    setMockLanguage,
+    voterSettingsManager,
+  };
 }
 
 const ALLOWED_AUDIO_CONTROLS: ReadonlySet<keyof AudioControls> = new Set<
   keyof AudioControls
->(['reset', 'setIsEnabled']);
+>(['setIsEnabled']);
 
 afterEach(() => {
   // Catch any unexpected audio control usage:
@@ -76,22 +112,10 @@ afterEach(() => {
 });
 
 test('Resets settings when election official logs in', () => {
-  const { rerender } = render(
-    <TestHookWrapper
-      authStatus={{
-        status: 'logged_in',
-        user: mockCardlessVoterUser(),
-        sessionExpiresAt: mockSessionExpiresAt(),
-      }}
-    />,
-    { vxTheme: DEFAULT_THEME }
-  );
+  const { result } = renderHook(useTestHook, { wrapper: TestHookWrapper });
 
-  expect(currentTheme).toEqual(
-    expect.objectContaining<Partial<DefaultTheme>>({
-      colorMode: 'contrastMedium',
-      sizeMode: 'touchMedium',
-    })
+  expect(result.current.theme).toEqual(
+    expect.objectContaining<Partial<DefaultTheme>>(DEFAULT_THEME)
   );
   expect(mockLanguageControls.reset).not.toHaveBeenCalled();
   expect(mockLanguageControls.setLanguage).not.toHaveBeenCalled();
@@ -100,62 +124,50 @@ test('Resets settings when election official logs in', () => {
 
   // Simulate changing session settings as voter:
   act(() => {
-    voterSettingsManager.setColorMode('contrastLow');
-    voterSettingsManager.setSizeMode('touchExtraLarge');
-    voterSettingsManager.setIsVisualModeDisabled(true);
+    result.current.voterSettingsManager.setColorMode('contrastLow');
+    result.current.voterSettingsManager.setSizeMode('touchExtraLarge');
+    result.current.voterSettingsManager.setIsVisualModeDisabled(true);
   });
-  expect(currentTheme).toEqual(
+  expect(result.current.theme).toEqual(
     expect.objectContaining<Partial<DefaultTheme>>({
       colorMode: 'contrastLow',
       sizeMode: 'touchExtraLarge',
       isVisualModeDisabled: true,
     })
   );
-  mockUseCurrentLanguage.mockReturnValue(SPANISH);
-  mockUseAudioEnabled.mockReturnValue(true);
+
+  act(() => {
+    result.current.setMockLanguage(SPANISH);
+    result.current.setMockAudioEnabled(true);
+  });
 
   // Should reset session settings on Election Manager login:
-  rerender(
-    <TestHookWrapper
-      authStatus={{
-        status: 'logged_in',
-        user: mockElectionManagerUser(),
-        sessionExpiresAt: mockSessionExpiresAt(),
-      }}
-    />
-  );
-  expect(currentTheme).toEqual(
+  act(() => result.current.setMockAuth(ELECTION_MANAGER_AUTH));
+
+  expect(result.current.theme).toEqual(
     expect.objectContaining<Partial<DefaultTheme>>(DEFAULT_THEME)
   );
   expect(mockLanguageControls.reset).toHaveBeenCalled();
-  expect(mockAudioControls.reset).not.toHaveBeenCalled();
   expect(mockLanguageControls.setLanguage).not.toHaveBeenCalled();
   expect(mockAudioControls.setIsEnabled).toHaveBeenLastCalledWith(false);
 
   // Simulate changing session settings as Election Manager:
   act(() => {
-    voterSettingsManager.setColorMode('contrastHighDark');
-    voterSettingsManager.setSizeMode('touchSmall');
+    result.current.voterSettingsManager.setColorMode('contrastHighDark');
+    result.current.voterSettingsManager.setSizeMode('touchSmall');
   });
-  expect(currentTheme).toEqual(
+  expect(result.current.theme).toEqual(
     expect.objectContaining<Partial<DefaultTheme>>({
       colorMode: 'contrastHighDark',
       sizeMode: 'touchSmall',
     })
   );
-  mockUseCurrentLanguage.mockReturnValue(CHINESE_SIMPLIFIED);
+  act(() => result.current.setMockLanguage(CHINESE_SIMPLIFIED));
 
   // Should return to voter settings on return to voter session:
-  rerender(
-    <TestHookWrapper
-      authStatus={{
-        status: 'logged_in',
-        user: mockCardlessVoterUser(),
-        sessionExpiresAt: mockSessionExpiresAt(),
-      }}
-    />
-  );
-  expect(currentTheme).toEqual(
+  act(() => result.current.setMockAuth(VOTER_AUTH));
+
+  expect(result.current.theme).toEqual(
     expect.objectContaining<Partial<DefaultTheme>>({
       colorMode: 'contrastLow',
       sizeMode: 'touchExtraLarge',
@@ -167,28 +179,19 @@ test('Resets settings when election official logs in', () => {
   expect(mockAudioControls.reset).not.toHaveBeenCalled();
 });
 
-test('Resets theme to default if returning to a new voter session', () => {
-  const { rerender } = render(
-    <TestHookWrapper
-      authStatus={{
-        status: 'logged_in',
-        user: mockCardlessVoterUser(),
-        sessionExpiresAt: mockSessionExpiresAt(),
-      }}
-    />,
-    { vxTheme: DEFAULT_THEME }
-  );
+test('Clears stored voter settings when session is ended', () => {
+  const { result } = renderHook(useTestHook, { wrapper: TestHookWrapper });
 
   // Simulate changing session settings as voter:
   act(() => {
-    voterSettingsManager.setColorMode('contrastLow');
-    voterSettingsManager.setSizeMode('touchExtraLarge');
-    voterSettingsManager.setIsVisualModeDisabled(true);
+    result.current.voterSettingsManager.setColorMode('contrastLow');
+    result.current.voterSettingsManager.setSizeMode('touchExtraLarge');
+    result.current.voterSettingsManager.setIsVisualModeDisabled(true);
+    result.current.setMockLanguage(SPANISH);
+    result.current.setMockAudioEnabled(false);
   });
-  mockUseCurrentLanguage.mockReturnValue(SPANISH);
-  mockUseAudioEnabled.mockReturnValue(false);
 
-  expect(currentTheme).toEqual(
+  expect(result.current.theme).toEqual(
     expect.objectContaining<Partial<DefaultTheme>>({
       colorMode: 'contrastLow',
       sizeMode: 'touchExtraLarge',
@@ -196,52 +199,25 @@ test('Resets theme to default if returning to a new voter session', () => {
     })
   );
 
-  // Simulate logging in ang changing voter settings as Election Manager:
-  rerender(
-    <TestHookWrapper
-      authStatus={{
-        status: 'logged_in',
-        user: mockElectionManagerUser(),
-        sessionExpiresAt: mockSessionExpiresAt(),
-      }}
-    />
-  );
-  mockUseCurrentLanguage.mockReturnValue(CHINESE_SIMPLIFIED);
+  // Simulate logging in as Election Manager and ending the voter session:
   act(() => {
-    voterSettingsManager.setColorMode('contrastHighDark');
-    voterSettingsManager.setSizeMode('touchSmall');
+    result.current.setMockAuth(ELECTION_MANAGER_AUTH);
+    result.current.onSessionEnd();
   });
-  expect(currentTheme).toEqual(
-    expect.objectContaining<Partial<DefaultTheme>>({
-      colorMode: 'contrastHighDark',
-      sizeMode: 'touchSmall',
-      isVisualModeDisabled: false,
-    })
-  );
 
   mockLanguageControls.reset.mockReset();
   mockLanguageControls.setLanguage.mockReset();
   mockAudioControls.reset.mockReset();
   mockAudioControls.setIsEnabled.mockReset();
 
-  // Should reset to default if voter session has been reset:
-  rerender(
-    <TestHookWrapper
-      authStatus={{
-        status: 'logged_in',
-        user: {
-          ...mockCardlessVoterUser(),
-          sessionId: 'new_session',
-        },
-        sessionExpiresAt: mockSessionExpiresAt(),
-      }}
-    />
-  );
-  expect(currentTheme).toEqual(
+  // Logging back in as a voter after session end should be a no-op:
+  act(() => result.current.setMockAuth(VOTER_AUTH));
+
+  expect(result.current.theme).toEqual(
     expect.objectContaining<Partial<DefaultTheme>>(DEFAULT_THEME)
   );
-  expect(mockLanguageControls.reset).toHaveBeenCalled();
+  expect(mockLanguageControls.reset).not.toHaveBeenCalled();
   expect(mockLanguageControls.setLanguage).not.toHaveBeenCalled();
-  expect(mockAudioControls.reset).toHaveBeenCalled();
+  expect(mockAudioControls.reset).not.toHaveBeenCalled();
   expect(mockAudioControls.setIsEnabled).not.toHaveBeenCalled();
 });

--- a/libs/mark-flow-ui/src/hooks/use_session_settings_manager.ts
+++ b/libs/mark-flow-ui/src/hooks/use_session_settings_manager.ts
@@ -1,7 +1,6 @@
 import React from 'react';
 import { DefaultTheme } from 'styled-components';
 
-import { isCardlessVoterAuth } from '@votingworks/utils';
 import {
   VoterSettingsManagerContext,
   useAudioControls,
@@ -11,9 +10,14 @@ import {
   useLanguageControls,
 } from '@votingworks/ui';
 import { InsertedSmartCardAuth, LanguageCode } from '@votingworks/types';
+import { isCardlessVoterAuth } from '@votingworks/utils';
 
 export interface UseSessionSettingsManagerParams {
   authStatus: InsertedSmartCardAuth.AuthStatus;
+}
+
+export interface UseSessionSettingsManagerResult {
+  onSessionEnd: () => void;
 }
 
 interface VoterSettings {
@@ -24,90 +28,101 @@ interface VoterSettings {
 
 export function useSessionSettingsManager(
   params: UseSessionSettingsManagerParams
-): void {
+): UseSessionSettingsManagerResult {
   const { authStatus } = params;
 
-  const previousAuthStatusRef =
-    React.useRef<InsertedSmartCardAuth.AuthStatus>();
-  const previousVoterAuthStatusRef =
-    React.useRef<InsertedSmartCardAuth.AuthStatus>();
-  const voterSettingsRef = React.useRef<VoterSettings>();
+  const [voterSettings, saveVoterSettings] = React.useState<VoterSettings>();
 
   const voterSettingsManager = React.useContext(VoterSettingsManagerContext);
   const currentTheme = useCurrentTheme();
 
-  const { reset: resetAudioSettings, setIsEnabled: setAudioEnabled } =
-    useAudioControls();
+  const { setIsEnabled: setAudioEnabled } = useAudioControls();
   const { reset: resetLanguage, setLanguage } = useLanguageControls();
   const currentLanguage = useCurrentLanguage();
   const isAudioEnabled = useAudioEnabled();
 
-  const wasPreviouslyLoggedInAsVoter =
-    previousAuthStatusRef.current &&
-    isCardlessVoterAuth(previousAuthStatusRef.current);
   const isLoggedInAsVoter = isCardlessVoterAuth(authStatus);
-  // If the pollworker deactivated the voter session and initiated a new one, the sessionId have changed.
-  const isNewVoterSession =
-    isLoggedInAsVoter &&
-    previousVoterAuthStatusRef.current &&
-    isCardlessVoterAuth(previousVoterAuthStatusRef.current) &&
-    previousVoterAuthStatusRef.current.user.sessionId !==
-      authStatus.user.sessionId;
 
+  //
+  // Wrap `isLoggedInAsVoter` in a ref for effects that don't need to re-run
+  // when it changes:
+  //
+  const isLoggedInAsVoterRef = React.useRef(isLoggedInAsVoter);
+  isLoggedInAsVoterRef.current = isLoggedInAsVoter;
+
+  //
+  // Save voter settings whenever they are changed during a voter session:
+  //
   React.useEffect(() => {
-    // Reset to default settings and disable audio when election official logs
-    // in during a voter session:
-    if (wasPreviouslyLoggedInAsVoter && !isLoggedInAsVoter) {
-      voterSettingsRef.current = {
-        isAudioEnabled,
-        language: currentLanguage,
-        theme: currentTheme,
-      };
-      voterSettingsManager.resetThemes();
-      resetLanguage();
-      setAudioEnabled(false);
-      previousVoterAuthStatusRef.current = previousAuthStatusRef.current;
+    if (!isLoggedInAsVoterRef.current) {
+      return;
     }
 
-    if (
-      !wasPreviouslyLoggedInAsVoter &&
-      isLoggedInAsVoter &&
-      voterSettingsRef.current
-    ) {
-      const voterSettings = voterSettingsRef.current;
-      if (!isNewVoterSession) {
-        // Reset to previous voter settings for the active voter session when
-        // when election official logs out:
-        voterSettingsManager.setColorMode(voterSettings.theme.colorMode);
-        voterSettingsManager.setSizeMode(voterSettings.theme.sizeMode);
-        voterSettingsManager.setIsVisualModeDisabled(
-          voterSettings.theme.isVisualModeDisabled
-        );
-        setLanguage(voterSettings.language);
-        setAudioEnabled(voterSettings.isAudioEnabled);
-        previousVoterAuthStatusRef.current = undefined;
-      } else {
-        // Reset to default settings for a new voter's session
-        voterSettingsManager.resetThemes();
-        resetLanguage();
-        resetAudioSettings();
-      }
-      voterSettingsRef.current = undefined;
+    saveVoterSettings({
+      isAudioEnabled,
+      language: currentLanguage,
+      theme: currentTheme,
+    });
+  }, [currentLanguage, currentTheme, isAudioEnabled]);
+
+  /**
+   * Callback for updating settings to match previously saved voter settings:
+   */
+  const restoreVoterSettings = React.useCallback(() => {
+    if (!voterSettings) {
+      return;
     }
 
-    previousAuthStatusRef.current = authStatus;
-  }, [
-    authStatus,
-    currentLanguage,
-    currentTheme,
-    isAudioEnabled,
-    isLoggedInAsVoter,
-    resetAudioSettings,
-    resetLanguage,
-    setAudioEnabled,
-    setLanguage,
-    voterSettingsManager,
-    wasPreviouslyLoggedInAsVoter,
-    isNewVoterSession,
-  ]);
+    voterSettingsManager.setColorMode(voterSettings.theme.colorMode);
+    voterSettingsManager.setSizeMode(voterSettings.theme.sizeMode);
+    voterSettingsManager.setIsVisualModeDisabled(
+      voterSettings.theme.isVisualModeDisabled
+    );
+    setLanguage(voterSettings.language);
+    setAudioEnabled(voterSettings.isAudioEnabled);
+  }, [setAudioEnabled, setLanguage, voterSettings, voterSettingsManager]);
+
+  /**
+   * Callback for resetting to setting defaults for non-voters:
+   */
+  const resetSettingsForNonVoter = React.useCallback(() => {
+    voterSettingsManager.resetThemes();
+    resetLanguage();
+    setAudioEnabled(false);
+  }, [resetLanguage, setAudioEnabled, voterSettingsManager]);
+
+  //
+  // Wrap the settings management callbacks in refs to enable usage in the
+  // effect below without creating explicit dependencies and triggering the
+  // effect every time the callbacks are recomputed:
+  //
+
+  const restoreSettingsFnRef = React.useRef(restoreVoterSettings);
+  restoreSettingsFnRef.current = restoreVoterSettings;
+
+  const resetForNonVoterFnRef = React.useRef(resetSettingsForNonVoter);
+  resetForNonVoterFnRef.current = resetSettingsForNonVoter;
+
+  //
+  // When auth state changes, either reset to default settings for non-voters,
+  // or restore previous voter settings for voter auth.
+  //
+  React.useEffect(() => {
+    if (isLoggedInAsVoter) {
+      restoreSettingsFnRef.current();
+    } else {
+      resetForNonVoterFnRef.current();
+    }
+  }, [isLoggedInAsVoter]);
+
+  //
+  // Return a callback for client apps to trigger when ending a voter session,
+  // which will clear the saved voter settings:
+  //
+
+  const onSessionEnd = React.useCallback(() => {
+    saveVoterSettings(undefined);
+  }, []);
+
+  return { onSessionEnd };
 }


### PR DESCRIPTION
## Overview

Fixes https://github.com/votingworks/vxsuite/issues/4947
Fixes https://github.com/votingworks/vxsuite/issues/5121

Attempting to make the `useSessionSettingsManager` hook a little less brittle and more readable:
- Moving the responsibility of resetting settings at the end of the session to the apps (VxMark, VxMarkScan), so that it's more explicit and more tightly coupled with the `resetBallot` action in each app.
- Break up the effect into smaller effects/callbacks to make sure each piece is running only when necessary.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/7089c5a5-552c-4be9-af7b-095b48cd2862

## Testing Plan
- Updated associated unit tests
- Manual testing:
  - Insert and remove card at various points during the voter flow - verify settings are restored when card is removed.
  - Deactivate voter session at various points during the voter flow - verify settings stay in default state when card is removed or when a new session is started.

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
