### PR TITLE
utils: Add `getBallotStyleGroup` helper

### DIFF
--- a/apps/admin/frontend/jest.config.js
+++ b/apps/admin/frontend/jest.config.js
@@ -15,7 +15,7 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: -87,
+      branches: -88,
       lines: -64,
     },
   },

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_tab.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_tab.tsx
@@ -15,10 +15,16 @@ import {
   TabPanel,
 } from '@votingworks/ui';
 import {
+  getBallotStyleGroup,
   getGroupedBallotStyles,
   isElectionManagerAuth,
 } from '@votingworks/utils';
-import { BallotStyleGroup, Election, Precinct } from '@votingworks/types';
+import {
+  BallotStyleGroup,
+  BallotStyleGroupId,
+  Election,
+  Precinct,
+} from '@votingworks/types';
 import type {
   ManualResultsVotingMethod,
   ManualResultsIdentifier,
@@ -229,9 +235,12 @@ export function ManualTalliesTab(): JSX.Element {
 
   function handleBallotStyleSelect(value?: string) {
     setSelectedBallotStyle(
-      getGroupedBallotStyles(election.ballotStyles).find(
-        (bs) => bs.id === value
-      )
+      value
+        ? getBallotStyleGroup({
+            election,
+            ballotStyleGroupId: value as BallotStyleGroupId,
+          })
+        : undefined
     );
     setSelectedPrecinct(undefined);
     setSelectedBallotType(undefined);

--- a/libs/utils/src/ballot_styles.test.ts
+++ b/libs/utils/src/ballot_styles.test.ts
@@ -3,12 +3,15 @@ import {
   BallotStyleGroupId,
   BallotStyleId,
   DistrictId,
+  Election,
   LanguageCode,
   Party,
   PartyId,
 } from '@votingworks/types';
+import { electionGeneral } from '@votingworks/fixtures';
 import {
   generateBallotStyleId,
+  getBallotStyleGroup,
   getGroupedBallotStyles,
   getRelatedBallotStyle,
 } from './ballot_styles';
@@ -138,6 +141,76 @@ describe('ballot style groups', () => {
         defaultLanguageBallotStyle: style3LegacySchema,
       },
     ]);
+  });
+
+  test('getBallotStyleGroup', () => {
+    const election: Election = {
+      ...electionGeneral,
+      ballotStyles: [
+        style1English,
+        style1Spanish,
+        style2GreenEnglish,
+        style2GreenEnglishMultiLanguage,
+        style2GreenNonEnglishSingleLanguage,
+        style2PurpleEnglish,
+        style3LegacySchema,
+      ],
+    };
+    expect(
+      getBallotStyleGroup({
+        election,
+        ballotStyleGroupId: '1' as BallotStyleGroupId,
+      })
+    ).toEqual({
+      ...style1English,
+      id: '1' as BallotStyleGroupId,
+      ballotStyles: [style1English, style1Spanish],
+      defaultLanguageBallotStyle: style1English,
+    });
+    expect(
+      getBallotStyleGroup({
+        election,
+        ballotStyleGroupId: '2-G' as BallotStyleGroupId,
+      })
+    ).toEqual({
+      ballotStyles: [
+        style2GreenEnglish,
+        style2GreenEnglishMultiLanguage,
+        style2GreenNonEnglishSingleLanguage,
+      ],
+      ...style2GreenEnglish,
+      id: '2-G' as BallotStyleGroupId,
+      defaultLanguageBallotStyle: style2GreenEnglish,
+    });
+    expect(
+      getBallotStyleGroup({
+        election,
+        ballotStyleGroupId: '2-P' as BallotStyleGroupId,
+      })
+    ).toEqual({
+      ...style2PurpleEnglish,
+      ballotStyles: [style2PurpleEnglish],
+      id: '2-P',
+      defaultLanguageBallotStyle: style2PurpleEnglish,
+    });
+    expect(
+      getBallotStyleGroup({
+        election,
+        ballotStyleGroupId: 'ballot-style-3' as BallotStyleGroupId,
+      })
+    ).toEqual({
+      ...style3LegacySchema,
+      ballotStyles: [style3LegacySchema],
+      id: 'ballot-style-3',
+      defaultLanguageBallotStyle: style3LegacySchema,
+    });
+
+    expect(
+      getBallotStyleGroup({
+        election,
+        ballotStyleGroupId: style1English.id as unknown as BallotStyleGroupId,
+      })
+    ).toBeUndefined();
   });
 
   test('getRelatedBallotStyle', () => {

--- a/libs/utils/src/ballot_styles.ts
+++ b/libs/utils/src/ballot_styles.ts
@@ -13,6 +13,7 @@ import {
   LanguageCode,
   BallotStyleGroup,
   Party,
+  Election,
 } from '@votingworks/types';
 
 const ID_LANGUAGES_SEPARATOR = '_';
@@ -36,6 +37,7 @@ export function generateBallotStyleId(params: {
   languages: LanguageCode[];
   party?: Party;
 }): BallotStyleId {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
   return [generateBallotStyleGroupId(params), ...params.languages].join(
     ID_LANGUAGES_SEPARATOR
   ) as BallotStyleId;
@@ -128,4 +130,19 @@ export function getGroupedBallotStyles(
       };
     })
     .toArray();
+}
+
+/**
+ * Finds a {@link BallotStyleGroup} by the given ID.
+ */
+export function getBallotStyleGroup({
+  election,
+  ballotStyleGroupId,
+}: {
+  election: Election;
+  ballotStyleGroupId: BallotStyleGroupId;
+}): BallotStyleGroup | undefined {
+  return getGroupedBallotStyles(election.ballotStyles).find(
+    (group) => group.id === ballotStyleGroupId
+  );
 }

--- a/libs/utils/src/tabulation/lookups.ts
+++ b/libs/utils/src/tabulation/lookups.ts
@@ -13,7 +13,7 @@ import {
   PrecinctId,
   Tabulation,
 } from '@votingworks/types';
-import { getGroupedBallotStyles } from '../ballot_styles';
+import { getBallotStyleGroup, getGroupedBallotStyles } from '../ballot_styles';
 
 /**
  * Creates a lookup function for getting some election metadata based on a key.
@@ -149,12 +149,10 @@ export function determinePartyId<T>(
   group: Tabulation.GroupOf<T>
 ): Optional<string> {
   if (group.partyId) return group.partyId;
-
   if (!group.ballotStyleGroupId) return undefined;
-  const ballotStyle = getGroupedBallotStyles(
-    electionDefinition.election.ballotStyles
-  ).find((bs) => bs.id === group.ballotStyleGroupId);
-  if (!ballotStyle) return undefined;
-
-  return ballotStyle.partyId;
+  const ballotStyleGroup = getBallotStyleGroup({
+    election: electionDefinition.election,
+    ballotStyleGroupId: group.ballotStyleGroupId as BallotStyleGroupId,
+  });
+  return ballotStyleGroup?.partyId;
 }


### PR DESCRIPTION
## Overview

For cases where we have a group ID and want to look it up. I realized I needed this when I was rebasing another PR after the recent refactor to ballot styles.
## Demo Video or Screenshot
N/A

## Testing Plan
Added new tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
