### PR TITLE
feat(test-utils): add `disposable` helpers

### DIFF
--- a/libs/test-utils/src/disposable.test.ts
+++ b/libs/test-utils/src/disposable.test.ts
@@ -1,0 +1,81 @@
+/* eslint-disable no-lone-blocks */
+import { expect, test } from 'vitest';
+import { asyncDisposable, disposable } from './disposable';
+
+test('disposable', () => {
+  let disposed = false;
+
+  {
+    using resource = disposable({}, () => {
+      disposed = true;
+    });
+
+    expect(Symbol.dispose in resource).toEqual(true);
+    expect(Symbol.asyncDispose in resource).toEqual(false);
+    expect(resource[Symbol.dispose]).toBeInstanceOf(Function);
+    expect(
+      (resource as { [Symbol.asyncDispose]?: unknown })[Symbol.asyncDispose]
+    ).toBeUndefined();
+    expect(disposed).toEqual(false);
+  }
+
+  expect(disposed).toEqual(true);
+});
+
+test('disposable runs even if an exception is thrown', () => {
+  let disposed = false;
+
+  try {
+    using resource = disposable({}, () => {
+      disposed = true;
+    });
+
+    throw new Error(resource.toString());
+  } catch (e) {
+    // ignore
+  }
+
+  expect(disposed).toEqual(true);
+});
+
+test('asyncDisposable', async () => {
+  let disposed = false;
+
+  {
+    await using resource = asyncDisposable(
+      await Promise.resolve({}),
+      async () => {
+        disposed = await Promise.resolve(true);
+      }
+    );
+
+    expect(Symbol.asyncDispose in resource).toEqual(true);
+    expect(resource[Symbol.asyncDispose]).toBeInstanceOf(Function);
+    expect(Symbol.dispose in resource).toEqual(false);
+    expect(
+      (resource as { [Symbol.dispose]?: unknown })[Symbol.dispose]
+    ).toBeUndefined();
+    expect(disposed).toEqual(false);
+  }
+
+  expect(disposed).toEqual(true);
+});
+
+test('asyncDisposable runs even if an exception is thrown', async () => {
+  let disposed = false;
+
+  try {
+    await using resource = asyncDisposable(
+      await Promise.resolve({}),
+      async () => {
+        disposed = await Promise.resolve(true);
+      }
+    );
+
+    throw new Error(resource.toString());
+  } catch (e) {
+    // ignore
+  }
+
+  expect(disposed).toEqual(true);
+});

--- a/libs/test-utils/src/disposable.ts
+++ b/libs/test-utils/src/disposable.ts
@@ -1,0 +1,64 @@
+/**
+ * Wraps a value and provides a method to dispose of it. Useful for cleaning up
+ * resources, especially in tests.
+ *
+ * @example
+ *
+ * ```ts
+ * test('example', () => {
+ *   using resource = disposable(createResource(), (r) => r.close());
+ *  // Use `resource` here.
+ * });
+ */
+export function disposable<T extends object>(
+  value: T,
+  dispose: (value: T) => void
+): T & Disposable {
+  return new Proxy(value, {
+    get(target, p, receiver) {
+      if (p === Symbol.dispose) {
+        return () => {
+          dispose(value);
+        };
+      }
+      return Reflect.get(target, p, receiver);
+    },
+
+    has(target, p) {
+      return p === Symbol.dispose || Reflect.has(target, p);
+    },
+  }) as T & Disposable;
+}
+
+/**
+ * Wraps a value and provides a method to dispose of it asynchronously. Useful
+ * for cleaning up resources, especially in tests.
+ *
+ * @example
+ *
+ * ```ts
+ * test('example', async () => {
+ *   await using resource = asyncDisposable(createResource(), (r) => r.close());
+ *   // Use `resource` here.
+ * });
+ * ```
+ */
+export function asyncDisposable<T extends object>(
+  value: T,
+  dispose: (value: T) => Promise<void>
+): T & AsyncDisposable {
+  return new Proxy(value, {
+    get(target, p, receiver) {
+      if (p === Symbol.asyncDispose) {
+        return async () => {
+          await dispose(value);
+        };
+      }
+      return Reflect.get(target, p, receiver);
+    },
+
+    has(target, p) {
+      return p === Symbol.asyncDispose || Reflect.has(target, p);
+    },
+  }) as T & AsyncDisposable;
+}

--- a/libs/test-utils/src/index.ts
+++ b/libs/test-utils/src/index.ts
@@ -5,6 +5,7 @@ export * from './backend_wait_for';
 export * from './child_process';
 export * from './compressed_tallies';
 export * from './console';
+export * from './disposable';
 export * from './mock_kiosk';
 export * from './mock_use_audio_controls';
 export * from './has_text_across_elements';


### PR DESCRIPTION
## Overview
Adds `disposable` and `asyncDisposable` for wrapping resources that have explicit cleanup functions that do not run automatically.  Uses a new feature of JavaScript: the `using` and `await using` declaration kinds.

Most resources in the NodeJS ecosystem don't support this feature yet, so this is a way of adding it specifically for use in tests where we might otherwise fail to clean up a resource because of an expectation failure.

## Demo Video or Screenshot
```ts
test('example', () => {
  using resource = disposable(createResource(), (r) => r.close());
 // Use `resource` here.
});
```

## Testing Plan
Added tests for this feature, and am using it on the branch that originally inspired these helpers.