### PR TITLE
Increase max election file size to 30MB

### DIFF
--- a/libs/fs/src/election.test.ts
+++ b/libs/fs/src/election.test.ts
@@ -47,15 +47,15 @@ test('file system error: no such file', async () => {
 
 test('file system error: file exceeds max size', async () => {
   const path = makeTmpFile();
-  writeFileSync(path, 'a'.repeat(10 * 1024 * 1024 + 1));
+  writeFileSync(path, 'a'.repeat(30 * 1024 * 1024 + 1));
   expect(await readElection(path)).toEqual(
     err(
       typedAs<ReadElectionError>({
         type: 'ReadFileError',
         error: {
           type: 'FileExceedsMaxSize',
-          maxSize: 10 * 1024 * 1024,
-          fileSize: 10 * 1024 * 1024 + 1,
+          maxSize: 30 * 1024 * 1024,
+          fileSize: 30 * 1024 * 1024 + 1,
         },
       })
     )

--- a/libs/fs/src/election.ts
+++ b/libs/fs/src/election.ts
@@ -14,9 +14,9 @@ export type ReadElectionError =
   | { type: 'ParseError'; error: ZodError | SyntaxError };
 
 /**
- * Maximum size of an election file (10 MB).
+ * Maximum size of an election file (30 MB).
  */
-const MAX_ELECTION_SIZE = 10 * 1024 * 1024;
+const MAX_ELECTION_SIZE = 30 * 1024 * 1024;
 
 /**
  * Reads an election from a file path.


### PR DESCRIPTION


## Overview

During scale testing, this limit prevented us from testing with a large mock election file. I temporarily increased it to enable the testing, and the system was generally able to handle a large election around 30MB without issue. So I'm increasing this limit to the tested size so that it doesn't end up accidentally biting us later in the extremely rare case that we have an election over 10MB.
## Demo Video or Screenshot
N/A
## Testing Plan
Manual scale testing
## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
