### PR TITLE
[BMD] Stop triggering open-cover alarm when polls aren't open

### DIFF
--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -429,6 +429,7 @@ export function buildMachine(
       async (context) => {
         const { auth: authApi, driver, workspace } = context;
 
+        const pollsState = context.workspace.store.getPollsState();
         const [handlerStatus, authStatus] = await Promise.all([
           driver.getPaperHandlerStatus(),
           authApi.getAuthStatus(constructAuthMachineState(workspace)),
@@ -437,8 +438,9 @@ export function buildMachine(
         const status: CoverStatus = {
           isOpen: isCoverOpen(handlerStatus),
           isAuthorized:
-            authStatus.status === 'logged_in' &&
-            !isCardlessVoterAuth(authStatus),
+            pollsState !== 'polls_open' ||
+            (authStatus.status === 'logged_in' &&
+              !isCardlessVoterAuth(authStatus)),
         };
 
         return { type: 'COVER_STATUS', status };


### PR DESCRIPTION
## Overview

Follow-up to https://github.com/votingworks/vxsuite/issues/3873

Fixes a bug in the BMD cover-open alarm logic so that the alarm is only triggered when polls are open.

## Testing Plan
- Added new test case for the `polls_closed` + `cover_open` state combination

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
