### PR TITLE
mark-scan diagnostic: handle blank interpretation gracefully

### DIFF
--- a/apps/mark-scan/backend/src/app.diagnostics.test.ts
+++ b/apps/mark-scan/backend/src/app.diagnostics.test.ts
@@ -370,7 +370,7 @@ describe('paper handler diagnostic', () => {
     clock.increment(delays.DELAY_PAPER_HANDLER_STATUS_POLLING_INTERVAL_MS);
     // Error is hit as soon as paper is loaded
     await waitForStatus('paper_handler_diagnostic.failure');
-    clock.increment(delays.DELAY_NOTIFICATION_DURATION_MS);
+    stateMachine.stopPaperHandlerDiagnostic();
     // State machine transitions back to its history state in the voting flow
     await waitForStatus('not_accepting_paper');
 
@@ -449,7 +449,7 @@ describe('paper handler diagnostic', () => {
 
       clock.increment(delays.DELAY_PAPER_HANDLER_STATUS_POLLING_INTERVAL_MS);
       await waitForStatus('paper_handler_diagnostic.failure');
-      clock.increment(delays.DELAY_NOTIFICATION_DURATION_MS);
+      stateMachine.stopPaperHandlerDiagnostic();
       await waitForStatus('ejecting_to_front');
       const record = await apiClient.getMostRecentDiagnostic({
         diagnosticType: 'mark-scan-paper-handler',

--- a/apps/mark-scan/backend/src/app.diagnostics.test.ts
+++ b/apps/mark-scan/backend/src/app.diagnostics.test.ts
@@ -330,7 +330,7 @@ describe('paper handler diagnostic', () => {
     clock.increment(delays.DELAY_PAPER_HANDLER_STATUS_POLLING_INTERVAL_MS);
     await waitForStatus('paper_handler_diagnostic.print_ballot_fixture');
     // Chromium, used by print_ballot_fixture, needs some time to spin up
-    await waitForStatus('paper_handler_diagnostic.scan_ballot', 300);
+    await waitForStatus('paper_handler_diagnostic.scan_ballot', 1000);
 
     mockScanResult.resolve(scannedPath);
     await waitForStatus('paper_handler_diagnostic.interpret_ballot');
@@ -404,12 +404,14 @@ describe('paper handler diagnostic', () => {
     await waitForStatus('paper_handler_diagnostic.prompt_for_paper');
 
     driver.setMockStatus('paperInserted');
+    clock.increment(delays.DELAY_PAPER_HANDLER_STATUS_POLLING_INTERVAL_MS);
     await waitForStatus('paper_handler_diagnostic.load_paper');
 
     driver.setMockStatus('paperParked');
+    clock.increment(delays.DELAY_PAPER_HANDLER_STATUS_POLLING_INTERVAL_MS);
     await waitForStatus('paper_handler_diagnostic.print_ballot_fixture');
     // Chromium, used by print_ballot_fixture, needs some time to spin up
-    await waitForStatus('paper_handler_diagnostic.scan_ballot', 300);
+    await waitForStatus('paper_handler_diagnostic.scan_ballot', 1000);
 
     mockScanResult.resolve(scannedPath);
     await waitForStatus('paper_handler_diagnostic.interpret_ballot');
@@ -422,7 +424,8 @@ describe('paper handler diagnostic', () => {
 
     mockInterpretResult.resolve(interpretationMock);
 
-    await waitForStatus('not_accepting_paper');
+    clock.increment(delays.DELAY_PAPER_HANDLER_STATUS_POLLING_INTERVAL_MS);
+    await waitForStatus('ejecting_to_front');
     const record = await apiClient.getMostRecentDiagnostic({
       diagnosticType: 'mark-scan-paper-handler',
     });

--- a/apps/mark-scan/backend/src/app.diagnostics.test.ts
+++ b/apps/mark-scan/backend/src/app.diagnostics.test.ts
@@ -376,4 +376,56 @@ describe('paper handler diagnostic', () => {
     });
     expect(assertDefined(record).outcome).toEqual('fail');
   });
+
+  test('failure due to bad interpretation', async () => {
+    mockSystemAdminAuth(auth);
+
+    const mockScanResult = deferred<string>();
+    const scannedPath = await getDiagnosticMockBallotImagePath();
+    mockOf(scanAndSave).mockResolvedValue(mockScanResult.promise);
+
+    const interpretationMock: SheetOf<InterpretFileResult> = [
+      {
+        interpretation: {
+          type: 'BlankPage',
+        },
+        normalizedImage: BLANK_PAGE_IMAGE_DATA,
+      },
+      BLANK_PAGE_MOCK,
+    ];
+    const mockInterpretResult = deferred<SheetOf<InterpretFileResult>>();
+    mockOf(interpretSimplexBmdBallot).mockResolvedValue(
+      mockInterpretResult.promise
+    );
+
+    driver.setMockStatus('noPaper');
+
+    await apiClient.startPaperHandlerDiagnostic();
+    await waitForStatus('paper_handler_diagnostic.prompt_for_paper');
+
+    driver.setMockStatus('paperInserted');
+    await waitForStatus('paper_handler_diagnostic.load_paper');
+
+    driver.setMockStatus('paperParked');
+    await waitForStatus('paper_handler_diagnostic.print_ballot_fixture');
+    // Chromium, used by print_ballot_fixture, needs some time to spin up
+    await waitForStatus('paper_handler_diagnostic.scan_ballot', 300);
+
+    mockScanResult.resolve(scannedPath);
+    await waitForStatus('paper_handler_diagnostic.interpret_ballot');
+
+    // Simulate a delay between the `ejectBallotToRear` call and the paper
+    // getting ejected, by resolving without actually moving into the `noPaper`
+    // state, to allow us to test for the`eject_to_rear` state
+    // transition:
+    jest.spyOn(driver, 'ejectBallotToRear').mockResolvedValue(true);
+
+    mockInterpretResult.resolve(interpretationMock);
+
+    await waitForStatus('not_accepting_paper');
+    const record = await apiClient.getMostRecentDiagnostic({
+      diagnosticType: 'mark-scan-paper-handler',
+    });
+    expect(assertDefined(record).outcome).toEqual('fail');
+  });
 });

--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -494,6 +494,10 @@ export function buildApi(
       stateMachine.startPaperHandlerDiagnostic();
     },
 
+    stopPaperHandlerDiagnostic(): void {
+      assertDefined(stateMachine).stopPaperHandlerDiagnostic();
+    },
+
     ...buildMockPaperHandlerApi({ paperHandler }),
   });
 }

--- a/apps/mark-scan/backend/src/custom-paper-handler/diagnostic/blank_page_interpretation_diagnostic_error.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/diagnostic/blank_page_interpretation_diagnostic_error.ts
@@ -1,4 +1,6 @@
-export class BlankPageInterpretationDiagnosticError extends Error {
+import { DiagnosticError } from './diagnostic_error';
+
+export class BlankPageInterpretationDiagnosticError extends DiagnosticError {
   constructor() {
     super(
       'No ballot QR code was detected on the page after printing. Ensure the page is inserted with the printable side up and try again.'

--- a/apps/mark-scan/backend/src/custom-paper-handler/diagnostic/blank_page_interpretation_diagnostic_error.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/diagnostic/blank_page_interpretation_diagnostic_error.ts
@@ -1,0 +1,7 @@
+export class BlankPageInterpretationDiagnosticError extends Error {
+  constructor() {
+    super(
+      'No ballot QR code was detected on the page after printing. Ensure the page is inserted with the printable side up and try again.'
+    );
+  }
+}

--- a/apps/mark-scan/backend/src/custom-paper-handler/diagnostic/diagnostic_error.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/diagnostic/diagnostic_error.ts
@@ -1,5 +1,5 @@
 export class DiagnosticError extends Error {
-  constructor(message: string, options: { originalError?: Error }) {
-    super(message, { cause: options.originalError });
+  constructor(message: string, options?: { originalError?: Error }) {
+    super(message, { cause: options?.originalError });
   }
 }

--- a/apps/mark-scan/backend/src/custom-paper-handler/diagnostic/diagnostic_error.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/diagnostic/diagnostic_error.ts
@@ -1,0 +1,5 @@
+export class DiagnosticError extends Error {
+  constructor(message: string, options: { originalError?: Error }) {
+    super(message, { cause: options.originalError });
+  }
+}

--- a/apps/mark-scan/backend/src/custom-paper-handler/diagnostic/unknown_interpretation_diagnostic_error.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/diagnostic/unknown_interpretation_diagnostic_error.ts
@@ -1,0 +1,7 @@
+import { PageInterpretationType } from '@votingworks/types';
+
+export class UnknownInterpretationDiagnosticError extends Error {
+  constructor(interpretationType: PageInterpretationType) {
+    super(`Unexpected test ballot interpretation: ${interpretationType}`);
+  }
+}

--- a/apps/mark-scan/backend/src/custom-paper-handler/diagnostic/unknown_interpretation_diagnostic_error.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/diagnostic/unknown_interpretation_diagnostic_error.ts
@@ -1,6 +1,7 @@
 import { PageInterpretationType } from '@votingworks/types';
+import { DiagnosticError } from './diagnostic_error';
 
-export class UnknownInterpretationDiagnosticError extends Error {
+export class UnknownInterpretationDiagnosticError extends DiagnosticError {
   constructor(interpretationType: PageInterpretationType) {
     super(`Unexpected test ballot interpretation: ${interpretationType}`);
   }

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -1272,13 +1272,6 @@ export function buildMachine(
               onDone: 'done',
             },
             failure: {
-              // entry: (context) => {
-              //   context.workspace.store.addDiagnosticRecord({
-              //     type: 'mark-scan-paper-handler',
-              //     outcome: 'fail',
-              //     message: context.diagnosticError?.message,
-              //   });
-              // },
               invoke: {
                 id: 'diagnostic.failure',
                 src: (context) => {
@@ -1305,7 +1298,7 @@ export function buildMachine(
                   );
                 },
               },
-              after: { [delays.DELAY_NOTIFICATION_DURATION_MS]: 'done' },
+              after: { [4 * delays.DELAY_NOTIFICATION_DURATION_MS]: 'done' },
             },
             done: {
               entry: async (context) => {

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -25,7 +25,6 @@ import {
   PropertyAssigner,
   ServiceMap,
   StateSchema,
-  State,
   sendParent,
   EventObject,
 } from 'xstate';
@@ -196,11 +195,6 @@ export interface PaperHandlerStateMachine {
   confirmBallotBoxEmptied(): void;
   setPatDeviceIsCalibrated(): void;
   isPatDeviceConnected(): boolean;
-  addTransitionListener(
-    listener: (
-      state: State<Context, PaperHandlerStatusEvent, any, any, any>
-    ) => void
-  ): void;
   startSessionWithPreprintedBallot(): void;
   returnPreprintedBallot(): void;
   startPaperHandlerDiagnostic(): void;
@@ -1681,10 +1675,6 @@ export async function getPaperHandlerStateMachine({
 
     isPatDeviceConnected(): boolean {
       return machineService.state.context.isPatDeviceConnected;
-    },
-
-    addTransitionListener(listener) {
-      machineService.onTransition(listener);
     },
 
     startSessionWithPreprintedBallot() {

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -1233,9 +1233,10 @@ export function buildMachine(
                   target: 'failure',
                   actions: assign({
                     diagnosticError: (context) => {
-                      const interpretationType = context.interpretation
-                        ? context.interpretation[0].interpretation.type
-                        : 'Unknown';
+                      const interpretationType = assertDefined(
+                        context.interpretation
+                      )[0].interpretation.type;
+
                       return new Error(
                         `Invalid interpretation type: ${interpretationType}`
                       );

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -1210,25 +1210,39 @@ export function buildMachine(
                   );
                 },
                 onDone: {
-                  target: 'eject_to_rear',
+                  target: 'handle_interpretation',
                   actions: assign({
-                    interpretation: (_, event) => {
-                      const interpretation = event.data;
-                      const interpretationType =
-                        interpretation[0].interpretation.type;
-                      /* istanbul ignore next */
-                      if (interpretationType !== 'InterpretedBmdPage') {
-                        throw new Error(
-                          `Unexpected interpretation type: ${interpretationType}`
-                        );
-                      }
-
-                      return interpretation;
-                    },
+                    interpretation: (_, event) => event.data,
                   }),
                 },
                 onError: createOnDiagnosticErrorHandler(),
               },
+            },
+            handle_interpretation: {
+              always: [
+                {
+                  target: 'eject_to_rear',
+                  cond: (context) =>
+                    !!(
+                      context.interpretation &&
+                      context.interpretation[0].interpretation.type ===
+                        'InterpretedBmdPage'
+                    ),
+                },
+                {
+                  target: 'failure',
+                  actions: assign({
+                    diagnosticError: (context) => {
+                      const interpretationType = context.interpretation
+                        ? context.interpretation[0].interpretation.type
+                        : 'Unknown';
+                      return new Error(
+                        `Invalid interpretation type: ${interpretationType}`
+                      );
+                    },
+                  }),
+                },
+              ],
             },
             eject_to_rear: {
               invoke: pollPaperHandlerStatus,

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -114,11 +114,16 @@ function createOnDiagnosticErrorHandler() {
     actions: assign({
       diagnosticError: (_: unknown, event: any) => {
         if (event.data instanceof DiagnosticError) {
+          /* istanbul ignore next */
           return event.data;
         }
 
         return new DiagnosticError('An unknown error occurred.', {
-          originalError: event.data instanceof Error ? event.data : undefined,
+          originalError:
+            event.data instanceof Error
+              ? /* istanbul ignore next */
+                event.data
+              : undefined,
         });
       },
     }),

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -1134,6 +1134,24 @@ export function buildMachine(
               on: {
                 PAPER_READY_TO_LOAD: 'load_paper',
               },
+              // always: {
+              //   target: 'handle_interpretation',
+              //   actions: assign({
+              //     interpretation: (): SheetOf<InterpretFileResult> => {
+              //       const interpretationMock: SheetOf<InterpretFileResult> = [
+              //         {
+              //           interpretation: { type: 'BlankPage' },
+              //           normalizedImage: BLANK_PAGE_IMAGE_DATA,
+              //         },
+              //         {
+              //           interpretation: { type: 'BlankPage' },
+              //           normalizedImage: BLANK_PAGE_IMAGE_DATA,
+              //         },
+              //       ];
+              //       return interpretationMock;
+              //     },
+              //   }),
+              // },
             },
             load_paper: {
               invoke: [

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -1302,7 +1302,9 @@ export function buildMachine(
                   );
                 },
               },
-              // No transition defined - frontend is expected to send SYSTEM_ADMIN_ENDED_PAPER_HANDLER_DIAGNOSTIC event
+              // No local transition defined. The frontend is expected to send a
+              // SYSTEM_ADMIN_ENDED_PAPER_HANDLER_DIAGNOSTIC event which is handled
+              // at by the parent state.
             },
             done: {
               entry: async (context) => {

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -184,6 +184,7 @@ function isEventUserAction(event: EventObject): boolean {
     'RESET',
     'START_SESSION_WITH_PREPRINTED_BALLOT',
     'SYSTEM_ADMIN_STARTED_PAPER_HANDLER_DIAGNOSTIC',
+    'SYSTEM_ADMIN_ENDED_PAPER_HANDLER_DIAGNOSTIC',
     'PAPER_READY_TO_LOAD', // paper was inserted by a user
   ].includes(event.type);
 }

--- a/apps/mark-scan/frontend/src/api.ts
+++ b/apps/mark-scan/frontend/src/api.ts
@@ -517,6 +517,18 @@ export const startPaperHandlerDiagnostic = {
   },
 } as const;
 
+export const stopPaperHandlerDiagnostic = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.stopPaperHandlerDiagnostic, {
+      async onSuccess() {
+        await queryClient.invalidateQueries(getStateMachineState.queryKey());
+      },
+    });
+  },
+} as const;
+
 export const systemCallApi = createSystemCallApi(useApiClient);
 
 export const startSessionWithPreprintedBallot = {

--- a/apps/mark-scan/frontend/src/pages/diagnostics/diagnostics_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/diagnostics/diagnostics_screen.test.tsx
@@ -233,6 +233,7 @@ test('pressing the button to start the paper handler diagnostic calls the right 
 
 test('ending paper handler diagnostic refetches the diagnostic record', async () => {
   apiMock.expectStartPaperHandlerDiagnostic();
+  apiMock.expectStopPaperHandlerDiagnostic();
 
   renderScreen();
   userEvent.click(await screen.findButton('Test Printer/Scanner'));

--- a/apps/mark-scan/frontend/src/pages/diagnostics/diagnostics_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/diagnostics/diagnostics_screen.tsx
@@ -24,6 +24,7 @@ import {
   getMostRecentDiagnostic,
   addDiagnosticRecord,
   getMarkScanBmdModel,
+  stopPaperHandlerDiagnostic,
 } from '../../api';
 import { PaperHandlerDiagnosticScreen } from './paper_handler_diagnostic_screen';
 import { HeadphoneInputDiagnosticScreen } from './headphone_input_diagnostic_screen';
@@ -58,6 +59,8 @@ export function DiagnosticsScreen({
 
   const startPaperHandlerDiagnosticMutation =
     startPaperHandlerDiagnostic.useMutation();
+  const stopPaperHandlerDiagnosticMutation =
+    stopPaperHandlerDiagnostic.useMutation();
   const addPatDiagnosticRecordMutation = addDiagnosticRecord.useMutation(
     'mark-scan-pat-input'
   );
@@ -209,7 +212,9 @@ export function DiagnosticsScreen({
         <PaperHandlerDiagnosticScreen
           mostRecentPaperHandlerDiagnostic={mostRecentPaperHandlerDiagnostic}
           onClose={async () => {
+            stopPaperHandlerDiagnosticMutation.mutate();
             history.push('/');
+
             // The diagnostic record is written by the backend after successful rear ejection.
             // Invalidating the query at the time of the last mutation in this flow is still too early
             // so we have to manually refetch.

--- a/apps/mark-scan/frontend/src/pages/diagnostics/diagnostics_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/diagnostics/diagnostics_screen.tsx
@@ -207,6 +207,7 @@ export function DiagnosticsScreen({
       </Route>
       <Route path="/paper-handler">
         <PaperHandlerDiagnosticScreen
+          mostRecentPaperHandlerDiagnostic={mostRecentPaperHandlerDiagnostic}
           onClose={async () => {
             history.push('/');
             // The diagnostic record is written by the backend after successful rear ejection.

--- a/apps/mark-scan/frontend/src/pages/diagnostics/paper_handler_diagnostic_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/diagnostics/paper_handler_diagnostic_screen.tsx
@@ -1,4 +1,6 @@
 import { Button, H2, Loading, Main, P, Screen } from '@votingworks/ui';
+import { DiagnosticRecord } from '@votingworks/types';
+import React from 'react';
 import {
   CancelButtonContainer,
   StepContainer,
@@ -7,10 +9,12 @@ import { getStateMachineState } from '../../api';
 
 export interface PaperHandlerDiagnosticProps {
   onClose: () => void;
+  mostRecentPaperHandlerDiagnostic?: DiagnosticRecord;
 }
 
 export function PaperHandlerDiagnosticScreen({
   onClose,
+  mostRecentPaperHandlerDiagnostic,
 }: PaperHandlerDiagnosticProps): JSX.Element {
   const getStateMachineStateQuery = getStateMachineState.useQuery();
 
@@ -51,11 +55,22 @@ export function PaperHandlerDiagnosticScreen({
         );
         break;
       case 'paper_handler_diagnostic.failure':
-        contents = (
-          <P>
-            The diagnostic failed. You may now close this page to try again.
-          </P>
-        );
+        if (mostRecentPaperHandlerDiagnostic?.message) {
+          contents = (
+            <React.Fragment>
+              <P>The diagnostic failed.</P>
+              <P>{mostRecentPaperHandlerDiagnostic.message}.</P>
+              <P>You may now close this page to try again.</P>
+            </React.Fragment>
+          );
+        } else {
+          contents = (
+            <P>
+              The diagnostic failed. You may now close this page to try again.
+            </P>
+          );
+        }
+
         closeButton = (
           <Button icon="Delete" onPress={onClose}>
             End Test
@@ -63,7 +78,12 @@ export function PaperHandlerDiagnosticScreen({
         );
         break;
       default:
-      // No-op because `contents` is already assigned above
+        contents = <P>The diagnostic has ended.</P>;
+        closeButton = (
+          <Button icon="Delete" onPress={onClose}>
+            End Test
+          </Button>
+        );
     }
   }
 

--- a/apps/mark-scan/frontend/src/pages/diagnostics/paper_handler_diagnostic_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/diagnostics/paper_handler_diagnostic_screen.tsx
@@ -78,12 +78,7 @@ export function PaperHandlerDiagnosticScreen({
         );
         break;
       default:
-        contents = <P>The diagnostic has ended.</P>;
-        closeButton = (
-          <Button icon="Delete" onPress={onClose}>
-            End Test
-          </Button>
-        );
+      // Default contents are handled when the variable is defined
     }
   }
 

--- a/apps/mark-scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/mark-scan/frontend/test/helpers/mock_api_client.tsx
@@ -350,6 +350,10 @@ export function createApiMock() {
       mockApiClient.startPaperHandlerDiagnostic.expectCallWith().resolves();
     },
 
+    expectStopPaperHandlerDiagnostic() {
+      mockApiClient.stopPaperHandlerDiagnostic.expectCallWith().resolves();
+    },
+
     expectSetPrecinctSelection(precinctSelection: PrecinctSelection) {
       mockApiClient.setPrecinctSelection
         .expectCallWith({ precinctSelection })


### PR DESCRIPTION
## Overview

Previously the paper handler diagnostic would crash the app when an unexpected interpretation type was returned. This happened because the `onError` handler does not catch and handle errors that happen in `onDone` of a service.

To avoid this, I broke out the post-interpretation logic to its own state with clearer transitions.

## Demo Video or Screenshot

![Screenshot 2024-09-23 at 6 48 36 PM](https://github.com/user-attachments/assets/d8b75dd2-2a19-4fb3-aa57-ccdcc93a430e)


## Testing Plan

- added automated tests
- manually tested in VM

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
