### PR TITLE
VxCentralScan: Ensure that HMPB timing marks aren't clipped

### DIFF
--- a/apps/central-scan/backend/src/fujitsu_scanner.test.ts
+++ b/apps/central-scan/backend/src/fujitsu_scanner.test.ts
@@ -115,9 +115,9 @@ test('fujitsu scanner can scans with expected params on letter size election', (
     'scanimage',
     expect.arrayContaining([
       '--page-width',
-      '215.872',
+      '215.9',
       '--page-height',
-      '336.506',
+      '336.55',
       '--bgcolor=black',
     ])
   );
@@ -144,9 +144,9 @@ test('fujitsu scanner can scan with expected params on legal size election', () 
     'scanimage',
     expect.arrayContaining([
       '--page-width',
-      '215.872',
+      '215.9',
       '--page-height',
-      '355.554',
+      '361.95',
       '--bgcolor=black',
     ])
   );

--- a/apps/central-scan/backend/src/fujitsu_scanner.ts
+++ b/apps/central-scan/backend/src/fujitsu_scanner.ts
@@ -150,19 +150,29 @@ export class FujitsuScanner implements BatchScanner {
       args.push('--endorser-string', `${imprintIdPrefix}_%04ud`);
     }
 
-    const MM_PER_INCH = 25.3967;
+    /**
+     * We've occasionally seen the Fujitsu return images where HMPB timing marks are ever so
+     * slightly clipped, so we add some buffer to the page height to ensure that we capture
+     * everything. Scanning extra is safe because the HMPB interpreter trims any extra scan area.
+     */
+    const HMPB_HEIGHT_BUFFER_INCHES = 0.25;
+    const MM_PER_INCH = 25.4;
+
     function toMillimeters(inches: number): string {
       return String(Math.round(inches * MM_PER_INCH * 1000) / 1000);
     }
-    const { width, height } = ballotPaperDimensions(pageSize);
-    const { height: bmdThermalHeight } = ballotPaperDimensions(
+
+    const { width, height: hmpbHeight } = ballotPaperDimensions(pageSize);
+    const { height: bmdbHeight } = ballotPaperDimensions(
       BmdBallotPaperSize.Vsap150Thermal
     );
     args.push(
       '--page-width',
       toMillimeters(width),
       '--page-height',
-      toMillimeters(Math.max(height, bmdThermalHeight))
+      toMillimeters(
+        Math.max(hmpbHeight + HMPB_HEIGHT_BUFFER_INCHES, bmdbHeight)
+      )
     );
 
     if (this.mode) {


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/5594

![clipping](https://github.com/user-attachments/assets/71d544f3-3427-455c-ae76-a789bccd5178)

With 22" ballots on VxCentralScan, we've sporadically seen interpretation fail because timing marks are clipped, ~circled~ squared in red above.

To address this, we're adding some buffer to the page height param that we specify to the Fujitsu. Scanning extra is safe because the HMPB interpreter trims any extra scan area. In fact, we already rely on this trimming when scanning letter HMPBs, as we specify the BMDB height for that case (13.25 inches > 11 inches).

## Testing Plan

- [x] Manually tested with 22" HMPBs