### PR TITLE
remove extra log from connection status reader

### DIFF
--- a/apps/mark-scan/backend/src/pat-input/connection_status_reader.ts
+++ b/apps/mark-scan/backend/src/pat-input/connection_status_reader.ts
@@ -82,9 +82,6 @@ export class PatConnectionStatusReader
 
   async openBmd150(): Promise<boolean> {
     await this.logger.log(LogEventId.ConnectToPatInputInit, 'system');
-    await this.logger.log(LogEventId.ConnectToPatInputComplete, 'system', {
-      disposition: 'success',
-    });
     const path = join(this.workspacePath, FAI_100_STATUS_FILENAME);
     const openResult = await fsOpen(path);
     if (openResult.isErr()) {


### PR DESCRIPTION
## Overview

Removes an extra log from PAT connection status reader. The actual success log is further down the function: https://github.com/votingworks/vxsuite/pull/5223/files#diff-b2fba0b85584356803af01772a0ced8158c9b86b3a3fef9fc57aaabbc22c648fR97

## Demo Video or Screenshot
N/A

## Testing Plan
Logging change only
