### PR TITLE
unmarked write-in accounting tweaks

### DIFF
--- a/apps/admin/backend/src/app.write_ins.test.ts
+++ b/apps/admin/backend/src/app.write_ins.test.ts
@@ -520,11 +520,11 @@ test('handling unmarked write-ins', async () => {
     ).toMatchObject(summary);
   }
 
-  // the unmarked write-in should appear as no vote at all in tallies
+  // UWIs should appear in the write-in summary, but not in the tally results
   await expectWriteInSummary({
-    pendingTally: 0,
+    pendingTally: 2,
     invalidTally: 0,
-    totalTally: 0,
+    totalTally: 2,
   });
   await expectContestResults({
     type: 'candidate',
@@ -538,16 +538,16 @@ test('handling unmarked write-ins', async () => {
     },
   });
 
-  // it should be reflected in tallies if we mark it as valid
+  // a UWI should be reflected in tallies if we mark it as valid
   await apiClient.adjudicateWriteIn({
     writeInId,
     type: 'official-candidate',
     candidateId: OFFICIAL_CANDIDATE_ID,
   });
   await expectWriteInSummary({
-    pendingTally: 0,
+    pendingTally: 1,
     invalidTally: 0,
-    totalTally: 1,
+    totalTally: 2,
     candidateTallies: {
       [OFFICIAL_CANDIDATE_ID]: {
         id: OFFICIAL_CANDIDATE_ID,
@@ -568,15 +568,15 @@ test('handling unmarked write-ins', async () => {
     },
   });
 
-  // it should, again, not be reflected in tallies if we mark it as invalid
+  // an invalid UWI should appear the same as unadjudicated in tallies
   await apiClient.adjudicateWriteIn({
     writeInId,
     type: 'invalid',
   });
   await expectWriteInSummary({
-    pendingTally: 0,
-    invalidTally: 0,
-    totalTally: 0,
+    pendingTally: 1,
+    invalidTally: 1,
+    totalTally: 2,
   });
   await expectContestResults({
     type: 'candidate',

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -1836,13 +1836,13 @@ export class Store {
    * Gets write-in tallies specifically for tabulation, filtered and and
    * grouped by cast vote record attributes.
    *
-   * When using write-in tallies to hydrate tally results, unadjudicated and
-   * unmarked write-ins should not be included because they are not associated
-   * with an original or adjudicated mark. When using write-in tallies as a
-   * summary of write-in adjudication, they should be included because they
-   * exist in the adjudication flow just as marked write-ins do. The behavior
-   * can be controlled with the `includeUnadjudicatedAndInvalidUnmarkedWriteIns`
-   * flag.
+   * When using write-in tallies to hydrate tally results, unmarked write-ins
+   * that haven't been adjudicated or are invalid should not be included
+   * because they are not associated with an original or adjudicated mark. Whe
+   * using write-in tallies as a summary of write-in adjudication, they should
+   * be included because they exist in the adjudication flow just as marked
+   * write-ins do. The behavior can be controlled with the
+   * `includeUnadjudicatedAndInvalidUnmarkedWriteIns` flag.
    */
   *getWriteInTallies({
     electionId,

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -103,7 +103,7 @@ type StoreCastVoteRecordAttributes = Omit<
   readonly partyId: string | null;
 };
 
-const WRITE_IN_QUEUE_ORDER_BY = `order by is_unmarked, sequence_id`;
+const WRITE_IN_QUEUE_ORDER_BY = `order by sequence_id`;
 
 /**
  * Path to the store's schema file, i.e. the file that defines the database.

--- a/apps/admin/backend/src/tabulation/write_ins.ts
+++ b/apps/admin/backend/src/tabulation/write_ins.ts
@@ -164,21 +164,24 @@ export function tabulateWriteInTallies({
   store,
   filter,
   groupBy,
+  includeUnadjudicatedAndInvalidUnmarkedWriteIns,
 }: {
   electionId: Id;
   store: Store;
   filter?: Tabulation.Filter;
   groupBy?: Tabulation.GroupBy;
+  includeUnadjudicatedAndInvalidUnmarkedWriteIns?: boolean;
 }): Tabulation.GroupMap<Tabulation.ElectionWriteInSummary> {
   const {
     electionDefinition: { election },
   } = assertDefined(store.getElection(electionId));
 
-  const writeInTallies = store.getWriteInTalliesForTabulation({
+  const writeInTallies = store.getWriteInTallies({
     electionId,
     election,
     filter,
     groupBy,
+    includeUnadjudicatedAndInvalidUnmarkedWriteIns,
   });
 
   const electionWriteInSummaryGroupMap: Tabulation.GroupMap<Tabulation.ElectionWriteInSummary> =
@@ -387,6 +390,7 @@ export function getOverallElectionWriteInSummary({
     tabulateWriteInTallies({
       electionId,
       store,
+      includeUnadjudicatedAndInvalidUnmarkedWriteIns: true,
     })
   )[0];
   assert(scannedElectionWriteInSummary);


### PR DESCRIPTION
## Overview

Closes #5382. Does two things:
- makes sure unmarked write-ins appear in the write-in adjudication report
- undoes the WIA adjudication queue ordering that always puts UWIs last, which can be confusing if a UWI and a proper WI are on the same ballot contest 

## Testing Plan

Updated existing test coverage to match new logic.