### PR TITLE
Fix bug that obscured BMD ballot test/official ballot mode errors

### DIFF
--- a/apps/design/backend/src/language_and_audio/translation_overrides.ts
+++ b/apps/design/backend/src/language_and_audio/translation_overrides.ts
@@ -289,8 +289,6 @@ export const GLOBAL_TRANSLATION_OVERRIDES: TranslationOverrides = {
       'No se contarán votos de esta votación.',
     'The ballot is jammed in the scanner.':
       'La boleta está atascada en el escáner.',
-    'The scanner is in test mode and a live ballot was detected.':
-      'El escáner está en modo de prueba y en vivo. se detectó la boleta.',
     'The ballot does not match the election this scanner is configured for.':
       'La boleta no coincide con la elección de este está configurado el escáner.',
     'The ballot does not match the precinct this scanner is configured for.':
@@ -298,8 +296,6 @@ export const GLOBAL_TRANSLATION_OVERRIDES: TranslationOverrides = {
     'Multiple sheets detected.': 'Se detectaron varias hojas.',
     'No votes were found when scanning this ballot.':
       'No se encontraron votos al escanear esto votación.',
-    'The scanner is in live mode and a test ballot was detected.':
-      'El escáner está en modo en vivo y se detectó una boleta.',
     'Sample Absentee Ballot': 'Modelo de boleta de voto ausente',
   },
 };

--- a/apps/scan/frontend/src/screens/scan_error_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/scan_error_screen.test.tsx
@@ -33,7 +33,7 @@ test('render correct test ballot error screen when we are in test mode', async (
   );
   await screen.findByText('Ballot Not Counted');
   await screen.findByText(
-    'The scanner is in test mode and a live ballot was detected.'
+    'The scanner is in test ballot mode. Official ballots may not be scanned.'
   );
 });
 
@@ -50,7 +50,7 @@ test('render correct test ballot error screen when we are in live mode', async (
   );
   await screen.findByText('Ballot Not Counted');
   await screen.findByText(
-    'The scanner is in live mode and a test ballot was detected.'
+    'The scanner is in official ballot mode. Test ballots may not be scanned.'
   );
 });
 

--- a/apps/scan/frontend/src/screens/scan_error_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_error_screen.tsx
@@ -32,8 +32,8 @@ export function ScanErrorScreen({
       // Invalid ballot interpretations
       case 'invalid_test_mode':
         return isTestMode
-          ? appStrings.warningScannerLiveBallotInTestMode()
-          : appStrings.warningScannerTestBallotInLiveMode();
+          ? appStrings.warningScannerOfficialBallotInTestMode()
+          : appStrings.warningScannerTestBallotInOfficialMode();
       case 'invalid_ballot_hash':
         return appStrings.warningScannerMismatchedElection();
       case 'invalid_precinct':

--- a/libs/ballot-interpreter/src/interpret.ts
+++ b/libs/ballot-interpreter/src/interpret.ts
@@ -723,7 +723,7 @@ function scoreInterpretFileResult(
     return 0;
   }
 
-  if (frontType === 'BlankPage' || backType === 'BlankPage') {
+  if (frontType === 'BlankPage' && backType === 'BlankPage') {
     return -100;
   }
 

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -1470,9 +1470,9 @@ export const appStrings = {
     </UiString>
   ),
 
-  warningScannerLiveBallotInTestMode: () => (
-    <UiString uiStringKey="warningScannerLiveBallotInTestMode">
-      The scanner is in test mode and a live ballot was detected.
+  warningScannerOfficialBallotInTestMode: () => (
+    <UiString uiStringKey="warningScannerOfficialBallotInTestMode">
+      The scanner is in test ballot mode. Official ballots may not be scanned.
     </UiString>
   ),
 
@@ -1500,9 +1500,9 @@ export const appStrings = {
     </UiString>
   ),
 
-  warningScannerTestBallotInLiveMode: () => (
-    <UiString uiStringKey="warningScannerTestBallotInLiveMode">
-      The scanner is in live mode and a test ballot was detected.
+  warningScannerTestBallotInOfficialMode: () => (
+    <UiString uiStringKey="warningScannerTestBallotInOfficialMode">
+      The scanner is in official ballot mode. Test ballots may not be scanned.
     </UiString>
   ),
 } as const;

--- a/libs/ui/src/ui_strings/app_strings_catalog/latest.json
+++ b/libs/ui/src/ui_strings/app_strings_catalog/latest.json
@@ -414,10 +414,10 @@
   "warningScannerAnotherScanInProgress": "Another ballot is being scanned.",
   "warningScannerBlankBallotSubmission": "No votes will be counted from this ballot.",
   "warningScannerJammed": "The ballot is jammed in the scanner.",
-  "warningScannerLiveBallotInTestMode": "The scanner is in test mode and a live ballot was detected.",
   "warningScannerMismatchedElection": "The ballot does not match the election this scanner is configured for.",
   "warningScannerMismatchedPrecinct": "The ballot does not match the precinct this scanner is configured for.",
   "warningScannerMultipleSheetsDetected": "Multiple sheets detected.",
   "warningScannerNoVotesFound": "No votes were found when scanning this ballot.",
-  "warningScannerTestBallotInLiveMode": "The scanner is in live mode and a test ballot was detected."
+  "warningScannerOfficialBallotInTestMode": "The scanner is in test ballot mode. Official ballots may not be scanned.",
+  "warningScannerTestBallotInOfficialMode": "The scanner is in official ballot mode. Test ballots may not be scanned."
 }


### PR DESCRIPTION
## Overview

Fixes https://github.com/votingworks/vxsuite/issues/5157

When scanning a test BMD ballot in official mode (or vice versa), we were getting a generic unreadable ballot error. The HMPB unreadable error was taking precedence since the logic deprioritized any interpretation with at least one blank page. Since there's always one blank page in a BMD ballot, all errors from BMD ballots were deprioritized. The fix is to only deprioritize ballots that are blank on both sides.

I also updated the error message to use "official ballot mode" instead of "live mode."

## Demo Video or Screenshot
![Screenshot-VxScan-2024-08-07T18:01:09 108Z](https://github.com/user-attachments/assets/4cf03e92-b207-41da-8af9-ef1fb738dc98)
![Screenshot-VxScan-2024-08-07T18:04:22 231Z](https://github.com/user-attachments/assets/d485c980-61e4-422e-830a-7a113d1c8152)


## Testing Plan
Manual test and updated automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
