### PR TITLE
Ignore an initial ack in custom printer driver scan command

### DIFF
--- a/libs/custom-paper-handler/src/driver/driver.ts
+++ b/libs/custom-paper-handler/src/driver/driver.ts
@@ -525,6 +525,11 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
       while (scanStatus === OK_CONTINUE) {
         const rawResponse = await this.transferInGeneric();
         assert(rawResponse?.data);
+
+        // We sometimes find an unexpected ack in the USB buffer when we go to read the scan
+        // response data. We don't yet know the root cause of this but do believe that this could
+        // be a bug in the Custom paper handler firmware. This *seems* to come up right after
+        // printing more complex ballots, e.g., with many contests.
         const isAck = AcknowledgementResponse.decode(
           bufferFromDataView(rawResponse.data)
         );

--- a/libs/custom-paper-handler/src/driver/driver.ts
+++ b/libs/custom-paper-handler/src/driver/driver.ts
@@ -525,6 +525,12 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
       while (scanStatus === OK_CONTINUE) {
         const rawResponse = await this.transferInGeneric();
         assert(rawResponse?.data);
+        const isAck = AcknowledgementResponse.decode(
+          bufferFromDataView(rawResponse.data)
+        );
+        if (isAck.isOk()) {
+          continue;
+        }
 
         const responseBuffer = new Uint8Array(
           rawResponse.data.buffer,


### PR DESCRIPTION
## Overview
Ignores an initial "ack" if seen on the transfer in endpoint when scanning. We have sporadically seen this in weird situations and ignoring it seems harmless. Note that @eventualbuddha has seen issues with scanning the image after this in dev but we have not repro'd those testing with images. 
<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
