### PR TITLE
Software mitigation strategies for crashes and potentially time-consuming CVR resyncs following sporadic USB drive disconnects (up-port to main)

### DIFF
--- a/apps/scan/backend/jest.config.js
+++ b/apps/scan/backend/jest.config.js
@@ -27,7 +27,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: -73,
-      lines: -54,
+      lines: -56,
     },
   },
 };

--- a/apps/scan/backend/schema.sql
+++ b/apps/scan/backend/schema.sql
@@ -12,6 +12,7 @@ create table election (
   last_polls_transition_ballot_count integer,
   is_sound_muted boolean not null default false,
   is_double_feed_detection_disabled boolean not null default false,
+  is_continuous_export_enabled boolean not null default true,
   created_at timestamp not null default current_timestamp
 );
 

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -279,10 +279,16 @@ export function buildApi({
       });
     },
 
-    setIsContinuousExportEnabled(input: {
+    async setIsContinuousExportEnabled(input: {
       isContinuousExportEnabled: boolean;
-    }): void {
+    }): Promise<void> {
       store.setIsContinuousExportEnabled(input.isContinuousExportEnabled);
+      await logger.logAsCurrentRole(LogEventId.ContinuousExportToggled, {
+        message: `Continuous export was ${
+          input.isContinuousExportEnabled ? 'resumed' : 'paused'
+        }`,
+        disposition: 'success',
+      });
     },
 
     async setTestMode(input: { isTestMode: boolean }): Promise<void> {

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -209,6 +209,7 @@ export function buildApi({
         isSoundMuted: store.getIsSoundMuted(),
         isTestMode: store.getTestMode(),
         isDoubleFeedDetectionDisabled: store.getIsDoubleFeedDetectionDisabled(),
+        isContinuousExportEnabled: store.getIsContinuousExportEnabled(),
       };
     },
 
@@ -278,6 +279,12 @@ export function buildApi({
       });
     },
 
+    setIsContinuousExportEnabled(input: {
+      isContinuousExportEnabled: boolean;
+    }): void {
+      store.setIsContinuousExportEnabled(input.isContinuousExportEnabled);
+    },
+
     async setTestMode(input: { isTestMode: boolean }): Promise<void> {
       const logMessage = input.isTestMode
         ? 'official to test'
@@ -319,9 +326,11 @@ export function buildApi({
       return resetPollsToPaused({ store, logger });
     },
 
-    async exportCastVoteRecordsToUsbDrive(): Promise<ExportCastVoteRecordsToUsbDriveResult> {
+    async exportCastVoteRecordsToUsbDrive(input: {
+      mode: 'full_export' | 'recovery_export';
+    }): Promise<ExportCastVoteRecordsToUsbDriveResult> {
       return exportCastVoteRecordsToUsbDrive({
-        mode: 'full_export',
+        mode: input.mode,
         workspace,
         usbDrive,
         logger,

--- a/apps/scan/backend/src/export.ts
+++ b/apps/scan/backend/src/export.ts
@@ -1,6 +1,10 @@
 import { LogEventId, Logger } from '@votingworks/logging';
 import { ExportCastVoteRecordsToUsbDriveError } from '@votingworks/types';
-import { Result, throwIllegalValue } from '@votingworks/basics';
+import {
+  extractErrorMessage,
+  Result,
+  throwIllegalValue,
+} from '@votingworks/basics';
 import { exportCastVoteRecordsToUsbDrive as exportCastVoteRecordsToUsbDriveBackend } from '@votingworks/backend';
 import { UsbDrive } from '@votingworks/usb-drive';
 import { Workspace } from './util/workspace';
@@ -16,7 +20,7 @@ export async function exportCastVoteRecordsToUsbDrive({
   usbDrive,
   logger,
 }: {
-  mode: 'full_export' | 'polls_closing';
+  mode: 'full_export' | 'polls_closing' | 'recovery_export';
   workspace: Workspace;
   usbDrive: UsbDrive;
   logger: Logger;
@@ -27,12 +31,14 @@ export async function exportCastVoteRecordsToUsbDrive({
     message:
       mode === 'polls_closing'
         ? 'Marking cast vote record export as complete on polls close...'
+        : mode === 'recovery_export'
+        ? 'Exporting cast vote records that failed to sync...'
         : 'Exporting cast vote records...',
   });
 
   // Use the continuous export mutex to ensure that any pending continuous export
   // operations finish first
-  let exportResult: ExportCastVoteRecordsToUsbDriveResult;
+  let exportResult: Result<void, ExportCastVoteRecordsToUsbDriveError>;
   switch (mode) {
     case 'full_export': {
       exportResult = await continuousExportMutex.withLock(() =>
@@ -55,6 +61,40 @@ export async function exportCastVoteRecordsToUsbDrive({
           arePollsClosing: true,
         })
       );
+      break;
+    }
+    case 'recovery_export': {
+      exportResult = await continuousExportMutex.withLock(async () => {
+        try {
+          const recoveryExportResult =
+            await exportCastVoteRecordsToUsbDriveBackend(
+              store,
+              usbDrive,
+              store.forEachSheetPendingContinuousExport(),
+              { scannerType: 'precinct', isRecoveryExport: true }
+            );
+          if (recoveryExportResult.isErr()) {
+            throw new Error(JSON.stringify(recoveryExportResult.err()));
+          }
+          return recoveryExportResult;
+        } catch (error) {
+          // Automatically fall back to a full export if the recovery export fails for any
+          // reason. We have to use a try-catch and can't just check for an error Result
+          // because certain errors, e.g., errors involving corrupted USB drive file systems,
+          // surface as unexpected errors.
+          await logger.logAsCurrentRole(LogEventId.ExportCastVoteRecordsInit, {
+            message: 'Falling back to full export...',
+            errorDetails: extractErrorMessage(error),
+          });
+          const fullExportResult = await exportCastVoteRecordsToUsbDriveBackend(
+            store,
+            usbDrive,
+            store.forEachSheet(),
+            { scannerType: 'precinct', isFullExport: true }
+          );
+          return fullExportResult;
+        }
+      });
       break;
     }
     /* istanbul ignore next: Compile-time check for completeness */

--- a/apps/scan/backend/src/polls.ts
+++ b/apps/scan/backend/src/polls.ts
@@ -80,8 +80,9 @@ export async function closePolls({
     });
   }
 
+  const isContinuousExportEnabled = store.getIsContinuousExportEnabled();
   const ballotsCounted = store.getBallotsCounted();
-  if (ballotsCounted > 0) {
+  if (isContinuousExportEnabled && ballotsCounted > 0) {
     const exportResult = await exportCastVoteRecordsToUsbDrive({
       mode: 'polls_closing',
       workspace,

--- a/apps/scan/backend/src/scanners/custom/state_machine.ts
+++ b/apps/scan/backend/src/scanners/custom/state_machine.ts
@@ -368,12 +368,14 @@ function buildMachine({
   auth,
   workspace,
   interpret,
+  logger,
   usbDrive,
 }: {
   createCustomClient?: CreateCustomClient;
   auth: InsertedSmartCardAuthApi;
   workspace: Workspace;
   interpret: InterpretFn;
+  logger: Logger;
   usbDrive: UsbDrive;
 }) {
   const { store } = workspace;
@@ -571,7 +573,12 @@ function buildMachine({
       states: {
         starting: {
           entry: (context) =>
-            recordRejectedSheet(workspace, usbDrive, context.interpretation),
+            recordRejectedSheet(
+              workspace,
+              usbDrive,
+              context.interpretation,
+              logger
+            ),
           invoke: {
             src: reject,
             // Calling `reject` tells the Custom scanner to eject the ballot
@@ -921,7 +928,8 @@ function buildMachine({
             recordAcceptedSheet(
               workspace,
               usbDrive,
-              assertDefined(context.interpretation)
+              assertDefined(context.interpretation),
+              logger
             ),
           invoke: pollPaperStatus(),
           initial: 'scanning_paused',
@@ -1244,6 +1252,7 @@ export function createPrecinctScannerStateMachine({
     auth,
     workspace,
     interpret,
+    logger,
     usbDrive,
   });
   const machineService = interpretStateMachine(

--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -218,11 +218,13 @@ function buildMachine({
   workspace,
   usbDrive,
   auth,
+  logger,
 }: {
   createScannerClient: () => ScannerClient;
   workspace: Workspace;
   usbDrive: UsbDrive;
   auth: InsertedSmartCardAuthApi;
+  logger: Logger;
 }) {
   const { store } = workspace;
   const initialClient = createScannerClient();
@@ -346,7 +348,12 @@ function buildMachine({
     states: {
       starting: {
         entry: (context) =>
-          recordRejectedSheet(workspace, usbDrive, context.interpretation),
+          recordRejectedSheet(
+            workspace,
+            usbDrive,
+            context.interpretation,
+            logger
+          ),
         invoke: [
           {
             src: async ({ client }) => {
@@ -779,7 +786,8 @@ function buildMachine({
             await recordAcceptedSheet(
               workspace,
               usbDrive,
-              assertDefined(context.interpretation)
+              assertDefined(context.interpretation),
+              logger
             );
             /* istanbul ignore next */
             scanAndInterpretTimer?.checkpoint('recordAcceptedSheet complete');
@@ -1222,6 +1230,7 @@ export function createPrecinctScannerStateMachine({
     workspace,
     usbDrive,
     auth,
+    logger,
   });
   const machineService = interpretStateMachine(
     machine,

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -389,6 +389,31 @@ export class Store {
     );
   }
 
+  getIsContinuousExportEnabled(): boolean {
+    const electionRow = this.client.one(
+      'select is_continuous_export_enabled as isContinuousExportEnabled from election'
+    ) as { isContinuousExportEnabled: number } | undefined;
+
+    if (!electionRow) {
+      return true;
+    }
+
+    return Boolean(electionRow.isContinuousExportEnabled);
+  }
+
+  setIsContinuousExportEnabled(isContinuousExportEnabled: boolean): void {
+    if (!this.hasElection()) {
+      throw new Error('Cannot toggle continuous export without an election.');
+    }
+
+    this.client.run(
+      'update election set is_continuous_export_enabled = ?',
+      isContinuousExportEnabled ? 1 : 0
+    );
+
+    clearDoesUsbDriveRequireCastVoteRecordSyncCachedResult();
+  }
+
   getBallotPaperSizeForElection(): BallotPaperSize {
     const electionRecord = this.getElectionRecord();
     return (
@@ -686,6 +711,7 @@ export class Store {
         this.client.run("delete from sqlite_sequence where name = 'batches'");
 
         // Reset all export-related metadata
+        this.setIsContinuousExportEnabled(true);
         this.setExportDirectoryName(undefined);
         this.deleteAllPendingContinuousExportOperations();
         this.clearCastVoteRecordHashes();
@@ -882,6 +908,22 @@ export class Store {
    */
   *forEachSheet(): Generator<Sheet> {
     const sql = `${getSheetsBaseQuery}
+      where
+        batches.deleted_at is null
+      order by sheets.id
+    `;
+    for (const row of this.client.each(sql) as Iterable<SheetRow>) {
+      yield sheetRowToSheet(row);
+    }
+  }
+
+  /**
+   * Yields all scanned sheets that are pending continuous export
+   */
+  *forEachSheetPendingContinuousExport(): Generator<Sheet> {
+    const sql = `${getSheetsBaseQuery}
+      inner join pending_continuous_export_operations on
+        sheets.id = pending_continuous_export_operations.sheet_id
       where
         batches.deleted_at is null
       order by sheets.id

--- a/apps/scan/backend/src/types.ts
+++ b/apps/scan/backend/src/types.ts
@@ -40,6 +40,7 @@ export interface PrecinctScannerConfig {
   isDoubleFeedDetectionDisabled: boolean;
   // "Config" that is specific to each election session
   isTestMode: boolean;
+  isContinuousExportEnabled: boolean;
 }
 
 /**

--- a/apps/scan/backend/test/helpers/custom_helpers.ts
+++ b/apps/scan/backend/test/helpers/custom_helpers.ts
@@ -153,7 +153,9 @@ export async function withApp(
     });
     mockUsbDrive.assertComplete();
   } finally {
-    await waitForContinuousExportToUsbDrive(workspace.store);
+    if (workspace.store.getIsContinuousExportEnabled()) {
+      await waitForContinuousExportToUsbDrive(workspace.store);
+    }
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
     });

--- a/apps/scan/frontend/src/api.ts
+++ b/apps/scan/frontend/src/api.ts
@@ -259,6 +259,18 @@ export const setIsDoubleFeedDetectionDisabled = {
   },
 } as const;
 
+export const setIsContinuousExportEnabled = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.setIsContinuousExportEnabled, {
+      async onSuccess() {
+        await queryClient.invalidateQueries(getConfig.queryKey());
+      },
+    });
+  },
+} as const;
+
 export const setTestMode = {
   useMutation() {
     const apiClient = useApiClient();

--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -403,7 +403,7 @@ test('voter can cast a ballot that scans successfully ', async () => {
   userEvent.click(await screen.findButton('Save CVRs'));
   await screen.findByRole('heading', { name: 'Save CVRs' });
 
-  apiMock.expectExportCastVoteRecordsToUsbDrive();
+  apiMock.expectExportCastVoteRecordsToUsbDrive({ mode: 'full_export' });
   userEvent.click(await screen.findByText('Save'));
   await screen.findByText('CVRs Saved');
 
@@ -894,7 +894,7 @@ test('requires CVR sync if necessary', async () => {
       'Cast vote records (CVRs) need to be synced to the USB drive.'
   );
 
-  apiMock.expectExportCastVoteRecordsToUsbDrive();
+  apiMock.expectExportCastVoteRecordsToUsbDrive({ mode: 'recovery_export' });
   userEvent.click(screen.getByRole('button', { name: 'Sync CVRs' }));
   const modal = await screen.findByRole('alertdialog');
   await within(modal).findByText('Syncing CVRs');

--- a/apps/scan/frontend/src/app_root.tsx
+++ b/apps/scan/frontend/src/app_root.tsx
@@ -79,6 +79,7 @@ export function AppRoot(): JSX.Element | null {
     isTestMode,
     precinctSelection,
     isSoundMuted,
+    isContinuousExportEnabled,
   } = configQuery.data;
   const scannerStatus = scannerStatusQuery.data;
   const usbDrive = usbDriveStatusQuery.data;
@@ -232,7 +233,11 @@ export function AppRoot(): JSX.Element | null {
     );
   }
 
-  if (usbDrive.status !== 'mounted' && pollsState !== 'polls_closed_final') {
+  if (
+    isContinuousExportEnabled &&
+    usbDrive.status !== 'mounted' &&
+    pollsState !== 'polls_closed_final'
+  ) {
     return <InsertUsbScreen />;
   }
 

--- a/apps/scan/frontend/src/components/export_results_modal.test.tsx
+++ b/apps/scan/frontend/src/components/export_results_modal.test.tsx
@@ -69,7 +69,7 @@ test('render export modal when a usb drive is mounted as expected and allows exp
   });
   getByText('Save CVRs');
 
-  apiMock.expectExportCastVoteRecordsToUsbDrive();
+  apiMock.expectExportCastVoteRecordsToUsbDrive({ mode: 'full_export' });
   userEvent.click(getByText('Save'));
   await waitFor(() => getByText('CVRs Saved'));
 
@@ -96,7 +96,7 @@ test('render export modal with errors when appropriate', async () => {
   getByText('Save CVRs');
 
   apiMock.mockApiClient.exportCastVoteRecordsToUsbDrive
-    .expectCallWith()
+    .expectCallWith({ mode: 'full_export' })
     .resolves(err({ type: 'file-system-error' }));
   userEvent.click(getByText('Save'));
   await waitFor(() =>

--- a/apps/scan/frontend/src/components/export_results_modal.tsx
+++ b/apps/scan/frontend/src/components/export_results_modal.tsx
@@ -43,17 +43,22 @@ export function ExportResultsModal({
 
   function exportResults() {
     setCurrentState(ModalState.SAVING);
-    exportCastVoteRecordsToUsbDriveMutation.mutate(undefined, {
-      onSuccess: (result) => {
-        if (result.isErr()) {
-          const errorDetails = userReadableMessageFromExportError(result.err());
-          setErrorMessage(`Failed to save CVRs. ${errorDetails}`);
-          setCurrentState(ModalState.ERROR);
-        } else {
-          setCurrentState(ModalState.DONE);
-        }
-      },
-    });
+    exportCastVoteRecordsToUsbDriveMutation.mutate(
+      { mode: 'full_export' },
+      {
+        onSuccess: (result) => {
+          if (result.isErr()) {
+            const errorDetails = userReadableMessageFromExportError(
+              result.err()
+            );
+            setErrorMessage(`Failed to save CVRs. ${errorDetails}`);
+            setCurrentState(ModalState.ERROR);
+          } else {
+            setCurrentState(ModalState.DONE);
+          }
+        },
+      }
+    );
   }
 
   if (currentState === ModalState.ERROR) {

--- a/apps/scan/frontend/src/screens/cast_vote_record_sync_required_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/cast_vote_record_sync_required_screen.test.tsx
@@ -70,7 +70,7 @@ test('CVR sync modal success case', async () => {
       'Cast vote records (CVRs) need to be synced to the USB drive.'
   );
 
-  apiMock.expectExportCastVoteRecordsToUsbDrive();
+  apiMock.expectExportCastVoteRecordsToUsbDrive({ mode: 'recovery_export' });
   userEvent.click(screen.getByRole('button', { name: 'Sync CVRs' }));
   const modal = await screen.findByRole('alertdialog');
   expect(setShouldStayOnCastVoteRecordSyncRequiredScreen).toHaveBeenCalledTimes(
@@ -104,7 +104,7 @@ test('CVR sync modal error case', async () => {
   );
 
   apiMock.mockApiClient.exportCastVoteRecordsToUsbDrive
-    .expectCallWith()
+    .expectCallWith({ mode: 'recovery_export' })
     .resolves(err({ type: 'file-system-error', message: '' }));
   userEvent.click(screen.getByRole('button', { name: 'Sync CVRs' }));
   const modal = await screen.findByRole('alertdialog');

--- a/apps/scan/frontend/src/screens/cast_vote_record_sync_required_screen.tsx
+++ b/apps/scan/frontend/src/screens/cast_vote_record_sync_required_screen.tsx
@@ -58,15 +58,18 @@ export function CastVoteRecordSyncRequiredScreen({
   function syncCastVoteRecords() {
     setShouldStayOnCastVoteRecordSyncRequiredScreen(true);
     setModalState('syncing');
-    exportCastVoteRecordsToUsbDriveMutation.mutate(undefined, {
-      onSuccess: (result) => {
-        if (result.isErr()) {
-          setModalState('error');
-          return;
-        }
-        setModalState('success');
-      },
-    });
+    exportCastVoteRecordsToUsbDriveMutation.mutate(
+      { mode: 'recovery_export' },
+      {
+        onSuccess: (result) => {
+          if (result.isErr()) {
+            setModalState('error');
+            return;
+          }
+          setModalState('success');
+        },
+      }
+    );
   }
 
   function closeModal() {

--- a/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
@@ -219,6 +219,42 @@ test('disables double feed detection properly', async () => {
   await screen.findByText('Enable Double Sheet Detection');
 });
 
+test('when continuous export is enabled, shows a button to pause continuous export', async () => {
+  apiMock.expectGetConfig({ isContinuousExportEnabled: true });
+  renderScreen();
+  await screen.findByRole('heading', { name: 'Election Manager Settings' });
+
+  userEvent.click(screen.getByRole('tab', { name: 'CVRs and Logs' }));
+
+  apiMock.mockApiClient.setIsContinuousExportEnabled
+    .expectCallWith({ isContinuousExportEnabled: false })
+    .resolves();
+  apiMock.expectGetConfig({ isContinuousExportEnabled: false });
+
+  userEvent.click(
+    screen.getByRole('button', { name: 'Pause Continuous CVR Export' })
+  );
+  await screen.findByRole('button', { name: 'Resume Continuous CVR Export' });
+});
+
+test('when continuous export is paused, shows a button to resume continuous export', async () => {
+  apiMock.expectGetConfig({ isContinuousExportEnabled: false });
+  renderScreen();
+  await screen.findByRole('heading', { name: 'Election Manager Settings' });
+
+  userEvent.click(screen.getByRole('tab', { name: 'CVRs and Logs' }));
+
+  apiMock.mockApiClient.setIsContinuousExportEnabled
+    .expectCallWith({ isContinuousExportEnabled: true })
+    .resolves();
+  apiMock.expectGetConfig({ isContinuousExportEnabled: true });
+
+  userEvent.click(
+    screen.getByRole('button', { name: 'Resume Continuous CVR Export' })
+  );
+  await screen.findByRole('button', { name: 'Pause Continuous CVR Export' });
+});
+
 test('switching mode when no ballots have been counted', async () => {
   apiMock.expectGetConfig({ isTestMode: true });
   renderScreen({ scannerStatus: { ...statusNoPaper, ballotsCounted: 0 } });

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -29,6 +29,7 @@ import {
   getPrinterStatus,
   getUsbDriveStatus,
   logOut,
+  setIsContinuousExportEnabled,
   setIsSoundMuted,
   setIsDoubleFeedDetectionDisabled,
   setPrecinctSelection,
@@ -78,6 +79,8 @@ export function ElectionManagerScreen({
   const unconfigureMutation = unconfigureElection.useMutation();
   const ejectUsbDriveMutation = ejectUsbDrive.useMutation();
   const logOutMutation = logOut.useMutation();
+  const setIsContinuousExportEnabledMutation =
+    setIsContinuousExportEnabled.useMutation();
 
   const [isConfirmingSwitchToTestMode, setIsConfirmingSwitchToTestMode] =
     useState(false);
@@ -102,6 +105,7 @@ export function ElectionManagerScreen({
     isTestMode,
     isSoundMuted,
     isDoubleFeedDetectionDisabled,
+    isContinuousExportEnabled,
   } = configQuery.data;
   const { pollsState } = pollsInfoQuery.data;
   const printerStatus = printerStatusQuery.data;
@@ -193,6 +197,15 @@ export function ElectionManagerScreen({
   const dataExportButtons = (
     <React.Fragment>
       <Button onPress={() => setIsExportingResults(true)}>Save CVRs</Button>{' '}
+      <Button
+        onPress={() =>
+          setIsContinuousExportEnabledMutation.mutate({
+            isContinuousExportEnabled: !isContinuousExportEnabled,
+          })
+        }
+      >
+        {isContinuousExportEnabled ? 'Pause' : 'Resume'} Continuous CVR Export
+      </Button>{' '}
       <ExportLogsButton usbDriveStatus={usbDrive} />
     </React.Fragment>
   );

--- a/apps/scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/scan/frontend/test/helpers/mock_api_client.tsx
@@ -48,6 +48,7 @@ const defaultConfig: PrecinctScannerConfig = {
   isSoundMuted: false,
   isDoubleFeedDetectionDisabled: false,
   isTestMode: true,
+  isContinuousExportEnabled: true,
   electionDefinition: electionGeneralDefinition,
   electionPackageHash: 'test-election-package-hash',
   precinctSelection: ALL_PRECINCTS_SELECTION,
@@ -214,9 +215,11 @@ export function createApiMock() {
       mockApiClient.resetPollsToPaused.expectCallWith().resolves();
     },
 
-    expectExportCastVoteRecordsToUsbDrive(): void {
+    expectExportCastVoteRecordsToUsbDrive(input: {
+      mode: 'full_export' | 'recovery_export';
+    }): void {
       mockApiClient.exportCastVoteRecordsToUsbDrive
-        .expectCallWith()
+        .expectCallWith(input)
         .resolves(ok());
     },
 

--- a/libs/backend/src/cast_vote_records/export.test.ts
+++ b/libs/backend/src/cast_vote_records/export.test.ts
@@ -205,7 +205,6 @@ test.each<{
     ],
     expectedBallotImageField: undefined,
   },
-
   {
     description: 'accepted HMPB with write-in on precinct scanner',
     sheetGenerator: () =>
@@ -894,6 +893,18 @@ test.each<{
   },
   {
     description:
+      'ballots cast, nothing on USB drive, continuous export disabled',
+    setupFn: () => {
+      mockUsbDrive.insertUsbDrive({});
+      mockPrecinctScannerStore.setElectionDefinition(electionDefinition);
+      mockPrecinctScannerStore.setPollsState('polls_open');
+      mockPrecinctScannerStore.setBallotsCounted(1);
+      mockPrecinctScannerStore.setIsContinuousExportEnabled(false);
+    },
+    shouldUsbDriveRequireCastVoteRecordSync: false,
+  },
+  {
+    description:
       'ballots cast, previous export operation may have failed midway',
     setupFn: async () => {
       mockUsbDrive.insertUsbDrive({});
@@ -907,6 +918,23 @@ test.each<{
       );
     },
     shouldUsbDriveRequireCastVoteRecordSync: true,
+  },
+  {
+    description:
+      'ballots cast, previous export operation may have failed midway, continuous export disabled',
+    setupFn: async () => {
+      mockUsbDrive.insertUsbDrive({});
+      mockPrecinctScannerStore.setElectionDefinition(electionDefinition);
+      mockPrecinctScannerStore.setPollsState('polls_open');
+      mockPrecinctScannerStore.setBallotsCounted(1);
+      const usbDriveStatus = await mockUsbDrive.usbDrive.status();
+      assert(usbDriveStatus.status === 'mounted');
+      mockPrecinctScannerStore.addPendingContinuousExportOperation(
+        'abcd1234-0000-0000-0000-000000000000'
+      );
+      mockPrecinctScannerStore.setIsContinuousExportEnabled(false);
+    },
+    shouldUsbDriveRequireCastVoteRecordSync: false,
   },
   {
     description: 'ballots cast and exported to USB drive',
@@ -946,6 +974,28 @@ test.each<{
       mockUsbDrive.insertUsbDrive({});
     },
     shouldUsbDriveRequireCastVoteRecordSync: true,
+  },
+  {
+    description:
+      'ballots cast and exported to USB drive, but USB drive replaced, continuous export disabled',
+    setupFn: async () => {
+      mockUsbDrive.insertUsbDrive({});
+      mockPrecinctScannerStore.setElectionDefinition(electionDefinition);
+      mockPrecinctScannerStore.setPollsState('polls_open');
+      mockPrecinctScannerStore.setBallotsCounted(1);
+      (
+        await exportCastVoteRecordsToUsbDrive(
+          mockPrecinctScannerStore,
+          mockUsbDrive.usbDrive,
+          [newAcceptedSheet(interpretedHmpb)],
+          { scannerType: 'precinct' }
+        )
+      ).unsafeUnwrap();
+      mockUsbDrive.removeUsbDrive();
+      mockUsbDrive.insertUsbDrive({});
+      mockPrecinctScannerStore.setIsContinuousExportEnabled(false);
+    },
+    shouldUsbDriveRequireCastVoteRecordSync: false,
   },
   {
     description:
@@ -1244,4 +1294,164 @@ test('export and subsequent import of that export', async () => {
       castVoteRecordResult.isOk()
     )
   ).toEqual(true);
+});
+
+test('recovery export', async () => {
+  const sheet1 = newAcceptedSheet(interpretedHmpb, sheet1Id);
+  const sheet2 = newAcceptedSheet(interpretedHmpb, sheet2Id);
+  const sheet3 = newAcceptedSheet(interpretedHmpb, sheet3Id);
+  const sheet4 = newAcceptedSheet(interpretedHmpb, sheet4Id);
+
+  for (const sheet of [sheet1, sheet2, sheet3]) {
+    expect(
+      await exportCastVoteRecordsToUsbDrive(
+        mockPrecinctScannerStore,
+        mockUsbDrive.usbDrive,
+        [sheet],
+        { scannerType: 'precinct' }
+      )
+    ).toEqual(ok());
+  }
+
+  const exportDirectoryPaths = await getCastVoteRecordExportDirectoryPaths(
+    mockUsbDrive.usbDrive
+  );
+  expect(exportDirectoryPaths).toHaveLength(1);
+  const exportDirectoryPath = assertDefined(exportDirectoryPaths[0]);
+
+  // Simulate an interrupted export operation
+  fs.rmSync(
+    path.join(
+      exportDirectoryPath,
+      `${sheet3Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`
+    )
+  );
+
+  // Simulate an interrupted creation timestamp update
+  fs.cpSync(
+    path.join(exportDirectoryPath, sheet1Id),
+    path.join(exportDirectoryPath, `${sheet1Id}-temp`),
+    { recursive: true }
+  );
+
+  // Simulate an interrupted creation timestamp update
+  fs.cpSync(
+    path.join(exportDirectoryPath, sheet2Id),
+    path.join(exportDirectoryPath, `${sheet2Id}-temp`),
+    { recursive: true }
+  );
+  fs.renameSync(
+    path.join(exportDirectoryPath, `${sheet2Id}-temp`),
+    path.join(exportDirectoryPath, `${sheet2Id}-temp-complete`)
+  );
+
+  expect(
+    await exportCastVoteRecordsToUsbDrive(
+      mockPrecinctScannerStore,
+      mockUsbDrive.usbDrive,
+      [sheet3, sheet4],
+      { scannerType: 'precinct', isRecoveryExport: true }
+    )
+  ).toEqual(ok());
+
+  const exportDirectoryContents =
+    await summarizeDirectoryContents(exportDirectoryPath);
+  const expectedExportDirectoryContents = [
+    CastVoteRecordExportFileName.METADATA,
+    `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+    `${sheet1Id}/${sheet1Id}-front.jpg`,
+    `${sheet1Id}/${sheet1Id}-back.jpg`,
+    `${sheet1Id}/${sheet1Id}-front.layout.json`,
+    `${sheet1Id}/${sheet1Id}-back.layout.json`,
+    `${sheet2Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+    `${sheet2Id}/${sheet2Id}-front.jpg`,
+    `${sheet2Id}/${sheet2Id}-back.jpg`,
+    `${sheet2Id}/${sheet2Id}-front.layout.json`,
+    `${sheet2Id}/${sheet2Id}-back.layout.json`,
+    `${sheet3Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+    `${sheet3Id}/${sheet3Id}-front.jpg`,
+    `${sheet3Id}/${sheet3Id}-back.jpg`,
+    `${sheet3Id}/${sheet3Id}-front.layout.json`,
+    `${sheet3Id}/${sheet3Id}-back.layout.json`,
+    `${sheet4Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+    `${sheet4Id}/${sheet4Id}-front.jpg`,
+    `${sheet4Id}/${sheet4Id}-back.jpg`,
+    `${sheet4Id}/${sheet4Id}-front.layout.json`,
+    `${sheet4Id}/${sheet4Id}-back.layout.json`,
+  ].sort();
+  expect(exportDirectoryContents).toEqual(expectedExportDirectoryContents);
+});
+
+test('recovery export expectedly errors if USB drive has been swapped', async () => {
+  const sheet1 = newAcceptedSheet(interpretedHmpb, sheet1Id);
+  const sheet2 = newAcceptedSheet(interpretedHmpb, sheet2Id);
+
+  expect(
+    await exportCastVoteRecordsToUsbDrive(
+      mockPrecinctScannerStore,
+      mockUsbDrive.usbDrive,
+      [sheet1],
+      { scannerType: 'precinct' }
+    )
+  ).toEqual(ok());
+
+  // Swap USB drive
+  mockUsbDrive.removeUsbDrive();
+  mockUsbDrive.insertUsbDrive({});
+
+  expect(
+    await exportCastVoteRecordsToUsbDrive(
+      mockPrecinctScannerStore,
+      mockUsbDrive.usbDrive,
+      [sheet2],
+      { scannerType: 'precinct', isRecoveryExport: true }
+    )
+  ).toEqual(
+    err({
+      type: 'recovery-export-error',
+      subType: 'expected-export-directory-does-not-exist',
+    })
+  );
+});
+
+test('recovery export expectedly errors if hash check fails', async () => {
+  const sheet1 = newAcceptedSheet(interpretedHmpb, sheet1Id);
+  const sheet2 = newAcceptedSheet(interpretedHmpb, sheet2Id);
+
+  expect(
+    await exportCastVoteRecordsToUsbDrive(
+      mockPrecinctScannerStore,
+      mockUsbDrive.usbDrive,
+      [sheet1],
+      { scannerType: 'precinct' }
+    )
+  ).toEqual(ok());
+
+  const exportDirectoryPaths = await getCastVoteRecordExportDirectoryPaths(
+    mockUsbDrive.usbDrive
+  );
+  expect(exportDirectoryPaths).toHaveLength(1);
+  const exportDirectoryPath = assertDefined(exportDirectoryPaths[0]);
+
+  fs.appendFileSync(
+    path.join(
+      exportDirectoryPath,
+      `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`
+    ),
+    'CORRUPTED'
+  );
+
+  expect(
+    await exportCastVoteRecordsToUsbDrive(
+      mockPrecinctScannerStore,
+      mockUsbDrive.usbDrive,
+      [sheet2],
+      { scannerType: 'precinct', isRecoveryExport: true }
+    )
+  ).toEqual(
+    err({
+      type: 'recovery-export-error',
+      subType: 'hash-mismatch-after-recovery-export',
+    })
+  );
 });

--- a/libs/backend/src/cast_vote_records/export.ts
+++ b/libs/backend/src/cast_vote_records/export.ts
@@ -1,7 +1,9 @@
 import crypto from 'node:crypto';
+import { existsSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import {
+  computeCastVoteRecordRootHashFromScratch,
   computeSingleCastVoteRecordHash,
   HashableFile,
   prepareSignatureFile,
@@ -51,11 +53,14 @@ import {
   CvrImageDataInput,
 } from './build_cast_vote_record';
 import {
-  buildCastVoteRecordReportMetadata as baseBuildCastVoteRecordReportMetadata,
   buildBatchManifest,
+  buildCastVoteRecordReportMetadata as baseBuildCastVoteRecordReportMetadata,
 } from './build_report_metadata';
 import { CanonicalizedSheet, canonicalizeSheet } from './canonicalize';
-import { updateCreationTimestampOfDirectoryAndChildrenFiles } from './file_system_utils';
+import {
+  recoverAfterInterruptedCreationTimestampUpdate,
+  updateCreationTimestampOfDirectoryAndChildrenFiles,
+} from './file_system_utils';
 import { readCastVoteRecordExportMetadata } from './import';
 import { buildElectionOptionPositionMap } from './option_map';
 
@@ -101,6 +106,7 @@ export interface PrecinctScannerStore extends ScannerStoreBase {
   deletePendingContinuousExportOperation(sheetId: string): void;
   getBallotsCounted(): number;
   getExportDirectoryName(): string | undefined;
+  getIsContinuousExportEnabled(): boolean;
   getPendingContinuousExportOperations(): string[];
   getPollsState(): PollsState;
   setExportDirectoryName(exportDirectoryName: string): void;
@@ -142,6 +148,10 @@ interface PrecinctScannerOptions {
    * support full exports.)
    */
   isFullExport?: boolean;
+  /**
+   * An export performed to recover after an error, e.g., a sporadic USB disconnect
+   */
+  isRecoveryExport?: boolean;
 }
 
 /**
@@ -244,8 +254,9 @@ function shouldIncludeImagesInMinimalExport(
  * for getting the continuous export directory back to a good state after an unexpected failure.
  */
 async function getExportDirectoryPathRelativeToUsbMountPoint(
-  exportContext: ExportContext
-): Promise<string> {
+  exportContext: ExportContext,
+  options: { errIfDirectoryNeedsToBeCreated?: boolean }
+): Promise<Result<string, 'directory-needs-to-be-created'>> {
   const { exportOptions, scannerState, scannerStore, usbMountPoint } =
     exportContext;
   const { electionDefinition, inTestMode } = scannerState;
@@ -283,11 +294,19 @@ async function getExportDirectoryPathRelativeToUsbMountPoint(
     SCANNER_RESULTS_FOLDER,
     exportDirectoryName
   );
-  await fs.mkdir(
-    path.join(usbMountPoint, exportDirectoryPathRelativeToUsbMountPoint),
-    { recursive: true }
+  const exportDirectoryPath = path.join(
+    usbMountPoint,
+    exportDirectoryPathRelativeToUsbMountPoint
   );
-  return exportDirectoryPathRelativeToUsbMountPoint;
+
+  if (
+    options.errIfDirectoryNeedsToBeCreated &&
+    !existsSync(exportDirectoryPath)
+  ) {
+    return err('directory-needs-to-be-created');
+  }
+  await fs.mkdir(exportDirectoryPath, { recursive: true });
+  return ok(exportDirectoryPathRelativeToUsbMountPoint);
 }
 
 function buildCastVoteRecordReportMetadata(
@@ -706,11 +725,35 @@ export async function exportCastVoteRecordsToUsbDrive(
     scannerStore.clearCastVoteRecordHashes();
   }
 
-  const exportDirectoryPathRelativeToUsbMountPoint =
-    await getExportDirectoryPathRelativeToUsbMountPoint(exportContext);
+  const isRecoveryExport =
+    exportOptions.scannerType === 'precinct' && exportOptions.isRecoveryExport;
+
+  const exportDirectoryResult =
+    await getExportDirectoryPathRelativeToUsbMountPoint(exportContext, {
+      errIfDirectoryNeedsToBeCreated: isRecoveryExport,
+    });
+  if (exportDirectoryResult.isErr()) {
+    assert(
+      isRecoveryExport &&
+        exportDirectoryResult.err() === 'directory-needs-to-be-created'
+    );
+    return err({
+      type: 'recovery-export-error',
+      subType: 'expected-export-directory-does-not-exist',
+    });
+  }
+  const exportDirectoryPathRelativeToUsbMountPoint = exportDirectoryResult.ok();
+  const exportDirectoryPath = path.join(
+    usbMountPoint,
+    exportDirectoryPathRelativeToUsbMountPoint
+  );
 
   const isCreationTimestampShufflingNecessary =
     exportOptions.scannerType === 'precinct' && !exportOptions.isFullExport;
+
+  if (isRecoveryExport) {
+    await recoverAfterInterruptedCreationTimestampUpdate(exportDirectoryPath);
+  }
 
   const castVoteRecordHashes: { [castVoteRecordId: string]: string } = {};
   const sheetIds: string[] = [];
@@ -721,6 +764,14 @@ export async function exportCastVoteRecordsToUsbDrive(
         'Minimal exports should only include accepted sheets.'
     );
     sheetIds.push(sheet.id);
+
+    if (isRecoveryExport) {
+      // Clean up any remnants from past failed exports
+      await fs.rm(path.join(exportDirectoryPath, sheet.id), {
+        recursive: true,
+        force: true,
+      });
+    }
 
     // Randomly decide whether to shuffle creation timestamps before or after cast vote record
     // creation. If we always did one or the other, the last voter's cast vote record would be
@@ -789,6 +840,21 @@ export async function exportCastVoteRecordsToUsbDrive(
   const updatedCastVoteRecordRootHash =
     scannerStore.getCastVoteRecordRootHash();
 
+  // As a final safeguard after a recovery export, confirm that the Merkle tree hash of cast vote
+  // records on the USB drive matches that on the machine
+  if (isRecoveryExport) {
+    const recomputedUsbDriveCastVoteRecordRootHash =
+      await computeCastVoteRecordRootHashFromScratch(exportDirectoryPath);
+    if (
+      recomputedUsbDriveCastVoteRecordRootHash !== updatedCastVoteRecordRootHash
+    ) {
+      return err({
+        type: 'recovery-export-error',
+        subType: 'hash-mismatch-after-recovery-export',
+      });
+    }
+  }
+
   const exportMetadataFileResult = await exportMetadataFileToUsbDrive(
     exportContext,
     updatedCastVoteRecordRootHash,
@@ -812,7 +878,7 @@ export async function exportCastVoteRecordsToUsbDrive(
 
   if (scannerStore.scannerType === 'precinct') {
     assert(exportOptions.scannerType === 'precinct');
-    if (exportOptions.isFullExport) {
+    if (exportOptions.isFullExport || exportOptions.isRecoveryExport) {
       /**
        * Perform the scanner store update before clearing the cache for
        * {@link doesUsbDriveRequireCastVoteRecordSync} because
@@ -855,6 +921,10 @@ export async function doesUsbDriveRequireCastVoteRecordSync(
   }
 
   const value = await (async () => {
+    if (!scannerStore.getIsContinuousExportEnabled()) {
+      return false;
+    }
+
     if (usbDriveStatus.status !== 'mounted') {
       return false;
     }

--- a/libs/backend/test/utils.ts
+++ b/libs/backend/test/utils.ts
@@ -126,6 +126,7 @@ export class MockPrecinctScannerStore
 
   private ballotsCounted: number;
   private exportDirectoryName?: string;
+  private isContinuousExportEnabled: boolean;
   private pendingContinuousExportOperations: string[];
   private pollsState: PollsState;
 
@@ -133,6 +134,7 @@ export class MockPrecinctScannerStore
     super();
     this.ballotsCounted = 0;
     this.exportDirectoryName = undefined;
+    this.isContinuousExportEnabled = true;
     this.pendingContinuousExportOperations = [];
     this.pollsState = 'polls_closed_initial';
   }
@@ -154,6 +156,10 @@ export class MockPrecinctScannerStore
 
   getExportDirectoryName(): string | undefined {
     return this.exportDirectoryName;
+  }
+
+  getIsContinuousExportEnabled(): boolean {
+    return this.isContinuousExportEnabled;
   }
 
   getPendingContinuousExportOperations(): string[] {
@@ -178,6 +184,10 @@ export class MockPrecinctScannerStore
 
   setBallotsCounted(ballotsCounted: number): void {
     this.ballotsCounted = ballotsCounted;
+  }
+
+  setIsContinuousExportEnabled(isContinuousExportEnabled: boolean): void {
+    this.isContinuousExportEnabled = isContinuousExportEnabled;
   }
 
   setPollsState(pollsState: PollsState): void {

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -430,6 +430,10 @@ IDs are logged with each log to identify the log being written.
 **Type:** [application-status](#application-status)  
 **Description:** Double sheet detection toggled on or off as indicated.  
 **Machines:** vx-scan
+### continuous-export-toggled
+**Type:** [application-status](#application-status)  
+**Description:** Continuous export paused or resumed as indicated.  
+**Machines:** vx-scan
 ### mark-scan-state-machine-event
 **Type:** [system-status](#system-status)  
 **Description:** Event fired by the mark-scan state machine.  

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -585,6 +585,12 @@ eventType = "application-status"
 documentationMessage = "Double sheet detection toggled on or off as indicated."
 restrictInDocumentationToApps = ["vx-scan"]
 
+[ContinuousExportToggled]
+eventId = "continuous-export-toggled"
+eventType = "application-status"
+documentationMessage = "Continuous export paused or resumed as indicated."
+restrictInDocumentationToApps = ["vx-scan"]
+
 # VxMarkScan specific logs
 [MarkScanStateMachineEvent]
 eventId = "mark-scan-state-machine-event"

--- a/libs/logging/src/log_event_ids.ts
+++ b/libs/logging/src/log_event_ids.ts
@@ -116,6 +116,7 @@ export enum LogEventId {
   ScannerStateChanged = 'scanner-state-machine-transition',
   SoundToggled = 'sound-toggled',
   DoubleSheetDetectionToggled = 'double-sheet-toggled',
+  ContinuousExportToggled = 'continuous-export-toggled',
   MarkScanStateMachineEvent = 'mark-scan-state-machine-event',
   PatDeviceError = 'pat-device-error',
   PaperHandlerStateChanged = 'paper-handler-state-machine-transition',
@@ -905,6 +906,13 @@ const DoubleSheetDetectionToggled: LogDetails = {
   restrictInDocumentationToApps: [AppName.VxScan],
 };
 
+const ContinuousExportToggled: LogDetails = {
+  eventId: LogEventId.ContinuousExportToggled,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage: 'Continuous export paused or resumed as indicated.',
+  restrictInDocumentationToApps: [AppName.VxScan],
+};
+
 const MarkScanStateMachineEvent: LogDetails = {
   eventId: LogEventId.MarkScanStateMachineEvent,
   eventType: LogEventType.SystemStatus,
@@ -1293,6 +1301,8 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return SoundToggled;
     case LogEventId.DoubleSheetDetectionToggled:
       return DoubleSheetDetectionToggled;
+    case LogEventId.ContinuousExportToggled:
+      return ContinuousExportToggled;
     case LogEventId.MarkScanStateMachineEvent:
       return MarkScanStateMachineEvent;
     case LogEventId.PatDeviceError:

--- a/libs/logging/types-rust/src/log_event_enums.rs
+++ b/libs/logging/types-rust/src/log_event_enums.rs
@@ -217,6 +217,8 @@ pub enum EventId {
     SoundToggled,
     #[serde(rename = "double-sheet-toggled")]
     DoubleSheetDetectionToggled,
+    #[serde(rename = "continuous-export-toggled")]
+    ContinuousExportToggled,
     #[serde(rename = "mark-scan-state-machine-event")]
     MarkScanStateMachineEvent,
     #[serde(rename = "pat-device-error")]

--- a/libs/types/src/cast_vote_records.ts
+++ b/libs/types/src/cast_vote_records.ts
@@ -130,12 +130,20 @@ export type SheetValidationError = {
     }
 );
 
+type RecoveryExportError = {
+  type: 'recovery-export-error';
+} & (
+  | { subType: 'expected-export-directory-does-not-exist' }
+  | { subType: 'hash-mismatch-after-recovery-export' }
+);
+
 /**
  * An error encountered while exporting cast vote records to a USB drive
  */
 export type ExportCastVoteRecordsToUsbDriveError =
   | { type: ExportDataError }
-  | SheetValidationError;
+  | SheetValidationError
+  | RecoveryExportError;
 
 /**
  * An error encountered while reading a cast vote record export's metadata file

--- a/libs/ui/src/cast_vote_records.test.ts
+++ b/libs/ui/src/cast_vote_records.test.ts
@@ -88,6 +88,20 @@ test.each<{
     expectedMessage:
       'Encountered an invalid sheet with non-consecutive page numbers: front = 1, back = 3.',
   },
+  {
+    error: {
+      type: 'recovery-export-error',
+      subType: 'expected-export-directory-does-not-exist',
+    },
+    expectedMessage: 'Recovery export failed.',
+  },
+  {
+    error: {
+      type: 'recovery-export-error',
+      subType: 'hash-mismatch-after-recovery-export',
+    },
+    expectedMessage: 'Recovery export failed.',
+  },
 ])('userReadableMessageFromExportError', ({ error, expectedMessage }) => {
   expect(userReadableMessageFromExportError(error)).toEqual(expectedMessage);
 });

--- a/libs/ui/src/cast_vote_records.ts
+++ b/libs/ui/src/cast_vote_records.ts
@@ -64,6 +64,9 @@ export function userReadableMessageFromExportError(
         }
       })();
     }
+    case 'recovery-export-error': {
+      return 'Recovery export failed.';
+    }
     /* istanbul ignore next: Compile-time check for completeness */
     default: {
       throwIllegalValue(error, 'type');


### PR DESCRIPTION
## Overview

This PR cherry-picks/up-ports the relevant changes in https://github.com/votingworks/vxsuite/pull/5471 for v3.1.2 onto main for v4. It specifically up-ports:

- Smart/fast recovery syncs
- Allowing pausing continuous export
- Continuous export logging

See https://github.com/votingworks/vxsuite/pull/5471 for lots of additional context, screenshots, and logically grouped commits.

Sorry for the one commit in this PR 😅 - that was ultimately the best way to accomplish the cherry-pick and address merge conflicts. But thankfully you've already reviewed this exact code @nbhatia823 haha.

## Testing Plan

- [x] Tested thoroughly in the context of [v3.1.2 QA](https://docs.google.com/document/d/1AQ6EQNiIBm2G86capEsJajgBHf1eCHhk1Z5QbSdj4mY/edit?usp=sharing)
- [x] Up-ported the relevant automated tests
- [x] Double checked that all merge conflicts have been handled post-cherry-pick

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced
- [x] I have added a screenshot and/or video to this PR to demo the change ➡️ By cross-referencing the [original PR](https://github.com/votingworks/vxsuite/pull/5471)
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates