### PR TITLE
[BMD] Fix typo in audio string

### DIFF
--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -919,7 +919,7 @@ export const appStrings = {
     <UiString uiStringKey="noteBmdContestCompleted">
       You've completed your selections on this contest. Press the right arrow
       button to advance to the next contest. You may continue navigating in this
-      contest to change your selections."
+      contest to change your selections.
     </UiString>
   ),
 

--- a/libs/ui/src/ui_strings/app_strings_catalog/latest.json
+++ b/libs/ui/src/ui_strings/app_strings_catalog/latest.json
@@ -181,7 +181,7 @@
   "noteBmdBallotSheetLoaded": "The ballot sheet has been loaded. You will have a chance to review your selections before reprinting your ballot.",
   "noteBmdCastingBallot": "Casting Ballot...",
   "noteBmdClearingBallot": "Clearing ballot",
-  "noteBmdContestCompleted": "You've completed your selections on this contest. Press the right arrow button to advance to the next contest. You may continue navigating in this contest to change your selections.\"",
+  "noteBmdContestCompleted": "You've completed your selections on this contest. Press the right arrow button to advance to the next contest. You may continue navigating in this contest to change your selections.",
   "noteBmdEitherNeitherNoSelection": "First, vote \"for either\" or \"against both\". Then select your preferred measure.",
   "noteBmdEitherNeitherSelectedEither": "You have selected \"for either\". <2>Now select your preferred measure.</2>",
   "noteBmdEitherNeitherSelectedEitherAndPreferred": "You have selected \"for either\" and your preferred measure.",


### PR DESCRIPTION
## Overview

Spotted while preparing strings for vendor translation - this entry has a stray quotation mark at the end.

## Demo Video or Screenshot
N/A - audio-only string

## Testing Plan
N/A

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
