### PR TITLE
chore(ballot-interpreter): remove unused dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,7 +224,6 @@ dependencies = [
  "imageproc",
  "itertools",
  "log",
- "logging_timer",
  "neon",
  "pretty_env_logger",
  "proptest",
@@ -1182,28 +1181,6 @@ name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
-
-[[package]]
-name = "logging_timer"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5669c09dbcb4a0b5f6de8364154495574238e18d6736bbdaa7726307f3268471"
-dependencies = [
- "log",
- "logging_timer_proc_macros",
-]
-
-[[package]]
-name = "logging_timer_proc_macros"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27906ca51651609191eeb2d1fdc6b52b8024789ec188b07aad88b6dfbe392fbe"
-dependencies = [
- "log",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "loop9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ libc = "0.2.153"
 log = "0.4.17"
 vx-logging = { path = "libs/logging" }
 daemon-utils = { path = "apps/mark-scan/daemon-utils" }
-logging_timer = "1.1.0"
 neon = { version = "1.0.0", default-features = false, features = ["napi-6"] }
 neon-serde3 = "0.10.0"
 nom = "7.1.3"

--- a/libs/ballot-interpreter/Cargo.toml
+++ b/libs/ballot-interpreter/Cargo.toml
@@ -17,7 +17,6 @@ clap = { workspace = true }
 image = { workspace = true }
 imageproc = { workspace = true }
 log = { workspace = true }
-logging_timer = { workspace = true }
 neon = { workspace = true }
 pretty_env_logger = { workspace = true }
 rayon = { workspace = true }

--- a/libs/ballot-interpreter/src/hmpb-rust/ballot_card.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/ballot_card.rs
@@ -1,7 +1,6 @@
 use std::{cmp::Ordering, io};
 
 use image::GrayImage;
-use logging_timer::time;
 use serde::Serialize;
 use types_rs::geometry::PixelUnit;
 
@@ -279,7 +278,6 @@ pub fn get_matching_paper_info_for_image_size(
         .map(|(paper_info, _)| *paper_info)
 }
 
-#[time]
 pub fn load_ballot_scan_bubble_image() -> Option<GrayImage> {
     let bubble_image_bytes = include_bytes!("../../data/bubble_scan.png");
     let inner = io::Cursor::new(bubble_image_bytes);
@@ -288,7 +286,6 @@ pub fn load_ballot_scan_bubble_image() -> Option<GrayImage> {
         .map(|image| image.to_luma8())
 }
 
-#[time]
 pub fn load_ballot_template_bubble_image() -> Option<GrayImage> {
     let bubble_image_bytes = include_bytes!("../../data/bubble_template.png");
     let inner = io::Cursor::new(bubble_image_bytes);

--- a/libs/ballot-interpreter/src/hmpb-rust/diagnostic.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/diagnostic.rs
@@ -72,7 +72,7 @@ fn inspect_cells(
     (passed_cells, failed_cells)
 }
 
-pub fn run_blank_paper_diagnostic(img: GrayImage, debug_path: Option<PathBuf>) -> bool {
+pub fn blank_paper(img: GrayImage, debug_path: Option<PathBuf>) -> bool {
     let bubble_img = load_ballot_scan_bubble_image().expect("loaded bubble image");
     let cell_width = bubble_img.width();
     let cell_height = bubble_img.height();
@@ -137,11 +137,7 @@ mod test {
                         .ok()
                         .map(DynamicImage::into_luma8)
                         .unwrap();
-                    assert_eq!(
-                        run_blank_paper_diagnostic(img, None),
-                        $expected,
-                        "image path: {path:?}"
-                    );
+                    assert_eq!(blank_paper(img, None), $expected, "image path: {path:?}");
                 }
             }
         };
@@ -177,6 +173,6 @@ mod test {
             .ok()
             .map(DynamicImage::into_luma8)
             .unwrap();
-        assert!(!run_blank_paper_diagnostic(img, None));
+        assert!(!blank_paper(img, None));
     }
 }

--- a/libs/ballot-interpreter/src/hmpb-rust/diagnostic.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/diagnostic.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 
 use image::{GenericImageView, GrayImage};
-use logging_timer::time;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use types_rs::geometry::Rect;
 
@@ -73,7 +72,6 @@ fn inspect_cells(
     (passed_cells, failed_cells)
 }
 
-#[time]
 pub fn run_blank_paper_diagnostic(img: GrayImage, debug_path: Option<PathBuf>) -> bool {
     let bubble_img = load_ballot_scan_bubble_image().expect("loaded bubble image");
     let cell_width = bubble_img.width();

--- a/libs/ballot-interpreter/src/hmpb-rust/image_utils.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/image_utils.rs
@@ -3,7 +3,6 @@ use image::{
     GenericImage, GenericImageView, GrayImage, ImageError, Luma, Rgb,
 };
 use itertools::Itertools;
-use logging_timer::time;
 use serde::Serialize;
 use types_rs::geometry::{PixelPosition, PixelUnit, Size, SubPixelUnit};
 use types_rs::{election::UnitIntervalValue, geometry::Quadrilateral};
@@ -173,7 +172,6 @@ pub fn count_pixels_in_shape(
 
 /// Resizes an image to fit within the given dimensions while maintaining the
 /// aspect ratio.
-#[time]
 pub fn size_image_to_fit(
     img: &GrayImage,
     max_width: PixelUnit,
@@ -196,7 +194,6 @@ pub fn size_image_to_fit(
 /// Resizes an image to fit within the given dimensions while maintaining the
 /// aspect ratio. If the image is already within the given dimensions, it is
 /// returned as-is.
-#[time]
 pub fn maybe_resize_image_to_fit(image: GrayImage, max_size: Size<PixelUnit>) -> GrayImage {
     let (width, height) = image.dimensions();
     let x_scale = max_size.width as SubPixelUnit / width as SubPixelUnit;
@@ -218,7 +215,6 @@ pub fn maybe_resize_image_to_fit(image: GrayImage, max_size: Size<PixelUnit>) ->
 }
 
 /// Expands an image by the given number of pixels on all sides.
-#[time]
 pub fn expand_image(
     img: &GrayImage,
     border_size: PixelUnit,

--- a/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 use image::GenericImage;
 use image::GrayImage;
 use imageproc::contrast::otsu_level;
-use logging_timer::time;
 use rayon::iter::IntoParallelRefIterator;
 use rayon::iter::ParallelIterator;
 use serde::Serialize;
@@ -185,7 +184,6 @@ impl ResizeStrategy {
 }
 
 /// Load both sides of a ballot card image and return the ballot card.
-#[time]
 pub fn prepare_ballot_card_images(
     side_a_image: GrayImage,
     side_b_image: GrayImage,
@@ -232,7 +230,6 @@ pub fn prepare_ballot_card_images(
 }
 
 /// Return the image with the black border cropped off.
-#[time]
 pub fn crop_ballot_page_image_borders(mut image: GrayImage) -> Option<BallotImage> {
     let threshold = otsu_level(&image);
     let border_inset = find_scanned_document_inset(&image, threshold)?;
@@ -254,7 +251,6 @@ pub fn crop_ballot_page_image_borders(mut image: GrayImage) -> Option<BallotImag
 
 /// Prepare a ballot page image for interpretation: crop the black border, and
 /// maybe resize it to the expected dimensions.
-#[time]
 fn prepare_ballot_page_image(
     label: &str,
     image: GrayImage,
@@ -297,7 +293,6 @@ fn prepare_ballot_page_image(
     })
 }
 
-#[time]
 pub fn interpret_ballot_card(
     side_a_image: GrayImage,
     side_b_image: GrayImage,
@@ -669,7 +664,6 @@ mod test {
     use super::*;
 
     /// Loads a ballot page image from disk as grayscale.
-    #[time]
     pub fn load_ballot_page_image(image_path: &Path) -> GrayImage {
         image::open(image_path).unwrap().into_luma8()
     }

--- a/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::similar_names)]
+
 use std::path::PathBuf;
 
 use image::GenericImage;
@@ -293,7 +295,8 @@ fn prepare_ballot_page_image(
     })
 }
 
-pub fn interpret_ballot_card(
+#[allow(clippy::too_many_lines)]
+pub fn ballot_card(
     side_a_image: GrayImage,
     side_b_image: GrayImage,
     options: &Options,
@@ -334,7 +337,7 @@ pub fn interpret_ballot_card(
             })
         }
     })
-    .collect::<Result<_, _>>()?;
+    .collect::<Result<(), _>>()?;
 
     let (side_a_grid_result, side_b_grid_result) = par_map_pair(
         (&side_a, &mut side_a_debug),
@@ -733,13 +736,13 @@ mod test {
     fn test_interpret_ballot_card() {
         let (side_a_image, side_b_image, options) =
             load_ballot_card_fixture("ashland", ("scan-side-a.jpeg", "scan-side-b.jpeg"));
-        interpret_ballot_card(side_a_image, side_b_image, &options).unwrap();
+        ballot_card(side_a_image, side_b_image, &options).unwrap();
 
         let (side_a_image, side_b_image, options) = load_ballot_card_fixture(
             "ashland",
             ("scan-rotated-side-a.jpeg", "scan-rotated-side-b.jpeg"),
         );
-        interpret_ballot_card(side_a_image, side_b_image, &options).unwrap();
+        ballot_card(side_a_image, side_b_image, &options).unwrap();
     }
 
     #[test]
@@ -756,7 +759,7 @@ mod test {
             }
         }
 
-        interpret_ballot_card(side_a_image, side_b_image, &options).unwrap();
+        ballot_card(side_a_image, side_b_image, &options).unwrap();
     }
 
     #[test]
@@ -781,8 +784,8 @@ mod test {
         let side_a_image_rotated = rotate180(&side_a_image);
         let side_b_image_rotated = rotate180(&side_b_image);
 
-        interpret_ballot_card(side_a_image, side_b_image, &options).unwrap();
-        interpret_ballot_card(side_a_image_rotated, side_b_image_rotated, &options).unwrap();
+        ballot_card(side_a_image, side_b_image, &options).unwrap();
+        ballot_card(side_a_image_rotated, side_b_image_rotated, &options).unwrap();
     }
 
     #[test]
@@ -794,7 +797,7 @@ mod test {
                 "timing-mark-smudge-back.jpeg",
             ),
         );
-        let interpretation = interpret_ballot_card(side_a_image, side_b_image, &options).unwrap();
+        let interpretation = ballot_card(side_a_image, side_b_image, &options).unwrap();
 
         for side in &[interpretation.front, interpretation.back] {
             for (_, ref scored_mark) in &side.marks {
@@ -810,7 +813,7 @@ mod test {
             "nh-test-ballot",
             ("missing-corner-front.png", "missing-corner-back.png"),
         );
-        interpret_ballot_card(side_a_image, side_b_image, &options).unwrap();
+        ballot_card(side_a_image, side_b_image, &options).unwrap();
     }
 
     #[test]
@@ -821,7 +824,7 @@ mod test {
         );
 
         let Error::MissingTimingMarks { reason, .. } =
-            interpret_ballot_card(side_a_image, side_b_image, &options).unwrap_err()
+            ballot_card(side_a_image, side_b_image, &options).unwrap_err()
         else {
             panic!("wrong error type");
         };
@@ -840,7 +843,7 @@ mod test {
         );
 
         let Error::MissingTimingMarks { reason, .. } =
-            interpret_ballot_card(side_a_image, side_b_image, &options).unwrap_err()
+            ballot_card(side_a_image, side_b_image, &options).unwrap_err()
         else {
             panic!("wrong error type");
         };
@@ -881,7 +884,7 @@ mod test {
         let Error::VerticalStreaksDetected {
             label,
             x_coordinates,
-        } = interpret_ballot_card(side_a_image, side_b_image, &options).unwrap_err()
+        } = ballot_card(side_a_image, side_b_image, &options).unwrap_err()
         else {
             panic!("wrong error type");
         };
@@ -911,7 +914,7 @@ mod test {
             .into();
 
         let interpretation =
-            interpret_ballot_card(side_a_image_rotated, side_b_image_rotated, &options).unwrap();
+            ballot_card(side_a_image_rotated, side_b_image_rotated, &options).unwrap();
 
         let front = interpretation.front;
         let back = interpretation.back;
@@ -936,7 +939,7 @@ mod test {
             ),
         );
         let Error::MissingTimingMarks { reason, .. } =
-            interpret_ballot_card(side_a_image, side_b_image, &options).unwrap_err()
+            ballot_card(side_a_image, side_b_image, &options).unwrap_err()
         else {
             panic!("wrong error type");
         };
@@ -954,7 +957,7 @@ mod test {
             ("high-top-skew-front.png", "high-top-skew-back.png"),
         );
         let Error::MissingTimingMarks { reason, .. } =
-            interpret_ballot_card(side_a_image, side_b_image, &options).unwrap_err()
+            ballot_card(side_a_image, side_b_image, &options).unwrap_err()
         else {
             panic!("wrong error type");
         };

--- a/libs/ballot-interpreter/src/hmpb-rust/js/mod.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/js/mod.rs
@@ -7,7 +7,7 @@ use neon::types::JsObject;
 
 use crate::ballot_card::load_ballot_scan_bubble_image;
 use crate::image_utils::bleed;
-use crate::interpret::{interpret_ballot_card, Options, SIDE_A_LABEL, SIDE_B_LABEL};
+use crate::interpret::{ballot_card, Options, SIDE_A_LABEL, SIDE_B_LABEL};
 
 use self::args::{
     get_election_definition_from_arg, get_image_data_or_path_from_arg, get_path_from_arg_opt,
@@ -87,7 +87,7 @@ pub fn interpret(mut cx: FunctionContext) -> JsResult<JsObject> {
         &threshold(&bubble_template, otsu_level(&bubble_template)),
         Luma([0u8]),
     );
-    let interpret_result = interpret_ballot_card(
+    let interpret_result = ballot_card(
         side_a_image,
         side_b_image,
         &Options {
@@ -189,7 +189,5 @@ pub fn run_blank_paper_diagnostic(mut cx: FunctionContext) -> JsResult<JsBoolean
         return cx.throw_error("failed to load image");
     };
 
-    Ok(cx.boolean(crate::diagnostic::run_blank_paper_diagnostic(
-        img, debug_path,
-    )))
+    Ok(cx.boolean(crate::diagnostic::blank_paper(img, debug_path)))
 }

--- a/libs/ballot-interpreter/src/hmpb-rust/scoring.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/scoring.rs
@@ -2,7 +2,6 @@ use std::fmt::{Display, Formatter};
 
 use image::{GenericImageView, GrayImage};
 use imageproc::contrast::otsu_level;
-use logging_timer::time;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use serde::Serialize;
 use types_rs::election::{GridLayout, GridLocation, GridPosition, UnitIntervalValue};
@@ -83,7 +82,6 @@ pub const DEFAULT_MAXIMUM_SEARCH_DISTANCE: u32 = 7;
 
 pub type ScoredBubbleMarks = Vec<(GridPosition, Option<ScoredBubbleMark>)>;
 
-#[time]
 pub fn score_bubble_marks_from_grid_layout(
     img: &GrayImage,
     bubble_template: &GrayImage,

--- a/libs/ballot-interpreter/src/hmpb-rust/timing_marks.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/timing_marks.rs
@@ -2,7 +2,6 @@ use std::{iter::once, ops::Range};
 
 use image::{imageops::rotate180, GenericImageView, GrayImage};
 use imageproc::contours::{find_contours_with_threshold, BorderType, Contour};
-use logging_timer::time;
 use rayon::iter::ParallelIterator;
 use rayon::prelude::IntoParallelRefIterator;
 use serde::Serialize;
@@ -306,7 +305,6 @@ pub struct FindTimingMarkGridOptions<'a> {
 
 /// Finds the timing marks in the given image and computes the grid of timing
 /// marks, i.e. the locations of all the possible bubbles.
-#[time]
 pub fn find_timing_mark_grid(
     geometry: &Geometry,
     ballot_image: &BallotImage,
@@ -493,7 +491,6 @@ const BORDER_SIZE: u8 = 1;
 
 /// Looks for possible timing mark shapes in the image without trying to
 /// determine if they are actually timing marks.
-#[time]
 pub fn find_timing_mark_shapes(
     geometry: &Geometry,
     ballot_image: &BallotImage,
@@ -562,7 +559,6 @@ const TIMING_MARK_SIZE_COMPARISON_ERROR_TOLERANCE: f32 = 4.0;
 /// found by some other method. This algorithm focuses on finding timing marks
 /// that intersect a line approximately aligned with the edges of the image,
 /// i.e. along the borders.
-#[time]
 pub fn find_partial_timing_marks_from_candidate_rects(
     geometry: &Geometry,
     rects: &[Rect],
@@ -948,7 +944,6 @@ impl Rotator180 {
     }
 }
 
-#[time]
 pub fn rotate_complete_timing_marks(
     image_size: &Size<u32>,
     complete_timing_marks: Complete,
@@ -1130,7 +1125,6 @@ pub struct FindCompleteTimingMarksFromPartialTimingMarksOptions<'a> {
     pub debug: &'a ImageDebugWriter,
 }
 
-#[time]
 pub fn find_complete_timing_marks_from_partial_timing_marks(
     ballot_image: &BallotImage,
     geometry: &Geometry,


### PR DESCRIPTION
We don't really use the `#[time]` output anymore for timing information.
