### PR TITLE
VxDesign: Update vendored translation for Spanish ballot label

### DIFF
--- a/apps/design/backend/src/language_and_audio/vendored_translations.json
+++ b/apps/design/backend/src/language_and_audio/vendored_translations.json
@@ -180,7 +180,7 @@
     "Review Your Ballot": "Revise su boleta",
     "Review Your Votes": "Revise sus votos",
     "Review": "Revisar",
-    "Sample Absentee Ballot": "Boleta de muestra de voto ausente",
+    "Sample Absentee Ballot": "Modelo de boleta de voto ausente",
     "Sample Ballot": "Boleta de muestra",
     "Sample Provisional Ballot": "Boleta de muestra provisional",
     "Scan one ballot sheet at a time.": "Escanee una boleta a la vez.",


### PR DESCRIPTION


## Overview

The ballot labels for the different ballot variants (sample/test/official and precinct/absentee) all need to fit on one line in order for ballot layout to work. In Spanish, the most verbose language we support, some of the auto-translations are too long, so we use shorter vendored translations instead. These recently got reset, so updating them again to make ballot layout work.

## Demo Video or Screenshot
N/A
## Testing Plan
Manual test

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
