### PR TITLE
VxAdmin: Polish manual tally entry flow

### DIFF
--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -462,6 +462,20 @@ export interface ManualResultsMetadataRecord extends ManualResultsIdentifier {
 }
 
 /**
+ * Validation error types for manual results.
+ * invalid - some contest has tallies that don't match the number of ballots
+ * incomplete - some contest is missing tallies
+ */
+export type ManualResultsValidationError = 'invalid' | 'incomplete';
+
+/**
+ * Manual results metadata with optional validation error.
+ */
+export interface ManualResultsMetadata extends ManualResultsMetadataRecord {
+  validationError?: 'invalid' | 'incomplete';
+}
+
+/**
  * Subset of cast vote record filters that we can filter on for manual results.
  */
 export type ManualResultsFilter = Omit<

--- a/apps/admin/frontend/jest.config.js
+++ b/apps/admin/frontend/jest.config.js
@@ -15,7 +15,7 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: -88,
+      branches: -87,
       lines: -64,
     },
   },

--- a/apps/admin/frontend/src/components/app_routes.tsx
+++ b/apps/admin/frontend/src/components/app_routes.tsx
@@ -24,7 +24,7 @@ import { ElectionScreen } from '../screens/election_screen';
 import { UnconfiguredScreen } from '../screens/unconfigured_screen';
 import { TallyScreen } from '../screens/tally/tally_screen';
 import { TallyWriteInReportScreen } from '../screens/reporting/write_in_adjudication_report_screen';
-import { ManualDataEntryScreen } from '../screens/tally/manual_tallies_form_screen';
+import { ManualTalliesFormScreen } from '../screens/tally/manual_tallies_form_screen';
 import { SmartCardsScreen } from '../screens/smart_cards_screen';
 import { MachineLockedScreen } from '../screens/machine_locked_screen';
 import { WriteInsSummaryScreen } from '../screens/write_ins_summary_screen';
@@ -150,14 +150,13 @@ export function AppRoutes(): JSX.Element | null {
         </Route>
       )}
       <Route
