### PR TITLE
Allow EMs to access diagnostics in VXAdmin and CentralScan

### DIFF
--- a/apps/admin/frontend/src/components/app_routes.tsx
+++ b/apps/admin/frontend/src/components/app_routes.tsx
@@ -220,6 +220,9 @@ export function AppRoutes(): JSX.Element | null {
       <Route exact path={routerPaths.settings}>
         <SettingsScreen />
       </Route>
+      <Route exact path={routerPaths.hardwareDiagnostics}>
+        <DiagnosticsScreen />
+      </Route>
       <Redirect to={routerPaths.election} />
     </Switch>
   );

--- a/apps/admin/frontend/src/components/navigation_screen.tsx
+++ b/apps/admin/frontend/src/components/navigation_screen.tsx
@@ -55,6 +55,7 @@ const ELECTION_MANAGER_NAV_ITEMS: readonly NavItem[] = [
     : []),
   { label: 'Reports', routerPath: routerPaths.reports },
   { label: 'Settings', routerPath: routerPaths.settings },
+  { label: 'Diagnostics', routerPath: routerPaths.hardwareDiagnostics },
 ];
 
 const ELECTION_MANAGER_NAV_ITEMS_NO_ELECTION: readonly NavItem[] = [];

--- a/apps/central-scan/frontend/README.md
+++ b/apps/central-scan/frontend/README.md
@@ -1,7 +1,6 @@
-# VotingWorks Ballot Scanner (BSD) (VxCentralScan)
+# VotingWorks Batch Scanner (VxCentralScan)
 
-Scans ballots printed by the VxSuite [Ballot Marking Device (BMD)](../mark) or
-the VxSuite [Election Manager](../admin).
+Scans ballots in batches using COTS (Commercial-off-the-Shelf) Fujitsu scanners.
 
 ## Setup
 
@@ -17,7 +16,7 @@ The server will be available at http://localhost:3000/.
 
 To scan ballots without scanner hardware use the `MOCK_SCANNER_FILES`
 environment variable set as described in
-[`apps/central-scan/backend`](../../backend).
+[`apps/central-scan/backend`](../backend).
 
 ## Testing
 

--- a/apps/central-scan/frontend/README.md
+++ b/apps/central-scan/frontend/README.md
@@ -1,7 +1,7 @@
 # VotingWorks Ballot Scanner (BSD) (VxCentralScan)
 
-Scans ballots printed by the VxSuite [Ballot Marking Device (BMD)](../bmd) or
-the VxSuite [Election Manager](../election-manager).
+Scans ballots printed by the VxSuite [Ballot Marking Device (BMD)](../mark) or
+the VxSuite [Election Manager](../admin).
 
 ## Setup
 

--- a/apps/central-scan/frontend/src/app_root.tsx
+++ b/apps/central-scan/frontend/src/app_root.tsx
@@ -189,6 +189,9 @@ export function AppRoot({ logger }: AppRootProps): JSX.Element | null {
             canUnconfigure={status.canUnconfigure}
           />
         </Route>
+        <Route path="/hardware-diagnostics">
+          <DiagnosticsScreen />
+        </Route>
         <Redirect to="/scan" />
       </Switch>
     </AppContext.Provider>


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/5266

PR for allowing EMs to access diagnostics to VXAdmin and VXCentralScan, as they are more straightforward. I'll be adding a subsequent PR for MarkScan and Scan.

## Demo Video or Screenshot
### VXCentral Scan
**System Admin (unchanged)**
![Screenshot 2024-09-16 at 1 01 00 PM](https://github.com/user-attachments/assets/da27c93c-8c87-49dc-ba71-1d7d99c3c885)

**Election manager (diagnostics added)**
![Screenshot 2024-09-16 at 1 00 24 PM](https://github.com/user-attachments/assets/f99ebff9-8271-4830-92da-f6a50958e28f)

### VXAdmin
<img width="986" alt="Screenshot 2024-09-16 at 10 10 43 AM" src="https://github.com/user-attachments/assets/baf12887-a415-4683-9849-b236058d7e9f">

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
