### PR TITLE
add features provider

### DIFF
--- a/apps/design/frontend/src/app.tsx
+++ b/apps/design/frontend/src/app.tsx
@@ -1,6 +1,12 @@
 import './polyfills';
 import { AppBase, ErrorBoundary } from '@votingworks/ui';
-import { BrowserRouter, Redirect, Route, Switch } from 'react-router-dom';
+import {
+  BrowserRouter,
+  Redirect,
+  Route,
+  Switch,
+  useParams,
+} from 'react-router-dom';
 import { QueryClientProvider } from '@tanstack/react-query';
 import {
   ApiClient,
@@ -9,7 +15,7 @@ import {
   createQueryClient,
 } from './api';
 import { ElectionsScreen } from './elections_screen';
-import { electionParamRoutes, routes } from './routes';
+import { ElectionIdParams, electionParamRoutes, routes } from './routes';
 import { ElectionInfoScreen } from './election_info_screen';
 import { GeographyScreen } from './geography_screen';
 import { ContestsScreen } from './contests_screen';
@@ -17,36 +23,43 @@ import { BallotsScreen } from './ballots_screen';
 import { TabulationScreen } from './tabulation_screen';
 import { ExportScreen } from './export_screen';
 import { ErrorScreen } from './error_screen';
+import { FeaturesProvider } from './features_provider';
 
 function ElectionScreens(): JSX.Element {
+  const { electionId } = useParams<ElectionIdParams>();
   return (
-    <Switch>
-      <Route
-        path={electionParamRoutes.electionInfo.path}
-        component={ElectionInfoScreen}
-      />
-      <Route
-        path={electionParamRoutes.geography.root.path}
-        component={GeographyScreen}
-      />
-      <Route
-        path={electionParamRoutes.contests.root.path}
-        component={ContestsScreen}
-      />
-      <Route
-        path={electionParamRoutes.ballots.root.path}
-        component={BallotsScreen}
-      />
-      <Route
-        path={electionParamRoutes.tabulation.path}
-        component={TabulationScreen}
-      />
-      <Route path={electionParamRoutes.export.path} component={ExportScreen} />
-      <Redirect
-        from={electionParamRoutes.root.path}
-        to={electionParamRoutes.electionInfo.path}
-      />
-    </Switch>
+    <FeaturesProvider electionId={electionId}>
+      <Switch>
+        <Route
+          path={electionParamRoutes.electionInfo.path}
+          component={ElectionInfoScreen}
+        />
+        <Route
+          path={electionParamRoutes.geography.root.path}
+          component={GeographyScreen}
+        />
+        <Route
+          path={electionParamRoutes.contests.root.path}
+          component={ContestsScreen}
+        />
+        <Route
+          path={electionParamRoutes.ballots.root.path}
+          component={BallotsScreen}
+        />
+        <Route
+          path={electionParamRoutes.tabulation.path}
+          component={TabulationScreen}
+        />
+        <Route
+          path={electionParamRoutes.export.path}
+          component={ExportScreen}
+        />
+        <Redirect
+          from={electionParamRoutes.root.path}
+          to={electionParamRoutes.electionInfo.path}
+        />
+      </Switch>
+    </FeaturesProvider>
   );
 }
 

--- a/apps/design/frontend/src/app.tsx
+++ b/apps/design/frontend/src/app.tsx
@@ -23,9 +23,10 @@ import { BallotsScreen } from './ballots_screen';
 import { TabulationScreen } from './tabulation_screen';
 import { ExportScreen } from './export_screen';
 import { ErrorScreen } from './error_screen';
-import { FeaturesProvider } from './features_provider';
+import { FeaturesProvider } from './features_context';
 
 function ElectionScreens(): JSX.Element {
+  /* istanbul ignore next */
   const { electionId } = useParams<ElectionIdParams>();
   return (
     <FeaturesProvider electionId={electionId}>

--- a/apps/design/frontend/src/ballot_screen.test.tsx
+++ b/apps/design/frontend/src/ballot_screen.test.tsx
@@ -76,7 +76,8 @@ function renderScreen() {
         path: routes
           .election(electionId)
           .ballots.viewBallot(ballotStyle.id, precinct.id).path,
-      })
+      }),
+      electionId
     )
   );
 }

