### PR TITLE
[MarkScan] Add open scanner detection and associated state machine state

### DIFF
--- a/apps/mark-scan/backend/src/app.auth.test.ts
+++ b/apps/mark-scan/backend/src/app.auth.test.ts
@@ -155,7 +155,9 @@ test('endCardlessVoterSession', async () => {
 
 test('getAuthStatus before election definition has been configured', async () => {
   await apiClient.getAuthStatus();
-  expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(1);
+
+  // Additional call expected from the state machine:
+  expect(mockAuth.getAuthStatus).toHaveBeenCalledTimes(2);
   expect(mockAuth.getAuthStatus).toHaveBeenNthCalledWith(
     1,
     DEFAULT_SYSTEM_SETTINGS.auth

--- a/apps/mark-scan/backend/src/custom-paper-handler/types.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/types.ts
@@ -6,6 +6,7 @@ export const SimpleStatusSchema = z.union([
   z.literal('ballot_accepted'),
   z.literal('ballot_removed_during_presentation'),
   z.literal('blank_page_interpretation'),
+  z.literal('cover_open_unauthorized'),
   z.literal('ejecting_to_front'),
   z.literal('ejecting_to_rear'),
   z.literal('empty_ballot_box'),

--- a/libs/custom-paper-handler/src/driver/mock_driver.ts
+++ b/libs/custom-paper-handler/src/driver/mock_driver.ts
@@ -80,6 +80,7 @@ export class MockPaperHandlerDriver implements PaperHandlerDriverInterface {
   private statusRef: PaperHandlerStatus = defaultPaperHandlerStatus();
   private mockStatus: MockPaperHandlerStatus = 'noPaper';
   private mockPaperContents?: ImageData;
+  private coverOpen = false;
 
   constructor() {
     this.setMockStatus('noPaper');
@@ -295,11 +296,23 @@ export class MockPaperHandlerDriver implements PaperHandlerDriverInterface {
 
   setMockStatus(mockStatus: MockPaperHandlerStatus): void {
     this.mockStatus = mockStatus;
-    this.statusRef = MOCK_STATUSES_DEFINITIONS[mockStatus];
+    this.statusRef = {
+      ...MOCK_STATUSES_DEFINITIONS[mockStatus],
+      optoSensor: this.coverOpen,
+    };
   }
 
   setMockPaperContents(contents?: ImageData): void {
     this.mockPaperContents = contents;
+  }
+
+  isCoverOpen(): boolean {
+    return this.coverOpen;
+  }
+
+  setCoverOpen(isOpen: boolean): void {
+    this.coverOpen = isOpen;
+    this.setMockStatus(this.mockStatus);
   }
 }
 

--- a/libs/custom-paper-handler/src/driver/scanner_status.ts
+++ b/libs/custom-paper-handler/src/driver/scanner_status.ts
@@ -11,6 +11,13 @@ export function isPaperReadyToLoad(
   );
 }
 
+export function isCoverOpen(paperHandlerStatus: PaperHandlerStatus): boolean {
+  const isHoodRaised = paperHandlerStatus.optoSensor;
+  const isDeviceOpen = paperHandlerStatus.coverOpen;
+
+  return isHoodRaised || isDeviceOpen;
+}
+
 export function isPaperJammed(paperHandlerStatus: PaperHandlerStatus): boolean {
   return paperHandlerStatus.paperJam;
 }


### PR DESCRIPTION
## Overview

Related to https://github.com/votingworks/vxsuite/issues/3873

Adding polling for the `optoSensor` (plastic hood open) and `coverOpen` (paper handler open) sensor flags and moving the state machine into a `cover_open_unauthorized` state accordingly, if there's no non-voter user logged in.

This will eventually be consumed in other parts of the app, to display an alert in the UI and play an alarm through the speakers.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/0296c450-a8d7-45fc-a143-0a8eb79a20fd

## Testing Plan
- Manual + unit tests

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
