### PR TITLE
adjust NH template write-in box

### DIFF
--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
@@ -339,9 +339,9 @@ function CandidateContest({
               writeInIndex,
               writeInArea: {
                 top: 0.8,
-                right: -0.8,
-                bottom: 0.3,
-                left: 8.8,
+                right: -0.9,
+                bottom: 0.2,
+                left: 8.7,
               },
             };
             return (


### PR DESCRIPTION
## Overview

Adjusts the write-in box to match the default template as recommended [here](https://github.com/votingworks/vxsuite/pull/5852#discussion_r1925672705).

## Demo Video or Screenshot

This video shows the NH template as a layer on top of the default template. As I toggle the layer visibility the box has minimal difference between NH and default.

https://github.com/user-attachments/assets/0652745b-eb98-4470-b934-40fa3e82628a




## Testing Plan

Checked with `libs/hmpb` preview tool.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
