### PR TITLE
Remove tallies for write-ins that are part of an overvote

### DIFF
--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -1549,7 +1549,6 @@ export class Store {
       electionId,
       cvrId
     ) as StoreCastVoteRecordAttributes & {
-      id: Id;
       sheetNumber: number | null;
       votes: string;
       adjudications: string | null;

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -1501,6 +1501,75 @@ export class Store {
     }
   }
 
+  getCastVoteRecord({
+    electionId,
+    cvrId,
+  }: {
+    electionId: Id;
+    cvrId: Id;
+  }): Tabulation.CastVoteRecord {
+    const row = this.client.one(
+      `
+        select
+          cvrs.ballot_style_group_id as ballotStyleGroupId,
+          ballot_styles.party_id as partyId,
+          cvrs.precinct_id as precinctId,
+          cvrs.ballot_type as votingMethod,
+          cvrs.batch_id as batchId,
+          scanner_batches.scanner_id as scannerId,
+          cvrs.sheet_number as sheetNumber,
+          cvrs.votes as votes,
+          aggregated_adjudications.adjudications as adjudications
+        from cvrs
+        inner join scanner_batches on cvrs.batch_id = scanner_batches.id
+        inner join ballot_styles on
+          cvrs.election_id = ballot_styles.election_id and
+          cvrs.ballot_style_group_id = ballot_styles.group_id
+        left join (
+          select
+            election_id,
+            cvr_id,
+            json_group_array(
+              json_object(
+                'contestId', contest_id,
+                'optionId', option_id,
+                'isVote', is_vote
+              )
+            ) as adjudications
+          from vote_adjudications
+          group by cvr_id
+        ) aggregated_adjudications
+          on
+            cvrs.election_id = aggregated_adjudications.election_id and
+            cvrs.id = aggregated_adjudications.cvr_id
+          where
+            cvrs.election_id = ? and
+            cvrs.id = ?
+      `,
+      electionId,
+      cvrId
+    ) as StoreCastVoteRecordAttributes & {
+      id: Id;
+      sheetNumber: number | null;
+      votes: string;
+      adjudications: string | null;
+    };
+
+    return {
+      ballotStyleGroupId: row.ballotStyleGroupId,
+      partyId: row.partyId ?? undefined,
+      votingMethod: row.votingMethod,
+      batchId: row.batchId,
+      scannerId: row.scannerId,
+      precinctId: row.precinctId,
+      card: this.convertSheetNumberToCard(row.sheetNumber),
+      votes: this.parseVotesWithAdjudications({
+        votesString: row.votes,
+        adjudicationsString: row.adjudications,
+      }),
+    };
+  }
+
   /**
    * Gets card tallies, filtered and grouped.
    */

--- a/apps/admin/backend/src/tabulation/full_results.ts
+++ b/apps/admin/backend/src/tabulation/full_results.ts
@@ -146,6 +146,7 @@ export async function tabulateElectionResults({
       electionId,
       store,
       groupedElectionResults,
+      groupBy,
     });
   }
 

--- a/apps/admin/backend/src/tabulation/full_results.ts
+++ b/apps/admin/backend/src/tabulation/full_results.ts
@@ -12,6 +12,7 @@ import memoize from 'lodash.memoize';
 import hash from 'object-hash';
 import { Store } from '../store';
 import {
+  removeOvervoteWriteInsFromElectionResults,
   modifyElectionResultsWithWriteInSummary,
   tabulateWriteInTallies,
 } from './write_ins';
@@ -139,6 +140,13 @@ export async function tabulateElectionResults({
           : electionResults;
       }
     );
+
+    debug('removing overvote write-ins from election results');
+    groupedElectionResults = removeOvervoteWriteInsFromElectionResults({
+      electionId,
+      store,
+      groupedElectionResults,
+    });
   }
 
   // include manual results if specified

