### PR TITLE
perf(cvr-fixture-generator): create one image per ballot size

### DIFF
--- a/libs/cvr-fixture-generator/src/cli/generate/main.test.ts
+++ b/libs/cvr-fixture-generator/src/cli/generate/main.test.ts
@@ -56,7 +56,7 @@ async function readAndValidateCastVoteRecordExport(
   expect(readResult).toEqual(ok(expect.anything()));
   const { castVoteRecordExportMetadata, castVoteRecordIterator } =
     readResult.ok()!;
-  const castVoteRecords = [];
+  const castVoteRecords: CVR.CVR[] = [];
   for await (const castVoteRecordResult of castVoteRecordIterator) {
     expect(castVoteRecordResult).toEqual(ok(expect.anything()));
     castVoteRecords.push(castVoteRecordResult.ok()!.castVoteRecord);


### PR DESCRIPTION
## Overview

CircleCI flagged `generating as BMD ballots (non-gridlayouts election)` as our [slowest test](https://app.circleci.com/insights/github/votingworks/vxsuite/workflows/test/tests). I believe it's recorded as taking 1m because that's actually the Jest timeout for the file, meaning it probably times out about 4% of the time (i.e. because 96% pass rate).

<img width="1254" alt="image" src="https://github.com/user-attachments/assets/78b0b047-81eb-478f-b41b-4032cc421359">


## Benchmarks
We don't actually make images with any content when generating CVR fixtures, so just re-use the images from previous generated CVRs. This speeds up the tests by a decent amount (ran the `main.test.ts` file before and after taking the best of three runs):

**BEFORE**

```
 PASS  src/cli/generate/main.test.ts (40.79 s)
  ✓ --help (13 ms)
  ✓ invalid option (2 ms)
  ✓ missing election definition (1 ms)
  ✓ missing output path (1 ms)
  ✓ generate with defaults (2108 ms)
  ✓ generate with custom number of records below the suggested number (1194 ms)
  ✓ generate with custom number of records above the suggested number (4795 ms)
  ✓ generate live mode CVRs (367 ms)
  ✓ generate test mode CVRs (378 ms)
  ✓ specifying scanner ids (4049 ms)
  ✓ including ballot images (2111 ms)
  ✓ generating as BMD ballots (non-gridlayouts election) (20167 ms)
  ✓ libs/fixtures are up to date - if this test fails run `pnpm generate-fixtures` (3536 ms)
```

**AFTER**

```
 PASS  src/cli/generate/main.test.ts (27.834 s)
  ✓ --help (13 ms)
  ✓ invalid option (1 ms)
  ✓ missing election definition (2 ms)
  ✓ missing output path (1 ms)
  ✓ generate with defaults (1438 ms)
  ✓ generate with custom number of records below the suggested number (956 ms)
  ✓ generate with custom number of records above the suggested number (3306 ms)
  ✓ generate live mode CVRs (412 ms)
  ✓ generate test mode CVRs (384 ms)
  ✓ specifying scanner ids (2769 ms)
  ✓ including ballot images (1591 ms)
  ✓ generating as BMD ballots (non-gridlayouts election) (11839 ms)
  ✓ libs/fixtures are up to date - if this test fails run `pnpm generate-fixtures` (3035 ms)
```

It also speeds up the CLI by a large amount:

**BEFORE**

```
❯ NODE_ENV=test hyperfine './bin/generate -p ../fixtures/data/electionFamousNames2021/election.json -o /tmp/cvrs/'
Benchmark 1: ./bin/generate -p ../fixtures/data/electionFamousNames2021/election.json -o /tmp/cvrs/
  Time (mean ± σ):     27.392 s ±  1.873 s    [User: 46.503 s, System: 2.440 s]
  Range (min … max):   24.480 s … 30.289 s    10 runs
```

**AFTER**

```
❯ NODE_ENV=test hyperfine './bin/generate -p ../fixtures/data/electionFamousNames2021/election.json -o /tmp/cvrs/'
Benchmark 1: ./bin/generate -p ../fixtures/data/electionFamousNames2021/election.json -o /tmp/cvrs/
  Time (mean ± σ):     12.958 s ±  1.912 s    [User: 19.910 s, System: 1.791 s]
  Range (min … max):   10.184 s … 15.601 s    10 runs
```