### PR TITLE
Do not render signature and signature caption on sample ballot

### DIFF
--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
@@ -140,7 +140,7 @@ function Header({
         </DualLanguageText>
       </div>
       <div style={{ flexGrow: 1 }}>
-        {clerkSignatureImage && (
+        {ballotMode !== 'sample' && clerkSignatureImage && (
           <div
             style={{
               height: '3rem',
@@ -153,7 +153,9 @@ function Header({
             }}
           />
         )}
-        {clerkSignatureCaption && <div>{clerkSignatureCaption}</div>}
+        {ballotMode !== 'sample' && clerkSignatureCaption && (
+          <div>{clerkSignatureCaption}</div>
+        )}
       </div>
     </div>
   );

--- a/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
@@ -167,7 +167,7 @@ function Header({
         </DualLanguageText>
       </div>
       <div style={{ flexGrow: 1 }}>
-        {clerkSignatureImage && (
+        {ballotMode !== 'sample' && clerkSignatureImage && (
           <div
             style={{
               height: '3rem',
@@ -180,7 +180,9 @@ function Header({
             }}
           />
         )}
-        {clerkSignatureCaption && <div>{clerkSignatureCaption}</div>}
+        {ballotMode !== 'sample' && clerkSignatureCaption && (
+          <div>{clerkSignatureCaption}</div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/4712

Omits signature and signature caption on sample ballots.

## Demo Video or Screenshot


https://github.com/user-attachments/assets/dd8ce002-9f43-48cd-b010-1cda6e4f5446



## Testing Plan

- Manually checked the render

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
