### PR TITLE
VxScan: Don't error if ballot removed but scan completes

### DIFF
--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -642,21 +642,12 @@ function buildMachine({
                     cond: (_, { status }) => status.documentJam,
                     target: '#rejecting',
                   },
-                  // This guard was put in during initial development to prevent
-                  // against cases where the scanner fails to grab the ballot.
-                  // Currently, those cases seem to be yielding a `scanFailed`
-                  // event, so we aren't hitting this guard. Nevertheless, it
-                  // seems like a good backup, so leaving it here.
+                  // If you pull the ballot out before it can be fully scanned,
+                  // we either get a scanFailed event (handled above) or a
+                  // scanComplete event but documentInScanner=false.
                   {
                     cond: (_, { status }) => !status.documentInScanner,
-                    target: '#error',
-                    /* c8 ignore start */
-                    actions: assign({
-                      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                      error: (_context) =>
-                        new PrecinctScannerError('scanning_failed'),
-                    }),
-                    /* c8 ignore stop */
+                    target: '#waitingForBallot',
                   },
                   { target: '#interpreting' },
                 ],


### PR DESCRIPTION


## Overview

Fixes https://github.com/votingworks/vxsuite/issues/5142

Previously, if there was no ballot in the scanner after a scan completed, we would declare an error and try to disconnect/reconnect to the scanner, since this seemed like an impossible case. It turns out you can produce this case by pulling the ballot out soon after the scan begins. Sometimes this will result in a failed scan, but other times the scan will complete even though the ballot is gone. Since we're confident in that case that there's no ballot in the scanner, we can abandon the scan and wait for a new ballot to be inserted. This is an improvement because we don't have to spend time disconnecting/reconnecting (and we have seen at least sometimes that disconnecting and reconnecting fails, which then requires a restart of the entire app).
## Demo Video or Screenshot
No visible change to UX

## Testing Plan
- Added regression test
- Manual tested

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
