### PR TITLE
VxAdmin: Show votes allowed in manual tally form

### DIFF
--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.test.tsx
@@ -177,6 +177,9 @@ test('entering initial ballot count and contest tallies', async () => {
     await screen.findByText(`${contestNumber} of ${contests.length}`);
     screen.getByRole('heading', { name: contest.title });
     screen.getByText(district.name);
+    if (contest.type === 'candidate') {
+      screen.getByText(`Vote for ${contest.seats}`);
+    }
     screen.getByText('No tallies entered');
 
     const saveButtonLabel =

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
@@ -742,8 +742,13 @@ function ContestForm({
     <TaskScreen>
       <TallyTaskContent>
         <FormCard>
-          <Caption>{getContestDistrictName(election, contest)}</Caption>
-          <H2 style={{ marginTop: 0 }}>{contest.title}</H2>
+          <div style={{ marginBottom: '0.5rem' }}>
+            <Caption>{getContestDistrictName(election, contest)}</Caption>
+            <H2 style={{ margin: 0 }}>{contest.title}</H2>
+            {contest.type === 'candidate' && (
+              <div>Vote for {contest.seats}</div>
+            )}
+          </div>
           <ContestSection
             fill={isOverridingBallotCount ? 'warning' : 'neutral'}
           >


### PR DESCRIPTION


## Overview

Fixes https://github.com/votingworks/vxsuite/issues/5215

This is important when the tallies don't match the ballots cast - you need to know how many votes are allowed per voter so you can do the math to work out the expected number of votes.

## Demo Video or Screenshot
![Screenshot-VxAdmin-2024-10-09T00:15:03 073Z](https://github.com/user-attachments/assets/933cb340-b22f-4ab9-980e-346910163f9c)

## Testing Plan
Updated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
