### PR TITLE
style: various changes to work with newer `@typescript-eslint` versions

### DIFF
--- a/apps/admin/frontend/src/components/reporting/filter_editor.tsx
+++ b/apps/admin/frontend/src/components/reporting/filter_editor.tsx
@@ -47,17 +47,15 @@ const RemoveButton = styled(Button)`
   width: 1rem;
 `;
 
-const FILTER_TYPES = [
-  'precinct',
-  'voting-method',
-  'ballot-style',
-  'scanner',
-  'batch',
-  'party',
-  'adjudication-status',
-  'district',
-] as const;
-export type FilterType = (typeof FILTER_TYPES)[number];
+export type FilterType =
+  | 'precinct'
+  | 'voting-method'
+  | 'ballot-style'
+  | 'scanner'
+  | 'batch'
+  | 'party'
+  | 'adjudication-status'
+  | 'district';
 
 interface FilterRow {
   rowId: number;

--- a/apps/admin/frontend/src/screens/election_screen.tsx
+++ b/apps/admin/frontend/src/screens/election_screen.tsx
@@ -38,7 +38,7 @@ export function ElectionScreen(): JSX.Element {
     try {
       await unconfigureMutation.mutateAsync();
       history.push(routerPaths.root);
-    } catch (e) {
+    } catch {
       // Handled by default query client error handling
     }
   }

--- a/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
@@ -503,7 +503,7 @@ export function WriteInsAdjudicationScreen(): JSX.Element {
       });
       adjudicateAsWriteInCandidate(writeInCandidate);
       hideNewWriteInCandidateForm();
-    } catch (error) {
+    } catch {
       // Handled by default query client error handling
     }
   }

--- a/apps/central-scan/frontend/src/screens/settings_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/settings_screen.tsx
@@ -58,7 +58,7 @@ export function SettingsScreen({
       await ejectUsbDriveMutation.mutateAsync();
       await unconfigureMutation.mutateAsync({ ignoreBackupRequirement: false });
       history.replace('/');
-    } catch (e) {
+    } catch {
       // Handled by default query client error handling
     }
   }

--- a/apps/central-scan/frontend/src/screens/system_administrator_settings_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/system_administrator_settings_screen.tsx
@@ -33,7 +33,7 @@ export function SystemAdministratorSettingsScreen(): JSX.Element {
             await unconfigureMutation.mutateAsync({
               ignoreBackupRequirement: true,
             });
-          } catch (e) {
+          } catch {
             // Handled by default query client error handling
           }
         }}

--- a/apps/design/frontend/src/tabs.tsx
+++ b/apps/design/frontend/src/tabs.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { useHistory, useLocation } from 'react-router-dom';
 import { Row } from './layout';
 
-interface Tab extends Route {}
+type Tab = Route;
 
 interface TabBarProps {
   tabs: Tab[];

--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -282,7 +282,7 @@ export function AppRoot(): JSX.Element | null {
       await setPollsStateMutateAsync({
         pollsState: 'polls_paused',
       });
-    } catch (error) {
+    } catch {
       // Handled by default query client error handling
     }
   }, [setPollsStateMutateAsync]);

--- a/apps/mark-scan/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/admin_screen.tsx
@@ -73,7 +73,7 @@ export function AdminScreen({
       // If there is a mounted usb, eject it so that it doesn't auto reconfigure the machine.
       await ejectUsbDriveMutation.mutateAsync();
       await unconfigure();
-    } catch (error) {
+    } catch {
       // Handled by default query client error handling
     }
   }
@@ -111,7 +111,7 @@ export function AdminScreen({
                     await setPrecinctSelectionMutation.mutateAsync({
                       precinctSelection: newPrecinctSelection,
                     });
-                  } catch (error) {
+                  } catch {
                     // Handled by default query client error handling
                   }
                 }}

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -294,7 +294,7 @@ export function AppRoot({ reload }: Props): JSX.Element | null {
       await setPollsStateMutateAsync({
         pollsState: 'polls_paused',
       });
-    } catch (error) {
+    } catch {
       // Handled by default query client error handling
     }
   }, [setPollsStateMutateAsync]);

--- a/apps/mark/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.tsx
@@ -86,7 +86,7 @@ export function AdminScreen({
                     await setPrecinctSelectionMutation.mutateAsync({
                       precinctSelection: newPrecinctSelection,
                     });
-                  } catch (error) {
+                  } catch {
                     // Handled by default query client error handling
                   }
                 }}

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -131,7 +131,7 @@ export function ElectionManagerScreen({
       // TODO move this to the backend?
       await ejectUsbDriveMutation.mutateAsync();
       await unconfigureMutation.mutateAsync();
-    } catch (error) {
+    } catch {
       // Handled by default query client error handling
     }
   }
@@ -144,7 +144,7 @@ export function ElectionManagerScreen({
           await setPrecinctSelectionMutation.mutateAsync({
             precinctSelection: newPrecinctSelection,
           });
-        } catch (error) {
+        } catch {
           // Handled by default query client error handling
         }
       }}

