### PR TITLE
allow system admin to access system even in hardware error states

### DIFF
--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -351,23 +351,11 @@ export function AppRoot(): JSX.Element | null {
   const machineConfig = machineConfigQuery.data;
   const usbDriveStatus = usbDriveStatusQuery.data;
 
-  if (stateMachineState === 'unrecoverable_error') {
-    return <UnrecoverableErrorPage />;
-  }
-
   if (
     authStatus.status === 'logged_out' &&
     authStatus.reason === 'no_card_reader'
   ) {
     return <SetupCardReaderPage />;
-  }
-
-  if (stateMachineState === 'cover_open_unauthorized') {
-    return <ScannerOpenAlarmScreen />;
-  }
-
-  if (stateMachineState === 'no_hardware') {
-    return <NoPaperHandlerPage />;
   }
 
   if (authStatus.status === 'checking_pin') {
@@ -414,6 +402,18 @@ export function AppRoot(): JSX.Element | null {
         usbDriveStatus={usbDriveStatus}
       />
     );
+  }
+
+  if (stateMachineState === 'unrecoverable_error') {
+    return <UnrecoverableErrorPage />;
+  }
+
+  if (stateMachineState === 'cover_open_unauthorized') {
+    return <ScannerOpenAlarmScreen />;
+  }
+
+  if (stateMachineState === 'no_hardware') {
+    return <NoPaperHandlerPage />;
   }
 
   if (isElectionManagerAuth(authStatus)) {


### PR DESCRIPTION
## Overview

Closes #5523. Allows the vendor and system admin screens to be accessed in hardware error states.