### PR TITLE
VxScan: Don't try to recover from unexpected errors during scanning

### DIFF
--- a/apps/scan/backend/jest.config.js
+++ b/apps/scan/backend/jest.config.js
@@ -11,7 +11,10 @@ module.exports = {
   // tsconfig.json values.
   roots: ['<rootDir>/src'],
   setupFiles: ['<rootDir>/test/set_env_vars.ts'],
-  setupFilesAfterEnv: ['<rootDir>/test/setup_custom_matchers.ts', '<rootDir>/test/setupTests.ts'],
+  setupFilesAfterEnv: [
+    '<rootDir>/test/setup_custom_matchers.ts',
+    '<rootDir>/test/setupTests.ts',
+  ],
   coverageProvider: 'babel',
   collectCoverageFrom: [
     '**/*.{ts,tsx}',
@@ -23,8 +26,8 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: -81,
-      lines: -56,
+      branches: -73,
+      lines: -53,
     },
   },
 };

--- a/apps/scan/backend/src/scanners/pdi/pdi_app_double_feed_calibration.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_double_feed_calibration.test.ts
@@ -180,8 +180,7 @@ test('error with calibration command for double sheet', async () => {
 
       await apiClient.beginDoubleFeedCalibration();
       await waitForStatus(apiClient, {
-        state: 'recovering_from_error',
-        error: 'client_error',
+        state: 'unrecoverable_error',
       });
     }
   );
@@ -215,8 +214,7 @@ test('error with calibration command for single sheet', async () => {
       // Simulate insert of double sheet
       mockScanner.emitEvent({ event: 'doubleFeedCalibrationComplete' });
       await waitForStatus(apiClient, {
-        state: 'recovering_from_error',
-        error: 'client_error',
+        state: 'unrecoverable_error',
       });
     }
   );

--- a/libs/ballot-interpreter/src/hmpb-ts/interpret.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/interpret.ts
@@ -102,17 +102,7 @@ export function interpret(
     options
   );
   const result = interpretImpl(...args);
-  const parseJsonResult = safeParseJson(result.value);
-
-  /* istanbul ignore next */
-  if (parseJsonResult.isErr()) {
-    return err({
-      type: 'unknown',
-      message: parseJsonResult.err().message,
-    });
-  }
-
-  const value = parseJsonResult.ok();
+  const value = safeParseJson(result.value).unsafeUnwrap();
 
   if (!result.success) {
     return err(value as InterpretError);

--- a/libs/ballot-interpreter/src/hmpb-ts/types.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/types.ts
@@ -418,8 +418,7 @@ export type InterpretError =
       type: 'verticalStreaksDetected';
       label: string;
       xCoordinates: PixelPosition[];
-    }
-  | { type: 'unknown'; message: string };
+    };
 
 /**
  * Information about a ballot page that has failed to be interpreted.

--- a/libs/ballot-interpreter/src/interpret.ts
+++ b/libs/ballot-interpreter/src/interpret.ts
@@ -59,7 +59,7 @@ import {
   InterpretedContestLayout,
   InterpretedContestOptionLayout,
   interpret as interpretHmpbBallotSheetRust,
-  HmpbInterpretResult as NextInterpretResult,
+  HmpbInterpretResult,
   Rect as NextRect,
   ScoredBubbleMark,
   ScoredBubbleMarks,
@@ -451,11 +451,11 @@ function convertInterpretedBallotPage(
  */
 export function convertRustInterpretResult(
   options: InterpreterOptions,
-  nextResult: NextInterpretResult,
+  result: HmpbInterpretResult,
   sheet: SheetOf<ImageData>
 ): InterpretResult {
   /* istanbul ignore next */
-  if (nextResult.isErr()) {
+  if (result.isErr()) {
     return ok(
       mapSheet(
         sheet,
@@ -463,7 +463,7 @@ export function convertRustInterpretResult(
           ({
             interpretation: {
               type: 'UnreadablePage',
-              reason: nextResult.err().type,
+              reason: result.err().type,
             },
             normalizedImage: imageData,
           }) as const
@@ -471,7 +471,7 @@ export function convertRustInterpretResult(
     );
   }
 
-  const ballotCard = nextResult.ok();
+  const ballotCard = result.ok();
   const currentResult: OkType<InterpretResult> = [
     convertInterpretedBallotPage(
       options.electionDefinition,


### PR DESCRIPTION
## Overview

Task: #5459 
 
Updates the PDI scanner state machine to fail on unexpected errors, rather than try to reject the ballot and recover. This will enable us to fail fast and catch unexpected errors in testing rather than allow them to masquerade as unexplained unreadable ballots. This is especially useful for intermittent unexpected errors.

I also did a brief audit of the interpretation code paths to see if there were any other unexpected errors that were being converted into a rejected ballot rather than failing. I found one - a JSON parsing error - and modified it.

## Demo Video or Screenshot
We use the existing unrecoverable error screen

![Screenshot-VxScan-2024-10-02T16:57:23 337Z](https://github.com/user-attachments/assets/64f51f95-7dd4-4ad8-8387-a93468b16170)


## Testing Plan
Simulated an unexpected error and manual tested. Updated automated tests.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
