### PR TITLE
[All Apps] Add code version & footer to sys admin views

### DIFF
--- a/apps/admin/frontend/src/components/sidebar.tsx
+++ b/apps/admin/frontend/src/components/sidebar.tsx
@@ -9,7 +9,6 @@ import {
   VerticalElectionInfoBar,
 } from '@votingworks/ui';
 
-import { assertDefined } from '@votingworks/basics';
 import { AppContext } from '../contexts/app_context';
 
 export interface SidebarProps {
@@ -46,18 +45,16 @@ export function Sidebar(props: SidebarProps): JSX.Element {
           </NavListItem>
         ))}
       </NavList>
-      {electionDefinition && (
-        <div style={{ marginTop: 'auto' }}>
-          <VerticalElectionInfoBar
-            mode="admin"
-            electionDefinition={electionDefinition}
-            electionPackageHash={assertDefined(electionPackageHash)}
-            codeVersion={machineConfig.codeVersion}
-            machineId={machineConfig.machineId}
-            inverse
-          />
-        </div>
-      )}
+      <div style={{ marginTop: 'auto' }}>
+        <VerticalElectionInfoBar
+          mode="admin"
+          electionDefinition={electionDefinition}
+          electionPackageHash={electionPackageHash}
+          codeVersion={machineConfig.codeVersion}
+          machineId={machineConfig.machineId}
+          inverse
+        />
+      </div>
     </LeftNav>
   );
 }

--- a/apps/admin/frontend/src/screens/machine_locked_screen.tsx
+++ b/apps/admin/frontend/src/screens/machine_locked_screen.tsx
@@ -1,7 +1,6 @@
 import { ElectionInfoBar, Main, Screen, H1, H3 } from '@votingworks/ui';
 import { useContext } from 'react';
 import styled from 'styled-components';
-import { assertDefined } from '@votingworks/basics';
 import { AppContext } from '../contexts/app_context';
 
 const LockedImage = styled.img`
@@ -27,15 +26,13 @@ export function MachineLockedScreen(): JSX.Element {
           </H3>
         </div>
       </Main>
-      {electionDefinition && (
-        <ElectionInfoBar
-          mode="admin"
-          electionDefinition={electionDefinition}
-          electionPackageHash={assertDefined(electionPackageHash)}
-          codeVersion={machineConfig.codeVersion}
-          machineId={machineConfig.machineId}
-        />
-      )}
+      <ElectionInfoBar
+        mode="admin"
+        electionDefinition={electionDefinition}
+        electionPackageHash={electionPackageHash}
+        codeVersion={machineConfig.codeVersion}
+        machineId={machineConfig.machineId}
+      />
     </Screen>
   );
 }

--- a/apps/central-scan/frontend/src/navigation_screen.tsx
+++ b/apps/central-scan/frontend/src/navigation_screen.tsx
@@ -25,7 +25,6 @@ import {
 } from '@votingworks/utils';
 import { DippedSmartCardAuth, ElectionDefinition } from '@votingworks/types';
 import { Link, useRouteMatch } from 'react-router-dom';
-import { assertDefined } from '@votingworks/basics';
 import { AppContext } from './contexts/app_context';
 import { ejectUsbDrive, logOut } from './api';
 
@@ -133,18 +132,16 @@ export function NavigationScreen({ children, title }: Props): JSX.Element {
             </NavListItem>
           ))}
         </NavList>
-        {electionDefinition && (
-          <div style={{ marginTop: 'auto' }}>
-            <VerticalElectionInfoBar
-              mode="admin"
-              electionDefinition={electionDefinition}
-              electionPackageHash={assertDefined(electionPackageHash)}
-              codeVersion={machineConfig.codeVersion}
-              machineId={machineConfig.machineId}
-              inverse
-            />
-          </div>
-        )}
+        <div style={{ marginTop: 'auto' }}>
+          <VerticalElectionInfoBar
+            mode="admin"
+            electionDefinition={electionDefinition}
+            electionPackageHash={electionPackageHash}
+            codeVersion={machineConfig.codeVersion}
+            machineId={machineConfig.machineId}
+            inverse
+          />
+        </div>
       </LeftNav>
       <Main flexColumn>
         <SessionTimeLimitTimer authStatus={auth} />

--- a/apps/central-scan/frontend/src/screens/machine_locked_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/machine_locked_screen.tsx
@@ -10,7 +10,6 @@ import {
 import { useContext } from 'react';
 import styled from 'styled-components';
 
-import { assertDefined } from '@votingworks/basics';
 import { AppContext } from '../contexts/app_context';
 
 const LockedImage = styled.img`
