### PR TITLE
Refine VxDesign ballot order info screen

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -320,7 +320,7 @@ test('Update ballot order info', async () => {
     absenteeBallotCount: '100',
     deliveryAddress: '123 Main St, Town, NH, 00000',
     deliveryRecipientName: 'Clerky Clerkson',
-    precinctBallotColor: 'Yellow for town, white for school',
+    ballotColor: 'Yellow for town, white for school',
     precinctBallotCount: '200',
     shouldAbsenteeBallotsBeScoredForFolding: true,
   };

--- a/apps/design/backend/src/ballot_style_reports.test.ts
+++ b/apps/design/backend/src/ballot_style_reports.test.ts
@@ -53,4 +53,4 @@ test('PDF layout regression test', async () => {
   await expect(reportPdf).toMatchPdfSnapshot();
 
   await renderer.cleanup();
-});
+}, 10_000);

--- a/apps/design/backend/src/types.ts
+++ b/apps/design/backend/src/types.ts
@@ -79,18 +79,18 @@ export function convertToVxfBallotStyle(
  */
 export interface BallotOrderInfo {
   absenteeBallotCount?: string;
+  ballotColor?: string;
   deliveryAddress?: string;
   deliveryRecipientName?: string;
-  precinctBallotColor?: string;
   precinctBallotCount?: string;
   shouldAbsenteeBallotsBeScoredForFolding?: boolean;
 }
 
 export const BallotOrderInfoSchema: z.ZodType<BallotOrderInfo> = z.object({
   absenteeBallotCount: z.string().optional(),
+  ballotColor: z.string().optional(),
   deliveryAddress: z.string().optional(),
   deliveryRecipientName: z.string().optional(),
-  precinctBallotColor: z.string().optional(),
   precinctBallotCount: z.string().optional(),
   shouldAbsenteeBallotsBeScoredForFolding: z.boolean().optional(),
 });

--- a/apps/design/frontend/src/ballot_order_info_screen.test.tsx
+++ b/apps/design/frontend/src/ballot_order_info_screen.test.tsx
@@ -61,11 +61,9 @@ test('updating ballot order info', async () => {
   expect(precinctBallotCountInput).toBeDisabled();
   expect(precinctBallotCountInput).toHaveValue('');
 
-  const precinctBallotColorInput = screen.getByLabelText(
-    'Paper Color for Polling Place Ballots'
-  );
-  expect(precinctBallotColorInput).toBeDisabled();
-  expect(precinctBallotColorInput).toHaveValue('');
+  const ballotColorInput = screen.getByLabelText('Paper Color for Ballots');
+  expect(ballotColorInput).toBeDisabled();
+  expect(ballotColorInput).toHaveValue('');
 
   const deliveryRecipientNameInput = screen.getByLabelText(
     'Delivery Recipient Name'
@@ -85,7 +83,7 @@ test('updating ballot order info', async () => {
   userEvent.type(absenteeBallotCountInput, '100');
   userEvent.click(shouldAbsenteeBallotsBeScoredForFolding);
   userEvent.type(precinctBallotCountInput, '200');
-  userEvent.type(precinctBallotColorInput, 'Yellow for town, white for school');
+  userEvent.type(ballotColorInput, 'Yellow for town, white for school');
   userEvent.type(deliveryRecipientNameInput, 'Clerky Clerkson');
   userEvent.type(deliveryAddressInput, '123 Main St, Town, NH, 00000');
 
@@ -93,7 +91,7 @@ test('updating ballot order info', async () => {
     absenteeBallotCount: '100',
     shouldAbsenteeBallotsBeScoredForFolding: true,
     precinctBallotCount: '200',
-    precinctBallotColor: 'Yellow for town, white for school',
+    ballotColor: 'Yellow for town, white for school',
     deliveryRecipientName: 'Clerky Clerkson',
     deliveryAddress: '123 Main St, Town, NH, 00000',
   };
@@ -111,9 +109,7 @@ test('updating ballot order info', async () => {
   expect(absenteeBallotCountInput).toHaveValue('100');
   expect(shouldAbsenteeBallotsBeScoredForFolding).toBeChecked();
   expect(precinctBallotCountInput).toHaveValue('200');
-  expect(precinctBallotColorInput).toHaveValue(
-    'Yellow for town, white for school'
-  );
+  expect(ballotColorInput).toHaveValue('Yellow for town, white for school');
   expect(deliveryRecipientNameInput).toHaveValue('Clerky Clerkson');
   expect(deliveryAddressInput).toHaveValue('123 Main St, Town, NH, 00000');
 
@@ -123,7 +119,7 @@ test('updating ballot order info', async () => {
   userEvent.clear(absenteeBallotCountInput);
   userEvent.click(shouldAbsenteeBallotsBeScoredForFolding);
   userEvent.clear(precinctBallotCountInput);
-  userEvent.clear(precinctBallotColorInput);
+  userEvent.clear(ballotColorInput);
   userEvent.clear(deliveryRecipientNameInput);
   userEvent.clear(deliveryAddressInput);
 
@@ -131,7 +127,7 @@ test('updating ballot order info', async () => {
     absenteeBallotCount: '',
     shouldAbsenteeBallotsBeScoredForFolding: false,
     precinctBallotCount: '',
-    precinctBallotColor: '',
+    ballotColor: '',
     deliveryRecipientName: '',
     deliveryAddress: '',
   };
@@ -149,7 +145,7 @@ test('updating ballot order info', async () => {
   expect(absenteeBallotCountInput).toHaveValue('');
   expect(shouldAbsenteeBallotsBeScoredForFolding).not.toBeChecked();
   expect(precinctBallotCountInput).toHaveValue('');
-  expect(precinctBallotColorInput).toHaveValue('');
+  expect(ballotColorInput).toHaveValue('');
   expect(deliveryRecipientNameInput).toHaveValue('');
   expect(deliveryAddressInput).toHaveValue('');
 
@@ -159,7 +155,7 @@ test('updating ballot order info', async () => {
   userEvent.type(absenteeBallotCountInput, 'A');
   userEvent.click(shouldAbsenteeBallotsBeScoredForFolding);
   userEvent.type(precinctBallotCountInput, 'B');
-  userEvent.type(precinctBallotColorInput, 'C');
+  userEvent.type(ballotColorInput, 'C');
   userEvent.type(deliveryRecipientNameInput, 'D');
   userEvent.type(deliveryAddressInput, 'E');
 
@@ -168,7 +164,7 @@ test('updating ballot order info', async () => {
   expect(absenteeBallotCountInput).toHaveValue('');
   expect(shouldAbsenteeBallotsBeScoredForFolding).not.toBeChecked();
   expect(precinctBallotCountInput).toHaveValue('');
-  expect(precinctBallotColorInput).toHaveValue('');
+  expect(ballotColorInput).toHaveValue('');
   expect(deliveryRecipientNameInput).toHaveValue('');
   expect(deliveryAddressInput).toHaveValue('');
 });

--- a/apps/design/frontend/src/ballot_order_info_screen.tsx
+++ b/apps/design/frontend/src/ballot_order_info_screen.tsx
@@ -16,8 +16,22 @@ import { getElection, updateBallotOrderInfo } from './api';
 import { Form, FormActionsRow, InputGroup } from './layout';
 import { ElectionNavScreen } from './nav_screen';
 
+export const Input = styled.input`
+  width: 25rem;
+`;
+
 export const Annotation = styled.div`
+  line-height: 1.25rem;
   margin-top: -1rem;
+  width: 25rem;
+`;
+
+export const CheckboxButtonContainer = styled.div`
+  width: 25rem;
+
+  button {
+    width: 100%;
+  }
 `;
 
 function BallotOrderInfoForm({
@@ -45,7 +59,7 @@ function BallotOrderInfoForm({
   return (
     <Form>
       <InputGroup label="Number of Absentee Ballots">
-        <input
+        <Input
           type="text"
           value={ballotOrderInfo.absenteeBallotCount ?? ''}
           onChange={(e) =>
@@ -60,7 +74,7 @@ function BallotOrderInfoForm({
       <Annotation>
         <Icons.Info /> This count should include ballots needed for testing.
       </Annotation>
-      <div>
+      <CheckboxButtonContainer>
         <CheckboxButton
           label="Score Absentee Ballots for Folding"
           isChecked={Boolean(
@@ -74,9 +88,9 @@ function BallotOrderInfoForm({
           }
           disabled={!isEditing}
         />
-      </div>
+      </CheckboxButtonContainer>
       <InputGroup label="Number of Polling Place Ballots">
-        <input
+        <Input
           type="text"
           value={ballotOrderInfo.precinctBallotCount ?? ''}
           onChange={(e) =>
@@ -91,14 +105,14 @@ function BallotOrderInfoForm({
       <Annotation>
         <Icons.Info /> This count should include ballots needed for testing.
       </Annotation>
-      <InputGroup label="Paper Color for Polling Place Ballots">
-        <input
+      <InputGroup label="Paper Color for Ballots">
+        <Input
           type="text"
-          value={ballotOrderInfo.precinctBallotColor ?? ''}
+          value={ballotOrderInfo.ballotColor ?? ''}
           onChange={(e) =>
             setBallotOrderInfo({
               ...ballotOrderInfo,
-              precinctBallotColor: e.target.value,
+              ballotColor: e.target.value,
             })
           }
           disabled={!isEditing}
@@ -109,7 +123,7 @@ function BallotOrderInfoForm({
         we’ll print on white.
       </Annotation>
       <InputGroup label="Delivery Recipient Name">
-        <input
+        <Input
           type="text"
           value={ballotOrderInfo.deliveryRecipientName ?? ''}
           onChange={(e) =>
@@ -122,7 +136,7 @@ function BallotOrderInfoForm({
         />
       </InputGroup>
       <InputGroup label="Delivery Address, City, State, and ZIP">
-        <input
+        <Input
           type="text"
           value={ballotOrderInfo.deliveryAddress ?? ''}
           onChange={(e) =>

--- a/apps/design/frontend/src/ballot_order_info_screen.tsx
+++ b/apps/design/frontend/src/ballot_order_info_screen.tsx
@@ -16,22 +16,17 @@ import { getElection, updateBallotOrderInfo } from './api';
 import { Form, FormActionsRow, InputGroup } from './layout';
 import { ElectionNavScreen } from './nav_screen';
 
-export const Input = styled.input`
+export const StyledForm = styled(Form)`
   width: 25rem;
+
+  input {
+    width: 100%;
+  }
 `;
 
 export const Annotation = styled.div`
   line-height: 1.25rem;
   margin-top: -1rem;
-  width: 25rem;
-`;
-
-export const CheckboxButtonContainer = styled.div`
-  width: 25rem;
-
-  button {
-    width: 100%;
-  }
 `;
 
 function BallotOrderInfoForm({
@@ -57,9 +52,9 @@ function BallotOrderInfoForm({
   }
 
   return (
-    <Form>
+    <StyledForm>
       <InputGroup label="Number of Absentee Ballots">
-        <Input
+        <input
           type="text"
           value={ballotOrderInfo.absenteeBallotCount ?? ''}
           onChange={(e) =>
@@ -74,23 +69,21 @@ function BallotOrderInfoForm({
       <Annotation>
         <Icons.Info /> This count should include ballots needed for testing.
       </Annotation>
-      <CheckboxButtonContainer>
-        <CheckboxButton
-          label="Score Absentee Ballots for Folding"
-          isChecked={Boolean(
-            ballotOrderInfo.shouldAbsenteeBallotsBeScoredForFolding
-          )}
-          onChange={(isChecked) =>
-            setBallotOrderInfo({
-              ...ballotOrderInfo,
-              shouldAbsenteeBallotsBeScoredForFolding: isChecked,
-            })
-          }
-          disabled={!isEditing}
-        />
-      </CheckboxButtonContainer>
+      <CheckboxButton
+        label="Score Absentee Ballots for Folding"
+        isChecked={Boolean(
+          ballotOrderInfo.shouldAbsenteeBallotsBeScoredForFolding
+        )}
+        onChange={(isChecked) =>
+          setBallotOrderInfo({
+            ...ballotOrderInfo,
+            shouldAbsenteeBallotsBeScoredForFolding: isChecked,
+          })
+        }
+        disabled={!isEditing}
+      />
       <InputGroup label="Number of Polling Place Ballots">
-        <Input
+        <input
           type="text"
           value={ballotOrderInfo.precinctBallotCount ?? ''}
           onChange={(e) =>
@@ -106,7 +99,7 @@ function BallotOrderInfoForm({
         <Icons.Info /> This count should include ballots needed for testing.
       </Annotation>
       <InputGroup label="Paper Color for Ballots">
-        <Input
+        <input
           type="text"
           value={ballotOrderInfo.ballotColor ?? ''}
           onChange={(e) =>
@@ -123,7 +116,7 @@ function BallotOrderInfoForm({
         we’ll print on white.
       </Annotation>
       <InputGroup label="Delivery Recipient Name">
-        <Input
+        <input
           type="text"
           value={ballotOrderInfo.deliveryRecipientName ?? ''}
           onChange={(e) =>
@@ -136,7 +129,7 @@ function BallotOrderInfoForm({
         />
       </InputGroup>
       <InputGroup label="Delivery Address, City, State, and ZIP">
-        <Input
+        <input
           type="text"
           value={ballotOrderInfo.deliveryAddress ?? ''}
           onChange={(e) =>
@@ -179,7 +172,7 @@ function BallotOrderInfoForm({
           </Button>
         </FormActionsRow>
       )}
-    </Form>
+    </StyledForm>
   );
 }
 


### PR DESCRIPTION
## Overview

This PR refines the VxDesign ballot order info screen. It specifically:

- Better aligns inputs and helper text
- Renames the "Paper Color for Polling Place Ballots" field "Paper Color for Ballots" - the values entered into this field will be used for both precinct (polling place) and absentee ballots

| Before | After |
| - | - |
| <img width="400" alt="before" src="https://github.com/user-attachments/assets/a4f68b0e-8bd7-4a86-afac-974bd153f613" /> | <img width="400" alt="after" src="https://github.com/user-attachments/assets/9c6d3508-9a1a-467e-90ba-14455381428e" /> |

## Testing Plan

- [x] Tested manually
- [x] Updated automated tests

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates