### PR TITLE
[MarkScan] Add voter screen for the cover_open_unauthorized state

### DIFF
--- a/apps/mark-scan/frontend/src/app_root.test.tsx
+++ b/apps/mark-scan/frontend/src/app_root.test.tsx
@@ -100,3 +100,28 @@ describe('renders PollWorkerAuthEndedUnexpectedlyPage for relevant states:', () 
     });
   }
 });
+
+test('scanner open alarm screen', async () => {
+  const electionDefinition = electionGeneralDefinition;
+  apiMock.expectGetElectionRecord(electionDefinition);
+  apiMock.setAuthStatus(mockCardlessVoterLoggedInAuth(electionDefinition));
+  apiMock.expectGetMachineConfig();
+  apiMock.expectGetSystemSettings(DEFAULT_SYSTEM_SETTINGS);
+  apiMock.expectGetElectionState({
+    precinctSelection: ALL_PRECINCTS_SELECTION,
+    pollsState: 'polls_open',
+  });
+
+  apiMock.setPaperHandlerState('cover_open_unauthorized');
+
+  mockOf(PollWorkerScreen).mockImplementation((props) => {
+    const { setVotes } = props;
+    React.useEffect(() => setVotes({ contest2: ['yes'] }), [setVotes]);
+
+    return <div>MockPollWorkerScreen</div>;
+  });
+
+  render(<AppRoot />, { apiMock, electionDefinition });
+
+  await screen.findByText('Printer Cover Open');
+});

--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -75,6 +75,7 @@ import { PollWorkerAuthEndedUnexpectedlyPage } from './pages/poll_worker_auth_en
 import { LOW_BATTERY_THRESHOLD } from './constants';
 import { VoterFlow } from './voter_flow';
 import { NoPaperHandlerPage } from './pages/no_paper_handler_page';
+import { ScannerOpenAlarmScreen } from './pages/scanner_open_alarm_screen';
 
 /**
  * These states require the Poll Worker to stay logged in until the voter
@@ -357,6 +358,10 @@ export function AppRoot(): JSX.Element | null {
     authStatus.reason === 'no_card_reader'
   ) {
     return <SetupCardReaderPage />;
+  }
+
+  if (stateMachineState === 'cover_open_unauthorized') {
+    return <ScannerOpenAlarmScreen />;
   }
 
   if (stateMachineState === 'no_hardware') {

--- a/apps/mark-scan/frontend/src/pages/scanner_open_alarm_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/scanner_open_alarm_screen.tsx
@@ -1,0 +1,27 @@
+import { Caption, H6, Icons, P } from '@votingworks/ui';
+
+import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+
+export function ScannerOpenAlarmScreen(): JSX.Element {
+  return (
+    <CenteredCardPageLayout
+      icon={<Icons.Danger color="danger" />}
+      title="Printer Cover Open"
+      voterFacing
+    >
+      <P>The printer cover is open and must be closed to continue voting.</P>
+      <P>Please ask a poll worker for help.</P>
+
+      {/* Poll Worker strings - not translated: */}
+      <H6 as="h2">
+        <Icons.Info /> Poll Workers:
+      </H6>
+      <P>
+        <Caption>
+          Insert a poll worker card to silence the alert. Close and seal the
+          cover to resume voting.
+        </Caption>
+      </P>
+    </CenteredCardPageLayout>
+  );
+}


### PR DESCRIPTION
## Overview

Related to https://github.com/votingworks/vxsuite/issues/3873

Adding a corresponding voter-facing screen for the `cover_open_unauthorized` state machine state. This will be visible while the an audio alarm is played through the speaker.

## Demo Video or Screenshot
<img width="350" src="https://github.com/user-attachments/assets/8844da0c-294c-4b3f-a010-ab802dc27191" />

_(fixed the missing period in the code after this screenshot)_

## Testing Plan
- Unit and manual tests

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
