### PR TITLE
feat(image-utils): enable `toMatchPdfSnapshot` with `vitest`

### DIFF
--- a/apps/admin/backend/test/setup_custom_matchers.ts
+++ b/apps/admin/backend/test/setup_custom_matchers.ts
@@ -1,6 +1,6 @@
 import {
   ToMatchPdfSnapshotOptions,
-  toMatchPdfSnapshot,
+  buildToMatchPdfSnapshot,
 } from '@votingworks/image-utils';
 import { toMatchImageSnapshot } from 'jest-image-snapshot';
 
@@ -13,4 +13,7 @@ declare global {
   }
 }
 
-expect.extend({ toMatchImageSnapshot, toMatchPdfSnapshot });
+expect.extend({
+  toMatchImageSnapshot,
+  toMatchPdfSnapshot: buildToMatchPdfSnapshot(expect),
+});

--- a/apps/central-scan/backend/test/setup_custom_matchers.ts
+++ b/apps/central-scan/backend/test/setup_custom_matchers.ts
@@ -1,6 +1,6 @@
 import {
   ToMatchPdfSnapshotOptions,
-  toMatchPdfSnapshot,
+  buildToMatchPdfSnapshot,
 } from '@votingworks/image-utils';
 import { toMatchImageSnapshot } from 'jest-image-snapshot';
 
@@ -13,4 +13,7 @@ declare global {
   }
 }
 
-expect.extend({ toMatchImageSnapshot, toMatchPdfSnapshot });
+expect.extend({
+  toMatchImageSnapshot,
+  toMatchPdfSnapshot: buildToMatchPdfSnapshot(expect),
+});

--- a/apps/design/backend/test/setupTests.ts
+++ b/apps/design/backend/test/setupTests.ts
@@ -1,5 +1,5 @@
 import {
-  toMatchPdfSnapshot,
+  buildToMatchPdfSnapshot,
   ToMatchPdfSnapshotOptions,
 } from '@votingworks/image-utils';
 import { cleanupCachedBrowser } from '@votingworks/printing';
@@ -18,4 +18,7 @@ declare global {
   }
 }
 
-expect.extend({ toMatchImageSnapshot, toMatchPdfSnapshot });
+expect.extend({
+  toMatchImageSnapshot,
+  toMatchPdfSnapshot: buildToMatchPdfSnapshot(expect),
+});

--- a/apps/mark-scan/backend/test/setup_custom_matchers.ts
+++ b/apps/mark-scan/backend/test/setup_custom_matchers.ts
@@ -3,7 +3,7 @@ import {
   ToMatchImageOptions,
   ToMatchPdfSnapshotOptions,
   toMatchImage,
-  toMatchPdfSnapshot,
+  buildToMatchPdfSnapshot,
 } from '@votingworks/image-utils';
 import { toMatchImageSnapshot } from 'jest-image-snapshot';
 import { setGracefulCleanup } from 'tmp';
@@ -24,4 +24,8 @@ declare global {
   }
 }
 
-expect.extend({ toMatchImageSnapshot, toMatchPdfSnapshot, toMatchImage });
+expect.extend({
+  toMatchImageSnapshot,
+  toMatchPdfSnapshot: buildToMatchPdfSnapshot(expect),
+  toMatchImage,
+});

--- a/apps/mark/backend/test/setup_custom_matchers.ts
+++ b/apps/mark/backend/test/setup_custom_matchers.ts
@@ -1,6 +1,6 @@
 import {
   ToMatchPdfSnapshotOptions,
-  toMatchPdfSnapshot,
+  buildToMatchPdfSnapshot,
 } from '@votingworks/image-utils';
 import { toMatchImageSnapshot } from 'jest-image-snapshot';
 
@@ -13,4 +13,7 @@ declare global {
   }
 }
 
-expect.extend({ toMatchImageSnapshot, toMatchPdfSnapshot });
+expect.extend({
+  toMatchImageSnapshot,
+  toMatchPdfSnapshot: buildToMatchPdfSnapshot(expect),
+});

--- a/apps/scan/backend/test/setup_custom_matchers.ts
+++ b/apps/scan/backend/test/setup_custom_matchers.ts
@@ -1,6 +1,6 @@
 import {
   ToMatchPdfSnapshotOptions,
-  toMatchPdfSnapshot,
+  buildToMatchPdfSnapshot,
 } from '@votingworks/image-utils';
 import { toMatchImageSnapshot } from 'jest-image-snapshot';
 
