### PR TITLE
Add additional inputs to VxDesign ballot order info screen

### DIFF
--- a/apps/design/backend/src/types.ts
+++ b/apps/design/backend/src/types.ts
@@ -81,16 +81,20 @@ export interface BallotOrderInfo {
   absenteeBallotCount?: string;
   ballotColor?: string;
   deliveryAddress?: string;
+  deliveryRecipientContactNumber?: string;
   deliveryRecipientName?: string;
   precinctBallotCount?: string;
   shouldAbsenteeBallotsBeScoredForFolding?: boolean;
+  shouldPrintCollated?: boolean;
 }
 
 export const BallotOrderInfoSchema: z.ZodType<BallotOrderInfo> = z.object({
   absenteeBallotCount: z.string().optional(),
   ballotColor: z.string().optional(),
   deliveryAddress: z.string().optional(),
+  deliveryRecipientContactNumber: z.string().optional(),
   deliveryRecipientName: z.string().optional(),
   precinctBallotCount: z.string().optional(),
   shouldAbsenteeBallotsBeScoredForFolding: z.boolean().optional(),
+  shouldPrintCollated: z.boolean().optional(),
 });

--- a/apps/design/backend/src/types.ts
+++ b/apps/design/backend/src/types.ts
@@ -81,8 +81,8 @@ export interface BallotOrderInfo {
   absenteeBallotCount?: string;
   ballotColor?: string;
   deliveryAddress?: string;
-  deliveryRecipientContactNumber?: string;
   deliveryRecipientName?: string;
+  deliveryRecipientPhoneNumber?: string;
   precinctBallotCount?: string;
   shouldAbsenteeBallotsBeScoredForFolding?: boolean;
   shouldPrintCollated?: boolean;
@@ -92,8 +92,8 @@ export const BallotOrderInfoSchema: z.ZodType<BallotOrderInfo> = z.object({
   absenteeBallotCount: z.string().optional(),
   ballotColor: z.string().optional(),
   deliveryAddress: z.string().optional(),
-  deliveryRecipientContactNumber: z.string().optional(),
   deliveryRecipientName: z.string().optional(),
+  deliveryRecipientPhoneNumber: z.string().optional(),
   precinctBallotCount: z.string().optional(),
   shouldAbsenteeBallotsBeScoredForFolding: z.boolean().optional(),
   shouldPrintCollated: z.boolean().optional(),

--- a/apps/design/frontend/src/ballot_order_info_screen.test.tsx
+++ b/apps/design/frontend/src/ballot_order_info_screen.test.tsx
@@ -65,11 +65,23 @@ test('updating ballot order info', async () => {
   expect(ballotColorInput).toBeDisabled();
   expect(ballotColorInput).toHaveValue('');
 
+  const shouldPrintCollated = screen.getByRole('checkbox', {
+    name: 'Print Collated',
+  });
+  expect(shouldPrintCollated).toBeDisabled();
+  expect(shouldPrintCollated).not.toBeChecked();
+
   const deliveryRecipientNameInput = screen.getByLabelText(
     'Delivery Recipient Name'
   );
   expect(deliveryRecipientNameInput).toBeDisabled();
   expect(deliveryRecipientNameInput).toHaveValue('');
+
+  const deliveryRecipientContactNumber = screen.getByLabelText(
+    'Delivery Recipient Contact Number'
+  );
+  expect(deliveryRecipientContactNumber).toBeDisabled();
+  expect(deliveryRecipientContactNumber).toHaveValue('');
 
   const deliveryAddressInput = screen.getByLabelText(
     'Delivery Address, City, State, and ZIP'
@@ -84,7 +96,9 @@ test('updating ballot order info', async () => {
   userEvent.click(shouldAbsenteeBallotsBeScoredForFolding);
   userEvent.type(precinctBallotCountInput, '200');
   userEvent.type(ballotColorInput, 'Yellow for town, white for school');
+  userEvent.click(shouldPrintCollated);
   userEvent.type(deliveryRecipientNameInput, 'Clerky Clerkson');
+  userEvent.type(deliveryRecipientContactNumber, '(123) 456-7890');
   userEvent.type(deliveryAddressInput, '123 Main St, Town, NH, 00000');
 
   let expectedBallotOrderInfo: BallotOrderInfo = {
@@ -92,7 +106,9 @@ test('updating ballot order info', async () => {
     shouldAbsenteeBallotsBeScoredForFolding: true,
     precinctBallotCount: '200',
     ballotColor: 'Yellow for town, white for school',
+    shouldPrintCollated: true,
     deliveryRecipientName: 'Clerky Clerkson',
+    deliveryRecipientContactNumber: '(123) 456-7890',
     deliveryAddress: '123 Main St, Town, NH, 00000',
   };
   apiMock.updateBallotOrderInfo
@@ -110,7 +126,9 @@ test('updating ballot order info', async () => {
   expect(shouldAbsenteeBallotsBeScoredForFolding).toBeChecked();
   expect(precinctBallotCountInput).toHaveValue('200');
   expect(ballotColorInput).toHaveValue('Yellow for town, white for school');
+  expect(shouldPrintCollated).toBeChecked();
   expect(deliveryRecipientNameInput).toHaveValue('Clerky Clerkson');
+  expect(deliveryRecipientContactNumber).toHaveValue('(123) 456-7890');
   expect(deliveryAddressInput).toHaveValue('123 Main St, Town, NH, 00000');
 
   // Clear ballot order info
@@ -120,7 +138,9 @@ test('updating ballot order info', async () => {
   userEvent.click(shouldAbsenteeBallotsBeScoredForFolding);
   userEvent.clear(precinctBallotCountInput);
   userEvent.clear(ballotColorInput);
+  userEvent.click(shouldPrintCollated);
   userEvent.clear(deliveryRecipientNameInput);
+  userEvent.clear(deliveryRecipientContactNumber);
   userEvent.clear(deliveryAddressInput);
 
   expectedBallotOrderInfo = {
@@ -128,7 +148,9 @@ test('updating ballot order info', async () => {
     shouldAbsenteeBallotsBeScoredForFolding: false,
     precinctBallotCount: '',
     ballotColor: '',
+    shouldPrintCollated: false,
     deliveryRecipientName: '',
+    deliveryRecipientContactNumber: '',
     deliveryAddress: '',
   };
   apiMock.updateBallotOrderInfo
@@ -146,7 +168,9 @@ test('updating ballot order info', async () => {
   expect(shouldAbsenteeBallotsBeScoredForFolding).not.toBeChecked();
   expect(precinctBallotCountInput).toHaveValue('');
   expect(ballotColorInput).toHaveValue('');
+  expect(shouldPrintCollated).not.toBeChecked();
   expect(deliveryRecipientNameInput).toHaveValue('');
+  expect(deliveryRecipientContactNumber).toHaveValue('');
   expect(deliveryAddressInput).toHaveValue('');
 
   // Begin repopulating ballot order info but cancel
@@ -156,8 +180,10 @@ test('updating ballot order info', async () => {
   userEvent.click(shouldAbsenteeBallotsBeScoredForFolding);
   userEvent.type(precinctBallotCountInput, 'B');
   userEvent.type(ballotColorInput, 'C');
-  userEvent.type(deliveryRecipientNameInput, 'D');
-  userEvent.type(deliveryAddressInput, 'E');
+  userEvent.type(shouldPrintCollated, 'D');
+  userEvent.type(deliveryRecipientNameInput, 'E');
+  userEvent.type(deliveryRecipientContactNumber, 'F');
+  userEvent.type(deliveryAddressInput, 'G');
 
   userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
@@ -165,6 +191,8 @@ test('updating ballot order info', async () => {
   expect(shouldAbsenteeBallotsBeScoredForFolding).not.toBeChecked();
   expect(precinctBallotCountInput).toHaveValue('');
   expect(ballotColorInput).toHaveValue('');
+  expect(shouldPrintCollated).not.toBeChecked();
   expect(deliveryRecipientNameInput).toHaveValue('');
+  expect(deliveryRecipientContactNumber).toHaveValue('');
   expect(deliveryAddressInput).toHaveValue('');
 });

--- a/apps/design/frontend/src/ballot_order_info_screen.test.tsx
+++ b/apps/design/frontend/src/ballot_order_info_screen.test.tsx
@@ -49,11 +49,12 @@ test('updating ballot order info', async () => {
   expect(absenteeBallotCountInput).toBeDisabled();
   expect(absenteeBallotCountInput).toHaveValue('');
 
-  const shouldAbsenteeBallotsBeScoredForFolding = screen.getByRole('checkbox', {
-    name: 'Score Absentee Ballots for Folding',
-  });
-  expect(shouldAbsenteeBallotsBeScoredForFolding).toBeDisabled();
-  expect(shouldAbsenteeBallotsBeScoredForFolding).not.toBeChecked();
+  const shouldAbsenteeBallotsBeScoredForFoldingCheckbox = screen.getByRole(
+    'checkbox',
+    { name: 'Score Absentee Ballots for Folding' }
+  );
+  expect(shouldAbsenteeBallotsBeScoredForFoldingCheckbox).toBeDisabled();
+  expect(shouldAbsenteeBallotsBeScoredForFoldingCheckbox).not.toBeChecked();
 
   const precinctBallotCountInput = screen.getByLabelText(
     'Number of Polling Place Ballots'
@@ -65,11 +66,11 @@ test('updating ballot order info', async () => {
   expect(ballotColorInput).toBeDisabled();
   expect(ballotColorInput).toHaveValue('');
 
-  const shouldPrintCollated = screen.getByRole('checkbox', {
+  const shouldPrintCollatedCheckbox = screen.getByRole('checkbox', {
     name: 'Print Collated',
   });
-  expect(shouldPrintCollated).toBeDisabled();
-  expect(shouldPrintCollated).not.toBeChecked();
+  expect(shouldPrintCollatedCheckbox).toBeDisabled();
+  expect(shouldPrintCollatedCheckbox).not.toBeChecked();
 
   const deliveryRecipientNameInput = screen.getByLabelText(
     'Delivery Recipient Name'
@@ -77,11 +78,11 @@ test('updating ballot order info', async () => {
   expect(deliveryRecipientNameInput).toBeDisabled();
   expect(deliveryRecipientNameInput).toHaveValue('');
 
-  const deliveryRecipientPhoneNumber = screen.getByLabelText(
+  const deliveryRecipientPhoneNumberInput = screen.getByLabelText(
     'Delivery Recipient Phone Number'
   );
-  expect(deliveryRecipientPhoneNumber).toBeDisabled();
-  expect(deliveryRecipientPhoneNumber).toHaveValue('');
+  expect(deliveryRecipientPhoneNumberInput).toBeDisabled();
+  expect(deliveryRecipientPhoneNumberInput).toHaveValue('');
 
   const deliveryAddressInput = screen.getByLabelText(
     'Delivery Address, City, State, and ZIP'
@@ -93,12 +94,12 @@ test('updating ballot order info', async () => {
 
   userEvent.click(screen.getByRole('button', { name: 'Edit' }));
   userEvent.type(absenteeBallotCountInput, '100');
-  userEvent.click(shouldAbsenteeBallotsBeScoredForFolding);
+  userEvent.click(shouldAbsenteeBallotsBeScoredForFoldingCheckbox);
   userEvent.type(precinctBallotCountInput, '200');
   userEvent.type(ballotColorInput, 'Yellow for town, white for school');
-  userEvent.click(shouldPrintCollated);
+  userEvent.click(shouldPrintCollatedCheckbox);
   userEvent.type(deliveryRecipientNameInput, 'Clerky Clerkson');
-  userEvent.type(deliveryRecipientPhoneNumber, '(123) 456-7890');
+  userEvent.type(deliveryRecipientPhoneNumberInput, '(123) 456-7890');
   userEvent.type(deliveryAddressInput, '123 Main St, Town, NH, 00000');
 
   let expectedBallotOrderInfo: BallotOrderInfo = {
@@ -123,24 +124,24 @@ test('updating ballot order info', async () => {
   await screen.findByRole('button', { name: 'Edit' });
 
   expect(absenteeBallotCountInput).toHaveValue('100');
-  expect(shouldAbsenteeBallotsBeScoredForFolding).toBeChecked();
+  expect(shouldAbsenteeBallotsBeScoredForFoldingCheckbox).toBeChecked();
   expect(precinctBallotCountInput).toHaveValue('200');
   expect(ballotColorInput).toHaveValue('Yellow for town, white for school');
-  expect(shouldPrintCollated).toBeChecked();
+  expect(shouldPrintCollatedCheckbox).toBeChecked();
   expect(deliveryRecipientNameInput).toHaveValue('Clerky Clerkson');
-  expect(deliveryRecipientPhoneNumber).toHaveValue('(123) 456-7890');
+  expect(deliveryRecipientPhoneNumberInput).toHaveValue('(123) 456-7890');
   expect(deliveryAddressInput).toHaveValue('123 Main St, Town, NH, 00000');
 
   // Clear ballot order info
 
   userEvent.click(screen.getByRole('button', { name: 'Edit' }));
   userEvent.clear(absenteeBallotCountInput);
-  userEvent.click(shouldAbsenteeBallotsBeScoredForFolding);
+  userEvent.click(shouldAbsenteeBallotsBeScoredForFoldingCheckbox);
   userEvent.clear(precinctBallotCountInput);
   userEvent.clear(ballotColorInput);
-  userEvent.click(shouldPrintCollated);
+  userEvent.click(shouldPrintCollatedCheckbox);
   userEvent.clear(deliveryRecipientNameInput);
-  userEvent.clear(deliveryRecipientPhoneNumber);
+  userEvent.clear(deliveryRecipientPhoneNumberInput);
   userEvent.clear(deliveryAddressInput);
 
   expectedBallotOrderInfo = {
@@ -165,34 +166,34 @@ test('updating ballot order info', async () => {
   await screen.findByRole('button', { name: 'Edit' });
 
   expect(absenteeBallotCountInput).toHaveValue('');
-  expect(shouldAbsenteeBallotsBeScoredForFolding).not.toBeChecked();
+  expect(shouldAbsenteeBallotsBeScoredForFoldingCheckbox).not.toBeChecked();
   expect(precinctBallotCountInput).toHaveValue('');
   expect(ballotColorInput).toHaveValue('');
-  expect(shouldPrintCollated).not.toBeChecked();
+  expect(shouldPrintCollatedCheckbox).not.toBeChecked();
   expect(deliveryRecipientNameInput).toHaveValue('');
-  expect(deliveryRecipientPhoneNumber).toHaveValue('');
+  expect(deliveryRecipientPhoneNumberInput).toHaveValue('');
   expect(deliveryAddressInput).toHaveValue('');
 
   // Begin repopulating ballot order info but cancel
 
   userEvent.click(screen.getByRole('button', { name: 'Edit' }));
   userEvent.type(absenteeBallotCountInput, 'A');
-  userEvent.click(shouldAbsenteeBallotsBeScoredForFolding);
+  userEvent.click(shouldAbsenteeBallotsBeScoredForFoldingCheckbox);
   userEvent.type(precinctBallotCountInput, 'B');
   userEvent.type(ballotColorInput, 'C');
-  userEvent.type(shouldPrintCollated, 'D');
+  userEvent.click(shouldPrintCollatedCheckbox);
   userEvent.type(deliveryRecipientNameInput, 'E');
-  userEvent.type(deliveryRecipientPhoneNumber, 'F');
+  userEvent.type(deliveryRecipientPhoneNumberInput, 'F');
   userEvent.type(deliveryAddressInput, 'G');
 
   userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
   expect(absenteeBallotCountInput).toHaveValue('');
-  expect(shouldAbsenteeBallotsBeScoredForFolding).not.toBeChecked();
+  expect(shouldAbsenteeBallotsBeScoredForFoldingCheckbox).not.toBeChecked();
   expect(precinctBallotCountInput).toHaveValue('');
   expect(ballotColorInput).toHaveValue('');
-  expect(shouldPrintCollated).not.toBeChecked();
+  expect(shouldPrintCollatedCheckbox).not.toBeChecked();
   expect(deliveryRecipientNameInput).toHaveValue('');
-  expect(deliveryRecipientPhoneNumber).toHaveValue('');
+  expect(deliveryRecipientPhoneNumberInput).toHaveValue('');
   expect(deliveryAddressInput).toHaveValue('');
 });

--- a/apps/design/frontend/src/ballot_order_info_screen.test.tsx
+++ b/apps/design/frontend/src/ballot_order_info_screen.test.tsx
@@ -77,11 +77,11 @@ test('updating ballot order info', async () => {
   expect(deliveryRecipientNameInput).toBeDisabled();
   expect(deliveryRecipientNameInput).toHaveValue('');
 
-  const deliveryRecipientContactNumber = screen.getByLabelText(
-    'Delivery Recipient Contact Number'
+  const deliveryRecipientPhoneNumber = screen.getByLabelText(
+    'Delivery Recipient Phone Number'
   );
-  expect(deliveryRecipientContactNumber).toBeDisabled();
-  expect(deliveryRecipientContactNumber).toHaveValue('');
+  expect(deliveryRecipientPhoneNumber).toBeDisabled();
+  expect(deliveryRecipientPhoneNumber).toHaveValue('');
 
   const deliveryAddressInput = screen.getByLabelText(
     'Delivery Address, City, State, and ZIP'
@@ -98,7 +98,7 @@ test('updating ballot order info', async () => {
   userEvent.type(ballotColorInput, 'Yellow for town, white for school');
   userEvent.click(shouldPrintCollated);
   userEvent.type(deliveryRecipientNameInput, 'Clerky Clerkson');
-  userEvent.type(deliveryRecipientContactNumber, '(123) 456-7890');
+  userEvent.type(deliveryRecipientPhoneNumber, '(123) 456-7890');
   userEvent.type(deliveryAddressInput, '123 Main St, Town, NH, 00000');
 
   let expectedBallotOrderInfo: BallotOrderInfo = {
@@ -108,7 +108,7 @@ test('updating ballot order info', async () => {
     ballotColor: 'Yellow for town, white for school',
     shouldPrintCollated: true,
     deliveryRecipientName: 'Clerky Clerkson',
-    deliveryRecipientContactNumber: '(123) 456-7890',
+    deliveryRecipientPhoneNumber: '(123) 456-7890',
     deliveryAddress: '123 Main St, Town, NH, 00000',
   };
   apiMock.updateBallotOrderInfo
@@ -128,7 +128,7 @@ test('updating ballot order info', async () => {
   expect(ballotColorInput).toHaveValue('Yellow for town, white for school');
   expect(shouldPrintCollated).toBeChecked();
   expect(deliveryRecipientNameInput).toHaveValue('Clerky Clerkson');
-  expect(deliveryRecipientContactNumber).toHaveValue('(123) 456-7890');
+  expect(deliveryRecipientPhoneNumber).toHaveValue('(123) 456-7890');
   expect(deliveryAddressInput).toHaveValue('123 Main St, Town, NH, 00000');
 
   // Clear ballot order info
@@ -140,7 +140,7 @@ test('updating ballot order info', async () => {
   userEvent.clear(ballotColorInput);
   userEvent.click(shouldPrintCollated);
   userEvent.clear(deliveryRecipientNameInput);
-  userEvent.clear(deliveryRecipientContactNumber);
+  userEvent.clear(deliveryRecipientPhoneNumber);
   userEvent.clear(deliveryAddressInput);
 
   expectedBallotOrderInfo = {
@@ -150,7 +150,7 @@ test('updating ballot order info', async () => {
     ballotColor: '',
     shouldPrintCollated: false,
     deliveryRecipientName: '',
-    deliveryRecipientContactNumber: '',
+    deliveryRecipientPhoneNumber: '',
     deliveryAddress: '',
   };
   apiMock.updateBallotOrderInfo
@@ -170,7 +170,7 @@ test('updating ballot order info', async () => {
   expect(ballotColorInput).toHaveValue('');
   expect(shouldPrintCollated).not.toBeChecked();
   expect(deliveryRecipientNameInput).toHaveValue('');
-  expect(deliveryRecipientContactNumber).toHaveValue('');
+  expect(deliveryRecipientPhoneNumber).toHaveValue('');
   expect(deliveryAddressInput).toHaveValue('');
 
   // Begin repopulating ballot order info but cancel
@@ -182,7 +182,7 @@ test('updating ballot order info', async () => {
   userEvent.type(ballotColorInput, 'C');
   userEvent.type(shouldPrintCollated, 'D');
   userEvent.type(deliveryRecipientNameInput, 'E');
-  userEvent.type(deliveryRecipientContactNumber, 'F');
+  userEvent.type(deliveryRecipientPhoneNumber, 'F');
   userEvent.type(deliveryAddressInput, 'G');
 
   userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
@@ -193,6 +193,6 @@ test('updating ballot order info', async () => {
   expect(ballotColorInput).toHaveValue('');
   expect(shouldPrintCollated).not.toBeChecked();
   expect(deliveryRecipientNameInput).toHaveValue('');
-  expect(deliveryRecipientContactNumber).toHaveValue('');
+  expect(deliveryRecipientPhoneNumber).toHaveValue('');
   expect(deliveryAddressInput).toHaveValue('');
 });

--- a/apps/design/frontend/src/ballot_order_info_screen.tsx
+++ b/apps/design/frontend/src/ballot_order_info_screen.tsx
@@ -115,6 +115,17 @@ function BallotOrderInfoForm({
         <Icons.Info /> Specify if for town or school ballots. If not specified,
         we’ll print on white.
       </Annotation>
+      <CheckboxButton
+        label="Print Collated"
+        isChecked={Boolean(ballotOrderInfo.shouldPrintCollated)}
+        onChange={(isChecked) =>
+          setBallotOrderInfo({
+            ...ballotOrderInfo,
+            shouldPrintCollated: isChecked,
+          })
+        }
+        disabled={!isEditing}
+      />
       <InputGroup label="Delivery Recipient Name">
         <input
           type="text"
@@ -123,6 +134,19 @@ function BallotOrderInfoForm({
             setBallotOrderInfo({
               ...ballotOrderInfo,
               deliveryRecipientName: e.target.value,
+            })
+          }
+          disabled={!isEditing}
+        />
+      </InputGroup>
+      <InputGroup label="Delivery Recipient Contact Number">
+        <input
+          type="text"
+          value={ballotOrderInfo.deliveryRecipientContactNumber ?? ''}
+          onChange={(e) =>
+            setBallotOrderInfo({
+              ...ballotOrderInfo,
+              deliveryRecipientContactNumber: e.target.value,
             })
           }
           disabled={!isEditing}

--- a/apps/design/frontend/src/ballot_order_info_screen.tsx
+++ b/apps/design/frontend/src/ballot_order_info_screen.tsx
@@ -139,14 +139,14 @@ function BallotOrderInfoForm({
           disabled={!isEditing}
         />
       </InputGroup>
-      <InputGroup label="Delivery Recipient Contact Number">
+      <InputGroup label="Delivery Recipient Phone Number">
         <input
           type="text"
-          value={ballotOrderInfo.deliveryRecipientContactNumber ?? ''}
+          value={ballotOrderInfo.deliveryRecipientPhoneNumber ?? ''}
           onChange={(e) =>
             setBallotOrderInfo({
               ...ballotOrderInfo,
-              deliveryRecipientContactNumber: e.target.value,
+              deliveryRecipientPhoneNumber: e.target.value,
             })
           }
           disabled={!isEditing}


### PR DESCRIPTION
## Overview

Was opening an issue for this when I realized that it was just as easy to just open the PR 😅

Per input from Ginny and customers, we're adding two inputs to the ballot order info screen, an option to print collated and a delivery recipient phone number.

<img width="1512" alt="new-fields" src="https://github.com/user-attachments/assets/fcf71d76-982b-406c-961a-efa19baa7ede" />

## Testing Plan

- [x] Updated automated tests
- [x] Tested manually

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
