### PR TITLE
feat(design): allow removing images

### DIFF
--- a/apps/design/frontend/src/election_info_screen.tsx
+++ b/apps/design/frontend/src/election_info_screen.tsx
@@ -194,7 +194,7 @@ function ElectionInfoForm({
             onChange={(seal = '') => setElectionInfo({ ...electionInfo, seal })}
             disabled={!isEditing}
             buttonLabel="Upload Seal Image"
-            removeButtonLabel="Remove Seal"
+            removeButtonLabel="Remove Seal Image"
             minWidthPx={200}
             minHeightPx={200}
             required

--- a/apps/design/frontend/src/election_info_screen.tsx
+++ b/apps/design/frontend/src/election_info_screen.tsx
@@ -194,6 +194,7 @@ function ElectionInfoForm({
             onChange={(seal = '') => setElectionInfo({ ...electionInfo, seal })}
             disabled={!isEditing}
             buttonLabel="Upload Seal Image"
+            removeButtonLabel="Remove Seal"
             minWidthPx={200}
             minHeightPx={200}
             required

--- a/apps/design/frontend/src/election_info_screen.tsx
+++ b/apps/design/frontend/src/election_info_screen.tsx
@@ -191,7 +191,7 @@ function ElectionInfoForm({
         <div style={{ display: 'inline-flex' }}>
           <SealImageInput
             value={electionInfo.seal}
-            onChange={(seal) => setElectionInfo({ ...electionInfo, seal })}
+            onChange={(seal = '') => setElectionInfo({ ...electionInfo, seal })}
             disabled={!isEditing}
             buttonLabel="Upload Seal Image"
             minWidthPx={200}

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -715,8 +715,8 @@ function PrecinctForm({
                               clerkSignatureImage: value,
                             })
                           }
-                          buttonLabel="Upload Image"
-                          removeButtonLabel="Remove Signature"
+                          buttonLabel="Upload Signature Image"
+                          removeButtonLabel="Remove Signature Image"
                           minHeightPx={50}
                           minWidthPx={100}
                         />

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -716,6 +716,7 @@ function PrecinctForm({
                             })
                           }
                           buttonLabel="Upload Image"
+                          removeButtonLabel="Remove Signature"
                           minHeightPx={50}
                           minWidthPx={100}
                         />

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -709,7 +709,7 @@ function PrecinctForm({
                         <FieldName>Signature Image</FieldName>
                         <ClerkSignatureImageInput
                           value={split.clerkSignatureImage}
-                          onChange={(value: string) =>
+                          onChange={(value = '') =>
                             setSplit(index, {
                               ...split,
                               clerkSignatureImage: value,

--- a/apps/design/frontend/src/image_input.test.tsx
+++ b/apps/design/frontend/src/image_input.test.tsx
@@ -112,4 +112,14 @@ describe('ImageInput', () => {
     userEvent.upload(input, tooLargeFile);
     screen.getByText('Image file size must be less than 5 MB');
   });
+
+  test('allows removing the image', async () => {
+    const onChange = jest.fn();
+    render(
+      <ImageInput value="test" onChange={onChange} buttonLabel="Upload" />
+    );
+    const removeButton = screen.getByRole('button', { name: 'Remove Image' });
+    userEvent.click(removeButton);
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(undefined));
+  });
 });

--- a/apps/design/frontend/src/image_input.test.tsx
+++ b/apps/design/frontend/src/image_input.test.tsx
@@ -12,7 +12,12 @@ describe('ImageInput', () => {
       type: 'image/svg+xml',
     });
     render(
-      <ImageInput value={undefined} onChange={onChange} buttonLabel="Upload" />
+      <ImageInput
+        value={undefined}
+        onChange={onChange}
+        buttonLabel="Upload"
+        removeButtonLabel="Remove"
+      />
     );
     const input = screen.getByLabelText('Upload');
     userEvent.upload(input, svgFile);
@@ -28,6 +33,7 @@ describe('ImageInput', () => {
         value={imageContents}
         onChange={jest.fn()}
         buttonLabel="Upload"
+        removeButtonLabel="Remove"
       />
     );
     const previewImage = await screen.findByRole('img', {
@@ -46,7 +52,12 @@ describe('ImageInput', () => {
     const onSubmit = jest.fn((e) => e.preventDefault());
     render(
       <form onSubmit={onSubmit}>
-        <ImageInput onChange={onChange} buttonLabel="Upload" required />
+        <ImageInput
+          onChange={onChange}
+          buttonLabel="Upload"
+          removeButtonLabel="Remove"
+          required
+        />
         <button type="submit">Submit</button>
       </form>
     );
@@ -116,9 +127,14 @@ describe('ImageInput', () => {
   test('allows removing the image', async () => {
     const onChange = jest.fn();
     render(
-      <ImageInput value="test" onChange={onChange} buttonLabel="Upload" />
+      <ImageInput
+        value="test"
+        onChange={onChange}
+        buttonLabel="Upload"
+        removeButtonLabel="Remove"
+      />
     );
-    const removeButton = screen.getByRole('button', { name: 'Remove Image' });
+    const removeButton = screen.getByRole('button', { name: 'Remove' });
     userEvent.click(removeButton);
     await waitFor(() => expect(onChange).toHaveBeenCalledWith(undefined));
   });

--- a/apps/design/frontend/src/image_input.tsx
+++ b/apps/design/frontend/src/image_input.tsx
@@ -1,6 +1,7 @@
 import { Buffer } from 'node:buffer';
 import sanitizeHtml from 'sanitize-html';
 import {
+  Button,
   Callout,
   FileInputButton,
   FileInputButtonProps,
@@ -209,7 +210,7 @@ export function ImageInput({
   minHeightPx,
 }: {
   value?: string;
-  onChange: (value: string) => void;
+  onChange: (value?: string) => void;
   buttonLabel: string;
   disabled?: boolean;
   className?: string;
@@ -265,6 +266,19 @@ export function ImageInput({
       >
         {buttonLabel}
       </ImageInputButton>
+      {value && (
+        <Button
+          onPress={() => onChange(undefined)}
+          disabled={disabled}
+          variant="danger"
+          icon="Delete"
+          style={{
+            marginLeft: '0.5rem',
+          }}
+        >
+          Remove Image
+        </Button>
+      )}
     </div>
   );
 }

--- a/apps/design/frontend/src/image_input.tsx
+++ b/apps/design/frontend/src/image_input.tsx
@@ -258,15 +258,12 @@ export function ImageInput({
           {error.message}
         </Callout>
       )}
-      {value ? (
+      {value && !required ? (
         <Button
           onPress={() => onChange(undefined)}
           disabled={disabled}
           variant="danger"
-          icon="Delete"
-          style={{
-            marginLeft: '0.5rem',
-          }}
+          fill="outlined"
         >
           {removeButtonLabel}
         </Button>

--- a/apps/design/frontend/src/image_input.tsx
+++ b/apps/design/frontend/src/image_input.tsx
@@ -203,6 +203,7 @@ export function ImageInput({
   value,
   onChange,
   buttonLabel,
+  removeButtonLabel,
   disabled,
   className,
   required,
@@ -212,6 +213,7 @@ export function ImageInput({
   value?: string;
   onChange: (value?: string) => void;
   buttonLabel: string;
+  removeButtonLabel: string;
   disabled?: boolean;
   className?: string;
   required?: boolean;
@@ -256,17 +258,7 @@ export function ImageInput({
           {error.message}
         </Callout>
       )}
-      <ImageInputButton
-        disabled={disabled}
-        onChange={onSuccessfulImageUpload}
-        onError={onError}
-        required={value ? false : required}
-        minWidthPx={minWidthPx}
-        minHeightPx={minHeightPx}
-      >
-        {buttonLabel}
-      </ImageInputButton>
-      {value && (
+      {value ? (
         <Button
           onPress={() => onChange(undefined)}
           disabled={disabled}
@@ -276,8 +268,19 @@ export function ImageInput({
             marginLeft: '0.5rem',
           }}
         >
-          Remove Image
+          {removeButtonLabel}
         </Button>
+      ) : (
+        <ImageInputButton
+          disabled={disabled}
+          onChange={onSuccessfulImageUpload}
+          onError={onError}
+          required={value ? false : required}
+          minWidthPx={minWidthPx}
+          minHeightPx={minHeightPx}
+        >
+          {buttonLabel}
+        </ImageInputButton>
       )}
     </div>
   );


### PR DESCRIPTION
## Overview

Refs #5895

Allows removing any images. This is mostly to allow removing images where the images are optional, such as clerk signatures.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/c2cdf621-faa1-4ea4-b368-be78b7cf4af4

## Testing Plan

Added an automated test, manually tested with the election seal image and clerk signature.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
