### PR TITLE
[Design] Add Postgres client management code

### DIFF
--- a/apps/design/backend/package.json
+++ b/apps/design/backend/package.json
@@ -17,6 +17,7 @@
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "db:reset": "./scripts/db_reset_dev.sh",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
     "lint": "pnpm type-check && eslint .",
     "lint:fix": "pnpm type-check && eslint . --fix",
@@ -47,6 +48,7 @@
     "fs-extra": "11.1.1",
     "js-sha256": "^0.9.0",
     "jszip": "^3.9.1",
+    "pg": "^8.13.1",
     "react": "18.3.1",
     "uuid": "9.0.1",
     "zod": "3.23.5"
@@ -61,6 +63,7 @@
     "@types/jest-image-snapshot": "^6.4.0",
     "@types/lodash.get": "^4.4.9",
     "@types/node": "20.16.0",
+    "@types/pg": "^8.11.10",
     "@types/react": "18.3.3",
     "@types/tmp": "0.2.4",
     "@types/uuid": "9.0.5",

--- a/apps/design/backend/schema.old.sql
+++ b/apps/design/backend/schema.old.sql
@@ -1,3 +1,15 @@
+create table elections (
+  id text primary key,
+  election_data text not null,
+  system_settings_data text not null,
+  precinct_data text not null,
+  created_at timestamp not null default current_timestamp,
+  election_package_task_id text,
+  election_package_url text,
+  foreign key (election_package_task_id) references background_tasks(id)
+    on delete set null
+);
+
 create table background_tasks (
   id text primary key,
   task_name text not null,
@@ -6,17 +18,6 @@ create table background_tasks (
   started_at timestamp,
   completed_at timestamp,
   error text
-);
-
-create table elections (
-  id text primary key,
-  election_data text not null,
-  system_settings_data text not null,
-  precinct_data text not null,
-  created_at timestamp not null default current_timestamp,
-  election_package_task_id text
-    constraint fk_background_tasks references background_tasks(id) on delete set null,
-  election_package_url text
 );
 
 create table translation_cache (

--- a/apps/design/backend/scripts/db_reset_dev.sh
+++ b/apps/design/backend/scripts/db_reset_dev.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# [TODO] Move schema management to migration tool
+# (e.g. https://salsita.github.io/node-pg-migrate/)
+
+SCRIPT_DIR="$(dirname "$0")"
+
+if [[ -z $(which psql) ]]; then
+  echo "🔴 [ERROR] psql not found - you may need to run install postgres first:"
+  echo "    > sudo apt install postgresql"
+  echo ""
+  exit 1
+fi
+
+sudo systemctl start postgresql
+
+sudo -u postgres psql -c "drop database design;"
+sudo -u postgres psql -c "drop user design;"
+
+sudo -u postgres psql -c "create user design password 'design';" &&
+  sudo -u postgres psql -c "create database design with owner design;" &&
+  sudo -u postgres psql -d design -f "${SCRIPT_DIR}/../schema.sql"

--- a/apps/design/backend/src/db/db.ts
+++ b/apps/design/backend/src/db/db.ts
@@ -1,0 +1,49 @@
+/* istanbul ignore file - [TODO] need to update CI image to include postgres. @preserve */
+
+// [TODO] Move to separate libs/ package once it's stable/cleaned up.
+
+import {
+  BaseLogger,
+  LogDispositionStandardTypes,
+  LogEventId,
+} from '@votingworks/logging';
+import makeDebug from 'debug';
+import * as pg from 'pg';
+import { Client } from './client';
+
+const debug = makeDebug('pg-client');
+
+/**
+ * Manages a pool of connections to a PostgreSQL database.
+ */
+export class Db {
+  private readonly pool: pg.Pool;
+
+  constructor(private readonly logger: BaseLogger) {
+    this.pool = new pg.Pool({
+      ssl: { rejectUnauthorized: false },
+    });
+    this.pool.on('error', (error) => {
+      void this.logger.log(
+        LogEventId.UnknownError, // [TODO] Figure out logging/reporting
+        'system',
+        {
+          disposition: LogDispositionStandardTypes.Failure,
+          message: `Postgres client error: ${error}`,
+        },
+        debug
+      );
+    });
+  }
+
+  async withClient<T>(fn: (client: Client) => Promise<T>): Promise<T> {
+    const poolClient = await this.pool.connect();
+    const client = new Client(await this.pool.connect());
+
+    try {
+      return await fn(client);
+    } finally {
+      poolClient.release();
+    }
+  }
+}

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -142,7 +142,7 @@ function hydrateElection(row: {
   };
 }
 
-const SchemaPath = join(__dirname, '../schema.sql');
+const SchemaPath = join(__dirname, '../schema.old.sql');
 
 export class Store {
   private constructor(private readonly client: DbClient) {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1188,6 +1188,9 @@ importers:
       jszip:
         specifier: ^3.9.1
         version: 3.9.1
+      pg:
+        specifier: ^8.13.1
+        version: 8.13.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -1225,6 +1228,9 @@ importers:
       '@types/node':
         specifier: 20.16.0
         version: 20.16.0
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.11.10
       '@types/react':
         specifier: 18.3.3
         version: 18.3.3
@@ -11477,6 +11483,14 @@ packages:
     resolution: {integrity: sha512-aGyFfB4Q8QjaSR3cBTiJfnFXBU6SXQaBVM7ADfBaZzq4L7EGbjuSoqXfHJofZmLFBfKzZ9b+9nXO2FfUIsw77w==}
     dev: true
 
+  /@types/pg@8.11.10:
+    resolution: {integrity: sha512-LczQUW4dbOQzsH2RQ5qoeJ6qJPdrcM/DcMLoqWQkMLMsq83J5lAX3LXjdkWdpscFy67JSOWDnh7Ny/sPFykmkg==}
+    dependencies:
+      '@types/node': 20.16.0
+      pg-protocol: 1.7.0
+      pg-types: 4.0.2
+    dev: true
+
   /@types/pify@3.0.2:
     resolution: {integrity: sha512-a5AKF1/9pCU3HGMkesgY6LsBdXHUY3WU+I2qgpU0J+I8XuJA1aFr59eS84/HP0+dxsyBSNbt+4yGI2adUpHwSg==}
     dev: true
@@ -19350,6 +19364,10 @@ packages:
       define-properties: 1.2.1
       es-abstract: 1.21.1
 
+  /obuf@1.1.2:
+    resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
+    dev: true
+
   /on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -19736,6 +19754,84 @@ packages:
   /performance-now@2.1.0:
     resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
+  /pg-cloudflare@1.1.1:
+    resolution: {integrity: sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==}
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /pg-connection-string@2.7.0:
+    resolution: {integrity: sha512-PI2W9mv53rXJQEOb8xNR8lH7Hr+EKa6oJa38zsK0S/ky2er16ios1wLKhZyxzD7jUReiWokc9WK5nxSnC7W1TA==}
+    dev: false
+
+  /pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  /pg-numeric@1.0.2:
+    resolution: {integrity: sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /pg-pool@3.7.0(pg@8.13.1):
+    resolution: {integrity: sha512-ZOBQForurqh4zZWjrgSwwAtzJ7QiRX0ovFkZr2klsen3Nm0aoh33Ls0fzfv3imeH/nw/O27cjdz5kzYJfeGp/g==}
+    peerDependencies:
+      pg: '>=8.0'
+    dependencies:
+      pg: 8.13.1
+    dev: false
+
+  /pg-protocol@1.7.0:
+    resolution: {integrity: sha512-hTK/mE36i8fDDhgDFjy6xNOG+LCorxLG3WO17tku+ij6sVHXh1jQUJ8hYAnRhNla4QVD2H8er/FOjc/+EgC6yQ==}
+
+  /pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.0
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+    dev: false
+
+  /pg-types@4.0.2:
+    resolution: {integrity: sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==}
+    engines: {node: '>=10'}
+    dependencies:
+      pg-int8: 1.0.1
+      pg-numeric: 1.0.2
+      postgres-array: 3.0.2
+      postgres-bytea: 3.0.0
+      postgres-date: 2.1.0
+      postgres-interval: 3.0.0
+      postgres-range: 1.1.4
+    dev: true
+
+  /pg@8.13.1:
+    resolution: {integrity: sha512-OUir1A0rPNZlX//c7ksiu7crsGZTKSOXJPgtNiHGIlC9H0lO+NC6ZDYksSgBYY/thSWhnSRBv8w1lieNNGATNQ==}
+    engines: {node: '>= 8.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+    dependencies:
+      pg-connection-string: 2.7.0
+      pg-pool: 3.7.0(pg@8.13.1)
+      pg-protocol: 1.7.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.1.1
+    dev: false
+
+  /pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+    dependencies:
+      split2: 4.2.0
+    dev: false
+
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
 
@@ -19905,6 +20001,54 @@ packages:
       nanoid: 3.3.7
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  /postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /postgres-array@3.0.2:
+    resolution: {integrity: sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /postgres-bytea@1.0.0:
+    resolution: {integrity: sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /postgres-bytea@3.0.0:
+    resolution: {integrity: sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==}
+    engines: {node: '>= 6'}
+    dependencies:
+      obuf: 1.1.2
+    dev: true
+
+  /postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /postgres-date@2.1.0:
+    resolution: {integrity: sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      xtend: 4.0.2
+    dev: false
+
+  /postgres-interval@3.0.0:
+    resolution: {integrity: sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /postgres-range@1.1.4:
+    resolution: {integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==}
+    dev: true
 
   /prebuild-install@7.1.1:
     resolution: {integrity: sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==}
@@ -21723,6 +21867,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       extend-shallow: 3.0.2
+    dev: false
+
+  /split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
     dev: false
 
   /sprintf-js@1.0.3:


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/5698

Adding (unused) postgres client lib to VsDesign for the upcoming conversion from sqlite.
Currently using the default setup and relying on the standard postgres [environment variables](https://www.postgresql.org/docs/current/libpq-envars.html), which are assigned accordingly in the Heroku dashboard (https://dashboard.heroku.com/apps/tmp-vxdesign-dev/settings).

Will eventually need  a schema migration tool, but for now, just adding a `db:reset` pnpm script for dev.

## Testing Plan
- Manual for now - will set up testing in upcoming PRs, when we start wiring up the store code.

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
