### PR TITLE
Address off-by-one error in BMDB interpreter that can result in a crash on BMDB interpretation

### DIFF
--- a/libs/ballot-interpreter/src/bmd/utils/qrcode.test.ts
+++ b/libs/ballot-interpreter/src/bmd/utils/qrcode.test.ts
@@ -48,3 +48,27 @@ test('getSearchArea, 2x2 placeholder image for simplex BMDB interpretation', () 
     },
   ]);
 });
+
+test('getSearchArea, prevent search areas from extending beyond the image', () => {
+  expect([...getSearchAreas({ width: 1, height: 3 })]).toEqual([
+    {
+      position: 'bottom',
+      bounds: { x: 0, y: 1, width: 1, height: 1 },
+    },
+    {
+      position: 'top',
+      bounds: { x: 0, y: 0, width: 1, height: 1 },
+    },
+  ]);
+
+  expect([...getSearchAreas({ width: 1, height: 5 })]).toEqual([
+    {
+      position: 'bottom',
+      bounds: { x: 0, y: 2, width: 1, height: 2 },
+    },
+    {
+      position: 'top',
+      bounds: { x: 0, y: 0, width: 1, height: 2 },
+    },
+  ]);
+});

--- a/libs/ballot-interpreter/src/bmd/utils/qrcode.ts
+++ b/libs/ballot-interpreter/src/bmd/utils/qrcode.ts
@@ -64,14 +64,16 @@ function decodeBase64FromUtf8(utf8StringData: Buffer): Buffer {
 export function* getSearchAreas(
   size: Size
 ): Generator<{ position: 'top' | 'bottom'; bounds: Rect }> {
-  const heightMidpoint = Math.round(size.height / 2);
+  // Use Math.floor instead of Math.round to prevent search areas from accidentally extending
+  // beyond the image
+  const heightMidpoint = Math.floor(size.height / 2);
   yield {
     position: 'bottom',
     bounds: {
       x: 0,
-      y: heightMidpoint - Math.round(size.height * 0.1),
+      y: heightMidpoint - Math.floor(size.height * 0.1),
       width: size.width,
-      height: heightMidpoint + Math.round(size.height * 0.1),
+      height: heightMidpoint + Math.floor(size.height * 0.1),
     },
   };
   yield {


### PR DESCRIPTION
## Overview

I've been noticing some sporadic crashes on interpretation in VxMark (Frankenstein) after applying https://github.com/votingworks/vxsuite/pull/5602. I found that this assert is sometimes failing:

https://github.com/votingworks/vxsuite/blob/3f79e47a935f0c3dfd4a94040cf264071b92cf1b/libs/ballot-interpreter/src/bmd/utils/luminosity.ts#L34

This indicates that we're attempting to read a pixel outside the bounds of the image.

I boiled this down to an issue with using `Math.round` when defining search areas. Take the super simple case of an image with width 1 and height 3:

```
0
0
0
```

The current computation will return the following bottom search area:

```
const heightMidpoint = Math.round(size.height / 2);
yield {
  position: 'bottom',
  bounds: {
    x: 0,
    y: heightMidpoint - Math.round(size.height * 0.1),
    width: size.width,
    height: heightMidpoint + Math.round(size.height * 0.1),
  },
};
```

```
heightMidpoint = Math.round(3/2) = Math.round(1.5) = 2
x = 0
y = 2 - 0 = 2
width = 1
height = 2 + 0 = 2
```

```
0
0
0 <-- y = 2, with a height of 2 pushes us past the image
```

My simple fix was to just use `Math.floor` everywhere instead of `Math.round`. With this, it's possible to miss the very last row of the image, but that should be inconsequential as it applies to BMDB interpretation.

Zooming out, even before https://github.com/votingworks/vxsuite/pull/5602, this issue could've affected any BMDB image _if_ we used the bottom search area (which reminder used to come second, after the top search area) _and_ the image height was an odd number. But I think that particular combo was rare since 1) on VxMark we typically scan with the QR code in the top search area and 2) on VxCentralScan BMDB images have a predefined height determined by the HMPB height that may always an even number.

## Testing Plan

- [x] Added a unit test
- [x] Patched on Frankenstein and interpreted many ballots without issue