### PR TITLE
VxDesign: Don't generate ballot styles for precincts/splits without contests assigned

### DIFF
--- a/apps/design/backend/src/ballot_styles.test.ts
+++ b/apps/design/backend/src/ballot_styles.test.ts
@@ -44,6 +44,10 @@ describe('generateBallotStyles()', () => {
     id: 'district-2' as DistrictId,
     name: 'District 2',
   };
+  const district3NoContests: District = {
+    id: 'district-3' as DistrictId,
+    name: 'District 3',
+  };
 
   const partyA: Party = {
     id: 'party-A' as PartyId,
@@ -93,6 +97,12 @@ describe('generateBallotStyles()', () => {
       // Shouldn't get a ballot style, since no districts assigned
       districtIds: [],
     }),
+    noContests: typedAs<PrecinctSplit>({
+      id: 'precinct-2-split-5',
+      name: 'Precinct 2 - Split 5',
+      // Shouldn't get a ballot style, since no contests assigned
+      districtIds: [district3NoContests.id],
+    }),
   } as const;
   const precinct3District1And2: Precinct = {
     id: 'precinct-3-with-splits',
@@ -105,6 +115,13 @@ describe('generateBallotStyles()', () => {
     name: 'Precinct 4',
     // Shouldn't get a ballot style, since no districts assigned
     districtIds: [],
+  };
+
+  const precinct5NoContests: Precinct = {
+    id: 'precinct-5',
+    name: 'Precinct 5',
+    // Shouldn't get a ballot style, since no contests assigned
+    districtIds: [district3NoContests.id],
   };
 
   const generalContest1 = makeContest('contest-1', district1.id);
@@ -127,7 +144,12 @@ describe('generateBallotStyles()', () => {
       contests: [generalContest1, generalContest2],
       electionType: 'general',
       parties: [],
-      precincts: [precinct1District1, precinct2District2, precinct4NoDistricts],
+      precincts: [
+        precinct1District1,
+        precinct2District2,
+        precinct4NoDistricts,
+        precinct5NoContests,
+      ],
     });
 
     expect(ballotStyles).toEqual<BallotStyle[]>([
@@ -162,6 +184,7 @@ describe('generateBallotStyles()', () => {
         precinct1District1,
         precinct3District1And2,
         precinct4NoDistricts,
+        precinct5NoContests,
       ],
     });
 
@@ -209,7 +232,12 @@ describe('generateBallotStyles()', () => {
       ],
       electionType: 'primary',
       parties: [partyA, partyB, partyC],
-      precincts: [precinct1District1, precinct2District2, precinct4NoDistricts],
+      precincts: [
+        precinct1District1,
+        precinct2District2,
+        precinct4NoDistricts,
+        precinct5NoContests,
+      ],
     });
 
     expect(ballotStyles).toEqual<BallotStyle[]>([
@@ -295,6 +323,7 @@ describe('generateBallotStyles()', () => {
         precinct1District1,
         precinct3District1And2,
         precinct4NoDistricts,
+        precinct5NoContests,
       ],
     });
 

--- a/apps/design/backend/src/ballot_styles.ts
+++ b/apps/design/backend/src/ballot_styles.ts
@@ -48,7 +48,14 @@ export function generateBallotStyles(params: {
       }
       return { precinctId: precinct.id, districtIds: precinct.districtIds };
     })
-    .filter(({ districtIds }) => districtIds.length > 0);
+    .filter(
+      ({ districtIds }) =>
+        districtIds.length > 0 &&
+        // Don't create ballot styles for precincts/splits with no contests assigned
+        districtIds.some((districtId) =>
+          contests.some((contest) => contest.districtId === districtId)
+        )
+    );
 
   const precinctsOrSplitsByDistricts: Array<
     [readonly DistrictId[], PrecinctOrSplitId[]]

--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -15,6 +15,7 @@ import {
   Card,
   Icons,
   Modal,
+  Font,
 } from '@votingworks/ui';
 import { Redirect, Route, Switch, useParams } from 'react-router-dom';
 import { assertDefined } from '@votingworks/basics';
@@ -244,6 +245,20 @@ function BallotStylesTab(): JSX.Element | null {
                           precinctId === precinct.id && splitId === undefined
                       )
                   );
+
+                  if (precinctBallotStyles.length === 0) {
+                    return (
+                      <NestedTr key={precinct.id}>
+                        <TD>{precinct.name}</TD>
+                        <TD>
+                          <Font italic>No contests assigned</Font>
+                        </TD>
+                        {election.type === 'primary' && <TD />}
+                        <TD />
+                      </NestedTr>
+                    );
+                  }
+
                   return precinctBallotStyles.map((ballotStyle) => (
                     <tr key={precinct.id + ballotStyle.id}>
                       <TD>{precinct.name}</TD>
@@ -290,6 +305,19 @@ function BallotStylesTab(): JSX.Element | null {
                         precinctId === precinct.id && splitId === split.id
                     )
                   );
+
+                  if (splitBallotStyles.length === 0) {
+                    return (
+                      <NestedTr key={split.id}>
+                        <TD>{split.name}</TD>
+                        <TD>
+                          <Font italic>No contests assigned</Font>
+                        </TD>
+                        {election.type === 'primary' && <TD />}
+                        <TD />
+                      </NestedTr>
+                    );
+                  }
 
                   return splitBallotStyles.map((ballotStyle) => (
                     <NestedTr key={split.id + ballotStyle.id}>


### PR DESCRIPTION
## Overview

Fixes: https://github.com/votingworks/vxsuite/issues/5871

VxDesign already doesn't generate ballot styles for precincts and precinct splits without any districts assigned. This PR extends that logic to also skip precincts/splits that have districts assigned, but the districts have no contests assigned.

Previously, precincts/splits with no ballot styles were omitted from the list of ballot styles on the ballot screen. This PR changes that screen to show these precincts/splits with a message that they don't have any contests assigned. This is a safeguard for users so they can catch any precincts/splits that should have ballots during proofing.

## Demo Video or Screenshot

<img width="1424" alt="Screenshot 2025-01-23 at 4 22 48 PM" src="https://github.com/user-attachments/assets/b924e337-1996-4329-add7-6354907d6f69" />


## Testing Plan
Updated automated tests


## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
