### PR TITLE
feat(auth): allow passing the mock `fn` to use

### DIFF
--- a/apps/central-scan/backend/test/helpers/setup_app.ts
+++ b/apps/central-scan/backend/test/helpers/setup_app.ts
@@ -35,7 +35,7 @@ export function buildMockLogger(
 
 export async function withApp(
   fn: (context: {
-    auth: ReturnType<typeof buildMockDippedSmartCardAuth>;
+    auth: jest.Mocked<DippedSmartCardAuthApi>;
     workspace: Workspace;
     scanner: MockScanner;
     mockUsbDrive: MockUsbDrive;

--- a/apps/mark-scan/frontend/src/apimachine_config.test.tsx
+++ b/apps/mark-scan/frontend/src/apimachine_config.test.tsx
@@ -1,8 +1,8 @@
 import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
-import { advanceTimersAndPromises } from '@votingworks/test-utils';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 import { render, screen } from '../test/react_testing_library';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
+import { advanceTimersAndPromises } from '../test/helpers/timers';
 import { App } from './app';
 
 let apiMock: ApiMock;

--- a/apps/mark-scan/frontend/test/helpers/timers.ts
+++ b/apps/mark-scan/frontend/test/helpers/timers.ts
@@ -1,9 +1,12 @@
-import { advanceTimers as advanceTimersBase } from '@votingworks/test-utils';
-import { waitFor } from '../react_testing_library';
+import { act, waitFor } from '../react_testing_library';
 import { AUTH_STATUS_POLLING_INTERVAL_MS_OVERRIDE } from '../../src/constants';
 
 export function advanceTimers(seconds = 0): void {
-  advanceTimersBase(seconds || AUTH_STATUS_POLLING_INTERVAL_MS_OVERRIDE / 1000);
+  act(() => {
+    jest.advanceTimersByTime(
+      seconds * 1000 || AUTH_STATUS_POLLING_INTERVAL_MS_OVERRIDE
+    );
+  });
 }
 
 export async function advanceTimersAndPromises(seconds = 0): Promise<void> {

--- a/apps/mark/frontend/src/pages/admin_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.test.tsx
@@ -8,11 +8,9 @@ import {
 } from '@votingworks/utils';
 import userEvent from '@testing-library/user-event';
 import { mockUsbDriveStatus } from '@votingworks/ui';
-import { screen, within } from '../../test/react_testing_library';
+import { act, screen, within } from '../../test/react_testing_library';
 import { render } from '../../test/test_utils';
 import { election, defaultPrecinctId } from '../../test/helpers/election';
-
-import { advanceTimers } from '../../test/helpers/timers';
 
 import { AdminScreen, AdminScreenProps } from './admin_screen';
 import { mockMachineConfig } from '../../test/helpers/mock_machine_config';
@@ -58,7 +56,9 @@ function renderScreen(props: Partial<AdminScreenProps> = {}) {
 test('renders date and time settings modal', async () => {
   renderScreen();
 
-  advanceTimers();
+  act(() => {
+    jest.advanceTimersByTime(0);
+  });
 
   // We just do a simple happy path test here, since the libs/ui/set_clock unit
   // tests cover full behavior

--- a/apps/mark/frontend/src/pages/diagnostics_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/diagnostics_screen.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from '@testing-library/user-event';
-import { advanceTimersAndPromises, mockOf } from '@votingworks/test-utils';
+import { mockOf } from '@votingworks/test-utils';
 import { MemoryRouter } from 'react-router-dom';
 import { DateTime } from 'luxon';
 import { act } from 'react';
@@ -12,6 +12,7 @@ import {
 import { AccessibleControllerDiagnosticScreen } from './accessible_controller_diagnostic_screen';
 import { ApiProvider } from '../api_provider';
 import { ApiMock, createApiMock } from '../../test/helpers/mock_api_client';
+import { advanceTimersAndPromises } from '../../test/helpers/timers';
 import { ACCESSIBLE_CONTROLLER_POLLING_INTERVAL_MS } from '../api';
 
 export const MOCK_MARKER_INFO: IppMarkerInfo = {

--- a/apps/mark/frontend/test/helpers/timers.ts
+++ b/apps/mark/frontend/test/helpers/timers.ts
@@ -1,9 +1,10 @@
-import { advanceTimers as advanceTimersBase } from '@votingworks/test-utils';
 import { AUTH_STATUS_POLLING_INTERVAL_MS } from '@votingworks/ui';
-import { waitFor } from '../react_testing_library';
+import { act, waitFor } from '../react_testing_library';
 
 export function advanceTimers(seconds = 0): void {
-  advanceTimersBase(seconds || AUTH_STATUS_POLLING_INTERVAL_MS / 1000);
+  act(() => {
+    jest.advanceTimersByTime(seconds * 1000 || AUTH_STATUS_POLLING_INTERVAL_MS);
+  });
 }
 
 export async function advanceTimersAndPromises(seconds = 0): Promise<void> {

--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -1,10 +1,6 @@
 import { singlePrecinctSelectionFor } from '@votingworks/utils';
 import userEvent from '@testing-library/user-event';
-import {
-  advanceTimersAndPromises,
-  mockSystemAdministratorUser,
-  mockOf,
-} from '@votingworks/test-utils';
+import { mockSystemAdministratorUser, mockOf } from '@votingworks/test-utils';
 import {
   electionGeneral,
   electionGeneralDefinition,
@@ -19,7 +15,13 @@ import {
 import { Result, deferred, err, ok } from '@votingworks/basics';
 
 import type { PrecinctScannerConfig } from '@votingworks/scan-backend';
-import { waitFor, screen, within, render } from '../test/react_testing_library';
+import {
+  waitFor,
+  screen,
+  within,
+  render,
+  act,
+} from '../test/react_testing_library';
 import { POLLING_INTERVAL_FOR_SCANNER_STATUS_MS } from './config/globals';
 import { scannerStatus } from '../test/helpers/helpers';
 import {
@@ -41,6 +43,15 @@ jest.setTimeout(20000);
 
 function renderApp(props: Partial<AppProps> = {}) {
   render(<App apiClient={apiMock.mockApiClient} {...props} />);
+}
+
+async function advanceTimersAndPromises(seconds: number) {
+  act(() => {
+    jest.advanceTimersByTime(seconds * 1000);
+  });
+  await waitFor(() => {
+    // Wait for promises
+  });
 }
 
 beforeEach(() => {

--- a/libs/auth/package.json
+++ b/libs/auth/package.json
@@ -49,6 +49,7 @@
     "@types/tmp": "0.2.4",
     "@types/uuid": "9.0.5",
     "@types/yargs": "17.0.22",
+    "@vitest/coverage-istanbul": "^2.1.8",
     "@votingworks/test-utils": "workspace:*",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",
@@ -60,6 +61,7 @@
     "lint-staged": "11.0.0",
     "sort-package-json": "^1.50.0",
     "ts-jest": "29.1.1",
+    "vitest": "^2.1.8",
     "wait-for-expect": "^3.0.2"
   },
   "packageManager": "pnpm@8.15.5"

--- a/libs/auth/src/test_utils.ts
+++ b/libs/auth/src/test_utils.ts
@@ -2,42 +2,88 @@ import {
   DippedSmartCardAuth as DippedSmartCardAuthTypes,
   InsertedSmartCardAuth as InsertedSmartCardAuthTypes,
 } from '@votingworks/types';
+import type { Mocked, vi } from 'vitest';
 
 import { DippedSmartCardAuthApi } from './dipped_smart_card_auth_api';
 import { InsertedSmartCardAuthApi } from './inserted_smart_card_auth_api';
 
+type jfn = typeof jest.fn;
+type vfn = typeof vi.fn;
+
 /**
  * Builds a mock dipped smart card auth instance for application-level tests
  */
-export function buildMockDippedSmartCardAuth(): jest.Mocked<DippedSmartCardAuthApi> {
+export function buildMockDippedSmartCardAuth(): jest.Mocked<DippedSmartCardAuthApi>;
+/**
+ * Builds a mock dipped smart card auth instance for application-level tests
+ */
+
+export function buildMockDippedSmartCardAuth(
+  fn: jfn
+): jest.Mocked<DippedSmartCardAuthApi>;
+
+/**
+ * Builds a mock dipped smart card auth instance for application-level tests
+ */
+export function buildMockDippedSmartCardAuth(
+  fn: vfn
+): Mocked<DippedSmartCardAuthApi>;
+
+/**
+ * Builds a mock dipped smart card auth instance for application-level tests
+ */
+export function buildMockDippedSmartCardAuth(
+  fn: jfn | vfn = jest.fn
+): jest.Mocked<DippedSmartCardAuthApi> | Mocked<DippedSmartCardAuthApi> {
   return {
-    getAuthStatus: jest
-      .fn()
-      .mockResolvedValue(DippedSmartCardAuthTypes.DEFAULT_AUTH_STATUS),
-    checkPin: jest.fn(),
-    logOut: jest.fn(),
-    updateSessionExpiry: jest.fn(),
-    programCard: jest.fn(),
-    unprogramCard: jest.fn(),
+    getAuthStatus: (fn as jfn)().mockResolvedValue(
+      DippedSmartCardAuthTypes.DEFAULT_AUTH_STATUS
+    ),
+    checkPin: (fn as jfn)(),
+    logOut: (fn as jfn)(),
+    updateSessionExpiry: (fn as jfn)(),
+    programCard: (fn as jfn)(),
+    unprogramCard: (fn as jfn)(),
   };
 }
 
 /**
  * Builds a mock inserted smart card auth instance for application-level tests
  */
-export function buildMockInsertedSmartCardAuth(): jest.Mocked<InsertedSmartCardAuthApi> {
+export function buildMockInsertedSmartCardAuth(): jest.Mocked<InsertedSmartCardAuthApi>;
+
+/**
+ * Builds a mock inserted smart card auth instance for application-level tests
+ */
+export function buildMockInsertedSmartCardAuth(
+  fn: jfn
+): jest.Mocked<InsertedSmartCardAuthApi>;
+
+/**
+ * Builds a mock inserted smart card auth instance for application-level tests
+ */
+export function buildMockInsertedSmartCardAuth(
+  fn: vfn
+): Mocked<InsertedSmartCardAuthApi>;
+
+/**
+ * Builds a mock inserted smart card auth instance for application-level tests
+ */
+export function buildMockInsertedSmartCardAuth(
+  fn: jfn | vfn = jest.fn
+): jest.Mocked<InsertedSmartCardAuthApi> | Mocked<InsertedSmartCardAuthApi> {
   return {
-    getAuthStatus: jest
-      .fn()
-      .mockResolvedValue(InsertedSmartCardAuthTypes.DEFAULT_AUTH_STATUS),
-    checkPin: jest.fn(),
-    logOut: jest.fn(),
-    updateSessionExpiry: jest.fn(),
-    startCardlessVoterSession: jest.fn(),
-    updateCardlessVoterBallotStyle: jest.fn(),
-    endCardlessVoterSession: jest.fn(),
-    readCardData: jest.fn(),
-    writeCardData: jest.fn(),
-    clearCardData: jest.fn(),
+    getAuthStatus: (fn as jfn)().mockResolvedValue(
+      InsertedSmartCardAuthTypes.DEFAULT_AUTH_STATUS
+    ),
+    checkPin: (fn as jfn)(),
+    logOut: (fn as jfn)(),
+    updateSessionExpiry: (fn as jfn)(),
+    startCardlessVoterSession: (fn as jfn)(),
+    updateCardlessVoterBallotStyle: (fn as jfn)(),
+    endCardlessVoterSession: (fn as jfn)(),
+    readCardData: (fn as jfn)(),
+    writeCardData: (fn as jfn)(),
+    clearCardData: (fn as jfn)(),
   };
 }

--- a/libs/test-utils/src/advance_timers.ts
+++ b/libs/test-utils/src/advance_timers.ts
@@ -1,24 +1,9 @@
-import { act, waitFor } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 
 export const IDLE_TIMEOUT_SECONDS = 5 * 60; // 5 minute
-
-export function advanceTimers(seconds = 0): void {
-  const maxSeconds = IDLE_TIMEOUT_SECONDS;
-  if (seconds > maxSeconds) {
-    throw new Error(`Seconds value should not be greater than ${maxSeconds}`);
-  }
-  act(() => {
-    jest.advanceTimersByTime(seconds * 1000);
-  });
-}
 
 export async function advancePromises(): Promise<void> {
   await waitFor(() => {
     // Wait for promises.
   });
-}
-
-export async function advanceTimersAndPromises(seconds = 0): Promise<void> {
-  advanceTimers(seconds);
-  await advancePromises();
 }

--- a/libs/ui/src/accessible_controllers/accessible_controller_sandbox.test.tsx
+++ b/libs/ui/src/accessible_controllers/accessible_controller_sandbox.test.tsx
@@ -1,8 +1,4 @@
-import {
-  advanceTimers,
-  mockUseAudioControls,
-  mockOf,
-} from '@votingworks/test-utils';
+import { mockUseAudioControls, mockOf } from '@votingworks/test-utils';
 import React from 'react';
 import { assert } from '@votingworks/basics';
 import { simulateKeyPress as baseSimulateKeyPress } from './test_utils';
@@ -57,7 +53,9 @@ function newRenderer() {
 
 function simulateKeyPress(key: string) {
   baseSimulateKeyPress(key);
-  advanceTimers();
+  act(() => {
+    jest.advanceTimersByTime(0);
+  });
 }
 
 type MockIllustrationButton = Keybinding.PAGE_NEXT | Keybinding.PAGE_PREVIOUS;

--- a/libs/ui/src/hooks/use_headphones_plugged_in.test.ts
+++ b/libs/ui/src/hooks/use_headphones_plugged_in.test.ts
@@ -3,15 +3,11 @@ import {
   getFeatureFlagMock,
   isFeatureFlagEnabled,
 } from '@votingworks/utils';
-import {
-  advanceTimers,
-  advanceTimersAndPromises,
-  mockOf,
-} from '@votingworks/test-utils';
+import { mockOf } from '@votingworks/test-utils';
 import { useHeadphonesPluggedIn } from './use_headphones_plugged_in';
 import { AUDIO_INFO_POLLING_INTERVAL_MS } from '../system_call_api';
 import { newTestContext } from '../../test/test_context';
-import { waitFor } from '../../test/react_testing_library';
+import { act, waitFor } from '../../test/react_testing_library';
 
 jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
   ...jest.requireActual('@votingworks/utils'),
@@ -47,11 +43,11 @@ test('uses getAudioInfo system call API', async () => {
   await waitFor(() => expect(result.current).toEqual(false));
 
   mockApiClient.getAudioInfo.mockResolvedValueOnce({ headphonesActive: true });
-  advanceTimers(AUDIO_INFO_POLLING_INTERVAL_MS / 1000);
+  jest.advanceTimersByTime(AUDIO_INFO_POLLING_INTERVAL_MS);
   await waitFor(() => expect(result.current).toEqual(true));
 
   mockApiClient.getAudioInfo.mockResolvedValueOnce({ headphonesActive: false });
-  advanceTimers(AUDIO_INFO_POLLING_INTERVAL_MS / 1000);
+  jest.advanceTimersByTime(AUDIO_INFO_POLLING_INTERVAL_MS);
   await waitFor(() => expect(result.current).toEqual(false));
 
   unmount(); // Prevent any further API polling.
@@ -70,6 +66,11 @@ test('always returns true if headphones restriction flag is disabled', async () 
   await waitFor(() => expect(result.current).toEqual(true));
   expect(result.current).toEqual(true);
 
-  await advanceTimersAndPromises(AUDIO_INFO_POLLING_INTERVAL_MS / 1000);
+  act(() => {
+    jest.advanceTimersByTime(AUDIO_INFO_POLLING_INTERVAL_MS);
+  });
+  await waitFor(() => {
+    // wait for promises
+  });
   expect(mockApiClient.getAudioInfo).not.toHaveBeenCalled();
 });

--- a/libs/ui/src/ui_strings/ui_string_screen_reader.test.tsx
+++ b/libs/ui/src/ui_strings/ui_string_screen_reader.test.tsx
@@ -1,8 +1,4 @@
-import {
-  advanceTimersAndPromises,
-  mockOf,
-  TestLanguageCode,
-} from '@votingworks/test-utils';
+import { mockOf, TestLanguageCode } from '@votingworks/test-utils';
 import userEvent from '@testing-library/user-event';
 import { act, screen, waitFor } from '../../test/react_testing_library';
 import { newTestContext } from '../../test/test_context';
@@ -129,13 +125,23 @@ test('resumes paused audio when user switches focus', async () => {
   const clickTarget = await screen.findByTestId('clickTarget');
 
   act(() => getAudioContext()?.setIsEnabled(true));
-  await advanceTimersAndPromises();
+  act(() => {
+    jest.advanceTimersByTime(0);
+  });
+  await waitFor(() => {
+    // wait for promises
+  });
 
   act(() => getAudioContext()?.setIsPaused(true));
   expect(getAudioContext()?.isPaused).toEqual(true);
 
   act(() => userEvent.click(clickTarget));
-  await advanceTimersAndPromises();
+  act(() => {
+    jest.advanceTimersByTime(0);
+  });
+  await waitFor(() => {
+    // wait for promises
+  });
 
   expect(getAudioContext()?.isPaused).toEqual(false);
 });
@@ -227,7 +233,12 @@ test('is a no-op when audio is disabled', async () => {
   const clickTarget = await screen.findByTestId('clickTarget');
   act(() => getAudioContext()?.setIsEnabled(false));
   act(() => userEvent.click(clickTarget));
-  await advanceTimersAndPromises();
+  act(() => {
+    jest.advanceTimersByTime(0);
+  });
+  await waitFor(() => {
+    // wait for promises
+  });
 
   expect(screen.queryByTestId('mockClips')).not.toBeInTheDocument();
 });
@@ -244,7 +255,12 @@ test('handles missing audio ID data', async () => {
   const clickTarget = await screen.findByTestId('clickTarget');
   act(() => getAudioContext()?.setIsEnabled(true));
   act(() => userEvent.click(clickTarget));
-  await advanceTimersAndPromises();
+  act(() => {
+    jest.advanceTimersByTime(0);
+  });
+  await waitFor(() => {
+    // wait for promises
+  });
 
   expect(screen.queryByTestId('mockClipOutput')).not.toBeInTheDocument();
   screen.getByTestId('clickTarget');
@@ -268,7 +284,12 @@ test('volume control API', async () => {
   const clickTarget = await screen.findByTestId('clickTarget');
   act(() => getAudioContext()?.setIsEnabled(true));
   act(() => userEvent.click(clickTarget));
-  await advanceTimersAndPromises();
+  act(() => {
+    jest.advanceTimersByTime(0);
+  });
+  await waitFor(() => {
+    // wait for promises
+  });
 
   expect(await screen.findByTestId('mockClipOutput')).toHaveTextContent(
     getMockClipOutput({ audioId: 'screen-title', languageCode: ENGLISH })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2963,6 +2963,9 @@ importers:
       '@types/yargs':
         specifier: 17.0.22
         version: 17.0.22
+      '@vitest/coverage-istanbul':
+        specifier: ^2.1.8
+        version: 2.1.8(vitest@2.1.8)
       '@votingworks/test-utils':
         specifier: workspace:*
         version: link:../test-utils
@@ -2996,6 +2999,9 @@ importers:
       ts-jest:
         specifier: 29.1.1
         version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.8
       wait-for-expect:
         specifier: ^3.0.2
         version: 3.0.2
@@ -5929,7 +5935,7 @@ packages:
     resolution: {integrity: sha512-KtLMbmicyuK2Ak/FTCJVbDnkN1SlT8/kceFTiuDiiRUUSMnHMidxSCdG4ndkTOHHpoomWe/4xkvHkEOncwjYIw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.10
+      '@babel/types': 7.26.0
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
@@ -5996,59 +6002,41 @@ packages:
       '@babel/helper-function-name': 7.22.5
       '@babel/helper-member-expression-to-functions': 7.22.5
       '@babel/helper-optimise-call-expression': 7.22.5
-      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.26.0)
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       semver: 6.3.1
     dev: true
 
-  /@babel/helper-create-class-features-plugin@7.22.10(@babel/core@7.26.0):
-    resolution: {integrity: sha512-5IBb77txKYQPpOEdUdIhBx8VrZyDCQ+H82H0+5dX1TmuscP5vJKEE3cKurjtIw/vFwzbVH48VweE78kVDBrqjA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-function-name': 7.22.5
-      '@babel/helper-member-expression-to-functions': 7.22.5
-      '@babel/helper-optimise-call-expression': 7.22.5
-      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.26.0)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      semver: 6.3.1
-    dev: true
-
-  /@babel/helper-create-regexp-features-plugin@7.20.5(@babel/core@7.26.0):
+  /@babel/helper-create-regexp-features-plugin@7.20.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-m68B1lkg3XDGX5yCvGO0kPx3v9WIYLnzjKfPcQiwntEQa5ZeRkPmo2X/ISJc8qxWGfwUr+kvZAeEzAwLec2r2w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-annotate-as-pure': 7.22.5
       regexpu-core: 5.2.2
     dev: true
 
-  /@babel/helper-create-regexp-features-plugin@7.22.9(@babel/core@7.26.0):
+  /@babel/helper-create-regexp-features-plugin@7.22.9(@babel/core@7.22.9):
     resolution: {integrity: sha512-+svjVa/tFwsNSG4NEy1h85+HQ5imbT92Q5/bgtS7P0GTQlP8WuFdqsiABmQouhiFGyV66oGxZFpeYHza1rNsKw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-annotate-as-pure': 7.22.5
       regexpu-core: 5.3.2
       semver: 6.3.1
     dev: true
 
-  /@babel/helper-define-polyfill-provider@0.4.2(@babel/core@7.26.0):
+  /@babel/helper-define-polyfill-provider@0.4.2(@babel/core@7.22.9):
     resolution: {integrity: sha512-k0qnnOqHn5dK9pZpfD5XXZ9SojAITdCKRn2Lp6rnDGzIbaP0rHyMPk/4wsSxVBVz4RfN0q6VpXWP2pDGIoQ7hw==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-compilation-targets': 7.22.10
       '@babel/helper-plugin-utils': 7.22.5
       debug: 4.3.4(supports-color@5.5.0)
@@ -6144,20 +6132,6 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.25.9
 
-  /@babel/helper-module-transforms@7.22.9(@babel/core@7.26.0):
-    resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-module-imports': 7.22.5
-      '@babel/helper-simple-access': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/helper-validator-identifier': 7.25.9
-    dev: true
-
   /@babel/helper-module-transforms@7.26.0(@babel/core@7.26.0):
     resolution: {integrity: sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==}
     engines: {node: '>=6.9.0'}
@@ -6197,25 +6171,25 @@ packages:
     resolution: {integrity: sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/helper-remap-async-to-generator@7.22.9(@babel/core@7.26.0):
+  /@babel/helper-remap-async-to-generator@7.22.9(@babel/core@7.22.9):
     resolution: {integrity: sha512-8WWC4oR4Px+tr+Fp0X3RHDVfINGpF3ad1HIbrc8A77epiR6eMMc6jsgozkzT2uDiOOdoS9cLIQ+XD2XvI2WSmQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-wrap-function': 7.22.10
     dev: true
 
-  /@babel/helper-replace-supers@7.22.9(@babel/core@7.26.0):
+  /@babel/helper-replace-supers@7.22.9(@babel/core@7.22.9):
     resolution: {integrity: sha512-LJIKvvpgPOPUThdYqcX6IXRuIcTkcAub0IaDRGCZH0p5GPUp7PhRU9QVgFcDDd51BaPkk77ZjqFwh6DZTAEmGg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-member-expression-to-functions': 7.22.5
       '@babel/helper-optimise-call-expression': 7.22.5
@@ -6312,26 +6286,26 @@ packages:
     dependencies:
       '@babel/types': 7.26.0
 
-  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-NP1M5Rf+u2Gw9qfSO4ihjcTGW5zXTi36ITLd4/EoAcEhIZ0yjMqmftDNl3QC19CX7olhrjpyU454g/2W7X0jvQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-31Bb65aZaUwqCbWMnZPduIZxCBngHFlzyN6Dq6KAJjtx+lx6ohKHubc61OomYi7XwVD4Ol0XCVz4h+pYFR048g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.13.0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-transform-optional-chaining': 7.22.10(@babel/core@7.26.0)
+      '@babel/plugin-transform-optional-chaining': 7.22.10(@babel/core@7.22.9)
     dev: true
 
   /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.22.9):
@@ -6368,13 +6342,13 @@ packages:
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.22.9)
     dev: true
 
-  /@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.26.0):
+  /@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.22.9):
     resolution: {integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
     dev: true
 
   /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.22.9):
@@ -6425,31 +6399,31 @@ packages:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.26.0):
+  /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.26.0):
+  /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.22.9):
     resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.26.0):
+  /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.22.9):
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -6463,23 +6437,23 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-syntax-import-assertions@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-syntax-import-assertions@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-rdV97N7KqsRzeNGoWUOK6yUsWarLjE5Su/Snk9IYPU9CwkWHs4t+rTGOvffTR8XGkJMTAdLfO0xVnXm8wugIJg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-syntax-import-attributes@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-syntax-import-attributes@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-KwvoWDeNKPETmozyFE0P2rOLqh39EoQHNjqizrI5B8Vt0ZNS7M56s7dAiAqbYfiAYOuIzIh96z3iR2ktgu3tEg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -6640,13 +6614,13 @@ packages:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.26.0):
+  /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -6687,186 +6661,186 @@ packages:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.26.0):
+  /@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.22.9):
     resolution: {integrity: sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.26.0)
+      '@babel/core': 7.22.9
+      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-arrow-functions@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-arrow-functions@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-26lTNXoVRdAnsaDXPpvCNUq+OVWEVC6bx7Vvz9rC53F2bagUWW4u4ii2+h8Fejfh7RYqPxn+libeFBBck9muEw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-async-generator-functions@7.22.10(@babel/core@7.26.0):
+  /@babel/plugin-transform-async-generator-functions@7.22.10(@babel/core@7.22.9):
     resolution: {integrity: sha512-eueE8lvKVzq5wIObKK/7dvoeKJ+xc6TvRn6aysIjS6pSCeLy7S/eVi7pEQknZqyqvzaNKdDtem8nUNTBgDVR2g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.26.0)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.26.0)
+      '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.22.9)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.22.9)
     dev: true
 
-  /@babel/plugin-transform-async-to-generator@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-async-to-generator@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-b1A8D8ZzE/VhNDoV1MSJTnpKkCG5bJo+19R4o4oy03zM7ws8yEMK755j61Dc3EyvdysbqH5BOOTquJ7ZX9C6vQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-module-imports': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.26.0)
+      '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.22.9)
     dev: true
 
-  /@babel/plugin-transform-block-scoped-functions@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-block-scoped-functions@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-tdXZ2UdknEKQWKJP1KMNmuF5Lx3MymtMN/pvA+p/VEkhK8jVcQ1fzSy8KM9qRYhAf2/lV33hoMPKI/xaI9sADA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-block-scoping@7.22.10(@babel/core@7.26.0):
+  /@babel/plugin-transform-block-scoping@7.22.10(@babel/core@7.22.9):
     resolution: {integrity: sha512-1+kVpGAOOI1Albt6Vse7c8pHzcZQdQKW+wJH+g8mCaszOdDVwRXa/slHPqIw+oJAJANTKDMuM2cBdV0Dg618Vg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-class-properties@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-class-properties@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-nDkQ0NfkOhPTq8YCLiWNxp1+f9fCobEjCb0n8WdbNUBc4IB5V7P1QnX9IjpSoquKrXF5SKojHleVNs2vGeHCHQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.26.0)
+      '@babel/core': 7.22.9
+      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-class-static-block@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-class-static-block@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-SPToJ5eYZLxlnp1UzdARpOGeC2GbHvr9d/UV0EukuVx8atktg194oe+C5BqQ8jRTkgLRVOPYeXRSBg1IlMoVRA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.26.0)
+      '@babel/core': 7.22.9
+      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.26.0)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.22.9)
     dev: true
 
-  /@babel/plugin-transform-classes@7.22.6(@babel/core@7.26.0):
+  /@babel/plugin-transform-classes@7.22.6(@babel/core@7.22.9):
     resolution: {integrity: sha512-58EgM6nuPNG6Py4Z3zSuu0xWu2VfodiMi72Jt5Kj2FECmaYk1RrTXA45z6KBFsu9tRgwQDwIiY4FXTt+YsSFAQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-compilation-targets': 7.22.10
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-function-name': 7.22.5
       '@babel/helper-optimise-call-expression': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.26.0)
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-split-export-declaration': 7.22.6
       globals: 11.12.0
     dev: true
 
-  /@babel/plugin-transform-computed-properties@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-computed-properties@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-4GHWBgRf0krxPX+AaPtgBAlTgTeZmqDynokHOX7aqqAB4tHs3U2Y02zH6ETFdLZGcg9UQSD1WCmkVrE9ErHeOg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/template': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-destructuring@7.22.10(@babel/core@7.26.0):
+  /@babel/plugin-transform-destructuring@7.22.10(@babel/core@7.22.9):
     resolution: {integrity: sha512-dPJrL0VOyxqLM9sritNbMSGx/teueHF/htMKrPT7DNxccXxRDPYqlgPFFdr8u+F+qUZOkZoXue/6rL5O5GduEw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-dotall-regex@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-dotall-regex@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-5/Yk9QxCQCl+sOIB1WelKnVRxTJDSAIxtJLL2/pqL14ZVlbH0fUQUZa/T5/UnQtBNgghR7mfB8ERBKyKPCi7Vw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.26.0)
+      '@babel/core': 7.22.9
+      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-duplicate-keys@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-duplicate-keys@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-dEnYD+9BBgld5VBXHnF/DbYGp3fqGMsyxKbtD1mDyIA7AkTSpKXFhCVuj/oQVOoALfBs77DudA0BE4d5mcpmqw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-dynamic-import@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-dynamic-import@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-0MC3ppTB1AMxd8fXjSrbPa7LT9hrImt+/fcj+Pg5YMD7UQyWp/02+JWpdnCymmsXwIx5Z+sYn1bwCn4ZJNvhqQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.22.9)
     dev: true
 
-  /@babel/plugin-transform-exponentiation-operator@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-exponentiation-operator@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-vIpJFNM/FjZ4rh1myqIya9jXwrwwgFRHPjT3DkUA9ZLHuzox8jiXkOLvwm1H+PQIP3CqfC++WPKeuDi0Sjdj1g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.10
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-export-namespace-from@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-export-namespace-from@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-X4hhm7FRnPgd4nDA4b/5V280xCx6oL7Oob5+9qVS5C13Zq4bh1qq7LU0GgRU6b5dBWBvhGaXYVB4AcN6+ol6vg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.22.9)
     dev: true
 
   /@babel/plugin-transform-flow-strip-types@7.19.0(@babel/core@7.22.9):
@@ -6880,78 +6854,78 @@ packages:
       '@babel/plugin-syntax-flow': 7.18.6(@babel/core@7.22.9)
     dev: true
 
-  /@babel/plugin-transform-for-of@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-for-of@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-3kxQjX1dU9uudwSshyLeEipvrLjBCVthCgeTp6CzE/9JYrlAIaeekVxRpCWsDDfYTfRZRoCeZatCQvwo+wvK8A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-function-name@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-function-name@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-UIzQNMS0p0HHiQm3oelztj+ECwFnj+ZRV4KnguvlsD2of1whUeM6o7wGNj6oLwcDoAXQ8gEqfgC24D+VdIcevg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-compilation-targets': 7.22.10
       '@babel/helper-function-name': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-json-strings@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-json-strings@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-DuCRB7fu8MyTLbEQd1ew3R85nx/88yMoqo2uPSjevMj3yoN7CDM8jkgrY0wmVxfJZyJ/B9fE1iq7EQppWQmR5A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.22.9)
     dev: true
 
-  /@babel/plugin-transform-literals@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-literals@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-fTLj4D79M+mepcw3dgFBTIDYpbcB9Sm0bpm4ppXPaO+U+PKFFyV9MGRvS0gvGw62sd10kT5lRMKXAADb9pWy8g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-logical-assignment-operators@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-logical-assignment-operators@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-MQQOUW1KL8X0cDWfbwYP+TbVbZm16QmQXJQ+vndPtH/BoO0lOKpVoEDMI7+PskYxH+IiE0tS8xZye0qr1lGzSA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.26.0)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.22.9)
     dev: true
 
-  /@babel/plugin-transform-member-expression-literals@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-member-expression-literals@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-RZEdkNtzzYCFl9SE9ATaUMTj2hqMb4StarOJLrZRbqqU4HSBE7UlBw9WBWQiDzrJZJdUWiMTVDI6Gv/8DPvfew==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-modules-amd@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-modules-amd@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-R+PTfLTcYEmb1+kK7FNkhQ1gP4KgjpSO6HfH9+f8/yfp2Nt3ggBjiVpRwmwTlfqZLafYKJACy36yDXlEmI9HjQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.26.0)
+      '@babel/core': 7.22.9
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -6962,179 +6936,167 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.26.0)
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-simple-access': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-modules-commonjs@7.22.5(@babel/core@7.26.0):
-    resolution: {integrity: sha512-B4pzOXj+ONRmuaQTg05b3y/4DuFz3WcCNAXPLb2Q0GT0TrGKGxNKV4jwsXts+StaM0LQczZbOpj8o1DLPDJIiA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.26.0)
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-simple-access': 7.22.5
-    dev: true
-
-  /@babel/plugin-transform-modules-systemjs@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-modules-systemjs@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-emtEpoaTMsOs6Tzz+nbmcePl6AKVtS1yC4YNAeMun9U8YCsgadPNxnOPQ8GhHFB2qdx+LZu9LgoC0Lthuu05DQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-hoist-variables': 7.22.5
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.26.0)
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-identifier': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-modules-umd@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-modules-umd@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-+S6kzefN/E1vkSsKx8kmQuqeQsvCKCd1fraCM7zXm4SFoggI099Tr4G8U81+5gtMdUeMQ4ipdQffbKLX0/7dBQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.26.0)
+      '@babel/core': 7.22.9
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-YgLLKmS3aUBhHaxp5hi1WJTgOUb/NCuDHzGT9z9WTt3YG+CPRhJs6nprbStx6DnWM4dh6gt7SU3sZodbZ08adQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.26.0)
+      '@babel/core': 7.22.9
+      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-new-target@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-new-target@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-AsF7K0Fx/cNKVyk3a+DW0JLo+Ua598/NxMRvxDnkpCIGFh43+h/v2xyhRUYf6oD8gE4QtL83C7zZVghMjHd+iw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-nullish-coalescing-operator@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-nullish-coalescing-operator@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-6CF8g6z1dNYZ/VXok5uYkkBBICHZPiGEl7oDnAx2Mt1hlHVHOSIKWJaXHjQJA5VB43KZnXZDIexMchY4y2PGdA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.22.9)
     dev: true
 
-  /@babel/plugin-transform-numeric-separator@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-numeric-separator@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-NbslED1/6M+sXiwwtcAB/nieypGw02Ejf4KtDeMkCEpP6gWFMX1wI9WKYua+4oBneCCEmulOkRpwywypVZzs/g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.26.0)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.22.9)
     dev: true
 
-  /@babel/plugin-transform-object-rest-spread@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-object-rest-spread@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-Kk3lyDmEslH9DnvCDA1s1kkd3YWQITiBOHngOtDL9Pt6BZjzqb6hiOlb8VfjiiQJ2unmegBqZu0rx5RxJb5vmQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.22.9
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-compilation-targets': 7.22.10
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.26.0)
-      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.22.9)
+      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.22.9)
     dev: true
 
