### PR TITLE
Fix flaky language_context test in libs/ui

### DIFF
--- a/libs/ui/src/ui_strings/language_context.test.tsx
+++ b/libs/ui/src/ui_strings/language_context.test.tsx
@@ -15,25 +15,24 @@ import {
   DEFAULT_LANGUAGE_CODE,
 } from './language_context';
 
-const {
-  getLanguageContext,
-  mockApiClient,
-  mockReactQueryUiStringsApi,
-  queryClient,
-  render,
-} = newTestContext();
+function setUp() {
+  const testContext = newTestContext();
+  const { mockApiClient } = testContext;
 
-beforeEach(() => {
   jest.resetAllMocks();
 
-  mockApiClient.getAvailableLanguages.mockResolvedValueOnce(['en', 'zh-Hant']);
+  mockApiClient.getAvailableLanguages.mockResolvedValue(['en', 'zh-Hant']);
 
   mockApiClient.getUiStrings.mockImplementation(({ languageCode }) =>
     Promise.resolve(TEST_UI_STRING_TRANSLATIONS[languageCode] || null)
   );
-});
+
+  return testContext;
+}
 
 test('availableLanguages', async () => {
+  const { getLanguageContext, render } = setUp();
+
   render(<div>foo</div>);
 
   await waitFor(() => expect(getLanguageContext()).toBeDefined());
@@ -41,6 +40,8 @@ test('availableLanguages', async () => {
 });
 
 test('setLanguage', async () => {
+  const { getLanguageContext, render } = setUp();
+
   render(<div>foo</div>);
 
   await waitFor(() => expect(getLanguageContext()).toBeDefined());
@@ -69,6 +70,14 @@ test('setLanguage', async () => {
 });
 
 test('resets language cache when backend data changes', async () => {
+  const {
+    getLanguageContext,
+    mockApiClient,
+    mockReactQueryUiStringsApi,
+    queryClient,
+    render,
+  } = setUp();
+
   mockApiClient.getUiStrings.mockImplementation(({ languageCode }) =>
     Promise.resolve(TEST_UI_STRING_TRANSLATIONS[languageCode] || null)
   );
@@ -106,6 +115,8 @@ test('resets language cache when backend data changes', async () => {
 });
 
 test('BackendLanguageContextProvider', async () => {
+  setUp();
+
   genericRender(
     <BackendLanguageContextProvider
       currentLanguageCode={DEFAULT_LANGUAGE_CODE}


### PR DESCRIPTION
## Overview

Fixing a [flaky test](https://app.circleci.com/pipelines/github/votingworks/vxsuite/17098/workflows/5671de94-9d2c-4e29-9c06-8717ff242970/jobs/674164) in libs/ui

Was caused by the combination of a recent change to clear the i18next cache when unconfiguring a machine and the fact that this test was sharing a render context across test cases (so changes to the i18next cache in one case were affecting another).

Updating to create a new context for each test case.

## Testing Plan
- Reproduced the failure consistently by changing the order of the tests so that the unconfigure test runs first.
- Verified that this change gets the tests passing again.

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
