### PR TITLE
Create libs/test-utils-vitest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1148,6 +1148,29 @@ jobs:
       - store_test_results:
           path: libs/test-utils/reports/
 
+  # @votingworks/test-utils-vitest
+  test-libs-test-utils-vitest:
+    executor: nodejs
+    resource_class: xlarge
+    steps:
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            pnpm --dir libs/test-utils-vitest build
+      - run:
+          name: Lint
+          command: |
+            pnpm --dir libs/test-utils-vitest lint
+      - run:
+          name: Test
+          command: |
+            pnpm --dir libs/test-utils-vitest test
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./reports/
+      - store_test_results:
+          path: libs/test-utils-vitest/reports/
+
   # @votingworks/types
   test-libs-types:
     executor: nodejs
@@ -1471,6 +1494,7 @@ workflows:
       - test-libs-printing
       - test-libs-res-to-ts
       - test-libs-test-utils
+      - test-libs-test-utils-vitest
       - test-libs-types
       - test-libs-types-rs
       - test-libs-ui

--- a/libs/test-utils-vitest/.eslintignore
+++ b/libs/test-utils-vitest/.eslintignore
@@ -1,0 +1,3 @@
+build
+coverage
+vitest.config.ts

--- a/libs/test-utils-vitest/.eslintrc.json
+++ b/libs/test-utils-vitest/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "extends": ["plugin:vx/recommended"],
+  "rules": {
+    // Disable JSDOC rule as code is self-documenting.
+    "vx/gts-jsdoc": "off"
+  }
+}

--- a/libs/test-utils-vitest/package.json
+++ b/libs/test-utils-vitest/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@votingworks/test-utils-vitest",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Test utilities for the monorepo using vitest instead of jest",
+  "license": "GPL-3.0-only",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
+  "files": [
+    "build"
+  ],
+  "scripts": {
+    "build": "pnpm --filter $npm_package_name... build:self",
+    "build:self": "tsc --build tsconfig.build.json",
+    "clean": "pnpm --filter $npm_package_name... clean:self",
+    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "lint": "pnpm type-check && eslint .",
+    "lint:fix": "pnpm type-check && eslint . --fix",
+    "pre-commit": "lint-staged",
+    "test": "is-ci test:ci test:watch",
+    "test:ci": "vitest --coverage --reporter junit --outputFile reports/junit.xml",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest",
+    "type-check": "tsc --build"
+  },
+  "dependencies": {
+    "@testing-library/react": "^15.0.7",
+    "@votingworks/basics": "workspace:*",
+    "@votingworks/types": "workspace:*",
+    "chalk": "4.1.2",
+    "jest-diff": "^29.6.2",
+    "react": "18.3.1",
+    "vitest": "^2.1.8"
+  },
+  "devDependencies": {
+    "@types/kiosk-browser": "workspace:*",
+    "@types/node": "20.16.0",
+    "@types/react": "18.3.3",
+    "@vitest/coverage-istanbul": "^2.1.8",
+    "eslint-plugin-vx": "workspace:*",
+    "is-ci-cli": "2.2.0",
+    "lint-staged": "11.0.0",
+    "sort-package-json": "^1.50.0"
+  },
+  "packageManager": "pnpm@8.15.5"
+}

--- a/libs/test-utils-vitest/src/advance_timers.ts
+++ b/libs/test-utils-vitest/src/advance_timers.ts
@@ -1,0 +1,25 @@
+import { vi } from 'vitest';
+import { act, waitFor } from '@testing-library/react';
+
+export const IDLE_TIMEOUT_SECONDS = 5 * 60; // 5 minute
+
+export function advanceTimers(seconds = 0): void {
+  const maxSeconds = IDLE_TIMEOUT_SECONDS;
+  if (seconds > maxSeconds) {
+    throw new Error(`Seconds value should not be greater than ${maxSeconds}`);
+  }
+  act(() => {
+    vi.advanceTimersByTime(seconds * 1000);
+  });
+}
+
+export async function advancePromises(): Promise<void> {
+  await waitFor(() => {
+    // Wait for promises.
+  });
+}
+
+export async function advanceTimersAndPromises(seconds = 0): Promise<void> {
+  advanceTimers(seconds);
+  await advancePromises();
+}

--- a/libs/test-utils-vitest/src/child_process.test.ts
+++ b/libs/test-utils-vitest/src/child_process.test.ts
@@ -1,0 +1,109 @@
+import { expect, test, vi } from 'vitest';
+import { Buffer } from 'node:buffer';
+import { mockChildProcess, mockReadable, mockWritable } from './child_process';
+
+test('mockReadable', () => {
+  const onReadable = vi.fn();
+  const onData = vi.fn();
+  const onEnd = vi.fn();
+  const readable = mockReadable()
+    .on('readable', onReadable)
+    .on('data', onData)
+    .on('end', onEnd);
+
+  expect(onReadable).not.toHaveBeenCalled();
+  expect(onData).not.toHaveBeenCalled();
+  expect(onEnd).not.toHaveBeenCalled();
+
+  readable.append('abcd');
+  expect(onReadable).toHaveBeenCalledTimes(1);
+  expect(onData).toHaveBeenNthCalledWith(1, 'abcd');
+  expect(onEnd).not.toHaveBeenCalled();
+  expect(readable.read(1)).toEqual('a');
+  expect(readable.read(1)).toEqual('b');
+  expect(readable.read()).toEqual('cd');
+  expect(readable.read()).toBeUndefined();
+
+  expect(readable.isPaused()).toEqual(false);
+  readable.pause();
+  expect(readable.isPaused()).toEqual(true);
+
+  readable.append('efgh');
+  expect(onReadable).toHaveBeenCalledTimes(1);
+  expect(onData).toHaveBeenCalledTimes(1);
+  expect(onEnd).not.toHaveBeenCalled();
+  readable.resume();
+  expect(onReadable).toHaveBeenCalledTimes(2);
+  expect(onData).toHaveBeenNthCalledWith(2, 'efgh');
+  expect(onEnd).not.toHaveBeenCalled();
+  readable.append('ijkl');
+  expect(onData).toHaveBeenNthCalledWith(3, 'ijkl');
+  expect(readable.read(5)).toEqual('efghi');
+  expect(readable.read(100)).toEqual('jkl');
+
+  readable.end();
+  expect(onEnd).toHaveBeenCalledTimes(1);
+});
+
+test('mockWritable', async () => {
+  const writable = mockWritable();
+  expect(writable.toBuffer()).toEqual(Buffer.of());
+  expect(writable.toString()).toEqual('');
+
+  writable.write(Buffer.of(1, 2, 3));
+  expect(writable.toBuffer()).toEqual(Buffer.of(1, 2, 3));
+  expect(writable.toString()).toEqual('\x01\x02\x03'); // mirrors `Buffer.of(1, 2, 3)`
+
+  writable.write('hi!', 'ascii');
+  expect(writable.toBuffer()).toEqual(Buffer.of(1, 2, 3, 104, 105, 33));
+  expect(writable.toString()).toEqual('\x01\x02\x03hi!'); // mirrors `Buffer.of(1, 2, 3, 104, 105, 33)`
+
+  {
+    const writeCallback = vi.fn();
+    writable.write('', 'utf-8', writeCallback);
+    await new Promise((resolve) => {
+      process.nextTick(resolve);
+    });
+    expect(writeCallback).toHaveBeenCalledWith();
+  }
+
+  {
+    const writeCallback = vi.fn();
+    writable.write('', writeCallback);
+    await new Promise((resolve) => {
+      process.nextTick(resolve);
+    });
+    expect(writeCallback).toHaveBeenCalledWith();
+  }
+
+  // @ts-expect-error - testing invalid argument type
+  expect(() => writable.write('', 88)).toThrowError(
+    'encoding expected to be a string'
+  );
+
+  const endCallback = vi.fn();
+  writable.end(endCallback);
+  await new Promise((resolve) => {
+    process.nextTick(resolve);
+  });
+  expect(endCallback).toHaveBeenCalledWith();
+
+  expect(writable.writes).toEqual([
+    { chunk: Buffer.of(1, 2, 3), encoding: undefined },
+    { chunk: 'hi!', encoding: 'ascii' },
+    { chunk: '', encoding: 'utf-8' },
+    { chunk: '', encoding: undefined },
+  ]);
+});
+
+test('mockChildProcess', () => {
+  const child = mockChildProcess();
+
+  expect(typeof child.pid).toEqual('number');
+  child.stdin.write('hello child!\n');
+
+  const onExit = vi.fn();
+  child.on('exit', onExit);
+  child.emit('exit');
+  expect(onExit).toHaveBeenCalled();
+});

--- a/libs/test-utils-vitest/src/child_process.ts
+++ b/libs/test-utils-vitest/src/child_process.ts
@@ -1,0 +1,180 @@
+import { vi } from 'vitest';
+import { Buffer } from 'node:buffer';
+import { ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { Readable, Writable } from 'node:stream';
+
+export interface MockReadable extends Readable {
+  append(chunk: string): void;
+  end(): void;
+}
+
+export interface MockWritable extends Writable {
+  toBuffer(): Buffer;
+  toString(): string;
+  writes: ReadonlyArray<{ chunk: unknown; encoding?: string }>;
+}
+
+/**
+ * Makes a mock readable stream.
+ */
+export function mockReadable(): MockReadable {
+  const readable = new EventEmitter() as MockReadable;
+  let buffer: string | undefined;
+  let isPaused = false;
+  let pendingChunks: unknown[] = [];
+
+  function flush(): void {
+    for (const chunk of pendingChunks) {
+      buffer = (buffer ?? '') + chunk;
+      readable.emit('readable');
+      readable.emit('data', chunk);
+    }
+    pendingChunks = [];
+  }
+
+  readable.resume = vi.fn(() => {
+    isPaused = false;
+    flush();
+    return readable;
+  });
+  readable.pause = vi.fn(() => {
+    isPaused = true;
+    return readable;
+  });
+  readable.isPaused = vi.fn().mockImplementation(() => isPaused);
+  readable.setEncoding = vi.fn();
+  readable.append = vi.fn((chunk): void => {
+    pendingChunks.push(chunk);
+    if (!isPaused) {
+      flush();
+    }
+  });
+  readable.read = vi.fn((size): unknown => {
+    if (typeof buffer === 'string') {
+      const readSize = size ?? buffer.length;
+      const result = buffer.slice(0, readSize);
+      buffer = buffer.length <= readSize ? undefined : buffer.slice(readSize);
+      return result;
+    }
+
+    return undefined;
+  });
+  readable.end = vi.fn(() => {
+    readable.emit('end');
+  });
+  return readable;
+}
+
+/**
+ * Makes a mock writable stream.
+ */
+export function mockWritable(): MockWritable {
+  const writable = new EventEmitter() as MockWritable;
+  const writes: Array<{ chunk: unknown; encoding?: string }> = [];
+
+  writable.writes = writes;
+  writable.write = vi.fn((...args: unknown[]): boolean => {
+    let chunk: unknown;
+    let encoding: unknown;
+    let callback: unknown;
+
+    if (args.length === 3) {
+      [chunk, encoding, callback] = args;
+    } else if (args.length === 2 && typeof args[1] === 'function') {
+      [chunk, callback] = args;
+    } else if (args.length === 2) {
+      [chunk, encoding] = args;
+    } else {
+      [chunk] = args;
+    }
+
+    if (typeof encoding !== 'undefined' && typeof encoding !== 'string') {
+      throw new TypeError('encoding expected to be a string');
+    }
+
+    if (typeof chunk !== 'undefined') {
+      writes.push({ chunk, encoding });
+    }
+
+    process.nextTick(() => {
+      if (typeof callback === 'function') {
+        callback();
+      }
+    });
+
+    return true;
+  });
+
+  writable.end = vi.fn((...args: unknown[]): MockWritable => {
+    let chunk: unknown;
+    let encoding: unknown;
+    let callback: unknown;
+
+    if (args.length === 3) {
+      [chunk, encoding, callback] = args;
+    } else if (args.length === 2 && typeof args[1] === 'function') {
+      [chunk, callback] = args;
+    } else if (args.length === 2) {
+      [chunk, encoding] = args;
+    } else {
+      [callback] = args;
+    }
+
+    if (typeof encoding !== 'undefined' && typeof encoding !== 'string') {
+      throw new TypeError('encoding expected to be a string');
+    }
+
+    if (typeof chunk !== 'undefined') {
+      writes.push({ chunk, encoding });
+    }
+
+    process.nextTick(() => {
+      if (typeof callback === 'function') {
+        callback();
+      }
+    });
+
+    return writable;
+  });
+
+  writable.toBuffer = () =>
+    writes.reduce(
+      (result, { chunk }) =>
+        Buffer.concat([result, Buffer.from(chunk as Buffer | string)]),
+      Buffer.of()
+    );
+
+  writable.toString = () =>
+    writes.reduce(
+      (result, { chunk, encoding }) =>
+        result +
+        (typeof chunk === 'string'
+          ? chunk
+          : (chunk as Buffer).toString(encoding as BufferEncoding | undefined)),
+      ''
+    );
+
+  return writable;
+}
+
+export interface MockChildProcess extends ChildProcess {
+  stdin: MockWritable;
+  stdout: MockReadable;
+  stderr: MockReadable;
+}
+
+/**
+ * Creates a mock child process with mock streams.
+ */
+export function mockChildProcess(): MockChildProcess {
+  const result: Partial<ChildProcess> = {
+    pid: Math.floor(Math.random() * 10_000),
+    stdin: mockWritable(),
+    stdout: mockReadable(),
+    stderr: mockReadable(),
+    kill: vi.fn(),
+  };
+
+  return Object.assign(new EventEmitter(), result) as MockChildProcess;
+}

--- a/libs/test-utils-vitest/src/console.test.ts
+++ b/libs/test-utils-vitest/src/console.test.ts
@@ -1,0 +1,39 @@
+/* eslint-disable no-console */
+import { expect, test } from 'vitest';
+import { suppressingConsoleOutput } from './console';
+
+test.each(['log', 'warn', 'error'] as const)(
+  'suppressingConsoleOutput replaces console.%s with a mock',
+  (method) => {
+    const original = console[method];
+    suppressingConsoleOutput(() => {
+      console[method]('test');
+      expect(console[method]).toHaveBeenNthCalledWith(1, 'test');
+    });
+    expect(console[method]).toStrictEqual(original);
+  }
+);
+
+test('suppressingConsoleOutput returns the value returned by the callback', () => {
+  expect(suppressingConsoleOutput(() => 'test')).toEqual('test');
+});
+
+test('suppressingConsoleOutput resolves to the value returned by the callback', async () => {
+  await expect(
+    suppressingConsoleOutput(async () => await Promise.resolve('test'))
+  ).resolves.toEqual('test');
+});
+
+test('suppressingConsoleOutput throws the error thrown by the callback', () => {
+  expect(() =>
+    suppressingConsoleOutput(() => {
+      throw new Error('test');
+    })
+  ).toThrowError('test');
+});
+
+test('suppressingConsoleOutput rejects with the error thrown by the callback', async () => {
+  await expect(
+    suppressingConsoleOutput(() => Promise.reject(new Error('test')))
+  ).rejects.toThrowError('test');
+});

--- a/libs/test-utils-vitest/src/console.ts
+++ b/libs/test-utils-vitest/src/console.ts
@@ -1,0 +1,182 @@
+import { afterAll, beforeAll, expect, vi } from 'vitest';
+import chalk from 'chalk';
+import { MaybePromise, Optional, assert, iter } from '@votingworks/basics';
+
+const capturedCallCountsByTest = new Map<
+  string,
+  Map<'log' | 'warn' | 'error', { count: number }>
+>();
+
+/**
+ * Strips ANSI escape codes from a string. When printing a box around a string
+ * with ANSI escape codes, the box will be the wrong size. This function removes
+ * the ANSI escape codes so that the box is the correct size.
+ */
+function stripAnsi(str: string): string {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+function printLinesInBox(lines: string[], out: NodeJS.WritableStream) {
+  const boxTopLeft = '┌';
+  const boxTopRight = '┐';
+  const boxTopAndBottom = '─';
+  const boxLeft = '│';
+  const boxRight = '│';
+  const boxBottomLeft = '└';
+  const boxBottomRight = '┘';
+
+  const longestLine =
+    iter(lines)
+      .map((line) => stripAnsi(line).length)
+      .max() ?? 0;
+
+  const boxTop = `${boxTopLeft}${boxTopAndBottom.repeat(
+    longestLine + 2
+  )}${boxTopRight}`;
+  const boxBottom = `${boxBottomLeft}${boxTopAndBottom.repeat(
+    longestLine + 2
+  )}${boxBottomRight}`;
+
+  out.write(chalk.dim(`${boxTop}\n`));
+  for (const line of lines) {
+    out.write(
+      chalk.dim(
+        `${boxLeft} ${line}${' '.repeat(
+          longestLine - stripAnsi(line).length
+        )} ${boxRight}\n`
+      )
+    );
+  }
+  out.write(chalk.dim(`${boxBottom}\n`));
+}
+
+if (typeof beforeAll === 'function' && typeof afterAll === 'function') {
+  beforeAll(() => {
+    capturedCallCountsByTest.clear();
+  });
+
+  afterAll(() => {
+    const shouldPrintSummary = process.env['CI'] !== 'true';
+
+    if (!shouldPrintSummary) {
+      return;
+    }
+
+    const allSummaries = Array.from(capturedCallCountsByTest).flatMap(
+      ([testName, capturedCallCounts]) => {
+        const summaries = Array.from(capturedCallCounts.entries())
+          .filter(([, { count }]) => count > 0)
+          .map(
+            ([name, { count }]) => `${count} ${name}${count > 1 ? 's' : ''}`
+          );
+
+        return summaries.length > 0
+          ? [`${testName} (${summaries.join(', ')})`]
+          : [];
+      }
+    );
+
+    if (allSummaries.length > 0) {
+      printLinesInBox(
+        [
+          '🤫 Some tests suppressed console output:',
+          '',
+          ...allSummaries,
+          '',
+          `Run with ${chalk.italic(
+            'SUPPRESS_CONSOLE_OUTPUT=false'
+          )} to see the output.`,
+        ],
+        process.stderr
+      );
+      process.stderr.write('\n');
+    }
+  });
+}
+
+/**
+ * Suppresses console output during the execution of a function. Resolves to the
+ * return value of the function.
+ */
+export function suppressingConsoleOutput<T>(fn: () => Promise<T>): Promise<T>;
+
+/**
+ * Suppresses console output during the execution of a function. Returns the
+ * return value of the function.
+ */
+export function suppressingConsoleOutput<T>(fn: () => T): T;
+
+export function suppressingConsoleOutput<T>(
+  fn: () => MaybePromise<T>
+): MaybePromise<T> {
+  if (process.env['SUPPRESS_CONSOLE_OUTPUT'] === 'false') {
+    return fn();
+  }
+
+  const { currentTestName } = expect.getState();
+  assert(currentTestName !== undefined);
+  const capturedCallCounts =
+    capturedCallCountsByTest.get(currentTestName) ??
+    new Map([
+      ['log', { count: 0 }],
+      ['warn', { count: 0 }],
+      ['error', { count: 0 }],
+    ]);
+  capturedCallCountsByTest.set(currentTestName, capturedCallCounts);
+  const logStats = capturedCallCounts.get('log') as { count: number };
+  const warnStats = capturedCallCounts.get('warn') as { count: number };
+  const errorStats = capturedCallCounts.get('error') as { count: number };
+
+  const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {
+    logStats.count += 1;
+  });
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {
+    warnStats.count += 1;
+  });
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {
+    errorStats.count += 1;
+  });
+
+  function cleanup() {
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  }
+
+  let value: Optional<MaybePromise<T>>;
+  let error: unknown;
+  let success = false;
+
+  try {
+    value = fn();
+    success = true;
+  } catch (e) {
+    error = e;
+  }
+
+  if (!success) {
+    cleanup();
+    throw error;
+  }
+
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Promise<T>).then === 'function'
+  ) {
+    return (value as Promise<T>).then(
+      (v) => {
+        cleanup();
+        return v;
+      },
+      (e) => {
+        cleanup();
+        throw e;
+      }
+    );
+  }
+
+  cleanup();
+  return value as T;
+}

