### PR TITLE
refactor(design): use `ElectionId` type for election IDs

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -22,7 +22,6 @@ import {
   DEFAULT_SYSTEM_SETTINGS,
   DistrictId,
   Election,
-  ElectionId,
   ElectionStringKey,
   SystemSettings,
   UiStringsPackage,
@@ -32,6 +31,8 @@ import {
   LanguageCode,
   getAllBallotLanguages,
   ElectionPackageFileName,
+  unsafeParse,
+  ElectionIdSchema,
 } from '@votingworks/types';
 import {
   BooleanEnvironmentVariableName,
@@ -129,7 +130,7 @@ test('CRUD elections', async () => {
   const { apiClient } = await setupApp();
   expect(await apiClient.listElections()).toEqual([]);
 
-  const expectedElectionId = 'election-1' as ElectionId;
+  const expectedElectionId = unsafeParse(ElectionIdSchema, 'election-1');
   const electionId = (
     await apiClient.createElection({ id: expectedElectionId })
   ).unsafeUnwrap();
@@ -284,7 +285,7 @@ test('Updating contests with candidate rotation', async () => {
 
 test('Update system settings', async () => {
   const { apiClient } = await setupApp();
-  const electionId = 'election-1' as ElectionId;
+  const electionId = unsafeParse(ElectionIdSchema, 'election-1');
   (await apiClient.createElection({ id: electionId })).unsafeUnwrap();
   const electionRecord = await apiClient.getElection({ electionId });
 
@@ -317,7 +318,7 @@ test('Update system settings', async () => {
 
 test('Update ballot order info', async () => {
   const { apiClient } = await setupApp();
-  const electionId = 'election-1' as ElectionId;
+  const electionId = unsafeParse(ElectionIdSchema, 'election-1');
   (await apiClient.createElection({ id: electionId })).unsafeUnwrap();
 
   const electionRecord = await apiClient.getElection({ electionId });

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -5,7 +5,6 @@ import { join } from 'node:path';
 import {
   Election,
   getPrecinctById,
-  Id,
   safeParseElection,
   HmpbBallotPaperSize,
   SystemSettings,
@@ -129,7 +128,7 @@ function buildApi({ workspace, translator }: AppContext) {
       return store.listElections();
     },
 
-    getElection(input: { electionId: Id }): Promise<ElectionRecord> {
+    getElection(input: { electionId: ElectionId }): Promise<ElectionRecord> {
       return store.getElection(input.electionId);
     },
 
@@ -172,7 +171,7 @@ function buildApi({ workspace, translator }: AppContext) {
     },
 
     async updateElection(input: {
-      electionId: Id;
+      electionId: ElectionId;
       election: Election;
     }): Promise<void> {
       const { election } = await store.getElection(input.electionId);
@@ -185,14 +184,14 @@ function buildApi({ workspace, translator }: AppContext) {
     },
 
     updateSystemSettings(input: {
-      electionId: Id;
+      electionId: ElectionId;
       systemSettings: SystemSettings;
     }): Promise<void> {
       return store.updateSystemSettings(input.electionId, input.systemSettings);
     },
 
     updateBallotOrderInfo(input: {
-      electionId: Id;
+      electionId: ElectionId;
       ballotOrderInfo: BallotOrderInfo;
     }): Promise<void> {
       return store.updateBallotOrderInfo(
@@ -202,29 +201,31 @@ function buildApi({ workspace, translator }: AppContext) {
     },
 
     updatePrecincts(input: {
-      electionId: Id;
+      electionId: ElectionId;
       precincts: Precinct[];
     }): Promise<void> {
       return store.updatePrecincts(input.electionId, input.precincts);
     },
 
-    deleteElection(input: { electionId: Id }): Promise<void> {
+    deleteElection(input: { electionId: ElectionId }): Promise<void> {
       return store.deleteElection(input.electionId);
     },
 
-    getBallotsFinalizedAt(input: { electionId: Id }): Promise<Date | null> {
+    getBallotsFinalizedAt(input: {
+      electionId: ElectionId;
+    }): Promise<Date | null> {
       return store.getBallotsFinalizedAt(input.electionId);
     },
 
     setBallotsFinalizedAt(input: {
-      electionId: Id;
+      electionId: ElectionId;
       finalizedAt: Date | null;
     }): Promise<void> {
       return store.setBallotsFinalizedAt(input);
     },
 
     async exportAllBallots(input: {
-      electionId: Id;
+      electionId: ElectionId;
       electionSerializationFormat: ElectionSerializationFormat;
     }): Promise<{ zipContents: Buffer; ballotHash: string }> {
       const {
@@ -297,7 +298,7 @@ function buildApi({ workspace, translator }: AppContext) {
     },
 
     async getBallotPreviewPdf(input: {
-      electionId: Id;
+      electionId: ElectionId;
       precinctId: string;
       ballotStyleId: BallotStyleId;
       ballotType: BallotType;
@@ -364,7 +365,7 @@ function buildApi({ workspace, translator }: AppContext) {
     getElectionPackage({
       electionId,
     }: {
-      electionId: Id;
+      electionId: ElectionId;
     }): Promise<ElectionPackage> {
       return store.getElectionPackage(electionId);
     },
@@ -373,7 +374,7 @@ function buildApi({ workspace, translator }: AppContext) {
       electionId,
       electionSerializationFormat,
     }: {
-      electionId: Id;
+      electionId: ElectionId;
       electionSerializationFormat: ElectionSerializationFormat;
     }): Promise<void> {
       return store.createElectionPackageBackgroundTask(
@@ -383,7 +384,7 @@ function buildApi({ workspace, translator }: AppContext) {
     },
 
     async exportTestDecks(input: {
-      electionId: Id;
+      electionId: ElectionId;
       electionSerializationFormat: ElectionSerializationFormat;
     }): Promise<{ zipContents: Buffer; ballotHash: string }> {
       const {
@@ -459,7 +460,7 @@ function buildApi({ workspace, translator }: AppContext) {
     },
 
     async setBallotTemplate(input: {
-      electionId: Id;
+      electionId: ElectionId;
       ballotTemplateId: BallotTemplateId;
     }): Promise<void> {
       await store.setBallotTemplate(input.electionId, input.ballotTemplateId);

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -11,6 +11,7 @@ import {
   LanguageCode,
   getBallotLanguageConfigs,
   safeParseJson,
+  ElectionId,
 } from '@votingworks/types';
 import { v4 as uuid } from 'uuid';
 import {
@@ -197,7 +198,7 @@ export class Store {
     );
   }
 
-  async getElection(electionId: Id): Promise<ElectionRecord> {
+  async getElection(electionId: ElectionId): Promise<ElectionRecord> {
     const electionRow = (
       await this.db.withClient((client) =>
         client.query(
@@ -261,7 +262,10 @@ export class Store {
     );
   }
 
-  async updateElection(electionId: Id, election: Election): Promise<void> {
+  async updateElection(
+    electionId: ElectionId,
+    election: Election
+  ): Promise<void> {
     await this.db.withClient((client) =>
       client.query(
         `
@@ -276,7 +280,7 @@ export class Store {
   }
 
   async updateSystemSettings(
-    electionId: Id,
+    electionId: ElectionId,
     systemSettings: SystemSettings
   ): Promise<void> {
     await this.db.withClient((client) =>
@@ -293,7 +297,7 @@ export class Store {
   }
 
   async updateBallotOrderInfo(
-    electionId: Id,
+    electionId: ElectionId,
     ballotOrderInfo: BallotOrderInfo
   ): Promise<void> {
     await this.db.withClient((client) =>
@@ -309,7 +313,10 @@ export class Store {
     );
   }
 
-  async updatePrecincts(electionId: Id, precincts: Precinct[]): Promise<void> {
+  async updatePrecincts(
+    electionId: ElectionId,
+    precincts: Precinct[]
+  ): Promise<void> {
     await this.db.withClient((client) =>
       client.query(
         `
@@ -323,13 +330,13 @@ export class Store {
     );
   }
 
-  async deleteElection(electionId: Id): Promise<void> {
+  async deleteElection(electionId: ElectionId): Promise<void> {
     await this.db.withClient((client) =>
       client.query(`delete from elections where id = $1`, electionId)
     );
   }
 
-  async getElectionPackage(electionId: Id): Promise<ElectionPackage> {
+  async getElectionPackage(electionId: ElectionId): Promise<ElectionPackage> {
     const electionPackage = (
       await this.db.withClient((client) =>
         client.query(
@@ -356,7 +363,7 @@ export class Store {
   }
 
   async createElectionPackageBackgroundTask(
-    electionId: Id,
+    electionId: ElectionId,
     electionSerializationFormat: ElectionSerializationFormat
   ): Promise<void> {
     await this.db.withClient(async (client) =>
@@ -393,7 +400,7 @@ export class Store {
     electionId,
     electionPackageUrl,
   }: {
-    electionId: Id;
+    electionId: ElectionId;
     electionPackageUrl: string;
   }): Promise<void> {
     await this.db.withClient((client) =>
@@ -409,7 +416,7 @@ export class Store {
     );
   }
 
-  async getBallotsFinalizedAt(electionId: Id): Promise<Date | null> {
+  async getBallotsFinalizedAt(electionId: ElectionId): Promise<Date | null> {
     const { ballots_finalized_at: ballotsFinalizedAt } = (
       await this.db.withClient((client) =>
         client.query(
@@ -429,7 +436,7 @@ export class Store {
     electionId,
     finalizedAt,
   }: {
-    electionId: Id;
+    electionId: ElectionId;
     finalizedAt: Date | null;
   }): Promise<void> {
     await this.db.withClient((client) =>
@@ -446,7 +453,7 @@ export class Store {
   }
 
   async setBallotTemplate(
-    electionId: Id,
+    electionId: ElectionId,
     ballotTemplateId: BallotTemplateId
   ): Promise<void> {
     await this.db.withClient((client) =>

--- a/apps/design/backend/src/worker/generate_election_package.ts
+++ b/apps/design/backend/src/worker/generate_election_package.ts
@@ -4,7 +4,6 @@ import {
   ElectionSerializationFormat,
   ElectionPackageFileName,
   ElectionPackageMetadata,
-  Id,
   mergeUiStrings,
   Election,
   formatElectionHashes,
@@ -12,6 +11,7 @@ import {
   SystemSettings,
   MarkThresholds,
   AdjudicationReason,
+  ElectionId,
 } from '@votingworks/types';
 import {
   renderMinimalBallotsToCreateElectionDefinition,
@@ -70,7 +70,7 @@ export async function generateElectionPackage(
     electionId,
     electionSerializationFormat,
   }: {
-    electionId: Id;
+    electionId: ElectionId;
     electionSerializationFormat: ElectionSerializationFormat;
   }
 ): Promise<void> {

--- a/apps/design/backend/src/worker/tasks.ts
+++ b/apps/design/backend/src/worker/tasks.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { throwIllegalValue } from '@votingworks/basics';
 import {
+  ElectionIdSchema,
   ElectionSerializationFormatSchema,
   safeParseJson,
 } from '@votingworks/types';
@@ -18,7 +19,7 @@ export async function processBackgroundTask(
       const parsedPayload = safeParseJson(
         payload,
         z.object({
-          electionId: z.string(),
+          electionId: ElectionIdSchema,
           electionSerializationFormat: ElectionSerializationFormatSchema,
         })
       ).unsafeUnwrap();

--- a/apps/design/backend/test/helpers.ts
+++ b/apps/design/backend/test/helpers.ts
@@ -6,7 +6,11 @@ import * as tmp from 'tmp';
 import * as grout from '@votingworks/grout';
 import { suppressingConsoleOutput } from '@votingworks/test-utils';
 import { assertDefined } from '@votingworks/basics';
-import { ElectionSerializationFormat, LanguageCode } from '@votingworks/types';
+import {
+  ElectionId,
+  ElectionSerializationFormat,
+  LanguageCode,
+} from '@votingworks/types';
 import { mockBaseLogger } from '@votingworks/logging';
 import {
   makeMockGoogleCloudTextToSpeechClient,
@@ -110,7 +114,7 @@ export async function exportElectionPackage({
   electionSerializationFormat,
 }: {
   apiClient: ApiClient;
-  electionId: string;
+  electionId: ElectionId;
   workspace: Workspace;
   electionSerializationFormat: ElectionSerializationFormat;
 }): Promise<string> {

--- a/apps/design/frontend/package.json
+++ b/apps/design/frontend/package.json
@@ -86,7 +86,8 @@
     "react-router-dom": "^5.3.4",
     "sanitize-html": "^2.13.0",
     "styled-components": "^5.3.11",
-    "util": "^0.12.4"
+    "util": "^0.12.4",
+    "zod": "3.23.5"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.17.0",

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -8,7 +8,7 @@ import {
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query';
-import { BallotStyleId, BallotType, Id } from '@votingworks/types';
+import { BallotStyleId, BallotType, ElectionId, Id } from '@votingworks/types';
 
 export type ApiClient = grout.Client<Api>;
 
@@ -59,7 +59,7 @@ export const getElection = {
   queryKey(id: Id): QueryKey {
     return ['getElection', id];
   },
-  useQuery(id: Id) {
+  useQuery(id: ElectionId) {
     const apiClient = useApiClient();
     return useQuery(this.queryKey(id), () =>
       apiClient.getElection({ electionId: id })
@@ -163,10 +163,10 @@ export const deleteElection = {
 } as const;
 
 export const getBallotsFinalizedAt = {
-  queryKey(electionId: Id): QueryKey {
+  queryKey(electionId: ElectionId): QueryKey {
     return ['getBallotsFinalizedAt', electionId];
   },
-  useQuery(electionId: Id) {
+  useQuery(electionId: ElectionId) {
     const apiClient = useApiClient();
     return useQuery(this.queryKey(electionId), () =>
       apiClient.getBallotsFinalizedAt({ electionId })
@@ -196,7 +196,7 @@ export const exportAllBallots = {
 } as const;
 
 interface GetBallotPreviewInput {
-  electionId: Id;
+  electionId: ElectionId;
   precinctId: string;
   ballotStyleId: BallotStyleId;
   ballotType: BallotType;
@@ -219,10 +219,10 @@ export const getBallotPreviewPdf = {
 } as const;
 
 export const getElectionPackage = {
-  queryKey(electionId: Id): QueryKey {
+  queryKey(electionId: ElectionId): QueryKey {
     return ['getElectionPackage', electionId];
   },
-  useQuery(electionId: Id) {
+  useQuery(electionId: ElectionId) {
     const apiClient = useApiClient();
     return useQuery(
       this.queryKey(electionId),

--- a/apps/design/frontend/src/ballot_order_info_screen.tsx
+++ b/apps/design/frontend/src/ballot_order_info_screen.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
-import { Id } from '@votingworks/types';
+import { z } from 'zod';
+import { ElectionId, ElectionIdSchema, unsafeParse } from '@votingworks/types';
 import {
   Button,
   CheckboxButton,
@@ -33,7 +34,7 @@ function BallotOrderInfoForm({
   electionId,
   savedBallotOrderInfo,
 }: {
-  electionId: Id;
+  electionId: ElectionId;
   savedBallotOrderInfo: BallotOrderInfo;
 }): JSX.Element {
   const [isEditing, setIsEditing] = useState(false);
@@ -201,7 +202,11 @@ function BallotOrderInfoForm({
 }
 
 export function BallotOrderInfoScreen(): JSX.Element | null {
-  const { electionId } = useParams<{ electionId: string }>();
+  const params = useParams<{ electionId: string }>();
+  const { electionId } = unsafeParse(
+    z.object({ electionId: ElectionIdSchema }),
+    params
+  );
   const getElectionQuery = getElection.useQuery(electionId);
 
   if (!getElectionQuery.isSuccess) {

--- a/apps/design/frontend/src/ballot_screen.tsx
+++ b/apps/design/frontend/src/ballot_screen.tsx
@@ -7,11 +7,15 @@ import {
   HmpbBallotPaperSize,
   BallotType,
   getPartyForBallotStyle,
-  BallotStyleId,
+  unsafeParse,
+  ElectionIdSchema,
+  BallotStyleIdSchema,
+  PrecinctIdSchema,
 } from '@votingworks/types';
 import { Buffer } from 'node:buffer';
 import React, { useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
+import { z } from 'zod';
 import {
   Button,
   Card,
@@ -215,11 +219,19 @@ export const paperSizeLabels: Record<HmpbBallotPaperSize, string> = {
 };
 
 export function BallotScreen(): JSX.Element | null {
-  const { electionId, ballotStyleId, precinctId } = useParams<{
+  const params = useParams<{
     electionId: string;
-    ballotStyleId: BallotStyleId;
+    ballotStyleId: string;
     precinctId: string;
   }>();
+  const { electionId, ballotStyleId, precinctId } = unsafeParse(
+    z.object({
+      electionId: ElectionIdSchema,
+      ballotStyleId: BallotStyleIdSchema,
+      precinctId: PrecinctIdSchema,
+    }),
+    params
+  );
 
   const getElectionQuery = getElection.useQuery(electionId);
   const [ballotType, setBallotType] = useState<BallotType>(BallotType.Precinct);

--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -23,6 +23,7 @@ import {
   HmpbBallotPaperSize,
   Election,
   getPartyForBallotStyle,
+  ElectionId,
 } from '@votingworks/types';
 import React, { useState } from 'react';
 import styled from 'styled-components';
@@ -42,7 +43,7 @@ function BallotDesignForm({
   electionId,
   savedElection,
 }: {
-  electionId: string;
+  electionId: ElectionId;
   savedElection: Election;
 }): JSX.Element {
   const [isEditing, setIsEditing] = useState(false);

--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -30,7 +30,7 @@ import {
   Contests,
   DistrictId,
   Election,
-  Id,
+  ElectionId,
   Party,
   PartyId,
   YesNoContest,
@@ -348,7 +348,7 @@ function ContestForm({
   contestId,
   savedElection,
 }: {
-  electionId: Id;
+  electionId: ElectionId;
   contestId?: ContestId;
   savedElection: Election;
 }): JSX.Element | null {
@@ -835,7 +835,7 @@ function PartyForm({
   partyId,
   savedElection,
 }: {
-  electionId: Id;
+  electionId: ElectionId;
   partyId?: PartyId;
   savedElection: Election;
 }): JSX.Element {

--- a/apps/design/frontend/src/election_info_screen.tsx
+++ b/apps/design/frontend/src/election_info_screen.tsx
@@ -1,5 +1,11 @@
 import React, { useState } from 'react';
-import { Election, Id } from '@votingworks/types';
+import {
+  Election,
+  ElectionId,
+  ElectionIdSchema,
+  Id,
+  unsafeParse,
+} from '@votingworks/types';
 import {
   Button,
   H1,
@@ -9,6 +15,7 @@ import {
 } from '@votingworks/ui';
 import { useHistory, useParams } from 'react-router-dom';
 import styled from 'styled-components';
+import { z } from 'zod';
 import { DateWithoutTime } from '@votingworks/basics';
 import { deleteElection, getElection, updateElection } from './api';
 import { FieldName, Form, FormActionsRow, InputGroup } from './layout';
@@ -40,7 +47,7 @@ function ElectionInfoForm({
   electionId,
   savedElection,
 }: {
-  electionId: Id;
+  electionId: ElectionId;
   savedElection: Election;
 }): JSX.Element {
   const [isEditing, setIsEditing] = useState(
@@ -190,7 +197,11 @@ function ElectionInfoForm({
 }
 
 export function ElectionInfoScreen(): JSX.Element | null {
-  const { electionId } = useParams<{ electionId: string }>();
+  const params = useParams<{ electionId: string }>();
+  const { electionId } = unsafeParse(
+    z.object({ electionId: ElectionIdSchema }),
+    params
+  );
   const getElectionQuery = getElection.useQuery(electionId);
 
   if (!getElectionQuery.isSuccess) {

--- a/apps/design/frontend/src/election_info_screen.tsx
+++ b/apps/design/frontend/src/election_info_screen.tsx
@@ -3,7 +3,6 @@ import {
   Election,
   ElectionId,
   ElectionIdSchema,
-  Id,
   unsafeParse,
 } from '@votingworks/types';
 import {

--- a/apps/design/frontend/src/features_context.tsx
+++ b/apps/design/frontend/src/features_context.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext } from 'react';
 import { assertDefined } from '@votingworks/basics';
+import { ElectionId } from '@votingworks/types';
 import { getElection } from './api';
 
 export enum FeatureName {
@@ -38,7 +39,7 @@ export function useFeaturesContext(): FeaturesEnabledRecord {
 
 interface FeaturesProviderProps {
   children: React.ReactNode;
-  electionId?: string;
+  electionId?: ElectionId;
 }
 
 export function FeaturesProvider({

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -26,7 +26,7 @@ import {
   District,
   DistrictId,
   Election,
-  Id,
+  ElectionId,
   PrecinctId,
 } from '@votingworks/types';
 import { assert } from '@votingworks/basics';
@@ -118,7 +118,7 @@ function DistrictForm({
   savedElection,
   savedPrecincts,
 }: {
-  electionId: Id;
+  electionId: ElectionId;
   districtId?: string;
   savedElection: Election;
   savedPrecincts?: Precinct[];
@@ -424,7 +424,7 @@ function PrecinctForm({
   savedPrecincts,
   districts,
 }: {
-  electionId: Id;
+  electionId: ElectionId;
   precinctId?: PrecinctId;
   savedPrecincts: Precinct[];
   districts: readonly District[];

--- a/apps/design/frontend/src/nav_screen.tsx
+++ b/apps/design/frontend/src/nav_screen.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ElectionId } from '@votingworks/types';
 import {
   AppLogo,
   LeftNav,
@@ -37,7 +38,7 @@ export function ElectionNavScreen({
   electionId,
   children,
 }: {
-  electionId: string;
+  electionId: ElectionId;
   children: React.ReactNode;
 }): JSX.Element {
   const currentRoute = useRouteMatch();

--- a/apps/design/frontend/src/routes.ts
+++ b/apps/design/frontend/src/routes.ts
@@ -1,4 +1,4 @@
-import { Id } from '@votingworks/types';
+import { ElectionId } from '@votingworks/types';
 import { Route } from '@votingworks/ui';
 
 export const routes = {
@@ -120,12 +120,12 @@ export const routes = {
 } as const;
 
 export interface ElectionIdParams {
-  electionId: Id;
+  electionId: ElectionId;
 }
 export const electionParamRoutes = routes.election(':electionId');
 
 export const rootNavRoutes: Route[] = [];
-export function electionNavRoutes(electionId: string): Route[] {
+export function electionNavRoutes(electionId: ElectionId): Route[] {
   const electionRoutes = routes.election(electionId);
   return [
     electionRoutes.electionInfo,

--- a/apps/design/frontend/src/tabulation_screen.tsx
+++ b/apps/design/frontend/src/tabulation_screen.tsx
@@ -10,7 +10,11 @@ import {
   CheckboxButton,
 } from '@votingworks/ui';
 import { useParams } from 'react-router-dom';
-import { AdjudicationReason, Id, SystemSettings } from '@votingworks/types';
+import {
+  AdjudicationReason,
+  ElectionId,
+  SystemSettings,
+} from '@votingworks/types';
 import { Form, Column, Row, FormActionsRow, InputGroup } from './layout';
 import { ElectionNavScreen } from './nav_screen';
 import { ElectionIdParams } from './routes';
@@ -28,7 +32,7 @@ export function TabulationForm({
   electionId,
   savedSystemSettings,
 }: {
-  electionId: Id;
+  electionId: ElectionId;
   savedSystemSettings: SystemSettings;
 }): JSX.Element {
   const [isEditing, setIsEditing] = useState(false);

--- a/apps/design/frontend/test/api_helpers.tsx
+++ b/apps/design/frontend/test/api_helpers.tsx
@@ -1,6 +1,7 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import type { Api } from '@votingworks/design-backend';
 import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
+import { ElectionId } from '@votingworks/types';
 import { TestErrorBoundary } from '@votingworks/ui';
 import { ApiClientContext, createQueryClient } from '../src/api';
 import { FeaturesProvider } from '../src/features_context';
@@ -14,7 +15,7 @@ export function createMockApiClient(): MockApiClient {
 export function provideApi(
   apiMock: ReturnType<typeof createMockApiClient>,
   children: React.ReactNode,
-  electionId?: string
+  electionId?: ElectionId
 ): JSX.Element {
   return (
     <TestErrorBoundary>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1390,6 +1390,9 @@ importers:
       util:
         specifier: ^0.12.4
         version: 0.12.4
+      zod:
+        specifier: 3.23.5
+        version: 3.23.5
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^5.17.0
@@ -5697,41 +5700,59 @@ packages:
       '@babel/helper-function-name': 7.22.5
       '@babel/helper-member-expression-to-functions': 7.22.5
       '@babel/helper-optimise-call-expression': 7.22.5
-      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.22.9)
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.26.0)
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       semver: 6.3.1
     dev: true
 
-  /@babel/helper-create-regexp-features-plugin@7.20.5(@babel/core@7.22.9):
+  /@babel/helper-create-class-features-plugin@7.22.10(@babel/core@7.26.0):
+    resolution: {integrity: sha512-5IBb77txKYQPpOEdUdIhBx8VrZyDCQ+H82H0+5dX1TmuscP5vJKEE3cKurjtIw/vFwzbVH48VweE78kVDBrqjA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-member-expression-to-functions': 7.22.5
+      '@babel/helper-optimise-call-expression': 7.22.5
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.26.0)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      semver: 6.3.1
+    dev: true
+
+  /@babel/helper-create-regexp-features-plugin@7.20.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-m68B1lkg3XDGX5yCvGO0kPx3v9WIYLnzjKfPcQiwntEQa5ZeRkPmo2X/ISJc8qxWGfwUr+kvZAeEzAwLec2r2w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-annotate-as-pure': 7.22.5
       regexpu-core: 5.2.2
     dev: true
 
-  /@babel/helper-create-regexp-features-plugin@7.22.9(@babel/core@7.22.9):
+  /@babel/helper-create-regexp-features-plugin@7.22.9(@babel/core@7.26.0):
     resolution: {integrity: sha512-+svjVa/tFwsNSG4NEy1h85+HQ5imbT92Q5/bgtS7P0GTQlP8WuFdqsiABmQouhiFGyV66oGxZFpeYHza1rNsKw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-annotate-as-pure': 7.22.5
       regexpu-core: 5.3.2
       semver: 6.3.1
     dev: true
 
-  /@babel/helper-define-polyfill-provider@0.4.2(@babel/core@7.22.9):
+  /@babel/helper-define-polyfill-provider@0.4.2(@babel/core@7.26.0):
     resolution: {integrity: sha512-k0qnnOqHn5dK9pZpfD5XXZ9SojAITdCKRn2Lp6rnDGzIbaP0rHyMPk/4wsSxVBVz4RfN0q6VpXWP2pDGIoQ7hw==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-compilation-targets': 7.22.10
       '@babel/helper-plugin-utils': 7.22.5
       debug: 4.3.4(supports-color@5.5.0)
@@ -5827,6 +5848,20 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.22.5
 
+  /@babel/helper-module-transforms@7.22.9(@babel/core@7.26.0):
+    resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-validator-identifier': 7.22.5
+    dev: true
+
   /@babel/helper-module-transforms@7.26.0(@babel/core@7.26.0):
     resolution: {integrity: sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==}
     engines: {node: '>=6.9.0'}
@@ -5866,25 +5901,25 @@ packages:
     resolution: {integrity: sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/helper-remap-async-to-generator@7.22.9(@babel/core@7.22.9):
+  /@babel/helper-remap-async-to-generator@7.22.9(@babel/core@7.26.0):
     resolution: {integrity: sha512-8WWC4oR4Px+tr+Fp0X3RHDVfINGpF3ad1HIbrc8A77epiR6eMMc6jsgozkzT2uDiOOdoS9cLIQ+XD2XvI2WSmQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-wrap-function': 7.22.10
     dev: true
 
-  /@babel/helper-replace-supers@7.22.9(@babel/core@7.22.9):
+  /@babel/helper-replace-supers@7.22.9(@babel/core@7.26.0):
     resolution: {integrity: sha512-LJIKvvpgPOPUThdYqcX6IXRuIcTkcAub0IaDRGCZH0p5GPUp7PhRU9QVgFcDDd51BaPkk77ZjqFwh6DZTAEmGg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-member-expression-to-functions': 7.22.5
       '@babel/helper-optimise-call-expression': 7.22.5
@@ -5981,26 +6016,26 @@ packages:
     dependencies:
       '@babel/types': 7.26.0
 
-  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-NP1M5Rf+u2Gw9qfSO4ihjcTGW5zXTi36ITLd4/EoAcEhIZ0yjMqmftDNl3QC19CX7olhrjpyU454g/2W7X0jvQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-31Bb65aZaUwqCbWMnZPduIZxCBngHFlzyN6Dq6KAJjtx+lx6ohKHubc61OomYi7XwVD4Ol0XCVz4h+pYFR048g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.13.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-transform-optional-chaining': 7.22.10(@babel/core@7.22.9)
+      '@babel/plugin-transform-optional-chaining': 7.22.10(@babel/core@7.26.0)
     dev: true
 
   /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.22.9):
@@ -6037,13 +6072,13 @@ packages:
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.22.9)
     dev: true
 
-  /@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.22.9):
+  /@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.26.0):
     resolution: {integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
     dev: true
 
   /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.22.9):
@@ -6094,31 +6129,31 @@ packages:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.22.9):
+  /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.22.9):
+  /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.26.0):
     resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.22.9):
+  /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.26.0):
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -6132,23 +6167,23 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-syntax-import-assertions@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-syntax-import-assertions@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-rdV97N7KqsRzeNGoWUOK6yUsWarLjE5Su/Snk9IYPU9CwkWHs4t+rTGOvffTR8XGkJMTAdLfO0xVnXm8wugIJg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-syntax-import-attributes@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-syntax-import-attributes@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-KwvoWDeNKPETmozyFE0P2rOLqh39EoQHNjqizrI5B8Vt0ZNS7M56s7dAiAqbYfiAYOuIzIh96z3iR2ktgu3tEg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -6318,13 +6353,13 @@ packages:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.22.9):
+  /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -6364,186 +6399,186 @@ packages:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.22.9):
+  /@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.26.0):
     resolution: {integrity: sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-arrow-functions@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-arrow-functions@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-26lTNXoVRdAnsaDXPpvCNUq+OVWEVC6bx7Vvz9rC53F2bagUWW4u4ii2+h8Fejfh7RYqPxn+libeFBBck9muEw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-async-generator-functions@7.22.10(@babel/core@7.22.9):
+  /@babel/plugin-transform-async-generator-functions@7.22.10(@babel/core@7.26.0):
     resolution: {integrity: sha512-eueE8lvKVzq5wIObKK/7dvoeKJ+xc6TvRn6aysIjS6pSCeLy7S/eVi7pEQknZqyqvzaNKdDtem8nUNTBgDVR2g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.22.9)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.22.9)
+      '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.26.0)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.26.0)
     dev: true
 
-  /@babel/plugin-transform-async-to-generator@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-async-to-generator@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-b1A8D8ZzE/VhNDoV1MSJTnpKkCG5bJo+19R4o4oy03zM7ws8yEMK755j61Dc3EyvdysbqH5BOOTquJ7ZX9C6vQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-module-imports': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.22.9)
+      '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.26.0)
     dev: true
 
-  /@babel/plugin-transform-block-scoped-functions@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-block-scoped-functions@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-tdXZ2UdknEKQWKJP1KMNmuF5Lx3MymtMN/pvA+p/VEkhK8jVcQ1fzSy8KM9qRYhAf2/lV33hoMPKI/xaI9sADA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-block-scoping@7.22.10(@babel/core@7.22.9):
+  /@babel/plugin-transform-block-scoping@7.22.10(@babel/core@7.26.0):
     resolution: {integrity: sha512-1+kVpGAOOI1Albt6Vse7c8pHzcZQdQKW+wJH+g8mCaszOdDVwRXa/slHPqIw+oJAJANTKDMuM2cBdV0Dg618Vg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-class-properties@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-class-properties@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-nDkQ0NfkOhPTq8YCLiWNxp1+f9fCobEjCb0n8WdbNUBc4IB5V7P1QnX9IjpSoquKrXF5SKojHleVNs2vGeHCHQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-class-static-block@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-class-static-block@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-SPToJ5eYZLxlnp1UzdARpOGeC2GbHvr9d/UV0EukuVx8atktg194oe+C5BqQ8jRTkgLRVOPYeXRSBg1IlMoVRA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.22.9)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.26.0)
     dev: true
 
-  /@babel/plugin-transform-classes@7.22.6(@babel/core@7.22.9):
+  /@babel/plugin-transform-classes@7.22.6(@babel/core@7.26.0):
     resolution: {integrity: sha512-58EgM6nuPNG6Py4Z3zSuu0xWu2VfodiMi72Jt5Kj2FECmaYk1RrTXA45z6KBFsu9tRgwQDwIiY4FXTt+YsSFAQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-compilation-targets': 7.22.10
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-function-name': 7.22.5
       '@babel/helper-optimise-call-expression': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.22.9)
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.26.0)
       '@babel/helper-split-export-declaration': 7.22.6
       globals: 11.12.0
     dev: true
 
-  /@babel/plugin-transform-computed-properties@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-computed-properties@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-4GHWBgRf0krxPX+AaPtgBAlTgTeZmqDynokHOX7aqqAB4tHs3U2Y02zH6ETFdLZGcg9UQSD1WCmkVrE9ErHeOg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/template': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-destructuring@7.22.10(@babel/core@7.22.9):
+  /@babel/plugin-transform-destructuring@7.22.10(@babel/core@7.26.0):
     resolution: {integrity: sha512-dPJrL0VOyxqLM9sritNbMSGx/teueHF/htMKrPT7DNxccXxRDPYqlgPFFdr8u+F+qUZOkZoXue/6rL5O5GduEw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-dotall-regex@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-dotall-regex@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-5/Yk9QxCQCl+sOIB1WelKnVRxTJDSAIxtJLL2/pqL14ZVlbH0fUQUZa/T5/UnQtBNgghR7mfB8ERBKyKPCi7Vw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-duplicate-keys@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-duplicate-keys@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-dEnYD+9BBgld5VBXHnF/DbYGp3fqGMsyxKbtD1mDyIA7AkTSpKXFhCVuj/oQVOoALfBs77DudA0BE4d5mcpmqw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-dynamic-import@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-dynamic-import@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-0MC3ppTB1AMxd8fXjSrbPa7LT9hrImt+/fcj+Pg5YMD7UQyWp/02+JWpdnCymmsXwIx5Z+sYn1bwCn4ZJNvhqQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.22.9)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.26.0)
     dev: true
 
-  /@babel/plugin-transform-exponentiation-operator@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-exponentiation-operator@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-vIpJFNM/FjZ4rh1myqIya9jXwrwwgFRHPjT3DkUA9ZLHuzox8jiXkOLvwm1H+PQIP3CqfC++WPKeuDi0Sjdj1g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.10
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-export-namespace-from@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-export-namespace-from@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-X4hhm7FRnPgd4nDA4b/5V280xCx6oL7Oob5+9qVS5C13Zq4bh1qq7LU0GgRU6b5dBWBvhGaXYVB4AcN6+ol6vg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.22.9)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.26.0)
     dev: true
 
   /@babel/plugin-transform-flow-strip-types@7.19.0(@babel/core@7.22.9):
@@ -6557,78 +6592,78 @@ packages:
       '@babel/plugin-syntax-flow': 7.18.6(@babel/core@7.22.9)
     dev: true
 
-  /@babel/plugin-transform-for-of@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-for-of@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-3kxQjX1dU9uudwSshyLeEipvrLjBCVthCgeTp6CzE/9JYrlAIaeekVxRpCWsDDfYTfRZRoCeZatCQvwo+wvK8A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-function-name@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-function-name@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-UIzQNMS0p0HHiQm3oelztj+ECwFnj+ZRV4KnguvlsD2of1whUeM6o7wGNj6oLwcDoAXQ8gEqfgC24D+VdIcevg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-compilation-targets': 7.22.10
       '@babel/helper-function-name': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-json-strings@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-json-strings@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-DuCRB7fu8MyTLbEQd1ew3R85nx/88yMoqo2uPSjevMj3yoN7CDM8jkgrY0wmVxfJZyJ/B9fE1iq7EQppWQmR5A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.22.9)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.26.0)
     dev: true
 
-  /@babel/plugin-transform-literals@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-literals@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-fTLj4D79M+mepcw3dgFBTIDYpbcB9Sm0bpm4ppXPaO+U+PKFFyV9MGRvS0gvGw62sd10kT5lRMKXAADb9pWy8g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-logical-assignment-operators@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-logical-assignment-operators@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-MQQOUW1KL8X0cDWfbwYP+TbVbZm16QmQXJQ+vndPtH/BoO0lOKpVoEDMI7+PskYxH+IiE0tS8xZye0qr1lGzSA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.22.9)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.26.0)
     dev: true
 
-  /@babel/plugin-transform-member-expression-literals@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-member-expression-literals@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-RZEdkNtzzYCFl9SE9ATaUMTj2hqMb4StarOJLrZRbqqU4HSBE7UlBw9WBWQiDzrJZJdUWiMTVDI6Gv/8DPvfew==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-modules-amd@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-modules-amd@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-R+PTfLTcYEmb1+kK7FNkhQ1gP4KgjpSO6HfH9+f8/yfp2Nt3ggBjiVpRwmwTlfqZLafYKJACy36yDXlEmI9HjQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -6639,167 +6674,179 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.9)
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-simple-access': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-modules-systemjs@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-modules-commonjs@7.22.5(@babel/core@7.26.0):
+    resolution: {integrity: sha512-B4pzOXj+ONRmuaQTg05b3y/4DuFz3WcCNAXPLb2Q0GT0TrGKGxNKV4jwsXts+StaM0LQczZbOpj8o1DLPDJIiA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.26.0)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-simple-access': 7.22.5
+    dev: true
+
+  /@babel/plugin-transform-modules-systemjs@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-emtEpoaTMsOs6Tzz+nbmcePl6AKVtS1yC4YNAeMun9U8YCsgadPNxnOPQ8GhHFB2qdx+LZu9LgoC0Lthuu05DQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-hoist-variables': 7.22.5
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.9)
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-identifier': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-modules-umd@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-modules-umd@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-+S6kzefN/E1vkSsKx8kmQuqeQsvCKCd1fraCM7zXm4SFoggI099Tr4G8U81+5gtMdUeMQ4ipdQffbKLX0/7dBQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-YgLLKmS3aUBhHaxp5hi1WJTgOUb/NCuDHzGT9z9WTt3YG+CPRhJs6nprbStx6DnWM4dh6gt7SU3sZodbZ08adQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-new-target@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-new-target@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-AsF7K0Fx/cNKVyk3a+DW0JLo+Ua598/NxMRvxDnkpCIGFh43+h/v2xyhRUYf6oD8gE4QtL83C7zZVghMjHd+iw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-nullish-coalescing-operator@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-nullish-coalescing-operator@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-6CF8g6z1dNYZ/VXok5uYkkBBICHZPiGEl7oDnAx2Mt1hlHVHOSIKWJaXHjQJA5VB43KZnXZDIexMchY4y2PGdA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.22.9)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.26.0)
     dev: true
 
-  /@babel/plugin-transform-numeric-separator@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-numeric-separator@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-NbslED1/6M+sXiwwtcAB/nieypGw02Ejf4KtDeMkCEpP6gWFMX1wI9WKYua+4oBneCCEmulOkRpwywypVZzs/g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.22.9)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.26.0)
     dev: true
 
-  /@babel/plugin-transform-object-rest-spread@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-object-rest-spread@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-Kk3lyDmEslH9DnvCDA1s1kkd3YWQITiBOHngOtDL9Pt6BZjzqb6hiOlb8VfjiiQJ2unmegBqZu0rx5RxJb5vmQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.22.9
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-compilation-targets': 7.22.10
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.22.9)
-      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.22.9)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.26.0)
     dev: true
 
-  /@babel/plugin-transform-object-super@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-object-super@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-klXqyaT9trSjIUrcsYIfETAzmOEZL3cBYqOYLJxBHfMFFggmXOv+NYSX/Jbs9mzMVESw/WycLFPRx8ba/b2Ipw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.22.9)
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.26.0)
     dev: true
 
-  /@babel/plugin-transform-optional-catch-binding@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-optional-catch-binding@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-pH8orJahy+hzZje5b8e2QIlBWQvGpelS76C63Z+jhZKsmzfNaPQ+LaW6dcJ9bxTpo1mtXbgHwy765Ro3jftmUg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.22.9)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.26.0)
     dev: true
 
-  /@babel/plugin-transform-optional-chaining@7.22.10(@babel/core@7.22.9):
+  /@babel/plugin-transform-optional-chaining@7.22.10(@babel/core@7.26.0):
     resolution: {integrity: sha512-MMkQqZAZ+MGj+jGTG3OTuhKeBpNcO+0oCEbrGNEaOmiEn+1MzRyQlYsruGiU8RTK3zV6XwrVJTmwiDOyYK6J9g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.22.9)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.26.0)
     dev: true
 
-  /@babel/plugin-transform-parameters@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-parameters@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-AVkFUBurORBREOmHRKo06FjHYgjrabpdqRSwq6+C7R5iTCZOsM4QbcB27St0a4U6fffyAOqh3s/qEfybAhfivg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-private-methods@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-private-methods@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-PPjh4gyrQnGe97JTalgRGMuU4icsZFnWkzicB/fUtzlKUqvsWBKEpPPfr5a2JiyirZkHxnAqkQMO5Z5B2kK3fA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-private-property-in-object@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-private-property-in-object@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-/9xnaTTJcVoBtSSmrVyhtSvO3kbqS2ODoh2juEU72c3aYonNF0OMGiaz2gjukyKM2wBBYJP38S4JiE0Wfb5VMQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.22.9)
+      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.22.9)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.26.0)
     dev: true
 
-  /@babel/plugin-transform-property-literals@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-property-literals@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-TiOArgddK3mK/x1Qwf5hay2pxI6wCZnvQqrFSqbtg1GLl2JcNMitVH/YnqjP+M31pLUeTfzY1HAXFDnUBV30rQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -6881,75 +6928,75 @@ packages:
       '@babel/types': 7.22.10
     dev: true
 
-  /@babel/plugin-transform-regenerator@7.22.10(@babel/core@7.22.9):
+  /@babel/plugin-transform-regenerator@7.22.10(@babel/core@7.26.0):
     resolution: {integrity: sha512-F28b1mDt8KcT5bUyJc/U9nwzw6cV+UmTeRlXYIl2TNqMMJif0Jeey9/RQ3C4NOd2zp0/TRsDns9ttj2L523rsw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
       regenerator-transform: 0.15.2
     dev: true
 
-  /@babel/plugin-transform-reserved-words@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-reserved-words@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-DTtGKFRQUDm8svigJzZHzb/2xatPc6TzNvAIJ5GqOKDsGFYgAskjRulbR/vGsPKq3OPqtexnz327qYpP57RFyA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-shorthand-properties@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-shorthand-properties@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-vM4fq9IXHscXVKzDv5itkO1X52SmdFBFcMIBZ2FRn2nqVYqw6dBexUgMvAjHW+KXpPPViD/Yo3GrDEBaRC0QYA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-spread@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-spread@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-5ZzDQIGyvN4w8+dMmpohL6MBo+l2G7tfC/O2Dg7/hjpgeWvUx8FzfeOKxGog9IimPa4YekaQ9PlDqTLOljkcxg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-sticky-regex@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-sticky-regex@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-zf7LuNpHG0iEeiyCNwX4j3gDg1jgt1k3ZdXBKbZSoA3BbGQGvMiSvfbZRR3Dr3aeJe3ooWFZxOOG3IRStYp2Bw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-template-literals@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-template-literals@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-5ciOehRNf+EyUeewo8NkbQiUs4d6ZxiHo6BcBcnFlgiJfu16q0bQUw9Jvo0b0gBKFG1SMhDSjeKXSYuJLeFSMA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-typeof-symbol@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-typeof-symbol@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-bYkI5lMzL4kPii4HHEEChkD0rkc+nvnlR6+o/qdqR6zrm0Sv/nodmyLhlq2DO0YKLUNd2VePmPRjJXSBh9OIdA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -6965,46 +7012,46 @@ packages:
       '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.22.9)
     dev: true
 
-  /@babel/plugin-transform-unicode-escapes@7.22.10(@babel/core@7.22.9):
+  /@babel/plugin-transform-unicode-escapes@7.22.10(@babel/core@7.26.0):
     resolution: {integrity: sha512-lRfaRKGZCBqDlRU3UIFovdp9c9mEvlylmpod0/OatICsSfuQ9YFthRo1tpTkGsklEefZdqlEFdY4A2dwTb6ohg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-unicode-property-regex@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-unicode-property-regex@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-HCCIb+CbJIAE6sXn5CjFQXMwkCClcOfPCzTlilJ8cUatfzwHlWQkbtV0zD338u9dZskwvuOYTuuaMaA8J5EI5A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-unicode-regex@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-unicode-regex@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-028laaOKptN5vHJf9/Arr/HiJekMd41hOEZYvNsrsXqJ7YPYuX2bQxh31fkZzGmq3YqHRJzYFFAVYvKfMPKqyg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-unicode-sets-regex@7.22.5(@babel/core@7.22.9):
+  /@babel/plugin-transform-unicode-sets-regex@7.22.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-lhMfi4FC15j13eKrh3DnYHjpGj6UKQHtNKTbtc1igvAhRy4+kLhV07OpLcsN0VgDEw/MjAvJO4BdMJsHwMhzCg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -7019,80 +7066,171 @@ packages:
       '@babel/helper-compilation-targets': 7.22.10
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-option': 7.22.5
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.22.9)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.22.9)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.22.9)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.22.9)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.22.9)
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.22.9)
-      '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-syntax-import-attributes': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.22.9)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.22.9)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.22.9)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.22.9)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.22.9)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.22.9)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.22.9)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.22.9)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.22.9)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.22.9)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.22.9)
-      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-async-generator-functions': 7.22.10(@babel/core@7.22.9)
-      '@babel/plugin-transform-async-to-generator': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-block-scoped-functions': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-block-scoping': 7.22.10(@babel/core@7.22.9)
-      '@babel/plugin-transform-class-properties': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-class-static-block': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-classes': 7.22.6(@babel/core@7.22.9)
-      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-destructuring': 7.22.10(@babel/core@7.22.9)
-      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-duplicate-keys': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-dynamic-import': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-exponentiation-operator': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-export-namespace-from': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-for-of': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-json-strings': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-logical-assignment-operators': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-member-expression-literals': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-modules-amd': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-modules-commonjs': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-modules-systemjs': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-modules-umd': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-new-target': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-numeric-separator': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-object-rest-spread': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-object-super': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-optional-catch-binding': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-optional-chaining': 7.22.10(@babel/core@7.22.9)
-      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-private-methods': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-private-property-in-object': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-property-literals': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-regenerator': 7.22.10(@babel/core@7.22.9)
-      '@babel/plugin-transform-reserved-words': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-shorthand-properties': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-sticky-regex': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-typeof-symbol': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-unicode-escapes': 7.22.10(@babel/core@7.22.9)
-      '@babel/plugin-transform-unicode-property-regex': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-unicode-regex': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-unicode-sets-regex': 7.22.5(@babel/core@7.22.9)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.22.9)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.26.0)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.26.0)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.26.0)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.26.0)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-syntax-import-attributes': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.26.0)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.26.0)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.26.0)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.26.0)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.26.0)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.26.0)
+      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-async-generator-functions': 7.22.10(@babel/core@7.26.0)
+      '@babel/plugin-transform-async-to-generator': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-block-scoped-functions': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-block-scoping': 7.22.10(@babel/core@7.26.0)
+      '@babel/plugin-transform-class-properties': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-class-static-block': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-classes': 7.22.6(@babel/core@7.26.0)
+      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-destructuring': 7.22.10(@babel/core@7.26.0)
+      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-duplicate-keys': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-dynamic-import': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-exponentiation-operator': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-export-namespace-from': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-for-of': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-json-strings': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-logical-assignment-operators': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-member-expression-literals': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-modules-amd': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-modules-commonjs': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-modules-systemjs': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-modules-umd': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-new-target': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-numeric-separator': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-object-rest-spread': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-object-super': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-optional-catch-binding': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-optional-chaining': 7.22.10(@babel/core@7.26.0)
+      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-private-methods': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-private-property-in-object': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-property-literals': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-regenerator': 7.22.10(@babel/core@7.26.0)
+      '@babel/plugin-transform-reserved-words': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-shorthand-properties': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-sticky-regex': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-typeof-symbol': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-unicode-escapes': 7.22.10(@babel/core@7.26.0)
+      '@babel/plugin-transform-unicode-property-regex': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-unicode-regex': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-unicode-sets-regex': 7.22.5(@babel/core@7.26.0)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.26.0)
       '@babel/types': 7.22.10
-      babel-plugin-polyfill-corejs2: 0.4.5(@babel/core@7.22.9)
-      babel-plugin-polyfill-corejs3: 0.8.3(@babel/core@7.22.9)
-      babel-plugin-polyfill-regenerator: 0.5.2(@babel/core@7.22.9)
+      babel-plugin-polyfill-corejs2: 0.4.5(@babel/core@7.26.0)
+      babel-plugin-polyfill-corejs3: 0.8.3(@babel/core@7.26.0)
+      babel-plugin-polyfill-regenerator: 0.5.2(@babel/core@7.26.0)
+      core-js-compat: 3.32.0
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/preset-env@7.22.10(@babel/core@7.26.0):
+    resolution: {integrity: sha512-riHpLb1drNkpLlocmSyEg4oYJIQFeXAK/d7rI6mbD0XsvoTOOweXDmQPG/ErxsEhWk3rl3Q/3F6RFQlVFS8m0A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/compat-data': 7.22.9
+      '@babel/core': 7.26.0
+      '@babel/helper-compilation-targets': 7.22.10
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-option': 7.22.5
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.26.0)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.26.0)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.26.0)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.26.0)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-syntax-import-attributes': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.26.0)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.26.0)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.26.0)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.26.0)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.26.0)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.26.0)
+      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-async-generator-functions': 7.22.10(@babel/core@7.26.0)
+      '@babel/plugin-transform-async-to-generator': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-block-scoped-functions': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-block-scoping': 7.22.10(@babel/core@7.26.0)
+      '@babel/plugin-transform-class-properties': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-class-static-block': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-classes': 7.22.6(@babel/core@7.26.0)
+      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-destructuring': 7.22.10(@babel/core@7.26.0)
+      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-duplicate-keys': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-dynamic-import': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-exponentiation-operator': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-export-namespace-from': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-for-of': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-json-strings': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-logical-assignment-operators': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-member-expression-literals': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-modules-amd': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-modules-commonjs': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-modules-systemjs': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-modules-umd': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-new-target': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-numeric-separator': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-object-rest-spread': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-object-super': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-optional-catch-binding': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-optional-chaining': 7.22.10(@babel/core@7.26.0)
+      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-private-methods': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-private-property-in-object': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-property-literals': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-regenerator': 7.22.10(@babel/core@7.26.0)
+      '@babel/plugin-transform-reserved-words': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-shorthand-properties': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-sticky-regex': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-typeof-symbol': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-unicode-escapes': 7.22.10(@babel/core@7.26.0)
+      '@babel/plugin-transform-unicode-property-regex': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-unicode-regex': 7.22.5(@babel/core@7.26.0)
+      '@babel/plugin-transform-unicode-sets-regex': 7.22.5(@babel/core@7.26.0)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.26.0)
+      '@babel/types': 7.22.10
+      babel-plugin-polyfill-corejs2: 0.4.5(@babel/core@7.26.0)
+      babel-plugin-polyfill-corejs3: 0.8.3(@babel/core@7.26.0)
+      babel-plugin-polyfill-regenerator: 0.5.2(@babel/core@7.26.0)
       core-js-compat: 3.32.0
       semver: 6.3.1
     transitivePeerDependencies:
@@ -7111,12 +7249,12 @@ packages:
       '@babel/plugin-transform-flow-strip-types': 7.19.0(@babel/core@7.22.9)
     dev: true
 
-  /@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.22.9):
+  /@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.26.0):
     resolution: {integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/types': 7.22.10
       esutils: 2.0.3
@@ -10568,7 +10706,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/preset-env': 7.22.10(@babel/core@7.22.9)
+      '@babel/preset-env': 7.22.10(@babel/core@7.26.0)
       '@babel/types': 7.22.5
       '@ndelangen/get-tarball': 3.0.9
       '@storybook/codemod': 7.2.2
@@ -13162,38 +13300,38 @@ packages:
       resolve: 1.22.4
     dev: false
 
-  /babel-plugin-polyfill-corejs2@0.4.5(@babel/core@7.22.9):
+  /babel-plugin-polyfill-corejs2@0.4.5(@babel/core@7.26.0):
     resolution: {integrity: sha512-19hwUH5FKl49JEsvyTcoHakh6BE0wgXLLptIyKZ3PijHc/Ci521wygORCUCCred+E/twuqRyAkE02BAWPmsHOg==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
       '@babel/compat-data': 7.22.9
-      '@babel/core': 7.22.9
-      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.26.0)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /babel-plugin-polyfill-corejs3@0.8.3(@babel/core@7.22.9):
+  /babel-plugin-polyfill-corejs3@0.8.3(@babel/core@7.26.0):
     resolution: {integrity: sha512-z41XaniZL26WLrvjy7soabMXrfPWARN25PZoriDEiLMxAp50AUW3t35BGQUMg5xK3UrpVTtagIDklxYa+MhiNA==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.26.0)
       core-js-compat: 3.32.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /babel-plugin-polyfill-regenerator@0.5.2(@babel/core@7.22.9):
+  /babel-plugin-polyfill-regenerator@0.5.2(@babel/core@7.26.0):
     resolution: {integrity: sha512-tAlOptU0Xj34V1Y2PNTL4Y0FOJMDB6bZmoW39FeCQIhigGLkqu3Fj6uiXpxIf6Ij274ENdYx64y6Au+ZKlb1IA==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.22.9)
+      '@babel/core': 7.26.0
+      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.26.0)
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
Pre-work for #5895 

Also removes a couple `as ElectionId` casts in favor of `unsafeParse` calls.