### PR TITLE
Clear cached query data on unconfigure in all apps

### DIFF
--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -599,12 +599,12 @@ export const unconfigure = {
     const apiClient = useApiClient();
     const queryClient = useQueryClient();
     return useMutation(apiClient.unconfigure, {
-      onSuccess() {
+      async onSuccess() {
         // If we configure with a different election, any data in the cache will
         // correspond to the previous election, so we don't just invalidate, but
-        // clear all cached queries, since invalidated queries may still return
-        // stale data while refetching.
-        queryClient.clear();
+        // reset all queries to clear their cached data, since invalidated
+        // queries may still return stale data while refetching.
+        await queryClient.resetQueries();
       },
     });
   },

--- a/apps/admin/frontend/src/app.test.tsx
+++ b/apps/admin/frontend/src/app.test.tsx
@@ -103,6 +103,7 @@ test('configuring with an election definition', async () => {
   // remove the election
   apiMock.expectUnconfigure();
   apiMock.expectGetCurrentElectionMetadata(null);
+  apiMock.expectGetSystemSettings();
   apiMock.expectGetMachineConfig();
   fireEvent.click(screen.getByText('Unconfigure Machine'));
   const modal = await screen.findByRole('alertdialog');
@@ -285,6 +286,7 @@ test('unconfiguring clears all cached data', async () => {
   // Reconfigure with a different election
   electionDefinition = electionFamousNames2021Fixtures.electionDefinition;
   apiMock.expectConfigure(electionPackage.path);
+  apiMock.expectGetSystemSettings();
   apiMock.expectGetCurrentElectionMetadata({ electionDefinition });
   userEvent.click(screen.getByText(electionPackage.name));
   await screen.findAllByText(electionDefinition.election.title);

--- a/apps/central-scan/frontend/src/api.ts
+++ b/apps/central-scan/frontend/src/api.ts
@@ -267,9 +267,11 @@ export const unconfigure = {
     const queryClient = useQueryClient();
     return useMutation(apiClient.unconfigure, {
       async onSuccess() {
-        await queryClient.invalidateQueries(getTestMode.queryKey());
-        await queryClient.invalidateQueries(getSystemSettings.queryKey());
-        await queryClient.invalidateQueries(getElectionRecord.queryKey());
+        // If we configure with a different election, any data in the cache will
+        // correspond to the previous election, so we don't just invalidate, but
+        // reset all queries to clear their cached data, since invalidated
+        // queries may still return stale data while refetching.
+        await queryClient.resetQueries();
       },
     });
   },

--- a/apps/mark-scan/frontend/src/api.ts
+++ b/apps/mark-scan/frontend/src/api.ts
@@ -355,10 +355,11 @@ export const unconfigureMachine = {
     const queryClient = useQueryClient();
     return useMutation(() => apiClient.unconfigureMachine(), {
       async onSuccess() {
-        await queryClient.invalidateQueries(getElectionRecord.queryKey());
-        await queryClient.invalidateQueries(getSystemSettings.queryKey());
-        await queryClient.invalidateQueries(getElectionState.queryKey());
-        await uiStringsApi.onMachineConfigurationChange(queryClient);
+        // If we configure with a different election, any data in the cache will
+        // correspond to the previous election, so we don't just invalidate, but
+        // reset all queries to clear their cached data, since invalidated
+        // queries may still return stale data while refetching.
+        await queryClient.resetQueries();
       },
     });
   },

--- a/apps/mark-scan/frontend/src/api_machine_configuration.test.tsx
+++ b/apps/mark-scan/frontend/src/api_machine_configuration.test.tsx
@@ -6,7 +6,6 @@ import {
   configureElectionPackageFromUsb,
   createApiClient,
   uiStringsApi,
-  unconfigureMachine,
 } from './api';
 import { ApiProvider } from './api_provider';
 
@@ -46,21 +45,6 @@ test('configureElectionPackageFromUsb', async () => {
     () => configureElectionPackageFromUsb.useMutation(),
     { wrapper: QueryWrapper }
   );
-
-  expect(mockOnConfigurationChange).not.toHaveBeenCalled();
-
-  result.current.mutate();
-  await waitFor(() => expect(result.current.isSuccess).toEqual(true));
-
-  expect(mockOnConfigurationChange).toHaveBeenCalled();
-});
-
-test('unconfigureMachine', async () => {
-  jest.mocked(mockBackendApi).unconfigureMachine.mockResolvedValueOnce();
-
-  const { result } = renderHook(() => unconfigureMachine.useMutation(), {
-    wrapper: QueryWrapper,
-  });
 
   expect(mockOnConfigurationChange).not.toHaveBeenCalled();
 

--- a/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark-scan/frontend/src/app_end_to_end.test.tsx
@@ -336,6 +336,9 @@ test('MarkAndPrint end-to-end flow', async () => {
 
   // Unconfigure the machine
   apiMock.expectUnconfigureMachine();
+  apiMock.expectGetMachineConfig({
+    screenOrientation: 'portrait',
+  });
   apiMock.expectGetSystemSettings();
   apiMock.expectGetElectionRecord(null);
   apiMock.expectGetElectionState();
@@ -371,6 +374,9 @@ test('MarkAndPrint end-to-end flow', async () => {
   userEvent.click(await screen.findByText('Unconfigure Machine'));
   const modal = await screen.findByRole('alertdialog');
   apiMock.expectUnconfigureMachine();
+  apiMock.expectGetMachineConfig({
+    screenOrientation: 'portrait',
+  });
   apiMock.expectGetSystemSettings();
   apiMock.expectGetElectionRecord(null);
   apiMock.expectGetElectionState();

--- a/apps/scan/frontend/src/api.ts
+++ b/apps/scan/frontend/src/api.ts
@@ -209,12 +209,11 @@ export const unconfigureElection = {
     const queryClient = useQueryClient();
     return useMutation(apiClient.unconfigureElection, {
       async onSuccess() {
-        await queryClient.invalidateQueries(getConfig.queryKey());
-        await queryClient.invalidateQueries(getPollsInfo.queryKey());
-        await uiStringsApi.onMachineConfigurationChange(queryClient);
-
-        // If doesUsbDriveRequireCastVoteRecordSync was true, unconfiguring resets it back to false
-        await queryClient.invalidateQueries(getUsbDriveStatus.queryKey());
+        // If we configure with a different election, any data in the cache will
+        // correspond to the previous election, so we don't just invalidate, but
+        // reset all queries to clear their cached data, since invalidated
+        // queries may still return stale data while refetching.
+        await queryClient.resetQueries();
       },
     });
   },

--- a/apps/scan/frontend/src/api_machine_configuration.test.tsx
+++ b/apps/scan/frontend/src/api_machine_configuration.test.tsx
@@ -6,7 +6,6 @@ import {
   ApiClient,
   configureFromElectionPackageOnUsbDrive,
   createApiClient,
-  unconfigureElection,
   uiStringsApi,
 } from './api';
 import { ApiProvider } from './api_provider';
@@ -46,21 +45,6 @@ test('configureFromElectionPackageOnUsbDrive', async () => {
     () => configureFromElectionPackageOnUsbDrive.useMutation(),
     { wrapper: QueryWrapper }
   );
-
-  expect(mockOnConfigurationChange).not.toHaveBeenCalled();
-
-  result.current.mutate();
-  await waitFor(() => expect(result.current.isSuccess).toEqual(true));
-
-  expect(mockOnConfigurationChange).toHaveBeenCalled();
-});
-
-test('unconfigureElection', async () => {
-  jest.mocked(mockBackendApi).unconfigureElection.mockResolvedValue();
-
-  const { result } = renderHook(() => unconfigureElection.useMutation(), {
-    wrapper: QueryWrapper,
-  });
 
   expect(mockOnConfigurationChange).not.toHaveBeenCalled();
 

--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -297,6 +297,7 @@ test('election manager and poll worker configuration', async () => {
 
   // Actually unconfigure
   apiMock.mockApiClient.unconfigureElection.expectCallWith().resolves();
+  apiMock.expectGetMachineConfig();
   apiMock.expectGetConfig({ electionDefinition: undefined });
   apiMock.expectGetPollsInfo();
   apiMock.mockApiClient.ejectUsbDrive.expectCallWith().resolves();
@@ -734,6 +735,7 @@ test('system administrator can log in and unconfigure machine', async () => {
   });
 
   apiMock.mockApiClient.unconfigureElection.expectCallWith().resolves();
+  apiMock.expectGetMachineConfig();
   apiMock.expectGetConfig({ electionDefinition: undefined });
   apiMock.expectGetPollsInfo();
   userEvent.click(unconfigureMachineButton);

--- a/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.test.tsx
@@ -141,6 +141,7 @@ test('unconfigure ejects a usb drive', async () => {
   userEvent.click(screen.getByRole('tab', { name: 'Configuration' }));
 
   apiMock.mockApiClient.unconfigureElection.expectCallWith().resolves();
+  apiMock.expectGetMachineConfig();
   apiMock.expectGetConfig({ electionDefinition: undefined });
   apiMock.expectGetPollsInfo();
   apiMock.mockApiClient.ejectUsbDrive.expectCallWith().resolves();


### PR DESCRIPTION
## Overview

Follow up to #5494, applied to all apps. Ensures that there's no outdated data in the cache after unconfiguring. Uses `resetQueries` instead of `clear` so that we can await the refetch of currently active queries.

Note that I couldn't update apps/mark since it caused the app to crash. I didn't look too deeply into what would need to be fixed, but since we're not currently using apps/mark, it doesn't seem worthwhile.

## Demo Video or Screenshot
N/A

## Testing Plan
Manual tested unconfigure on each app, updated automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
