### PR TITLE
fix(scan): improve acceptance rate of skewed ballots

### DIFF
--- a/libs/ballot-interpreter/src/hmpb-rust/image_utils.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/image_utils.rs
@@ -233,7 +233,8 @@ pub fn expand_image(
 }
 
 /// Finds the inset of a scanned document in an image such that each side of the
-/// inset has more than half of its pixels above the given threshold.
+/// inset has more than `min_ratio_above_threshold` of its pixels above the
+/// given threshold.
 #[allow(clippy::similar_names)]
 pub fn find_scanned_document_inset(
     image: &GrayImage,

--- a/libs/ballot-interpreter/src/hmpb-rust/image_utils.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/image_utils.rs
@@ -235,7 +235,11 @@ pub fn expand_image(
 /// Finds the inset of a scanned document in an image such that each side of the
 /// inset has more than half of its pixels above the given threshold.
 #[allow(clippy::similar_names)]
-pub fn find_scanned_document_inset(image: &GrayImage, threshold: u8) -> Option<Inset> {
+pub fn find_scanned_document_inset(
+    image: &GrayImage,
+    threshold: u8,
+    min_ratio_above_threshold: UnitIntervalValue,
+) -> Option<Inset> {
     let (width, height) = image.dimensions();
     let (max_x, max_y) = (width - 1, height - 1);
 
@@ -243,25 +247,25 @@ pub fn find_scanned_document_inset(image: &GrayImage, threshold: u8) -> Option<I
         (0..width)
             .filter(|x| image.get_pixel(*x, *y)[0] > threshold)
             .count()
-            > (width / 2) as usize
+            > (width as f32 * min_ratio_above_threshold) as usize
     });
     let max_y_above_threshold = (0..height).rev().find(|y| {
         (0..width)
             .filter(|x| image.get_pixel(*x, *y)[0] > threshold)
             .count()
-            > (width / 2) as usize
+            > (width as f32 * min_ratio_above_threshold) as usize
     });
     let min_x_above_threshold = (0..width).find(|x| {
         (0..height)
             .filter(|y| image.get_pixel(*x, *y)[0] > threshold)
             .count()
-            > (height / 2) as usize
+            > (height as f32 * min_ratio_above_threshold) as usize
     });
     let max_x_above_threshold = (0..width).rev().find(|x| {
         (0..height)
             .filter(|y| image.get_pixel(*x, *y)[0] > threshold)
             .count()
-            > (height / 2) as usize
+            > (height as f32 * min_ratio_above_threshold) as usize
     });
 
     match (
@@ -394,14 +398,14 @@ mod test {
     #[test]
     fn test_find_scanned_document_inset_all_black() {
         let image = GrayImage::new(100, 100);
-        let inset = find_scanned_document_inset(&image, otsu_level(&image));
+        let inset = find_scanned_document_inset(&image, otsu_level(&image), 0.5);
         assert_eq!(inset, None);
     }
 
     #[test]
     fn test_find_scanned_document_inset_all_white() {
         let image = GrayImage::from_pixel(100, 100, Luma([u8::MAX]));
-        let inset = find_scanned_document_inset(&image, otsu_level(&image));
+        let inset = find_scanned_document_inset(&image, otsu_level(&image), 0.5);
         assert_eq!(
             inset,
             Some(Inset {
@@ -419,7 +423,7 @@ mod test {
         let image = image::load(Cursor::new(image_bytes), image::ImageFormat::Jpeg)
             .unwrap()
             .into_luma8();
-        let inset = find_scanned_document_inset(&image, otsu_level(&image));
+        let inset = find_scanned_document_inset(&image, otsu_level(&image), 0.5);
         assert_eq!(
             inset,
             Some(Inset {

--- a/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
@@ -235,7 +235,7 @@ pub fn prepare_ballot_card_images(
 /// Return the image with the black border cropped off.
 pub fn crop_ballot_page_image_borders(mut image: GrayImage) -> Option<BallotImage> {
     let threshold = otsu_level(&image);
-    let border_inset = find_scanned_document_inset(&image, threshold)?;
+    let border_inset = find_scanned_document_inset(&image, threshold, 0.1)?;
     let image = image
         .sub_image(
             border_inset.left,

--- a/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
@@ -232,10 +232,21 @@ pub fn prepare_ballot_card_images(
     })
 }
 
+/// This sets the ratio of pixels required to be white (above the threshold) in
+/// a given edge row or column to consider it no longer eligible to be cropped.
+/// This used to be 50%, but we found that too much of the top/bottom of the
+/// actual ballot content was being cropped, especially in the case of a skewed
+/// ballot. In such cases, one of the corners would sometimes be partially or
+/// completely cropped, leading to the ballot being rejected. We chose the new
+/// value by trial and error, in particular by seeing how much cropping occurred
+/// on ballots with significant but still acceptable skew (i.e. 3 degrees).
+const CROP_BORDERS_THRESHOLD_RATIO: f32 = 0.1;
+
 /// Return the image with the black border cropped off.
 pub fn crop_ballot_page_image_borders(mut image: GrayImage) -> Option<BallotImage> {
     let threshold = otsu_level(&image);
-    let border_inset = find_scanned_document_inset(&image, threshold, 0.1)?;
+    let border_inset =
+        find_scanned_document_inset(&image, threshold, CROP_BORDERS_THRESHOLD_RATIO)?;
     let image = image
         .sub_image(
             border_inset.left,

--- a/libs/ballot-interpreter/src/hmpb-ts/__snapshots__/interpret.test.ts.snap
+++ b/libs/ballot-interpreter/src/hmpb-ts/__snapshots__/interpret.test.ts.snap
@@ -5,7 +5,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
   {
     "bounds": {
       "height": 102,
-      "left": 372,
+      "left": 373,
       "top": 455,
       "width": 1301,
     },
@@ -14,7 +14,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 372,
+          "left": 373,
           "top": 455,
           "width": 302,
         },
@@ -28,7 +28,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 722,
+          "left": 723,
           "top": 455,
           "width": 301,
         },
@@ -42,7 +42,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 1072,
+          "left": 1073,
           "top": 455,
           "width": 301,
         },
@@ -56,7 +56,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 1372,
+          "left": 1373,
           "top": 455,
           "width": 301,
         },
@@ -72,7 +72,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
   {
     "bounds": {
       "height": 102,
-      "left": 373,
+      "left": 374,
       "top": 606,
       "width": 1300,
     },
@@ -81,7 +81,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 373,
+          "left": 374,
           "top": 606,
           "width": 301,
         },
@@ -95,7 +95,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 723,
+          "left": 724,
           "top": 606,
           "width": 300,
         },
@@ -109,7 +109,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 101,
-          "left": 1372,
+          "left": 1373,
           "top": 606,
           "width": 301,
         },
@@ -125,7 +125,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
   {
     "bounds": {
       "height": 103,
-      "left": 373,
+      "left": 374,
       "top": 757,
       "width": 1301,
     },
@@ -134,7 +134,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 103,
-          "left": 373,
+          "left": 374,
           "top": 757,
           "width": 301,
         },
@@ -148,7 +148,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 723,
+          "left": 724,
           "top": 757,
           "width": 301,
         },
@@ -162,7 +162,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 1072,
+          "left": 1073,
           "top": 757,
           "width": 302,
         },
@@ -176,7 +176,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 1372,
+          "left": 1373,
           "top": 757,
           "width": 302,
         },
@@ -192,7 +192,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
   {
     "bounds": {
       "height": 102,
-      "left": 373,
+      "left": 374,
       "top": 908,
       "width": 1301,
     },
@@ -201,7 +201,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 101,
-          "left": 373,
+          "left": 374,
           "top": 909,
           "width": 301,
         },
@@ -215,7 +215,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 723,
+          "left": 724,
           "top": 908,
           "width": 301,
         },
@@ -229,7 +229,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 101,
-          "left": 1373,
+          "left": 1374,
           "top": 908,
           "width": 301,
         },
@@ -245,7 +245,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
   {
     "bounds": {
       "height": 104,
-      "left": 373,
+      "left": 374,
       "top": 1058,
       "width": 1301,
     },
@@ -254,7 +254,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 103,
-          "left": 373,
+          "left": 374,
           "top": 1059,
           "width": 302,
         },
@@ -268,7 +268,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 723,
+          "left": 724,
           "top": 1059,
           "width": 301,
         },
@@ -282,7 +282,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 1373,
+          "left": 1374,
           "top": 1058,
           "width": 301,
         },
@@ -298,7 +298,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
   {
     "bounds": {
       "height": 356,
-      "left": 374,
+      "left": 375,
       "top": 1209,
       "width": 1301,
     },
@@ -307,7 +307,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 374,
+          "left": 375,
           "top": 1261,
           "width": 301,
         },
@@ -321,7 +321,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 101,
-          "left": 374,
+          "left": 375,
           "top": 1362,
           "width": 301,
         },
@@ -335,7 +335,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 103,
-          "left": 374,
+          "left": 375,
           "top": 1462,
           "width": 302,
         },
@@ -349,7 +349,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 724,
+          "left": 725,
           "top": 1210,
           "width": 301,
         },
@@ -363,7 +363,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 724,
+          "left": 725,
           "top": 1310,
           "width": 301,
         },
@@ -377,7 +377,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 103,
-          "left": 724,
+          "left": 725,
           "top": 1411,
           "width": 301,
         },
@@ -391,7 +391,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 1073,
+          "left": 1074,
           "top": 1260,
           "width": 302,
         },
@@ -405,7 +405,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 1074,
+          "left": 1075,
           "top": 1360,
           "width": 301,
         },
@@ -419,7 +419,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 1373,
+          "left": 1374,
           "top": 1209,
           "width": 302,
         },
@@ -433,7 +433,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 101,
-          "left": 1374,
+          "left": 1375,
           "top": 1310,
           "width": 301,
         },
@@ -447,7 +447,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 103,
-          "left": 1373,
+          "left": 1374,
           "top": 1410,
           "width": 302,
         },
@@ -463,7 +463,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
   {
     "bounds": {
       "height": 104,
-      "left": 375,
+      "left": 376,
       "top": 1661,
       "width": 1301,
     },
@@ -472,7 +472,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 375,
+          "left": 376,
           "top": 1663,
           "width": 301,
         },
@@ -486,7 +486,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 725,
+          "left": 726,
           "top": 1662,
           "width": 301,
         },
@@ -500,7 +500,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 1074,
+          "left": 1075,
           "top": 1661,
           "width": 302,
         },
@@ -514,7 +514,7 @@ exports[`interpret \`ImageData\` objects 1`] = `
       {
         "bounds": {
           "height": 101,
-          "left": 1374,
+          "left": 1375,
           "top": 1661,
           "width": 302,
         },
@@ -897,7 +897,7 @@ exports[`interpret images from paths 1`] = `
   {
     "bounds": {
       "height": 102,
-      "left": 372,
+      "left": 373,
       "top": 455,
       "width": 1301,
     },
@@ -906,7 +906,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 372,
+          "left": 373,
           "top": 455,
           "width": 302,
         },
@@ -920,7 +920,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 722,
+          "left": 723,
           "top": 455,
           "width": 301,
         },
@@ -934,7 +934,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 1072,
+          "left": 1073,
           "top": 455,
           "width": 301,
         },
@@ -948,7 +948,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 1372,
+          "left": 1373,
           "top": 455,
           "width": 301,
         },
@@ -964,7 +964,7 @@ exports[`interpret images from paths 1`] = `
   {
     "bounds": {
       "height": 102,
-      "left": 373,
+      "left": 374,
       "top": 606,
       "width": 1300,
     },
@@ -973,7 +973,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 373,
+          "left": 374,
           "top": 606,
           "width": 301,
         },
@@ -987,7 +987,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 723,
+          "left": 724,
           "top": 606,
           "width": 300,
         },
@@ -1001,7 +1001,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 101,
-          "left": 1372,
+          "left": 1373,
           "top": 606,
           "width": 301,
         },
@@ -1017,7 +1017,7 @@ exports[`interpret images from paths 1`] = `
   {
     "bounds": {
       "height": 103,
-      "left": 373,
+      "left": 374,
       "top": 757,
       "width": 1301,
     },
@@ -1026,7 +1026,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 103,
-          "left": 373,
+          "left": 374,
           "top": 757,
           "width": 301,
         },
@@ -1040,7 +1040,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 723,
+          "left": 724,
           "top": 757,
           "width": 301,
         },
@@ -1054,7 +1054,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 1072,
+          "left": 1073,
           "top": 757,
           "width": 302,
         },
@@ -1068,7 +1068,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 1372,
+          "left": 1373,
           "top": 757,
           "width": 302,
         },
@@ -1084,7 +1084,7 @@ exports[`interpret images from paths 1`] = `
   {
     "bounds": {
       "height": 102,
-      "left": 373,
+      "left": 374,
       "top": 908,
       "width": 1301,
     },
@@ -1093,7 +1093,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 101,
-          "left": 373,
+          "left": 374,
           "top": 909,
           "width": 301,
         },
@@ -1107,7 +1107,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 723,
+          "left": 724,
           "top": 908,
           "width": 301,
         },
@@ -1121,7 +1121,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 101,
-          "left": 1373,
+          "left": 1374,
           "top": 908,
           "width": 301,
         },
@@ -1137,7 +1137,7 @@ exports[`interpret images from paths 1`] = `
   {
     "bounds": {
       "height": 104,
-      "left": 373,
+      "left": 374,
       "top": 1058,
       "width": 1301,
     },
@@ -1146,7 +1146,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 103,
-          "left": 373,
+          "left": 374,
           "top": 1059,
           "width": 302,
         },
@@ -1160,7 +1160,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 723,
+          "left": 724,
           "top": 1059,
           "width": 301,
         },
@@ -1174,7 +1174,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 1373,
+          "left": 1374,
           "top": 1058,
           "width": 301,
         },
@@ -1190,7 +1190,7 @@ exports[`interpret images from paths 1`] = `
   {
     "bounds": {
       "height": 356,
-      "left": 374,
+      "left": 375,
       "top": 1209,
       "width": 1301,
     },
@@ -1199,7 +1199,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 374,
+          "left": 375,
           "top": 1261,
           "width": 301,
         },
@@ -1213,7 +1213,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 101,
-          "left": 374,
+          "left": 375,
           "top": 1362,
           "width": 301,
         },
@@ -1227,7 +1227,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 103,
-          "left": 374,
+          "left": 375,
           "top": 1462,
           "width": 302,
         },
@@ -1241,7 +1241,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 724,
+          "left": 725,
           "top": 1210,
           "width": 301,
         },
@@ -1255,7 +1255,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 724,
+          "left": 725,
           "top": 1310,
           "width": 301,
         },
@@ -1269,7 +1269,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 103,
-          "left": 724,
+          "left": 725,
           "top": 1411,
           "width": 301,
         },
@@ -1283,7 +1283,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 1073,
+          "left": 1074,
           "top": 1260,
           "width": 302,
         },
@@ -1297,7 +1297,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 1074,
+          "left": 1075,
           "top": 1360,
           "width": 301,
         },
@@ -1311,7 +1311,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 1373,
+          "left": 1374,
           "top": 1209,
           "width": 302,
         },
@@ -1325,7 +1325,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 101,
-          "left": 1374,
+          "left": 1375,
           "top": 1310,
           "width": 301,
         },
@@ -1339,7 +1339,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 103,
-          "left": 1373,
+          "left": 1374,
           "top": 1410,
           "width": 302,
         },
@@ -1355,7 +1355,7 @@ exports[`interpret images from paths 1`] = `
   {
     "bounds": {
       "height": 104,
-      "left": 375,
+      "left": 376,
       "top": 1661,
       "width": 1301,
     },
@@ -1364,7 +1364,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 375,
+          "left": 376,
           "top": 1663,
           "width": 301,
         },
@@ -1378,7 +1378,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 725,
+          "left": 726,
           "top": 1662,
           "width": 301,
         },
@@ -1392,7 +1392,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 102,
-          "left": 1074,
+          "left": 1075,
           "top": 1661,
           "width": 302,
         },
@@ -1406,7 +1406,7 @@ exports[`interpret images from paths 1`] = `
       {
         "bounds": {
           "height": 101,
-          "left": 1374,
+          "left": 1375,
           "top": 1661,
           "width": 302,
         },
@@ -1805,19 +1805,19 @@ exports[`score write in areas 1`] = `
     "score": 0,
     "shape": {
       "bottomLeft": {
-        "x": 1371.8636,
+        "x": 1372.8636,
         "y": 515.5,
       },
       "bottomRight": {
-        "x": 1596.591,
+        "x": 1597.591,
         "y": 515.5,
       },
       "topLeft": {
-        "x": 1371.6818,
+        "x": 1372.6818,
         "y": 472,
       },
       "topRight": {
-        "x": 1596.5454,
+        "x": 1597.5454,
         "y": 472,
       },
     },
@@ -1841,19 +1841,19 @@ exports[`score write in areas 1`] = `
     "score": 0,
     "shape": {
       "bottomLeft": {
-        "x": 1371.8635,
+        "x": 1372.8635,
         "y": 666.1818,
       },
       "bottomRight": {
-        "x": 1596.5908,
+        "x": 1597.5908,
         "y": 666.0455,
       },
       "topLeft": {
-        "x": 1371.8636,
+        "x": 1372.8636,
         "y": 623.0909,
       },
       "topRight": {
-        "x": 1596.5908,
+        "x": 1597.5908,
         "y": 623.0227,
       },
     },
@@ -1877,19 +1877,19 @@ exports[`score write in areas 1`] = `
     "score": 0,
     "shape": {
       "bottomLeft": {
-        "x": 1371.8636,
+        "x": 1372.8636,
         "y": 817.2727,
       },
       "bottomRight": {
-        "x": 1596.591,
+        "x": 1597.591,
         "y": 817.0682,
       },
       "topLeft": {
-        "x": 1371.8635,
+        "x": 1372.8635,
         "y": 773.6818,
       },
       "topRight": {
-        "x": 1596.5908,
+        "x": 1597.5908,
         "y": 773.5455,
       },
     },
@@ -1913,19 +1913,19 @@ exports[`score write in areas 1`] = `
     "score": 0.12888889,
     "shape": {
       "bottomLeft": {
-        "x": 1373.5,
+        "x": 1374.5,
         "y": 967.36365,
       },
       "bottomRight": {
-        "x": 1598.5,
+        "x": 1599.5,
         "y": 967.0909,
       },
       "topLeft": {
-        "x": 1372.6818,
+        "x": 1373.6818,
         "y": 925.1818,
       },
       "topRight": {
-        "x": 1597.5454,
+        "x": 1598.5454,
         "y": 925.0455,
       },
     },
@@ -1949,19 +1949,19 @@ exports[`score write in areas 1`] = `
     "score": 0,
     "shape": {
       "bottomLeft": {
-        "x": 1372.6818,
+        "x": 1373.6818,
         "y": 1119.1818,
       },
       "bottomRight": {
-        "x": 1597.5454,
+        "x": 1598.5454,
         "y": 1119.0454,
       },
       "topLeft": {
-        "x": 1372.6819,
+        "x": 1373.6819,
         "y": 1075.3636,
       },
       "topRight": {
-        "x": 1597.5455,
+        "x": 1598.5455,
         "y": 1075.091,
       },
     },
@@ -1985,19 +1985,19 @@ exports[`score write in areas 1`] = `
     "score": 0,
     "shape": {
       "bottomLeft": {
-        "x": 1372.8636,
+        "x": 1373.8636,
         "y": 1269.9546,
       },
       "bottomRight": {
-        "x": 1597.591,
+        "x": 1598.591,
         "y": 1269.6136,
       },
       "topLeft": {
-        "x": 1372.8636,
+        "x": 1373.8636,
         "y": 1226.4546,
       },
       "topRight": {
-        "x": 1597.591,
+        "x": 1598.591,
         "y": 1226.1136,
       },
     },
@@ -2021,19 +2021,19 @@ exports[`score write in areas 1`] = `
     "score": 0,
     "shape": {
       "bottomLeft": {
-        "x": 1373.6818,
+        "x": 1374.6818,
         "y": 1370.4546,
       },
       "bottomRight": {
-        "x": 1598.5454,
+        "x": 1599.5454,
         "y": 1370.1136,
       },
       "topLeft": {
-        "x": 1373.6818,
+        "x": 1374.6818,
         "y": 1326.9546,
       },
       "topRight": {
-        "x": 1598.5454,
+        "x": 1599.5454,
         "y": 1326.6136,
       },
     },
@@ -2057,19 +2057,19 @@ exports[`score write in areas 1`] = `
     "score": 0,
     "shape": {
       "bottomLeft": {
-        "x": 1373.6818,
+        "x": 1374.6818,
         "y": 1470.5454,
       },
       "bottomRight": {
-        "x": 1598.5453,
+        "x": 1599.5453,
         "y": 1470.1364,
       },
       "topLeft": {
-        "x": 1373.6818,
+        "x": 1374.6818,
         "y": 1427.4546,
       },
       "topRight": {
-        "x": 1598.5454,
+        "x": 1599.5454,
         "y": 1427.1136,
       },
     },
@@ -2093,19 +2093,19 @@ exports[`score write in areas 1`] = `
     "score": 0,
     "shape": {
       "bottomLeft": {
-        "x": 1374.6819,
+        "x": 1375.6819,
         "y": 1720.7273,
       },
       "bottomRight": {
-        "x": 1599.5454,
+        "x": 1600.5454,
         "y": 1720.1818,
       },
       "topLeft": {
-        "x": 1373.8636,
+        "x": 1374.8636,
         "y": 1678.3182,
       },
       "topRight": {
-        "x": 1598.5908,
+        "x": 1599.5908,
         "y": 1677.7046,
       },
     },

--- a/libs/ballot-interpreter/src/hmpb-ts/interpret.test.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/interpret.test.ts
@@ -48,9 +48,9 @@ test('interpret `ImageData` objects', async () => {
   const backImageData =
     await electionGridLayoutNewHampshireTestBallotFixtures.scanMarkedBack.asImageData();
   // While we would usually expect a normalized image to differ from the
-  // original more significantly, in this case their dimensions are basically
-  // identical due to minimal cropping and no scaling, which makes for a basic test.
-  expect(front.normalizedImage.width).toEqual(frontImageData.width - 1);
+  // original more significantly, in this case their dimensions are identical
+  // due to minimal cropping and no scaling, which makes for a basic test.
+  expect(front.normalizedImage.width).toEqual(frontImageData.width);
   expect(front.normalizedImage.height).toEqual(frontImageData.height);
   expect(back.normalizedImage.width).toEqual(backImageData.width);
   expect(back.normalizedImage.height).toEqual(backImageData.height);
@@ -382,9 +382,9 @@ test('interpret images from paths', async () => {
   const backImageData =
     await electionGridLayoutNewHampshireTestBallotFixtures.scanMarkedBack.asImageData();
   // While we would usually expect a normalized image to differ from the
-  // original more significantly, in this case their dimensions are basically
-  // identical due to minimal cropping and no scaling, which makes for a basic test.
-  expect(front.normalizedImage.width).toEqual(frontImageData.width - 1);
+  // original more significantly, in this case their dimensions are identical
+  // due to minimal cropping and no scaling, which makes for a basic test.
+  expect(front.normalizedImage.width).toEqual(frontImageData.width);
   expect(front.normalizedImage.height).toEqual(frontImageData.height);
   expect(back.normalizedImage.width).toEqual(backImageData.width);
   expect(back.normalizedImage.height).toEqual(backImageData.height);


### PR DESCRIPTION
## Overview

When a ballot has a significant skew (>= 1 degree), the previous implementation of `find_scanned_document_inset` would cause too much of the ballot to be cropped out of the image. Because it would only stop cropping once the white pixels were half of a given row, the portion of a skewed ballot that would be cropped was likely to contain timing marks. At the very least, it was likely to partially or completely crop the corner timing mark, which we require in order to proceed with interpretation.

The new implementation takes a configurable ratio of white to black pixels at which to stop cropping, which we now set to 10% (vs the previous 50%). This makes the cropping much more conservative while still cropping off any edge rows/columns of pure black. This preserves the corner timing marks even with skew around 3 degrees, which is as high as we're likely to be able to interpret successfully.

## Demo Video or Screenshot
| Original | Before (missing top-left corner) | After (top-left corner present) |
|-|-|-|
|![image](https://github.com/user-attachments/assets/e90ffc70-7df5-4be3-a64f-fc48efc5ca24)|![image](https://github.com/user-attachments/assets/8dc01079-5dba-4c28-bcf4-0ee4947c5e08)|![image](https://github.com/user-attachments/assets/2b30b757-1414-43c1-99d7-c2a68d0ff6c8)|

## Testing Plan
Tested with the corpus @adghayes provided from TRR. Ignoring the ballots that were rejected for non-skew reasons (defaced timing marks or QR codes, mainly), the original results were like so:

- 968 accepted
- 61 rejected
- 6% rejection rate (30/500)

With the changes in this PR, the new results are:

- 1005 accepted (37 newly accepted)
- 24 rejected (0 newly rejected)
- 2.3% rejection rate (11.6/500)

Looking at the remaining ones that are failing, the pattern seems to be poor corner finding:

![CleanShot 2024-11-19 at 10 27 07@2x](https://github.com/user-attachments/assets/3d43e24f-76f0-4005-af0e-4398c7fbfda2)

I have another change that may fix this, but it's a more significant change so I'll be doing it separately.