### PR TITLE
show printer success icon for VxAdmin printer diagnostics as long as its connected

### DIFF
--- a/apps/admin/frontend/src/screens/diagnostics_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/diagnostics_screen.test.tsx
@@ -86,7 +86,7 @@ test('displays printer state and allows diagnostic', async () => {
     connected: true,
     config: mockPrinterConfig,
   });
-  await expectTextWithIcon('Connected', 'spinner');
+  await expectTextWithIcon('Connected', 'square-check');
 
   apiMock.setPrinterStatus({
     connected: true,

--- a/libs/ui/src/diagnostics/printer_section.test.tsx
+++ b/libs/ui/src/diagnostics/printer_section.test.tsx
@@ -115,7 +115,7 @@ describe('PrinterSection status message', () => {
         }}
       />
     );
-    await expectTextWithIcon('Connected', 'spinner');
+    await expectTextWithIcon('Connected', 'square-check');
   });
 
   test('idle', async () => {

--- a/libs/ui/src/diagnostics/printer_section.tsx
+++ b/libs/ui/src/diagnostics/printer_section.tsx
@@ -114,7 +114,7 @@ export function PrinterStatusDisplay({
   if (!richStatus) {
     return (
       <P>
-        <LoadingIcon /> Connected
+        <SuccessIcon /> Connected
       </P>
     );
   }


### PR DESCRIPTION
references #5503
