### PR TITLE
Increase timeouts for readiness report tests

### DIFF
--- a/apps/admin/backend/src/app.diagnostics.test.ts
+++ b/apps/admin/backend/src/app.diagnostics.test.ts
@@ -15,6 +15,8 @@ import {
   mockSystemAdministratorAuth,
 } from '../test/app';
 
+jest.setTimeout(60_000);
+
 jest.mock(
   '@votingworks/backend',
   (): typeof import('@votingworks/backend') => ({

--- a/apps/central-scan/backend/src/app.diagnostics.test.ts
+++ b/apps/central-scan/backend/src/app.diagnostics.test.ts
@@ -12,7 +12,7 @@ import { electionTwoPartyPrimaryDefinition } from '@votingworks/fixtures';
 import { mockSystemAdministratorAuth } from '../test/helpers/auth';
 import { withApp } from '../test/helpers/setup_app';
 
-jest.setTimeout(20_000);
+jest.setTimeout(60_000);
 
 jest.mock(
   '@votingworks/backend',

--- a/apps/mark-scan/backend/src/app.diagnostics.test.ts
+++ b/apps/mark-scan/backend/src/app.diagnostics.test.ts
@@ -54,6 +54,8 @@ import {
 } from './custom-paper-handler/application_driver';
 import { BLANK_PAGE_MOCK } from '../test/ballot_helpers';
 
+jest.setTimeout(60_000);
+
 const TEST_POLLING_INTERVAL_MS = 5;
 
 const featureFlagMock = getFeatureFlagMock();


### PR DESCRIPTION


## Overview

These have been flaky, and we already set the apps/scan/backend test to have a 60s timeout. So standardize the rest of the apps on that timeout.
## Demo Video or Screenshot
N/A
## Testing Plan
🤞 
## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
