### PR TITLE
[UiStrings] Clear i18next cache when backend translations are removed

### DIFF
--- a/libs/ui/src/ui_strings/language_context.tsx
+++ b/libs/ui/src/ui_strings/language_context.tsx
@@ -76,7 +76,15 @@ export function UiStringsLoader(): React.ReactNode {
   const { data, isLoading } = context.api.getUiStrings.useQuery(languageCode);
 
   React.useEffect(() => {
-    if (!languageCode || isLoading || !data) {
+    if (!languageCode || isLoading) {
+      return;
+    }
+
+    // Clear the i18next cache whenever the translation data in the backend is
+    // empty (e.g. after unconfiguring a previous election, or switching to an
+    // election with no translations).
+    if (!data) {
+      i18next.removeResourceBundle(languageCode, DEFAULT_I18NEXT_NAMESPACE);
       return;
     }
 

--- a/libs/ui/test/test_context.tsx
+++ b/libs/ui/test/test_context.tsx
@@ -36,6 +36,8 @@ export interface TestContext {
   getAudioControls: () => Optional<AudioControls>;
   getLanguageContext: () => Optional<FrontendLanguageContextInterface>;
   mockApiClient: jest.Mocked<ApiClient>;
+  mockReactQueryUiStringsApi: UiStringsReactQueryApi;
+  queryClient: QueryClient;
   render: (
     ui: React.ReactElement,
     renderOptions?: VxRenderOptions
@@ -137,6 +139,8 @@ export function newTestContext(
 
   return {
     mockApiClient,
+    mockReactQueryUiStringsApi,
+    queryClient,
     render: (ui, renderOptions) => {
       const result = render(<Wrapper>{ui}</Wrapper>, renderOptions);
       return {


### PR DESCRIPTION
## Overview

Fixes https://github.com/votingworks/vxsuite/issues/5265

Whenever machines are unconfigured, we clear the backend DB and frontend query cache, but our translation library, i18next, has a cache of its own that we weren't clearing yet. That meant stale translations (including English strings) in the voter-facing bits of the UI. These would ordinarily get overwritten when a new election is configured, along with the new translations, but not when we use elections without translations.

Making sure we reset the i18next cache whenever the query cache changes (which happens on unconfigure).

## Testing Plan
- Added a new test case to repro and verify the fix
- Manual verification

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
