### PR TITLE
style: separate formatting & linting

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,0 +1,5 @@
+const { base } = require('./.lintstagedrc.shared');
+
+module.exports = {
+  ...base,
+};

--- a/.lintstagedrc.shared.js
+++ b/.lintstagedrc.shared.js
@@ -1,0 +1,20 @@
+// @ts-check
+
+const base = {
+  '*.+(js|jsx|ts|tsx|css|graphql|json|less|md|mdx|sass|scss|yaml|yml)': [
+    'prettier --write',
+  ],
+  '*.+(js|jsx|ts|tsx)': ['eslint --quiet --fix'],
+  'package.json': ['sort-package-json'],
+};
+
+const frontend = {
+  ...base,
+  '*.+(js|jsx|ts|tsx)': ['stylelint --quiet --fix', 'eslint --quiet --fix'],
+  '*.css': ['stylelint --config .stylelintrc-css.js --fix'],
+};
+
+module.exports = {
+  base,
+  frontend,
+};

--- a/apps/admin/backend/package.json
+++ b/apps/admin/backend/package.json
@@ -27,17 +27,6 @@
     "test:watch": "TZ=America/Anchorage jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@votingworks/auth": "workspace:*",
     "@votingworks/backend": "workspace:*",

--- a/apps/admin/backend/src/app.ballot_count_report_csv.test.ts
+++ b/apps/admin/backend/src/app.ballot_count_report_csv.test.ts
@@ -24,13 +24,11 @@ jest.setTimeout(60_000);
 
 // mock SKIP_CVR_BALLOT_HASH_CHECK to allow us to use old cvr fixtures
 const featureFlagMock = getFeatureFlagMock();
