### PR TITLE
VxScan: remove battery indicators

### DIFF
--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -54,7 +54,6 @@ beforeEach(() => {
 
   apiMock = createApiMock();
   apiMock.expectGetMachineConfig();
-  apiMock.setBatteryInfo();
   apiMock.removeCard(); // Set a default auth state of no card inserted.
 
   mockOf(VoterSettingsManager).mockReturnValue(null);

--- a/apps/scan/frontend/src/app_root.tsx
+++ b/apps/scan/frontend/src/app_root.tsx
@@ -29,7 +29,6 @@ import {
   getPollsInfo,
   getScannerStatus,
   getUsbDriveStatus,
-  systemCallApi,
 } from './api';
 import { VoterScreen } from './screens/voter_screen';
 import { LoginPromptScreen } from './screens/login_prompt_screen';
@@ -45,8 +44,6 @@ export function AppRoot(): JSX.Element | null {
   const usbDriveStatusQuery = getUsbDriveStatus.useQuery();
   const checkPinMutation = checkPin.useMutation();
 
-  const batteryInfoQuery = systemCallApi.getBatteryInfo.useQuery();
-
   const scannerStatusQuery = getScannerStatus.useQuery({
     refetchInterval: POLLING_INTERVAL_FOR_SCANNER_STATUS_MS,
   });
@@ -57,8 +54,7 @@ export function AppRoot(): JSX.Element | null {
       configQuery.isSuccess &&
       scannerStatusQuery.isSuccess &&
       usbDriveStatusQuery.isSuccess &&
-      pollsInfoQuery.isSuccess &&
-      batteryInfoQuery.isSuccess
+      pollsInfoQuery.isSuccess
     )
   ) {
     return <LoadingConfigurationScreen />;
@@ -75,8 +71,6 @@ export function AppRoot(): JSX.Element | null {
   } = configQuery.data;
   const scannerStatus = scannerStatusQuery.data;
   const usbDrive = usbDriveStatusQuery.data;
-  const batteryInfo = batteryInfoQuery.data;
-  const batteryIsCharging = batteryInfo ? !batteryInfo.discharging : true;
   const pollsInfo = pollsInfoQuery.data;
   const { pollsState } = pollsInfo;
 
@@ -142,10 +136,7 @@ export function AppRoot(): JSX.Element | null {
 
   if (scannerStatus.state === 'disconnected') {
     return (
-      <SetupScannerScreen
-        batteryIsCharging={batteryIsCharging}
-        scannedBallotCount={scannerStatus.ballotsCounted}
-      />
+      <SetupScannerScreen scannedBallotCount={scannerStatus.ballotsCounted} />
     );
   }
 
@@ -229,7 +220,6 @@ export function AppRoot(): JSX.Element | null {
       <PollsNotOpenScreen
         isLiveMode={!isTestMode}
         pollsState={pollsState}
-        showNoChargerWarning={!batteryIsCharging}
         scannedBallotCount={scannerStatus.ballotsCounted}
       />
     );
@@ -245,7 +235,6 @@ export function AppRoot(): JSX.Element | null {
       systemSettings={systemSettings}
       isTestMode={isTestMode}
       isSoundMuted={isSoundMuted}
-      batteryIsCharging={batteryIsCharging}
     />
   );
 }

--- a/apps/scan/frontend/src/screens/insert_ballot_screen.tsx
+++ b/apps/scan/frontend/src/screens/insert_ballot_screen.tsx
@@ -1,23 +1,15 @@
-import {
-  Caption,
-  Icons,
-  InsertBallotImage,
-  P,
-  appStrings,
-} from '@votingworks/ui';
+import { InsertBallotImage, P, appStrings } from '@votingworks/ui';
 import { Screen } from '../components/layout';
 import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout';
 
 interface Props {
   isLiveMode: boolean;
   scannedBallotCount: number;
-  showNoChargerWarning: boolean;
 }
 
 export function InsertBallotScreen({
   isLiveMode,
   scannedBallotCount,
-  showNoChargerWarning,
 }: Props): JSX.Element {
   return (
     <Screen
@@ -31,11 +23,6 @@ export function InsertBallotScreen({
         image={<InsertBallotImage ballotFeedLocation="top" />}
       >
         <P>{appStrings.instructionsScannerInsertBallotScreen()}</P>
-        {showNoChargerWarning && (
-          <Caption>
-            <Icons.Warning color="warning" /> {appStrings.warningNoPower()}
-          </Caption>
-        )}
       </FullScreenPromptLayout>
     </Screen>
   );
@@ -43,33 +30,10 @@ export function InsertBallotScreen({
 
 /* istanbul ignore next */
 export function ZeroBallotsScannedPreview(): JSX.Element {
-  return (
-    <InsertBallotScreen
-      scannedBallotCount={0}
-      isLiveMode
-      showNoChargerWarning={false}
-    />
-  );
+  return <InsertBallotScreen scannedBallotCount={0} isLiveMode />;
 }
 
 /* istanbul ignore next */
 export function ManyBallotsScannedPreview(): JSX.Element {
-  return (
-    <InsertBallotScreen
-      scannedBallotCount={1234}
-      isLiveMode
-      showNoChargerWarning={false}
-    />
-  );
-}
-
-/* istanbul ignore next */
-export function NoPowerConnectedTestModePreview(): JSX.Element {
-  return (
-    <InsertBallotScreen
-      isLiveMode={false}
-      scannedBallotCount={1234}
-      showNoChargerWarning
-    />
-  );
+  return <InsertBallotScreen scannedBallotCount={1234} isLiveMode />;
 }

--- a/apps/scan/frontend/src/screens/polls_not_open_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/polls_not_open_screen.test.tsx
@@ -34,7 +34,6 @@ function renderScreen(props: Partial<PollsNotOpenScreenProps> = {}) {
     provideApi(
       apiMock,
       <PollsNotOpenScreen
-        showNoChargerWarning={false}
         isLiveMode
         pollsState="polls_closed_initial"
         scannedBallotCount={TEST_BALLOT_COUNT}
@@ -64,11 +63,6 @@ describe('PollsNotOpenScreen', () => {
     expect(
       screen.queryByText('Insert a poll worker card to open polls.')
     ).not.toBeInTheDocument();
-  });
-
-  test('shows "No Power Detected" when called for', async () => {
-    renderScreen({ showNoChargerWarning: true });
-    await screen.findByText('No Power Detected.');
   });
 
   test('does not show "No Power Detected" when not called for', async () => {

--- a/apps/scan/frontend/src/screens/polls_not_open_screen.tsx
+++ b/apps/scan/frontend/src/screens/polls_not_open_screen.tsx
@@ -1,4 +1,4 @@
-import { Caption, FullScreenIconWrapper, Icons, P } from '@votingworks/ui';
+import { FullScreenIconWrapper, Icons, P } from '@votingworks/ui';
 import { PollsState } from '@votingworks/types';
 import { Screen } from '../components/layout';
 import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout';
@@ -6,14 +6,12 @@ import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout'
 export interface PollsNotOpenScreenProps {
   isLiveMode: boolean;
   pollsState: Omit<PollsState, 'polls_open'>;
-  showNoChargerWarning: boolean;
   scannedBallotCount: number;
 }
 
 export function PollsNotOpenScreen({
   isLiveMode,
   pollsState,
-  showNoChargerWarning,
   scannedBallotCount,
 }: PollsNotOpenScreenProps): JSX.Element {
   return (
@@ -41,13 +39,6 @@ export function PollsNotOpenScreen({
         ) : (
           <P>Insert a poll worker card to open polls.</P>
         )}
-        {showNoChargerWarning && (
-          <Caption>
-            <Icons.Warning color="warning" />{' '}
-            <strong>No Power Detected.</strong> Please ask a poll worker to plug
-            in the power cord.
-          </Caption>
-        )}
       </FullScreenPromptLayout>
     </Screen>
   );
@@ -59,7 +50,6 @@ export function DefaultPreview(): JSX.Element {
     <PollsNotOpenScreen
       isLiveMode
       pollsState="polls_closed_initial"
-      showNoChargerWarning={false}
       scannedBallotCount={42}
     />
   );
@@ -71,7 +61,6 @@ export function DefaultTestModePreview(): JSX.Element {
     <PollsNotOpenScreen
       isLiveMode={false}
       pollsState="polls_closed_initial"
-      showNoChargerWarning={false}
       scannedBallotCount={42}
     />
   );
@@ -83,7 +72,6 @@ export function NoPowerConnectedPreview(): JSX.Element {
     <PollsNotOpenScreen
       isLiveMode
       pollsState="polls_closed_initial"
-      showNoChargerWarning
       scannedBallotCount={42}
     />
   );
@@ -95,7 +83,6 @@ export function PollsPausedPreview(): JSX.Element {
     <PollsNotOpenScreen
       isLiveMode
       pollsState="polls_paused"
-      showNoChargerWarning={false}
       scannedBallotCount={42}
     />
   );
@@ -107,7 +94,6 @@ export function PollsClosedFinalPreview(): JSX.Element {
     <PollsNotOpenScreen
       isLiveMode
       pollsState="polls_closed_final"
-      showNoChargerWarning={false}
       scannedBallotCount={42}
     />
   );

--- a/apps/scan/frontend/src/screens/setup_scanner_screen.tsx
+++ b/apps/scan/frontend/src/screens/setup_scanner_screen.tsx
@@ -2,42 +2,24 @@ import { CenteredLargeProse, H1, P, appStrings } from '@votingworks/ui';
 import { ScreenMainCenterChild } from '../components/layout';
 
 interface Props {
-  batteryIsCharging: boolean;
   scannedBallotCount?: number;
 }
 
-export function SetupScannerScreen({
-  batteryIsCharging,
-  scannedBallotCount,
-}: Props): JSX.Element {
+export function SetupScannerScreen({ scannedBallotCount }: Props): JSX.Element {
   // If the power cord is plugged in, but we can't detect a scanner, it's an
   // internal wiring issue. Otherwise if we can't detect the scanner, the power
   // cord is likely not plugged in.
   return (
     <ScreenMainCenterChild ballotCountOverride={scannedBallotCount} voterFacing>
-      {batteryIsCharging ? (
-        <CenteredLargeProse>
-          <H1>{appStrings.titleInternalConnectionProblem()}</H1>
-          <P>{appStrings.instructionsAskForHelp()}</P>
-        </CenteredLargeProse>
-      ) : (
-        <CenteredLargeProse>
-          <H1>{appStrings.titleNoPowerDetected()}</H1>
-          <P>{appStrings.instructionsAskPollWorkerToPlugInPower()}</P>
-        </CenteredLargeProse>
-      )}
+      <CenteredLargeProse>
+        <H1>{appStrings.titleInternalConnectionProblem()}</H1>
+        <P>{appStrings.instructionsAskForHelp()}</P>
+      </CenteredLargeProse>
     </ScreenMainCenterChild>
   );
 }
 
 /* istanbul ignore next */
-export function PowerDisconnectedPreview(): JSX.Element {
-  return (
-    <SetupScannerScreen batteryIsCharging={false} scannedBallotCount={42} />
-  );
-}
-
-/* istanbul ignore next */
 export function ScannerDisconnectedPreview(): JSX.Element {
-  return <SetupScannerScreen batteryIsCharging scannedBallotCount={42} />;
+  return <SetupScannerScreen scannedBallotCount={42} />;
 }

--- a/apps/scan/frontend/src/screens/voter_screen.tsx
+++ b/apps/scan/frontend/src/screens/voter_screen.tsx
@@ -19,7 +19,6 @@ interface VoterScreenProps {
   systemSettings: SystemSettings;
   isTestMode: boolean;
   isSoundMuted: boolean;
-  batteryIsCharging: boolean;
 }
 
 export function VoterScreen({
@@ -27,7 +26,6 @@ export function VoterScreen({
   systemSettings,
   isTestMode,
   isSoundMuted,
-  batteryIsCharging,
 }: VoterScreenProps): JSX.Element | null {
   const scannerStatusQuery = getScannerStatus.useQuery({
     refetchInterval: POLLING_INTERVAL_FOR_SCANNER_STATUS_MS,
@@ -122,7 +120,6 @@ export function VoterScreen({
         <InsertBallotScreen
           isLiveMode={!isTestMode}
           scannedBallotCount={scannerStatus.ballotsCounted}
-          showNoChargerWarning={!batteryIsCharging}
         />
       );
     case 'hardware_ready_to_scan':

--- a/apps/scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/scan/frontend/test/helpers/mock_api_client.tsx
@@ -33,11 +33,7 @@ import {
 import { UsbDriveStatus } from '@votingworks/usb-drive';
 import { TestErrorBoundary, mockUsbDriveStatus } from '@votingworks/ui';
 import { BROTHER_THERMAL_PRINTER_CONFIG } from '@votingworks/printing';
-import type {
-  BatteryInfo,
-  DiskSpaceSummary,
-  ExportDataResult,
-} from '@votingworks/backend';
+import type { DiskSpaceSummary, ExportDataResult } from '@votingworks/backend';
 import { mockPollsInfo } from './mock_polls_info';
 import { ApiProvider } from '../../src/api_provider';
 
@@ -92,14 +88,6 @@ export function createApiMock() {
     });
   }
 
-  function setBatteryInfo(batteryInfo?: Partial<BatteryInfo>): void {
-    mockApiClient.getBatteryInfo.expectRepeatedCallsWith().resolves({
-      level: 1,
-      discharging: false,
-      ...(batteryInfo ?? {}),
-    });
-  }
-
   return {
     mockApiClient,
 
@@ -107,8 +95,6 @@ export function createApiMock() {
 
     setPrinterStatusV3,
     setPrinterStatusV4,
-
-    setBatteryInfo,
 
     authenticateAsSystemAdministrator() {
       setAuthStatus({


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/5234

This machine does not have a built-in chargeable battery anymore so this logic is no longer relevant.
<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot
N/A

## Testing Plan
Ran tests

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
