### PR TITLE
Add vendor screen and display it after authentication with a vendor card

### DIFF
--- a/apps/admin/frontend/src/app.test.tsx
+++ b/apps/admin/frontend/src/app.test.tsx
@@ -555,3 +555,25 @@ test('battery display and alert', async () => {
   // updated battery level in nav bar
   await screen.findByText('10%');
 });
+
+test('vendor screen', async () => {
+  const { renderApp } = buildApp(apiMock);
+  apiMock.expectGetCurrentElectionMetadata();
+  renderApp();
+
+  await apiMock.authenticateAsVendor();
+  await screen.findButton('Reboot to Vendor Menu');
+  const lockMachineButton = screen.getButton('Lock Machine');
+
+  // Test "Lock Machine" button
+  apiMock.expectLogOut();
+  userEvent.click(lockMachineButton);
+  apiMock.setAuthStatus({ status: 'logged_out', reason: 'machine_locked' });
+  await screen.findByText('VxAdmin is Locked');
+
+  // Test "Reboot to Vendor Menu" button
+  await apiMock.authenticateAsVendor();
+  const rebootButton = await screen.findButton('Reboot to Vendor Menu');
+  apiMock.expectRebootToVendorMenu();
+  userEvent.click(rebootButton);
+});

--- a/apps/admin/frontend/src/components/app_routes.tsx
+++ b/apps/admin/frontend/src/components/app_routes.tsx
@@ -5,6 +5,7 @@ import {
   InvalidCardScreen,
   UnlockMachineScreen,
   RemoveCardScreen,
+  VendorScreen,
 } from '@votingworks/ui';
 
 import {
@@ -30,7 +31,7 @@ import { WriteInsSummaryScreen } from '../screens/write_ins_summary_screen';
 import { SettingsScreen } from '../screens/settings_screen';
 import { ReportsScreen } from '../screens/reporting/reports_screen';
 import { SmartcardTypeRegExPattern } from '../config/types';
-import { checkPin } from '../api';
+import { checkPin, logOut, useApiClient } from '../api';
 import { WriteInsAdjudicationScreen } from '../screens/write_ins_adjudication_screen';
 import { TallyReportBuilder } from '../screens/reporting/tally_report_builder';
 import { BallotCountReportBuilder } from '../screens/reporting/ballot_count_report_builder';
@@ -44,7 +45,9 @@ import { DiagnosticsScreen } from '../screens/diagnostics_screen';
 export function AppRoutes(): JSX.Element | null {
   const { electionDefinition, auth } = useContext(AppContext);
   const election = electionDefinition?.election;
+  const apiClient = useApiClient();
   const checkPinMutation = checkPin.useMutation();
+  const logOutMutation = logOut.useMutation();
 
   const hasCardReaderAttached = !(
     auth.status === 'logged_out' && auth.reason === 'no_card_reader'
@@ -94,9 +97,13 @@ export function AppRoutes(): JSX.Element | null {
     );
   }
 
-  /* istanbul ignore next */
   if (isVendorAuth(auth)) {
-    return null;
+    return (
+      <VendorScreen
+        logOut={() => logOutMutation.mutate()}
+        rebootToVendorMenu={() => apiClient.rebootToVendorMenu()}
+      />
+    );
   }
 
   if (isSystemAdministratorAuth(auth)) {

--- a/apps/admin/frontend/test/helpers/mock_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_api_client.ts
@@ -28,6 +28,7 @@ import {
   mockElectionManagerUser,
   mockSessionExpiresAt,
   mockSystemAdministratorUser,
+  mockVendorUser,
 } from '@votingworks/test-utils';
 import {
   Admin,
@@ -149,6 +150,17 @@ export function createApiMock(
     },
 
     setPrinterStatus,
+
+    async authenticateAsVendor() {
+      // First verify that we're logged out
+      await screen.findByText('VxAdmin is Locked');
+      this.setAuthStatus({
+        status: 'logged_in',
+        user: mockVendorUser(),
+        sessionExpiresAt: mockSessionExpiresAt(),
+      });
+      await screen.findByText('Lock Machine');
+    },
 
     async authenticateAsSystemAdministrator() {
       // first verify that we're logged out
@@ -609,6 +621,10 @@ export function createApiMock(
     expectExportWriteInAdjudicationReportPdf: createDeferredMock(
       apiClient.exportWriteInAdjudicationReportPdf
     ),
+
+    expectRebootToVendorMenu() {
+      apiClient.rebootToVendorMenu.expectCallWith().resolves();
+    },
   };
 }
 

--- a/apps/central-scan/frontend/src/app_root.tsx
+++ b/apps/central-scan/frontend/src/app_root.tsx
@@ -13,6 +13,7 @@ import {
   Screen,
   SetupCardReaderPage,
   H1,
+  VendorScreen,
 } from '@votingworks/ui';
 import { BaseLogger } from '@votingworks/logging';
 import { assert } from '@votingworks/basics';
@@ -31,6 +32,8 @@ import {
   getStatus,
   getTestMode,
   getUsbDriveStatus,
+  logOut,
+  useApiClient,
 } from './api';
 import { UnconfiguredElectionScreenWrapper } from './screens/unconfigured_election_screen_wrapper';
 import { SystemAdministratorSettingsScreen } from './screens/system_administrator_settings_screen';
@@ -41,11 +44,13 @@ export interface AppRootProps {
 }
 
 export function AppRoot({ logger }: AppRootProps): JSX.Element | null {
+  const apiClient = useApiClient();
   const machineConfigQuery = getMachineConfig.useQuery();
   const usbDriveStatusQuery = getUsbDriveStatus.useQuery();
   const authStatusQuery = getAuthStatus.useQuery();
   const checkPinMutation = checkPin.useMutation();
   const statusQuery = getStatus.useQuery();
+  const logOutMutation = logOut.useMutation();
 
   const getTestModeQuery = getTestMode.useQuery();
   const isTestMode = getTestModeQuery.data ?? false;
@@ -140,9 +145,13 @@ export function AppRoot({ logger }: AppRootProps): JSX.Element | null {
     );
   }
 
-  /* istanbul ignore next */
   if (isVendorAuth(authStatus)) {
-    return null;
+    return (
+      <VendorScreen
+        logOut={() => logOutMutation.mutate()}
+        rebootToVendorMenu={() => apiClient.rebootToVendorMenu()}
+      />
+    );
   }
 
   if (isSystemAdministratorAuth(authStatus)) {

--- a/apps/central-scan/frontend/test/api.tsx
+++ b/apps/central-scan/frontend/test/api.tsx
@@ -157,6 +157,10 @@ export function createApiMock(
         .expectCallWith()
         .resolves(summary);
     },
+
+    expectRebootToVendorMenu() {
+      apiClient.rebootToVendorMenu.expectCallWith().resolves();
+    },
   };
 }
 

--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -23,6 +23,7 @@ import {
   InvalidCardScreen,
   SetupCardReaderPage,
   UnlockMachineScreen,
+  VendorScreen,
   VoterSettingsManagerContext,
   useAudioControls,
   useLanguageControls,
@@ -52,6 +53,7 @@ import {
   updateCardlessVoterBallotStyle,
   unconfigureMachine,
   systemCallApi,
+  useApiClient,
 } from './api';
 
 import * as GLOBALS from './config/globals';
@@ -170,6 +172,8 @@ export function AppRoot(): JSX.Element | null {
   const voterSettingsManager = React.useContext(VoterSettingsManagerContext);
   const { reset: resetAudioSettings } = useAudioControls();
   const { reset: resetLanguage } = useLanguageControls();
+
+  const apiClient = useApiClient();
 
   const machineConfigQuery = getMachineConfig.useQuery();
   const batteryQuery = systemCallApi.getBatteryInfo.useQuery();
@@ -400,9 +404,10 @@ export function AppRoot(): JSX.Element | null {
     );
   }
 
-  /* istanbul ignore next */
   if (isVendorAuth(authStatus)) {
-    return null;
+    return (
+      <VendorScreen rebootToVendorMenu={() => apiClient.rebootToVendorMenu()} />
+    );
   }
 
   if (isSystemAdministratorAuth(authStatus)) {

--- a/apps/mark-scan/frontend/src/app_vendor_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/app_vendor_screen.test.tsx
@@ -1,0 +1,31 @@
+import userEvent from '@testing-library/user-event';
+
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
+import { render, screen } from '../test/react_testing_library';
+import { App } from './app';
+
+let apiMock: ApiMock;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  apiMock = createApiMock();
+  apiMock.expectGetSystemSettings();
+});
+
+afterEach(() => {
+  apiMock.mockApiClient.assertComplete();
+});
+
+test('Vendor screen', async () => {
+  apiMock.expectGetMachineConfig();
+  apiMock.expectGetElectionRecord(null);
+  apiMock.expectGetElectionState();
+  render(<App apiClient={apiMock.mockApiClient} />);
+
+  apiMock.setAuthStatusVendorLoggedIn();
+  const rebootButton = await screen.findButton('Reboot to Vendor Menu');
+  screen.getByText('Remove the card to leave this screen.');
+
+  apiMock.expectRebootToVendorMenu();
+  userEvent.click(rebootButton);
+});

--- a/apps/mark-scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/mark-scan/frontend/test/helpers/mock_api_client.tsx
@@ -30,6 +30,7 @@ import {
   mockPollWorkerUser,
   mockSessionExpiresAt,
   mockSystemAdministratorUser,
+  mockVendorUser,
 } from '@votingworks/test-utils';
 import { err, ok, Result } from '@votingworks/basics';
 import type { BatteryInfo, DiskSpaceSummary } from '@votingworks/backend';
@@ -120,6 +121,14 @@ export function createApiMock() {
     setUsbDriveStatus,
 
     setAuthStatus,
+
+    setAuthStatusVendorLoggedIn() {
+      setAuthStatus({
+        status: 'logged_in',
+        user: mockVendorUser(),
+        sessionExpiresAt: mockSessionExpiresAt(),
+      });
+    },
 
     setAuthStatusSystemAdministratorLoggedIn() {
       setAuthStatus({
@@ -377,6 +386,10 @@ export function createApiMock() {
           total: 2_000_000_000,
         }
       );
+    },
+
+    expectRebootToVendorMenu() {
+      mockApiClient.rebootToVendorMenu.expectCallWith().resolves();
     },
   };
 }

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -31,6 +31,7 @@ import {
   useLanguageControls,
   InvalidCardScreen,
   useQueryChangeListener,
+  VendorScreen,
 } from '@votingworks/ui';
 
 import { assert, assertDefined, throwIllegalValue } from '@votingworks/basics';
@@ -56,6 +57,7 @@ import {
   getPrinterStatus,
   systemCallApi,
   getAccessibleControllerConnected,
+  useApiClient,
 } from './api';
 
 import { Ballot } from './components/ballot';
@@ -148,6 +150,8 @@ export function AppRoot({ reload }: Props): JSX.Element | null {
   const voterSettingsManager = React.useContext(VoterSettingsManagerContext);
   const { reset: resetAudioSettings } = useAudioControls();
   const { reset: resetLanguage } = useLanguageControls();
+
+  const apiClient = useApiClient();
 
   const machineConfigQuery = getMachineConfig.useQuery();
 
@@ -426,9 +430,10 @@ export function AppRoot({ reload }: Props): JSX.Element | null {
     );
   }
 
-  /* istanbul ignore next */
   if (isVendorAuth(authStatus)) {
-    return null;
+    return (
+      <VendorScreen rebootToVendorMenu={() => apiClient.rebootToVendorMenu()} />
+    );
   }
 
   if (isSystemAdministratorAuth(authStatus)) {

--- a/apps/mark/frontend/src/app_vendor_screen.test.tsx
+++ b/apps/mark/frontend/src/app_vendor_screen.test.tsx
@@ -1,0 +1,31 @@
+import userEvent from '@testing-library/user-event';
+
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
+import { render, screen } from '../test/react_testing_library';
+import { App } from './app';
+
+let apiMock: ApiMock;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  apiMock = createApiMock();
+  apiMock.expectGetSystemSettings();
+});
+
+afterEach(() => {
+  apiMock.mockApiClient.assertComplete();
+});
+
+test('Vendor screen', async () => {
+  apiMock.expectGetMachineConfig();
+  apiMock.expectGetElectionRecord(null);
+  apiMock.expectGetElectionState();
+  render(<App apiClient={apiMock.mockApiClient} />);
+
+  apiMock.setAuthStatusVendorLoggedIn();
+  const rebootButton = await screen.findButton('Reboot to Vendor Menu');
+  screen.getByText('Remove the card to leave this screen.');
+
+  apiMock.expectRebootToVendorMenu();
+  userEvent.click(rebootButton);
+});

--- a/apps/mark/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/mark/frontend/test/helpers/mock_api_client.tsx
@@ -28,6 +28,7 @@ import {
   mockPollWorkerUser,
   mockSessionExpiresAt,
   mockSystemAdministratorUser,
+  mockVendorUser,
 } from '@votingworks/test-utils';
 import { err, ok, Result } from '@votingworks/basics';
 import { TestErrorBoundary } from '@votingworks/ui';
@@ -149,6 +150,14 @@ export function createApiMock() {
     setAccessibleControllerConnected,
 
     setAuthStatus,
+
+    setAuthStatusVendorLoggedIn() {
+      setAuthStatus({
+        status: 'logged_in',
+        user: mockVendorUser(),
+        sessionExpiresAt: mockSessionExpiresAt(),
+      });
+    },
 
     setAuthStatusSystemAdministratorLoggedIn() {
       setAuthStatus({
@@ -307,6 +316,10 @@ export function createApiMock() {
           ...input,
         })
         .resolves();
+    },
+
+    expectRebootToVendorMenu() {
+      mockApiClient.rebootToVendorMenu.expectCallWith().resolves();
     },
   };
 }

--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -1013,3 +1013,19 @@ test('double feed detection calibration failure', async () => {
   });
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
 });
