### PR TITLE
Optimize retrieval of election key during auth polling

### DIFF
--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -225,6 +225,12 @@ test('configuring with a CDF election', async () => {
   expect(currentElectionMetadata?.electionDefinition.ballotHash).toEqual(
     ballotHash
   );
+
+  // Ensure loading auth election key from db works
+  mockElectionManagerAuth(auth, electionGeneral);
+  expect(await apiClient.getAuthStatus()).toMatchObject({
+    status: 'logged_in',
+  });
 });
 
 test('configuring with an election not from removable media in prod errs', async () => {

--- a/apps/admin/backend/src/util/auth.ts
+++ b/apps/admin/backend/src/util/auth.ts
@@ -1,15 +1,10 @@
-import { assert } from '@votingworks/basics';
 import {
   DEV_JURISDICTION,
   DippedSmartCardAuthApi,
   DippedSmartCardAuthMachineState,
 } from '@votingworks/auth';
 import { isIntegrationTest } from '@votingworks/utils';
-import {
-  DEFAULT_SYSTEM_SETTINGS,
-  constructElectionKey,
-  TEST_JURISDICTION,
-} from '@votingworks/types';
+import { DEFAULT_SYSTEM_SETTINGS, TEST_JURISDICTION } from '@votingworks/types';
 import { LoggingUserRole } from '@votingworks/logging';
 import { Workspace } from './workspace';
 
@@ -19,34 +14,24 @@ import { Workspace } from './workspace';
 export function constructAuthMachineState(
   workspace: Workspace
 ): DippedSmartCardAuthMachineState {
-  const electionRecord = (() => {
-    const electionId = workspace.store.getCurrentElectionId();
-    if (!electionId) {
-      return undefined;
-    }
-    const record = workspace.store.getElection(electionId);
-    assert(record);
-    return record;
-  })();
+  const electionId = workspace.store.getCurrentElectionId();
 
   /* c8 ignore next 3 - covered by integration testing */
   const jurisdiction = isIntegrationTest()
     ? TEST_JURISDICTION
     : process.env.VX_MACHINE_JURISDICTION ?? DEV_JURISDICTION;
 
-  if (!electionRecord) {
+  if (!electionId) {
     return {
       ...DEFAULT_SYSTEM_SETTINGS.auth,
       jurisdiction,
     };
   }
 
-  const systemSettings = workspace.store.getSystemSettings(electionRecord.id);
+  const systemSettings = workspace.store.getSystemSettings(electionId);
   return {
     ...systemSettings.auth,
-    electionKey: constructElectionKey(
-      electionRecord.electionDefinition.election
-    ),
+    electionKey: workspace.store.getElectionKey(electionId),
     jurisdiction,
   };
 }

--- a/apps/central-scan/backend/src/util/auth.ts
+++ b/apps/central-scan/backend/src/util/auth.ts
@@ -2,25 +2,20 @@ import {
   DippedSmartCardAuthApi,
   DippedSmartCardAuthMachineState,
 } from '@votingworks/auth';
-import {
-  DEFAULT_SYSTEM_SETTINGS,
-  constructElectionKey,
-} from '@votingworks/types';
+import { DEFAULT_SYSTEM_SETTINGS } from '@votingworks/types';
 import { LoggingUserRole } from '@votingworks/logging';
 import { Workspace } from './workspace';
 
 export function constructAuthMachineState(
   workspace: Workspace
 ): DippedSmartCardAuthMachineState {
-  const electionRecord = workspace.store.getElectionRecord();
+  const electionKey = workspace.store.getElectionKey();
   const jurisdiction = workspace.store.getJurisdiction();
   const systemSettings =
     workspace.store.getSystemSettings() ?? DEFAULT_SYSTEM_SETTINGS;
   return {
     ...systemSettings.auth,
-    electionKey:
-      electionRecord &&
-      constructElectionKey(electionRecord.electionDefinition.election),
+    electionKey,
     jurisdiction,
   };
 }

--- a/apps/mark-scan/backend/src/store.ts
+++ b/apps/mark-scan/backend/src/store.ts
@@ -10,7 +10,7 @@ import {
   getMostRecentDiagnosticRecord,
   updateMaximumUsableDiskSpace,
 } from '@votingworks/backend';
-import { Optional } from '@votingworks/basics';
+import { DateWithoutTime, Optional } from '@votingworks/basics';
 import { Client as DbClient } from '@votingworks/db';
 import {
   ElectionDefinition,
@@ -25,6 +25,8 @@ import {
   PollsStateSchema,
   DiagnosticRecord,
   DiagnosticType,
+  ElectionId,
+  ElectionKey,
 } from '@votingworks/types';
 import { join } from 'path';
 
@@ -111,6 +113,28 @@ export class Store {
           electionRow.electionData
         ).unsafeUnwrap(),
         electionPackageHash: electionRow.electionPackageHash,
+      }
+    );
+  }
+
+  /**
+   * Retrieves the election key (used for auth) for the current election. This
+   * method is faster than than {@link getElectionRecord} and thus more appropriate
+   * for use during auth polling.
+   */
+  getElectionKey(): ElectionKey | undefined {
+    const result = this.client.one(
+      `
+      select
+        election_data ->> 'id' as id,
+        election_data ->> 'date' as date
+      from election
+      `
+    ) as { id: string; date: string } | undefined;
+    return (
+      result && {
+        id: result.id as ElectionId,
+        date: new DateWithoutTime(result.date),
       }
     );
   }

--- a/apps/mark-scan/backend/src/util/auth.ts
+++ b/apps/mark-scan/backend/src/util/auth.ts
@@ -11,10 +11,7 @@ import {
   isFeatureFlagEnabled,
   isIntegrationTest,
 } from '@votingworks/utils';
-import {
-  DEFAULT_SYSTEM_SETTINGS,
-  constructElectionKey,
-} from '@votingworks/types';
+import { DEFAULT_SYSTEM_SETTINGS } from '@votingworks/types';
 import { Workspace } from './workspace';
 
 export function getDefaultAuth(logger: BaseLogger): InsertedSmartCardAuth {
@@ -32,15 +29,13 @@ export function getDefaultAuth(logger: BaseLogger): InsertedSmartCardAuth {
 export function constructAuthMachineState(
   workspace: Workspace
 ): InsertedSmartCardAuthMachineState {
-  const electionRecord = workspace.store.getElectionRecord();
+  const electionKey = workspace.store.getElectionKey();
   const jurisdiction = workspace.store.getJurisdiction();
   const systemSettings =
     workspace.store.getSystemSettings() ?? DEFAULT_SYSTEM_SETTINGS;
   return {
     ...systemSettings.auth,
-    electionKey:
-      electionRecord &&
-      constructElectionKey(electionRecord.electionDefinition.election),
+    electionKey,
     jurisdiction,
   };
 }

--- a/apps/mark/backend/src/store.ts
+++ b/apps/mark/backend/src/store.ts
@@ -3,7 +3,7 @@
 //
 
 import { UiStringsStore, createUiStringStore } from '@votingworks/backend';
-import { Optional } from '@votingworks/basics';
+import { DateWithoutTime, Optional } from '@votingworks/basics';
 import { Client as DbClient } from '@votingworks/db';
 import {
   ElectionDefinition,
@@ -16,6 +16,8 @@ import {
   PollsState,
   safeParse,
   PollsStateSchema,
+  ElectionId,
+  ElectionKey,
 } from '@votingworks/types';
 import { join } from 'path';
 
@@ -102,6 +104,28 @@ export class Store {
           electionRow.electionData
         ).unsafeUnwrap(),
         electionPackageHash: electionRow.electionPackageHash,
+      }
+    );
+  }
+
+  /**
+   * Retrieves the election key (used for auth) for the current election. This
+   * method is faster than than {@link getElectionRecord} and thus more appropriate
+   * for use during auth polling.
+   */
+  getElectionKey(): ElectionKey | undefined {
+    const result = this.client.one(
+      `
+      select
+        election_data ->> 'id' as id,
+        election_data ->> 'date' as date
+      from election
+      `
+    ) as { id: string; date: string } | undefined;
+    return (
+      result && {
+        id: result.id as ElectionId,
+        date: new DateWithoutTime(result.date),
       }
     );
   }

--- a/apps/mark/backend/src/util/auth.ts
+++ b/apps/mark/backend/src/util/auth.ts
@@ -2,25 +2,20 @@ import {
   InsertedSmartCardAuthApi,
   InsertedSmartCardAuthMachineState,
 } from '@votingworks/auth';
-import {
-  DEFAULT_SYSTEM_SETTINGS,
-  constructElectionKey,
-} from '@votingworks/types';
+import { DEFAULT_SYSTEM_SETTINGS } from '@votingworks/types';
 import { LoggingUserRole } from '@votingworks/logging';
 import { Workspace } from './workspace';
 
 export function constructAuthMachineState(
   workspace: Workspace
 ): InsertedSmartCardAuthMachineState {
-  const electionRecord = workspace.store.getElectionRecord();
+  const electionKey = workspace.store.getElectionKey();
   const jurisdiction = workspace.store.getJurisdiction();
   const systemSettings =
     workspace.store.getSystemSettings() ?? DEFAULT_SYSTEM_SETTINGS;
   return {
     ...systemSettings.auth,
-    electionKey:
-      electionRecord &&
-      constructElectionKey(electionRecord.electionDefinition.election),
+    electionKey,
     jurisdiction,
   };
 }

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -27,8 +27,16 @@ import {
   PollsTransitionType,
   DiagnosticRecord,
   DiagnosticType,
+  ElectionKey,
+  ElectionId,
 } from '@votingworks/types';
-import { assert, assertDefined, Optional, typedAs } from '@votingworks/basics';
+import {
+  assert,
+  assertDefined,
+  DateWithoutTime,
+  Optional,
+  typedAs,
+} from '@votingworks/basics';
 import { DateTime } from 'luxon';
 import { join } from 'path';
 import { v4 as uuid } from 'uuid';
@@ -215,6 +223,28 @@ export class Store {
           electionRow.electionData
         ).unsafeUnwrap(),
         electionPackageHash: electionRow.electionPackageHash,
+      }
+    );
+  }
+
+  /**
+   * Retrieves the election key (used for auth) for the current election. This
+   * method is faster than than {@link getElectionRecord} and thus more appropriate
+   * for use during auth polling.
+   */
+  getElectionKey(): ElectionKey | undefined {
+    const result = this.client.one(
+      `
+      select
+        election_data ->> 'id' as id,
+        election_data ->> 'date' as date
+      from election
+      `
+    ) as { id: string; date: string } | undefined;
+    return (
+      result && {
+        id: result.id as ElectionId,
+        date: new DateWithoutTime(result.date),
       }
     );
   }

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -29,6 +29,7 @@ import {
   DiagnosticType,
   ElectionKey,
   ElectionId,
+  constructElectionKey,
 } from '@votingworks/types';
 import {
   assert,
@@ -240,7 +241,19 @@ export class Store {
         election_data ->> 'date' as date
       from election
       `
-    ) as { id: string; date: string } | undefined;
+    ) as { id?: string; date?: string } | undefined;
+
+    if (!result) return undefined;
+
+    // The election might be in CDF, in which case, we won't get `id` and `date`
+    // fields, so just load and parse it to construct the key. We don't need to
+    // optimize speed for CDF.
+    if (!(result.id && result.date)) {
+      return constructElectionKey(
+        assertDefined(this.getElectionRecord()).electionDefinition.election
+      );
+    }
+
     return (
       result && {
         id: result.id as ElectionId,

--- a/apps/scan/backend/src/util/auth.ts
+++ b/apps/scan/backend/src/util/auth.ts
@@ -2,10 +2,7 @@ import {
   InsertedSmartCardAuthApi,
   InsertedSmartCardAuthMachineState,
 } from '@votingworks/auth';
-import {
-  DEFAULT_SYSTEM_SETTINGS,
-  constructElectionKey,
-} from '@votingworks/types';
+import { DEFAULT_SYSTEM_SETTINGS } from '@votingworks/types';
 import { LoggingUserRole } from '@votingworks/logging';
 import { Store } from '../store';
 import { Workspace } from './workspace';
@@ -13,14 +10,12 @@ import { Workspace } from './workspace';
 export function constructAuthMachineState(
   store: Store
 ): InsertedSmartCardAuthMachineState {
-  const electionRecord = store.getElectionRecord();
+  const electionKey = store.getElectionKey();
   const jurisdiction = store.getJurisdiction();
   const systemSettings = store.getSystemSettings() ?? DEFAULT_SYSTEM_SETTINGS;
   return {
     ...systemSettings.auth,
-    electionKey:
-      electionRecord &&
-      constructElectionKey(electionRecord.electionDefinition.election),
+    electionKey,
     jurisdiction,
   };
 }


### PR DESCRIPTION
## Overview

Fixes #4790 

During scale testing with a large election definition, I noticed that auth polling was very slow due to loading the election definition from the database on every polling request. This caused the entire app to lag.

To fix this, I changed the auth polling to extract only the relevant fields for the election key (id and date) from the JSON at the database level.

## Demo Video or Screenshot
Before

https://github.com/user-attachments/assets/5859693d-b25c-4959-bdb6-f5572ded0fd3

After

https://github.com/user-attachments/assets/087eb45d-d86b-4f42-8838-ece523939fe7



## Testing Plan
Manual testing

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
