### PR TITLE
libs/usb-drive: Add `sync` method to enable mocking

### DIFF
--- a/apps/admin/backend/src/app.diagnostics.test.ts
+++ b/apps/admin/backend/src/app.diagnostics.test.ts
@@ -151,6 +151,7 @@ test('print or save readiness report', async () => {
   jest.useRealTimers();
 
   mockUsbDrive.insertUsbDrive({});
+  mockUsbDrive.usbDrive.sync.expectCallWith().resolves();
   const exportFileResult = await apiClient.saveReadinessReport();
   exportFileResult.assertOk('error saving readiness report to USB');
   expect(logger.log).toHaveBeenCalledWith(

--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -353,6 +353,7 @@ test('saveElectionPackageToUsb', async () => {
   await configureMachine(apiClient, auth, electionDefinition);
 
   mockUsbDrive.insertUsbDrive({});
+  mockUsbDrive.usbDrive.sync.expectRepeatedCallsWith().resolves();
   const response = await apiClient.saveElectionPackageToUsb();
   expect(response).toEqual(ok());
 });

--- a/apps/admin/backend/src/util/export_file.ts
+++ b/apps/admin/backend/src/util/export_file.ts
@@ -40,6 +40,11 @@ export function exportFile({
         () => {
           return Promise.resolve();
         },
+      sync:
+        /* istanbul ignore next */
+        () => {
+          return Promise.resolve();
+        },
     },
   });
 

--- a/apps/central-scan/backend/src/app.diagnostics.test.ts
+++ b/apps/central-scan/backend/src/app.diagnostics.test.ts
@@ -79,6 +79,7 @@ test('save readiness report', async () => {
       jest.useRealTimers();
 
       mockUsbDrive.insertUsbDrive({});
+      mockUsbDrive.usbDrive.sync.expectCallWith().resolves();
       const exportResult = await apiClient.saveReadinessReport();
       exportResult.assertOk('Failed to save readiness report');
       expect(logger.log).toHaveBeenCalledWith(

--- a/apps/central-scan/backend/src/end_to_end_bmd.test.ts
+++ b/apps/central-scan/backend/src/end_to_end_bmd.test.ts
@@ -70,6 +70,7 @@ test('going through the whole process works - BMD', async () => {
 
       {
         mockUsbDrive.insertUsbDrive({});
+        mockUsbDrive.usbDrive.sync.expectRepeatedCallsWith().resolves();
 
         expect(
           await apiClient.exportCastVoteRecordsToUsbDrive({

--- a/apps/central-scan/backend/src/end_to_end_hmpb.test.ts
+++ b/apps/central-scan/backend/src/end_to_end_hmpb.test.ts
@@ -86,6 +86,7 @@ test('going through the whole process works - HMPB', async () => {
 
       {
         mockUsbDrive.insertUsbDrive({});
+        mockUsbDrive.usbDrive.sync.expectRepeatedCallsWith().resolves();
 
         expect(
           await apiClient.exportCastVoteRecordsToUsbDrive({

--- a/apps/mark-scan/backend/src/app.diagnostics.test.ts
+++ b/apps/mark-scan/backend/src/app.diagnostics.test.ts
@@ -228,6 +228,7 @@ test('saving the readiness report', async () => {
   await apiClient.setPrecinctSelection({
     precinctSelection: ALL_PRECINCTS_SELECTION,
   });
+  mockUsbDrive.usbDrive.sync.expectCallWith().resolves();
   const exportResult = await apiClient.saveReadinessReport();
   expect(exportResult).toEqual(ok(expect.anything()));
   expect(logger.logAsCurrentRole).toHaveBeenCalledWith(

--- a/apps/scan/backend/test/helpers/custom_helpers.ts
+++ b/apps/scan/backend/test/helpers/custom_helpers.ts
@@ -90,6 +90,7 @@ export async function withApp(
   const logger = buildMockLogger(mockAuth, workspace);
   const mockScanner = mocks.mockCustomScanner();
   const mockUsbDrive = createMockUsbDrive();
+  mockUsbDrive.usbDrive.sync.expectOptionalRepeatedCallsWith().resolves(); // Called by continuous export
   const mockPrinterHandler = createMockPrinterHandler();
   const mockFujitsuPrinterHandler = createMockFujitsuPrinterHandler();
   const deferredConnect = deferred<void>();

--- a/apps/scan/backend/test/helpers/pdi_helpers.ts
+++ b/apps/scan/backend/test/helpers/pdi_helpers.ts
@@ -223,6 +223,7 @@ export async function withApp(
   const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger());
   const logger = buildMockLogger(mockAuth, workspace);
   const mockUsbDrive = createMockUsbDrive();
+  mockUsbDrive.usbDrive.sync.expectOptionalRepeatedCallsWith().resolves(); // Called by continuous export
   const mockPrinterHandler = createMockPrinterHandler();
   const mockFujitsuPrinterHandler = createMockFujitsuPrinterHandler();
   const printer = isFeatureFlagEnabled(

--- a/libs/backend/src/cast_vote_records/export.test.ts
+++ b/libs/backend/src/cast_vote_records/export.test.ts
@@ -75,7 +75,7 @@ beforeEach(() => {
   tempDirectoryPath = dirSync().name;
 
   mockUsbDrive.insertUsbDrive({});
-  mockUsbDrive.usbDrive.sync.expectRepeatedCallsWith().resolves();
+  mockUsbDrive.usbDrive.sync.expectOptionalRepeatedCallsWith().resolves();
   mockCentralScannerStore.setElectionDefinition(electionDefinition);
   mockCentralScannerStore.setSystemSettings(DEFAULT_SYSTEM_SETTINGS);
   mockCentralScannerStore.setBatches([batch1]);
@@ -88,6 +88,7 @@ beforeEach(() => {
 afterEach(() => {
   fs.rmSync(tempDirectoryPath, { recursive: true });
   clearDoesUsbDriveRequireCastVoteRecordSyncCachedResult();
+  mockUsbDrive.assertComplete();
 });
 
 const sheet1Id = uuid();

--- a/libs/backend/src/cast_vote_records/export.test.ts
+++ b/libs/backend/src/cast_vote_records/export.test.ts
@@ -75,6 +75,7 @@ beforeEach(() => {
   tempDirectoryPath = dirSync().name;
 
   mockUsbDrive.insertUsbDrive({});
+  mockUsbDrive.usbDrive.sync.expectRepeatedCallsWith().resolves();
   mockCentralScannerStore.setElectionDefinition(electionDefinition);
   mockCentralScannerStore.setSystemSettings(DEFAULT_SYSTEM_SETTINGS);
   mockCentralScannerStore.setBatches([batch1]);

--- a/libs/backend/src/exporter.test.ts
+++ b/libs/backend/src/exporter.test.ts
@@ -36,6 +36,7 @@ afterEach(() => {
     tmpDir.removeCallback();
   }
   tmpDirs.length = 0;
+  mockUsbDrive.assertComplete();
 });
 
 test('exportData with string', async () => {

--- a/libs/backend/src/exporter.test.ts
+++ b/libs/backend/src/exporter.test.ts
@@ -148,6 +148,7 @@ test('exportDataToUsbDrive happy path', async () => {
   usbDrive.status
     .expectCallWith()
     .resolves({ status: 'mounted', mountPoint: tmpDir });
+  usbDrive.sync.expectCallWith().resolves();
   const result = await exporter.exportDataToUsbDrive(
     'bucket',
     'test.txt',
@@ -155,7 +156,6 @@ test('exportDataToUsbDrive happy path', async () => {
   );
   expect(result).toEqual(ok([path]));
   expect(await readFile(path, 'utf-8')).toEqual('bar');
-  expect(execFileMock).toHaveBeenCalledWith('sync', ['-f', tmpDir]);
 });
 
 test('exportDataToUsbDrive with maximumFileSize', async () => {
@@ -164,6 +164,7 @@ test('exportDataToUsbDrive with maximumFileSize', async () => {
   usbDrive.status
     .expectCallWith()
     .resolves({ status: 'mounted', mountPoint: tmpDir });
+  usbDrive.sync.expectCallWith().resolves();
   const result = await exporter.exportDataToUsbDrive(
     'bucket',
     'test.txt',
@@ -175,7 +176,6 @@ test('exportDataToUsbDrive with maximumFileSize', async () => {
   expect(result).toEqual(ok([`${path}-part-1`, `${path}-part-2`]));
   expect(await readFile(`${path}-part-1`, 'utf-8')).toEqual('ba');
   expect(await readFile(`${path}-part-2`, 'utf-8')).toEqual('r');
-  expect(execFileMock).toHaveBeenCalledWith('sync', ['-f', tmpDir]);
 });
 
 test('exportDataToUsbDrive with machineDirectoryToWriteToFirst', async () => {
@@ -183,6 +183,7 @@ test('exportDataToUsbDrive with machineDirectoryToWriteToFirst', async () => {
   usbDrive.status
     .expectCallWith()
     .resolves({ status: 'mounted', mountPoint: tmpDir });
+  usbDrive.sync.expectCallWith().resolves();
 
   const result = await exporter.exportDataToUsbDrive(
     'bucket',
@@ -195,5 +196,4 @@ test('exportDataToUsbDrive with machineDirectoryToWriteToFirst', async () => {
   expect(result).toEqual(ok([usbFilePath]));
   expect(await readFile(usbFilePath, 'utf-8')).toEqual('1234');
   expect(await readFile(machineFilePath, 'utf-8')).toEqual('1234');
-  expect(execFileMock).toHaveBeenCalledWith('sync', ['-f', tmpDir]);
 });

--- a/libs/backend/src/exporter.ts
+++ b/libs/backend/src/exporter.ts
@@ -8,7 +8,6 @@ import { Buffer } from 'buffer';
 import { ExportDataError as BaseExportDataError } from '@votingworks/types';
 import { UsbDrive } from '@votingworks/usb-drive';
 import { splitToFiles } from './split';
-import { execFile } from './exec';
 
 /**
  * The largest file size that can be exported to a USB drive formatted as FAT32.
@@ -158,7 +157,7 @@ export class Exporter {
 
     // Exporting a file might take a while. Ensure the data is flushed to the USB
     // drive before we consider it safe to remove.
-    await execFile('sync', ['-f', usbDriveStatus.mountPoint]);
+    await this.usbDrive.sync();
 
     return result;
   }

--- a/libs/backend/src/system_call/export_logs_to_usb.test.ts
+++ b/libs/backend/src/system_call/export_logs_to_usb.test.ts
@@ -177,6 +177,8 @@ test('exportLogsToUsb works for vxf format when all conditions are met', async (
       message: 'Successfully saved logs on the usb drive.',
     })
   );
+
+  mockUsbDrive.assertComplete();
 });
 
 test('exportLogsToUsb returns error when cdf conversion fails', async () => {
@@ -321,6 +323,8 @@ test('exportLogsToUsb works for cdf format when all conditions are met', async (
       message: 'Successfully saved logs on the usb drive.',
     })
   );
+
+  mockUsbDrive.assertComplete();
 });
 
 test('exportLogsToUsb works for error format when all conditions are met', async () => {
@@ -382,4 +386,6 @@ test('exportLogsToUsb works for error format when all conditions are met', async
       message: 'Successfully saved logs on the usb drive.',
     })
   );
+
+  mockUsbDrive.assertComplete();
 });

--- a/libs/backend/src/system_call/export_logs_to_usb.test.ts
+++ b/libs/backend/src/system_call/export_logs_to_usb.test.ts
@@ -137,6 +137,7 @@ test('exportLogsToUsb works for vxf format when all conditions are met', async (
     status: 'mounted',
     mountPoint: '/media/usb-drive',
   });
+  mockUsbDrive.usbDrive.sync.expectCallWith().resolves();
 
   const mockStats = new Stats();
   mockStats.isDirectory = jest.fn().mockReturnValue(true);
@@ -167,8 +168,6 @@ test('exportLogsToUsb works for vxf format when all conditions are met', async (
     '/var/log/votingworks',
     expect.stringMatching('^/media/usb-drive/logs/machine_TEST-MACHINE-ID/'),
   ]);
-
-  expect(execFileMock).toHaveBeenCalledWith('sync', ['-f', '/media/usb-drive']);
 
   expect(logger.log).toHaveBeenCalledWith(
     LogEventId.FileSaved,
@@ -261,6 +260,7 @@ test('exportLogsToUsb works for cdf format when all conditions are met', async (
     status: 'mounted',
     mountPoint: '/media/usb-drive',
   });
+  mockUsbDrive.usbDrive.sync.expectCallWith().resolves();
 
   const mockStats = new Stats();
   mockStats.isDirectory = jest.fn().mockReturnValue(true);
@@ -300,7 +300,6 @@ test('exportLogsToUsb works for cdf format when all conditions are met', async (
     expect.stringMatching('^/media/usb-drive/logs/machine_TEST-MACHINE-ID/'),
   ]);
 
-  expect(execFileMock).toHaveBeenCalledWith('sync', ['-f', '/media/usb-drive']);
   expect(createWriteStreamMock).toHaveBeenCalledWith(
     expect.stringContaining('vx-logs.cdf.log.json')
   );
@@ -331,6 +330,7 @@ test('exportLogsToUsb works for error format when all conditions are met', async
     status: 'mounted',
     mountPoint: '/media/usb-drive',
   });
+  mockUsbDrive.usbDrive.sync.expectCallWith().resolves();
 
   const mockStats = new Stats();
   mockStats.isDirectory = jest.fn().mockReturnValue(true);
@@ -370,7 +370,6 @@ test('exportLogsToUsb works for error format when all conditions are met', async
     expect.stringMatching('^/media/usb-drive/logs/machine_TEST-MACHINE-ID/'),
   ]);
 
-  expect(execFileMock).toHaveBeenCalledWith('sync', ['-f', '/media/usb-drive']);
   expect(createWriteStreamMock).toHaveBeenCalledWith(
     expect.stringContaining('vx-logs.errors.log')
   );

--- a/libs/backend/src/system_call/export_logs_to_usb.ts
+++ b/libs/backend/src/system_call/export_logs_to_usb.ts
@@ -177,7 +177,7 @@ async function exportLogsToUsbHelper({
       default:
         throwIllegalValue(format);
     }
-    await execFile('sync', ['-f', status.mountPoint]);
+    await usbDrive.sync();
   } catch (error) {
     return err('copy-failed');
   } finally {

--- a/libs/test-utils/src/mock_function.test.ts
+++ b/libs/test-utils/src/mock_function.test.ts
@@ -341,22 +341,4 @@ describe('mockFunction', () => {
 
     addMock.assertComplete();
   });
-
-  it('properly tracks whether expected calls have been set up', () => {
-    const addMock = mockFunction<typeof add>('add');
-
-    expect(addMock.hasExpectedCalls()).toEqual(false);
-
-    addMock.expectCallWith(1, 2).returns(3);
-    expect(addMock.hasExpectedCalls()).toEqual(true);
-
-    addMock.reset();
-    expect(addMock.hasExpectedCalls()).toEqual(false);
-
-    addMock.expectRepeatedCallsWith(1, 2).returns(3);
-    expect(addMock.hasExpectedCalls()).toEqual(true);
-
-    addMock.reset();
-    expect(addMock.hasExpectedCalls()).toEqual(false);
-  });
 });

--- a/libs/test-utils/src/mock_function.test.ts
+++ b/libs/test-utils/src/mock_function.test.ts
@@ -184,6 +184,15 @@ describe('mockFunction', () => {
     `);
   });
 
+  it('supports optional repeated calls', () => {
+    const addMock = mockFunction<typeof add>('add');
+    addMock.expectOptionalRepeatedCallsWith(1, 2).returns(3);
+    addMock.assertComplete();
+    expect(addMock(1, 2)).toEqual(3);
+    expect(addMock(1, 2)).toEqual(3);
+    addMock.assertComplete();
+  });
+
   it('assertComplete errors if not all expected calls are used', () => {
     const addMock = mockFunction<typeof add>('add');
     addMock.expectCallWith(1, 2).returns(3);

--- a/libs/test-utils/src/mock_function.ts
+++ b/libs/test-utils/src/mock_function.ts
@@ -55,7 +55,6 @@ export interface MockFunction<Func extends AnyFunc> {
     : Omit<ReturnHelpers<Func>, 'throws'>;
   reset(): void;
   assertComplete(): void;
-  hasExpectedCalls(): boolean;
 }
 
 interface MockFunctionState<Func extends AnyFunc> {
@@ -346,8 +345,6 @@ export function mockFunction<Func extends AnyFunc>(
       throw new MockFunctionError(message);
     }
   };
-
-  mock.hasExpectedCalls = () => state.expectedCalls.length > 0;
 
   return mock;
 }

--- a/libs/usb-drive/src/mocks/file_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/file_usb_drive.ts
@@ -119,6 +119,10 @@ export class MockFileUsbDrive implements UsbDrive {
   format(): Promise<void> {
     return this.eject();
   }
+
+  sync(): Promise<void> {
+    return Promise.resolve();
+  }
 }
 
 interface MockFileUsbDriveHandler {

--- a/libs/usb-drive/src/mocks/memory_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/memory_usb_drive.ts
@@ -47,6 +47,7 @@ export function createMockUsbDrive(): MockUsbDrive {
     status: mockFunction('status'),
     eject: mockFunction('eject'),
     format: mockFunction('format'),
+    sync: mockFunction('sync'),
   };
 
   return {

--- a/libs/usb-drive/src/types.ts
+++ b/libs/usb-drive/src/types.ts
@@ -11,4 +11,5 @@ export interface UsbDrive {
   status(): Promise<UsbDriveStatus>;
   eject(): Promise<void>;
   format(): Promise<void>;
+  sync(): Promise<void>;
 }

--- a/libs/usb-drive/src/usb_drive.test.ts
+++ b/libs/usb-drive/src/usb_drive.test.ts
@@ -606,6 +606,32 @@ describe('format', () => {
   });
 });
 
+describe('sync', () => {
+  test('no drive - no op', async () => {
+    const logger = mockLogger();
+    const usbDrive = detectUsbDrive(logger);
+    readdirMock.mockResolvedValueOnce([]);
+
+    await expect(usbDrive.sync()).resolves.toBeUndefined();
+    expect(execMock).not.toHaveBeenCalled();
+  });
+
+  test('when mounted, execs sync', async () => {
+    const logger = mockLogger();
+    const usbDrive = detectUsbDrive(logger);
+    mockBlockDeviceOnce({ mountpoint: '/media/usb-drive-sdb1' });
+    execMock.mockResolvedValueOnce({ stdout: '' }); // sync
+
+    await usbDrive.sync();
+
+    expect(execMock).toHaveBeenCalledTimes(2); // status, sync
+    expect(execMock).toHaveBeenLastCalledWith('sync', [
+      '-f',
+      '/media/usb-drive-sdb1',
+    ]);
+  });
+});
+
 test('action locking', async () => {
   const logger = mockLogger();
   const usbDrive = detectUsbDrive(logger);

--- a/libs/usb-drive/src/usb_drive.ts
+++ b/libs/usb-drive/src/usb_drive.ts
@@ -365,5 +365,14 @@ export function detectUsbDrive(logger: Logger): UsbDrive {
         }
       }
     },
+
+    async sync(): Promise<void> {
+      const deviceInfo = await getUsbDriveDeviceInfo();
+      if (!deviceInfo?.mountpoint) {
+        debug('No USB drive mounted, skipping sync');
+        return;
+      }
+      await exec('sync', ['-f', deviceInfo.mountpoint]);
+    },
   };
 }


### PR DESCRIPTION
## Overview

Adds a `sync` method to `libs/usb-drive` so that we can easily mock sync calls in tests. This will hopefully help prevent test flakiness due to hanging sync calls in `apps/scan/backend`.

To enable easy mocking across all of the `apps/scan/backend` tests, adds a new mock function method `expectOptionalRepeatedCallsWith`.

## Demo Video or Screenshot

## Testing Plan
Updated tests. Hope it solves flakiness but can't be sure - ran ~20 runs with no flake.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
