### PR TITLE
[Mark] Reset state and provide poll worker escape hatches where relevant

### DIFF
--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -80,6 +80,8 @@ import {
   MOCK_IMAGE,
 } from '../../test/ballot_helpers';
 
+jest.setTimeout(500);
+
 // Use shorter polling interval in tests to reduce run times
 const TEST_POLL_INTERVAL_MS = 50;
 // Must be longer than backendWaitForInterval or tests can't
@@ -734,6 +736,10 @@ test('ending poll worker auth in accepting_paper returns to initial state', asyn
 });
 
 describe('poll_worker_auth_ended_unexpectedly', () => {
+  beforeEach(() => {
+    mockPollWorkerAuth(auth, electionGeneralDefinition);
+  });
+
   test('loading_paper state', async () => {
     machine.setAcceptingPaper();
     const ballotStyle = electionGeneralDefinition.election.ballotStyles[1];
@@ -874,6 +880,8 @@ test('reset() API', async () => {
 });
 
 test('insert and validate new blank sheet', async () => {
+  mockPollWorkerAuth(auth, electionGeneralDefinition);
+
   featureFlagMock.disableFeatureFlag(
     BooleanEnvironmentVariableName.MARK_SCAN_DISABLE_BALLOT_REINSERTION
   );
@@ -910,6 +918,8 @@ describe('insert pre-printed ballot', () => {
     featureFlagMock.disableFeatureFlag(
       BooleanEnvironmentVariableName.MARK_SCAN_DISABLE_BALLOT_REINSERTION
     );
+
+    mockPollWorkerAuth(auth, electionGeneralDefinition);
   });
 
   test('start session with valid pre-printed ballot', async () => {

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -80,8 +80,6 @@ import {
   MOCK_IMAGE,
 } from '../../test/ballot_helpers';
 
-jest.setTimeout(500);
-
 // Use shorter polling interval in tests to reduce run times
 const TEST_POLL_INTERVAL_MS = 50;
 // Must be longer than backendWaitForInterval or tests can't

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -544,6 +544,7 @@ export function buildMachine(
                   'loading_paper',
                 ],
                 AUTH_STATUS_CARDLESS_VOTER: 'resetting_state_machine_no_delay',
+                AUTH_STATUS_LOGGED_OUT: 'resetting_state_machine_no_delay',
               },
             },
             loading_paper: {
@@ -561,6 +562,7 @@ export function buildMachine(
                 // The poll worker pulled their card too early
                 AUTH_STATUS_CARDLESS_VOTER:
                   'poll_worker_auth_ended_unexpectedly',
+                AUTH_STATUS_LOGGED_OUT: 'resetting_state_machine_no_delay',
               },
             },
 
@@ -573,6 +575,7 @@ export function buildMachine(
                 // The poll worker pulled their card too early
                 AUTH_STATUS_CARDLESS_VOTER:
                   'poll_worker_auth_ended_unexpectedly',
+                AUTH_STATUS_LOGGED_OUT: 'resetting_state_machine_no_delay',
               },
             },
             validating_new_sheet: {
@@ -600,6 +603,7 @@ export function buildMachine(
                 // The poll worker pulled their card too early
                 AUTH_STATUS_CARDLESS_VOTER:
                   'poll_worker_auth_ended_unexpectedly',
+                AUTH_STATUS_LOGGED_OUT: 'resetting_state_machine_no_delay',
               },
               onDone: [
                 {
@@ -623,6 +627,7 @@ export function buildMachine(
                 // The poll worker pulled their card too early
                 AUTH_STATUS_CARDLESS_VOTER:
                   'poll_worker_auth_ended_unexpectedly',
+                AUTH_STATUS_LOGGED_OUT: 'resetting_state_machine_no_delay',
                 START_SESSION_WITH_PREPRINTED_BALLOT: 'presenting_ballot',
                 RETURN_PREPRINTED_BALLOT: {
                   actions: [
@@ -642,6 +647,7 @@ export function buildMachine(
                 // The poll worker pulled their card too early
                 AUTH_STATUS_CARDLESS_VOTER:
                   'poll_worker_auth_ended_unexpectedly',
+                AUTH_STATUS_LOGGED_OUT: 'resetting_state_machine_no_delay',
               },
             },
 
@@ -649,6 +655,7 @@ export function buildMachine(
               invoke: pollAuthStatus(),
               on: {
                 AUTH_STATUS_CARDLESS_VOTER: 'waiting_for_ballot_data',
+                AUTH_STATUS_LOGGED_OUT: 'resetting_state_machine_no_delay',
               },
             },
 

--- a/apps/mark-scan/frontend/src/app_cardless_voting.test.tsx
+++ b/apps/mark-scan/frontend/src/app_cardless_voting.test.tsx
@@ -79,6 +79,7 @@ test('Cardless Voting Flow', async () => {
   screen.getByText(/(12)/);
 
   await screen.findByText('Load Ballot Sheet');
+  screen.getButton('Start a New Voting Session');
   mockLoadPaper();
 
   // Poll Worker deactivates ballot style

--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -190,7 +190,6 @@ export function AppRoot(): JSX.Element | null {
   const startCardlessVoterSessionMutate =
     startCardlessVoterSessionMutation.mutate;
   const endCardlessVoterSessionMutation = endCardlessVoterSession.useMutation();
-  const endCardlessVoterSessionMutate = endCardlessVoterSessionMutation.mutate;
   const endCardlessVoterSessionMutateAsync =
     endCardlessVoterSessionMutation.mutateAsync;
   const unconfigureMachineMutation = unconfigureMachine.useMutation();
@@ -296,15 +295,6 @@ export function AppRoot(): JSX.Element | null {
     },
     [authStatus, resetBallot, startCardlessVoterSessionMutate]
   );
-
-  const resetCardlessBallot = useCallback(() => {
-    assert(isPollWorkerAuth(authStatus));
-    endCardlessVoterSessionMutate(undefined, {
-      onSuccess() {
-        history.push('/');
-      },
-    });
-  }, [authStatus, endCardlessVoterSessionMutate, history]);
 
   useEffect(() => {
     function resetBallotOnLogout() {
@@ -516,7 +506,6 @@ export function AppRoot(): JSX.Element | null {
         <PollWorkerScreen
           pollWorkerAuth={authStatus}
           activateCardlessVoterSession={activateCardlessBallot}
-          resetCardlessVoterSession={resetCardlessBallot}
           electionDefinition={electionDefinition}
           electionPackageHash={assertDefined(electionPackageHash)}
           isLiveMode={!isTestMode}

--- a/apps/mark-scan/frontend/src/components/deactivate_voter_session_button.test.tsx
+++ b/apps/mark-scan/frontend/src/components/deactivate_voter_session_button.test.tsx
@@ -1,0 +1,58 @@
+import userEvent from '@testing-library/user-event';
+import { mockOf } from '@votingworks/test-utils';
+import { render, screen } from '../../test/react_testing_library';
+import {
+  ResetVoterSessionButton,
+  ResetVoterSessionButtonProps,
+} from './deactivate_voter_session_button';
+import * as api from '../api';
+
+jest.mock('../api');
+
+function renderButton(
+  button: JSX.Element,
+  options: {
+    buttonProps?: ResetVoterSessionButtonProps;
+    isMutationInProgress: boolean;
+  }
+) {
+  const { isMutationInProgress } = options;
+  const mockMutate = jest.fn();
+
+  mockOf(api.endCardlessVoterSession.useMutation).mockReturnValue({
+    mutate: mockMutate,
+    isLoading: isMutationInProgress,
+  } as unknown as ReturnType<typeof api.endCardlessVoterSession.useMutation>);
+
+  return {
+    mockMutate,
+    result: render(button),
+  };
+}
+
+test('calls reset API on press', () => {
+  const { mockMutate } = renderButton(<ResetVoterSessionButton />, {
+    isMutationInProgress: false,
+  });
+  expect(mockMutate).not.toHaveBeenCalled();
+
+  userEvent.click(screen.getButton(/deactivate/i));
+  expect(mockMutate).toHaveBeenCalled();
+});
+
+test('is disabled while mutation is progress', () => {
+  renderButton(<ResetVoterSessionButton />, { isMutationInProgress: true });
+  expect(screen.getButton(/deactivate/i)).toBeDisabled();
+});
+
+test('is customizable', () => {
+  renderButton(
+    <ResetVoterSessionButton icon="Previous" variant="primary">
+      Start Over
+    </ResetVoterSessionButton>,
+    { isMutationInProgress: false }
+  );
+
+  screen.getButton('Start Over');
+  // TODO: Verify color/icon.
+});

--- a/apps/mark-scan/frontend/src/components/deactivate_voter_session_button.tsx
+++ b/apps/mark-scan/frontend/src/components/deactivate_voter_session_button.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import { Button, ButtonProps } from '@votingworks/ui';
+
+import * as api from '../api';
+
+interface Props {
+  /** @default 'Deactivate Voting Session' */
+  children?: React.ReactNode;
+
+  /** @default 'Delete' */
+  icon?: ButtonProps['icon'];
+
+  /** @default 'danger' */
+  variant?: ButtonProps['variant'];
+}
+export type { Props as ResetVoterSessionButtonProps };
+
+export function ResetVoterSessionButton(props: Props): React.ReactNode {
+  const {
+    children = 'Deactivate Voting Session',
+    icon = 'Delete',
+    variant = 'danger',
+  } = props;
+
+  const endSessionMutation = api.endCardlessVoterSession.useMutation();
+
+  return (
+    <Button
+      disabled={endSessionMutation.isLoading}
+      icon={icon}
+      variant={variant}
+      onPress={endSessionMutation.mutate}
+    >
+      {children}
+    </Button>
+  );
+}

--- a/apps/mark-scan/frontend/src/hooks/use_is_voter_auth.test.ts
+++ b/apps/mark-scan/frontend/src/hooks/use_is_voter_auth.test.ts
@@ -1,0 +1,43 @@
+import { renderHook } from '@testing-library/react';
+import { electionGeneralDefinition } from '@votingworks/fixtures';
+import { advancePromises } from '@votingworks/test-utils';
+import { useIsVoterAuth } from './use_is_voter_auth';
+import {
+  ApiMock,
+  createApiMock,
+  provideApi,
+} from '../../test/helpers/mock_api_client';
+
+let apiMock: ApiMock;
+
+beforeEach(() => {
+  apiMock = createApiMock();
+});
+
+afterEach(() => {
+  apiMock.mockApiClient.assertComplete();
+});
+
+test('with voter auth', async () => {
+  apiMock.setAuthStatusCardlessVoterLoggedInWithDefaults(
+    electionGeneralDefinition
+  );
+
+  const { result } = renderHook(useIsVoterAuth, {
+    wrapper: ({ children }) => provideApi(apiMock, children),
+  });
+  await advancePromises();
+
+  expect(result.current).toEqual(true);
+});
+
+test('with non-voter auth', async () => {
+  apiMock.setAuthStatusPollWorkerLoggedIn(electionGeneralDefinition);
+
+  const { result } = renderHook(useIsVoterAuth, {
+    wrapper: ({ children }) => provideApi(apiMock, children),
+  });
+  await advancePromises();
+
+  expect(result.current).toEqual(false);
+});

--- a/apps/mark-scan/frontend/src/hooks/use_is_voter_auth.ts
+++ b/apps/mark-scan/frontend/src/hooks/use_is_voter_auth.ts
@@ -1,0 +1,8 @@
+import { isCardlessVoterAuth } from '@votingworks/utils';
+
+import * as api from '../api';
+
+export function useIsVoterAuth(): boolean {
+  const authStatusQuery = api.getAuthStatus.useQuery();
+  return authStatusQuery.isSuccess && isCardlessVoterAuth(authStatusQuery.data);
+}

--- a/apps/mark-scan/frontend/src/pages/ballot_ready_for_review_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/ballot_ready_for_review_screen.test.tsx
@@ -1,19 +1,20 @@
-import userEvent from '@testing-library/user-event';
 import { render, screen } from '../../test/react_testing_library';
 import { BallotReadyForReviewScreen } from './ballot_ready_for_review_screen';
+import { ResetVoterSessionButton } from '../components/deactivate_voter_session_button';
+
+jest.mock('../components/deactivate_voter_session_button');
 
 test('renders instructions', () => {
-  render(<BallotReadyForReviewScreen resetCardlessVoterSession={jest.fn()} />);
+  render(<BallotReadyForReviewScreen />);
   screen.getByText(/remove the poll worker card/i);
 });
 
 test('allows voter session deactivation', () => {
-  const mockReset = jest.fn();
+  jest
+    .mocked(ResetVoterSessionButton)
+    .mockImplementation(() => <div data-testid="MockResetSessionButton" />);
 
-  render(<BallotReadyForReviewScreen resetCardlessVoterSession={mockReset} />);
+  render(<BallotReadyForReviewScreen />);
 
-  expect(mockReset).not.toHaveBeenCalled();
-
-  userEvent.click(screen.getButton(/deactivate/i));
-  expect(mockReset).toHaveBeenCalled();
+  screen.getByTestId('MockResetSessionButton');
 });

--- a/apps/mark-scan/frontend/src/pages/ballot_ready_for_review_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/ballot_ready_for_review_screen.tsx
@@ -1,23 +1,12 @@
-import { Button, Icons, P } from '@votingworks/ui';
+import { Icons, P } from '@votingworks/ui';
 
 import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { ResetVoterSessionButton } from '../components/deactivate_voter_session_button';
 
-export interface BallotReadyForReviewScreenProps {
-  resetCardlessVoterSession: () => void;
-}
-
-export function BallotReadyForReviewScreen(
-  props: BallotReadyForReviewScreenProps
-): JSX.Element {
-  const { resetCardlessVoterSession } = props;
-
+export function BallotReadyForReviewScreen(): JSX.Element {
   return (
     <CenteredCardPageLayout
-      buttons={
-        <Button onPress={resetCardlessVoterSession} variant="danger">
-          Deactivate Voting Session
-        </Button>
-      }
+      buttons={<ResetVoterSessionButton />}
       icon={<Icons.Done color="success" />}
       title="Remove Poll Worker Card"
       voterFacing={false}

--- a/apps/mark-scan/frontend/src/pages/load_paper_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/load_paper_page.tsx
@@ -1,5 +1,6 @@
-import { Icons, P } from '@votingworks/ui';
+import { Caption, Icons, P } from '@votingworks/ui';
 import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { ResetVoterSessionButton } from '../components/deactivate_voter_session_button';
 
 export function LoadPaperPage(): JSX.Element {
   return (
@@ -7,8 +8,17 @@ export function LoadPaperPage(): JSX.Element {
       icon={<Icons.Info />}
       title="Load Ballot Sheet"
       voterFacing={false}
+      buttons={
+        <ResetVoterSessionButton icon="Previous" variant="neutral">
+          Start a New Voting Session
+        </ResetVoterSessionButton>
+      }
     >
       <P>Please feed one sheet of paper into the front input tray.</P>
+      <Caption>
+        <Icons.Info /> If you would like to return to the previous screen and
+        start a new session, press the button below.
+      </Caption>
     </CenteredCardPageLayout>
   );
 }

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.test.tsx
@@ -93,7 +93,6 @@ function renderScreen(
       <PollWorkerScreen
         pollWorkerAuth={pollWorkerAuth}
         activateCardlessVoterSession={jest.fn()}
-        resetCardlessVoterSession={jest.fn()}
         electionDefinition={electionDefinition}
         electionPackageHash="test-election-package-hash"
         hasVotes={false}

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
@@ -65,6 +65,7 @@ import {
   BallotReinsertionFlow,
   isBallotReinsertionState,
 } from '../ballot_reinsertion_flow';
+import { ResetVoterSessionButton } from '../components/deactivate_voter_session_button';
 
 function isBallotReinsertionEnabled() {
   return !isFeatureFlagEnabled(
@@ -157,7 +158,6 @@ export interface PollworkerScreenProps {
     precinctId: PrecinctId,
     ballotStyleId: BallotStyleId
   ) => void;
-  resetCardlessVoterSession: () => void;
   electionDefinition: ElectionDefinition;
   electionPackageHash: string;
   hasVotes: boolean;
@@ -172,7 +172,6 @@ export interface PollworkerScreenProps {
 export function PollWorkerScreen({
   pollWorkerAuth,
   activateCardlessVoterSession,
-  resetCardlessVoterSession,
   electionDefinition,
   electionPackageHash,
   isLiveMode,
@@ -272,11 +271,7 @@ export function PollWorkerScreen({
   }
 
   if (stateMachineState === 'presenting_ballot') {
-    return (
-      <BallotReadyForReviewScreen
-        resetCardlessVoterSession={resetCardlessVoterSession}
-      />
-    );
+    return <BallotReadyForReviewScreen />;
   }
 
   if (
@@ -300,13 +295,7 @@ export function PollWorkerScreen({
               Remove card to allow voter to continue voting, or reset ballot.
             </P>
             <P>
-              <Button
-                variant="danger"
-                icon="Delete"
-                onPress={resetCardlessVoterSession}
-              >
-                Reset Ballot
-              </Button>
+              <ResetVoterSessionButton>Reset Ballot</ResetVoterSessionButton>
             </P>
           </Text>
         </Main>
@@ -324,11 +313,7 @@ export function PollWorkerScreen({
     ) {
       return (
         <CenteredCardPageLayout
-          buttons={
-            <Button onPress={resetCardlessVoterSession}>
-              Deactivate Voting Session
-            </Button>
-          }
+          buttons={<ResetVoterSessionButton />}
           icon={<Icons.Done color="success" />}
           title="Voting Session Active:"
           voterFacing={false}

--- a/apps/mark-scan/frontend/src/pages/remove_jammed_sheet_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/remove_jammed_sheet_screen.tsx
@@ -1,7 +1,8 @@
 /* istanbul ignore file - trivial presentational component. */
 
-import { Icons, P } from '@votingworks/ui';
+import { Caption, Icons, P } from '@votingworks/ui';
 import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { ResetVoterSessionButton } from '../components/deactivate_voter_session_button';
 
 export function RemoveJammedSheetScreen(): JSX.Element {
   return (
@@ -9,11 +10,16 @@ export function RemoveJammedSheetScreen(): JSX.Element {
       icon={<Icons.Warning color="warning" />}
       title="Paper is Jammed"
       voterFacing={false}
+      buttons={<ResetVoterSessionButton />}
     >
       <P>
         Please remove the jammed sheet, opening the printer cover or ballot box
         if necessary.
       </P>
+      <Caption>
+        <Icons.Info /> To end the current voter session and start over, press
+        the button below to deactivate the voter session.
+      </Caption>
     </CenteredCardPageLayout>
   );
 }

--- a/apps/mark-scan/frontend/src/pages/waiting_for_ballot_reinsertion_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/waiting_for_ballot_reinsertion_screen.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '../../test/react_testing_library';
+import { ResetVoterSessionButton } from '../components/deactivate_voter_session_button';
+import { useIsVoterAuth } from '../hooks/use_is_voter_auth';
+import { WaitingForBallotReinsertionBallotScreen } from './waiting_for_ballot_reinsertion_screen';
+
+jest.mock('../api');
+jest.mock('../hooks/use_is_voter_auth');
+jest.mock('../components/deactivate_voter_session_button');
+
+const mockUseIsVoterAuth = jest.mocked(useIsVoterAuth);
+
+const MOCK_REST_SESSION_BUTTON_TEST_ID = 'MockResetSessionButton';
+
+beforeEach(() => {
+  jest
+    .mocked(ResetVoterSessionButton)
+    .mockImplementation(() => (
+      <div data-testid={MOCK_REST_SESSION_BUTTON_TEST_ID} />
+    ));
+});
+
+test('with voter auth', () => {
+  mockUseIsVoterAuth.mockReturnValue(true);
+
+  render(<WaitingForBallotReinsertionBallotScreen />);
+
+  screen.getByText(/ballot removed/i);
+  expect(
+    screen.queryByTestId(MOCK_REST_SESSION_BUTTON_TEST_ID)
+  ).not.toBeInTheDocument();
+});
+
+test('with non-voter auth', () => {
+  mockUseIsVoterAuth.mockReturnValue(false);
+
+  render(<WaitingForBallotReinsertionBallotScreen />);
+
+  screen.getByText(/ballot removed/i);
+  screen.getByTestId(MOCK_REST_SESSION_BUTTON_TEST_ID);
+});

--- a/apps/mark-scan/frontend/src/pages/waiting_for_ballot_reinsertion_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/waiting_for_ballot_reinsertion_screen.tsx
@@ -1,13 +1,18 @@
 import { appStrings, Caption, Icons, P } from '@votingworks/ui';
 
 import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { useIsVoterAuth } from '../hooks/use_is_voter_auth';
+import { ResetVoterSessionButton } from '../components/deactivate_voter_session_button';
 
 export function WaitingForBallotReinsertionBallotScreen(): JSX.Element {
+  const isVoterAuth = useIsVoterAuth();
+
   return (
     <CenteredCardPageLayout
       icon={<Icons.Warning color="warning" />}
       title={appStrings.titleBmdBallotRemovedScreen()}
-      voterFacing
+      voterFacing={isVoterAuth}
+      buttons={isVoterAuth ? undefined : <ResetVoterSessionButton />}
     >
       <P>{appStrings.warningBmdBallotRemoved()}</P>
       <P>{appStrings.instructionsBmdReinsertBallot()}</P>

--- a/apps/mark-scan/frontend/src/voter_flow.test.tsx
+++ b/apps/mark-scan/frontend/src/voter_flow.test.tsx
@@ -55,6 +55,18 @@ jest.mock(
   })
 );
 
+const MOCK_WAITING_FOR_REINSERTION_SCREEN_CONTENTS =
+  'MockWaitingForReinsertionScreen';
+jest.mock(
+  './pages/waiting_for_ballot_reinsertion_screen',
+  (): typeof import('./pages/waiting_for_ballot_reinsertion_screen') => ({
+    ...jest.requireActual('./pages/waiting_for_ballot_reinsertion_screen'),
+    WaitingForBallotReinsertionBallotScreen: () => (
+      <div>{MOCK_WAITING_FOR_REINSERTION_SCREEN_CONTENTS}</div>
+    ),
+  })
+);
+
 const mockApi = createApiMock();
 
 function TestContext(props: React.PropsWithChildren) {
@@ -158,7 +170,8 @@ describe('ballot removal/re-insertion', () => {
   const ballotReinsertionStateScreenContents: Partial<
     Record<SimpleServerStatus, string | RegExp>
   > = {
-    waiting_for_ballot_reinsertion: /ballot removed/i,
+    waiting_for_ballot_reinsertion:
+      MOCK_WAITING_FOR_REINSERTION_SCREEN_CONTENTS,
     loading_reinserted_ballot: /loading your ballot/i,
     validating_reinserted_ballot: /loading your ballot/i,
     reinserted_invalid_ballot: MOCK_INVALID_BALLOT_SCREEN_CONTENTS,


### PR DESCRIPTION
## Overview

Fixes https://github.com/votingworks/vxsuite/issues/5207

Adding a button to reset the voter session to relevant screens whenever a Poll Worker is logged in, to prevent the UI from getting stuck in certain states with no way to start over except waiting for the session timer to expire.

## Demo Video or Screenshot [ 🔇 ]

### Ballot Re-Insertion Flow (voter-facing, with poll worker intervention):

https://github.com/user-attachments/assets/ca7c4e4e-1d95-47d6-a43a-3a035ff2e2f1

### New Sheet Insertion Flows (poll-worker-facing):

https://github.com/user-attachments/assets/b753696a-8644-48ae-a9e0-67f5a90185f1

## Testing Plan
- Added/updated unit tests
- Manual verification runs

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
