### PR TITLE
Add vertical streak detection controls

### DIFF
--- a/apps/central-scan/backend/src/importer.ts
+++ b/apps/central-scan/backend/src/importer.ts
@@ -195,6 +195,8 @@ export class Importer {
           electionDefinition,
           precinctSelection: ALL_PRECINCTS_SELECTION,
           testMode: store.getTestMode(),
+          disableVerticalStreakDetection:
+            store.isVerticalStreakDetectionDisabled(),
           adjudicationReasons: store.getAdjudicationReasons(),
           markThresholds: store.getMarkThresholds(),
           allowOfficialBallotsInTestMode: assertDefined(

--- a/apps/central-scan/backend/src/importer.ts
+++ b/apps/central-scan/backend/src/importer.ts
@@ -188,6 +188,11 @@ export class Importer {
   ): Promise<Result<SheetOf<PageInterpretationWithFiles>, Error>> {
     const electionDefinition = this.getElectionDefinition();
     const { store } = this.workspace;
+    const {
+      allowOfficialBallotsInTestMode,
+      disableVerticalStreakDetection,
+      markThresholds,
+    } = assertDefined(store.getSystemSettings());
 
     return ok(
       await interpretSheetAndSaveImages(
@@ -195,13 +200,10 @@ export class Importer {
           electionDefinition,
           precinctSelection: ALL_PRECINCTS_SELECTION,
           testMode: store.getTestMode(),
-          disableVerticalStreakDetection:
-            store.isVerticalStreakDetectionDisabled(),
+          disableVerticalStreakDetection,
           adjudicationReasons: store.getAdjudicationReasons(),
-          markThresholds: store.getMarkThresholds(),
-          allowOfficialBallotsInTestMode: assertDefined(
-            store.getSystemSettings()
-          ).allowOfficialBallotsInTestMode,
+          markThresholds,
+          allowOfficialBallotsInTestMode,
         },
         [frontImageData, backImageData],
         sheetId,

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -392,6 +392,14 @@ export class Store {
   }
 
   /**
+   * Gets the current setting of {@link SystemSettings.disableVerticalStreakDetection},
+   * if present.
+   */
+  isVerticalStreakDetectionDisabled(): boolean | undefined {
+    return this.getSystemSettings()?.disableVerticalStreakDetection;
+  }
+
+  /**
    * Gets the current precinct `scan` is accepting ballots for. If set to
    * `undefined`, ballots from all precincts will be accepted (this is the
    * default).

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -10,7 +10,6 @@ import {
   BatchInfo,
   Iso8601Timestamp,
   mapSheet,
-  MarkThresholds,
   PageInterpretationSchema,
   PageInterpretationWithFiles,
   PollsState as PollsStateType,
@@ -382,21 +381,9 @@ export class Store {
     );
   }
 
-  getMarkThresholds(): MarkThresholds {
-    return assertDefined(this.getSystemSettings()).markThresholds;
-  }
-
   getAdjudicationReasons(): readonly AdjudicationReason[] {
     return assertDefined(this.getSystemSettings())
       .centralScanAdjudicationReasons;
-  }
-
-  /**
-   * Gets the current setting of {@link SystemSettings.disableVerticalStreakDetection},
-   * if present.
-   */
-  isVerticalStreakDetectionDisabled(): boolean | undefined {
-    return this.getSystemSettings()?.disableVerticalStreakDetection;
   }
 
   /**

--- a/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
@@ -156,6 +156,7 @@ export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
 
   let isOvervotedSheet = false;
   let isUndervotedSheet = false;
+  let verticalStreaksDetected = false;
   let isFrontBlank = false;
   let isBackBlank = false;
   let isInvalidTestModeSheet = false;
@@ -186,7 +187,12 @@ export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
         reviewInfo.interpreted.back.adjudicationFinishedAt,
     },
   ]) {
-    if (reviewPageInfo.interpretation.type === 'InvalidTestModePage') {
+    if (
+      reviewPageInfo.interpretation.type === 'UnreadablePage' &&
+      reviewPageInfo.interpretation.reason === 'verticalStreaksDetected'
+    ) {
+      verticalStreaksDetected = true;
+    } else if (reviewPageInfo.interpretation.type === 'InvalidTestModePage') {
       isInvalidTestModeSheet = true;
     } else if (reviewPageInfo.interpretation.type === 'InvalidBallotHashPage') {
       isInvalidBallotHashSheet = true;
@@ -233,6 +239,22 @@ export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
   }
 
   const ejectInfo: EjectInformation = (() => {
+    if (verticalStreaksDetected) {
+      return {
+        header: 'Streak Detected',
+        body: (
+          <React.Fragment>
+            <P>
+              The last scanned ballot was not tabulated because the scanner
+              needs to be cleaned.
+            </P>
+            <P>Clean the scanner before continuing to scan ballots.</P>
+          </React.Fragment>
+        ),
+        allowBallotDuplication: false,
+      };
+    }
+
     if (isInvalidTestModeSheet) {
       return isTestMode
         ? {

--- a/apps/scan/backend/src/app_scanning.test.ts
+++ b/apps/scan/backend/src/app_scanning.test.ts
@@ -1,0 +1,132 @@
+import { electionGridLayoutNewHampshireTestBallotFixtures } from '@votingworks/fixtures';
+import { DEFAULT_SYSTEM_SETTINGS } from '@votingworks/types';
+import {
+  BooleanEnvironmentVariableName,
+  getFeatureFlagMock,
+} from '@votingworks/utils';
+import { simulateScan, withApp } from '../test/helpers/pdi_helpers';
+import { configureApp, waitForStatus } from '../test/helpers/shared_helpers';
+import { delays } from './scanners/pdi/state_machine';
+
+const mockFeatureFlagger = getFeatureFlagMock();
+
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
+  return {
+    ...jest.requireActual('@votingworks/utils'),
+    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+  };
+});
+
+beforeEach(() => {
+  mockFeatureFlagger.resetFeatureFlags();
+  mockFeatureFlagger.enableFeatureFlag(
+    BooleanEnvironmentVariableName.SKIP_ELECTION_PACKAGE_AUTHENTICATION
+  );
+});
+
+test('scanBatch with streaked page', async () => {
+  const { scanMarkedFront, scanMarkedBack } =
+    electionGridLayoutNewHampshireTestBallotFixtures;
+
+  const frontImageData = await scanMarkedFront.asImageData();
+  const backImageData = await scanMarkedBack.asImageData();
+
+  // add a vertical streak
+  for (
+    let offset = 500;
+    offset < frontImageData.data.length;
+    offset += frontImageData.width * 4
+  ) {
+    frontImageData.data[offset] = 0;
+    frontImageData.data[offset + 1] = 0;
+    frontImageData.data[offset + 2] = 0;
+    frontImageData.data[offset + 3] = 255;
+  }
+
+  // try with vertical streak detection enabled
+  await withApp(
+    async ({
+      apiClient,
+      clock,
+      mockAuth,
+      mockScanner,
+      mockUsbDrive,
+      workspace,
+    }) => {
+      await configureApp(apiClient, mockAuth, mockUsbDrive, {
+        electionPackage:
+          electionGridLayoutNewHampshireTestBallotFixtures.electionJson.toElectionPackage(),
+        testMode: true,
+      });
+
+      workspace.store.setSystemSettings({
+        ...DEFAULT_SYSTEM_SETTINGS,
+        // enable vertical streak detection
+        disableVerticalStreakDetection: false,
+      });
+
+      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
+      await waitForStatus(apiClient, { state: 'no_paper' });
+      expect(mockScanner.client.enableScanning).toHaveBeenCalledWith({
+        doubleFeedDetectionEnabled: true,
+        paperLengthInches: 11,
+      });
+
+      await simulateScan(apiClient, mockScanner, [
+        frontImageData,
+        backImageData,
+      ]);
+
+      await waitForStatus(apiClient, {
+        state: 'rejecting',
+        interpretation: {
+          type: 'InvalidSheet',
+          reason: 'vertical_streaks_detected',
+        },
+      });
+    }
+  );
+
+  // try again with vertical streak detection disabled
+  await withApp(
+    async ({
+      apiClient,
+      clock,
+      mockAuth,
+      mockScanner,
+      mockUsbDrive,
+      workspace,
+    }) => {
+      await configureApp(apiClient, mockAuth, mockUsbDrive, {
+        electionPackage:
+          electionGridLayoutNewHampshireTestBallotFixtures.electionJson.toElectionPackage(),
+        testMode: true,
+      });
+
+      workspace.store.setSystemSettings({
+        ...DEFAULT_SYSTEM_SETTINGS,
+        // disable vertical streak detection
+        disableVerticalStreakDetection: true,
+      });
+
+      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
+      await waitForStatus(apiClient, { state: 'no_paper' });
+      expect(mockScanner.client.enableScanning).toHaveBeenCalledWith({
+        doubleFeedDetectionEnabled: true,
+        paperLengthInches: 11,
+      });
+
+      await simulateScan(apiClient, mockScanner, [
+        frontImageData,
+        backImageData,
+      ]);
+
+      await waitForStatus(apiClient, {
+        state: 'accepting',
+        interpretation: {
+          type: 'ValidSheet',
+        },
+      });
+    }
+  );
+});

--- a/apps/scan/backend/src/scanners/custom/state_machine.ts
+++ b/apps/scan/backend/src/scanners/custom/state_machine.ts
@@ -309,6 +309,7 @@ async function interpretSheet(
         .electionDefinition,
       precinctSelection: assertDefined(store.getPrecinctSelection()),
       testMode: store.getTestMode(),
+      disableVerticalStreakDetection: store.isVerticalStreakDetectionDisabled(),
       ballotImagesPath: workspace.ballotImagesPath,
       markThresholds: store.getMarkThresholds(),
       adjudicationReasons: store.getAdjudicationReasons(),

--- a/apps/scan/backend/src/scanners/custom/state_machine.ts
+++ b/apps/scan/backend/src/scanners/custom/state_machine.ts
@@ -303,15 +303,18 @@ async function interpretSheet(
   assert(scannedSheet);
   const sheetId = uuid();
   const { store } = workspace;
+  const { disableVerticalStreakDetection, markThresholds } = assertDefined(
+    store.getSystemSettings()
+  );
   const interpretation = (
     await interpret(sheetId, scannedSheet, {
       electionDefinition: assertDefined(store.getElectionRecord())
         .electionDefinition,
       precinctSelection: assertDefined(store.getPrecinctSelection()),
       testMode: store.getTestMode(),
-      disableVerticalStreakDetection: store.isVerticalStreakDetectionDisabled(),
+      disableVerticalStreakDetection,
       ballotImagesPath: workspace.ballotImagesPath,
-      markThresholds: store.getMarkThresholds(),
+      markThresholds,
       adjudicationReasons: store.getAdjudicationReasons(),
     })
   ).unsafeUnwrap();

--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -69,6 +69,7 @@ async function interpretSheet(
         .electionDefinition,
       precinctSelection: assertDefined(store.getPrecinctSelection()),
       testMode: store.getTestMode(),
+      disableVerticalStreakDetection: store.isVerticalStreakDetectionDisabled(),
       ballotImagesPath: workspace.ballotImagesPath,
       markThresholds: store.getMarkThresholds(),
       adjudicationReasons: store.getAdjudicationReasons(),

--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -63,18 +63,22 @@ async function interpretSheet(
   const { store } = workspace;
 
   const interpretTimer = time(debug, 'interpret');
+  const {
+    allowOfficialBallotsInTestMode,
+    disableVerticalStreakDetection,
+    markThresholds,
+  } = assertDefined(store.getSystemSettings());
   const interpretation = (
     await interpret(sheetId, scanImages, {
       electionDefinition: assertDefined(store.getElectionRecord())
         .electionDefinition,
       precinctSelection: assertDefined(store.getPrecinctSelection()),
       testMode: store.getTestMode(),
-      disableVerticalStreakDetection: store.isVerticalStreakDetectionDisabled(),
+      disableVerticalStreakDetection,
       ballotImagesPath: workspace.ballotImagesPath,
-      markThresholds: store.getMarkThresholds(),
+      markThresholds,
       adjudicationReasons: store.getAdjudicationReasons(),
-      allowOfficialBallotsInTestMode: assertDefined(store.getSystemSettings())
-        .allowOfficialBallotsInTestMode,
+      allowOfficialBallotsInTestMode,
     })
   ).unsafeUnwrap();
   interpretTimer.end();

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -432,6 +432,14 @@ export class Store {
   }
 
   /**
+   * Gets the current setting of {@link SystemSettings.disableVerticalStreakDetection},
+   * if present.
+   */
+  isVerticalStreakDetectionDisabled(): boolean | undefined {
+    return this.getSystemSettings()?.disableVerticalStreakDetection;
+  }
+
+  /**
    * Gets the current precinct `scan` is accepting ballots for. If set to
    * `undefined`, ballots from all precincts will be accepted (this is the
    * default).

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -10,7 +10,6 @@ import {
   BatchInfo,
   Iso8601Timestamp,
   mapSheet,
-  MarkThresholds,
   PageInterpretationSchema,
   PageInterpretationWithFiles,
   PollsState as PollsStateType,
@@ -422,21 +421,9 @@ export class Store {
     );
   }
 
-  getMarkThresholds(): MarkThresholds {
-    return assertDefined(this.getSystemSettings()).markThresholds;
-  }
-
   getAdjudicationReasons(): readonly AdjudicationReason[] {
     return assertDefined(this.getSystemSettings())
       .precinctScanAdjudicationReasons;
-  }
-
-  /**
-   * Gets the current setting of {@link SystemSettings.disableVerticalStreakDetection},
-   * if present.
-   */
-  isVerticalStreakDetectionDisabled(): boolean | undefined {
-    return this.getSystemSettings()?.disableVerticalStreakDetection;
   }
 
   /**

--- a/libs/backend/src/cast_vote_records/export.ts
+++ b/libs/backend/src/cast_vote_records/export.ts
@@ -81,7 +81,6 @@ export interface ScannerStoreBase {
   getCastVoteRecordRootHash(): string;
   getElectionRecord(): ElectionRecord | undefined;
   getSystemSettings(): SystemSettings | undefined;
-  getMarkThresholds(): MarkThresholds;
   getTestMode(): boolean;
   updateCastVoteRecordHashes(
     castVoteRecordId: string,
@@ -696,6 +695,7 @@ export async function exportCastVoteRecordsToUsbDrive(
   if (usbMountPoint === undefined) {
     return err({ type: 'missing-usb-drive' });
   }
+  const systemSettings = assertDefined(scannerStore.getSystemSettings());
   const exportContext: ExportContext = {
     exporter: new Exporter({
       allowedExportPatterns: SCAN_ALLOWED_EXPORT_PATTERNS,
@@ -706,9 +706,9 @@ export async function exportCastVoteRecordsToUsbDrive(
       batches: scannerStore.getBatches(),
       electionDefinition: assertDefined(scannerStore.getElectionRecord())
         .electionDefinition,
-      systemSettings: assertDefined(scannerStore.getSystemSettings()),
+      systemSettings,
       inTestMode: scannerStore.getTestMode(),
-      markThresholds: scannerStore.getMarkThresholds(),
+      markThresholds: systemSettings.markThresholds,
       pollsState:
         scannerStore.scannerType === 'precinct'
           ? scannerStore.getPollsState()

--- a/libs/ballot-interpreter/src/hmpb-rust/js/args.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/js/args.rs
@@ -33,10 +33,9 @@ pub fn get_image_data_or_path_from_arg(
         let path = path.value(&mut *cx);
         Ok(ImageSource::Path(PathBuf::from(path)))
     } else if let Ok(image_data) = argument.downcast::<JsObject, _>(cx) {
-        ImageData::from_js_object(cx, image_data).map_or_else(
-            || cx.throw_type_error("unable to read argument as ImageData"),
-            |image| Ok(ImageSource::ImageData(image)),
-        )
+        Ok(ImageSource::ImageData(ImageData::from_js_object(
+            cx, image_data,
+        )?))
     } else {
         cx.throw_type_error("expected image data or path")
     }

--- a/libs/ballot-interpreter/src/hmpb-rust/js/image_data.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/js/image_data.rs
@@ -35,19 +35,18 @@ impl ImageData {
     }
 
     /// Converts a JavaScript `ImageData` object to a Rust `ImageData`.
-    pub fn from_js_object(cx: &mut FunctionContext, js_object: Handle<JsObject>) -> Option<Self> {
-        let width = js_object.get::<JsNumber, _, _>(cx, "width").ok()?.value(cx) as u32;
-        let height = js_object
-            .get::<JsNumber, _, _>(cx, "height")
-            .ok()?
-            .value(cx) as u32;
+    pub fn from_js_object(
+        cx: &mut FunctionContext,
+        js_object: Handle<JsObject>,
+    ) -> NeonResult<Self> {
+        let width = js_object.get::<JsNumber, _, _>(cx, "width")?.value(cx) as u32;
+        let height = js_object.get::<JsNumber, _, _>(cx, "height")?.value(cx) as u32;
         let data = js_object
-            .get::<JsBuffer, _, _>(cx, "data")
-            .ok()?
+            .get::<JsBuffer, _, _>(cx, "data")?
             .borrow()
             .as_slice(cx)
             .to_vec();
-        Some(Self::new(width, height, data))
+        Ok(Self::new(width, height, data))
     }
 
     pub fn to_js_object<'a>(&self, cx: &mut FunctionContext<'a>) -> JsResult<'a, JsObject> {

--- a/libs/ballot-interpreter/src/hmpb-rust/js/mod.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/js/mod.rs
@@ -54,13 +54,22 @@ pub fn interpret(mut cx: FunctionContext) -> JsResult<JsObject> {
     let side_b_image_or_path = get_image_data_or_path_from_arg(&mut cx, 2)?;
     let debug_side_a_base = get_path_from_arg_opt(&mut cx, 3);
     let debug_side_b_base = get_path_from_arg_opt(&mut cx, 4);
+
+    // Equivalent to:
+    //   let options = typeof arguments[5] === 'object' ? arguments[5] : {};
     let options = match cx.argument_opt(5) {
         Some(arg) => arg.downcast::<JsObject, _>(&mut cx).or_throw(&mut cx)?,
         None => cx.empty_object(),
     };
 
+    // Equivalent to:
+    //   let score_write_ins =
+    //     typeof options.scoreWriteIns === 'boolean'
+    //     ? options.scoreWriteIns
+    //     : false;
     let score_write_ins = options
-        .get::<JsBoolean, _, _>(&mut cx, "scoreWriteIns")
+        .get_value(&mut cx, "scoreWriteIns")?
+        .downcast::<JsBoolean, _>(&mut cx)
         .ok()
         .map_or(false, |b| b.value(&mut cx));
 

--- a/libs/ballot-interpreter/src/hmpb-rust/js/mod.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/js/mod.rs
@@ -73,6 +73,17 @@ pub fn interpret(mut cx: FunctionContext) -> JsResult<JsObject> {
         .ok()
         .map_or(false, |b| b.value(&mut cx));
 
+    // Equivalent to:
+    //   let disable_vertical_streak_detection =
+    //     typeof options.disableVerticalStreakDetection === 'boolean'
+    //     ? options.disableVerticalStreakDetection
+    //     : false;
+    let disable_vertical_streak_detection = options
+        .get_value(&mut cx, "disableVerticalStreakDetection")?
+        .downcast::<JsBoolean, _>(&mut cx)
+        .ok()
+        .map_or(false, |b| b.value(&mut cx));
+
     let side_a_label = side_a_image_or_path.as_label_or(SIDE_A_LABEL);
     let side_b_label = side_b_image_or_path.as_label_or(SIDE_B_LABEL);
     let (side_a_image, side_b_image) = rayon::join(
@@ -105,6 +116,7 @@ pub fn interpret(mut cx: FunctionContext) -> JsResult<JsObject> {
             debug_side_a_base,
             debug_side_b_base,
             score_write_ins,
+            disable_vertical_streak_detection,
         },
     );
 

--- a/libs/ballot-interpreter/src/hmpb-ts/cli.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/cli.ts
@@ -48,14 +48,19 @@ function usage(out: NodeJS.WritableStream): void {
   );
   out.write(`\n`);
   out.write(chalk.bold(`Options:\n`));
-  out.write('  -h, --help       Show this help text.\n');
-  out.write('  -w, --write-ins  Score write-in areas.\n');
-  out.write(`  -j, --json       Output JSON instead of human-readable text.\n`);
+  out.write('  -h, --help                Show this help text.\n');
+  out.write('  -w, --write-ins           Score write-in areas.\n');
   out.write(
-    `  -d, --debug  Output debug information (images alongside inputs).\n`
+    `  -j, --json                Output JSON instead of human-readable text.\n`
   );
   out.write(
-    '  --default-mark-thresholds  Use default mark thresholds if none provided.\n'
+    `  -d, --debug               Output debug information (images alongside inputs).\n`
+  );
+  out.write(
+    '  --default-mark-thresholds           Use default mark thresholds if none provided.\n'
+  );
+  out.write(
+    '  --disable-vertical-streak-detection Disable vertical streak detection.\n'
   );
   out.write(`\n`);
   out.write(chalk.bold('Examples:\n'));
@@ -215,7 +220,13 @@ async function interpretFiles(
   const result = interpret(
     electionDefinition,
     [ballotPathSideA, ballotPathSideB],
-    { scoreWriteIns, disableVerticalStreakDetection, debug }
+    {
+      scoreWriteIns,
+      disableVerticalStreakDetection:
+        disableVerticalStreakDetection ??
+        systemSettings?.disableVerticalStreakDetection,
+      debug,
+    }
   );
 
   if (result.isErr()) {
@@ -348,6 +359,7 @@ async function interpretWorkspace(
     stderr,
     sheetIds,
     scoreWriteIns = false,
+    disableVerticalStreakDetection,
     json = false,
     debug = false,
     useDefaultMarkThresholds = false,
@@ -356,6 +368,7 @@ async function interpretWorkspace(
     stderr: NodeJS.WritableStream;
     sheetIds: Iterable<string>;
     scoreWriteIns?: boolean;
+    disableVerticalStreakDetection?: boolean;
     json?: boolean;
     debug?: boolean;
     useDefaultMarkThresholds?: boolean;
@@ -453,7 +466,15 @@ async function interpretWorkspace(
       electionDefinition,
       systemSettings,
       correctionResult.ok(),
-      { stdout, stderr, scoreWriteIns, json, debug, useDefaultMarkThresholds }
+      {
+        stdout,
+        stderr,
+        scoreWriteIns,
+        disableVerticalStreakDetection,
+        json,
+        debug,
+        useDefaultMarkThresholds,
+      }
     );
 
     count += 1;
@@ -479,6 +500,7 @@ async function interpretCastVoteRecordFolder(
     stdout,
     stderr,
     scoreWriteIns = false,
+    disableVerticalStreakDetection,
     json = false,
     debug = false,
     useDefaultMarkThresholds = false,
@@ -486,6 +508,7 @@ async function interpretCastVoteRecordFolder(
     stdout: NodeJS.WritableStream;
     stderr: NodeJS.WritableStream;
     scoreWriteIns?: boolean;
+    disableVerticalStreakDetection?: boolean;
     json?: boolean;
     debug?: boolean;
     useDefaultMarkThresholds?: boolean;
@@ -514,6 +537,7 @@ async function interpretCastVoteRecordFolder(
             stdout,
             stderr,
             scoreWriteIns,
+            disableVerticalStreakDetection,
             json,
             debug,
             useDefaultMarkThresholds,
@@ -537,6 +561,7 @@ export async function main(args: string[], io: IO = process): Promise<number> {
   let ballotPathSideA: string | undefined;
   let ballotPathSideB: string | undefined;
   let scoreWriteIns: boolean | undefined;
+  let disableVerticalStreakDetection: boolean | undefined;
   let json = false;
   let debug = false;
   let useDefaultMarkThresholds = false;
@@ -564,6 +589,11 @@ export async function main(args: string[], io: IO = process): Promise<number> {
 
     if (arg === '--default-mark-thresholds') {
       useDefaultMarkThresholds = true;
+      continue;
+    }
+
+    if (arg === '--disable-vertical-streak-detection') {
+      disableVerticalStreakDetection = true;
       continue;
     }
 
@@ -629,6 +659,7 @@ export async function main(args: string[], io: IO = process): Promise<number> {
       stderr: io.stderr,
       json,
       scoreWriteIns,
+      disableVerticalStreakDetection,
       debug,
       useDefaultMarkThresholds,
     });
@@ -676,6 +707,7 @@ export async function main(args: string[], io: IO = process): Promise<number> {
           stdout: io.stdout,
           stderr: io.stderr,
           scoreWriteIns,
+          disableVerticalStreakDetection,
           json,
           debug,
           useDefaultMarkThresholds,
@@ -691,6 +723,7 @@ export async function main(args: string[], io: IO = process): Promise<number> {
           stdout: io.stdout,
           stderr: io.stderr,
           scoreWriteIns,
+          disableVerticalStreakDetection,
           json,
           debug,
           useDefaultMarkThresholds,

--- a/libs/ballot-interpreter/src/hmpb-ts/cli.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/cli.ts
@@ -197,7 +197,8 @@ async function interpretFiles(
   {
     stdout,
     stderr,
-    scoreWriteIns = false,
+    scoreWriteIns,
+    disableVerticalStreakDetection,
     json = false,
     debug = false,
     useDefaultMarkThresholds = false,
@@ -205,6 +206,7 @@ async function interpretFiles(
     stdout: NodeJS.WritableStream;
     stderr: NodeJS.WritableStream;
     scoreWriteIns?: boolean;
+    disableVerticalStreakDetection?: boolean;
     json?: boolean;
     debug?: boolean;
     useDefaultMarkThresholds?: boolean;
@@ -213,7 +215,7 @@ async function interpretFiles(
   const result = interpret(
     electionDefinition,
     [ballotPathSideA, ballotPathSideB],
-    { scoreWriteIns, debug }
+    { scoreWriteIns, disableVerticalStreakDetection, debug }
   );
 
   if (result.isErr()) {

--- a/libs/ballot-interpreter/src/hmpb-ts/interpret.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/interpret.ts
@@ -38,8 +38,16 @@ function normalizeArgumentsForBridge(
   electionDefinition: ElectionDefinition,
   ballotImageSources: SheetOf<string> | SheetOf<ImageData>,
   options:
-    | { scoreWriteIns?: boolean; debug?: boolean }
-    | { scoreWriteIns?: boolean; debugBasePaths?: SheetOf<string> }
+    | {
+        scoreWriteIns?: boolean;
+        disableVerticalStreakDetection?: boolean;
+        debug?: boolean;
+      }
+    | {
+        scoreWriteIns?: boolean;
+        disableVerticalStreakDetection?: boolean;
+        debugBasePaths?: SheetOf<string>;
+      } = {}
 ): Parameters<typeof interpretImpl> {
   assert(typeof electionDefinition.electionData === 'string');
   assert(ballotImageSources.length === 2);
@@ -66,7 +74,10 @@ function normalizeArgumentsForBridge(
     ...ballotImageSources,
     debugBasePathSideA,
     debugBasePathSideB,
-    { scoreWriteIns: options.scoreWriteIns ?? false },
+    {
+      scoreWriteIns: options.scoreWriteIns,
+      disableVerticalStreakDetection: options.disableVerticalStreakDetection,
+    },
   ];
 }
 
@@ -76,7 +87,11 @@ function normalizeArgumentsForBridge(
 export function interpret(
   electionDefinition: ElectionDefinition,
   ballotImagePaths: SheetOf<string>,
-  options?: { scoreWriteIns?: boolean; debug?: boolean }
+  options?: {
+    scoreWriteIns?: boolean;
+    disableVerticalStreakDetection?: boolean;
+    debug?: boolean;
+  }
 ): HmpbInterpretResult;
 /**
  * Interprets a scanned ballot.
@@ -84,7 +99,11 @@ export function interpret(
 export function interpret(
   electionDefinition: ElectionDefinition,
   ballotImages: SheetOf<ImageData>,
-  options?: { scoreWriteIns?: boolean; debugBasePaths?: SheetOf<string> }
+  options?: {
+    scoreWriteIns?: boolean;
+    disableVerticalStreakDetection?: boolean;
+    debugBasePaths?: SheetOf<string>;
+  }
 ): HmpbInterpretResult;
 /**
  * Interprets a scanned ballot.
@@ -92,9 +111,17 @@ export function interpret(
 export function interpret(
   electionDefinition: ElectionDefinition,
   ballotImageSources: SheetOf<string> | SheetOf<ImageData>,
-  options:
-    | { scoreWriteIns?: boolean; debug?: boolean }
-    | { scoreWriteIns?: boolean; debugBasePaths?: SheetOf<string> } = {}
+  options?:
+    | {
+        scoreWriteIns?: boolean;
+        disableVerticalStreakDetection?: boolean;
+        debug?: boolean;
+      }
+    | {
+        scoreWriteIns?: boolean;
+        disableVerticalStreakDetection?: boolean;
+        debugBasePaths?: SheetOf<string>;
+      }
 ): HmpbInterpretResult {
   const args = normalizeArgumentsForBridge(
     electionDefinition,

--- a/libs/ballot-interpreter/src/hmpb-ts/rust_addon.d.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/rust_addon.d.ts
@@ -28,7 +28,10 @@ export function interpret(
   ballotImageSourceSideB: string | ImageData,
   debugBasePathSideA?: string,
   debugBasePathSideB?: string,
-  options?: { scoreWriteIns?: boolean }
+  options?: {
+    scoreWriteIns?: boolean;
+    disableVerticalStreakDetection?: boolean;
+  }
 ): BridgeInterpretResult;
 
 /**

--- a/libs/ballot-interpreter/src/interpret.ts
+++ b/libs/ballot-interpreter/src/interpret.ts
@@ -614,6 +614,7 @@ function interpretHmpb(
   const { electionDefinition } = options;
   const result = interpretHmpbBallotSheetRust(electionDefinition, sheet, {
     scoreWriteIns: shouldScoreWriteIns(options),
+    disableVerticalStreakDetection: options.disableVerticalStreakDetection,
   });
 
   return validateInterpretResults(

--- a/libs/ballot-interpreter/src/types.ts
+++ b/libs/ballot-interpreter/src/types.ts
@@ -12,6 +12,7 @@ export interface InterpreterOptions {
   adjudicationReasons: readonly AdjudicationReason[];
   electionDefinition: ElectionDefinition;
   allowOfficialBallotsInTestMode?: boolean;
+  disableVerticalStreakDetection?: boolean;
   markThresholds: MarkThresholds;
   precinctSelection: PrecinctSelection;
   testMode: boolean;

--- a/libs/types/src/system_settings.ts
+++ b/libs/types/src/system_settings.ts
@@ -74,6 +74,12 @@ export interface SystemSettings {
    * import/export time (required for CDF).
    */
   readonly castVoteRecordsIncludeRedundantMetadata?: boolean;
+  /**
+   * Disables vertical streak detection when scanning. This should only be used
+   * as a workaround in case the ballots have a design that triggers false
+   * positives.
+   */
+  readonly disableVerticalStreakDetection?: boolean;
 }
 
 export const SystemSettingsSchema: z.ZodType<SystemSettings> = z.object({
@@ -90,6 +96,7 @@ export const SystemSettingsSchema: z.ZodType<SystemSettings> = z.object({
   precinctScanEnableShoeshineMode: z.boolean().optional(),
   castVoteRecordsIncludeOriginalSnapshots: z.boolean().optional(),
   castVoteRecordsIncludeRedundantMetadata: z.boolean().optional(),
+  disableVerticalStreakDetection: z.boolean().optional(),
 });
 
 /**


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/5538

Adds a system setting that disables streak detection for an election. We might want this in case of a ballot design that triggers false positives when looking for streaks. Because we support taking someone else's AccuVote-style ballot, we may not be able to ensure no streaks are naturally present in the original image. This is unlikely, but this gives us an escape hatch.

## Demo Video or Screenshot
<img width="1880" alt="image" src="https://github.com/user-attachments/assets/b6dad853-3829-427d-83aa-25c99dab4049">

## Testing Plan
Automated testing and manual testing of VxCentralScan via `MOCK_SCANNER_FILES`.
