### PR TITLE
move shared components to ballot_components.tsx

### DIFF
--- a/libs/hmpb/src/all_bubble_ballot_fixtures.tsx
+++ b/libs/hmpb/src/all_bubble_ballot_fixtures.tsx
@@ -18,6 +18,7 @@ import makeDebug from 'debug';
 import { Buffer } from 'node:buffer';
 import {
   Bubble,
+  Footer,
   Page,
   TimingMarkGrid,
   pageMarginsInches,
@@ -28,7 +29,6 @@ import {
   PagedElementResult,
   renderAllBallotsAndCreateElectionDefinition,
 } from './render_ballot';
-import { Footer } from './ballot_templates/vx_default_ballot_template';
 import { RenderScratchpad, Renderer } from './renderer';
 import { PixelDimensions } from './types';
 import { markBallotDocument } from './mark_ballot';

--- a/libs/hmpb/src/ballot_components.tsx
+++ b/libs/hmpb/src/ballot_components.tsx
@@ -226,18 +226,17 @@ export function Bubble({
 
 export function BubbleWrapper({
   optionInfo,
-  isWriteIn,
+  style = {},
 }: {
   optionInfo: OptionInfo;
-  isWriteIn?: boolean;
+  style: React.CSSProperties;
 }): React.ReactElement {
   return (
     <div
       style={{
         display: 'flex',
         alignItems: 'center',
-        // Match line-height of text to align bubble to center of first line of option label or write-in candidate name
-        height: isWriteIn ? '1.25rem' : '1.2rem',
+        ...style,
       }}
     >
       <Bubble optionInfo={optionInfo} />

--- a/libs/hmpb/src/ballot_components.tsx
+++ b/libs/hmpb/src/ballot_components.tsx
@@ -1,8 +1,25 @@
 import styled from 'styled-components';
 import React from 'react';
-import { BALLOT_HASH_DISPLAY_LENGTH, Outset } from '@votingworks/types';
-import { range } from '@votingworks/basics';
+import {
+  BALLOT_HASH_DISPLAY_LENGTH,
+  BallotStyle,
+  BallotStyleId,
+  Election,
+  getBallotStyle,
+  getPrecinctById,
+  Outset,
+  PrecinctId,
+} from '@votingworks/types';
+import { assertDefined, range, unique } from '@votingworks/basics';
+import { InEnglish, useLanguageContext } from '@votingworks/ui';
+import { format } from '@votingworks/utils';
 import { InchDimensions, InchMargins } from './types';
+import { hmpbStrings } from './hmpb_strings';
+import {
+  ArrowRightCircle,
+  InstructionsDiagramFillBubble,
+  InstructionsDiagramWriteIn,
+} from './svg_assets';
 
 /**
  * Include 5mm margins by default to create room for an imprinting ID
@@ -14,6 +31,17 @@ export const pageMarginsInches = {
   right: 0.19685, // 5mm
   left: 0.19685, // 5mm
 } as const;
+
+export const Colors = {
+  BLACK: '#000000',
+  LIGHT_GRAY: '#EDEDED',
+  DARK_GRAY: '#DADADA',
+  DARKER_GRAY: '#B0B0B0',
+} as const;
+
+export function primaryLanguageCode(ballotStyle: BallotStyle): string {
+  return ballotStyle.languages?.[0] ?? 'en';
+}
 
 export const TIMING_MARK_DIMENSIONS: InchDimensions = {
   width: 0.1875,
@@ -196,6 +224,27 @@ export function Bubble({
   );
 }
 
+export function BubbleWrapper({
+  optionInfo,
+  isWriteIn,
+}: {
+  optionInfo: OptionInfo;
+  isWriteIn?: boolean;
+}): React.ReactElement {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        // Match line-height of text to align bubble to center of first line of option label or write-in candidate name
+        height: isWriteIn ? '1.25rem' : '1.2rem',
+      }}
+    >
+      <Bubble optionInfo={optionInfo} />
+    </div>
+  );
+}
+
 export const WRITE_IN_OPTION_CLASS = 'write-in-option';
 
 export const MARK_OVERLAY_CLASS = 'mark-overlay';
@@ -254,3 +303,306 @@ export function Page({
     </div>
   );
 }
+
+/**
+ * Flex row that adds delimiters between each child element. However, if a child
+ * element wraps to the next line, omits the delimiter before that element.
+ */
+const DelimitedOrWrapped = styled.div<{ delimiter: string }>`
+  display: flex;
+  flex-wrap: wrap;
+  /* Hide the overflow of the container so that a child's delimiter is hidden if
+   * the child is at the beginning of a line */
+  overflow: hidden;
+  position: relative;
+
+  /* Add delimiter before each child */
+  > *:before {
+    content: '${(p) => p.delimiter}';
+    /* Absolute position takes it out of the flow so it can overflow to the left
+     * of the container */
+    position: absolute;
+    margin-left: -0.8em;
+    /* Use a fixed width that's based on the font size of the children */
+    width: 0.8em;
+    text-align: center;
+  }
+  /* Create a space between the children for the delimiter to go */
+  > *:not(:last-child) {
+    margin-right: 0.8em;
+  }
+`;
+
+/**
+ * Must be rendered within a LanguageContext
+ */
+export function DualLanguageText({
+  children,
+  delimiter,
+}: {
+  children: React.ReactNode;
+  delimiter?: string;
+}): React.ReactNode {
+  const languageContext = useLanguageContext();
+  if (!languageContext || languageContext.currentLanguageCode === 'en') {
+    return children;
+  }
+
+  const text = (
+    <React.Fragment>
+      {children}
+      <InEnglish>{children}</InEnglish>
+    </React.Fragment>
+  );
+
+  if (delimiter) {
+    return (
+      <DelimitedOrWrapped delimiter={delimiter}>{text}</DelimitedOrWrapped>
+    );
+  }
+  return text;
+}
+
+export function BlankPageMessage(): React.ReactElement {
+  return (
+    <div
+      style={{
+        height: '100%',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}
+    >
+      <div style={{ textAlign: 'center' }}>
+        <DualLanguageText>
+          <h1>{hmpbStrings.hmpbPageIntentionallyBlank}</h1>
+        </DualLanguageText>
+      </div>
+    </div>
+  );
+}
+
+export const Box = styled.div<{ fill?: 'transparent' | 'tinted' }>`
+  border: 1px solid ${Colors.BLACK};
+  border-top-width: 3px;
+  padding: 0.75rem;
+  background-color: ${(p) =>
+    p.fill === 'tinted' ? Colors.LIGHT_GRAY : 'none'};
+`;
+
+export function WriteInLabel(): React.ReactElement {
+  return (
+    <span>
+      <DualLanguageText delimiter="/">
+        {hmpbStrings.hmpbWriteIn}
+      </DualLanguageText>
+    </span>
+  );
+}
+
+export function Instructions({
+  languageCode,
+}: {
+  languageCode?: string;
+}): React.ReactElement {
+  // To minimize vertical space used, we do a slightly different layout for
+  // English-only vs bilingual ballots.
+  if (!languageCode || languageCode === 'en') {
+    return (
+      <Box
+        fill="tinted"
+        style={{
+          padding: '0.5rem 0.5rem',
+          display: 'grid',
+          gap: '0.125rem 0.75rem',
+          gridTemplateColumns: '1fr 7rem 1.8fr 8rem',
+        }}
+      >
+        <div>
+          <h2>{hmpbStrings.hmpbInstructions}</h2>
+          <h4>{hmpbStrings.hmpbInstructionsToVoteTitle}</h4>
+          <div>{hmpbStrings.hmpbInstructionsToVoteText}</div>
+        </div>
+        <div style={{ alignSelf: 'center' }}>
+          <InstructionsDiagramFillBubble />
+        </div>
+
+        <div>
+          <h4>{hmpbStrings.hmpbInstructionsWriteInTitle}</h4>
+          <div>{hmpbStrings.hmpbInstructionsWriteInText}</div>
+        </div>
+        <div style={{ alignSelf: 'center' }}>
+          <InstructionsDiagramWriteIn writeInLabel={<WriteInLabel />} />
+        </div>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      fill="tinted"
+      style={{
+        padding: '0.5rem 0.5rem',
+        display: 'grid',
+        gap: '0.125rem 0.75rem',
+        gridTemplateColumns: '7.5rem 1fr 1fr',
+      }}
+    >
+      {/* Row 1 */}
+      <div />
+      <DualLanguageText>
+        <h2>{hmpbStrings.hmpbInstructions}</h2>
+      </DualLanguageText>
+
+      {/* Row 2 */}
+      <div style={{ alignSelf: 'center' }}>
+        <InstructionsDiagramFillBubble />
+      </div>
+      <DualLanguageText>
+        <div>
+          <b>{hmpbStrings.hmpbInstructionsToVoteTitle}</b>
+          <div>{hmpbStrings.hmpbInstructionsToVoteText}</div>
+        </div>
+      </DualLanguageText>
+
+      {/* Row 3 */}
+      <div style={{ alignSelf: 'center' }}>
+        <InstructionsDiagramWriteIn writeInLabel={<WriteInLabel />} />
+      </div>
+      <DualLanguageText>
+        <div>
+          <b>{hmpbStrings.hmpbInstructionsWriteInTitle}</b>
+          <div>{hmpbStrings.hmpbInstructionsWriteInText}</div>
+        </div>
+      </DualLanguageText>
+    </Box>
+  );
+}
+
+export function Footer({
+  election,
+  ballotStyleId,
+  precinctId,
+  pageNumber,
+  totalPages,
+}: {
+  election: Election;
+  ballotStyleId: BallotStyleId;
+  precinctId: PrecinctId;
+  pageNumber: number;
+  totalPages: number;
+}): JSX.Element {
+  const precinct = assertDefined(getPrecinctById({ election, precinctId }));
+  const ballotStyle = assertDefined(
+    getBallotStyle({ election, ballotStyleId })
+  );
+  const languageCode = primaryLanguageCode(
+    assertDefined(getBallotStyle({ election, ballotStyleId }))
+  );
+  const languageText = unique([languageCode, 'en'])
+    .map((code) =>
+      format.languageDisplayName({
+        languageCode: code,
+        displayLanguageCode: 'en',
+      })
+    )
+    .join(' / ');
+
+  const continueVoting = (
+    <div
+      style={{
+        display: 'flex',
+        gap: '0.75rem',
+        alignItems: 'center',
+      }}
+    >
+      <div style={{ textAlign: 'right' }}>
+        <DualLanguageText>
+          <h3>
+            {pageNumber % 2 === 1
+              ? hmpbStrings.hmpbContinueVotingOnBack
+              : hmpbStrings.hmpbContinueVotingOnNextSheet}
+          </h3>
+        </DualLanguageText>
+      </div>
+      <ArrowRightCircle style={{ height: '2rem' }} />
+    </div>
+  );
+  const ballotComplete = (
+    <div style={{ textAlign: 'right' }}>
+      <DualLanguageText>
+        <h3>{hmpbStrings.hmpbVotingComplete}</h3>
+      </DualLanguageText>
+    </div>
+  );
+  const endOfPageInstruction =
+    pageNumber === totalPages ? ballotComplete : continueVoting;
+
+  return (
+    <div>
+      <div style={{ display: 'flex', gap: '0.75rem' }}>
+        <QrCodeSlot />
+        <Box
+          fill="tinted"
+          style={{
+            padding: '0.25rem 0.5rem',
+            flex: 1,
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          <div>
+            <div style={{ fontSize: '0.85rem' }}>
+              <DualLanguageText delimiter="/">
+                {hmpbStrings.hmpbPage}
+              </DualLanguageText>
+            </div>
+            <h1>
+              {pageNumber}/{totalPages}
+            </h1>
+          </div>
+          <div>{endOfPageInstruction}</div>
+        </Box>
+      </div>
+      {pageNumber % 2 === 1 && (
+        <div
+          style={{
+            fontSize: '8pt',
+            display: 'flex',
+            justifyContent: 'space-between',
+            gap: '0.5rem',
+            borderWidth: '1px',
+            marginTop: '0.325rem',
+            // There's padding at the bottom of the timing mark grid that we
+            // want to eat into a little bit here, so we set a height that's
+            // slightly smaller than the actual height of this text and let it
+            // overflow a bit.
+            height: '0.5rem',
+          }}
+        >
+          <span>
+            Election:{' '}
+            <b>
+              <BallotHashSlot />
+            </b>
+          </span>
+          <span>
+            Ballot Style: <b>{ballotStyle.groupId}</b>
+          </span>
+          <span>
+            Precinct: <b>{precinct.name}</b>
+          </span>
+          <span>
+            Language: <b>{languageText}</b>
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const ContestHeader = styled.div`
+  background: ${Colors.LIGHT_GRAY};
+  padding: 0.5rem 0.5rem;
+`;

--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
@@ -327,7 +327,10 @@ function CandidateContest({
                     </DualLanguageText>
                   )}
                 </div>
-                <BubbleWrapper optionInfo={optionInfo} />
+                <BubbleWrapper
+                  optionInfo={optionInfo}
+                  style={{ height: '1.2rem' }}
+                />
               </div>
             </li>
           );
@@ -368,7 +371,11 @@ function CandidateContest({
                     <WriteInLabel />
                   </div>
                 </div>
-                <BubbleWrapper isWriteIn optionInfo={optionInfo} />
+                <BubbleWrapper
+                  optionInfo={optionInfo}
+                  // Match line-height of text to align bubble to center of write-in candidate name
+                  style={{ height: '1.25rem' }}
+                />
               </li>
             );
           })}

--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
@@ -39,10 +39,6 @@ import {
   TimingMarkGrid,
   WRITE_IN_OPTION_CLASS,
   pageMarginsInches,
-} from '../ballot_components';
-import { BallotMode, PixelDimensions } from '../types';
-import { hmpbStrings } from '../hmpb_strings';
-import {
   BlankPageMessage,
   Box,
   BubbleWrapper,
@@ -53,7 +49,9 @@ import {
   Instructions,
   primaryLanguageCode,
   WriteInLabel,
-} from './vx_default_ballot_template';
+} from '../ballot_components';
+import { BallotMode, PixelDimensions } from '../types';
+import { hmpbStrings } from '../hmpb_strings';
 import { layOutInColumns } from '../layout_in_columns';
 import { Watermark } from './watermark';
 

--- a/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
@@ -282,7 +282,11 @@ function CandidateContest({
                   gap: '0.5rem',
                 }}
               >
-                <BubbleWrapper optionInfo={optionInfo} />
+                {/* Match line-height of text to align bubble to center of first line of option label */}
+                <BubbleWrapper
+                  optionInfo={optionInfo}
+                  style={{ height: '1.2rem' }}
+                />
                 <div>
                   <strong>{candidate.name}</strong>
                   {partyText && (
@@ -320,7 +324,11 @@ function CandidateContest({
                   borderTop: `1px solid ${Colors.DARK_GRAY}`,
                 }}
               >
-                <BubbleWrapper isWriteIn optionInfo={optionInfo} />
+                {/* Match line-height of text to align bubble to center of write-in candidate name */}
+                <BubbleWrapper
+                  optionInfo={optionInfo}
+                  style={{ height: '1.25rem' }}
+                />
                 <div style={{ flex: 1 }}>
                   <div
                     style={{

--- a/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
@@ -4,36 +4,28 @@ import {
   iter,
   range,
   throwIllegalValue,
-  unique,
 } from '@votingworks/basics';
 import { Buffer } from 'node:buffer';
-import styled from 'styled-components';
 import {
   AnyContest,
-  BallotStyle,
   BallotStyleId,
   BallotType,
   CandidateContest as CandidateContestStruct,
   Election,
   ElectionDefinition,
   ElectionSerializationFormat,
-  PrecinctId,
   YesNoContest,
   ballotPaperDimensions,
   getBallotStyle,
   getContests,
   getPartyForBallotStyle,
-  getPrecinctById,
 } from '@votingworks/types';
 import {
   BackendLanguageContextProvider,
   CandidatePartyList,
-  InEnglish,
   electionStrings,
-  useLanguageContext,
   RichText,
 } from '@votingworks/ui';
-import { format } from '@votingworks/utils';
 import {
   BallotPageTemplate,
   BaseBallotProps,
@@ -43,98 +35,26 @@ import {
 import { Renderer, RenderScratchpad } from '../renderer';
 import {
   Bubble,
-  BallotHashSlot,
   OptionInfo,
   Page,
-  QrCodeSlot,
   TimingMarkGrid,
   WRITE_IN_OPTION_CLASS,
   pageMarginsInches,
+  DualLanguageText,
+  primaryLanguageCode,
+  Instructions,
+  Footer,
+  Box,
+  ContestHeader,
+  Colors,
+  WriteInLabel,
+  BlankPageMessage,
+  BubbleWrapper,
 } from '../ballot_components';
 import { BallotMode, PixelDimensions } from '../types';
-import {
-  ArrowRightCircle,
-  InstructionsDiagramFillBubble,
-  InstructionsDiagramWriteIn,
-} from '../svg_assets';
 import { layOutInColumns } from '../layout_in_columns';
 import { hmpbStrings } from '../hmpb_strings';
 import { Watermark } from './watermark';
-
-export const Colors = {
-  BLACK: '#000000',
-  LIGHT_GRAY: '#EDEDED',
-  DARK_GRAY: '#DADADA',
-  DARKER_GRAY: '#B0B0B0',
-} as const;
-
-export function primaryLanguageCode(ballotStyle: BallotStyle): string {
-  return ballotStyle.languages?.[0] ?? 'en';
-}
-
-/**
- * Flex row that adds delimiters between each child element. However, if a child
- * element wraps to the next line, omits the delimiter before that element.
- */
-const DelimitedOrWrapped = styled.div<{ delimiter: string }>`
-  display: flex;
-  flex-wrap: wrap;
-  /* Hide the overflow of the container so that a child's delimiter is hidden if
-   * the child is at the beginning of a line */
-  overflow: hidden;
-  position: relative;
-
-  /* Add delimiter before each child */
-  > *:before {
-    content: '${(p) => p.delimiter}';
-    /* Absolute position takes it out of the flow so it can overflow to the left
-     * of the container */
-    position: absolute;
-    margin-left: -0.8em;
-    /* Use a fixed width that's based on the font size of the children */
-    width: 0.8em;
-    text-align: center;
-  }
-  /* Create a space between the children for the delimiter to go */
-  > *:not(:last-child) {
-    margin-right: 0.8em;
-  }
-`;
-
-export function DualLanguageText({
-  children,
-  delimiter,
-}: {
-  children: React.ReactNode;
-  delimiter?: string;
-}): React.ReactNode {
-  const languageContext = useLanguageContext();
-  if (!languageContext || languageContext.currentLanguageCode === 'en') {
-    return children;
-  }
-
-  const text = (
-    <React.Fragment>
-      {children}
-      <InEnglish>{children}</InEnglish>
-    </React.Fragment>
-  );
-
-  if (delimiter) {
-    return (
-      <DelimitedOrWrapped delimiter={delimiter}>{text}</DelimitedOrWrapped>
-    );
-  }
-  return text;
-}
-
-export const Box = styled.div<{ fill?: 'transparent' | 'tinted' }>`
-  border: 1px solid ${Colors.BLACK};
-  border-top-width: 3px;
-  padding: 0.75rem;
-  background-color: ${(p) =>
-    p.fill === 'tinted' ? Colors.LIGHT_GRAY : 'none'};
-`;
 
 function Header({
   election,
@@ -206,218 +126,6 @@ function Header({
           </div>
         </div>
       </DualLanguageText>
-    </div>
-  );
-}
-
-export function WriteInLabel(): React.ReactElement {
-  return (
-    <span>
-      <DualLanguageText delimiter="/">
-        {hmpbStrings.hmpbWriteIn}
-      </DualLanguageText>
-    </span>
-  );
-}
-
-export function Instructions({
-  languageCode,
-}: {
-  languageCode?: string;
-}): React.ReactElement {
-  // To minimize vertical space used, we do a slightly different layout for
-  // English-only vs bilingual ballots.
-  if (!languageCode || languageCode === 'en') {
-    return (
-      <Box
-        fill="tinted"
-        style={{
-          padding: '0.5rem 0.5rem',
-          display: 'grid',
-          gap: '0.125rem 0.75rem',
-          gridTemplateColumns: '1fr 7rem 1.8fr 8rem',
-        }}
-      >
-        <div>
-          <h2>{hmpbStrings.hmpbInstructions}</h2>
-          <h4>{hmpbStrings.hmpbInstructionsToVoteTitle}</h4>
-          <div>{hmpbStrings.hmpbInstructionsToVoteText}</div>
-        </div>
-        <div style={{ alignSelf: 'center' }}>
-          <InstructionsDiagramFillBubble />
-        </div>
-
-        <div>
-          <h4>{hmpbStrings.hmpbInstructionsWriteInTitle}</h4>
-          <div>{hmpbStrings.hmpbInstructionsWriteInText}</div>
-        </div>
-        <div style={{ alignSelf: 'center' }}>
-          <InstructionsDiagramWriteIn writeInLabel={<WriteInLabel />} />
-        </div>
-      </Box>
-    );
-  }
-
-  return (
-    <Box
-      fill="tinted"
-      style={{
-        padding: '0.5rem 0.5rem',
-        display: 'grid',
-        gap: '0.125rem 0.75rem',
-        gridTemplateColumns: '7.5rem 1fr 1fr',
-      }}
-    >
-      {/* Row 1 */}
-      <div />
-      <DualLanguageText>
-        <h2>{hmpbStrings.hmpbInstructions}</h2>
-      </DualLanguageText>
-
-      {/* Row 2 */}
-      <div style={{ alignSelf: 'center' }}>
-        <InstructionsDiagramFillBubble />
-      </div>
-      <DualLanguageText>
-        <div>
-          <b>{hmpbStrings.hmpbInstructionsToVoteTitle}</b>
-          <div>{hmpbStrings.hmpbInstructionsToVoteText}</div>
-        </div>
-      </DualLanguageText>
-
-      {/* Row 3 */}
-      <div style={{ alignSelf: 'center' }}>
-        <InstructionsDiagramWriteIn writeInLabel={<WriteInLabel />} />
-      </div>
-      <DualLanguageText>
-        <div>
-          <b>{hmpbStrings.hmpbInstructionsWriteInTitle}</b>
-          <div>{hmpbStrings.hmpbInstructionsWriteInText}</div>
-        </div>
-      </DualLanguageText>
-    </Box>
-  );
-}
-
-export function Footer({
-  election,
-  ballotStyleId,
-  precinctId,
-  pageNumber,
-  totalPages,
-}: {
-  election: Election;
-  ballotStyleId: BallotStyleId;
-  precinctId: PrecinctId;
-  pageNumber: number;
-  totalPages: number;
-}): JSX.Element {
-  const precinct = assertDefined(getPrecinctById({ election, precinctId }));
-  const ballotStyle = assertDefined(
-    getBallotStyle({ election, ballotStyleId })
-  );
-  const languageCode = primaryLanguageCode(
-    assertDefined(getBallotStyle({ election, ballotStyleId }))
-  );
-  const languageText = unique([languageCode, 'en'])
-    .map((code) =>
-      format.languageDisplayName({
-        languageCode: code,
-        displayLanguageCode: 'en',
-      })
-    )
-    .join(' / ');
-
-  const continueVoting = (
-    <div
-      style={{
-        display: 'flex',
-        gap: '0.75rem',
-        alignItems: 'center',
-      }}
-    >
-      <div style={{ textAlign: 'right' }}>
-        <DualLanguageText>
-          <h3>
-            {pageNumber % 2 === 1
-              ? hmpbStrings.hmpbContinueVotingOnBack
-              : hmpbStrings.hmpbContinueVotingOnNextSheet}
-          </h3>
-        </DualLanguageText>
-      </div>
-      <ArrowRightCircle style={{ height: '2rem' }} />
-    </div>
-  );
-  const ballotComplete = (
-    <div style={{ textAlign: 'right' }}>
-      <DualLanguageText>
-        <h3>{hmpbStrings.hmpbVotingComplete}</h3>
-      </DualLanguageText>
-    </div>
-  );
-  const endOfPageInstruction =
-    pageNumber === totalPages ? ballotComplete : continueVoting;
-
-  return (
-    <div>
-      <div style={{ display: 'flex', gap: '0.75rem' }}>
-        <QrCodeSlot />
-        <Box
-          fill="tinted"
-          style={{
-            padding: '0.25rem 0.5rem',
-            flex: 1,
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-          }}
-        >
-          <div>
-            <div style={{ fontSize: '0.85rem' }}>
-              <DualLanguageText delimiter="/">
-                {hmpbStrings.hmpbPage}
-              </DualLanguageText>
-            </div>
-            <h1>
-              {pageNumber}/{totalPages}
-            </h1>
-          </div>
-          <div>{endOfPageInstruction}</div>
-        </Box>
-      </div>
-      {pageNumber % 2 === 1 && (
-        <div
-          style={{
-            fontSize: '8pt',
-            display: 'flex',
-            justifyContent: 'space-between',
-            gap: '0.5rem',
-            borderWidth: '1px',
-            marginTop: '0.325rem',
-            // There's padding at the bottom of the timing mark grid that we
-            // want to eat into a little bit here, so we set a height that's
-            // slightly smaller than the actual height of this text and let it
-            // overflow a bit.
-            height: '0.5rem',
-          }}
-        >
-          <span>
-            Election:{' '}
-            <b>
-              <BallotHashSlot />
-            </b>
-          </span>
-          <span>
-            Ballot Style: <b>{ballotStyle.groupId}</b>
-          </span>
-          <span>
-            Precinct: <b>{precinct.name}</b>
-          </span>
-          <span>
-            Language: <b>{languageText}</b>
-          </span>
-        </div>
-      )}
     </div>
   );
 }
@@ -496,32 +204,6 @@ function BallotPageFrame({
         </TimingMarkGrid>
       </Page>
     </BackendLanguageContextProvider>
-  );
-}
-
-export const ContestHeader = styled.div`
-  background: ${Colors.LIGHT_GRAY};
-  padding: 0.5rem 0.5rem;
-`;
-
-export function BubbleWrapper({
-  optionInfo,
-  isWriteIn,
-}: {
-  optionInfo: OptionInfo;
-  isWriteIn?: boolean;
-}): React.ReactElement {
-  return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        // Match line-height of text to align bubble to center of first line of option label or write-in candidate name
-        height: isWriteIn ? '1.25rem' : '1.2rem',
-      }}
-    >
-      <Bubble optionInfo={optionInfo} />
-    </div>
   );
 }
 
@@ -754,26 +436,7 @@ function Contest({
   }
 }
 
-export function BlankPageMessage(): React.ReactElement {
-  return (
-    <div
-      style={{
-        height: '100%',
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-      }}
-    >
-      <div style={{ textAlign: 'center' }}>
-        <DualLanguageText>
-          <h1>{hmpbStrings.hmpbPageIntentionallyBlank}</h1>
-        </DualLanguageText>
-      </div>
-    </div>
-  );
-}
-
-export async function BallotPageContent(
+async function BallotPageContent(
   props: (BaseBallotProps & { dimensions: PixelDimensions }) | undefined,
   scratchpad: RenderScratchpad
 ): Promise<PagedElementResult<BaseBallotProps>> {


### PR DESCRIPTION
## Overview

Moves shared components from the default HMPB template to `ballot_components.tsx` and updates imports.

## Demo Video or Screenshot

N/A refactor

## Testing Plan

- [x] Verify ballots still render with preview tool

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
