### PR TITLE
[Node20] Update JSON error checks in tests

### DIFF
--- a/apps/mark-scan/backend/src/store.test.ts
+++ b/apps/mark-scan/backend/src/store.test.ts
@@ -76,9 +76,7 @@ test('errors when election definition cannot be parsed', () => {
     jurisdiction,
     electionPackageHash: 'test-election-package-hash',
   });
-  expect(() => store.getElectionRecord()).toThrow(
-    'Unexpected token m in JSON at position 1'
-  );
+  expect(() => store.getElectionRecord()).toThrow(SyntaxError);
 });
 
 test('reset clears the database', () => {

--- a/apps/mark/backend/src/store.test.ts
+++ b/apps/mark/backend/src/store.test.ts
@@ -56,9 +56,7 @@ test('errors when election definition cannot be parsed', () => {
     jurisdiction,
     electionPackageHash: 'test-election-package-hash',
   });
-  expect(() => store.getElectionRecord()).toThrow(
-    'Unexpected token m in JSON at position 1'
-  );
+  expect(() => store.getElectionRecord()).toThrow(SyntaxError);
 });
 
 test('reset clears the database', () => {

--- a/libs/backend/src/election_package/election_package_io.test.ts
+++ b/libs/backend/src/election_package/election_package_io.test.ts
@@ -358,7 +358,7 @@ test('readElectionPackageFromFile errors when given an invalid election', async 
   expect(await readElectionPackageFromFile(file)).toEqual(
     err({
       type: 'invalid-election',
-      message: 'Unexpected token o in JSON at position 1',
+      message: expect.stringMatching(/JSON/i),
     })
   );
 });
@@ -375,7 +375,7 @@ test('readElectionPackageFromFile errors when given invalid system settings', as
   expect(await readElectionPackageFromFile(file)).toEqual(
     err({
       type: 'invalid-system-settings',
-      message: 'Unexpected token o in JSON at position 1',
+      message: expect.stringMatching(/JSON/i),
     })
   );
 });
@@ -392,7 +392,7 @@ test('readElectionPackageFromFile errors when given invalid metadata', async () 
   expect(await readElectionPackageFromFile(file)).toEqual(
     err({
       type: 'invalid-metadata',
-      message: 'Unexpected token a in JSON at position 0',
+      message: expect.stringMatching(/JSON/i),
     })
   );
 });

--- a/libs/grout/src/serialization.test.ts
+++ b/libs/grout/src/serialization.test.ts
@@ -119,10 +119,8 @@ test('JSON serialization/deserialization', () => {
 });
 
 test('deserialize errors with invalid JSON', () => {
-  expect(() => deserialize('')).toThrow('Unexpected end of JSON input');
-  expect(() => deserialize('{a}')).toThrow(
-    'Unexpected token a in JSON at position 1'
-  );
+  expect(() => deserialize('')).toThrow(SyntaxError);
+  expect(() => deserialize('{a}')).toThrow(SyntaxError);
   expect(() =>
     deserialize('{"__grout_type": "not a real type","__grout_value": 1}')
   ).toThrow('Unknown tag: not a real type');

--- a/libs/types/src/schema.test.ts
+++ b/libs/types/src/schema.test.ts
@@ -13,9 +13,7 @@ test('parsing JSON.parses a string', () => {
 });
 
 test('parsing invalid JSON', () => {
-  expect(t.safeParseElection('{').unsafeUnwrapErr().message).toEqual(
-    'Unexpected end of JSON input'
-  );
+  expect(t.safeParseElection('{').isErr()).toEqual(true);
 });
 
 test('parsing JSON without a schema', () => {


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/4163

Messages for JON `SyntaxError`s have change since Node 16 - updating the tests so they compare error types instead of relying on the string content (except in the election package parsing case, where we wrap the errors in a way that doesn't retain the type information).

## Testing Plan
- Existing tests

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
