### PR TITLE
VxScan: Fix erroneous jam error message after double sheet detected

### DIFF
--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -577,6 +577,12 @@ function buildMachine({
               on: {
                 SCANNER_EVENT: [
                   {
+                    cond: (context, { event }) =>
+                      event.event === 'scanComplete' &&
+                      context.error !== undefined,
+                    target: '#rejecting',
+                  },
+                  {
                     cond: (_, { event }) => event.event === 'scanComplete',
                     actions: assign({
                       scanImages: (_, { event }) => {
@@ -588,11 +594,12 @@ function buildMachine({
                   },
                 ],
                 SCANNER_ERROR: [
-                  // A doubleFeedDetected event will always be followed by a
-                  // scanFailed event (which indicates that the scan actually
-                  // stopped), so we don't transition states yet, just record
-                  // that it happened. Otherwise, we'd have a scanFailed event
-                  // come in later and be unhandled.
+                  // A doubleFeedDetected event will either be followed by a
+                  // scanFailed event or a scanComplete event (which both
+                  // indicate that the scan actually stopped), so we don't
+                  // transition states yet, just record that it happened.
+                  // Otherwise, we'd have a scanFailed/scanComplete event come
+                  // in later and be unhandled.
                   {
                     cond: (_, { error }) => error.code === 'doubleFeedDetected',
                     actions: assign({

--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -300,12 +300,12 @@ function buildMachine({
         on: {
           SCANNER_STATUS: [
             {
-              cond: (_, { status }) => status.documentJam,
-              target: '#jammed',
-            },
-            {
               cond: (_, { status }) => !anyRearSensorCovered(status),
               target: 'ejected',
+            },
+            {
+              cond: (_, { status }) => status.documentJam,
+              target: '#jammed',
             },
           ],
         },


### PR DESCRIPTION
## Overview

Fixes #5143 

Details in the commit messages

## Demo Video or Screenshot
Before

https://github.com/user-attachments/assets/1564047e-c214-44dc-a1f7-51f75b913401




After


https://github.com/user-attachments/assets/dd87a13a-9733-4c4d-b461-6b71d2999330


## Testing Plan
- Added regression test
- Manually tested

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