@@ -43,15 +42,13 @@ export function MachineLockedScreen(): JSX.Element {
           </Font>
         )}
       </Main>
-      {electionDefinition && (
-        <ElectionInfoBar
-          mode="admin"
-          electionDefinition={electionDefinition}
-          electionPackageHash={assertDefined(electionPackageHash)}
-          codeVersion={machineConfig.codeVersion}
-          machineId={machineConfig.machineId}
-        />
-      )}
+      <ElectionInfoBar
+        mode="admin"
+        electionDefinition={electionDefinition}
+        electionPackageHash={electionPackageHash}
+        codeVersion={machineConfig.codeVersion}
+        machineId={machineConfig.machineId}
+      />
     </Screen>
   );
 }

--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -399,7 +399,11 @@ export function AppRoot(): JSX.Element | null {
         resetPollsToPaused={
           pollsState === 'polls_closed_final' ? resetPollsToPaused : undefined
         }
+        machineConfig={machineConfig}
+        electionDefinition={electionDefinition}
+        electionPackageHash={electionPackageHash}
         usbDriveStatus={usbDriveStatus}
+        precinctSelection={precinctSelection}
       />
     );
   }

--- a/apps/mark-scan/frontend/src/pages/system_administrator_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/system_administrator_screen.test.tsx
@@ -1,6 +1,8 @@
 import userEvent from '@testing-library/user-event';
 import { mockUsbDriveStatus } from '@votingworks/ui';
+import { formatElectionHashes } from '@votingworks/types';
 import { screen, waitFor } from '../../test/react_testing_library';
+import { electionDefinition, election } from '../../test/helpers/election';
 
 import { render } from '../../test/test_utils';
 import { SystemAdministratorScreen } from './system_administrator_screen';
@@ -9,6 +11,7 @@ import {
   createApiMock,
   provideApi,
 } from '../../test/helpers/mock_api_client';
+import { mockMachineConfig } from '../../test/helpers/mock_machine_config';
 
 let apiMock: ApiMock;
 
