### PR TITLE
Fix bug in error boundary

### DIFF
--- a/libs/ui/src/error_boundary.tsx
+++ b/libs/ui/src/error_boundary.tsx
@@ -29,6 +29,9 @@ export class ErrorBoundary extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {};
+
+    // Non-React-lifecycle methods are not automatically bound
+    this.handleUnhandledRejection = this.handleUnhandledRejection.bind(this);
   }
 
   static getDerivedStateFromError(error: unknown): State {


### PR DESCRIPTION
## Overview

While working on the v3.1.2 patch for New Hampshire, I found a bug in our shared React error boundary logic that exists in v4 too.

If we ever encounter an unhandled promise rejection on the frontend, the error boundary will itself crash. Here's a simple contrived example:

```tsx
<Button onPress={() => Promise.reject(new Error('Uh oh!'))}>
  Test
</Button>
```

The issue is just that we have an unbound method in our error boundary class. Non-React-lifecycle methods are not automatically bound.

## Before

https://github.com/user-attachments/assets/c03b44bd-ffd2-49ae-b3b0-600e309fe48d

<img width="1512" alt="before" src="https://github.com/user-attachments/assets/a781c2c2-ca38-4e39-b16d-e25728ecefd2">

## After

https://github.com/user-attachments/assets/e423cbf1-03db-4c25-a4eb-7b3932123309

## Testing Plan

- [x] Tested manually