### PR TITLE
VxDesign: Refactor to find precinct split from ballot style in ballot preview

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -968,7 +968,6 @@ test('getBallotPreviewPdf returns a ballot pdf for precinct with splits', async 
       ballotStyleId: ballotStyle.id,
       ballotType: BallotType.Precinct,
       ballotMode: 'test',
-      splitId: split.id,
     })
   ).unsafeUnwrap();
 
@@ -1021,7 +1020,6 @@ test('getBallotPreviewPdf returns a ballot pdf for NH election with split precin
       ballotStyleId: ballotStyle.id,
       ballotType: BallotType.Precinct,
       ballotMode: 'test',
-      splitId: split.id,
     })
   ).unsafeUnwrap();
 

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -201,7 +201,6 @@ interface GetBallotPreviewInput {
   ballotStyleId: BallotStyleId;
   ballotType: BallotType;
   ballotMode: BallotMode;
-  splitId?: string;
 }
 
 export const getBallotPreviewPdf = {

--- a/apps/design/frontend/src/ballot_screen.tsx
+++ b/apps/design/frontend/src/ballot_screen.tsx
@@ -1,4 +1,4 @@
-import { useLocation, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { assertDefined, range } from '@votingworks/basics';
 import {
   getPrecinctById,
@@ -210,9 +210,6 @@ export function BallotScreen(): JSX.Element | null {
     ballotStyleId: BallotStyleId;
     precinctId: string;
   }>();
-  const { search } = useLocation();
-  const searchParams = new URLSearchParams(search);
-  const splitId = searchParams.get('splitId');
 
   const getElectionQuery = getElection.useQuery(electionId);
   const [ballotType, setBallotType] = useState<BallotType>(BallotType.Precinct);
@@ -223,8 +220,6 @@ export function BallotScreen(): JSX.Element | null {
     ballotStyleId,
     ballotType,
     ballotMode,
-    // Avoid serializing `null` or `undefined` when calling API
-    ...(splitId !== null ? { splitId } : {}),
   });
 
   if (!getElectionQuery.isSuccess) {

--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -329,11 +329,8 @@ function BallotStylesTab(): JSX.Element | null {
                       <TD>
                         <LinkButton
                           to={
-                            ballotRoutes.viewBallot(
-                              ballotStyle.id,
-                              precinct.id,
-                              split.id
-                            ).path
+                            ballotRoutes.viewBallot(ballotStyle.id, precinct.id)
+                              .path
                           }
                         >
                           View Ballot

--- a/apps/design/frontend/src/routes.ts
+++ b/apps/design/frontend/src/routes.ts
@@ -98,15 +98,9 @@ export const routes = {
           title: 'Ballot Layout',
           path: `${root}/ballots/layout`,
         },
-        viewBallot: (
-          ballotStyleId: string,
-          precinctId: string,
-          splitId?: string
-        ) => ({
+        viewBallot: (ballotStyleId: string, precinctId: string) => ({
           title: 'View Ballot',
-          path: `${root}/ballots/${ballotStyleId}/${precinctId}${
-            splitId ? `?${new URLSearchParams({ splitId }).toString()}` : ''
-          }`,
+          path: `${root}/ballots/${ballotStyleId}/${precinctId}`,
         }),
       },
       ballotOrderInfo: {


### PR DESCRIPTION
## Overview
If a precinct has splits, VxDesign creates a separate ballot style for each split. When previewing a particular ballot style, we know the precinct ID and the ballot style ID, so we can figure out the relevant split ID (if there is one) from that information. If the precinct has splits, then we look up which split this ballot style corresponds to.

This refactor helps set up for factoring out the logic to add the NH-specific ballot props in all of the other places where we render ballots.

## Demo Video or Screenshot

## Testing Plan
Updated existing tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
