### PR TITLE
test(logging): fix local test running

### DIFF
--- a/libs/logging/package.json
+++ b/libs/logging/package.json
@@ -22,8 +22,8 @@
     "lint": "pnpm type-check && eslint .",
     "lint:fix": "pnpm type-check && eslint . --fix",
     "test": "is-ci test:ci test:watch",
-    "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage",
+    "test:watch": "TZ=UTC jest --watch",
+    "test:coverage": "TZ=UTC jest --coverage",
     "test:ci": "pnpm build && pnpm test:coverage --reporters=default --reporters=jest-junit --maxWorkers=6 && pnpm build:generate-typescript-types --check && pnpm build:generate-rust-types --check",
     "pre-commit": "lint-staged"
   },


### PR DESCRIPTION
The tests were assuming UTC timezone, so running in any other timezone fails. CI runs in UTC by default, so that was going fine.
