### PR TITLE
camelcase log keys

### DIFF
--- a/libs/logging/types-rust/src/types.rs
+++ b/libs/logging/types-rust/src/types.rs
@@ -44,10 +44,10 @@ pub enum User {
 #[serde(deny_unknown_fields)]
 pub struct Log {
     pub source: String,
-    #[serde(rename = "event-id")]
+    #[serde(rename = "eventId")]
     pub event_id: EventId,
     pub message: String,
-    #[serde(rename = "event-type")]
+    #[serde(rename = "eventType")]
     pub event_type: EventType,
     pub user: User,
     pub disposition: Disposition,

--- a/libs/logging/types-rust/src/types.rs
+++ b/libs/logging/types-rust/src/types.rs
@@ -42,12 +42,11 @@ pub enum User {
 
 #[derive(Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 pub struct Log {
     pub source: String,
-    #[serde(rename = "eventId")]
     pub event_id: EventId,
     pub message: String,
-    #[serde(rename = "eventType")]
     pub event_type: EventType,
     pub user: User,
     pub disposition: Disposition,


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/5334

Uses camelcase for log event keys when logging with Rust.

## Demo Video or Screenshot
n/a

## Testing Plan
Ran Rust daemon and manually confirmed camelcase output.

```
{"source":"vx-mark-scan-fai-100-controller-daemon","eventId":"create-virtual-uinput-device-init","message":"","eventType":"system-action","user":"system","disposition":"n/a"}
```
