### PR TITLE
Software mitigation strategies for crashes and potentially time-consuming CVR resyncs following sporadic USB drive disconnects

### DIFF
--- a/apps/scan/backend/schema.sql
+++ b/apps/scan/backend/schema.sql
@@ -12,6 +12,7 @@ create table election (
   ballot_count_when_ballot_bag_last_replaced integer not null default 0,
   is_sound_muted boolean not null default false,
   is_ultrasonic_disabled boolean not null default false,
+  is_continuous_export_enabled boolean not null default true,
   created_at timestamp not null default current_timestamp
 );
 

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -193,6 +193,7 @@ export function buildApi(
         isTestMode: store.getTestMode(),
         isUltrasonicDisabled:
           !machine.supportsUltrasonic() || store.getIsUltrasonicDisabled(),
+        isContinuousExportEnabled: store.getIsContinuousExportEnabled(),
         ballotCountWhenBallotBagLastReplaced:
           store.getBallotCountWhenBallotBagLastReplaced(),
       };
@@ -233,6 +234,12 @@ export function buildApi(
 
     setIsUltrasonicDisabled(input: { isUltrasonicDisabled: boolean }): void {
       store.setIsUltrasonicDisabled(input.isUltrasonicDisabled);
+    },
+
+    setIsContinuousExportEnabled(input: {
+      isContinuousExportEnabled: boolean;
+    }): void {
+      store.setIsContinuousExportEnabled(input.isContinuousExportEnabled);
     },
 
     async setTestMode(input: { isTestMode: boolean }): Promise<void> {

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -26,6 +26,7 @@ import {
 import {
   assert,
   assertDefined,
+  extractErrorMessage,
   ok,
   Result,
   throwIllegalValue,
@@ -304,13 +305,15 @@ export function buildApi(
     },
 
     async exportCastVoteRecordsToUsbDrive(input: {
-      mode: 'full_export' | 'polls_closing';
+      mode: 'full_export' | 'polls_closing' | 'recovery_export';
     }): Promise<Result<void, ExportCastVoteRecordsToUsbDriveError>> {
       const userRole = (await getUserRole()) ?? 'system';
       await logger.log(LogEventId.ExportCastVoteRecordsInit, userRole, {
         message:
           input.mode === 'polls_closing'
             ? 'Marking cast vote record export as complete on polls close...'
+            : input.mode === 'recovery_export'
+            ? 'Exporting cast vote records that failed to sync...'
             : 'Exporting cast vote records...',
       });
 
@@ -335,6 +338,46 @@ export function buildApi(
               scannerType: 'precinct',
               arePollsClosing: true,
             })
+          );
+          break;
+        }
+        case 'recovery_export': {
+          exportResult = await workspace.continuousExportMutex.withLock(
+            async () => {
+              try {
+                const recoveryExportResult =
+                  await exportCastVoteRecordsToUsbDrive(
+                    store,
+                    usbDrive,
+                    store.forEachSheetPendingContinuousExport(),
+                    { scannerType: 'precinct', isRecoveryExport: true }
+                  );
+                if (recoveryExportResult.isErr()) {
+                  throw new Error(JSON.stringify(recoveryExportResult.err()));
+                }
+                return recoveryExportResult;
+              } catch (error) {
+                // Automatically fall back to a full export if the recovery export fails for any
+                // reason. We have to use a try-catch and can't just check for an error Result
+                // because certain errors, e.g., errors involving corrupted USB drive file systems,
+                // surface as unexpected errors.
+                await logger.log(
+                  LogEventId.ExportCastVoteRecordsInit,
+                  userRole,
+                  {
+                    message: 'Falling back to full export...',
+                    errorDetails: extractErrorMessage(error),
+                  }
+                );
+                const fullExportResult = await exportCastVoteRecordsToUsbDrive(
+                  store,
+                  usbDrive,
+                  store.forEachSheet(),
+                  { scannerType: 'precinct', isFullExport: true }
+                );
+                return fullExportResult;
+              }
+            }
           );
           break;
         }

--- a/apps/scan/backend/src/app_export.test.ts
+++ b/apps/scan/backend/src/app_export.test.ts
@@ -272,9 +272,9 @@ test('pausing and resuming continuous CVR export', async () => {
       });
 
       let usbDriveStatus = await apiClient.getUsbDriveStatus();
-      expect(usbDriveStatus.doesUsbDriveRequireCastVoteRecordSync).toEqual(
-        undefined
-      );
+      expect(
+        usbDriveStatus.doesUsbDriveRequireCastVoteRecordSync
+      ).toBeUndefined();
 
       await apiClient.setIsContinuousExportEnabled({
         isContinuousExportEnabled: true,
@@ -290,6 +290,11 @@ test('pausing and resuming continuous CVR export', async () => {
           mode: 'recovery_export',
         })
       ).toEqual(ok());
+
+      usbDriveStatus = await apiClient.getUsbDriveStatus();
+      expect(
+        usbDriveStatus.doesUsbDriveRequireCastVoteRecordSync
+      ).toBeUndefined();
 
       const exportDirectoryPaths = await getCastVoteRecordExportDirectoryPaths(
         mockUsbDrive.usbDrive

--- a/apps/scan/backend/src/scanners/custom/state_machine.ts
+++ b/apps/scan/backend/src/scanners/custom/state_machine.ts
@@ -1,6 +1,7 @@
 import {
   assert,
   assertDefined,
+  extractErrorMessage,
   Result,
   throwIllegalValue,
 } from '@votingworks/basics';
@@ -20,7 +21,13 @@ import {
 } from '@votingworks/custom-scanner';
 import { toRgba, writeImageData } from '@votingworks/image-utils';
 import { LogEventId, Logger, LogLine } from '@votingworks/logging';
-import { Id, mapSheet, SheetInterpretation, SheetOf } from '@votingworks/types';
+import {
+  ExportCastVoteRecordsToUsbDriveError,
+  Id,
+  mapSheet,
+  SheetInterpretation,
+  SheetOf,
+} from '@votingworks/types';
 import { createImageData } from 'canvas';
 import { join } from 'path';
 import { switchMap, throwError, timeout, timer } from 'rxjs';
@@ -458,11 +465,64 @@ function storeInterpretedSheet(
   return addedSheetId;
 }
 
-async function recordAcceptedSheet(
+async function exportCastVoteRecordToUsbDriveWithLogging(
   { continuousExportMutex, store }: Workspace,
   usbDrive: UsbDrive,
-  { interpretation }: Context
+  sheetId: string,
+  acceptedOrRejected: 'accepted' | 'rejected',
+  logger: Logger
 ) {
+  // Intentionally don't use the sheet ID in logs as that may inadvertently reveal the order in
+  // which ballots were cast
+  const operationId = uuid();
+
+  await logger.log(LogEventId.ExportCastVoteRecordsInit, 'system', {
+    message: `Queueing ${acceptedOrRejected} sheet for continuous export to USB drive.`,
+    operationId,
+  });
+
+  let exportResult: Result<void, ExportCastVoteRecordsToUsbDriveError>;
+  try {
+    exportResult = await continuousExportMutex.withLock(async () => {
+      await logger.log(LogEventId.ExportCastVoteRecordsInit, 'system', {
+        message: `Exporting cast vote record for ${acceptedOrRejected} sheet to USB drive...`,
+        operationId,
+      });
+      return await exportCastVoteRecordsToUsbDrive(
+        store,
+        usbDrive,
+        [assertDefined(store.getSheet(sheetId))],
+        { scannerType: 'precinct' }
+      );
+    });
+    if (exportResult.isErr()) {
+      throw new Error(JSON.stringify(exportResult.err()));
+    }
+  } catch (error) {
+    // We have to use a try-catch and can't just check for an error Result because certain errors,
+    // e.g., errors involving corrupted USB drive file systems, surface as unexpected errors.
+    await logger.log(LogEventId.ExportCastVoteRecordsComplete, 'system', {
+      disposition: 'failure',
+      message: `Error exporting cast vote record for ${acceptedOrRejected} sheet to USB drive.`,
+      errorDetails: extractErrorMessage(error),
+      operationId,
+    });
+    throw error;
+  }
+  await logger.log(LogEventId.ExportCastVoteRecordsComplete, 'system', {
+    disposition: 'success',
+    message: `Successfully exported cast vote record for ${acceptedOrRejected} sheet to USB drive.`,
+    operationId,
+  });
+}
+
+async function recordAcceptedSheet(
+  workspace: Workspace,
+  usbDrive: UsbDrive,
+  { interpretation }: Context,
+  logger: Logger
+) {
+  const { store } = workspace;
   assert(interpretation);
   const { sheetId } = interpretation;
   store.withTransaction(() => {
@@ -479,25 +539,25 @@ async function recordAcceptedSheet(
   });
 
   if (store.getIsContinuousExportEnabled()) {
-    const exportResult = await continuousExportMutex.withLock(() =>
-      exportCastVoteRecordsToUsbDrive(
-        store,
-        usbDrive,
-        [assertDefined(store.getSheet(sheetId))],
-        { scannerType: 'precinct' }
-      )
+    await exportCastVoteRecordToUsbDriveWithLogging(
+      workspace,
+      usbDrive,
+      sheetId,
+      'accepted',
+      logger
     );
-    exportResult.unsafeUnwrap();
   }
 
   debug('Stored accepted sheet: %s', sheetId);
 }
 
 async function recordRejectedSheet(
-  { continuousExportMutex, store }: Workspace,
+  workspace: Workspace,
   usbDrive: UsbDrive,
-  { interpretation }: Context
+  { interpretation }: Context,
+  logger: Logger
 ) {
+  const { store } = workspace;
   if (!interpretation) return;
   const { sheetId } = interpretation;
   store.withTransaction(() => {
@@ -513,15 +573,13 @@ async function recordRejectedSheet(
   });
 
   if (store.getIsContinuousExportEnabled()) {
-    const exportResult = await continuousExportMutex.withLock(() =>
-      exportCastVoteRecordsToUsbDrive(
-        store,
-        usbDrive,
-        [assertDefined(store.getSheet(sheetId))],
-        { scannerType: 'precinct' }
-      )
+    await exportCastVoteRecordToUsbDriveWithLogging(
+      workspace,
+      usbDrive,
+      sheetId,
+      'rejected',
+      logger
     );
-    exportResult.unsafeUnwrap();
   }
 
   debug('Stored rejected sheet: %s', sheetId);
@@ -542,12 +600,14 @@ function buildMachine({
   createCustomClient = defaultCreateCustomClient,
   workspace,
   interpret,
+  logger,
   usbDrive,
   delayOverrides,
 }: {
   createCustomClient?: CreateCustomClient;
   workspace: Workspace;
   interpret: InterpretFn;
+  logger: Logger;
   usbDrive: UsbDrive;
   delayOverrides: Partial<Delays>;
 }) {
@@ -703,7 +763,8 @@ function buildMachine({
       initial: 'starting',
       states: {
         starting: {
-          entry: (context) => recordRejectedSheet(workspace, usbDrive, context),
+          entry: (context) =>
+            recordRejectedSheet(workspace, usbDrive, context, logger),
           invoke: {
             src: reject,
             // Calling `reject` tells the Custom scanner to eject the ballot
@@ -1029,7 +1090,8 @@ function buildMachine({
         accepting: acceptingState,
         accepted: {
           id: 'accepted',
-          entry: (context) => recordAcceptedSheet(workspace, usbDrive, context),
+          entry: (context) =>
+            recordAcceptedSheet(workspace, usbDrive, context, logger),
           invoke: pollPaperStatus(),
           initial: 'scanning_paused',
           on: { SCANNER_NO_PAPER: doNothing },
@@ -1340,6 +1402,7 @@ export function createPrecinctScannerStateMachine({
     createCustomClient,
     workspace,
     interpret,
+    logger,
     usbDrive,
     delayOverrides: delays,
   });

--- a/apps/scan/backend/src/scanners/custom/state_machine.ts
+++ b/apps/scan/backend/src/scanners/custom/state_machine.ts
@@ -478,15 +478,17 @@ async function recordAcceptedSheet(
     store.addPendingContinuousExportOperation(sheetId);
   });
 
-  const exportResult = await continuousExportMutex.withLock(() =>
-    exportCastVoteRecordsToUsbDrive(
-      store,
-      usbDrive,
-      [assertDefined(store.getSheet(sheetId))],
-      { scannerType: 'precinct' }
-    )
-  );
-  exportResult.unsafeUnwrap();
+  if (store.getIsContinuousExportEnabled()) {
+    const exportResult = await continuousExportMutex.withLock(() =>
+      exportCastVoteRecordsToUsbDrive(
+        store,
+        usbDrive,
+        [assertDefined(store.getSheet(sheetId))],
+        { scannerType: 'precinct' }
+      )
+    );
+    exportResult.unsafeUnwrap();
+  }
 
   debug('Stored accepted sheet: %s', sheetId);
 }
@@ -510,15 +512,17 @@ async function recordRejectedSheet(
     store.addPendingContinuousExportOperation(sheetId);
   });
 
-  const exportResult = await continuousExportMutex.withLock(() =>
-    exportCastVoteRecordsToUsbDrive(
-      store,
-      usbDrive,
-      [assertDefined(store.getSheet(sheetId))],
-      { scannerType: 'precinct' }
-    )
-  );
-  exportResult.unsafeUnwrap();
+  if (store.getIsContinuousExportEnabled()) {
+    const exportResult = await continuousExportMutex.withLock(() =>
+      exportCastVoteRecordsToUsbDrive(
+        store,
+        usbDrive,
+        [assertDefined(store.getSheet(sheetId))],
+        { scannerType: 'precinct' }
+      )
+    );
+    exportResult.unsafeUnwrap();
+  }
 
   debug('Stored rejected sheet: %s', sheetId);
 }

--- a/apps/scan/backend/src/store.test.ts
+++ b/apps/scan/backend/src/store.test.ts
@@ -215,6 +215,36 @@ test('get/set is ultrasonic disabled mode', () => {
   expect(store.getIsUltrasonicDisabled()).toEqual(false);
 });
 
+test('get/set isContinuousExportEnabled', () => {
+  const store = Store.memoryStore();
+
+  // Before setting an election
+  expect(store.getIsContinuousExportEnabled()).toEqual(true);
+  expect(() => store.setIsContinuousExportEnabled(true)).toThrowError();
+
+  store.setElectionAndJurisdiction({
+    electionData:
+      electionGridLayoutNewHampshireAmherstFixtures.electionDefinition
+        .electionData,
+    jurisdiction,
+  });
+
+  expect(store.getIsContinuousExportEnabled()).toEqual(true);
+
+  store.setIsContinuousExportEnabled(false);
+  expect(store.getIsContinuousExportEnabled()).toEqual(false);
+
+  store.setIsContinuousExportEnabled(true);
+  expect(store.getIsContinuousExportEnabled()).toEqual(true);
+
+  store.setIsContinuousExportEnabled(false);
+  expect(store.getIsContinuousExportEnabled()).toEqual(false);
+
+  // Make sure that resetting election session resumes continuous export if paused
+  store.resetElectionSession();
+  expect(store.getIsContinuousExportEnabled()).toEqual(true);
+});
+
 test('get/set ballot count when ballot bag last replaced', () => {
   const store = Store.memoryStore();
 
@@ -837,6 +867,61 @@ test(
     expect(store.getPendingContinuousExportOperations()).toEqual([]);
   }
 );
+
+test('forEachSheetPendingContinuousExport', () => {
+  const store = Store.memoryStore();
+
+  const batchId = store.addBatch();
+
+  const sheet1Id = uuid();
+  store.addSheet(sheet1Id, batchId, [
+    { ...testSheetWithFiles[0], imagePath: '1-front.jpg' },
+    { ...testSheetWithFiles[1], imagePath: '1-back.jpg' },
+  ]);
+
+  const sheet2Id = uuid();
+  store.addSheet(sheet2Id, batchId, [
+    { ...testSheetWithFiles[0], imagePath: '2-front.jpg' },
+    { ...testSheetWithFiles[1], imagePath: '2-back.jpg' },
+  ]);
+  const expectedSheet2: AcceptedSheet = {
+    type: 'accepted',
+    id: sheet2Id,
+    batchId,
+    interpretation: mapSheet(testSheetWithFiles, (page) => page.interpretation),
+    frontImagePath: '2-front.jpg',
+    backImagePath: '2-back.jpg',
+  };
+
+  const sheet3Id = uuid();
+  store.addSheet(sheet3Id, batchId, [
+    { ...testSheetWithFiles[0], imagePath: '3-front.jpg' },
+    { ...testSheetWithFiles[1], imagePath: '3-back.jpg' },
+  ]);
+  const expectedSheet3: AcceptedSheet = {
+    type: 'accepted',
+    id: sheet3Id,
+    batchId,
+    interpretation: mapSheet(testSheetWithFiles, (page) => page.interpretation),
+    frontImagePath: '3-front.jpg',
+    backImagePath: '3-back.jpg',
+  };
+
+  store.addPendingContinuousExportOperation(sheet2Id);
+  store.addPendingContinuousExportOperation(sheet3Id);
+
+  expect(Array.from(store.forEachSheetPendingContinuousExport())).toEqual(
+    sortSheets([expectedSheet2, expectedSheet3])
+  );
+
+  store.deletePendingContinuousExportOperation(sheet2Id);
+  expect(Array.from(store.forEachSheetPendingContinuousExport())).toEqual([
+    expectedSheet3,
+  ]);
+
+  store.deletePendingContinuousExportOperation(sheet3Id);
+  expect(Array.from(store.forEachSheetPendingContinuousExport())).toEqual([]);
+});
 
 test('getCastVoteRecordRootHash, updateCastVoteRecordHashes, and clearCastVoteRecordHashes', () => {
   const store = Store.memoryStore();

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -867,6 +867,22 @@ export class Store {
   }
 
   /**
+   * Yields all scanned sheets that are pending continuous export
+   */
+  *forEachSheetPendingContinuousExport(): Generator<Sheet> {
+    const sql = `${getSheetsBaseQuery}
+      inner join pending_continuous_export_operations on
+        sheets.id = pending_continuous_export_operations.sheet_id
+      where
+        batches.deleted_at is null
+      order by sheets.id
+    `;
+    for (const row of this.client.each(sql) as Iterable<SheetRow>) {
+      yield sheetRowToSheet(row);
+    }
+  }
+
+  /**
    * Gets a sheet given a sheet ID. Returns undefined if the sheet doesn't exist.
    */
   getSheet(sheetId: string): Sheet | undefined {

--- a/apps/scan/backend/src/types.ts
+++ b/apps/scan/backend/src/types.ts
@@ -53,6 +53,7 @@ export interface PrecinctScannerConfig {
   // "Config" that is specific to each election session
   isTestMode: boolean;
   ballotCountWhenBallotBagLastReplaced: number;
+  isContinuousExportEnabled: boolean;
 }
 
 /**

--- a/apps/scan/backend/test/helpers/custom_helpers.ts
+++ b/apps/scan/backend/test/helpers/custom_helpers.ts
@@ -124,7 +124,9 @@ export async function withApp(
     });
     mockUsbDrive.assertComplete();
   } finally {
-    await waitForContinuousExportToUsbDrive(workspace.store);
+    if (workspace.store.getIsContinuousExportEnabled()) {
+      await waitForContinuousExportToUsbDrive(workspace.store);
+    }
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
     });

--- a/apps/scan/frontend/src/api.ts
+++ b/apps/scan/frontend/src/api.ts
@@ -231,6 +231,18 @@ export const setIsUltrasonicDisabled = {
   },
 } as const;
 
+export const setIsContinuousExportEnabled = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.setIsContinuousExportEnabled, {
+      async onSuccess() {
+        await queryClient.invalidateQueries(getConfig.queryKey());
+      },
+    });
+  },
+} as const;
+
 export const setTestMode = {
   useMutation() {
     const apiClient = useApiClient();

--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -1047,7 +1047,7 @@ test('requires CVR sync if necessary', async () => {
       'Cast vote records (CVRs) need to be synced to the USB drive.'
   );
 
-  apiMock.expectExportCastVoteRecordsToUsbDrive({ mode: 'full_export' });
+  apiMock.expectExportCastVoteRecordsToUsbDrive({ mode: 'recovery_export' });
   userEvent.click(screen.getByRole('button', { name: 'Sync CVRs' }));
   const modal = await screen.findByRole('alertdialog');
   await within(modal).findByText('Syncing CVRs');

--- a/apps/scan/frontend/src/app.tsx
+++ b/apps/scan/frontend/src/app.tsx
@@ -72,10 +72,10 @@ export function App({
                 <P>Ask a poll worker to restart the scanner.</P>
                 <P>
                   <Button
-                    onPress={() => assertDefined(window.kiosk).reboot()}
+                    onPress={() => assertDefined(window.kiosk).powerDown()}
                     variant="primary"
                   >
-                    Restart
+                    Power Down
                   </Button>
                 </P>
               </CenteredLargeProse>

--- a/apps/scan/frontend/src/app_root.tsx
+++ b/apps/scan/frontend/src/app_root.tsx
@@ -113,6 +113,7 @@ export function AppRoot({
     precinctSelection,
     isSoundMuted,
     ballotCountWhenBallotBagLastReplaced,
+    isContinuousExportEnabled,
   } = configQuery.data;
   const scannerStatus = scannerStatusQuery.data;
   const usbDrive = usbDriveStatusQuery.data;
@@ -220,7 +221,7 @@ export function AppRoot({
 
   if (!precinctSelection) return <UnconfiguredPrecinctScreen />;
 
-  if (usbDrive.status !== 'mounted') {
+  if (isContinuousExportEnabled && usbDrive.status !== 'mounted') {
     return <InsertUsbScreen />;
   }
 
@@ -249,6 +250,7 @@ export function AppRoot({
         isLiveMode={!isTestMode}
         logger={logger}
         precinctReportDestination={precinctReportDestination}
+        isContinuousExportEnabled={isContinuousExportEnabled}
       />
     );
   }

--- a/apps/scan/frontend/src/app_unhappy_paths.test.tsx
+++ b/apps/scan/frontend/src/app_unhappy_paths.test.tsx
@@ -63,8 +63,8 @@ test('when backend does not respond shows error screen', async () => {
     renderApp();
     await screen.findByText('Something went wrong');
     expect(console.error).toHaveBeenCalled();
-    userEvent.click(await screen.findButton('Restart'));
-    expect(window.kiosk?.reboot).toHaveBeenCalledTimes(1);
+    userEvent.click(await screen.findButton('Power Down'));
+    expect(window.kiosk?.powerDown).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/scan/frontend/src/screens/cast_vote_record_sync_required_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/cast_vote_record_sync_required_screen.test.tsx
@@ -52,7 +52,7 @@ test('CVR sync modal success case', async () => {
       'Cast vote records (CVRs) need to be synced to the USB drive.'
   );
 
-  apiMock.expectExportCastVoteRecordsToUsbDrive({ mode: 'full_export' });
+  apiMock.expectExportCastVoteRecordsToUsbDrive({ mode: 'recovery_export' });
   userEvent.click(screen.getByRole('button', { name: 'Sync CVRs' }));
   const modal = await screen.findByRole('alertdialog');
   expect(setShouldStayOnCastVoteRecordSyncRequiredScreen).toHaveBeenCalledTimes(
@@ -83,7 +83,7 @@ test('CVR sync modal error case', async () => {
   );
 
   apiMock.mockApiClient.exportCastVoteRecordsToUsbDrive
-    .expectCallWith({ mode: 'full_export' })
+    .expectCallWith({ mode: 'recovery_export' })
     .resolves(err({ type: 'file-system-error', message: '' }));
   userEvent.click(screen.getByRole('button', { name: 'Sync CVRs' }));
   const modal = await screen.findByRole('alertdialog');

--- a/apps/scan/frontend/src/screens/cast_vote_record_sync_required_screen.tsx
+++ b/apps/scan/frontend/src/screens/cast_vote_record_sync_required_screen.tsx
@@ -47,7 +47,7 @@ export function CastVoteRecordSyncRequiredScreen({
     setShouldStayOnCastVoteRecordSyncRequiredScreen(true);
     setModalState('syncing');
     exportCastVoteRecordsToUsbDriveMutation.mutate(
-      { mode: 'full_export' },
+      { mode: 'recovery_export' },
       {
         onSuccess: (result) => {
           if (result.isErr()) {

--- a/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
@@ -230,6 +230,42 @@ test('disables ultrasonic properly', async () => {
   await screen.findByText('Enable Double Sheet Detection');
 });
 
+test('when continuous export is enabled, shows a button to pause continuous export', async () => {
+  apiMock.expectGetConfig({ isContinuousExportEnabled: true });
+  renderScreen();
+  await screen.findByRole('heading', { name: 'Election Manager Settings' });
+
+  apiMock.mockApiClient.setIsContinuousExportEnabled
+    .expectCallWith({ isContinuousExportEnabled: false })
+    .resolves();
+  apiMock.expectGetConfig({ isContinuousExportEnabled: false });
+
+  userEvent.click(screen.getByRole('tab', { name: 'CVRs and Logs' }));
+
+  userEvent.click(
+    screen.getByRole('button', { name: 'Pause Continuous CVR Export' })
+  );
+  await screen.findByRole('button', { name: 'Resume Continuous CVR Export' });
+});
+
+test('when continuous export is paused, shows a button to resume continuous export', async () => {
+  apiMock.expectGetConfig({ isContinuousExportEnabled: false });
+  renderScreen();
+  await screen.findByRole('heading', { name: 'Election Manager Settings' });
+
+  apiMock.mockApiClient.setIsContinuousExportEnabled
+    .expectCallWith({ isContinuousExportEnabled: true })
+    .resolves();
+  apiMock.expectGetConfig({ isContinuousExportEnabled: true });
+
+  userEvent.click(screen.getByRole('tab', { name: 'CVRs and Logs' }));
+
+  userEvent.click(
+    screen.getByRole('button', { name: 'Resume Continuous CVR Export' })
+  );
+  await screen.findByRole('button', { name: 'Pause Continuous CVR Export' });
+});
+
 test('switching mode when no ballots have been counted', async () => {
   apiMock.expectGetConfig({ isTestMode: true });
   renderScreen({ scannerStatus: { ...statusNoPaper, ballotsCounted: 0 } });

--- a/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
@@ -235,12 +235,12 @@ test('when continuous export is enabled, shows a button to pause continuous expo
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
 
+  userEvent.click(screen.getByRole('tab', { name: 'CVRs and Logs' }));
+
   apiMock.mockApiClient.setIsContinuousExportEnabled
     .expectCallWith({ isContinuousExportEnabled: false })
     .resolves();
   apiMock.expectGetConfig({ isContinuousExportEnabled: false });
-
-  userEvent.click(screen.getByRole('tab', { name: 'CVRs and Logs' }));
 
   userEvent.click(
     screen.getByRole('button', { name: 'Pause Continuous CVR Export' })
@@ -253,12 +253,12 @@ test('when continuous export is paused, shows a button to resume continuous expo
   renderScreen();
   await screen.findByRole('heading', { name: 'Election Manager Settings' });
 
+  userEvent.click(screen.getByRole('tab', { name: 'CVRs and Logs' }));
+
   apiMock.mockApiClient.setIsContinuousExportEnabled
     .expectCallWith({ isContinuousExportEnabled: true })
     .resolves();
   apiMock.expectGetConfig({ isContinuousExportEnabled: true });
-
-  userEvent.click(screen.getByRole('tab', { name: 'CVRs and Logs' }));
 
   userEvent.click(
     screen.getByRole('button', { name: 'Resume Continuous CVR Export' })

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -31,6 +31,7 @@ import {
   getPollsInfo,
   getUsbDriveStatus,
   logOut,
+  setIsContinuousExportEnabled,
   setIsSoundMuted,
   setIsUltrasonicDisabled,
   setPrecinctSelection,
@@ -73,6 +74,8 @@ export function ElectionManagerScreen({
   const unconfigureMutation = unconfigureElection.useMutation();
   const ejectUsbDriveMutation = ejectUsbDrive.useMutation();
   const logOutMutation = logOut.useMutation();
+  const setIsContinuousExportEnabledMutation =
+    setIsContinuousExportEnabled.useMutation();
 
   const [isConfirmingSwitchToTestMode, setIsConfirmingSwitchToTestMode] =
     useState(false);
@@ -90,8 +93,13 @@ export function ElectionManagerScreen({
   }
 
   const { election } = electionDefinition;
-  const { precinctSelection, isTestMode, isSoundMuted, isUltrasonicDisabled } =
-    configQuery.data;
+  const {
+    precinctSelection,
+    isTestMode,
+    isSoundMuted,
+    isUltrasonicDisabled,
+    isContinuousExportEnabled,
+  } = configQuery.data;
   const { pollsState } = pollsInfoQuery.data;
   const authStatus = authStatusQuery.data;
 
@@ -182,6 +190,17 @@ export function ElectionManagerScreen({
     <React.Fragment>
       <P>
         <Button onPress={() => setIsExportingResults(true)}>Save CVRs</Button>{' '}
+      </P>
+      <P>
+        <Button
+          onPress={() =>
+            setIsContinuousExportEnabledMutation.mutate({
+              isContinuousExportEnabled: !isContinuousExportEnabled,
+            })
+          }
+        >
+          {isContinuousExportEnabled ? 'Pause' : 'Resume'} Continuous CVR Export
+        </Button>
       </P>
       <P>
         <ExportLogsButton

--- a/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
@@ -76,6 +76,7 @@ function renderScreen(
         printerInfo={fakePrinterInfo()}
         logger={fakeLogger()}
         precinctReportDestination="laser-printer"
+        isContinuousExportEnabled
         {...props}
       />
     )

--- a/apps/scan/frontend/src/screens/poll_worker_screen.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.tsx
@@ -94,6 +94,7 @@ export interface PollWorkerScreenProps {
   printerInfo?: KioskBrowser.PrinterInfo;
   logger: Logger;
   precinctReportDestination: PrecinctReportDestination;
+  isContinuousExportEnabled: boolean;
 }
 
 const ButtonGrid = styled.div`
@@ -113,6 +114,7 @@ export function PollWorkerScreen({
   printerInfo,
   logger,
   precinctReportDestination,
+  isContinuousExportEnabled,
 }: PollWorkerScreenProps): JSX.Element {
   const scannerResultsByPartyQuery = getScannerResultsByParty.useQuery();
   const usbDriveStatusQuery = getUsbDriveStatus.useQuery();
@@ -208,7 +210,11 @@ export function PollWorkerScreen({
         numPagesCallback: setNumReportPages,
       });
 
-      if (pollsTransitionType === 'close_polls' && scannedBallotCount > 0) {
+      if (
+        isContinuousExportEnabled &&
+        pollsTransitionType === 'close_polls' &&
+        scannedBallotCount > 0
+      ) {
         (
           await exportCastVoteRecordsMutation.mutateAsync({
             mode: 'polls_closing',

--- a/apps/scan/frontend/src/screens/poll_worker_screen.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.tsx
@@ -240,6 +240,7 @@ export function PollWorkerScreen({
           error: (error as Error).message,
         }
       );
+      throw error;
     }
   }
 

--- a/apps/scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/scan/frontend/test/helpers/mock_api_client.tsx
@@ -42,6 +42,7 @@ const defaultConfig: PrecinctScannerConfig = {
   isSoundMuted: false,
   isUltrasonicDisabled: false,
   isTestMode: true,
+  isContinuousExportEnabled: true,
   ballotCountWhenBallotBagLastReplaced: 0,
   electionDefinition: electionGeneralDefinition,
   precinctSelection: ALL_PRECINCTS_SELECTION,
@@ -169,7 +170,7 @@ export function createApiMock() {
     },
 
     expectExportCastVoteRecordsToUsbDrive(input: {
-      mode: 'full_export' | 'polls_closing';
+      mode: 'full_export' | 'polls_closing' | 'recovery_export';
     }): void {
       mockApiClient.exportCastVoteRecordsToUsbDrive
         .expectCallWith(input)

--- a/libs/backend/src/cast_vote_records/export.ts
+++ b/libs/backend/src/cast_vote_records/export.ts
@@ -1,7 +1,9 @@
 import crypto from 'crypto';
+import { existsSync } from 'fs';
 import fs from 'fs/promises';
 import path from 'path';
 import {
+  computeCastVoteRecordRootHashFromScratch,
   computeSingleCastVoteRecordHash,
   HashableFile,
   prepareSignatureFile,
@@ -53,7 +55,10 @@ import {
 } from './build_cast_vote_record';
 import { buildCastVoteRecordReportMetadata as baseBuildCastVoteRecordReportMetadata } from './build_report_metadata';
 import { CanonicalizedSheet, canonicalizeSheet } from './canonicalize';
-import { updateCreationTimestampOfDirectoryAndChildrenFiles } from './file_system_utils';
+import {
+  recoverAfterInterruptedCreationTimestampUpdate,
+  updateCreationTimestampOfDirectoryAndChildrenFiles,
+} from './file_system_utils';
 import { readCastVoteRecordExportMetadata } from './import';
 import { buildElectionOptionPositionMap } from './option_map';
 
@@ -130,6 +135,10 @@ interface PrecinctScannerOptions {
    * support full exports.)
    */
   isFullExport?: boolean;
+  /**
+   * An export performed to recover after an error, e.g., a sporadic USB disconnect
+   */
+  isRecoveryExport?: boolean;
 }
 
 /**
@@ -227,8 +236,9 @@ function shouldIncludeImagesInMinimalExport(
  * for getting the continuous export directory back to a good state after an unexpected failure.
  */
 async function getExportDirectoryPathRelativeToUsbMountPoint(
-  exportContext: ExportContext
-): Promise<string> {
+  exportContext: ExportContext,
+  options: { errIfDirectoryNeedsToBeCreated?: boolean }
+): Promise<Result<string, 'directory-needs-to-be-created'>> {
   const { exportOptions, scannerState, scannerStore, usbMountPoint } =
     exportContext;
   const { electionDefinition, inTestMode } = scannerState;
@@ -266,11 +276,19 @@ async function getExportDirectoryPathRelativeToUsbMountPoint(
     SCANNER_RESULTS_FOLDER,
     exportDirectoryName
   );
-  await fs.mkdir(
-    path.join(usbMountPoint, exportDirectoryPathRelativeToUsbMountPoint),
-    { recursive: true }
+  const exportDirectoryPath = path.join(
+    usbMountPoint,
+    exportDirectoryPathRelativeToUsbMountPoint
   );
-  return exportDirectoryPathRelativeToUsbMountPoint;
+
+  if (
+    options.errIfDirectoryNeedsToBeCreated &&
+    !existsSync(exportDirectoryPath)
+  ) {
+    return err('directory-needs-to-be-created');
+  }
+  await fs.mkdir(exportDirectoryPath, { recursive: true });
+  return ok(exportDirectoryPathRelativeToUsbMountPoint);
 }
 
 function buildCastVoteRecordReportMetadata(
@@ -679,11 +697,35 @@ export async function exportCastVoteRecordsToUsbDrive(
     scannerStore.clearCastVoteRecordHashes();
   }
 
-  const exportDirectoryPathRelativeToUsbMountPoint =
-    await getExportDirectoryPathRelativeToUsbMountPoint(exportContext);
+  const isRecoveryExport =
+    exportOptions.scannerType === 'precinct' && exportOptions.isRecoveryExport;
+
+  const exportDirectoryResult =
+    await getExportDirectoryPathRelativeToUsbMountPoint(exportContext, {
+      errIfDirectoryNeedsToBeCreated: isRecoveryExport,
+    });
+  if (exportDirectoryResult.isErr()) {
+    assert(
+      isRecoveryExport &&
+        exportDirectoryResult.err() === 'directory-needs-to-be-created'
+    );
+    return err({
+      type: 'recovery-export-error',
+      subType: 'expected-export-directory-does-not-exist',
+    });
+  }
+  const exportDirectoryPathRelativeToUsbMountPoint = exportDirectoryResult.ok();
+  const exportDirectoryPath = path.join(
+    usbMountPoint,
+    exportDirectoryPathRelativeToUsbMountPoint
+  );
 
   const isCreationTimestampShufflingNecessary =
     exportOptions.scannerType === 'precinct' && !exportOptions.isFullExport;
+
+  if (isRecoveryExport) {
+    await recoverAfterInterruptedCreationTimestampUpdate(exportDirectoryPath);
+  }
 
   const castVoteRecordHashes: { [castVoteRecordId: string]: string } = {};
   const sheetIds: string[] = [];
@@ -694,6 +736,14 @@ export async function exportCastVoteRecordsToUsbDrive(
         'Minimal exports should only include accepted sheets.'
     );
     sheetIds.push(sheet.id);
+
+    if (isRecoveryExport) {
+      // Clean up any remnants from past failed exports
+      await fs.rm(path.join(exportDirectoryPath, sheet.id), {
+        recursive: true,
+        force: true,
+      });
+    }
 
     // Randomly decide whether to shuffle creation timestamps before or after cast vote record
     // creation. If we always did one or the other, the last voter's cast vote record would be
@@ -762,6 +812,21 @@ export async function exportCastVoteRecordsToUsbDrive(
   const updatedCastVoteRecordRootHash =
     scannerStore.getCastVoteRecordRootHash();
 
+  // As a final safeguard after a recovery export, confirm that the Merkle tree hash of cast vote
+  // records on the USB drive matches that on the machine
+  if (isRecoveryExport) {
+    const recomputedUsbDriveCastVoteRecordRootHash =
+      await computeCastVoteRecordRootHashFromScratch(exportDirectoryPath);
+    if (
+      recomputedUsbDriveCastVoteRecordRootHash !== updatedCastVoteRecordRootHash
+    ) {
+      return err({
+        type: 'recovery-export-error',
+        subType: 'hash-mismatch-after-recovery-export',
+      });
+    }
+  }
+
   const exportMetadataFileResult = await exportMetadataFileToUsbDrive(
     exportContext,
     updatedCastVoteRecordRootHash,
@@ -785,7 +850,7 @@ export async function exportCastVoteRecordsToUsbDrive(
 
   if (scannerStore.scannerType === 'precinct') {
     assert(exportOptions.scannerType === 'precinct');
-    if (exportOptions.isFullExport) {
+    if (exportOptions.isFullExport || exportOptions.isRecoveryExport) {
       /**
        * Perform the scanner store update before clearing the cache for
        * {@link doesUsbDriveRequireCastVoteRecordSync} because

--- a/libs/backend/src/cast_vote_records/export.ts
+++ b/libs/backend/src/cast_vote_records/export.ts
@@ -95,6 +95,7 @@ export interface PrecinctScannerStore extends ScannerStoreBase {
   deletePendingContinuousExportOperation(sheetId: string): void;
   getBallotsCounted(): number;
   getExportDirectoryName(): string | undefined;
+  getIsContinuousExportEnabled(): boolean;
   getPendingContinuousExportOperations(): string[];
   getPollsState(): PollsState;
   setExportDirectoryName(exportDirectoryName: string): void;
@@ -893,6 +894,10 @@ export async function doesUsbDriveRequireCastVoteRecordSync(
   }
 
   const value = await (async () => {
+    if (!scannerStore.getIsContinuousExportEnabled()) {
+      return false;
+    }
+
     if (usbDriveStatus.status !== 'mounted') {
       return false;
     }

--- a/libs/backend/test/utils.ts
+++ b/libs/backend/test/utils.ts
@@ -114,6 +114,7 @@ export class MockPrecinctScannerStore
 
   private ballotsCounted: number;
   private exportDirectoryName?: string;
+  private isContinuousExportEnabled: boolean;
   private pendingContinuousExportOperations: string[];
   private pollsState: PollsState;
 
@@ -121,6 +122,7 @@ export class MockPrecinctScannerStore
     super();
     this.ballotsCounted = 0;
     this.exportDirectoryName = undefined;
+    this.isContinuousExportEnabled = true;
     this.pendingContinuousExportOperations = [];
     this.pollsState = 'polls_closed_initial';
   }
@@ -142,6 +144,10 @@ export class MockPrecinctScannerStore
 
   getExportDirectoryName(): string | undefined {
     return this.exportDirectoryName;
+  }
+
+  getIsContinuousExportEnabled(): boolean {
+    return this.isContinuousExportEnabled;
   }
 
   getPendingContinuousExportOperations(): string[] {
@@ -166,6 +172,10 @@ export class MockPrecinctScannerStore
 
   setBallotsCounted(ballotsCounted: number): void {
     this.ballotsCounted = ballotsCounted;
+  }
+
+  setIsContinuousExportEnabled(isContinuousExportEnabled: boolean): void {
+    this.isContinuousExportEnabled = isContinuousExportEnabled;
   }
 
   setPollsState(pollsState: PollsState): void {

--- a/libs/types/src/cast_vote_records.ts
+++ b/libs/types/src/cast_vote_records.ts
@@ -109,12 +109,20 @@ export type SheetValidationError = {
     }
 );
 
+type RecoveryExportError = {
+  type: 'recovery-export-error';
+} & (
+  | { subType: 'expected-export-directory-does-not-exist' }
+  | { subType: 'hash-mismatch-after-recovery-export' }
+);
+
 /**
  * An error encountered while exporting cast vote records to a USB drive
  */
 export type ExportCastVoteRecordsToUsbDriveError =
   | { type: ExportDataError }
-  | SheetValidationError;
+  | SheetValidationError
+  | RecoveryExportError;
 
 /**
  * An error encountered while reading a cast vote record export's metadata file

--- a/libs/ui/src/cast_vote_records.test.ts
+++ b/libs/ui/src/cast_vote_records.test.ts
@@ -87,6 +87,20 @@ test.each<{
     expectedMessage:
       'Encountered an invalid sheet with non-consecutive page numbers: front = 1, back = 3.',
   },
+  {
+    error: {
+      type: 'recovery-export-error',
+      subType: 'expected-export-directory-does-not-exist',
+    },
+    expectedMessage: 'Recovery export failed.',
+  },
+  {
+    error: {
+      type: 'recovery-export-error',
+      subType: 'hash-mismatch-after-recovery-export',
+    },
+    expectedMessage: 'Recovery export failed.',
+  },
 ])('userReadableMessageFromExportError', ({ error, expectedMessage }) => {
   expect(userReadableMessageFromExportError(error)).toEqual(expectedMessage);
 });

--- a/libs/ui/src/cast_vote_records.ts
+++ b/libs/ui/src/cast_vote_records.ts
@@ -64,6 +64,9 @@ export function userReadableMessageFromExportError(
         }
       })();
     }
+    case 'recovery-export-error': {
+      return 'Recovery export failed.';
+    }
     /* istanbul ignore next: Compile-time check for completeness */
     default: {
       throwIllegalValue(error, 'type');

--- a/libs/ui/src/error_boundary.tsx
+++ b/libs/ui/src/error_boundary.tsx
@@ -28,6 +28,8 @@ export class ErrorBoundary extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {};
+
+    this.handleUnhandledRejection = this.handleUnhandledRejection.bind(this);
   }
 
   static getDerivedStateFromError(error: unknown): State {


### PR DESCRIPTION
## Overview

It's long been known that a USB drive disconnect in the middle of a CVR export operation causes a crash. What's been less known is the likelihood of a sporadic disconnect without physical USB drive removal. We now have real data on that front and saw two sporadic USB drive disconnects in the field this past election. That's high enough that we've decided to improve the recovery flow for this case.

The current recovery flow is as follows:
1. Machine accepts or rejects ballot
2. Machine saves CVR to its own drive
3. Machine saves CVR to USB drive
4. USB drive disconnects mid-write
5. Machine crashes and displays the "Something went wrong" screen
6. User restarts
7. Machine detects that the USB drive is out of sync on boot and prompts the user to sync CVRs
8. Machine simplistically syncs all CVRs from scratch

| Resync screen |
| -- |
| ![resync](https://github.com/user-attachments/assets/2b1a10b3-c17b-46c8-a7de-aa5bc1a5d918) |

This PR makes a few critical changes.

## Smart/Fast Recovery Sync

First, the PR attempts a smart/fast recovery sync before falling back to a full sync, which can be slow if many ballots have been cast (~4 minutes for 1000 ballots in the most recent election). We actually already have a lot of infrastructure in place for this. We already maintain a queue of pending continuous export operations in durable storage for example. The recovery sync performs necessary cleanup, syncs the few CVRs still in the queue, and confirms that the Merkle tree hash of cast vote records on the USB drive matches that on the machine. The cleanup accounts for failures during random timestamp shuffling. And the final confirmation step ensures that we detect if the USB drive was swapped and needs a full sync, or if the export has been generally corrupted.

## Allowing Pausing Continuous Export

Second, the PR allows users to pause continuous export, via the election manager menu. This completely removes the USB drive from the critical voter path and presents a heavy-handed solution for the worst-case scenario that a USB drive repeatedly fails, and a replacement isn't available or an election official can't wait for a full sync because the voter line will grow too long. This setting allows you to remove the USB drive completely without triggering the "No USB drive detected" screen. We also don't write to the USB drive on polls close. The thinking is that you can export CVRs manually via the election manager menu after polls close and the release of some time pressure.

| Pause | Resume |
| -- | -- |
| ![pause](https://github.com/user-attachments/assets/99abfc54-9330-4dc1-812a-a9c3d029304b) | ![resume](https://github.com/user-attachments/assets/3d3108af-433f-46ae-9b3b-7063350fc7d6) |

## Tweaking "Something Went Wrong" Screen

Third, this PR replaces the "Restart" button on the "Something went wrong" screen with a "Power Down" button. Users will then unplug and replug the machine to power it back on. Experience in the field plus @jdVotingWorks's (awesome) research/testing has found that a complete removal of power is necessary to get these USB drives to properly reregister. A restart, I'm learning, doesn't fully remove power.

## Other Misc Changes

There are other small changes included in this PR, namely for improved logging and making sure that errors during polls close are properly surfaced.

I'll be porting over all of the changes that are relevant here to v4 as well.

## Testing Plan

- [x] Lots of manual testing, see #issue-v311-crashes
- [x] Automated testing

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates