### PR TITLE
support ERR write-ins and validate non-write-in candidate IDs

### DIFF
--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -478,27 +478,27 @@ describe('ERR file import', () => {
             undervotes: 0,
             ballots: 65,
           },
-          'best-animal-mammal': {
-            contestId: 'best-animal-mammal',
+          council: {
+            contestId: 'council',
             contestType: 'candidate',
             votesAllowed: 2,
             overvotes: 8,
             undervotes: 2,
             ballots: 65,
             tallies: {
-              zebra: {
-                id: 'zebra',
-                name: 'Zebra',
+              'barchi-hallaren': {
+                id: 'barchi-hallaren',
+                name: 'Joseph Barchi and Joseph Hallaren',
                 tally: 60,
               },
-              ibex: {
-                id: 'ibex',
-                name: 'Ibex',
+              'cramer-vuocolo': {
+                id: 'cramer-vuocolo',
+                name: 'Adam Cramer and Greg Vuocolo',
                 tally: 30,
               },
-              gazelle: {
-                id: 'gazelle',
-                name: 'Gazelle',
+              'court-blumhardt': {
+                id: 'court-blumhardt',
+                name: 'Daniel Court and Amy Blumhardt',
                 tally: 30,
               },
             },

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -89,7 +89,7 @@ import {
   getWriteInAdjudicationContext,
   getWriteInImageView,
 } from './util/write_ins';
-import { handleEnteredWriteInCandidateData } from './util/manual_results';
+import { transformWriteInsAndSetManualResults } from './util/manual_results';
 import { addFileToZipStream } from './util/zip';
 import { exportFile } from './util/export_file';
 import { generateTallyReportCsv } from './exports/csv_tally_report';
@@ -705,20 +705,13 @@ function buildApi({
       }
     ): Promise<void> {
       const electionId = loadCurrentElectionIdOrThrow(workspace);
-      await store.withTransaction(() => {
-        const manualResults = handleEnteredWriteInCandidateData({
-          manualResults: input.manualResults,
-          electionId,
-          store,
-        });
-        store.setManualResults({
-          electionId,
-          precinctId: input.precinctId,
-          ballotStyleId: input.ballotStyleId,
-          votingMethod: input.votingMethod,
-          manualResults,
-        });
-        return Promise.resolve();
+      await transformWriteInsAndSetManualResults({
+        manualResults: input.manualResults,
+        electionId,
+        store,
+        precinctId: input.precinctId,
+        ballotStyleId: input.ballotStyleId,
+        votingMethod: input.votingMethod,
       });
 
       await logger.logAsCurrentRole(LogEventId.ManualTallyDataEdited, {
@@ -802,21 +795,13 @@ function buildApi({
 
       const manualResults = wrappedManualResults.ok();
 
-      await store.withTransaction(() => {
-        const writeInAdjustedManualResults = handleEnteredWriteInCandidateData({
-          manualResults,
-          electionId,
-          store,
-        });
-
-        store.setManualResults({
-          electionId,
-          precinctId: input.precinctId,
-          ballotStyleId: input.ballotStyleId,
-          votingMethod: input.votingMethod,
-          manualResults: writeInAdjustedManualResults,
-        });
-        return Promise.resolve();
+      await transformWriteInsAndSetManualResults({
+        manualResults,
+        electionId,
+        store,
+        precinctId: input.precinctId,
+        ballotStyleId: input.ballotStyleId,
+        votingMethod: input.votingMethod,
       });
 
       await logger.logAsCurrentRole(

--- a/apps/admin/backend/src/util/manual_results.ts
+++ b/apps/admin/backend/src/util/manual_results.ts
@@ -1,4 +1,5 @@
 import { Id, Tabulation } from '@votingworks/types';
+import { TEMPORARY_WRITE_IN_ID_PREFIX } from '@votingworks/types/src/admin';
 import { Store } from '../store';
 
 /**
@@ -26,7 +27,7 @@ export function handleEnteredWriteInCandidateData({
           if (candidateTally.tally === 0) {
             // if any write-in candidate has no votes, remove them from tally
             delete contestResults.tallies[candidateId];
-          } else if (candidateId.startsWith('temp-write-in-')) {
+          } else if (candidateId.startsWith(TEMPORARY_WRITE_IN_ID_PREFIX)) {
             // for temp-write-in candidates, create records and substitute ids
             const writeInCandidateRecord = store.addWriteInCandidate({
               electionId,

--- a/apps/admin/backend/src/util/manual_results.ts
+++ b/apps/admin/backend/src/util/manual_results.ts
@@ -1,5 +1,4 @@
-import { Id, Tabulation } from '@votingworks/types';
-import { TEMPORARY_WRITE_IN_ID_PREFIX } from '@votingworks/types/src/admin';
+import { Id, Tabulation, Admin as AdminTypes } from '@votingworks/types';
 import { Store } from '../store';
 import { ManualResultsVotingMethod } from '../types';
 
@@ -28,7 +27,9 @@ function handleEnteredWriteInCandidateData({
           if (candidateTally.tally === 0) {
             // if any write-in candidate has no votes, remove them from tally
             delete contestResults.tallies[candidateId];
-          } else if (candidateId.startsWith(TEMPORARY_WRITE_IN_ID_PREFIX)) {
+          } else if (
+            candidateId.startsWith(AdminTypes.TEMPORARY_WRITE_IN_ID_PREFIX)
+          ) {
             // for temp-write-in candidates, create records and substitute ids
             const writeInCandidateRecord = store.addWriteInCandidate({
               electionId,

--- a/apps/admin/frontend/src/screens/manual_data_entry_screen.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_entry_screen.tsx
@@ -14,6 +14,7 @@ import {
   getContests,
   Tabulation,
   CandidateId,
+  Admin as AdminTypes,
 } from '@votingworks/types';
 import {
   Button,
@@ -40,8 +41,6 @@ import type {
   ManualResultsRecord,
   WriteInCandidateRecord,
 } from '@votingworks/admin-backend';
-import { TEMPORARY_WRITE_IN_ID_PREFIX } from '@votingworks/types/src/admin';
-import { ManualDataEntryScreenProps } from '../config/types';
 import { routerPaths } from '../router_paths';
 
 import { AppContext } from '../contexts/app_context';
@@ -52,6 +51,7 @@ import {
   setManualResults,
 } from '../api';
 import { normalizeWriteInName } from '../utils/write_ins';
+import { ManualDataEntryScreenProps } from '../config/types';
 
 export const TITLE = 'Edit Tallies';
 
@@ -473,7 +473,7 @@ function ManualResultsDataEntryScreenForm({
     setTempWriteInCandidates([
       ...tempWriteInCandidates,
       {
-        id: `${TEMPORARY_WRITE_IN_ID_PREFIX}(${name})`,
+        id: `${AdminTypes.TEMPORARY_WRITE_IN_ID_PREFIX}(${name})`,
         name,
         contestId,
       },

--- a/apps/admin/frontend/src/screens/manual_data_entry_screen.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_entry_screen.tsx
@@ -40,6 +40,7 @@ import type {
   ManualResultsRecord,
   WriteInCandidateRecord,
 } from '@votingworks/admin-backend';
+import { TEMPORARY_WRITE_IN_ID_PREFIX } from '@votingworks/types/src/admin';
 import { ManualDataEntryScreenProps } from '../config/types';
 import { routerPaths } from '../router_paths';
 
@@ -472,7 +473,7 @@ function ManualResultsDataEntryScreenForm({
     setTempWriteInCandidates([
       ...tempWriteInCandidates,
       {
-        id: `temp-write-in-(${name})`,
+        id: `${TEMPORARY_WRITE_IN_ID_PREFIX}(${name})`,
         name,
         contestId,
       },

--- a/apps/admin/frontend/src/screens/manual_data_summary_screen.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_summary_screen.tsx
@@ -362,8 +362,8 @@ export function ManualDataSummaryScreen(): JSX.Element {
                   selectedPrecinct &&
                   selectedVotingMethod
                     ? routerPaths.manualDataEntry({
-                        ballotStyleId: selectedBallotStyle?.id,
-                        precinctId: selectedPrecinct?.id,
+                        ballotStyleId: selectedBallotStyle.id,
+                        precinctId: selectedPrecinct.id,
                         votingMethod: selectedVotingMethod,
                       })
                     : routerPaths.manualDataSummary

--- a/libs/types/src/admin/index.ts
+++ b/libs/types/src/admin/index.ts
@@ -1,1 +1,2 @@
+export * from './manual_results';
 export * from './reporting';

--- a/libs/types/src/admin/manual_results.ts
+++ b/libs/types/src/admin/manual_results.ts
@@ -1,0 +1,1 @@
+export const TEMPORARY_WRITE_IN_ID_PREFIX = 'temp-write-in-';

--- a/libs/types/src/cdf/election-results-reporting/convert.ts
+++ b/libs/types/src/cdf/election-results-reporting/convert.ts
@@ -15,6 +15,7 @@ import {
   isCandidateContest,
   isRetentionContest,
 } from './types';
+import { TEMPORARY_WRITE_IN_ID_PREFIX } from '../../admin';
 
 type CandidateNameRecord = Record<CandidateId, Candidate['name']>;
 
@@ -205,7 +206,7 @@ function getCandidateTallies(
   for (const selection of contest.ContestSelection as ResultsReporting.CandidateSelection[]) {
     if (selection.IsWriteIn) {
       // ID prefix indicates to VxAdmin logic that this was a write in
-      const candidateId = `temp-write-in-${selection['@id']}`;
+      const candidateId = `${TEMPORARY_WRITE_IN_ID_PREFIX}${selection['@id']}`;
 
       const name = candidateNameRecord[selection['@id']];
       const tally: VxTabulation.CandidateTally = {

--- a/libs/types/src/cdf/election-results-reporting/convert.ts
+++ b/libs/types/src/cdf/election-results-reporting/convert.ts
@@ -242,26 +242,23 @@ function getCandidateTallies(
   for (const lowerCaseName of Object.keys(writeInCandidateNameRecord)) {
     // Get list of tallies grouped by case-insensitive name
     const talliesForName = writeInCandidateNameRecord[lowerCaseName];
-    // Ignore names that only have one tally object
-    if (talliesForName.length > 1) {
-      // Sort by vote count descending
-      const sorted = talliesForName.slice().sort((a, b) => b.tally - a.tally);
-      // Sum vote count for candidate across all spellings
-      const voteSum = sorted
-        .map((tally) => tally.tally)
-        .reduce((prevSum, incremental) => prevSum + incremental, 0);
+    // Sort by vote count descending
+    const sorted = talliesForName.slice().sort((a, b) => b.tally - a.tally);
+    // Sum vote count for candidate across all spellings
+    const voteSum = sorted
+      .map((tally) => tally.tally)
+      .reduce((prevSum, incremental) => prevSum + incremental, 0);
 
-      // Choose the most popular spelling and update their vote count to the summed vote count
-      const mostPopularSpelling = sorted[0];
-      tallies[mostPopularSpelling.id] = {
-        ...tallies[mostPopularSpelling.id],
-        tally: voteSum,
-      };
+    // Choose the most popular spelling and update their vote count to the summed vote count
+    const mostPopularSpelling = sorted[0];
+    tallies[mostPopularSpelling.id] = {
+      ...tallies[mostPopularSpelling.id],
+      tally: voteSum,
+    };
 
-      // Delete tallies for all other spellings
-      for (let i = 1; i < sorted.length; i += 1) {
-        delete tallies[sorted[i].id];
-      }
+    // Delete tallies for all other spellings
+    for (let i = 1; i < sorted.length; i += 1) {
+      delete tallies[sorted[i].id];
     }
   }
 
@@ -396,7 +393,8 @@ function validateCandidateIds(
 }
 /**
  * Converts an ElectionReport to an instance of ManualElectionResults.
- * @param electionReport
+ * @param electionReport Data from a CDF Election Results Reporting file.
+ * @param validCandidateIds A list of candidate IDs extracted from an ElectionDefinition. ERR candidate IDs unknown to the caller (eg. those specified in an ElectionDefinition) are unsupported. The implementation will return an error if the ERR contents contain a candidate ID not specified in validCandidateIds.
  * @returns an instance of ManualElectionResults.
  */
 export function convertElectionResultsReportingReportToVxManualResults(

--- a/libs/types/src/cdf/election-results-reporting/fixtures.ts
+++ b/libs/types/src/cdf/election-results-reporting/fixtures.ts
@@ -21,6 +21,9 @@ function asInternationalizedText(text: string): InternationalizedText {
   };
 }
 
+/**
+ * A mock ElectionReport designed to work with the ElectionGeneral mock election.
+ */
 export const testElectionReport: ElectionReport = {
   '@type': 'ElectionResults.ElectionReport',
   Issuer: 'VotingWorks',
@@ -56,22 +59,24 @@ export const testElectionReport: ElectionReport = {
       ],
       Candidate: [
         {
-          '@id': 'zebra',
+          '@id': 'barchi-hallaren',
           '@type': 'ElectionResults.Candidate',
-          BallotName: asInternationalizedText('Zebra'),
+          BallotName: asInternationalizedText(
+            'Joseph Barchi and Joseph Hallaren'
+          ),
           PartyId: '0',
         },
         {
-          '@id': 'ibex',
+          '@id': 'cramer-vuocolo',
           '@type': 'ElectionResults.Candidate',
-          BallotName: asInternationalizedText('Ibex'),
+          BallotName: asInternationalizedText('Adam Cramer and Greg Vuocolo'),
           PartyId: '1',
         },
         {
-          '@id': 'gazelle',
+          '@id': 'court-blumhardt',
           '@type': 'ElectionResults.Candidate',
-          BallotName: asInternationalizedText('Gazelle'),
-          PartyId: '2',
+          BallotName: asInternationalizedText('Daniel Court and Amy Blumhardt'),
+          PartyId: '1',
         },
       ],
       Contest: [
@@ -122,7 +127,7 @@ export const testElectionReport: ElectionReport = {
           '@id': 'judge',
           Name: 'Judge Retention',
           ElectionDistrictId: 'state-of-hamilton',
-          CandidateId: 'zebra',
+          CandidateId: 'barchi-hallaren',
           ContestSelection: [
             {
               '@type': 'ElectionResults.BallotMeasureSelection',
@@ -162,14 +167,14 @@ export const testElectionReport: ElectionReport = {
         },
         {
           '@type': 'ElectionResults.CandidateContest',
-          '@id': 'best-animal-mammal',
-          Name: 'Best Animal Mammal',
+          '@id': 'council',
+          Name: 'Council',
           ElectionDistrictId: 'state-of-hamilton',
           VotesAllowed: 2,
           ContestSelection: [
             {
               '@type': 'ElectionResults.CandidateSelection',
-              '@id': 'zebra',
+              '@id': 'barchi-hallaren',
               VoteCounts: [
                 {
                   '@type': 'ElectionResults.VoteCounts',
@@ -181,7 +186,7 @@ export const testElectionReport: ElectionReport = {
             },
             {
               '@type': 'ElectionResults.CandidateSelection',
-              '@id': 'ibex',
+              '@id': 'cramer-vuocolo',
               VoteCounts: [
                 {
                   '@type': 'ElectionResults.VoteCounts',
@@ -193,7 +198,7 @@ export const testElectionReport: ElectionReport = {
             },
             {
               '@type': 'ElectionResults.CandidateSelection',
-              '@id': 'gazelle',
+              '@id': 'court-blumhardt',
               VoteCounts: [
                 {
                   '@type': 'ElectionResults.VoteCounts',
@@ -210,6 +215,110 @@ export const testElectionReport: ElectionReport = {
               GpUnitId: 'state-of-hamilton',
               Overvotes: 8,
               Undervotes: 2,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+export const testElectionReportWriteIns: ElectionReport = {
+  '@type': 'ElectionResults.ElectionReport',
+  Issuer: 'VotingWorks',
+  GeneratedDate: '2021-06-06T00:00:00Z',
+  SequenceStart: 1,
+  SequenceEnd: 1,
+  Format: ReportDetailLevel.SummaryContest,
+  Status: ResultsStatus.UnofficialComplete,
+  IssuerAbbreviation: 'VX',
+  VendorApplicationId: 'VX',
+  Election: [
+    {
+      '@type': 'ElectionResults.Election',
+      ElectionScopeId: 'state-of-hamilton',
+      StartDate: '2021-06-06',
+      EndDate: '2021-06-06',
+      Name: asInternationalizedText('Lincoln Municipal General Election'),
+      Type: ElectionType.General,
+      BallotCounts: [
+        {
+          '@type': 'ElectionResults.BallotCounts',
+          GpUnitId: 'state-of-hamilton',
+          Type: CountItemType.Total,
+          BallotsCast: 10,
+        },
+      ],
+      CountStatus: [
+        {
+          '@type': 'ElectionResults.CountStatus',
+          Type: CountItemType.Total,
+          Status: CountItemStatus.Completed,
+        },
+      ],
+      Candidate: [
+        {
+          '@id': 'zebra',
+          '@type': 'ElectionResults.Candidate',
+          BallotName: asInternationalizedText('Zebra'),
+          PartyId: '0',
+        },
+        {
+          '@id': 'ibex-01',
+          '@type': 'ElectionResults.Candidate',
+          BallotName: asInternationalizedText('IBEX'),
+        },
+        {
+          '@id': 'ibex-02',
+          '@type': 'ElectionResults.Candidate',
+          BallotName: asInternationalizedText('Ibex'),
+        },
+      ],
+      Contest: [
+        {
+          '@type': 'ElectionResults.CandidateContest',
+          '@id': 'best-animal-mammal',
+          Name: 'Best Animal Mammal',
+          ElectionDistrictId: 'state-of-hamilton',
+          VotesAllowed: 1,
+          ContestSelection: [
+            {
+              '@type': 'ElectionResults.CandidateSelection',
+              '@id': 'zebra',
+              VoteCounts: [
+                {
+                  '@type': 'ElectionResults.VoteCounts',
+                  GpUnitId: 'state-of-hamilton',
+                  Count: 6,
+                  Type: CountItemType.Total,
+                },
+              ],
+            },
+            {
+              '@type': 'ElectionResults.CandidateSelection',
+              '@id': 'ibex-01',
+              IsWriteIn: true,
+              VoteCounts: [
+                {
+                  '@type': 'ElectionResults.VoteCounts',
+                  GpUnitId: 'state-of-hamilton',
+                  Count: 1,
+                  Type: CountItemType.Total,
+                },
+              ],
+            },
+            {
+              '@type': 'ElectionResults.CandidateSelection',
+              '@id': 'ibex-02',
+              IsWriteIn: true,
+              VoteCounts: [
+                {
+                  '@type': 'ElectionResults.VoteCounts',
+                  GpUnitId: 'state-of-hamilton',
+                  Count: 3,
+                  Type: CountItemType.Total,
+                },
+              ],
             },
           ],
         },


### PR DESCRIPTION
## Overview

* Adds support for write-ins when importing ERR files
* Validates non-write-in candidate IDs against the machine's election definition. Returns an error if candidate IDs specified in the ERR file do not have a match in the election definition.
  * Updates ERR fixtures to work with `electionGeneralDefinition`; previous mammal-themed mock values did not have a corresponding election definition.

## Demo Video or Screenshot

**Write-ins**

https://github.com/user-attachments/assets/7aff1ef6-8eab-4d61-8760-f9ebd004d9b1

**Candidate ID validation**

https://github.com/user-attachments/assets/a79e854b-cc08-4a0e-b3a9-b14db77e327c

## Testing Plan
- added tests
- manually tested

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
