### PR TITLE
VxAdmin: Show human-readable batch name in reports

### DIFF
--- a/apps/admin/backend/src/exports/csv_shared.ts
+++ b/apps/admin/backend/src/exports/csv_shared.ts
@@ -169,6 +169,7 @@ export function generateCsvMetadataHeaders({
   }
 
   if (metadataStructure.batch === 'single') {
+    headers.push('Batch');
     headers.push('Batch ID');
   }
 
@@ -265,7 +266,13 @@ export function getCsvMetadataRowValues({
   }
 
   if (metadataStructure.batch === 'single') {
-    values.push(assertOnlyElement(filter.batchIds));
+    const batchId = assertOnlyElement(filter.batchIds);
+    const batchLabel =
+      batchId === Tabulation.MANUAL_BATCH_ID
+        ? 'Manual Tallies'
+        : assertDefined(batchLookup[batchId]).label;
+    values.push(batchLabel);
+    values.push(batchId);
   }
 
   // Multi Attributes

--- a/apps/admin/backend/src/exports/csv_tally_report.test.ts
+++ b/apps/admin/backend/src/exports/csv_tally_report.test.ts
@@ -53,6 +53,7 @@ test('uses appropriate headers', async () => {
     Party: 'Mammal',
     'Party ID': '0',
     'Voting Method': 'Precinct',
+    Batch: 'Batch batch-1',
     'Batch ID': 'batch-1',
     'Scanner ID': 'scanner-1',
     Contest: 'Ballot Measure 3',
@@ -91,7 +92,7 @@ test('uses appropriate headers', async () => {
     },
     {
       groupBy: { groupByBatch: true },
-      additionalHeaders: ['Scanner ID', 'Batch ID'],
+      additionalHeaders: ['Scanner ID', 'Batch', 'Batch ID'],
     },
     // redundant multiple groupings
     {
@@ -100,7 +101,7 @@ test('uses appropriate headers', async () => {
     },
     {
       groupBy: { groupByScanner: true, groupByBatch: true },
-      additionalHeaders: ['Scanner ID', 'Batch ID'],
+      additionalHeaders: ['Scanner ID', 'Batch', 'Batch ID'],
     },
     // multiple groupings
     {
@@ -122,7 +123,7 @@ test('uses appropriate headers', async () => {
     },
     {
       filter: { batchIds: ['batch-1'] },
-      additionalHeaders: ['Scanner ID', 'Batch ID'],
+      additionalHeaders: ['Scanner ID', 'Batch', 'Batch ID'],
     },
     // multi-filters requiring multi-value columns
     {
@@ -530,6 +531,7 @@ test('separate rows for manual data when grouping by an incompatible dimension',
       rows
         .filter((r) => r['Contest ID'] === 'fishing')
         .map((row) => [
+          row['Batch'],
           row['Batch ID'],
           row['Scanner ID'],
           row['Selection ID'],
@@ -538,12 +540,21 @@ test('separate rows for manual data when grouping by an incompatible dimension',
           row['Total Votes'],
         ])
     ).toEqual([
-      ['batch-1', 'scanner-1', 'ban-fishing', '0', '1', '1'],
-      ['batch-1', 'scanner-1', 'allow-fishing', '0', '0', '0'],
-      ['batch-1', 'scanner-1', 'overvotes', '0', '0', '0'],
-      ['batch-1', 'scanner-1', 'undervotes', '0', '0', '0'],
-      ['NO_BATCH__MANUAL', 'NO_SCANNER__MANUAL', 'ban-fishing', '1', '0', '1'],
+      ['Batch batch-1', 'batch-1', 'scanner-1', 'ban-fishing', '0', '1', '1'],
+      ['Batch batch-1', 'batch-1', 'scanner-1', 'allow-fishing', '0', '0', '0'],
+      ['Batch batch-1', 'batch-1', 'scanner-1', 'overvotes', '0', '0', '0'],
+      ['Batch batch-1', 'batch-1', 'scanner-1', 'undervotes', '0', '0', '0'],
       [
+        'Manual Tallies',
+        'NO_BATCH__MANUAL',
+        'NO_SCANNER__MANUAL',
+        'ban-fishing',
+        '1',
+        '0',
+        '1',
+      ],
+      [
+        'Manual Tallies',
         'NO_BATCH__MANUAL',
         'NO_SCANNER__MANUAL',
         'allow-fishing',
@@ -551,8 +562,24 @@ test('separate rows for manual data when grouping by an incompatible dimension',
         '0',
         '0',
       ],
-      ['NO_BATCH__MANUAL', 'NO_SCANNER__MANUAL', 'overvotes', '0', '0', '0'],
-      ['NO_BATCH__MANUAL', 'NO_SCANNER__MANUAL', 'undervotes', '0', '0', '0'],
+      [
+        'Manual Tallies',
+        'NO_BATCH__MANUAL',
+        'NO_SCANNER__MANUAL',
+        'overvotes',
+        '0',
+        '0',
+        '0',
+      ],
+      [
+        'Manual Tallies',
+        'NO_BATCH__MANUAL',
+        'NO_SCANNER__MANUAL',
+        'undervotes',
+        '0',
+        '0',
+        '0',
+      ],
     ]);
   }
 

--- a/apps/admin/backend/src/reports/tally_report.ts
+++ b/apps/admin/backend/src/reports/tally_report.ts
@@ -75,6 +75,7 @@ function buildTallyReport({
         key: `tally-report-${index}`,
         title,
         tallyReportResults,
+        scannerBatches,
         isOfficial: isOfficialResults,
         isTest,
         customFilter: displayedFilter,

--- a/apps/admin/backend/src/reports/titles.test.ts
+++ b/apps/admin/backend/src/reports/titles.test.ts
@@ -109,7 +109,7 @@ test('generateTitleForReport', () => {
       {
         batchIds: ['12345678-0000-0000-0000-000000000000'],
       },
-      'Tally Report • Scanner VX-00-001, Batch 12345678',
+      'Tally Report • Scanner VX-00-001, Batch 1',
     ],
     [
       {

--- a/apps/admin/backend/src/reports/titles.ts
+++ b/apps/admin/backend/src/reports/titles.ts
@@ -16,10 +16,6 @@ import { ScannerBatch } from '../types';
 
 const MANUAL_BATCH_REPORT_LABEL = 'Manual Tallies';
 
-function getBatchLabel(batchId: string): string {
-  return `Batch ${batchId.slice(0, Tabulation.BATCH_ID_DISPLAY_LENGTH)}`;
-}
-
 /**
  * Checks whether the report has any filters which have multiple values selected.
  */
@@ -105,12 +101,14 @@ export function generateTitleForReport({
         return MANUAL_BATCH_REPORT_LABEL;
       }
 
-      const { scannerId: resolvedScannerId } = find(
+      const { scannerId: resolvedScannerId, label: batchLabel } = find(
         scannerBatches,
         (b) => b.batchId === batchId
       );
 
-      return `Scanner ${resolvedScannerId}, ${getBatchLabel(batchId)}`;
+      // VxScan and VxCentralScan produce batch labels of the form 'Batch 1',
+      // 'Batch 2', etc., so we don't need to prefix them with 'Batch'.
+      return `Scanner ${resolvedScannerId}, ${batchLabel}`;
     }
 
     if (scannerId) {

--- a/apps/admin/backend/test/mock_cvr_file.ts
+++ b/apps/admin/backend/test/mock_cvr_file.ts
@@ -52,7 +52,7 @@ export function addMockCvrFileToStore({
       electionId,
       batchId: mockCastVoteRecord.batchId,
       scannerId: mockCastVoteRecord.scannerId,
-      label: mockCastVoteRecord.batchId,
+      label: `Batch ${mockCastVoteRecord.batchId}`,
     });
     scannerIds.add(mockCastVoteRecord.scannerId);
   }

--- a/apps/admin/frontend/src/components/reporting/filter_editor.test.tsx
+++ b/apps/admin/frontend/src/components/reporting/filter_editor.test.tsx
@@ -152,10 +152,10 @@ test('scanner, batch selection', async () => {
   userEvent.click(screen.getByText('Batch'));
   expect(onChange).toHaveBeenNthCalledWith(3, { batchIds: [] });
   userEvent.click(screen.getByLabelText('Select Filter Values'));
-  screen.getByText('scanner-1 • 12345678');
-  screen.getByText('scanner-1 • 23456789');
-  screen.getByText('scanner-2 • 34567890');
-  userEvent.click(screen.getByText('scanner-1 • 12345678'));
+  screen.getByText('Scanner scanner-1, Batch 1');
+  screen.getByText('Scanner scanner-1, Batch 2');
+  screen.getByText('Scanner scanner-2, Batch 3');
+  userEvent.click(screen.getByText('Scanner scanner-1, Batch 1'));
   expect(onChange).toHaveBeenNthCalledWith(4, {
     batchIds: ['12345678-0000-0000-0000-000000000000'],
   });

--- a/apps/admin/frontend/src/components/reporting/filter_editor.tsx
+++ b/apps/admin/frontend/src/components/reporting/filter_editor.tsx
@@ -128,7 +128,7 @@ function generateOptionsForFilter({
     case 'batch':
       return scannerBatches.map((sb) => ({
         value: sb.batchId,
-        label: `${sb.scannerId} • ${sb.batchId.slice(0, 8)}`,
+        label: `Scanner ${sb.scannerId}, ${sb.label}`,
       }));
     case 'adjudication-status':
       return Object.entries(Admin.ADJUDICATION_FLAG_LABELS).map(

--- a/libs/ui/src/reports/admin_tally_report.stories.tsx
+++ b/libs/ui/src/reports/admin_tally_report.stories.tsx
@@ -76,6 +76,7 @@ const batchReportArgs: AdminTallyReportProps = {
   contests,
   scannedElectionResults,
   customFilter: undefined,
+  scannerBatches: undefined,
   includeSignatureLines: false,
 };
 
@@ -125,6 +126,7 @@ const ballotStyleManualReportArgs: AdminTallyReportProps = {
   scannedElectionResults,
   manualElectionResults,
   customFilter: undefined,
+  scannerBatches: undefined,
   includeSignatureLines: false,
 };
 
@@ -201,6 +203,7 @@ const fullElectionWriteInReportArgs: AdminTallyReportProps = {
     },
   }),
   customFilter: undefined,
+  scannerBatches: undefined,
   includeSignatureLines: true,
 };
 

--- a/libs/ui/src/reports/admin_tally_report.test.tsx
+++ b/libs/ui/src/reports/admin_tally_report.test.tsx
@@ -8,6 +8,7 @@ import { hasTextAcrossElements } from '@votingworks/test-utils';
 import { formatElectionHashes } from '@votingworks/types';
 import { render, screen, within } from '../../test/react_testing_library';
 import { AdminTallyReport } from './admin_tally_report';
+import { mockScannerBatches } from '../../test/fixtures';
 
 const electionDefinition = electionTwoPartyPrimaryDefinition;
 const { election } = electionDefinition;
@@ -229,6 +230,7 @@ test('displays custom filter', () => {
         hmpb: [],
       }}
       customFilter={{ precinctIds: ['precinct-1'] }}
+      scannerBatches={mockScannerBatches}
     />
   );
   screen.getByText(hasTextAcrossElements('Precinct: Precinct 1'));

--- a/libs/ui/src/reports/admin_tally_report.tsx
+++ b/libs/ui/src/reports/admin_tally_report.tsx
@@ -4,7 +4,7 @@ import {
   ElectionDefinition,
   Tabulation,
 } from '@votingworks/types';
-import { assert } from '@votingworks/basics';
+import { assert, assertDefined } from '@votingworks/basics';
 import { ThemeProvider } from 'styled-components';
 import {
   printedReportThemeFn,
@@ -15,7 +15,7 @@ import { LogoMark } from '../logo_mark';
 import { ContestResultsTable } from './contest_results_table';
 import { TallyReportCardCounts } from './tally_report_card_counts';
 import { CustomFilterSummary } from './custom_filter_summary';
-import { prefixedTitle } from './utils';
+import { LabeledScannerBatch, prefixedTitle } from './utils';
 import { CertificationSignatures } from './certification_signatures';
 import {
   ReportHeader,
@@ -41,6 +41,7 @@ export interface AdminTallyReportProps {
   cardCountsOverride?: Tabulation.CardCounts;
   generatedAtTime?: Date;
   customFilter?: Admin.FrontendReportingFilter;
+  scannerBatches?: LabeledScannerBatch[]; // Only needed when customFilter is present
   includeSignatureLines?: boolean;
 }
 
@@ -59,6 +60,7 @@ export function AdminTallyReport({
   cardCountsOverride,
   generatedAtTime = new Date(),
   customFilter,
+  scannerBatches,
   includeSignatureLines,
 }: AdminTallyReportProps): JSX.Element {
   const { election } = electionDefinition;
@@ -83,6 +85,7 @@ export function AdminTallyReport({
           {customFilter && (
             <CustomFilterSummary
               electionDefinition={electionDefinition}
+              scannerBatches={assertDefined(scannerBatches)}
               filter={customFilter}
             />
           )}

--- a/libs/ui/src/reports/admin_tally_report_by_party.test.tsx
+++ b/libs/ui/src/reports/admin_tally_report_by_party.test.tsx
@@ -7,6 +7,7 @@ import { hasTextAcrossElements } from '@votingworks/test-utils';
 import { formatBallotHash } from '@votingworks/types';
 import { render, screen, within } from '../../test/react_testing_library';
 import { AdminTallyReportByParty } from './admin_tally_report_by_party';
+import { mockScannerBatches } from '../../test/fixtures';
 
 test('general election, full election report', () => {
   const { election, electionDefinition } = electionFamousNames2021Fixtures;
@@ -22,6 +23,7 @@ test('general election, full election report', () => {
         election,
         scannedBallotCount: 15,
       })}
+      scannerBatches={mockScannerBatches}
     />
   );
 
@@ -59,6 +61,7 @@ test('general election, precinct report with manual results', () => {
         scannedBallotCount: 15,
         manualBallotCount: 1,
       })}
+      scannerBatches={mockScannerBatches}
     />
   );
 
@@ -105,6 +108,7 @@ test('primary election, full election report with manual results', () => {
           },
         },
       })}
+      scannerBatches={mockScannerBatches}
     />
   );
 
@@ -178,6 +182,7 @@ test('primary election, party report, test deck', () => {
           .filter((c) => c.type === 'yesno' || c.partyId === '0')
           .map((c) => c.id),
       })}
+      scannerBatches={mockScannerBatches}
     />
   );
 

--- a/libs/ui/src/reports/admin_tally_report_by_party.tsx
+++ b/libs/ui/src/reports/admin_tally_report_by_party.tsx
@@ -8,6 +8,7 @@ import {
   getPartyById,
 } from '@votingworks/utils';
 import { AdminTallyReport } from './admin_tally_report';
+import { LabeledScannerBatch } from './utils';
 
 export interface AdminTallyReportByPartyProps {
   electionDefinition: ElectionDefinition;
@@ -20,6 +21,7 @@ export interface AdminTallyReportByPartyProps {
   testId: string;
   generatedAtTime: Date;
   customFilter?: Admin.FrontendReportingFilter;
+  scannerBatches?: LabeledScannerBatch[];
   includeSignatureLines?: boolean;
 }
 
@@ -45,6 +47,7 @@ export function AdminTallyReportByParty({
   testId,
   generatedAtTime,
   customFilter,
+  scannerBatches,
   includeSignatureLines,
 }: AdminTallyReportByPartyProps): JSX.Element {
   const contests = tallyReportResults.contestIds.map((contestId) =>
@@ -67,6 +70,7 @@ export function AdminTallyReportByParty({
         isForLogicAndAccuracyTesting={isForLogicAndAccuracyTesting}
         generatedAtTime={generatedAtTime}
         customFilter={customFilter}
+        scannerBatches={scannerBatches}
         includeSignatureLines={includeSignatureLines}
       />
     );
@@ -108,6 +112,7 @@ export function AdminTallyReportByParty({
         cardCountsOverride={partyCardCounts}
         generatedAtTime={generatedAtTime}
         customFilter={customFilter}
+        scannerBatches={scannerBatches}
         includeSignatureLines={includeSignatureLines}
       />
     );
@@ -132,6 +137,7 @@ export function AdminTallyReportByParty({
         isForLogicAndAccuracyTesting={isForLogicAndAccuracyTesting}
         generatedAtTime={generatedAtTime}
         customFilter={customFilter}
+        scannerBatches={scannerBatches}
         includeSignatureLines={includeSignatureLines}
       />
     );

--- a/libs/ui/src/reports/ballot_count_report.stories.tsx
+++ b/libs/ui/src/reports/ballot_count_report.stories.tsx
@@ -9,6 +9,7 @@ import {
   BallotCountReport,
   BallotCountReportProps,
 } from './ballot_count_report';
+import { LabeledScannerBatch } from './utils';
 
 const ReportPreview = styled.div`
   section {
@@ -197,6 +198,7 @@ const singleGroupReportArgs: BallotCountReportProps = {
   scannerBatches: [
     {
       batchId: 'batch-1',
+      label: 'Batch 1',
       scannerId: 'scanner-1',
     },
   ],
@@ -209,37 +211,45 @@ export const SingleGroupReport: Story = {
   args: singleGroupReportArgs,
 };
 
-const maxReportScannerBatches: Tabulation.ScannerBatch[] = [
+const maxReportScannerBatches: LabeledScannerBatch[] = [
   {
     batchId: 'batch-10',
+    label: 'Batch 10',
     scannerId: 'scanner-1',
   },
   {
     batchId: 'batch-11',
+    label: 'Batch 11',
     scannerId: 'scanner-1',
   },
   {
     batchId: 'batch-20',
+    label: 'Batch 20',
     scannerId: 'scanner-2',
   },
   {
     batchId: 'batch-21',
+    label: 'Batch 21',
     scannerId: 'scanner-2',
   },
   {
     batchId: 'batch-22',
+    label: 'Batch 22',
     scannerId: 'scanner-2',
   },
   {
     batchId: 'batch-30',
+    label: 'Batch 30',
     scannerId: 'scanner-3',
   },
   {
     batchId: 'batch-31',
+    label: 'Batch 31',
     scannerId: 'scanner-3',
   },
   {
     batchId: 'batch-32',
+    label: 'Batch 32',
     scannerId: 'scanner-3',
   },
 ];

--- a/libs/ui/src/reports/ballot_count_report.test.tsx
+++ b/libs/ui/src/reports/ballot_count_report.test.tsx
@@ -16,21 +16,7 @@ import {
   BallotCountReport,
   FILLER_COLUMNS,
 } from './ballot_count_report';
-
-const mockScannerBatches: Tabulation.ScannerBatch[] = [
-  {
-    batchId: 'batch-10',
-    scannerId: 'scanner-1',
-  },
-  {
-    batchId: 'batch-11',
-    scannerId: 'scanner-1',
-  },
-  {
-    batchId: 'batch-20',
-    scannerId: 'scanner-2',
-  },
-];
+import { mockScannerBatches } from '../../test/fixtures';
 
 // shorthand for creating a card counts object
 function cc(
@@ -181,7 +167,7 @@ test('can render all attribute columns', () => {
   const expectedRows: RowData[] = [
     {
       'ballot-style': '1M',
-      batch: 'batch-10',
+      batch: 'Batch 10',
       party: 'Mammal',
       precinct: 'Precinct 1',
       scanner: 'scanner-1',
@@ -192,7 +178,7 @@ test('can render all attribute columns', () => {
     },
     {
       'ballot-style': '2F',
-      batch: 'batch-20',
+      batch: 'Batch 20',
       party: 'Fish',
       precinct: 'Precinct 2',
       scanner: 'scanner-2',
@@ -441,15 +427,15 @@ test('shows separate manual rows when group by is not compatible with manual res
   const expectedRows: RowData[] = [
     {
       scanner: 'scanner-1',
-      batch: 'batch-10',
+      batch: 'Batch 10',
       manual: '0',
       bmd: '3',
       hmpb: '0',
       total: '3',
     },
     {
-      scanner: 'Manual',
-      batch: 'Manual',
+      scanner: 'Manual Tallies',
+      batch: 'Manual Tallies',
       manual: '2',
       bmd: '0',
       hmpb: '0',

--- a/libs/ui/src/reports/custom_filter_summary.test.tsx
+++ b/libs/ui/src/reports/custom_filter_summary.test.tsx
@@ -4,12 +4,14 @@ import {
 } from '@votingworks/fixtures';
 import { render, screen } from '../../test/react_testing_library';
 import { CustomFilterSummary } from './custom_filter_summary';
+import { mockScannerBatches } from '../../test/fixtures';
 
 test('precinct filter', () => {
   const { electionDefinition } = electionFamousNames2021Fixtures;
   render(
     <CustomFilterSummary
       electionDefinition={electionDefinition}
+      scannerBatches={mockScannerBatches}
       filter={{ precinctIds: ['23'] }}
     />
   );
@@ -23,6 +25,7 @@ test('ballot style filter', () => {
   render(
     <CustomFilterSummary
       electionDefinition={electionDefinition}
+      scannerBatches={mockScannerBatches}
       filter={{ ballotStyleIds: ['1'] }}
     />
   );
@@ -36,6 +39,7 @@ test('voting method filter', () => {
   render(
     <CustomFilterSummary
       electionDefinition={electionDefinition}
+      scannerBatches={mockScannerBatches}
       filter={{ votingMethods: ['absentee'] }}
     />
   );
@@ -49,6 +53,7 @@ test('scanner filter', () => {
   render(
     <CustomFilterSummary
       electionDefinition={electionDefinition}
+      scannerBatches={mockScannerBatches}
       filter={{ scannerIds: ['VX-00-000'] }}
     />
   );
@@ -59,14 +64,16 @@ test('scanner filter', () => {
 
 test('batch filter', () => {
   const { electionDefinition } = electionFamousNames2021Fixtures;
+  const batch = mockScannerBatches[1];
   render(
     <CustomFilterSummary
       electionDefinition={electionDefinition}
-      filter={{ batchIds: ['12345678-0000-0000-0000-000000000000'] }}
+      scannerBatches={mockScannerBatches}
+      filter={{ batchIds: [batch.batchId] }}
     />
   );
   expect(screen.getByTestId('custom-filter-summary').textContent).toEqual(
-    'Batch: 12345678'
+    `Batch: ${batch.label}`
   );
 });
 
@@ -76,6 +83,7 @@ test('adjudication status filter', () => {
   const { unmount } = render(
     <CustomFilterSummary
       electionDefinition={electionDefinition}
+      scannerBatches={mockScannerBatches}
       filter={{ adjudicationFlags: ['isBlank'] }}
     />
   );
@@ -87,6 +95,7 @@ test('adjudication status filter', () => {
   render(
     <CustomFilterSummary
       electionDefinition={electionDefinition}
+      scannerBatches={mockScannerBatches}
       filter={{ adjudicationFlags: ['hasWriteIn', 'hasOvervote'] }}
     />
   );
@@ -100,6 +109,7 @@ test('district filter', () => {
   render(
     <CustomFilterSummary
       electionDefinition={electionDefinition}
+      scannerBatches={mockScannerBatches}
       filter={{ districtIds: ['district-1'] }}
     />
   );
@@ -114,6 +124,7 @@ test('party filter', () => {
   render(
     <CustomFilterSummary
       electionDefinition={electionDefinition}
+      scannerBatches={mockScannerBatches}
       filter={{ partyIds: [party.id] }}
     />
   );
@@ -127,6 +138,7 @@ test('complex filter', () => {
   render(
     <CustomFilterSummary
       electionDefinition={electionDefinition}
+      scannerBatches={mockScannerBatches}
       filter={{
         precinctIds: ['23'],
         ballotStyleIds: ['1'],

--- a/libs/ui/src/reports/custom_filter_summary.tsx
+++ b/libs/ui/src/reports/custom_filter_summary.tsx
@@ -9,11 +9,12 @@ import {
 import pluralize from 'pluralize';
 import styled from 'styled-components';
 import { Font } from '../typography';
-import { getBatchLabel, getScannerLabel } from './utils';
+import { getBatchLabel, getScannerLabel, LabeledScannerBatch } from './utils';
 import { Box } from './layout';
 
 interface Props {
   electionDefinition: ElectionDefinition;
+  scannerBatches: LabeledScannerBatch[];
   filter: Admin.FrontendReportingFilter;
 }
 
@@ -31,6 +32,7 @@ const FilterDisplayRow = styled.p`
 
 export function CustomFilterSummary({
   electionDefinition,
+  scannerBatches,
   filter,
 }: Props): JSX.Element {
   return (
@@ -81,7 +83,9 @@ export function CustomFilterSummary({
           <Font weight="semiBold">
             {pluralize('Batch', filter.batchIds.length)}:
           </Font>{' '}
-          {filter.batchIds.map(getBatchLabel).join(', ')}
+          {filter.batchIds
+            .map((batchId) => getBatchLabel(batchId, scannerBatches))
+            .join(', ')}
         </FilterDisplayRow>
       )}
       {filter.adjudicationFlags && (

--- a/libs/ui/src/reports/utils.ts
+++ b/libs/ui/src/reports/utils.ts
@@ -1,13 +1,23 @@
+import { find } from '@votingworks/basics';
 import { Tabulation } from '@votingworks/types';
 
-export function getBatchLabel(batchId: string): string {
+export type LabeledScannerBatch = Tabulation.ScannerBatch & { label: string };
+
+// VxScan and VxCentralScan produce batch labels of the form 'Batch 1',
+// 'Batch 2', etc., so we don't need to prefix them with 'Batch'.
+export function getBatchLabel(
+  batchId: string,
+  scannerBatches: LabeledScannerBatch[]
+): string {
   return batchId === Tabulation.MANUAL_BATCH_ID
-    ? 'Manual'
-    : batchId.slice(0, Tabulation.BATCH_ID_DISPLAY_LENGTH);
+    ? 'Manual Tallies'
+    : find(scannerBatches, (batch) => batch.batchId === batchId).label;
 }
 
 export function getScannerLabel(scannerId: string): string {
-  return scannerId === Tabulation.MANUAL_SCANNER_ID ? 'Manual' : scannerId;
+  return scannerId === Tabulation.MANUAL_SCANNER_ID
+    ? 'Manual Tallies'
+    : scannerId;
 }
 
 export function prefixedTitle({

--- a/libs/ui/test/fixtures.ts
+++ b/libs/ui/test/fixtures.ts
@@ -1,0 +1,19 @@
+import { LabeledScannerBatch } from '../src/reports/utils';
+
+export const mockScannerBatches: LabeledScannerBatch[] = [
+  {
+    batchId: 'batch-10',
+    label: 'Batch 10',
+    scannerId: 'scanner-1',
+  },
+  {
+    batchId: 'batch-11',
+    label: 'Batch 11',
+    scannerId: 'scanner-1',
+  },
+  {
+    batchId: 'batch-20',
+    label: 'Batch 20',
+    scannerId: 'scanner-2',
+  },
+];


### PR DESCRIPTION
## Overview

Closes #5420 

Instead of showing a truncated UUID when labeling batches in reports, show the human readable name (e.g. "Batch 1", "Batch 2", etc.). Also adds the human-readable name alongside the UUID in CSV reports.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/782f0d66-ddf6-4591-a0e2-f1100888e2d9


## Testing Plan
Updated automated tests and did some manual testing

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
