### PR TITLE
[Scan] Left-align ballot count when there's no header title

### DIFF
--- a/apps/scan/frontend/src/components/layout.tsx
+++ b/apps/scan/frontend/src/components/layout.tsx
@@ -138,7 +138,11 @@ export function Screen(props: ScreenProps): JSX.Element | null {
         </ButtonBar>
       )}
       <Header>
-        <TitleContainer>{title && <H1>{title}</H1>}</TitleContainer>
+        {title && (
+          <TitleContainer>
+            <H1>{title}</H1>
+          </TitleContainer>
+        )}
         {!hideBallotCountFromProps && ballotCount !== undefined && (
           <ScannedBallotCount count={ballotCount} />
         )}

--- a/apps/scan/frontend/src/components/layout.tsx
+++ b/apps/scan/frontend/src/components/layout.tsx
@@ -64,6 +64,10 @@ const ButtonBar = styled.div`
     height: 100%;
     width: 100%;
   }
+
+  & > :only-child {
+    grid-column: 1 / span 2;
+  }
 `;
 
 const Header = styled.div`
@@ -138,11 +142,7 @@ export function Screen(props: ScreenProps): JSX.Element | null {
         </ButtonBar>
       )}
       <Header>
-        {title && (
-          <TitleContainer>
-            <H1>{title}</H1>
-          </TitleContainer>
-        )}
+        <TitleContainer>{title && <H1>{title}</H1>}</TitleContainer>
         {!hideBallotCountFromProps && ballotCount !== undefined && (
           <ScannedBallotCount count={ballotCount} />
         )}

--- a/apps/scan/frontend/src/components/layout.tsx
+++ b/apps/scan/frontend/src/components/layout.tsx
@@ -70,8 +70,14 @@ const ButtonBar = styled.div`
   }
 `;
 
-const Header = styled.div`
-  align-items: center;
+const VoterHeader = styled.div`
+  align-items: start;
+  display: flex;
+  gap: ${(p) => getSpacingValueRem(p)}rem;
+  padding: ${(p) => getSpacingValueRem(p)}rem;
+`;
+
+const TitleBar = styled.div`
   display: flex;
   gap: ${(p) => getSpacingValueRem(p)}rem;
   padding: ${(p) => getSpacingValueRem(p)}rem;
@@ -79,6 +85,16 @@ const Header = styled.div`
 
 const TitleContainer = styled.div`
   display: flex;
+  flex-grow: 1;
+`;
+
+const BallotCountContainer = styled.div`
+  display: flex;
+  flex-grow: 1;
+  justify-content: end;
+`;
+
+const Spacer = styled.div`
   flex-grow: 1;
 `;
 
@@ -130,23 +146,30 @@ export function Screen(props: ScreenProps): JSX.Element | null {
     !electionDefinition ||
     ELECTION_BAR_HIDDEN_SIZE_MODES.has(currentTheme.sizeMode);
 
+  const ballotCountElement = !hideBallotCountFromProps &&
+    ballotCount !== undefined && (
+      <BallotCountContainer>
+        <ScannedBallotCount count={ballotCount} />
+      </BallotCountContainer>
+    );
+
   return (
     <ScreenBase>
       {!isLiveMode && <TestMode />}
       {voterFacing && (
-        <ButtonBar>
+        <VoterHeader>
           <LanguageSettingsButton
             onPress={() => setShouldShowLanguageSettings(true)}
           />
           <VoterSettingsButton />
-        </ButtonBar>
+          <Spacer />
+          {ballotCountElement}
+        </VoterHeader>
       )}
-      <Header>
+      <TitleBar>
         <TitleContainer>{title && <H1>{title}</H1>}</TitleContainer>
-        {!hideBallotCountFromProps && ballotCount !== undefined && (
-          <ScannedBallotCount count={ballotCount} />
-        )}
-      </Header>
+        {!voterFacing && ballotCountElement}
+      </TitleBar>
       <Main centerChild={centerContent} padded={padded}>
         {children}
       </Main>

--- a/apps/scan/frontend/src/screens/scan_warning_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_warning_screen.tsx
@@ -149,7 +149,6 @@ function MisvoteWarningScreen({
           )}
         </React.Fragment>
       }
-      centerContent
       padded
       title={
         <React.Fragment>


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/4964

Removing the title placeholder in the screen header when there's no title, so that the scanned ballot count falls to the left in those cases.

## Demo Video or Screenshot
| Single-Language  | Multi-Language |
| ------------- | ------------- |
| ![Screenshot 2024-08-22 at 12 34 29](https://github.com/user-attachments/assets/15ab8ae3-4ba7-4e14-b1f0-7b95a54e6fcd) | ![Screenshot 2024-08-22 at 12 34 08](https://github.com/user-attachments/assets/233849ba-1886-4866-821f-24213ca96bda) |
| ![Screenshot 2024-08-22 at 12 34 38](https://github.com/user-attachments/assets/96b799c6-74c0-42f0-af88-f992410ceef5) | ![Screenshot 2024-08-22 at 12 34 45](https://github.com/user-attachments/assets/486e0ff8-e829-4389-8279-ab6fa1f8a84a) |

## Testing Plan
- Manual

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
