### PR TITLE
VxScan UI polish for long election content

### DIFF
--- a/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
@@ -107,7 +107,7 @@ test('MarkAndPrint end-to-end flow', async () => {
 
   // Configure election with Election Manager Card
   apiMock.setAuthStatusElectionManagerLoggedIn(electionDefinition);
-  await screen.findByLabelText('Precinct');
+  await screen.findByLabelText('Select a precinct…');
   screen.queryByText(`Election ID: ${expectedBallotHash}`);
   screen.queryByText('Machine ID: 000');
 
@@ -123,7 +123,8 @@ test('MarkAndPrint end-to-end flow', async () => {
   apiMock.expectGetElectionState({
     precinctSelection,
   });
-  userEvent.selectOptions(screen.getByLabelText('Precinct'), precinctName);
+  userEvent.click(screen.getByText('Select a precinct…'));
+  userEvent.click(screen.getByText(precinctName));
   await within(screen.getByTestId('electionInfoBar')).findByText(
     /Center Springfield/
   );

--- a/apps/mark-scan/frontend/src/pages/admin_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/admin_screen.test.tsx
@@ -90,15 +90,15 @@ test('renders date and time settings modal', async () => {
 test('can switch the precinct', async () => {
   renderScreen();
 
-  const precinctSelect = await screen.findByLabelText('Precinct');
   apiMock.expectSetPrecinctSelection(ALL_PRECINCTS_SELECTION);
-  userEvent.selectOptions(precinctSelect, 'All Precincts');
+  userEvent.click(await screen.findByText('Select a precinct…'));
+  userEvent.click(await screen.findByText('All Precincts'));
 });
 
 test('precinct change disabled if polls closed', async () => {
   renderScreen({ pollsState: 'polls_closed_final' });
 
-  const precinctSelect = await screen.findByLabelText('Precinct');
+  const precinctSelect = await screen.findByLabelText('Select a precinct…');
   expect(precinctSelect).toBeDisabled();
 });
 
@@ -109,7 +109,7 @@ test('precinct selection disabled if single precinct election', async () => {
   });
 
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
-  expect(screen.getByTestId('selectPrecinct')).toBeDisabled();
+  expect(screen.getByLabelText('Select a precinct…')).toBeDisabled();
   screen.getByText(
     'Precinct cannot be changed because there is only one precinct configured for this election.'
   );

--- a/apps/mark/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark/frontend/src/app_end_to_end.test.tsx
@@ -110,7 +110,7 @@ test('MarkAndPrint end-to-end flow', async () => {
 
   // Configure election with Election Manager Card
   apiMock.setAuthStatusElectionManagerLoggedIn(electionDefinition);
-  await screen.findByLabelText('Precinct');
+  await screen.findByLabelText('Select a precinct…');
   screen.queryByText(`Election ID: ${expectedBallotHash}`);
   screen.queryByText('Machine ID: 000');
 
@@ -121,10 +121,8 @@ test('MarkAndPrint end-to-end flow', async () => {
     precinctSelection,
   });
   screen.getByText('State of Hamilton');
-  userEvent.selectOptions(
-    screen.getByLabelText('Precinct'),
-    'Center Springfield'
-  );
+  userEvent.click(screen.getByText('Select a precinct…'));
+  userEvent.click(screen.getByText('Center Springfield'));
   await within(screen.getByTestId('electionInfoBar')).findByText(
     /Center Springfield/
   );

--- a/apps/mark/frontend/src/pages/admin_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.test.tsx
@@ -93,15 +93,15 @@ test('renders date and time settings modal', async () => {
 test('can switch the precinct', () => {
   renderScreen();
 
-  const precinctSelect = screen.getByLabelText('Precinct');
   apiMock.expectSetPrecinctSelection(ALL_PRECINCTS_SELECTION);
-  userEvent.selectOptions(precinctSelect, 'All Precincts');
+  userEvent.click(screen.getByLabelText('Select a precinct…'));
+  userEvent.click(screen.getByText('All Precincts'));
 });
 
 test('precinct change disabled if polls closed', () => {
   renderScreen({ pollsState: 'polls_closed_final' });
 
-  const precinctSelect = screen.getByLabelText('Precinct');
+  const precinctSelect = screen.getByLabelText('Select a precinct…');
   expect(precinctSelect).toBeDisabled();
 });
 
@@ -113,7 +113,7 @@ test('precinct selection disabled if single precinct election', async () => {
   });
 
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
-  expect(screen.getByTestId('selectPrecinct')).toBeDisabled();
+  expect(screen.getByLabelText('Select a precinct…')).toBeDisabled();
   screen.getByText(
     'Precinct cannot be changed because there is only one precinct configured for this election.'
   );

--- a/apps/mark/integration-testing/e2e/scroll_buttons.spec.ts
+++ b/apps/mark/integration-testing/e2e/scroll_buttons.spec.ts
@@ -56,9 +56,8 @@ test('configure, open polls, and test contest scroll buttons', async ({
 
   // Election Manager: set precinct
   await page.getByText('Precinct', { exact: true }).waitFor();
-  await page
-    .getByTestId('selectPrecinct')
-    .selectOption({ label: 'All Precincts' });
+  await page.getByText('Select a precinct…').click({ force: true });
+  await page.getByText('All Precincts', { exact: true }).click();
 
   mockCardRemoval();
 

--- a/apps/scan/frontend/src/components/printer_management/election_manager_printer_tab_content.tsx
+++ b/apps/scan/frontend/src/components/printer_management/election_manager_printer_tab_content.tsx
@@ -50,7 +50,7 @@ function StatusText({ printerStatus }: { printerStatus: PrinterStatus }) {
 
 const ButtonRow = styled(P)`
   display: flex;
-  gap: 1rem;
+  gap: 0.5rem;
 `;
 
 export function ElectionManagerPrinterTabContent(): JSX.Element | null {

--- a/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
@@ -109,9 +109,12 @@ test('option to set precinct if more than one', async () => {
   apiMock.expectSetPrecinct(precinctSelection);
   apiMock.expectGetPollsInfo();
   apiMock.expectGetConfig({ precinctSelection });
-  const selectPrecinct = await screen.findByTestId('selectPrecinct');
-  userEvent.selectOptions(selectPrecinct, precinct.id);
-  await screen.findByDisplayValue(precinct.name);
+  userEvent.click(await screen.findByLabelText('Select a precinct…'));
+  userEvent.click(screen.getByText(precinct.name));
+  await waitFor(() => {
+    // Once in the precinct select, once in the election info bar
+    expect(screen.getAllByText(precinct.name)).toHaveLength(2);
+  });
 });
 
 test('no option to change precinct if there is only one precinct', async () => {
@@ -124,7 +127,7 @@ test('no option to change precinct if there is only one precinct', async () => {
   renderScreen({ electionDefinition });
 
   await screen.findByText('Election Manager Settings');
-  expect(screen.queryByTestId('selectPrecinct')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText('Select a precinct…')).not.toBeInTheDocument();
 });
 
 test('unconfigure ejects a usb drive', async () => {

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -16,6 +16,7 @@ import {
 import React, { useState } from 'react';
 import type { PrecinctScannerStatus } from '@votingworks/scan-backend';
 import type { UsbDriveStatus } from '@votingworks/usb-drive';
+import styled from 'styled-components';
 import { ExportResultsModal } from '../components/export_results_modal';
 import { Screen } from '../components/layout';
 import {
@@ -38,7 +39,12 @@ import { usePreviewContext } from '../preview_dashboard';
 import { SignedHashValidationButton } from '../components/signed_hash_validation_button';
 import { ElectionManagerPrinterTabContent } from '../components/printer_management/election_manager_printer_tab_content';
 
-export const SELECT_PRECINCT_TEXT = 'Select a precinct for this device…';
+const TabPanel = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: start;
+`;
 
 export interface ElectionManagerScreenProps {
   // We pass electionDefinition in as a prop because the preview dashboard needs
@@ -127,139 +133,117 @@ export function ElectionManagerScreen({
   }
 
   const changePrecinctButton = election.precincts.length > 1 && (
-    <P>
-      <ChangePrecinctButton
-        appPrecinctSelection={precinctSelection}
-        updatePrecinctSelection={async (newPrecinctSelection) => {
-          try {
-            await setPrecinctSelectionMutation.mutateAsync({
-              precinctSelection: newPrecinctSelection,
-            });
-          } catch (error) {
-            // Handled by default query client error handling
-          }
-        }}
-        election={election}
-        mode={
-          pollsState === 'polls_closed_initial'
-            ? 'default'
-            : pollsState !== 'polls_closed_final' &&
-              scannerStatus.ballotsCounted === 0
-            ? 'confirmation_required'
-            : 'disabled'
+    <ChangePrecinctButton
+      appPrecinctSelection={precinctSelection}
+      updatePrecinctSelection={async (newPrecinctSelection) => {
+        try {
+          await setPrecinctSelectionMutation.mutateAsync({
+            precinctSelection: newPrecinctSelection,
+          });
+        } catch (error) {
+          // Handled by default query client error handling
         }
-      />
-    </P>
+      }}
+      election={election}
+      mode={
+        pollsState === 'polls_closed_initial'
+          ? 'default'
+          : pollsState !== 'polls_closed_final' &&
+            scannerStatus.ballotsCounted === 0
+          ? 'confirmation_required'
+          : 'disabled'
+      }
+    />
   );
 
   const ballotMode = (
-    <P>
-      <SegmentedButton
-        disabled={
-          setTestModeMutation.isLoading ||
-          isCvrSyncRequired ||
-          disableConfiguration
+    <SegmentedButton
+      disabled={
+        setTestModeMutation.isLoading ||
+        isCvrSyncRequired ||
+        disableConfiguration
+      }
+      label="Ballot Mode:"
+      hideLabel
+      onChange={() => {
+        if (!isTestMode && scannerStatus.ballotsCounted > 0) {
+          setIsConfirmingSwitchToTestMode(true);
+          return;
         }
-        label="Ballot Mode:"
-        hideLabel
-        onChange={() => {
-          if (!isTestMode && scannerStatus.ballotsCounted > 0) {
-            setIsConfirmingSwitchToTestMode(true);
-            return;
-          }
-          switchMode();
-        }}
-        options={[
-          { id: 'test', label: 'Test Ballot Mode' },
-          { id: 'official', label: 'Official Ballot Mode' },
-        ]}
-        selectedOptionId={isTestMode ? 'test' : 'official'}
-      />
-    </P>
+        switchMode();
+      }}
+      options={[
+        { id: 'test', label: 'Test Ballot Mode' },
+        { id: 'official', label: 'Official Ballot Mode' },
+      ]}
+      selectedOptionId={isTestMode ? 'test' : 'official'}
+    />
   );
 
   const dateTimeButton = (
-    <P>
-      <SetClockButton logOut={() => logOutMutation.mutate()}>
-        Set Date and Time
-      </SetClockButton>
-    </P>
+    <SetClockButton logOut={() => logOutMutation.mutate()}>
+      Set Date and Time
+    </SetClockButton>
   );
 
   const dataExportButtons = (
     <React.Fragment>
-      <P>
-        <Button onPress={() => setIsExportingResults(true)}>Save CVRs</Button>{' '}
-      </P>
-      <P>
-        <ExportLogsButton usbDriveStatus={usbDrive} />
-      </P>
+      <Button onPress={() => setIsExportingResults(true)}>Save CVRs</Button>{' '}
+      <ExportLogsButton usbDriveStatus={usbDrive} />
     </React.Fragment>
   );
 
   const doubleSheetDetectionToggle = (
-    <P>
-      <Button
-        onPress={() =>
-          setIsDoubleFeedDetectionDisabledMutation.mutate({
-            isDoubleFeedDetectionDisabled: !isDoubleFeedDetectionDisabled,
-          })
-        }
-      >
-        {isDoubleFeedDetectionDisabled
-          ? 'Enable Double Sheet Detection'
-          : 'Disable Double Sheet Detection'}
-      </Button>
-    </P>
+    <Button
+      onPress={() =>
+        setIsDoubleFeedDetectionDisabledMutation.mutate({
+          isDoubleFeedDetectionDisabled: !isDoubleFeedDetectionDisabled,
+        })
+      }
+    >
+      {isDoubleFeedDetectionDisabled
+        ? 'Enable Double Sheet Detection'
+        : 'Disable Double Sheet Detection'}
+    </Button>
   );
 
   const calibrateDoubleSheetDetectionButton = (
-    <P>
-      <Button
-        disabled={scannerStatus.state === 'disconnected'}
-        onPress={() => beginDoubleFeedCalibrationMutation.mutate()}
-      >
-        Calibrate Double Sheet Detection
-      </Button>
-    </P>
+    <Button
+      disabled={scannerStatus.state === 'disconnected'}
+      onPress={() => beginDoubleFeedCalibrationMutation.mutate()}
+    >
+      Calibrate Double Sheet Detection
+    </Button>
   );
 
   const audioMuteToggle = (
-    <P>
-      <Button
-        onPress={() =>
-          setIsSoundMutedMutation.mutate({
-            isSoundMuted: !isSoundMuted,
-          })
-        }
-      >
-        {isSoundMuted ? 'Unmute Sounds' : 'Mute Sounds'}
-      </Button>
-    </P>
+    <Button
+      onPress={() =>
+        setIsSoundMutedMutation.mutate({
+          isSoundMuted: !isSoundMuted,
+        })
+      }
+    >
+      {isSoundMuted ? 'Unmute Sounds' : 'Mute Sounds'}
+    </Button>
   );
 
   const unconfigureElectionButton = (
-    <P>
-      <UnconfigureMachineButton
-        // TODO rename isMachineConfigured -> disabled to be clearer
-        isMachineConfigured={!isCvrSyncRequired}
-        unconfigureMachine={unconfigureMachine}
-      />
-    </P>
+    <UnconfigureMachineButton
+      // TODO rename isMachineConfigured -> disabled to be clearer
+      isMachineConfigured={!isCvrSyncRequired}
+      unconfigureMachine={unconfigureMachine}
+    />
   );
 
-  const powerDownButton = (
-    <P>
-      <PowerDownButton />
-    </P>
-  );
+  const powerDownButton = <PowerDownButton />;
 
   const cvrSyncRequiredWarning = isCvrSyncRequired ? (
-    <P>
+    <div>
       <Icons.Warning color="warning" /> Cast vote records (CVRs) need to be
       synced to the inserted USB drive before you can modify the machine
       configuration. Remove your election manager card to sync.
-    </P>
+    </div>
   ) : null;
 
   const tabs: TabConfig[] = [
@@ -267,12 +251,12 @@ export function ElectionManagerScreen({
       paneId: 'managerSettingsConfiguration',
       label: 'Configuration',
       content: (
-        <React.Fragment>
+        <TabPanel>
           {cvrSyncRequiredWarning}
           {changePrecinctButton}
           {ballotMode}
           {unconfigureElectionButton}
-        </React.Fragment>
+        </TabPanel>
       ),
     },
   ];
@@ -292,20 +276,20 @@ export function ElectionManagerScreen({
     {
       paneId: 'managerSettingsData',
       label: 'CVRs and Logs',
-      content: <React.Fragment>{dataExportButtons}</React.Fragment>,
+      content: <TabPanel>{dataExportButtons}</TabPanel>,
     },
     {
       paneId: 'managerSettingsSystem',
       label: 'System Settings',
       content: (
-        <React.Fragment>
+        <TabPanel>
           {calibrateDoubleSheetDetectionButton}
           {doubleSheetDetectionToggle}
           {dateTimeButton}
           {audioMuteToggle}
           <SignedHashValidationButton />
           {powerDownButton}
-        </React.Fragment>
+        </TabPanel>
       ),
     }
   );

--- a/libs/ui/src/election_info_bar.tsx
+++ b/libs/ui/src/election_info_bar.tsx
@@ -66,21 +66,19 @@ export function ElectionInfoBar({
   } = electionDefinition;
 
   const electionInfoLabel = (
-    <React.Fragment>
+    <Font maxLines={2}>
       {precinctSelection && (
         <React.Fragment>
-          <Font noWrap>
-            <PrecinctSelectionName
-              electionPrecincts={precincts}
-              precinctSelection={precinctSelection}
-            />
-            ,
-          </Font>{' '}
+          <PrecinctSelectionName
+            electionPrecincts={precincts}
+            precinctSelection={precinctSelection}
+          />
+          ,{' '}
         </React.Fragment>
       )}
-      <Font noWrap>{electionStrings.countyName(county)},</Font>{' '}
-      <Font noWrap>{electionStrings.stateName(election)}</Font>
-    </React.Fragment>
+      {electionStrings.countyName(county)},{' '}
+      {electionStrings.stateName(election)}
+    </Font>
   );
 
   const electionInfo = (

--- a/libs/ui/src/modal.tsx
+++ b/libs/ui/src/modal.tsx
@@ -179,6 +179,7 @@ export interface ModalProps {
   modalWidth?: ModalWidth;
   themeDeprecated?: Theme;
   title?: ReactNode;
+  className?: string;
 }
 
 export function Modal({
@@ -195,6 +196,7 @@ export function Modal({
   modalWidth,
   themeDeprecated,
   title,
+  className,
 }: ModalProps): JSX.Element {
   const isInVoterAudioContext = !!useAudioContext();
   const shouldPlayAudioOnOpen = isInVoterAudioContext && !disableAutoplayAudio;
@@ -245,7 +247,7 @@ export function Modal({
       )}
       // className properties are required to prevent react-modal
       // from overriding the styles defined in contentElement and overlayElement
-      className="_"
+      className={className ?? '_'}
       overlayClassName="_"
     >
       <ModalContent centerContent={centerContent} fullscreen={fullscreen}>

--- a/libs/ui/src/search_select.tsx
+++ b/libs/ui/src/search_select.tsx
@@ -140,7 +140,6 @@ export function SearchSelect<T extends string = string>({
       unstyled
       components={{ DropdownIndicator, MultiValueRemove }}
       className="search-select"
-      minMenuHeight="45vh"
       maxMenuHeight="50vh"
       styles={typedAs<StylesConfig>({
         container: (baseStyles) => ({
@@ -198,7 +197,10 @@ export function SearchSelect<T extends string = string>({
           border: `${theme.sizes.bordersRem.thin}rem solid ${theme.colors.outline}`,
           borderRadius,
           backgroundColor: theme.colors.background,
-          top: 'calc(100% + 0.5rem)',
+          margin:
+            theme.sizeMode === 'desktop'
+              ? '0.5rem 0'
+              : `${theme.sizes.minTouchAreaSeparationPx}px 0`,
           width: '100%',
           zIndex: 10,
         }),


### PR DESCRIPTION
## Overview

Task: https://github.com/votingworks/vxsuite/issues/5247
Fixes: https://github.com/votingworks/vxsuite/issues/5201

An assortment of polish for issues found using an election definition with long content (e.g. 100 character contest and candidate names).

## Demo Video or Screenshot
Added to individual commits

## Testing Plan
Manual testing and automated test updates

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
