### PR TITLE
VxDesign: Button to finalize ballots

### DIFF
--- a/apps/design/backend/schema.sql
+++ b/apps/design/backend/schema.sql
@@ -16,7 +16,8 @@ create table elections (
   created_at timestamp not null default current_timestamp,
   election_package_task_id text
     constraint fk_background_tasks references background_tasks(id) on delete set null,
-  election_package_url text
+  election_package_url text,
+  ballots_finalized_at timestamptz
 );
 
 create table translation_cache (

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -295,6 +295,28 @@ test('Update system settings', async () => {
   });
 });
 
+test('Finalize ballots', async () => {
+  const { apiClient } = await setupApp();
+  const electionId = (
+    await apiClient.loadElection({
+      electionData: electionFamousNames2021Fixtures.electionJson.asText(),
+    })
+  ).unsafeUnwrap();
+
+  expect(await apiClient.getBallotsFinalizedAt({ electionId })).toEqual(null);
+
+  const finalizedAt = new Date();
+  await apiClient.setBallotsFinalizedAt({ electionId, finalizedAt });
+
+  expect(await apiClient.getBallotsFinalizedAt({ electionId })).toEqual(
+    finalizedAt
+  );
+
+  await apiClient.setBallotsFinalizedAt({ electionId, finalizedAt: null });
+
+  expect(await apiClient.getBallotsFinalizedAt({ electionId })).toEqual(null);
+});
+
 test('Election package management', async () => {
   const baseElectionDefinition =
     electionFamousNames2021Fixtures.readElectionDefinition();

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -177,6 +177,17 @@ function buildApi({ workspace, translator }: AppContext) {
       return store.deleteElection(input.electionId);
     },
 
+    getBallotsFinalizedAt(input: { electionId: Id }): Promise<Date | null> {
+      return store.getBallotsFinalizedAt(input.electionId);
+    },
+
+    setBallotsFinalizedAt(input: {
+      electionId: Id;
+      finalizedAt: Date | null;
+    }): Promise<void> {
+      return store.setBallotsFinalizedAt(input);
+    },
+
     async exportAllBallots(input: {
       electionId: Id;
       electionSerializationFormat: ElectionSerializationFormat;

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -360,6 +360,42 @@ export class Store {
     );
   }
 
+  async getBallotsFinalizedAt(electionId: Id): Promise<Date | null> {
+    const { ballots_finalized_at: ballotsFinalizedAt } = (
+      await this.db.withClient((client) =>
+        client.query(
+          `
+          select ballots_finalized_at
+          from elections
+          where id = $1
+        `,
+          electionId
+        )
+      )
+    ).rows[0];
+    return ballotsFinalizedAt;
+  }
+
+  async setBallotsFinalizedAt({
+    electionId,
+    finalizedAt,
+  }: {
+    electionId: Id;
+    finalizedAt: Date | null;
+  }): Promise<void> {
+    await this.db.withClient((client) =>
+      client.query(
+        `
+          update elections
+          set ballots_finalized_at = $1
+          where id = $2
+        `,
+        finalizedAt ? finalizedAt.toISOString() : null,
+        electionId
+      )
+    );
+  }
+
   //
   // Language and audio management
   //

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -150,6 +150,32 @@ export const deleteElection = {
   },
 } as const;
 
+export const getBallotsFinalizedAt = {
+  queryKey(electionId: Id): QueryKey {
+    return ['getBallotsFinalizedAt', electionId];
+  },
+  useQuery(electionId: Id) {
+    const apiClient = useApiClient();
+    return useQuery(this.queryKey(electionId), () =>
+      apiClient.getBallotsFinalizedAt({ electionId })
+    );
+  },
+} as const;
+
+export const setBallotsFinalizedAt = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.setBallotsFinalizedAt, {
+      async onSuccess(_, { electionId }) {
+        await queryClient.invalidateQueries(
+          getBallotsFinalizedAt.queryKey(electionId)
+        );
+      },
+    });
+  },
+} as const;
+
 export const exportAllBallots = {
   useMutation() {
     const apiClient = useApiClient();


### PR DESCRIPTION
## Overview

Task: #5793 

First step towards a ballot proofing flow. Adds a button to "finalize ballots" to the Ballots screen. Currently, there's no way to undo finalizing ballots, but eventually we can build this into our internal tools. Also, finalizing ballots should lock the rest of the election to prevent further edits, but that is punted for now as well.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/f9cf7c11-f8bd-4010-ae52-a590941dfe4b



## Testing Plan
Added new automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
