### PR TITLE
Revert iter changes on copy sheets script

### DIFF
--- a/apps/scan/backend/scripts/copy_sheets.ts
+++ b/apps/scan/backend/scripts/copy_sheets.ts
@@ -87,12 +87,16 @@ function copySheets({ targetSheetCount }: CopySheetsInput): void {
     500 // A cap to limit how much data the script loads
   );
 
-  const newSheetIds = iter(store.forEachAcceptedSheet())
+  const sheets = iter(store.forEachAcceptedSheet())
     .take(maxNumSheetsToReadForCopying)
-    .cycle()
-    .take(numSheetsToCreate)
-    .map((sheet) => copySheet(store, sheet))
     .toArray();
+
+  const newSheetIds: string[] = [];
+  for (let i = 0; i < numSheetsToCreate; i += 1) {
+    const sheet = sheets[i % sheets.length];
+    const newSheetId = copySheet(store, sheet);
+    newSheetIds.push(newSheetId);
+  }
 
   const sheetOrSheets = numSheetsToCreate === 1 ? 'sheet' : 'sheets';
   console.log(


### PR DESCRIPTION
## Overview
The script was hanging saying that the db connection was busy after this PR https://github.com/votingworks/vxsuite/pull/4991/files This reverts the changes to the copy sheets script from that PR. Since this is just a script using for periodic testing and not production I think just using a basic for loop is fine. 
<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot

## Testing Plan
Copied to a qa image in tty2 and used successfully 

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
