### PR TITLE
VxAdmin: Manual tallies - disable adding write-in with enter key if button disabled

### DIFF
--- a/apps/admin/frontend/src/screens/manual_data_entry_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_entry_screen.test.tsx
@@ -325,12 +325,32 @@ test('adding new write-in candidates', async () => {
   ).not.toBeInTheDocument();
   // "Add" button should be disabled without anything entered
   expect(within(zooCouncilMammal).getButton('Add')).toBeDisabled();
-  // "Add button should be disabled if an entry is an existing name"
+  // Enter should also be disabled
+  userEvent.type(
+    within(zooCouncilMammal).getByTestId('zoo-council-mammal-write-in-input'),
+    '{enter}'
+  );
+  expect(
+    within(zooCouncilMammal).queryByTestId(
+      'zoo-council-mammal-temp-write-in-(Zebra)-input'
+    )
+  ).not.toBeInTheDocument();
+  // "Add" button should be disabled if an entry is an existing name
   userEvent.type(
     within(zooCouncilMammal).getByTestId('zoo-council-mammal-write-in-input'),
     'Zebra'
   );
   expect(within(zooCouncilMammal).getButton('Add')).toBeDisabled();
+  // Enter should also be disabled
+  userEvent.type(
+    within(zooCouncilMammal).getByTestId('zoo-council-mammal-write-in-input'),
+    '{enter}'
+  );
+  expect(
+    within(zooCouncilMammal).queryByTestId(
+      'zoo-council-mammal-temp-write-in-(Zebra)-input'
+    )
+  ).not.toBeInTheDocument();
   // Cancel, re-open, and add new
   userEvent.click(within(zooCouncilMammal).getByText('Cancel'));
   userEvent.click(within(zooCouncilMammal).getByText('Add Write-In Candidate'));

--- a/apps/admin/frontend/src/screens/manual_data_entry_screen.tsx
+++ b/apps/admin/frontend/src/screens/manual_data_entry_screen.tsx
@@ -134,6 +134,9 @@ function AddWriteInRow({
     setIsAddingWriteIn(false);
     setWriteInName('');
   }, [addWriteInCandidate, writeInName]);
+  const disabled =
+    writeInName.length === 0 ||
+    disallowedCandidateNames.includes(normalizeWriteInName(writeInName));
 
   if (isAddingWriteIn) {
     return (
@@ -147,7 +150,7 @@ function AddWriteInRow({
             setWriteInName(e.target.value)
           }
           onKeyDown={(event) => {
-            if (event.key === 'Enter') {
+            if (!disabled && event.key === 'Enter') {
               onAdd();
             }
           }}
@@ -157,10 +160,7 @@ function AddWriteInRow({
           icon="Add"
           variant="primary"
           onPress={onAdd}
-          disabled={
-            writeInName.length === 0 ||
-            disallowedCandidateNames.includes(normalizeWriteInName(writeInName))
-          }
+          disabled={disabled}
         >
           Add
         </Button>


### PR DESCRIPTION


## Overview

Fixes #5450 

We already prevent adding two write-ins with the same name using the "Add" button, but forgot to also disable the Enter key, which enables you to erroneously add the candidate anyway.

## Demo Video or Screenshot

## Testing Plan
Manual test and added regression test

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
