### PR TITLE
[Node Upgrade] Revert packages using v8 coverage back to babel

### DIFF
--- a/apps/admin/backend/jest.config.js
+++ b/apps/admin/backend/jest.config.js
@@ -22,7 +22,7 @@ module.exports = {
       lines: 100,
     },
   },
-  coverageProvider: 'v8',
+  coverageProvider: 'babel',
   collectCoverageFrom: [
     '**/*.{ts,tsx}',
     '!**/*.d.ts',

--- a/apps/admin/backend/src/adjudication.ts
+++ b/apps/admin/backend/src/adjudication.ts
@@ -29,7 +29,7 @@ export function adjudicateVote(
 
   const scannedIsVote = contestVotes
     ? contestVotes.includes(voteAdjudication.optionId)
-    : /* c8 ignore next 1 */
+    : /* istanbul ignore next */
       false;
 
   // if the vote is already the target status, do nothing
@@ -63,10 +63,9 @@ async function logWriteInAdjudication({
         return `a vote for an official candidate (${initialWriteInRecord.candidateId})`;
       case 'write-in-candidate':
         return `a vote for a write-in candidate (${initialWriteInRecord.candidateId})`;
-      /* c8 ignore start */
+      /* istanbul ignore next */
       default:
         throwIllegalValue(initialWriteInRecord, 'adjudicationType');
-      /* c8 ignore stop */
     }
   })();
 
@@ -80,10 +79,9 @@ async function logWriteInAdjudication({
         return `a vote for a write-in candidate (${adjudicationAction.candidateId})`;
       case 'reset':
         return `unadjudicated`;
-      /* c8 ignore start */
+      /* istanbul ignore next */
       default:
         throwIllegalValue(adjudicationAction, 'type');
-      /* c8 ignore stop */
     }
   })();
 
@@ -169,10 +167,9 @@ export async function adjudicateWriteIn(
       // ensure the vote appears as it originally was in tallies
       store.deleteVoteAdjudication(initialWriteInRecord);
       break;
-    /* c8 ignore start */
+    /* istanbul ignore next */
     default:
       throwIllegalValue(adjudicationAction, 'type');
-    /* c8 ignore stop */
   }
 
   // if we are switching away from a write-in candidate, we may have to clean

--- a/apps/admin/backend/src/app.tally_report_data.test.ts
+++ b/apps/admin/backend/src/app.tally_report_data.test.ts
@@ -9,6 +9,8 @@ import {
 } from '@votingworks/utils';
 import { assert, find } from '@votingworks/basics';
 import { Tabulation } from '@votingworks/types';
+import { initializeGetWorkspaceDiskSpaceSummary } from '@votingworks/backend';
+import { mockOf } from '@votingworks/test-utils';
 import {
   buildTestEnvironment,
   configureMachine,
@@ -27,6 +29,14 @@ jest.mock('@votingworks/utils', () => {
   };
 });
 
