### PR TITLE
vxdesign structured name input

### DIFF
--- a/apps/design/backend/src/candidate_rotation.test.ts
+++ b/apps/design/backend/src/candidate_rotation.test.ts
@@ -149,4 +149,96 @@ describe('rotateCandidates', () => {
       },
     ]);
   });
+
+  test('rotates candidates according to structured last name data', () => {
+    const contest: CandidateContest = {
+      ...candidateContest,
+      candidates: [
+        {
+          id: '1',
+          name: 'Lana del Rey',
+          firstName: 'Lana',
+          lastName: 'del Rey',
+        },
+        {
+          id: '2',
+          name: 'Warren Harding',
+          firstName: 'Warren',
+          lastName: 'Harding',
+        },
+        {
+          id: '3',
+          name: 'John Adams',
+          firstName: 'John',
+          lastName: 'Adams',
+        },
+      ],
+    };
+    expect((rotateCandidates(contest) as CandidateContest).candidates).toEqual([
+      {
+        id: '3',
+        name: 'John Adams',
+        firstName: 'John',
+        lastName: 'Adams',
+      },
+      // 'del Rey' comes after 'Adams' but before 'Harding'
+      {
+        id: '1',
+        name: 'Lana del Rey',
+        firstName: 'Lana',
+        lastName: 'del Rey',
+      },
+      {
+        id: '2',
+        name: 'Warren Harding',
+        firstName: 'Warren',
+        lastName: 'Harding',
+      },
+    ]);
+  });
+
+  test('rotates by first name if last name is not present', () => {
+    const contest: CandidateContest = {
+      ...candidateContest,
+      candidates: [
+        {
+          id: '1',
+          name: 'George',
+          firstName: 'George',
+        },
+        {
+          id: '2',
+          name: 'Warren Harding',
+          firstName: 'Warren',
+          lastName: 'Harding',
+        },
+        {
+          id: '3',
+          name: 'John Adams',
+          firstName: 'John',
+          lastName: 'Adams',
+        },
+      ],
+    };
+    expect((rotateCandidates(contest) as CandidateContest).candidates).toEqual([
+      {
+        id: '3',
+        name: 'John Adams',
+        firstName: 'John',
+        lastName: 'Adams',
+      },
+      // 'George' comes after 'Adams' but before 'Harding'
+      {
+        id: '1',
+        name: 'George',
+        firstName: 'George',
+      },
+      {
+        id: '2',
+        name: 'Warren Harding',
+        firstName: 'Warren',
+        lastName: 'Harding',
+      },
+    ]);
+  });
 });

--- a/apps/design/backend/src/candidate_rotation.ts
+++ b/apps/design/backend/src/candidate_rotation.ts
@@ -1,5 +1,5 @@
 import { assertDefined } from '@votingworks/basics';
-import { AnyContest } from '@votingworks/types';
+import { AnyContest, Candidate } from '@votingworks/types';
 
 // Maps the number of candidates in a contest to the index at which to rotate
 // the candidates. These indexes are randomly selected by the state every 2
