### PR TITLE
VxAdmin: Only show card programming modal on smart cards screen

### DIFF
--- a/apps/admin/frontend/jest.config.js
+++ b/apps/admin/frontend/jest.config.js
@@ -15,8 +15,8 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: -101,
-      lines: -93,
+      branches: -97,
+      lines: -81,
     },
   },
   moduleFileExtensions: [

--- a/apps/admin/frontend/src/app.test.tsx
+++ b/apps/admin/frontend/src/app.test.tsx
@@ -394,53 +394,6 @@ test('system administrator UI has expected nav', async () => {
   screen.getByRole('button', { name: 'Lock Machine' });
 });
 
-test('system administrator UI has expected nav when no election', async () => {
-  const { renderApp } = buildApp(apiMock);
-  apiMock.expectGetCurrentElectionMetadata(null);
-  apiMock.expectListPotentialElectionPackagesOnUsbDrive([electionPackage]);
-  renderApp();
-
-  await apiMock.authenticateAsSystemAdministrator();
-
-  userEvent.click(screen.getButton('Election'));
-  await screen.findByRole('heading', { name: 'Election' });
-  userEvent.click(screen.getButton('Settings'));
-  await screen.findByRole('heading', { name: 'Settings' });
-  screen.getByRole('button', { name: 'Lock Machine' });
-
-  expect(screen.queryByText('Smartcards')).not.toBeInTheDocument();
-
-  // Configure with an election definition and verify that previously hidden tabs appear
-  apiMock.expectListPotentialElectionPackagesOnUsbDrive([electionPackage]);
-  userEvent.click(screen.getButton('Election'));
-  await screen.findByRole('heading', { name: 'Election' });
-  const { electionDefinition } = electionFamousNames2021Fixtures;
-  apiMock.expectConfigure(electionPackage.path);
-  apiMock.expectGetSystemSettings();
-  apiMock.expectGetCurrentElectionMetadata({ electionDefinition });
-  userEvent.click(screen.getByText(electionPackage.name));
-  await screen.findAllByText(electionDefinition.election.title);
-  screen.getByText('Smartcards');
-
-  // Remove the election definition and verify that those same tabs disappear
-  apiMock.expectListPotentialElectionPackagesOnUsbDrive([]);
-  apiMock.expectUnconfigure();
-  apiMock.expectGetCurrentElectionMetadata(null);
-  apiMock.expectGetMachineConfig();
-  apiMock.expectGetSystemSettings();
-  userEvent.click(screen.getButton('Unconfigure Machine'));
-  const modal = await screen.findByRole('alertdialog');
-  userEvent.click(
-    within(modal).getByRole('button', { name: 'Yes, Delete Election Data' })
-  );
-  await waitFor(() =>
-    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
-  );
-  await waitFor(() =>
-    expect(screen.queryByText('Smartcards')).not.toBeInTheDocument()
-  );
-});
-
 test('system administrator Smartcards screen navigation', async () => {
   const electionDefinition = eitherNeitherElectionDefinition;
   const { renderApp } = buildApp(apiMock);

--- a/apps/admin/frontend/src/components/app_routes.tsx
+++ b/apps/admin/frontend/src/components/app_routes.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { Switch, Route, Redirect } from 'react-router-dom';
 import {
   SetupCardReaderPage,
@@ -30,7 +30,6 @@ import { WriteInsSummaryScreen } from '../screens/write_ins_summary_screen';
 import { SettingsScreen } from '../screens/settings_screen';
 import { ReportsScreen } from '../screens/reporting/reports_screen';
 import { SmartcardTypeRegExPattern } from '../config/types';
-import { SmartcardModal } from './smartcard_modal';
 import { checkPin } from '../api';
 import { WriteInsAdjudicationScreen } from '../screens/write_ins_adjudication_screen';
 import { TallyReportBuilder } from '../screens/reporting/tally_report_builder';
@@ -43,7 +42,7 @@ import { FullElectionTallyReportScreen } from '../screens/reporting/full_electio
 import { DiagnosticsScreen } from '../screens/diagnostics_screen';
 
 export function AppRoutes(): JSX.Element | null {
-  const { electionDefinition, configuredAt, auth } = useContext(AppContext);
+  const { electionDefinition, auth } = useContext(AppContext);
   const election = electionDefinition?.election;
   const checkPinMutation = checkPin.useMutation();
 
@@ -98,55 +97,32 @@ export function AppRoutes(): JSX.Element | null {
   }
 
   if (isSystemAdministratorAuth(auth)) {
-    if (!election || !configuredAt) {
-      return (
-        <React.Fragment>
-          <Switch>
-            <Route exact path={routerPaths.election}>
-              <UnconfiguredScreen />
-            </Route>
-            <Route exact path={routerPaths.settings}>
-              <SettingsScreen />
-            </Route>
-            <Route exact path={routerPaths.hardwareDiagnostics}>
-              <DiagnosticsScreen />
-            </Route>
-            <Redirect to={routerPaths.election} />
-          </Switch>
-          <SmartcardModal />
-        </React.Fragment>
-      );
-    }
-
     return (
-      <React.Fragment>
-        <Switch>
-          <Route exact path={routerPaths.election}>
-            <ElectionScreen />
-          </Route>
-          <Route exact path={routerPaths.smartcards}>
-            <Redirect
-              to={routerPaths.smartcardsByType({ smartcardType: 'election' })}
-            />
-          </Route>
-          <Route
-            exact
-            path={routerPaths.smartcardsByType({
-              smartcardType: `:smartcardType${SmartcardTypeRegExPattern}`,
-            })}
-          >
-            <SmartcardsScreen />
-          </Route>
-          <Route exact path={routerPaths.settings}>
-            <SettingsScreen />
-          </Route>
-          <Route exact path={routerPaths.hardwareDiagnostics}>
-            <DiagnosticsScreen />
-          </Route>
-          <Redirect to={routerPaths.election} />
-        </Switch>
-        <SmartcardModal />
-      </React.Fragment>
+      <Switch>
+        <Route exact path={routerPaths.election}>
+          {election ? <ElectionScreen /> : <UnconfiguredScreen />}
+        </Route>
+        <Route exact path={routerPaths.smartcards}>
+          <Redirect
+            to={routerPaths.smartcardsByType({ smartcardType: 'election' })}
+          />
+        </Route>
+        <Route
+          exact
+          path={routerPaths.smartcardsByType({
+            smartcardType: `:smartcardType${SmartcardTypeRegExPattern}`,
+          })}
+        >
+          <SmartcardsScreen />
+        </Route>
+        <Route exact path={routerPaths.settings}>
+          <SettingsScreen />
+        </Route>
+        <Route exact path={routerPaths.hardwareDiagnostics}>
+          <DiagnosticsScreen />
+        </Route>
+        <Redirect to={routerPaths.election} />
+      </Switch>
     );
   }
 

--- a/apps/admin/frontend/src/components/navigation_screen.tsx
+++ b/apps/admin/frontend/src/components/navigation_screen.tsx
@@ -20,7 +20,7 @@ import {
   isSystemAdministratorAuth,
 } from '@votingworks/utils';
 
-import { DippedSmartCardAuth, Election } from '@votingworks/types';
+import { DippedSmartCardAuth } from '@votingworks/types';
 import styled from 'styled-components';
 import { AppContext } from '../contexts/app_context';
 import { routerPaths } from '../router_paths';
@@ -41,12 +41,6 @@ const SYSTEM_ADMIN_NAV_ITEMS: readonly NavItem[] = [
   { label: 'Diagnostics', routerPath: routerPaths.hardwareDiagnostics },
 ];
 
-const SYSTEM_ADMIN_NAV_ITEMS_NO_ELECTION: readonly NavItem[] = [
-  { label: 'Election', routerPath: routerPaths.election },
-  { label: 'Settings', routerPath: routerPaths.settings },
-  { label: 'Diagnostics', routerPath: routerPaths.hardwareDiagnostics },
-];
-
 const ELECTION_MANAGER_NAV_ITEMS: readonly NavItem[] = [
   { label: 'Election', routerPath: routerPaths.election },
   { label: 'Tally', routerPath: routerPaths.tally },
@@ -57,34 +51,13 @@ const ELECTION_MANAGER_NAV_ITEMS: readonly NavItem[] = [
   { label: 'Settings', routerPath: routerPaths.settings },
 ];
 
-const ELECTION_MANAGER_NAV_ITEMS_NO_ELECTION: readonly NavItem[] = [];
-
-function getSysAdminNavItems(election?: Election) {
-  if (!election) {
-    return SYSTEM_ADMIN_NAV_ITEMS_NO_ELECTION;
-  }
-
-  return SYSTEM_ADMIN_NAV_ITEMS;
-}
-
-function getElectionManagerNavItems(election?: Election) {
-  if (!election) {
-    return ELECTION_MANAGER_NAV_ITEMS_NO_ELECTION;
-  }
-
-  return ELECTION_MANAGER_NAV_ITEMS;
-}
-
-function getNavItems(
-  auth: DippedSmartCardAuth.AuthStatus,
-  election?: Election
-) {
+function getNavItems(auth: DippedSmartCardAuth.AuthStatus) {
   if (isSystemAdministratorAuth(auth)) {
-    return getSysAdminNavItems(election);
+    return SYSTEM_ADMIN_NAV_ITEMS;
   }
 
   if (isElectionManagerAuth(auth)) {
-    return getElectionManagerNavItems(election);
+    return ELECTION_MANAGER_NAV_ITEMS;
   }
 
   return [];
@@ -109,14 +82,13 @@ export function NavigationScreen({
   parentRoutes,
   noPadding,
 }: Props): JSX.Element {
-  const { electionDefinition, usbDriveStatus, auth } = useContext(AppContext);
-  const election = electionDefinition?.election;
+  const { usbDriveStatus, auth } = useContext(AppContext);
   const logOutMutation = logOut.useMutation();
   const ejectUsbDriveMutation = ejectUsbDrive.useMutation();
 
   return (
     <Screen flexDirection="row">
-      <Sidebar navItems={getNavItems(auth, election)} />
+      <Sidebar navItems={getNavItems(auth)} />
       <Main flexColumn>
         <SessionTimeLimitTimer authStatus={auth} />
         <Header>

--- a/apps/admin/frontend/src/components/smartcard_modal/smartcard_modal.test.tsx
+++ b/apps/admin/frontend/src/components/smartcard_modal/smartcard_modal.test.tsx
@@ -112,8 +112,8 @@ test('Smartcard modal displays card details', async () => {
     },
   ];
 
-  // The smartcard modal should open on any screen, not just the Smartcards screen
-  await screen.findByRole('heading', { name: 'Election' });
+  userEvent.click(await screen.findButton('Smartcards'));
+  await screen.findByRole('heading', { name: 'Election Cards' });
 
   for (const testCase of testCases) {
     const {
@@ -162,13 +162,12 @@ test('Smartcard modal displays card details', async () => {
     await waitFor(() =>
       expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
     );
-    await screen.findByRole('heading', { name: 'Election' });
+    await screen.findByRole('heading', { name: 'Election Cards' });
   }
 });
 
 test('Smartcard modal displays card details when no election definition on machine', async () => {
   const { renderApp } = buildApp(apiMock);
-  apiMock.expectListPotentialElectionPackagesOnUsbDrive([]);
   apiMock.expectGetCurrentElectionMetadata(null);
   renderApp();
   await apiMock.authenticateAsSystemAdministrator();
@@ -215,7 +214,8 @@ test('Smartcard modal displays card details when no election definition on machi
     },
   ];
 
-  await screen.findByRole('heading', { name: 'Election' });
+  userEvent.click(await screen.findButton('Smartcards'));
+  await screen.findByRole('heading', { name: 'Election Cards' });
 
   for (const testCase of testCases) {
     const {
@@ -271,7 +271,7 @@ test('Smartcard modal displays card details when no election definition on machi
     await waitFor(() =>
       expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
     );
-    await screen.findByRole('heading', { name: 'Election' });
+    await screen.findByRole('heading', { name: 'Election Cards' });
   }
 });
 
@@ -311,8 +311,8 @@ test('Programming election manager and poll worker smartcards', async () => {
     },
   ];
 
-  // The smartcard modal should open on any screen, not just the Smartcards screen
-  await screen.findByRole('heading', { name: 'Election' });
+  userEvent.click(await screen.findButton('Smartcards'));
+  await screen.findByRole('heading', { name: 'Election Cards' });
 
   for (const testCase of testCases) {
     const {
@@ -379,7 +379,7 @@ test('Programming election manager and poll worker smartcards', async () => {
     await waitFor(() =>
       expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
     );
-    await screen.findByRole('heading', { name: 'Election' });
+    await screen.findByRole('heading', { name: 'Election Cards' });
   }
 });
 
@@ -445,11 +445,11 @@ test('Programming system administrator smartcards', async () => {
 
 test('Programming smartcards when no election definition on machine', async () => {
   const { renderApp } = buildApp(apiMock);
-  apiMock.expectListPotentialElectionPackagesOnUsbDrive([]);
   apiMock.expectGetCurrentElectionMetadata(null);
   renderApp();
   await apiMock.authenticateAsSystemAdministrator();
-  await screen.findByRole('heading', { name: 'Election' });
+  userEvent.click(await screen.findByText('Smartcards'));
+  await screen.findByRole('heading', { name: 'Election Cards' });
 
   apiMock.setAuthStatus({
     status: 'logged_in',
@@ -480,7 +480,7 @@ test('Programming smartcards when no election definition on machine', async () =
   await waitFor(() =>
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
   );
-  await screen.findByRole('heading', { name: 'Election' });
+  await screen.findByRole('heading', { name: 'Election Cards' });
 });
 
 test('Resetting smartcard PINs', async () => {
@@ -518,8 +518,8 @@ test('Resetting smartcard PINs', async () => {
     },
   ];
 
-  // The smartcard modal should open on any screen, not just the Smartcards screen
-  await screen.findByRole('heading', { name: 'Election' });
+  userEvent.click(await screen.findButton('Smartcards'));
+  await screen.findByRole('heading', { name: 'Election Cards' });
 
   for (const testCase of testCases) {
     const { programmedUser, expectedHeading } = testCase;
@@ -551,18 +551,18 @@ test('Resetting smartcard PINs', async () => {
     await waitFor(() =>
       expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
     );
-    await screen.findByRole('heading', { name: 'Election' });
+    await screen.findByRole('heading', { name: 'Election Cards' });
   }
 });
 
 test('Resetting system administrator smartcard PINs when no election definition on machine', async () => {
   const { renderApp } = buildApp(apiMock);
-  apiMock.expectListPotentialElectionPackagesOnUsbDrive([]);
   apiMock.expectGetCurrentElectionMetadata(null);
   renderApp();
   await apiMock.authenticateAsSystemAdministrator();
 
-  await screen.findByRole('heading', { name: 'Election' });
+  userEvent.click(await screen.findButton('Smartcards'));
+  await screen.findByRole('heading', { name: 'Election Cards' });
 
   apiMock.setAuthStatus({
     status: 'logged_in',
@@ -594,7 +594,7 @@ test('Resetting system administrator smartcard PINs when no election definition 
   await waitFor(() =>
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
   );
-  await screen.findByText('Select an election package to configure VxAdmin');
+  await screen.findByRole('heading', { name: 'Election Cards' });
 });
 
 test('Unprogramming smartcards', async () => {
@@ -603,8 +603,8 @@ test('Unprogramming smartcards', async () => {
   renderApp();
   await apiMock.authenticateAsSystemAdministrator();
 
-  // The smartcard modal should open on any screen, not just the Smartcards screen
-  await screen.findByRole('heading', { name: 'Election' });
+  userEvent.click(await screen.findButton('Smartcards'));
+  await screen.findByRole('heading', { name: 'Election Cards' });
 
   const testCases: Array<{
     programmedUser: UserWithCard;
@@ -666,7 +666,7 @@ test('Unprogramming smartcards', async () => {
     await waitFor(() =>
       expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
     );
-    await screen.findByRole('heading', { name: 'Election' });
+    await screen.findByRole('heading', { name: 'Election Cards' });
   }
 });
 

--- a/apps/admin/frontend/src/screens/smartcards_screen.tsx
+++ b/apps/admin/frontend/src/screens/smartcards_screen.tsx
@@ -6,6 +6,7 @@ import { useParams } from 'react-router-dom';
 import { NavigationScreen } from '../components/navigation_screen';
 import { routerPaths } from '../router_paths';
 import { SmartcardsScreenProps, SmartcardType } from '../config/types';
+import { SmartcardModal } from '../components/smartcard_modal';
 
 const Body = styled.div`
   flex-grow: 1;
@@ -53,6 +54,7 @@ export function SmartcardsScreen(): JSX.Element {
           </LinkButton>
         </div>
       </div>
+      <SmartcardModal />
     </NavigationScreen>
   );
 }


### PR DESCRIPTION
## Overview

Short term fix for https://github.com/votingworks/vxsuite/issues/5388

Instead of showing the card programming modal on any screen when logged in as a sys admin, only show it on the smart cards screen. This will prevent users from accidentally resetting their system admin card PIN.

In addition, add the smart cards screen to the system admin left nav when unconfigured (to maintain the existing ability to program sys admin cards without configuring the machine). Note that currently the smart cards screen will have some misleading copy about creating election cards when unconfigured, but I'll be updating that screen in the next PR, so it's just a momentary issue.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/1df6516e-2cf9-4b60-a6c4-f1a5f7c321fd



## Testing Plan
Manual test and updated automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
