### PR TITLE
mark-scan/backend: Increase timeout for test hooks

### DIFF
--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -147,7 +147,7 @@ beforeAll(async () => {
   });
   scannedBallotFixtureFilepaths =
     await writeFirstBallotPageToImageFile(ballotPdfData);
-});
+}, 10_000);
 
 beforeEach(async () => {
   featureFlagMock.resetFeatureFlags();
@@ -190,12 +190,12 @@ beforeEach(async () => {
     patConnectionStatusReader,
     clock,
   })) as PaperHandlerStateMachine;
-});
+}, 10_000);
 
 afterEach(async () => {
   await machine.cleanUp();
   jest.resetAllMocks();
-});
+}, 10_000);
 
 async function setMockStatusAndIncrementClock(status: MockPaperHandlerStatus) {
   // Without this sleep the effects of `SimulatedCLock.increment()` are not


### PR DESCRIPTION


## Overview

Not sure why these are timing out occasionally, but the default timeout is 2s, so bumping to 10s to see if that helps.
## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