--- a/libs/backend/src/system_call/export_logs_to_usb.ts
+++ b/libs/backend/src/system_call/export_logs_to_usb.ts
@@ -114,7 +114,7 @@ async function exportLogsToUsbHelper({
   try {
     const sourceStatus = await fs.stat(LOG_DIR);
     logDirPathExistsAndIsDirectory = sourceStatus.isDirectory();
-  } catch (e) {
+  } catch {
     // ignore
   }
 
@@ -178,7 +178,7 @@ async function exportLogsToUsbHelper({
         throwIllegalValue(format);
     }
     await usbDrive.sync();
-  } catch (error) {
+  } catch {
     return err('copy-failed');
   } finally {
     if (format === 'cdf' || format === 'err') {

--- a/libs/ballot-interpreter/src/hmpb-ts/cli.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/cli.ts
@@ -300,7 +300,7 @@ function tryReadElectionFromConfigTable(
     return electionDefinitionJson
       ? (safeParseJson(electionDefinitionJson).ok() as ElectionDefinition)
       : undefined;
-  } catch (error) {
+  } catch {
     return undefined;
   }
 }

--- a/libs/cdf-schema-builder/src/xsd.test.ts
+++ b/libs/cdf-schema-builder/src/xsd.test.ts
@@ -95,7 +95,7 @@ test('extractDocumentation', () => {
   const [mondayElement, tuesdayElement] = getChildrenOfType(
     getChildOfType(dayOfWeekElement, 'xsd:restriction')!,
     'xsd:enumeration'
-  )!;
+  );
   expect(extractDocumentation(mondayElement!)).toEqual(
     'The first day of the week.'
   );

--- a/libs/logging/src/export.ts
+++ b/libs/logging/src/export.ts
@@ -22,7 +22,7 @@ export async function* filterErrorLogs(
       if (obj['disposition'] && obj.disposition === 'failure') {
         yield line;
       }
-    } catch (error) {
+    } catch {
       // Skip this line if there are any errors parsing the JSON
     }
   }

--- a/libs/mark-flow-ui/src/components/candidate_contest.test.tsx
+++ b/libs/mark-flow-ui/src/components/candidate_contest.test.tsx
@@ -146,17 +146,17 @@ describe('supports single-seat contest', () => {
     );
 
     userEvent.click(
-      screen.getByText(candidateContest.candidates[0]!.name).closest('button')!
+      screen.getByText(candidateContest.candidates[0].name).closest('button')!
     );
     expect(updateVote).toHaveBeenCalledTimes(1);
 
     userEvent.click(
-      screen.getByText(candidateContest.candidates[1]!.name).closest('button')!
+      screen.getByText(candidateContest.candidates[1].name).closest('button')!
     );
     expect(updateVote).toHaveBeenCalledTimes(2);
 
     userEvent.click(
-      screen.getByText(candidateContest.candidates[2]!.name).closest('button')!
+      screen.getByText(candidateContest.candidates[2].name).closest('button')!
     );
     expect(updateVote).toHaveBeenCalledTimes(3);
 
@@ -177,7 +177,7 @@ describe('supports single-seat contest', () => {
     );
 
     const candidateButton = screen
-      .getByText(candidateContest.candidates[0]!.name)
+      .getByText(candidateContest.candidates[0].name)
       .closest('button')!;
     candidateButton.focus();
     await advanceTimersAndPromises();

--- a/libs/ui/src/power_down_button.tsx
+++ b/libs/ui/src/power_down_button.tsx
@@ -4,7 +4,8 @@ import { Loading } from './loading';
 import { Modal } from './modal';
 import { useSystemCallApi } from './system_call_api';
 
-export interface PowerDownButtonProps extends Omit<ButtonProps, 'onPress'> {}
+export type PowerDownButtonProps = Omit<ButtonProps, 'onPress'>;
+
 /**
  * Button that powers down the machine.
  */

--- a/libs/ui/src/radio_group.tsx
+++ b/libs/ui/src/radio_group.tsx
@@ -191,8 +191,7 @@ export function RadioGroupWithRef<T extends RadioGroupValue>(
 // Redeclare forwardRef so that it will work with our generic prop type
 // https://stackoverflow.com/a/58473012
 declare module 'react' {
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  function forwardRef<T, P = {}>(
+  function forwardRef<T, P = object>(
     render: (props: P, ref: React.Ref<T>) => React.ReactNode | null
   ): (props: P & React.RefAttributes<T>) => React.ReactNode | null;
 }

--- a/libs/ui/src/reports/ballot_count_report.tsx
+++ b/libs/ui/src/reports/ballot_count_report.tsx
@@ -39,8 +39,7 @@ interface AttributeColumn {
   id: AttributeColumnId;
 }
 
-const BALLOT_COUNT_COLUMNS = ['manual', 'bmd', 'hmpb', 'total'] as const;
-type BallotCountColumnId = (typeof BALLOT_COUNT_COLUMNS)[number];
+type BallotCountColumnId = 'manual' | 'bmd' | 'hmpb' | 'total';
 interface BallotCountColumn {
   type: 'ballot-count';
   id: BallotCountColumnId;

--- a/libs/utils/src/tabulation/tabulation.ts
+++ b/libs/utils/src/tabulation/tabulation.ts
@@ -249,15 +249,13 @@ function getCastVoteRecordGroupSpecifier(
 }
 
 export const GROUP_KEY_ROOT: Tabulation.GroupKey = 'root';
-const GROUP_KEY_PART_TYPES = [
-  'ballotStyleId',
-  'batchId',
-  'partyId',
-  'precinctId',
-  'scannerId',
-  'votingMethod',
-] as const;
-type GroupKeyPartType = (typeof GROUP_KEY_PART_TYPES)[number];
+type GroupKeyPartType =
+  | 'ballotStyleId'
+  | 'batchId'
+  | 'partyId'
+  | 'precinctId'
+  | 'scannerId'
+  | 'votingMethod';
 
 function escapeGroupKeyValue(groupKeyValue: string): string {
   return groupKeyValue


### PR DESCRIPTION

## Overview

In particular, newer versions of `@typescript-eslint` want:
- type aliases instead of empty `extends` interfaces
- no values used only for their types
- no unused `catch` bindings

This commit doesn't update the versions of `@typescript-eslint` packages because there's some CI-only issue (https://github.com/votingworks/vxsuite/pull/5422).

## Demo Video or Screenshot
n/a

## Testing Plan
Automated.