### PR TITLE
Remove getDefaultLangaugeBallotStyles and update uses

### DIFF
--- a/apps/admin/backend/src/store.test.ts
+++ b/apps/admin/backend/src/store.test.ts
@@ -17,7 +17,7 @@ import { tmpNameSync } from 'tmp';
 import { zipFile } from '@votingworks/test-utils';
 import { sha256 } from 'js-sha256';
 import { mockBaseLogger } from '@votingworks/logging';
-import { getDefaultLanguageBallotStyles } from '@votingworks/utils';
+import { getGroupedBallotStyles } from '@votingworks/utils';
 import { Store } from './store';
 import {
   ElectionRecord,
@@ -363,11 +363,9 @@ describe('getTabulationGroups', () => {
         electionId,
         groupBy: { groupByBallotStyle: true },
       }),
-      getDefaultLanguageBallotStyles(election.ballotStyles).map(
-        (ballotStyle) => ({
-          ballotStyleGroupId: ballotStyle.groupId,
-        })
-      )
+      getGroupedBallotStyles(election.ballotStyles).map((ballotStyleGroup) => ({
+        ballotStyleGroupId: ballotStyleGroup.id,
+      }))
     );
   });
 
@@ -399,11 +397,11 @@ describe('getTabulationGroups', () => {
         electionId,
         groupBy: { groupByBallotStyle: true, groupByPrecinct: true },
       }),
