### PR TITLE
VxScan: Improve handling of jam on ballot accept with PDI scanner

### DIFF
--- a/apps/scan/backend/src/scanners/pdi/pdi_app_scan_cover_open.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_scan_cover_open.test.ts
@@ -74,7 +74,10 @@ test('cover open while jammed', async () => {
         error: 'scanning_failed',
       });
       deferredEject.resolve(ok());
-      await waitForStatus(apiClient, { state: 'jammed' });
+      await waitForStatus(apiClient, {
+        state: 'jammed',
+        error: 'scanning_failed',
+      });
 
       mockScanner.setScannerStatus(mockStatus.jammedCoverOpen);
       mockScanner.emitEvent({ event: 'coverOpen' });

--- a/apps/scan/backend/src/types.ts
+++ b/apps/scan/backend/src/types.ts
@@ -29,6 +29,7 @@ export type PrecinctScannerErrorType =
   | 'scanning_failed'
   | 'both_sides_have_paper'
   | 'double_feed_detected'
+  | 'outfeed_blocked'
   | 'paper_in_back_after_accept'
   | 'paper_in_front_after_reconnect'
   | 'paper_in_back_after_reconnect'

--- a/apps/scan/frontend/src/screens/scan_error_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_error_screen.tsx
@@ -59,6 +59,9 @@ export function ScanErrorScreen({
         // These cases require restart, so we don't need to show an error
         // message, since that's handled below.
         return undefined;
+      case 'outfeed_blocked':
+        // Should only be shown in ScanJamScreen
+        throw new Error('Unexpected outfeed_blocked error');
       default:
         throwIllegalValue(error);
     }

--- a/apps/scan/frontend/src/screens/scan_jam_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_jam_screen.tsx
@@ -5,25 +5,35 @@ import {
   P,
   appStrings,
 } from '@votingworks/ui';
+import type { PrecinctScannerErrorType } from '@votingworks/scan-backend';
 import { Screen } from '../components/layout';
 import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout';
 
 interface Props {
+  error?: PrecinctScannerErrorType;
   scannedBallotCount: number;
 }
 
-export function ScanJamScreen({ scannedBallotCount }: Props): JSX.Element {
+export function ScanJamScreen({
+  error,
+  scannedBallotCount,
+}: Props): JSX.Element {
+  const isOutfeedBlocked = error === 'outfeed_blocked';
   return (
     <Screen centerContent ballotCountOverride={scannedBallotCount} voterFacing>
       <FullScreenPromptLayout
-        title={appStrings.titleScannerBallotNotCounted()}
+        title={
+          isOutfeedBlocked
+            ? appStrings.titleScannerOutfeedBlocked()
+            : appStrings.titleScannerBallotNotCounted()
+        }
         image={
           <FullScreenIconWrapper>
             <Icons.Delete color="danger" />
           </FullScreenIconWrapper>
         }
       >
-        <P>{appStrings.warningScannerJammed()}</P>
+        {!isOutfeedBlocked && <P>{appStrings.warningScannerJammed()}</P>}
         <Caption>{appStrings.instructionsAskForHelp()}</Caption>
       </FullScreenPromptLayout>
     </Screen>

--- a/apps/scan/frontend/src/screens/voter_screen.tsx
+++ b/apps/scan/frontend/src/screens/voter_screen.tsx
@@ -176,7 +176,10 @@ export function VoterScreen({
       );
     case 'jammed':
       return (
-        <ScanJamScreen scannedBallotCount={scannerStatus.ballotsCounted} />
+        <ScanJamScreen
+          error={scannerStatus.error}
+          scannedBallotCount={scannerStatus.ballotsCounted}
+        />
       );
     case 'double_sheet_jammed':
       return (

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -1317,6 +1317,12 @@ export const appStrings = {
     </UiString>
   ),
 
+  titleScannerOutfeedBlocked: () => (
+    <UiString uiStringKey="titleScannerOutfeedBlocked">
+      Ballot Box Opening is Blocked
+    </UiString>
+  ),
+
   titleScannerOvervoteWarning: () => (
     <UiString uiStringKey="titleScannerOvervoteWarning">
       Too many votes marked:

--- a/libs/ui/src/ui_strings/app_strings_catalog/latest.json
+++ b/libs/ui/src/ui_strings/app_strings_catalog/latest.json
@@ -385,6 +385,7 @@
   "titleScannerCvrSyncRequired": "CVR Sync Required",
   "titleScannerInsertBallotScreen": "Insert Your Ballot",
   "titleScannerNoVotesWarning": "No votes marked:",
+  "titleScannerOutfeedBlocked": "Ballot Box Opening is Blocked",
   "titleScannerOvervoteWarning": "Too many votes marked:",
   "titleScannerProcessingScreen": "Please wait…",
   "titleScannerSuccessScreen": "Your ballot was counted!",


### PR DESCRIPTION
## Overview
Fixes https://github.com/votingworks/vxsuite/issues/4956

Previously, if a ballot jammed during the accept command, we tried to reject it back out of the front. However, due to an unknown bug (likely a race condition), the scanner did not actually turn on the motor when it received the command to eject the ballot to the front. This caused the ballot to be recorded as rejected even though it remained in the back of the scanner (and could easily fall into the ballot box as it wasn't held by the rollers). This would result in a ballot in the ballot box that was not counted.

To ensure that a ballot in the box is always counted, we change the approach taken. Since the ballot in this case is already ejected enough from the rear of the scanner to fall into the ballot box, we always record it as accepted. Then, when we prepare to start waiting for a new ballot to be inserted, if the rear sensors are still covered (meaning the last ballot didn't fully make it into the ballot box), we declare a jam and show a message that the ballot box opening is obstructed (since this is likely to occur only when the ballot box is overfull).

## Demo Video or Screenshot
(note that the copy is changed from what you see in this video, "Ballot Box Opening Blocked," to "Ballot Box Opening is Blocked")
https://github.com/user-attachments/assets/9c562dda-7e3c-4b7d-9625-4a86b6325bbc

## Testing Plan
- Updated automated tests
- Manually tested by obstructing ballots on accept
## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
