### PR TITLE
[Mark] Calibrate screen reader volume for new headphones on VSAP 150

### DIFF
--- a/libs/ui/src/ui_strings/audio_volume.ts
+++ b/libs/ui/src/ui_strings/audio_volume.ts
@@ -44,13 +44,13 @@ export enum AudioVolume {
  * in roughly an output level of {@link MIN_VOLUME_DB_SPL} when the OS volume is
  * set to its maximum output level.
  *
- * Last Calibration: 2024-05-14 on VSAP with JLAB Studio On-Ear Headphones.
+ * Last Calibration: 2024-09-11 on VSAP 150 with Lorelei X6 Headphones.
  *
  * TODO: Might be worth defining different offsets for different machines
  * (VxMark vs VxMarkScan), since audio hardware and output levels will likely
  * differ between the two.
  */
-const GOOGLE_CLOUD_TTS_GAIN_OFFSET_FOR_MIN_VOLUME = -68;
+const GOOGLE_CLOUD_TTS_GAIN_OFFSET_FOR_MIN_VOLUME = -55;
 
 export function getAudioGainAmountDb(volume: AudioVolume): number {
   // eslint-disable-next-line vx/gts-safe-number-parse


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/5352

We recently changed the model of headphones we're using on the VxMark and they require a bit more power to drive, so bumping up our volume calibration to put the default volume back in the 60-70 dB range.

## Testing Plan
- SPL meter in a styrofoam head

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
