### PR TITLE
VxAdmin: Disable PDF preview/export for large reports

### DIFF
--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -110,6 +110,7 @@ import {
   exportWriteInAdjudicationReportPdf,
   generateWriteInAdjudicationReportPreview,
   printWriteInAdjudicationReport,
+  WriteInAdjudicationReportPreview,
 } from './reports/write_in_adjudication_report';
 import {
   BallotCountReportPreview,
@@ -951,7 +952,7 @@ function buildApi({
       return getElectionWriteInSummary();
     },
 
-    async getWriteInAdjudicationReportPreview(): Promise<Buffer> {
+    async getWriteInAdjudicationReportPreview(): Promise<WriteInAdjudicationReportPreview> {
       return generateWriteInAdjudicationReportPreview({
         store,
         electionWriteInSummary: getElectionWriteInSummary(),

--- a/apps/admin/backend/src/reports/ballot_count_report.ts
+++ b/apps/admin/backend/src/reports/ballot_count_report.ts
@@ -88,17 +88,19 @@ export async function generateBallotCountReportPreview({
 
   ...reportProps
 }: BallotCountReportPreviewProps): Promise<BallotCountReportPreview> {
-  const report = buildBallotCountReport(reportProps);
   await logger.logAsCurrentRole(LogEventId.ElectionReportPreviewed, {
     message: `User previewed a ballot count report.`,
     disposition: 'success',
   });
+  const warning = getBallotCountReportWarning(reportProps);
+  if (warning?.type === 'no-reports-match-filter') {
+    return { warning };
+  }
+  const report = buildBallotCountReport(reportProps);
   const pdf = await renderToPdf({ document: report });
   return {
     pdf: pdf.ok(),
-    warning: pdf.isErr()
-      ? { type: pdf.err() }
-      : getBallotCountReportWarning(reportProps),
+    warning: pdf.isErr() ? { type: pdf.err() } : warning,
   };
 }
 

--- a/apps/admin/backend/src/reports/readiness.ts
+++ b/apps/admin/backend/src/reports/readiness.ts
@@ -60,7 +60,9 @@ export async function saveReadinessReport({
   const generatedAtTime = new Date(getCurrentTime());
   const report = await getReadinessReport({ workspace, printer });
 
-  const data = await renderToPdf({ document: report });
+  // Readiness reports shouldn't be large enough to hit the PDF size limit, so
+  // we don't expect rendering the PDF to error
+  const data = (await renderToPdf({ document: report })).unsafeUnwrap();
   const exporter = new Exporter({
     usbDrive,
     allowedExportPatterns: ADMIN_ALLOWED_EXPORT_PATTERNS,

--- a/apps/admin/backend/src/reports/test_print.ts
+++ b/apps/admin/backend/src/reports/test_print.ts
@@ -85,8 +85,9 @@ export async function printTestPage({
     cardCountsList: allMockCardCounts,
   });
 
-  const data = await renderToPdf({ document: report });
   try {
+    // The test print shouldn't hit the PDF size limit
+    const data = (await renderToPdf({ document: report })).unsafeUnwrap();
     await printer.print({ data });
     await logger.logAsCurrentRole(LogEventId.DiagnosticInit, {
       message: `User started a print diagnostic by printing a test page.`,

--- a/apps/admin/backend/src/reports/warnings.test.ts
+++ b/apps/admin/backend/src/reports/warnings.test.ts
@@ -33,9 +33,7 @@ describe('getBallotCountReportWarning', () => {
       getBallotCountReportWarning({
         allCardCounts: [getEmptyCardCounts()],
       })
-    ).toEqual<BallotCountReportWarning>({
-      type: 'none',
-    });
+    ).toBeUndefined();
   });
 });
 
@@ -63,9 +61,7 @@ describe('getTallyReportWarning', () => {
         ],
         election,
       })
-    ).toEqual<TallyReportWarning>({
-      type: 'none',
-    });
+    ).toBeUndefined();
   });
 
   test('does give warning when contest has votes all for one option', () => {
@@ -271,8 +267,6 @@ describe('getTallyReportWarning', () => {
         allTallyReports: [tallyReportWithManualResults],
         election,
       })
-    ).toEqual<TallyReportWarning>({
-      type: 'none',
-    });
+    ).toBeUndefined();
   });
 });

