### PR TITLE
Fix VxMark paper handler diagnostic in prod

### DIFF
--- a/apps/mark-scan/frontend/Makefile
+++ b/apps/mark-scan/frontend/Makefile
@@ -17,7 +17,10 @@ run-all:
 	(trap 'kill 0' SIGINT SIGHUP; make -C $(BACKEND) run & cd prodserver && node index.js)
 
 build: FORCE
-	pnpm install && pnpm --dir ../../../libs/ballot-interpreter build && pnpm build
+	pnpm install && \
+		pnpm --dir ../../../libs/ballot-interpreter build && \
+		pnpm --dir ../backend build && \
+		pnpm build
 
 bootstrap: install build
 


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/5176

Very similar to https://github.com/votingworks/vxsuite/pull/5066, this PR _should_ fix the currently crashing VxMark paper handler diagnostic in prod by making sure that we run `pnpm build` in `apps/mark-scan/backend` as part of `make build` in `apps/mark-scan/frontend`. As a reminder, during the build process, we run `make build` in every frontend.

The `pnpm build` in `apps/mark-scan/backend` includes a command to copy over static files to the `build` directory, namely `custom-paper-handler/diagnostic/election.json`, which we need for the diagnostic. I believe the lack of that file in the `apps/mark-scan/backend/build` directory explains the crashing.

## Testing Plan

Adam tested this fix for me on a VxAustin prod VxMark :tada: