### PR TITLE
Add high level logging to DB Client

### DIFF
--- a/apps/admin/backend/src/server.test.ts
+++ b/apps/admin/backend/src/server.test.ts
@@ -1,6 +1,6 @@
 import { assert } from '@votingworks/basics';
 
-import { LogEventId } from '@votingworks/logging';
+import { LogEventId, mockBaseLogger } from '@votingworks/logging';
 import { Server } from 'http';
 import { dirSync } from 'tmp';
 import { buildMockDippedSmartCardAuth } from '@votingworks/auth';
@@ -19,7 +19,7 @@ beforeEach(() => {
 
 test('starts with default logger and port', async () => {
   const auth = buildMockDippedSmartCardAuth();
-  const workspace = createWorkspace(dirSync().name);
+  const workspace = createWorkspace(dirSync().name, mockBaseLogger());
   const logger = buildMockLogger(auth, workspace);
   const { usbDrive } = createMockUsbDrive();
   const { printer } = createMockPrinterHandler();
@@ -43,7 +43,7 @@ test('starts with default logger and port', async () => {
 
 test('start with config options', async () => {
   const auth = buildMockDippedSmartCardAuth();
-  const workspace = createWorkspace(dirSync().name);
+  const workspace = createWorkspace(dirSync().name, mockBaseLogger());
   const logger = buildMockLogger(auth, workspace);
   const { usbDrive } = createMockUsbDrive();
   const { printer } = createMockPrinterHandler();
@@ -65,7 +65,7 @@ test('start with config options', async () => {
 
 test('errors on start with no workspace', async () => {
   const auth = buildMockDippedSmartCardAuth();
-  const workspace = createWorkspace(dirSync().name);
+  const workspace = createWorkspace(dirSync().name, mockBaseLogger());
   const logger = buildMockLogger(auth, workspace);
   const { usbDrive } = createMockUsbDrive();
   const { printer } = createMockPrinterHandler();
@@ -98,7 +98,7 @@ test('errors on start with no workspace', async () => {
 
 test('logs device attach/un-attach events', async () => {
   const auth = buildMockDippedSmartCardAuth();
-  const workspace = createWorkspace(dirSync().name);
+  const workspace = createWorkspace(dirSync().name, mockBaseLogger());
   const logger = buildMockLogger(auth, workspace);
   const { usbDrive } = createMockUsbDrive();
   const { printer } = createMockPrinterHandler();

--- a/apps/admin/backend/src/server.ts
+++ b/apps/admin/backend/src/server.ts
@@ -66,7 +66,7 @@ export async function start({
         'workspace path could not be determined; pass a workspace or run with ADMIN_WORKSPACE'
       );
     }
-    resolvedWorkspace = createWorkspace(workspacePath);
+    resolvedWorkspace = createWorkspace(workspacePath, baseLogger);
   }
   /* c8 ignore stop */
 

--- a/apps/admin/backend/src/store.test.ts
+++ b/apps/admin/backend/src/store.test.ts
@@ -15,6 +15,7 @@ import { join } from 'path';
 import { tmpNameSync } from 'tmp';
 import { zipFile } from '@votingworks/test-utils';
 import { sha256 } from 'js-sha256';
+import { mockBaseLogger } from '@votingworks/logging';
 import { Store } from './store';
 import {
   ElectionRecord,
@@ -26,7 +27,7 @@ test('create a file store', async () => {
   const tmpDir = tmpNameSync();
   await fs.mkdir(tmpDir);
   const tmpDbPath = join(tmpDir, 'ballots.db');
-  const store = Store.fileStore(tmpDbPath);
+  const store = Store.fileStore(tmpDbPath, mockBaseLogger());
 
   expect(store).toBeInstanceOf(Store);
   expect(store.getDbPath()).toEqual(tmpDbPath);
@@ -600,7 +601,7 @@ test('deleteElection reclaims disk space (vacuums the database)', async () => {
   const tmpDir = tmpNameSync();
   await fs.mkdir(tmpDir);
   const tmpDbPath = join(tmpDir, 'data.db');
-  const store = Store.fileStore(tmpDbPath);
+  const store = Store.fileStore(tmpDbPath, mockBaseLogger());
 
   const electionId = store.addElection({
     electionData:

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -60,6 +60,7 @@ import {
   getMostRecentDiagnosticRecord,
   updateMaximumUsableDiskSpace,
 } from '@votingworks/backend';
+import { BaseLogger } from '@votingworks/logging';
 import {
   CastVoteRecordFileRecord,
   CastVoteRecordFileRecordSchema,
@@ -156,8 +157,8 @@ export class Store {
   /**
    * Builds and returns a new store at `dbPath`.
    */
-  static fileStore(dbPath: string): Store {
-    return new Store(DbClient.fileClient(dbPath, SchemaPath));
+  static fileStore(dbPath: string, logger: BaseLogger): Store {
+    return new Store(DbClient.fileClient(dbPath, logger, SchemaPath));
   }
 
   /**

--- a/apps/admin/backend/src/util/workspace.test.ts
+++ b/apps/admin/backend/src/util/workspace.test.ts
@@ -1,6 +1,7 @@
 import * as tmp from 'tmp';
 import { mockOf } from '@votingworks/test-utils';
 import { initializeGetWorkspaceDiskSpaceSummary } from '@votingworks/backend';
+import { mockBaseLogger } from '@votingworks/logging';
 import { createWorkspace } from './workspace';
 import { Store } from '../store';
 
@@ -18,7 +19,7 @@ const initializeGetWorkspaceDiskSpaceSummaryMock = mockOf(
 
 test('createWorkspace', () => {
   const dir = tmp.dirSync();
-  const workspace = createWorkspace(dir.name);
+  const workspace = createWorkspace(dir.name, mockBaseLogger());
   expect(workspace.path).toEqual(dir.name);
   expect(workspace.store).toBeInstanceOf(Store);
 });
@@ -29,7 +30,7 @@ test('disk space tracking setup', () => {
   initializeGetWorkspaceDiskSpaceSummaryMock.mockReturnValueOnce(
     getWorkspaceDiskSpaceSummary
   );
-  const workspace = createWorkspace(dir.name);
+  const workspace = createWorkspace(dir.name, mockBaseLogger());
   expect(initializeGetWorkspaceDiskSpaceSummaryMock).toHaveBeenCalledTimes(1);
   expect(initializeGetWorkspaceDiskSpaceSummaryMock).toHaveBeenCalledWith(
     workspace.store,

--- a/apps/admin/backend/src/util/workspace.ts
+++ b/apps/admin/backend/src/util/workspace.ts
@@ -4,6 +4,7 @@ import {
   DiskSpaceSummary,
   initializeGetWorkspaceDiskSpaceSummary,
 } from '@votingworks/backend';
+import { BaseLogger } from '@votingworks/logging';
 import { Store } from '../store';
 
 /**
@@ -18,12 +19,12 @@ export interface Workspace {
 /**
  * Returns a Workspace with the path of the working directory and store.
  */
-export function createWorkspace(root: string): Workspace {
+export function createWorkspace(root: string, logger: BaseLogger): Workspace {
   const resolvedRoot = resolve(root);
   ensureDirSync(resolvedRoot);
 
   const dbPath = join(resolvedRoot, 'data.db');
-  const store = Store.fileStore(dbPath);
+  const store = Store.fileStore(dbPath, logger);
 
   // check disk space on summary to detect a new maximum available disk space
   const getWorkspaceDiskSpaceSummary = initializeGetWorkspaceDiskSpaceSummary(

--- a/apps/admin/backend/test/app.ts
+++ b/apps/admin/backend/test/app.ts
@@ -29,7 +29,12 @@ import {
 import { createMockUsbDrive } from '@votingworks/usb-drive';
 import { writeFileSync } from 'fs';
 import { createMockPrinterHandler } from '@votingworks/printing';
-import { Logger, LogSource, mockLogger } from '@votingworks/logging';
+import {
+  Logger,
+  LogSource,
+  mockBaseLogger,
+  mockLogger,
+} from '@votingworks/logging';
 import { Api } from '../src';
 import { createWorkspace, Workspace } from '../src/util/workspace';
 import { buildApp } from '../src/app';
@@ -142,7 +147,7 @@ export function buildTestEnvironment(workspaceRoot?: string) {
       deleteTmpFileAfterTestSuiteCompletes(defaultWorkspaceRoot);
       return defaultWorkspaceRoot;
     })();
-  const workspace = createWorkspace(resolvedWorkspaceRoot);
+  const workspace = createWorkspace(resolvedWorkspaceRoot, mockBaseLogger());
   const logger = buildMockLogger(auth, workspace);
   const mockUsbDrive = createMockUsbDrive();
   const mockPrinterHandler = createMockPrinterHandler();

--- a/apps/central-scan/backend/scripts/copy_batch.ts
+++ b/apps/central-scan/backend/scripts/copy_batch.ts
@@ -9,6 +9,7 @@ import {
 } from '@votingworks/basics';
 import { Id, safeParseInt } from '@votingworks/types';
 
+import { BaseLogger, LogSource } from '@votingworks/logging';
 import { SCAN_WORKSPACE } from '../src/globals';
 import { Store } from '../src/store';
 import { createWorkspace } from '../src/util/workspace';
@@ -91,7 +92,10 @@ function getAcceptedSheetsInBatch(
 }
 
 function copyBatch({ batchName, numCopies }: CopyBatchInput): void {
-  const { store } = createWorkspace(assertDefined(SCAN_WORKSPACE));
+  const { store } = createWorkspace(
+    assertDefined(SCAN_WORKSPACE),
+    new BaseLogger(LogSource.VxDevelopmentScript)
+  );
 
   const sheets = getAcceptedSheetsInBatch(store, batchName);
 

--- a/apps/central-scan/backend/src/app.deprecated_api.test.ts
+++ b/apps/central-scan/backend/src/app.deprecated_api.test.ts
@@ -21,7 +21,7 @@ import {
   DippedSmartCardAuthApi,
 } from '@votingworks/auth';
 import { Server } from 'http';
-import { Logger } from '@votingworks/logging';
+import { Logger, mockBaseLogger } from '@votingworks/logging';
 import { MockUsbDrive, createMockUsbDrive } from '@votingworks/usb-drive';
 import { makeMock, makeMockScanner } from '../test/util/mocks';
 import { Importer } from './importer';
@@ -43,7 +43,7 @@ let mockUsbDrive: MockUsbDrive;
 
 beforeEach(() => {
   auth = buildMockDippedSmartCardAuth();
-  workspace = createWorkspace(dirSync().name);
+  workspace = createWorkspace(dirSync().name, mockBaseLogger());
   workspace.store.setElectionAndJurisdiction({
     electionData:
       electionGridLayoutNewHampshireTestBallotFixtures.electionDefinition

--- a/apps/central-scan/backend/src/auth.test.ts
+++ b/apps/central-scan/backend/src/auth.test.ts
@@ -7,7 +7,7 @@ import {
   DippedSmartCardAuthApi,
 } from '@votingworks/auth';
 import * as grout from '@votingworks/grout';
-import { Logger } from '@votingworks/logging';
+import { Logger, mockBaseLogger } from '@votingworks/logging';
 import {
   DEFAULT_SYSTEM_SETTINGS,
   constructElectionKey,
@@ -33,7 +33,7 @@ let logger: Logger;
 beforeEach(async () => {
   const port = await getPort();
   auth = buildMockDippedSmartCardAuth();
-  workspace = createWorkspace(dirSync().name);
+  workspace = createWorkspace(dirSync().name, mockBaseLogger());
   logger = buildMockLogger(auth, workspace);
   const scanner = makeMockScanner();
 

--- a/apps/central-scan/backend/src/importer.test.ts
+++ b/apps/central-scan/backend/src/importer.test.ts
@@ -1,12 +1,12 @@
 import { dirSync } from 'tmp';
-import { mockLogger } from '@votingworks/logging';
+import { mockBaseLogger, mockLogger } from '@votingworks/logging';
 import { createImageData } from 'canvas';
 import { Importer } from './importer';
 import { createWorkspace } from './util/workspace';
 import { makeMockScanner } from '../test/util/mocks';
 
 test('no election is configured', async () => {
-  const workspace = createWorkspace(dirSync().name);
+  const workspace = createWorkspace(dirSync().name, mockBaseLogger());
   const scanner = makeMockScanner();
   const importer = new Importer({
     workspace,

--- a/apps/central-scan/backend/src/server.test.ts
+++ b/apps/central-scan/backend/src/server.test.ts
@@ -3,6 +3,7 @@ import { dirSync } from 'tmp';
 import { createMockUsbDrive } from '@votingworks/usb-drive';
 import { testDetectDevices } from '@votingworks/backend';
 import { Server } from 'http';
+import { mockBaseLogger } from '@votingworks/logging';
 import { createWorkspace } from './util/workspace';
 import { buildMockLogger } from '../test/helpers/setup_app';
 import { makeMockScanner } from '../test/util/mocks';
@@ -12,7 +13,7 @@ import { start } from './server';
 
 test('logs device attach/un-attach events', async () => {
   const auth = buildMockDippedSmartCardAuth();
-  const workspace = createWorkspace(dirSync().name);
+  const workspace = createWorkspace(dirSync().name, mockBaseLogger());
   const logger = buildMockLogger(auth, workspace);
   const { usbDrive } = createMockUsbDrive();
   const scanner = makeMockScanner();

--- a/apps/central-scan/backend/src/server.ts
+++ b/apps/central-scan/backend/src/server.ts
@@ -62,7 +62,7 @@ export async function start({
         'workspace path could not be determined; pass a workspace or run with SCAN_WORKSPACE'
       );
     }
-    resolvedWorkspace = createWorkspace(workspacePath);
+    resolvedWorkspace = createWorkspace(workspacePath, baseLogger);
   }
   /* c8 ignore stop */
 

--- a/apps/central-scan/backend/src/store.test.ts
+++ b/apps/central-scan/backend/src/store.test.ts
@@ -21,6 +21,7 @@ import { sleep } from '@votingworks/basics';
 import { AcceptedSheet, RejectedSheet } from '@votingworks/backend';
 import { electionGridLayoutNewHampshireTestBallotFixtures } from '@votingworks/fixtures';
 import { sha256 } from 'js-sha256';
+import { mockBaseLogger } from '@votingworks/logging';
 import { zeroRect } from '../test/fixtures/zero_rect';
 import { Store } from './store';
 
@@ -181,7 +182,7 @@ test('get/set scanner as backed up', () => {
 
 test('batch cleanup works correctly', () => {
   const dbFile = tmp.fileSync();
-  const store = Store.fileStore(dbFile.name);
+  const store = Store.fileStore(dbFile.name, mockBaseLogger());
 
   store.reset();
 
@@ -752,7 +753,7 @@ test('iterating over each accepted sheet includes correct batch sequence id', ()
 
 test('resetElectionSession', () => {
   const dbFile = tmp.fileSync();
-  const store = Store.fileStore(dbFile.name);
+  const store = Store.fileStore(dbFile.name, mockBaseLogger());
   store.setElectionAndJurisdiction({
     electionData,
     jurisdiction,

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -57,6 +57,7 @@ import {
   getCastVoteRecordRootHash,
   updateCastVoteRecordHashes,
 } from '@votingworks/auth';
+import { BaseLogger } from '@votingworks/logging';
 import { sheetRequiresAdjudication } from './sheet_requires_adjudication';
 import { normalizeAndJoin } from './util/path';
 
@@ -169,8 +170,8 @@ export class Store {
   /**
    * Builds and returns a new store at `dbPath`.
    */
-  static fileStore(dbPath: string): Store {
-    return new Store(DbClient.fileClient(dbPath, SchemaPath));
+  static fileStore(dbPath: string, logger: BaseLogger): Store {
+    return new Store(DbClient.fileClient(dbPath, logger, SchemaPath));
   }
 
   /**

--- a/apps/central-scan/backend/src/util/workspace.test.ts
+++ b/apps/central-scan/backend/src/util/workspace.test.ts
@@ -1,6 +1,7 @@
 import { initializeGetWorkspaceDiskSpaceSummary } from '@votingworks/backend';
 import { mockOf } from '@votingworks/test-utils';
 import tmp from 'tmp';
+import { mockBaseLogger } from '@votingworks/logging';
 import { createWorkspace } from './workspace';
 
 jest.mock(
@@ -21,7 +22,7 @@ test('disk space tracking setup', () => {
   initializeGetWorkspaceDiskSpaceSummaryMock.mockReturnValueOnce(
     getWorkspaceDiskSpaceSummary
   );
-  const workspace = createWorkspace(dir.name);
+  const workspace = createWorkspace(dir.name, mockBaseLogger());
   expect(initializeGetWorkspaceDiskSpaceSummaryMock).toHaveBeenCalledTimes(1);
   expect(initializeGetWorkspaceDiskSpaceSummaryMock).toHaveBeenCalledWith(
     workspace.store,

--- a/apps/central-scan/backend/src/util/workspace.ts
+++ b/apps/central-scan/backend/src/util/workspace.ts
@@ -4,6 +4,7 @@ import {
   DiskSpaceSummary,
   initializeGetWorkspaceDiskSpaceSummary,
 } from '@votingworks/backend';
+import { BaseLogger } from '@votingworks/logging';
 import { Store } from '../store';
 
 export interface Workspace {
@@ -54,7 +55,7 @@ export interface Workspace {
   getDiskSpaceSummary: () => Promise<DiskSpaceSummary>;
 }
 
-export function createWorkspace(root: string): Workspace {
+export function createWorkspace(root: string, logger: BaseLogger): Workspace {
   const resolvedRoot = resolve(root);
   const ballotImagesPath = join(resolvedRoot, 'ballot-images');
   const scannedImagesPath = join(ballotImagesPath, 'scanned-images');
@@ -63,7 +64,7 @@ export function createWorkspace(root: string): Workspace {
   ensureDirSync(scannedImagesPath);
 
   const dbPath = join(resolvedRoot, 'ballots.db');
-  const store = Store.fileStore(dbPath);
+  const store = Store.fileStore(dbPath, logger);
   const getWorkspaceDiskSpaceSummary = initializeGetWorkspaceDiskSpaceSummary(
     store,
     [resolvedRoot]

--- a/apps/central-scan/backend/test/helpers/setup_app.ts
+++ b/apps/central-scan/backend/test/helpers/setup_app.ts
@@ -1,5 +1,10 @@
 import { Application } from 'express';
-import { LogSource, Logger, mockLogger } from '@votingworks/logging';
+import {
+  LogSource,
+  Logger,
+  mockBaseLogger,
+  mockLogger,
+} from '@votingworks/logging';
 import { Server } from 'http';
 import * as grout from '@votingworks/grout';
 import {
@@ -43,7 +48,7 @@ export async function withApp(
 ): Promise<void> {
   const port = await getPort();
   const auth = buildMockDippedSmartCardAuth();
-  const workspace = createWorkspace(dirSync().name);
+  const workspace = createWorkspace(dirSync().name, mockBaseLogger());
   const logger = buildMockLogger(auth, workspace);
   const scanner = makeMockScanner();
   const importer = new Importer({ workspace, scanner, logger });

--- a/apps/design/backend/package.json
+++ b/apps/design/backend/package.json
@@ -44,6 +44,7 @@
     "@votingworks/db": "workspace:*",
     "@votingworks/grout": "workspace:*",
     "@votingworks/hmpb": "workspace:*",
+    "@votingworks/logging": "workspace:*",
     "@votingworks/printing": "workspace:*",
     "@votingworks/types": "workspace:*",
     "@votingworks/ui": "workspace:*",

--- a/apps/design/backend/src/index.ts
+++ b/apps/design/backend/src/index.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'path';
 import { loadEnvVarsFromDotenvFiles } from '@votingworks/backend';
+import { BaseLogger, LogSource } from '@votingworks/logging';
 import { WORKSPACE } from './globals';
 import * as server from './server';
 import { createWorkspace } from './workspace';
@@ -34,7 +35,10 @@ function main(): Promise<number> {
     );
   }
   const workspacePath = resolve(WORKSPACE);
-  const workspace = createWorkspace(workspacePath);
+  const workspace = createWorkspace(
+    workspacePath,
+    new BaseLogger(LogSource.VxDesignService)
+  );
   const { store } = workspace;
   const speechSynthesizer = new GoogleCloudSpeechSynthesizer({ store });
   const translator = new GoogleCloudTranslator({ store });

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -16,6 +16,7 @@ import {
   BooleanEnvironmentVariableName,
   isFeatureFlagEnabled,
 } from '@votingworks/utils';
+import { BaseLogger } from '@votingworks/logging';
 import {
   BallotLanguageConfig,
   BallotLanguageConfigs,
@@ -161,8 +162,8 @@ export class Store {
   /**
    * Builds and returns a new store at `dbPath`.
    */
-  static fileStore(dbPath: string): Store {
-    return new Store(DbClient.fileClient(dbPath, SchemaPath));
+  static fileStore(dbPath: string, logger: BaseLogger): Store {
+    return new Store(DbClient.fileClient(dbPath, logger, SchemaPath));
   }
 
   /**

--- a/apps/design/backend/src/worker/index.ts
+++ b/apps/design/backend/src/worker/index.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import { loadEnvVarsFromDotenvFiles } from '@votingworks/backend';
 import { assertDefined } from '@votingworks/basics';
 
+import { BaseLogger, LogSource } from '@votingworks/logging';
 import { WORKSPACE } from '../globals';
 import {
   GoogleCloudSpeechSynthesizer,
@@ -14,7 +15,10 @@ loadEnvVarsFromDotenvFiles();
 
 async function main(): Promise<void> {
   const workspacePath = path.resolve(assertDefined(WORKSPACE));
-  const workspace = createWorkspace(workspacePath);
+  const workspace = createWorkspace(
+    workspacePath,
+    new BaseLogger(LogSource.VxDesignWorker)
+  );
   const { store } = workspace;
   const speechSynthesizer = new GoogleCloudSpeechSynthesizer({ store });
   const translator = new GoogleCloudTranslator({ store });

--- a/apps/design/backend/src/workspace.ts
+++ b/apps/design/backend/src/workspace.ts
@@ -1,6 +1,7 @@
 import { ensureDirSync } from 'fs-extra';
 import { join } from 'path';
 
+import { BaseLogger } from '@votingworks/logging';
 import { Store } from './store';
 
 export interface Workspace {
@@ -8,14 +9,17 @@ export interface Workspace {
   store: Store;
 }
 
-export function createWorkspace(workspacePath: string): Workspace {
+export function createWorkspace(
+  workspacePath: string,
+  logger: BaseLogger
+): Workspace {
   ensureDirSync(workspacePath);
 
   const assetDirectoryPath = join(workspacePath, 'assets');
   ensureDirSync(assetDirectoryPath);
 
   const dbPath = join(workspacePath, 'design-backend.db');
-  const store = Store.fileStore(dbPath);
+  const store = Store.fileStore(dbPath, logger);
 
   return { assetDirectoryPath, store };
 }

--- a/apps/design/backend/test/helpers.ts
+++ b/apps/design/backend/test/helpers.ts
@@ -7,6 +7,7 @@ import * as grout from '@votingworks/grout';
 import { suppressingConsoleOutput } from '@votingworks/test-utils';
 import { assertDefined } from '@votingworks/basics';
 import { ElectionSerializationFormat, LanguageCode } from '@votingworks/types';
+import { mockBaseLogger } from '@votingworks/logging';
 import { buildApp } from '../src/app';
 import type { Api } from '../src/app';
 import {
@@ -97,7 +98,7 @@ export function testSetupHelpers() {
   const servers: Server[] = [];
 
   function setupApp() {
-    const workspace = createWorkspace(tmp.dirSync().name);
+    const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger());
     const { store } = workspace;
     const speechSynthesizer = new GoogleCloudSpeechSynthesizer({
       store,

--- a/apps/mark-scan/backend/src/app.preprinted_ballot_insertion.test.ts
+++ b/apps/mark-scan/backend/src/app.preprinted_ballot_insertion.test.ts
@@ -5,6 +5,7 @@ import { createMockUsbDrive } from '@votingworks/usb-drive';
 import { typedAs } from '@votingworks/basics';
 import { Browser, launchBrowser } from '@votingworks/printing';
 
+import { mockBaseLogger } from '@votingworks/logging';
 import { Store } from './store';
 import { createWorkspace } from './util/workspace';
 import { buildApi } from './app';
@@ -30,7 +31,9 @@ afterEach(async () => {
 
 function buildTestApi() {
   const store = Store.memoryStore();
-  const workspace = createWorkspace(tmp.dirSync().name, { store });
+  const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger(), {
+    store,
+  });
   const mockAuth = buildMockInsertedSmartCardAuth();
   const mockStateMachine = getMockStateMachine();
 

--- a/apps/mark-scan/backend/src/app.test.ts
+++ b/apps/mark-scan/backend/src/app.test.ts
@@ -36,7 +36,7 @@ import {
 } from '@votingworks/types';
 import { MockUsbDrive } from '@votingworks/usb-drive';
 import { MockPaperHandlerDriver } from '@votingworks/custom-paper-handler';
-import { LogEventId, Logger } from '@votingworks/logging';
+import { LogEventId, Logger, mockBaseLogger } from '@votingworks/logging';
 import { Browser } from '@votingworks/printing';
 import { AddressInfo } from 'net';
 import { SimulatedClock } from 'xstate/lib/SimulatedClock';
@@ -661,7 +661,7 @@ test('addDiagnosticRecord', async () => {
 });
 
 test('startPaperHandlerDiagnostic fails test if no state machine', async () => {
-  const workspace = createWorkspace(tmp.dirSync().name);
+  const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger());
   const app = buildApp(
     mockAuth,
     logger,

--- a/apps/mark-scan/backend/src/app.ui_strings.test.ts
+++ b/apps/mark-scan/backend/src/app.ui_strings.test.ts
@@ -16,6 +16,7 @@ import {
 } from '@votingworks/utils';
 import { MockUsbDrive, createMockUsbDrive } from '@votingworks/usb-drive';
 import { Browser } from '@votingworks/printing';
+import { mockBaseLogger } from '@votingworks/logging';
 import { Store } from './store';
 import { createWorkspace } from './util/workspace';
 import { Api, buildApi } from './app';
@@ -32,7 +33,9 @@ jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
 });
 
 const store = Store.memoryStore();
-const workspace = createWorkspace(tmp.dirSync().name, { store });
+const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger(), {
+  store,
+});
 const mockAuth = buildMockInsertedSmartCardAuth();
 const electionDefinition = safeParseElectionDefinition(
   JSON.stringify(testCdfBallotDefinition)

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -157,7 +157,7 @@ beforeEach(async () => {
 
   logger = mockBaseLogger();
   auth = buildMockInsertedSmartCardAuth();
-  workspace = createWorkspace(dirSync().name);
+  workspace = createWorkspace(dirSync().name, mockBaseLogger());
   workspace.store.setElectionAndJurisdiction({
     electionData: electionGeneralDefinition.electionData,
     jurisdiction: TEST_JURISDICTION,

--- a/apps/mark-scan/backend/src/index.ts
+++ b/apps/mark-scan/backend/src/index.ts
@@ -27,7 +27,7 @@ async function resolveWorkspace(): Promise<Workspace> {
       'workspace path could not be determined; pass a workspace or run with MARK_SCAN_WORKSPACE'
     );
   }
-  return createWorkspace(workspacePath);
+  return createWorkspace(workspacePath, logger);
 }
 
 async function main(): Promise<number> {

--- a/apps/mark-scan/backend/src/server.test.ts
+++ b/apps/mark-scan/backend/src/server.test.ts
@@ -1,4 +1,4 @@
-import { LogEventId, mockLogger } from '@votingworks/logging';
+import { LogEventId, mockBaseLogger, mockLogger } from '@votingworks/logging';
 import tmp from 'tmp';
 import { buildMockInsertedSmartCardAuth } from '@votingworks/auth';
 import {
@@ -35,7 +35,7 @@ afterEach(() => {
 test('can start server', async () => {
   const auth = buildMockInsertedSmartCardAuth();
   const logger = mockLogger();
-  const workspace = createWorkspace(tmp.dirSync().name);
+  const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger());
 
   const server = await start({
     auth,
@@ -55,7 +55,7 @@ test('can start without providing auth', async () => {
   );
 
   const logger = mockLogger();
-  const workspace = createWorkspace(tmp.dirSync().name);
+  const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger());
 
   const server = await start({
     logger,
@@ -72,7 +72,7 @@ test('logs device attach/un-attach events', async () => {
     BooleanEnvironmentVariableName.USE_MOCK_CARDS
   );
   const logger = mockLogger();
-  const workspace = createWorkspace(tmp.dirSync().name);
+  const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger());
 
   const server = await start({
     logger,

--- a/apps/mark-scan/backend/src/store.ts
+++ b/apps/mark-scan/backend/src/store.ts
@@ -12,6 +12,7 @@ import {
 } from '@votingworks/backend';
 import { assertDefined, DateWithoutTime, Optional } from '@votingworks/basics';
 import { Client as DbClient } from '@votingworks/db';
+import { BaseLogger } from '@votingworks/logging';
 import {
   ElectionDefinition,
   PrecinctSelection,
@@ -63,8 +64,8 @@ export class Store {
   /**
    * Builds and returns a new store at `dbPath`.
    */
-  static fileStore(dbPath: string): Store {
-    const client = DbClient.fileClient(dbPath, SchemaPath);
+  static fileStore(dbPath: string, logger: BaseLogger): Store {
+    const client = DbClient.fileClient(dbPath, logger, SchemaPath);
     const uiStringsStore = createUiStringStore(client);
     return new Store(client, uiStringsStore);
   }

--- a/apps/mark-scan/backend/src/util/workspace.test.ts
+++ b/apps/mark-scan/backend/src/util/workspace.test.ts
@@ -1,6 +1,7 @@
 import { dirSync } from 'tmp';
 import { mockOf } from '@votingworks/test-utils';
 import { initializeGetWorkspaceDiskSpaceSummary } from '@votingworks/backend';
+import { mockBaseLogger } from '@votingworks/logging';
 import { createWorkspace } from './workspace';
 
 jest.mock(
@@ -16,7 +17,7 @@ const initializeGetWorkspaceDiskSpaceSummaryMock = mockOf(
 );
 
 test('workspace.reset rests the store', () => {
-  const workspace = createWorkspace(dirSync().name);
+  const workspace = createWorkspace(dirSync().name, mockBaseLogger());
   const fn = jest.fn();
   workspace.store.reset = fn;
   workspace.reset();
@@ -29,7 +30,7 @@ test('disk space tracking setup', () => {
   initializeGetWorkspaceDiskSpaceSummaryMock.mockReturnValueOnce(
     getWorkspaceDiskSpaceSummary
   );
-  const workspace = createWorkspace(dir.name);
+  const workspace = createWorkspace(dir.name, mockBaseLogger());
   expect(initializeGetWorkspaceDiskSpaceSummaryMock).toHaveBeenCalledTimes(1);
   expect(initializeGetWorkspaceDiskSpaceSummaryMock).toHaveBeenCalledWith(
     workspace.store,

--- a/apps/mark-scan/backend/src/util/workspace.ts
+++ b/apps/mark-scan/backend/src/util/workspace.ts
@@ -4,6 +4,7 @@ import {
   DiskSpaceSummary,
   initializeGetWorkspaceDiskSpaceSummary,
 } from '@votingworks/backend';
+import { BaseLogger } from '@votingworks/logging';
 import { Store } from '../store';
 
 export interface Workspace {
@@ -31,13 +32,14 @@ export interface Workspace {
 
 export function createWorkspace(
   root: string,
+  logger: BaseLogger,
   options: { store?: Store } = {}
 ): Workspace {
   const resolvedRoot = resolve(root);
   ensureDirSync(resolvedRoot);
 
   const dbPath = join(resolvedRoot, 'mark.db');
-  const store = options.store || Store.fileStore(dbPath);
+  const store = options.store || Store.fileStore(dbPath, logger);
   const getWorkspaceDiskSpaceSummary = initializeGetWorkspaceDiskSpaceSummary(
     store,
     [resolvedRoot]

--- a/apps/mark-scan/backend/test/app_helpers.ts
+++ b/apps/mark-scan/backend/test/app_helpers.ts
@@ -10,6 +10,7 @@ import {
   mockLogger,
   LogSource,
   Logger,
+  mockBaseLogger,
 } from '@votingworks/logging';
 import tmp from 'tmp';
 import { mockElectionPackageFileTree } from '@votingworks/backend';
@@ -97,7 +98,7 @@ export async function createApp(
   options?: CreateAppOptions
 ): Promise<MockAppContents> {
   const mockAuth = buildMockInsertedSmartCardAuth();
-  const workspace = createWorkspace(tmp.dirSync().name);
+  const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger());
   const logger = buildMockLogger(mockAuth, workspace);
   const mockUsbDrive = createMockUsbDrive();
   const browser = await launchBrowser();

--- a/apps/mark/backend/src/app.ui_strings.test.ts
+++ b/apps/mark/backend/src/app.ui_strings.test.ts
@@ -22,6 +22,7 @@ import {
 } from '@votingworks/test-utils';
 import { MockUsbDrive, createMockUsbDrive } from '@votingworks/usb-drive';
 import { createMockPrinterHandler } from '@votingworks/printing';
+import { mockBaseLogger } from '@votingworks/logging';
 import { Store } from './store';
 import { createWorkspace } from './util/workspace';
 import { Api, buildApi } from './app';
@@ -37,7 +38,9 @@ jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
 });
 
 const store = Store.memoryStore();
-const workspace = createWorkspace(tmp.dirSync().name, { store });
+const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger(), {
+  store,
+});
 const mockAuth = buildMockInsertedSmartCardAuth();
 const electionDefinition = safeParseElectionDefinition(
   JSON.stringify(testCdfBallotDefinition)

--- a/apps/mark/backend/src/index.ts
+++ b/apps/mark/backend/src/index.ts
@@ -26,7 +26,7 @@ async function resolveWorkspace(): Promise<Workspace> {
       'workspace path could not be determined; pass a workspace or run with MARK_WORKSPACE'
     );
   }
-  return createWorkspace(workspacePath);
+  return createWorkspace(workspacePath, baseLogger);
 }
 
 async function main(): Promise<number> {

--- a/apps/mark/backend/src/server.test.ts
+++ b/apps/mark/backend/src/server.test.ts
@@ -17,7 +17,7 @@ jest.mock('@votingworks/backend', (): typeof import('@votingworks/backend') => {
 test('can start server', async () => {
   const auth = buildMockInsertedSmartCardAuth();
   const baseLogger = mockBaseLogger();
-  const workspace = createWorkspace(tmp.dirSync().name);
+  const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger());
 
   const server = await start({
     auth,

--- a/apps/mark/backend/src/store.ts
+++ b/apps/mark/backend/src/store.ts
@@ -5,6 +5,7 @@
 import { UiStringsStore, createUiStringStore } from '@votingworks/backend';
 import { assertDefined, DateWithoutTime, Optional } from '@votingworks/basics';
 import { Client as DbClient } from '@votingworks/db';
+import { BaseLogger } from '@votingworks/logging';
 import {
   ElectionDefinition,
   safeParseElectionDefinition,
@@ -54,8 +55,8 @@ export class Store {
   /**
    * Builds and returns a new store at `dbPath`.
    */
-  static fileStore(dbPath: string): Store {
-    const client = DbClient.fileClient(dbPath, SchemaPath);
+  static fileStore(dbPath: string, logger: BaseLogger): Store {
+    const client = DbClient.fileClient(dbPath, logger, SchemaPath);
     const uiStringsStore = createUiStringStore(client);
     return new Store(client, uiStringsStore);
   }

--- a/apps/mark/backend/src/util/workspace.test.ts
+++ b/apps/mark/backend/src/util/workspace.test.ts
@@ -1,8 +1,9 @@
 import { dirSync } from 'tmp';
+import { mockBaseLogger } from '@votingworks/logging';
 import { createWorkspace } from './workspace';
 
 test('workspace.reset rests the store', () => {
-  const workspace = createWorkspace(dirSync().name);
+  const workspace = createWorkspace(dirSync().name, mockBaseLogger());
   const fn = jest.fn();
   workspace.store.reset = fn;
   workspace.reset();

--- a/apps/mark/backend/src/util/workspace.ts
+++ b/apps/mark/backend/src/util/workspace.ts
@@ -1,5 +1,6 @@
 import { ensureDirSync } from 'fs-extra';
 import { join, resolve } from 'path';
+import { BaseLogger } from '@votingworks/logging';
 import { Store } from '../store';
 
 export interface Workspace {
@@ -22,13 +23,14 @@ export interface Workspace {
 
 export function createWorkspace(
   root: string,
+  baseLogger: BaseLogger,
   options: { store?: Store } = {}
 ): Workspace {
   const resolvedRoot = resolve(root);
   ensureDirSync(resolvedRoot);
 
   const dbPath = join(resolvedRoot, 'mark.db');
-  const store = options.store || Store.fileStore(dbPath);
+  const store = options.store || Store.fileStore(dbPath, baseLogger);
 
   return {
     path: resolvedRoot,

--- a/apps/mark/backend/test/app_helpers.ts
+++ b/apps/mark/backend/test/app_helpers.ts
@@ -5,7 +5,12 @@ import {
 import * as grout from '@votingworks/grout';
 import { Application } from 'express';
 import { AddressInfo } from 'net';
-import { mockLogger, LogSource, Logger } from '@votingworks/logging';
+import {
+  mockLogger,
+  LogSource,
+  Logger,
+  mockBaseLogger,
+} from '@votingworks/logging';
 import tmp from 'tmp';
 import { mockElectionPackageFileTree } from '@votingworks/backend';
 import { Server } from 'http';
@@ -50,7 +55,7 @@ export function buildMockLogger(
 }
 
 export function createApp(): MockAppContents {
-  const workspace = createWorkspace(tmp.dirSync().name);
+  const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger());
   const mockAuth = buildMockInsertedSmartCardAuth();
   const logger = buildMockLogger(mockAuth, workspace);
   const mockUsbDrive = createMockUsbDrive();

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -156,7 +156,7 @@ export function AppRoot({ reload }: Props): JSX.Element | null {
   const printerStatus: PrinterStatus = printerStatusQuery.isSuccess
     ? printerStatusQuery.data
     : { connected: false };
-  const hasPrinterAttached = printerStatus.connected;
+  const hasPrinterAttached = 1 || printerStatus.connected;
   const usbDriveStatusQuery = getUsbDriveStatus.useQuery();
   const authStatusQuery = getAuthStatus.useQuery();
   const authStatus = authStatusQuery.isSuccess

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -156,7 +156,7 @@ export function AppRoot({ reload }: Props): JSX.Element | null {
   const printerStatus: PrinterStatus = printerStatusQuery.isSuccess
     ? printerStatusQuery.data
     : { connected: false };
-  const hasPrinterAttached = 1 || printerStatus.connected;
+  const hasPrinterAttached = printerStatus.connected;
   const usbDriveStatusQuery = getUsbDriveStatus.useQuery();
   const authStatusQuery = getAuthStatus.useQuery();
   const authStatus = authStatusQuery.isSuccess

--- a/apps/scan/backend/scripts/copy_sheets.ts
+++ b/apps/scan/backend/scripts/copy_sheets.ts
@@ -10,6 +10,7 @@ import {
 } from '@votingworks/basics';
 import { safeParseInt } from '@votingworks/types';
 
+import { BaseLogger, LogSource } from '@votingworks/logging';
 import { SCAN_WORKSPACE } from '../src/globals';
 import { Store } from '../src/store';
 import { createWorkspace } from '../src/util/workspace';
@@ -69,7 +70,10 @@ function copySheet(store: Store, sheet: AcceptedSheet): string {
 }
 
 function copySheets({ targetSheetCount }: CopySheetsInput): void {
-  const { store } = createWorkspace(assertDefined(SCAN_WORKSPACE));
+  const { store } = createWorkspace(
+    assertDefined(SCAN_WORKSPACE),
+    new BaseLogger(LogSource.VxDevelopmentScript)
+  );
 
   const currentSheetCount = store.getBallotsCounted();
   assert(

--- a/apps/scan/backend/src/app_ui_strings.test.ts
+++ b/apps/scan/backend/src/app_ui_strings.test.ts
@@ -22,6 +22,7 @@ import {
   testCdfBallotDefinition,
 } from '@votingworks/types';
 import { createMockPrinterHandler } from '@votingworks/printing';
+import { mockBaseLogger } from '@votingworks/logging';
 import { Store } from './store';
 import { buildApi } from './app';
 import { createWorkspace } from './util/workspace';
@@ -41,7 +42,9 @@ jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
 });
 
 const store = Store.memoryStore();
-const workspace = createWorkspace(tmp.dirSync().name, { store });
+const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger(), {
+  store,
+});
 const mockUsbDrive = createMockUsbDrive();
 const { printer } = createMockPrinterHandler();
 const mockAuth = buildMockInsertedSmartCardAuth();

--- a/apps/scan/backend/src/index.ts
+++ b/apps/scan/backend/src/index.ts
@@ -57,7 +57,7 @@ async function resolveWorkspace(): Promise<Workspace> {
       'workspace path could not be determined; pass a workspace or run with SCAN_WORKSPACE'
     );
   }
-  return createWorkspace(workspacePath);
+  return createWorkspace(workspacePath, baseLogger);
 }
 
 async function main(): Promise<number> {

--- a/apps/scan/backend/src/scanners/pdi/pdi_app_scan_disconnect.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_scan_disconnect.test.ts
@@ -16,6 +16,7 @@ import { buildMockInsertedSmartCardAuth } from '@votingworks/auth';
 import { dirSync } from 'tmp';
 import { createMockUsbDrive } from '@votingworks/usb-drive';
 import waitForExpect from 'wait-for-expect';
+import { mockBaseLogger } from '@votingworks/logging';
 import {
   MockPdiScannerClient,
   ballotImages,
@@ -74,7 +75,7 @@ test('scanner disconnected on startup', async () => {
   mockScanner.client.connect.mockResolvedValue(err({ code: 'disconnected' }));
   const clock = new SimulatedClock();
   const mockAuth = buildMockInsertedSmartCardAuth();
-  const workspace = createWorkspace(dirSync().name);
+  const workspace = createWorkspace(dirSync().name, mockBaseLogger());
   const mockUsbDrive = createMockUsbDrive();
   const logger = buildMockLogger(mockAuth, workspace);
   const precinctScannerMachine = createPrecinctScannerStateMachine({

--- a/apps/scan/backend/src/server.test.ts
+++ b/apps/scan/backend/src/server.test.ts
@@ -1,4 +1,4 @@
-import { LogEventId } from '@votingworks/logging';
+import { LogEventId, mockBaseLogger } from '@votingworks/logging';
 import { Application } from 'express';
 import { dirSync } from 'tmp';
 import { buildMockInsertedSmartCardAuth } from '@votingworks/auth';
@@ -19,7 +19,7 @@ const buildAppMock = buildApp as jest.MockedFunction<typeof buildApp>;
 let workspace!: Workspace;
 
 beforeEach(() => {
-  workspace = createWorkspace(dirSync().name);
+  workspace = createWorkspace(dirSync().name, mockBaseLogger());
 });
 
 afterEach(() => {

--- a/apps/scan/backend/src/store.test.ts
+++ b/apps/scan/backend/src/store.test.ts
@@ -30,6 +30,7 @@ import {
 } from '@votingworks/fixtures';
 import { sha256 } from 'js-sha256';
 import { createMockUsbDrive } from '@votingworks/usb-drive';
+import { mockBaseLogger } from '@votingworks/logging';
 import { zeroRect } from '../test/fixtures/zero_rect';
 import { Store } from './store';
 
@@ -305,7 +306,7 @@ test('get/set polls state', () => {
 
 test('batch cleanup works correctly', () => {
   const dbFile = tmp.fileSync();
-  const store = Store.fileStore(dbFile.name);
+  const store = Store.fileStore(dbFile.name, mockBaseLogger());
 
   store.reset();
 
@@ -633,7 +634,7 @@ test('getSheet', () => {
 
 test('resetElectionSession', async () => {
   const dbFile = tmp.fileSync();
-  const store = Store.fileStore(dbFile.name);
+  const store = Store.fileStore(dbFile.name, mockBaseLogger());
   store.setElectionAndJurisdiction({
     electionData:
       electionGridLayoutNewHampshireTestBallotFixtures.electionDefinition

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -60,6 +60,7 @@ import {
   updateCastVoteRecordHashes,
 } from '@votingworks/auth';
 import { getPollsTransitionDestinationState } from '@votingworks/utils';
+import { BaseLogger } from '@votingworks/logging';
 import { sheetRequiresAdjudication } from './sheet_requires_adjudication';
 import { rootDebug } from './util/debug';
 import { PollsTransition } from './types';
@@ -163,8 +164,8 @@ export class Store {
   /**
    * Builds and returns a new store at `dbPath`.
    */
-  static fileStore(dbPath: string): Store {
-    const client = DbClient.fileClient(dbPath, SchemaPath);
+  static fileStore(dbPath: string, logger: BaseLogger): Store {
+    const client = DbClient.fileClient(dbPath, logger, SchemaPath);
     const uiStringsStore = createUiStringStore(client);
     return new Store(client, uiStringsStore);
   }

--- a/apps/scan/backend/src/util/workspace.test.ts
+++ b/apps/scan/backend/src/util/workspace.test.ts
@@ -1,6 +1,7 @@
 import * as tmp from 'tmp';
 import { mockOf } from '@votingworks/test-utils';
 import { initializeGetWorkspaceDiskSpaceSummary } from '@votingworks/backend';
+import { mockBaseLogger } from '@votingworks/logging';
 import { createWorkspace } from './workspace';
 import { Store } from '../store';
 
@@ -18,7 +19,7 @@ const initializeGetWorkspaceDiskSpaceSummaryMock = mockOf(
 
 test('createWorkspace', () => {
   const dir = tmp.dirSync();
-  const workspace = createWorkspace(dir.name);
+  const workspace = createWorkspace(dir.name, mockBaseLogger());
   expect(workspace.path).toEqual(dir.name);
   expect(workspace.store).toBeInstanceOf(Store);
 });
@@ -29,7 +30,7 @@ test('disk space tracking setup', () => {
   initializeGetWorkspaceDiskSpaceSummaryMock.mockReturnValueOnce(
     getWorkspaceDiskSpaceSummary
   );
-  const workspace = createWorkspace(dir.name);
+  const workspace = createWorkspace(dir.name, mockBaseLogger());
   expect(initializeGetWorkspaceDiskSpaceSummaryMock).toHaveBeenCalledTimes(1);
   expect(initializeGetWorkspaceDiskSpaceSummaryMock).toHaveBeenCalledWith(
     workspace.store,

--- a/apps/scan/backend/src/util/workspace.ts
+++ b/apps/scan/backend/src/util/workspace.ts
@@ -5,6 +5,7 @@ import {
   DiskSpaceSummary,
   initializeGetWorkspaceDiskSpaceSummary,
 } from '@votingworks/backend';
+import { BaseLogger } from '@votingworks/logging';
 import { Store } from '../store';
 
 export interface Workspace {
@@ -62,6 +63,7 @@ export interface Workspace {
 
 export function createWorkspace(
   root: string,
+  logger: BaseLogger,
   options: { store?: Store } = {}
 ): Workspace {
   const resolvedRoot = resolve(root);
@@ -72,7 +74,7 @@ export function createWorkspace(
   ensureDirSync(scannedImagesPath);
 
   const dbPath = join(resolvedRoot, 'ballots.db');
-  const store = options.store || Store.fileStore(dbPath);
+  const store = options.store || Store.fileStore(dbPath, logger);
 
   // check disk space on startup to detect a new maximum available disk space
   const getWorkspaceDiskSpaceSummary = initializeGetWorkspaceDiskSpaceSummary(

--- a/apps/scan/backend/test/helpers/custom_helpers.ts
+++ b/apps/scan/backend/test/helpers/custom_helpers.ts
@@ -25,7 +25,7 @@ import {
   RGBA_CHANNEL_COUNT,
   isRgba,
 } from '@votingworks/image-utils';
-import { Logger } from '@votingworks/logging';
+import { Logger, mockBaseLogger } from '@votingworks/logging';
 import { SheetOf, mapSheet } from '@votingworks/types';
 import { Application } from 'express';
 import { Server } from 'http';
@@ -86,7 +86,7 @@ export async function withApp(
   }) => Promise<void>
 ): Promise<void> {
   const mockAuth = buildMockInsertedSmartCardAuth();
-  const workspace = createWorkspace(tmp.dirSync().name);
+  const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger());
   const logger = buildMockLogger(mockAuth, workspace);
   const mockScanner = mocks.mockCustomScanner();
   const mockUsbDrive = createMockUsbDrive();

--- a/apps/scan/backend/test/helpers/pdi_helpers.ts
+++ b/apps/scan/backend/test/helpers/pdi_helpers.ts
@@ -22,7 +22,7 @@ import {
   MemoryFujitsuPrinterHandler,
   createMockFujitsuPrinterHandler,
 } from '@votingworks/fujitsu-thermal-printer';
-import { Logger } from '@votingworks/logging';
+import { Logger, mockBaseLogger } from '@votingworks/logging';
 import { Server } from 'http';
 import { Result, deferred, ok } from '@votingworks/basics';
 import {
@@ -220,7 +220,7 @@ export async function withApp(
   }) => Promise<void>
 ): Promise<void> {
   const mockAuth = buildMockInsertedSmartCardAuth();
-  const workspace = createWorkspace(tmp.dirSync().name);
+  const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger());
   const logger = buildMockLogger(mockAuth, workspace);
   const mockUsbDrive = createMockUsbDrive();
   const mockPrinterHandler = createMockPrinterHandler();

--- a/libs/db/package.json
+++ b/libs/db/package.json
@@ -21,6 +21,7 @@
   "packageManager": "pnpm@8.3.1",
   "dependencies": {
     "@votingworks/basics": "workspace:*",
+    "@votingworks/logging": "workspace:*",
     "better-sqlite3": "8.2.0",
     "debug": "4.3.4"
   },

--- a/libs/db/tsconfig.build.json
+++ b/libs/db/tsconfig.build.json
@@ -10,6 +10,7 @@
   },
   "references": [
     { "path": "../basics/tsconfig.build.json" },
+    { "path": "../logging/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../utils/tsconfig.build.json" }
   ]

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -538,10 +538,6 @@ IDs are logged with each log to identify the log being written.
 **Type:** [system-action](#system-action)  
 **Description:** Database created and setup. Success or failure indicated by disposition.  
 **Machines:** All
-### database-reset
-**Type:** [system-action](#system-action)  
-**Description:** Database reset to an empty database.  
-**Machines:** All
 ### database-destroy-init
 **Type:** [system-action](#system-action)  
 **Description:** Initiating destruction of the database.  
@@ -549,16 +545,4 @@ IDs are logged with each log to identify the log being written.
 ### database-destroy-complete
 **Type:** [system-action](#system-action)  
 **Description:** Database destroyed. Success or failure indicated by disposition.  
-**Machines:** All
-### database-transaction-init
-**Type:** [system-action](#system-action)  
-**Description:** Initiating a transaction with the database.  
-**Machines:** All
-### database-transaction-complete
-**Type:** [system-action](#system-action)  
-**Description:** Database transaction complete. Success or failure indicated by disposition.  
-**Machines:** All
-### database-system-log
-**Type:** [system-action](#system-action)  
-**Description:** Logs written from the db client when transactions occur.  
 **Machines:** All

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -522,3 +522,43 @@ IDs are logged with each log to identify the log being written.
 **Type:** [system-action](#system-action)  
 **Description:** A system action failed to parse data.  
 **Machines:** All
+### database-connect-init
+**Type:** [system-action](#system-action)  
+**Description:** Initiating connection to the database.  
+**Machines:** All
+### database-connect-complete
+**Type:** [system-action](#system-action)  
+**Description:** Database connection established. Success or failure indicated by disposition.  
+**Machines:** All
+### database-create-init
+**Type:** [system-action](#system-action)  
+**Description:** Initiating creation of the database.  
+**Machines:** All
+### database-create-complete
+**Type:** [system-action](#system-action)  
+**Description:** Database created and setup. Success or failure indicated by disposition.  
+**Machines:** All
+### database-reset
+**Type:** [system-action](#system-action)  
+**Description:** Database reset to an empty database.  
+**Machines:** All
+### database-destroy-init
+**Type:** [system-action](#system-action)  
+**Description:** Initiating destruction of the database.  
+**Machines:** All
+### database-destroy-complete
+**Type:** [system-action](#system-action)  
+**Description:** Database destroyed. Success or failure indicated by disposition.  
+**Machines:** All
+### database-transaction-init
+**Type:** [system-action](#system-action)  
+**Description:** Initiating a transaction with the database.  
+**Machines:** All
+### database-transaction-complete
+**Type:** [system-action](#system-action)  
+**Description:** Database transaction complete. Success or failure indicated by disposition.  
+**Machines:** All
+### database-system-log
+**Type:** [system-action](#system-action)  
+**Description:** Logs written from the db client when transactions occur.  
+**Machines:** All

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -800,8 +800,3 @@ documentationMessage = "Initiating destruction of the database."
 eventId = "database-destroy-complete"
 eventType = "system-action"
 documentationMessage = "Database destroyed. Success or failure indicated by disposition."
-
-[DatabaseSystemLog]
-eventId = "database-system-log"
-eventType = "system-action"
-documentationMessage = "Logs written from the db client when transactions occur."

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -771,3 +771,37 @@ eventId = "parse-error"
 eventType = "system-action"
 documentationMessage = "A system action failed to parse data."
 
+[DatabaseConnectInit]
+eventId = "database-connect-init"
+eventType = "system-action"
+documentationMessage = "Initiating connection to the database."
+
+[DatabaseConnectComplete]
+eventId = "database-connect-complete"
+eventType = "system-action"
+documentationMessage = "Database connection established. Success or failure indicated by disposition."
+
+[DatabaseCreateInit]
+eventId = "database-create-init"
+eventType = "system-action"
+documentationMessage = "Initiating creation of the database."
+
+[DatabaseCreateComplete]
+eventId = "database-create-complete"
+eventType = "system-action"
+documentationMessage = "Database created and setup. Success or failure indicated by disposition."
+
+[DatabaseDestroyInit]
+eventId = "database-destroy-init"
+eventType = "system-action"
+documentationMessage = "Initiating destruction of the database."
+
+[DatabaseDestroyComplete]
+eventId = "database-destroy-complete"
+eventType = "system-action"
+documentationMessage = "Database destroyed. Success or failure indicated by disposition."
+
+[DatabaseSystemLog]
+eventId = "database-system-log"
+eventType = "system-action"
+documentationMessage = "Logs written from the db client when transactions occur."

--- a/libs/logging/src/base_types/log_source.ts
+++ b/libs/logging/src/base_types/log_source.ts
@@ -6,6 +6,8 @@ export enum LogSource {
   VxCentralScanFrontend = 'vx-central-scan-frontend',
   VxCentralScanFrontendServer = 'vx-central-scan-frontend-server',
   VxCentralScanService = 'vx-central-scan-service',
+  VxDesignService = 'vx-design-service',
+  VxDesignWorker = 'vx-design-worker',
   VxScanFrontend = 'vx-scan-frontend',
   VxScanFrontendServer = 'vx-scan-frontend-server',
   VxScanBackend = 'vx-scan-backend',
@@ -20,6 +22,7 @@ export enum LogSource {
   VxBallotActivationFrontend = 'vx-ballot-activation-frontend',
   VxBallotActivationService = 'vx-ballot-activation-service',
   VxScanService = 'vx-scan-service',
+  VxDevelopmentScript = 'vx-development-script',
 }
 // The following log sources are frontends and always expect to log through window.kiosk
 // In various tests window.kiosk may not be defined and we don't want to fallback to logging with console.log

--- a/libs/logging/src/log_event_ids.ts
+++ b/libs/logging/src/log_event_ids.ts
@@ -145,7 +145,6 @@ export enum LogEventId {
   DatabaseCreateComplete = 'database-create-complete',
   DatabaseDestroyInit = 'database-destroy-init',
   DatabaseDestroyComplete = 'database-destroy-complete',
-  DatabaseSystemLog = 'database-system-log',
 }
 
 const ElectionConfigured: LogDetails = {
@@ -1216,13 +1215,6 @@ const DatabaseDestroyComplete: LogDetails = {
     'Database destroyed. Success or failure indicated by disposition.',
 };
 
-const DatabaseSystemLog: LogDetails = {
-  eventId: LogEventId.DatabaseSystemLog,
-  eventType: LogEventType.SystemAction,
-  documentationMessage:
-    'Logs written from the db client when transactions occur.',
-};
-
 export function getDetailsForEventId(eventId: LogEventId): LogDetails {
   switch (eventId) {
     case LogEventId.ElectionConfigured:
@@ -1491,8 +1483,6 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return DatabaseDestroyInit;
     case LogEventId.DatabaseDestroyComplete:
       return DatabaseDestroyComplete;
-    case LogEventId.DatabaseSystemLog:
-      return DatabaseSystemLog;
     /* istanbul ignore next - compile time check for completeness */
     default:
       throwIllegalValue(eventId);

--- a/libs/logging/src/log_event_ids.ts
+++ b/libs/logging/src/log_event_ids.ts
@@ -143,11 +143,8 @@ export enum LogEventId {
   DatabaseConnectComplete = 'database-connect-complete',
   DatabaseCreateInit = 'database-create-init',
   DatabaseCreateComplete = 'database-create-complete',
-  DatabaseReset = 'database-reset',
   DatabaseDestroyInit = 'database-destroy-init',
   DatabaseDestroyComplete = 'database-destroy-complete',
-  DatabaseTransactionInit = 'database-transaction-init',
-  DatabaseTransactionComplete = 'database-transaction-complete',
   DatabaseSystemLog = 'database-system-log',
 }
 
@@ -1206,12 +1203,6 @@ const DatabaseCreateComplete: LogDetails = {
     'Database created and setup. Success or failure indicated by disposition.',
 };
 
-const DatabaseReset: LogDetails = {
-  eventId: LogEventId.DatabaseReset,
-  eventType: LogEventType.SystemAction,
-  documentationMessage: 'Database reset to an empty database.',
-};
-
 const DatabaseDestroyInit: LogDetails = {
   eventId: LogEventId.DatabaseDestroyInit,
   eventType: LogEventType.SystemAction,
@@ -1223,19 +1214,6 @@ const DatabaseDestroyComplete: LogDetails = {
   eventType: LogEventType.SystemAction,
   documentationMessage:
     'Database destroyed. Success or failure indicated by disposition.',
-};
-
-const DatabaseTransactionInit: LogDetails = {
-  eventId: LogEventId.DatabaseTransactionInit,
-  eventType: LogEventType.SystemAction,
-  documentationMessage: 'Initiating a transaction with the database.',
-};
-
-const DatabaseTransactionComplete: LogDetails = {
-  eventId: LogEventId.DatabaseTransactionComplete,
-  eventType: LogEventType.SystemAction,
-  documentationMessage:
-    'Database transaction complete. Success or failure indicated by disposition.',
 };
 
 const DatabaseSystemLog: LogDetails = {
@@ -1509,16 +1487,10 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return DatabaseCreateInit;
     case LogEventId.DatabaseCreateComplete:
       return DatabaseCreateComplete;
-    case LogEventId.DatabaseReset:
-      return DatabaseReset;
     case LogEventId.DatabaseDestroyInit:
       return DatabaseDestroyInit;
     case LogEventId.DatabaseDestroyComplete:
       return DatabaseDestroyComplete;
-    case LogEventId.DatabaseTransactionInit:
-      return DatabaseTransactionInit;
-    case LogEventId.DatabaseTransactionComplete:
-      return DatabaseTransactionComplete;
     case LogEventId.DatabaseSystemLog:
       return DatabaseSystemLog;
     /* istanbul ignore next - compile time check for completeness */

--- a/libs/logging/src/log_event_ids.ts
+++ b/libs/logging/src/log_event_ids.ts
@@ -139,6 +139,16 @@ export enum LogEventId {
   PermissionDenied = 'permission-denied',
   NoPid = 'no-pid',
   ParseError = 'parse-error',
+  DatabaseConnectInit = 'database-connect-init',
+  DatabaseConnectComplete = 'database-connect-complete',
+  DatabaseCreateInit = 'database-create-init',
+  DatabaseCreateComplete = 'database-create-complete',
+  DatabaseReset = 'database-reset',
+  DatabaseDestroyInit = 'database-destroy-init',
+  DatabaseDestroyComplete = 'database-destroy-complete',
+  DatabaseTransactionInit = 'database-transaction-init',
+  DatabaseTransactionComplete = 'database-transaction-complete',
+  DatabaseSystemLog = 'database-system-log',
 }
 
 const ElectionConfigured: LogDetails = {
@@ -1170,6 +1180,71 @@ const ParseError: LogDetails = {
   documentationMessage: 'A system action failed to parse data.',
 };
 
+const DatabaseConnectInit: LogDetails = {
+  eventId: LogEventId.DatabaseConnectInit,
+  eventType: LogEventType.SystemAction,
+  documentationMessage: 'Initiating connection to the database.',
+};
+
+const DatabaseConnectComplete: LogDetails = {
+  eventId: LogEventId.DatabaseConnectComplete,
+  eventType: LogEventType.SystemAction,
+  documentationMessage:
+    'Database connection established. Success or failure indicated by disposition.',
+};
+
+const DatabaseCreateInit: LogDetails = {
+  eventId: LogEventId.DatabaseCreateInit,
+  eventType: LogEventType.SystemAction,
+  documentationMessage: 'Initiating creation of the database.',
+};
+
+const DatabaseCreateComplete: LogDetails = {
+  eventId: LogEventId.DatabaseCreateComplete,
+  eventType: LogEventType.SystemAction,
+  documentationMessage:
+    'Database created and setup. Success or failure indicated by disposition.',
+};
+
+const DatabaseReset: LogDetails = {
+  eventId: LogEventId.DatabaseReset,
+  eventType: LogEventType.SystemAction,
+  documentationMessage: 'Database reset to an empty database.',
+};
+
+const DatabaseDestroyInit: LogDetails = {
+  eventId: LogEventId.DatabaseDestroyInit,
+  eventType: LogEventType.SystemAction,
+  documentationMessage: 'Initiating destruction of the database.',
+};
+
+const DatabaseDestroyComplete: LogDetails = {
+  eventId: LogEventId.DatabaseDestroyComplete,
+  eventType: LogEventType.SystemAction,
+  documentationMessage:
+    'Database destroyed. Success or failure indicated by disposition.',
+};
+
+const DatabaseTransactionInit: LogDetails = {
+  eventId: LogEventId.DatabaseTransactionInit,
+  eventType: LogEventType.SystemAction,
+  documentationMessage: 'Initiating a transaction with the database.',
+};
+
+const DatabaseTransactionComplete: LogDetails = {
+  eventId: LogEventId.DatabaseTransactionComplete,
+  eventType: LogEventType.SystemAction,
+  documentationMessage:
+    'Database transaction complete. Success or failure indicated by disposition.',
+};
+
+const DatabaseSystemLog: LogDetails = {
+  eventId: LogEventId.DatabaseSystemLog,
+  eventType: LogEventType.SystemAction,
+  documentationMessage:
+    'Logs written from the db client when transactions occur.',
+};
+
 export function getDetailsForEventId(eventId: LogEventId): LogDetails {
   switch (eventId) {
     case LogEventId.ElectionConfigured:
@@ -1426,6 +1501,26 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return NoPid;
     case LogEventId.ParseError:
       return ParseError;
+    case LogEventId.DatabaseConnectInit:
+      return DatabaseConnectInit;
+    case LogEventId.DatabaseConnectComplete:
+      return DatabaseConnectComplete;
+    case LogEventId.DatabaseCreateInit:
+      return DatabaseCreateInit;
+    case LogEventId.DatabaseCreateComplete:
+      return DatabaseCreateComplete;
+    case LogEventId.DatabaseReset:
+      return DatabaseReset;
+    case LogEventId.DatabaseDestroyInit:
+      return DatabaseDestroyInit;
+    case LogEventId.DatabaseDestroyComplete:
+      return DatabaseDestroyComplete;
+    case LogEventId.DatabaseTransactionInit:
+      return DatabaseTransactionInit;
+    case LogEventId.DatabaseTransactionComplete:
+      return DatabaseTransactionComplete;
+    case LogEventId.DatabaseSystemLog:
+      return DatabaseSystemLog;
     /* istanbul ignore next - compile time check for completeness */
     default:
       throwIllegalValue(eventId);

--- a/libs/logging/types-rust/src/log_event_enums.rs
+++ b/libs/logging/types-rust/src/log_event_enums.rs
@@ -275,6 +275,4 @@ pub enum EventId {
     DatabaseDestroyInit,
     #[serde(rename = "database-destroy-complete")]
     DatabaseDestroyComplete,
-    #[serde(rename = "database-system-log")]
-    DatabaseSystemLog,
 }

--- a/libs/logging/types-rust/src/log_event_enums.rs
+++ b/libs/logging/types-rust/src/log_event_enums.rs
@@ -263,4 +263,24 @@ pub enum EventId {
     NoPid,
     #[serde(rename = "parse-error")]
     ParseError,
+    #[serde(rename = "database-connect-init")]
+    DatabaseConnectInit,
+    #[serde(rename = "database-connect-complete")]
+    DatabaseConnectComplete,
+    #[serde(rename = "database-create-init")]
+    DatabaseCreateInit,
+    #[serde(rename = "database-create-complete")]
+    DatabaseCreateComplete,
+    #[serde(rename = "database-reset")]
+    DatabaseReset,
+    #[serde(rename = "database-destroy-init")]
+    DatabaseDestroyInit,
+    #[serde(rename = "database-destroy-complete")]
+    DatabaseDestroyComplete,
+    #[serde(rename = "database-transaction-init")]
+    DatabaseTransactionInit,
+    #[serde(rename = "database-transaction-complete")]
+    DatabaseTransactionComplete,
+    #[serde(rename = "database-system-log")]
+    DatabaseSystemLog,
 }

--- a/libs/logging/types-rust/src/log_event_enums.rs
+++ b/libs/logging/types-rust/src/log_event_enums.rs
@@ -271,16 +271,10 @@ pub enum EventId {
     DatabaseCreateInit,
     #[serde(rename = "database-create-complete")]
     DatabaseCreateComplete,
-    #[serde(rename = "database-reset")]
-    DatabaseReset,
     #[serde(rename = "database-destroy-init")]
     DatabaseDestroyInit,
     #[serde(rename = "database-destroy-complete")]
     DatabaseDestroyComplete,
-    #[serde(rename = "database-transaction-init")]
-    DatabaseTransactionInit,
-    #[serde(rename = "database-transaction-complete")]
-    DatabaseTransactionComplete,
     #[serde(rename = "database-system-log")]
     DatabaseSystemLog,
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1155,6 +1155,9 @@ importers:
       '@votingworks/hmpb':
         specifier: workspace:*
         version: link:../../../libs/hmpb
+      '@votingworks/logging':
+        specifier: workspace:*
+        version: link:../../../libs/logging
       '@votingworks/printing':
         specifier: workspace:*
         version: link:../../../libs/printing

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1072,7 +1072,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       type-fest:
         specifier: ^0.18.0
         version: 0.18.1
@@ -1462,7 +1462,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -1857,7 +1857,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -2265,7 +2265,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -2721,7 +2721,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -2772,7 +2772,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/@types/compress-commons:
     dependencies:
@@ -2846,7 +2846,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/auth:
     dependencies:
@@ -2961,7 +2961,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       wait-for-expect:
         specifier: ^3.0.2
         version: 3.0.2
@@ -3121,7 +3121,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/ballot-encoder:
     dependencies:
@@ -3173,7 +3173,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/ballot-interpreter:
     dependencies:
@@ -3294,7 +3294,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/basics:
     dependencies:
@@ -3340,7 +3340,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/bmd-ballot-fixtures:
     dependencies:
@@ -3413,7 +3413,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       util:
         specifier: ^0.12.4
         version: 0.12.4
@@ -3468,7 +3468,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/custom-paper-handler:
     dependencies:
@@ -3547,7 +3547,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/custom-scanner:
     dependencies:
@@ -3620,7 +3620,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@16.18.23)
@@ -3630,6 +3630,9 @@ importers:
       '@votingworks/basics':
         specifier: workspace:*
         version: link:../basics
+      '@votingworks/logging':
+        specifier: workspace:*
+        version: link:../logging
       better-sqlite3:
         specifier: 8.2.0
         version: 8.2.0
@@ -3751,7 +3754,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/dev-dock/frontend:
     dependencies:
@@ -3860,7 +3863,7 @@ importers:
         version: 5.3.11(react-dom@18.3.1)(react-is@18.2.0)(react@18.3.1)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/eslint-plugin-vx:
     dependencies:
@@ -3939,7 +3942,7 @@ importers:
         version: 18.3.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/fixture-generators:
     dependencies:
@@ -4027,7 +4030,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/fixtures:
     dependencies:
@@ -4079,7 +4082,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/fs:
     dependencies:
@@ -4158,7 +4161,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/fujitsu-thermal-printer:
     dependencies:
@@ -4222,7 +4225,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/grout:
     dependencies:
@@ -4283,7 +4286,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/grout/test-utils:
     dependencies:
@@ -4323,7 +4326,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/hmpb:
     dependencies:
@@ -4608,7 +4611,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/mark-flow-ui:
     dependencies:
@@ -4822,7 +4825,7 @@ importers:
         version: 5.3.11(react-dom@18.3.1)(react-is@18.2.0)(react@18.3.1)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       util:
         specifier: ^0.12.4
         version: 0.12.4
@@ -4862,7 +4865,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/monorepo-utils:
     dependencies:
@@ -4932,7 +4935,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       typescript:
         specifier: 5.5.3
         version: 5.5.3
@@ -4987,7 +4990,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/printing:
     dependencies:
@@ -5099,7 +5102,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/res-to-ts:
     dependencies:
@@ -5154,7 +5157,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/test-utils:
     dependencies:
@@ -5236,7 +5239,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/types:
     dependencies:
@@ -5327,7 +5330,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/types-rs: {}
 
@@ -5606,7 +5609,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       util:
         specifier: ^0.12.4
         version: 0.12.4
@@ -5679,7 +5682,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/utils:
     dependencies:
@@ -5794,7 +5797,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   script:
     dependencies:
@@ -21232,7 +21235,6 @@ packages:
       semver: 7.5.4
       typescript: 5.5.3
       yargs-parser: 21.1.1
-    dev: true
 
   /ts-jest@29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3):
     resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
@@ -21268,6 +21270,7 @@ packages:
       semver: 7.5.4
       typescript: 5.5.3
       yargs-parser: 21.1.1
+    dev: true
 
   /tsconfig-paths@3.14.1:
     resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}


### PR DESCRIPTION
## Overview
Adds basic logging when we connect to the db, create the db and destroy the db. I used the BaseLogger here since the workspace with the db needs to be created for the auth status polling used in the Logger class. This means that the logs will have the user "system" rather then the currently logged in user. I think this is okay / makes sense for low-level actions like creating and connecting to the database. The currently logged in user could be determined via context with other logs in the timeline. 

## Demo Video or Screenshot

## Testing Plan
Ran apps, saw initial connection logs. 

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
