### PR TITLE
[BMD] Fix unstable event listeners in PAT device calibration flow

### DIFF
--- a/apps/mark-scan/frontend/src/pages/pat_device_identification/identify_input_step.tsx
+++ b/apps/mark-scan/frontend/src/pages/pat_device_identification/identify_input_step.tsx
@@ -90,7 +90,7 @@ export function IdentifyInputStep({
     return () => {
       document.removeEventListener('keydown', handleInput);
     };
-  });
+  }, [handleInput]);
 
   let headerContent: React.ReactNode = null;
   let bodyContent: React.ReactNode = null;

--- a/apps/mark-scan/frontend/src/pages/pat_device_identification/pat_introduction_step.tsx
+++ b/apps/mark-scan/frontend/src/pages/pat_device_identification/pat_introduction_step.tsx
@@ -26,7 +26,7 @@ export function PatIntroductionStep({
     return () => {
       document.removeEventListener('keydown', handleInput);
     };
-  });
+  }, [handleInput]);
 
   return (
     <PortraitStepInnerContainer>


### PR DESCRIPTION
## Overview

Fixes https://github.com/votingworks/vxsuite/issues/5630

We've noticed inconsistent responsiveness to PAT device inputs in the calibration flow - debug logging shows the event listener getting added and removed frequently (likely in response to data fetches from API polling).
Updating the related React hook dependency lists to avoid the thrash.

## Testing Plan
- Repro'd semi-consistently (took at least 2 key-press attempts to register) and then verified that inputs are responsive on single-key presses after the change.

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
