### PR TITLE
V4 PW Flow Tweaks

### DIFF
--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -236,7 +236,7 @@ test('election manager and poll worker configuration', async () => {
   apiMock.expectPrintReportV3();
   apiMock.expectGetPollsInfo('polls_open');
   apiMock.authenticateAsPollWorker(electionDefinition);
-  userEvent.click(await screen.findByText('Yes, Open the Polls'));
+  userEvent.click(await screen.findByText('Open Polls'));
   await screen.findByText(
     'Remove the poll worker card once you have printed all necessary reports.'
   );
@@ -274,7 +274,7 @@ test('election manager and poll worker configuration', async () => {
   apiMock.expectGetPollsInfo('polls_open');
   apiMock.authenticateAsPollWorker(electionDefinition);
   await screen.findByText('Do you want to open the polls?');
-  userEvent.click(await screen.findByText('Yes, Open the Polls'));
+  userEvent.click(await screen.findByText('Open Polls'));
 
   await screen.findByText(
     'Remove the poll worker card once you have printed all necessary reports.'
@@ -368,7 +368,7 @@ test('voter can cast a ballot that scans successfully ', async () => {
   apiMock.expectClosePolls();
   apiMock.expectPrintReportV3();
   apiMock.expectGetPollsInfo('polls_closed_final');
-  userEvent.click(await screen.findByText('Yes, Close the Polls'));
+  userEvent.click(await screen.findByText('Close Polls'));
   await screen.findByText('Closing Polls…');
   await screen.findByText('Polls Closed');
 
@@ -545,7 +545,7 @@ test('scanning is not triggered when polls closed or cards present', async () =>
   apiMock.expectOpenPolls();
   apiMock.expectPrintReportV3();
   apiMock.expectGetPollsInfo('polls_open');
-  userEvent.click(screen.getByText('Yes, Open the Polls'));
+  userEvent.click(screen.getByText('Open Polls'));
   await screen.findByText('Polls Opened');
 
   // Once we remove the poll worker card, scanning should start
@@ -572,7 +572,7 @@ test('poll worker can open and close polls without scanning any ballots', async 
   apiMock.expectOpenPolls();
   apiMock.expectPrintReportV3();
   apiMock.expectGetPollsInfo('polls_open');
-  userEvent.click(screen.getByRole('button', { name: 'Yes, Open the Polls' }));
+  userEvent.click(screen.getByRole('button', { name: 'Open Polls' }));
   await screen.findByText('Polls Opened');
   apiMock.expectPrintReportV3();
   userEvent.click(
@@ -591,7 +591,7 @@ test('poll worker can open and close polls without scanning any ballots', async 
   apiMock.expectClosePolls();
   apiMock.expectPrintReportV3();
   apiMock.expectGetPollsInfo('polls_closed_final');
-  userEvent.click(screen.getByRole('button', { name: 'Yes, Close the Polls' }));
+  userEvent.click(screen.getByRole('button', { name: 'Close Polls' }));
   await screen.findByText('Polls Closed');
   apiMock.expectPrintReportV3();
   userEvent.click(
@@ -622,7 +622,7 @@ test('open polls, scan ballot, close polls, save results', async () => {
   apiMock.expectOpenPolls();
   apiMock.expectPrintReportV3();
   apiMock.expectGetPollsInfo('polls_open');
-  userEvent.click(await screen.findByText('Yes, Open the Polls'));
+  userEvent.click(await screen.findByText('Open Polls'));
   await screen.findByText(
     'Remove the poll worker card once you have printed all necessary reports.'
   );
@@ -637,7 +637,7 @@ test('open polls, scan ballot, close polls, save results', async () => {
   apiMock.expectClosePolls();
   apiMock.expectPrintReportV3();
   apiMock.expectGetPollsInfo('polls_closed_final');
-  userEvent.click(await screen.findByText('Yes, Close the Polls'));
+  userEvent.click(await screen.findByText('Close Polls'));
   await screen.findByText('Closing Polls…');
   await screen.findByText('Polls Closed');
   await screen.findByText(
@@ -663,7 +663,7 @@ test('poll worker can open, pause, unpause, and close poll without scanning any 
   apiMock.expectOpenPolls();
   apiMock.expectPrintReportV3();
   apiMock.expectGetPollsInfo('polls_open');
-  userEvent.click(await screen.findByText('Yes, Open the Polls'));
+  userEvent.click(await screen.findByText('Open Polls'));
   await screen.findByText(
     'Remove the poll worker card once you have printed all necessary reports.'
   );
@@ -673,7 +673,7 @@ test('poll worker can open, pause, unpause, and close poll without scanning any 
   // Pause Voting Flow
   apiMock.authenticateAsPollWorker(electionGeneralDefinition);
   await screen.findByText('Do you want to close the polls?');
-  userEvent.click(await screen.findByText('No'));
+  userEvent.click(await screen.findByText('Menu'));
   apiMock.expectPauseVoting();
   apiMock.expectPrintReportV3();
   apiMock.expectGetPollsInfo('polls_paused');
@@ -691,7 +691,7 @@ test('poll worker can open, pause, unpause, and close poll without scanning any 
   apiMock.expectResumeVoting();
   apiMock.expectPrintReportV3();
   apiMock.expectGetPollsInfo('polls_open', { type: 'resume_voting' });
-  userEvent.click(await screen.findByText('Yes, Resume Voting'));
+  userEvent.click(await screen.findByText('Resume Voting'));
   await screen.findByText('Resuming Voting…');
   await screen.findByText(
     'Remove the poll worker card once you have printed all necessary reports.'
@@ -705,7 +705,7 @@ test('poll worker can open, pause, unpause, and close poll without scanning any 
   apiMock.expectClosePolls();
   apiMock.expectPrintReportV3();
   apiMock.expectGetPollsInfo('polls_closed_final');
-  userEvent.click(await screen.findByText('Yes, Close the Polls'));
+  userEvent.click(await screen.findByText('Close Polls'));
   await screen.findByText('Closing Polls…');
   await screen.findByText(
     'Remove the poll worker card once you have printed all necessary reports.'

--- a/apps/scan/frontend/src/app_unhappy_paths.test.tsx
+++ b/apps/scan/frontend/src/app_unhappy_paths.test.tsx
@@ -163,12 +163,12 @@ test('shows message when printer cover is open', async () => {
   await screen.findByText(/The paper roll holder is not attached/);
   apiMock.setPrinterStatusV4({ state: 'idle' });
   await waitFor(() => {
-    expect(screen.getButton('Yes, Open the Polls')).toBeEnabled();
+    expect(screen.getButton('Open Polls')).toBeEnabled();
   });
   apiMock.expectOpenPolls();
   apiMock.expectPrintReportV4();
   apiMock.expectGetPollsInfo('polls_open');
-  userEvent.click(await screen.findByText('Yes, Open the Polls'));
+  userEvent.click(await screen.findByText('Open Polls'));
 
   // Remove pollworker card
   apiMock.removeCard();
@@ -320,11 +320,11 @@ test('shows message when scanner cover is open', async () => {
 
   // Open Polls
   apiMock.authenticateAsPollWorker(electionGeneralDefinition);
-  await screen.findByText('Yes, Open the Polls');
+  await screen.findByText('Open Polls');
   apiMock.expectOpenPolls();
   apiMock.expectPrintReportV3();
   apiMock.expectGetPollsInfo('polls_open');
-  userEvent.click(await screen.findByText('Yes, Open the Polls'));
+  userEvent.click(await screen.findByText('Open Polls'));
   await screen.findByText('Polls Opened');
 
   // Remove pollworker card

--- a/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
@@ -79,7 +79,7 @@ describe('transitions from polls closed initial', () => {
     apiMock.expectOpenPolls();
     apiMock.expectPrintReportV3();
     apiMock.expectGetPollsInfo('polls_open');
-    userEvent.click(screen.getByText('Yes, Open the Polls'));
+    userEvent.click(screen.getByText('Open Polls'));
     await screen.findByText('Opening Polls…');
     await screen.findByText('Polls Opened');
   });
@@ -88,7 +88,7 @@ describe('transitions from polls closed initial', () => {
     apiMock.expectOpenPolls();
     apiMock.expectPrintReportV3();
     apiMock.expectGetPollsInfo('polls_open');
-    userEvent.click(screen.getByText('No'));
+    userEvent.click(screen.getByText('Menu'));
     userEvent.click(await screen.findByText('Open Polls'));
     await screen.findByText('Opening Polls…');
     await screen.findByText('Polls Opened');
@@ -108,7 +108,7 @@ describe('transitions from polls open', () => {
     apiMock.expectClosePolls();
     apiMock.expectPrintReportV3();
     apiMock.expectGetPollsInfo('polls_closed_final');
-    userEvent.click(screen.getByText('Yes, Close the Polls'));
+    userEvent.click(screen.getByText('Close Polls'));
     await screen.findByText('Closing Polls…');
     await screen.findByText('Polls Closed');
     expect(startNewVoterSessionMock).toHaveBeenCalledTimes(1);
@@ -118,7 +118,7 @@ describe('transitions from polls open', () => {
     apiMock.expectClosePolls();
     apiMock.expectPrintReportV3();
     apiMock.expectGetPollsInfo('polls_closed_final');
-    userEvent.click(screen.getByText('No'));
+    userEvent.click(screen.getByText('Menu'));
     userEvent.click(await screen.findByText('Close Polls'));
     await screen.findByText('Closing Polls…');
     await screen.findByText('Polls Closed');
@@ -129,7 +129,7 @@ describe('transitions from polls open', () => {
     apiMock.expectPauseVoting();
     apiMock.expectPrintReportV3();
     apiMock.expectGetPollsInfo('polls_paused');
-    userEvent.click(screen.getByText('No'));
+    userEvent.click(screen.getByText('Menu'));
     userEvent.click(await screen.findByText('Pause Voting'));
     await screen.findByText('Pausing Voting…');
     await screen.findByText('Voting Paused');
@@ -149,7 +149,7 @@ describe('transitions from polls paused', () => {
     apiMock.expectResumeVoting();
     apiMock.expectPrintReportV3();
     apiMock.expectGetPollsInfo('polls_open', { type: 'resume_voting' });
-    userEvent.click(screen.getByText('Yes, Resume Voting'));
+    userEvent.click(screen.getByText('Resume Voting'));
     await screen.findByText('Resuming Voting…');
     await screen.findByText('Voting Resumed');
   });
@@ -158,7 +158,7 @@ describe('transitions from polls paused', () => {
     apiMock.expectResumeVoting();
     apiMock.expectPrintReportV3();
     apiMock.expectGetPollsInfo('polls_open', { type: 'resume_voting' });
-    userEvent.click(screen.getByText('No'));
+    userEvent.click(screen.getByText('Menu'));
     userEvent.click(await screen.findByText('Resume Voting'));
     await screen.findByText('Resuming Voting…');
     await screen.findByText('Voting Resumed');
@@ -168,7 +168,7 @@ describe('transitions from polls paused', () => {
     apiMock.expectClosePolls();
     apiMock.expectPrintReportV3();
     apiMock.expectGetPollsInfo('polls_closed_final');
-    userEvent.click(screen.getByText('No'));
+    userEvent.click(screen.getByText('Menu'));
     userEvent.click(await screen.findByText('Close Polls'));
     await screen.findByText('Closing Polls…');
     await screen.findByText('Polls Closed');
@@ -181,9 +181,7 @@ test('no transitions from polls closed final', async () => {
   renderScreen({
     scannedBallotCount: 0,
   });
-  await screen.findByText(
-    'Voting is complete and the polls cannot be reopened.'
-  );
+  await screen.findByText(/Voting is complete/);
 
   // There should only be the power down and print previous report button
   expect(screen.queryAllByRole('button')).toHaveLength(3);
@@ -200,7 +198,7 @@ test('there is a warning if we attempt to open polls with ballots scanned', asyn
   await screen.findByText('Do you want to open the polls?');
   apiMock.expectOpenPolls(err('ballots-already-scanned'));
   apiMock.expectGetPollsInfo('polls_closed_initial');
-  userEvent.click(screen.getByText('Yes, Open the Polls'));
+  userEvent.click(screen.getByText('Open Polls'));
   await screen.findByText('Ballots Already Scanned');
 });
 
@@ -209,7 +207,7 @@ describe('reprinting previous report', () => {
     apiMock.expectGetPollsInfo('polls_closed_initial');
     renderScreen({});
 
-    userEvent.click(await screen.findByText('No'));
+    userEvent.click(await screen.findByText('Menu'));
     expect(screen.getAllByRole('button').map((b) => b.textContent)).toEqual([
       'Open Polls',
       'Signed Hash Validation',
@@ -221,7 +219,7 @@ describe('reprinting previous report', () => {
     apiMock.expectGetPollsInfo('polls_open');
     renderScreen({});
 
-    userEvent.click(await screen.findByText('No'));
+    userEvent.click(await screen.findByText('Menu'));
     const button = await screen.findByText('Print Polls Opened Report');
     expect(button).toBeEnabled();
     apiMock.expectPrintReportV3();
@@ -237,7 +235,7 @@ describe('reprinting previous report', () => {
     apiMock.expectGetPollsInfo('polls_paused');
     renderScreen({});
 
-    userEvent.click(await screen.findByText('No'));
+    userEvent.click(await screen.findByText('Menu'));
     const button = await screen.findByText('Print Voting Paused Report');
     expect(button).toBeEnabled();
     apiMock.expectPrintReportV3();
@@ -249,7 +247,7 @@ describe('reprinting previous report', () => {
     apiMock.expectGetPollsInfo('polls_open', { type: 'resume_voting' });
     renderScreen({});
 
-    userEvent.click(await screen.findByText('No'));
+    userEvent.click(await screen.findByText('Menu'));
     const button = await screen.findByText('Print Voting Resumed Report');
     expect(button).toBeEnabled();
     apiMock.expectPrintReportV3();
@@ -276,14 +274,14 @@ describe('must have printer attached to transition polls and print reports', () 
     renderScreen({});
 
     const attachText = await screen.findByText('The printer is disconnected');
-    expect(screen.getButton('Yes, Open the Polls')).toBeDisabled();
+    expect(screen.getButton('Open Polls')).toBeDisabled();
     apiMock.setPrinterStatusV4({ state: 'idle' });
     await waitForElementToBeRemoved(attachText);
     apiMock.expectOpenPolls();
     const { resolve } = apiMock.expectPrintReportV4();
     resolve();
     apiMock.expectGetPollsInfo('polls_open');
-    userEvent.click(screen.getByText('Yes, Open the Polls'));
+    userEvent.click(screen.getByText('Open Polls'));
     await screen.findByText('Reprint Polls Opened Report');
 
     apiMock.setPrinterStatusV4({ state: 'error', type: 'disconnected' });
@@ -300,7 +298,7 @@ describe('must have printer attached to transition polls and print reports', () 
     await screen.findByText('The printer is disconnected');
 
     // Go to screen with all options available
-    userEvent.click(screen.getByText('No'));
+    userEvent.click(screen.getByText('Menu'));
     // Check that Open Polls is disabled
     expect(screen.getButton('Open Polls')).toBeDisabled();
 
@@ -332,7 +330,7 @@ describe('must have printer attached to transition polls and print reports', () 
     const { resolve } = apiMock.expectPrintReportV4();
     resolve();
     apiMock.expectGetPollsInfo('polls_open');
-    userEvent.click(await screen.findByText('Yes, Open the Polls'));
+    userEvent.click(await screen.findByText('Open Polls'));
     expect(
       await screen.findByText('Reprint Polls Opened Report')
     ).toBeEnabled();
@@ -349,7 +347,7 @@ describe('must have printer attached to transition polls and print reports', () 
     renderScreen({});
 
     const attachText = await screen.findByText('The printer is disconnected');
-    expect(screen.getButton('Yes, Close the Polls')).toBeDisabled();
+    expect(screen.getButton('Close Polls')).toBeDisabled();
 
     apiMock.setPrinterStatusV4({ state: 'idle' });
     await waitForElementToBeRemoved(attachText);
@@ -357,7 +355,7 @@ describe('must have printer attached to transition polls and print reports', () 
     const { resolve } = apiMock.expectPrintReportV4();
     resolve();
     apiMock.expectGetPollsInfo('polls_closed_final');
-    userEvent.click(screen.getByText('Yes, Close the Polls'));
+    userEvent.click(screen.getByText('Close Polls'));
     await screen.findByText('Reprint Polls Closed Report');
     expect(startNewVoterSessionMock).toHaveBeenCalledTimes(1);
   });
@@ -368,7 +366,7 @@ describe('must have printer attached to transition polls and print reports', () 
     renderScreen({});
     await screen.findByText('The printer is disconnected');
 
-    userEvent.click(screen.getByText('No'));
+    userEvent.click(screen.getByText('Menu'));
 
     expect(screen.getButton('Close Polls')).toBeDisabled();
 
@@ -397,13 +395,13 @@ describe('must have usb drive attached to transition polls', () => {
     const attachText = await screen.findByText(
       'Insert a USB drive to continue.'
     );
-    expect(screen.getButton('Yes, Open the Polls')).toBeDisabled();
+    expect(screen.getButton('Open Polls')).toBeDisabled();
     apiMock.expectGetUsbDriveStatus('mounted');
     await waitForElementToBeRemoved(attachText);
     apiMock.expectOpenPolls();
     apiMock.expectPrintReportV3();
     apiMock.expectGetPollsInfo('polls_open');
-    userEvent.click(screen.getByText('Yes, Open the Polls'));
+    userEvent.click(screen.getByText('Open Polls'));
     await screen.findByText('Print Additional Polls Opened Report');
   });
 
@@ -416,7 +414,7 @@ describe('must have usb drive attached to transition polls', () => {
     await screen.findByText('Insert a USB drive to continue.');
 
     // Go to screen with all options available
-    userEvent.click(screen.getByText('No'));
+    userEvent.click(screen.getByText('Menu'));
     // Check that Open Polls is disabled
     expect(screen.getButton('Open Polls')).toBeDisabled();
 
@@ -442,14 +440,14 @@ describe('must have usb drive attached to transition polls', () => {
     const attachText = await screen.findByText(
       'Insert a USB drive to continue.'
     );
-    expect(screen.getButton('Yes, Resume Voting')).toBeDisabled();
+    expect(screen.getButton('Resume Voting')).toBeDisabled();
 
     apiMock.expectGetUsbDriveStatus('mounted');
     await waitForElementToBeRemoved(attachText);
     apiMock.expectResumeVoting();
     apiMock.expectPrintReportV3();
     apiMock.expectGetPollsInfo('polls_open');
-    userEvent.click(screen.getByText('Yes, Resume Voting'));
+    userEvent.click(screen.getByText('Resume Voting'));
     await screen.findByText('Voting Resumed');
   });
 
@@ -460,7 +458,7 @@ describe('must have usb drive attached to transition polls', () => {
     renderScreen({});
 
     await screen.findByText('Insert a USB drive to continue.');
-    userEvent.click(screen.getByText('No'));
+    userEvent.click(screen.getByText('Menu'));
 
     expect(screen.getButton('Resume Voting')).toBeDisabled();
     expect(screen.getButton('Close Polls')).toBeDisabled();
@@ -487,14 +485,14 @@ describe('must have usb drive attached to transition polls', () => {
     const attachText = await screen.findByText(
       'Insert a USB drive to continue.'
     );
-    expect(screen.getButton('Yes, Close the Polls')).toBeDisabled();
+    expect(screen.getButton('Close Polls')).toBeDisabled();
 
     apiMock.expectGetUsbDriveStatus('mounted');
     await waitForElementToBeRemoved(attachText);
     apiMock.expectClosePolls();
     apiMock.expectPrintReportV3();
     apiMock.expectGetPollsInfo('polls_closed_final');
-    userEvent.click(screen.getByText('Yes, Close the Polls'));
+    userEvent.click(screen.getByText('Close Polls'));
     await screen.findByText('Print Additional Polls Closed Report');
     expect(startNewVoterSessionMock).toHaveBeenCalledTimes(1);
   });
@@ -506,7 +504,7 @@ describe('must have usb drive attached to transition polls', () => {
     renderScreen({});
     await screen.findByText('Insert a USB drive to continue.');
 
-    userEvent.click(screen.getByText('No'));
+    userEvent.click(screen.getByText('Menu'));
 
     expect(screen.getButton('Close Polls')).toBeDisabled();
     // Allow pausing in unexpected situations.
@@ -539,7 +537,7 @@ describe('hardware V4 report printing', () => {
 
     // close polls to trigger first section to print
     await screen.findByText('Do you want to open the polls?');
-    userEvent.click(screen.getByText('Yes, Open the Polls'));
+    userEvent.click(screen.getByText('Open Polls'));
     await screen.findByText('Opening Polls…');
     resolve();
     await screen.findByText('Polls Opened');
@@ -570,7 +568,7 @@ describe('hardware V4 report printing', () => {
 
     // close polls to trigger first section to print
     await screen.findByText('Do you want to open the polls?');
-    userEvent.click(screen.getByText('Yes, Open the Polls'));
+    userEvent.click(screen.getByText('Open Polls'));
     await screen.findByText('Opening Polls…');
     resolveMammal();
     await screen.findByText('Polls Opened');
@@ -629,7 +627,7 @@ describe('hardware V4 report printing', () => {
 
     // pause voting flow
     await screen.findByText('Do you want to close the polls?');
-    userEvent.click(screen.getByText('No'));
+    userEvent.click(screen.getByText('Menu'));
     apiMock.expectGetPollsInfo('polls_paused');
     apiMock.expectPauseVoting();
     const { resolve: resolveReport } = apiMock.expectPrintReportV4();
@@ -665,7 +663,7 @@ describe('hardware V4 report printing', () => {
     await screen.findByText('Do you want to open the polls?');
     const { resolve } = apiMock.expectPrintReportV4({ state: 'no-paper' });
     apiMock.setPrinterStatusV4({ state: 'no-paper' });
-    userEvent.click(screen.getByText('Yes, Open the Polls'));
+    userEvent.click(screen.getByText('Open Polls'));
     await screen.findByText('Opening Polls…');
     resolve();
     await screen.findByText('Printing Stopped');
@@ -715,7 +713,7 @@ describe('hardware V4 report printing', () => {
       state: 'error',
       type: 'disconnected',
     });
-    userEvent.click(screen.getByText('Yes, Open the Polls'));
+    userEvent.click(screen.getByText('Open Polls'));
     await screen.findByText('Opening Polls…');
     resolve();
     await screen.findByText('Printing Stopped');
@@ -732,7 +730,9 @@ describe('hardware V4 report printing', () => {
       });
 
       await screen.findByText('The printer is disconnected');
-      expect(screen.getButton(/Yes/)).toBeDisabled();
+      expect(
+        screen.getButton(/(Open Polls)|(Close Polls)|(Resume Voting)/)
+      ).toBeDisabled();
     }
   );
 
@@ -741,7 +741,7 @@ describe('hardware V4 report printing', () => {
     apiMock.setPrinterStatusV4({ state: 'no-paper' });
     renderScreen({});
 
-    userEvent.click(await screen.findByText('No'));
+    userEvent.click(await screen.findByText('Menu'));
     userEvent.click(await screen.findByText('Load Printer Paper'));
     await screen.findByText('Remove Paper Roll Holder');
   });
@@ -751,7 +751,7 @@ describe('hardware V4 report printing', () => {
     apiMock.setPrinterStatusV4({ state: 'idle' });
     renderScreen({});
 
-    userEvent.click(await screen.findByText('No'));
+    userEvent.click(await screen.findByText('Menu'));
     const { resolve } = apiMock.expectPrintReportV4();
     userEvent.click(await screen.findButton('Print Polls Opened Report'));
     resolve();
@@ -763,7 +763,7 @@ test('Signed hash validation', async () => {
   apiMock.expectGetPollsInfo('polls_open');
   renderScreen({});
 
-  userEvent.click(await screen.findByText('No'));
+  userEvent.click(await screen.findByText('Menu'));
   expect(screen.queryByText('Signed Hash Validation')).toBeTruthy();
 
   apiMock.expectGenerateSignedHashValidationQrCodeValue();

--- a/apps/scan/frontend/src/screens/poll_worker_screen.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.tsx
@@ -11,6 +11,9 @@ import {
   FullScreenIconWrapper,
   Icons,
   SignedHashValidationButton,
+  H6,
+  Font,
+  H5,
 } from '@votingworks/ui';
 import { getPollsReportTitle } from '@votingworks/utils';
 import { ElectionDefinition, PollsTransitionType } from '@votingworks/types';
@@ -40,6 +43,7 @@ import {
 import { LegacyPostPrintScreen } from './poll_worker_legacy_post_print_screen';
 import { FujitsuPostPrintScreen } from './poll_worker_fujitsu_post_print_screen';
 import { Screen } from './poll_worker_shared';
+import { Screen as PlainScreen } from '../components/layout';
 import { PollWorkerLoadAndReprintButton } from '../components/printer_management/poll_worker_load_and_reprint_button';
 
 type PollWorkerFlowState =
@@ -145,9 +149,9 @@ function OpenPollsPromptScreen({
             onPress={onConfirm}
             disabled={!shouldAllowTogglingPolls(printerSummary, usbDriveStatus)}
           >
-            Yes, Open the Polls
+            Open Polls
           </Button>{' '}
-          <Button onPress={onClose}>No</Button>
+          <Button onPress={onClose}>Menu</Button>
         </P>
         <PrinterAlertText printerSummary={printerSummary} />
         <UsbDriveAlertText usbDriveStatus={usbDriveStatus} />
@@ -177,9 +181,9 @@ function ResumeVotingPromptScreen({
             onPress={onConfirm}
             disabled={!shouldAllowTogglingPolls(printerSummary, usbDriveStatus)}
           >
-            Yes, Resume Voting
+            Resume Voting
           </Button>{' '}
-          <Button onPress={onClose}>No</Button>
+          <Button onPress={onClose}>Menu</Button>
         </P>
         <PrinterAlertText printerSummary={printerSummary} />
         <UsbDriveAlertText usbDriveStatus={usbDriveStatus} />
@@ -209,9 +213,9 @@ function ClosePollsPromptScreen({
             onPress={onConfirm}
             disabled={!shouldAllowTogglingPolls(printerSummary, usbDriveStatus)}
           >
-            Yes, Close the Polls
+            Close Polls
           </Button>{' '}
-          <Button onPress={onClose}>No</Button>
+          <Button onPress={onClose}>Menu</Button>
         </P>
         <PrinterAlertText printerSummary={printerSummary} />
         <UsbDriveAlertText usbDriveStatus={usbDriveStatus} />
@@ -242,11 +246,18 @@ export interface PollWorkerScreenProps {
   startNewVoterSession: () => void;
 }
 
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  margin: 0 0.35rem 0.35rem;
+`;
+
 const ButtonGrid = styled.div`
   display: grid;
   grid-auto-rows: 1fr;
   grid-gap: max(${(p) => p.theme.sizes.minTouchAreaSeparationPx}px, 0.25rem);
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: 1fr 1fr;
 `;
 
 function PollWorkerScreenContents({
@@ -520,8 +531,11 @@ function PollWorkerScreenContents({
     switch (pollsState) {
       case 'polls_closed_initial':
         return (
-          <React.Fragment>
-            <P>The polls have not been opened.</P>
+          <Container>
+            <P>
+              The polls are <Font weight="bold">closed</Font>. Open the polls to
+              begin voting.
+            </P>
             <ButtonGrid>
               <Button
                 variant="primary"
@@ -532,16 +546,20 @@ function PollWorkerScreenContents({
               >
                 Open Polls
               </Button>
-              {commonActions}
             </ButtonGrid>
-          </React.Fragment>
+            <H5>Other Actions</H5>
+            <ButtonGrid>{commonActions}</ButtonGrid>
+          </Container>
         );
       case 'polls_open':
         // Do not disable Pausing Voting if shouldAllowTogglingPolls is false as in the unlikely event of an internal connection failure
         // officials may want to pause voting on the machine.
         return (
-          <React.Fragment>
-            <P>The polls are currently open.</P>
+          <Container>
+            <P>
+              The polls are <Font weight="bold">open</Font>. Close the polls to
+              end voting.
+            </P>
             <ButtonGrid>
               <Button
                 variant="primary"
@@ -552,15 +570,20 @@ function PollWorkerScreenContents({
               >
                 Close Polls
               </Button>
+            </ButtonGrid>
+            <H5>Other Actions</H5>
+            <ButtonGrid>
               <Button onPress={pauseVoting}>Pause Voting</Button>
               {commonActions}
             </ButtonGrid>
-          </React.Fragment>
+          </Container>
         );
       case 'polls_paused':
         return (
-          <React.Fragment>
-            <P>Voting is currently paused.</P>
+          <Container>
+            <P>
+              Voting is <Font weight="bold">paused</Font>.
+            </P>
             <ButtonGrid>
               <Button
                 variant="primary"
@@ -571,6 +594,9 @@ function PollWorkerScreenContents({
               >
                 Resume Voting
               </Button>
+            </ButtonGrid>
+            <H6>Other Actions</H6>
+            <ButtonGrid>
               <Button
                 onPress={closePolls}
                 disabled={
@@ -581,14 +607,17 @@ function PollWorkerScreenContents({
               </Button>
               {commonActions}
             </ButtonGrid>
-          </React.Fragment>
+          </Container>
         );
       case 'polls_closed_final':
         return (
-          <React.Fragment>
-            <P>Voting is complete and the polls cannot be reopened.</P>
+          <Container>
+            <P>
+              Polls are <Font weight="bold">closed</Font>. Voting is complete
+              and the polls cannot be reopened.
+            </P>
             <ButtonGrid>{commonActions}</ButtonGrid>
-          </React.Fragment>
+          </Container>
         );
       /* istanbul ignore next - compile-time check for completeness */
       default:
@@ -597,10 +626,13 @@ function PollWorkerScreenContents({
   })();
 
   return (
-    <Screen>
-      <H1>Poll Worker Actions</H1>
+    <PlainScreen
+      title="Poll Worker Menu"
+      infoBarMode="admin"
+      voterFacing={false}
+    >
       {content}
-    </Screen>
+    </PlainScreen>
   );
 }
 

--- a/apps/scan/frontend/src/screens/poll_worker_screen.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.tsx
@@ -144,14 +144,14 @@ function OpenPollsPromptScreen({
       <CenteredLargeProse>
         <P>Do you want to open the polls?</P>
         <P>
+          <Button onPress={onClose}>Menu</Button>{' '}
           <Button
             variant="primary"
             onPress={onConfirm}
             disabled={!shouldAllowTogglingPolls(printerSummary, usbDriveStatus)}
           >
             Open Polls
-          </Button>{' '}
-          <Button onPress={onClose}>Menu</Button>
+          </Button>
         </P>
         <PrinterAlertText printerSummary={printerSummary} />
         <UsbDriveAlertText usbDriveStatus={usbDriveStatus} />
@@ -176,14 +176,14 @@ function ResumeVotingPromptScreen({
       <CenteredLargeProse>
         <P>Do you want to resume voting?</P>
         <P>
+          <Button onPress={onClose}>Menu</Button>{' '}
           <Button
             variant="primary"
             onPress={onConfirm}
             disabled={!shouldAllowTogglingPolls(printerSummary, usbDriveStatus)}
           >
             Resume Voting
-          </Button>{' '}
-          <Button onPress={onClose}>Menu</Button>
+          </Button>
         </P>
         <PrinterAlertText printerSummary={printerSummary} />
         <UsbDriveAlertText usbDriveStatus={usbDriveStatus} />
@@ -208,14 +208,14 @@ function ClosePollsPromptScreen({
       <CenteredLargeProse>
         <P>Do you want to close the polls?</P>
         <P>
+          <Button onPress={onClose}>Menu</Button>{' '}
           <Button
             variant="primary"
             onPress={onConfirm}
             disabled={!shouldAllowTogglingPolls(printerSummary, usbDriveStatus)}
           >
             Close Polls
-          </Button>{' '}
-          <Button onPress={onClose}>Menu</Button>
+          </Button>
         </P>
         <PrinterAlertText printerSummary={printerSummary} />
         <UsbDriveAlertText usbDriveStatus={usbDriveStatus} />


### PR DESCRIPTION
## Overview

An addendum to the series of copy change PRs, changes the options on the open / close / resume prompt to be a little more direct and reformats the poll worker menu to match other screens.

## Demo Video or Screenshot

| Before | After |
| -------- | ------- |
| <img width="1060" alt="Screen Shot 2024-10-29 at 10 59 35 AM" src="https://github.com/user-attachments/assets/c46f605e-3968-4343-8c29-72ae21709420">  | <img width="1060" alt="Screen Shot 2024-10-29 at 12 29 27 PM" src="https://github.com/user-attachments/assets/0bef5473-521c-40ec-9529-80db1bf8bc91">|
| <img width="1059" alt="Screen Shot 2024-10-29 at 10 59 46 AM" src="https://github.com/user-attachments/assets/3f9b525d-525a-4bd6-92c3-3b021d77c35e"> |<img width="1060" alt="Screen Shot 2024-10-29 at 10 28 39 AM" src="https://github.com/user-attachments/assets/0022fc83-f40c-4a8d-bfa8-3f77983d616c"> |
| <img width="1061" alt="Screen Shot 2024-10-29 at 11 00 04 AM" src="https://github.com/user-attachments/assets/6673422d-2813-4385-bdf2-ba322e1ff793"> | <img width="1060" alt="Screen Shot 2024-10-29 at 12 29 54 PM" src="https://github.com/user-attachments/assets/44b0d6ce-782b-4024-b7a3-84b4f507cddf">|
| <img width="1059" alt="Screen Shot 2024-10-29 at 11 00 10 AM" src="https://github.com/user-attachments/assets/8d5b5db2-55bd-44de-8cf2-14c05fd9c349"> | <img width="1061" alt="Screen Shot 2024-10-29 at 10 29 07 AM" src="https://github.com/user-attachments/assets/be90a329-759a-4acc-b834-593f9b8d120c"> |
| <img width="1059" alt="Screen Shot 2024-10-29 at 11 00 27 AM" src="https://github.com/user-attachments/assets/f76d8f42-d117-41c8-af24-ac90275d7383"> | <img width="1058" alt="Screen Shot 2024-10-29 at 12 30 12 PM" src="https://github.com/user-attachments/assets/7e9dab94-1aaf-40e0-a1d8-4773cde9d8c9"> |
|<img width="1059" alt="Screen Shot 2024-10-29 at 11 00 39 AM" src="https://github.com/user-attachments/assets/aee1fedb-8a0a-42f0-8f00-9d6d68d69e56">|<img width="1062" alt="Screen Shot 2024-10-29 at 10 29 34 AM" src="https://github.com/user-attachments/assets/e480d232-a165-4bcd-b035-36f9745302bb">|
|<img width="1060" alt="Screen Shot 2024-10-29 at 11 01 02 AM" src="https://github.com/user-attachments/assets/0a7cc962-eea1-4fb7-8201-d245ec818800">|<img width="1060" alt="Screen Shot 2024-10-29 at 10 30 02 AM" src="https://github.com/user-attachments/assets/aaf0b815-8a1d-40fc-921a-457e784cc467">|