### PR TITLE
Fix bug in contest layout for HMPBs

### DIFF
--- a/libs/hmpb/src/vx_default_ballot_template.tsx
+++ b/libs/hmpb/src/vx_default_ballot_template.tsx
@@ -788,8 +788,10 @@ async function BallotPageContent(
   const pageSections: JSX.Element[] = [];
   let heightUsed = 0;
 
-  // TODO is there a better way to incorporate gutter width here?
-  const gutterWidthPx = 0.75 * 16; // Assuming 16px per 1rem
+  // TODO is there some way we can use rem here instead of having to know the
+  // font size and map to px?
+  const horizontalGapPx = 0.75 * 16; // Assuming 16px per 1rem
+  const verticalGapPx = horizontalGapPx;
   while (contestSections.length > 0 && heightUsed < dimensions.height) {
     const section = assertDefined(contestSectionsLeftToLayout.shift());
     const contestElements = section.map((contest) => (
@@ -797,7 +799,7 @@ async function BallotPageContent(
     ));
     const numColumns = section[0].type === 'candidate' ? 3 : 2;
     const columnWidthPx =
-      (dimensions.width - gutterWidthPx * (numColumns - 1)) / numColumns;
+      (dimensions.width - horizontalGapPx * (numColumns - 1)) / numColumns;
     const contestMeasurements = await scratchpad.measureElements(
       <BackendLanguageContextProvider
         currentLanguageCode={primaryLanguageCode(ballotStyle)}
@@ -824,9 +826,7 @@ async function BallotPageContent(
       elements: measuredContests,
       numColumns,
       maxColumnHeight: dimensions.height - heightUsed,
-      // Use the same spacing as the column gutter for vertical spacing between
-      // contests
-      elementGap: gutterWidthPx,
+      elementGap: verticalGapPx,
     });
 
     // Put leftover elements back on the front of the queue
@@ -841,11 +841,12 @@ async function BallotPageContent(
       break;
     }
 
-    heightUsed += height;
+    // Add vertical gap to account for space between sections
+    heightUsed += height + verticalGapPx;
     pageSections.push(
       <div
         key={`section-${pageSections.length + 1}`}
-        style={{ display: 'flex', gap: `${gutterWidthPx}px` }}
+        style={{ display: 'flex', gap: `${horizontalGapPx}px` }}
       >
         {columns.map((column, i) => (
           <div
@@ -854,7 +855,7 @@ async function BallotPageContent(
               flex: 1,
               display: 'flex',
               flexDirection: 'column',
-              gap: `${gutterWidthPx}px`,
+              gap: `${verticalGapPx}px`,
             }}
           >
             {column.map(({ element }) => element)}
@@ -870,7 +871,7 @@ async function BallotPageContent(
         style={{
           display: 'flex',
           flexDirection: 'column',
-          gap: `${gutterWidthPx}px`,
+          gap: `${verticalGapPx}px`,
         }}
       >
         {pageSections}


### PR DESCRIPTION

## Overview

When laying out multiple contest sections on the same page, the code calculates whether there is enough vertical space left before adding a new section. That calculation forgot to include the gap between sections. This caused it to believe there was more space available than there actually was. Occasionally, this would result in adding more contests than would fit on the page, causing the page content to grow a bit longer and eat into the bottom margin of the page.

## Demo Video or Screenshot

Before - the bottom row of timing marks overflows into the bottom page margin
<img width="547" alt="Screenshot 2024-11-26 at 2 41 59 PM" src="https://github.com/user-attachments/assets/52450c6b-7cc7-4dab-976a-52bb466b58a8">

After - Proposition 1 is correctly bumped to the next page and the bottom timing marks stay in bounds
<img width="550" alt="Screenshot 2024-11-26 at 2 42 21 PM" src="https://github.com/user-attachments/assets/4ec65f3c-a884-42e4-aaaa-7959fcc0ebae">

## Testing Plan
Manual test with the election that caused the bug. Our HMPB fixtures don't cover this case.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
