### PR TITLE
refactor(jest): inline calls to `advanceTimers`

### DIFF
--- a/apps/mark-scan/frontend/src/apimachine_config.test.tsx
+++ b/apps/mark-scan/frontend/src/apimachine_config.test.tsx
@@ -1,8 +1,8 @@
 import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
-import { advanceTimersAndPromises } from '@votingworks/test-utils';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 import { render, screen } from '../test/react_testing_library';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
+import { advanceTimersAndPromises } from '../test/helpers/timers';
 import { App } from './app';
 
 let apiMock: ApiMock;

--- a/apps/mark-scan/frontend/test/helpers/timers.ts
+++ b/apps/mark-scan/frontend/test/helpers/timers.ts
@@ -1,9 +1,12 @@
-import { advanceTimers as advanceTimersBase } from '@votingworks/test-utils';
-import { waitFor } from '../react_testing_library';
+import { act, waitFor } from '../react_testing_library';
 import { AUTH_STATUS_POLLING_INTERVAL_MS_OVERRIDE } from '../../src/constants';
 
 export function advanceTimers(seconds = 0): void {
-  advanceTimersBase(seconds || AUTH_STATUS_POLLING_INTERVAL_MS_OVERRIDE / 1000);
+  act(() => {
+    jest.advanceTimersByTime(
+      seconds * 1000 || AUTH_STATUS_POLLING_INTERVAL_MS_OVERRIDE
+    );
+  });
 }
 
 export async function advanceTimersAndPromises(seconds = 0): Promise<void> {

--- a/apps/mark/frontend/src/pages/admin_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.test.tsx
@@ -8,11 +8,9 @@ import {
 } from '@votingworks/utils';
 import userEvent from '@testing-library/user-event';
 import { mockUsbDriveStatus } from '@votingworks/ui';
-import { screen, within } from '../../test/react_testing_library';
+import { act, screen, within } from '../../test/react_testing_library';
 import { render } from '../../test/test_utils';
 import { election, defaultPrecinctId } from '../../test/helpers/election';
-
-import { advanceTimers } from '../../test/helpers/timers';
 
 import { AdminScreen, AdminScreenProps } from './admin_screen';
 import { mockMachineConfig } from '../../test/helpers/mock_machine_config';
@@ -58,7 +56,9 @@ function renderScreen(props: Partial<AdminScreenProps> = {}) {
 test('renders date and time settings modal', async () => {
   renderScreen();
 
-  advanceTimers();
+  act(() => {
+    jest.advanceTimersByTime(0);
+  });
 
   // We just do a simple happy path test here, since the libs/ui/set_clock unit
   // tests cover full behavior

--- a/apps/mark/frontend/src/pages/diagnostics_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/diagnostics_screen.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from '@testing-library/user-event';
-import { advanceTimersAndPromises, mockOf } from '@votingworks/test-utils';
+import { mockOf } from '@votingworks/test-utils';
 import { MemoryRouter } from 'react-router-dom';
 import { DateTime } from 'luxon';
 import { act } from 'react';
@@ -12,6 +12,7 @@ import {
 import { AccessibleControllerDiagnosticScreen } from './accessible_controller_diagnostic_screen';
 import { ApiProvider } from '../api_provider';
 import { ApiMock, createApiMock } from '../../test/helpers/mock_api_client';
+import { advanceTimersAndPromises } from '../../test/helpers/timers';
 import { ACCESSIBLE_CONTROLLER_POLLING_INTERVAL_MS } from '../api';
 
 export const MOCK_MARKER_INFO: IppMarkerInfo = {

--- a/apps/mark/frontend/test/helpers/timers.ts
+++ b/apps/mark/frontend/test/helpers/timers.ts
@@ -1,9 +1,10 @@
-import { advanceTimers as advanceTimersBase } from '@votingworks/test-utils';
 import { AUTH_STATUS_POLLING_INTERVAL_MS } from '@votingworks/ui';
-import { waitFor } from '../react_testing_library';
+import { act, waitFor } from '../react_testing_library';
 
 export function advanceTimers(seconds = 0): void {
-  advanceTimersBase(seconds || AUTH_STATUS_POLLING_INTERVAL_MS / 1000);
+  act(() => {
+    jest.advanceTimersByTime(seconds * 1000 || AUTH_STATUS_POLLING_INTERVAL_MS);
+  });
 }
 
 export async function advanceTimersAndPromises(seconds = 0): Promise<void> {

--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -1,10 +1,6 @@
 import { singlePrecinctSelectionFor } from '@votingworks/utils';
 import userEvent from '@testing-library/user-event';
-import {
-  advanceTimersAndPromises,
-  mockSystemAdministratorUser,
-  mockOf,
-} from '@votingworks/test-utils';
+import { mockSystemAdministratorUser, mockOf } from '@votingworks/test-utils';
 import {
   electionGeneral,
   electionGeneralDefinition,
@@ -19,7 +15,13 @@ import {
 import { Result, deferred, err, ok } from '@votingworks/basics';
 
 import type { PrecinctScannerConfig } from '@votingworks/scan-backend';
-import { waitFor, screen, within, render } from '../test/react_testing_library';
+import {
+  waitFor,
+  screen,
+  within,
+  render,
+  act,
+} from '../test/react_testing_library';
 import { POLLING_INTERVAL_FOR_SCANNER_STATUS_MS } from './config/globals';
 import { scannerStatus } from '../test/helpers/helpers';
 import {
@@ -41,6 +43,15 @@ jest.setTimeout(20000);
 
 function renderApp(props: Partial<AppProps> = {}) {
   render(<App apiClient={apiMock.mockApiClient} {...props} />);
+}
+
+async function advanceTimersAndPromises(seconds: number) {
+  act(() => {
+    jest.advanceTimersByTime(seconds * 1000);
+  });
+  await waitFor(() => {
+    // Wait for promises
+  });
 }
 
 beforeEach(() => {

--- a/libs/test-utils/src/advance_timers.ts
+++ b/libs/test-utils/src/advance_timers.ts
@@ -1,24 +1,9 @@
-import { act, waitFor } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 
 export const IDLE_TIMEOUT_SECONDS = 5 * 60; // 5 minute
-
-export function advanceTimers(seconds = 0): void {
-  const maxSeconds = IDLE_TIMEOUT_SECONDS;
-  if (seconds > maxSeconds) {
-    throw new Error(`Seconds value should not be greater than ${maxSeconds}`);
-  }
-  act(() => {
-    jest.advanceTimersByTime(seconds * 1000);
-  });
-}
 
 export async function advancePromises(): Promise<void> {
   await waitFor(() => {
     // Wait for promises.
   });
-}
-
-export async function advanceTimersAndPromises(seconds = 0): Promise<void> {
-  advanceTimers(seconds);
-  await advancePromises();
 }

--- a/libs/ui/src/accessible_controllers/accessible_controller_sandbox.test.tsx
+++ b/libs/ui/src/accessible_controllers/accessible_controller_sandbox.test.tsx
@@ -1,8 +1,4 @@
-import {
-  advanceTimers,
-  mockUseAudioControls,
-  mockOf,
-} from '@votingworks/test-utils';
+import { mockUseAudioControls, mockOf } from '@votingworks/test-utils';
 import React from 'react';
 import { assert } from '@votingworks/basics';
 import { simulateKeyPress as baseSimulateKeyPress } from './test_utils';
@@ -57,7 +53,9 @@ function newRenderer() {
 
 function simulateKeyPress(key: string) {
   baseSimulateKeyPress(key);
-  advanceTimers();
+  act(() => {
+    jest.advanceTimersByTime(0);
+  });
 }
 
 type MockIllustrationButton = Keybinding.PAGE_NEXT | Keybinding.PAGE_PREVIOUS;

--- a/libs/ui/src/hooks/use_headphones_plugged_in.test.ts
+++ b/libs/ui/src/hooks/use_headphones_plugged_in.test.ts
@@ -3,15 +3,11 @@ import {
   getFeatureFlagMock,
   isFeatureFlagEnabled,
 } from '@votingworks/utils';
-import {
-  advanceTimers,
-  advanceTimersAndPromises,
-  mockOf,
-} from '@votingworks/test-utils';
+import { mockOf } from '@votingworks/test-utils';
 import { useHeadphonesPluggedIn } from './use_headphones_plugged_in';
 import { AUDIO_INFO_POLLING_INTERVAL_MS } from '../system_call_api';
 import { newTestContext } from '../../test/test_context';
-import { waitFor } from '../../test/react_testing_library';
+import { act, waitFor } from '../../test/react_testing_library';
 
 jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
   ...jest.requireActual('@votingworks/utils'),
@@ -47,11 +43,11 @@ test('uses getAudioInfo system call API', async () => {
   await waitFor(() => expect(result.current).toEqual(false));
 
   mockApiClient.getAudioInfo.mockResolvedValueOnce({ headphonesActive: true });
-  advanceTimers(AUDIO_INFO_POLLING_INTERVAL_MS / 1000);
+  jest.advanceTimersByTime(AUDIO_INFO_POLLING_INTERVAL_MS);
   await waitFor(() => expect(result.current).toEqual(true));
 
   mockApiClient.getAudioInfo.mockResolvedValueOnce({ headphonesActive: false });
-  advanceTimers(AUDIO_INFO_POLLING_INTERVAL_MS / 1000);
+  jest.advanceTimersByTime(AUDIO_INFO_POLLING_INTERVAL_MS);
   await waitFor(() => expect(result.current).toEqual(false));
 
   unmount(); // Prevent any further API polling.
@@ -70,6 +66,11 @@ test('always returns true if headphones restriction flag is disabled', async () 
   await waitFor(() => expect(result.current).toEqual(true));
   expect(result.current).toEqual(true);
 
-  await advanceTimersAndPromises(AUDIO_INFO_POLLING_INTERVAL_MS / 1000);
+  act(() => {
+    jest.advanceTimersByTime(AUDIO_INFO_POLLING_INTERVAL_MS);
+  });
+  await waitFor(() => {
+    // wait for promises
+  });
   expect(mockApiClient.getAudioInfo).not.toHaveBeenCalled();
 });

--- a/libs/ui/src/ui_strings/ui_string_screen_reader.test.tsx
+++ b/libs/ui/src/ui_strings/ui_string_screen_reader.test.tsx
@@ -1,8 +1,4 @@
-import {
-  advanceTimersAndPromises,
-  mockOf,
-  TestLanguageCode,
-} from '@votingworks/test-utils';
+import { mockOf, TestLanguageCode } from '@votingworks/test-utils';
 import userEvent from '@testing-library/user-event';
 import { act, screen, waitFor } from '../../test/react_testing_library';
 import { newTestContext } from '../../test/test_context';
@@ -129,13 +125,23 @@ test('resumes paused audio when user switches focus', async () => {
   const clickTarget = await screen.findByTestId('clickTarget');
 
   act(() => getAudioContext()?.setIsEnabled(true));
-  await advanceTimersAndPromises();
+  act(() => {
+    jest.advanceTimersByTime(0);
+  });
+  await waitFor(() => {
+    // wait for promises
+  });
 
   act(() => getAudioContext()?.setIsPaused(true));
   expect(getAudioContext()?.isPaused).toEqual(true);
 
   act(() => userEvent.click(clickTarget));
-  await advanceTimersAndPromises();
+  act(() => {
+    jest.advanceTimersByTime(0);
+  });
+  await waitFor(() => {
+    // wait for promises
+  });
 
   expect(getAudioContext()?.isPaused).toEqual(false);
 });
@@ -227,7 +233,12 @@ test('is a no-op when audio is disabled', async () => {
   const clickTarget = await screen.findByTestId('clickTarget');
   act(() => getAudioContext()?.setIsEnabled(false));
   act(() => userEvent.click(clickTarget));
-  await advanceTimersAndPromises();
+  act(() => {
+    jest.advanceTimersByTime(0);
+  });
+  await waitFor(() => {
+    // wait for promises
+  });
 
   expect(screen.queryByTestId('mockClips')).not.toBeInTheDocument();
 });
@@ -244,7 +255,12 @@ test('handles missing audio ID data', async () => {
   const clickTarget = await screen.findByTestId('clickTarget');
   act(() => getAudioContext()?.setIsEnabled(true));
   act(() => userEvent.click(clickTarget));
-  await advanceTimersAndPromises();
+  act(() => {
+    jest.advanceTimersByTime(0);
+  });
+  await waitFor(() => {
+    // wait for promises
+  });
 
   expect(screen.queryByTestId('mockClipOutput')).not.toBeInTheDocument();
   screen.getByTestId('clickTarget');
@@ -268,7 +284,12 @@ test('volume control API', async () => {
   const clickTarget = await screen.findByTestId('clickTarget');
   act(() => getAudioContext()?.setIsEnabled(true));
   act(() => userEvent.click(clickTarget));
-  await advanceTimersAndPromises();
+  act(() => {
+    jest.advanceTimersByTime(0);
+  });
+  await waitFor(() => {
+    // wait for promises
+  });
 
   expect(await screen.findByTestId('mockClipOutput')).toHaveTextContent(
     getMockClipOutput({ audioId: 'screen-title', languageCode: ENGLISH })


### PR DESCRIPTION
This way we can replace the `jest` with `vi` at individual callsites as we get to them.