### PR TITLE
[Mark] Enable scrolling with PAT devices on long ballot measures

### DIFF
--- a/apps/mark/integration-testing/e2e/scroll_buttons.spec.ts
+++ b/apps/mark/integration-testing/e2e/scroll_buttons.spec.ts
@@ -25,6 +25,10 @@ test.beforeEach(async ({ page }) => {
   await forceReset(page);
 });
 
+// TODO(https://github.com/votingworks/vxsuite/issues/4900): Add a mock PAT
+// device to the backend, so we can test PAT scrolling on long yes/no contests.
+// We'd probably need to port this test over to `mark-scan` to do that.
+
 test('configure, open polls, and test contest scroll buttons', async ({
   page,
 }) => {

--- a/libs/mark-flow-ui/src/components/yes_no_contest.tsx
+++ b/libs/mark-flow-ui/src/components/yes_no_contest.tsx
@@ -20,6 +20,7 @@ import {
   AssistiveTechInstructions,
   Pre,
   PageNavigationButtonId,
+  useIsPatDeviceConnected,
 } from '@votingworks/ui';
 
 import { getSingleYesNoVote } from '@votingworks/utils';
@@ -49,6 +50,8 @@ export function YesNoContest({
   const [overvoteSelection, setOvervoteSelection] =
     useState<Optional<YesNoContestOptionId>>();
   const [deselectedVote, setDeselectedVote] = useState('');
+
+  const isPatDeviceConnected = useIsPatDeviceConnected();
 
   useEffect(() => {
     if (deselectedVote !== '') {
@@ -92,7 +95,7 @@ export function YesNoContest({
             </AudioOnly>
           </Caption>
         </ContestHeader>
-        <WithScrollButtons>
+        <WithScrollButtons focusable={isPatDeviceConnected}>
           <Caption>{electionStrings.contestDescription(contest, Pre)}</Caption>
         </WithScrollButtons>
         <ContestFooter>

--- a/libs/ui/src/with_scroll_buttons.tsx
+++ b/libs/ui/src/with_scroll_buttons.tsx
@@ -12,6 +12,7 @@ import { appStrings } from './ui_strings';
 
 export interface WithScrollButtonsProps {
   children: React.ReactNode;
+  focusable?: boolean;
   noPadding?: boolean;
 }
 
@@ -134,7 +135,7 @@ const BottomShadow = styled.div`
  * which has an explicit height/max height set.
  */
 export function WithScrollButtons(props: WithScrollButtonsProps): JSX.Element {
-  const { children, noPadding } = props;
+  const { children, focusable, noPadding } = props;
 
   const [canScrollUp, setCanScrollUp] = React.useState(false);
   const [canScrollDown, setCanScrollDown] = React.useState(false);
@@ -204,7 +205,7 @@ export function WithScrollButtons(props: WithScrollButtonsProps): JSX.Element {
             });
           }}
         >
-          <Controls aria-hidden>
+          <Controls aria-hidden={!focusable}>
             <Control
               disabled={!canScrollUp}
               onPress={onScrollUp}


### PR DESCRIPTION
## Overview

Fixes https://github.com/votingworks/vxsuite/issues/4900

When yes/no contest descriptions are long enough to overflow the available screen height, we show scroll buttons, but they are only accessible to touchscreen users. Tabbing over the scroll buttons was intentionally de-activated to avoid audio-only voters having to tab over them after listening to the contest description.

This change conditionally enables tab focus for the scroll buttons when a PAT device is connected.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/d8f77ceb-ebc9-45f2-a4d6-a244dca6973c

## Testing Plan
- Unit test for `YesNoContext` -> `WithScrollButtons` component interaction
- Manual test for actual focus/click behaviour with PAT inputs. Would like to add a browser integration test for this eventually; just a little more effort than necessary right now.

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
