### PR TITLE
fix(basics): correct the type of `iter::async`

### DIFF
--- a/libs/basics/src/iterators/async_iterator_plus.test.ts
+++ b/libs/basics/src/iterators/async_iterator_plus.test.ts
@@ -2,10 +2,20 @@ import * as fc from 'fast-check';
 import { integers } from './integers';
 import { iter } from './iter';
 import { naturals } from './naturals';
+import { typedAs } from '../typed_as';
 
-test('async', () => {
+test('async', async () => {
   const it = iter([]).async();
   expect(it.async()).toEqual(it);
+
+  // ensure `.async()` transforms `IteratorPlus<Promise<T>>` to `AsyncIteratorPlus<T>`
+  expect(
+    await typedAs<Promise<number[]>>(
+      iter([Promise.resolve(0)])
+        .async()
+        .toArray()
+    )
+  ).toEqual([0]);
 });
 
 test('map', async () => {

--- a/libs/basics/src/iterators/async_iterator_plus.ts
+++ b/libs/basics/src/iterators/async_iterator_plus.ts
@@ -44,8 +44,8 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
     return this.intoInner()[Symbol.asyncIterator]();
   }
 
-  async(): AsyncIteratorPlus<T> {
-    return this;
+  async(): AsyncIteratorPlus<Awaited<T>> {
+    return this as AsyncIteratorPlus<Awaited<T>>;
   }
 
   chain<U>(other: AsyncIterable<U>): AsyncIteratorPlus<T | U> {

--- a/libs/basics/src/iterators/iterator_plus.ts
+++ b/libs/basics/src/iterators/iterator_plus.ts
@@ -49,10 +49,10 @@ export class IteratorPlusImpl<T> implements IteratorPlus<T>, AsyncIterable<T> {
     return this.async()[Symbol.asyncIterator]();
   }
 
-  async(): AsyncIteratorPlus<T> {
+  async(): AsyncIteratorPlus<Awaited<T>> {
     const iterable = this.intoInner();
     return new AsyncIteratorPlusImpl(
-      (async function* gen(): AsyncGenerator<T> {
+      (async function* gen(): AsyncGenerator<Awaited<T>> {
         for (const value of iterable) {
           yield await Promise.resolve(value);
         }

--- a/libs/basics/src/iterators/types.ts
+++ b/libs/basics/src/iterators/types.ts
@@ -9,7 +9,7 @@ export interface IteratorPlus<T> extends Iterable<T> {
   /**
    * Returns an async iterator that yields the same values as this iterator.
    */
-  async(): AsyncIteratorPlus<T>;
+  async(): AsyncIteratorPlus<Awaited<T>>;
 
   /**
    * Chains elements from `this` and `other` together.


### PR DESCRIPTION
## Overview

This ensures that, if we somehow get an `IteratorPlus<Promise<T>>`, that calling `.async()` will return an `AsyncIterablePlus<T>`, not an `AsyncIterablePlus<Promise<T>>`. This is both more correct and improves the ergonomics of async iterables.

## Demo Video or Screenshot
<img width="871" alt="image" src="https://github.com/user-attachments/assets/f4935cce-2bf0-4c3f-9f03-d463ad4be6b6">

## Testing Plan
Added a type assertion.
