### PR TITLE
VxAdmin/VxCentralScan: Wrap long screen titles

### DIFF
--- a/apps/admin/frontend/src/components/navigation_screen.tsx
+++ b/apps/admin/frontend/src/components/navigation_screen.tsx
@@ -69,12 +69,14 @@ export const Header = styled(MainHeader)`
   align-items: center;
   justify-content: space-between;
   padding-left: 0.75rem;
+  gap: 0.5rem;
 `;
 
 export const HeaderActions = styled.div`
   display: flex;
   gap: 0.5rem;
   align-items: center;
+  flex-shrink: 0;
 `;
 
 export function NavigationScreen({

--- a/apps/central-scan/frontend/src/navigation_screen.tsx
+++ b/apps/central-scan/frontend/src/navigation_screen.tsx
@@ -38,12 +38,14 @@ export const Header = styled(MainHeader)`
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 0.5rem;
 `;
 
 const HeaderActions = styled.div`
   display: flex;
   gap: 0.5rem;
   align-items: center;
+  flex-shrink: 0;
 `;
 
 const TestModeCallout = styled(Card).attrs({ color: 'warning' })`
@@ -53,6 +55,8 @@ const TestModeCallout = styled(Card).attrs({ color: 'warning' })`
   > div {
     padding: 0.5rem 1rem;
   }
+
+  flex-shrink: 0;
 `;
 
 // Because the VxCentralScan is such a long app name, we have to resize the app


### PR DESCRIPTION


## Overview

Fixes: https://github.com/votingworks/vxsuite/issues/5237

Instead of letting the buttons or other content in the header wrap internally, wrap the titles. This is currently only an issue on the Voting Method Ballot Count Report screen, but is good to have in place for the future. There might be a larger redesign we can do so that the actions don't take up as much header space, but this is a viable quick fix, and since the issue only affects one screen, it's probably good enough for now.
## Demo Video or Screenshot
Before
![Screenshot-VxAdmin-2024-09-26T23:08:20 012Z](https://github.com/user-attachments/assets/3a621a87-f8be-4595-a30b-814de9e8d461)

After
![Screenshot-VxAdmin-2024-09-26T23:08:29 492Z](https://github.com/user-attachments/assets/84d55a3f-4762-4a9c-8247-1d9849841c36)


## Testing Plan
Manual test

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
