### PR TITLE
remove bubble position toggle

### DIFF
--- a/apps/design/frontend/src/ballots_screen.test.tsx
+++ b/apps/design/frontend/src/ballots_screen.test.tsx
@@ -1,6 +1,5 @@
 import userEvent from '@testing-library/user-event';
 import { HmpbBallotPaperSize, Election, ElectionId } from '@votingworks/types';
-import { ElectionRecord } from '@votingworks/design-backend';
 import {
   provideApi,
   createMockApiClient,
@@ -158,44 +157,6 @@ describe('Ballot styles tab', () => {
       screen.getByRole('button', { name: 'Finalize Ballots' })
     ).toBeDisabled();
   });
-});
-
-test('Ballot layout tab; NH-specific features', async () => {
-  const nhElection: ElectionRecord = {
-    ...generalElectionRecord,
-    election: { ...generalElectionRecord.election, state: 'NH' },
-  };
-  const electionId = nhElection.election.id;
-  apiMock.getElection.expectCallWith({ electionId }).resolves(nhElection);
-  apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
-
-  renderScreen(electionId);
-  await screen.findByRole('heading', { name: 'Ballots' });
-
-  userEvent.click(screen.getByRole('tab', { name: 'Ballot Layout' }));
-
-  const bubblePositionControl = screen.getByRole('listbox', {
-    name: 'Bubble Position',
-  });
-
-  // Bubble position initial state
-  expect(
-    within(bubblePositionControl).getByRole('option', {
-      name: 'Left',
-      selected: true,
-    })
-  ).toBeDisabled();
-  expect(
-    within(bubblePositionControl).getByRole('option', {
-      name: 'Right',
-      selected: false,
-    })
-  ).toBeDisabled();
-
-  userEvent.click(screen.getByRole('button', { name: /Edit/ }));
-
-  userEvent.click(screen.getByRole('option', { name: 'Right' }));
-  screen.getByRole('option', { name: 'Right', selected: true });
 });
 
 test('Ballot layout tab', async () => {

--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -11,7 +11,6 @@ import {
   MainContent,
   TabPanel,
   RouterTabBar,
-  SegmentedButton,
   H3,
   Card,
   Icons,
@@ -37,7 +36,6 @@ import { ElectionNavScreen } from './nav_screen';
 import { ElectionIdParams, electionParamRoutes, routes } from './routes';
 import { hasSplits } from './utils';
 import { BallotScreen, paperSizeLabels } from './ballot_screen';
-import { FeatureName, useFeaturesContext } from './features_context';
 
 function BallotDesignForm({
   electionId,
@@ -48,11 +46,7 @@ function BallotDesignForm({
 }): JSX.Element {
   const [isEditing, setIsEditing] = useState(false);
   const [ballotLayout, setBallotLayout] = useState(savedElection.ballotLayout);
-  const [bubblePosition, setBubblePosition] = useState<'left' | 'right'>(
-    'left'
-  );
   const updateElectionMutation = updateElection.useMutation();
-  const features = useFeaturesContext();
 
   function onSavePress() {
     updateElectionMutation.mutate(
@@ -88,21 +82,6 @@ function BallotDesignForm({
         }
         disabled={!isEditing}
       />
-
-      {features[FeatureName.BALLOT_BUBBLE_SIDE] && (
-        <SegmentedButton
-          label="Bubble Position"
-          options={[
-            { id: 'left', label: 'Left' },
-            { id: 'right', label: 'Right' },
-          ]}
-          selectedOptionId={bubblePosition}
-          onChange={(targetMarkPosition: 'left' | 'right') =>
-            setBubblePosition(targetMarkPosition)
-          }
-          disabled={!isEditing}
-        />
-      )}
 
       {isEditing ? (
         <FormActionsRow>


### PR DESCRIPTION
## Overview

Deletes the bubble position toggle because it will always be `left` for the default template and `right` for NH.

## Demo Video or Screenshot

Before

![Screenshot 2025-01-22 at 11 18 31 AM](https://github.com/user-attachments/assets/1021dfd8-8136-4c3c-9fdc-a34b007e4843)


After


![Screenshot 2025-01-22 at 11 18 31 AM](https://github.com/user-attachments/assets/72ab361a-3db4-40c4-9000-fa7a86df5b37)

## Testing Plan

Manually verified it's gone and deleted the automated test.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
