### PR TITLE
Update dev dock to have full list of fixtures elections

### DIFF
--- a/libs/dev-dock/backend/src/dev_dock_api.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.ts
@@ -109,6 +109,29 @@ function buildApi(devDockFilePath: string, machineType: MachineType) {
       return readDevDockFileContents(devDockFilePath).electionInfo;
     },
 
+    getCurrentFixtureElectionPaths(): DevDockElectionInfo[] {
+      const baseFixturePath = join(__dirname, '../../../../libs/fixtures/data');
+      return fs
+        .readdirSync(baseFixturePath, {
+          withFileTypes: true,
+        })
+        .filter((item) => item.isDirectory())
+        .map((item) => {
+          const filesInDir = fs.readdirSync(join(baseFixturePath, item.name));
+          const electionFile = filesInDir.find((file) =>
+            /^election\.json$/.test(file)
+          );
+          if (electionFile) {
+            return {
+              path: join(join(baseFixturePath, item.name), 'election.json'),
+              title: item.name,
+            };
+          }
+          return undefined;
+        })
+        .filter((item) => item !== undefined);
+    },
+
     getCardStatus(): CardStatus {
       return readFromCardMockFile().cardStatus;
     },

--- a/libs/dev-dock/backend/src/dev_dock_api.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.ts
@@ -123,7 +123,7 @@ function buildApi(devDockFilePath: string, machineType: MachineType) {
           );
           if (electionFile) {
             return {
-              path: join(join(baseFixturePath, item.name), 'election.json'),
+              path: join(baseFixturePath, item.name, 'election.json'),
               title: item.name,
             };
           }

--- a/libs/dev-dock/frontend/src/dev_dock.test.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.test.tsx
@@ -57,6 +57,20 @@ beforeEach(() => {
   mockApiClient.getMachineType.expectCallWith().resolves('central-scan');
   mockApiClient.getCardStatus.expectCallWith().resolves(noCardStatus);
   mockApiClient.getUsbDriveStatus.expectCallWith().resolves('removed');
+  mockApiClient.getCurrentFixtureElectionPaths.expectCallWith().resolves([
+    {
+      title: 'electionGeneral',
+      path: 'libs/fixtures/data/electionGeneral/election.json',
+    },
+    {
+      title: 'electionFamousNames2021',
+      path: 'libs/fixtures/data/electionFamousNames2021/election.json',
+    },
+    {
+      title: 'electionTwoPartyPrimary',
+      path: 'libs/fixtures/data/electionTwoPartyPrimary/election.json',
+    },
+  ]);
   mockApiClient.getElection.expectCallWith().resolves({
     title: 'Sample General Election',
     path: 'libs/fixtures/data/electionGeneral/election.json',
@@ -84,6 +98,7 @@ test('renders nothing if dev dock is disabled', () => {
   mockApiClient.getElection.reset();
   mockApiClient.getUsbDriveStatus.reset();
   mockApiClient.getMachineType.reset();
+  mockApiClient.getCurrentFixtureElectionPaths.reset();
   featureFlagMock.disableFeatureFlag(
     BooleanEnvironmentVariableName.ENABLE_DEV_DOCK
   );
@@ -216,7 +231,7 @@ test('election selector', async () => {
   });
   userEvent.selectOptions(
     electionSelector,
-    screen.getByRole('option', { name: /Famous Names/ })
+    screen.getByRole('option', { name: /electionFamousNames2021/ })
   );
   await waitFor(() => {
     expect(electionSelector).toHaveValue(

--- a/libs/dev-dock/frontend/src/dev_dock.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.tsx
@@ -63,26 +63,6 @@ const ElectionControlSelect = styled.select`
   }
 `;
 
-// For now, we have a small list of pre-populated election choices, plus the
-// ability to pick from a file. Some future ideas:
-// - Start with all elections in the fixtures directory.
-// - Show a list of recently used elections.
-// - Allow searching for elections.
-const ELECTIONS = [
-  {
-    title: 'Sample General Election',
-    path: 'libs/fixtures/data/electionGeneral/election.json',
-  },
-  {
-    title: 'Sample Primary Election',
-    path: 'libs/fixtures/data/electionTwoPartyPrimary/election.json',
-  },
-  {
-    title: 'Famous Names',
-    path: 'libs/fixtures/data/electionFamousNames2021/election.json',
-  },
-];
-
 function ElectionControl(): JSX.Element | null {
   const queryClient = useQueryClient();
   const apiClient = useApiClient();
@@ -90,6 +70,11 @@ function ElectionControl(): JSX.Element | null {
     ['getElection'],
     async () => (await apiClient.getElection()) ?? null
   );
+  const currentFixturesQuery = useQuery(
+    ['getCurrentFixtureElectionPaths'],
+    async () => (await apiClient.getCurrentFixtureElectionPaths()) ?? []
+  );
+  const fixturesElections = currentFixturesQuery.data || [];
   const setElectionMutation = useMutation(apiClient.setElection, {
     onSuccess: async () => await queryClient.invalidateQueries(['getElection']),
   });
@@ -117,7 +102,7 @@ function ElectionControl(): JSX.Element | null {
   }
 
   const elections = uniqueBy(
-    ELECTIONS.concat(selectedElection ?? []),
+    fixturesElections.concat(selectedElection ?? []),
     (election) => election.path
   );
 

--- a/libs/dev-dock/frontend/src/dev_dock.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.tsx
@@ -72,7 +72,7 @@ function ElectionControl(): JSX.Element | null {
   );
   const currentFixturesQuery = useQuery(
     ['getCurrentFixtureElectionPaths'],
-    async () => (await apiClient.getCurrentFixtureElectionPaths()) ?? []
+    async () => (await apiClient.getCurrentFixtureElectionPaths()) ?? null
   );
   const fixturesElections = currentFixturesQuery.data || [];
   const setElectionMutation = useMutation(apiClient.setElection, {


### PR DESCRIPTION
## Overview
The dev dock today just hard codes a few fixtures elections, I find this frustrating when I'm working with other elections so I am proposing we just generate this list from the fixtures/data directory and look for any subfolders with an election*.json file inside. 

Next step would be to add a way to autopopulate the mock usb drive with the election package for the current selected election (maybe with different system settings options) 
<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot
<img width="777" alt="Screenshot 2024-10-07 at 3 51 26 PM" src="https://github.com/user-attachments/assets/bdeec397-5ce9-45fb-9da9-91c66600d8b5">

## Testing Plan
Used dev dock
