### PR TITLE
Add script for generating a root CA key and cert

### DIFF
--- a/libs/auth/scripts/generate-root-cert-authority-key-and-cert
+++ b/libs/auth/scripts/generate-root-cert-authority-key-and-cert
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+require('esbuild-runner').install({
+  type: 'transform',
+});
+require('./src/generate_root_cert_authority_key_and_cert').main(
+  process.argv.slice(2)
+);

--- a/libs/auth/scripts/src/check_pin.ts
+++ b/libs/auth/scripts/src/check_pin.ts
@@ -1,4 +1,4 @@
-import { createInterface } from 'node:readline';
+import readline from 'node:readline';
 import { extractErrorMessage, throwIllegalValue } from '@votingworks/basics';
 
 import { CommonAccessCard, CommonAccessCardDetails } from '../../src/cac';
@@ -21,12 +21,11 @@ function parseCommandLineArgs(args: readonly string[]): CheckPinInput {
 }
 
 async function checkPin({ cardType }: CheckPinInput): Promise<void> {
+  const rl = readline.createInterface(process.stdin, process.stdout);
   const pin = await new Promise<string>((resolve) => {
-    createInterface(process.stdin, process.stdout).question(
-      'Enter PIN: ',
-      resolve
-    );
+    rl.question('Enter PIN: ', resolve);
   });
+  rl.close();
 
   let card: PinProtectedCard &
     StatefulCard<CardDetails | CommonAccessCardDetails | undefined>;

--- a/libs/auth/scripts/src/generate_root_cert_authority_key_and_cert.ts
+++ b/libs/auth/scripts/src/generate_root_cert_authority_key_and_cert.ts
@@ -1,0 +1,96 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import yargs from 'yargs';
+import { extractErrorMessage } from '@votingworks/basics';
+
+import { CERT_EXPIRY_IN_DAYS } from '../../src/certs';
+import { generatePrivateKey, generateSelfSignedCert } from './utils';
+
+interface GenerateRootCertAuthorityKeyAndCertInput {
+  commonName: string;
+  outputDir: string;
+}
+
+async function parseCommandLineArgs(
+  args: readonly string[]
+): Promise<GenerateRootCertAuthorityKeyAndCertInput> {
+  const argParser = yargs()
+    .options({
+      'common-name': {
+        description: 'The common name to use in the cert subject',
+        type: 'string',
+      },
+      'output-dir': {
+        description: 'The directory to output the generated key and cert to',
+        type: 'string',
+      },
+    })
+    .hide('help')
+    .version(false)
+    .example('$ generate-root-cert-authority-key-and-cert --help', '')
+    .example(
+      '$ generate-root-cert-authority-key-and-cert \\\n' +
+        '--common-name "VotingWorks Development" --output-dir path/to/output-dir',
+      ''
+    )
+    .strict();
+
+  const helpMessage = await argParser.getHelp();
+  argParser.fail((errorMessage: string) => {
+    throw new Error(`${errorMessage}\n\n${helpMessage}`);
+  });
+
+  const parsedArgs = argParser.parse(args) as {
+    commonName?: string;
+    help?: boolean;
+    outputDir?: string;
+  };
+
+  if (parsedArgs.help || !parsedArgs.commonName || !parsedArgs.outputDir) {
+    console.log(helpMessage);
+    process.exit(parsedArgs.help ? 0 : 1);
+  }
+
+  return {
+    commonName: parsedArgs.commonName,
+    outputDir: parsedArgs.outputDir,
+  };
+}
+
+async function generateRootCertAuthorityKeyAndCert({
+  commonName,
+  outputDir,
+}: GenerateRootCertAuthorityKeyAndCertInput): Promise<void> {
+  await fs.mkdir(outputDir, { recursive: true });
+  const privateKeyPath = path.join(outputDir, 'private-key.pem');
+  const certPath = path.join(outputDir, 'cert.pem');
+
+  console.log('🔑 Generating private key');
+  const privateKey = await generatePrivateKey({ encrypted: true });
+  await fs.writeFile(privateKeyPath, privateKey);
+  console.log(`Private key written to: ${privateKeyPath}\n`);
+
+  console.log('🔏 Generating cert');
+  const cert = await generateSelfSignedCert({
+    privateKeyPath,
+    commonName,
+    expiryDays: CERT_EXPIRY_IN_DAYS.ROOT_CERT_AUTHORITY_CERT,
+  });
+  await fs.writeFile(certPath, cert);
+  console.log(`Cert written to: ${certPath}\n`);
+
+  console.log('✅ Done!');
+}
+
+/**
+ * A script for generating a root cert authority key and cert.
+ */
+export async function main(args: readonly string[]): Promise<void> {
+  try {
+    const userInputs = await parseCommandLineArgs(args);
+    await generateRootCertAuthorityKeyAndCert(userInputs);
+  } catch (error) {
+    console.error(`❌ ${extractErrorMessage(error)}`);
+    process.exit(1);
+  }
+}

--- a/libs/auth/scripts/src/mock_card.ts
+++ b/libs/auth/scripts/src/mock_card.ts
@@ -80,7 +80,7 @@ async function parseCommandLineArgs(
 
   if (parsedArgs.help || args.length === 0) {
     console.log(helpMessage);
-    process.exit(0);
+    process.exit(parsedArgs.help ? 0 : 1);
   }
 
   if (!parsedArgs.cardType) {

--- a/libs/auth/scripts/src/utils.ts
+++ b/libs/auth/scripts/src/utils.ts
@@ -5,15 +5,51 @@ import { generatePin, hyphenatePin } from '@votingworks/utils';
 
 import { ResponseApduError } from '../../src/apdu';
 import { CardStatusReady, StatefulCard } from '../../src/card';
+import { STANDARD_CERT_FIELDS } from '../../src/certs';
 import { openssl } from '../../src/cryptography';
 import { JavaCard } from '../../src/java_card';
 
 /**
  * Generates an ECC private key and returns the private key contents in a buffer. The key is not
- * stored in a TPM.
+ * stored in an HSM.
  */
-export async function generatePrivateKey(): Promise<Buffer> {
-  return await openssl(['ecparam', '-genkey', '-name', 'prime256v1', '-noout']);
+export async function generatePrivateKey(
+  options: { encrypted?: boolean } = {}
+): Promise<Buffer> {
+  return await openssl([
+    'genpkey',
+    '-algorithm',
+    'EC',
+    '-pkeyopt',
+    'ec_paramgen_curve:prime256v1',
+    ...(options.encrypted ? ['-aes-256-cbc'] : []),
+  ]);
+}
+
+/**
+ * Generates a self-signed cert to be used as the root in a cert chain
+ */
+export async function generateSelfSignedCert({
+  privateKeyPath,
+  commonName,
+  expiryDays,
+}: {
+  privateKeyPath: string;
+  commonName: string;
+  expiryDays: number;
+}): Promise<Buffer> {
+  const certFields = [...STANDARD_CERT_FIELDS, `CN=${commonName}`];
+  return openssl([
+    'req',
+    '-new',
+    '-x509',
+    '-key',
+    privateKeyPath,
+    '-subj',
+    `/${certFields.join('/')}`,
+    '-days',
+    `${expiryDays}`,
+  ]);
 }
 
 /**

--- a/libs/auth/scripts/src/utils.ts
+++ b/libs/auth/scripts/src/utils.ts
@@ -1,5 +1,5 @@
 import { Buffer } from 'node:buffer';
-import { sleep, throwIllegalValue } from '@votingworks/basics';
+import { assert, sleep, throwIllegalValue } from '@votingworks/basics';
 import { SystemAdministratorUser, VendorUser } from '@votingworks/types';
 import { generatePin, hyphenatePin } from '@votingworks/utils';
 
@@ -39,6 +39,10 @@ export async function generateSelfSignedCert({
   expiryDays: number;
 }): Promise<Buffer> {
   const certFields = [...STANDARD_CERT_FIELDS, `CN=${commonName}`];
+  assert(
+    certFields.every((certField) => !certField.includes('/')),
+    `Cert fields cannot contain a slash: ${certFields}`
+  );
   return openssl([
     'req',
     '-new',

--- a/libs/auth/src/certs.ts
+++ b/libs/auth/src/certs.ts
@@ -210,6 +210,7 @@ const CustomCertFieldsSchema: z.ZodSchema<CustomCertFields> = z.union([
  * Cert expiries in days. Must be integers.
  */
 export const CERT_EXPIRY_IN_DAYS = {
+  ROOT_CERT_AUTHORITY_CERT: 365 * 100, // 100 years
   MACHINE_VX_CERT: 365 * 100, // 100 years
   CARD_VX_CERT: 365 * 100, // 100 years
   VENDOR_CARD_IDENTITY_CERT: 7, // 1 week


### PR DESCRIPTION
## Overview

This PR adds a script for generating a root CA key and cert:

```
$ ./scripts/generate-root-cert-authority-key-and-cert 
Options:
  --common-name  The common name to use in the cert subject             [string]
  --output-dir   The directory to output the generated key and cert to  [string]

Examples:
  $ generate-root-cert-authority-key-and-cert --help
  $ generate-root-cert-authority-key-and-cert \
  --common-name "VotingWorks Development" --output-dir path/to/output-dir
```

```
$ ./scripts/generate-root-cert-authority-key-and-cert --common-name "Test 1234" --output-dir ~/test-1234
🔑 Generating private key
Enter PEM pass phrase:
Verifying - Enter PEM pass phrase:
Private key written to: /home/vx/test-1234/private-key.pem

🔏 Generating cert
Enter pass phrase for /home/vx/test-1234/private-key.pem:
Cert written to: /home/vx/test-1234/cert.pem

✅ Done!
```

I've run into the need to create a new root a handful of times recently, e.g., for the CACvote milestone and now for the new label QR code system. This should make that easier and more consistent and will also enforce the conventions of 1) encrypting the private key with a passphrase and 2) using a common name to distinguish the different roots.

In a subsequent PR, I'll commit an updated dev root cert with a "VotingWorks Development" common name added. That's generated using the `generate-dev-keys-and-certs` script, also updated in this PR. I'm committing that separately because that entails updating CVR fixtures (to generate a new .vxsig file) which results in a pretty big diff that bogs the GitHub UI down.

## Testing Plan

- [x] Lots of manual testing, including signing and verifying a blob using the generated outputs