### PR TITLE
[BMD] Add retries to pulse audio command for output selection

### DIFF
--- a/apps/mark-scan/backend/src/audio/outputs.test.ts
+++ b/apps/mark-scan/backend/src/audio/outputs.test.ts
@@ -1,0 +1,70 @@
+import { execFile } from '@votingworks/backend';
+import { sleep } from '@votingworks/basics';
+import { mockOf } from '@votingworks/test-utils';
+import { LogEventId, mockLogger } from '@votingworks/logging';
+import { getNodeEnv } from '../globals';
+import {
+  AudioOutput,
+  MAX_PULSE_COMMAND_ATTEMPTS,
+  setAudioOutput,
+} from './outputs';
+
+jest.mock('@votingworks/backend');
+
+jest.mock('../globals');
+
+jest.mock('@votingworks/basics', (): typeof import('@votingworks/basics') => ({
+  ...jest.requireActual('@votingworks/basics'),
+  sleep: jest.fn(),
+}));
+
+const mockExecFile = mockOf(execFile);
+const mockSleep = mockOf(sleep);
+const mockGetNodeEnv = mockOf(getNodeEnv);
+const mockLog = mockLogger();
+
+test('setAudioOutput - success on retry', async () => {
+  mockGetNodeEnv.mockReturnValue('production');
+  mockSleep.mockResolvedValue();
+  mockExecFile.mockRejectedValueOnce('command failed');
+  mockExecFile.mockResolvedValueOnce({ stdout: 'ok', stderr: '' });
+
+  await setAudioOutput(AudioOutput.SPEAKER, mockLog);
+
+  expect(mockExecFile).toHaveBeenCalledTimes(2);
+  expect(mockSleep).toHaveBeenCalledTimes(1);
+  expect(mockLog.log).toHaveBeenCalledTimes(1);
+  expect(mockLog.log).toHaveBeenCalledWith(
+    LogEventId.Info,
+    'system',
+    expect.objectContaining({
+      message: expect.stringContaining('command failed'),
+    })
+  );
+});
+
+test('setAudioOutput - retries and rethrows on failure', async () => {
+  mockGetNodeEnv.mockReturnValue('production');
+  mockSleep.mockResolvedValue();
+  mockExecFile.mockRejectedValue('command failed');
+
+  await expect(() =>
+    setAudioOutput(AudioOutput.SPEAKER, mockLog)
+  ).rejects.toMatchObject({
+    message: /command failed/,
+  });
+
+  expect(mockExecFile).toHaveBeenCalledTimes(MAX_PULSE_COMMAND_ATTEMPTS);
+  expect(mockSleep).toHaveBeenCalledTimes(MAX_PULSE_COMMAND_ATTEMPTS - 1);
+  expect(mockLog.log).toHaveBeenCalledTimes(MAX_PULSE_COMMAND_ATTEMPTS - 1);
+});
+
+test('setAudioOutput - no-op in non-prod environments', async () => {
+  mockGetNodeEnv.mockReturnValue('development');
+
+  await setAudioOutput(AudioOutput.SPEAKER, mockLog);
+
+  expect(mockExecFile).not.toHaveBeenCalled();
+  expect(mockSleep).not.toHaveBeenCalled();
+  expect(mockLog.log).not.toHaveBeenCalled();
+});

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -1253,7 +1253,8 @@ describe('open cover detection', () => {
     await setMockCoverOpen(true);
     expect(machine.getSimpleStatus()).toEqual('cover_open_unauthorized');
     expect(mockOf(setAudioOutput)).toHaveBeenLastCalledWith(
-      AudioOutput.SPEAKER
+      AudioOutput.SPEAKER,
+      expect.anything() // logger
     );
 
     // Stops triggering for Poll Worker:
@@ -1262,7 +1263,8 @@ describe('open cover detection', () => {
     await sleep(0);
     expect(machine.getSimpleStatus()).toEqual('not_accepting_paper');
     expect(mockOf(setAudioOutput)).toHaveBeenLastCalledWith(
-      AudioOutput.HEADPHONES
+      AudioOutput.HEADPHONES,
+      expect.anything() // logger
     );
 
     // Stops triggering for EM:
@@ -1283,14 +1285,16 @@ describe('open cover detection', () => {
     await sleep(0);
     expect(machine.getSimpleStatus()).toEqual('cover_open_unauthorized');
     expect(mockOf(setAudioOutput)).toHaveBeenLastCalledWith(
-      AudioOutput.SPEAKER
+      AudioOutput.SPEAKER,
+      expect.anything() // logger
     );
 
     // Close cover to stop triggering:
     await setMockCoverOpen(false);
     expect(machine.getSimpleStatus()).toEqual('not_accepting_paper');
     expect(mockOf(setAudioOutput)).toHaveBeenLastCalledWith(
-      AudioOutput.HEADPHONES
+      AudioOutput.HEADPHONES,
+      expect.anything() // logger
     );
   });
 

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -1392,8 +1392,8 @@ export function buildMachine(
         },
         cover_open_unauthorized: {
           invoke: pollCoverOpenStatus,
-          entry: () => setAudioOutput(AudioOutput.SPEAKER),
-          exit: () => setAudioOutput(AudioOutput.HEADPHONES),
+          entry: ({ logger }) => setAudioOutput(AudioOutput.SPEAKER, logger),
+          exit: ({ logger }) => setAudioOutput(AudioOutput.HEADPHONES, logger),
           on: {
             AUTH_STATUS_LOGGED_OUT: 'voting_flow.history',
             AUTH_STATUS_POLL_WORKER: 'voting_flow.history',

--- a/apps/mark-scan/backend/src/globals.ts
+++ b/apps/mark-scan/backend/src/globals.ts
@@ -15,13 +15,19 @@ const NodeEnvSchema = z.union([
   z.literal('production'),
 ]);
 
-/**
- * Which node environment is this?
- */
-export const NODE_ENV = unsafeParse(
+const NODE_ENV = unsafeParse(
   NodeEnvSchema,
   process.env.NODE_ENV ?? 'development'
 );
+
+/**
+ * Which node environment is this?
+ *
+ * NOTE: Exposed as a function to enable mocking.
+ */
+export function getNodeEnv(): z.TypeOf<typeof NodeEnvSchema> {
+  return NODE_ENV;
+}
 
 /**
  * Where should the database, audio, and hardware status files go?


### PR DESCRIPTION
## Overview

We have some signal that attempting to run the `pactl set-sink-port` command too early after boot-up (which happens if we start up with the printer cover open), the `pulse audio` service may not be running yet or fully spun up.

This adds two retries with delays to attempt to wait until `pulse audio` is ready to run the command.

## Demo Video or Screenshot

## Testing Plan
- Patch was tested on a VSAP 150 that seemed to be running into the issue and verified that it at least prevents crashes on startup.
- Unit tests for the retry logic

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
