### PR TITLE
VxDesign: Assign ballot template to each election

### DIFF
--- a/apps/design/backend/schema.sql
+++ b/apps/design/backend/schema.sql
@@ -18,6 +18,7 @@ create table elections (
   election_package_task_id text
     constraint fk_background_tasks references background_tasks(id) on delete set null,
   election_package_url text,
+  ballot_template_id text not null,
   ballots_finalized_at timestamptz
 );
 

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -43,11 +43,7 @@ import {
   mockCloudTranslatedText,
   readElectionPackageFromFile,
 } from '@votingworks/backend';
-import {
-  countObjectLeaves,
-  getObjectLeaves,
-  mockOf,
-} from '@votingworks/test-utils';
+import { countObjectLeaves, getObjectLeaves } from '@votingworks/test-utils';
 import {
   allBaseBallotProps,
   BallotMode,
@@ -1110,7 +1106,7 @@ test('setBallotTemplate changes the ballot template used to render ballots', asy
   }
 
   const props = allBaseBallotProps(electionDefinition.election);
-  mockOf(renderAllBallotsAndCreateElectionDefinition).mockResolvedValue({
+  vi.mocked(renderAllBallotsAndCreateElectionDefinition).mockResolvedValue({
     ballotDocuments: props.map(mockBallotDocument),
     electionDefinition,
   });
@@ -1125,6 +1121,6 @@ test('setBallotTemplate changes the ballot template used to render ballots', asy
     'vxf'
   );
   expect(
-    mockOf(renderAllBallotsAndCreateElectionDefinition).mock.calls[0][2]
+    vi.mocked(renderAllBallotsAndCreateElectionDefinition).mock.calls[0][2]
   ).toHaveLength(props.length);
 });

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -43,6 +43,7 @@ import {
 import { AppContext } from './context';
 import { rotateCandidates } from './candidate_rotation';
 import { renderBallotStyleReadinessReport } from './ballot_style_reports';
+import { createBallotPropsForTemplate, defaultBallotTemplate } from './ballots';
 
 export const BALLOT_STYLE_READINESS_REPORT_FILE_NAME =
   'ballot-style-readiness-report.pdf';
@@ -224,9 +225,13 @@ function buildApi({ workspace, translator }: AppContext) {
       electionId: Id;
       electionSerializationFormat: ElectionSerializationFormat;
     }): Promise<{ zipContents: Buffer; ballotHash: string }> {
-      const { election, ballotLanguageConfigs } = await store.getElection(
-        input.electionId
-      );
+      const {
+        election,
+        ballotLanguageConfigs,
+        precincts,
+        ballotStyles,
+        ballotTemplateId,
+      } = await store.getElection(input.electionId);
       const ballotStrings = await translateBallotStrings(
         translator,
         election,
@@ -237,37 +242,26 @@ function buildApi({ workspace, translator }: AppContext) {
         ...election,
         ballotStrings,
       };
-
-      const renderer = await createPlaywrightRenderer();
-
-      const ballotTypes = [BallotType.Precinct, BallotType.Absentee];
-      const ballotProps = election.ballotStyles.flatMap((ballotStyle) =>
-        ballotStyle.precincts.flatMap((precinctId) =>
-          ballotTypes.flatMap((ballotType) =>
-            BALLOT_MODES.map(
-              (ballotMode): BaseBallotProps => ({
-                election: electionWithBallotStrings,
-                ballotStyleId: ballotStyle.id,
-                precinctId,
-                ballotType,
-                ballotMode,
-              })
-            )
-          )
-        )
+      const allBallotProps = createBallotPropsForTemplate(
+        ballotTemplateId,
+        electionWithBallotStrings,
+        precincts,
+        ballotStyles
       );
-
+      const renderer = await createPlaywrightRenderer();
       const { ballotDocuments, electionDefinition } =
         await renderAllBallotsAndCreateElectionDefinition(
           renderer,
-          getTemplate(election.state),
-          ballotProps,
+          ballotTemplates[ballotTemplateId],
+          allBallotProps,
           input.electionSerializationFormat
         );
 
       const zip = new JsZip();
 
-      for (const [props, document] of iter(ballotProps).zip(ballotDocuments)) {
+      for (const [props, document] of iter(allBallotProps).zip(
+        ballotDocuments
+      )) {
         const pdf = await document.renderToPdf();
         const { precinctId, ballotStyleId, ballotType, ballotMode } = props;
         const precinct = assertDefined(
@@ -307,8 +301,13 @@ function buildApi({ workspace, translator }: AppContext) {
       ballotType: BallotType;
       ballotMode: BallotMode;
     }): Promise<Result<{ pdfData: Buffer; fileName: string }, Error>> {
-      const { election, ballotLanguageConfigs, precincts, ballotStyles } =
-        await store.getElection(input.electionId);
+      const {
+        election,
+        ballotLanguageConfigs,
+        precincts,
+        ballotStyles,
+        ballotTemplateId,
+      } = await store.getElection(input.electionId);
       const ballotStrings = await translateBallotStrings(
         translator,
         election,
@@ -319,41 +318,36 @@ function buildApi({ workspace, translator }: AppContext) {
         ...election,
         ballotStrings,
       };
-
-      const precinct = find(precincts, (p) => p.id === input.precinctId);
-      let extraProps: NhPrecinctSplitOptions = {};
-      if (hasSplits(precinct)) {
-        const ballotStyle = find(
-          ballotStyles,
-          (bs) => bs.id === input.ballotStyleId
-        );
-        const { splitId } = find(
-          ballotStyle.precinctsOrSplits,
-          (p) => p.precinctId === input.precinctId
-        );
-        const split = find(precinct.splits, (s) => s.id === splitId);
-        extraProps = {
-          electionTitleOverride: split.electionTitleOverride,
-          clerkSignatureImage: split.clerkSignatureImage,
-          clerkSignatureCaption: split.clerkSignatureCaption,
-        };
-      }
-
+      const allBallotProps = createBallotPropsForTemplate(
+        ballotTemplateId,
+        electionWithBallotStrings,
+        precincts,
+        ballotStyles
+      );
+      const ballotProps = find(
+        allBallotProps,
+        (props) =>
+          props.precinctId === input.precinctId &&
+          props.ballotStyleId === input.ballotStyleId &&
+          props.ballotType === input.ballotType &&
+          props.ballotMode === input.ballotMode
+      );
       const renderer = await createPlaywrightRenderer();
       const ballotPdf = await renderBallotPreviewToPdf(
         renderer,
-        getTemplate(election.state),
-        {
-          ...input,
-          ...extraProps,
-          election: electionWithBallotStrings,
-          // NOTE: Changing this text means you should also change the font size
-          // of the <Watermark> component in the ballot template.
-          watermark: 'PROOF',
-        }
+        ballotTemplates[ballotTemplateId],
+        // NOTE: Changing this text means you should also change the font size
+        // of the <Watermark> component in the ballot template.
+
+        { ...ballotProps, watermark: 'PROOF' }
       );
       // eslint-disable-next-line no-console
       renderer.cleanup().catch(console.error);
+
+      const precinct = find(
+        election.precincts,
+        (p) => p.id === input.precinctId
+      );
       return ok({
         pdfData: ballotPdf,
         fileName: `PROOF-${getPdfFileName(
@@ -390,9 +384,13 @@ function buildApi({ workspace, translator }: AppContext) {
       electionId: Id;
       electionSerializationFormat: ElectionSerializationFormat;
     }): Promise<{ zipContents: Buffer; ballotHash: string }> {
-      const { election, ballotLanguageConfigs } = await store.getElection(
-        input.electionId
-      );
+      const {
+        election,
+        ballotLanguageConfigs,
+        precincts,
+        ballotStyles,
+        ballotTemplateId,
+      } = await store.getElection(input.electionId);
       const ballotStrings = await translateBallotStrings(
         translator,
         election,
@@ -403,26 +401,26 @@ function buildApi({ workspace, translator }: AppContext) {
         ...election,
         ballotStrings,
       };
-      const allBallotProps = election.ballotStyles.flatMap((ballotStyle) =>
-        ballotStyle.precincts.map(
-          (precinctId): BaseBallotProps => ({
-            election: electionWithBallotStrings,
-            ballotStyleId: ballotStyle.id,
-            precinctId,
-            ballotType: BallotType.Precinct,
-            ballotMode: 'test',
-          })
-        )
+      const allBallotProps = createBallotPropsForTemplate(
+        ballotTemplateId,
+        electionWithBallotStrings,
+        precincts,
+        ballotStyles
+      );
+      const testBallotProps = allBallotProps.filter(
+        (props) =>
+          props.ballotMode === 'test' &&
+          props.ballotType === BallotType.Precinct
       );
       const renderer = await createPlaywrightRenderer();
       const { electionDefinition, ballotDocuments } =
         await renderAllBallotsAndCreateElectionDefinition(
           renderer,
-          getTemplate(election.state),
-          allBallotProps,
+          ballotTemplates[ballotTemplateId],
+          testBallotProps,
           input.electionSerializationFormat
         );
-      const ballots = iter(allBallotProps)
+      const ballots = iter(testBallotProps)
         .zip(ballotDocuments)
         .map(([props, document]) => ({
           props,

--- a/apps/design/backend/src/ballots.ts
+++ b/apps/design/backend/src/ballots.ts
@@ -73,6 +73,7 @@ export function createBallotPropsForTemplate(
       return baseBallotProps;
 
     default:
+      /* istanbul ignore next - @preserve */
       throwIllegalValue(templateId);
   }
 }

--- a/apps/design/backend/src/ballots.ts
+++ b/apps/design/backend/src/ballots.ts
@@ -72,8 +72,9 @@ export function createBallotPropsForTemplate(
     case 'VxDefaultBallot':
       return baseBallotProps;
 
-    default:
+    default: {
       /* istanbul ignore next - @preserve */
       throwIllegalValue(templateId);
+    }
   }
 }

--- a/apps/design/backend/src/ballots.ts
+++ b/apps/design/backend/src/ballots.ts
@@ -1,0 +1,78 @@
+import { Election } from '@votingworks/types';
+import {
+  allBaseBallotProps,
+  BallotTemplateId,
+  BaseBallotProps,
+  NhBallotProps,
+} from '@votingworks/hmpb';
+import { find, throwIllegalValue } from '@votingworks/basics';
+import {
+  BallotStyle,
+  hasSplits,
+  normalizeState,
+  Precinct,
+  PrecinctSplit,
+  PrecinctWithSplits,
+  UsState,
+} from './types';
+
+function getPrecinctSplitForBallotStyle(
+  precinct: PrecinctWithSplits,
+  ballotStyle: BallotStyle
+): PrecinctSplit {
+  return find(precinct.splits, (split) =>
+    ballotStyle.precinctsOrSplits.some(
+      (precinctOrSplit) =>
+        precinctOrSplit.precinctId === precinct.id &&
+        precinctOrSplit.splitId === split.id
+    )
+  );
+}
+
+export function defaultBallotTemplate(state: string): BallotTemplateId {
+  switch (normalizeState(state)) {
+    case UsState.NEW_HAMPSHIRE:
+      return 'NhBallot';
+    case UsState.MISSISSIPPI:
+    case UsState.UNKNOWN:
+    default:
+      return 'VxDefaultBallot';
+  }
+}
+
+export function createBallotPropsForTemplate(
+  templateId: BallotTemplateId,
+  election: Election,
+  precincts: Precinct[],
+  ballotStyles: BallotStyle[]
+): BaseBallotProps[] {
+  const baseBallotProps = allBaseBallotProps(election);
+  switch (templateId) {
+    case 'NhBallot':
+    case 'NhBallotV3': {
+      return baseBallotProps.map((props): NhBallotProps => {
+        const precinct = find(precincts, (p) => p.id === props.precinctId);
+        if (!hasSplits(precinct)) {
+          return props;
+        }
+        const ballotStyle = find(
+          ballotStyles,
+          (bs) => bs.id === props.ballotStyleId
+        );
+        const split = getPrecinctSplitForBallotStyle(precinct, ballotStyle);
+        return {
+          ...props,
+          electionTitleOverride: split.electionTitleOverride,
+          clerkSignatureImage: split.clerkSignatureImage,
+          clerkSignatureCaption: split.clerkSignatureCaption,
+        };
+      });
+    }
+
+    case 'VxDefaultBallot':
+      return baseBallotProps;
+
+    default:
+      throwIllegalValue(templateId);
+  }
+}

--- a/apps/design/backend/src/index.ts
+++ b/apps/design/backend/src/index.ts
@@ -20,6 +20,7 @@ export type {
 } from './types';
 export type { Api } from './app';
 export type { BallotMode } from '@votingworks/hmpb';
+export type { BallotTemplateId } from '@votingworks/hmpb';
 
 // Frontend tests import these for generating test data
 export { generateBallotStyles } from './ballot_styles';

--- a/apps/design/backend/src/test_decks.test.ts
+++ b/apps/design/backend/src/test_decks.test.ts
@@ -2,12 +2,12 @@ import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
 import { readElection } from '@votingworks/fs';
 import {
   Renderer,
+  ballotTemplates,
   createPlaywrightRenderer,
   famousNamesFixtures,
   generalElectionFixtures,
   primaryElectionFixtures,
   renderAllBallotsAndCreateElectionDefinition,
-  vxDefaultBallotTemplate,
 } from '@votingworks/hmpb';
 import { assert, find, iter } from '@votingworks/basics';
 import {
@@ -45,7 +45,7 @@ describe('createPrecinctTestDeck', () => {
     const { ballotDocuments } =
       await renderAllBallotsAndCreateElectionDefinition(
         renderer,
-        vxDefaultBallotTemplate,
+        ballotTemplates.VxDefaultBallot,
         fixtures.allBallotProps,
         'vxf'
       );
@@ -87,7 +87,7 @@ describe('createPrecinctTestDeck', () => {
     const { ballotDocuments } =
       await renderAllBallotsAndCreateElectionDefinition(
         renderer,
-        vxDefaultBallotTemplate,
+        ballotTemplates.VxDefaultBallot,
         fixtures.allBallotProps,
         'vxf'
       );

--- a/apps/design/backend/src/types.test.ts
+++ b/apps/design/backend/src/types.test.ts
@@ -1,11 +1,11 @@
-import { expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import {
   BallotStyle as VxfBallotStyle,
   DistrictId,
   PartyId,
   LanguageCode,
 } from '@votingworks/types';
-import { convertToVxfBallotStyle } from './types';
+import { convertToVxfBallotStyle, normalizeState, UsState } from './types';
 
 const { ENGLISH, SPANISH } = LanguageCode;
 
@@ -50,5 +50,26 @@ test('convertToVxfBallotStyle()', () => {
     groupId: '2' as VxfBallotStyle['groupId'],
     precincts: ['precinct1'],
     languages: [SPANISH],
+  });
+});
+
+describe('normalizeState', () => {
+  test.each([
+    {
+      input: ['nh', 'NH', 'New Hampshire', 'NEW HAMPSHIRE'],
+      expectedState: UsState.NEW_HAMPSHIRE,
+    },
+    {
+      input: ['ms', 'MS', 'Mississippi', 'MISSISSIPPI'],
+      expectedState: UsState.MISSISSIPPI,
+    },
+    {
+      input: ['State of Hamilton'],
+      expectedState: UsState.UNKNOWN,
+    },
+  ])('normalizes state string: $state', ({ input, expectedState }) => {
+    for (const state of input) {
+      expect(normalizeState(state)).toEqual(expectedState);
+    }
   });
 });

--- a/apps/design/backend/src/types.test.ts
+++ b/apps/design/backend/src/types.test.ts
@@ -67,7 +67,7 @@ describe('normalizeState', () => {
       input: ['State of Hamilton'],
       expectedState: UsState.UNKNOWN,
     },
-  ])('normalizes state string: $state', ({ input, expectedState }) => {
+  ])('normalizes state string: $expectedState', ({ input, expectedState }) => {
     for (const state of input) {
       expect(normalizeState(state)).toEqual(expectedState);
     }

--- a/apps/design/backend/src/types.ts
+++ b/apps/design/backend/src/types.ts
@@ -1,5 +1,4 @@
 import z from 'zod';
-import { NhPrecinctSplitOptions } from '@votingworks/hmpb';
 import {
   BallotStyle as VxfBallotStyle,
   BallotStyleId,
@@ -10,6 +9,7 @@ import {
   BallotStyleGroupId,
   LanguageCode,
 } from '@votingworks/types';
+import { NhPrecinctSplitOptions } from '@votingworks/hmpb';
 
 // We create new types for precincts that can be split, since the existing
 // election types don't support this. We will likely want to extend the existing
@@ -94,3 +94,22 @@ export const BallotOrderInfoSchema: z.ZodType<BallotOrderInfo> = z.object({
   precinctBallotCount: z.string().optional(),
   shouldAbsenteeBallotsBeScoredForFolding: z.boolean().optional(),
 });
+
+export enum UsState {
+  NEW_HAMPSHIRE = 'New Hampshire',
+  MISSISSIPPI = 'Mississippi',
+  UNKNOWN = 'Unknown',
+}
+
+export function normalizeState(state: string): UsState {
+  switch (state.toLowerCase()) {
+    case 'nh':
+    case 'new hampshire':
+      return UsState.NEW_HAMPSHIRE;
+    case 'ms':
+    case 'mississippi':
+      return UsState.MISSISSIPPI;
+    default:
+      return UsState.UNKNOWN;
+  }
+}

--- a/apps/design/backend/vitest.config.ts
+++ b/apps/design/backend/vitest.config.ts
@@ -7,8 +7,8 @@ export default defineConfig({
     clearMocks: true,
     coverage: {
       thresholds: {
-        lines: 88,
-        branches: 80,
+        lines: 92,
+        branches: 83,
       },
     },
     alias: [

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -256,3 +256,15 @@ export const exportTestDecks = {
     return useMutation(apiClient.exportTestDecks);
   },
 } as const;
+
+export const setBallotTemplate = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.setBallotTemplate, {
+      async onSuccess(_, { electionId }) {
+        await queryClient.invalidateQueries(getElection.queryKey(electionId));
+      },
+    });
+  },
+} as const;

--- a/apps/design/frontend/src/export_screen.tsx
+++ b/apps/design/frontend/src/export_screen.tsx
@@ -9,6 +9,7 @@ import {
   LoadingButton,
   Icons,
   CheckboxButton,
+  SearchSelect,
 } from '@votingworks/ui';
 import fileDownload from 'js-file-download';
 import { useParams } from 'react-router-dom';
@@ -17,23 +18,35 @@ import {
   formatBallotHash,
 } from '@votingworks/types';
 import { assertDefined } from '@votingworks/basics';
+import type { BallotTemplateId } from '@votingworks/design-backend';
 import {
   exportAllBallots,
   exportElectionPackage,
   exportTestDecks,
+  getElection,
   getElectionPackage,
+  setBallotTemplate,
 } from './api';
 import { ElectionNavScreen } from './nav_screen';
 import { ElectionIdParams } from './routes';
 import { downloadFile } from './utils';
+import { InputGroup } from './layout';
+
+const ballotTemplateOptions = {
+  VxDefaultBallot: 'VotingWorks Default Ballot',
+  NhBallot: 'New Hampshire Ballot - V4',
+  NhBallotV3: 'New Hampshire Ballot - V3',
+} satisfies Record<BallotTemplateId, string>;
 
 export function ExportScreen(): JSX.Element | null {
   const { electionId } = useParams<ElectionIdParams>();
+  const getElectionQuery = getElection.useQuery(electionId);
 
   const electionPackageQuery = getElectionPackage.useQuery(electionId);
   const exportAllBallotsMutation = exportAllBallots.useMutation();
   const exportElectionPackageMutation = exportElectionPackage.useMutation();
   const exportTestDecksMutation = exportTestDecks.useMutation();
+  const setBallotTemplateMutation = setBallotTemplate.useMutation();
 
   const [electionSerializationFormat, setElectionSerializationFormat] =
     useState<ElectionSerializationFormat>('vxf');
@@ -150,6 +163,23 @@ export function ExportScreen(): JSX.Element | null {
               setElectionSerializationFormat(isChecked ? 'cdf' : 'vxf')
             }
           />
+        </P>
+
+        <P>
+          <InputGroup label="Ballot Template">
+            <SearchSelect
+              value={getElectionQuery.data?.ballotTemplateId}
+              options={Object.entries(ballotTemplateOptions).map(
+                ([value, label]) => ({ value, label })
+              )}
+              onChange={(value) => {
+                setBallotTemplateMutation.mutate({
+                  electionId,
+                  ballotTemplateId: value as BallotTemplateId,
+                });
+              }}
+            />
+          </InputGroup>
         </P>
       </MainContent>
     </ElectionNavScreen>

--- a/apps/design/frontend/test/fixtures.ts
+++ b/apps/design/frontend/test/fixtures.ts
@@ -47,6 +47,7 @@ export function makeElectionRecord(baseElection: Election): ElectionRecord {
     ballotStyles,
     createdAt: new Date().toISOString(),
     ballotLanguageConfigs,
+    ballotTemplateId: 'VxDefaultBallot',
   };
 }
 

--- a/libs/fixture-generators/src/generate-election-package/generate_election_package.test.ts
+++ b/libs/fixture-generators/src/generate-election-package/generate_election_package.test.ts
@@ -16,9 +16,11 @@ import {
 } from '@votingworks/types';
 import {
   Renderer,
-  createElectionDefinitionForDefaultHmpbTemplate,
+  allBaseBallotProps,
+  ballotTemplates,
   createPlaywrightRenderer,
   hmpbStringsCatalog,
+  renderMinimalBallotsToCreateElectionDefinition,
 } from '@votingworks/hmpb';
 import { GoogleCloudTranslatorWithElectionCache } from './translator_with_election_cache';
 
@@ -90,9 +92,10 @@ describe('fixtures are up to date - run `pnpm generate-election-packages` if thi
 
       // Check that the generated election's ballot hash has not changed.
       const electionDefinition =
-        await createElectionDefinitionForDefaultHmpbTemplate(
+        await renderMinimalBallotsToCreateElectionDefinition(
           renderer,
-          electionWithBallotStrings,
+          ballotTemplates.VxDefaultBallot,
+          allBaseBallotProps(electionWithBallotStrings),
           'vxf'
         );
       expect(electionDefinition.ballotHash).toEqual(

--- a/libs/fixture-generators/src/generate-election-package/generate_election_package.ts
+++ b/libs/fixture-generators/src/generate-election-package/generate_election_package.ts
@@ -3,9 +3,11 @@ import {
   getAllStringsForElectionPackage,
 } from '@votingworks/backend';
 import {
-  createElectionDefinitionForDefaultHmpbTemplate,
+  allBaseBallotProps,
+  ballotTemplates,
   createPlaywrightRenderer,
   hmpbStringsCatalog,
+  renderMinimalBallotsToCreateElectionDefinition,
 } from '@votingworks/hmpb';
 import {
   DEFAULT_SYSTEM_SETTINGS,
@@ -72,11 +74,11 @@ export async function generateElectionPackage(
     ...election,
     ballotStrings,
   };
-
   const electionDefinition =
-    await createElectionDefinitionForDefaultHmpbTemplate(
+    await renderMinimalBallotsToCreateElectionDefinition(
       renderer,
-      electionWithBallotStrings,
+      ballotTemplates.VxDefaultBallot,
+      allBaseBallotProps(electionWithBallotStrings),
       'vxf'
     );
 

--- a/libs/hmpb/src/ballot_templates/index.ts
+++ b/libs/hmpb/src/ballot_templates/index.ts
@@ -1,0 +1,22 @@
+import { nhBallotTemplate } from './nh_ballot_template';
+import { nhBallotTemplateV3 } from './v3_nh_ballot_template';
+import { vxDefaultBallotTemplate } from './vx_default_ballot_template';
+
+export type {
+  NhBallotProps,
+  NhPrecinctSplitOptions,
+} from './nh_ballot_template';
+
+/**
+ * All ballot templates, indexed by ID.
+ */
+export const ballotTemplates = {
+  VxDefaultBallot: vxDefaultBallotTemplate,
+  NhBallot: nhBallotTemplate,
+  NhBallotV3: nhBallotTemplateV3,
+} as const;
+
+/**
+ * The ID of a ballot template.
+ */
+export type BallotTemplateId = keyof typeof ballotTemplates;

--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
@@ -11,8 +11,6 @@ import {
   BallotType,
   CandidateContest as CandidateContestStruct,
   Election,
-  ElectionDefinition,
-  ElectionSerializationFormat,
   YesNoContest,
   ballotPaperDimensions,
   getBallotStyle,
@@ -29,9 +27,8 @@ import {
   BallotPageTemplate,
   BaseBallotProps,
   PagedElementResult,
-  renderAllBallotsAndCreateElectionDefinition,
 } from '../render_ballot';
-import { Renderer, RenderScratchpad } from '../renderer';
+import { RenderScratchpad } from '../renderer';
 import {
   Bubble,
   OptionInfo,
@@ -625,31 +622,3 @@ export const nhBallotTemplate: BallotPageTemplate<NhBallotProps> = {
   frameComponent: BallotPageFrame,
   contentComponent: BallotPageContent,
 };
-
-/**
- * Helper function that renders ballots and generates an election definition for a
- * New Hampshire town hmpb ballot layout.
- */
-export async function createElectionDefinitionForNhTownHmpbTemplate(
-  renderer: Renderer,
-  election: Election,
-  electionSerializationFormat: ElectionSerializationFormat
-): Promise<ElectionDefinition> {
-  const { electionDefinition } =
-    await renderAllBallotsAndCreateElectionDefinition(
-      renderer,
-      nhBallotTemplate,
-      // Each ballot style will have exactly one grid layout regardless of precinct, ballot type, or ballot mode
-      // So we just need to render a single ballot per ballot style to create the election definition
-      election.ballotStyles.map((ballotStyle) => ({
-        election,
-        ballotStyleId: ballotStyle.id,
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        precinctId: ballotStyle.precincts[0]!,
-        ballotType: BallotType.Precinct,
-        ballotMode: 'test',
-      })),
-      electionSerializationFormat
-    );
-  return electionDefinition;
-}

--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
@@ -619,7 +619,9 @@ async function BallotPageContent(
   };
 }
 
-export const nhBallotTemplate: BallotPageTemplate<BaseBallotProps> = {
+export type NhBallotProps = BaseBallotProps & NhPrecinctSplitOptions;
+
+export const nhBallotTemplate: BallotPageTemplate<NhBallotProps> = {
   frameComponent: BallotPageFrame,
   contentComponent: BallotPageContent,
 };

--- a/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
@@ -49,7 +49,7 @@ import {
 import { BallotMode, PixelDimensions } from '../types';
 import { hmpbStrings } from '../hmpb_strings';
 import { layOutInColumns } from '../layout_in_columns';
-import { NhPrecinctSplitOptions } from './nh_ballot_template';
+import { NhBallotProps, NhPrecinctSplitOptions } from './nh_ballot_template';
 
 const Colors = {
   BLACK: '#000000',
@@ -793,11 +793,9 @@ async function BallotPageContent(
   };
 }
 
-interface BallotPageTemplateV3 extends BallotPageTemplate<BaseBallotProps> {
+export const nhBallotTemplateV3: BallotPageTemplate<NhBallotProps> & {
   machineVersion: 'v3';
-}
-
-export const v3NhTownBallotTemplate: BallotPageTemplateV3 = {
+} = {
   frameComponent: BallotPageFrame,
   contentComponent: BallotPageContent,
   machineVersion: 'v3',

--- a/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
@@ -12,8 +12,6 @@ import {
   BallotType,
   CandidateContest as CandidateContestStruct,
   Election,
-  ElectionDefinition,
-  ElectionSerializationFormat,
   YesNoContest,
   ballotPaperDimensions,
   getBallotStyle,
@@ -30,9 +28,8 @@ import {
   BallotPageTemplate,
   BaseBallotProps,
   PagedElementResult,
-  renderAllBallotsAndCreateElectionDefinition,
 } from '../render_ballot';
-import { Renderer, RenderScratchpad } from '../renderer';
+import { RenderScratchpad } from '../renderer';
 import {
   Bubble,
   OptionInfo,
@@ -587,31 +584,3 @@ export const vxDefaultBallotTemplate: BallotPageTemplate<BaseBallotProps> = {
   frameComponent: BallotPageFrame,
   contentComponent: BallotPageContent,
 };
-
-/**
- * Helper function that renders ballots and generates an election definition for the standard
- * VxSuite hmpb ballot layout.
- */
-export async function createElectionDefinitionForDefaultHmpbTemplate(
-  renderer: Renderer,
-  election: Election,
-  electionSerializationFormat: ElectionSerializationFormat
-): Promise<ElectionDefinition> {
-  const { electionDefinition } =
-    await renderAllBallotsAndCreateElectionDefinition(
-      renderer,
-      vxDefaultBallotTemplate,
-      // Each ballot style will have exactly one grid layout regardless of precinct, ballot type, or ballot mode
-      // So we just need to render a single ballot per ballot style to create the election definition
-      election.ballotStyles.map((ballotStyle) => ({
-        election,
-        ballotStyleId: ballotStyle.id,
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        precinctId: ballotStyle.precincts[0]!,
-        ballotType: BallotType.Precinct,
-        ballotMode: 'test',
-      })),
-      electionSerializationFormat
-    );
-  return electionDefinition;
-}

--- a/libs/hmpb/src/index.ts
+++ b/libs/hmpb/src/index.ts
@@ -6,7 +6,5 @@ export * from './mark_ballot';
 export * from './playwright_renderer';
 export * from './render_ballot';
 export * from './renderer';
-export * from './ballot_templates/nh_ballot_template';
-export * from './ballot_templates/v3_nh_ballot_template';
-export * from './ballot_templates/vx_default_ballot_template';
+export * from './ballot_templates';
 export * from './types';

--- a/libs/hmpb/src/render_ballot.test.tsx
+++ b/libs/hmpb/src/render_ballot.test.tsx
@@ -1,0 +1,66 @@
+import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import { test, expect } from 'vitest';
+import { BallotType } from '@votingworks/types';
+import {
+  allBaseBallotProps,
+  BaseBallotProps,
+  renderMinimalBallotsToCreateElectionDefinition,
+} from './render_ballot';
+import { BALLOT_MODES } from './types';
+import { createPlaywrightRenderer } from './playwright_renderer';
+import { ballotTemplates } from './ballot_templates';
+
+function combinations<T extends Record<string, unknown>>(
+  arrays: Array<Array<Partial<T>>>
+): T[] {
+  return arrays.reduce(
+    (acc, array) =>
+      acc.flatMap((accItem) =>
+        array.map((arrayItem) => ({ ...accItem, ...arrayItem }))
+      ),
+    [{}]
+  ) as T[];
+}
+
+test('allBaseBallotProps creates props all possible ballots for an election', () => {
+  const election = electionFamousNames2021Fixtures.readElection();
+  const allBallotProps = allBaseBallotProps(election);
+  const expectedPropCombos = combinations<
+    Pick<
+      BaseBallotProps,
+      'ballotStyleId' | 'precinctId' | 'ballotType' | 'ballotMode'
+    >
+  >([
+    election.ballotStyles.flatMap((ballotStyle) =>
+      ballotStyle.precincts.map((precinctId) => ({
+        ballotStyleId: ballotStyle.id,
+        precinctId,
+      }))
+    ),
+    [{ ballotType: BallotType.Absentee }, { ballotType: BallotType.Precinct }],
+    BALLOT_MODES.map((ballotMode) => ({ ballotMode })),
+  ]);
+  expect(allBallotProps).toHaveLength(expectedPropCombos.length);
+  for (const expectedPropCombo of expectedPropCombos) {
+    const expectedProps: BaseBallotProps = { ...expectedPropCombo, election };
+    expect(allBallotProps).toContainEqual(expectedProps);
+  }
+  for (const actualProps of allBallotProps) {
+    expect(actualProps.watermark).toBeUndefined();
+  }
+});
+
+test('renderMinimalBallotsToCreateElectionDefinition', async () => {
+  const fixtureElectionDefinition =
+    electionFamousNames2021Fixtures.readElectionDefinition();
+  const allBallotProps = allBaseBallotProps(fixtureElectionDefinition.election);
+  const renderer = await createPlaywrightRenderer();
+  const electionDefinition =
+    await renderMinimalBallotsToCreateElectionDefinition(
+      renderer,
+      ballotTemplates.VxDefaultBallot,
+      allBallotProps,
+      'vxf'
+    );
+  expect(electionDefinition).toEqual(fixtureElectionDefinition);
+});

--- a/libs/hmpb/src/render_ballot.test.tsx
+++ b/libs/hmpb/src/render_ballot.test.tsx
@@ -40,6 +40,18 @@ test('allBaseBallotProps creates props all possible ballots for an election', ()
     [{ ballotType: BallotType.Absentee }, { ballotType: BallotType.Precinct }],
     BALLOT_MODES.map((ballotMode) => ({ ballotMode })),
   ]);
+
+  const someBallotStyle = election.ballotStyles[0];
+  const somePrecinctId = someBallotStyle.precincts[0];
+
+  expect(allBallotProps).toContainEqual({
+    election,
+    ballotStyleId: someBallotStyle.id,
+    precinctId: somePrecinctId,
+    ballotType: BallotType.Precinct,
+    ballotMode: 'official',
+  });
+
   expect(allBallotProps).toHaveLength(expectedPropCombos.length);
   for (const expectedPropCombo of expectedPropCombos) {
     const expectedProps: BaseBallotProps = { ...expectedPropCombo, election };

--- a/libs/hmpb/src/render_ballot.test.tsx
+++ b/libs/hmpb/src/render_ballot.test.tsx
@@ -22,7 +22,7 @@ function combinations<T extends Record<string, unknown>>(
   ) as T[];
 }
 
-test('allBaseBallotProps creates props all possible ballots for an election', () => {
+test('allBaseBallotProps creates props for all possible ballots for an election', () => {
   const election = electionFamousNames2021Fixtures.readElection();
   const allBallotProps = allBaseBallotProps(election);
   const expectedPropCombos = combinations<

--- a/libs/hmpb/vitest.config.ts
+++ b/libs/hmpb/vitest.config.ts
@@ -5,8 +5,8 @@ export default defineConfig({
     setupFiles: ['test/setupTests.ts'],
     coverage: {
       thresholds: {
-        lines: 68,
-        branches: 74,
+        lines: 87,
+        branches: 79,
       },
       exclude: [
         // tested by src/preview.test.ts, but no coverage is collected


### PR DESCRIPTION
## Overview

Task: https://github.com/votingworks/vxsuite/issues/5702

To support towns that require a v3-compatible ballot vs a v4 ballot, adds a ballot template id field to the election in the database. We default all new elections to the NH ballot template. When loading an election, we pick a template based on the `Election.state` field. Internal VX users can change the template for an election via a dropdown on the Export screen (temporarily placed there until we have internal tools).

## Demo Video or Screenshot


https://github.com/user-attachments/assets/412ad5fc-98e9-43c5-abb4-d1f8da64a820



## Testing Plan
Updated existing automated tests


## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
