### PR TITLE
style(rust): fix issues flagged by clippy in Rust 1.80.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,6 @@ zbar-rust = "0.0.23"
 dead_code = "deny"
 
 [workspace.lints.clippy]
-pedantic = "deny"
-nursery = "deny"
+pedantic = { level = "deny", priority = -1 }
+nursery = { level = "deny", priority = -1 }
 unwrap_used = "deny"

--- a/apps/mark-scan/accessible-controller/src/controllerd.rs
+++ b/apps/mark-scan/accessible-controller/src/controllerd.rs
@@ -45,7 +45,7 @@ struct Args {
     #[arg(short, long)]
     skip_hardware_check: bool,
 
-    /// Path to the directory where MarkScan's working files are stored.
+    /// Path to the directory where `MarkScan`'s working files are stored.
     #[arg(long, env = "MARK_SCAN_WORKSPACE")]
     mark_scan_workspace: PathBuf,
 }

--- a/apps/mark-scan/fai-100-controller/src/fai_100_controllerd.rs
+++ b/apps/mark-scan/fai-100-controller/src/fai_100_controllerd.rs
@@ -49,7 +49,7 @@ struct Args {
     #[arg(short, long)]
     skip_hardware_check: bool,
 
-    /// Path to the directory where MarkScan's working files are stored.
+    /// Path to the directory where `MarkScan`'s working files are stored.
     #[arg(long, env = "MARK_SCAN_WORKSPACE")]
     mark_scan_workspace: PathBuf,
 }

--- a/libs/ballot-interpreter/src/hmpb-rust/timing_marks.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/timing_marks.rs
@@ -222,12 +222,12 @@ impl TimingMarkGrid {
     ///
     /// The point location is determined by:
     /// 1. Finding the left and right timing marks for the given row (if given a
-    /// fractional row index, then interpolating vertically between the closest
-    /// two rows).
+    ///    fractional row index, then interpolating vertically between the closest
+    ///    two rows).
     /// 2. Correcting the left/right timing mark position to account for
-    /// the marks being cropped during scanning or border removal
+    ///    the marks being cropped during scanning or border removal
     /// 3. Interpolating horizontally between the left/right timing mark
-    /// positions based on the given column index.
+    ///    positions based on the given column index.
     pub fn point_for_location(
         &self,
         column: SubGridUnit,

--- a/libs/pdi-scanner/src/rust/protocol/packets.rs
+++ b/libs/pdi-scanner/src/rust/protocol/packets.rs
@@ -231,11 +231,11 @@ pub enum Outgoing {
     /// - `<ESC> ‘+’ = (1BH) (2BH)`: Command to increase the Top CIS threshold by a single step.
     /// - `<ESC> ‘-’ = (1BH) (2DH)`: Command to decrease the Top CIS threshold by a single step.
     /// - `<ESC> ‘>’ = (1BH) (3EH)`: Command to increase the threshold of Top
-    /// CIS (simplex units) by five steps, or increase the Bottom CIS threshold
-    /// (duplex units) by one step.
+    ///   CIS (simplex units) by five steps, or increase the Bottom CIS threshold
+    ///   (duplex units) by one step.
     /// - `<ESC> ‘<’ = (1BH) (3CH)`: Command to decrease the threshold of Top
-    /// CIS (simplex units) by five steps, or decrease the Bottom CIS threshold
-    /// (duplex units) by one step.
+    ///   CIS (simplex units) by five steps, or decrease the Bottom CIS threshold
+    ///   (duplex units) by one step.
     ///
     /// After execution of any (above) threshold adjustment command, the new
     /// threshold value is ‘echoed-back’ to the user - using the ’X’ (58H)
@@ -964,11 +964,11 @@ pub enum Incoming {
     /// - `<ESC> ‘+’ = (1BH) (2BH)`: Command to increase the Top CIS threshold by a single step.
     /// - `<ESC> ‘-’ = (1BH) (2DH)`: Command to decrease the Top CIS threshold by a single step.
     /// - `<ESC> ‘>’ = (1BH) (3EH)`: Command to increase the threshold of Top
-    /// CIS (simplex units) by five steps, or increase the Bottom CIS threshold
-    /// (duplex units) by one step.
+    ///   CIS (simplex units) by five steps, or increase the Bottom CIS threshold
+    ///   (duplex units) by one step.
     /// - `<ESC> ‘<’ = (1BH) (3CH)`: Command to decrease the threshold of Top
-    /// CIS (simplex units) by five steps, or decrease the Bottom CIS threshold
-    /// (duplex units) by one step.
+    ///   CIS (simplex units) by five steps, or decrease the Bottom CIS threshold
+    ///   (duplex units) by one step.
     ///
     /// After execution of any (above) threshold adjustment command, the new
     /// threshold value is ‘echoed-back’ to the user - using the ’X’ (58H)


### PR DESCRIPTION
## Overview

Rust introduced some new clippy lints since the version we're pinned to (1.76.0). This makes `cargo clippy` report cleanly up to v1.80.0. See [this](https://rust-lang.github.io/rust-clippy/master/index.html#/lint_groups_priority) for the `Cargo.toml` change. The others are just about documentation comment formatting.

## Demo Video or Screenshot
n/a

## Testing Plan
Ran `cargo clippy` locally at the project root.
