### PR TITLE
style(scan): fix clippy lints

### DIFF
--- a/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
@@ -728,7 +728,7 @@ mod test {
             serde_json::from_reader(BufReader::new(File::open(election_path).unwrap())).unwrap();
 
         let bubble_template = load_ballot_scan_bubble_image().unwrap();
-        let side_a_path = fixture_path.join(format!("blank-ballot-p{}.jpg", starting_page_number));
+        let side_a_path = fixture_path.join(format!("blank-ballot-p{starting_page_number}.jpg"));
         let side_b_path =
             fixture_path.join(format!("blank-ballot-p{}.jpg", starting_page_number + 1));
         let (side_a_image, side_b_image) = load_ballot_card_images(&side_a_path, &side_b_path);
@@ -874,7 +874,7 @@ mod test {
     fn test_vertical_streaks() {
         let (mut side_a_image, mut side_b_image, options) =
             load_hmpb_fixture("general-election/letter", 1);
-        let thin_complete_streak_x = side_a_image.width() * 1 / 5;
+        let thin_complete_streak_x = side_a_image.width() / 5;
         let thick_complete_streak_x = side_a_image.width() * 2 / 5;
         let fuzzy_streak_x = side_a_image.width() * 3 / 5;
         let incomplete_streak_x = side_a_image.width() * 4 / 5;

--- a/libs/ballot-interpreter/src/hmpb-rust/timing_marks.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/timing_marks.rs
@@ -1604,7 +1604,10 @@ fn infer_missing_timing_marks_on_segment(
             );
 
         // if the closest timing mark is close enough, use it
-        if closest_rect.center().distance_to(&current_timing_mark_center) <= maximum_error
+        if closest_rect
+            .center()
+            .distance_to(&current_timing_mark_center)
+            <= maximum_error
         {
             inferred_timing_marks.push(*closest_rect);
             current_timing_mark_center = closest_rect.center() + next_point_vector;
@@ -1820,6 +1823,7 @@ pub fn detect_metadata_and_normalize_orientation(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use std::path::{Path, PathBuf};
 
@@ -1932,8 +1936,8 @@ mod tests {
                 removed_rects: vec![rects[2]],
                 mean_width: 10.6,
                 mean_height: 10.4,
-                stddev_width: 1.356466,
-                stddev_height: 1.3564659,
+                stddev_width: 1.356_466,
+                stddev_height: 1.356_465_9,
                 stddev_threshold: 1.0,
                 width_range: 9..12,
                 height_range: 9..12,
@@ -1948,8 +1952,8 @@ mod tests {
                 removed_rects: vec![],
                 mean_width: 10.6,
                 mean_height: 10.4,
-                stddev_width: 1.356466,
-                stddev_height: 1.3564659,
+                stddev_width: 1.356_466,
+                stddev_height: 1.356_465_9,
                 stddev_threshold: 5.0,
                 width_range: 3..18,
                 height_range: 3..18,


### PR DESCRIPTION
Fix some lints pointed out by clippy @ Rust 1.81.0.