+jest.mock(
+  '@votingworks/backend',
+  (): typeof import('@votingworks/backend') => ({
+    ...jest.requireActual('@votingworks/backend'),
+    initializeGetWorkspaceDiskSpaceSummary: jest.fn(),
+  })
+);
+
 beforeEach(() => {
   jest.restoreAllMocks();
   featureFlagMock.enableFeatureFlag(
@@ -34,6 +44,13 @@ beforeEach(() => {
   );
   featureFlagMock.enableFeatureFlag(
     BooleanEnvironmentVariableName.SKIP_CAST_VOTE_RECORDS_AUTHENTICATION
+  );
+  mockOf(initializeGetWorkspaceDiskSpaceSummary).mockReturnValue(() =>
+    Promise.resolve({
+      total: 10 * 1_000_000,
+      used: 1 * 1_000_000,
+      available: 9 * 1_000_000,
+    })
   );
 });
 

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -143,7 +143,7 @@ function getCurrentElectionRecord(
   workspace: Workspace
 ): Optional<ElectionRecord> {
   const electionId = workspace.store.getCurrentElectionId();
-  /* c8 ignore next 3 */
+  /* istanbul ignore next */
   if (!electionId) {
     return undefined;
   }
@@ -249,7 +249,7 @@ function buildApi({
       return printer.status();
     },
 
-    /* c8 ignore start */
+    /* istanbul ignore next */
     generateSignedHashValidationQrCodeValue() {
       const { machineId } = getMachineConfig();
       const electionRecord = getCurrentElectionRecord(workspace);
@@ -258,7 +258,6 @@ function buildApi({
         ballotHash: electionRecord?.electionDefinition?.ballotHash,
       });
     },
-    /* c8 ignore stop */
 
     async getUsbDriveStatus(): Promise<UsbDriveStatus> {
       return usbDrive.status();
@@ -327,12 +326,11 @@ function buildApi({
           signatureFile.fileName,
           signatureFile.fileContents
         );
-        /* c8 ignore start: Tricky to make this second export err but the first export succeed
+        /* istanbul ignore next: Tricky to make this second export err but the first export succeed
           without significant mocking */
         if (exportSignatureFileResult.isErr()) {
           return exportSignatureFileResult;
         }
-        /* c8 ignore stop */
       } finally {
         await fs.rm(tempDirectory, { recursive: true });
       }
@@ -433,7 +431,7 @@ function buildApi({
           await zipPromise.promise;
           const fileContents = Buffer.concat(chunks);
           const result = await readElectionPackageFromBuffer(fileContents);
-          /* c8 ignore next */
+          /* istanbul ignore next */
           return result.isErr() ? result : ok({ ...result.ok(), fileContents });
         }
         return await readElectionPackageFromFile(input.electionFilePath);

--- a/apps/admin/backend/src/cast_vote_records.ts
+++ b/apps/admin/backend/src/cast_vote_records.ts
@@ -138,16 +138,14 @@ export async function listCastVoteRecordExportsOnUsbDrive(
         case 'not-directory': {
           return err('found-file-instead-of-directory');
         }
-        /* c8 ignore start: Hard to trigger without significant mocking */
+        /* istanbul ignore next: Hard to trigger without significant mocking */
         case 'permission-denied': {
           return err('permission-denied');
         }
-        /* c8 ignore stop */
-        /* c8 ignore start: Compile-time check for completeness */
+        /* istanbul ignore next: Compile-time check for completeness */
         default: {
           throwIllegalValue(errorType);
         }
-        /* c8 ignore stop */
       }
     }
 
@@ -180,7 +178,10 @@ export async function listCastVoteRecordExportsOnUsbDrive(
 
   return ok(
     [...castVoteRecordExportSummaries].sort(
-      (a, b) => b.exportTimestamp.getTime() - a.exportTimestamp.getTime()
+      /* istanbul ignore next */
+      (a, b) => {
+        return b.exportTimestamp.getTime() - a.exportTimestamp.getTime();
+      }
     )
   );
 }

--- a/apps/admin/backend/src/exports/csv_ballot_count_report.ts
+++ b/apps/admin/backend/src/exports/csv_ballot_count_report.ts
@@ -68,7 +68,7 @@ function buildRow({
   const values: string[] = [...metadataValues];
 
   const counts: number[] = [];
-  /* c8 ignore next - trivial fallthrough case */
+  /* istanbul ignore next - trivial fallthrough case */
   const manual = cardCounts.manual ?? 0;
   const { bmd } = cardCounts;
   const total = getBallotCount(cardCounts);
@@ -81,7 +81,7 @@ function buildRow({
 
   if (maxSheetsPerBallot) {
     for (let i = 0; i < maxSheetsPerBallot; i += 1) {
-      /* c8 ignore next - trivial fallthrough case */
+      /* istanbul ignore next - trivial fallthrough case */
       const currentSheetCount = cardCounts.hmpb[i] ?? 0;
       counts.push(currentSheetCount);
     }

--- a/apps/admin/backend/src/reports/readiness.ts
+++ b/apps/admin/backend/src/reports/readiness.ts
@@ -29,9 +29,10 @@ async function getReadinessReport({
     {};
 
   return AdminReadinessReport({
-    /* c8 ignore start */
-    batteryInfo: (await getBatteryInfo()) ?? undefined,
-    /* c8 ignore stop */
+    batteryInfo:
+      (await getBatteryInfo()) ??
+      /* istanbul ignore next */
+      undefined,
     diskSpaceSummary: await workspace.getDiskSpaceSummary(),
     printerStatus: await printer.status(),
     mostRecentPrinterDiagnostic:

--- a/apps/admin/backend/src/reports/titles.ts
+++ b/apps/admin/backend/src/reports/titles.ts
@@ -148,7 +148,7 @@ export function generateTitleForReport({
           return ok(`Undervoted ${reportType} Report`);
         case 'hasWriteIn':
           return ok(`Write-In ${reportType} Report`);
-        /* c8 ignore next 2 */
+        /* istanbul ignore next */
         default:
           throwIllegalValue(adjudicationFlag);
       }

--- a/apps/admin/backend/src/server.ts
+++ b/apps/admin/backend/src/server.ts
@@ -49,7 +49,7 @@ export async function start({
   debug('starting server...');
   detectDevices({ logger: baseLogger });
   let resolvedWorkspace = workspace;
-  /* c8 ignore start */
+  /* istanbul ignore next */
   if (!resolvedWorkspace) {
     const workspacePath = ADMIN_WORKSPACE;
     if (!workspacePath) {
@@ -64,11 +64,10 @@ export async function start({
     }
     resolvedWorkspace = createWorkspace(workspacePath, baseLogger);
   }
-  /* c8 ignore stop */
 
   let resolvedApp = app;
 
-  /* c8 ignore start */
+  /* istanbul ignore next */
   if (!resolvedApp) {
     const auth = new DippedSmartCardAuth({
       card:
@@ -97,7 +96,6 @@ export async function start({
       workspace: resolvedWorkspace,
     });
   }
-  /* c8 ignore stop */
 
   const server = resolvedApp.listen(port, async () => {
     await baseLogger.log(LogEventId.ApplicationStartup, 'system', {

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -1400,8 +1400,8 @@ export class Store {
     ) as CastVoteRecordVoteAdjudication[];
 
     for (const adjudication of adjudications) {
-      const currentContestVotes =
-        votes[adjudication.contestId] ?? /* c8 ignore next 1 */ [];
+      /* istanbul ignore next */
+      const currentContestVotes = votes[adjudication.contestId] ?? [];
       if (adjudication.isVote) {
         votes[adjudication.contestId] = [
           ...currentContestVotes,
@@ -1463,7 +1463,7 @@ export class Store {
           from vote_adjudications
           group by cvr_id
         ) aggregated_adjudications
-          on 
+          on
             cvrs.election_id = aggregated_adjudications.election_id and
             cvrs.id = aggregated_adjudications.cvr_id
         where ${whereParts.join(' and ')}
@@ -1569,8 +1569,11 @@ export class Store {
         ballotStyleId: groupBy.groupByBallotStyle
           ? row.ballotStyleId
           : undefined,
-        /* c8 ignore next - edge case coverage needed for bad party grouping in general election */
-        partyId: groupBy.groupByParty ? row.partyId ?? undefined : undefined,
+        /* istanbul ignore next - edge case coverage needed for bad party grouping in general election */
+        partyId: groupBy.groupByParty
+          ? /* istanbul ignore next */
+            row.partyId ?? undefined
+          : undefined,
         batchId: groupBy.groupByBatch ? row.batchId : undefined,
         scannerId: groupBy.groupByScanner ? row.scannerId : undefined,
         precinctId: groupBy.groupByPrecinct ? row.precinctId : undefined,
@@ -1928,8 +1931,11 @@ export class Store {
         ballotStyleId: groupBy.groupByBallotStyle
           ? row.ballotStyleId
           : undefined,
-        /* c8 ignore next - edge case coverage needed for bad party grouping in general election */
-        partyId: groupBy.groupByParty ? row.partyId ?? undefined : undefined,
+        /* istanbul ignore next - edge case coverage needed for bad party grouping in general election */
+        partyId: groupBy.groupByParty
+          ? /* istanbul ignore next */
+            row.partyId ?? undefined
+          : undefined,
         batchId: groupBy.groupByBatch ? row.batchId : undefined,
         scannerId: groupBy.groupByScanner ? row.scannerId : undefined,
         precinctId: groupBy.groupByPrecinct ? row.precinctId : undefined,
@@ -2188,7 +2194,7 @@ export class Store {
     this.client.run(
       `
       delete from vote_adjudications
-      where 
+      where
         election_id = ? and
         cvr_id = ? and
         contest_id = ? and
@@ -2595,7 +2601,7 @@ export class Store {
     updateMaximumUsableDiskSpace(this.client, space);
   }
 
-  /* c8 ignore start */
+  /* istanbul ignore next */
   getDebugSummary(): Map<string, number> {
     const tableNameRows = this.client.all(
       `select name from sqlite_schema where type='table' order by name;`
@@ -2615,5 +2621,4 @@ export class Store {
       )
     );
   }
-  /* c8 ignore stop */
 }

--- a/apps/admin/backend/src/tabulation/card_counts.ts
+++ b/apps/admin/backend/src/tabulation/card_counts.ts
@@ -31,9 +31,9 @@ function addCardTallyToCardCounts({
     // eslint-disable-next-line no-param-reassign
     cardCounts.bmd += tally;
   } else {
+    /* istanbul ignore next - trivial fallback case */
     // eslint-disable-next-line no-param-reassign
     cardCounts.hmpb[card.sheetNumber - 1] =
-      /* c8 ignore next - trivial fallback case */
       (cardCounts.hmpb[card.sheetNumber - 1] ?? 0) + tally;
   }
 

--- a/apps/admin/backend/src/tabulation/full_results.ts
+++ b/apps/admin/backend/src/tabulation/full_results.ts
@@ -152,6 +152,7 @@ export async function tabulateElectionResults({
     });
 
     // ignore manual results if the tabulation is not successful
+    /* istanbul ignore else */
     if (queryResult.isOk()) {
       debug('merging manual results into CVR results');
       const groupedManualResults = queryResult.ok();
@@ -180,8 +181,8 @@ export async function tabulateElectionResults({
           });
         }
       );
-      /* c8 ignore next 3 - debug only */
-    } else {
+    } /* istanbul ignore next - debug only */ else {
+      /* istanbul ignore next */
       debug('filter or group by is not compatible with manual results');
     }
   }

--- a/apps/admin/backend/src/tabulation/manual_results.ts
+++ b/apps/admin/backend/src/tabulation/manual_results.ts
@@ -42,15 +42,13 @@ function getManualResultsGroupSpecifier(
  * Aggregates an iterable list of manual results records into one or many
  * combined manual results based on the specified grouping.
  */
-export function aggregateManualResults({
-  election,
-  manualResultsRecords,
-  groupBy = {},
-}: {
+export function aggregateManualResults(params: {
   election: Election;
   manualResultsRecords: Iterable<ManualResultsRecord>;
   groupBy?: Tabulation.GroupBy;
 }): Tabulation.ManualResultsGroupMap {
+  /* istanbul ignore next */
+  const { election, manualResultsRecords, groupBy = {} } = params;
   const manualResultsGroupMap: Tabulation.ManualResultsGroupMap = {};
 
   const ballotStyleIdPartyIdLookup = getBallotStyleIdPartyIdLookup(election);

--- a/apps/admin/backend/src/tabulation/tally_reports.ts
+++ b/apps/admin/backend/src/tabulation/tally_reports.ts
@@ -45,17 +45,14 @@ function addContestIdsToReports<U>({
  * adjusted with write-in adjudication data (but combining all unofficial write-ins)
  * and manual results separately.
  */
-export async function tabulateTallyReportResults({
-  electionId,
-  store,
-  filter = {},
-  groupBy = {},
-}: {
+export async function tabulateTallyReportResults(params: {
   electionId: Id;
   store: Store;
   filter?: Tabulation.Filter;
   groupBy?: Tabulation.GroupBy;
 }): Promise<Tabulation.GroupList<Admin.TallyReportResults>> {
+  /* istanbul ignore next - type-checked defaults */
+  const { electionId, store, filter = {}, groupBy = {} } = params;
   const {
     electionDefinition: { election },
   } = assertDefined(store.getElection(electionId));

--- a/apps/admin/backend/src/tabulation/write_ins.ts
+++ b/apps/admin/backend/src/tabulation/write_ins.ts
@@ -146,7 +146,7 @@ function addWriteInTallyToElectionWriteInSummary({
           isWriteIn: true,
         };
         break;
-      /* c8 ignore next 2 */
+      /* istanbul ignore next */
       default:
         throwIllegalValue(writeInTally);
     }

--- a/apps/admin/backend/src/util/auth.ts
+++ b/apps/admin/backend/src/util/auth.ts
@@ -16,7 +16,7 @@ export function constructAuthMachineState(
 ): DippedSmartCardAuthMachineState {
   const electionId = workspace.store.getCurrentElectionId();
 
-  /* c8 ignore next 3 - covered by integration testing */
+  /* istanbul ignore next - covered by integration testing */
   const jurisdiction = isIntegrationTest()
     ? TEST_JURISDICTION
     : process.env.VX_MACHINE_JURISDICTION ?? DEV_JURISDICTION;
@@ -49,6 +49,6 @@ export async function getUserRole(
   if (authStatus.status === 'logged_in') {
     return authStatus.user.role;
   }
-  /* c8 ignore next 2 - trivial fallback case */
+  /* istanbul ignore next - trivial fallback case */
   return 'unknown';
 }

--- a/apps/admin/backend/src/util/cdf_results.ts
+++ b/apps/admin/backend/src/util/cdf_results.ts
@@ -59,8 +59,9 @@ function buildOfficialCandidates(
   return candidates.map((candidate) => ({
     '@type': 'ElectionResults.Candidate',
     '@id': candidate.id,
-    /* c8 ignore next 1 -- trivial fallthrough case */
-    PartyId: candidate.partyIds?.[0],
+    PartyId:
+      /* istanbul ignore next -- trivial fallthrough case */
+      candidate.partyIds?.[0],
     BallotName: asInternationalizedText(candidate.name),
   }));
 }

--- a/apps/admin/backend/src/util/export_file.ts
+++ b/apps/admin/backend/src/util/export_file.ts
@@ -21,16 +21,26 @@ export function exportFile({
   const exporter = new Exporter({
     allowedExportPatterns: ADMIN_ALLOWED_EXPORT_PATTERNS,
     /* We're not using `exportDataToUsbDrive` here, so a mock `usbDrive` is OK */
-    /* c8 ignore start */
     usbDrive: {
-      status: () =>
-        Promise.resolve({
-          status: 'no_drive',
-        }),
-      eject: () => Promise.resolve(),
-      format: () => Promise.resolve(),
+      status:
+        /* istanbul ignore next */
+        () => {
+          return Promise.resolve({
+            status: 'no_drive',
+          });
+        },
+
+      eject:
+        /* istanbul ignore next */
+        () => {
+          return Promise.resolve();
+        },
+      format:
+        /* istanbul ignore next */
+        () => {
+          return Promise.resolve();
+        },
     },
-    /* c8 ignore stop */
   });
 
   debug('exporting data to file %s', path);

--- a/apps/admin/backend/src/util/write_ins.ts
+++ b/apps/admin/backend/src/util/write_ins.ts
@@ -40,7 +40,7 @@ export async function getWriteInImageView({
   const contestLayout = layout.contests.find(
     (contest) => contest.contestId === contestId
   );
-  /* c8 ignore next 3 - TODO: revisit our layout assumptions based on our new ballots */
+  /* istanbul ignore next - TODO: revisit our layout assumptions based on our new ballots */
   if (!contestLayout) {
     throw new Error('unable to find a layout for the specified contest');
   }
@@ -52,13 +52,13 @@ export async function getWriteInImageView({
   const writeInOptionIndex = safeParseNumber(
     optionId.slice('write-in-'.length)
   );
-  /* c8 ignore next 3 - TODO: revisit our layout assumptions based on our new ballots */
+  /* istanbul ignore next - TODO: revisit our layout assumptions based on our new ballots */
   if (writeInOptionIndex.isErr() || writeInOptions === undefined) {
     throw new Error('unable to interpret layout write-in options');
   }
 
   const writeInLayout = writeInOptions[writeInOptionIndex.ok()];
-  /* c8 ignore next 3 - TODO: revisit our layout assumptions based on our new ballots */
+  /* istanbul ignore next - TODO: revisit our layout assumptions based on our new ballots */
   if (writeInLayout === undefined) {
     throw new Error('unexpected write-in option index');
   }

--- a/apps/admin/backend/src/util/zip.ts
+++ b/apps/admin/backend/src/util/zip.ts
@@ -11,7 +11,7 @@ export function addFileToZipStream(
 ): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     zipStream.entry(file.contents, { name: file.path }, (error) => {
-      /* c8 ignore next 2 - trivial error case */
+      /* istanbul ignore next - trivial error case */
       if (error) {
         reject(error);
       } else {

--- a/apps/central-scan/backend/jest.config.js
+++ b/apps/central-scan/backend/jest.config.js
@@ -12,7 +12,7 @@ module.exports = {
   roots: ['<rootDir>/src'],
   setupFiles: ['<rootDir>/test/set_env_vars.ts'],
   setupFilesAfterEnv: ['<rootDir>/test/setup_custom_matchers.ts'],
-  coverageProvider: 'v8',
+  coverageProvider: 'babel',
   collectCoverageFrom: [
     '**/*.{ts,tsx}',
     '!**/node_modules/**',
@@ -23,10 +23,10 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      statements: 94,
-      branches: 86,
+      statements: 93,
+      branches: 81,
       functions: 91,
-      lines: 94,
+      lines: 93,
     },
   },
 };

--- a/apps/central-scan/backend/src/readiness_report.ts
+++ b/apps/central-scan/backend/src/readiness_report.ts
@@ -32,9 +32,8 @@ export async function saveReadinessReport({
   const { electionDefinition, electionPackageHash } =
     store.getElectionRecord() ?? {};
   const report = CentralScanReadinessReport({
-    /* c8 ignore start */
-    batteryInfo: (await getBatteryInfo()) ?? undefined,
-    /* c8 ignore stop */
+    batteryInfo:
+      (await getBatteryInfo()) ?? /* istanbul ignore next */ undefined,
     diskSpaceSummary: await workspace.getDiskSpaceSummary(),
     isScannerAttached,
     mostRecentScannerDiagnostic:

--- a/apps/central-scan/backend/src/server.ts
+++ b/apps/central-scan/backend/src/server.ts
@@ -45,7 +45,7 @@ export async function start({
 }: Partial<StartOptions> = {}): Promise<Server> {
   detectDevices({ logger: baseLogger });
   let resolvedWorkspace = workspace;
-  /* c8 ignore start */
+  /* istanbul ignore next */
   if (!resolvedWorkspace) {
     const workspacePath = SCAN_WORKSPACE;
     if (!workspacePath) {
@@ -60,14 +60,13 @@ export async function start({
     }
     resolvedWorkspace = createWorkspace(workspacePath, baseLogger);
   }
-  /* c8 ignore stop */
 
   // Clear any cached data
   resolvedWorkspace.clearUploads();
   resolvedWorkspace.store.cleanupIncompleteBatches();
 
   let resolvedApp = app;
-  /* c8 ignore start */
+  /* istanbul ignore next */
   if (!resolvedApp) {
     const auth = new DippedSmartCardAuth({
       card:
@@ -107,7 +106,6 @@ export async function start({
       workspace: resolvedWorkspace,
     });
   }
-  /* c8 ignore stop */
 
   return resolvedApp.listen(port, async () => {
     await baseLogger.log(LogEventId.ApplicationStartup, 'system', {

--- a/apps/scan/backend/jest.config.js
+++ b/apps/scan/backend/jest.config.js
@@ -12,7 +12,7 @@ module.exports = {
   roots: ['<rootDir>/src'],
   setupFiles: ['<rootDir>/test/set_env_vars.ts'],
   setupFilesAfterEnv: ['<rootDir>/test/setup_custom_matchers.ts'],
-  coverageProvider: 'v8',
+  coverageProvider: 'babel',
   collectCoverageFrom: [
     '**/*.{ts,tsx}',
     '!**/node_modules/**',
@@ -24,8 +24,8 @@ module.exports = {
   coverageThreshold: {
     global: {
       statements: -180,
-      branches: -60,
-      functions: -15,
+      branches: -83,
+      functions: -18,
       lines: -180,
     },
   },

--- a/apps/scan/backend/src/export.ts
+++ b/apps/scan/backend/src/export.ts
@@ -57,11 +57,10 @@ export async function exportCastVoteRecordsToUsbDrive({
       );
       break;
     }
-    /* c8 ignore start: Compile-time check for completeness */
+    /* istanbul ignore next: Compile-time check for completeness */
     default: {
       throwIllegalValue(mode);
     }
-    /* c8 ignore stop */
   }
 
   if (exportResult.isErr()) {

--- a/apps/scan/backend/src/scanners/custom/state_machine.ts
+++ b/apps/scan/backend/src/scanners/custom/state_machine.ts
@@ -1329,7 +1329,7 @@ export function createPrecinctScannerStateMachine({
               type: interpretation.type,
               reasons: interpretation.reasons,
             };
-          /* c8 ignore next 2 */
+          /* istanbul ignore next */
           default:
             throwIllegalValue(interpretation, 'type');
         }
@@ -1362,13 +1362,13 @@ export function createPrecinctScannerStateMachine({
       machineService.stop();
     },
 
-    /* c8 ignore start */
+    /* istanbul ignore next */
     beginDoubleFeedCalibration: () => {
       throw new Error('Not supported');
     },
+    /* istanbul ignore next */
     endDoubleFeedCalibration: () => {
       throw new Error('Not supported');
     },
-    /* c8 ignore stop */
   };
 }

--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -429,7 +429,7 @@ function buildMachine({
             cond: (_, { event }) => event.event === 'coverClosed',
             target: undefined,
           },
-          /* c8 ignore start - fallback case, shouldn't happen */
+          /* istanbul ignore next - fallback case, shouldn't happen */
           {
             target: '#error',
             actions: assign({
@@ -440,7 +440,6 @@ function buildMachine({
                 ),
             }),
           },
-          /* c8 ignore stop */
         ],
         SCANNER_ERROR: {
           target: 'error',
@@ -1018,7 +1017,7 @@ function setupLogging(
       }
     })
     .onChange(async (context, previousContext) => {
-      /* c8 ignore next */
+      /* istanbul ignore next */
       if (!previousContext) return;
       const changed = Object.entries(context).filter(
         ([key, value]) => previousContext[key as keyof Context] !== value
@@ -1148,7 +1147,7 @@ export function createPrecinctScannerStateMachine({
             return 'calibrating_double_feed_detection.done';
           case state.matches('shoeshineModeRescanningBallot'):
             return 'accepted';
-          /* c8 ignore next 2 */
+          /* istanbul ignore next */
           default:
             throw new Error(`Unexpected state: ${state.value}`);
         }
@@ -1172,7 +1171,7 @@ export function createPrecinctScannerStateMachine({
               type: interpretation.type,
               reasons: interpretation.reasons,
             };
-          /* c8 ignore next 2 */
+          /* istanbul ignore next */
           default:
             return throwIllegalValue(interpretation, 'type');
         }

--- a/apps/scan/backend/src/util/diagnostics.ts
+++ b/apps/scan/backend/src/util/diagnostics.ts
@@ -22,11 +22,11 @@ export function testPrintFailureDiagnosticMessage(
           return 'The printer experienced a data transmission error during printing.';
         case 'hardware':
           return 'The printer experienced an unknown hardware error during printing.';
-        /* c8 ignore next 2 */
+        /* istanbul ignore next */
         default:
           throwIllegalValue(failureStatus.type);
       }
-    /* c8 ignore next 3 */
+    /* istanbul ignore next */
     // eslint-disable-next-line no-fallthrough
     default:
       throwIllegalValue(failureStatus, 'state');

--- a/libs/custom-scanner/jest.config.js
+++ b/libs/custom-scanner/jest.config.js
@@ -12,5 +12,5 @@ module.exports = {
     '!src/mocks/**/*.ts',
     '!src/types/**/*.ts',
   ],
-  coverageProvider: 'v8',
+  coverageProvider: 'babel',
 };

--- a/libs/custom-scanner/src/custom_a4_scanner.ts
+++ b/libs/custom-scanner/src/custom_a4_scanner.ts
@@ -178,7 +178,7 @@ export class CustomA4Scanner implements CustomScanner {
         createJob(channel)
       );
 
-      /* c8 ignore start */
+      /* istanbul ignore next */
       if (createJobResult.isErr()) {
         const errorCode = createJobResult.err();
         debug('create job error: %o', errorCode);
@@ -193,7 +193,6 @@ export class CustomA4Scanner implements CustomScanner {
       } else {
         break;
       }
-      /* c8 ignore stop */
     }
 
     debug('create job result: %o', createJobResult);
@@ -273,9 +272,9 @@ export class CustomA4Scanner implements CustomScanner {
   scan(
     scanParameters: ScanParameters,
     {
-      /* c8 ignore next */
+      /* istanbul ignore next */
       maxTimeoutNoMoveNoScan = 5_000,
-      /* c8 ignore next */
+      /* istanbul ignore next */
       maxRetries = 3,
     }: { maxTimeoutNoMoveNoScan?: number; maxRetries?: number } = {}
   ): Promise<Result<SheetOf<ImageFromScanner>, ErrorCode>> {
@@ -349,7 +348,7 @@ export class CustomA4Scanner implements CustomScanner {
           const getImagePortionBySideResult =
             await this.getImagePortionBySideInternal(currentSide, pageSize);
 
-          /* c8 ignore start */
+          /* istanbul ignore next */
           if (getImagePortionBySideResult.isErr()) {
             readImageDataErrorCount += 1;
             if (readImageDataErrorCount < maxRetries) {
@@ -359,7 +358,6 @@ export class CustomA4Scanner implements CustomScanner {
 
             return getImagePortionBySideResult;
           }
-          /* c8 ignore stop */
 
           scannerImage.imageBuffer = Buffer.concat([
             scannerImage.imageBuffer,
@@ -421,10 +419,10 @@ export class CustomA4Scanner implements CustomScanner {
             debug('waiting for motor on and scan in progress timed out');
             void (await this.stopScanInternal());
             return err(ErrorCode.ScannerError);
-          } /* c8 ignore start */ else {
+          } /* istanbul ignore else */ else {
             /* this branch often does not run during tests in CircleCI */
             debug('still waiting for motor on and scan in progress');
-          } /* c8 ignore stop */
+          }
         } else {
           startNoMoveNoScan = 0;
         }
@@ -468,7 +466,7 @@ export class CustomA4Scanner implements CustomScanner {
           ).okOrElse(fail);
         }
 
-        /* c8 ignore start */
+        /* istanbul ignore next */
         if (
           status.isScanInProgress &&
           a4Status.pageSizeSideA === 0 &&
@@ -476,7 +474,6 @@ export class CustomA4Scanner implements CustomScanner {
         ) {
           debug('scan in progress but no data available');
         }
-        /* c8 ignore stop */
 
         return ok('continue');
       };
@@ -488,7 +485,7 @@ export class CustomA4Scanner implements CustomScanner {
         for (;;) {
           const action = (await scanLoopTick()).okOrElse(fail);
 
-          /* c8 ignore start */
+          /* istanbul ignore next */
           if (action === 'continue') {
             continue;
           } else if (action === 'break') {
@@ -496,7 +493,6 @@ export class CustomA4Scanner implements CustomScanner {
           } else {
             throwIllegalValue(action);
           }
-          /* c8 ignore stop */
         }
       } finally {
         unlock();
@@ -518,11 +514,10 @@ export class CustomA4Scanner implements CustomScanner {
     scanSide: ScanSide,
     imagePortionSize: number
   ): Promise<Result<Buffer, ErrorCode>> {
-    /* c8 ignore start */
+    /* istanbul ignore next */
     if (imagePortionSize === 0) {
       return ok(Buffer.alloc(0));
     }
-    /* c8 ignore stop */
 
     return await this.channelMutex.withLock((channel) =>
       getImageData(

--- a/libs/custom-scanner/src/mocks/coder.ts
+++ b/libs/custom-scanner/src/mocks/coder.ts
@@ -4,11 +4,10 @@
 
 import { Coder } from '@votingworks/message-coder';
 
-/* c8 ignore start */
+/* istanbul ignore next */
 function notImplemented() {
   throw new Error('not implemented');
 }
-/* c8 ignore stop */
 
 /**
  * Creates a mock coder.

--- a/libs/custom-scanner/src/mocks/protocol.ts
+++ b/libs/custom-scanner/src/mocks/protocol.ts
@@ -111,7 +111,7 @@ export function usbChannelWithMockProtocol({
   function setNextReadBuffer(buffer: Buffer | Result<Buffer, unknown>): void {
     const newBuffer = Buffer.isBuffer(buffer) ? buffer : buffer.unsafeUnwrap();
 
-    /* c8 ignore start */
+    /* istanbul ignore next */
     if (readBuffer) {
       throw new Error(
         `read buffer already set: ${inspect(
@@ -119,7 +119,6 @@ export function usbChannelWithMockProtocol({
         )}, cannot use new buffer: ${inspect(newBuffer.toString())}`
       );
     }
-    /* c8 ignore stop */
 
     readBuffer = Buffer.isBuffer(buffer) ? buffer : buffer.unsafeUnwrap();
   }

--- a/libs/custom-scanner/src/parameters.ts
+++ b/libs/custom-scanner/src/parameters.ts
@@ -52,7 +52,7 @@ function convertToMultiSheetDetectionSensorLevelInternal(
       return MultiSheetDetectionSensorLevelInternal.Level3;
     case DoubleSheetDetectOpt.Level4:
       return MultiSheetDetectionSensorLevelInternal.Level4;
-    /* c8 ignore next 2 */
+    /* istanbul ignore next */
     default:
       throwIllegalValue(option);
   }

--- a/libs/custom-scanner/src/protocol.ts
+++ b/libs/custom-scanner/src/protocol.ts
@@ -667,7 +667,7 @@ class GetImageDataRequestScanSideCoder extends BaseCoder<ScanSide> {
         case GetImageDataRequestScanSideCoder.SideB:
           return { value: ScanSide.B, bitOffset: decoded.bitOffset };
 
-        /* c8 ignore next 2 */
+        /* istanbul ignore next */
         default:
           return err('InvalidValue');
       }
@@ -819,7 +819,7 @@ export function checkAnswer(data: Buffer): CheckAnswerResult {
       case ResponseErrorCode.INVALID_JOB_ID:
         return { type: 'error', errorCode: ErrorCode.JobNotValid };
 
-      /* c8 ignore next 2 */
+      /* istanbul ignore next */
       default:
         throwIllegalValue(errorCode);
     }
@@ -856,7 +856,7 @@ function mapCoderError<T>(result: Result<T, CoderError>): Result<T, ErrorCode> {
     case 'UnsupportedOffset':
       throw new Error(`BUG: unsupported offset`);
 
-    /* c8 ignore next 2 */
+    /* istanbul ignore next */
     default:
       throwIllegalValue(coderError);
   }

--- a/libs/custom-scanner/src/usb_channel.ts
+++ b/libs/custom-scanner/src/usb_channel.ts
@@ -9,13 +9,12 @@ const debug = makeDebug('custom:usb-channel');
 const READ_RETRY_MAX = 5;
 const WRITE_RETRY_MAX = 3;
 
-/* c8 ignore start */
+/* istanbul ignore next */
 function truncateStringForDisplay(string: string, maxLength = 100): string {
   return string.length > maxLength
     ? `${string.slice(0, maxLength - 1)}…`
     : string;
 }
-/* c8 ignore stop */
 
 /**
  * Options for building a `UsbChannel`.

--- a/libs/pdi-scanner/jest.config.js
+++ b/libs/pdi-scanner/jest.config.js
@@ -10,5 +10,5 @@ module.exports = {
     '!src/ts/index.ts',
     '!src/ts/demo.ts',
   ],
-  coverageProvider: 'v8',
+  coverageProvider: 'babel',
 };

--- a/libs/pdi-scanner/src/ts/scanner_client.ts
+++ b/libs/pdi-scanner/src/ts/scanner_client.ts
@@ -282,17 +282,19 @@ export function createPdiScannerClient() {
         emit(message);
         break;
       }
-      /* c8 ignore start */
+      /* istanbul ignore next */
       default:
         throwIllegalValue(message, 'event');
-      /* c8 ignore stop */
     }
   });
 
-  pdictl.stderr.on('data', (data) => {
-    /* c8 ignore next */
-    debug('pdictl stderr:', data.toString('utf-8'));
-  });
+  pdictl.stderr.on(
+    'data',
+    /* istanbul ignore next */
+    (data) => {
+      debug('pdictl stderr:', data.toString('utf-8'));
+    }
+  );
 
   pdictl.on('close', (code) => {
     pdictlIsClosed = true;

--- a/libs/utils/jest.config.js
+++ b/libs/utils/jest.config.js
@@ -7,10 +7,10 @@ module.exports = {
   ...shared,
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
-  coverageProvider: 'v8',
+  coverageProvider: 'babel',
   coverageThreshold: {
     global: {
-      branches: -30,
+      branches: -42,
       lines: -123,
     },
   },

--- a/libs/utils/src/cast_vote_records.ts
+++ b/libs/utils/src/cast_vote_records.ts
@@ -222,7 +222,7 @@ function getValidContestOptions(contest: AnyContest): ContestOptionId[] {
       ];
     case 'yesno':
       return [contest.yesOption.id, contest.noOption.id];
-    /* c8 ignore next 2 */
+    /* istanbul ignore next */
     default:
       return throwIllegalValue(contest);
   }

--- a/libs/utils/src/compressed_tallies.ts
+++ b/libs/utils/src/compressed_tallies.ts
@@ -48,7 +48,7 @@ export function compressTally(
         ]);
       }
 
-      /* c8 ignore next 2 */
+      /* istanbul ignore next */
       default:
         throwIllegalValue(contest, 'type');
     }
@@ -118,7 +118,7 @@ function getContestTalliesForCompressedContest(
         tallies: candidateTallies,
       };
     }
-    /* c8 ignore next 2 */
+    /* istanbul ignore next */
     default:
       throwIllegalValue(contest, 'type');
   }

--- a/libs/utils/src/environment_variable.ts
+++ b/libs/utils/src/environment_variable.ts
@@ -161,7 +161,7 @@ export function getEnvironmentVariable(
       return process.env.REACT_APP_VX_ONLY_ENABLE_SCREEN_READER_FOR_HEADPHONES;
     case BooleanEnvironmentVariableName.MARK_SCAN_DISABLE_BALLOT_REINSERTION:
       return process.env.REACT_APP_VX_MARK_SCAN_DISABLE_BALLOT_REINSERTION;
-    /* c8 ignore next 2 */
+    /* istanbul ignore next */
     default:
       throwIllegalValue(name);
   }
@@ -286,7 +286,7 @@ export function getBooleanEnvVarConfig(
         allowInProduction: true,
         autoEnableInDevelopment: false,
       };
-    /* c8 ignore next 2 */
+    /* istanbul ignore next */
     default:
       throwIllegalValue(name);
   }
@@ -302,7 +302,7 @@ export function getStringEnvVarConfig(
         defaultValue: 'ms-sems',
         zodSchema: ConverterClientTypeSchema,
       };
-    /* c8 ignore next 2 */
+    /* istanbul ignore next */
     default:
       throwIllegalValue(name);
   }

--- a/libs/utils/src/file_reading.ts
+++ b/libs/utils/src/file_reading.ts
@@ -19,11 +19,11 @@ export function readFile(file: File): Promise<Buffer> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
 
-    /* c8 ignore start */
-    reader.onerror = () => {
-      reject(reader.error);
-    };
-    /* c8 ignore stop */
+    reader.onerror =
+      /* istanbul ignore next */
+      () => {
+        reject(reader.error);
+      };
 
     reader.onload = () => {
       if (!reader.result) {

--- a/libs/utils/src/filenames.ts
+++ b/libs/utils/src/filenames.ts
@@ -95,7 +95,7 @@ export function generateLogFilename(
       return `${logFileName}${SUBSECTION_SEPARATOR}${timeSuffix}.log`;
     case LogFileType.Cdf:
       return `${logFileName}${WORD_SEPARATOR}cdf${SUBSECTION_SEPARATOR}${timeSuffix}.json`;
-    /* c8 ignore next 2 */
+    /* istanbul ignore next */
     default:
       throwIllegalValue(fileType);
   }

--- a/libs/utils/src/hmpb/all_contest_options.ts
+++ b/libs/utils/src/hmpb/all_contest_options.ts
@@ -69,7 +69,7 @@ export function* allContestOptions(
       break;
     }
 
-    /* c8 ignore next 2 */
+    /* istanbul ignore next */
     default:
       throwIllegalValue(contest, 'type');
   }

--- a/libs/utils/src/polls.ts
+++ b/libs/utils/src/polls.ts
@@ -16,7 +16,7 @@ export function getPollsTransitionDestinationState(
       return 'polls_paused';
     case 'close_polls':
       return 'polls_closed_final';
-    /* c8 ignore next 2 */
+    /* istanbul ignore next */
     default:
       throwIllegalValue(transitionType);
   }
@@ -34,7 +34,7 @@ export function getPollsTransitionAction(
       return 'Resume Voting';
     case 'close_polls':
       return 'Close Polls';
-    /* c8 ignore next 2 */
+    /* istanbul ignore next */
     default:
       throwIllegalValue(transitionType);
   }
@@ -52,7 +52,7 @@ export function getPollsReportTitle(
       return 'Voting Paused Report';
     case 'close_polls':
       return 'Polls Closed Report';
-    /* c8 ignore next 2 */
+    /* istanbul ignore next */
     default:
       throwIllegalValue(transitionType);
   }
@@ -67,7 +67,7 @@ export function getPollsStateName(state: PollsState): string {
     case 'polls_closed_initial':
     case 'polls_closed_final':
       return 'Closed';
-    /* c8 ignore next 2 */
+    /* istanbul ignore next */
     default:
       throwIllegalValue(state);
   }
@@ -89,7 +89,7 @@ export function getPollTransitionsFromState(
       return ['open_polls'];
     case 'polls_closed_final':
       return [];
-    /* c8 ignore next 2 */
+    /* istanbul ignore next */
     default:
       throwIllegalValue(state);
   }
@@ -110,7 +110,7 @@ export function isValidPollsStateChange(
       return newState === 'polls_open' || newState === 'polls_closed_final';
     case 'polls_closed_final':
       return false;
-    /* c8 ignore next 2 */
+    /* istanbul ignore next */
     default:
       throwIllegalValue(prevState);
   }
@@ -127,7 +127,7 @@ export function getPollsTransitionActionPastTense(
       return 'Voting Resumed';
     case 'pause_voting':
       return 'Voting Paused';
-    /* c8 ignore next 2 */
+    /* istanbul ignore next */
     default:
       throwIllegalValue(transitionType);
   }
@@ -143,7 +143,7 @@ export function isPollsSuspensionTransition(
     case 'resume_voting':
     case 'pause_voting':
       return true;
-    /* c8 ignore next 2 */
+    /* istanbul ignore next */
     default:
       throwIllegalValue(transitionType);
   }

--- a/libs/utils/src/tabulation/tabulation.ts
+++ b/libs/utils/src/tabulation/tabulation.ts
@@ -354,7 +354,7 @@ export function getGroupSpecifierFromGroupKey(
           value
         ) as Tabulation.VotingMethod;
         break;
-      /* c8 ignore next 2 */
+      /* istanbul ignore next */
       default:
         throwIllegalValue(key);
     }

--- a/libs/utils/src/votes.ts
+++ b/libs/utils/src/votes.ts
@@ -153,7 +153,7 @@ export function convertMarksToVotesDict(
         ? markToCandidateVotes(contest, markThresholds, mark)
         : contest.type === 'yesno'
         ? markToYesNoVotes(markThresholds, mark)
-        : /* c8 ignore next */
+        : /* istanbul ignore next */
           throwIllegalValue(contest, 'type');
 
     votesDict[mark.contestId] = [...existingVotes, ...newVotes] as Vote;


### PR DESCRIPTION
## Overview

Prepping for a Node upgrade, 16 -> (hopefully) 20 and `v8` coverage breaks in v20 (https://github.com/nodejs/node/issues/51251). Moving back to the `babel` coverage provider in packages that we previously moved to `v8`

Had to do some minor refactoring in a few cases to be able to mark the right blocks with `istanbul ignore`, but no functional changes.