### PR TITLE
Address vendor card edge cases in VxAdmin smart card UI

### DIFF
--- a/apps/admin/frontend/src/screens/smart_cards_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/smart_cards_screen.test.tsx
@@ -499,6 +499,9 @@ test('Insert vendor card', async () => {
   await screen.findByRole('heading', { name: 'Smart Cards' });
 
   screen.getByText('Vendor Card');
+  expect(
+    screen.queryByRole('heading', { name: 'Modify Card' })
+  ).not.toBeInTheDocument();
   expect(screen.queryButton('Unprogram Card')).not.toBeInTheDocument();
   expect(screen.queryButton('Reset Card PIN')).not.toBeInTheDocument();
 });

--- a/apps/admin/frontend/src/screens/smart_cards_screen.tsx
+++ b/apps/admin/frontend/src/screens/smart_cards_screen.tsx
@@ -500,8 +500,9 @@ function CardDetailsAndActions({
         )}
         {programmedUser ? (
           // After a successful action, hide the modify card actions to keep
-          // user focus on the success message
-          !(actionResult?.status === 'Success') && (
+          // user focus on the success message.
+          // Also show no actions section for vendor cards.
+          !(actionResult?.status === 'Success' || role === 'vendor') && (
             <CardActions>
               {unprogramAllowed && unprogramDisabled && (
                 <Callout color="warning" icon="Info">

--- a/libs/auth/src/dipped_smart_card_auth.ts
+++ b/libs/auth/src/dipped_smart_card_auth.ts
@@ -66,7 +66,8 @@ function cardStatusToProgrammableCard(
         programmedUser:
           // If one jurisdiction somehow attains a card from another jurisdiction, treat it as
           // unprogrammed
-          user?.jurisdiction !== machineState.jurisdiction ||
+          (user?.jurisdiction !== machineState.jurisdiction &&
+            !areUniversalVendorCardDetails(cardDetails)) ||
           // If a poll worker card doesn't have a PIN but poll worker card PINs are enabled, treat
           // the card as unprogrammed. And vice versa. If a poll worker card does have a PIN but
           // poll worker card PINs are not enabled, also treat the card as unprogrammed.


### PR DESCRIPTION
## Overview

Some quick patches around vendor card edge cases in the VxAdmin smart card UI. The current behavior in the VxAdmin smart card UI is as follows:

1. Insert a vendor card programmed for that jurisdiction and it shows up in the UI as a vendor card, with no actions
2. Insert a universal vendor card (with the special `*` jurisdiction) and it shows up in the UI as a blank card that can be overwritten
3. Insert a vendor card programmed for another jurisdiction and it shows up in the UI as a blank card that can be overwritten
4. For 1 and 2, we show a "Modify Card" heading despite the fact that you can't take any modification actions

After this PR:

1. **UNCHANGED** Insert a vendor card programmed for that jurisdiction and it shows up in the UI as a vendor card, with no actions
2. **CHANGED** Insert a universal vendor card (with the special `*` jurisdiction) and it shows up in the UI as a vendor card, with no actions
3. **UNCHANGED** Insert a vendor card programmed for another jurisdiction and it shows up in the UI as a blank card that can be overwritten
4. **CHANGED** For 1 and 2, we no longer show a "Modify Card" heading

| Before | After |
| - | - |
| ![before](https://github.com/user-attachments/assets/45d22e22-d800-4580-8f26-1fa955e3e954) | ![after](https://github.com/user-attachments/assets/5543b762-0813-4f3c-84c5-2abcc6283a05) |

## Testing Plan

- [x] Updated automated tests
- [x] Tested manually on a patched QA-imaged VxAdmin