### PR TITLE
[MarkScan] Translate voter-facing text on the cover open alarm screen

### DIFF
--- a/apps/mark-scan/frontend/src/pages/scanner_open_alarm_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/scanner_open_alarm_screen.test.tsx
@@ -1,0 +1,22 @@
+import { mockOf, mockUseAudioControls } from '@votingworks/test-utils';
+import { useAudioEnabled } from '@votingworks/ui';
+import { render } from '../../test/react_testing_library';
+import { ScannerOpenAlarmScreen } from './scanner_open_alarm_screen';
+
+const audioControlsMock = mockUseAudioControls();
+jest.mock('@votingworks/ui', (): typeof import('@votingworks/ui') => ({
+  ...jest.requireActual('@votingworks/ui'),
+  useAudioEnabled: jest.fn(),
+  useAudioControls: () => audioControlsMock,
+}));
+
+test('mutes audio on render, unmutes on unmount', () => {
+  const mockUseAudioEnabled = mockOf(useAudioEnabled);
+  mockUseAudioEnabled.mockReturnValue(true);
+
+  const { unmount } = render(<ScannerOpenAlarmScreen />);
+  expect(audioControlsMock.setIsEnabled).toHaveBeenLastCalledWith(false);
+
+  unmount();
+  expect(audioControlsMock.setIsEnabled).toHaveBeenLastCalledWith(true);
+});

--- a/apps/mark-scan/frontend/src/pages/scanner_open_alarm_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/scanner_open_alarm_screen.tsx
@@ -1,16 +1,37 @@
-import { Caption, H6, Icons, P } from '@votingworks/ui';
+import {
+  appStrings,
+  Caption,
+  H6,
+  Icons,
+  P,
+  useAudioControls,
+  useAudioEnabled,
+} from '@votingworks/ui';
 
+import React from 'react';
 import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
 
 export function ScannerOpenAlarmScreen(): JSX.Element {
+  const wasAudioEnabled = React.useRef(useAudioEnabled());
+  const { setIsEnabled: setAudioEnabled } = useAudioControls();
+
+  React.useEffect(() => {
+    setAudioEnabled(false);
+
+    function restoreAudioOnExit() {
+      setAudioEnabled(wasAudioEnabled.current);
+    }
+    return restoreAudioOnExit;
+  }, [setAudioEnabled]);
+
   return (
     <CenteredCardPageLayout
       icon={<Icons.Danger color="danger" />}
       title="Printer Cover Open"
       voterFacing
     >
-      <P>The printer cover is open and must be closed to continue voting.</P>
-      <P>Please ask a poll worker for help.</P>
+      <P>{appStrings.instructionsBmdClosePrinterCover()}</P>
+      <P>{appStrings.instructionsAskForHelp()}</P>
 
       {/* Poll Worker strings - not translated: */}
       <H6 as="h2">

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -358,6 +358,12 @@ export const appStrings = {
     </UiString>
   ),
 
+  instructionsBmdClosePrinterCover: () => (
+    <UiString uiStringKey="instructionsBmdClosePrinterCover">
+      The printer cover is open and must be closed to continue voting.
+    </UiString>
+  ),
+
   instructionsBmdContestNavigation: () => (
     <UiString uiStringKey="instructionsBmdContestNavigation">
       To navigate through the contest choices, use the down button. To move to

--- a/libs/ui/src/ui_strings/app_strings_catalog/latest.json
+++ b/libs/ui/src/ui_strings/app_strings_catalog/latest.json
@@ -67,6 +67,7 @@
   "instructionsBmdCastBallotPreamblePostPrint": "Your official ballot has been removed from the printer. Complete the following steps to finish voting:",
   "instructionsBmdCastBallotStep1": "1. Verify your official ballot.",
   "instructionsBmdCastBallotStep2": "2. Scan your official ballot.",
+  "instructionsBmdClosePrinterCover": "The printer cover is open and must be closed to continue voting.",
   "instructionsBmdConfirmCastingBallot": "Press the select button to confirm your selections are correct and cast your ballot.",
   "instructionsBmdConfirmCastingBallotPatDevice": "Use the select input to confirm your selections are correct and cast your ballot.",
   "instructionsBmdConfirmPrintingBallot": "Press the select button to confirm your selections and print your ballot.",


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/3873

Adding missing translations for the voter-facing text on the cover open alarm screen - also adding a temporary screen reader mute to avoid trying to read on-screen text while the alarm's going off.

## Testing Plan
- unit and manual

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
