### PR TITLE
Switch scanning for write-ins

### DIFF
--- a/libs/mark-flow-ui/src/components/candidate_contest.test.tsx
+++ b/libs/mark-flow-ui/src/components/candidate_contest.test.tsx
@@ -331,6 +331,32 @@ describe('supports write-in candidates', () => {
     });
   });
 
+  test('renders a virtual keyboard with scan panels when switch scanning is enabled', () => {
+    const updateVote = jest.fn();
+    render(
+      <CandidateContest
+        election={electionDefinition.election}
+        contest={candidateContestWithWriteIns}
+        vote={[]}
+        updateVote={updateVote}
+        enableSwitchScanning
+      />
+    );
+    userEvent.click(
+      screen.getByText('add write-in candidate').closest('button')!
+    );
+
+    const modal = within(screen.getByRole('alertdialog'));
+
+    modal.getByRole('heading', {
+      name: `Write-In: ${candidateContestWithWriteIns.title}`,
+    });
+    modal.getByText(hasTextAcrossElements(/characters remaining: 40/i));
+    // The default VirtualKeyboard doesn't have a button with text equal
+    // to the entire keyboard row
+    modal.getButton('Q W E R T Y U I O P');
+  });
+
   test('displays warning when deselecting a write-in candidate', () => {
     const updateVote = jest.fn();
     render(

--- a/libs/mark-flow-ui/src/components/candidate_contest.tsx
+++ b/libs/mark-flow-ui/src/components/candidate_contest.tsx
@@ -30,6 +30,7 @@ import {
   ReadOnLoad,
   AssistiveTechInstructions,
   PageNavigationButtonId,
+  ScanPanelVirtualKeyboard,
 } from '@votingworks/ui';
 import { assert } from '@votingworks/basics';
 
@@ -45,6 +46,7 @@ interface Props {
   contest: CandidateContestInterface;
   vote: CandidateVote;
   updateVote: UpdateVoteFunction;
+  enableSwitchScanning?: boolean;
 }
 
 const WriteInModalBody = styled.div`
@@ -83,6 +85,7 @@ export function CandidateContest({
   contest,
   vote,
   updateVote,
+  enableSwitchScanning,
 }: Props): JSX.Element {
   const district = getContestDistrict(election, contest);
 
@@ -465,11 +468,19 @@ export function CandidateContest({
                       </Caption>
                     </P>
                   </ReadOnLoad>
-                  <VirtualKeyboard
-                    onBackspace={onKeyboardBackspace}
-                    onKeyPress={onKeyboardInput}
-                    keyDisabled={keyDisabled}
-                  />
+                  {enableSwitchScanning ? (
+                    <ScanPanelVirtualKeyboard
+                      onBackspace={onKeyboardBackspace}
+                      onKeyPress={onKeyboardInput}
+                      keyDisabled={keyDisabled}
+                    />
+                  ) : (
+                    <VirtualKeyboard
+                      onBackspace={onKeyboardBackspace}
+                      onKeyPress={onKeyboardInput}
+                      keyDisabled={keyDisabled}
+                    />
+                  )}
                 </WriteInForm>
                 {!screenInfo.isPortrait && (
                   <WriteInModalActionsSidebar>

--- a/libs/mark-flow-ui/src/components/contest.tsx
+++ b/libs/mark-flow-ui/src/components/contest.tsx
@@ -37,6 +37,12 @@ export interface ContestProps {
    * Updates the votes for the contest.
    */
   updateVote: UpdateVoteFunction;
+
+  /**
+   * Whether the on-screen write-in keyboard should use scan panels
+   * for assistive technology input switches
+   */
+  enableSwitchScanning?: boolean;
 }
 
 export function Contest({
@@ -45,6 +51,7 @@ export function Contest({
   contest,
   votes,
   updateVote,
+  enableSwitchScanning,
 }: ContestProps): JSX.Element {
   const vote = votes[contest.id];
 
@@ -58,6 +65,7 @@ export function Contest({
           contest={contest}
           vote={(vote ?? []) as CandidateVote}
           updateVote={updateVote}
+          enableSwitchScanning={enableSwitchScanning}
         />
       )}
       {contest.type === 'yesno' && (

--- a/libs/mark-flow-ui/src/pages/contest_page.tsx
+++ b/libs/mark-flow-ui/src/pages/contest_page.tsx
@@ -182,6 +182,7 @@ export function ContestPage(props: ContestPageProps): JSX.Element {
         contest={contest}
         votes={votes}
         updateVote={handleUpdateVote}
+        enableSwitchScanning={!!isPatDeviceConnected}
       />
     </VoterScreen>
   );

--- a/libs/ui/src/button.tsx
+++ b/libs/ui/src/button.tsx
@@ -318,7 +318,7 @@ const paddingStyles: Record<SizeMode, string> = {
   touchExtraLarge: '0.15rem 0.2rem',
 };
 
-const gapStyles: Record<SizeMode, string> = {
+export const gapStyles: Record<SizeMode, string> = {
   desktop: '0.5rem',
   print: '0.5rem',
   touchSmall: '0.5rem',

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -93,6 +93,7 @@ export * from './usb_drive_image';
 export * from './power_down_button';
 export * from './verify_ballot_image';
 export * from './visual_mode_disabled_overlay';
+export * from './virtual_keyboard/scan_panel_virtual_keyboard';
 export * from './virtual_keyboard/virtual_keyboard';
 export * from './voter_contest_summary';
 export * from './with_scroll_buttons';

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -93,7 +93,7 @@ export * from './usb_drive_image';
 export * from './power_down_button';
 export * from './verify_ballot_image';
 export * from './visual_mode_disabled_overlay';
-export * from './virtual_keyboard';
+export * from './virtual_keyboard/virtual_keyboard';
 export * from './voter_contest_summary';
 export * from './with_scroll_buttons';
 export * from './search_select';

--- a/libs/ui/src/virtual_keyboard/common.ts
+++ b/libs/ui/src/virtual_keyboard/common.ts
@@ -1,0 +1,19 @@
+import { DefaultTheme } from 'styled-components';
+
+export interface Key {
+  audioLanguageOverride?: string;
+  renderAudioString: () => React.ReactNode;
+  /** @defaultvalue () => {@link value} */
+  renderLabel?: () => React.ReactNode;
+  value: string;
+}
+
+/* istanbul ignore next */
+export function getBorderWidthRem(p: { theme: DefaultTheme }): number {
+  switch (p.theme.sizeMode) {
+    case 'touchExtraLarge':
+      return p.theme.sizes.bordersRem.hairline;
+    default:
+      return p.theme.sizes.bordersRem.thin;
+  }
+}

--- a/libs/ui/src/virtual_keyboard/scan_panel_virtual_keyboard.test.tsx
+++ b/libs/ui/src/virtual_keyboard/scan_panel_virtual_keyboard.test.tsx
@@ -1,0 +1,245 @@
+import userEvent from '@testing-library/user-event';
+
+import {
+  hasTextAcrossElements,
+  mockOf,
+  TestLanguageCode,
+} from '@votingworks/test-utils';
+import { assertDefined } from '@votingworks/basics';
+
+import { act, render, screen, waitFor } from '../../test/react_testing_library';
+import { newTestContext as newUiStringsTestContext } from '../../test/test_context';
+import { AudioOnly } from '../ui_strings/audio_only';
+import { useCurrentLanguage } from '../hooks/use_current_language';
+import {
+  ScanPanelVirtualKeyboard,
+  US_ENGLISH_SCAN_PANEL_KEYMAP,
+} from './scan_panel_virtual_keyboard';
+
+jest.mock(
+  '../ui_strings/audio_only',
+  (): typeof import('../ui_strings/audio_only') => ({
+    ...jest.requireActual('../ui_strings/audio_only'),
+    AudioOnly: jest.fn(),
+  })
+);
+
+const { ENGLISH, SPANISH } = TestLanguageCode;
+
+const firstRow = 'QWERTYUIOP';
+const secondRow = `ASDFGHJKL'"`;
+const thirdRow = 'ZXCVBNM,.-';
+const fourthRow = 'space delete';
+
+function getMockAudioOnlyTextPrefix(languageCode: string) {
+  return `[AudioOnly] [${languageCode}]`;
+}
+
+beforeEach(() => {
+  mockOf(AudioOnly).mockImplementation((props) => {
+    const { children, ...rest } = props;
+    const languageCode = useCurrentLanguage();
+
+    return (
+      <span {...rest}>
+        {getMockAudioOnlyTextPrefix(languageCode)} {children}
+      </span>
+    );
+  });
+});
+
+test('fires key events', async () => {
+  const { getLanguageContext, render: renderInUiStringsContext } =
+    newUiStringsTestContext();
+
+  const onKeyPress = jest.fn();
+  const onBackspace = jest.fn();
+
+  renderInUiStringsContext(
+    <ScanPanelVirtualKeyboard
+      onBackspace={onBackspace}
+      onKeyPress={onKeyPress}
+      keyDisabled={() => false}
+    />
+  );
+
+  await waitFor(() => expect(getLanguageContext()).toBeDefined());
+
+  const { setLanguage } = assertDefined(getLanguageContext());
+  act(() => setLanguage(SPANISH));
+
+  const keysSpokenInVoterLanguage = new Set([',', '.', "'", '"', '-']);
+
+  // Ignore last row of keys (delete, space) because they don't fit this pattern
+  for (const row of US_ENGLISH_SCAN_PANEL_KEYMAP.rows.slice(0, -1)) {
+    const rowSearchValue = row
+      .map((panel) => panel.keys.map((keySpec) => keySpec.value).join(''))
+      .join('');
+    for (const panel of row) {
+      const panelSearchValue = panel.keys
+        .map((keySpec) => keySpec.value)
+        .join('');
+      for (const key of panel.keys) {
+        // Click the relevant row. After each keypress focus will reset and
+        // rows, not individual keys, will be clickable again.
+        userEvent.click(
+          screen.getByText(hasTextAcrossElements(rowSearchValue))
+        );
+        // Click the relevant scan panel
+        userEvent.click(
+          screen.getByText(hasTextAcrossElements(panelSearchValue))
+        );
+
+        const expectedLanguageCode = keysSpokenInVoterLanguage.has(key.value)
+          ? SPANISH
+          : ENGLISH;
+
+        const expectedButtonContent = `${key.value}${getMockAudioOnlyTextPrefix(
+          expectedLanguageCode
+        )} ${key.value}`;
+
+        // Using `getByText` here instead of `getButton`, since the latter is
+        // significantly slower, especially with this many iterations.
+        // The "custom keymap" test below verifies that the keys are rendered as
+        // accessible buttons.
+        userEvent.click(
+          screen.getByText(hasTextAcrossElements(expectedButtonContent))
+        );
+        expect(onKeyPress).lastCalledWith(key.value);
+      }
+    }
+  }
+
+  function clickLastRowAndScanPanel() {
+    // The last row has only one scan panel, so we click the "same" button twice
+    // Click row
+    userEvent.click(screen.getButton('space delete'));
+    // Click scan panel
+    userEvent.click(screen.getButton('space delete'));
+  }
+
+  clickLastRowAndScanPanel();
+  const spaceBar = screen.getButton(
+    `space ${getMockAudioOnlyTextPrefix(SPANISH)} space`
+  );
+  userEvent.click(spaceBar);
+  expect(onKeyPress).lastCalledWith(' ');
+
+  clickLastRowAndScanPanel();
+  expect(onBackspace).not.toHaveBeenCalled();
+
+  userEvent.click(
+    screen.getButton(`delete ${getMockAudioOnlyTextPrefix(SPANISH)} delete`)
+  );
+  expect(onBackspace).toHaveBeenCalled();
+});
+
+test('supports tab and enter keypresses to navigate the keyboard', () => {
+  const onKeyPress = jest.fn();
+  const onBackspace = jest.fn();
+
+  render(
+    <ScanPanelVirtualKeyboard
+      onBackspace={onBackspace}
+      onKeyPress={onKeyPress}
+      keyDisabled={() => false}
+    />
+  );
+
+  const firstRowElement = screen.getByText(hasTextAcrossElements(firstRow));
+  userEvent.tab();
+  expect(firstRowElement).toHaveFocus();
+  userEvent.tab();
+  expect(screen.getByText(hasTextAcrossElements(secondRow))).toHaveFocus();
+  userEvent.tab();
+  expect(screen.getByText(hasTextAcrossElements(thirdRow))).toHaveFocus();
+  userEvent.tab();
+  expect(screen.getByText(hasTextAcrossElements(fourthRow))).toHaveFocus();
+  // The next tab event will focus the whole keyboard, so tab twice to cycle around
+  userEvent.tab();
+  userEvent.tab();
+  expect(firstRowElement).toHaveFocus();
+
+  userEvent.keyboard('{enter}');
+  // After Enter event, need to press tab again to refocus first element
+  userEvent.tab();
+  expect(screen.getByText(hasTextAcrossElements('QWER'))).toHaveFocus();
+  userEvent.tab();
+  expect(screen.getByText(hasTextAcrossElements('TYU'))).toHaveFocus();
+  userEvent.keyboard('{enter}');
+  userEvent.tab();
+  // Need to use slower getButton here because getByText will find the child <span>
+  expect(
+    screen.getButton(`T ${getMockAudioOnlyTextPrefix(ENGLISH)} T`)
+  ).toHaveFocus();
+  expect(onKeyPress).not.toHaveBeenCalled();
+  userEvent.keyboard('{enter}');
+  expect(onKeyPress).toHaveBeenCalledWith('T');
+});
+
+test("doesn't fire key events for disabled keys", () => {
+  const mPanel = 'BNM';
+
+  const onKeyPress = jest.fn();
+  const onBackspace = jest.fn();
+
+  render(
+    <ScanPanelVirtualKeyboard
+      onBackspace={onBackspace}
+      onKeyPress={onKeyPress}
+      keyDisabled={(k) => k === 'M'}
+    />
+  );
+
+  userEvent.click(screen.getByText(hasTextAcrossElements(thirdRow)));
+  userEvent.click(screen.getByText(hasTextAcrossElements(mPanel)));
+
+  userEvent.click(screen.getButton(/\bM\b/));
+  expect(onKeyPress).not.toHaveBeenCalled();
+});
+
+test('custom keymap', () => {
+  const onKeyPress = jest.fn();
+  const onBackspace = jest.fn();
+
+  render(
+    <ScanPanelVirtualKeyboard
+      onBackspace={onBackspace}
+      onKeyPress={onKeyPress}
+      keyDisabled={(k) => k === 'M'}
+      keyMap={{
+        rows: [
+          [
+            {
+              keys: [
+                { value: '😂', renderAudioString: () => 'lol' },
+                {
+                  value: '✨',
+                  renderAudioString: () => 'magic',
+                  renderLabel: () => 'magic',
+                },
+              ],
+            },
+          ],
+        ],
+      }}
+    />
+  );
+
+  // Click twice, once for row and once for scan panel
+  userEvent.click(screen.getByText(hasTextAcrossElements('😂magic')));
+  userEvent.click(screen.getByText(hasTextAcrossElements('😂magic')));
+
+  userEvent.click(
+    screen.getButton(`😂 ${getMockAudioOnlyTextPrefix(ENGLISH)} lol`)
+  );
+  expect(onKeyPress).lastCalledWith('😂');
+
+  // Click row and panel again after focus has reset
+  userEvent.click(screen.getByText(hasTextAcrossElements('😂magic')));
+  userEvent.click(screen.getByText(hasTextAcrossElements('😂magic')));
+  userEvent.click(
+    screen.getButton(`magic ${getMockAudioOnlyTextPrefix(ENGLISH)} magic`)
+  );
+  expect(onKeyPress).lastCalledWith('✨');
+});

--- a/libs/ui/src/virtual_keyboard/scan_panel_virtual_keyboard.tsx
+++ b/libs/ui/src/virtual_keyboard/scan_panel_virtual_keyboard.tsx
@@ -1,0 +1,471 @@
+import { useCallback, useState } from 'react';
+import styled, { DefaultTheme, StyledComponent } from 'styled-components';
+import { Icons } from '../icons';
+import { appStrings } from '../ui_strings';
+import { SPACE_BAR_KEY } from './virtual_keyboard';
+import { Key } from './common';
+import { ScanPanelRow } from './scan_panels/scan_panel_row';
+import { KeyButton } from './scan_panels/key_button';
+import { ScanPanel, ScanPanelRenderOption } from './scan_panels/scan_panel';
+import { buttonStyles, gapStyles } from '../button';
+
+const Keyboard = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+
+  & button {
+    ${buttonStyles}
+  }
+
+  /* Overrides buttonStyles's justify-content.
+   * https://styled-components.com/docs/faqs#how-can-i-override-styles-with-higher-specificity
+  */
+  && button {
+    justify-content: space-between;
+  }
+`;
+
+const SpaceBarDisplay = styled.span`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex-grow: 1;
+  border-right: 1px solid;
+  border-color: ${(p) => p.theme.colors.outline};
+  gap: ${(p) => gapStyles[p.theme.sizeMode]};
+`;
+
+const DeleteKey = styled.div`
+  display: flex;
+
+  & svg {
+    margin-right: ${(p) => gapStyles[p.theme.sizeMode]};
+  }
+`;
+
+const SpaceBarButton = styled.span`
+  flex-grow: 1;
+
+  && button {
+    width: 100%;
+    justify-content: center;
+  }
+`;
+
+export interface ScanPanelVirtualKeyboardProps {
+  onKeyPress: (key: string) => void;
+  onBackspace: () => void;
+  keyDisabled(key: string): boolean;
+  keyMap?: ScanPanelKeyMap;
+}
+
+interface KeyWithRenderSpec extends Key {
+  renderWithComponent?: {
+    button: StyledComponent<'span', DefaultTheme, object, never>;
+    display: StyledComponent<'span', DefaultTheme, object, never>;
+  };
+}
+
+interface ScanPanel {
+  keys: KeyWithRenderSpec[];
+}
+
+interface ScanPanelKeyMap {
+  rows: Array<ScanPanel[]>;
+}
+
+// NOTE: Although the letter keys here are rendered and spoken in English, the
+// punctuation keys are spoken in the currently selected user language, if any,
+// to improve comprehension for audio-only users.
+//
+// This assumes all current and future VxSuite supported languages have names
+// for these punctuation symbols. We may need to update this logic if we find
+// that to not be true for a language we add in the future.
+export const US_ENGLISH_SCAN_PANEL_KEYMAP: ScanPanelKeyMap = {
+  rows: [
+    [
+      {
+        keys: [
+          {
+            value: 'Q',
+            renderAudioString: () => appStrings.letterQ(),
+            audioLanguageOverride: 'en',
+          },
+          {
+            value: 'W',
+            renderAudioString: () => appStrings.letterW(),
+            audioLanguageOverride: 'en',
+          },
+          {
+            value: 'E',
+            renderAudioString: () => appStrings.letterE(),
+            audioLanguageOverride: 'en',
+          },
+          {
+            value: 'R',
+            renderAudioString: () => appStrings.letterR(),
+            audioLanguageOverride: 'en',
+          },
+        ],
+      },
+      {
+        keys: [
+          {
+            value: 'T',
+            renderAudioString: () => appStrings.letterT(),
+            audioLanguageOverride: 'en',
+          },
+          {
+            value: 'Y',
+            renderAudioString: () => appStrings.letterY(),
+            audioLanguageOverride: 'en',
+          },
+          {
+            value: 'U',
+            renderAudioString: () => appStrings.letterU(),
+            audioLanguageOverride: 'en',
+          },
+        ],
+      },
+      {
+        keys: [
+          {
+            value: 'I',
+            renderAudioString: () => appStrings.letterI(),
+            audioLanguageOverride: 'en',
+          },
+          {
+            value: 'O',
+            renderAudioString: () => appStrings.letterO(),
+            audioLanguageOverride: 'en',
+          },
+          {
+            value: 'P',
+            renderAudioString: () => appStrings.letterP(),
+            audioLanguageOverride: 'en',
+          },
+        ],
+      },
+    ],
+    [
+      {
+        keys: [
+          {
+            value: 'A',
+            renderAudioString: () => appStrings.letterA(),
+            audioLanguageOverride: 'en',
+          },
+          {
+            value: 'S',
+            renderAudioString: () => appStrings.letterS(),
+            audioLanguageOverride: 'en',
+          },
+          {
+            value: 'D',
+            renderAudioString: () => appStrings.letterD(),
+            audioLanguageOverride: 'en',
+          },
+          {
+            value: 'F',
+            renderAudioString: () => appStrings.letterF(),
+            audioLanguageOverride: 'en',
+          },
+        ],
+      },
+      {
+        keys: [
+          {
+            value: 'G',
+            renderAudioString: () => appStrings.letterG(),
+            audioLanguageOverride: 'en',
+          },
+          {
+            value: 'H',
+            renderAudioString: () => appStrings.letterH(),
+            audioLanguageOverride: 'en',
+          },
+          {
+            value: 'J',
+            renderAudioString: () => appStrings.letterJ(),
+            audioLanguageOverride: 'en',
+          },
+          {
+            value: 'K',
+            renderAudioString: () => appStrings.letterK(),
+            audioLanguageOverride: 'en',
+          },
+        ],
+      },
+      {
+        keys: [
+          {
+            value: 'L',
+            renderAudioString: () => appStrings.letterL(),
+            audioLanguageOverride: 'en',
+          },
+          {
+            value: "'",
+            renderAudioString: () => appStrings.labelKeyboardSingleQuote(),
+          },
+          {
+            value: '"',
+            renderAudioString: () => appStrings.labelKeyboardDoubleQuote(),
+          },
+        ],
+      },
+    ],
+    [
+      {
+        keys: [
+          {
+            value: 'Z',
+            renderAudioString: () => appStrings.letterZ(),
+            audioLanguageOverride: 'en',
+          },
+          {
+            value: 'X',
+            renderAudioString: () => appStrings.letterX(),
+            audioLanguageOverride: 'en',
+          },
+          {
+            value: 'C',
+            renderAudioString: () => appStrings.letterC(),
+            audioLanguageOverride: 'en',
+          },
+          {
+            value: 'V',
+            renderAudioString: () => appStrings.letterV(),
+            audioLanguageOverride: 'en',
+          },
+        ],
+      },
+      {
+        keys: [
+          {
+            value: 'B',
+            renderAudioString: () => appStrings.letterB(),
+            audioLanguageOverride: 'en',
+          },
+          {
+            value: 'N',
+            renderAudioString: () => appStrings.letterN(),
+            audioLanguageOverride: 'en',
+          },
+          {
+            value: 'M',
+            renderAudioString: () => appStrings.letterM(),
+            audioLanguageOverride: 'en',
+          },
+        ],
+      },
+      {
+        keys: [
+          {
+            value: ',',
+            renderAudioString: () => appStrings.labelKeyboardComma(),
+          },
+          {
+            value: '.',
+            renderAudioString: () => appStrings.labelKeyboardPeriod(),
+          },
+          {
+            value: '-',
+            renderAudioString: () => appStrings.labelKeyboardHyphen(),
+          },
+        ],
+      },
+    ],
+    [
+      {
+        keys: [
+          {
+            ...SPACE_BAR_KEY,
+            renderWithComponent: {
+              button: SpaceBarButton,
+              display: SpaceBarDisplay,
+            },
+          },
+          {
+            value: 'delete',
+            renderAudioString: () => appStrings.labelKeyboardDelete(),
+            renderLabel: () => (
+              <DeleteKey>
+                <Icons.Backspace /> {appStrings.labelKeyboardDelete()}
+              </DeleteKey>
+            ),
+          },
+        ],
+      },
+    ],
+  ],
+};
+
+enum SelectionLevel {
+  Rows,
+  ScanPanels,
+  Keys,
+}
+
+export function ScanPanelVirtualKeyboard({
+  onBackspace,
+  onKeyPress,
+  keyDisabled,
+  keyMap = US_ENGLISH_SCAN_PANEL_KEYMAP,
+}: ScanPanelVirtualKeyboardProps): JSX.Element {
+  const [selectionLevel, setSelectionLevel] = useState<SelectionLevel>(
+    SelectionLevel.Rows
+  );
+  const [selectedRowIndex, setSelectedRowIndex] = useState<number>(-1);
+  const [selectedScanPanelIndex, setSelectedScanPanelIndex] =
+    useState<number>(-1);
+
+  function rowIsSelected(index: number) {
+    return selectionLevel !== SelectionLevel.Rows && index === selectedRowIndex;
+  }
+
+  function scanPanelIsSelected(index: number) {
+    return (
+      selectionLevel === SelectionLevel.Keys && index === selectedScanPanelIndex
+    );
+  }
+
+  function getScanPanelRenderOption(
+    rowIndex: number,
+    panelIndex: number
+  ): ScanPanelRenderOption {
+    // 3 cases:
+    // 1. Render as enabled button (parent row selected, no scan panel selected)
+    // 2. Render as disabled button (parent row selected, other scan panel in same row selected)
+    // 3. Render as simple div container (row selected, this scan panel selected)
+    if (rowIsSelected(rowIndex)) {
+      const anyScanPanelIsSelected = selectionLevel === SelectionLevel.Keys;
+      if (anyScanPanelIsSelected) {
+        return scanPanelIsSelected(panelIndex)
+          ? 'container'
+          : 'button-disabled';
+      }
+      return 'button-enabled';
+    }
+
+    /* istanbul ignore next - scan panel is currently never rendered unless the parent row is selected */
+    throw new Error(
+      'Rendering a scan panel without its parent row selected is undefined behavior.'
+    );
+  }
+
+  const resetFocusState = useCallback(() => {
+    setSelectionLevel(SelectionLevel.Rows);
+    setSelectedRowIndex(-1);
+    setSelectedScanPanelIndex(-1);
+  }, [setSelectionLevel, setSelectedRowIndex, setSelectedScanPanelIndex]);
+
+  function onSelectRow(i: number) {
+    setSelectionLevel(SelectionLevel.ScanPanels);
+    setSelectedRowIndex(i);
+    setSelectedScanPanelIndex(0);
+  }
+
+  function onSelectScanPanel(i: number) {
+    setSelectionLevel(SelectionLevel.Keys);
+    setSelectedScanPanelIndex(i);
+  }
+
+  // Handler for when a key (letter, punctuation, delete, etc) is selected
+  function onSelectKey(key: string) {
+    resetFocusState();
+
+    if (key.toLowerCase() === 'delete') {
+      onBackspace();
+      return;
+    }
+
+    onKeyPress(key);
+  }
+
+  function renderKey(
+    keySpec: KeyWithRenderSpec,
+    rowIndex?: number,
+    panelIndex?: number
+  ) {
+    const { value, renderWithComponent } = keySpec;
+    const selectable =
+      selectionLevel === SelectionLevel.Keys &&
+      rowIndex !== undefined &&
+      selectedRowIndex === rowIndex &&
+      panelIndex !== undefined &&
+      selectedScanPanelIndex === panelIndex;
+
+    const keyComponent = (
+      <KeyButton
+        key={value}
+        keySpec={keySpec}
+        onKeyPress={onSelectKey}
+        disabled={keyDisabled(value)}
+        selectable={selectable}
+      />
+    );
+
+    if (renderWithComponent) {
+      const Wrapper = selectable
+        ? renderWithComponent.button
+        : renderWithComponent.display;
+      return <Wrapper key={value}>{keyComponent}</Wrapper>;
+    }
+
+    return keyComponent;
+  }
+
+  function renderFlatRow(row: ScanPanel[], rowIndex: number) {
+    // Flatten a row of scan panels into a list of Key specs
+    const keySpecs = row
+      .map((panel) => panel.keys.map((keySpec) => keySpec))
+      .reduce((acc, r) => acc.concat(r));
+
+    // Render a Row of KeyButtons without the intermediate ScanPanels
+    return (
+      <ScanPanelRow
+        onSelect={() => onSelectRow(rowIndex)}
+        key={`row-${keySpecs.map((spec) => spec.value).join()}`}
+        selectable={selectionLevel === SelectionLevel.Rows}
+        selected={selectedRowIndex === rowIndex}
+      >
+        {keySpecs.map((keySpec) => renderKey(keySpec, rowIndex))}
+      </ScanPanelRow>
+    );
+  }
+
+  return (
+    <Keyboard data-testid="virtual-keyboard">
+      {keyMap.rows.map((row, rowIndex) => {
+        if (rowIsSelected(rowIndex) && selectionLevel !== SelectionLevel.Rows) {
+          const panels = row.map((panel, panelIndex) => (
+            <ScanPanel
+              numKeys={panel.keys.length}
+              key={panel.keys.map((k) => k.value).join()}
+              renderAs={getScanPanelRenderOption(rowIndex, panelIndex)}
+              onSelect={() => onSelectScanPanel(panelIndex)}
+            >
+              {panel.keys.map((keySpec) =>
+                renderKey(keySpec, rowIndex, panelIndex)
+              )}
+            </ScanPanel>
+          ));
+
+          return (
+            <ScanPanelRow
+              key={`row-${row
+                .map((panel) => panel.keys.map((k) => k.value).join())
+                .join()}`}
+              selectable={false}
+              selected={selectedRowIndex === rowIndex}
+            >
+              {panels}
+            </ScanPanelRow>
+          );
+        }
+
+        return renderFlatRow(row, rowIndex);
+      })}
+    </Keyboard>
+  );
+}

--- a/libs/ui/src/virtual_keyboard/scan_panels/key_button.tsx
+++ b/libs/ui/src/virtual_keyboard/scan_panels/key_button.tsx
@@ -1,0 +1,66 @@
+import styled from 'styled-components';
+import { Button } from '../../button';
+import { WithAltAudio } from '../../ui_strings';
+import { getBorderWidthRem, Key } from '../common';
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+
+  button {
+    border-width: ${getBorderWidthRem}rem;
+    font-weight: ${(p) => p.theme.sizes.fontWeight.semiBold};
+    min-height: ${(p) => p.theme.sizes.minTouchAreaSizePx}px;
+    min-width: ${(p) => p.theme.sizes.minTouchAreaSizePx}px;
+
+    &:disabled {
+      border-width: ${getBorderWidthRem}rem;
+    }
+  }
+`;
+
+export interface KeyButtonProps {
+  keySpec: Key;
+  onKeyPress: (key: string) => void;
+  disabled: boolean;
+  selectable: boolean;
+}
+
+/**
+ * KeyButton is a visual representation of a single keyboard key.
+ */
+export function KeyButton({
+  keySpec,
+  onKeyPress,
+  disabled,
+  selectable,
+}: KeyButtonProps): JSX.Element {
+  const {
+    audioLanguageOverride,
+    renderAudioString,
+    value,
+    renderLabel = () => value,
+  } = keySpec;
+
+  return (
+    <Wrapper>
+      {selectable ? (
+        <Button
+          key={value}
+          value={value}
+          onPress={onKeyPress}
+          disabled={disabled}
+        >
+          <WithAltAudio
+            audioLanguageOverride={audioLanguageOverride}
+            audioText={renderAudioString()}
+          >
+            {renderLabel()}
+          </WithAltAudio>
+        </Button>
+      ) : (
+        renderLabel()
+      )}
+    </Wrapper>
+  );
+}

--- a/libs/ui/src/virtual_keyboard/scan_panels/scan_panel.tsx
+++ b/libs/ui/src/virtual_keyboard/scan_panels/scan_panel.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import styled from 'styled-components';
+import { gapStyles } from '../../button';
+import { getBorderWidthRem } from '../common';
+
+interface StyledComponentProps {
+  numKeys: number;
+}
+const ScanPanelButton = styled.button<StyledComponentProps>`
+  flex-grow: ${(p) => p.numKeys};
+  border-width: ${getBorderWidthRem}rem;
+`;
+
+const ScanPanelDisplay = styled.div<StyledComponentProps>`
+  display: flex;
+  flex-grow: ${(p) => p.numKeys};
+  justify-content: space-between;
+  gap: ${(p) => gapStyles[p.theme.sizeMode]};
+`;
+
+export type ScanPanelRenderOption =
+  | 'button-enabled'
+  | 'button-disabled'
+  | 'container';
+
+interface ScanPanelProps {
+  children?: React.ReactNode;
+  numKeys: number;
+  onSelect: () => void;
+  renderAs: ScanPanelRenderOption;
+}
+
+export function ScanPanel({
+  children,
+  renderAs,
+  numKeys,
+  onSelect,
+}: ScanPanelProps): JSX.Element {
+  switch (renderAs) {
+    case 'button-enabled':
+      return (
+        <ScanPanelButton numKeys={numKeys} onClick={onSelect}>
+          {children}
+        </ScanPanelButton>
+      );
+    case 'button-disabled':
+      return (
+        <ScanPanelButton numKeys={numKeys} onClick={onSelect} disabled>
+          {children}
+        </ScanPanelButton>
+      );
+    case 'container':
+    default:
+      return <ScanPanelDisplay numKeys={numKeys}>{children}</ScanPanelDisplay>;
+  }
+}

--- a/libs/ui/src/virtual_keyboard/scan_panels/scan_panel_row.tsx
+++ b/libs/ui/src/virtual_keyboard/scan_panels/scan_panel_row.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const RowButton = styled.button`
+  margin-bottom: ${(p) => p.theme.sizes.minTouchAreaSeparationPx}px;
+  flex-basis: 100%;
+`;
+
+const RowDisplay = styled.div`
+  display: flex;
+  gap: ${(p) => p.theme.sizes.minTouchAreaSeparationPx}px;
+  margin-bottom: ${(p) => p.theme.sizes.minTouchAreaSeparationPx}px;
+  flex-grow: 1;
+`;
+
+interface ScanPanelRowProps {
+  children?: React.ReactNode;
+  onSelect?: () => void;
+  selectable: boolean;
+  selected: boolean;
+}
+
+export function ScanPanelRow({
+  children,
+  onSelect = () => {},
+  selectable,
+  selected,
+}: ScanPanelRowProps): JSX.Element {
+  return selected ? (
+    <RowDisplay>{children}</RowDisplay>
+  ) : (
+    <RowButton onClick={onSelect} disabled={!selectable}>
+      {children}
+    </RowButton>
+  );
+}

--- a/libs/ui/src/virtual_keyboard/virtual_keyboard.test.tsx
+++ b/libs/ui/src/virtual_keyboard/virtual_keyboard.test.tsx
@@ -7,16 +7,16 @@ import {
 } from '@votingworks/test-utils';
 import { assertDefined } from '@votingworks/basics';
 
-import { act, render, screen, waitFor } from '../test/react_testing_library';
+import { act, render, screen, waitFor } from '../../test/react_testing_library';
 import { US_ENGLISH_KEYMAP, VirtualKeyboard } from './virtual_keyboard';
-import { newTestContext as newUiStringsTestContext } from '../test/test_context';
-import { AudioOnly } from './ui_strings/audio_only';
-import { useCurrentLanguage } from './hooks/use_current_language';
+import { newTestContext as newUiStringsTestContext } from '../../test/test_context';
+import { AudioOnly } from '../ui_strings/audio_only';
+import { useCurrentLanguage } from '../hooks/use_current_language';
 
 jest.mock(
-  './ui_strings/audio_only',
-  (): typeof import('./ui_strings/audio_only') => ({
-    ...jest.requireActual('./ui_strings/audio_only'),
+  '../ui_strings/audio_only',
+  (): typeof import('../ui_strings/audio_only') => ({
+    ...jest.requireActual('../ui_strings/audio_only'),
     AudioOnly: jest.fn(),
   })
 );

--- a/libs/ui/src/virtual_keyboard/virtual_keyboard.tsx
+++ b/libs/ui/src/virtual_keyboard/virtual_keyboard.tsx
@@ -1,19 +1,9 @@
-import React from 'react';
-import styled, { DefaultTheme } from 'styled-components';
+import styled from 'styled-components';
 
-import { Button } from './button';
-import { Icons } from './icons';
-import { WithAltAudio, appStrings } from './ui_strings';
-
-/* istanbul ignore next */
-function getBorderWidthRem(p: { theme: DefaultTheme }): number {
-  switch (p.theme.sizeMode) {
-    case 'touchExtraLarge':
-      return p.theme.sizes.bordersRem.hairline;
-    default:
-      return p.theme.sizes.bordersRem.thin;
-  }
-}
+import { Button } from '../button';
+import { Icons } from '../icons';
+import { WithAltAudio, appStrings } from '../ui_strings';
+import { getBorderWidthRem, Key } from './common';
 
 const Keyboard = styled.div`
   & button {
@@ -47,14 +37,6 @@ export interface VirtualKeyboardProps {
   onBackspace: () => void;
   keyDisabled(key: string): boolean;
   keyMap?: KeyMap;
-}
-
-interface Key {
-  audioLanguageOverride?: string;
-  renderAudioString: () => React.ReactNode;
-  /** @defaultvalue () => {@link value} */
-  renderLabel?: () => React.ReactNode;
-  value: string;
 }
 
 interface KeyMap {


### PR DESCRIPTION
## Overview

Adds scan panels to the candidate write-in screen. See [this doc](https://docs.google.com/document/d/1nan1Gwrb0CCC757h1UYK4pdGVmiUwSfuuZ2-VNZ_hpQ/edit?tab=t.0#heading=h.77fs298fyke8) for more details.

There are a few necessary follow-ups that I think should be in separate PRs to keep diff size down:
* audio strings for rows and scan panels
* resetting focus state after
  * tabbing through all scan panels in a row twice
  * tabbing through all keys in a scan panel twice
* remapping ATI controller direction pad for the default virtual keyboard

Note that the row with `Space` and `Delete` is a row of a single scan panel, so a voter needs to select the row, then the scan panel, and finally the desired key. I went back and forth on this decision but landed this way because
* it maintains consistency with the row -> panel -> key hierarchy of other rows
* it reduces special-casing in the code

Open to discussion on this interaction pattern because it has a major downside of forcing more actions from the voter than strictly necessary. The alternative is to render a row of keys, skipping the intermediate scan panel.

## Demo Video or Screenshot


https://github.com/user-attachments/assets/83005670-e9b5-48e8-9d36-19ebf0e87f5d

<img width="426" alt="Screenshot 2024-12-16 at 6 48 21 PM" src="https://github.com/user-attachments/assets/0209f248-d9f0-4922-a0e3-6561882817f4" />
<img width="429" alt="Screenshot 2024-12-16 at 6 48 28 PM" src="https://github.com/user-attachments/assets/9247c331-626f-457c-a782-703d5cdbc96e" />
<img width="431" alt="Screenshot 2024-12-16 at 6 48 36 PM" src="https://github.com/user-attachments/assets/a2bf6e28-50b9-4bb5-b9f8-70db250f4418" />
<img width="433" alt="Screenshot 2024-12-16 at 6 48 55 PM" src="https://github.com/user-attachments/assets/fb3be11d-4896-45be-9bb5-1431a3298eec" />

Non-default font sizes:

<img width="429" alt="Screenshot 2024-12-16 at 7 58 55 PM" src="https://github.com/user-attachments/assets/1787ae15-4424-45d3-8bc0-1124aadb5d41" />
<img width="433" alt="Screenshot 2024-12-16 at 7 59 01 PM" src="https://github.com/user-attachments/assets/718ffc5b-a8b6-4620-a6c6-b7d5756af7e7" />
<img width="429" alt="Screenshot 2024-12-16 at 7 59 05 PM" src="https://github.com/user-attachments/assets/5d64bf7b-a5db-4505-a9c9-56a52c7796c6" />
<img width="430" alt="Screenshot 2024-12-16 at 7 59 15 PM" src="https://github.com/user-attachments/assets/0acc43d0-5f70-4790-81f0-dc21a2d21ac3" />
<img width="432" alt="Screenshot 2024-12-16 at 7 59 20 PM" src="https://github.com/user-attachments/assets/cc82cc9e-c009-40b3-a4a9-525cb677d03d" />
<img width="434" alt="Screenshot 2024-12-16 at 7 59 25 PM" src="https://github.com/user-attachments/assets/f77d201e-bfa4-4bd7-8b11-284a56f31dad" />
<img width="434" alt="Screenshot 2024-12-16 at 7 59 38 PM" src="https://github.com/user-attachments/assets/2b7ccab4-1757-4a25-8e38-3e2388d7de30" />
<img width="430" alt="Screenshot 2024-12-16 at 7 59 43 PM" src="https://github.com/user-attachments/assets/9f521228-1747-41e6-bcd1-bac1cce88143" />
<img width="432" alt="Screenshot 2024-12-16 at 7 59 49 PM" src="https://github.com/user-attachments/assets/628246dc-422b-43c3-b94f-d779221b74a5" />

## Testing Plan
-  [x] added automated tests

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
