### PR TITLE
Kevin/mark scan diagnostic pat status

### DIFF
--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -55,7 +55,7 @@ import {
   SimpleServerStatus,
   buildMockPaperHandlerApi,
 } from './custom-paper-handler';
-import { ElectionState, PrintBallotProps } from './types';
+import { BmdModelNumber, ElectionState, PrintBallotProps } from './types';
 import { isAccessibleControllerDaemonRunning } from './util/hardware';
 import { saveReadinessReport } from './readiness_report';
 import { renderBallot } from './util/render_ballot';
@@ -471,6 +471,10 @@ export function buildApi(
         disposition: 'success',
       });
       return qrCodeValue;
+    },
+
+    getMarkScanBmdModel(): BmdModelNumber {
+      return this.getMarkScanBmdModel();
     },
 
     startPaperHandlerDiagnostic(): void {

--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -56,7 +56,10 @@ import {
   buildMockPaperHandlerApi,
 } from './custom-paper-handler';
 import { BmdModelNumber, ElectionState, PrintBallotProps } from './types';
-import { isAccessibleControllerDaemonRunning } from './util/hardware';
+import {
+  getMarkScanBmdModel,
+  isAccessibleControllerDaemonRunning,
+} from './util/hardware';
 import { saveReadinessReport } from './readiness_report';
 import { renderBallot } from './util/render_ballot';
 import { ElectionRecord, Store } from './store';
@@ -474,7 +477,7 @@ export function buildApi(
     },
 
     getMarkScanBmdModel(): BmdModelNumber {
-      return this.getMarkScanBmdModel();
+      return getMarkScanBmdModel();
     },
 
     startPaperHandlerDiagnostic(): void {

--- a/apps/mark-scan/frontend/src/api.ts
+++ b/apps/mark-scan/frontend/src/api.ts
@@ -198,6 +198,36 @@ export const getIsAccessibleControllerInputDetected = {
   },
 } as const;
 
+export const getIsPatDeviceConnected = {
+  queryKey(): QueryKey {
+    return ['getIsPatDeviceConnected'];
+  },
+
+  useQuery() {
+    const apiClient = useApiClient();
+
+    return useQuery(
+      this.queryKey(),
+      () => apiClient.getIsPatDeviceConnected(),
+      {
+        refetchInterval: STATE_MACHINE_POLLING_INTERVAL_MS,
+      }
+    );
+  },
+} as const;
+
+export const getMarkScanBmdModel = {
+  queryKey(): QueryKey {
+    return ['getMarkScanBmdModel'];
+  },
+
+  useQuery() {
+    const apiClient = useApiClient();
+
+    return useQuery(this.queryKey(), () => apiClient.getMarkScanBmdModel());
+  },
+} as const;
+
 export const addDiagnosticRecord = {
   useMutation(diagnosticType: DiagnosticType) {
     const apiClient = useApiClient();
@@ -472,24 +502,6 @@ export const saveReadinessReport = {
   useMutation() {
     const apiClient = useApiClient();
     return useMutation(apiClient.saveReadinessReport);
-  },
-} as const;
-
-export const getIsPatDeviceConnected = {
-  queryKey(): QueryKey {
-    return ['getIsPatDeviceConnected'];
-  },
-
-  useQuery() {
-    const apiClient = useApiClient();
-
-    return useQuery(
-      this.queryKey(),
-      () => apiClient.getIsPatDeviceConnected(),
-      {
-        refetchInterval: STATE_MACHINE_POLLING_INTERVAL_MS,
-      }
-    );
   },
 } as const;
 

--- a/apps/mark-scan/frontend/src/pages/admin_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/admin_screen.test.tsx
@@ -175,6 +175,7 @@ test('Shows diagnostics button and renders screen after click', async () => {
   apiMock.expectGetMostRecentDiagnostic('mark-scan-paper-handler');
   apiMock.expectGetMostRecentDiagnostic('mark-scan-pat-input');
   apiMock.expectGetMostRecentDiagnostic('mark-scan-headphone-input');
+  apiMock.expectGetMarkScanBmdModel();
 
   const diagnosticsButton = await screen.findByText('Diagnostics');
   userEvent.click(diagnosticsButton);

--- a/apps/mark-scan/frontend/src/pages/system_administrator_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/system_administrator_screen.test.tsx
@@ -84,6 +84,7 @@ test('navigates to System Diagnostics screen', async () => {
   apiMock.expectGetMostRecentDiagnostic('mark-scan-paper-handler');
   apiMock.expectGetMostRecentDiagnostic('mark-scan-pat-input');
   apiMock.expectGetMostRecentDiagnostic('mark-scan-headphone-input');
+  apiMock.expectGetMarkScanBmdModel();
   apiMock.expectGetApplicationDiskSpaceSummary();
 
   userEvent.click(screen.getButton('System Diagnostics'));

--- a/apps/mark-scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/mark-scan/frontend/test/helpers/mock_api_client.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
 import {
   ACCEPTED_PAPER_TYPES,
+  BmdModelNumber,
   type AcceptedPaperType,
   type Api,
   type ElectionState,
@@ -376,6 +377,10 @@ export function createApiMock() {
       mockApiClient.getMostRecentDiagnostic
         .expectCallWith({ diagnosticType })
         .resolves(record ?? null);
+    },
+
+    expectGetMarkScanBmdModel(model: BmdModelNumber = 'bmd-150') {
+      mockApiClient.getMarkScanBmdModel.expectCallWith().resolves(model);
     },
 
     expectGetApplicationDiskSpaceSummary(summary?: DiskSpaceSummary) {

--- a/libs/ui/src/diagnostics/mark_scan_device_diagnostic_section.tsx
+++ b/libs/ui/src/diagnostics/mark_scan_device_diagnostic_section.tsx
@@ -11,6 +11,8 @@ export interface MarkScanDeviceDiagnosticSectionProps {
   mostRecentDiagnosticRecord?: DiagnosticRecord;
   children?: React.ReactNode;
   title: DiagnosticSectionTitle;
+  connectedText?: string;
+  notConnectedText?: string;
 }
 
 export function MarkScanDeviceDiagnosticSection({
@@ -19,6 +21,8 @@ export function MarkScanDeviceDiagnosticSection({
   mostRecentDiagnosticRecord,
   children,
   title,
+  connectedText,
+  notConnectedText,
 }: MarkScanDeviceDiagnosticSectionProps): JSX.Element {
   if (mostRecentDiagnosticRecord) {
     assert(mostRecentDiagnosticRecord.type === diagnosticType);
@@ -29,13 +33,13 @@ export function MarkScanDeviceDiagnosticSection({
     if (isDeviceConnected === true) {
       detectedText = (
         <P>
-          <SuccessIcon /> Connected
+          <SuccessIcon /> {connectedText || 'Connected'}
         </P>
       );
     } else {
       detectedText = (
         <P>
-          <WarningIcon /> Not connected
+          <WarningIcon /> {notConnectedText || 'Not connected'}
         </P>
       );
     }

--- a/libs/ui/src/diagnostics/mark_scan_readiness_report.test.tsx
+++ b/libs/ui/src/diagnostics/mark_scan_readiness_report.test.tsx
@@ -3,7 +3,7 @@ import { electionTwoPartyPrimaryDefinition } from '@votingworks/fixtures';
 import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 import { MarkScanReadinessReport } from './mark_scan_readiness_report';
 import { render, screen } from '../../test/react_testing_library';
-import { expectConnected, expectDiagnosticResult } from './test_utils';
+import { expectConnectionStatus, expectDiagnosticResult } from './test_utils';
 import { DiagnosticSectionTitle } from './types';
 
 test('MarkScanReadinessReport', () => {
@@ -67,9 +67,13 @@ test('MarkScanReadinessReport', () => {
   screen.getByText(/Example Primary Election/);
   screen.getByText(/All Precincts/);
   screen.getByText('Free Disk Space: 50% (500 GB / 1000 GB)');
-  expectConnected(screen, DiagnosticSectionTitle.PaperHandler, true);
-  expectConnected(screen, DiagnosticSectionTitle.AccessibleController, true);
-  expectConnected(screen, DiagnosticSectionTitle.PatInput, true);
+  expectConnectionStatus(screen, DiagnosticSectionTitle.PaperHandler, true);
+  expectConnectionStatus(
+    screen,
+    DiagnosticSectionTitle.AccessibleController,
+    true
+  );
+  expectConnectionStatus(screen, DiagnosticSectionTitle.PatInput, true);
   expectDiagnosticResult(screen, DiagnosticSectionTitle.PaperHandler, true);
   expectDiagnosticResult(screen, DiagnosticSectionTitle.PatInput, true);
   expectDiagnosticResult(screen, DiagnosticSectionTitle.HeadphoneInput, true);

--- a/libs/ui/src/diagnostics/test_utils.ts
+++ b/libs/ui/src/diagnostics/test_utils.ts
@@ -19,16 +19,12 @@ function expectTextInSection(
   ).toBeDefined();
 }
 
-export function expectConnected(
+export function expectConnectionStatus(
   screen: VxScreen,
   headerText: DiagnosticSectionTitle,
-  connectedExpected: boolean
+  connectionStatusText: string
 ): void {
-  expectTextInSection(
-    screen,
-    headerText,
-    connectedExpected ? 'Connected' : 'Not connected'
-  );
+  expectTextInSection(screen, headerText, connectionStatusText);
 }
 
 export function expectDiagnosticResult(


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/5275

## Demo Video or Screenshot

https://github.com/user-attachments/assets/cc0c9997-e124-489e-a84b-38c68286810c


## Testing Plan

- updated existing tests
- added test for BMD 155 fallback
- manually tested on VM

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
