### PR TITLE
VxScan: Accept ballots on backend after interpretation

### DIFF
--- a/apps/scan/backend/src/scanners/custom/custom_app_scan.test.ts
+++ b/apps/scan/backend/src/scanners/custom/custom_app_scan.test.ts
@@ -103,7 +103,7 @@ function checkLogs(logger: BaseLogger): void {
     {
       message: 'Context updated',
       changedFields: expect.stringMatching(
-        /{"interpretation":"(ValidSheet|InvalidSheet|NeedsReviewSheet)"}/
+        /{"interpretation":"(ValidSheet|InvalidSheet|NeedsReviewSheet)"/
       ),
     },
     expect.any(Function)
@@ -143,15 +143,10 @@ test('configure and scan hmpb', async () => {
       simulateScan(mockScanner, await ballotImages.completeHmpb(), clock);
       await waitForStatus(apiClient, { state: 'scanning' });
       await waitForStatus(apiClient, {
-        state: 'ready_to_accept',
-        interpretation,
-      });
-
-      await apiClient.acceptBallot();
-      await expectStatus(apiClient, {
         state: 'accepting',
         interpretation,
       });
+
       mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_NO_PAPER));
       clock.increment(delays.DELAY_PAPER_STATUS_POLLING_INTERVAL);
       await waitForStatus(apiClient, {
@@ -189,13 +184,8 @@ test('configure and scan bmd ballot', async () => {
 
       simulateScan(mockScanner, await ballotImages.completeBmd(), clock);
       await waitForStatus(apiClient, { state: 'scanning' });
+      clock.increment(delays.DELAY_PAPER_STATUS_POLLING_INTERVAL);
       await waitForStatus(apiClient, {
-        state: 'ready_to_accept',
-        interpretation,
-      });
-
-      await apiClient.acceptBallot();
-      await expectStatus(apiClient, {
         state: 'accepting',
         interpretation,
       });
@@ -597,7 +587,7 @@ test('scanning paused when election manager card is inserted', async () => {
       // now we can scan
       clock.increment(delays.DELAY_APP_READY_TO_SCAN_POLLING_INTERVAL);
       await waitForStatus(apiClient, {
-        state: 'ready_to_accept',
+        state: 'accepting',
         interpretation: {
           type: 'ValidSheet',
         },
@@ -646,7 +636,7 @@ test('scanning paused when poll worker card is inserted', async () => {
       // now we can scan
       clock.increment(delays.DELAY_APP_READY_TO_SCAN_POLLING_INTERVAL);
       await waitForStatus(apiClient, {
-        state: 'ready_to_accept',
+        state: 'accepting',
         interpretation: {
           type: 'ValidSheet',
         },
@@ -697,7 +687,7 @@ test('scanning paused when ballot bag needs replacement', async () => {
       // now we can scan
       clock.increment(delays.DELAY_APP_READY_TO_SCAN_POLLING_INTERVAL);
       await waitForStatus(apiClient, {
-        state: 'ready_to_accept',
+        state: 'accepting',
         interpretation: {
           type: 'ValidSheet',
         },

--- a/apps/scan/backend/src/scanners/custom/custom_app_scan_double_sheets.test.ts
+++ b/apps/scan/backend/src/scanners/custom/custom_app_scan_double_sheets.test.ts
@@ -73,12 +73,9 @@ test('insert second ballot before first ballot accept', async () => {
       mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
       clock.increment(delays.DELAY_PAPER_STATUS_POLLING_INTERVAL);
       await waitForStatus(apiClient, {
-        state: 'ready_to_accept',
+        state: 'accepting',
         interpretation,
       });
-
-      await apiClient.acceptBallot();
-      await waitForStatus(apiClient, { state: 'accepting', interpretation });
 
       mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_NO_PAPER));
       clock.increment(delays.DELAY_PAPER_STATUS_POLLING_INTERVAL_DURING_ACCEPT);
@@ -109,11 +106,9 @@ test('insert second ballot while first ballot is accepting', async () => {
       simulateScan(mockScanner, await ballotImages.completeBmd(), clock);
 
       await waitForStatus(apiClient, {
-        state: 'ready_to_accept',
+        state: 'accepting',
         interpretation,
       });
-      await apiClient.acceptBallot();
-      await waitForStatus(apiClient, { state: 'accepting', interpretation });
 
       mockScanner.getStatus.mockResolvedValue(
         ok(mocks.MOCK_BOTH_SIDES_HAVE_PAPER)

--- a/apps/scan/backend/src/scanners/custom/custom_app_scan_jam.test.ts
+++ b/apps/scan/backend/src/scanners/custom/custom_app_scan_jam.test.ts
@@ -82,12 +82,9 @@ test('jam on accept', async () => {
 
       simulateScan(mockScanner, await ballotImages.completeBmd(), clock);
       await waitForStatus(apiClient, {
-        state: 'ready_to_accept',
+        state: 'accepting',
         interpretation,
       });
-
-      await apiClient.acceptBallot();
-      await waitForStatus(apiClient, { state: 'accepting', interpretation });
       clock.increment(delays.DELAY_ACCEPTING_TIMEOUT);
       // The paper can't get permanently jammed on accept - it just stays held in
       // the back and we can reject at that point

--- a/apps/scan/backend/src/scanners/custom/custom_app_scan_power_off.test.ts
+++ b/apps/scan/backend/src/scanners/custom/custom_app_scan_power_off.test.ts
@@ -88,11 +88,11 @@ test('scanner powered off while accepting', async () => {
 
       simulateScan(mockScanner, await ballotImages.completeBmd(), clock);
       await waitForStatus(apiClient, {
-        state: 'ready_to_accept',
+        state: 'accepting',
         interpretation,
       });
       mockScanner.getStatus.mockResolvedValue(err(ErrorCode.ScannerOffline));
-      await apiClient.acceptBallot();
+      clock.increment(delays.DELAY_PAPER_STATUS_POLLING_INTERVAL);
       await waitForStatus(apiClient, { state: 'disconnected' });
 
       mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_EJECT));
@@ -120,11 +120,6 @@ test('scanner powered off after accepting', async () => {
       await configureApp(apiClient, mockAuth, mockUsbDrive, { testMode: true });
 
       simulateScan(mockScanner, await ballotImages.completeBmd(), clock);
-      await waitForStatus(apiClient, {
-        state: 'ready_to_accept',
-        interpretation,
-      });
-      await apiClient.acceptBallot();
       await waitForStatus(apiClient, {
         state: 'accepting',
         interpretation,

--- a/apps/scan/backend/src/scanners/custom/custom_app_scan_precinct_config.test.ts
+++ b/apps/scan/backend/src/scanners/custom/custom_app_scan_precinct_config.test.ts
@@ -86,7 +86,7 @@ test('bmd ballot is accepted if precinct is set for the right precinct', async (
       simulateScan(mockScanner, await ballotImages.completeBmd(), clock);
 
       await waitForStatus(apiClient, {
-        state: 'ready_to_accept',
+        state: 'accepting',
         interpretation: validInterpretation,
       });
     }

--- a/apps/scan/backend/src/scanners/custom/custom_app_scan_shoeshine_mode.test.ts
+++ b/apps/scan/backend/src/scanners/custom/custom_app_scan_shoeshine_mode.test.ts
@@ -12,7 +12,6 @@ import {
 import {
   configureApp,
   waitForStatus,
-  expectStatus,
 } from '../../../test/helpers/shared_helpers';
 import {
   ballotImages,
@@ -60,14 +59,8 @@ test('shoeshine mode scans the same ballot repeatedly', async () => {
       };
 
       simulateScan(mockScanner, await ballotImages.completeHmpb(), clock);
-      await waitForStatus(apiClient, {
-        state: 'ready_to_accept',
-        interpretation,
-      });
-
-      await apiClient.acceptBallot();
       const ballotsCounted = 1;
-      await expectStatus(apiClient, {
+      await waitForStatus(apiClient, {
         state: 'accepted',
         interpretation,
         ballotsCounted,
@@ -81,13 +74,6 @@ test('shoeshine mode scans the same ballot repeatedly', async () => {
       mockScanner.getStatus.mockResolvedValue(ok(mocks.MOCK_READY_TO_SCAN));
       simulateScan(mockScanner, await ballotImages.completeHmpb(), clock);
       await waitForStatus(apiClient, {
-        state: 'ready_to_accept',
-        interpretation,
-        ballotsCounted,
-      });
-
-      await apiClient.acceptBallot();
-      await expectStatus(apiClient, {
         state: 'accepted',
         interpretation,
         ballotsCounted: 2,

--- a/apps/scan/backend/src/scanners/custom/state_machine.ts
+++ b/apps/scan/backend/src/scanners/custom/state_machine.ts
@@ -908,14 +908,10 @@ function buildMachine({
         },
         ready_to_accept: {
           id: 'ready_to_accept',
-          invoke: pollPaperStatus(),
-          on: {
-            ACCEPT: [
-              { cond: isShoeshineModeEnabled, target: 'accepted' },
-              { target: 'accepting' },
-            ],
-            SCANNER_READY_TO_EJECT: doNothing,
-          },
+          always: [
+            { cond: isShoeshineModeEnabled, target: 'accepted' },
+            { target: 'accepting' },
+          ],
         },
         accepting: acceptingState,
         accepted: {
@@ -1281,7 +1277,6 @@ export function createPrecinctScannerStateMachine({
           case state.matches('interpreting'):
             return 'scanning';
           case state.matches('ready_to_accept'):
-            return 'ready_to_accept';
           case state.matches('accepting'):
             return 'accepting';
           case state.matches('accepted'):

--- a/apps/scan/backend/src/scanners/pdi/pdi_app_scan.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_scan.test.ts
@@ -73,12 +73,6 @@ test('configure and scan hmpb', async () => {
 
       const interpretation: SheetInterpretation = { type: 'ValidSheet' };
       await waitForStatus(apiClient, {
-        state: 'ready_to_accept',
-        interpretation,
-      });
-
-      await apiClient.acceptBallot();
-      await expectStatus(apiClient, {
         state: 'accepting',
         interpretation,
       });
@@ -153,12 +147,6 @@ test('configure and scan bmd ballot', async () => {
 
       const interpretation: SheetInterpretation = { type: 'ValidSheet' };
       await waitForStatus(apiClient, {
-        state: 'ready_to_accept',
-        interpretation,
-      });
-
-      await apiClient.acceptBallot();
-      await expectStatus(apiClient, {
         state: 'accepting',
         interpretation,
       });

--- a/apps/scan/backend/src/scanners/pdi/pdi_app_scan_double_sheet.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_scan_double_sheet.test.ts
@@ -66,11 +66,10 @@ test('insert second ballot after scan', async () => {
 
       const interpretation: SheetInterpretation = { type: 'ValidSheet' };
       await waitForStatus(apiClient, {
-        state: 'ready_to_accept',
+        state: 'accepting',
         interpretation,
       });
 
-      await apiClient.acceptBallot();
       mockScanner.emitEvent({ event: 'ejectPaused' });
       await waitForStatus(apiClient, {
         state: 'both_sides_have_paper',
@@ -114,12 +113,11 @@ test('insert second ballot before accept', async () => {
       );
       const interpretation: SheetInterpretation = { type: 'ValidSheet' };
       await waitForStatus(apiClient, {
-        state: 'ready_to_accept',
+        state: 'accepting',
         interpretation,
       });
 
       mockScanner.setScannerStatus(mockStatus.documentInFrontAndRear);
-      await apiClient.acceptBallot();
       mockScanner.emitEvent({ event: 'ejectPaused' });
       await waitForStatus(apiClient, {
         state: 'both_sides_have_paper',
@@ -155,12 +153,10 @@ test('insert second ballot during accept', async () => {
       );
       const interpretation: SheetInterpretation = { type: 'ValidSheet' };
       await waitForStatus(apiClient, {
-        state: 'ready_to_accept',
+        state: 'accepting',
         interpretation,
       });
 
-      await apiClient.acceptBallot();
-      await waitForStatus(apiClient, { state: 'accepting', interpretation });
       // Simulate that the first ballot was already ejected when the second
       // ballot is inserted
       mockScanner.setScannerStatus(mockStatus.documentInFront);
@@ -253,12 +249,11 @@ test('insert second ballot after accept, should be scanned', async () => {
       );
       const interpretation: SheetInterpretation = { type: 'ValidSheet' };
       await waitForStatus(apiClient, {
-        state: 'ready_to_accept',
+        state: 'accepting',
         interpretation,
       });
 
       mockScanner.client.enableScanning.mockClear();
-      await apiClient.acceptBallot();
       mockScanner.setScannerStatus(mockStatus.idleScanningDisabled);
       clock.increment(delays.DELAY_SCANNER_STATUS_POLLING_INTERVAL);
       const ballotsCounted = 1;
@@ -287,7 +282,7 @@ test('insert second ballot after accept, should be scanned', async () => {
         ballotsCounted
       );
       await waitForStatus(apiClient, {
-        state: 'ready_to_accept',
+        state: 'accepting',
         interpretation,
         ballotsCounted,
       });

--- a/apps/scan/backend/src/scanners/pdi/pdi_app_scan_jam.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_scan_jam.test.ts
@@ -93,17 +93,14 @@ test('jam while accepting', async () => {
       );
 
       const interpretation: SheetInterpretation = { type: 'ValidSheet' };
-      await waitForStatus(apiClient, {
-        state: 'ready_to_accept',
-        interpretation,
-      });
-
       const deferredAccept = deferred<Result<void, ScannerError>>();
       mockScanner.client.ejectDocument.mockReturnValueOnce(
         deferredAccept.promise
       );
-      await apiClient.acceptBallot();
-      await expectStatus(apiClient, { state: 'accepting', interpretation });
+      await waitForStatus(apiClient, {
+        state: 'accepting',
+        interpretation,
+      });
 
       mockScanner.setScannerStatus(mockStatus.jammed);
       deferredAccept.resolve(ok());
@@ -148,12 +145,9 @@ test('timeout while accepting', async () => {
 
       const interpretation: SheetInterpretation = { type: 'ValidSheet' };
       await waitForStatus(apiClient, {
-        state: 'ready_to_accept',
+        state: 'accepting',
         interpretation,
       });
-
-      await apiClient.acceptBallot();
-      await expectStatus(apiClient, { state: 'accepting', interpretation });
 
       clock.increment(delays.DELAY_ACCEPTING_TIMEOUT);
       await waitForStatus(apiClient, {

--- a/apps/scan/backend/src/scanners/pdi/pdi_app_scan_shoeshine_mode.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_scan_shoeshine_mode.test.ts
@@ -14,7 +14,6 @@ import {
 } from '../../../test/helpers/pdi_helpers';
 import {
   configureApp,
-  expectStatus,
   waitForStatus,
 } from '../../../test/helpers/shared_helpers';
 import { delays } from './state_machine';
@@ -62,14 +61,8 @@ test('shoeshine mode scans the same ballot repeatedly', async () => {
       );
 
       const interpretation: SheetInterpretation = { type: 'ValidSheet' };
-      await waitForStatus(apiClient, {
-        state: 'ready_to_accept',
-        interpretation,
-      });
-
-      await apiClient.acceptBallot();
       let ballotsCounted = 1;
-      await expectStatus(apiClient, {
+      await waitForStatus(apiClient, {
         state: 'accepted',
         interpretation,
         ballotsCounted,
@@ -91,15 +84,8 @@ test('shoeshine mode scans the same ballot repeatedly', async () => {
         await ballotImages.completeHmpb(),
         ballotsCounted
       );
-      await waitForStatus(apiClient, {
-        state: 'ready_to_accept',
-        interpretation,
-        ballotsCounted,
-      });
-
-      await apiClient.acceptBallot();
       ballotsCounted = 2;
-      await expectStatus(apiClient, {
+      await waitForStatus(apiClient, {
         state: 'accepted',
         interpretation,
         ballotsCounted,
@@ -126,14 +112,8 @@ test('handles error on eject for rescan', async () => {
       );
 
       const interpretation: SheetInterpretation = { type: 'ValidSheet' };
-      await waitForStatus(apiClient, {
-        state: 'ready_to_accept',
-        interpretation,
-      });
-
-      await apiClient.acceptBallot();
       const ballotsCounted = 1;
-      await expectStatus(apiClient, {
+      await waitForStatus(apiClient, {
         state: 'accepted',
         interpretation,
         ballotsCounted,

--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -695,12 +695,10 @@ function buildMachine({
         },
 
         readyToAccept: {
-          on: {
-            ACCEPT: [
-              { cond: isShoeshineModeEnabled, target: 'accepted' },
-              { target: 'accepting' },
-            ],
-          },
+          always: [
+            { cond: isShoeshineModeEnabled, target: 'accepted' },
+            { target: 'accepting' },
+          ],
         },
 
         accepting: acceptingState,
@@ -1087,7 +1085,7 @@ export function createPrecinctScannerStateMachine({
           case state.matches('interpreting'):
             return 'scanning';
           case state.matches('readyToAccept'):
-            return 'ready_to_accept';
+            return 'accepting';
           case state.matches('accepting.paperInFront'):
           case state.matches('acceptingAfterReview.paperInFront'):
             return 'both_sides_have_paper';

--- a/apps/scan/backend/test/helpers/custom_helpers.ts
+++ b/apps/scan/backend/test/helpers/custom_helpers.ts
@@ -270,7 +270,7 @@ export async function scanBallot(
     return ok(await ballotImages.completeBmd());
   });
   await waitForStatus(apiClient, {
-    state: 'ready_to_accept',
+    state: 'accepting',
     ballotsCounted: initialBallotsCounted,
     interpretation: { type: 'ValidSheet' },
   });

--- a/apps/scan/backend/test/helpers/pdi_helpers.ts
+++ b/apps/scan/backend/test/helpers/pdi_helpers.ts
@@ -339,12 +339,10 @@ export async function scanBallot(
     initialBallotsCounted
   );
   await waitForStatus(apiClient, {
-    state: 'ready_to_accept',
+    state: 'accepting',
     ballotsCounted: initialBallotsCounted,
     interpretation: { type: 'ValidSheet' },
   });
-
-  await apiClient.acceptBallot();
   expect(mockScanner.client.ejectDocument).toHaveBeenCalledWith('toRear');
   mockScanner.setScannerStatus(mockStatus.idleScanningDisabled);
   clock.increment(delays.DELAY_SCANNER_STATUS_POLLING_INTERVAL);

--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -322,8 +322,7 @@ async function scanBallot() {
   apiMock.expectGetScannerStatus(scannerStatus({ state: 'scanning' }));
   jest.advanceTimersByTime(POLLING_INTERVAL_FOR_SCANNER_STATUS_MS);
 
-  apiMock.expectGetScannerStatus(scannerStatus({ state: 'ready_to_accept' }));
-  apiMock.mockApiClient.acceptBallot.expectCallWith().resolves();
+  apiMock.expectGetScannerStatus(scannerStatus({ state: 'accepting' }));
   jest.advanceTimersByTime(POLLING_INTERVAL_FOR_SCANNER_STATUS_MS);
 
   apiMock.expectGetScannerStatus(scannerStatus({ state: 'accepted' }));

--- a/apps/scan/frontend/src/screens/voter_screen.tsx
+++ b/apps/scan/frontend/src/screens/voter_screen.tsx
@@ -1,7 +1,7 @@
 import { ElectionDefinition, SystemSettings } from '@votingworks/types';
 import { useQueryChangeListener } from '@votingworks/ui';
 import { assert, throwIllegalValue } from '@votingworks/basics';
-import { acceptBallot, getScannerStatus } from '../api';
+import { getScannerStatus } from '../api';
 import { POLLING_INTERVAL_FOR_SCANNER_STATUS_MS } from '../config/globals';
 import { useSound } from '../utils/use_sound';
 import { InsertBallotScreen } from './insert_ballot_screen';
@@ -31,18 +31,6 @@ export function VoterScreen({
 }: VoterScreenProps): JSX.Element | null {
   const scannerStatusQuery = getScannerStatus.useQuery({
     refetchInterval: POLLING_INTERVAL_FOR_SCANNER_STATUS_MS,
-  });
-
-  // The backend waits to receive a command accept a ballot. The frontend
-  // controls when this happens for now. In the future, we should move this to
-  // the backend.
-  const acceptBallotMutation = acceptBallot.useMutation();
-  useQueryChangeListener(scannerStatusQuery, {
-    onChange: (newScannerStatus) => {
-      if (newScannerStatus.state === 'ready_to_accept') {
-        acceptBallotMutation.mutate();
-      }
-    },
   });
 
   // Play sounds for scan result events
@@ -82,7 +70,6 @@ export function VoterScreen({
         case 'paused':
         case 'scanning':
         case 'returning_to_rescan':
-        case 'ready_to_accept':
         case 'accepting':
         case 'accepting_after_review':
         case 'returning':
@@ -140,7 +127,6 @@ export function VoterScreen({
       );
     case 'hardware_ready_to_scan':
     case 'scanning':
-    case 'ready_to_accept':
     case 'accepting':
     case 'returning_to_rescan':
       return <ScanProcessingScreen />;

--- a/libs/types/src/precinct_scanner.ts
+++ b/libs/types/src/precinct_scanner.ts
@@ -5,7 +5,6 @@ export const PRECINCT_SCANNER_STATES = [
   'hardware_ready_to_scan',
   'scanning',
   'returning_to_rescan',
-  'ready_to_accept',
   'accepting',
   'accepted',
   'needs_review',


### PR DESCRIPTION
## Overview

Closes #5162 

There's no need to wait for the frontend to send an accept command. Note that I chose to _not_ check auth status and whatnot before accepting. While we've had that guard in the past (by waiting for the frontend accept command), I figured that the time between starting the scan and accepting is so short that it seems reasonable to just rely on the check we already do before starting the scan.

## Demo Video or Screenshot
No change, just faster 😄 

## Testing Plan
- Updated automated tests
- Manually tested with each scanner

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
