### PR TITLE
[Mark] Reject blank sheets in the explicit pre-printed ballot flow

### DIFF
--- a/apps/mark-scan/backend/jest.config.js
+++ b/apps/mark-scan/backend/jest.config.js
@@ -23,8 +23,8 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: -16,
-      lines: -19,
+      branches: -17,
+      lines: -20,
     },
   },
 };

--- a/apps/mark-scan/backend/src/app.test.ts
+++ b/apps/mark-scan/backend/src/app.test.ts
@@ -40,7 +40,10 @@ import {
   waitForStatus as waitForStatusHelper,
 } from '../test/app_helpers';
 import { Api, buildApp } from './app';
-import { PaperHandlerStateMachine } from './custom-paper-handler';
+import {
+  ACCEPTED_PAPER_TYPES,
+  PaperHandlerStateMachine,
+} from './custom-paper-handler';
 import { ElectionState } from './types';
 import {
   mockCardlessVoterAuth,
@@ -403,7 +406,7 @@ test('empty ballot box', async () => {
 
 test('getPaperHandlerState returns state machine state', async () => {
   await configureForTestElection(electionGeneralDefinition);
-  await apiClient.setAcceptingPaperState();
+  await apiClient.setAcceptingPaperState({ paperTypes: ACCEPTED_PAPER_TYPES });
   expect(await apiClient.getPaperHandlerState()).toEqual('accepting_paper');
 });
 
@@ -415,7 +418,9 @@ async function mockLoadFlow(
   testApiClient: grout.Client<Api>,
   testDriver: MockPaperHandlerDriver
 ) {
-  await testApiClient.setAcceptingPaperState();
+  await testApiClient.setAcceptingPaperState({
+    paperTypes: ACCEPTED_PAPER_TYPES,
+  });
   testDriver.setMockStatus('paperInserted');
   mockCardlessVoterAuth(mockAuth);
   await waitForStatus('waiting_for_ballot_data');

--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -47,6 +47,7 @@ import { getMachineConfig } from './machine_config';
 import { Workspace } from './util/workspace';
 import {
   PaperHandlerStateMachine,
+  AcceptedPaperType,
   SimpleServerStatus,
   buildMockPaperHandlerApi,
 } from './custom-paper-handler';
@@ -208,9 +209,9 @@ export function buildApi(
       return stateMachine.getSimpleStatus();
     },
 
-    setAcceptingPaperState(): void {
+    setAcceptingPaperState(input: { paperTypes: AcceptedPaperType[] }): void {
       assert(stateMachine);
-      stateMachine.setAcceptingPaper();
+      stateMachine.setAcceptingPaper(input.paperTypes);
     },
 
     /**
@@ -435,7 +436,7 @@ export function buildApi(
 
 export type Api = ReturnType<typeof buildApi>;
 
-export type { MockPaperHandlerStatus };
+export type { MockPaperHandlerStatus, AcceptedPaperType };
 
 export function buildApp(
   auth: InsertedSmartCardAuthApi,

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -42,6 +42,7 @@ import {
 } from '@votingworks/image-utils';
 import { join } from 'path';
 import {
+  ACCEPTED_PAPER_TYPES,
   PaperHandlerStateMachine,
   getPaperHandlerStateMachine,
   paperHandlerStatusToEvent,
@@ -220,7 +221,7 @@ afterEach(async () => {
 describe('not_accepting_paper', () => {
   it('transitions to accepting_paper state on BEGIN_ACCEPTING_PAPER event', () => {
     expect(machine.getSimpleStatus()).toEqual('not_accepting_paper');
-    machine.setAcceptingPaper();
+    machine.setAcceptingPaper(ACCEPTED_PAPER_TYPES);
     expect(machine.getSimpleStatus()).toEqual('accepting_paper');
   });
 
@@ -262,7 +263,7 @@ describe('eject_to_front', () => {
 
 describe('accepting_paper', () => {
   it('transitions to loading_paper state when front sensors are triggered', async () => {
-    machine.setAcceptingPaper();
+    machine.setAcceptingPaper(ACCEPTED_PAPER_TYPES);
     expect(machine.getSimpleStatus()).toEqual('accepting_paper');
 
     driver.setMockStatus('paperInserted');
@@ -272,7 +273,7 @@ describe('accepting_paper', () => {
 
 describe('loading_paper', () => {
   it('calls load and park functions on driver', async () => {
-    machine.setAcceptingPaper();
+    machine.setAcceptingPaper(ACCEPTED_PAPER_TYPES);
     expect(machine.getSimpleStatus()).toEqual('accepting_paper');
 
     // Restore the original `loadAndParkPaper`, so it calls the underlying
@@ -399,7 +400,7 @@ async function executePrintBallotAndAssert(
     jest.requireActual('./application_driver').loadAndParkPaper
   );
 
-  machine.setAcceptingPaper();
+  machine.setAcceptingPaper(ACCEPTED_PAPER_TYPES);
   driver.setMockStatus('paperInserted');
   await expectStatusTransitionTo('loading_paper');
   await expectStatusTransitionTo('waiting_for_voter_auth');
@@ -606,7 +607,7 @@ describe('paper handler status observable', () => {
 
 describe('PAT device', () => {
   async function setupForVoterSession() {
-    machine.setAcceptingPaper();
+    machine.setAcceptingPaper(ACCEPTED_PAPER_TYPES);
     expect(machine.getSimpleStatus()).toEqual('accepting_paper');
     driver.setMockStatus('paperInserted');
 
@@ -640,7 +641,7 @@ describe('PAT device', () => {
 
   test('successful connection flow', async () => {
     await setupForVoterSession();
-    machine.setAcceptingPaper();
+    machine.setAcceptingPaper(ACCEPTED_PAPER_TYPES);
 
     mockOf(patConnectionStatusReader.isPatDeviceConnected).mockResolvedValue(
       true
@@ -664,7 +665,7 @@ describe('PAT device', () => {
 
   test('connecting PAT device while on pollworker screen', async () => {
     mockPollWorkerAuth(auth, electionGeneralDefinition);
-    machine.setAcceptingPaper();
+    machine.setAcceptingPaper(ACCEPTED_PAPER_TYPES);
     await expectStatusTransitionTo('accepting_paper');
     expect(machine.isPatDeviceConnected()).toEqual(false);
     mockOf(patConnectionStatusReader.isPatDeviceConnected).mockResolvedValue(
@@ -724,7 +725,7 @@ describe('PAT device', () => {
 });
 
 test('ending poll worker auth in accepting_paper returns to initial state', async () => {
-  machine.setAcceptingPaper();
+  machine.setAcceptingPaper(ACCEPTED_PAPER_TYPES);
   const ballotStyle = electionGeneralDefinition.election.ballotStyles[1];
   mockCardlessVoterAuth(auth, {
     ballotStyleId: ballotStyle.id,
@@ -739,7 +740,7 @@ describe('poll_worker_auth_ended_unexpectedly', () => {
   });
 
   test('loading_paper state', async () => {
-    machine.setAcceptingPaper();
+    machine.setAcceptingPaper(ACCEPTED_PAPER_TYPES);
     const ballotStyle = electionGeneralDefinition.election.ballotStyles[1];
     driver.setMockStatus('paperInserted');
     await expectStatusTransitionTo('loading_paper');
@@ -755,7 +756,7 @@ describe('poll_worker_auth_ended_unexpectedly', () => {
       BooleanEnvironmentVariableName.MARK_SCAN_DISABLE_BALLOT_REINSERTION
     );
 
-    machine.setAcceptingPaper();
+    machine.setAcceptingPaper(ACCEPTED_PAPER_TYPES);
     await expectStatusTransitionTo('accepting_paper');
 
     jest.spyOn(driver, 'loadPaper').mockImplementation(() => {
@@ -777,7 +778,7 @@ describe('poll_worker_auth_ended_unexpectedly', () => {
       BooleanEnvironmentVariableName.MARK_SCAN_DISABLE_BALLOT_REINSERTION
     );
 
-    machine.setAcceptingPaper();
+    machine.setAcceptingPaper(ACCEPTED_PAPER_TYPES);
     await expectStatusTransitionTo('accepting_paper');
 
     const deferredScan = deferred<string>();
@@ -801,7 +802,7 @@ describe('poll_worker_auth_ended_unexpectedly', () => {
       BooleanEnvironmentVariableName.MARK_SCAN_DISABLE_BALLOT_REINSERTION
     );
 
-    machine.setAcceptingPaper();
+    machine.setAcceptingPaper(ACCEPTED_PAPER_TYPES);
     await expectStatusTransitionTo('accepting_paper');
 
     mockOf(scanAndSave).mockResolvedValue(await writeTmpBlankImage());
@@ -827,7 +828,7 @@ describe('poll_worker_auth_ended_unexpectedly', () => {
       BooleanEnvironmentVariableName.MARK_SCAN_DISABLE_BALLOT_REINSERTION
     );
 
-    machine.setAcceptingPaper();
+    machine.setAcceptingPaper(ACCEPTED_PAPER_TYPES);
     await expectStatusTransitionTo('accepting_paper');
 
     mockOf(scanAndSave).mockResolvedValue(await writeTmpBlankImage());
@@ -846,7 +847,7 @@ describe('poll_worker_auth_ended_unexpectedly', () => {
 
 describe('paper handler diagnostic', () => {
   test('system admin log out', async () => {
-    machine.setAcceptingPaper();
+    machine.setAcceptingPaper(ACCEPTED_PAPER_TYPES);
     expect(machine.getSimpleStatus()).toEqual('accepting_paper');
 
     mockSystemAdminAuth(auth);
@@ -884,7 +885,7 @@ test('insert and validate new blank sheet', async () => {
     BooleanEnvironmentVariableName.MARK_SCAN_DISABLE_BALLOT_REINSERTION
   );
 
-  machine.setAcceptingPaper();
+  machine.setAcceptingPaper(ACCEPTED_PAPER_TYPES);
   expect(machine.getSimpleStatus()).toEqual('accepting_paper');
 
   const mockInterpretResult = deferred<SheetOf<InterpretFileResult>>();
@@ -921,7 +922,7 @@ describe('insert pre-printed ballot', () => {
   });
 
   test('start session with valid pre-printed ballot', async () => {
-    machine.setAcceptingPaper();
+    machine.setAcceptingPaper(ACCEPTED_PAPER_TYPES);
 
     mockOf(scanAndSave).mockResolvedValue(await writeTmpBlankImage());
     mockOf(interpretSimplexBmdBallot).mockResolvedValue(
@@ -937,7 +938,7 @@ describe('insert pre-printed ballot', () => {
   });
 
   test('return valid pre-printed ballot', async () => {
-    machine.setAcceptingPaper();
+    machine.setAcceptingPaper(ACCEPTED_PAPER_TYPES);
 
     mockOf(scanAndSave).mockResolvedValue(await writeTmpBlankImage());
     mockOf(interpretSimplexBmdBallot).mockResolvedValue(
@@ -972,7 +973,7 @@ describe('insert pre-printed ballot', () => {
       .filterMap(([type, enabled]) => (enabled ? type : undefined))
       .toArray()
   )('insert invalid sheet: %s', async (interpretationType) => {
-    machine.setAcceptingPaper();
+    machine.setAcceptingPaper(ACCEPTED_PAPER_TYPES);
     expect(machine.getSimpleStatus()).toEqual('accepting_paper');
 
     mockOf(scanAndSave).mockResolvedValue(await writeTmpBlankImage());
@@ -999,6 +1000,22 @@ describe('insert pre-printed ballot', () => {
     driver.setMockStatus('noPaper');
     await expectStatusTransitionTo('accepting_paper');
   });
+
+  test('insert blank sheet when accepting only pre-printed ballots', async () => {
+    machine.setAcceptingPaper(['InterpretedBmdPage']);
+    expect(machine.getSimpleStatus()).toEqual('accepting_paper');
+
+    mockOf(scanAndSave).mockResolvedValue(await writeTmpBlankImage());
+
+    mockOf(interpretSimplexBmdBallot).mockResolvedValue(
+      BLANK_PAGE_INTERPRETATION_MOCK
+    );
+
+    driver.setMockStatus('paperInserted');
+    await expectStatusTransitionTo('loading_new_sheet');
+    await expectStatusTransitionTo('validating_new_sheet');
+    await expectStatusTransitionTo('inserted_invalid_new_sheet');
+  });
 });
 
 describe('re-insert removed ballot', () => {
@@ -1013,7 +1030,7 @@ describe('re-insert removed ballot', () => {
     // 1. [Setup] Seed voting session with pre-printed ballot:
     //
 
-    machine.setAcceptingPaper();
+    machine.setAcceptingPaper(ACCEPTED_PAPER_TYPES);
 
     mockOf(scanAndSave).mockResolvedValue(await writeTmpBlankImage());
     mockOf(interpretSimplexBmdBallot).mockResolvedValue(
@@ -1078,7 +1095,7 @@ describe('re-insert removed ballot', () => {
     // 1. [Setup] Seed voting session with pre-printed ballot:
     //
 
-    machine.setAcceptingPaper();
+    machine.setAcceptingPaper(ACCEPTED_PAPER_TYPES);
 
     mockOf(scanAndSave).mockResolvedValue(await writeTmpBlankImage());
     mockOf(interpretSimplexBmdBallot).mockResolvedValue(

--- a/apps/mark-scan/frontend/src/pages/inserted_blank_sheet_instead_of_ballot_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/inserted_blank_sheet_instead_of_ballot_screen.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import { Icons, P } from '@votingworks/ui';
+
+import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+
+export function InsertedBlankSheetInsteadOfBallotScreen(): React.ReactNode {
+  return (
+    <CenteredCardPageLayout
+      icon={<Icons.Warning color="warning" />}
+      title="No Ballot Detected"
+      voterFacing={false}
+    >
+      <P>There was no ballot information detected on the inserted sheet.</P>
+      <P>
+        Please remove the sheet and insert a valid ballot. Be sure to insert the
+        sheet with the printed side facing upwards.
+      </P>
+    </CenteredCardPageLayout>
+  );
+}

--- a/apps/mark-scan/frontend/src/pages/inserted_invalid_new_sheet_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/inserted_invalid_new_sheet_screen.test.tsx
@@ -39,7 +39,7 @@ function setMockInterpretation(type: PageInterpretationType) {
 const expectedScreenContents: Readonly<
   Record<PageInterpretationType, string | RegExp>
 > = {
-  BlankPage: 'Test Error Boundary',
+  BlankPage: /no ballot detected/i,
   InterpretedBmdPage: 'Test Error Boundary',
   InterpretedHmpbPage: /unable to read ballot/i,
   InvalidBallotHashPage: /wrong election/i,

--- a/apps/mark-scan/frontend/src/pages/inserted_invalid_new_sheet_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/inserted_invalid_new_sheet_screen.tsx
@@ -6,17 +6,18 @@ import { InsertedWrongElectionBallotScreen } from './inserted_wrong_election_bal
 import { InsertedWrongPrecinctBallotScreen } from './inserted_wrong_precinct_ballot_screen';
 import { InsertedWrongTestModeBallotScreen } from './inserted_wrong_test_mode_ballot_screen';
 import { InsertedUnreadableBallotScreen } from './inserted_unreadable_ballot_screen';
+import { InsertedBlankSheetInsteadOfBallotScreen } from './inserted_blank_sheet_instead_of_ballot_screen';
 
 const SCREENS: Readonly<
   Record<PageInterpretationType, JSX.Element | undefined>
 > = {
   InterpretedBmdPage: undefined, // This page should be unreachable for this result.
-  BlankPage: undefined, // This page should be unreachable for this result.
 
   // Not currently reachable in practice - HMPBs are interpreted as `BlankPage`s
   // in VxMarkScan:
   InterpretedHmpbPage: <InsertedUnreadableBallotScreen />,
 
+  BlankPage: <InsertedBlankSheetInsteadOfBallotScreen />,
   InvalidBallotHashPage: <InsertedWrongElectionBallotScreen />,
   InvalidTestModePage: <InsertedWrongTestModeBallotScreen />,
   InvalidPrecinctPage: <InsertedWrongPrecinctBallotScreen />,

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.test.tsx
@@ -23,7 +23,7 @@ import {
 } from '@votingworks/test-utils';
 import userEvent from '@testing-library/user-event';
 
-import { DateWithoutTime } from '@votingworks/basics';
+import { assertDefined, DateWithoutTime } from '@votingworks/basics';
 import { SimpleServerStatus } from '@votingworks/mark-scan-backend';
 import { fireEvent, screen } from '../../test/react_testing_library';
 
@@ -237,8 +237,24 @@ test('displays only default English ballot styles', async () => {
     screen.queryByRole('button', { name: ballotStyleSpanish.id })
   ).not.toBeInTheDocument();
 });
-
 describe('pre-printed ballots', () => {
+  test('start new session with blank sheet', () => {
+    mockFeatureFlagger.disableFeatureFlag(
+      BooleanEnvironmentVariableName.MARK_SCAN_DISABLE_BALLOT_REINSERTION
+    );
+
+    renderScreen({ electionDefinition: electionGeneralDefinition });
+
+    const ballotStyle = assertDefined(
+      electionGeneralDefinition.election.ballotStyles[0]
+    );
+    apiMock.expectSetAcceptingPaperState(['BlankPage', 'InterpretedBmdPage']);
+
+    userEvent.click(
+      screen.getButton(extractBallotStyleGroupId(ballotStyle.id))
+    );
+  });
+
   test('can insert pre-printed ballots without ballot style selection', () => {
     mockFeatureFlagger.disableFeatureFlag(
       BooleanEnvironmentVariableName.MARK_SCAN_DISABLE_BALLOT_REINSERTION
@@ -246,7 +262,7 @@ describe('pre-printed ballots', () => {
 
     renderScreen();
 
-    apiMock.expectSetAcceptingPaperState();
+    apiMock.expectSetAcceptingPaperState(['InterpretedBmdPage']);
     userEvent.click(screen.getButton(/insert printed ballot/i));
   });
 

--- a/apps/mark-scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/mark-scan/frontend/test/helpers/mock_api_client.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
-import type {
-  Api,
-  ElectionState,
-  MachineConfig,
-  PrintBallotProps,
-  SimpleServerStatus,
+import {
+  ACCEPTED_PAPER_TYPES,
+  type AcceptedPaperType,
+  type Api,
+  type ElectionState,
+  type MachineConfig,
+  type PrintBallotProps,
+  type SimpleServerStatus,
 } from '@votingworks/mark-scan-backend';
 import {
   ElectionPackageConfigurationError,
@@ -253,14 +255,22 @@ export function createApiMock() {
 
     // Some e2e tests repeatedly reset voter session. Each time a voter session is activated
     // setAcceptingPaperState is called.
-    expectRepeatedSetAcceptingPaperState(): void {
-      mockApiClient.setAcceptingPaperState.expectRepeatedCallsWith().resolves();
+    expectRepeatedSetAcceptingPaperState(
+      paperTypes: AcceptedPaperType[] = ACCEPTED_PAPER_TYPES
+    ): void {
+      mockApiClient.setAcceptingPaperState
+        .expectRepeatedCallsWith({ paperTypes })
+        .resolves();
       setPaperHandlerState('accepting_paper');
     },
 
     // Mocked version of a real method on the API client
-    expectSetAcceptingPaperState(): void {
-      mockApiClient.setAcceptingPaperState.expectCallWith().resolves();
+    expectSetAcceptingPaperState(
+      paperTypes: AcceptedPaperType[] = ACCEPTED_PAPER_TYPES
+    ): void {
+      mockApiClient.setAcceptingPaperState
+        .expectCallWith({ paperTypes })
+        .resolves();
     },
 
     // Helper on the mock API client; does not exist on real API client


### PR DESCRIPTION
## Overview

Resolves https://github.com/votingworks/vxsuite/issues/5232

Updating the new session flow to reject blank sheets when the Poll Worker explicitly chooses to go through the "Cast a Previously Printed Ballot" flow.

We were previously dropping them back into the ballot style selection screen if a blank sheet was inserted before picking a ballot style - this change makes behaviour more explicit to avoid confusion.

Pre-printed ballots are still accepted even after picking a ballot style in the mainline flow.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/84be278e-59d4-466f-b78a-80854c7361b4

## Testing Plan
- Updated unit tests
- Manual verification for the different paths to starting a new session

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