--- a/apps/admin/backend/src/reports/warnings.ts
+++ b/apps/admin/backend/src/reports/warnings.ts
@@ -1,3 +1,4 @@
+import { PdfError } from '@votingworks/printing';
 import { Admin, ContestId, Election, Tabulation } from '@votingworks/types';
 import {
   combineElectionResults,
@@ -9,12 +10,8 @@ import {
  * A warning about a generated ballot count report to be shown to the user.
  */
 export type BallotCountReportWarning =
-  | {
-      type: 'none';
-    }
-  | {
-      type: 'no-reports-match-filter';
-    };
+  | { type: 'no-reports-match-filter' }
+  | { type: PdfError };
 
 /**
  * Defines the warnings that should be presented to the user for a given
@@ -25,14 +22,12 @@ export function getBallotCountReportWarning({
   allCardCounts,
 }: {
   allCardCounts: Tabulation.GroupList<Tabulation.CardCounts>;
-}): BallotCountReportWarning {
+}): BallotCountReportWarning | undefined {
   if (allCardCounts.length === 0) {
     return {
       type: 'no-reports-match-filter',
     };
   }
-
-  return { type: 'none' };
 }
 
 type TallyReportPrivacyWarning =
@@ -52,13 +47,9 @@ type TallyReportPrivacyWarning =
  * A warning about a generated tally report to be shown to the user.
  */
 export type TallyReportWarning =
-  | {
-      type: 'none';
-    }
-  | {
-      type: 'no-reports-match-filter';
-    }
-  | TallyReportPrivacyWarning;
+  | { type: 'no-reports-match-filter' }
+  | TallyReportPrivacyWarning
+  | { type: PdfError };
 
 function isLowBallotCountPrivacyRisk(ballotCount: number): boolean {
   return (
@@ -135,7 +126,7 @@ export function getTallyReportWarning({
 }: {
   allTallyReports: Tabulation.GroupList<Admin.TallyReportResults>;
   election: Election;
-}): TallyReportWarning {
+}): TallyReportWarning | undefined {
   if (allTallyReports.length === 0) {
     return {
       type: 'no-reports-match-filter',
@@ -182,6 +173,4 @@ export function getTallyReportWarning({
       };
     }
   }
-
-  return { type: 'none' };
 }

--- a/apps/admin/frontend/jest.config.js
+++ b/apps/admin/frontend/jest.config.js
@@ -15,8 +15,8 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: -103,
-      lines: -95,
+      branches: -101,
+      lines: -93,
     },
   },
   moduleFileExtensions: [

--- a/apps/admin/frontend/src/components/reporting/ballot_count_report_viewer.test.tsx
+++ b/apps/admin/frontend/src/components/reporting/ballot_count_report_viewer.test.tsx
@@ -135,7 +135,7 @@ test('shows returned warnings, and disables actions if no report', async () => {
     warning: {
       type: 'no-reports-match-filter',
     },
-    pdfContent: 'Unofficial Full Election Ballot Count Report',
+    pdfContent: undefined,
   });
 
   renderInAppContext(
@@ -160,6 +160,41 @@ test('shows returned warnings, and disables actions if no report', async () => {
   ]) {
     expect(screen.getButton(buttonLabel)).toBeDisabled();
   }
+});
+
+test('shows warning and prevents actions when PDF is too large', async () => {
+  const { electionDefinition } = electionTwoPartyPrimaryFixtures;
+  apiMock.expectGetBallotCountReportPreview({
+    reportSpec: {
+      filter: {},
+      groupBy: { groupByBatch: true },
+      includeSheetCounts: false,
+    },
+    warning: {
+      type: 'content-too-large',
+    },
+    pdfContent: undefined,
+  });
+
+  renderInAppContext(
+    <BallotCountReportViewer
+      disabled={false}
+      filter={{}}
+      groupBy={{ groupByBatch: true }}
+      includeSheetCounts={false}
+      autoGenerateReport
+    />,
+    { apiMock, electionDefinition }
+  );
+
+  await screen.findByText(
+    'This report is too large to be exported as a PDF. You may export the report as a CSV instead.'
+  );
+
+  for (const buttonLabel of ['Print Report', 'Export Report PDF']) {
+    expect(screen.getButton(buttonLabel)).toBeDisabled();
+  }
+  expect(screen.getButton('Export Report CSV')).toBeEnabled();
 });
 
 test('printing report', async () => {

--- a/apps/admin/frontend/src/components/reporting/ballot_count_report_viewer.tsx
+++ b/apps/admin/frontend/src/components/reporting/ballot_count_report_viewer.tsx
@@ -42,19 +42,12 @@ export function BallotCountReportViewer({
     { enabled: !disabled && autoGenerateReport }
   );
 
-  /**
-   * No fetch has been attempted yet. The viewer must not be in autogenerate
-   * mode, and the user hasn't pressed "Generate Report" yet.
-   */
-  const previewQueryNotAttempted =
-    !previewQuery.isFetching && !previewQuery.isSuccess;
-
-  const reportIsEmpty =
-    previewQuery.isSuccess &&
-    previewQuery.data.warning.type === 'no-reports-match-filter';
-
   const disableActionButtons =
-    disabled || !previewQuery.isSuccess || reportIsEmpty;
+    disabled ||
+    !previewQuery.isSuccess ||
+    previewQuery.data.warning?.type === 'no-reports-match-filter';
+  const disablePdfExport =
+    previewQuery.data?.warning?.type === 'content-too-large';
 
   return (
     <React.Fragment>
@@ -74,7 +67,7 @@ export function BallotCountReportViewer({
         )}
         <ExportActions>
           <PrintButton
-            disabled={disableActionButtons}
+            disabled={disableActionButtons || disablePdfExport}
             print={() =>
               printReportMutation.mutateAsync({
                 filter,
@@ -103,7 +96,7 @@ export function BallotCountReportViewer({
             }
             fileType="ballot count report"
             fileTypeTitle="Ballot Count Report"
-            disabled={disableActionButtons}
+            disabled={disableActionButtons || disablePdfExport}
           />
           <ExportFileButton
             buttonText="Export Report CSV"
@@ -125,17 +118,17 @@ export function BallotCountReportViewer({
             disabled={disableActionButtons}
           />
         </ExportActions>
-        {previewQuery.isSuccess && (
-          <ReportWarning
-            text={getBallotCountReportWarningText({
+        {previewQuery.data?.warning && (
+          <ReportWarning>
+            {getBallotCountReportWarningText({
               ballotCountReportWarning: previewQuery.data.warning,
             })}
-          />
+          </ReportWarning>
         )}
       </div>
       <PdfViewer
-        pdfData={previewQuery.isSuccess ? previewQuery.data.pdf : undefined}
-        disabled={disabled || previewQueryNotAttempted}
+        pdfData={previewQuery.data?.pdf}
+        loading={previewQuery.isFetching}
       />
     </React.Fragment>
   );

--- a/apps/admin/frontend/src/components/reporting/ballot_count_report_warnings.test.ts
+++ b/apps/admin/frontend/src/components/reporting/ballot_count_report_warnings.test.ts
@@ -7,15 +7,12 @@ test('getBallotCountReportWarningText', () => {
     expected: string;
   }> = [
     {
-      ballotCountReportWarning: {
-        type: 'none',
-      },
-      expected: '',
+      ballotCountReportWarning: { type: 'content-too-large' },
+      expected:
+        'This report is too large to be exported as a PDF. You may export the report as a CSV instead.',
     },
     {
-      ballotCountReportWarning: {
-        type: 'no-reports-match-filter',
-      },
+      ballotCountReportWarning: { type: 'no-reports-match-filter' },
       expected: 'The current report parameters do not match any ballots.',
     },
   ];

--- a/apps/admin/frontend/src/components/reporting/ballot_count_report_warnings.ts
+++ b/apps/admin/frontend/src/components/reporting/ballot_count_report_warnings.ts
@@ -13,6 +13,7 @@ export function getBallotCountReportWarningText({
       return `The current report parameters do not match any ballots.`;
     case 'content-too-large':
       return `This report is too large to be exported as a PDF. You may export the report as a CSV instead.`;
+    /* istanbul ignore next */
     default:
       throwIllegalValue(ballotCountReportWarning);
   }

--- a/apps/admin/frontend/src/components/reporting/ballot_count_report_warnings.ts
+++ b/apps/admin/frontend/src/components/reporting/ballot_count_report_warnings.ts
@@ -1,4 +1,5 @@
 import type { BallotCountReportWarning } from '@votingworks/admin-backend';
+import { throwIllegalValue } from '@votingworks/basics';
 
 interface BallotCountReportWarningProps {
   ballotCountReportWarning: BallotCountReportWarning;
@@ -7,9 +8,12 @@ interface BallotCountReportWarningProps {
 export function getBallotCountReportWarningText({
   ballotCountReportWarning,
 }: BallotCountReportWarningProps): string {
-  if (ballotCountReportWarning.type === 'no-reports-match-filter') {
-    return `The current report parameters do not match any ballots.`;
+  switch (ballotCountReportWarning.type) {
+    case 'no-reports-match-filter':
+      return `The current report parameters do not match any ballots.`;
+    case 'content-too-large':
+      return `This report is too large to be exported as a PDF. You may export the report as a CSV instead.`;
+    default:
+      throwIllegalValue(ballotCountReportWarning);
   }
-
-  return '';
 }

--- a/apps/admin/frontend/src/components/reporting/pdf_viewer.tsx
+++ b/apps/admin/frontend/src/components/reporting/pdf_viewer.tsx
@@ -58,10 +58,10 @@ const DEFAULT_ZOOM = 1.8;
 
 export function PdfViewer({
   pdfData,
-  disabled,
+  loading,
 }: {
   pdfData?: Buffer;
-  disabled?: boolean;
+  loading?: boolean;
 }): JSX.Element {
   const [numPages, setNumPages] = useState<number>();
   const [currentPage, setCurrentPage] = useState(1);
@@ -82,7 +82,7 @@ export function PdfViewer({
     const scrollProgress = (scrollTop + pageHeight / 6) / scrollHeight;
     setCurrentPage(Math.floor(scrollProgress * numPages) + 1);
   }
-  const loading = (
+  const loadingSpinner = (
     <Row
       style={{
         justifyContent: 'center',
@@ -104,7 +104,7 @@ export function PdfViewer({
       </PdfControls>
       {file ? (
         <PdfDocumentScroller onScroll={onScroll} data-testid="pdf-scroller">
-          {!numPages && loading}
+          {!numPages && loadingSpinner}
           <Document
             file={file}
             onSourceSuccess={() => setNumPages(undefined)}
@@ -135,8 +135,8 @@ export function PdfViewer({
               ))}
           </Document>
         </PdfDocumentScroller>
-      ) : !disabled ? (
-        loading
+      ) : loading ? (
+        loadingSpinner
       ) : null}
     </PdfContainer>
   );

--- a/apps/admin/frontend/src/components/reporting/pdf_viewer.tsx
+++ b/apps/admin/frontend/src/components/reporting/pdf_viewer.tsx
@@ -1,12 +1,16 @@
 import { Document, Page, pdfjs } from 'react-pdf';
 import styled from 'styled-components';
 import React, { useMemo, useState } from 'react';
-import { Icons } from '@votingworks/ui';
+import { H3, Icons, P } from '@votingworks/ui';
 import { Buffer } from 'buffer';
 import { range } from '@votingworks/basics';
 
 // Worker file must be copied from pdfjs-dist into public directory
 pdfjs.GlobalWorkerOptions.workerSrc = '/pdf.worker.min.js';
+
+// Large PDFs can crash the page. We've seen this occur at ~100 pages, so set a
+// conservative limit to make sure it never happens in production.
+const MAX_NUM_PAGES = 50;
 
 const PdfContainer = styled.div`
   flex: 1;
@@ -96,6 +100,22 @@ export function PdfViewer({
       <Icons.Loading />
     </Row>
   );
+
+  if (numPages && numPages > MAX_NUM_PAGES) {
+    return (
+      <PdfContainer>
+        <PdfControls />
+        <div style={{ margin: 'auto', padding: '1rem' }}>
+          <H3>Preview Disabled</H3>
+          <P>
+            This report is too large to preview.
+            <br />
+            Print or export the report instead.
+          </P>
+        </div>
+      </PdfContainer>
+    );
+  }
 
   return (
     <PdfContainer>

--- a/apps/admin/frontend/src/components/reporting/pdf_viewer.tsx
+++ b/apps/admin/frontend/src/components/reporting/pdf_viewer.tsx
@@ -60,13 +60,12 @@ export const Row = styled.div`
 
 const DEFAULT_ZOOM = 1.8;
 
-export function PdfViewer({
-  pdfData,
-  loading,
-}: {
+interface PdfViewerProps {
   pdfData?: Buffer;
   loading?: boolean;
-}): JSX.Element {
+}
+
+function PdfViewerHelper({ pdfData, loading }: PdfViewerProps): JSX.Element {
   const [numPages, setNumPages] = useState<number>();
   const [currentPage, setCurrentPage] = useState(1);
   const file = useMemo(
@@ -159,5 +158,15 @@ export function PdfViewer({
         loadingSpinner
       ) : null}
     </PdfContainer>
+  );
+}
+
+export function PdfViewer({ loading, pdfData }: PdfViewerProps): JSX.Element {
+  return (
+    <PdfViewerHelper
+      {...{ loading, pdfData }}
+      // Reset the page count state whenever we change the PDF data
+      key={String(Boolean(pdfData))}
+    />
   );
 }

--- a/apps/admin/frontend/src/components/reporting/shared.tsx
+++ b/apps/admin/frontend/src/components/reporting/shared.tsx
@@ -35,13 +35,14 @@ export const WarningContainer = styled.div`
   margin-top: 1rem;
 `;
 
-export function ReportWarning({ text }: { text: string }): JSX.Element | null {
-  if (!text) {
-    return null;
-  }
+export function ReportWarning({
+  children,
+}: {
+  children: React.ReactNode;
+}): JSX.Element | null {
   return (
     <WarningContainer>
-      <Icons.Warning color="warning" /> {text}
+      <Icons.Warning color="warning" /> {children}
     </WarningContainer>
   );
 }

--- a/apps/admin/frontend/src/components/reporting/tally_report_viewer.test.tsx
+++ b/apps/admin/frontend/src/components/reporting/tally_report_viewer.test.tsx
@@ -121,6 +121,7 @@ test('shows no results warning and prevents actions when no results', async () =
   apiMock.expectGetTallyReportPreview({
     reportSpec: MOCK_REPORT_SPEC,
     warning: { type: 'no-reports-match-filter' },
+    pdfContent: undefined,
   });
 
   renderInAppContext(
@@ -143,6 +144,33 @@ test('shows no results warning and prevents actions when no results', async () =
   ]) {
     expect(screen.getButton(buttonLabel)).toBeDisabled();
   }
+});
+
+test('shows warning and prevents actions when PDF is too large', async () => {
+  const { electionDefinition } = electionTwoPartyPrimaryFixtures;
+  apiMock.expectGetTallyReportPreview({
+    reportSpec: MOCK_REPORT_SPEC,
+    warning: { type: 'content-too-large' },
+    pdfContent: undefined,
+  });
+
+  renderInAppContext(
+    <TallyReportViewer
+      disabled={false}
+      autoGenerateReport
+      {...MOCK_REPORT_SPEC}
+    />,
+    { apiMock, electionDefinition }
+  );
+
+  await screen.findByText(
+    'This report is too large to be exported as a PDF. You may export the report as a CSV instead.'
+  );
+
+  for (const buttonLabel of ['Print Report', 'Export Report PDF']) {
+    expect(screen.getButton(buttonLabel)).toBeDisabled();
+  }
+  expect(screen.getButton('Export Report CSV')).toBeEnabled();
 });
 
 test('printing report', async () => {

--- a/apps/admin/frontend/src/components/reporting/tally_report_viewer.tsx
+++ b/apps/admin/frontend/src/components/reporting/tally_report_viewer.tsx
@@ -61,19 +61,12 @@ export function TallyReportViewer({
     { enabled: !disabled && autoGenerateReport }
   );
 
-  /**
-   * No fetch has been attempted yet. The viewer must not be in autogenerate
-   * mode, and the user hasn't pressed "Generate Report" yet.
-   */
-  const previewQueryNotAttempted =
-    !previewQuery.isFetching && !previewQuery.isSuccess;
-
-  const reportIsEmpty =
-    previewQuery.isSuccess &&
-    previewQuery.data.warning.type === 'no-reports-match-filter';
-
   const disableActionButtons =
-    disabled || !previewQuery.isSuccess || reportIsEmpty;
+    disabled ||
+    !previewQuery.isSuccess ||
+    previewQuery.data.warning?.type === 'no-reports-match-filter';
+  const disablePdfExport =
+    previewQuery.data?.warning?.type === 'content-too-large';
 
   return (
     <React.Fragment>
@@ -93,7 +86,7 @@ export function TallyReportViewer({
         )}
         <ExportActions>
           <PrintButton
-            disabled={disableActionButtons}
+            disabled={disableActionButtons || disablePdfExport}
             print={() =>
               printReportMutation.mutateAsync({
                 filter,
@@ -122,7 +115,7 @@ export function TallyReportViewer({
             }
             fileType="tally report"
             fileTypeTitle="Tally Report"
-            disabled={disableActionButtons}
+            disabled={disableActionButtons || disablePdfExport}
           />
           <ExportFileButton
             buttonText="Export Report CSV"
@@ -158,18 +151,18 @@ export function TallyReportViewer({
             />
           )}
         </ExportActions>
-        {previewQuery.isSuccess && (
-          <ReportWarning
-            text={getTallyReportWarningText({
+        {previewQuery.data?.warning && (
+          <ReportWarning>
+            {getTallyReportWarningText({
               tallyReportWarning: previewQuery.data.warning,
               election,
             })}
-          />
+          </ReportWarning>
         )}
       </div>
       <PdfViewer
-        pdfData={previewQuery.isSuccess ? previewQuery.data.pdf : undefined}
-        disabled={disabled || previewQueryNotAttempted}
+        pdfData={previewQuery.data?.pdf}
+        loading={previewQuery.isFetching}
       />
     </React.Fragment>
   );

--- a/apps/admin/frontend/src/components/reporting/tally_report_warnings.test.ts
+++ b/apps/admin/frontend/src/components/reporting/tally_report_warnings.test.ts
@@ -10,10 +10,9 @@ test('getTallyReportWarningText', () => {
     expected: string;
   }> = [
     {
-      tallyReportWarning: {
-        type: 'none',
-      },
-      expected: '',
+      tallyReportWarning: { type: 'content-too-large' },
+      expected:
+        'This report is too large to be exported as a PDF. You may export the report as a CSV instead.',
     },
     {
       tallyReportWarning: {

--- a/apps/admin/frontend/src/components/reporting/tally_report_warnings.ts
+++ b/apps/admin/frontend/src/components/reporting/tally_report_warnings.ts
@@ -23,39 +23,44 @@ export function getTallyReportWarningText({
   tallyReportWarning,
   election,
 }: TallyReportWarningProps): string {
-  if (tallyReportWarning.type === 'none') {
-    return '';
-  }
+  switch (tallyReportWarning.type) {
+    case 'no-reports-match-filter':
+      return `The current report parameters do not match any ballots.`;
 
-  if (tallyReportWarning.type === 'no-reports-match-filter') {
-    return `The current report parameters do not match any ballots.`;
-  }
+    case 'content-too-large':
+      return `This report is too large to be exported as a PDF. You may export the report as a CSV instead.`;
 
-  const targetReportLabel = tallyReportWarning.isOnlyOneReport
-    ? 'This tally report'
-    : `A section of this tally report`;
+    case 'privacy': {
+      const targetReportLabel = tallyReportWarning.isOnlyOneReport
+        ? 'This tally report'
+        : `A section of this tally report`;
 
-  switch (tallyReportWarning.subType) {
-    case 'low-ballot-count':
-      return `${targetReportLabel} contains fewer than ${Tabulation.TALLY_REPORT_PRIVACY_THRESHOLD} ballots, which may pose a voter privacy risk.`;
-    case 'contest-same-vote': {
-      const contests = getContestsFromIds(
-        election,
-        tallyReportWarning.contestIds
-      );
-      const baseWarningText = `${targetReportLabel} has ${
-        contests.length > 1 ? 'contests' : 'a contest'
-      } where all votes are for the same option, which may pose a voter privacy risk.`;
-      if (contests.length <= 3) {
-        return `${baseWarningText} Check ${oxfordCommaJoin(
-          contests.map((c) => c.title)
-        )}.`;
+      switch (tallyReportWarning.subType) {
+        case 'low-ballot-count':
+          return `${targetReportLabel} contains fewer than ${Tabulation.TALLY_REPORT_PRIVACY_THRESHOLD} ballots, which may pose a voter privacy risk.`;
+        case 'contest-same-vote': {
+          const contests = getContestsFromIds(
+            election,
+            tallyReportWarning.contestIds
+          );
+          const baseWarningText = `${targetReportLabel} has ${
+            contests.length > 1 ? 'contests' : 'a contest'
+          } where all votes are for the same option, which may pose a voter privacy risk.`;
+          if (contests.length <= 3) {
+            return `${baseWarningText} Check ${oxfordCommaJoin(
+              contests.map((c) => c.title)
+            )}.`;
+          }
+
+          return baseWarningText;
+        }
+        // istanbul ignore next
+        default:
+          return throwIllegalValue(tallyReportWarning, 'subType');
       }
-
-      return baseWarningText;
     }
     // istanbul ignore next
     default:
-      throwIllegalValue(tallyReportWarning, 'subType');
+      throwIllegalValue(tallyReportWarning, 'type');
   }
 }

--- a/apps/admin/frontend/src/screens/reporting/write_in_adjudication_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/write_in_adjudication_report_screen.tsx
@@ -8,6 +8,7 @@ import {
   ExportActions,
   reportParentRoutes,
   ReportScreenContainer,
+  ReportWarning,
 } from '../../components/reporting/shared';
 import { PrintButton } from '../../components/print_button';
 import { PdfViewer } from '../../components/reporting/pdf_viewer';
@@ -22,6 +23,8 @@ export function TallyWriteInReportScreen(): JSX.Element {
   const pdfExportMutation = exportWriteInAdjudicationReportPdf.useMutation();
 
   const isPreviewLoading = !previewQuery.isSuccess;
+  const disablePdfExport =
+    previewQuery.data?.warning?.type === 'content-too-large';
 
   return (
     <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes} noPadding>
@@ -29,7 +32,7 @@ export function TallyWriteInReportScreen(): JSX.Element {
         <div style={{ padding: '1rem' }}>
           <ExportActions>
             <PrintButton
-              disabled={isPreviewLoading}
+              disabled={isPreviewLoading || disablePdfExport}
               print={() => printMutation.mutateAsync()}
               variant="primary"
             >
@@ -50,11 +53,17 @@ export function TallyWriteInReportScreen(): JSX.Element {
               }
               fileType="write-in adjudication report"
               fileTypeTitle="Write-In Adjudication Report"
-              disabled={isPreviewLoading}
+              disabled={isPreviewLoading || disablePdfExport}
             />
           </ExportActions>
+          {previewQuery.data?.warning && (
+            <ReportWarning>This report is too large to export.</ReportWarning>
+          )}
         </div>
-        <PdfViewer pdfData={previewQuery.data} />
+        <PdfViewer
+          loading={previewQuery.isFetching}
+          pdfData={previewQuery.data?.pdf}
+        />
       </ReportScreenContainer>
     </NavigationScreen>
   );

--- a/apps/admin/frontend/test/helpers/mock_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_api_client.ts
@@ -544,8 +544,8 @@ export function createApiMock(
       pdfContent?: string;
     }) {
       apiClient.getTallyReportPreview.expectCallWith(reportSpec).resolves({
-        pdf: Buffer.from(pdfContent ?? 'mock-pdf'),
-        warning: warning ?? { type: 'none' },
+        pdf: pdfContent ? Buffer.from(pdfContent) : undefined,
+        warning,
       });
     },
 
@@ -572,8 +572,8 @@ export function createApiMock(
       apiClient.getBallotCountReportPreview
         .expectCallWith(reportSpec)
         .resolves({
-          pdf: Buffer.from(pdfContent ?? 'mock-pdf'),
-          warning: warning ?? { type: 'none' },
+          pdf: pdfContent ? Buffer.from(pdfContent) : undefined,
+          warning,
         });
     },
 
@@ -590,7 +590,7 @@ export function createApiMock(
     expectGetWriteInAdjudicationReportPreview(pdfContent: string) {
       apiClient.getWriteInAdjudicationReportPreview
         .expectCallWith()
-        .resolves(Buffer.from(pdfContent));
+        .resolves({ pdf: Buffer.from(pdfContent) });
     },
 
     expectPrintWriteInAdjudicationReport: createDeferredMock(

--- a/apps/admin/frontend/test/react_pdf_mocks.tsx
+++ b/apps/admin/frontend/test/react_pdf_mocks.tsx
@@ -3,11 +3,11 @@ import { useEffect } from 'react';
 import { Buffer } from 'buffer';
 import styled from 'styled-components';
 
-const mockPdf: { numPages: number } = {
+const mockPdf: { numPages?: number } = {
   numPages: 1,
 };
 
-export function setMockPdfNumPages(numPages: number): void {
+export function setMockPdfNumPages(numPages?: number): void {
   mockPdf.numPages = numPages;
 }
 

--- a/apps/central-scan/backend/src/readiness_report.ts
+++ b/apps/central-scan/backend/src/readiness_report.ts
@@ -45,7 +45,8 @@ export async function saveReadinessReport({
     electionPackageHash,
   });
 
-  const data = await renderToPdf({ document: report });
+  // Readiness report PDF shouldn't be too long, so we don't expect a render error
+  const data = (await renderToPdf({ document: report })).unsafeUnwrap();
   const exporter = new Exporter({
     usbDrive,
     allowedExportPatterns: SCAN_ALLOWED_EXPORT_PATTERNS,

--- a/apps/design/backend/src/ballot_style_reports.ts
+++ b/apps/design/backend/src/ballot_style_reports.ts
@@ -12,16 +12,18 @@ export interface BallotStyleReadinessReportParams {
   renderer: PlaywrightRenderer;
 }
 
-export function renderBallotStyleReadinessReport(
+export async function renderBallotStyleReadinessReport(
   params: BallotStyleReadinessReportParams
 ): Promise<Buffer> {
   const { renderer, componentProps } = params;
 
-  return renderToPdf(
-    {
-      document: BallotStyleReadinessReport(componentProps),
-      usePrintTheme: true,
-    },
-    renderer.getBrowser()
-  );
+  return (
+    await renderToPdf(
+      {
+        document: BallotStyleReadinessReport(componentProps),
+        usePrintTheme: true,
+      },
+      renderer.getBrowser()
+    )
+  ).unsafeUnwrap();
 }

--- a/apps/design/backend/src/test_decks.ts
+++ b/apps/design/backend/src/test_decks.ts
@@ -230,18 +230,20 @@ export async function createTestDeckTallyReport({
 
   const tallyReportResults = await getTallyReportResults(election);
 
-  return await renderToPdf({
-    document: AdminTallyReportByParty({
-      electionDefinition,
-      title: undefined,
-      isOfficial: false,
-      isTest: true,
-      isForLogicAndAccuracyTesting: true,
-      testId: 'full-test-deck-tally-report',
-      tallyReportResults,
-      generatedAtTime: generatedAtTime ?? new Date(),
-    }),
-  });
+  return (
+    await renderToPdf({
+      document: AdminTallyReportByParty({
+        electionDefinition,
+        title: undefined,
+        isOfficial: false,
+        isTest: true,
+        isForLogicAndAccuracyTesting: true,
+        testId: 'full-test-deck-tally-report',
+        tallyReportResults,
+        generatedAtTime: generatedAtTime ?? new Date(),
+      }),
+    })
+  ).unsafeUnwrap();
 }
 
 export const FULL_TEST_DECK_TALLY_REPORT_FILE_NAME =

--- a/apps/mark-scan/backend/src/readiness_report.ts
+++ b/apps/mark-scan/backend/src/readiness_report.ts
@@ -68,7 +68,8 @@ export async function saveReadinessReport({
     expectPrecinctSelection: true,
     precinctSelection,
   });
-  const data = await renderToPdf({ document: report });
+  // Readiness report PDF shouldn't be too long, so we don't expect a render error
+  const data = (await renderToPdf({ document: report })).unsafeUnwrap();
 
   const exporter = new Exporter({
     usbDrive,

--- a/apps/mark-scan/backend/src/util/render_ballot.tsx
+++ b/apps/mark-scan/backend/src/util/render_ballot.tsx
@@ -61,10 +61,12 @@ export async function renderTestModeBallotWithoutLanguageContext(
     />
   );
 
-  return renderToPdf({
-    document: ballot,
-    paperDimensions: getPaperDimensions(),
-  });
+  return (
+    await renderToPdf({
+      document: ballot,
+      paperDimensions: getPaperDimensions(),
+    })
+  ).unsafeUnwrap();
 }
 
 export async function renderBallot({
@@ -96,11 +98,13 @@ export async function renderBallot({
     </BackendLanguageContextProvider>
   );
 
-  return renderToPdf(
-    {
-      document: ballot,
-      paperDimensions: getPaperDimensions(),
-    },
-    browser
-  );
+  return (
+    await renderToPdf(
+      {
+        document: ballot,
+        paperDimensions: getPaperDimensions(),
+      },
+      browser
+    )
+  ).unsafeUnwrap();
 }

--- a/apps/mark/backend/src/util/print_ballot.tsx
+++ b/apps/mark/backend/src/util/print_ballot.tsx
@@ -47,9 +47,7 @@ export async function printBallot({
   );
 
   return printer.print({
-    data: await renderToPdf({
-      document: ballot,
-    }),
+    data: (await renderToPdf({ document: ballot })).unsafeUnwrap(),
     sides: PrintSides.OneSided,
   });
 }

--- a/apps/scan/backend/src/printing/print_full_report.ts
+++ b/apps/scan/backend/src/printing/print_full_report.ts
@@ -66,7 +66,7 @@ export async function printFullReport({
     });
   })();
 
-  const pdfData = await renderToPdf({ document: report });
+  const pdfData = (await renderToPdf({ document: report })).unsafeUnwrap();
   await printer.print(pdfData);
 
   const pdfDocument = await getDocument(pdfData).promise;

--- a/apps/scan/backend/src/printing/print_report_section.ts
+++ b/apps/scan/backend/src/printing/print_report_section.ts
@@ -118,10 +118,12 @@ export async function printReportSection({
 }): Promise<PrintResult> {
   assert(printer.scheme === 'hardware-v4');
   const section = await getReportSection(store, index);
-  const data = await renderToPdf({
-    document: section,
-    paperDimensions: PAPER_DIMENSIONS.LetterRoll,
-    marginDimensions: ADJUSTED_MARGIN_DIMENSIONS,
-  });
+  const data = (
+    await renderToPdf({
+      document: section,
+      paperDimensions: PAPER_DIMENSIONS.LetterRoll,
+      marginDimensions: ADJUSTED_MARGIN_DIMENSIONS,
+    })
+  ).unsafeUnwrap();
   return printer.print(data);
 }

--- a/apps/scan/backend/src/printing/readiness_report.ts
+++ b/apps/scan/backend/src/printing/readiness_report.ts
@@ -48,7 +48,8 @@ export async function saveReadinessReport({
     generatedAtTime,
   });
 
-  const data = await renderToPdf({ document: report });
+  // Readiness report PDF shouldn't be too long, so we don't expect a render error
+  const data = (await renderToPdf({ document: report })).unsafeUnwrap();
   const exporter = new Exporter({
     usbDrive,
     allowedExportPatterns: SCAN_ALLOWED_EXPORT_PATTERNS,

--- a/libs/bmd-ballot-fixtures/src/bmd_ballot_fixtures.tsx
+++ b/libs/bmd-ballot-fixtures/src/bmd_ballot_fixtures.tsx
@@ -44,13 +44,12 @@ export async function renderBmdBallotFixture(
       {!frontPageOnly && <div style={{ pageBreakAfter: 'always' }} />}
     </React.Fragment>
   );
-  if (rotateImage) {
-    return renderToPdf({
-      document: <div style={{ transform: 'rotate(180deg)' }}>{ballot}</div>,
-    });
-  }
-
-  return renderToPdf({ document: ballot });
+  const document = rotateImage ? (
+    <div style={{ transform: 'rotate(180deg)' }}>{ballot}</div>
+  ) : (
+    ballot
+  );
+  return (await renderToPdf({ document })).unsafeUnwrap();
 }
 
 // Writes the first page of `pdfData` to an image file and returns the filepath.

--- a/libs/printing/scripts/render_tally_report.tsx
+++ b/libs/printing/scripts/render_tally_report.tsx
@@ -15,22 +15,24 @@ export async function main(args: readonly string[]): Promise<void> {
   const electionDefinition = (await readElection(electionPath)).unsafeUnwrap();
   const { election } = electionDefinition;
 
-  await renderToPdf({
-    document: (
-      <AdminTallyReportByParty
-        electionDefinition={electionDefinition}
-        isTest={false}
-        isOfficial={false}
-        isForLogicAndAccuracyTesting={false}
-        includeSignatureLines={false}
-        generatedAtTime={new Date()}
-        testId="render-tally-report"
-        tallyReportResults={buildSimpleMockTallyReportResults({
-          election,
-          scannedBallotCount: 0,
-        })}
-      />
-    ),
-    outputPath,
-  });
+  (
+    await renderToPdf({
+      document: (
+        <AdminTallyReportByParty
+          electionDefinition={electionDefinition}
+          isTest={false}
+          isOfficial={false}
+          isForLogicAndAccuracyTesting={false}
+          includeSignatureLines={false}
+          generatedAtTime={new Date()}
+          testId="render-tally-report"
+          tallyReportResults={buildSimpleMockTallyReportResults({
+            election,
+            scannedBallotCount: 0,
+          })}
+        />
+      ),
+      outputPath,
+    })
+  ).unsafeUnwrap();
 }


### PR DESCRIPTION
## Overview

Fixes: https://github.com/votingworks/vxsuite/issues/5278

When report PDFs are very very long (~1000 pages), Chromium will crash when trying to render them. In addition, the frontend PDF preview can crash at ~100 pages.

To prevent this, we set two limits:
- A limit on the HTML content length that we'll try to render as a PDF
- A limit on the page length for PDF previews

This PR also fixes two small bugs:
- Don't render empty reports
- Reset page count when PDF data changes

## Demo Video or Screenshot


https://github.com/user-attachments/assets/116bcb9f-9d01-425c-961b-d1b91e7fcf1f


## Testing Plan
To set the limits, I tested a variety of content lengths and chose conservative numbers. I also updated automated tests

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
