### PR TITLE
feat(design): validate Election Info screen inputs

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -49,7 +49,11 @@ import {
   mockCloudTranslatedText,
   readElectionPackageFromFile,
 } from '@votingworks/backend';
-import { countObjectLeaves, getObjectLeaves } from '@votingworks/test-utils';
+import {
+  countObjectLeaves,
+  getObjectLeaves,
+  suppressingConsoleOutput,
+} from '@votingworks/test-utils';
 import {
   allBaseBallotProps,
   BallotMode,
@@ -261,28 +265,19 @@ test('update election info', async () => {
   expect(election.seal).toEqual('\r\n<svg>updated seal</svg>\r\n');
   expect(election.date).toEqual(new DateWithoutTime('2022-01-01'));
 
-  // empty string values do overwrite existing values
-  await apiClient.updateElectionInfo({
-    electionId,
-    type: 'primary',
-    title: '',
-    jurisdiction: '  ',
-    state: '',
-    seal: '',
-    date: new DateWithoutTime('2022-01-01'),
-  });
-
-  expect(await apiClient.getElection({ electionId })).toEqual(
-    expect.objectContaining({
-      election: expect.objectContaining({
+  // empty string values are rejected
+  await suppressingConsoleOutput(() =>
+    expect(
+      apiClient.updateElectionInfo({
+        electionId,
+        type: 'primary',
         title: '',
-        county: expect.objectContaining({
-          name: '',
-        }),
+        jurisdiction: '  ',
         state: '',
         seal: '',
-      }),
-    })
+        date: new DateWithoutTime('2022-01-01'),
+      })
+    ).rejects.toThrow()
   );
 });
 

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -12,6 +12,10 @@ import {
   ElectionSerializationFormat,
   ElectionId,
   BallotStyleId,
+  ElectionType,
+  ElectionIdSchema,
+  DateWithoutTimeSchema,
+  unsafeParse,
 } from '@votingworks/types';
 import express, { Application } from 'express';
 import {
@@ -35,6 +39,7 @@ import {
 } from '@votingworks/hmpb';
 import { translateBallotStrings } from '@votingworks/backend';
 import { readFileSync } from 'node:fs';
+import { z } from 'zod';
 import { ElectionPackage, ElectionRecord } from './store';
 import { BallotOrderInfo, Precinct, UsState } from './types';
 import {
@@ -59,7 +64,7 @@ export function createBlankElection(id: ElectionId): Election {
     date: DateWithoutTime.today(),
     state: '',
     county: {
-      id: '',
+      id: 'county-id',
       name: '',
     },
     seal: '',
@@ -122,6 +127,28 @@ function getPdfFileName(
   )}-${ballotStyleId}.pdf`;
 }
 
+const TextInput = z.string().transform((s) => s.trim());
+
+export interface ElectionInfo {
+  electionId: ElectionId;
+  type: ElectionType;
+  date: DateWithoutTime;
+  title: string;
+  state: string;
+  jurisdiction: string;
+  seal: string;
+}
+
+const UpdateElectionInfoInputSchema = z.object({
+  electionId: ElectionIdSchema,
+  type: z.union([z.literal('general'), z.literal('primary')]),
+  date: DateWithoutTimeSchema,
+  title: TextInput,
+  state: TextInput,
+  jurisdiction: TextInput,
+  seal: z.string(),
+});
+
 function buildApi({ workspace, translator }: AppContext) {
   const { store } = workspace;
 
@@ -170,6 +197,39 @@ function buildApi({ workspace, translator }: AppContext) {
         defaultBallotTemplate(UsState.NEW_HAMPSHIRE)
       );
       return ok(election.id);
+    },
+
+    async getElectionInfo(input: {
+      electionId: ElectionId;
+    }): Promise<ElectionInfo> {
+      const { election } = await store.getElection(input.electionId);
+      return {
+        electionId: election.id,
+        title: election.title,
+        date: election.date,
+        type: election.type,
+        state: election.state,
+        jurisdiction: election.county.name,
+        seal: election.seal,
+      };
+    },
+
+    async updateElectionInfo(input: ElectionInfo) {
+      const { electionId, title, date, type, state, jurisdiction, seal } =
+        unsafeParse(UpdateElectionInfoInputSchema, input);
+      const { election } = await store.getElection(electionId);
+      await store.updateElection(electionId, {
+        ...election,
+        title,
+        date,
+        type,
+        state,
+        county: {
+          ...election.county,
+          name: jurisdiction,
+        },
+        seal,
+      });
     },
 
     async updateElection(input: {

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -127,7 +127,10 @@ function getPdfFileName(
   )}-${ballotStyleId}.pdf`;
 }
 
-const TextInput = z.string().transform((s) => s.trim());
+const TextInput = z
+  .string()
+  .transform((s) => s.trim())
+  .refine((s) => s.length > 0);
 
 export interface ElectionInfo {
   electionId: ElectionId;

--- a/apps/design/backend/src/index.ts
+++ b/apps/design/backend/src/index.ts
@@ -19,7 +19,7 @@ export type {
   PrecinctWithSplits,
   PrecinctWithoutSplits,
 } from './types';
-export type { Api } from './app';
+export type { Api, ElectionInfo } from './app';
 export type { BallotMode } from '@votingworks/hmpb';
 export type { BallotTemplateId } from '@votingworks/hmpb';
 

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -85,6 +85,7 @@ async function invalidateElectionQueries(
 ) {
   await queryClient.invalidateQueries(getElection.queryKey(electionId));
   await queryClient.invalidateQueries(getElectionInfo.queryKey(electionId));
+  await queryClient.invalidateQueries(listElections.queryKey());
 }
 
 export const updateElectionInfo = {

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -67,6 +67,38 @@ export const getElection = {
   },
 } as const;
 
+export const getElectionInfo = {
+  queryKey(id: ElectionId): QueryKey {
+    return ['getElectionInfo', id];
+  },
+  useQuery(id: ElectionId) {
+    const apiClient = useApiClient();
+    return useQuery(this.queryKey(id), () =>
+      apiClient.getElectionInfo({ electionId: id })
+    );
+  },
+} as const;
+
+async function invalidateElectionQueries(
+  queryClient: QueryClient,
+  electionId: ElectionId
+) {
+  await queryClient.invalidateQueries(getElection.queryKey(electionId));
+  await queryClient.invalidateQueries(getElectionInfo.queryKey(electionId));
+}
+
+export const updateElectionInfo = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.updateElectionInfo, {
+      async onSuccess(_, { electionId }) {
+        await invalidateElectionQueries(queryClient, electionId);
+      },
+    });
+  },
+} as const;
+
 export const loadElection = {
   useMutation() {
     const apiClient = useApiClient();
@@ -103,7 +135,7 @@ export const updateElection = {
           // fresh when user navigates back to elections list
           refetchType: 'all',
         });
-        await queryClient.invalidateQueries(getElection.queryKey(electionId));
+        await invalidateElectionQueries(queryClient, electionId);
       },
     });
   },
