### PR TITLE
test(image-utils): disable `encodeImageData` perf test

### DIFF
--- a/libs/image-utils/src/image_data.test.ts
+++ b/libs/image-utils/src/image_data.test.ts
@@ -269,7 +269,14 @@ async function measureRepeatedly(
   }
 }
 
-test('encodeImageData performance', async () => {
+// TODO: Replace this with a service specifically geared toward measuring performance.
+//
+// This is too inconsistent to be a reliable performance benchmark. It's unclear whether
+// it's the test environment, the test itself, or the code being tested that's causing
+// the inconsistency.
+//
+// Consider replacing with a service like https://codspeed.io/.
+test.skip('encodeImageData performance', async () => {
   const imageData = createImageData(1000, 1000);
   randomFillSync(imageData.data);
 


### PR DESCRIPTION

## Overview

We should consider replacing this with https://codspeed.io/ or similar. I didn't disable this only in CI because it's inconsistent even on a dev machine.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated.
