### PR TITLE
Update log export filenames to use locale timestamps instead of UTC

### DIFF
--- a/libs/backend/src/system_call/export_logs_to_usb.ts
+++ b/libs/backend/src/system_call/export_logs_to_usb.ts
@@ -14,6 +14,7 @@ import { createReadStream, createWriteStream } from 'node:fs';
 import { pipeline } from 'node:stream/promises';
 import { createGunzip, createGzip } from 'node:zlib';
 import { dirSync } from 'tmp';
+import { generateFileTimeSuffix } from '@votingworks/utils';
 import { execFile } from '../exec';
 
 const LOG_DIR = '/var/log/votingworks';
@@ -129,8 +130,7 @@ async function exportLogsToUsbHelper({
 
   const machineNamePath = join(status.mountPoint, `/logs/machine_${machineId}`);
 
-  const dateString = new Date().toISOString().replaceAll(':', '-');
-  const destinationDirectory = join(machineNamePath, dateString);
+  const destinationDirectory = join(machineNamePath, generateFileTimeSuffix());
   const tempDirectory = dirSync().name;
 
   switch (format) {


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/5346

To avoid user confusion, this updates filenames on log export directories to reflect the date/time in the locale of the machine they were saved from, instead of using the UTC date/time, which might not match the day of the election at first glance.

Initially went with a format that included the timezone code at the end, but later found the utility used for our CVR exports, so just using that to be consistent.

## Demo Video or Screenshot

![Screenshot 2024-10-23 at 15 45 18](https://github.com/user-attachments/assets/b8c0d954-dc81-4c8a-af3f-d83059369e35)

## Testing Plan
- Tried out a logs export on MarkScan before and after the change.

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
