### PR TITLE
Launch a single Chromium instance on VxMark startup for BMDB printing

### DIFF
--- a/apps/mark-scan/backend/src/app.preprinted_ballot_insertion.test.ts
+++ b/apps/mark-scan/backend/src/app.preprinted_ballot_insertion.test.ts
@@ -3,7 +3,7 @@ import tmp from 'tmp';
 import { buildMockInsertedSmartCardAuth } from '@votingworks/auth';
 import { createMockUsbDrive } from '@votingworks/usb-drive';
 import { typedAs } from '@votingworks/basics';
-import { Browser, launchChromium } from '@votingworks/printing';
+import { Browser, launchBrowser } from '@votingworks/printing';
 
 import { Store } from './store';
 import { createWorkspace } from './util/workspace';
@@ -18,14 +18,14 @@ function getMockStateMachine() {
   }) as unknown as jest.Mocked<PaperHandlerStateMachine>;
 }
 
-let chromium: Browser;
+let browser: Browser;
 
 beforeEach(async () => {
-  chromium = await launchChromium();
+  browser = await launchBrowser();
 });
 
 afterEach(async () => {
-  await chromium.close();
+  await browser.close();
 });
 
 function buildTestApi() {
@@ -39,7 +39,7 @@ function buildTestApi() {
     createMockUsbDrive().usbDrive,
     buildMockLogger(mockAuth, workspace),
     workspace,
-    chromium,
+    browser,
     mockStateMachine
   );
 

--- a/apps/mark-scan/backend/src/app.preprinted_ballot_insertion.test.ts
+++ b/apps/mark-scan/backend/src/app.preprinted_ballot_insertion.test.ts
@@ -3,6 +3,7 @@ import tmp from 'tmp';
 import { buildMockInsertedSmartCardAuth } from '@votingworks/auth';
 import { createMockUsbDrive } from '@votingworks/usb-drive';
 import { typedAs } from '@votingworks/basics';
+import { Browser, launchChromium } from '@votingworks/printing';
 
 import { Store } from './store';
 import { createWorkspace } from './util/workspace';
@@ -17,6 +18,16 @@ function getMockStateMachine() {
   }) as unknown as jest.Mocked<PaperHandlerStateMachine>;
 }
 
