### PR TITLE
Add fujtisu printer logging

### DIFF
--- a/apps/scan/backend/src/printing/printer.ts
+++ b/apps/scan/backend/src/printing/printer.ts
@@ -12,7 +12,7 @@ import {
   BooleanEnvironmentVariableName,
   isFeatureFlagEnabled,
 } from '@votingworks/utils';
-import { BaseLogger } from '@votingworks/logging';
+import { Logger } from '@votingworks/logging';
 import { assert, Result } from '@votingworks/basics';
 import { Buffer } from 'buffer';
 
@@ -88,7 +88,7 @@ export function wrapFujitsuThermalPrinter(
   };
 }
 
-export function getPrinter(logger: BaseLogger): Printer {
+export function getPrinter(logger: Logger): Printer {
   if (
     isFeatureFlagEnabled(BooleanEnvironmentVariableName.USE_BROTHER_PRINTER)
   ) {
@@ -96,7 +96,7 @@ export function getPrinter(logger: BaseLogger): Printer {
     return wrapLegacyPrinter(legacyPrinter);
   }
 
-  const printer = getFujitsuThermalPrinter();
+  const printer = getFujitsuThermalPrinter(logger);
   assert(printer);
   return wrapFujitsuThermalPrinter(printer);
 }

--- a/libs/fujitsu-thermal-printer/package.json
+++ b/libs/fujitsu-thermal-printer/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@votingworks/basics": "workspace:*",
     "@votingworks/image-utils": "workspace:*",
+    "@votingworks/logging": "workspace:*",
     "@votingworks/message-coder": "workspace:*",
     "@votingworks/types": "workspace:*",
     "@votingworks/utils": "workspace:*",

--- a/libs/fujitsu-thermal-printer/src/cli.ts
+++ b/libs/fujitsu-thermal-printer/src/cli.ts
@@ -6,6 +6,7 @@ import { assert, throwIllegalValue } from '@votingworks/basics';
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { safeParseInt } from '@votingworks/types';
+import { BaseLogger, LogSource, Logger } from '@votingworks/logging';
 import { FujitsuThermalPrinter } from './printer';
 
 /**
@@ -90,7 +91,11 @@ async function handleCommand(
 export async function main(): Promise<number> {
   printUsage();
 
-  const printer = new FujitsuThermalPrinter();
+  const printer = new FujitsuThermalPrinter(
+    Logger.from(new BaseLogger(LogSource.System), () =>
+      Promise.resolve('unknown')
+    )
+  );
   assert(printer, 'Could not get printer. Is a printer connected?');
 
   const lines = createInterface(process.stdin);

--- a/libs/fujitsu-thermal-printer/src/index.ts
+++ b/libs/fujitsu-thermal-printer/src/index.ts
@@ -1,5 +1,6 @@
 /* istanbul ignore file */
 export * from './types';
+export * from './logging';
 export * from './printer';
 export * from './mocks/memory_printer';
 export * from './mocks/file_printer';

--- a/libs/fujitsu-thermal-printer/src/logging.ts
+++ b/libs/fujitsu-thermal-printer/src/logging.ts
@@ -1,0 +1,49 @@
+import { BaseLogger, LogEventId } from '@votingworks/logging';
+import { PrinterStatus } from './types';
+
+export async function logPrinterStatusIfChanged(
+  logger: BaseLogger,
+  previousStatus?: PrinterStatus,
+  newStatus?: PrinterStatus
+): Promise<void> {
+  if (!previousStatus && !newStatus) {
+    return;
+  }
+  if (!previousStatus) {
+    await logger.log(LogEventId.PrinterStatusChanged, 'system', {
+      message: `Printer Status initiated with ${JSON.stringify(newStatus)}`,
+      status: JSON.stringify(newStatus),
+      disposition:
+        newStatus && newStatus.state === 'error' ? 'failure' : 'success',
+    });
+    return;
+  }
+  if (!newStatus) {
+    await logger.log(LogEventId.PrinterStatusChanged, 'system', {
+      message: `Printer status disconnected.`,
+      disposition: 'failure',
+    });
+    return;
+  }
+  if (previousStatus.state !== newStatus.state) {
+    await logger.log(LogEventId.PrinterStatusChanged, 'system', {
+      message: `Printer Status updated from ${JSON.stringify(
+        previousStatus
+      )} to ${JSON.stringify(newStatus)}`,
+      status: JSON.stringify(newStatus),
+      disposition: newStatus.state === 'error' ? 'failure' : 'success',
+    });
+  } else if (
+    previousStatus.state === 'error' &&
+    newStatus.state === 'error' &&
+    previousStatus.type !== newStatus.type
+  ) {
+    await logger.log(LogEventId.PrinterStatusChanged, 'system', {
+      message: `Printer Status updated from ${JSON.stringify(
+        previousStatus
+      )} to ${JSON.stringify(newStatus)}`,
+      status: JSON.stringify(newStatus),
+      disposition: 'failure',
+    });
+  }
+}

--- a/libs/fujitsu-thermal-printer/tsconfig.build.json
+++ b/libs/fujitsu-thermal-printer/tsconfig.build.json
@@ -15,6 +15,7 @@
     { "path": "../../libs/image-utils/tsconfig.build.json" },
     { "path": "../../libs/test-utils/tsconfig.build.json" },
     { "path": "../../libs/types/tsconfig.build.json" },
-    { "path": "../../libs/utils/tsconfig.build.json" }
+    { "path": "../../libs/utils/tsconfig.build.json" },
+    { "path": "../../libs/logging/tsconfig.build.json" }
   ]
 }

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -134,6 +134,18 @@ IDs are logged with each log to identify the log being written.
 **Type:** [application-status](#application-status)  
 **Description:** Application saw a change to the connection status of a given configured printer.  
 **Machines:** All
+### printer-status-changed
+**Type:** [application-status](#application-status)  
+**Description:** Application saw a change in the status of the currently connected printer.  
+**Machines:** All
+### printer-print-request
+**Type:** [user-action](#user-action)  
+**Description:** A print request was triggered.  
+**Machines:** All
+### printer-print-complete
+**Type:** [user-action](#user-action)  
+**Description:** A print request was completed. Success or failure is indicated by disposition.  
+**Machines:** All
 ### device-attached
 **Type:** [application-status](#application-status)  
 **Description:** Application saw a device attached to the system.  

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -179,6 +179,21 @@ eventId = "printer-connection-update"
 eventType = "application-status"
 documentationMessage = "Application saw a change to the connection status of a given configured printer."
 
+[PrinterStatusChanged]
+eventId = "printer-status-changed"
+eventType = "application-status"
+documentationMessage = "Application saw a change in the status of the currently connected printer."
+
+[PrinterPrintRequest]
+eventId = "printer-print-request"
+eventType = "user-action"
+documentationMessage = "A print request was triggered."
+
+[PrinterPrintComplete]
+eventId = "printer-print-complete"
+eventType = "user-action"
+documentationMessage = "A print request was completed. Success or failure is indicated by disposition."
+
 [DeviceAttached]
 eventId = "device-attached"
 eventType = "application-status"

--- a/libs/logging/src/log_event_ids.ts
+++ b/libs/logging/src/log_event_ids.ts
@@ -42,6 +42,9 @@ export enum LogEventId {
   PrinterConfigurationAdded = 'printer-config-added',
   PrinterConfigurationRemoved = 'printer-config-removed',
   PrinterConnectionUpdate = 'printer-connection-update',
+  PrinterStatusChanged = 'printer-status-changed',
+  PrinterPrintRequest = 'printer-print-request',
+  PrinterPrintComplete = 'printer-print-complete',
   DeviceAttached = 'device-attached',
   DeviceUnattached = 'device-unattached',
   FileSaved = 'file-saved',
@@ -370,6 +373,26 @@ const PrinterConnectionUpdate: LogDetails = {
   eventType: LogEventType.ApplicationStatus,
   documentationMessage:
     'Application saw a change to the connection status of a given configured printer.',
+};
+
+const PrinterStatusChanged: LogDetails = {
+  eventId: LogEventId.PrinterStatusChanged,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage:
+    'Application saw a change in the status of the currently connected printer.',
+};
+
+const PrinterPrintRequest: LogDetails = {
+  eventId: LogEventId.PrinterPrintRequest,
+  eventType: LogEventType.UserAction,
+  documentationMessage: 'A print request was triggered.',
+};
+
+const PrinterPrintComplete: LogDetails = {
+  eventId: LogEventId.PrinterPrintComplete,
+  eventType: LogEventType.UserAction,
+  documentationMessage:
+    'A print request was completed. Success or failure is indicated by disposition.',
 };
 
 const DeviceAttached: LogDetails = {
@@ -1288,6 +1311,12 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return PrinterConfigurationRemoved;
     case LogEventId.PrinterConnectionUpdate:
       return PrinterConnectionUpdate;
+    case LogEventId.PrinterStatusChanged:
+      return PrinterStatusChanged;
+    case LogEventId.PrinterPrintRequest:
+      return PrinterPrintRequest;
+    case LogEventId.PrinterPrintComplete:
+      return PrinterPrintComplete;
     case LogEventId.DeviceAttached:
       return DeviceAttached;
     case LogEventId.DeviceUnattached:

--- a/libs/logging/types-rust/src/log_event_enums.rs
+++ b/libs/logging/types-rust/src/log_event_enums.rs
@@ -69,6 +69,12 @@ pub enum EventId {
     PrinterConfigurationRemoved,
     #[serde(rename = "printer-connection-update")]
     PrinterConnectionUpdate,
+    #[serde(rename = "printer-status-changed")]
+    PrinterStatusChanged,
+    #[serde(rename = "printer-print-request")]
+    PrinterPrintRequest,
+    #[serde(rename = "printer-print-complete")]
+    PrinterPrintComplete,
     #[serde(rename = "device-attached")]
     DeviceAttached,
     #[serde(rename = "device-unattached")]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4174,6 +4174,9 @@ importers:
       '@votingworks/image-utils':
         specifier: workspace:*
         version: link:../image-utils
+      '@votingworks/logging':
+        specifier: workspace:*
+        version: link:../logging
       '@votingworks/message-coder':
         specifier: workspace:*
         version: link:../message-coder


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/5339
Adds basic logging on status changes and print events for the fujitsu printer

<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot

## Testing Plan
Tested mock printer and real printer manually, saw logs as expected.

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