-jest.mock('@votingworks/utils', () => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
-      featureFlagMock.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', () => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
 
 beforeEach(() => {
   jest.restoreAllMocks();

--- a/apps/admin/backend/src/app.ballot_count_report_data.test.ts
+++ b/apps/admin/backend/src/app.ballot_count_report_data.test.ts
@@ -15,13 +15,11 @@ jest.setTimeout(60_000);
 
 // mock SKIP_CVR_BALLOT_HASH_CHECK to allow us to use old cvr fixtures
 const featureFlagMock = getFeatureFlagMock();
-jest.mock('@votingworks/utils', () => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
-      featureFlagMock.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', () => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
 
 beforeEach(() => {
   jest.restoreAllMocks();

--- a/apps/admin/backend/src/app.ballot_count_report_pdf.test.ts
+++ b/apps/admin/backend/src/app.ballot_count_report_pdf.test.ts
@@ -32,13 +32,11 @@ jest.mock('./util/get_current_time', () => ({
 
 // mock SKIP_CVR_BALLOT_HASH_CHECK to allow us to use old cvr fixtures
 const featureFlagMock = getFeatureFlagMock();
-jest.mock('@votingworks/utils', () => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
-      featureFlagMock.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', () => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
 
 jest.mock('@votingworks/printing', () => {
   const original = jest.requireActual('@votingworks/printing');

--- a/apps/admin/backend/src/app.caching.test.ts
+++ b/apps/admin/backend/src/app.caching.test.ts
@@ -18,13 +18,11 @@ import { Api } from './app';
 
 // enable us to use modified fixtures that don't pass authentication
 const featureFlagMock = getFeatureFlagMock();
-jest.mock('@votingworks/utils', () => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
-      featureFlagMock.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', () => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
 featureFlagMock.enableFeatureFlag(
   BooleanEnvironmentVariableName.SKIP_CAST_VOTE_RECORDS_AUTHENTICATION
 );

--- a/apps/admin/backend/src/app.cvr_files.test.ts
+++ b/apps/admin/backend/src/app.cvr_files.test.ts
@@ -53,13 +53,11 @@ jest.mock('@votingworks/auth', (): typeof import('@votingworks/auth') => ({
 
 // mock SKIP_CVR_BALLOT_HASH_CHECK to allow us to use old cvr fixtures
 const featureFlagMock = getFeatureFlagMock();
-jest.mock('@votingworks/utils', () => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
-      featureFlagMock.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', () => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
 
 beforeEach(() => {
   jest.restoreAllMocks();

--- a/apps/admin/backend/src/app.err_cdf_export.test.ts
+++ b/apps/admin/backend/src/app.err_cdf_export.test.ts
@@ -32,13 +32,11 @@ jest.setTimeout(60_000);
 
 // mock SKIP_CVR_BALLOT_HASH_CHECK to allow us to use old cvr fixtures
 const featureFlagMock = getFeatureFlagMock();
-jest.mock('@votingworks/utils', () => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
-      featureFlagMock.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', () => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
 
 beforeEach(() => {
   jest.restoreAllMocks();

--- a/apps/admin/backend/src/app.tally_report_csv.test.ts
+++ b/apps/admin/backend/src/app.tally_report_csv.test.ts
@@ -25,13 +25,11 @@ jest.setTimeout(60_000);
 
 // mock SKIP_CVR_BALLOT_HASH_CHECK to allow us to use old cvr fixtures
 const featureFlagMock = getFeatureFlagMock();
-jest.mock('@votingworks/utils', () => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
-      featureFlagMock.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', () => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
 
 beforeEach(() => {
   jest.restoreAllMocks();

--- a/apps/admin/backend/src/app.tally_report_data.test.ts
+++ b/apps/admin/backend/src/app.tally_report_data.test.ts
@@ -26,13 +26,11 @@ jest.setTimeout(60_000);
 
 // mock SKIP_CVR_BALLOT_HASH_CHECK to allow us to use old cvr fixtures
 const featureFlagMock = getFeatureFlagMock();
-jest.mock('@votingworks/utils', () => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
-      featureFlagMock.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', () => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
 
 jest.mock(
   '@votingworks/backend',

--- a/apps/admin/backend/src/app.tally_report_pdf.test.ts
+++ b/apps/admin/backend/src/app.tally_report_pdf.test.ts
@@ -35,13 +35,11 @@ jest.mock('./util/get_current_time', () => ({
 
 // mock SKIP_CVR_BALLOT_HASH_CHECK to allow us to use old cvr fixtures
 const featureFlagMock = getFeatureFlagMock();
-jest.mock('@votingworks/utils', () => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
-      featureFlagMock.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', () => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
 
 jest.mock('@votingworks/printing', () => {
   const original = jest.requireActual('@votingworks/printing');

--- a/apps/admin/backend/src/app.write_in_adjudication_report_pdf.test.ts
+++ b/apps/admin/backend/src/app.write_in_adjudication_report_pdf.test.ts
@@ -28,13 +28,11 @@ jest.mock('./util/get_current_time', () => ({
 
 // mock SKIP_CVR_BALLOT_HASH_CHECK to allow us to use old cvr fixtures
 const featureFlagMock = getFeatureFlagMock();
-jest.mock('@votingworks/utils', () => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
-      featureFlagMock.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', () => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
 
 jest.mock('@votingworks/printing', () => {
   const original = jest.requireActual('@votingworks/printing');

--- a/apps/admin/backend/src/app.write_ins.test.ts
+++ b/apps/admin/backend/src/app.write_ins.test.ts
@@ -31,13 +31,11 @@ jest.setTimeout(30_000);
 
 // mock SKIP_CVR_BALLOT_HASH_CHECK to allow us to use old cvr fixtures
 const featureFlagMock = getFeatureFlagMock();
-jest.mock('@votingworks/utils', () => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
-      featureFlagMock.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', () => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
 
 beforeEach(() => {
   jest.restoreAllMocks();

--- a/apps/admin/backend/src/cast_vote_records.ts
+++ b/apps/admin/backend/src/cast_vote_records.ts
@@ -181,9 +181,7 @@ export async function listCastVoteRecordExportsOnUsbDrive(
   return ok(
     [...castVoteRecordExportSummaries].sort(
       /* istanbul ignore next */
-      (a, b) => {
-        return b.exportTimestamp.getTime() - a.exportTimestamp.getTime();
-      }
+      (a, b) => b.exportTimestamp.getTime() - a.exportTimestamp.getTime()
     )
   );
 }

--- a/apps/admin/backend/src/exports/csv_tally_report.ts
+++ b/apps/admin/backend/src/exports/csv_tally_report.ts
@@ -260,12 +260,10 @@ export async function* generateTallyReportCsv({
       mergeTabulationGroupMaps(
         allScannedResults,
         allManualResults,
-        (scannedResults, manualResults) => {
-          return {
-            scannedResults: scannedResults ?? getEmptyElectionResults(election),
-            manualResults,
-          };
-        }
+        (scannedResults, manualResults) => ({
+          scannedResults: scannedResults ?? getEmptyElectionResults(election),
+          manualResults,
+        })
       )
     );
 

--- a/apps/admin/backend/src/tabulation/card_counts.ts
+++ b/apps/admin/backend/src/tabulation/card_counts.ts
@@ -149,11 +149,9 @@ export function tabulateFullCardCounts({
   return mergeTabulationGroupMaps(
     groupedScannedCardCounts,
     groupedManualBallotCounts,
-    (scannedCardCounts, manualBallotCount) => {
-      return {
-        ...(scannedCardCounts ?? getEmptyCardCounts()),
-        manual: manualBallotCount ?? 0,
-      };
-    }
+    (scannedCardCounts, manualBallotCount) => ({
+      ...(scannedCardCounts ?? getEmptyCardCounts()),
+      manual: manualBallotCount ?? 0,
+    })
   );
 }

--- a/apps/admin/backend/src/tabulation/full_results.test.ts
+++ b/apps/admin/backend/src/tabulation/full_results.test.ts
@@ -31,13 +31,11 @@ import { adjudicateWriteIn } from '../adjudication';
 
 // mock SKIP_CVR_BALLOT_HASH_CHECK to allow us to use old cvr fixtures
 const featureFlagMock = getFeatureFlagMock();
-jest.mock('@votingworks/utils', () => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
-      featureFlagMock.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', () => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
 
 beforeEach(() => {
   jest.restoreAllMocks();

--- a/apps/admin/backend/src/tabulation/tally_reports.ts
+++ b/apps/admin/backend/src/tabulation/tally_reports.ts
@@ -98,17 +98,15 @@ export async function tabulateTallyReportResults(params: {
     mergeTabulationGroupMaps(
       allScannedResults,
       allManualResults,
-      (scannedResults, manualResults) => {
-        return {
-          scannedResults: scannedResults || getEmptyElectionResults(election),
-          manualResults,
-          hasPartySplits: false,
-          cardCounts: {
-            ...(scannedResults?.cardCounts ?? getEmptyCardCounts()),
-            manual: manualResults?.ballotCount,
-          },
-        };
-      }
+      (scannedResults, manualResults) => ({
+        scannedResults: scannedResults || getEmptyElectionResults(election),
+        manualResults,
+        hasPartySplits: false,
+        cardCounts: {
+          ...(scannedResults?.cardCounts ?? getEmptyCardCounts()),
+          manual: manualResults?.ballotCount,
+        },
+      })
     )
   );
 

--- a/apps/admin/backend/src/util/export_file.ts
+++ b/apps/admin/backend/src/util/export_file.ts
@@ -24,27 +24,20 @@ export function exportFile({
     usbDrive: {
       status:
         /* istanbul ignore next */
-        () => {
-          return Promise.resolve({
+        () =>
+          Promise.resolve({
             status: 'no_drive',
-          });
-        },
+          }),
 
       eject:
         /* istanbul ignore next */
-        () => {
-          return Promise.resolve();
-        },
+        () => Promise.resolve(),
       format:
         /* istanbul ignore next */
-        () => {
-          return Promise.resolve();
-        },
+        () => Promise.resolve(),
       sync:
         /* istanbul ignore next */
-        () => {
-          return Promise.resolve();
-        },
+        () => Promise.resolve(),
     },
   });
 

--- a/apps/admin/frontend/.lintstagedrc.js
+++ b/apps/admin/frontend/.lintstagedrc.js
@@ -1,0 +1,7 @@
+// @ts-check
+
+const { frontend } = require('../../../.lintstagedrc.shared');
+
+module.exports = {
+  ...frontend,
+};

--- a/apps/admin/frontend/package.json
+++ b/apps/admin/frontend/package.json
@@ -28,21 +28,6 @@
     "test:watch": "TZ=America/Anchorage jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "stylelint --quiet --fix",
-      "eslint --quiet --fix"
-    ],
-    "*.css": [
-      "stylelint --config .stylelintrc-css.js --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_tab.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_tab.tsx
@@ -163,15 +163,12 @@ export function ManualTalliesTab(): JSX.Element | null {
     if (!getManualTallyMetadataQuery.data) return [];
 
     return [...getManualTallyMetadataQuery.data].sort(
-      (metadataA, metadataB) => {
-        return (
-          metadataA.ballotStyleGroupId.localeCompare(
-            metadataB.ballotStyleGroupId
-          ) ||
-          metadataA.precinctId.localeCompare(metadataB.precinctId) ||
-          metadataA.votingMethod.localeCompare(metadataB.votingMethod)
-        );
-      }
+      (metadataA, metadataB) =>
+        metadataA.ballotStyleGroupId.localeCompare(
+          metadataB.ballotStyleGroupId
+        ) ||
+        metadataA.precinctId.localeCompare(metadataB.precinctId) ||
+        metadataA.votingMethod.localeCompare(metadataB.votingMethod)
     );
   }, [getManualTallyMetadataQuery.data]);
   const hasManualTally = manualTallyMetadataRecords.length > 0;
@@ -185,17 +182,19 @@ export function ManualTalliesTab(): JSX.Element | null {
     useState<ManualResultsIdentifier>();
 
   // metadata for tallies which do not exist yet and thus could be added
-  const uncreatedManualTallyMetadata = useMemo(() => {
-    return getAllPossibleManualTallyIdentifiers(election).filter(
-      (identifier) =>
-        !manualTallyMetadataRecords.some(
-          ({ ballotStyleGroupId, precinctId, votingMethod }) =>
-            ballotStyleGroupId === identifier.ballotStyleGroupId &&
-            precinctId === identifier.precinctId &&
-            votingMethod === identifier.votingMethod
-        )
-    );
-  }, [election, manualTallyMetadataRecords]);
+  const uncreatedManualTallyMetadata = useMemo(
+    () =>
+      getAllPossibleManualTallyIdentifiers(election).filter(
+        (identifier) =>
+          !manualTallyMetadataRecords.some(
+            ({ ballotStyleGroupId, precinctId, votingMethod }) =>
+              ballotStyleGroupId === identifier.ballotStyleGroupId &&
+              precinctId === identifier.precinctId &&
+              votingMethod === identifier.votingMethod
+          )
+      ),
+    [election, manualTallyMetadataRecords]
+  );
 
   const [selectedPrecinct, setSelectedPrecinct] = useState<Precinct>();
   const [selectedBallotStyle, setSelectedBallotStyle] =
@@ -207,30 +206,30 @@ export function ManualTalliesTab(): JSX.Element | null {
 
   const selectableBallotStyles = getGroupedBallotStyles(
     election.ballotStyles
-  ).filter((bs) => {
-    return uncreatedManualTallyMetadata.some(
+  ).filter((bs) =>
+    uncreatedManualTallyMetadata.some(
       (metadata) => metadata.ballotStyleGroupId === bs.id
-    );
-  });
+    )
+  );
   const selectablePrecincts = selectedBallotStyle
-    ? election.precincts.filter((precinct) => {
-        return uncreatedManualTallyMetadata.some(
+    ? election.precincts.filter((precinct) =>
+        uncreatedManualTallyMetadata.some(
           (metadata) =>
             metadata.ballotStyleGroupId === selectedBallotStyle.id &&
             metadata.precinctId === precinct.id
-        );
-      })
+        )
+      )
     : [];
   const selectableBallotTypes: ManualResultsVotingMethod[] =
     selectedBallotStyle && selectedPrecinct
-      ? ALL_MANUAL_TALLY_BALLOT_TYPES.filter((votingMethod) => {
-          return uncreatedManualTallyMetadata.some(
+      ? ALL_MANUAL_TALLY_BALLOT_TYPES.filter((votingMethod) =>
+          uncreatedManualTallyMetadata.some(
             (metadata) =>
               metadata.ballotStyleGroupId === selectedBallotStyle.id &&
               metadata.precinctId === selectedPrecinct.id &&
               metadata.votingMethod === votingMethod
-          );
-        })
+          )
+        )
       : [];
 
   function handleBallotStyleSelect(value?: string) {

--- a/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/write_ins_adjudication_screen.tsx
@@ -577,26 +577,22 @@ export function WriteInsAdjudicationScreen(): JSX.Element {
             ) : null}
             {writeInCandidates.length > 0 && (
               <CandidateButtonList>
-                {writeInCandidates.map((candidate) => {
-                  return (
-                    <CandidateButton
-                      key={candidate.id}
-                      candidate={candidate}
-                      isSelected={
-                        currentWriteIn &&
-                        currentWriteIn.status === 'adjudicated' &&
-                        currentWriteIn.adjudicationType ===
-                          'write-in-candidate' &&
-                        currentWriteIn.candidateId === candidate.id
-                      }
-                      isSelectedStatusUpToDate={
-                        isWriteInAdjudicationContextFresh
-                      }
-                      onSelect={() => adjudicateAsWriteInCandidate(candidate)}
-                      onDeselect={resetAdjudication}
-                    />
-                  );
-                })}
+                {writeInCandidates.map((candidate) => (
+                  <CandidateButton
+                    key={candidate.id}
+                    candidate={candidate}
+                    isSelected={
+                      currentWriteIn &&
+                      currentWriteIn.status === 'adjudicated' &&
+                      currentWriteIn.adjudicationType ===
+                        'write-in-candidate' &&
+                      currentWriteIn.candidateId === candidate.id
+                    }
+                    isSelectedStatusUpToDate={isWriteInAdjudicationContextFresh}
+                    onSelect={() => adjudicateAsWriteInCandidate(candidate)}
+                    onDeselect={resetAdjudication}
+                  />
+                ))}
               </CandidateButtonList>
             )}
             {showNewWriteInCandidateForm ? (
@@ -642,24 +638,21 @@ export function WriteInsAdjudicationScreen(): JSX.Element {
               <SectionLabel>Official Candidates</SectionLabel>
             ) : null}
             <CandidateButtonList>
-              {officialCandidates.map((candidate) => {
-                return (
-                  <CandidateButton
-                    key={candidate.id}
-                    candidate={candidate}
-                    isSelected={
-                      currentWriteIn &&
-                      currentWriteIn.status === 'adjudicated' &&
-                      currentWriteIn.adjudicationType ===
-                        'official-candidate' &&
-                      currentWriteIn.candidateId === candidate.id
-                    }
-                    isSelectedStatusUpToDate={isWriteInAdjudicationContextFresh}
-                    onSelect={() => adjudicateAsOfficialCandidate(candidate)}
-                    onDeselect={resetAdjudication}
-                  />
-                );
-              })}
+              {officialCandidates.map((candidate) => (
+                <CandidateButton
+                  key={candidate.id}
+                  candidate={candidate}
+                  isSelected={
+                    currentWriteIn &&
+                    currentWriteIn.status === 'adjudicated' &&
+                    currentWriteIn.adjudicationType === 'official-candidate' &&
+                    currentWriteIn.candidateId === candidate.id
+                  }
+                  isSelectedStatusUpToDate={isWriteInAdjudicationContextFresh}
+                  onSelect={() => adjudicateAsOfficialCandidate(candidate)}
+                  onDeselect={resetAdjudication}
+                />
+              ))}
             </CandidateButtonList>
           </AdjudicationForm>
           <AdjudicationStickyFooter>

--- a/apps/admin/integration-testing/package.json
+++ b/apps/admin/integration-testing/package.json
@@ -13,17 +13,6 @@
     "test": "playwright test",
     "test:watch": "playwright test --ui"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@playwright/test": "^1.48.1",
     "@votingworks/auth": "workspace:*",

--- a/apps/central-scan/backend/package.json
+++ b/apps/central-scan/backend/package.json
@@ -28,17 +28,6 @@
     "test:watch": "TZ=America/Anchorage jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@votingworks/api": "workspace:*",
     "@votingworks/auth": "workspace:*",

--- a/apps/central-scan/backend/src/app.grout.test.ts
+++ b/apps/central-scan/backend/src/app.grout.test.ts
@@ -29,13 +29,11 @@ import { withApp } from '../test/helpers/setup_app';
 import { mockElectionManagerAuth } from '../test/helpers/auth';
 
 const featureFlagMock = getFeatureFlagMock();
-jest.mock('@votingworks/utils', () => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
-      featureFlagMock.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', () => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
 
 const jurisdiction = TEST_JURISDICTION;
 

--- a/apps/central-scan/backend/src/end_to_end_bmd.test.ts
+++ b/apps/central-scan/backend/src/end_to_end_bmd.test.ts
@@ -21,13 +21,11 @@ import { ScannedSheetInfo } from './fujitsu_scanner';
 jest.setTimeout(20000);
 
 const featureFlagMock = getFeatureFlagMock();
-jest.mock('@votingworks/utils', () => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
-      featureFlagMock.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', () => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
 
 test('going through the whole process works - BMD', async () => {
   const { electionDefinition } = electionFamousNames2021Fixtures;

--- a/apps/central-scan/backend/src/end_to_end_hmpb.test.ts
+++ b/apps/central-scan/backend/src/end_to_end_hmpb.test.ts
@@ -25,13 +25,11 @@ import { mockElectionManagerAuth } from '../test/helpers/auth';
 jest.setTimeout(20000);
 
 const featureFlagMock = getFeatureFlagMock();
-jest.mock('@votingworks/utils', () => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
-      featureFlagMock.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', () => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
 
 test('going through the whole process works - HMPB', async () => {
   featureFlagMock.enableFeatureFlag(

--- a/apps/central-scan/frontend/.lintstagedrc.js
+++ b/apps/central-scan/frontend/.lintstagedrc.js
@@ -1,0 +1,7 @@
+// @ts-check
+
+const { frontend } = require('../../../.lintstagedrc.shared');
+
+module.exports = {
+  ...frontend,
+};

--- a/apps/central-scan/frontend/package.json
+++ b/apps/central-scan/frontend/package.json
@@ -27,18 +27,6 @@
     "test:watch": "TZ=America/Anchorage jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.+(js|jsx|ts|tsx)": [
-      "stylelint --quiet --fix",
-      "eslint --quiet --fix"
-    ],
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/apps/central-scan/integration-testing/package.json
+++ b/apps/central-scan/integration-testing/package.json
@@ -13,17 +13,6 @@
     "test": "playwright test",
     "test:watch": "playwright test --ui"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@playwright/test": "^1.48.1",
     "@votingworks/auth": "workspace:*",

--- a/apps/design/backend/package.json
+++ b/apps/design/backend/package.json
@@ -28,17 +28,6 @@
     "test:watch": "TZ=America/Anchorage jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@google-cloud/text-to-speech": "^5.0.1",
     "@google-cloud/translate": "^8.0.2",

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -72,12 +72,10 @@ jest.setTimeout(60_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 jest.mock('./ballot_style_reports');
 

--- a/apps/design/backend/src/ballot_styles.ts
+++ b/apps/design/backend/src/ballot_styles.ts
@@ -45,13 +45,11 @@ export function generateBallotStyles(params: {
   > = precincts
     .flatMap((precinct) => {
       if (hasSplits(precinct)) {
-        return precinct.splits.map((split) => {
-          return {
-            precinctId: precinct.id,
-            splitId: split.id,
-            districtIds: split.districtIds,
-          };
-        });
+        return precinct.splits.map((split) => ({
+          precinctId: precinct.id,
+          splitId: split.id,
+          districtIds: split.districtIds,
+        }));
       }
       return { precinctId: precinct.id, districtIds: precinct.districtIds };
     })

--- a/apps/design/frontend/.lintstagedrc.js
+++ b/apps/design/frontend/.lintstagedrc.js
@@ -1,0 +1,7 @@
+// @ts-check
+
+const { frontend } = require('../../../.lintstagedrc.shared');
+
+module.exports = {
+  ...frontend,
+};

--- a/apps/design/frontend/package.json
+++ b/apps/design/frontend/package.json
@@ -27,18 +27,6 @@
     "test:watch": "jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "stylelint --quiet --fix",
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/apps/design/frontend/src/nav_screen.tsx
+++ b/apps/design/frontend/src/nav_screen.tsx
@@ -45,15 +45,13 @@ export function ElectionNavScreen({
     <NavScreen
       navContent={
         <NavList>
-          {electionNavRoutes(electionId).map(({ title, path }) => {
-            return (
-              <NavListItem key={path}>
-                <NavLink to={path} isActive={path === currentRoute.url}>
-                  {title}
-                </NavLink>
-              </NavListItem>
-            );
-          })}
+          {electionNavRoutes(electionId).map(({ title, path }) => (
+            <NavListItem key={path}>
+              <NavLink to={path} isActive={path === currentRoute.url}>
+                {title}
+              </NavLink>
+            </NavListItem>
+          ))}
           <NavDivider />
           <NavListItem>
             <LinkButton

--- a/apps/design/frontend/test/setupTests.ts
+++ b/apps/design/frontend/test/setupTests.ts
@@ -17,13 +17,9 @@ beforeEach(() => {
   idFactory.reset();
 });
 
-jest.mock('nanoid', () => {
-  return {
-    customAlphabet: () => () => {
-      return idFactory.next();
-    },
-  };
-});
+jest.mock('nanoid', () => ({
+  customAlphabet: () => () => idFactory.next(),
+}));
 
 global.TextEncoder = TextEncoder;
 

--- a/apps/mark-scan/backend/package.json
+++ b/apps/mark-scan/backend/package.json
@@ -25,17 +25,6 @@
     "test:watch": "TZ=America/Anchorage jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@votingworks/auth": "workspace:*",
     "@votingworks/backend": "workspace:*",

--- a/apps/mark-scan/backend/src/app.auth.test.ts
+++ b/apps/mark-scan/backend/src/app.auth.test.ts
@@ -38,12 +38,10 @@ const systemSettings: SystemSettings = {
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 let apiClient: grout.Client<Api>;
 let mockAuth: InsertedSmartCardAuthApi;

--- a/apps/mark-scan/backend/src/app.diagnostics.test.ts
+++ b/apps/mark-scan/backend/src/app.diagnostics.test.ts
@@ -60,13 +60,11 @@ jest.setTimeout(60_000);
 const TEST_POLLING_INTERVAL_MS = 5;
 
 const featureFlagMock = getFeatureFlagMock();
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
-      featureFlagMock.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
 
 const MOCK_DISK_SPACE_SUMMARY: DiskSpaceSummary = {
   total: 10 * 1_000_000,

--- a/apps/mark-scan/backend/src/app.test.ts
+++ b/apps/mark-scan/backend/src/app.test.ts
@@ -64,14 +64,12 @@ const TEST_POLLING_INTERVAL_MS = 15;
 jest.mock('./pat-input/connection_status_reader');
 
 const featureFlagMock = getFeatureFlagMock();
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
-      featureFlagMock.isEnabled(flag),
-    randomBallotId: () => '12345',
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+  randomBallotId: () => '12345',
+}));
 
 let apiClient: grout.Client<Api>;
 let mockAuth: InsertedSmartCardAuthApi;

--- a/apps/mark-scan/backend/src/app.ui_strings.test.ts
+++ b/apps/mark-scan/backend/src/app.ui_strings.test.ts
@@ -24,12 +24,10 @@ import { mockElectionManagerAuth } from '../test/auth_helpers';
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 const store = Store.memoryStore();
 const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger(), {

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -107,13 +107,11 @@ let clock: SimulatedClock;
 
 const precinctId = electionGeneralDefinition.election.precincts[1].id;
 const featureFlagMock = getFeatureFlagMock();
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
-      featureFlagMock.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
 jest.mock('../audio/outputs');
 jest.setTimeout(2000);
 
@@ -332,9 +330,9 @@ it('logs when an auth error happens', async () => {
 describe('paper jam', () => {
   it('during voter session - logged out', async () => {
     const resetDriverResult = deferred<PaperHandlerDriverInterface>();
-    mockOf(resetAndReconnect).mockImplementation(async () => {
-      return resetDriverResult.promise;
-    });
+    mockOf(resetAndReconnect).mockImplementation(
+      async () => resetDriverResult.promise
+    );
 
     mockOf(auth.getAuthStatus).mockResolvedValue({
       status: 'logged_out',
@@ -355,9 +353,9 @@ describe('paper jam', () => {
 
   it('during voter session - with poll worker auth', async () => {
     const resetDriverResult = deferred<PaperHandlerDriverInterface>();
-    mockOf(resetAndReconnect).mockImplementation(async () => {
-      return resetDriverResult.promise;
-    });
+    mockOf(resetAndReconnect).mockImplementation(
+      async () => resetDriverResult.promise
+    );
 
     mockCardlessVoterAuth(auth);
     clock.increment(delays.DELAY_AUTH_STATUS_POLLING_INTERVAL_MS);
@@ -385,9 +383,9 @@ describe('paper jam', () => {
 
   it('during voter session - with cardless voter auth', async () => {
     const resetDriverResult = deferred<PaperHandlerDriverInterface>();
-    mockOf(resetAndReconnect).mockImplementation(async () => {
-      return resetDriverResult.promise;
-    });
+    mockOf(resetAndReconnect).mockImplementation(
+      async () => resetDriverResult.promise
+    );
 
     mockCardlessVoterAuth(auth);
     clock.increment(delays.DELAY_AUTH_STATUS_POLLING_INTERVAL_MS);
@@ -1355,14 +1353,12 @@ describe('unrecoverable_error', () => {
   beforeEach(() => {
     jest.mock(
       '@votingworks/ballot-interpreter',
-      (): typeof import('@votingworks/ballot-interpreter') => {
-        return {
-          ...jest.requireActual('@votingworks/ballot-interpreter'),
-          interpretSimplexBmdBallot: () => {
-            throw new Error('Test error interpreting BMD ballot');
-          },
-        };
-      }
+      (): typeof import('@votingworks/ballot-interpreter') => ({
+        ...jest.requireActual('@votingworks/ballot-interpreter'),
+        interpretSimplexBmdBallot: () => {
+          throw new Error('Test error interpreting BMD ballot');
+        },
+      })
     );
   });
 

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -619,9 +619,7 @@ export function buildMachine(
                 BEGIN_ACCEPTING_PAPER: {
                   target: 'accepting_paper',
                   actions: assign({
-                    acceptedPaperTypes: (_, event) => {
-                      return event.paperTypes;
-                    },
+                    acceptedPaperTypes: (_, event) => event.paperTypes,
                   }),
                 },
               },
@@ -804,9 +802,7 @@ export function buildMachine(
               invoke: [
                 {
                   id: 'scanAndSave',
-                  src: (context) => {
-                    return scanAndSave(context.driver, 'backward');
-                  },
+                  src: (context) => scanAndSave(context.driver, 'backward'),
                   onDone: {
                     target: 'interpreting',
                     actions: assign({
@@ -1176,10 +1172,9 @@ export function buildMachine(
           id: 'jam_physically_cleared',
           invoke: {
             id: 'resetScanAndDriver',
-            src: (context) => {
-              // Issue the scan-reset command, create a new WebUSB device, and reconnect
-              return resetAndReconnect(context.driver);
-            },
+            src: (context) =>
+              // Issue the scan-reset command, create a new WebUSB device, and reconnect*/
+              resetAndReconnect(context.driver),
             onDone: {
               target: 'voting_flow.resetting_state_machine_after_jam',
               actions: assign({

--- a/apps/mark-scan/backend/src/server.test.ts
+++ b/apps/mark-scan/backend/src/server.test.ts
@@ -13,20 +13,19 @@ import { resolveDriver, start } from './server';
 import { createWorkspace } from './util/workspace';
 
 const featureFlagMock = getFeatureFlagMock();
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
-      featureFlagMock.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
 
-jest.mock('@votingworks/backend', (): typeof import('@votingworks/backend') => {
-  return {
+jest.mock(
+  '@votingworks/backend',
+  (): typeof import('@votingworks/backend') => ({
     ...jest.requireActual('@votingworks/backend'),
     initializeSystemAudio: jest.fn(),
-  };
-});
+  })
+);
 
 afterEach(() => {
   featureFlagMock.resetFeatureFlags();

--- a/apps/mark-scan/backend/src/util/hardware.test.ts
+++ b/apps/mark-scan/backend/src/util/hardware.test.ts
@@ -15,13 +15,11 @@ import {
 
 jest.mock('@votingworks/backend');
 const featureFlagMock = getFeatureFlagMock();
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
-      featureFlagMock.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
 
 let workspaceDir: tmp.DirResult;
 const MOCK_PID = 12345;

--- a/apps/mark-scan/backend/src/util/render_ballot.test.ts
+++ b/apps/mark-scan/backend/src/util/render_ballot.test.ts
@@ -82,9 +82,9 @@ test("throws an error if a single page can't be rendered after max retries", asy
 });
 
 test('short ciruits if getLayout returns an error', async () => {
-  mockOf(getLayout).mockImplementation(() => {
-    return err(new NoLayoutOptionError(10, 10, 'markScan'));
-  });
+  mockOf(getLayout).mockImplementation(() =>
+    err(new NoLayoutOptionError(10, 10, 'markScan'))
+  );
   mockOf(pdfToImages).mockImplementation(() => mockPdfToImages(1));
 
   const { store } = workspace;

--- a/apps/mark-scan/frontend/.lintstagedrc.js
+++ b/apps/mark-scan/frontend/.lintstagedrc.js
@@ -1,0 +1,7 @@
+// @ts-check
+
+const { frontend } = require('../../../.lintstagedrc.shared');
+
+module.exports = {
+  ...frontend,
+};

--- a/apps/mark-scan/frontend/package.json
+++ b/apps/mark-scan/frontend/package.json
@@ -28,18 +28,6 @@
     "test:watch": "TZ=America/Anchorage jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.+(js|jsx|ts|tsx)": [
-      "stylelint --quiet --fix",
-      "eslint --quiet --fix"
-    ],
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.test.tsx
@@ -45,12 +45,10 @@ const { election } = electionGeneralDefinition;
 let apiMock: ApiMock;
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 jest.mock('./inserted_invalid_new_sheet_screen');
 jest.mock('./inserted_preprinted_ballot_screen');

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
@@ -484,20 +484,18 @@ export function PollWorkerScreen({
           </P>
           <ButtonGrid>
             {getPollTransitionsFromState(pollsState).map(
-              (pollsTransition, index) => {
-                return (
-                  <UpdatePollsButton
-                    pollsTransition={pollsTransition}
-                    updatePollsState={(newPollsState) =>
-                      setPollsStateMutation.mutate({
-                        pollsState: newPollsState,
-                      })
-                    }
-                    isPrimaryButton={index === 0}
-                    key={`${pollsTransition}-button`}
-                  />
-                );
-              }
+              (pollsTransition, index) => (
+                <UpdatePollsButton
+                  pollsTransition={pollsTransition}
+                  updatePollsState={(newPollsState) =>
+                    setPollsStateMutation.mutate({
+                      pollsState: newPollsState,
+                    })
+                  }
+                  isPrimaryButton={index === 0}
+                  key={`${pollsTransition}-button`}
+                />
+              )
             )}
           </ButtonGrid>
           <H3>System</H3>

--- a/apps/mark-scan/integration-testing/package.json
+++ b/apps/mark-scan/integration-testing/package.json
@@ -13,17 +13,6 @@
     "test": "playwright test",
     "test:watch": "playwright test --ui"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@playwright/test": "^1.48.1",
     "@votingworks/auth": "workspace:*",

--- a/apps/mark/backend/package.json
+++ b/apps/mark/backend/package.json
@@ -25,17 +25,6 @@
     "test:watch": "jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@votingworks/auth": "workspace:*",
     "@votingworks/backend": "workspace:*",

--- a/apps/mark/backend/src/app.auth.test.ts
+++ b/apps/mark/backend/src/app.auth.test.ts
@@ -34,12 +34,10 @@ beforeAll(() => {
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 beforeEach(() => {
   mockFeatureFlagger.enableFeatureFlag(

--- a/apps/mark/backend/src/app.test.ts
+++ b/apps/mark/backend/src/app.test.ts
@@ -55,13 +55,11 @@ import { isAccessibleControllerAttached } from './util/accessible_controller';
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-    randomBallotId: () => '12345',
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+  randomBallotId: () => '12345',
+}));
 
 jest.mock('./util/accessible_controller');
 

--- a/apps/mark/backend/src/app.ui_strings.test.ts
+++ b/apps/mark/backend/src/app.ui_strings.test.ts
@@ -30,12 +30,10 @@ import { buildMockLogger } from '../test/app_helpers';
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 const store = Store.memoryStore();
 const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger(), {

--- a/apps/mark/backend/src/server.test.ts
+++ b/apps/mark/backend/src/server.test.ts
@@ -7,12 +7,13 @@ import { PORT } from './globals';
 import { start } from './server';
 import { createWorkspace } from './util/workspace';
 
-jest.mock('@votingworks/backend', (): typeof import('@votingworks/backend') => {
-  return {
+jest.mock(
+  '@votingworks/backend',
+  (): typeof import('@votingworks/backend') => ({
     ...jest.requireActual('@votingworks/backend'),
     initializeSystemAudio: jest.fn(),
-  };
-});
+  })
+);
 
 test('can start server', async () => {
   const auth = buildMockInsertedSmartCardAuth();

--- a/apps/mark/frontend/.lintstagedrc.js
+++ b/apps/mark/frontend/.lintstagedrc.js
@@ -1,0 +1,7 @@
+// @ts-check
+
+const { frontend } = require('../../../.lintstagedrc.shared');
+
+module.exports = {
+  ...frontend,
+};

--- a/apps/mark/frontend/package.json
+++ b/apps/mark/frontend/package.json
@@ -28,18 +28,6 @@
     "test:watch": "TZ=America/Anchorage jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.+(js|jsx|ts|tsx)": [
-      "stylelint --quiet --fix",
-      "eslint --quiet --fix"
-    ],
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -379,21 +379,19 @@ export function PollWorkerScreen({
               )}
               <P>
                 {getPollTransitionsFromState(pollsState).map(
-                  (pollsTransition, index) => {
-                    return (
-                      <P key={`${pollsTransition}-button`}>
-                        <UpdatePollsButton
-                          pollsTransition={pollsTransition}
-                          updatePollsState={(newPollsState) =>
-                            setPollsStateMutation.mutate({
-                              pollsState: newPollsState,
-                            })
-                          }
-                          isPrimaryButton={index === 0}
-                        />
-                      </P>
-                    );
-                  }
+                  (pollsTransition, index) => (
+                    <P key={`${pollsTransition}-button`}>
+                      <UpdatePollsButton
+                        pollsTransition={pollsTransition}
+                        updatePollsState={(newPollsState) =>
+                          setPollsStateMutation.mutate({
+                            pollsState: newPollsState,
+                          })
+                        }
+                        isPrimaryButton={index === 0}
+                      />
+                    </P>
+                  )
                 )}
               </P>
               <P>

--- a/apps/mark/frontend/src/pages/print_page.tsx
+++ b/apps/mark/frontend/src/pages/print_page.tsx
@@ -30,11 +30,12 @@ export function PrintPage(): JSX.Element {
   }
 
   // Make sure we clean up any pending timeout on unmount
-  useEffect(() => {
-    return () => {
+  useEffect(
+    () => () => {
       clearTimeout(printerTimer.current);
-    };
-  }, []);
+    },
+    []
+  );
 
   return <MarkFlowPrintPage print={print} />;
 }

--- a/apps/mark/integration-testing/package.json
+++ b/apps/mark/integration-testing/package.json
@@ -13,17 +13,6 @@
     "test": "playwright test",
     "test:watch": "playwright test --ui"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@playwright/test": "^1.48.1",
     "@votingworks/auth": "workspace:*",

--- a/apps/scan/backend/package.json
+++ b/apps/scan/backend/package.json
@@ -28,17 +28,6 @@
     "test:watch": "TZ=America/Anchorage jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@votingworks/auth": "workspace:*",
     "@votingworks/backend": "workspace:*",

--- a/apps/scan/backend/src/app_auth.test.ts
+++ b/apps/scan/backend/src/app_auth.test.ts
@@ -40,12 +40,10 @@ beforeAll(() => {
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 beforeEach(() => {
   mockFeatureFlagger.enableFeatureFlag(

--- a/apps/scan/backend/src/app_config.test.ts
+++ b/apps/scan/backend/src/app_config.test.ts
@@ -33,12 +33,10 @@ jest.setTimeout(30_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 function mockElectionManager(
   mockAuth: InsertedSmartCardAuthApi,

--- a/apps/scan/backend/src/app_diagnostics.test.ts
+++ b/apps/scan/backend/src/app_diagnostics.test.ts
@@ -18,12 +18,10 @@ jest.setTimeout(60_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 beforeEach(() => {
   mockFeatureFlagger.enableFeatureFlag(

--- a/apps/scan/backend/src/app_export.test.ts
+++ b/apps/scan/backend/src/app_export.test.ts
@@ -19,12 +19,10 @@ jest.setTimeout(30_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 beforeEach(() => {
   mockFeatureFlagger.resetFeatureFlags();

--- a/apps/scan/backend/src/app_legacy_printing.test.ts
+++ b/apps/scan/backend/src/app_legacy_printing.test.ts
@@ -12,12 +12,10 @@ jest.setTimeout(60_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 beforeEach(() => {
   mockFeatureFlagger.enableFeatureFlag(

--- a/apps/scan/backend/src/app_polls.test.ts
+++ b/apps/scan/backend/src/app_polls.test.ts
@@ -12,12 +12,10 @@ jest.setTimeout(60_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 const pollsTransitionTime = new Date('2021-01-01T00:00:00.000').getTime();
 jest.mock('./util/get_current_time', () => ({

--- a/apps/scan/backend/src/app_polls_reports.test.ts
+++ b/apps/scan/backend/src/app_polls_reports.test.ts
@@ -11,12 +11,10 @@ jest.setTimeout(60_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 beforeEach(() => {
   mockFeatureFlagger.enableFeatureFlag(

--- a/apps/scan/backend/src/app_scanning.test.ts
+++ b/apps/scan/backend/src/app_scanning.test.ts
@@ -10,12 +10,10 @@ import { delays } from './scanners/pdi/state_machine';
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 beforeEach(() => {
   mockFeatureFlagger.resetFeatureFlags();

--- a/apps/scan/backend/src/app_ui_strings.test.ts
+++ b/apps/scan/backend/src/app_ui_strings.test.ts
@@ -34,12 +34,10 @@ import {
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 const store = Store.memoryStore();
 const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger(), {

--- a/apps/scan/backend/src/app_usb_drive.test.ts
+++ b/apps/scan/backend/src/app_usb_drive.test.ts
@@ -8,12 +8,10 @@ import { configureApp } from '../test/helpers/shared_helpers';
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 beforeEach(() => {
   mockFeatureFlagger.resetFeatureFlags();

--- a/apps/scan/backend/src/scanners/custom/custom_app_scan.test.ts
+++ b/apps/scan/backend/src/scanners/custom/custom_app_scan.test.ts
@@ -58,12 +58,10 @@ jest.setTimeout(20_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 /**
  * Basic checks for logging. We don't try to be exhaustive here because paper

--- a/apps/scan/backend/src/scanners/custom/custom_app_scan_double_sheets.test.ts
+++ b/apps/scan/backend/src/scanners/custom/custom_app_scan_double_sheets.test.ts
@@ -31,12 +31,10 @@ jest.setTimeout(20_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 beforeEach(() => {
   mockFeatureFlagger.enableFeatureFlag(

--- a/apps/scan/backend/src/scanners/custom/custom_app_scan_jam.test.ts
+++ b/apps/scan/backend/src/scanners/custom/custom_app_scan_jam.test.ts
@@ -25,12 +25,10 @@ jest.setTimeout(20_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 const needsReviewInterpretation: SheetInterpretation = {
   type: 'NeedsReviewSheet',

--- a/apps/scan/backend/src/scanners/custom/custom_app_scan_power_off.test.ts
+++ b/apps/scan/backend/src/scanners/custom/custom_app_scan_power_off.test.ts
@@ -25,12 +25,10 @@ jest.setTimeout(20_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 const needsReviewInterpretation: SheetInterpretation = {
   type: 'NeedsReviewSheet',

--- a/apps/scan/backend/src/scanners/custom/custom_app_scan_precinct_config.test.ts
+++ b/apps/scan/backend/src/scanners/custom/custom_app_scan_precinct_config.test.ts
@@ -20,12 +20,10 @@ jest.setTimeout(20_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 beforeEach(() => {
   mockFeatureFlagger.enableFeatureFlag(

--- a/apps/scan/backend/src/scanners/custom/custom_app_scan_shoeshine_mode.test.ts
+++ b/apps/scan/backend/src/scanners/custom/custom_app_scan_shoeshine_mode.test.ts
@@ -24,12 +24,10 @@ jest.setTimeout(20_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 beforeEach(() => {
   mockFeatureFlagger.enableFeatureFlag(
     BooleanEnvironmentVariableName.SKIP_ELECTION_PACKAGE_AUTHENTICATION

--- a/apps/scan/backend/src/scanners/pdi/pdi_app_diagnostic.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_diagnostic.test.ts
@@ -23,12 +23,10 @@ jest.setTimeout(20_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 beforeEach(() => {
   mockFeatureFlagger.enableFeatureFlag(

--- a/apps/scan/backend/src/scanners/pdi/pdi_app_double_feed_calibration.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_double_feed_calibration.test.ts
@@ -20,12 +20,10 @@ jest.setTimeout(20_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 beforeEach(() => {
   mockFeatureFlagger.enableFeatureFlag(

--- a/apps/scan/backend/src/scanners/pdi/pdi_app_scan.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_scan.test.ts
@@ -28,12 +28,10 @@ jest.setTimeout(20_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 beforeEach(() => {
   mockFeatureFlagger.enableFeatureFlag(

--- a/apps/scan/backend/src/scanners/pdi/pdi_app_scan_cover_open.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_scan_cover_open.test.ts
@@ -15,12 +15,10 @@ jest.setTimeout(20_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 beforeEach(() => {
   mockFeatureFlagger.enableFeatureFlag(

--- a/apps/scan/backend/src/scanners/pdi/pdi_app_scan_disconnect.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_scan_disconnect.test.ts
@@ -38,12 +38,10 @@ jest.setTimeout(20_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 beforeEach(() => {
   mockFeatureFlagger.enableFeatureFlag(

--- a/apps/scan/backend/src/scanners/pdi/pdi_app_scan_double_sheet.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_scan_double_sheet.test.ts
@@ -33,12 +33,10 @@ jest.setTimeout(20_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 beforeEach(() => {
   mockFeatureFlagger.enableFeatureFlag(

--- a/apps/scan/backend/src/scanners/pdi/pdi_app_scan_jam.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_scan_jam.test.ts
@@ -28,12 +28,10 @@ jest.setTimeout(20_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 beforeEach(() => {
   mockFeatureFlagger.enableFeatureFlag(

--- a/apps/scan/backend/src/scanners/pdi/pdi_app_scan_paused.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_scan_paused.test.ts
@@ -19,12 +19,10 @@ jest.setTimeout(20_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 beforeEach(() => {
   mockFeatureFlagger.enableFeatureFlag(

--- a/apps/scan/backend/src/scanners/pdi/pdi_app_scan_shoeshine_mode.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_scan_shoeshine_mode.test.ts
@@ -22,12 +22,10 @@ jest.setTimeout(20_000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 beforeEach(() => {
   mockFeatureFlagger.enableFeatureFlag(

--- a/apps/scan/backend/src/store.test.ts
+++ b/apps/scan/backend/src/store.test.ts
@@ -40,12 +40,10 @@ jest.setTimeout(20000);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 const jurisdiction = TEST_JURISDICTION;
 const electionPackageHash = 'test-election-package-hash';

--- a/apps/scan/frontend/.lintstagedrc.js
+++ b/apps/scan/frontend/.lintstagedrc.js
@@ -1,0 +1,7 @@
+// @ts-check
+
+const { frontend } = require('../../../.lintstagedrc.shared');
+
+module.exports = {
+  ...frontend,
+};

--- a/apps/scan/frontend/package.json
+++ b/apps/scan/frontend/package.json
@@ -28,18 +28,6 @@
     "test:watch": "TZ=America/Anchorage jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "stylelint --quiet --fix",
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/apps/scan/frontend/src/preview_dashboard.tsx
+++ b/apps/scan/frontend/src/preview_dashboard.tsx
@@ -172,22 +172,20 @@ export function PreviewDashboard({
             <div style={{ height: '100%', overflow: 'auto' }}>
               <H1>Previews</H1>
               <PreviewColumns>
-                {previewables.map(({ componentName, previews }) => {
-                  return (
-                    <Prose key={componentName}>
-                      <H4>{componentName}</H4>
-                      <ul>
-                        {previews.map((preview) => (
-                          <li key={preview.previewName}>
-                            <Link to={getPreviewUrl(preview)}>
-                              {preview.previewName}
-                            </Link>
-                          </li>
-                        ))}
-                      </ul>
-                    </Prose>
-                  );
-                })}
+                {previewables.map(({ componentName, previews }) => (
+                  <Prose key={componentName}>
+                    <H4>{componentName}</H4>
+                    <ul>
+                      {previews.map((preview) => (
+                        <li key={preview.previewName}>
+                          <Link to={getPreviewUrl(preview)}>
+                            {preview.previewName}
+                          </Link>
+                        </li>
+                      ))}
+                    </ul>
+                  </Prose>
+                ))}
               </PreviewColumns>
               <ConfigBox>
                 <Select

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -344,39 +344,35 @@ export function ElectionManagerScreen({
       <TabbedSection ariaLabel="Election Manager Menu" tabs={tabs} />
 
       {isConfirmingBallotModeSwitch &&
-        (() => {
-          return (
-            <Modal
-              title={`Switch to ${
-                isTestMode ? 'Official' : 'Test'
-              } Ballot Mode`}
-              content={
-                <P>
-                  Switching to {isTestMode ? 'official' : 'test'} ballot mode
-                  will clear all scanned ballot data and reset the polls.
-                </P>
-              }
-              actions={
-                <React.Fragment>
-                  <Button
-                    onPress={switchMode}
-                    variant={isTestMode ? 'primary' : 'danger'}
-                    icon={isTestMode ? undefined : 'Danger'}
-                    disabled={setTestModeMutation.isLoading}
-                  >
-                    Switch to {isTestMode ? 'Official' : 'Test'} Ballot Mode
-                  </Button>
-                  <Button
-                    onPress={() => setIsConfirmingBallotModeSwitch(false)}
-                    disabled={setTestModeMutation.isLoading}
-                  >
-                    Cancel
-                  </Button>
-                </React.Fragment>
-              }
-            />
-          );
-        })()}
+        (() => (
+          <Modal
+            title={`Switch to ${isTestMode ? 'Official' : 'Test'} Ballot Mode`}
+            content={
+              <P>
+                Switching to {isTestMode ? 'official' : 'test'} ballot mode will
+                clear all scanned ballot data and reset the polls.
+              </P>
+            }
+            actions={
+              <React.Fragment>
+                <Button
+                  onPress={switchMode}
+                  variant={isTestMode ? 'primary' : 'danger'}
+                  icon={isTestMode ? undefined : 'Danger'}
+                  disabled={setTestModeMutation.isLoading}
+                >
+                  Switch to {isTestMode ? 'Official' : 'Test'} Ballot Mode
+                </Button>
+                <Button
+                  onPress={() => setIsConfirmingBallotModeSwitch(false)}
+                  disabled={setTestModeMutation.isLoading}
+                >
+                  Cancel
+                </Button>
+              </React.Fragment>
+            }
+          />
+        ))()}
 
       {isExportingResults && (
         <ExportResultsModal

--- a/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
@@ -25,13 +25,11 @@ let startNewVoterSessionMock: jest.Mock;
 
 const featureFlagMock = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
-      featureFlagMock.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
 
 beforeEach(() => {
   featureFlagMock.resetFeatureFlags();

--- a/apps/scan/frontend/src/screens/scan_warning_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/scan_warning_screen.test.tsx
@@ -19,12 +19,10 @@ import {
   MisvoteWarnings,
 } from '../components/misvote_warnings';
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: jest.fn(),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: jest.fn(),
+}));
 
 jest.mock(
   '../components/misvote_warnings',

--- a/docs/exercises/package.json
+++ b/docs/exercises/package.json
@@ -16,17 +16,6 @@
     "test:watch": "jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@types/jest": "^29.5.3",
     "@types/node": "20.16.0",

--- a/libs/api/package.json
+++ b/libs/api/package.json
@@ -23,17 +23,6 @@
     "test:watch": "jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@votingworks/basics": "workspace:*",
     "@votingworks/fixtures": "workspace:*",

--- a/libs/auth/package.json
+++ b/libs/auth/package.json
@@ -20,17 +20,6 @@
     "test:watch": "jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@votingworks/basics": "workspace:*",
     "@votingworks/db": "workspace:*",

--- a/libs/backend/package.json
+++ b/libs/backend/package.json
@@ -23,17 +23,6 @@
     "test:watch": "TZ=America/Anchorage jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@types/uuid": "9.0.5",
     "@votingworks/auth": "workspace:*",

--- a/libs/backend/src/cast_vote_records/build_report_metadata.ts
+++ b/libs/backend/src/cast_vote_records/build_report_metadata.ts
@@ -115,13 +115,11 @@ function buildElection({
     '@type': 'CVR.Election',
     '@id': electionId,
     Name: election.title,
-    Candidate: allCandidatesDeduplicated.map((candidate) => {
-      return {
-        '@type': 'CVR.Candidate',
-        '@id': candidate.id,
-        Name: candidate.name,
-      };
-    }),
+    Candidate: allCandidatesDeduplicated.map((candidate) => ({
+      '@type': 'CVR.Candidate',
+      '@id': candidate.id,
+      Name: candidate.name,
+    })),
     Contest: election.contests.map(buildContest),
     ElectionScopeId: electionScopeId,
   };

--- a/libs/backend/src/cast_vote_records/import.test.ts
+++ b/libs/backend/src/cast_vote_records/import.test.ts
@@ -25,12 +25,10 @@ import {
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 beforeEach(() => {
   process.env['VX_MACHINE_TYPE'] = 'admin';

--- a/libs/ballot-encoder/package.json
+++ b/libs/ballot-encoder/package.json
@@ -22,17 +22,6 @@
     "test:watch": "jest --watch",
     "pre-commit": "lint-staged"
   },
-  "lint-staged": {
-    "*.(js|ts)": [
-      "eslint --quiet --fix"
-    ],
-    "*.md": [
-      "prettier --write"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@votingworks/basics": "workspace:*",
     "@votingworks/types": "workspace:*",

--- a/libs/ballot-interpreter/package.json
+++ b/libs/ballot-interpreter/package.json
@@ -29,17 +29,6 @@
     "test:ts:watch": "jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@votingworks/ballot-encoder": "workspace:*",
     "@votingworks/basics": "workspace:*",

--- a/libs/ballot-interpreter/src/interpret.ts
+++ b/libs/ballot-interpreter/src/interpret.ts
@@ -879,12 +879,10 @@ export async function interpretSheetAndSaveImages(
     return asSheet(
       iter(interpreted)
         .zip(imagePaths)
-        .map(([{ interpretation }, imagePath]) => {
-          return {
-            interpretation,
-            imagePath,
-          };
-        })
+        .map(([{ interpretation }, imagePath]) => ({
+          interpretation,
+          imagePath,
+        }))
         .toArray()
     );
   } finally {

--- a/libs/basics/package.json
+++ b/libs/basics/package.json
@@ -20,17 +20,6 @@
     "test:watch": "jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "deep-eql": "4.1.3",
     "util": "^0.12.4"

--- a/libs/basics/src/result.test.ts
+++ b/libs/basics/src/result.test.ts
@@ -142,19 +142,11 @@ test('resultBlock trivial', () => {
 });
 
 test('resultBlock ok', () => {
-  expect(
-    resultBlock(() => {
-      return 0;
-    })
-  ).toEqual(ok(0));
+  expect(resultBlock(() => 0)).toEqual(ok(0));
 });
 
 test('resultBlock ok result', () => {
-  expect(
-    resultBlock(() => {
-      return ok(0);
-    })
-  ).toEqual(ok(0));
+  expect(resultBlock(() => ok(0))).toEqual(ok(0));
 });
 
 test('resultBlock thrown error', () => {
@@ -212,18 +204,14 @@ test('asyncResultBlock trivial', async () => {
 });
 
 test('asyncResultBlock ok', async () => {
-  expect(
-    await asyncResultBlock(async () => {
-      return await Promise.resolve(0);
-    })
-  ).toEqual(ok(0));
+  expect(await asyncResultBlock(async () => await Promise.resolve(0))).toEqual(
+    ok(0)
+  );
 });
 
 test('asyncResultBlock ok result', async () => {
   expect(
-    await asyncResultBlock(async () => {
-      return await Promise.resolve(ok(0));
-    })
+    await asyncResultBlock(async () => await Promise.resolve(ok(0)))
   ).toEqual(ok(0));
 });
 

--- a/libs/bmd-ballot-fixtures/.lintstagedrc.js
+++ b/libs/bmd-ballot-fixtures/.lintstagedrc.js
@@ -1,0 +1,7 @@
+// @ts-check
+
+const { frontend } = require('../../.lintstagedrc.shared');
+
+module.exports = {
+  ...frontend,
+};

--- a/libs/bmd-ballot-fixtures/package.json
+++ b/libs/bmd-ballot-fixtures/package.json
@@ -26,18 +26,6 @@
     "test:watch": "TZ=America/Anchorage jest --watch",
     "pre-commit": "lint-staged"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "stylelint --quiet --fix",
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@types/tmp": "0.2.4",
     "@votingworks/basics": "workspace:*",

--- a/libs/cdf-schema-builder/package.json
+++ b/libs/cdf-schema-builder/package.json
@@ -26,17 +26,6 @@
     "test:watch": "jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.(js|ts)": [
-      "eslint --quiet --fix"
-    ],
-    "*.md": [
-      "prettier --write"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@votingworks/basics": "workspace:*",
     "jsdom": "20.0.1",

--- a/libs/custom-paper-handler/src/driver/driver.ts
+++ b/libs/custom-paper-handler/src/driver/driver.ts
@@ -243,12 +243,8 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
     let i = -1;
     while (!bufferClear) {
       bufferClear = await Promise.race([
-        sleep(1000).then(() => {
-          return true;
-        }),
-        this.transferInGeneric().then(() => {
-          return false;
-        }),
+        sleep(1000).then(() => true),
+        this.transferInGeneric().then(() => false),
       ]);
       i += 1;
     }

--- a/libs/custom-paper-handler/src/driver/mock_minimal_web_usb_device.ts
+++ b/libs/custom-paper-handler/src/driver/mock_minimal_web_usb_device.ts
@@ -2,21 +2,11 @@ import { MinimalWebUsbDevice } from './minimal_web_usb_device';
 
 export function mockMinimalWebUsbDevice(): MinimalWebUsbDevice {
   return {
-    open: () => {
-      return Promise.resolve();
-    },
-    close: () => {
-      return Promise.resolve();
-    },
-    transferOut: () => {
-      return Promise.resolve(new USBOutTransferResult('ok'));
-    },
-    transferIn: () => {
-      return Promise.resolve(new USBInTransferResult('ok'));
-    },
-    claimInterface: (): Promise<void> => {
-      return Promise.resolve();
-    },
+    open: () => Promise.resolve(),
+    close: () => Promise.resolve(),
+    transferOut: () => Promise.resolve(new USBOutTransferResult('ok')),
+    transferIn: () => Promise.resolve(new USBInTransferResult('ok')),
+    claimInterface: (): Promise<void> => Promise.resolve(),
     selectConfiguration(): Promise<void> {
       return Promise.resolve();
     },

--- a/libs/dev-dock/backend/package.json
+++ b/libs/dev-dock/backend/package.json
@@ -20,17 +20,6 @@
     "test:watch": "jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@votingworks/auth": "workspace:*",
     "@votingworks/basics": "workspace:*",

--- a/libs/dev-dock/backend/src/dev_dock_api.test.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.test.ts
@@ -33,13 +33,11 @@ import {
 const TEST_DEV_DOCK_FILE_PATH = '/tmp/dev-dock.test.json';
 
 const featureFlagMock = getFeatureFlagMock();
-jest.mock('@votingworks/utils', () => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
-      featureFlagMock.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', () => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
 
 let server: Server;
 

--- a/libs/dev-dock/frontend/package.json
+++ b/libs/dev-dock/frontend/package.json
@@ -20,17 +20,6 @@
     "test:watch": "jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^6.2.1",
     "@fortawesome/react-fontawesome": "^0.2.0",

--- a/libs/dev-dock/frontend/src/dev_dock.test.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.test.tsx
@@ -41,13 +41,11 @@ const pollWorkerCardStatus: CardStatus = {
 };
 
 const featureFlagMock = getFeatureFlagMock();
-jest.mock('@votingworks/utils', () => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
-      featureFlagMock.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', () => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
 
 let mockApiClient: MockClient<Api>;
 let kiosk!: jest.Mocked<KioskBrowser.Kiosk>;

--- a/libs/eslint-plugin-vx/package.json
+++ b/libs/eslint-plugin-vx/package.json
@@ -38,7 +38,6 @@
     "eslint-plugin-jest": "^27.2.3",
     "eslint-plugin-jsx-a11y": "^6.6.1",
     "eslint-plugin-n": "17",
-    "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-react": "^7.31.8",
     "typescript": "5.6.2"
   },

--- a/libs/eslint-plugin-vx/src/configs/react.ts
+++ b/libs/eslint-plugin-vx/src/configs/react.ts
@@ -14,7 +14,7 @@ export = {
     'plugin:react/recommended',
     'plugin:react/jsx-runtime',
     'plugin:jsx-a11y/recommended',
-    'plugin:prettier/recommended', // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
+    'prettier', // Disables rules that conflict with Prettier
   ],
   settings: {
     ...recommended.settings,

--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -19,7 +19,7 @@ export = {
     'plugin:import/typescript',
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended', // Uses the recommended rules from @typescript-eslint/eslint-plugin
-    'plugin:prettier/recommended', // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
+    'prettier', // Disables rules that conflict with Prettier
   ],
   plugins: ['@typescript-eslint/eslint-plugin', 'n', 'vx'],
   settings: {

--- a/libs/fixture-generators/src/cli/generate-cvrs/main.test.ts
+++ b/libs/fixture-generators/src/cli/generate-cvrs/main.test.ts
@@ -39,12 +39,10 @@ const outputPath = join(
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
 
 beforeEach(() => {
   mkdirSync(outputPath);

--- a/libs/fixtures/package.json
+++ b/libs/fixtures/package.json
@@ -26,17 +26,6 @@
     "test:ci": "jest --coverage --ci --reporters=default --reporters=jest-junit --maxWorkers=6 && pnpm build:resources --check",
     "pre-commit": "lint-staged"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@votingworks/types": "workspace:*",
     "buffer": "^6.0.3",

--- a/libs/fs/package.json
+++ b/libs/fs/package.json
@@ -23,17 +23,6 @@
     "test:watch": "jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@votingworks/basics": "workspace:*",
     "@votingworks/grout": "workspace:*",

--- a/libs/fujitsu-thermal-printer/src/driver/mock_minimal_web_usb_device.ts
+++ b/libs/fujitsu-thermal-printer/src/driver/mock_minimal_web_usb_device.ts
@@ -2,24 +2,12 @@ import { MinimalWebUsbDevice } from './minimal_web_usb_device';
 
 export function mockMinimalWebUsbDevice(): MinimalWebUsbDevice {
   return {
-    open: () => {
-      return Promise.resolve();
-    },
-    close: () => {
-      return Promise.resolve();
-    },
-    transferOut: () => {
-      return Promise.resolve(new USBOutTransferResult('ok'));
-    },
-    controlTransferIn: () => {
-      return Promise.resolve(new USBInTransferResult('ok'));
-    },
-    claimInterface: (): Promise<void> => {
-      return Promise.resolve();
-    },
-    releaseInterface: (): Promise<void> => {
-      return Promise.resolve();
-    },
+    open: () => Promise.resolve(),
+    close: () => Promise.resolve(),
+    transferOut: () => Promise.resolve(new USBOutTransferResult('ok')),
+    controlTransferIn: () => Promise.resolve(new USBInTransferResult('ok')),
+    claimInterface: (): Promise<void> => Promise.resolve(),
+    releaseInterface: (): Promise<void> => Promise.resolve(),
     selectConfiguration(): Promise<void> {
       return Promise.resolve();
     },

--- a/libs/grout/package.json
+++ b/libs/grout/package.json
@@ -20,17 +20,6 @@
     "test:watch": "jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@votingworks/basics": "workspace:*",
     "cross-fetch": "^3.1.5",

--- a/libs/grout/src/serialization.ts
+++ b/libs/grout/src/serialization.ts
@@ -125,9 +125,7 @@ const resultTagger: Tagger<
     isOk: value.isOk(),
     value: value.isOk() ? value.ok() : value.err(),
   }),
-  deserialize: (value) => {
-    return value.isOk ? ok(value.value) : err(value.value);
-  },
+  deserialize: (value) => (value.isOk ? ok(value.value) : err(value.value)),
 };
 
 const bufferTagger: Tagger<Buffer, string> = {

--- a/libs/grout/test-utils/package.json
+++ b/libs/grout/test-utils/package.json
@@ -20,17 +20,6 @@
     "test:watch": "jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@votingworks/test-utils": "workspace:*"
   },

--- a/libs/hmpb/package.json
+++ b/libs/hmpb/package.json
@@ -27,17 +27,6 @@
     "test:watch": "jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@votingworks/ballot-encoder": "workspace:*",
     "@votingworks/basics": "workspace:*",

--- a/libs/image-utils/package.json
+++ b/libs/image-utils/package.json
@@ -31,17 +31,6 @@
     "pixelmatch": "^5.3.0",
     "tmp": "^0.2.1"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "devDependencies": {
     "@jest/types": "^29.6.1",
     "@types/debug": "4.1.8",

--- a/libs/logging/.lintstagedrc.js
+++ b/libs/logging/.lintstagedrc.js
@@ -1,0 +1,8 @@
+// @ts-check
+
+const { base } = require('../../.lintstagedrc.shared');
+
+module.exports = {
+  ...base,
+  'log_event_ids.ts': ['pnpm build:generate_docs'],
+};

--- a/libs/logging/package.json
+++ b/libs/logging/package.json
@@ -27,20 +27,6 @@
     "test:ci": "pnpm build && pnpm test:coverage --reporters=default --reporters=jest-junit --maxWorkers=6 && pnpm build:generate-typescript-types --check && pnpm build:generate-rust-types --check",
     "pre-commit": "lint-staged"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "log_event_ids.ts": [
-      "pnpm build:generate_docs"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@iarna/toml": "^2.2.5",
     "@votingworks/basics": "workspace:*",

--- a/libs/logging/scripts/generate_types_from_toml.ts
+++ b/libs/logging/scripts/generate_types_from_toml.ts
@@ -1,6 +1,6 @@
 import yargs from 'yargs/yargs';
 import { promisify } from 'node:util';
-import { exec as callbackExec } from 'node:child_process';
+import { execFile as callbackExecFile } from 'node:child_process';
 import toml from '@iarna/toml';
 import fs from 'node:fs/promises';
 import { createReadStream, createWriteStream } from 'node:fs';
@@ -18,7 +18,7 @@ import {
   getTypedConfig,
 } from './types';
 
-const exec = promisify(callbackExec);
+const execFile = promisify(callbackExecFile);
 
 async function prepareOutputFile(filepath: string): Promise<void> {
   await fs.copyFile(logEventIdsTemplateFilepath, filepath);
@@ -126,7 +126,7 @@ async function main(): Promise<void> {
     yield* formatGetDetailsForEventId(typedConfig);
   }, out);
 
-  const { stderr } = await exec(`eslint ${filepath} --fix`);
+  const { stderr } = await execFile('prettier', ['--write', filepath]);
   if (stderr) {
     throw new Error(`Error running eslint: ${stderr}`);
   }

--- a/libs/logging/src/log_documentation.ts
+++ b/libs/logging/src/log_documentation.ts
@@ -65,13 +65,11 @@ export function generateCdfLogDocumentationFileContent(
         eventIdDetails.restrictInDocumentationToApps === undefined ||
         eventIdDetails.restrictInDocumentationToApps.includes(appType)
     )
-    .map((eventIdDetails) => {
-      return {
-        '@type': 'EventLogging.EventIdDescription',
-        Id: eventIdDetails.eventId,
-        Description: eventIdDetails.documentationMessage,
-      };
-    });
+    .map((eventIdDetails) => ({
+      '@type': 'EventLogging.EventIdDescription',
+      Id: eventIdDetails.eventId,
+      Description: eventIdDetails.documentationMessage,
+    }));
   const documentationLog: EventLogging.ElectionEventLogDocumentation = {
     '@type': 'EventLogging.ElectionEventLogDocumentation',
     DeviceManufacturer: machineManufacturer,

--- a/libs/mark-flow-ui/.lintstagedrc.js
+++ b/libs/mark-flow-ui/.lintstagedrc.js
@@ -1,0 +1,10 @@
+// @ts-check
+
+const { frontend } = require('../../.lintstagedrc.shared');
+
+module.exports = {
+  ...frontend,
+  '(app_strings.tsx|number_strings.ts|finalize_app_strings_catalog.ts)': [
+    'pnpm build:app-strings-catalog',
+  ],
+};

--- a/libs/mark-flow-ui/package.json
+++ b/libs/mark-flow-ui/package.json
@@ -27,18 +27,6 @@
     "test:watch": "jest --watch",
     "pre-commit": "lint-staged"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "stylelint --quiet --fix",
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.2.1",
     "@fortawesome/free-regular-svg-icons": "^6.2.1",

--- a/libs/mark-flow-ui/src/components/candidate_contest.tsx
+++ b/libs/mark-flow-ui/src/components/candidate_contest.tsx
@@ -195,18 +195,18 @@ export function CandidateContest({
   }
 
   function onKeyboardInput(key: string) {
-    setWriteInCandidateName((prevName) => {
-      return (prevName + key)
+    setWriteInCandidateName((prevName) =>
+      (prevName + key)
         .trimStart()
         .replace(/\s+/g, ' ')
-        .slice(0, WRITE_IN_CANDIDATE_MAX_LENGTH);
-    });
+        .slice(0, WRITE_IN_CANDIDATE_MAX_LENGTH)
+    );
   }
 
   function onKeyboardBackspace() {
-    setWriteInCandidateName((prevName) => {
-      return prevName.slice(0, Math.max(0, prevName.length - 1));
-    });
+    setWriteInCandidateName((prevName) =>
+      prevName.slice(0, Math.max(0, prevName.length - 1))
+    );
   }
 
   const writeInCharsRemaining =
@@ -333,27 +333,25 @@ export function CandidateContest({
             {contest.allowWriteIns &&
               vote
                 .filter((c) => c.isWriteIn)
-                .map((candidate) => {
-                  return (
-                    <ContestChoiceButton
-                      key={candidate.id}
-                      isSelected
-                      choice={candidate.id}
-                      onPress={handleUpdateSelection}
-                      label={
-                        <React.Fragment>
-                          <AudioOnly>
-                            {appStrings.labelSelected()}
-                            {appStrings.labelWriteInCandidateName()}
-                          </AudioOnly>
-                          {/* User-generated content - no translation/audio available: */}
-                          {candidate.name}
-                        </React.Fragment>
-                      }
-                      caption={appStrings.labelWriteInTitleCase()}
-                    />
-                  );
-                })}
+                .map((candidate) => (
+                  <ContestChoiceButton
+                    key={candidate.id}
+                    isSelected
+                    choice={candidate.id}
+                    onPress={handleUpdateSelection}
+                    label={
+                      <React.Fragment>
+                        <AudioOnly>
+                          {appStrings.labelSelected()}
+                          {appStrings.labelWriteInCandidateName()}
+                        </AudioOnly>
+                        {/* User-generated content - no translation/audio available: */}
+                        {candidate.name}
+                      </React.Fragment>
+                    }
+                    caption={appStrings.labelWriteInTitleCase()}
+                  />
+                ))}
             {contest.allowWriteIns && (
               <ContestChoiceButton
                 choice="write-in"

--- a/libs/message-coder/src/byte_array_with_length_prefix.ts
+++ b/libs/message-coder/src/byte_array_with_length_prefix.ts
@@ -30,12 +30,11 @@ class VariableLengthByteArrayCoder extends BaseCoder<Uint8Array> {
   }
 
   bitLength(value: Uint8Array): Result<number, CoderError> {
-    return resultBlock((fail) => {
-      return (
+    return resultBlock(
+      (fail) =>
         this.lengthCoder.bitLength(value.length).okOrElse(fail) +
         toBitLength(value.byteLength)
-      );
-    });
+    );
   }
 
   encodeInto(

--- a/libs/monorepo-utils/package.json
+++ b/libs/monorepo-utils/package.json
@@ -20,17 +20,6 @@
     "test:ci": "jest --coverage --ci --reporters=default --reporters=jest-junit --maxWorkers=7",
     "pre-commit": "lint-staged"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@votingworks/basics": "workspace:*"
   },

--- a/libs/pdi-scanner/package.json
+++ b/libs/pdi-scanner/package.json
@@ -28,17 +28,6 @@
     "test:ts:watch": "jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@votingworks/basics": "workspace:*",
     "@votingworks/image-utils": "workspace:*",

--- a/libs/printing/package.json
+++ b/libs/printing/package.json
@@ -21,17 +21,6 @@
     "test:watch": "TZ=America/Anchorage jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@votingworks/basics": "workspace:*",
     "@votingworks/fixtures": "workspace:*",

--- a/libs/printing/src/printer/printer.test.ts
+++ b/libs/printing/src/printer/printer.test.ts
@@ -10,13 +10,11 @@ import { BROTHER_THERMAL_PRINTER_CONFIG, HP_LASER_PRINTER_CONFIG } from '.';
 import { MockFilePrinter } from './mocks/file_printer';
 
 const featureFlagMock = getFeatureFlagMock();
-jest.mock('@votingworks/utils', () => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
-      featureFlagMock.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', () => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
 
 const mockConfigurePrinter = mockFunction('configurePrinter');
 jest.mock('./configure', (): typeof import('./configure') => ({

--- a/libs/printing/src/printer/status.test.ts
+++ b/libs/printing/src/printer/status.test.ts
@@ -13,12 +13,10 @@ import { exec } from '../utils/exec';
 
 jest.mock('../utils/exec');
 
-jest.mock('node:fs/promises', (): typeof import('node:fs/promises') => {
-  return {
-    ...jest.requireActual('node:fs/promises'),
-    writeFile: jest.fn(),
-  };
-});
+jest.mock('node:fs/promises', (): typeof import('node:fs/promises') => ({
+  ...jest.requireActual('node:fs/promises'),
+  writeFile: jest.fn(),
+}));
 
 const execMock = mockOf(exec);
 const writeFileMock = mockOf(writeFile);

--- a/libs/test-utils/package.json
+++ b/libs/test-utils/package.json
@@ -23,17 +23,6 @@
     "test:watch": "jest --watch",
     "pre-commit": "lint-staged"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@testing-library/react": "^15.0.7",
     "@votingworks/basics": "workspace:*",

--- a/libs/test-utils/src/arbitraries.ts
+++ b/libs/test-utils/src/arbitraries.ts
@@ -422,11 +422,12 @@ export function arbitraryElection(): fc.Arbitrary<Election> {
               min: new Date('0001-01-01'),
               max: new Date('9999-12-31'),
             })
-            .map((date) => {
-              return new DateWithoutTime(
-                assertDefined(date.toISOString().split('T')[0])
-              );
-            }),
+            .map(
+              (date) =>
+                new DateWithoutTime(
+                  assertDefined(date.toISOString().split('T')[0])
+                )
+            ),
           seal: fc.string({ minLength: 1, maxLength: 200 }),
           parties: fc.constant(parties),
           contests: arbitraryContests({

--- a/libs/test-utils/src/has_text_across_elements.ts
+++ b/libs/test-utils/src/has_text_across_elements.ts
@@ -16,9 +16,7 @@ export function hasTextAcrossElements(text: string | RegExp): Matcher {
     return nodeHasText && childrenDontHaveText;
   }
 
-  matcher.toString = () => {
-    return `"${text}" [searching across elements]`;
-  };
+  matcher.toString = () => `"${text}" [searching across elements]`;
 
   return matcher;
 }

--- a/libs/test-utils/src/mock_function.ts
+++ b/libs/test-utils/src/mock_function.ts
@@ -222,63 +222,57 @@ export function mockFunction<Func extends AnyFunc>(
     return expectedCall.output;
   };
 
-  mock.expectCallWith = (...input: Parameters<Func>) => {
-    return {
-      returns(output: ReturnType<Func>) {
-        state.expectedCalls.push({ input, output, repeated: false });
-      },
-      throws(error: unknown) {
-        state.expectedCalls.push({ input, error, repeated: false });
-      },
-      resolves(output: Awaited<ReturnType<Func>>) {
-        state.expectedCalls.push({
-          input,
-          output: Promise.resolve(output) as ReturnType<Func>,
-          repeated: false,
-        });
-      },
-    };
-  };
+  mock.expectCallWith = (...input: Parameters<Func>) => ({
+    returns(output: ReturnType<Func>) {
+      state.expectedCalls.push({ input, output, repeated: false });
+    },
+    throws(error: unknown) {
+      state.expectedCalls.push({ input, error, repeated: false });
+    },
+    resolves(output: Awaited<ReturnType<Func>>) {
+      state.expectedCalls.push({
+        input,
+        output: Promise.resolve(output) as ReturnType<Func>,
+        repeated: false,
+      });
+    },
+  });
 
-  mock.expectRepeatedCallsWith = (...input: Parameters<Func>) => {
-    return {
-      returns(output: ReturnType<Func>) {
-        state.expectedCalls.push({
-          input,
-          output,
-          repeated: true,
-        });
-      },
-      resolves(output: Awaited<ReturnType<Func>>) {
-        state.expectedCalls.push({
-          input,
-          output: Promise.resolve(output) as ReturnType<Func>,
-          repeated: true,
-        });
-      },
-    };
-  };
+  mock.expectRepeatedCallsWith = (...input: Parameters<Func>) => ({
+    returns(output: ReturnType<Func>) {
+      state.expectedCalls.push({
+        input,
+        output,
+        repeated: true,
+      });
+    },
+    resolves(output: Awaited<ReturnType<Func>>) {
+      state.expectedCalls.push({
+        input,
+        output: Promise.resolve(output) as ReturnType<Func>,
+        repeated: true,
+      });
+    },
+  });
 
-  mock.expectOptionalRepeatedCallsWith = (...input: Parameters<Func>) => {
-    return {
-      returns(output: ReturnType<Func>) {
-        state.expectedCalls.push({
-          input,
-          output,
-          repeated: true,
-          optional: true,
-        });
-      },
-      resolves(output: Awaited<ReturnType<Func>>) {
-        state.expectedCalls.push({
-          input,
-          output: Promise.resolve(output) as ReturnType<Func>,
-          repeated: true,
-          optional: true,
-        });
-      },
-    };
-  };
+  mock.expectOptionalRepeatedCallsWith = (...input: Parameters<Func>) => ({
+    returns(output: ReturnType<Func>) {
+      state.expectedCalls.push({
+        input,
+        output,
+        repeated: true,
+        optional: true,
+      });
+    },
+    resolves(output: Awaited<ReturnType<Func>>) {
+      state.expectedCalls.push({
+        input,
+        output: Promise.resolve(output) as ReturnType<Func>,
+        repeated: true,
+        optional: true,
+      });
+    },
+  });
 
   mock.reset = () => {
     state.expectedCalls = [];
@@ -334,13 +328,14 @@ export function mockFunction<Func extends AnyFunc>(
     if (firstMismatchedCallIndex !== -1) {
       const message = `Mismatch between expected mock function calls and actual mock function calls:\n\n${callCorrespondence
         .slice(0, firstMismatchedCallIndex + 1)
-        .map(({ actualCall, expectedCall }, index) => {
-          return `Call #${index}\n${formatExpectedAndActualCalls(
-            name,
-            actualCall,
-            expectedCall
-          )}`;
-        })
+        .map(
+          ({ actualCall, expectedCall }, index) =>
+            `Call #${index}\n${formatExpectedAndActualCalls(
+              name,
+              actualCall,
+              expectedCall
+            )}`
+        )
         .join('\n\n')}`;
       throw new MockFunctionError(message);
     }

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -27,17 +27,6 @@
     "cdf:logging:build-schema": "cdf-schema-builder data/cdf/election-event-logging/nist-schema.xsd data/cdf/election-event-logging/nist-schema.json > src/cdf/election-event-logging/index.ts",
     "cdf:err:build-schema": "cdf-schema-builder data/cdf/election-results-reporting/nist-schema.xsd data/cdf/election-results-reporting/nist-schema.json > src/cdf/election-results-reporting/index.ts"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@antongolub/iso8601": "^1.2.1",
     "@votingworks/basics": "workspace:*",

--- a/libs/types/src/cdf/ballot-definition/convert.ts
+++ b/libs/types/src/cdf/ballot-definition/convert.ts
@@ -945,14 +945,12 @@ export function convertCdfBallotDefinitionToVxfElection(
     // handled in the Seal ui component.
     seal: '',
 
-    parties: cdfBallotDefinition.Party.map((party) => {
-      return {
-        id: party['@id'] as Vxf.PartyId,
-        name: englishText(party.Name),
-        fullName: englishText(party.Name),
-        abbrev: englishText(party.Abbreviation),
-      };
-    }),
+    parties: cdfBallotDefinition.Party.map((party) => ({
+      id: party['@id'] as Vxf.PartyId,
+      name: englishText(party.Name),
+      fullName: englishText(party.Name),
+      abbrev: englishText(party.Abbreviation),
+    })),
 
     contests: election.Contest.map((contest): Vxf.AnyContest => {
       const contestBase = {
@@ -1045,11 +1043,11 @@ export function convertCdfBallotDefinitionToVxfElection(
       );
       // To find the districts for a ballot style, we look at the associated
       // precincts/splits and find the districts that contain them
-      const ballotStyleDistricts = ballotStyle.GpUnitIds.flatMap((gpUnitId) => {
-        return districts.filter((district) =>
+      const ballotStyleDistricts = ballotStyle.GpUnitIds.flatMap((gpUnitId) =>
+        districts.filter((district) =>
           assertDefined(district.ComposingGpUnitIds).includes(gpUnitId)
-        );
-      });
+        )
+      );
       const districtIds = unique(
         ballotStyleDistricts.map(
           (district) => district['@id'] as Vxf.DistrictId

--- a/libs/ui/.lintstagedrc.js
+++ b/libs/ui/.lintstagedrc.js
@@ -1,0 +1,10 @@
+// @ts-check
+
+const { frontend } = require('../../.lintstagedrc.shared');
+
+module.exports = {
+  ...frontend,
+  '(app_strings.tsx|number_strings.ts|finalize_app_strings_catalog.ts)': [
+    'pnpm build:app-strings-catalog',
+  ],
+};

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -29,21 +29,6 @@
     "test:watch": "TZ=America/Anchorage jest --watch",
     "pre-commit": "lint-staged"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "stylelint --quiet --fix",
-      "eslint --quiet --fix"
-    ],
-    "(app_strings.tsx|number_strings.ts|finalize_app_strings_catalog.ts)": [
-      "pnpm build:app-strings-catalog"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.2.1",
     "@fortawesome/free-regular-svg-icons": "^6.2.1",

--- a/libs/ui/src/bmd_paper_ballot.test.tsx
+++ b/libs/ui/src/bmd_paper_ballot.test.tsx
@@ -32,13 +32,11 @@ import {
 } from './bmd_paper_ballot';
 import * as QrCodeModule from './qrcode';
 
-jest.mock('@votingworks/ballot-encoder', () => {
-  return {
-    ...jest.requireActual('@votingworks/ballot-encoder'),
-    // mock encoded ballot so BMD ballot QR code does not change with every change to election definition
-    encodeBallot: jest.fn(),
-  };
-});
+jest.mock('@votingworks/ballot-encoder', () => ({
+  ...jest.requireActual('@votingworks/ballot-encoder'),
+  // mock encoded ballot so BMD ballot QR code does not change with every change to election definition
+  encodeBallot: jest.fn(),
+}));
 
 const encodeBallotMock = mockOf(encodeBallot);
 const mockEncodedBallotData = new Uint8Array([0, 1, 2, 3]);

--- a/libs/ui/src/icons.stories.tsx
+++ b/libs/ui/src/icons.stories.tsx
@@ -41,13 +41,11 @@ export function icons(props: IconProps): JSX.Element {
       <H5 as="h2">Icon List:</H5>
       {Object.entries(Icons)
         .filter(([, Icon]) => typeof Icon === 'function')
-        .map(([name, Icon]) => {
-          return (
-            <P key={name}>
-              <Icon {...props} /> &mdash; {name}
-            </P>
-          );
-        })}
+        .map(([name, Icon]) => (
+          <P key={name}>
+            <Icon {...props} /> &mdash; {name}
+          </P>
+        ))}
     </div>
   );
 }

--- a/libs/ui/src/system_administrator_screen_contents.test.tsx
+++ b/libs/ui/src/system_administrator_screen_contents.test.tsx
@@ -10,12 +10,10 @@ import { SystemAdministratorScreenContents } from './system_administrator_screen
 import { newTestContext } from '../test/test_context';
 import { mockUsbDriveStatus } from './test-utils/mock_usb_drive';
 
-jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isVxDev: jest.fn(),
-  };
-});
+jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isVxDev: jest.fn(),
+}));
 
 const { render, mockApiClient } = newTestContext({ skipUiStringsApi: true });
 

--- a/libs/ui/src/themes/color_palette.stories.tsx
+++ b/libs/ui/src/themes/color_palette.stories.tsx
@@ -39,32 +39,30 @@ export function ColorPalettes({ palette: paletteLabel }: Props): JSX.Element {
         <div key={hue}>
           <h3 style={{ marginTop: 0, marginBottom: '10px' }}>{hue}</h3>
           <div style={{ display: 'flex', gap: '5px' }}>
-            {variants.map(({ value, color }) => {
-              return (
+            {variants.map(({ value, color }) => (
+              <div
+                key={value}
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: '5px',
+                  width: 'min-content',
+                }}
+              >
                 <div
-                  key={value}
                   style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: '5px',
-                    width: 'min-content',
+                    height: '60px',
+                    width: '60px',
+                    borderRadius: '10%',
+                    backgroundColor: color,
                   }}
-                >
-                  <div
-                    style={{
-                      height: '60px',
-                      width: '60px',
-                      borderRadius: '10%',
-                      backgroundColor: color,
-                    }}
-                  />
-                  <h4 style={{ margin: 0 }}>{value}</h4>
-                  <div style={{ fontSize: '0.7em', userSelect: 'text' }}>
-                    {color}
-                  </div>
+                />
+                <h4 style={{ margin: 0 }}>{value}</h4>
+                <div style={{ fontSize: '0.7em', userSelect: 'text' }}>
+                  {color}
                 </div>
-              );
-            })}
+              </div>
+            ))}
           </div>
         </div>
       ))}

--- a/libs/ui/src/ui_strings/election_strings.tsx
+++ b/libs/ui/src/ui_strings/election_strings.tsx
@@ -55,16 +55,14 @@ export const electionStrings = {
     </InEnglish>
   ),
 
-  [Key.CONTEST_DESCRIPTION]: (contest: ContestWithDescription) => {
-    return (
-      <UiRichTextString
-        uiStringKey={Key.CONTEST_DESCRIPTION}
-        uiStringSubKey={contest.id}
-      >
-        {contest.description}
-      </UiRichTextString>
-    );
-  },
+  [Key.CONTEST_DESCRIPTION]: (contest: ContestWithDescription) => (
+    <UiRichTextString
+      uiStringKey={Key.CONTEST_DESCRIPTION}
+      uiStringSubKey={contest.id}
+    >
+      {contest.description}
+    </UiRichTextString>
+  ),
 
   [Key.CONTEST_OPTION_LABEL]: (option: YesNoOption) => (
     <UiString uiStringKey={Key.CONTEST_OPTION_LABEL} uiStringSubKey={option.id}>

--- a/libs/ui/src/unconfigure_machine_button.test.tsx
+++ b/libs/ui/src/unconfigure_machine_button.test.tsx
@@ -7,12 +7,10 @@ import {
   UnconfigureMachineButton,
 } from './unconfigure_machine_button';
 
-jest.mock('@votingworks/basics', (): typeof import('@votingworks/basics') => {
-  return {
-    ...jest.requireActual('@votingworks/basics'),
-    sleep: jest.fn(),
-  };
-});
+jest.mock('@votingworks/basics', (): typeof import('@votingworks/basics') => ({
+  ...jest.requireActual('@votingworks/basics'),
+  sleep: jest.fn(),
+}));
 
 test('UnconfigureMachineButton interactions', async () => {
   const unconfigureMachine = jest.fn();

--- a/libs/ui/src/virtual_keyboard.tsx
+++ b/libs/ui/src/virtual_keyboard.tsx
@@ -259,13 +259,11 @@ export function VirtualKeyboard({
 
   return (
     <Keyboard data-testid="virtual-keyboard">
-      {keyMap.rows.map((row) => {
-        return (
-          <KeyRow key={`row-${row.map((key) => key.value).join()}`}>
-            {row.map(renderKey)}
-          </KeyRow>
-        );
-      })}
+      {keyMap.rows.map((row) => (
+        <KeyRow key={`row-${row.map((key) => key.value).join()}`}>
+          {row.map(renderKey)}
+        </KeyRow>
+      ))}
       <KeyRow>
         <SpaceBar>{renderKey(SPACE_BAR_KEY)}</SpaceBar>
         <Button onPress={onBackspace}>

--- a/libs/usb-drive/package.json
+++ b/libs/usb-drive/package.json
@@ -20,17 +20,6 @@
     "test:watch": "jest --watch",
     "type-check": "tsc --build"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@votingworks/basics": "workspace:*",
     "@votingworks/fs": "workspace:*",

--- a/libs/usb-drive/src/mocks/file_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/file_usb_drive.ts
@@ -142,9 +142,7 @@ export interface MockFileUsbDriveHandler {
 
 export function getMockFileUsbDriveHandler(): MockFileUsbDriveHandler {
   return {
-    status: () => {
-      return readFromMockFile().status;
-    },
+    status: () => readFromMockFile().status,
     insert: (contents?: MockFileTree) => {
       if (contents) {
         writeMockFileTree(getMockUsbDataDirPath(), contents);

--- a/libs/usb-drive/src/usb_drive.test.ts
+++ b/libs/usb-drive/src/usb_drive.test.ts
@@ -38,13 +38,11 @@ jest.mock('./exec', () => ({
 }));
 
 const featureFlagMock = getFeatureFlagMock();
-jest.mock('@votingworks/utils', () => {
-  return {
-    ...jest.requireActual('@votingworks/utils'),
-    isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
-      featureFlagMock.isEnabled(flag),
-  };
-});
+jest.mock('@votingworks/utils', () => ({
+  ...jest.requireActual('@votingworks/utils'),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
 
 const readdirMock = fs.readdir as unknown as jest.Mock<Promise<string[]>>;
 const readlinkMock = fs.readlink as unknown as jest.Mock<Promise<string>>;

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -23,17 +23,6 @@
     "test:ci": "TZ=America/Anchorage pnpm build && pnpm test:coverage --reporters=default --reporters=jest-junit --maxWorkers=6",
     "pre-commit": "lint-staged"
   },
-  "lint-staged": {
-    "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write"
-    ],
-    "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix"
-    ],
-    "package.json": [
-      "sort-package-json"
-    ]
-  },
   "dependencies": {
     "@votingworks/basics": "workspace:*",
     "@votingworks/types": "workspace:*",

--- a/libs/utils/src/ballot_styles.ts
+++ b/libs/utils/src/ballot_styles.ts
@@ -36,7 +36,6 @@ export function generateBallotStyleId(params: {
   languages: string[];
   party?: Party;
 }): BallotStyleId {
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
   return [generateBallotStyleGroupId(params), ...params.languages].join(
     ID_LANGUAGES_SEPARATOR
   ) as BallotStyleId;

--- a/libs/utils/src/features_mock.ts
+++ b/libs/utils/src/features_mock.ts
@@ -17,9 +17,8 @@ export function getFeatureFlagMock(): FeatureFlagMock {
   let mockedFlags: Dictionary<boolean> = {};
 
   return {
-    isEnabled: (flag: BooleanEnvironmentVariableName) => {
-      return mockedFlags[flag] ?? isFeatureFlagEnabled(flag);
-    },
+    isEnabled: (flag: BooleanEnvironmentVariableName) =>
+      mockedFlags[flag] ?? isFeatureFlagEnabled(flag),
     enableFeatureFlag: (flag: BooleanEnvironmentVariableName) => {
       mockedFlags[flag] = true;
     },

--- a/libs/utils/src/make_async.test.ts
+++ b/libs/utils/src/make_async.test.ts
@@ -1,9 +1,7 @@
 import { makeAsync } from './make_async';
 
 test('makes function async', async () => {
-  const concatenate = jest.fn((num: number, str: string) => {
-    return `${num} ${str}`;
-  });
+  const concatenate = jest.fn((num: number, str: string) => `${num} ${str}`);
   expect(concatenate(1, 'thing')).toEqual('1 thing');
   expect(concatenate).toHaveBeenCalledTimes(1);
 

--- a/libs/utils/src/make_async.ts
+++ b/libs/utils/src/make_async.ts
@@ -1,7 +1,5 @@
 export function makeAsync<T extends unknown[], P>(
   fn: (...args: T) => P
 ): (...args: T) => Promise<P> {
-  return (...args: T) => {
-    return Promise.resolve(fn(...args));
-  };
+  return (...args: T) => Promise.resolve(fn(...args));
 }

--- a/libs/utils/src/pins.test.ts
+++ b/libs/utils/src/pins.test.ts
@@ -11,12 +11,10 @@ import {
   MIN_PIN_LENGTH,
 } from './pins';
 
-jest.mock('./features', (): typeof import('./features') => {
-  return {
-    ...jest.requireActual('./features'),
-    isFeatureFlagEnabled: jest.fn(),
-  };
-});
+jest.mock('./features', (): typeof import('./features') => ({
+  ...jest.requireActual('./features'),
+  isFeatureFlagEnabled: jest.fn(),
+}));
 
 jest.mock('randombytes', (): typeof import('randombytes') => jest.fn());
 

--- a/libs/utils/src/tabulation/tally_reports.ts
+++ b/libs/utils/src/tabulation/tally_reports.ts
@@ -101,9 +101,10 @@ function getAggregatedWriteInRows({
   const candidateTalliesDescending = Object.values(
     combinedContestResults.tallies
   )
-    .sort((a: Tabulation.CandidateTally, b: Tabulation.CandidateTally) => {
-      return -(a.tally - b.tally); // sort by descending vote tally
-    })
+    .sort(
+      (a: Tabulation.CandidateTally, b: Tabulation.CandidateTally) =>
+        -(a.tally - b.tally) // sort by descending vote tally
+    )
     .filter((candidateTally) => !isNonCandidateWriteInTally(candidateTally));
 
   // The least number of votes for someone is winning the race. Notes:

--- a/libs/utils/src/tabulation/transformations.test.ts
+++ b/libs/utils/src/tabulation/transformations.test.ts
@@ -104,13 +104,11 @@ test('coalesceGroupsAcrossParty', () => {
   const coalescedBallotCounts = coalesceGroupsAcrossParty(
     ballotCounts,
     { groupByPrecinct: true },
-    (partyBallotCounts) => {
-      return {
-        ballotCount: iter(partyBallotCounts)
-          .map(({ ballotCount }) => ballotCount)
-          .sum(),
-      };
-    }
+    (partyBallotCounts) => ({
+      ballotCount: iter(partyBallotCounts)
+        .map(({ ballotCount }) => ballotCount)
+        .sum(),
+    })
   );
 
   expect(coalescedBallotCounts).toEqual([

--- a/package.json
+++ b/package.json
@@ -10,10 +10,6 @@
     "configure-vxdev-env": "node libs/utils/build/scripts/generate_env_file.js --isVxDev -o /vx/config/.env.local",
     "run-dev": "script/run-dev"
   },
-  "lint-staged": {
-    "package.json": "sort-package-json",
-    "*.ts,*.md,*.json": "prettier --write"
-  },
   "packageManager": "pnpm@8.15.5",
   "devDependencies": {
     "@storybook/addon-a11y": "^7.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3946,9 +3946,6 @@ importers:
       eslint-plugin-n:
         specifier: '17'
         version: 17.10.2(eslint@8.57.0)
-      eslint-plugin-prettier:
-        specifier: ^5.0.0
-        version: 5.0.0(@types/eslint@8.4.1)(eslint-config-prettier@9.0.0)(eslint@8.57.0)(prettier@3.0.3)
       eslint-plugin-react:
         specifier: ^7.31.8
         version: 7.31.8(eslint@8.57.0)
@@ -8769,6 +8766,7 @@ packages:
       open: 9.1.0
       picocolors: 1.0.0
       tslib: 2.6.2
+    dev: true
 
   /@playwright/test@1.48.1:
     resolution: {integrity: sha512-s9RtWoxkOLmRJdw3oFvhFbs9OJS0BzrLUc8Hf6l2UdCNd1rqeEyD4BhCJkvzeEoD1FsK4mirsWwGerhVmYKtZg==}
@@ -10715,6 +10713,7 @@ packages:
     dependencies:
       '@types/estree': 1.0.5
       '@types/json-schema': 7.0.12
+    dev: true
 
   /@types/estree@0.0.51:
     resolution: {integrity: sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==}
@@ -10722,6 +10721,7 @@ packages:
 
   /@types/estree@1.0.5:
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
+    dev: true
 
   /@types/express-serve-static-core@4.17.31:
     resolution: {integrity: sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==}
@@ -12357,6 +12357,7 @@ packages:
   /big-integer@1.6.51:
     resolution: {integrity: sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==}
     engines: {node: '>=0.6'}
+    dev: true
 
   /big.js@5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
@@ -12431,6 +12432,7 @@ packages:
     engines: {node: '>= 5.10.0'}
     dependencies:
       big-integer: 1.6.51
+    dev: true
 
   /brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -12649,6 +12651,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       run-applescript: 5.0.0
+    dev: true
 
   /busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
@@ -13621,6 +13624,7 @@ packages:
     dependencies:
       bplist-parser: 0.2.0
       untildify: 4.0.0
+    dev: true
 
   /default-browser@4.0.0:
     resolution: {integrity: sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==}
@@ -13630,6 +13634,7 @@ packages:
       default-browser-id: 3.0.0
       execa: 7.2.0
       titleize: 3.0.0
+    dev: true
 
   /defaults@1.0.3:
     resolution: {integrity: sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==}
@@ -13653,6 +13658,7 @@ packages:
   /define-lazy-prop@3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
+    dev: true
 
   /define-properties@1.2.0:
     resolution: {integrity: sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==}
@@ -14547,6 +14553,7 @@ packages:
       prettier: 3.0.3
       prettier-linter-helpers: 1.0.0
       synckit: 0.8.5
+    dev: true
 
   /eslint-plugin-react-hooks@4.6.0(eslint@8.57.0):
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
@@ -14783,6 +14790,7 @@ packages:
       onetime: 6.0.0
       signal-exit: 3.0.7
       strip-final-newline: 3.0.0
+    dev: true
 
   /exenv@1.2.2:
     resolution: {integrity: sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=}
@@ -14928,6 +14936,7 @@ packages:
 
   /fast-diff@1.2.0:
     resolution: {integrity: sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==}
+    dev: true
 
   /fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
@@ -16052,6 +16061,7 @@ packages:
   /human-signals@4.3.1:
     resolution: {integrity: sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==}
     engines: {node: '>=14.18.0'}
+    dev: true
 
   /husky@7.0.0:
     resolution: {integrity: sha512-xK7lO0EtSzfFPiw+oQncQVy/XqV7UVVjxBByc+Iv5iK3yhW9boDoWgvZy3OGo48QKg/hUtZkzz0hi2HXa0kn7w==}
@@ -16371,11 +16381,13 @@ packages:
     resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
     engines: {node: '>=8'}
     hasBin: true
+    dev: true
 
   /is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
+    dev: true
 
   /is-empty@1.2.0:
     resolution: {integrity: sha512-F2FnH/otLNJv0J6wc73A5Xo7oHLNnqplYqZhUu01tD54DIPvxIRSTSLkrUB/M0nHO4vo1O9PDfN4KoTxCzLh/w==}
@@ -16442,6 +16454,7 @@ packages:
     hasBin: true
     dependencies:
       is-docker: 3.0.0
+    dev: true
 
   /is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
@@ -16557,6 +16570,7 @@ packages:
   /is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: true
 
   /is-string@1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
@@ -16629,6 +16643,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       is-docker: 2.2.1
+    dev: true
 
   /isarray@0.0.1:
     resolution: {integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==}
@@ -18006,6 +18021,7 @@ packages:
   /mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
+    dev: true
 
   /mimic-response@2.1.0:
     resolution: {integrity: sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==}
@@ -18447,6 +18463,7 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       path-key: 4.0.0
+    dev: true
 
   /npmlog@5.0.1:
     resolution: {integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==}
@@ -18594,6 +18611,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       mimic-fn: 4.0.0
+    dev: true
 
   /open@8.4.0:
     resolution: {integrity: sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==}
@@ -18612,6 +18630,7 @@ packages:
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
       is-wsl: 2.2.0
+    dev: true
 
   /optionator@0.8.3:
     resolution: {integrity: sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==}
@@ -18830,6 +18849,7 @@ packages:
   /path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
+    dev: true
 
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -19136,6 +19156,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       fast-diff: 1.2.0
+    dev: true
 
   /prettier@2.6.2:
     resolution: {integrity: sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==}
@@ -19152,6 +19173,7 @@ packages:
     resolution: {integrity: sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==}
     engines: {node: '>=14'}
     hasBin: true
+    dev: true
 
   /pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
@@ -20412,6 +20434,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       execa: 5.1.1
+    dev: true
 
   /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -21117,6 +21140,7 @@ packages:
   /strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
+    dev: true
 
   /strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
@@ -21332,6 +21356,7 @@ packages:
     dependencies:
       '@pkgr/utils': 2.4.2
       tslib: 2.6.2
+    dev: true
 
   /table@6.8.1:
     resolution: {integrity: sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==}
@@ -21515,6 +21540,7 @@ packages:
   /titleize@3.0.0:
     resolution: {integrity: sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==}
     engines: {node: '>=12'}
+    dev: true
 
   /tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}

--- a/vxsuite.code-workspace
+++ b/vxsuite.code-workspace
@@ -227,7 +227,28 @@
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": "explicit",
-      "source.fixAll.stylelint": "explicit"
+      "source.fixAll.stylelint": "explicit",
+    },
+    "[typescript]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[typescriptreact]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[javascript]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[javascriptreact]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[css]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[markdown]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[json]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
     "cSpell.words": [
       "accuvote",
@@ -285,7 +306,8 @@
       "**/build": true,
       "**/coverage": true
     },
-    "typescript.tsdk": "vxsuite/node_modules/typescript/lib"
+    "typescript.tsdk": "vxsuite/node_modules/typescript/lib",
+    "editor.tabSize": 2
   },
   "extensions": {
     "recommendations": [


### PR DESCRIPTION
## Overview
Running `prettier` as part of `eslint` isn't great for a couple reasons:
- seeing red error squiggles when the formatting just needs an autofix is annoying and potentially confusing
- any ESLint autofixes that result in invalid formatting will cause ESLint to re-run linting multiple times until there are no more changes to be made, causing slow performance

## Demo Video or Screenshot
n/a

## Testing Plan
As part of running `git commit` to create this PR, worked through any issues that `lint-staged` flagged with the configuration and fixed them.