-  /@babel/plugin-transform-object-super@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-object-super@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-klXqyaT9trSjIUrcsYIfETAzmOEZL3cBYqOYLJxBHfMFFggmXOv+NYSX/Jbs9mzMVESw/WycLFPRx8ba/b2Ipw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.26.0)
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.22.9)
     dev: true
 
-  /@babel/plugin-transform-optional-catch-binding@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-optional-catch-binding@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-pH8orJahy+hzZje5b8e2QIlBWQvGpelS76C63Z+jhZKsmzfNaPQ+LaW6dcJ9bxTpo1mtXbgHwy765Ro3jftmUg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.22.9)
     dev: true
 
-  /@babel/plugin-transform-optional-chaining@7.22.10(@babel/core@7.26.0):
+  /@babel/plugin-transform-optional-chaining@7.22.10(@babel/core@7.22.9):
     resolution: {integrity: sha512-MMkQqZAZ+MGj+jGTG3OTuhKeBpNcO+0oCEbrGNEaOmiEn+1MzRyQlYsruGiU8RTK3zV6XwrVJTmwiDOyYK6J9g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.22.9)
     dev: true
 
-  /@babel/plugin-transform-parameters@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-parameters@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-AVkFUBurORBREOmHRKo06FjHYgjrabpdqRSwq6+C7R5iTCZOsM4QbcB27St0a4U6fffyAOqh3s/qEfybAhfivg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-private-methods@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-private-methods@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-PPjh4gyrQnGe97JTalgRGMuU4icsZFnWkzicB/fUtzlKUqvsWBKEpPPfr5a2JiyirZkHxnAqkQMO5Z5B2kK3fA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.26.0)
+      '@babel/core': 7.22.9
+      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-private-property-in-object@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-private-property-in-object@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-/9xnaTTJcVoBtSSmrVyhtSvO3kbqS2ODoh2juEU72c3aYonNF0OMGiaz2gjukyKM2wBBYJP38S4JiE0Wfb5VMQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.26.0)
+      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.26.0)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.22.9)
     dev: true
 
-  /@babel/plugin-transform-property-literals@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-property-literals@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-TiOArgddK3mK/x1Qwf5hay2pxI6wCZnvQqrFSqbtg1GLl2JcNMitVH/YnqjP+M31pLUeTfzY1HAXFDnUBV30rQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -7216,75 +7178,75 @@ packages:
       '@babel/types': 7.22.10
     dev: true
 
-  /@babel/plugin-transform-regenerator@7.22.10(@babel/core@7.26.0):
+  /@babel/plugin-transform-regenerator@7.22.10(@babel/core@7.22.9):
     resolution: {integrity: sha512-F28b1mDt8KcT5bUyJc/U9nwzw6cV+UmTeRlXYIl2TNqMMJif0Jeey9/RQ3C4NOd2zp0/TRsDns9ttj2L523rsw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
       regenerator-transform: 0.15.2
     dev: true
 
-  /@babel/plugin-transform-reserved-words@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-reserved-words@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-DTtGKFRQUDm8svigJzZHzb/2xatPc6TzNvAIJ5GqOKDsGFYgAskjRulbR/vGsPKq3OPqtexnz327qYpP57RFyA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-shorthand-properties@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-shorthand-properties@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-vM4fq9IXHscXVKzDv5itkO1X52SmdFBFcMIBZ2FRn2nqVYqw6dBexUgMvAjHW+KXpPPViD/Yo3GrDEBaRC0QYA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-spread@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-spread@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-5ZzDQIGyvN4w8+dMmpohL6MBo+l2G7tfC/O2Dg7/hjpgeWvUx8FzfeOKxGog9IimPa4YekaQ9PlDqTLOljkcxg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-sticky-regex@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-sticky-regex@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-zf7LuNpHG0iEeiyCNwX4j3gDg1jgt1k3ZdXBKbZSoA3BbGQGvMiSvfbZRR3Dr3aeJe3ooWFZxOOG3IRStYp2Bw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-template-literals@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-template-literals@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-5ciOehRNf+EyUeewo8NkbQiUs4d6ZxiHo6BcBcnFlgiJfu16q0bQUw9Jvo0b0gBKFG1SMhDSjeKXSYuJLeFSMA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-typeof-symbol@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-typeof-symbol@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-bYkI5lMzL4kPii4HHEEChkD0rkc+nvnlR6+o/qdqR6zrm0Sv/nodmyLhlq2DO0YKLUNd2VePmPRjJXSBh9OIdA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -7300,46 +7262,46 @@ packages:
       '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.22.9)
     dev: true
 
-  /@babel/plugin-transform-unicode-escapes@7.22.10(@babel/core@7.26.0):
+  /@babel/plugin-transform-unicode-escapes@7.22.10(@babel/core@7.22.9):
     resolution: {integrity: sha512-lRfaRKGZCBqDlRU3UIFovdp9c9mEvlylmpod0/OatICsSfuQ9YFthRo1tpTkGsklEefZdqlEFdY4A2dwTb6ohg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-unicode-property-regex@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-unicode-property-regex@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-HCCIb+CbJIAE6sXn5CjFQXMwkCClcOfPCzTlilJ8cUatfzwHlWQkbtV0zD338u9dZskwvuOYTuuaMaA8J5EI5A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.26.0)
+      '@babel/core': 7.22.9
+      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-unicode-regex@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-unicode-regex@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-028laaOKptN5vHJf9/Arr/HiJekMd41hOEZYvNsrsXqJ7YPYuX2bQxh31fkZzGmq3YqHRJzYFFAVYvKfMPKqyg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.26.0)
+      '@babel/core': 7.22.9
+      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-unicode-sets-regex@7.22.5(@babel/core@7.26.0):
+  /@babel/plugin-transform-unicode-sets-regex@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-lhMfi4FC15j13eKrh3DnYHjpGj6UKQHtNKTbtc1igvAhRy4+kLhV07OpLcsN0VgDEw/MjAvJO4BdMJsHwMhzCg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.26.0)
+      '@babel/core': 7.22.9
+      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -7354,171 +7316,80 @@ packages:
       '@babel/helper-compilation-targets': 7.22.10
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-option': 7.22.5
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.26.0)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.26.0)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.26.0)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.26.0)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.26.0)
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.26.0)
-      '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-syntax-import-attributes': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.26.0)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.26.0)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.26.0)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.26.0)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.26.0)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.26.0)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.26.0)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.26.0)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.26.0)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.26.0)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.26.0)
-      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-async-generator-functions': 7.22.10(@babel/core@7.26.0)
-      '@babel/plugin-transform-async-to-generator': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-block-scoped-functions': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-block-scoping': 7.22.10(@babel/core@7.26.0)
-      '@babel/plugin-transform-class-properties': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-class-static-block': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-classes': 7.22.6(@babel/core@7.26.0)
-      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-destructuring': 7.22.10(@babel/core@7.26.0)
-      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-duplicate-keys': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-dynamic-import': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-exponentiation-operator': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-export-namespace-from': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-for-of': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-json-strings': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-logical-assignment-operators': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-member-expression-literals': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-modules-amd': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-modules-commonjs': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-modules-systemjs': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-modules-umd': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-new-target': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-numeric-separator': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-object-rest-spread': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-object-super': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-optional-catch-binding': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-optional-chaining': 7.22.10(@babel/core@7.26.0)
-      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-private-methods': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-private-property-in-object': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-property-literals': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-regenerator': 7.22.10(@babel/core@7.26.0)
-      '@babel/plugin-transform-reserved-words': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-shorthand-properties': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-sticky-regex': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-typeof-symbol': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-unicode-escapes': 7.22.10(@babel/core@7.26.0)
-      '@babel/plugin-transform-unicode-property-regex': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-unicode-regex': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-unicode-sets-regex': 7.22.5(@babel/core@7.26.0)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.26.0)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.22.9)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.22.9)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.22.9)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.22.9)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.22.9)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.22.9)
+      '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-syntax-import-attributes': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.22.9)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.22.9)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.22.9)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.22.9)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.22.9)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.22.9)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.22.9)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.22.9)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.22.9)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.22.9)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.22.9)
+      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-async-generator-functions': 7.22.10(@babel/core@7.22.9)
+      '@babel/plugin-transform-async-to-generator': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-block-scoped-functions': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-block-scoping': 7.22.10(@babel/core@7.22.9)
+      '@babel/plugin-transform-class-properties': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-class-static-block': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-classes': 7.22.6(@babel/core@7.22.9)
+      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-destructuring': 7.22.10(@babel/core@7.22.9)
+      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-duplicate-keys': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-dynamic-import': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-exponentiation-operator': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-export-namespace-from': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-for-of': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-json-strings': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-logical-assignment-operators': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-member-expression-literals': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-modules-amd': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-modules-commonjs': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-modules-systemjs': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-modules-umd': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-new-target': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-numeric-separator': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-object-rest-spread': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-object-super': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-optional-catch-binding': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-optional-chaining': 7.22.10(@babel/core@7.22.9)
+      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-private-methods': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-private-property-in-object': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-property-literals': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-regenerator': 7.22.10(@babel/core@7.22.9)
+      '@babel/plugin-transform-reserved-words': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-shorthand-properties': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-sticky-regex': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-typeof-symbol': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-unicode-escapes': 7.22.10(@babel/core@7.22.9)
+      '@babel/plugin-transform-unicode-property-regex': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-unicode-regex': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-transform-unicode-sets-regex': 7.22.5(@babel/core@7.22.9)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.22.9)
       '@babel/types': 7.22.10
