### PR TITLE
VxMark: Don't auto-click "My Ballot is Incorrect" on controller left press

### DIFF
--- a/apps/mark-scan/frontend/src/pages/validate_ballot_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/validate_ballot_page.tsx
@@ -71,11 +71,7 @@ export function ValidateBallotPage(): JSX.Element | null {
     <VoterScreen
       actionButtons={
         <React.Fragment>
-          <Button
-            id={PageNavigationButtonId.PREVIOUS}
-            variant="danger"
-            onPress={invalidateBallotCallback}
-          >
+          <Button variant="danger" onPress={invalidateBallotCallback}>
             {appStrings.buttonBallotIsIncorrect()}
           </Button>
           <Button


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/5598

Currently, on the final validation screen in VxMark, when you're given the two options, `My Ballot is Incorrect` and `Cast My Ballot`, if you press the left button on the controller, we auto-click `My Ballot is Incorrect`, which rejects your ballot and has the poll worker spoil it so that you can start over.

I'm 99% sure that that wasn't intentional, just an artifact of us intentionally auto-clicking the `Previous` button on controller left press on contest screens.

Quick fix 🛠️

## Testing Plan

- [x] Tested on actual hardware