### PR TITLE
VxAdmin: Allow continuous CVR exports to be re-imported

### DIFF
--- a/apps/admin/frontend/src/components/import_cvrfiles_modal.test.tsx
+++ b/apps/admin/frontend/src/components/import_cvrfiles_modal.test.tsx
@@ -193,8 +193,17 @@ describe('when USB is properly mounted', () => {
   test('locks to test mode when in test mode & shows previously loaded files as loaded', async () => {
     const closeFn = jest.fn();
     apiMock.expectGetCastVoteRecordFileMode('test');
+    const [, testFile1, testFile2] = mockCastVoteRecordFileMetadata;
     apiMock.expectGetCastVoteRecordFiles([
-      { ...mockCastVoteRecordFileRecord, filename: TEST_FILE1 },
+      {
+        ...mockCastVoteRecordFileRecord,
+        filename: testFile1.name,
+        exportTimestamp: testFile1.exportTimestamp.toISOString(),
+      },
+      {
+        ...mockCastVoteRecordFileRecord,
+        filename: testFile2.name,
+      },
     ]);
     apiMock.expectListCastVoteRecordFilesOnUsb(mockCastVoteRecordFileMetadata);
     renderInAppContext(<ImportCvrFilesModal onClose={closeFn} />, {


### PR DESCRIPTION

## Overview
Fixes https://github.com/votingworks/vxsuite/issues/5158

Previously, if you imported a continuous CVR export from VxScan into VxAdmin, then scanned more ballots and tried to re-import the same export, the "Load" button would be disabled. This fixes the logic for disabling that button to check the export timestamp, which changes when new ballots are exported (instead of just checking the file name, which doesn't change). The backend already knows how to only import the newly added CVRs, so the only fix needed is enabling the button.
## Demo Video or Screenshot
Skipping since this is fixing a regression

## Testing Plan
Manual test, updated automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
