### PR TITLE
sort reports by precinct name rather than ID

### DIFF
--- a/apps/admin/backend/src/exports/csv_ballot_count_report.test.ts
+++ b/apps/admin/backend/src/exports/csv_ballot_count_report.test.ts
@@ -352,15 +352,6 @@ test('can include sheet counts', async () => {
 
   expect(rows).toEqual([
     {
-      BMD: '3',
-      HMPB: '12',
-      'HMPB Sheet 2': '10',
-      'HMPB Sheet 3': '7',
-      Precinct: 'West Lincoln',
-      'Precinct ID': '20',
-      Total: '15',
-    },
-    {
       BMD: '0',
       HMPB: '0',
       'HMPB Sheet 2': '0',
@@ -368,6 +359,15 @@ test('can include sheet counts', async () => {
       Precinct: 'East Lincoln',
       'Precinct ID': '21',
       Total: '0',
+    },
+    {
+      BMD: '9',
+      HMPB: '11',
+      'HMPB Sheet 2': '11',
+      'HMPB Sheet 3': '10',
+      Precinct: 'North Lincoln',
+      'Precinct ID': '23',
+      Total: '20',
     },
     {
       BMD: '0',
@@ -379,13 +379,13 @@ test('can include sheet counts', async () => {
       Total: '0',
     },
     {
-      BMD: '9',
-      HMPB: '11',
-      'HMPB Sheet 2': '11',
-      'HMPB Sheet 3': '10',
-      Precinct: 'North Lincoln',
-      'Precinct ID': '23',
-      Total: '20',
+      BMD: '3',
+      HMPB: '12',
+      'HMPB Sheet 2': '10',
+      'HMPB Sheet 3': '7',
+      Precinct: 'West Lincoln',
+      'Precinct ID': '20',
+      Total: '15',
     },
   ]);
 });

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -672,7 +672,7 @@ export class Store {
     if (groupBy.groupByPrecinct) {
       selectParts.push('precincts.id as precinctId');
       groupByParts.push('precinctId');
-      sortByParts.push('precinctId');
+      sortByParts.push('precincts.name');
     }
     if (groupBy.groupByParty) {
       selectParts.push('ballot_styles.party_id as partyId');


### PR DESCRIPTION
Currently, tally report sections / ballot count report rows are ordered by precinct ID rather than precinct name - if precinct is included in the grouping (and batch + scanner is not). The ordering problem is bigger, and I created #5501 to track for v4.1, but this seems like a safe change to sneak in for v4.0. Previously we didn't see this issue because we mostly used fixtures where the IDs were just lowercased versions of the names, but that is not be the case for VxDesign.