+
+test('vendor screen', async () => {
+  apiMock.expectGetConfig();
+  apiMock.expectGetPollsInfo('polls_closed_initial');
+  apiMock.expectGetUsbDriveStatus('mounted');
+  apiMock.expectGetScannerStatus(statusNoPaper);
+  apiMock.setPrinterStatusV3({ connected: true });
+  renderApp();
+
+  apiMock.authenticateAsVendor();
+  const rebootButton = await screen.findButton('Reboot to Vendor Menu');
+  screen.getByText('Remove the card to leave this screen.');
+
+  apiMock.expectRebootToVendorMenu();
+  userEvent.click(rebootButton);
+});

--- a/apps/scan/frontend/src/app_root.tsx
+++ b/apps/scan/frontend/src/app_root.tsx
@@ -1,4 +1,8 @@
-import { SetupCardReaderPage, UnlockMachineScreen } from '@votingworks/ui';
+import {
+  SetupCardReaderPage,
+  UnlockMachineScreen,
+  VendorScreen,
+} from '@votingworks/ui';
 import {
   isSystemAdministratorAuth,
   isElectionManagerAuth,
@@ -27,6 +31,7 @@ import {
   getPrinterStatus,
   getScannerStatus,
   getUsbDriveStatus,
+  useApiClient,
 } from './api';
 import { VoterScreen } from './screens/voter_screen';
 import { LoginPromptScreen } from './screens/login_prompt_screen';
@@ -42,6 +47,7 @@ export function AppRoot(): JSX.Element | null {
     setShouldStayOnCastVoteRecordSyncRequiredScreen,
   ] = useState(false);
 
+  const apiClient = useApiClient();
   const authStatusQuery = getAuthStatus.useQuery();
   const configQuery = getConfig.useQuery();
   const pollsInfoQuery = getPollsInfo.useQuery();
@@ -119,9 +125,10 @@ export function AppRoot(): JSX.Element | null {
     );
   }
 