--- a/apps/admin/backend/src/tabulation/full_results.ts
+++ b/apps/admin/backend/src/tabulation/full_results.ts
@@ -12,7 +12,7 @@ import memoize from 'lodash.memoize';
 import hash from 'object-hash';
 import { Store } from '../store';
 import {
-  removeOvervoteWriteInsFromElectionResults,
+  filterOvervoteWriteInsFromElectionResults,
   modifyElectionResultsWithWriteInSummary,
   tabulateWriteInTallies,
 } from './write_ins';
@@ -141,8 +141,8 @@ export async function tabulateElectionResults({
       }
     );
 
-    debug('removing overvote write-ins from election results');
-    groupedElectionResults = removeOvervoteWriteInsFromElectionResults({
+    debug('filtering overvote write-ins from election results');
+    groupedElectionResults = filterOvervoteWriteInsFromElectionResults({
       electionId,
       store,
       groupedElectionResults,

--- a/apps/admin/backend/src/tabulation/write_ins.test.ts
+++ b/apps/admin/backend/src/tabulation/write_ins.test.ts
@@ -9,7 +9,8 @@ import {
   DEFAULT_SYSTEM_SETTINGS,
   Tabulation,
 } from '@votingworks/types';
-import { getEmptyElectionResults } from '@votingworks/utils';
+import { getEmptyElectionResults, GROUP_KEY_ROOT } from '@votingworks/utils';
+import { mockBaseLogger } from '@votingworks/logging';
 import {
   convertContestWriteInSummaryToWriteInTallies,
   getEmptyContestWriteInSummary,
@@ -17,12 +18,14 @@ import {
   tabulateWriteInTallies,
   modifyElectionResultsWithWriteInSummary,
   combineElectionWriteInSummaries,
+  removeOvervoteWriteInsFromElectionResults,
 } from './write_ins';
 import {
   MockCastVoteRecordFile,
   addMockCvrFileToStore,
 } from '../../test/mock_cvr_file';
 import { Store } from '../store';
+import { adjudicateWriteIn } from '../adjudication';
 
 const electionTwoPartyPrimary = readElectionTwoPartyPrimary();
 
@@ -540,4 +543,195 @@ test('combineElectionWriteInSummaries', () => {
       },
     },
   });
+});
+
+test('removeOvervoteWriteInsFromElectionResults', async () => {
+  const store = Store.memoryStore();
+  const logger = mockBaseLogger({ fn: jest.fn });
+  const contestId = 'zoo-council-mammal';
+  const electionDefinition =
+    electionTwoPartyPrimaryFixtures.readElectionDefinition();
+  const { electionData } = electionDefinition;
+  const electionId = store.addElection({
+    electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
+    electionPackageHash: 'test-election-package-hash',
+  });
+  store.setCurrentElectionId(electionId);
+
+  // Add mock cast vote records with pending write-ins to the store, two overvotes and one normal
+  const mockCastVoteRecordFile: MockCastVoteRecordFile = [
+    {
+      ballotStyleGroupId: '1M' as BallotStyleGroupId,
+      batchId: 'batch-1-1',
+      scannerId: 'scanner-1',
+      precinctId: 'precinct-1',
+      votingMethod: 'precinct',
+      votes: { 'zoo-council-mammal': ['write-in', 'lion'] },
+      card: { type: 'bmd' },
+    },
+    {
+      ballotStyleGroupId: '1M' as BallotStyleGroupId,
+      batchId: 'batch-1-1',
+      scannerId: 'scanner-1',
+      precinctId: 'precinct-1',
+      votingMethod: 'precinct',
+      votes: { 'zoo-council-mammal': ['write-in-invalid', 'write-in', 'lion'] },
+      card: { type: 'bmd' },
+    },
+    {
+      ballotStyleGroupId: '1M' as BallotStyleGroupId,
+      batchId: 'batch-1-1',
+      scannerId: 'scanner-1',
+      precinctId: 'precinct-1',
+      votingMethod: 'absentee',
+      votes: { 'zoo-council-mammal': ['lion'] },
+      card: { type: 'bmd' },
+    },
+  ];
+  addMockCvrFileToStore({ electionId, mockCastVoteRecordFile, store });
+
+  function getElectionResults(
+    writeInTally: number,
+    lionTally: number,
+    writeInId?: string
+  ): Tabulation.ElectionResultsGroupMap {
+    return {
+      [GROUP_KEY_ROOT]: {
+        contestResults: {
+          'zoo-council-mammal': {
+            contestType: 'candidate',
+            contestId: 'zoo-council-mammal',
+            votesAllowed: 1,
+            overvotes: 2,
+            undervotes: 0,
+            ballots: 3,
+            tallies: {
+              [writeInId || Tabulation.GENERIC_WRITE_IN_ID]: {
+                tally: writeInTally,
+                id: writeInId || Tabulation.GENERIC_WRITE_IN_ID,
+                name: writeInId
+                  ? 'Mr. Pickles'
+                  : Tabulation.GENERIC_WRITE_IN_NAME,
+              },
+              lion: {
+                tally: lionTally,
+                id: 'lion',
+                name: 'Lion',
+              },
+            },
+          },
+        },
+        cardCounts: {
+          bmd: 3,
+          hmpb: [],
+        },
+      },
+    };
+  }
+
+  // Validate initial election results
+  const preAdjudicationElectionResults = getElectionResults(3, 1);
+
+  const contestResults =
+    preAdjudicationElectionResults[GROUP_KEY_ROOT]?.contestResults[
+      'zoo-council-mammal'
+    ];
+
+  expect(
+    contestResults?.contestType === 'candidate' &&
+      contestResults?.tallies[Tabulation.GENERIC_WRITE_IN_ID]?.tally
+  ).toEqual(3);
+
+  // Remove overvotes, which should remove both pending write-ins
+  const finalResults = removeOvervoteWriteInsFromElectionResults({
+    electionId,
+    store,
+    groupedElectionResults: preAdjudicationElectionResults,
+  });
+
+  const finalContestResults =
+    finalResults[GROUP_KEY_ROOT]?.contestResults['zoo-council-mammal'];
+
+  expect(
+    finalContestResults?.contestType === 'candidate' &&
+      finalContestResults?.tallies[Tabulation.GENERIC_WRITE_IN_ID]?.tally
+  ).toEqual(0);
+
+  expect(
+    finalContestResults?.contestType === 'candidate' &&
+      finalContestResults?.tallies['lion']?.tally
+  ).toEqual(1);
+
+  // Adjudicate write-ins, one as valid, one as invalid thus removing the second overvote
+
+  const writeIns = store.getWriteInRecords({
+    electionId,
+    contestId: 'zoo-council-mammal',
+  });
+
+  const [writeIn1, writeIn2, writeIn3] = writeIns;
+  const writeInCandidate = store.addWriteInCandidate({
+    electionId,
+    contestId,
+    name: 'Mr. Pickles',
+  });
+  await adjudicateWriteIn(
+    {
+      writeInId: writeIn1!.id,
+      type: 'write-in-candidate',
+      candidateId: writeInCandidate.id,
+    },
+    store,
+    logger
+  );
+  await adjudicateWriteIn(
+    {
+      writeInId: writeIn2!.id,
+      type: 'invalid',
+    },
+    store,
+    logger
+  );
+  await adjudicateWriteIn(
+    {
+      writeInId: writeIn3!.id,
+      type: 'write-in-candidate',
+      candidateId: writeInCandidate.id,
+    },
+    store,
+    logger
+  );
+
+  // Validate post adjudicated election results, now starting with 2 vote for the write-in,
+  // since the third was marked invalid
+
+  const postAdjudicationElectionResults = getElectionResults(
+    2,
+    1,
+    writeInCandidate.id
+  );
+
+  const finalPostAdjudicationResults =
+    removeOvervoteWriteInsFromElectionResults({
+      electionId,
+      store,
+      groupedElectionResults: postAdjudicationElectionResults,
+    });
+
+  const finalPostAdjudicationContestResults =
+    finalPostAdjudicationResults[GROUP_KEY_ROOT]?.contestResults[
+      'zoo-council-mammal'
+    ];
+
+  expect(
+    finalPostAdjudicationContestResults?.contestType === 'candidate' &&
+      finalPostAdjudicationContestResults?.tallies[writeInCandidate.id]?.tally
+  ).toEqual(0);
+
+  expect(
+    finalPostAdjudicationContestResults?.contestType === 'candidate' &&
+      finalPostAdjudicationContestResults?.tallies['lion']?.tally
+  ).toEqual(1);
 });

--- a/apps/admin/backend/src/tabulation/write_ins.ts
+++ b/apps/admin/backend/src/tabulation/write_ins.ts
@@ -416,11 +416,9 @@ export function getOverallElectionWriteInSummary({
 
 /**
  * Fixes a bug in {@link tabulateWriteInTallies} that results in write-ins being
- * added to tallies even when part of an overvote. Because we aggregate write-ins
- * across CVRs via {@link Store.getWriteInTallies}, we don't know if a write-in is
- * part of an overvote when we include the write-ins in the final results. This
- * function goes through each write-in, and removes a tally from the candidate if
- * the CVR has an overvote for the contest.
+ * added to tallies even when part of an overvote.
+ *
+ * See https://github.com/votingworks/vxsuite/issues/5656
  */
 export function filterOvervoteWriteInsFromElectionResults({
   electionId,

--- a/apps/admin/backend/src/tabulation/write_ins.ts
+++ b/apps/admin/backend/src/tabulation/write_ins.ts
@@ -434,12 +434,17 @@ export function removeOvervoteWriteInsFromElectionResults({
 }): Tabulation.ElectionResultsGroupMap {
   const writeIns = store.getWriteInRecords({ electionId });
   for (const writeIn of writeIns) {
-    const { contestId } = writeIn;
-    const cvr = store.getCastVoteRecord({ electionId, cvrId: writeIn.cvrId });
+    const { contestId, cvrId } = writeIn;
+    const cvr = store.getCastVoteRecord({ electionId, cvrId });
     const cvrContestVotes = assertDefined(cvr.votes[contestId]);
     const groupKey = !groupBy ? GROUP_KEY_ROOT : getGroupKey(cvr, groupBy);
+    const groupElectionResults = groupedElectionResults[groupKey];
+    // If there is no existing group, these election results are filtered to not include this write-in
+    if (!groupElectionResults) {
+      continue;
+    }
     const contestResult = assertDefined(
-      groupedElectionResults[groupKey]?.contestResults[contestId]
+      groupElectionResults.contestResults[contestId]
     );
 
     // Write-ins are only for candidate contests


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/5656

This bug fix is intended to be included in 4.0.x, so instead of fixing the underlying data structures to filter out overvote write-ins before tallies are made, this PR simply removes the extra tallies after the fact. It is less efficient, but should make the code change easier to review in cert. For 4.1, we may fix the underlying tabulation error so overvote write-ins are never tabulated, but that would be during a larger scale refactor with the adjudication revamp.

The cause of the bug is that when tabulating votes, we first tabulate votes from CVRs, and next we go through all write-ins and create a tally summary for them, ignoring write-ins that were marked as invalid, but including all other write-ins, including those that may have been in an overvote, and this [ElectionWriteInSummary](https://github.com/votingworks/vxsuite/blob/main/apps/admin/backend/src/tabulation/write_ins.ts#L162) has no information about which CVRs the write-ins came from. The [SQL query ](https://github.com/votingworks/vxsuite/blob/main/apps/admin/backend/src/store.ts#L1942-L1947)that we use to get the writeIns aggregates them, hence why the CVR info is lost. We then add these tallies to the original tabulation. So, the fix reviews the write-ins records, looks at the original CVR, and decrements a tally if the write-in was part of an overvote.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/e9c31f2a-487f-46fc-8ea4-c69416ed2a85

## Testing Plan

Tested with:
1. Vote-for-one overvote, pre and post adjudication
2. Vote-for-many overvote, pre and post adjudication
3. Existing candidate write-in overvote, pre and post adjudication
4. Grouped tally reports
5. Unmarked write-in contributing to overvote

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
