### PR TITLE
Central system polish for long election content

### DIFF
--- a/apps/admin/frontend/src/components/reporting/filter_editor.tsx
+++ b/apps/admin/frontend/src/components/reporting/filter_editor.tsx
@@ -26,7 +26,11 @@ const FilterRow = styled.div`
   flex-shrink: 0;
   width: 100%;
   display: grid;
-  grid-template-columns: 10rem 4rem 1fr 2.25rem;
+  grid-template-columns:
+    10rem
+    4rem
+    minmax(0, 1fr) /* Prevent select from overflowing when options are long */
+    2.25rem;
   align-items: center;
 `;
 

--- a/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
@@ -147,7 +147,7 @@ const AdjudicationMetadata = styled(Caption)`
 `;
 
 const AdjudicationForm = styled.div`
-  overflow: scroll;
+  overflow-y: scroll;
   padding: 0.5rem;
 `;
 
@@ -572,29 +572,6 @@ export function WriteInsAdjudicationScreen(): JSX.Element {
             )}
           </ContestTitleContainer>
           <AdjudicationForm>
-            {officialCandidates.length > 0 ? (
-              <SectionLabel>Official Candidates</SectionLabel>
-            ) : null}
-            <CandidateButtonList>
-              {officialCandidates.map((candidate) => {
-                return (
-                  <CandidateButton
-                    key={candidate.id}
-                    candidate={candidate}
-                    isSelected={
-                      currentWriteIn &&
-                      currentWriteIn.status === 'adjudicated' &&
-                      currentWriteIn.adjudicationType ===
-                        'official-candidate' &&
-                      currentWriteIn.candidateId === candidate.id
-                    }
-                    isSelectedStatusUpToDate={isWriteInAdjudicationContextFresh}
-                    onSelect={() => adjudicateAsOfficialCandidate(candidate)}
-                    onDeselect={resetAdjudication}
-                  />
-                );
-              })}
-            </CandidateButtonList>
             {showNewWriteInCandidateForm || writeInCandidates.length > 0 ? (
               <SectionLabel>Write-In Candidates</SectionLabel>
             ) : null}
@@ -622,8 +599,8 @@ export function WriteInsAdjudicationScreen(): JSX.Element {
                 })}
               </CandidateButtonList>
             )}
