### PR TITLE
VxCentralScan: Support BMDBs in all orientations when configured for 22" HMPBs

### DIFF
--- a/libs/ballot-interpreter/src/bmd/utils/qrcode.test.ts
+++ b/libs/ballot-interpreter/src/bmd/utils/qrcode.test.ts
@@ -35,3 +35,16 @@ test('getSearchArea', () => {
     2 // 1 top, 1 bottom
   );
 });
+
+test('getSearchArea, 2x2 placeholder image for simplex BMDB interpretation', () => {
+  expect([...getSearchAreas({ width: 2, height: 2 })]).toEqual([
+    {
+      position: 'bottom',
+      bounds: { x: 0, y: 1, width: 2, height: 1 },
+    },
+    {
+      position: 'top',
+      bounds: { x: 0, y: 0, width: 2, height: 1 },
+    },
+  ]);
+});

--- a/libs/ballot-interpreter/src/bmd/utils/qrcode.ts
+++ b/libs/ballot-interpreter/src/bmd/utils/qrcode.ts
@@ -27,8 +27,8 @@ function decodeBase64FromUtf8(utf8StringData: Buffer): Buffer {
 /**
  * We search for a QR code in the bottom and top "halves" of the BMDB image.
  *
- * The bottom "half" is really the bottom 60% of the image. The extra 10% is to account for the
- * following situation:
+ * The bottom search area is really the bottom 60% of the image. The extra 10% is to account for
+ * the following situation:
  * - We're using VxCentralScan.
  * - We're configured to scan 22" HMPBs.
  * - The BMDB is inserted into the scanner right side up, which results in an upside down image.

--- a/libs/ballot-interpreter/src/interpret.ts
+++ b/libs/ballot-interpreter/src/interpret.ts
@@ -746,7 +746,9 @@ export async function interpretSimplexBmdBallot(
 ): Promise<SheetOf<InterpretFileResult>> {
   const ballotImages: SheetOf<ImageData> = [
     frontImage,
-    fromGrayScale(new Uint8ClampedArray([0]), 1, 1),
+    // We need at least a 2x2 placeholder image for top-bottom search area logic to work as
+    // expected (see getSearchAreas in src/bmd/utils/qrcode.ts)
+    fromGrayScale(new Uint8ClampedArray([0, 0, 0, 0]), 2, 2),
   ];
   return interpretBmdBallot(ballotImages, options);
 }


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/5593

In our final v4 QA, we found that BMDBs only scan in one orientation on VxCentralScan when it's configured for 22" HMPBs.

We search for a QR code in the top and bottom halves of the image, but under the following circumstances:

- VxCentralScan, which doesn't auto-crop when it hits the end of the paper
- 22" HMPBs
- BMDB is inserted into the scanner right side up, which results in an upside down image

The QR code happens to fall right in between the two halves. To mitigate this, we're updating the bottom search area to really be the bottom 60% of the image. The top search area is still the top 50% of the image, not 40%. We could probably change that, but I'm playing it safe and trying not to introduce another edge case at another paper-length + orientation this close to cert submission.

To ensure that images are still rotated correctly, we switched the order of the search area usage, now bottom first. I left a comment in the code explaining why this works:

>  The QR code ends up right in the middle of the image and is missed if you search exact halves.
> To address this case, we expand the bottom search area and also intentionally search in that half
> first, since we rotate the image when we detect a QR code in the bottom half, which we do want
> to do in this case. If we were to expand the top search area and search in that half first, we'd
> still catch the QR code but miss that we need to rotate the image.
>
> While this logic is optimized for this specific case, it works for all other HMPB sizes and BMDB
> orientations as well.

| Before | After |
| -- | -- |
| <img src='https://github.com/user-attachments/assets/1f763e10-d57f-45a3-ab79-a1f4cad4d2d8' alt='before' width=400 /> | <img src='https://github.com/user-attachments/assets/b029fad7-6942-4f4c-a055-8984a55dc696' alt='after' width=400 /> |

## Testing Plan

- [x] Tested manually
- [x] Ensured that existing automated tests still pass