### PR TITLE
Fix mark-scan test timeout

### DIFF
--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -195,12 +195,12 @@ beforeEach(async () => {
     patConnectionStatusReader,
     clock,
   });
-});
+}, 10_000);
 
 afterEach(async () => {
   await machine.cleanUp();
   jest.resetAllMocks();
-});
+}, 10_000);
 
 async function setMockStatusAndIncrementClock(status: MockPaperHandlerStatus) {
   // Without this sleep the effects of `SimulatedCLock.increment()` are not

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -182,14 +182,14 @@ beforeEach(async () => {
 
   mockOf(HID.devices).mockReturnValue([]);
 
-  machine = (await getPaperHandlerStateMachine({
+  machine = await getPaperHandlerStateMachine({
     workspace,
     auth,
     logger,
     driver,
     patConnectionStatusReader,
     clock,
-  })) as PaperHandlerStateMachine;
+  });
 });
 
 afterEach(async () => {

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -140,14 +140,19 @@ function expectMockPaperHandlerStatus(
   expect(mockDriver.getMockStatus()).toEqual(mockStatus);
 }
 
-beforeAll(async () => {
-  ballotPdfData = await renderBmdBallotFixture({
-    electionDefinition: electionGeneralDefinition,
-    frontPageOnly: true,
-  });
-  scannedBallotFixtureFilepaths =
-    await writeFirstBallotPageToImageFile(ballotPdfData);
-});
+beforeAll(
+  async () => {
+    ballotPdfData = await renderBmdBallotFixture({
+      electionDefinition: electionGeneralDefinition,
+      frontPageOnly: true,
+    });
+    scannedBallotFixtureFilepaths =
+      await writeFirstBallotPageToImageFile(ballotPdfData);
+  },
+  // Increase timeout for this hook only because ballot fixture
+  // rendering can take a few seconds
+  10_000
+);
 
 beforeEach(async () => {
   featureFlagMock.resetFeatureFlags();

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -1351,7 +1351,7 @@ export async function getPaperHandlerStateMachine({
   driver: PaperHandlerDriverInterface;
   patConnectionStatusReader: PatConnectionStatusReaderInterface;
   clock?: Clock;
-}): Promise<Optional<PaperHandlerStateMachine>> {
+}): Promise<PaperHandlerStateMachine> {
   const diagnosticElectionDefinitionResult = await readElection(
     DIAGNOSTIC_ELECTION_PATH
   );


### PR DESCRIPTION
## Overview

Increases the timeout on mark-scan state machine tests to 10s. The ballot fixture render in this step can take longer than the global timeout for that file (2s).

Hopefully addresses flaky tests: https://app.circleci.com/pipelines/github/votingworks/vxsuite/16750/workflows/8b0a21d9-f214-4e67-80fb-ec5d143af6a8/jobs/653438

## Demo Video or Screenshot

N/a

## Testing Plan

Ran locally a few times but couldn't repro. We'll have to see if flakiness is reduced in CI over time.
