### PR TITLE
fix(central-scan): prevent `scanimage` race

### DIFF
--- a/apps/central-scan/backend/src/fujitsu_scanner.ts
+++ b/apps/central-scan/backend/src/fujitsu_scanner.ts
@@ -140,7 +140,7 @@ export class FujitsuScanner implements BatchScanner {
       `--batch=${join(directory, `${dateStamp()}-ballot-%04d.${this.format}`)}`,
       `--batch-print`,
       `--batch-prompt`,
-      // If the sheet is smaller then the given size fill in extra image space with black
+      // If the sheet is smaller than the given size fill in extra image space with black
       `--bgcolor=black`,
     ];
 

--- a/apps/central-scan/backend/src/fujitsu_scanner.ts
+++ b/apps/central-scan/backend/src/fujitsu_scanner.ts
@@ -93,10 +93,10 @@ export class FujitsuScanner implements BatchScanner {
     );
   }
 
-  async isImprinterAttached(): Promise<boolean> {
+  isImprinterAttached(): Promise<boolean> {
     return new Promise((resolve) => {
       const process = streamExecFile('scanimage', [
-        '-d',
+        '--device-name',
         'fujitsu',
         '--endorser=yes',
         '--format=jpeg',
@@ -104,16 +104,21 @@ export class FujitsuScanner implements BatchScanner {
       ]);
 
       assert(process.stderr);
+      let stderr = '';
       process.stderr.on('data', (data: string) => {
-        // If there is no imprinter attached a message will be sent to stderr
-        // that the endorser parameter is readonly.
-        if (data.includes(EXPECTED_IMPRINTER_UNATTACHED_ERROR)) {
-          resolve(false);
-        }
+        // Collect all stderr output rather than checking each chunk as it comes
+        // in because the message we're looking for may be split across multiple
+        // chunks.
+        stderr += data;
       });
 
       process.on('close', () => {
-        resolve(true);
+        // If there is no imprinter attached a message will be sent to stderr
+        // that the endorser parameter is readonly.
+        const hasErrorMessage = stderr.includes(
+          EXPECTED_IMPRINTER_UNATTACHED_ERROR
+        );
+        resolve(!hasErrorMessage);
       });
     });
   }
@@ -124,7 +129,7 @@ export class FujitsuScanner implements BatchScanner {
     imprintIdPrefix,
   }: ScanOptions = {}): BatchControl {
     const args: string[] = [
-      '-d',
+      '--device-name',
       'fujitsu',
       '--resolution',
       '200',

--- a/apps/central-scan/backend/src/importer.ts
+++ b/apps/central-scan/backend/src/importer.ts
@@ -1,6 +1,7 @@
 import { Result, assert, assertDefined, ok, sleep } from '@votingworks/basics';
 import {
   ElectionDefinition,
+  Id,
   PageInterpretation,
   PageInterpretationWithFiles,
   SheetOf,
@@ -35,6 +36,25 @@ export interface Options {
   logger: Logger;
 }
 
+interface CurrentBatch {
+  /**
+   * The ID of the current batch being scanned.
+   */
+  batchId: Id;
+
+  /**
+   * The scanner control object for the current batch.
+   */
+  sheetGenerator: BatchControl;
+
+  /**
+   * The working directory for `sheetGenerator`, where scanned images are placed
+   * before being interpreted. This directory is removed when the batch is
+   * finished.
+   */
+  directory: string;
+}
+
 /**
  * Imports ballot images from a `Scanner` and stores them in a `Store`.
  */
@@ -42,8 +62,7 @@ export class Importer {
   private readonly workspace: Workspace;
   private readonly scanner: BatchScanner;
   private readonly logger: Logger;
-  private sheetGenerator?: BatchControl;
-  private batchId?: string;
+  private currentBatch?: CurrentBatch;
 
   constructor({ workspace, scanner, logger }: Options) {
     this.workspace = workspace;
@@ -264,35 +283,36 @@ export class Importer {
   }
 
   private async finishBatch(error?: string): Promise<void> {
-    if (this.batchId) {
-      this.workspace.store.finishBatch({ batchId: this.batchId, error });
-      const batch = this.workspace.store.getBatch(this.batchId);
-      await logBatchComplete(this.logger, batch);
-      this.batchId = undefined;
+    const { currentBatch } = this;
+    if (!currentBatch) {
+      return;
     }
 
-    if (this.sheetGenerator) {
-      await this.sheetGenerator.endBatch();
-      this.sheetGenerator = undefined;
-    }
+    this.workspace.store.finishBatch({
+      batchId: currentBatch.batchId,
+      error,
+    });
+    const batch = this.workspace.store.getBatch(currentBatch.batchId);
+    await logBatchComplete(this.logger, batch);
+    await currentBatch.sheetGenerator.endBatch();
+    await fsExtra.remove(currentBatch.directory);
+    this.currentBatch = undefined;
   }
 
   /**
    * Scan a single sheet and see how it looks
    */
   private async scanOneSheet(): Promise<void> {
-    assert(
-      typeof this.sheetGenerator !== 'undefined' &&
-        typeof this.batchId !== 'undefined'
-    );
+    const { currentBatch } = this;
+    assert(typeof currentBatch !== 'undefined');
 
-    const sheet = await this.sheetGenerator.scanSheet();
+    const sheet = await currentBatch.sheetGenerator.scanSheet();
     if (!sheet) {
-      debug('closing batch %s', this.batchId);
+      debug('closing batch %s', currentBatch.batchId);
       await this.finishBatch();
     } else {
       debug('got a ballot card: %o', sheet);
-      const sheetId = await this.sheetAdded(sheet, this.batchId);
+      const sheetId = await this.sheetAdded(sheet, currentBatch.batchId);
       debug('got a ballot card: %o, %s', sheet, sheetId);
 
       const adjudicationStatus = this.workspace.store.adjudicationStatus();
@@ -309,33 +329,38 @@ export class Importer {
     this.getElectionDefinition(); // ensure election definition is loaded
     const hasImprinter = await this.scanner.isImprinterAttached();
 
-    if (this.sheetGenerator) {
+    if (this.currentBatch) {
       throw new Error('scanning already in progress');
     }
 
-    this.batchId = this.workspace.store.addBatch();
+    const batchId = this.workspace.store.addBatch();
     const batchScanDirectory = join(
       this.workspace.ballotImagesPath,
-      `batch-${this.batchId}`
+      `batch-${batchId}`
     );
     await fsExtra.ensureDir(batchScanDirectory);
     debug(
       'scanning starting for batch %s into %s',
-      this.batchId,
+      batchId,
       batchScanDirectory
     );
     const ballotPaperSize =
       this.workspace.store.getBallotPaperSizeForElection();
-    this.sheetGenerator = this.scanner.scanSheets({
+    const sheetGenerator = this.scanner.scanSheets({
       directory: batchScanDirectory,
       pageSize: ballotPaperSize,
       // If the imprinter is attached automatically imprint an ID prefixed by the batchID
-      imprintIdPrefix: hasImprinter ? `${this.batchId}` : undefined,
+      imprintIdPrefix: hasImprinter ? batchId : undefined,
     });
 
+    this.currentBatch = {
+      batchId,
+      sheetGenerator,
+      directory: batchScanDirectory,
+    };
     this.continueImport({ forceAccept: false });
 
-    return this.batchId;
+    return batchId;
   }
 
   /**
@@ -352,7 +377,7 @@ export class Importer {
       }
     }
 
-    if (this.sheetGenerator && this.batchId) {
+    if (this.currentBatch) {
       this.scanOneSheet().catch((error) => {
         debug('processing sheet failed with error: %s', error.stack);
         void this.finishBatch(error.toString());
@@ -366,7 +391,7 @@ export class Importer {
    * this is really for testing
    */
   async waitForEndOfBatchOrScanningPause(): Promise<void> {
-    if (!this.batchId) {
+    if (!this.currentBatch) {
       return;
     }
 
@@ -399,7 +424,7 @@ export class Importer {
   getStatus(): ScanStatus {
     return {
       isScannerAttached: this.scanner.isAttached(),
-      ongoingBatchId: this.batchId,
+      ongoingBatchId: this.currentBatch?.batchId,
       adjudicationsRemaining:
         this.workspace.store.adjudicationStatus().remaining,
       batches: this.workspace.store.getBatches(),

--- a/apps/central-scan/backend/src/util/workspace.ts
+++ b/apps/central-scan/backend/src/util/workspace.ts
@@ -19,11 +19,6 @@ export interface Workspace {
   readonly ballotImagesPath: string;
 
   /**
-   * The directory where the scanner will save images.
-   */
-  readonly scannedImagesPath: string;
-
-  /**
    * The directory where files are uploaded.
    */
   readonly uploadsPath: string;
@@ -58,10 +53,8 @@ export interface Workspace {
 export function createWorkspace(root: string, logger: BaseLogger): Workspace {
   const resolvedRoot = resolve(root);
   const ballotImagesPath = join(resolvedRoot, 'ballot-images');
-  const scannedImagesPath = join(ballotImagesPath, 'scanned-images');
   const uploadsPath = join(resolvedRoot, 'uploads');
   ensureDirSync(ballotImagesPath);
-  ensureDirSync(scannedImagesPath);
 
   const dbPath = join(resolvedRoot, 'ballots.db');
   const store = Store.fileStore(dbPath, logger);
@@ -73,22 +66,17 @@ export function createWorkspace(root: string, logger: BaseLogger): Workspace {
   return {
     path: resolvedRoot,
     ballotImagesPath,
-    scannedImagesPath,
     uploadsPath,
     store,
     resetElectionSession() {
       store.resetElectionSession();
       emptyDirSync(ballotImagesPath);
-      emptyDirSync(scannedImagesPath);
       ensureDirSync(ballotImagesPath);
-      ensureDirSync(scannedImagesPath);
     },
     reset() {
       store.reset();
       emptyDirSync(ballotImagesPath);
-      emptyDirSync(scannedImagesPath);
       ensureDirSync(ballotImagesPath);
-      ensureDirSync(scannedImagesPath);
     },
     clearUploads() {
       emptyDirSync(uploadsPath);


### PR DESCRIPTION
## Overview
Ever since #4994 we call `scanimage` twice when starting a batch, once to determine whether an imprinter is present and once to actually start the scan. Both invocations require communicating with the scanner, which means both need to open the USB device. Because we previously resolved the `isImprinterAttached` promise early in the case where the expected error message is present, the first `scanimage` instance could still be running and holding the USB device open when we try to run the second `scanimage` instance. When that happens, the second instance would fail to open the USB device and we'd get a zero-sheet batch and this error message: `scanimage: open of device fujitsu failed: Invalid argument`.

In my testing on macOS host with a Debian VM with the attached fi-7180, this happens on every scan attempt. It may be that different configurations behave differently, as the outcome of the race is non-deterministic. This change fixes the issue by waiting until the `scanimage` process exits to resolve the `isImprinterAttached` promise.

Additionally, I changed a few other things:
- expand the shorthand `scanimage` option `-d` to `--device-name`
- collect `scanimage` stderr before checking for the expected error message in case it is split across multiple chunks (unlikely but possible)
- update tests to fail if the `isImprinterAttached` promise resolves early or if we don't see the error message split across multiple stderr chunks

## Demo Video or Screenshot
| Before (0-sheet batch) | After (3-sheet batch) |
|-|-|
| ![CleanShot 2024-10-30 at 16 39 34@2x](https://github.com/user-attachments/assets/a4024d42-f7ce-44a4-b21d-5a0e4ec60eb3) | ![CleanShot 2024-10-30 at 16 40 33@2x](https://github.com/user-attachments/assets/75605ee2-4ae7-475a-88dc-6f36e14a0fc7) |

## Testing Plan
Tested manually with the fi-7180 on macOS host / Debian VM