-            <div style={{ margin: '0.5rem 0' }}>
-              {showNewWriteInCandidateForm ? (
+            {showNewWriteInCandidateForm ? (
+              <div style={{ margin: '0.5rem 0' }}>
                 <div style={{ display: 'flex', gap: '0.5rem' }}>
                   <input
                     key={currentWriteInId}
@@ -659,8 +636,31 @@ export function WriteInsAdjudicationScreen(): JSX.Element {
                     Add
                   </Button>
                 </div>
-              ) : null}
-            </div>
+              </div>
+            ) : null}
+            {officialCandidates.length > 0 ? (
+              <SectionLabel>Official Candidates</SectionLabel>
+            ) : null}
+            <CandidateButtonList>
+              {officialCandidates.map((candidate) => {
+                return (
+                  <CandidateButton
+                    key={candidate.id}
+                    candidate={candidate}
+                    isSelected={
+                      currentWriteIn &&
+                      currentWriteIn.status === 'adjudicated' &&
+                      currentWriteIn.adjudicationType ===
+                        'official-candidate' &&
+                      currentWriteIn.candidateId === candidate.id
+                    }
+                    isSelectedStatusUpToDate={isWriteInAdjudicationContextFresh}
+                    onSelect={() => adjudicateAsOfficialCandidate(candidate)}
+                    onDeselect={resetAdjudication}
+                  />
+                );
+              })}
+            </CandidateButtonList>
           </AdjudicationForm>
           <AdjudicationStickyFooter>
             <WriteInActionButton

--- a/apps/admin/frontend/src/screens/write_ins_summary_screen.tsx
+++ b/apps/admin/frontend/src/screens/write_ins_summary_screen.tsx
@@ -116,7 +116,7 @@ export function WriteInsSummaryScreen(): JSX.Element {
                 const hasWriteIns = totalCount > 0;
                 return (
                   <tr key={contest.id}>
-                    <TD nowrap>
+                    <TD>
                       <Font weight={hasWriteIns ? 'semiBold' : 'regular'}>
                         {getContestDistrictName(election, contest)},{' '}
                         {contest.title}

--- a/apps/central-scan/frontend/README.md
+++ b/apps/central-scan/frontend/README.md
@@ -15,14 +15,9 @@ pnpm start
 
 The server will be available at http://localhost:3000/.
 
-To set the election configuration you will either need to scan a smartcard (you
-can use `./scripts/mock-card` in [`libs/auth`](../../../libs/auth) for this),
-load an election.json file, or load an election package from
-[election-manager](../election-manager). You should load an election package if
-you intend to test hand-marked paper ballots (HMPBs).
-
-To display a batch of scanned ballots use the `MOCK_SCANNER_FILES` environment
-variable set as described in [`services/scan`](../../../services/scan).
+To scan ballots without scanner hardware use the `MOCK_SCANNER_FILES`
+environment variable set as described in
+[`apps/central-scan/backend`](../../backend).
 
 ## Testing
 

--- a/apps/central-scan/frontend/src/components/scan_button.tsx
+++ b/apps/central-scan/frontend/src/components/scan_button.tsx
@@ -15,7 +15,7 @@ export function ScanButton({
   return (
     <Button
       icon={isScannerAttached ? 'Add' : 'Closed'}
-      disabled={disabled || !isScannerAttached}
+      disabled={disabled || !isScannerAttached || scanBatchMutation.isLoading}
       variant="primary"
       onPress={() => scanBatchMutation.mutate()}
     >

--- a/apps/design/frontend/src/ballot_screen.tsx
+++ b/apps/design/frontend/src/ballot_screen.tsx
@@ -238,7 +238,7 @@ export function BallotScreen(): JSX.Element | null {
   return (
     <TaskScreen>
       <MainWrapper>
-        <TaskControls>
+        <TaskControls style={{ width: '20rem' }}>
           <TaskHeader>
             <H1>{title}</H1>
             <LinkButton

--- a/libs/ui/src/diagnostics/components.ts
+++ b/libs/ui/src/diagnostics/components.ts
@@ -3,6 +3,10 @@ import styled from 'styled-components';
 export const ReportContents = styled.section`
   display: flex;
   flex-direction: column;
-  margin-top: 1.5em;
+
+  &:not(:first-child) {
+    margin-top: 1.5em;
+  }
+
   row-gap: 1.5em;
 `;

--- a/libs/ui/src/election_info_bar.tsx
+++ b/libs/ui/src/election_info_bar.tsx
@@ -166,17 +166,23 @@ export function VerticalElectionInfoBar({
         <Seal seal={seal} maxWidth="3rem" inverse={inverse} />
 
         <Caption weight="regular" align="left">
-          <Font weight="bold">{electionStrings.electionTitle(election)}</Font>
+          <Font weight="bold" maxLines={4}>
+            {electionStrings.electionTitle(election)}
+          </Font>
           {precinctSelection && (
-            <PrecinctSelectionName
-              electionPrecincts={precincts}
-              precinctSelection={precinctSelection}
-            />
+            <Font maxLines={4}>
+              <PrecinctSelectionName
+                electionPrecincts={precincts}
+                precinctSelection={precinctSelection}
+              />
+            </Font>
           )}
 
           <div>
-            {electionStrings.countyName(county)},{' '}
-            {electionStrings.stateName(election)}
+            <Font maxLines={4}>
+              {electionStrings.countyName(county)},{' '}
+              {electionStrings.stateName(election)}
+            </Font>
           </div>
 
           <div>{electionStrings.electionDate(election)}</div>

--- a/libs/ui/src/save_readiness_report_button.tsx
+++ b/libs/ui/src/save_readiness_report_button.tsx
@@ -129,7 +129,7 @@ export function SaveReadinessReportButton(
 
   return (
     <React.Fragment>
-      <Button onPress={() => setIsModalOpen(true)}>
+      <Button style={{ flexShrink: 0 }} onPress={() => setIsModalOpen(true)}>
         Save Readiness Report
       </Button>
       {isModalOpen && (

--- a/libs/ui/src/search_select.tsx
+++ b/libs/ui/src/search_select.tsx
@@ -109,7 +109,7 @@ export function SearchSelect<T extends string = string>({
   ariaLabel,
   disabled,
   placeholder,
-  style,
+  style = {},
 }: SearchSelectSingleProps<T> | SearchSelectMultiProps<T>): JSX.Element {
   const theme = useTheme();
   const borderRadius = `${theme.sizes.borderRadiusRem}rem`;
@@ -140,13 +140,15 @@ export function SearchSelect<T extends string = string>({
       unstyled
       components={{ DropdownIndicator, MultiValueRemove }}
       className="search-select"
+      minMenuHeight="45vh"
+      maxMenuHeight="50vh"
       styles={typedAs<StylesConfig>({
         container: (baseStyles) => ({
           ...baseStyles,
           display: 'inline-block',
           lineHeight: theme.sizes.lineHeight,
           fontWeight: theme.sizes.fontWeight.semiBold,
-          .../* istanbul ignore next */ (style ?? {}),
+          ...style,
         }),
         control: (baseStyles, state) => ({
           ...baseStyles,
@@ -197,9 +199,7 @@ export function SearchSelect<T extends string = string>({
           borderRadius,
           backgroundColor: theme.colors.background,
           top: 'calc(100% + 0.5rem)',
-          // Always match longest option width
-          width: 'max-content',
-          minWidth: '100%',
+          width: '100%',
           zIndex: 10,
         }),
         menuList: (baseStyles) => ({

--- a/libs/ui/src/typography.tsx
+++ b/libs/ui/src/typography.tsx
@@ -18,6 +18,7 @@ export interface FontProps {
   noWrap?: boolean;
   style?: React.CSSProperties;
   weight?: keyof SizeTheme['fontWeight'];
+  maxLines?: number;
 }
 
 /** Props for {@link Pre} */
@@ -38,6 +39,13 @@ export type HeadingProps = Omit<FontProps, 'weight'> & {
   as?: HeadingType;
 };
 
+const maxLinesStyles = css<FontProps>`
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: ${(p) => p.maxLines};
+`;
+
 const fontStyles = css<FontProps>`
   font-size: 1em;
   font-style: ${(p) => (p.italic ? 'italic' : undefined)};
@@ -47,6 +55,7 @@ const fontStyles = css<FontProps>`
   margin: 0;
   text-align: ${(p) => p.align};
   white-space: ${(p) => (p.noWrap ? 'nowrap' : undefined)};
+  ${(p) => p.maxLines && maxLinesStyles}
 `;
 
 const StyledFont = styled.span<FontProps>`


### PR DESCRIPTION
## Overview

Task: #5247 
Fixes: https://github.com/votingworks/vxsuite/issues/5236

An assortment of polish for issues found using an election definition with long content (e.g. 100 character contest and candidate names).

## Demo Video or Screenshot

Added to individual commits

## Testing Plan
Manual testing

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