-  /* istanbul ignore next */
   if (isVendorAuth(authStatus)) {
-    return null;
+    return (
+      <VendorScreen rebootToVendorMenu={() => apiClient.rebootToVendorMenu()} />
+    );
   }
 
   if (isSystemAdministratorAuth(authStatus)) {

--- a/apps/scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/scan/frontend/test/helpers/mock_api_client.tsx
@@ -30,6 +30,7 @@ import {
   mockPollWorkerUser,
   mockSessionExpiresAt,
   mockSystemAdministratorUser,
+  mockVendorUser,
 } from '@votingworks/test-utils';
 import { UsbDriveStatus } from '@votingworks/usb-drive';
 import { TestErrorBoundary, mockUsbDriveStatus } from '@votingworks/ui';
@@ -99,6 +100,14 @@ export function createApiMock() {
 
     setPrinterStatusV3,
     setPrinterStatusV4,
+
+    authenticateAsVendor() {
+      setAuthStatus({
+        status: 'logged_in',
+        user: mockVendorUser(),
+        sessionExpiresAt: mockSessionExpiresAt(),
+      });
+    },
 
     authenticateAsSystemAdministrator() {
       setAuthStatus({
@@ -344,6 +353,10 @@ export function createApiMock() {
       result: ExportDataResult = ok(['/media/vx/usb-drive/report.pdf'])
     ) {
       mockApiClient.saveReadinessReport.expectCallWith().resolves(result);
+    },
+
+    expectRebootToVendorMenu() {
+      mockApiClient.rebootToVendorMenu.expectCallWith().resolves();
     },
   };
 }

--- a/libs/backend/src/env.d.ts
+++ b/libs/backend/src/env.d.ts
@@ -5,6 +5,7 @@ declare namespace NodeJS {
   export interface ProcessEnv {
     readonly NODE_ENV: 'development' | 'production' | 'test';
     readonly SCAN_ALLOWED_EXPORT_PATTERNS?: string;
+    readonly VX_CONFIG_ROOT?: string;
     readonly VX_MACHINE_ID?: string;
   }
 }

--- a/libs/backend/src/intermediate-scripts/reboot-to-vendor-menu
+++ b/libs/backend/src/intermediate-scripts/reboot-to-vendor-menu
@@ -2,11 +2,9 @@
 
 set -euo pipefail
 
-if [[ -z "${VX_CONFIG_ROOT}" ]]; then
-  echo "VX_CONFIG_ROOT is not set, likely because running in dev" >&2
-else
-  touch "${VX_CONFIG_ROOT}/app-flags/REBOOT_TO_VENDOR_MENU"
-fi
+APP_FLAGS_LOCATION="${1}"
+
+touch "${APP_FLAGS_LOCATION}/REBOOT_TO_VENDOR_MENU"
 
 # -i prevents blocking the reboot on other logged-in users
 systemctl reboot -i

--- a/libs/backend/src/intermediate-scripts/reboot-to-vendor-menu
+++ b/libs/backend/src/intermediate-scripts/reboot-to-vendor-menu
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ -z "${VX_CONFIG_ROOT}" ]]; then
+  echo "VX_CONFIG_ROOT is not set likely because running in dev" >&2
+else
+  echo 1 > "${VX_CONFIG_ROOT}/REBOOT_TO_VENDOR_MENU"
+fi
+
+# -i prevents blocking the reboot on other logged-in users
+systemctl reboot -i

--- a/libs/backend/src/intermediate-scripts/reboot-to-vendor-menu
+++ b/libs/backend/src/intermediate-scripts/reboot-to-vendor-menu
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 if [[ -z "${VX_CONFIG_ROOT}" ]]; then
-  echo "VX_CONFIG_ROOT is not set likely because running in dev" >&2
+  echo "VX_CONFIG_ROOT is not set, likely because running in dev" >&2
 else
-  echo 1 > "${VX_CONFIG_ROOT}/REBOOT_TO_VENDOR_MENU"
+  touch "${VX_CONFIG_ROOT}/app-flags/REBOOT_TO_VENDOR_MENU"
 fi
 
 # -i prevents blocking the reboot on other logged-in users

--- a/libs/backend/src/intermediate_scripts.ts
+++ b/libs/backend/src/intermediate_scripts.ts
@@ -6,7 +6,12 @@ import path from 'node:path';
  * file (defined in vxsuite-complete-system).
  */
 export function intermediateScript(
-  script: 'power-down' | 'reboot' | 'reboot-to-bios' | 'set-clock'
+  script:
+    | 'power-down'
+    | 'reboot'
+    | 'reboot-to-bios'
+    | 'reboot-to-vendor-menu'
+    | 'set-clock'
 ): string {
   // Prefix with ../src since we're actually in ../build at runtime
   return path.join(__dirname, '../src/intermediate-scripts', script);

--- a/libs/backend/src/system_call/api.test.ts
+++ b/libs/backend/src/system_call/api.test.ts
@@ -48,7 +48,7 @@ test('rebootToBios', async () => {
   expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
     LogEventId.RebootMachine,
     {
-      message: 'User trigged a reboot of the machine to BIOS screen…',
+      message: 'User rebooted the machine into the BIOS.',
     }
   );
   expect(execMock).toHaveBeenCalledWith('sudo', [
@@ -58,10 +58,27 @@ test('rebootToBios', async () => {
   ]);
 });
 
+test('rebootToVendorMenu', async () => {
+  await api.rebootToVendorMenu();
+  expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
+    LogEventId.RebootMachine,
+    {
+      message: 'Vendor rebooted the machine into the vendor menu.',
+    }
+  );
+  expect(execMock).toHaveBeenCalledWith('sudo', [
+    expect.stringMatching(
+      new RegExp(
+        '^/.*/libs/backend/src/intermediate-scripts/reboot-to-vendor-menu$'
+      )
+    ),
+  ]);
+});
+
 test('powerDown', async () => {
   await api.powerDown();
   expect(logger.logAsCurrentRole).toHaveBeenCalledWith(LogEventId.PowerDown, {
-    message: 'User triggered the machine to power down.',
+    message: 'User powered down the machine.',
   });
   expect(execMock).toHaveBeenCalledWith('sudo', [
     expect.stringMatching(

--- a/libs/backend/src/system_call/api.test.ts
+++ b/libs/backend/src/system_call/api.test.ts
@@ -27,6 +27,7 @@ let logger: Logger;
 let api: SystemCallApi;
 
 beforeEach(() => {
+  (process.env.VX_CONFIG_ROOT as string) = '/vx/config';
   mockUsbDrive = createMockUsbDrive();
   logger = mockLogger();
   api = createSystemCallApi({
@@ -72,6 +73,28 @@ test('rebootToVendorMenu', async () => {
         '^/.*/libs/backend/src/intermediate-scripts/reboot-to-vendor-menu$'
       )
     ),
+    '/vx/config/app-flags',
+  ]);
+});
+
+test('rebootToVendorMenu in dev', async () => {
+  delete (process.env as unknown as { VX_CONFIG_ROOT: undefined })
+    .VX_CONFIG_ROOT;
+
+  await api.rebootToVendorMenu();
+  expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
+    LogEventId.RebootMachine,
+    {
+      message: 'Vendor rebooted the machine into the vendor menu.',
+    }
+  );
+  expect(execMock).toHaveBeenCalledWith('sudo', [
+    expect.stringMatching(
+      new RegExp(
+        '^/.*/libs/backend/src/intermediate-scripts/reboot-to-vendor-menu$'
+      )
+    ),
+    '/tmp',
   ]);
 });
 

--- a/libs/backend/src/system_call/api.ts
+++ b/libs/backend/src/system_call/api.ts
@@ -4,6 +4,7 @@ import { UsbDrive } from '@votingworks/usb-drive';
 import { LogExportFormat, Logger } from '@votingworks/logging';
 import { exportLogsToUsb } from './export_logs_to_usb';
 import { rebootToBios } from './reboot_to_bios';
+import { rebootToVendorMenu } from './reboot_to_vendor_menu';
 import { powerDown } from './power_down';
 import { setClock } from './set_clock';
 import { getBatteryInfo } from './get_battery_info';
@@ -30,6 +31,7 @@ function buildApi({
         codeVersion,
       }),
     rebootToBios: async () => rebootToBios(logger),
+    rebootToVendorMenu: async () => rebootToVendorMenu(logger),
     powerDown: async () => powerDown(logger),
     setClock,
     getBatteryInfo,

--- a/libs/backend/src/system_call/power_down.ts
+++ b/libs/backend/src/system_call/power_down.ts
@@ -3,13 +3,12 @@ import { execFile } from '../exec';
 import { intermediateScript } from '../intermediate_scripts';
 
 /**
- * Reboots the machine.
+ * Powers down the machine.
  */
 export async function powerDown(logger: Logger): Promise<void> {
   await logger.logAsCurrentRole(LogEventId.PowerDown, {
-    message: 'User triggered the machine to power down.',
+    message: 'User powered down the machine.',
   });
 
-  // -i prevents blocking the reboot on other logged in users
   void execFile('sudo', [intermediateScript('power-down')]);
 }

--- a/libs/backend/src/system_call/reboot_to_bios.ts
+++ b/libs/backend/src/system_call/reboot_to_bios.ts
@@ -7,7 +7,7 @@ import { intermediateScript } from '../intermediate_scripts';
  */
 export async function rebootToBios(logger: Logger): Promise<void> {
   await logger.logAsCurrentRole(LogEventId.RebootMachine, {
-    message: 'User trigged a reboot of the machine to BIOS screen…',
+    message: 'User rebooted the machine into the BIOS.',
   });
 
   void execFile('sudo', [intermediateScript('reboot-to-bios')]);

--- a/libs/backend/src/system_call/reboot_to_vendor_menu.ts
+++ b/libs/backend/src/system_call/reboot_to_vendor_menu.ts
@@ -1,4 +1,6 @@
+import path from 'node:path';
 import { LogEventId, Logger } from '@votingworks/logging';
+
 import { execFile } from '../exec';
 import { intermediateScript } from '../intermediate_scripts';
 
@@ -10,5 +12,14 @@ export async function rebootToVendorMenu(logger: Logger): Promise<void> {
     message: 'Vendor rebooted the machine into the vendor menu.',
   });
 
-  void execFile('sudo', [intermediateScript('reboot-to-vendor-menu')]);
+  // Not all env vars are propagated when using sudo, so we access the VX_CONFIG_ROOT env var here
+  // rather than in the script itself
+  const appFlagsLocation = process.env.VX_CONFIG_ROOT
+    ? path.join(process.env.VX_CONFIG_ROOT, 'app-flags')
+    : '/tmp'; // VX_CONFIG_ROOT is not defined in dev
+
+  void execFile('sudo', [
+    intermediateScript('reboot-to-vendor-menu'),
+    appFlagsLocation,
+  ]);
 }

--- a/libs/backend/src/system_call/reboot_to_vendor_menu.ts
+++ b/libs/backend/src/system_call/reboot_to_vendor_menu.ts
@@ -1,0 +1,14 @@
+import { LogEventId, Logger } from '@votingworks/logging';
+import { execFile } from '../exec';
+import { intermediateScript } from '../intermediate_scripts';
+
+/**
+ * Reboots the machine into the vendor menu.
+ */
+export async function rebootToVendorMenu(logger: Logger): Promise<void> {
+  await logger.logAsCurrentRole(LogEventId.RebootMachine, {
+    message: 'Vendor rebooted the machine into the vendor menu.',
+  });
+
+  void execFile('sudo', [intermediateScript('reboot-to-vendor-menu')]);
+}

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -88,6 +88,7 @@ export * from './timer';
 export * from './touch_text_input';
 export * from './typography';
 export * from './usbcontroller_button';
+export * from './vendor_screen';
 export * from './remove_card_screen';
 export { InvalidCardScreen } from './invalid_card_screen';
 export * from './ui_strings';

--- a/libs/ui/src/system_call_api.test.tsx
+++ b/libs/ui/src/system_call_api.test.tsx
@@ -21,6 +21,7 @@ function QueryWrapper(props: { children: React.ReactNode }) {
 
 const mockApiClient: jest.Mocked<SystemCallApiClient> = {
   rebootToBios: jest.fn(),
+  rebootToVendorMenu: jest.fn(),
   powerDown: jest.fn(),
   setClock: jest.fn(),
   exportLogsToUsb: jest.fn(),

--- a/libs/ui/src/vendor_screen.test.tsx
+++ b/libs/ui/src/vendor_screen.test.tsx
@@ -1,0 +1,44 @@
+import userEvent from '@testing-library/user-event';
+
+import { render, screen } from '../test/react_testing_library';
+import { VendorScreen } from './vendor_screen';
+
+let mockLogOut: jest.Mock;
+let mockRebootToVendorMenu: jest.Mock;
+
+beforeEach(() => {
+  mockLogOut = jest.fn();
+  mockRebootToVendorMenu = jest.fn();
+});
+
+test('Renders properly when logOut is provided', () => {
+  render(
+    <VendorScreen
+      logOut={mockLogOut}
+      rebootToVendorMenu={mockRebootToVendorMenu}
+    />
+  );
+
+  const rebootToVendorMenuButton = screen.getByText('Reboot to Vendor Menu');
+  const lockMachineButton = screen.getByText('Lock Machine');
+  expect(mockRebootToVendorMenu).not.toHaveBeenCalled();
+  expect(mockLogOut).not.toHaveBeenCalled();
+
+  userEvent.click(rebootToVendorMenuButton);
+  expect(mockRebootToVendorMenu).toHaveBeenCalledTimes(1);
+  expect(mockLogOut).not.toHaveBeenCalled();
+
+  userEvent.click(lockMachineButton);
+  expect(mockRebootToVendorMenu).toHaveBeenCalledTimes(1);
+  expect(mockLogOut).toHaveBeenCalledTimes(1);
+});
+
+test('Renders properly when logOut is not provided', () => {
+  render(<VendorScreen rebootToVendorMenu={mockRebootToVendorMenu} />);
+
+  const rebootToVendorMenuButton = screen.getByText('Reboot to Vendor Menu');
+  screen.getByText('Remove the card to leave this screen.');
+
+  userEvent.click(rebootToVendorMenuButton);
+  expect(mockRebootToVendorMenu).toHaveBeenCalledTimes(1);
+});

--- a/libs/ui/src/vendor_screen.tsx
+++ b/libs/ui/src/vendor_screen.tsx
@@ -1,0 +1,33 @@
+import { Button } from './button';
+import { Main } from './main';
+import { Screen } from './screen';
+import { P } from './typography';
+
+interface Props {
+  logOut?: () => void;
+  rebootToVendorMenu: () => Promise<void>;
+}
+
+export function VendorScreen({
+  logOut,
+  rebootToVendorMenu,
+}: Props): JSX.Element {
+  return (
+    <Screen>
+      <Main centerChild>
+        <P>
+          <Button onPress={rebootToVendorMenu} variant="primary">
+            Reboot to Vendor Menu
+          </Button>
+        </P>
+        {logOut ? (
+          <P>
+            <Button onPress={logOut}>Lock Machine</Button>
+          </P>
+        ) : (
+          <P>Remove the card to leave this screen.</P>
+        )}
+      </Main>
+    </Screen>
+  );
+}

--- a/libs/ui/test/test_context.tsx
+++ b/libs/ui/test/test_context.tsx
@@ -87,6 +87,7 @@ export function newTestContext(
 
   const mockSystemCallApiClient: jest.Mocked<SystemCallApiClient> = {
     rebootToBios: jest.fn(),
+    rebootToVendorMenu: jest.fn(),
     powerDown: jest.fn(),
     setClock: jest.fn(),
     exportLogsToUsb: jest.fn(),


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/4760

Finally pushing vendor card work over the finish line 😅

This PR adds a vendor screen and displays it after authentication with a vendor card. The exact mechanics of booting to the current TTY2 admin menu in TTY1 are covered in https://github.com/votingworks/vxsuite-complete-system/pull/395.

## Demo Video or Screenshot

_VxAdmin / VxCentralScan_

![central-system](https://github.com/user-attachments/assets/cb98a443-4b9c-4734-a678-103f94eb5f07)

_VxMark / VxScan_

![precinct-system](https://github.com/user-attachments/assets/fe7dab76-410c-4561-a597-d47a1209f825)

## Testing Plan

- [x] Added automated tests
- [x] Tested each app manually

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates