### PR TITLE
Add various logs

### DIFF
--- a/apps/central-scan/backend/src/app.grout.test.ts
+++ b/apps/central-scan/backend/src/app.grout.test.ts
@@ -126,7 +126,7 @@ test('getElectionDefinition', async () => {
       electionPackageHash,
     });
 
-    importer.unconfigure();
+    await importer.unconfigure();
     expect(await apiClient.getElectionRecord()).toEqual(null);
   });
 });
@@ -220,16 +220,15 @@ test('clearing scanning data', async () => {
     await apiClient.clearBallotData();
     expect(store.getBallotsCounted()).toEqual(0);
     expect(logger.log).toHaveBeenNthCalledWith(
-      5,
+      4,
       LogEventId.ClearingBallotData,
       'unknown',
       {
-        message: 'Removing all ballot data, clearing 1 ballots...',
-        currentNumberOfBallots: 1,
+        message: 'Removing all ballot data...',
       }
     );
     expect(logger.log).toHaveBeenNthCalledWith(
-      6,
+      5,
       LogEventId.ClearedBallotData,
       'unknown',
       {

--- a/apps/central-scan/backend/src/app.ts
+++ b/apps/central-scan/backend/src/app.ts
@@ -94,7 +94,7 @@ function buildApi({
       await logger.logAsCurrentRole(LogEventId.TogglingTestMode, {
         message: `Toggling to ${testMode ? 'Test' : 'Official'} Ballot Mode...`,
       });
-      importer.setTestMode(testMode);
+      await importer.setTestMode(testMode);
       await logger.logAsCurrentRole(LogEventId.ToggledTestMode, {
         disposition: 'success',
         message: `Successfully toggled to ${
@@ -224,7 +224,7 @@ function buildApi({
       // frontend should only allow this call if the machine can be unconfigured
       assert(store.getCanUnconfigure() || input.ignoreBackupRequirement);
 
-      importer.unconfigure();
+      await importer.unconfigure();
       await logger.logAsCurrentRole(LogEventId.ElectionUnconfigured, {
         disposition: 'success',
         message:
@@ -233,20 +233,10 @@ function buildApi({
     },
 
     async clearBallotData(): Promise<void> {
-      const currentNumberOfBallots = store.getBallotsCounted();
-
       // frontend should only allow this call if the machine can be unconfigured
       assert(store.getCanUnconfigure());
 
-      await logger.logAsCurrentRole(LogEventId.ClearingBallotData, {
-        message: `Removing all ballot data, clearing ${currentNumberOfBallots} ballots...`,
-        currentNumberOfBallots,
-      });
-      importer.doZero();
-      await logger.logAsCurrentRole(LogEventId.ClearedBallotData, {
-        disposition: 'success',
-        message: 'Successfully cleared all ballot data.',
-      });
+      await importer.doZero();
     },
 
     async exportCastVoteRecordsToUsbDrive(input: {

--- a/apps/central-scan/backend/src/importer.ts
+++ b/apps/central-scan/backend/src/importer.ts
@@ -11,7 +11,7 @@ import * as fsExtra from 'fs-extra';
 import { join } from 'path';
 import { v4 as uuid } from 'uuid';
 import { interpretSheetAndSaveImages } from '@votingworks/ballot-interpreter';
-import { Logger } from '@votingworks/logging';
+import { LogEventId, Logger } from '@votingworks/logging';
 import { ImageData } from 'canvas';
 import { loadImageData } from '@votingworks/image-utils';
 import {
@@ -68,9 +68,9 @@ export class Importer {
     this.workspace.store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
   }
 
-  setTestMode(testMode: boolean): void {
+  async setTestMode(testMode: boolean): Promise<void> {
     debug('setting test mode to %s', testMode);
-    this.doZero();
+    await this.doZero();
     this.workspace.store.setTestMode(testMode);
   }
 
@@ -375,8 +375,15 @@ export class Importer {
   /**
    * Reset all the data, both in the store and the ballot images.
    */
-  doZero(): void {
+  async doZero(): Promise<void> {
+    await this.logger.logAsCurrentRole(LogEventId.ClearingBallotData, {
+      message: `Removing all ballot data...`,
+    });
     this.workspace.resetElectionSession();
+    await this.logger.logAsCurrentRole(LogEventId.ClearedBallotData, {
+      disposition: 'success',
+      message: 'Successfully cleared all ballot data.',
+    });
   }
 
   /**
@@ -396,8 +403,8 @@ export class Importer {
   /**
    * Resets all data like `doZero`, removes election info, and stops importing.
    */
-  unconfigure(): void {
-    this.doZero();
+  async unconfigure(): Promise<void> {
+    await this.doZero();
     this.workspace.store.reset(); // destroy all data
   }
 

--- a/apps/mark-scan/backend/src/app.test.ts
+++ b/apps/mark-scan/backend/src/app.test.ts
@@ -388,12 +388,22 @@ test('test mode', async () => {
   await setUpUsbAndConfigureElection(
     electionFamousNames2021Fixtures.electionDefinition
   );
+  expect(logger.logAsCurrentRole).toHaveBeenCalledTimes(1);
 
   await apiClient.setTestMode({ isTestMode: false });
   await expectElectionState({ isTestMode: false });
+  expect(logger.logAsCurrentRole).toHaveBeenCalledTimes(3);
+  expect(logger.logAsCurrentRole).toHaveBeenLastCalledWith(
+    LogEventId.ToggledTestMode,
+    {
+      disposition: 'success',
+      message: expect.anything(),
+    }
+  );
 
   await apiClient.setTestMode({ isTestMode: true });
   await expectElectionState({ isTestMode: true });
+  expect(logger.logAsCurrentRole).toHaveBeenCalledTimes(5);
 });
 
 test('setting precinct', async () => {

--- a/apps/mark-scan/backend/src/app.test.ts
+++ b/apps/mark-scan/backend/src/app.test.ts
@@ -398,6 +398,7 @@ test('test mode', async () => {
     {
       disposition: 'success',
       message: expect.anything(),
+      isTestMode: false,
     }
   );
 

--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -380,10 +380,20 @@ export function buildApi(
       await logger.logAsCurrentRole(logEvent, { disposition: 'success' });
     },
 
-    setTestMode(input: { isTestMode: boolean }) {
+    async setTestMode(input: { isTestMode: boolean }) {
+      const logMessage = input.isTestMode
+        ? 'official to test'
+        : 'test to official';
+      await logger.logAsCurrentRole(LogEventId.TogglingTestMode, {
+        message: `Toggling from ${logMessage} mode`,
+      });
       store.setTestMode(input.isTestMode);
       store.setPollsState('polls_closed_initial');
       store.setBallotsPrintedCount(0);
+      await logger.logAsCurrentRole(LogEventId.ToggledTestMode, {
+        disposition: 'success',
+        message: `Successfully toggled from ${logMessage} mode.`,
+      });
     },
 
     async setPrecinctSelection(input: {

--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -386,6 +386,7 @@ export function buildApi(
         : 'test to official';
       await logger.logAsCurrentRole(LogEventId.TogglingTestMode, {
         message: `Toggling from ${logMessage} mode`,
+        isTestMode: input.isTestMode,
       });
       store.setTestMode(input.isTestMode);
       store.setPollsState('polls_closed_initial');
@@ -393,6 +394,7 @@ export function buildApi(
       await logger.logAsCurrentRole(LogEventId.ToggledTestMode, {
         disposition: 'success',
         message: `Successfully toggled from ${logMessage} mode.`,
+        isTestMode: input.isTestMode,
       });
     },
 

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -248,16 +248,28 @@ export function buildApi({
       });
     },
 
-    setIsSoundMuted(input: { isSoundMuted: boolean }): void {
+    async setIsSoundMuted(input: { isSoundMuted: boolean }): Promise<void> {
       store.setIsSoundMuted(input.isSoundMuted);
+      await logger.logAsCurrentRole(LogEventId.SoundToggled, {
+        message: `Sounds were toggled ${input.isSoundMuted ? 'off' : 'on'}`,
+        disposition: 'success',
+        isSoundMuted: input.isSoundMuted,
+      });
     },
 
-    setIsDoubleFeedDetectionDisabled(input: {
+    async setIsDoubleFeedDetectionDisabled(input: {
       isDoubleFeedDetectionDisabled: boolean;
-    }): void {
+    }): Promise<void> {
       store.setIsDoubleFeedDetectionDisabled(
         input.isDoubleFeedDetectionDisabled
       );
+      await logger.logAsCurrentRole(LogEventId.DoubleSheetDetectionToggled, {
+        message: `Double sheet detection was toggled ${
+          input.isDoubleFeedDetectionDisabled ? 'off' : 'on'
+        }`,
+        disposition: 'success',
+        isDoubleFeedDetectionDisabled: input.isDoubleFeedDetectionDisabled,
+      });
     },
 
     async setTestMode(input: { isTestMode: boolean }): Promise<void> {

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -261,12 +261,24 @@ export function buildApi({
     },
 
     async setTestMode(input: { isTestMode: boolean }): Promise<void> {
+      const logMessage = input.isTestMode
+        ? 'official to test'
+        : 'test to official';
+      await logger.logAsCurrentRole(LogEventId.TogglingTestMode, {
+        message: `Toggling from ${logMessage} mode`,
+        isTestMode: input.isTestMode,
+      });
       // Use the continuous export mutex to ensure that any pending continuous export operations
       // finish first
       await workspace.continuousExportMutex.withLock(() =>
         workspace.resetElectionSession()
       );
       store.setTestMode(input.isTestMode);
+      await logger.logAsCurrentRole(LogEventId.ToggledTestMode, {
+        disposition: 'success',
+        message: `Successfully toggled from ${logMessage} mode.`,
+        isTestMode: input.isTestMode,
+      });
     },
 
     async openPolls(): Promise<OpenPollsResult> {

--- a/apps/scan/backend/src/app_config.test.ts
+++ b/apps/scan/backend/src/app_config.test.ts
@@ -223,11 +223,40 @@ test('setTestMode false will reset polls to closed', async () => {
       {
         disposition: 'success',
         message: expect.anything(),
+        isTestMode: false,
       }
     );
     expect(await apiClient.getPollsInfo()).toEqual<PrecinctScannerPollsInfo>({
       pollsState: 'polls_closed_initial',
     });
+  });
+});
+
+test('setIsSoundMuted logs', async () => {
+  await withApp(async ({ apiClient, mockUsbDrive, mockAuth, logger }) => {
+    await configureApp(apiClient, mockAuth, mockUsbDrive);
+    expect(await apiClient.getConfig()).toMatchObject(
+      expect.objectContaining({
+        isSoundMuted: false,
+      })
+    );
+
+    await apiClient.setIsSoundMuted({
+      isSoundMuted: true,
+    });
+    expect(logger.logAsCurrentRole).toHaveBeenLastCalledWith(
+      LogEventId.SoundToggled,
+      {
+        disposition: 'success',
+        message: expect.anything(),
+        isSoundMuted: true,
+      }
+    );
+    expect(await apiClient.getConfig()).toMatchObject(
+      expect.objectContaining({
+        isSoundMuted: true,
+      })
+    );
   });
 });
 

--- a/apps/scan/backend/src/app_config.test.ts
+++ b/apps/scan/backend/src/app_config.test.ts
@@ -200,6 +200,37 @@ test('setPrecinctSelection will reset polls to closed', async () => {
   });
 });
 
+test('setTestMode false will reset polls to closed', async () => {
+  await withApp(async ({ apiClient, mockUsbDrive, mockAuth, logger }) => {
+    await configureApp(apiClient, mockAuth, mockUsbDrive);
+
+    expect(await apiClient.getPollsInfo()).toEqual<PrecinctScannerPollsInfo>({
+      pollsState: 'polls_open',
+      lastPollsTransition: {
+        type: 'open_polls',
+        time: expect.anything(),
+        ballotCount: 0,
+      },
+    });
+
+    expect(logger.logAsCurrentRole).toHaveBeenCalledTimes(5);
+    await apiClient.setTestMode({
+      isTestMode: false,
+    });
+    expect(logger.logAsCurrentRole).toHaveBeenCalledTimes(7);
+    expect(logger.logAsCurrentRole).toHaveBeenLastCalledWith(
+      LogEventId.ToggledTestMode,
+      {
+        disposition: 'success',
+        message: expect.anything(),
+      }
+    );
+    expect(await apiClient.getPollsInfo()).toEqual<PrecinctScannerPollsInfo>({
+      pollsState: 'polls_closed_initial',
+    });
+  });
+});
+
 test('unconfiguring machine', async () => {
   await withApp(
     async ({ apiClient, mockUsbDrive, workspace, mockAuth, logger }) => {

--- a/apps/scan/backend/src/scanners/pdi/pdi_app_scan_double_sheet.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_scan_double_sheet.test.ts
@@ -15,6 +15,7 @@ import {
   mockOf,
   mockSessionExpiresAt,
 } from '@votingworks/test-utils';
+import { LogEventId } from '@votingworks/logging';
 import {
   ballotImages,
   mockStatus,
@@ -379,11 +380,26 @@ test('insert two sheets at once - scanComplete event', async () => {
 
 test('disabling double feed detection', async () => {
   await withApp(
-    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
+    async ({
+      apiClient,
+      mockScanner,
+      mockUsbDrive,
+      mockAuth,
+      clock,
+      logger,
+    }) => {
       await configureApp(apiClient, mockAuth, mockUsbDrive);
       await apiClient.setIsDoubleFeedDetectionDisabled({
         isDoubleFeedDetectionDisabled: true,
       });
+      expect(logger.logAsCurrentRole).toHaveBeenLastCalledWith(
+        LogEventId.DoubleSheetDetectionToggled,
+        {
+          message: expect.anything(),
+          disposition: 'success',
+          isDoubleFeedDetectionDisabled: true,
+        }
+      );
 
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
       await waitForStatus(apiClient, { state: 'no_paper' });

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -98,6 +98,14 @@ IDs are logged with each log to identify the log being written.
 **Type:** [application-status](#application-status)  
 **Description:** Message from the backend service about how it is configured while starting up.  
 **Machines:** All
+### toggle-test-mode-init
+**Type:** [user-action](#user-action)  
+**Description:** User has initiated toggling between test mode and live mode in the current application.  
+**Machines:** All
+### toggled-test-mode
+**Type:** [user-action](#user-action)  
+**Description:** User has finished toggling between live mode and test mode in the given application. Success or failure is indicated by the disposition.  
+**Machines:** All
 ### file-saved
 **Type:** [user-action](#user-action)  
 **Description:** File is saved to a USB drive. Success or failure indicated by disposition. Type of file specified with "fileType" key. For success logs the saved filename specified with "filename" key.  
@@ -302,14 +310,6 @@ IDs are logged with each log to identify the log being written.
 **Type:** [user-action](#user-action)  
 **Description:** User adjudicated a write-in.  
 **Machines:** vx-admin
-### toggle-test-mode-init
-**Type:** [user-action](#user-action)  
-**Description:** User has initiated toggling between test mode and live mode in the current application.  
-**Machines:** vx-central-scan
-### toggled-test-mode
-**Type:** [user-action](#user-action)  
-**Description:** User has finished toggling between live mode and test mode in the given application. Success or failure is indicated by the disposition.  
-**Machines:** vx-central-scan
 ### clear-ballot-data-init
 **Type:** [user-action](#user-action)  
 **Description:** User has initiated clearing ballot data in the current application.  
@@ -417,6 +417,14 @@ IDs are logged with each log to identify the log being written.
 ### scanner-state-machine-transition
 **Type:** [application-status](#application-status)  
 **Description:** Precinct scanner state machine transitioned states.  
+**Machines:** vx-scan
+### sound-toggled
+**Type:** [application-status](#application-status)  
+**Description:** Sounds on the precinct scanner were toggled on or off as indicated.  
+**Machines:** vx-scan
+### double-sheet-toggled
+**Type:** [application-status](#application-status)  
+**Description:** Double sheet detection toggled on or off as indicated.  
 **Machines:** vx-scan
 ### mark-scan-state-machine-event
 **Type:** [system-status](#system-status)  

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -113,6 +113,16 @@ eventType = "application-status"
 documentationMessage = "Message from the backend service about how it is configured while starting up."
 
 # General logs that are not specific to any application
+[TogglingTestMode]
+eventId = "toggle-test-mode-init"
+eventType = "user-action"
+documentationMessage = "User has initiated toggling between test mode and live mode in the current application."
+
+[ToggledTestMode]
+eventId = "toggled-test-mode"
+eventType = "user-action"
+documentationMessage = "User has finished toggling between live mode and test mode in the given application. Success or failure is indicated by the disposition."
+
 [FileSaved]
 eventId = "file-saved"
 eventType = "user-action"
@@ -391,18 +401,6 @@ documentationMessage = "User adjudicated a write-in."
 restrictInDocumentationToApps = ["vx-admin"]
 
 # VxCentralScan-specific user action logs
-[TogglingTestMode]
-eventId = "toggle-test-mode-init"
-eventType = "user-action"
-documentationMessage = "User has initiated toggling between test mode and live mode in the current application."
-restrictInDocumentationToApps = ["vx-central-scan"]
-
-[ToggledTestMode]
-eventId = "toggled-test-mode"
-eventType = "user-action"
-documentationMessage = "User has finished toggling between live mode and test mode in the given application. Success or failure is indicated by the disposition."
-restrictInDocumentationToApps = ["vx-central-scan"]
-
 [ClearingBallotData]
 eventId = "clear-ballot-data-init"
 eventType = "user-action"

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -568,6 +568,18 @@ eventType = "application-status"
 documentationMessage = "Precinct scanner state machine transitioned states."
 restrictInDocumentationToApps = ["vx-scan"]
 
+[SoundToggled]
+eventId = "sound-toggled"
+eventType = "application-status"
+documentationMessage = "Sounds on the precinct scanner were toggled on or off as indicated."
+restrictInDocumentationToApps = ["vx-scan"]
+
+[DoubleSheetDetectionToggled]
+eventId = "double-sheet-toggled"
+eventType = "application-status"
+documentationMessage = "Double sheet detection toggled on or off as indicated."
+restrictInDocumentationToApps = ["vx-scan"]
+
 # VxMarkScan specific logs
 [MarkScanStateMachineEvent]
 eventId = "mark-scan-state-machine-event"

--- a/libs/logging/src/log_event_ids.ts
+++ b/libs/logging/src/log_event_ids.ts
@@ -33,6 +33,8 @@ export enum LogEventId {
   DeviceAttached = 'device-attached',
   DeviceUnattached = 'device-unattached',
   WorkspaceConfigurationMessage = 'workspace-config',
+  TogglingTestMode = 'toggle-test-mode-init',
+  ToggledTestMode = 'toggled-test-mode',
   FileSaved = 'file-saved',
   LogConversionToCdfComplete = 'convert-log-cdf-complete',
   LogConversionToCdfLogLineError = 'convert-log-cdf-log-line-error',
@@ -84,8 +86,6 @@ export enum LogEventId {
   ElectionReportPreviewed = 'election-report-previewed',
   ElectionReportPrinted = 'election-report-printed',
   WriteInAdjudicated = 'write-in-adjudicated',
-  TogglingTestMode = 'toggle-test-mode-init',
-  ToggledTestMode = 'toggled-test-mode',
   ClearingBallotData = 'clear-ballot-data-init',
   ClearedBallotData = 'clear-ballot-data-complete',
   DeleteScanBatchInit = 'delete-cvr-batch-init',
@@ -113,6 +113,8 @@ export enum LogEventId {
   ScannerBatchEnded = 'scanner-batch-ended',
   ScannerEvent = 'scanner-state-machine-event',
   ScannerStateChanged = 'scanner-state-machine-transition',
+  SoundToggled = 'sound-toggled',
+  DoubleSheetDetectionToggled = 'double-sheet-toggled',
   MarkScanStateMachineEvent = 'mark-scan-state-machine-event',
   PatDeviceError = 'pat-device-error',
   PaperHandlerStateChanged = 'paper-handler-state-machine-transition',
@@ -282,6 +284,20 @@ const WorkspaceConfigurationMessage: LogDetails = {
   eventType: LogEventType.ApplicationStatus,
   documentationMessage:
     'Message from the backend service about how it is configured while starting up.',
+};
+
+const TogglingTestMode: LogDetails = {
+  eventId: LogEventId.TogglingTestMode,
+  eventType: LogEventType.UserAction,
+  documentationMessage:
+    'User has initiated toggling between test mode and live mode in the current application.',
+};
+
+const ToggledTestMode: LogDetails = {
+  eventId: LogEventId.ToggledTestMode,
+  eventType: LogEventType.UserAction,
+  documentationMessage:
+    'User has finished toggling between live mode and test mode in the given application. Success or failure is indicated by the disposition.',
 };
 
 const FileSaved: LogDetails = {
@@ -633,22 +649,6 @@ const WriteInAdjudicated: LogDetails = {
   restrictInDocumentationToApps: [AppName.VxAdmin],
 };
 
-const TogglingTestMode: LogDetails = {
-  eventId: LogEventId.TogglingTestMode,
-  eventType: LogEventType.UserAction,
-  documentationMessage:
-    'User has initiated toggling between test mode and live mode in the current application.',
-  restrictInDocumentationToApps: [AppName.VxCentralScan],
-};
-
-const ToggledTestMode: LogDetails = {
-  eventId: LogEventId.ToggledTestMode,
-  eventType: LogEventType.UserAction,
-  documentationMessage:
-    'User has finished toggling between live mode and test mode in the given application. Success or failure is indicated by the disposition.',
-  restrictInDocumentationToApps: [AppName.VxCentralScan],
-};
-
 const ClearingBallotData: LogDetails = {
   eventId: LogEventId.ClearingBallotData,
   eventType: LogEventType.UserAction,
@@ -879,6 +879,22 @@ const ScannerStateChanged: LogDetails = {
   restrictInDocumentationToApps: [AppName.VxScan],
 };
 
+const SoundToggled: LogDetails = {
+  eventId: LogEventId.SoundToggled,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage:
+    'Sounds on the precinct scanner were toggled on or off as indicated.',
+  restrictInDocumentationToApps: [AppName.VxScan],
+};
+
+const DoubleSheetDetectionToggled: LogDetails = {
+  eventId: LogEventId.DoubleSheetDetectionToggled,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage:
+    'Double sheet detection toggled on or off as indicated.',
+  restrictInDocumentationToApps: [AppName.VxScan],
+};
+
 const MarkScanStateMachineEvent: LogDetails = {
   eventId: LogEventId.MarkScanStateMachineEvent,
   eventType: LogEventType.SystemStatus,
@@ -1086,6 +1102,10 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return DeviceUnattached;
     case LogEventId.WorkspaceConfigurationMessage:
       return WorkspaceConfigurationMessage;
+    case LogEventId.TogglingTestMode:
+      return TogglingTestMode;
+    case LogEventId.ToggledTestMode:
+      return ToggledTestMode;
     case LogEventId.FileSaved:
       return FileSaved;
     case LogEventId.LogConversionToCdfComplete:
@@ -1188,10 +1208,6 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return ElectionReportPrinted;
     case LogEventId.WriteInAdjudicated:
       return WriteInAdjudicated;
-    case LogEventId.TogglingTestMode:
-      return TogglingTestMode;
-    case LogEventId.ToggledTestMode:
-      return ToggledTestMode;
     case LogEventId.ClearingBallotData:
       return ClearingBallotData;
     case LogEventId.ClearedBallotData:
@@ -1246,6 +1262,10 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return ScannerEvent;
     case LogEventId.ScannerStateChanged:
       return ScannerStateChanged;
+    case LogEventId.SoundToggled:
+      return SoundToggled;
+    case LogEventId.DoubleSheetDetectionToggled:
+      return DoubleSheetDetectionToggled;
     case LogEventId.MarkScanStateMachineEvent:
       return MarkScanStateMachineEvent;
     case LogEventId.PatDeviceError:

--- a/libs/logging/types-rust/src/log_event_enums.rs
+++ b/libs/logging/types-rust/src/log_event_enums.rs
@@ -51,6 +51,10 @@ pub enum EventId {
     DeviceUnattached,
     #[serde(rename = "workspace-config")]
     WorkspaceConfigurationMessage,
+    #[serde(rename = "toggle-test-mode-init")]
+    TogglingTestMode,
+    #[serde(rename = "toggled-test-mode")]
+    ToggledTestMode,
     #[serde(rename = "file-saved")]
     FileSaved,
     #[serde(rename = "convert-log-cdf-complete")]
@@ -153,10 +157,6 @@ pub enum EventId {
     ElectionReportPrinted,
     #[serde(rename = "write-in-adjudicated")]
     WriteInAdjudicated,
-    #[serde(rename = "toggle-test-mode-init")]
-    TogglingTestMode,
-    #[serde(rename = "toggled-test-mode")]
-    ToggledTestMode,
     #[serde(rename = "clear-ballot-data-init")]
     ClearingBallotData,
     #[serde(rename = "clear-ballot-data-complete")]
@@ -211,6 +211,10 @@ pub enum EventId {
     ScannerEvent,
     #[serde(rename = "scanner-state-machine-transition")]
     ScannerStateChanged,
+    #[serde(rename = "sound-toggled")]
+    SoundToggled,
+    #[serde(rename = "double-sheet-toggled")]
+    DoubleSheetDetectionToggled,
     #[serde(rename = "mark-scan-state-machine-event")]
     MarkScanStateMachineEvent,
     #[serde(rename = "pat-device-error")]


### PR DESCRIPTION
## Overview
Adds a few missing logs:

Mark: Failure log if you try to open polls when there is previous ballot data
Mark: Logs for toggling test/live mode
Scan: Logs for toggling test/love mode
Scan: Logs for toggling sounds
Scan: Logs for toggling MSD 
CentralScan: Moves the log for clearing ballot data a bit lower in the stack so that it gets logged when data is cleared through actions like toggling test/live mode 
<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot

## Testing Plan
Did actions, saw logs, ran test

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
