### PR TITLE
Save cdf log files as json extension

### DIFF
--- a/libs/backend/src/system_call/export_logs_to_usb.test.ts
+++ b/libs/backend/src/system_call/export_logs_to_usb.test.ts
@@ -302,7 +302,7 @@ test('exportLogsToUsb works for cdf format when all conditions are met', async (
 
   expect(execFileMock).toHaveBeenCalledWith('sync', ['-f', '/media/usb-drive']);
   expect(createWriteStreamMock).toHaveBeenCalledWith(
-    expect.stringContaining('vx-logs.cdf.log')
+    expect.stringContaining('vx-logs.cdf.log.json')
   );
 
   expect(logger.log).toHaveBeenCalledWith(

--- a/libs/backend/src/system_call/export_logs_to_usb.ts
+++ b/libs/backend/src/system_call/export_logs_to_usb.ts
@@ -44,14 +44,14 @@ async function convertLogsToCdf(
       createReadStream(join(logDir, 'vx-logs.log'), 'utf8'),
       (inputStream: AsyncIterable<string>) =>
         buildCdfLog(logger, inputStream, machineId, codeVersion),
-      createWriteStream(join(outputDir, 'vx-logs.cdf.log'))
+      createWriteStream(join(outputDir, 'vx-logs.cdf.log.json'))
     );
   }
 
   // Create CDF for all compressed vx-logs files
   for (const file of files) {
     if (file.match(COMPRESSED_VX_LOGS_NAME_REGEX)) {
-      const cdfFileName = file.replace('vx-logs', 'vx-logs.cdf');
+      const cdfFileName = file.replace('vx-logs', 'vx-logs.cdf.json');
       await pipeline(
         createReadStream(join(logDir, file)),
         createGunzip(),


### PR DESCRIPTION
## Overview
The CDF log files are json formatted and in order to work with the NIST cdf validator tool the extension needs to be .json, which probably makes sense anyway since ... it is json. 

<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot

## Testing Plan
Ran tests

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
