### PR TITLE
Remove outdated and now unused variable

### DIFF
--- a/libs/auth/src/cryptography.ts
+++ b/libs/auth/src/cryptography.ts
@@ -19,14 +19,6 @@ import { runCommand } from './shell';
 import { tpmOpensslParams } from './tpm';
 
 /**
- * The path to the OpenSSL config file
- */
-export const OPENSSL_CONFIG_FILE_PATH = path.join(
-  __dirname,
-  '../certs/openssl.cnf'
-);
-
-/**
  * The static header for a public key in DER format
  */
 export const PUBLIC_KEY_IN_DER_FORMAT_HEADER = Buffer.of(


### PR DESCRIPTION
Missed this back when I opened https://github.com/votingworks/vxsuite/pull/5620. The config file referenced by this variable no longer exists, and this variable is also now unused.