### PR TITLE
VxCentralScan/VxAdmin: Move session timer from header to banner

### DIFF
--- a/apps/admin/frontend/src/components/navigation_screen.tsx
+++ b/apps/admin/frontend/src/components/navigation_screen.tsx
@@ -116,6 +116,7 @@ export function NavigationScreen({
     <Screen flexDirection="row">
       <Sidebar navItems={getNavItems(auth, election)} />
       <Main flexColumn>
+        <SessionTimeLimitTimer authStatus={auth} />
         <Header>
           <div>
             {title && (
@@ -131,7 +132,6 @@ export function NavigationScreen({
             )}
           </div>
           <HeaderActions>
-            <SessionTimeLimitTimer authStatus={auth} />
             {(isSystemAdministratorAuth(auth) ||
               isElectionManagerAuth(auth)) && (
               <React.Fragment>

--- a/apps/central-scan/frontend/src/navigation_screen.tsx
+++ b/apps/central-scan/frontend/src/navigation_screen.tsx
@@ -140,6 +140,7 @@ export function NavigationScreen({ children, title }: Props): JSX.Element {
         )}
       </LeftNav>
       <Main flexColumn>
+        <SessionTimeLimitTimer authStatus={auth} />
         <Header>
           <H1>{title}</H1>
           {isTestMode && isElectionManagerAuth(auth) && electionDefinition && (
@@ -148,7 +149,6 @@ export function NavigationScreen({ children, title }: Props): JSX.Element {
             </TestModeCallout>
           )}
           <HeaderActions>
-            <SessionTimeLimitTimer authStatus={auth} />
             {(isSystemAdministratorAuth(auth) ||
               isElectionManagerAuth(auth)) && (
               <React.Fragment>

--- a/libs/ui/src/session_time_limit_tracker.tsx
+++ b/libs/ui/src/session_time_limit_tracker.tsx
@@ -9,12 +9,14 @@ import {
   SystemSettings,
 } from '@votingworks/types';
 
+import styled from 'styled-components';
 import { Button } from './button';
 import { useNow } from './hooks/use_now';
 import { Modal } from './modal';
 import { Prose } from './prose';
 import { Timer } from './timer';
-import { Caption, H1, P } from './typography';
+import { H1, P } from './typography';
+import { Card } from './card';
 
 const SECONDS_TO_WRAP_UP_AFTER_INACTIVE_SESSION_TIME_LIMIT = 60;
 const SECONDS_AHEAD_OF_OVERALL_SESSION_TIME_LIMIT_TO_WARN = 15 * 60;
@@ -189,6 +191,16 @@ interface SessionTimeLimitTimerProps {
     | InsertedSmartCardAuth.AuthStatus;
 }
 
+const TimerCallout = styled(Card).attrs({ color: 'warning' })`
+  border-radius: 0;
+  border-left: none;
+  border-right: none;
+
+  > div {
+    padding: 0.5rem;
+  }
+`;
+
 /**
  * Displays a count down timer to session expiry. Appears at the same time as the prompts surfaced
  * by SessionTimeLimitTracker.
@@ -203,10 +215,10 @@ export function SessionTimeLimitTimer({
   }
   if (shouldDisplayTimeLimitPrompt(authStatus, now)) {
     return (
-      <span>
-        <Caption>Machine will automatically lock in</Caption>{' '}
+      <TimerCallout>
+        Machine will automatically lock in{' '}
         <Timer countDownTo={new Date(authStatus.sessionExpiresAt)} />
-      </span>
+      </TimerCallout>
     );
   }
   return null;

--- a/libs/ui/src/session_time_limit_tracker.tsx
+++ b/libs/ui/src/session_time_limit_tracker.tsx
@@ -13,7 +13,6 @@ import styled from 'styled-components';
 import { Button } from './button';
 import { useNow } from './hooks/use_now';
 import { Modal } from './modal';
-import { Prose } from './prose';
 import { Timer } from './timer';
 import { H1, P } from './typography';
 import { Card } from './card';
@@ -109,14 +108,13 @@ function SessionTimeLimitTrackerHelper({
           </React.Fragment>
         }
         content={
-          <Prose textCenter>
+          <React.Fragment>
             <H1>Session Time Limit</H1>
             {hasInactiveSessionTimeLimitBeenHit ? (
               // Inactive session time limit
               <P>
                 Your session has been inactive for{' '}
                 {pluralize('minutes', inactiveSessionTimeLimitMinutes, true)}.
-                <br />
                 The machine will automatically lock in{' '}
                 <Timer countDownTo={new Date(authStatus.sessionExpiresAt)} />.
               </P>
@@ -124,18 +122,16 @@ function SessionTimeLimitTrackerHelper({
               // Overall session time limit
               <P>
                 You are approaching the session time limit of{' '}
-                {pluralize('hours', overallSessionTimeLimitHours, true)}.
-                <br />
-                The machine will automatically lock in{' '}
+                {pluralize('hours', overallSessionTimeLimitHours, true)}. The
+                machine will automatically lock in{' '}
                 <Timer countDownTo={new Date(authStatus.sessionExpiresAt)} />.
               </P>
             )}
             <P>
-              Lock the machine now and reauthenticate
-              <br />
-              with your smart card to continue working.
+              Lock the machine now and reauthenticate with your smart card to
+              continue working.
             </P>
-          </Prose>
+          </React.Fragment>
         }
       />
     );


### PR DESCRIPTION

## Overview

Fixes #5152 

The header is too crowded, so when the timer shows up, it causes weird wrapping. To fix this, we move the timer to its own banner. While we're at it, give it warning styling, since it is a warning.

I also polished the session limit modal to have left aligned text.

## Demo Video or Screenshot
VxCentralScan before
![Screenshot-VxCentralScan-2024-08-15T00:11:07 190Z](https://github.com/user-attachments/assets/a1ee7dce-0337-484c-8639-9d08dc15e528)

VxCentralScan after
![Screenshot-VxCentralScan-2024-08-15T00:12:29 320Z](https://github.com/user-attachments/assets/b8ec9cc7-bb2a-4f7f-a5d1-924b34c5fa75)



VxAdmin before
![Screenshot-VxAdmin-2024-08-15T00:10:23 888Z](https://github.com/user-attachments/assets/9b3f1a0f-0b03-437a-a46a-6b87adf32a8b)



VxAdmin after
![Screenshot-VxAdmin-2024-08-15T00:08:31 929Z](https://github.com/user-attachments/assets/a7c4d935-2925-4664-b283-1c61034246c7)


Modal before
![Screenshot-VxAdmin-2024-08-15T00:10:18 304Z](https://github.com/user-attachments/assets/ba1c478e-6c6a-408e-b9c5-1d32885e6036)


Modal after
![Screenshot-VxAdmin-2024-08-15T00:07:57 317Z](https://github.com/user-attachments/assets/1e2a2f3d-973a-42e9-bd5b-26a36b8d573c)

## Testing Plan
Manual testing

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
