### PR TITLE
VxAdmin/VxCentralScan: Show scrollbars

### DIFF
--- a/apps/admin/frontend/src/components/navigation_screen.tsx
+++ b/apps/admin/frontend/src/components/navigation_screen.tsx
@@ -31,6 +31,7 @@ interface Props {
   children: React.ReactNode;
   title?: string;
   parentRoutes?: Route[];
+  noPadding?: boolean;
 }
 
 const SYSTEM_ADMIN_NAV_ITEMS: readonly NavItem[] = [
@@ -106,6 +107,7 @@ export function NavigationScreen({
   children,
   title,
   parentRoutes,
+  noPadding,
 }: Props): JSX.Element {
   const { electionDefinition, usbDriveStatus, auth } = useContext(AppContext);
   const election = electionDefinition?.election;
@@ -148,7 +150,9 @@ export function NavigationScreen({
             )}
           </HeaderActions>
         </Header>
-        <MainContent>{children}</MainContent>
+        <MainContent style={{ padding: noPadding ? 0 : undefined }}>
+          {children}
+        </MainContent>
       </Main>
     </Screen>
   );

--- a/apps/admin/frontend/src/components/reporting/ballot_count_report_viewer.tsx
+++ b/apps/admin/frontend/src/components/reporting/ballot_count_report_viewer.tsx
@@ -58,79 +58,81 @@ export function BallotCountReportViewer({
 
   return (
     <React.Fragment>
-      {!autoGenerateReport && (
-        <GenerateButtonWrapper>
-          <Button
-            variant="primary"
-            disabled={
-              disabled || previewQuery.isSuccess || previewQuery.isFetching
+      <div style={{ padding: '1rem' }}>
+        {!autoGenerateReport && (
+          <GenerateButtonWrapper>
+            <Button
+              variant="primary"
+              disabled={
+                disabled || previewQuery.isSuccess || previewQuery.isFetching
+              }
+              onPress={() => previewQuery.refetch()}
+            >
+              Generate Report
+            </Button>
+          </GenerateButtonWrapper>
+        )}
+        <ExportActions>
+          <PrintButton
+            disabled={disableActionButtons}
+            print={() =>
+              printReportMutation.mutateAsync({
+                filter,
+                groupBy,
+                includeSheetCounts,
+              })
             }
-            onPress={() => previewQuery.refetch()}
+            variant={autoGenerateReport ? 'primary' : undefined}
           >
-            Generate Report
-          </Button>
-        </GenerateButtonWrapper>
-      )}
-      <ExportActions>
-        <PrintButton
-          disabled={disableActionButtons}
-          print={() =>
-            printReportMutation.mutateAsync({
+            Print Report
+          </PrintButton>
+          <ExportFileButton
+            buttonText="Export Report PDF"
+            exportMutation={exportReportPdfMutation}
+            exportParameters={{
               filter,
               groupBy,
               includeSheetCounts,
-            })
-          }
-          variant={autoGenerateReport ? 'primary' : undefined}
-        >
-          Print Report
-        </PrintButton>
-        <ExportFileButton
-          buttonText="Export Report PDF"
-          exportMutation={exportReportPdfMutation}
-          exportParameters={{
-            filter,
-            groupBy,
-            includeSheetCounts,
-          }}
-          generateFilename={(sharedFilenameProps) =>
-            generateBallotCountReportPdfFilename({
+            }}
+            generateFilename={(sharedFilenameProps) =>
+              generateBallotCountReportPdfFilename({
+                filter,
+                groupBy,
+                ...sharedFilenameProps,
+              })
+            }
+            fileType="ballot count report"
+            fileTypeTitle="Ballot Count Report"
+            disabled={disableActionButtons}
+          />
+          <ExportFileButton
+            buttonText="Export Report CSV"
+            exportMutation={exportReportCsvMutation}
+            exportParameters={{
               filter,
               groupBy,
-              ...sharedFilenameProps,
-            })
-          }
-          fileType="ballot count report"
-          fileTypeTitle="Ballot Count Report"
-          disabled={disableActionButtons}
-        />
-        <ExportFileButton
-          buttonText="Export Report CSV"
-          exportMutation={exportReportCsvMutation}
-          exportParameters={{
-            filter,
-            groupBy,
-            includeSheetCounts,
-          }}
-          generateFilename={(sharedFilenameProps) =>
-            generateBallotCountReportCsvFilename({
-              filter,
-              groupBy,
-              ...sharedFilenameProps,
-            })
-          }
-          fileType="ballot count report"
-          fileTypeTitle="Ballot Count Report"
-          disabled={disableActionButtons}
-        />
-      </ExportActions>
-      {previewQuery.isSuccess && (
-        <ReportWarning
-          text={getBallotCountReportWarningText({
-            ballotCountReportWarning: previewQuery.data.warning,
-          })}
-        />
-      )}
+              includeSheetCounts,
+            }}
+            generateFilename={(sharedFilenameProps) =>
+              generateBallotCountReportCsvFilename({
+                filter,
+                groupBy,
+                ...sharedFilenameProps,
+              })
+            }
+            fileType="ballot count report"
+            fileTypeTitle="Ballot Count Report"
+            disabled={disableActionButtons}
+          />
+        </ExportActions>
+        {previewQuery.isSuccess && (
+          <ReportWarning
+            text={getBallotCountReportWarningText({
+              ballotCountReportWarning: previewQuery.data.warning,
+            })}
+          />
+        )}
+      </div>
       <PdfViewer
         pdfData={previewQuery.isSuccess ? previewQuery.data.pdf : undefined}
         disabled={disabled || previewQueryNotAttempted}

--- a/apps/admin/frontend/src/components/reporting/pdf_viewer.tsx
+++ b/apps/admin/frontend/src/components/reporting/pdf_viewer.tsx
@@ -9,24 +9,19 @@ import { range } from '@votingworks/basics';
 pdfjs.GlobalWorkerOptions.workerSrc = '/pdf.worker.min.js';
 
 const PdfContainer = styled.div`
-  position: relative;
-  height: 100%;
+  flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
   background: ${(p) => p.theme.colors.container};
-
-  /* Override the padding on the main container so that the preview runs to the
-   * side edges and bottom of the main container. */
-  left: -1rem;
-  width: calc(100% + 2rem);
-  margin-bottom: -1rem;
+  max-height: 100%;
 `;
 
 const PdfDocumentScroller = styled.div`
-  overflow: auto;
+  overflow-y: auto;
   flex: 1;
-  padding: 1.5rem;
+  padding: 1rem 0;
+  width: 100%;
   /* stylelint-disable selector-class-pattern */
   .react-pdf__Document .react-pdf__Page {
     box-shadow: 0 0 0.5rem rgb(0, 0, 0, 25%);
@@ -94,6 +89,7 @@ export function PdfViewer({
         alignItems: 'center',
         fontSize: '3rem',
         height: '100%',
+        minHeight: '5rem',
       }}
       data-testid="pdf-loading"
     >
@@ -104,9 +100,7 @@ export function PdfViewer({
   return (
     <PdfContainer>
       <PdfControls>
-        <div>
-          <span>{numPages ? `Page: ${currentPage}/${numPages}` : ''}</span>
-        </div>
+        <span>{numPages ? `Page: ${currentPage}/${numPages}` : ''}</span>
       </PdfControls>
       {file ? (
         <PdfDocumentScroller onScroll={onScroll} data-testid="pdf-scroller">

--- a/apps/admin/frontend/src/components/reporting/shared.tsx
+++ b/apps/admin/frontend/src/components/reporting/shared.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 import { routerPaths } from '../../router_paths';
 
 export const ExportActions = styled.div`
-  margin-bottom: 1rem;
   display: flex;
   justify-content: start;
   gap: 0.5rem;
@@ -24,7 +23,7 @@ export const GenerateButtonWrapper = styled.div`
 
 export const ReportBuilderControls = styled(Card)`
   background: ${(p) => p.theme.colors.containerLow};
-  margin-bottom: 1rem;
+  margin: 1rem 1rem 0;
   overflow: visible;
 `;
 
@@ -33,7 +32,7 @@ export const ControlLabel = styled(H3)`
 `;
 
 export const WarningContainer = styled.div`
-  margin: 1rem 0;
+  margin-top: 1rem;
 `;
 
 export function ReportWarning({ text }: { text: string }): JSX.Element | null {
@@ -50,3 +49,15 @@ export function ReportWarning({ text }: { text: string }): JSX.Element | null {
 export const reportParentRoutes = [
   { title: 'Reports', path: routerPaths.reports },
 ];
+
+/**
+ * Goes around all of the content in a report screen. The flex column
+ * ensures that the report PDF viewer is able to fill the entirety of the
+ * container.
+ */
+export const ReportScreenContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+`;

--- a/apps/admin/frontend/src/components/reporting/tally_report_viewer.tsx
+++ b/apps/admin/frontend/src/components/reporting/tally_report_viewer.tsx
@@ -77,94 +77,96 @@ export function TallyReportViewer({
 
   return (
     <React.Fragment>
-      {!autoGenerateReport && (
-        <GenerateButtonWrapper>
-          <Button
-            variant="primary"
-            disabled={
-              disabled || previewQuery.isSuccess || previewQuery.isFetching
+      <div style={{ padding: '1rem' }}>
+        {!autoGenerateReport && (
+          <GenerateButtonWrapper>
+            <Button
+              variant="primary"
+              disabled={
+                disabled || previewQuery.isSuccess || previewQuery.isFetching
+              }
+              onPress={() => previewQuery.refetch()}
+            >
+              Generate Report
+            </Button>
+          </GenerateButtonWrapper>
+        )}
+        <ExportActions>
+          <PrintButton
+            disabled={disableActionButtons}
+            print={() =>
+              printReportMutation.mutateAsync({
+                filter,
+                groupBy,
+                includeSignatureLines,
+              })
             }
-            onPress={() => previewQuery.refetch()}
+            variant={autoGenerateReport ? 'primary' : undefined}
           >
-            Generate Report
-          </Button>
-        </GenerateButtonWrapper>
-      )}
-      <ExportActions>
-        <PrintButton
-          disabled={disableActionButtons}
-          print={() =>
-            printReportMutation.mutateAsync({
+            Print Report
+          </PrintButton>
+          <ExportFileButton
+            buttonText="Export Report PDF"
+            exportMutation={exportReportPdfMutation}
+            exportParameters={{
               filter,
               groupBy,
               includeSignatureLines,
-            })
-          }
-          variant={autoGenerateReport ? 'primary' : undefined}
-        >
-          Print Report
-        </PrintButton>
-        <ExportFileButton
-          buttonText="Export Report PDF"
-          exportMutation={exportReportPdfMutation}
-          exportParameters={{
-            filter,
-            groupBy,
-            includeSignatureLines,
-          }}
-          generateFilename={(sharedFilenameProps) =>
-            generateTallyReportPdfFilename({
-              filter,
-              groupBy,
-              ...sharedFilenameProps,
-            })
-          }
-          fileType="tally report"
-          fileTypeTitle="Tally Report"
-          disabled={disableActionButtons}
-        />
-        <ExportFileButton
-          buttonText="Export Report CSV"
-          exportMutation={exportReportCsvMutation}
-          exportParameters={{
-            filter,
-            groupBy,
-          }}
-          generateFilename={(sharedFilenameProps) =>
-            generateTallyReportCsvFilename({
-              filter,
-              groupBy,
-              ...sharedFilenameProps,
-            })
-          }
-          fileType="tally report"
-          fileTypeTitle="Tally Report"
-          disabled={disableActionButtons}
-        />
-        {isFullElectionReport && !disabled && (
-          <ExportFileButton
-            buttonText="Export CDF Report"
-            exportMutation={exportCdfReportMutation}
-            exportParameters={{}}
+            }}
             generateFilename={(sharedFilenameProps) =>
-              generateCdfElectionResultsReportFilename({
+              generateTallyReportPdfFilename({
+                filter,
+                groupBy,
                 ...sharedFilenameProps,
               })
             }
-            fileType="CDF election results report"
-            fileTypeTitle="CDF Election Results Report"
+            fileType="tally report"
+            fileTypeTitle="Tally Report"
             disabled={disableActionButtons}
           />
+          <ExportFileButton
+            buttonText="Export Report CSV"
+            exportMutation={exportReportCsvMutation}
+            exportParameters={{
+              filter,
+              groupBy,
+            }}
+            generateFilename={(sharedFilenameProps) =>
+              generateTallyReportCsvFilename({
+                filter,
+                groupBy,
+                ...sharedFilenameProps,
+              })
+            }
+            fileType="tally report"
+            fileTypeTitle="Tally Report"
+            disabled={disableActionButtons}
+          />
+          {isFullElectionReport && !disabled && (
+            <ExportFileButton
+              buttonText="Export CDF Report"
+              exportMutation={exportCdfReportMutation}
+              exportParameters={{}}
+              generateFilename={(sharedFilenameProps) =>
+                generateCdfElectionResultsReportFilename({
+                  ...sharedFilenameProps,
+                })
+              }
+              fileType="CDF election results report"
+              fileTypeTitle="CDF Election Results Report"
+              disabled={disableActionButtons}
+            />
+          )}
+        </ExportActions>
+        {previewQuery.isSuccess && (
+          <ReportWarning
+            text={getTallyReportWarningText({
+              tallyReportWarning: previewQuery.data.warning,
+              election,
+            })}
+          />
         )}
-      </ExportActions>
-      {previewQuery.isSuccess && (
-        <ReportWarning
-          text={getTallyReportWarningText({
-            tallyReportWarning: previewQuery.data.warning,
-            election,
-          })}
-        />
-      )}
+      </div>
       <PdfViewer
         pdfData={previewQuery.isSuccess ? previewQuery.data.pdf : undefined}
         disabled={disabled || previewQueryNotAttempted}

--- a/apps/admin/frontend/src/index.tsx
+++ b/apps/admin/frontend/src/index.tsx
@@ -37,6 +37,7 @@ root.render(
       defaultColorMode="desktop"
       defaultSizeMode="desktop"
       screenType="lenovoThinkpad15"
+      showScrollBars
     >
       {/* TODO: Move these wrappers down a level into <App> so that we can 1) test the ErrorBoundary
       and 2) be more consistent with other Vx apps. This will require updating test utils to not

--- a/apps/admin/frontend/src/screens/reporting/all_precincts_tally_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/all_precincts_tally_report_screen.tsx
@@ -4,7 +4,10 @@ import { isElectionManagerAuth } from '@votingworks/utils';
 import { AppContext } from '../../contexts/app_context';
 import { NavigationScreen } from '../../components/navigation_screen';
 import { TallyReportViewer } from '../../components/reporting/tally_report_viewer';
-import { reportParentRoutes } from '../../components/reporting/shared';
+import {
+  reportParentRoutes,
+  ReportScreenContainer,
+} from '../../components/reporting/shared';
 
 export const TITLE = 'All Precincts Tally Report';
 
@@ -14,13 +17,15 @@ export function AllPrecinctsTallyReportScreen(): JSX.Element {
   assert(isElectionManagerAuth(auth));
 
   return (
-    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes}>
-      <TallyReportViewer
-        filter={{}}
-        groupBy={{ groupByPrecinct: true }}
-        disabled={false}
-        autoGenerateReport
-      />
+    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes} noPadding>
+      <ReportScreenContainer>
+        <TallyReportViewer
+          filter={{}}
+          groupBy={{ groupByPrecinct: true }}
+          disabled={false}
+          autoGenerateReport
+        />
+      </ReportScreenContainer>
     </NavigationScreen>
   );
 }

--- a/apps/admin/frontend/src/screens/reporting/ballot_count_report_builder.tsx
+++ b/apps/admin/frontend/src/screens/reporting/ballot_count_report_builder.tsx
@@ -27,6 +27,7 @@ import {
   ControlLabel,
   ReportBuilderControls,
   reportParentRoutes,
+  ReportScreenContainer,
 } from '../../components/reporting/shared';
 
 export const TITLE = 'Ballot Count Report Builder';
@@ -76,36 +77,38 @@ export function BallotCountReportBuilder(): JSX.Element {
 
   const hasMadeSelections = !isFilterEmpty(filter) || !isGroupByEmpty(groupBy);
   return (
-    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes}>
-      <ReportBuilderControls>
-        <div style={{ marginBottom: '1.5rem' }}>
-          <ControlLabel>Filters</ControlLabel>
-          <P>Restrict the report to ballots matching the criteria</P>
-          <FilterEditor
-            election={election}
-            onChange={updateFilter}
-            allowedFilters={allowedFilters}
-          />
-        </div>
-        <div>
-          <ControlLabel>Report By</ControlLabel>
-          <P>Organize the ballot counts into multiple groups</P>
-          <GroupByEditor
-            groupBy={groupBy}
-            setGroupBy={updateGroupBy}
-            includeSheetCounts={includeSheetCounts}
-            setIncludeSheetCounts={setIncludeSheetCounts}
-            allowedOptions={allowedGroupBys}
-          />
-        </div>
-      </ReportBuilderControls>
-      <BallotCountReportViewer
-        filter={filter}
-        groupBy={groupBy}
-        includeSheetCounts={includeSheetCounts}
-        disabled={!hasMadeSelections}
-        autoGenerateReport={false}
-      />
+    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes} noPadding>
+      <ReportScreenContainer>
+        <ReportBuilderControls>
+          <div style={{ marginBottom: '1.5rem' }}>
+            <ControlLabel>Filters</ControlLabel>
+            <P>Restrict the report to ballots matching the criteria</P>
+            <FilterEditor
+              election={election}
+              onChange={updateFilter}
+              allowedFilters={allowedFilters}
+            />
+          </div>
+          <div>
+            <ControlLabel>Report By</ControlLabel>
+            <P>Organize the ballot counts into multiple groups</P>
+            <GroupByEditor
+              groupBy={groupBy}
+              setGroupBy={updateGroupBy}
+              includeSheetCounts={includeSheetCounts}
+              setIncludeSheetCounts={setIncludeSheetCounts}
+              allowedOptions={allowedGroupBys}
+            />
+          </div>
+        </ReportBuilderControls>
+        <BallotCountReportViewer
+          filter={filter}
+          groupBy={groupBy}
+          includeSheetCounts={includeSheetCounts}
+          disabled={!hasMadeSelections}
+          autoGenerateReport={false}
+        />
+      </ReportScreenContainer>
     </NavigationScreen>
   );
 }

--- a/apps/admin/frontend/src/screens/reporting/full_election_tally_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/full_election_tally_report_screen.tsx
@@ -4,7 +4,10 @@ import { assert } from '@votingworks/basics';
 import { AppContext } from '../../contexts/app_context';
 import { NavigationScreen } from '../../components/navigation_screen';
 import { TallyReportViewer } from '../../components/reporting/tally_report_viewer';
-import { reportParentRoutes } from '../../components/reporting/shared';
+import {
+  reportParentRoutes,
+  ReportScreenContainer,
+} from '../../components/reporting/shared';
 
 export const TITLE = 'Full Election Tally Report';
 
@@ -14,13 +17,15 @@ export function FullElectionTallyReportScreen(): JSX.Element {
   assert(isElectionManagerAuth(auth));
 
   return (
-    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes}>
-      <TallyReportViewer
-        filter={{}}
-        groupBy={{}}
-        disabled={false}
-        autoGenerateReport
-      />
+    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes} noPadding>
+      <ReportScreenContainer>
+        <TallyReportViewer
+          filter={{}}
+          groupBy={{}}
+          disabled={false}
+          autoGenerateReport
+        />
+      </ReportScreenContainer>
     </NavigationScreen>
   );
 }

--- a/apps/admin/frontend/src/screens/reporting/precinct_ballot_count_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/precinct_ballot_count_report_screen.tsx
@@ -4,7 +4,10 @@ import { isElectionManagerAuth } from '@votingworks/utils';
 import { AppContext } from '../../contexts/app_context';
 import { NavigationScreen } from '../../components/navigation_screen';
 import { BallotCountReportViewer } from '../../components/reporting/ballot_count_report_viewer';
-import { reportParentRoutes } from '../../components/reporting/shared';
+import {
+  reportParentRoutes,
+  ReportScreenContainer,
+} from '../../components/reporting/shared';
 
 export const TITLE = 'Precinct Ballot Count Report';
 
@@ -14,17 +17,19 @@ export function PrecinctBallotCountReport(): JSX.Element {
   assert(isElectionManagerAuth(auth));
 
   return (
-    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes}>
-      <BallotCountReportViewer
-        filter={{}}
-        groupBy={{
-          groupByPrecinct: true,
-          groupByParty: electionDefinition.election.type === 'primary',
-        }}
-        includeSheetCounts={false}
-        disabled={false}
-        autoGenerateReport
-      />
+    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes} noPadding>
+      <ReportScreenContainer>
+        <BallotCountReportViewer
+          filter={{}}
+          groupBy={{
+            groupByPrecinct: true,
+            groupByParty: electionDefinition.election.type === 'primary',
+          }}
+          includeSheetCounts={false}
+          disabled={false}
+          autoGenerateReport
+        />
+      </ReportScreenContainer>
     </NavigationScreen>
   );
 }

--- a/apps/admin/frontend/src/screens/reporting/single_precinct_tally_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/single_precinct_tally_report_screen.tsx
@@ -1,4 +1,4 @@
-import { P, SearchSelect } from '@votingworks/ui';
+import { SearchSelect } from '@votingworks/ui';
 import { useContext, useState } from 'react';
 import { assert } from '@votingworks/basics';
 import { isElectionManagerAuth } from '@votingworks/utils';
@@ -6,20 +6,21 @@ import styled from 'styled-components';
 import { AppContext } from '../../contexts/app_context';
 import { NavigationScreen } from '../../components/navigation_screen';
 import { TallyReportViewer } from '../../components/reporting/tally_report_viewer';
-import { reportParentRoutes } from '../../components/reporting/shared';
+import {
+  reportParentRoutes,
+  ReportScreenContainer,
+} from '../../components/reporting/shared';
 
 export const TITLE = 'Single Precinct Tally Report';
 
 const SelectPrecinctContainer = styled.div`
-  display: grid;
-  grid-template-columns: min-content 30%;
-  gap: 1rem;
+  padding: 1rem 1rem 0;
+  display: flex;
+  gap: 0.5rem;
   align-items: center;
-  margin-bottom: 1rem;
 
-  p {
+  > span {
     white-space: nowrap;
-    margin: 0;
   }
 `;
 
@@ -32,27 +33,30 @@ export function SinglePrecinctTallyReportScreen(): JSX.Element {
   const [precinctId, setPrecinctId] = useState<string>();
 
   return (
-    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes}>
-      <SelectPrecinctContainer>
-        <P>Select Precinct:</P>
-        <SearchSelect
-          isMulti={false}
-          isSearchable
-          value={precinctId}
-          options={election.precincts.map((precinct) => ({
-            value: precinct.id,
-            label: precinct.name,
-          }))}
-          onChange={(value) => setPrecinctId(value)}
-          ariaLabel="Select Precinct"
+    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes} noPadding>
+      <ReportScreenContainer>
+        <SelectPrecinctContainer>
+          <span>Select Precinct:</span>
+          <SearchSelect
+            isMulti={false}
+            isSearchable
+            value={precinctId}
+            options={election.precincts.map((precinct) => ({
+              value: precinct.id,
+              label: precinct.name,
+            }))}
+            onChange={(value) => setPrecinctId(value)}
+            ariaLabel="Select Precinct"
+            style={{ width: '30rem' }}
+          />
+        </SelectPrecinctContainer>
+        <TallyReportViewer
+          filter={{ precinctIds: precinctId ? [precinctId] : [] }}
+          groupBy={{}}
+          disabled={!precinctId}
+          autoGenerateReport
         />
-      </SelectPrecinctContainer>
-      <TallyReportViewer
-        filter={{ precinctIds: precinctId ? [precinctId] : [] }}
-        groupBy={{}}
-        disabled={!precinctId}
-        autoGenerateReport
-      />
+      </ReportScreenContainer>
     </NavigationScreen>
   );
 }

--- a/apps/admin/frontend/src/screens/reporting/tally_report_builder.tsx
+++ b/apps/admin/frontend/src/screens/reporting/tally_report_builder.tsx
@@ -17,6 +17,7 @@ import {
   ReportBuilderControls,
   ControlLabel,
   reportParentRoutes,
+  ReportScreenContainer,
 } from '../../components/reporting/shared';
 
 const TITLE = 'Tally Report Builder';
@@ -40,46 +41,48 @@ export function TallyReportBuilder(): JSX.Element {
 
   const hasMadeSelections = !isFilterEmpty(filter) || !isGroupByEmpty(groupBy);
   return (
-    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes}>
-      <ReportBuilderControls>
-        <div style={{ marginBottom: '1.5rem' }}>
-          <ControlLabel>Filters</ControlLabel>
-          <P>Restrict the report to ballots matching the criteria</P>
-          <FilterEditor
-            election={election}
-            onChange={updateFilter}
-            allowedFilters={[
-              'ballot-style',
-              'batch',
-              'precinct',
-              'scanner',
-              'voting-method',
-              'district',
-            ]} // omits party
-          />
-        </div>
-        <div>
-          <ControlLabel>Report By</ControlLabel>
-          <P>Organize the results into multiple reports</P>
-          <GroupByEditor
-            groupBy={groupBy}
-            setGroupBy={updateGroupBy}
-            allowedOptions={[
-              'groupByBallotStyle',
-              'groupByBatch',
-              'groupByPrecinct',
-              'groupByScanner',
-              'groupByVotingMethod',
-            ]} // omits party
-          />
-        </div>
-      </ReportBuilderControls>
-      <TallyReportViewer
-        filter={filter}
-        groupBy={groupBy}
-        disabled={!hasMadeSelections}
-        autoGenerateReport={false}
-      />
+    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes} noPadding>
+      <ReportScreenContainer>
+        <ReportBuilderControls>
+          <div style={{ marginBottom: '1.5rem' }}>
+            <ControlLabel>Filters</ControlLabel>
+            <P>Restrict the report to ballots matching the criteria</P>
+            <FilterEditor
+              election={election}
+              onChange={updateFilter}
+              allowedFilters={[
+                'ballot-style',
+                'batch',
+                'precinct',
+                'scanner',
+                'voting-method',
+                'district',
+              ]} // omits party
+            />
+          </div>
+          <div>
+            <ControlLabel>Report By</ControlLabel>
+            <P>Organize the results into multiple reports</P>
+            <GroupByEditor
+              groupBy={groupBy}
+              setGroupBy={updateGroupBy}
+              allowedOptions={[
+                'groupByBallotStyle',
+                'groupByBatch',
+                'groupByPrecinct',
+                'groupByScanner',
+                'groupByVotingMethod',
+              ]} // omits party
+            />
+          </div>
+        </ReportBuilderControls>
+        <TallyReportViewer
+          filter={filter}
+          groupBy={groupBy}
+          disabled={!hasMadeSelections}
+          autoGenerateReport={false}
+        />
+      </ReportScreenContainer>
     </NavigationScreen>
   );
 }

--- a/apps/admin/frontend/src/screens/reporting/voting_method_ballot_count_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/voting_method_ballot_count_report_screen.tsx
@@ -4,7 +4,10 @@ import { isElectionManagerAuth } from '@votingworks/utils';
 import { AppContext } from '../../contexts/app_context';
 import { NavigationScreen } from '../../components/navigation_screen';
 import { BallotCountReportViewer } from '../../components/reporting/ballot_count_report_viewer';
-import { reportParentRoutes } from '../../components/reporting/shared';
+import {
+  reportParentRoutes,
+  ReportScreenContainer,
+} from '../../components/reporting/shared';
 
 export const TITLE = 'Voting Method Ballot Count Report';
 
@@ -14,17 +17,19 @@ export function VotingMethodBallotCountReport(): JSX.Element {
   assert(isElectionManagerAuth(auth));
 
   return (
-    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes}>
-      <BallotCountReportViewer
-        filter={{}}
-        groupBy={{
-          groupByVotingMethod: true,
-          groupByParty: electionDefinition.election.type === 'primary',
-        }}
-        includeSheetCounts={false}
-        disabled={false}
-        autoGenerateReport
-      />
+    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes} noPadding>
+      <ReportScreenContainer>
+        <BallotCountReportViewer
+          filter={{}}
+          groupBy={{
+            groupByVotingMethod: true,
+            groupByParty: electionDefinition.election.type === 'primary',
+          }}
+          includeSheetCounts={false}
+          disabled={false}
+          autoGenerateReport
+        />
+      </ReportScreenContainer>
     </NavigationScreen>
   );
 }

--- a/apps/admin/frontend/src/screens/reporting/write_in_adjudication_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/write_in_adjudication_report_screen.tsx
@@ -7,6 +7,7 @@ import {
 import {
   ExportActions,
   reportParentRoutes,
+  ReportScreenContainer,
 } from '../../components/reporting/shared';
 import { PrintButton } from '../../components/print_button';
 import { PdfViewer } from '../../components/reporting/pdf_viewer';
@@ -23,34 +24,38 @@ export function TallyWriteInReportScreen(): JSX.Element {
   const isPreviewLoading = !previewQuery.isSuccess;
 
   return (
-    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes}>
-      <ExportActions>
-        <PrintButton
-          disabled={isPreviewLoading}
-          print={() => printMutation.mutateAsync()}
-          variant="primary"
-        >
-          Print Report
-        </PrintButton>{' '}
-        <ExportFileButton
-          buttonText="Export Report PDF"
-          exportMutation={pdfExportMutation}
-          exportParameters={{}}
-          generateFilename={(sharedFilenameProps) =>
-            generateReportFilename({
-              filter: {},
-              groupBy: {},
-              type: 'write-in-adjudication-report',
-              extension: 'pdf',
-              ...sharedFilenameProps,
-            })
-          }
-          fileType="write-in adjudication report"
-          fileTypeTitle="Write-In Adjudication Report"
-          disabled={isPreviewLoading}
-        />
-      </ExportActions>
-      <PdfViewer pdfData={previewQuery.data} />
+    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes} noPadding>
+      <ReportScreenContainer>
+        <div style={{ padding: '1rem' }}>
+          <ExportActions>
+            <PrintButton
+              disabled={isPreviewLoading}
+              print={() => printMutation.mutateAsync()}
+              variant="primary"
+            >
+              Print Report
+            </PrintButton>{' '}
+            <ExportFileButton
+              buttonText="Export Report PDF"
+              exportMutation={pdfExportMutation}
+              exportParameters={{}}
+              generateFilename={(sharedFilenameProps) =>
+                generateReportFilename({
+                  filter: {},
+                  groupBy: {},
+                  type: 'write-in-adjudication-report',
+                  extension: 'pdf',
+                  ...sharedFilenameProps,
+                })
+              }
+              fileType="write-in adjudication report"
+              fileTypeTitle="Write-In Adjudication Report"
+              disabled={isPreviewLoading}
+            />
+          </ExportActions>
+        </div>
+        <PdfViewer pdfData={previewQuery.data} />
+      </ReportScreenContainer>
     </NavigationScreen>
   );
 }

--- a/apps/central-scan/frontend/src/app.tsx
+++ b/apps/central-scan/frontend/src/app.tsx
@@ -34,6 +34,7 @@ export function App({
         defaultColorMode="desktop"
         defaultSizeMode="desktop"
         screenType="lenovoThinkpad15"
+        showScrollBars
       >
         <AppErrorBoundary
           restartMessage="Please restart the machine."

--- a/libs/ui/src/search_select.tsx
+++ b/libs/ui/src/search_select.tsx
@@ -205,6 +205,7 @@ export function SearchSelect<T extends string = string>({
         menuList: (baseStyles) => ({
           ...baseStyles,
           borderRadius,
+          '::-webkit-scrollbar': { display: 'none' },
         }),
         option: (baseStyles, state) => ({
           ...baseStyles,


### PR DESCRIPTION
## Overview

On desktop apps, it's useful to have a scrollbar when scrolling is possible, both as a visual indicator of overflow and as a tool for scrolling.

## Demo Video or Screenshot
VxCentralScan
https://github.com/user-attachments/assets/bc695c47-6e68-4558-a06b-95c5f59145f8


VxAdmin
Note that there are nested scrollbars on the report pages. These nested scrollable areas existed before, they just weren't as obvious. I experimented with some other solutions (e.g. one continuous scroll for all the content, a button to expand/shrink the PDF viewer to use the whole content area), but they all felt less useable overall, so I kept the current UX. It's a little ugly, but I think it works fine.
https://github.com/user-attachments/assets/7e84f370-68dd-44c2-a4f0-b5548ec8c876


## Testing Plan

Manual testing

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