-      getDefaultLanguageBallotStyles(election.ballotStyles).flatMap(
-        (ballotStyle) =>
-          ballotStyle.precincts.map((precinctId) => ({
+      getGroupedBallotStyles(election.ballotStyles).flatMap(
+        (ballotStyleGroup) =>
+          ballotStyleGroup.precincts.map((precinctId) => ({
             precinctId,
-            ballotStyleGroupId: ballotStyle.groupId,
+            ballotStyleGroupId: ballotStyleGroup.id,
           }))
       )
     );
@@ -450,12 +448,12 @@ describe('getTabulationGroups', () => {
           partyIds: ['0'],
         },
       }),
-      getDefaultLanguageBallotStyles(election.ballotStyles)
+      getGroupedBallotStyles(election.ballotStyles)
         .filter((bs) => bs.partyId === '0')
         .flatMap((ballotStyle) =>
           ballotStyle.precincts.map((precinctId) => ({
             precinctId,
-            ballotStyleGroupId: ballotStyle.groupId,
+            ballotStyleGroupId: ballotStyle.id,
           }))
         )
     );

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_tab.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_tab.test.tsx
@@ -4,8 +4,8 @@ import { createMemoryHistory } from 'history';
 import { Router } from 'react-router-dom';
 
 import userEvent from '@testing-library/user-event';
-import { getDefaultLanguageBallotStyles } from '@votingworks/utils';
 import { BallotStyleGroupId } from '@votingworks/types';
+import { getGroupedBallotStyles } from '@votingworks/utils';
 import { screen, waitFor, within } from '../../../test/react_testing_library';
 import {
   ALL_MANUAL_TALLY_BALLOT_TYPES,
@@ -138,11 +138,11 @@ test('delete an existing tally', async () => {
 
 test('full table & clearing all data', async () => {
   apiMock.expectGetManualResultsMetadata(
-    getDefaultLanguageBallotStyles(election.ballotStyles).flatMap((bs) =>
+    getGroupedBallotStyles(election.ballotStyles).flatMap((bs) =>
       bs.precincts.flatMap((precinctId) =>
         ALL_MANUAL_TALLY_BALLOT_TYPES.flatMap((votingMethod) => [
           {
-            ballotStyleGroupId: bs.groupId,
+            ballotStyleGroupId: bs.id,
             precinctId,
             votingMethod,
             ballotCount: 10,

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
@@ -42,7 +42,7 @@ import {
   getPollTransitionsFromState,
   isFeatureFlagEnabled,
   BooleanEnvironmentVariableName,
-  getDefaultLanguageBallotStyles,
+  getGroupedBallotStyles,
 } from '@votingworks/utils';
 
 import type {
@@ -219,8 +219,8 @@ export function PollWorkerScreen({
     );
 
   const precinctBallotStyles = selectedCardlessVoterPrecinctId
-    ? getDefaultLanguageBallotStyles(election.ballotStyles).filter((bs) =>
-        bs.precincts.includes(selectedCardlessVoterPrecinctId)
+    ? getGroupedBallotStyles(election.ballotStyles).filter((group) =>
+        group.precincts.includes(selectedCardlessVoterPrecinctId)
       )
     : [];
   /*
@@ -438,13 +438,15 @@ export function PollWorkerScreen({
                 </H6>
                 {selectedCardlessVoterPrecinctId ? (
                   <ButtonList data-testid="ballot-styles">
-                    {precinctBallotStyles.map((ballotStyle) => (
+                    {precinctBallotStyles.map((ballotStyleGroup) => (
                       <Button
-                        key={ballotStyle.id}
+                        key={ballotStyleGroup.id}
                         onPress={onChooseBallotStyle}
-                        value={ballotStyle.id}
+                        value={ballotStyleGroup.defaultLanguageBallotStyle.id}
                       >
-                        {electionStrings.ballotStyleId(ballotStyle)}
+                        {electionStrings.ballotStyleId(
+                          ballotStyleGroup.defaultLanguageBallotStyle
+                        )}
                       </Button>
                     ))}
                   </ButtonList>

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -38,7 +38,7 @@ import {
   getPollsStateName,
   getPollsTransitionAction,
   getPollTransitionsFromState,
-  getDefaultLanguageBallotStyles,
+  getGroupedBallotStyles,
 } from '@votingworks/utils';
 
 import type { MachineConfig } from '@votingworks/mark-backend';
@@ -171,8 +171,8 @@ export function PollWorkerScreen({
     );
 
   const precinctBallotStyles = selectedCardlessVoterPrecinctId
-    ? getDefaultLanguageBallotStyles(election.ballotStyles).filter((bs) =>
-        bs.precincts.includes(selectedCardlessVoterPrecinctId)
+    ? getGroupedBallotStyles(election.ballotStyles).filter((group) =>
+        group.precincts.includes(selectedCardlessVoterPrecinctId)
       )
     : [];
   /*
@@ -335,17 +335,17 @@ export function PollWorkerScreen({
                 </H6>
                 {selectedCardlessVoterPrecinctId ? (
                   <ButtonList data-testid="ballot-styles">
-                    {precinctBallotStyles.map((ballotStyle) => (
+                    {precinctBallotStyles.map((ballotStyleGroup) => (
                       <Button
-                        key={ballotStyle.id}
+                        key={ballotStyleGroup.id}
                         onPress={() =>
                           activateCardlessVoterSession(
                             selectedCardlessVoterPrecinctId,
-                            ballotStyle.id
+                            ballotStyleGroup.defaultLanguageBallotStyle.id
                           )
                         }
                       >
-                        {ballotStyle.groupId}
+                        {ballotStyleGroup.id}
                       </Button>
                     ))}
                   </ButtonList>

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -326,6 +326,7 @@ export const BallotStyleGroupIdSchema =
   IdSchema as unknown as z.ZodSchema<BallotStyleGroupId>;
 export interface BallotStyleGroup {
   readonly id: BallotStyleGroupId;
+  readonly defaultLanguageBallotStyle: BallotStyle;
   readonly ballotStyles: readonly BallotStyle[];
   readonly precincts: readonly PrecinctId[];
   readonly districts: readonly DistrictId[];

--- a/libs/utils/src/ballot_styles.test.ts
+++ b/libs/utils/src/ballot_styles.test.ts
@@ -9,7 +9,6 @@ import {
 } from '@votingworks/types';
 import {
   generateBallotStyleId,
-  getDefaultLanguageBallotStyles,
   getGroupedBallotStyles,
   getRelatedBallotStyle,
 } from './ballot_styles';
@@ -193,24 +192,5 @@ describe('ballot style groups', () => {
         targetBallotStyleLanguage: LanguageCode.SPANISH,
       }).err()
     ).toMatch('not found');
-  });
-
-  test('getDefaultLanguageBallotStyles', () => {
-    expect(
-      getDefaultLanguageBallotStyles([
-        style1English,
-        style1Spanish,
-        style2GreenEnglish,
-        style2GreenEnglishMultiLanguage,
-        style2GreenNonEnglishSingleLanguage,
-        style2PurpleEnglish,
-        style3LegacySchema,
-      ])
-    ).toEqual([
-      style1English,
-      style2GreenEnglish,
-      style2PurpleEnglish,
-      style3LegacySchema,
-    ]);
   });
 });

--- a/libs/utils/src/ballot_styles.test.ts
+++ b/libs/utils/src/ballot_styles.test.ts
@@ -113,6 +113,7 @@ describe('ballot style groups', () => {
         ...style1English,
         id: '1' as BallotStyleGroupId,
         ballotStyles: [style1English, style1Spanish],
+        defaultLanguageBallotStyle: style1English,
       },
       {
         ballotStyles: [
@@ -122,16 +123,19 @@ describe('ballot style groups', () => {
         ],
         ...style2GreenEnglish,
         id: '2-G' as BallotStyleGroupId,
+        defaultLanguageBallotStyle: style2GreenEnglish,
       },
       {
         ballotStyles: [style2PurpleEnglish],
         ...style2PurpleEnglish,
         id: '2-P',
+        defaultLanguageBallotStyle: style2PurpleEnglish,
       },
       {
         ballotStyles: [style3LegacySchema],
         ...style3LegacySchema,
         id: 'ballot-style-3',
+        defaultLanguageBallotStyle: style3LegacySchema,
       },
     ]);
   });

--- a/libs/utils/src/ballot_styles.ts
+++ b/libs/utils/src/ballot_styles.ts
@@ -89,39 +89,6 @@ export function getRelatedBallotStyle(params: {
 }
 
 /**
- * Returns English-language-only ballot styles from the given list.
- *
- * The returned list will include all legacy language-agnostic ballot styles as
- * well, if included in the original list.
- */
-export function getDefaultLanguageBallotStyles(
-  ballotStyles: readonly BallotStyle[]
-): BallotStyle[] {
-  const ballotStyleGroups = getBallotStyleGroupMap(ballotStyles);
-
-  return iter(ballotStyleGroups.values())
-    .map((ballotStyleGroup) => {
-      let englishBallotStyle: BallotStyle | undefined;
-      let legacyBallotStyle: BallotStyle | undefined;
-
-      for (const ballotStyle of ballotStyleGroup) {
-        if (deepEqual(ballotStyle.languages, [LanguageCode.ENGLISH])) {
-          englishBallotStyle = ballotStyle;
-        } else if (!ballotStyle.languages) {
-          legacyBallotStyle = ballotStyle;
-        }
-      }
-
-      return assertDefined(
-        englishBallotStyle || legacyBallotStyle,
-        'Expected at least one English language ballot style per ballot style group.'
-      );
-    })
-    .toArray()
-    .sort((a, b) => a.id.localeCompare(b.id));
-}
-
-/**
  * Returns ballot style group details from the given total set of ballot styles
  *
  * The returned list will include all legacy language-agnostic ballot styles as their own
@@ -149,14 +116,15 @@ export function getGroupedBallotStyles(
         }
       }
 
-      const defaultBallotStyleInfo = assertDefined(
+      const defaultLanguageBallotStyle = assertDefined(
         englishBallotStyle || legacyBallotStyle,
         'Expected at least one English language ballot style per ballot style group.'
       );
       return {
-        ...defaultBallotStyleInfo,
+        ...defaultLanguageBallotStyle,
         id: groupId,
         ballotStyles: Array.from(ballotStyleGroup),
+        defaultLanguageBallotStyle,
       };
     })
     .toArray();


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/5481
Removes getDefaultLanguageBallotStyles and updates use cases to use getGroupedBallotStyles instead. I added defaultLanguageBallotStyle as an explicit item in BallotStyleGroup to make the code in mark/mark-scan straight forward. 

Thanks for letting me do this as its own PR haha 
<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot

## Testing Plan
Ran tests, manually tested mark and mark-scan poll worker screen selection of ballot styles and changing language as the voter 

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