@@ -13,4 +13,7 @@ declare global {
   }
 }
 
-expect.extend({ toMatchImageSnapshot, toMatchPdfSnapshot });
+expect.extend({
+  toMatchImageSnapshot,
+  toMatchPdfSnapshot: buildToMatchPdfSnapshot(expect),
+});

--- a/libs/image-utils/src/jest_pdf_snapshot.ts
+++ b/libs/image-utils/src/jest_pdf_snapshot.ts
@@ -1,3 +1,4 @@
+import type * as vitest from 'vitest';
 import { readFile } from 'node:fs/promises';
 import { Buffer } from 'node:buffer';
 import { pdfToImages } from './pdf_to_images';
@@ -20,31 +21,37 @@ export interface ToMatchPdfSnapshotOptions {
   failureThreshold?: number;
 }
 
-/**
- * Custom `jest` matcher to compare a PDF to a snapshot. Accepts a buffer or
- * path to a PDF file. Converts the PDF to PNG files and uses
- * `jest-image-snapshot` to snapshot them.
- */
-export async function toMatchPdfSnapshot(
-  received: string | Buffer,
-  options: ToMatchPdfSnapshotOptions = {}
-): Promise<jest.CustomMatcherResult> {
-  const pdfContents =
-    typeof received === 'string' ? await readFile(received) : received;
-  const pdfPages = pdfToImages(pdfContents, { scale: 200 / 72 });
-  for await (const { page, pageNumber } of pdfPages) {
-    const imageBuffer = toImageBuffer(page);
-    expect(imageBuffer).toMatchImageSnapshot({
-      failureThreshold: options.failureThreshold ?? 0,
-      failureThresholdType: 'percent',
-      customSnapshotIdentifier: options.customSnapshotIdentifier
-        ? `${options.customSnapshotIdentifier}-${pageNumber}`
-        : undefined,
-    });
-  }
+type JestExpect = typeof expect;
 
-  return {
-    pass: true,
-    message: () => '',
+/**
+ * Builds a custom `jest` matcher to compare a PDF to a snapshot. The matcher
+ * accepts a buffer or path to a PDF file. Converts the PDF to PNG files and
+ * uses `jest-image-snapshot` to snapshot them.
+ */
+export function buildToMatchPdfSnapshot(
+  expect: JestExpect | typeof vitest.expect
+): (
+  received: string | Buffer,
+  options?: ToMatchPdfSnapshotOptions
+) => Promise<jest.CustomMatcherResult> {
+  return async (received, options = {}) => {
+    const pdfContents =
+      typeof received === 'string' ? await readFile(received) : received;
+    const pdfPages = pdfToImages(pdfContents, { scale: 200 / 72 });
+    for await (const { page, pageNumber } of pdfPages) {
+      const imageBuffer = toImageBuffer(page);
+      expect(imageBuffer).toMatchImageSnapshot({
+        failureThreshold: options.failureThreshold ?? 0,
+        failureThresholdType: 'percent',
+        customSnapshotIdentifier: options.customSnapshotIdentifier
+          ? `${options.customSnapshotIdentifier}-${pageNumber}`
+          : undefined,
+      });
+    }
+
+    return {
+      pass: true,
+      message: () => '',
+    };
   };
 }

--- a/libs/printing/test/setupTests.ts
+++ b/libs/printing/test/setupTests.ts
@@ -1,6 +1,6 @@
 import {
   ToMatchPdfSnapshotOptions,
-  toMatchPdfSnapshot,
+  buildToMatchPdfSnapshot,
 } from '@votingworks/image-utils';
 import { toMatchImageSnapshot } from 'jest-image-snapshot';
 
@@ -13,4 +13,7 @@ declare global {
   }
 }
 
-expect.extend({ toMatchImageSnapshot, toMatchPdfSnapshot });
+expect.extend({
+  toMatchImageSnapshot,
+  toMatchPdfSnapshot: buildToMatchPdfSnapshot(expect),
+});


### PR DESCRIPTION
## Overview

Enables using `toMatchPdfSnapshot` with `vitest` by turning the matcher function into a matcher builder.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated.