### PR TITLE
disable edit forms when ballots are finalized

### DIFF
--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -42,9 +42,11 @@ import { BallotScreen, paperSizeLabels } from './ballot_screen';
 function BallotDesignForm({
   electionId,
   savedElection,
+  ballotsFinalizedAt,
 }: {
   electionId: ElectionId;
   savedElection: Election;
+  ballotsFinalizedAt: Date | null;
 }): JSX.Element {
   const [isEditing, setIsEditing] = useState(false);
   const [ballotLayout, setBallotLayout] = useState(savedElection.ballotLayout);
@@ -113,7 +115,12 @@ function BallotDesignForm({
         </FormActionsRow>
       ) : (
         <FormActionsRow>
-          <Button type="reset" variant="primary" icon="Edit">
+          <Button
+            type="reset"
+            variant="primary"
+            icon="Edit"
+            disabled={!!ballotsFinalizedAt}
+          >
             Edit
           </Button>
         </FormActionsRow>
@@ -369,16 +376,22 @@ function BallotStylesTab(): JSX.Element | null {
 function BallotLayoutTab(): JSX.Element | null {
   const { electionId } = useParams<ElectionIdParams>();
   const getElectionQuery = getElection.useQuery(electionId);
+  const getBallotsFinalizedAtQuery = getBallotsFinalizedAt.useQuery(electionId);
 
-  if (!getElectionQuery.isSuccess) {
+  if (!getElectionQuery.isSuccess || !getBallotsFinalizedAtQuery.isSuccess) {
     return null;
   }
 
   const { election } = getElectionQuery.data;
+  const ballotsFinalizedAt = getBallotsFinalizedAtQuery.data;
 
   return (
     <TabPanel>
-      <BallotDesignForm electionId={electionId} savedElection={election} />
+      <BallotDesignForm
+        electionId={electionId}
+        savedElection={election}
+        ballotsFinalizedAt={ballotsFinalizedAt}
+      />
     </TabPanel>
   );
 }

--- a/apps/design/frontend/src/contests_screen.test.tsx
+++ b/apps/design/frontend/src/contests_screen.test.tsx
@@ -100,6 +100,7 @@ describe('Contests tab', () => {
     apiMock.getElection
       .expectCallWith({ electionId })
       .resolves(electionWithNoContestsRecord);
+    apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen(electionId);
 
     await screen.findByRole('heading', { name: 'Contests' });
@@ -257,6 +258,7 @@ describe('Contests tab', () => {
     apiMock.getElection
       .expectCallWith({ electionId })
       .resolves(primaryElectionRecord);
+    apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen(electionId);
 
     await screen.findByRole('heading', { name: 'Contests' });
@@ -473,6 +475,9 @@ describe('Contests tab', () => {
       apiMock.getElection
         .expectCallWith({ electionId })
         .resolves(electionWithNoContestsRecord);
+      apiMock.getBallotsFinalizedAt
+        .expectCallWith({ electionId })
+        .resolves(null);
       renderScreen(electionId);
 
       await screen.findByRole('heading', { name: 'Contests' });
@@ -594,6 +599,7 @@ describe('Contests tab', () => {
     apiMock.getElection
       .expectCallWith({ electionId })
       .resolves(generalElectionRecord);
+    apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen(electionId);
 
     await screen.findByRole('heading', { name: 'Contests' });
@@ -694,6 +700,7 @@ describe('Contests tab', () => {
     apiMock.getElection
       .expectCallWith({ electionId })
       .resolves(generalElectionRecord);
+    apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen(electionId);
 
     await screen.findByRole('heading', { name: 'Contests' });
@@ -771,6 +778,7 @@ describe('Contests tab', () => {
     apiMock.getElection
       .expectCallWith({ electionId })
       .resolves(generalElectionRecord);
+    apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen(electionId);
 
     await screen.findByRole('heading', { name: 'Contests' });
@@ -844,5 +852,37 @@ describe('Contests tab', () => {
 
     await screen.findByRole('button', { name: 'Reorder Contests' });
     expect(getRowOrder()).toEqual(newOrder);
+  });
+
+  test('changing contests is disabled when ballots are finalized', async () => {
+    const { election } = generalElectionRecord;
+    const electionId = election.id;
+    // Mock needed for react-flip-toolkit
+    window.matchMedia = jest.fn().mockImplementation(() => ({
+      matches: false,
+    }));
+
+    apiMock.getElection
+      .expectCallWith({ electionId })
+      .resolves(generalElectionRecord);
+    apiMock.getBallotsFinalizedAt
+      .expectCallWith({ electionId })
+      .resolves(new Date());
+    renderScreen(electionId);
+
+    await screen.findByRole('heading', { name: 'Contests' });
+
+    expect(
+      screen.getByRole('button', { name: 'Reorder Contests' })
+    ).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Add Contest' })).toBeDisabled();
+
+    const savedContest = election.contests.find(
+      (contest): contest is CandidateContest => contest.type === 'candidate'
+    )!;
+    const savedContestRow = screen.getByText(savedContest.title).closest('tr')!;
+    expect(
+      within(savedContestRow).getByRole('button', { name: 'Edit' })
+    ).toBeDisabled();
   });
 });

--- a/apps/design/frontend/src/election_info_screen.test.tsx
+++ b/apps/design/frontend/src/election_info_screen.test.tsx
@@ -41,9 +41,11 @@ function renderScreen(electionId: ElectionId) {
 }
 
 test('newly created election starts in edit mode', async () => {
+  const electionId = blankElectionRecord.election.id;
   apiMock.getElection
-    .expectCallWith({ electionId: blankElectionRecord.election.id })
+    .expectCallWith({ electionId })
     .resolves(blankElectionRecord);
+  apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
   renderScreen(blankElectionRecord.election.id);
   await screen.findByRole('heading', { name: 'Election Info' });
 
@@ -88,6 +90,7 @@ test('edit and save election', async () => {
   apiMock.getElection
     .expectCallWith({ electionId })
     .resolves(generalElectionRecord);
+  apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
   renderScreen(electionId);
   await screen.findByRole('heading', { name: 'Election Info' });
 
@@ -184,6 +187,7 @@ test('delete election', async () => {
   apiMock.getElection
     .expectCallWith({ electionId })
     .resolves(generalElectionRecord);
+  apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
   const history = renderScreen(electionId);
   await screen.findByRole('heading', { name: 'Election Info' });
 
@@ -194,4 +198,20 @@ test('delete election', async () => {
   await waitFor(() =>
     expect(history.location.pathname).toEqual(routes.root.path)
   );
+});
+
+test('edit election disabled when ballots are finalized', async () => {
+  const electionId = generalElectionRecord.election.id;
+  apiMock.getElection
+    .expectCallWith({ electionId })
+    .resolves(generalElectionRecord);
+  apiMock.getBallotsFinalizedAt
+    .expectCallWith({ electionId })
+    .resolves(new Date());
+
+  renderScreen(electionId);
+  await screen.findByRole('heading', { name: 'Election Info' });
+
+  const editButton = screen.getByRole('button', { name: 'Edit' });
+  expect(editButton).toBeDisabled();
 });

--- a/apps/design/frontend/src/election_info_screen.tsx
+++ b/apps/design/frontend/src/election_info_screen.tsx
@@ -16,7 +16,12 @@ import { useHistory, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { z } from 'zod';
 import { DateWithoutTime } from '@votingworks/basics';
-import { deleteElection, getElection, updateElection } from './api';
+import {
+  deleteElection,
+  getBallotsFinalizedAt,
+  getElection,
+  updateElection,
+} from './api';
 import { FieldName, Form, FormActionsRow, InputGroup } from './layout';
 import { ElectionNavScreen } from './nav_screen';
 import { routes } from './routes';
@@ -45,9 +50,11 @@ function hasBlankElectionInfo(election: Election): boolean {
 function ElectionInfoForm({
   electionId,
   savedElection,
+  ballotsFinalizedAt,
 }: {
   electionId: ElectionId;
   savedElection: Election;
+  ballotsFinalizedAt: Date | null;
 }): JSX.Element {
   const [isEditing, setIsEditing] = useState(
     // Default to editing for newly created elections
@@ -182,7 +189,12 @@ function ElectionInfoForm({
       ) : (
         <div>
           <FormActionsRow>
-            <Button type="reset" variant="primary" icon="Edit">
+            <Button
+              type="reset"
+              variant="primary"
+              icon="Edit"
+              disabled={!!ballotsFinalizedAt}
+            >
               Edit
             </Button>
           </FormActionsRow>
@@ -209,12 +221,14 @@ export function ElectionInfoScreen(): JSX.Element | null {
     params
   );
   const getElectionQuery = getElection.useQuery(electionId);
+  const getBallotsFinalizedAtQuery = getBallotsFinalizedAt.useQuery(electionId);
 
-  if (!getElectionQuery.isSuccess) {
+  if (!getElectionQuery.isSuccess || !getBallotsFinalizedAtQuery.isSuccess) {
     return null;
   }
 
   const { election } = getElectionQuery.data;
+  const ballotsFinalizedAt = getBallotsFinalizedAtQuery.data;
 
   return (
     <ElectionNavScreen electionId={electionId}>
@@ -222,7 +236,11 @@ export function ElectionInfoScreen(): JSX.Element | null {
         <H1>Election Info</H1>
       </MainHeader>
       <MainContent>
-        <ElectionInfoForm electionId={electionId} savedElection={election} />
+        <ElectionInfoForm
+          electionId={electionId}
+          savedElection={election}
+          ballotsFinalizedAt={ballotsFinalizedAt}
+        />
       </MainContent>
     </ElectionNavScreen>
   );

--- a/apps/design/frontend/src/geography_screen.test.tsx
+++ b/apps/design/frontend/src/geography_screen.test.tsx
@@ -77,6 +77,7 @@ describe('Districts tab', () => {
     apiMock.getElection
       .expectCallWith({ electionId })
       .resolves(electionWithNoGeographyRecord);
+    apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen();
 
     await screen.findByRole('heading', { name: 'Geography' });
@@ -128,6 +129,7 @@ describe('Districts tab', () => {
     apiMock.getElection
       .expectCallWith({ electionId })
       .resolves(generalElectionRecord);
+    apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen();
 
     await screen.findByRole('heading', { name: 'Geography' });
@@ -183,6 +185,7 @@ describe('Districts tab', () => {
     apiMock.getElection
       .expectCallWith({ electionId })
       .resolves(generalElectionRecord);
+    apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen();
 
     await screen.findByRole('heading', { name: 'Geography' });
@@ -262,6 +265,30 @@ describe('Districts tab', () => {
     );
     expect(screen.queryByText(savedDistrict.name)).not.toBeInTheDocument();
   });
+
+  test('editing or adding a district is disabled when ballots are finalized', async () => {
+    const { election } = generalElectionRecord;
+    const savedDistrict = election.districts[0];
+
+    apiMock.getElection
+      .expectCallWith({ electionId })
+      .resolves(generalElectionRecord);
+    apiMock.getBallotsFinalizedAt
+      .expectCallWith({ electionId })
+      .resolves(new Date());
+    renderScreen();
+
+    await screen.findByRole('heading', { name: 'Geography' });
+    screen.getByRole('tab', { name: 'Districts', selected: true });
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(election.districts.length + 1);
+
+    const savedContestRow = screen.getByText(savedDistrict.name).closest('tr')!;
+    expect(
+      within(savedContestRow).getByRole('button', { name: 'Edit' })
+    ).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Add District' })).toBeDisabled();
+  });
 });
 
 describe('Precincts tab', () => {
@@ -276,6 +303,7 @@ describe('Precincts tab', () => {
     apiMock.getElection
       .expectCallWith({ electionId })
       .resolves(electionWithNoPrecinctsRecord);
+    apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen();
 
     await screen.findByRole('heading', { name: 'Geography' });
@@ -367,6 +395,7 @@ describe('Precincts tab', () => {
     apiMock.getElection
       .expectCallWith({ electionId })
       .resolves(nhElectionRecord);
+    apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen();
 
     await screen.findByRole('heading', { name: 'Geography' });
@@ -541,6 +570,7 @@ describe('Precincts tab', () => {
     apiMock.getElection
       .expectCallWith({ electionId })
       .resolves(generalElectionRecord);
+    apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen();
 
     await screen.findByRole('heading', { name: 'Geography' });
@@ -616,6 +646,7 @@ describe('Precincts tab', () => {
     apiMock.getElection
       .expectCallWith({ electionId })
       .resolves(generalElectionRecord);
+    apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen();
 
     await screen.findByRole('heading', { name: 'Geography' });

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -44,7 +44,12 @@ import {
   InputGroup,
   FieldName,
 } from './layout';
-import { getElection, updateElection, updatePrecincts } from './api';
+import {
+  getBallotsFinalizedAt,
+  getElection,
+  updateElection,
+  updatePrecincts,
+} from './api';
 import { generateId, hasSplits, replaceAtIndex } from './utils';
 import { ImageInput } from './image_input';
 import { useFeaturesContext } from './features_context';
@@ -52,11 +57,13 @@ import { useFeaturesContext } from './features_context';
 function DistrictsTab(): JSX.Element | null {
   const { electionId } = useParams<ElectionIdParams>();
   const getElectionQuery = getElection.useQuery(electionId);
+  const getBallotsFinalizedAtQuery = getBallotsFinalizedAt.useQuery(electionId);
 
-  if (!getElectionQuery.isSuccess) {
+  if (!getElectionQuery.isSuccess || !getBallotsFinalizedAtQuery.isSuccess) {
     return null;
   }
 
+  const ballotsFinalizedAt = getBallotsFinalizedAtQuery.data;
   const {
     election: { districts },
   } = getElectionQuery.data;
@@ -72,6 +79,7 @@ function DistrictsTab(): JSX.Element | null {
           icon="Add"
           variant="primary"
           to={districtsRoutes.addDistrict.path}
+          disabled={!!ballotsFinalizedAt}
         >
           Add District
         </LinkButton>
@@ -92,6 +100,7 @@ function DistrictsTab(): JSX.Element | null {
                   <LinkButton
                     icon="Edit"
                     to={districtsRoutes.editDistrict(district.id).path}
+                    disabled={!!ballotsFinalizedAt}
                   >
                     Edit
                   </LinkButton>
@@ -334,12 +343,14 @@ function PrecinctsTab(): JSX.Element | null {
   const { electionId } = useParams<ElectionIdParams>();
   const geographyRoutes = routes.election(electionId).geography;
   const getElectionQuery = getElection.useQuery(electionId);
+  const getBallotsFinalizedAtQuery = getBallotsFinalizedAt.useQuery(electionId);
 
-  if (!getElectionQuery.isSuccess) {
+  if (!getElectionQuery.isSuccess || !getBallotsFinalizedAtQuery.isSuccess) {
     return null;
   }
 
   const { precincts, election } = getElectionQuery.data;
+  const ballotsFinalizedAt = getBallotsFinalizedAtQuery.data;
 
   const districtIdToName = new Map(
     election.districts.map((district) => [district.id, district.name])
@@ -355,6 +366,7 @@ function PrecinctsTab(): JSX.Element | null {
           variant="primary"
           icon="Add"
           to={geographyRoutes.precincts.addPrecinct.path}
+          disabled={!!ballotsFinalizedAt}
         >
           Add Precinct
         </LinkButton>
@@ -385,6 +397,7 @@ function PrecinctsTab(): JSX.Element | null {
                       to={
                         geographyRoutes.precincts.editPrecinct(precinct.id).path
                       }
+                      disabled={!!ballotsFinalizedAt}
                     >
                       Edit
                     </LinkButton>

--- a/apps/design/frontend/src/tabulation_screen.test.tsx
+++ b/apps/design/frontend/src/tabulation_screen.test.tsx
@@ -43,6 +43,7 @@ function renderScreen() {
 
 test('mark thresholds', async () => {
   apiMock.getElection.expectCallWith({ electionId }).resolves(electionRecord);
+  apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
   renderScreen();
   await screen.findByRole('heading', { name: 'Tabulation' });
 
@@ -103,6 +104,7 @@ test('mark thresholds', async () => {
 
 test('adjudication reasons', async () => {
   apiMock.getElection.expectCallWith({ electionId }).resolves(electionRecord);
+  apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
   renderScreen();
   await screen.findByRole('heading', { name: 'Tabulation' });
 
@@ -159,6 +161,7 @@ test('adjudication reasons', async () => {
 
 test('setting write-in text area threshold', async () => {
   apiMock.getElection.expectCallWith({ electionId }).resolves(electionRecord);
+  apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
   renderScreen();
   await screen.findByRole('heading', { name: 'Tabulation' });
 
@@ -224,4 +227,15 @@ test('setting write-in text area threshold', async () => {
   expect(thresholdInput).toHaveValue(
     updatedSystemSettings.markThresholds.writeInTextArea
   );
+});
+
+test('editing tabulation options', async () => {
+  apiMock.getElection.expectCallWith({ electionId }).resolves(electionRecord);
+  apiMock.getBallotsFinalizedAt
+    .expectCallWith({ electionId })
+    .resolves(new Date());
+  renderScreen();
+  await screen.findByRole('heading', { name: 'Tabulation' });
+
+  expect(screen.getByRole('button', { name: 'Edit' })).toBeDisabled();
 });

--- a/apps/design/frontend/src/tabulation_screen.test.tsx
+++ b/apps/design/frontend/src/tabulation_screen.test.tsx
@@ -229,7 +229,7 @@ test('setting write-in text area threshold', async () => {
   );
 });
 
-test('editing tabulation options', async () => {
+test('editing tabulation options is disabled when ballots are finalized', async () => {
   apiMock.getElection.expectCallWith({ electionId }).resolves(electionRecord);
   apiMock.getBallotsFinalizedAt
     .expectCallWith({ electionId })

--- a/apps/design/frontend/src/tabulation_screen.tsx
+++ b/apps/design/frontend/src/tabulation_screen.tsx
@@ -18,7 +18,11 @@ import {
 import { Form, Column, Row, FormActionsRow, InputGroup } from './layout';
 import { ElectionNavScreen } from './nav_screen';
 import { ElectionIdParams } from './routes';
-import { updateSystemSettings, getElection } from './api';
+import {
+  updateSystemSettings,
+  getElection,
+  getBallotsFinalizedAt,
+} from './api';
 
 type TabulationSettings = Pick<
   SystemSettings,
@@ -31,9 +35,11 @@ type TabulationSettings = Pick<
 export function TabulationForm({
   electionId,
   savedSystemSettings,
+  ballotsFinalizedAt,
 }: {
   electionId: ElectionId;
   savedSystemSettings: SystemSettings;
+  ballotsFinalizedAt: Date | null;
 }): JSX.Element {
   const [isEditing, setIsEditing] = useState(false);
   const [tabulationSettings, setTabulationSettings] =
@@ -224,7 +230,12 @@ export function TabulationForm({
         </FormActionsRow>
       ) : (
         <FormActionsRow>
-          <Button type="reset" variant="primary" icon="Edit">
+          <Button
+            type="reset"
+            variant="primary"
+            icon="Edit"
+            disabled={!!ballotsFinalizedAt}
+          >
             Edit
           </Button>
         </FormActionsRow>
@@ -236,12 +247,14 @@ export function TabulationForm({
 export function TabulationScreen(): JSX.Element | null {
   const { electionId } = useParams<ElectionIdParams>();
   const getElectionQuery = getElection.useQuery(electionId);
+  const getBallotsFinalizedAtQuery = getBallotsFinalizedAt.useQuery(electionId);
 
-  if (!getElectionQuery.isSuccess) {
+  if (!getElectionQuery.isSuccess || !getBallotsFinalizedAtQuery.isSuccess) {
     return null;
   }
 
   const { systemSettings } = getElectionQuery.data;
+  const ballotsFinalizedAt = getBallotsFinalizedAtQuery.data;
 
   return (
     <ElectionNavScreen electionId={electionId}>
@@ -252,6 +265,7 @@ export function TabulationScreen(): JSX.Element | null {
         <TabulationForm
           electionId={electionId}
           savedSystemSettings={systemSettings}
+          ballotsFinalizedAt={ballotsFinalizedAt}
         />
       </MainContent>
     </ElectionNavScreen>


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/5838

Disables all editing fields when ballots are finalized. Note there are a few form controls that aren't disabled:

* District search dropdown (view only)
* Ballot order form (need to order ballots after finalizing the ballots)
* Ballot template dropdown (internal use only)
* Delete Election button (will be hidden for initial release)

## Demo Video or Screenshot

https://github.com/user-attachments/assets/45f3cd2d-cd7e-4b39-8a7c-762e0f39138f



![Screenshot 2025-01-29 at 12 41 12 PM](https://github.com/user-attachments/assets/31150fc3-b2d6-4960-8201-8cc3f8a21ca8)
![Screenshot 2025-01-29 at 12 41 13 PM](https://github.com/user-attachments/assets/12d9f582-a63a-4c10-9615-70976800448d)
![Screenshot 2025-01-29 at 12 41 15 PM](https://github.com/user-attachments/assets/8c0852e7-52fd-4b0a-b611-b598a2bebd65)
![Screenshot 2025-01-29 at 12 41 17 PM](https://github.com/user-attachments/assets/2da90787-0f00-454d-8915-9921101a8702)
![Screenshot 2025-01-29 at 12 41 18 PM](https://github.com/user-attachments/assets/4fb7a84e-2e61-4160-a87f-bc66d30f0a9b)
![Screenshot 2025-01-29 at 12 41 20 PM](https://github.com/user-attachments/assets/a1fa23b0-ec2a-4f5b-9a72-ab227efc844c)
![Screenshot 2025-01-29 at 12 41 21 PM](https://github.com/user-attachments/assets/cc3f3b77-646e-49c2-ab88-0b0b4c2b9328)
![Screenshot 2025-01-29 at 12 41 26 PM](https://github.com/user-attachments/assets/7ff54c79-dfc1-42e7-bae2-24d56a195855)

## Testing Plan
- added tests for disabled state

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
