### PR TITLE
Properly flush logs to USB drive before indicating success

### DIFF
--- a/libs/backend/src/logs/logs_api.test.ts
+++ b/libs/backend/src/logs/logs_api.test.ts
@@ -106,4 +106,6 @@ test('exportLogsToUsb works when all conditions are met', async () => {
     '/var/log/votingworks',
     expect.stringMatching('^/media/usb-drive/logs/machine_TEST-MACHINE-ID/'),
   ]);
+
+  expect(execFileMock).toHaveBeenCalledWith('sync', ['-f', '/media/usb-drive']);
 });

--- a/libs/backend/src/logs/logs_api.ts
+++ b/libs/backend/src/logs/logs_api.ts
@@ -52,6 +52,7 @@ function buildApi({
       try {
         await execFile('mkdir', ['-p', machineNamePath]);
         await execFile('cp', ['-r', LOG_DIR, destinationDirectory]);
+        await execFile('sync', ['-f', status.mountPoint]);
       } catch {
         return err('copy-failed');
       }


### PR DESCRIPTION
In a previous round of testing, SLI observed incomplete log exports. The log export success modal appears quickly before logs have been fully flushed to the connected USB drive.

We've since fixed this issue on main for v4 (https://github.com/votingworks/vxsuite/pull/4770). This PR fixes this issue retroactively for v3.