### PR TITLE
V3-compatible NH town ballot template 

### DIFF
--- a/libs/ballot-encoder/src/v3.ts
+++ b/libs/ballot-encoder/src/v3.ts
@@ -21,10 +21,15 @@ import {
   YesNoContest,
   YesNoVote,
 } from '@votingworks/types';
-import { assert, iter } from '@votingworks/basics';
-import { BitReader, BitWriter, CustomEncoding, Uint8, Uint8Size } from './bits';
-
-export * as v3 from './v3';
+import { assert } from '@votingworks/basics';
+import {
+  BitReader,
+  BitWriter,
+  CustomEncoding,
+  toUint8,
+  Uint8,
+  Uint8Size,
+} from './bits';
 
 /**
  * Maximum number of characters in a write-in.
@@ -32,9 +37,9 @@ export * as v3 from './v3';
 export const MAXIMUM_WRITE_IN_LENGTH = 40;
 
 /**
- * Exact length of the ballot hash used in the ballot encoding.
+ * Exact length of the SHA256 hash of the election definition.
  */
-export const BALLOT_HASH_ENCODING_LENGTH = 20;
+export const ELECTION_HASH_LENGTH = 20;
 
 /**
  * Maximum number of pages in a hand-marked paper ballot.
@@ -42,21 +47,11 @@ export const BALLOT_HASH_ENCODING_LENGTH = 20;
 export const MAXIMUM_PAGE_NUMBERS = 30;
 
 /**
- * Maximum number of precincts in an election that we can encode in 12 bits.
- */
-export const MAXIMUM_PRECINCTS = 4096;
-
-/**
- * Maximum number of ballot styles in an election that we can encode in 12 bits.
- */
-export const MAXIMUM_BALLOT_STYLES = 4096;
-
-/**
- * Slices a ballot hash down to the length used in ballot encoding. Useful
+ * Slices an election hash down to the length used in ballot encoding. Useful
  * to have this as a utility function so it can be mocked in other modules' tests.
  */