@@ -115,7 +147,7 @@ export const updateSystemSettings = {
     const queryClient = useQueryClient();
     return useMutation(apiClient.updateSystemSettings, {
       async onSuccess(_, { electionId }) {
-        await queryClient.invalidateQueries(getElection.queryKey(electionId));
+        await invalidateElectionQueries(queryClient, electionId);
       },
     });
   },
@@ -127,7 +159,7 @@ export const updateBallotOrderInfo = {
     const queryClient = useQueryClient();
     return useMutation(apiClient.updateBallotOrderInfo, {
       async onSuccess(_, { electionId }) {
-        await queryClient.invalidateQueries(getElection.queryKey(electionId));
+        await invalidateElectionQueries(queryClient, electionId);
       },
     });
   },
@@ -139,7 +171,7 @@ export const updatePrecincts = {
     const queryClient = useQueryClient();
     return useMutation(apiClient.updatePrecincts, {
       async onSuccess(_, { electionId }) {
-        await queryClient.invalidateQueries(getElection.queryKey(electionId));
+        await invalidateElectionQueries(queryClient, electionId);
       },
     });
   },
@@ -263,7 +295,7 @@ export const setBallotTemplate = {
     const queryClient = useQueryClient();
     return useMutation(apiClient.setBallotTemplate, {
       async onSuccess(_, { electionId }) {
-        await queryClient.invalidateQueries(getElection.queryKey(electionId));
+        await invalidateElectionQueries(queryClient, electionId);
       },
     });
   },

