### PR TITLE
Allow System Admins to access diagnostics in VxScan and MarkScan

### DIFF
--- a/apps/mark-scan/frontend/src/pages/admin_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/admin_screen.test.tsx
@@ -176,7 +176,7 @@ test('Shows diagnostics button and renders screen after click', async () => {
   apiMock.expectGetMostRecentDiagnostic('mark-scan-pat-input');
   apiMock.expectGetMostRecentDiagnostic('mark-scan-headphone-input');
 
-  const diagnosticsButton = await screen.findByText('View Diagnostics');
+  const diagnosticsButton = await screen.findByText('Diagnostics');
   userEvent.click(diagnosticsButton);
   await screen.findByRole('heading', { name: 'System Diagnostics' });
   userEvent.click(screen.getByText('Back'));

--- a/apps/mark-scan/frontend/src/pages/admin_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/admin_screen.test.tsx
@@ -164,3 +164,21 @@ test('Shows election info', () => {
     )
   );
 });
+
+test('Shows diagnostics button and renders screen after click', async () => {
+  renderScreen();
+  apiMock.expectGetElectionRecord(null);
+  apiMock.expectGetElectionState();
+  apiMock.expectGetApplicationDiskSpaceSummary();
+  apiMock.expectGetIsAccessibleControllerInputDetected();
+  apiMock.expectGetMostRecentDiagnostic('mark-scan-accessible-controller');
+  apiMock.expectGetMostRecentDiagnostic('mark-scan-paper-handler');
+  apiMock.expectGetMostRecentDiagnostic('mark-scan-pat-input');
+  apiMock.expectGetMostRecentDiagnostic('mark-scan-headphone-input');
+
+  const diagnosticsButton = await screen.findByText('View Diagnostics');
+  userEvent.click(diagnosticsButton);
+  await screen.findByRole('heading', { name: 'System Diagnostics' });
+  userEvent.click(screen.getByText('Back'));
+  await screen.findByRole('heading', { name: 'Election Manager Settings' });
+});

