### PR TITLE
VxAdmin: Use correct image dimensions in write-in adjudication highlight

### DIFF
--- a/apps/admin/backend/src/app.write_ins.test.ts
+++ b/apps/admin/backend/src/app.write_ins.test.ts
@@ -282,9 +282,19 @@ test('getWriteInImageView on hmpb', async () => {
     writeInCoordinates: writeInCoordinatesA,
   } = writeInImageViewA as HmpbWriteInImageView;
 
+  const expectedImage = await loadImageData(
+    join(
+      reportDirectoryPath,
+      '864a2854-ee26-4223-8097-9633b7bed096',
+      '864a2854-ee26-4223-8097-9633b7bed096-front.jpg'
+    )
+  );
+  const expectedImageUrl = toDataUrl(expectedImage, 'image/jpeg');
+  expect(actualImageUrl).toEqual(expectedImageUrl);
+
   const expectedBallotCoordinates: Rect = {
-    height: 2200,
-    width: 1696,
+    height: expectedImage.height,
+    width: expectedImage.width,
     x: 0,
     y: 0,
   };
@@ -304,16 +314,6 @@ test('getWriteInImageView on hmpb', async () => {
       "y": 1274,
     }
   `);
-
-  const expectedImage = await loadImageData(
-    join(
-      reportDirectoryPath,
-      '864a2854-ee26-4223-8097-9633b7bed096',
-      '864a2854-ee26-4223-8097-9633b7bed096-front.jpg'
-    )
-  );
-  const expectedImageUrl = toDataUrl(expectedImage, 'image/jpeg');
-  expect(actualImageUrl).toEqual(expectedImageUrl);
 
   // check the second write-in image view, which should have the same image
   // but different writeInCoordinates

--- a/apps/admin/backend/src/util/write_ins.ts
+++ b/apps/admin/backend/src/util/write_ins.ts
@@ -64,12 +64,14 @@ export async function getWriteInImageView({
   }
 
   debug('created write-in image view');
+  const imageData = await loadImageData(image);
   return {
     writeInId,
     cvrId,
-    imageUrl: toDataUrl(await loadImageData(image), 'image/jpeg'),
+    imageUrl: toDataUrl(imageData, 'image/jpeg'),
     ballotCoordinates: {
-      ...layout.pageSize,
+      width: imageData.width,
+      height: imageData.height,
       x: 0,
       y: 0,
     },


### PR DESCRIPTION


## Overview

Fixes #5202 

Previously, we used ballot image dimensions based on the interpreter's computed page geometry. This doesn't always match the actual image size, since the interpreter just looks for the closest known page size (e.g. letter, legal). This was causing the write-in adjudication highlight to be slightly off, since the actual image dimensions rarely match the idealized page size exactly. To fix it, we just use the actual image dimensions instead of the idealized ones.

## Demo Video or Screenshot
Before

![Screenshot-VxAdmin-2024-10-09T20:56:59 095Z](https://github.com/user-attachments/assets/cd1e777f-eddf-4017-9a43-cb523d264732)

After
![Screenshot-VxAdmin-2024-10-09T20:55:58 778Z](https://github.com/user-attachments/assets/24288712-5285-466b-a2b8-0890299b2afb)


## Testing Plan
Manual test, updated backend test

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