--- a/apps/design/frontend/src/election_info_screen.test.tsx
+++ b/apps/design/frontend/src/election_info_screen.test.tsx
@@ -230,6 +230,9 @@ test('edit election disabled when ballots are finalized', async () => {
   apiMock.getElection
     .expectCallWith({ electionId })
     .resolves(generalElectionRecord);
+  apiMock.getElectionInfo
+    .expectCallWith({ electionId })
+    .resolves(generalElectionInfo);
   apiMock.getBallotsFinalizedAt
     .expectCallWith({ electionId })
     .resolves(new Date());

--- a/apps/design/frontend/src/election_info_screen.test.tsx
+++ b/apps/design/frontend/src/election_info_screen.test.tsx
@@ -204,6 +204,29 @@ test('edit and save election', async () => {
   await screen.findByRole('button', { name: 'Edit' });
 });
 
+test('cancel update', async () => {
+  const electionId = generalElectionRecord.election.id;
+  apiMock.getElection
+    .expectCallWith({ electionId })
+    .resolves(generalElectionRecord);
+  apiMock.getElectionInfo
+    .expectCallWith({ electionId })
+    .resolves(generalElectionInfo);
+  apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
+  renderScreen(electionId);
+  await screen.findByRole('heading', { name: 'Election Info' });
+
+  userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+  const titleInput = screen.getByLabelText('Title');
+  userEvent.clear(titleInput);
+  userEvent.type(titleInput, 'New Title');
+
+  userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+  expect(titleInput).toHaveValue(generalElectionRecord.election.title);
+});
+
 test('delete election', async () => {
   const electionId = generalElectionRecord.election.id;
   apiMock.getElection

--- a/apps/design/frontend/src/election_info_screen.tsx
+++ b/apps/design/frontend/src/election_info_screen.tsx
@@ -1,10 +1,5 @@
 import React, { useState } from 'react';
-import {
-  Election,
-  ElectionId,
-  ElectionIdSchema,
-  unsafeParse,
-} from '@votingworks/types';
+import { ElectionIdSchema, unsafeParse } from '@votingworks/types';
 import {
   Button,
   H1,
@@ -12,6 +7,7 @@ import {
   MainHeader,
   SegmentedButton,
 } from '@votingworks/ui';
+import type { ElectionInfo } from '@votingworks/design-backend';
 import { useHistory, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { z } from 'zod';
@@ -19,18 +15,13 @@ import { DateWithoutTime } from '@votingworks/basics';
 import {
   deleteElection,
   getBallotsFinalizedAt,
-  getElection,
-  updateElection,
+  getElectionInfo,
+  updateElectionInfo,
 } from './api';
 import { FieldName, Form, FormActionsRow, InputGroup } from './layout';
 import { ElectionNavScreen } from './nav_screen';
 import { routes } from './routes';
 import { ImageInput } from './image_input';
-
-type ElectionInfo = Pick<
-  Election,
-  'title' | 'date' | 'type' | 'state' | 'county' | 'seal'
->;
 
 const SealImageInput = styled(ImageInput)`
   img {
@@ -38,58 +29,77 @@ const SealImageInput = styled(ImageInput)`
   }
 `;
 
-function hasBlankElectionInfo(election: Election): boolean {
+function hasBlankElectionInfo(electionInfo: ElectionInfo): boolean {
   return (
-    election.title === '' &&
-    election.state === '' &&
-    election.county.name === '' &&
-    election.seal === ''
+    !electionInfo.title &&
+    !electionInfo.state &&
+    !electionInfo.jurisdiction &&
+    !electionInfo.seal
   );
 }
 
 function ElectionInfoForm({
-  electionId,
-  savedElection,
+  savedElectionInfo,
   ballotsFinalizedAt,
 }: {
-  electionId: ElectionId;
-  savedElection: Election;
+  savedElectionInfo: ElectionInfo;
   ballotsFinalizedAt: Date | null;
 }): JSX.Element {
   const [isEditing, setIsEditing] = useState(
     // Default to editing for newly created elections
-    hasBlankElectionInfo(savedElection)
+    hasBlankElectionInfo(savedElectionInfo)
   );
-  const [electionInfo, setElectionInfo] = useState<ElectionInfo>(savedElection);
-  const updateElectionMutation = updateElection.useMutation();
+  const [editedElectionInfo, setEditedElectionInfo] = useState<ElectionInfo>();
+  const updateElectionInfoMutation = updateElectionInfo.useMutation();
   const deleteElectionMutation = deleteElection.useMutation();
   const history = useHistory();
+  const electionInfo = isEditing
+    ? editedElectionInfo ?? savedElectionInfo
+    : savedElectionInfo;
+
+  function resetForm() {
+    setIsEditing(false);
+    setEditedElectionInfo(undefined);
+  }
 
   function onSubmit() {
-    updateElectionMutation.mutate(
-      { electionId, election: { ...savedElection, ...electionInfo } },
-      { onSuccess: () => setIsEditing(false) }
-    );
+    updateElectionInfoMutation.mutate(electionInfo, {
+      onSuccess: resetForm,
+    });
   }
 
   function onReset() {
     if (isEditing) {
-      setElectionInfo(savedElection);
-      setIsEditing(false);
+      resetForm();
     } else {
+      setEditedElectionInfo(savedElectionInfo);
       setIsEditing(true);
     }
   }
 
-  function onInputChange(field: keyof ElectionInfo) {
+  type TextProperties = Exclude<keyof ElectionInfo, 'date' | 'electionId'>;
+
+  function onInputChange(field: TextProperties) {
     return (e: React.ChangeEvent<HTMLInputElement>) => {
-      setElectionInfo((prev) => ({ ...prev, [field]: e.target.value }));
+      setEditedElectionInfo((prev = savedElectionInfo) => ({
+        ...prev,
+        [field]: e.target.value,
+      }));
+    };
+  }
+
+  function onInputBlur(field: TextProperties) {
+    return () => {
+      setEditedElectionInfo((prev = savedElectionInfo) => ({
+        ...prev,
+        [field]: prev[field]?.trim(),
+      }));
     };
   }
 
   function onDeletePress() {
     deleteElectionMutation.mutate(
-      { electionId },
+      { electionId: electionInfo.electionId },
       {
         onSuccess: () => {
           history.push(routes.root.path);
@@ -114,7 +124,10 @@ function ElectionInfoForm({
           type="text"
           value={electionInfo.title}
           onChange={onInputChange('title')}
+          onBlur={onInputBlur('title')}
           disabled={!isEditing}
+          autoComplete="off"
+          required
         />
       </InputGroup>
       <InputGroup label="Date">
@@ -122,7 +135,7 @@ function ElectionInfoForm({
           type="date"
           value={electionInfo.date.toISOString()}
           onChange={(e) =>
-            setElectionInfo({
+            setEditedElectionInfo({
               ...electionInfo,
               date: new DateWithoutTime(e.target.value),
             })
@@ -137,7 +150,7 @@ function ElectionInfoForm({
           { label: 'Primary', id: 'primary' },
         ]}
         selectedOptionId={electionInfo.type}
-        onChange={(type) => setElectionInfo({ ...electionInfo, type })}
+        onChange={(type) => setEditedElectionInfo({ ...electionInfo, type })}
         disabled={!isEditing}
       />
       <InputGroup label="State">
@@ -145,32 +158,31 @@ function ElectionInfoForm({
           type="text"
           value={electionInfo.state}
           onChange={onInputChange('state')}
+          onBlur={onInputBlur('state')}
           disabled={!isEditing}
+          autoComplete="off"
+          required
         />
       </InputGroup>
       <InputGroup label="Jurisdiction">
         <input
           type="text"
-          value={electionInfo.county.name}
-          onChange={(e) =>
-            setElectionInfo({
-              ...electionInfo,
-              county: {
-                name: e.target.value,
-                id: 'county-id',
-              },
-            })
-          }
+          value={electionInfo.jurisdiction}
+          onChange={onInputChange('jurisdiction')}
+          onBlur={onInputBlur('jurisdiction')}
           disabled={!isEditing}
+          autoComplete="off"
+          required
         />
       </InputGroup>
       <div>
         <FieldName>Seal</FieldName>
         <SealImageInput
           value={electionInfo.seal}
-          onChange={(seal) => setElectionInfo({ ...electionInfo, seal })}
+          onChange={(seal) => setEditedElectionInfo({ ...electionInfo, seal })}
           disabled={!isEditing}
           buttonLabel="Upload Seal Image"
+          required
         />
       </div>
 
@@ -181,7 +193,7 @@ function ElectionInfoForm({
             type="submit"
             variant="primary"
             icon="Done"
-            disabled={updateElectionMutation.isLoading}
+            disabled={updateElectionInfoMutation.isLoading}
           >
             Save
           </Button>
@@ -220,14 +232,15 @@ export function ElectionInfoScreen(): JSX.Element | null {
     z.object({ electionId: ElectionIdSchema }),
     params
   );
-  const getElectionQuery = getElection.useQuery(electionId);
+  const getElectionInfoQuery = getElectionInfo.useQuery(electionId);
   const getBallotsFinalizedAtQuery = getBallotsFinalizedAt.useQuery(electionId);
 
-  if (!getElectionQuery.isSuccess || !getBallotsFinalizedAtQuery.isSuccess) {
+  if (
+    !getElectionInfoQuery.isSuccess ||
+    !getBallotsFinalizedAtQuery.isSuccess
+  ) {
     return null;
   }
-
-  const { election } = getElectionQuery.data;
   const ballotsFinalizedAt = getBallotsFinalizedAtQuery.data;
 
   return (
@@ -237,8 +250,7 @@ export function ElectionInfoScreen(): JSX.Element | null {
       </MainHeader>
       <MainContent>
         <ElectionInfoForm
-          electionId={electionId}
-          savedElection={election}
+          savedElectionInfo={getElectionInfoQuery.data}
           ballotsFinalizedAt={ballotsFinalizedAt}
         />
       </MainContent>

--- a/apps/design/frontend/src/election_info_screen.tsx
+++ b/apps/design/frontend/src/election_info_screen.tsx
@@ -49,40 +49,29 @@ function ElectionInfoForm({
     // Default to editing for newly created elections
     hasBlankElectionInfo(savedElectionInfo)
   );
-  const [editedElectionInfo, setEditedElectionInfo] =
-    useState(savedElectionInfo);
+  const [electionInfo, setElectionInfo] = useState(savedElectionInfo);
   const updateElectionInfoMutation = updateElectionInfo.useMutation();
   const deleteElectionMutation = deleteElection.useMutation();
   const history = useHistory();
-  const electionInfo = isEditing
-    ? editedElectionInfo ?? savedElectionInfo
-    : savedElectionInfo;
-
-  function resetForm() {
-    setIsEditing(false);
-    setEditedElectionInfo(savedElectionInfo);
-  }
 
   function onSubmit() {
     updateElectionInfoMutation.mutate(electionInfo, {
-      onSuccess: resetForm,
+      onSuccess: () => {
+        setIsEditing(false);
+      },
     });
   }
 
   function onReset() {
-    if (isEditing) {
-      resetForm();
-    } else {
-      setEditedElectionInfo(savedElectionInfo);
-      setIsEditing(true);
-    }
+    setElectionInfo(savedElectionInfo);
+    setIsEditing((prev) => !prev);
   }
 
   type TextProperties = Exclude<keyof ElectionInfo, 'date' | 'electionId'>;
 
   function onInputChange(field: TextProperties) {
     return (e: React.ChangeEvent<HTMLInputElement>) => {
-      setEditedElectionInfo((prev = savedElectionInfo) => ({
+      setElectionInfo((prev = savedElectionInfo) => ({
         ...prev,
         [field]: e.target.value,
       }));
@@ -91,7 +80,7 @@ function ElectionInfoForm({
 
   function onInputBlur(field: TextProperties) {
     return () => {
-      setEditedElectionInfo((prev = savedElectionInfo) => ({
+      setElectionInfo((prev = savedElectionInfo) => ({
         ...prev,
         [field]: prev[field]?.trim(),
       }));
@@ -136,7 +125,7 @@ function ElectionInfoForm({
           type="date"
           value={electionInfo.date.toISOString()}
           onChange={(e) =>
-            setEditedElectionInfo({
+            setElectionInfo({
               ...electionInfo,
               date: new DateWithoutTime(e.target.value),
             })
@@ -151,7 +140,7 @@ function ElectionInfoForm({
           { label: 'Primary', id: 'primary' },
         ]}
         selectedOptionId={electionInfo.type}
-        onChange={(type) => setEditedElectionInfo({ ...electionInfo, type })}
+        onChange={(type) => setElectionInfo({ ...electionInfo, type })}
         disabled={!isEditing}
       />
       <InputGroup label="State">
@@ -180,7 +169,7 @@ function ElectionInfoForm({
         <FieldName>Seal</FieldName>
         <SealImageInput
           value={electionInfo.seal}
-          onChange={(seal) => setEditedElectionInfo({ ...electionInfo, seal })}
+          onChange={(seal) => setElectionInfo({ ...electionInfo, seal })}
           disabled={!isEditing}
           buttonLabel="Upload Seal Image"
           required

--- a/apps/design/frontend/src/election_info_screen.tsx
+++ b/apps/design/frontend/src/election_info_screen.tsx
@@ -49,7 +49,8 @@ function ElectionInfoForm({
     // Default to editing for newly created elections
     hasBlankElectionInfo(savedElectionInfo)
   );
-  const [editedElectionInfo, setEditedElectionInfo] = useState<ElectionInfo>();
+  const [editedElectionInfo, setEditedElectionInfo] =
+    useState(savedElectionInfo);
   const updateElectionInfoMutation = updateElectionInfo.useMutation();
   const deleteElectionMutation = deleteElection.useMutation();
   const history = useHistory();
@@ -59,7 +60,7 @@ function ElectionInfoForm({
 
   function resetForm() {
     setIsEditing(false);
-    setEditedElectionInfo(undefined);
+    setEditedElectionInfo(savedElectionInfo);
   }
 
   function onSubmit() {

--- a/apps/design/frontend/src/image_input.test.tsx
+++ b/apps/design/frontend/src/image_input.test.tsx
@@ -41,6 +41,39 @@ describe('ImageInput', () => {
     );
   });
 
+  test('when required, blocks form submission if no value given', () => {
+    const onChange = jest.fn();
+    const onSubmit = jest.fn((e) => e.preventDefault());
+    render(
+      <form onSubmit={onSubmit}>
+        <ImageInput onChange={onChange} buttonLabel="Upload" required />
+        <button type="submit">Submit</button>
+      </form>
+    );
+    const submitButton = screen.getByRole('button', { name: 'Submit' });
+    userEvent.click(submitButton);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  test('when required, does not block form submission if it has a value', () => {
+    const onChange = jest.fn();
+    const onSubmit = jest.fn((e) => e.preventDefault());
+    render(
+      <form onSubmit={onSubmit}>
+        <ImageInput
+          value="<svg><circle r='1' fill='black' /></svg>"
+          onChange={onChange}
+          buttonLabel="Upload"
+          required
+        />
+        <button type="submit">Submit</button>
+      </form>
+    );
+    const submitButton = screen.getByRole('button', { name: 'Submit' });
+    userEvent.click(submitButton);
+    expect(onSubmit).toHaveBeenCalled();
+  });
+
   test.each(['png', 'jpeg'])('converts %s images to SVG', async (imageType) => {
     // Mock Image so we can test getting the dimensions of the uploaded image
     HTMLImageElement.prototype.decode = function decode() {

--- a/apps/design/frontend/src/image_input.tsx
+++ b/apps/design/frontend/src/image_input.tsx
@@ -113,6 +113,7 @@ async function loadBitmapImageAndConvertToSvg(file: File): Promise<string> {
 interface ImageInputButtonProps
   extends Pick<FileInputButtonProps, 'disabled' | 'buttonProps' | 'children'> {
   onChange: (svgImage: string) => void;
+  required?: boolean;
 }
 
 export function ImageInputButton({
@@ -156,12 +157,14 @@ export function ImageInput({
   buttonLabel,
   disabled,
   className,
+  required,
 }: {
   value?: string;
   onChange: (value: string) => void;
   buttonLabel: string;
   disabled?: boolean;
   className?: string;
+  required?: boolean;
 }): JSX.Element {
   return (
     <div className={className}>
@@ -174,7 +177,11 @@ export function ImageInput({
           style={{ marginBottom: '0.5rem' }}
         />
       )}
-      <ImageInputButton disabled={disabled} onChange={onChange}>
+      <ImageInputButton
+        disabled={disabled}
+        onChange={onChange}
+        required={value ? false : required}
+      >
         {buttonLabel}
       </ImageInputButton>
     </div>

--- a/apps/design/frontend/test/fixtures.ts
+++ b/apps/design/frontend/test/fixtures.ts
@@ -1,4 +1,4 @@
-import type { ElectionRecord } from '@votingworks/design-backend';
+import type { ElectionInfo, ElectionRecord } from '@votingworks/design-backend';
 import {
   createBlankElection,
   convertVxfPrecincts,
@@ -54,7 +54,25 @@ export function makeElectionRecord(baseElection: Election): ElectionRecord {
 export const blankElectionRecord = makeElectionRecord(
   createBlankElection(generateId() as ElectionId)
 );
+export const blankElectionInfo: ElectionInfo = {
+  electionId: blankElectionRecord.election.id,
+  type: blankElectionRecord.election.type,
+  date: blankElectionRecord.election.date,
+  title: blankElectionRecord.election.title,
+  jurisdiction: blankElectionRecord.election.county.name,
+  state: blankElectionRecord.election.state,
+  seal: blankElectionRecord.election.seal,
+};
 export const generalElectionRecord = makeElectionRecord(readElectionGeneral());
 export const primaryElectionRecord = makeElectionRecord(
   electionPrimaryPrecinctSplitsFixtures.readElection()
 );
+export const generalElectionInfo: ElectionInfo = {
+  electionId: generalElectionRecord.election.id,
+  type: generalElectionRecord.election.type,
+  date: generalElectionRecord.election.date,
+  title: generalElectionRecord.election.title,
+  jurisdiction: generalElectionRecord.election.county.name,
+  state: generalElectionRecord.election.state,
+  seal: generalElectionRecord.election.seal,
+};

--- a/libs/ui/src/file_input_button.tsx
+++ b/libs/ui/src/file_input_button.tsx
@@ -29,6 +29,7 @@ export interface FileInputButtonProps {
   accept?: string;
   buttonProps?: Omit<ButtonProps, 'onPress'>;
   disabled?: boolean;
+  required?: boolean;
   name?: string;
   multiple?: boolean;
   children: React.ReactNode;


### PR DESCRIPTION
## Overview

Adds both client and server-side validation. The client validation is fairly simple, just trimming the text and ensuring something non-blank is set. The server-side validation does a tiny bit more, and for now just crashes if it fails.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/7cb28a3c-efc1-49e5-a618-1964de451eca


## Testing Plan
Mostly manual testing, plus a couple new automated tests.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
