### PR TITLE
[BMD] Provide clearer audio feedback after using all votes in a contest

### DIFF
--- a/libs/mark-flow-ui/src/components/candidate_contest.tsx
+++ b/libs/mark-flow-ui/src/components/candidate_contest.tsx
@@ -277,19 +277,21 @@ export function CandidateContest({
               }
               let prefixAudioText: ReactNode = null;
               let suffixAudioText: ReactNode = null;
+
+              const numVotesRemaining = contest.seats - vote.length;
               if (isChecked) {
                 prefixAudioText = appStrings.labelSelected();
 
                 if (recentlySelectedCandidate === candidate.id) {
-                  suffixAudioText = (
-                    <React.Fragment>
-                      {appStrings.labelNumVotesRemaining()}{' '}
-                      <NumberString
-                        value={contest.seats - vote.length}
-                        weight="bold"
-                      />
-                    </React.Fragment>
-                  );
+                  suffixAudioText =
+                    numVotesRemaining > 0 ? (
+                      <React.Fragment>
+                        {appStrings.labelNumVotesRemaining()}{' '}
+                        <NumberString value={numVotesRemaining} weight="bold" />
+                      </React.Fragment>
+                    ) : (
+                      appStrings.noteBmdContestCompleted()
+                    );
                 }
               } else if (recentlyDeselectedCandidate === candidate.id) {
                 prefixAudioText = appStrings.labelDeselected();
@@ -297,10 +299,7 @@ export function CandidateContest({
                 suffixAudioText = (
                   <React.Fragment>
                     {appStrings.labelNumVotesRemaining()}{' '}
-                    <NumberString
-                      value={contest.seats - vote.length}
-                      weight="bold"
-                    />
+                    <NumberString value={numVotesRemaining} weight="bold" />
                   </React.Fragment>
                 );
               }

--- a/libs/mark-flow-ui/src/components/yes_no_contest.test.tsx
+++ b/libs/mark-flow-ui/src/components/yes_no_contest.test.tsx
@@ -109,7 +109,9 @@ test('audio cue for vote', () => {
   );
 
   // now the choice is selected
-  getOption(/Selected.+Ballot Measure 3.+yes/i);
+  getOption(
+    /Selected.+Ballot Measure 3.+yes.*you've completed your selections/i
+  );
 
   // unselect the choice
   userEvent.click(yesButton);

--- a/libs/mark-flow-ui/src/components/yes_no_contest.tsx
+++ b/libs/mark-flow-ui/src/components/yes_no_contest.tsx
@@ -108,8 +108,10 @@ export function YesNoContest({
                 handleChangeVoteAlert(option.id);
               }
               let prefixAudioText: ReactNode = null;
+              let suffixAudioText: ReactNode = null;
               if (isChecked) {
                 prefixAudioText = appStrings.labelSelectedOption();
+                suffixAudioText = appStrings.noteBmdContestCompleted();
               } else if (deselectedVote === option.id) {
                 prefixAudioText = appStrings.labelDeselectedOption();
               }
@@ -128,6 +130,7 @@ export function YesNoContest({
                         {electionStrings.contestTitle(contest)} |{' '}
                       </AudioOnly>
                       {electionStrings.contestOptionLabel(option)}
+                      <AudioOnly>{suffixAudioText}</AudioOnly>
                     </React.Fragment>
                   }
                 />

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -919,6 +919,14 @@ export const appStrings = {
     <UiString uiStringKey="noteBmdClearingBallot">Clearing ballot</UiString>
   ),
 
+  noteBmdContestCompleted: () => (
+    <UiString uiStringKey="noteBmdContestCompleted">
+      You've completed your selections on this contest. Press the right arrow
+      button to advance to the next contest. You may continue navigating in this
+      contest to change your selections."
+    </UiString>
+  ),
+
   noteBmdEitherNeitherNoSelection: () => (
     <UiString uiStringKey="noteBmdEitherNeitherNoSelection">
       First, vote "for either" or "against both". Then select your preferred

--- a/libs/ui/src/ui_strings/app_strings_catalog/latest.json
+++ b/libs/ui/src/ui_strings/app_strings_catalog/latest.json
@@ -182,6 +182,7 @@
   "noteBmdBallotSheetLoaded": "The ballot sheet has been loaded. You will have a chance to review your selections before reprinting your ballot.",
   "noteBmdCastingBallot": "Casting Ballot...",
   "noteBmdClearingBallot": "Clearing ballot",
+  "noteBmdContestCompleted": "You've completed your selections on this contest. Press the right arrow button to advance to the next contest. You may continue navigating in this contest to change your selections.\"",
   "noteBmdEitherNeitherNoSelection": "First, vote \"for either\" or \"against both\". Then select your preferred measure.",
   "noteBmdEitherNeitherSelectedEither": "You have selected \"for either\". <2>Now select your preferred measure.</2>",
   "noteBmdEitherNeitherSelectedEitherAndPreferred": "You have selected \"for either\" and your preferred measure.",


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/5315

When voters make a selection, we play audio reading out the number of remaining votes.
This updates that audio when the final available selection in a contest is made, to make it clearer that the voter can advance to the next contest.

## Demo Video or Screenshot [ 🔊 ]

https://github.com/user-attachments/assets/75eb5040-db3d-4d6a-aa05-80e78d632d1b

## Testing Plan
- Unit tests and manual verification with generated audio

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
