### PR TITLE
Break pages up when long enough on tally report

### DIFF
--- a/libs/printing/src/render.test.tsx
+++ b/libs/printing/src/render.test.tsx
@@ -111,6 +111,21 @@ test('page can be longer than letter when using LetterRoll', async () => {
   });
 });
 
+test('page can not be longer than 100 inches when using LetterRoll', async () => {
+  const outputPath = tmpNameSync();
+  const pdfData = await renderToPdf({
+    document: <ManyHeadings count={500} />,
+    outputPath,
+    paperDimensions: PAPER_DIMENSIONS.LetterRoll,
+  });
+
+  const pdf = await parsePdf(pdfData);
+  expect(pdf.numPages).toEqual(3);
+  const { height, width } = (await pdf.getPage(1)).getViewport({ scale: 1 });
+  expect(width * PDF_SCALING).toEqual(1700); // letter
+  expect(height * PDF_SCALING).toEqual(20000); // maximum length
+});
+
 test('bmd 150 page is 13.25"', async () => {
   const outputPath = tmpNameSync();
   const pdfData = await renderToPdf({

--- a/libs/printing/src/render.tsx
+++ b/libs/printing/src/render.tsx
@@ -24,7 +24,7 @@ export const PAPER_DIMENSIONS = {
   // their own, followed by a mostly blank line. This causes stripes in the printed page.
   Bmd150: { width: 7.975, height: 13.25 },
   Letter: { width: 8.5, height: 11 },
-  LetterRoll: { width: 8.5, height: 100 }, // If we make the height infinite the canvas conversion to an image can seg fault. Break into pages beyond 100inches.
+  LetterRoll: { width: 8.5, height: 100 }, // If we make the height infinite the canvas conversion to an image can seg fault. Break into pages beyond 100 inches.
 } satisfies Record<string, PaperDimensions>;
 
 export interface MarginDimensions {


### PR DESCRIPTION
## Overview
Fixes https://github.com/votingworks/vxsuite/issues/5263

On the all bubble ballot the pdf we generate is so long that canvas seg faults when converting to an image. To avoid this problem we can just break up the page when it streches beyond 100 inches, which will never happen in anything but extreme situations. If the content height is longer then a standard paper length but shorter then 100 inches we will still truncate the length of the report to the length of the content (and we will never make it smaller then a standard page). 

Note this change should really only affect the all bubble ballot.
<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot
PDF of printed all bubble polls open report 
[print-job-2024-08-21T00:36:50.587Z.pdf](https://github.com/user-attachments/files/16696348/print-job-2024-08-21T00.36.50.587Z.pdf)

Note the contest starts on the second page because of an unrelated annoyance with how tally reports render for this election. 

## Testing Plan
Used mock printer and inspected pdfs, ran tests and saw them still pass, added new test. 

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
