### PR TITLE
Add disposition failure to all error logs in app

### DIFF
--- a/apps/mark-scan/accessible-controller/src/controllerd.rs
+++ b/apps/mark-scan/accessible-controller/src/controllerd.rs
@@ -74,7 +74,8 @@ fn main() -> color_eyre::Result<()> {
         log!(
             event_id: EventId::ErrorSettingSigintHandler,
             message: e.to_string(),
-            event_type: EventType::SystemStatus
+            event_type: EventType::SystemStatus,
+            disposition: Disposition::Failure
         );
     }
 
@@ -162,7 +163,8 @@ fn run_event_loop(mut keyboard: impl VirtualKeyboard, mut port: Port, running: &
                 log!(
                     event_id: EventId::UnknownError,
                     message: format!("Unexpected error when reading from serial port: {e:?}"),
-                    event_type: EventType::SystemStatus
+                    event_type: EventType::SystemStatus,
+                    disposition: Disposition::Failure
                 );
             }
         }
@@ -180,14 +182,19 @@ fn on_port_data_received(keyboard: &mut impl VirtualKeyboard, data: &[u8]) {
                     &[]
                 },
             ) {
-                log!(EventId::UnknownError, "Error sending key: {err}");
+                log!(
+                    event_id: EventId::UnknownError,
+                    message: format!("Error sending key: {err}"),
+                    disposition: Disposition::Failure
+                );
             }
         }
         Ok(None) => {}
         Err(err) => log!(
             event_id: EventId::UnknownError,
             message: format!("Unexpected error when handling controller command: {err}"),
-            event_type: EventType::SystemStatus
+            event_type: EventType::SystemStatus,
+            disposition: Disposition::Failure
         ),
     }
 }

--- a/apps/mark-scan/accessible-controller/src/port.rs
+++ b/apps/mark-scan/accessible-controller/src/port.rs
@@ -84,14 +84,16 @@ impl Port {
                     Err(e) => log!(
                         event_id: EventId::UnknownError,
                         message: format!("Error clearing in-buffer: {e:?}"),
-                        event_type: EventType::SystemStatus
+                        event_type: EventType::SystemStatus,
+                        disposition: Disposition::Failure
                     ),
                 };
             }
             Err(e) => log!(
                 event_id: EventId::UnknownError,
                 message: format!("Error checking bytes to read: {e:?}"),
-                event_type: EventType::SystemStatus
+                event_type: EventType::SystemStatus,
+                disposition: Disposition::Failure
             ),
         }
 

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -297,6 +297,7 @@ it('logs when an auth error happens', async () => {
   await backendWaitFor(() => {
     expect(logger.log).toHaveBeenCalledWith(LogEventId.UnknownError, 'system', {
       error: 'mock auth error',
+      disposition: 'failure',
     });
   });
 });

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -428,6 +428,7 @@ export function buildMachine(
         } catch (err) {
           await logger.log(LogEventId.PatDeviceError, 'system', {
             error: (err as Error).message,
+            disposition: 'failure',
           });
           return { type: 'PAT_DEVICE_STATUS_UNHANDLED' };
         }
@@ -467,6 +468,7 @@ export function buildMachine(
         } catch (err) {
           await logger.log(LogEventId.UnknownError, 'system', {
             error: (err as Error).message,
+            disposition: 'failure',
           });
           return { type: 'AUTH_STATUS_UNHANDLED' };
         }

--- a/apps/mark-scan/backend/src/util/hardware.test.ts
+++ b/apps/mark-scan/backend/src/util/hardware.test.ts
@@ -117,6 +117,7 @@ test('unknown error', async () => {
   expect(logger.log).toHaveBeenCalledWith(LogEventId.UnknownError, 'system', {
     message: 'Unknown error when checking PID',
     error: expect.anything(),
+    disposition: 'failure',
   });
 });
 
@@ -142,5 +143,6 @@ test('when reported PID is not a number', async () => {
   ).toEqual(false);
   expect(logger.log).toHaveBeenCalledWith(LogEventId.ParseError, 'system', {
     message: `Unable to parse accessible controller daemon PID: ${wrongPidStr}`,
+    disposition: 'failure',
   });
 });

--- a/apps/mark-scan/backend/src/util/hardware.ts
+++ b/apps/mark-scan/backend/src/util/hardware.ts
@@ -41,6 +41,7 @@ export async function isAccessibleControllerDaemonRunning(
   if (pidResult.isErr()) {
     await logger.log(LogEventId.ParseError, 'system', {
       message: `Unable to parse accessible controller daemon PID: ${pidString}`,
+      disposition: 'failure',
     });
     return false;
   }
@@ -67,6 +68,7 @@ export async function isAccessibleControllerDaemonRunning(
         await logger.log(LogEventId.UnknownError, 'system', {
           message: 'Unknown error when checking PID',
           error: JSON.stringify(error),
+          disposition: 'failure',
         });
         return false;
     }

--- a/apps/mark-scan/fai-100-controller/src/fai_100_controllerd.rs
+++ b/apps/mark-scan/fai-100-controller/src/fai_100_controllerd.rs
@@ -94,7 +94,8 @@ fn main() -> color_eyre::Result<()> {
         log!(
             event_id: EventId::ErrorSettingSigintHandler,
             message: e.to_string(),
-            event_type: EventType::SystemStatus
+            event_type: EventType::SystemStatus,
+            disposition: Disposition::Failure
         );
     }
 
@@ -201,7 +202,8 @@ fn validate_connection(usb_device: &mut UsbDevice) -> Result<(), io::Error> {
         Err(e) => log!(
             event_id: EventId::UnknownError,
             message: format!("validate_connection unexpected error when writing command: {e:?}"),
-            event_type: EventType::SystemStatus
+            event_type: EventType::SystemStatus,
+            disposition: Disposition::Failure
         ),
     }
     let _ = usb_device.flush();
@@ -314,7 +316,11 @@ fn send_keystroke(keypress: &KeypressSpec, keyboard: &mut impl VirtualKeyboard) 
             &[]
         },
     ) {
-        log!(EventId::UnknownError, "Error sending key: {err}");
+        log!(
+            event_id: EventId::UnknownError,
+            message: format!("Error sending key: {err}"),
+            disposition: Disposition::Failure
+        );
     }
 }
 
@@ -455,7 +461,8 @@ fn run_event_loop(
             Err(e) => log!(
                 event_id: EventId::UnknownError,
                 message: format!("Unexpected error when writing get_notifications_command: {e:?}"),
-                event_type: EventType::SystemStatus
+                event_type: EventType::SystemStatus,
+                disposition: Disposition::Failure
             ),
         }
         let _ = usb_device.flush();
@@ -476,14 +483,16 @@ fn run_event_loop(
                             Err(e) => log!(
                                 event_id: EventId::UnknownError,
                                 message: format!("Unexpected error when handling status response: {e:?}"),
-                                event_type: EventType::SystemStatus
+                                event_type: EventType::SystemStatus,
+                                disposition: Disposition::Failure
                             ),
                         }
                     }
                     Err(e) => log!(
                         event_id: EventId::UnknownError,
                         message: format!("Unexpected error when parsing status response from raw data: {e:?}"),
-                        event_type: EventType::SystemStatus
+                        event_type: EventType::SystemStatus,
+                        disposition: Disposition::Failure
                     ),
                 }
             }
@@ -493,7 +502,8 @@ fn run_event_loop(
                 log!(
                     event_id: EventId::UnknownError,
                     message: format!("Unexpected error when reading from bulk endpoint: {e:?}"),
-                    event_type: EventType::SystemStatus
+                    event_type: EventType::SystemStatus,
+                    disposition: Disposition::Failure
                 );
             }
         }

--- a/apps/mark-scan/pat-device-input/src/patinputd.rs
+++ b/apps/mark-scan/pat-device-input/src/patinputd.rs
@@ -77,7 +77,8 @@ fn main() {
         log!(
             event_id: EventId::ErrorSettingSigintHandler,
             message: e.to_string(),
-            event_type: EventType::SystemStatus
+            event_type: EventType::SystemStatus,
+            disposition: Disposition::Failure
         );
     }
 
