### PR TITLE
CDF ERR export: conform to NCName and ID uniqueness constraints

### DIFF
--- a/apps/admin/backend/src/app.err_cdf_export.test.ts
+++ b/apps/admin/backend/src/app.err_cdf_export.test.ts
@@ -200,28 +200,28 @@ it('exports results and metadata accurately', async () => {
     GeneratedDate: expect.anything(),
     IsTest: true,
     Issuer: 'Test Ballot',
-    IssuerAbbreviation: '00701',
+    IssuerAbbreviation: 'vx_00701',
     SequenceEnd: 1,
     SequenceStart: 1,
     Status: 'unofficial-complete',
     VendorApplicationId: 'VxAdmin, version dev',
   });
   expect(GpUnit?.map((gpUnit) => gpUnit['@id'])).toEqual([
-    'nh',
-    '00701',
-    'town-id-00701-precinct-id-default',
+    'vx_nh',
+    'vx_00701',
+    'vx_town-id-00701-precinct-id-default',
   ]);
   expect(Party?.map((gpUnit) => gpUnit['@id'])).toEqual([
-    'Democratic-aea20adb',
-    'Republican-f0167ce7',
-    'OC-3a386d2b',
+    'vx_Democratic-aea20adb',
+    'vx_Republican-f0167ce7',
+    'vx_OC-3a386d2b',
   ]);
   assert(Election);
   const { Candidate, Contest, BallotCounts, ...electionMetadata } =
     assertDefined(Election[0]);
   expect(electionMetadata).toEqual({
     '@type': 'ElectionResults.Election',
-    ElectionScopeId: 'nh',
+    ElectionScopeId: 'vx_nh',
     EndDate: '2022-07-12',
     Name: {
       '@type': 'ElectionResults.InternationalizedText',
@@ -240,7 +240,7 @@ it('exports results and metadata accurately', async () => {
   expect(BallotCounts![0]).toEqual({
     '@type': 'ElectionResults.BallotCounts',
     BallotsCast: 194, // includes manual ballot count
-    GpUnitId: '00701',
+    GpUnitId: 'vx_00701',
     Type: 'total',
   });
   const expectedOfficialCandidateIds = election.contests
@@ -248,13 +248,13 @@ it('exports results and metadata accurately', async () => {
       (contest): contest is CandidateContest => contest.type === 'candidate'
     )
     .flatMap((contest) => contest.candidates)
-    .map((candidate) => candidate.id)
+    .map((candidate) => `vx_${candidate.id}`)
     .sort();
   expect(Candidate?.map((c) => c['@id']).sort()).toEqual(
     [
       ...expectedOfficialCandidateIds,
-      writeInCandidate1.id,
-      writeInCandidate2.id,
+      `vx_${writeInCandidate1.id}`,
+      `vx_${writeInCandidate2.id}`,
       Tabulation.GENERIC_WRITE_IN_ID,
     ].sort()
   );
@@ -264,26 +264,26 @@ it('exports results and metadata accurately', async () => {
     'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc';
   const ballotMeasureContest = find(
     Contest,
-    (c) => c['@id'] === ballotMeasureContestId
+    (c) => c['@id'] === `vx_${ballotMeasureContestId}`
   );
 
   function expectedCount(num: number) {
     return expect.objectContaining({
       '@type': 'ElectionResults.VoteCounts',
       Count: num,
-      GpUnitId: 'town-id-00701-precinct-id-default',
+      GpUnitId: 'vx_town-id-00701-precinct-id-default',
       Type: 'total',
     });
   }
 
   expect(ballotMeasureContest).toEqual({
     '@id':
-      'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc',
+      'vx_Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc',
     '@type': 'ElectionResults.BallotMeasureContest',
     ContestSelection: [
       {
         '@id':
-          'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-yes',
+          'vx_Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-yes',
         '@type': 'ElectionResults.BallotMeasureSelection',
         Selection: {
           '@type': 'ElectionResults.InternationalizedText',
@@ -299,7 +299,7 @@ it('exports results and metadata accurately', async () => {
       },
       {
         '@id':
-          'Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-no',
+          'vx_Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-no',
         '@type': 'ElectionResults.BallotMeasureSelection',
         Selection: {
           '@type': 'ElectionResults.InternationalizedText',
@@ -314,12 +314,12 @@ it('exports results and metadata accurately', async () => {
         VoteCounts: [expectedCount(2)],
       },
     ],
-    ElectionDistrictId: 'town-id-00701-precinct-id-default',
+    ElectionDistrictId: 'vx_town-id-00701-precinct-id-default',
     Name: 'Constitutional Amendment Question #1',
     OtherCounts: [
       {
         '@type': 'ElectionResults.OtherCounts',
-        GpUnitId: 'town-id-00701-precinct-id-default',
+        GpUnitId: 'vx_town-id-00701-precinct-id-default',
         Overvotes: 2,
         Undervotes: 178,
       },
@@ -328,43 +328,45 @@ it('exports results and metadata accurately', async () => {
 
   const candidateContest = find(
     Contest,
-    (c) => c['@id'] === candidateContestId
+    (c) => c['@id'] === `vx_${candidateContestId}`
   );
 
+  const contestId = 'State-Representatives-Hillsborough-District-34-b1012d38';
+
   expect(candidateContest).toEqual({
-    '@id': 'State-Representatives-Hillsborough-District-34-b1012d38',
+    '@id': `vx_${contestId}`,
     '@type': 'ElectionResults.CandidateContest',
     ContestSelection: expect.arrayContaining([
       {
-        '@id': 'Obadiah-Carrigan-5c95145a',
+        '@id': `vx_${contestId}_Obadiah-Carrigan-5c95145a`,
         '@type': 'ElectionResults.CandidateSelection',
         VoteCounts: [expectedCount(66)],
       },
       {
-        '@id': 'write-in',
+        '@id': `vx_${contestId}_write-in`,
         '@type': 'ElectionResults.CandidateSelection',
         IsWriteIn: true,
         VoteCounts: [expectedCount(54)],
       },
       {
-        '@id': writeInCandidate1.id,
+        '@id': `vx_${contestId}_${writeInCandidate1.id}`,
         '@type': 'ElectionResults.CandidateSelection',
         IsWriteIn: true,
         VoteCounts: [expectedCount(3)],
       },
       {
-        '@id': writeInCandidate2.id,
+        '@id': `vx_${contestId}_${writeInCandidate2.id}`,
         '@type': 'ElectionResults.CandidateSelection',
         IsWriteIn: true,
         VoteCounts: [expectedCount(1)],
       },
     ]),
-    ElectionDistrictId: 'town-id-00701-precinct-id-default',
+    ElectionDistrictId: 'vx_town-id-00701-precinct-id-default',
     Name: 'State Representatives  Hillsborough District 34',
     OtherCounts: [
       {
         '@type': 'ElectionResults.OtherCounts',
-        GpUnitId: 'town-id-00701-precinct-id-default',
+        GpUnitId: 'vx_town-id-00701-precinct-id-default',
         Overvotes: 31,
         Undervotes: 13,
       },

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -932,9 +932,7 @@ function buildApi({
             isTestMode,
             writeInCandidates,
             machineConfig: getMachineConfig(),
-          }),
-          null,
-          2
+          })
         ),
       });
 

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -921,6 +921,7 @@ function buildApi({
       assert(electionResults);
 
       debug('exporting CDF election results report JSON file: %o', input);
+
       const exportFileResult = await exportFile({
         path: input.path,
         data: JSON.stringify(
@@ -931,7 +932,9 @@ function buildApi({
             isTestMode,
             writeInCandidates,
             machineConfig: getMachineConfig(),
-          })
+          }),
+          null,
+          2
         ),
       });
 

--- a/apps/admin/backend/src/util/ncname.ts
+++ b/apps/admin/backend/src/util/ncname.ts
@@ -1,0 +1,100 @@
+import {
+  Candidate,
+  Contest,
+  District,
+  Election,
+  Party,
+  YesNoContest,
+  Tabulation,
+} from '@votingworks/types';
+
+/**
+ * Formats a string as NCName by prefixing with "vx_" and removing the ":" character.
+ * See: https://www.w3.org/TR/xml-names/#NT-NCName and https://www.w3.org/TR/REC-xml/#NT-NameStartChar.
+ */
+function asNcName(id: string): string {
+  return `vx_${id.replaceAll(':', '')}`;
+}
+
+/**
+ * Gets the state ID from an Election, formatted as an NCName.
+ */
+export function getStateId(election: Election): string {
+  return asNcName(election.state.toLowerCase().replaceAll(' ', '-'));
+}
+
+/**
+ * Gets the county ID from an Election, formatted as an NCName.
+ */
+export function getCountyId(election: Election): string {
+  return asNcName(election.county.id);
+}
+
+/**
+ * Gets the district ID from a District, formatted as an NCName.
+ */
+export function getDistrictId(district: District): string {
+  return asNcName(district.id);
+}
+
+/**
+ * Gets the contest ID from a Contest, formatted as an NCName.
+ */
+export function getContestId(contest: Contest): string {
+  return asNcName(contest.id);
+}
+
+/**
+ * Gets the district ID from a Contest, formatted as an NCName.
+ */
+export function getDistrictIdFromContest(contest: Contest): string {
+  return asNcName(contest.districtId);
+}
+
+/**
+ * Gets the party ID from a Party, formatted as an NCName.
+ */
+export function getPartyId(party: Party): string {
+  return asNcName(party.id);
+}
+
+/**
+ * Gets the candidate ID from a Candidate, formatted as an NCName.
+ */
+export function getCandidateId(candidate: Candidate): string {
+  return asNcName(candidate.id);
+}
+
+/**
+ * Constructs a candidate selection ID in the format `vx_<contestId>_<candidateTallyId>`, formatted as an NCName.
+ */
+export function getCandidateSelectionId(
+  contest: Contest,
+  candidateTally: Tabulation.CandidateTally
+): string {
+  return asNcName(`${contest.id}_${candidateTally.id}`);
+}
+
+/**
+ * Gets the ID for the "Yes" option in a YesNoContest, formatted as an NCName.
+ */
+export function getYesOptionId(contest: YesNoContest): string {
+  return asNcName(contest.yesOption.id);
+}
+
+/**
+ * Gets the ID for the "No" option in a YesNoContest, formatted as an NCName.
+ */
+export function getNoOptionId(contest: YesNoContest): string {
+  return asNcName(contest.noOption.id);
+}
+
+/**
+ * Gets the party ID for a Candidate, formatted as an NCName.
+ */
+export function getPartyIdForCandidate(
+  candidate: Candidate
+): string | undefined {
+  /* istanbul ignore next -- trivial fallthrough case */
+  return candidate.partyIds?.[0] ? asNcName(candidate.partyIds[0]) : undefined;
+}


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/5368

Fixes ERR validation errors on exported CDF ERR files from VxAdmin. The errors fall into 2 categories:

1. IDs are `NCName`s ([spec](https://www.w3.org/TR/xml-names/#NT-NCName)) which can only start with letters, `_`, or `.`. They also can't have the colon character, though our IDs are unlikely to include this character.
2. IDs must be globally unique, but we used the same candidate ID for both `Candidate` and `CandidateSelection` objects. 

The fixes are:
1. Prefix all IDs with `vx_` and remove the `:` character.
2. Use a concatenation of `contest` and `candidate` IDs for `CandidateSelection`. `CandidateSelection` describes the tally for a single candidate in in a single contest so this concatenation seemed like the most accurate option.

## Demo Video or Screenshot

Not a new feature, but exporting ERR files from VxAdmin still works:


https://github.com/user-attachments/assets/ff07850c-5638-4bfc-884b-ee511035ac36



Here's an example ERR file and the output of running the validator tool on that file.

[err.json](https://github.com/user-attachments/files/17168511/err.json)

```
<?xml version="1.0" encoding="UTF-8"?>
<reports xmlns="http://www.xproc.org/ns/xvrl">
   <metadata xmlns:tm="http://itl.nist.gov/ns/voting/test-method">
      <creator name="NIST Common Data Format Test Method" version="1.0.1"/>
      <timestamp>2024-09-27T11:21:40.61-07:00</timestamp>
      <summary>Please review each report to determine conformance to the applicable test assertions / requirements</summary>
      <supplemental tm:xproc-engine-version="1.2" tm:psvi-supported="false" tm:xproc-engine-vendor="&lt;xml-project /&gt; Achim Berndzen" tm:xproc-engine-name="MorganaXProc-IIIse">
         <tm:validity>valid</tm:validity>
         <tm:validity-reason/>
         <tm:runcode>Episode-1727461299329</tm:runcode>
      </supplemental>
   </metadata>
   <report>
      <metadata>
         <timestamp>2024-09-27T11:21:39.31-07:00</timestamp>
         <document href="file:///path/to/cdf-test-method-v1.0.1/err.json"/>
         <schema href="http://itl.nist.gov/ns/voting/1500-100/v2/json" schematypens="JsonSchema"/>
         <validator name="networknt/json-schema-validator"/>
      </metadata>
      <digest/>
   </report>
   <report>
      <metadata>
         <timestamp>2024-09-27T11:21:40.05-07:00</timestamp>
         <document href="file:///path/to/cdf-test-method-v1.0.1/err.json"/>
         <schema href="http://itl.nist.gov/ns/voting/1500-100/v2" schematypens="http://www.w3.org/2001/XMLSchema"/>
         <validator name="org.apache.xerces.jaxp.validation.XMLSchemaFactory"/>
      </metadata>
      <digest/>
   </report>
   <report>
      <metadata>
         <timestamp>2024-09-27T11:21:40.6-07:00</timestamp>
         <document href="file:///path/to/cdf-test-method-v1.0.1/err.json"/>
         <schema href="http://itl.nist.gov/ns/voting/1500-100/v2/sch" schematypens="http://purl.oclc.org/dsdl/schematron"/>
         <validator name="SchXslt"/>
      </metadata>
      <digest/>
   </report>
</reports>
```

## Testing Plan

Updated existing correctness test.
