### PR TITLE
[Mark|MarkScan] Remove old memory-leak-protection frontend restart logic

### DIFF
--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -11,7 +11,6 @@ import {
 } from '@votingworks/types';
 
 import { useHistory } from 'react-router-dom';
-import { IdleTimerProvider } from 'react-idle-timer';
 import {
   isElectionManagerAuth,
   isCardlessVoterAuth,
@@ -56,7 +55,6 @@ import {
   useApiClient,
 } from './api';
 
-import * as GLOBALS from './config/globals';
 import { handleKeyboardEvent } from './lib/assistive_technology';
 import { AdminScreen } from './pages/admin_screen';
 import { InsertCardScreen } from './pages/insert_card_screen';
@@ -564,19 +562,14 @@ export function AppRoot(): JSX.Element | null {
     }
 
     return (
-      <IdleTimerProvider
-        onIdle={() => /* istanbul ignore next */ window.kiosk?.quit()}
-        timeout={GLOBALS.QUIT_KIOSK_IDLE_SECONDS * 1000}
-      >
-        <InsertCardScreen
-          appPrecinct={precinctSelection}
-          electionDefinition={electionDefinition}
-          electionPackageHash={assertDefined(electionPackageHash)}
-          showNoChargerAttachedWarning={!!battery && battery.discharging}
-          isLiveMode={!isTestMode}
-          pollsState={pollsState}
-        />
-      </IdleTimerProvider>
+      <InsertCardScreen
+        appPrecinct={precinctSelection}
+        electionDefinition={electionDefinition}
+        electionPackageHash={assertDefined(electionPackageHash)}
+        showNoChargerAttachedWarning={!!battery && battery.discharging}
+        isLiveMode={!isTestMode}
+        pollsState={pollsState}
+      />
     );
   }
 

--- a/apps/mark/frontend/src/app_quit_on_idle.test.tsx
+++ b/apps/mark/frontend/src/app_quit_on_idle.test.tsx
@@ -1,4 +1,3 @@
-import { mockKiosk } from '@votingworks/test-utils';
 import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 
 import { electionGeneralDefinition } from '@votingworks/fixtures';
@@ -13,7 +12,6 @@ import { App } from './app';
 
 import { advanceTimersAndPromises } from '../test/helpers/timers';
 
-import { QUIT_KIOSK_IDLE_SECONDS } from './config/globals';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
 let apiMock: ApiMock;
@@ -21,41 +19,12 @@ let apiMock: ApiMock;
 jest.useFakeTimers();
 beforeEach(() => {
   createReactIdleTimerMocks();
-  window.kiosk = mockKiosk();
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
 });
 
 afterEach(() => {
-  window.kiosk = undefined;
   apiMock.mockApiClient.assertComplete();
-});
-
-test('Insert Card screen idle timeout to quit app', async () => {
-  apiMock.expectGetMachineConfig({
-    // machineId used to determine whether we quit. Now they all do.
-    // making sure a machineId that ends in 0 still triggers.
-    machineId: '0000',
-  });
-
-  apiMock.expectGetElectionRecord(electionGeneralDefinition);
-  apiMock.expectGetElectionState({
-    precinctSelection: ALL_PRECINCTS_SELECTION,
-    pollsState: 'polls_open',
-  });
-
-  render(<App apiClient={apiMock.mockApiClient} reload={jest.fn()} />);
-
-  // Ensure we're on the Insert Card screen
-  await screen.findByText('Insert Card');
-
-  expect(window.kiosk?.quit).not.toHaveBeenCalled();
-
-  // Check that we requested a quit after the idle timer fired.
-  await advanceTimersAndPromises(QUIT_KIOSK_IDLE_SECONDS);
-  await waitFor(() => {
-    expect(window.kiosk?.quit).toHaveBeenCalledTimes(1);
-  });
 });
 
 test('Voter idle timeout', async () => {

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -13,7 +13,6 @@ import {
 
 import Gamepad from 'react-gamepad';
 import { useHistory } from 'react-router-dom';
-import { IdleTimerProvider } from 'react-idle-timer';
 import {
   isElectionManagerAuth,
   isCardlessVoterAuth,
@@ -525,20 +524,15 @@ export function AppRoot({ reload }: Props): JSX.Element | null {
     }
 
     return (
-      <IdleTimerProvider
-        onIdle={() => /* istanbul ignore next */ window.kiosk?.quit()}
-        timeout={GLOBALS.QUIT_KIOSK_IDLE_SECONDS * 1000}
-      >
-        <InsertCardScreen
-          appPrecinct={appPrecinct}
-          electionDefinition={electionDefinition}
-          electionPackageHash={assertDefined(electionPackageHash)}
-          showNoAccessibleControllerWarning={!accessibleControllerConnected}
-          showNoChargerAttachedWarning={batteryIsDischarging}
-          isLiveMode={!isTestMode}
-          pollsState={pollsState}
-        />
-      </IdleTimerProvider>
+      <InsertCardScreen
+        appPrecinct={appPrecinct}
+        electionDefinition={electionDefinition}
+        electionPackageHash={assertDefined(electionPackageHash)}
+        showNoAccessibleControllerWarning={!accessibleControllerConnected}
+        showNoChargerAttachedWarning={batteryIsDischarging}
+        isLiveMode={!isTestMode}
+        pollsState={pollsState}
+      />
     );
   }
   return <UnconfiguredScreen />;


### PR DESCRIPTION
## Overview

Resolves https://github.com/votingworks/vxsuite/issues/5457

More context in [this slack thread](https://votingworks.slack.com/archives/C03Q42V9MJ5/p1727815213763589), but in summary, this code was added to force an exist and restart of the (pre-electron) kiosk browser to prevent a potential memory leak that was causing older versions of VxMark to crash after extended usage. Removing, since this is no longer an issue and hasn't come up on our other electron-based apps.

## Testing Plan
- Manual 

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
