### PR TITLE
fix(central-scan): only keep two images per scanned sheet

### DIFF
--- a/apps/central-scan/backend/src/fujitsu_scanner.ts
+++ b/apps/central-scan/backend/src/fujitsu_scanner.ts
@@ -140,7 +140,7 @@ export class FujitsuScanner implements BatchScanner {
       `--batch=${join(directory, `${dateStamp()}-ballot-%04d.${this.format}`)}`,
       `--batch-print`,
       `--batch-prompt`,
-      // If the sheet is smaller then the given size fill in extra image space with black
+      // If the sheet is smaller than the given size fill in extra image space with black
       `--bgcolor=black`,
     ];
 

--- a/apps/central-scan/backend/src/util/workspace.ts
+++ b/apps/central-scan/backend/src/util/workspace.ts
@@ -19,11 +19,6 @@ export interface Workspace {
   readonly ballotImagesPath: string;
 
   /**
-   * The directory where the scanner will save images.
-   */
-  readonly scannedImagesPath: string;
-
-  /**
    * The directory where files are uploaded.
    */
   readonly uploadsPath: string;
@@ -58,10 +53,8 @@ export interface Workspace {
 export function createWorkspace(root: string, logger: BaseLogger): Workspace {
   const resolvedRoot = resolve(root);
   const ballotImagesPath = join(resolvedRoot, 'ballot-images');
-  const scannedImagesPath = join(ballotImagesPath, 'scanned-images');
   const uploadsPath = join(resolvedRoot, 'uploads');
   ensureDirSync(ballotImagesPath);
-  ensureDirSync(scannedImagesPath);
 
   const dbPath = join(resolvedRoot, 'ballots.db');
   const store = Store.fileStore(dbPath, logger);
@@ -73,22 +66,17 @@ export function createWorkspace(root: string, logger: BaseLogger): Workspace {
   return {
     path: resolvedRoot,
     ballotImagesPath,
-    scannedImagesPath,
     uploadsPath,
     store,
     resetElectionSession() {
       store.resetElectionSession();
       emptyDirSync(ballotImagesPath);
-      emptyDirSync(scannedImagesPath);
       ensureDirSync(ballotImagesPath);
-      ensureDirSync(scannedImagesPath);
     },
     reset() {
       store.reset();
       emptyDirSync(ballotImagesPath);
-      emptyDirSync(scannedImagesPath);
       ensureDirSync(ballotImagesPath);
-      ensureDirSync(scannedImagesPath);
     },
     clearUploads() {
       emptyDirSync(uploadsPath);


### PR DESCRIPTION
## Overview

When scanning ballots in VxCentralScan we use `scanimage`, which puts images on disk. We then read them, interpret them, normalize them, and write them to disk at a new location of our choosing. This second image per side is the only one we really care about, and the first is just taking up space. To fix this, we now delete the directory we create for batches after the batch is completely scanned.

Additionally, this commit removes the `Workspace::scannedImagesPath` property and stops creating the `scanned-images` directory in the workspace. Before we put files for a given batch in their own directory we would put them in this directory. That hasn't been true in some time.

## Demo Video or Screenshot

## Testing Plan
Watched the `ballot-images` directory during and after scanning, and added automated tests.

```
❯ tree dev-workspace/ballot-images/
dev-workspace/ballot-images/
└── batch-99ea6e3e-2a49-4a24-8e49-73c50b8fff04
    └── 20241003_165118-ballot-0001.jpeg.part

2 directories, 1 file

❯ tree dev-workspace/ballot-images/
dev-workspace/ballot-images/
├── batch-99ea6e3e-2a49-4a24-8e49-73c50b8fff04
│   ├── 20241003_165118-ballot-0001.jpeg
│   ├── 20241003_165118-ballot-0002.jpeg
│   └── 20241003_165118-ballot-0003.jpeg.part
├── c16f6c3c-3ed1-47c4-be7a-1767dd2b3604-back.png
└── c16f6c3c-3ed1-47c4-be7a-1767dd2b3604-front.png

2 directories, 5 files

❯ tree dev-workspace/ballot-images/
dev-workspace/ballot-images/
├── 35ec2d1c-7c66-4467-a83c-f8d6c7ba5df5-back.png
├── 35ec2d1c-7c66-4467-a83c-f8d6c7ba5df5-front.png
├── batch-99ea6e3e-2a49-4a24-8e49-73c50b8fff04
│   ├── 20241003_165118-ballot-0001.jpeg
│   ├── 20241003_165118-ballot-0002.jpeg
│   ├── 20241003_165118-ballot-0003.jpeg
│   ├── 20241003_165118-ballot-0004.jpeg
│   └── 20241003_165118-ballot-0005.jpeg.part
├── c16f6c3c-3ed1-47c4-be7a-1767dd2b3604-back.png
└── c16f6c3c-3ed1-47c4-be7a-1767dd2b3604-front.png

2 directories, 9 files

❯ tree dev-workspace/ballot-images/
dev-workspace/ballot-images/
├── 35ec2d1c-7c66-4467-a83c-f8d6c7ba5df5-back.png
├── 35ec2d1c-7c66-4467-a83c-f8d6c7ba5df5-front.png
├── batch-99ea6e3e-2a49-4a24-8e49-73c50b8fff04
│   ├── 20241003_165118-ballot-0001.jpeg
│   ├── 20241003_165118-ballot-0002.jpeg
│   ├── 20241003_165118-ballot-0003.jpeg
│   ├── 20241003_165118-ballot-0004.jpeg
│   ├── 20241003_165118-ballot-0005.jpeg
│   └── 20241003_165118-ballot-0006.jpeg
├── c16f6c3c-3ed1-47c4-be7a-1767dd2b3604-back.png
└── c16f6c3c-3ed1-47c4-be7a-1767dd2b3604-front.png

2 directories, 10 files

❯ tree dev-workspace/ballot-images/
dev-workspace/ballot-images/
├── 35ec2d1c-7c66-4467-a83c-f8d6c7ba5df5-back.png
├── 35ec2d1c-7c66-4467-a83c-f8d6c7ba5df5-front.png
├── 9ebbc67e-9e3c-4410-ac58-c700076d57ea-back.png
├── 9ebbc67e-9e3c-4410-ac58-c700076d57ea-front.png
├── c16f6c3c-3ed1-47c4-be7a-1767dd2b3604-back.png
└── c16f6c3c-3ed1-47c4-be7a-1767dd2b3604-front.png

1 directory, 6 files
```
