### PR TITLE
refactor(image-utils): remove `main` export

### DIFF
--- a/libs/image-utils/jest.config.js
+++ b/libs/image-utils/jest.config.js
@@ -5,5 +5,8 @@ const shared = require('../../jest.config.shared');
  */
 module.exports = {
   ...shared,
-  coveragePathIgnorePatterns: ['src/jest_pdf_snapshot.ts'],
+  coveragePathIgnorePatterns: [
+    'src/jest_pdf_snapshot.ts',
+    'src/cli/pdf_to_images.ts',
+  ],
 };

--- a/libs/image-utils/src/cli/pdf_to_images.ts
+++ b/libs/image-utils/src/cli/pdf_to_images.ts
@@ -1,0 +1,33 @@
+import { assertDefined } from '@votingworks/basics';
+import { promises as fs } from 'fs';
+import { basename, dirname, extname, join } from 'path';
+import { writeImageData } from '../image_data';
+import { pdfToImages } from '..';
+
+/**
+ * Reads a PDF file at the given path and writes a series of image files - one
+ * for each page. If the PDF file is named `ballot.pdf`, then the image files
+ * will be named `ballot-p1.jpg`, `ballot-p2.jpg`, etc. The images are 200 DPI
+ * JPGs.
+ */
+/* istanbul ignore next */
+export async function main(
+  argv: string[],
+  { stderr }: { stderr: NodeJS.WritableStream }
+): Promise<number> {
+  if (argv.length !== 1) {
+    stderr.write('Usage: pdf-to-images PDF_PATH\n');
+    return 1;
+  }
+  const pdfPath = assertDefined(argv[0]);
+  const pdf = await fs.readFile(pdfPath);
+  const dir = dirname(pdfPath);
+  const base = basename(pdfPath, extname(pdfPath));
+  for await (const { page, pageNumber } of pdfToImages(pdf, {
+    scale: 200 / 72,
+  })) {
+    const path = join(dir, `${base}-p${pageNumber}.jpg`);
+    await writeImageData(path, page);
+  }
+  return 0;
+}

--- a/libs/image-utils/src/pdf_to_images.ts
+++ b/libs/image-utils/src/pdf_to_images.ts
@@ -1,10 +1,7 @@
-import { assert, assertDefined } from '@votingworks/basics';
+import { assert } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 import { Canvas, createCanvas } from 'canvas';
-import { promises as fs } from 'fs';
-import { basename, dirname, extname, join } from 'path';
-import { CanvasFactory, getDocument, GlobalWorkerOptions } from 'pdfjs-dist';
-import { writeImageData } from './image_data';
+import { CanvasFactory, GlobalWorkerOptions, getDocument } from 'pdfjs-dist';
 
 // Extend `pdfjs-dist`'s `render` function to include `canvasFactory`.
 declare module 'pdfjs-dist' {
@@ -115,32 +112,4 @@ export async function* pdfToImages(
 export function setPdfRenderWorkerSrc(workerSrc: string): void {
   // See `setupProxy.js` for more details.
   GlobalWorkerOptions.workerSrc = workerSrc;
-}
-
-/**
- * Reads a PDF file at the given path and writes a series of image files - one
- * for each page. If the PDF file is named `ballot.pdf`, then the image files
- * will be named `ballot-p1.jpg`, `ballot-p2.jpg`, etc. The images are 200 DPI
- * JPGs.
- */
-/* istanbul ignore next */
-export async function main(
-  argv: string[],
-  { stderr }: { stderr: NodeJS.WritableStream }
-): Promise<number> {
-  if (argv.length !== 1) {
-    stderr.write('Usage: pdf-to-images PDF_PATH\n');
-    return 1;
-  }
-  const pdfPath = assertDefined(argv[0]);
-  const pdf = await fs.readFile(pdfPath);
-  const dir = dirname(pdfPath);
-  const base = basename(pdfPath, extname(pdfPath));
-  for await (const { page, pageNumber } of pdfToImages(pdf, {
-    scale: 200 / 72,
-  })) {
-    const path = join(dir, `${base}-p${pageNumber}.jpg`);
-    await writeImageData(path, page);
-  }
-  return 0;
 }


### PR DESCRIPTION
We don't actually want this exported from the library.
