### PR TITLE
build(design): do not require `postgres` permissions

### DIFF
--- a/apps/design/backend/scripts/db_reset_dev.sh
+++ b/apps/design/backend/scripts/db_reset_dev.sh
@@ -19,4 +19,4 @@ sudo -u postgres psql -c "drop user design;"
 
 sudo -u postgres psql -c "create user design superuser password 'design';" &&
   sudo -u postgres psql -c "create database design with owner design;" &&
-  sudo -u postgres psql -d design -f "${SCRIPT_DIR}/../schema.sql"
+  sudo -u postgres psql -d design < "${SCRIPT_DIR}/../schema.sql"


### PR DESCRIPTION
I get this when running `pnpm db:reset`:

```
❯ pnpm db:reset

> @votingworks/design-backend@0.1.0 db:reset /media/parallels/WorkingFiles/code/vxsuite/apps/design/backend
> ./scripts/db_reset_dev.sh

could not change directory to "/media/parallels/WorkingFiles/code/vxsuite/apps/design/backend": Permission denied
DROP DATABASE
could not change directory to "/media/parallels/WorkingFiles/code/vxsuite/apps/design/backend": Permission denied
DROP ROLE
could not change directory to "/media/parallels/WorkingFiles/code/vxsuite/apps/design/backend": Permission denied
CREATE ROLE
could not change directory to "/media/parallels/WorkingFiles/code/vxsuite/apps/design/backend": Permission denied
CREATE DATABASE
could not change directory to "/media/parallels/WorkingFiles/code/vxsuite/apps/design/backend": Permission denied
psql: error: schema.sql: No such file or directory
ELIFECYCLE  Command failed with exit code 1.
```

This is because the script uses `-f` to specify the file path to read. Instead, we can send the file contents as stdin to avoid the permissions issue.
