### PR TITLE
Improve state machine logging

### DIFF
--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -6,7 +6,12 @@ import {
 } from '@votingworks/custom-paper-handler';
 import { Buffer } from 'buffer';
 import { dirSync } from 'tmp';
-import { LogEventId, BaseLogger, mockBaseLogger } from '@votingworks/logging';
+import {
+  LogEventId,
+  BaseLogger,
+  mockBaseLogger,
+  mockLogger,
+} from '@votingworks/logging';
 import {
   InsertedSmartCardAuthApi,
   buildMockInsertedSmartCardAuth,
@@ -160,7 +165,7 @@ beforeEach(async () => {
     BooleanEnvironmentVariableName.MARK_SCAN_DISABLE_BALLOT_REINSERTION
   );
 
-  logger = mockBaseLogger();
+  logger = mockLogger();
   auth = buildMockInsertedSmartCardAuth();
   workspace = createWorkspace(dirSync().name, mockBaseLogger());
   workspace.store.setElectionAndJurisdiction({

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -8,7 +8,7 @@ import { Buffer } from 'buffer';
 import { dirSync } from 'tmp';
 import {
   LogEventId,
-  BaseLogger,
+  Logger,
   mockBaseLogger,
   mockLogger,
 } from '@votingworks/logging';
@@ -95,7 +95,7 @@ jest.mock('node-hid');
 let driver: MockPaperHandlerDriver;
 let workspace: Workspace;
 let machine: PaperHandlerStateMachine;
-let logger: BaseLogger;
+let logger: Logger;
 let patConnectionStatusReader: PatConnectionStatusReaderInterface;
 let auth: InsertedSmartCardAuthApi;
 let ballotPdfData: Buffer;

--- a/apps/mark-scan/backend/test/app_helpers.ts
+++ b/apps/mark-scan/backend/test/app_helpers.ts
@@ -6,7 +6,6 @@ import * as grout from '@votingworks/grout';
 import { Application } from 'express';
 import { AddressInfo } from 'net';
 import {
-  BaseLogger,
   mockLogger,
   LogSource,
   Logger,
@@ -56,7 +55,7 @@ export async function getMockStateMachine(
   workspace: Workspace,
   patConnectionStatusReader: PatConnectionStatusReaderInterface,
   driver: MockPaperHandlerDriver,
-  logger: BaseLogger,
+  logger: Logger,
   clock: SimulatedClock,
   authOverride?: InsertedSmartCardAuthApi
 ): Promise<PaperHandlerStateMachine> {

--- a/apps/scan/backend/src/scanners/custom/state_machine.ts
+++ b/apps/scan/backend/src/scanners/custom/state_machine.ts
@@ -19,7 +19,7 @@ import {
   SensorStatus,
 } from '@votingworks/custom-scanner';
 import { fromGrayScale, ImageData } from '@votingworks/image-utils';
-import { BaseLogger, LogEventId, LogLine } from '@votingworks/logging';
+import { Logger, LogEventId, LogLine } from '@votingworks/logging';
 import { mapSheet, SheetInterpretation, SheetOf } from '@votingworks/types';
 import { UsbDrive } from '@votingworks/usb-drive';
 import { v4 as uuid } from 'uuid';
@@ -1129,7 +1129,7 @@ function buildMachine({
 function setupLogging(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   machineService: Interpreter<Context, any, Event, any, any>,
-  logger: BaseLogger
+  logger: Logger
 ) {
   machineService
     .onEvent(async (event) => {
@@ -1234,7 +1234,7 @@ export function createPrecinctScannerStateMachine({
   auth: InsertedSmartCardAuthApi;
   workspace: Workspace;
   interpret?: InterpretFn;
-  logger: BaseLogger;
+  logger: Logger;
   usbDrive: UsbDrive;
   clock?: Clock;
 }): PrecinctScannerStateMachine {

--- a/apps/scan/backend/src/scanners/pdi/pdi_app_scan.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_scan.test.ts
@@ -94,7 +94,10 @@ test('configure and scan hmpb', async () => {
       expect(logger.log).toHaveBeenCalledWith(
         'scanner-state-machine-transition',
         'system',
-        { message: 'Transitioned to: {"waitingForBallot":"checkingStatus"}' },
+        {
+          message: 'Transitioned to: {"waitingForBallot":"checkingStatus"}',
+          newState: '{"waitingForBallot":"checkingStatus"}',
+        },
         expect.any(Function)
       );
       // Make sure we got an event

--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -1016,7 +1016,10 @@ function setupLogging(
       await logger.log(
         LogEventId.ScannerStateChanged,
         'system',
-        { message: `Transitioned to: ${JSON.stringify(state.value)}` },
+        {
+          message: `Transitioned to: ${JSON.stringify(state.value)}`,
+          newState: JSON.stringify(state.value),
+        },
         (logLine: LogLine) => debug(logLine.message)
       );
     });

--- a/apps/scan/backend/src/scanners/shared.ts
+++ b/apps/scan/backend/src/scanners/shared.ts
@@ -115,6 +115,8 @@ export function cleanLogData(key: string, value: unknown): unknown {
       'layout',
       'client',
       'rootListenerRef',
+      'imagePath',
+      'sheetId',
     ].includes(key)
   ) {
     return '[hidden]';

--- a/libs/logging/src/logger.test.ts
+++ b/libs/logging/src/logger.test.ts
@@ -59,3 +59,26 @@ test('Logger.from', async () => {
   );
   expect(logSpy).toHaveBeenCalled();
 });
+
+test('can provide fallback user', async () => {
+  console.log = jest.fn();
+  const baseLogger = new BaseLogger(LogSource.VxCentralScanService);
+  const logSpy = jest.spyOn(baseLogger, 'log');
+  const logger = Logger.from(baseLogger, () => Promise.resolve('unknown'));
+  await logger.logAsCurrentRole(
+    LogEventId.FileSaved,
+    {},
+    undefined,
+    'cardless_voter'
+  );
+  expect(console.log).toHaveBeenCalledWith(
+    JSON.stringify({
+      source: LogSource.VxCentralScanService,
+      eventId: LogEventId.FileSaved,
+      eventType: LogEventType.UserAction,
+      user: 'cardless_voter',
+      disposition: LogDispositionStandardTypes.NotApplicable,
+    })
+  );
+  expect(logSpy).toHaveBeenCalled();
+});

--- a/libs/logging/src/logger.ts
+++ b/libs/logging/src/logger.ts
@@ -14,8 +14,16 @@ export class Logger extends BaseLogger {
   async logAsCurrentRole(
     eventId: LogEventId,
     logData?: LogData,
-    outerDebug?: (logLine: LogLine) => void
+    outerDebug?: (logLine: LogLine) => void,
+    // When defined if the user is 'unknown' we will instead log the value provided here.
+    // This should be used sparingly. It is used for example with the precinct scanner as the
+    // "voter" user does not authenticate with the system and can be assumed.
+    fallbackUser?: LoggingUserRole
   ): Promise<void> {
+    const currentUser = await this.getCurrentRole();
+    if (currentUser === 'unknown' && fallbackUser) {
+      return this.log(eventId, fallbackUser, logData, outerDebug);
+    }
     return this.log(eventId, await this.getCurrentRole(), logData, outerDebug);
   }
 


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/5342
Improvements after audit state machine logging in mark and scan. We were unneccesarily downgrading the logger to BaseLogger in the function calls so I fixed that in both. I also am logging new states on the state transition logs as an explicit key in the json blob. Now that we are using Logger, I will log with the current role rather then 'system' for "event" logs that come from a user action, on VxScan this will log as "voter" if no one is currently authenticated. This makes sures on the precinct scanner that we log with the user as voter: 
1. Initiating a scan with the "scanStart" log
2. Accepting a ballot after adjudication
3. Returning a ballot after adjudication. 

Things like calibration will now be logged with the right user as well. Similar logic applied to MarkScan to make sure we log the happy path voter actions: 
1. Initiating a print 
2. Invalidating a ballot after review
2. Casting a ballot after review

And the pollworker will have logs for
1. Loading the paper at the begining of the flow 

There were already explicit other logs for the validated/invalidate voter-actions in mark-scan that I decided to leave in place as those logs are a bit easier to find but this change is still useful to get the "user" on more other mark-scan logs.  

## Demo Video or Screenshot

## Testing Plan
Tested in dev setup, ran test cases, planning to test more on real vsap at atrium for more mark-scan flows will make other PRs if I need to tweak things

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