@@ -38,13 +38,19 @@ export function rotateCandidates(contest: AnyContest): AnyContest {
   if (contest.type !== 'candidate') return contest;
   if (contest.candidates.length < 2) return contest;
 
-  // Lacking structured name data, we approximate last name by using the last word
-  function lastName(name: string): string {
-    return assertDefined(name.split(' ').at(-1));
+  function getSortingName(candidate: Candidate): string {
+    return (
+      // || instead of ?? because when lastName and firstName are empty string we want to sort by
+      // the last word of `name`. This supports backwards compatibility with elections that were
+      // created before structured name input.
+      candidate.lastName ||
+      candidate.firstName ||
+      assertDefined(candidate.name.split(' ').at(-1))
+    );
   }
 
   const orderedCandidates = [...contest.candidates].sort((a, b) =>
-    lastName(a.name).localeCompare(lastName(b.name))
+    getSortingName(a).localeCompare(getSortingName(b))
   );
 
   const rotationIndex =

--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -402,6 +402,33 @@ function ContestForm({
     );
   }
 
+  function onNameChange(
+    contestToUpdate: CandidateContest,
+    candidate: Candidate,
+    index: number,
+    nameParts: {
+      first?: string;
+      middle?: string;
+      last?: string;
+    }
+  ) {
+    const { first, middle, last } = nameParts;
+    const fullName = [first, middle, last]
+      .filter((part) => !!part)
+      .join(' ')
+      .trim();
+    setContest({
+      ...contestToUpdate,
+      candidates: replaceAtIndex(contestToUpdate.candidates, index, {
+        ...candidate,
+        name: fullName,
+        firstName: first,
+        middleName: middle,
+        lastName: last,
+      }),
+    });
+  }
+
   return (
     <Form>
       <InputGroup label="Title">
@@ -513,7 +540,9 @@ function ContestForm({
               <Table>
                 <thead>
                   <tr>
-                    <TH>Name</TH>
+                    <TH>First Name</TH>
+                    <TH>Middle Name</TH>
+                    <TH>Last Name</TH>
                     <TH>Party</TH>
                     <TH />
                   </tr>
@@ -523,22 +552,45 @@ function ContestForm({
                     <tr key={candidate.id}>
                       <TD>
                         <input
-                          aria-label={`Candidate ${index + 1} Name`}
+                          aria-label={`Candidate ${index + 1} First Name`}
                           type="text"
-                          value={candidate.name}
+                          // Fall back to candidate.name for backwards compatibility
+                          value={candidate.firstName || candidate.name || ''}
                           // eslint-disable-next-line jsx-a11y/no-autofocus
                           autoFocus
                           onChange={(e) =>
-                            setContest({
-                              ...contest,
-                              candidates: replaceAtIndex(
-                                contest.candidates,
-                                index,
-                                {
-                                  ...candidate,
-                                  name: e.target.value,
-                                }
-                              ),
+                            onNameChange(contest, candidate, index, {
+                              first: e.target.value,
+                              middle: candidate.middleName,
+                              last: candidate.lastName,
+                            })
+                          }
+                        />
+                      </TD>
+                      <TD>
+                        <input
+                          aria-label={`Candidate ${index + 1} Middle Name`}
+                          type="text"
+                          value={candidate.middleName || ''}
+                          onChange={(e) =>
+                            onNameChange(contest, candidate, index, {
+                              first: candidate.firstName,
+                              middle: e.target.value,
+                              last: candidate.lastName,
+                            })
+                          }
+                        />
+                      </TD>
+                      <TD>
+                        <input
+                          aria-label={`Candidate ${index + 1} Last Name`}
+                          type="text"
+                          value={candidate.lastName || ''}
+                          onChange={(e) =>
+                            onNameChange(contest, candidate, index, {
+                              first: candidate.firstName,
+                              middle: candidate.middleName,
+                              last: e.target.value,
                             })
                           }
                         />

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -112,6 +112,10 @@ export interface Candidate {
   readonly partyIds?: readonly PartyId[];
   readonly isWriteIn?: boolean;
   readonly writeInIndex?: number;
+  // Structured name properties are supported only in VxDesign.
+  readonly firstName?: string;
+  readonly middleName?: string;
+  readonly lastName?: string;
 }
 export const CandidateSchema: z.ZodSchema<Candidate> = z
   .object({


### PR DESCRIPTION
## Overview

* Adds structured first, middle, and last name inputs to VxDesign candidate contest creation
* Prefers to sort by last name, first name, and finally full concatenated name


## Demo Video or Screenshot

![Screenshot 2025-01-09 at 11 14 26 AM](https://github.com/user-attachments/assets/c6daed2b-47e4-4cb5-8fd8-81b57fb5de10)

https://github.com/user-attachments/assets/0cac2142-99a1-4f10-a2b9-e22978e20faf

## Testing Plan
- Added tests to `contests_screen.test.tsx` and `candidate_rotation.test.ts`

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
