### PR TITLE
VxDesign: Factor out selecting template and creating ballot props

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -46,10 +46,8 @@ import {
 import { countObjectLeaves, getObjectLeaves } from '@votingworks/test-utils';
 import {
   BallotMode,
-  BallotPageTemplate,
   BaseBallotProps,
   hmpbStringsCatalog,
-  nhBallotTemplate,
   renderAllBallotsAndCreateElectionDefinition,
   vxDefaultBallotTemplate,
 } from '@votingworks/hmpb';
@@ -73,7 +71,7 @@ import { generateBallotStyles } from './ballot_styles';
 import { ElectionRecord } from '.';
 import { getTempBallotLanguageConfigsForCert } from './store';
 import { renderBallotStyleReadinessReport } from './ballot_style_reports';
-import { BALLOT_STYLE_READINESS_REPORT_FILE_NAME, getTemplate } from './app';
+import { BALLOT_STYLE_READINESS_REPORT_FILE_NAME } from './app';
 
 vi.setConfig({
   testTimeout: 60_000,
@@ -1064,34 +1062,4 @@ test('getBallotPreviewPdf returns a ballot pdf for precinct with no split', asyn
   ).unsafeUnwrap();
 
   await expect(result.pdfData).toMatchPdfSnapshot({ failureThreshold: 0.01 });
-});
-
-interface TemplateTestSpec {
-  states: string[];
-  expectedTemplate: BallotPageTemplate<BaseBallotProps>;
-}
-
-describe('getTemplate', () => {
-  const templateTests: TemplateTestSpec[] = [
-    {
-      states: ['nh', 'NH', 'New Hampshire', 'NEW HAMPSHIRE'],
-      expectedTemplate: nhBallotTemplate,
-    },
-    {
-      states: ['ms', 'MS', 'Mississippi', 'MISSISSIPPI'],
-      expectedTemplate: vxDefaultBallotTemplate,
-    },
-    {
-      states: ['State of Hamilton'],
-      expectedTemplate: vxDefaultBallotTemplate,
-    },
-  ];
-  test.each(templateTests)(
-    'returns the right template for state: $state',
-    ({ states, expectedTemplate }) => {
-      for (const state of states) {
-        expect(getTemplate(state)).toEqual(expectedTemplate);
-      }
-    }
-  );
 });

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -25,20 +25,14 @@ import {
 import JsZip from 'jszip';
 import {
   BallotMode,
-  BALLOT_MODES,
-  BaseBallotProps,
   createPlaywrightRenderer,
   hmpbStringsCatalog,
   renderAllBallotsAndCreateElectionDefinition,
   renderBallotPreviewToPdf,
-  vxDefaultBallotTemplate,
-  BallotPageTemplate,
-  NhPrecinctSplitOptions,
-  nhBallotTemplate,
 } from '@votingworks/hmpb';
 import { translateBallotStrings } from '@votingworks/backend';
 import { ElectionPackage, ElectionRecord } from './store';
-import { BallotOrderInfo, hasSplits, Precinct } from './types';
+import { BallotOrderInfo, Precinct } from './types';
 import {
   createPrecinctTestDeck,
   FULL_TEST_DECK_TALLY_REPORT_FILE_NAME,
@@ -47,41 +41,10 @@ import {
 import { AppContext } from './context';
 import { rotateCandidates } from './candidate_rotation';
 import { renderBallotStyleReadinessReport } from './ballot_style_reports';
+import { selectTemplateAndCreateBallotProps } from './ballots';
 
 export const BALLOT_STYLE_READINESS_REPORT_FILE_NAME =
   'ballot-style-readiness-report.pdf';
-
-enum UsState {
-  NEW_HAMPSHIRE = 'New Hampshire',
-  MISSISSIPPI = 'Mississippi',
-  UNKNOWN = 'Unknown',
-}
-
-function normalizeState(state: string): UsState {
-  switch (state.toLowerCase()) {
-    case 'nh':
-    case 'new hampshire':
-      return UsState.NEW_HAMPSHIRE;
-    case 'ms':
-    case 'mississippi':
-      return UsState.MISSISSIPPI;
-    default:
-      return UsState.UNKNOWN;
-  }
-}
-
-export function getTemplate(
-  state: string
-): BallotPageTemplate<BaseBallotProps> {
-  switch (normalizeState(state)) {
-    case UsState.NEW_HAMPSHIRE:
-      return nhBallotTemplate;
-    case UsState.MISSISSIPPI:
-    case UsState.UNKNOWN:
-    default:
-      return vxDefaultBallotTemplate;
-  }
-}
 
 export function createBlankElection(id: ElectionId): Election {
   return {
@@ -250,9 +213,8 @@ function buildApi({ workspace, translator }: AppContext) {
       electionId: Id;
       electionSerializationFormat: ElectionSerializationFormat;
     }): Promise<{ zipContents: Buffer; ballotHash: string }> {
-      const { election, ballotLanguageConfigs } = await store.getElection(
-        input.electionId
-      );
+      const { election, ballotLanguageConfigs, precincts, ballotStyles } =
+        await store.getElection(input.electionId);
       const ballotStrings = await translateBallotStrings(
         translator,
         election,
@@ -263,37 +225,25 @@ function buildApi({ workspace, translator }: AppContext) {
         ...election,
         ballotStrings,
       };
-
-      const renderer = await createPlaywrightRenderer();
-
-      const ballotTypes = [BallotType.Precinct, BallotType.Absentee];
-      const ballotProps = election.ballotStyles.flatMap((ballotStyle) =>
-        ballotStyle.precincts.flatMap((precinctId) =>
-          ballotTypes.flatMap((ballotType) =>
-            BALLOT_MODES.map(
-              (ballotMode): BaseBallotProps => ({
-                election: electionWithBallotStrings,
-                ballotStyleId: ballotStyle.id,
-                precinctId,
-                ballotType,
-                ballotMode,
-              })
-            )
-          )
-        )
+      const { template, allBallotProps } = selectTemplateAndCreateBallotProps(
+        electionWithBallotStrings,
+        precincts,
+        ballotStyles
       );
-
+      const renderer = await createPlaywrightRenderer();
       const { ballotDocuments, electionDefinition } =
         await renderAllBallotsAndCreateElectionDefinition(
           renderer,
-          getTemplate(election.state),
-          ballotProps,
+          template,
+          allBallotProps,
           input.electionSerializationFormat
         );
 
       const zip = new JsZip();
 
-      for (const [props, document] of iter(ballotProps).zip(ballotDocuments)) {
+      for (const [props, document] of iter(allBallotProps).zip(
+        ballotDocuments
+      )) {
         const pdf = await document.renderToPdf();
         const { precinctId, ballotStyleId, ballotType, ballotMode } = props;
         const precinct = assertDefined(
@@ -345,41 +295,35 @@ function buildApi({ workspace, translator }: AppContext) {
         ...election,
         ballotStrings,
       };
-
-      const precinct = find(precincts, (p) => p.id === input.precinctId);
-      let extraProps: NhPrecinctSplitOptions = {};
-      if (hasSplits(precinct)) {
-        const ballotStyle = find(
-          ballotStyles,
-          (bs) => bs.id === input.ballotStyleId
-        );
-        const { splitId } = find(
-          ballotStyle.precinctsOrSplits,
-          (p) => p.precinctId === input.precinctId
-        );
-        const split = find(precinct.splits, (s) => s.id === splitId);
-        extraProps = {
-          electionTitleOverride: split.electionTitleOverride,
-          clerkSignatureImage: split.clerkSignatureImage,
-          clerkSignatureCaption: split.clerkSignatureCaption,
-        };
-      }
-
+      const { template, allBallotProps } = selectTemplateAndCreateBallotProps(
+        electionWithBallotStrings,
+        precincts,
+        ballotStyles
+      );
+      const ballotProps = find(
+        allBallotProps,
+        (props) =>
+          props.precinctId === input.precinctId &&
+          props.ballotStyleId === input.ballotStyleId &&
+          props.ballotType === input.ballotType &&
+          props.ballotMode === input.ballotMode
+      );
       const renderer = await createPlaywrightRenderer();
       const ballotPdf = await renderBallotPreviewToPdf(
         renderer,
-        getTemplate(election.state),
-        {
-          ...input,
-          ...extraProps,
-          election: electionWithBallotStrings,
-          // NOTE: Changing this text means you should also change the font size
-          // of the <Watermark> component in the ballot template.
-          watermark: 'PROOF',
-        }
+        template,
+        // NOTE: Changing this text means you should also change the font size
+        // of the <Watermark> component in the ballot template.
+        // eslint-disable-next-line vx/gts-spread-like-types
+        { ...ballotProps, watermark: 'PROOF' }
       );
       // eslint-disable-next-line no-console
       renderer.cleanup().catch(console.error);
+
+      const precinct = find(
+        election.precincts,
+        (p) => p.id === input.precinctId
+      );
       return ok({
         pdfData: ballotPdf,
         fileName: `PROOF-${getPdfFileName(
@@ -416,9 +360,8 @@ function buildApi({ workspace, translator }: AppContext) {
       electionId: Id;
       electionSerializationFormat: ElectionSerializationFormat;
     }): Promise<{ zipContents: Buffer; ballotHash: string }> {
-      const { election, ballotLanguageConfigs } = await store.getElection(
-        input.electionId
-      );
+      const { election, ballotLanguageConfigs, precincts, ballotStyles } =
+        await store.getElection(input.electionId);
       const ballotStrings = await translateBallotStrings(
         translator,
         election,
@@ -429,26 +372,25 @@ function buildApi({ workspace, translator }: AppContext) {
         ...election,
         ballotStrings,
       };
-      const allBallotProps = election.ballotStyles.flatMap((ballotStyle) =>
-        ballotStyle.precincts.map(
-          (precinctId): BaseBallotProps => ({
-            election: electionWithBallotStrings,
-            ballotStyleId: ballotStyle.id,
-            precinctId,
-            ballotType: BallotType.Precinct,
-            ballotMode: 'test',
-          })
-        )
+      const { template, allBallotProps } = selectTemplateAndCreateBallotProps(
+        electionWithBallotStrings,
+        precincts,
+        ballotStyles
+      );
+      const testBallotProps = allBallotProps.filter(
+        (props) =>
+          props.ballotMode === 'test' &&
+          props.ballotType === BallotType.Precinct
       );
       const renderer = await createPlaywrightRenderer();
       const { electionDefinition, ballotDocuments } =
         await renderAllBallotsAndCreateElectionDefinition(
           renderer,
-          getTemplate(election.state),
-          allBallotProps,
+          template,
+          testBallotProps,
           input.electionSerializationFormat
         );
-      const ballots = iter(allBallotProps)
+      const ballots = iter(testBallotProps)
         .zip(ballotDocuments)
         .map(([props, document]) => ({
           props,

--- a/apps/design/backend/src/ballots.ts
+++ b/apps/design/backend/src/ballots.ts
@@ -1,6 +1,6 @@
-import { BallotType, Election } from '@votingworks/types';
+import { Election } from '@votingworks/types';
 import {
-  BALLOT_MODES,
+  allBaseBallotProps,
   BallotPageTemplate,
   BaseBallotProps,
   NhBallotProps,
@@ -39,22 +39,7 @@ export function selectTemplateAndCreateBallotProps(
   template: BallotPageTemplate<BaseBallotProps>;
   allBallotProps: BaseBallotProps[];
 } {
-  const ballotTypes = [BallotType.Precinct, BallotType.Absentee];
-  const baseBallotProps: BaseBallotProps[] = election.ballotStyles.flatMap(
-    (ballotStyle) =>
-      ballotStyle.precincts.flatMap((precinctId) =>
-        ballotTypes.flatMap((ballotType) =>
-          BALLOT_MODES.map((ballotMode) => ({
-            election,
-            ballotStyleId: ballotStyle.id,
-            precinctId,
-            ballotType,
-            ballotMode,
-          }))
-        )
-      )
-  );
-
+  const baseBallotProps = allBaseBallotProps(election);
   switch (normalizeState(election.state)) {
     case UsState.NEW_HAMPSHIRE: {
       const nhBallotProps = baseBallotProps.map((props): NhBallotProps => {

--- a/apps/design/backend/src/ballots.ts
+++ b/apps/design/backend/src/ballots.ts
@@ -1,0 +1,93 @@
+import { BallotType, Election } from '@votingworks/types';
+import {
+  BALLOT_MODES,
+  BallotPageTemplate,
+  BaseBallotProps,
+  NhBallotProps,
+  nhBallotTemplate,
+  vxDefaultBallotTemplate,
+} from '@votingworks/hmpb';
+import { find } from '@votingworks/basics';
+import {
+  BallotStyle,
+  hasSplits,
+  normalizeState,
+  Precinct,
+  PrecinctSplit,
+  PrecinctWithSplits,
+  UsState,
+} from './types';
+
+function getPrecinctSplitForBallotStyle(
+  precinct: PrecinctWithSplits,
+  ballotStyle: BallotStyle
+): PrecinctSplit {
+  return find(precinct.splits, (split) =>
+    ballotStyle.precinctsOrSplits.some(
+      (precinctOrSplit) =>
+        precinctOrSplit.precinctId === precinct.id &&
+        precinctOrSplit.splitId === split.id
+    )
+  );
+}
+
+export function selectTemplateAndCreateBallotProps(
+  election: Election,
+  precincts: Precinct[],
+  ballotStyles: BallotStyle[]
+): {
+  template: BallotPageTemplate<BaseBallotProps>;
+  allBallotProps: BaseBallotProps[];
+} {
+  const ballotTypes = [BallotType.Precinct, BallotType.Absentee];
+  const baseBallotProps: BaseBallotProps[] = election.ballotStyles.flatMap(
+    (ballotStyle) =>
+      ballotStyle.precincts.flatMap((precinctId) =>
+        ballotTypes.flatMap((ballotType) =>
+          BALLOT_MODES.map((ballotMode) => ({
+            election,
+            ballotStyleId: ballotStyle.id,
+            precinctId,
+            ballotType,
+            ballotMode,
+          }))
+        )
+      )
+  );
+
+  switch (normalizeState(election.state)) {
+    case UsState.NEW_HAMPSHIRE: {
+      const nhBallotProps = baseBallotProps.map((props): NhBallotProps => {
+        const precinct = find(precincts, (p) => p.id === props.precinctId);
+        if (!hasSplits(precinct)) {
+          return props;
+        }
+        const ballotStyle = find(
+          ballotStyles,
+          (bs) => bs.id === props.ballotStyleId
+        );
+        const split = getPrecinctSplitForBallotStyle(precinct, ballotStyle);
+        return {
+          ...props,
+          electionTitleOverride: split.electionTitleOverride,
+          clerkSignatureImage: split.clerkSignatureImage,
+          clerkSignatureCaption: split.clerkSignatureCaption,
+        };
+      });
+      // TODO how can we use the type system to ensure that the template and
+      // props match?
+      return {
+        template: nhBallotTemplate,
+        allBallotProps: nhBallotProps,
+      };
+    }
+
+    case UsState.MISSISSIPPI:
+    case UsState.UNKNOWN:
+    default:
+      return {
+        template: vxDefaultBallotTemplate,
+        allBallotProps: baseBallotProps,
+      };
+  }
+}

--- a/apps/design/backend/src/types.test.ts
+++ b/apps/design/backend/src/types.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import {
   BallotStyle as VxfBallotStyle,
   DistrictId,

--- a/apps/design/backend/src/types.test.ts
+++ b/apps/design/backend/src/types.test.ts
@@ -5,7 +5,7 @@ import {
   PartyId,
   LanguageCode,
 } from '@votingworks/types';
-import { convertToVxfBallotStyle } from './types';
+import { convertToVxfBallotStyle, normalizeState, UsState } from './types';
 
 const { ENGLISH, SPANISH } = LanguageCode;
 
@@ -50,5 +50,26 @@ test('convertToVxfBallotStyle()', () => {
     groupId: '2' as VxfBallotStyle['groupId'],
     precincts: ['precinct1'],
     languages: [SPANISH],
+  });
+});
+
+describe('normalizeState', () => {
+  test.each([
+    {
+      input: ['nh', 'NH', 'New Hampshire', 'NEW HAMPSHIRE'],
+      expectedState: UsState.NEW_HAMPSHIRE,
+    },
+    {
+      input: ['ms', 'MS', 'Mississippi', 'MISSISSIPPI'],
+      expectedState: UsState.MISSISSIPPI,
+    },
+    {
+      input: ['State of Hamilton'],
+      expectedState: UsState.UNKNOWN,
+    },
+  ])('normalizes state string: $state', ({ input, expectedState }) => {
+    for (const state of input) {
+      expect(normalizeState(state)).toEqual(expectedState);
+    }
   });
 });

--- a/apps/design/backend/src/types.ts
+++ b/apps/design/backend/src/types.ts
@@ -94,3 +94,22 @@ export const BallotOrderInfoSchema: z.ZodType<BallotOrderInfo> = z.object({
   precinctBallotCount: z.string().optional(),
   shouldAbsenteeBallotsBeScoredForFolding: z.boolean().optional(),
 });
+
+export enum UsState {
+  NEW_HAMPSHIRE = 'New Hampshire',
+  MISSISSIPPI = 'Mississippi',
+  UNKNOWN = 'Unknown',
+}
+
+export function normalizeState(state: string): UsState {
+  switch (state.toLowerCase()) {
+    case 'nh':
+    case 'new hampshire':
+      return UsState.NEW_HAMPSHIRE;
+    case 'ms':
+    case 'mississippi':
+      return UsState.MISSISSIPPI;
+    default:
+      return UsState.UNKNOWN;
+  }
+}

--- a/libs/fixture-generators/src/generate-election-package/generate_election_package.test.ts
+++ b/libs/fixture-generators/src/generate-election-package/generate_election_package.test.ts
@@ -16,9 +16,11 @@ import {
 } from '@votingworks/types';
 import {
   Renderer,
-  createElectionDefinitionForDefaultHmpbTemplate,
+  allBaseBallotProps,
   createPlaywrightRenderer,
   hmpbStringsCatalog,
+  renderMinimalBallotsToCreateElectionDefinition,
+  vxDefaultBallotTemplate,
 } from '@votingworks/hmpb';
 import { GoogleCloudTranslatorWithElectionCache } from './translator_with_election_cache';
 
@@ -90,9 +92,10 @@ describe('fixtures are up to date - run `pnpm generate-election-packages` if thi
 
       // Check that the generated election's ballot hash has not changed.
       const electionDefinition =
-        await createElectionDefinitionForDefaultHmpbTemplate(
+        await renderMinimalBallotsToCreateElectionDefinition(
           renderer,
-          electionWithBallotStrings,
+          vxDefaultBallotTemplate,
+          allBaseBallotProps(electionWithBallotStrings),
           'vxf'
         );
       expect(electionDefinition.ballotHash).toEqual(

--- a/libs/fixture-generators/src/generate-election-package/generate_election_package.ts
+++ b/libs/fixture-generators/src/generate-election-package/generate_election_package.ts
@@ -3,15 +3,13 @@ import {
   getAllStringsForElectionPackage,
 } from '@votingworks/backend';
 import {
-  BALLOT_MODES,
-  BaseBallotProps,
+  allBaseBallotProps,
   createPlaywrightRenderer,
   hmpbStringsCatalog,
   renderMinimalBallotsToCreateElectionDefinition,
   vxDefaultBallotTemplate,
 } from '@votingworks/hmpb';
 import {
-  BallotType,
   DEFAULT_SYSTEM_SETTINGS,
   Election,
   ElectionPackage,
@@ -76,26 +74,11 @@ export async function generateElectionPackage(
     ...election,
     ballotStrings,
   };
-  const ballotTypes = [BallotType.Precinct, BallotType.Absentee];
-  const allBallotProps: BaseBallotProps[] =
-    electionWithBallotStrings.ballotStyles.flatMap((ballotStyle) =>
-      electionWithBallotStrings.precincts.flatMap((precinct) =>
-        ballotTypes.flatMap((ballotType) =>
-          BALLOT_MODES.map((ballotMode) => ({
-            election: electionWithBallotStrings,
-            ballotStyleId: ballotStyle.id,
-            precinctId: precinct.id,
-            ballotType,
-            ballotMode,
-          }))
-        )
-      )
-    );
   const electionDefinition =
     await renderMinimalBallotsToCreateElectionDefinition(
       renderer,
       vxDefaultBallotTemplate,
-      allBallotProps,
+      allBaseBallotProps(electionWithBallotStrings),
       'vxf'
     );
 

--- a/libs/fixture-generators/src/generate-election-package/generate_election_package.ts
+++ b/libs/fixture-generators/src/generate-election-package/generate_election_package.ts
@@ -3,11 +3,15 @@ import {
   getAllStringsForElectionPackage,
 } from '@votingworks/backend';
 import {
-  createElectionDefinitionForDefaultHmpbTemplate,
+  BALLOT_MODES,
+  BaseBallotProps,
   createPlaywrightRenderer,
   hmpbStringsCatalog,
+  renderMinimalBallotsToCreateElectionDefinition,
+  vxDefaultBallotTemplate,
 } from '@votingworks/hmpb';
 import {
+  BallotType,
   DEFAULT_SYSTEM_SETTINGS,
   Election,
   ElectionPackage,
@@ -72,11 +76,26 @@ export async function generateElectionPackage(
     ...election,
     ballotStrings,
   };
-
+  const ballotTypes = [BallotType.Precinct, BallotType.Absentee];
+  const allBallotProps: BaseBallotProps[] =
+    electionWithBallotStrings.ballotStyles.flatMap((ballotStyle) =>
+      electionWithBallotStrings.precincts.flatMap((precinct) =>
+        ballotTypes.flatMap((ballotType) =>
+          BALLOT_MODES.map((ballotMode) => ({
+            election: electionWithBallotStrings,
+            ballotStyleId: ballotStyle.id,
+            precinctId: precinct.id,
+            ballotType,
+            ballotMode,
+          }))
+        )
+      )
+    );
   const electionDefinition =
-    await createElectionDefinitionForDefaultHmpbTemplate(
+    await renderMinimalBallotsToCreateElectionDefinition(
       renderer,
-      electionWithBallotStrings,
+      vxDefaultBallotTemplate,
+      allBallotProps,
       'vxf'
     );
 

--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
@@ -11,8 +11,6 @@ import {
   BallotType,
   CandidateContest as CandidateContestStruct,
   Election,
-  ElectionDefinition,
-  ElectionSerializationFormat,
   YesNoContest,
   ballotPaperDimensions,
   getBallotStyle,
@@ -29,9 +27,8 @@ import {
   BallotPageTemplate,
   BaseBallotProps,
   PagedElementResult,
-  renderAllBallotsAndCreateElectionDefinition,
 } from '../render_ballot';
-import { Renderer, RenderScratchpad } from '../renderer';
+import { RenderScratchpad } from '../renderer';
 import {
   Bubble,
   OptionInfo,
@@ -614,35 +611,9 @@ async function BallotPageContent(
   };
 }
 
-export const nhBallotTemplate: BallotPageTemplate<BaseBallotProps> = {
+export type NhBallotProps = BaseBallotProps & NhPrecinctSplitOptions;
+
+export const nhBallotTemplate: BallotPageTemplate<NhBallotProps> = {
   frameComponent: BallotPageFrame,
   contentComponent: BallotPageContent,
 };
-
-/**
- * Helper function that renders ballots and generates an election definition for a
- * New Hampshire town hmpb ballot layout.
- */
-export async function createElectionDefinitionForNhTownHmpbTemplate(
-  renderer: Renderer,
-  election: Election,
-  electionSerializationFormat: ElectionSerializationFormat
-): Promise<ElectionDefinition> {
-  const { electionDefinition } =
-    await renderAllBallotsAndCreateElectionDefinition(
-      renderer,
-      nhBallotTemplate,
-      // Each ballot style will have exactly one grid layout regardless of precinct, ballot type, or ballot mode
-      // So we just need to render a single ballot per ballot style to create the election definition
-      election.ballotStyles.map((ballotStyle) => ({
-        election,
-        ballotStyleId: ballotStyle.id,
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        precinctId: ballotStyle.precincts[0]!,
-        ballotType: BallotType.Precinct,
-        ballotMode: 'test',
-      })),
-      electionSerializationFormat
-    );
-  return electionDefinition;
-}

--- a/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
@@ -15,8 +15,6 @@ import {
   BallotType,
   CandidateContest as CandidateContestStruct,
   Election,
-  ElectionDefinition,
-  ElectionSerializationFormat,
   PrecinctId,
   YesNoContest,
   ballotPaperDimensions,
@@ -38,9 +36,8 @@ import {
   BallotPageTemplate,
   BaseBallotProps,
   PagedElementResult,
-  renderAllBallotsAndCreateElectionDefinition,
 } from '../render_ballot';
-import { Renderer, RenderScratchpad } from '../renderer';
+import { RenderScratchpad } from '../renderer';
 import {
   Bubble,
   BallotHashSlot,
@@ -916,31 +913,3 @@ export const vxDefaultBallotTemplate: BallotPageTemplate<BaseBallotProps> = {
   frameComponent: BallotPageFrame,
   contentComponent: BallotPageContent,
 };
-
-/**
- * Helper function that renders ballots and generates an election definition for the standard
- * VxSuite hmpb ballot layout.
- */
-export async function createElectionDefinitionForDefaultHmpbTemplate(
-  renderer: Renderer,
-  election: Election,
-  electionSerializationFormat: ElectionSerializationFormat
-): Promise<ElectionDefinition> {
-  const { electionDefinition } =
-    await renderAllBallotsAndCreateElectionDefinition(
-      renderer,
-      vxDefaultBallotTemplate,
-      // Each ballot style will have exactly one grid layout regardless of precinct, ballot type, or ballot mode
-      // So we just need to render a single ballot per ballot style to create the election definition
-      election.ballotStyles.map((ballotStyle) => ({
-        election,
-        ballotStyleId: ballotStyle.id,
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        precinctId: ballotStyle.precincts[0]!,
-        ballotType: BallotType.Precinct,
-        ballotMode: 'test',
-      })),
-      electionSerializationFormat
-    );
-  return electionDefinition;
-}

--- a/libs/hmpb/src/render_ballot.tsx
+++ b/libs/hmpb/src/render_ballot.tsx
@@ -39,7 +39,13 @@ import {
   TIMING_MARK_CLASS,
   WRITE_IN_OPTION_CLASS,
 } from './ballot_components';
-import { BallotMode, PixelDimensions, Pixels, Point } from './types';
+import {
+  BALLOT_MODES,
+  BallotMode,
+  PixelDimensions,
+  Pixels,
+  Point,
+} from './types';
 
 export type FrameComponent<P> = (
   props: P & { children: JSX.Element; pageNumber: number; totalPages: number }
@@ -524,6 +530,28 @@ export async function renderAllBallotsAndCreateElectionDefinition<
     ballotDocuments: ballotsWithLayouts.map((ballot) => ballot.document),
     electionDefinition,
   };
+}
+
+/**
+ * Creates a list of the {@link BaseBallotProps} for all possible ballots -
+ * every combination of ballot style, precinct, ballot type (precinct/absentee),
+ * and ballot mode (official/test/sample).
+ */
+export function allBaseBallotProps(election: Election): BaseBallotProps[] {
+  const ballotTypes = [BallotType.Precinct, BallotType.Absentee];
+  return election.ballotStyles.flatMap((ballotStyle) =>
+    ballotStyle.precincts.flatMap((precinctId) =>
+      ballotTypes.flatMap((ballotType) =>
+        BALLOT_MODES.map((ballotMode) => ({
+          election,
+          ballotStyleId: ballotStyle.id,
+          precinctId,
+          ballotType,
+          ballotMode,
+        }))
+      )
+    )
+  );
 }
 
 /**

--- a/libs/hmpb/src/render_ballot.tsx
+++ b/libs/hmpb/src/render_ballot.tsx
@@ -4,6 +4,7 @@ import {
   assert,
   assertDefined,
   deepEqual,
+  groupBy,
   iter,
   throwIllegalValue,
 } from '@votingworks/basics';
@@ -523,4 +524,32 @@ export async function renderAllBallotsAndCreateElectionDefinition<
     ballotDocuments: ballotsWithLayouts.map((ballot) => ballot.document),
     electionDefinition,
   };
+}
+
+/**
+ * Renders the minimal set of ballots required to create an election definition
+ * with grid layouts included. Each ballot style will have exactly one grid
+ * layout regardless of precinct, ballot type, or ballot mode. So we just need
+ * to render a single ballot per ballot style to create the election definition
+ */
+export async function renderMinimalBallotsToCreateElectionDefinition<
+  P extends BaseBallotProps,
+>(
+  renderer: Renderer,
+  template: BallotPageTemplate<P>,
+  allBallotProps: P[],
+  electionSerializationFormat: ElectionSerializationFormat
+): Promise<ElectionDefinition> {
+  const minimalBallotProps = groupBy(
+    allBallotProps,
+    (props) => props.ballotStyleId
+  ).map(([, [, props]]) => props);
+  const { electionDefinition } =
+    await renderAllBallotsAndCreateElectionDefinition(
+      renderer,
+      template,
+      minimalBallotProps,
+      electionSerializationFormat
+    );
+  return electionDefinition;
 }


### PR DESCRIPTION
## Overview

Factors out logic to select the ballot template based on the state and create the ballot props for that template (including any custom props needed). The new function `selectTemplateAndCreateBallotProps` creates props for every possible ballot, allowing consumers to filter down to the props they need in their specific situation.

I also removed the functions from each template file that just render enough ballots to create an election definition and replaced it with a function `renderMinimalBallotsToCreateElectionDefinition`, which encapsulates that bit of logic but is agnostic to which template is used.

## Demo Video or Screenshot

## Testing Plan
Add automated tests (TODO)

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
