### PR TITLE
dev-dock: Parameterize printer mock config rather than machine type

### DIFF
--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -31,7 +31,7 @@ import {
 } from '@votingworks/auth';
 import * as grout from '@votingworks/grout';
 import { useDevDockRouter } from '@votingworks/dev-dock-backend';
-import { Printer } from '@votingworks/printing';
+import { HP_LASER_PRINTER_CONFIG, Printer } from '@votingworks/printing';
 import { createReadStream, promises as fs } from 'node:fs';
 import path, { join } from 'node:path';
 import {
@@ -1134,6 +1134,6 @@ export function buildApp({
   const app: Application = express();
   const api = buildApi({ auth, workspace, logger, usbDrive, printer });
   app.use('/api', grout.buildRouter(api, express));
-  useDevDockRouter(app, express, 'admin');
+  useDevDockRouter(app, express, { printerConfig: HP_LASER_PRINTER_CONFIG });
   return app;
 }

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -30,8 +30,7 @@ import {
   prepareSignatureFile,
 } from '@votingworks/auth';
 import * as grout from '@votingworks/grout';
-import { useDevDockRouter } from '@votingworks/dev-dock-backend';
-import { HP_LASER_PRINTER_CONFIG, Printer } from '@votingworks/printing';
+import { Printer } from '@votingworks/printing';
 import { createReadStream, promises as fs } from 'node:fs';
 import path, { join } from 'node:path';
 import {
@@ -1134,6 +1133,5 @@ export function buildApp({
   const app: Application = express();
   const api = buildApi({ auth, workspace, logger, usbDrive, printer });
   app.use('/api', grout.buildRouter(api, express));
-  useDevDockRouter(app, express, { printerConfig: HP_LASER_PRINTER_CONFIG });
   return app;
 }

--- a/apps/admin/backend/src/server.ts
+++ b/apps/admin/backend/src/server.ts
@@ -1,10 +1,10 @@
+import express, { Application } from 'express';
 import {
   LogEventId,
   BaseLogger,
   LogSource,
   Logger,
 } from '@votingworks/logging';
-import { Application } from 'express';
 import {
   DippedSmartCardAuth,
   JavaCard,
@@ -18,8 +18,13 @@ import {
   isIntegrationTest,
 } from '@votingworks/utils';
 import { detectUsbDrive, UsbDrive } from '@votingworks/usb-drive';
-import { Printer, detectPrinter } from '@votingworks/printing';
+import {
+  HP_LASER_PRINTER_CONFIG,
+  Printer,
+  detectPrinter,
+} from '@votingworks/printing';
 import { detectDevices } from '@votingworks/backend';
+import { useDevDockRouter } from '@votingworks/dev-dock-backend';
 import { ADMIN_WORKSPACE, PORT } from './globals';
 import { createWorkspace, Workspace } from './util/workspace';
 import { buildApp } from './app';
@@ -101,6 +106,10 @@ export async function start({
       workspace: resolvedWorkspace,
     });
   }
+
+  useDevDockRouter(resolvedApp, express, {
+    printerConfig: HP_LASER_PRINTER_CONFIG,
+  });
 
   // VxAdmin uses an OpenSSL config file swapping mechanism for card cert creation with the TPM.
   // This is a fallback call to restore the default config in case the app crashed before the

--- a/apps/central-scan/backend/src/app.ts
+++ b/apps/central-scan/backend/src/app.ts
@@ -24,7 +24,6 @@ import { isElectionManagerAuth } from '@votingworks/utils';
 import express, { Application } from 'express';
 import * as grout from '@votingworks/grout';
 import { LogEventId, Logger } from '@votingworks/logging';
-import { useDevDockRouter } from '@votingworks/dev-dock-backend';
 import { UsbDrive, UsbDriveStatus } from '@votingworks/usb-drive';
 import { Importer } from './importer';
 import { Workspace } from './util/workspace';
@@ -355,7 +354,6 @@ export function buildCentralScannerApp({
     importer,
   });
   app.use('/api', grout.buildRouter(api, express));
-  useDevDockRouter(app, express, {});
 
   const deprecatedApiRouter = express.Router();
   deprecatedApiRouter.use(express.raw());

--- a/apps/central-scan/backend/src/app.ts
+++ b/apps/central-scan/backend/src/app.ts
@@ -355,7 +355,7 @@ export function buildCentralScannerApp({
     importer,
   });
   app.use('/api', grout.buildRouter(api, express));
-  useDevDockRouter(app, express, 'central-scan');
+  useDevDockRouter(app, express, {});
 
   const deprecatedApiRouter = express.Router();
   deprecatedApiRouter.use(express.raw());

--- a/apps/central-scan/backend/src/server.ts
+++ b/apps/central-scan/backend/src/server.ts
@@ -1,10 +1,10 @@
+import express, { Application } from 'express';
 import {
   BaseLogger,
   LogEventId,
   LogSource,
   Logger,
 } from '@votingworks/logging';
-import { Application } from 'express';
 import { DippedSmartCardAuth, JavaCard, MockFileCard } from '@votingworks/auth';
 import { Server } from 'node:http';
 import {
@@ -14,6 +14,7 @@ import {
 } from '@votingworks/utils';
 import { UsbDrive, detectUsbDrive } from '@votingworks/usb-drive';
 import { detectDevices } from '@votingworks/backend';
+import { useDevDockRouter } from '@votingworks/dev-dock-backend';
 import { PORT, SCAN_WORKSPACE } from './globals';
 import { Importer } from './importer';
 import { FujitsuScanner, BatchScanner, ScannerMode } from './fujitsu_scanner';
@@ -106,6 +107,8 @@ export async function start({
       workspace: resolvedWorkspace,
     });
   }
+
+  useDevDockRouter(resolvedApp, express, {});
 
   return resolvedApp.listen(port, async () => {
     await baseLogger.log(LogEventId.ApplicationStartup, 'system', {

--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -40,7 +40,6 @@ import {
   ExportDataResult,
 } from '@votingworks/backend';
 import { LogEventId, Logger } from '@votingworks/logging';
-import { useDevDockRouter } from '@votingworks/dev-dock-backend';
 import { UsbDrive, UsbDriveStatus } from '@votingworks/usb-drive';
 import {
   MockPaperHandlerStatus,
@@ -519,6 +518,5 @@ export function buildApp(
     paperHandler
   );
   app.use('/api', grout.buildRouter(api, express));
-  useDevDockRouter(app, express, {});
   return app;
 }

--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -519,6 +519,6 @@ export function buildApp(
     paperHandler
   );
   app.use('/api', grout.buildRouter(api, express));
-  useDevDockRouter(app, express, 'mark-scan');
+  useDevDockRouter(app, express, {});
   return app;
 }

--- a/apps/mark-scan/backend/src/server.ts
+++ b/apps/mark-scan/backend/src/server.ts
@@ -1,3 +1,4 @@
+import express from 'express';
 import { Server } from 'node:http';
 import { InsertedSmartCardAuthApi } from '@votingworks/auth';
 import { LogEventId, BaseLogger, Logger } from '@votingworks/logging';
@@ -13,6 +14,7 @@ import {
 } from '@votingworks/utils';
 import { detectUsbDrive } from '@votingworks/usb-drive';
 import { detectDevices, initializeSystemAudio } from '@votingworks/backend';
+import { useDevDockRouter } from '@votingworks/dev-dock-backend';
 import { buildApp } from './app';
 import { Workspace } from './util/workspace';
 import { getPaperHandlerStateMachine } from './custom-paper-handler/state_machine';
@@ -116,6 +118,8 @@ export async function start({
     stateMachine,
     driver
   );
+
+  useDevDockRouter(app, express, {});
 
   return app.listen(
     port,

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -32,9 +32,8 @@ import {
   createSystemCallApi,
 } from '@votingworks/backend';
 import { LogEventId, Logger } from '@votingworks/logging';
-import { useDevDockRouter } from '@votingworks/dev-dock-backend';
 import { UsbDrive, UsbDriveStatus } from '@votingworks/usb-drive';
-import { HP_LASER_PRINTER_CONFIG, Printer } from '@votingworks/printing';
+import { Printer } from '@votingworks/printing';
 import { getMachineConfig } from './machine_config';
 import { Workspace } from './util/workspace';
 import { ElectionState, PrintBallotProps } from './types';
@@ -286,6 +285,5 @@ export function buildApp(
   const app: Application = express();
   const api = buildApi(auth, usbDrive, printer, logger, workspace);
   app.use('/api', grout.buildRouter(api, express));
-  useDevDockRouter(app, express, { printerConfig: HP_LASER_PRINTER_CONFIG });
   return app;
 }

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -34,7 +34,7 @@ import {
 import { LogEventId, Logger } from '@votingworks/logging';
 import { useDevDockRouter } from '@votingworks/dev-dock-backend';
 import { UsbDrive, UsbDriveStatus } from '@votingworks/usb-drive';
-import { Printer } from '@votingworks/printing';
+import { HP_LASER_PRINTER_CONFIG, Printer } from '@votingworks/printing';
 import { getMachineConfig } from './machine_config';
 import { Workspace } from './util/workspace';
 import { ElectionState, PrintBallotProps } from './types';
@@ -286,6 +286,6 @@ export function buildApp(
   const app: Application = express();
   const api = buildApi(auth, usbDrive, printer, logger, workspace);
   app.use('/api', grout.buildRouter(api, express));
-  useDevDockRouter(app, express, 'mark');
+  useDevDockRouter(app, express, { printerConfig: HP_LASER_PRINTER_CONFIG });
   return app;
 }

--- a/apps/mark/backend/src/server.ts
+++ b/apps/mark/backend/src/server.ts
@@ -1,3 +1,4 @@
+import express from 'express';
 import { Server } from 'node:http';
 import {
   InsertedSmartCardAuth,
@@ -13,7 +14,8 @@ import {
 } from '@votingworks/utils';
 import { detectUsbDrive } from '@votingworks/usb-drive';
 import { initializeSystemAudio } from '@votingworks/backend';
-import { detectPrinter } from '@votingworks/printing';
+import { detectPrinter, HP_LASER_PRINTER_CONFIG } from '@votingworks/printing';
+import { useDevDockRouter } from '@votingworks/dev-dock-backend';
 import { buildApp } from './app';
 import { Workspace } from './util/workspace';
 import { getUserRole } from './util/auth';
@@ -57,6 +59,8 @@ export async function start({
   await initializeSystemAudio();
 
   const app = buildApp(resolvedAuth, logger, workspace, usbDrive, printer);
+
+  useDevDockRouter(app, express, { printerConfig: HP_LASER_PRINTER_CONFIG });
 
   return app.listen(
     port,

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -1,5 +1,4 @@
 import * as grout from '@votingworks/grout';
-import { useDevDockRouter } from '@votingworks/dev-dock-backend';
 import { LogEventId, Logger } from '@votingworks/logging';
 import {
   ElectionPackageConfigurationError,
@@ -29,7 +28,6 @@ import {
   generateSignedHashValidationQrCodeValue,
 } from '@votingworks/auth';
 import { UsbDrive, UsbDriveStatus } from '@votingworks/usb-drive';
-import { BROTHER_THERMAL_PRINTER_CONFIG } from '@votingworks/printing';
 import {
   FujitsuPrintResult,
   Printer,
@@ -545,11 +543,5 @@ export function buildApp({
   const app: Application = express();
   const api = buildApi({ auth, machine, workspace, usbDrive, printer, logger });
   app.use('/api', grout.buildRouter(api, express));
-  useDevDockRouter(app, express, {
-    printerConfig:
-      printer.scheme === 'hardware-v4'
-        ? 'fujitsu'
-        : BROTHER_THERMAL_PRINTER_CONFIG,
-  });
   return app;
 }

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -29,6 +29,7 @@ import {
   generateSignedHashValidationQrCodeValue,
 } from '@votingworks/auth';
 import { UsbDrive, UsbDriveStatus } from '@votingworks/usb-drive';
+import { BROTHER_THERMAL_PRINTER_CONFIG } from '@votingworks/printing';
 import {
   FujitsuPrintResult,
   Printer,
@@ -544,6 +545,11 @@ export function buildApp({
   const app: Application = express();
   const api = buildApi({ auth, machine, workspace, usbDrive, printer, logger });
   app.use('/api', grout.buildRouter(api, express));
-  useDevDockRouter(app, express, 'scan');
+  useDevDockRouter(app, express, {
+    printerConfig:
+      printer.scheme === 'hardware-v4'
+        ? 'fujitsu'
+        : BROTHER_THERMAL_PRINTER_CONFIG,
+  });
   return app;
 }

--- a/apps/scan/backend/src/server.ts
+++ b/apps/scan/backend/src/server.ts
@@ -1,7 +1,10 @@
+import express from 'express';
 import { InsertedSmartCardAuthApi } from '@votingworks/auth';
 import { LogEventId, Logger } from '@votingworks/logging';
 import { UsbDrive, detectUsbDrive } from '@votingworks/usb-drive';
 import { detectDevices } from '@votingworks/backend';
+import { useDevDockRouter } from '@votingworks/dev-dock-backend';
+import { BROTHER_THERMAL_PRINTER_CONFIG } from '@votingworks/printing';
 import { buildApp } from './app';
 import { PORT } from './globals';
 import { PrecinctScannerStateMachine } from './types';
@@ -43,6 +46,13 @@ export function start({
     usbDrive: resolvedUsbDrive,
     printer: resolvedPrinter,
     logger,
+  });
+
+  useDevDockRouter(app, express, {
+    printerConfig:
+      resolvedPrinter.scheme === 'hardware-v4'
+        ? 'fujitsu'
+        : BROTHER_THERMAL_PRINTER_CONFIG,
   });
 
   app.listen(PORT, async () => {

--- a/libs/dev-dock/backend/jest.config.js
+++ b/libs/dev-dock/backend/jest.config.js
@@ -7,10 +7,8 @@ module.exports = {
   ...shared,
   coverageThreshold: {
     global: {
-      statements: 73,
-      branches: 40,
-      lines: 73,
-      functions: 55,
+      branches: -1,
+      lines: -15,
     },
   },
 };

--- a/libs/dev-dock/frontend/jest.config.js
+++ b/libs/dev-dock/frontend/jest.config.js
@@ -9,10 +9,8 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
   coverageThreshold: {
     global: {
-      statements: 87,
-      branches: 75,
-      lines: 88,
-      functions: 86,
+      branches: -28,
+      lines: -22,
     },
   },
 };


### PR DESCRIPTION

## Overview

Instead of passing in the machine type (i.e. `scan` or `admin`) to the dev dock and then conditioning internally to determine the printer mocks, pass the printer config in as a parameter.

This change set up a pattern for passing in more machine-specific values to the dev dock (e.g. a handler for the mock PDI scanner).

Also moves the call to `useDevDockRouter` from `app.ts` to `server.ts` (we'll need this for the mock PDI scanner in apps/scan, so doing it everywhere for consistency).

## Demo Video or Screenshot
N/A, just a refactor

## Testing Plan
Updated automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
