### PR TITLE
build(ballot-interpreter): fix build in Rust v1.80.0

### DIFF
--- a/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
@@ -63,14 +63,6 @@ pub struct BallotCard {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct NormalizedImageBuffer {
-    width: u32,
-    height: u32,
-    data: Vec<u8>,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
 pub struct InterpretedBallotPage {
     pub grid: TimingMarkGrid,
     pub metadata: BallotPageMetadata,


### PR DESCRIPTION
The latest Rust seems stricter about unused structs. Let's remove them!
