### PR TITLE
Fix bug shows 'No' on review page for undervote yesno

### DIFF
--- a/libs/mark-flow-ui/src/components/review.test.tsx
+++ b/libs/mark-flow-ui/src/components/review.test.tsx
@@ -167,6 +167,17 @@ describe('yesno contest', () => {
     within(screen.getByTestId(`contest-wrapper-${contest.id}`)).getByText(
       /no selection/i
     );
+    // Make sure there are not elements with the text 'Yes' or 'No' to represent those votes.
+    expect(
+      within(screen.getByTestId(`contest-wrapper-${contest.id}`)).queryByText(
+        'Yes'
+      )
+    ).toBeNull();
+    expect(
+      within(screen.getByTestId(`contest-wrapper-${contest.id}`)).queryByText(
+        'No'
+      )
+    ).toBeNull();
   });
 });
 

--- a/libs/mark-flow-ui/src/components/review.tsx
+++ b/libs/mark-flow-ui/src/components/review.tsx
@@ -107,7 +107,11 @@ function YesNoContestResult({
   const district = getContestDistrict(election, contest);
   const yesNo = getSingleYesNoVote(vote);
   const selectedOption =
-    yesNo === contest.yesOption.id ? contest.yesOption : contest.noOption;
+    yesNo === contest.yesOption.id
+      ? contest.yesOption
+      : yesNo === contest.noOption.id
+      ? contest.noOption
+      : null;
 
   const votes: ContestVote[] = selectedOption
     ? [


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/5168

We were accidently just checking for a "yes" option in rendering this UI and treating an undervote like "no"
<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot
Before
<img width="986" alt="Screenshot 2024-08-01 at 11 09 37 AM" src="https://github.com/user-attachments/assets/e1dd1e06-50ff-4ffa-b7fd-c59d12d1f0e9">

After

<img width="987" alt="Screenshot 2024-08-01 at 11 09 04 AM" src="https://github.com/user-attachments/assets/17bbd7fe-d21c-4883-be1e-604fd752850b">

## Testing Plan
Added test case, saw failure, did change, saw pass
Manually tested visually in the UI as seen above

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
