### PR TITLE
fix disappearing measure description

### DIFF
--- a/libs/mark-flow-ui/src/components/contest_header.tsx
+++ b/libs/mark-flow-ui/src/components/contest_header.tsx
@@ -13,16 +13,12 @@ import {
 import { Contest, District } from '@votingworks/types';
 import { MsEitherNeitherContest } from '../utils/ms_either_neither_contests';
 
-interface ContainerProps {
-  horizontalPadding?: boolean;
-}
-
 export interface ContestHeaderProps {
   breadcrumbs?: BreadcrumbMetadata;
   children?: React.ReactNode;
   contest: Contest | MsEitherNeitherContest;
   district: District;
-  styleOverrides?: ContainerProps;
+  className?: string;
 }
 
 export interface BreadcrumbMetadata {
@@ -30,8 +26,13 @@ export interface BreadcrumbMetadata {
   contestNumber: number;
 }
 
-const Container = styled.div<ContainerProps>`
-  padding: 0.25rem ${(p) => (p.horizontalPadding ? '0.5rem' : '0')} 0.5rem;
+const Container = styled.div`
+  padding: 0.25rem 0.5rem 0.5rem;
+
+  &.no-horizontal-padding {
+    padding-left: 0;
+    padding-right: 0;
+  }
 `;
 
 export function Breadcrumbs(props: BreadcrumbMetadata): React.ReactNode {
@@ -53,16 +54,10 @@ export function Breadcrumbs(props: BreadcrumbMetadata): React.ReactNode {
 }
 
 export function ContestHeader(props: ContestHeaderProps): JSX.Element {
-  const {
-    breadcrumbs,
-    children,
-    contest,
-    district,
-    styleOverrides = { horizontalPadding: true },
-  } = props;
+  const { breadcrumbs, children, contest, district, className } = props;
 
   return (
-    <Container id="contest-header" {...styleOverrides}>
+    <Container id="contest-header" className={className}>
       <ReadOnLoad>
         {/*
          * NOTE: This is visually rendered elsewhere in the screen footer, but

--- a/libs/mark-flow-ui/src/components/contest_header.tsx
+++ b/libs/mark-flow-ui/src/components/contest_header.tsx
@@ -13,11 +13,16 @@ import {
 import { Contest, District } from '@votingworks/types';
 import { MsEitherNeitherContest } from '../utils/ms_either_neither_contests';
 
+interface ContainerProps {
+  horizontalPadding?: boolean;
+}
+
 export interface ContestHeaderProps {
   breadcrumbs?: BreadcrumbMetadata;
   children?: React.ReactNode;
   contest: Contest | MsEitherNeitherContest;
   district: District;
+  styleOverrides?: ContainerProps;
 }
 
 export interface BreadcrumbMetadata {
@@ -25,8 +30,8 @@ export interface BreadcrumbMetadata {
   contestNumber: number;
 }
 
-const Container = styled.div`
-  padding: 0.25rem 0.5rem 0.5rem;
+const Container = styled.div<ContainerProps>`
+  padding: 0.25rem ${(p) => (p.horizontalPadding ? '0.5rem' : '0')} 0.5rem;
 `;
 
 export function Breadcrumbs(props: BreadcrumbMetadata): React.ReactNode {
@@ -48,10 +53,16 @@ export function Breadcrumbs(props: BreadcrumbMetadata): React.ReactNode {
 }
 
 export function ContestHeader(props: ContestHeaderProps): JSX.Element {
-  const { breadcrumbs, children, contest, district } = props;
+  const {
+    breadcrumbs,
+    children,
+    contest,
+    district,
+    styleOverrides = { horizontalPadding: true },
+  } = props;
 
   return (
-    <Container id="contest-header">
+    <Container id="contest-header" {...styleOverrides}>
       <ReadOnLoad>
         {/*
          * NOTE: This is visually rendered elsewhere in the screen footer, but

--- a/libs/mark-flow-ui/src/components/contest_screen_layout.tsx
+++ b/libs/mark-flow-ui/src/components/contest_screen_layout.tsx
@@ -5,6 +5,7 @@ export const ContestFooter = styled.div`
   width: 100%;
   padding: 0.5rem;
 `;
+
 export const ChoicesGrid = styled.div.attrs({
   'aria-multiselectable': true,
   role: 'listbox',

--- a/libs/mark-flow-ui/src/components/yes_no_contest.test.tsx
+++ b/libs/mark-flow-ui/src/components/yes_no_contest.test.tsx
@@ -50,9 +50,11 @@ test('voting for both yes and no', () => {
 
   screen.getByRole('heading', { name: contest.title });
 
-  within(screen.getByTestId(MOCK_WITH_SCROLL_BUTTONS_TEST_ID)).getByText(
-    contest.description
-  );
+  const descriptions = within(
+    screen.getByTestId(MOCK_WITH_SCROLL_BUTTONS_TEST_ID)
+  ).getAllByText(contest.description);
+  // Expect once for AudioOnly component and once for visual component
+  expect(descriptions.length).toEqual(2);
 
   const contestChoices = screen.getByTestId('contest-choices');
   userEvent.click(within(contestChoices).getByText('YES').closest('button')!);

--- a/libs/mark-flow-ui/src/components/yes_no_contest.tsx
+++ b/libs/mark-flow-ui/src/components/yes_no_contest.tsx
@@ -85,7 +85,7 @@ export function YesNoContest({
             breadcrumbs={breadcrumbs}
             contest={contest}
             district={district}
-            styleOverrides={{ horizontalPadding: false }}
+            className="no-horizontal-padding"
           >
             <Caption>
               <AudioOnly>

--- a/libs/mark-flow-ui/src/components/yes_no_contest.tsx
+++ b/libs/mark-flow-ui/src/components/yes_no_contest.tsx
@@ -80,22 +80,23 @@ export function YesNoContest({
   return (
     <React.Fragment>
       <Main flexColumn>
-        <ContestHeader
-          breadcrumbs={breadcrumbs}
-          contest={contest}
-          district={district}
-        >
-          <Caption>
-            <AudioOnly>
-              {electionStrings.contestDescription(contest)}
-              <AssistiveTechInstructions
-                controllerString={appStrings.instructionsBmdContestNavigation()}
-                patDeviceString={appStrings.instructionsBmdContestNavigationPatDevice()}
-              />
-            </AudioOnly>
-          </Caption>
-        </ContestHeader>
         <WithScrollButtons focusable={isPatDeviceConnected}>
+          <ContestHeader
+            breadcrumbs={breadcrumbs}
+            contest={contest}
+            district={district}
+            styleOverrides={{ horizontalPadding: false }}
+          >
+            <Caption>
+              <AudioOnly>
+                {electionStrings.contestDescription(contest)}
+                <AssistiveTechInstructions
+                  controllerString={appStrings.instructionsBmdContestNavigation()}
+                  patDeviceString={appStrings.instructionsBmdContestNavigationPatDevice()}
+                />
+              </AudioOnly>
+            </Caption>
+          </ContestHeader>
           <RichText>{electionStrings.contestDescription(contest)}</RichText>
         </WithScrollButtons>
         <ContestFooter>


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/5515

Fixes a bug where ballot measure description is not shown when using XL display settings.

This change always shows the contest options and allows scrolling of the measure title and description (rather than include contest options in the scroll box). I thought this was preferable because it would cut down on repetitive scrolling for voters who know how they want to vote based on contest title alone.

## Demo Video or Screenshot

**Medium**
![Screenshot 2024-10-15 at 2 58 09 PM](https://github.com/user-attachments/assets/e2c04cd5-ed0c-431a-9597-62ba4118ac77)

**Large**
![Screenshot 2024-10-15 at 3 45 45 PM](https://github.com/user-attachments/assets/51b24489-aad9-4f2f-8f07-c2da46bd0057)


**XL**
![Screenshot 2024-10-15 at 3 45 52 PM](https://github.com/user-attachments/assets/dad44893-59d3-4b70-830f-5deaa97dcd92)

**Video of scrolling behavior**

https://github.com/user-attachments/assets/11d10f2c-d81b-46b0-896f-0e88c9f895ae




## Testing Plan
* Manual testing

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
