### PR TITLE
VxDesign: Add screen for ballot order info

### DIFF
--- a/apps/design/backend/schema.sql
+++ b/apps/design/backend/schema.sql
@@ -12,6 +12,7 @@ create table elections (
   id text primary key,
   election_data text not null,
   system_settings_data text not null,
+  ballot_order_info_data text not null,
   precinct_data text not null,
   created_at timestamp not null default current_timestamp,
   election_package_task_id text

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -59,7 +59,12 @@ import {
   testSetupHelpers,
 } from '../test/helpers';
 import { FULL_TEST_DECK_TALLY_REPORT_FILE_NAME } from './test_decks';
-import { BallotStyle, Precinct, convertToVxfBallotStyle } from './types';
+import {
+  BallotOrderInfo,
+  BallotStyle,
+  Precinct,
+  convertToVxfBallotStyle,
+} from './types';
 import { generateBallotStyles } from './ballot_styles';
 import { ElectionRecord } from '.';
 import { getTempBallotLanguageConfigsForCert } from './store';
@@ -145,6 +150,7 @@ test('CRUD elections', async () => {
       ballotStrings: {},
     },
     systemSettings: DEFAULT_SYSTEM_SETTINGS,
+    ballotOrderInfo: {},
     ballotStyles: [],
     precincts: [],
     createdAt: expect.any(String),
@@ -185,6 +191,7 @@ test('CRUD elections', async () => {
       gridLayouts: undefined, // Grid layouts should be stripped out
     },
     systemSettings: DEFAULT_SYSTEM_SETTINGS,
+    ballotOrderInfo: {},
     // TODO test that ballot styles/precincts are correct
     ballotStyles: expectedBallotStyles,
     precincts: expectedPrecincts,
@@ -292,6 +299,33 @@ test('Update system settings', async () => {
   expect(await apiClient.getElection({ electionId })).toEqual({
     ...electionRecord,
     systemSettings: updatedSystemSettings,
+  });
+});
+
+test('Update ballot order info', async () => {
+  const { apiClient } = await setupApp();
+  const electionId = 'election-1' as ElectionId;
+  (await apiClient.createElection({ id: electionId })).unsafeUnwrap();
+
+  const electionRecord = await apiClient.getElection({ electionId });
+  expect(electionRecord.ballotOrderInfo).toEqual({});
+
+  const updateBallotOrderInfo: BallotOrderInfo = {
+    absenteeBallotCount: '100',
+    deliveryAddress: '123 Main St, Town, NH, 00000',
+    deliveryRecipientName: 'Clerky Clerkson',
+    precinctBallotColor: 'Yellow for town, white for school',
+    precinctBallotCount: '200',
+    shouldAbsenteeBallotsBeScoredForFolding: true,
+  };
+  await apiClient.updateBallotOrderInfo({
+    electionId,
+    ballotOrderInfo: updateBallotOrderInfo,
+  });
+
+  expect(await apiClient.getElection({ electionId })).toEqual({
+    ...electionRecord,
+    ballotOrderInfo: updateBallotOrderInfo,
   });
 });
 

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -34,7 +34,7 @@ import {
 } from '@votingworks/hmpb';
 import { translateBallotStrings } from '@votingworks/backend';
 import { ElectionPackage, ElectionRecord } from './store';
-import { Precinct } from './types';
+import { BallotOrderInfo, Precinct } from './types';
 import {
   createPrecinctTestDeck,
   FULL_TEST_DECK_TALLY_REPORT_FILE_NAME,
@@ -164,6 +164,16 @@ function buildApi({ workspace, translator }: AppContext) {
       systemSettings: SystemSettings;
     }): Promise<void> {
       return store.updateSystemSettings(input.electionId, input.systemSettings);
+    },
+
+    updateBallotOrderInfo(input: {
+      electionId: Id;
+      ballotOrderInfo: BallotOrderInfo;
+    }): Promise<void> {
+      return store.updateBallotOrderInfo(
+        input.electionId,
+        input.ballotOrderInfo
+      );
     },
 
     updatePrecincts(input: {

--- a/apps/design/backend/src/index.ts
+++ b/apps/design/backend/src/index.ts
@@ -11,6 +11,7 @@ import { GoogleCloudSpeechSynthesizerWithDbCache } from './speech_synthesizer';
 
 export type { ElectionRecord } from './store';
 export type {
+  BallotOrderInfo,
   BallotStyle,
   Precinct,
   PrecinctSplit,

--- a/apps/design/backend/src/types.ts
+++ b/apps/design/backend/src/types.ts
@@ -1,3 +1,4 @@
+import z from 'zod';
 import {
   BallotStyle as VxfBallotStyle,
   BallotStyleId,
@@ -63,3 +64,26 @@ export function convertToVxfBallotStyle(
     languages: ballotStyle.languages,
   };
 }
+
+/**
+ * Ballot order info, currently fairly specific to New Hampshire. Every field is a string to allow
+ * for freeform data entry and custom notes, and every field is optional as we want to avoid having
+ * to run a migration if these fields change.
+ */
+export interface BallotOrderInfo {
+  absenteeBallotCount?: string;
+  deliveryAddress?: string;
+  deliveryRecipientName?: string;
+  precinctBallotColor?: string;
+  precinctBallotCount?: string;
+  shouldAbsenteeBallotsBeScoredForFolding?: boolean;
+}
+
+export const BallotOrderInfoSchema: z.ZodType<BallotOrderInfo> = z.object({
+  absenteeBallotCount: z.string().optional(),
+  deliveryAddress: z.string().optional(),
+  deliveryRecipientName: z.string().optional(),
+  precinctBallotColor: z.string().optional(),
+  precinctBallotCount: z.string().optional(),
+  shouldAbsenteeBallotsBeScoredForFolding: z.boolean().optional(),
+});

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -121,6 +121,18 @@ export const updateSystemSettings = {
   },
 } as const;
 
+export const updateBallotOrderInfo = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.updateBallotOrderInfo, {
+      async onSuccess(_, { electionId }) {
+        await queryClient.invalidateQueries(getElection.queryKey(electionId));
+      },
+    });
+  },
+} as const;
+
 export const updatePrecincts = {
   useMutation() {
     const apiClient = useApiClient();

--- a/apps/design/frontend/src/app.tsx
+++ b/apps/design/frontend/src/app.tsx
@@ -20,6 +20,7 @@ import { ElectionInfoScreen } from './election_info_screen';
 import { GeographyScreen } from './geography_screen';
 import { ContestsScreen } from './contests_screen';
 import { BallotsScreen } from './ballots_screen';
+import { BallotOrderInfoScreen } from './ballot_order_info_screen';
 import { TabulationScreen } from './tabulation_screen';
 import { ExportScreen } from './export_screen';
 import { ErrorScreen } from './error_screen';
@@ -46,6 +47,10 @@ function ElectionScreens(): JSX.Element {
         <Route
           path={electionParamRoutes.ballots.root.path}
           component={BallotsScreen}
+        />
+        <Route
+          path={electionParamRoutes.ballotOrderInfo.path}
+          component={BallotOrderInfoScreen}
         />
         <Route
           path={electionParamRoutes.tabulation.path}

--- a/apps/design/frontend/src/ballot_order_info_screen.test.tsx
+++ b/apps/design/frontend/src/ballot_order_info_screen.test.tsx
@@ -1,15 +1,16 @@
 import userEvent from '@testing-library/user-event';
 import type { BallotOrderInfo } from '@votingworks/design-backend';
-import { render, screen } from '../test/react_testing_library';
+
 import {
-  MockApiClient,
   createMockApiClient,
+  MockApiClient,
   provideApi,
 } from '../test/api_helpers';
-import { withRoute } from '../test/routing_helpers';
-import { routes } from './routes';
 import { generalElectionRecord } from '../test/fixtures';
+import { render, screen } from '../test/react_testing_library';
+import { withRoute } from '../test/routing_helpers';
 import { BallotOrderInfoScreen } from './ballot_order_info_screen';
+import { routes } from './routes';
 
 const electionRecord = generalElectionRecord;
 const electionId = electionRecord.election.id;

--- a/apps/design/frontend/src/ballot_order_info_screen.test.tsx
+++ b/apps/design/frontend/src/ballot_order_info_screen.test.tsx
@@ -1,0 +1,173 @@
+import userEvent from '@testing-library/user-event';
+import type { BallotOrderInfo } from '@votingworks/design-backend';
+import { render, screen } from '../test/react_testing_library';
+import {
+  MockApiClient,
+  createMockApiClient,
+  provideApi,
+} from '../test/api_helpers';
+import { withRoute } from '../test/routing_helpers';
+import { routes } from './routes';
+import { generalElectionRecord } from '../test/fixtures';
+import { BallotOrderInfoScreen } from './ballot_order_info_screen';
+
+const electionRecord = generalElectionRecord;
+const electionId = electionRecord.election.id;
+
+let apiMock: MockApiClient;
+
+beforeEach(() => {
+  apiMock = createMockApiClient();
+});
+
+afterEach(() => {
+  apiMock.assertComplete();
+});
+
+function renderScreen() {
+  render(
+    provideApi(
+      apiMock,
+      withRoute(<BallotOrderInfoScreen />, {
+        paramPath: routes.election(':electionId').tabulation.path,
+        path: routes.election(electionId).tabulation.path,
+      }),
+      electionId
+    )
+  );
+}
+
+test('updating ballot order info', async () => {
+  apiMock.getElection.expectCallWith({ electionId }).resolves(electionRecord);
+  renderScreen();
+  await screen.findByRole('heading', { name: 'Ballot Order Info' });
+
+  const absenteeBallotCountInput = screen.getByLabelText(
+    'Number of Absentee Ballots'
+  );
+  expect(absenteeBallotCountInput).toBeDisabled();
+  expect(absenteeBallotCountInput).toHaveValue('');
+
+  const shouldAbsenteeBallotsBeScoredForFolding = screen.getByRole('checkbox', {
+    name: 'Score Absentee Ballots for Folding',
+  });
+  expect(shouldAbsenteeBallotsBeScoredForFolding).toBeDisabled();
+  expect(shouldAbsenteeBallotsBeScoredForFolding).not.toBeChecked();
+
+  const precinctBallotCountInput = screen.getByLabelText(
+    'Number of Polling Place Ballots'
+  );
+  expect(precinctBallotCountInput).toBeDisabled();
+  expect(precinctBallotCountInput).toHaveValue('');
+
+  const precinctBallotColorInput = screen.getByLabelText(
+    'Paper Color for Polling Place Ballots'
+  );
+  expect(precinctBallotColorInput).toBeDisabled();
+  expect(precinctBallotColorInput).toHaveValue('');
+
+  const deliveryRecipientNameInput = screen.getByLabelText(
+    'Delivery Recipient Name'
+  );
+  expect(deliveryRecipientNameInput).toBeDisabled();
+  expect(deliveryRecipientNameInput).toHaveValue('');
+
+  const deliveryAddressInput = screen.getByLabelText(
+    'Delivery Address, City, State, and ZIP'
+  );
+  expect(deliveryAddressInput).toBeDisabled();
+  expect(deliveryAddressInput).toHaveValue('');
+
+  // Populate ballot order info
+
+  userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+  userEvent.type(absenteeBallotCountInput, '100');
+  userEvent.click(shouldAbsenteeBallotsBeScoredForFolding);
+  userEvent.type(precinctBallotCountInput, '200');
+  userEvent.type(precinctBallotColorInput, 'Yellow for town, white for school');
+  userEvent.type(deliveryRecipientNameInput, 'Clerky Clerkson');
+  userEvent.type(deliveryAddressInput, '123 Main St, Town, NH, 00000');
+
+  let expectedBallotOrderInfo: BallotOrderInfo = {
+    absenteeBallotCount: '100',
+    shouldAbsenteeBallotsBeScoredForFolding: true,
+    precinctBallotCount: '200',
+    precinctBallotColor: 'Yellow for town, white for school',
+    deliveryRecipientName: 'Clerky Clerkson',
+    deliveryAddress: '123 Main St, Town, NH, 00000',
+  };
+  apiMock.updateBallotOrderInfo
+    .expectCallWith({ electionId, ballotOrderInfo: expectedBallotOrderInfo })
+    .resolves();
+  apiMock.getElection.expectCallWith({ electionId }).resolves({
+    ...electionRecord,
+    ballotOrderInfo: expectedBallotOrderInfo,
+  });
+
+  userEvent.click(screen.getByRole('button', { name: 'Save' }));
+  await screen.findByRole('button', { name: 'Edit' });
+
+  expect(absenteeBallotCountInput).toHaveValue('100');
+  expect(shouldAbsenteeBallotsBeScoredForFolding).toBeChecked();
+  expect(precinctBallotCountInput).toHaveValue('200');
+  expect(precinctBallotColorInput).toHaveValue(
+    'Yellow for town, white for school'
+  );
+  expect(deliveryRecipientNameInput).toHaveValue('Clerky Clerkson');
+  expect(deliveryAddressInput).toHaveValue('123 Main St, Town, NH, 00000');
+
+  // Clear ballot order info
+
+  userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+  userEvent.clear(absenteeBallotCountInput);
+  userEvent.click(shouldAbsenteeBallotsBeScoredForFolding);
+  userEvent.clear(precinctBallotCountInput);
+  userEvent.clear(precinctBallotColorInput);
+  userEvent.clear(deliveryRecipientNameInput);
+  userEvent.clear(deliveryAddressInput);
+
+  expectedBallotOrderInfo = {
+    absenteeBallotCount: '',
+    shouldAbsenteeBallotsBeScoredForFolding: false,
+    precinctBallotCount: '',
+    precinctBallotColor: '',
+    deliveryRecipientName: '',
+    deliveryAddress: '',
+  };
+  apiMock.updateBallotOrderInfo
+    .expectCallWith({ electionId, ballotOrderInfo: expectedBallotOrderInfo })
+    .resolves();
+  apiMock.getElection.expectCallWith({ electionId }).resolves({
+    ...electionRecord,
+    ballotOrderInfo: expectedBallotOrderInfo,
+  });
+
+  userEvent.click(screen.getByRole('button', { name: 'Save' }));
+  await screen.findByRole('button', { name: 'Edit' });
+
+  expect(absenteeBallotCountInput).toHaveValue('');
+  expect(shouldAbsenteeBallotsBeScoredForFolding).not.toBeChecked();
+  expect(precinctBallotCountInput).toHaveValue('');
+  expect(precinctBallotColorInput).toHaveValue('');
+  expect(deliveryRecipientNameInput).toHaveValue('');
+  expect(deliveryAddressInput).toHaveValue('');
+
+  // Begin repopulating ballot order info but cancel
+
+  userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+  userEvent.type(absenteeBallotCountInput, 'A');
+  userEvent.click(shouldAbsenteeBallotsBeScoredForFolding);
+  userEvent.type(precinctBallotCountInput, 'B');
+  userEvent.type(precinctBallotColorInput, 'C');
+  userEvent.type(deliveryRecipientNameInput, 'D');
+  userEvent.type(deliveryAddressInput, 'E');
+
+  userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+  expect(absenteeBallotCountInput).toHaveValue('');
+  expect(shouldAbsenteeBallotsBeScoredForFolding).not.toBeChecked();
+  expect(precinctBallotCountInput).toHaveValue('');
+  expect(precinctBallotColorInput).toHaveValue('');
+  expect(deliveryRecipientNameInput).toHaveValue('');
+  expect(deliveryAddressInput).toHaveValue('');
+});

--- a/apps/design/frontend/src/ballot_order_info_screen.tsx
+++ b/apps/design/frontend/src/ballot_order_info_screen.tsx
@@ -1,18 +1,20 @@
 import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import styled from 'styled-components';
+import { Id } from '@votingworks/types';
 import {
-  H1,
   Button,
+  CheckboxButton,
+  H1,
+  Icons,
   MainContent,
   MainHeader,
-  CheckboxButton,
 } from '@votingworks/ui';
-import { useParams } from 'react-router-dom';
-import { Id } from '@votingworks/types';
 import type { BallotOrderInfo } from '@votingworks/design-backend';
-import styled from 'styled-components';
+
+import { getElection, updateBallotOrderInfo } from './api';
 import { Form, FormActionsRow, InputGroup } from './layout';
 import { ElectionNavScreen } from './nav_screen';
-import { getElection, updateBallotOrderInfo } from './api';
 
 export const Annotation = styled.div`
   margin-top: -1rem;
@@ -55,6 +57,9 @@ function BallotOrderInfoForm({
           disabled={!isEditing}
         />
       </InputGroup>
+      <Annotation>
+        <Icons.Info /> This count should include ballots needed for testing.
+      </Annotation>
       <div>
         <CheckboxButton
           label="Score Absentee Ballots for Folding"
@@ -83,6 +88,9 @@ function BallotOrderInfoForm({
           disabled={!isEditing}
         />
       </InputGroup>
+      <Annotation>
+        <Icons.Info /> This count should include ballots needed for testing.
+      </Annotation>
       <InputGroup label="Paper Color for Polling Place Ballots">
         <input
           type="text"
@@ -97,8 +105,8 @@ function BallotOrderInfoForm({
         />
       </InputGroup>
       <Annotation>
-        Specify if for town or school ballots. If not specified, we’ll print on
-        white.
+        <Icons.Info /> Specify if for town or school ballots. If not specified,
+        we’ll print on white.
       </Annotation>
       <InputGroup label="Delivery Recipient Name">
         <input

--- a/apps/design/frontend/src/ballot_order_info_screen.tsx
+++ b/apps/design/frontend/src/ballot_order_info_screen.tsx
@@ -1,0 +1,187 @@
+import { useState } from 'react';
+import {
+  H1,
+  Button,
+  MainContent,
+  MainHeader,
+  CheckboxButton,
+} from '@votingworks/ui';
+import { useParams } from 'react-router-dom';
+import { Id } from '@votingworks/types';
+import type { BallotOrderInfo } from '@votingworks/design-backend';
+import styled from 'styled-components';
+import { Form, FormActionsRow, InputGroup } from './layout';
+import { ElectionNavScreen } from './nav_screen';
+import { getElection, updateBallotOrderInfo } from './api';
+
+export const Annotation = styled.div`
+  margin-top: -1rem;
+`;
+
+function BallotOrderInfoForm({
+  electionId,
+  savedBallotOrderInfo,
+}: {
+  electionId: Id;
+  savedBallotOrderInfo: BallotOrderInfo;
+}): JSX.Element {
+  const [isEditing, setIsEditing] = useState(false);
+  const [ballotOrderInfo, setBallotOrderInfo] =
+    useState<BallotOrderInfo>(savedBallotOrderInfo);
+  const updateBallotOrderInfoMutation = updateBallotOrderInfo.useMutation();
+
+  function onSaveButtonPress() {
+    updateBallotOrderInfoMutation.mutate(
+      {
+        electionId,
+        ballotOrderInfo: { ...savedBallotOrderInfo, ...ballotOrderInfo },
+      },
+      { onSuccess: () => setIsEditing(false) }
+    );
+  }
+
+  return (
+    <Form>
+      <InputGroup label="Number of Absentee Ballots">
+        <input
+          type="text"
+          value={ballotOrderInfo.absenteeBallotCount ?? ''}
+          onChange={(e) =>
+            setBallotOrderInfo({
+              ...ballotOrderInfo,
+              absenteeBallotCount: e.target.value,
+            })
+          }
+          disabled={!isEditing}
+        />
+      </InputGroup>
+      <div>
+        <CheckboxButton
+          label="Score Absentee Ballots for Folding"
+          isChecked={Boolean(
+            ballotOrderInfo.shouldAbsenteeBallotsBeScoredForFolding
+          )}
+          onChange={(isChecked) =>
+            setBallotOrderInfo({
+              ...ballotOrderInfo,
+              shouldAbsenteeBallotsBeScoredForFolding: isChecked,
+            })
+          }
+          disabled={!isEditing}
+        />
+      </div>
+      <InputGroup label="Number of Polling Place Ballots">
+        <input
+          type="text"
+          value={ballotOrderInfo.precinctBallotCount ?? ''}
+          onChange={(e) =>
+            setBallotOrderInfo({
+              ...ballotOrderInfo,
+              precinctBallotCount: e.target.value,
+            })
+          }
+          disabled={!isEditing}
+        />
+      </InputGroup>
+      <InputGroup label="Paper Color for Polling Place Ballots">
+        <input
+          type="text"
+          value={ballotOrderInfo.precinctBallotColor ?? ''}
+          onChange={(e) =>
+            setBallotOrderInfo({
+              ...ballotOrderInfo,
+              precinctBallotColor: e.target.value,
+            })
+          }
+          disabled={!isEditing}
+        />
+      </InputGroup>
+      <Annotation>
+        Specify if for town or school ballots. If not specified, we’ll print on
+        white.
+      </Annotation>
+      <InputGroup label="Delivery Recipient Name">
+        <input
+          type="text"
+          value={ballotOrderInfo.deliveryRecipientName ?? ''}
+          onChange={(e) =>
+            setBallotOrderInfo({
+              ...ballotOrderInfo,
+              deliveryRecipientName: e.target.value,
+            })
+          }
+          disabled={!isEditing}
+        />
+      </InputGroup>
+      <InputGroup label="Delivery Address, City, State, and ZIP">
+        <input
+          type="text"
+          value={ballotOrderInfo.deliveryAddress ?? ''}
+          onChange={(e) =>
+            setBallotOrderInfo({
+              ...ballotOrderInfo,
+              deliveryAddress: e.target.value,
+            })
+          }
+          disabled={!isEditing}
+        />
+      </InputGroup>
+
+      {isEditing ? (
+        <FormActionsRow>
+          <Button
+            onPress={() => {
+              setBallotOrderInfo(savedBallotOrderInfo);
+              setIsEditing(false);
+            }}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            icon="Done"
+            onPress={onSaveButtonPress}
+            disabled={updateBallotOrderInfoMutation.isLoading}
+          >
+            Save
+          </Button>
+        </FormActionsRow>
+      ) : (
+        <FormActionsRow>
+          <Button
+            variant="primary"
+            icon="Edit"
+            onPress={() => setIsEditing(true)}
+          >
+            Edit
+          </Button>
+        </FormActionsRow>
+      )}
+    </Form>
+  );
+}
+
+export function BallotOrderInfoScreen(): JSX.Element | null {
+  const { electionId } = useParams<{ electionId: string }>();
+  const getElectionQuery = getElection.useQuery(electionId);
+
+  if (!getElectionQuery.isSuccess) {
+    return null;
+  }
+
+  const { ballotOrderInfo } = getElectionQuery.data;
+
+  return (
+    <ElectionNavScreen electionId={electionId}>
+      <MainHeader>
+        <H1>Ballot Order Info</H1>
+      </MainHeader>
+      <MainContent>
+        <BallotOrderInfoForm
+          electionId={electionId}
+          savedBallotOrderInfo={ballotOrderInfo}
+        />
+      </MainContent>
+    </ElectionNavScreen>
+  );
+}

--- a/apps/design/frontend/src/routes.ts
+++ b/apps/design/frontend/src/routes.ts
@@ -103,6 +103,10 @@ export const routes = {
           path: `${root}/ballots/${ballotStyleId}/${precinctId}`,
         }),
       },
+      ballotOrderInfo: {
+        title: 'Ballot Order Info',
+        path: `${root}/ballot-order-info`,
+      },
       tabulation: {
         title: 'Tabulation',
         path: `${root}/tabulation`,
@@ -128,6 +132,7 @@ export function electionNavRoutes(electionId: string): Route[] {
     electionRoutes.geography.root,
     electionRoutes.contests.root,
     electionRoutes.ballots.root,
+    electionRoutes.ballotOrderInfo,
     electionRoutes.tabulation,
     electionRoutes.export,
   ];

--- a/apps/design/frontend/test/fixtures.ts
+++ b/apps/design/frontend/test/fixtures.ts
@@ -42,6 +42,7 @@ export function makeElectionRecord(baseElection: Election): ElectionRecord {
   return {
     election,
     systemSettings: DEFAULT_SYSTEM_SETTINGS,
+    ballotOrderInfo: {},
     precincts,
     ballotStyles,
     createdAt: new Date().toISOString(),


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/5796

As we shift ballot data entry from Google Forms to VxDesign, we need a screen in VxDesign for ballot order info, e.g., number of ballots to print, paper color, delivery address, etc. This PR ports the [Google Form that we used last year](https://docs.google.com/forms/d/e/1FAIpQLScYssKunYzQX5E3zJMBbBS2lysoCiNFkEjLuV9Mu9g1gBGRqQ/viewform) (see page 2) into VxDesign.

Note that all fields, even those for ballot counts, accept freeform text as towns may want to communicate additional details. Again, going for parity with the Google Form from last year.

<img width="1512" alt="01" src="https://github.com/user-attachments/assets/105d0022-7a42-4530-99a5-bb5ca5bbc6a9" />

<img width="1512" alt="02" src="https://github.com/user-attachments/assets/496f39c5-2109-4b69-8d58-7dff5e5f271c" />



## Testing Plan

- [x] Tested manually
- [x] Added automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates