### PR TITLE
[Scan] Add API for audio diagnostics

### DIFF
--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -7,6 +7,7 @@ import {
   PrecinctSelection,
   SinglePrecinctSelection,
   DiagnosticRecord,
+  DiagnosticOutcome,
 } from '@votingworks/types';
 import {
   getPrecinctSelectionName,
@@ -59,6 +60,7 @@ import { printTestPage } from './printing/test_print';
 import { printFullReport } from './printing/print_full_report';
 import { printReportSection } from './printing/print_report_section';
 import {
+  TEST_AUDIO_USER_FAIL_REASON,
   TEST_PRINT_USER_FAIL_REASON,
   testPrintFailureDiagnosticMessage,
 } from './util/diagnostics';
@@ -446,6 +448,26 @@ export function buildApi({
         usbDrive,
         logger,
         printer,
+      });
+    },
+
+    getMostAudioDiagnostic(): DiagnosticRecord | null {
+      return store.getMostRecentDiagnosticRecord('scan-audio') ?? null;
+    },
+
+    logAudioDiagnosticOutcome(input: { outcome: DiagnosticOutcome }): void {
+      store.addDiagnosticRecord({
+        type: 'scan-audio',
+        outcome: input.outcome,
+        message:
+          input.outcome === 'pass' ? undefined : TEST_AUDIO_USER_FAIL_REASON,
+      });
+      void logger.logAsCurrentRole(LogEventId.DiagnosticComplete, {
+        disposition: input.outcome === 'pass' ? 'success' : 'failure',
+        message:
+          input.outcome === 'pass'
+            ? 'Audio playback successful.'
+            : `Audio playback failed. ${TEST_AUDIO_USER_FAIL_REASON}`,
       });
     },
 

--- a/apps/scan/backend/src/util/diagnostics.ts
+++ b/apps/scan/backend/src/util/diagnostics.ts
@@ -35,3 +35,6 @@ export function testPrintFailureDiagnosticMessage(
 
 export const TEST_PRINT_USER_FAIL_REASON =
   'The user indicated the print was not successful.';
+
+export const TEST_AUDIO_USER_FAIL_REASON =
+  'The user indicated audio playback was not successful.';

--- a/apps/scan/frontend/src/api.ts
+++ b/apps/scan/frontend/src/api.ts
@@ -458,6 +458,30 @@ export const logTestPrintOutcome = {
   },
 } as const;
 
+// istanbul ignore next - not yet hooked up
+export const getMostAudioDiagnostic = {
+  queryKey(): QueryKey {
+    return ['getMostAudioDiagnostic'];
+  },
+  useQuery() {
+    const apiClient = useApiClient();
+    return useQuery(this.queryKey(), () => apiClient.getMostAudioDiagnostic());
+  },
+} as const;
+
+// istanbul ignore next - not yet hooked up
+export const logAudioDiagnosticOutcome = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.logAudioDiagnosticOutcome, {
+      async onSuccess() {
+        await queryClient.invalidateQueries(getMostAudioDiagnostic.queryKey());
+      },
+    });
+  },
+} as const;
+
 export const saveReadinessReport = {
   useMutation() {
     const apiClient = useApiClient();

--- a/libs/types/src/diagnostics.ts
+++ b/libs/types/src/diagnostics.ts
@@ -7,7 +7,8 @@ export type DiagnosticType =
   | 'mark-scan-accessible-controller'
   | 'mark-scan-paper-handler'
   | 'mark-scan-pat-input'
-  | 'mark-scan-headphone-input';
+  | 'mark-scan-headphone-input'
+  | 'scan-audio';
 
 /**
  * The outcome of a hardware diagnostics test.


### PR DESCRIPTION
## Overview

Related to https://github.com/votingworks/vxsuite/issues/5193

Setting up the server/client APIs for getting and logging audio diagnostic records for upcoming work in the UI.
Following the patterns set in the print diagnostic flow.

## Testing Plan
- Deferred till the UI is hooked up

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