--- a/libs/test-utils-vitest/src/index.ts
+++ b/libs/test-utils-vitest/src/index.ts
@@ -1,0 +1,6 @@
+export * from './advance_timers';
+export * from './child_process';
+export * from './console';
+export * from './mock_kiosk';
+export * from './mock_of';
+export * from './mock_use_audio_controls';

--- a/libs/test-utils-vitest/src/mock_function.test.ts
+++ b/libs/test-utils-vitest/src/mock_function.test.ts
@@ -1,0 +1,344 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { describe, expect, it } from 'vitest';
+import { mockFunction } from './mock_function';
+
+describe('mockFunction', () => {
+  function add(num1: number, num2: number): number {
+    throw new Error('Not implemented');
+  }
+
+  it('creates a mock function that returns a value', () => {
+    const addMock = mockFunction<typeof add>('add');
+    addMock.expectCallWith(1, 2).returns(3);
+    expect(addMock(1, 2)).toEqual(3);
+    addMock.assertComplete();
+  });
+
+  it('ensures the actual input matches the expected input', () => {
+    const addMock = mockFunction<typeof add>('add');
+    addMock.expectCallWith(1, 2).returns(3);
+    const expectedMessage =
+      'Mismatched call to mock function:\nExpected: add(1, 2)\nActual: add(1, 3)';
+    expect(() => addMock(1, 3)).toThrow(expectedMessage);
+  });
+
+  it('errors on unexpected calls', () => {
+    const addMock = mockFunction<typeof add>('add');
+    const expectedMessage = 'Unexpected call to mock function: add(1, 2)';
+    expect(() => addMock(1, 2)).toThrow(expectedMessage);
+  });
+
+  it('handles multiple calls', () => {
+    const addMock = mockFunction<typeof add>('add');
+    addMock.expectCallWith(1, 2).returns(3);
+    addMock.expectCallWith(1, 3).returns(4);
+    expect(addMock(1, 2)).toEqual(3);
+    expect(addMock(1, 3)).toEqual(4);
+    addMock.assertComplete();
+  });
+
+  it('only allows calls to be used once', () => {
+    const addMock = mockFunction<typeof add>('add');
+    addMock.expectCallWith(1, 2).returns(3);
+    expect(addMock(1, 2)).toEqual(3);
+    expect(() => addMock(1, 2)).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Unexpected call to mock function: add(1, 2)]`
+    );
+  });
+
+  it('enforces the order of calls', () => {
+    const addMock = mockFunction<typeof add>('add');
+    addMock.expectCallWith(1, 2).returns(3);
+    addMock.expectCallWith(1, 3).returns(4);
+    expect(() => addMock(1, 3)).toThrowErrorMatchingInlineSnapshot(`
+      [Error: Mismatched call to mock function:
+      Expected: add(1, 2)
+      Actual: add(1, 3)
+      Input diff: - Expected
+      + Received
+
+        Array [
+          1,
+      -   2,
+      +   3,
+        ]]
+    `);
+  });
+
+  it('supports all different types of arguments', () => {
+    function funcWithManyTypes(
+      a: string,
+      b: number,
+      c: boolean,
+      d: null,
+      e: undefined,
+      f: { foo: string },
+      g: number[]
+    ): string {
+      throw new Error('Not implemented');
+    }
+    const funcMock =
+      mockFunction<typeof funcWithManyTypes>('funcWithManyTypes');
+    funcMock
+      .expectCallWith('a', 1, true, null, undefined, { foo: 'bar' }, [1, 2])
+      .returns('success');
+    expect(
+      funcMock('a', 1, true, null, undefined, { foo: 'bar' }, [1, 2])
+    ).toEqual('success');
+    expect(() =>
+      funcMock('a', 1, true, null, undefined, { foo: 'bar' }, [1, 2])
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Unexpected call to mock function: funcWithManyTypes('a', 1, true, null, undefined, { foo: 'bar' }, [ 1, 2 ])]`
+    );
+    funcMock.reset();
+    funcMock
+      .expectCallWith('a', 1, true, null, undefined, { foo: 'bar' }, [1, 2])
+      .returns('success');
+    expect(() =>
+      funcMock('a', 1, true, null, undefined, { foo: 'wrong' }, [1, 2])
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [Error: Mismatched call to mock function:
+      Expected: funcWithManyTypes('a', 1, true, null, undefined, { foo: 'bar' }, [ 1, 2 ])
+      Actual: funcWithManyTypes('a', 1, true, null, undefined, { foo: 'wrong' }, [ 1, 2 ])
+      Input diff: - Expected
+      + Received
+
+        Array [
+          "a",
+          1,
+          true,
+          null,
+          undefined,
+          Object {
+      -     "foo": "bar",
+      +     "foo": "wrong",
+          },
+          Array [
+            1,
+            2,
+          ],
+        ]]
+    `);
+  });
+
+  it('enforces correct types', () => {
+    const addMock = mockFunction<typeof add>('add');
+    // @ts-expect-error - wrong argument type
+    addMock.expectCallWith('1', 2).returns(3);
+    // @ts-expect-error - wrong return type
+    addMock.expectCallWith(1, 2).returns('3');
+  });
+
+  it('supports async functions', async () => {
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async function addAsync(num1: number, num2: number): Promise<number> {
+      throw new Error('Not implemented');
+    }
+    const addMock = mockFunction<typeof addAsync>('addAsync');
+    addMock.expectCallWith(1, 2).returns(Promise.resolve(3));
+    addMock.expectCallWith(1, 2).resolves(3);
+    addMock.expectRepeatedCallsWith(1, 2).resolves(3);
+    expect(await addMock(1, 2)).toEqual(3);
+    expect(await addMock(1, 2)).toEqual(3);
+    expect(await addMock(1, 2)).toEqual(3);
+    expect(await addMock(1, 2)).toEqual(3);
+  });
+
+  it('supports mocking an exception', () => {
+    const addMock = mockFunction<typeof add>('add');
+    const error = new Error('Mock error');
+    addMock.expectCallWith(1, 2).throws(error);
+    expect(() => addMock(1, 2)).toThrow(error);
+  });
+
+  it('supports repeated calls', () => {
+    const addMock = mockFunction<typeof add>('add');
+    addMock.expectRepeatedCallsWith(1, 2).returns(3);
+    expect(addMock(1, 2)).toEqual(3);
+    expect(addMock(1, 2)).toEqual(3);
+    expect(addMock(1, 2)).toEqual(3);
+    addMock.expectCallWith(1, 2).returns(4);
+    expect(addMock(1, 2)).toEqual(4);
+    addMock.expectRepeatedCallsWith(1, 2).returns(5);
+    expect(addMock(1, 2)).toEqual(5);
+    expect(addMock(1, 2)).toEqual(5);
+    addMock.assertComplete();
+  });
+
+  it('errors if actual input doesnt match expected input of repeated call', () => {
+    const addMock = mockFunction<typeof add>('add');
+    addMock.expectRepeatedCallsWith(1, 2).returns(3);
+    expect(addMock(1, 2)).toEqual(3);
+    expect(() => addMock(1, 3)).toThrowErrorMatchingInlineSnapshot(`
+      [Error: Mismatched call to mock function:
+      Expected: add(1, 2) (repeated)
+      Actual: add(1, 3)
+      Input diff: - Expected
+      + Received
+
+        Array [
+          1,
+      -   2,
+      +   3,
+        ]]
+    `);
+  });
+
+  it('supports optional repeated calls', () => {
+    const addMock = mockFunction<typeof add>('add');
+    addMock.expectOptionalRepeatedCallsWith(1, 2).returns(3);
+    addMock.assertComplete();
+    expect(addMock(1, 2)).toEqual(3);
+    expect(addMock(1, 2)).toEqual(3);
+    addMock.assertComplete();
+  });
+
+  it('assertComplete errors if not all expected calls are used', () => {
+    const addMock = mockFunction<typeof add>('add');
+    addMock.expectCallWith(1, 2).returns(3);
+    addMock.expectCallWith(2, 2).returns(4);
+    addMock(1, 2);
+    expect(() => addMock.assertComplete()).toThrowErrorMatchingInlineSnapshot(`
+      [Error: Mismatch between expected mock function calls and actual mock function calls:
+
+      Call #0
+      Expected: add(1, 2)
+      Actual: add(1, 2)
+
+      Call #1
+      Expected: add(2, 2)
+      Actual: <none>]
+    `);
+  });
+
+  it('assertComplete errors if not all repeated expected calls are used', () => {
+    const addMock = mockFunction<typeof add>('add');
+    addMock.expectCallWith(1, 2).returns(3);
+    addMock.expectRepeatedCallsWith(2, 2).returns(4);
+    addMock(1, 2);
+    expect(() => addMock.assertComplete()).toThrowErrorMatchingInlineSnapshot(`
+      [Error: Mismatch between expected mock function calls and actual mock function calls:
+
+      Call #0
+      Expected: add(1, 2)
+      Actual: add(1, 2)
+
+      Call #1
+      Expected: add(2, 2) (repeated)
+      Actual: <none>]
+    `);
+  });
+
+  it('assertComplete errors if there are unexpected calls', () => {
+    const addMock = mockFunction<typeof add>('add');
+    addMock.expectCallWith(1, 2).returns(3);
+    expect(addMock(1, 2)).toEqual(3);
+    expect(() => addMock(1, 3)).toThrow();
+    expect(() => addMock.assertComplete()).toThrowErrorMatchingInlineSnapshot(`
+      [Error: Mismatch between expected mock function calls and actual mock function calls:
+
+      Call #0
+      Expected: add(1, 2)
+      Actual: add(1, 2)
+
+      Call #1
+      Expected: <none>
+      Actual: add(1, 3)]
+    `);
+  });
+
+  it('assertComplete errors if there are unexpected calls with repeated calls', () => {
+    const addMock = mockFunction<typeof add>('add');
+    addMock.expectRepeatedCallsWith(1, 2).returns(3);
+    expect(addMock(1, 2)).toEqual(3);
+    expect(() => addMock(1, 3)).toThrow();
+    expect(() => addMock.assertComplete()).toThrowErrorMatchingInlineSnapshot(`
+      [Error: Mismatch between expected mock function calls and actual mock function calls:
+
+      Call #0
+      Expected: add(1, 2) (repeated)
+      Actual: add(1, 2)
+
+      Call #1
+      Expected: add(1, 2) (repeated)
+      Actual: add(1, 3)
+      Input diff: - Expected
+      + Received
+
+        Array [
+          1,
+      -   2,
+      +   3,
+        ]]
+    `);
+  });
+
+  it('assertComplete errors if there are mismatched calls', () => {
+    const addMock = mockFunction<typeof add>('add');
+    addMock.expectCallWith(1, 2).returns(3);
+    addMock.expectCallWith(1, 3).returns(4);
+    expect(() => addMock(1, 3)).toThrow();
+    expect(() => addMock(1, 2)).toThrow();
+    expect(() => addMock.assertComplete()).toThrowErrorMatchingInlineSnapshot(`
+      [Error: Mismatch between expected mock function calls and actual mock function calls:
+
+      Call #0
+      Expected: add(1, 2)
+      Actual: add(1, 3)
+      Input diff: - Expected
+      + Received
+
+        Array [
+          1,
+      -   2,
+      +   3,
+        ]]
+    `);
+  });
+
+  it('assertComplete errors if there are mismatched calls with repeated calls', () => {
+    const addMock = mockFunction<typeof add>('add');
+    addMock.expectRepeatedCallsWith(1, 3).returns(4);
+    addMock.expectCallWith(1, 2).returns(3);
+    expect(() => addMock(1, 2)).toThrow();
+    expect(() => addMock(1, 3)).toThrow();
+    expect(() => addMock.assertComplete()).toThrowErrorMatchingInlineSnapshot(`
+      [Error: Mismatch between expected mock function calls and actual mock function calls:
+
+      Call #0
+      Expected: add(1, 3) (repeated)
+      Actual: add(1, 2)
+      Input diff: - Expected
+      + Received
+
+        Array [
+          1,
+      -   3,
+      +   2,
+        ]]
+    `);
+  });
+
+  it('reset clears the mock state', () => {
+    const addMock = mockFunction<typeof add>('add');
+
+    addMock.expectCallWith(1, 2).returns(3);
+    expect(addMock(1, 2)).toEqual(3);
+    addMock.assertComplete();
+    addMock.reset();
+
+    addMock.expectCallWith(1, 2).returns(3);
+    addMock.reset();
+
+    expect(() => addMock(1, 2)).toThrow();
+    addMock.reset();
+
+    addMock.expectRepeatedCallsWith(1, 2).returns(3);
+    expect(addMock(1, 2)).toEqual(3);
+    expect(addMock(1, 2)).toEqual(3);
+    addMock.assertComplete();
+    addMock.reset();
+
+    addMock.assertComplete();
+  });
+});

--- a/libs/test-utils-vitest/src/mock_function.ts
+++ b/libs/test-utils-vitest/src/mock_function.ts
@@ -1,0 +1,345 @@
+import { inspect } from 'node:util';
+import { diff } from 'jest-diff';
+import { assertDefined, deepEqual } from '@votingworks/basics';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyFunc = (...args: any[]) => any;
+
+interface Call<Func extends AnyFunc> {
+  input: Parameters<Func>;
+}
+
+type ActualCall<Func extends AnyFunc> = Call<Func> & {
+  matchingExpectedCallIndex?: number;
+};
+
+type ExpectedCall<Func extends AnyFunc> =
+  | ({
+      output: ReturnType<Func>;
+      repeated: boolean;
+      optional?: boolean;
+    } & Call<Func>)
+  | ({
+      error: unknown;
+      repeated: false;
+      optional?: false;
+    } & Call<Func>);
+
+interface ReturnHelpers<Func extends AnyFunc> {
+  returns(output: ReturnType<Func>): void;
+  throws(error: unknown): void;
+}
+
+interface AsyncReturnHelpers<Func extends AnyFunc> extends ReturnHelpers<Func> {
+  resolves(output: Awaited<ReturnType<Func>>): void;
+}
+
+export class MockFunctionError extends Error {}
+
+export interface MockFunction<Func extends AnyFunc> {
+  (...input: Parameters<Func>): ReturnType<Func>;
+  expectCallWith(
+    ...input: Parameters<Func>
+  ): ReturnType<Func> extends Promise<unknown>
+    ? AsyncReturnHelpers<Func>
+    : ReturnHelpers<Func>;
+  expectRepeatedCallsWith(
+    ...input: Parameters<Func>
+  ): ReturnType<Func> extends Promise<unknown>
+    ? Omit<AsyncReturnHelpers<Func>, 'throws'>
+    : Omit<ReturnHelpers<Func>, 'throws'>;
+  expectOptionalRepeatedCallsWith(
+    ...input: Parameters<Func>
+  ): ReturnType<Func> extends Promise<unknown>
+    ? Omit<AsyncReturnHelpers<Func>, 'throws'>
+    : Omit<ReturnHelpers<Func>, 'throws'>;
+  reset(): void;
+  assertComplete(): void;
+}
+
+interface MockFunctionState<Func extends AnyFunc> {
+  expectedCalls: Array<ExpectedCall<Func>>;
+  actualCalls: Array<ActualCall<Func>>;
+}
+
+function formatFunctionCall(name: string, input: unknown[]): string {
+  return `${name}(${input
+    .map((arg) => inspect(arg, { depth: null }))
+    .join(', ')})`;
+}
+
+function formatExpectedAndActualCalls(
+  name: string,
+  actualCall?: Call<AnyFunc>,
+  expectedCall?: ExpectedCall<AnyFunc>
+): string {
+  const expectedStr = expectedCall
+    ? formatFunctionCall(name, expectedCall.input) +
+      (expectedCall.repeated ? ' (repeated)' : '') +
+      (expectedCall.optional ? ' (optional)' : '')
+    : '<none>';
+  const actualStr = actualCall
+    ? formatFunctionCall(name, actualCall.input)
+    : '<none>';
+  const diffStr =
+    expectedCall &&
+    actualCall &&
+    !deepEqual(actualCall.input, expectedCall.input)
+      ? diff(expectedCall.input, actualCall.input)
+      : undefined;
+  return [`Expected: ${expectedStr}`, `Actual: ${actualStr}`]
+    .concat(diffStr ? [`Input diff: ${diffStr}`] : [])
+    .join('\n');
+}
+
+/**
+ * Creates a mock function, similar to jest.fn(), but with stricter rules to
+ * help you avoid making unintentional mistakes.
+ *
+ * Example usage:
+ *
+ *  // Let's say we have a real function, add, that we want to mock
+ *  function add(num1: number, num2: number): number {
+ *    return num1 + num2;
+ *  }
+ *
+ *  // We can create a mock function that behaves the same way
+ *  const addMock = mockFunction<typeof add>('add');
+ *  addMock.expectCallWith(1, 2).returns(3);
+ *  addMock(1, 2); // -> returns 3
+ *  addMock.expectCallWith(1, NaN).throws(new Error('Cant add NaN'));
+ *  addMock(1, NaN); // -> throws Error('Cant add NaN')
+ *
+ *  // Unlike jest.fn(), mockFunction is strict...
+ *
+ *  // Each expected call can only be used once, in order
+ *  addMock.expectCallWith(1, 2).returns(3);
+ *  addMock(1, 2); // -> returns 3
+ *  addMock(1, 2); // -> throws an error because we didn't expect this call
+ *
+ *  // The actual input must match the expected input
+ *  addMock.expectCallWith(1, 2).returns(3);
+ *  addMock(1, 3); // -> throws an error because the input doesn't match
+ *
+ *  // Every expected call must be used
+ *  addMock.expectCallWith(1, 2).returns(3);
+ *  addMock.assertComplete(); // -> throws an error because we didn't use the expected call
+ *
+ *  // You can also expect repeated calls, which is useful for functions that are polled
+ *  addMock.expectedRepeatedCallsWith(1, 2).returns(3);
+ *  addMock(1, 2); // -> returns 3
+ *  addMock(1, 2); // -> returns 3
+ *  addMock(1, 3); // -> throws an error because the input doesn't match
+ *
+ * Recommendations:
+ * - Always call mockFunction.assertComplete() to ensure that all expected calls were used
+ * - If you are going to reuse a mock between test cases, call mockFunction.reset() in afterEach
+ */
+// eslint-disable-next-line vx/gts-no-return-type-only-generics
+export function mockFunction<Func extends AnyFunc>(
+  name: string
+): MockFunction<Func> {
+  const state: MockFunctionState<Func> = {
+    expectedCalls: [],
+    actualCalls: [],
+  };
+
+  // Find the next expected call that should be used for the given actual call.
+  // We track which expected call each actual call matched and then base the
+  // next appropriate expected call on that.
+  function findExpectedCallForActualCallIndex(actualCallIndex: number) {
+    const previousActualCall = state.actualCalls[actualCallIndex - 1];
+    if (!previousActualCall) {
+      return state.expectedCalls[0];
+    }
+
+    // If the previous actual call didn't match any expected call, then we don't
+    // know what the next expected call should be.
+    if (previousActualCall.matchingExpectedCallIndex === undefined) {
+      throw new MockFunctionError(
+        'Previous call to mock function did not match expected calls'
+      );
+    }
+
+    // If we have a next expected call, use that
+    const nextExpectedCallIndex =
+      previousActualCall.matchingExpectedCallIndex + 1;
+    if (nextExpectedCallIndex < state.expectedCalls.length) {
+      return state.expectedCalls[nextExpectedCallIndex];
+    }
+
+    // Otherwise, maybe the previous expected call was a repeated expected call,
+    // so we can use that
+    const previousExpectedCall =
+      state.expectedCalls[previousActualCall.matchingExpectedCallIndex];
+    if (assertDefined(previousExpectedCall).repeated) {
+      return previousExpectedCall;
+    }
+
+    return undefined;
+  }
+
+  const mock: MockFunction<Func> = (...input: Parameters<Func>) => {
+    // Special case - [] and [undefined] are equivalent as args
+    if (input.length === 1 && input[0] === undefined) {
+      // eslint-disable-next-line no-param-reassign
+      input = [] as unknown as Parameters<Func>;
+    }
+
+    const expectedCall = findExpectedCallForActualCallIndex(
+      state.actualCalls.length
+    );
+    const callMatches = expectedCall && deepEqual(input, expectedCall.input);
+
+    state.actualCalls.push({
+      input,
+      matchingExpectedCallIndex: callMatches
+        ? state.expectedCalls.indexOf(expectedCall)
+        : undefined,
+    });
+
+    if (!expectedCall) {
+      const message = `Unexpected call to mock function: ${formatFunctionCall(
+        name,
+        input
+      )}`;
+      throw new MockFunctionError(message);
+    }
+
+    if (!callMatches) {
+      const message = `Mismatched call to mock function:\n${formatExpectedAndActualCalls(
+        name,
+        { input },
+        expectedCall
+      )}`;
+      throw new MockFunctionError(message);
+    }
+
+    if ('error' in expectedCall) {
+      throw expectedCall.error;
+    }
+
+    return expectedCall.output;
+  };
+
+  mock.expectCallWith = (...input: Parameters<Func>) => ({
+    returns(output: ReturnType<Func>) {
+      state.expectedCalls.push({ input, output, repeated: false });
+    },
+    throws(error: unknown) {
+      state.expectedCalls.push({ input, error, repeated: false });
+    },
+    resolves(output: Awaited<ReturnType<Func>>) {
+      state.expectedCalls.push({
+        input,
+        output: Promise.resolve(output) as ReturnType<Func>,
+        repeated: false,
+      });
+    },
+  });
+
+  mock.expectRepeatedCallsWith = (...input: Parameters<Func>) => ({
+    returns(output: ReturnType<Func>) {
+      state.expectedCalls.push({
+        input,
+        output,
+        repeated: true,
+      });
+    },
+    resolves(output: Awaited<ReturnType<Func>>) {
+      state.expectedCalls.push({
+        input,
+        output: Promise.resolve(output) as ReturnType<Func>,
+        repeated: true,
+      });
+    },
+  });
+
+  mock.expectOptionalRepeatedCallsWith = (...input: Parameters<Func>) => ({
+    returns(output: ReturnType<Func>) {
+      state.expectedCalls.push({
+        input,
+        output,
+        repeated: true,
+        optional: true,
+      });
+    },
+    resolves(output: Awaited<ReturnType<Func>>) {
+      state.expectedCalls.push({
+        input,
+        output: Promise.resolve(output) as ReturnType<Func>,
+        repeated: true,
+        optional: true,
+      });
+    },
+  });
+
+  mock.reset = () => {
+    state.expectedCalls = [];
+    state.actualCalls = [];
+  };
+
+  mock.assertComplete = () => {
+    // We want to check:
+    // - Every actual call matched an expected call
+    // - Every expected call was used
+    // So we build a correspondence of actual calls with their expected calls.
+
+    const actualCallsWithTheirExpectedCalls = state.actualCalls.map(
+      (actualCall, actualCallIndex) => {
+        const expectedCall =
+          findExpectedCallForActualCallIndex(actualCallIndex);
+        return {
+          actualCall,
+          expectedCall,
+        };
+      }
+    );
+
+    const unusedExpectedCalls = state.expectedCalls.filter(
+      (expectedCall) =>
+        !expectedCall.optional &&
+        !actualCallsWithTheirExpectedCalls.some(
+          ({ expectedCall: usedExpectedCall }) =>
+            usedExpectedCall === expectedCall
+        )
+    );
+
+    const callCorrespondence = [
+      ...actualCallsWithTheirExpectedCalls,
+      ...unusedExpectedCalls.map((expectedCall) => ({
+        actualCall: undefined,
+        expectedCall,
+      })),
+    ];
+
+    // We can only accurately report a correspondence of expected and actual
+    // calls up to the first mismatched call. After that, we don't know which
+    // expected calls were used for which actual calls.
+    const firstMismatchedCallIndex = callCorrespondence.findIndex(
+      ({ actualCall, expectedCall }) =>
+        !(
+          actualCall &&
+          expectedCall &&
+          actualCall.matchingExpectedCallIndex !== undefined
+        )
+    );
+
+    if (firstMismatchedCallIndex !== -1) {
+      const message = `Mismatch between expected mock function calls and actual mock function calls:\n\n${callCorrespondence
+        .slice(0, firstMismatchedCallIndex + 1)
+        .map(
+          ({ actualCall, expectedCall }, index) =>
+            `Call #${index}\n${formatExpectedAndActualCalls(
+              name,
+              actualCall,
+              expectedCall
+            )}`
+        )
+        .join('\n\n')}`;
+      throw new MockFunctionError(message);
+    }
+  };
+
+  return mock;
+}

--- a/libs/test-utils-vitest/src/mock_kiosk.ts
+++ b/libs/test-utils-vitest/src/mock_kiosk.ts
@@ -1,0 +1,15 @@
+import { Mocked, vi } from 'vitest';
+
+export type MockKiosk = Mocked<KioskBrowser.Kiosk>;
+
+/**
+ * Builds a `Kiosk` instance with mock methods.
+ */
+export function mockKiosk(): MockKiosk {
+  return {
+    quit: vi.fn(),
+    log: vi.fn(),
+    captureScreenshot: vi.fn().mockResolvedValue(Uint8Array.of()),
+    showOpenDialog: vi.fn(),
+  };
+}

--- a/libs/test-utils-vitest/src/mock_of.ts
+++ b/libs/test-utils-vitest/src/mock_of.ts
@@ -1,0 +1,18 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { MockedFunction } from 'vitest';
+
+/**
+ * Returns a properly-typed mock for an already-mocked function.
+ *
+ * @example
+ *
+ * import * as fs from 'node:fs'
+ * vi.mock('node:fs')
+ * const readFileMock = mockOf(fs.readFile)
+ * readFileMock.mockImplementation(…)
+ */
+export function mockOf<T extends (...args: any[]) => any>(
+  fn: T
+): MockedFunction<T> {
+  return fn as MockedFunction<T>;
+}

--- a/libs/test-utils-vitest/src/mock_use_audio_controls.ts
+++ b/libs/test-utils-vitest/src/mock_use_audio_controls.ts
@@ -1,0 +1,17 @@
+import { AudioControls } from '@votingworks/types';
+import { Mocked, vi } from 'vitest';
+
+export function mockUseAudioControls(): Mocked<AudioControls> {
+  return {
+    decreasePlaybackRate: vi.fn(),
+    decreaseVolume: vi.fn(),
+    increasePlaybackRate: vi.fn(),
+    increaseVolume: vi.fn(),
+    reset: vi.fn(),
+    replay: vi.fn(),
+    setControlsEnabled: vi.fn(),
+    setIsEnabled: vi.fn(),
+    toggleEnabled: vi.fn(),
+    togglePause: vi.fn(),
+  };
+}

--- a/libs/test-utils-vitest/tsconfig.build.json
+++ b/libs/test-utils-vitest/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"],
+  "compilerOptions": {
+    "noEmit": false,
+    "rootDir": "src",
+    "outDir": "build",
+    "declaration": true
+  },
+  "references": [
+    { "path": "../basics/tsconfig.build.json" },
+    { "path": "../eslint-plugin-vx/tsconfig.build.json" },
+    { "path": "../types/tsconfig.build.json" }
+  ]
+}

--- a/libs/test-utils-vitest/tsconfig.json
+++ b/libs/test-utils-vitest/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.shared.json",
+  "include": ["src"],
+  "exclude": [],
+  "compilerOptions": {
+    "module": "node16",
+    "composite": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "skipLibCheck": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "references": [
+    { "path": "../basics/tsconfig.build.json" },
+    { "path": "../eslint-plugin-vx/tsconfig.build.json" },
+    { "path": "../types/tsconfig.build.json" }
+  ]
+}

--- a/libs/test-utils-vitest/vitest.config.ts
+++ b/libs/test-utils-vitest/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    coverage: {
+      thresholds: {
+        lines: 84,
+        branches: 79,
+      },
+      provider: 'istanbul',
+      include: ['src/**/*.ts'],
+      exclude: [
+        'src/**/*.test.ts',
+        'src/advance_timers.ts',
+        'src/mock_of.ts',
+        'src/mock_kiosk.ts',
+        'src/mock_use_audio_controls.ts',
+      ],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,7 +107,7 @@ importers:
         version: 5.2.0
       postcss-styled-syntax:
         specifier: ^0.4.0
-        version: 0.4.0(postcss@8.4.38)(typescript@5.6.2)
+        version: 0.4.0(postcss@8.4.49)(typescript@5.6.2)
       prettier:
         specifier: ^3.0.3
         version: 3.0.3
@@ -336,7 +336,7 @@ importers:
         version: 6.1.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
 
   apps/admin/frontend:
     dependencies:
@@ -604,7 +604,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
       vite:
         specifier: 4.5.2
         version: 4.5.2(@types/node@20.16.0)
@@ -846,7 +846,7 @@ importers:
         version: 6.1.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
 
   apps/central-scan/frontend:
     dependencies:
@@ -1066,7 +1066,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
       type-fest:
         specifier: ^0.18.0
         version: 0.18.1
@@ -1287,7 +1287,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
 
   apps/design/frontend:
     dependencies:
@@ -1522,7 +1522,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
       vite:
         specifier: 4.5.2
         version: 4.5.2(@types/node@20.16.0)
@@ -1703,7 +1703,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
 
   apps/mark-scan/frontend:
     dependencies:
@@ -1914,7 +1914,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
       vite:
         specifier: 4.5.2
         version: 4.5.2(@types/node@20.16.0)
@@ -2102,7 +2102,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
 
   apps/mark/frontend:
     dependencies:
@@ -2319,7 +2319,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
       vite:
         specifier: 4.5.2
         version: 4.5.2(@types/node@20.16.0)
@@ -2567,7 +2567,7 @@ importers:
         version: 6.1.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
       wait-for-expect:
         specifier: ^3.0.2
         version: 3.0.2
@@ -2763,7 +2763,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
       vite:
         specifier: 4.5.2
         version: 4.5.2(@types/node@20.16.0)
@@ -2814,7 +2814,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
 
   libs/@types/compress-commons:
     dependencies:
@@ -2886,7 +2886,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
 
   libs/auth:
     dependencies:
@@ -3001,7 +3001,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
       wait-for-expect:
         specifier: ^3.0.2
         version: 3.0.2
@@ -3161,7 +3161,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
 
   libs/ballot-encoder:
     dependencies:
@@ -3213,7 +3213,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
 
   libs/ballot-interpreter:
     dependencies:
@@ -3334,7 +3334,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
 
   libs/basics:
     dependencies:
@@ -3380,7 +3380,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
 
   libs/bmd-ballot-fixtures:
     dependencies:
@@ -3453,7 +3453,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
       util:
         specifier: ^0.12.4
         version: 0.12.4
@@ -3508,7 +3508,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
 
   libs/custom-paper-handler:
     dependencies:
@@ -3587,7 +3587,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
 
   libs/custom-scanner:
     dependencies:
@@ -3660,7 +3660,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
       vite:
         specifier: 4.5.2
         version: 4.5.2(@types/node@20.16.0)
@@ -3718,7 +3718,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
 
   libs/dev-dock/backend:
     dependencies:
@@ -3800,7 +3800,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
 
   libs/dev-dock/frontend:
     dependencies:
@@ -3909,7 +3909,7 @@ importers:
         version: 5.3.11(react-dom@18.3.1)(react-is@18.2.0)(react@18.3.1)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
 
   libs/eslint-plugin-vx:
     dependencies:
@@ -3985,7 +3985,7 @@ importers:
         version: 18.3.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
 
   libs/fixture-generators:
     dependencies:
@@ -4073,7 +4073,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
 
   libs/fixtures:
     dependencies:
@@ -4125,7 +4125,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
 
   libs/fs:
     dependencies:
@@ -4204,7 +4204,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
 
   libs/fujitsu-thermal-printer:
     dependencies:
@@ -4271,7 +4271,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
 
   libs/grout:
     dependencies:
@@ -4332,7 +4332,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
 
   libs/grout/test-utils:
     dependencies:
@@ -4372,7 +4372,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
 
   libs/hmpb:
     dependencies:
@@ -4487,7 +4487,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
       vite:
         specifier: 4.5.2
         version: 4.5.2(@types/node@20.16.0)
@@ -4578,7 +4578,7 @@ importers:
         version: 11.0.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
 
   libs/logging:
     dependencies:
@@ -4660,7 +4660,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
 
   libs/mark-flow-ui:
     dependencies:
@@ -4868,7 +4868,7 @@ importers:
         version: 5.3.11(react-dom@18.3.1)(react-is@18.2.0)(react@18.3.1)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
       util:
         specifier: ^0.12.4
         version: 0.12.4
@@ -4908,7 +4908,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
 
   libs/monorepo-utils:
     dependencies:
@@ -4978,7 +4978,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
       typescript:
         specifier: 5.6.2
         version: 5.6.2
@@ -5036,7 +5036,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
 
   libs/printing:
     dependencies:
@@ -5148,7 +5148,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
 
   libs/res-to-ts:
     dependencies:
@@ -5203,7 +5203,7 @@ importers:
         version: 2.2.2(jest@29.6.2)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
 
   libs/test-utils:
     dependencies:
@@ -5285,7 +5285,56 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
+
+  libs/test-utils-vitest:
+    dependencies:
+      '@testing-library/react':
+        specifier: ^15.0.7
+        version: 15.0.7(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@votingworks/basics':
+        specifier: workspace:*
+        version: link:../basics
+      '@votingworks/types':
+        specifier: workspace:*
+        version: link:../types
+      chalk:
+        specifier: 4.1.2
+        version: 4.1.2
+      jest-diff:
+        specifier: ^29.6.2
+        version: 29.6.2
+      react:
+        specifier: 18.3.1
+        version: 18.3.1
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.8(@types/node@20.16.0)
+    devDependencies:
+      '@types/kiosk-browser':
+        specifier: workspace:*
+        version: link:../@types/kiosk-browser
+      '@types/node':
+        specifier: 20.16.0
+        version: 20.16.0
+      '@types/react':
+        specifier: 18.3.3
+        version: 18.3.3
+      '@vitest/coverage-istanbul':
+        specifier: ^2.1.8
+        version: 2.1.8(vitest@2.1.8)
+      eslint-plugin-vx:
+        specifier: workspace:*
+        version: link:../eslint-plugin-vx
+      is-ci-cli:
+        specifier: 2.2.0
+        version: 2.2.0
+      lint-staged:
+        specifier: 11.0.0
+        version: 11.0.0
+      sort-package-json:
+        specifier: ^1.50.0
+        version: 1.53.1
 
   libs/types:
     dependencies:
@@ -5376,7 +5425,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
 
   libs/types-rs: {}
 
@@ -5655,7 +5704,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
       util:
         specifier: ^0.12.4
         version: 0.12.4
@@ -5728,7 +5777,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
 
   libs/utils:
     dependencies:
@@ -5843,7 +5892,7 @@ importers:
         version: 1.50.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2)
 
   script:
     dependencies:
@@ -5925,6 +5974,10 @@ packages:
     resolution: {integrity: sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==}
     engines: {node: '>=6.9.0'}
 
+  /@babel/compat-data@7.26.3:
+    resolution: {integrity: sha512-nHIxvKPniQXpmQLb0vhY3VaFb3S0YrTAwpOWJZh1wn3oJPjJk9Asva204PsBdmAE8vpzfHudT8DB0scYvy9q0g==}
+    engines: {node: '>=6.9.0'}
+
   /@babel/core@7.20.12:
     resolution: {integrity: sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==}
     engines: {node: '>=6.9.0'}
@@ -5963,6 +6016,28 @@ packages:
       '@babel/traverse': 7.23.2(supports-color@5.5.0)
       '@babel/types': 7.22.10
       convert-source-map: 1.9.0
+      debug: 4.3.4(supports-color@5.5.0)
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  /@babel/core@7.26.0:
+    resolution: {integrity: sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@ampproject/remapping': 2.2.1
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.26.2
+      '@babel/helper-compilation-targets': 7.25.9
+      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.0)
+      '@babel/helpers': 7.26.0
+      '@babel/parser': 7.26.2
+      '@babel/template': 7.25.9
+      '@babel/traverse': 7.23.2(supports-color@5.5.0)
+      '@babel/types': 7.26.0
+      convert-source-map: 2.0.0
       debug: 4.3.4(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
@@ -6019,6 +6094,16 @@ packages:
       lru-cache: 5.1.1
       semver: 6.3.1
 
+  /@babel/helper-compilation-targets@7.25.9:
+    resolution: {integrity: sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/compat-data': 7.26.3
+      '@babel/helper-validator-option': 7.25.9
+      browserslist: 4.24.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
   /@babel/helper-create-class-features-plugin@7.22.10(@babel/core@7.22.9):
     resolution: {integrity: sha512-5IBb77txKYQPpOEdUdIhBx8VrZyDCQ+H82H0+5dX1TmuscP5vJKEE3cKurjtIw/vFwzbVH48VweE78kVDBrqjA==}
     engines: {node: '>=6.9.0'}
@@ -6031,41 +6116,59 @@ packages:
       '@babel/helper-function-name': 7.22.5
       '@babel/helper-member-expression-to-functions': 7.22.5
       '@babel/helper-optimise-call-expression': 7.22.5
-      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.22.9)
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.26.0)
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       semver: 6.3.1
     dev: true
 
-  /@babel/helper-create-regexp-features-plugin@7.20.5(@babel/core@7.22.9):
+  /@babel/helper-create-class-features-plugin@7.22.10(@babel/core@7.26.0):
+    resolution: {integrity: sha512-5IBb77txKYQPpOEdUdIhBx8VrZyDCQ+H82H0+5dX1TmuscP5vJKEE3cKurjtIw/vFwzbVH48VweE78kVDBrqjA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-member-expression-to-functions': 7.22.5
+      '@babel/helper-optimise-call-expression': 7.22.5
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.26.0)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      semver: 6.3.1
+    dev: true
+
+  /@babel/helper-create-regexp-features-plugin@7.20.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-m68B1lkg3XDGX5yCvGO0kPx3v9WIYLnzjKfPcQiwntEQa5ZeRkPmo2X/ISJc8qxWGfwUr+kvZAeEzAwLec2r2w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-annotate-as-pure': 7.22.5
       regexpu-core: 5.2.2
     dev: true
 
-  /@babel/helper-create-regexp-features-plugin@7.22.9(@babel/core@7.22.9):
+  /@babel/helper-create-regexp-features-plugin@7.22.9(@babel/core@7.26.0):
     resolution: {integrity: sha512-+svjVa/tFwsNSG4NEy1h85+HQ5imbT92Q5/bgtS7P0GTQlP8WuFdqsiABmQouhiFGyV66oGxZFpeYHza1rNsKw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-annotate-as-pure': 7.22.5
       regexpu-core: 5.3.2
       semver: 6.3.1
     dev: true
 
-  /@babel/helper-define-polyfill-provider@0.4.2(@babel/core@7.22.9):
+  /@babel/helper-define-polyfill-provider@0.4.2(@babel/core@7.26.0):
     resolution: {integrity: sha512-k0qnnOqHn5dK9pZpfD5XXZ9SojAITdCKRn2Lp6rnDGzIbaP0rHyMPk/4wsSxVBVz4RfN0q6VpXWP2pDGIoQ7hw==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-compilation-targets': 7.22.10
       '@babel/helper-plugin-utils': 7.22.5
       debug: 4.3.4(supports-color@5.5.0)
@@ -6125,6 +6228,15 @@ packages:
     dependencies:
       '@babel/types': 7.22.10
 
+  /@babel/helper-module-imports@7.25.9:
+    resolution: {integrity: sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/traverse': 7.23.2(supports-color@5.5.0)
+      '@babel/types': 7.26.0
+    transitivePeerDependencies:
+      - supports-color
+
   /@babel/helper-module-transforms@7.22.9(@babel/core@7.20.12):
     resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
     engines: {node: '>=6.9.0'}
@@ -6152,6 +6264,33 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.22.5
 
+  /@babel/helper-module-transforms@7.22.9(@babel/core@7.26.0):
+    resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-validator-identifier': 7.22.5
+    dev: true
+
+  /@babel/helper-module-transforms@7.26.0(@babel/core@7.26.0):
+    resolution: {integrity: sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/traverse': 7.23.2(supports-color@5.5.0)
+    transitivePeerDependencies:
+      - supports-color
+
   /@babel/helper-optimise-call-expression@7.22.5:
     resolution: {integrity: sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==}
     engines: {node: '>=6.9.0'}
@@ -6178,25 +6317,25 @@ packages:
     resolution: {integrity: sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/helper-remap-async-to-generator@7.22.9(@babel/core@7.22.9):
+  /@babel/helper-remap-async-to-generator@7.22.9(@babel/core@7.26.0):
     resolution: {integrity: sha512-8WWC4oR4Px+tr+Fp0X3RHDVfINGpF3ad1HIbrc8A77epiR6eMMc6jsgozkzT2uDiOOdoS9cLIQ+XD2XvI2WSmQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-wrap-function': 7.22.10
     dev: true
 
-  /@babel/helper-replace-supers@7.22.9(@babel/core@7.22.9):
+  /@babel/helper-replace-supers@7.22.9(@babel/core@7.26.0):
     resolution: {integrity: sha512-LJIKvvpgPOPUThdYqcX6IXRuIcTkcAub0IaDRGCZH0p5GPUp7PhRU9QVgFcDDd51BaPkk77ZjqFwh6DZTAEmGg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-member-expression-to-functions': 7.22.5
       '@babel/helper-optimise-call-expression': 7.22.5
@@ -6241,6 +6380,10 @@ packages:
     resolution: {integrity: sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==}
     engines: {node: '>=6.9.0'}
 
+  /@babel/helper-validator-option@7.25.9:
+    resolution: {integrity: sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==}
+    engines: {node: '>=6.9.0'}
+
   /@babel/helper-wrap-function@7.22.10:
     resolution: {integrity: sha512-OnMhjWjuGYtdoO3FmsEFWvBStBAe2QOgwOLsLNDjN+aaiMD8InJk1/O3HSD8lkqTjCgg5YI34Tz15KNNA3p+nQ==}
     engines: {node: '>=6.9.0'}
@@ -6259,6 +6402,13 @@ packages:
       '@babel/types': 7.22.10
     transitivePeerDependencies:
       - supports-color
+
+  /@babel/helpers@7.26.0:
+    resolution: {integrity: sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.25.9
+      '@babel/types': 7.26.0
 
   /@babel/highlight@7.22.5:
     resolution: {integrity: sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==}
@@ -6282,26 +6432,26 @@ packages:
     dependencies:
       '@babel/types': 7.26.0
 
-  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-NP1M5Rf+u2Gw9qfSO4ihjcTGW5zXTi36ITLd4/EoAcEhIZ0yjMqmftDNl3QC19CX7olhrjpyU454g/2W7X0jvQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-31Bb65aZaUwqCbWMnZPduIZxCBngHFlzyN6Dq6KAJjtx+lx6ohKHubc61OomYi7XwVD4Ol0XCVz4h+pYFR048g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.13.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-transform-optional-chaining': 7.22.10(@babel/core@7.22.9)
+      '@babel/plugin-transform-optional-chaining': 7.22.10(@babel/core@7.26.0)
     dev: true
 
   /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.22.9):
@@ -6338,13 +6488,13 @@ packages:
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.22.9)
     dev: true
 
-  /@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.22.9):
+  /@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.26.0):
     resolution: {integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
     dev: true
 
   /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.22.9):
@@ -6354,6 +6504,15 @@ packages:
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
+
+  /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.26.0):
+    resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.22.9):
     resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
@@ -6371,31 +6530,40 @@ packages:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.22.9):
+  /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.26.0):
+    resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
+
+  /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.22.9):
+  /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.26.0):
     resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.22.9):
+  /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.26.0):
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -6409,23 +6577,23 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-syntax-import-assertions@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-syntax-import-assertions@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-rdV97N7KqsRzeNGoWUOK6yUsWarLjE5Su/Snk9IYPU9CwkWHs4t+rTGOvffTR8XGkJMTAdLfO0xVnXm8wugIJg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-syntax-import-attributes@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-syntax-import-attributes@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-KwvoWDeNKPETmozyFE0P2rOLqh39EoQHNjqizrI5B8Vt0ZNS7M56s7dAiAqbYfiAYOuIzIh96z3iR2ktgu3tEg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -6437,6 +6605,15 @@ packages:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
+  /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.26.0):
+    resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
+
   /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.22.9):
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
     peerDependencies:
@@ -6444,6 +6621,15 @@ packages:
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
+
+  /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.26.0):
+    resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-jsx@7.18.6(@babel/core@7.20.12):
     resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
@@ -6482,6 +6668,15 @@ packages:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
+  /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.26.0):
+    resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
+
   /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.22.9):
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
     peerDependencies:
@@ -6489,6 +6684,15 @@ packages:
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
+
+  /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.26.0):
+    resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.22.9):
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
@@ -6498,6 +6702,15 @@ packages:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
+  /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.26.0):
+    resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
+
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.22.9):
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
     peerDependencies:
@@ -6505,6 +6718,15 @@ packages:
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
+
+  /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.26.0):
+    resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.22.9):
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
@@ -6514,6 +6736,15 @@ packages:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
+  /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.26.0):
+    resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
+
   /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.22.9):
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
     peerDependencies:
@@ -6522,13 +6753,22 @@ packages:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.22.9):
+  /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.26.0):
+    resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
+
+  /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -6541,6 +6781,16 @@ packages:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
+  /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.26.0):
+    resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
+
   /@babel/plugin-syntax-typescript@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-1mS2o03i7t1c6VzH6fdQ3OA8tcEIxwG18zIPRp+UY1Ihv6W+XZzBCVxExF9upussPXJ0xE9XRHwMoNs1ep/nRQ==}
     engines: {node: '>=6.9.0'}
@@ -6550,186 +6800,186 @@ packages:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.22.9):
+  /@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.26.0):
     resolution: {integrity: sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-arrow-functions@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-arrow-functions@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-26lTNXoVRdAnsaDXPpvCNUq+OVWEVC6bx7Vvz9rC53F2bagUWW4u4ii2+h8Fejfh7RYqPxn+libeFBBck9muEw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-async-generator-functions@7.22.10(@babel/core@7.22.9):
+  /@babel/plugin-transform-async-generator-functions@7.22.10(@babel/core@7.26.0):
     resolution: {integrity: sha512-eueE8lvKVzq5wIObKK/7dvoeKJ+xc6TvRn6aysIjS6pSCeLy7S/eVi7pEQknZqyqvzaNKdDtem8nUNTBgDVR2g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.22.9)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.22.9)
+      '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.26.0)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.26.0)
     dev: true
 
-  /@babel/plugin-transform-async-to-generator@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-async-to-generator@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-b1A8D8ZzE/VhNDoV1MSJTnpKkCG5bJo+19R4o4oy03zM7ws8yEMK755j61Dc3EyvdysbqH5BOOTquJ7ZX9C6vQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-module-imports': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.22.9)
+      '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.26.0)
     dev: true
 
-  /@babel/plugin-transform-block-scoped-functions@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-block-scoped-functions@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-tdXZ2UdknEKQWKJP1KMNmuF5Lx3MymtMN/pvA+p/VEkhK8jVcQ1fzSy8KM9qRYhAf2/lV33hoMPKI/xaI9sADA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-block-scoping@7.22.10(@babel/core@7.22.9):
+  /@babel/plugin-transform-block-scoping@7.22.10(@babel/core@7.26.0):
     resolution: {integrity: sha512-1+kVpGAOOI1Albt6Vse7c8pHzcZQdQKW+wJH+g8mCaszOdDVwRXa/slHPqIw+oJAJANTKDMuM2cBdV0Dg618Vg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-class-properties@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-class-properties@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-nDkQ0NfkOhPTq8YCLiWNxp1+f9fCobEjCb0n8WdbNUBc4IB5V7P1QnX9IjpSoquKrXF5SKojHleVNs2vGeHCHQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-class-static-block@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-class-static-block@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-SPToJ5eYZLxlnp1UzdARpOGeC2GbHvr9d/UV0EukuVx8atktg194oe+C5BqQ8jRTkgLRVOPYeXRSBg1IlMoVRA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.22.9)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.26.0)
     dev: true
 
-  /@babel/plugin-transform-classes@7.22.6(@babel/core@7.22.9):
+  /@babel/plugin-transform-classes@7.22.6(@babel/core@7.26.0):
     resolution: {integrity: sha512-58EgM6nuPNG6Py4Z3zSuu0xWu2VfodiMi72Jt5Kj2FECmaYk1RrTXA45z6KBFsu9tRgwQDwIiY4FXTt+YsSFAQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-compilation-targets': 7.22.10
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-function-name': 7.22.5
       '@babel/helper-optimise-call-expression': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.22.9)
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.26.0)
       '@babel/helper-split-export-declaration': 7.22.6
       globals: 11.12.0
     dev: true
 
-  /@babel/plugin-transform-computed-properties@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-computed-properties@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-4GHWBgRf0krxPX+AaPtgBAlTgTeZmqDynokHOX7aqqAB4tHs3U2Y02zH6ETFdLZGcg9UQSD1WCmkVrE9ErHeOg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/template': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-destructuring@7.22.10(@babel/core@7.22.9):
+  /@babel/plugin-transform-destructuring@7.22.10(@babel/core@7.26.0):
     resolution: {integrity: sha512-dPJrL0VOyxqLM9sritNbMSGx/teueHF/htMKrPT7DNxccXxRDPYqlgPFFdr8u+F+qUZOkZoXue/6rL5O5GduEw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-dotall-regex@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-dotall-regex@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-5/Yk9QxCQCl+sOIB1WelKnVRxTJDSAIxtJLL2/pqL14ZVlbH0fUQUZa/T5/UnQtBNgghR7mfB8ERBKyKPCi7Vw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-duplicate-keys@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-duplicate-keys@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-dEnYD+9BBgld5VBXHnF/DbYGp3fqGMsyxKbtD1mDyIA7AkTSpKXFhCVuj/oQVOoALfBs77DudA0BE4d5mcpmqw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-dynamic-import@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-dynamic-import@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-0MC3ppTB1AMxd8fXjSrbPa7LT9hrImt+/fcj+Pg5YMD7UQyWp/02+JWpdnCymmsXwIx5Z+sYn1bwCn4ZJNvhqQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.22.9)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.26.0)
     dev: true
 
-  /@babel/plugin-transform-exponentiation-operator@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-exponentiation-operator@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-vIpJFNM/FjZ4rh1myqIya9jXwrwwgFRHPjT3DkUA9ZLHuzox8jiXkOLvwm1H+PQIP3CqfC++WPKeuDi0Sjdj1g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.10
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-export-namespace-from@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-export-namespace-from@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-X4hhm7FRnPgd4nDA4b/5V280xCx6oL7Oob5+9qVS5C13Zq4bh1qq7LU0GgRU6b5dBWBvhGaXYVB4AcN6+ol6vg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.22.9)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.26.0)
     dev: true
 
   /@babel/plugin-transform-flow-strip-types@7.19.0(@babel/core@7.22.9):
@@ -6743,78 +6993,78 @@ packages:
       '@babel/plugin-syntax-flow': 7.18.6(@babel/core@7.22.9)
     dev: true
 
-  /@babel/plugin-transform-for-of@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-for-of@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-3kxQjX1dU9uudwSshyLeEipvrLjBCVthCgeTp6CzE/9JYrlAIaeekVxRpCWsDDfYTfRZRoCeZatCQvwo+wvK8A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-function-name@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-function-name@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-UIzQNMS0p0HHiQm3oelztj+ECwFnj+ZRV4KnguvlsD2of1whUeM6o7wGNj6oLwcDoAXQ8gEqfgC24D+VdIcevg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-compilation-targets': 7.22.10
       '@babel/helper-function-name': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-json-strings@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-json-strings@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-DuCRB7fu8MyTLbEQd1ew3R85nx/88yMoqo2uPSjevMj3yoN7CDM8jkgrY0wmVxfJZyJ/B9fE1iq7EQppWQmR5A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.22.9)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.26.0)
     dev: true
 
-  /@babel/plugin-transform-literals@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-literals@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-fTLj4D79M+mepcw3dgFBTIDYpbcB9Sm0bpm4ppXPaO+U+PKFFyV9MGRvS0gvGw62sd10kT5lRMKXAADb9pWy8g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-logical-assignment-operators@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-logical-assignment-operators@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-MQQOUW1KL8X0cDWfbwYP+TbVbZm16QmQXJQ+vndPtH/BoO0lOKpVoEDMI7+PskYxH+IiE0tS8xZye0qr1lGzSA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.22.9)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.26.0)
     dev: true
 
-  /@babel/plugin-transform-member-expression-literals@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-member-expression-literals@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-RZEdkNtzzYCFl9SE9ATaUMTj2hqMb4StarOJLrZRbqqU4HSBE7UlBw9WBWQiDzrJZJdUWiMTVDI6Gv/8DPvfew==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-modules-amd@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-modules-amd@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-R+PTfLTcYEmb1+kK7FNkhQ1gP4KgjpSO6HfH9+f8/yfp2Nt3ggBjiVpRwmwTlfqZLafYKJACy36yDXlEmI9HjQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -6825,167 +7075,179 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.9)
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-simple-access': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-modules-systemjs@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-modules-commonjs@7.22.5(@babel/core@7.26.0):
+    resolution: {integrity: sha512-B4pzOXj+ONRmuaQTg05b3y/4DuFz3WcCNAXPLb2Q0GT0TrGKGxNKV4jwsXts+StaM0LQczZbOpj8o1DLPDJIiA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.26.0)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-simple-access': 7.22.5
+    dev: true
+
+  /@babel/plugin-transform-modules-systemjs@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-emtEpoaTMsOs6Tzz+nbmcePl6AKVtS1yC4YNAeMun9U8YCsgadPNxnOPQ8GhHFB2qdx+LZu9LgoC0Lthuu05DQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-hoist-variables': 7.22.5
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.9)
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-identifier': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-modules-umd@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-modules-umd@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-+S6kzefN/E1vkSsKx8kmQuqeQsvCKCd1fraCM7zXm4SFoggI099Tr4G8U81+5gtMdUeMQ4ipdQffbKLX0/7dBQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-YgLLKmS3aUBhHaxp5hi1WJTgOUb/NCuDHzGT9z9WTt3YG+CPRhJs6nprbStx6DnWM4dh6gt7SU3sZodbZ08adQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-new-target@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-new-target@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-AsF7K0Fx/cNKVyk3a+DW0JLo+Ua598/NxMRvxDnkpCIGFh43+h/v2xyhRUYf6oD8gE4QtL83C7zZVghMjHd+iw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-nullish-coalescing-operator@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-nullish-coalescing-operator@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-6CF8g6z1dNYZ/VXok5uYkkBBICHZPiGEl7oDnAx2Mt1hlHVHOSIKWJaXHjQJA5VB43KZnXZDIexMchY4y2PGdA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.22.9)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.26.0)
     dev: true
 
-  /@babel/plugin-transform-numeric-separator@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-numeric-separator@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-NbslED1/6M+sXiwwtcAB/nieypGw02Ejf4KtDeMkCEpP6gWFMX1wI9WKYua+4oBneCCEmulOkRpwywypVZzs/g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.22.9)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.26.0)
     dev: true
 
-  /@babel/plugin-transform-object-rest-spread@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-object-rest-spread@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-Kk3lyDmEslH9DnvCDA1s1kkd3YWQITiBOHngOtDL9Pt6BZjzqb6hiOlb8VfjiiQJ2unmegBqZu0rx5RxJb5vmQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.22.9
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-compilation-targets': 7.22.10
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.22.9)
-      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.26.0)
     dev: true
 
-  /@babel/plugin-transform-object-super@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-object-super@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-klXqyaT9trSjIUrcsYIfETAzmOEZL3cBYqOYLJxBHfMFFggmXOv+NYSX/Jbs9mzMVESw/WycLFPRx8ba/b2Ipw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.22.9)
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.26.0)
     dev: true
 
-  /@babel/plugin-transform-optional-catch-binding@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-optional-catch-binding@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-pH8orJahy+hzZje5b8e2QIlBWQvGpelS76C63Z+jhZKsmzfNaPQ+LaW6dcJ9bxTpo1mtXbgHwy765Ro3jftmUg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.22.9)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.26.0)
     dev: true
 
-  /@babel/plugin-transform-optional-chaining@7.22.10(@babel/core@7.22.9):
+  /@babel/plugin-transform-optional-chaining@7.22.10(@babel/core@7.26.0):
     resolution: {integrity: sha512-MMkQqZAZ+MGj+jGTG3OTuhKeBpNcO+0oCEbrGNEaOmiEn+1MzRyQlYsruGiU8RTK3zV6XwrVJTmwiDOyYK6J9g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.22.9)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.26.0)
     dev: true
 
-  /@babel/plugin-transform-parameters@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-parameters@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-AVkFUBurORBREOmHRKo06FjHYgjrabpdqRSwq6+C7R5iTCZOsM4QbcB27St0a4U6fffyAOqh3s/qEfybAhfivg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-private-methods@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-private-methods@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-PPjh4gyrQnGe97JTalgRGMuU4icsZFnWkzicB/fUtzlKUqvsWBKEpPPfr5a2JiyirZkHxnAqkQMO5Z5B2kK3fA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-private-property-in-object@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-private-property-in-object@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-/9xnaTTJcVoBtSSmrVyhtSvO3kbqS2ODoh2juEU72c3aYonNF0OMGiaz2gjukyKM2wBBYJP38S4JiE0Wfb5VMQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.22.9)
+      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.22.9)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.26.0)
     dev: true
 
-  /@babel/plugin-transform-property-literals@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-property-literals@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-TiOArgddK3mK/x1Qwf5hay2pxI6wCZnvQqrFSqbtg1GLl2JcNMitVH/YnqjP+M31pLUeTfzY1HAXFDnUBV30rQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -7067,75 +7329,75 @@ packages:
       '@babel/types': 7.22.10
     dev: true
 
-  /@babel/plugin-transform-regenerator@7.22.10(@babel/core@7.22.9):
+  /@babel/plugin-transform-regenerator@7.22.10(@babel/core@7.26.0):
     resolution: {integrity: sha512-F28b1mDt8KcT5bUyJc/U9nwzw6cV+UmTeRlXYIl2TNqMMJif0Jeey9/RQ3C4NOd2zp0/TRsDns9ttj2L523rsw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
       regenerator-transform: 0.15.2
     dev: true
 
-  /@babel/plugin-transform-reserved-words@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-reserved-words@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-DTtGKFRQUDm8svigJzZHzb/2xatPc6TzNvAIJ5GqOKDsGFYgAskjRulbR/vGsPKq3OPqtexnz327qYpP57RFyA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-shorthand-properties@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-shorthand-properties@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-vM4fq9IXHscXVKzDv5itkO1X52SmdFBFcMIBZ2FRn2nqVYqw6dBexUgMvAjHW+KXpPPViD/Yo3GrDEBaRC0QYA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-spread@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-spread@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-5ZzDQIGyvN4w8+dMmpohL6MBo+l2G7tfC/O2Dg7/hjpgeWvUx8FzfeOKxGog9IimPa4YekaQ9PlDqTLOljkcxg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-sticky-regex@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-sticky-regex@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-zf7LuNpHG0iEeiyCNwX4j3gDg1jgt1k3ZdXBKbZSoA3BbGQGvMiSvfbZRR3Dr3aeJe3ooWFZxOOG3IRStYp2Bw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-template-literals@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-template-literals@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-5ciOehRNf+EyUeewo8NkbQiUs4d6ZxiHo6BcBcnFlgiJfu16q0bQUw9Jvo0b0gBKFG1SMhDSjeKXSYuJLeFSMA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-typeof-symbol@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-typeof-symbol@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-bYkI5lMzL4kPii4HHEEChkD0rkc+nvnlR6+o/qdqR6zrm0Sv/nodmyLhlq2DO0YKLUNd2VePmPRjJXSBh9OIdA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -7151,46 +7413,46 @@ packages:
       '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.22.9)
     dev: true
 
-  /@babel/plugin-transform-unicode-escapes@7.22.10(@babel/core@7.22.9):
+  /@babel/plugin-transform-unicode-escapes@7.22.10(@babel/core@7.26.0):
     resolution: {integrity: sha512-lRfaRKGZCBqDlRU3UIFovdp9c9mEvlylmpod0/OatICsSfuQ9YFthRo1tpTkGsklEefZdqlEFdY4A2dwTb6ohg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-unicode-property-regex@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-unicode-property-regex@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-HCCIb+CbJIAE6sXn5CjFQXMwkCClcOfPCzTlilJ8cUatfzwHlWQkbtV0zD338u9dZskwvuOYTuuaMaA8J5EI5A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-unicode-regex@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-unicode-regex@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-028laaOKptN5vHJf9/Arr/HiJekMd41hOEZYvNsrsXqJ7YPYuX2bQxh31fkZzGmq3YqHRJzYFFAVYvKfMPKqyg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-unicode-sets-regex@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-unicode-sets-regex@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-lhMfi4FC15j13eKrh3DnYHjpGj6UKQHtNKTbtc1igvAhRy4+kLhV07OpLcsN0VgDEw/MjAvJO4BdMJsHwMhzCg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -7205,80 +7467,171 @@ packages:
       '@babel/helper-compilation-targets': 7.22.10
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-option': 7.22.5
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.22.9)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.22.9)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.22.9)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.22.9)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.22.9)
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.22.9)
-      '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-syntax-import-attributes': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.22.9)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.22.9)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.22.9)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.22.9)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.22.9)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.22.9)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.22.9)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.22.9)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.22.9)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.22.9)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.22.9)
-      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-async-generator-functions': 7.22.10(@babel/core@7.22.9)
-      '@babel/plugin-transform-async-to-generator': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-block-scoped-functions': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-block-scoping': 7.22.10(@babel/core@7.22.9)
-      '@babel/plugin-transform-class-properties': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-class-static-block': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-classes': 7.22.6(@babel/core@7.22.9)
-      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-destructuring': 7.22.10(@babel/core@7.22.9)
-      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-duplicate-keys': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-dynamic-import': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-exponentiation-operator': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-export-namespace-from': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-for-of': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-json-strings': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-logical-assignment-operators': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-member-expression-literals': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-modules-amd': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-modules-commonjs': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-modules-systemjs': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-modules-umd': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-new-target': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-numeric-separator': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-object-rest-spread': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-object-super': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-optional-catch-binding': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-optional-chaining': 7.22.10(@babel/core@7.22.9)
-      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-private-methods': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-private-property-in-object': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-property-literals': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-regenerator': 7.22.10(@babel/core@7.22.9)
-      '@babel/plugin-transform-reserved-words': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-shorthand-properties': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-sticky-regex': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-typeof-symbol': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-unicode-escapes': 7.22.10(@babel/core@7.22.9)
-      '@babel/plugin-transform-unicode-property-regex': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-unicode-regex': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-unicode-sets-regex': 7.22.5(@babel/core@7.22.9)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.22.9)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.26.0)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.26.0)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.26.0)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.26.0)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-syntax-import-attributes': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.26.0)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.26.0)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.26.0)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.26.0)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.26.0)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.26.0)
+      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-async-generator-functions': 7.22.10(@babel/core@7.26.0)
+      '@babel/plugin-transform-async-to-generator': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-block-scoped-functions': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-block-scoping': 7.22.10(@babel/core@7.26.0)
+      '@babel/plugin-transform-class-properties': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-class-static-block': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-classes': 7.22.6(@babel/core@7.26.0)
+      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-destructuring': 7.22.10(@babel/core@7.26.0)
+      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-duplicate-keys': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-dynamic-import': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-exponentiation-operator': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-export-namespace-from': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-for-of': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-json-strings': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-logical-assignment-operators': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-member-expression-literals': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-modules-amd': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-modules-commonjs': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-modules-systemjs': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-modules-umd': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-new-target': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-numeric-separator': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-object-rest-spread': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-object-super': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-optional-catch-binding': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-optional-chaining': 7.22.10(@babel/core@7.26.0)
+      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-private-methods': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-private-property-in-object': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-property-literals': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-regenerator': 7.22.10(@babel/core@7.26.0)
+      '@babel/plugin-transform-reserved-words': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-shorthand-properties': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-sticky-regex': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-typeof-symbol': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-unicode-escapes': 7.22.10(@babel/core@7.26.0)
+      '@babel/plugin-transform-unicode-property-regex': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-unicode-regex': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-unicode-sets-regex': 7.22.5(@babel/core@7.26.0)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.26.0)
       '@babel/types': 7.22.10
-      babel-plugin-polyfill-corejs2: 0.4.5(@babel/core@7.22.9)
-      babel-plugin-polyfill-corejs3: 0.8.3(@babel/core@7.22.9)
-      babel-plugin-polyfill-regenerator: 0.5.2(@babel/core@7.22.9)
+      babel-plugin-polyfill-corejs2: 0.4.5(@babel/core@7.26.0)
+      babel-plugin-polyfill-corejs3: 0.8.3(@babel/core@7.26.0)
+      babel-plugin-polyfill-regenerator: 0.5.2(@babel/core@7.26.0)
+      core-js-compat: 3.32.0
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/preset-env@7.22.10(@babel/core@7.26.0):
+    resolution: {integrity: sha512-riHpLb1drNkpLlocmSyEg4oYJIQFeXAK/d7rI6mbD0XsvoTOOweXDmQPG/ErxsEhWk3rl3Q/3F6RFQlVFS8m0A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/compat-data': 7.22.9
+      '@babel/core': 7.26.0
+      '@babel/helper-compilation-targets': 7.22.10
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-option': 7.22.5
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.26.0)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.26.0)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.26.0)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.26.0)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-syntax-import-attributes': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.26.0)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.26.0)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.26.0)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.26.0)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.26.0)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.26.0)
+      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-async-generator-functions': 7.22.10(@babel/core@7.26.0)
+      '@babel/plugin-transform-async-to-generator': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-block-scoped-functions': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-block-scoping': 7.22.10(@babel/core@7.26.0)
+      '@babel/plugin-transform-class-properties': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-class-static-block': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-classes': 7.22.6(@babel/core@7.26.0)
+      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-destructuring': 7.22.10(@babel/core@7.26.0)
+      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-duplicate-keys': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-dynamic-import': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-exponentiation-operator': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-export-namespace-from': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-for-of': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-json-strings': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-logical-assignment-operators': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-member-expression-literals': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-modules-amd': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-modules-commonjs': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-modules-systemjs': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-modules-umd': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-new-target': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-numeric-separator': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-object-rest-spread': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-object-super': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-optional-catch-binding': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-optional-chaining': 7.22.10(@babel/core@7.26.0)
+      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-private-methods': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-private-property-in-object': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-property-literals': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-regenerator': 7.22.10(@babel/core@7.26.0)
+      '@babel/plugin-transform-reserved-words': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-shorthand-properties': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-sticky-regex': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-typeof-symbol': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-unicode-escapes': 7.22.10(@babel/core@7.26.0)
+      '@babel/plugin-transform-unicode-property-regex': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-unicode-regex': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-unicode-sets-regex': 7.22.5(@babel/core@7.26.0)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.26.0)
+      '@babel/types': 7.22.10
+      babel-plugin-polyfill-corejs2: 0.4.5(@babel/core@7.26.0)
+      babel-plugin-polyfill-corejs3: 0.8.3(@babel/core@7.26.0)
+      babel-plugin-polyfill-regenerator: 0.5.2(@babel/core@7.26.0)
       core-js-compat: 3.32.0
       semver: 6.3.1
     transitivePeerDependencies:
@@ -7297,12 +7650,12 @@ packages:
       '@babel/plugin-transform-flow-strip-types': 7.19.0(@babel/core@7.22.9)
     dev: true
 
-  /@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.22.9):
+  /@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.26.0):
     resolution: {integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/types': 7.22.10
       esutils: 2.0.3
@@ -7598,6 +7951,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/aix-ppc64@0.21.5:
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/android-arm64@0.17.11:
     resolution: {integrity: sha512-QnK4d/zhVTuV4/pRM4HUjcsbl43POALU2zvBynmrrqZt9LPcLA3x1fTZPBg2RRguBQnJcnU059yKr+bydkntjg==}
     engines: {node: '>=12'}
@@ -7617,6 +7978,14 @@ packages:
 
   /@esbuild/android-arm64@0.21.2:
     resolution: {integrity: sha512-SGZKngoTWVUriO5bDjI4WDGsNx2VKZoXcds+ita/kVYB+8IkSCKDRDaK+5yu0b5S0eq6B3S7fpiEvpsa2ammlQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    optional: true
+
+  /@esbuild/android-arm64@0.21.5:
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -7648,6 +8017,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/android-arm@0.21.5:
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/android-x64@0.17.11:
     resolution: {integrity: sha512-3PL3HKtsDIXGQcSCKtWD/dy+mgc4p2Tvo2qKgKHj9Yf+eniwFnuoQ0OUhlSfAEpKAFzF9N21Nwgnap6zy3L3MQ==}
     engines: {node: '>=12'}
@@ -7667,6 +8044,14 @@ packages:
 
   /@esbuild/android-x64@0.21.2:
     resolution: {integrity: sha512-1wzzNoj2QtNkAYwIcWJ66UTRA80+RTQ/kuPMtEuP0X6dp5Ar23Dn566q3aV61h4EYrrgGlOgl/HdcqN/2S/2vg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    optional: true
+
+  /@esbuild/android-x64@0.21.5:
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -7698,6 +8083,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/darwin-arm64@0.21.5:
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/darwin-x64@0.17.11:
     resolution: {integrity: sha512-iB0dQkIHXyczK3BZtzw1tqegf0F0Ab5texX2TvMQjiJIWXAfM4FQl7D909YfXWnB92OQz4ivBYQ2RlxBJrMJOw==}
     engines: {node: '>=12'}
@@ -7717,6 +8110,14 @@ packages:
 
   /@esbuild/darwin-x64@0.21.2:
     resolution: {integrity: sha512-K4ZdVq1zP9v51h/cKVna7im7G0zGTKKB6bP2yJiSmHjjOykbd8DdhrSi8V978sF69rkwrn8zCyL2t6I3ei6j9A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.21.5:
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -7748,6 +8149,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/freebsd-arm64@0.21.5:
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/freebsd-x64@0.17.11:
     resolution: {integrity: sha512-iPgenptC8i8pdvkHQvXJFzc1eVMR7W2lBPrTE6GbhR54sLcF42mk3zBOjKPOodezzuAz/KSu8CPyFSjcBMkE9g==}
     engines: {node: '>=12'}
@@ -7767,6 +8176,14 @@ packages:
 
   /@esbuild/freebsd-x64@0.21.2:
     resolution: {integrity: sha512-ShS+R09nuHzDBfPeMUliKZX27Wrmr8UFp93aFf/S8p+++x5BZ+D344CLKXxmY6qzgTL3mILSImPCNJOzD6+RRg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.21.5:
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -7798,6 +8215,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/linux-arm64@0.21.5:
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-arm@0.17.11:
     resolution: {integrity: sha512-M9iK/d4lgZH0U5M1R2p2gqhPV/7JPJcRz+8O8GBKVgqndTzydQ7B2XGDbxtbvFkvIs53uXTobOhv+RyaqhUiMg==}
     engines: {node: '>=12'}
@@ -7817,6 +8242,14 @@ packages:
 
   /@esbuild/linux-arm@0.21.2:
     resolution: {integrity: sha512-nnGXjOAv+7cM3LYRx4tJsYdgy8dGDGkAzF06oIDGppWbUkUKN9SmgQA8H0KukpU0Pjrj9XmgbWqMVSX/U7eeTA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@esbuild/linux-arm@0.21.5:
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -7848,6 +8281,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/linux-ia32@0.21.5:
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-loong64@0.17.11:
     resolution: {integrity: sha512-aCWlq70Q7Nc9WDnormntGS1ar6ZFvUpqr8gXtO+HRejRYPweAFQN615PcgaSJkZjhHp61+MNLhzyVALSF2/Q0g==}
     engines: {node: '>=12'}
@@ -7867,6 +8308,14 @@ packages:
 
   /@esbuild/linux-loong64@0.21.2:
     resolution: {integrity: sha512-84eYHwwWHq3myIY/6ikALMcnwkf6Qo7NIq++xH0x+cJuUNpdwh8mlpUtRY+JiGUc60yu7ElWBbVHGWTABTclGw==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.21.5:
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -7898,6 +8347,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/linux-mips64el@0.21.5:
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-ppc64@0.17.11:
     resolution: {integrity: sha512-BdlziJQPW/bNe0E8eYsHB40mYOluS+jULPCjlWiHzDgr+ZBRXPtgMV1nkLEGdpjrwgmtkZHEGEPaKdS/8faLDA==}
     engines: {node: '>=12'}
@@ -7917,6 +8374,14 @@ packages:
 
   /@esbuild/linux-ppc64@0.21.2:
     resolution: {integrity: sha512-y0T4aV2CA+ic04ULya1A/8M2RDpDSK2ckgTj6jzHKFJvCq0jQg8afQQIn4EM0G8u2neyOiNHgSF9YKPfuqKOVw==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.21.5:
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -7948,6 +8413,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/linux-riscv64@0.21.5:
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-s390x@0.17.11:
     resolution: {integrity: sha512-4N5EMESvws0Ozr2J94VoUD8HIRi7X0uvUv4c0wpTHZyZY9qpaaN7THjosdiW56irQ4qnJ6Lsc+i+5zGWnyqWqQ==}
     engines: {node: '>=12'}
@@ -7967,6 +8440,14 @@ packages:
 
   /@esbuild/linux-s390x@0.21.2:
     resolution: {integrity: sha512-NP7fTpGSFWdXyvp8iAFU04uFh9ARoplFVM/m+8lTRpaYG+2ytHPZWyscSsMM6cvObSIK2KoPHXiZD4l99WaxbQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.21.5:
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -7998,6 +8479,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/linux-x64@0.21.5:
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/netbsd-x64@0.17.11:
     resolution: {integrity: sha512-4WaAhuz5f91h3/g43VBGdto1Q+X7VEZfpcWGtOFXnggEuLvjV+cP6DyLRU15IjiU9fKLLk41OoJfBFN5DhPvag==}
     engines: {node: '>=12'}
@@ -8017,6 +8506,14 @@ packages:
 
   /@esbuild/netbsd-x64@0.21.2:
     resolution: {integrity: sha512-IeFMfGFSQfIj1d4XU+6lkbFzMR+mFELUUVYrZ+jvWzG4NGvs6o53ReEHLHpYkjRbdEjJy2W3lTekTxrFHW7YJg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    optional: true
+
+  /@esbuild/netbsd-x64@0.21.5:
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -8048,6 +8545,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/openbsd-x64@0.21.5:
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/sunos-x64@0.17.11:
     resolution: {integrity: sha512-1/gxTifDC9aXbV2xOfCbOceh5AlIidUrPsMpivgzo8P8zUtczlq1ncFpeN1ZyQJ9lVs2hILy1PG5KPp+w8QPPg==}
     engines: {node: '>=12'}
@@ -8067,6 +8572,14 @@ packages:
 
   /@esbuild/sunos-x64@0.21.2:
     resolution: {integrity: sha512-90r3nTBLgdIgD4FCVV9+cR6Hq2Dzs319icVsln+NTmTVwffWcCqXGml8rAoocHuJ85kZK36DCteii96ba/PX8g==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    optional: true
+
+  /@esbuild/sunos-x64@0.21.5:
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -8098,6 +8611,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/win32-arm64@0.21.5:
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/win32-ia32@0.17.11:
     resolution: {integrity: sha512-GFPSLEGQr4wHFTiIUJQrnJKZhZjjq4Sphf+mM76nQR6WkQn73vm7IsacmBRPkALfpOCHsopSvLgqdd4iUW2mYw==}
     engines: {node: '>=12'}
@@ -8123,6 +8644,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/win32-ia32@0.21.5:
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/win32-x64@0.17.11:
     resolution: {integrity: sha512-N9vXqLP3eRL8BqSy8yn4Y98cZI2pZ8fyuHx6lKjiG2WABpT2l01TXdzq5Ma2ZUBzfB7tx5dXVhge8X9u0S70ZQ==}
     engines: {node: '>=12'}
@@ -8142,6 +8671,14 @@ packages:
 
   /@esbuild/win32-x64@0.21.2:
     resolution: {integrity: sha512-VEfTCZicoZnZ6sGkjFPGRFFJuL2fZn2bLhsekZl1CJslflp2cJS/VoKs1jMk+3pDfsGW6CfQVUckP707HwbXeQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
+  /@esbuild/win32-x64@0.21.5:
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -8548,7 +9085,7 @@ packages:
     resolution: {integrity: sha512-oA+I2SHHQGxDCZpbrsCQSoMLb3Bz547JnM+jUr9qEbuw0vQlWZfpPS7CO9J7XiwKicEz9OFn/IYoLkkiUD7bzA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.18
+      '@jridgewell/trace-mapping': 0.3.25
       callsites: 3.1.0
       graceful-fs: 4.2.11
 
@@ -8664,6 +9201,9 @@ packages:
 
   /@jridgewell/sourcemap-codec@1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
+
+  /@jridgewell/sourcemap-codec@1.5.0:
+    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
   /@jridgewell/trace-mapping@0.3.18:
     resolution: {integrity: sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==}
@@ -9249,6 +9789,139 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /@rollup/rollup-android-arm-eabi@4.28.1:
+    resolution: {integrity: sha512-2aZp8AES04KI2dy3Ss6/MDjXbwBzj+i0GqKtWXgw2/Ma6E4jJvujryO6gJAghIRVz7Vwr9Gtl/8na3nDUKpraQ==}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-android-arm64@4.28.1:
+    resolution: {integrity: sha512-EbkK285O+1YMrg57xVA+Dp0tDBRB93/BZKph9XhMjezf6F4TpYjaUSuPt5J0fZXlSag0LmZAsTmdGGqPp4pQFA==}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-darwin-arm64@4.28.1:
+    resolution: {integrity: sha512-prduvrMKU6NzMq6nxzQw445zXgaDBbMQvmKSJaxpaZ5R1QDM8w+eGxo6Y/jhT/cLoCvnZI42oEqf9KQNYz1fqQ==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-darwin-x64@4.28.1:
+    resolution: {integrity: sha512-WsvbOunsUk0wccO/TV4o7IKgloJ942hVFK1CLatwv6TJspcCZb9umQkPdvB7FihmdxgaKR5JyxDjWpCOp4uZlQ==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-freebsd-arm64@4.28.1:
+    resolution: {integrity: sha512-HTDPdY1caUcU4qK23FeeGxCdJF64cKkqajU0iBnTVxS8F7H/7BewvYoG+va1KPSL63kQ1PGNyiwKOfReavzvNA==}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-freebsd-x64@4.28.1:
+    resolution: {integrity: sha512-m/uYasxkUevcFTeRSM9TeLyPe2QDuqtjkeoTpP9SW0XxUWfcYrGDMkO/m2tTw+4NMAF9P2fU3Mw4ahNvo7QmsQ==}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-gnueabihf@4.28.1:
+    resolution: {integrity: sha512-QAg11ZIt6mcmzpNE6JZBpKfJaKkqTm1A9+y9O+frdZJEuhQxiugM05gnCWiANHj4RmbgeVJpTdmKRmH/a+0QbA==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-musleabihf@4.28.1:
+    resolution: {integrity: sha512-dRP9PEBfolq1dmMcFqbEPSd9VlRuVWEGSmbxVEfiq2cs2jlZAl0YNxFzAQS2OrQmsLBLAATDMb3Z6MFv5vOcXg==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-gnu@4.28.1:
+    resolution: {integrity: sha512-uGr8khxO+CKT4XU8ZUH1TTEUtlktK6Kgtv0+6bIFSeiSlnGJHG1tSFSjm41uQ9sAO/5ULx9mWOz70jYLyv1QkA==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-musl@4.28.1:
+    resolution: {integrity: sha512-QF54q8MYGAqMLrX2t7tNpi01nvq5RI59UBNx+3+37zoKX5KViPo/gk2QLhsuqok05sSCRluj0D00LzCwBikb0A==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-linux-loongarch64-gnu@4.28.1:
+    resolution: {integrity: sha512-vPul4uodvWvLhRco2w0GcyZcdyBfpfDRgNKU+p35AWEbJ/HPs1tOUrkSueVbBS0RQHAf/A+nNtDpvw95PeVKOA==}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-linux-powerpc64le-gnu@4.28.1:
+    resolution: {integrity: sha512-pTnTdBuC2+pt1Rmm2SV7JWRqzhYpEILML4PKODqLz+C7Ou2apEV52h19CR7es+u04KlqplggmN9sqZlekg3R1A==}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-linux-riscv64-gnu@4.28.1:
+    resolution: {integrity: sha512-vWXy1Nfg7TPBSuAncfInmAI/WZDd5vOklyLJDdIRKABcZWojNDY0NJwruY2AcnCLnRJKSaBgf/GiJfauu8cQZA==}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-linux-s390x-gnu@4.28.1:
+    resolution: {integrity: sha512-/yqC2Y53oZjb0yz8PVuGOQQNOTwxcizudunl/tFs1aLvObTclTwZ0JhXF2XcPT/zuaymemCDSuuUPXJJyqeDOg==}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-gnu@4.28.1:
+    resolution: {integrity: sha512-fzgeABz7rrAlKYB0y2kSEiURrI0691CSL0+KXwKwhxvj92VULEDQLpBYLHpF49MSiPG4sq5CK3qHMnb9tlCjBw==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-musl@4.28.1:
+    resolution: {integrity: sha512-xQTDVzSGiMlSshpJCtudbWyRfLaNiVPXt1WgdWTwWz9n0U12cI2ZVtWe/Jgwyv/6wjL7b66uu61Vg0POWVfz4g==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-win32-arm64-msvc@4.28.1:
+    resolution: {integrity: sha512-wSXmDRVupJstFP7elGMgv+2HqXelQhuNf+IS4V+nUpNVi/GUiBgDmfwD0UGN3pcAnWsgKG3I52wMOBnk1VHr/A==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-win32-ia32-msvc@4.28.1:
+    resolution: {integrity: sha512-ZkyTJ/9vkgrE/Rk9vhMXhf8l9D+eAhbAVbsGsXKy2ohmJaWg0LPQLnIxRdRp/bKyr8tXuPlXhIoGlEB5XpJnGA==}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-win32-x64-msvc@4.28.1:
+    resolution: {integrity: sha512-ZvK2jBafvttJjoIdKm/Q/Bh7IJ1Ose9IBOwpOXcOvW3ikGTQGmKDgxTC6oCAzW6PynbkKP8+um1du81XJHZ0JA==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
   /@rooks/use-interval@4.5.0(react@18.3.1):
     resolution: {integrity: sha512-As0DueIAGLJLYATKPPOCDGqoIlwbhPAcYP14TNTHaAj9/ODdvUYFXAP3jFCRzDNpjXCIgSe4oBuzVVmM526n+Q==}
     peerDependencies:
@@ -9772,7 +10445,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/preset-env': 7.22.10(@babel/core@7.22.9)
+      '@babel/preset-env': 7.22.10(@babel/core@7.26.0)
       '@babel/types': 7.22.5
       '@ndelangen/get-tarball': 3.0.9
       '@storybook/codemod': 7.2.2
@@ -10295,7 +10968,7 @@ packages:
     resolution: {integrity: sha512-wdsYKy5zupPyLCW2Je5DLHSxSfbIp6h80WoHOQc+RPtmPGA52O9x5MJEkv92Sjonpq+poOAtUKhh1kBGAXBrNA==}
     engines: {node: '>=18'}
     dependencies:
-      '@babel/code-frame': 7.22.5
+      '@babel/code-frame': 7.26.2
       '@babel/runtime': 7.23.9
       '@types/aria-query': 5.0.1
       aria-query: 5.3.0
@@ -10719,7 +11392,9 @@ packages:
 
   /@types/estree@1.0.5:
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
-    dev: true
+
+  /@types/estree@1.0.6:
+    resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
   /@types/express-serve-static-core@4.17.31:
     resolution: {integrity: sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==}
@@ -11510,6 +12185,80 @@ packages:
       - supports-color
     dev: true
 
+  /@vitest/coverage-istanbul@2.1.8(vitest@2.1.8):
+    resolution: {integrity: sha512-cSaCd8KcWWvgDwEJSXm0NEWZ1YTiJzjicKHy+zOEbUm0gjbbkz+qJf1p8q71uBzSlS7vdnZA8wRLeiwVE3fFTA==}
+    peerDependencies:
+      vitest: 2.1.8
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      debug: 4.3.7
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-instrument: 6.0.3
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.1.7
+      magicast: 0.3.5
+      test-exclude: 7.0.1
+      tinyrainbow: 1.2.0
+      vitest: 2.1.8(@types/node@20.16.0)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@vitest/expect@2.1.8:
+    resolution: {integrity: sha512-8ytZ/fFHq2g4PJVAtDX57mayemKgDR6X3Oa2Foro+EygiOJHUXhCqBAAKQYYajZpFoIfvBCF1j6R6IYRSIUFuw==}
+    dependencies:
+      '@vitest/spy': 2.1.8
+      '@vitest/utils': 2.1.8
+      chai: 5.1.2
+      tinyrainbow: 1.2.0
+
+  /@vitest/mocker@2.1.8(vite@5.4.11):
+    resolution: {integrity: sha512-7guJ/47I6uqfttp33mgo6ga5Gr1VnL58rcqYKyShoRK9ebu8T5Rs6HN3s1NABiBeVTdWNrwUMcHH54uXZBN4zA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+    dependencies:
+      '@vitest/spy': 2.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.14
+      vite: 5.4.11(@types/node@20.16.0)
+
+  /@vitest/pretty-format@2.1.8:
+    resolution: {integrity: sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==}
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  /@vitest/runner@2.1.8:
+    resolution: {integrity: sha512-17ub8vQstRnRlIU5k50bG+QOMLHRhYPAna5tw8tYbj+jzjcspnwnwtPtiOlkuKC4+ixDPTuLZiqiWWQ2PSXHVg==}
+    dependencies:
+      '@vitest/utils': 2.1.8
+      pathe: 1.1.2
+
+  /@vitest/snapshot@2.1.8:
+    resolution: {integrity: sha512-20T7xRFbmnkfcmgVEz+z3AU/3b0cEzZOt/zmnvZEctg64/QZbSDJEVm9fLnnlSi74KibmRsO9/Qabi+t0vCRPg==}
+    dependencies:
+      '@vitest/pretty-format': 2.1.8
+      magic-string: 0.30.14
+      pathe: 1.1.2
+
+  /@vitest/spy@2.1.8:
+    resolution: {integrity: sha512-5swjf2q95gXeYPevtW0BLk6H8+bPlMb4Vw/9Em4hFxDcaOxS+e0LOX4yqNxoHzMR2akEB2xfpnWUzkZokmgWDg==}
+    dependencies:
+      tinyspy: 3.0.2
+
+  /@vitest/utils@2.1.8:
+    resolution: {integrity: sha512-dwSoui6djdwbfFmIgbIjX2ZhIoG7Ex/+xpxyiEgIGzjliY8xGkcpITKTlp6B4MgtGkF2ilvm97cPM96XZaAgcA==}
+    dependencies:
+      '@vitest/pretty-format': 2.1.8
+      loupe: 3.1.2
+      tinyrainbow: 1.2.0
+
   /@votingworks/qrdetect@1.0.1:
     resolution: {integrity: sha512-Qk2i4NQoQy1tbkX1ADPZecXLDzBC0gaL2DcJUsOL90KXjP1lUE47UgmSWMRIlNNYu5iivpbwKA9Kl7sahgbSxg==}
     requiresBuild: true
@@ -12092,6 +12841,10 @@ packages:
       object-is: 1.1.5
       util: 0.12.4
 
+  /assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   /assign-symbols@1.0.0:
     resolution: {integrity: sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==}
     engines: {node: '>=0.10.0'}
@@ -12222,7 +12975,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@babel/template': 7.22.5
-      '@babel/types': 7.22.10
+      '@babel/types': 7.26.0
       '@types/babel__core': 7.20.1
       '@types/babel__traverse': 7.20.1
 
@@ -12235,38 +12988,38 @@ packages:
       resolve: 1.22.4
     dev: false
 
-  /babel-plugin-polyfill-corejs2@0.4.5(@babel/core@7.22.9):
+  /babel-plugin-polyfill-corejs2@0.4.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-19hwUH5FKl49JEsvyTcoHakh6BE0wgXLLptIyKZ3PijHc/Ci521wygORCUCCred+E/twuqRyAkE02BAWPmsHOg==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
       '@babel/compat-data': 7.22.9
-      '@babel/core': 7.22.9
-      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.26.0)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /babel-plugin-polyfill-corejs3@0.8.3(@babel/core@7.22.9):
+  /babel-plugin-polyfill-corejs3@0.8.3(@babel/core@7.26.0):
     resolution: {integrity: sha512-z41XaniZL26WLrvjy7soabMXrfPWARN25PZoriDEiLMxAp50AUW3t35BGQUMg5xK3UrpVTtagIDklxYa+MhiNA==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.26.0)
       core-js-compat: 3.32.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /babel-plugin-polyfill-regenerator@0.5.2(@babel/core@7.22.9):
+  /babel-plugin-polyfill-regenerator@0.5.2(@babel/core@7.26.0):
     resolution: {integrity: sha512-tAlOptU0Xj34V1Y2PNTL4Y0FOJMDB6bZmoW39FeCQIhigGLkqu3Fj6uiXpxIf6Ij274ENdYx64y6Au+ZKlb1IA==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.26.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12590,6 +13343,16 @@ packages:
       node-releases: 2.0.13
       update-browserslist-db: 1.0.11(browserslist@4.21.10)
 
+  /browserslist@4.24.2:
+    resolution: {integrity: sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+    dependencies:
+      caniuse-lite: 1.0.30001687
+      electron-to-chromium: 1.5.72
+      node-releases: 2.0.18
+      update-browserslist-db: 1.1.1(browserslist@4.24.2)
+
   /bs-logger@0.2.6:
     resolution: {integrity: sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==}
     engines: {node: '>= 6'}
@@ -12685,6 +13448,10 @@ packages:
       yargs-parser: 20.2.9
     dev: true
 
+  /cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   /cacache@12.0.4:
     resolution: {integrity: sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==}
     dependencies:
@@ -12764,6 +13531,9 @@ packages:
   /caniuse-lite@1.0.30001519:
     resolution: {integrity: sha512-0QHgqR+Jv4bxHMp8kZ1Kn8CH55OikjKJ6JmKkZYP1F3D7w+lnFXF70nG5eNfsZS89jadi5Ywy5UCSKLAglIRkg==}
 
+  /caniuse-lite@1.0.30001687:
+    resolution: {integrity: sha512-0S/FDhf4ZiqrTUiQ39dKeUjYRjkv7lOZU1Dgif2rIqrTzX/1wV2hfKu9TOm1IHkdSijfLswxTFzl/cvir+SLSQ==}
+
   /canvas@2.11.2:
     resolution: {integrity: sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==}
     engines: {node: '>=6'}
@@ -12781,6 +13551,16 @@ packages:
     resolution: {integrity: sha512-6F+UYzTaGB+awsTXg0uSJA1/b/B3DDJzpKVRu0UmyI7DmNeaAl2RFHuTGIN6fEgpadRxoXGb7gbC1xo4C3IdyA==}
     hasBin: true
     dev: true
+
+  /chai@5.1.2:
+    resolution: {integrity: sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==}
+    engines: {node: '>=12'}
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.1.2
+      pathval: 2.0.0
 
   /chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -12816,6 +13596,10 @@ packages:
   /char-regex@2.0.1:
     resolution: {integrity: sha512-oSvEeo6ZUD7NepqAat3RqoucZ5SeqLJgOvVIwkafu6IP3V0pO38s/ypdVUmDDK6qIIHNlYHJAKX9E7R7HoKElw==}
     engines: {node: '>=12.20'}
+
+  /check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   /cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
@@ -13519,7 +14303,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.3
-    dev: false
 
   /decamelize-keys@1.1.0:
     resolution: {integrity: sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==}
@@ -13578,6 +14361,10 @@ packages:
     dependencies:
       type-detect: 4.0.8
     dev: false
+
+  /deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   /deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -13879,6 +14666,9 @@ packages:
   /electron-to-chromium@1.4.485:
     resolution: {integrity: sha512-1ndQ5IBNEnFirPwvyud69GHL+31FkE09gH/CJ6m3KCbkx3i0EVOrjwz4UNxRmN9H8OVHbC6vMRZGN1yCvjSs9w==}
 
+  /electron-to-chromium@1.5.72:
+    resolution: {integrity: sha512-ZpSAUOZ2Izby7qnZluSrAlGgGQzucmFbN0n64dYzocYxnxV5ufurpj3VgEe4cUp7ir9LmeLxNYo8bVnlM8bQHw==}
+
   /elliptic@6.5.7:
     resolution: {integrity: sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==}
     dependencies:
@@ -14031,6 +14821,9 @@ packages:
     resolution: {integrity: sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==}
     dev: true
 
+  /es-module-lexer@1.5.4:
+    resolution: {integrity: sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==}
+
   /es-set-tostringtag@2.0.1:
     resolution: {integrity: sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==}
     engines: {node: '>= 0.4'}
@@ -14169,8 +14962,42 @@ packages:
       '@esbuild/win32-ia32': 0.21.2
       '@esbuild/win32-x64': 0.21.2
 
+  /esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
+    engines: {node: '>=6'}
+
+  /escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
   /escape-html@1.0.3:
@@ -14678,6 +15505,11 @@ packages:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
     dev: true
 
+  /estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+    dependencies:
+      '@types/estree': 1.0.5
+
   /esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -14766,6 +15598,10 @@ packages:
   /expect-type@0.15.0:
     resolution: {integrity: sha512-yWnriYB4e8G54M5/fAFj7rCIBiKs1HAACaY13kCz6Ku0dezjS9aMcfcdVK2X8Tv2tEV1BPz/wKfQ7WA4S/d8aA==}
     dev: true
+
+  /expect-type@1.1.0:
+    resolution: {integrity: sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==}
+    engines: {node: '>=12.0.0'}
 
   /expect@29.6.2:
     resolution: {integrity: sha512-iAErsLxJ8C+S02QbLAwgSGSezLQK+XXRDt8IuFXFpwCNw2ECmzZSmjKcCaFVp5VRMk+WAvz6h6jokzEzBFZEuA==}
@@ -15508,6 +16344,18 @@ packages:
       minimatch: 9.0.5
       minipass: 7.0.3
       path-scurry: 1.10.1
+    dev: true
+
+  /glob@10.4.5:
+    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
+    dependencies:
+      foreground-child: 3.1.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
     dev: true
 
   /glob@7.2.3:
@@ -16606,23 +17454,40 @@ packages:
     resolution: {integrity: sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==}
     engines: {node: '>=8'}
 
+  /istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
   /istanbul-lib-instrument@5.2.1:
     resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
     engines: {node: '>=8'}
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/parser': 7.22.7
+      '@babel/parser': 7.26.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
+  /istanbul-lib-instrument@6.0.3:
+    resolution: {integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==}
+    engines: {node: '>=10'}
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/parser': 7.26.2
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-coverage: 3.2.2
+      semver: 7.6.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /istanbul-lib-report@3.0.1:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
     engines: {node: '>=10'}
     dependencies:
-      istanbul-lib-coverage: 3.2.0
+      istanbul-lib-coverage: 3.2.2
       make-dir: 4.0.0
       supports-color: 7.2.0
 
@@ -16636,6 +17501,17 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      debug: 4.3.4(supports-color@5.5.0)
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /istanbul-reports@3.1.6:
     resolution: {integrity: sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==}
     engines: {node: '>=8'}
@@ -16643,9 +17519,25 @@ packages:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
+  /istanbul-reports@3.1.7:
+    resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
+    engines: {node: '>=8'}
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+    dev: true
+
   /jackspeak@2.2.3:
     resolution: {integrity: sha512-pF0kfjmg8DJLxDrizHoCZGUFz4P4czQ3HyfW4BU0ffebYkzAVlBywp5zaxW/TM+r0sGbmrQdi8EQQVTJFxnGsQ==}
     engines: {node: '>=14'}
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+    dev: true
+
+  /jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
     dependencies:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
@@ -17465,7 +18357,7 @@ packages:
       execa: 5.1.1
       listr2: 3.14.0(enquirer@2.3.6)
       log-symbols: 4.1.0
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       normalize-path: 3.0.0
       please-upgrade-node: 3.2.0
       string-argv: 0.3.1
@@ -17629,9 +18521,16 @@ packages:
       commander: 9.5.0
     dev: true
 
+  /loupe@3.1.2:
+    resolution: {integrity: sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==}
+
   /lru-cache@10.0.1:
     resolution: {integrity: sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==}
     engines: {node: 14 || >=16.14}
+    dev: true
+
+  /lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
     dev: true
 
   /lru-cache@5.1.1:
@@ -17665,11 +18564,24 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
+  /magic-string@0.30.14:
+    resolution: {integrity: sha512-5c99P1WKTed11ZC0HMJOj6CDIue6F8ySu+bJL+85q1zBEIY8IklrJ1eiKC2NDRh3Ct3FcvmJPyQHb9erXMTJNw==}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
+
   /magic-string@0.30.2:
     resolution: {integrity: sha512-lNZdu7pewtq/ZvWUp9Wpf/x7WzMTsR26TWV03BRZrXFsv+BI6dy8RAiKgm1uM/kyR0rCfUcqvOlXKG66KhIGug==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
+
+  /magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+    dependencies:
+      '@babel/parser': 7.26.2
+      '@babel/types': 7.26.0
+      source-map-js: 1.2.0
     dev: true
 
   /make-cancellable-promise@1.3.2:
@@ -18033,6 +18945,11 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     dev: true
 
+  /minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dev: true
+
   /minizlib@2.1.2:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
     engines: {node: '>= 8'}
@@ -18301,6 +19218,9 @@ packages:
 
   /node-releases@2.0.13:
     resolution: {integrity: sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==}
+
+  /node-releases@2.0.18:
+    resolution: {integrity: sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==}
 
   /nodemon@3.1.7:
     resolution: {integrity: sha512-hLj7fuMow6f0lbB0cD14Lz2xNjwsyruH251Pk4t/yIitCFJbmY1myuLlHm/q06aST4jg6EgAh74PIBBrRqpVAQ==}
@@ -18667,6 +19587,10 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  /package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+    dev: true
+
   /pako@0.2.9:
     resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
     dev: true
@@ -18785,6 +19709,14 @@ packages:
       minipass: 7.0.3
     dev: true
 
+  /path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.2
+    dev: true
+
   /path-to-regexp@0.1.7:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
 
@@ -18817,6 +19749,13 @@ packages:
   /pathe@1.1.0:
     resolution: {integrity: sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==}
     dev: true
+
+  /pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  /pathval@2.0.0:
+    resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
+    engines: {node: '>= 14.16'}
 
   /pbkdf2@3.1.2:
     resolution: {integrity: sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==}
@@ -18885,6 +19824,9 @@ packages:
 
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
+
+  /picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
@@ -19009,14 +19951,14 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /postcss-styled-syntax@0.4.0(postcss@8.4.38)(typescript@5.6.2):
+  /postcss-styled-syntax@0.4.0(postcss@8.4.49)(typescript@5.6.2):
     resolution: {integrity: sha512-LvG++K8LtIyX1Q1mNuZVQYmBo+SCwn90cEkMigo4/I0QwXrEiYt8nPeJ5rrI5Uuh+5w7hRfPyJKlvQdhVZBhUg==}
     peerDependencies:
       postcss: ^8.4.21
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.2)
       estree-walker: 2.0.2
-      postcss: 8.4.38
+      postcss: 8.4.49
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -19041,6 +19983,14 @@ packages:
       nanoid: 3.3.7
       picocolors: 1.0.0
       source-map-js: 1.2.0
+
+  /postcss@8.4.49:
+    resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.7
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   /prebuild-install@7.1.1:
     resolution: {integrity: sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==}
@@ -20335,6 +21285,34 @@ packages:
       fsevents: 2.3.3
     dev: true
 
+  /rollup@4.28.1:
+    resolution: {integrity: sha512-61fXYl/qNVinKmGSTHAZ6Yy8I3YIJC/r2m9feHo6SwVAVcLT5MPwOUFe7EuURA/4m0NR8lXG4BBXuo/IZEsjMg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+    dependencies:
+      '@types/estree': 1.0.6
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.28.1
+      '@rollup/rollup-android-arm64': 4.28.1
+      '@rollup/rollup-darwin-arm64': 4.28.1
+      '@rollup/rollup-darwin-x64': 4.28.1
+      '@rollup/rollup-freebsd-arm64': 4.28.1
+      '@rollup/rollup-freebsd-x64': 4.28.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.28.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.28.1
+      '@rollup/rollup-linux-arm64-gnu': 4.28.1
+      '@rollup/rollup-linux-arm64-musl': 4.28.1
+      '@rollup/rollup-linux-loongarch64-gnu': 4.28.1
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.28.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.28.1
+      '@rollup/rollup-linux-s390x-gnu': 4.28.1
+      '@rollup/rollup-linux-x64-gnu': 4.28.1
+      '@rollup/rollup-linux-x64-musl': 4.28.1
+      '@rollup/rollup-win32-arm64-msvc': 4.28.1
+      '@rollup/rollup-win32-ia32-msvc': 4.28.1
+      '@rollup/rollup-win32-x64-msvc': 4.28.1
+      fsevents: 2.3.3
+
   /rope-sequence@1.3.4:
     resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
     dev: false
@@ -20610,6 +21588,9 @@ packages:
       object-inspect: 1.13.2
     dev: false
 
+  /siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -20745,6 +21726,10 @@ packages:
     resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
     engines: {node: '>=0.10.0'}
 
+  /source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   /source-map-resolve@0.5.3:
     resolution: {integrity: sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==}
     deprecated: See https://github.com/lydell/source-map-resolve#deprecated
@@ -20840,6 +21825,9 @@ packages:
     dependencies:
       escape-string-regexp: 2.0.0
 
+  /stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   /standardized-audio-context@25.3.63:
     resolution: {integrity: sha512-6hB0GbZOx3Q0npxg1QMZTN/jioom3jMkVcr3EqZbwywytqykevtuCgZuaUJqntTzv7q2mEW9KsCUtFCpbWpCkw==}
     dependencies:
@@ -20859,6 +21847,9 @@ packages:
   /statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
+
+  /std-env@3.8.0:
+    resolution: {integrity: sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==}
 
   /store2@2.14.2:
     resolution: {integrity: sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==}
@@ -21412,6 +22403,15 @@ packages:
       glob: 7.2.3
       minimatch: 3.1.2
 
+  /test-exclude@7.0.1:
+    resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 10.4.5
+      minimatch: 9.0.5
+    dev: true
+
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
@@ -21449,6 +22449,24 @@ packages:
 
   /tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
+
+  /tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  /tinyexec@0.3.1:
+    resolution: {integrity: sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==}
+
+  /tinypool@1.0.2:
+    resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  /tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  /tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   /tippy.js@6.3.7:
     resolution: {integrity: sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==}
@@ -21605,7 +22623,7 @@ packages:
       typescript: 5.6.2
     dev: true
 
-  /ts-jest@29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2):
+  /ts-jest@29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.18.17)(jest@29.6.2)(typescript@5.6.2):
     resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -21626,7 +22644,7 @@ packages:
       esbuild:
         optional: true
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@jest/types': 29.6.1
       bs-logger: 0.2.6
       esbuild: 0.18.17
@@ -21640,7 +22658,7 @@ packages:
       typescript: 5.6.2
       yargs-parser: 21.1.1
 
-  /ts-jest@29.1.1(@babel/core@7.22.9)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2):
+  /ts-jest@29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2):
     resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -21661,7 +22679,7 @@ packages:
       esbuild:
         optional: true
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@jest/types': 29.6.1
       bs-logger: 0.2.6
       esbuild: 0.21.2
@@ -21965,6 +22983,16 @@ packages:
       escalade: 3.1.1
       picocolors: 1.0.0
 
+  /update-browserslist-db@1.1.1(browserslist@4.24.2):
+    resolution: {integrity: sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+    dependencies:
+      browserslist: 4.24.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   /uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
@@ -22130,7 +23158,7 @@ packages:
     resolution: {integrity: sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==}
     engines: {node: '>=10.12.0'}
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.18
+      '@jridgewell/trace-mapping': 0.3.25
       '@types/istanbul-lib-coverage': 2.0.4
       convert-source-map: 1.9.0
 
@@ -22212,6 +23240,27 @@ packages:
       teex: 1.0.1
     dev: false
 
+  /vite-node@2.1.8(@types/node@20.16.0):
+    resolution: {integrity: sha512-uPAwSr57kYjAUux+8E2j0q0Fxpn8M9VoyfGiRI8Kfktz9NcYMCenwY5RnZxnF1WTu3TGiYipirIzacLL3VVGFg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.7
+      es-module-lexer: 1.5.4
+      pathe: 1.1.2
+      vite: 5.4.11(@types/node@20.16.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   /vite@4.5.2(@types/node@20.16.0):
     resolution: {integrity: sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -22247,6 +23296,101 @@ packages:
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
+
+  /vite@5.4.11(@types/node@20.16.0):
+    resolution: {integrity: sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 20.16.0
+      esbuild: 0.21.5
+      postcss: 8.4.49
+      rollup: 4.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  /vitest@2.1.8(@types/node@20.16.0):
+    resolution: {integrity: sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.8
+      '@vitest/ui': 2.1.8
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/node': 20.16.0
+      '@vitest/expect': 2.1.8
+      '@vitest/mocker': 2.1.8(vite@5.4.11)
+      '@vitest/pretty-format': 2.1.8
+      '@vitest/runner': 2.1.8
+      '@vitest/snapshot': 2.1.8
+      '@vitest/spy': 2.1.8
+      '@vitest/utils': 2.1.8
+      chai: 5.1.2
+      debug: 4.3.7
+      expect-type: 1.1.0
+      magic-string: 0.30.14
+      pathe: 1.1.2
+      std-env: 3.8.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.1
+      tinypool: 1.0.2
+      tinyrainbow: 1.2.0
+      vite: 5.4.11(@types/node@20.16.0)
+      vite-node: 2.1.8(@types/node@20.16.0)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   /vm-browserify@1.1.2:
     resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}
@@ -22480,6 +23624,14 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
+
+  /why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   /wide-align@1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}

--- a/vxsuite.code-workspace
+++ b/vxsuite.code-workspace
@@ -197,6 +197,10 @@
       "path": "libs/test-utils"
     },
     {
+      "name": "libs/test-utils-vitest",
+      "path": "libs/test-utils-vitest"
+    },
+    {
       "name": "libs/types",
       "path": "libs/types"
     },


### PR DESCRIPTION


## Overview

Copies all files from libs/test-utils that rely on `jest` and migrates them to use `vitest` instead. This will enable any packages that currently use libs/test-utils to be migrated to vitest by using the vitest version of these utils. Eventually, when we're done migrating and there are no more jest tests, we can move these back into libs/test-utils, replacing the jest versions.

## Demo Video or Screenshot
N/A

## Testing Plan
Updated automated tests. Also used some of these when migrating libs/mark-flow-ui to vitest. There may be some more tweaks needed as we use them further.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
