### PR TITLE
allow import of candidate with same name

### DIFF
--- a/libs/types/src/cdf/election-results-reporting/fixtures.ts
+++ b/libs/types/src/cdf/election-results-reporting/fixtures.ts
@@ -78,6 +78,12 @@ export const testElectionReport: ElectionReport = {
           BallotName: asInternationalizedText('Daniel Court and Amy Blumhardt'),
           PartyId: '1',
         },
+        {
+          '@id': 'boone-lian',
+          '@type': 'ElectionResults.Candidate',
+          BallotName: asInternationalizedText('Alvin Boone and James Lian'),
+          PartyId: '1',
+        },
       ],
       Contest: [
         {
@@ -206,7 +212,21 @@ export const testElectionReport: ElectionReport = {
                 {
                   '@type': 'ElectionResults.VoteCounts',
                   GpUnitId: 'state-of-hamilton',
-                  Count: 30,
+                  Count: 25,
+                  Type: CountItemType.Total,
+                },
+              ],
+            },
+            {
+              '@type': 'ElectionResults.CandidateSelection',
+              '@id': 'council-boone-lian',
+              CandidateIds: ['boone-lian'],
+              IsWriteIn: true,
+              VoteCounts: [
+                {
+                  '@type': 'ElectionResults.VoteCounts',
+                  GpUnitId: 'state-of-hamilton',
+                  Count: 5,
                   Type: CountItemType.Total,
                 },
               ],


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/5468

Fixes a bug where CDF ERR import would hard fail if a duplicate write-in candidate was specified in its tallies. That is, if a candidate for the given `election`, `contest`, and `name` already exists in the `write_in_candidates` table (as it would when a popular 3rd party option is written in), the app would crash. 

## Demo Video or Screenshot

Before:

https://github.com/user-attachments/assets/9866a9b5-efa1-4de8-87b4-c2dc18f80424

After:


https://github.com/user-attachments/assets/b2770cfa-6ba2-4629-8e4a-7c9a051307df





## Testing Plan
- manual testing
- added test for double import

## Checklist

- [ x I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change