### PR TITLE
automatically focus the first row/panel/key on first render and after making selections

### DIFF
--- a/libs/ui/src/virtual_keyboard/scan_panel_virtual_keyboard.test.tsx
+++ b/libs/ui/src/virtual_keyboard/scan_panel_virtual_keyboard.test.tsx
@@ -147,7 +147,6 @@ test('supports tab and enter keypresses to navigate the keyboard', () => {
   );
 
   const firstRowElement = screen.getByText(hasTextAcrossElements(firstRow));
-  userEvent.tab();
   expect(firstRowElement).toHaveFocus();
   userEvent.tab();
   expect(screen.getByText(hasTextAcrossElements(secondRow))).toHaveFocus();
@@ -161,13 +160,10 @@ test('supports tab and enter keypresses to navigate the keyboard', () => {
   expect(firstRowElement).toHaveFocus();
 
   userEvent.keyboard('{enter}');
-  // After Enter event, need to press tab again to refocus first element
-  userEvent.tab();
   expect(screen.getByText(hasTextAcrossElements('QWER'))).toHaveFocus();
   userEvent.tab();
   expect(screen.getByText(hasTextAcrossElements('TYU'))).toHaveFocus();
   userEvent.keyboard('{enter}');
-  userEvent.tab();
   // Need to use slower getButton here because getByText will find the child <span>
   expect(
     screen.getButton(`T ${getMockAudioOnlyTextPrefix(ENGLISH)} T`)

--- a/libs/ui/src/virtual_keyboard/scan_panel_virtual_keyboard.tsx
+++ b/libs/ui/src/virtual_keyboard/scan_panel_virtual_keyboard.tsx
@@ -340,8 +340,10 @@ export function ScanPanelVirtualKeyboard({
 
   useEffect(() => {
     if (selectionLevel === SelectionLevel.Keys) {
+      /* istanbul ignore next */
       keyButtonRef.current?.focus();
     } else {
+      /* istanbul ignore next */
       focusRef.current?.focus();
     }
   }, [focusRef, selectionLevel]);

--- a/libs/ui/src/virtual_keyboard/scan_panel_virtual_keyboard.tsx
+++ b/libs/ui/src/virtual_keyboard/scan_panel_virtual_keyboard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import styled, { DefaultTheme, StyledComponent } from 'styled-components';
 import { Icons } from '../icons';
 import { appStrings } from '../ui_strings';
@@ -7,7 +7,7 @@ import { Key } from './common';
 import { ScanPanelRow } from './scan_panels/scan_panel_row';
 import { KeyButton } from './scan_panels/key_button';
 import { ScanPanel, ScanPanelRenderOption } from './scan_panels/scan_panel';
-import { buttonStyles, gapStyles } from '../button';
+import { Button, buttonStyles, gapStyles } from '../button';
 
 const Keyboard = styled.div`
   display: flex;
@@ -319,6 +319,33 @@ export function ScanPanelVirtualKeyboard({
   const [selectedScanPanelIndex, setSelectedScanPanelIndex] =
     useState<number>(-1);
 
+  const focusRef = useRef<HTMLButtonElement>(null);
+  function getFocusRefForRow(rowIndex: number) {
+    return selectionLevel === SelectionLevel.Rows && rowIndex === 0
+      ? focusRef
+      : undefined;
+  }
+  function getFocusRefForScanPanel(panelIndex: number) {
+    return selectionLevel === SelectionLevel.ScanPanels && panelIndex === 0
+      ? focusRef
+      : undefined;
+  }
+
+  const keyButtonRef = useRef<Button<string>>(null);
+  function getFocusRefForKeyButton(keyIndex: number) {
+    return selectionLevel === SelectionLevel.Keys && keyIndex === 0
+      ? keyButtonRef
+      : undefined;
+  }
+
+  useEffect(() => {
+    if (selectionLevel === SelectionLevel.Keys) {
+      keyButtonRef.current?.focus();
+    } else {
+      focusRef.current?.focus();
+    }
+  }, [focusRef, selectionLevel]);
+
   function rowIsSelected(index: number) {
     return selectionLevel !== SelectionLevel.Rows && index === selectedRowIndex;
   }
@@ -384,6 +411,7 @@ export function ScanPanelVirtualKeyboard({
 
   function renderKey(
     keySpec: KeyWithRenderSpec,
+    keyIndex: number,
     rowIndex?: number,
     panelIndex?: number
   ) {
@@ -397,6 +425,7 @@ export function ScanPanelVirtualKeyboard({
 
     const keyComponent = (
       <KeyButton
+        ref={getFocusRefForKeyButton(keyIndex)}
         key={value}
         keySpec={keySpec}
         onKeyPress={onSelectKey}
@@ -424,12 +453,15 @@ export function ScanPanelVirtualKeyboard({
     // Render a Row of KeyButtons without the intermediate ScanPanels
     return (
       <ScanPanelRow
+        ref={getFocusRefForRow(rowIndex)}
         onSelect={() => onSelectRow(rowIndex)}
         key={`row-${keySpecs.map((spec) => spec.value).join()}`}
         selectable={selectionLevel === SelectionLevel.Rows}
         selected={selectedRowIndex === rowIndex}
       >
-        {keySpecs.map((keySpec) => renderKey(keySpec, rowIndex))}
+        {keySpecs.map((keySpec, keyIndex) =>
+          renderKey(keySpec, keyIndex, rowIndex)
+        )}
       </ScanPanelRow>
     );
   }
@@ -440,13 +472,14 @@ export function ScanPanelVirtualKeyboard({
         if (rowIsSelected(rowIndex) && selectionLevel !== SelectionLevel.Rows) {
           const panels = row.map((panel, panelIndex) => (
             <ScanPanel
+              ref={getFocusRefForScanPanel(panelIndex)}
               numKeys={panel.keys.length}
               key={panel.keys.map((k) => k.value).join()}
               renderAs={getScanPanelRenderOption(rowIndex, panelIndex)}
               onSelect={() => onSelectScanPanel(panelIndex)}
             >
-              {panel.keys.map((keySpec) =>
-                renderKey(keySpec, rowIndex, panelIndex)
+              {panel.keys.map((keySpec, keyIndex) =>
+                renderKey(keySpec, keyIndex, rowIndex, panelIndex)
               )}
             </ScanPanel>
           ));

--- a/libs/ui/src/virtual_keyboard/scan_panels/key_button.tsx
+++ b/libs/ui/src/virtual_keyboard/scan_panels/key_button.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { forwardRef, Ref } from 'react';
 import { Button } from '../../button';
 import { WithAltAudio } from '../../ui_strings';
 import { getBorderWidthRem, Key } from '../common';
@@ -29,38 +30,40 @@ export interface KeyButtonProps {
 /**
  * KeyButton is a visual representation of a single keyboard key.
  */
-export function KeyButton({
-  keySpec,
-  onKeyPress,
-  disabled,
-  selectable,
-}: KeyButtonProps): JSX.Element {
-  const {
-    audioLanguageOverride,
-    renderAudioString,
-    value,
-    renderLabel = () => value,
-  } = keySpec;
+// eslint-disable-next-line react/display-name
+export const KeyButton = forwardRef(
+  (
+    { keySpec, onKeyPress, disabled, selectable }: KeyButtonProps,
+    ref: Ref<Button<string>>
+  ): JSX.Element => {
+    const {
+      audioLanguageOverride,
+      renderAudioString,
+      value,
+      renderLabel = () => value,
+    } = keySpec;
 
-  return (
-    <Wrapper>
-      {selectable ? (
-        <Button
-          key={value}
-          value={value}
-          onPress={onKeyPress}
-          disabled={disabled}
-        >
-          <WithAltAudio
-            audioLanguageOverride={audioLanguageOverride}
-            audioText={renderAudioString()}
+    return (
+      <Wrapper>
+        {selectable ? (
+          <Button
+            ref={ref}
+            key={value}
+            value={value}
+            onPress={onKeyPress}
+            disabled={disabled}
           >
-            {renderLabel()}
-          </WithAltAudio>
-        </Button>
-      ) : (
-        renderLabel()
-      )}
-    </Wrapper>
-  );
-}
+            <WithAltAudio
+              audioLanguageOverride={audioLanguageOverride}
+              audioText={renderAudioString()}
+            >
+              {renderLabel()}
+            </WithAltAudio>
+          </Button>
+        ) : (
+          renderLabel()
+        )}
+      </Wrapper>
+    );
+  }
+);

--- a/libs/ui/src/virtual_keyboard/scan_panels/scan_panel.tsx
+++ b/libs/ui/src/virtual_keyboard/scan_panels/scan_panel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef, Ref } from 'react';
 import styled from 'styled-components';
 import { gapStyles } from '../../button';
 import { getBorderWidthRem } from '../common';
@@ -30,27 +30,30 @@ interface ScanPanelProps {
   renderAs: ScanPanelRenderOption;
 }
 
-export function ScanPanel({
-  children,
-  renderAs,
-  numKeys,
-  onSelect,
-}: ScanPanelProps): JSX.Element {
-  switch (renderAs) {
-    case 'button-enabled':
-      return (
-        <ScanPanelButton numKeys={numKeys} onClick={onSelect}>
-          {children}
-        </ScanPanelButton>
-      );
-    case 'button-disabled':
-      return (
-        <ScanPanelButton numKeys={numKeys} onClick={onSelect} disabled>
-          {children}
-        </ScanPanelButton>
-      );
-    case 'container':
-    default:
-      return <ScanPanelDisplay numKeys={numKeys}>{children}</ScanPanelDisplay>;
+// eslint-disable-next-line react/display-name
+export const ScanPanel = forwardRef(
+  (
+    { children, renderAs, numKeys, onSelect }: ScanPanelProps,
+    ref: Ref<HTMLButtonElement>
+  ): JSX.Element => {
+    switch (renderAs) {
+      case 'button-enabled':
+        return (
+          <ScanPanelButton numKeys={numKeys} onClick={onSelect} ref={ref}>
+            {children}
+          </ScanPanelButton>
+        );
+      case 'button-disabled':
+        return (
+          <ScanPanelButton numKeys={numKeys} onClick={onSelect} disabled>
+            {children}
+          </ScanPanelButton>
+        );
+      case 'container':
+      default:
+        return (
+          <ScanPanelDisplay numKeys={numKeys}>{children}</ScanPanelDisplay>
+        );
+    }
   }
-}
+);

--- a/libs/ui/src/virtual_keyboard/scan_panels/scan_panel_row.tsx
+++ b/libs/ui/src/virtual_keyboard/scan_panels/scan_panel_row.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef, Ref } from 'react';
 import styled from 'styled-components';
 
 const RowButton = styled.button`
@@ -20,17 +20,17 @@ interface ScanPanelRowProps {
   selected: boolean;
 }
 
-export function ScanPanelRow({
-  children,
-  onSelect = () => {},
-  selectable,
-  selected,
-}: ScanPanelRowProps): JSX.Element {
-  return selected ? (
-    <RowDisplay>{children}</RowDisplay>
-  ) : (
-    <RowButton onClick={onSelect} disabled={!selectable}>
-      {children}
-    </RowButton>
-  );
-}
+// eslint-disable-next-line react/display-name
+export const ScanPanelRow = forwardRef(
+  (
+    { children, onSelect = () => {}, selectable, selected }: ScanPanelRowProps,
+    ref: Ref<HTMLButtonElement>
+  ): JSX.Element =>
+    selected ? (
+      <RowDisplay>{children}</RowDisplay>
+    ) : (
+      <RowButton onClick={onSelect} disabled={!selectable} ref={ref}>
+        {children}
+      </RowButton>
+    )
+);


### PR DESCRIPTION
## Overview

Small QOL change for the switch scanning keyboard for write-ins

* Focus the first row when the keyboard is first rendered
* After a row/panel/key is selected, focus the first child
  * Row selected -> focus first panel
  * Panel selected -> focus first key

## Demo Video or Screenshot


https://github.com/user-attachments/assets/b7d1af23-9d02-4417-b7a3-ce49992ce770



## Testing Plan

Updated existing tab/enter test to expect focus without tabbing

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