@@ -121,16 +122,18 @@ fn main() {
                 if new_signal_a && !signal_a {
                     if let Err(err) = send_key(&mut device, keyboard::Key::_1) {
                         log!(
-                            EventId::PatDeviceError,
-                            "Error sending 1 keypress event: {err}"
+                            event_id: EventId::PatDeviceError,
+                            message:  format!("Error sending 1 keypress event: {err}"),
+                            disposition: Disposition::Failure
                         );
                     }
                 }
                 if new_signal_b && !signal_b {
                     if let Err(err) = send_key(&mut device, keyboard::Key::_2) {
                         log!(
-                            EventId::PatDeviceError,
-                            "Error sending 2 keypress event: {err}"
+                            event_id: EventId::PatDeviceError,
+                            message: format!("Error sending 2 keypress event: {err}"),
+                            disposition: Disposition::Failure
                         );
                     }
                 }

--- a/apps/mark-scan/pat-device-input/src/pin.rs
+++ b/apps/mark-scan/pat-device-input/src/pin.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use vx_logging::{log, EventId};
+use vx_logging::{log, Disposition, EventId};
 
 const EXPORT_PIN_FILEPATH: &str = "/sys/class/gpio/export";
 const UNEXPORT_PIN_FILEPATH: &str = "/sys/class/gpio/unexport";
@@ -68,8 +68,9 @@ impl Pin for GpioPin {
         let filepath = format!("/sys/class/gpio/gpio{self}/value");
         let Ok(mut file) = File::open(filepath) else {
             log!(
-                EventId::PatDeviceError,
-                "Failed to open file for pin {self}",
+                event_id: EventId::PatDeviceError,
+                message: format!("Failed to open file for pin {self}"),
+                disposition: Disposition::Failure
             );
             return false;
         };
@@ -77,8 +78,9 @@ impl Pin for GpioPin {
         let mut buf = [0; 1];
         if let Err(e) = file.read_exact(&mut buf) {
             log!(
-                EventId::PatDeviceError,
-                "Failed to read file for pin {self}: {e}",
+                event_id: EventId::PatDeviceError,
+                message: format!("Failed to read file for pin {self}: {e}"),
+                disposition: Disposition::Failure
             );
             return false;
         }
@@ -93,9 +95,9 @@ impl Pin for GpioPin {
             b'1' => false,
             _ => {
                 log!(
-                    EventId::PatDeviceError,
-                    "Unexpected value for pin #{self}: {char}",
-                    char = buf[0] as char,
+                    event_id: EventId::PatDeviceError,
+                    message: format!("Unexpected value for pin #{self}: {char}", char = buf[0] as char),
+                    disposition: Disposition::Failure
                 );
                 false
             }

--- a/libs/backend/src/exceptions.ts
+++ b/libs/backend/src/exceptions.ts
@@ -13,6 +13,7 @@ export function handleUncaughtExceptions(logger: BaseLogger): void {
   ) {
     await logger.log(LogEventId.UnknownError, 'system', {
       message: `server shutting down due to ${origin}: ${error.message} | ${error.stack}`,
+      disposition: 'failure',
     });
 
     // To avoid proceeding in a potentially corrupted state, we shut down the

--- a/libs/backend/src/system_call/get_audio_info.test.ts
+++ b/libs/backend/src/system_call/get_audio_info.test.ts
@@ -74,6 +74,7 @@ test('execFile error', async () => {
     LogEventId.HeadphonesDetectionError,
     {
       message: expect.stringContaining('execFile failed'),
+      disposition: 'failure',
     }
   );
 });
@@ -90,6 +91,7 @@ test('pactl error', async () => {
     LogEventId.HeadphonesDetectionError,
     {
       message: expect.stringContaining('access denied'),
+      disposition: 'failure',
     }
   );
 });

--- a/libs/backend/src/system_call/get_audio_info.ts
+++ b/libs/backend/src/system_call/get_audio_info.ts
@@ -20,6 +20,7 @@ export async function getAudioInfo(logger: Logger): Promise<AudioInfo> {
   } catch (error) {
     void logger.logAsCurrentRole(LogEventId.HeadphonesDetectionError, {
       message: `Unable to run pactl command: ${error}}`,
+      disposition: 'failure',
     });
 
     return { headphonesActive: false };
@@ -28,6 +29,7 @@ export async function getAudioInfo(logger: Logger): Promise<AudioInfo> {
   if (errorOutput) {
     void logger.logAsCurrentRole(LogEventId.HeadphonesDetectionError, {
       message: `pactl command failed: ${errorOutput}}`,
+      disposition: 'failure',
     });
 
     return { headphonesActive: false };

--- a/libs/ui/src/error_boundary.test.tsx
+++ b/libs/ui/src/error_boundary.test.tsx
@@ -30,13 +30,18 @@ test('renders children when there is no error', async () => {
 
 test.each<{
   error: unknown;
-  expectedLog: { errorMessage: string; errorStack?: string };
+  expectedLog: {
+    errorMessage: string;
+    errorStack?: string;
+    disposition: string;
+  };
 }>([
   {
     error: new Error('Whoa!'),
     expectedLog: {
       errorMessage: 'Whoa!',
       errorStack: expect.stringContaining('Whoa!'),
+      disposition: 'failure',
     },
   },
   {
@@ -44,6 +49,7 @@ test.each<{
     expectedLog: {
       errorMessage: '42',
       errorStack: undefined,
+      disposition: 'failure',
     },
   },
 ])(

--- a/libs/ui/src/error_boundary.tsx
+++ b/libs/ui/src/error_boundary.tsx
@@ -47,6 +47,7 @@ export class ErrorBoundary extends React.Component<Props, State> {
     await logger?.log(LogEventId.UnknownError, 'system', {
       errorMessage: extractErrorMessage(error),
       errorStack: error instanceof Error ? error.stack : undefined,
+      disposition: 'failure',
     });
   }
 


### PR DESCRIPTION
## Overview
In order to filter logs for only errors we need a way to identify errors, I think filtering for the required cdf field "disposition" as "failure" is the most appropriate place to do this. This PR adds the disposition: failure designation to logs it was missing from that are clearly indicating errors based on type. Just did a naive search for log event IDs with "Error" in the name. 
<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot

## Testing Plan
Ran Tests

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
