### PR TITLE
Enable formatting of non-dos partition table USB drives

### DIFF
--- a/libs/usb-drive/scripts/format_fat32.sh
+++ b/libs/usb-drive/scripts/format_fat32.sh
@@ -26,6 +26,9 @@ if [[ ${#LABEL} -gt 11 ]]; then
     exit 1
 fi
 
+# set the partition table type to dos before using a type=c partition
+echo 'label: dos' | sfdisk "${DEVICE}"
+
 # partition the device with a single FAT32 (type=c) partition
 echo 'type=c' | sfdisk --wipe always --wipe-partitions always "${DEVICE}"
 


### PR DESCRIPTION
This PR fixes [5045](https://github.com/votingworks/vxsuite/issues/5045). By first ensuring the partition table type is `dos`, the second `sfdisk` command can successfully execute, even if the drive was originally created with the wrong table type, i.e. `gpt`. 

To test, I've created multiple USB drive configurations:
* dos - single fat32 partition
* dos - multiple fat32 partitions
* dos - single ext4 partition 
* dos - multiple ext4 partitions
* dos - multiple fat32 and ext4 partitions
* gpt - all of the above

In all cases, you end up with a dos - single fat32 partition with our expected VxUSB-XXXXX naming convention.