@@ -28,12 +31,27 @@ test('SystemAdministratorScreen renders expected contents', () => {
       unconfigureMachine={unconfigureMachine}
       isMachineConfigured
       usbDriveStatus={mockUsbDriveStatus('mounted')}
+      electionDefinition={electionDefinition}
+      electionPackageHash="test-election-package-hash"
+      machineConfig={mockMachineConfig({
+        codeVersion: 'test', // Override default
+      })}
+      precinctSelection={undefined}
     />
   );
 
   // These buttons are further tested in libs/ui
   screen.getByRole('button', { name: 'Unconfigure Machine' });
   screen.getByRole('button', { name: 'Save Logs' });
+
+  // Has election info bar
+  screen.getByText(election.title);
+  screen.getByText(
+    formatElectionHashes(
+      electionDefinition.ballotHash,
+      'test-election-package-hash'
+    )
+  );
 });
 
 test('Can set date and time', async () => {
@@ -44,6 +62,12 @@ test('Can set date and time', async () => {
         unconfigureMachine={jest.fn()}
         isMachineConfigured
         usbDriveStatus={mockUsbDriveStatus('mounted')}
+        electionDefinition={electionDefinition}
+        electionPackageHash="test-election-package-hash"
+        machineConfig={mockMachineConfig({
+          codeVersion: 'test', // Override default
+        })}
+        precinctSelection={undefined}
       />
     )
   );
@@ -71,6 +95,12 @@ test('navigates to Diagnostics screen', async () => {
         unconfigureMachine={jest.fn()}
         isMachineConfigured
         usbDriveStatus={mockUsbDriveStatus('mounted')}
+        electionDefinition={electionDefinition}
+        electionPackageHash="test-election-package-hash"
+        machineConfig={mockMachineConfig({
+          codeVersion: 'test', // Override default
+        })}
+        precinctSelection={undefined}
       />
     )
   );

--- a/apps/mark-scan/frontend/src/pages/system_administrator_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/system_administrator_screen.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 
 import {
   Button,
+  ElectionInfoBar,
   H2,
   Main,
   Screen,
@@ -9,8 +10,10 @@ import {
   SystemAdministratorScreenContents,
 } from '@votingworks/ui';
 import { UsbDriveStatus } from '@votingworks/usb-drive';
-import { logOut, useApiClient } from '../api';
+import type { MachineConfig } from '@votingworks/mark-scan-backend';
+import { ElectionDefinition, PrecinctSelection } from '@votingworks/types';
 import { DiagnosticsScreen } from './diagnostics/diagnostics_screen';
+import { logOut, useApiClient } from '../api';
 
 const resetPollsToPausedText =
   'The polls are closed and voting is complete. After resetting the polls to paused, it will be possible to re-open the polls and resume voting. The printed ballots count will be preserved.';
@@ -20,6 +23,10 @@ interface Props {
   isMachineConfigured: boolean;
   resetPollsToPaused?: () => Promise<void>;
   usbDriveStatus: UsbDriveStatus;
+  electionDefinition?: ElectionDefinition;
+  electionPackageHash?: string;
+  machineConfig: MachineConfig;
+  precinctSelection?: PrecinctSelection;
 }
 
 /**
@@ -30,6 +37,10 @@ export function SystemAdministratorScreen({
   isMachineConfigured,
   resetPollsToPaused,
   usbDriveStatus,
+  electionDefinition,
+  electionPackageHash,
+  machineConfig,
+  precinctSelection,
 }: Props): JSX.Element {
   const apiClient = useApiClient();
   const logOutMutation = logOut.useMutation();
@@ -71,6 +82,14 @@ export function SystemAdministratorScreen({
           }
         />
       </Main>
+      <ElectionInfoBar
+        mode="admin"
+        electionDefinition={electionDefinition}
+        electionPackageHash={electionPackageHash}
+        codeVersion={machineConfig.codeVersion}
+        machineId={machineConfig.machineId}
+        precinctSelection={precinctSelection}
+      />
     </Screen>
   );
 }

--- a/apps/mark/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.tsx
@@ -162,16 +162,14 @@ export function AdminScreen({
           usbDriveIsEjecting={ejectUsbDriveMutation.isLoading}
         />
       </Main>
-      {election && (
-        <ElectionInfoBar
-          mode="admin"
-          electionDefinition={electionDefinition}
-          electionPackageHash={electionPackageHash}
-          codeVersion={machineConfig.codeVersion}
-          machineId={machineConfig.machineId}
-          precinctSelection={appPrecinct}
-        />
-      )}
+      <ElectionInfoBar
+        mode="admin"
+        electionDefinition={electionDefinition}
+        electionPackageHash={electionPackageHash}
+        codeVersion={machineConfig.codeVersion}
+        machineId={machineConfig.machineId}
+        precinctSelection={appPrecinct}
+      />
     </Screen>
   );
 }

--- a/apps/scan/frontend/src/components/layout.tsx
+++ b/apps/scan/frontend/src/components/layout.tsx
@@ -11,7 +11,6 @@ import {
 } from '@votingworks/ui';
 import styled, { DefaultTheme, ThemeContext } from 'styled-components';
 import { SizeMode } from '@votingworks/types';
-import { assertDefined } from '@votingworks/basics';
 import { getConfig, getMachineConfig, getScannerStatus } from '../api';
 import { ScannedBallotCount } from './scanned_ballot_count';
 import { VoterSettingsButton } from './voter_settings_button';
@@ -143,8 +142,9 @@ export function Screen(props: ScreenProps): JSX.Element | null {
 
   const hideInfoBar =
     hideInfoBarFromProps ||
-    !electionDefinition ||
-    ELECTION_BAR_HIDDEN_SIZE_MODES.has(currentTheme.sizeMode);
+    (infoBarMode !== 'admin' &&
+      (!electionDefinition ||
+        ELECTION_BAR_HIDDEN_SIZE_MODES.has(currentTheme.sizeMode)));
 
   const ballotCountElement = !hideBallotCountFromProps &&
     ballotCount !== undefined && (
@@ -179,7 +179,7 @@ export function Screen(props: ScreenProps): JSX.Element | null {
           mode={infoBarMode}
           precinctSelection={precinctSelection}
           electionDefinition={electionDefinition}
-          electionPackageHash={assertDefined(electionPackageHash)}
+          electionPackageHash={electionPackageHash}
           codeVersion={codeVersion}
           machineId={machineId}
         />

--- a/apps/scan/frontend/src/screens/system_administrator_screen.tsx
+++ b/apps/scan/frontend/src/screens/system_administrator_screen.tsx
@@ -47,6 +47,7 @@ export function SystemAdministratorScreen({
     <Screen
       title="System Administrator Menu"
       voterFacing={false}
+      infoBarMode="admin"
       padded
       hideBallotCount
     >

--- a/libs/ui/src/election_info_bar.test.tsx
+++ b/libs/ui/src/election_info_bar.test.tsx
@@ -42,6 +42,15 @@ describe('ElectionInfoBar', () => {
     );
   });
 
+  test('Renders without election information', () => {
+    render(<ElectionInfoBar machineId="0000" codeVersion="DEV" mode="admin" />);
+    const versionLabel = screen.getByText('Version');
+    expect(versionLabel.parentElement?.lastChild).toHaveTextContent('DEV');
+
+    const machineIdLabel = screen.getByText('Machine ID');
+    expect(machineIdLabel.parentElement?.lastChild).toHaveTextContent('0000');
+  });
+
   test('Renders with all precincts when specified', () => {
     render(
       <ElectionInfoBar
@@ -137,6 +146,18 @@ describe('VerticalElectionInfoBar', () => {
         mockElectionPackageHash
       )
     );
+  });
+
+  test('Renders without election information', () => {
+    render(
+      <VerticalElectionInfoBar
+        machineId="0000"
+        codeVersion="DEV"
+        mode="admin"
+      />
+    );
+    screen.getByText(hasTextAcrossElements('Version: DEV'));
+    screen.getByText(hasTextAcrossElements('Machine ID: 0000'));
   });
 
   test('Renders with all precincts when specified', () => {

--- a/libs/ui/src/election_info_bar.tsx
+++ b/libs/ui/src/election_info_bar.tsx
@@ -6,6 +6,7 @@ import {
   PrecinctSelection,
 } from '@votingworks/types';
 import styled from 'styled-components';
+import { assertDefined } from '@votingworks/basics';
 import { Seal } from './seal';
 import { Caption, Font } from './typography';
 import { LabelledText } from './labelled_text';
@@ -44,8 +45,8 @@ export type InfoBarMode = 'voter' | 'pollworker' | 'admin';
 
 export interface ElectionInfoBarProps {
   mode?: InfoBarMode;
-  electionDefinition: ElectionDefinition;
-  electionPackageHash: string;
+  electionDefinition?: ElectionDefinition;
+  electionPackageHash?: string;
   codeVersion?: string;
   machineId?: string;
   precinctSelection?: PrecinctSelection;
@@ -60,6 +61,35 @@ export function ElectionInfoBar({
   precinctSelection,
   inverse,
 }: ElectionInfoBarProps): JSX.Element {
+  const codeVersionInfo =
+    mode !== 'voter' && codeVersion ? (
+      <Caption noWrap>
+        <LabelledText label="Version">
+          <Font weight="bold">{codeVersion}</Font>
+        </LabelledText>
+      </Caption>
+    ) : null;
+
+  const machineIdInfo =
+    mode !== 'voter' && machineId ? (
+      <Caption noWrap>
+        <LabelledText label="Machine ID">
+          <Font weight="bold">{machineId}</Font>
+        </LabelledText>
+      </Caption>
+    ) : null;
+
+  if (!electionDefinition) {
+    return (
+      <Bar data-testid="electionInfoBar" inverse={inverse}>
+        <SystemInfoContainer>
+          {codeVersionInfo}
+          {machineIdInfo}
+        </SystemInfoContainer>
+      </Bar>
+    );
+  }
+
   const {
     election,
     election: { precincts, county, seal },
@@ -90,31 +120,13 @@ export function ElectionInfoBar({
     </Caption>
   );
 
-  const codeVersionInfo =
-    mode !== 'voter' && codeVersion ? (
-      <Caption noWrap>
-        <LabelledText label="Version">
-          <Font weight="bold">{codeVersion}</Font>
-        </LabelledText>
-      </Caption>
-    ) : null;
-
-  const machineIdInfo =
-    mode !== 'voter' && machineId ? (
-      <Caption noWrap>
-        <LabelledText label="Machine ID">
-          <Font weight="bold">{machineId}</Font>
-        </LabelledText>
-      </Caption>
-    ) : null;
-
   const electionIdInfo = (
     <Caption>
       <LabelledText label="Election ID">
         <Font weight="bold">
           {formatElectionHashes(
             electionDefinition.ballotHash,
-            electionPackageHash
+            assertDefined(electionPackageHash)
           )}
         </Font>
       </LabelledText>
@@ -153,6 +165,25 @@ export function VerticalElectionInfoBar({
   precinctSelection,
   inverse,
 }: ElectionInfoBarProps): JSX.Element {
+  if (!electionDefinition) {
+    return (
+      <VerticalBar inverse={inverse}>
+        <Caption>
+          {mode !== 'voter' && codeVersion && (
+            <div>
+              Version: <Font weight="semiBold">{codeVersion}</Font>
+            </div>
+          )}
+
+          {mode !== 'voter' && machineId && (
+            <div>
+              Machine ID: <Font weight="semiBold">{machineId}</Font>
+            </div>
+          )}
+        </Caption>
+      </VerticalBar>
+    );
+  }
   const {
     election,
     election: { precincts, county, seal },
@@ -205,7 +236,7 @@ export function VerticalElectionInfoBar({
           <Font weight="semiBold">
             {formatElectionHashes(
               electionDefinition.ballotHash,
-              electionPackageHash
+              assertDefined(electionPackageHash)
             )}
           </Font>
         </div>


### PR DESCRIPTION
## Overview
Makes sure the code version is always accessible from a sysadmin screen when a machine is unconfigured. 

Changed all apps to show ElectionInfoBar in unconfigured states.
Added ElectionInfoBar to system administrator screen in MarkScan

<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot
I do want to call out this as a nontrivial change in terms of number of screenshots in the docs it might touch @adghayes 
![markscan](https://github.com/user-attachments/assets/4ceb7f3b-445e-4436-8865-e13b97322862)
![systemadmincentral](https://github.com/user-attachments/assets/afe9e8b1-8147-414b-8faf-3b3147d42637)
![vxadminlocked](https://github.com/user-attachments/assets/dcf8b36c-3b41-43df-acbb-a5be5d32d260)
![vxadminsysadminunconfigured](https://github.com/user-attachments/assets/320bf24c-7a44-4514-88f9-53b3f1daafc1)
![vxcentralscanlocked](https://github.com/user-attachments/assets/2ad88010-6eb8-4402-9b2b-851d8ae55a72)
![vxscan](https://github.com/user-attachments/assets/09c70b73-767c-4102-96be-47fa726fcee8)


## Testing Plan
Loaded various apps

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
