### PR TITLE
Remove Stray `assert` to allow programming sys admin cards when VxAdmin is unconfigured

### DIFF
--- a/apps/admin/frontend/src/screens/smart_cards_screen.tsx
+++ b/apps/admin/frontend/src/screens/smart_cards_screen.tsx
@@ -386,7 +386,6 @@ function CardDetailsAndActions({
     useState<ConfirmSystemAdminCardAction>();
 
   function programCard(role: CardRole) {
-    assert(electionDefinition);
     assert(role !== 'vendor');
 
     programCardMutation.mutate(


### PR DESCRIPTION
Closes #5578.