-export function sliceBallotHashForEncoding(ballotHash: string): string {
-  return ballotHash.slice(0, BALLOT_HASH_ENCODING_LENGTH);
+export function sliceElectionHash(electionHash: string): string {
+  return electionHash.slice(0, ELECTION_HASH_LENGTH);
 }
 
 // TODO: include "magic number" and encoding version
@@ -70,7 +65,7 @@ export const WriteInEncoding = new CustomEncoding(
 );
 
 /**
- * Encoding for hexadecimal string values, e.g. the ballot hash.
+ * Encoding for hexadecimal string values, e.g. the election hash.
  */
 export const HexEncoding = new CustomEncoding('0123456789abcdef');
 
@@ -89,14 +84,21 @@ export const HmpbPrelude: readonly Uint8[] = [
 ];
 
 /**
- * Detect whether `data` is a votingworks encoded ballot / metadata.
+ * Detects whether `data` is a v1-encoded ballot.
  */
-export function isVxBallot(data: Uint8Array): boolean {
+export function detectRawBytesBmdBallot(data: Uint8Array): boolean {
   const prelude = data.slice(0, BmdPrelude.length);
   return (
     prelude.length === BmdPrelude.length &&
     prelude.every((byte, i) => byte === BmdPrelude[i])
   );
+}
+
+/**
+ * Detect whether `data` is a votingworks encoded ballot / metadata.
+ */
+export function isVxBallot(data: Uint8Array): boolean {
+  return detectRawBytesBmdBallot(data);
 }
 
 /**
@@ -126,7 +128,10 @@ export function encodeBallotConfigInto(
   }: BallotConfig,
   bits: BitWriter
 ): BitWriter {
-  const { precincts, ballotStyles } = election;
+  const { precincts, ballotStyles, contests } = election;
+  const precinctCount = toUint8(precincts.length);
+  const ballotStyleCount = toUint8(ballotStyles.length);
+  const contestCount = toUint8(contests.length);
   const precinctIndex = precincts.findIndex((p) => p.id === precinctId);
   const ballotStyleIndex = ballotStyles.findIndex(
     (bs) => bs.id === ballotStyleId
@@ -141,8 +146,9 @@ export function encodeBallotConfigInto(
   }
 
   bits
-    .writeUint(precinctIndex, { max: MAXIMUM_PRECINCTS })
-    .writeUint(ballotStyleIndex, { max: MAXIMUM_BALLOT_STYLES });
+    .writeUint8(precinctCount, ballotStyleCount, contestCount)
+    .writeUint(precinctIndex, { max: precinctCount - 1 })
+    .writeUint(ballotStyleIndex, { max: ballotStyleCount - 1 });
 
   if (pageNumber !== undefined) {
     bits.writeUint(pageNumber, { max: MAXIMUM_PAGE_NUMBERS });
@@ -170,10 +176,31 @@ export function decodeBallotConfigFromReader(
   bits: BitReader,
   { readPageNumber = false }: { readPageNumber?: boolean } = {}
 ): BallotConfig {
-  const { precincts, ballotStyles } = election;
+  const { precincts, ballotStyles, contests } = election;
+  const precinctCount = bits.readUint8();
+  const ballotStyleCount = bits.readUint8();
+  const contestCount = bits.readUint8();
 
-  const precinctIndex = bits.readUint({ max: MAXIMUM_PRECINCTS });
-  const ballotStyleIndex = bits.readUint({ max: MAXIMUM_BALLOT_STYLES });
+  if (precinctCount !== precincts.length) {
+    throw new Error(
+      `expected ${precincts.length} precinct(s), but read ${precinctCount} from encoded config`
+    );
+  }
+
+  if (ballotStyleCount !== ballotStyles.length) {
+    throw new Error(
+      `expected ${ballotStyles.length} ballot style(s), but read ${ballotStyleCount} from encoded config`
+    );
+  }
+
+  const precinctIndex = bits.readUint({ max: precinctCount - 1 });
+  const ballotStyleIndex = bits.readUint({ max: ballotStyleCount - 1 });
+
+  if (contestCount !== contests.length) {
+    throw new Error(
+      `expected ${contests.length} contest(s), but read ${contestCount} from encoded config`
+    );
+  }
 
   const pageNumber = readPageNumber
     ? bits.readUint({ max: MAXIMUM_PAGE_NUMBERS })
@@ -257,9 +284,10 @@ function encodeBallotVotesInto(
 
         if (contest.allowWriteIns) {
           // write write-in data
-          const writeInCount = iter(choices)
-            .filter((choice) => choice.isWriteIn)
-            .count();
+          const writeInCount = choices.reduce(
+            (count, choice) => count + (choice.isWriteIn ? 1 : 0),
+            0
+          );
           const nonWriteInCount = choices.length - writeInCount;
           const maximumWriteIns = Math.max(0, contest.seats - nonWriteInCount);
 
@@ -289,7 +317,7 @@ function encodeBallotVotesInto(
 export function encodeBallotInto(
   election: Election,
   {
-    ballotHash,
+    ballotHash: electionHash,
     ballotStyleId,
     precinctId,
     votes,
@@ -311,10 +339,10 @@ export function encodeBallotInto(
 
   return bits
     .writeUint8(...BmdPrelude)
-    .writeString(sliceBallotHashForEncoding(ballotHash), {
+    .writeString(sliceElectionHash(electionHash), {
       encoding: HexEncoding,
       includeLength: false,
-      length: BALLOT_HASH_ENCODING_LENGTH,
+      length: ELECTION_HASH_LENGTH,
     })
     .with(() =>
       encodeBallotConfigInto(
@@ -439,9 +467,9 @@ export function decodeBallotFromReader(
     );
   }
 
-  const ballotHash = bits.readString({
+  const electionHash = bits.readString({
     encoding: HexEncoding,
-    length: BALLOT_HASH_ENCODING_LENGTH,
+    length: ELECTION_HASH_LENGTH,
   });
 
   const { ballotId, ballotStyleId, ballotType, isTestMode, precinctId } =
@@ -458,7 +486,7 @@ export function decodeBallotFromReader(
   readPaddingToEnd(bits);
 
   return {
-    ballotHash,
+    ballotHash: electionHash,
     ballotId,
     ballotStyleId,
     precinctId,
@@ -479,24 +507,24 @@ export function decodeBallot(
 }
 
 /**
- * Reads the ballot hash from an encoded BMD ballot metadata.
+ * Reads the election hash from an encoded BMD ballot metadata.
  */
-export function decodeBallotHashFromReader(
+export function decodeElectionHashFromReader(
   bits: BitReader
 ): string | undefined {
   if (bits.skipUint8(...BmdPrelude) || bits.skipUint8(...HmpbPrelude)) {
     return bits.readString({
       encoding: HexEncoding,
-      length: BALLOT_HASH_ENCODING_LENGTH,
+      length: ELECTION_HASH_LENGTH,
     });
   }
 }
 
 /**
- * Reads the ballot hash from an encoded ballot metadata.
+ * Reads the election hash from an encoded ballot metadata.
  */
-export function decodeBallotHash(data: Uint8Array): string | undefined {
-  return decodeBallotHashFromReader(new BitReader(data));
+export function decodeElectionHash(data: Uint8Array): string | undefined {
+  return decodeElectionHashFromReader(new BitReader(data));
 }
 
 /**
@@ -508,7 +536,7 @@ export function encodeHmpbBallotPageMetadataInto(
     ballotId,
     ballotStyleId,
     ballotType,
-    ballotHash,
+    ballotHash: electionHash,
     isTestMode,
     pageNumber,
     precinctId,
@@ -517,10 +545,10 @@ export function encodeHmpbBallotPageMetadataInto(
 ): BitWriter {
   return bits
     .writeUint8(...HmpbPrelude)
-    .writeString(sliceBallotHashForEncoding(ballotHash), {
+    .writeString(sliceElectionHash(electionHash), {
       encoding: HexEncoding,
       includeLength: false,
-      length: BALLOT_HASH_ENCODING_LENGTH,
+      length: ELECTION_HASH_LENGTH,
     })
     .with(() =>
       encodeBallotConfigInto(

--- a/libs/ballot-encoder/vitest.config.ts
+++ b/libs/ballot-encoder/vitest.config.ts
@@ -3,5 +3,8 @@ import { defineConfig } from '../../vitest.config.shared.mjs';
 export default defineConfig({
   test: {
     setupFiles: ['test/expect.ts'],
+    coverage: {
+      exclude: ['src/v3.ts'],
+    },
   },
 });

--- a/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
@@ -1,0 +1,797 @@
+import {
+  assertDefined,
+  iter,
+  range,
+  throwIllegalValue,
+} from '@votingworks/basics';
+import { Buffer } from 'node:buffer';
+import {
+  AnyContest,
+  BallotStyleId,
+  BallotType,
+  CandidateContest as CandidateContestStruct,
+  Election,
+  YesNoContest,
+  ballotPaperDimensions,
+  getBallotStyle,
+  getContests,
+  getPartyForBallotStyle,
+} from '@votingworks/types';
+import {
+  BackendLanguageContextProvider,
+  CandidatePartyList,
+  electionStrings,
+  RichText,
+} from '@votingworks/ui';
+import styled from 'styled-components';
+import React from 'react';
+import {
+  BallotPageTemplate,
+  BaseBallotProps,
+  PagedElementResult,
+} from '../render_ballot';
+import { RenderScratchpad } from '../renderer';
+import {
+  Bubble,
+  OptionInfo,
+  Page,
+  TIMING_MARK_DIMENSIONS,
+  TimingMarkGrid,
+  WRITE_IN_OPTION_CLASS,
+  pageMarginsInches,
+  BlankPageMessage,
+  DualLanguageText,
+  Footer,
+  Instructions,
+  primaryLanguageCode,
+} from '../ballot_components';
+import { BallotMode, PixelDimensions } from '../types';
+import { hmpbStrings } from '../hmpb_strings';
+import { layOutInColumns } from '../layout_in_columns';
+import { NhPrecinctSplitOptions } from './nh_ballot_template';
+
+const Colors = {
+  BLACK: '#000000',
+  LIGHT_GRAY: '#EDEDED',
+  DARK_GRAY: '#DADADA',
+  DARKER_GRAY: '#B0B0B0',
+} as const;
+
+const Box = styled.div<{ fill?: 'transparent' | 'tinted' }>`
+  border: 1px solid ${Colors.BLACK};
+  border-top-width: 3px;
+  padding: 0.75rem;
+  background-color: ${(p) =>
+    p.fill === 'tinted' ? Colors.LIGHT_GRAY : 'none'};
+`;
+
+async function snapToGridRow(
+  scratchpad: RenderScratchpad,
+  gridRowHeightInches: number,
+  renderElement: (style: React.CSSProperties) => JSX.Element
+) {
+  const measurements = await scratchpad.measureElements(
+    <div className="wrapper">{renderElement({})}</div>,
+    '.wrapper'
+  );
+  const { height } = measurements[0];
+  const gridRowHeightPx = gridRowHeightInches * 96;
+  const numRows = Math.ceil(height / gridRowHeightPx);
+  const snappedHeight = numRows * gridRowHeightPx;
+  return {
+    element: renderElement({
+      height: `${snappedHeight}px`,
+    }),
+    height: snappedHeight,
+  };
+}
+
+function Header({
+  election,
+  ballotStyleId,
+  ballotType,
+  ballotMode,
+
+  electionTitleOverride,
+  clerkSignatureImage,
+  clerkSignatureCaption,
+}: {
+  election: Election;
+  ballotStyleId: BallotStyleId;
+  ballotType: BallotType;
+  ballotMode: BallotMode;
+} & NhPrecinctSplitOptions) {
+  const ballotTitles: Record<BallotMode, Record<BallotType, JSX.Element>> = {
+    official: {
+      [BallotType.Precinct]: hmpbStrings.hmpbOfficialBallot,
+      [BallotType.Absentee]: hmpbStrings.hmpbOfficialAbsenteeBallot,
+      [BallotType.Provisional]: hmpbStrings.hmpbOfficialProvisionalBallot,
+    },
+    sample: {
+      [BallotType.Precinct]: hmpbStrings.hmpbSampleBallot,
+      [BallotType.Absentee]: hmpbStrings.hmpbSampleAbsenteeBallot,
+      [BallotType.Provisional]: hmpbStrings.hmpbSampleProvisionalBallot,
+    },
+    test: {
+      [BallotType.Precinct]: hmpbStrings.hmpbTestBallot,
+      [BallotType.Absentee]: hmpbStrings.hmpbTestAbsenteeBallot,
+      [BallotType.Provisional]: hmpbStrings.hmpbTestProvisionalBallot,
+    },
+  };
+  const ballotTitle = ballotTitles[ballotMode][ballotType];
+
+  const party =
+    election.type === 'primary'
+      ? assertDefined(getPartyForBallotStyle({ election, ballotStyleId }))
+      : undefined;
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        gap: '0.75rem',
+        alignItems: 'center',
+      }}
+    >
+      <div
+        style={{
+          height: '5rem',
+          aspectRatio: '1 / 1',
+          backgroundImage: `url(data:image/svg+xml;base64,${Buffer.from(
+            election.seal
+          ).toString('base64')})`,
+          backgroundSize: 'contain',
+          backgroundRepeat: 'no-repeat',
+          marginTop: '0.125rem',
+        }}
+      />
+      <div style={{ flexGrow: 2 }}>
+        <DualLanguageText>
+          <div>
+            <h1>{ballotTitle}</h1>
+            {party && <h1>{electionStrings.partyFullName(party)}</h1>}
+            <h2>
+              {electionTitleOverride ?? electionStrings.electionTitle(election)}
+            </h2>
+            <h2>{electionStrings.electionDate(election)}</h2>
+            <div>
+              {/* TODO comma-delimiting the components of a location doesn't
+            necessarily work in all languages. We need to figure out a
+            language-aware way to denote hierarchical locations. */}
+              {electionStrings.countyName(election.county)},{' '}
+              {electionStrings.stateName(election)}
+            </div>
+          </div>
+        </DualLanguageText>
+      </div>
+      <div style={{ flexGrow: 1 }}>
+        {clerkSignatureImage && (
+          <div
+            style={{
+              height: '3rem',
+              backgroundImage: `url(data:image/svg+xml;base64,${Buffer.from(
+                clerkSignatureImage
+              ).toString('base64')})`,
+              backgroundSize: 'contain',
+              backgroundRepeat: 'no-repeat',
+              marginTop: '0.125rem',
+            }}
+          />
+        )}
+        {clerkSignatureCaption && <div>{clerkSignatureCaption}</div>}
+      </div>
+    </div>
+  );
+}
+
+// Almost identical to vx_default_ballot_template BallotPageFrame except additional props are passed to Header.
+function BallotPageFrame({
+  election,
+  ballotStyleId,
+  precinctId,
+  ballotType,
+  ballotMode,
+  pageNumber,
+  totalPages,
+  children,
+  electionTitleOverride,
+  clerkSignatureImage,
+  clerkSignatureCaption,
+}: BaseBallotProps &
+  NhPrecinctSplitOptions & {
+    pageNumber: number;
+    totalPages: number;
+    children: JSX.Element;
+  }): JSX.Element {
+  const pageDimensions = ballotPaperDimensions(election.ballotLayout.paperSize);
+  const ballotStyle = assertDefined(
+    getBallotStyle({ election, ballotStyleId })
+  );
+  const languageCode = primaryLanguageCode(ballotStyle);
+  return (
+    <BackendLanguageContextProvider
+      key={pageNumber}
+      currentLanguageCode={primaryLanguageCode(ballotStyle)}
+      uiStringsPackage={election.ballotStrings}
+    >
+      <Page
+        pageNumber={pageNumber}
+        dimensions={pageDimensions}
+        margins={pageMarginsInches}
+      >
+        <TimingMarkGrid pageDimensions={pageDimensions}>
+          <div
+            style={{
+              flex: 1,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '0.75rem',
+              padding: '0.11in 0.125in 0.125in 0.125in',
+            }}
+          >
+            {pageNumber === 1 && (
+              <>
+                <Header
+                  election={election}
+                  ballotStyleId={ballotStyleId}
+                  ballotType={ballotType}
+                  ballotMode={ballotMode}
+                  electionTitleOverride={electionTitleOverride}
+                  clerkSignatureImage={clerkSignatureImage}
+                  clerkSignatureCaption={clerkSignatureCaption}
+                />
+                <Instructions languageCode={languageCode} />
+              </>
+            )}
+            <div
+              style={{
+                flex: 1,
+                // Prevent this flex item from overflowing its container
+                // https://stackoverflow.com/a/66689926
+                minHeight: 0,
+              }}
+            >
+              {children}
+            </div>
+            <Footer
+              election={election}
+              ballotStyleId={ballotStyleId}
+              precinctId={precinctId}
+              pageNumber={pageNumber}
+              totalPages={totalPages}
+            />
+          </div>
+        </TimingMarkGrid>
+      </Page>
+    </BackendLanguageContextProvider>
+  );
+}
+
+const ContestHeader = styled.div`
+  background: ${Colors.LIGHT_GRAY};
+  padding: 0.25rem 0.5rem 0.125rem 0.5rem;
+`;
+
+function WriteInLabel() {
+  return (
+    <span>
+      <DualLanguageText delimiter="/">
+        {hmpbStrings.hmpbWriteIn}
+      </DualLanguageText>
+    </span>
+  );
+}
+
+async function CandidateContest({
+  scratchpad,
+  key,
+  election,
+  contest,
+  gridRowHeightInches,
+  width,
+}: {
+  scratchpad: RenderScratchpad;
+  key: React.Key;
+  election: Election;
+  contest: CandidateContestStruct;
+  gridRowHeightInches: number;
+  width: number;
+}) {
+  const voteForText = {
+    1: hmpbStrings.hmpbVoteFor1,
+    2: hmpbStrings.hmpbVoteFor2,
+    3: hmpbStrings.hmpbVoteFor3,
+    4: hmpbStrings.hmpbVoteFor4,
+    5: hmpbStrings.hmpbVoteFor5,
+    6: hmpbStrings.hmpbVoteFor6,
+    7: hmpbStrings.hmpbVoteFor7,
+    8: hmpbStrings.hmpbVoteFor8,
+    9: hmpbStrings.hmpbVoteFor9,
+    10: hmpbStrings.hmpbVoteFor10,
+  }[contest.seats];
+  if (!voteForText) {
+    throw new Error(
+      `Unsupported number of seats for contest: ${contest.seats}`
+    );
+  }
+
+  const contestHeader = await snapToGridRow(
+    scratchpad,
+    gridRowHeightInches,
+    (style) => (
+      <ContestHeader style={{ ...style, width }}>
+        <DualLanguageText delimiter="/">
+          <h3>{electionStrings.contestTitle(contest)}</h3>
+        </DualLanguageText>
+        <DualLanguageText delimiter="/">
+          <div>{voteForText}</div>
+        </DualLanguageText>
+        {contest.termDescription && (
+          <DualLanguageText delimiter="/">
+            <div>{electionStrings.contestTerm(contest)}</div>
+          </DualLanguageText>
+        )}
+      </ContestHeader>
+    )
+  );
+
+  const candidateOptions = await iter(contest.candidates)
+    .async()
+    .map((candidate) =>
+      snapToGridRow(scratchpad, gridRowHeightInches, (style) => {
+        const partyText =
+          election.type === 'primary' ? undefined : (
+            <CandidatePartyList
+              candidate={candidate}
+              electionParties={election.parties}
+            />
+          );
+        const optionInfo: OptionInfo = {
+          type: 'option',
+          contestId: contest.id,
+          optionId: candidate.id,
+        };
+        return (
+          <div
+            key={candidate.id}
+            style={{
+              padding: '0.375rem 0.75rem 0.125rem 0.5rem',
+              borderTop: `1px solid ${Colors.DARK_GRAY}`,
+              ...style,
+              width,
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                gap: '0.5rem',
+              }}
+            >
+              <div
+                style={{ flex: 1, textAlign: 'right', marginTop: '-0.25rem' }}
+              >
+                <strong>{candidate.name}</strong>
+                {partyText && (
+                  <DualLanguageText delimiter="/">
+                    <div>{partyText}</div>
+                  </DualLanguageText>
+                )}
+              </div>
+              <div>
+                <Bubble optionInfo={optionInfo} />
+              </div>
+            </div>
+          </div>
+        );
+      })
+    )
+    .toArray();
+
+  const writeInOptions = await iter(
+    range(0, contest.allowWriteIns ? contest.seats : 0)
+  )
+    .async()
+    .map((writeInIndex) =>
+      snapToGridRow(scratchpad, gridRowHeightInches, (style) => {
+        const optionInfo: OptionInfo = {
+          type: 'write-in',
+          contestId: contest.id,
+          writeInIndex,
+          writeInArea: {
+            top: 0.8,
+            left: -0.9,
+            bottom: 0.2,
+            right: 8.7,
+          },
+        };
+        return (
+          <div
+            key={writeInIndex}
+            className={WRITE_IN_OPTION_CLASS}
+            style={{
+              display: 'flex',
+              gap: '0.5rem',
+              padding: '0.375rem 0.75rem 0rem 0.5rem',
+              borderTop: `1px solid ${Colors.DARK_GRAY}`,
+              ...style,
+              width,
+            }}
+          >
+            <div style={{ flex: 1 }}>
+              <div
+                style={{
+                  borderBottom: `1px solid ${Colors.BLACK}`,
+                  height: '1.75rem',
+                }}
+              />
+              <div style={{ fontSize: '0.75rem', textAlign: 'right' }}>
+                <WriteInLabel />
+              </div>
+            </div>
+            <div>
+              <Bubble optionInfo={optionInfo} />
+            </div>
+          </div>
+        );
+      })
+    )
+    .toArray();
+
+  const options = candidateOptions.concat(writeInOptions);
+
+  const contestHeight =
+    contestHeader.height + iter(options).sum((option) => option.height);
+
+  return (
+    <Box
+      key={key}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        padding: 0,
+        height: contestHeight,
+        width,
+        overflow: 'hidden',
+      }}
+    >
+      {contestHeader.element}
+      <div>{options.map((option) => option.element)}</div>
+    </Box>
+  );
+}
+
+async function BallotMeasureContest({
+  scratchpad,
+  key,
+  contest,
+  gridRowHeightInches,
+  width,
+}: {
+  scratchpad: RenderScratchpad;
+  key: React.Key;
+  contest: YesNoContest;
+  gridRowHeightInches: number;
+  width: number;
+}) {
+  const contestHeader = await snapToGridRow(
+    scratchpad,
+    gridRowHeightInches,
+    (style) => (
+      <ContestHeader style={{ ...style, width }}>
+        <DualLanguageText delimiter="/">
+          <h2>{electionStrings.contestTitle(contest)}</h2>
+        </DualLanguageText>
+      </ContestHeader>
+    )
+  );
+
+  const contestDescription = await snapToGridRow(
+    scratchpad,
+    gridRowHeightInches,
+    (style) => (
+      <div
+        style={{
+          padding: '0.5rem 0.5rem 0.25rem 0.5rem',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '0.5rem',
+          ...style,
+          width,
+        }}
+      >
+        <DualLanguageText>
+          <RichText
+            tableBorderWidth={'1px'}
+            tableBorderColor={Colors.DARKER_GRAY}
+            tableHeaderBackgroundColor={Colors.LIGHT_GRAY}
+          >
+            {electionStrings.contestDescription(contest)}
+          </RichText>
+        </DualLanguageText>
+      </div>
+    )
+  );
+
+  const options = await iter([contest.yesOption, contest.noOption])
+    .async()
+    .map((option) =>
+      snapToGridRow(scratchpad, gridRowHeightInches, (style) => (
+        <div
+          key={option.id}
+          style={{
+            padding: '0.375rem 0.75rem 0.125rem 0.5rem',
+            borderTop: `1px solid ${Colors.LIGHT_GRAY}`,
+            ...style,
+            width,
+          }}
+        >
+          <div style={{ display: 'flex', gap: '0.5rem' }}>
+            <strong
+              style={{ flex: 1, textAlign: 'right', marginTop: '-0.25rem' }}
+            >
+              <DualLanguageText delimiter="/">
+                {electionStrings.contestOptionLabel(option)}
+              </DualLanguageText>
+            </strong>
+            <div>
+              <Bubble
+                optionInfo={{
+                  type: 'option',
+                  contestId: contest.id,
+                  optionId: option.id,
+                }}
+              />
+            </div>
+          </div>
+        </div>
+      ))
+    )
+    .toArray();
+
+  const contestHeight =
+    contestHeader.height +
+    contestDescription.height +
+    iter(options).sum((option) => option.height);
+
+  return (
+    <Box
+      key={key}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        padding: 0,
+        height: contestHeight,
+        width,
+        overflow: 'hidden',
+      }}
+    >
+      {contestHeader.element}
+      {contestDescription.element}
+      {options.map((option) => option.element)}
+    </Box>
+  );
+}
+
+async function Contest({
+  scratchpad,
+  key,
+  contest,
+  election,
+  gridRowHeightInches,
+  width,
+}: {
+  scratchpad: RenderScratchpad;
+  key: React.Key;
+  contest: AnyContest;
+  election: Election;
+  gridRowHeightInches: number;
+  width: number;
+}) {
+  switch (contest.type) {
+    case 'candidate':
+      return CandidateContest({
+        scratchpad,
+        key,
+        election,
+        contest,
+        gridRowHeightInches,
+        width,
+      });
+    case 'yesno':
+      return BallotMeasureContest({
+        scratchpad,
+        key,
+        contest,
+        gridRowHeightInches,
+        width,
+      });
+    default:
+      return throwIllegalValue(contest);
+  }
+}
+
+async function BallotPageContent(
+  props: (BaseBallotProps & { dimensions: PixelDimensions }) | undefined,
+  scratchpad: RenderScratchpad
+): Promise<PagedElementResult<BaseBallotProps>> {
+  if (!props) {
+    return {
+      currentPageElement: <BlankPageMessage />,
+      nextPageProps: undefined,
+    };
+  }
+
+  const { election, ballotStyleId, dimensions, ...restProps } = props;
+  const ballotStyle = assertDefined(
+    getBallotStyle({ election, ballotStyleId })
+  );
+  // For now, just one section for candidate contests, one for ballot measures.
+  // TODO support arbitrarily defined sections
+  const contests = getContests({ election, ballotStyle });
+  if (contests.length === 0) {
+    throw new Error('No contests assigned to this precinct.');
+  }
+  const contestSections = iter(contests)
+    .partition((contest) => contest.type === 'candidate')
+    .filter((section) => section.length > 0);
+
+  const pageDimensions = ballotPaperDimensions(election.ballotLayout.paperSize);
+  const ppi = 96;
+  // Copied from TimingMarkGrid component
+  const columnsPerInch = 4;
+  const rowsPerInch = 4;
+  const gridRows = pageDimensions.height * rowsPerInch - 3 - 1;
+  const gridColumns = pageDimensions.width * columnsPerInch - 1;
+  const gridHeightInches =
+    pageDimensions.height -
+    (pageMarginsInches.top + pageMarginsInches.bottom) -
+    TIMING_MARK_DIMENSIONS.height;
+  const gridWidthInches =
+    pageDimensions.width -
+    (pageMarginsInches.left + pageMarginsInches.right) -
+    TIMING_MARK_DIMENSIONS.width;
+  const gridRowHeightInches = gridHeightInches / gridRows;
+  const gridColumnWidthInches = gridWidthInches / gridColumns;
+
+  // Add as many contests on this page as will fit.
+  const contestSectionsLeftToLayout = contestSections;
+  const pageSections: JSX.Element[] = [];
+  let heightUsed = 0;
+
+  // TODO is there some way we can use rem here instead of having to know the
+  // font size and map to px?
+  const horizontalGapPx = gridColumnWidthInches * ppi;
+  const verticalGapPx = gridRowHeightInches * ppi;
+  while (contestSections.length > 0 && heightUsed < dimensions.height) {
+    const section = assertDefined(contestSectionsLeftToLayout.shift());
+    const numColumns = section[0].type === 'candidate' ? 3 : 2;
+    const contestGridColumnsTotal = Math.floor(
+      (dimensions.width - horizontalGapPx * (numColumns - 1)) /
+        (gridColumnWidthInches * ppi)
+    );
+    const columnGridWidth = Math.floor(contestGridColumnsTotal / numColumns);
+    const columnWidthPx = columnGridWidth * gridColumnWidthInches * ppi;
+    const contestElements = await iter(section)
+      .async()
+      .map((contest, i) =>
+        Contest({
+          scratchpad,
+          key: i,
+          contest,
+          election,
+          gridRowHeightInches,
+          width: columnWidthPx,
+        })
+      )
+      .toArray();
+    const contestMeasurements = await scratchpad.measureElements(
+      <BackendLanguageContextProvider
+        currentLanguageCode={primaryLanguageCode(ballotStyle)}
+        uiStringsPackage={election.ballotStrings}
+      >
+        {contestElements.map((contest, i) => (
+          <div
+            className="contestWrapper"
+            key={i}
+            style={{ width: `${columnWidthPx}px` }}
+          >
+            {contest}
+          </div>
+        ))}
+      </BackendLanguageContextProvider>,
+      '.contestWrapper'
+    );
+
+    const measuredContests = iter(contestElements)
+      .zip(contestMeasurements)
+      .map(([element, measurements], i) => ({
+        element,
+        ...measurements,
+        contest: section[i],
+      }))
+      .toArray();
+
+    const { columns, height, leftoverElements } = layOutInColumns({
+      elements: measuredContests,
+      numColumns,
+      maxColumnHeight: dimensions.height - heightUsed,
+      elementGap: verticalGapPx,
+    });
+
+    // Put leftover elements back on the front of the queue
+    if (leftoverElements.length > 0) {
+      contestSectionsLeftToLayout.unshift(
+        leftoverElements.map((element) => element.contest)
+      );
+    }
+
+    // If there wasn't enough room left for any contests, go to the next page
+    if (height === 0) {
+      break;
+    }
+
+    // Add vertical gap to account for space between sections
+    heightUsed += height + verticalGapPx;
+    pageSections.push(
+      <div
+        key={`section-${pageSections.length + 1}`}
+        style={{
+          display: 'flex',
+          gap: `${horizontalGapPx}px`,
+        }}
+      >
+        {columns.map((column, i) => (
+          <div
+            key={`column-${i}`}
+            style={{
+              // flex: 1,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: `${verticalGapPx}px`,
+              width: `${columnWidthPx}px`,
+              overflow: 'hidden',
+            }}
+          >
+            {column.map(({ element }) => element)}
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  const currentPageElement =
+    pageSections.length > 0 ? (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: `${verticalGapPx}px`,
+        }}
+      >
+        {pageSections}
+      </div>
+    ) : (
+      <BlankPageMessage />
+    );
+  const nextPageProps =
+    contestSectionsLeftToLayout.length > 0
+      ? {
+          ...restProps,
+          ballotStyleId,
+          election: {
+            ...election,
+            contests: contestSectionsLeftToLayout.flat(),
+          },
+        }
+      : undefined;
+
+  return {
+    currentPageElement,
+    nextPageProps,
+  };
+}
+
+export const v3NhTownBallotTemplate: BallotPageTemplate<BaseBallotProps> = {
+  frameComponent: BallotPageFrame,
+  contentComponent: BallotPageContent,
+};

--- a/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
@@ -128,6 +128,7 @@ function Header({
   return (
     <div
       style={{
+        paddingTop: '0.125rem',
         display: 'flex',
         gap: '0.75rem',
         alignItems: 'center',
@@ -791,7 +792,12 @@ async function BallotPageContent(
   };
 }
 
-export const v3NhTownBallotTemplate: BallotPageTemplate<BaseBallotProps> = {
+interface BallotPageTemplateV3 extends BallotPageTemplate<BaseBallotProps> {
+  machineVersion: 'v3';
+}
+
+export const v3NhTownBallotTemplate: BallotPageTemplateV3 = {
   frameComponent: BallotPageFrame,
   contentComponent: BallotPageContent,
+  machineVersion: 'v3',
 };

--- a/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
@@ -399,10 +399,10 @@ async function CandidateContest({
           contestId: contest.id,
           writeInIndex,
           writeInArea: {
-            top: 0.8,
-            left: -0.9,
-            bottom: 0.2,
-            right: 8.7,
+            top: 0.3,
+            right: -0.9,
+            bottom: 0.7,
+            left: 7.7,
           },
         };
         return (

--- a/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
@@ -1,3 +1,4 @@
+/* istanbul ignore file - must be manually tested against v3 interpreter @preserve */
 import {
   assertDefined,
   iter,

--- a/libs/hmpb/src/index.ts
+++ b/libs/hmpb/src/index.ts
@@ -7,5 +7,6 @@ export * from './playwright_renderer';
 export * from './render_ballot';
 export * from './renderer';
 export * from './ballot_templates/nh_ballot_template';
+export * from './ballot_templates/v3_nh_ballot_template';
 export * from './ballot_templates/vx_default_ballot_template';
 export * from './types';

--- a/libs/hmpb/src/preview/browser_preview.ts
+++ b/libs/hmpb/src/preview/browser_preview.ts
@@ -181,7 +181,7 @@ export async function main(): Promise<void> {
         }px`;
         writeInAreaElement.style.width = `${gridWidthToPixels(
           grid,
-          writeInArea.left + writeInArea.right
+          Math.abs(writeInArea.left + writeInArea.right)
         )}px`;
         writeInAreaElement.style.height = `${gridWidthToPixels(
           grid,

--- a/libs/hmpb/src/render_ballot.tsx
+++ b/libs/hmpb/src/render_ballot.tsx
@@ -240,8 +240,14 @@ function snapCoordinatesToGrid(coordinates: { column: number; row: number }): {
     coordinates.column - Math.round(coordinates.column)
   );
   const deltaRow = Math.abs(coordinates.row - Math.round(coordinates.row));
-  assert(deltaColumn <= 0.1);
-  assert(deltaRow <= 0.1);
+  assert(
+    deltaColumn <= 0.1,
+    'Column coordinate is not close to an integer - bubble may be misaligned'
+  );
+  assert(
+    deltaRow <= 0.1,
+    'Row coordinate is not close to an integer - bubble may be misaligned'
+  );
   return {
     column: Math.round(coordinates.column),
     row: Math.round(coordinates.row),

--- a/libs/hmpb/src/render_ballot.tsx
+++ b/libs/hmpb/src/render_ballot.tsx
@@ -333,7 +333,7 @@ async function extractGridLayout(
       y: firstWriteInOptionBubble.y + firstWriteInOptionBubble.height / 2,
     };
     const grid = await measureTimingMarkGrid(document, 1);
-    return {
+    let bounds: Outset<number> = {
       top: pixelsToGridHeight(
         grid,
         firstWriteInOptionBubbleCenter.y - firstWriteInOption.y
@@ -355,6 +355,15 @@ async function extractGridLayout(
           firstWriteInOptionBubbleCenter.y
       ),
     };
+    if ('machineVersion' in template && template.machineVersion === 'v3') {
+      bounds = {
+        top: Math.ceil(bounds.top),
+        left: Math.ceil(bounds.left),
+        right: Math.ceil(bounds.right),
+        bottom: Math.ceil(bounds.bottom),
+      };
+    }
+    return bounds;
   })();
 
   return {


### PR DESCRIPTION
## Overview

Task: https://github.com/votingworks/vxsuite/issues/5702

Creates a copy of the NH town ballot template that produces ballots and election definitions that are compatible with VxSuite v3.

Note that this ballot template isn't integrated into VxDesign yet - that will come in a later PR.

## Demo Video or Screenshot
Sample ballot
[test-absentee-ballot-Center_Springfield-1_en.pdf](https://github.com/user-attachments/files/18497719/test-absentee-ballot-Center_Springfield-1_en.pdf)

Write-in adjudication
![image](https://github.com/user-attachments/assets/3ffae128-53ca-4918-bfaa-4a7ebd343869)

Unmarked write-in detection
![image](https://github.com/user-attachments/assets/a7403474-2b5d-471f-ad60-75ec30a4803e)


## Testing Plan
Manual tests:
- Ballot scans and votes are detected correctly
- Write-in adjudication crop areas look right
- Unmarked write-ins are detected

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
