### PR TITLE
feat(logging): allow configuring the mock function used

### DIFF
--- a/apps/admin/backend/test/app.ts
+++ b/apps/admin/backend/test/app.ts
@@ -132,9 +132,10 @@ export function buildMockLogger(
   auth: DippedSmartCardAuthApi,
   workspace: Workspace
 ): Logger {
-  return mockLogger(LogSource.VxAdminService, () =>
-    getUserRole(auth, workspace)
-  );
+  return mockLogger({
+    source: LogSource.VxAdminService,
+    getCurrentRole: () => getUserRole(auth, workspace),
+  });
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types

--- a/apps/central-scan/backend/test/helpers/setup_app.ts
+++ b/apps/central-scan/backend/test/helpers/setup_app.ts
@@ -27,9 +27,10 @@ export function buildMockLogger(
   auth: DippedSmartCardAuthApi,
   workspace: Workspace
 ): Logger {
-  return mockLogger(LogSource.VxCentralScanService, () =>
-    getUserRole(auth, workspace)
-  );
+  return mockLogger({
+    source: LogSource.VxCentralScanService,
+    getCurrentRole: () => getUserRole(auth, workspace),
+  });
 }
 
 export async function withApp(

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -8,8 +8,8 @@ import { Buffer } from 'node:buffer';
 import { dirSync } from 'tmp';
 import {
   LogEventId,
-  Logger,
   mockBaseLogger,
+  MockLogger,
   mockLogger,
 } from '@votingworks/logging';
 import {
@@ -98,7 +98,7 @@ jest.mock('node-hid');
 let driver: MockPaperHandlerDriver;
 let workspace: Workspace;
 let machine: PaperHandlerStateMachine;
-let logger: Logger;
+let logger: MockLogger;
 let patConnectionStatusReader: PatConnectionStatusReaderInterface;
 let auth: InsertedSmartCardAuthApi;
 let ballotPdfData: Buffer;

--- a/apps/mark-scan/backend/src/pat-input/connection_status_reader.test.ts
+++ b/apps/mark-scan/backend/src/pat-input/connection_status_reader.test.ts
@@ -1,4 +1,8 @@
-import { LogEventId, BaseLogger, mockBaseLogger } from '@votingworks/logging';
+import {
+  LogEventId,
+  mockBaseLogger,
+  MockBaseLogger,
+} from '@votingworks/logging';
 import tmp from 'tmp';
 import * as fs from 'node:fs/promises';
 import { Buffer } from 'node:buffer';
@@ -8,7 +12,7 @@ import { FAI_100_STATUS_FILENAME } from './constants';
 const ASCII_ZERO = 48;
 const ASCII_ONE = 49;
 
-let logger: BaseLogger;
+let logger: MockBaseLogger;
 let mockWorkspaceDir: tmp.DirResult;
 // Replaces /sys/class/gpio
 let mockGpioDir: tmp.DirResult;

--- a/apps/mark-scan/backend/src/pat-input/mock_connection_status_reader.test.ts
+++ b/apps/mark-scan/backend/src/pat-input/mock_connection_status_reader.test.ts
@@ -1,7 +1,7 @@
-import { BaseLogger, mockBaseLogger } from '@votingworks/logging';
+import { MockBaseLogger, mockBaseLogger } from '@votingworks/logging';
 import { MockPatConnectionStatusReader } from './mock_connection_status_reader';
 
-let logger: BaseLogger;
+let logger: MockBaseLogger;
 let mockReader: MockPatConnectionStatusReader;
 
 beforeEach(() => {

--- a/apps/mark-scan/backend/src/util/hardware.test.ts
+++ b/apps/mark-scan/backend/src/util/hardware.test.ts
@@ -5,7 +5,7 @@ import {
 import tmp from 'tmp';
 import fs from 'node:fs';
 import { Buffer } from 'node:buffer';
-import { LogEventId, Logger, mockLogger } from '@votingworks/logging';
+import { LogEventId, MockLogger, mockLogger } from '@votingworks/logging';
 import { join } from 'node:path';
 import {
   getMarkScanBmdModel,
@@ -24,7 +24,7 @@ jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
 let workspaceDir: tmp.DirResult;
 const MOCK_PID = 12345;
 let processKillSpy: jest.SpyInstance;
-let logger: Logger;
+let logger: MockLogger;
 let tmpFile: tmp.FileResult;
 
 beforeEach(() => {

--- a/apps/mark-scan/backend/test/app_helpers.ts
+++ b/apps/mark-scan/backend/test/app_helpers.ts
@@ -45,9 +45,10 @@ export function buildMockLogger(
   auth: InsertedSmartCardAuthApi,
   workspace: Workspace
 ): Logger {
-  return mockLogger(LogSource.VxMarkScanBackend, () =>
-    getUserRole(auth, workspace)
-  );
+  return mockLogger({
+    source: LogSource.VxMarkScanBackend,
+    getCurrentRole: () => getUserRole(auth, workspace),
+  });
 }
 
 export async function getMockStateMachine(

--- a/apps/mark/backend/test/app_helpers.ts
+++ b/apps/mark/backend/test/app_helpers.ts
@@ -49,9 +49,10 @@ export function buildMockLogger(
   auth: InsertedSmartCardAuthApi,
   workspace: Workspace
 ): Logger {
-  return mockLogger(LogSource.VxMarkBackend, () =>
-    getUserRole(auth, workspace)
-  );
+  return mockLogger({
+    source: LogSource.VxMarkBackend,
+    getCurrentRole: () => getUserRole(auth, workspace),
+  });
 }
 
 export function createApp(): MockAppContents {

--- a/apps/scan/backend/test/helpers/shared_helpers.ts
+++ b/apps/scan/backend/test/helpers/shared_helpers.ts
@@ -140,9 +140,10 @@ export function buildMockLogger(
   auth: InsertedSmartCardAuthApi,
   workspace: Workspace
 ): Logger {
-  return mockLogger(LogSource.VxScanBackend, () =>
-    getUserRole(auth, workspace)
-  );
+  return mockLogger({
+    source: LogSource.VxScanBackend,
+    getCurrentRole: () => getUserRole(auth, workspace),
+  });
 }
 
 export function createPrecinctScannerStateMachineMock(): jest.Mocked<PrecinctScannerStateMachine> {

--- a/libs/auth/src/dipped_smart_card_auth.test.ts
+++ b/libs/auth/src/dipped_smart_card_auth.test.ts
@@ -9,6 +9,7 @@ import {
   LogDispositionStandardTypes,
   LogEventId,
   BaseLogger,
+  MockBaseLogger,
 } from '@votingworks/logging';
 import {
   mockElectionManagerUser,
@@ -57,7 +58,7 @@ const pin = '123456';
 const wrongPin = '654321';
 
 let mockCard: MockCard;
-let mockLogger: BaseLogger;
+let mockLogger: MockBaseLogger;
 let mockTime: DateTime;
 
 beforeEach(() => {

--- a/libs/auth/src/inserted_smart_card_auth.test.ts
+++ b/libs/auth/src/inserted_smart_card_auth.test.ts
@@ -10,6 +10,7 @@ import {
   LogDispositionStandardTypes,
   LogEventId,
   BaseLogger,
+  MockBaseLogger,
 } from '@votingworks/logging';
 import {
   mockCardlessVoterUser,
@@ -55,7 +56,7 @@ const pin = '123456';
 const wrongPin = '654321';
 
 let mockCard: MockCard;
-let mockLogger: BaseLogger;
+let mockLogger: MockBaseLogger;
 let mockTime: DateTime;
 
 beforeEach(() => {

--- a/libs/backend/src/system_call/api.test.ts
+++ b/libs/backend/src/system_call/api.test.ts
@@ -3,7 +3,7 @@
 
 import { MockUsbDrive, createMockUsbDrive } from '@votingworks/usb-drive';
 import { mockOf } from '@votingworks/test-utils';
-import { LogEventId, Logger, mockLogger } from '@votingworks/logging';
+import { LogEventId, MockLogger, mockLogger } from '@votingworks/logging';
 import { SystemCallApi, createSystemCallApi } from './api';
 import { execFile } from '../exec';
 import { getAudioInfo } from './get_audio_info';
@@ -23,7 +23,7 @@ jest.mock('./get_audio_info');
 const execMock = mockOf(execFile);
 
 let mockUsbDrive: MockUsbDrive;
-let logger: Logger;
+let logger: MockLogger;
 let api: SystemCallApi;
 
 beforeEach(() => {

--- a/libs/backend/src/system_call/export_logs_to_usb.test.ts
+++ b/libs/backend/src/system_call/export_logs_to_usb.test.ts
@@ -4,7 +4,7 @@ import { createMockUsbDrive } from '@votingworks/usb-drive';
 import * as fs from 'node:fs/promises';
 import { Stats, createReadStream, createWriteStream } from 'node:fs';
 import { mockOf } from '@votingworks/test-utils';
-import { LogEventId, Logger, mockLogger } from '@votingworks/logging';
+import { LogEventId, MockLogger, mockLogger } from '@votingworks/logging';
 import { tmpNameSync } from 'tmp';
 import { PassThrough } from 'node:stream';
 import { execFile } from '../exec';
@@ -34,7 +34,7 @@ jest.mock('../exec', (): typeof import('../exec') => ({
 
 const execFileMock = mockOf(execFile);
 
-let logger: Logger;
+let logger: MockLogger;
 
 beforeEach(() => {
   logger = mockLogger();

--- a/libs/logging/package.json
+++ b/libs/logging/package.json
@@ -43,6 +43,7 @@
     "@types/kiosk-browser": "workspace:*",
     "@types/node": "20.16.0",
     "@types/yargs": "17.0.22",
+    "@vitest/coverage-istanbul": "^2.1.8",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
     "esbuild": "0.21.2",
@@ -55,7 +56,8 @@
     "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "11.0.0",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "29.1.1"
+    "ts-jest": "29.1.1",
+    "vitest": "^2.1.8"
   },
   "packageManager": "pnpm@8.15.5"
 }

--- a/libs/logging/src/export.test.ts
+++ b/libs/logging/src/export.test.ts
@@ -2,14 +2,7 @@ import { assert, iter } from '@votingworks/basics';
 import { EventLogging, safeParseJson } from '@votingworks/types';
 import { createReadStream } from 'node:fs';
 import { join } from 'node:path';
-import {
-  LogEventId,
-  LogEventType,
-  LogLine,
-  LogSource,
-  mockLogger,
-  mockLoggerWithRoleAndSource,
-} from '.';
+import { LogEventId, LogEventType, LogLine, LogSource, mockLogger } from '.';
 import { buildCdfLog, filterErrorLogs } from './export';
 
 jest.useFakeTimers().setSystemTime(new Date('2020-07-24T00:00:00.000Z'));
@@ -40,7 +33,7 @@ describe('filterErrorLogs', () => {
 
 describe('buildCdfLog', () => {
   test('builds device and election info properly', async () => {
-    const logger = mockLogger(LogSource.VxAdminFrontend);
+    const logger = mockLogger({ source: LogSource.VxAdminFrontend });
     const cdfLogContent = buildCdfLog(
       logger,
       iter(['']).async(),
@@ -68,10 +61,10 @@ describe('buildCdfLog', () => {
   });
 
   test('converts basic log as expected', async () => {
-    const logger = mockLoggerWithRoleAndSource(
-      LogSource.VxAdminFrontend,
-      'election_manager'
-    );
+    const logger = mockLogger({
+      source: LogSource.VxAdminFrontend,
+      role: 'election_manager',
+    });
     const logSpy = jest.spyOn(logger, 'log').mockResolvedValue();
     const cdfLogContent = buildCdfLog(
       logger,
@@ -115,7 +108,7 @@ describe('buildCdfLog', () => {
   });
 
   test('log with unspecified disposition as expected', async () => {
-    const logger = mockLogger(LogSource.VxAdminFrontend);
+    const logger = mockLogger({ source: LogSource.VxAdminFrontend });
     const cdfLogContent = buildCdfLog(
       logger,
       iter([
@@ -141,7 +134,7 @@ describe('buildCdfLog', () => {
   });
 
   test('converts log with custom disposition and extra details as expected', async () => {
-    const logger = mockLogger(LogSource.VxAdminFrontend);
+    const logger = mockLogger({ source: LogSource.VxAdminFrontend });
     const cdfLogContent = buildCdfLog(
       logger,
       iter([
@@ -176,10 +169,10 @@ describe('buildCdfLog', () => {
   });
 
   test('malformed logs are logged', async () => {
-    const logger = mockLoggerWithRoleAndSource(
-      LogSource.VxAdminFrontend,
-      'election_manager'
-    );
+    const logger = mockLogger({
+      source: LogSource.VxAdminFrontend,
+      role: 'election_manager',
+    });
     const logSpy = jest.spyOn(logger, 'log').mockResolvedValue();
     const missingTimeLogLine: LogLine = {
       source: LogSource.System,
@@ -246,7 +239,7 @@ describe('buildCdfLog', () => {
     const logFile = createReadStream(
       join(__dirname, '../fixtures/samplelog.log')
     );
-    const logger = mockLogger(LogSource.VxAdminFrontend);
+    const logger = mockLogger({ source: LogSource.VxAdminFrontend });
     const cdfLogContent = buildCdfLog(logger, logFile, '1234', 'codeversion');
     const cdfLogResult = safeParseJson(
       await iter(cdfLogContent).toString(),

--- a/libs/logging/src/logger.test.ts
+++ b/libs/logging/src/logger.test.ts
@@ -9,7 +9,7 @@ import {
 } from '.';
 
 test('logger can log with passed user role', async () => {
-  console.log = jest.fn();
+  jest.spyOn(console, 'log').mockReturnValue();
   const getUserRole = jest.fn();
 
   const logger = new Logger(LogSource.VxMarkBackend, getUserRole);
@@ -43,7 +43,7 @@ test('logger can log with passed user role', async () => {
 });
 
 test('Logger.from', async () => {
-  console.log = jest.fn();
+  jest.spyOn(console, 'log').mockReturnValue();
   const baseLogger = new BaseLogger(LogSource.VxCentralScanService);
   const logSpy = jest.spyOn(baseLogger, 'log');
   const logger = Logger.from(baseLogger, () => Promise.resolve('unknown'));
@@ -61,7 +61,7 @@ test('Logger.from', async () => {
 });
 
 test('can provide fallback user', async () => {
-  console.log = jest.fn();
+  jest.spyOn(console, 'log').mockReturnValue();
   const baseLogger = new BaseLogger(LogSource.VxCentralScanService);
   const logSpy = jest.spyOn(baseLogger, 'log');
   const logger = Logger.from(baseLogger, () => Promise.resolve('unknown'));

--- a/libs/logging/src/test_utils.test.ts
+++ b/libs/logging/src/test_utils.test.ts
@@ -1,11 +1,7 @@
 import { typedAs } from '@votingworks/basics';
 import { LogEventType, LogLine, LogSource } from '.';
 import { LogEventId } from './log_event_ids';
-import {
-  mockBaseLogger,
-  mockLogger,
-  mockLoggerWithRoleAndSource,
-} from './test_utils';
+import { mockBaseLogger, mockLogger } from './test_utils';
 
 test('mockBaseLogger returns a logger with a spy on logger.log', async () => {
   const logger = mockBaseLogger();
@@ -14,7 +10,7 @@ test('mockBaseLogger returns a logger with a spy on logger.log', async () => {
 });
 
 test('mockLogger returns a logger that can print debug logs', async () => {
-  const logger = mockLogger(LogSource.System);
+  const logger = mockLogger({ source: LogSource.System });
   const debug = jest.fn();
   await logger.log(LogEventId.MachineBootInit, 'system', undefined, debug);
   expect(debug).toHaveBeenCalledWith(
@@ -30,9 +26,10 @@ test('mockLogger returns a logger that can print debug logs', async () => {
 });
 
 test('mockLogger', async () => {
-  const logger = mockLogger(LogSource.VxAdminService, () =>
-    Promise.resolve('election_manager')
-  );
+  const logger = mockLogger({
+    source: LogSource.VxAdminService,
+    role: 'election_manager',
+  });
 
   await logger.logAsCurrentRole(LogEventId.MachineBootInit);
   expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
@@ -74,33 +71,4 @@ test('mockLogger with defaults', async () => {
     'unknown'
   );
   expect(logger.getSource()).toEqual(LogSource.System);
-});
-
-test('mockLoggerWithRoleAndSource', async () => {
-  const logger = mockLoggerWithRoleAndSource(
-    LogSource.VxAdminService,
-    'election_manager'
-  );
-  await logger.logAsCurrentRole(LogEventId.MachineBootInit);
-  expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
-    LogEventId.MachineBootInit
-  );
-  expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.MachineBootInit,
-    'election_manager'
-  );
-  expect(logger.getSource()).toEqual(LogSource.VxAdminService);
-});
-
-test('mockLoggerWithRoleAndSource defaults to sysadmin', async () => {
-  const logger = mockLoggerWithRoleAndSource(LogSource.VxCentralScanFrontend);
-  await logger.logAsCurrentRole(LogEventId.MachineBootInit);
-  expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
-    LogEventId.MachineBootInit
-  );
-  expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.MachineBootInit,
-    'system_administrator'
-  );
-  expect(logger.getSource()).toEqual(LogSource.VxCentralScanFrontend);
 });

--- a/libs/logging/src/test_utils.ts
+++ b/libs/logging/src/test_utils.ts
@@ -4,19 +4,58 @@ import { LogDispositionStandardTypes, LogLine, LoggingUserRole } from './types';
 import { BaseLogger } from './base_logger';
 import { getDetailsForEventId } from './log_event_ids';
 
-export function mockBaseLogger(
-  logSource: LogSource = LogSource.System
-): BaseLogger {
+export function mockBaseLogger({
+  logSource = LogSource.System,
+}: {
+  logSource?: LogSource;
+} = {}): BaseLogger {
   const logger = new BaseLogger(logSource);
   logger.log = jest.fn().mockResolvedValue(undefined);
   return logger;
 }
 
-export function mockLogger(
-  source: LogSource = LogSource.System,
-  getCurrentRole: () => Promise<LoggingUserRole> = () =>
-    Promise.resolve('unknown')
-): Logger {
+/**
+ * Create a mock logger for testing with a source of `LogSource.System` and role
+ * of `unknown`.
+ */
+export function mockLogger(): Logger;
+
+/**
+ * Create a mock logger for testing with a specific source and a role of
+ * `unknown`.
+ */
+export function mockLogger(options: { source: LogSource }): Logger;
+
+/**
+ * Create a mock logger for testing with a specific role and a source of
+ * `LogSource.System` if not provided.
+ */
+export function mockLogger(options: {
+  source?: LogSource;
+  role: LoggingUserRole;
+}): Logger;
+
+/**
+ * Create a mock logger for testing with a function to get the current role each
+ * time a log is made and a source of `LogSource.System` if not provided.
+ */
+export function mockLogger(options: {
+  source?: LogSource;
+  getCurrentRole: () => Promise<LoggingUserRole>;
+}): Logger;
+
+/**
+ * Create a mock logger for testing.
+ */
+export function mockLogger({
+  source = LogSource.System,
+  role = 'unknown',
+  getCurrentRole = () => Promise.resolve(role),
+}: {
+  source?: LogSource;
+  role?: LoggingUserRole;
+  getCurrentRole?: () => Promise<LoggingUserRole>;
+} = {}): Logger {
   const logger = new Logger(source, getCurrentRole);
 
   // eslint-disable-next-line @typescript-eslint/require-await
@@ -47,11 +86,4 @@ export function mockLogger(
       : logger.log(eventId, await getCurrentRole())
   );
   return logger;
-}
-
-export function mockLoggerWithRoleAndSource(
-  source: LogSource,
-  role: LoggingUserRole = 'system_administrator'
-): Logger {
-  return mockLogger(source, () => Promise.resolve(role));
 }

--- a/libs/logging/src/test_utils.ts
+++ b/libs/logging/src/test_utils.ts
@@ -1,48 +1,87 @@
+import type { Mocked, vi } from 'vitest';
 import { Logger } from './logger';
 import { LogSource } from './base_types/log_source';
 import { LogDispositionStandardTypes, LogLine, LoggingUserRole } from './types';
 import { BaseLogger } from './base_logger';
 import { getDetailsForEventId } from './log_event_ids';
 
+export interface MockBaseLogger<T = typeof jest.fn> extends BaseLogger {
+  log: T extends typeof jest.fn
+    ? jest.MockedFunction<BaseLogger['log']>
+    : T extends typeof vi.fn
+    ? Mocked<BaseLogger['log']>
+    : never;
+}
+
+export function mockBaseLogger(): MockBaseLogger;
+export function mockBaseLogger(options: {
+  logSource?: LogSource;
+  fn: typeof jest.fn;
+}): MockBaseLogger<typeof jest.fn>;
+export function mockBaseLogger(options: {
+  logSource?: LogSource;
+  fn: typeof vi.fn;
+}): MockBaseLogger<typeof vi.fn>;
 export function mockBaseLogger({
   logSource = LogSource.System,
+  fn = jest.fn,
 }: {
   logSource?: LogSource;
-} = {}): BaseLogger {
+  fn?: typeof jest.fn | typeof vi.fn;
+} = {}): MockBaseLogger<typeof jest.fn> | MockBaseLogger<typeof vi.fn> {
   const logger = new BaseLogger(logSource);
-  logger.log = jest.fn().mockResolvedValue(undefined);
+  logger.log = (fn as typeof jest.fn)().mockResolvedValue(undefined);
   return logger;
+}
+
+export interface MockLogger<T = typeof jest.fn> extends Logger {
+  log: T extends typeof jest.fn
+    ? jest.MockedFunction<Logger['log']>
+    : T extends typeof vi.fn
+    ? Mocked<Logger['log']>
+    : never;
+  logAsCurrentRole: T extends typeof jest.fn
+    ? jest.MockedFunction<Logger['logAsCurrentRole']>
+    : T extends typeof vi.fn
+    ? Mocked<Logger['logAsCurrentRole']>
+    : never;
 }
 
 /**
  * Create a mock logger for testing with a source of `LogSource.System` and role
  * of `unknown`.
  */
-export function mockLogger(): Logger;
+export function mockLogger(): MockLogger;
 
 /**
- * Create a mock logger for testing with a specific source and a role of
- * `unknown`.
+ * Create a mock logger for testing with a source (default `LogSource.System`)
+ * and a role of `unknown`.
  */
-export function mockLogger(options: { source: LogSource }): Logger;
+export function mockLogger(options: { source?: LogSource }): MockLogger;
 
 /**
- * Create a mock logger for testing with a specific role and a source of
- * `LogSource.System` if not provided.
+ * Create a mock logger for testing with a role and a source (default
+ * `LogSource.System`).
  */
-export function mockLogger(options: {
+export function mockLogger<
+  T extends typeof jest.fn | typeof vi.fn = typeof jest.fn,
+>(options: {
   source?: LogSource;
   role: LoggingUserRole;
-}): Logger;
+  fn?: T;
+}): MockLogger<T>;
 
 /**
  * Create a mock logger for testing with a function to get the current role each
  * time a log is made and a source of `LogSource.System` if not provided.
  */
-export function mockLogger(options: {
+export function mockLogger<
+  T extends typeof jest.fn | typeof vi.fn = typeof jest.fn,
+>(options: {
   source?: LogSource;
   getCurrentRole: () => Promise<LoggingUserRole>;
-}): Logger;
+  fn?: T;
+}): MockLogger<T>;
 
 /**
  * Create a mock logger for testing.
@@ -51,36 +90,40 @@ export function mockLogger({
   source = LogSource.System,
   role = 'unknown',
   getCurrentRole = () => Promise.resolve(role),
+  fn = jest.fn,
 }: {
   source?: LogSource;
   role?: LoggingUserRole;
   getCurrentRole?: () => Promise<LoggingUserRole>;
-} = {}): Logger {
+  fn?: typeof jest.fn | typeof vi.fn;
+} = {}): MockLogger<typeof jest.fn> | MockLogger<typeof vi.fn> {
   const logger = new Logger(source, getCurrentRole);
 
-  // eslint-disable-next-line @typescript-eslint/require-await
-  logger.log = jest.fn(async (eventId, user, logData, outerDebug) => {
-    if (outerDebug) {
-      const eventSpecificDetails = getDetailsForEventId(eventId);
-      /* istanbul ignore next */
-      const {
-        message = eventSpecificDetails.defaultMessage,
-        disposition = LogDispositionStandardTypes.NotApplicable,
-        ...additionalData
-      } = logData ?? {};
-      const logLine: LogLine = {
-        source,
-        eventId,
-        eventType: eventSpecificDetails.eventType,
-        user,
-        message,
-        disposition,
-        ...additionalData,
-      };
-      outerDebug(logLine);
+  logger.log = (fn as typeof jest.fn)(
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async (eventId, user, logData, outerDebug) => {
+      if (outerDebug) {
+        const eventSpecificDetails = getDetailsForEventId(eventId);
+        /* istanbul ignore next */
+        const {
+          message = eventSpecificDetails.defaultMessage,
+          disposition = LogDispositionStandardTypes.NotApplicable,
+          ...additionalData
+        } = logData ?? {};
+        const logLine: LogLine = {
+          source,
+          eventId,
+          eventType: eventSpecificDetails.eventType,
+          user,
+          message,
+          disposition,
+          ...additionalData,
+        };
+        outerDebug(logLine);
+      }
     }
-  });
-  logger.logAsCurrentRole = jest.fn(async (eventId, logData) =>
+  );
+  logger.logAsCurrentRole = (fn as typeof jest.fn)(async (eventId, logData) =>
     logData
       ? logger.log(eventId, await getCurrentRole(), logData)
       : logger.log(eventId, await getCurrentRole())

--- a/libs/usb-drive/src/usb_drive.test.ts
+++ b/libs/usb-drive/src/usb_drive.test.ts
@@ -2,12 +2,7 @@ import { promises as fs, existsSync, rmSync } from 'node:fs';
 import { deferred } from '@votingworks/basics';
 import { backendWaitFor } from '@votingworks/test-utils';
 import { join } from 'node:path';
-import {
-  LogEventId,
-  LogSource,
-  mockLogger,
-  mockLoggerWithRoleAndSource,
-} from '@votingworks/logging';
+import { LogEventId, LogSource, mockLogger } from '@votingworks/logging';
 import {
   BooleanEnvironmentVariableName,
   getFeatureFlagMock,
@@ -106,10 +101,10 @@ async function confirmLockReleased(usbDrive: UsbDrive) {
 
 describe('status', () => {
   test('no drive', async () => {
-    const logger = mockLoggerWithRoleAndSource(
-      LogSource.VxAdminFrontend,
-      'election_manager'
-    );
+    const logger = mockLogger({
+      source: LogSource.VxAdminFrontend,
+      role: 'election_manager',
+    });
     const usbDrive = detectUsbDrive(logger);
 
     readdirMock.mockResolvedValueOnce([]);
@@ -416,10 +411,10 @@ describe('eject', () => {
   });
 
   test('mounted', async () => {
-    const logger = mockLoggerWithRoleAndSource(
-      LogSource.VxAdminFrontend,
-      'election_manager'
-    );
+    const logger = mockLogger({
+      source: LogSource.VxAdminFrontend,
+      role: 'election_manager',
+    });
     const usbDrive = detectUsbDrive(logger);
 
     mockBlockDeviceOnce({ mountpoint: '/media/usb-drive-sdb1' });
@@ -456,10 +451,10 @@ describe('eject', () => {
   });
 
   test('fails to eject', async () => {
-    const logger = mockLoggerWithRoleAndSource(
-      LogSource.VxAdminFrontend,
-      'election_manager'
-    );
+    const logger = mockLogger({
+      source: LogSource.VxAdminFrontend,
+      role: 'election_manager',
+    });
     const usbDrive = detectUsbDrive(logger);
 
     mockBlockDeviceOnce({ mountpoint: '/media/usb-drive-sdb1' });
@@ -490,10 +485,10 @@ describe('format', () => {
   });
 
   test('on mounted, previously formatted drive', async () => {
-    const logger = mockLoggerWithRoleAndSource(
-      LogSource.VxAdminFrontend,
-      'system_administrator'
-    );
+    const logger = mockLogger({
+      source: LogSource.VxAdminFrontend,
+      role: 'system_administrator',
+    });
     const usbDrive = detectUsbDrive(logger);
     mockBlockDeviceOnce({ mountpoint: '/media/usb-drive-sdb1' });
     execMock.mockResolvedValueOnce({ stdout: '' }); // unmount
@@ -554,10 +549,10 @@ describe('format', () => {
   });
 
   test('on format failure', async () => {
-    const logger = mockLoggerWithRoleAndSource(
-      LogSource.VxAdminFrontend,
-      'system_administrator'
-    );
+    const logger = mockLogger({
+      source: LogSource.VxAdminFrontend,
+      role: 'system_administrator',
+    });
     const usbDrive = detectUsbDrive(logger);
     mockBlockDeviceOnce({ fstype: 'unknown', mountpoint: null, label: null });
     execMock.mockRejectedValueOnce(new Error('Command: failed')); // format

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4589,6 +4589,9 @@ importers:
       '@types/yargs':
         specifier: 17.0.22
         version: 17.0.22
+      '@vitest/coverage-istanbul':
+        specifier: ^2.1.8
+        version: 2.1.8(vitest@2.1.8)
       '@votingworks/fixtures':
         specifier: workspace:*
         version: link:../fixtures
@@ -4628,6 +4631,9 @@ importers:
       ts-jest:
         specifier: 29.1.1
         version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
 
   libs/mark-flow-ui:
     dependencies:


### PR DESCRIPTION
## Overview

Refs #5725 

Unblocks converting packages that use `@votingworks/logging`'s mock factories.

## Demo Video or Screenshot
```ts
// jest by default
const logger = mockLogger();

// vitest by request
const logger = mockLogger({ fn: vi.fn });
```

## Testing Plan
Converted `libs/db`, which uses `mockBaseLogger`, to use `vi.fn`.
