### PR TITLE
allow spaces and underscores in usb drive mount points

### DIFF
--- a/libs/usb-drive/scripts/unmount.sh
+++ b/libs/usb-drive/scripts/unmount.sh
@@ -13,15 +13,15 @@ fi
 
 MOUNTPOINT=$1
 
-MOUNTPOINT_REGEX=^/media/[a-Z0-9-]+/[a-Z0-9-]+$
+MOUNTPOINT_REGEX=^/media/[[:alnum:]\ -_]+/[[:alnum:]\ -_]+$
 
-if ! [[ $MOUNTPOINT =~ $MOUNTPOINT_REGEX ]]; then
+if ! [[ "$MOUNTPOINT" =~ $MOUNTPOINT_REGEX ]]; then
     echo "unmount.sh: mount point \"${MOUNTPOINT}\" is not a valid mounted USB drive"
     exit 1
 fi
 
 # Run sync before unmounting to force any cached file data to be flushed to the
 # removable drive. Used to prevent incomplete file transfers.
-sync -f $MOUNTPOINT
+sync -f "$MOUNTPOINT"
 
-umount $MOUNTPOINT
+umount "$MOUNTPOINT"


### PR DESCRIPTION
Closes #4833. Confirmed this doesn't break the regular flow (default mounting point) and now works with a wonky mount point like `/media/vx/free-_ space`.