### PR TITLE
Allow CDF and Error-Only Log Exports

### DIFF
--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -1015,6 +1015,7 @@ function buildApi({
       usbDrive,
       logger,
       machineId: getMachineConfig().machineId,
+      codeVersion: getMachineConfig().codeVersion,
     }),
   });
 }

--- a/apps/admin/frontend/src/app.test.tsx
+++ b/apps/admin/frontend/src/app.test.tsx
@@ -93,7 +93,7 @@ test('configuring with an election definition', async () => {
   fireEvent.click(screen.getByText('Save Log File'));
   await screen.findByText('No USB Drive Detected');
   apiMock.expectGetUsbDriveStatus('mounted');
-  await screen.findByText('Save logs on the inserted USB drive?');
+  await screen.findByText(/Select a logging format/);
 
   fireEvent.click(screen.getByText('Election'));
 
@@ -116,7 +116,7 @@ test('configuring with an election definition', async () => {
   fireEvent.click(screen.getByText('Settings'));
   await screen.findByText('Save Log File');
   fireEvent.click(screen.getByText('Save Log File'));
-  await screen.findByText('Save logs on the inserted USB drive?');
+  await screen.findByText(/Select a logging format/);
 });
 
 test('authentication works', async () => {

--- a/apps/admin/frontend/src/screens/settings_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/settings_screen.test.tsx
@@ -78,11 +78,13 @@ describe('as System Admin', () => {
       usbDriveStatus: mockUsbDriveStatus('mounted'),
     });
 
-    apiMock.apiClient.exportLogsToUsb.expectCallWith().resolves(ok());
+    apiMock.apiClient.exportLogsToUsb
+      .expectCallWith({ format: 'vxf' })
+      .resolves(ok());
 
     // Log saving is tested fully in src/components/export_logs_modal.test.tsx
     userEvent.click(screen.getButton('Save Log File'));
-    await screen.findByText('Save logs on the inserted USB drive?');
+    await screen.findByText(/Select a logging format/);
     userEvent.click(screen.getButton('Save'));
     userEvent.click(await screen.findButton('Close'));
     await waitFor(() =>
@@ -125,11 +127,13 @@ describe('as Election Manager', () => {
       usbDriveStatus: mockUsbDriveStatus('mounted'),
     });
 
-    apiMock.apiClient.exportLogsToUsb.expectCallWith().resolves(ok());
+    apiMock.apiClient.exportLogsToUsb
+      .expectCallWith({ format: 'vxf' })
+      .resolves(ok());
 
     // Log saving is tested fully in src/components/export_logs_modal.test.tsx
     userEvent.click(screen.getButton('Save Log File'));
-    await screen.findByText('Save logs on the inserted USB drive?');
+    await screen.findByText(/Select a logging format/);
     userEvent.click(screen.getButton('Save'));
     userEvent.click(await screen.findButton('Close'));
     await waitFor(() =>

--- a/apps/central-scan/backend/src/app.ts
+++ b/apps/central-scan/backend/src/app.ts
@@ -313,6 +313,7 @@ function buildApi({
       usbDrive,
       logger,
       machineId: getMachineConfig().machineId,
+      codeVersion: getMachineConfig().codeVersion,
     }),
   });
 }

--- a/apps/central-scan/frontend/src/screens/system_administrator_settings_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/system_administrator_settings_screen.test.tsx
@@ -44,11 +44,13 @@ test('Exporting logs', async () => {
     usbDriveStatus: mockUsbDriveStatus('mounted'),
   });
 
-  apiMock.apiClient.exportLogsToUsb.expectCallWith().resolves(ok());
+  apiMock.apiClient.exportLogsToUsb
+    .expectCallWith({ format: 'vxf' })
+    .resolves(ok());
 
   // Log saving is tested fully in src/components/export_logs_modal.test.tsx
   userEvent.click(screen.getButton('Save Log File'));
-  await screen.findByText('Save logs on the inserted USB drive?');
+  await screen.findByText(/Select a logging format/);
   userEvent.click(screen.getButton('Save'));
   userEvent.click(await screen.findButton('Close'));
   await waitFor(() =>

--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -327,6 +327,7 @@ export function buildApi(
       usbDrive,
       logger,
       machineId: getMachineConfig().machineId,
+      codeVersion: getMachineConfig().codeVersion,
     }),
 
     async setPollsState(input: { pollsState: PollsState }) {

--- a/apps/mark-scan/frontend/src/pages/admin_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/admin_screen.test.tsx
@@ -126,7 +126,7 @@ test('renders a save logs button with usb mounted', async () => {
   renderScreen({ usbDriveStatus: mockUsbDriveStatus('mounted') });
   const saveLogsButton = await screen.findByText('Save Log File');
   userEvent.click(saveLogsButton);
-  await screen.findByText('Save logs on the inserted USB drive?');
+  await screen.findByText(/Select a logging format/);
 });
 
 test('renders a USB controller button', async () => {

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -200,6 +200,7 @@ export function buildApi(
       usbDrive,
       logger,
       machineId: getMachineConfig().machineId,
+      codeVersion: getMachineConfig().codeVersion,
     }),
 
     async printBallot(input: PrintBallotProps) {

--- a/apps/mark/frontend/src/pages/admin_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.test.tsx
@@ -130,7 +130,7 @@ test('renders a save logs button with usb mounted', async () => {
   renderScreen({ usbDriveStatus: mockUsbDriveStatus('mounted') });
   const saveLogsButton = await screen.findByText('Save Log File');
   userEvent.click(saveLogsButton);
-  await screen.findByText('Save logs on the inserted USB drive?');
+  await screen.findByText(/Select a logging format/);
 });
 
 test('renders a USB controller button', async () => {

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -450,6 +450,7 @@ export function buildApi({
       usbDrive,
       logger,
       machineId: getMachineConfig().machineId,
+      codeVersion: getMachineConfig().codeVersion,
     }),
   });
 }

--- a/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
@@ -467,7 +467,9 @@ test('renders buttons for saving logs', async () => {
 
   userEvent.click(screen.getByRole('tab', { name: 'CVRs and Logs' }));
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
-  apiMock.mockApiClient.exportLogsToUsb.expectCallWith().resolves(ok());
+  apiMock.mockApiClient.exportLogsToUsb
+    .expectCallWith({ format: 'vxf' })
+    .resolves(ok());
   userEvent.click(screen.getByText('Save Log File'));
   userEvent.click(screen.getByText('Save'));
   await screen.findByText('Logs Saved');

--- a/libs/backend/src/system_call/api.test.ts
+++ b/libs/backend/src/system_call/api.test.ts
@@ -33,11 +33,14 @@ beforeEach(() => {
     usbDrive: mockUsbDrive.usbDrive,
     logger,
     machineId: 'TEST-MACHINE-ID',
+    codeVersion: 'TEST-CODE-VERSION',
   });
 });
 
 test('exportLogsToUsb', async () => {
-  expect((await api.exportLogsToUsb()).err()).toEqual('no-logs-directory');
+  expect((await api.exportLogsToUsb({ format: 'vxf' })).err()).toEqual(
+    'no-logs-directory'
+  );
 });
 
 test('rebootToBios', async () => {

--- a/libs/backend/src/system_call/api.ts
+++ b/libs/backend/src/system_call/api.ts
@@ -1,7 +1,7 @@
 import * as grout from '@votingworks/grout';
 import { UsbDrive } from '@votingworks/usb-drive';
 
-import { Logger } from '@votingworks/logging';
+import { LogExportFormat, Logger } from '@votingworks/logging';
 import { exportLogsToUsb } from './export_logs_to_usb';
 import { rebootToBios } from './reboot_to_bios';
 import { powerDown } from './power_down';
@@ -13,14 +13,22 @@ function buildApi({
   usbDrive,
   logger,
   machineId,
+  codeVersion,
 }: {
   usbDrive: UsbDrive;
   logger: Logger;
   machineId: string;
+  codeVersion: string;
 }) {
   return grout.createApi({
-    exportLogsToUsb: async () =>
-      exportLogsToUsb({ usbDrive, logger, machineId }),
+    exportLogsToUsb: async (input: { format: LogExportFormat }) =>
+      exportLogsToUsb({
+        usbDrive,
+        logger,
+        format: input.format,
+        machineId,
+        codeVersion,
+      }),
     rebootToBios: async () => rebootToBios(logger),
     powerDown: async () => powerDown(logger),
     setClock,
@@ -37,10 +45,12 @@ export function createSystemCallApi({
   usbDrive,
   logger,
   machineId,
+  codeVersion,
 }: {
   usbDrive: UsbDrive;
   logger: Logger;
   machineId: string;
+  codeVersion: string;
 }): SystemCallApi {
-  return buildApi({ usbDrive, logger, machineId });
+  return buildApi({ usbDrive, logger, machineId, codeVersion });
 }

--- a/libs/backend/src/system_call/export_logs_to_usb.test.ts
+++ b/libs/backend/src/system_call/export_logs_to_usb.test.ts
@@ -2,16 +2,29 @@
 
 import { createMockUsbDrive } from '@votingworks/usb-drive';
 import * as fs from 'fs/promises';
-import { Stats } from 'fs';
+import { Stats, createReadStream, createWriteStream } from 'fs';
 import { mockOf } from '@votingworks/test-utils';
 import { LogEventId, Logger, mockLogger } from '@votingworks/logging';
+import { tmpNameSync } from 'tmp';
+import { PassThrough } from 'stream';
 import { execFile } from '../exec';
 import { exportLogsToUsb } from './export_logs_to_usb';
 
 jest.mock('fs/promises', () => ({
   ...jest.requireActual('fs/promises'),
   stat: jest.fn().mockRejectedValue(new Error('not mocked yet')),
+  readdir: jest.fn(),
 }));
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  createReadStream: jest.fn(),
+  createWriteStream: jest.fn(),
+}));
+const { createReadStream: realCreateReadStream } = jest.requireActual('fs');
+const createReadStreamMock = mockOf(createReadStream) as jest.Mock;
+const createWriteStreamMock = mockOf(createWriteStream) as jest.Mock;
+
+createReadStreamMock.mockImplementation(realCreateReadStream);
 
 jest.mock('../exec', (): typeof import('../exec') => ({
   ...jest.requireActual('../exec'),
@@ -24,6 +37,8 @@ let logger: Logger;
 
 beforeEach(() => {
   logger = mockLogger();
+  createWriteStreamMock.mockReturnValue(new PassThrough());
+  createReadStreamMock.mockReset();
 });
 
 test('exportLogsToUsb without logs directory', async () => {
@@ -36,6 +51,8 @@ test('exportLogsToUsb without logs directory', async () => {
         usbDrive: mockUsbDrive.usbDrive,
         logger,
         machineId: 'TEST-MACHINE-ID',
+        codeVersion: 'TEST-CODE-VERSION',
+        format: 'vxf',
       })
     ).err()
   ).toEqual('no-logs-directory');
@@ -51,6 +68,8 @@ test('exportLogsToUsb without logs directory', async () => {
         usbDrive: mockUsbDrive.usbDrive,
         logger,
         machineId: 'TEST-MACHINE-ID',
+        codeVersion: 'TEST-CODE-VERSION',
+        format: 'vxf',
       })
     ).err()
   ).toEqual('no-logs-directory');
@@ -79,6 +98,8 @@ test('exportLogsToUsb without USB', async () => {
         usbDrive: mockUsbDrive.usbDrive,
         logger,
         machineId: 'TEST-MACHINE-ID',
+        codeVersion: 'TEST-CODE-VERSION',
+        format: 'vxf',
       })
     ).err()
   ).toEqual('no-usb-drive');
@@ -102,12 +123,14 @@ test('exportLogsToUsb with unknown failure', async () => {
         usbDrive: mockUsbDrive.usbDrive,
         logger,
         machineId: 'TEST-MACHINE-ID',
+        codeVersion: 'TEST-CODE-VERSION',
+        format: 'vxf',
       })
     ).err()
   ).toEqual('copy-failed');
 });
 
-test('exportLogsToUsb works when all conditions are met', async () => {
+test('exportLogsToUsb works for vxf format when all conditions are met', async () => {
   const mockUsbDrive = createMockUsbDrive();
   mockUsbDrive.usbDrive.status.reset();
   mockUsbDrive.usbDrive.status.expectRepeatedCallsWith().resolves({
@@ -127,6 +150,8 @@ test('exportLogsToUsb works when all conditions are met', async () => {
         usbDrive: mockUsbDrive.usbDrive,
         logger,
         machineId: 'TEST-MACHINE-ID',
+        codeVersion: 'TEST-CODE-VERSION',
+        format: 'vxf',
       })
     ).isOk()
   ).toBeTruthy();
@@ -144,6 +169,211 @@ test('exportLogsToUsb works when all conditions are met', async () => {
   ]);
 
   expect(execFileMock).toHaveBeenCalledWith('sync', ['-f', '/media/usb-drive']);
+
+  expect(logger.log).toHaveBeenCalledWith(
+    LogEventId.FileSaved,
+    'unknown',
+    expect.objectContaining({
+      disposition: 'success',
+      message: 'Sucessfully saved logs on the usb drive.',
+    })
+  );
+});
+
+test('exportLogsToUsb returns error when cdf conversion fails', async () => {
+  const mockUsbDrive = createMockUsbDrive();
+  mockUsbDrive.usbDrive.status.reset();
+  mockUsbDrive.usbDrive.status.expectRepeatedCallsWith().resolves({
+    status: 'mounted',
+    mountPoint: '/media/usb-drive',
+  });
+
+  const mockStats = new Stats();
+  mockStats.isDirectory = jest.fn().mockReturnValue(true);
+  mockOf(fs.stat).mockResolvedValueOnce(mockStats);
+  const readdirMock = fs.readdir as unknown as jest.Mock<Promise<string[]>>;
+  readdirMock.mockResolvedValue(['vx-logs.log', 'vx-logs.log-20240101.gz']);
+
+  const logFile = tmpNameSync();
+  await fs.writeFile(logFile, ``);
+  createReadStreamMock.mockReturnValueOnce(
+    realCreateReadStream(logFile, 'utf8')
+  );
+  // There will be an error uncompressing if this is an empty file
+  createReadStreamMock.mockReturnValueOnce(
+    realCreateReadStream(logFile, 'utf8')
+  );
+
+  execFileMock.mockResolvedValue({ stdout: '', stderr: '' });
+
+  const result = await exportLogsToUsb({
+    usbDrive: mockUsbDrive.usbDrive,
+    logger,
+    machineId: 'TEST-MACHINE-ID',
+    codeVersion: 'TEST-CODE-VERSION',
+    format: 'cdf',
+  });
+  expect(result.isErr()).toBeTruthy();
+  expect(result.err()).toEqual('cdf-conversion-failed');
+});
+
+test('exportLogsToUsb returns error when error filtering fails', async () => {
+  const mockUsbDrive = createMockUsbDrive();
+  mockUsbDrive.usbDrive.status.reset();
+  mockUsbDrive.usbDrive.status.expectRepeatedCallsWith().resolves({
+    status: 'mounted',
+    mountPoint: '/media/usb-drive',
+  });
+
+  const mockStats = new Stats();
+  mockStats.isDirectory = jest.fn().mockReturnValue(true);
+  mockOf(fs.stat).mockResolvedValueOnce(mockStats);
+  const readdirMock = fs.readdir as unknown as jest.Mock<Promise<string[]>>;
+  readdirMock.mockResolvedValue(['vx-logs.log', 'vx-logs.log-20240101.gz']);
+
+  const logFile = tmpNameSync();
+  await fs.writeFile(logFile, ``);
+  createReadStreamMock.mockReturnValueOnce(
+    realCreateReadStream(logFile, 'utf8')
+  );
+  // There will be an error uncompressing if this is an empty file
+  createReadStreamMock.mockReturnValueOnce(
+    realCreateReadStream(logFile, 'utf8')
+  );
+
+  execFileMock.mockResolvedValue({ stdout: '', stderr: '' });
+
+  const result = await exportLogsToUsb({
+    usbDrive: mockUsbDrive.usbDrive,
+    logger,
+    machineId: 'TEST-MACHINE-ID',
+    codeVersion: 'TEST-CODE-VERSION',
+    format: 'err',
+  });
+  expect(result.isErr()).toBeTruthy();
+  expect(result.err()).toEqual('error-filtering-failed');
+});
+
+test('exportLogsToUsb works for cdf format when all conditions are met', async () => {
+  const mockUsbDrive = createMockUsbDrive();
+  mockUsbDrive.usbDrive.status.reset();
+  mockUsbDrive.usbDrive.status.expectRepeatedCallsWith().resolves({
+    status: 'mounted',
+    mountPoint: '/media/usb-drive',
+  });
+
+  const mockStats = new Stats();
+  mockStats.isDirectory = jest.fn().mockReturnValue(true);
+  mockOf(fs.stat).mockResolvedValueOnce(mockStats);
+  const readdirMock = fs.readdir as unknown as jest.Mock<Promise<string[]>>;
+  readdirMock.mockResolvedValue(['vx-logs.log']);
+
+  const logFile = tmpNameSync();
+  await fs.writeFile(logFile, ``);
+  createReadStreamMock.mockReturnValueOnce(
+    realCreateReadStream(logFile, 'utf8')
+  );
+
+  execFileMock.mockResolvedValue({ stdout: '', stderr: '' });
+
+  expect(
+    (
+      await exportLogsToUsb({
+        usbDrive: mockUsbDrive.usbDrive,
+        logger,
+        machineId: 'TEST-MACHINE-ID',
+        codeVersion: 'TEST-CODE-VERSION',
+        format: 'cdf',
+      })
+    ).isOk()
+  ).toBeTruthy();
+  expect(mockOf(fs.stat)).toHaveBeenCalledWith('/var/log/votingworks');
+
+  expect(execFileMock).toHaveBeenCalledWith('mkdir', [
+    '-p',
+    '/media/usb-drive/logs/machine_TEST-MACHINE-ID',
+  ]);
+
+  expect(execFileMock).toHaveBeenCalledWith('cp', [
+    '-r',
+    expect.stringContaining('/tmp/'),
+    expect.stringMatching('^/media/usb-drive/logs/machine_TEST-MACHINE-ID/'),
+  ]);
+
+  expect(execFileMock).toHaveBeenCalledWith('sync', ['-f', '/media/usb-drive']);
+  expect(createWriteStreamMock).toHaveBeenCalledWith(
+    expect.stringContaining('vx-logs.cdf.log')
+  );
+
+  expect(logger.log).toHaveBeenCalledWith(
+    LogEventId.LogConversionToCdfComplete,
+    'unknown',
+    expect.objectContaining({
+      disposition: 'success',
+      message: expect.anything(),
+    })
+  );
+
+  expect(logger.log).toHaveBeenCalledWith(
+    LogEventId.FileSaved,
+    'unknown',
+    expect.objectContaining({
+      disposition: 'success',
+      message: 'Sucessfully saved logs on the usb drive.',
+    })
+  );
+});
+
+test('exportLogsToUsb works for error format when all conditions are met', async () => {
+  const mockUsbDrive = createMockUsbDrive();
+  mockUsbDrive.usbDrive.status.reset();
+  mockUsbDrive.usbDrive.status.expectRepeatedCallsWith().resolves({
+    status: 'mounted',
+    mountPoint: '/media/usb-drive',
+  });
+
+  const mockStats = new Stats();
+  mockStats.isDirectory = jest.fn().mockReturnValue(true);
+  mockOf(fs.stat).mockResolvedValueOnce(mockStats);
+  const readdirMock = fs.readdir as unknown as jest.Mock<Promise<string[]>>;
+  readdirMock.mockResolvedValue(['vx-logs.log']);
+
+  const logFile = tmpNameSync();
+  await fs.writeFile(logFile, ``);
+  createReadStreamMock.mockReturnValueOnce(
+    realCreateReadStream(logFile, 'utf8')
+  );
+
+  execFileMock.mockResolvedValue({ stdout: '', stderr: '' });
+
+  expect(
+    (
+      await exportLogsToUsb({
+        usbDrive: mockUsbDrive.usbDrive,
+        logger,
+        machineId: 'TEST-MACHINE-ID',
+        codeVersion: 'TEST-CODE-VERSION',
+        format: 'err',
+      })
+    ).isOk()
+  ).toBeTruthy();
+  expect(mockOf(fs.stat)).toHaveBeenCalledWith('/var/log/votingworks');
+
+  expect(execFileMock).toHaveBeenCalledWith('mkdir', [
+    '-p',
+    '/media/usb-drive/logs/machine_TEST-MACHINE-ID',
+  ]);
+
+  expect(execFileMock).toHaveBeenCalledWith('cp', [
+    '-r',
+    expect.stringContaining('/tmp/'),
+    expect.stringMatching('^/media/usb-drive/logs/machine_TEST-MACHINE-ID/'),
+  ]);
+
+  expect(execFileMock).toHaveBeenCalledWith('sync', ['-f', '/media/usb-drive']);
+  expect(createWriteStreamMock).toHaveBeenCalledWith(
+    expect.stringContaining('vx-logs.errors.log')
+  );
 
   expect(logger.log).toHaveBeenCalledWith(
     LogEventId.FileSaved,

--- a/libs/backend/src/system_call/export_logs_to_usb.test.ts
+++ b/libs/backend/src/system_call/export_logs_to_usb.test.ts
@@ -175,7 +175,7 @@ test('exportLogsToUsb works for vxf format when all conditions are met', async (
     'unknown',
     expect.objectContaining({
       disposition: 'success',
-      message: 'Sucessfully saved logs on the usb drive.',
+      message: 'Successfully saved logs on the usb drive.',
     })
   );
 });
@@ -319,7 +319,7 @@ test('exportLogsToUsb works for cdf format when all conditions are met', async (
     'unknown',
     expect.objectContaining({
       disposition: 'success',
-      message: 'Sucessfully saved logs on the usb drive.',
+      message: 'Successfully saved logs on the usb drive.',
     })
   );
 });
@@ -380,7 +380,7 @@ test('exportLogsToUsb works for error format when all conditions are met', async
     'unknown',
     expect.objectContaining({
       disposition: 'success',
-      message: 'Sucessfully saved logs on the usb drive.',
+      message: 'Successfully saved logs on the usb drive.',
     })
   );
 });

--- a/libs/backend/src/system_call/export_logs_to_usb.ts
+++ b/libs/backend/src/system_call/export_logs_to_usb.ts
@@ -1,28 +1,114 @@
-import { Result, err, ok } from '@votingworks/basics';
+import { Result, err, ok, throwIllegalValue } from '@votingworks/basics';
 import { UsbDrive } from '@votingworks/usb-drive';
 import * as fs from 'fs/promises';
 import { join } from 'path';
 
-import { LogEventId, Logger } from '@votingworks/logging';
+import {
+  LogEventId,
+  LogExportFormat,
+  Logger,
+  buildCdfLog,
+  filterErrorLogs,
+} from '@votingworks/logging';
+import { createReadStream, createWriteStream } from 'fs';
+import { pipeline } from 'stream/promises';
+import { createGunzip, createGzip } from 'zlib';
+import { dirSync } from 'tmp';
 import { execFile } from '../exec';
 
 const LOG_DIR = '/var/log/votingworks';
+const COMPRESSED_VX_LOGS_NAME_REGEX = 'vx-logs.log-[0-9]*.gz';
 
 /** type of return value from exporting logs */
 export type LogsResultType = Result<
   void,
-  'no-logs-directory' | 'no-usb-drive' | 'copy-failed'
+  | 'no-logs-directory'
+  | 'no-usb-drive'
+  | 'copy-failed'
+  | 'cdf-conversion-failed'
+  | 'error-filtering-failed'
 >;
+
+async function convertLogsToCdf(
+  logDir: string,
+  outputDir: string,
+  logger: Logger,
+  machineId: string,
+  codeVersion: string
+): Promise<void> {
+  const files = await fs.readdir(logDir);
+
+  // Create CDF for vx-logs.log
+  if (files.includes('vx-logs.log')) {
+    await pipeline(
+      createReadStream(join(logDir, 'vx-logs.log'), 'utf8'),
+      (inputStream: AsyncIterable<string>) =>
+        buildCdfLog(logger, inputStream, machineId, codeVersion),
+      createWriteStream(join(outputDir, 'vx-logs.cdf.log'))
+    );
+  }
+
+  // Create CDF for all compressed vx-logs files
+  for (const file of files) {
+    if (file.match(COMPRESSED_VX_LOGS_NAME_REGEX)) {
+      const cdfFileName = file.replace('vx-logs', 'vx-logs.cdf');
+      await pipeline(
+        createReadStream(join(logDir, file)),
+        createGunzip(),
+        (inputStream: AsyncIterable<string>) =>
+          buildCdfLog(logger, inputStream, machineId, 'DEV'),
+        createGzip(),
+        createWriteStream(join(outputDir, cdfFileName))
+      );
+    }
+  }
+}
+
+async function filterLogsToErrors(
+  logDir: string,
+  outputDir: string
+): Promise<void> {
+  const files = await fs.readdir(logDir);
+
+  // Create errors only version of current vx-logs file
+  if (files.includes('vx-logs.log')) {
+    await pipeline(
+      createReadStream(join(logDir, 'vx-logs.log'), 'utf8'),
+      filterErrorLogs,
+      createWriteStream(join(outputDir, 'vx-logs.errors.log'))
+    );
+  }
+
+  // Create errors only versions of all compressed vx-logs files
+  for (const file of files) {
+    if (file.match(COMPRESSED_VX_LOGS_NAME_REGEX)) {
+      const errorFileName = file.replace('vx-logs', 'vx-logs.errors');
+      await pipeline(
+        createReadStream(join(logDir, file)),
+        createGunzip(),
+        filterErrorLogs,
+        createGzip(),
+        createWriteStream(join(outputDir, errorFileName))
+      );
+    }
+  }
+}
 
 /**
  * Copies the logs directory to a USB drive, does not log the action.
  */
 async function exportLogsToUsbHelper({
   usbDrive,
+  format,
   machineId,
+  codeVersion,
+  logger,
 }: {
   usbDrive: UsbDrive;
+  format: LogExportFormat;
   machineId: string;
+  codeVersion: string;
+  logger: Logger;
 }): Promise<LogsResultType> {
   let logDirPathExistsAndIsDirectory = false;
   try {
@@ -45,13 +131,59 @@ async function exportLogsToUsbHelper({
 
   const dateString = new Date().toISOString().replaceAll(':', '-');
   const destinationDirectory = join(machineNamePath, dateString);
+  const tempDirectory = dirSync().name;
+
+  switch (format) {
+    case 'vxf':
+      break;
+    case 'cdf':
+      try {
+        await convertLogsToCdf(
+          LOG_DIR,
+          tempDirectory,
+          logger,
+          machineId,
+          codeVersion
+        );
+      } catch {
+        await fs.rm(tempDirectory, { recursive: true });
+        return err('cdf-conversion-failed');
+      }
+      break;
+    case 'err':
+      try {
+        await filterLogsToErrors(LOG_DIR, tempDirectory);
+      } catch {
+        await fs.rm(tempDirectory, { recursive: true });
+        return err('error-filtering-failed');
+      }
+      break;
+    /* istanbul ignore next - compile time check */
+    default:
+      throwIllegalValue(format);
+  }
 
   try {
     await execFile('mkdir', ['-p', machineNamePath]);
-    await execFile('cp', ['-r', LOG_DIR, destinationDirectory]);
+    switch (format) {
+      case 'vxf':
+        await execFile('cp', ['-r', LOG_DIR, destinationDirectory]);
+        break;
+      case 'cdf':
+      case 'err':
+        await execFile('cp', ['-r', tempDirectory, destinationDirectory]);
+        break;
+      /* istanbul ignore next - compile time check */
+      default:
+        throwIllegalValue(format);
+    }
     await execFile('sync', ['-f', status.mountPoint]);
-  } catch {
+  } catch (error) {
     return err('copy-failed');
+  } finally {
+    if (format === 'cdf' || format === 'err') {
+      await fs.rm(tempDirectory, { recursive: true });
+    }
   }
 
   return ok();
@@ -63,13 +195,23 @@ async function exportLogsToUsbHelper({
 export async function exportLogsToUsb({
   usbDrive,
   machineId,
+  codeVersion,
+  format,
   logger,
 }: {
   usbDrive: UsbDrive;
   machineId: string;
+  codeVersion: string;
+  format: LogExportFormat;
   logger: Logger;
 }): Promise<LogsResultType> {
-  const result = await exportLogsToUsbHelper({ usbDrive, machineId });
+  const result = await exportLogsToUsbHelper({
+    usbDrive,
+    format,
+    machineId,
+    codeVersion,
+    logger,
+  });
 
   await logger.logAsCurrentRole(LogEventId.FileSaved, {
     disposition: result.isOk() ? 'success' : 'failure',

--- a/libs/backend/src/system_call/export_logs_to_usb.ts
+++ b/libs/backend/src/system_call/export_logs_to_usb.ts
@@ -216,7 +216,7 @@ export async function exportLogsToUsb({
   await logger.logAsCurrentRole(LogEventId.FileSaved, {
     disposition: result.isOk() ? 'success' : 'failure',
     message: result.isOk()
-      ? 'Sucessfully saved logs on the usb drive.'
+      ? 'Successfully saved logs on the usb drive.'
       : `Failed to save logs to usb drive: ${result.err()}`,
     fileType: 'logs',
   });

--- a/libs/backend/src/system_call/export_logs_to_usb.ts
+++ b/libs/backend/src/system_call/export_logs_to_usb.ts
@@ -56,7 +56,7 @@ async function convertLogsToCdf(
         createReadStream(join(logDir, file)),
         createGunzip(),
         (inputStream: AsyncIterable<string>) =>
-          buildCdfLog(logger, inputStream, machineId, 'DEV'),
+          buildCdfLog(logger, inputStream, machineId, codeVersion),
         createGzip(),
         createWriteStream(join(outputDir, cdfFileName))
       );

--- a/libs/logging/package.json
+++ b/libs/logging/package.json
@@ -46,6 +46,7 @@
     "@votingworks/types": "workspace:*",
     "@votingworks/utils": "workspace:*",
     "debug": "4.3.4",
+    "stream": "^0.0.3",
     "yargs": "17.7.1",
     "zod": "3.23.5"
   },

--- a/libs/logging/src/test_utils.test.ts
+++ b/libs/logging/src/test_utils.test.ts
@@ -1,7 +1,11 @@
 import { typedAs } from '@votingworks/basics';
 import { LogEventType, LogLine, LogSource } from '.';
 import { LogEventId } from './log_event_ids';
-import { mockBaseLogger, mockLogger } from './test_utils';
+import {
+  mockBaseLogger,
+  mockLogger,
+  mockLoggerWithRoleAndSource,
+} from './test_utils';
 
 test('mockBaseLogger returns a logger with a spy on logger.log', async () => {
   const logger = mockBaseLogger();
@@ -70,4 +74,33 @@ test('mockLogger with defaults', async () => {
     'unknown'
   );
   expect(logger.getSource()).toEqual(LogSource.System);
+});
+
+test('mockLoggerWithRoleAndSource', async () => {
+  const logger = mockLoggerWithRoleAndSource(
+    LogSource.VxAdminService,
+    'election_manager'
+  );
+  await logger.logAsCurrentRole(LogEventId.MachineBootInit);
+  expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
+    LogEventId.MachineBootInit
+  );
+  expect(logger.log).toHaveBeenCalledWith(
+    LogEventId.MachineBootInit,
+    'election_manager'
+  );
+  expect(logger.getSource()).toEqual(LogSource.VxAdminService);
+});
+
+test('mockLoggerWithRoleAndSource defaults to sysadmin', async () => {
+  const logger = mockLoggerWithRoleAndSource(LogSource.VxCentralScanFrontend);
+  await logger.logAsCurrentRole(LogEventId.MachineBootInit);
+  expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
+    LogEventId.MachineBootInit
+  );
+  expect(logger.log).toHaveBeenCalledWith(
+    LogEventId.MachineBootInit,
+    'system_administrator'
+  );
+  expect(logger.getSource()).toEqual(LogSource.VxCentralScanFrontend);
 });

--- a/libs/logging/src/test_utils.ts
+++ b/libs/logging/src/test_utils.ts
@@ -48,3 +48,10 @@ export function mockLogger(
   );
   return logger;
 }
+
+export function mockLoggerWithRoleAndSource(
+  source: LogSource,
+  role: LoggingUserRole = 'system_administrator'
+): Logger {
+  return mockLogger(source, () => Promise.resolve(role));
+}

--- a/libs/ui/src/export_logs_modal.test.tsx
+++ b/libs/ui/src/export_logs_modal.test.tsx
@@ -41,7 +41,7 @@ test('render no usb found screen when there is not a mounted usb drive', async (
   }
 });
 
-test('successful save raw logs flow', async () => {
+test('successful save default logs flow', async () => {
   mockApiClient.exportLogsToUsb.mockResolvedValueOnce(ok());
 
   render(<ExportLogsButton usbDriveStatus={mockUsbDriveStatus('mounted')} />);
@@ -55,4 +55,50 @@ test('successful save raw logs flow', async () => {
   expect(screen.queryByRole('alertdialog')).toBeFalsy();
 
   expect(mockApiClient.exportLogsToUsb).toHaveBeenCalledTimes(1);
+  expect(mockApiClient.exportLogsToUsb).toHaveBeenCalledWith({ format: 'vxf' });
+});
+
+test('successful save cdf logs flow', async () => {
+  mockApiClient.exportLogsToUsb.mockResolvedValueOnce(ok());
+
+  render(<ExportLogsButton usbDriveStatus={mockUsbDriveStatus('mounted')} />);
+  userEvent.click(screen.getByText('Save Log File'));
+  await screen.findByText('Save Logs');
+
+  userEvent.click(screen.getByText('CDF'));
+  await screen.findByText(
+    'It may take a few minutes to save the logs in this format.'
+  );
+
+  userEvent.click(screen.getByText('Save'));
+  await screen.findByText(/Saving Logs/);
+  await screen.findByText(/Logs Saved/);
+  userEvent.click(screen.getByText('Close'));
+  expect(screen.queryByRole('alertdialog')).toBeFalsy();
+
+  expect(mockApiClient.exportLogsToUsb).toHaveBeenCalledTimes(1);
+  expect(mockApiClient.exportLogsToUsb).toHaveBeenCalledWith({ format: 'cdf' });
+});
+
+test('successful save error logs flow', async () => {
+  mockApiClient.exportLogsToUsb.mockResolvedValueOnce(ok());
+
+  render(<ExportLogsButton usbDriveStatus={mockUsbDriveStatus('mounted')} />);
+  userEvent.click(screen.getByText('Save Log File'));
+  await screen.findByText('Save Logs');
+
+  userEvent.click(screen.getByText('Errors'));
+  await screen.findByText(
+    'It may take a few minutes to save the logs in this format.'
+  );
+
+  userEvent.click(screen.getByText('Save'));
+  await screen.findByText(/Saving Logs/);
+  await screen.findByText(/Logs Saved/);
+
+  userEvent.click(screen.getByText('Close'));
+  expect(screen.queryByRole('alertdialog')).toBeFalsy();
+
+  expect(mockApiClient.exportLogsToUsb).toHaveBeenCalledTimes(1);
+  expect(mockApiClient.exportLogsToUsb).toHaveBeenCalledWith({ format: 'err' });
 });

--- a/libs/ui/src/system_call_api.test.tsx
+++ b/libs/ui/src/system_call_api.test.tsx
@@ -75,7 +75,7 @@ describe('React Query API calls the right client methods', () => {
       }
     );
     mockApiClient.exportLogsToUsb.mockResolvedValueOnce(ok());
-    (await mutation.current.mutateAsync()).unsafeUnwrap();
+    (await mutation.current.mutateAsync({ format: 'vxf' })).unsafeUnwrap();
     expect(mockApiClient.exportLogsToUsb).toHaveBeenCalledTimes(1);
   });
 

--- a/libs/usb-drive/src/usb_drive.test.ts
+++ b/libs/usb-drive/src/usb_drive.test.ts
@@ -5,9 +5,8 @@ import { join } from 'path';
 import {
   LogEventId,
   LogSource,
-  Logger,
-  LoggingUserRole,
   mockLogger,
+  mockLoggerWithRoleAndSource,
 } from '@votingworks/logging';
 import {
   BooleanEnvironmentVariableName,
@@ -107,15 +106,12 @@ async function confirmLockReleased(usbDrive: UsbDrive) {
   });
 }
 
-function mockLoggerWithRole(
-  role: LoggingUserRole = 'system_administrator'
-): Logger {
-  return mockLogger(LogSource.VxAdminService, () => Promise.resolve(role));
-}
-
 describe('status', () => {
   test('no drive', async () => {
-    const logger = mockLoggerWithRole();
+    const logger = mockLoggerWithRoleAndSource(
+      LogSource.VxAdminFrontend,
+      'election_manager'
+    );
     const usbDrive = detectUsbDrive(logger);
 
     readdirMock.mockResolvedValueOnce([]);
@@ -422,7 +418,10 @@ describe('eject', () => {
   });
 
   test('mounted', async () => {
-    const logger = mockLoggerWithRole('election_manager');
+    const logger = mockLoggerWithRoleAndSource(
+      LogSource.VxAdminFrontend,
+      'election_manager'
+    );
     const usbDrive = detectUsbDrive(logger);
 
     mockBlockDeviceOnce({ mountpoint: '/media/usb-drive-sdb1' });
@@ -459,7 +458,10 @@ describe('eject', () => {
   });
 
   test('fails to eject', async () => {
-    const logger = mockLoggerWithRole('election_manager');
+    const logger = mockLoggerWithRoleAndSource(
+      LogSource.VxAdminFrontend,
+      'election_manager'
+    );
     const usbDrive = detectUsbDrive(logger);
 
     mockBlockDeviceOnce({ mountpoint: '/media/usb-drive-sdb1' });
@@ -490,7 +492,10 @@ describe('format', () => {
   });
 
   test('on mounted, previously formatted drive', async () => {
-    const logger = mockLoggerWithRole();
+    const logger = mockLoggerWithRoleAndSource(
+      LogSource.VxAdminFrontend,
+      'system_administrator'
+    );
     const usbDrive = detectUsbDrive(logger);
     mockBlockDeviceOnce({ mountpoint: '/media/usb-drive-sdb1' });
     execMock.mockResolvedValueOnce({ stdout: '' }); // unmount
@@ -551,7 +556,10 @@ describe('format', () => {
   });
 
   test('on format failure', async () => {
-    const logger = mockLoggerWithRole();
+    const logger = mockLoggerWithRoleAndSource(
+      LogSource.VxAdminFrontend,
+      'system_administrator'
+    );
     const usbDrive = detectUsbDrive(logger);
     mockBlockDeviceOnce({ fstype: 'unknown', mountpoint: null, label: null });
     execMock.mockRejectedValueOnce(new Error('Command: failed')); // format

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4554,6 +4554,9 @@ importers:
       debug:
         specifier: 4.3.4
         version: 4.3.4(supports-color@5.5.0)
+      stream:
+        specifier: ^0.0.3
+        version: 0.0.3
       yargs:
         specifier: 17.7.1
         version: 17.7.1
@@ -12774,6 +12777,11 @@ packages:
   /component-emitter@1.3.0:
     resolution: {integrity: sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==}
 
+  /component-emitter@2.0.0:
+    resolution: {integrity: sha512-4m5s3Me2xxlVKG9PkZpQqHQR7bgpnN7joDMJ4yvVkVXngjoITG76IaZmzmywSeRTeTpc6N6r3H3+KyUurV8OYw==}
+    engines: {node: '>=18'}
+    dev: false
+
   /compress-commons@4.1.1:
     resolution: {integrity: sha512-QLdDLCKNV2dtoTorqgxngQCMA+gWXkM/Nwu7FpeBhk/RdkzimqC3jueb/FDmaZeXh+uby1jkBqE3xArsLBE5wQ==}
     engines: {node: '>= 10'}
@@ -20518,6 +20526,12 @@ packages:
 
   /stream-shift@1.0.1:
     resolution: {integrity: sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==}
+
+  /stream@0.0.3:
+    resolution: {integrity: sha512-aMsbn7VKrl4A2T7QAQQbzgN7NVc70vgF5INQrBXqn4dCXN1zy3L9HGgLO5s7PExmdrzTJ8uR/27aviW8or8/+A==}
+    dependencies:
+      component-emitter: 2.0.0
+    dev: false
 
   /streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/5006
https://github.com/votingworks/vxsuite/issues/5333
Adds the ability to export logs as an error-only report or as CDF. The CDF conversion code was pre-existing. This just adds the UI logic and the logic to uncompress/recompress old files in addition to the error-only filtering. 

On moderately large log files this can take a minute or so for the CDF conversion, the error filtering is instantaneous which I find surprising since both need to uncompress / parse json / recompress, so I may play around a bit and see if there is something dumb we are doing. Otherwise will test on larger data from Ben and on a real image after merging. 
## Demo Video or Screenshot

https://github.com/user-attachments/assets/5384cb26-290d-4da8-aceb-43daf1089569



## Testing Plan
Copied logs from a prod machine to the appropriate location in my VM, then exported logs in all formats and inspected the results. 

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
