### PR TITLE
VxDesign: Add DEPLOY_ENV env var to differentiate staging from production in Sentry errors

### DIFF
--- a/Dockerfile.vxdesign
+++ b/Dockerfile.vxdesign
@@ -68,6 +68,7 @@ COPY . .
 RUN . ~/.bashrc && pnpm install --frozen-lockfile
 
 ENV NODE_ENV="production"
+ENV DEPLOY_ENV=$DEPLOY_ENV
 RUN . ~/.bashrc && pnpm -dir=apps/design/frontend build:prod
 
 EXPOSE 80

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -35,6 +35,7 @@ import {
   renderBallotPreviewToPdf,
 } from '@votingworks/hmpb';
 import { translateBallotStrings } from '@votingworks/backend';
+import { readFileSync } from 'node:fs';
 import { ElectionPackage, ElectionRecord } from './store';
 import { BallotOrderInfo, Precinct, UsState } from './types';
 import {
@@ -46,6 +47,7 @@ import { AppContext } from './context';
 import { rotateCandidates } from './candidate_rotation';
 import { renderBallotStyleReadinessReport } from './ballot_style_reports';
 import { createBallotPropsForTemplate, defaultBallotTemplate } from './ballots';
+import { DEPLOY_ENV } from './globals';
 
 export const BALLOT_STYLE_READINESS_REPORT_FILE_NAME =
   'ballot-style-readiness-report.pdf';
@@ -472,11 +474,20 @@ export function buildApp(context: AppContext): Application {
   const app: Application = express();
   const api = buildApi(context);
   app.use('/api', grout.buildRouter(api, express));
-  app.use(express.static(context.workspace.assetDirectoryPath));
+  app.use(
+    express.static(context.workspace.assetDirectoryPath, { index: false })
+  );
 
-  // serve the index.html file for everything else
+  // Serve the index.html file for everything else, adding in some environment variables
+  // (we don't need a full templating engine since it's just a couple of variables)
+  const indexFileContents = readFileSync(
+    join(context.workspace.assetDirectoryPath, 'index.html'),
+    'utf8'
+  )
+    .replace('{{ SENTRY_DSN }}', process.env.SENTRY_DSN ?? '')
+    .replace('{{ DEPLOY_ENV }}', DEPLOY_ENV);
   app.get('*', (_req, res) => {
-    res.sendFile(join(context.workspace.assetDirectoryPath, 'index.html'));
+    res.send(indexFileContents);
   });
 
   Sentry.setupExpressErrorHandler(app);

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -47,7 +47,7 @@ import { AppContext } from './context';
 import { rotateCandidates } from './candidate_rotation';
 import { renderBallotStyleReadinessReport } from './ballot_style_reports';
 import { createBallotPropsForTemplate, defaultBallotTemplate } from './ballots';
-import { DEPLOY_ENV } from './globals';
+import { DEPLOY_ENV, NODE_ENV } from './globals';
 
 export const BALLOT_STYLE_READINESS_REPORT_FILE_NAME =
   'ballot-style-readiness-report.pdf';
@@ -480,12 +480,15 @@ export function buildApp(context: AppContext): Application {
 
   // Serve the index.html file for everything else, adding in some environment variables
   // (we don't need a full templating engine since it's just a couple of variables)
-  const indexFileContents = readFileSync(
-    join(context.workspace.assetDirectoryPath, 'index.html'),
-    'utf8'
-  )
-    .replace('{{ SENTRY_DSN }}', process.env.SENTRY_DSN ?? '')
-    .replace('{{ DEPLOY_ENV }}', DEPLOY_ENV);
+  const indexFileContents =
+    NODE_ENV === 'test'
+      ? ''
+      : readFileSync(
+          join(context.workspace.assetDirectoryPath, 'index.html'),
+          'utf8'
+        )
+          .replace('{{ SENTRY_DSN }}', process.env.SENTRY_DSN ?? '')
+          .replace('{{ DEPLOY_ENV }}', DEPLOY_ENV);
   app.get('*', (_req, res) => {
     res.send(indexFileContents);
   });

--- a/apps/design/backend/src/configure_sentry.ts
+++ b/apps/design/backend/src/configure_sentry.ts
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/node';
 if (process.env.NODE_ENV !== 'test') {
   Sentry.init({
     dsn: process.env.SENTRY_DSN,
-    environment: process.env.NODE_ENV,
+    environment: process.env.DEPLOY_ENV,
     tracesSampleRate: 0.2,
   });
 }

--- a/apps/design/backend/src/env.d.ts
+++ b/apps/design/backend/src/env.d.ts
@@ -2,6 +2,7 @@ declare namespace NodeJS {
   /** process.env typings */
   export interface ProcessEnv {
     readonly CI?: string;
+    readonly DEPLOY_ENV: 'development' | 'staging' | 'production';
     readonly NODE_ENV: 'development' | 'production' | 'test';
     readonly PORT?: string;
     readonly SENTRY_DSN?: string;

--- a/apps/design/backend/src/globals.ts
+++ b/apps/design/backend/src/globals.ts
@@ -2,6 +2,12 @@ import { unsafeParse } from '@votingworks/types';
 import { join } from 'node:path';
 import { z } from 'zod';
 
+/**
+ * Default port for the server.
+ */
+// eslint-disable-next-line vx/gts-safe-number-parse
+export const PORT = Number(process.env.PORT || 3002);
+
 const NodeEnvSchema = z.union([
   z.literal('development'),
   z.literal('test'),
@@ -9,17 +15,26 @@ const NodeEnvSchema = z.union([
 ]);
 
 /**
- * Default port for the server.
- */
-// eslint-disable-next-line vx/gts-safe-number-parse
-export const PORT = Number(process.env.PORT || 3002);
-
-/**
- * Which node environment is this?
+ * Which node environment is this? In any deployment, this should always be set
+ * to 'production'.
  */
 export const NODE_ENV = unsafeParse(
   NodeEnvSchema,
   process.env.NODE_ENV ?? 'development'
+);
+
+const DeployEnvSchema = z.union([
+  z.literal('development'),
+  z.literal('staging'),
+  z.literal('production'),
+]);
+
+/**
+ * Which deployment environment is this (production, staging, development)?
+ */
+export const DEPLOY_ENV = unsafeParse(
+  DeployEnvSchema,
+  process.env.DEPLOY_ENV ?? 'development'
 );
 
 /**

--- a/apps/design/frontend/index.html
+++ b/apps/design/frontend/index.html
@@ -8,6 +8,12 @@
     <meta name="description" content="Another election tool from VotingWorks" />
     <link rel="stylesheet" href="/fonts/noto-emoji.css" />
     <title>VotingWorks VxDesign</title>
+    <script type="text/javascript">
+      // Inject environment variables from the Node backend by rendering
+      // this HTML page as a template
+      window._vxdesign_deploy_env = '{{ DEPLOY_ENV }}';
+      window._vxdesign_sentry_dsn = '{{ SENTRY_DSN }}';
+    </script>
   </head>
 
   <body>

--- a/apps/design/frontend/src/env.d.ts
+++ b/apps/design/frontend/src/env.d.ts
@@ -2,5 +2,6 @@ declare namespace NodeJS {
   export interface ProcessEnv {
     readonly CI?: string;
     readonly NODE_ENV: 'development' | 'production' | 'test';
+    readonly DEPLOY_ENV: 'development' | 'staging' | 'production';
   }
 }

--- a/apps/design/frontend/src/index.tsx
+++ b/apps/design/frontend/src/index.tsx
@@ -6,10 +6,14 @@ import { App } from './app';
 
 /* istanbul ignore next - @preserve */
 if (process.env.NODE_ENV === 'production') {
+  /* eslint-disable no-underscore-dangle */
+  const envVars = window as unknown as {
+    _vxdesign_sentry_dsn: string;
+    _vxdesign_deploy_env: string;
+  };
   Sentry.init({
-    // Note: This isn't a secret
-    dsn: 'https://941de51b2e7e464aaed34ef659f0036a@o471921.ingest.us.sentry.io/4508717994016768',
-    environment: process.env.DEPLOY_ENV,
+    dsn: envVars._vxdesign_sentry_dsn,
+    environment: envVars._vxdesign_deploy_env,
     integrations: [Sentry.browserTracingIntegration()],
     tracesSampleRate: 0.2,
   });

--- a/apps/design/frontend/src/index.tsx
+++ b/apps/design/frontend/src/index.tsx
@@ -9,7 +9,7 @@ if (process.env.NODE_ENV === 'production') {
   Sentry.init({
     // Note: This isn't a secret
     dsn: 'https://941de51b2e7e464aaed34ef659f0036a@o471921.ingest.us.sentry.io/4508717994016768',
-    environment: process.env.NODE_ENV,
+    environment: process.env.DEPLOY_ENV,
     integrations: [Sentry.browserTracingIntegration()],
     tracesSampleRate: 0.2,
   });


### PR DESCRIPTION
## Overview

Follow up to #5898.

`NODE_ENV` needs to always be set to `production` to ensure that staging and production environments run the same code. So we can't use it to differentiate which environment an error occurs in when capturing it with Sentry.

Instead, we add a new env var, `DEPLOY_ENV`. We then load this into Sentry on the backend. We also pass it to the frontend via injecting it into the index.html page as a JS string (the same approach used in Arlo), since we can't inject it at build time since the Dockerfile doesn't have access to config vars during build.

## Demo Video or Screenshot
N/A

## Testing Plan
Manual testing with a review app

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
