### PR TITLE
Allow for system admins to save election packages in same way election manager can

### DIFF
--- a/apps/admin/frontend/src/screens/election_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/election_screen.test.tsx
@@ -47,6 +47,7 @@ describe('as System Admin', () => {
     screen.getByText(new RegExp(`${election.county.name}, ${election.state}`));
     screen.getByText('November 3, 2020');
 
+    screen.getButton('Save Election Package');
     screen.getButton('Unconfigure Machine');
   });
 });

--- a/apps/admin/frontend/src/screens/election_screen.tsx
+++ b/apps/admin/frontend/src/screens/election_screen.tsx
@@ -61,17 +61,16 @@ export function ElectionScreen(): JSX.Element {
           </P>
         </div>
       </ElectionCard>
-      <div style={{ display: 'flex', gap: '1rem' }}>
-        {(isSystemAdministratorAuth(auth) || isElectionManagerAuth(auth)) && (
+      {isSystemAdministratorAuth(auth) && (
+        <div style={{ display: 'flex', gap: '1rem' }}>
           <ExportElectionPackageModalButton />
-        )}
-        {isSystemAdministratorAuth(auth) && (
           <UnconfigureMachineButton
             isMachineConfigured
             unconfigureMachine={unconfigureMachine}
           />
-        )}
-      </div>
+        </div>
+      )}
+      {isElectionManagerAuth(auth) && <ExportElectionPackageModalButton />}
     </NavigationScreen>
   );
 }

--- a/apps/admin/frontend/src/screens/election_screen.tsx
+++ b/apps/admin/frontend/src/screens/election_screen.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import styled from 'styled-components';
 import {
   format,
@@ -61,23 +61,17 @@ export function ElectionScreen(): JSX.Element {
           </P>
         </div>
       </ElectionCard>
-      {isSystemAdministratorAuth(auth) && (
-        <UnconfigureMachineButton
-          isMachineConfigured
-          unconfigureMachine={unconfigureMachine}
-        />
-      )}
-      {isElectionManagerAuth(auth) && (
-        <React.Fragment>
-          <P>
-            Save the election package to the USB drive to configure VxSuite
-            components.
-          </P>
-          <P>
-            <ExportElectionPackageModalButton />
-          </P>
-        </React.Fragment>
-      )}
+      <div style={{ display: 'flex', gap: '1rem' }}>
+        {(isSystemAdministratorAuth(auth) || isElectionManagerAuth(auth)) && (
+          <ExportElectionPackageModalButton />
+        )}
+        {isSystemAdministratorAuth(auth) && (
+          <UnconfigureMachineButton
+            isMachineConfigured
+            unconfigureMachine={unconfigureMachine}
+          />
+        )}
+      </div>
     </NavigationScreen>
   );
 }

--- a/apps/admin/frontend/src/screens/election_screen.tsx
+++ b/apps/admin/frontend/src/screens/election_screen.tsx
@@ -30,6 +30,7 @@ export function ElectionScreen(): JSX.Element {
   const history = useHistory();
   const unconfigureMutation = unconfigure.useMutation();
 
+  assert(isSystemAdministratorAuth(auth) || isElectionManagerAuth(auth));
   assert(electionDefinition && typeof configuredAt === 'string');
   const { election } = electionDefinition;
 
@@ -61,16 +62,15 @@ export function ElectionScreen(): JSX.Element {
           </P>
         </div>
       </ElectionCard>
-      {isSystemAdministratorAuth(auth) && (
-        <div style={{ display: 'flex', gap: '1rem' }}>
-          <ExportElectionPackageModalButton />
+      <div style={{ display: 'flex', gap: '0.5rem' }}>
+        <ExportElectionPackageModalButton />
+        {isSystemAdministratorAuth(auth) && (
           <UnconfigureMachineButton
             isMachineConfigured
             unconfigureMachine={unconfigureMachine}
           />
-        </div>
-      )}
-      {isElectionManagerAuth(auth) && <ExportElectionPackageModalButton />}
+        )}
+      </div>
     </NavigationScreen>
   );
 }


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/5320

## Demo Video or Screenshot

Current System Admin

<img width="1007" alt="Screenshot 2024-09-11 at 2 35 40 PM" src="https://github.com/user-attachments/assets/484f7781-8db5-48e7-95f4-ab6c7506c9bc">

Current Election Manager

<img width="1000" alt="Screenshot 2024-09-11 at 2 36 40 PM" src="https://github.com/user-attachments/assets/5e68c622-6040-42fd-983b-e1d81d25ba8c">

System Admins + Election Manager without explanations

<img width="1001" alt="Screenshot 2024-09-11 at 2 20 00 PM" src="https://github.com/user-attachments/assets/afb7454a-f3c1-42e0-a359-1416f1f0eafa">
<img width="1000" alt="Screenshot 2024-09-11 at 2 40 41 PM" src="https://github.com/user-attachments/assets/4c66e6b1-9c7a-41e5-9345-56f25f39f894">

OUTDATED: Systems Admins with short explanations (Not using this approach)

<img width="1302" alt="Screenshot 2024-09-10 at 9 18 23 PM" src="https://github.com/user-attachments/assets/ca343829-e66e-462c-b780-f879941bbc28">

## Testing Plan

Test added

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