--- a/apps/mark-scan/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/admin_screen.tsx
@@ -18,6 +18,7 @@ import {
   UnconfigureMachineButton,
   ExportLogsButton,
   SignedHashValidationButton,
+  Button,
 } from '@votingworks/ui';
 import {
   ElectionDefinition,
@@ -33,6 +34,7 @@ import {
   setTestMode,
   useApiClient,
 } from '../api';
+import { DiagnosticsScreen } from './diagnostics/diagnostics_screen';
 
 export interface AdminScreenProps {
   appPrecinct?: PrecinctSelection;
@@ -63,6 +65,8 @@ export function AdminScreen({
   const ejectUsbDriveMutation = ejectUsbDrive.useMutation();
   const setPrecinctSelectionMutation = setPrecinctSelection.useMutation();
   const setTestModeMutation = setTestMode.useMutation();
+  const [isDiagnosticsScreenOpen, setIsDiagnosticsScreenOpen] =
+    React.useState(false);
 
   async function unconfigureMachineAndEjectUsb() {
     try {
@@ -72,6 +76,14 @@ export function AdminScreen({
     } catch (error) {
       // Handled by default query client error handling
     }
+  }
+
+  if (isDiagnosticsScreenOpen) {
+    return (
+      <DiagnosticsScreen
+        onBackButtonPress={() => setIsDiagnosticsScreenOpen(false)}
+      />
+    );
   }
 
   return (
@@ -183,6 +195,12 @@ export function AdminScreen({
         <H6 as="h2">Security</H6>
         <P>
           <SignedHashValidationButton apiClient={apiClient} />
+        </P>
+        <H6 as="h2">Diagnostics</H6>
+        <P>
+          <Button onPress={() => setIsDiagnosticsScreenOpen(true)}>
+            View Diagnostics
+          </Button>
         </P>
       </Main>
       {election && (

--- a/apps/mark-scan/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/admin_screen.tsx
@@ -196,10 +196,10 @@ export function AdminScreen({
         <P>
           <SignedHashValidationButton apiClient={apiClient} />
         </P>
-        <H6 as="h2">Diagnostics</H6>
+        <H6 as="h2">System</H6>
         <P>
           <Button onPress={() => setIsDiagnosticsScreenOpen(true)}>
-            View Diagnostics
+            Diagnostics
           </Button>
         </P>
       </Main>

--- a/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
@@ -475,6 +475,40 @@ test('renders buttons for saving logs', async () => {
   await screen.findByText('Logs Saved');
 });
 
+test('shows diagnostics button for hardware v4 and renders screen after click', async () => {
+  apiMock.expectGetConfig();
+  apiMock.setPrinterStatusV4({ state: 'no-paper' });
+  apiMock.expectGetDiskSpaceSummary();
+  apiMock.expectGetMostRecentScannerDiagnostic();
+  apiMock.expectGetMostRecentPrinterDiagnostic();
+  apiMock.expectGetMostRecentAudioDiagnostic();
+  renderScreen({
+    scannerStatus: statusNoPaper,
+    usbDrive: mockUsbDriveStatus('mounted'),
+  });
+
+  await screen.findByRole('heading', { name: 'Election Manager Settings' });
+  userEvent.click(screen.getByRole('tab', { name: 'System Settings' }));
+  await screen.findByRole('heading', { name: 'Election Manager Settings' });
+  userEvent.click(screen.getByText('Diagnostics'));
+  await screen.findByRole('heading', { name: 'System Diagnostics' });
+  userEvent.click(screen.getByText('Back'));
+  await screen.findByRole('heading', { name: 'Election Manager Settings' });
+});
+
+test('no diagnostics button shown for hardware v3', async () => {
+  apiMock.expectGetConfig();
+  renderScreen({
+    scannerStatus: statusNoPaper,
+    usbDrive: mockUsbDriveStatus('mounted'),
+  });
+
+  await screen.findByRole('heading', { name: 'Election Manager Settings' });
+  userEvent.click(screen.getByRole('tab', { name: 'System Settings' }));
+  await screen.findByRole('heading', { name: 'Election Manager Settings' });
+  expect(screen.queryByText('Diagnostics')).not.toBeInTheDocument();
+});
+
 describe('hardware V4 printer management', () => {
   test('loading paper + printing test page', async () => {
     apiMock.expectGetConfig();

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -241,7 +241,7 @@ export function ElectionManagerScreen({
   );
 
   const diagnosticsButton =
-    printerStatusQuery.data?.scheme === 'hardware-v4' ? (
+    printerStatus.scheme === 'hardware-v4' ? (
       <Button onPress={() => setIsDiagnosticsScreenOpen(true)}>
         Diagnostics
       </Button>

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -39,6 +39,7 @@ import {
 } from '../api';
 import { usePreviewContext } from '../preview_dashboard';
 import { ElectionManagerPrinterTabContent } from '../components/printer_management/election_manager_printer_tab_content';
+import { DiagnosticsScreen } from './diagnostics_screen';
 
 const TabPanel = styled.div`
   display: flex;
@@ -80,6 +81,7 @@ export function ElectionManagerScreen({
 
   const [isConfirmingSwitchToTestMode, setIsConfirmingSwitchToTestMode] =
     useState(false);
+  const [isDiagnosticsScreenOpen, setIsDiagnosticsScreenOpen] = useState(false);
 
   const [isExportingResults, setIsExportingResults] = useState(false);
 
@@ -238,6 +240,13 @@ export function ElectionManagerScreen({
     />
   );
 
+  const diagnosticsButton =
+    printerStatusQuery.data?.scheme === 'hardware-v4' ? (
+      <Button onPress={() => setIsDiagnosticsScreenOpen(true)}>
+        Diagnostics
+      </Button>
+    ) : null;
+
   const powerDownButton = <PowerDownButton />;
 
   const cvrSyncRequiredWarning = isCvrSyncRequired ? (
@@ -290,11 +299,18 @@ export function ElectionManagerScreen({
           {dateTimeButton}
           {audioMuteToggle}
           <SignedHashValidationButton apiClient={apiClient} />
+          {diagnosticsButton}
           {powerDownButton}
         </TabPanel>
       ),
     }
   );
+
+  if (isDiagnosticsScreenOpen) {
+    return (
+      <DiagnosticsScreen onClose={() => setIsDiagnosticsScreenOpen(false)} />
+    );
+  }
 
   return (
     <Screen


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/5266

## Demo Video or Screenshot

**Scan - Election Manager access of Diagnostics under System Settings**

https://github.com/user-attachments/assets/5350db3a-dfa2-42ee-b1c8-3943367120cd

- Note: One non-ideal functionality shown in the video is that after a user closes the Diagnostics, they return to the Configuration tab rather than remaining in the System Settings tab. This is because the `TabbedSection` is not being rendered, so state is reset. We could fix this by pulling the state to the `ElectionManagerScreen`, but I am not sure if we feel this is needed.

**MarkScan - Election Manager access of Diagnostics**

https://github.com/user-attachments/assets/9e57a4a7-68d2-4966-911a-ca11d3ae6188

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
