### PR TITLE
Add printer cover is open screen

### DIFF
--- a/apps/scan/frontend/src/app_root.tsx
+++ b/apps/scan/frontend/src/app_root.tsx
@@ -37,6 +37,7 @@ import { LoginPromptScreen } from './screens/login_prompt_screen';
 import { CastVoteRecordSyncRequiredScreen } from './screens/cast_vote_record_sync_required_screen';
 import { SystemAdministratorScreen } from './screens/system_administrator_screen';
 import { ScannerCoverOpenScreen } from './screens/scanner_cover_open_screen';
+import { PrinterCoverOpenScreen } from './screens/printer_cover_open_screen';
 import { ScannerDoubleFeedCalibrationScreen } from './screens/scanner_double_feed_calibration_screen';
 
 export function AppRoot(): JSX.Element | null {
@@ -257,6 +258,13 @@ export function AppRoot(): JSX.Element | null {
 
   if (scannerStatus.state === 'cover_open') {
     return <ScannerCoverOpenScreen />;
+  }
+
+  if (
+    printerStatus.scheme === 'hardware-v4' &&
+    printerStatus.state === 'cover-open'
+  ) {
+    return <PrinterCoverOpenScreen />;
   }
 
   return (

--- a/apps/scan/frontend/src/screens/printer_cover_open_screen.tsx
+++ b/apps/scan/frontend/src/screens/printer_cover_open_screen.tsx
@@ -1,0 +1,13 @@
+import { CenteredLargeProse, H1, P, appStrings } from '@votingworks/ui';
+import { ScreenMainCenterChild } from '../components/layout';
+
+export function PrinterCoverOpenScreen(): JSX.Element {
+  return (
+    <ScreenMainCenterChild voterFacing>
+      <CenteredLargeProse>
+        <H1>{appStrings.titlePrinterCoverIsOpen()}</H1>
+        <P>{appStrings.instructionsAskForHelp()}</P>
+      </CenteredLargeProse>
+    </ScreenMainCenterChild>
+  );
+}

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -1241,6 +1241,12 @@ export const appStrings = {
     </UiString>
   ),
 
+  titlePrinterCoverIsOpen: () => (
+    <UiString uiStringKey="titlePrinterCoverIsOpen">
+      Printer Cover is Open
+    </UiString>
+  ),
+
   titleScannerCoverIsOpen: () => (
     <UiString uiStringKey="titleScannerCoverIsOpen">
       Scanner Cover is Open

--- a/libs/ui/src/ui_strings/app_strings_catalog/latest.json
+++ b/libs/ui/src/ui_strings/app_strings_catalog/latest.json
@@ -381,6 +381,7 @@
   "titleNoPowerDetected": "No Power Detected",
   "titleOfficialBallot": "Official Ballot",
   "titlePrecinct": "Precinct",
+  "titlePrinterCoverIsOpen": "Printer Cover is Open",
   "titleRemoveYourBallot": "Remove Your Ballot",
   "titleScannerBallotNotCounted": "Ballot Not Counted",
   "titleScannerBallotWarningsScreen": "Review Your Ballot",


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/5259 
Adds a screen when the printer cover is open. This follows the pattern of the scanner cover is open screen where it is only shown when polls are open. The pollworker flows already have blocks that prevent opening/closing polls in this case. I could see moving it above the polls closed screen though but since this could just jostle open I think it makes sense to just not alert on it unless you are in a situation where it could actually present an issue. 

<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot


https://github.com/user-attachments/assets/df395ede-7a1e-4555-a1a7-a7ff0de53271


## Testing Plan
Added test, tested manually using dev dock mock. 

## Checklist
I am intending a more comprehensive review to add logs to any missing hardware states like this in VxScan in another PR. 

<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
