### PR TITLE
Kevin/bmd adjudication flags

### DIFF
--- a/apps/central-scan/backend/src/sheet_requires_adjudication.test.ts
+++ b/apps/central-scan/backend/src/sheet_requires_adjudication.test.ts
@@ -219,6 +219,12 @@ test('sheetRequiresAdjudication is happy with a BMD ballot', () => {
       isTestMode: true,
       ballotType: BallotType.Precinct,
     },
+    adjudicationInfo: {
+      requiresAdjudication: false,
+      ignoredReasonInfos: [],
+      enabledReasonInfos: [],
+      enabledReasons: [],
+    },
     votes: {},
   };
 

--- a/apps/central-scan/backend/src/validation.test.ts
+++ b/apps/central-scan/backend/src/validation.test.ts
@@ -22,6 +22,12 @@ const BmdPage: InterpretedBmdPage = {
     ballotHash: 'abc',
     isTestMode: false,
   },
+  adjudicationInfo: {
+    requiresAdjudication: false,
+    ignoredReasonInfos: [],
+    enabledReasonInfos: [],
+    enabledReasons: [],
+  },
   votes: {},
 };
 

--- a/apps/mark-scan/backend/src/app.diagnostics.test.ts
+++ b/apps/mark-scan/backend/src/app.diagnostics.test.ts
@@ -306,6 +306,12 @@ describe('paper handler diagnostic', () => {
             precinctId: electionDefinition.election.precincts[0].id,
             isTestMode: true,
           },
+          adjudicationInfo: {
+            requiresAdjudication: false,
+            ignoredReasonInfos: [],
+            enabledReasonInfos: [],
+            enabledReasons: [],
+          },
           votes: {},
         },
         normalizedImage: BLANK_PAGE_IMAGE_DATA,

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -129,6 +129,12 @@ const SUCCESSFUL_INTERPRETATION_MOCK: SheetOf<InterpretFileResult> = [
         precinctId: '21',
         isTestMode: true,
       },
+      adjudicationInfo: {
+        requiresAdjudication: false,
+        ignoredReasonInfos: [],
+        enabledReasonInfos: [],
+        enabledReasons: [],
+      },
       votes: {},
     },
     normalizedImage: BLANK_PAGE_IMAGE_DATA,

--- a/apps/mark-scan/frontend/test/helpers/interpretation.ts
+++ b/apps/mark-scan/frontend/test/helpers/interpretation.ts
@@ -37,6 +37,12 @@ export function getMockInterpretation(
       precinctId: electionDefinition.election.precincts[0].id,
       ballotType: BallotType.Precinct,
     },
+    adjudicationInfo: {
+      requiresAdjudication: false,
+      ignoredReasonInfos: [],
+      enabledReasonInfos: [],
+      enabledReasons: [],
+    },
     votes,
   };
 }

--- a/apps/scan/backend/src/interpret.test.ts
+++ b/apps/scan/backend/src/interpret.test.ts
@@ -129,35 +129,6 @@ test('respects adjudication reasons for a BMD ballot on the front side', async (
   }
 });
 
-test('respects adjudication reasons for a BMD ballot on the back side', async () => {
-  const result = await interpret(
-    'foo-sheet-id',
-    asSheet(ballotImages.undervoteBmdBallot.toReversed()),
-    {
-      electionDefinition: electionFamousNames2021Fixtures.electionDefinition,
-      precinctSelection: ALL_PRECINCTS_SELECTION,
-      ballotImagesPath,
-      testMode: true,
-      markThresholds: DEFAULT_MARK_THRESHOLDS,
-      adjudicationReasons: [AdjudicationReason.Undervote],
-    }
-  );
-  const interpretation = assertDefined(result.ok());
-  assert(interpretation.type === 'NeedsReviewSheet');
-
-  // if statement for type narrowing only
-  if (interpretation.type === 'NeedsReviewSheet') {
-    expect(interpretation.reasons).toEqual([
-      {
-        contestId: 'city-council',
-        expected: 4,
-        optionIds: ['marie-curie'],
-        type: 'Undervote',
-      },
-    ]);
-  }
-});
-
 test('treats either page being an invalid test mode as an invalid sheet', () => {
   const invalidTestModePageInterpretation: PageInterpretation = {
     type: 'InvalidTestModePage',

--- a/apps/scan/backend/src/interpret.ts
+++ b/apps/scan/backend/src/interpret.ts
@@ -6,6 +6,7 @@ import { ok, Result } from '@votingworks/basics';
 import {
   AdjudicationReason,
   AdjudicationReasonInfo,
+  InterpretedBmdPage,
   PageInterpretationWithFiles,
   SheetInterpretation,
   SheetInterpretationWithPages,
@@ -22,10 +23,21 @@ export function combinePageInterpretationsForSheet(
   const frontType = front.interpretation.type;
   const backType = back.interpretation.type;
 
+  // Exactly one side can be printed on a BMD ballot.
   if (
     (frontType === 'InterpretedBmdPage' && backType === 'BlankPage') ||
     (backType === 'InterpretedBmdPage' && frontType === 'BlankPage')
   ) {
+    const printedPage = frontType === 'InterpretedBmdPage' ? front : back;
+    const interpretation = printedPage.interpretation as InterpretedBmdPage;
+
+    if (interpretation.adjudicationInfo.requiresAdjudication) {
+      return {
+        type: 'NeedsReviewSheet',
+        reasons: [...interpretation.adjudicationInfo.enabledReasonInfos],
+      };
+    }
+
     return { type: 'ValidSheet' };
   }
 

--- a/apps/scan/backend/src/interpret.ts
+++ b/apps/scan/backend/src/interpret.ts
@@ -28,6 +28,7 @@ export function combinePageInterpretationsForSheet(
     (frontType === 'InterpretedBmdPage' && backType === 'BlankPage') ||
     (backType === 'InterpretedBmdPage' && frontType === 'BlankPage')
   ) {
+    /* istanbul ignore next */
     const printedPage = frontType === 'InterpretedBmdPage' ? front : back;
     const interpretation = printedPage.interpretation as InterpretedBmdPage;
 

--- a/apps/scan/backend/src/sheet_requires_adjudication.test.ts
+++ b/apps/scan/backend/src/sheet_requires_adjudication.test.ts
@@ -219,6 +219,12 @@ test('sheetRequiresAdjudication is happy with a BMD ballot', () => {
       isTestMode: true,
       ballotType: BallotType.Precinct,
     },
+    adjudicationInfo: {
+      requiresAdjudication: false,
+      ignoredReasonInfos: [],
+      enabledReasonInfos: [],
+      enabledReasons: [],
+    },
     votes: {},
   };
 

--- a/libs/backend/test/fixtures/interpretations.ts
+++ b/libs/backend/test/fixtures/interpretations.ts
@@ -181,6 +181,12 @@ export const interpretedBmdPage: InterpretedBmdPage = {
     [fishingContest.id]: [fishingContest.noOption.id],
     [fishCouncilContest.id]: fishCouncilContest.candidates.slice(0, 1),
   },
+  adjudicationInfo: {
+    requiresAdjudication: false,
+    ignoredReasonInfos: [],
+    enabledReasonInfos: [],
+    enabledReasons: [],
+  },
 };
 
 export const interpretedBmdPageWithWriteIn: InterpretedBmdPage = {
@@ -191,6 +197,12 @@ export const interpretedBmdPageWithWriteIn: InterpretedBmdPage = {
     [fishCouncilContest.id]: [
       { id: 'write-in-1', name: 'Write In #1', isWriteIn: true },
     ],
+  },
+  adjudicationInfo: {
+    requiresAdjudication: false,
+    ignoredReasonInfos: [],
+    enabledReasonInfos: [],
+    enabledReasons: [],
   },
 };
 

--- a/libs/ballot-interpreter/src/__snapshots__/interpret_bmd_ballots.test.ts.snap
+++ b/libs/ballot-interpreter/src/__snapshots__/interpret_bmd_ballots.test.ts.snap
@@ -3,6 +3,12 @@
 exports[`VX BMD interpretation extracts votes encoded in a QR code 1`] = `
 [
   {
+    "adjudicationInfo": {
+      "enabledReasonInfos": [],
+      "enabledReasons": [],
+      "ignoredReasonInfos": [],
+      "requiresAdjudication": false,
+    },
     "ballotId": undefined,
     "metadata": {
       "ballotHash": "8ff0a69bd970b489209d",
@@ -138,6 +144,12 @@ exports[`VX BMD interpretation extracts votes encoded in a QR code 1`] = `
 exports[`VX BMD interpretation interpretSimplexBmdBallot 1`] = `
 [
   {
+    "adjudicationInfo": {
+      "enabledReasonInfos": [],
+      "enabledReasons": [],
+      "ignoredReasonInfos": [],
+      "requiresAdjudication": false,
+    },
     "ballotId": undefined,
     "metadata": {
       "ballotHash": "8ff0a69bd970b489209d",
@@ -266,6 +278,403 @@ exports[`VX BMD interpretation interpretSimplexBmdBallot 1`] = `
   },
   {
     "type": "BlankPage",
+  },
+]
+`;
+
+exports[`adjudication reporting correctly reports blank ballot adjudication flag 1`] = `
+{
+  "enabledReasonInfos": [
+    {
+      "contestId": "president",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "senator",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "representative-district-6",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "governor",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "lieutenant-governor",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "secretary-of-state",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "state-senator-district-31",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "state-assembly-district-54",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "county-commissioners",
+      "expected": 4,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "county-registrar-of-wills",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "city-mayor",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "city-council",
+      "expected": 3,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "judicial-robert-demergue",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "judicial-elmer-hull",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "question-a",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "question-b",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "question-c",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "proposition-1",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "measure-101",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "102",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "type": "BlankBallot",
+    },
+  ],
+  "enabledReasons": [
+    "BlankBallot",
+    "Undervote",
+  ],
+  "ignoredReasonInfos": [],
+  "requiresAdjudication": true,
+}
+`;
+
+exports[`adjudication reporting ignores blank ballot adjudication flag when configured to do so 1`] = `
+{
+  "enabledReasonInfos": [
+    {
+      "contestId": "president",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "senator",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "representative-district-6",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "governor",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "lieutenant-governor",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "secretary-of-state",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "state-senator-district-31",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "state-assembly-district-54",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "county-commissioners",
+      "expected": 4,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "county-registrar-of-wills",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "city-mayor",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "city-council",
+      "expected": 3,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "judicial-robert-demergue",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "judicial-elmer-hull",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "question-a",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "question-b",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "question-c",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "proposition-1",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "measure-101",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+    {
+      "contestId": "102",
+      "expected": 1,
+      "optionIds": [],
+      "type": "Undervote",
+    },
+  ],
+  "enabledReasons": [
+    "Undervote",
+  ],
+  "ignoredReasonInfos": [
+    {
+      "type": "BlankBallot",
+    },
+  ],
+  "requiresAdjudication": true,
+}
+`;
+
+exports[`adjudication reporting ignores undervote adjudication flag when configured to do so 1`] = `
+[
+  {
+    "contestId": "president",
+    "expected": 1,
+    "optionIds": [],
+    "type": "Undervote",
+  },
+  {
+    "contestId": "senator",
+    "expected": 1,
+    "optionIds": [],
+    "type": "Undervote",
+  },
+  {
+    "contestId": "representative-district-6",
+    "expected": 1,
+    "optionIds": [],
+    "type": "Undervote",
+  },
+  {
+    "contestId": "governor",
+    "expected": 1,
+    "optionIds": [],
+    "type": "Undervote",
+  },
+  {
+    "contestId": "lieutenant-governor",
+    "expected": 1,
+    "optionIds": [],
+    "type": "Undervote",
+  },
+  {
+    "contestId": "secretary-of-state",
+    "expected": 1,
+    "optionIds": [],
+    "type": "Undervote",
+  },
+  {
+    "contestId": "state-senator-district-31",
+    "expected": 1,
+    "optionIds": [],
+    "type": "Undervote",
+  },
+  {
+    "contestId": "state-assembly-district-54",
+    "expected": 1,
+    "optionIds": [],
+    "type": "Undervote",
+  },
+  {
+    "contestId": "county-commissioners",
+    "expected": 4,
+    "optionIds": [],
+    "type": "Undervote",
+  },
+  {
+    "contestId": "county-registrar-of-wills",
+    "expected": 1,
+    "optionIds": [],
+    "type": "Undervote",
+  },
+  {
+    "contestId": "city-mayor",
+    "expected": 1,
+    "optionIds": [],
+    "type": "Undervote",
+  },
+  {
+    "contestId": "city-council",
+    "expected": 3,
+    "optionIds": [],
+    "type": "Undervote",
+  },
+  {
+    "contestId": "judicial-robert-demergue",
+    "expected": 1,
+    "optionIds": [],
+    "type": "Undervote",
+  },
+  {
+    "contestId": "judicial-elmer-hull",
+    "expected": 1,
+    "optionIds": [],
+    "type": "Undervote",
+  },
+  {
+    "contestId": "question-a",
+    "expected": 1,
+    "optionIds": [],
+    "type": "Undervote",
+  },
+  {
+    "contestId": "question-b",
+    "expected": 1,
+    "optionIds": [],
+    "type": "Undervote",
+  },
+  {
+    "contestId": "question-c",
+    "expected": 1,
+    "optionIds": [],
+    "type": "Undervote",
+  },
+  {
+    "contestId": "proposition-1",
+    "expected": 1,
+    "optionIds": [],
+    "type": "Undervote",
+  },
+  {
+    "contestId": "measure-101",
+    "expected": 1,
+    "optionIds": [],
+    "type": "Undervote",
+  },
+  {
+    "contestId": "102",
+    "expected": 1,
+    "optionIds": [],
+    "type": "Undervote",
   },
 ]
 `;

--- a/libs/ballot-interpreter/src/adjudication_reasons.ts
+++ b/libs/ballot-interpreter/src/adjudication_reasons.ts
@@ -79,11 +79,16 @@ export function getAllPossibleAdjudicationReasonsForBmdVotes(
           break;
         case 'yesno':
           for (const option of actualVotes as YesNoVote) {
+            // Should never be executed because a yes/no contest should have at
+            // most 1 vote so an undervote would be 0 votes. But the type
+            // doesn't enforce this, so we should handle the case where the
+            // contest has > 1 vote.
+            /* istanbul ignore next */
             optionIds.push(option);
           }
           break;
+        /* istanbul ignore next */
         default:
-          /* istanbul ignore next */
           throwIllegalValue(contestType);
       }
 

--- a/libs/ballot-interpreter/src/adjudication_reasons.ts
+++ b/libs/ballot-interpreter/src/adjudication_reasons.ts
@@ -9,7 +9,6 @@ import {
   MarkStatus,
   VotesDict,
   WriteInAreaStatus,
-  YesNoVote,
 } from '@votingworks/types';
 import { assertDefined, throwIllegalValue } from '@votingworks/basics';
 import { allContestOptions } from '@votingworks/utils';
@@ -68,6 +67,7 @@ export function getAllPossibleAdjudicationReasonsForBmdVotes(
       isBlankBallot = false;
     }
 
+    // Check for undervotes
     if (actualVoteCount < expectedSelectionCount) {
       const optionIds: string[] = [];
       const contestType = contest.type;
@@ -78,14 +78,11 @@ export function getAllPossibleAdjudicationReasonsForBmdVotes(
           }
           break;
         case 'yesno':
-          for (const option of actualVotes as YesNoVote) {
-            // Should never be executed because a yes/no contest should have at
-            // most 1 vote so an undervote would be 0 votes. But the type
-            // doesn't enforce this, so we should handle the case where the
-            // contest has > 1 vote.
-            /* istanbul ignore next */
-            optionIds.push(option);
-          }
+          // There will never be any optionIds to populate for an undervoted
+          // yes/no contest.
+          // That's because a yes/no contest may have at most 1 vote.
+          // At this point in the code we know there is an undervote,
+          // so there must be 0 votes.
           break;
         /* istanbul ignore next */
         default:

--- a/libs/ballot-interpreter/src/interpret_bmd_ballots.test.ts
+++ b/libs/ballot-interpreter/src/interpret_bmd_ballots.test.ts
@@ -258,7 +258,7 @@ describe('adjudication reporting', () => {
     assert(result[0].interpretation.type === 'InterpretedBmdPage');
     const frontInterpretation = result[0].interpretation as InterpretedBmdPage;
 
-    // Use snapshot testing because ignoredRerasonInfos for undervotes
+    // Use snapshot testing because ignoredReasonInfos for undervotes
     // on all contests is very verbose
     expect(
       frontInterpretation.adjudicationInfo.ignoredReasonInfos

--- a/libs/ballot-interpreter/src/validation.test.ts
+++ b/libs/ballot-interpreter/src/validation.test.ts
@@ -26,6 +26,12 @@ function createMockInterpretation(spec: {
       isTestMode: spec.isTestModeBallot,
     },
     votes: {},
+    adjudicationInfo: {
+      requiresAdjudication: false,
+      enabledReasons: [],
+      enabledReasonInfos: [],
+      ignoredReasonInfos: [],
+    },
   };
 }
 

--- a/libs/bmd-ballot-fixtures/src/bmd_ballot_fixtures.tsx
+++ b/libs/bmd-ballot-fixtures/src/bmd_ballot_fixtures.tsx
@@ -10,7 +10,10 @@ import {
 } from '@votingworks/types';
 import { BmdPaperBallot, BmdPaperBallotProps } from '@votingworks/ui';
 import { Buffer } from 'node:buffer';
-import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import {
+  electionFamousNames2021Fixtures,
+  electionGeneralDefinition,
+} from '@votingworks/fixtures';
 import { assertDefined, iter } from '@votingworks/basics';
 import { pdfToImages, writeImageData } from '@votingworks/image-utils';
 
@@ -90,5 +93,41 @@ export const DEFAULT_FAMOUS_NAMES_VOTES = vote(
       'mona-lisa',
       'jackie-chan',
     ],
+  }
+);
+
+export const DEFAULT_ELECTION_GENERAL_BALLOT_STYLE_ID =
+  electionGeneralDefinition.election.ballotStyles[0].id;
+export const DEFAULT_ELECTION_GENERAL_PRECINCT_ID: PrecinctId =
+  electionGeneralDefinition.election.precincts[0].id;
+
+export const DEFAULT_ELECTION_GENERAL_VOTES = vote(
+  electionGeneralDefinition.election.contests,
+  {
+    president: ['barchi-hallaren'],
+    senator: ['weiford'],
+    'representative-district-6': ['plunkard'],
+    governor: ['franz'],
+    'lieutenant-governor': ['norberg'],
+    'secretary-of-state': ['shamsi'],
+    'state-senator-district-31': ['shiplett'],
+    'state-assembly-district-54': ['solis'],
+    'county-commissioners': [
+      'argent',
+      'witherspoonsmithson',
+      'bainbridge',
+      'hennessey',
+    ],
+    'county-registrar-of-wills': ['ramachandrani'],
+    'city-mayor': ['white'],
+    'city-council': ['eagle', 'rupp', 'shry'],
+    'judicial-robert-demergue': ['judicial-robert-demergue-option-yes'],
+    'judicial-elmer-hull': ['judicial-elmer-hull-option-yes'],
+    'question-a': ['question-a-option-yes'],
+    'question-b': ['question-b-option-yes'],
+    'question-c': ['question-c-option-yes'],
+    'proposition-1': ['proposition-1-option-yes'],
+    'measure-101': ['measure-101-option-yes'],
+    '102': ['measure-102-option-yes'],
   }
 );

--- a/libs/types/src/interpretation.ts
+++ b/libs/types/src/interpretation.ts
@@ -40,6 +40,7 @@ export interface InterpretedBmdPage {
   ballotId?: BallotId;
   metadata: BallotMetadata;
   votes: VotesDict;
+  adjudicationInfo: AdjudicationInfo;
 }
 export const InterpretedBmdPageSchema: z.ZodSchema<InterpretedBmdPage> =
   z.object({
@@ -47,6 +48,7 @@ export const InterpretedBmdPageSchema: z.ZodSchema<InterpretedBmdPage> =
     ballotId: BallotIdSchema.optional(),
     metadata: BallotMetadataSchema,
     votes: VotesDictSchema,
+    adjudicationInfo: AdjudicationInfoSchema,
   });
 
 export interface UnmarkedWriteIn {


### PR DESCRIPTION
## Overview

* Evaluates `Undervote` and `BlankBallot` adjudication reasons for BMD ballots and reports them on `AdjudicationReasonInfo`
* Handles `AdjudicationReasonInfos` in `scan/backend` for BMD ballots so the frontend can call for user action

## Demo Video or Screenshot

Currently no hardware setup for me to demo this

## Testing Plan

Added tests at library and app level

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