-        exact
-        path={routerPaths.manualDataEntry({
+        path={routerPaths.tallyManualForm({
           precinctId: ':precinctId',
           ballotStyleGroupId: ':ballotStyleGroupId' as BallotStyleGroupId,
           votingMethod: ':votingMethod' as ManualResultsVotingMethod,
         })}
       >
-        <ManualDataEntryScreen />
+        <ManualTalliesFormScreen />
       </Route>
       <Route path={routerPaths.tally}>
         <TallyScreen />

--- a/apps/admin/frontend/src/config/types.ts
+++ b/apps/admin/frontend/src/config/types.ts
@@ -14,16 +14,16 @@ export type TextareaEventFunction = (
   event: React.FormEvent<HTMLTextAreaElement>
 ) => PromiseOr<void>;
 
-// Router Props
-export interface ManualDataEntryScreenProps {
+// Router Params
+export interface ManualTallyFormParams {
   precinctId: PrecinctId;
   ballotStyleGroupId: BallotStyleGroupId;
   votingMethod: ManualResultsVotingMethod;
 }
-export interface SmartcardsScreenProps {
-  smartcardType: string;
+export interface ManualTallyFormContestParams extends ManualTallyFormParams {
+  contestId: ContestId;
 }
-export interface WriteInsAdjudicationScreenProps {
+export interface WriteInsAdjudicationScreenParams {
   contestId: ContestId;
 }
 

--- a/apps/admin/frontend/src/router_paths.ts
+++ b/apps/admin/frontend/src/router_paths.ts
@@ -1,6 +1,7 @@
 import {
-  ManualDataEntryScreenProps,
-  WriteInsAdjudicationScreenProps,
+  ManualTallyFormContestParams,
+  ManualTallyFormParams,
+  WriteInsAdjudicationScreenParams,
 } from './config/types';
 
 export const routerPaths = {
@@ -11,12 +12,19 @@ export const routerPaths = {
   tally: '/tally',
   tallyCvrs: '/tally/cvrs',
   tallyManual: '/tally/manual',
-  manualDataEntry: ({
+  tallyManualForm: ({
     precinctId,
     ballotStyleGroupId,
     votingMethod,
-  }: ManualDataEntryScreenProps): string =>
-    `/tally/manual-data-entry/${ballotStyleGroupId}/${votingMethod}/${precinctId}`,
+  }: ManualTallyFormParams): string =>
+    `/tally/manual/${ballotStyleGroupId}/${votingMethod}/${precinctId}`,
+  tallyManualFormContest: ({
+    precinctId,
+    ballotStyleGroupId,
+    votingMethod,
+    contestId,
+  }: ManualTallyFormContestParams): string =>
+    `/tally/manual/${ballotStyleGroupId}/${votingMethod}/${precinctId}/${contestId}`,
   reports: '/reports',
   tallyFullReport: '/reports/tally/full',
   tallySinglePrecinctReport: `/reports/tally/precinct`,
@@ -29,7 +37,7 @@ export const routerPaths = {
   writeIns: '/write-ins',
   writeInsAdjudication: ({
     contestId,
-  }: WriteInsAdjudicationScreenProps): string =>
+  }: WriteInsAdjudicationScreenParams): string =>
     `/write-ins/adjudication/${contestId}`,
   settings: '/settings',
   hardwareDiagnostics: '/hardware-diagnostics',

--- a/apps/admin/frontend/src/screens/tally/cast_vote_records_tab.tsx
+++ b/apps/admin/frontend/src/screens/tally/cast_vote_records_tab.tsx
@@ -6,7 +6,6 @@ import {
   Button,
   Table,
   TD,
-  Loading,
   Card,
   TabPanel,
   Font,
@@ -31,7 +30,7 @@ const Actions = styled.div`
   margin-bottom: 0.5rem;
 `;
 
-export function CastVoteRecordsTab(): JSX.Element {
+export function CastVoteRecordsTab(): JSX.Element | null {
   const { electionDefinition, isOfficialResults } = useContext(AppContext);
   const { election } = assertDefined(electionDefinition);
 
@@ -52,7 +51,7 @@ export function CastVoteRecordsTab(): JSX.Element {
     !castVoteRecordFilesQuery.isSuccess ||
     !castVoteRecordFileModeQuery.isSuccess
   ) {
-    return <Loading />;
+    return null;
   }
 
   const fileMode = castVoteRecordFileModeQuery.data;

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.test.tsx
@@ -13,7 +13,7 @@ import { hasTextAcrossElements } from '@votingworks/test-utils';
 import { createMemoryHistory } from 'history';
 import { screen, waitFor, within } from '../../../test/react_testing_library';
 import { renderInAppContext } from '../../../test/render_in_app_context';
-import { ManualDataEntryScreen, TITLE } from './manual_tallies_form_screen';
+import { ManualTalliesFormScreen, TITLE } from './manual_tallies_form_screen';
 import { ApiMock, createApiMock } from '../../../test/helpers/mock_api_client';
 
 let apiMock: ApiMock;
@@ -92,7 +92,7 @@ test('displays correct contests for ballot style', async () => {
   });
   renderInAppContext(
     <Route path="/tally/manual-data-entry/:ballotStyleGroupId/:votingMethod/:precinctId">
-      <ManualDataEntryScreen />
+      <ManualTalliesFormScreen />
     </Route>,
     {
       route: '/tally/manual-data-entry/1M/absentee/precinct-1',
@@ -134,7 +134,7 @@ test('can edit counts, receive validation messages, and save', async () => {
   });
   renderInAppContext(
     <Route path="/tally/manual-data-entry/:ballotStyleGroupId/:votingMethod/:precinctId">
-      <ManualDataEntryScreen />
+      <ManualTalliesFormScreen />
     </Route>,
     {
       route: '/tally/manual-data-entry/1M/absentee/precinct-1',
@@ -252,7 +252,7 @@ test('loads pre-existing manual data to edit', async () => {
   );
   renderInAppContext(
     <Route path="/tally/manual-data-entry/:ballotStyleGroupId/:votingMethod/:precinctId">
-      <ManualDataEntryScreen />
+      <ManualTalliesFormScreen />
     </Route>,
     {
       route: '/tally/manual-data-entry/1M/absentee/precinct-1',
@@ -303,7 +303,7 @@ test('adding new write-in candidates', async () => {
   });
   renderInAppContext(
     <Route path="/tally/manual-data-entry/:ballotStyleGroupId/:votingMethod/:precinctId">
-      <ManualDataEntryScreen />
+      <ManualTalliesFormScreen />
     </Route>,
     {
       electionDefinition,
@@ -487,7 +487,7 @@ test('loads existing write-in candidates', async () => {
   );
   renderInAppContext(
     <Route path="/tally/manual-data-entry/:ballotStyleGroupId/:votingMethod/:precinctId">
-      <ManualDataEntryScreen />
+      <ManualTalliesFormScreen />
     </Route>,
     {
       route: '/tally/manual-data-entry/1M/precinct/precinct-1',

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.test.tsx
@@ -375,6 +375,7 @@ test('adding new write-in candidates', async () => {
   userEvent.click(screen.getButton('Add Write-In Candidate'));
   userEvent.type(screen.getByLabelText('Write-in'), 'Mock Candidate');
   userEvent.click(screen.getButton('Add'));
+  screen.getByText('Incomplete tallies');
 
   // Can add to new write-in candidate's count
   userEvent.type(screen.getByLabelText('Mock Candidate (write-in)'), '30');

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
@@ -1,7 +1,6 @@
 import {
   assert,
   assertDefined,
-  iter,
   mapObject,
   throwIllegalValue,
 } from '@votingworks/basics';
@@ -42,6 +41,7 @@ import {
   format,
   getContestById,
   getBallotStyleGroup,
+  areContestResultsValid,
 } from '@votingworks/utils';
 
 import type {
@@ -326,26 +326,10 @@ function validateTallies(
     return 'incomplete';
   }
   const contestResults = formContestResults as Tabulation.ContestResults;
-
-  const ballotMultiplier = // number of votes expected per ballot
-    formContestResults.contestType === 'yesno'
-      ? 1
-      : formContestResults.votesAllowed;
-
-  const expectedVotes = contestResults.ballots * ballotMultiplier;
-
-  const enteredVotes =
-    contestResults.overvotes +
-    contestResults.undervotes +
-    (contestResults.contestType === 'yesno'
-      ? contestResults.yesTally + contestResults.noTally
-      : iter(Object.values(contestResults.tallies))
-          .map(({ tally }) => tally)
-          .sum());
-
-  if (enteredVotes !== expectedVotes) {
+  if (!areContestResultsValid(contestResults)) {
     return 'invalid';
   }
+  return undefined;
 }
 
 function convertTabulationResultsToFormResults(

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
@@ -887,7 +887,7 @@ function ContestForm({
             )}
             {contest.type === 'candidate' && contest.allowWriteIns && (
               <AddWriteInRow
-                addWriteInCandidate={(name) => addFormWriteInCandidate(name)}
+                addWriteInCandidate={addFormWriteInCandidate}
                 disallowedCandidateNames={disallowedNewWriteInCandidateNames}
               />
             )}

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
@@ -186,6 +186,7 @@ function AddWriteInRow({
           autoFocus
           defaultValue=""
           data-testid="write-in-input"
+          aria-label="Write-in"
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
             setWriteInName(e.target.value)
           }
@@ -300,6 +301,7 @@ function emptyFormContestResults(
         ),
       };
 
+    /* istanbul ignore next */
     default:
       throwIllegalValue(contest);
   }
@@ -517,7 +519,7 @@ function ContestForm({
   savedManualResults,
 }: {
   savedWriteInCandidates: WriteInCandidateRecord[];
-  savedManualResults: ManualResultsRecord | null;
+  savedManualResults: ManualResultsRecord;
 }): JSX.Element {
   const { precinctId, ballotStyleGroupId, votingMethod, contestId } =
     useParams<ManualTallyFormContestParams>();
@@ -544,7 +546,7 @@ function ContestForm({
 
   const initialManualResults = convertTabulationResultsToFormResults(
     contests,
-    savedManualResults?.manualResults
+    savedManualResults.manualResults
   );
   const [formManualResults, setFormManualResults] =
     useState<FormManualResults>(initialManualResults);
@@ -707,7 +709,7 @@ function ContestForm({
     // remove form candidate from contest
     const contestResults = formManualResults.contestResults[contestId];
     assert(contestResults.contestType === 'candidate');
-    delete contestResults?.tallies[id];
+    delete contestResults.tallies[id];
 
     updateManualResultsWithNewContestResults(contestResults);
   }
@@ -876,7 +878,7 @@ function ContestForm({
                 <React.Fragment>
                   <ContestDataRow data-testid={`${contest.yesOption.id}`}>
                     <TallyInput
-                      name="yes"
+                      id="yes"
                       data-testid={`${contest.yesOption.id}-input`}
                       value={getValueForInput('yesTally')}
                       onChange={(e) => updateContestData('yesTally', e)}
@@ -957,6 +959,7 @@ function ContestForm({
                         valid
                       </P>
                     );
+                  /* istanbul ignore next */
                   default:
                     throwIllegalValue(validationError);
                 }
@@ -1019,7 +1022,7 @@ function ContestFormWrapper({
   return (
     <ContestForm
       savedWriteInCandidates={savedWriteInCandidates}
-      savedManualResults={savedManualResults}
+      savedManualResults={assertDefined(savedManualResults)}
       key={contestId}
     />
   );

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
@@ -691,14 +691,26 @@ function ContestForm({
   }
 
   function addFormWriteInCandidate(name: string): void {
-    setFormWriteInCandidates([
-      ...formWriteInCandidates,
-      {
-        id: `${AdminTypes.TEMPORARY_WRITE_IN_ID_PREFIX}(${name})`,
-        name,
-        contestId,
+    const writeInCandidate: FormWriteInCandidate = {
+      id: `${AdminTypes.TEMPORARY_WRITE_IN_ID_PREFIX}(${name})`,
+      name,
+      contestId,
+    };
+    setFormWriteInCandidates([...formWriteInCandidates, writeInCandidate]);
+    const contestResults = formManualResults.contestResults[contestId];
+    assert(contestResults.contestType === 'candidate');
+    updateManualResultsWithNewContestResults({
+      ...contestResults,
+      tallies: {
+        ...contestResults.tallies,
+        [writeInCandidate.id]: {
+          id: writeInCandidate.id,
+          name: writeInCandidate.name,
+          isWriteIn: true,
+          tally: '',
+        },
       },
-    ]);
+    });
   }
 
   function removeFormWriteInCandidate(id: string): void {

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
@@ -293,7 +293,6 @@ interface FormManualResults {
 interface FormWriteInCandidate {
   readonly id: string;
   readonly name: string;
-  readonly contestId: string;
 }
 
 function emptyFormContestResults(
@@ -694,7 +693,6 @@ function ContestForm({
     const writeInCandidate: FormWriteInCandidate = {
       id: `${AdminTypes.TEMPORARY_WRITE_IN_ID_PREFIX}(${name})`,
       name,
-      contestId,
     };
     setFormWriteInCandidates([...formWriteInCandidates, writeInCandidate]);
     const contestResults = formManualResults.contestResults[contestId];
@@ -732,15 +730,12 @@ function ContestForm({
   const contestWriteInCandidates = savedWriteInCandidates.filter(
     (candidate) => candidate.contestId === contestId
   );
-  const contestFormWriteInCandidates = formWriteInCandidates.filter(
-    (candidate) => candidate.contestId === contestId
-  );
   const disallowedNewWriteInCandidateNames =
     contest.type === 'candidate'
       ? [
           ...contest.candidates,
           ...contestWriteInCandidates,
-          ...contestFormWriteInCandidates,
+          ...formWriteInCandidates,
         ].map(({ name }) => normalizeWriteInName(name))
       : [];
 
@@ -851,7 +846,7 @@ function ContestForm({
                     </label>
                   </ContestDataRow>
                 ))}
-                {contestFormWriteInCandidates.map((candidate) => (
+                {formWriteInCandidates.map((candidate) => (
                   <ContestDataRow key={candidate.id} data-testid={candidate.id}>
                     <TallyInput
                       autoFocus

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
@@ -15,9 +15,9 @@ import {
   CandidateId,
   Admin as AdminTypes,
   AnyContest,
-  Election,
   getPrecinctById,
   BallotStyleGroupId,
+  Contests,
 } from '@votingworks/types';
 import {
   Button,
@@ -333,11 +333,11 @@ function validateTallies(
 }
 
 function convertTabulationResultsToFormResults(
-  election: Election,
+  contests: Contests,
   savedResults?: Tabulation.ManualElectionResults
 ): FormManualResults {
   const contestResults = Object.fromEntries(
-    election.contests.map((contest) => [
+    contests.map((contest) => [
       contest.id,
       savedResults?.contestResults[contest.id] ??
         emptyFormContestResults(contest, savedResults?.ballotCount),
@@ -393,7 +393,7 @@ function BallotCountForm({
   const contests = getContests({ election, ballotStyle: ballotStyleGroup });
 
   const initialManualResults = convertTabulationResultsToFormResults(
-    election,
+    contests,
     savedManualResults?.manualResults
   );
   const [ballotCount, setBallotCount] = useState<number | EmptyValue>(
@@ -543,7 +543,7 @@ function ContestForm({
   const setManualTallyMutation = setManualResults.useMutation();
 
   const initialManualResults = convertTabulationResultsToFormResults(
-    election,
+    contests,
     savedManualResults?.manualResults
   );
   const [formManualResults, setFormManualResults] =

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
@@ -584,104 +584,6 @@ function ManualResultsDataEntryScreenForm({
 
   return (
     <TaskScreen>
-      <TaskControls style={{ width: '24rem' }}>
-        <TaskHeader>
-          <H1>{TITLE}</H1>
-          <LinkButton
-            icon="X"
-            color="inverseNeutral"
-            fill="transparent"
-            to={routerPaths.tallyManual}
-            tabIndex={-1}
-          >
-            Close
-          </LinkButton>
-        </TaskHeader>
-        <ControlsContent>
-          <TallyMetadata>
-            <LabelledText label="Ballot Style">
-              {ballotStyleGroupId}
-            </LabelledText>
-            <LabelledText label="Precinct">{precinct.name}</LabelledText>
-            <LabelledText label="Voting Method">
-              {votingMethodTitle}
-            </LabelledText>
-          </TallyMetadata>
-          <div>
-            <ValidationMessage>
-              {(() => {
-                switch (validationError) {
-                  case 'empty':
-                    return (
-                      <P>
-                        <Icons.Info /> No tallies entered
-                      </P>
-                    );
-                  case 'incomplete':
-                    return (
-                      <P>
-                        <Icons.Warning color="warning" /> Incomplete tallies
-                      </P>
-                    );
-                  case 'invalid':
-                    return (
-                      <P>
-                        <Icons.Warning color="warning" /> Entered tallies do not
-                        match total ballots cast
-                      </P>
-                    );
-                  case undefined:
-                    return (
-                      <P>
-                        <Icons.Checkbox color="success" /> Entered tallies are
-                        valid
-                      </P>
-                    );
-                  default:
-                    throwIllegalValue(validationError);
-                }
-              })()}
-            </ValidationMessage>
-            <Actions>
-              {previousContest ? (
-                <Button
-                  icon="Previous"
-                  onPress={() => {
-                    history.push(
-                      routerPaths.tallyManualFormContest({
-                        precinctId,
-                        ballotStyleGroupId,
-                        votingMethod,
-                        contestId: previousContest.id,
-                      })
-                    );
-                    firstInputRef.current?.focus();
-                  }}
-                >
-                  Previous
-                </Button>
-              ) : (
-                <LinkButton to={routerPaths.tallyManual}>Cancel</LinkButton>
-              )}
-              <Caption weight="semiBold" style={{ whiteSpace: 'nowrap' }}>
-                {format.count(contestIndex + 1)} of{' '}
-                {format.count(contests.length)}
-              </Caption>
-              <Button
-                variant="primary"
-                icon="Done"
-                onPress={saveResults}
-                disabled={
-                  validationError === 'incomplete' ||
-                  setManualTallyMutation.isLoading
-                }
-              >
-                {nextContest ? 'Next' : 'Finish'}
-              </Button>
-            </Actions>
-          </div>
-        </ControlsContent>
-      </TaskControls>
       <TaskContent>
         <ContestsContainer>
           <ContestData>
@@ -813,6 +715,104 @@ function ManualResultsDataEntryScreenForm({
           </ContestData>
         </ContestsContainer>
       </TaskContent>
+      <TaskControls style={{ width: '24rem' }}>
+        <TaskHeader>
+          <H1>{TITLE}</H1>
+          <LinkButton
+            icon="X"
+            color="inverseNeutral"
+            fill="transparent"
+            to={routerPaths.tallyManual}
+            tabIndex={-1}
+          >
+            Close
+          </LinkButton>
+        </TaskHeader>
+        <ControlsContent>
+          <TallyMetadata>
+            <LabelledText label="Ballot Style">
+              {ballotStyleGroupId}
+            </LabelledText>
+            <LabelledText label="Precinct">{precinct.name}</LabelledText>
+            <LabelledText label="Voting Method">
+              {votingMethodTitle}
+            </LabelledText>
+          </TallyMetadata>
+          <div>
+            <ValidationMessage>
+              {(() => {
+                switch (validationError) {
+                  case 'empty':
+                    return (
+                      <P>
+                        <Icons.Info /> No tallies entered
+                      </P>
+                    );
+                  case 'incomplete':
+                    return (
+                      <P>
+                        <Icons.Warning color="warning" /> Incomplete tallies
+                      </P>
+                    );
+                  case 'invalid':
+                    return (
+                      <P>
+                        <Icons.Warning color="warning" /> Entered tallies do not
+                        match total ballots cast
+                      </P>
+                    );
+                  case undefined:
+                    return (
+                      <P>
+                        <Icons.Checkbox color="success" /> Entered tallies are
+                        valid
+                      </P>
+                    );
+                  default:
+                    throwIllegalValue(validationError);
+                }
+              })()}
+            </ValidationMessage>
+            <Actions>
+              {previousContest ? (
+                <Button
+                  icon="Previous"
+                  onPress={() => {
+                    history.push(
+                      routerPaths.tallyManualFormContest({
+                        precinctId,
+                        ballotStyleGroupId,
+                        votingMethod,
+                        contestId: previousContest.id,
+                      })
+                    );
+                    firstInputRef.current?.focus();
+                  }}
+                >
+                  Previous
+                </Button>
+              ) : (
+                <LinkButton to={routerPaths.tallyManual}>Cancel</LinkButton>
+              )}
+              <Caption weight="semiBold" style={{ whiteSpace: 'nowrap' }}>
+                {format.count(contestIndex + 1)} of{' '}
+                {format.count(contests.length)}
+              </Caption>
+              <Button
+                variant="primary"
+                icon="Done"
+                onPress={saveResults}
+                disabled={
+                  validationError === 'incomplete' ||
+                  setManualTallyMutation.isLoading
+                }
+              >
+                {nextContest ? 'Next' : 'Finish'}
+              </Button>
+            </Actions>
+          </div>
+        </ControlsContent>
+      </TaskControls>
     </TaskScreen>
   );
 }

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
@@ -122,7 +122,7 @@ const ContestData = styled(Card)`
   }
 `;
 
-const TallyInput = styled.input`
+const TallyInput = styled.input.attrs({ type: 'number' })`
   width: 5.5em;
 
   ::-webkit-inner-spin-button,
@@ -621,31 +621,26 @@ function ContestForm({
     candidateName?: string
   ) {
     const contestResults = formManualResults.contestResults[contestId];
-    const stringValue = event.currentTarget.value;
-    // eslint-disable-next-line vx/gts-safe-number-parse
-    const numericalValue = Number(stringValue);
-    if (Number.isNaN(numericalValue)) {
-      return;
-    }
-    const valueToSave = stringValue === '' ? '' : numericalValue;
+    const value =
+      event.currentTarget.value === '' ? '' : event.currentTarget.valueAsNumber;
     let newContestResults = contestResults;
     switch (dataKey) {
       case 'overvotes':
         newContestResults = {
           ...contestResults,
-          overvotes: valueToSave,
+          overvotes: value,
         };
         break;
       case 'undervotes':
         newContestResults = {
           ...contestResults,
-          undervotes: valueToSave,
+          undervotes: value,
         };
         break;
       case 'numBallots':
         newContestResults = {
           ...contestResults,
-          ballots: valueToSave,
+          ballots: value,
         };
         break;
       case 'noTally':
@@ -655,12 +650,12 @@ function ContestForm({
         if (dataKey === 'yesTally') {
           newContestResults = {
             ...contestResults,
-            yesTally: valueToSave,
+            yesTally: value,
           };
         } else {
           newContestResults = {
             ...contestResults,
-            noTally: valueToSave,
+            noTally: value,
           };
         }
         break;
@@ -671,13 +666,13 @@ function ContestForm({
         const newCandidateTally: FormCandidateTally = candidateTally
           ? {
               ...candidateTally,
-              tally: valueToSave,
+              tally: value,
             }
           : {
               id: dataKey,
               isWriteIn: true,
               name: assertDefined(candidateName),
-              tally: valueToSave,
+              tally: value,
             };
         newContestResults = {
           ...contestResults,

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
@@ -218,7 +218,6 @@ function AddWriteInRow({
           // eslint-disable-next-line jsx-a11y/no-autofocus
           autoFocus
           defaultValue=""
-          data-testid="write-in-input"
           aria-label="Write-in"
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
             setWriteInName(e.target.value)
@@ -748,10 +747,9 @@ function ContestForm({
           <ContestSection
             fill={isOverridingBallotCount ? 'warning' : 'neutral'}
           >
-            <ContestDataRow data-testid="numBallots">
+            <ContestDataRow>
               <TallyInput
                 id="numBallots"
-                data-testid="numBallots-input"
                 value={getValueForInput('numBallots')}
                 onChange={(e) => updateContestData('numBallots', e)}
                 disabled={!isOverridingBallotCount}
@@ -789,20 +787,18 @@ function ContestForm({
           </ContestSection>
 
           <ContestSection>
-            <ContestDataRow data-testid="undervotes">
+            <ContestDataRow>
               <TallyInput
                 ref={firstInputRef}
                 id="undervotes"
-                data-testid="undervotes-input"
                 value={getValueForInput('undervotes')}
                 onChange={(e) => updateContestData('undervotes', e)}
               />
               <label htmlFor="undervotes">Undervotes</label>
             </ContestDataRow>
-            <ContestDataRow data-testid="overvotes">
+            <ContestDataRow>
               <TallyInput
                 id="overvotes"
-                data-testid="overvotes-input"
                 value={getValueForInput('overvotes')}
                 onChange={(e) => updateContestData('overvotes', e)}
               />
@@ -816,13 +812,9 @@ function ContestForm({
                 {contest.candidates
                   .filter((c) => !c.isWriteIn)
                   .map((candidate) => (
-                    <ContestDataRow
-                      key={candidate.id}
-                      data-testid={candidate.id}
-                    >
+                    <ContestDataRow key={candidate.id}>
                       <TallyInput
                         id={candidate.id}
-                        data-testid={`${candidate.id}-input`}
                         value={getValueForInput(candidate.id)}
                         onChange={(e) => updateContestData(candidate.id, e)}
                       />
@@ -832,10 +824,9 @@ function ContestForm({
                     </ContestDataRow>
                   ))}
                 {contestWriteInCandidates.map((candidate) => (
-                  <ContestDataRow key={candidate.id} data-testid={candidate.id}>
+                  <ContestDataRow key={candidate.id}>
                     <TallyInput
                       id={candidate.id}
-                      data-testid={`${candidate.id}-input`}
                       value={getValueForInput(candidate.id)}
                       onChange={(e) =>
                         updateContestData(candidate.id, e, candidate.name)
@@ -847,11 +838,10 @@ function ContestForm({
                   </ContestDataRow>
                 ))}
                 {formWriteInCandidates.map((candidate) => (
-                  <ContestDataRow key={candidate.id} data-testid={candidate.id}>
+                  <ContestDataRow key={candidate.id}>
                     <TallyInput
                       autoFocus
                       id={candidate.id}
-                      data-testid={`${candidate.id}-input`}
                       value={getValueForInput(candidate.id)}
                       onChange={(e) =>
                         updateContestData(candidate.id, e, candidate.name)
@@ -877,19 +867,17 @@ function ContestForm({
             )}
             {contest.type === 'yesno' && (
               <React.Fragment>
-                <ContestDataRow data-testid={`${contest.yesOption.id}`}>
+                <ContestDataRow>
                   <TallyInput
                     id="yes"
-                    data-testid={`${contest.yesOption.id}-input`}
                     value={getValueForInput('yesTally')}
                     onChange={(e) => updateContestData('yesTally', e)}
                   />
                   <label htmlFor="yes">{contest.yesOption.label}</label>
                 </ContestDataRow>
-                <ContestDataRow data-testid={`${contest.noOption.id}`}>
+                <ContestDataRow>
                   <TallyInput
                     id="no"
-                    data-testid={`${contest.noOption.id}-input`}
                     value={getValueForInput('noTally')}
                     onChange={(e) => updateContestData('noTally', e)}
                   />

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_tab.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_tab.tsx
@@ -376,7 +376,7 @@ export function ManualTalliesTab(): JSX.Element | null {
                 selectedBallotStyle &&
                 selectedPrecinct &&
                 selectedVotingMethod &&
-                routerPaths.manualDataEntry({
+                routerPaths.tallyManualForm({
                   ballotStyleGroupId: selectedBallotStyle.id,
                   precinctId: selectedPrecinct.id,
                   votingMethod: selectedVotingMethod,
@@ -433,7 +433,7 @@ export function ManualTalliesTab(): JSX.Element | null {
                       <LinkButton
                         icon="Edit"
                         fill="transparent"
-                        to={routerPaths.manualDataEntry(metadata)}
+                        to={routerPaths.tallyManualForm(metadata)}
                         style={{ marginRight: '0.5rem' }}
                         disabled={isOfficialResults}
                       >

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_tab.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_tab.tsx
@@ -34,7 +34,6 @@ import { routerPaths } from '../../router_paths';
 import { AppContext } from '../../contexts/app_context';
 import { ConfirmRemoveAllManualTalliesModal } from './confirm_remove_all_manual_tallies_modal';
 import { deleteManualResults, getManualResultsMetadata } from '../../api';
-import { Loading } from '../../components/loading';
 import { ImportElectionsResultReportingFileModal } from './import_election_results_reporting_file_modal';
 
 export const TITLE = 'Manual Tallies';
@@ -150,7 +149,7 @@ function RemoveManualTallyModal({
   );
 }
 
-export function ManualTalliesTab(): JSX.Element {
+export function ManualTalliesTab(): JSX.Element | null {
   const { electionDefinition, auth, isOfficialResults } =
     useContext(AppContext);
   assert(electionDefinition);
@@ -278,7 +277,7 @@ export function ManualTalliesTab(): JSX.Element {
   }
 
   if (!getManualTallyMetadataQuery.isSuccess) {
-    return <Loading />;
+    return null;
   }
 
   return (

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_tab.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_tab.tsx
@@ -13,6 +13,7 @@ import {
   SearchSelect,
   Card,
   TabPanel,
+  Icons,
 } from '@votingworks/ui';
 import {
   getBallotStyleGroup,
@@ -406,6 +407,7 @@ export function ManualTalliesTab(): JSX.Element | null {
                   Ballot Count
                 </TD>
                 <TD as="th" narrow nowrap />
+                <TD as="th" narrow nowrap />
               </tr>
             </thead>
             <tbody>
@@ -429,12 +431,23 @@ export function ManualTalliesTab(): JSX.Element | null {
                     <TD nowrap data-testid="numBallots">
                       {metadata.ballotCount.toLocaleString()}
                     </TD>
-                    <TD nowrap>
+                    <TD narrow nowrap>
+                      {metadata.validationError === 'invalid' && (
+                        <React.Fragment>
+                          <Icons.Warning color="warning" /> Invalid
+                        </React.Fragment>
+                      )}
+                      {metadata.validationError === 'incomplete' && (
+                        <React.Fragment>
+                          <Icons.Info /> Incomplete
+                        </React.Fragment>
+                      )}
+                    </TD>
+                    <TD nowrap style={{ minWidth: '13rem' }}>
                       <LinkButton
                         icon="Edit"
                         fill="transparent"
                         to={routerPaths.tallyManualForm(metadata)}
-                        style={{ marginRight: '0.5rem' }}
                         disabled={isOfficialResults}
                       >
                         Edit

--- a/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
@@ -42,7 +42,7 @@ import {
 } from '../api';
 import { normalizeWriteInName } from '../utils/write_ins';
 import { AppContext } from '../contexts/app_context';
-import { WriteInsAdjudicationScreenProps } from '../config/types';
+import { WriteInsAdjudicationScreenParams } from '../config/types';
 import { routerPaths } from '../router_paths';
 import {
   BallotStaticImageViewer,
@@ -229,7 +229,7 @@ const CandidateButtonList = styled.div`
 `;
 
 export function WriteInsAdjudicationScreen(): JSX.Element {
-  const { contestId } = useParams<WriteInsAdjudicationScreenProps>();
+  const { contestId } = useParams<WriteInsAdjudicationScreenParams>();
   const { electionDefinition } = useContext(AppContext);
   assert(electionDefinition);
   const { election } = electionDefinition;

--- a/apps/admin/frontend/test/api_mock_data.ts
+++ b/apps/admin/frontend/test/api_mock_data.ts
@@ -2,7 +2,7 @@ import type {
   CastVoteRecordFileMetadata,
   CastVoteRecordFileRecord,
   CvrFileImportInfo,
-  ManualResultsMetadataRecord,
+  ManualResultsMetadata,
 } from '@votingworks/admin-backend';
 import { BallotStyleGroupId } from '@votingworks/types';
 
@@ -61,7 +61,7 @@ export const mockCastVoteRecordFileMetadata: CastVoteRecordFileMetadata[] = [
   },
 ];
 
-export const mockManualResultsMetadata: ManualResultsMetadataRecord[] = [
+export const mockManualResultsMetadata: ManualResultsMetadata[] = [
   {
     ballotStyleGroupId: '1-Ma' as BallotStyleGroupId,
     precinctId: 'precinct-c1-w1-1',

--- a/apps/admin/frontend/test/helpers/mock_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_api_client.ts
@@ -8,7 +8,6 @@ import type {
   CvrFileMode,
   MachineConfig,
   ManualResultsIdentifier,
-  ManualResultsMetadataRecord,
   WriteInCandidateRecord,
   WriteInAdjudicationContext,
   ScannerBatch,
@@ -17,6 +16,7 @@ import type {
   ExportDataError,
   TallyReportSpec,
   TallyReportWarning,
+  ManualResultsMetadata,
 } from '@votingworks/admin-backend';
 import type { BatteryInfo, DiskSpaceSummary } from '@votingworks/backend';
 import { FileSystemEntry, FileSystemEntryType } from '@votingworks/fs';
@@ -479,7 +479,7 @@ export function createApiMock(
         .resolves(ok());
     },
 
-    expectGetManualResultsMetadata(records: ManualResultsMetadataRecord[]) {
+    expectGetManualResultsMetadata(records: ManualResultsMetadata[]) {
       apiClient.getManualResultsMetadata.expectCallWith().resolves(records);
     },
 

--- a/apps/design/frontend/src/ballot_screen.tsx
+++ b/apps/design/frontend/src/ballot_screen.tsx
@@ -17,7 +17,6 @@ import {
   H1,
   Icons,
   LinkButton,
-  MainWrapper,
   RadioGroup,
   TaskContent,
   TaskControls,
@@ -238,107 +237,105 @@ export function BallotScreen(): JSX.Element | null {
 
   return (
     <TaskScreen>
-      <MainWrapper>
-        <TaskControls style={{ width: '20rem' }}>
-          <TaskHeader>
-            <H1>{title}</H1>
-            <LinkButton
-              to={ballotRoutes.root.path}
-              icon="X"
-              color="inverseNeutral"
-              fill="transparent"
-              aria-label="Close"
-              style={{ fontSize: '1.5rem' }}
+      <TaskContent style={{ display: 'flex' }}>
+        <Viewer>
+          {(() => {
+            if (!getBallotPreviewPdfQuery.isSuccess) {
+              return <PdfViewer />;
+            }
+
+            const ballotResult = getBallotPreviewPdfQuery.data;
+
+            if (ballotResult.isErr()) {
+              return (
+                <Row
+                  style={{
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                    height: '100%',
+                  }}
+                >
+                  <Card color="danger">
+                    Error:{' '}
+                    {ballotResult.err().message ?? 'Something went wrong'}
+                  </Card>
+                </Row>
+              );
+            }
+
+            return <PdfViewer pdfData={ballotResult.ok()} />;
+          })()}
+        </Viewer>
+      </TaskContent>
+      <TaskControls style={{ width: '20rem' }}>
+        <TaskHeader>
+          <H1>{title}</H1>
+          <LinkButton
+            to={ballotRoutes.root.path}
+            icon="X"
+            color="inverseNeutral"
+            fill="transparent"
+            aria-label="Close"
+            style={{ fontSize: '1.5rem' }}
+          />
+        </TaskHeader>
+
+        <Controls>
+          <Column style={{ gap: '1rem' }}>
+            <div>
+              <FieldName>Ballot Style</FieldName>
+              {ballotStyle.id}
+            </div>
+
+            <div>
+              <FieldName>Precinct</FieldName>
+              {precinct.name}
+            </div>
+
+            {election.type === 'primary' && (
+              <div>
+                <FieldName>Party</FieldName>
+                {
+                  assertDefined(
+                    getPartyForBallotStyle({
+                      election,
+                      ballotStyleId: ballotStyle.id,
+                    })
+                  ).fullName
+                }
+              </div>
+            )}
+
+            <div>
+              <FieldName>Page Size</FieldName>
+              {paperSizeLabels[paperSize]}{' '}
+            </div>
+
+            <RadioGroup
+              label="Ballot Type"
+              options={[
+                { value: BallotType.Precinct, label: 'Precinct' },
+                { value: BallotType.Absentee, label: 'Absentee' },
+              ]}
+              value={ballotType}
+              onChange={setBallotType}
+              inverse
             />
-          </TaskHeader>
 
-          <Controls>
-            <Column style={{ gap: '1rem' }}>
-              <div>
-                <FieldName>Ballot Style</FieldName>
-                {ballotStyle.id}
-              </div>
-
-              <div>
-                <FieldName>Precinct</FieldName>
-                {precinct.name}
-              </div>
-
-              {election.type === 'primary' && (
-                <div>
-                  <FieldName>Party</FieldName>
-                  {
-                    assertDefined(
-                      getPartyForBallotStyle({
-                        election,
-                        ballotStyleId: ballotStyle.id,
-                      })
-                    ).fullName
-                  }
-                </div>
-              )}
-
-              <div>
-                <FieldName>Page Size</FieldName>
-                {paperSizeLabels[paperSize]}{' '}
-              </div>
-
-              <RadioGroup
-                label="Ballot Type"
-                options={[
-                  { value: BallotType.Precinct, label: 'Precinct' },
-                  { value: BallotType.Absentee, label: 'Absentee' },
-                ]}
-                value={ballotType}
-                onChange={setBallotType}
-                inverse
-              />
-
-              <RadioGroup
-                label="Tabulation Mode"
-                options={[
-                  { value: 'official', label: 'Official Ballot' },
-                  { value: 'test', label: 'L&A Test Ballot' },
-                  { value: 'sample', label: 'Sample Ballot' },
-                ]}
-                value={ballotMode}
-                onChange={setBallotMode}
-                inverse
-              />
-            </Column>
-          </Controls>
-        </TaskControls>
-        <TaskContent style={{ display: 'flex' }}>
-          <Viewer>
-            {(() => {
-              if (!getBallotPreviewPdfQuery.isSuccess) {
-                return <PdfViewer />;
-              }
-
-              const ballotResult = getBallotPreviewPdfQuery.data;
-
-              if (ballotResult.isErr()) {
-                return (
-                  <Row
-                    style={{
-                      justifyContent: 'center',
-                      alignItems: 'center',
-                      height: '100%',
-                    }}
-                  >
-                    <Card color="danger">
-                      Error:{' '}
-                      {ballotResult.err().message ?? 'Something went wrong'}
-                    </Card>
-                  </Row>
-                );
-              }
-
-              return <PdfViewer pdfData={ballotResult.ok()} />;
-            })()}
-          </Viewer>
-        </TaskContent>
-      </MainWrapper>
+            <RadioGroup
+              label="Tabulation Mode"
+              options={[
+                { value: 'official', label: 'Official Ballot' },
+                { value: 'test', label: 'L&A Test Ballot' },
+                { value: 'sample', label: 'Sample Ballot' },
+              ]}
+              value={ballotMode}
+              onChange={setBallotMode}
+              inverse
+            />
+          </Column>
+        </Controls>
+      </TaskControls>
     </TaskScreen>
   );
 }

--- a/libs/ui/src/global_styles.tsx
+++ b/libs/ui/src/global_styles.tsx
@@ -123,7 +123,7 @@ ${NORMALIZE_CSS}
     border-radius: ${(p) => p.theme.sizes.borderRadiusRem}rem;
 
     &:focus {
-      background: none;
+      background: ${(p) => p.theme.colors.background};
     }
 
     &:disabled {

--- a/libs/ui/src/task_screen.tsx
+++ b/libs/ui/src/task_screen.tsx
@@ -6,9 +6,8 @@ interface TaskScreenProps {
   children: React.ReactNode;
 }
 
-export const MainWrapper = styled(Main)`
+const MainWrapper = styled(Main)`
   display: flex;
-  flex-direction: row-reverse;
   overflow: hidden;
   height: 100%;
 `;

--- a/libs/utils/src/tabulation/tabulation.test.ts
+++ b/libs/utils/src/tabulation/tabulation.test.ts
@@ -44,6 +44,7 @@ import {
   getHmpbBallotCount,
   combineCandidateContestResults,
   buildContestResultsFixture,
+  areContestResultsValid,
 } from './tabulation';
 import {
   convertCastVoteRecordVotesToTabulationVotes,
@@ -1340,4 +1341,86 @@ test('combinedCandidateContestResults - does not alter original tallies', () => 
 
   expect(JSON.stringify(contestResultsA)).toEqual(aString);
   expect(JSON.stringify(contestResultsB)).toEqual(bString);
+});
+
+test('areContestResultsValid', () => {
+  const validCandidateContestResults: Tabulation.ContestResults = {
+    ballots: 50,
+    contestId: 'contest-1',
+    contestType: 'candidate',
+    overvotes: 10,
+    undervotes: 30,
+    votesAllowed: 2,
+    tallies: {
+      candidate1: { id: 'candidate1', name: 'Candidate 1', tally: 0 },
+      candidate2: { id: 'candidate2', name: 'Candidate 2', tally: 20 },
+      candidate3: { id: 'candidate3', name: 'Candidate 3', tally: 40 },
+    },
+  };
+
+  const validYesNoContestResults: Tabulation.YesNoContestResults = {
+    ballots: 50,
+    contestId: 'contest-1',
+    contestType: 'yesno',
+    overvotes: 10,
+    undervotes: 5,
+    yesOptionId: 'yes',
+    noOptionId: 'no',
+    yesTally: 25,
+    noTally: 10,
+  };
+
+  expect(areContestResultsValid(validCandidateContestResults)).toEqual(true);
+  expect(areContestResultsValid(validYesNoContestResults)).toEqual(true);
+
+  expect(
+    areContestResultsValid({
+      ...validCandidateContestResults,
+      overvotes: validCandidateContestResults.overvotes - 1,
+    })
+  ).toEqual(false);
+  expect(
+    areContestResultsValid({
+      ...validCandidateContestResults,
+      undervotes: validCandidateContestResults.undervotes - 1,
+    })
+  ).toEqual(false);
+  expect(
+    areContestResultsValid({
+      ...validCandidateContestResults,
+      tallies: {
+        ...validCandidateContestResults.tallies,
+        candidate1: {
+          id: 'candidate1',
+          name: 'Candidate 1',
+          tally: validCandidateContestResults.tallies['candidate1']!.tally + 1,
+        },
+      },
+    })
+  ).toEqual(false);
+
+  expect(
+    areContestResultsValid({
+      ...validYesNoContestResults,
+      overvotes: validYesNoContestResults.overvotes - 1,
+    })
+  ).toEqual(false);
+  expect(
+    areContestResultsValid({
+      ...validYesNoContestResults,
+      undervotes: validYesNoContestResults.undervotes - 1,
+    })
+  ).toEqual(false);
+  expect(
+    areContestResultsValid({
+      ...validYesNoContestResults,
+      yesTally: validYesNoContestResults.yesTally + 1,
+    })
+  ).toEqual(false);
+  expect(
+    areContestResultsValid({
+      ...validYesNoContestResults,
+      noTally: validYesNoContestResults.noTally + 1,
+    })
+  ).toEqual(false);
 });

--- a/libs/utils/src/tabulation/tabulation.ts
+++ b/libs/utils/src/tabulation/tabulation.ts
@@ -909,3 +909,23 @@ export function mergeWriteInTallies<
     contestResults: newElectionContestResults,
   };
 }
+
+/**
+ * Validates that the number of votes entered for the contest matches the number
+ * of ballots.
+ */
+export function areContestResultsValid(
+  contestResults: Tabulation.ContestResults
+): boolean {
+  const votesAllowed =
+    contestResults.contestType === 'yesno' ? 1 : contestResults.votesAllowed;
+  const expectedVotes = contestResults.ballots * votesAllowed;
+  const enteredVotes =
+    contestResults.overvotes +
+    contestResults.undervotes +
+    (contestResults.contestType === 'yesno'
+      ? contestResults.yesTally + contestResults.noTally
+      : iter(Object.values(contestResults.tallies)).sum(({ tally }) => tally));
+
+  return enteredVotes === expectedVotes;
+}

--- a/libs/utils/src/tabulation/tabulation.ts
+++ b/libs/utils/src/tabulation/tabulation.ts
@@ -920,12 +920,12 @@ export function areContestResultsValid(
   const votesAllowed =
     contestResults.contestType === 'yesno' ? 1 : contestResults.votesAllowed;
   const expectedVotes = contestResults.ballots * votesAllowed;
-  const enteredVotes =
+  const tallyVotes =
     contestResults.overvotes +
     contestResults.undervotes +
     (contestResults.contestType === 'yesno'
       ? contestResults.yesTally + contestResults.noTally
       : iter(Object.values(contestResults.tallies)).sum(({ tally }) => tally));
 
-  return enteredVotes === expectedVotes;
+  return tallyVotes === expectedVotes;
 }


### PR DESCRIPTION
## Overview


Reworks the manual tally entry flow to address a number of UX issues. The main changes:
- Enter and save tallies for one contest at a time 
  Fixes #5390 
  Fixes #5381

- Default tallies to blank, not 0, and disallow saving until you fill out all the tallies 
  Fixes #5295
- Enter an overall ballot count once at the beginning, then allow overriding for a specific contest if needed
  Fixes #5407

## Demo Video or Screenshot

https://github.com/user-attachments/assets/7183bb99-bee3-40b5-95e7-288d4de3a036



## Testing Plan
Manual testing, updated automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
