### PR TITLE
bug: handling double endorsement tabulation

### DIFF
--- a/libs/ballot-interpreter/src/__snapshots__/interpret_nh_hmpb.test.ts.snap
+++ b/libs/ballot-interpreter/src/__snapshots__/interpret_nh_hmpb.test.ts.snap
@@ -6097,14 +6097,6 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 57`] = `
               "Republican-f0167ce7",
             ],
           },
-          {
-            "id": "Edward-Randolph-bf4c848a",
-            "name": "Edward Randolph",
-            "partyIds": [
-              "Democratic-aea20adb",
-              "Republican-f0167ce7",
-            ],
-          },
         ],
       },
     },
@@ -6369,14 +6361,6 @@ exports[`HMPB - m17 backup Interprets all ballots correctly 60`] = `
           "Shall-there-be-a-convention-to-amend-or-revise-the-constitution--15e8b5bc-option-yes",
         ],
         "Sheriff-4243fe0b": [
-          {
-            "id": "Edward-Randolph-bf4c848a",
-            "name": "Edward Randolph",
-            "partyIds": [
-              "Democratic-aea20adb",
-              "Republican-f0167ce7",
-            ],
-          },
           {
             "id": "Edward-Randolph-bf4c848a",
             "name": "Edward Randolph",

--- a/libs/ballot-interpreter/src/adjudication_reasons.ts
+++ b/libs/ballot-interpreter/src/adjudication_reasons.ts
@@ -25,7 +25,7 @@ function rankMarkStatus(markStatus: MarkStatus): number {
   }
 }
 
-function sortMarkStatusDescending(
+function compareMarkStatusDescending(
   markStatusA: MarkStatus,
   markStatusB: MarkStatus
 ): number {
@@ -72,7 +72,7 @@ export function getAllPossibleAdjudicationReasons(
           (scoredContestOption) => scoredContestOption.option.id === option.id
         )
         .sort((scoredContestOptionA, scoredContestOptionB) =>
-          sortMarkStatusDescending(
+          compareMarkStatusDescending(
             scoredContestOptionA.markStatus,
             scoredContestOptionB.markStatus
           )

--- a/libs/utils/src/votes.test.ts
+++ b/libs/utils/src/votes.test.ts
@@ -169,6 +169,16 @@ test('markInfoToVotesDict candidate', () => {
       }),
     ],
   });
+
+  // when there are multiple marks for the same candidate due to a double
+  // party endorsement, they should be treated as one selection
+  expect(
+    convertMarksToVotesDict(
+      election.contests,
+      { marginal: 0.04, definite: 0.1 },
+      [sherlockForMayorMark, sherlockForMayorMark]
+    )
+  ).toEqual({ [mayorContest.id]: [sherlockCandidate] });
 });
 
 test('markInfoToVotesDict yesno', () => {

--- a/libs/utils/src/votes.ts
+++ b/libs/utils/src/votes.ts
@@ -1,4 +1,4 @@
-import { assert, throwIllegalValue } from '@votingworks/basics';
+import { assert, throwIllegalValue, uniqueBy } from '@votingworks/basics';
 import {
   BallotTargetMark,
   Candidate,
@@ -136,6 +136,24 @@ function markToYesNoVotes(
 }
 
 /**
+ * There may be two positions on the ballot for the same candidate if they
+ * are endorsed by multiple parties. We need to deduplicate votes such that,
+ * in cases where both positions have valid marks, we treat them as one.
+ */
+function deduplicateVotes(vote: Vote): Vote {
+  if (vote.length === 0) {
+    return vote;
+  }
+
+  // if YesNoVote, no deduplication is necessary
+  if (typeof vote[0] === 'string') {
+    return vote;
+  }
+
+  return uniqueBy(vote as CandidateVote, (c) => c.id);
+}
+
+/**
  * Convert {@link BallotTargetMark}s to {@link VotesDict}.
  */
 export function convertMarksToVotesDict(
@@ -156,7 +174,10 @@ export function convertMarksToVotesDict(
         : /* c8 ignore next */
           throwIllegalValue(contest, 'type');
 
-    votesDict[mark.contestId] = [...existingVotes, ...newVotes] as Vote;
+    votesDict[mark.contestId] = deduplicateVotes([
+      ...existingVotes,
+      ...newVotes,
+    ] as Vote);
   }
   return votesDict;
 }


### PR DESCRIPTION
## Bug Description  

We've noticed that on a ballots with two ballot positions for the same candidate (due to a double party endorsement) we hit a couple interrelated tabulation bugs. First, when both positions are filled out, the scanner accepts the ballot (correct) but tabulates it as an overvote:

![valid_double](https://github.com/user-attachments/assets/8a1736ac-c1b2-4268-b6db-75a10b485d21)

Second, we are not detecting overvotes when the second position is filled in, but the first is not. For example, this is not rejected as an overvote:

![overvote_2](https://github.com/user-attachments/assets/339999c2-39d9-485e-b203-aab70484fe75)

But this is correctly rejected as an overvote:

![overvote_1](https://github.com/user-attachments/assets/d0934b49-6e8c-4f8b-8a73-e8a4ba78417d)


## Bug Cause

It seems that when we introduced double endorsements we broke with an underlying assumption that each candidate had only one ballot position, which we did not completely root out.

First, when we convert marks to votes, we were not deduplicating candidates. That is why the first example was eventually tabulated as an overvote.

Second, when we analyze marks for adjudication reasons, we just analyze the first mark we see each candidate option. That's why the second example was adjudicated properly, but the third example was not. 

## Bug Fix

When we convert marks to votes, we now deduplicate candidates. That is the first commit and addresses improper tabulation.

When we analyze marks for adjudication reasons, if there are multiple marks for a candidate, we now base our analysis off of the _more filled in mark_ rather than the _first_ mark. I'm not 100% sure this is the right handling for all cases, but I think within our current adjudication framework it is sufficient. If either mark is filled in, we count it. If neither mark is filled in, we don't count it. If neither is filled in, but either is marginal, we flag it as a marginal mark. We don't actually have marginal mark adjudication but I wanted to keep behavior consistent.

## Testing

After the changes, I confirmed that all the examples above scan as expected, as tabulated as expected, and appear in the CVR as expected. I've added automated testing to enforce expected behavior.

## Small Loose Ends

We may need to revisit this issue insofar as how these marks appear in the CVR files. Currently, with each position we specify in the CVR we specify an `OptionPosition` which is an index of the candidate in the race. Due to the single-candidate-single-position assumption, we only ever track this as the _first_ position in the race. For example, say a candidate is positions 0 and 1. Both sets of mark metadata in the original snapshot will show 0, and only the 0 position will appear in the modified snapshot.

First, we will need to fix this so the correct option positions appear. This may involve tracking more metadata about each mark, so could be more involved and gets closer to the interpreter.

Second, we want to consider the behavior we want in the modified snapshot in the first example. Do we want the modified snapshot to have both marks, and VxAdmin sorts it out? Or do we just choose one?