+let chromium: Browser;
+
+beforeEach(async () => {
+  chromium = await launchChromium();
+});
+
+afterEach(async () => {
+  await chromium.close();
+});
+
 function buildTestApi() {
   const store = Store.memoryStore();
   const workspace = createWorkspace(tmp.dirSync().name, { store });
@@ -28,6 +39,7 @@ function buildTestApi() {
     createMockUsbDrive().usbDrive,
     buildMockLogger(mockAuth, workspace),
     workspace,
+    chromium,
     mockStateMachine
   );
 

--- a/apps/mark-scan/backend/src/app.test.ts
+++ b/apps/mark-scan/backend/src/app.test.ts
@@ -79,7 +79,7 @@ let stateMachine: PaperHandlerStateMachine;
 let driver: MockPaperHandlerDriver;
 let patConnectionStatusReader: PatConnectionStatusReader;
 let logger: Logger;
-let chromium: Browser;
+let browser: Browser;
 
 beforeEach(async () => {
   featureFlagMock.enableFeatureFlag(
@@ -113,13 +113,13 @@ beforeEach(async () => {
   server = result.server;
   stateMachine = result.stateMachine;
   driver = result.driver;
-  chromium = result.chromium;
+  browser = result.browser;
 });
 
 afterEach(async () => {
   featureFlagMock.resetFeatureFlags();
   await stateMachine.cleanUp();
-  await chromium.close();
+  await browser.close();
   server.close();
 });
 
@@ -630,7 +630,7 @@ test('startPaperHandlerDiagnostic fails test if no state machine', async () => {
     logger,
     workspace,
     mockUsbDrive.usbDrive,
-    chromium
+    browser
   );
   const serverNoStateMachine = app.listen();
   const { port } = serverNoStateMachine.address() as AddressInfo;

--- a/apps/mark-scan/backend/src/app.test.ts
+++ b/apps/mark-scan/backend/src/app.test.ts
@@ -37,6 +37,7 @@ import {
 import { MockUsbDrive } from '@votingworks/usb-drive';
 import { MockPaperHandlerDriver } from '@votingworks/custom-paper-handler';
 import { LogEventId, Logger } from '@votingworks/logging';
+import { Browser } from '@votingworks/printing';
 import { AddressInfo } from 'net';
 import {
   createApp,
@@ -78,6 +79,7 @@ let stateMachine: PaperHandlerStateMachine;
 let driver: MockPaperHandlerDriver;
 let patConnectionStatusReader: PatConnectionStatusReader;
 let logger: Logger;
+let chromium: Browser;
 
 beforeEach(async () => {
   featureFlagMock.enableFeatureFlag(
@@ -111,12 +113,14 @@ beforeEach(async () => {
   server = result.server;
   stateMachine = result.stateMachine;
   driver = result.driver;
+  chromium = result.chromium;
 });
 
 afterEach(async () => {
   featureFlagMock.resetFeatureFlags();
   await stateMachine.cleanUp();
-  server?.close();
+  await chromium.close();
+  server.close();
 });
 
 async function waitForStatus(status: string): Promise<void> {
@@ -621,7 +625,13 @@ test('addDiagnosticRecord', async () => {
 
 test('startPaperHandlerDiagnostic fails test if no state machine', async () => {
   const workspace = createWorkspace(tmp.dirSync().name);
-  const app = buildApp(mockAuth, logger, workspace, mockUsbDrive.usbDrive);
+  const app = buildApp(
+    mockAuth,
+    logger,
+    workspace,
+    mockUsbDrive.usbDrive,
+    chromium
+  );
   const serverNoStateMachine = app.listen();
   const { port } = serverNoStateMachine.address() as AddressInfo;
   const baseUrl = `http://localhost:${port}/api`;

--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -81,7 +81,7 @@ export function buildApi(
   usbDrive: UsbDrive,
   logger: Logger,
   workspace: Workspace,
-  chromium: Browser,
+  browser: Browser,
   stateMachine?: PaperHandlerStateMachine,
   paperHandler?: PaperHandlerDriverInterface
 ) {
@@ -234,7 +234,7 @@ export function buildApi(
 
       const pdfData = await renderBallot({
         store,
-        chromium,
+        browser,
         ...input,
       });
       stateMachine.printBallot(pdfData);
@@ -449,7 +449,7 @@ export function buildApp(
   logger: Logger,
   workspace: Workspace,
   usbDrive: UsbDrive,
-  chromium: Browser,
+  browser: Browser,
   stateMachine?: PaperHandlerStateMachine,
   paperHandler?: PaperHandlerDriverInterface
 ): Application {
@@ -459,7 +459,7 @@ export function buildApp(
     usbDrive,
     logger,
     workspace,
-    chromium,
+    browser,
     stateMachine,
     paperHandler
   );

--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -46,6 +46,7 @@ import {
   MockPaperHandlerStatus,
   PaperHandlerDriverInterface,
 } from '@votingworks/custom-paper-handler';
+import { Browser } from '@votingworks/printing';
 import { getMachineConfig } from './machine_config';
 import { Workspace } from './util/workspace';
 import {
@@ -80,6 +81,7 @@ export function buildApi(
   usbDrive: UsbDrive,
   logger: Logger,
   workspace: Workspace,
+  chromium: Browser,
   stateMachine?: PaperHandlerStateMachine,
   paperHandler?: PaperHandlerDriverInterface
 ) {
@@ -232,6 +234,7 @@ export function buildApi(
 
       const pdfData = await renderBallot({
         store,
+        chromium,
         ...input,
       });
       stateMachine.printBallot(pdfData);
@@ -446,6 +449,7 @@ export function buildApp(
   logger: Logger,
   workspace: Workspace,
   usbDrive: UsbDrive,
+  chromium: Browser,
   stateMachine?: PaperHandlerStateMachine,
   paperHandler?: PaperHandlerDriverInterface
 ): Application {
@@ -455,6 +459,7 @@ export function buildApp(
     usbDrive,
     logger,
     workspace,
+    chromium,
     stateMachine,
     paperHandler
   );

--- a/apps/mark-scan/backend/src/app.ui_strings.test.ts
+++ b/apps/mark-scan/backend/src/app.ui_strings.test.ts
@@ -38,9 +38,9 @@ const electionDefinition = safeParseElectionDefinition(
   JSON.stringify(testCdfBallotDefinition)
 ).unsafeUnwrap();
 
-// Chromium isn't needed for these tests, and we can't easily launch a real instance in this test
-// file using an async beforeEach and afterEach given how runUiStringApiTests is called
-const mockChromium = {} as unknown as Browser;
+// A headless browser isn't needed for these tests, and we can't easily launch a real instance in
+// this test file using an async beforeEach and afterEach given how runUiStringApiTests is called
+const mockBrowser = {} as unknown as Browser;
 
 afterEach(() => {
   workspace.reset();
@@ -52,7 +52,7 @@ runUiStringApiTests({
     createMockUsbDrive().usbDrive,
     buildMockLogger(mockAuth, workspace),
     workspace,
-    mockChromium
+    mockBrowser
   ),
   store: store.getUiStringsStore(),
 });
@@ -73,7 +73,7 @@ describe('configureElectionPackageFromUsb', () => {
       mockUsbDrive.usbDrive,
       buildMockLogger(mockAuth, workspace),
       workspace,
-      mockChromium
+      mockBrowser
     );
 
     mockElectionManagerAuth(mockAuth, electionDefinition);
@@ -93,7 +93,7 @@ describe('unconfigureMachine', () => {
     createMockUsbDrive().usbDrive,
     buildMockLogger(mockAuth, workspace),
     workspace,
-    mockChromium
+    mockBrowser
   );
 
   runUiStringMachineDeconfigurationTests({

--- a/apps/mark-scan/backend/src/app.ui_strings.test.ts
+++ b/apps/mark-scan/backend/src/app.ui_strings.test.ts
@@ -15,6 +15,7 @@ import {
   getFeatureFlagMock,
 } from '@votingworks/utils';
 import { MockUsbDrive, createMockUsbDrive } from '@votingworks/usb-drive';
+import { Browser } from '@votingworks/printing';
 import { Store } from './store';
 import { createWorkspace } from './util/workspace';
 import { Api, buildApi } from './app';
@@ -37,6 +38,10 @@ const electionDefinition = safeParseElectionDefinition(
   JSON.stringify(testCdfBallotDefinition)
 ).unsafeUnwrap();
 
+// Chromium isn't needed for these tests, and we can't easily launch a real instance in this test
+// file using an async beforeEach and afterEach given how runUiStringApiTests is called
+const mockChromium = {} as unknown as Browser;
+
 afterEach(() => {
   workspace.reset();
 });
@@ -46,7 +51,8 @@ runUiStringApiTests({
     mockAuth,
     createMockUsbDrive().usbDrive,
     buildMockLogger(mockAuth, workspace),
-    workspace
+    workspace,
+    mockChromium
   ),
   store: store.getUiStringsStore(),
 });
@@ -67,7 +73,7 @@ describe('configureElectionPackageFromUsb', () => {
       mockUsbDrive.usbDrive,
       buildMockLogger(mockAuth, workspace),
       workspace,
-      undefined
+      mockChromium
     );
 
     mockElectionManagerAuth(mockAuth, electionDefinition);
@@ -87,7 +93,7 @@ describe('unconfigureMachine', () => {
     createMockUsbDrive().usbDrive,
     buildMockLogger(mockAuth, workspace),
     workspace,
-    undefined
+    mockChromium
   );
 
   runUiStringMachineDeconfigurationTests({

--- a/apps/mark-scan/backend/src/server.ts
+++ b/apps/mark-scan/backend/src/server.ts
@@ -13,6 +13,7 @@ import {
 } from '@votingworks/utils';
 import { detectUsbDrive } from '@votingworks/usb-drive';
 import { detectDevices, initializeSystemAudio } from '@votingworks/backend';
+import { launchChromium } from '@votingworks/printing';
 import { buildApp } from './app';
 import { Workspace } from './util/workspace';
 import { getPaperHandlerStateMachine } from './custom-paper-handler/state_machine';
@@ -114,6 +115,8 @@ export async function start({
 
   const usbDrive = detectUsbDrive(logger);
 
+  const chromium = await launchChromium();
+
   await initializeSystemAudio();
 
   const app = buildApp(
@@ -121,6 +124,7 @@ export async function start({
     logger,
     workspace,
     usbDrive,
+    chromium,
     stateMachine,
     driver
   );

--- a/apps/mark-scan/backend/src/server.ts
+++ b/apps/mark-scan/backend/src/server.ts
@@ -13,7 +13,7 @@ import {
 } from '@votingworks/utils';
 import { detectUsbDrive } from '@votingworks/usb-drive';
 import { detectDevices, initializeSystemAudio } from '@votingworks/backend';
-import { launchChromium } from '@votingworks/printing';
+import { launchBrowser } from '@votingworks/printing';
 import { buildApp } from './app';
 import { Workspace } from './util/workspace';
 import { getPaperHandlerStateMachine } from './custom-paper-handler/state_machine';
@@ -115,7 +115,7 @@ export async function start({
 
   const usbDrive = detectUsbDrive(logger);
 
-  const chromium = await launchChromium();
+  const browser = await launchBrowser();
 
   await initializeSystemAudio();
 
@@ -124,7 +124,7 @@ export async function start({
     logger,
     workspace,
     usbDrive,
-    chromium,
+    browser,
     stateMachine,
     driver
   );

--- a/apps/mark-scan/backend/src/util/render_ballot.tsx
+++ b/apps/mark-scan/backend/src/util/render_ballot.tsx
@@ -23,7 +23,7 @@ import { getMarkScanBmdModel } from './hardware';
 
 export interface RenderBallotProps {
   store: Store;
-  chromium: Browser;
+  browser: Browser;
   precinctId: string;
   ballotStyleId: string;
   votes: VotesDict;
@@ -69,7 +69,7 @@ export async function renderTestModeBallotWithoutLanguageContext(
 
 export async function renderBallot({
   store,
-  chromium,
+  browser,
   precinctId,
   ballotStyleId,
   votes,
@@ -101,6 +101,6 @@ export async function renderBallot({
       document: ballot,
       paperDimensions: getPaperDimensions(),
     },
-    chromium
+    browser
   );
 }

--- a/apps/mark-scan/backend/src/util/render_ballot.tsx
+++ b/apps/mark-scan/backend/src/util/render_ballot.tsx
@@ -1,4 +1,5 @@
 import {
+  Browser,
   PAPER_DIMENSIONS,
   PaperDimensions,
   renderToPdf,
@@ -22,6 +23,7 @@ import { getMarkScanBmdModel } from './hardware';
 
 export interface RenderBallotProps {
   store: Store;
+  chromium: Browser;
   precinctId: string;
   ballotStyleId: string;
   votes: VotesDict;
@@ -67,6 +69,7 @@ export async function renderTestModeBallotWithoutLanguageContext(
 
 export async function renderBallot({
   store,
+  chromium,
   precinctId,
   ballotStyleId,
   votes,
@@ -93,8 +96,11 @@ export async function renderBallot({
     </BackendLanguageContextProvider>
   );
 
-  return renderToPdf({
-    document: ballot,
-    paperDimensions: getPaperDimensions(),
-  });
+  return renderToPdf(
+    {
+      document: ballot,
+      paperDimensions: getPaperDimensions(),
+    },
+    chromium
+  );
 }

--- a/apps/mark-scan/backend/test/app_helpers.ts
+++ b/apps/mark-scan/backend/test/app_helpers.ts
@@ -30,6 +30,7 @@ import {
 import { MockPaperHandlerDriver } from '@votingworks/custom-paper-handler';
 import { assert } from '@votingworks/basics';
 import { createMockUsbDrive, MockUsbDrive } from '@votingworks/usb-drive';
+import { Browser, launchChromium } from '@votingworks/printing';
 import { Api, buildApp } from '../src/app';
 import { createWorkspace, Workspace } from '../src/util/workspace';
 import {
@@ -90,6 +91,7 @@ interface MockAppContents {
   stateMachine: PaperHandlerStateMachine;
   patConnectionStatusReader: PatConnectionStatusReaderInterface;
   driver: MockPaperHandlerDriver;
+  chromium: Browser;
 }
 
 export interface CreateAppOptions {
@@ -104,6 +106,7 @@ export async function createApp(
   const workspace = createWorkspace(tmp.dirSync().name);
   const logger = buildMockLogger(mockAuth, workspace);
   const mockUsbDrive = createMockUsbDrive();
+  const chromium = await launchChromium();
   const patConnectionStatusReader =
     options?.patConnectionStatusReader ??
     new MockPatConnectionStatusReader(logger);
@@ -123,6 +126,7 @@ export async function createApp(
     logger,
     workspace,
     mockUsbDrive.usbDrive,
+    chromium,
     stateMachine
   );
 
@@ -142,6 +146,7 @@ export async function createApp(
     stateMachine,
     patConnectionStatusReader,
     driver,
+    chromium,
   };
 }
 

--- a/apps/mark-scan/backend/test/app_helpers.ts
+++ b/apps/mark-scan/backend/test/app_helpers.ts
@@ -30,7 +30,7 @@ import {
 import { MockPaperHandlerDriver } from '@votingworks/custom-paper-handler';
 import { assert } from '@votingworks/basics';
 import { createMockUsbDrive, MockUsbDrive } from '@votingworks/usb-drive';
-import { Browser, launchChromium } from '@votingworks/printing';
+import { Browser, launchBrowser } from '@votingworks/printing';
 import { Api, buildApp } from '../src/app';
 import { createWorkspace, Workspace } from '../src/util/workspace';
 import {
@@ -91,7 +91,7 @@ interface MockAppContents {
   stateMachine: PaperHandlerStateMachine;
   patConnectionStatusReader: PatConnectionStatusReaderInterface;
   driver: MockPaperHandlerDriver;
-  chromium: Browser;
+  browser: Browser;
 }
 
 export interface CreateAppOptions {
@@ -106,7 +106,7 @@ export async function createApp(
   const workspace = createWorkspace(tmp.dirSync().name);
   const logger = buildMockLogger(mockAuth, workspace);
   const mockUsbDrive = createMockUsbDrive();
-  const chromium = await launchChromium();
+  const browser = await launchBrowser();
   const patConnectionStatusReader =
     options?.patConnectionStatusReader ??
     new MockPatConnectionStatusReader(logger);
@@ -126,7 +126,7 @@ export async function createApp(
     logger,
     workspace,
     mockUsbDrive.usbDrive,
-    chromium,
+    browser,
     stateMachine
   );
 
@@ -146,7 +146,7 @@ export async function createApp(
     stateMachine,
     patConnectionStatusReader,
     driver,
-    chromium,
+    browser,
   };
 }
 

--- a/libs/printing/src/index.ts
+++ b/libs/printing/src/index.ts
@@ -1,2 +1,3 @@
+export type { Browser } from 'playwright';
 export * from './printer';
 export * from './render';

--- a/libs/printing/src/render.tsx
+++ b/libs/printing/src/render.tsx
@@ -61,7 +61,7 @@ function getContentHeight(page: Page): Promise<number> {
   });
 }
 
-export async function launchChromium(): Promise<Browser> {
+export async function launchBrowser(): Promise<Browser> {
   return await chromium.launch({
     // Font hinting (https://fonts.google.com/knowledge/glossary/hinting) is on by default, but
     // causes fonts to render awkwardly at higher resolutions, so we disable it
@@ -92,7 +92,7 @@ export async function renderToPdf(
 ): Promise<Buffer | Buffer[]> {
   const specs = Array.isArray(spec) ? spec : [spec];
 
-  const browser = browserOverride ?? (await launchChromium());
+  const browser = browserOverride ?? (await launchBrowser());
   const context = await browser.newContext();
   const page = await context.newPage();
 

--- a/libs/printing/src/render.tsx
+++ b/libs/printing/src/render.tsx
@@ -61,6 +61,15 @@ function getContentHeight(page: Page): Promise<number> {
   });
 }
 
+export async function launchChromium(): Promise<Browser> {
+  return await chromium.launch({
+    // Font hinting (https://fonts.google.com/knowledge/glossary/hinting) is on by default, but
+    // causes fonts to render awkwardly at higher resolutions, so we disable it
+    args: ['--font-render-hinting=none'],
+    executablePath: OPTIONAL_EXECUTABLE_PATH_OVERRIDE,
+  });
+}
+
 export interface RenderSpec {
   document: JSX.Element | JSX.Element[];
   paperDimensions?: PaperDimensions;
@@ -83,15 +92,7 @@ export async function renderToPdf(
 ): Promise<Buffer | Buffer[]> {
   const specs = Array.isArray(spec) ? spec : [spec];
 
-  const browser =
-    browserOverride ||
-    (await chromium.launch({
-      // font hinting (https://fonts.google.com/knowledge/glossary/hinting)
-      // is on by default, but causes fonts to render more awkwardly at higher
-      // resolutions, so we disable it
-      args: ['--font-render-hinting=none'],
-      executablePath: OPTIONAL_EXECUTABLE_PATH_OVERRIDE,
-    }));
+  const browser = browserOverride ?? (await launchChromium());
   const context = await browser.newContext();
   const page = await context.newPage();
 


### PR DESCRIPTION
## Overview

This PR should address https://github.com/votingworks/vxsuite/issues/5245 per my testing. After considering a few explanations that turned out to be red herrings, we ultimately found that printing sporadically stalling in production involved the Chromium `newPage` call hanging:

https://github.com/votingworks/vxsuite/blob/034edbcc5e89f33397961c7e88636af51385b81f/libs/printing/src/render.tsx#L96

We found [this relevant Playwright issue](https://github.com/microsoft/playwright/issues/3939). The poster notes that they're constantly launching new Chromium instances, like we are, and saw the issue go away after switching to a single persisted instance (among other changes). We, too, have been wanting to shift away from launching and closing a new Chromium instance every time we print, primarily for speed gains. But now we have another reason. The exact reason why repeatedly launching and closing new Chromium instances has this effect is still a bit unclear, maybe something to do with memory usage.

## Testing Plan

With this change (hackily) applied to two production 150s, I've not been able to repro print stalling across 40 prints (30 on one machine, 10 on the other). I was definitely reproing this more often than once every 40 prints before so feeling optimistic that this will do the trick.