### PR TITLE
test(logging): replace `jest` with `vitest`

### DIFF
--- a/apps/admin/backend/src/adjudication.test.ts
+++ b/apps/admin/backend/src/adjudication.test.ts
@@ -107,7 +107,7 @@ test('adjudicateVote', () => {
 
 test('adjudicateWriteIn', async () => {
   const store = Store.memoryStore();
-  const logger = mockBaseLogger();
+  const logger = mockBaseLogger({ fn: jest.fn });
   const { electionDefinition } = electionTwoPartyPrimaryFixtures;
   const { electionData } = electionDefinition;
   const electionId = store.addElection({

--- a/apps/admin/backend/src/server.test.ts
+++ b/apps/admin/backend/src/server.test.ts
@@ -19,7 +19,10 @@ beforeEach(() => {
 
 test('starts with default logger and port', async () => {
   const auth = buildMockDippedSmartCardAuth();
-  const workspace = createWorkspace(dirSync().name, mockBaseLogger());
+  const workspace = createWorkspace(
+    dirSync().name,
+    mockBaseLogger({ fn: jest.fn })
+  );
   const logger = buildMockLogger(auth, workspace);
   const { usbDrive } = createMockUsbDrive();
   const { printer } = createMockPrinterHandler();
@@ -43,7 +46,10 @@ test('starts with default logger and port', async () => {
 
 test('start with config options', async () => {
   const auth = buildMockDippedSmartCardAuth();
-  const workspace = createWorkspace(dirSync().name, mockBaseLogger());
+  const workspace = createWorkspace(
+    dirSync().name,
+    mockBaseLogger({ fn: jest.fn })
+  );
   const logger = buildMockLogger(auth, workspace);
   const { usbDrive } = createMockUsbDrive();
   const { printer } = createMockPrinterHandler();
@@ -65,7 +71,10 @@ test('start with config options', async () => {
 
 test('errors on start with no workspace', async () => {
   const auth = buildMockDippedSmartCardAuth();
-  const workspace = createWorkspace(dirSync().name, mockBaseLogger());
+  const workspace = createWorkspace(
+    dirSync().name,
+    mockBaseLogger({ fn: jest.fn })
+  );
   const logger = buildMockLogger(auth, workspace);
   const { usbDrive } = createMockUsbDrive();
   const { printer } = createMockPrinterHandler();
@@ -98,7 +107,10 @@ test('errors on start with no workspace', async () => {
 
 test('logs device attach/un-attach events', async () => {
   const auth = buildMockDippedSmartCardAuth();
-  const workspace = createWorkspace(dirSync().name, mockBaseLogger());
+  const workspace = createWorkspace(
+    dirSync().name,
+    mockBaseLogger({ fn: jest.fn })
+  );
   const logger = buildMockLogger(auth, workspace);
   const { usbDrive } = createMockUsbDrive();
   const { printer } = createMockPrinterHandler();

--- a/apps/admin/backend/src/store.test.ts
+++ b/apps/admin/backend/src/store.test.ts
@@ -29,7 +29,7 @@ test('create a file store', async () => {
   const tmpDir = tmpNameSync();
   await fs.mkdir(tmpDir);
   const tmpDbPath = join(tmpDir, 'ballots.db');
-  const store = Store.fileStore(tmpDbPath, mockBaseLogger());
+  const store = Store.fileStore(tmpDbPath, mockBaseLogger({ fn: jest.fn }));
 
   expect(store).toBeInstanceOf(Store);
   expect(store.getDbPath()).toEqual(tmpDbPath);
@@ -606,7 +606,7 @@ test('deleteElection reclaims disk space (vacuums the database)', async () => {
   const tmpDir = tmpNameSync();
   await fs.mkdir(tmpDir);
   const tmpDbPath = join(tmpDir, 'data.db');
-  const store = Store.fileStore(tmpDbPath, mockBaseLogger());
+  const store = Store.fileStore(tmpDbPath, mockBaseLogger({ fn: jest.fn }));
 
   const electionId = store.addElection({
     electionData:

--- a/apps/admin/backend/src/tabulation/election_results_reporting.test.ts
+++ b/apps/admin/backend/src/tabulation/election_results_reporting.test.ts
@@ -10,7 +10,7 @@ test('reads and parses an Election Results Reporting file', async () => {
   const filepath = tmpNameSync();
   await writeFile(filepath, JSON.stringify(errContents));
 
-  const logger = mockLogger();
+  const logger = mockLogger({ fn: jest.fn });
 
   const result = await parseElectionResultsReportingFile(filepath, logger);
   assert(result.isOk(), 'Unexpected error in test when parsing ERR file');
@@ -18,7 +18,7 @@ test('reads and parses an Election Results Reporting file', async () => {
 });
 
 test('logs on file reading error', async () => {
-  const logger = mockLogger();
+  const logger = mockLogger({ fn: jest.fn });
   const result = await parseElectionResultsReportingFile(
     './not/a/real/filepath',
     logger

--- a/apps/admin/backend/src/tabulation/full_results.test.ts
+++ b/apps/admin/backend/src/tabulation/full_results.test.ts
@@ -293,7 +293,7 @@ const candidateContestId =
 
 test('tabulateElectionResults - write-in handling', async () => {
   const store = Store.memoryStore();
-  const logger = mockBaseLogger();
+  const logger = mockBaseLogger({ fn: jest.fn });
 
   const { electionDefinition, castVoteRecordExport } =
     electionGridLayoutNewHampshireTestBallotFixtures;
@@ -702,7 +702,7 @@ test('tabulateElectionResults - write-in handling', async () => {
 
 test('tabulateElectionResults - group and filter by voting method', async () => {
   const store = Store.memoryStore();
-  const logger = mockBaseLogger();
+  const logger = mockBaseLogger({ fn: jest.fn });
   const { electionDefinition, castVoteRecordExport } =
     electionGridLayoutNewHampshireTestBallotFixtures;
   const { election, electionData } = electionDefinition;

--- a/apps/admin/backend/src/util/workspace.test.ts
+++ b/apps/admin/backend/src/util/workspace.test.ts
@@ -19,7 +19,7 @@ const initializeGetWorkspaceDiskSpaceSummaryMock = mockOf(
 
 test('createWorkspace', () => {
   const dir = tmp.dirSync();
-  const workspace = createWorkspace(dir.name, mockBaseLogger());
+  const workspace = createWorkspace(dir.name, mockBaseLogger({ fn: jest.fn }));
   expect(workspace.path).toEqual(dir.name);
   expect(workspace.store).toBeInstanceOf(Store);
 });
@@ -30,7 +30,7 @@ test('disk space tracking setup', () => {
   initializeGetWorkspaceDiskSpaceSummaryMock.mockReturnValueOnce(
     getWorkspaceDiskSpaceSummary
   );
-  const workspace = createWorkspace(dir.name, mockBaseLogger());
+  const workspace = createWorkspace(dir.name, mockBaseLogger({ fn: jest.fn }));
   expect(initializeGetWorkspaceDiskSpaceSummaryMock).toHaveBeenCalledTimes(1);
   expect(initializeGetWorkspaceDiskSpaceSummaryMock).toHaveBeenCalledWith(
     workspace.store,

--- a/apps/admin/backend/test/app.ts
+++ b/apps/admin/backend/test/app.ts
@@ -148,7 +148,10 @@ export function buildTestEnvironment(workspaceRoot?: string) {
       deleteTmpFileAfterTestSuiteCompletes(defaultWorkspaceRoot);
       return defaultWorkspaceRoot;
     })();
-  const workspace = createWorkspace(resolvedWorkspaceRoot, mockBaseLogger());
+  const workspace = createWorkspace(
+    resolvedWorkspaceRoot,
+    mockBaseLogger({ fn: jest.fn })
+  );
   const logger = buildMockLogger(auth, workspace);
   const mockUsbDrive = createMockUsbDrive();
   const mockPrinterHandler = createMockPrinterHandler();

--- a/apps/admin/backend/test/app.ts
+++ b/apps/admin/backend/test/app.ts
@@ -135,6 +135,7 @@ export function buildMockLogger(
   return mockLogger({
     source: LogSource.VxAdminService,
     getCurrentRole: () => getUserRole(auth, workspace),
+    fn: jest.fn,
   });
 }
 

--- a/apps/central-scan/backend/src/app.deprecated_api.test.ts
+++ b/apps/central-scan/backend/src/app.deprecated_api.test.ts
@@ -44,7 +44,7 @@ let mockUsbDrive: MockUsbDrive;
 
 beforeEach(() => {
   auth = buildMockDippedSmartCardAuth();
-  workspace = createWorkspace(dirSync().name, mockBaseLogger());
+  workspace = createWorkspace(dirSync().name, mockBaseLogger({ fn: jest.fn }));
   workspace.store.setElectionAndJurisdiction({
     electionData:
       electionGridLayoutNewHampshireTestBallotFixtures.electionDefinition

--- a/apps/central-scan/backend/src/auth.test.ts
+++ b/apps/central-scan/backend/src/auth.test.ts
@@ -33,7 +33,7 @@ let logger: Logger;
 beforeEach(async () => {
   const port = await getPort();
   auth = buildMockDippedSmartCardAuth();
-  workspace = createWorkspace(dirSync().name, mockBaseLogger());
+  workspace = createWorkspace(dirSync().name, mockBaseLogger({ fn: jest.fn }));
   logger = buildMockLogger(auth, workspace);
   const scanner = makeMockScanner();
 

--- a/apps/central-scan/backend/src/importer.test.ts
+++ b/apps/central-scan/backend/src/importer.test.ts
@@ -6,12 +6,15 @@ import { createWorkspace } from './util/workspace';
 import { makeMockScanner } from '../test/util/mocks';
 
 test('no election is configured', async () => {
-  const workspace = createWorkspace(dirSync().name, mockBaseLogger());
+  const workspace = createWorkspace(
+    dirSync().name,
+    mockBaseLogger({ fn: jest.fn })
+  );
   const scanner = makeMockScanner();
   const importer = new Importer({
     workspace,
     scanner,
-    logger: mockLogger(),
+    logger: mockLogger({ fn: jest.fn }),
   });
 
   await expect(importer.startImport()).rejects.toThrowError(

--- a/apps/central-scan/backend/src/server.test.ts
+++ b/apps/central-scan/backend/src/server.test.ts
@@ -13,7 +13,10 @@ import { start } from './server';
 
 test('logs device attach/un-attach events', async () => {
   const auth = buildMockDippedSmartCardAuth();
-  const workspace = createWorkspace(dirSync().name, mockBaseLogger());
+  const workspace = createWorkspace(
+    dirSync().name,
+    mockBaseLogger({ fn: jest.fn })
+  );
   const logger = buildMockLogger(auth, workspace);
   const { usbDrive } = createMockUsbDrive();
   const scanner = makeMockScanner();

--- a/apps/central-scan/backend/src/store.test.ts
+++ b/apps/central-scan/backend/src/store.test.ts
@@ -161,7 +161,7 @@ test('get/set scanner as backed up', () => {
 
 test('batch cleanup works correctly', () => {
   const dbFile = tmp.fileSync();
-  const store = Store.fileStore(dbFile.name, mockBaseLogger());
+  const store = Store.fileStore(dbFile.name, mockBaseLogger({ fn: jest.fn }));
 
   store.reset();
 
@@ -730,7 +730,7 @@ test('iterating over each accepted sheet includes correct batch sequence id', ()
 
 test('resetElectionSession', () => {
   const dbFile = tmp.fileSync();
-  const store = Store.fileStore(dbFile.name, mockBaseLogger());
+  const store = Store.fileStore(dbFile.name, mockBaseLogger({ fn: jest.fn }));
   store.setElectionAndJurisdiction({
     electionData,
     jurisdiction,

--- a/apps/central-scan/backend/src/util/workspace.test.ts
+++ b/apps/central-scan/backend/src/util/workspace.test.ts
@@ -22,7 +22,7 @@ test('disk space tracking setup', () => {
   initializeGetWorkspaceDiskSpaceSummaryMock.mockReturnValueOnce(
     getWorkspaceDiskSpaceSummary
   );
-  const workspace = createWorkspace(dir.name, mockBaseLogger());
+  const workspace = createWorkspace(dir.name, mockBaseLogger({ fn: jest.fn }));
   expect(initializeGetWorkspaceDiskSpaceSummaryMock).toHaveBeenCalledTimes(1);
   expect(initializeGetWorkspaceDiskSpaceSummaryMock).toHaveBeenCalledWith(
     workspace.store,

--- a/apps/central-scan/backend/test/helpers/setup_app.ts
+++ b/apps/central-scan/backend/test/helpers/setup_app.ts
@@ -49,7 +49,10 @@ export async function withApp(
 ): Promise<void> {
   const port = await getPort();
   const auth = buildMockDippedSmartCardAuth();
-  const workspace = createWorkspace(dirSync().name, mockBaseLogger());
+  const workspace = createWorkspace(
+    dirSync().name,
+    mockBaseLogger({ fn: jest.fn })
+  );
   const logger = buildMockLogger(auth, workspace);
   const scanner = makeMockScanner();
   const importer = new Importer({ workspace, scanner, logger });

--- a/apps/central-scan/backend/test/helpers/setup_app.ts
+++ b/apps/central-scan/backend/test/helpers/setup_app.ts
@@ -30,6 +30,7 @@ export function buildMockLogger(
   return mockLogger({
     source: LogSource.VxCentralScanService,
     getCurrentRole: () => getUserRole(auth, workspace),
+    fn: jest.fn,
   });
 }
 

--- a/apps/central-scan/frontend/src/screens/ballot_eject_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/ballot_eject_screen.test.tsx
@@ -48,7 +48,7 @@ test('says the sheet is unreadable if it is', async () => {
     })
   );
 
-  const logger = mockBaseLogger();
+  const logger = mockBaseLogger({ fn: jest.fn });
 
   renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock, logger });
 
@@ -159,7 +159,7 @@ test('says the ballot sheet is overvoted if it is', async () => {
     })
   );
 
-  const logger = mockBaseLogger();
+  const logger = mockBaseLogger({ fn: jest.fn });
 
   renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock, logger });
 
@@ -271,7 +271,7 @@ test('says the ballot sheet is undervoted if it is', async () => {
     })
   );
 
-  const logger = mockBaseLogger();
+  const logger = mockBaseLogger({ fn: jest.fn });
 
   renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock, logger });
 
@@ -390,7 +390,7 @@ test('says the ballot sheet is blank if it is', async () => {
     })
   );
 
-  const logger = mockBaseLogger();
+  const logger = mockBaseLogger({ fn: jest.fn });
 
   renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock, logger });
 
@@ -458,7 +458,7 @@ test('calls out official ballot sheets in test mode', async () => {
     })
   );
 
-  const logger = mockBaseLogger();
+  const logger = mockBaseLogger({ fn: jest.fn });
 
   renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock, logger });
 
@@ -524,7 +524,7 @@ test('calls out test ballot sheets in live mode', async () => {
     })
   );
 
-  const logger = mockBaseLogger();
+  const logger = mockBaseLogger({ fn: jest.fn });
 
   renderInAppContext(<BallotEjectScreen isTestMode={false} />, {
     apiMock,
@@ -577,7 +577,7 @@ test('shows invalid election screen when appropriate', async () => {
     })
   );
 
-  const logger = mockBaseLogger();
+  const logger = mockBaseLogger({ fn: jest.fn });
 
   renderInAppContext(<BallotEjectScreen isTestMode={false} />, {
     apiMock,
@@ -693,7 +693,7 @@ test('does not allow tabulating the overvote if disallowCastingOvervotes is set'
     })
   );
 
-  const logger = mockBaseLogger();
+  const logger = mockBaseLogger({ fn: jest.fn });
 
   renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock, logger });
 
@@ -734,7 +734,7 @@ test('says the scanner needs cleaning if a streak is detected', async () => {
     })
   );
 
-  const logger = mockBaseLogger();
+  const logger = mockBaseLogger({ fn: jest.fn });
 
   renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock, logger });
 

--- a/apps/design/backend/test/helpers.ts
+++ b/apps/design/backend/test/helpers.ts
@@ -34,7 +34,10 @@ export function testSetupHelpers() {
   const servers: Server[] = [];
 
   function setupApp() {
-    const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger());
+    const workspace = createWorkspace(
+      tmp.dirSync().name,
+      mockBaseLogger({ fn: jest.fn })
+    );
     const { store } = workspace;
     const speechSynthesizer = new GoogleCloudSpeechSynthesizerWithDbCache({
       store,

--- a/apps/mark-scan/backend/src/app.preprinted_ballot_insertion.test.ts
+++ b/apps/mark-scan/backend/src/app.preprinted_ballot_insertion.test.ts
@@ -20,9 +20,13 @@ function getMockStateMachine() {
 
 function buildTestApi() {
   const store = Store.memoryStore();
-  const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger(), {
-    store,
-  });
+  const workspace = createWorkspace(
+    tmp.dirSync().name,
+    mockBaseLogger({ fn: jest.fn }),
+    {
+      store,
+    }
+  );
   const mockAuth = buildMockInsertedSmartCardAuth();
   const mockStateMachine = getMockStateMachine();
 

--- a/apps/mark-scan/backend/src/app.test.ts
+++ b/apps/mark-scan/backend/src/app.test.ts
@@ -634,7 +634,10 @@ test('addDiagnosticRecord', async () => {
 });
 
 test('startPaperHandlerDiagnostic fails test if no state machine', async () => {
-  const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger());
+  const workspace = createWorkspace(
+    tmp.dirSync().name,
+    mockBaseLogger({ fn: jest.fn })
+  );
   const app = buildApp(mockAuth, logger, workspace, mockUsbDrive.usbDrive);
   const serverNoStateMachine = app.listen();
   const { port } = serverNoStateMachine.address() as AddressInfo;

--- a/apps/mark-scan/backend/src/app.ui_strings.test.ts
+++ b/apps/mark-scan/backend/src/app.ui_strings.test.ts
@@ -30,9 +30,13 @@ jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
 }));
 
 const store = Store.memoryStore();
-const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger(), {
-  store,
-});
+const workspace = createWorkspace(
+  tmp.dirSync().name,
+  mockBaseLogger({ fn: jest.fn }),
+  {
+    store,
+  }
+);
 const mockAuth = buildMockInsertedSmartCardAuth();
 const electionDefinition = safeParseElectionDefinition(
   JSON.stringify(testCdfBallotDefinition)

--- a/apps/mark-scan/backend/src/audio/outputs.test.ts
+++ b/apps/mark-scan/backend/src/audio/outputs.test.ts
@@ -21,7 +21,7 @@ jest.mock('@votingworks/basics', (): typeof import('@votingworks/basics') => ({
 const mockExecFile = mockOf(execFile);
 const mockSleep = mockOf(sleep);
 const mockGetNodeEnv = mockOf(getNodeEnv);
-const mockLog = mockLogger();
+const mockLog = mockLogger({ fn: jest.fn });
 
 test('setAudioOutput - success on retry', async () => {
   mockGetNodeEnv.mockReturnValue('production');

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -170,9 +170,9 @@ beforeAll(
 beforeEach(async () => {
   featureFlagMock.resetFeatureFlags();
 
-  logger = mockLogger();
+  logger = mockLogger({ fn: jest.fn });
   auth = buildMockInsertedSmartCardAuth();
-  workspace = createWorkspace(dirSync().name, mockBaseLogger());
+  workspace = createWorkspace(dirSync().name, mockBaseLogger({ fn: jest.fn }));
   workspace.store.setElectionAndJurisdiction({
     electionData: electionGeneralDefinition.electionData,
     jurisdiction: TEST_JURISDICTION,

--- a/apps/mark-scan/backend/src/pat-input/connection_status_reader.test.ts
+++ b/apps/mark-scan/backend/src/pat-input/connection_status_reader.test.ts
@@ -12,7 +12,7 @@ import { FAI_100_STATUS_FILENAME } from './constants';
 const ASCII_ZERO = 48;
 const ASCII_ONE = 49;
 
-let logger: MockBaseLogger;
+let logger: MockBaseLogger<typeof jest.fn>;
 let mockWorkspaceDir: tmp.DirResult;
 // Replaces /sys/class/gpio
 let mockGpioDir: tmp.DirResult;
@@ -26,7 +26,7 @@ function expectedStatusToAsciiChar(expectedStatus: boolean) {
 beforeEach(() => {
   mockWorkspaceDir = tmp.dirSync();
   mockGpioDir = tmp.dirSync();
-  logger = mockBaseLogger();
+  logger = mockBaseLogger({ fn: jest.fn });
 });
 
 test('logs when it cannot access the gpio pin sysfs file', async () => {

--- a/apps/mark-scan/backend/src/pat-input/mock_connection_status_reader.test.ts
+++ b/apps/mark-scan/backend/src/pat-input/mock_connection_status_reader.test.ts
@@ -1,11 +1,11 @@
 import { MockBaseLogger, mockBaseLogger } from '@votingworks/logging';
 import { MockPatConnectionStatusReader } from './mock_connection_status_reader';
 
-let logger: MockBaseLogger;
+let logger: MockBaseLogger<typeof jest.fn>;
 let mockReader: MockPatConnectionStatusReader;
 
 beforeEach(() => {
-  logger = mockBaseLogger();
+  logger = mockBaseLogger({ fn: jest.fn });
   mockReader = new MockPatConnectionStatusReader(logger);
 });
 

--- a/apps/mark-scan/backend/src/server.test.ts
+++ b/apps/mark-scan/backend/src/server.test.ts
@@ -33,8 +33,11 @@ afterEach(() => {
 
 test('can start server', async () => {
   const auth = buildMockInsertedSmartCardAuth();
-  const logger = mockLogger();
-  const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger());
+  const logger = mockLogger({ fn: jest.fn });
+  const workspace = createWorkspace(
+    tmp.dirSync().name,
+    mockBaseLogger({ fn: jest.fn })
+  );
 
   const server = await start({
     auth,
@@ -53,8 +56,11 @@ test('can start without providing auth', async () => {
     BooleanEnvironmentVariableName.USE_MOCK_CARDS
   );
 
-  const logger = mockLogger();
-  const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger());
+  const logger = mockLogger({ fn: jest.fn });
+  const workspace = createWorkspace(
+    tmp.dirSync().name,
+    mockBaseLogger({ fn: jest.fn })
+  );
 
   const server = await start({
     logger,
@@ -70,8 +76,11 @@ test('logs device attach/un-attach events', async () => {
   featureFlagMock.enableFeatureFlag(
     BooleanEnvironmentVariableName.USE_MOCK_CARDS
   );
-  const logger = mockLogger();
-  const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger());
+  const logger = mockLogger({ fn: jest.fn });
+  const workspace = createWorkspace(
+    tmp.dirSync().name,
+    mockBaseLogger({ fn: jest.fn })
+  );
 
   const server = await start({
     logger,
@@ -89,7 +98,7 @@ test('resolveDriver returns a mock driver if feature flag is on', async () => {
   featureFlagMock.enableFeatureFlag(
     BooleanEnvironmentVariableName.USE_MOCK_PAPER_HANDLER
   );
-  const logger = mockLogger();
+  const logger = mockLogger({ fn: jest.fn });
 
   const driver = await resolveDriver(logger);
   expect(driver).toBeInstanceOf(MockPaperHandlerDriver);

--- a/apps/mark-scan/backend/src/util/hardware.test.ts
+++ b/apps/mark-scan/backend/src/util/hardware.test.ts
@@ -30,7 +30,7 @@ let tmpFile: tmp.FileResult;
 beforeEach(() => {
   workspaceDir = tmp.dirSync();
   tmpFile = tmp.fileSync({ name: PID_FILENAME, dir: workspaceDir.name });
-  logger = mockLogger();
+  logger = mockLogger({ fn: jest.fn });
 
   processKillSpy = jest.spyOn(process, 'kill').mockImplementation((pid) => {
     if (pid === MOCK_PID) {

--- a/apps/mark-scan/backend/src/util/render_ballot.test.ts
+++ b/apps/mark-scan/backend/src/util/render_ballot.test.ts
@@ -47,7 +47,10 @@ let workspace: Workspace;
 
 beforeEach(() => {
   const mockWorkspaceDir = tmp.dirSync();
-  workspace = createWorkspace(mockWorkspaceDir.name, mockBaseLogger());
+  workspace = createWorkspace(
+    mockWorkspaceDir.name,
+    mockBaseLogger({ fn: jest.fn })
+  );
   workspace.store.setElectionAndJurisdiction({
     electionData: electionGeneralDefinition.electionData,
     jurisdiction: TEST_JURISDICTION,

--- a/apps/mark-scan/backend/src/util/workspace.test.ts
+++ b/apps/mark-scan/backend/src/util/workspace.test.ts
@@ -17,7 +17,10 @@ const initializeGetWorkspaceDiskSpaceSummaryMock = mockOf(
 );
 
 test('workspace.reset rests the store', () => {
-  const workspace = createWorkspace(dirSync().name, mockBaseLogger());
+  const workspace = createWorkspace(
+    dirSync().name,
+    mockBaseLogger({ fn: jest.fn })
+  );
   const fn = jest.fn();
   workspace.store.reset = fn;
   workspace.reset();
@@ -30,7 +33,7 @@ test('disk space tracking setup', () => {
   initializeGetWorkspaceDiskSpaceSummaryMock.mockReturnValueOnce(
     getWorkspaceDiskSpaceSummary
   );
-  const workspace = createWorkspace(dir.name, mockBaseLogger());
+  const workspace = createWorkspace(dir.name, mockBaseLogger({ fn: jest.fn }));
   expect(initializeGetWorkspaceDiskSpaceSummaryMock).toHaveBeenCalledTimes(1);
   expect(initializeGetWorkspaceDiskSpaceSummaryMock).toHaveBeenCalledWith(
     workspace.store,

--- a/apps/mark-scan/backend/test/app_helpers.ts
+++ b/apps/mark-scan/backend/test/app_helpers.ts
@@ -96,7 +96,10 @@ export async function createApp(
   options?: CreateAppOptions
 ): Promise<MockAppContents> {
   const mockAuth = buildMockInsertedSmartCardAuth();
-  const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger());
+  const workspace = createWorkspace(
+    tmp.dirSync().name,
+    mockBaseLogger({ fn: jest.fn })
+  );
   const logger = buildMockLogger(mockAuth, workspace);
   const mockUsbDrive = createMockUsbDrive();
   const patConnectionStatusReader =

--- a/apps/mark-scan/backend/test/app_helpers.ts
+++ b/apps/mark-scan/backend/test/app_helpers.ts
@@ -48,6 +48,7 @@ export function buildMockLogger(
   return mockLogger({
     source: LogSource.VxMarkScanBackend,
     getCurrentRole: () => getUserRole(auth, workspace),
+    fn: jest.fn,
   });
 }
 

--- a/apps/mark-scan/frontend/test/helpers/build_app.tsx
+++ b/apps/mark-scan/frontend/test/helpers/build_app.tsx
@@ -8,7 +8,7 @@ export function buildApp(apiMock: ReturnType<typeof createApiMock>): {
   reload: () => void;
   renderApp: () => RenderResult;
 } {
-  const logger = mockBaseLogger();
+  const logger = mockBaseLogger({ fn: jest.fn });
   const reload = jest.fn();
   function renderApp() {
     return render(<App logger={logger} apiClient={apiMock.mockApiClient} />);

--- a/apps/mark/backend/src/app.ui_strings.test.ts
+++ b/apps/mark/backend/src/app.ui_strings.test.ts
@@ -36,9 +36,13 @@ jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
 }));
 
 const store = Store.memoryStore();
-const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger(), {
-  store,
-});
+const workspace = createWorkspace(
+  tmp.dirSync().name,
+  mockBaseLogger({ fn: jest.fn }),
+  {
+    store,
+  }
+);
 const mockAuth = buildMockInsertedSmartCardAuth();
 const electionDefinition = safeParseElectionDefinition(
   JSON.stringify(testCdfBallotDefinition)

--- a/apps/mark/backend/src/server.test.ts
+++ b/apps/mark/backend/src/server.test.ts
@@ -17,8 +17,11 @@ jest.mock(
 
 test('can start server', async () => {
   const auth = buildMockInsertedSmartCardAuth();
-  const baseLogger = mockBaseLogger();
-  const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger());
+  const baseLogger = mockBaseLogger({ fn: jest.fn });
+  const workspace = createWorkspace(
+    tmp.dirSync().name,
+    mockBaseLogger({ fn: jest.fn })
+  );
 
   const server = await start({
     auth,

--- a/apps/mark/backend/src/util/workspace.test.ts
+++ b/apps/mark/backend/src/util/workspace.test.ts
@@ -3,7 +3,10 @@ import { mockBaseLogger } from '@votingworks/logging';
 import { createWorkspace } from './workspace';
 
 test('workspace.reset rests the store', () => {
-  const workspace = createWorkspace(dirSync().name, mockBaseLogger());
+  const workspace = createWorkspace(
+    dirSync().name,
+    mockBaseLogger({ fn: jest.fn })
+  );
   const fn = jest.fn();
   workspace.store.reset = fn;
   workspace.reset();

--- a/apps/mark/backend/test/app_helpers.ts
+++ b/apps/mark/backend/test/app_helpers.ts
@@ -56,7 +56,10 @@ export function buildMockLogger(
 }
 
 export function createApp(): MockAppContents {
-  const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger());
+  const workspace = createWorkspace(
+    tmp.dirSync().name,
+    mockBaseLogger({ fn: jest.fn })
+  );
   const mockAuth = buildMockInsertedSmartCardAuth();
   const logger = buildMockLogger(mockAuth, workspace);
   const mockUsbDrive = createMockUsbDrive();

--- a/apps/mark/backend/test/app_helpers.ts
+++ b/apps/mark/backend/test/app_helpers.ts
@@ -52,6 +52,7 @@ export function buildMockLogger(
   return mockLogger({
     source: LogSource.VxMarkBackend,
     getCurrentRole: () => getUserRole(auth, workspace),
+    fn: jest.fn,
   });
 }
 

--- a/apps/mark/frontend/src/app_election_package_config.test.tsx
+++ b/apps/mark/frontend/src/app_election_package_config.test.tsx
@@ -28,7 +28,7 @@ test('renders an error if election package config endpoint returns an error', as
   render(
     <App
       reload={jest.fn()}
-      logger={mockBaseLogger()}
+      logger={mockBaseLogger({ fn: jest.fn })}
       apiClient={apiMock.mockApiClient}
     />
   );

--- a/apps/mark/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark/frontend/src/app_end_to_end.test.tsx
@@ -43,7 +43,7 @@ afterEach(() => {
 jest.setTimeout(60_000);
 
 test('MarkAndPrint end-to-end flow', async () => {
-  const logger = mockBaseLogger();
+  const logger = mockBaseLogger({ fn: jest.fn });
   const electionDefinition = electionGeneralDefinition;
   const electionKey = constructElectionKey(electionDefinition.election);
   apiMock.expectGetMachineConfig({

--- a/apps/mark/frontend/test/helpers/build_app.tsx
+++ b/apps/mark/frontend/test/helpers/build_app.tsx
@@ -8,7 +8,7 @@ export function buildApp(apiMock: ReturnType<typeof createApiMock>): {
   reload: () => void;
   renderApp: () => RenderResult;
 } {
-  const logger = mockBaseLogger();
+  const logger = mockBaseLogger({ fn: jest.fn });
   const reload = jest.fn();
   function renderApp() {
     return render(

--- a/apps/scan/backend/src/app_ui_strings.test.ts
+++ b/apps/scan/backend/src/app_ui_strings.test.ts
@@ -40,9 +40,13 @@ jest.mock('@votingworks/utils', (): typeof import('@votingworks/utils') => ({
 }));
 
 const store = Store.memoryStore();
-const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger(), {
-  store,
-});
+const workspace = createWorkspace(
+  tmp.dirSync().name,
+  mockBaseLogger({ fn: jest.fn }),
+  {
+    store,
+  }
+);
 const mockUsbDrive = createMockUsbDrive();
 const { printer } = createMockPrinterHandler();
 const mockAuth = buildMockInsertedSmartCardAuth();

--- a/apps/scan/backend/src/polls.test.ts
+++ b/apps/scan/backend/src/polls.test.ts
@@ -4,7 +4,7 @@ import { openPolls } from './polls';
 import { Store } from './store';
 
 test('opening polls fails if ballots have already been scanned', async () => {
-  const logger = mockLogger();
+  const logger = mockLogger({ fn: jest.fn });
   const store = Store.memoryStore();
   jest.spyOn(store, 'getBallotsCounted').mockReturnValue(1);
 

--- a/apps/scan/backend/src/scanners/pdi/pdi_app_scan_disconnect.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_scan_disconnect.test.ts
@@ -72,7 +72,10 @@ test('scanner disconnected on startup', async () => {
   mockScanner.client.connect.mockResolvedValue(err({ code: 'disconnected' }));
   const clock = new SimulatedClock();
   const mockAuth = buildMockInsertedSmartCardAuth();
-  const workspace = createWorkspace(dirSync().name, mockBaseLogger());
+  const workspace = createWorkspace(
+    dirSync().name,
+    mockBaseLogger({ fn: jest.fn })
+  );
   const mockUsbDrive = createMockUsbDrive();
   const logger = buildMockLogger(mockAuth, workspace);
   const precinctScannerMachine = createPrecinctScannerStateMachine({

--- a/apps/scan/backend/src/server.test.ts
+++ b/apps/scan/backend/src/server.test.ts
@@ -16,7 +16,7 @@ const buildAppMock = buildApp as jest.MockedFunction<typeof buildApp>;
 let workspace!: Workspace;
 
 beforeEach(() => {
-  workspace = createWorkspace(dirSync().name, mockBaseLogger());
+  workspace = createWorkspace(dirSync().name, mockBaseLogger({ fn: jest.fn }));
 });
 
 afterEach(() => {

--- a/apps/scan/backend/src/store.test.ts
+++ b/apps/scan/backend/src/store.test.ts
@@ -312,7 +312,7 @@ test('get/set polls state', () => {
 
 test('batch cleanup works correctly', () => {
   const dbFile = tmp.fileSync();
-  const store = Store.fileStore(dbFile.name, mockBaseLogger());
+  const store = Store.fileStore(dbFile.name, mockBaseLogger({ fn: jest.fn }));
 
   store.reset();
 
@@ -638,7 +638,7 @@ test('getSheet', () => {
 
 test('resetElectionSession', async () => {
   const dbFile = tmp.fileSync();
-  const store = Store.fileStore(dbFile.name, mockBaseLogger());
+  const store = Store.fileStore(dbFile.name, mockBaseLogger({ fn: jest.fn }));
   store.setElectionAndJurisdiction({
     electionData:
       electionGridLayoutNewHampshireTestBallotFixtures.electionDefinition

--- a/apps/scan/backend/src/util/workspace.test.ts
+++ b/apps/scan/backend/src/util/workspace.test.ts
@@ -19,7 +19,7 @@ const initializeGetWorkspaceDiskSpaceSummaryMock = mockOf(
 
 test('createWorkspace', () => {
   const dir = tmp.dirSync();
-  const workspace = createWorkspace(dir.name, mockBaseLogger());
+  const workspace = createWorkspace(dir.name, mockBaseLogger({ fn: jest.fn }));
   expect(workspace.path).toEqual(dir.name);
   expect(workspace.store).toBeInstanceOf(Store);
 });
@@ -30,7 +30,7 @@ test('disk space tracking setup', () => {
   initializeGetWorkspaceDiskSpaceSummaryMock.mockReturnValueOnce(
     getWorkspaceDiskSpaceSummary
   );
-  const workspace = createWorkspace(dir.name, mockBaseLogger());
+  const workspace = createWorkspace(dir.name, mockBaseLogger({ fn: jest.fn }));
   expect(initializeGetWorkspaceDiskSpaceSummaryMock).toHaveBeenCalledTimes(1);
   expect(initializeGetWorkspaceDiskSpaceSummaryMock).toHaveBeenCalledWith(
     workspace.store,

--- a/apps/scan/backend/test/helpers/custom_helpers.ts
+++ b/apps/scan/backend/test/helpers/custom_helpers.ts
@@ -86,7 +86,10 @@ export async function withApp(
   }) => Promise<void>
 ): Promise<void> {
   const mockAuth = buildMockInsertedSmartCardAuth();
-  const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger());
+  const workspace = createWorkspace(
+    tmp.dirSync().name,
+    mockBaseLogger({ fn: jest.fn })
+  );
   const logger = buildMockLogger(mockAuth, workspace);
   const mockScanner = mocks.mockCustomScanner();
   const mockUsbDrive = createMockUsbDrive();

--- a/apps/scan/backend/test/helpers/pdi_helpers.ts
+++ b/apps/scan/backend/test/helpers/pdi_helpers.ts
@@ -143,7 +143,10 @@ export async function withApp(
   }) => Promise<void>
 ): Promise<void> {
   const mockAuth = buildMockInsertedSmartCardAuth();
-  const workspace = createWorkspace(tmp.dirSync().name, mockBaseLogger());
+  const workspace = createWorkspace(
+    tmp.dirSync().name,
+    mockBaseLogger({ fn: jest.fn })
+  );
   const logger = buildMockLogger(mockAuth, workspace);
   const mockUsbDrive = createMockUsbDrive();
   mockUsbDrive.usbDrive.sync.expectOptionalRepeatedCallsWith().resolves(); // Called by continuous export

--- a/apps/scan/backend/test/helpers/shared_helpers.ts
+++ b/apps/scan/backend/test/helpers/shared_helpers.ts
@@ -143,6 +143,7 @@ export function buildMockLogger(
   return mockLogger({
     source: LogSource.VxScanBackend,
     getCurrentRole: () => getUserRole(auth, workspace),
+    fn: jest.fn,
   });
 }
 

--- a/libs/backend/src/detect_devices.test.ts
+++ b/libs/backend/src/detect_devices.test.ts
@@ -3,7 +3,7 @@ import { detectDevices } from './detect_devices';
 import { testDetectDevices } from './test_detect_devices';
 
 test('detectDevices', () => {
-  const logger = mockBaseLogger();
+  const logger = mockBaseLogger({ fn: jest.fn });
   detectDevices({ logger });
   testDetectDevices(logger);
 });

--- a/libs/backend/src/election_package/election_package_io.test.ts
+++ b/libs/backend/src/election_package/election_package_io.test.ts
@@ -415,7 +415,7 @@ test('readElectionPackageFromUsb can read an election package from usb', async (
   const electionPackageResult = await readSignedElectionPackageFromUsb(
     authStatus,
     mockUsbDrive.usbDrive,
-    mockBaseLogger()
+    mockBaseLogger({ fn: jest.fn })
   );
   assert(electionPackageResult.isOk());
   const { electionPackage } = electionPackageResult.ok();
@@ -452,7 +452,7 @@ test("readElectionPackageFromUsb uses default system settings when system settin
   const electionPackageResult = await readSignedElectionPackageFromUsb(
     authStatus,
     mockUsbDrive.usbDrive,
-    mockBaseLogger()
+    mockBaseLogger({ fn: jest.fn })
   );
   assert(electionPackageResult.isOk());
   const { electionPackage } = electionPackageResult.ok();
@@ -472,7 +472,7 @@ test('errors if logged-out auth is passed', async () => {
     await mockElectionPackageFileTree({ electionDefinition })
   );
 
-  const logger = mockBaseLogger();
+  const logger = mockBaseLogger({ fn: jest.fn });
 
   const electionPackageResult = await readSignedElectionPackageFromUsb(
     authStatus,
@@ -507,7 +507,7 @@ test('errors if election key on provided auth is different than election package
   const electionPackageResult = await readSignedElectionPackageFromUsb(
     authStatus,
     mockUsbDrive.usbDrive,
-    mockBaseLogger()
+    mockBaseLogger({ fn: jest.fn })
   );
   assert(electionPackageResult.isErr());
   expect(electionPackageResult.err()).toEqual('election_key_mismatch');
@@ -529,7 +529,7 @@ test('errors if there is no election package on usb drive', async () => {
   const electionPackageResult = await readSignedElectionPackageFromUsb(
     authStatus,
     mockUsbDrive.usbDrive,
-    mockBaseLogger()
+    mockBaseLogger({ fn: jest.fn })
   );
   assert(electionPackageResult.isErr());
   expect(electionPackageResult.err()).toEqual(
@@ -554,7 +554,7 @@ test('errors if a user is authenticated but is not an election manager', async (
     readSignedElectionPackageFromUsb(
       authStatus,
       mockUsbDrive.usbDrive,
-      mockBaseLogger()
+      mockBaseLogger({ fn: jest.fn })
     )
   ).rejects.toThrow(
     'Only election managers may configure an election package.'
@@ -609,7 +609,7 @@ test('configures using the most recently created election package for an electio
   const electionPackageResult = await readSignedElectionPackageFromUsb(
     authStatus,
     mockUsbDrive.usbDrive,
-    mockBaseLogger()
+    mockBaseLogger({ fn: jest.fn })
   );
   assert(electionPackageResult.isOk());
   const { electionPackage } = electionPackageResult.ok();
@@ -675,7 +675,7 @@ test('configures using the most recently created election package across electio
   const electionPackageResult = await readSignedElectionPackageFromUsb(
     authStatus,
     mockUsbDrive.usbDrive,
-    mockBaseLogger()
+    mockBaseLogger({ fn: jest.fn })
   );
   assert(electionPackageResult.isOk());
   const { electionPackage } = electionPackageResult.ok();
@@ -725,7 +725,7 @@ test('ignores hidden `.`-prefixed files, even if they are newer', async () => {
   const electionPackageResult = await readSignedElectionPackageFromUsb(
     authStatus,
     mockUsbDrive.usbDrive,
-    mockBaseLogger()
+    mockBaseLogger({ fn: jest.fn })
   );
   assert(electionPackageResult.isOk());
   const { electionPackage } = electionPackageResult.ok();
@@ -759,7 +759,7 @@ test('readElectionPackageFromUsb returns error result if election package authen
   const electionPackageResult = await readSignedElectionPackageFromUsb(
     authStatus,
     mockUsbDrive.usbDrive,
-    mockBaseLogger()
+    mockBaseLogger({ fn: jest.fn })
   );
   expect(electionPackageResult).toEqual(
     err('election_package_authentication_error')
@@ -793,7 +793,7 @@ test('readElectionPackageFromUsb ignores election package authentication errors 
   const electionPackageResult = await readSignedElectionPackageFromUsb(
     authStatus,
     mockUsbDrive.usbDrive,
-    mockBaseLogger()
+    mockBaseLogger({ fn: jest.fn })
   );
   expect(electionPackageResult.isOk()).toEqual(true);
 });

--- a/libs/backend/src/system_call/api.test.ts
+++ b/libs/backend/src/system_call/api.test.ts
@@ -29,7 +29,7 @@ let api: SystemCallApi;
 beforeEach(() => {
   (process.env.VX_CONFIG_ROOT as string) = '/vx/config';
   mockUsbDrive = createMockUsbDrive();
-  logger = mockLogger();
+  logger = mockLogger({ fn: jest.fn });
   api = createSystemCallApi({
     usbDrive: mockUsbDrive.usbDrive,
     logger,

--- a/libs/backend/src/system_call/export_logs_to_usb.test.ts
+++ b/libs/backend/src/system_call/export_logs_to_usb.test.ts
@@ -37,7 +37,7 @@ const execFileMock = mockOf(execFile);
 let logger: MockLogger;
 
 beforeEach(() => {
-  logger = mockLogger();
+  logger = mockLogger({ fn: jest.fn });
   createWriteStreamMock.mockReturnValue(new PassThrough());
   createReadStreamMock.mockReset();
 });

--- a/libs/backend/src/system_call/get_audio_info.test.ts
+++ b/libs/backend/src/system_call/get_audio_info.test.ts
@@ -27,7 +27,7 @@ test('command successful - headphones active', async () => {
     `,
   });
 
-  const logger = mockLogger();
+  const logger = mockLogger({ fn: jest.fn });
   expect(await getAudioInfo(logger)).toEqual<AudioInfo>({
     headphonesActive: true,
   });
@@ -54,7 +54,7 @@ test('command successful - speakers active', async () => {
     `,
   });
 
-  const logger = mockLogger();
+  const logger = mockLogger({ fn: jest.fn });
   expect(await getAudioInfo(logger)).toEqual<AudioInfo>({
     headphonesActive: false,
   });
@@ -65,7 +65,7 @@ test('command successful - speakers active', async () => {
 test('execFile error', async () => {
   mockExecFile.mockRejectedValue('execFile failed');
 
-  const logger = mockLogger();
+  const logger = mockLogger({ fn: jest.fn });
   expect(await getAudioInfo(logger)).toEqual<AudioInfo>({
     headphonesActive: false,
   });
@@ -82,7 +82,7 @@ test('execFile error', async () => {
 test('pactl error', async () => {
   mockExecFile.mockResolvedValue({ stderr: 'access denied', stdout: '' });
 
-  const logger = mockLogger();
+  const logger = mockLogger({ fn: jest.fn });
   expect(await getAudioInfo(logger)).toEqual<AudioInfo>({
     headphonesActive: false,
   });

--- a/libs/fujitsu-thermal-printer/src/mocks/file_printer.test.ts
+++ b/libs/fujitsu-thermal-printer/src/mocks/file_printer.test.ts
@@ -14,7 +14,7 @@ beforeEach(() => {
 });
 
 test('status management', async () => {
-  const logger = mockLogger();
+  const logger = mockLogger({ fn: jest.fn });
   const filePrinter = new MockFileFujitsuPrinter(logger);
   const filePrinterHandler = getMockFileFujitsuPrinterHandler();
 
@@ -49,7 +49,7 @@ test('status management', async () => {
 });
 
 test('fails printing if not initial idle', async () => {
-  const logger = mockLogger();
+  const logger = mockLogger({ fn: jest.fn });
   const filePrinter = new MockFileFujitsuPrinter(logger);
   const filePrinterHandler = getMockFileFujitsuPrinterHandler();
 
@@ -74,7 +74,7 @@ test('fails printing if not initial idle', async () => {
 });
 
 test('successful printing', async () => {
-  const logger = mockLogger();
+  const logger = mockLogger({ fn: jest.fn });
   // set a short print polling interval to speed up the test
   const filePrinter = new MockFileFujitsuPrinter(logger, {
     interval: 50,
@@ -116,7 +116,7 @@ test('successful printing', async () => {
 });
 
 test('failed print', async () => {
-  const logger = mockLogger();
+  const logger = mockLogger({ fn: jest.fn });
   // set a short print polling interval to speed up the test
   const filePrinter = new MockFileFujitsuPrinter(logger, {
     interval: 50,

--- a/libs/logging/.eslintignore
+++ b/libs/logging/.eslintignore
@@ -1,3 +1,3 @@
 build
 coverage
-jest.config.js
+vitest.config.ts

--- a/libs/logging/jest.config.js
+++ b/libs/logging/jest.config.js
@@ -1,8 +1,0 @@
-const shared = require('../../jest.config.shared');
-
-/**
- * @type {import('@jest/types').Config.InitialOptions}
- */
-module.exports = {
-  ...shared,
-};

--- a/libs/logging/package.json
+++ b/libs/logging/package.json
@@ -22,9 +22,9 @@
     "lint": "pnpm type-check && eslint .",
     "lint:fix": "pnpm type-check && eslint . --fix",
     "test": "is-ci test:ci test:watch",
-    "test:watch": "TZ=UTC vitest",
-    "test:coverage": "TZ=UTC vitest --coverage",
-    "test:ci": "pnpm build && TZ=UTC vitest run --coverage && pnpm build:generate-typescript-types --check && pnpm build:generate-rust-types --check",
+    "test:watch": "TZ=America/Anchorage vitest",
+    "test:coverage": "TZ=America/Anchorage vitest --coverage",
+    "test:ci": "pnpm build && TZ=America/Anchorage vitest run --coverage && pnpm build:generate-typescript-types --check && pnpm build:generate-rust-types --check",
     "pre-commit": "lint-staged"
   },
   "dependencies": {

--- a/libs/logging/package.json
+++ b/libs/logging/package.json
@@ -22,9 +22,9 @@
     "lint": "pnpm type-check && eslint .",
     "lint:fix": "pnpm type-check && eslint . --fix",
     "test": "is-ci test:ci test:watch",
-    "test:watch": "TZ=UTC jest --watch",
-    "test:coverage": "TZ=UTC jest --coverage",
-    "test:ci": "pnpm build && pnpm test:coverage --reporters=default --reporters=jest-junit --maxWorkers=6 && pnpm build:generate-typescript-types --check && pnpm build:generate-rust-types --check",
+    "test:watch": "TZ=UTC vitest",
+    "test:coverage": "TZ=UTC vitest --coverage",
+    "test:ci": "pnpm build && TZ=UTC vitest run --coverage && pnpm build:generate-typescript-types --check && pnpm build:generate-rust-types --check",
     "pre-commit": "lint-staged"
   },
   "dependencies": {
@@ -51,12 +51,8 @@
     "eslint-plugin-vx": "workspace:*",
     "fast-check": "2.23.2",
     "is-ci-cli": "2.2.0",
-    "jest": "^29.6.2",
-    "jest-junit": "^16.0.0",
-    "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "11.0.0",
     "sort-package-json": "^1.50.0",
-    "ts-jest": "29.1.1",
     "vitest": "^2.1.8"
   },
   "packageManager": "pnpm@8.15.5"

--- a/libs/logging/scripts/generate_types_from_toml.ts
+++ b/libs/logging/scripts/generate_types_from_toml.ts
@@ -87,7 +87,6 @@ function formatGetDetailsForEventId(config: ParsedConfig): string {
   }
 
   output += `
-      /* istanbul ignore next - compile time check for completeness */
       default:
         throwIllegalValue(eventId);
     }

--- a/libs/logging/src/base_logger.test.ts
+++ b/libs/logging/src/base_logger.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import { expect, test, vi } from 'vitest';
 import { mockKiosk } from '@votingworks/test-utils';
 import { LogEventId } from './log_event_ids';
 import { LogEventType } from './base_types/log_event_types';
@@ -6,10 +7,10 @@ import { CLIENT_SIDE_LOG_SOURCES, LogSource } from './base_types/log_source';
 import { BaseLogger } from './base_logger';
 import { DEVICE_TYPES_FOR_APP, LogDispositionStandardTypes } from './types';
 
-jest.useFakeTimers().setSystemTime(new Date('2020-07-24T00:00:00.000Z'));
+vi.useFakeTimers().setSystemTime(new Date('2020-07-24T00:00:00.000Z'));
 
 test('logger logs server logs as expected', async () => {
-  console.log = jest.fn();
+  console.log = vi.fn();
   const logger = new BaseLogger(LogSource.System);
   await logger.log(LogEventId.MachineBootInit, 'system', {
     message: 'I come back stronger than a 90s trend',
@@ -30,8 +31,8 @@ test('logger logs server logs as expected', async () => {
 });
 
 test('logger logs client logs as expected through kiosk browser with overridden message', async () => {
-  console.log = jest.fn();
-  const kiosk = mockKiosk();
+  console.log = vi.fn();
+  const kiosk = mockKiosk(vi.fn);
   const logger = new BaseLogger(LogSource.VxAdminFrontend, kiosk);
   await logger.log(LogEventId.ElectionConfigured, 'election_manager', {
     message: 'On my tallest tiptoes',
@@ -55,8 +56,8 @@ test('logger logs client logs as expected through kiosk browser with overridden 
 });
 
 test('defaults to default message when defined and no disposition', async () => {
-  console.log = jest.fn();
-  const kiosk = mockKiosk();
+  console.log = vi.fn();
+  const kiosk = mockKiosk(vi.fn);
   const logger = new BaseLogger(LogSource.VxAdminFrontend, kiosk);
   await logger.log(LogEventId.ElectionUnconfigured, 'election_manager');
   expect(kiosk.log).toHaveBeenCalledTimes(1);
@@ -75,7 +76,7 @@ test('defaults to default message when defined and no disposition', async () => 
 });
 
 test('logs unknown disposition as expected', async () => {
-  console.log = jest.fn();
+  console.log = vi.fn();
   const logger = new BaseLogger(LogSource.System);
   await logger.log(LogEventId.MachineBootComplete, 'system', {
     message: 'threw out our cloaks and our daggers now',
@@ -100,7 +101,7 @@ test('logs unknown disposition as expected', async () => {
 });
 
 test('logging from a client side app without sending window.kiosk does NOT log to console', async () => {
-  console.log = jest.fn();
+  console.log = vi.fn();
   const logger = new BaseLogger(LogSource.VxAdminFrontend);
   await logger.log(LogEventId.AuthLogin, 'election_manager');
   expect(console.log).not.toHaveBeenCalled();

--- a/libs/logging/src/base_logger.test.ts
+++ b/libs/logging/src/base_logger.test.ts
@@ -42,7 +42,7 @@ test('logger logs client logs as expected through kiosk browser with overridden 
   expect(kiosk.log).toHaveBeenCalledTimes(1);
   expect(kiosk.log).toHaveBeenCalledWith(
     JSON.stringify({
-      timeLogInitiated: new Date(2020, 6, 24).getTime().toString(),
+      timeLogInitiated: new Date(2020, 6, 23, 16).getTime().toString(),
       source: LogSource.VxAdminFrontend,
       eventId: LogEventId.ElectionConfigured,
       eventType: LogEventType.UserAction,
@@ -63,7 +63,7 @@ test('defaults to default message when defined and no disposition', async () => 
   expect(kiosk.log).toHaveBeenCalledTimes(1);
   expect(kiosk.log).toHaveBeenCalledWith(
     JSON.stringify({
-      timeLogInitiated: new Date(2020, 6, 24).getTime().toString(),
+      timeLogInitiated: new Date(2020, 6, 23, 16).getTime().toString(),
       source: LogSource.VxAdminFrontend,
       eventId: LogEventId.ElectionUnconfigured,
       eventType: LogEventType.UserAction,

--- a/libs/logging/src/base_logger.ts
+++ b/libs/logging/src/base_logger.ts
@@ -53,7 +53,7 @@ export class BaseLogger {
     };
     // If the caller is passing in a debug instance, and we are not in production log to the debugger rather than through the normal logging pipeline.
     // This is to make logs more manageable in development, so a developer can toggle what logs to view with the normal debug namespaces.
-    /* istanbul ignore next - figure out how to test this */
+    /* istanbul ignore next - figure out how to test this @preserve */
     if (outerDebug && process.env.NODE_ENV !== 'production') {
       outerDebug(logLine);
       return;

--- a/libs/logging/src/base_types/log_event_types.test.ts
+++ b/libs/logging/src/base_types/log_event_types.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from 'vitest';
 import { getDocumentationForEventType, LogEventType } from './log_event_types';
 
 test('getDocumentationForEventType implemented for all log event types properly', () => {
@@ -5,4 +6,9 @@ test('getDocumentationForEventType implemented for all log event types properly'
     const documentation = getDocumentationForEventType(eventType);
     expect(documentation.eventType).toEqual(eventType);
   }
+});
+
+test('getDocumentationForEventType rejects invalid event types', () => {
+  // @ts-expect-error - invalid type
+  expect(() => getDocumentationForEventType('invalid')).toThrow();
 });

--- a/libs/logging/src/base_types/log_event_types.ts
+++ b/libs/logging/src/base_types/log_event_types.ts
@@ -65,7 +65,6 @@ export function getDocumentationForEventType(
       return ApplicationStatusEventDocumentation;
     case LogEventType.ApplicationAction:
       return ApplicationActionEventDocumentation;
-    /* istanbul ignore next - compile time check for completeness */
     default:
       throwIllegalValue(eventType);
   }

--- a/libs/logging/src/export.test.ts
+++ b/libs/logging/src/export.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test, vi } from 'vitest';
 import { assert, iter } from '@votingworks/basics';
 import { EventLogging, safeParseJson } from '@votingworks/types';
 import { createReadStream } from 'node:fs';
@@ -5,7 +6,7 @@ import { join } from 'node:path';
 import { LogEventId, LogEventType, LogLine, LogSource, mockLogger } from '.';
 import { buildCdfLog, filterErrorLogs } from './export';
 
-jest.useFakeTimers().setSystemTime(new Date('2020-07-24T00:00:00.000Z'));
+vi.useFakeTimers().setSystemTime(new Date('2020-07-24T00:00:00.000Z'));
 
 describe('filterErrorLogs', () => {
   test('converts basic log as expected', async () => {
@@ -33,7 +34,7 @@ describe('filterErrorLogs', () => {
 
 describe('buildCdfLog', () => {
   test('builds device and election info properly', async () => {
-    const logger = mockLogger({ source: LogSource.VxAdminFrontend });
+    const logger = mockLogger({ source: LogSource.VxAdminFrontend, fn: vi.fn });
     const cdfLogContent = buildCdfLog(
       logger,
       iter(['']).async(),
@@ -64,8 +65,9 @@ describe('buildCdfLog', () => {
     const logger = mockLogger({
       source: LogSource.VxAdminFrontend,
       role: 'election_manager',
+      fn: vi.fn,
     });
-    const logSpy = jest.spyOn(logger, 'log').mockResolvedValue();
+    const logSpy = vi.spyOn(logger, 'log').mockResolvedValue();
     const cdfLogContent = buildCdfLog(
       logger,
       iter([
@@ -108,7 +110,7 @@ describe('buildCdfLog', () => {
   });
 
   test('log with unspecified disposition as expected', async () => {
-    const logger = mockLogger({ source: LogSource.VxAdminFrontend });
+    const logger = mockLogger({ source: LogSource.VxAdminFrontend, fn: vi.fn });
     const cdfLogContent = buildCdfLog(
       logger,
       iter([
@@ -134,7 +136,7 @@ describe('buildCdfLog', () => {
   });
 
   test('converts log with custom disposition and extra details as expected', async () => {
-    const logger = mockLogger({ source: LogSource.VxAdminFrontend });
+    const logger = mockLogger({ source: LogSource.VxAdminFrontend, fn: vi.fn });
     const cdfLogContent = buildCdfLog(
       logger,
       iter([
@@ -172,8 +174,9 @@ describe('buildCdfLog', () => {
     const logger = mockLogger({
       source: LogSource.VxAdminFrontend,
       role: 'election_manager',
+      fn: vi.fn,
     });
-    const logSpy = jest.spyOn(logger, 'log').mockResolvedValue();
+    const logSpy = vi.spyOn(logger, 'log').mockResolvedValue();
     const missingTimeLogLine: LogLine = {
       source: LogSource.System,
       eventId: LogEventId.DeviceAttached,
@@ -239,7 +242,7 @@ describe('buildCdfLog', () => {
     const logFile = createReadStream(
       join(__dirname, '../fixtures/samplelog.log')
     );
-    const logger = mockLogger({ source: LogSource.VxAdminFrontend });
+    const logger = mockLogger({ source: LogSource.VxAdminFrontend, fn: vi.fn });
     const cdfLogContent = buildCdfLog(logger, logFile, '1234', 'codeversion');
     const cdfLogResult = safeParseJson(
       await iter(cdfLogContent).toString(),

--- a/libs/logging/src/helpers.test.ts
+++ b/libs/logging/src/helpers.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from 'vitest';
 import { getLogEventIdForPollsTransition } from './helpers';
 import { LogEventId } from './log_event_ids';
 
@@ -14,4 +15,6 @@ test('getLogEventIdForPollsTransition', () => {
   expect(getLogEventIdForPollsTransition('close_polls')).toEqual(
     LogEventId.PollsClosed
   );
+  // @ts-expect-error - invalid value passed to function
+  expect(() => getLogEventIdForPollsTransition('invalid')).toThrow();
 });

--- a/libs/logging/src/helpers.ts
+++ b/libs/logging/src/helpers.ts
@@ -14,7 +14,6 @@ export function getLogEventIdForPollsTransition(
       return LogEventId.VotingResumed;
     case 'close_polls':
       return LogEventId.PollsClosed;
-    /* istanbul ignore next */
     default:
       throwIllegalValue(transitionType);
   }

--- a/libs/logging/src/index.ts
+++ b/libs/logging/src/index.ts
@@ -1,4 +1,4 @@
-/* istanbul ignore file */
+/* istanbul ignore file - @preserve */
 export * from './base_types';
 export * from './export';
 export * from './helpers';

--- a/libs/logging/src/log_documentation.test.ts
+++ b/libs/logging/src/log_documentation.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test, vi } from 'vitest';
 import { EventLogging, safeParseJson } from '@votingworks/types';
 import { assert } from '@votingworks/basics';
 import * as fs from 'node:fs';
@@ -8,7 +9,7 @@ import {
 } from './log_documentation';
 import { AppName } from './base_types/log_source';
 
-jest.useFakeTimers().setSystemTime(new Date('2020-07-24T00:00:00.000Z'));
+vi.useFakeTimers().setSystemTime(new Date('2020-07-24T00:00:00.000Z'));
 
 describe('test cdf documentation generation', () => {
   test('builds expected documentation for VxAdminFrontend', () => {

--- a/libs/logging/src/log_event_ids.test.ts
+++ b/libs/logging/src/log_event_ids.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from 'vitest';
 import { getDetailsForEventId, LogEventId } from './log_event_ids';
 
 test('getDetailsForEventId implemented for all events properly', () => {
@@ -5,6 +6,11 @@ test('getDetailsForEventId implemented for all events properly', () => {
     const logDetails = getDetailsForEventId(eventId);
     expect(logDetails.eventId).toEqual(eventId);
   }
+});
+
+test('getDefaultsForEventId rejects invalid event IDs', () => {
+  // @ts-expect-error - invalid value
+  expect(() => getDetailsForEventId('invalid')).toThrow();
 });
 
 test('all event Ids are unique', () => {

--- a/libs/logging/src/log_event_ids.ts
+++ b/libs/logging/src/log_event_ids.ts
@@ -1349,7 +1349,6 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return SignedHashValidationInit;
     case LogEventId.SignedHashValidationComplete:
       return SignedHashValidationComplete;
-    /* istanbul ignore next - compile time check for completeness */
     default:
       throwIllegalValue(eventId);
   }

--- a/libs/logging/src/logger.test.ts
+++ b/libs/logging/src/logger.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import { expect, test, vi } from 'vitest';
 import {
   BaseLogger,
   LogDispositionStandardTypes,
@@ -9,8 +10,8 @@ import {
 } from '.';
 
 test('logger can log with passed user role', async () => {
-  jest.spyOn(console, 'log').mockReturnValue();
-  const getUserRole = jest.fn();
+  vi.spyOn(console, 'log').mockReturnValue();
+  const getUserRole = vi.fn();
 
   const logger = new Logger(LogSource.VxMarkBackend, getUserRole);
   getUserRole.mockResolvedValue('election_manager');
@@ -43,9 +44,9 @@ test('logger can log with passed user role', async () => {
 });
 
 test('Logger.from', async () => {
-  jest.spyOn(console, 'log').mockReturnValue();
+  vi.spyOn(console, 'log').mockReturnValue();
   const baseLogger = new BaseLogger(LogSource.VxCentralScanService);
-  const logSpy = jest.spyOn(baseLogger, 'log');
+  const logSpy = vi.spyOn(baseLogger, 'log');
   const logger = Logger.from(baseLogger, () => Promise.resolve('unknown'));
   await logger.logAsCurrentRole(LogEventId.FileSaved);
   expect(console.log).toHaveBeenCalledWith(
@@ -61,9 +62,9 @@ test('Logger.from', async () => {
 });
 
 test('can provide fallback user', async () => {
-  jest.spyOn(console, 'log').mockReturnValue();
+  vi.spyOn(console, 'log').mockReturnValue();
   const baseLogger = new BaseLogger(LogSource.VxCentralScanService);
-  const logSpy = jest.spyOn(baseLogger, 'log');
+  const logSpy = vi.spyOn(baseLogger, 'log');
   const logger = Logger.from(baseLogger, () => Promise.resolve('unknown'));
   await logger.logAsCurrentRole(
     LogEventId.FileSaved,

--- a/libs/logging/src/test_utils.test.ts
+++ b/libs/logging/src/test_utils.test.ts
@@ -1,17 +1,18 @@
+import { expect, test, vi } from 'vitest';
 import { typedAs } from '@votingworks/basics';
 import { LogEventType, LogLine, LogSource } from '.';
 import { LogEventId } from './log_event_ids';
 import { mockBaseLogger, mockLogger } from './test_utils';
 
 test('mockBaseLogger returns a logger with a spy on logger.log', async () => {
-  const logger = mockBaseLogger();
+  const logger = mockBaseLogger({ fn: vi.fn });
   await logger.log(LogEventId.MachineBootInit, 'system');
   expect(logger.log).toHaveBeenCalledWith(LogEventId.MachineBootInit, 'system');
 });
 
 test('mockLogger returns a logger that can print debug logs', async () => {
-  const logger = mockLogger({ source: LogSource.System });
-  const debug = jest.fn();
+  const logger = mockLogger({ source: LogSource.System, fn: vi.fn });
+  const debug = vi.fn();
   await logger.log(LogEventId.MachineBootInit, 'system', undefined, debug);
   expect(debug).toHaveBeenCalledWith(
     typedAs<LogLine>({
@@ -29,6 +30,7 @@ test('mockLogger', async () => {
   const logger = mockLogger({
     source: LogSource.VxAdminService,
     role: 'election_manager',
+    fn: vi.fn,
   });
 
   await logger.logAsCurrentRole(LogEventId.MachineBootInit);
@@ -61,7 +63,7 @@ test('mockLogger', async () => {
 });
 
 test('mockLogger with defaults', async () => {
-  const logger = mockLogger();
+  const logger = mockLogger({ fn: vi.fn });
   await logger.logAsCurrentRole(LogEventId.MachineBootInit);
   expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
     LogEventId.MachineBootInit

--- a/libs/logging/vitest.config.ts
+++ b/libs/logging/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from '../../vitest.config.shared.mjs';
+
+export default defineConfig();

--- a/libs/printing/src/printer/printer.test.ts
+++ b/libs/printing/src/printer/printer.test.ts
@@ -47,7 +47,7 @@ afterEach(() => {
 });
 
 test('status and configuration', async () => {
-  const logger = mockBaseLogger();
+  const logger = mockBaseLogger({ fn: jest.fn });
   const printer = detectPrinter(logger);
 
   // no printer connected
@@ -123,14 +123,14 @@ test('uses mock file printer when feature flag is set', () => {
     BooleanEnvironmentVariableName.USE_MOCK_PRINTER
   );
 
-  const printer = detectPrinter(mockBaseLogger());
+  const printer = detectPrinter(mockBaseLogger({ fn: jest.fn }));
   expect(printer).toBeInstanceOf(MockFilePrinter);
   featureFlagMock.resetFeatureFlags();
 });
 
 describe('rich status', () => {
   test('does not get rich status if printer is not an IPP printer', async () => {
-    const printer = detectPrinter(mockBaseLogger());
+    const printer = detectPrinter(mockBaseLogger({ fn: jest.fn }));
 
     // connect printer
     const uri = `${BROTHER_THERMAL_PRINTER_CONFIG.baseDeviceUri}/serial=1234`;
@@ -149,7 +149,7 @@ describe('rich status', () => {
   });
 
   test('attempts to get rich status if printer is an IPP printer', async () => {
-    const printer = detectPrinter(mockBaseLogger());
+    const printer = detectPrinter(mockBaseLogger({ fn: jest.fn }));
 
     // connect printer
     const uri = `${HP_LASER_PRINTER_CONFIG.baseDeviceUri}/serial=1234`;

--- a/libs/ui/src/error_boundary.test.tsx
+++ b/libs/ui/src/error_boundary.test.tsx
@@ -55,7 +55,7 @@ test.each<{
 ])(
   'logs error if logger is provided - $error',
   async ({ error, expectedLog }) => {
-    const logger = mockBaseLogger();
+    const logger = mockBaseLogger({ fn: jest.fn });
     await suppressingConsoleOutput(async () => {
       render(
         <ErrorBoundary errorMessage="jellyfish" logger={logger}>
@@ -87,7 +87,7 @@ test('TestErrorBoundary shows caught error message', async () => {
 });
 
 test('AppErrorBoundary shows "Something went wrong" when something goes wrong', async () => {
-  const logger = mockBaseLogger();
+  const logger = mockBaseLogger({ fn: jest.fn });
   await suppressingConsoleOutput(async () => {
     render(
       <AppErrorBoundary

--- a/libs/usb-drive/src/usb_drive.test.ts
+++ b/libs/usb-drive/src/usb_drive.test.ts
@@ -117,7 +117,7 @@ describe('status', () => {
   });
 
   test('completely ignores invalid devices', async () => {
-    const logger = mockLogger();
+    const logger = mockLogger({ fn: jest.fn });
     const usbDrive = detectUsbDrive(logger);
 
     readdirMock.mockResolvedValue(['usb-foobar-part23']);
@@ -162,7 +162,7 @@ describe('status', () => {
   });
 
   test('one drive, mounted', async () => {
-    const logger = mockLogger();
+    const logger = mockLogger({ fn: jest.fn });
     const usbDrive = detectUsbDrive(logger);
 
     readdirMock.mockResolvedValueOnce(['usb-foobar-part23']);
@@ -191,7 +191,7 @@ describe('status', () => {
   });
 
   test('one drive, unmounted', async () => {
-    const logger = mockLogger();
+    const logger = mockLogger({ fn: jest.fn });
     const usbDrive = detectUsbDrive(logger);
 
     readdirMock.mockResolvedValue(['usb-foobar-part23']);
@@ -289,7 +289,7 @@ describe('status', () => {
     ];
 
     for (const testCase of testCases) {
-      const logger = mockLogger();
+      const logger = mockLogger({ fn: jest.fn });
       const usbDrive = detectUsbDrive(logger);
       readdirMock.mockResolvedValue([
         'notausb-bazbar-part21', // this device should be ignored
@@ -319,7 +319,7 @@ describe('status', () => {
   });
 
   test('error getting block device info', async () => {
-    const logger = mockLogger();
+    const logger = mockLogger({ fn: jest.fn });
     const usbDrive = detectUsbDrive(logger);
 
     readdirMock.mockResolvedValueOnce(['usb-foobar-part23']);
@@ -332,7 +332,7 @@ describe('status', () => {
   });
 
   test('bad format', async () => {
-    const logger = mockLogger();
+    const logger = mockLogger({ fn: jest.fn });
     const usbDrive = detectUsbDrive(logger);
 
     readdirMock.mockResolvedValue(['usb-foobar-part23']);
@@ -365,7 +365,7 @@ describe('status', () => {
   });
 
   test('fails to mount', async () => {
-    const logger = mockLogger();
+    const logger = mockLogger({ fn: jest.fn });
     const usbDrive = detectUsbDrive(logger);
 
     readdirMock.mockResolvedValue(['usb-foobar-part23']);
@@ -393,7 +393,7 @@ describe('status', () => {
 
 describe('eject', () => {
   test('no drive - no op', async () => {
-    const logger = mockLogger();
+    const logger = mockLogger({ fn: jest.fn });
     const usbDrive = detectUsbDrive(logger);
 
     readdirMock.mockResolvedValueOnce([]);
@@ -402,7 +402,7 @@ describe('eject', () => {
   });
 
   test('not mounted - no op', async () => {
-    const logger = mockLogger();
+    const logger = mockLogger({ fn: jest.fn });
     const usbDrive = detectUsbDrive(logger);
 
     mockBlockDeviceOnce({ mountpoint: null });
@@ -476,7 +476,7 @@ describe('eject', () => {
 
 describe('format', () => {
   test('no drive - no op', async () => {
-    const logger = mockLogger();
+    const logger = mockLogger({ fn: jest.fn });
     const usbDrive = detectUsbDrive(logger);
     readdirMock.mockResolvedValueOnce([]);
 
@@ -529,7 +529,7 @@ describe('format', () => {
   });
 
   test('on bad format drive', async () => {
-    const logger = mockLogger();
+    const logger = mockLogger({ fn: jest.fn });
     const usbDrive = detectUsbDrive(logger);
     mockBlockDeviceOnce({ fstype: 'exfat', mountpoint: null, label: 'DATA' });
     execMock.mockResolvedValueOnce({ stdout: '' }); // format
@@ -575,7 +575,7 @@ describe('format', () => {
   });
 
   test('status polling while formatting', async () => {
-    const logger = mockLogger();
+    const logger = mockLogger({ fn: jest.fn });
     const usbDrive = detectUsbDrive(logger);
     mockBlockDeviceOnce({ mountpoint: '/media/usb-drive-sdb1' });
     execMock.mockResolvedValueOnce({ stdout: '' }); // unmount
@@ -601,7 +601,7 @@ describe('format', () => {
 
 describe('sync', () => {
   test('no drive - no op', async () => {
-    const logger = mockLogger();
+    const logger = mockLogger({ fn: jest.fn });
     const usbDrive = detectUsbDrive(logger);
     readdirMock.mockResolvedValueOnce([]);
 
@@ -610,7 +610,7 @@ describe('sync', () => {
   });
 
   test('when mounted, execs sync', async () => {
-    const logger = mockLogger();
+    const logger = mockLogger({ fn: jest.fn });
     const usbDrive = detectUsbDrive(logger);
     mockBlockDeviceOnce({ mountpoint: '/media/usb-drive-sdb1' });
     execMock.mockResolvedValueOnce({ stdout: '' }); // sync
@@ -626,7 +626,7 @@ describe('sync', () => {
 });
 
 test('action locking', async () => {
-  const logger = mockLogger();
+  const logger = mockLogger({ fn: jest.fn });
   const usbDrive = detectUsbDrive(logger);
 
   mockBlockDeviceOnce({ mountpoint: '/media/usb-drive-sdb1' });
@@ -669,7 +669,7 @@ test('uses mock file usb drive if environment variable is set', async () => {
   }
   expect(existsSync(stateFilePath)).toEqual(false);
 
-  const usbDrive = detectUsbDrive(mockLogger());
+  const usbDrive = detectUsbDrive(mockLogger({ fn: jest.fn }));
   expect(await usbDrive.status()).toEqual({ status: 'no_drive' });
   expect(existsSync(stateFilePath)).toEqual(true);
 });

--- a/libs/usb-drive/src/usb_drive.test.ts
+++ b/libs/usb-drive/src/usb_drive.test.ts
@@ -104,6 +104,7 @@ describe('status', () => {
     const logger = mockLogger({
       source: LogSource.VxAdminFrontend,
       role: 'election_manager',
+      fn: jest.fn,
     });
     const usbDrive = detectUsbDrive(logger);
 
@@ -414,6 +415,7 @@ describe('eject', () => {
     const logger = mockLogger({
       source: LogSource.VxAdminFrontend,
       role: 'election_manager',
+      fn: jest.fn,
     });
     const usbDrive = detectUsbDrive(logger);
 
@@ -454,6 +456,7 @@ describe('eject', () => {
     const logger = mockLogger({
       source: LogSource.VxAdminFrontend,
       role: 'election_manager',
+      fn: jest.fn,
     });
     const usbDrive = detectUsbDrive(logger);
 
@@ -488,6 +491,7 @@ describe('format', () => {
     const logger = mockLogger({
       source: LogSource.VxAdminFrontend,
       role: 'system_administrator',
+      fn: jest.fn,
     });
     const usbDrive = detectUsbDrive(logger);
     mockBlockDeviceOnce({ mountpoint: '/media/usb-drive-sdb1' });
@@ -552,6 +556,7 @@ describe('format', () => {
     const logger = mockLogger({
       source: LogSource.VxAdminFrontend,
       role: 'system_administrator',
+      fn: jest.fn,
     });
     const usbDrive = detectUsbDrive(logger);
     mockBlockDeviceOnce({ fstype: 'unknown', mountpoint: null, label: null });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4541,24 +4541,12 @@ importers:
       is-ci-cli:
         specifier: 2.2.0
         version: 2.2.0
-      jest:
-        specifier: ^29.6.2
-        version: 29.6.2(@types/node@20.16.0)
-      jest-junit:
-        specifier: ^16.0.0
-        version: 16.0.0
-      jest-watch-typeahead:
-        specifier: ^2.2.2
-        version: 2.2.2(jest@29.6.2)
       lint-staged:
         specifier: 11.0.0
         version: 11.0.0
       sort-package-json:
         specifier: ^1.50.0
         version: 1.50.0
-      ts-jest:
-        specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.1)(esbuild@0.21.2)(jest@29.6.2)(typescript@5.6.2)
       vitest:
         specifier: ^2.1.8
         version: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)


### PR DESCRIPTION
Closes #5725 

In addition to changing the tests for `libs/logging` itself, changes `mockLogger` et al to require a mock function. Some of the `istanbul ignore` directives no longer work because `esbuild` at the version `vitest` uses doesn't support preserving comments preceding a `case` or `default` (see [this](https://github.com/evanw/esbuild/issues/3838)).