### PR TITLE
Print through a single chromium instance cached in libs/printing

### DIFF
--- a/apps/admin/frontend/package.json
+++ b/apps/admin/frontend/package.json
@@ -130,7 +130,6 @@
     "@votingworks/fs": "workspace:*",
     "@votingworks/grout-test-utils": "workspace:*",
     "@votingworks/monorepo-utils": "workspace:*",
-    "@votingworks/printing": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
     "@votingworks/usb-drive": "workspace:*",
     "eslint-plugin-vx": "workspace:*",

--- a/apps/central-scan/backend/jest.config.js
+++ b/apps/central-scan/backend/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
   // tsconfig.json values.
   roots: ['<rootDir>/src'],
   setupFiles: ['<rootDir>/test/set_env_vars.ts'],
-  setupFilesAfterEnv: ['<rootDir>/test/setup_custom_matchers.ts'],
+  setupFilesAfterEnv: ['<rootDir>/test/setup_custom_matchers.ts', '<rootDir>/test/setupTests.ts'],
   coverageProvider: 'babel',
   collectCoverageFrom: [
     '**/*.{ts,tsx}',

--- a/apps/central-scan/backend/test/setupTests.ts
+++ b/apps/central-scan/backend/test/setupTests.ts
@@ -1,7 +1,5 @@
 import { cleanupCachedBrowser } from '@votingworks/printing';
-import { cleanupTestSuiteTmpFiles } from './cleanup';
 
 afterAll(async () => {
-  cleanupTestSuiteTmpFiles();
   await cleanupCachedBrowser();
 });

--- a/apps/design/backend/test/setupTests.ts
+++ b/apps/design/backend/test/setupTests.ts
@@ -2,7 +2,12 @@ import {
   toMatchPdfSnapshot,
   ToMatchPdfSnapshotOptions,
 } from '@votingworks/image-utils';
+import { cleanupCachedBrowser } from '@votingworks/printing';
 import { toMatchImageSnapshot } from 'jest-image-snapshot';
+
+afterAll(async () => {
+  await cleanupCachedBrowser();
+});
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/apps/mark-scan/backend/jest.config.js
+++ b/apps/mark-scan/backend/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
   // tsconfig.json values.
   roots: ['<rootDir>/src'],
   setupFiles: ['<rootDir>/test/set_env_vars.ts'],
-  setupFilesAfterEnv: ['<rootDir>/test/setup_custom_matchers.ts'],
+  setupFilesAfterEnv: ['<rootDir>/test/setup_custom_matchers.ts', '<rootDir>/test/setupTests.ts'],
   collectCoverageFrom: [
     '**/*.{ts,tsx}',
     '!**/node_modules/**',

--- a/apps/mark-scan/backend/src/app.preprinted_ballot_insertion.test.ts
+++ b/apps/mark-scan/backend/src/app.preprinted_ballot_insertion.test.ts
@@ -3,7 +3,6 @@ import tmp from 'tmp';
 import { buildMockInsertedSmartCardAuth } from '@votingworks/auth';
 import { createMockUsbDrive } from '@votingworks/usb-drive';
 import { typedAs } from '@votingworks/basics';
-import { Browser, launchBrowser } from '@votingworks/printing';
 
 import { mockBaseLogger } from '@votingworks/logging';
 import { Store } from './store';
@@ -19,16 +18,6 @@ function getMockStateMachine() {
   }) as unknown as jest.Mocked<PaperHandlerStateMachine>;
 }
 
-let browser: Browser;
-
-beforeEach(async () => {
-  browser = await launchBrowser();
-});
-
-afterEach(async () => {
-  await browser.close();
-});
-
 function buildTestApi() {
   const store = Store.memoryStore();
   const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger(), {
@@ -42,7 +31,6 @@ function buildTestApi() {
     createMockUsbDrive().usbDrive,
     buildMockLogger(mockAuth, workspace),
     workspace,
-    browser,
     mockStateMachine
   );
 

--- a/apps/mark-scan/backend/src/app.test.ts
+++ b/apps/mark-scan/backend/src/app.test.ts
@@ -37,7 +37,6 @@ import {
 import { MockUsbDrive } from '@votingworks/usb-drive';
 import { MockPaperHandlerDriver } from '@votingworks/custom-paper-handler';
 import { LogEventId, Logger, mockBaseLogger } from '@votingworks/logging';
-import { Browser } from '@votingworks/printing';
 import { AddressInfo } from 'node:net';
 import { SimulatedClock } from 'xstate/lib/SimulatedClock';
 import {
@@ -81,7 +80,6 @@ let stateMachine: PaperHandlerStateMachine;
 let driver: MockPaperHandlerDriver;
 let patConnectionStatusReader: PatConnectionStatusReader;
 let logger: Logger;
-let browser: Browser;
 let clock: SimulatedClock;
 
 beforeEach(async () => {
@@ -116,14 +114,12 @@ beforeEach(async () => {
   server = result.server;
   stateMachine = result.stateMachine;
   driver = result.driver;
-  browser = result.browser;
   clock = result.clock;
 });
 
 afterEach(async () => {
   featureFlagMock.resetFeatureFlags();
   await stateMachine.cleanUp();
-  await browser.close();
   server.close();
 });
 
@@ -673,13 +669,7 @@ test('addDiagnosticRecord', async () => {
 
 test('startPaperHandlerDiagnostic fails test if no state machine', async () => {
   const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger());
-  const app = buildApp(
-    mockAuth,
-    logger,
-    workspace,
-    mockUsbDrive.usbDrive,
-    browser
-  );
+  const app = buildApp(mockAuth, logger, workspace, mockUsbDrive.usbDrive);
   const serverNoStateMachine = app.listen();
   const { port } = serverNoStateMachine.address() as AddressInfo;
   const baseUrl = `http://localhost:${port}/api`;

--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -46,7 +46,6 @@ import {
   MockPaperHandlerStatus,
   PaperHandlerDriverInterface,
 } from '@votingworks/custom-paper-handler';
-import { Browser } from '@votingworks/printing';
 import { getMachineConfig } from './machine_config';
 import { Workspace } from './util/workspace';
 import {
@@ -81,7 +80,6 @@ export function buildApi(
   usbDrive: UsbDrive,
   logger: Logger,
   workspace: Workspace,
-  browser: Browser,
   stateMachine?: PaperHandlerStateMachine,
   paperHandler?: PaperHandlerDriverInterface
 ) {
@@ -246,7 +244,6 @@ export function buildApi(
 
       const pdfData = await renderBallot({
         store,
-        browser,
         ...input,
       });
       stateMachine.printBallot(pdfData);
@@ -500,7 +497,6 @@ export function buildApp(
   logger: Logger,
   workspace: Workspace,
   usbDrive: UsbDrive,
-  browser: Browser,
   stateMachine?: PaperHandlerStateMachine,
   paperHandler?: PaperHandlerDriverInterface
 ): Application {
@@ -510,7 +506,6 @@ export function buildApp(
     usbDrive,
     logger,
     workspace,
-    browser,
     stateMachine,
     paperHandler
   );

--- a/apps/mark-scan/backend/src/app.ui_strings.test.ts
+++ b/apps/mark-scan/backend/src/app.ui_strings.test.ts
@@ -15,7 +15,6 @@ import {
   getFeatureFlagMock,
 } from '@votingworks/utils';
 import { MockUsbDrive, createMockUsbDrive } from '@votingworks/usb-drive';
-import { Browser } from '@votingworks/printing';
 import { mockBaseLogger } from '@votingworks/logging';
 import { Store } from './store';
 import { createWorkspace } from './util/workspace';
@@ -41,10 +40,6 @@ const electionDefinition = safeParseElectionDefinition(
   JSON.stringify(testCdfBallotDefinition)
 ).unsafeUnwrap();
 
-// A headless browser isn't needed for these tests, and we can't easily launch a real instance in
-// this test file using an async beforeEach and afterEach given how runUiStringApiTests is called
-const mockBrowser = {} as unknown as Browser;
-
 afterEach(() => {
   workspace.reset();
 });
@@ -54,8 +49,7 @@ runUiStringApiTests({
     mockAuth,
     createMockUsbDrive().usbDrive,
     buildMockLogger(mockAuth, workspace),
-    workspace,
-    mockBrowser
+    workspace
   ),
   store: store.getUiStringsStore(),
 });
@@ -75,8 +69,7 @@ describe('configureElectionPackageFromUsb', () => {
       mockAuth,
       mockUsbDrive.usbDrive,
       buildMockLogger(mockAuth, workspace),
-      workspace,
-      mockBrowser
+      workspace
     );
 
     mockElectionManagerAuth(mockAuth, electionDefinition);
@@ -95,8 +88,7 @@ describe('unconfigureMachine', () => {
     mockAuth,
     createMockUsbDrive().usbDrive,
     buildMockLogger(mockAuth, workspace),
-    workspace,
-    mockBrowser
+    workspace
   );
 
   runUiStringMachineDeconfigurationTests({

--- a/apps/mark-scan/backend/src/server.ts
+++ b/apps/mark-scan/backend/src/server.ts
@@ -13,7 +13,6 @@ import {
 } from '@votingworks/utils';
 import { detectUsbDrive } from '@votingworks/usb-drive';
 import { detectDevices, initializeSystemAudio } from '@votingworks/backend';
-import { launchBrowser } from '@votingworks/printing';
 import { buildApp } from './app';
 import { Workspace } from './util/workspace';
 import { getPaperHandlerStateMachine } from './custom-paper-handler/state_machine';
@@ -107,8 +106,6 @@ export async function start({
 
   const usbDrive = detectUsbDrive(logger);
 
-  const browser = await launchBrowser();
-
   await initializeSystemAudio();
 
   const app = buildApp(
@@ -116,7 +113,6 @@ export async function start({
     logger,
     workspace,
     usbDrive,
-    browser,
     stateMachine,
     driver
   );

--- a/apps/mark-scan/backend/src/util/render_ballot.tsx
+++ b/apps/mark-scan/backend/src/util/render_ballot.tsx
@@ -1,5 +1,4 @@
 import {
-  Browser,
   PAPER_DIMENSIONS,
   PaperDimensions,
   renderToPdf,
@@ -23,7 +22,6 @@ import { getMarkScanBmdModel } from './hardware';
 
 export interface RenderBallotProps {
   store: Store;
-  browser: Browser;
   precinctId: string;
   ballotStyleId: string;
   votes: VotesDict;
@@ -72,7 +70,6 @@ export async function renderTestModeBallotWithoutLanguageContext(
 
 export async function renderBallot({
   store,
-  browser,
   precinctId,
   ballotStyleId,
   votes,
@@ -101,12 +98,9 @@ export async function renderBallot({
   );
 
   return (
-    await renderToPdf(
-      {
-        document: ballot,
-        paperDimensions: getPaperDimensions(),
-      },
-      browser
-    )
+    await renderToPdf({
+      document: ballot,
+      paperDimensions: getPaperDimensions(),
+    })
   ).unsafeUnwrap();
 }

--- a/apps/mark-scan/backend/test/app_helpers.ts
+++ b/apps/mark-scan/backend/test/app_helpers.ts
@@ -30,7 +30,6 @@ import {
 import { MockPaperHandlerDriver } from '@votingworks/custom-paper-handler';
 import { assert } from '@votingworks/basics';
 import { createMockUsbDrive, MockUsbDrive } from '@votingworks/usb-drive';
-import { Browser, launchBrowser } from '@votingworks/printing';
 import { SimulatedClock } from 'xstate/lib/SimulatedClock';
 import { Api, buildApp } from '../src/app';
 import { createWorkspace, Workspace } from '../src/util/workspace';
@@ -84,7 +83,6 @@ interface MockAppContents {
   stateMachine: PaperHandlerStateMachine;
   patConnectionStatusReader: PatConnectionStatusReaderInterface;
   driver: MockPaperHandlerDriver;
-  browser: Browser;
   clock: SimulatedClock;
 }
 
@@ -100,7 +98,6 @@ export async function createApp(
   const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger());
   const logger = buildMockLogger(mockAuth, workspace);
   const mockUsbDrive = createMockUsbDrive();
-  const browser = await launchBrowser();
   const patConnectionStatusReader =
     options?.patConnectionStatusReader ??
     new MockPatConnectionStatusReader(logger);
@@ -121,7 +118,6 @@ export async function createApp(
     logger,
     workspace,
     mockUsbDrive.usbDrive,
-    browser,
     stateMachine
   );
 
@@ -141,7 +137,6 @@ export async function createApp(
     stateMachine,
     patConnectionStatusReader,
     driver,
-    browser,
     clock,
   };
 }

--- a/apps/mark-scan/backend/test/setupTests.ts
+++ b/apps/mark-scan/backend/test/setupTests.ts
@@ -1,7 +1,5 @@
 import { cleanupCachedBrowser } from '@votingworks/printing';
-import { cleanupTestSuiteTmpFiles } from './cleanup';
 
 afterAll(async () => {
-  cleanupTestSuiteTmpFiles();
   await cleanupCachedBrowser();
 });

--- a/apps/mark/backend/jest.config.js
+++ b/apps/mark/backend/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
   // tsconfig.json values.
   roots: ['<rootDir>/src'],
   setupFiles: ['<rootDir>/test/set_env_vars.ts'],
-  setupFilesAfterEnv: ['<rootDir>/test/setup_custom_matchers.ts'],
+  setupFilesAfterEnv: ['<rootDir>/test/setup_custom_matchers.ts', '<rootDir>/test/setupTests.ts'],
   collectCoverageFrom: [
     '**/*.{ts,tsx}',
     '!**/node_modules/**',

--- a/apps/mark/backend/test/setupTests.ts
+++ b/apps/mark/backend/test/setupTests.ts
@@ -1,7 +1,5 @@
 import { cleanupCachedBrowser } from '@votingworks/printing';
-import { cleanupTestSuiteTmpFiles } from './cleanup';
 
 afterAll(async () => {
-  cleanupTestSuiteTmpFiles();
   await cleanupCachedBrowser();
 });

--- a/apps/scan/backend/jest.config.js
+++ b/apps/scan/backend/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
   // tsconfig.json values.
   roots: ['<rootDir>/src'],
   setupFiles: ['<rootDir>/test/set_env_vars.ts'],
-  setupFilesAfterEnv: ['<rootDir>/test/setup_custom_matchers.ts'],
+  setupFilesAfterEnv: ['<rootDir>/test/setup_custom_matchers.ts', '<rootDir>/test/setupTests.ts'],
   coverageProvider: 'babel',
   collectCoverageFrom: [
     '**/*.{ts,tsx}',

--- a/apps/scan/backend/test/setupTests.ts
+++ b/apps/scan/backend/test/setupTests.ts
@@ -1,7 +1,5 @@
 import { cleanupCachedBrowser } from '@votingworks/printing';
-import { cleanupTestSuiteTmpFiles } from './cleanup';
 
 afterAll(async () => {
-  cleanupTestSuiteTmpFiles();
   await cleanupCachedBrowser();
 });

--- a/libs/bmd-ballot-fixtures/jest.config.js
+++ b/libs/bmd-ballot-fixtures/jest.config.js
@@ -5,7 +5,7 @@ const shared = require('../../jest.config.shared');
  */
 module.exports = {
   ...shared,
-  setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
+  setupFilesAfterEnv: ['<rootDir>/test/setupTests.ts'],
   coverageThreshold: {
     global: {
       lines: 100,

--- a/libs/bmd-ballot-fixtures/package.json
+++ b/libs/bmd-ballot-fixtures/package.json
@@ -19,7 +19,7 @@
     "stylelint:run": "stylelint 'src/**/*.{js,jsx,ts,tsx}'",
     "stylelint:run:fix": "stylelint 'src/**/*.{js,jsx,ts,tsx}' --fix",
     "test": "is-ci test:ci test:watch",
-    "test:coverage": "TZ=America/Anchorage jest --coverage",
+    "test:coverage": "TZ=America/Anchorage jest --coverage --detectOpenHandles",
     "test:ci": "TZ=America/Anchorage jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:watch": "TZ=America/Anchorage jest --watch",
     "pre-commit": "lint-staged"

--- a/libs/bmd-ballot-fixtures/package.json
+++ b/libs/bmd-ballot-fixtures/package.json
@@ -19,7 +19,7 @@
     "stylelint:run": "stylelint 'src/**/*.{js,jsx,ts,tsx}'",
     "stylelint:run:fix": "stylelint 'src/**/*.{js,jsx,ts,tsx}' --fix",
     "test": "is-ci test:ci test:watch",
-    "test:coverage": "TZ=America/Anchorage jest --coverage --detectOpenHandles",
+    "test:coverage": "TZ=America/Anchorage jest --coverage",
     "test:ci": "TZ=America/Anchorage jest --coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "test:watch": "TZ=America/Anchorage jest --watch",
     "pre-commit": "lint-staged"

--- a/libs/bmd-ballot-fixtures/src/setupTests.ts
+++ b/libs/bmd-ballot-fixtures/src/setupTests.ts
@@ -1,3 +1,0 @@
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
-
-expect.extend({ toMatchImageSnapshot });

--- a/libs/bmd-ballot-fixtures/test/setupTests.ts
+++ b/libs/bmd-ballot-fixtures/test/setupTests.ts
@@ -1,7 +1,8 @@
+import { toMatchImageSnapshot } from 'jest-image-snapshot';
 import { cleanupCachedBrowser } from '@votingworks/printing';
-import { cleanupTestSuiteTmpFiles } from './cleanup';
 
 afterAll(async () => {
-  cleanupTestSuiteTmpFiles();
   await cleanupCachedBrowser();
 });
+
+expect.extend({ toMatchImageSnapshot });

--- a/libs/printing/src/render.tsx
+++ b/libs/printing/src/render.tsx
@@ -16,7 +16,7 @@ import { OPTIONAL_EXECUTABLE_PATH_OVERRIDE } from './chromium';
 const PLAYWRIGHT_PIXELS_PER_INCH = 96;
 const MAX_HTML_CHARACTERS = 5_000_000;
 
-let cachedBrowser: Browser;
+let cachedBrowser: Browser | undefined;
 
 export type PdfError = 'content-too-large';
 
@@ -74,6 +74,14 @@ export async function launchBrowser(): Promise<Browser> {
     args: ['--font-render-hinting=none'],
     executablePath: OPTIONAL_EXECUTABLE_PATH_OVERRIDE,
   });
+}
+
+/* istanbul ignore next - cleanup function for jest */
+export async function cleanupCachedBrowser(): Promise<void> {
+  if (cachedBrowser) {
+    await cachedBrowser.close();
+  }
+  cachedBrowser = undefined;
 }
 
 async function getOrCreateCachedBrowser(): Promise<Browser> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 overrides:
   '@types/eslint': 8.4.1
   graceful-fs: ^4.2.9
@@ -568,9 +564,6 @@ importers:
       '@votingworks/monorepo-utils':
         specifier: workspace:*
         version: link:../../../libs/monorepo-utils
-      '@votingworks/printing':
-        specifier: workspace:*
-        version: link:../../../libs/printing
       '@votingworks/test-utils':
         specifier: workspace:*
         version: link:../../../libs/test-utils
@@ -1074,7 +1067,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       type-fest:
         specifier: ^0.18.0
         version: 0.18.1
@@ -1533,7 +1526,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@20.16.0)
@@ -3032,7 +3025,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       wait-for-expect:
         specifier: ^3.0.2
         version: 3.0.2
@@ -3365,7 +3358,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/basics:
     dependencies:
@@ -3618,7 +3611,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/custom-scanner:
     dependencies:
@@ -3691,7 +3684,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@20.16.0)
@@ -4101,7 +4094,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/fixtures:
     dependencies:
@@ -4299,7 +4292,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/grout:
     dependencies:
@@ -4688,7 +4681,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/mark-flow-ui:
     dependencies:
@@ -5006,7 +4999,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       typescript:
         specifier: 5.5.3
         version: 5.5.3
@@ -5061,7 +5054,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/printing:
     dependencies:
@@ -5173,7 +5166,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/res-to-ts:
     dependencies:
@@ -5228,7 +5221,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/test-utils:
     dependencies:
@@ -5401,7 +5394,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/types-rs: {}
 
@@ -5680,7 +5673,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
       util:
         specifier: ^0.12.4
         version: 0.12.4
@@ -5753,7 +5746,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.5.3)
+        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.5.3)
 
   libs/utils:
     dependencies:
@@ -8612,7 +8605,7 @@ packages:
   /@joshwooding/vite-plugin-react-docgen-typescript@0.2.1(typescript@5.5.3)(vite@4.5.0):
     resolution: {integrity: sha512-ou4ZJSXMMWHqGS4g8uNRbC5TiTWxAgQZiVucoUrOCWuPrTbkpJbmVyIi9jU72SBry7gQtuMEDp4YR8EEXAg7VQ==}
     peerDependencies:
-      typescript: 5.5.3
+      typescript: '>= 4.3.x'
       vite: ^3.0.0 || ^4.0.0
     peerDependenciesMeta:
       typescript:
@@ -9695,7 +9688,7 @@ packages:
     resolution: {integrity: sha512-3YDxZPJsHOsRQob/85X2Xf6pYfwbQilJBsEcuwmEV0JEO4p3JijOlO8xV58uCjkZSpuJ0ARl6t5oCMBo89DKCQ==}
     peerDependencies:
       '@preact/preset-vite': '*'
-      typescript: 5.5.3
+      typescript: '>= 4.3.x'
       vite: ^3.0.0 || ^4.0.0
       vite-plugin-glimmerx: '*'
     peerDependenciesMeta:
@@ -10153,7 +10146,7 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-      typescript: 5.5.3
+      typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -14546,7 +14539,7 @@ packages:
     resolution: {integrity: sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      '@types/eslint': 8.4.1
+      '@types/eslint': '>=8.0.0'
       eslint: '>=8.0.0'
       eslint-config-prettier: '*'
       prettier: '>=3.0.0'
@@ -15202,7 +15195,7 @@ packages:
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
       eslint: '>= 6'
-      typescript: 5.5.3
+      typescript: '>= 2.7'
       vue-template-compiler: '*'
       webpack: '>= 4'
     peerDependenciesMeta:
@@ -15234,7 +15227,7 @@ packages:
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
       eslint: '>= 6'
-      typescript: 5.5.3
+      typescript: '>= 2.7'
       vue-template-compiler: '*'
       webpack: '>= 4'
     peerDependenciesMeta:
@@ -17065,7 +17058,7 @@ packages:
     resolution: {integrity: sha512-2ynEZ7IEJNrhrgshklDMhrOdnmW4Nt+PhkyRqZxRgpwMo7JjmFWMzyp0+eSyk+H9KK1QjXI5xTZIw6x7cVDcRg==}
     peerDependencies:
       jest: ^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0
-      typescript: 5.5.3
+      typescript: ^3.0.0 || ^4.0.0 || ^5.0.0
     dependencies:
       jest: 29.6.2(@types/node@20.16.0)
       ts-essentials: 7.0.3(typescript@5.5.3)
@@ -19703,7 +19696,7 @@ packages:
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
     peerDependencies:
-      typescript: 5.5.3
+      typescript: '>=2.7'
       webpack: '>=4'
     peerDependenciesMeta:
       typescript:
@@ -19745,7 +19738,7 @@ packages:
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
     peerDependencies:
-      typescript: 5.5.3
+      typescript: '>=2.7'
       webpack: '>=4'
     peerDependenciesMeta:
       typescript:
@@ -19785,7 +19778,7 @@ packages:
   /react-docgen-typescript@2.2.2(typescript@5.5.3):
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
-      typescript: 5.5.3
+      typescript: '>= 4.3.x'
     dependencies:
       typescript: 5.5.3
     dev: true
@@ -21849,7 +21842,7 @@ packages:
     resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
     engines: {node: '>=16.13.0'}
     peerDependencies:
-      typescript: 5.5.3
+      typescript: '>=4.2.0'
     dependencies:
       typescript: 5.5.3
 
@@ -21861,7 +21854,7 @@ packages:
   /ts-essentials@7.0.3(typescript@5.5.3):
     resolution: {integrity: sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==}
     peerDependencies:
-      typescript: 5.5.3
+      typescript: '>=3.7.0'
     dependencies:
       typescript: 5.5.3
     dev: true
@@ -21876,7 +21869,7 @@ packages:
       babel-jest: ^29.0.0
       esbuild: '*'
       jest: ^29.0.0
-      typescript: 5.5.3
+      typescript: '>=4.3 <6'
     peerDependenciesMeta:
       '@babel/core':
         optional: true
@@ -21911,7 +21904,7 @@ packages:
       babel-jest: ^29.0.0
       esbuild: '*'
       jest: ^29.0.0
-      typescript: 5.5.3
+      typescript: '>=4.3 <6'
     peerDependenciesMeta:
       '@babel/core':
         optional: true
@@ -21958,7 +21951,7 @@ packages:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
-      typescript: 5.5.3
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
       typescript: 5.5.3
@@ -22991,3 +22984,7 @@ packages:
   /zod@3.23.5:
     resolution: {integrity: sha512-fkwiq0VIQTksNNA131rDOsVJcns0pfVUjHzLrNBiF/O/Xxb5lQyEXkhZWcJ7npWsYlvs+h0jFWXXy4X46Em1JA==}
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
## Overview
After discussion in https://github.com/votingworks/vxsuite/pull/5431 look into this caching approach. Overall worked well with the main issue being test cleanup. I initially cleaned up the cached browser through the jest globalTeardown function but found that was still giving me warning about things being open (despite logging confirming it was closing the browser) and failing CI in bmd_ballot_fixtures. When I instead cleaned up in a global afterAll that was resolved and I noticed that is how we are already cleaning up other state in VxAdminBackend so decided that that seemed like the safer approach. 

Note the safeguard I add in the caching for the isConnected() check is in case a browser was closed mistakenly, I have never seen this happen in testing (unless I had a bug) but it seemed like a good safety to make sure we don't just break in production if that happens. Open to removing though. 
<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot
N/A

## Testing Plan
Compiled apps, ran tests, manual testing of prints 

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
