### PR TITLE
fix(pdi-scanner): use a smaller USB buffer in development

### DIFF
--- a/libs/pdi-scanner/build.rs
+++ b/libs/pdi-scanner/build.rs
@@ -1,0 +1,13 @@
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(production)");
+    println!("cargo:rerun-if-env-changed=NODE_ENV");
+
+    let is_production = match std::env::var("NODE_ENV") {
+        Ok(env) => env == "production",
+        Err(_) => false,
+    };
+
+    if is_production {
+        println!("cargo:rustc-cfg=production");
+    }
+}

--- a/libs/pdi-scanner/src/rust/scanner.rs
+++ b/libs/pdi-scanner/src/rust/scanner.rs
@@ -82,7 +82,14 @@ impl Scanner {
         /// bit trying to catch the paper, we might need a bit more. So for any
         /// reasonable paper size, 4 MB should be plenty and doesn't really put
         /// a dent in available memory.
+        #[cfg(production)]
         const BUFFER_SIZE: usize = 4_194_304;
+
+        /// For development, we want a smaller buffer because, for reasons we
+        /// don't understand, communicating with the scanner times out with a
+        /// larger buffer.
+        #[cfg(not(production))]
+        const BUFFER_SIZE: usize = 16_384;
 
         let (host_to_scanner_tx, host_to_scanner_rx) =
             mpsc::channel::<(usize, packets::Outgoing)>();


### PR DESCRIPTION
## Overview

Closes #5541

## Demo Video or Screenshot

```
❯ cargo run --example scan_forever --release
   Compiling pdi-scanner v0.1.0 (/media/parallels/WorkingFiles/code/vxsuite/libs/pdi-scanner)
    Finished `release` profile [optimized] target(s) in 1.53s
     Running `/media/parallels/WorkingFiles/code/vxsuite/target/release/examples/scan_forever`
waiting for sheet…
event: BeginScanEvent
event: EndScanEvent
Saved images from scan:
- Top: scan-0000-top.png
- Bottom: scan-0000-bottom.png
waiting for sheet…
^Creceived SIGINT
exiting

❯ NODE_ENV=production cargo run --example scan_forever --release
   Compiling pdi-scanner v0.1.0 (/media/parallels/WorkingFiles/code/vxsuite/libs/pdi-scanner)
    Finished `release` profile [optimized] target(s) in 3.28s
     Running `/media/parallels/WorkingFiles/code/vxsuite/target/release/examples/scan_forever`
Error: 
   0: failed to receive: timed out waiting on channel
   1: timed out waiting on channel

Location:
   libs/pdi-scanner/examples/scan_forever.rs:66

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```

## Testing Plan
See above.