--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -27,7 +27,7 @@ import { ElectionNavScreen } from './nav_screen';
 import { ElectionIdParams, electionParamRoutes, routes } from './routes';
 import { hasSplits } from './utils';
 import { BallotScreen, paperSizeLabels } from './ballot_screen';
-import { FeatureName, useFeatures } from './features_provider';
+import { FeatureName, useFeaturesContext } from './features_context';
 
 function BallotDesignForm({
   electionId,
@@ -42,7 +42,7 @@ function BallotDesignForm({
     'left'
   );
   const updateElectionMutation = updateElection.useMutation();
-  const features = useFeatures();
+  const features = useFeaturesContext();
 
   function onSavePress() {
     updateElectionMutation.mutate(

--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -11,6 +11,7 @@ import {
   MainContent,
   TabPanel,
   RouterTabBar,
+  SegmentedButton,
 } from '@votingworks/ui';
 import { Redirect, Route, Switch, useParams } from 'react-router-dom';
 import { assertDefined } from '@votingworks/basics';
@@ -26,6 +27,7 @@ import { ElectionNavScreen } from './nav_screen';
 import { ElectionIdParams, electionParamRoutes, routes } from './routes';
 import { hasSplits } from './utils';
 import { BallotScreen, paperSizeLabels } from './ballot_screen';
+import { FeatureName, useFeatures } from './features_provider';
 
 function BallotDesignForm({
   electionId,
@@ -36,7 +38,11 @@ function BallotDesignForm({
 }): JSX.Element {
   const [isEditing, setIsEditing] = useState(false);
   const [ballotLayout, setBallotLayout] = useState(savedElection.ballotLayout);
+  const [bubblePosition, setBubblePosition] = useState<'left' | 'right'>(
+    'left'
+  );
   const updateElectionMutation = updateElection.useMutation();
+  const features = useFeatures();
 
   function onSavePress() {
     updateElectionMutation.mutate(
@@ -72,6 +78,21 @@ function BallotDesignForm({
         }
         disabled={!isEditing}
       />
+
+      {features[FeatureName.BALLOT_BUBBLE_SIDE] && (
+        <SegmentedButton
+          label="Bubble Position"
+          options={[
+            { id: 'left', label: 'Left' },
+            { id: 'right', label: 'Right' },
+          ]}
+          selectedOptionId={bubblePosition}
+          onChange={(targetMarkPosition: 'left' | 'right') =>
+            setBubblePosition(targetMarkPosition)
+          }
+          disabled={!isEditing}
+        />
+      )}
 
       {isEditing ? (
         <FormActionsRow>

--- a/apps/design/frontend/src/contests_screen.test.tsx
+++ b/apps/design/frontend/src/contests_screen.test.tsx
@@ -43,7 +43,8 @@ function renderScreen(electionId: ElectionId) {
       withRoute(<ContestsScreen />, {
         paramPath: routes.election(':electionId').contests.root.path,
         path,
-      })
+      }),
+      electionId
     )
   );
   return history;

--- a/apps/design/frontend/src/election_info_screen.test.tsx
+++ b/apps/design/frontend/src/election_info_screen.test.tsx
@@ -33,7 +33,8 @@ function renderScreen(electionId: ElectionId) {
       withRoute(<ElectionInfoScreen />, {
         paramPath: routes.election(':electionId').electionInfo.path,
         history,
-      })
+      }),
+      electionId
     )
   );
   return history;

--- a/apps/design/frontend/src/export_screen.test.tsx
+++ b/apps/design/frontend/src/export_screen.test.tsx
@@ -28,6 +28,9 @@ let apiMock: MockApiClient;
 
 beforeEach(() => {
   apiMock = createMockApiClient();
+  apiMock.getElection
+    .expectCallWith({ electionId })
+    .resolves(generalElectionRecord);
   apiMock.getElectionPackage.expectCallWith({ electionId }).resolves({});
 });
 
@@ -42,7 +45,8 @@ function renderScreen() {
       withRoute(<ExportScreen />, {
         paramPath: routes.election(':electionId').export.path,
         path: routes.election(electionId).export.path,
-      })
+      }),
+      electionId
     )
   );
 }

--- a/apps/design/frontend/src/features_context.test.tsx
+++ b/apps/design/frontend/src/features_context.test.tsx
@@ -1,0 +1,44 @@
+import { ElectionRecord } from '@votingworks/design-backend';
+import {
+  createMockApiClient,
+  MockApiClient,
+  provideApi,
+} from '../test/api_helpers';
+import { generalElectionRecord } from '../test/fixtures';
+import { renderHook, waitFor } from '../test/react_testing_library';
+import {
+  DEFAULT_ENABLED_FEATURES,
+  NH_ENABLED_FEATURES,
+  useFeaturesContext,
+} from './features_context';
+
+let apiMock: MockApiClient;
+
+beforeEach(() => {
+  apiMock = createMockApiClient();
+});
+
+afterEach(() => {
+  apiMock.assertComplete();
+});
+
+test('returns default feature set if no election specified', () => {
+  const { result } = renderHook(useFeaturesContext);
+  expect(result.current).toEqual(DEFAULT_ENABLED_FEATURES);
+});
+
+test('returns NH feature set for NH election', async () => {
+  const nhElection: ElectionRecord = {
+    ...generalElectionRecord,
+    election: { ...generalElectionRecord.election, state: 'NH' },
+  };
+  const electionId = nhElection.election.id;
+  apiMock.getElection.expectCallWith({ electionId }).resolves(nhElection);
+
+  const { result } = renderHook(() => useFeaturesContext(), {
+    wrapper: ({ children }) => provideApi(apiMock, children, electionId),
+  });
+  await waitFor(() => {
+    expect(result.current).toEqual(NH_ENABLED_FEATURES);
+  });
+});

--- a/apps/design/frontend/src/features_context.tsx
+++ b/apps/design/frontend/src/features_context.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext } from 'react';
+import { assertDefined } from '@votingworks/basics';
 import { getElection } from './api';
 
 export enum FeatureName {
@@ -7,11 +8,11 @@ export enum FeatureName {
 
 export type FeaturesEnabledRecord = Record<FeatureName, boolean>;
 
-const DEFAULT_ENABLED_FEATURES: FeaturesEnabledRecord = {
+export const DEFAULT_ENABLED_FEATURES: FeaturesEnabledRecord = {
   BALLOT_BUBBLE_SIDE: false,
 };
 
-const NH_ENABLED_FEATURES: FeaturesEnabledRecord = {
+export const NH_ENABLED_FEATURES: FeaturesEnabledRecord = {
   BALLOT_BUBBLE_SIDE: true,
 };
 
@@ -19,23 +20,30 @@ const FeaturesContext = createContext<FeaturesEnabledRecord>(
   DEFAULT_ENABLED_FEATURES
 );
 
-export function useFeatures(): FeaturesEnabledRecord {
-  const context = useContext(FeaturesContext);
-  if (context === undefined) {
-    throw new Error('useFeatures must be used within a FeaturesProvider');
-  }
-  return context;
+export function useFeaturesContext(): FeaturesEnabledRecord {
+  return assertDefined(
+    useContext(FeaturesContext),
+    'useFeatures must be used within a FeaturesProvider'
+  );
 }
 
 interface FeaturesProviderProps {
   children: React.ReactNode;
-  electionId: string;
+  electionId?: string;
 }
 
 export function FeaturesProvider({
   children,
   electionId,
 }: FeaturesProviderProps): JSX.Element {
+  if (!electionId) {
+    return (
+      <FeaturesContext.Provider value={DEFAULT_ENABLED_FEATURES}>
+        {children}
+      </FeaturesContext.Provider>
+    );
+  }
+
   const getElectionQuery = getElection.useQuery(electionId);
   let features = DEFAULT_ENABLED_FEATURES;
 

--- a/apps/design/frontend/src/features_provider.tsx
+++ b/apps/design/frontend/src/features_provider.tsx
@@ -1,0 +1,56 @@
+import React, { createContext, useContext } from 'react';
+import { getElection } from './api';
+
+export enum FeatureName {
+  BALLOT_BUBBLE_SIDE = 'BALLOT_BUBBLE_SIDE',
+}
+
+export type FeaturesEnabledRecord = Record<FeatureName, boolean>;
+
+const DEFAULT_ENABLED_FEATURES: FeaturesEnabledRecord = {
+  BALLOT_BUBBLE_SIDE: false,
+};
+
+const NH_ENABLED_FEATURES: FeaturesEnabledRecord = {
+  BALLOT_BUBBLE_SIDE: true,
+};
+
+const FeaturesContext = createContext<FeaturesEnabledRecord>(
+  DEFAULT_ENABLED_FEATURES
+);
+
+export function useFeatures(): FeaturesEnabledRecord {
+  const context = useContext(FeaturesContext);
+  if (context === undefined) {
+    throw new Error('useFeatures must be used within a FeaturesProvider');
+  }
+  return context;
+}
+
+interface FeaturesProviderProps {
+  children: React.ReactNode;
+  electionId: string;
+}
+
+export function FeaturesProvider({
+  children,
+  electionId,
+}: FeaturesProviderProps): JSX.Element {
+  const getElectionQuery = getElection.useQuery(electionId);
+  let features = DEFAULT_ENABLED_FEATURES;
+
+  if (getElectionQuery.isSuccess) {
+    const { election } = getElectionQuery.data;
+    // TODO expand to include vx or SLI users who should have access to all features.
+    // Blocked on auth implementation.
+    if (election.state.toLowerCase() === 'nh') {
+      features = NH_ENABLED_FEATURES;
+    }
+  }
+
+  return (
+    <FeaturesContext.Provider value={features}>
+      {children}
+    </FeaturesContext.Provider>
+  );
+}

--- a/apps/design/frontend/src/geography_screen.test.tsx
+++ b/apps/design/frontend/src/geography_screen.test.tsx
@@ -46,7 +46,8 @@ function renderScreen() {
       withRoute(<GeographyScreen />, {
         paramPath: routes.election(':electionId').geography.root.path,
         path,
-      })
+      }),
+      electionId
     )
   );
   return history;

--- a/apps/design/frontend/src/tabulation_screen.test.tsx
+++ b/apps/design/frontend/src/tabulation_screen.test.tsx
@@ -35,7 +35,8 @@ function renderScreen() {
       withRoute(<TabulationScreen />, {
         paramPath: routes.election(':electionId').tabulation.path,
         path: routes.election(electionId).tabulation.path,
-      })
+      }),
+      electionId
     )
   );
 }

--- a/apps/design/frontend/test/api_helpers.tsx
+++ b/apps/design/frontend/test/api_helpers.tsx
@@ -3,6 +3,7 @@ import type { Api } from '@votingworks/design-backend';
 import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
 import { TestErrorBoundary } from '@votingworks/ui';
 import { ApiClientContext, createQueryClient } from '../src/api';
+import { FeaturesProvider } from '../src/features_context';
 
 export type MockApiClient = MockClient<Api>;
 
@@ -12,13 +13,16 @@ export function createMockApiClient(): MockApiClient {
 
 export function provideApi(
   apiMock: ReturnType<typeof createMockApiClient>,
-  children: React.ReactNode
+  children: React.ReactNode,
+  electionId?: string
 ): JSX.Element {
   return (
     <TestErrorBoundary>
       <ApiClientContext.Provider value={apiMock}>
         <QueryClientProvider client={createQueryClient()}>
-          {children}
+          <FeaturesProvider electionId={electionId}>
+            {children}
+          </FeaturesProvider>
         </QueryClientProvider>
       </ApiClientContext.Provider>
     </TestErrorBoundary>


### PR DESCRIPTION
## Overview

Related to https://github.com/votingworks/vxsuite/issues/5795

Adds a `FeaturesContext` to expose feature configuration by state. Right now it's just NH vs not-NH but eventually we'll want to support different configurations for NH, MS, and VX users.

I added the "Bubble Position" SegmentedControl for illustration, but it's not wired up to anything yet.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/0c2ec8a1-79d0-4779-9988-5c1cf1ca627c


## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
