### PR TITLE
start contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,23 @@
+# Contributors
+
+This document will evolve as we make sure to include all the
+contributors to the VotingWorks system.
+
+## VotingWorks Pioneers
+
+VotingWorks has benefited from the input of dozens of election
+administrators around the country. Some of them were particularly
+helpful: they took a chance on VotingWorks at the pilot stage, when
+all we had were prototypes. They dealt with the pains of an
+in-development product and gave us critical feedback. VotingWorks
+wouldn't be VotingWorks without them.
+
+In Choctaw County, Mississippi: Amy Burdine and Dr. Wayne McLeod
+
+In Warren County, Mississippi: Jan Daigre, Sara Dionne, Donald Oakes, Shelley Plett, Joe Tom
+
+In Calhoun County, Mississippi: Carlton Baker
+
+In Woodstock, New Hampshire: Judy Welch and Ken Chapman
+
+In Moultonborough, New Hampshire: Julia Marchand and Paul Punturieri


### PR DESCRIPTION
Add a contributors list and in particular include VotingWorks pioneers, the election administrators who piloted VotingWorks when it was just a prototype.