### PR TITLE
Change SHV control flow

### DIFF
--- a/libs/auth/src/intermediate-scripts/compute-system-hash
+++ b/libs/auth/src/intermediate-scripts/compute-system-hash
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+VERITY_HASH="$(cat /proc/cmdline | awk -F'verity.hash=' '{print $2}' | cut -d' ' -f1)"
+
+if [[ ! -z "${VERITY_HASH}" ]]; then
+    echo "${VERITY_HASH}"
+else
+    echo "UNVERIFIED"
+fi


### PR DESCRIPTION
## Overview

This PR changes the control flow of signed hash valildation. Rather than having `vxsuite` call a `vxsuite-complete-system` script, this PR brings the core script directly into `vxsuite`. This allows us to remove a lot of the previous special-casing for local dev vs. prod.

In the process, this fixes a bug that was causing us to display the UNVERIFIED placeholder hash for locked-down images instead of the real hash. The source of that bug was a faulty existence check for a script in `vxsuite-complete-system`. While the script did exist (`/vx/vendor/vendor-functions/hash-signature.sh`), it was only visible to the `vx-vendor` user, not the `vx-services` user.

Corresponding `vxsuite-complete-system` change: https://github.com/votingworks/vxsuite-complete-system/pull/412

## Testing Plan

- [x] Manually patched an image and tested in production
- [x] Made sure that the `compute-system-hash` script works in a local dev env

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A