### PR TITLE
[All] Add logs for configuration/unconfiguration and configuration errors

### DIFF
--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -80,6 +80,14 @@ test('managing the current election', async () => {
   });
   assert(badConfigureResult.isErr());
   expect(badConfigureResult.err().type).toEqual('invalid-zip');
+  expect(logger.log).toHaveBeenNthCalledWith(
+    1,
+    LogEventId.ElectionConfigured,
+    'system_administrator',
+    expect.objectContaining({
+      disposition: 'failure',
+    })
+  );
 
   // try configuring with malformed election data
   const badElectionPackage = await zipFile({
@@ -90,6 +98,15 @@ test('managing the current election', async () => {
   });
   assert(badElectionConfigureResult.isErr());
   expect(badElectionConfigureResult.err().type).toEqual('invalid-election');
+
+  expect(logger.log).toHaveBeenNthCalledWith(
+    2,
+    LogEventId.ElectionConfigured,
+    'system_administrator',
+    expect.objectContaining({
+      disposition: 'failure',
+    })
+  );
 
   const { electionDefinition } = electionTwoPartyPrimaryFixtures;
   const { ballotHash } = electionDefinition;
@@ -106,6 +123,14 @@ test('managing the current election', async () => {
   expect(badSystemSettingsConfigureResult.err().type).toEqual(
     'invalid-system-settings'
   );
+  expect(logger.log).toHaveBeenNthCalledWith(
+    3,
+    LogEventId.ElectionConfigured,
+    'system_administrator',
+    expect.objectContaining({
+      disposition: 'failure',
+    })
+  );
 
   // configure with well-formed data
   const goodPackage = await zipFile({
@@ -120,7 +145,7 @@ test('managing the current election', async () => {
   assert(configureResult.isOk());
   const { electionId } = configureResult.ok();
   expect(logger.log).toHaveBeenNthCalledWith(
-    1,
+    4,
     LogEventId.ElectionConfigured,
     'system_administrator',
     {
@@ -139,7 +164,7 @@ test('managing the current election', async () => {
   mockElectionManagerAuth(auth, electionDefinition.election);
   await apiClient.markResultsOfficial();
   expect(logger.log).toHaveBeenNthCalledWith(
-    2,
+    5,
     LogEventId.MarkedTallyResultsOfficial,
     'election_manager',
     expect.objectContaining({
@@ -156,7 +181,7 @@ test('managing the current election', async () => {
   mockSystemAdministratorAuth(auth);
   await apiClient.unconfigure();
   expect(logger.log).toHaveBeenNthCalledWith(
-    3,
+    6,
     LogEventId.ElectionUnconfigured,
     'system_administrator',
     expect.objectContaining({

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -436,6 +436,11 @@ function buildApi({
       })();
 
       if (electionPackageResult.isErr()) {
+        await logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
+          message: `Error configuring machine.`,
+          disposition: 'failure',
+          errorDetails: JSON.stringify(electionPackageResult.err()),
+        });
         return electionPackageResult;
       }
       const { electionPackage, electionPackageHash, fileContents } =

--- a/apps/central-scan/backend/src/app.ts
+++ b/apps/central-scan/backend/src/app.ts
@@ -154,6 +154,11 @@ function buildApi({
         logger
       );
       if (electionPackageResult.isErr()) {
+        await logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
+          message: `Error configuring machine.`,
+          disposition: 'failure',
+          errorDetails: JSON.stringify(electionPackageResult.err()),
+        });
         return electionPackageResult;
       }
       assert(isElectionManagerAuth(authStatus));

--- a/apps/mark-scan/backend/src/app.test.ts
+++ b/apps/mark-scan/backend/src/app.test.ts
@@ -192,6 +192,12 @@ test('configureElectionPackageFromUsb reads to and writes from store', async () 
 
   mockElectionManagerAuth(mockAuth, electionDefinition);
   await setUpUsbAndConfigureElection(electionDefinition);
+  expect(logger.logAsCurrentRole).toHaveBeenLastCalledWith(
+    LogEventId.ElectionConfigured,
+    expect.objectContaining({
+      disposition: 'success',
+    })
+  );
 
   const readResult = await apiClient.getSystemSettings();
   expect(readResult).toEqual(
@@ -216,6 +222,12 @@ test('unconfigureMachine deletes system settings and election definition', async
 
   await setUpUsbAndConfigureElection(electionDefinition);
   await apiClient.unconfigureMachine();
+  expect(logger.logAsCurrentRole).toHaveBeenLastCalledWith(
+    LogEventId.ElectionUnconfigured,
+    expect.objectContaining({
+      disposition: 'success',
+    })
+  );
 
   readResult = await apiClient.getSystemSettings();
   expect(readResult).toEqual(DEFAULT_SYSTEM_SETTINGS);
@@ -257,6 +269,12 @@ test('configureElectionPackageFromUsb returns an error if election package parsi
   const result = await apiClient.configureElectionPackageFromUsb();
   assert(result.isErr());
   expect(result.err()).toEqual('auth_required_before_election_package_load');
+  expect(logger.logAsCurrentRole).toHaveBeenLastCalledWith(
+    LogEventId.ElectionConfigured,
+    expect.objectContaining({
+      disposition: 'failure',
+    })
+  );
 });
 
 test('configure with CDF election', async () => {

--- a/apps/mark/backend/src/app.test.ts
+++ b/apps/mark/backend/src/app.test.ts
@@ -161,6 +161,12 @@ test('configureElectionPackageFromUsb reads to and writes from store', async () 
 
   const writeResult = await apiClient.configureElectionPackageFromUsb();
   assert(writeResult.isOk());
+  expect(logger.logAsCurrentRole).toHaveBeenLastCalledWith(
+    LogEventId.ElectionConfigured,
+    expect.objectContaining({
+      disposition: 'success',
+    })
+  );
 
   const readResult = await apiClient.getSystemSettings();
   expect(readResult).toEqual(
@@ -191,6 +197,12 @@ test('unconfigureMachine deletes system settings and election definition', async
   const writeResult = await apiClient.configureElectionPackageFromUsb();
   assert(writeResult.isOk());
   await apiClient.unconfigureMachine();
+  expect(logger.logAsCurrentRole).toHaveBeenLastCalledWith(
+    LogEventId.ElectionUnconfigured,
+    expect.objectContaining({
+      disposition: 'success',
+    })
+  );
 
   const readResult = await apiClient.getSystemSettings();
   expect(readResult).toEqual(DEFAULT_SYSTEM_SETTINGS);
@@ -232,6 +244,12 @@ test('configureElectionPackageFromUsb returns an error if election package parsi
   const result = await apiClient.configureElectionPackageFromUsb();
   assert(result.isErr());
   expect(result.err()).toEqual('auth_required_before_election_package_load');
+  expect(logger.logAsCurrentRole).toHaveBeenLastCalledWith(
+    LogEventId.ElectionConfigured,
+    expect.objectContaining({
+      disposition: 'failure',
+    })
+  );
 });
 
 test('configure with CDF election', async () => {

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -123,8 +123,13 @@ export function buildApi(
       return workspace.store.getSystemSettings() ?? DEFAULT_SYSTEM_SETTINGS;
     },
 
-    unconfigureMachine() {
+    async unconfigureMachine() {
       workspace.store.reset();
+      await logger.logAsCurrentRole(LogEventId.ElectionUnconfigured, {
+        disposition: 'success',
+        message:
+          'User successfully unconfigured the machine to remove the current election.',
+      });
     },
 
     async configureElectionPackageFromUsb(): Promise<
@@ -140,6 +145,11 @@ export function buildApi(
         logger
       );
       if (electionPackageResult.isErr()) {
+        await logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
+          disposition: 'failure',
+          message: 'Error configuring machine.',
+          errorDetails: JSON.stringify(electionPackageResult.err()),
+        });
         return electionPackageResult;
       }
       assert(isElectionManagerAuth(authStatus));
@@ -172,8 +182,10 @@ export function buildApi(
         });
       });
 
-      await logger.log(LogEventId.ElectionPackageLoadedFromUsb, 'system', {
+      await logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
+        message: `Machine configured for election with hash: ${electionDefinition.ballotHash}`,
         disposition: 'success',
+        ballotHash: electionDefinition.ballotHash,
       });
 
       return ok(electionDefinition);

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -145,6 +145,11 @@ export function buildApi({
         logger
       );
       if (electionPackageResult.isErr()) {
+        await logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
+          disposition: 'failure',
+          message: 'Error configuring machine.',
+          errorDetails: JSON.stringify(electionPackageResult.err()),
+        });
         return electionPackageResult;
       }
       assert(isElectionManagerAuth(authStatus));
@@ -178,6 +183,11 @@ export function buildApi({
         });
       });
 
+      await logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
+        message: `Machine configured for election with hash: ${electionDefinition.ballotHash}`,
+        disposition: 'success',
+        ballotHash: electionDefinition.ballotHash,
+      });
       return ok();
     },
 
@@ -210,8 +220,13 @@ export function buildApi({
       };
     },
 
-    unconfigureElection(): void {
+    async unconfigureElection(): Promise<void> {
       workspace.reset();
+      await logger.logAsCurrentRole(LogEventId.ElectionUnconfigured, {
+        disposition: 'success',
+        message:
+          'User successfully unconfigured the machine to remove the current election and all current ballot data.',
+      });
     },
 
     async setPrecinctSelection(input: {


### PR DESCRIPTION
## Overview
Various VVSG 2.0 rules specify that we must log all configuration, unconfiguration, and any errors in configuration. This PR does a review across apps of our logging during these actions and makes them consistent and adds any missing logs along with tests.
<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot

## Testing Plan
Tested manually and visually verified logs in addition to running tests.

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