-      babel-plugin-polyfill-corejs2: 0.4.5(@babel/core@7.26.0)
-      babel-plugin-polyfill-corejs3: 0.8.3(@babel/core@7.26.0)
-      babel-plugin-polyfill-regenerator: 0.5.2(@babel/core@7.26.0)
-      core-js-compat: 3.32.0
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/preset-env@7.22.10(@babel/core@7.26.0):
-    resolution: {integrity: sha512-riHpLb1drNkpLlocmSyEg4oYJIQFeXAK/d7rI6mbD0XsvoTOOweXDmQPG/ErxsEhWk3rl3Q/3F6RFQlVFS8m0A==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/compat-data': 7.22.9
-      '@babel/core': 7.26.0
-      '@babel/helper-compilation-targets': 7.22.10
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-validator-option': 7.22.5
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.26.0)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.26.0)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.26.0)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.26.0)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.26.0)
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.26.0)
-      '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-syntax-import-attributes': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.26.0)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.26.0)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.26.0)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.26.0)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.26.0)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.26.0)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.26.0)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.26.0)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.26.0)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.26.0)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.26.0)
-      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-async-generator-functions': 7.22.10(@babel/core@7.26.0)
-      '@babel/plugin-transform-async-to-generator': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-block-scoped-functions': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-block-scoping': 7.22.10(@babel/core@7.26.0)
-      '@babel/plugin-transform-class-properties': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-class-static-block': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-classes': 7.22.6(@babel/core@7.26.0)
-      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-destructuring': 7.22.10(@babel/core@7.26.0)
-      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-duplicate-keys': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-dynamic-import': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-exponentiation-operator': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-export-namespace-from': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-for-of': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-json-strings': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-logical-assignment-operators': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-member-expression-literals': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-modules-amd': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-modules-commonjs': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-modules-systemjs': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-modules-umd': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-new-target': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-numeric-separator': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-object-rest-spread': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-object-super': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-optional-catch-binding': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-optional-chaining': 7.22.10(@babel/core@7.26.0)
-      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-private-methods': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-private-property-in-object': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-property-literals': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-regenerator': 7.22.10(@babel/core@7.26.0)
-      '@babel/plugin-transform-reserved-words': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-shorthand-properties': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-sticky-regex': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-typeof-symbol': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-unicode-escapes': 7.22.10(@babel/core@7.26.0)
-      '@babel/plugin-transform-unicode-property-regex': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-unicode-regex': 7.22.5(@babel/core@7.26.0)
-      '@babel/plugin-transform-unicode-sets-regex': 7.22.5(@babel/core@7.26.0)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.26.0)
-      '@babel/types': 7.22.10
-      babel-plugin-polyfill-corejs2: 0.4.5(@babel/core@7.26.0)
-      babel-plugin-polyfill-corejs3: 0.8.3(@babel/core@7.26.0)
-      babel-plugin-polyfill-regenerator: 0.5.2(@babel/core@7.26.0)
+      babel-plugin-polyfill-corejs2: 0.4.5(@babel/core@7.22.9)
+      babel-plugin-polyfill-corejs3: 0.8.3(@babel/core@7.22.9)
+      babel-plugin-polyfill-regenerator: 0.5.2(@babel/core@7.22.9)
       core-js-compat: 3.32.0
       semver: 6.3.1
     transitivePeerDependencies:
@@ -7537,12 +7408,12 @@ packages:
       '@babel/plugin-transform-flow-strip-types': 7.19.0(@babel/core@7.22.9)
     dev: true
 
-  /@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.26.0):
+  /@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.22.9):
     resolution: {integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/types': 7.26.0
       esutils: 2.0.3
@@ -10363,7 +10234,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/preset-env': 7.22.10(@babel/core@7.26.0)
+      '@babel/preset-env': 7.22.10(@babel/core@7.22.9)
       '@babel/types': 7.22.5
       '@ndelangen/get-tarball': 3.0.9
       '@storybook/codemod': 7.2.2
@@ -12120,7 +11991,7 @@ packages:
       magicast: 0.3.5
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
+      vitest: 2.1.8
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12916,38 +12787,38 @@ packages:
       resolve: 1.22.4
     dev: false
 
-  /babel-plugin-polyfill-corejs2@0.4.5(@babel/core@7.26.0):
+  /babel-plugin-polyfill-corejs2@0.4.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-19hwUH5FKl49JEsvyTcoHakh6BE0wgXLLptIyKZ3PijHc/Ci521wygORCUCCred+E/twuqRyAkE02BAWPmsHOg==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
       '@babel/compat-data': 7.22.9
-      '@babel/core': 7.26.0
-      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.26.0)
+      '@babel/core': 7.22.9
+      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.22.9)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /babel-plugin-polyfill-corejs3@0.8.3(@babel/core@7.26.0):
+  /babel-plugin-polyfill-corejs3@0.8.3(@babel/core@7.22.9):
     resolution: {integrity: sha512-z41XaniZL26WLrvjy7soabMXrfPWARN25PZoriDEiLMxAp50AUW3t35BGQUMg5xK3UrpVTtagIDklxYa+MhiNA==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.26.0)
+      '@babel/core': 7.22.9
+      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.22.9)
       core-js-compat: 3.32.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /babel-plugin-polyfill-regenerator@0.5.2(@babel/core@7.26.0):
+  /babel-plugin-polyfill-regenerator@0.5.2(@babel/core@7.22.9):
     resolution: {integrity: sha512-tAlOptU0Xj34V1Y2PNTL4Y0FOJMDB6bZmoW39FeCQIhigGLkqu3Fj6uiXpxIf6Ij274ENdYx64y6Au+ZKlb1IA==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.26.0)
+      '@babel/core': 7.22.9
+      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.22.9)
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
Refs #5740 

Unblocks converting packages using mocks from `libs/auth` from `jest` to `vitest`.

- [x] Merge #5738 first